### PR TITLE
Prevent panic in proxy diffing

### DIFF
--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -839,9 +839,9 @@ func (g *genericCollector[T, R]) processEventsAndUpdateCurrent(ctx context.Conte
 			}
 
 			key := g.ResourceKey(resource)
-			current := g.current[key]
+			current, exists := g.current[key]
 			g.current[key] = resource
-			updated = g.ResourceDiffer(current, resource)
+			updated = !exists || g.ResourceDiffer(current, resource)
 		default:
 			g.Logger.WarnContext(ctx, "Skipping unsupported event type", "event_type", event.Type)
 		}

--- a/lib/services/watcher_test.go
+++ b/lib/services/watcher_test.go
@@ -134,6 +134,9 @@ func TestProxyWatcher(t *testing.T) {
 		},
 		ProxyGetter: presence,
 		ProxiesC:    make(chan []types.Server, 10),
+		ProxyDiffer: func(old, new types.Server) bool {
+			return old.GetPeerAddr() != new.GetPeerAddr()
+		},
 	})
 	require.NoError(t, err)
 	t.Cleanup(w.Close)


### PR DESCRIPTION
#47561 incorrectly translated the logic on when to call the diff function for resources. The previous logic only called the differ _if_ the resource had already been seen before, which guaranteed that both the old and new resource provided to the diff function were not nil. However, after the conversion to the generic watcher the diff function was called for new resources, resulting in a nil value being provided for the old resource and caused a panic. The previous behavior has been restored, and the ProxyWatcher test has been updated to set a diff function to prevent regressions.