### PR TITLE
Suppress stack trace on HostSudoers handled error

### DIFF
--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -70,7 +70,7 @@ func NewHostSudoers(uuid string) HostSudoers {
 	backend, err := newHostSudoersBackend(uuid)
 	switch {
 	case trace.IsNotImplemented(err):
-		slog.DebugContext(context.Background(), "Skipping host sudoers management", "error", err)
+		slog.DebugContext(context.Background(), "Skipping host sudoers management", "error", err.Error())
 		return nil
 	case err != nil: //nolint:staticcheck // linter fails on non-linux system as only linux implementation returns useful values.
 		slog.DebugContext(context.Background(), "Error making new HostSudoersBackend", "error", err)


### PR DESCRIPTION
On non-Linux systems, the implementation returns `trace.NotImplemented`.
This was being logged with the stack trace which could lead to thinking there was real issue.
However, given that we are already handling the error gracefully, we can just print the error message and suppress the stack trace.

Before
```
2024-10-22T11:05:11+01:00 DEBU  Skipping host sudoers management error:[
ERROR REPORT:
Original Error: *trace.NotImplementedError Host user creation management is only supported on linux
Stack Trace:
        github.com/gravitational/teleport/lib/srv/usermgmt_other.go:35 github.com/gravitational/teleport/lib/srv.newHostSudoersBackend
        github.com/gravitational/teleport/lib/srv/usermgmt.go:70 github.com/gravitational/teleport/lib/srv.NewHostSudoers
        github.com/gravitational/teleport/lib/srv/regular/sshserver.go:802 github.com/gravitational/teleport/lib/srv/regular.New
        github.com/gravitational/teleport/lib/service/service.go:4800 github.com/gravitational/teleport/lib/service.(*TeleportProcess).initProxyEndpoint
        github.com/gravitational/teleport/lib/service/service.go:3795 github.com/gravitational/teleport/lib/service.(*TeleportProcess).initProxy.func1
        github.com/gravitational/teleport/lib/service/supervisor.go:581 github.com/gravitational/teleport/lib/service.(*LocalService).Serve
        github.com/gravitational/teleport/lib/service/supervisor.go:307 github.com/gravitational/teleport/lib/service.(*LocalSupervisor).serve.func1
        runtime/asm_arm64.s:1223 runtime.goexit
User Message: Host user creation management is only supported on linux] srv/usermgmt.go:73
```

After
```
2024-10-22T11:07:58+01:00 DEBU  Skipping host sudoers management error:Host user creation management is only supported on linux srv/usermgmt.go:73
```