### PR TITLE
Connect: Fix fetching access requests when leaf cluster is selected

### DIFF
--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/useAccessRequests.tsx
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/useAccessRequests.tsx
@@ -45,11 +45,7 @@ export default function useAccessRequests(doc: types.DocumentAccessRequests) {
   const ctx = useAppContext();
   ctx.clustersService.useState();
 
-  const {
-    localClusterUri: clusterUri,
-    rootClusterUri,
-    documentsService,
-  } = useWorkspaceContext();
+  const { rootClusterUri, documentsService } = useWorkspaceContext();
 
   const assumed = ctx.clustersService.getAssumedRequests(rootClusterUri);
   const loggedInUser = useWorkspaceLoggedInUser();
@@ -74,12 +70,14 @@ export default function useAccessRequests(doc: types.DocumentAccessRequests) {
 
   const getRequests = async () => {
     try {
-      const response = await retryWithRelogin(ctx, clusterUri, async () => {
-        const { response } = await ctx.tshd.getAccessRequests({ clusterUri });
+      const response = await retryWithRelogin(ctx, rootClusterUri, async () => {
+        const { response } = await ctx.tshd.getAccessRequests({
+          clusterUri: rootClusterUri,
+        });
         return response.requests;
       });
       setAttempt({ status: 'success' });
-      // transform tshd access request to the webui access request and add flags
+      // Transform tshd access request to the webui access request and add flags.
       const requests = response.map(r => makeUiAccessRequest(r));
       setAccessRequests(requests);
     } catch (err) {
@@ -91,11 +89,11 @@ export default function useAccessRequests(doc: types.DocumentAccessRequests) {
   };
 
   useEffect(() => {
-    // only fetch when visitng RequestList
+    // Only fetch when visiting RequestList.
     if (doc.state === 'browsing') {
       getRequests();
     }
-  }, [doc.state, clusterUri]);
+  }, [doc.state]);
 
   useEffect(() => {
     // if assumed object changes, we update which roles have been assumed in the table

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/useAccessRequests.tsx
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/useAccessRequests.tsx
@@ -28,13 +28,11 @@ import {
 import { RequestFlags } from 'shared/components/AccessRequests/ReviewRequests';
 
 import { Timestamp } from 'gen-proto-ts/google/protobuf/timestamp_pb';
+import { LoggedInUser } from 'gen-proto-ts/teleport/lib/teleterm/v1/cluster_pb';
+import { AccessRequest as TshdAccessRequest } from 'gen-proto-ts/teleport/lib/teleterm/v1/access_request_pb';
 
 import * as types from 'teleterm/ui/services/workspacesService';
-import {
-  AssumedRequest,
-  LoggedInUser,
-  AccessRequest as TshdAccessRequest,
-} from 'teleterm/services/tshd/types';
+import { AssumedRequest } from 'teleterm/services/tshd/types';
 
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { retryWithRelogin } from 'teleterm/ui/utils';


### PR DESCRIPTION
While going through the test plan I noticed that if a leaf cluster is selected in the cluster selector, Connect attempts to fetch access requests from that leaf cluster:

https://github.com/user-attachments/assets/7d644d85-fd59-496c-a47c-58db7abfd5df

I completely removed accessing `localClusterUri` from that hook as it's not really needed for anything. The bug was introduced in #42533.

If you want to test it yourself, you have to cherry-pick those changes on branch/v17. Master is currently bugged and won't give you the option to see the list of requests after successfully submitting one.

https://github.com/user-attachments/assets/2d2c195f-691f-4757-8c4d-71252d92a61e

changelog: Fixed showing the list of access requests in Teleport Connect when a leaf cluster is selected in the cluster selector