### PR TITLE
[v16] Remove unused `NewCLIPromptV2`

### DIFF
--- a/lib/client/mfa/cli.go
+++ b/lib/client/mfa/cli.go
@@ -72,12 +72,6 @@ func NewCLIPrompt(cfg *CLIPromptConfig) *CLIPrompt {
 	}
 }
 
-// NewCLIPromptV2 returns a new CLI mfa prompt with the given config.
-// TODO(Joerger): remove once /e is no longer dependent on this.
-func NewCLIPromptV2(cfg *CLIPromptConfig) *CLIPrompt {
-	return NewCLIPrompt(cfg)
-}
-
 func (c *CLIPrompt) stdin() prompt.StdinReader {
 	if c.cfg.StdinFunc == nil {
 		return prompt.Stdin()


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/48239 to branch/v16