### PR TITLE
docs: update policy prereqs

### DIFF
--- a/docs/pages/admin-guides/teleport-policy/integrations/aws-sync.mdx
+++ b/docs/pages/admin-guides/teleport-policy/integrations/aws-sync.mdx
@@ -60,12 +60,13 @@ graphical representation thereof.
 ## Prerequisites
 
 - A running Teleport Enterprise cluster v14.3.9/v15.2.0 or later.
-- For self-hosted clusters, an updated `license.pem` with Teleport Policy enabled.
-- For self-hosted clusters, a running Access Graph node v1.17.0 or later. 
-Check [Access Graph page](../teleport-policy.mdx) for details on
+- Teleport Policy enabled for your account.
+- For self-hosted clusters:
+  - Ensure that an up-to-date `license.pem` is used in the Auth Service configuration.
+  - A running Access Graph node v1.17.0 or later.
+Check the [Teleport Policy page](../teleport-policy.mdx) for details on
 how to set up Access Graph.
-- The node running the Access Graph service must be reachable
-from Teleport Auth Service and Discovery Service. 
+  - The node running the Access Graph service must be reachable from the Teleport Auth Service.
 
 ## Step 1/2. Configure Discovery Service (Self-hosted only)
 

--- a/docs/pages/admin-guides/teleport-policy/integrations/entra-id.mdx
+++ b/docs/pages/admin-guides/teleport-policy/integrations/entra-id.mdx
@@ -35,11 +35,12 @@ These resources are then visualized using the graph representation detailed in t
 
 - A running Teleport Enterprise cluster v15.4.2/v16.0.0 or later.
 - Teleport Identity and Teleport Policy enabled for your account.
-  - For self-hosted clusters, ensure that an up-to-date `license.pem` is used in the Auth Service configuration.
-- For self-hosted clusters, a running Access Graph node v1.21.3 or later.
+- For self-hosted clusters:
+  - Ensure that an up-to-date `license.pem` is used in the Auth Service configuration.
+  - A running Access Graph node v1.21.3 or later.
 Check the [Teleport Policy page](../teleport-policy.mdx) for details on
 how to set up Access Graph.
-- The node running the Access Graph service must be reachable from the Teleport Auth Service.
+  - The node running the Access Graph service must be reachable from the Teleport Auth Service.
 - Your user must have privileged administrator permissions in the Azure account
 
 To verify that Access Graph is set up correctly for your cluster, sign in to the Teleport Web UI and navigate to the Management tab.

--- a/docs/pages/admin-guides/teleport-policy/integrations/gitlab.mdx
+++ b/docs/pages/admin-guides/teleport-policy/integrations/gitlab.mdx
@@ -46,13 +46,14 @@ graphical representation thereof.
 ## Prerequisites
 
 - A running Teleport Enterprise cluster v14.3.20/v15.3.1/v16.0.0 or later.
-- For self-hosted clusters, an updated `license.pem` with Teleport Policy enabled.
-- For self-hosted clusters, a running Access Graph node v1.21.4 or later.
-Check [Access Graph page](../teleport-policy.mdx) for details on
-how to set up Access Graph.
-- For self-hosted clusters, the node running the Access Graph service must be reachable
-from Teleport Auth Service.
+- Teleport Policy enabled for your account.
 - A GitLab instance running GitLab v9.0 or later.
+- For self-hosted clusters:
+  - Ensure that an up-to-date `license.pem` is used in the Auth Service configuration.
+  - A running Access Graph node v1.21.4 or later.
+Check the [Teleport Policy page](../teleport-policy.mdx) for details on
+how to set up Access Graph.
+  - The node running the Access Graph service must be reachable from the Teleport Auth Service.
 
 ## Step 1/3. Create GitLab token
 

--- a/docs/pages/admin-guides/teleport-policy/integrations/ssh-keys-scan.mdx
+++ b/docs/pages/admin-guides/teleport-policy/integrations/ssh-keys-scan.mdx
@@ -70,15 +70,16 @@ It also never sends the private key path or any other sensitive information.
 ## Prerequisites
 
 - A running Teleport Enterprise cluster v15.4.16/v16.2.0 or later.
-- For self-hosted clusters, an updated `license.pem` with Teleport Policy enabled.
-- For self-hosted clusters, a running Access Graph node v1.22.0 or later.
-Check [Access Graph page](../teleport-policy.mdx) for details on
-how to set up Access Graph.
-- For self-hosted clusters, the node running the Access Graph service must be reachable
-from Teleport Auth Service.
+- Teleport Policy enabled for your account.
 - A Linux/macOS server running the Teleport SSH Service.
 - Devices enrolled in the [Teleport Device Trust feature](../../access-controls/device-trust.mdx).
 - For Jamf Pro integration, devices must be enrolled in Jamf Pro and have the signed `tsh` binary installed.
+- For self-hosted clusters:
+  - Ensure that an up-to-date `license.pem` is used in the Auth Service configuration.
+  - A running Access Graph node v1.22.0 or later.
+Check the [Teleport Policy page](../teleport-policy.mdx) for details on
+how to set up Access Graph.
+  - The node running the Access Graph service must be reachable from the Teleport Auth Service.
 
 ## Step 1/3. Enable SSH Key Scanning
 


### PR DESCRIPTION
Pre-reqs for Teleport Policy integrations were not consistent for self-hosted. 