### PR TITLE
[v16] switch event exporter to bulk api

### DIFF
--- a/integrations/event-handler/events_job.go
+++ b/integrations/event-handler/events_job.go
@@ -16,21 +16,29 @@ package main
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	"github.com/gravitational/trace"
 	limiter "github.com/sethvargo/go-limiter"
 	"github.com/sethvargo/go-limiter/memorystore"
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
+	auditlogpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/auditlog/v1"
+	"github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/integrations/lib"
 	"github.com/gravitational/teleport/integrations/lib/logger"
+	"github.com/gravitational/teleport/lib/events/export"
 )
 
 // EventsJob incapsulates audit log event consumption logic
 type EventsJob struct {
 	lib.ServiceJob
-	app *App
-	rl  limiter.Store
+	app             *App
+	rl              limiter.Store
+	eventsProcessed atomic.Uint64
+	targetDate      atomic.Pointer[time.Time]
 }
 
 // NewEventsJob creates new EventsJob structure
@@ -51,6 +59,25 @@ func (j *EventsJob) run(ctx context.Context) error {
 		return nil
 	})
 
+	// set up background logging of event processing rate
+	go func() {
+		logTicker := time.NewTicker(time.Minute)
+		defer logTicker.Stop()
+
+		for {
+			select {
+			case <-logTicker.C:
+				ll := log.WithField("events_per_minute", j.eventsProcessed.Swap(0))
+				if td := j.targetDate.Load(); td != nil {
+					ll = ll.WithField("date", td.Format(time.DateOnly))
+				}
+				ll.Info("event processing")
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
 	store, err := memorystore.New(&memorystore.Config{
 		Tokens:   uint64(j.app.Config.LockFailedAttemptsCount),
 		Interval: j.app.Config.LockPeriod,
@@ -62,65 +89,198 @@ func (j *EventsJob) run(ctx context.Context) error {
 	j.rl = store
 
 	j.SetReady(true)
+	defer j.app.Terminate()
 
 	for {
 		err := j.runPolling(ctx)
-
-		switch {
-		case trace.IsConnectionProblem(err):
-			log.WithError(err).Error("Failed to connect to Teleport Auth server. Reconnecting...")
-		case trace.IsEOF(err):
-			log.WithError(err).Error("Watcher stream closed. Reconnecting...")
-		case lib.IsCanceled(err):
-			log.Debug("Watcher context is canceled")
-			j.app.Terminate()
-			return nil
-		default:
-			j.app.Terminate()
-			if err == nil {
-				return nil
-			}
-			log.WithError(err).Error("Watcher event loop failed")
+		if err == nil || ctx.Err() != nil {
+			log.Debug("watch loop exiting")
 			return trace.Wrap(err)
+		}
+
+		log.WithError(err).Error("unexpected error in watch loop. reconnecting in 5s...")
+
+		select {
+		case <-time.After(time.Second * 5):
+		case <-ctx.Done():
+			return nil
 		}
 	}
 }
 
 // runPolling runs actual event queue polling
 func (j *EventsJob) runPolling(ctx context.Context) error {
-	log := logger.Get(ctx)
+	cursorV2State := j.app.State.GetCursorV2State()
+	if cursorV2State.IsEmpty() {
+		// we haven't started using the newer bulk event export API yet. check if the upstream implements it by
+		// performing a fake request. if it does not, we'll need to fallback to using the legacy API.
+		chunks := j.app.client.GetEventExportChunks(ctx, &auditlogpb.GetEventExportChunksRequest{
+			// target a date 2 days in the future to be confident that we're querying a valid but
+			// empty date range, even in the context of reasonable clock drift.
+			Date: timestamppb.New(time.Now().AddDate(0, 0, 2)),
+		})
 
-	evtCh, errCh := j.app.EventWatcher.Events(ctx)
+		if err := stream.Drain(chunks); err != nil {
+			if trace.IsNotImplemented(err) {
+				// fallback to legacy behavior
+				return j.runLegacyPolling(ctx)
+			}
+			return trace.Wrap(err)
+		}
 
-	logTicker := time.NewTicker(time.Minute)
-	defer logTicker.Stop()
+		// the new API is implemented, check if there is preexisting legacy cursor state.
+		legacyStates, err := j.app.State.GetLegacyCursorValues()
+		if err != nil {
+			return trace.Wrap(err)
+		}
 
-	var eventsProcessed int
+		if !legacyStates.IsEmpty() {
+			// cursorV2 state isn't totally compatible, but we can skip ahead to the same target date as
+			// was being tracked by the legacy cursor.
+			cursorV2State.Dates[normalizeDate(legacyStates.WindowStartTime)] = export.DateExporterState{}
+		}
+	}
+
+	startTime, err := j.app.State.GetStartTime()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	idleCh := make(chan struct{}, 1)
+
+	// a minimum concurrency of 3 for the date exporter is enforced because 3 is the largest number of chunks we'd
+	// expect to show up simultaneously due to normal ongoing activity. as concurrency is scaled up we apply a quarter
+	// of the value of the global concurrency limit to the exporter. this has been shown in manual scale testing to be
+	// a fairly optimal ratio relative to session processing concurrency (which uses the concurrency limit directly).
+	// using the global concurrency limit directly results in a lot of stalled chunks because each chunk will typically
+	// contain a large number of sessions that need to be processed.
+	concurrency := max(j.app.Config.Concurrency/4, 3)
+
+	exporter, err := export.NewExporter(export.ExporterConfig{
+		Client:    j.app.client,
+		StartDate: *startTime,
+		Export:    j.handleEventV2,
+		OnIdle: func(_ context.Context) {
+			select {
+			case idleCh <- struct{}{}:
+			default:
+			}
+		},
+		PreviousState: cursorV2State,
+		Concurrency:   concurrency,
+		BacklogSize:   2,
+		MaxBackoff:    time.Second * 90,
+		PollInterval:  time.Second * 16,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// the exporter manages retries internally once successfully created, so from here on out
+	// we just want to periodically sync state to disk until the event exporter closes.
+	cursorTicker := time.NewTicker(time.Millisecond * 666)
+	defer cursorTicker.Stop()
 
 	for {
 		select {
-		case err := <-errCh:
-			log.WithField("err", err).Error("Error ingesting Audit Log")
-			return trace.Wrap(err)
-
-		case evt := <-evtCh:
-			if evt == nil {
+		case <-cursorTicker.C:
+			date := exporter.GetCurrentDate()
+			j.targetDate.Store(&date)
+			if err := j.app.State.SetCursorV2State(exporter.GetState()); err != nil {
+				log.WithError(err).Error("Failed to save cursor_v2 values, will retry")
+			}
+		case <-ctx.Done():
+			exporter.Close()
+			<-exporter.Done()
+			// optimistically attempt one last save
+			j.app.State.SetCursorV2State(exporter.GetState())
+			return nil
+		case <-idleCh:
+			// the exporter is idle, which means it has caught up to the present.
+			if j.app.Config.ExitOnLastEvent {
+				exporter.Close()
+				<-exporter.Done()
+				// optimistically attempt one last save
+				j.app.State.SetCursorV2State(exporter.GetState())
 				return nil
 			}
-
-			err := j.handleEvent(ctx, evt)
-			if err != nil {
-				return trace.Wrap(err)
-			}
-
-			eventsProcessed++
-		case <-logTicker.C:
-			log.WithField("events_per_minute", eventsProcessed).Info("event processing rate")
-			eventsProcessed = 0
-		case <-ctx.Done():
-			return ctx.Err()
 		}
 	}
+}
+
+// runLegacyPolling handles event processing via the old API.
+func (j *EventsJob) runLegacyPolling(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	log := logger.Get(ctx)
+
+	lc, err := j.app.State.GetLegacyCursorValues()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if lc.IsEmpty() {
+		st, err := j.app.State.GetStartTime()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		lc.WindowStartTime = *st
+	}
+
+	eventWatcher := NewLegacyEventsWatcher(j.app.Config, j.app.client, *lc, j.handleEvent)
+
+	// periodically sync cursor values to disk
+	go func() {
+		ticker := time.NewTicker(time.Millisecond * 666)
+		defer ticker.Stop()
+
+		lastCursorValues := *lc
+		for {
+			select {
+			case <-ticker.C:
+				currentCursorValues := eventWatcher.GetCursorValues()
+				date := normalizeDate(currentCursorValues.WindowStartTime)
+				j.targetDate.Store(&date)
+				if currentCursorValues.Equals(lastCursorValues) {
+					continue
+				}
+				if err := j.app.State.SetLegacyCursorValues(currentCursorValues); err != nil {
+					log.WithError(err).Error("Failed to save cursor values, will retry")
+					continue
+				}
+				lastCursorValues = currentCursorValues
+			case <-ctx.Done():
+				// optimistically attempt one last save. this is good practice, but note that
+				// we don't promise not to emit duplicate events post-restart, so this we don't
+				// bother checking for errors here.
+				j.app.State.SetLegacyCursorValues(eventWatcher.GetCursorValues())
+				return
+			}
+		}
+	}()
+
+	return eventWatcher.ExportEvents(ctx)
+}
+
+// handleEventV2 processes an event from the newer export API.
+func (j *EventsJob) handleEventV2(ctx context.Context, evt *auditlogpb.ExportEventUnstructured) error {
+
+	// filter out unwanted event types (in the v1 event export logic this was an internal behavior
+	// of the event processing helper since it would perform conversion prior to storing the event
+	// in its internal buffer).
+	if _, ok := j.app.Config.SkipEventTypes[evt.Event.Type]; ok {
+		return nil
+	}
+
+	// convert the event to teleport-event-exporter's internal representation
+	event, err := NewTeleportEvent(evt.Event)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// remaining handling logic is common to v1 and v2 event export
+	return j.handleEvent(ctx, event)
 }
 
 // handleEvent processes an event
@@ -144,13 +304,7 @@ func (j *EventsJob) handleEvent(ctx context.Context, evt *TeleportEvent) error {
 		}
 	}
 
-	// Save last event id and cursor to disk
-	if err := j.app.State.SetID(evt.ID); err != nil {
-		return trace.Wrap(err)
-	}
-	if err := j.app.State.SetCursor(evt.Cursor); err != nil {
-		return trace.Wrap(err)
-	}
+	j.eventsProcessed.Add(1)
 
 	return nil
 }
@@ -176,7 +330,7 @@ func (j *EventsJob) TryLockUser(ctx context.Context, evt *TeleportEvent) error {
 		return nil
 	}
 
-	err = j.app.EventWatcher.UpsertLock(ctx, evt.FailedLoginData.User, evt.FailedLoginData.Login, j.app.Config.LockFor)
+	err = upsertLock(ctx, j.app.client, evt.FailedLoginData.User, evt.FailedLoginData.Login, j.app.Config.LockFor)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/integrations/event-handler/helpers.go
+++ b/integrations/event-handler/helpers.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2024 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/proto"
+	auditlogpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/auditlog/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/integrations/lib"
+	"github.com/gravitational/teleport/integrations/lib/credentials"
+	"github.com/gravitational/teleport/lib/events/export"
+)
+
+// TeleportSearchEventsClient is an interface for client.Client, required for testing
+type TeleportSearchEventsClient interface {
+	export.Client
+	// SearchEvents searches for events in the audit log and returns them using their protobuf representation.
+	SearchEvents(ctx context.Context, fromUTC, toUTC time.Time, namespace string, eventTypes []string, limit int, order types.EventOrder, startKey string) ([]events.AuditEvent, string, error)
+	// StreamSessionEvents returns session events stream for a given session ID using their protobuf representation.
+	StreamSessionEvents(ctx context.Context, sessionID string, startIndex int64) (chan events.AuditEvent, chan error)
+	// SearchUnstructuredEvents searches for events in the audit log and returns them using an unstructured representation (structpb.Struct).
+	SearchUnstructuredEvents(ctx context.Context, fromUTC, toUTC time.Time, namespace string, eventTypes []string, limit int, order types.EventOrder, startKey string) ([]*auditlogpb.EventUnstructured, string, error)
+	// StreamUnstructuredSessionEvents returns session events stream for a given session ID using an unstructured representation (structpb.Struct).
+	StreamUnstructuredSessionEvents(ctx context.Context, sessionID string, startIndex int64) (chan *auditlogpb.EventUnstructured, chan error)
+	UpsertLock(ctx context.Context, lock types.Lock) error
+	Ping(ctx context.Context) (proto.PingResponse, error)
+	Close() error
+}
+
+// newClient performs teleport api client setup, including credentials loading, validation, and
+// setup of credentials refresh if needed.
+func newClient(ctx context.Context, c *StartCmdConfig) (*client.Client, error) {
+	var creds []client.Credentials
+	switch {
+	case c.TeleportIdentityFile != "" && !c.TeleportRefreshEnabled:
+		creds = []client.Credentials{client.LoadIdentityFile(c.TeleportIdentityFile)}
+	case c.TeleportIdentityFile != "" && c.TeleportRefreshEnabled:
+		cred, err := lib.NewIdentityFileWatcher(ctx, c.TeleportIdentityFile, c.TeleportRefreshInterval)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		creds = []client.Credentials{cred}
+	case c.TeleportCert != "" && c.TeleportKey != "" && c.TeleportCA != "":
+		creds = []client.Credentials{client.LoadKeyPair(c.TeleportCert, c.TeleportKey, c.TeleportCA)}
+	default:
+		return nil, trace.BadParameter("no credentials configured")
+	}
+
+	if validCred, err := credentials.CheckIfExpired(creds); err != nil {
+		log.Warn(err)
+		if !validCred {
+			return nil, trace.BadParameter(
+				"No valid credentials found, this likely means credentials are expired. In this case, please sign new credentials and increase their TTL if needed.",
+			)
+		}
+		log.Info("At least one non-expired credential has been found, continuing startup")
+	}
+
+	clientConfig := client.Config{
+		Addrs:       []string{c.TeleportAddr},
+		Credentials: creds,
+	}
+
+	teleportClient, err := client.New(ctx, clientConfig)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return teleportClient, nil
+}
+
+// upsertLock is a helper used to create or update the event handler's auto lock.
+func upsertLock(ctx context.Context, clt TeleportSearchEventsClient, user string, login string, period time.Duration) error {
+	var expires *time.Time
+
+	if period > 0 {
+		t := time.Now()
+		t = t.Add(period)
+		expires = &t
+	}
+
+	lock := &types.LockV2{
+		Metadata: types.Metadata{
+			Name: fmt.Sprintf("event-handler-auto-lock-%v-%v", user, login),
+		},
+		Spec: types.LockSpecV2{
+			Target: types.LockTarget{
+				Login: login,
+				User:  user,
+			},
+			Message: lockMessage,
+			Expires: expires,
+		},
+	}
+
+	return clt.UpsertLock(ctx, lock)
+}
+
+// normalizeDate normalizes a timestamp to the beginning of the day in UTC.
+func normalizeDate(t time.Time) time.Time {
+	t = t.UTC()
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+}

--- a/integrations/event-handler/legacy_events_watcher_test.go
+++ b/integrations/event-handler/legacy_events_watcher_test.go
@@ -31,10 +31,12 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/events"
 	libevents "github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/events/export"
 )
 
 // mockTeleportEventWatcher is Teleport client mock
 type mockTeleportEventWatcher struct {
+	export.Client
 	mu sync.Mutex
 	// events is the mock list of events
 	events []events.AuditEvent
@@ -133,27 +135,25 @@ func (c *mockTeleportEventWatcher) Close() error {
 	return nil
 }
 
-func newTeleportEventWatcher(t *testing.T, eventsClient TeleportSearchEventsClient, startTime time.Time, skipEventTypesRaw []string) *TeleportEventsWatcher {
+func newTeleportEventWatcher(t *testing.T, eventsClient TeleportSearchEventsClient, startTime time.Time, skipEventTypesRaw []string, exportFn func(context.Context, *TeleportEvent) error) *LegacyEventsWatcher {
 	skipEventTypes := map[string]struct{}{}
 	for _, eventType := range skipEventTypesRaw {
 		skipEventTypes[eventType] = struct{}{}
 	}
-	client := &TeleportEventsWatcher{
-		client: eventsClient,
-		pos:    -1,
-		config: &StartCmdConfig{
-			IngestConfig: IngestConfig{
-				BatchSize:           5,
-				ExitOnLastEvent:     true,
-				SkipEventTypes:      skipEventTypes,
-				SkipSessionTypesRaw: skipEventTypesRaw,
-				WindowSize:          24 * time.Hour,
-			},
-		},
-		windowStartTime: startTime,
+
+	cursor := LegacyCursorValues{
+		WindowStartTime: startTime,
 	}
 
-	return client
+	return NewLegacyEventsWatcher(&StartCmdConfig{
+		IngestConfig: IngestConfig{
+			BatchSize:           5,
+			ExitOnLastEvent:     true,
+			SkipEventTypes:      skipEventTypes,
+			SkipSessionTypesRaw: skipEventTypesRaw,
+			WindowSize:          24 * time.Hour,
+		},
+	}, eventsClient, cursor, exportFn)
 }
 
 func TestEvents(t *testing.T) {
@@ -175,10 +175,19 @@ func TestEvents(t *testing.T) {
 
 	// Add the 20 events to a mock event watcher.
 	mockEventWatcher := &mockTeleportEventWatcher{events: testAuditEvents}
-	client := newTeleportEventWatcher(t, mockEventWatcher, time.Now().Add(-48*time.Hour), nil)
 
-	// Start the events goroutine
-	chEvt, chErr := client.Events(ctx)
+	chEvt, chErr := make(chan *TeleportEvent, 128), make(chan error, 1)
+	client := newTeleportEventWatcher(t, mockEventWatcher, time.Now().Add(-48*time.Hour), nil, func(ctx context.Context, evt *TeleportEvent) error {
+		select {
+		case chEvt <- evt:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	})
+	go func() {
+		chErr <- client.ExportEvents(ctx)
+	}()
 
 	// Collect all 20 events
 	for i := 0; i < 20; i++ {
@@ -197,34 +206,14 @@ func TestEvents(t *testing.T) {
 		}
 	}
 
-	// Both channels should be closed once the last event is reached.
+	// watcher should exit automatically
 	select {
-	case _, ok := <-chEvt:
-		require.False(t, ok, "Events channel should be closed")
+	case evt := <-chEvt:
+		t.Fatalf("received unexpected event while waiting for watcher exit: %v", evt)
+	case err := <-chErr:
+		require.NoError(t, err)
 	case <-time.After(2 * time.Second):
-		t.Fatalf("No events received within deadline")
-	}
-
-	select {
-	case _, ok := <-chErr:
-		require.False(t, ok, "Error channel should be closed")
-	case <-time.After(2 * time.Second):
-		t.Fatalf("No events received within deadline")
-	}
-
-	// Both channels should be closed
-	select {
-	case _, ok := <-chEvt:
-		require.False(t, ok, "Events channel should be closed")
-	case <-time.After(2 * time.Second):
-		t.Fatalf("No events received within deadline")
-	}
-
-	select {
-	case _, ok := <-chErr:
-		require.False(t, ok, "Error channel should be closed")
-	case <-time.After(2 * time.Second):
-		t.Fatalf("No events received within deadline")
+		t.Fatalf("timeout waiting for watcher to exit")
 	}
 }
 
@@ -248,30 +237,25 @@ func TestEventsError(t *testing.T) {
 	// Add the 20 events to a mock event watcher.
 	mockErr := trace.Errorf("error")
 	mockEventWatcher := &mockTeleportEventWatcher{events: testAuditEvents, mockSearchErr: mockErr}
-	client := newTeleportEventWatcher(t, mockEventWatcher, time.Now().Add(-48*time.Hour), nil)
 
-	// Start the events goroutine
-	chEvt, chErr := client.Events(ctx)
+	chEvt, chErr := make(chan *TeleportEvent, 128), make(chan error, 1)
+	client := newTeleportEventWatcher(t, mockEventWatcher, time.Now().Add(-48*time.Hour), nil, func(ctx context.Context, evt *TeleportEvent) error {
+		select {
+		case chEvt <- evt:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	})
+	go func() {
+		chErr <- client.ExportEvents(ctx)
+	}()
 
 	select {
-	case err, ok := <-chErr:
-		require.True(t, ok, "Channel unexpectedly close")
+	case evt := <-chEvt:
+		t.Fatalf("received unexpected event while waiting for watcher exit: %v", evt)
+	case err := <-chErr:
 		require.ErrorIs(t, err, mockErr)
-	case <-time.After(2 * time.Second):
-		t.Fatalf("No events received within deadline")
-	}
-
-	// Both channels should be closed
-	select {
-	case _, ok := <-chEvt:
-		require.False(t, ok, "Events channel should be closed")
-	case <-time.After(2 * time.Second):
-		t.Fatalf("No events received within deadline")
-	}
-
-	select {
-	case _, ok := <-chErr:
-		require.False(t, ok, "Error channel should be closed")
 	case <-time.After(2 * time.Second):
 		t.Fatalf("No events received within deadline")
 	}
@@ -295,11 +279,21 @@ func TestUpdatePage(t *testing.T) {
 	defer cancel()
 
 	mockEventWatcher := &mockTeleportEventWatcher{}
-	client := newTeleportEventWatcher(t, mockEventWatcher, time.Now().Add(-1*time.Hour), nil)
+
+	chEvt, chErr := make(chan *TeleportEvent, 128), make(chan error, 1)
+	client := newTeleportEventWatcher(t, mockEventWatcher, time.Now().Add(-1*time.Hour), nil, func(ctx context.Context, evt *TeleportEvent) error {
+		select {
+		case chEvt <- evt:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	})
 	client.config.ExitOnLastEvent = false
 
-	// Start the events goroutine
-	chEvt, chErr := client.Events(ctx)
+	go func() {
+		chErr <- client.ExportEvents(ctx)
+	}()
 
 	// Add an incomplete page of 3 events and collect them.
 	mockEventWatcher.setEvents(testAuditEvents[:3])
@@ -379,24 +373,10 @@ func TestUpdatePage(t *testing.T) {
 	mockEventWatcher.setSearchEventsError(mockErr)
 
 	select {
-	case err, ok := <-chErr:
-		require.True(t, ok, "Channel unexpectedly close")
+	case evt := <-chEvt:
+		t.Fatalf("received unexpected event while waiting for watcher exit: %v", evt)
+	case err := <-chErr:
 		require.ErrorIs(t, err, mockErr)
-	case <-time.After(2 * time.Second):
-		t.Fatalf("No events received within deadline")
-	}
-
-	// Both channels should be closed
-	select {
-	case _, ok := <-chEvt:
-		require.False(t, ok, "Events channel should be closed")
-	case <-time.After(2 * time.Second):
-		t.Fatalf("No events received within deadline")
-	}
-
-	select {
-	case _, ok := <-chErr:
-		require.False(t, ok, "Error channel should be closed")
 	case <-time.After(2 * time.Second):
 		t.Fatalf("No events received within deadline")
 	}
@@ -576,10 +556,19 @@ func TestEventsWithWindowSkip(t *testing.T) {
 
 	// Add the 20 events to a mock event watcher.
 	mockEventWatcher := &mockTeleportEventWatcher{events: testAuditEvents}
-	client := newTeleportEventWatcher(t, mockEventWatcher, time.Now().Add(-48*time.Hour), []string{libevents.UserCreateEvent})
 
-	// Start the events goroutine
-	chEvt, chErr := client.Events(ctx)
+	chEvt, chErr := make(chan *TeleportEvent, 128), make(chan error, 1)
+	client := newTeleportEventWatcher(t, mockEventWatcher, time.Now().Add(-48*time.Hour), []string{libevents.UserCreateEvent}, func(ctx context.Context, evt *TeleportEvent) error {
+		select {
+		case chEvt <- evt:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	})
+	go func() {
+		chErr <- client.ExportEvents(ctx)
+	}()
 
 	// Collect all 10 first events
 	for i := 0; i < 10; i++ {
@@ -614,33 +603,13 @@ func TestEventsWithWindowSkip(t *testing.T) {
 		}
 	}
 
-	// Both channels should be closed once the last event is reached.
+	// watcher should exit automatically
 	select {
-	case _, ok := <-chEvt:
-		require.False(t, ok, "Events channel should be closed")
+	case evt := <-chEvt:
+		t.Fatalf("received unexpected event while waiting for watcher exit: %v", evt)
+	case err := <-chErr:
+		require.NoError(t, err)
 	case <-time.After(2 * time.Second):
-		t.Fatalf("No events received within deadline")
-	}
-
-	select {
-	case _, ok := <-chErr:
-		require.False(t, ok, "Error channel should be closed")
-	case <-time.After(2 * time.Second):
-		t.Fatalf("No events received within deadline")
-	}
-
-	// Both channels should be closed
-	select {
-	case _, ok := <-chEvt:
-		require.False(t, ok, "Events channel should be closed")
-	case <-time.After(2 * time.Second):
-		t.Fatalf("No events received within deadline")
-	}
-
-	select {
-	case _, ok := <-chErr:
-		require.False(t, ok, "Error channel should be closed")
-	case <-time.After(2 * time.Second):
-		t.Fatalf("No events received within deadline")
+		t.Fatalf("timeout waiting for watcher to exit")
 	}
 }

--- a/integrations/event-handler/session_events_job_test.go
+++ b/integrations/event-handler/session_events_job_test.go
@@ -29,19 +29,15 @@ import (
 // if no events are found.
 func TestConsumeSessionNoEventsFound(t *testing.T) {
 	sessionID := "test"
-	j := &SessionEventsJob{
-		app: &App{
-			Config: &StartCmdConfig{},
-			EventWatcher: &TeleportEventsWatcher{
-				client: &mockClient{},
-			},
-			State: &State{
-				dv: diskv.New(diskv.Options{
-					BasePath: t.TempDir(),
-				}),
-			},
+	j := NewSessionEventsJob(&App{
+		Config: &StartCmdConfig{},
+		State: &State{
+			dv: diskv.New(diskv.Options{
+				BasePath: t.TempDir(),
+			}),
 		},
-	}
+		client: &mockClient{},
+	})
 	_, err := j.consumeSession(context.Background(), session{ID: sessionID})
 	require.NoError(t, err)
 }

--- a/integrations/event-handler/teleport_event_test.go
+++ b/integrations/event-handler/teleport_event_test.go
@@ -44,11 +44,10 @@ func TestNew(t *testing.T) {
 	protoEvent, err := eventToProto(events.AuditEvent(e))
 	require.NoError(t, err)
 
-	event, err := NewTeleportEvent(protoEvent, "cursor")
+	event, err := NewTeleportEvent(protoEvent)
 	require.NoError(t, err)
 	assert.Equal(t, "test", event.ID)
 	assert.Equal(t, "mock", event.Type)
-	assert.Equal(t, "cursor", event.Cursor)
 }
 
 func TestGenID(t *testing.T) {
@@ -57,7 +56,7 @@ func TestGenID(t *testing.T) {
 	protoEvent, err := eventToProto(events.AuditEvent(e))
 	require.NoError(t, err)
 
-	event, err := NewTeleportEvent(protoEvent, "cursor")
+	event, err := NewTeleportEvent(protoEvent)
 	require.NoError(t, err)
 	assert.NotEmpty(t, event.ID)
 }
@@ -75,7 +74,7 @@ func TestSessionEnd(t *testing.T) {
 	protoEvent, err := eventToProto(events.AuditEvent(e))
 	require.NoError(t, err)
 
-	event, err := NewTeleportEvent(protoEvent, "cursor")
+	event, err := NewTeleportEvent(protoEvent)
 	require.NoError(t, err)
 	assert.NotEmpty(t, event.ID)
 	assert.NotEmpty(t, event.SessionID)
@@ -95,7 +94,7 @@ func TestFailedLogin(t *testing.T) {
 	protoEvent, err := eventToProto(events.AuditEvent(e))
 	require.NoError(t, err)
 
-	event, err := NewTeleportEvent(protoEvent, "cursor")
+	event, err := NewTeleportEvent(protoEvent)
 	require.NoError(t, err)
 	assert.NotEmpty(t, event.ID)
 	assert.True(t, event.IsFailedLogin)
@@ -114,7 +113,7 @@ func TestSuccessLogin(t *testing.T) {
 	protoEvent, err := eventToProto(events.AuditEvent(e))
 	require.NoError(t, err)
 
-	event, err := NewTeleportEvent(protoEvent, "cursor")
+	event, err := NewTeleportEvent(protoEvent)
 	require.NoError(t, err)
 	assert.NotEmpty(t, event.ID)
 	assert.False(t, event.IsFailedLogin)

--- a/lib/events/export/exporter.go
+++ b/lib/events/export/exporter.go
@@ -195,6 +195,13 @@ func (e *Exporter) Done() <-chan struct{} {
 	return e.done
 }
 
+// GetCurrentDate returns the current target date. Note that earlier dates may also be being processed concurrently.
+func (e *Exporter) GetCurrentDate() time.Time {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.currentDate
+}
+
 // GetState loads the current state of the exporter. Note that there may be concurrent export operations
 // in progress, meaning that by the time state is observed it may already be outdated.
 func (e *Exporter) GetState() ExporterState {


### PR DESCRIPTION
Backport #47369 to branch/v16

changelog: reworked the `teleport-event-handler` integration to significantly improve performance, especially when running with larger `--concurrency` values.
