### PR TITLE
[v15] [aws] exclude session recordings from S3 sync in `teleport-renew-cert`

### DIFF
--- a/assets/aws/files/bin/teleport-renew-cert
+++ b/assets/aws/files/bin/teleport-renew-cert
@@ -17,7 +17,7 @@ if [ ! -f /etc/teleport.d/role.auth ] && [ ! -f /etc/teleport.d/role.all ]; then
 fi
 
 # Fetching certbot state
-aws s3 sync --exact-timestamps "s3://${TELEPORT_S3_BUCKET}" /etc/letsencrypt/ --sse=AES256
+aws s3 sync '--exclude=records/*' --exact-timestamps "s3://${TELEPORT_S3_BUCKET}" /etc/letsencrypt/ --sse=AES256
 
 # s3 does not support symlinks, we have to create them after the sync, else certbot will fail.
 # live/ symlinks point to the latest archive/<domain>/<object>XX.pem where XX is incremented at each cert-renewal.


### PR DESCRIPTION
Backport #47610 to branch/v15

changelog: Fixes a bug where Let's Encrypt certificate renewal failed in AMI and HA deployments due to insufficient disk space caused by syncing audit logs.
