### PR TITLE
Fix discover reporting for static matchers

### DIFF
--- a/lib/srv/discovery/status.go
+++ b/lib/srv/discovery/status.go
@@ -45,6 +45,12 @@ import (
 // - AWS Sync (TAG) status
 // - AWS EC2 Auto Discover status
 func (s *Server) updateDiscoveryConfigStatus(discoveryConfigName string) {
+	// Static configurations (ie those in `teleport.yaml/discovery_config.<cloud>.matchers`) do not have a DiscoveryConfig resource.
+	// Those are discarded because there's no Status to update.
+	if discoveryConfigName == "" {
+		return
+	}
+
 	discoveryConfigStatus := discoveryconfig.Status{
 		State:                          discoveryconfigv1.DiscoveryConfigState_DISCOVERY_CONFIG_STATE_SYNCING.String(),
 		LastSyncTime:                   s.clock.Now(),


### PR DESCRIPTION
Discovery Service now reports the status of the auto enrollment flows when the matchers come from a DiscoveryConfig resource.

For static matchers, those in
`teleport.yaml/discovery_service.<cloud>.<matcher>` there's no status to write to.


Fixes: https://github.com/gravitational/teleport/issues/47171