### PR TITLE
fix agent connection to proxy behind l7 lb

### DIFF
--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -1215,7 +1215,9 @@ func (process *TeleportProcess) newClientThroughTunnel(tlsConfig *tls.Config, ss
 		ClientConfig:          sshConfig,
 		Log:                   process.logger,
 		InsecureSkipTLSVerify: lib.IsInsecureDevMode(),
-		GetClusterCAs:         apiclient.ClusterCAsFromCertPool(tlsConfig.RootCAs),
+		GetClusterCAs: func(context.Context) (*x509.CertPool, error) {
+			return getClusterCAs()
+		},
 	})
 	if err != nil {
 		return nil, nil, trace.Wrap(err)


### PR DESCRIPTION
fixes #48238

Integration test could not catch this since they run in insecure mode.

Also note that `ALPNDialer` does call `GetClusterCAs` on each dial so no need for the `VerifyConnection` hack:
https://github.com/gravitational/teleport/blob/c1f368e6f73712267f67e44e1ff530d4f1eb5311/api/client/alpn.go#L126-L131