### PR TITLE
docs: remove deny nodes in impersonation examples

### DIFF
--- a/docs/pages/admin-guides/access-controls/guides/impersonation.mdx
+++ b/docs/pages/admin-guides/access-controls/guides/impersonation.mdx
@@ -86,11 +86,6 @@ spec:
       users: ['jenkins']
       roles: ['jenkins']
 
-  # The deny section uses the identical format as the 'allow' section.
-  # The deny rules always override allow rules.
-  deny:
-    node_labels:
-      '*': '*'
 ```
 
 Create the `role` resource:
@@ -207,12 +202,6 @@ spec:
       where: >
         equals(impersonate_role.metadata.labels["group"], "security") && 
         equals(impersonate_user.metadata.labels["group"], "security")
-
-  # The deny section uses the identical format as the 'allow' section.
-  # The deny rules always override allow rules.
-  deny:
-    node_labels:
-      '*': '*'
 ```
 
 Create the resources:
@@ -285,12 +274,6 @@ spec:
       where: >
         contains(user.spec.traits["group"], impersonate_role.metadata.labels["group"]) && 
         contains(user.spec.traits["group"], impersonate_user.metadata.labels["group"])
-
-  # The deny section uses the identical format as the 'allow' section.
-  # The deny rules always override allow rules.
-  deny:
-    node_labels:
-      '*': '*'
 ```
 
 While user traits typically come from an external identity provider, we can test


### PR DESCRIPTION
These deny rules are not required for the impersonation example. By using them this as the role example this could block a user being assigned them from accessing any ssh node from legitimate other roles.