### PR TITLE
Fix flaky TestInitDatabaseService

### DIFF
--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -1782,12 +1782,16 @@ func TestInitDatabaseService(t *testing.T) {
 
 			cfg := servicecfg.MakeDefaultConfig()
 			cfg.DataDir = t.TempDir()
+			cfg.DebugService = servicecfg.DebugConfig{
+				Enabled: false,
+			}
 			cfg.Auth.StorageConfig.Params["path"] = t.TempDir()
 			cfg.Hostname = "default.example.com"
 			cfg.Auth.Enabled = true
 			cfg.SetAuthServerAddress(utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"})
 			cfg.Auth.ListenAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
 			cfg.Auth.StorageConfig.Params["path"] = t.TempDir()
+			cfg.Auth.SessionRecordingConfig.SetMode(types.RecordOff)
 			cfg.Proxy.Enabled = true
 			cfg.Proxy.DisableWebInterface = true
 			cfg.Proxy.WebAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: "localhost:0"}


### PR DESCRIPTION
Addresses two separate issues caused by using t.TempDir as the data directory in the test.

- Session recording is disabled to avoid cleanup problems with a non-empty data dir
- The debug service is disabled to prevent long unix socket paths from failing tests on macOS

Closes #42963