### PR TITLE
Convert `lib/proxy/peer` to slog

### DIFF
--- a/lib/proxy/peer/client.go
+++ b/lib/proxy/peer/client.go
@@ -421,7 +421,7 @@ func (c *Client) sync() {
 		},
 	})
 	if err != nil {
-		c.config.Log.ErrorContext(c.ctx, "Error initializing proxy peer watcher.", "error", err)
+		c.config.Log.ErrorContext(c.ctx, "error initializing proxy peer watcher", "error", err)
 		return
 	}
 	defer proxyWatcher.Close()
@@ -429,14 +429,14 @@ func (c *Client) sync() {
 	for {
 		select {
 		case <-c.ctx.Done():
-			c.config.Log.DebugContext(c.ctx, "Stopping peer proxy sync: context done.")
+			c.config.Log.DebugContext(c.ctx, "stopping peer proxy sync: context done")
 			return
 		case <-proxyWatcher.Done():
-			c.config.Log.DebugContext(c.ctx, "Stopping peer proxy sync: proxy watcher done.")
+			c.config.Log.DebugContext(c.ctx, "stopping peer proxy sync: proxy watcher done")
 			return
 		case proxies := <-proxyWatcher.ProxiesC:
 			if err := c.updateConnections(proxies); err != nil {
-				c.config.Log.ErrorContext(c.ctx, "Error syncing peer proxies.", "error", err)
+				c.config.Log.ErrorContext(c.ctx, "error syncing peer proxies", "error", err)
 			}
 		}
 	}
@@ -487,7 +487,7 @@ func (c *Client) updateConnections(proxies []types.Server) error {
 		conn, err := c.connect(id, proxy.GetPeerAddr(), supportsQuic)
 		if err != nil {
 			c.metrics.reportTunnelError(errorProxyPeerTunnelDial)
-			c.config.Log.DebugContext(c.ctx, "Error dialing peer proxy.", "peer_id", id, "peer_addr", proxy.GetPeerAddr())
+			c.config.Log.DebugContext(c.ctx, "error dialing peer proxy", "peer_id", id, "peer_addr", proxy.GetPeerAddr())
 			errs = append(errs, err)
 			continue
 		}
@@ -688,7 +688,7 @@ func (c *Client) getConnections(proxyIDs []string) ([]clientConn, bool, error) {
 		conn, err := c.connect(id, proxy.GetPeerAddr(), supportsQuic)
 		if err != nil {
 			c.metrics.reportTunnelError(errorProxyPeerTunnelDirectDial)
-			c.config.Log.DebugContext(c.ctx, "Error direct dialing peer proxy.", "peer_id", id, "peer_addr", proxy.GetPeerAddr())
+			c.config.Log.DebugContext(c.ctx, "error direct dialing peer proxy", "peer_id", id, "peer_addr", proxy.GetPeerAddr())
 			errs = append(errs, err)
 			continue
 		}

--- a/lib/proxy/peer/client.go
+++ b/lib/proxy/peer/client.go
@@ -21,6 +21,7 @@ package peer
 import (
 	"context"
 	"crypto/tls"
+	"log/slog"
 	"math/rand/v2"
 	"net"
 	"sync"
@@ -29,7 +30,6 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/quic-go/quic-go"
-	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
@@ -72,7 +72,7 @@ type ClientConfig struct {
 	// TLSCipherSuites optionally contains a list of TLS ciphersuites to use.
 	TLSCipherSuites []uint16
 	// Log is the proxy client logger.
-	Log logrus.FieldLogger
+	Log *slog.Logger
 	// Clock is used to control connection monitoring ticker.
 	Clock clockwork.Clock
 	// GracefulShutdownTimout is used set the graceful shutdown
@@ -112,10 +112,10 @@ func noopConnShuffler() connShuffler {
 // checkAndSetDefaults checks and sets default values
 func (c *ClientConfig) checkAndSetDefaults() error {
 	if c.Log == nil {
-		c.Log = logrus.New()
+		c.Log = slog.Default()
 	}
 
-	c.Log = c.Log.WithField(
+	c.Log = c.Log.With(
 		teleport.ComponentKey,
 		teleport.Component(teleport.ComponentProxyPeer),
 	)
@@ -414,15 +414,14 @@ func (c *Client) sync() {
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
 			Component: teleport.Component(teleport.ComponentProxyPeer),
 			Client:    c.config.AccessPoint,
-			// TODO(tross): use the configured logger after updating peering to use slog
-			// Logger:       c.config.Logger,
+			Logger:    c.config.Log,
 		},
 		ProxyDiffer: func(old, new types.Server) bool {
 			return old.GetPeerAddr() != new.GetPeerAddr()
 		},
 	})
 	if err != nil {
-		c.config.Log.Errorf("Error initializing proxy peer watcher: %+v.", err)
+		c.config.Log.ErrorContext(c.ctx, "Error initializing proxy peer watcher.", "error", err)
 		return
 	}
 	defer proxyWatcher.Close()
@@ -430,14 +429,14 @@ func (c *Client) sync() {
 	for {
 		select {
 		case <-c.ctx.Done():
-			c.config.Log.Debug("Stopping peer proxy sync: context done.")
+			c.config.Log.DebugContext(c.ctx, "Stopping peer proxy sync: context done.")
 			return
 		case <-proxyWatcher.Done():
-			c.config.Log.Debug("Stopping peer proxy sync: proxy watcher done.")
+			c.config.Log.DebugContext(c.ctx, "Stopping peer proxy sync: proxy watcher done.")
 			return
 		case proxies := <-proxyWatcher.ProxiesC:
 			if err := c.updateConnections(proxies); err != nil {
-				c.config.Log.Errorf("Error syncing peer proxies: %+v.", err)
+				c.config.Log.ErrorContext(c.ctx, "Error syncing peer proxies.", "error", err)
 			}
 		}
 	}
@@ -488,7 +487,7 @@ func (c *Client) updateConnections(proxies []types.Server) error {
 		conn, err := c.connect(id, proxy.GetPeerAddr(), supportsQuic)
 		if err != nil {
 			c.metrics.reportTunnelError(errorProxyPeerTunnelDial)
-			c.config.Log.Debugf("Error dialing peer proxy %+v at %+v", id, proxy.GetPeerAddr())
+			c.config.Log.DebugContext(c.ctx, "Error dialing peer proxy.", "peer_id", id, "peer_addr", proxy.GetPeerAddr())
 			errs = append(errs, err)
 			continue
 		}
@@ -689,7 +688,7 @@ func (c *Client) getConnections(proxyIDs []string) ([]clientConn, bool, error) {
 		conn, err := c.connect(id, proxy.GetPeerAddr(), supportsQuic)
 		if err != nil {
 			c.metrics.reportTunnelError(errorProxyPeerTunnelDirectDial)
-			c.config.Log.Debugf("Error direct dialing peer proxy %+v at %+v", id, proxy.GetPeerAddr())
+			c.config.Log.DebugContext(c.ctx, "Error direct dialing peer proxy", "peer_id", id, "peer_addr", proxy.GetPeerAddr())
 			errs = append(errs, err)
 			continue
 		}

--- a/lib/proxy/peer/client.go
+++ b/lib/proxy/peer/client.go
@@ -688,7 +688,7 @@ func (c *Client) getConnections(proxyIDs []string) ([]clientConn, bool, error) {
 		conn, err := c.connect(id, proxy.GetPeerAddr(), supportsQuic)
 		if err != nil {
 			c.metrics.reportTunnelError(errorProxyPeerTunnelDirectDial)
-			c.config.Log.DebugContext(c.ctx, "Error direct dialing peer proxy", "peer_id", id, "peer_addr", proxy.GetPeerAddr())
+			c.config.Log.DebugContext(c.ctx, "Error direct dialing peer proxy.", "peer_id", id, "peer_addr", proxy.GetPeerAddr())
 			errs = append(errs, err)
 			continue
 		}

--- a/lib/proxy/peer/credentials_test.go
+++ b/lib/proxy/peer/credentials_test.go
@@ -113,7 +113,7 @@ func TestClientCredentials(t *testing.T) {
 				},
 			}
 
-			creds := newClientCredentials(test.expectedPeerID, test.peerAddr, utils.NewLoggerForTests(), newTestCredentials(cert))
+			creds := newClientCredentials(test.expectedPeerID, test.peerAddr, utils.NewSlogLoggerForTests(), newTestCredentials(cert))
 
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 			defer cancel()

--- a/lib/proxy/peer/service.go
+++ b/lib/proxy/peer/service.go
@@ -59,7 +59,7 @@ func (s *proxyService) DialNode(stream proto.ProxyService_DialNodeServer) error 
 		"src", dial.Source.Addr,
 		"dst", dial.Destination.Addr,
 	)
-	log.DebugContext(stream.Context(), "Dial request from peer.")
+	log.DebugContext(stream.Context(), "dial request from peer")
 
 	_, clusterName, err := splitServerID(dial.NodeID)
 	if err != nil {
@@ -103,7 +103,7 @@ func (s *proxyService) DialNode(stream proto.ProxyService_DialNodeServer) error 
 
 	err = utils.ProxyConn(stream.Context(), streamConn, nodeConn)
 	sent, received := streamConn.Stat()
-	log.DebugContext(stream.Context(), "Closing dial request from peer.", "sent", sent, "received", received)
+	log.DebugContext(stream.Context(), "closing dial request from peer", "sent", sent, "received", received)
 	return trace.Wrap(err)
 }
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4347,7 +4347,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				TLSCipherSuites:   cfg.CipherSuites,
 				GetTLSCertificate: conn.ClientGetCertificate,
 				GetTLSRoots:       conn.ClientGetPool,
-				Log:               process.log,
+				Log:               process.logger,
 				Clock:             process.Clock,
 				ClusterName:       clusterName,
 				QUICTransport:     peerQUICTransport,


### PR DESCRIPTION
Finish the conversion of `lib/proxy/peer` from logrus to slog, now that resource watchers use slog.