### PR TITLE
Machine ID: Fix `tshwrap` destination dir handling

### DIFF
--- a/lib/tbot/tshwrap/wrap_test.go
+++ b/lib/tbot/tshwrap/wrap_test.go
@@ -68,16 +68,16 @@ func TestGetDestinationDirectory(t *testing.T) {
 		return cfg
 	}
 	t.Run("one output configured", func(t *testing.T) {
-		dest, err := GetDestinationDirectory(config(1))
+		dest, err := GetDestinationDirectory("", config(1))
 		require.NoError(t, err)
 		require.Equal(t, "/from-bot-config0", dest.Path)
 	})
 	t.Run("no outputs specified", func(t *testing.T) {
-		_, err := GetDestinationDirectory(config(0))
+		_, err := GetDestinationDirectory("", config(0))
 		require.ErrorContains(t, err, "either --destination-dir or a config file containing an output or service must be specified")
 	})
 	t.Run("multiple outputs specified", func(t *testing.T) {
-		_, err := GetDestinationDirectory(config(2))
+		_, err := GetDestinationDirectory("", config(2))
 		require.ErrorContains(t, err, "the config file contains multiple outputs and services; a --destination-dir must be specified")
 	})
 }

--- a/tool/tbot/db.go
+++ b/tool/tbot/db.go
@@ -40,7 +40,7 @@ func onDBCommand(globalCfg *cli.GlobalArgs, dbCmd *cli.DBCommand) error {
 		return trace.Wrap(err)
 	}
 
-	destination, err := tshwrap.GetDestinationDirectory(botConfig)
+	destination, err := tshwrap.GetDestinationDirectory(dbCmd.DestinationDir, botConfig)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tbot/proxy.go
+++ b/tool/tbot/proxy.go
@@ -44,7 +44,7 @@ func onProxyCommand(
 		return trace.Wrap(err)
 	}
 
-	destination, err := tshwrap.GetDestinationDirectory(botConfig)
+	destination, err := tshwrap.GetDestinationDirectory(proxyCmd.DestinationDir, botConfig)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
Recent CLI handling changes broke destination dir resolution for commands that use `tshwrap.GetDestinationDir()` to resolve destinations from either the CLI or config file.

The old behavior depends on implicit creation of an identity service if `--destination-dir` was provided on the CLI and no config file is loaded. We now no longer make this assumption and prefer to only resolve explicit configurations, so this tweaks
`tshwrap.GetDestinationDir()` to explicitly handle the CLI parameter rather than hoping it appears in the generated config.

While this is legacy functionality, it's not slated for removal in v17. Most users should still prefer to use the new app and database tunnel services wherever possible.

Fixes #48107