### PR TITLE
Include `PluginTypeAWSIdentityCenter` in `PluginV1.GetType` method

### DIFF
--- a/api/types/plugin.go
+++ b/api/types/plugin.go
@@ -520,6 +520,8 @@ func (p *PluginV1) GetType() PluginType {
 		return PluginTypeSCIM
 	case *PluginSpecV1_Datadog:
 		return PluginTypeDatadog
+	case *PluginSpecV1_AwsIc:
+		return PluginTypeAWSIdentityCenter
 
 	default:
 		return PluginTypeUnknown


### PR DESCRIPTION
The result from this method is used to add correct plugin type in the plugin list `/enterprise/plugin` Web API.