### PR TITLE
Include access request metadata in `app.session.start` events

### DIFF
--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -609,7 +609,17 @@ func (a *Server) CreateAppSessionFromReq(ctx context.Context, req NewAppSessionR
 	log.Debugf("Generated application web session for %v with TTL %v.", req.User, req.SessionTTL)
 	UserLoginCount.Inc()
 
-	userMetadata := req.Identity.GetUserMetadata()
+	// Extract the identity of the user from the certificate, this will include metadata from any actively assumed access requests.
+	certificate, err := tlsca.ParseCertificatePEM(session.GetTLSCert())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	identity, err := tlsca.FromSubject(certificate.Subject, certificate.NotAfter)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	userMetadata := identity.GetUserMetadata()
 	userMetadata.User = session.GetUser()
 	userMetadata.AWSRoleARN = req.AWSRoleARN
 


### PR DESCRIPTION
## Purpose

This PR resolves https://github.com/gravitational/teleport/issues/46622

This PR fixes an issue where access request metadata was not included in `app.session.start` events when an app was launched while assuming an access request.

### Before

```
{
  "app_name": "pgadmin",
  "app_public_addr": "localhost",
  "app_uri": "http://localhost:5050/",
  "cluster_name": "im-a-nodename",
  "code": "T2007I",
  "ei": 0,
  "event": "app.session.start",
  "namespace": "default",
  "public_addr": "localhost",
  "server_id": "59f4906c-d997-4b77-b5cb-0b29346f6469",
  "server_version": "17.0.0-dev",
  "sid": "a501122ed99288081450acd661cbf801e7bd4b3a86244a615898020ffc300056",
  "time": "2024-11-08T09:05:55.206Z",
  "uid": "09b89978-b76c-460d-9e2c-bb2d85b893d4",
  "user": "alice",
  "user_kind": 1
}
```

### After

```
{
  "access_requests": [
    "01930b05-6315-7c48-944d-33eb23b33400"
  ],
  "app_name": "pgadmin",
  "app_public_addr": "localhost",
  "app_uri": "http://localhost:5050/",
  "cluster_name": "im-a-nodename",
  "code": "T2007I",
  "ei": 0,
  "event": "app.session.start",
  "namespace": "default",
  "public_addr": "localhost",
  "server_id": "59f4906c-d997-4b77-b5cb-0b29346f6469",
  "server_version": "17.0.0-dev",
  "sid": "29288f72a81f763bbd2e64c7babab39dcf4318e8e1a86054ae625b9584c5d28e",
  "time": "2024-11-08T09:10:29.787Z",
  "uid": "037644e2-f658-4a86-ad89-65267d23e380",
  "user": "alice",
  "user_kind": 1
}
```

changelog: Fix missing access request metadata in app.session.start audit events