### PR TITLE
Prepare to remove go-oidc/oauth2 from config packages

### DIFF
--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -3673,6 +3673,10 @@ func TestAuthHostedPlugins(t *testing.T) {
 				require.NotNil(t, p.OAuthProviders.Slack)
 				require.Equal(t, "foo", p.OAuthProviders.Slack.ID)
 				require.Equal(t, "bar", p.OAuthProviders.Slack.Secret)
+
+				require.NotNil(t, p.OAuthProviders.SlackCredentials)
+				require.Equal(t, "foo", p.OAuthProviders.SlackCredentials.ClientID)
+				require.Equal(t, "bar", p.OAuthProviders.SlackCredentials.ClientSecret)
 			},
 		},
 	}

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1321,7 +1321,11 @@ func (p *PluginOAuthProviders) Parse() (servicecfg.PluginOAuthProviders, error) 
 		if err != nil {
 			return out, trace.Wrap(err)
 		}
-		out.Slack = slack
+		out.Slack = &oauth2.ClientCredentials{
+			ID:     slack.ClientID,
+			Secret: slack.ClientSecret,
+		}
+		out.SlackCredentials = slack
 	}
 	return out, nil
 }
@@ -1335,7 +1339,7 @@ type OAuthClientCredentials struct {
 	ClientSecret string `yaml:"client_secret"`
 }
 
-func (o *OAuthClientCredentials) Parse() (*oauth2.ClientCredentials, error) {
+func (o *OAuthClientCredentials) Parse() (*servicecfg.OAuthClientCredentials, error) {
 	if o.ClientID == "" || o.ClientSecret == "" {
 		return nil, trace.BadParameter("both client_id and client_secret paths must be specified")
 	}
@@ -1354,9 +1358,9 @@ func (o *OAuthClientCredentials) Parse() (*oauth2.ClientCredentials, error) {
 	}
 	clientSecret = strings.TrimSpace(string(content))
 
-	return &oauth2.ClientCredentials{
-		ID:     clientID,
-		Secret: clientSecret,
+	return &servicecfg.OAuthClientCredentials{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
 	}, nil
 }
 

--- a/lib/service/servicecfg/auth.go
+++ b/lib/service/servicecfg/auth.go
@@ -178,7 +178,18 @@ type HostedPluginsConfig struct {
 // PluginOAuthProviders holds application credentials for each
 // 3rd party API provider
 type PluginOAuthProviders struct {
+	// TODO(tross) delete once teleport.e has been converted.
+	// Deprecated: use SlackCredentials instead.
 	Slack *oauth2.ClientCredentials
+
+	SlackCredentials *OAuthClientCredentials
+}
+
+// OAuthClientCredentials stores the client_id and client_secret
+// of an OAuth application.
+type OAuthClientCredentials struct {
+	ClientID     string
+	ClientSecret string
 }
 
 // KeystoreConfig configures the auth keystore.


### PR DESCRIPTION
Adds a OAuthClientCredentials type directly into the servicecfg package so that the dependency on go-oidc/oauth2 can be removed. The PluginOAuthProviders.Slack field has been deprecated, but left in place so as not to break teleport.e and a new PluginOAuthProviders.SlackCredentials field has been added to use the new type. Both fields are being populated with the same data from the file config at the moment. Once teleport.e has been updated to consume the credentials from PluginOAuthProviders.SlackCredentials the original field will be removed.