### PR TITLE
docs: include directory sharing option in role specs

### DIFF
--- a/docs/pages/enroll-resources/desktop-access/rbac.mdx
+++ b/docs/pages/enroll-resources/desktop-access/rbac.mdx
@@ -11,7 +11,7 @@ desktop access:
 
 ```yaml
 kind: role
-version: v4
+version: v5
 metadata:
   name: developer
 spec:
@@ -30,6 +30,12 @@ spec:
     # if unspecified. If one or more of the user's roles has disabled
     # the clipboard, then it will be disabled.
     desktop_clipboard: true
+
+    # Specify whether directory sharing should be allowed from the
+    # local machine to remote desktop (requires a supported browser). Defaults to true
+    # if unspecified. If one or more of the user's roles has disabled
+    # directory sharing, then it will be disabled.
+    desktop_directory_sharing: true
 
     # Specify whether local users should be created automatically at connection
     # time. By default, this feature is disabled, and the user must already exist.

--- a/docs/pages/includes/role-spec.mdx
+++ b/docs/pages/includes/role-spec.mdx
@@ -88,6 +88,11 @@ spec:
     # if unspecified. If one or more of the user's roles has disabled
     # the clipboard, then it will be disabled.
     desktop_clipboard: true
+    # Specify whether directory sharing should be allowed from the
+    # local machine to remote desktop (requires a supported browser). Defaults to true
+    # if unspecified. If one or more of the user's roles has disabled
+    # directory sharing, then it will be disabled.
+    desktop_directory_sharing: true
     # enterprise-only: when enabled, the source IP that was used to log in is embedded in the user
     # certificates, preventing a compromised certificate from being used on another
     # network. The default is false.

--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -68,6 +68,7 @@ user:
 | `max_kubernetes_connections` | Defines the maximum number of concurrent Kubernetes sessions per user | |
 | `record_session` |Defines the [Session recording mode](../monitoring/audit.mdx).|The strictest value takes precedence.|
 | `desktop_clipboard` | Allow clipboard sharing for desktop sessions | Logical "AND" i.e. evaluates to "yes" if all roles enable clipboard sharing |
+| `desktop_directory_sharing` | Allows sharing local workstation directory to remote desktop | Logical "AND" i.e. evaluates to "yes" if all roles enable directory sharing |
 | `pin_source_ip` | Enable source IP pinning for SSH certificates. | Logical "OR" i.e. evaluates to "yes" if at least one role requires session termination |
 | `cert_extensions` | Specifies extensions to be included in SSH certificates | |
 | `create_host_user_mode` | Allow users to be automatically created on a host |  Logical "AND" i.e. if all roles matching a server specify host user creation (`off`, `keep`, `insecure-drop`), it will evaluate to the option specified by all of the roles. If some roles specify both `insecure-drop` or `keep` it will evaluate to `keep`|


### PR DESCRIPTION
Includes role dir sharing option in desktop role spec and overall role spec.