### PR TITLE
Web: fix pointer events disabling hover badges on integration tiles

### DIFF
--- a/web/packages/shared/components/Select/Select.tsx
+++ b/web/packages/shared/components/Select/Select.tsx
@@ -395,6 +395,7 @@ const StyledSelect = styled.div<{
     }
   }
   .react-select__menu {
+    z-index: 10;
     margin-top: 0px;
     // If the component is on an elevated platform (such as a dialog), use a lighter background.
     background-color: ${props =>

--- a/web/packages/teleport/src/Integrations/Enroll/IntegrationTiles.test.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/IntegrationTiles.test.tsx
@@ -18,7 +18,7 @@
 
 import React from 'react';
 import { MemoryRouter } from 'react-router';
-import { render, screen } from 'design/utils/testing';
+import { render, screen, userEvent } from 'design/utils/testing';
 
 import cfg from 'teleport/config';
 
@@ -51,8 +51,10 @@ test('render disabled', async () => {
     </MemoryRouter>
   );
 
-  expect(screen.getByText(/lacking permission/i)).toBeInTheDocument();
   expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  expect(
+    screen.queryByText(/request additional permissions/i)
+  ).not.toBeInTheDocument();
 
   const tile = screen.getByTestId('tile-aws-oidc');
   expect(tile).not.toHaveAttribute('href');
@@ -61,6 +63,13 @@ test('render disabled', async () => {
   // so "toBeDisabled" interprets it as false.
   // eslint-disable-next-line jest-dom/prefer-enabled-disabled
   expect(tile).toHaveAttribute('disabled');
+
+  // Disabled states have badges on them. Test it renders on hover.
+  const badge = screen.getByText(/lacking permission/i);
+  await userEvent.hover(badge);
+  expect(
+    screen.getByText(/request additional permissions/i)
+  ).toBeInTheDocument();
 });
 
 test('dont render External Audit Storage for enterprise unless it is cloud', async () => {

--- a/web/packages/teleport/src/Integrations/Enroll/common.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/common.tsx
@@ -35,12 +35,11 @@ export const IntegrationTile = styled(Flex)<{
   width: 170px;
   background-color: ${({ theme }) => theme.colors.buttons.secondary.default};
   text-align: center;
-  cursor: pointer;
-
+  cursor: ${({ disabled, $exists }) =>
+    disabled || $exists ? 'default' : 'pointer'};
   ${props => {
-    const pointerEvents = props.disabled || props.$exists ? 'none' : 'auto';
     if (props.$exists) {
-      return { pointerEvents };
+      return;
     }
 
     return `
@@ -48,9 +47,8 @@ export const IntegrationTile = styled(Flex)<{
     &:hover {
       background-color: ${props.theme.colors.buttons.secondary.hover};
     }
-    pointer-events: ${pointerEvents};
     `;
-  }}
+  }};
 `;
 
 export const NoCodeIntegrationDescription = () => (


### PR DESCRIPTION
integration tiles when disabled, will have `badges`, and on hover have different states:

<img width="331" alt="image" src="https://github.com/user-attachments/assets/8bbe018c-a619-44dc-aad1-ce4a2a7e54c3">

<img width="455" alt="image" src="https://github.com/user-attachments/assets/52fb97b3-5247-466f-818b-c307e172fbcc">


etc.

setting `pointer-events: none`, disabled these hover popovers. `pointer-events` were used to prevent `onClicks`, but that's now removed in favor of explicitly setting click handlers to `undefined` if disabled (enterprise change)

also increases the `z-index` of our react select styled component, before, the header is seen through the dropdown:
<img width="593" alt="image" src="https://github.com/user-attachments/assets/86912bc5-7c08-4a40-9d35-9cc6e2c2c23e">

