### PR TITLE
feat: SSO MFA - Add `MFAToken` to SSO Callback flow

### DIFF
--- a/lib/auth/authclient/clt.go
+++ b/lib/auth/authclient/clt.go
@@ -896,7 +896,7 @@ type OIDCAuthResponse struct {
 	// HostSigners is a list of signing host public keys
 	// trusted by proxy, used in console login
 	HostSigners []types.CertAuthority `json:"host_signers"`
-	// MFAToken is an SSO MFA token used in SSOChallengeResponse.
+	// MFAToken is an SSO MFA token.
 	MFAToken string `json:"mfa_token"`
 }
 
@@ -943,7 +943,7 @@ type SAMLAuthResponse struct {
 	// HostSigners is a list of signing host public keys
 	// trusted by proxy, used in console login
 	HostSigners []types.CertAuthority `json:"host_signers"`
-	// MFAToken is an SSO MFA token used in SSOChallengeResponse.
+	// MFAToken is an SSO MFA token.
 	MFAToken string `json:"mfa_token"`
 }
 
@@ -1489,7 +1489,7 @@ type SSHLoginResponse struct {
 	HostSigners []TrustedCerts `json:"host_signers"`
 	// SAMLSingleLogoutEnabled is whether SAML SLO (single logout) is enabled for the SAML auth connector being used, if applicable.
 	SAMLSingleLogoutEnabled bool `json:"samlSingleLogoutEnabled"`
-	// MFAToken is an SSO MFA token used in SSOChallengeResponse.
+	// MFAToken is an SSO MFA token.
 	MFAToken string `json:"mfa_token"`
 }
 

--- a/lib/auth/authclient/clt.go
+++ b/lib/auth/authclient/clt.go
@@ -896,6 +896,8 @@ type OIDCAuthResponse struct {
 	// HostSigners is a list of signing host public keys
 	// trusted by proxy, used in console login
 	HostSigners []types.CertAuthority `json:"host_signers"`
+	// MFAToken is an SSO MFA token used in SSOChallengeResponse.
+	MFAToken string `json:"mfa_token"`
 }
 
 // OIDCAuthRequest is an OIDC auth request that supports standard json marshaling.
@@ -941,6 +943,8 @@ type SAMLAuthResponse struct {
 	// HostSigners is a list of signing host public keys
 	// trusted by proxy, used in console login
 	HostSigners []types.CertAuthority `json:"host_signers"`
+	// MFAToken is an SSO MFA token used in SSOChallengeResponse.
+	MFAToken string `json:"mfa_token"`
 }
 
 // SAMLAuthRequest is a SAML auth request that supports standard json marshaling.
@@ -1485,6 +1489,8 @@ type SSHLoginResponse struct {
 	HostSigners []TrustedCerts `json:"host_signers"`
 	// SAMLSingleLogoutEnabled is whether SAML SLO (single logout) is enabled for the SAML auth connector being used, if applicable.
 	SAMLSingleLogoutEnabled bool `json:"samlSingleLogoutEnabled"`
+	// MFAToken is an SSO MFA token used in SSOChallengeResponse.
+	MFAToken string `json:"mfa_token"`
 }
 
 // TrustedCerts contains host certificates, it preserves backwards compatibility

--- a/lib/auth/authclient/http_client.go
+++ b/lib/auth/authclient/http_client.go
@@ -638,6 +638,8 @@ type OIDCAuthRawResponse struct {
 	// HostSigners is a list of signing host public keys
 	// trusted by proxy, used in console login
 	HostSigners []json.RawMessage `json:"host_signers"`
+	// MFAToken is an SSO MFA token used in SSOChallengeResponse.
+	MFAToken string `json:"mfa_token"`
 }
 
 // ValidateOIDCAuthCallback validates OIDC auth callback returned from redirect
@@ -658,6 +660,7 @@ func (c *HTTPClient) ValidateOIDCAuthCallback(ctx context.Context, q url.Values)
 		Cert:     rawResponse.Cert,
 		Req:      rawResponse.Req,
 		TLSCert:  rawResponse.TLSCert,
+		MFAToken: rawResponse.MFAToken,
 	}
 	if len(rawResponse.Session) != 0 {
 		session, err := services.UnmarshalWebSession(rawResponse.Session)
@@ -707,6 +710,8 @@ type SAMLAuthRawResponse struct {
 	HostSigners []json.RawMessage `json:"host_signers"`
 	// TLSCert is TLS certificate authority certificate
 	TLSCert []byte `json:"tls_cert,omitempty"`
+	// MFAToken is an SSO MFA token used in SSOChallengeResponse.
+	MFAToken string `json:"mfa_token"`
 }
 
 // ValidateSAMLResponse validates response returned by SAML identity provider
@@ -729,6 +734,7 @@ func (c *HTTPClient) ValidateSAMLResponse(ctx context.Context, samlResponse, con
 		Cert:     rawResponse.Cert,
 		Req:      rawResponse.Req,
 		TLSCert:  rawResponse.TLSCert,
+		MFAToken: rawResponse.MFAToken,
 	}
 	if len(rawResponse.Session) != 0 {
 		session, err := services.UnmarshalWebSession(rawResponse.Session)

--- a/lib/auth/authclient/http_client.go
+++ b/lib/auth/authclient/http_client.go
@@ -638,7 +638,7 @@ type OIDCAuthRawResponse struct {
 	// HostSigners is a list of signing host public keys
 	// trusted by proxy, used in console login
 	HostSigners []json.RawMessage `json:"host_signers"`
-	// MFAToken is an SSO MFA token used in SSOChallengeResponse.
+	// MFAToken is an SSO MFA token.
 	MFAToken string `json:"mfa_token"`
 }
 
@@ -710,7 +710,7 @@ type SAMLAuthRawResponse struct {
 	HostSigners []json.RawMessage `json:"host_signers"`
 	// TLSCert is TLS certificate authority certificate
 	TLSCert []byte `json:"tls_cert,omitempty"`
-	// MFAToken is an SSO MFA token used in SSOChallengeResponse.
+	// MFAToken is an SSO MFA token.
 	MFAToken string `json:"mfa_token"`
 }
 

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2184,6 +2184,8 @@ type AuthParams struct {
 	// FIPS mode means Teleport started in a FedRAMP/FIPS 140-2 compliant
 	// configuration.
 	FIPS bool
+	// MFAToken is an SSO MFA token used in SSOChallengeResponse.
+	MFAToken string
 }
 
 // ConstructSSHResponse creates a special SSH response for SSH login method
@@ -2198,6 +2200,7 @@ func ConstructSSHResponse(response AuthParams) (*url.URL, error) {
 		Cert:        response.Cert,
 		TLSCert:     response.TLSCert,
 		HostSigners: authclient.AuthoritiesToTrustedCerts(response.HostSigners),
+		MFAToken:    response.MFAToken,
 	}
 	out, err := json.Marshal(consoleResponse)
 	if err != nil {
@@ -5022,6 +5025,8 @@ type SSOCallbackResponse struct {
 	// ClientRedirectURL is the URL to redirect back to on completion of
 	// the SSO login process.
 	ClientRedirectURL string
+	// MFAToken is an SSO MFA token used in SSOChallengeResponse.
+	MFAToken string
 }
 
 // SSOSetWebSessionAndRedirectURL validates the CSRF token in the response

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2184,7 +2184,7 @@ type AuthParams struct {
 	// FIPS mode means Teleport started in a FedRAMP/FIPS 140-2 compliant
 	// configuration.
 	FIPS bool
-	// MFAToken is an SSO MFA token used in SSOChallengeResponse.
+	// MFAToken is an SSO MFA token.
 	MFAToken string
 }
 
@@ -5025,7 +5025,7 @@ type SSOCallbackResponse struct {
 	// ClientRedirectURL is the URL to redirect back to on completion of
 	// the SSO login process.
 	ClientRedirectURL string
-	// MFAToken is an SSO MFA token used in SSOChallengeResponse.
+	// MFAToken is an SSO MFA token.
 	MFAToken string
 }
 


### PR DESCRIPTION
Part of the implementation of [SSO MFA](https://github.com/gravitational/teleport/pull/44699)

The new `MFAToken` will be used in a follow up e PR.