### PR TITLE
gha(amplify-preview): use custom action to generate Amplify previews for Teleport Docs

### DIFF
--- a/.github/workflows/docs-amplify.yaml
+++ b/.github/workflows/docs-amplify.yaml
@@ -23,8 +23,19 @@ jobs:
 
     - name: Create Amplify preview environment
       uses: gravitational/shared-workflows/tools/amplify-preview@tools/amplify-preview/v0.0.1
+      continue-on-error: true
       with:
         app_ids: ${{ vars.AMPLIFY_APP_IDS }}
         create_branches: "true"
         github_token: ${{ secrets.GITHUB_TOKEN }}
         wait: "true"
+
+    - name: Print failure message
+      if: failure()
+      env:
+        ERR_TITLE: Teleport Docs preview build failed
+        ERR_MESSAGE: >-
+          Please refer to the following documentation for help: https://www.notion.so/goteleport/How-to-Amplify-deployments-162fdd3830be8096ba72efa1a49ee7bc?pvs=4
+      run: |
+        echo ::error title=$ERR_TITLE::$ERR_MESSAGE
+        exit 1

--- a/.github/workflows/docs-amplify.yaml
+++ b/.github/workflows/docs-amplify.yaml
@@ -1,0 +1,30 @@
+name: Docs Preview
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+  workflow_dispatch:
+  
+permissions:
+  pull-requests: write
+  id-token: write
+  
+jobs:
+  amplify-preview:
+    name: Prepare Amplify preview URL
+    runs-on: ubuntu-22.04-2core-arm64
+    environment: docs-amplify
+    steps:    
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
+      with:
+        aws-region: us-west-2
+        role-to-assume: ${{ vars.IAM_ROLE }}
+
+    - name: Create Amplify preview environment
+      uses: gravitational/shared-workflows/tools/amplify-preview@tools/amplify-preview/v0.0.1
+      with:
+        app_ids: ${{ vars.AMPLIFY_APP_IDS }}
+        create_branches: "true"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        wait: "true"

--- a/.github/workflows/docs-amplify.yaml
+++ b/.github/workflows/docs-amplify.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - 'docs/**'
+      - .github/workflows/docs-amplify.yaml
   workflow_dispatch:
   
 permissions:


### PR DESCRIPTION
### Summary

This PR adds new custom workflow which will prepare Amplify preview URLs using custom action [`amplify-preview`](https://github.com/gravitational/shared-workflows/tree/main/tools/amplify-preview) instead of native Amplify's integration with Github because of following problems:
- Hard limit of 50 previews per app[^1]
    [^1]: https://docs.aws.amazon.com/general/latest/gr/amplify.html
- Lack of functionality to filter PRs based on modified path (we need previews only for PRs when `docs/` were modified)
   - https://github.com/aws-amplify/amplify-hosting/issues/3960

Existing `aws-amplify-us-west-2` bot will be disabled separately via AWS APIs.


### Testing 

https://github.com/gravitational/teleport/pull/48512#issuecomment-2548342535