### PR TITLE
Prevent go-cmp from being imported in production code

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -185,6 +185,36 @@ linters-settings:
             desc: '"lib/system/signal" requires CGO'
           - pkg: github.com/gravitational/teleport/lib/vnet/daemon
             desc: '"vnet/daemon" requires CGO'
+      # Prevent importing go-cmp into production code. From the go-cmp docs:
+      # > It is intended to only be used in tests, as performance is not a goal
+      # > and it may panic if it cannot compare the values. Its propensity towards
+      # > panicking means that its unsuitable for production environments where a
+      # > spurious panic may be fatal.
+      go-cmp:
+        files:
+          # Tests can do anything
+          - '!$test'
+          # Various test helpers defined outside _test.go files are allowed
+          - '!**/integration/helpers/**'
+          - '!**/integrations/operator/controllers/resources/testlib/**'
+          - '!**/lib/auth/test/**'
+          - '!**/lib/services/suite/**'
+          # Non-compliant legacy code. These should be converted to compare by another mechanism
+          # and be removed from this list in the future. Use caution before adding any additional
+          # exclusions to this list.
+          - '!**/e/lib/accesslist/equal.go'
+          - '!**/e/lib/auth/saml.go'
+          - '!**lib/services/authority.go'
+          - '!**lib/services/compare.go'
+          - '!**/lib/services/local/access_list.go'
+          - '!**/lib/services/local/users.go'
+          - '!**/lib/services/server.go'
+          - '!**/lib/services/user.go'
+        deny:
+          - pkg: github.com/google/go-cmp/cmp
+            desc: '"github.com/google/go-cmp/cmp" should only be used in tests'
+          - pkg: github.com/google/go-cmp/cmp/cmpopts
+            desc: '"github.com/google/go-cmp/cmp/cmpopts" should only be used in tests'
   errorlint:
     comparison: true
     asserts: true


### PR DESCRIPTION
Adds a new depguard rule to limit the use of go-cmp to test code. There are a few notable exceptions for legacy code that relies on go-cmp which should find other suitable means for comparisions. However, in the interest in limiting new code from introducing more production depenency on go-cmp, the existing violations are allowed for the time being and should be refactored and removed from the list in the future.