### PR TITLE
[v16] spellfix in github actions flow

### DIFF
--- a/web/packages/teleport/src/Bots/Add/GitHubActions/ConnectGitHub.test.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActions/ConnectGitHub.test.tsx
@@ -72,7 +72,7 @@ describe('connectGitHub Component', () => {
       screen.getByText('Name of the GitHub Actions Workflow')
     ).toBeInTheDocument();
     expect(screen.getByPlaceholderText('cd')).toBeInTheDocument();
-    expect(screen.getByText('Environmnet')).toBeInTheDocument();
+    expect(screen.getByText('Environment')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('development')).toBeInTheDocument();
     expect(screen.getByText('Restrict to a GitHub User')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('octocat')).toBeInTheDocument();

--- a/web/packages/teleport/src/Bots/Add/GitHubActions/ConnectGitHub.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActions/ConnectGitHub.tsx
@@ -221,7 +221,7 @@ export function ConnectGitHub({ nextStep, prevStep }: FlowStepProps) {
 
                   <FormItem>
                     <Text>
-                      Environmnet <OptionalFieldText />
+                      Environment <OptionalFieldText />
                     </Text>
                     <Input
                       disabled={isLoading}


### PR DESCRIPTION
This was fixed in `master` but not backported to branch/v16 and branch/v15.