### PR TITLE
Remove unused `NewCLIPromptV2`

### DIFF
--- a/lib/client/mfa/cli.go
+++ b/lib/client/mfa/cli.go
@@ -86,12 +86,6 @@ func NewCLIPrompt(cfg *CLIPromptConfig) *CLIPrompt {
 	}
 }
 
-// NewCLIPromptV2 returns a new CLI mfa prompt with the given config.
-// TODO(Joerger): remove once /e is no longer dependent on this.
-func NewCLIPromptV2(cfg *CLIPromptConfig) *CLIPrompt {
-	return NewCLIPrompt(cfg)
-}
-
 func (c *CLIPrompt) stdin() prompt.StdinReader {
 	if c.cfg.StdinFunc == nil {
 		return prompt.Stdin()


### PR DESCRIPTION
Fourth and final follow up to https://github.com/gravitational/teleport/pull/47874