### PR TITLE
SSO MFA - fail gracefully when the Proxy is down

### DIFF
--- a/api/mfa/ceremony.go
+++ b/api/mfa/ceremony.go
@@ -75,7 +75,7 @@ func (c *Ceremony) Run(ctx context.Context, req *proto.CreateAuthenticateChallen
 		if err != nil {
 			// We may fail to start the SSO MFA flow in cases where the Proxy is down or broken. Fall
 			// back to skipping SSO MFA, especially since SSO MFA may not even be allowed on the server.
-			slog.DebugContext(ctx, "Failed to attempt SSO MFA, continuing with other MFA methods.", "error", err)
+			slog.DebugContext(ctx, "Failed to attempt SSO MFA, continuing with other MFA methods", "error", err)
 		} else {
 			defer ssoMFACeremony.Close()
 			req.SSOClientRedirectURL = ssoMFACeremony.GetClientCallbackURL()

--- a/lib/client/mfa.go
+++ b/lib/client/mfa.go
@@ -95,7 +95,7 @@ func (tc *TeleportClient) NewSSOMFACeremony(ctx context.Context) (mfa.SSOMFACere
 
 	rd, err := sso.NewRedirector(rdConfig)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.Wrap(err, "failed to create a redirector for SSO MFA")
 	}
 
 	if tc.SSOMFACeremonyConstructor != nil {


### PR DESCRIPTION
Allow SSO MFA to fail gracefully on the client when the Proxy is down. The SSO MFA ceremony construct fails because it can't create the redirector flow without the proxy addr.

Fixes https://github.com/gravitational/teleport/issues/48633