### PR TITLE
[v15] Update Proxy Features

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4583,6 +4583,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			TracerProvider:            process.TracingProvider,
 			AutomaticUpgradesChannels: cfg.Proxy.AutomaticUpgradesChannels,
 			IntegrationAppHandler:     connectionsHandler,
+			FeatureWatchInterval:      utils.HalfJitter(web.DefaultFeatureWatchInterval * 2),
 		}
 		webHandler, err := web.NewHandler(webConfig)
 		if err != nil {

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -169,8 +169,8 @@ type Handler struct {
 	// userConns tracks amount of current active connections with user certificates.
 	userConns atomic.Int32
 
-	// clusterFeatures contain flags for supported and unsupported features.
-	clusterFeatures proto.Features
+	// ClusterFeatures contain flags for supported and unsupported features.
+	ClusterFeatures proto.Features
 
 	// nodeWatcher is a services.NodeWatcher used by Assist to lookup nodes from
 	// the proxy's cache and get nodes in real time.
@@ -405,7 +405,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 		log:                  newPackageLogger(),
 		logger:               slog.Default().With(teleport.ComponentKey, teleport.ComponentWeb),
 		clock:                clockwork.NewRealClock(),
-		clusterFeatures:      cfg.ClusterFeatures,
+		ClusterFeatures:      cfg.ClusterFeatures,
 		healthCheckAppServer: cfg.HealthCheckAppServer,
 		tracer:               cfg.TracerProvider.Tracer(teleport.ComponentWeb),
 		wsIODeadline:         wsIODeadline,

--- a/lib/web/features.go
+++ b/lib/web/features.go
@@ -29,7 +29,7 @@ func (h *Handler) SetClusterFeatures(features proto.Features) {
 	h.Mutex.Lock()
 	defer h.Mutex.Unlock()
 
-	h.clusterFeatures = features
+	h.ClusterFeatures = features
 }
 
 // GetClusterFeatures returns flags for supported and unsupported features.
@@ -37,7 +37,7 @@ func (h *Handler) GetClusterFeatures() proto.Features {
 	h.Mutex.Lock()
 	defer h.Mutex.Unlock()
 
-	return h.clusterFeatures
+	return h.ClusterFeatures
 }
 
 // startFeatureWatcher periodically pings the auth server and updates `clusterFeatures`.

--- a/lib/web/features.go
+++ b/lib/web/features.go
@@ -1,0 +1,71 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package web
+
+import (
+	"github.com/gravitational/teleport/api/client/proto"
+)
+
+// SetClusterFeatures sets the flags for supported and unsupported features.
+// TODO(mcbattirola): make method unexported, fix tests using it to set
+// test modules instead.
+func (h *Handler) SetClusterFeatures(features proto.Features) {
+	h.Mutex.Lock()
+	defer h.Mutex.Unlock()
+
+	h.clusterFeatures = features
+}
+
+// GetClusterFeatures returns flags for supported and unsupported features.
+func (h *Handler) GetClusterFeatures() proto.Features {
+	h.Mutex.Lock()
+	defer h.Mutex.Unlock()
+
+	return h.clusterFeatures
+}
+
+// startFeatureWatcher periodically pings the auth server and updates `clusterFeatures`.
+// Must be called only once per `handler`, otherwise it may close an already closed channel
+// which will cause a panic.
+// The watcher doesn't ping the auth server immediately upon start because features are
+// already set by the config object in `NewHandler`.
+func (h *Handler) startFeatureWatcher() {
+	ticker := h.clock.NewTicker(h.cfg.FeatureWatchInterval)
+	h.log.WithField("interval", h.cfg.FeatureWatchInterval).Info("Proxy handler features watcher has started")
+	ctx := h.cfg.Context
+
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.Chan():
+			h.log.Info("Pinging auth server for features")
+			pingResponse, err := h.GetProxyClient().Ping(ctx)
+			if err != nil {
+				h.log.WithError(err).Error("Auth server ping failed")
+				continue
+			}
+
+			h.SetClusterFeatures(*pingResponse.ServerFeatures)
+			h.log.WithField("features", pingResponse.ServerFeatures).Info("Done updating proxy features")
+		case <-ctx.Done():
+			h.log.Info("Feature service has stopped")
+			return
+		}
+	}
+}

--- a/lib/web/features_test.go
+++ b/lib/web/features_test.go
@@ -1,0 +1,176 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package web
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/entitlements"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+)
+
+// mockedPingTestProxy is a test proxy with a mocked Ping method
+// that returns the internal features
+type mockedFeatureGetter struct {
+	authclient.ClientI
+	features proto.Features
+}
+
+func (m *mockedFeatureGetter) Ping(ctx context.Context) (proto.PingResponse, error) {
+	return proto.PingResponse{
+		ServerFeatures: utils.CloneProtoMsg(&m.features),
+	}, nil
+}
+
+func (m *mockedFeatureGetter) setFeatures(f proto.Features) {
+	m.features = f
+}
+
+func TestFeaturesWatcher(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+
+	mockClient := &mockedFeatureGetter{features: proto.Features{
+		Kubernetes:     true,
+		Entitlements:   map[string]*proto.EntitlementInfo{},
+		AccessRequests: &proto.AccessRequestsFeature{},
+	}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	handler := &Handler{
+		cfg: Config{
+			FeatureWatchInterval: 100 * time.Millisecond,
+			ProxyClient:          mockClient,
+			Context:              ctx,
+		},
+		clock:           clock,
+		clusterFeatures: proto.Features{},
+		log:             newPackageLogger(),
+		logger:          slog.Default().With(teleport.ComponentKey, teleport.ComponentWeb),
+	}
+
+	// before running the watcher, features should match the value passed to the handler
+	requireFeatures(t, clock, proto.Features{}, handler.GetClusterFeatures)
+
+	go handler.startFeatureWatcher()
+	clock.BlockUntil(1)
+
+	// after starting the watcher, handler.GetClusterFeatures should return
+	// values matching the client's response
+	features := proto.Features{
+		Kubernetes:     true,
+		Entitlements:   map[string]*proto.EntitlementInfo{},
+		AccessRequests: &proto.AccessRequestsFeature{},
+	}
+	entitlements.BackfillFeatures(&features)
+	expected := utils.CloneProtoMsg(&features)
+	requireFeatures(t, clock, *expected, handler.GetClusterFeatures)
+
+	// update values once again and check if the features are properly updated
+	features = proto.Features{
+		Kubernetes:     false,
+		Entitlements:   map[string]*proto.EntitlementInfo{},
+		AccessRequests: &proto.AccessRequestsFeature{},
+	}
+	entitlements.BackfillFeatures(&features)
+	mockClient.setFeatures(features)
+	expected = utils.CloneProtoMsg(&features)
+	requireFeatures(t, clock, *expected, handler.GetClusterFeatures)
+
+	// test updating entitlements
+	features = proto.Features{
+		Kubernetes: true,
+		Entitlements: map[string]*proto.EntitlementInfo{
+			string(entitlements.ExternalAuditStorage):   {Enabled: true},
+			string(entitlements.AccessLists):            {Enabled: true},
+			string(entitlements.AccessMonitoring):       {Enabled: true},
+			string(entitlements.App):                    {Enabled: true},
+			string(entitlements.CloudAuditLogRetention): {Enabled: true},
+		},
+		AccessRequests: &proto.AccessRequestsFeature{},
+	}
+	entitlements.BackfillFeatures(&features)
+	mockClient.setFeatures(features)
+
+	expected = &proto.Features{
+		Kubernetes: true,
+		Entitlements: map[string]*proto.EntitlementInfo{
+			string(entitlements.ExternalAuditStorage):   {Enabled: true},
+			string(entitlements.AccessLists):            {Enabled: true},
+			string(entitlements.AccessMonitoring):       {Enabled: true},
+			string(entitlements.App):                    {Enabled: true},
+			string(entitlements.CloudAuditLogRetention): {Enabled: true},
+		},
+		AccessRequests: &proto.AccessRequestsFeature{},
+	}
+	entitlements.BackfillFeatures(expected)
+	requireFeatures(t, clock, *expected, handler.GetClusterFeatures)
+
+	// stop watcher and ensure it stops updating features
+	cancel()
+	features = proto.Features{
+		Kubernetes:     !features.Kubernetes,
+		App:            !features.App,
+		DB:             true,
+		Entitlements:   map[string]*proto.EntitlementInfo{},
+		AccessRequests: &proto.AccessRequestsFeature{},
+	}
+	entitlements.BackfillFeatures(&features)
+	mockClient.setFeatures(features)
+	notExpected := utils.CloneProtoMsg(&features)
+	// assert the handler never get these last features as the watcher is stopped
+	neverFeatures(t, clock, *notExpected, handler.GetClusterFeatures)
+}
+
+// requireFeatures is a helper function that advances the clock, then
+// calls `getFeatures` every 100ms for up to 1 second, until it
+// returns the expected result (`want`).
+func requireFeatures(t *testing.T, fakeClock clockwork.FakeClock, want proto.Features, getFeatures func() proto.Features) {
+	t.Helper()
+
+	// Advance the clock so the service fetch and stores features
+	fakeClock.Advance(1 * time.Second)
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		diff := cmp.Diff(want, getFeatures())
+		assert.Empty(t, diff)
+	}, 5*time.Second, time.Millisecond*100)
+}
+
+// neverFeatures is a helper function that advances the clock, then
+// calls `getFeatures` every 100ms for up to 1 second. If at some point `getFeatures`
+// returns `doNotWant`, the test fails.
+func neverFeatures(t *testing.T, fakeClock clockwork.FakeClock, doNotWant proto.Features, getFeatures func() proto.Features) {
+	t.Helper()
+
+	fakeClock.Advance(1 * time.Second)
+	require.Never(t, func() bool {
+		return cmp.Diff(doNotWant, getFeatures()) == ""
+	}, 1*time.Second, time.Millisecond*100)
+}

--- a/lib/web/features_test.go
+++ b/lib/web/features_test.go
@@ -70,7 +70,7 @@ func TestFeaturesWatcher(t *testing.T) {
 			Context:              ctx,
 		},
 		clock:           clock,
-		clusterFeatures: proto.Features{},
+		ClusterFeatures: proto.Features{},
 		log:             newPackageLogger(),
 		logger:          slog.Default().With(teleport.ComponentKey, teleport.ComponentWeb),
 	}

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -125,7 +125,7 @@ func (h *Handler) awsOIDCDeployService(w http.ResponseWriter, r *http.Request, p
 	}
 
 	teleportVersionTag := teleport.Version
-	if automaticUpgrades(h.ClusterFeatures) {
+	if automaticUpgrades(h.GetClusterFeatures()) {
 		cloudStableVersion, err := h.cfg.AutomaticUpgradesChannels.DefaultVersion(ctx)
 		if err != nil {
 			return "", trace.Wrap(err)
@@ -178,7 +178,7 @@ func (h *Handler) awsOIDCDeployDatabaseServices(w http.ResponseWriter, r *http.R
 	}
 
 	teleportVersionTag := teleport.Version
-	if automaticUpgrades(h.ClusterFeatures) {
+	if automaticUpgrades(h.GetClusterFeatures()) {
 		cloudStableVersion, err := h.cfg.AutomaticUpgradesChannels.DefaultVersion(ctx)
 		if err != nil {
 			return "", trace.Wrap(err)
@@ -480,7 +480,7 @@ func (h *Handler) awsOIDCEnrollEKSClusters(w http.ResponseWriter, r *http.Reques
 		return nil, trace.BadParameter("an integration name is required")
 	}
 
-	agentVersion, err := kubeutils.GetKubeAgentVersion(ctx, h.cfg.ProxyClient, h.ClusterFeatures, h.cfg.AutomaticUpgradesChannels)
+	agentVersion, err := kubeutils.GetKubeAgentVersion(ctx, h.cfg.ProxyClient, h.GetClusterFeatures(), h.cfg.AutomaticUpgradesChannels)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/join_tokens.go
+++ b/lib/web/join_tokens.go
@@ -216,7 +216,7 @@ func (h *Handler) createTokenHandle(w http.ResponseWriter, r *http.Request, para
 func (h *Handler) getAutoUpgrades(ctx context.Context) (bool, string, error) {
 	var autoUpgradesVersion string
 	var err error
-	autoUpgrades := automaticUpgrades(h.ClusterFeatures)
+	autoUpgrades := automaticUpgrades(h.GetClusterFeatures())
 	if autoUpgrades {
 		autoUpgradesVersion, err = h.cfg.AutomaticUpgradesChannels.DefaultVersion(ctx)
 		if err != nil {


### PR DESCRIPTION
Backport #45979 to branch/v15

This was manually backported and required some changes:

- There's no `entitlements` package on v15, so all calls to its methods and types were removed.
- Some tests were updated to include more feature tests (since in master and v16 we tested mostly the Entitlements)
- I didn't update `getUserContext` to use `h.GetFeatures()`. This is because in v15 this method has some additional logic for compatibility that it uses the `Ping` call to determine.   In the original PR, the `Ping` was only for fetching features, so it was replaced, but in this PR I didn't touch that code to preserve the current behavior.
- I added an additional commit https://github.com/gravitational/teleport/pull/48224/commits/72b7e756ea25b992e4e69acb8f0f960d5988f57c. This commit exports `h.ClusterFeatures`, that the original PR made private. This is to prevent the build from breaking when we merge this PR, since Teleport Enterprise uses this method.

Teleport.E backport: https://github.com/gravitational/teleport.e/pull/5295

Note that  `Entitlements` is a new version of `Features`. They currently coexist in master for compatibility, so even though a package used in the original PR doesn't exist, it is fine to backport this because the original PR also updated the `Features`.