### PR TITLE
Remove OIDCClaimsToTraits helper function

### DIFF
--- a/lib/services/oidc.go
+++ b/lib/services/oidc.go
@@ -21,39 +21,11 @@ package services
 import (
 	"net/url"
 
-	"github.com/coreos/go-oidc/jose"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/utils"
 )
-
-// GetClaimNames returns a list of claim names from the claim values
-func GetClaimNames(claims jose.Claims) []string {
-	var out []string
-	for claim := range claims {
-		out = append(out, claim)
-	}
-	return out
-}
-
-// OIDCClaimsToTraits converts OIDC-style claims into teleport-specific trait format
-func OIDCClaimsToTraits(claims jose.Claims) map[string][]string {
-	traits := make(map[string][]string)
-
-	for claimName := range claims {
-		claimValue, ok, _ := claims.StringClaim(claimName)
-		if ok {
-			traits[claimName] = []string{claimValue}
-		}
-		claimValues, ok, _ := claims.StringsClaim(claimName)
-		if ok {
-			traits[claimName] = claimValues
-		}
-	}
-
-	return traits
-}
 
 // GetRedirectURL gets a redirect URL for the given connector. If the connector
 // has a redirect URL which matches the host of the given Proxy address, then

--- a/lib/services/oidc_test.go
+++ b/lib/services/oidc_test.go
@@ -21,42 +21,12 @@ package services
 import (
 	"testing"
 
-	"github.com/coreos/go-oidc/jose"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 )
-
-// TestOIDCRoleMapping verifies basic mapping from OIDC claims to roles.
-func TestOIDCRoleMapping(t *testing.T) {
-	// create a connector
-	oidcConnector, err := types.NewOIDCConnector("example", types.OIDCConnectorSpecV3{
-		IssuerURL:     "https://www.exmaple.com",
-		ClientID:      "example-client-id",
-		ClientSecret:  "example-client-secret",
-		Display:       "sign in with example.com",
-		Scope:         []string{"foo", "bar"},
-		ClaimsToRoles: []types.ClaimMapping{{Claim: "roles", Value: "teleport-user", Roles: []string{"user"}}},
-		RedirectURLs:  []string{"https://localhost:3080/v1/webapi/oidc/callback"},
-	})
-	require.NoError(t, err)
-
-	// create some claims
-	var claims = make(jose.Claims)
-	claims.Add("roles", "teleport-user")
-	claims.Add("email", "foo@example.com")
-	claims.Add("nickname", "foo")
-	claims.Add("full_name", "foo bar")
-
-	traits := OIDCClaimsToTraits(claims)
-	require.Len(t, traits, 4)
-
-	_, roles := TraitsToRoles(oidcConnector.GetTraitMappings(), traits)
-	require.Len(t, roles, 1)
-	require.Equal(t, "user", roles[0])
-}
 
 // TestOIDCUnmarshal tests UnmarshalOIDCConnector
 func TestOIDCUnmarshal(t *testing.T) {

--- a/lib/services/user_test.go
+++ b/lib/services/user_test.go
@@ -273,7 +273,7 @@ func TestOIDCMapping(t *testing.T) {
 		}
 		for _, input := range testCase.inputs {
 			comment := fmt.Sprintf("OIDC Test case %v %q, input %q", i, testCase.comment, input.comment)
-			_, outRoles := TraitsToRoles(conn.GetTraitMappings(), OIDCClaimsToTraits(input.claims))
+			_, outRoles := TraitsToRoles(conn.GetTraitMappings(), oidcClaimsToTraits(input.claims))
 			require.Empty(t, cmp.Diff(outRoles, input.expectedRoles), comment)
 		}
 
@@ -323,6 +323,25 @@ func claimMappingsToAttributeMappings(in []types.ClaimMapping) []types.Attribute
 		})
 	}
 	return out
+}
+
+// oidcClaimsToTraits converts OIDC-style claims into teleport-specific trait format
+func oidcClaimsToTraits(claims jose.Claims) map[string][]string {
+	traits := make(map[string][]string)
+
+	for claimName := range claims {
+		claimValue, ok, _ := claims.StringClaim(claimName)
+		if ok {
+			traits[claimName] = []string{claimValue}
+			continue
+		}
+		claimValues, ok, _ := claims.StringsClaim(claimName)
+		if ok {
+			traits[claimName] = claimValues
+		}
+	}
+
+	return traits
 }
 
 // claimsToAttributes maps jose.Claims type to attributes for testing


### PR DESCRIPTION
The function was relocated to the only place it was being called in https://github.com/gravitational/teleport.e/pull/5374 and is no longer needed in lib/services. This also has the added benefit of removing go-oidc as a direct dependency of lib/services.