### PR TITLE
Refactor CLI prompt and config logic

### DIFF
--- a/api/mfa/prompt.go
+++ b/api/mfa/prompt.go
@@ -40,7 +40,7 @@ func (f PromptFunc) Run(ctx context.Context, chal *proto.MFAAuthenticateChalleng
 // PromptConstructor is a function that creates a new MFA prompt.
 type PromptConstructor func(...PromptOpt) Prompt
 
-// PromptConfig contains common mfa prompt config options.
+// PromptConfig contains universal mfa prompt config options.
 type PromptConfig struct {
 	// PromptReason is an optional message to share with the user before an MFA Prompt.
 	// It is intended to provide context about why the user is being prompted where it may

--- a/lib/client/mfa.go
+++ b/lib/client/mfa.go
@@ -57,7 +57,16 @@ type WebauthnLoginFunc = libmfa.WebauthnLoginFunc
 func (tc *TeleportClient) NewMFAPrompt(opts ...mfa.PromptOpt) mfa.Prompt {
 	cfg := tc.newPromptConfig(opts...)
 
-	var prompt mfa.Prompt = libmfa.NewCLIPrompt(cfg, tc.Stderr)
+	var prompt mfa.Prompt = &libmfa.CLIPrompt{
+		CLIPromptConfig: libmfa.CLIPromptConfig{
+			PromptConfig:     *cfg,
+			Writer:           tc.Stderr,
+			PreferOTP:        tc.PreferOTP,
+			AllowStdinHijack: tc.AllowStdinHijack,
+			StdinFunc:        tc.StdinFunc,
+		},
+	}
+
 	if tc.MFAPromptConstructor != nil {
 		prompt = tc.MFAPromptConstructor(cfg)
 	}
@@ -68,10 +77,6 @@ func (tc *TeleportClient) NewMFAPrompt(opts ...mfa.PromptOpt) mfa.Prompt {
 func (tc *TeleportClient) newPromptConfig(opts ...mfa.PromptOpt) *libmfa.PromptConfig {
 	cfg := libmfa.NewPromptConfig(tc.WebProxyAddr, opts...)
 	cfg.AuthenticatorAttachment = tc.AuthenticatorAttachment
-	cfg.PreferOTP = tc.PreferOTP
-	cfg.AllowStdinHijack = tc.AllowStdinHijack
-	cfg.StdinFunc = tc.StdinFunc
-
 	if tc.WebauthnLogin != nil {
 		cfg.WebauthnLoginFunc = tc.WebauthnLogin
 		cfg.WebauthnSupported = true

--- a/lib/client/mfa.go
+++ b/lib/client/mfa.go
@@ -57,15 +57,13 @@ type WebauthnLoginFunc = libmfa.WebauthnLoginFunc
 func (tc *TeleportClient) NewMFAPrompt(opts ...mfa.PromptOpt) mfa.Prompt {
 	cfg := tc.newPromptConfig(opts...)
 
-	var prompt mfa.Prompt = &libmfa.CLIPrompt{
-		CLIPromptConfig: libmfa.CLIPromptConfig{
-			PromptConfig:     *cfg,
-			Writer:           tc.Stderr,
-			PreferOTP:        tc.PreferOTP,
-			AllowStdinHijack: tc.AllowStdinHijack,
-			StdinFunc:        tc.StdinFunc,
-		},
-	}
+	var prompt mfa.Prompt = libmfa.NewCLIPromptV2(&libmfa.CLIPromptConfig{
+		PromptConfig:     *cfg,
+		Writer:           tc.Stderr,
+		PreferOTP:        tc.PreferOTP,
+		AllowStdinHijack: tc.AllowStdinHijack,
+		StdinFunc:        tc.StdinFunc,
+	})
 
 	if tc.MFAPromptConstructor != nil {
 		prompt = tc.MFAPromptConstructor(cfg)

--- a/lib/client/mfa/cli_test.go
+++ b/lib/client/mfa/cli_test.go
@@ -239,7 +239,6 @@ Enter your security key PIN:
 			prompt.SetStdin(stdin)
 
 			cfg := mfa.NewPromptConfig("proxy.example.com")
-			cfg.AllowStdinHijack = true
 			cfg.WebauthnSupported = true
 			if tc.makeWebauthnLoginFunc != nil {
 				cfg.WebauthnLoginFunc = tc.makeWebauthnLoginFunc(stdin)
@@ -261,7 +260,13 @@ Enter your security key PIN:
 			buffer := make([]byte, 0, 100)
 			out := bytes.NewBuffer(buffer)
 
-			prompt := mfa.NewCLIPrompt(cfg, out)
+			prompt := &mfa.CLIPrompt{
+				CLIPromptConfig: mfa.CLIPromptConfig{
+					PromptConfig:     *cfg,
+					Writer:           out,
+					AllowStdinHijack: true,
+				},
+			}
 			resp, err := prompt.Run(ctx, tc.challenge)
 
 			if tc.expectErr != nil {

--- a/lib/client/mfa/cli_test.go
+++ b/lib/client/mfa/cli_test.go
@@ -260,13 +260,11 @@ Enter your security key PIN:
 			buffer := make([]byte, 0, 100)
 			out := bytes.NewBuffer(buffer)
 
-			prompt := &mfa.CLIPrompt{
-				CLIPromptConfig: mfa.CLIPromptConfig{
-					PromptConfig:     *cfg,
-					Writer:           out,
-					AllowStdinHijack: true,
-				},
-			}
+			prompt := mfa.NewCLIPromptV2(&mfa.CLIPromptConfig{
+				PromptConfig:     *cfg,
+				Writer:           out,
+				AllowStdinHijack: true,
+			})
 			resp, err := prompt.Run(ctx, tc.challenge)
 
 			if tc.expectErr != nil {

--- a/lib/client/mfa/prompt.go
+++ b/lib/client/mfa/prompt.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/mfa"
-	"github.com/gravitational/teleport/api/utils/prompt"
 	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 )
@@ -44,7 +43,8 @@ type WebauthnLoginFunc func(
 	opts *wancli.LoginOpts,
 ) (*proto.MFAAuthenticateResponse, string, error)
 
-// PromptConfig contains common mfa prompt config options.
+// PromptConfig contains common mfa prompt config options shared by
+// different implementations of [mfa.Prompt].
 type PromptConfig struct {
 	mfa.PromptConfig
 	// ProxyAddress is the address of the authenticating proxy. required.
@@ -64,9 +64,6 @@ type PromptConfig struct {
 	PreferOTP bool
 	// WebauthnSupported indicates whether Webauthn is supported.
 	WebauthnSupported bool
-	// StdinFunc allows tests to override prompt.Stdin().
-	// If nil prompt.Stdin() is used.
-	StdinFunc func() prompt.StdinReader
 }
 
 // NewPromptConfig returns a prompt config that will induce default behavior.

--- a/lib/client/mfa_test.go
+++ b/lib/client/mfa_test.go
@@ -21,7 +21,6 @@ package client_test
 import (
 	"context"
 	"errors"
-	"os"
 	"testing"
 	"time"
 
@@ -73,7 +72,7 @@ func TestPromptMFAChallenge_usingNonRegisteredDevice(t *testing.T) {
 	tests := []struct {
 		name            string
 		challenge       *proto.MFAAuthenticateChallenge
-		customizePrompt func(p *mfa.PromptConfig)
+		customizePrompt func(p *mfa.CLIPrompt)
 	}{
 		{
 			name:      "webauthn only",
@@ -82,7 +81,7 @@ func TestPromptMFAChallenge_usingNonRegisteredDevice(t *testing.T) {
 		{
 			name:      "webauthn and OTP",
 			challenge: challengeWebauthnOTP,
-			customizePrompt: func(p *mfa.PromptConfig) {
+			customizePrompt: func(p *mfa.CLIPrompt) {
 				p.AllowStdinHijack = true // required for OTP+WebAuthn prompt.
 			},
 		},
@@ -109,11 +108,17 @@ func TestPromptMFAChallenge_usingNonRegisteredDevice(t *testing.T) {
 				return nil, "", wancli.ErrUsingNonRegisteredDevice
 			}
 
-			if test.customizePrompt != nil {
-				test.customizePrompt(promptConfig)
+			prompt := &mfa.CLIPrompt{
+				CLIPromptConfig: mfa.CLIPromptConfig{
+					PromptConfig: *promptConfig,
+				},
 			}
 
-			_, err := mfa.NewCLIPrompt(promptConfig, os.Stderr).Run(ctx, test.challenge)
+			if test.customizePrompt != nil {
+				test.customizePrompt(prompt)
+			}
+
+			_, err := prompt.Run(ctx, test.challenge)
 			if !errors.Is(err, wancli.ErrUsingNonRegisteredDevice) {
 				t.Errorf("PromptMFAChallenge returned err=%q, want %q", err, wancli.ErrUsingNonRegisteredDevice)
 			}

--- a/lib/client/mfa_test.go
+++ b/lib/client/mfa_test.go
@@ -72,7 +72,7 @@ func TestPromptMFAChallenge_usingNonRegisteredDevice(t *testing.T) {
 	tests := []struct {
 		name            string
 		challenge       *proto.MFAAuthenticateChallenge
-		customizePrompt func(p *mfa.CLIPrompt)
+		customizePrompt func(p *mfa.CLIPromptConfig)
 	}{
 		{
 			name:      "webauthn only",
@@ -81,7 +81,7 @@ func TestPromptMFAChallenge_usingNonRegisteredDevice(t *testing.T) {
 		{
 			name:      "webauthn and OTP",
 			challenge: challengeWebauthnOTP,
-			customizePrompt: func(p *mfa.CLIPrompt) {
+			customizePrompt: func(p *mfa.CLIPromptConfig) {
 				p.AllowStdinHijack = true // required for OTP+WebAuthn prompt.
 			},
 		},
@@ -108,17 +108,15 @@ func TestPromptMFAChallenge_usingNonRegisteredDevice(t *testing.T) {
 				return nil, "", wancli.ErrUsingNonRegisteredDevice
 			}
 
-			prompt := &mfa.CLIPrompt{
-				CLIPromptConfig: mfa.CLIPromptConfig{
-					PromptConfig: *promptConfig,
-				},
+			cliConfig := &mfa.CLIPromptConfig{
+				PromptConfig: *promptConfig,
 			}
 
 			if test.customizePrompt != nil {
-				test.customizePrompt(prompt)
+				test.customizePrompt(cliConfig)
 			}
 
-			_, err := prompt.Run(ctx, test.challenge)
+			_, err := mfa.NewCLIPromptV2(cliConfig).Run(ctx, test.challenge)
 			if !errors.Is(err, wancli.ErrUsingNonRegisteredDevice) {
 				t.Errorf("PromptMFAChallenge returned err=%q, want %q", err, wancli.ErrUsingNonRegisteredDevice)
 			}

--- a/tool/tctl/common/admin_action_test.go
+++ b/tool/tctl/common/admin_action_test.go
@@ -1029,7 +1029,11 @@ func newAdminActionTestSuite(t *testing.T) *adminActionTestSuite {
 		promptCfg := libmfa.NewPromptConfig(proxyPublicAddr.String(), opts...)
 		promptCfg.WebauthnLoginFunc = mockWebauthnLogin
 		promptCfg.WebauthnSupported = true
-		return libmfa.NewCLIPrompt(promptCfg, os.Stderr)
+		return &libmfa.CLIPrompt{
+			CLIPromptConfig: libmfa.CLIPromptConfig{
+				PromptConfig: *promptCfg,
+			},
+		}
 	}
 
 	// Login as the admin user.

--- a/tool/tctl/common/admin_action_test.go
+++ b/tool/tctl/common/admin_action_test.go
@@ -1029,11 +1029,9 @@ func newAdminActionTestSuite(t *testing.T) *adminActionTestSuite {
 		promptCfg := libmfa.NewPromptConfig(proxyPublicAddr.String(), opts...)
 		promptCfg.WebauthnLoginFunc = mockWebauthnLogin
 		promptCfg.WebauthnSupported = true
-		return &libmfa.CLIPrompt{
-			CLIPromptConfig: libmfa.CLIPromptConfig{
-				PromptConfig: *promptCfg,
-			},
-		}
+		return libmfa.NewCLIPromptV2(&libmfa.CLIPromptConfig{
+			PromptConfig: *promptCfg,
+		})
 	}
 
 	// Login as the admin user.

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -253,11 +253,9 @@ func TryRun(commands []CLICommand, args []string) error {
 	proxyAddr := resp.ProxyPublicAddr
 	client.SetMFAPromptConstructor(func(opts ...mfa.PromptOpt) mfa.Prompt {
 		promptCfg := libmfa.NewPromptConfig(proxyAddr, opts...)
-		return &libmfa.CLIPrompt{
-			CLIPromptConfig: libmfa.CLIPromptConfig{
-				PromptConfig: *promptCfg,
-			},
-		}
+		return libmfa.NewCLIPromptV2(&libmfa.CLIPromptConfig{
+			PromptConfig: *promptCfg,
+		})
 	})
 
 	// execute whatever is selected:

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -253,7 +253,11 @@ func TryRun(commands []CLICommand, args []string) error {
 	proxyAddr := resp.ProxyPublicAddr
 	client.SetMFAPromptConstructor(func(opts ...mfa.PromptOpt) mfa.Prompt {
 		promptCfg := libmfa.NewPromptConfig(proxyAddr, opts...)
-		return libmfa.NewCLIPrompt(promptCfg, os.Stderr)
+		return &libmfa.CLIPrompt{
+			CLIPromptConfig: libmfa.CLIPromptConfig{
+				PromptConfig: *promptCfg,
+			},
+		}
 	})
 
 	// execute whatever is selected:


### PR DESCRIPTION
Refactor CLI prompt and config logic in preparation for some UX changes coming with SSO MFA. These changes will make sense in the context of the SSO MFA changes to follow. This PR is separate in order to backport this refactored logic and simplify future backports when needed.