### PR TITLE
Fix "tsh db connect" when cluster has separate MongoDB port

### DIFF
--- a/tool/tsh/common/db.go
+++ b/tool/tsh/common/db.go
@@ -655,7 +655,6 @@ func maybeStartLocalProxy(ctx context.Context, cf *CLIConf,
 	host := "localhost"
 	cmdOpts := []dbcmd.ConnectCommandFunc{
 		dbcmd.WithLocalProxy(host, addr.Port(0), profile.CACertPathForCluster(rootClusterName)),
-		dbcmd.WithGetDatabaseFunc(dbInfo.getDatabaseForDBCmd),
 	}
 	if requires.tunnel {
 		cmdOpts = append(cmdOpts, dbcmd.WithNoTLS())
@@ -779,7 +778,10 @@ func onDatabaseConnect(cf *CLIConf) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	opts = append(opts, dbcmd.WithLogger(log))
+	opts = append(opts,
+		dbcmd.WithLogger(log),
+		dbcmd.WithGetDatabaseFunc(dbInfo.getDatabaseForDBCmd),
+	)
 
 	if opts, err = maybeAddDBUserPassword(cf, tc, dbInfo, opts); err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
Fixes #47895

changelog: Fix `missing GetDatabaseFunc` error when `tsh` connects MongoDB databases in cluster with a separate MongoDB port

related:
- #43867

The current logic fails to provide a `GetDatabaseFunc` when local proxy is **NOT** required and then it throws an error on db cmd generation failure.

Adding UT is difficult (needs some refactoring and heavy mocking) so i chose to skip it. I can work on it though if any reviewer feels strongly about it.