### PR TITLE
Disable server-side TLS session tickets

### DIFF
--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -1098,7 +1098,8 @@ func (t *TestTLSServer) CloneClient(tt *testing.T, clt *authclient.Client) *auth
 	// shared between all clients that use the same TLS config.
 	// Reusing the cache will skip the TLS handshake and may introduce a weird
 	// behavior in tests.
-	if !tlsConfig.SessionTicketsDisabled {
+	if tlsConfig.ClientSessionCache != nil {
+		tlsConfig = tlsConfig.Clone()
 		tlsConfig.ClientSessionCache = tls.NewLRUClientSessionCache(utils.DefaultLRUCapacity)
 	}
 

--- a/lib/utils/tls.go
+++ b/lib/utils/tls.go
@@ -43,6 +43,11 @@ func SetupTLSConfig(config *tls.Config, cipherSuites []uint16) {
 		config.CipherSuites = cipherSuites
 	}
 
+	// pre-v17 Teleport uses a client ticket cache, which doesn't play well with
+	// verification (both client- and server-side) when using dynamic
+	// credentials and CAs (in v17+ Teleport)
+	config.SessionTicketsDisabled = true
+
 	config.MinVersion = tls.VersionTLS12
 }
 


### PR DESCRIPTION
After #44882 , Teleport 17+ will no longer restart after changing host CAs and reissuing credentials; as part of #44882, the client-side TLS session resumption machinery was disabled (it wouldn't really work with how Teleport uses internal services anyway). This PR disables server-side TLS session resumption so that v16 (and earlier, but that's not relevant) clients will continue to play well with v17 servers at all times during and after a CA rotation.