### PR TITLE
[v16] Fix racy X11 forwarding test

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -4790,7 +4790,7 @@ func testX11Forwarding(t *testing.T, suite *integrationTestSuite) {
 
 						// Reading the display may fail if the session is not fully initialized
 						// and the write to stdin is swallowed.
-						var display string
+						display := make(chan string, 1)
 						require.EventuallyWithT(t, func(t *assert.CollectT) {
 							// enter 'printenv DISPLAY > /path/to/tmp/file' into the session (dumping the value of DISPLAY into the temp file)
 							_, err = keyboard.Write([]byte(fmt.Sprintf("printenv %v > %s\n\r", x11.DisplayEnv, tmpFile.Name())))
@@ -4799,7 +4799,7 @@ func testX11Forwarding(t *testing.T, suite *integrationTestSuite) {
 							assert.Eventually(t, func() bool {
 								output, err := os.ReadFile(tmpFile.Name())
 								if err == nil && len(output) != 0 {
-									display = strings.TrimSpace(string(output))
+									display <- strings.TrimSpace(string(output))
 									return true
 								}
 								return false
@@ -4807,7 +4807,7 @@ func testX11Forwarding(t *testing.T, suite *integrationTestSuite) {
 						}, 10*time.Second, time.Second)
 
 						// Make a new connection to the XServer proxy to confirm that forwarding is working.
-						serverDisplay, err := x11.ParseDisplay(display)
+						serverDisplay, err := x11.ParseDisplay(<-display)
 						require.NoError(t, err)
 
 						conn, err := serverDisplay.Dial()


### PR DESCRIPTION
{require,assert}.Eventually run the passed in func on a new goroutine for each attempt, so it's not safe to write to a shared variable without any synchronization.

Closes #47756
Backports #48045