### PR TITLE
[v16] feat: Disable auto-enroll via environment variable

### DIFF
--- a/lib/devicetrust/enroll/auto_enroll.go
+++ b/lib/devicetrust/enroll/auto_enroll.go
@@ -20,11 +20,20 @@ package enroll
 
 import (
 	"context"
+	"errors"
+	"os"
+	"strconv"
 
 	"github.com/gravitational/trace"
 
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 )
+
+// ErrAutoEnrollDisabled signifies that auto-enroll is disabled in the current
+// device.
+// Setting the TELEPORT_DEVICE_AUTO_ENROLL_DISABLED=1 environment disables
+// auto-enroll.
+var ErrAutoEnrollDisabled = errors.New("auto-enroll disabled")
 
 // AutoEnrollCeremony is the auto-enrollment version of [Ceremony].
 type AutoEnrollCeremony struct {
@@ -49,6 +58,11 @@ func AutoEnroll(ctx context.Context, devicesClient devicepb.DeviceTrustServiceCl
 // [devicepb.DeviceTrustServiceClient.CreateDeviceEnrollToken] and enrolls the
 // device using a regular [Ceremony].
 func (c *AutoEnrollCeremony) Run(ctx context.Context, devicesClient devicepb.DeviceTrustServiceClient) (*devicepb.Device, error) {
+	const autoEnrollDisabledKey = "TELEPORT_DEVICE_AUTO_ENROLL_DISABLED"
+	if disabled, _ := strconv.ParseBool(os.Getenv(autoEnrollDisabledKey)); disabled {
+		return nil, trace.Wrap(ErrAutoEnrollDisabled)
+	}
+
 	// Creating the init message straight away aborts the process cleanly if the
 	// device cannot create the device key (for example, if it lacks a TPM).
 	// This avoids a situation where we ask for escalation, like a sudo prompt or

--- a/lib/devicetrust/enroll/auto_enroll_test.go
+++ b/lib/devicetrust/enroll/auto_enroll_test.go
@@ -20,7 +20,6 @@ package enroll_test
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -70,7 +69,7 @@ func TestAutoEnrollCeremony_Run(t *testing.T) {
 }
 
 func TestAutoEnroll_disabledByEnv(t *testing.T) {
-	os.Setenv("TELEPORT_DEVICE_AUTO_ENROLL_DISABLED", "1")
+	t.Setenv("TELEPORT_DEVICE_AUTO_ENROLL_DISABLED", "1")
 
 	_, err := enroll.AutoEnroll(context.Background(), nil /* devicesClient */)
 	assert.ErrorIs(t, err, enroll.ErrAutoEnrollDisabled, "AutoEnroll() error mismatch")

--- a/lib/devicetrust/enroll/auto_enroll_test.go
+++ b/lib/devicetrust/enroll/auto_enroll_test.go
@@ -20,6 +20,7 @@ package enroll_test
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -66,4 +67,11 @@ func TestAutoEnrollCeremony_Run(t *testing.T) {
 			assert.NotNil(t, dev, "AutoEnroll returned nil device")
 		})
 	}
+}
+
+func TestAutoEnroll_disabledByEnv(t *testing.T) {
+	os.Setenv("TELEPORT_DEVICE_AUTO_ENROLL_DISABLED", "1")
+
+	_, err := enroll.AutoEnroll(context.Background(), nil /* devicesClient */)
+	assert.ErrorIs(t, err, enroll.ErrAutoEnrollDisabled, "AutoEnroll() error mismatch")
 }


### PR DESCRIPTION
Backport #47679 and #47723 to branch/v16

changelog: Auto-enroll may be locally disabled using the TELEPORT_DEVICE_AUTO_ENROLL_DISABLED=1 environment variable
