### PR TITLE
Prevent AWS OIDC integration deletion if referenced by AWS Identity Center plugin

### DIFF
--- a/lib/services/local/integrations.go
+++ b/lib/services/local/integrations.go
@@ -201,7 +201,7 @@ func integrationReferencedByEAS(ctx context.Context, bk backend.Backend, name st
 // by an existing AWS Identity Center plugin. In case the AWS Identity Center plugin exists
 // but does not reference this integration, a conditional action is returned with a revision
 // of the plugin to ensure that plugin hasn't changed during deletion of the AWS OIDC integration.
-// Returns nil ConditionalAction if no AWS Identity Center plugin is found.
+// Returns nil ConditionalAction if AWS Identity Center plugin is not found.
 func integrationReferencedByAWSICPlugin(ctx context.Context, bk backend.Backend, name string) (*backend.ConditionalAction, error) {
 	pluginService := NewPluginsService(bk)
 	plugins, err := pluginService.GetPlugins(ctx, false)


### PR DESCRIPTION
This PR updates `DeleteIntegration` to ensure that deletion is prevented if the integration is referenced by the AWS Identity Center plugin. 

The prevention machinery is based on existing implementation for External Audit storage (EAS), which is now wrapped with new `integrationConditionalDeletion` function that checks for both EAS and AWS Identity Center plugin reference. 



Part of https://github.com/gravitational/teleport.e/issues/4839