### PR TITLE
Use GOWORK=off in certain targets to prevent missing package errors

### DIFF
--- a/integrations/terraform/Makefile
+++ b/integrations/terraform/Makefile
@@ -29,7 +29,8 @@ clean: tfclean
 
 .PHONY: build
 build: clean
-	GOOS=$(OS) GOARCH=$(ARCH) $(CGOFLAG) go build -o $(BUILDDIR)/terraform-provider-teleport $(BUILDFLAGS)
+# Turning off GOWORK to prevent missing package errors.
+	GOWORK=off GOOS=$(OS) GOARCH=$(ARCH) $(CGOFLAG) go build -o $(BUILDDIR)/terraform-provider-teleport $(BUILDFLAGS)
 
 build-darwin-universal: $(addprefix $(BUILDDIR)/terraform-provider-teleport_,arm64 amd64)
 	lipo -create -output $(BUILDDIR)/terraform-provider-teleport $^

--- a/integrations/terraform/Makefile
+++ b/integrations/terraform/Makefile
@@ -196,4 +196,5 @@ $(LOCALBIN):
 
 bin/tfplugindocs: go.mod $(LOCALBIN)
 	mkdir -p bin
-	GOBIN=$(LOCALBIN) go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
+# Turning off GOWORK to prevent missing package errors.
+	GOWORK=off GOBIN=$(LOCALBIN) go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs

--- a/version.mk
+++ b/version.mk
@@ -43,4 +43,5 @@ tsh-version:
 
 .PHONY:validate-semver
 validate-semver:
-	cd build.assets/tooling && CGO_ENABLED=0 go run ./cmd/check -check valid -tag v$(VERSION)
+# Turning off GOWORK to prevent missing package errors.
+	GOWORK=off CGO_ENABLED=0 go -C build.assets/tooling run ./cmd/check -check valid -tag v$(VERSION)


### PR DESCRIPTION
This should prevent errors like this one: `main module (github.com/gravitational/teleport) does not contain package github.com/gravitational/teleport/integrations/terraform`.