### PR TITLE
docs: update table to mark which roles are ent and community preset

### DIFF
--- a/docs/pages/includes/preset-roles-table.mdx
+++ b/docs/pages/includes/preset-roles-table.mdx
@@ -1,5 +1,5 @@
 | Role | Description | Enterprise-only |
-| --- | --- |  --- | --- |
+| --- | --- |  --- |
 | `access`| Allows access to cluster resources. |  |
 | `editor` | Allows editing of cluster configuration settings. |  |
 | `auditor`| Allows reading cluster events, audit logs, and playing back session records. |  |

--- a/docs/pages/includes/preset-roles-table.mdx
+++ b/docs/pages/includes/preset-roles-table.mdx
@@ -1,13 +1,13 @@
-| Role | Description |
-| --- | --- |
-| `access`| Allows access to cluster resources. |
-| `editor` | Allows editing of cluster configuration settings. |
-| `auditor`| Allows reading cluster events, audit logs, and playing back session records. |
-| `requester`| Enterprise-only role that allows a user to create Access Requests. |
-| `reviewer`| Enterprise-only role that allows review of Access Requests. |
-| `group-access`| Allows access to all user groups. | 
-| `device-admin`| Used to manage trusted devices. | 
-| `device-enroll`| Used to grant device enrollment powers to users. |
-| `require-trusted-device`| Requires trusted device access to resources. |
-| `terraform-provider`| Allows the Teleport Terraform provider to configure all of its supported Teleport resources. |
+| Role | Description | Community Edition | Enterprise |
+| --- | --- |  --- | --- |
+| `access`| Allows access to cluster resources. | ✔ | ✔ |
+| `editor` | Allows editing of cluster configuration settings. | ✔ | ✔ |
+| `auditor`| Allows reading cluster events, audit logs, and playing back session records. | ✔ | ✔ |
+| `requester`| Allows a user to create Access Requests. | ✖ | ✔ |
+| `reviewer`| Allows review of Access Requests. | ✖ | ✔ |
+| `group-access`| Allows access to all user groups. | ✖ | ✔ |
+| `device-admin`| Used to manage trusted devices. | ✖ | ✔ |
+| `device-enroll`| Used to grant device enrollment powers to users. | ✖ | ✔ |
+| `require-trusted-device`| Requires trusted device access to resources. | ✖ | ✔ |
+| `terraform-provider`| Allows the Teleport Terraform provider to configure all of its supported Teleport resources. | ✔ | ✔ |
 

--- a/docs/pages/includes/preset-roles-table.mdx
+++ b/docs/pages/includes/preset-roles-table.mdx
@@ -1,13 +1,13 @@
-| Role | Description | Community Edition | Enterprise |
+| Role | Description | Enterprise-only |
 | --- | --- |  --- | --- |
-| `access`| Allows access to cluster resources. | ✔ | ✔ |
-| `editor` | Allows editing of cluster configuration settings. | ✔ | ✔ |
-| `auditor`| Allows reading cluster events, audit logs, and playing back session records. | ✔ | ✔ |
-| `requester`| Allows a user to create Access Requests. | ✖ | ✔ |
-| `reviewer`| Allows review of Access Requests. | ✖ | ✔ |
-| `group-access`| Allows access to all user groups. | ✖ | ✔ |
-| `device-admin`| Used to manage trusted devices. | ✖ | ✔ |
-| `device-enroll`| Used to grant device enrollment powers to users. | ✖ | ✔ |
-| `require-trusted-device`| Requires trusted device access to resources. | ✖ | ✔ |
-| `terraform-provider`| Allows the Teleport Terraform provider to configure all of its supported Teleport resources. | ✔ | ✔ |
+| `access`| Allows access to cluster resources. |  |
+| `editor` | Allows editing of cluster configuration settings. |  |
+| `auditor`| Allows reading cluster events, audit logs, and playing back session records. |  |
+| `requester`| Allows a user to create Access Requests. | ✔ |
+| `reviewer`| Allows review of Access Requests. | ✔ |
+| `group-access`| Allows access to all user groups. | ✔ |
+| `device-admin`| Used to manage trusted devices. | ✔ |
+| `device-enroll`| Used to grant device enrollment powers to users. | ✔ |
+| `require-trusted-device`| Requires trusted device access to resources. | ✔ |
+| `terraform-provider`| Allows the Teleport Terraform provider to configure all of its supported Teleport resources. | ✔ |
 


### PR DESCRIPTION
This didn't capture all of which were ent and/or community. Using checkmark approach.