### PR TITLE
[v14] Remove expirations for managed users

### DIFF
--- a/integration/hostuser_test.go
+++ b/integration/hostuser_test.go
@@ -444,6 +444,94 @@ func TestRootHostUsers(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("Test expiration removal", func(t *testing.T) {
+		expiredUser := "expired-user"
+		backendExpiredUser := "backend-expired-user"
+		t.Cleanup(func() { cleanupUsersAndGroups([]string{expiredUser, backendExpiredUser}, []string{"test-group"}) })
+
+		defaultBackend, err := srv.DefaultHostUsersBackend()
+		require.NoError(t, err)
+
+		backend := &hostUsersBackendWithExp{HostUsersBackend: defaultBackend}
+		users := srv.NewHostUsers(context.Background(), presence, "host_uuid", srv.WithHostUsersBackend(backend))
+
+		// Make sure the backend actually creates expired users
+		err = backend.CreateUser("backend-expired-user", nil, "", "", "")
+		require.NoError(t, err)
+
+		hasExpirations, _, err := host.UserHasExpirations(backendExpiredUser)
+		require.NoError(t, err)
+		require.True(t, hasExpirations)
+
+		// Upsert a new user which should have the expirations removed
+		_, err = users.UpsertUser(expiredUser, services.HostUsersInfo{
+			Mode: types.CreateHostUserMode_HOST_USER_MODE_KEEP,
+		})
+		require.NoError(t, err)
+
+		hasExpirations, _, err = host.UserHasExpirations(expiredUser)
+		require.NoError(t, err)
+		require.False(t, hasExpirations)
+
+		// Expire existing user so we can test that updates also remove expirations
+		expireUser := func(username string) error {
+			chageBin, err := exec.LookPath("chage")
+			require.NoError(t, err)
+
+			cmd := exec.Command(chageBin, "-E", "1", "-I", "1", "-M", "1", username)
+			return cmd.Run()
+		}
+		require.NoError(t, expireUser(expiredUser))
+		hasExpirations, _, err = host.UserHasExpirations(expiredUser)
+		require.NoError(t, err)
+		require.True(t, hasExpirations)
+
+		// Update user without any changes
+		_, err = users.UpsertUser(expiredUser, services.HostUsersInfo{
+			Mode: types.CreateHostUserMode_HOST_USER_MODE_KEEP,
+		})
+		require.NoError(t, err)
+
+		hasExpirations, _, err = host.UserHasExpirations(expiredUser)
+		require.NoError(t, err)
+		require.False(t, hasExpirations)
+
+		// Reinstate expirations again
+		require.NoError(t, expireUser(expiredUser))
+		hasExpirations, _, err = host.UserHasExpirations(expiredUser)
+		require.NoError(t, err)
+		require.True(t, hasExpirations)
+
+		// Update user with changes
+		_, err = users.UpsertUser(expiredUser, services.HostUsersInfo{
+			Mode:   types.CreateHostUserMode_HOST_USER_MODE_KEEP,
+			Groups: []string{"test-group"},
+		})
+		require.NoError(t, err)
+
+		hasExpirations, _, err = host.UserHasExpirations(expiredUser)
+		require.NoError(t, err)
+		require.False(t, hasExpirations)
+	})
+}
+
+type hostUsersBackendWithExp struct {
+	srv.HostUsersBackend
+}
+
+func (u *hostUsersBackendWithExp) CreateUser(name string, groups []string, home, uid, gid string) error {
+	if err := u.HostUsersBackend.CreateUser(name, groups, home, uid, gid); err != nil {
+		return trace.Wrap(err)
+	}
+
+	chageBin, err := exec.LookPath("chage")
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	cmd := exec.Command(chageBin, "-E", "1", "-I", "1", "-M", "1", name)
+	return cmd.Run()
 }
 
 func TestRootLoginAsHostUser(t *testing.T) {

--- a/lib/srv/usermgmt_test.go
+++ b/lib/srv/usermgmt_test.go
@@ -181,6 +181,10 @@ func (*testHostUserBackend) CheckSudoers(contents []byte) error {
 	return errors.New("invalid")
 }
 
+func (*testHostUserBackend) RemoveExpirations(user string) error {
+	return nil
+}
+
 // WriteSudoersFile implements HostUsersBackend
 func (tm *testHostUserBackend) WriteSudoersFile(user string, entries []byte) error {
 	entry := strings.TrimSpace(string(entries))

--- a/lib/utils/host/hostusers.go
+++ b/lib/utils/host/hostusers.go
@@ -17,6 +17,7 @@ limitations under the License.
 package host
 
 import (
+	"bufio"
 	"bytes"
 	"errors"
 	"os/exec"
@@ -152,6 +153,82 @@ func GetAllUsers() ([]string, int, error) {
 		}
 	}
 	return users, -1, nil
+}
+
+// UserHasExpirations determines if the given username has an expired password, inactive password, or expired account
+// by parsing the output of 'chage -l <username>'.
+func UserHasExpirations(username string) (bool bool, exitCode int, err error) {
+	chageBin, err := exec.LookPath("chage")
+	if err != nil {
+		return false, -1, trace.NotFound("cannot find chage binary: %s", err)
+	}
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	cmd := exec.Command(chageBin, "-l", username)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		return false, cmd.ProcessState.ExitCode(), trace.WrapWithMessage(err, "running chage: %s", stderr.String())
+	}
+
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			// ignore empty lines
+			continue
+		}
+
+		key, value, validLine := strings.Cut(line, ":")
+		if !validLine {
+			return false, -1, trace.Errorf("chage output invalid")
+		}
+
+		if strings.TrimSpace(value) == "never" {
+			continue
+		}
+
+		switch strings.TrimSpace(key) {
+		case "Password expires", "Password inactive", "Account expires":
+			return true, 0, nil
+		}
+	}
+
+	return false, cmd.ProcessState.ExitCode(), nil
+}
+
+// RemoveUserExpirations uses chage to remove any future or past expirations associated with the given username. It also uses usermod to remove any account locks that may have been placed.
+func RemoveUserExpirations(username string) (exitCode int, err error) {
+	chageBin, err := exec.LookPath("chage")
+	if err != nil {
+		return -1, trace.NotFound("cannot find chage binary: %s", err)
+	}
+
+	usermodBin, err := exec.LookPath("usermod")
+	if err != nil {
+		return -1, trace.NotFound("cannot find usermod binary: %s", err)
+	}
+
+	// remove all expirations from user
+	// chage -E -1 -I -1 <username>
+	cmd := exec.Command(chageBin, "-E", "-1", "-I", "-1", "-M", "-1", username)
+	var errs []error
+	if err := cmd.Run(); err != nil {
+		errs = append(errs, trace.Wrap(err, "removing expirations with chage"))
+	}
+
+	// unlock user password if locked
+	cmd = exec.Command(usermodBin, "-U", username)
+	if err := cmd.Run(); err != nil {
+		errs = append(errs, trace.Wrap(err, "removing lock with usermod"))
+	}
+
+	if len(errs) > 0 {
+		return cmd.ProcessState.ExitCode(), trace.NewAggregate(errs...)
+	}
+
+	return cmd.ProcessState.ExitCode(), nil
 }
 
 var ErrInvalidSudoers = errors.New("visudo: invalid sudoers file")


### PR DESCRIPTION
Backport #47774 to branch/v14

changelog: Updated host user creation to prevent local password expiration policies from affecting Teleport managed users.
