### PR TITLE
Convert tctl sso configure oidc to use go-oidc/v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -80,6 +80,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.1.2
 	github.com/charmbracelet/lipgloss v1.0.0
 	github.com/coreos/go-oidc v2.2.1+incompatible // replaced
+	github.com/coreos/go-oidc/v3 v3.11.0
 	github.com/coreos/go-semver v0.3.1
 	github.com/creack/pty v1.1.24
 	github.com/crewjam/saml v0.4.14

--- a/tool/tctl/sso/configure/oidc.go
+++ b/tool/tctl/sso/configure/oidc.go
@@ -19,13 +19,12 @@ package configure
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"net/url"
 	"os"
 	"strings"
 
 	"github.com/alecthomas/kingpin/v2"
-	"github.com/coreos/go-oidc/oidc"
+	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
@@ -289,8 +288,7 @@ func oidcRunFunc(ctx context.Context, cmd *SSOConfigureCommand, spec *types.OIDC
 	}
 
 	// verify .well-known/openid-configuration is reachable
-	err = checkOpenidConfiguration(spec.IssuerURL)
-	if err != nil {
+	if _, err := oidc.NewProvider(ctx, spec.IssuerURL); err != nil {
 		if cmd.Config.Debug {
 			cmd.Logger.WithError(err).Warnf("Failed to load .well-known/openid-configuration for issuer URL %q", spec.IssuerURL)
 		}
@@ -345,10 +343,4 @@ func oidcRunFunc(ctx context.Context, cmd *SSOConfigureCommand, spec *types.OIDC
 	}
 
 	return trace.Wrap(utils.WriteYAML(os.Stdout, connector))
-}
-
-func checkOpenidConfiguration(issuerURL string) error {
-	r := oidc.NewHTTPProviderConfigGetter(http.DefaultClient, issuerURL)
-	_, err := r.Get()
-	return trace.Wrap(err)
 }


### PR DESCRIPTION
Migrates the command to the upstream version of go-oidc in an effort to reduce reliance on our outdated fork.