### PR TITLE
[cli] update tbot command descriptions

### DIFF
--- a/lib/tbot/cli/start_application.go
+++ b/lib/tbot/cli/start_application.go
@@ -41,7 +41,7 @@ type ApplicationCommand struct {
 // NewApplicationCommand initializes a command and flag for application outputs
 // and returns a struct that will contain the parse result.
 func NewApplicationCommand(parentCmd *kingpin.CmdClause, action MutatorAction) *ApplicationCommand {
-	cmd := parentCmd.Command("application", "Starts with an application output").Alias("app")
+	cmd := parentCmd.Command("application", "Starts with an application output.").Alias("app")
 
 	c := &ApplicationCommand{}
 	c.sharedStartArgs = newSharedStartArgs(cmd)

--- a/lib/tbot/cli/start_application_tunnel.go
+++ b/lib/tbot/cli/start_application_tunnel.go
@@ -40,7 +40,7 @@ type ApplicationTunnelCommand struct {
 // NewApplicationTunnelCommand initializes flags for an app tunnel command and
 // returns a struct to contain the parse result.
 func NewApplicationTunnelCommand(parentCmd *kingpin.CmdClause, action MutatorAction) *ApplicationTunnelCommand {
-	cmd := parentCmd.Command("application-tunnel", "Starts an application tunnel").Alias("app-tunnel")
+	cmd := parentCmd.Command("application-tunnel", "Starts an application tunnel.").Alias("app-tunnel")
 
 	c := &ApplicationTunnelCommand{}
 	c.sharedStartArgs = newSharedStartArgs(cmd)

--- a/lib/tbot/cli/start_database.go
+++ b/lib/tbot/cli/start_database.go
@@ -43,7 +43,7 @@ type DatabaseCommand struct {
 // NewDatabaseCommand initializes a command and flags for database outputs and
 // returns a struct that will contain the parse result.
 func NewDatabaseCommand(parentCmd *kingpin.CmdClause, action MutatorAction) *DatabaseCommand {
-	cmd := parentCmd.Command("database", "Starts with a database output").Alias("db")
+	cmd := parentCmd.Command("database", "Starts with a database output.").Alias("db")
 
 	c := &DatabaseCommand{}
 	c.sharedStartArgs = newSharedStartArgs(cmd)

--- a/lib/tbot/cli/start_database_tunnel.go
+++ b/lib/tbot/cli/start_database_tunnel.go
@@ -41,7 +41,7 @@ type DatabaseTunnelCommand struct {
 
 // NewDatabaseTunnelCommand creates a command supporting `tbot start database-tunnel`
 func NewDatabaseTunnelCommand(parentCmd *kingpin.CmdClause, action MutatorAction) *DatabaseTunnelCommand {
-	cmd := parentCmd.Command("database-tunnel", "Start a database tunnel listener").Alias("db-tunnel")
+	cmd := parentCmd.Command("database-tunnel", "Start a database tunnel listener.").Alias("db-tunnel")
 
 	c := &DatabaseTunnelCommand{}
 	c.sharedStartArgs = newSharedStartArgs(cmd)

--- a/lib/tbot/cli/start_identity.go
+++ b/lib/tbot/cli/start_identity.go
@@ -40,7 +40,7 @@ type IdentityCommand struct {
 // NewIdentityCommand initializes the command and flags for identity outputs
 // and returns a struct that will contain the parse result.
 func NewIdentityCommand(parentCmd *kingpin.CmdClause, action MutatorAction) *IdentityCommand {
-	cmd := parentCmd.Command("identity", "Start with an identity output for SSH and Teleport API access").Alias("ssh").Alias("id")
+	cmd := parentCmd.Command("identity", "Start with an identity output for SSH and Teleport API access.").Alias("ssh").Alias("id")
 
 	c := &IdentityCommand{}
 	c.sharedDestinationArgs = newSharedDestinationArgs(cmd)

--- a/lib/tbot/cli/start_kubernetes.go
+++ b/lib/tbot/cli/start_kubernetes.go
@@ -41,7 +41,7 @@ type KubernetesCommand struct {
 // NewKubernetesCommand initializes the command and flags for kubernetes outputs
 // and returns a struct to contain the parse result.
 func NewKubernetesCommand(parentCmd *kingpin.CmdClause, action MutatorAction) *KubernetesCommand {
-	cmd := parentCmd.Command("kubernetes", "Starts with a kubernetes output").Alias("k8s")
+	cmd := parentCmd.Command("kubernetes", "Starts with a kubernetes output.").Alias("k8s")
 
 	c := &KubernetesCommand{}
 	c.sharedStartArgs = newSharedStartArgs(cmd)

--- a/lib/tbot/cli/start_legacy.go
+++ b/lib/tbot/cli/start_legacy.go
@@ -140,7 +140,7 @@ func NewLegacyCommand(parentCmd *kingpin.CmdClause, action MutatorAction) *Legac
 
 	c := &LegacyCommand{
 		action: action,
-		cmd:    parentCmd.Command("legacy", "Start with either a config file or a legacy output").Default(),
+		cmd:    parentCmd.Command("legacy", "Start with either a config file or a legacy output.").Default(),
 	}
 	c.AuthProxyArgs = newAuthProxyArgs(c.cmd)
 	c.LegacyDestinationDirArgs = newLegacyDestinationDirArgs(c.cmd)

--- a/lib/tbot/cli/start_spiffe_svid.go
+++ b/lib/tbot/cli/start_spiffe_svid.go
@@ -46,7 +46,7 @@ type SPIFFESVIDCommand struct {
 // `spiffe-svid` output and returns a struct that will contain the parse
 // result.
 func NewSPIFFESVIDCommand(parentCmd *kingpin.CmdClause, action MutatorAction) *SPIFFESVIDCommand {
-	cmd := parentCmd.Command("spiffe-svid", "Starts with a SPIFFE-compatible SVID output")
+	cmd := parentCmd.Command("spiffe-svid", "Starts with a SPIFFE-compatible SVID output.")
 
 	c := &SPIFFESVIDCommand{}
 	c.sharedStartArgs = newSharedStartArgs(cmd)


### PR DESCRIPTION
Includes `.` at end of command descriptions to match other cli commands' descriptions.