### PR TITLE
Restore S3 FIPS and custom endpoint capabilities

### DIFF
--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -32,6 +32,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -43,6 +44,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/test"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -604,24 +606,60 @@ func randStringAlpha(n int) string {
 	return string(b)
 }
 
-func TestCustomEndpoint(t *testing.T) {
-	ctx := context.Background()
-	t.Setenv("AWS_ACCESS_KEY", "llama")
-	t.Setenv("AWS_SECRET_KEY", "alpaca")
+func TestEndpoints(t *testing.T) {
+	tests := []struct {
+		name string
+		fips bool
+	}{
+		{
+			name: "fips",
+			fips: true,
+		},
+		{
+			name: "without fips",
+		},
+	}
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusTeapot)
-	})
-	srv := httptest.NewServer(mux)
-	defer srv.Close()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 
-	b, err := New(ctx, Config{
-		Tablename:    "teleport-test",
-		UIDGenerator: utils.NewFakeUID(),
-		Endpoint:     srv.URL,
-	})
-	assert.Error(t, err)
-	assert.Nil(t, b)
-	require.ErrorContains(t, err, fmt.Sprintf("StatusCode: %d", http.StatusTeapot))
+			fips := types.ClusterAuditConfigSpecV2_FIPS_DISABLED
+			if tt.fips {
+				fips = types.ClusterAuditConfigSpecV2_FIPS_ENABLED
+				modules.SetTestModules(t, &modules.TestModules{
+					FIPS: true,
+				})
+			}
+
+			mux := http.NewServeMux()
+			mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusTeapot)
+			}))
+
+			server := httptest.NewServer(mux)
+			t.Cleanup(server.Close)
+
+			b, err := New(context.Background(), Config{
+				Region:          "us-west-1",
+				Tablename:       "teleport-test",
+				UIDGenerator:    utils.NewFakeUID(),
+				Endpoint:        server.URL,
+				UseFIPSEndpoint: fips,
+				CredentialsProvider: aws.CredentialsProviderFunc(func(ctx context.Context) (aws.Credentials, error) {
+					return aws.Credentials{}, nil
+				}),
+			})
+			// FIPS mode should fail because it is a violation to enable FIPS
+			// while also setting a custom endpoint.
+			if tt.fips {
+				assert.Error(t, err)
+				require.ErrorContains(t, err, "FIPS")
+				return
+			}
+
+			assert.Error(t, err)
+			assert.Nil(t, b)
+			require.ErrorContains(t, err, fmt.Sprintf("StatusCode: %d", http.StatusTeapot))
+		})
+	}
 }

--- a/lib/events/s3sessions/s3handler_config_test.go
+++ b/lib/events/s3sessions/s3handler_config_test.go
@@ -20,13 +20,19 @@ package s3sessions
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
+	"sync"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -122,14 +128,90 @@ func TestConfig_SetFromURL(t *testing.T) {
 }
 
 func TestUploadMetadata(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	}))
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
 	handler, err := NewHandler(context.Background(), Config{
-		Region: "us-west-1",
-		Path:   "/test/",
-		Bucket: "teleport-unit-tests",
+		Region:   "us-west-1",
+		Path:     "/test/",
+		Bucket:   "teleport-unit-tests",
+		Endpoint: server.URL,
+		CredentialsProvider: aws.CredentialsProviderFunc(func(ctx context.Context) (aws.Credentials, error) {
+			return aws.Credentials{}, nil
+		}),
 	})
 	require.NoError(t, err)
 	defer handler.Close()
 
 	meta := handler.GetUploadMetadata("test-session-id")
 	require.Equal(t, "s3://teleport-unit-tests/test/test-session-id", meta.URL)
+}
+
+func TestEndpoints(t *testing.T) {
+	tests := []struct {
+		name string
+		fips bool
+	}{
+		{
+			name: "fips",
+			fips: true,
+		},
+		{
+			name: "without fips",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fips := types.ClusterAuditConfigSpecV2_FIPS_DISABLED
+			if tt.fips {
+				fips = types.ClusterAuditConfigSpecV2_FIPS_ENABLED
+				modules.SetTestModules(t, &modules.TestModules{
+					FIPS: true,
+				})
+			}
+
+			var request *http.Request
+			var once sync.Once
+			mux := http.NewServeMux()
+			mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				once.Do(func() { request = r.Clone(context.Background()) })
+				w.WriteHeader(http.StatusTeapot)
+			}))
+
+			server := httptest.NewServer(mux)
+			t.Cleanup(server.Close)
+
+			handler, err := NewHandler(context.Background(), Config{
+				Region:          "us-west-1",
+				Path:            "/test/",
+				Bucket:          "teleport-unit-tests",
+				Endpoint:        server.URL,
+				UseFIPSEndpoint: fips,
+				Insecure:        true,
+				CredentialsProvider: aws.CredentialsProviderFunc(func(ctx context.Context) (aws.Credentials, error) {
+					return aws.Credentials{}, nil
+				}),
+			})
+			// FIPS mode should fail because it is a violation to enable FIPS
+			// while also setting a custom endpoint.
+			if tt.fips {
+				assert.Error(t, err)
+				require.ErrorContains(t, err, "FIPS")
+				return
+			}
+
+			require.NoError(t, err)
+			defer handler.Close()
+			require.NotNil(t, request.URL)
+			require.Equal(t, "/teleport-unit-tests", request.URL.Path)
+		})
+	}
 }

--- a/lib/events/s3sessions/s3handler_test.go
+++ b/lib/events/s3sessions/s3handler_test.go
@@ -25,19 +25,12 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/lib/events/test"
-	"github.com/gravitational/teleport/lib/utils"
 )
-
-func TestMain(m *testing.M) {
-	utils.InitLoggerForTests()
-	os.Exit(m.Run())
-}
 
 // TestStreams tests various streaming upload scenarios
 func TestStreams(t *testing.T) {

--- a/lib/modules/test.go
+++ b/lib/modules/test.go
@@ -41,6 +41,8 @@ type TestModules struct {
 	TestBuildType string
 	// TestFeatures is returned from the Features function.
 	TestFeatures Features
+	// FIPS allows tests to toggle fips behavior.
+	FIPS bool
 
 	defaultModules
 
@@ -80,7 +82,7 @@ func (m *TestModules) PrintVersion() {
 
 // IsBoringBinary checks if the binary was compiled with BoringCrypto.
 func (m *TestModules) IsBoringBinary() bool {
-	return m.defaultModules.IsBoringBinary()
+	return m.FIPS
 }
 
 // Features returns supported features.


### PR DESCRIPTION
When migrating the S3 events handler to use aws-sdk-go-v2 applying the FIPS settings and custom endpoint were inadvertently dropped. This restores the functionality, while also adding tests to ensure that they are always respected going forward.

A similar test was added to the dynamodb events handler as well to prevent any regressions with FIPS settings there.