### PR TITLE
Increasing timeout for pam smoke tests

### DIFF
--- a/build.assets/charts/smoke_tests/01_pam/test.sh
+++ b/build.assets/charts/smoke_tests/01_pam/test.sh
@@ -6,4 +6,4 @@
 #
 # If teleport is still up when the timeout expires, then we're 
 # probably OK
-timeout --preserve-status 10s docker run --platform $1 --rm --entrypoint /usr/local/bin/teleport -v "$(pwd):/etc/teleport" $2 start -c /etc/teleport/config.yaml
+timeout --preserve-status 20s docker run --platform $1 --rm --entrypoint /usr/local/bin/teleport -v "$(pwd):/etc/teleport" $2 start -c /etc/teleport/config.yaml

--- a/build.assets/charts/smoke_tests/01_pam/test.sh
+++ b/build.assets/charts/smoke_tests/01_pam/test.sh
@@ -6,4 +6,8 @@
 #
 # If teleport is still up when the timeout expires, then we're 
 # probably OK
+#
+# A timeout of 20s is set to account for potentially slow startup times.
+# QEMU eumlation may slow startup time for some platforms and during that
+# time the process won't shutdown gracefully resulting in a nonzero code.
 timeout --preserve-status 20s docker run --platform $1 --rm --entrypoint /usr/local/bin/teleport -v "$(pwd):/etc/teleport" $2 start -c /etc/teleport/config.yaml


### PR DESCRIPTION
## Overview

Our PAM smoke tests have been failing pretty often in our release pipelines (i.e. https://github.com/gravitational/teleport.e/actions/runs/11590925746/job/32271801318)

From a brief bit of testing we believe it may be due to a slow startup of the process in the container (`linux/arm`) probably due to emulation loading. When the timeout is up, SIGTERM isn't caught by the process since it hasn't started and it doesn't shut down gracefully resulting in an unfavorable exit status.

We can increase the timeout a bit more to make this test more consistent. This does come with the tradeoff of adding 10 more seconds to the smoke test job of our release pipeline.