### PR TITLE
[v15] teleport-cluster: set automountServiceAccountToken to false on ServiceAccounts when using newer Kubernetes distributions

### DIFF
--- a/examples/chart/teleport-cluster/templates/auth/serviceaccount.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/serviceaccount.yaml
@@ -1,4 +1,5 @@
 {{- $auth := mustMergeOverwrite (mustDeepCopy .Values) .Values.auth -}}
+{{- $projectedServiceAccountToken := semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version }}
 {{- if $auth.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
@@ -19,4 +20,7 @@ metadata:
     azure.workload.identity/client-id: "{{ $auth.azure.clientID }}"
     {{- end }}
   {{- end -}}
+{{- if $projectedServiceAccountToken }}
+automountServiceAccountToken: false
+{{- end }}
 {{- end }}

--- a/examples/chart/teleport-cluster/templates/proxy/serviceaccount.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/serviceaccount.yaml
@@ -1,4 +1,5 @@
 {{- $proxy := mustMergeOverwrite (mustDeepCopy .Values) .Values.proxy -}}
+{{- $projectedServiceAccountToken := semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version }}
 {{- if $proxy.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
@@ -13,4 +14,7 @@ metadata:
 {{- if $proxy.annotations.serviceAccount }}
   annotations: {{- toYaml $proxy.annotations.serviceAccount | nindent 4 }}
 {{- end -}}
+{{- if $projectedServiceAccountToken }}
+automountServiceAccountToken: false
+{{- end }}
 {{- end }}

--- a/examples/chart/teleport-cluster/tests/auth_serviceaccount_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_serviceaccount_test.yaml
@@ -50,3 +50,25 @@ tests:
       - equal:
           path: metadata.labels.baz
           value: overridden
+
+  - it: does not set automountServiceAccountToken if cluster version is <1.20
+    set:
+      clusterName: helm-lint
+    capabilities:
+      majorVersion: 1
+      minorVersion: 18
+    asserts:
+      - notEqual:
+          path: automountServiceAccountToken
+          value: false
+
+  - it: sets automountServiceAccountToken to false if cluster version is >=1.20
+    set:
+      clusterName: helm-lint
+    capabilities:
+      majorVersion: 1
+      minorVersion: 20
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: false

--- a/examples/chart/teleport-cluster/tests/proxy_serviceaccount_test.yaml
+++ b/examples/chart/teleport-cluster/tests/proxy_serviceaccount_test.yaml
@@ -40,3 +40,25 @@ tests:
       - equal:
           path: metadata.labels.baz
           value: overridden
+
+  - it: does not set automountServiceAccountToken if cluster version is <1.20
+    set:
+      clusterName: helm-lint
+    capabilities:
+      majorVersion: 1
+      minorVersion: 18
+    asserts:
+      - notEqual:
+          path: automountServiceAccountToken
+          value: false
+
+  - it: sets automountServiceAccountToken to false if cluster version is >=1.20
+    set:
+      clusterName: helm-lint
+    capabilities:
+      majorVersion: 1
+      minorVersion: 20
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: false


### PR DESCRIPTION
Backport #47680 to branch/v15

changelog: Alter ServiceAccounts in the teleport-cluster Helm chart to automatically disable mounting of service account tokens on newer Kubernetes distributions, helping satisfy security linters.
