### PR TITLE
Discover: rename EC2 auto enroll tile

### DIFF
--- a/web/packages/teleport/src/Discover/SelectResource/resources.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/resources.tsx
@@ -94,7 +94,7 @@ export const SERVERS: ResourceSpec[] = [
     platform: Platform.macOS,
   },
   {
-    name: 'EC2 Auto Enrollment',
+    name: 'EC2 Auto Enrollment via SSM',
     kind: ResourceKind.Server,
     keywords: [
       ...baseServerKeywords,


### PR DESCRIPTION
Demo:
<img width="757" alt="image" src="https://github.com/user-attachments/assets/0699a1bb-80a2-45c1-9734-a5243709d16f">


Fixes https://github.com/gravitational/teleport/issues/45842