### PR TITLE
support plugin audit events in web ui

### DIFF
--- a/web/packages/teleport/src/Audit/EventList/EventTypeCell.tsx
+++ b/web/packages/teleport/src/Audit/EventList/EventTypeCell.tsx
@@ -280,6 +280,9 @@ const EventIconMap: Record<EventCode, any> = {
   [eventCodes.USER_TASK_UPDATE]: Icons.Info,
   [eventCodes.USER_TASK_DELETE]: Icons.Info,
   [eventCodes.SFTP_SUMMARY]: Icons.FolderPlus,
+  [eventCodes.PLUGIN_CREATE]: Icons.Info,
+  [eventCodes.PLUGIN_UPDATE]: Icons.Info,
+  [eventCodes.PLUGIN_DELETE]: Icons.Info,
   [eventCodes.UNKNOWN]: Icons.Question,
 };
 

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -1834,6 +1834,27 @@ export const formatters: Formatters = {
       return `User [${user}] completed a file transfer on [${server_hostname}]`;
     },
   },
+  [eventCodes.PLUGIN_CREATE]: {
+    type: 'plugin.create',
+    desc: 'Plugin Created',
+    format: ({ user, name, plugin_type }) => {
+      return `User [${user}] created a plugin [${name}] of type [${plugin_type}]`;
+    },
+  },
+  [eventCodes.PLUGIN_UPDATE]: {
+    type: 'plugin.update',
+    desc: 'Plugin Updated',
+    format: ({ user, name, plugin_type }) => {
+      return `User [${user}] updated a plugin [${name}] of type [${plugin_type}]`;
+    },
+  },
+  [eventCodes.PLUGIN_DELETE]: {
+    type: 'plugin.delete',
+    desc: 'Plugin Deleted',
+    format: ({ user, name }) => {
+      return `User [${user}] deleted a plugin [${name}]`;
+    },
+  },
   [eventCodes.UNKNOWN]: {
     type: 'unknown',
     desc: 'Unknown Event',

--- a/web/packages/teleport/src/services/audit/types.ts
+++ b/web/packages/teleport/src/services/audit/types.ts
@@ -300,6 +300,9 @@ export const eventCodes = {
   USER_TASK_CREATE: 'UT001I',
   USER_TASK_UPDATE: 'UT002I',
   USER_TASK_DELETE: 'UT003I',
+  PLUGIN_CREATE: 'PG001I',
+  PLUGIN_UPDATE: 'PG002I',
+  PLUGIN_DELETE: 'PG003I',
 } as const;
 
 /**
@@ -1692,6 +1695,18 @@ export type RawEvents = {
   [eventCodes.USER_TASK_DELETE]: RawEvent<
     typeof eventCodes.USER_TASK_DELETE,
     HasName
+  >;
+  [eventCodes.PLUGIN_CREATE]: RawEvent<
+    typeof eventCodes.PLUGIN_CREATE,
+    Merge<HasName, { plugin_type: string }>
+  >;
+  [eventCodes.PLUGIN_UPDATE]: RawEvent<
+    typeof eventCodes.PLUGIN_UPDATE,
+    Merge<HasName, { plugin_type: string }>
+  >;
+  [eventCodes.PLUGIN_DELETE]: RawEvent<
+    typeof eventCodes.PLUGIN_DELETE,
+    Merge<HasName, { user: string }>
   >;
   [eventCodes.SFTP_SUMMARY]: RawEvent<
     typeof eventCodes.SFTP_SUMMARY,


### PR DESCRIPTION
This PR extends support for WebUI to be able to display Plugin create, update and delete events.


<img width="2417" alt="Screenshot 2024-11-05 at 16 30 46" src="https://github.com/user-attachments/assets/2c927b8d-63f6-4701-b4c0-38eedce138d7">

Changelog: Fixed a bug that prevented the Teleport UI from properly displaying Plugin Audit log details.

Closes https://github.com/gravitational/teleport/issues/48444