### PR TITLE
Add reason-required request_access option

### DIFF
--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -2903,7 +2903,7 @@ message RoleOptions {
   // concurrent sessions per connection.
   int64 MaxSessions = 10 [(gogoproto.jsontag) = "max_sessions,omitempty"];
 
-  // RequestAccess defines the request strategy (optional|note|always)
+  // RequestAccess defines the request strategy (optional|reason|reason-required|always)
   // where optional is the default.
   string RequestAccess = 11 [
     (gogoproto.jsontag) = "request_access,omitempty",

--- a/api/types/access_request.go
+++ b/api/types/access_request.go
@@ -656,6 +656,10 @@ const (
 	// users should be prompted for a reason.
 	RequestStrategyReason RequestStrategy = "reason"
 
+	// RequestStrategyReasonRequired is the same as "optional" but with the
+	// users required to provide a reason when making a request.
+	RequestStrategyReasonRequired RequestStrategy = "reason-required"
+
 	// RequestStrategyAlways indicates that client implementations
 	// should automatically generate wildcard requests on login, but
 	// that reasons are not required.
@@ -678,7 +682,12 @@ func (s RequestStrategy) ShouldAutoRequest() bool {
 // is one that requires users to always supply
 // reasons with their requests.
 func (s RequestStrategy) RequireReason() bool {
-	return s == RequestStrategyReason
+	switch s {
+	case RequestStrategyReason, RequestStrategyReasonRequired:
+		return true
+	default:
+		return false
+	}
 }
 
 // stateVariants allows iteration of the expected variants

--- a/api/types/types.pb.go
+++ b/api/types/types.pb.go
@@ -7881,7 +7881,7 @@ type RoleOptions struct {
 	// MaxSessions defines the maximum number of
 	// concurrent sessions per connection.
 	MaxSessions int64 `protobuf:"varint,10,opt,name=MaxSessions,proto3" json:"max_sessions,omitempty"`
-	// RequestAccess defines the request strategy (optional|note|always)
+	// RequestAccess defines the request strategy (optional|reason|reason-required|always)
 	// where optional is the default.
 	RequestAccess RequestStrategy `protobuf:"bytes,11,opt,name=RequestAccess,proto3,casttype=RequestStrategy" json:"request_access,omitempty"`
 	// RequestPrompt is an optional message which tells users what they aught to request.

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -1893,7 +1893,7 @@ func UnmarshalAccessRequestAllowedPromotion(data []byte) (*types.AccessRequestAl
 // pruneResourceRequestRoles takes an access request and does one of two things:
 //  1. If it is a role request, returns it unchanged.
 //  2. If it is a resource request, all available `search_as_roles` for the user
-//     should have been populated on the request by `ValidateAccessReqeustForUser`.
+//     should have been populated on the request by `ValidateAccessRequestForUser`.
 //     This function will attempt to prune these roles to a minimal necessary set
 //     based on the following rules:
 //     - If a role does not grant access to any resources in the set, it is pruned.
@@ -2033,7 +2033,7 @@ func countAllowedLogins(role types.Role) int {
 }
 
 func (m *RequestValidator) roleAllowsResource(
-	ctx context.Context,
+	_ context.Context,
 	role types.Role,
 	resource types.ResourceWithLabels,
 	loginHint string,

--- a/lib/services/access_request_test.go
+++ b/lib/services/access_request_test.go
@@ -2059,6 +2059,13 @@ func TestAutoRequest(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	reasonRequiredRole, err := types.NewRole("reason-required", types.RoleSpecV6{
+		Options: types.RoleOptions{
+			RequestAccess: types.RequestStrategyReasonRequired,
+		},
+	})
+	require.NoError(t, err)
+
 	alwaysRole, err := types.NewRole("always", types.RoleSpecV6{
 		Options: types.RoleOptions{
 			RequestAccess: types.RequestStrategyAlways,
@@ -2113,6 +2120,24 @@ func TestAutoRequest(t *testing.T) {
 				require.True(t, validator.requireReason)
 				require.True(t, validator.autoRequest)
 				require.Empty(t, validator.prompt)
+			},
+		},
+		{
+			name:  "with reason-required",
+			roles: []types.Role{reasonRequiredRole},
+			assertion: func(t *testing.T, validator *RequestValidator) {
+				require.True(t, validator.requireReason)
+				require.False(t, validator.autoRequest)
+				require.Empty(t, validator.prompt)
+			},
+		},
+		{
+			name:  "with reason-required and prompt",
+			roles: []types.Role{reasonRequiredRole, promptRole},
+			assertion: func(t *testing.T, validator *RequestValidator) {
+				require.True(t, validator.requireReason)
+				require.False(t, validator.autoRequest)
+				require.Equal(t, "test prompt", validator.prompt)
 			},
 		},
 	}

--- a/lib/web/ui/usercontext.go
+++ b/lib/web/ui/usercontext.go
@@ -84,8 +84,16 @@ func getAccessStrategy(roleset services.RoleSet) accessStrategy {
 			break
 		}
 
+		if strategy == types.RequestStrategyAlways {
+			continue
+		}
+
 		if options.RequestAccess == types.RequestStrategyAlways {
 			strategy = types.RequestStrategyAlways
+		}
+
+		if options.RequestAccess == types.RequestStrategyReasonRequired {
+			strategy = types.RequestStrategyReasonRequired
 		}
 	}
 

--- a/web/packages/teleport/src/services/user/types.ts
+++ b/web/packages/teleport/src/services/user/types.ts
@@ -21,7 +21,7 @@ import { Cluster } from 'teleport/services/clusters';
 export type AuthType = 'local' | 'sso' | 'passwordless';
 
 export interface AccessStrategy {
-  type: 'optional' | 'always' | 'reason';
+  type: 'optional' | 'always' | 'reason' | 'reason-required';
   prompt: string;
 }
 


### PR DESCRIPTION
Issue https://github.com/gravitational/teleport/issues/20164

This adds `reason-required` option to `role.options.requrest_access` (see https://goteleport.com/docs/admin-guides/access-controls/access-requests/access-request-configuration/#how-clients-request-access). The new option has only higher priority than `optional` if multiple roles with `requrest_access` are attached to a user.

changelog: Added `reason-required` option to `role.options.requrest_access`.