### PR TITLE
ensure ca caches include correct revision

### DIFF
--- a/lib/services/local/trust.go
+++ b/lib/services/local/trust.go
@@ -232,13 +232,6 @@ func (s *CA) UpsertCertAuthority(ctx context.Context, ca types.CertAuthority) er
 		return trace.Wrap(err)
 	}
 
-	// try to skip writes that would have no effect
-	if existing, err := s.GetCertAuthority(ctx, ca.GetID(), true); err == nil {
-		if services.CertAuthoritiesEquivalent(existing, ca) {
-			return nil
-		}
-	}
-
 	item, err := caToItem(activeCAKey(ca.GetID()), ca)
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
The `UpsertCertAuthority` method was skipping writes if the substantive content of a CA resource was unchanged.  This worked fine before the introduction of revisions and atomic writes, but it is now common for items to have their revision change without their spec changing, and common for conditional operations to rely on the revisions present in the cache.

This problem was brought to light because the recent changes to `UpsertTrustedCluster` (https://github.com/gravitational/teleport/pull/48009) made this issue much more likely to be hit, though we have a number of places where revisions/atomics were already used with CAs so its likely that this has been a problem for a while.

Fixes https://github.com/gravitational/teleport/issues/48330

changelog: fixed an issue where modifying trusted clusters and/or cert authorities could result in a spurious "concurrent update" error.