### PR TITLE
add info to auto upgrade version fetch error

### DIFF
--- a/lib/automaticupgrades/version/basichttp.go
+++ b/lib/automaticupgrades/version/basichttp.go
@@ -47,7 +47,7 @@ func (b *basicHTTPVersionClient) Get(ctx context.Context) (string, error) {
 	versionURL := b.baseURL.JoinPath(constants.VersionPath)
 	body, err := b.client.GetContent(ctx, *versionURL)
 	if err != nil {
-		return "", trace.Wrap(err)
+		return "", trace.Wrap(err, "failed to get version from %s", versionURL)
 	}
 	response := string(body)
 	if response == constants.NoVersion {


### PR DESCRIPTION
This tiny PR adds a little bit of info when failing to fetch the version from auto upgrades `forward_url`.

Without this, the error can be really unhelpful in the web UI, i.e it would just say "non-200 status code received: '404'" without explaining what it was trying to do.

I ran into this error because of https://github.com/gravitational/teleport/issues/48508 while going through the RDS enrollment wizard in the web ui - basically it's because the `stable/cloud/v17` upgrade channel doesn't exist yet, so GET returns 404.

Now at least it's a little more specific about what it was trying to fetch:

![image](https://github.com/user-attachments/assets/c4c9f028-d658-4ca2-9ff3-40230feb6f02)