### PR TITLE
Fix timeout for auto update integration tests

### DIFF
--- a/integration/autoupdate/tools/updater_test.go
+++ b/integration/autoupdate/tools/updater_test.go
@@ -46,7 +46,7 @@ var (
 // TestUpdate verifies the basic update logic. We first download a lower version, then request
 // an update to a newer version, expecting it to re-execute with the updated version.
 func TestUpdate(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
 	defer cancel()
 
 	// Fetch compiled test binary with updater logic and install to $TELEPORT_HOME.
@@ -88,7 +88,7 @@ func TestUpdate(t *testing.T) {
 // first update is complete, other processes should acquire the lock one by one and re-execute
 // the command with the updated version without any new downloads.
 func TestParallelUpdate(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
 	defer cancel()
 
 	// Initial fetch the updater binary un-archive and replace.
@@ -162,7 +162,7 @@ func TestParallelUpdate(t *testing.T) {
 
 // TestUpdateInterruptSignal verifies the interrupt signal send to the process must stop downloading.
 func TestUpdateInterruptSignal(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
 	defer cancel()
 
 	// Initial fetch the updater binary un-archive and replace.

--- a/integration/autoupdate/tools/updater_test.go
+++ b/integration/autoupdate/tools/updater_test.go
@@ -46,7 +46,7 @@ var (
 // TestUpdate verifies the basic update logic. We first download a lower version, then request
 // an update to a newer version, expecting it to re-execute with the updated version.
 func TestUpdate(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
 	// Fetch compiled test binary with updater logic and install to $TELEPORT_HOME.
@@ -88,7 +88,7 @@ func TestUpdate(t *testing.T) {
 // first update is complete, other processes should acquire the lock one by one and re-execute
 // the command with the updated version without any new downloads.
 func TestParallelUpdate(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
 	// Initial fetch the updater binary un-archive and replace.
@@ -162,7 +162,7 @@ func TestParallelUpdate(t *testing.T) {
 
 // TestUpdateInterruptSignal verifies the interrupt signal send to the process must stop downloading.
 func TestUpdateInterruptSignal(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
 	// Initial fetch the updater binary un-archive and replace.


### PR DESCRIPTION
In this PR extended timeout for integration autoupdate test `TestUpdate` mentioned in https://github.com/gravitational/teleport/issues/47915
Average CI/CD execution time of `TestUpdate` right now is ~29sec, which might easily exceed current timeout in 30sec

`-race` flag adds a lot of overhead for this specific tests, in local run difference
```
=== RUN   TestUpdate
2024/10/25 03:55:00 Calculating and serving file checksum: /tmp/updater4001372424/teleport-v1.2.3-linux-arm64-bin.tar.gz
Update progress: [▒▒▒▒▒▒▒▒▒▒] (Ctrl-C to cancel update)
2024/10/25 03:55:01 Calculating and serving file checksum: /tmp/updater4001372424/teleport-v3.2.1-linux-arm64-bin.tar.gz
--- PASS: TestUpdate (2.14s)
```
with `-race` flag:
```
=== RUN   TestUpdate
2024/10/25 03:59:55 Calculating and serving file checksum: /tmp/updater2983531478/teleport-v1.2.3-linux-arm64-bin.tar.gz
Update progress: [▒▒▒▒▒▒▒▒▒▒] (Ctrl-C to cancel update)
2024/10/25 04:00:14 Calculating and serving file checksum: /tmp/updater2983531478/teleport-v3.2.1-linux-arm64-bin.tar.gz
--- PASS: TestUpdate (19.52s)
```

Results of running `go test . -v -count 300 -race -timeout 0`
```
PASS
ok  	github.com/gravitational/teleport/integration/autoupdate/tools	17350.623s
```
