### PR TITLE
Validate redirect URL origin during app authentication

### DIFF
--- a/lib/web/app/redirect.go
+++ b/lib/web/app/redirect.go
@@ -103,8 +103,9 @@ const appRedirectHTML = `
     <title>Teleport Redirection Service</title>
     <script nonce="{{.}}">
       (function() {
-        var url = new URL(window.location);
-        var params = new URLSearchParams(url.search);
+        var currentUrl = new URL(window.location);
+        var currentOrigin = currentUrl.origin;
+        var params = new URLSearchParams(currentUrl.search);
         var stateValue = params.get('state');
         var subjectValue = params.get('subject');
         var path = params.get('path');
@@ -137,16 +138,20 @@ const appRedirectHTML = `
               return;
             }
             try {
-              // if a path parameter was passed through the redirect, append that path to the target url
+              // if a path parameter was passed through the redirect, append that path to the current origin
               if (path) {
-                var redirectUrl = new URL(path, url.origin)
-                window.location.replace(redirectUrl.toString());
+                var redirectUrl = new URL(path, currentOrigin)
+                if (redirectUrl.origin === currentOrigin) {
+                  window.location.replace(redirectUrl.toString())
+                } else {
+                  window.location.replace(currentOrigin)
+                }
               } else {
-                window.location.replace(url.origin);
+                window.location.replace(currentOrigin)
               }
             } catch (error) {
-              // in case of malformed url, return to origin
-              window.location.replace(url.origin)
+              // in case of malformed url, return to current origin
+              window.location.replace(currentOrigin)
             }
           }
         });


### PR DESCRIPTION
This validates the incoming path param ensuring that it is equal to the requested app's origin and if it doesn't match, returns the path only. 

The alternative is returning the `redirectUrl.pathname` but it may be weird seeing something like `https://myapp.teleport.com/https://badnamehere.com/my/path`.