### PR TITLE
Make conditional vs unconditional updates clearer

### DIFF
--- a/lib/services/local/access_monitoring_rules.go
+++ b/lib/services/local/access_monitoring_rules.go
@@ -85,7 +85,7 @@ func (s *AccessMonitoringRulesService) CreateAccessMonitoringRule(ctx context.Co
 
 // UpdateAccessMonitoringRule updates an existing AccessMonitoringRule resource.
 func (s *AccessMonitoringRulesService) UpdateAccessMonitoringRule(ctx context.Context, amr *accessmonitoringrulesv1.AccessMonitoringRule) (*accessmonitoringrulesv1.AccessMonitoringRule, error) {
-	updated, err := s.svc.UpdateResource(ctx, amr)
+	updated, err := s.svc.UnconditionalUpdateResource(ctx, amr)
 	return updated, trace.Wrap(err)
 }
 

--- a/lib/services/local/databaseobject.go
+++ b/lib/services/local/databaseobject.go
@@ -45,7 +45,7 @@ func (s *DatabaseObjectService) UpsertDatabaseObject(ctx context.Context, object
 }
 
 func (s *DatabaseObjectService) UpdateDatabaseObject(ctx context.Context, object *dbobjectv1.DatabaseObject) (*dbobjectv1.DatabaseObject, error) {
-	out, err := s.service.UpdateResource(ctx, object)
+	out, err := s.service.UnconditionalUpdateResource(ctx, object)
 	return out, trace.Wrap(err)
 }
 

--- a/lib/services/local/databaseobjectimportrule.go
+++ b/lib/services/local/databaseobjectimportrule.go
@@ -43,7 +43,7 @@ func (s *databaseObjectImportRuleService) UpsertDatabaseObjectImportRule(ctx con
 }
 
 func (s *databaseObjectImportRuleService) UpdateDatabaseObjectImportRule(ctx context.Context, rule *databaseobjectimportrulev1.DatabaseObjectImportRule) (*databaseobjectimportrulev1.DatabaseObjectImportRule, error) {
-	out, err := s.service.UpdateResource(ctx, rule)
+	out, err := s.service.UnconditionalUpdateResource(ctx, rule)
 	return out, trace.Wrap(err)
 }
 

--- a/lib/services/local/generic/generic_wrapper.go
+++ b/lib/services/local/generic/generic_wrapper.go
@@ -126,7 +126,10 @@ func (s ServiceWrapper[T]) UpsertResource(ctx context.Context, resource T) (T, e
 }
 
 // UnconditionalUpdateResource updates an existing resource without checking the provided resource revision.
-// This is faster and cheaper than ConditionalUpdateResource but can cause data loss on concurrent writes.
+// Because UnconditionalUpdateResource can blindly overwrite an existing item, ConditionalUpdateResource should
+// be preferred.
+// See https://github.com/gravitational/teleport/blob/master/rfd/0153-resource-guidelines.md#update-1 for more details
+// about the Update operation.
 func (s ServiceWrapper[T]) UnconditionalUpdateResource(ctx context.Context, resource T) (T, error) {
 	adapter, err := s.service.UpdateResource(ctx, newResourceMetadataAdapter(resource))
 	return adapter.resource, trace.Wrap(err)
@@ -134,7 +137,8 @@ func (s ServiceWrapper[T]) UnconditionalUpdateResource(ctx context.Context, reso
 
 // ConditionalUpdateResource updates an existing resource if the provided
 // resource and the existing resource have matching revisions.
-// This is safer than UnconditionalUpdateResource but more expensive and might not suit high-load scenarios.
+// See https://github.com/gravitational/teleport/blob/master/rfd/0126-backend-migrations.md#optimistic-locking for more
+// details about the conditional update.
 func (s ServiceWrapper[T]) ConditionalUpdateResource(ctx context.Context, resource T) (T, error) {
 	adapter, err := s.service.ConditionalUpdateResource(ctx, newResourceMetadataAdapter(resource))
 	return adapter.resource, trace.Wrap(err)

--- a/lib/services/local/generic/generic_wrapper.go
+++ b/lib/services/local/generic/generic_wrapper.go
@@ -125,14 +125,16 @@ func (s ServiceWrapper[T]) UpsertResource(ctx context.Context, resource T) (T, e
 	return adapter.resource, trace.Wrap(err)
 }
 
-// UpdateResource updates an existing resource.
-func (s ServiceWrapper[T]) UpdateResource(ctx context.Context, resource T) (T, error) {
+// UnconditionalUpdateResource updates an existing resource without checking the provided resource revision.
+// This is faster and cheaper than ConditionalUpdateResource but can cause data loss on concurrent writes.
+func (s ServiceWrapper[T]) UnconditionalUpdateResource(ctx context.Context, resource T) (T, error) {
 	adapter, err := s.service.UpdateResource(ctx, newResourceMetadataAdapter(resource))
 	return adapter.resource, trace.Wrap(err)
 }
 
 // ConditionalUpdateResource updates an existing resource if the provided
 // resource and the existing resource have matching revisions.
+// This is safer than UnconditionalUpdateResource but more expensive and might not suit high-load scenarios.
 func (s ServiceWrapper[T]) ConditionalUpdateResource(ctx context.Context, resource T) (T, error) {
 	adapter, err := s.service.ConditionalUpdateResource(ctx, newResourceMetadataAdapter(resource))
 	return adapter.resource, trace.Wrap(err)

--- a/lib/services/local/generic/generic_wrapper_test.go
+++ b/lib/services/local/generic/generic_wrapper_test.go
@@ -180,7 +180,7 @@ func TestGenericWrapperCRUD(t *testing.T) {
 
 	// Update a resource.
 	r1.Metadata.Labels = map[string]string{"newlabel": "newvalue"}
-	r1, err = service.UpdateResource(ctx, r1)
+	r1, err = service.UnconditionalUpdateResource(ctx, r1)
 	require.NoError(t, err)
 	r, err = service.GetResource(ctx, r1.GetMetadata().GetName())
 	require.NoError(t, err)
@@ -198,7 +198,7 @@ func TestGenericWrapperCRUD(t *testing.T) {
 
 	// Update a resource that doesn't exist.
 	doesNotExist := newTestResource153("doesnotexist")
-	_, err = service.UpdateResource(ctx, doesNotExist)
+	_, err = service.UnconditionalUpdateResource(ctx, doesNotExist)
 	require.True(t, trace.IsNotFound(err))
 
 	// Delete a resource.


### PR DESCRIPTION
When implementing AU services we mistakenly used unconditional updates instead of conditional updates.
This PR renames `UpdateResource` into `UnconditionalUpdateResource` to make it clearer that this might be unsafe and there's a `ConditionalUpdateResource` option.