### PR TITLE
Turn off import/no-unresolved ESLint rule

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,9 +241,6 @@ importers:
       jest-fail-on-console:
         specifier: ^3.3.0
         version: 3.3.0
-      jest-styled-components:
-        specifier: ^7.2.0
-        version: 7.2.0(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       jsdom:
         specifier: ^25.0.1
         version: 25.0.1
@@ -278,6 +275,9 @@ importers:
       '@types/styled-system':
         specifier: ^5.1.22
         version: 5.1.22
+      jest-styled-components:
+        specifier: ^7.2.0
+        version: 7.2.0(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
 
   web/packages/shared:
     dependencies:

--- a/web/packages/build/.eslintrc.js
+++ b/web/packages/build/.eslintrc.js
@@ -83,6 +83,9 @@ module.exports = {
         'newlines-between': 'always-and-inside-groups',
       },
     ],
+    // typescript-eslint recommends to turn import/no-unresolved off.
+    // https://typescript-eslint.io/troubleshooting/typed-linting/performance/#eslint-plugin-import
+    'import/no-unresolved': 0,
     'no-unused-vars': 'off', // disabled to allow the typescript one to take over and avoid errors in reporting
     '@typescript-eslint/no-unused-vars': ['error'],
 
@@ -111,8 +114,6 @@ module.exports = {
     'no-alert': 0,
     'import/no-named-as-default': 0,
     'import/default': 2,
-    // XXX Change to a 2 once e pkg imports are removed from teleterm.
-    'import/no-unresolved': 1,
     'no-underscore-dangle': 0,
     'no-case-declarations': 0,
     'prefer-const': 0,

--- a/web/packages/build/package.json
+++ b/web/packages/build/package.json
@@ -30,7 +30,6 @@
     "eslint-plugin-testing-library": "^6.3.0",
     "jest-environment-jsdom": "^29.7.0",
     "jest-fail-on-console": "^3.3.0",
-    "jest-styled-components": "^7.2.0",
     "jsdom": "^25.0.1",
     "rollup-plugin-visualizer": "^5.12.0",
     "typescript-eslint": "^7.14.1",

--- a/web/packages/design/package.json
+++ b/web/packages/design/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@gravitational/build": "workspace:*",
-    "@types/styled-system": "^5.1.22"
+    "@types/styled-system": "^5.1.22",
+    "jest-styled-components": "^7.2.0"
   }
 }


### PR DESCRIPTION
It was temporarily downgraded to a warning ever since OSS builds of teleterm were broken due to OSS importing stuff from teleport.e. That has since been fixed, so in theory we could re-enable it, but.

[typescript-eslint recommends disabling this rule](https://typescript-eslint.io/troubleshooting/typed-linting/performance/#eslint-plugin-import) since TypeScript itself provides the same guarantees during type checking.

Arguably, import/no-unresolved helped me discover the only issue it flagged in our project that was not covered by TS, which I fixed in this PR. typescript-eslint also recommends enabling `no-require-imports`, but I didn't want to do this at the moment as there's still a bunch of places which use `require` and I just don't have enough time to change them and verify that they're still working.