### PR TITLE
Decrease log severity when using non-resumable connection to mux

### DIFF
--- a/lib/resumption/server_detect.go
+++ b/lib/resumption/server_detect.go
@@ -211,7 +211,7 @@ func (r *SSHServerWrapper) HandleConnection(nc net.Conn) {
 	}
 
 	if !isResumeV1 {
-		slog.ErrorContext(context.TODO(), "returning non-resumable connection to multiplexer")
+		slog.DebugContext(context.TODO(), "returning non-resumable connection to multiplexer")
 		r.sshServer(&sshVersionSkipConn{
 			Conn: conn,
 


### PR DESCRIPTION
This was wrongly converted from a debug to an error message in
https://github.com/gravitational/teleport/pull/44244/files#diff-4ad3d291c4e579d86d5a5e9d2fc8b7ff606354e5168d196eef5e6998a49b9427L222-L224

<img width="827" alt="image" src="https://github.com/user-attachments/assets/84a03b49-e4e4-401f-a7b5-48345249a22d">
