### PR TITLE
[v15] docs: configure second webhook in "Update docs webhook" job

### DIFF
--- a/.github/workflows/update-docs-webhook.yaml
+++ b/.github/workflows/update-docs-webhook.yaml
@@ -1,6 +1,8 @@
 name: Update docs webhook
 on:
   push:
+    paths:
+      - 'docs/**'
     branches:
       - master
       - branch/v*
@@ -11,11 +13,19 @@ jobs:
     name: Update docs webhook
     runs-on: ubuntu-latest
     environment: update-docs
+    strategy:
+      fail-fast: false
+      matrix:
+        webhooks:
+        - url_secret_name: DOCS_DEPLOY_HOOK
+          http_method: GET
+        - url_secret_name: AMPLIFY_DOCS_DEPLOY_HOOK
+          http_method: POST
     steps:
       - name: Call deployment webhook
         env:
-          WEBHOOK_URL: ${{ secrets.DOCS_DEPLOY_HOOK }}
+          WEBHOOK_URL: ${{ secrets[matrix.webhooks.url_secret_name] }}
         run: |
-          if curl --silent --fail --show-error "$WEBHOOK_URL" > /dev/null; then
+          if curl -X ${{ matrix.webhooks.http_method }} --silent --fail --show-error "$WEBHOOK_URL" > /dev/null; then
             echo "Triggered successfully"
           fi


### PR DESCRIPTION
### Summary

Configure matrix to trigger additional webhook for jobs deployment.

Also configure `path` filter, to reduce build time/cost.

Backports #48091