### PR TITLE
docs: update networking reference

### DIFF
--- a/docs/pages/reference/networking.mdx
+++ b/docs/pages/reference/networking.mdx
@@ -36,8 +36,8 @@ following use cases:
 </TabItem>
 <TabItem scope={["cloud", "team"]} label="Cloud-Hosted">
 
-On Teleport Enterprise (Cloud) the Teleport agent services always
-connect using reverse tunnels so there is no need to set a public address for a agent.
+On Teleport Enterprise (Cloud) the Teleport Agent services always
+connect using reverse tunnels so there is no need to set a public address for an agent.
 
 </TabItem>
 </Tabs>

--- a/docs/pages/reference/networking.mdx
+++ b/docs/pages/reference/networking.mdx
@@ -37,7 +37,7 @@ following use cases:
 <TabItem scope={["cloud", "team"]} label="Cloud-Hosted">
 
 On Teleport Enterprise (Cloud) the Teleport Agent services always
-connect using reverse tunnels so there is no need to set a public address for an agent.
+connect using reverse tunnels so there is no need to set a public address for an Agent.
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
Verbiage update to match existing backports such as https://github.com/gravitational/teleport/pull/48145.