### PR TITLE
teleport-kube-agent: Propagate resources to post-install and post-delete hooks

### DIFF
--- a/examples/chart/teleport-kube-agent/templates/delete_hook.yaml
+++ b/examples/chart/teleport-kube-agent/templates/delete_hook.yaml
@@ -118,3 +118,6 @@ spec:
         {{- if .Values.securityContext }}
         securityContext: {{- toYaml .Values.securityContext | nindent 10 }}
         {{- end }}
+        {{- if .Values.resources }}
+        resources: {{- toYaml .Values.resources | nindent 10 }}
+        {{- end }}

--- a/examples/chart/teleport-kube-agent/templates/hook.yaml
+++ b/examples/chart/teleport-kube-agent/templates/hook.yaml
@@ -103,4 +103,7 @@ spec:
         {{- if .Values.securityContext }}
         securityContext: {{- toYaml .Values.securityContext | nindent 10 }}
         {{- end }}
+        {{- if .Values.resources }}
+        resources: {{- toYaml .Values.resources | nindent 10 }}
+        {{- end }}
 {{- end}}

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
@@ -185,3 +185,40 @@ should set nodeSelector in post-delete hook:
       gravitational.io/k8s-role: node
     restartPolicy: OnFailure
     serviceAccountName: RELEASE-NAME-delete-hook
+should set resources in the Job's pod spec if resources is set in values:
+  1: |
+    containers:
+    - args:
+      - kube-state
+      - delete
+      command:
+      - teleport
+      env:
+      - name: KUBE_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
+      - name: RELEASE_NAME
+        value: RELEASE-NAME
+      image: public.ecr.aws/gravitational/teleport-distroless:17.0.0-dev
+      imagePullPolicy: IfNotPresent
+      name: post-delete-job
+      resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
+        requests:
+          cpu: 1
+          memory: 2Gi
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 9807
+        seccompProfile:
+          type: RuntimeDefault
+    restartPolicy: OnFailure
+    serviceAccountName: RELEASE-NAME-delete-hook

--- a/examples/chart/teleport-kube-agent/tests/job_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/job_test.yaml
@@ -268,4 +268,35 @@ tests:
           value:
             app: RELEASE-NAME
             testLabel: testValue
-    
+
+  - it: should set resources in the Job's pod spec if resources is set in values
+    template: delete_hook.yaml
+    # documentIndex: 0=ServiceAccount 1=Role 2=RoleBinding 3=Job
+    documentIndex: 3
+    values:
+      - ../.lint/backwards-compatibility.yaml
+    set:
+      # These are just sample values to test the chart.
+      # They are not intended to be guidelines or suggestions for running teleport.
+      resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
+        requests:
+          cpu: 1
+          memory: 2Gi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 2
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 4Gi
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 1
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 2Gi
+      - matchSnapshot:
+          path: spec.template.spec


### PR DESCRIPTION
changelog: Propagate resources configured in teleport-kube-agent chart values to post-install and post-delete hooks.

Fixes #47598