### PR TITLE
[v16] [buddy] fix: use proxy from env for compatible integrations

### DIFF
--- a/integrations/access/datadog/client.go
+++ b/integrations/access/datadog/client.go
@@ -75,6 +75,7 @@ func NewDatadogClient(conf DatadogConfig, webProxyAddr string, statusSink common
 		Transport: &http.Transport{
 			MaxConnsPerHost:     datadogMaxConns,
 			MaxIdleConnsPerHost: datadogMaxConns,
+			Proxy:               http.ProxyFromEnvironment,
 		}}).
 		SetBaseURL(apiEndpoint).
 		SetHeader("Accept", "application/json").

--- a/integrations/access/discord/config.go
+++ b/integrations/access/discord/config.go
@@ -109,6 +109,7 @@ func (c *Config) NewBot(clusterName, webProxyAddr string) (common.MessagingBot, 
 			Transport: &http.Transport{
 				MaxConnsPerHost:     discordMaxConns,
 				MaxIdleConnsPerHost: discordMaxConns,
+				Proxy:               http.ProxyFromEnvironment,
 			},
 		}).
 		SetBaseURL(c.Discord.APIURL).

--- a/integrations/access/jira/client.go
+++ b/integrations/access/jira/client.go
@@ -99,6 +99,7 @@ func NewJiraClient(conf JiraConfig, clusterName, teleportProxyAddr string, statu
 		Transport: &http.Transport{
 			MaxConnsPerHost:     jiraMaxConns,
 			MaxIdleConnsPerHost: jiraMaxConns,
+			Proxy:               http.ProxyFromEnvironment,
 		}}).
 		SetBaseURL(conf.URL).
 		SetBasicAuth(conf.Username, conf.APIToken).

--- a/integrations/access/mattermost/bot.go
+++ b/integrations/access/mattermost/bot.go
@@ -116,6 +116,7 @@ func NewBot(conf Config, clusterName, webProxyAddr string) (Bot, error) {
 			Transport: &http.Transport{
 				MaxConnsPerHost:     mmMaxConns,
 				MaxIdleConnsPerHost: mmMaxConns,
+				Proxy:               http.ProxyFromEnvironment,
 			},
 		}).
 		SetBaseURL(conf.Mattermost.URL).

--- a/integrations/access/opsgenie/client.go
+++ b/integrations/access/opsgenie/client.go
@@ -116,6 +116,9 @@ func (cfg *ClientConfig) CheckAndSetDefaults() error {
 // NewClient creates a new Opsgenie client for managing alerts.
 func NewClient(conf ClientConfig) (*Client, error) {
 	client := resty.NewWithClient(defaults.Config().HTTPClient)
+	client.SetTransport(&http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+	})
 	client.SetHeader("Authorization", "GenieKey "+conf.APIKey)
 	client.SetBaseURL(conf.APIEndpoint)
 	return &Client{

--- a/integrations/access/pagerduty/client.go
+++ b/integrations/access/pagerduty/client.go
@@ -89,6 +89,7 @@ func NewPagerdutyClient(conf PagerdutyConfig, clusterName, webProxyAddr string, 
 		Transport: &http.Transport{
 			MaxConnsPerHost:     pdMaxConns,
 			MaxIdleConnsPerHost: pdMaxConns,
+			Proxy:               http.ProxyFromEnvironment,
 		}}).
 		SetBaseURL(conf.APIEndpoint).
 		SetHeader("Accept", "application/vnd.pagerduty+json;version=2").

--- a/integrations/access/servicenow/client.go
+++ b/integrations/access/servicenow/client.go
@@ -102,6 +102,9 @@ func NewClient(conf ClientConfig) (*Client, error) {
 		return nil, trace.Wrap(err)
 	}
 	client := resty.NewWithClient(defaults.Config().HTTPClient)
+	client.SetTransport(&http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+	})
 	apiURL, err := url.Parse(conf.APIEndpoint)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/integrations/access/slack/config.go
+++ b/integrations/access/slack/config.go
@@ -139,7 +139,6 @@ func (c *Config) NewBot(clusterName, webProxyAddr string) (common.MessagingBot, 
 			return nil
 		}).
 		OnAfterResponse(onAfterResponseSlack(c.StatusSink))
-
 	return Bot{
 		client:      client,
 		clock:       c.Clock,

--- a/integrations/access/slack/http.go
+++ b/integrations/access/slack/http.go
@@ -37,5 +37,8 @@ func makeSlackClient(apiURL string) *resty.Client {
 		}).
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetBaseURL(apiURL)
+		SetBaseURL(apiURL).
+		SetTransport(&http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+		})
 }


### PR DESCRIPTION
Backport #47663 to branch/v16

changelog: Respect `HTTP_PROXY` environment variables for Access Request integrations.
