### PR TITLE
feat: role version V8

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -568,6 +568,9 @@ const (
 	// access graph settings.
 	MetaNameAccessGraphSettings = "access-graph-settings"
 
+	// V8 is the eighth version of resources.
+	V8 = "v8"
+
 	// V7 is the seventh version of resources.
 	V7 = "v7"
 

--- a/api/types/types.pb.go
+++ b/api/types/types.pb.go
@@ -7726,7 +7726,7 @@ type RoleV6 struct {
 	// SubKind is an optional resource sub kind, used in some resources
 	SubKind string `protobuf:"bytes,2,opt,name=SubKind,proto3" json:"sub_kind,omitempty"`
 	// Version is the resource version. It must be specified.
-	// Supported values are: `v3`, `v4`, `v5`, `v6`, `v7`.
+	// Supported values are: `v3`, `v4`, `v5`, `v6`, `v7`, `v8`.
 	Version string `protobuf:"bytes,3,opt,name=Version,proto3" json:"version"`
 	// Metadata is resource metadata
 	Metadata Metadata `protobuf:"bytes,4,opt,name=Metadata,proto3" json:"metadata"`

--- a/integrations/lib/tctl/resources.go
+++ b/integrations/lib/tctl/resources.go
@@ -91,7 +91,7 @@ func (res *streamResource) UnmarshalJSON(raw []byte) error {
 		}
 	case types.KindRole:
 		switch header.Version {
-		case types.V4, types.V5, types.V6, types.V7:
+		case types.V4, types.V5, types.V6, types.V7, types.V8:
 			resource = &types.RoleV6{}
 		default:
 			return trace.BadParameter("unsupported resource version %s", header.Version)

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -77,6 +77,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/installers"
 	"github.com/gravitational/teleport/api/types/wrappers"
+	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/auth/accessmonitoringrules/accessmonitoringrulesv1"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/autoupdate/autoupdatev1"
@@ -1966,12 +1967,52 @@ func (g *GRPCServer) DeleteAllKubernetesServers(ctx context.Context, req *authpb
 
 // maybeDowngradeRole tests the client version passed through the gRPC metadata,
 // and if the client version is unknown or less than the minimum supported
-// version for some features of the role returns a shallow copy of the given
-// role downgraded for compatibility with the older version.
+// version, it returns a shallow copy of the given role downgraded
+// for compatibility with the older version.
 func maybeDowngradeRole(ctx context.Context, role *types.RoleV6) (*types.RoleV6, error) {
-	// Teleport 16 supports all role features that Teleport 15 does,
-	// so no downgrade is necessary.
+	clientVersionString, ok := metadata.ClientVersionFromContext(ctx)
+	if !ok {
+		// This client is not reporting its version via gRPC metadata. Teleport
+		// clients have been reporting their version for long enough that older
+		// clients won't even support v6 roles at all, so this is likely a
+		// third-party client, and we shouldn't assume that downgrading the role
+		// will do more good than harm.
+		return role, nil
+	}
+
+	clientVersion, err := semver.NewVersion(clientVersionString)
+	if err != nil {
+		return nil, trace.BadParameter("unrecognized client version: %s is not a valid semver", clientVersionString)
+	}
+
+	role = maybeDowngradeRoleVersionToV7(role, clientVersion)
 	return role, nil
+}
+
+var minSupportedRoleV8Version = semver.New(utils.VersionBeforeAlpha("17.0.0"))
+
+// maybeDowngradeRoleVersionToV7 downgrades the role version to V7 if
+// the client version passed through the gRPC metadata is below the version
+// specified in minSupportedRoleV8Version.
+func maybeDowngradeRoleVersionToV7(role *types.RoleV6, clientVersion *semver.Version) *types.RoleV6 {
+	if !clientVersion.LessThan(*minSupportedRoleV8Version) || role.GetVersion() != types.V8 {
+		return role
+	}
+
+	// Make a shallow copy of the role so that we don't mutate the original.
+	// This is necessary because the role is shared
+	// between multiple clients sessions when notifying about changes in watchers.
+	// If we mutate the original role, it will be mutated for all clients
+	// which can cause panics since it causes a race condition.
+	role = apiutils.CloneProtoMsg(role)
+	role.Version = types.V7
+
+	reason := fmt.Sprintf(`Role V8 is only supported from the client version %q and above.`, minSupportedRoleV8Version)
+	if role.Metadata.Labels == nil {
+		role.Metadata.Labels = make(map[string]string, 1)
+	}
+	role.Metadata.Labels[types.TeleportDowngradedLabel] = reason
+	return role
 }
 
 // GetRole retrieves a role by name.

--- a/lib/auth/session_access.go
+++ b/lib/auth/session_access.go
@@ -187,7 +187,7 @@ func (e *SessionAccessEvaluator) matchesKind(allow []string) bool {
 func RoleSupportsModeratedSessions(roles []types.Role) bool {
 	for _, role := range roles {
 		switch role.GetVersion() {
-		case types.V5, types.V6, types.V7:
+		case types.V5, types.V6, types.V7, types.V8:
 			return true
 		}
 	}

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -87,6 +87,10 @@ type AccessChecker interface {
 	//nolint:revive // Because we want this to be IdP.
 	CheckAccessToSAMLIdP(readonly.AuthPreference, AccessState) error
 
+	// CheckRoleSupportsSAMLIdPAppLabelMatcher checks if role supports
+	// app_labels matcher for saml_idp_service_provider kind.
+	CheckRoleSupportsSAMLIdPAppLabelMatcher() bool
+
 	// AdjustSessionTTL will reduce the requested ttl to lowest max allowed TTL
 	// for this role set, otherwise it returns ttl unchanged
 	AdjustSessionTTL(ttl time.Duration) time.Duration

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -882,7 +882,7 @@ func (p *roleParser) parse(event backend.Event) (types.Resource, error) {
 
 		return &types.ResourceHeader{
 			Kind:    types.KindRole,
-			Version: types.V7,
+			Version: types.V8,
 			Metadata: types.Metadata{
 				Name:      strings.TrimPrefix(name, backend.SeparatorString),
 				Namespace: apidefaults.Namespace,

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -1592,6 +1592,19 @@ func (set RoleSet) CheckGCPServiceAccounts(ttl time.Duration, overrideTTL bool) 
 	return utils.StringsSliceFromSet(accounts), nil
 }
 
+// CheckRoleSupportsSAMLIdPAppLabelMatcher checks if user has a role
+// that supports app_labels matchers for sam_idp_service_provider kind.
+func (set RoleSet) CheckRoleSupportsSAMLIdPAppLabelMatcher() bool {
+	for _, role := range set {
+		version := role.GetVersion()
+		if version == types.V8 {
+			return true
+		}
+	}
+
+	return false
+}
+
 // CheckAccessToSAMLIdP checks access to the SAML IdP.
 //
 //nolint:revive // Because we want this to be IdP.
@@ -3379,7 +3392,7 @@ func UnmarshalRoleV6(bytes []byte, opts ...MarshalOption) (*types.RoleV6, error)
 	version := jsoniter.Get(bytes, "version").ToString()
 	switch version {
 	// these are all backed by the same shape of data, they just have different semantics and defaults
-	case types.V3, types.V4, types.V5, types.V6, types.V7:
+	case types.V3, types.V4, types.V5, types.V6, types.V7, types.V8:
 	default:
 		return nil, trace.BadParameter("role version %q is not supported", version)
 	}

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -1060,10 +1060,35 @@ func TestValidateRole(t *testing.T) {
 			var warning error
 			err := ValidateRole(&types.RoleV6{
 				Metadata: types.Metadata{
-					Name:      "name1",
+					Name:      "role1",
 					Namespace: apidefaults.Namespace,
 				},
 				Version: types.V7,
+				Spec:    tc.spec,
+			}, withWarningReporter(func(err error) {
+				warning = err
+			}))
+			if tc.expectError != nil {
+				require.ErrorIs(t, err, tc.expectError)
+				return
+			}
+			require.NoError(t, err, trace.DebugReport(err))
+
+			if len(tc.expectWarnings) == 0 {
+				require.Empty(t, warning)
+			}
+			for _, msg := range tc.expectWarnings {
+				require.ErrorContains(t, warning, msg)
+			}
+		})
+		t.Run(tc.name, func(t *testing.T) {
+			var warning error
+			err := ValidateRole(&types.RoleV6{
+				Metadata: types.Metadata{
+					Name:      "role2",
+					Namespace: apidefaults.Namespace,
+				},
+				Version: types.V8,
 				Spec:    tc.spec,
 			}, withWarningReporter(func(err error) {
 				warning = err

--- a/lib/web/resources_test.go
+++ b/lib/web/resources_test.go
@@ -245,7 +245,7 @@ spec:
       default: best_effort
       desktop: true
     ssh_file_copy: true
-version: v7
+version: v8
 `
 	role, err := types.NewRole("roleName", types.RoleSpecV6{
 		Allow: types.RoleConditions{

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.story.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.story.tsx
@@ -62,7 +62,7 @@ const parseHandler = http.post(
     HttpResponse.json({
       resource: withDefaults({
         metadata: { name: 'dummy-role' },
-        version: 'v7',
+        version: 'v8',
       }),
     })
 );

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
@@ -98,7 +98,7 @@ test('rendering and switching tabs for new role', async () => {
         deny: {},
         options: {},
       },
-      version: 'v7',
+      version: 'v8',
     })
   );
   expect(screen.getByRole('button', { name: 'Create Role' })).toBeEnabled();
@@ -209,7 +209,7 @@ test('saving a new role', async () => {
         deny: {},
         options: defaultOptions(),
       },
-      version: 'v7',
+      version: 'v8',
     },
   });
   expect(userEventService.captureUserEvent).toHaveBeenCalledWith({

--- a/web/packages/teleport/src/Roles/RoleEditor/standardmodel.test.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/standardmodel.test.ts
@@ -26,7 +26,7 @@ import {
 import { withDefaults } from './withDefaults';
 
 const minimalRole = () =>
-  withDefaults({ metadata: { name: 'foobar' }, version: 'v7' });
+  withDefaults({ metadata: { name: 'foobar' }, version: 'v8' });
 
 const minimalRoleModel = (): RoleEditorModel => ({
   metadata: { name: 'foobar' },

--- a/web/packages/teleport/src/Roles/RoleEditor/standardmodel.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/standardmodel.ts
@@ -85,7 +85,7 @@ export type ServerAccessSpec = AccessSpecBase<'node'> & {
   logins: readonly Option[];
 };
 
-const roleVersion = 'v7';
+const roleVersion = 'v8';
 
 /**
  * Returns the role object with required fields defined with empty values.


### PR DESCRIPTION
- Implemented to support `app_labels` matcher for `saml_idp_service_provider` kind. App label matchers will only be enforced in SAML service provider starting version role `v8`. This is managed with a new `CheckRoleSupportsSAMLIdPAppLabelMatcher` method which returns true when user is assigned with a role version `v8`.
- The RBAC configuration fields between role version `v7` and `v8` all remains the same. No new fields added to the role and rule spec. Does not affect any RBAC behaviour except for `saml_idp_service_provider` resource.
- The gRPC service for `GetRole` is updated to downgrade the role versions from `v8` to `v7` for clients that have version below than the `v17.0.0`.
- New roles will have a default `v8` version.

Not covered in this PR:
- Operators and terraform still use `v7`
- Once access role preset is updated to `v8`. Other presets remains as is.

Part of https://github.com/gravitational/teleport.e/issues/4723