### PR TITLE
[v17] Fix markdown-lint issues

### DIFF
--- a/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
@@ -198,12 +198,12 @@ chart.
 
 1. Install the `teleport-cluster` Helm chart using the values file you wrote:
 
-    ```code
-    $ helm install teleport-cluster teleport/teleport-cluster \
-      --create-namespace \
-      --version (=teleport.version=) \
-      --values teleport-cluster-values.yaml
-    ```
+   ```code
+   $ helm install teleport-cluster teleport/teleport-cluster \
+     --create-namespace \
+     --version (=teleport.version=) \
+     --values teleport-cluster-values.yaml
+   ```
 
 1. After installing the `teleport-cluster` chart, wait a minute or so and ensure
    that both the Auth Service and Proxy Service pods are running:

--- a/docs/pages/admin-guides/deploy-a-cluster/hsm.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/hsm.mdx
@@ -188,6 +188,7 @@ to use.
    DEBU[0000] preflight complete                            cert= config= key= pid=73502 seccomp=false serial= syslog=false timeout=0s version=3.0.3
    DEBU[0000] takeoff                                       TLS=false listen="localhost:12345" pid=73502
    ```
+
 1. Use `yubihsm-shell` to create a new authentication key to be used by
    Teleport with the necessary capabilities.
 

--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/terraform-cloud.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/terraform-cloud.mdx
@@ -42,6 +42,7 @@ provider in these environments.
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)
 
 - (!docs/pages/includes/tctl.mdx!)
+
 - [Terraform >= (=terraform.version=)+](https://learn.hashicorp.com/tutorials/terraform/install-cli)
 
   ```code

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/mongodb-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/mongodb-self-hosted.mdx
@@ -34,6 +34,7 @@ videoBanner: 6lgVObxoLkc
   </Admonition>
 
 - (!docs/pages/includes/tctl.mdx!)
+
 - A certificate authority for MongoDB Replica Set, and the public certificate
   for that CA, in PEM format: `<Var name="/path/to/your/ca.crt" />`. You can
   also configure Teleport to trust this CA for standalone MongoDB instances. 

--- a/docs/pages/upgrading/automatic-agent-updates.mdx
+++ b/docs/pages/upgrading/automatic-agent-updates.mdx
@@ -316,10 +316,10 @@ This section assumes that the name of your `teleport-kube-agent` release is
    
 1. Check for any deployment issues by checking the updater logs:
    
-    ```code
-    $ kubectl -n <Var name="teleport" /> logs deployment/<Var name="teleport-agent" />-updater
-    2023-04-28T13:13:30Z	INFO	StatefulSet is already up-to-date, not updating.	{"controller": "statefulset", "controllerGroup": "apps", "controllerKind": "StatefulSet", "StatefulSet": {"name":"my-agent","namespace":"agent"}, "namespace": "agent", "name": "my-agent", "reconcileID": "10419f20-a4c9-45d4-a16f-406866b7fc05", "namespacedname": "agent/my-agent", "kind": "StatefulSet", "err": "no new version (current: \"v12.2.3\", next: \"v12.2.3\")"}
-    ```
+   ```code
+   $ kubectl -n <Var name="teleport" /> logs deployment/<Var name="teleport-agent" />-updater
+   2023-04-28T13:13:30Z	INFO	StatefulSet is already up-to-date, not updating.	{"controller": "statefulset", "controllerGroup": "apps", "controllerKind": "StatefulSet", "StatefulSet": {"name":"my-agent","namespace":"agent"}, "namespace": "agent", "name": "my-agent", "reconcileID": "10419f20-a4c9-45d4-a16f-406866b7fc05", "namespacedname": "agent/my-agent", "kind": "StatefulSet", "err": "no new version (current: \"v12.2.3\", next: \"v12.2.3\")"}
+   ```
 
 ## Troubleshooting
 

--- a/docs/pages/upgrading/upgrading-reference.mdx
+++ b/docs/pages/upgrading/upgrading-reference.mdx
@@ -369,15 +369,15 @@ your `teleport-cluster` release is called `teleport-cluster`.
 1. Update the Teleport Helm chart repository so you can install the latest
    version of the `teleport-cluster` chart:
 
-    (!docs/pages/includes/kubernetes-access/helm/helm-repo-add.mdx!)
+   (!docs/pages/includes/kubernetes-access/helm/helm-repo-add.mdx!)
 
 1. Upgrade the `teleport-cluster` Helm release:
 
-    ```code
-    $ helm upgrade teleport-cluster teleport/teleport-cluster \
-      --version=<Var name="(=teleport.version=)" /> \
-      --values=values.yaml
-    ```
+   ```code
+   $ helm upgrade teleport-cluster teleport/teleport-cluster \
+     --version=<Var name="(=teleport.version=)" /> \
+     --values=values.yaml
+   ```
 
    The `teleport-cluster` Helm chart automatically waits for the previous
    version of the Proxy Service to stop responding to requests before running a
@@ -395,7 +395,7 @@ that your `teleport-kube-agent` release is called `teleport-agent`.
 1. Update the Teleport Helm chart repository so you can install the latest
    version of the `teleport-kube-agent` chart:
 
-      (!docs/pages/includes/kubernetes-access/helm/helm-repo-add.mdx!)
+   (!docs/pages/includes/kubernetes-access/helm/helm-repo-add.mdx!)
 
 1. Upgrade the Helm release:
 


### PR DESCRIPTION
Running markdown-lint in the Docusaurus site flags some issues that the gravitational/docs markdown-lint configuration doesn't catch. This change resolves these issues, fixing indentation and list item spacing.