### PR TITLE
Machine ID: Initialize destinations and file ACLs at runtime

### DIFF
--- a/lib/tbot/botfs/botfs.go
+++ b/lib/tbot/botfs/botfs.go
@@ -100,13 +100,15 @@ type ACLOptions struct {
 }
 
 // ACLSelector is a target for an ACL entry, pointing at e.g. a single user or
-// group.
+// group. Only one field may be specified in a given selector and this should be
+// validated with `CheckAndSetDefaults()`.
 type ACLSelector struct {
 	// User is a user specifier. If numeric, it is treated as a UID. Only one
-	// field may be specified per entry.
+	// field may be specified per ACLSelector.
 	User string `yaml:"user,omitempty"`
 
-	// Group is a group specifier. If numeric, it is treated as a UID.
+	// Group is a group specifier. If numeric, it is treated as a UID. Only one
+	// field may be specified per ACLSelector.
 	Group string `yaml:"group,omitempty"`
 }
 
@@ -162,7 +164,9 @@ func createStandard(path string, isDir bool) error {
 }
 
 // TestACL attempts to create a temporary file in the given parent directory and
-// apply an ACL to it.
+// apply an ACL to it. Note that `readers` should be representative of runtime
+// reader configuration as `ConfigureACL()` may attempt to resolve named users,
+// and may fail if resolution fails.
 func TestACL(directory string, readers []*ACLSelector) error {
 	// Note: we need to create the test file in the dest dir to ensure we
 	// actually test the target filesystem.

--- a/lib/tbot/botfs/botfs.go
+++ b/lib/tbot/botfs/botfs.go
@@ -23,7 +23,9 @@ import (
 	"io/fs"
 	"os"
 	"os/user"
+	"path/filepath"
 
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
@@ -97,6 +99,29 @@ type ACLOptions struct {
 	ReaderUser *user.User
 }
 
+// ACLSelector is a target for an ACL entry, pointing at e.g. a single user or
+// group.
+type ACLSelector struct {
+	// User is a user specifier. If numeric, it is treated as a UID. Only one
+	// field may be specified per entry.
+	User string `yaml:"user,omitempty"`
+
+	// Group is a group specifier. If numeric, it is treated as a UID.
+	Group string `yaml:"group,omitempty"`
+}
+
+func (s *ACLSelector) CheckAndSetDefaults() error {
+	if s.User != "" && s.Group != "" {
+		return trace.BadParameter("reader: only one of 'user' and 'group' may be set, not both")
+	}
+
+	if s.User == "" && s.Group == "" {
+		return trace.BadParameter("reader: one of 'user' or 'group' must be set")
+	}
+
+	return nil
+}
+
 // openStandard attempts to open the given path for reading and writing with
 // O_CREATE set.
 func openStandard(path string, mode OpenMode) (*os.File, error) {
@@ -131,6 +156,41 @@ func createStandard(path string, isDir bool) error {
 			"path", path,
 			"error", err,
 		)
+	}
+
+	return nil
+}
+
+// TestACL attempts to create a temporary file in the given parent directory and
+// apply an ACL to it.
+func TestACL(directory string, readers []*ACLSelector) error {
+	// Note: we need to create the test file in the dest dir to ensure we
+	// actually test the target filesystem.
+	id, err := uuid.NewRandom()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	testFile := filepath.Join(directory, id.String())
+	if err := Create(testFile, false, SymlinksInsecure); err != nil {
+		return trace.Wrap(err)
+	}
+
+	defer func() {
+		err := os.Remove(testFile)
+		if err != nil {
+			log.DebugContext(
+				context.TODO(),
+				"Failed to delete ACL test file",
+				"path", testFile,
+			)
+		}
+	}()
+
+	// Configure a dummy ACL that redundantly includes the user as a reader.
+	//nolint:staticcheck // staticcheck doesn't like nop implementations in fs_other.go
+	if err := ConfigureACL(testFile, readers); err != nil {
+		return trace.Wrap(err)
 	}
 
 	return nil

--- a/lib/tbot/botfs/fs_linux.go
+++ b/lib/tbot/botfs/fs_linux.go
@@ -24,6 +24,7 @@ package botfs
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -44,6 +45,9 @@ import (
 // Openat2MinKernel is the kernel release that adds support for the openat2()
 // syscall.
 const Openat2MinKernel = "5.6.0"
+
+// mostACLRead is a permission mode granting readonly access to a file.
+const modeACLRead fs.FileMode = 04
 
 // modeACLReadExecute is the permissions mode needed for read on directories.
 const modeACLReadExecute fs.FileMode = 05
@@ -267,10 +271,11 @@ func desiredPerms(path string) (ownerMode fs.FileMode, botAndReaderMode fs.FileM
 	return
 }
 
-// VerifyACL verifies whether the ACL of the given file allows writes from the
-// bot user. Errors may optionally be used as more informational warnings;
-// ConfigureACL can be used to correct them, assuming the user has permissions.
-func VerifyACL(path string, opts *ACLOptions) error {
+// VerifyLegacyACL verifies whether the ACL of the given file allows writes from
+// the bot user. Errors may optionally be used as more informational warnings;
+// ConfigureLegacyACL can be used to correct them, assuming the user has
+// permissions.
+func VerifyLegacyACL(path string, opts *ACLOptions) error {
 	current, err := acl.Get(path)
 	if err != nil {
 		return trace.Wrap(err)
@@ -365,9 +370,9 @@ func VerifyACL(path string, opts *ACLOptions) error {
 	return trace.NewAggregate(errors...)
 }
 
-// ConfigureACL configures ACLs of the given file to allow writes from the bot
+// ConfigureLegacyACL configures ACLs of the given file to allow writes from the bot
 // user.
-func ConfigureACL(path string, owner *user.User, opts *ACLOptions) error {
+func ConfigureLegacyACL(path string, owner *user.User, opts *ACLOptions) error {
 	if owner.Uid == opts.BotUser.Uid && owner.Uid == opts.ReaderUser.Uid {
 		// We'll end up with an empty ACL. This isn't technically a problem
 		log.WarnContext(
@@ -439,11 +444,219 @@ func ConfigureACL(path string, owner *user.User, opts *ACLOptions) error {
 
 	log.DebugContext(
 		context.TODO(),
+		"Configuring legacy ACL on path",
+		"path", path,
+		"acl", desiredACL,
+	)
+	return trace.ConvertSystemError(trace.Wrap(acl.Set(path, desiredACL)))
+}
+
+// resolveACLReaderSelector attempts to convert an ACL selector into a
+// platform-specific acl.Entry that can be applied to a file.
+func resolveACLReaderSelector(s *ACLSelector, dir bool) (acl.Entry, error) {
+	var perm fs.FileMode = modeACLRead
+	if dir {
+		perm = modeACLReadExecute
+	}
+
+	switch {
+	case s.User != "":
+		_, err := strconv.ParseInt(s.User, 10, 32)
+		if err == nil {
+			// User is a valid number, so return it directly. We don't need to
+			// check the particular value as it's explicitly allowed to
+			// configure entries for nonexistent users.
+			return acl.Entry{
+				Tag:       acl.TagUser,
+				Qualifier: s.User,
+				Perms:     perm,
+			}, nil
+		}
+
+		user, err := user.Lookup(s.User)
+		if err != nil {
+			return acl.Entry{}, trace.Wrap(err)
+		}
+
+		return acl.Entry{
+			Tag:       acl.TagUser,
+			Qualifier: user.Uid,
+			Perms:     perm,
+		}, nil
+	case s.Group != "":
+		_, err := strconv.ParseInt(s.Group, 10, 32)
+		if err == nil {
+			// Group is a valid number, so return it directly.
+			return acl.Entry{
+				Tag:       acl.TagGroup,
+				Qualifier: s.Group,
+				Perms:     perm,
+			}, nil
+		}
+
+		group, err := user.LookupGroup(s.Group)
+		if err != nil {
+			return acl.Entry{}, trace.Wrap(err)
+		}
+
+		return acl.Entry{
+			Tag:       acl.TagGroup,
+			Qualifier: group.Gid,
+			Perms:     perm,
+		}, nil
+	default:
+		return acl.Entry{}, trace.BadParameter("unable to resolve ACL selector, user or group must be specified: %+v", s)
+	}
+}
+
+// aclMaskForSelectors returns an appropriate ACL mask entry given the list of
+// selectors.
+func aclReaderMask(dir bool) acl.Entry {
+	perms := modeACLRead
+	if dir {
+		perms = modeACLReadExecute
+	}
+
+	return acl.Entry{
+		Tag:   acl.TagMask,
+		Perms: perms,
+	}
+}
+
+// aclFromReaders builds an ACL for a generic file or directory from the given
+// list of reader selectors.
+func aclFromReaders(selectors []*ACLSelector, dir bool) (acl.ACL, error) {
+	// Note: these entries are out of their required order, but go-acl sorts
+	// them before applying.
+	ownerPerms := modeACLReadWrite
+	if dir {
+		ownerPerms = modeACLReadWriteExecute
+	}
+
+	desiredACL := acl.ACL{
+		{
+			Tag:   acl.TagUserObj,
+			Perms: ownerPerms,
+		},
+		{
+			Tag:   acl.TagGroupObj,
+			Perms: modeACLNone,
+		},
+		aclReaderMask(dir),
+		{
+			Tag:   acl.TagOther,
+			Perms: modeACLNone,
+		},
+	}
+
+	for _, selector := range selectors {
+		entry, err := resolveACLReaderSelector(selector, dir)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		desiredACL = append(desiredACL, entry)
+	}
+
+	return desiredACL, nil
+}
+
+// ConfigureACL configures a bot-user-owned ACL at the given path such that it
+// can be read by the given list of readers. If the list is empty, appropriate
+// non-ACL permissions will be set to ensure only the bot user can read the
+// file.
+func ConfigureACL(path string, readers []*ACLSelector) error {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	dir := stat.IsDir()
+
+	desiredACL, err := aclFromReaders(readers, dir)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	log.DebugContext(
+		context.TODO(),
 		"Configuring ACL on path",
 		"path", path,
 		"acl", desiredACL,
 	)
 	return trace.ConvertSystemError(trace.Wrap(acl.Set(path, desiredACL)))
+}
+
+// permStrings is a list of possible permission string representations,
+// duplicated from `acl` as it is private.
+var permStrings = []string{
+	0: "---",
+	1: "--x",
+	2: "-w-",
+	3: "-wx",
+	4: "r--",
+	5: "r-x",
+	6: "rw-",
+	7: "rwx",
+}
+
+// formatEntry formats an ACL entry without attempting to resolve UIDs or GIDs
+// to ensure consistent results in tests and elsewhere. Inlined from
+// acl.Entry.String().
+func formatEntry(e acl.Entry) string {
+	middle := "::"
+	if e.Tag == acl.TagUser || e.Tag == acl.TagGroup {
+		middle = ":" + e.Qualifier + ":"
+	}
+	return fmt.Sprintf("%s%s%s", e.Tag, middle, permStrings[7&e.Perms])
+}
+
+// CompareACL compares two ACLs to check if they match. Returns an empty list if
+// the two are identity, otherwise returns a list of error messages for each
+// issue found.
+func CompareACL(expected, candidate acl.ACL) []string {
+	expectedSet := utils.NewSet(expected...)
+	candidateSet := utils.NewSet(candidate...)
+
+	missing := expectedSet.Clone().Subtract(candidateSet)
+	unexpected := candidateSet.Clone().Subtract(expectedSet)
+
+	var issues []string
+	for m := range missing {
+		issues = append(issues, fmt.Sprintf("missing required entry: %s", formatEntry(m)))
+	}
+	for u := range unexpected {
+		issues = append(issues, fmt.Sprintf("unexpected entry: %s", formatEntry(u)))
+	}
+
+	return issues
+}
+
+// VerifyACL loads the ACL for the file at the given path and compares it to
+// the expected ACL as determined by the given list of reader selectors,
+// returning a list of issues found. An empty list (and nil error) implies a
+// valid ACL. The path must exist and the user must have permission to `os.Stat`
+// it. Errors will be returned if the ACL was unable to be read.
+func VerifyACL(path string, readers []*ACLSelector) ([]string, error) {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return []string{}, trace.Wrap(err)
+	}
+
+	dir := stat.IsDir()
+
+	expected, err := aclFromReaders(readers, dir)
+	if err != nil {
+		return []string{}, trace.Wrap(err)
+	}
+
+	fsACL, err := acl.Get(path)
+	if err != nil {
+		return []string{}, trace.Wrap(err)
+	}
+
+	issues := CompareACL(expected, fsACL)
+	return issues, nil
 }
 
 // HasACLSupport determines if this binary / system supports ACLs.
@@ -496,12 +709,12 @@ func GetOwner(fileInfo fs.FileInfo) (*user.User, error) {
 
 // IsOwnedBy checks that the file at the given path is owned by the given user.
 // Returns a trace.NotImplemented() on unsupported platforms.
-func IsOwnedBy(fileInfo fs.FileInfo, user *user.User) (bool, error) {
+func IsOwnedBy(fileInfo fs.FileInfo, uid int) (bool, error) {
 	info, ok := fileInfo.Sys().(*syscall.Stat_t)
 	if !ok {
 		return false, trace.Errorf("unexpected type of file info on Linux: %T", fileInfo.Sys())
 	}
 
 	// Our files are 0600, so don't bother checking gid.
-	return strconv.Itoa(int(info.Uid)) == user.Uid, nil
+	return int(info.Uid) == uid, nil
 }

--- a/lib/tbot/botfs/fs_linux_test.go
+++ b/lib/tbot/botfs/fs_linux_test.go
@@ -1,0 +1,100 @@
+//go:build linux
+// +build linux
+
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package botfs
+
+import (
+	"testing"
+
+	"github.com/joshlf/go-acl"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompareACL(t *testing.T) {
+	// Note: no named users or groups since we can't depend on names.
+	readersA := []*ACLSelector{
+		{User: "123"},
+		{Group: "456"},
+	}
+	readersB := []*ACLSelector{
+		{Group: "123"},
+		{User: "456"},
+	}
+
+	testA, err := aclFromReaders(readersA, false)
+	require.NoError(t, err)
+
+	testB, err := aclFromReaders(readersB, false)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		expected  acl.ACL
+		candidate acl.ACL
+		assert    func(t *testing.T, issues []string)
+	}{
+		{
+			name:      "matching",
+			expected:  testA,
+			candidate: testA,
+			assert: func(t *testing.T, issues []string) {
+				require.Empty(t, issues)
+			},
+		},
+		{
+			name:      "empty candidate",
+			expected:  testA,
+			candidate: acl.ACL{},
+			assert: func(t *testing.T, issues []string) {
+				require.Len(t, issues, 6)
+				require.ElementsMatch(t, issues, []string{
+					"missing required entry: u::rw-",
+					"missing required entry: g::---",
+					"missing required entry: m::r--",
+					"missing required entry: o::---",
+					"missing required entry: u:123:r--",
+					"missing required entry: g:456:r--",
+				})
+			},
+		},
+		{
+			name:      "mismatched",
+			expected:  testA,
+			candidate: testB,
+			assert: func(t *testing.T, issues []string) {
+				require.Len(t, issues, 4)
+				require.ElementsMatch(t, issues, []string{
+					"missing required entry: u:123:r--",
+					"missing required entry: g:456:r--",
+					"unexpected entry: g:123:r--",
+					"unexpected entry: u:456:r--",
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issues := CompareACL(tt.expected, tt.candidate)
+			tt.assert(t, issues)
+		})
+	}
+}

--- a/lib/tbot/botfs/fs_windows.go
+++ b/lib/tbot/botfs/fs_windows.go
@@ -106,19 +106,39 @@ func Write(path string, data []byte, symlinksMode SymlinksMode) error {
 	return nil
 }
 
-// VerifyACL verifies whether the ACL of the given file allows writes from the
+// VerifyLegacyACL verifies whether the ACL of the given file allows writes from the
 // bot user.
 //
 //nolint:staticcheck // staticcheck does not like our nop implementations.
-func VerifyACL(path string, opts *ACLOptions) error {
+func VerifyLegacyACL(path string, opts *ACLOptions) error {
 	return trace.NotImplemented("ACLs not supported on this platform")
 }
 
-// ConfigureACL configures ACLs of the given file to allow writes from the bot
+// VerifyACL loads the ACL for the file at the given path and compares it to
+// the expected ACL as determined by the given list of reader selectors,
+// returning a list of issues found. This is not implemented for Windows
+// targets.
+//
+//nolint:staticcheck // staticcheck does not like our nop implementations.
+func VerifyACL(path string, readers []*ACLSelector) ([]string, error) {
+	return nil, trace.NotImplemented("ACLs not supported on this platform")
+}
+
+// ConfigureACL configures a bot-user-owned ACL at the given path such that it
+// can be read by the given list of readers. If the list is empty, appropriate
+// non-ACL permissions will be set to ensure only the bot user can read the
+// file. This is not implemented for Windows targets.
+//
+//nolint:staticcheck // staticcheck does not like our nop implementations.
+func ConfigureACL(path string, readers []*ACLSelector) error {
+	return trace.NotImplemented("ACLs are not supported on this platform")
+}
+
+// ConfigureLegacyACL configures ACLs of the given file to allow writes from the bot
 // user.
 //
 //nolint:staticcheck // staticcheck does not like our nop implementations.
-func ConfigureACL(path string, owner *user.User, opts *ACLOptions) error {
+func ConfigureLegacyACL(path string, owner *user.User, opts *ACLOptions) error {
 	return trace.NotImplemented("ACLs not supported on this platform")
 }
 
@@ -137,6 +157,6 @@ func HasSecureWriteSupport() bool {
 
 // IsOwnedBy checks that the file at the given path is owned by the given user.
 // Returns a trace.NotImplemented() on unsupported platforms.
-func IsOwnedBy(_ fs.FileInfo, _ *user.User) (bool, error) {
+func IsOwnedBy(_ fs.FileInfo, _ int) (bool, error) {
 	return false, trace.NotImplemented("Cannot verify file ownership on this platform.")
 }

--- a/lib/tbot/cli/start_application.go
+++ b/lib/tbot/cli/start_application.go
@@ -31,9 +31,9 @@ import (
 // `tbot configure application`.
 type ApplicationCommand struct {
 	*sharedStartArgs
+	*sharedDestinationArgs
 	*genericMutatorHandler
 
-	Destination           string
 	AppName               string
 	SpecificTLSExtensions bool
 }
@@ -45,9 +45,9 @@ func NewApplicationCommand(parentCmd *kingpin.CmdClause, action MutatorAction) *
 
 	c := &ApplicationCommand{}
 	c.sharedStartArgs = newSharedStartArgs(cmd)
+	c.sharedDestinationArgs = newSharedDestinationArgs(cmd)
 	c.genericMutatorHandler = newGenericMutatorHandler(cmd, c, action)
 
-	cmd.Flag("destination", "A destination URI, such as file:///foo/bar").Required().StringVar(&c.Destination)
 	cmd.Flag("app", "The name of the app in Teleport").Required().StringVar(&c.AppName)
 	cmd.Flag("specific-tls-extensions", "If set, include additional `tls.crt`, `tls.key`, and `tls.cas` for apps that require these file extensions").BoolVar(&c.SpecificTLSExtensions)
 
@@ -61,7 +61,7 @@ func (c *ApplicationCommand) ApplyConfig(cfg *config.BotConfig, l *slog.Logger) 
 		return trace.Wrap(err)
 	}
 
-	dest, err := config.DestinationFromURI(c.Destination)
+	dest, err := c.BuildDestination()
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/tbot/cli/start_database.go
+++ b/lib/tbot/cli/start_database.go
@@ -34,10 +34,10 @@ type DatabaseCommand struct {
 	*sharedDestinationArgs
 	*genericMutatorHandler
 
-	Format      string
-	Service     string
-	Username    string
-	Database    string
+	Format   string
+	Service  string
+	Username string
+	Database string
 }
 
 // NewDatabaseCommand initializes a command and flags for database outputs and

--- a/lib/tbot/cli/start_database.go
+++ b/lib/tbot/cli/start_database.go
@@ -31,9 +31,9 @@ import (
 // `tbot configure database`.
 type DatabaseCommand struct {
 	*sharedStartArgs
+	*sharedDestinationArgs
 	*genericMutatorHandler
 
-	Destination string
 	Format      string
 	Service     string
 	Username    string
@@ -47,9 +47,9 @@ func NewDatabaseCommand(parentCmd *kingpin.CmdClause, action MutatorAction) *Dat
 
 	c := &DatabaseCommand{}
 	c.sharedStartArgs = newSharedStartArgs(cmd)
+	c.sharedDestinationArgs = newSharedDestinationArgs(cmd)
 	c.genericMutatorHandler = newGenericMutatorHandler(cmd, c, action)
 
-	cmd.Flag("destination", "A destination URI, such as file:///foo/bar").Required().StringVar(&c.Destination)
 	cmd.Flag("format", "The database output format if necessary").Default("").EnumVar(&c.Format, config.SupportedDatabaseFormatStrings()...)
 	cmd.Flag("service", "The database service name").Required().StringVar(&c.Service)
 	cmd.Flag("username", "The database user name").Required().StringVar(&c.Username)
@@ -63,7 +63,7 @@ func (c *DatabaseCommand) ApplyConfig(cfg *config.BotConfig, l *slog.Logger) err
 		return trace.Wrap(err)
 	}
 
-	dest, err := config.DestinationFromURI(c.Destination)
+	dest, err := c.BuildDestination()
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/tbot/cli/start_identity.go
+++ b/lib/tbot/cli/start_identity.go
@@ -34,7 +34,6 @@ type IdentityCommand struct {
 	*sharedDestinationArgs
 	*genericMutatorHandler
 
-	Destination string
 	Cluster     string
 }
 
@@ -61,7 +60,7 @@ func (c *IdentityCommand) ApplyConfig(cfg *config.BotConfig, l *slog.Logger) err
 		return trace.Wrap(err)
 	}
 
-	dest, err := c.sharedDestinationArgs.BuildDestination()
+	dest, err := c.BuildDestination()
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/tbot/cli/start_identity.go
+++ b/lib/tbot/cli/start_identity.go
@@ -34,7 +34,7 @@ type IdentityCommand struct {
 	*sharedDestinationArgs
 	*genericMutatorHandler
 
-	Cluster     string
+	Cluster string
 }
 
 // NewIdentityCommand initializes the command and flags for identity outputs

--- a/lib/tbot/cli/start_kubernetes.go
+++ b/lib/tbot/cli/start_kubernetes.go
@@ -31,9 +31,9 @@ import (
 // `tbot configure kubernetes`.
 type KubernetesCommand struct {
 	*sharedStartArgs
+	*sharedDestinationArgs
 	*genericMutatorHandler
 
-	Destination       string
 	KubernetesCluster string
 	DisableExecPlugin bool
 }
@@ -45,9 +45,9 @@ func NewKubernetesCommand(parentCmd *kingpin.CmdClause, action MutatorAction) *K
 
 	c := &KubernetesCommand{}
 	c.sharedStartArgs = newSharedStartArgs(cmd)
+	c.sharedDestinationArgs = newSharedDestinationArgs(cmd)
 	c.genericMutatorHandler = newGenericMutatorHandler(cmd, c, action)
 
-	cmd.Flag("destination", "A destination URI, such as file:///foo/bar").Required().StringVar(&c.Destination)
 	cmd.Flag("kubernetes-cluster", "The name of the Kubernetes cluster in Teleport for which to fetch credentials").Required().StringVar(&c.KubernetesCluster)
 	cmd.Flag("disable-exec-plugin", "If set, disables the exec plugin. This allows credentials to be used without the `tbot` binary.").BoolVar(&c.DisableExecPlugin)
 
@@ -61,7 +61,7 @@ func (c *KubernetesCommand) ApplyConfig(cfg *config.BotConfig, l *slog.Logger) e
 		return trace.Wrap(err)
 	}
 
-	dest, err := config.DestinationFromURI(c.Destination)
+	dest, err := c.BuildDestination()
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/tbot/cli/start_shared.go
+++ b/lib/tbot/cli/start_shared.go
@@ -30,6 +30,8 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/tbot/bot"
+	"github.com/gravitational/teleport/lib/tbot/botfs"
 	"github.com/gravitational/teleport/lib/tbot/config"
 )
 
@@ -232,4 +234,56 @@ func (s *sharedStartArgs) ApplyConfig(cfg *config.BotConfig, l *slog.Logger) err
 	}
 
 	return nil
+}
+
+// sharedDestinationArgs are arguments common to all commands that accept a
+// --destination flag and any related flags. Downstream commands will need to
+// call `BuildDestination()` to retreive the value.
+type sharedDestinationArgs struct {
+	Destination  string
+	ReaderUsers  []string
+	ReaderGroups []string
+}
+
+// newSharedDestinationArgs initializes args that provide --destination and
+// related flags.
+func newSharedDestinationArgs(cmd *kingpin.CmdClause) *sharedDestinationArgs {
+	args := &sharedDestinationArgs{}
+
+	cmd.Flag("destination", "A destination URI, such as file:///foo/bar").Required().StringVar(&args.Destination)
+	cmd.Flag("reader-user", "An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.").StringsVar(&args.ReaderUsers)
+	cmd.Flag("reader-group", "An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.").StringsVar(&args.ReaderUsers)
+
+	return args
+}
+
+func (s *sharedDestinationArgs) BuildDestination() (bot.Destination, error) {
+	dest, err := config.DestinationFromURI(s.Destination)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if len(s.ReaderUsers) > 0 || len(s.ReaderGroups) > 0 {
+		// These flags are only supported on directory destinations, so ensure
+		// that's what was built.
+
+		dd, ok := dest.(*config.DestinationDirectory)
+		if !ok {
+			return nil, trace.BadParameter("--reader-user and --reader-group are only compatible with file destinations")
+		}
+
+		for _, r := range s.ReaderUsers {
+			dd.Readers = append(dd.Readers, &botfs.ACLSelector{
+				User: r,
+			})
+		}
+
+		for _, r := range s.ReaderGroups {
+			dd.Readers = append(dd.Readers, &botfs.ACLSelector{
+				Group: r,
+			})
+		}
+	}
+
+	return dest, nil
 }

--- a/lib/tbot/cli/start_shared.go
+++ b/lib/tbot/cli/start_shared.go
@@ -252,7 +252,7 @@ func newSharedDestinationArgs(cmd *kingpin.CmdClause) *sharedDestinationArgs {
 
 	cmd.Flag("destination", "A destination URI, such as file:///foo/bar").Required().StringVar(&args.Destination)
 	cmd.Flag("reader-user", "An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.").StringsVar(&args.ReaderUsers)
-	cmd.Flag("reader-group", "An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.").StringsVar(&args.ReaderUsers)
+	cmd.Flag("reader-group", "An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.").StringsVar(&args.ReaderGroups)
 
 	return args
 }

--- a/lib/tbot/cli/start_shared.go
+++ b/lib/tbot/cli/start_shared.go
@@ -238,7 +238,7 @@ func (s *sharedStartArgs) ApplyConfig(cfg *config.BotConfig, l *slog.Logger) err
 
 // sharedDestinationArgs are arguments common to all commands that accept a
 // --destination flag and any related flags. Downstream commands will need to
-// call `BuildDestination()` to retreive the value.
+// call `BuildDestination()` to retrieve the value.
 type sharedDestinationArgs struct {
 	Destination  string
 	ReaderUsers  []string

--- a/lib/tbot/cli/start_spiffe_svid.go
+++ b/lib/tbot/cli/start_spiffe_svid.go
@@ -31,9 +31,9 @@ import (
 // `tbot configure spiffe-svid`.
 type SPIFFESVIDCommand struct {
 	*sharedStartArgs
+	*sharedDestinationArgs
 	*genericMutatorHandler
 
-	Destination                  string
 	IncludeFederatedTrustBundles bool
 
 	SVIDPath string
@@ -50,9 +50,9 @@ func NewSPIFFESVIDCommand(parentCmd *kingpin.CmdClause, action MutatorAction) *S
 
 	c := &SPIFFESVIDCommand{}
 	c.sharedStartArgs = newSharedStartArgs(cmd)
+	c.sharedDestinationArgs = newSharedDestinationArgs(cmd)
 	c.genericMutatorHandler = newGenericMutatorHandler(cmd, c, action)
 
-	cmd.Flag("destination", "A destination URI, such as file:///foo/bar").Required().StringVar(&c.Destination)
 	cmd.Flag("include-federated-trust-bundles", "If set, include federated trust bundles in the output").BoolVar(&c.IncludeFederatedTrustBundles)
 	cmd.Flag("svid-path", "A SPIFFE ID to request, prefixed with '/'").Required().StringVar(&c.SVIDPath)
 	cmd.Flag("svid-hint", "An optional hint for consumers of the SVID to aid in identification").StringVar(&c.SVIDHint)
@@ -67,7 +67,7 @@ func (c *SPIFFESVIDCommand) ApplyConfig(cfg *config.BotConfig, l *slog.Logger) e
 		return trace.Wrap(err)
 	}
 
-	dest, err := config.DestinationFromURI(c.Destination)
+	dest, err := c.BuildDestination()
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/tbot/config/destination_directory.go
+++ b/lib/tbot/config/destination_directory.go
@@ -168,12 +168,13 @@ func (dd *DestinationDirectory) Init(ctx context.Context, subdirs []string) erro
 					"underlying issue.")
 			}
 
+			const msg = "ACLs were requested but could not be configured, they " +
+				"will be disabled. To resolve this warning, ensure ACLs are " +
+				"supported and the directory is owned by the bot user, or " +
+				"remove any configured readers to disable ACLs"
 			log.WarnContext(
 				ctx,
-				"ACLs were requested but could not be configured, they will be "+
-					"disabled. To resolve this warning, ensure ACLs are supported "+
-					"and the directory is owned by the bot user, or remove any "+
-					"configured readers to disable ACLs",
+				msg,
 				"path", dd.Path,
 				"error", err,
 				"readers", dd.Readers,
@@ -322,11 +323,12 @@ func (dd *DestinationDirectory) Verify(keys []string) error {
 	if len(dd.Readers) > 0 {
 		// TODO: consider moving ownership check into Init()?
 		if !ownedByBot {
+			const msg = "This destination is not owned by the bot user so ACLs " +
+				"will not be enforced. To silence this warning, fix destination " +
+				"file ownership or remove configured `readers`"
 			log.WarnContext(
 				context.TODO(),
-				"This destination is not owned by the bot user so ACLs will "+
-					"not be enforced. To silence this warning, fix destination "+
-					"file ownership or remove configured `readers`",
+				msg,
 				"path", dd.Path,
 			)
 

--- a/lib/tbot/config/destination_directory.go
+++ b/lib/tbot/config/destination_directory.go
@@ -80,6 +80,12 @@ func (dd *DestinationDirectory) CheckAndSetDefaults() error {
 		return trace.BadParameter("destination path must not be empty")
 	}
 
+	for i, reader := range dd.Readers {
+		if err := reader.CheckAndSetDefaults(); err != nil {
+			return trace.Wrap(err, "reader entry %d is invalid", i)
+		}
+	}
+
 	switch dd.Symlinks {
 	case "":
 		// We default to SymlinksTrySecure. It's become apparent that the

--- a/lib/tbot/config/destination_directory.go
+++ b/lib/tbot/config/destination_directory.go
@@ -27,6 +27,7 @@ import (
 	"os/user"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/gravitational/trace"
 	"go.opentelemetry.io/otel/attribute"
@@ -41,9 +42,15 @@ const DestinationDirectoryType = "directory"
 
 // DestinationDirectory is a Destination that writes to the local filesystem
 type DestinationDirectory struct {
-	Path     string             `yaml:"path,omitempty"`
-	Symlinks botfs.SymlinksMode `yaml:"symlinks,omitempty"`
-	ACLs     botfs.ACLMode      `yaml:"acls,omitempty"`
+	Path     string               `yaml:"path,omitempty"`
+	Symlinks botfs.SymlinksMode   `yaml:"symlinks,omitempty"`
+	ACLs     botfs.ACLMode        `yaml:"acls,omitempty"`
+	Readers  []*botfs.ACLSelector `yaml:"readers,omitempty"`
+
+	// aclsEnabled is set during `Init()` if new-style ACLs are requested and
+	// the ACL test succeeds. When true, ACLs will be corrected on-the-fly
+	// during `Write()`.
+	aclsEnabled bool
 }
 
 func (dd *DestinationDirectory) UnmarshalYAML(node *yaml.Node) error {
@@ -145,28 +152,73 @@ func mkdir(p string) error {
 	return nil
 }
 
-func (dd *DestinationDirectory) Init(_ context.Context, subdirs []string) error {
+func (dd *DestinationDirectory) Init(ctx context.Context, subdirs []string) error {
 	// Create the directory if needed.
 	if err := mkdir(dd.Path); err != nil {
 		return trace.Wrap(err)
+	}
+
+	// Check for ACL configuration and test to ensure support.
+	if len(dd.Readers) > 0 && dd.ACLs != botfs.ACLOff {
+		// Run a test to ensure we can actually make use of them.
+		if err := botfs.TestACL(dd.Path, dd.Readers); err != nil {
+			if dd.ACLs == botfs.ACLRequired {
+				return trace.Wrap(err, "ACLs were marked as required but the "+
+					"write test failed. Remove `acls: required` or resolve the "+
+					"underlying issue.")
+			}
+
+			log.WarnContext(
+				ctx,
+				"ACLs were requested but could not be configured, they will be "+
+					"disabled. To resolve this warning, ensure ACLs are supported "+
+					"and the directory is owned by the bot user, or remove any "+
+					"configured readers to disable ACLs",
+				"path", dd.Path,
+				"error", err,
+				"readers", dd.Readers,
+			)
+
+			dd.aclsEnabled = false
+		} else {
+			dd.aclsEnabled = true
+			log.InfoContext(
+				ctx,
+				"ACL test succeeded and will be configured at runtime",
+				"path", dd.Path,
+				"readers", len(dd.Readers),
+			)
+		}
+	}
+
+	if dd.aclsEnabled {
+		// Correct the base directory ACLs. Note that no default ACL is
+		// configured; we manage each file/subdirectory ACL manually.
+		if err := dd.verifyAndCorrectACL(ctx, ""); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 
 	for _, dir := range subdirs {
 		if err := mkdir(path.Join(dd.Path, dir)); err != nil {
 			return trace.Wrap(err)
 		}
+
+		if dd.aclsEnabled {
+			if err := dd.verifyAndCorrectACL(ctx, dir); err != nil {
+				return trace.Wrap(err)
+			}
+		}
 	}
 
 	return nil
 }
 
-func (dd *DestinationDirectory) Verify(keys []string) error {
-	// If ACLs are disabled or unsupported, just bail as there's nothing to
-	// check.
-	if dd.ACLs == botfs.ACLOff || !botfs.HasACLSupport() {
-		return nil
-	}
-
+// verifyLegacyACLs performs minor runtime verification of legacy-style ACLs,
+// where it is _not_ assumed that the destination is owned by the bot user.
+// This will not attempt to correct any issues, but will cause a hard failure if
+// `acls: required` is configured and issues are detected.
+func (dd *DestinationDirectory) verifyLegacyACLs(keys []string) error {
 	currentUser, err := user.Current()
 	if err != nil {
 		// user.Current will fail if the user id does not exist in /etc/passwd
@@ -184,36 +236,18 @@ func (dd *DestinationDirectory) Verify(keys []string) error {
 		return nil
 	}
 
-	stat, err := os.Stat(dd.Path)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	ownedByBot, err := botfs.IsOwnedBy(stat, currentUser)
-	if trace.IsNotImplemented(err) {
-		// If file owners aren't supported, ACLs certainly aren't. Just bail.
-		// (Subject to change if we ever try to support Windows ACLs.)
-		return nil
-	} else if err != nil {
-		return trace.Wrap(err)
-	}
-
-	// Make sure it's worth warning about ACLs for this Destination. If the
-	// destination is owned by the bot (implying the user is not trying to use
-	//ACLs), just bail.
-	if ownedByBot {
-		return nil
-	}
-
 	errors := []error{}
 	for _, key := range keys {
 		path := filepath.Join(dd.Path, key)
 
-		errors = append(errors, botfs.VerifyACL(path, &botfs.ACLOptions{
+		errors = append(errors, botfs.VerifyLegacyACL(path, &botfs.ACLOptions{
 			BotUser: currentUser,
 		}))
 	}
 
+	// Unlike new-style ACLs, we'll allow hard fails here: we don't expect to
+	// be able to manage legacy ACLs at runtime and need to depend on them being
+	// correct from the start, so hard fails at this stage make sense.
 	aggregate := trace.NewAggregate(errors...)
 	if dd.ACLs == botfs.ACLRequired {
 		// Hard fail if ACLs are specifically requested and there are errors.
@@ -232,6 +266,125 @@ func (dd *DestinationDirectory) Verify(keys []string) error {
 	return nil
 }
 
+func (dd *DestinationDirectory) Verify(keys []string) error {
+	// Preflight: Warn on common misconfigurations where any kind of ACL
+	// management will be impossible.
+	if dd.ACLs == botfs.ACLOff {
+		if len(dd.Readers) > 0 {
+			log.InfoContext(
+				context.TODO(),
+				"Readers are configured but ACLs are disabled for this destination. No ACLs will be managed or verified.",
+				"path", dd.Path,
+			)
+		}
+		return nil
+	}
+
+	if !botfs.HasACLSupport() {
+		if dd.ACLs == botfs.ACLRequired {
+			return trace.BadParameter("ACLs are marked as required for destination %s but are not supported on this platform. Set `acls: off` to resolve this error.", dd.Path)
+		}
+
+		if len(dd.Readers) > 0 {
+			log.WarnContext(
+				context.TODO(),
+				"Readers are configured but this platform does not support filesystem ACLs. ACL management will be disabled.",
+				"path", dd.Path,
+			)
+		}
+	}
+
+	stat, err := os.Stat(dd.Path)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Note: os.Getuid() returns -1 on Windows, but we've implicitly eliminated
+	// that as an option with the `botfs.HasACLSupport()` check above.
+	ownedByBot, err := botfs.IsOwnedBy(stat, os.Getuid())
+	if trace.IsNotImplemented(err) {
+		// If file owners aren't supported, ACLs certainly aren't. Just bail.
+		// (Subject to change if we ever try to support Windows ACLs.)
+		log.WarnContext(
+			context.TODO(),
+			"unable to determine file ownership on this platform, ACL verification will be skipped",
+			"path", dd.Path,
+			"error", err,
+		)
+		return nil
+	} else if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Check for new-style ACL configuration. These explicitly require
+	// destinations to be owned by the bot user. This is somewhat arbitrarily
+	// here instead of in Init() and will run before each write attempt.
+	if len(dd.Readers) > 0 {
+		// TODO: consider moving ownership check into Init()?
+		if !ownedByBot {
+			log.WarnContext(
+				context.TODO(),
+				"This destination is not owned by the bot user so ACLs will "+
+					"not be enforced. To silence this warning, fix destination "+
+					"file ownership or remove configured `readers`",
+				"path", dd.Path,
+			)
+
+			return nil
+		}
+
+		return nil
+	}
+
+	// For legacy ACLs, make sure it's worth warning about them. If the
+	// destination is owned by the bot (implying the user is not trying to use
+	// ACLs), just bail.
+	if ownedByBot {
+		return nil
+	}
+
+	return trace.Wrap(dd.verifyLegacyACLs(keys))
+}
+
+// verifyAndCorrectACL performs validation and attempts correction on new-style
+// ACLs when configured.
+func (dd *DestinationDirectory) verifyAndCorrectACL(ctx context.Context, subpath string) error {
+	p := filepath.Join(dd.Path, subpath)
+
+	// As a sanity check, try to ensure the resulting path is (lexically) a
+	// child of this destination.
+	if !strings.HasPrefix(p, filepath.Clean(dd.Path)) {
+		return trace.BadParameter("path %s is not a child of destination %s", p, dd.Path)
+	}
+
+	log.DebugContext(ctx, "verifying ACL", "path", p)
+	issues, err := botfs.VerifyACL(p, dd.Readers)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// If issues exist, attempt remediation. As the test during `Init()`
+	// passed, regardless of ACL mode (try, required), treat all errors here
+	// as hard failures.
+	if len(issues) > 0 {
+		if err := botfs.ConfigureACL(p, dd.Readers); err != nil {
+			// TODO: should this always be a hard fail? Would we want to just
+			// warn on `acls: try`?
+			return trace.Wrap(err, "unable to fix misconfigured ACL at path %s with issues %v", p, issues)
+		}
+
+		log.InfoContext(
+			ctx,
+			"corrected ACLs on destination file",
+			"destination", dd.Path,
+			"path", subpath,
+			"issues", issues,
+		)
+	}
+
+	return nil
+}
+
 func (dd *DestinationDirectory) Write(ctx context.Context, name string, data []byte) error {
 	_, span := tracer.Start(
 		ctx,
@@ -240,7 +393,46 @@ func (dd *DestinationDirectory) Write(ctx context.Context, name string, data []b
 	)
 	defer span.End()
 
-	return trace.Wrap(botfs.Write(filepath.Join(dd.Path, name), data, dd.Symlinks))
+	// If there are any parent directories, attempt to mkdir them again in case
+	// things have drifted since `Init()` was run. We don't bother with secure
+	// botfs.Create() since it's a no-op for directory creation.
+	if dir, _ := filepath.Split(name); dir != "" {
+		if err := mkdir(filepath.Join(dd.Path, dir)); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	path := filepath.Join(dd.Path, name)
+
+	// We can't configure permissions on a file that doesn't exist, so attempt
+	// to read the file first to determine if it exists, and create it if
+	// necessary.
+	_, err := botfs.Read(path, dd.Symlinks)
+	if trace.IsNotFound(err) {
+		log.DebugContext(ctx, "file is missing, creating to apply permissions", "path", path)
+		if err := botfs.Create(path, false, dd.Symlinks); err != nil {
+			return trace.Wrap(err)
+		}
+	} else if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if dd.aclsEnabled {
+		// Sequentially check all subdirectory ACLs.
+		dirs := strings.Split(name, string(os.PathSeparator))
+		for i := 1; i < len(dirs); i++ {
+			// note: filepath.Join() will call `filepath.Clean()` on each result
+			if err := dd.verifyAndCorrectACL(ctx, filepath.Join(dirs[:i]...)); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+
+		if err := dd.verifyAndCorrectACL(ctx, name); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	return trace.Wrap(botfs.Write(path, data, dd.Symlinks))
 }
 
 func (dd *DestinationDirectory) Read(ctx context.Context, name string) ([]byte, error) {

--- a/lib/tbot/config/destination_directory_test.go
+++ b/lib/tbot/config/destination_directory_test.go
@@ -19,12 +19,16 @@
 package config
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/lib/tbot/botfs"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/trace"
 )
 
 func TestDestinationDirectory_Lock(t *testing.T) {
@@ -69,6 +73,88 @@ func TestDestinationDirectory_YAML(t *testing.T) {
 				Path: "/my/path",
 			},
 		},
+		{
+			name: "acl readers",
+			in: DestinationDirectory{
+				Path: "/my/path",
+				ACLs: botfs.ACLRequired,
+				Readers: []*botfs.ACLSelector{
+					{
+						User: "foo",
+					},
+					{
+						Group: "123",
+					},
+				},
+			},
+		},
 	}
 	testYAML(t, tests)
+}
+
+func TestDestinationDirectory_ACLs(t *testing.T) {
+	if !botfs.HasACLSupport() {
+		t.Skipf("ACLs not supported on this host")
+	}
+
+	ctx := context.Background()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test")
+
+	dd := DestinationDirectory{
+		Path: path,
+		ACLs: botfs.ACLRequired,
+		Readers: []*botfs.ACLSelector{
+			{
+				// We explicitly want to support nonexistent UIDs, so we'll pick
+				// an arbitrary UID we don't expect to exist. This particular
+				// value is outside the usual reserved ranges documented by
+				// Debian:
+				// https://www.debian.org/doc/debian-policy/ch-opersys.html#uid-and-gid-classes
+				User: "59123",
+			},
+		},
+	}
+	require.NoError(t, dd.CheckAndSetDefaults())
+
+	err := dd.Init(ctx, []string{"foo"})
+	if trace.IsNotImplemented(err) {
+		t.Skipf("ACLs were unexpectedly not supported: %+v", err)
+	}
+
+	require.NoError(t, err)
+
+	// An ACL should be configured for the root directory
+	issues, err := botfs.VerifyACL(path, dd.Readers)
+	require.NoError(t, err)
+	require.Empty(t, issues)
+
+	// Create an empty file to simulate an artifact. We explicitly want to
+	// observe ACL problems from a file created out-of-band, so that Write() can
+	// attempt to fix them.
+	artifactPath := filepath.Join(path, "foo", "bar")
+	f, err := os.Create(artifactPath)
+	require.NoError(t, err)
+	f.Close()
+
+	issues, err = botfs.VerifyACL(artifactPath, dd.Readers)
+	require.NoError(t, err)
+
+	// note, lib/tbot/botfs's TestCompareACL tests the specifics of an empty ACL
+	require.NotEmpty(t, issues)
+
+	err = dd.Write(ctx, "foo/bar", []byte("hello world"))
+	require.NoError(t, err)
+
+	// The previous issues should now be resolved.
+	issues, err = botfs.VerifyACL(artifactPath, dd.Readers)
+	require.NoError(t, err)
+	require.Empty(t, issues)
+
+	// Finally, try writing to a completely separate path to ensure Write()
+	// initializes new files with a sane ACL.
+	require.NoError(t, dd.Write(ctx, "baz", []byte("example")))
+	issues, err = botfs.VerifyACL(filepath.Join(path, "baz"), dd.Readers)
+	require.NoError(t, err)
+	require.Empty(t, issues)
 }

--- a/lib/tbot/config/destination_directory_test.go
+++ b/lib/tbot/config/destination_directory_test.go
@@ -24,11 +24,11 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/lib/tbot/botfs"
 	"github.com/gravitational/teleport/lib/utils"
-	"github.com/gravitational/trace"
 )
 
 func TestDestinationDirectory_Lock(t *testing.T) {

--- a/lib/tbot/config/testdata/TestDestinationDirectory_YAML/acl_readers.golden
+++ b/lib/tbot/config/testdata/TestDestinationDirectory_YAML/acl_readers.golden
@@ -1,0 +1,6 @@
+type: directory
+path: /my/path
+acls: required
+readers:
+  - user: foo
+  - group: "123"

--- a/tool/tbot/init.go
+++ b/tool/tbot/init.go
@@ -121,7 +121,7 @@ func testACL(directory string, ownerUser *user.User, opts *botfs.ACLOptions) err
 	}()
 
 	//nolint:staticcheck // staticcheck doesn't like nop implementations in fs_other.go
-	if err := botfs.ConfigureACL(testFile, ownerUser, opts); err != nil {
+	if err := botfs.ConfigureLegacyACL(testFile, ownerUser, opts); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -211,8 +211,18 @@ func ensurePermissions(
 		return trace.Wrap(err)
 	}
 
+	uid, err := strconv.Atoi(params.ownerUser.Uid)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	gid, err := strconv.Atoi(params.ownerGroup.Gid)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	// Correct ownership.
-	ownedByDesiredOwner, err := botfs.IsOwnedBy(stat, params.ownerUser)
+	ownedByDesiredOwner, err := botfs.IsOwnedBy(stat, uid)
 	if err != nil {
 		log.DebugContext(ctx, "Could not determine file ownership", "path", path, "error", err)
 
@@ -225,16 +235,6 @@ func ensurePermissions(
 		// If we're not running as root, this will probably fail.
 		if currentUser.Uid != RootUID && runtime.GOOS != constants.WindowsOS {
 			log.WarnContext(ctx, "Not running as root, ownership change is likely to fail")
-		}
-
-		uid, err := strconv.Atoi(params.ownerUser.Uid)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-
-		gid, err := strconv.Atoi(params.ownerGroup.Gid)
-		if err != nil {
-			return trace.Wrap(err)
 		}
 
 		if verboseLogging {
@@ -259,7 +259,7 @@ func ensurePermissions(
 		// are incorrect.
 
 		//nolint:staticcheck // staticcheck doesn't like nop implementations in fs_other.go
-		err = botfs.VerifyACL(path, params.aclOptions)
+		err = botfs.VerifyLegacyACL(path, params.aclOptions)
 		//nolint:staticcheck // staticcheck doesn't like nop implementations in fs_other.go
 		if err != nil && (currentUser.Uid == RootUID || currentUser.Uid == params.ownerUser.Uid) {
 			if verboseLogging {
@@ -271,7 +271,7 @@ func ensurePermissions(
 				)
 			}
 
-			return trace.Wrap(botfs.ConfigureACL(path, params.ownerUser, params.aclOptions))
+			return trace.Wrap(botfs.ConfigureLegacyACL(path, params.ownerUser, params.aclOptions))
 		} else if err != nil {
 			log.ErrorContext(
 				ctx,


### PR DESCRIPTION
This adds support for initializing ACLs at runtime without needing to use `tbot init`. Users now configure a list of allowed readers from which an ACL template is built, and then ACLs will be verified and corrected both at startup and immediately before writing to an artifact.

Existing ACL mode semantics remain largely unchanged: `acls: try` is the default, and will enable runtime ACL correction and enforcement if a write test completes successfully; `acls: required` results in a hard failure if the startup write test fails.

As runtime ACL management requires the bot user to own the destination directory, bot user ownership is now a prerequisite for ACL management. `tbot init` itself still exists to help manage these situations, but is now marked as legacy.

These new-style ACLs additionally support UIDs and GIDs, even those not defined in `/etc/passwd`, to better support containerized usage.

This also adds CLI flags to add reader users and groups to the new `tbot start $service` family of flags, so runtime ACLs can be used without a `tbot.yaml`.

## Usage examples

YAML:
```yaml
version: v2
onboarding:
  token: foo
  join_method: token
storage:
  type: directory
  path: ./tbot-data
  symlinks: try-secure
  acls: try
services:
  - type: identity
    destination:
      type: directory
      path: ./tbot-user
      symlinks: try-secure
      acls: try
      readers:
        - user: teleport
    ssh_config: "on"
proxy_server: example.teleport.sh:443
certificate_ttl: 1h0m0s
renewal_interval: 20m0s
oneshot: false
fips: false
```

CLI only:

```bash
# Start a bot and allow user `teleport` to read the destination directory.
$ tbot start identity --join-method=token --token=foo --destination=./tbot-user --proxy-server=example.teleport.sh443 --storage=./tbot-data --reader-user=teleport

# Examine the ACL
$ getfacl ./tbot-user/identity
# file: tbot-user-1/identity
# owner: foo
# group: foo
user::rw-
user:teleport:r--
group::---
mask::r--
other::---
```


Closes #43554

Changelog: Machine ID can now manage filesystem ACLs at runtime to avoid running `tbot init`