### PR TITLE
Remove go-oidc dependency from lib/jwt

### DIFF
--- a/lib/jwt/jwt.go
+++ b/lib/jwt/jwt.go
@@ -32,7 +32,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/coreos/go-oidc"
 	"github.com/go-jose/go-jose/v3"
 	"github.com/go-jose/go-jose/v3/cryptosigner"
 	"github.com/go-jose/go-jose/v3/jwt"
@@ -639,11 +638,18 @@ type Claims struct {
 	Traits wrappers.Traits `json:"traits"`
 }
 
+// IDToken allows introspecting claims from an OpenID Connect
+// ID Token.
+type IDToken interface {
+	// Claims unmarshals the raw JSON payload of the ID Token into a provided struct.
+	Claims(v any) error
+}
+
 // CheckNotBefore ensures the token was not issued in the future.
 // https://www.rfc-editor.org/rfc/rfc7519#section-4.1.5
 // 4.1.5.  "nbf" (Not Before) Claim
 // TODO(strideynet): upstream support for `nbf` into the go-oidc lib.
-func CheckNotBefore(now time.Time, leeway time.Duration, token *oidc.IDToken) error {
+func CheckNotBefore(now time.Time, leeway time.Duration, token IDToken) error {
 	claims := struct {
 		NotBefore *JSONTime `json:"nbf"`
 	}{}


### PR DESCRIPTION
Abstracts the claims extraction via a new IDToken interface instead of importing oidc.IDToken directly. This is being done to reduce the footprint of the outdated go-oidc library in hopes that we can move off our internal and outdated fork.