### PR TITLE
[v17] Improve Teleport's ability to reconnect to LDAP

### DIFF
--- a/lib/srv/desktop/discovery.go
+++ b/lib/srv/desktop/discovery.go
@@ -99,11 +99,6 @@ func (s *WindowsService) ldapSearchFilter() string {
 
 // getDesktopsFromLDAP discovers Windows hosts via LDAP
 func (s *WindowsService) getDesktopsFromLDAP() map[string]types.WindowsDesktop {
-	if !s.ldapReady() {
-		s.cfg.Logger.WarnContext(context.Background(), "skipping desktop discovery: LDAP not yet initialized")
-		return nil
-	}
-
 	filter := s.ldapSearchFilter()
 	s.cfg.Logger.DebugContext(context.Background(), "searching for desktops", "filter", filter)
 
@@ -250,7 +245,11 @@ func (s *WindowsService) lookupDesktop(ctx context.Context, hostname string) ([]
 
 // ldapEntryToWindowsDesktop generates the Windows Desktop resource
 // from an LDAP search result
-func (s *WindowsService) ldapEntryToWindowsDesktop(ctx context.Context, entry *ldap.Entry, getHostLabels func(string) map[string]string) (types.WindowsDesktop, error) {
+func (s *WindowsService) ldapEntryToWindowsDesktop(
+	ctx context.Context,
+	entry *ldap.Entry,
+	getHostLabels func(string) map[string]string,
+) (types.WindowsDesktop, error) {
 	hostname := entry.GetAttributeValue(windows.AttrDNSHostName)
 	if hostname == "" {
 		attrs := make([]string, len(entry.Attributes))

--- a/lib/srv/desktop/discovery.go
+++ b/lib/srv/desktop/discovery.go
@@ -99,6 +99,16 @@ func (s *WindowsService) ldapSearchFilter() string {
 
 // getDesktopsFromLDAP discovers Windows hosts via LDAP
 func (s *WindowsService) getDesktopsFromLDAP() map[string]types.WindowsDesktop {
+	// Check whether we've ever successfully initialized our LDAP client.
+	s.mu.Lock()
+	if !s.ldapInitialized {
+		s.cfg.Logger.DebugContext(context.Background(), "LDAP not ready, skipping discovery and attempting to reconnect")
+		s.mu.Unlock()
+		s.initializeLDAP()
+		return nil
+	}
+	s.mu.Unlock()
+
 	filter := s.ldapSearchFilter()
 	s.cfg.Logger.DebugContext(context.Background(), "searching for desktops", "filter", filter)
 

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -425,6 +425,34 @@ func NewWindowsService(cfg WindowsServiceConfig) (*WindowsService, error) {
 		s.cfg.Logger.InfoContext(ctx, "desktop discovery via LDAP is disabled, set 'base_dn' to enable")
 	}
 
+	// if LDAP-based discovery is not enabled, but we have configured LDAP
+	// then it's important that we periodically try to use the LDAP connection
+	// to detect connection closure
+	if s.ldapConfigured && len(s.cfg.DiscoveryBaseDN) == 0 {
+		s.cfg.Log.Debugln("starting LDAP connection checker")
+		go func() {
+			t := s.cfg.Clock.NewTicker(5 * time.Minute)
+			defer t.Stop()
+
+			for {
+				select {
+				case <-t.Chan():
+					// attempt to read CAs in the NTAuth store (we know we have permissions to do so)
+					ntAuthDN := "CN=NTAuthCertificates,CN=Public Key Services,CN=Services,CN=Configuration," + s.cfg.LDAPConfig.DomainDN()
+					_, err := s.lc.Read(ntAuthDN, "certificationAuthority", []string{"cACertificate"})
+					if trace.IsConnectionProblem(err) {
+						s.cfg.Log.Infoln("reconnecting to LDAP server")
+						if err := s.initializeLDAP(); err != nil {
+							s.cfg.Log.Warnf("failed to reconnect to LDAP: %v", err)
+						}
+					}
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+
 	ok = true
 	return s, nil
 }
@@ -690,12 +718,6 @@ func (s *WindowsService) readyForConnections() bool {
 
 	// If LDAP was configured, then we need to wait for it to be initialized
 	// before accepting connections.
-	return s.ldapInitialized
-}
-
-func (s *WindowsService) ldapReady() bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	return s.ldapInitialized
 }
 

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -429,32 +429,41 @@ func NewWindowsService(cfg WindowsServiceConfig) (*WindowsService, error) {
 	// then it's important that we periodically try to use the LDAP connection
 	// to detect connection closure
 	if s.ldapConfigured && len(s.cfg.DiscoveryBaseDN) == 0 {
-		s.cfg.Log.Debugln("starting LDAP connection checker")
-		go func() {
-			t := s.cfg.Clock.NewTicker(5 * time.Minute)
-			defer t.Stop()
-
-			for {
-				select {
-				case <-t.Chan():
-					// attempt to read CAs in the NTAuth store (we know we have permissions to do so)
-					ntAuthDN := "CN=NTAuthCertificates,CN=Public Key Services,CN=Services,CN=Configuration," + s.cfg.LDAPConfig.DomainDN()
-					_, err := s.lc.Read(ntAuthDN, "certificationAuthority", []string{"cACertificate"})
-					if trace.IsConnectionProblem(err) {
-						s.cfg.Log.Infoln("reconnecting to LDAP server")
-						if err := s.initializeLDAP(); err != nil {
-							s.cfg.Log.Warnf("failed to reconnect to LDAP: %v", err)
-						}
-					}
-				case <-ctx.Done():
-					return
-				}
-			}
-		}()
+		s.startLDAPConnectionCheck(ctx)
 	}
 
 	ok = true
 	return s, nil
+}
+
+// startLDAPConnectionCheck starts a background process that
+// periodically reads from the LDAP connection in order to detect
+// connection closure, and reconnects if necessary.
+// This is useful when LDAP-based discovery is disabled, because without
+// discovery the connection goes idle and may be closed by the server.
+func (s *WindowsService) startLDAPConnectionCheck(ctx context.Context) {
+	s.cfg.Logger.DebugContext(ctx, "starting LDAP connection checker")
+	go func() {
+		t := s.cfg.Clock.NewTicker(5 * time.Minute)
+		defer t.Stop()
+
+		for {
+			select {
+			case <-t.Chan():
+				// attempt to read CAs in the NTAuth store (we know we have permissions to do so)
+				ntAuthDN := "CN=NTAuthCertificates,CN=Public Key Services,CN=Services,CN=Configuration," + s.cfg.LDAPConfig.DomainDN()
+				_, err := s.lc.Read(ntAuthDN, "certificationAuthority", []string{"cACertificate"})
+				if trace.IsConnectionProblem(err) {
+					s.cfg.Logger.DebugContext(ctx, "detected broken LDAP connection, will reconnect")
+					if err := s.initializeLDAP(); err != nil {
+						s.cfg.Logger.WarnContext(ctx, "failed to reconnect to LDAP", "error", err)
+					}
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
 }
 
 func (s *WindowsService) newSessionRecorder(recConfig types.SessionRecordingConfig, sessionID string) (libevents.SessionPreparerRecorder, error) {


### PR DESCRIPTION
Backport #36281 to branch/v17
Backport #48041 to branch/v17

changelog: ensure that Teleport can re-establish broken LDAP connections.
