### PR TITLE
[v14] fix EAS bootstrap script

### DIFF
--- a/lib/integrations/externalauditstorage/bootstrap.go
+++ b/lib/integrations/externalauditstorage/bootstrap.go
@@ -184,8 +184,7 @@ func createTransientBucket(ctx context.Context, clt BootstrapS3Client, bucketNam
 					Status: s3types.ExpirationStatusEnabled,
 					ID:     aws.String("ExpireNonCurrentVersionsAndDeleteMarkers"),
 					NoncurrentVersionExpiration: &s3types.NoncurrentVersionExpiration{
-						NewerNoncurrentVersions: aws.Int32(0),
-						NoncurrentDays:          aws.Int32(1),
+						NoncurrentDays: aws.Int32(1),
 					},
 					AbortIncompleteMultipartUpload: &s3types.AbortIncompleteMultipartUpload{
 						DaysAfterInitiation: aws.Int32(7),


### PR DESCRIPTION
Backport #37068 to branch/v14

This was originally broken after an aws-sdk-go-v2 update, and fix was not backported to v14 which at the time was still on an older version of the SDK where everything still worked. The SDK was later updated in branch/v14 by #39490, introducing the bug to v14 without the fix.

Fixes #48155

changelog: Fixed a bug in the External Audit Storage bootstrap script that broke S3 bucket creation