### PR TITLE
[v16] operator: fix oidc connector max age

### DIFF
--- a/integrations/operator/Makefile
+++ b/integrations/operator/Makefile
@@ -139,6 +139,10 @@ test: export KUBEBUILDER_ASSETS=$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p
 test:
 	go test ./... -coverprofile cover.out
 
+.PHONY: echo-kubebuilder-assets
+echo-kubebuilder-assets:
+	@echo KUBEBUILDER_ASSETS=$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)
+
 .PHONY: crdgen-test
 crdgen-test: ## Run crdgen tests.
 	make -C crdgen test

--- a/integrations/operator/apis/resources/v3/oidcconnector_types_test.go
+++ b/integrations/operator/apis/resources/v3/oidcconnector_types_test.go
@@ -21,9 +21,11 @@ package v3
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/wrappers"
 )
 
@@ -50,6 +52,11 @@ func TestTeleportOIDCConnectorSpec_MarshalJSON(t *testing.T) {
 			TeleportOIDCConnectorSpec{RedirectURLs: wrappers.Strings{"foo", "bar"}},
 			`{"redirect_url":["foo","bar"],"issuer_url":"","client_id":"","client_secret":""}`,
 		},
+		{
+			"MaxAge",
+			TeleportOIDCConnectorSpec{MaxAge: &types.MaxAge{Value: types.Duration(time.Hour)}},
+			`{"max_age":"1h0m0s","issuer_url":"","client_id":"","client_secret":""}`,
+		},
 	}
 	for _, tc := range tests {
 		tc := tc
@@ -57,6 +64,42 @@ func TestTeleportOIDCConnectorSpec_MarshalJSON(t *testing.T) {
 			result, err := json.Marshal(tc.spec)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedJSON, string(result))
+		})
+	}
+}
+func TestTeleportOIDCConnectorSpec_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name         string
+		expectedSpec TeleportOIDCConnectorSpec
+		inputJSON    string
+	}{
+		{
+			"Empty string",
+			TeleportOIDCConnectorSpec{RedirectURLs: wrappers.Strings{""}},
+			`{"redirect_url":[""],"issuer_url":"","client_id":"","client_secret":""}`,
+		},
+		{
+			"Single string",
+			TeleportOIDCConnectorSpec{RedirectURLs: wrappers.Strings{"foo"}},
+			`{"redirect_url":["foo"],"issuer_url":"","client_id":"","client_secret":""}`,
+		},
+		{
+			"Multiple strings",
+			TeleportOIDCConnectorSpec{RedirectURLs: wrappers.Strings{"foo", "bar"}},
+			`{"redirect_url":["foo","bar"],"issuer_url":"","client_id":"","client_secret":""}`,
+		},
+		{
+			"MaxAge",
+			TeleportOIDCConnectorSpec{MaxAge: &types.MaxAge{Value: types.Duration(time.Hour)}},
+			`{"max_age":"1h0m0s","issuer_url":"","client_id":"","client_secret":""}`,
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var spec TeleportOIDCConnectorSpec
+			require.NoError(t, json.Unmarshal([]byte(tc.inputJSON), &spec))
+			require.Equal(t, tc.expectedSpec, spec)
 		})
 	}
 }

--- a/integrations/operator/controllers/resources/oidc_connector_controller_test.go
+++ b/integrations/operator/controllers/resources/oidc_connector_controller_test.go
@@ -21,6 +21,7 @@ package resources_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/trace"
@@ -46,6 +47,7 @@ var oidcSpec = types.OIDCConnectorSpecV3{
 		Roles: []string{"roleA"},
 	}},
 	RedirectURLs: []string{"https://redirect"},
+	MaxAge:       &types.MaxAge{Value: types.Duration(time.Hour)},
 }
 
 type oidcTestingPrimitives struct {


### PR DESCRIPTION
Backport #48316 to branch/v16

changelog: fix a Teleport Kubernetes Operator bug that happened for OIDCConnector resources with non-nil `max_age`.
