### PR TITLE
adding missing GID value when fetching Hostuser

### DIFF
--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -689,6 +689,7 @@ func (u *HostUserManagement) getHostUser(username string) (*HostUser, error) {
 	return &HostUser{
 		Name:   username,
 		UID:    usr.Uid,
+		GID:    usr.Gid,
 		Home:   usr.HomeDir,
 		Groups: groups,
 	}, trace.NewAggregate(groupErrs...)


### PR DESCRIPTION
Fixes #48243 

This fixes a regression that breaks migrating existing, unmanaged host users to Teleport. The missing value for `GID` when fetching a `HostUser` causes an error while trying to conver to an int for home directory creation. The migration flow is covered by unit tests, but since this only manifests in the linux backend it wasn't caught. I added a new host user integration test to cover this regression going forward.

changelog: Fixed an issue preventing migration of unmanaged users to Teleport host users when including `teleport-keep` in a role's `host_groups`.