### PR TITLE
Discover EKS: handle 'CONFIG_MAP' authentication mode gracefully

### DIFF
--- a/lib/integrations/awsoidc/eks_enroll_clusters.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters.go
@@ -378,7 +378,10 @@ func enrollEKSCluster(ctx context.Context, log *slog.Logger, clock clockwork.Clo
 
 	// When clusters are using CONFIG_MAP, API is not acessible and thus Teleport can't install the Teleport's Helm chart.
 	// You can read more about the Authentication Modes here: https://aws.amazon.com/blogs/containers/a-deep-dive-into-simplified-amazon-eks-access-management-controls/
-	allowedAuthModes := []eksTypes.AuthenticationMode{"API", "API_AND_CONFIG_MAP"}
+	allowedAuthModes := []eksTypes.AuthenticationMode{
+		eksTypes.AuthenticationModeApi,
+		eksTypes.AuthenticationModeApiAndConfigMap,
+	}
 	if !slices.Contains(allowedAuthModes, eksCluster.AccessConfig.AuthenticationMode) {
 		return "", trace.BadParameter("can't enroll %q because its access config's authentication mode is %q, only %v are supported", clusterName, eksCluster.AccessConfig.AuthenticationMode, allowedAuthModes)
 	}

--- a/lib/integrations/awsoidc/eks_enroll_clusters.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -373,6 +374,13 @@ func enrollEKSCluster(ctx context.Context, log *slog.Logger, clock clockwork.Clo
 	// We can't discover private EKS clusters for cloud clients, since we know that auth server is running in our VPC.
 	if req.IsCloud && !eksCluster.ResourcesVpcConfig.EndpointPublicAccess {
 		return "", trace.AccessDenied(`can't enroll %q because it is not accessible from Teleport Cloud, please enable endpoint public access in your EKS cluster and try again.`, clusterName)
+	}
+
+	// When clusters are using CONFIG_MAP, API is not acessible and thus Teleport can't install the Teleport's Helm chart.
+	// You can read more about the Authentication Modes here: https://aws.amazon.com/blogs/containers/a-deep-dive-into-simplified-amazon-eks-access-management-controls/
+	allowedAuthModes := []eksTypes.AuthenticationMode{"API", "API_AND_CONFIG_MAP"}
+	if !slices.Contains(allowedAuthModes, eksCluster.AccessConfig.AuthenticationMode) {
+		return "", trace.BadParameter("can't enroll %q because its access config's authentication mode is %q, only %v are supported", clusterName, eksCluster.AccessConfig.AuthenticationMode, allowedAuthModes)
 	}
 
 	principalArn, err := getAccessEntryPrincipalArn(ctx, clt.GetCallerIdentity)

--- a/lib/integrations/awsoidc/eks_enroll_clusters_test.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters_test.go
@@ -98,6 +98,9 @@ func TestEnrollEKSClusters(t *testing.T) {
 			Tags:                 map[string]string{"label1": "value1"},
 			CertificateAuthority: &eksTypes.Certificate{Data: aws.String(testCAData)},
 			Status:               eksTypes.ClusterStatusActive,
+			AccessConfig: &eksTypes.AccessConfigResponse{
+				AuthenticationMode: eksTypes.AuthenticationModeApiAndConfigMap,
+			},
 		},
 		{
 			Name: aws.String("EKS2"),
@@ -108,6 +111,9 @@ func TestEnrollEKSClusters(t *testing.T) {
 			Tags:                 map[string]string{"label2": "value2"},
 			CertificateAuthority: &eksTypes.Certificate{Data: aws.String(testCAData)},
 			Status:               eksTypes.ClusterStatusActive,
+			AccessConfig: &eksTypes.AccessConfigResponse{
+				AuthenticationMode: eksTypes.AuthenticationModeApiAndConfigMap,
+			},
 		},
 	}
 
@@ -238,6 +244,29 @@ func TestEnrollEKSClusters(t *testing.T) {
 			},
 		},
 		{
+			name:         "cluster with CONFIG_MAP authentication mode is not enrolled",
+			enrollClient: baseClient,
+			eksClusters: []eksTypes.Cluster{
+				{
+					Name:                 aws.String("EKS1"),
+					Arn:                  aws.String(clustersBaseArn + "1"),
+					Tags:                 map[string]string{"label1": "value1"},
+					CertificateAuthority: &eksTypes.Certificate{Data: aws.String(testCAData)},
+					Status:               eksTypes.ClusterStatusActive,
+					AccessConfig: &eksTypes.AccessConfigResponse{
+						AuthenticationMode: eksTypes.AuthenticationModeConfigMap,
+					},
+				},
+			},
+			request:             baseRequest,
+			requestClusterNames: []string{"EKS1"},
+			responseCheck: func(t *testing.T, response *EnrollEKSClusterResponse) {
+				require.Len(t, response.Results, 1)
+				require.ErrorContains(t, response.Results[0].Error,
+					`can't enroll "EKS1" because its access config's authentication mode is "CONFIG_MAP", only [API API_AND_CONFIG_MAP] are supported`)
+			},
+		},
+		{
 			name:         "private cluster in cloud is not enrolled",
 			enrollClient: baseClient,
 			eksClusters: []eksTypes.Cluster{
@@ -250,6 +279,9 @@ func TestEnrollEKSClusters(t *testing.T) {
 					Tags:                 map[string]string{"label3": "value3"},
 					CertificateAuthority: &eksTypes.Certificate{Data: aws.String(testCAData)},
 					Status:               eksTypes.ClusterStatusActive,
+					AccessConfig: &eksTypes.AccessConfigResponse{
+						AuthenticationMode: eksTypes.AuthenticationModeApiAndConfigMap,
+					},
 				},
 			},
 			request: EnrollEKSClustersRequest{
@@ -279,6 +311,9 @@ func TestEnrollEKSClusters(t *testing.T) {
 					Tags:                 map[string]string{"label3": "value3"},
 					CertificateAuthority: &eksTypes.Certificate{Data: aws.String(testCAData)},
 					Status:               eksTypes.ClusterStatusActive,
+					AccessConfig: &eksTypes.AccessConfigResponse{
+						AuthenticationMode: eksTypes.AuthenticationModeApiAndConfigMap,
+					},
 				},
 			},
 			request: EnrollEKSClustersRequest{


### PR DESCRIPTION
EKS Cluster Access Config's Authentication mode can be set to one of:
- API
- API_AND_CONFIG_MAP
- CONFIG_MAP

Teleport requires either API or API_AND_CONFIG_MAP to install the helm chart.

This PR checks this value before trying to install the helm chart. This way the user is presented with a better error message.