### PR TITLE
use AWS ECS service per VPC for DB service

### DIFF
--- a/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.test.tsx
+++ b/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.test.tsx
@@ -240,7 +240,7 @@ function getMockedContexts() {
   };
 
   jest
-    .spyOn(integrationService, 'deployAwsOidcService')
+    .spyOn(integrationService, 'deployDatabaseServices')
     .mockResolvedValue('dashboard-url');
 
   jest.spyOn(teleCtx.databaseService, 'fetchDatabases').mockResolvedValue({

--- a/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.tsx
+++ b/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.tsx
@@ -126,22 +126,24 @@ export function AutoDeploy({ toggleDeployMethod }: DeployServiceProp) {
       agentMeta.awsIntegration.spec.roleArn
     );
 
+    const deployment = {
+      region: dbMeta.awsRegion,
+      accountId: awsAccountId,
+      taskRoleArn,
+      deployments: [
+        {
+          vpcId: dbMeta.awsVpcId,
+          subnetIds: selectedSubnetIds,
+          securityGroups: selectedSecurityGroups,
+        },
+      ],
+    };
+
     if (wantAutoDiscover) {
       setAttempt({ status: 'processing' });
 
       integrationService
-        .deployDatabaseServices(integrationName, {
-          region: dbMeta.awsRegion,
-          accountId: awsAccountId,
-          taskRoleArn,
-          deployments: [
-            {
-              vpcId: dbMeta.awsVpcId,
-              subnetIds: selectedSubnetIds,
-              securityGroups: selectedSecurityGroups,
-            },
-          ],
-        })
+        .deployDatabaseServices(integrationName, deployment)
         .then(url => {
           setAttempt({ status: 'success' });
           setSvcDeployedAwsUrl(url);
@@ -155,15 +157,7 @@ export function AutoDeploy({ toggleDeployMethod }: DeployServiceProp) {
     } else {
       setAttempt({ status: 'processing' });
       integrationService
-        .deployAwsOidcService(integrationName, {
-          deploymentMode: 'database-service',
-          region: dbMeta.awsRegion,
-          subnetIds: selectedSubnetIds,
-          taskRoleArn,
-          securityGroups: selectedSecurityGroups,
-          vpcId: dbMeta.awsVpcId,
-          accountId: awsAccountId,
-        })
+        .deployDatabaseServices(integrationName, deployment)
         // The user is still technically in the "processing"
         // state, because after this call succeeds, we will
         // start pinging for the newly registered db


### PR DESCRIPTION
## The Problem

Without this change, you are only able to have the db agent deployed in one VPC at a time, because the ECS service can only be in one VPC at a time and our deployment will always update the existing ECS service if it exists.

## Background

Originally, single db enrollment deployed a DB service for an entire AWS region. This behavior was recently changed to deploy the DB service for a specific VPC in a region.
So now the AWS ECS service must be named after the VPC it is deployed to for single db enrollment.


We already have an endpoint that deploys database service by VPC - it was used for discovery service because we used to deploy a db service for each VPC when doing the auto-discovery enrollment flow.

All this PR does is align the single db enrollment flow and auto-discovery flow to deploy the DB service in the same way - ECS service named after the VPC.

This screenshot might help to illustrate the effect of this change:
![image](https://github.com/user-attachments/assets/a95d9755-f414-4881-8efc-26b36531f0a0)


old deployments: 
- `gavin-leaf_cloud_gravitational_io-teleport-database-service`
(can only be in one VPC at a time)

new deployments: 
- `database-service-vpc-082b35328b1fd4a56`
- `database-service-vpc-0e2541caa0a269def`
(can deploy to multiple VPCs)