### PR TITLE
Downgrade wasm-pack to 0.12.1

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -10,7 +10,7 @@ NODE_VERSION ?= 20.18.0
 
 # Run lint-rust check locally before merging code after you bump this.
 RUST_VERSION ?= 1.81.0
-WASM_PACK_VERSION ?= 0.13.1
+WASM_PACK_VERSION ?= 0.12.1
 LIBBPF_VERSION ?= 1.2.2
 LIBPCSCLITE_VERSION ?= 1.9.9-teleport
 


### PR DESCRIPTION
@camscale investigated and:
> wasm-pack 0.13.1 uses wasm-bindgen 0.2.93 and it downloads the binaries for that from the repo's release page.
> The ARM64 binaries are linked against glibc 2.34, but our buildbox-node is debian bullseye which is glibc 2.31.
> No problems on AMD64 as the wasm-bindgen binary is statically linked for that architecture.
>
> This means we need to bump the base image for buildbox-node to use bookworm, which will increase the minimum requirements for Teleport Connect.

I ran[ a test build](https://github.com/gravitational/teleport.e/actions/runs/11666910161) with the downgraded `wasm-pack` and it solved wasm-related build errors. So this is a revert to make the builds green again.