### PR TITLE
Update Electron to 33.0.2 and Node.js to 20.18.0

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -6,7 +6,7 @@
 GOLANG_VERSION ?= go1.23.2
 GOLANGCI_LINT_VERSION ?= v1.61.0
 
-NODE_VERSION ?= 20.17.0
+NODE_VERSION ?= 20.18.0
 
 # Run lint-rust check locally before merging code after you bump this.
 RUST_VERSION ?= 1.81.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5391,8 +5391,8 @@ packages:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
 
-  node-abi@3.65.0:
-    resolution: {integrity: sha512-ThjYBfoDNr08AWx6hGaRbfPwxKV9kVzAzOzlLKbk2CuqXE2xnCh+cbAGnwM3t8Lq4v9rUB7VfondlkBckcJrVA==}
+  node-abi@3.71.0:
+    resolution: {integrity: sha512-SZ40vRiy/+wRTf21hxkkEjPJZpARzUMVcJoQse2EF8qkUWbbO2z7vd5oA/H6bVH6SZQ5STGcu0KRDS7biNRfxw==}
     engines: {node: '>=10'}
 
   node-addon-api@1.7.2:
@@ -7969,7 +7969,7 @@ snapshots:
       detect-libc: 2.0.3
       fs-extra: 10.1.0
       got: 11.8.6
-      node-abi: 3.65.0
+      node-abi: 3.71.0
       node-api-version: 0.2.0
       node-gyp: 9.4.1
       ora: 5.4.1
@@ -13096,7 +13096,7 @@ snapshots:
 
   negotiator@0.6.3: {}
 
-  node-abi@3.65.0:
+  node-abi@3.71.0:
     dependencies:
       semver: 7.6.3
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -449,8 +449,8 @@ importers:
         specifier: ^5.5.0
         version: 5.5.0
       electron:
-        specifier: 32.1.2
-        version: 32.1.2
+        specifier: 33.0.2
+        version: 33.0.2
       electron-builder:
         specifier: ^25.1.7
         version: 25.1.7(electron-builder-squirrel-windows@25.1.7(dmg-builder@25.1.7))
@@ -3159,6 +3159,7 @@ packages:
 
   boolean@3.1.4:
     resolution: {integrity: sha512-3hx0kwU3uzG6ReQ3pnaFQPSktpBw6RHN3/ivDKEuU8g1XSfafowyvDnadjv1xp8IZqhtSukxlwv9bF6FhX8m0w==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -3785,8 +3786,8 @@ packages:
       '@swc/core':
         optional: true
 
-  electron@32.1.2:
-    resolution: {integrity: sha512-CXe6doFzhmh1U7daOvUzmF6Cj8hssdYWMeEPRnRO6rB9/bbwMlWctcQ7P8NJXhLQ88/vYUJQrJvlJPh8qM0BRQ==}
+  electron@33.0.2:
+    resolution: {integrity: sha512-C2WksfP0COsMHbYXSJG68j6S3TjuGDrw/YT42B526yXalIlNQZ2GeAYKryg6AEMkIp3p8TUfDRD0+HyiyCt/nw==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
@@ -10961,7 +10962,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@32.1.2:
+  electron@33.0.2:
     dependencies:
       '@electron/get': 2.0.2
       '@types/node': 20.16.10

--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -45,7 +45,7 @@
     "@types/whatwg-url": "^11.0.5",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
-    "electron": "32.1.2",
+    "electron": "33.0.2",
     "electron-builder": "^25.1.7",
     "electron-vite": "^2.3.0",
     "events": "3.3.0",


### PR DESCRIPTION
I didn't test the [dev build](https://github.com/gravitational/teleport.e/actions/runs/11498144425), we will do so during the test plan. I will backport it after that.

[Release notes](https://www.electronjs.org/blog/electron-33-0)
Electron 33 drops support for macOS 10.15 (same as Go 1.23) so this table is correct: https://goteleport.com/docs/ver/17.x/installation/#operating-system-support.
On other release branches we say that 10.15 is supported (since we have Go 1.22 there), but well, I think I will leave it as is.