### PR TITLE
Specify default logger in app.CopyAndConfigureTLS

### DIFF
--- a/lib/srv/app/connections_handler.go
+++ b/lib/srv/app/connections_handler.go
@@ -755,6 +755,9 @@ func (c *ConnectionsHandler) deleteConnAuth(conn net.Conn) {
 // for Teleport application proxy servers.
 func CopyAndConfigureTLS(log logrus.FieldLogger, client authclient.AccessCache, config *tls.Config) *tls.Config {
 	tlsConfig := config.Clone()
+	if log == nil {
+		log = logrus.StandardLogger()
+	}
 
 	// Require clients to present a certificate
 	tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert


### PR DESCRIPTION
As some code begins migrating to slog, there will be no logrus logger to provide to this function. Until the transition is complete, allow a nil logger to be provided and use the default logger instead.