### PR TITLE
[entraid] ignore unsuported groups members and parse nested group members

### DIFF
--- a/lib/msgraph/models.go
+++ b/lib/msgraph/models.go
@@ -116,8 +116,14 @@ func decodeGroupMember(msg json.RawMessage) (GroupMember, error) {
 		var u *User
 		err = json.Unmarshal(msg, &u)
 		member = u
+	case "#microsoft.graph.group":
+		var g *Group
+		err = json.Unmarshal(msg, &g)
+		member = g
 	default:
-		err = trace.BadParameter("unsupported group member type: %s", temp.Type)
+		// Return an error if we encounter a type we do not support.
+		// The caller ignores the error and continues processing the next entry.
+		err = &unsupportedGroupMember{Type: temp.Type}
 	}
 
 	return member, trace.Wrap(err)


### PR DESCRIPTION
This PR corrects a typo that led to errors not being ignored, causing failures when group memberships included other groups or unsupported types.

The fix ensures that `unsupportedGroupMember` is properly returned and adds support for parsing groups nested within other groups.

