### PR TITLE
fix: Exempt dependabot from the changelog workflow

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -16,7 +16,7 @@ on:
 permissions:
   pull-requests: write
 
-concurrency: 
+concurrency:
   cancel-in-progress: true
   # This value is arbitrary as long as it includes the pull request number
   group: 'limit to running one instance at a time for the pull request ${{ github.event.pull_request.number }}'
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   validate-changelog:
     name: Validate the changelog entry
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !startsWith(github.head_ref, 'dependabot/') && !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     steps:
       # Checkout main branch of shared-workflow repository.


### PR DESCRIPTION
The changelog workflow fails because the -reviewers flag is empty. I think that was always the case, but now that the workflow is required this blocks all dependabot PRs.

Example failure:

```
Run cd .github/shared-workflows/bot && go run main.go -workflow=changelog -token="***" -reviewers=""

2024/11/01 13:42:03 Failed to parse flags: 
ERROR REPORT:
Original Error: *trace.BadParameterError reviewers required for assign and check
Stack Trace:
	/home/runner/work/teleport/teleport/.github/shared-workflows/bot/main.go:141 main.parseFlags
	/home/runner/work/teleport/teleport/.github/shared-workflows/bot/main.go:37 main.main
	/opt/hostedtoolcache/go/1.23.2/x[6](https://github.com/gravitational/teleport/actions/runs/11627067334/job/32388964174?pr=48261#step:4:7)4/src/runtime/proc.go:272 runtime.main
	/opt/hostedtoolcache/go/1.23.2/x64/src/runtime/asm_amd64.s:1[7](https://github.com/gravitational/teleport/actions/runs/11627067334/job/32388964174?pr=48261#step:4:8)00 runtime.goexit
User Message: reviewers required for assign and check.
exit status 1
Error: Process completed with exit code 1.
```

Reference on shared-workflows:

* https://github.com/gravitational/shared-workflows/blob/340561d4996e85b686c714df97a53cd40c142838/bot/main.go#L141
