### PR TITLE
[v17] fix: Provide `membershipKind` fields for owners/members in tests

### DIFF
--- a/integrations/operator/controllers/resources/testlib/accesslist_controller_tests.go
+++ b/integrations/operator/controllers/resources/testlib/accesslist_controller_tests.go
@@ -44,7 +44,7 @@ func newAccessListSpec(nextAudit time.Time) accesslist.Spec {
 	return accesslist.Spec{
 		Title:       "crane operation",
 		Description: "Access list that Gru uses to allow the minions to operate the crane.",
-		Owners:      []accesslist.Owner{{Name: "Gru", Description: "The super villain."}},
+		Owners:      []accesslist.Owner{{Name: "Gru", Description: "The super villain.", MembershipKind: accesslist.MembershipKindUser}},
 		Audit: accesslist.Audit{
 			Recurrence: accesslist.Recurrence{
 				Frequency:  accesslist.SixMonths,


### PR DESCRIPTION
Backports #48191
