### PR TITLE
add `aws-identity-center` to PluginKind

### DIFF
--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -177,7 +177,8 @@ export type PluginKind =
   | 'servicenow'
   | 'jamf'
   | 'entra-id'
-  | 'datadog';
+  | 'datadog'
+  | 'aws-identity-center';
 
 export type PluginOktaSpec = {
   // scimBearerToken is the plain text of the bearer token that Okta will use


### PR DESCRIPTION
`aws-identity-center` value will be used to identify identity center plugin and resources connected with the plugin in the Web UI and in the backend. 