### PR TITLE
only preload local cluster cas

### DIFF
--- a/lib/auth/client_tls_config_generator.go
+++ b/lib/auth/client_tls_config_generator.go
@@ -211,10 +211,10 @@ func (c *ClientTLSConfigGenerator) refreshClientTLSConfigs(ctx context.Context) 
 	}
 }
 
-// watchForCAChanges sets up a cert authority watcher and triggers regeneration of client
-// tls configs for a given cluster whenever a CA associated with that cluster is modified.
-// note that this function errs on the side of regenerating more often than might be
-// strictly necessary.
+// watchForCAChanges sets up a cert authority watcher to ensure that we don't serve outdated
+// tls configs. for the local cluster it aggressively triggers regeneration. for other clusters
+// it invalidates extant state, allowing lazy generation on first need. this function errs on the
+// side of caution and triggers regen/invalidation more often than might be strictly necessary.
 func (c *ClientTLSConfigGenerator) watchForCAChanges(ctx context.Context) error {
 	watcher, err := c.cfg.AccessPoint.NewWatcher(ctx, types.Watch{
 		Name: "client-tls-config-generator",
@@ -254,8 +254,14 @@ func (c *ClientTLSConfigGenerator) watchForCAChanges(ctx context.Context) error 
 					// ignore non-local cluster CA events when we aren't configured to support them
 					continue
 				}
-				// trigger regen of client tls configs for the associated cluster.
-				c.clientTLSConfigs.Generate(event.Resource.GetName())
+
+				if event.Resource.GetName() == c.cfg.ClusterName {
+					// actively regenerate on modifications associated with the local cluster
+					c.clientTLSConfigs.Generate(event.Resource.GetName())
+				} else {
+					// clear extant state on modifications associated with non-local clusters
+					c.clientTLSConfigs.Terminate(event.Resource.GetName())
+				}
 			}
 		case <-ctx.Done():
 			return nil


### PR DESCRIPTION
The original implementation of the client TLS config generator tried to always pre-generate all TLS configs for all known CAs on all changes.  This was nice in theory, but created spurious error logs due to remote clusters not having all requisite CAs stored, and was wasted effort in many cases.

This PR tweaks the event-handling logic of the client TLS config generator to only aggressively generate TLS configs in response to modification events for the local cluster.  For all other clusters, it invalidates any now stale state, but waits until a connection actually comes in before nothing to try to build the TLS config.

Fixes https://github.com/gravitational/teleport/issues/48331