### PR TITLE
Clean up spacing in login modal in Connect

### DIFF
--- a/web/packages/design/src/index.ts
+++ b/web/packages/design/src/index.ts
@@ -31,7 +31,7 @@ import ButtonLink from './ButtonLink';
 import { ButtonWithMenu } from './ButtonWithMenu';
 import Card from './Card';
 import CardSuccess, { CardSuccessLogin } from './CardSuccess';
-import Indicator from './Indicator';
+import { Indicator } from './Indicator';
 import Input from './Input';
 import Label from './Label';
 import LabelInput from './LabelInput';

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterAdd/ClusterAdd.story.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterAdd/ClusterAdd.story.tsx
@@ -24,7 +24,7 @@ import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvi
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
 
-import { dialogCss } from '../ClusterConnect';
+import { dialogCss } from '../spacing';
 
 import { ClusterAdd } from './ClusterAdd';
 

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterAdd/ClusterAdd.story.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterAdd/ClusterAdd.story.tsx
@@ -16,11 +16,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
+
+import Dialog from 'design/Dialog';
 
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
+
+import { dialogCss } from '../ClusterConnect';
 
 import { ClusterAdd } from './ClusterAdd';
 
@@ -33,11 +37,13 @@ export default {
 export const Story = () => {
   return (
     <MockAppContextProvider appContext={getMockAppContext()}>
-      <ClusterAdd
-        prefill={{ clusterAddress: undefined }}
-        onSuccess={() => {}}
-        onCancel={() => {}}
-      />
+      <Wrapper>
+        <ClusterAdd
+          prefill={{ clusterAddress: undefined }}
+          onSuccess={() => {}}
+          onCancel={() => {}}
+        />
+      </Wrapper>
     </MockAppContextProvider>
   );
 };
@@ -45,11 +51,13 @@ export const Story = () => {
 export const WithPrefill = () => {
   return (
     <MockAppContextProvider appContext={getMockAppContext()}>
-      <ClusterAdd
-        prefill={{ clusterAddress: 'foo.example.com:3080' }}
-        onSuccess={() => {}}
-        onCancel={() => {}}
-      />
+      <Wrapper>
+        <ClusterAdd
+          prefill={{ clusterAddress: 'foo.example.com:3080' }}
+          onSuccess={() => {}}
+          onCancel={() => {}}
+        />
+      </Wrapper>
     </MockAppContextProvider>
   );
 };
@@ -62,11 +70,13 @@ export const ErrorOnSubmit = () => {
           Promise.reject(new Error('Oops, something went wrong.')),
       })}
     >
-      <ClusterAdd
-        prefill={{ clusterAddress: undefined }}
-        onSuccess={() => {}}
-        onCancel={() => {}}
-      />
+      <Wrapper>
+        <ClusterAdd
+          prefill={{ clusterAddress: undefined }}
+          onSuccess={() => {}}
+          onCancel={() => {}}
+        />
+      </Wrapper>
     </MockAppContextProvider>
   );
 };
@@ -81,3 +91,9 @@ function getMockAppContext(
     args.addRootCluster || (() => Promise.resolve(makeRootCluster()));
   return appContext;
 }
+
+const Wrapper = ({ children }: PropsWithChildren) => (
+  <Dialog dialogCss={dialogCss} open>
+    {children}
+  </Dialog>
+);

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterAdd/ClusterAdd.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterAdd/ClusterAdd.tsx
@@ -16,9 +16,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import * as Alerts from 'design/Alert';
-import { Box, ButtonPrimary, ButtonSecondary, H2 } from 'design';
+import { Box, Flex, ButtonPrimary, ButtonSecondary, H2 } from 'design';
 import FieldInput from 'shared/components/FieldInput';
 import Validation from 'shared/components/Validation';
 import { requiredField } from 'shared/components/Validation/rules';
@@ -26,6 +26,8 @@ import { DialogContent, DialogHeader } from 'design/Dialog';
 import { useAsync } from 'shared/hooks/useAsync';
 
 import { useAppContext } from 'teleterm/ui/appContextProvider';
+
+import { outermostPadding } from '../spacing';
 
 export function ClusterAdd(props: {
   onCancel(): void;
@@ -43,7 +45,7 @@ export function ClusterAdd(props: {
   const [addr, setAddr] = useState(props.prefill.clusterAddress || '');
 
   return (
-    <Box p={4}>
+    <Box px={outermostPadding}>
       <Validation>
         {({ validator }) => (
           <form
@@ -55,9 +57,9 @@ export function ClusterAdd(props: {
             <DialogHeader>
               <H2>Enter cluster address</H2>
             </DialogHeader>
-            <DialogContent mb={2}>
+            <DialogContent mb={0} gap={3}>
               {status === 'error' && (
-                <Alerts.Danger mb={5} details={statusText}>
+                <Alerts.Danger mb={0} details={statusText}>
                   Could not add the cluster
                 </Alerts.Danger>
               )}
@@ -65,15 +67,12 @@ export function ClusterAdd(props: {
                 rule={requiredField('Cluster address is required')}
                 value={addr}
                 autoFocus
+                mb={0}
                 onChange={e => setAddr(e.target.value)}
                 placeholder="teleport.example.com"
               />
-              <Box mt="5">
-                <ButtonPrimary
-                  disabled={status === 'processing'}
-                  mr="3"
-                  type="submit"
-                >
+              <Flex gap={3}>
+                <ButtonPrimary disabled={status === 'processing'} type="submit">
                   Next
                 </ButtonPrimary>
                 <ButtonSecondary
@@ -86,7 +85,7 @@ export function ClusterAdd(props: {
                 >
                   Cancel
                 </ButtonSecondary>
-              </Box>
+              </Flex>
             </DialogContent>
           </form>
         )}

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterConnect.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterConnect.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import Dialog from 'design/Dialog';
 
@@ -26,6 +26,8 @@ import { RootClusterUri } from 'teleterm/ui/uri';
 
 import { ClusterAdd } from './ClusterAdd';
 import { ClusterLogin } from './ClusterLogin';
+
+import type { StyleFunction } from 'styled-components';
 
 export function ClusterConnect(props: { dialog: DialogClusterConnect }) {
   const [createdClusterUri, setCreatedClusterUri] = useState<
@@ -45,11 +47,7 @@ export function ClusterConnect(props: { dialog: DialogClusterConnect }) {
 
   return (
     <Dialog
-      dialogCss={() => ({
-        maxWidth: '480px',
-        width: '100%',
-        padding: '0',
-      })}
+      dialogCss={dialogCss}
       disableEscapeKeyDown={false}
       onClose={props.dialog.onCancel}
       open={true}
@@ -72,3 +70,11 @@ export function ClusterConnect(props: { dialog: DialogClusterConnect }) {
     </Dialog>
   );
 }
+
+type NoExtraProps = Record<string, never>;
+export const dialogCss: StyleFunction<NoExtraProps> = () =>
+  `
+max-width: 480px;
+width: 100%;
+padding: 0;
+`;

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterConnect.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterConnect.tsx
@@ -26,8 +26,7 @@ import { RootClusterUri } from 'teleterm/ui/uri';
 
 import { ClusterAdd } from './ClusterAdd';
 import { ClusterLogin } from './ClusterLogin';
-
-import type { StyleFunction } from 'styled-components';
+import { dialogCss } from './spacing';
 
 export function ClusterConnect(props: { dialog: DialogClusterConnect }) {
   const [createdClusterUri, setCreatedClusterUri] = useState<
@@ -70,11 +69,3 @@ export function ClusterConnect(props: { dialog: DialogClusterConnect }) {
     </Dialog>
   );
 }
-
-type NoExtraProps = Record<string, never>;
-export const dialogCss: StyleFunction<NoExtraProps> = () =>
-  `
-max-width: 480px;
-width: 100%;
-padding: 0;
-`;

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.story.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.story.tsx
@@ -18,7 +18,7 @@
 
 import { FC, PropsWithChildren } from 'react';
 
-import { Box } from 'design';
+import Dialog from 'design/Dialog';
 import {
   Attempt,
   makeErrorAttempt,
@@ -26,6 +26,8 @@ import {
 } from 'shared/hooks/useAsync';
 
 import * as types from 'teleterm/ui/services/clusters/types';
+
+import { dialogCss } from '../ClusterConnect';
 
 import {
   ClusterLoginPresentation,
@@ -320,16 +322,7 @@ export const SsoPrompt = () => {
 };
 
 const TestContainer: FC<PropsWithChildren> = ({ children }) => (
-  <>
-    <span>Bordered box is not part of the component</span>
-    <Box
-      css={`
-        width: 450px;
-        border: 1px solid ${props => props.theme.colors.levels.elevated};
-        background: ${props => props.theme.colors.levels.surface};
-      `}
-    >
+  <Dialog dialogCss={dialogCss} open={true}>
       {children}
-    </Box>
-  </>
+  </Dialog>
 );

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.story.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.story.tsx
@@ -15,59 +15,14 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { makeErrorAttempt, makeProcessingAttempt } from 'shared/hooks/useAsync';
 
-import { FC, PropsWithChildren } from 'react';
-
-import Dialog from 'design/Dialog';
-import {
-  Attempt,
-  makeErrorAttempt,
-  makeProcessingAttempt,
-  makeSuccessAttempt,
-} from 'shared/hooks/useAsync';
-
-import * as types from 'teleterm/ui/services/clusters/types';
-
-import { dialogCss } from '../ClusterConnect';
-
-import {
-  ClusterLoginPresentation,
-  ClusterLoginPresentationProps,
-} from './ClusterLogin';
+import { ClusterLoginPresentation } from './ClusterLogin';
+import { TestContainer, makeProps } from './storyHelpers';
 
 export default {
   title: 'Teleterm/ModalsHost/ClusterLogin',
 };
-
-function makeProps(): ClusterLoginPresentationProps {
-  return {
-    shouldPromptSsoStatus: false,
-    title: 'localhost',
-    loginAttempt: {
-      status: '',
-      statusText: '',
-    } as Attempt<void>,
-    init: () => null,
-    initAttempt: makeSuccessAttempt({
-      localAuthEnabled: true,
-      authProviders: [],
-      type: '',
-      hasMessageOfTheDay: false,
-      allowPasswordless: true,
-      localConnectorName: '',
-      authType: 'local',
-    } as types.AuthSettings),
-    loggedInUserName: null,
-    onCloseDialog: () => null,
-    onAbort: () => null,
-    onLoginWithLocal: () => Promise.resolve<[void, Error]>([null, null]),
-    onLoginWithPasswordless: () => Promise.resolve<[void, Error]>([null, null]),
-    onLoginWithSso: () => null,
-    clearLoginAttempt: () => null,
-    passwordlessLoginState: null,
-    reason: undefined,
-  };
-}
 
 export const LocalOnly = () => {
   const props = makeProps();
@@ -345,9 +300,3 @@ export const HardwareCredentialPromptProcessing = () => {
     </TestContainer>
   );
 };
-
-const TestContainer: FC<PropsWithChildren> = ({ children }) => (
-  <Dialog dialogCss={dialogCss} open={true}>
-    {children}
-  </Dialog>
-);

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.tsx
@@ -18,7 +18,15 @@
 
 import React from 'react';
 import * as Alerts from 'design/Alert';
-import { ButtonIcon, Text, Indicator, Box, H2, ButtonPrimary } from 'design';
+import {
+  ButtonIcon,
+  Text,
+  Indicator,
+  Box,
+  Flex,
+  H2,
+  ButtonPrimary,
+} from 'design';
 import * as Icons from 'design/Icon';
 import { DialogHeader, DialogContent } from 'design/Dialog';
 import { PrimaryAuthType } from 'shared/services';
@@ -26,6 +34,8 @@ import { PrimaryAuthType } from 'shared/services';
 import { AuthSettings } from 'teleterm/ui/services/clusters/types';
 import { ClusterConnectReason } from 'teleterm/ui/services/modals';
 import { getTargetNameFromUri } from 'teleterm/services/tshd/gateway';
+
+import { outermostPadding } from '../spacing';
 
 import LoginForm from './FormLogin';
 import useClusterLogin, { State, Props } from './useClusterLogin';
@@ -58,7 +68,7 @@ export function ClusterLoginPresentation({
 }: ClusterLoginPresentationProps) {
   return (
     <>
-      <DialogHeader px={4} pt={4} mb={0}>
+      <DialogHeader px={outermostPadding}>
         <H2>
           Log in to <b>{title}</b>
         </H2>
@@ -66,19 +76,32 @@ export function ClusterLoginPresentation({
           <Icons.Cross size="medium" />
         </ButtonIcon>
       </DialogHeader>
-      <DialogContent mb={0}>
-        {reason && <Reason reason={reason} />}
+      <DialogContent mb={0} gap={2}>
+        {reason && (
+          <Box px={outermostPadding}>
+            <Reason reason={reason} />
+          </Box>
+        )}
 
         {initAttempt.status === 'error' && (
-          <Box m={4}>
-            <Alerts.Danger details={initAttempt.statusText}>
+          <Flex
+            px={outermostPadding}
+            flexDirection="column"
+            alignItems="flex-start"
+            gap={3}
+          >
+            <Alerts.Danger
+              details={initAttempt.statusText}
+              margin={0}
+              width="100%"
+            >
               Unable to retrieve cluster auth preferences
             </Alerts.Danger>
             <ButtonPrimary onClick={init}>Retry</ButtonPrimary>
-          </Box>
+          </Flex>
         )}
         {initAttempt.status === 'processing' && (
-          <Box textAlign="center" m={4}>
+          <Box px={outermostPadding} textAlign="center">
             <Indicator delay="none" />
           </Box>
         )}
@@ -119,7 +142,7 @@ function Reason({ reason }: { reason: ClusterConnectReason }) {
   const $targetDesc = getTargetDesc(reason);
 
   return (
-    <Text px={4} pt={2} mb={0}>
+    <Text>
       You tried to connect to {$targetDesc} but your session has expired. Please
       log in to refresh the session.
     </Text>

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLoginReason.story.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLoginReason.story.tsx
@@ -15,22 +15,14 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-import { FC, PropsWithChildren } from 'react';
-import { Box } from 'design';
-import { Attempt } from 'shared/hooks/useAsync';
-
-import * as types from 'teleterm/ui/services/clusters/types';
 import {
   appUri,
   makeDatabaseGateway,
   makeKubeGateway,
 } from 'teleterm/services/tshd/testHelpers';
 
-import {
-  ClusterLoginPresentation,
-  ClusterLoginPresentationProps,
-} from './ClusterLogin';
+import { TestContainer, makeProps } from './storyHelpers';
+import { ClusterLoginPresentation } from './ClusterLogin';
 
 export default {
   title: 'Teleterm/ModalsHost/ClusterLogin/Reason',
@@ -99,56 +91,6 @@ export const VnetCertExpired = () => {
     </TestContainer>
   );
 };
-
-function makeProps(): ClusterLoginPresentationProps {
-  return {
-    shouldPromptSsoStatus: false,
-    title: 'localhost',
-    loginAttempt: {
-      status: '',
-      statusText: '',
-    } as Attempt<void>,
-    init: () => null,
-    initAttempt: {
-      status: 'success',
-      statusText: '',
-      data: {
-        localAuthEnabled: true,
-        authProviders: [],
-        type: '',
-        hasMessageOfTheDay: false,
-        allowPasswordless: true,
-        localConnectorName: '',
-        authType: 'local',
-      } as types.AuthSettings,
-    } as const,
-
-    loggedInUserName: null,
-    onCloseDialog: () => null,
-    onAbort: () => null,
-    onLoginWithLocal: () => Promise.resolve<[void, Error]>([null, null]),
-    onLoginWithPasswordless: () => Promise.resolve<[void, Error]>([null, null]),
-    onLoginWithSso: () => null,
-    clearLoginAttempt: () => null,
-    passwordlessLoginState: null,
-    reason: undefined,
-  };
-}
-
-const TestContainer: FC<PropsWithChildren> = ({ children }) => (
-  <>
-    <span>Bordered box is not part of the component</span>
-    <Box
-      css={`
-        width: 450px;
-        border: 1px solid ${props => props.theme.colors.levels.elevated};
-        background: ${props => props.theme.colors.levels.surface};
-      `}
-    >
-      {children}
-    </Box>
-  </>
-);
 
 const dbGateway = makeDatabaseGateway({
   uri: '/gateways/gateway1',

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/FormLocal/FormLocal.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/FormLocal/FormLocal.tsx
@@ -17,7 +17,7 @@
  */
 
 import React, { useState } from 'react';
-import { ButtonPrimary, Box } from 'design';
+import { ButtonPrimary, Flex } from 'design';
 
 import Validation, { Validator } from 'shared/components/Validation';
 import FieldInput from 'shared/components/FieldInput';
@@ -62,7 +62,7 @@ export const FormLocal = ({
   return (
     <Validation>
       {({ validator }) => (
-        <Box as="form">
+        <Flex as="form" flexDirection="column" gap={3}>
           <FieldInput
             ref={usernameInputRef}
             rule={requiredField('Username is required')}
@@ -70,7 +70,7 @@ export const FormLocal = ({
             value={user}
             onChange={e => setUser(e.target.value)}
             placeholder="Username"
-            mb={3}
+            mb={0}
             disabled={isProcessing}
           />
           <FieldInput
@@ -81,23 +81,24 @@ export const FormLocal = ({
             onChange={e => setPass(e.target.value)}
             type="password"
             placeholder="Password"
-            mb={3}
+            mb={0}
             width="100%"
             disabled={isProcessing}
           />
-          <LinearProgress absolute={false} hidden={!isProcessing} />
-          <ButtonPrimary
-            width="100%"
-            mt={2}
-            mb={1}
-            type="submit"
-            size="large"
-            onClick={e => onLoginClick(e, validator)}
-            disabled={isProcessing}
-          >
-            Sign In
-          </ButtonPrimary>
-        </Box>
+          <Flex flexDirection="column" gap={2}>
+            <LinearProgress absolute={false} hidden={!isProcessing} />
+            <ButtonPrimary
+              width="100%"
+              mb={0}
+              type="submit"
+              size="large"
+              onClick={e => onLoginClick(e, validator)}
+              disabled={isProcessing}
+            >
+              Sign In
+            </ButtonPrimary>
+          </Flex>
+        </Flex>
       )}
     </Validation>
   );

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/FormLogin.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/FormLogin.tsx
@@ -82,7 +82,10 @@ export default function LoginForm(props: Props) {
   if (!localAuthEnabled) {
     return (
       <FlexBordered px={outermostPadding}>
-        <Alerts.Danger details="The ability to login has not been enabled. Please contact your system administrator for more information.">
+        <Alerts.Danger
+          m={0}
+          details="The ability to login has not been enabled. Please contact your system administrator for more information."
+        >
           Login has not been enabled
         </Alerts.Danger>
       </FlexBordered>

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/FormLogin.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/FormLogin.tsx
@@ -24,6 +24,8 @@ import { Attempt } from 'shared/hooks/useAsync';
 
 import * as types from 'teleterm/ui/services/clusters/types';
 
+import { outermostPadding } from '../../spacing';
+
 import { PromptPasswordless } from './PromptPasswordless';
 import PromptSsoStatus from './PromptSsoStatus';
 import { FormPasswordless } from './FormPasswordless';
@@ -46,12 +48,18 @@ export default function LoginForm(props: Props) {
 
   if (passwordlessLoginState) {
     return (
-      <PromptPasswordless onCancel={onAbort} {...passwordlessLoginState} />
+      <OutermostPadding>
+        <PromptPasswordless onCancel={onAbort} {...passwordlessLoginState} />
+      </OutermostPadding>
     );
   }
 
   if (shouldPromptSsoStatus) {
-    return <PromptSsoStatus onCancel={onAbort} />;
+    return (
+      <OutermostPadding>
+        <PromptSsoStatus onCancel={onAbort} />
+      </OutermostPadding>
+    );
   }
 
   const ssoEnabled = authProviders?.length > 0;
@@ -60,9 +68,9 @@ export default function LoginForm(props: Props) {
   // and display sso providers if any.
   if (!localAuthEnabled && ssoEnabled) {
     return (
-      <FlexBordered p={4} pb={5}>
+      <FlexBordered px={outermostPadding}>
         {loginAttempt.status === 'error' && (
-          <Alerts.Danger m={5} mb={0} details={loginAttempt.statusText}>
+          <Alerts.Danger m={0} details={loginAttempt.statusText}>
             Could not log in
           </Alerts.Danger>
         )}
@@ -73,7 +81,7 @@ export default function LoginForm(props: Props) {
 
   if (!localAuthEnabled) {
     return (
-      <FlexBordered p={4}>
+      <FlexBordered px={outermostPadding}>
         <Alerts.Danger details="The ability to login has not been enabled. Please contact your system administrator for more information.">
           Login has not been enabled
         </Alerts.Danger>
@@ -83,9 +91,16 @@ export default function LoginForm(props: Props) {
 
   // Everything below requires local auth to be enabled.
   return (
+    // No extra padding so that StepSlider children can span the whole width of the parent
+    // component. This way when they slide, they slide from one side to the other, without
+    // disappearing behind padding.
     <FlexBordered>
       {loginAttempt.status === 'error' && (
-        <Alerts.Danger m={4} mb={0} details={loginAttempt.statusText}>
+        <Alerts.Danger
+          mx={outermostPadding}
+          my={0}
+          details={loginAttempt.statusText}
+        >
           Could not log in
         </Alerts.Danger>
       )}
@@ -130,8 +145,13 @@ const Primary = ({
   }
 
   return (
-    <Box ref={refCallback} px={4} py={3}>
-      <Box mb={3}>{$primary}</Box>
+    <Flex
+      px={outermostPadding}
+      flexDirection="column"
+      gap={2}
+      ref={refCallback}
+    >
+      <Box>{$primary}</Box>
       {otherOptionsAvailable && (
         <Box textAlign="center">
           <ButtonText
@@ -146,7 +166,7 @@ const Primary = ({
           </ButtonText>
         </Box>
       )}
-    </Box>
+    </Flex>
   );
 };
 
@@ -207,20 +227,24 @@ const Secondary = ({
   }
 
   return (
-    <Box ref={refCallback} px={4} py={3}>
-      {$secondary}
-      <Box pt={3} textAlign="center">
-        <ButtonText
-          disabled={otherProps.loginAttempt.status === 'processing'}
-          onClick={() => {
-            otherProps.clearLoginAttempt();
-            prev();
-          }}
-        >
-          Back
-        </ButtonText>
-      </Box>
-    </Box>
+    <Flex
+      px={outermostPadding}
+      flexDirection="column"
+      gap={2}
+      ref={refCallback}
+    >
+      <div>{$secondary}</div>
+      <ButtonText
+        alignSelf="center"
+        disabled={otherProps.loginAttempt.status === 'processing'}
+        onClick={() => {
+          otherProps.clearLoginAttempt();
+          prev();
+        }}
+      >
+        Back
+      </ButtonText>
+    </Flex>
   );
 };
 
@@ -239,9 +263,11 @@ const Divider = () => (
   </Flex>
 );
 
-const FlexBordered = props => (
-  <Flex justifyContent="center" flexDirection="column" {...props} />
-);
+const FlexBordered = styled(Flex).attrs({
+  justifyContent: 'center',
+  flexDirection: 'column',
+  gap: 3,
+})``;
 
 const StyledOr = styled.div`
   background: ${props => props.theme.colors.levels.surface};
@@ -272,3 +298,5 @@ export type Props = types.AuthSettings & {
   onLogin(username: string, password: string): void;
   autoFocus?: boolean;
 };
+
+const OutermostPadding = styled(Box).attrs({ px: outermostPadding })``;

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/FormSso/FormSso.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/FormSso/FormSso.tsx
@@ -15,8 +15,6 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-import React from 'react';
 import { Box } from 'design';
 
 import SSOButtonList from './SsoButtons';

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/FormSso/SsoButtons.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/FormSso/SsoButtons.tsx
@@ -16,8 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-import { Box, Text } from 'design';
+import { Flex, Text } from 'design';
 import ButtonSso, { guessProviderType } from 'shared/components/ButtonSso';
 
 import * as types from 'teleterm/ui/services/clusters/types';
@@ -33,14 +32,12 @@ const SSOBtnList = ({
     let { name, type, displayName } = item;
     const title = displayName || `${prefixText} ${name}`;
     const ssoType = guessProviderType(title, type as types.AuthProviderType);
-    const isLastItem = providers.length - 1 === index;
     return (
       <ButtonSso
         key={index}
         title={title}
         ssoType={ssoType}
         disabled={isDisabled}
-        mb={isLastItem ? 0 : 3}
         autoFocus={index === 0 && autoFocus}
         onClick={e => {
           e.preventDefault();
@@ -54,7 +51,11 @@ const SSOBtnList = ({
     return <Text typography="h3">You have no SSO providers configured</Text>;
   }
 
-  return <Box>{$btns}</Box>;
+  return (
+    <Flex flexDirection="column" gap={3}>
+      {$btns}
+    </Flex>
+  );
 };
 
 type Props = {

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/PromptPasswordless/PromptPasswordless.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/PromptPasswordless/PromptPasswordless.tsx
@@ -36,7 +36,7 @@ type Props = PasswordlessLoginState & {
 export function PromptPasswordless(props: Props) {
   const { prompt } = props;
   return (
-    <Box minHeight="40px" p={4}>
+    <Box minHeight="40px">
       {prompt === 'credential' && <PromptCredential {...props} />}
       {(prompt === 'tap' || prompt === 'retap') && <PromptTouch {...props} />}
       {prompt === 'pin' && <PromptPin {...props} />}

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/PromptSsoStatus/PromptSsoStatus.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/PromptSsoStatus/PromptSsoStatus.tsx
@@ -22,7 +22,7 @@ import { LinearProgress } from 'teleterm/ui/components/LinearProgress';
 
 export default function PromptSsoStatus(props: Props) {
   return (
-    <Flex p={4} gap={4} flexDirection="column" alignItems="flex-start">
+    <Flex gap={4} flexDirection="column" alignItems="flex-start">
       <Box style={{ position: 'relative' }}>
         <Text bold mb={2} textAlign="center">
           Please follow the steps in the new browser window to authenticate.

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/storyHelpers.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/storyHelpers.tsx
@@ -18,9 +18,6 @@
 
 import { FC, PropsWithChildren } from 'react';
 import Dialog from 'design/Dialog';
-import { Attempt } from 'shared/hooks/useAsync';
-
-import * as types from 'teleterm/ui/services/clusters/types';
 
 import { dialogCss } from '../spacing';
 
@@ -39,7 +36,8 @@ export function makeProps(): ClusterLoginPresentationProps {
     loginAttempt: {
       status: '',
       statusText: '',
-    } as Attempt<void>,
+      data: undefined,
+    },
     init: () => null,
     initAttempt: {
       status: 'success',
@@ -47,13 +45,12 @@ export function makeProps(): ClusterLoginPresentationProps {
       data: {
         localAuthEnabled: true,
         authProviders: [],
-        type: '',
         hasMessageOfTheDay: false,
         allowPasswordless: true,
         localConnectorName: '',
         authType: 'local',
-      } as types.AuthSettings,
-    } as const,
+      },
+    },
 
     loggedInUserName: null,
     onCloseDialog: () => null,

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/storyHelpers.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/storyHelpers.tsx
@@ -22,12 +22,12 @@ import { Attempt } from 'shared/hooks/useAsync';
 
 import * as types from 'teleterm/ui/services/clusters/types';
 
-import { dialogCss } from '../ClusterConnect';
+import { dialogCss } from '../spacing';
 
 import { ClusterLoginPresentationProps } from './ClusterLogin';
 
 export const TestContainer: FC<PropsWithChildren> = ({ children }) => (
-  <Dialog dialogCss={dialogCss} open={true}>
+  <Dialog dialogCss={dialogCss} open>
     {children}
   </Dialog>
 );

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/storyHelpers.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/storyHelpers.tsx
@@ -1,0 +1,68 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { FC, PropsWithChildren } from 'react';
+import Dialog from 'design/Dialog';
+import { Attempt } from 'shared/hooks/useAsync';
+
+import * as types from 'teleterm/ui/services/clusters/types';
+
+import { dialogCss } from '../ClusterConnect';
+
+import { ClusterLoginPresentationProps } from './ClusterLogin';
+
+export const TestContainer: FC<PropsWithChildren> = ({ children }) => (
+  <Dialog dialogCss={dialogCss} open={true}>
+    {children}
+  </Dialog>
+);
+
+export function makeProps(): ClusterLoginPresentationProps {
+  return {
+    shouldPromptSsoStatus: false,
+    title: 'localhost',
+    loginAttempt: {
+      status: '',
+      statusText: '',
+    } as Attempt<void>,
+    init: () => null,
+    initAttempt: {
+      status: 'success',
+      statusText: '',
+      data: {
+        localAuthEnabled: true,
+        authProviders: [],
+        type: '',
+        hasMessageOfTheDay: false,
+        allowPasswordless: true,
+        localConnectorName: '',
+        authType: 'local',
+      } as types.AuthSettings,
+    } as const,
+
+    loggedInUserName: null,
+    onCloseDialog: () => null,
+    onAbort: () => null,
+    onLoginWithLocal: () => Promise.resolve<[void, Error]>([null, null]),
+    onLoginWithPasswordless: () => Promise.resolve<[void, Error]>([null, null]),
+    onLoginWithSso: () => null,
+    clearLoginAttempt: () => null,
+    passwordlessLoginState: null,
+    reason: undefined,
+  };
+}

--- a/web/packages/teleterm/src/ui/ClusterConnect/spacing.ts
+++ b/web/packages/teleterm/src/ui/ClusterConnect/spacing.ts
@@ -1,0 +1,38 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import type { StyleFunction } from 'styled-components';
+
+/**
+ * outermostPadding is the padding used in the visually outermost layer of ClusterConnect.
+ * Components inside should use spacing of value 3 or lower, otherwise individual elements might
+ * appear too far from each other.
+ */
+export const outermostPadding = 4;
+
+type NoExtraProps = Record<string, never>;
+/**
+ * dialogCss needs to avoid setting horizontal padding. This is so that child StepSlider components
+ * in ClusterLogin are able to span the whole width of the parent component. This way when they
+ * slide, they slide from one slide to another, without disappearing behind padding.
+ */
+export const dialogCss: StyleFunction<NoExtraProps> = props =>
+  `
+max-width: 480px;
+width: 100%;
+padding: ${props.theme.space[outermostPadding]}px 0 ${props.theme.space[outermostPadding]}px 0;
+`;


### PR DESCRIPTION
Closes #48059.

The spacing in `ClusterConnect` was a little bit all over the place with individual elements setting their own paddings and margins. I tried to limit it as much as possible, only to discover that it's not as simple as setting a uniform padding in `dialogCss` in `ClusterConnect`.

That's because the login modal utilizes `StepSlider` which has individual children that slide from one side to another. In order for the animation to look seamless, those individual children need to occupy the whole width of the parent component. Otherwise they'll slide within the boundaries set by the padding of the parent, as seen in the video below.

<details>
<summary>An example of how padding affects animation</summary>

In the first implementation, the whole form slides from side to side. In the other implementation, it hides behind the parent padding when going offscreen.

https://github.com/user-attachments/assets/25b6cc9e-ea04-46e7-9ad6-8da49efb7f98

</details>

Unfortunately, a lot of our design elements set margins by themselves which [is not useful](https://every-layout.dev/layouts/stack/#the-problem) when you want to set gaps uniformly with `gap`. This means that despite switching a lot of places to use `<Flex gap={…}>`, I still had to specify things like `m={0}` in a lot of places.

In addition, I tried to curb the spacing a little bit, this is most clearly shown when comparing `ClusterAdd` to the previous implementation. The idea is that if the outermost padding is set to 4, components within the dialog should not use this spacing value (or bigger) to space out elements, especially when it comes to vertical spacing. Otherwise it can lead to situations where an element is closer to a modal border than it is to another element in the modal, making those two elements appear disjointed and out of place. Spacing should be used to group elements meant to appear together.

## Demo

In the first tab there's a version from master, in the second tab there's the version from this branch.

https://github.com/user-attachments/assets/2e2ddf62-2ef5-4675-a40b-bb89bef0a01c

