### PR TITLE
[v15] fix: Avoid needless user escalation during auto-enroll

### DIFF
--- a/lib/devicetrust/enroll/auto_enroll_test.go
+++ b/lib/devicetrust/enroll/auto_enroll_test.go
@@ -59,7 +59,6 @@ func TestAutoEnrollCeremony_Run(t *testing.T) {
 					SignChallenge:           test.dev.SignChallenge,
 					SolveTPMEnrollChallenge: test.dev.SolveTPMEnrollChallenge,
 				},
-				CollectDeviceData: test.dev.CollectDeviceData,
 			}
 
 			dev, err := c.Run(ctx, devices)

--- a/lib/devicetrust/enroll/enroll.go
+++ b/lib/devicetrust/enroll/enroll.go
@@ -171,6 +171,15 @@ func (c *Ceremony) Run(ctx context.Context, devicesClient devicepb.DeviceTrustSe
 	}
 	init.Token = enrollToken
 
+	return c.run(ctx, devicesClient, debug, init)
+}
+
+func (c *Ceremony) run(ctx context.Context, devicesClient devicepb.DeviceTrustServiceClient, debug bool, init *devicepb.EnrollDeviceInit) (*devicepb.Device, error) {
+	// Sanity check.
+	if init.GetToken() == "" {
+		return nil, trace.BadParameter("enroll init message lacks enrollment token")
+	}
+
 	stream, err := devicesClient.EnrollDevice(ctx)
 	if err != nil {
 		return nil, trace.Wrap(devicetrust.HandleUnimplemented(err))


### PR DESCRIPTION
Backport #47676 to branch/v15

changelog: Avoid tsh auto-enroll escalation in machines without a TPM
