### PR TITLE
Lax "request.kubernetes_resources" field check when querying kube resources

### DIFF
--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -3317,6 +3317,16 @@ func (set RoleSet) GetAllowedSearchAsRolesForKubeResourceKind(requestedKubeResou
 			}
 		}
 	}
+
+	// Look for a role with unconfigured "kubernetes_resources" field,
+	// which will override configured fields (allow all kinds)
+	for _, role := range set {
+		allow := role.GetAccessRequestConditions(types.Allow).KubernetesResources
+		if len(allow) == 0 {
+			return set.GetAllowedSearchAsRoles()
+		}
+	}
+
 	return set.GetAllowedSearchAsRoles(WithAllowedKubernetesResourceKindFilter(requestedKubeResourceKind))
 }
 


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/46742

Keeps the behavior consistent with validating access request where if a user's static role, had no `allow.request.kubernetes_resources` configured, then this would allow all kinds regardless of other roles with this field configured