### PR TITLE
[v14] helm: Add serviceAccountName to pre-deploy jobs

### DIFF
--- a/examples/chart/teleport-cluster/templates/auth/predeploy_job.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/predeploy_job.yaml
@@ -36,7 +36,7 @@ spec:
 {{- if $auth.resources }}
         resources:
   {{- toYaml $auth.resources | nindent 10 }}
-{{- end }}        
+{{- end }}
 {{- if or $auth.extraEnv $auth.tls.existingCASecretName }}
         env:
   {{- if (gt (len $auth.extraEnv) 0) }}
@@ -104,4 +104,5 @@ spec:
 {{- if .Values.extraVolumes }}
   {{- toYaml .Values.extraVolumes | nindent 6 }}
 {{- end }}
+      serviceAccountName: {{ include "teleport-cluster.auth.serviceAccountName" . }}
 {{- end }}

--- a/examples/chart/teleport-cluster/templates/auth/predeploy_serviceaccount.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/predeploy_serviceaccount.yaml
@@ -1,0 +1,34 @@
+# this is a carbon copy of the regular serviceAccount object which is only used to run pre-deploy jobs
+# on first install of the chart. it will be deleted by Helm after the pre-deploy hooks run, then the
+# regular serviceAccount is created with the same name.
+{{- $auth := mustMergeOverwrite (mustDeepCopy .Values) .Values.auth -}}
+{{- $projectedServiceAccountToken := semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version }}
+{{- if $auth.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "teleport-cluster.auth.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "teleport-cluster.auth.labels" . | nindent 4 }}
+    {{- if $auth.extraLabels.serviceAccount }}
+    {{- toYaml $auth.extraLabels.serviceAccount | nindent 4 }}
+    {{- end }}
+  annotations:
+    # this ServiceAccount resource MUST only be hooked on pre-install, as it would conflict
+    # with the existing ServiceAccount if hooked on pre-upgrade.
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "3"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  {{- if or $auth.annotations.serviceAccount $auth.azure.clientID }}
+    {{- if $auth.annotations.serviceAccount }}
+      {{- toYaml $auth.annotations.serviceAccount | nindent 4 }}
+    {{- end }}
+    {{- if $auth.azure.clientID }}
+    azure.workload.identity/client-id: "{{ $auth.azure.clientID }}"
+    {{- end }}
+  {{- end -}}
+{{- if $projectedServiceAccountToken }}
+automountServiceAccountToken: false
+{{- end }}
+{{- end }}

--- a/examples/chart/teleport-cluster/templates/auth/predeploy_serviceaccount.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/predeploy_serviceaccount.yaml
@@ -1,6 +1,6 @@
 # this is a carbon copy of the regular serviceAccount object which is only used to run pre-deploy jobs
-# on first install of the chart. it will be deleted by Helm after the pre-deploy hooks run, then the
-# regular serviceAccount is created with the same name.
+# upon first install of the chart. it will be deleted by Helm after the pre-deploy hooks run, then the
+# regular serviceAccount is created with the same name and exists for the lifetime of the release.
 {{- $auth := mustMergeOverwrite (mustDeepCopy .Values) .Values.auth -}}
 {{- $projectedServiceAccountToken := semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version }}
 {{- if $auth.serviceAccount.create }}

--- a/examples/chart/teleport-cluster/templates/proxy/predeploy_job.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/predeploy_job.yaml
@@ -100,4 +100,5 @@ spec:
 {{- if $proxy.extraVolumes }}
   {{- toYaml $proxy.extraVolumes | nindent 6 }}
 {{- end }}
+      serviceAccountName: {{ include "teleport-cluster.proxy.serviceAccountName" . }}
 {{- end }}

--- a/examples/chart/teleport-cluster/templates/proxy/predeploy_serviceaccount.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/predeploy_serviceaccount.yaml
@@ -1,0 +1,29 @@
+# this is a carbon copy of the regular serviceAccount object which is only used to run pre-deploy jobs
+# on first install of the chart. it will be deleted by Helm after the pre-deploy hooks run, then the
+# regular serviceAccount is created with the same name.
+{{- $proxy := mustMergeOverwrite (mustDeepCopy .Values) .Values.proxy -}}
+{{- $projectedServiceAccountToken := semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version }}
+{{- if $proxy.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "teleport-cluster.proxy.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "teleport-cluster.proxy.labels" . | nindent 4 }}
+    {{- if $proxy.extraLabels.serviceAccount }}
+    {{- toYaml $proxy.extraLabels.serviceAccount | nindent 4 }}
+    {{- end }}
+  annotations:
+    # this ServiceAccount resource MUST only be hooked on pre-install, as it would conflict
+    # with the existing ServiceAccount if hooked on pre-upgrade.
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "3"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+{{- if $proxy.annotations.serviceAccount }}
+  {{- toYaml $proxy.annotations.serviceAccount | nindent 4 }}
+{{- end -}}
+{{- if $projectedServiceAccountToken }}
+automountServiceAccountToken: false
+{{- end }}
+{{- end }}

--- a/examples/chart/teleport-cluster/templates/proxy/predeploy_serviceaccount.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/predeploy_serviceaccount.yaml
@@ -1,6 +1,6 @@
 # this is a carbon copy of the regular serviceAccount object which is only used to run pre-deploy jobs
-# on first install of the chart. it will be deleted by Helm after the pre-deploy hooks run, then the
-# regular serviceAccount is created with the same name.
+# upon first install of the chart. it will be deleted by Helm after the pre-deploy hooks run, then the
+# regular serviceAccount is created with the same name and exists for the lifetime of the release.
 {{- $proxy := mustMergeOverwrite (mustDeepCopy .Values) .Values.proxy -}}
 {{- $projectedServiceAccountToken := semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version }}
 {{- if $proxy.serviceAccount.create }}

--- a/examples/chart/teleport-cluster/tests/predeploy_test.yaml
+++ b/examples/chart/teleport-cluster/tests/predeploy_test.yaml
@@ -188,3 +188,43 @@ tests:
       - equal:
           path: metadata.labels.baz
           value: overridden
+
+  - it: should use default serviceAccount name for auth predeploy job SA when not set in values
+    template: auth/predeploy_job.yaml
+    set:
+      clusterName: helm-lint
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME
+
+  - it: should use serviceAccount.name for auth predeploy job SA when set in values
+    template: auth/predeploy_job.yaml
+    set:
+      clusterName: helm-lint
+      serviceAccount:
+        name: helm-test-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: helm-test-sa
+
+  - it: should use default serviceAccount name for proxy predeploy job SA when not set in values
+    template: proxy/predeploy_job.yaml
+    set:
+      clusterName: helm-lint
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-proxy
+
+  - it: should use serviceAccount.name for proxy predeploy job SA when set in values
+    template: proxy/predeploy_job.yaml
+    set:
+      clusterName: helm-lint
+      serviceAccount:
+        name: helm-test-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: helm-test-sa-proxy


### PR DESCRIPTION
Backport #48530 to branch/v14

changelog: The teleport-cluster Helm chart now uses the configured serviceAccount.name from chart values for its pre-deploy configuration check Jobs.