### PR TITLE
[v15] Fix UserContext SSO detection in UI for Okta Users

### DIFF
--- a/api/types/user.go
+++ b/api/types/user.go
@@ -521,11 +521,15 @@ func (u UserV2) GetGCPServiceAccounts() []string {
 
 // GetUserType indicates if the User was created by an SSO Provider or locally.
 func (u UserV2) GetUserType() UserType {
-	if u.GetCreatedBy().Connector == nil {
-		return UserTypeLocal
+	if u.GetCreatedBy().Connector != nil ||
+		len(u.GetOIDCIdentities()) > 0 ||
+		len(u.GetGithubIdentities()) > 0 ||
+		len(u.GetSAMLIdentities()) > 0 {
+
+		return UserTypeSSO
 	}
 
-	return UserTypeSSO
+	return UserTypeLocal
 }
 
 // IsBot returns true if the user is a bot.

--- a/lib/web/ui/usercontext.go
+++ b/lib/web/ui/usercontext.go
@@ -104,7 +104,8 @@ func NewUserContext(user types.User, userRoles services.RoleSet, features proto.
 	authType := authLocal
 
 	// check for any SSO identities
-	isSSO := len(user.GetOIDCIdentities()) > 0 ||
+	isSSO := user.GetUserType() == types.UserTypeSSO ||
+		len(user.GetOIDCIdentities()) > 0 ||
 		len(user.GetGithubIdentities()) > 0 ||
 		len(user.GetSAMLIdentities()) > 0
 

--- a/lib/web/ui/usercontext.go
+++ b/lib/web/ui/usercontext.go
@@ -104,10 +104,7 @@ func NewUserContext(user types.User, userRoles services.RoleSet, features proto.
 	authType := authLocal
 
 	// check for any SSO identities
-	isSSO := user.GetUserType() == types.UserTypeSSO ||
-		len(user.GetOIDCIdentities()) > 0 ||
-		len(user.GetGithubIdentities()) > 0 ||
-		len(user.GetSAMLIdentities()) > 0
+	isSSO := user.GetUserType() == types.UserTypeSSO
 
 	if isSSO {
 		// SSO user

--- a/lib/web/ui/usercontext_test.go
+++ b/lib/web/ui/usercontext_test.go
@@ -68,6 +68,25 @@ func TestNewUserContext(t *testing.T) {
 	userContext, err = NewUserContext(user, roleSet, proto.Features{}, true, false)
 	require.NoError(t, err)
 	require.Equal(t, authSSO, userContext.AuthType)
+
+	// test sso auth type for users with the CreatedBy.Connector field set.
+	// Eg users import from okta do not have any <IdP>Identities, so the CreatedBy.Connector must be checked.
+	userCreatedExternally := &types.UserV2{
+		Metadata: types.Metadata{
+			Name: "root",
+		},
+		Status: types.UserStatusV2{
+			PasswordState: types.PasswordState_PASSWORD_STATE_SET,
+		},
+		Spec: types.UserSpecV2{
+			CreatedBy: types.CreatedBy{
+				Connector: &types.ConnectorRef{},
+			},
+		},
+	}
+	userContext, err = NewUserContext(userCreatedExternally, roleSet, proto.Features{}, true, false)
+	require.NoError(t, err)
+	require.Equal(t, authSSO, userContext.AuthType)
 }
 
 func TestNewUserContextCloud(t *testing.T) {


### PR DESCRIPTION
Backport #47944 to branch/v15

changelog: During the Set Up Access of the Enroll New Resource flows, Okta users will be asked to change the role instead of entering the principals and getting an error afterwards.
