### PR TITLE
Add a timeout to Lint (Docs) dep installation

### DIFF
--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -48,6 +48,8 @@ jobs:
           path: "docs"
 
       - name: Prepare docs site configuration
+        # Prevent occasional `yarn install` executions that run indefinitely
+        timeout-minutes: 10
         # The environment we use for linting the docs differs from the one we
         # use for the live docs site in that we only test a single version of
         # the content.


### PR DESCRIPTION
For reasons that are unclear, the dependency installation step in the Lint (Docs) GitHub Actions job occasionally takes an indefinite time to complete, and must be canceled manually or after reaching the maximum GitHub Actions runtime.

To prevent this situation, this change adds a timeout of 10 minutes to the step that installs NodeJS dependencies for the Lint (Docs) job. This step tends to take around 7 minutes to complete, so a 10-minute timeout should be reasonable.