### PR TITLE
Properly propagate private key for azure app

### DIFF
--- a/lib/srv/alpnproxy/azure_msi_middleware_test.go
+++ b/lib/srv/alpnproxy/azure_msi_middleware_test.go
@@ -53,15 +53,16 @@ func testAzureMSIMiddlewareHandleRequest(t *testing.T, alg cryptosuites.Algorith
 		require.NoError(t, err)
 		return privateKey
 	}
+	key := newPrivateKey()
 	m := &AzureMSIMiddleware{
 		Identity: "azureTestIdentity",
 		TenantID: "cafecafe-cafe-4aaa-cafe-cafecafecafe",
 		ClientID: "decaffff-cafe-4aaa-cafe-cafecafecafe",
 		Log:      logrus.WithField(teleport.ComponentKey, "msi"),
 		Clock:    clockwork.NewFakeClockAt(time.Date(2022, 1, 1, 9, 0, 0, 0, time.UTC)),
-		Key:      newPrivateKey(),
 		Secret:   "my-secret",
 	}
+	m.SetPrivateKey(key)
 	require.NoError(t, m.CheckAndSetDefaults())
 
 	tests := []struct {
@@ -182,7 +183,7 @@ func testAzureMSIMiddlewareHandleRequest(t *testing.T, alg cryptosuites.Algorith
 					return key.VerifyAzureToken(token)
 				}
 
-				claims, err := fromJWT(req.AccessToken, m.Key)
+				claims, err := fromJWT(req.AccessToken, key)
 				require.NoError(t, err)
 				require.Equal(t, jwt.AzureTokenClaims{
 					TenantID: "cafecafe-cafe-4aaa-cafe-cafecafecafe",

--- a/lib/srv/alpnproxy/local_proxy.go
+++ b/lib/srv/alpnproxy/local_proxy.go
@@ -93,7 +93,7 @@ type LocalProxyConfig struct {
 	// verifyUpstreamConnection is a callback function to verify upstream connection state.
 	verifyUpstreamConnection func(tls.ConnectionState) error
 	// onSetCert is a callback when lp.SetCert is called.
-	onSetCert func(*tls.Certificate)
+	onSetCert func(tls.Certificate)
 }
 
 // LocalProxyMiddleware provides callback functions for LocalProxy.
@@ -489,7 +489,7 @@ func (l *LocalProxy) SetCert(cert tls.Certificate) {
 
 	// Callback, if any.
 	if l.cfg.onSetCert != nil {
-		l.cfg.onSetCert(&cert)
+		l.cfg.onSetCert(cert)
 	}
 }
 

--- a/lib/srv/alpnproxy/local_proxy.go
+++ b/lib/srv/alpnproxy/local_proxy.go
@@ -92,6 +92,8 @@ type LocalProxyConfig struct {
 	CheckCertNeeded bool
 	// verifyUpstreamConnection is a callback function to verify upstream connection state.
 	verifyUpstreamConnection func(tls.ConnectionState) error
+	// onSetCert is a callback when lp.SetCert is called.
+	onSetCert func(*tls.Certificate)
 }
 
 // LocalProxyMiddleware provides callback functions for LocalProxy.
@@ -484,6 +486,11 @@ func (l *LocalProxy) SetCert(cert tls.Certificate) {
 	l.certMu.Lock()
 	defer l.certMu.Unlock()
 	l.cfg.Cert = cert
+
+	// Callback, if any.
+	if l.cfg.onSetCert != nil {
+		l.cfg.onSetCert(&cert)
+	}
 }
 
 // getCertForConn determines if certificates should be used when dialing

--- a/lib/srv/alpnproxy/local_proxy_config_opt.go
+++ b/lib/srv/alpnproxy/local_proxy_config_opt.go
@@ -170,3 +170,11 @@ func mySQLVersionToProto(database types.Database) string {
 	// Include MySQL server version
 	return string(common.ProtocolMySQLWithVerPrefix) + versionBase64
 }
+
+// WithOnSetCert provides a callback when lp.SetCert is called.
+func WithOnSetCert(callback func(*tls.Certificate)) LocalProxyConfigOpt {
+	return func(config *LocalProxyConfig) error {
+		config.onSetCert = callback
+		return nil
+	}
+}

--- a/lib/srv/alpnproxy/local_proxy_config_opt.go
+++ b/lib/srv/alpnproxy/local_proxy_config_opt.go
@@ -172,7 +172,7 @@ func mySQLVersionToProto(database types.Database) string {
 }
 
 // WithOnSetCert provides a callback when lp.SetCert is called.
-func WithOnSetCert(callback func(*tls.Certificate)) LocalProxyConfigOpt {
+func WithOnSetCert(callback func(tls.Certificate)) LocalProxyConfigOpt {
 	return func(config *LocalProxyConfig) error {
 		config.onSetCert = callback
 		return nil

--- a/tool/tsh/common/app_azure.go
+++ b/tool/tsh/common/app_azure.go
@@ -21,6 +21,7 @@ package common
 import (
 	"context"
 	"crypto"
+	"crypto/tls"
 	"fmt"
 	"os"
 	"os/exec"
@@ -72,17 +73,11 @@ type azureApp struct {
 	*localProxyApp
 
 	cf        *CLIConf
-	signer    crypto.Signer
 	msiSecret string
 }
 
 // newAzureApp creates a new Azure app.
 func newAzureApp(tc *client.TeleportClient, cf *CLIConf, appInfo *appInfo) (*azureApp, error) {
-	keyRing, err := tc.LocalAgent().GetCoreKeyRing()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	msiSecret, err := getMSISecret()
 	if err != nil {
 		return nil, err
@@ -91,7 +86,6 @@ func newAzureApp(tc *client.TeleportClient, cf *CLIConf, appInfo *appInfo) (*azu
 	return &azureApp{
 		localProxyApp: newLocalProxyApp(tc, appInfo, cf.LocalProxyPort, cf.InsecureSkipVerify),
 		cf:            cf,
-		signer:        keyRing.TLSPrivateKey,
 		msiSecret:     msiSecret,
 	}, nil
 }
@@ -133,7 +127,6 @@ func getMSISecret() (string, error) {
 // These calls are served entirely locally, which helps the overall performance experienced by the user.
 func (a *azureApp) StartLocalProxies(ctx context.Context) error {
 	azureMiddleware := &alpnproxy.AzureMSIMiddleware{
-		Key:    a.signer,
 		Secret: a.msiSecret,
 		// we could, in principle, get the actual TenantID either from live data or from static configuration,
 		// but at this moment there is no clear advantage over simply issuing a new random identifier.
@@ -143,7 +136,21 @@ func (a *azureApp) StartLocalProxies(ctx context.Context) error {
 	}
 
 	// HTTPS proxy mode
-	err := a.StartLocalProxyWithForwarder(ctx, alpnproxy.MatchAzureRequests, alpnproxy.WithHTTPMiddleware(azureMiddleware))
+	err := a.StartLocalProxyWithForwarder(ctx,
+		alpnproxy.MatchAzureRequests,
+		alpnproxy.WithHTTPMiddleware(azureMiddleware),
+		alpnproxy.WithOnSetCert(func(cert *tls.Certificate) {
+			if cert != nil {
+				// Note that the PrivateKey is most likely set by api/utils/keys.TLSCertificateForSigner.
+				signer, ok := cert.PrivateKey.(crypto.Signer)
+				if ok {
+					azureMiddleware.SetPrivateKey(signer)
+				} else {
+					log.Warn("Provided tls.Certificate has no valid private key.")
+				}
+			}
+		}),
+	)
 	return trace.Wrap(err)
 }
 

--- a/tool/tsh/common/app_azure.go
+++ b/tool/tsh/common/app_azure.go
@@ -139,15 +139,13 @@ func (a *azureApp) StartLocalProxies(ctx context.Context) error {
 	err := a.StartLocalProxyWithForwarder(ctx,
 		alpnproxy.MatchAzureRequests,
 		alpnproxy.WithHTTPMiddleware(azureMiddleware),
-		alpnproxy.WithOnSetCert(func(cert *tls.Certificate) {
-			if cert != nil {
-				// Note that the PrivateKey is most likely set by api/utils/keys.TLSCertificateForSigner.
-				signer, ok := cert.PrivateKey.(crypto.Signer)
-				if ok {
-					azureMiddleware.SetPrivateKey(signer)
-				} else {
-					log.Warn("Provided tls.Certificate has no valid private key.")
-				}
+		alpnproxy.WithOnSetCert(func(cert tls.Certificate) {
+			// Note that the PrivateKey is most likely set by api/utils/keys.TLSCertificateForSigner.
+			signer, ok := cert.PrivateKey.(crypto.Signer)
+			if ok {
+				azureMiddleware.SetPrivateKey(signer)
+			} else {
+				log.Warn("Provided tls.Certificate has no valid private key.")
 			}
 		}),
 	)


### PR DESCRIPTION
Fixes #48522
- #48522 

Azure middleware needs to use a private key to sign JWT and the server verifies the JWT using the App TLS cert. This is broken after the App TLS cert uses its own key instead of the core one.
