### PR TITLE
Cache node_modules in `Lint (Docs)`

### DIFF
--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -47,9 +47,28 @@ jobs:
           repository: "gravitational/docs"
           path: "docs"
 
-      - name: Prepare docs site configuration
+      # Cache node_modules. Unlike the example in the actions/cache repo, this
+      # caches the node_modules directory instead of the yarn cache. This is
+      # because yarn needs to build fresh packages even when it copies files
+      # from the yarn cache into node_modules.
+      # See:
+      # https://github.com/actions/cache/blob/main/examples.md#node---yarn
+      - uses: actions/cache@v4
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: '${{ github.workspace }}/docs/node_modules'
+          key: ${{ runner.os }}-yarn-${{ hashFiles(format('{0}/docs/yarn.lock', github.workspace)) }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install docs site dependencies
+        working-directory: docs
+        if: ${{ steps.yarn-cache.outputs.cache-hit != 'true' }}
         # Prevent occasional `yarn install` executions that run indefinitely
         timeout-minutes: 10
+        run: yarn install
+
+      - name: Prepare docs site configuration
         # The environment we use for linting the docs differs from the one we
         # use for the live docs site in that we only test a single version of
         # the content.
@@ -85,7 +104,6 @@ jobs:
           git submodule add --force -b $BRANCH -- https://github.com/gravitational/teleport
           cd $GITHUB_WORKSPACE/docs
           echo "{\"versions\": [{\"name\": \"teleport\", \"branch\": \"$BRANCH\", \"deprecated\": false}]}" > $GITHUB_WORKSPACE/docs/config.json
-          yarn install
           yarn build-node
 
       - name: Check spelling
@@ -95,7 +113,8 @@ jobs:
         run: cd $GITHUB_WORKSPACE/docs && yarn markdown-lint
 
       - name: Test the docs build
-        run: cd $GITHUB_WORKSPACE/docs && yarn install && yarn build
+        working-directory: docs
+        run: yarn build
 
   stylecheck:
     name: Lint docs prose style


### PR DESCRIPTION
The `Lint (Docs)` GitHub Actions workflow spends the most time installing NodeJS dependencies. Cache these dependencies across workflow runs to reduce runtime. Use the `actions/cache` workflow and add configuration based on the workflow's documentation for Yarn.