### PR TITLE
Reduce log spam generated by conflicting session_id and event_index

### DIFF
--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -575,12 +575,18 @@ func (l *Log) putAuditEvent(ctx context.Context, sessionID string, in apievents.
 			// item event index/session id. Since we can't change the session
 			// id, update the event index with a new value and retry the put
 			// item.
-			l.logger.ErrorContext(ctx, "Conflict on event session_id and event_index",
-				"error", err,
-				"event_type", in.GetType(),
-				"session_id", sessionID,
-				"event_index", in.GetIndex())
-			return trace.Wrap(l.handleConditionError(ctx, err, sessionID, in))
+			if err2 := l.handleConditionError(ctx, err, sessionID, in); err2 != nil {
+				// Only log about the original conflict if updating
+				// the session information fails.
+				l.logger.ErrorContext(ctx, "Conflict on event session_id and event_index",
+					"error", err,
+					"event_type", in.GetType(),
+					"session_id", sessionID,
+					"event_index", in.GetIndex())
+				return trace.Wrap(err2)
+			}
+
+			return nil
 		}
 
 		return err


### PR DESCRIPTION
Alters the log messages from https://github.com/gravitational/teleport/pull/40854 such that they only occur if the fallback mechanism fails.

Updates https://github.com/gravitational/teleport/issues/46801