### PR TITLE
[v16] Migrate old db_object_import_rule preset to new preset (#47683)

### DIFF
--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -1105,6 +1105,25 @@ func createPresetDatabaseObjectImportRule(ctx context.Context, rules services.Da
 		return trace.Wrap(err, "failed listing available database object import rules")
 	}
 	if len(importRules) > 0 {
+		// If the single rule is the old preset, we assume the user hasn't used
+		// DB DAC feature yet since the old preset alone is usually not enough
+		// to make things work. Replace it with the new preset.
+		//
+		// Creating and updating the database object import rule is handled on
+		// a best-effort basis, so it’s not included in backend migrations.
+		//
+		// TODO(greedy52) DELETE in 18.0
+		if len(importRules) == 1 && databaseobjectimportrule.IsOldImportAllObjectsRulePreset(importRules[0]) {
+			rule := databaseobjectimportrule.NewPresetImportAllObjectsRule()
+			if rule == nil {
+				return nil
+			}
+
+			_, err = rules.UpsertDatabaseObjectImportRule(ctx, rule)
+			if err != nil {
+				return trace.Wrap(err, "failed to update the default database object import rule")
+			}
+		}
 		return nil
 	}
 

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -38,11 +38,14 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
+	"google.golang.org/protobuf/proto"
 	kyaml "k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
+	dbobjectimportrulev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobjectimportrule/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/label"
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/auth/state"
@@ -53,6 +56,7 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/observability/tracing"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv/db/common/databaseobjectimportrule"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/proxy"
@@ -1881,6 +1885,110 @@ func TestTeleportProcessAuthVersionUpgradeCheck(t *testing.T) {
 			lastKnownVersion, err := authCfg.VersionStorage.GetTeleportVersion(ctx)
 			require.NoError(t, err)
 			require.Equal(t, test.expectedVersion, lastKnownVersion.String())
+		})
+	}
+}
+
+type mockDatabaseObjectImportRules struct {
+	services.DatabaseObjectImportRules
+	listRules []*dbobjectimportrulev1.DatabaseObjectImportRule
+	created   *dbobjectimportrulev1.DatabaseObjectImportRule
+	upserted  *dbobjectimportrulev1.DatabaseObjectImportRule
+}
+
+func (m *mockDatabaseObjectImportRules) ListDatabaseObjectImportRules(context.Context, int, string) ([]*dbobjectimportrulev1.DatabaseObjectImportRule, string, error) {
+	return m.listRules, "", nil
+}
+func (m *mockDatabaseObjectImportRules) CreateDatabaseObjectImportRule(ctx context.Context, rule *dbobjectimportrulev1.DatabaseObjectImportRule) (*dbobjectimportrulev1.DatabaseObjectImportRule, error) {
+	m.created = rule
+	return rule, nil
+}
+func (m *mockDatabaseObjectImportRules) UpsertDatabaseObjectImportRule(ctx context.Context, rule *dbobjectimportrulev1.DatabaseObjectImportRule) (*dbobjectimportrulev1.DatabaseObjectImportRule, error) {
+	m.upserted = rule
+	return rule, nil
+}
+
+func Test_createPresetDatabaseObjectImportRule(t *testing.T) {
+	presetRule := databaseobjectimportrule.NewPresetImportAllObjectsRule()
+	require.NotNil(t, presetRule)
+
+	customRule, err := databaseobjectimportrule.NewDatabaseObjectImportRule("dev_rule", &dbobjectimportrulev1.DatabaseObjectImportRuleSpec{
+		Priority:       100,
+		DatabaseLabels: label.FromMap(map[string][]string{"env": {"dev"}}),
+		Mappings: []*dbobjectimportrulev1.DatabaseObjectImportRuleMapping{{
+			Match: &dbobjectimportrulev1.DatabaseObjectImportMatch{
+				TableNames: []string{"*"},
+			},
+			AddLabels: map[string]string{
+				"env": "dev",
+			},
+			Scope: &dbobjectimportrulev1.DatabaseObjectImportScope{
+				SchemaNames: []string{"public"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	oldPresetRule, err := databaseobjectimportrule.NewDatabaseObjectImportRule("import_all_objects", &dbobjectimportrulev1.DatabaseObjectImportRuleSpec{
+		DatabaseLabels: label.FromMap(map[string][]string{"*": {"*"}}),
+		Mappings: []*dbobjectimportrulev1.DatabaseObjectImportRuleMapping{
+			{
+				Match:     &dbobjectimportrulev1.DatabaseObjectImportMatch{TableNames: []string{"*"}},
+				AddLabels: map[string]string{"kind": "table"},
+			},
+			{
+				Match:     &dbobjectimportrulev1.DatabaseObjectImportMatch{ViewNames: []string{"*"}},
+				AddLabels: map[string]string{"kind": "view"},
+			},
+			{
+				Match:     &dbobjectimportrulev1.DatabaseObjectImportMatch{ProcedureNames: []string{"*"}},
+				AddLabels: map[string]string{"kind": "procedure"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		existingRules []*dbobjectimportrulev1.DatabaseObjectImportRule
+		expectCreate  *dbobjectimportrulev1.DatabaseObjectImportRule
+		expectUpsert  *dbobjectimportrulev1.DatabaseObjectImportRule
+	}{
+		{
+			name:         "create preset in new cluster",
+			expectCreate: presetRule,
+		},
+		{
+			name:          "no action with custom rule",
+			existingRules: []*dbobjectimportrulev1.DatabaseObjectImportRule{customRule},
+		},
+		{
+			name:          "no action with old preset and custom rule",
+			existingRules: []*dbobjectimportrulev1.DatabaseObjectImportRule{oldPresetRule, customRule},
+		},
+		{
+			name:          "no action with preset rule",
+			existingRules: []*dbobjectimportrulev1.DatabaseObjectImportRule{presetRule},
+		},
+		{
+			name:          "migrate old preset to new",
+			existingRules: []*dbobjectimportrulev1.DatabaseObjectImportRule{oldPresetRule},
+			expectUpsert:  presetRule,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			m := &mockDatabaseObjectImportRules{
+				listRules: test.existingRules,
+			}
+
+			err := createPresetDatabaseObjectImportRule(context.Background(), m)
+			require.NoError(t, err)
+			require.True(t, proto.Equal(test.expectCreate, m.created))
+			require.True(t, proto.Equal(test.expectUpsert, m.upserted))
 		})
 	}
 }


### PR DESCRIPTION
backport of #47683 to branch/v16

changelog: added migration to update the old import_all_objects database object import rule to the new preset

minor merge conflict on imports in `init_test.go`