### PR TITLE
Turn off HTTPS in Vite dev server in Connect

### DIFF
--- a/web/packages/teleterm/electron.vite.config.mts
+++ b/web/packages/teleterm/electron.vite.config.mts
@@ -17,7 +17,6 @@
  */
 
 import path from 'node:path';
-import { existsSync, readFileSync } from 'node:fs';
 
 import { defineConfig, externalizeDepsPlugin, UserConfig } from 'electron-vite';
 
@@ -119,31 +118,6 @@ const config = defineConfig(env => {
       },
     },
   };
-
-  if (env.mode === 'development') {
-    if (process.env.VITE_HTTPS_KEY && process.env.VITE_HTTPS_CERT) {
-      config.renderer.server.https = {
-        key: readFileSync(process.env.VITE_HTTPS_KEY),
-        cert: readFileSync(process.env.VITE_HTTPS_CERT),
-      };
-    } else {
-      const certsDirectory = path.resolve(rootDirectory, 'web/certs');
-
-      if (!existsSync(certsDirectory)) {
-        throw new Error(
-          'Could not find SSL certificates. Please follow web/README.md to generate certificates.'
-        );
-      }
-
-      const keyPath = path.resolve(certsDirectory, 'server.key');
-      const certPath = path.resolve(certsDirectory, 'server.crt');
-
-      config.renderer.server.https = {
-        key: readFileSync(keyPath),
-        cert: readFileSync(certPath),
-      };
-    }
-  }
 
   return config;
 });

--- a/web/packages/teleterm/src/mainProcess/windowsManager.ts
+++ b/web/packages/teleterm/src/mainProcess/windowsManager.ts
@@ -362,7 +362,7 @@ export class WindowsManager {
  * */
 function getWindowUrl(isDev: boolean): string {
   if (isDev) {
-    return 'https://localhost:8080/';
+    return 'http://localhost:8080/';
   }
 
   // The returned URL is percent-encoded.


### PR DESCRIPTION
After one of the vite or electron-vite updates, `pnpm start-term` started showing a blank window. Opening the dev tools revealed that the browser failed to load some individual source files with error `ERR_HTTP2_PROTOCOL_ERROR`. The workaround was to `Cmd+R`, sometimes multiple times.

Vite's has [a bunch of issues about this](https://github.com/vitejs/vite/issues?q=is%3Aissue+ERR_HTTP2_PROTOCOL_ERROR+is%3Aclosed), but they've all been closed. We tried adjusting a couple of Vite settings, but none of that helped ([further increasing `maxSessionMemory`](https://github.com/vitejs/vite/pull/6207), [`server.warmup`](https://vite.dev/config/server-options.html#server-warmup), [`server.fs.cachedChecks`](https://vite.dev/config/server-options.html#server-fs-cachedchecks)). Fortunately, it seems that turning off HTTPS for the dev server does the trick.

AFAIK the Web UI needs HTTPS in its dev server for `PROXY_TARGET` to work with `pnpm start-teleport`. Connect does no such proxying, so having HTTPS enabled is not strictly necessary. For what it's worth, APIs such as `crypto.randomUUID` still work.

Unlike in the Web UI, turning of HTTPS in development doesn't make the dev environment differ from the prod environment, as in a packaged app the frontend files are read from the disk rather than being returned by a server.