### PR TITLE
Adding Azure role definitions and assignments clients

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	connectrpc.com/connect v1.17.0
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.16.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v3 v3.0.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2 v2.4.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -664,6 +664,7 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0/go.mod h1:eWRD7oawr1Mu1sLC
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 h1:ywEEhmNahHBihViHepv3xPBn1663uRv2t2q/ESv9seY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkYRNWPENUnqx6bJ2xnSDFI2tjwZNuY=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0/go.mod h1:/pz8dyNQe+Ey3yBp/XuYz7oqX8YDNWVpPB0hH3XWfbc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v3 v3.0.1 h1:H3g2mkmu105ON0c/Gqx3Bm+bzoIijLom8LmV9Gjn7X0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v3 v3.0.1/go.mod h1:EAc3kjhZf9soch7yLID8PeKcE6VfKvQTllSBHYVdXd8=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2 v2.4.0 h1:1u/K2BFv0MwkG6he8RYuUcbbeK22rkoZbg4lKa/msZU=

--- a/go.sum
+++ b/go.sum
@@ -664,6 +664,7 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0/go.mod h1:eWRD7oawr1Mu1sLC
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 h1:ywEEhmNahHBihViHepv3xPBn1663uRv2t2q/ESv9seY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkYRNWPENUnqx6bJ2xnSDFI2tjwZNuY=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0 h1:Hp+EScFOu9HeCbeW8WU2yQPJd4gGwhMgKxWe+G6jNzw=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0/go.mod h1:/pz8dyNQe+Ey3yBp/XuYz7oqX8YDNWVpPB0hH3XWfbc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v3 v3.0.1 h1:H3g2mkmu105ON0c/Gqx3Bm+bzoIijLom8LmV9Gjn7X0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v3 v3.0.1/go.mod h1:EAc3kjhZf9soch7yLID8PeKcE6VfKvQTllSBHYVdXd8=

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.16.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v3 v3.0.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2 v2.4.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.2.0 // indirect

--- a/integrations/event-handler/go.sum
+++ b/integrations/event-handler/go.sum
@@ -631,6 +631,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.3.0 h1:+m0M/LFxN43KvUL
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.3.0/go.mod h1:PwOyop78lveYMRs6oCxjiVyBdyCgIYH6XHIVZO9/SFQ=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 h1:ywEEhmNahHBihViHepv3xPBn1663uRv2t2q/ESv9seY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkYRNWPENUnqx6bJ2xnSDFI2tjwZNuY=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0 h1:Hp+EScFOu9HeCbeW8WU2yQPJd4gGwhMgKxWe+G6jNzw=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0/go.mod h1:/pz8dyNQe+Ey3yBp/XuYz7oqX8YDNWVpPB0hH3XWfbc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v3 v3.0.1 h1:H3g2mkmu105ON0c/Gqx3Bm+bzoIijLom8LmV9Gjn7X0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v3 v3.0.1/go.mod h1:EAc3kjhZf9soch7yLID8PeKcE6VfKvQTllSBHYVdXd8=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2 v2.4.0 h1:1u/K2BFv0MwkG6he8RYuUcbbeK22rkoZbg4lKa/msZU=

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.16.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v3 v3.0.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2 v2.4.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.2.0 // indirect

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -644,6 +644,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.3.0 h1:+m0M/LFxN43KvUL
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.3.0/go.mod h1:PwOyop78lveYMRs6oCxjiVyBdyCgIYH6XHIVZO9/SFQ=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 h1:ywEEhmNahHBihViHepv3xPBn1663uRv2t2q/ESv9seY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkYRNWPENUnqx6bJ2xnSDFI2tjwZNuY=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0 h1:Hp+EScFOu9HeCbeW8WU2yQPJd4gGwhMgKxWe+G6jNzw=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0/go.mod h1:/pz8dyNQe+Ey3yBp/XuYz7oqX8YDNWVpPB0hH3XWfbc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v3 v3.0.1 h1:H3g2mkmu105ON0c/Gqx3Bm+bzoIijLom8LmV9Gjn7X0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v3 v3.0.1/go.mod h1:EAc3kjhZf9soch7yLID8PeKcE6VfKvQTllSBHYVdXd8=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2 v2.4.0 h1:1u/K2BFv0MwkG6he8RYuUcbbeK22rkoZbg4lKa/msZU=

--- a/lib/cloud/azure/interfaces.go
+++ b/lib/cloud/azure/interfaces.go
@@ -20,6 +20,7 @@ package azure
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysql"
@@ -122,4 +123,16 @@ type PostgresFlexServersClient interface {
 	ListAll(ctx context.Context) ([]*armpostgresqlflexibleservers.Server, error)
 	// ListWithinGroup returns all Azure Postgres Flex servers within an Azure resource group.
 	ListWithinGroup(ctx context.Context, group string) ([]*armpostgresqlflexibleservers.Server, error)
+}
+
+// RoleAssignmentsClient is an interface for an Azure role assignments client
+type RoleAssignmentsClient interface {
+	// ListRoleAssignments returns all role assignments within a given scope.
+	ListRoleAssignments(ctx context.Context, scope string) ([]*armauthorization.RoleAssignment, error)
+}
+
+// RoleDefinitionsClient is an interface for an Azure role definitions client
+type RoleDefinitionsClient interface {
+	// ListRoleDefinitions returns all role definitions within a given scope.
+	ListRoleDefinitions(ctx context.Context, scope string) ([]*armauthorization.RoleDefinition, error)
 }

--- a/lib/cloud/azure/roleassignments.go
+++ b/lib/cloud/azure/roleassignments.go
@@ -2,6 +2,7 @@ package azure
 
 import (
 	"context"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"

--- a/lib/cloud/azure/roleassignments.go
+++ b/lib/cloud/azure/roleassignments.go
@@ -1,0 +1,39 @@
+package azure
+
+import (
+	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
+	"github.com/gravitational/trace"
+)
+
+type RoleAssignmentsClient interface {
+	ListRoleAssignments(ctx context.Context, scope string) ([]*armauthorization.RoleAssignment, error)
+}
+
+type roleAssignmentsClient struct {
+	cli *armauthorization.RoleAssignmentsClient
+}
+
+func (c *roleAssignmentsClient) ListRoleAssignments(ctx context.Context, scope string) ([]*armauthorization.RoleAssignment, error) {
+	pager := c.cli.NewListForScopePager(scope, nil)
+	roleDefs := make([]*armauthorization.RoleAssignment, 0, 128)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		roleDefs = append(roleDefs, page.Value...)
+	}
+	return roleDefs, nil
+}
+
+func NewRoleAssignmentsClient(subscription string, cred azcore.TokenCredential, options *arm.ClientOptions) (RoleAssignmentsClient, error) {
+	clientFactory, err := armauthorization.NewClientFactory(subscription, cred, options)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	roleDefCli := clientFactory.NewRoleAssignmentsClient()
+	return &roleAssignmentsClient{cli: roleDefCli}, nil
+}

--- a/lib/cloud/azure/roleassignments.go
+++ b/lib/cloud/azure/roleassignments.go
@@ -9,10 +9,6 @@ import (
 	"github.com/gravitational/trace"
 )
 
-type RoleAssignmentsClient interface {
-	ListRoleAssignments(ctx context.Context, scope string) ([]*armauthorization.RoleAssignment, error)
-}
-
 type roleAssignmentsClient struct {
 	cli *armauthorization.RoleAssignmentsClient
 }

--- a/lib/cloud/azure/roledefinitions.go
+++ b/lib/cloud/azure/roledefinitions.go
@@ -2,6 +2,7 @@ package azure
 
 import (
 	"context"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"

--- a/lib/cloud/azure/roledefinitions.go
+++ b/lib/cloud/azure/roledefinitions.go
@@ -1,0 +1,39 @@
+package azure
+
+import (
+	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
+	"github.com/gravitational/trace"
+)
+
+type RoleDefinitionsClient interface {
+	ListRoleDefinitions(ctx context.Context, scope string) ([]*armauthorization.RoleDefinition, error)
+}
+
+type roleDefinitionsClient struct {
+	cli *armauthorization.RoleDefinitionsClient
+}
+
+func (c *roleDefinitionsClient) ListRoleDefinitions(ctx context.Context, scope string) ([]*armauthorization.RoleDefinition, error) {
+	pager := c.cli.NewListPager(scope, nil)
+	roleDefs := make([]*armauthorization.RoleDefinition, 0, 128)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		roleDefs = append(roleDefs, page.Value...)
+	}
+	return roleDefs, nil
+}
+
+func NewRoleDefinitionsClient(subscription string, cred azcore.TokenCredential, options *arm.ClientOptions) (RoleDefinitionsClient, error) {
+	clientFactory, err := armauthorization.NewClientFactory(subscription, cred, options)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	roleDefCli := clientFactory.NewRoleDefinitionsClient()
+	return &roleDefinitionsClient{cli: roleDefCli}, nil
+}

--- a/lib/cloud/azure/roledefinitions.go
+++ b/lib/cloud/azure/roledefinitions.go
@@ -9,10 +9,6 @@ import (
 	"github.com/gravitational/trace"
 )
 
-type RoleDefinitionsClient interface {
-	ListRoleDefinitions(ctx context.Context, scope string) ([]*armauthorization.RoleDefinition, error)
-}
-
 type roleDefinitionsClient struct {
 	cli *armauthorization.RoleDefinitionsClient
 }

--- a/lib/cloud/clients.go
+++ b/lib/cloud/clients.go
@@ -179,6 +179,10 @@ type AzureClients interface {
 	GetAzurePostgresFlexServersClient(subscription string) (azure.PostgresFlexServersClient, error)
 	// GetAzureRunCommandClient returns an Azure Run Command client for the given subscription.
 	GetAzureRunCommandClient(subscription string) (azure.RunCommandClient, error)
+	// GetAzureRoleDefinitionsClient returns an Azure Role Definitions client for the given subscription.
+	GetAzureRoleDefinitionsClient(subscription string) (azure.RoleDefinitionsClient, error)
+	// GetAzureRoleAssignmentsClient returns an Azure Role Assignment client for the given subscription.
+	GetAzureRoleAssignmentsClient(subscription string) (azure.RoleAssignmentsClient, error)
 }
 
 type clientConstructor[T any] func(context.Context) (T, error)
@@ -241,6 +245,14 @@ func newAzureClients() (*azureClients, error) {
 		return nil, trace.Wrap(err)
 	}
 	azClients.azureRunCommandClients, err = azure.NewClientMap(azure.NewRunCommandClient)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	azClients.azureRoleDefinitionsClients, err = azure.NewClientMap(azure.NewRoleDefinitionsClient)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	azClients.azureRoleAssignmentsClients, err = azure.NewClientMap(azure.NewRoleAssignmentsClient)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -364,6 +376,10 @@ type azureClients struct {
 	azurePostgresFlexServersClients azure.ClientMap[azure.PostgresFlexServersClient]
 	// azureRunCommandClients contains the cached Azure Run Command clients.
 	azureRunCommandClients azure.ClientMap[azure.RunCommandClient]
+	// azureRoleDefinitionsClients contains the cached Azure Role Definitions clients.
+	azureRoleDefinitionsClients azure.ClientMap[azure.RoleDefinitionsClient]
+	// azureRoleAssignmentsClients contains the cached Azure Role Assignments clients.
+	azureRoleAssignmentsClients azure.ClientMap[azure.RoleAssignmentsClient]
 }
 
 // credentialsSource defines where the credentials must come from.
@@ -772,6 +788,16 @@ func (c *cloudClients) GetAzureRunCommandClient(subscription string) (azure.RunC
 	return c.azureRunCommandClients.Get(subscription, c.GetAzureCredential)
 }
 
+// GetAzureRoleDefinitionsClient returns an Azure Role Definitions client
+func (c *cloudClients) GetAzureRoleDefinitionsClient(subscription string) (azure.RoleDefinitionsClient, error) {
+	return c.azureRoleDefinitionsClients.Get(subscription, c.GetAzureCredential)
+}
+
+// GetAzureRoleAssignmentsClient returns an Azure Role Assignments client
+func (c *cloudClients) GetAzureRoleAssignmentsClient(subscription string) (azure.RoleAssignmentsClient, error) {
+	return c.azureRoleAssignmentsClients.Get(subscription, c.GetAzureCredential)
+}
+
 // Close closes all initialized clients.
 func (c *cloudClients) Close() (err error) {
 	c.mtx.Lock()
@@ -1055,6 +1081,8 @@ type TestCloudClients struct {
 	AzureMySQLFlex          azure.MySQLFlexServersClient
 	AzurePostgresFlex       azure.PostgresFlexServersClient
 	AzureRunCommand         azure.RunCommandClient
+	AzureRoleDefinitions    azure.RoleDefinitionsClient
+	AzureRoleAssignments    azure.RoleAssignmentsClient
 }
 
 // GetAWSSession returns AWS session for the specified region, optionally
@@ -1326,9 +1354,19 @@ func (c *TestCloudClients) GetAzurePostgresFlexServersClient(subscription string
 	return c.AzurePostgresFlex, nil
 }
 
-// GetAzureRunCommand returns an Azure Run Command client for the given subscription.
+// GetAzureRunCommandClient returns an Azure Run Command client for the given subscription.
 func (c *TestCloudClients) GetAzureRunCommandClient(subscription string) (azure.RunCommandClient, error) {
 	return c.AzureRunCommand, nil
+}
+
+// GetAzureRoleDefinitionsClient returns an Azure Role Definitions client for the given subscription.
+func (c *TestCloudClients) GetAzureRoleDefinitionsClient(subscription string) (azure.RoleDefinitionsClient, error) {
+	return c.AzureRoleDefinitions, nil
+}
+
+// GetAzureRoleAssignmentsClient returns an Azure Role Assignments client for the given subscription.
+func (c *TestCloudClients) GetAzureRoleAssignmentsClient(subscription string) (azure.RoleAssignmentsClient, error) {
+	return c.AzureRoleAssignments, nil
 }
 
 // Close closes all initialized clients.


### PR DESCRIPTION
Part of of https://github.com/gravitational/access-graph/issues/640 to provide visibility of Azure resource in the Access Graph, and originating from the Azure integration POC branch https://github.com/gravitational/teleport/compare/master...mvbrock/azure-integration-poc. This PR adds the Azure role definitions and assignments clients to the cloud library, in order to build access graph relationships for Azure identities.