### PR TITLE
[teleport-update] Add update subcommand

### DIFF
--- a/lib/autoupdate/agent/installer.go
+++ b/lib/autoupdate/agent/installer.go
@@ -498,6 +498,7 @@ func tryLink(oldname, newname string) (orig string, err error) {
 	if orig == oldname {
 		return "", nil
 	}
+	// TODO(sclevine): verify oldname is valid binary
 	err = renameio.Symlink(oldname, newname)
 	if err != nil {
 		return orig, trace.Wrap(err)

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/FIPS_and_Enterprise_flags.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/FIPS_and_Enterprise_flags.golden
@@ -1,0 +1,10 @@
+version: v1
+kind: update_config
+spec:
+    proxy: localhost
+    group: ""
+    url_template: https://example.com
+    enabled: true
+status:
+    active_version: 16.3.0
+    backup_version: old-version

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/backup_version_kept_when_no_change.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/backup_version_kept_when_no_change.golden
@@ -1,0 +1,10 @@
+version: v1
+kind: update_config
+spec:
+    proxy: localhost
+    group: ""
+    url_template: https://example.com
+    enabled: true
+status:
+    active_version: 16.3.0
+    backup_version: backup-version

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/backup_version_removed_on_install.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/backup_version_removed_on_install.golden
@@ -1,0 +1,10 @@
+version: v1
+kind: update_config
+spec:
+    proxy: localhost
+    group: ""
+    url_template: https://example.com
+    enabled: true
+status:
+    active_version: 16.3.0
+    backup_version: old-version

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_disabled_during_window.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_disabled_during_window.golden
@@ -1,0 +1,10 @@
+version: v1
+kind: update_config
+spec:
+    proxy: localhost
+    group: group
+    url_template: https://example.com
+    enabled: false
+status:
+    active_version: old-version
+    backup_version: ""

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_disabled_outside_of_window.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_disabled_outside_of_window.golden
@@ -1,0 +1,10 @@
+version: v1
+kind: update_config
+spec:
+    proxy: localhost
+    group: group
+    url_template: https://example.com
+    enabled: false
+status:
+    active_version: old-version
+    backup_version: ""

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_enabled_during_window.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_enabled_during_window.golden
@@ -1,0 +1,10 @@
+version: v1
+kind: update_config
+spec:
+    proxy: localhost
+    group: group
+    url_template: https://example.com
+    enabled: true
+status:
+    active_version: 16.3.0
+    backup_version: old-version

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_enabled_outside_of_window.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_enabled_outside_of_window.golden
@@ -1,0 +1,10 @@
+version: v1
+kind: update_config
+spec:
+    proxy: localhost
+    group: group
+    url_template: https://example.com
+    enabled: true
+status:
+    active_version: old-version
+    backup_version: ""

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/version_already_installed_in_window.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/version_already_installed_in_window.golden
@@ -1,0 +1,10 @@
+version: v1
+kind: update_config
+spec:
+    proxy: localhost
+    group: ""
+    url_template: https://example.com
+    enabled: true
+status:
+    active_version: 16.3.0
+    backup_version: ""

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/version_already_installed_outside_of_window.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/version_already_installed_outside_of_window.golden
@@ -1,0 +1,10 @@
+version: v1
+kind: update_config
+spec:
+    proxy: localhost
+    group: ""
+    url_template: https://example.com
+    enabled: true
+status:
+    active_version: 16.3.0
+    backup_version: ""

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -60,9 +60,9 @@ const (
 
 // Log keys
 const (
-	targetVersionKey = "targetVersion"
-	activeVersionKey = "activeVersion"
-	backupVersionKey = "backupVersion"
+	targetVersionKey = "target_version"
+	activeVersionKey = "active_version"
+	backupVersionKey = "backup_version"
 	errorKey         = "error"
 )
 

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client/webclient"
 	libdefaults "github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/modules"
 	libutils "github.com/gravitational/teleport/lib/utils"
 )
 
@@ -293,8 +294,12 @@ func (u *Updater) Enable(ctx context.Context, override OverrideConfig) error {
 			return trace.Errorf("failed to request version from proxy: %w", err)
 		}
 		targetVersion = resp.AutoUpdate.AgentVersion
-		if resp.Edition == "ent" {
+		switch resp.Edition {
+		case modules.BuildEnterprise:
 			flags |= FlagEnterprise
+		case modules.BuildOSS, modules.BuildCommunity:
+		default:
+			u.Log.WarnContext(ctx, "Unknown edition detected, defaulting to community.", "edition", resp.Edition)
 		}
 		if resp.FIPS {
 			flags |= FlagFIPS

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -504,7 +504,7 @@ func (u *Updater) update(ctx context.Context, cfg *UpdateConfig, targetVersion s
 		u.Log.InfoContext(ctx, "Target version successfully validated.", targetVersionKey, targetVersion)
 	}
 	if v := cfg.Status.BackupVersion; v != "" {
-		u.Log.InfoContext(ctx, "Backup version set.", "backupVersion", v)
+		u.Log.InfoContext(ctx, "Backup version set.", backupVersionKey, v)
 	}
 
 	// Check if manual cleanup might be needed.

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -384,8 +384,12 @@ func (u *Updater) Update(ctx context.Context) error {
 	}
 	targetVersion := resp.AutoUpdate.AgentVersion
 	var flags InstallFlags
-	if resp.Edition == "ent" {
+	switch resp.Edition {
+	case modules.BuildEnterprise:
 		flags |= FlagEnterprise
+	case modules.BuildOSS, modules.BuildCommunity:
+	default:
+		u.Log.WarnContext(ctx, "Unknown edition detected, defaulting to community.", "edition", resp.Edition)
 	}
 	if resp.FIPS {
 		flags |= FlagFIPS

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -58,6 +58,14 @@ const (
 	updateConfigKind    = "update_config"
 )
 
+// Log keys
+const (
+	targetVersionKey = "targetVersion"
+	activeVersionKey = "activeVersion"
+	backupVersionKey = "backupVersion"
+	errorKey         = "error"
+)
+
 // UpdateConfig describes the update.yaml file schema.
 type UpdateConfig struct {
 	// Version of the configuration file
@@ -243,6 +251,8 @@ type OverrideConfig struct {
 	URLTemplate string
 	// ForceVersion to the specified version.
 	ForceVersion string
+	// ForceFlags in installed Teleport.
+	ForceFlags InstallFlags
 }
 
 // Enable enables agent updates and attempts an initial update.
@@ -258,6 +268,9 @@ func (u *Updater) Enable(ctx context.Context, override OverrideConfig) error {
 	if err := validateConfigSpec(&cfg.Spec, override); err != nil {
 		return trace.Wrap(err)
 	}
+	if cfg.Spec.Proxy == "" {
+		return trace.Errorf("Teleport proxy URL must be specified with --proxy or present in %s", updateConfigName)
+	}
 
 	// Lookup target version from the proxy.
 
@@ -265,9 +278,9 @@ func (u *Updater) Enable(ctx context.Context, override OverrideConfig) error {
 	if err != nil {
 		return trace.Errorf("failed to parse proxy server address: %w", err)
 	}
-	desiredVersion := override.ForceVersion
-	var flags InstallFlags
-	if desiredVersion == "" {
+	targetVersion := override.ForceVersion
+	flags := override.ForceFlags
+	if targetVersion == "" {
 		resp, err := webclient.Find(&webclient.Config{
 			Context:     ctx,
 			ProxyAddr:   addr.Addr,
@@ -279,7 +292,7 @@ func (u *Updater) Enable(ctx context.Context, override OverrideConfig) error {
 		if err != nil {
 			return trace.Errorf("failed to request version from proxy: %w", err)
 		}
-		desiredVersion = resp.AutoUpdate.AgentVersion
+		targetVersion = resp.AutoUpdate.AgentVersion
 		if resp.Edition == "ent" {
 			flags |= FlagEnterprise
 		}
@@ -288,97 +301,12 @@ func (u *Updater) Enable(ctx context.Context, override OverrideConfig) error {
 		}
 	}
 
-	if desiredVersion == "" {
+	if targetVersion == "" {
 		return trace.Errorf("agent version not available from Teleport cluster")
 	}
-	switch cfg.Status.BackupVersion {
-	case "", desiredVersion, cfg.Status.ActiveVersion:
-	default:
-		if desiredVersion == cfg.Status.ActiveVersion {
-			// Keep backup version if we are only verifying active version
-			break
-		}
-		err := u.Installer.Remove(ctx, cfg.Status.BackupVersion)
-		if err != nil {
-			// this could happen if it was already removed due to a failed installation
-			u.Log.WarnContext(ctx, "Failed to remove backup version of Teleport before new install.", "error", err)
-		}
-	}
 
-	// Install the desired version (or validate existing installation)
-
-	template := cfg.Spec.URLTemplate
-	if template == "" {
-		template = cdnURITemplate
-	}
-	err = u.Installer.Install(ctx, desiredVersion, template, flags)
-	if err != nil {
-		return trace.Errorf("failed to install: %w", err)
-	}
-	revert, err := u.Installer.Link(ctx, desiredVersion)
-	if err != nil {
-		return trace.Errorf("failed to link: %w", err)
-	}
-
-	// If we fail to revert after this point, the next update/enable will
-	// fix the link to restore the active version.
-
-	// Sync process configuration after linking.
-
-	if err := u.Process.Sync(ctx); err != nil {
-		if errors.Is(err, context.Canceled) {
-			return trace.Errorf("sync canceled")
-		}
-		// If sync fails, we may have left the host in a bad state, so we revert linking and re-Sync.
-		u.Log.ErrorContext(ctx, "Reverting symlinks due to invalid configuration.")
-		if ok := revert(ctx); !ok {
-			u.Log.ErrorContext(ctx, "Failed to revert Teleport symlinks. Installation likely broken.")
-		} else if err := u.Process.Sync(ctx); err != nil {
-			u.Log.ErrorContext(ctx, "Failed to sync configuration after failed restart.", "error", err)
-		}
-		u.Log.WarnContext(ctx, "Teleport updater encountered a configuration error and successfully reverted the installation.")
-
-		return trace.Errorf("failed to validate configuration for new version %q of Teleport: %w", desiredVersion, err)
-	}
-
-	// Restart Teleport if necessary.
-
-	if cfg.Status.ActiveVersion != desiredVersion {
-		u.Log.InfoContext(ctx, "Target version successfully installed.", "version", desiredVersion)
-		if err := u.Process.Reload(ctx); err != nil && !errors.Is(err, ErrNotNeeded) {
-			if errors.Is(err, context.Canceled) {
-				return trace.Errorf("reload canceled")
-			}
-			// If reloading Teleport at the new version fails, revert, resync, and reload.
-			u.Log.ErrorContext(ctx, "Reverting symlinks due to failed restart.")
-			if ok := revert(ctx); !ok {
-				u.Log.ErrorContext(ctx, "Failed to revert Teleport symlinks to older version. Installation likely broken.")
-			} else if err := u.Process.Sync(ctx); err != nil {
-				u.Log.ErrorContext(ctx, "Invalid configuration found after reverting Teleport to older version. Installation likely broken.", "error", err)
-			} else if err := u.Process.Reload(ctx); err != nil && !errors.Is(err, ErrNotNeeded) {
-				u.Log.ErrorContext(ctx, "Failed to revert Teleport to older version. Installation likely broken.", "error", err)
-			}
-			u.Log.WarnContext(ctx, "Teleport updater encountered a configuration error and successfully reverted the installation.")
-
-			return trace.Errorf("failed to start new version %q of Teleport: %w", desiredVersion, err)
-		}
-		cfg.Status.BackupVersion = cfg.Status.ActiveVersion
-		cfg.Status.ActiveVersion = desiredVersion
-	} else {
-		u.Log.InfoContext(ctx, "Target version successfully validated.", "version", desiredVersion)
-	}
-	if v := cfg.Status.BackupVersion; v != "" {
-		u.Log.InfoContext(ctx, "Backup version set.", "version", v)
-	}
-
-	// Check if manual cleanup might be needed.
-
-	versions, err := u.Installer.List(ctx)
-	if err != nil {
-		return trace.Errorf("failed to list installed versions: %w", err)
-	}
-	if n := len(versions); n > 2 {
-		u.Log.WarnContext(ctx, "More than 2 versions of Teleport installed. Version directory may need cleanup to save space.", "count", n)
+	if err := u.update(ctx, cfg, targetVersion, flags); err != nil {
+		return trace.Wrap(err)
 	}
 
 	// Always write the configuration file if enable succeeds.
@@ -406,6 +334,189 @@ func (u *Updater) Disable(ctx context.Context) error {
 	if err := writeConfig(u.ConfigPath, cfg); err != nil {
 		return trace.Errorf("failed to write %s: %w", updateConfigName, err)
 	}
+	return nil
+}
+
+// Update initiates an agent update.
+// If the update succeeds, the new installed version is marked as active.
+// Otherwise, the auto-updates configuration is not changed.
+// Unlike Enable, Update will not validate or repair the current version.
+// This function is idempotent.
+func (u *Updater) Update(ctx context.Context) error {
+	// Read configuration from update.yaml and override any new values passed as flags.
+	cfg, err := readConfig(u.ConfigPath)
+	if err != nil {
+		return trace.Errorf("failed to read %s: %w", updateConfigName, err)
+	}
+	if err := validateConfigSpec(&cfg.Spec, OverrideConfig{}); err != nil {
+		return trace.Wrap(err)
+	}
+	activeVersion := cfg.Status.ActiveVersion
+	if !cfg.Spec.Enabled {
+		u.Log.InfoContext(ctx, "Automatic updates disabled.", activeVersionKey, activeVersion)
+		return nil
+	}
+	if cfg.Spec.Proxy == "" {
+		return trace.Errorf("Teleport proxy URL must be present in %s", updateConfigName)
+	}
+
+	// Lookup target version from the proxy.
+
+	addr, err := libutils.ParseAddr(cfg.Spec.Proxy)
+	if err != nil {
+		return trace.Errorf("failed to parse proxy server address: %w", err)
+	}
+	resp, err := webclient.Find(&webclient.Config{
+		Context:     ctx,
+		ProxyAddr:   addr.Addr,
+		Insecure:    u.InsecureSkipVerify,
+		Timeout:     30 * time.Second,
+		UpdateGroup: cfg.Spec.Group,
+		Pool:        u.Pool,
+	})
+	if err != nil {
+		return trace.Errorf("failed to request version from proxy: %w", err)
+	}
+	targetVersion := resp.AutoUpdate.AgentVersion
+	var flags InstallFlags
+	if resp.Edition == "ent" {
+		flags |= FlagEnterprise
+	}
+	if resp.FIPS {
+		flags |= FlagFIPS
+	}
+
+	if !resp.AutoUpdate.AgentAutoUpdate {
+		switch targetVersion {
+		case "":
+			u.Log.WarnContext(ctx, "Cannot determine target agent version. Waiting for both version and update window.")
+		case activeVersion:
+			u.Log.InfoContext(ctx, "Teleport is up-to-date. Update window is not active.", activeVersionKey, activeVersion)
+		default:
+			u.Log.InfoContext(ctx, "Update available, but update window is not active.", targetVersionKey, targetVersion, activeVersionKey, activeVersion)
+		}
+		return nil
+	}
+
+	switch targetVersion {
+	case "":
+		u.Log.ErrorContext(ctx, "Update window is active, but target version is not available.", activeVersionKey, activeVersion)
+		return trace.Errorf("target version missing")
+	case activeVersion:
+		u.Log.InfoContext(ctx, "Teleport is up-to-date. Update window is active, but no action is needed.", activeVersionKey, activeVersion)
+		return nil
+	default:
+		u.Log.InfoContext(ctx, "Update available. Initiating update.", targetVersionKey, targetVersion, activeVersionKey, activeVersion)
+	}
+
+	jitterSec := resp.AutoUpdate.AgentUpdateJitterSeconds
+	time.Sleep(time.Duration(jitterSec) * time.Second)
+
+	if err := u.update(ctx, cfg, targetVersion, flags); err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Write the configuration file if update succeeds.
+
+	if err := writeConfig(u.ConfigPath, cfg); err != nil {
+		return trace.Errorf("failed to write %s: %w", updateConfigName, err)
+	}
+	u.Log.InfoContext(ctx, "Configuration updated.")
+	return nil
+}
+
+func (u *Updater) update(ctx context.Context, cfg *UpdateConfig, targetVersion string, flags InstallFlags) error {
+	activeVersion := cfg.Status.ActiveVersion
+	switch v := cfg.Status.BackupVersion; v {
+	case "", targetVersion, activeVersion:
+	default:
+		if targetVersion == activeVersion {
+			// Keep backup version if we are only verifying active version
+			break
+		}
+		err := u.Installer.Remove(ctx, v)
+		if err != nil {
+			// this could happen if it was already removed due to a failed installation
+			u.Log.WarnContext(ctx, "Failed to remove backup version of Teleport before new install.", errorKey, err, backupVersionKey, v)
+		}
+	}
+
+	// Install the desired version (or validate existing installation)
+
+	template := cfg.Spec.URLTemplate
+	if template == "" {
+		template = cdnURITemplate
+	}
+	err := u.Installer.Install(ctx, targetVersion, template, flags)
+	if err != nil {
+		return trace.Errorf("failed to install: %w", err)
+	}
+	revert, err := u.Installer.Link(ctx, targetVersion)
+	if err != nil {
+		return trace.Errorf("failed to link: %w", err)
+	}
+
+	// If we fail to revert after this point, the next update/enable will
+	// fix the link to restore the active version.
+
+	// Sync process configuration after linking.
+
+	if err := u.Process.Sync(ctx); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return trace.Errorf("sync canceled")
+		}
+		// If sync fails, we may have left the host in a bad state, so we revert linking and re-Sync.
+		u.Log.ErrorContext(ctx, "Reverting symlinks due to invalid configuration.")
+		if ok := revert(ctx); !ok {
+			u.Log.ErrorContext(ctx, "Failed to revert Teleport symlinks. Installation likely broken.")
+		} else if err := u.Process.Sync(ctx); err != nil {
+			u.Log.ErrorContext(ctx, "Failed to sync configuration after failed restart.", errorKey, err)
+		}
+		u.Log.WarnContext(ctx, "Teleport updater encountered a configuration error and successfully reverted the installation.")
+
+		return trace.Errorf("failed to validate configuration for new version %q of Teleport: %w", targetVersion, err)
+	}
+
+	// Restart Teleport if necessary.
+
+	if cfg.Status.ActiveVersion != targetVersion {
+		u.Log.InfoContext(ctx, "Target version successfully installed.", targetVersionKey, targetVersion)
+		if err := u.Process.Reload(ctx); err != nil && !errors.Is(err, ErrNotNeeded) {
+			if errors.Is(err, context.Canceled) {
+				return trace.Errorf("reload canceled")
+			}
+			// If reloading Teleport at the new version fails, revert, resync, and reload.
+			u.Log.ErrorContext(ctx, "Reverting symlinks due to failed restart.")
+			if ok := revert(ctx); !ok {
+				u.Log.ErrorContext(ctx, "Failed to revert Teleport symlinks to older version. Installation likely broken.")
+			} else if err := u.Process.Sync(ctx); err != nil {
+				u.Log.ErrorContext(ctx, "Invalid configuration found after reverting Teleport to older version. Installation likely broken.", errorKey, err)
+			} else if err := u.Process.Reload(ctx); err != nil && !errors.Is(err, ErrNotNeeded) {
+				u.Log.ErrorContext(ctx, "Failed to revert Teleport to older version. Installation likely broken.", errorKey, err)
+			}
+			u.Log.WarnContext(ctx, "Teleport updater encountered a configuration error and successfully reverted the installation.")
+
+			return trace.Errorf("failed to start new version %q of Teleport: %w", targetVersion, err)
+		}
+		cfg.Status.BackupVersion = cfg.Status.ActiveVersion
+		cfg.Status.ActiveVersion = targetVersion
+	} else {
+		u.Log.InfoContext(ctx, "Target version successfully validated.", targetVersionKey, targetVersion)
+	}
+	if v := cfg.Status.BackupVersion; v != "" {
+		u.Log.InfoContext(ctx, "Backup version set.", "backupVersion", v)
+	}
+
+	// Check if manual cleanup might be needed.
+
+	versions, err := u.Installer.List(ctx)
+	if err != nil {
+		return trace.Errorf("failed to list installed versions: %w", err)
+	}
+	if n := len(versions); n > 2 {
+		u.Log.WarnContext(ctx, "More than 2 versions of Teleport installed. Version directory may need cleanup to save space.", "count", n)
+	}
+
 	return nil
 }
 
@@ -466,9 +577,6 @@ func validateConfigSpec(spec *UpdateSpec, override OverrideConfig) error {
 	if spec.URLTemplate != "" &&
 		!strings.HasPrefix(strings.ToLower(spec.URLTemplate), "https://") {
 		return trace.Errorf("Teleport download URL must use TLS (https://)")
-	}
-	if spec.Proxy == "" {
-		return trace.Errorf("Teleport proxy URL must be specified with --proxy or present in %s", updateConfigName)
 	}
 	return nil
 }

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -115,12 +115,11 @@ func Run(args []string) error {
 		Short('t').Envar(templateEnvVar).StringVar(&ccfg.URLTemplate)
 	enableCmd.Flag("force-version", "Force the provided version instead of querying it from the Teleport cluster.").
 		Short('f').Envar(updateVersionEnvVar).Hidden().StringVar(&ccfg.ForceVersion)
+	// TODO(sclevine): add force-fips and force-enterprise as hidden flags
 
 	disableCmd := app.Command("disable", "Disable agent auto-updates.")
 
 	updateCmd := app.Command("update", "Update agent to the latest version, if a new version is available.")
-	updateCmd.Flag("force-version", "Use the provided version instead of querying it from the Teleport cluster.").
-		Short('f').Envar(updateVersionEnvVar).Hidden().StringVar(&ccfg.ForceVersion)
 
 	libutils.UpdateAppUsageTemplate(app, args)
 	command, err := app.Parse(args)


### PR DESCRIPTION
This PR adds the `update` subcommand to the `teleport-update` command.

Unlike the `enable` subcommand, the `update` subcommand:
1. Will not validate or modify an existing installation of Teleport that is already at the correct version.
2. Respects the `agent_auto_update` and `agent_auto_update_jitter` fields in the `/webapi/find` response.

This is the fifth in a series of PRs implementing `teleport-update`:
Reloading with rollbacks: https://github.com/gravitational/teleport/pull/47929
Linking: https://github.com/gravitational/teleport/pull/47879
Enable Command: https://github.com/gravitational/teleport/pull/47565
Initial scaffolding PR: https://github.com/gravitational/teleport/pull/46418

The `teleport-update` binary will be used to enable, disable, and trigger automatic Teleport agent updates. The new auto-updates system manages a local installation of the cluster-specified version of Teleport stored in `/var/lib/teleport/versions`.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/10289