### PR TITLE
Fix flaky integration tests caused by prometheus metrics conflict

### DIFF
--- a/integration/tctl_terraform_env_test.go
+++ b/integration/tctl_terraform_env_test.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
-	"github.com/prometheus/client_golang/prometheus"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -33,6 +32,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/integration/tctl_terraform_env_test.go
+++ b/integration/tctl_terraform_env_test.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"github.com/prometheus/client_golang/prometheus"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -52,6 +53,7 @@ import (
 // service and generates valid credentials Terraform can use to connect to Teleport.
 func TestTCTLTerraformCommand_ProxyJoin(t *testing.T) {
 	testDir := t.TempDir()
+	prometheus.DefaultRegisterer = metricRegistryBlackHole{}
 
 	// Test setup: creating a teleport instance running auth and proxy
 	clusterName := "root.example.com"
@@ -127,6 +129,7 @@ func TestTCTLTerraformCommand_ProxyJoin(t *testing.T) {
 func TestTCTLTerraformCommand_AuthJoin(t *testing.T) {
 	t.Parallel()
 	testDir := t.TempDir()
+	prometheus.DefaultRegisterer = metricRegistryBlackHole{}
 
 	// Test setup: creating a teleport instance running auth and proxy
 	clusterName := "root.example.com"
@@ -347,4 +350,21 @@ func connectWithCredentialsFromVars(t *testing.T, vars map[string]string, clt *a
 	require.NoError(t, err)
 	_, err = botClt.Ping(ctx)
 	require.NoError(t, err)
+}
+
+// metricRegistryBlackHole is a fake prometheus.Registerer that accepts every metric and do nothing.
+// This is a workaround for different teleport component using the global registry but registering incompatible metrics.
+// Those issues can surface during integration tests starting Teleport auth, proxy, and tbot.
+// The long-term fix is to have every component use its own registry instead of the global one.
+type metricRegistryBlackHole struct {
+}
+
+func (m metricRegistryBlackHole) Register(_ prometheus.Collector) error {
+	return nil
+}
+
+func (m metricRegistryBlackHole) MustRegister(_ ...prometheus.Collector) {}
+
+func (m metricRegistryBlackHole) Unregister(_ prometheus.Collector) bool {
+	return true
 }


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/44944 by overriding the default metrics registry with a blackhole.

This is quite ugly as this override will need to happen on every test running both auth/proxy and tbot in the same process.
The best long-term fix this would be to have tbot use a tbot-scoped registry.