### PR TITLE
Fix `tctl users add` reference examples

### DIFF
--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -1641,11 +1641,9 @@ These flags are available for all commands `--debug, --config`. Run
 ### Examples
 
 ```code
-# Adds teleport user "joe" with mappings to
-# OS users and {{ internal.logins }} to "joe" and "ubuntu"
-$ tctl users add joe --roles=access,requester joe,ubuntu
-# Adds Teleport user "joe" with mappings to the editor role
-$ tctl users add joe --roles=editor,reviewer
+# Adds Teleport user "joe" with the "access" and "requester" roles and
+# permissions to assume the "joe" and "ubuntu" logins
+$ tctl users add joe --roles=access,requester --logins=joe,ubuntu
 ```
 
 ## tctl users ls


### PR DESCRIPTION
Closes #10574

- Present the examples with a correct use of the `logins` flag
- Since the current examples overlap, just use one

The remaining issues identified by #10574 are already resolved or out of date.