### PR TITLE
Match SideNavigation scrollbars to theme

### DIFF
--- a/web/packages/teleport/src/Navigation/SideNavigation/Section.tsx
+++ b/web/packages/teleport/src/Navigation/SideNavigation/Section.tsx
@@ -70,6 +70,7 @@ export const RightPanel = styled(Box).attrs({ pt: 2, px: 2 })<{
   left: var(--sidenav-width);
   height: 100%;
   scrollbar-gutter: auto;
+  scrollbar-color: ${p => p.theme.colors.spotBackground[2]} transparent;
   overflow: visible;
   width: ${rightPanelWidth};
   background: ${p => p.theme.colors.levels.surface};


### PR DESCRIPTION
Tiny fix. Add `scrollbar-color` to SideNavigation panels so scrollbars don't stand out when not needed
