### PR TITLE
[Web] Fix error when using sidenav search while on non-sidenav section

### DIFF
--- a/web/packages/teleport/src/Navigation/SideNavigation/Search.tsx
+++ b/web/packages/teleport/src/Navigation/SideNavigation/Search.tsx
@@ -123,7 +123,7 @@ function SearchContent({
               <SearchResult
                 key={index}
                 subsection={subsection}
-                $active={currentView.route === subsection.route}
+                $active={currentView?.route === subsection.route}
               />
             ))}
           </Flex>


### PR DESCRIPTION
This PR fixes a bug in the search which didn't handle `currentView` being undefined, which occurs when the user is on a page which isn't part of the sidenav (such as `Account Settings`). `currentView` is intended to represent the current sidenav section that the user is on, this is used to highlight that section in the sidenav to indicate it as being active. This meant that using the sidenav search while on one of those pages would trigger an error, since it would be a page not on the sidenav and thus `currentView` would be undefined.