### PR TITLE
Make Event Handler addresses consistent

### DIFF
--- a/docs/pages/includes/plugins/config-toml-teleport.mdx
+++ b/docs/pages/includes/plugins/config-toml-teleport.mdx
@@ -2,7 +2,7 @@
 <TabItem label="Executable or Docker">
 
 **`addr`**: Include the hostname and HTTPS port of your Teleport Proxy Service
-or Teleport Enterprise Cloud tenant (e.g., `teleport.example.com:443` or
+or Teleport Enterprise Cloud account (e.g., `teleport.example.com:443` or
 `mytenant.teleport.sh:443`).
 
 **`identity`**: Fill this in with the path to the identity file you exported

--- a/examples/chart/event-handler/README.md
+++ b/examples/chart/event-handler/README.md
@@ -21,7 +21,9 @@ The following values can be set for the Helm chart:
 
   <tr>
     <td><code>teleport.address</code></td>
-    <td>Host/port combination of the teleport auth server</td>
+    <td>hostname and HTTPS port of your Teleport Proxy Service
+or Teleport Enterprise Cloud account (e.g., `teleport.example.com:443` or
+`mytenant.teleport.sh:443`)</td>
     <td>string</td>
     <td><code>""</code></td>
     <td>yes</td>


### PR DESCRIPTION
Closes #43181

Address inconsistent information between the Event Handler README and step-by-step guides by using the information in the step-by-step guides, which is more in line with our current recommendations.