### PR TITLE
Extend resource access request validation checks

### DIFF
--- a/lib/services/access_request_test.go
+++ b/lib/services/access_request_test.go
@@ -2158,7 +2158,7 @@ func (mcg mockClusterGetter) GetRemoteCluster(ctx context.Context, clusterName s
 	return nil, trace.NotFound("remote cluster %q was not found", clusterName)
 }
 
-func TestValidateDuplicateRequestedResources(t *testing.T) {
+func TestValidateResourceRequestSizeLimits(t *testing.T) {
 	g := &mockGetter{
 		roles:       make(map[string]types.Role),
 		userStates:  make(map[string]*userloginstate.UserLoginState),
@@ -2220,6 +2220,17 @@ func TestValidateDuplicateRequestedResources(t *testing.T) {
 	require.Len(t, req.GetRequestedResourceIDs(), 2)
 	require.Equal(t, "/someCluster/node/resource1", types.ResourceIDToString(req.GetRequestedResourceIDs()[0]))
 	require.Equal(t, "/someCluster/node/resource2", types.ResourceIDToString(req.GetRequestedResourceIDs()[1]))
+
+	var requestedResourceIDs []types.ResourceID
+	for i := 0; i < 200; i++ {
+		requestedResourceIDs = append(requestedResourceIDs, types.ResourceID{
+			ClusterName: "someCluster",
+			Kind:        "node",
+			Name:        "resource" + strconv.Itoa(i),
+		})
+	}
+	req.SetRequestedResourceIDs(requestedResourceIDs)
+	require.ErrorContains(t, ValidateAccessRequestForUser(context.Background(), clock, g, req, identity, ExpandVars(true)), "access request exceeds maximum length")
 }
 
 func TestValidateAccessRequestClusterNames(t *testing.T) {


### PR DESCRIPTION
In #46780 we put a cap on the total number of resources that can be requested in a single request, which helps avoid situations where a large access request can exceed resource size limits and break request listing.

This change expands on the validations by also checking that the sum of the lengths of all of the requested IDs stays below a reasonable limit.