### PR TITLE
Filter Linux hosts out from desktop LDAP discovery results

### DIFF
--- a/lib/srv/desktop/discovery.go
+++ b/lib/srv/desktop/discovery.go
@@ -262,6 +262,10 @@ func (s *WindowsService) ldapEntryToWindowsDesktop(ctx context.Context, entry *l
 	labels[types.DiscoveryLabelWindowsDomain] = s.cfg.Domain
 	s.applyLabelsFromLDAP(entry, labels)
 
+	if os, ok := labels[types.DiscoveryLabelWindowsOS]; ok && strings.Contains(os, "linux") {
+		return nil, trace.BadParameter("LDAP entry looks like a Linux host")
+	}
+
 	addrs, err := s.lookupDesktop(ctx, hostname)
 	if err != nil || len(addrs) == 0 {
 		return nil, trace.WrapWithMessage(err, "couldn't resolve %q", hostname)


### PR DESCRIPTION
Domain joined Linux hosts (including those used for Teleport's db_service with MS SQL) won't support RDP, so prevent them from being discovered and registered with Teleport.

Closes #14116

Changelog: Teleport's Windows desktop service now filters domain-joined Linux hosts out during LDAP discovery.