### PR TITLE
fix: Avoid needless user escalation during auto-enroll

### DIFF
--- a/lib/devicetrust/enroll/auto_enroll_test.go
+++ b/lib/devicetrust/enroll/auto_enroll_test.go
@@ -59,7 +59,6 @@ func TestAutoEnrollCeremony_Run(t *testing.T) {
 					SignChallenge:           test.dev.SignChallenge,
 					SolveTPMEnrollChallenge: test.dev.SolveTPMEnrollChallenge,
 				},
-				CollectDeviceData: test.dev.CollectDeviceData,
 			}
 
 			dev, err := c.Run(ctx, devices)

--- a/lib/devicetrust/enroll/enroll.go
+++ b/lib/devicetrust/enroll/enroll.go
@@ -173,6 +173,15 @@ func (c *Ceremony) Run(ctx context.Context, devicesClient devicepb.DeviceTrustSe
 	}
 	init.Token = enrollToken
 
+	return c.run(ctx, devicesClient, debug, init)
+}
+
+func (c *Ceremony) run(ctx context.Context, devicesClient devicepb.DeviceTrustServiceClient, debug bool, init *devicepb.EnrollDeviceInit) (*devicepb.Device, error) {
+	// Sanity check.
+	if init.GetToken() == "" {
+		return nil, trace.BadParameter("enroll init message lacks enrollment token")
+	}
+
 	stream, err := devicesClient.EnrollDevice(ctx)
 	if err != nil {
 		return nil, trace.Wrap(devicetrust.HandleUnimplemented(err))


### PR DESCRIPTION
Auto-enroll was generating sudo prompts on machines without a TPM, which is pointless because without a TPM the ceremony cannot succeed.

The root cause is that auto-enroll was trying to gather device data (which needs sudo) before checking for a TPM (which does not need sudo). Changing the order of the operations (which is how EnrollDeviceInit is coded) resolves the issue. Other device trust operations are already careful to do that, so the problem is exclusive to auto-enroll. It's also arguably worse for auto-enroll, as it is an unprompted ceremony if the corresponding setting is enabled.

Changelog: Avoid tsh auto-enroll escalation in machines without a TPM