### PR TITLE
Fixing some issues with the Mac build for ent

### DIFF
--- a/build.assets/build-package.sh
+++ b/build.assets/build-package.sh
@@ -221,7 +221,7 @@ if [[ "${PACKAGE_TYPE}" == "pkg" ]]; then
     FILE_LIST="${TAR_PATH}/teleport ${TAR_PATH}/tbot ${TAR_PATH}/fdpass-teleport"
     BUNDLE_ID="${b:-com.gravitational.teleport}"
     if [[ "${TELEPORT_TYPE}" == "ent" ]]; then
-        PKG_FILENAME="teleport-ent-${TELEPORT_VERSION}${ARCH_TAG}.${PACKAGE_TYPE}"
+        PKG_FILENAME="teleport-ent-bin-${TELEPORT_VERSION}${ARCH_TAG}.${PACKAGE_TYPE}"
     else
         PKG_FILENAME="teleport-bin-${TELEPORT_VERSION}${ARCH_TAG}.${PACKAGE_TYPE}"
     fi

--- a/build.assets/build-pkg-app.sh
+++ b/build.assets/build-pkg-app.sh
@@ -162,7 +162,7 @@ or name of the key to sign packages"
 
   # Prepare app shell.
   local target="$tmp/root/$PACKAGE_NAME.app"
-  cp -r "$tmp/teleport/$PACKAGE_NAME.app" "$target"
+  cp -r "$tmp/teleport$ent/$PACKAGE_NAME.app" "$target"
 
   local entitlements="$buildassets/macos/$TSH_SKELETON/$TSH_SKELETON.entitlements"
   if [[ "$PACKAGE_NAME" == "tctl" ]]; then

--- a/build.assets/macos/install
+++ b/build.assets/macos/install
@@ -40,9 +40,9 @@ cp -rf tctl.app/ "$APPS_DIR"/tctl.app/ || exit 1
 
 
 # If tsh exists and is not a link, make a backup.
-if [ -f "$BINDIR/tsh" ] && [ ! -L "$BIN/tsh" ]; then
+if [ -f "$BINDIR/tsh" ] && [ ! -L "$BINDIR/tsh" ]; then
 rm -f "$BINDIR/tsh.bak"
-mv "$BINDIR/tsh" "$BIN/tsh.bak"
+mv "$BINDIR/tsh" "$BINDIR/tsh.bak"
 fi
 
 # Link package to $BINDIR.
@@ -50,14 +50,14 @@ rm -f "$BINDIR/tsh"  # in case link exists
 ln -s "$APPS_DIR/tsh.app/Contents/MacOS/tsh" "$BINDIR/tsh"
 
 # If tctl exists and is not a link, make a backup.
-if [ -f "$BINDIR/tctl" ] && [ ! -L "$BIN/tctl" ]; then
+if [ -f "$BINDIR/tctl" ] && [ ! -L "$BINDIR/tctl" ]; then
 rm -f "$BINDIR/tctl.bak"
-mv "$BINDIR/tctl" "$BIN/tctl.bak"
+mv "$BINDIR/tctl" "$BINDIR/tctl.bak"
 fi
 
 # Link package to $BINDIR.
 rm -f "$BINDIR/tctl"  # in case link exists
-ln -s "$APPSDIR/tctl.app/Contents/MacOS/tctl" "$BINDIR/tctl"
+ln -s "$APPS_DIR/tctl.app/Contents/MacOS/tctl" "$BINDIR/tctl"
 
 
 echo "Teleport binaries have been copied to $BINDIR"

--- a/build.assets/macos/install
+++ b/build.assets/macos/install
@@ -38,6 +38,28 @@ cp -f teleport tbot fdpass-teleport $BINDIR/ || exit 1
 cp -rf tsh.app/ "$APPS_DIR"/tsh.app/ || exit 1
 cp -rf tctl.app/ "$APPS_DIR"/tctl.app/ || exit 1
 
+
+# If tsh exists and is not a link, make a backup.
+if [ -f "$BINDIR/tsh" ] && [ ! -L "$BIN/tsh" ]; then
+rm -f "$BINDIR/tsh.bak"
+mv "$BINDIR/tsh" "$BIN/tsh.bak"
+fi
+
+# Link package to $BINDIR.
+rm -f "$BINDIR/tsh"  # in case link exists
+ln -s "$APPS_DIR/tsh.app/Contents/MacOS/tsh" "$BINDIR/tsh"
+
+# If tctl exists and is not a link, make a backup.
+if [ -f "$BINDIR/tctl" ] && [ ! -L "$BIN/tctl" ]; then
+rm -f "$BINDIR/tctl.bak"
+mv "$BINDIR/tctl" "$BIN/tctl.bak"
+fi
+
+# Link package to $BINDIR.
+rm -f "$BINDIR/tctl"  # in case link exists
+ln -s "$APPSDIR/tctl.app/Contents/MacOS/tctl" "$BINDIR/tctl"
+
+
 echo "Teleport binaries have been copied to $BINDIR"
 echo ""
 echo "Thanks for installing Teleport."


### PR DESCRIPTION
## Overview

The [PR](https://github.com/gravitational/teleport.e/pull/5339) for introducing `tsh.app` and `tctl.app` to ent packages needs some updates to function correctly. This introduces some more friendly behavior for ent.