### PR TITLE
[teleport-update] Add support for reloading the agent & reverting symlinks on failed reload

### DIFF
--- a/lib/autoupdate/agent/installer.go
+++ b/lib/autoupdate/agent/installer.go
@@ -496,6 +496,9 @@ func tryLink(oldname, newname string) (orig string, err error) {
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return orig, trace.Wrap(err)
 	}
+	if orig == oldname {
+		return orig, nil
+	}
 	err = renameio.Symlink(oldname, newname)
 	if err != nil {
 		return orig, trace.Wrap(err)

--- a/lib/autoupdate/agent/installer.go
+++ b/lib/autoupdate/agent/installer.go
@@ -497,7 +497,7 @@ func tryLink(oldname, newname string) (orig string, err error) {
 		return orig, trace.Wrap(err)
 	}
 	if orig == oldname {
-		return orig, nil
+		return "", nil
 	}
 	err = renameio.Symlink(oldname, newname)
 	if err != nil {

--- a/lib/autoupdate/agent/installer.go
+++ b/lib/autoupdate/agent/installer.go
@@ -99,7 +99,7 @@ func (li *LocalInstaller) Remove(ctx context.Context, version string) error {
 		return trace.Errorf("failed to determine if linked: %w", err)
 	}
 	if linked {
-		return trace.Wrap(ErrLinked)
+		return trace.Errorf("refusing to remove: %w", ErrLinked)
 	}
 
 	// invalidate checksum first, to protect against partially-removed

--- a/lib/autoupdate/agent/installer.go
+++ b/lib/autoupdate/agent/installer.go
@@ -85,6 +85,7 @@ type LocalInstaller struct {
 
 // Remove a Teleport version directory from InstallDir.
 // This function is idempotent.
+// See Installer interface for additional specs.
 func (li *LocalInstaller) Remove(ctx context.Context, version string) error {
 	// os.RemoveAll is dangerous because it can remove an entire directory tree.
 	// We must validate the version to ensure that we remove only a single path
@@ -117,6 +118,7 @@ func (li *LocalInstaller) Remove(ctx context.Context, version string) error {
 
 // Install a Teleport version directory in InstallDir.
 // This function is idempotent.
+// See Installer interface for additional specs.
 func (li *LocalInstaller) Install(ctx context.Context, version, template string, flags InstallFlags) error {
 	versionDir, err := li.versionDir(version)
 	if err != nil {
@@ -372,7 +374,9 @@ func (li *LocalInstaller) List(ctx context.Context) (versions []string, err erro
 	return versions, nil
 }
 
-// Link the specified version into the system LinkBinDir.
+// Link the specified version into the system LinkBinDir and LinkServiceDir.
+// The revert function restores the previous linking.
+// See Installer interface for additional specs.
 func (li *LocalInstaller) Link(ctx context.Context, version string) (revert func(context.Context) bool, err error) {
 	// setup revert function
 	type symlink struct {

--- a/lib/autoupdate/agent/installer.go
+++ b/lib/autoupdate/agent/installer.go
@@ -183,10 +183,9 @@ func (li *LocalInstaller) Install(ctx context.Context, version, template string,
 	// If interrupted, close the file immediately to stop extracting.
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	go func() {
-		<-ctx.Done()
-		_ = f.Close()
-	}()
+	context.AfterFunc(ctx, func() {
+		_ = f.Close() // safe to close file multiple times
+	})
 	// Check integrity before decompression
 	if !bytes.Equal(newSum, pathSum) {
 		return trace.Errorf("mismatched checksum, download possibly corrupt")

--- a/lib/autoupdate/agent/installer_test.go
+++ b/lib/autoupdate/agent/installer_test.go
@@ -397,7 +397,7 @@ func TestLocalInstaller_Remove(t *testing.T) {
 			ctx := context.Background()
 
 			if tt.linkedVersion != "" {
-				err = installer.Link(ctx, tt.linkedVersion)
+				_, err = installer.Link(ctx, tt.linkedVersion)
 				require.NoError(t, err)
 			}
 			err = installer.Remove(ctx, tt.removeVersion)

--- a/lib/autoupdate/agent/installer_test.go
+++ b/lib/autoupdate/agent/installer_test.go
@@ -196,16 +196,18 @@ func TestLocalInstaller_Link(t *testing.T) {
 	const version = "new-version"
 
 	tests := []struct {
-		name  string
-		dirs  []string
-		files []string
+		name          string
+		installDirs   []string
+		installFiles  []string
+		existingLinks []string
+		existingFiles []string
 
-		links    []string
-		errMatch string
+		resultLinks []string
+		errMatch    string
 	}{
 		{
-			name: "present",
-			dirs: []string{
+			name: "present with new links",
+			installDirs: []string{
 				"bin",
 				"bin/somedir",
 				"etc",
@@ -213,7 +215,7 @@ func TestLocalInstaller_Link(t *testing.T) {
 				"etc/systemd/somedir",
 				"somedir",
 			},
-			files: []string{
+			installFiles: []string{
 				"bin/teleport",
 				"bin/tsh",
 				"bin/tbot",
@@ -221,7 +223,7 @@ func TestLocalInstaller_Link(t *testing.T) {
 				"README",
 			},
 
-			links: []string{
+			resultLinks: []string{
 				"bin/teleport",
 				"bin/tsh",
 				"bin/tbot",
@@ -229,15 +231,102 @@ func TestLocalInstaller_Link(t *testing.T) {
 			},
 		},
 		{
-			name:  "no links",
-			files: []string{"README"},
-			dirs:  []string{"bin"},
+			name: "present with existing links",
+			installDirs: []string{
+				"bin",
+				"bin/somedir",
+				"etc",
+				"etc/systemd",
+				"etc/systemd/somedir",
+				"somedir",
+			},
+			installFiles: []string{
+				"bin/teleport",
+				"bin/tsh",
+				"bin/tbot",
+				servicePath,
+				"README",
+			},
+			existingLinks: []string{
+				"bin/teleport",
+				"bin/tsh",
+				"bin/tbot",
+				"lib/systemd/system/teleport.service",
+			},
+
+			resultLinks: []string{
+				"bin/teleport",
+				"bin/tsh",
+				"bin/tbot",
+				"lib/systemd/system/teleport.service",
+			},
+		},
+		{
+			name: "conflicting systemd files",
+			installDirs: []string{
+				"bin",
+				"bin/somedir",
+				"etc",
+				"etc/systemd",
+				"etc/systemd/somedir",
+				"somedir",
+			},
+			installFiles: []string{
+				"bin/teleport",
+				"bin/tsh",
+				"bin/tbot",
+				servicePath,
+				"README",
+			},
+			existingLinks: []string{
+				"bin/teleport",
+				"bin/tsh",
+				"bin/tbot",
+			},
+			existingFiles: []string{
+				"lib/systemd/system/teleport.service",
+			},
+
+			errMatch: "refusing",
+		},
+		{
+			name: "conflicting bin files",
+			installDirs: []string{
+				"bin",
+				"bin/somedir",
+				"etc",
+				"etc/systemd",
+				"etc/systemd/somedir",
+				"somedir",
+			},
+			installFiles: []string{
+				"bin/teleport",
+				"bin/tsh",
+				"bin/tbot",
+				servicePath,
+				"README",
+			},
+			existingLinks: []string{
+				"bin/teleport",
+				"bin/tbot",
+				"lib/systemd/system/teleport.service",
+			},
+			existingFiles: []string{
+				"bin/tsh",
+			},
+
+			errMatch: "refusing",
+		},
+		{
+			name:         "no links",
+			installFiles: []string{"README"},
+			installDirs:  []string{"bin"},
 
 			errMatch: "no binaries",
 		},
 		{
-			name:  "no bin directory",
-			files: []string{"README"},
+			name:         "no bin directory",
+			installFiles: []string{"README"},
 
 			errMatch: "binary directory",
 		},
@@ -251,16 +340,27 @@ func TestLocalInstaller_Link(t *testing.T) {
 			err := os.MkdirAll(versionDir, 0o755)
 			require.NoError(t, err)
 
-			for _, d := range tt.dirs {
+			for _, d := range tt.installDirs {
 				err := os.Mkdir(filepath.Join(versionDir, d), os.ModePerm)
 				require.NoError(t, err)
 			}
-			for _, n := range tt.files {
+			for _, n := range tt.installFiles {
 				err := os.WriteFile(filepath.Join(versionDir, n), []byte(filepath.Base(n)), os.ModePerm)
 				require.NoError(t, err)
 			}
-
 			linkDir := t.TempDir()
+			for _, n := range tt.existingLinks {
+				err := os.MkdirAll(filepath.Dir(filepath.Join(linkDir, n)), os.ModePerm)
+				require.NoError(t, err)
+				err = os.Symlink(filepath.Base(n)+".old", filepath.Join(linkDir, n))
+				require.NoError(t, err)
+			}
+			for _, n := range tt.existingFiles {
+				err := os.MkdirAll(filepath.Dir(filepath.Join(linkDir, n)), os.ModePerm)
+				require.NoError(t, err)
+				err = os.WriteFile(filepath.Join(linkDir, n), []byte(filepath.Base(n)), os.ModePerm)
+				require.NoError(t, err)
+			}
 
 			installer := &LocalInstaller{
 				InstallDir:     versionsDir,
@@ -269,18 +369,43 @@ func TestLocalInstaller_Link(t *testing.T) {
 				Log:            slog.Default(),
 			}
 			ctx := context.Background()
-			err = installer.Link(ctx, version)
+			revert, err := installer.Link(ctx, version)
 			if tt.errMatch != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errMatch)
+
+				// verify automatic reverts
+				for _, link := range tt.existingLinks {
+					v, err := os.Readlink(filepath.Join(linkDir, link))
+					require.NoError(t, err)
+					require.Equal(t, filepath.Base(link)+".old", v)
+				}
+				for _, n := range tt.existingFiles {
+					v, err := os.ReadFile(filepath.Join(linkDir, n))
+					require.NoError(t, err)
+					require.Equal(t, filepath.Base(n), string(v))
+				}
 				return
 			}
 			require.NoError(t, err)
 
-			for _, link := range tt.links {
+			for _, link := range tt.resultLinks {
 				v, err := os.ReadFile(filepath.Join(linkDir, link))
 				require.NoError(t, err)
 				require.Equal(t, filepath.Base(link), string(v))
+			}
+			ok := revert(ctx)
+			require.True(t, ok)
+
+			for _, link := range tt.existingLinks {
+				v, err := os.Readlink(filepath.Join(linkDir, link))
+				require.NoError(t, err)
+				require.Equal(t, filepath.Base(link)+".old", v)
+			}
+			for _, n := range tt.existingFiles {
+				v, err := os.ReadFile(filepath.Join(linkDir, n))
+				require.NoError(t, err)
+				require.Equal(t, filepath.Base(n), string(v))
 			}
 		})
 	}

--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -1,0 +1,42 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package agent
+
+import (
+	"context"
+	"log/slog"
+)
+
+// SystemdService manages a Teleport systemd service.
+type SystemdService struct {
+	ServiceName string
+	// Log contains a logger.
+	Log *slog.Logger
+}
+
+func (s SystemdService) Reload(ctx context.Context) error {
+	s.Log.InfoContext(ctx, "Teleport gracefully reloaded.")
+	s.Log.WarnContext(ctx, "Teleport ungracefully restarted.")
+	s.Log.WarnContext(ctx, "Teleport not running.")
+	panic("implement me")
+}
+
+func (s SystemdService) Sync(ctx context.Context) error {
+	panic("implement me")
+}

--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -142,10 +142,9 @@ func (w *lineLogger) Write(p []byte) (n int, err error) {
 	if len(lines) == 0 || err != nil {
 		return n, trace.Wrap(err)
 	}
-	w.log.Log(w.ctx, w.level, w.last.String())
-	w.last.Reset()
+	w.Flush()
 	for _, line := range lines[:len(lines)-1] {
-		w.log.Log(w.ctx, w.level, string(line))
+		w.log.Log(w.ctx, w.level, string(line)) //nolint:sloglint
 		n += len(line)
 	}
 	n2, err := w.last.Write(lines[0])
@@ -154,6 +153,6 @@ func (w *lineLogger) Write(p []byte) (n int, err error) {
 }
 
 func (w *lineLogger) Flush() {
-	w.log.Log(w.ctx, w.level, w.last.String())
+	w.log.Log(w.ctx, w.level, w.last.String()) //nolint:sloglint
 	w.last.Reset()
 }

--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -149,13 +149,13 @@ func (w *lineLogger) Write(p []byte) (n int, err error) {
 	}
 
 	// Newline found, log line
-	w.log.Log(w.ctx, w.level, w.last.String()) //nolint:sloglint
+	w.log.Log(w.ctx, w.level, w.last.String()) //nolint:sloglint // msg cannot be constant
 	n += w.last.Len() + 1
 	w.last.Reset()
 
 	// Log lines that are already newline-terminated
 	for _, line := range lines[:len(lines)-1] {
-		w.log.Log(w.ctx, w.level, string(line)) //nolint:sloglint
+		w.log.Log(w.ctx, w.level, string(line)) //nolint:sloglint // msg cannot be constant
 		n += len(line) + 1
 	}
 
@@ -170,6 +170,6 @@ func (w *lineLogger) Flush() {
 	if w.last.Len() == 0 {
 		return
 	}
-	w.log.Log(w.ctx, w.level, w.last.String()) //nolint:sloglint
+	w.log.Log(w.ctx, w.level, w.last.String()) //nolint:sloglint // msg cannot be constant
 	w.last.Reset()
 }

--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -116,7 +116,9 @@ func (s SystemdService) systemctl(ctx context.Context, errLevel slog.Level, args
 	stdout.Flush()
 	code := cmd.ProcessState.ExitCode()
 
-	// Treat out-of-range code as an error with OS executing the command, not as an intentionally returned 255.
+	// Treat out-of-range exit code (255) as an error executing the command.
+	// This allows callers to treat codes that are more likely OS-related as execution errors
+	// instead of intentionally returned error codes.
 	if code == 255 {
 		code = -1
 	}

--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -153,6 +153,9 @@ func (w *lineLogger) Write(p []byte) (n int, err error) {
 }
 
 func (w *lineLogger) Flush() {
+	if w.last.Len() == 0 {
+		return
+	}
 	w.log.Log(w.ctx, w.level, w.last.String()) //nolint:sloglint
 	w.last.Reset()
 }

--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -49,7 +49,7 @@ func (s SystemdService) Reload(ctx context.Context) error {
 		return trace.Errorf("unable to determine if systemd service is active")
 	}
 	if code > 0 {
-		s.Log.WarnContext(ctx, "Teleport service not running.")
+		s.Log.WarnContext(ctx, "Teleport systemd service not running.")
 		return trace.Wrap(ErrNotNeeded)
 	}
 	code = s.systemctl(ctx, slog.LevelError, "reload", s.ServiceName)
@@ -59,9 +59,9 @@ func (s SystemdService) Reload(ctx context.Context) error {
 	if code > 0 {
 		code = s.systemctl(ctx, slog.LevelError, "try-restart", s.ServiceName)
 		if code != 0 {
-			return trace.Errorf("hard restart of systemd failed")
+			return trace.Errorf("hard restart of Teleport systemd service failed")
 		}
-		s.Log.WarnContext(ctx, "Teleport ungracefully restarted. Connections may have been dropped.")
+		s.Log.WarnContext(ctx, "Teleport ungracefully restarted. Connections potentially dropped.")
 		return nil
 	}
 	s.Log.InfoContext(ctx, "Teleport gracefully reloaded.")
@@ -85,7 +85,7 @@ func (s SystemdService) Sync(ctx context.Context) error {
 func (s SystemdService) checkSystem(ctx context.Context) error {
 	_, err := os.Stat("/run/systemd/system")
 	if errors.Is(err, os.ErrNotExist) {
-		s.Log.ErrorContext(ctx, "This system does not support SystemD, which is required by the updater.")
+		s.Log.ErrorContext(ctx, "This system does not support systemd, which is required by the updater.")
 		return trace.Wrap(ErrNotSupported)
 	}
 	return trace.Wrap(err)

--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -116,7 +116,7 @@ func (s SystemdService) systemctl(ctx context.Context, errLevel slog.Level, args
 	stdout.Flush()
 	code := cmd.ProcessState.ExitCode()
 
-	// treat out-of-range code as an error with OS executing command, not as intentional 255
+	// Treat out-of-range code as an error with OS executing the command, not as an intentionally returned 255.
 	if code == 255 {
 		code = -1
 	}

--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -115,6 +115,8 @@ func (s SystemdService) systemctl(ctx context.Context, errLevel slog.Level, args
 	stderr.Flush()
 	stdout.Flush()
 	code := cmd.ProcessState.ExitCode()
+
+	// treat out-of-range code as an error with OS executing command, not as intentional 255
 	if code == 255 {
 		code = -1
 	}
@@ -150,7 +152,7 @@ func (w *lineLogger) Write(p []byte) (n int, err error) {
 
 	// Newline found, log line
 	w.log.Log(w.ctx, w.level, w.last.String()) //nolint:sloglint // msg cannot be constant
-	n += w.last.Len() + 1
+	n += 1
 	w.last.Reset()
 
 	// Log lines that are already newline-terminated

--- a/lib/autoupdate/agent/process_test.go
+++ b/lib/autoupdate/agent/process_test.go
@@ -1,0 +1,69 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package agent
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLineLogger(t *testing.T) {
+	t.Parallel()
+
+	out := &bytes.Buffer{}
+	ll := lineLogger{
+		ctx: context.Background(),
+		log: slog.New(slog.NewTextHandler(out,
+			&slog.HandlerOptions{ReplaceAttr: msgOnly},
+		)),
+	}
+
+	for _, e := range []struct {
+		v string
+		n int
+	}{
+		{v: "a", n: 1},
+		{v: "b\n", n: 2},
+		{v: "c\nd", n: 3},
+		{v: "e\nf\ng", n: 5},
+		{v: "h", n: 1},
+		{v: "", n: 0},
+		{v: "i\n", n: 2},
+		{v: "j", n: 1},
+	} {
+		n, err := ll.Write([]byte(e.v))
+		require.NoError(t, err)
+		require.Equal(t, e.n, n)
+	}
+	require.Equal(t, "msg=ab\nmsg=c\nmsg=de\nmsg=f\nmsg=ghi\n", out.String())
+	ll.Flush()
+	require.Equal(t, "msg=ab\nmsg=c\nmsg=de\nmsg=f\nmsg=ghi\nmsg=j\n", out.String())
+}
+
+func msgOnly(_ []string, a slog.Attr) slog.Attr {
+	switch a.Key {
+	case "time", "level":
+		return slog.Attr{}
+	}
+	return slog.Attr{Key: a.Key, Value: a.Value}
+}

--- a/lib/autoupdate/agent/process_test.go
+++ b/lib/autoupdate/agent/process_test.go
@@ -42,12 +42,14 @@ func TestLineLogger(t *testing.T) {
 		v string
 		n int
 	}{
+		{v: "", n: 0},
 		{v: "a", n: 1},
 		{v: "b\n", n: 2},
 		{v: "c\nd", n: 3},
 		{v: "e\nf\ng", n: 5},
 		{v: "h", n: 1},
 		{v: "", n: 0},
+		{v: "\n", n: 1},
 		{v: "i\n", n: 2},
 		{v: "j", n: 1},
 	} {
@@ -55,9 +57,9 @@ func TestLineLogger(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, e.n, n)
 	}
-	require.Equal(t, "msg=ab\nmsg=c\nmsg=de\nmsg=f\nmsg=ghi\n", out.String())
+	require.Equal(t, "msg=ab\nmsg=c\nmsg=de\nmsg=f\nmsg=gh\nmsg=i\n", out.String())
 	ll.Flush()
-	require.Equal(t, "msg=ab\nmsg=c\nmsg=de\nmsg=f\nmsg=ghi\nmsg=j\n", out.String())
+	require.Equal(t, "msg=ab\nmsg=c\nmsg=de\nmsg=f\nmsg=gh\nmsg=i\nmsg=j\n", out.String())
 }
 
 func msgOnly(_ []string, a slog.Attr) slog.Attr {

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -327,7 +327,7 @@ func (u *Updater) Enable(ctx context.Context, override OverrideConfig) error {
 
 	if err := u.Process.Sync(ctx); err != nil {
 		if errors.Is(err, context.Canceled) {
-			return trace.Errorf("sync cancelled")
+			return trace.Errorf("sync canceled")
 		}
 		// If sync fails, we may have left the host in a bad state, so we revert linking and re-Sync.
 		u.Log.ErrorContext(ctx, "Reverting symlinks due to invalid configuration.")
@@ -347,7 +347,7 @@ func (u *Updater) Enable(ctx context.Context, override OverrideConfig) error {
 		u.Log.InfoContext(ctx, "Target version successfully installed.", "version", desiredVersion)
 		if err := u.Process.Reload(ctx); err != nil && !errors.Is(err, ErrNotNeeded) {
 			if errors.Is(err, context.Canceled) {
-				return trace.Errorf("reload cancelled")
+				return trace.Errorf("reload canceled")
 			}
 			// If reloading Teleport at the new version fails, revert, resync, and reload.
 			u.Log.ErrorContext(ctx, "Reverting symlinks due to failed restart.")

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -180,8 +180,9 @@ type Installer interface {
 	// Install must be idempotent.
 	Install(ctx context.Context, version, template string, flags InstallFlags) error
 	// Link the Teleport agent at the specified version into the system location.
-	// The revert function must restore the previous linking, returning false on failure.
+	// The revert function must restore the previous linking, returning false on any failure.
 	// Link must be idempotent.
+	// Link's revert function must be idempotent.
 	Link(ctx context.Context, version string) (revert func(context.Context) bool, err error)
 	// List the installed versions of Teleport.
 	List(ctx context.Context) (versions []string, err error)

--- a/lib/utils/unpack.go
+++ b/lib/utils/unpack.go
@@ -50,7 +50,8 @@ func Extract(r io.Reader, dir string, paths ...ExtractPath) error {
 		} else if err != nil {
 			return trace.Wrap(err)
 		}
-		if ok := filterHeader(header, paths); !ok {
+		dirMode, ok := filterHeader(header, paths)
+		if !ok {
 			continue
 		}
 		err = sanitizeTarPath(header, dir)
@@ -58,7 +59,7 @@ func Extract(r io.Reader, dir string, paths ...ExtractPath) error {
 			return trace.Wrap(err)
 		}
 
-		if err := extractFile(tarball, header, dir); err != nil {
+		if err := extractFile(tarball, header, dir, dirMode); err != nil {
 			return trace.Wrap(err)
 		}
 	}
@@ -74,11 +75,15 @@ type ExtractPath struct {
 	Src, Dst string
 	// Skip extracting the Src path and ignore Dst.
 	Skip bool
+	// DirMode is the file mode for implicit parent directories in Dst.
+	DirMode os.FileMode
 }
 
 // filterHeader modifies the tar header by filtering it through the ExtractPaths.
 // filterHeader returns false if the tar header should be skipped.
-func filterHeader(hdr *tar.Header, paths []ExtractPath) (include bool) {
+// If no paths are provided, filterHeader assumes the header should be included, and sets
+// the mode for implicit parent directories to teleport.DirMaskSharedGroup.
+func filterHeader(hdr *tar.Header, paths []ExtractPath) (dirMode os.FileMode, include bool) {
 	name := path.Clean(hdr.Name)
 	for _, p := range paths {
 		src := path.Clean(p.Src)
@@ -98,14 +103,14 @@ func filterHeader(hdr *tar.Header, paths []ExtractPath) (include bool) {
 				dst += "/" // tar directory headers end in /
 			}
 			hdr.Name = dst
-			return !p.Skip
+			return p.DirMode, !p.Skip
 		default:
 			// If name is a file, then
 			// if src is an exact match to the file name, assume src is a file and write directly to dst,
 			// otherwise, assume src is a directory prefix, and replace that prefix with dst.
 			if src == name {
 				hdr.Name = path.Clean(p.Dst)
-				return !p.Skip
+				return p.DirMode, !p.Skip
 			}
 			if src != "/" {
 				src += "/" // ensure HasPrefix does not match partial names
@@ -114,26 +119,26 @@ func filterHeader(hdr *tar.Header, paths []ExtractPath) (include bool) {
 				continue
 			}
 			hdr.Name = path.Join(p.Dst, strings.TrimPrefix(name, src))
-			return !p.Skip
+			return p.DirMode, !p.Skip
 
 		}
 	}
-	return len(paths) == 0
+	return teleport.DirMaskSharedGroup, len(paths) == 0
 }
 
 // extractFile extracts a single file or directory from tarball into dir.
 // Uses header to determine the type of item to create
 // Based on https://github.com/mholt/archiver
-func extractFile(tarball *tar.Reader, header *tar.Header, dir string) error {
+func extractFile(tarball *tar.Reader, header *tar.Header, dir string, dirMode os.FileMode) error {
 	switch header.Typeflag {
 	case tar.TypeDir:
-		return withDir(filepath.Join(dir, header.Name), nil)
+		return withDir(filepath.Join(dir, header.Name), dirMode, nil)
 	case tar.TypeBlock, tar.TypeChar, tar.TypeReg, tar.TypeFifo:
-		return writeFile(filepath.Join(dir, header.Name), tarball, header.FileInfo().Mode())
+		return writeFile(filepath.Join(dir, header.Name), tarball, header.FileInfo().Mode(), dirMode)
 	case tar.TypeLink:
-		return writeHardLink(filepath.Join(dir, header.Name), filepath.Join(dir, header.Linkname))
+		return writeHardLink(filepath.Join(dir, header.Name), filepath.Join(dir, header.Linkname), dirMode)
 	case tar.TypeSymlink:
-		return writeSymbolicLink(filepath.Join(dir, header.Name), header.Linkname)
+		return writeSymbolicLink(filepath.Join(dir, header.Name), header.Linkname, dirMode)
 	default:
 		log.Warnf("Unsupported type flag %v for %v.", header.Typeflag, header.Name)
 	}
@@ -141,7 +146,7 @@ func extractFile(tarball *tar.Reader, header *tar.Header, dir string) error {
 }
 
 // sanitizeTarPath checks that the tar header paths resolve to a subdirectory
-// path, and don't contain file paths or links that could escape the tar file
+// path, and don't contain file paths or links that could escape the tar fileteleport.DirMaskSharedGroup
 // like ../../etc/password.
 func sanitizeTarPath(header *tar.Header, dir string) error {
 	// Sanitize all tar paths resolve to within the destination directory.
@@ -168,8 +173,8 @@ func sanitizeTarPath(header *tar.Header, dir string) error {
 	return nil
 }
 
-func writeFile(path string, r io.Reader, mode os.FileMode) error {
-	err := withDir(path, func() error {
+func writeFile(path string, r io.Reader, mode, dirMode os.FileMode) error {
+	err := withDir(path, dirMode, func() error {
 		// Create file only if it does not exist to prevent overwriting existing
 		// files (like session recordings).
 		out, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode)
@@ -182,24 +187,24 @@ func writeFile(path string, r io.Reader, mode os.FileMode) error {
 	return trace.Wrap(err)
 }
 
-func writeSymbolicLink(path string, target string) error {
-	err := withDir(path, func() error {
+func writeSymbolicLink(path, target string, dirMode os.FileMode) error {
+	err := withDir(path, dirMode, func() error {
 		err := os.Symlink(target, path)
 		return trace.ConvertSystemError(err)
 	})
 	return trace.Wrap(err)
 }
 
-func writeHardLink(path string, target string) error {
-	err := withDir(path, func() error {
+func writeHardLink(path, target string, dirMode os.FileMode) error {
+	err := withDir(path, dirMode, func() error {
 		err := os.Link(target, path)
 		return trace.ConvertSystemError(err)
 	})
 	return trace.Wrap(err)
 }
 
-func withDir(path string, fn func() error) error {
-	err := os.MkdirAll(filepath.Dir(path), teleport.DirMaskSharedGroup)
+func withDir(path string, mode os.FileMode, fn func() error) error {
+	err := os.MkdirAll(filepath.Dir(path), mode)
 	if err != nil {
 		return trace.ConvertSystemError(err)
 	}

--- a/lib/utils/unpack.go
+++ b/lib/utils/unpack.go
@@ -146,7 +146,7 @@ func extractFile(tarball *tar.Reader, header *tar.Header, dir string, dirMode os
 }
 
 // sanitizeTarPath checks that the tar header paths resolve to a subdirectory
-// path, and don't contain file paths or links that could escape the tar fileteleport.DirMaskSharedGroup
+// path, and don't contain file paths or links that could escape the tar file
 // like ../../etc/password.
 func sanitizeTarPath(header *tar.Header, dir string) error {
 	// Sanitize all tar paths resolve to within the destination directory.

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -61,6 +61,8 @@ const (
 	versionsDirName = "versions"
 	// lockFileName specifies the name of the file inside versionsDirName containing the flock lock preventing concurrent updater execution.
 	lockFileName = ".lock"
+	// defaultLinkDir is the default location where Teleport binaries and services are linked.
+	defaultLinkDir = "/usr/local"
 )
 
 var plog = logutils.NewPackageLogger(teleport.ComponentKey, teleport.ComponentUpdater)
@@ -98,7 +100,7 @@ func Run(args []string) error {
 	app.Flag("log-format", "Controls the format of output logs. Can be `json` or `text`. Defaults to `text`.").
 		Default(libutils.LogFormatText).EnumVar(&ccfg.LogFormat, libutils.LogFormatJSON, libutils.LogFormatText)
 	app.Flag("link-dir", "Directory to create system symlinks to binaries and services.").
-		Default(filepath.Join("usr", "local")).Hidden().StringVar(&ccfg.LinkDir)
+		Default(defaultLinkDir).Hidden().StringVar(&ccfg.LinkDir)
 
 	app.HelpFlag.Short('h')
 


### PR DESCRIPTION
This PR adds support for reloading the Teleport agent process when the `enable` subcommand to the `teleport-update` binary is executed. Additionally, this PR reverts the system to the previously installed version of the agent on failure.

This PR also adds:
- Additional validation when creating symlinks so that they cannot replace regular files (e.g., real Teleport binaries)
- Fixes to symlink directory permissions (`0750` -> `0755`)
- Ungraceful restart fallback when graceful reloading fails

Notably, this PR is missing:
- Proper healthchecking for the Teleport service (see TODO)

This is the fourth in a series of PRs implementing `teleport-update`:
Linking: https://github.com/gravitational/teleport/pull/47879
Enable Command: https://github.com/gravitational/teleport/pull/47565
Initial scaffolding PR: https://github.com/gravitational/teleport/pull/46418

The `teleport-update` binary will be used to enable, disable, and trigger automatic Teleport agent updates. The new auto-updates system manages a local installation of the cluster-specified version of Teleport stored in `/var/lib/teleport/versions`.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/10289

---

Example:
```
ubuntu@legendary-mite:~/mounts/teleport/tool/teleport-update$ sudo ./teleport-update enable --proxy=levine.teleport.sh --force-version=16.4.3
2024-10-28T21:25:23Z INFO [UPDATER]   Version already present. version:16.4.3 agent/installer.go:145
2024-10-28T21:25:23Z INFO [UPDATER]   Target version successfully installed. version:16.4.3 agent/updater.go:334
2024-10-28T21:25:23Z INFO [UPDATER]   Teleport gracefully reloaded. agent/process.go:75
2024-10-28T21:25:23Z INFO [UPDATER]   Backup version set. version:16.4.2 agent/updater.go:356
2024-10-28T21:25:23Z INFO [UPDATER]   Configuration updated. agent/updater.go:375
ubuntu@legendary-mite:~/mounts/teleport/tool/teleport-update$ ls -la /usr/local/bin
total 8
drwxr-xr-x  2 root root 4096 Oct 28 21:27 .
drwxr-xr-x 10 root root 4096 Oct  8 23:12 ..
lrwxrwxrwx  1 root root   53 Oct 28 21:27 fdpass-teleport -> /var/lib/teleport/versions/16.4.3/bin/fdpass-teleport
lrwxrwxrwx  1 root root   42 Oct 28 21:27 tbot -> /var/lib/teleport/versions/16.4.3/bin/tbot
lrwxrwxrwx  1 root root   42 Oct 28 21:27 tctl -> /var/lib/teleport/versions/16.4.3/bin/tctl
lrwxrwxrwx  1 root root   46 Oct 28 21:27 teleport -> /var/lib/teleport/versions/16.4.3/bin/teleport
lrwxrwxrwx  1 root root   41 Oct 28 21:27 tsh -> /var/lib/teleport/versions/16.4.3/bin/tsh
ubuntu@legendary-mite:~/mounts/teleport/tool/teleport-update$ ls -la /usr/local/lib/systemd/system/
total 12
drwxr-xr-x 2 root root 4096 Oct 28 21:27 .
drwxr-xr-x 3 root root 4096 Oct 28 19:03 ..
lrwxrwxrwx 1 root root   62 Oct 28 21:27 teleport.service -> /var/lib/teleport/versions/16.4.3/etc/systemd/teleport.service
ubuntu@legendary-mite:~/mounts/teleport/tool/teleport-update$ cat /var/lib/teleport/versions/update.yaml 
version: v1
kind: update_config
spec:
    proxy: levine.teleport.sh
    group: ""
    url_template: ""
    enabled: true
status:
    active_version: 16.4.3
    backup_version: 16.4.2
```