### PR TITLE
add `sso:ListPermissionSetsProvisionedToAccount` permission to `StatementForAWSIdentityCenterAccess`

### DIFF
--- a/lib/cloud/aws/policy_statements.go
+++ b/lib/cloud/aws/policy_statements.go
@@ -457,6 +457,7 @@ func StatementForAWSIdentityCenterAccess() *Statement {
 			"sso:DescribePermissionSet",
 			"sso:ListPermissionSets",
 			"sso:ListAccountAssignmentsForPrincipal",
+			"sso:ListPermissionSetsProvisionedToAccount",
 
 			// CreateAndDeleteAccountAssignment
 			"sso:CreateAccountAssignment",

--- a/lib/integrations/awsoidc/testdata/TestConfigureIdPIAMWithPolicyPresetOutput.golden
+++ b/lib/integrations/awsoidc/testdata/TestConfigureIdPIAMWithPolicyPresetOutput.golden
@@ -79,6 +79,7 @@ AssignPolicy: {
             "sso:DescribePermissionSet",
             "sso:ListPermissionSets",
             "sso:ListAccountAssignmentsForPrincipal",
+            "sso:ListPermissionSetsProvisionedToAccount",
             "sso:CreateAccountAssignment",
             "sso:DescribeAccountAssignmentCreationStatus",
             "sso:DeleteAccountAssignment",


### PR DESCRIPTION
The policy is required to list permission sets assigned to an Identity Center account. 