### PR TITLE
[web] Allow providing `ReactNode`s as Table header text

### DIFF
--- a/web/packages/design/src/DataTable/Cells.tsx
+++ b/web/packages/design/src/DataTable/Cells.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { TdHTMLAttributes } from 'react';
-
 import { Theme } from 'design/theme';
 
 import Label from '../Label';
@@ -26,7 +24,8 @@ import * as Icons from '../Icon';
 
 import { displayDate } from '../datetime';
 
-import {
+import type { ReactNode, TdHTMLAttributes } from 'react';
+import type {
   ServersideProps,
   SortDir,
   TableColumn,
@@ -58,6 +57,7 @@ export function SortHeaderCell<T>({
         <a
           onClick={handleServersideClick}
           style={{ display: 'flex', alignItems: 'center' }}
+          aria-label={column.ariaLabel || undefined}
         >
           {text}
           <SortIndicator
@@ -162,7 +162,7 @@ export const ClickableLabelCell = ({
 type SortHeaderCellProps<T> = {
   column: TableColumn<T>;
   serversideProps?: ServersideProps;
-  text: string;
+  text: string | ReactNode;
   dir?: SortDir;
   onClick: () => void;
 };

--- a/web/packages/design/src/DataTable/types.ts
+++ b/web/packages/design/src/DataTable/types.ts
@@ -20,6 +20,8 @@ import { MatchCallback } from 'design/utils/match';
 
 import { Pagination } from './useTable';
 
+import type { ReactNode } from 'react';
+
 export type TableProps<T> = {
   data: T[];
   columns: TableColumn<T>[];
@@ -91,7 +93,8 @@ export type TableProps<T> = {
 };
 
 type TableColumnBase<T> = {
-  headerText?: string;
+  headerText?: string | ReactNode;
+  ariaLabel?: string;
   render?: (row: T) => JSX.Element;
   isSortable?: boolean;
   onSort?: (a: T, b: T) => number;

--- a/web/packages/teleport/src/components/hooks/useUrlFiltering/encodeUrlQueryParams.test.ts
+++ b/web/packages/teleport/src/components/hooks/useUrlFiltering/encodeUrlQueryParams.test.ts
@@ -29,17 +29,17 @@ const testCases: {
   {
     title: 'No query params',
     args: { pathname: '/foo' },
-    expected: '/foo?pinnedOnly=false',
+    expected: '/foo',
   },
   {
     title: 'Search string',
     args: { pathname: '/test', searchString: 'something' },
-    expected: '/test?search=something&pinnedOnly=false',
+    expected: '/test?search=something',
   },
   {
     title: 'Search string, encoded',
     args: { pathname: '/test', searchString: 'a$b$c' },
-    expected: '/test?search=a%24b%24c&pinnedOnly=false',
+    expected: '/test?search=a%24b%24c',
   },
   {
     title: 'Advanced search',
@@ -48,7 +48,7 @@ const testCases: {
       searchString: 'foo=="bar"',
       isAdvancedSearch: true,
     },
-    expected: '/test?query=foo%3D%3D%22bar%22&pinnedOnly=false',
+    expected: '/test?query=foo%3D%3D%22bar%22',
   },
   {
     title: 'Search and sort',
@@ -57,7 +57,7 @@ const testCases: {
       searchString: 'foobar',
       sort: { fieldName: 'name', dir: 'ASC' },
     },
-    expected: '/test?search=foobar&sort=name%3Aasc&pinnedOnly=false',
+    expected: '/test?search=foobar&sort=name%3Aasc',
   },
   {
     title: 'Sort only',
@@ -65,7 +65,7 @@ const testCases: {
       pathname: '/test',
       sort: { fieldName: 'name', dir: 'ASC' },
     },
-    expected: '/test?sort=name%3Aasc&pinnedOnly=false',
+    expected: '/test?sort=name%3Aasc',
   },
   {
     title: 'Search, sort, and filter by kind',
@@ -75,8 +75,7 @@ const testCases: {
       sort: { fieldName: 'name', dir: 'DESC' },
       kinds: ['db', 'node'],
     },
-    expected:
-      '/test?search=foo&sort=name%3Adesc&pinnedOnly=false&kinds=db&kinds=node',
+    expected: '/test?search=foo&sort=name%3Adesc&kinds=db&kinds=node',
   },
 ];
 

--- a/web/packages/teleport/src/components/hooks/useUrlFiltering/encodeUrlQueryParams.ts
+++ b/web/packages/teleport/src/components/hooks/useUrlFiltering/encodeUrlQueryParams.ts
@@ -33,7 +33,7 @@ export function encodeUrlQueryParams({
   sort,
   kinds,
   isAdvancedSearch = false,
-  pinnedOnly = false,
+  pinnedOnly,
 }: EncodeUrlQueryParamsProps) {
   const urlParams = new URLSearchParams();
 


### PR DESCRIPTION
Related to [#5075](https://github.com/gravitational/teleport.e/pull/5075). Allow providing `ReactNode`s as Table header text, e.g. so icons can be used as header text.