### PR TITLE
[v15] support plugin audit events in web ui

### DIFF
--- a/web/packages/teleport/src/Audit/EventList/EventTypeCell.tsx
+++ b/web/packages/teleport/src/Audit/EventList/EventTypeCell.tsx
@@ -287,6 +287,9 @@ const EventIconMap: Record<EventCode, any> = {
   [eventCodes.CROWN_JEWEL_CREATE]: Icons.Info,
   [eventCodes.CROWN_JEWEL_UPDATE]: Icons.Info,
   [eventCodes.CROWN_JEWEL_DELETE]: Icons.Info,
+  [eventCodes.PLUGIN_CREATE]: Icons.Info,
+  [eventCodes.PLUGIN_UPDATE]: Icons.Info,
+  [eventCodes.PLUGIN_DELETE]: Icons.Info,
   [eventCodes.UNKNOWN]: Icons.Question,
 };
 

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -1902,6 +1902,27 @@ export const formatters: Formatters = {
       return `User [${user}] deleted a crown jewel [${name}]`;
     },
   },
+  [eventCodes.PLUGIN_CREATE]: {
+    type: 'plugin.create',
+    desc: 'Plugin Created',
+    format: ({ user, name, plugin_type }) => {
+      return `User [${user}] created a plugin [${name}] of type [${plugin_type}]`;
+    },
+  },
+  [eventCodes.PLUGIN_UPDATE]: {
+    type: 'plugin.update',
+    desc: 'Plugin Updated',
+    format: ({ user, name, plugin_type }) => {
+      return `User [${user}] updated a plugin [${name}] of type [${plugin_type}]`;
+    },
+  },
+  [eventCodes.PLUGIN_DELETE]: {
+    type: 'plugin.delete',
+    desc: 'Plugin Deleted',
+    format: ({ user, name }) => {
+      return `User [${user}] deleted a plugin [${name}]`;
+    },
+  },
   [eventCodes.UNKNOWN]: {
     type: 'unknown',
     desc: 'Unknown Event',

--- a/web/packages/teleport/src/services/audit/types.ts
+++ b/web/packages/teleport/src/services/audit/types.ts
@@ -307,6 +307,9 @@ export const eventCodes = {
   CROWN_JEWEL_CREATE: 'CJ001I',
   CROWN_JEWEL_UPDATE: 'CJ002I',
   CROWN_JEWEL_DELETE: 'CJ003I',
+  PLUGIN_CREATE: 'PG001I',
+  PLUGIN_UPDATE: 'PG002I',
+  PLUGIN_DELETE: 'PG003I',
 } as const;
 
 /**
@@ -1694,6 +1697,18 @@ export type RawEvents = {
   [eventCodes.CROWN_JEWEL_DELETE]: RawEvent<
     typeof eventCodes.CROWN_JEWEL_DELETE,
     HasName
+  >;
+  [eventCodes.PLUGIN_CREATE]: RawEvent<
+    typeof eventCodes.PLUGIN_CREATE,
+    Merge<HasName, { plugin_type: string }>
+  >;
+  [eventCodes.PLUGIN_UPDATE]: RawEvent<
+    typeof eventCodes.PLUGIN_UPDATE,
+    Merge<HasName, { plugin_type: string }>
+  >;
+  [eventCodes.PLUGIN_DELETE]: RawEvent<
+    typeof eventCodes.PLUGIN_DELETE,
+    Merge<HasName, { user: string }>
   >;
 };
 


### PR DESCRIPTION
Backport #48450 to branch/v15

changelog: Fixed a bug that prevented the Teleport UI from properly displaying Plugin Audit log details.
