### PR TITLE
Refactor `useUrlFiltering`

### DIFF
--- a/web/packages/teleport/src/components/hooks/useUrlFiltering/useUrlFiltering.ts
+++ b/web/packages/teleport/src/components/hooks/useUrlFiltering/useUrlFiltering.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useLocation } from 'react-router';
 import { SortType } from 'design/DataTable/types';
 
@@ -42,23 +42,45 @@ export function useUrlFiltering(
   initialParams: Partial<ResourceFilter>
 ): UrlFilteringState {
   const { search, pathname } = useLocation();
-  const [params, setParams] = useState<ResourceFilter>({
-    ...initialParams,
-    ...getResourceUrlQueryParams(search),
-  });
 
   function replaceHistory(path: string) {
     history.replace(path);
   }
 
   function setSort(sort: SortType) {
-    setParams({ ...params, sort });
+    replaceHistory(
+      encodeUrlQueryParams({
+        pathname,
+        searchString: params.search || params.query,
+        sort: { ...params.sort, ...sort },
+        kinds: params.kinds,
+        isAdvancedSearch: !!params.query,
+        pinnedOnly: params.pinnedOnly,
+      })
+    );
+  }
+
+  const [initialParamsState] = useState(initialParams);
+  const params = useMemo(() => {
+    return { ...initialParamsState, ...getResourceUrlQueryParams(search) };
+  }, [initialParamsState, search]);
+
+  function setParams(newParams: ResourceFilter) {
+    replaceHistory(
+      encodeUrlQueryParams({
+        pathname,
+        searchString: newParams.search || newParams.query,
+        sort: newParams.sort,
+        kinds: newParams.kinds,
+        isAdvancedSearch: !!params.query,
+        pinnedOnly: newParams.pinnedOnly,
+      })
+    );
   }
 
   const onLabelClick = (label: ResourceLabel) => {
     const queryAfterLabelClick = makeAdvancedSearchQueryForLabel(label, params);
 
-    setParams({ ...params, search: '', query: queryAfterLabelClick });
     replaceHistory(
       encodeUrlQueryParams({
         pathname,


### PR DESCRIPTION
This PR refactors `useUrlFiltering` so that the `params` in the location are always the source of truth and kept in sync with the params returned by the hook even when updated. This change was originally part of https://github.com/gravitational/teleport/pull/47882 but I'm making it into a separate PR to make sure it gets in before the test plan.