### PR TITLE
[v17] ha-autoscale-cluster: Source unit file environment variables from /etc/default/teleport

### DIFF
--- a/assets/aws/files/system/teleport-proxy-acm.service
+++ b/assets/aws/files/system/teleport-proxy-acm.service
@@ -11,8 +11,6 @@ Restart=always
 RestartSec=5
 RuntimeDirectory=teleport
 EnvironmentFile=-/etc/default/teleport
-# TODO(gus): REMOVE IN 17.0.0 - /etc/default/teleport should be used instead
-EnvironmentFile=/etc/teleport.d/conf
 ExecStartPre=/usr/local/bin/teleport-ssm-get-token
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3000 --pid-file=/run/teleport/teleport.pid
 # systemd before 239 needs an absolute path

--- a/assets/aws/files/system/teleport-proxy.service
+++ b/assets/aws/files/system/teleport-proxy.service
@@ -11,8 +11,6 @@ Restart=always
 RestartSec=5
 RuntimeDirectory=teleport
 EnvironmentFile=-/etc/default/teleport
-# TODO(gus): REMOVE IN 17.0.0 - /etc/default/teleport should be used instead
-EnvironmentFile=/etc/teleport.d/conf
 ExecStartPre=/usr/local/bin/teleport-ssm-get-token
 ExecStartPre=/bin/aws s3 sync s3://${TELEPORT_S3_BUCKET}/live/${TELEPORT_DOMAIN_NAME} /var/lib/teleport
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3000 --pid-file=/run/teleport/teleport.pid

--- a/examples/aws/terraform/ha-autoscale-cluster/proxy-user-data.tpl
+++ b/examples/aws/terraform/ha-autoscale-cluster/proxy-user-data.tpl
@@ -14,3 +14,8 @@ TELEPORT_ENABLE_POSTGRES=${enable_postgres_listener}
 USE_ACM=${use_acm}
 USE_TLS_ROUTING=${use_tls_routing}
 EOF
+cat >>/etc/default/teleport <<EOF
+EC2_REGION=${region}
+TELEPORT_DOMAIN_NAME=${domain_name}
+TELEPORT_S3_BUCKET=${s3_bucket}
+EOF


### PR DESCRIPTION
Backport #48040 to branch/v17

changelog: Teleport AMIs no longer source `/etc/teleport.d/conf` in the Proxy Service systemd unit. Use `/etc/default/teleport` if you want to set Proxy Service environment variables.
