### PR TITLE
docs: include aws oidc in integration list

### DIFF
--- a/docs/pages/admin-guides/management/guides/guides.mdx
+++ b/docs/pages/admin-guides/management/guides/guides.mdx
@@ -9,7 +9,7 @@ tasks in your cluster. These guides describe Teleport integrations that are not
 documented elsewhere:
 
   - [AWS OIDC Integration with Teleport](awsoidc-integration.mdx). How
-    to setup AWS OIDC Integration to allow Teleport to interact with AWS.
+    to set up the AWS OIDC integration to allow Teleport to interact with AWS.
   - [EC2 tags as Teleport agent labels](ec2-tags.mdx). How to set up
     Teleport agent labels based on EC2 tags.
   - [GCP tags and labels as Teleport agent labels](gcp-tags.mdx). How

--- a/docs/pages/admin-guides/management/guides/guides.mdx
+++ b/docs/pages/admin-guides/management/guides/guides.mdx
@@ -8,6 +8,8 @@ You can integrate Teleport with third-party tools in order to complete various
 tasks in your cluster. These guides describe Teleport integrations that are not
 documented elsewhere:
 
+  - [AWS OIDC Integration with Teleport](awsoidc-integration.mdx). How
+    to setup AWS OIDC Integration to allow Teleport to interact with AWS.
   - [EC2 tags as Teleport agent labels](ec2-tags.mdx). How to set up
     Teleport agent labels based on EC2 tags.
   - [GCP tags and labels as Teleport agent labels](gcp-tags.mdx). How


### PR DESCRIPTION
AWS OIDC integration was not include in the index page