### PR TITLE
[v15] adding missing GID value when fetching Hostuser

### DIFF
--- a/integration/hostuser_test.go
+++ b/integration/hostuser_test.go
@@ -499,6 +499,28 @@ func TestRootHostUsers(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, hasExpirations)
 	})
+
+	t.Run("Test migrate unmanaged user", func(t *testing.T) {
+		t.Cleanup(func() { cleanupUsersAndGroups([]string{testuser}, []string{types.TeleportKeepGroup}) })
+
+		users := srv.NewHostUsers(context.Background(), presence, "host_uuid")
+		_, err := host.UserAdd(testuser, nil, "", "", "")
+		require.NoError(t, err)
+
+		closer, err := users.UpsertUser(testuser, services.HostUsersInfo{Mode: types.CreateHostUserMode_HOST_USER_MODE_KEEP, Groups: []string{types.TeleportKeepGroup}})
+		require.NoError(t, err)
+		require.Nil(t, closer)
+
+		u, err := user.Lookup(testuser)
+		require.NoError(t, err)
+
+		gids, err := u.GroupIds()
+		require.NoError(t, err)
+
+		keepGroup, err := user.LookupGroup(types.TeleportKeepGroup)
+		require.NoError(t, err)
+		require.Contains(t, gids, keepGroup.Gid)
+	})
 }
 
 type hostUsersBackendWithExp struct {

--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -672,6 +672,7 @@ func (u *HostUserManagement) getHostUser(username string) (*HostUser, error) {
 	return &HostUser{
 		Name:   username,
 		UID:    usr.Uid,
+		GID:    usr.Gid,
 		Home:   usr.HomeDir,
 		Groups: groups,
 	}, trace.NewAggregate(groupErrs...)


### PR DESCRIPTION
Backport #48245 to branch/v15

changelog: Fixed an issue preventing migration of unmanaged users to Teleport host users when including `teleport-keep` in a role's `host_groups`.
