### PR TITLE
(tsh) Support specific listen interface on tsh proxy aws|gcloud|azure

### DIFF
--- a/tool/tsh/common/app_aws.go
+++ b/tool/tsh/common/app_aws.go
@@ -143,7 +143,7 @@ type awsApp struct {
 // newAWSApp creates a new AWS app.
 func newAWSApp(tc *client.TeleportClient, cf *CLIConf, appInfo *appInfo) (*awsApp, error) {
 	return &awsApp{
-		localProxyApp: newLocalProxyApp(tc, appInfo, cf.LocalProxyPort, cf.InsecureSkipVerify),
+		localProxyApp: newLocalProxyApp(tc, appInfo, cf.LocalProxyInterface, cf.LocalProxyPort, cf.InsecureSkipVerify),
 		cf:            cf,
 	}, nil
 }

--- a/tool/tsh/common/app_azure.go
+++ b/tool/tsh/common/app_azure.go
@@ -89,7 +89,7 @@ func newAzureApp(tc *client.TeleportClient, cf *CLIConf, appInfo *appInfo) (*azu
 	}
 
 	return &azureApp{
-		localProxyApp: newLocalProxyApp(tc, appInfo, cf.LocalProxyPort, cf.InsecureSkipVerify),
+		localProxyApp: newLocalProxyApp(tc, appInfo, cf.LocalProxyInterface, cf.LocalProxyPort, cf.InsecureSkipVerify),
 		cf:            cf,
 		signer:        keyRing.TLSPrivateKey,
 		msiSecret:     msiSecret,

--- a/tool/tsh/common/app_gcp.go
+++ b/tool/tsh/common/app_gcp.go
@@ -116,7 +116,7 @@ func newGCPApp(tc *client.TeleportClient, cf *CLIConf, appInfo *appInfo) (*gcpAp
 	prefix := fmt.Sprintf("%x", h.Sum32())
 
 	return &gcpApp{
-		localProxyApp: newLocalProxyApp(tc, appInfo, cf.LocalProxyPort, cf.InsecureSkipVerify),
+		localProxyApp: newLocalProxyApp(tc, appInfo, cf.LocalProxyInterface, cf.LocalProxyPort, cf.InsecureSkipVerify),
 		cf:            cf,
 		secret:        secret,
 		prefix:        prefix,

--- a/tool/tsh/common/proxy.go
+++ b/tool/tsh/common/proxy.go
@@ -416,7 +416,7 @@ func onProxyCommandApp(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	proxyApp := newLocalProxyApp(tc, appInfo, cf.LocalProxyPort, cf.InsecureSkipVerify)
+	proxyApp := newLocalProxyApp(tc, appInfo, cf.LocalProxyInterface, cf.LocalProxyPort, cf.InsecureSkipVerify)
 	if err := proxyApp.StartLocalProxy(cf.Context, alpnproxy.WithALPNProtocol(alpnProtocolForApp(app))); err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -411,6 +411,8 @@ type CLIConf struct {
 	// GlobalTshConfigPath is a path to global TSH config. Can be overridden with TELEPORT_GLOBAL_TSH_CONFIG.
 	GlobalTshConfigPath string
 
+	// LocalProxyInterface is the interface used by local proxy listener.
+	LocalProxyInterface string
 	// LocalProxyPort is a port used by local proxy listener.
 	LocalProxyPort string
 	// LocalProxyTunnel specifies whether local proxy will open auth'd tunnel.
@@ -904,24 +906,28 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 
 	proxyApp := proxy.Command("app", "Start local TLS proxy for app connection when using Teleport in single-port mode.")
 	proxyApp.Arg("app", "The name of the application to start local proxy for").Required().StringVar(&cf.AppName)
-	proxyApp.Flag("port", "Specifies the source port used by by the proxy app listener").Short('p').StringVar(&cf.LocalProxyPort)
+	proxyApp.Flag("port", "Specifies the source port used by the proxy app listener").Short('p').StringVar(&cf.LocalProxyPort)
+	proxyApp.Flag("interface", "Specifies the listen interface used by the proxy app listener").Default("localhost").StringVar(&cf.LocalProxyInterface)
 	proxyApp.Flag("cluster", clusterHelp).Short('c').StringVar(&cf.SiteName)
 
 	proxyAWS := proxy.Command("aws", "Start local proxy for AWS access.")
 	proxyAWS.Flag("app", "Optional Name of the AWS application to use if logged into multiple.").StringVar(&cf.AppName)
 	proxyAWS.Flag("port", "Specifies the source port used by the proxy listener.").Short('p').StringVar(&cf.LocalProxyPort)
+	proxyAWS.Flag("interface", "Specifies the listen interface used by the proxy listener").Default("localhost").StringVar(&cf.LocalProxyInterface)
 	proxyAWS.Flag("endpoint-url", "Run local proxy to serve as an AWS endpoint URL. If not specified, local proxy serves as an HTTPS proxy.").Short('e').BoolVar(&cf.AWSEndpointURLMode)
 	proxyAWS.Flag("format", awsProxyFormatFlagDescription()).Short('f').Default(envVarDefaultFormat()).EnumVar(&cf.Format, awsProxyFormats...)
 
 	proxyAzure := proxy.Command("azure", "Start local proxy for Azure access.")
 	proxyAzure.Flag("app", "Optional Name of the Azure application to use if logged into multiple.").StringVar(&cf.AppName)
 	proxyAzure.Flag("port", "Specifies the source port used by the proxy listener.").Short('p').StringVar(&cf.LocalProxyPort)
+	proxyAzure.Flag("interface", "Specifies the listen interface used by the proxy listener").Default("localhost").StringVar(&cf.LocalProxyInterface)
 	proxyAzure.Flag("format", envVarFormatFlagDescription()).Short('f').Default(envVarDefaultFormat()).EnumVar(&cf.Format, envVarFormats...)
 	proxyAzure.Alias("az")
 
 	proxyGcloud := proxy.Command("gcloud", "Start local proxy for GCP access.")
 	proxyGcloud.Flag("app", "Optional Name of the GCP application to use if logged into multiple.").StringVar(&cf.AppName)
 	proxyGcloud.Flag("port", "Specifies the source port used by the proxy listener.").Short('p').StringVar(&cf.LocalProxyPort)
+	proxyGcloud.Flag("interface", "Specifies the listen interface used by the proxy listener").Default("localhost").StringVar(&cf.LocalProxyInterface)
 	proxyGcloud.Flag("format", envVarFormatFlagDescription()).Short('f').Default(envVarDefaultFormat()).EnumVar(&cf.Format, envVarFormats...)
 	proxyGcloud.Alias("gcp")
 


### PR DESCRIPTION
This PR adds proxy support for listening on a specific network interface when running `tsh proxy aws|gcloud|azure ...`.

Usage example:
```
tsh proxy aws --app aws-app --port 9000 --interface 192.168.56.1
```

This can be useful, for example, when a local container needs to access the host's tsh proxy and using host network is not possible (docker desktop on macos/windows).

Changelog: support specific listen interface on tsh proxy aws|gcloud|azure

Closes: https://github.com/gravitational/teleport/issues/47923