### PR TITLE
Fix the icon story generation template

### DIFF
--- a/web/packages/design/src/Icon/script/StoryTemplate.txt
+++ b/web/packages/design/src/Icon/script/StoryTemplate.txt
@@ -16,11 +16,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { ComponentType } from 'react';
 
 import { Text } from '..';
 
 import Flex from './../Flex';
+
+import { IconProps } from './Icon';
 
 import * as Icon from '.';
 
@@ -40,7 +42,13 @@ export const Icons = () => (
   </Flex>
 );
 
-const IconBox = ({ IconCmpt, text }) => (
+const IconBox = ({
+  IconCmpt,
+  text,
+}: {
+  IconCmpt: ComponentType<IconProps>;
+  text: string;
+}) => (
   <Flex m="10px" width="300px">
     <IconCmpt />
     <Text ml={2}>{text}</Text>


### PR DESCRIPTION
I'm not entirely sure why but it looks like this template hasn't generated the code that we have in `Icons.story.tsx` for a while - the types are missing and the imports don't match. This updates the template to match the code.