### PR TITLE
[v17] Remove deprecated grpc-js `start()` method calls

### DIFF
--- a/web/packages/teleterm/src/services/tshdEvents/index.ts
+++ b/web/packages/teleterm/src/services/tshdEvents/index.ts
@@ -85,8 +85,6 @@ async function createServer(
           return logger.error(error.message);
         }
 
-        server.start();
-
         const resolvedAddress = requestedAddress.startsWith('tcp:')
           ? `localhost:${port}`
           : requestedAddress;

--- a/web/packages/teleterm/src/sharedProcess/sharedProcess.ts
+++ b/web/packages/teleterm/src/sharedProcess/sharedProcess.ts
@@ -89,8 +89,6 @@ async function initializeServer(
       if (error) {
         return logger.error(error.message);
       }
-
-      server.start();
     });
   } catch (e) {
     logger.error('Could not start shared server', e);


### PR DESCRIPTION
Backport #48114 to branch/v17