### PR TITLE
Fix a redirect

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -392,7 +392,7 @@
     },
     {
       "source": "/application-access/jwt/",
-      "destination": "/enroll-resources/application-access/jwt/",
+      "destination": "/enroll-resources/application-access/jwt/jwt/",
       "permanent": true
     },
     {


### PR DESCRIPTION
Fix a redirect that was actually broken but slipped past `gravitational/docs` protections due to incorrect destination-checking logic.