### PR TITLE
Document preference for capitalized log messages

### DIFF
--- a/rfd/0154-logging-guidelines.md
+++ b/rfd/0154-logging-guidelines.md
@@ -138,9 +138,9 @@ log several messages, be that in a function or a logger that is a struct member.
 >```go
 >slogLogger := slog.With("device_id", ref.DeviceID, "os_type", ref.OSType, "asset_tag", assetTag)
 >...
->slogLogger.DebugContext(ctx, "some message")
+>slogLogger.DebugContext(ctx, "Some message")
 >...
->slogLogger.WarnContext(ctx, "some other message")
+>slogLogger.WarnContext(ctx, "Some other message")
 >```
 
 #### WithError

--- a/rfd/0154-logging-guidelines.md
+++ b/rfd/0154-logging-guidelines.md
@@ -211,6 +211,8 @@ to `log/slog`, we should do our best to start following a few simple rules.
    a `context.Background` to indicate as such.
 1) The message should be a fragment, and not a full sentence. Terminating the message with punctuation should be
    avoided.
+1) Starting the message with capitalization is preferred ("Speed threshold reached" instead of "speed threshold
+   reached").
 
 To achieve these, we can add enable the [`sloglint`](https://github.com/go-simpler/sloglint) linter in our golangci-lint
 configuration.


### PR DESCRIPTION
Document the preferred logging style for messages (capitalized vs lowercase).