### PR TITLE
[v17] fix app access regression when the app is on a leaf cluster

### DIFF
--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -617,11 +617,14 @@ const (
 //
 // The URL's are formed this way to help isolate the path params reserved for the app
 // launchers route, where order and existence of previous params matter for this route.
-func makeAppRedirectURL(r *http.Request, proxyPublicAddr, hostname string, req launcherURLParams) string {
+func makeAppRedirectURL(r *http.Request, proxyPublicAddr, addr string, req launcherURLParams) string {
+	if req.requiresAppRedirect {
+		addr = req.publicAddr
+	}
 	u := url.URL{
 		Scheme: "https",
 		Host:   proxyPublicAddr,
-		Path:   fmt.Sprintf("/web/launch/%s", hostname),
+		Path:   fmt.Sprintf("/web/launch/%s", addr),
 	}
 
 	// Presence of a stateToken means we are beginning an app auth exchange.
@@ -634,7 +637,7 @@ func makeAppRedirectURL(r *http.Request, proxyPublicAddr, hostname string, req l
 		v.Add("required-apps", req.requiredAppFQDNs)
 		u.RawQuery = v.Encode()
 
-		urlPath := []string{"web", "launch", hostname}
+		urlPath := []string{"web", "launch", addr}
 
 		// The order and existence of previous params matter.
 		//

--- a/lib/web/app/middleware.go
+++ b/lib/web/app/middleware.go
@@ -81,12 +81,8 @@ func (h *Handler) redirectToLauncher(w http.ResponseWriter, r *http.Request, p l
 			"https://goteleport.com/docs/application-access/guides/connecting-apps/#start-authproxy-service.")
 		return trace.BadParameter("public address of the proxy is not set")
 	}
-	host := p.publicAddr
-	if host == "" {
-		host = r.Host
-	}
 
-	addr, err := utils.ParseAddr(host)
+	addr, err := utils.ParseAddr(r.Host)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/47778.

changelog: fix app access regression to apps on leaf clusters