### PR TITLE
Properly default auth's storage config

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -6135,8 +6135,8 @@ func warnOnErr(ctx context.Context, err error, log *slog.Logger) {
 // initAuthStorage initializes the storage backend for the auth service.
 func (process *TeleportProcess) initAuthStorage() (backend.Backend, error) {
 	ctx := context.TODO()
-	process.logger.DebugContext(process.ExitContext(), "Initializing auth backend.", "backend", process.Config.Auth.StorageConfig.Type)
 	bc := process.Config.Auth.StorageConfig
+	process.logger.DebugContext(process.ExitContext(), "Initializing auth backend.", "type", bc.Type)
 	bk, err := backend.New(ctx, bc.Type, bc.Params)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -555,7 +555,7 @@ func ApplyDefaults(cfg *Config) {
 	cfg.Auth.Enabled = true
 	cfg.Auth.ListenAddr = *defaults.AuthListenAddr()
 	cfg.Auth.StorageConfig.Type = lite.GetName()
-	cfg.Auth.StorageConfig.Params = backend.Params{defaults.BackendPath: filepath.Join(cfg.DataDir, defaults.BackendDir)}
+	cfg.Auth.StorageConfig.Params = make(backend.Params)
 	cfg.Auth.StaticTokens = types.DefaultStaticTokens()
 	cfg.Auth.AuditConfig = types.DefaultClusterAuditConfig()
 	cfg.Auth.NetworkingConfig = types.DefaultClusterNetworkingConfig()
@@ -655,6 +655,15 @@ func ValidateConfig(cfg *Config) error {
 
 	if cfg.DataDir == "" {
 		return trace.BadParameter("config: please supply data directory")
+	}
+
+	if cfg.Auth.Enabled {
+		if cfg.Auth.StorageConfig.Params.GetString(defaults.BackendPath) == "" {
+			if cfg.Auth.StorageConfig.Params == nil {
+				cfg.Auth.StorageConfig.Params = make(backend.Params)
+			}
+			cfg.Auth.StorageConfig.Params[defaults.BackendPath] = filepath.Join(cfg.DataDir, defaults.BackendDir)
+		}
 	}
 
 	for i := range cfg.Auth.Authorities {

--- a/lib/service/servicecfg/config_test.go
+++ b/lib/service/servicecfg/config_test.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -88,7 +87,7 @@ func TestDefaultConfig(t *testing.T) {
 	require.Equal(t, localAuthAddr, auth.ListenAddr)
 	require.Equal(t, int64(defaults.LimiterMaxConnections), auth.Limiter.MaxConnections)
 	require.Equal(t, lite.GetName(), config.Auth.StorageConfig.Type)
-	require.Equal(t, filepath.Join(config.DataDir, defaults.BackendDir), auth.StorageConfig.Params[defaults.BackendPath])
+	require.Empty(t, auth.StorageConfig.Params[defaults.BackendPath])
 
 	// SSH section
 	ssh := config.SSH


### PR DESCRIPTION
I was trying to run `TestDynamicClientReuse` locally and noticed an error trying to write to `/var/lib/teleport`, which is unexpected since the test sets the data dir to a temp directory.

It turns out that most of our tests override the datadir, but fail to also update the auth's storage config.

Instead of fixing this in a bunch of tests, stop defaulting auth storage to a hard-coded `/var/lib/teleport` and instead set the default after we know what the configured data dir is supposed to be.