### PR TITLE
[entraid] add setup script for offline clusters.

### DIFF
--- a/api/utils/entraid/federation_metadata.go
+++ b/api/utils/entraid/federation_metadata.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2024 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package entraid
+
+import (
+	"net/url"
+	"path"
+)
+
+// FederationMetadataURL returns the URL for the federation metadata endpoint
+func FederationMetadataURL(tenantID, appID string) string {
+	return (&url.URL{
+		Scheme: "https",
+		Host:   "login.microsoftonline.com",
+		Path:   path.Join(tenantID, "federationmetadata", "2007-06", "federationmetadata.xml"),
+		RawQuery: url.Values{
+			"appid": {appID},
+		}.Encode(),
+	}).String()
+}

--- a/go.mod
+++ b/go.mod
@@ -91,6 +91,7 @@ require (
 	github.com/elimity-com/scim v0.0.0-20240320110924-172bf2aee9c8
 	github.com/envoyproxy/go-control-plane v0.13.0
 	github.com/evanphx/json-patch v5.9.0+incompatible
+	github.com/fatih/color v1.17.0
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/fsouza/fake-gcs-server v1.49.3
 	github.com/fxamacker/cbor/v2 v2.7.0
@@ -323,7 +324,6 @@ require (
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
 	github.com/fatih/camelcase v1.0.0 // indirect
-	github.com/fatih/color v1.17.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/go-asn1-ber/asn1-ber v1.5.5 // indirect

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -297,6 +297,9 @@ type IntegrationConfAzureOIDC struct {
 	// When this is true, the integration script will produce
 	// a cache file necessary for TAG synchronization.
 	AccessGraphEnabled bool
+
+	// SkipOIDCConfiguration is a flag indicating that OIDC configuration should be skipped.
+	SkipOIDCConfiguration bool
 }
 
 // IntegrationConfDeployServiceIAM contains the arguments of

--- a/lib/integrations/azureoidc/provision_sso.go
+++ b/lib/integrations/azureoidc/provision_sso.go
@@ -48,6 +48,9 @@ func setupSSO(ctx context.Context, graphClient *msgraph.Client, appObjectID stri
 	webApp := &msgraph.WebApplication{}
 	webApp.RedirectURIs = &uris
 	app.Web = webApp
+	securityGroups := new(string)
+	*securityGroups = "SecurityGroup"
+	app.GroupMembershipClaims = securityGroups
 
 	err = graphClient.UpdateApplication(ctx, appObjectID, app)
 

--- a/lib/msgraph/models.go
+++ b/lib/msgraph/models.go
@@ -18,6 +18,7 @@ package msgraph
 
 import (
 	"encoding/json"
+	"slices"
 
 	"github.com/gravitational/trace"
 )
@@ -34,6 +35,12 @@ type DirectoryObject struct {
 
 type Group struct {
 	DirectoryObject
+	GroupTypes []string `json:"groupTypes,omitempty"`
+}
+
+func (g *Group) IsOffice365Group() bool {
+	const office365Group = "Unified"
+	return slices.Contains(g.GroupTypes, office365Group)
 }
 
 func (g *Group) isGroupMember() {}
@@ -53,9 +60,10 @@ func (u *User) GetID() *string { return u.ID }
 type Application struct {
 	DirectoryObject
 
-	AppID          *string         `json:"appId,omitempty"`
-	IdentifierURIs *[]string       `json:"identifierUris,omitempty"`
-	Web            *WebApplication `json:"web,omitempty"`
+	AppID                 *string         `json:"appId,omitempty"`
+	IdentifierURIs        *[]string       `json:"identifierUris,omitempty"`
+	Web                   *WebApplication `json:"web,omitempty"`
+	GroupMembershipClaims *string         `json:"groupMembershipClaims,omitempty"`
 }
 
 type WebApplication struct {

--- a/tool/tctl/common/plugin/entraid.go
+++ b/tool/tctl/common/plugin/entraid.go
@@ -47,7 +47,7 @@ var (
 	bold    = color.New(color.Bold).SprintFunc()
 	boldRed = color.New(color.Bold, color.FgRed).SprintFunc()
 
-	step1Template = `Step 1: Run the Setup Script
+	step1Template = bold("Step 1: Run the Setup Script") + `
 
 1. Open ` + bold("Azure Cloud Shell") + ` (Bash) [https://portal.azure.com/#cloudshell/] using ` + bold("Google Chrome") + ` or ` + bold("Safari") + ` for the best compatibility.
 2. Upload the setup script in ` + boldRed("%s") + ` using the ` + bold("Upload") + ` button in the Cloud Shell toolbar.
@@ -60,11 +60,13 @@ var (
 - During the script execution, you'll be prompted to run 'az login' to authenticate with Azure. ` + bold("Teleport") + ` does not store or persist your credentials.
 - ` + bold("Mozilla Firefox") + ` users may experience connectivity issues in Azure Cloud Shell; using Chrome or Safari is recommended.
 
+To rerun the script, type 'exit' to close and then restart the process.
+
 `
 
 	step2Template = `
 	
-Step 2: Input Tenant ID and Client ID
+` + bold("Step 2: Input Tenant ID and Client ID") + `
 
 With the output of Step 1, please copy and paste the following information:
 `
@@ -151,7 +153,7 @@ func (p *PluginsCommand) entraSetupGuide(proxyPublicAddr string) (entraSettings,
 	fmt.Fprintf(os.Stdout, step1Template, fileLoc, filepath.Base(fileLoc))
 
 	op, err := readData(os.Stdin, os.Stdout,
-		"Once the script completes, type 'continue' to proceed, 'exit' to quit. If you need to rerun the script, type 'exit' and restart the process.",
+		`Once the script completes, type 'continue' to proceed, 'exit' to quit`,
 		func(input string) bool {
 			return input == "continue" || input == "exit"
 		}, "Invalid input. Please enter 'continue' or 'exit'.")

--- a/tool/tctl/common/plugin/entraid.go
+++ b/tool/tctl/common/plugin/entraid.go
@@ -82,7 +82,7 @@ func (p *PluginsCommand) initInstallEntra(parent *kingpin.CmdClause) {
 		Flag("force", "Proceed with installation even if plugin already exists.").
 		Short('f').
 		Default("false").
-		BoolVar(&p.install.scim.force)
+		BoolVar(&p.install.entraID.force)
 }
 
 type entraSettings struct {
@@ -215,7 +215,7 @@ func (p *PluginsCommand) InstallEntra(ctx context.Context, args installPluginArg
 	saml, err := types.NewSAMLConnector(inputs.entraID.authConnectorName, types.SAMLConnectorSpecV2{
 		AssertionConsumerService: proxyPublicAddr + "/v1/webapi/saml/acs/" + inputs.entraID.authConnectorName,
 		AllowIDPInitiated:        true,
-		// AttributesToRoles is required, but Entra ID does not by have a default group (like Okta's "Everyone"),
+		// AttributesToRoles is required, but Entra ID does not have a default group (like Okta's "Everyone"),
 		// so we add a dummy claim that will never be fulfilled with the default configuration instead,
 		// and expect the user to modify it per their requirements.
 		AttributesToRoles: []types.AttributeMapping{
@@ -315,7 +315,6 @@ func (p *PluginsCommand) InstallEntra(ctx context.Context, args installPluginArg
 }
 
 func buildScript(proxyPublicAddr string, authConnectorName string, accessGraph, skipOIDCSetup bool) (string, error) {
-
 	oidcIssuer, err := oidc.IssuerFromPublicAddress(proxyPublicAddr, "")
 	if err != nil {
 		return "", trace.Wrap(err)

--- a/tool/tctl/common/plugin/entraid.go
+++ b/tool/tctl/common/plugin/entraid.go
@@ -1,0 +1,403 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package plugin
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/google/safetext/shsprintf"
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+
+	pluginspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/plugins/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/e/lib/entraid"
+	"github.com/gravitational/teleport/lib/integrations/azureoidc"
+	"github.com/gravitational/teleport/lib/utils/oidc"
+	"github.com/gravitational/teleport/lib/web/scripts/oneoff"
+)
+
+type entraArgs struct {
+	cmd                  *kingpin.CmdClause
+	authConnectorName    string
+	defaultOwners        []string
+	useSystemCredentials bool
+	accessGraph          bool
+	force                bool
+}
+
+func (p *PluginsCommand) initInstallEntra(parent *kingpin.CmdClause) {
+	p.install.entraID.cmd = parent.Command("entraid", "Install an EntraId integration.")
+	cmd := p.install.entraID.cmd
+	cmd.
+		Flag("name", "Name of the plugin resource to create").
+		Default("entra-id").
+		StringVar(&p.install.name)
+
+	cmd.
+		Flag("auth-connector-name", "Name of the SAML connector resource to create").
+		Default("entra-id-default").
+		StringVar(&p.install.entraID.authConnectorName)
+
+	cmd.
+		Flag("use-system-credentials", "Uses system credentials instead of OIDC.").
+		BoolVar(&p.install.entraID.useSystemCredentials)
+
+	cmd.Flag("default-owner", "List of Teleport users that are default owners for the imported access lists. Multiple flags allowed.").
+		Required().
+		StringsVar(&p.install.entraID.defaultOwners)
+
+	cmd.
+		Flag("access-graph", "Enables Access Graph cache build.").
+		Default("true").
+		BoolVar(&p.install.entraID.accessGraph)
+
+	cmd.
+		Flag("force", "Proceed with installation even if plugin already exists.").
+		Short('f').
+		Default("false").
+		BoolVar(&p.install.scim.force)
+}
+
+type entraSettings struct {
+	accessGraphCache *azureoidc.TAGInfoCache
+	clientID         string
+	tenantID         string
+}
+
+var (
+	errCancel = trace.BadParameter("operation canceled")
+)
+
+func (p *PluginsCommand) entraSetupGuide(proxyPublicAddr string) (entraSettings, error) {
+	fileLoc, err := pathForFile(os.Stdout, os.Stdin)
+	if err != nil {
+		return entraSettings{}, trace.Wrap(err, "failed to get file location")
+	}
+
+	buildScript, err := buildScript(proxyPublicAddr, p.install.entraID.authConnectorName, p.install.entraID.accessGraph, p.install.entraID.useSystemCredentials)
+	if err != nil {
+		return entraSettings{}, trace.Wrap(err, "failed to build script")
+	}
+
+	if err := os.WriteFile(fileLoc, []byte(buildScript), 0644); err != nil {
+		return entraSettings{}, trace.Wrap(err, "failed to write script to file")
+	}
+
+	tmpl := `Step 1: Run the Setup Script
+
+1. Open **Azure Cloud Shell** (Bash) using **Google Chrome** or **Safari** for the best compatibility.
+2. Upload the setup script using the **Upload** button in the Cloud Shell toolbar.
+3. Once uploaded, execute the script by running the following command:
+   $ bash %s
+
+**Important Considerations**:
+- You must have **Azure privileged administrator permissions** to complete the integration.
+- Ensure you're using the **Bash** environment in Cloud Shell.
+- During the script execution, you'll be prompted to run 'az login' to authenticate with Azure. **Teleport** does not store or persist your credentials.
+- **Mozilla Firefox** users may experience connectivity issues in Azure Cloud Shell; using Chrome or Safari is recommended.
+
+`
+
+	fmt.Fprintf(os.Stdout, tmpl, filepath.Base(fileLoc))
+
+	op, err := readData(os.Stdin, os.Stdout,
+		"Once the script completes, type 'continue' to proceed, 'exit' to quit",
+		func(input string) bool {
+			return input == "continue" || input == "exit"
+		}, "Invalid input. Please enter 'continue' or 'exit'.")
+	if err != nil {
+		return entraSettings{}, trace.Wrap(err, "failed to read operation")
+	}
+	if op == "exit" { // User chose to exit
+		return entraSettings{}, errCancel
+	}
+
+	validUUID := func(input string) bool {
+		_, err := uuid.Parse(input)
+		return err == nil
+	}
+
+	tmpl = `
+	
+Step 2: Input Tenant ID and Client ID
+
+With the output of Step 1, please copy and paste the following information:
+`
+	fmt.Fprint(os.Stdout, tmpl)
+	var settings entraSettings
+	settings.tenantID, err = readData(os.Stdin, os.Stdout, "Enter the Tenant ID", validUUID, "Invalid Tenant ID")
+	if err != nil {
+		return settings, trace.Wrap(err, "failed to read Tenant ID")
+	}
+
+	settings.clientID, err = readData(os.Stdin, os.Stdout, "Enter the Client ID", validUUID, "Invalid Client ID")
+	if err != nil {
+		return settings, trace.Wrap(err, "failed to read Client ID")
+	}
+
+	if p.install.entraID.accessGraph {
+		dataValidator := func(input string) bool {
+			settings.accessGraphCache, err = readTAGCache(input)
+			return err == nil
+		}
+		_, err = readData(os.Stdin, os.Stdout, "Enter the Access Graph Cache file location", dataValidator, "File does not exist or is invalid")
+		if err != nil {
+			return settings, trace.Wrap(err, "failed to read Access Graph Cache file")
+		}
+	}
+	return settings, nil
+}
+
+func (p *PluginsCommand) InstallEntra(ctx context.Context, args installPluginArgs) error {
+	inputs := p.install
+
+	proxyPublicAddr, err := getProxyPublicAddr(ctx, args.authClient)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	settings, err := p.entraSetupGuide(proxyPublicAddr)
+	if err != nil {
+		if errors.Is(err, errCancel) {
+			return nil
+		}
+		return trace.Wrap(err)
+	}
+
+	var tagSyncSettings *types.PluginEntraIDAccessGraphSettings
+	if settings.accessGraphCache != nil {
+		tagSyncSettings = &types.PluginEntraIDAccessGraphSettings{
+			AppSsoSettingsCache: settings.accessGraphCache.AppSsoSettingsCache,
+		}
+	}
+
+	saml, err := types.NewSAMLConnector(inputs.entraID.authConnectorName, types.SAMLConnectorSpecV2{
+		AssertionConsumerService: proxyPublicAddr + "/v1/webapi/saml/acs/" + inputs.entraID.authConnectorName,
+		AllowIDPInitiated:        true,
+		// AttributesToRoles is required, but Entra ID does not by have a default group (like Okta's "Everyone"),
+		// so we add a dummy claim that will never be fulfilled with the default configuration instead,
+		// and expect the user to modify it per their requirements.
+		AttributesToRoles: []types.AttributeMapping{
+			{
+				Name:  "https://example.com/my_attribute",
+				Value: "my_value",
+				Roles: []string{"requester"},
+			},
+		},
+		Display:             "Entra ID",
+		EntityDescriptorURL: entraid.FederationMetadataURL(settings.tenantID, settings.clientID),
+	})
+	if err != nil {
+		return trace.Wrap(err, "failed to create SAML connector")
+	}
+
+	if _, err = args.authClient.CreateSAMLConnector(ctx, saml); err != nil {
+		if !trace.IsAlreadyExists(err) || !inputs.entraID.force {
+			return trace.Wrap(err, "failed to create SAML connector")
+		}
+		if _, err = args.authClient.UpsertSAMLConnector(ctx, saml); err != nil {
+			return trace.Wrap(err, "failed to upsert SAML connector")
+		}
+	}
+
+	if !inputs.entraID.useSystemCredentials {
+		integrationSpec, err := types.NewIntegrationAzureOIDC(
+			types.Metadata{Name: inputs.name},
+			&types.AzureOIDCIntegrationSpecV1{
+				TenantID: settings.tenantID,
+				ClientID: settings.clientID,
+			},
+		)
+		if err != nil {
+			return trace.Wrap(err, "failed to create Azure OIDC integration")
+		}
+
+		if _, err = args.authClient.CreateIntegration(ctx, integrationSpec); err != nil {
+			if !trace.IsAlreadyExists(err) || !inputs.entraID.force {
+				return trace.Wrap(err, "failed to create Azure OIDC integration")
+			}
+			if err = args.authClient.DeleteIntegration(ctx, integrationSpec.GetName()); err != nil {
+				return trace.Wrap(err, "failed to delete Azure OIDC integration")
+			}
+			if _, err = args.authClient.CreateIntegration(ctx, integrationSpec); err != nil {
+				return trace.Wrap(err, "failed to create Azure OIDC integration")
+			}
+		}
+	}
+
+	credentialsSource := types.EntraIDCredentialsSource_ENTRAID_CREDENTIALS_SOURCE_OIDC
+	if inputs.entraID.useSystemCredentials {
+		credentialsSource = types.EntraIDCredentialsSource_ENTRAID_CREDENTIALS_SOURCE_SYSTEM_CREDENTIALS
+	}
+	req := &pluginspb.CreatePluginRequest{
+		Plugin: &types.PluginV1{
+			Metadata: types.Metadata{
+				Name: inputs.name,
+				Labels: map[string]string{
+					"teleport.dev/hosted-plugin": "true",
+				},
+			},
+			Spec: types.PluginSpecV1{
+				Settings: &types.PluginSpecV1_EntraId{
+					EntraId: &types.PluginEntraIDSettings{
+						SyncSettings: &types.PluginEntraIDSyncSettings{
+							DefaultOwners:     inputs.entraID.defaultOwners,
+							SsoConnectorId:    inputs.entraID.authConnectorName,
+							CredentialsSource: credentialsSource,
+							TenantId:          settings.tenantID,
+						},
+						AccessGraphSettings: tagSyncSettings,
+					},
+				},
+			},
+		},
+	}
+
+	_, err = args.plugins.CreatePlugin(ctx, req)
+	if err != nil {
+		if !trace.IsAlreadyExists(err) || !inputs.entraID.force {
+			return trace.Wrap(err)
+		}
+		if _, err = args.plugins.DeletePlugin(ctx, &pluginspb.DeletePluginRequest{
+			Name: inputs.name,
+		}); err != nil {
+			return trace.Wrap(err)
+		}
+		if _, err = args.plugins.CreatePlugin(ctx, req); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	fmt.Printf("Successfully created EntraID plugin %q\n\n", p.install.name)
+
+	return nil
+}
+
+func buildScript(proxyPublicAddr string, authConnectorName string, accessGraph, skipOIDCSetup bool) (string, error) {
+
+	oidcIssuer, err := oidc.IssuerFromPublicAddress(proxyPublicAddr, "")
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	// The script must execute the following command:
+	argsList := []string{
+		"integration", "configure", "azure-oidc",
+		fmt.Sprintf("--proxy-public-addr=%s", shsprintf.EscapeDefaultContext(oidcIssuer)),
+		fmt.Sprintf("--auth-connector-name=%s", shsprintf.EscapeDefaultContext(authConnectorName)),
+	}
+
+	if accessGraph {
+		argsList = append(argsList, "--access-graph")
+	}
+
+	if skipOIDCSetup {
+		argsList = append(argsList, "--skip-oidc-integration")
+	}
+
+	script, err := oneoff.BuildScript(oneoff.OneOffScriptParams{
+		TeleportArgs:   strings.Join(argsList, " "),
+		SuccessMessage: "Success! You can now go back to the Teleport Web UI to use the integration with Azure.",
+	})
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	return script, nil
+}
+
+func getProxyPublicAddr(ctx context.Context, authClient authClient) (string, error) {
+	pingResp, err := authClient.Ping(ctx)
+	if err != nil {
+		return "", trace.Wrap(err, "failed fetching cluster info")
+	}
+	proxyPublicAddr := pingResp.GetProxyPublicAddr()
+	return proxyPublicAddr, nil
+}
+
+func pathForFile(w io.Writer, r io.Reader) (string, error) {
+
+	pwd, err := os.Getwd()
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	const defaultFileName = "entraid.sh"
+
+	file := filepath.Join(pwd, defaultFileName)
+	_, err = readData(r, w, fmt.Sprintf("Enter the path to write the script file [%s]", file), func(input string) bool {
+		if input != "" {
+			file = input
+		}
+		// Check if the directory exists
+		_, err = os.Stat(filepath.Dir(file))
+		return err == nil
+	},
+		"Invalid directory file location",
+	)
+
+	return file, trace.Wrap(err)
+}
+
+var (
+	errNoTAGCache = trace.BadParameter("no TAG cache file found")
+)
+
+func readTAGCache(fileLoc string) (*azureoidc.TAGInfoCache, error) {
+	if fileLoc == "" {
+		return nil, trace.Wrap(errNoTAGCache)
+	}
+
+	file, err := os.Open(fileLoc)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer file.Close()
+
+	var result azureoidc.TAGInfoCache
+	if err := json.NewDecoder(file).Decode(&result); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &result, nil
+}
+
+func readData(r io.Reader, w io.Writer, message string, validate func(string) bool, errorMessage string) (string, error) {
+	reader := bufio.NewReader(r)
+	for {
+		fmt.Fprintf(w, "%s: ", message)
+		input, _ := reader.ReadString('\n')
+		input = strings.TrimSpace(input) // Clean up any extra newlines or spaces
+
+		if !validate(input) {
+			fmt.Fprintf(w, "%s\n", errorMessage)
+			continue
+		}
+		return input, nil
+	}
+}

--- a/tool/tctl/common/plugin/entraid.go
+++ b/tool/tctl/common/plugin/entraid.go
@@ -36,7 +36,7 @@ import (
 
 	pluginspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/plugins/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/e/lib/entraid"
+	entraapiutils "github.com/gravitational/teleport/api/utils/entraid"
 	"github.com/gravitational/teleport/lib/integrations/azureoidc"
 	"github.com/gravitational/teleport/lib/utils/oidc"
 	"github.com/gravitational/teleport/lib/web/scripts/oneoff"
@@ -211,7 +211,7 @@ func (p *PluginsCommand) InstallEntra(ctx context.Context, args installPluginArg
 			},
 		},
 		Display:             "Entra ID",
-		EntityDescriptorURL: entraid.FederationMetadataURL(settings.tenantID, settings.clientID),
+		EntityDescriptorURL: entraapiutils.FederationMetadataURL(settings.tenantID, settings.clientID),
 	})
 	if err != nil {
 		return trace.Wrap(err, "failed to create SAML connector")

--- a/tool/tctl/common/plugin/plugins_command.go
+++ b/tool/tctl/common/plugin/plugins_command.go
@@ -49,10 +49,11 @@ func logErrorMessage(err error) slog.Attr {
 }
 
 type pluginInstallArgs struct {
-	cmd  *kingpin.CmdClause
-	name string
-	okta oktaArgs
-	scim scimArgs
+	cmd     *kingpin.CmdClause
+	name    string
+	okta    oktaArgs
+	scim    scimArgs
+	entraID entraArgs
 }
 
 type scimArgs struct {
@@ -98,6 +99,7 @@ func (p *PluginsCommand) initInstall(parent *kingpin.CmdClause, config *servicec
 
 	p.initInstallOkta(p.install.cmd)
 	p.initInstallSCIM(p.install.cmd)
+	p.initInstallEntra(p.install.cmd)
 }
 
 func (p *PluginsCommand) initInstallSCIM(parent *kingpin.CmdClause) {
@@ -200,11 +202,16 @@ func (p *PluginsCommand) Cleanup(ctx context.Context, clusterAPI *authclient.Cli
 
 type authClient interface {
 	GetSAMLConnector(ctx context.Context, id string, withSecrets bool) (types.SAMLConnector, error)
+	CreateSAMLConnector(ctx context.Context, connector types.SAMLConnector) (types.SAMLConnector, error)
+	UpsertSAMLConnector(ctx context.Context, connector types.SAMLConnector) (types.SAMLConnector, error)
+	CreateIntegration(ctx context.Context, ig types.Integration) (types.Integration, error)
+	DeleteIntegration(ctx context.Context, name string) error
 	Ping(ctx context.Context) (proto.PingResponse, error)
 }
 
 type pluginsClient interface {
 	CreatePlugin(ctx context.Context, in *pluginsv1.CreatePluginRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	DeletePlugin(ctx context.Context, in *pluginsv1.DeletePluginRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 }
 
 type installPluginArgs struct {
@@ -310,6 +317,9 @@ func (p *PluginsCommand) TryRun(ctx context.Context, cmd string, client *authcli
 		err = p.InstallOkta(ctx, args)
 	case p.install.scim.cmd.FullCommand():
 		err = p.InstallSCIM(ctx, client)
+	case p.install.entraID.cmd.FullCommand():
+		args := installPluginArgs{authClient: client, plugins: client.PluginsClient()}
+		err = p.InstallEntra(ctx, args)
 	case p.delete.cmd.FullCommand():
 		err = p.Delete(ctx, client)
 	default:

--- a/tool/tctl/common/plugin/plugins_command.go
+++ b/tool/tctl/common/plugin/plugins_command.go
@@ -205,13 +205,15 @@ type authClient interface {
 	CreateSAMLConnector(ctx context.Context, connector types.SAMLConnector) (types.SAMLConnector, error)
 	UpsertSAMLConnector(ctx context.Context, connector types.SAMLConnector) (types.SAMLConnector, error)
 	CreateIntegration(ctx context.Context, ig types.Integration) (types.Integration, error)
-	DeleteIntegration(ctx context.Context, name string) error
+	GetIntegration(ctx context.Context, name string) (types.Integration, error)
+	UpdateIntegration(ctx context.Context, ig types.Integration) (types.Integration, error)
 	Ping(ctx context.Context) (proto.PingResponse, error)
 }
 
 type pluginsClient interface {
 	CreatePlugin(ctx context.Context, in *pluginsv1.CreatePluginRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
-	DeletePlugin(ctx context.Context, in *pluginsv1.DeletePluginRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	GetPlugin(ctx context.Context, in *pluginsv1.GetPluginRequest, opts ...grpc.CallOption) (*types.PluginV1, error)
+	UpdatePlugin(ctx context.Context, in *pluginsv1.UpdatePluginRequest, opts ...grpc.CallOption) (*types.PluginV1, error)
 }
 
 type installPluginArgs struct {

--- a/tool/tctl/common/plugin/plugins_command_test.go
+++ b/tool/tctl/common/plugin/plugins_command_test.go
@@ -449,6 +449,11 @@ func (m *mockPluginsClient) CreatePlugin(ctx context.Context, in *pluginsv1.Crea
 	return result.Get(0).(*emptypb.Empty), result.Error(1)
 }
 
+func (m *mockPluginsClient) DeletePlugin(ctx context.Context, in *pluginsv1.DeletePluginRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	result := m.Called(ctx, in, opts)
+	return result.Get(0).(*emptypb.Empty), result.Error(1)
+}
+
 type mockAuthClient struct {
 	mock.Mock
 }
@@ -457,7 +462,22 @@ func (m *mockAuthClient) GetSAMLConnector(ctx context.Context, id string, withSe
 	result := m.Called(ctx, id, withSecrets)
 	return result.Get(0).(types.SAMLConnector), result.Error(1)
 }
-
+func (m *mockAuthClient) CreateSAMLConnector(ctx context.Context, connector types.SAMLConnector) (types.SAMLConnector, error) {
+	result := m.Called(ctx, connector)
+	return result.Get(0).(types.SAMLConnector), result.Error(1)
+}
+func (m *mockAuthClient) UpsertSAMLConnector(ctx context.Context, connector types.SAMLConnector) (types.SAMLConnector, error) {
+	result := m.Called(ctx, connector)
+	return result.Get(0).(types.SAMLConnector), result.Error(1)
+}
+func (m *mockAuthClient) CreateIntegration(ctx context.Context, ig types.Integration) (types.Integration, error) {
+	result := m.Called(ctx, ig)
+	return result.Get(0).(types.Integration), result.Error(1)
+}
+func (m *mockAuthClient) DeleteIntegration(ctx context.Context, name string) error {
+	result := m.Called(ctx, name)
+	return result.Error(0)
+}
 func (m *mockAuthClient) Ping(ctx context.Context) (proto.PingResponse, error) {
 	result := m.Called(ctx)
 	return result.Get(0).(proto.PingResponse), result.Error(1)

--- a/tool/tctl/common/plugin/plugins_command_test.go
+++ b/tool/tctl/common/plugin/plugins_command_test.go
@@ -449,9 +449,14 @@ func (m *mockPluginsClient) CreatePlugin(ctx context.Context, in *pluginsv1.Crea
 	return result.Get(0).(*emptypb.Empty), result.Error(1)
 }
 
-func (m *mockPluginsClient) DeletePlugin(ctx context.Context, in *pluginsv1.DeletePluginRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+func (m *mockPluginsClient) GetPlugin(ctx context.Context, in *pluginsv1.GetPluginRequest, opts ...grpc.CallOption) (*types.PluginV1, error) {
 	result := m.Called(ctx, in, opts)
-	return result.Get(0).(*emptypb.Empty), result.Error(1)
+	return result.Get(0).(*types.PluginV1), result.Error(1)
+}
+
+func (m *mockPluginsClient) UpdatePlugin(ctx context.Context, in *pluginsv1.UpdatePluginRequest, opts ...grpc.CallOption) (*types.PluginV1, error) {
+	result := m.Called(ctx, in, opts)
+	return result.Get(0).(*types.PluginV1), result.Error(1)
 }
 
 type mockAuthClient struct {
@@ -474,10 +479,16 @@ func (m *mockAuthClient) CreateIntegration(ctx context.Context, ig types.Integra
 	result := m.Called(ctx, ig)
 	return result.Get(0).(types.Integration), result.Error(1)
 }
-func (m *mockAuthClient) DeleteIntegration(ctx context.Context, name string) error {
-	result := m.Called(ctx, name)
-	return result.Error(0)
+func (m *mockAuthClient) UpdateIntegration(ctx context.Context, ig types.Integration) (types.Integration, error) {
+	result := m.Called(ctx, ig)
+	return result.Get(0).(types.Integration), result.Error(1)
 }
+
+func (m *mockAuthClient) GetIntegration(ctx context.Context, name string) (types.Integration, error) {
+	result := m.Called(ctx, name)
+	return result.Get(0).(types.Integration), result.Error(1)
+}
+
 func (m *mockAuthClient) Ping(ctx context.Context) (proto.PingResponse, error) {
 	result := m.Called(ctx)
 	return result.Get(0).(proto.PingResponse), result.Error(1)

--- a/tool/teleport/common/integration_configure.go
+++ b/tool/teleport/common/integration_configure.go
@@ -251,7 +251,7 @@ func onIntegrationConfAzureOIDCCmd(ctx context.Context, params config.Integratio
 
 	fmt.Println("Teleport is setting up the Azure integration. This may take a few minutes.")
 
-	appID, tenantID, err := azureoidc.SetupEnterpriseApp(ctx, params.ProxyPublicAddr, params.AuthConnectorName)
+	appID, tenantID, err := azureoidc.SetupEnterpriseApp(ctx, params.ProxyPublicAddr, params.AuthConnectorName, params.SkipOIDCConfiguration)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -552,6 +552,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	integrationConfAzureOIDCCmd.Flag("proxy-public-addr", "The public address of Teleport Proxy Service").Required().StringVar(&ccf.IntegrationConfAzureOIDCArguments.ProxyPublicAddr)
 	integrationConfAzureOIDCCmd.Flag("auth-connector-name", "The name of Entra ID SAML Auth connector in Teleport.").Required().StringVar(&ccf.IntegrationConfAzureOIDCArguments.AuthConnectorName)
 	integrationConfAzureOIDCCmd.Flag("access-graph", "Enable Access Graph integration.").BoolVar(&ccf.IntegrationConfAzureOIDCArguments.AccessGraphEnabled)
+	integrationConfAzureOIDCCmd.Flag("skip-oidc-integration", "Skip OIDC integration.").BoolVar(&ccf.IntegrationConfAzureOIDCArguments.SkipOIDCConfiguration)
 
 	integrationConfSAMLIdP := integrationConfigureCmd.Command("samlidp", "Manage SAML IdP integrations.")
 	integrationSAMLIdPGCPWorkforce := integrationConfSAMLIdP.Command("gcp-workforce", "Configures GCP Workforce Identity Federation pool and SAML provider.")


### PR DESCRIPTION
This PR introduces a CLI configuration option for Entra ID, allowing the use of system credentials as the default authentication method instead of OIDC. This is particularly useful for private clusters that are not accessible via the internet, where OIDC may not be a viable option.

The UX is the following:

```text
Enter the path to write the script file [/home/tiago/code/teleport/entraid.sh]:

Step 1: Run the Setup Script

1. Open **Azure Cloud Shell** (Bash) using **Google Chrome** or **Safari** for the best compatibility.
2. Upload the setup script using the **Upload** button in the Cloud Shell toolbar.
3. Once uploaded, execute the script by running the following command:
   $ bash entraid.sh

**Important Considerations**:
- You must have **Azure privileged administrator permissions** to complete the integration.
- Ensure you're using the **Bash** environment in Cloud Shell.
- During the script execution, you'll be prompted to run 'az login' to authenticate with Azure. **Teleport** does not store or persist your credentials.
- **Mozilla Firefox** users may experience connectivity issues in Azure Cloud Shell; using Chrome or Safari is recommended.

Once the script completes, type 'continue' to proceed, 'exit' to quit: continue

Step 2: Input Tenant ID and Client ID

With the output of Step 1, please copy and paste the following information:
Enter the Tenant ID: 1056b571-0390-4b08-86c8-2edba8d9ae79
Enter the Client ID: 1056b571-0390-4b08-86c8-2edba8d9ae79

Successfully created EntraID plugin "name".
```

Changelog:  Added support for Entra ID directory synchronization for clusters without public internet access.