### PR TITLE
Fix flaky test `TestHardwareKeySSH`

### DIFF
--- a/tool/teleport/testenv/test_server.go
+++ b/tool/teleport/testenv/test_server.go
@@ -569,7 +569,7 @@ func CreateAgentlessNode(t *testing.T, authServer *auth.Server, clusterName, nod
 	require.NoError(t, err)
 
 	// wait for node resource to be written to the backend
-	timedCtx, cancel := context.WithTimeout(ctx, time.Second)
+	timedCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	t.Cleanup(cancel)
 	w, err := authServer.NewWatcher(timedCtx, types.Watch{
 		Name: "node-create watcher",


### PR DESCRIPTION
Extend timeout to avoid test flakes.

```
=== FAIL: tool/tsh/common TestHardwareKeySSH (1.64s)
    hardware_key_test.go:222: Did not receive node create event
```

https://github.com/gravitational/teleport/actions/runs/11370803109/job/31631399926