### PR TITLE
[v14] Fix markdown-lint issues

### DIFF
--- a/docs/pages/admin-guides/access-controls/sso/google-workspace.mdx
+++ b/docs/pages/admin-guides/access-controls/sso/google-workspace.mdx
@@ -31,7 +31,7 @@ Before you get started, verify the following:
 
 - You have a Teleport cluster, Enterprise edition, and command-line tools.
    
-   (!docs/pages/includes/commercial-prereqs-tabs.mdx!)
+  (!docs/pages/includes/commercial-prereqs-tabs.mdx!)
 
 - (!docs/pages/includes/tctl.mdx!)
 

--- a/docs/pages/admin-guides/deploy-a-cluster/gcp-kms.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/gcp-kms.mdx
@@ -36,7 +36,6 @@ higher.
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)
 
 - (!docs/pages/includes/tctl.mdx!)
-
 - A Google Cloud account.
 
 ## Step 1/5. Create a key ring in GCP

--- a/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
@@ -198,12 +198,12 @@ chart.
 
 1. Install the `teleport-cluster` Helm chart using the values file you wrote:
 
-    ```code
-    $ helm install teleport-cluster teleport/teleport-cluster \
-      --create-namespace \
-      --version (=teleport.version=) \
-      --values teleport-cluster-values.yaml
-    ```
+   ```code
+   $ helm install teleport-cluster teleport/teleport-cluster \
+     --create-namespace \
+     --version (=teleport.version=) \
+     --values teleport-cluster-values.yaml
+   ```
 
 1. After installing the `teleport-cluster` chart, wait a minute or so and ensure
    that both the Auth Service and Proxy Service pods are running:

--- a/docs/pages/admin-guides/deploy-a-cluster/hsm.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/hsm.mdx
@@ -185,6 +185,7 @@ to use.
    DEBU[0000] preflight complete                            cert= config= key= pid=73502 seccomp=false serial= syslog=false timeout=0s version=3.0.3
    DEBU[0000] takeoff                                       TLS=false listen="localhost:12345" pid=73502
    ```
+
 1. Use `yubihsm-shell` to create a new authentication key to be used by
    Teleport with the necessary capabilities.
 

--- a/docs/pages/contributing/documentation/style-guide.mdx
+++ b/docs/pages/contributing/documentation/style-guide.mdx
@@ -163,9 +163,9 @@ for the audience of a specific guide.
 
 - Prefer putting commands (e.g., Bash scripts) into full-line code snippets. These will render with a handy copy button.
 
-   ```code
-   $ echo "This is an example."
-   ```
+  ```code
+  $ echo "This is an example."
+  ```
 
 ### Diagrams
 

--- a/docs/pages/upgrading/cloud-kubernetes.mdx
+++ b/docs/pages/upgrading/cloud-kubernetes.mdx
@@ -39,6 +39,7 @@ updating works. Automatic agent upgrades require:
   $ curl -s https://mytenant.teleport.sh/webapi/ping | jq '.automatic_upgrades'
   true
   ```
+
 - At least one Teleport Enterprise agent deployed via the `teleport-kube-agent`
   Helm chart.
 
@@ -187,7 +188,7 @@ Run the following commands to upgrade Teleport agents running on Kubernetes.
 1. Update the Teleport Helm chart repository so you can install the latest
    version of the `teleport-kube-agent` chart:
 
-      (!docs/pages/includes/kubernetes-access/helm/helm-repo-add.mdx!)
+   (!docs/pages/includes/kubernetes-access/helm/helm-repo-add.mdx!)
 
 1. Upgrade the Helm release:
 

--- a/docs/pages/upgrading/self-hosted-automatic-agent-updates.mdx
+++ b/docs/pages/upgrading/self-hosted-automatic-agent-updates.mdx
@@ -340,10 +340,10 @@ This section assumes that the name of your `teleport-kube-agent` release is
    
 1. Check for any deployment issues by checking the updater logs:
    
-    ```code
-    $ kubectl -n <Var name="teleport" /> logs deployment/<Var name="teleport-agent" />-updater
-    2023-04-28T13:13:30Z	INFO	StatefulSet is already up-to-date, not updating.	{"controller": "statefulset", "controllerGroup": "apps", "controllerKind": "StatefulSet", "StatefulSet": {"name":"my-agent","namespace":"agent"}, "namespace": "agent", "name": "my-agent", "reconcileID": "10419f20-a4c9-45d4-a16f-406866b7fc05", "namespacedname": "agent/my-agent", "kind": "StatefulSet", "err": "no new version (current: \"v12.2.3\", next: \"v12.2.3\")"}
-    ```
+   ```code
+   $ kubectl -n <Var name="teleport" /> logs deployment/<Var name="teleport-agent" />-updater
+   2023-04-28T13:13:30Z	INFO	StatefulSet is already up-to-date, not updating.	{"controller": "statefulset", "controllerGroup": "apps", "controllerKind": "StatefulSet", "StatefulSet": {"name":"my-agent","namespace":"agent"}, "namespace": "agent", "name": "my-agent", "reconcileID": "10419f20-a4c9-45d4-a16f-406866b7fc05", "namespacedname": "agent/my-agent", "kind": "StatefulSet", "err": "no new version (current: \"v12.2.3\", next: \"v12.2.3\")"}
+   ```
 
 ### Troubleshooting automatic agent upgrades on Kubernetes
 

--- a/docs/pages/upgrading/self-hosted-kubernetes.mdx
+++ b/docs/pages/upgrading/self-hosted-kubernetes.mdx
@@ -45,15 +45,15 @@ running on Kubernetes.
 1. Update the Teleport Helm chart repository so you can install the latest
    version of the `teleport-cluster` chart:
 
-    (!docs/pages/includes/kubernetes-access/helm/helm-repo-add.mdx!)
+   (!docs/pages/includes/kubernetes-access/helm/helm-repo-add.mdx!)
 
 1. Upgrade the Helm release:
 
-    ```code
-    $ helm upgrade teleport-cluster teleport/teleport-cluster \
-      --version=<Var name="(=teleport.version=)" /> \
-      --values=values.yaml
-    ```
+   ```code
+   $ helm upgrade teleport-cluster teleport/teleport-cluster \
+     --version=<Var name="(=teleport.version=)" /> \
+     --values=values.yaml
+   ```
 
 The `teleport-cluster` Helm chart automatically waits for the previous version
 of the Proxy Service to stop responding to requests before running a new version
@@ -66,7 +66,7 @@ Run the following commands to upgrade Teleport agents running on Kubernetes.
 1. Update the Teleport Helm chart repository so you can install the latest
    version of the `teleport-kube-agent` chart:
 
-      (!docs/pages/includes/kubernetes-access/helm/helm-repo-add.mdx!)
+   (!docs/pages/includes/kubernetes-access/helm/helm-repo-add.mdx!)
 
 1. Upgrade the Helm release:
 


### PR DESCRIPTION
Running markdown-lint in the Docusaurus site flags some issues that the gravitational/docs markdown-lint configuration doesn't catch. This change resolves these issues, fixing indentation and list item spacing.