### PR TITLE
WebShared: Update how request checkout handles kube resource related errors

### DIFF
--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/KubeNamespaceSelector.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/KubeNamespaceSelector.tsx
@@ -24,8 +24,6 @@ import { ActionMeta } from 'react-select';
 import { Option } from 'shared/components/Select';
 import { FieldSelectAsync } from 'shared/components/FieldSelect';
 
-import { requiredField } from 'shared/components/Validation/rules';
-
 import { CheckableOptionComponent } from '../CheckableOption';
 
 import { PendingListItem, PendingKubeResourceItem } from './RequestCheckout';
@@ -38,7 +36,6 @@ export function KubeNamespaceSelector({
   savedResourceItems,
   toggleResource,
   bulkToggleKubeResources,
-  namespaceRequired,
 }: {
   kubeClusterItem: PendingListItem;
   fetchKubeNamespaces(p: KubeNamespaceRequest): Promise<string[]>;
@@ -48,7 +45,6 @@ export function KubeNamespaceSelector({
     resources: PendingKubeResourceItem[],
     resource: PendingListItem
   ) => void;
-  namespaceRequired: boolean;
 }) {
   // Flag is used to determine if we need to perform batch action
   // eg: When menu is open, we want to apply changes only after
@@ -144,7 +140,7 @@ export function KubeNamespaceSelector({
   return (
     <Box width="100%" mb={-3}>
       <StyledSelect
-        label={`Namespaces${namespaceRequired ? ' (required)' : ''}:`}
+        label={`Namespaces:`}
         inputId={kubeClusterItem.id}
         width="100%"
         placeholder="Start typing a namespace and press enter"
@@ -162,11 +158,6 @@ export function KubeNamespaceSelector({
         onChange={handleChange}
         value={selectedOpts}
         menuPosition="fixed" /* required to render dropdown out of its row */
-        rule={
-          namespaceRequired
-            ? requiredField('namespace selection required')
-            : undefined
-        }
         initOptionsOnMenuOpen={(opts: Option[]) => setInitOptions(opts)}
         defaultOptions={initOptions}
       />

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/KubeNamespaceSelector.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/KubeNamespaceSelector.tsx
@@ -143,7 +143,7 @@ export function KubeNamespaceSelector({
   return (
     <Box width="100%" mb={-3}>
       <StyledSelect
-        label={`Namespaces:`}
+        label={`Namespaces`}
         inputId={kubeClusterItem.id}
         width="100%"
         placeholder="Start typing a namespace and press enter"

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/KubeNamespaceSelector.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/KubeNamespaceSelector.tsx
@@ -34,13 +34,11 @@ export function KubeNamespaceSelector({
   kubeClusterItem,
   fetchKubeNamespaces,
   savedResourceItems,
-  toggleResource,
   bulkToggleKubeResources,
 }: {
   kubeClusterItem: PendingListItem;
   fetchKubeNamespaces(p: KubeNamespaceRequest): Promise<string[]>;
   savedResourceItems: PendingListItem[];
-  toggleResource: (resource: PendingListItem) => void;
   bulkToggleKubeResources: (
     resources: PendingKubeResourceItem[],
     resource: PendingListItem
@@ -83,13 +81,18 @@ export function KubeNamespaceSelector({
         );
         return;
       case 'remove-value':
-        toggleResource({
-          kind: 'namespace',
-          id: kubeClusterItem.id,
-          subResourceName: actionMeta.removedValue.value,
-          clusterName: kubeClusterItem.clusterName,
-          name: actionMeta.removedValue.value,
-        });
+        bulkToggleKubeResources(
+          [
+            {
+              kind: 'namespace',
+              id: kubeClusterItem.id,
+              subResourceName: actionMeta.removedValue.value,
+              clusterName: kubeClusterItem.clusterName,
+              name: actionMeta.removedValue.value,
+            },
+          ],
+          kubeClusterItem
+        );
         return;
     }
   }

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.story.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.story.tsx
@@ -152,15 +152,27 @@ export const FailedResourceRequest = () => (
   </MemoryRouter>
 );
 
-export const FailedUnsupportedKubeResourceKind = () => (
+export const FailedUnsupportedKubeResourceKindWithTooltip = () => (
   <MemoryRouter>
     <RequestCheckoutWithSlider
       {...baseProps}
       isResourceRequest={true}
       fetchResourceRequestRolesAttempt={{
         status: 'failed',
-        statusText:
-          'Your Teleport roles request_mode field restricts you from requesting kinds [kube_cluster] for Kubernetes cluster "pumpkin-kube-cluster". Allowed kinds: [pod secret]',
+        statusText: `your Teleport role's "request.kubernetes_resources" field did not allow requesting to some or all of the requested Kubernetes resources. allowed kinds for each requestable roles: test-role-1: [deployment], test-role-2: [pod secret configmap service serviceaccount kube_node persistentvolume persistentvolumeclaim deployment replicaset statefulset daemonset clusterrole kube_role clusterrolebinding rolebinding cronjob job certificatesigningrequest ingress]`,
+      }}
+    />
+  </MemoryRouter>
+);
+
+export const FailedUnsupportedKubeResourceKindWithoutTooltip = () => (
+  <MemoryRouter>
+    <RequestCheckoutWithSlider
+      {...baseProps}
+      isResourceRequest={true}
+      fetchResourceRequestRolesAttempt={{
+        status: 'failed',
+        statusText: `your Teleport role's "request.kubernetes_resources" field did not allow requesting to some or all of the requested Kubernetes resources. allowed kinds for each requestable roles: test-role-1: [deployment]`,
       }}
     />
   </MemoryRouter>

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
@@ -34,7 +34,6 @@ import {
   P3,
   Subtitle2,
   Text,
-  Mark,
 } from 'design';
 import { ArrowBack, ChevronDown, ChevronRight, Warning } from 'design/Icon';
 import Table, { Cell } from 'design/DataTable';
@@ -42,18 +41,19 @@ import { Danger } from 'design/Alert';
 
 import Validation, { useRule, Validator } from 'shared/components/Validation';
 import { Attempt } from 'shared/hooks/useAttemptNext';
-import { listToSentence, pluralize } from 'shared/utils/text';
+import { pluralize } from 'shared/utils/text';
 import { Option } from 'shared/components/Select';
 import { FieldCheckbox } from 'shared/components/FieldCheckbox';
 import { mergeRefs } from 'shared/libs/mergeRefs';
 import { TextSelectCopyMulti } from 'shared/components/TextSelectCopy';
 import { RequestableResourceKind } from 'shared/components/AccessRequests/NewRequest/resource';
+import { HoverTooltip } from 'shared/components/ToolTip';
 
 import { CreateRequest } from '../../Shared/types';
 import { AssumeStartTime } from '../../AssumeStartTime/AssumeStartTime';
 import { AccessDurationRequest } from '../../AccessDuration';
 import {
-  checkForUnsupportedKubeRequestModes,
+  checkSupportForKubeResources,
   isKubeClusterWithNamespaces,
   type KubeNamespaceRequest,
 } from '../kube';
@@ -191,15 +191,10 @@ export function RequestCheckout<T extends PendingListItem>({
     });
   }
 
-  const {
-    affectedKubeClusterName,
-    unsupportedKubeRequestModes,
-    requiresNamespaceSelect,
-  } = checkForUnsupportedKubeRequestModes(fetchResourceRequestRolesAttempt);
-
-  const hasUnsupportedKubeRequestModes = !!unsupportedKubeRequestModes;
-  const showRequestRoleErrBanner =
-    !hasUnsupportedKubeRequestModes && !requiresNamespaceSelect;
+  const { requestKubeResourceSupported, isRequestKubeResourceError } =
+    checkSupportForKubeResources(fetchResourceRequestRolesAttempt);
+  const hasUnsupporteKubeResourceKinds =
+    !requestKubeResourceSupported && isRequestKubeResourceError;
 
   const isInvalidRoleSelection =
     resourceRequestRoles.length > 0 &&
@@ -211,8 +206,7 @@ export function RequestCheckout<T extends PendingListItem>({
     createAttempt.status === 'processing' ||
     isInvalidRoleSelection ||
     (fetchResourceRequestRolesAttempt.status === 'failed' &&
-      hasUnsupportedKubeRequestModes) ||
-    requiresNamespaceSelect ||
+      hasUnsupporteKubeResourceKinds) ||
     fetchResourceRequestRolesAttempt.status === 'processing';
 
   const cancelBtnDisabled =
@@ -272,10 +266,6 @@ export function RequestCheckout<T extends PendingListItem>({
                 toggleResource={toggleResource}
                 fetchKubeNamespaces={fetchKubeNamespaces}
                 bulkToggleKubeResources={bulkToggleKubeResources}
-                namespaceRequired={
-                  requiresNamespaceSelect &&
-                  affectedKubeClusterName.includes(item.id)
-                }
               />
             </Flex>
           </Flex>
@@ -288,21 +278,30 @@ export function RequestCheckout<T extends PendingListItem>({
     <Validation>
       {({ validator }) => (
         <>
-          {showRequestRoleErrBanner &&
+          {!isRequestKubeResourceError &&
             fetchResourceRequestRolesAttempt.status === 'failed' && (
               <Alert
                 kind="danger"
                 children={fetchResourceRequestRolesAttempt.statusText}
               />
             )}
-          {hasUnsupportedKubeRequestModes && (
+          {hasUnsupporteKubeResourceKinds && (
             <Alert kind="danger">
+              <HoverTooltip
+                position="left"
+                tipContent={
+                  fetchResourceRequestRolesAttempt.statusText.length > 248
+                    ? fetchResourceRequestRolesAttempt.statusText
+                    : null
+                }
+              >
+                <ShortenedText mb={2}>
+                  {fetchResourceRequestRolesAttempt.statusText}
+                </ShortenedText>
+              </HoverTooltip>
               <Text mb={2}>
-                You can only request Kubernetes resource{' '}
-                {pluralize(unsupportedKubeRequestModes.length, 'kind')}{' '}
-                <Mark>{listToSentence(unsupportedKubeRequestModes)}</Mark> for
-                cluster <Mark>{affectedKubeClusterName}</Mark>. Requesting those
-                resource kinds is currently only supported through the{' '}
+                The listed allowed kinds are currently only supported through
+                the{' '}
                 <ExternalLink
                   target="_blank"
                   href="https://goteleport.com/docs/connect-your-client/tsh/#installing-tsh"
@@ -316,14 +315,14 @@ export function RequestCheckout<T extends PendingListItem>({
                 >
                   tsh request search
                 </ExternalLink>{' '}
-                command that will help you construct the request.
+                that will help you construct the request.
               </Text>
-              <Box width="360px">
+              <Box width="325px">
                 Example:
                 <TextSelectCopyMulti
                   lines={[
                     {
-                      text: `tsh request search --kind=${unsupportedKubeRequestModes[0]} --kube-cluster=${affectedKubeClusterName} --all-kube-namespaces`,
+                      text: `tsh request search --kind=ALLOWED_KIND --kube-cluster=CLUSTER_NAME --all-kube-namespaces`,
                     },
                   ]}
                 />
@@ -862,6 +861,12 @@ const StyledTable = styled(Table)`
   box-shadow: ${props => props.theme.boxShadow[0]};
   overflow: hidden;
 ` as typeof Table;
+
+const ShortenedText = styled(Text)`
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 6;
+`;
 
 export type RequestCheckoutWithSliderProps<
   T extends PendingListItem = PendingListItem,

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
@@ -279,6 +279,7 @@ export function RequestCheckout<T extends PendingListItem>({
       {({ validator }) => (
         <>
           {!isRequestKubeResourceError &&
+            createAttempt.status !== 'failed' &&
             fetchResourceRequestRolesAttempt.status === 'failed' && (
               <Alert
                 kind="danger"

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
@@ -263,7 +263,6 @@ export function RequestCheckout<T extends PendingListItem>({
               <KubeNamespaceSelector
                 kubeClusterItem={item}
                 savedResourceItems={pendingAccessRequests}
-                toggleResource={toggleResource}
                 fetchKubeNamespaces={fetchKubeNamespaces}
                 bulkToggleKubeResources={bulkToggleKubeResources}
               />

--- a/web/packages/shared/components/AccessRequests/NewRequest/kube.test.ts
+++ b/web/packages/shared/components/AccessRequests/NewRequest/kube.test.ts
@@ -16,46 +16,148 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { checkForUnsupportedKubeRequestModes } from './kube';
+import { Attempt } from 'shared/hooks/useAttemptNext';
 
-test('checkForUnsupportedKubeRequestModes: non failed status', () => {
-  const {
-    affectedKubeClusterName,
-    unsupportedKubeRequestModes,
-    requiresNamespaceSelect,
-  } = checkForUnsupportedKubeRequestModes({ status: '' });
+import { checkSupportForKubeResources } from './kube';
 
-  expect(affectedKubeClusterName).toBeFalsy();
-  expect(unsupportedKubeRequestModes).toBeFalsy();
-  expect(requiresNamespaceSelect).toBeFalsy();
-});
+describe('requestKubeResourceSupported()', () => {
+  const testCases: {
+    name: string;
+    attempt: Attempt;
+    expected: {
+      requestKubeResourceSupported: boolean;
+      isRequestKubeResourceError: boolean;
+    };
+  }[] = [
+    {
+      name: 'non failed status',
+      attempt: { status: '' },
+      expected: {
+        requestKubeResourceSupported: true,
+        isRequestKubeResourceError: false,
+      },
+    },
+    {
+      name: 'non request.kubernetes_resources related error',
+      attempt: {
+        status: 'failed',
+        statusText: `some other error`,
+      },
+      expected: {
+        requestKubeResourceSupported: true,
+        isRequestKubeResourceError: false,
+      },
+    },
+    {
+      name: 'with supported namespace in error (single role)',
+      attempt: {
+        status: 'failed',
+        statusText: `your Teleport role's "request.kubernetes_resources" field did not allow requesting \
+        to some or all of the requested Kubernetes resources. allowed kinds for \
+        each requestable roles: test-role-1: [namespace]`,
+      },
+      expected: {
+        requestKubeResourceSupported: true,
+        isRequestKubeResourceError: true,
+      },
+    },
+    {
+      name: 'with supported namespace in error (multi role)',
+      attempt: {
+        status: 'failed',
+        statusText: `your Teleport role's "request.kubernetes_resources" field did not allow requesting \
+        to some or all of the requested Kubernetes resources. allowed kinds for \
+        each requestable roles: test-role-1: [pod secret], test-role-2: [deployment namespace]`,
+      },
+      expected: {
+        requestKubeResourceSupported: true,
+        isRequestKubeResourceError: true,
+      },
+    },
+    {
+      name: 'with supported kube_cluster in error (multi role)',
+      attempt: {
+        status: 'failed',
+        statusText: `your Teleport role's "request.kubernetes_resources" field did not allow requesting \
+        to some or all of the requested Kubernetes resources. allowed kinds for \
+        each requestable roles: test-role-1: [pod secret], test-role-2: [deployment kube_cluster]`,
+      },
+      expected: {
+        requestKubeResourceSupported: true,
+        isRequestKubeResourceError: true,
+      },
+    },
+    {
+      name: 'with supported kube_cluster and namespace in error (multi role)',
+      attempt: {
+        status: 'failed',
+        statusText: `your Teleport role's "request.kubernetes_resources" field did not allow requesting \
+        to some or all of the requested Kubernetes resources. allowed kinds for \
+        each requestable roles: test-role-1: [pod], test-role-2: [namespace kube_cluster]`,
+      },
+      expected: {
+        requestKubeResourceSupported: true,
+        isRequestKubeResourceError: true,
+      },
+    },
+    {
+      name: 'without supported kinds in error',
+      attempt: {
+        status: 'failed',
+        statusText: `your Teleport role's "request.kubernetes_resources" field did not allow requesting \
+        to some or all of the requested Kubernetes resources. allowed kinds for \
+        each requestable roles: test-role-1: [deployment], test-role-2: [pod secret]`,
+      },
+      expected: {
+        requestKubeResourceSupported: false,
+        isRequestKubeResourceError: true,
+      },
+    },
+    // empty bracket case can happen from admin configuration error
+    // where allow and deny canceled each other so nothing is allowed.
+    {
+      name: 'empty bracket with space',
+      attempt: {
+        status: 'failed',
+        statusText: `your Teleport role's "request.kubernetes_resources" field did not allow requesting \
+        to some or all of the requested Kubernetes resources. allowed kinds for \
+        each requestable roles: test-role-1: [ ]`,
+      },
+      expected: {
+        requestKubeResourceSupported: false,
+        isRequestKubeResourceError: true,
+      },
+    },
+    {
+      name: 'empty bracket without space',
+      attempt: {
+        status: 'failed',
+        statusText: `your Teleport role's "request.kubernetes_resources" field did not allow requesting \
+        to some or all of the requested Kubernetes resources. allowed kinds for \
+        each requestable roles: test-role-1: []`,
+      },
+      expected: {
+        requestKubeResourceSupported: false,
+        isRequestKubeResourceError: true,
+      },
+    },
+    // should never happen but just in case
+    {
+      name: 'without any role',
+      attempt: {
+        status: 'failed',
+        statusText: `your Teleport role's "request.kubernetes_resources" field did not allow requesting \
+        to some or all of the requested Kubernetes resources. allowed kinds for \
+        each requestable roles: `,
+      },
+      expected: {
+        requestKubeResourceSupported: true,
+        isRequestKubeResourceError: false,
+      },
+    },
+  ];
 
-test('checkForUnsupportedKubeRequestModes: failed status with unsupported kinds', () => {
-  const {
-    affectedKubeClusterName,
-    unsupportedKubeRequestModes,
-    requiresNamespaceSelect,
-  } = checkForUnsupportedKubeRequestModes({
-    status: 'failed',
-    statusText: `Your Teleport roles request_mode field restricts you from requesting kinds [kube_cluster] for Kubernetes cluster "pumpkin-kube-cluster". Allowed kinds: [pod secret]`,
+  test.each(testCases)('$name', ({ attempt, expected }) => {
+    expect(checkSupportForKubeResources(attempt)).toEqual(expected);
   });
-
-  expect(affectedKubeClusterName).toEqual(`pumpkin-kube-cluster`);
-  expect(unsupportedKubeRequestModes).toEqual(['pod', 'secret']);
-  expect(requiresNamespaceSelect).toBeFalsy();
-});
-
-test('checkForUnsupportedKubeRequestModes: failed status with supported namespace', () => {
-  const {
-    affectedKubeClusterName,
-    unsupportedKubeRequestModes,
-    requiresNamespaceSelect,
-  } = checkForUnsupportedKubeRequestModes({
-    status: 'failed',
-    statusText: `Your Teleport roles request_mode field restricts you from requesting kinds [kube_cluster] for Kubernetes cluster "pumpkin-kube-cluster". Allowed kinds: [pod secret namespace]`,
-  });
-
-  expect(affectedKubeClusterName).toEqual(`pumpkin-kube-cluster`);
-  expect(unsupportedKubeRequestModes).toBeFalsy();
-  expect(requiresNamespaceSelect).toBeTruthy();
 });

--- a/web/packages/shared/components/AccessRequests/NewRequest/kube.ts
+++ b/web/packages/shared/components/AccessRequests/NewRequest/kube.ts
@@ -45,14 +45,12 @@ export function isKubeClusterWithNamespaces(
 }
 
 /**
- * Parses error messsage (in an expected format) to see if
- * in the message it's a type of request.kubernetes_resources
- * related error, then check if namespace or kube_cluster is mentioned
- * in the "allowed kinds" portion of the error message.
+ * Parses error message (in an expected format returned from the backend) to see if
+ * the message is a type of request.kubernetes_resources related error:
+ * https://github.com/gravitational/teleport/blob/master/lib/services/access_request.go#L2050
  *
- * The web UI currently only supports selecting namespaces or kube_cluster
- * for kube related resources, anything else we have to help direct
- * user to another tool that does support it.
+ * If error matches, it then checks if namespace or kube_cluster is mentioned
+ * in the "allowed kinds" portion of the error message.
  */
 export function checkSupportForKubeResources(requestRoleAttempt: Attempt) {
   let requestKubeResourceSupported = true;

--- a/web/packages/shared/components/AccessRequests/NewRequest/useSpecifiableFields.ts
+++ b/web/packages/shared/components/AccessRequests/NewRequest/useSpecifiableFields.ts
@@ -98,6 +98,16 @@ export function useSpecifiableFields() {
     );
   }
 
+  function reset() {
+    setDryRunResponse(null);
+    setResourceRequestRoles([]);
+    setSelectedResourceRequestRoles([]);
+    setSelectedReviewers([]);
+    setStartTime(null);
+    setMaxDuration(null);
+    setPendingRequestTtl(null);
+  }
+
   function preselectPendingRequestTtlOption(
     newMaxDuration: number,
     dryRequestCreated: Date
@@ -190,5 +200,6 @@ export function useSpecifiableFields() {
     startTime,
     onStartTimeChange,
     onDryRunChange,
+    reset,
   };
 }

--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.ts
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.ts
@@ -77,6 +77,7 @@ export default function useAccessRequestCheckout() {
     onDryRunChange,
     startTime,
     onStartTimeChange,
+    reset: resetSpecifiableFields,
   } = useSpecifiableFields();
 
   const [showCheckout, setShowCheckout] = useState(false);
@@ -371,6 +372,7 @@ export default function useAccessRequestCheckout() {
   }
 
   function reset() {
+    resetSpecifiableFields();
     if (workspaceAccessRequest) {
       return workspaceAccessRequest.clearPendingAccessRequest();
     }


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/46742

The backend error messaging has changed, so this PR just updates how the web UI processes that error.

It also fixes a subtle bug where, after a request was created (or when user cancels the request), the specifiable fields (eg: suggested reviewers and especially the selected resource roles) were retained, so when user tries to create a new checkout, the `resource roles` fetch can fail, and the following `dry run` fetch referred to the previous requests values of selected roles, which resulted in incorrect error message referring to the wrong roles.

Screenshots:

with tooltip, if the error message gets long (happens with wildcard expanded into all kinds supported):
<img width="818" alt="image" src="https://github.com/user-attachments/assets/ebcd3dc2-170c-4c25-a67c-f2beaec0bfd8">



without tooltip (reasonably short error message)
<img width="503" alt="image" src="https://github.com/user-attachments/assets/aea5e8c8-4489-4734-9f6c-98d3c743d188">
