### PR TITLE
Discover: update supported distro versions in pick resource screen

### DIFF
--- a/web/packages/teleport/src/Discover/SelectResource/resources.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/resources.tsx
@@ -46,7 +46,7 @@ const kubeKeywords = ['kubernetes', 'k8s', 'kubes', 'cluster'];
 
 export const SERVERS: ResourceSpec[] = [
   {
-    name: 'Ubuntu 14.04+',
+    name: 'Ubuntu 18.04+',
     kind: ResourceKind.Server,
     keywords: [...baseServerKeywords, 'ubuntu', 'linux'],
     icon: 'linux',
@@ -54,7 +54,7 @@ export const SERVERS: ResourceSpec[] = [
     platform: Platform.Linux,
   },
   {
-    name: 'Debian 8+',
+    name: 'Debian 11+',
     kind: ResourceKind.Server,
     keywords: [...baseServerKeywords, 'debian', 'linux'],
     icon: 'linux',
@@ -62,7 +62,7 @@ export const SERVERS: ResourceSpec[] = [
     platform: Platform.Linux,
   },
   {
-    name: 'RHEL/CentOS 7+',
+    name: 'RHEL 8+/CentOS Stream 9+',
     kind: ResourceKind.Server,
     keywords: [...baseServerKeywords, 'rhel', 'redhat', 'centos', 'linux'],
     icon: 'linux',


### PR DESCRIPTION
Even tho older versions are supported by Teleport, some of them reached end of life and should be removed.

Ubuntu
https://ubuntu.com/about/release-cycle

Debian
https://www.debian.org/releases/

RHEL
https://access.redhat.com/support/policy/updates/errata

CentOS
https://www.centos.org/centos-stream/


Fixes: https://github.com/gravitational/teleport/issues/46413