### PR TITLE
[v14] feat: Disable auto-enroll via environment variable

### DIFF
--- a/lib/devicetrust/enroll/auto_enroll_test.go
+++ b/lib/devicetrust/enroll/auto_enroll_test.go
@@ -16,6 +16,7 @@ package enroll_test
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -62,4 +63,11 @@ func TestAutoEnrollCeremony_Run(t *testing.T) {
 			assert.NotNil(t, dev, "AutoEnroll returned nil device")
 		})
 	}
+}
+
+func TestAutoEnroll_disabledByEnv(t *testing.T) {
+	os.Setenv("TELEPORT_DEVICE_AUTO_ENROLL_DISABLED", "1")
+
+	_, err := enroll.AutoEnroll(context.Background(), nil /* devicesClient */)
+	assert.ErrorIs(t, err, enroll.ErrAutoEnrollDisabled, "AutoEnroll() error mismatch")
 }

--- a/lib/devicetrust/enroll/auto_enroll_test.go
+++ b/lib/devicetrust/enroll/auto_enroll_test.go
@@ -16,7 +16,6 @@ package enroll_test
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -66,7 +65,7 @@ func TestAutoEnrollCeremony_Run(t *testing.T) {
 }
 
 func TestAutoEnroll_disabledByEnv(t *testing.T) {
-	os.Setenv("TELEPORT_DEVICE_AUTO_ENROLL_DISABLED", "1")
+	t.Setenv("TELEPORT_DEVICE_AUTO_ENROLL_DISABLED", "1")
 
 	_, err := enroll.AutoEnroll(context.Background(), nil /* devicesClient */)
 	assert.ErrorIs(t, err, enroll.ErrAutoEnrollDisabled, "AutoEnroll() error mismatch")


### PR DESCRIPTION
Backport #47679 and #47723 to branch/v14

changelog: Auto-enroll may be locally disabled using the `TELEPORT_DEVICE_AUTO_ENROLL_DISABLED=1` environment variable
