### PR TITLE
[v17] Machine ID: Support overriding Proxy address from ProxyPing when using TLS routing

### DIFF
--- a/lib/tbot/service_application_tunnel.go
+++ b/lib/tbot/service_application_tunnel.go
@@ -133,9 +133,9 @@ func (s *ApplicationTunnelService) buildLocalProxyConfig(ctx context.Context) (l
 	if err != nil {
 		return alpnproxy.LocalProxyConfig{}, trace.Wrap(err, "pinging proxy")
 	}
-	proxyAddr, err := proxyPing.tlsRoutingProxyPublicAddr()
+	proxyAddr, err := proxyPing.proxyWebAddr()
 	if err != nil {
-		return alpnproxy.LocalProxyConfig{}, trace.Wrap(err, "getting proxy address")
+		return alpnproxy.LocalProxyConfig{}, trace.Wrap(err, "determining proxy web addr")
 	}
 
 	s.log.DebugContext(ctx, "Issuing initial certificate for local proxy.")

--- a/lib/tbot/service_application_tunnel.go
+++ b/lib/tbot/service_application_tunnel.go
@@ -133,7 +133,10 @@ func (s *ApplicationTunnelService) buildLocalProxyConfig(ctx context.Context) (l
 	if err != nil {
 		return alpnproxy.LocalProxyConfig{}, trace.Wrap(err, "pinging proxy")
 	}
-	proxyAddr := proxyPing.Proxy.SSH.PublicAddr
+	proxyAddr, err := proxyPing.tlsRoutingProxyPublicAddr()
+	if err != nil {
+		return alpnproxy.LocalProxyConfig{}, trace.Wrap(err, "getting proxy address")
+	}
 
 	s.log.DebugContext(ctx, "Issuing initial certificate for local proxy.")
 	appCert, app, err := s.issueCert(ctx, roles)

--- a/lib/tbot/service_database_tunnel.go
+++ b/lib/tbot/service_database_tunnel.go
@@ -97,9 +97,6 @@ func (s *DatabaseTunnelService) buildLocalProxyConfig(ctx context.Context) (lpCf
 	if err != nil {
 		return alpnproxy.LocalProxyConfig{}, trace.Wrap(err, "determining proxy web address")
 	}
-	if !proxyPing.Proxy.TLSRoutingEnabled {
-		return alpnproxy.LocalProxyConfig{}, trace.BadParameter("proxy does not support TLS routing")
-	}
 
 	// Fetch information about the database and then issue the initial
 	// certificate. We issue the initial certificate to allow us to fail faster.

--- a/lib/tbot/service_database_tunnel.go
+++ b/lib/tbot/service_database_tunnel.go
@@ -93,9 +93,12 @@ func (s *DatabaseTunnelService) buildLocalProxyConfig(ctx context.Context) (lpCf
 	if err != nil {
 		return alpnproxy.LocalProxyConfig{}, trace.Wrap(err, "pinging proxy")
 	}
-	proxyAddr, err := proxyPing.tlsRoutingProxyPublicAddr()
+	proxyAddr, err := proxyPing.proxyWebAddr()
 	if err != nil {
-		return alpnproxy.LocalProxyConfig{}, trace.Wrap(err, "determining tls routing address")
+		return alpnproxy.LocalProxyConfig{}, trace.Wrap(err, "determining proxy web address")
+	}
+	if !proxyPing.Proxy.TLSRoutingEnabled {
+		return alpnproxy.LocalProxyConfig{}, trace.BadParameter("proxy does not support TLS routing")
 	}
 
 	// Fetch information about the database and then issue the initial

--- a/lib/tbot/service_database_tunnel.go
+++ b/lib/tbot/service_database_tunnel.go
@@ -93,7 +93,10 @@ func (s *DatabaseTunnelService) buildLocalProxyConfig(ctx context.Context) (lpCf
 	if err != nil {
 		return alpnproxy.LocalProxyConfig{}, trace.Wrap(err, "pinging proxy")
 	}
-	proxyAddr := proxyPing.Proxy.SSH.PublicAddr
+	proxyAddr, err := proxyPing.tlsRoutingProxyPublicAddr()
+	if err != nil {
+		return alpnproxy.LocalProxyConfig{}, trace.Wrap(err, "determining tls routing address")
+	}
 
 	// Fetch information about the database and then issue the initial
 	// certificate. We issue the initial certificate to allow us to fail faster.

--- a/lib/tbot/service_identity_output.go
+++ b/lib/tbot/service_identity_output.go
@@ -252,13 +252,9 @@ func renderSSHConfig(
 	)
 	defer span.End()
 
-	proxyAddr := proxyPing.Proxy.SSH.PublicAddr
-	if proxyPing.Proxy.TLSRoutingEnabled {
-		var err error
-		proxyAddr, err = proxyPing.tlsRoutingProxyPublicAddr()
-		if err != nil {
-			return trace.Wrap(err, "determining tls routing address")
-		}
+	proxyAddr, err := proxyPing.proxyWebAddr()
+	if err != nil {
+		return trace.Wrap(err, "determining proxy web addr")
 	}
 
 	proxyHost, proxyPort, err := utils.SplitHostPort(proxyAddr)

--- a/lib/tbot/service_identity_output.go
+++ b/lib/tbot/service_identity_output.go
@@ -253,11 +253,16 @@ func renderSSHConfig(
 	)
 	defer span.End()
 
-	proxyHost, proxyPort, err := utils.SplitHostPort(proxyPing.Proxy.SSH.PublicAddr)
+	proxyAddr := proxyPing.Proxy.SSH.PublicAddr
+	if proxyPing.Proxy.TLSRoutingEnabled {
+
+	}
+
+	proxyHost, proxyPort, err := utils.SplitHostPort(proxyAddr)
 	if err != nil {
 		return trace.BadParameter(
 			"proxy %+v has no usable public address: %v",
-			proxyPing.Proxy.SSH.PublicAddr, err,
+			proxyAddr, err,
 		)
 	}
 

--- a/lib/tbot/service_identity_output_test.go
+++ b/lib/tbot/service_identity_output_test.go
@@ -157,12 +157,14 @@ func Test_renderSSHConfig(t *testing.T) {
 			err := renderSSHConfig(
 				context.Background(),
 				utils.NewSlogLoggerForTests(),
-				&webclient.PingResponse{
-					ClusterName: mockClusterName,
-					Proxy: webclient.ProxySettings{
-						TLSRoutingEnabled: tc.TLSRouting,
-						SSH: webclient.SSHProxySettings{
-							PublicAddr: mockProxyAddr,
+				&proxyPingResponse{
+					PingResponse: &webclient.PingResponse{
+						ClusterName: mockClusterName,
+						Proxy: webclient.ProxySettings{
+							TLSRoutingEnabled: tc.TLSRouting,
+							SSH: webclient.SSHProxySettings{
+								PublicAddr: mockProxyAddr,
+							},
 						},
 					},
 				},

--- a/lib/tbot/service_kubernetes_output.go
+++ b/lib/tbot/service_kubernetes_output.go
@@ -32,7 +32,6 @@ import (
 
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authclient"
@@ -418,7 +417,7 @@ func getKubeCluster(ctx context.Context, clt *authclient.Client, name string) (t
 
 // selectKubeConnectionMethod determines the address and SNI that should be
 // put into the kubeconfig file.
-func selectKubeConnectionMethod(proxyPong *webclient.PingResponse) (
+func selectKubeConnectionMethod(proxyPong *proxyPingResponse) (
 	clusterAddr string, sni string, err error,
 ) {
 	// First we check for TLS routing. If this is enabled, we use the Proxy's
@@ -427,8 +426,11 @@ func selectKubeConnectionMethod(proxyPong *webclient.PingResponse) (
 	// Even if KubePublicAddr is specified, we still use the general
 	// PublicAddr when using TLS routing.
 	if proxyPong.Proxy.TLSRoutingEnabled {
-		addr := proxyPong.Proxy.SSH.PublicAddr
-		host, _, err := net.SplitHostPort(proxyPong.Proxy.SSH.PublicAddr)
+		addr, err := proxyPong.tlsRoutingProxyPublicAddr()
+		if err != nil {
+			return "", "", trace.Wrap(err)
+		}
+		host, _, err := net.SplitHostPort(addr)
 		if err != nil {
 			return "", "", trace.Wrap(err, "parsing proxy public_addr")
 		}

--- a/lib/tbot/service_kubernetes_output.go
+++ b/lib/tbot/service_kubernetes_output.go
@@ -426,7 +426,7 @@ func selectKubeConnectionMethod(proxyPong *proxyPingResponse) (
 	// Even if KubePublicAddr is specified, we still use the general
 	// PublicAddr when using TLS routing.
 	if proxyPong.Proxy.TLSRoutingEnabled {
-		addr, err := proxyPong.tlsRoutingProxyPublicAddr()
+		addr, err := proxyPong.proxyWebAddr()
 		if err != nil {
 			return "", "", trace.Wrap(err)
 		}

--- a/lib/tbot/service_kubernetes_output_test.go
+++ b/lib/tbot/service_kubernetes_output_test.go
@@ -279,7 +279,9 @@ func Test_selectKubeConnectionMethod(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			addr, sni, err := selectKubeConnectionMethod(tt.proxyPing)
+			addr, sni, err := selectKubeConnectionMethod(&proxyPingResponse{
+				PingResponse: tt.proxyPing,
+			})
 			require.NoError(t, err)
 			require.Equal(t, tt.wantAddr, addr)
 			require.Equal(t, tt.wantSNI, sni)

--- a/lib/tbot/service_ssh_multiplexer.go
+++ b/lib/tbot/service_ssh_multiplexer.go
@@ -273,23 +273,23 @@ func (s *SSHMultiplexerService) setup(ctx context.Context) (
 	if err != nil {
 		return nil, nil, "", nil, trace.Wrap(err)
 	}
-	proxyAddr := proxyPing.Proxy.SSH.PublicAddr
+	proxyAddr, err := proxyPing.proxyWebAddr()
+	if err != nil {
+		return nil, nil, "", nil, trace.Wrap(err, "determining proxy web addr")
+	}
+	proxyHost, _, err = net.SplitHostPort(proxyAddr)
+	if err != nil {
+		return nil, nil, "", nil, trace.Wrap(err)
+	}
+
 	connUpgradeRequired := false
 	if proxyPing.Proxy.TLSRoutingEnabled {
-		proxyAddr, err = proxyPing.tlsRoutingProxyPublicAddr()
-		if err != nil {
-			return nil, nil, "", nil, trace.Wrap(err, "determining proxy address")
-		}
 		connUpgradeRequired, err = s.alpnUpgradeCache.isUpgradeRequired(
 			ctx, proxyAddr, s.botCfg.Insecure,
 		)
 		if err != nil {
 			return nil, nil, "", nil, trace.Wrap(err, "determining if ALPN upgrade is required")
 		}
-	}
-	proxyHost, _, err = net.SplitHostPort(proxyAddr)
-	if err != nil {
-		return nil, nil, "", nil, trace.Wrap(err)
 	}
 
 	// Create Proxy and Auth clients

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -777,11 +777,11 @@ type proxyPingResponse struct {
 const useProxyAddrEnv = "TBOT_USE_PROXY_ADDR"
 
 // shouldUseProxyAddr returns true if the TBOT_USE_PROXY_ADDR environment
-// variable is set to "1". More generally, this indicates that the user wishes
+// variable is set to "yes". More generally, this indicates that the user wishes
 // for tbot to prefer using the proxy address that has been explicitly provided
 // by the user rather than the one fetched via a discovery process (e.g ping).
 func shouldUseProxyAddr() bool {
-	return os.Getenv(useProxyAddrEnv) == "1"
+	return os.Getenv(useProxyAddrEnv) == "yes"
 }
 
 // proxyWebAddr returns the address to use to connect to the proxy web port.


### PR DESCRIPTION
Backport #48373 to branch/v17

changelog: Machine ID can now be forced to use the explicitly configured proxy address using the `TBOT_USE_PROXY_ADDR` environment variable. This should better support split proxy address operation.
