### PR TITLE
Wait for policy features to be loaded on page init

### DIFF
--- a/web/packages/teleport/src/teleportContext.tsx
+++ b/web/packages/teleport/src/teleportContext.tsx
@@ -110,7 +110,7 @@ class TeleportContext implements types.Context {
 
     if (user.acl.accessGraph.list) {
       // If access graph is enabled, check what features are enabled and store them in local storage.
-      userService
+      await userService
         .fetchAccessGraphFeatures()
         .then(features => {
           for (let key in features) {

--- a/web/packages/teleport/src/teleportContext.tsx
+++ b/web/packages/teleport/src/teleportContext.tsx
@@ -110,6 +110,9 @@ class TeleportContext implements types.Context {
 
     if (user.acl.accessGraph.list) {
       // If access graph is enabled, check what features are enabled and store them in local storage.
+      // We await this so it is done by the time the page renders, otherwise the local storage event
+      // wouldn't trigger a re-render and Policy could end up not being displayed until the navigation
+      // is re-rendered.
       await userService
         .fetchAccessGraphFeatures()
         .then(features => {


### PR DESCRIPTION
When deployed in production, the part of the init code that loads access graph features and then stores them in local storage doesn't do anything that causes React to re-render. This is why it can take a strangely long amount of time to show up in the navigation. Before the new nav, the nav would've re-rendered when swapping to the access management tab, so it wouldn't have been an issue.

By awaiting TAG's features response and setting of values in local storage, the policy link should be shown on initial render, as the page isn't rendered until `init` completes. This does _slightly_ slow down the page initialization for clusters with policy enabled.

Closes https://github.com/gravitational/access-graph/issues/1302.

changelog: Fix Policy not showing in the navigation immediately on page load