### PR TITLE
Machine ID: TBOT_USE_PROXY_ADDR use "yes" vs "1" for consistency

### DIFF
--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -777,11 +777,11 @@ type proxyPingResponse struct {
 const useProxyAddrEnv = "TBOT_USE_PROXY_ADDR"
 
 // shouldUseProxyAddr returns true if the TBOT_USE_PROXY_ADDR environment
-// variable is set to "1". More generally, this indicates that the user wishes
+// variable is set to "yes". More generally, this indicates that the user wishes
 // for tbot to prefer using the proxy address that has been explicitly provided
 // by the user rather than the one fetched via a discovery process (e.g ping).
 func shouldUseProxyAddr() bool {
-	return os.Getenv(useProxyAddrEnv) == "1"
+	return os.Getenv(useProxyAddrEnv) == "yes"
 }
 
 // proxyWebAddr returns the address to use to connect to the proxy web port.


### PR DESCRIPTION
Gus rightly pointed out that we tend to use "yes" rather than "1" for truthiness with env var flags.

