### PR TITLE
Add owner property to TrustedDevices type

### DIFF
--- a/web/packages/teleport/src/DeviceTrust/types.ts
+++ b/web/packages/teleport/src/DeviceTrust/types.ts
@@ -23,6 +23,7 @@ export type TrustedDevice = {
   assetTag: string;
   osType: TrustedDeviceOSType;
   enrollStatus: string;
+  owner?: string;
 };
 
 export type TrustedDeviceOSType = 'Windows' | 'Linux' | 'macOS';


### PR DESCRIPTION
This adds the owner property to our TrustedDevices type to support adding owner to our device trust table in `e`

Adding as optional for now to not break `e` and will change after the `e` changes are in.