### PR TITLE
add a hidden `--tunnel` flag to `tsh db connect` to force local proxy tunnel

### DIFF
--- a/tool/tsh/common/db.go
+++ b/tool/tsh/common/db.go
@@ -760,7 +760,7 @@ func onDatabaseConnect(cf *CLIConf) error {
 		return trace.BadParameter(formatDbCmdUnsupportedDBProtocol(cf, dbInfo.RouteToDatabase))
 	}
 
-	requires := getDBConnectLocalProxyRequirement(cf.Context, tc, dbInfo.RouteToDatabase)
+	requires := getDBConnectLocalProxyRequirement(cf.Context, tc, dbInfo.RouteToDatabase, cf.LocalProxyTunnel)
 	if err := maybeDatabaseLogin(cf, tc, profile, dbInfo, requires); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1678,8 +1678,13 @@ func getDBLocalProxyRequirement(tc *client.TeleportClient, route tlsca.RouteToDa
 	return &out
 }
 
-func getDBConnectLocalProxyRequirement(ctx context.Context, tc *client.TeleportClient, route tlsca.RouteToDatabase) *dbLocalProxyRequirement {
+func getDBConnectLocalProxyRequirement(ctx context.Context, tc *client.TeleportClient, route tlsca.RouteToDatabase, tunnelFlag bool) *dbLocalProxyRequirement {
 	r := getDBLocalProxyRequirement(tc, route)
+	// Forces local proxy tunnel when --tunnel is on.
+	if !r.tunnel && tunnelFlag {
+		r.addLocalProxyWithTunnel(dbConnectRequireReasonTunnelFlag)
+	}
+	// Forces local proxy when cluster has TLS routing enabled.
 	if !r.localProxy && tc.TLSRoutingEnabled {
 		r.addLocalProxy(formatTLSRoutingReason(tc.SiteName))
 	}
@@ -1912,4 +1917,8 @@ Hint: use '{{ .listCommand }} -v' or '{{ .listCommand }} --format=[json|yaml]' t
 Hint: try selecting the {{ .kind }} with a more specific name (ex: {{ .command }} {{ .example }}).
 Hint: try selecting the {{ .kind }} with additional --labels or --query predicate.
 `))
+
+	// dbConnectRequireReasonTunnelFlag is the reason used in local proxy
+	// requirement calculation when --tunnel flag is specified.
+	dbConnectRequireReasonTunnelFlag = "--tunnel flag is specified"
 )

--- a/tool/tsh/common/db.go
+++ b/tool/tsh/common/db.go
@@ -1860,6 +1860,12 @@ const (
 	dbFormatYAML = "yaml"
 )
 
+const (
+	// dbConnectRequireReasonTunnelFlag is the reason used in local proxy
+	// requirement calculation when --tunnel flag is specified.
+	dbConnectRequireReasonTunnelFlag = "--tunnel flag is specified"
+)
+
 var (
 	// dbCmdUnsupportedTemplate is the error message printed when some
 	// database subcommands are not supported.
@@ -1917,8 +1923,4 @@ Hint: use '{{ .listCommand }} -v' or '{{ .listCommand }} --format=[json|yaml]' t
 Hint: try selecting the {{ .kind }} with a more specific name (ex: {{ .command }} {{ .example }}).
 Hint: try selecting the {{ .kind }} with additional --labels or --query predicate.
 `))
-
-	// dbConnectRequireReasonTunnelFlag is the reason used in local proxy
-	// requirement calculation when --tunnel flag is specified.
-	dbConnectRequireReasonTunnelFlag = "--tunnel flag is specified"
 )

--- a/tool/tsh/common/db_test.go
+++ b/tool/tsh/common/db_test.go
@@ -577,11 +577,13 @@ func TestLocalProxyRequirement(t *testing.T) {
 	defaultAuthPref, err := authServer.GetAuthPreference(ctx)
 	require.NoError(t, err)
 	tests := map[string]struct {
-		clusterAuthPref types.AuthPreference
-		route           *tlsca.RouteToDatabase
-		setupTC         func(*client.TeleportClient)
-		wantLocalProxy  bool
-		wantTunnel      bool
+		clusterAuthPref  types.AuthPreference
+		route            *tlsca.RouteToDatabase
+		setupTC          func(*client.TeleportClient)
+		tunnelFlag       bool
+		wantLocalProxy   bool
+		wantTunnel       bool
+		wantTunnelReason string
 	}{
 		"tunnel not required": {
 			clusterAuthPref: defaultAuthPref,
@@ -599,8 +601,9 @@ func TestLocalProxyRequirement(t *testing.T) {
 					RequireMFAType: types.RequireMFAType_SESSION,
 				},
 			},
-			wantLocalProxy: true,
-			wantTunnel:     true,
+			wantLocalProxy:   true,
+			wantTunnel:       true,
+			wantTunnelReason: "MFA is required",
 		},
 		"local proxy not required for separate port": {
 			clusterAuthPref: defaultAuthPref,
@@ -620,6 +623,25 @@ func TestLocalProxyRequirement(t *testing.T) {
 			},
 			wantLocalProxy: true,
 			wantTunnel:     false,
+		},
+		"tunnel required by tunnel flag": {
+			clusterAuthPref:  defaultAuthPref,
+			tunnelFlag:       true,
+			wantLocalProxy:   true,
+			wantTunnel:       true,
+			wantTunnelReason: dbConnectRequireReasonTunnelFlag,
+		},
+		"tunnel required for separate port by tunnel flag": {
+			clusterAuthPref: defaultAuthPref,
+			setupTC: func(tc *client.TeleportClient) {
+				tc.TLSRoutingEnabled = false
+				tc.TLSRoutingConnUpgradeRequired = false
+				tc.PostgresProxyAddr = "separate.postgres.hostport:8888"
+			},
+			tunnelFlag:       true,
+			wantLocalProxy:   true,
+			wantTunnel:       true,
+			wantTunnelReason: dbConnectRequireReasonTunnelFlag,
 		},
 	}
 	for name, tt := range tests {
@@ -647,12 +669,12 @@ func TestLocalProxyRequirement(t *testing.T) {
 				Username:    "alice",
 				Database:    "postgres",
 			}
-			requires := getDBConnectLocalProxyRequirement(ctx, tc, route)
+			requires := getDBConnectLocalProxyRequirement(ctx, tc, route, tt.tunnelFlag)
 			require.Equal(t, tt.wantLocalProxy, requires.localProxy)
 			require.Equal(t, tt.wantTunnel, requires.tunnel)
 			if requires.tunnel {
 				require.Len(t, requires.tunnelReasons, 1)
-				require.Contains(t, requires.tunnelReasons[0], "MFA is required")
+				require.Contains(t, requires.tunnelReasons[0], tt.wantTunnelReason)
 			}
 		})
 	}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -996,6 +996,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	dbConnect.Flag("query", queryHelp).StringVar(&cf.PredicateExpression)
 	dbConnect.Flag("request-reason", "Reason for requesting access").StringVar(&cf.RequestReason)
 	dbConnect.Flag("disable-access-request", "Disable automatic resource access requests").BoolVar(&cf.disableAccessRequest)
+	dbConnect.Flag("tunnel", "Open authenticated tunnel using database's client certificate so clients don't need to authenticate").Hidden().BoolVar(&cf.LocalProxyTunnel)
 
 	// join
 	join := app.Command("join", "Join the active SSH or Kubernetes session.")


### PR DESCRIPTION
The hidden "--tunnel" flag allows quick debugging in scenarios where regular `tsh db connect` fails but local proxy tunnel may proceed. For example, one known issue is some older `psql` doesn't work well with newer openssl. Another example is regular `tsh db connect` uses separate db ports that may not work.

The current alternative is to use `tsh proxy db --tunnel`, then run the db client in a separate terminal.