### PR TITLE
`tsh --cluster` saves oracle wallet to leaf dir

### DIFF
--- a/lib/client/db/oracle/oracle.go
+++ b/lib/client/db/oracle/oracle.go
@@ -42,8 +42,8 @@ import (
 // wallet.jks   - Java Wallet format used by JDBC Drivers.
 // sqlnet.ora   - Generic Oracle Client Configuration File allowing to specify Wallet Location.
 // tnsnames.ora - Oracle Net Service mapped to connections descriptors.
-func GenerateClientConfiguration(signer crypto.Signer, db tlsca.RouteToDatabase, profile *client.ProfileStatus) error {
-	walletPath := profile.OracleWalletDir(profile.Cluster, db.ServiceName)
+func GenerateClientConfiguration(signer crypto.Signer, db tlsca.RouteToDatabase, profile *client.ProfileStatus, siteName string) error {
+	walletPath := profile.OracleWalletDir(siteName, db.ServiceName)
 	if err := os.MkdirAll(walletPath, teleport.PrivateDirMode); err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tsh/common/db.go
+++ b/tool/tsh/common/db.go
@@ -335,7 +335,7 @@ func databaseLogin(cf *CLIConf, tc *client.TeleportClient, dbInfo *databaseInfo)
 		if err := generateDBLocalProxyCert(keyRing.TLSPrivateKey, profile); err != nil {
 			return trace.Wrap(err)
 		}
-		err = oracle.GenerateClientConfiguration(keyRing.TLSPrivateKey, dbInfo.RouteToDatabase, profile)
+		err = oracle.GenerateClientConfiguration(keyRing.TLSPrivateKey, dbInfo.RouteToDatabase, profile, tc.SiteName)
 		if err != nil {
 			return trace.Wrap(err)
 		}


### PR DESCRIPTION
Changelog: Fixed tsh connections to Oracle database via trusted cluster.

Fixes #48324
- #48324

tested manually that this works in both "normal" and leaf cluster cases with self-hosted oracle db connections.

The fix is to respect the --cluster flag or env vars instead of always saving the wallet into the profile's directory.