### PR TITLE
Allow TtyPlayer.stop to be called while still connecting

### DIFF
--- a/web/packages/teleport/src/lib/term/ttyPlayer.js
+++ b/web/packages/teleport/src/lib/term/ttyPlayer.js
@@ -243,6 +243,10 @@ export default class TtyPlayer extends Tty {
     this.cancelTimeUpdate();
     this._setPlayerStatus(StatusEnum.PAUSED);
 
+    if (this.webSocket.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
     const buffer = new ArrayBuffer(4);
     const dv = new DataView(buffer);
     dv.setUint8(0, messageTypePlayPause);


### PR DESCRIPTION
Fixes #48333. The `stop` method was called in a `useEffect` cancel callback, and if it happened while the socket was still connecting, the whole app crashed.