### PR TITLE
Fix "Missing Region" error for teleport bootstrap commands

### DIFF
--- a/lib/configurators/aws/aws.go
+++ b/lib/configurators/aws/aws.go
@@ -326,7 +326,7 @@ type localRegionGetter interface {
 func getFallbackRegion(ctx context.Context, w io.Writer, fips bool, localRegionGetter localRegionGetter) (string, error) {
 	if localRegionGetter == nil {
 		imdsClient, err := awsimds.NewInstanceMetadataClient(ctx)
-		if err == nil && imdsClient != nil {
+		if err == nil && imdsClient != nil && imdsClient.IsAvailable(ctx) {
 			localRegionGetter = imdsClient
 		}
 	}

--- a/lib/configurators/aws/aws_test.go
+++ b/lib/configurators/aws/aws_test.go
@@ -21,6 +21,7 @@ package aws
 import (
 	"context"
 	"fmt"
+	"io"
 	"regexp"
 	"sort"
 	"testing"
@@ -1917,4 +1918,58 @@ func (m *iamMock) GetRole(ctx context.Context, input *iam.GetRoleInput, optFns .
 	}
 	arn := fmt.Sprintf("arn:%s:iam::%s:role%s%s", m.partition, m.account, path, roleName)
 	return &iam.GetRoleOutput{Role: &iamtypes.Role{Arn: &arn}}, nil
+}
+
+type mockLocalRegionGetter struct {
+	region string
+	err    error
+}
+
+func (m mockLocalRegionGetter) GetRegion(context.Context) (string, error) {
+	return m.region, m.err
+}
+
+func Test_getFallbackRegion(t *testing.T) {
+	tests := []struct {
+		name              string
+		fips              bool
+		localRegionGetter localRegionGetter
+		wantError         bool
+		wantRegion        string
+	}{
+		{
+			name: "fallback to retrieved local region",
+			localRegionGetter: mockLocalRegionGetter{
+				region: "my-local-region",
+			},
+			wantRegion: "my-local-region",
+		},
+		{
+			name: "fails to fallback (fips)",
+			localRegionGetter: mockLocalRegionGetter{
+				err: fmt.Errorf("failed to get local region"),
+			},
+			fips:      true,
+			wantError: true,
+		},
+		{
+			name: "fallback to aws-global",
+			localRegionGetter: mockLocalRegionGetter{
+				err: fmt.Errorf("failed to get local region"),
+			},
+			wantRegion: "aws-global",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			region, err := getFallbackRegion(context.Background(), io.Discard, test.fips, test.localRegionGetter)
+			if test.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.wantRegion, region)
+			}
+		})
+	}
 }

--- a/lib/configurators/aws/aws_test.go
+++ b/lib/configurators/aws/aws_test.go
@@ -1932,9 +1932,7 @@ func (m mockLocalRegionGetter) GetRegion(context.Context) (string, error) {
 func Test_getFallbackRegion(t *testing.T) {
 	tests := []struct {
 		name              string
-		fips              bool
 		localRegionGetter localRegionGetter
-		wantError         bool
 		wantRegion        string
 	}{
 		{
@@ -1945,31 +1943,18 @@ func Test_getFallbackRegion(t *testing.T) {
 			wantRegion: "my-local-region",
 		},
 		{
-			name: "fails to fallback (fips)",
+			name: "fallback to us-east",
 			localRegionGetter: mockLocalRegionGetter{
 				err: fmt.Errorf("failed to get local region"),
 			},
-			fips:      true,
-			wantError: true,
-		},
-		{
-			name: "fallback to aws-global",
-			localRegionGetter: mockLocalRegionGetter{
-				err: fmt.Errorf("failed to get local region"),
-			},
-			wantRegion: "aws-global",
+			wantRegion: "us-east-1",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			region, err := getFallbackRegion(context.Background(), io.Discard, test.fips, test.localRegionGetter)
-			if test.wantError {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, test.wantRegion, region)
-			}
+			region := getFallbackRegion(context.Background(), io.Discard, test.localRegionGetter)
+			require.Equal(t, test.wantRegion, region)
 		})
 	}
 }


### PR DESCRIPTION
changelog: Fix "Missing Region" error for teleport bootstrap commands

related:
- https://github.com/gravitational/teleport/pull/46367

sample outputs on my mac without region specified in `~/.aws/config`:
```
$ teleport discovery bootstrap -c teleport_db.yaml 
Reading configuration at "teleport_db.yaml"...

Warning: No region found from the default AWS config or instance metadata. Defaulting to 'us-east-1'.
To avoid seeing this warning, please provide a region in your AWS config or through the AWS_REGION environment variable.

The agent doesn't require any extra configuration.
```

sample output on ec2:
```
$ teleport discovery bootstrap -c teleport_db.yaml 
Reading configuration at "teleport_db.yaml"...
Using region "ca-central-1" from instance metadata.

Configure AWS for Discovery Service
1. Create IAM Policy "TeleportEC2Discovery":
...
```