### PR TITLE
fix: prevent tctl edit overwriting static file config

### DIFF
--- a/tool/tctl/common/edit_command.go
+++ b/tool/tctl/common/edit_command.go
@@ -44,10 +44,11 @@ import (
 // EditCommand implements the `tctl edit` command for modifying
 // Teleport resources.
 type EditCommand struct {
-	app    *kingpin.Application
-	cmd    *kingpin.CmdClause
-	config *servicecfg.Config
-	ref    services.Ref
+	app     *kingpin.Application
+	cmd     *kingpin.CmdClause
+	config  *servicecfg.Config
+	ref     services.Ref
+	confirm bool
 
 	// Editor is used by tests to inject the editing mechanism
 	// so that different scenarios can be asserted.
@@ -61,9 +62,10 @@ func (e *EditCommand) Initialize(app *kingpin.Application, config *servicecfg.Co
 	e.cmd.Arg("resource type/resource name", `Resource to update
 	<resource type>  Type of a resource [for example: rc]
 	<resource name>  Resource name to update
-	
+
 	Example:
 	$ tctl edit rc/remote`).SetValue(&e.ref)
+	e.cmd.Flag("confirm", "Confirm an unsafe or temporary resource update").Hidden().BoolVar(&e.confirm)
 }
 
 func (e *EditCommand) TryRun(ctx context.Context, cmd string, client *authclient.Client) (bool, error) {
@@ -115,6 +117,7 @@ func (e *EditCommand) editResource(ctx context.Context, client *authclient.Clien
 		filename:    f.Name(),
 		force:       true,
 		withSecrets: true,
+		confirm:     e.confirm,
 	}
 	rc.Initialize(e.app, e.config)
 


### PR DESCRIPTION
`tctl create -f` prevents overwriting the `cluster_auth_preference`, `cluster_networking_config`, or `session_recording_config` if their configuration is coming from a static config file. Any dynamic edits made to these resources would be overwritten the next time the auth server restarts, so a user trying to edit them using `tctl` is usually making a mistake. `tctl create` prevents this mistake unless the user explicitly passes `--confirm` which might be useful in some break-glass scenarios.

But unfortunately `tctl edit` does nothing to prevent edits to these resources and I have confused myself many times when my config later gets overwritten after a successful `tctl edit`. This PR updates `tctl edit` to do the same check and require the `--confirm` flag to edit any resources configured statically.

changelog: Added a warning to `tctl edit` about dynamic edits to statically configured resources