### PR TITLE
[v17] adding missing GID value when fetching Hostuser

### DIFF
--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -689,6 +689,7 @@ func (u *HostUserManagement) getHostUser(username string) (*HostUser, error) {
 	return &HostUser{
 		Name:   username,
 		UID:    usr.Uid,
+		GID:    usr.Gid,
 		Home:   usr.HomeDir,
 		Groups: groups,
 	}, trace.NewAggregate(groupErrs...)


### PR DESCRIPTION
Backport #48245 to branch/v17

changelog: Fixed an issue preventing migration of unmanaged users to Teleport host users when including `teleport-keep` in a role's `host_groups`.
