### PR TITLE
Narrow EnrollStatus type in web UI

### DIFF
--- a/web/packages/teleport/src/DeviceTrust/types.ts
+++ b/web/packages/teleport/src/DeviceTrust/types.ts
@@ -22,8 +22,8 @@ export type TrustedDevice = {
   id: string;
   assetTag: string;
   osType: TrustedDeviceOSType;
-  enrollStatus: string;
-  owner?: string;
+  enrollStatus: 'Enrolled' | 'Not Enrolled';
+  owner: string;
 };
 
 export type TrustedDeviceOSType = 'Windows' | 'Linux' | 'macOS';


### PR DESCRIPTION
This makes the enroll status explicitly Enrolled or Not Enrolled instead of just a string. Also, I've made 'owner' no longer optional now that the code in `e` is merged

supports https://github.com/gravitational/teleport.e/pull/5343