### PR TITLE
set default algorithm suite when other auth pref fields are set

### DIFF
--- a/api/types/authentication.go
+++ b/api/types/authentication.go
@@ -621,6 +621,9 @@ type SignatureAlgorithmSuiteParams struct {
 // brand new cluster or after resetting the auth preference.
 func (c *AuthPreferenceV2) SetDefaultSignatureAlgorithmSuite(params SignatureAlgorithmSuiteParams) {
 	switch {
+	case c.Spec.SignatureAlgorithmSuite != SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_UNSPECIFIED && c.Metadata.Labels[OriginLabel] != OriginDefaults:
+		// If the suite is set and it's not a default value, return.
+		return
 	case params.FIPS:
 		c.SetSignatureAlgorithmSuite(SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_FIPS_V1)
 	case params.UsingHSMOrKMS || params.Cloud:

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -788,32 +788,39 @@ func initializeAuthPreference(ctx context.Context, asrv *Server, newAuthPref typ
 			return nil
 		}
 
+		switch {
+		case storedAuthPref == nil:
+			// This is a brand new cluster with no stored auth pref, set a
+			// default signature algorithm suite.
+			newAuthPref = newAuthPref.Clone()
+			newAuthPref.SetDefaultSignatureAlgorithmSuite(types.SignatureAlgorithmSuiteParams{
+				FIPS:          asrv.fips,
+				UsingHSMOrKMS: asrv.keyStore.UsingHSMOrKMS(),
+				Cloud:         modules.GetModules().Features().Cloud,
+			})
+		case newAuthPref.Origin() == types.OriginDefaults:
+			// There is a stored auth preference which we are overwriting with a
+			// default auth preference. Maintain the stored signature algorithm
+			// suite to avoid automatically changing it on version upgrades, new
+			// suites should always be opt-in for existing clusters.
+			newAuthPref = newAuthPref.Clone()
+			newAuthPref.SetSignatureAlgorithmSuite(storedAuthPref.GetSignatureAlgorithmSuite())
+		case newAuthPref.GetSignatureAlgorithmSuite() == types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_UNSPECIFIED:
+			// There is a stored auth preference and the new auth preference is
+			// coming from a config file where the signature_algorithm_suite is
+			// unset. Maintain the stored signature algorithm suite otherwise we
+			// would unset the default suite after the first auth restart.
+			newAuthPref = newAuthPref.Clone()
+			newAuthPref.SetSignatureAlgorithmSuite(storedAuthPref.GetSignatureAlgorithmSuite())
+		}
+
 		if storedAuthPref == nil {
 			log.Infof("Creating cluster auth preference: %v.", newAuthPref)
-
-			if newAuthPref.Origin() == types.OriginDefaults {
-				// Set a default signature algorithm suite for a new cluster.
-				newAuthPref.SetDefaultSignatureAlgorithmSuite(types.SignatureAlgorithmSuiteParams{
-					FIPS:          asrv.fips,
-					UsingHSMOrKMS: asrv.keyStore.UsingHSMOrKMS(),
-					Cloud:         modules.GetModules().Features().Cloud,
-				})
-			}
-
 			_, err := asrv.CreateAuthPreference(ctx, newAuthPref)
 			if trace.IsAlreadyExists(err) {
 				continue
 			}
-
 			return trace.Wrap(err)
-		}
-
-		if newAuthPref.Origin() == types.OriginDefaults {
-			// Never overwrite a stored signature algorithm suite with a default
-			// signature algorithm suite. This prevents the suite from being
-			// "upgraded" by a Teleport version upgrade alone, even if defaults
-			// are used on both versions.
-			newAuthPref.SetSignatureAlgorithmSuite(storedAuthPref.GetSignatureAlgorithmSuite())
 		}
 
 		newAuthPref.SetRevision(storedAuthPref.GetRevision())


### PR DESCRIPTION
For new clusters in master and v17 we currently try to set a default `cluster_auth_preference.spec.signature_algorithm_suite` so that new clusters will use the new signature algorithms. However, we currently only set this default if the `teleport.dev/origin` label of the `cluster_auth_preference` is `defaults`. If the user sets any other field in the teleport.yaml config that ends up being stored in the `cluster_auth_preference`, the origin label ends up being `config-file` and the cluster doesn't get the new default signature_algorithm_suite.

This can cause unexpected behaviour - for example, if you don't set up webauthn in teleport.yaml your cluster gets the new algorithms, if you do set up webauthn you are stuck with RSA.

This PR updates the logic to set the default `signature_algorithm_suite` for new clusters whether or not any other field in the `cluster_auth_preference` is set in the config file.