### PR TITLE
Remove nested tabs from docs pages

### DIFF
--- a/docs/pages/admin-guides/access-controls/guides/locking.mdx
+++ b/docs/pages/admin-guides/access-controls/guides/locking.mdx
@@ -194,51 +194,27 @@ the last known locks. This decision strategy is encoded as one of the two modes:
 
 The cluster-wide mode defaults to `best_effort`. You can set up the default
 locking mode via API or CLI using a `cluster_auth_preference` resource or static
-configuration file:
+configuration file.
 
-<Tabs>
-  <TabItem label="API or CLI">
+If your Auth Service configuration (`/etc/teleport.yaml` by default) contains
+an `auth_service.authentication` section, edit the Teleport configuration
+file to contain the following:
 
-    Create a YAML file called `cap.yaml` or get the existing file using
-    `tctl get cap`.
+```yaml
+auth_service:
+    authentication:
+        locking_mode: best_effort
+```
 
-    ```yaml
-    kind: cluster_auth_preference
-    metadata:
-      name: cluster-auth-preference
-    spec:
-      locking_mode: best_effort
-    version: v2
-    ```
+Restart or redeploy the Auth Service for the change to take effect.
 
-    Create a resource:
+If not, edit your cluster authentication preference resource: 
 
-    ```code
-    $ tctl create -f cap.yaml
-    # cluster auth preference has been updated
-    ```
-  </TabItem>
-  <TabItem label="Static Config">
-    Edit `/etc/teleport.yaml` on the Auth Server:
+```code
+$ tctl edit cap
+```
 
-    ```yaml
-    auth_service:
-        authentication:
-            locking_mode: best_effort
-    ```
-
-    Restart the Auth Server for the change to take effect.
-  </TabItem>
-</Tabs>
-
-</TabItem>
-<TabItem scope={["Enterprise"]} label="Teleport Enterprise">
-
-The cluster-wide mode defaults to `best_effort`. You can set up the default
-locking mode via API or CLI using a `cluster_auth_preference` resource:
-
-Create a YAML file called `cap.yaml` or get the existing file using
-`tctl get cap`.
+Adjust the file in your editor to include the following:
 
 ```yaml
 kind: cluster_auth_preference
@@ -249,15 +225,32 @@ spec:
 version: v2
 ```
 
-Create a resource:
-
-```code
-$ tctl create -f cap.yaml
-# cluster auth preference has been updated
-```
+Save and close your editor to apply your changes.
 
 </TabItem>
+<TabItem scope={["Enterprise"]} label="Teleport Enterprise (Cloud)">
 
+The cluster-wide mode defaults to `best_effort`. You can set up the default
+locking mode via API or CLI using a `cluster_auth_preference` resource:
+
+```code
+$ tctl edit cap
+```
+
+Adjust the file in your editor to include the following:
+
+```yaml
+kind: cluster_auth_preference
+metadata:
+  name: cluster-auth-preference
+spec:
+  locking_mode: best_effort
+version: v2
+```
+
+Save and close your editor to apply your changes.
+
+</TabItem>
 </Tabs>
 
 It is also possible to configure the locking mode for a particular role:

--- a/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/aws.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/aws.mdx
@@ -290,11 +290,9 @@ Edit your `aws-values.yaml` file (created below) to refer to the name of your se
 
 ## Step 5/7. Set values to configure the cluster
 
-<Tabs>
-<TabItem scope="enterprise" label="Teleport Enterprise">
-
-Before you can install Teleport in your Kubernetes cluster, you will need to
-create a secret that contains your Teleport license information.
+If you run Teleport Enterprise, you will need to create a secret that contains
+your Teleport license information before you can install Teleport in your
+Kubernetes cluster. 
 
 (!docs/pages/includes//enterprise/obtainlicense.mdx!)
 
@@ -305,17 +303,10 @@ this secret as long as your file is named `license.pem`.
 $ kubectl -n <Var name="namespace" /> create secret generic license --from-file=license.pem
 ```
 
-</TabItem>
-
-</Tabs>
-
 Next, configure the `teleport-cluster` Helm chart to use the `aws` mode. Create
 a file called `aws-values.yaml` and write the values you've chosen above to it:
 
 <Tabs>
-<TabItem scope={["oss"]} label="Teleport Community Edition">
-
-<Tabs>
 <TabItem label="cert-manager">
 ```yaml
 chartMode: aws
@@ -334,6 +325,9 @@ highAvailability:
   certManager:
     enabled: true                                 # Enable cert-manager support to get TLS certificates
     issuerName: letsencrypt-production            # Name of the cert-manager Issuer to use (as configured above)
+# Indicate that this is a Teleport Enterprise deployment. Set to false for
+# Teleport Community Edition.
+enterprise: true                                  
 # If you are running Kubernetes 1.23 or above, disable PodSecurityPolicies
 podSecurityPolicy:
   enabled: false
@@ -365,97 +359,9 @@ aws:
   dynamoAutoScaling: false                        # Whether Teleport should configure DynamoDB's autoscaling.
 highAvailability:
   replicaCount: 2                                 # Number of replicas to configure
-ingress:
-  enabled: true
-  spec:
-    ingressClassName: alb
-annotations:
-  ingress:
-    alb.ingress.kubernetes.io/target-type: ip
-    alb.ingress.kubernetes.io/backend-protocol: HTTPS
-    alb.ingress.kubernetes.io/scheme: internet-facing
-    alb.ingress.kubernetes.io/load-balancer-attributes: idle_timeout.timeout_seconds=350
-    alb.ingress.kubernetes.io/healthcheck-protocol: HTTPS
-    alb.ingress.kubernetes.io/success-codes: 200,301,302
-    # Replace with your AWS certificate ARN
-    alb.ingress.kubernetes.io/certificate-arn: "<Var name="arn:aws:acm:us-west-2:1234567890:certificate/12345678-43c7-4dd1-a2f6-c495b91ebece"/>"
-# If you are running Kubernetes 1.23 or above, disable PodSecurityPolicies
-podSecurityPolicy:
-  enabled: false
-```
-
-To use an internal AWS application load balancer (as opposed to an internet-facing ALB), you should
-edit the `alb.ingress.kubernetes.io/scheme` annotation:
-
-  ```yaml
-    alb.ingress.kubernetes.io/scheme: internal
-  ```
-
-To automatically redirect HTTP requests on port 80 to HTTPS requests on port 443, you
-can also optionally provide these two values under `annotations.ingress`:
-
-  ```yaml
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-    alb.ingress.kubernetes.io/ssl-redirect: '443'
-  ```
-</TabItem>
-</Tabs>
-
-</TabItem>
-<TabItem scope={["enterprise"]} label="Teleport Enterprise">
-
-<Tabs>
-<TabItem label="cert-manager">
-```yaml
-chartMode: aws
-clusterName: <Var name="teleport.example.com" />                 # Name of your cluster. Use the FQDN you intend to configure in DNS below.
-proxyListenerMode: multiplex
-aws:
-  region: <Var name="us-west-2" />                # AWS region
-  backendTable: <Var name="teleport-helm-backend" /> # DynamoDB table to use for the Teleport backend
-  auditLogTable: <Var name="teleport-helm-events" />             # DynamoDB table to use for the Teleport audit log (must be different to the backend table)
-  auditLogMirrorOnStdout: false                   # Whether to mirror audit log entries to stdout in JSON format (useful for external log collectors)
-  sessionRecordingBucket: <Var name="your-sessions-bucket" />  # S3 bucket to use for Teleport session recordings
-  backups: true                                   # Whether or not to turn on DynamoDB backups
-  dynamoAutoScaling: false                        # Whether Teleport should configure DynamoDB's autoscaling.
-highAvailability:
-  replicaCount: 2                                 # Number of replicas to configure
-  certManager:
-    enabled: true                                 # Enable cert-manager support to get TLS certificates
-    issuerName: letsencrypt-production            # Name of the cert-manager Issuer to use (as configured above)
-enterprise: true                                  # Indicate that this is a Teleport Enterprise deployment
-# If you are running Kubernetes 1.23 or above, disable PodSecurityPolicies
-podSecurityPolicy:
-  enabled: false
-```
-<Admonition type="note">
-If using an AWS PCA with cert-manager, you will need to
-[ensure you set](../../../reference/helm-reference/teleport-cluster.mdx)
-`highAvailability.certManager.addCommonName: true` in your values file.  You will also need to get the certificate authority
-certificate for the CA (`aws acm-pca get-certificate-authority-certificate --certificate-authority-arn <arn>`),
-upload the full certificate chain to a secret, and
-[reference the secret](../../../reference/helm-reference/teleport-cluster.mdx)
-with `tls.existingCASecretName` in the values file.
-</Admonition>
-</TabItem>
-<TabItem label="AWS Certificate Manager">
-```yaml
-chartMode: aws
-clusterName: <Var name="teleport.example.com" />                 # Name of your cluster. Use the FQDN you intend to configure in DNS below.
-proxyListenerMode: multiplex
-service:
-  type: ClusterIP
-aws:
-  region: <Var name="us-west-2" />                # AWS region
-  backendTable: <Var name="teleport-helm-backend" /> # DynamoDB table to use for the Teleport backend
-  auditLogTable: <Var name="teleport-helm-events" />             # DynamoDB table to use for the Teleport audit log (must be different to the backend table)
-  auditLogMirrorOnStdout: false                   # Whether to mirror audit log entries to stdout in JSON format (useful for external log collectors)
-  sessionRecordingBucket: <Var name="your-sessions-bucket" />  # S3 bucket to use for Teleport session recordings
-  backups: true                                   # Whether or not to turn on DynamoDB backups
-  dynamoAutoScaling: false                        # Whether Teleport should configure DynamoDB's autoscaling.
-highAvailability:
-  replicaCount: 2                                 # Number of replicas to configure
-enterprise: true                                  # Indicate that this is a Teleport Enterprise deployment
+# Indicate that this is a Teleport Enterprise deployment. Set to false for
+# Teleport Community Edition.
+enterprise: true                                  
 ingress:
   enabled: true
   spec:
@@ -491,10 +397,6 @@ can also optionally provide these two values under `annotations.ingress`:
   ```
 
 </TabItem>
-</Tabs>
-
-</TabItem>
-
 </Tabs>
 
 Install the chart with the values from your `aws-values.yaml` file using this command:

--- a/docs/pages/admin-guides/management/admin/self-signed-certs.mdx
+++ b/docs/pages/admin-guides/management/admin/self-signed-certs.mdx
@@ -110,37 +110,37 @@ running Teleport: via the `teleport` CLI, using a Helm chart, or via systemd:
     <TabItem label="Helm chart">
     If you are using the `teleport-cluster` Helm chart, set
     [extraArgs](../../../reference/helm-reference/teleport-cluster.mdx)
-    to include the extra argument: `--insecure`:
-    <Tabs>
-      <TabItem label="values.yaml">
-      ```yaml
-      extraArgs:
-      - "--insecure"
+    to include the extra argument: `--insecure`.
+
+    Here is an example of the field within a values file:
+
+    ```yaml
+    extraArgs:
+    - "--insecure"
+    ```
+
+    When using the `--set` flag, use the following syntax:
+
+
+      ```text
+      --set "extraArgs={--insecure}"
       ```
-      </TabItem>
-      <TabItem label="--set">
-      ```code
-      $ --set "extraArgs={--insecure}"
-      ```
-      </TabItem>
-    </Tabs>
-    
     
     If you are using the `teleport-kube-agent` chart, set the 
     [insecureSkipProxyTLSVerify](../../../reference/helm-reference/teleport-kube-agent.mdx)
-    flag to `true`:
-    <Tabs>
-      <TabItem label="values.yaml">
-      ```yaml
-      insecureSkipProxyTLSVerify: true
-      ```
-      </TabItem>
-      <TabItem label="--set">
-      ```code
-      $ --set insecureSkipProxyTLSVerify=true
-      ```
-      </TabItem>
-    </Tabs>
+    flag to `true`.
+
+    In a values file, this would appear as follows:
+
+    ```yaml
+    insecureSkipProxyTLSVerify: true
+    ```
+
+    When using the `--set` flag, use the following syntax:
+
+    ```text
+    --set insecureSkipProxyTLSVerify=true
+    ```
     </TabItem>
 
     <TabItem label="systemd">

--- a/docs/pages/connect-your-client/gui-clients.mdx
+++ b/docs/pages/connect-your-client/gui-clients.mdx
@@ -19,11 +19,32 @@ work with Teleport.
 
 ### Get connection information
 
-<Tabs>
-<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
+Get information about the host and port where your database is available so you
+can configure your GUI client to access the database.
 
-<Tabs>
-<TabItem label="Authenticated Proxy">
+#### Using a local proxy server
+
+Use the `tsh proxy db` command to start a local TLS proxy your GUI database
+client will be connecting to. This command requires that you use Teleport
+Enterprise (Cloud) or, if self-hosting Teleport, have enabled [TLS
+routing](../admin-guides/management/operations/tls-routing.mdx) mode.
+
+Run a command similar to the following::
+
+```code
+$ tsh proxy db <database-name>
+Started DB proxy on 127.0.0.1:61740
+
+Use following credentials to connect to the <database-name> proxy:
+  ca_file=/Users/r0mant/.tsh/keys/root.gravitational.io/certs.pem
+  cert_file=/Users/r0mant/.tsh/keys/root.gravitational.io/alice-db/root/<database-name>-x509.pem
+  key_file=/Users/r0mant/.tsh/keys/root.gravitational.io/alice
+```
+
+Use the displayed local proxy host/port and credentials paths when configuring
+your GUI client below. When entering the hostname, use `localhost` rather than
+`127.0.0.1`.
+
 Starting the local database proxy with the `--tunnel` flag will create an
 authenticated tunnel that you can use to connect to your database instances.
 You won't need to configure any credentials when connecting to this tunnel.
@@ -46,30 +67,11 @@ $ tsh proxy db --db-user=my-database-user --db-name=my-schema --tunnel <database
 Now, you can connect to the address the proxy command returns. In our example it
 is `127.0.0.1:62652`.
 
-</TabItem>
-<TabItem label="TLS routing">
-If you're using Teleport in [TLS routing](../admin-guides/management/operations/tls-routing.mdx)
-mode where each database protocol is multiplexed on the same web proxy port, use
-the following command to start a local TLS proxy your GUI database client will
-be connecting to:
+#### Using a remote host and port
 
-```code
-$ tsh proxy db <database-name>
-Started DB proxy on 127.0.0.1:61740
-
-Use following credentials to connect to the <database-name> proxy:
-  ca_file=/Users/r0mant/.tsh/keys/root.gravitational.io/certs.pem
-  cert_file=/Users/r0mant/.tsh/keys/root.gravitational.io/alice-db/root/<database-name>-x509.pem
-  key_file=/Users/r0mant/.tsh/keys/root.gravitational.io/alice
-```
-
-Use the displayed local proxy host/port and credentials paths when configuring
-your GUI client below. When entering the hostname, use `localhost` rather than
-`127.0.0.1`.
-</TabItem>
-<TabItem label="Separate ports">
-If you're not using TLS routing, run the following command to see the database
-connection information:
+If you are self-hosting Teleport and not using [TLS
+routing](../admin-guides/management/operations/tls-routing.mdx), run the
+following command to see the database connection information:
 
 ```code
 # View configuration for the database you're logged in to.
@@ -94,32 +96,6 @@ Key:       /Users/alice/.tsh/keys/teleport.example.com/alice
 The displayed `CA`, `Cert`, and `Key` files are used to connect through pgAdmin
 4, MySQL Workbench, and other graphical database clients that support mutual
 TLS authentication.
-</TabItem>
-</Tabs>
-
-</TabItem>
-<TabItem scope="cloud" label="Teleport Enterprise Cloud">
-
-Use the following command to start a local TLS proxy your GUI database client
-will be connecting to:
-
-```code
-$ tsh proxy db <database-name>
-Started DB proxy on 127.0.0.1:61740
-
-Use following credentials to connect to the <database-name> proxy:
-  ca_file=/Users/r0mant/.tsh/keys/root.gravitational.io/certs.pem
-  cert_file=/Users/r0mant/.tsh/keys/root.gravitational.io/alice-db/root/<database-name>-x509.pem
-  key_file=/Users/r0mant/.tsh/keys/root.gravitational.io/alice
-```
-
-Use the displayed local proxy host/port and credentials paths when configuring
-your GUI client below. When entering the hostname, use `localhost` rather than
-`127.0.0.1`.
-
-</TabItem>
-
-</Tabs>
 
 ## MongoDB Compass
 

--- a/docs/pages/connect-your-client/introduction.mdx
+++ b/docs/pages/connect-your-client/introduction.mdx
@@ -16,52 +16,11 @@ Teleport, and includes links to more detailed documentation at the end.
 your Teleport cluster:
 
 <Tabs>
-<TabItem scope={["oss"]} label="Teleport Community Edition">
-<Tabs>
 <TabItem label="Local user">
 
-```code
-$ tsh login --proxy=<Var name="teleport.example.com" description="Your Teleport Proxy Service or Teleport Cloud tenant address"/> --user=<Var name="user" description="Your Teleport username"/>
-Enter password for Teleport user alice:
-Tap any security key
-> Profile URL:        https://teleport.example.com:443
-  Logged in as:       alice
-  Cluster:            example.com
-  Roles:              access
-  Logins:             ubuntu, ec2-user
-  Kubernetes:         enabled
-  Valid until:        2022-11-01 22:37:05 -0500 CDT [valid for 12h0m0s]
-  Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty, private-key-policy
-```
+Authenticate to Teleport as a local user with `tsh login` by 
+assigning <Var name="user"/> to your Teleport username:
 
-</TabItem>
-<TabItem label="GitHub user">
-
-```code
-$ tsh login --proxy=<Var name="teleport.example.com"/> --auth=github
-If browser window does not open automatically, open it by clicking on the link:
- http://127.0.0.1:49927/1d80e257-ec61-4ed2-9403-784f8d35b2fe
-> Profile URL:        https://teleport.example.com:443
-  Logged in as:       user@example.com
-  Cluster:            example.com
-  Roles:              access
-  Logins:             ubuntu, ec2-user
-  Kubernetes:         enabled
-  Valid until:        2022-11-01 22:37:05 -0500 CDT [valid for 12h0m0s]
-  Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty, private-key-policy
-```
-
-Depending on how Teleport was configured for your network, you may not need
-the additional flags `--auth`. Your administrator should provide the details
-required for your particular use case.
-
-</TabItem>
-</Tabs>
-</TabItem>
-
-<TabItem scope={["enterprise", "cloud"]} label="Commercial">
-<Tabs>
-<TabItem label="Local user">
 ```code
 $ tsh login --proxy=<Var name="teleport.example.com" description="Your Teleport Proxy Service or Teleport Cloud tenant address"/> --user=<Var name="user" description="Your Teleport username"/>
 Enter password for Teleport user alice:
@@ -77,7 +36,11 @@ Tap any security key
 ```
 
 </TabItem>
-<TabItem label="SAML / OIDC / GitHub user">
+<TabItem label="Single sign-on user">
+
+Authenticate to Teleport as a single sign-on (SSO) user by running `tsh login`
+and assinging the `auth` flag to the name of your authentication connector, if
+implemented by your administrators:
 
 ```code
 $ tsh login --proxy=<Var name="teleport.example.com"/> --auth=<Var name="your-idp-connector" description="Your Identity Provider connection name, if implemented by your administrators"/>
@@ -97,8 +60,6 @@ Depending on how Teleport was configured for your network, you may not need
 the additional flags `--auth`. Your administrator should provide the details
 required for your particular use case.
 
-</TabItem>
-</Tabs>
 </TabItem>
 </Tabs>
 

--- a/docs/pages/connect-your-client/introduction.mdx
+++ b/docs/pages/connect-your-client/introduction.mdx
@@ -39,7 +39,7 @@ Tap any security key
 <TabItem label="Single sign-on user">
 
 Authenticate to Teleport as a single sign-on (SSO) user by running `tsh login`
-and assinging the `auth` flag to the name of your authentication connector, if
+and assigning the `auth` flag to the name of your authentication connector, if
 implemented by your administrators:
 
 ```code

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/aws.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/aws.mdx
@@ -137,11 +137,26 @@ subjects:
 
 ### IAM mapping
 
-<Tabs>
-  <TabItem label="EKS access entry" >
+If you cluster includes the `aws-auth` config map, edit the `configmap/aws-auth`
+in the `kube-system` namespace and append the following to `mapRoles`. Replace
+`{teleport_aws_iam_role}` with the appropriate IAM role that Teleport Kubernetes
+Service will use. This step will link the Teleport IAM role into the Kubernetes
+RBAC group `teleport`, allowing Teleport Kubernetes Service to forward requests
+into the cluster:
 
-Create an EKS access entry to link the <Var name="arn:aws:iam::222222222222:role/teleport-role" />
-to the Kubernetes Group `teleport` we created in the previous step.
+```yaml
+apiVersion: v1
+data:
+  mapRoles: |
+    - groups:
+      - teleport
+      rolearn: {teleport_aws_iam_role} # e.g. arn:aws:iam::222222222222:role/teleport-role
+      username: teleport
+```
+
+Otherwise, create an EKS access entry to link the <Var
+name="arn:aws:iam::222222222222:role/teleport-role" /> to the Kubernetes Group
+`teleport` we created in the previous step:
 
 ```code
 $ aws eks create-access-entry \
@@ -154,28 +169,6 @@ $ aws eks create-access-entry \
   ...
 }
 ```
-
-  </TabItem>
-
-  <TabItem label="aws-auth Configmap" >
-
-Finally, edit the `configmap/aws-auth` in the `kube-system` namespace and append
-the following to `mapRoles`. Replace `{teleport_aws_iam_role}` with the
-appropriate IAM role that Teleport Kubernetes Service will use.
-This step will link the Teleport IAM role into the Kubernetes RBAC group `teleport`,
-allowing Teleport Kubernetes Service to forward requests into the cluster.
-
-```yaml
-apiVersion: v1
-data:
-  mapRoles: |
-    - groups:
-      - teleport
-      rolearn: {teleport_aws_iam_role} # e.g. arn:aws:iam::222222222222:role/teleport-role
-      username: teleport
-```
-  </TabItem>
-</Tabs>
 
 At this point, the Teleport IAM role already has the minimum permissions
 to forward requests to the cluster.
@@ -215,13 +208,29 @@ service means granting administrator-level permissions on the Kubernetes cluster
 To follow least privilege principle we do not recommend using this method in production.
   </Notice>
 
+If your cluster contains an `aws-auth` config map, you can use this to associate
+the Teleport IAM role with the `system:masters` RBAC group. Edit the
+`configmap/aws-auth` in the `kube-system` namespace and append the following to
+`mapRoles`:
 
+```yaml
+apiVersion: v1
+data:
+  mapRoles: |
+  ...
+    - groups:
+      - system:masters
+      rolearn: {teleport_aws_iam_role} # e.g. arn:aws:iam::222222222222:role/teleport-role
+      username: teleport
+```
 
-<Tabs>
-  <TabItem label="EKS access entry" >
+Replace `{teleport_aws_iam_role}` with the appropriate IAM role that
+Teleport Kubernetes Service is using.
 
-Create an EKS access entry and Access Policy to link the <Var name="arn:aws:iam::222222222222:role/teleport-role" />
-to the cluster wide policy `arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy` (equivalent of `cluster-admin` `ClusterRole`).
+Otherwise, create an EKS access entry and Access Policy to link the <Var
+name="arn:aws:iam::222222222222:role/teleport-role" /> to the cluster wide
+policy `arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy`
+(equivalent of `cluster-admin` `ClusterRole`):
 
 ```code
 $ aws eks create-access-entry \
@@ -245,31 +254,6 @@ $ aws eks associate-access-policy \
 }
 
 ```
-
-  </TabItem>
-
-  <TabItem label="aws-auth Configmap" >
-
-To associate the Teleport IAM role with the `system:masters` RBAC group,
-edit the `configmap/aws-auth` in the `kube-system` namespace and append
-the following to `mapRoles`.
-
-```yaml
-apiVersion: v1
-data:
-  mapRoles: |
-  ...
-    - groups:
-      - system:masters
-      rolearn: {teleport_aws_iam_role} # e.g. arn:aws:iam::222222222222:role/teleport-role
-      username: teleport
-```
-
-Please replace `{teleport_aws_iam_role}` with the appropriate IAM role that
-Teleport Kubernetes Service is using.
-  </TabItem>
-</Tabs>
-
 
 At this point, the Teleport IAM role already has the minimum permissions
 to forward requests to the cluster.

--- a/docs/pages/reference/architecture/architecture.mdx
+++ b/docs/pages/reference/architecture/architecture.mdx
@@ -93,7 +93,7 @@ about the architecture of Teleport Agent features:
   Teleport cluster ensures that Agents run the most up-to-date version of the
   `teleport` binary.
 - [Automatically discovering Kubernetes
-  applications](../../reference/architecture//kubernetes-applications-architecture.mdx):
+  applications](../../reference/architecture/kubernetes-applications-architecture.mdx):
   The Teleport Discovery Service queries your Kubernetes cluster and registers
   applications with the Teleport Auth Service.
 - [Session recordings](session-recording.mdx): Teleport Agents record user


### PR DESCRIPTION
Closes #35870

Used the following command to find nested tabs:

```
$ find docs/pages -name "*.mdx" -exec awk '
/<TabItem/{ti=1}
ti==1 && /<\/TabItem/{ti=0}
ti==1 && /<Tabs/{n=1;if(lines=="") lines=FNR; else lines=(lines "," FNR)}
END{if(n>0) print FILENAME ":" lines}' {} \;
```

Edit the following guides:

- **Connect your Client intro:** Remove branching between Community Edition and Teleport Enterprise. The only difference was the assumption that Community Edition users would only have a GitHub connector available. But if users must ask their administrator for an SSO connector name anyway, we don't need to specify the connector name here.
- **GUI clients:** Use separate H4s to describe using a local proxy server and getting remote host information.
- **Self-Signed Certs:** Don't use tabs to explain the difference in syntax between using `--set` and a values file in Helm. Instead, use inline prose.
- **Locking:** Explain both the CAP and static config file in the "Self-Hosted" tab.
- **AWS Helm deployment:** Remove the Community Edition tab in Step 5 and explain how to disable the `enterprise` field using a YAML comment
- **Kubernetes AWS auto-discovery:** Collapse `aws-auth` and `eks create-access-entry` instructions into a single passage of text.