### PR TITLE
chore: Upgrade buildbox gci to 0.13.5

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -318,7 +318,7 @@ RUN go install "github.com/gogo/protobuf/protoc-gen-gogofast@$GOGO_PROTO_TAG"
 RUN go install github.com/google/addlicense@v1.0.0
 
 # Install GCI.
-RUN go install github.com/daixiang0/gci@v0.12.3
+RUN go install github.com/daixiang0/gci@v0.13.5
 
 # Install gotestsum.
 RUN go install gotest.tools/gotestsum@v1.10.1


### PR DESCRIPTION
The current verson of GCI in the buildbox treats the Go 1.23 `iter` package
as an external package rather than part of the stdlib. This patch updates gci
to a version that groups it correctly with other standard library packages.
