### PR TITLE
[entraid] ask for mfa reuse during entraid plugin setup

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3645,7 +3645,7 @@ func (a *ServerWithRoles) CreateSAMLConnector(ctx context.Context, connector typ
 		return nil, trace.Wrap(err)
 	}
 
-	if err := a.context.AuthorizeAdminAction(); err != nil {
+	if err := a.context.AuthorizeAdminActionAllowReusedMFA(); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/tool/tctl/common/plugin/plugins_command.go
+++ b/tool/tctl/common/plugin/plugins_command.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	pluginsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/plugins/v1"
+	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
@@ -128,7 +129,6 @@ func (p *PluginsCommand) initInstallSCIM(parent *kingpin.CmdClause) {
 		Short('f').
 		Default("false").
 		BoolVar(&p.install.scim.force)
-
 }
 
 func (p *PluginsCommand) initDelete(parent *kingpin.CmdClause) {
@@ -208,6 +208,7 @@ type authClient interface {
 	GetIntegration(ctx context.Context, name string) (types.Integration, error)
 	UpdateIntegration(ctx context.Context, ig types.Integration) (types.Integration, error)
 	Ping(ctx context.Context) (proto.PingResponse, error)
+	PerformMFACeremony(ctx context.Context, challengeRequest *proto.CreateAuthenticateChallengeRequest, promptOpts ...mfa.PromptOpt) (*proto.MFAAuthenticateResponse, error)
 }
 
 type pluginsClient interface {

--- a/tool/tctl/common/plugin/plugins_command_test.go
+++ b/tool/tctl/common/plugin/plugins_command_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	pluginsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/plugins/v1"
+	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 )
@@ -492,6 +493,10 @@ func (m *mockAuthClient) GetIntegration(ctx context.Context, name string) (types
 func (m *mockAuthClient) Ping(ctx context.Context) (proto.PingResponse, error) {
 	result := m.Called(ctx)
 	return result.Get(0).(proto.PingResponse), result.Error(1)
+}
+
+func (m *mockAuthClient) PerformMFACeremony(ctx context.Context, challengeRequest *proto.CreateAuthenticateChallengeRequest, promptOpts ...mfa.PromptOpt) (*proto.MFAAuthenticateResponse, error) {
+	return &proto.MFAAuthenticateResponse{}, nil
 }
 
 // anyContext is an argument matcher for testify mocks that matches any context.


### PR DESCRIPTION
This PR fixes a bug where MFA for admin actions prevents creating multiple objects during the entra id setup guide.

Part of #48485