### PR TITLE
[v17] Add owner property to TrustedDevices type and Narrow EnrollStatus (#48408)

### DIFF
--- a/web/packages/teleport/src/DeviceTrust/types.ts
+++ b/web/packages/teleport/src/DeviceTrust/types.ts
@@ -22,7 +22,8 @@ export type TrustedDevice = {
   id: string;
   assetTag: string;
   osType: TrustedDeviceOSType;
-  enrollStatus: string;
+  enrollStatus: 'Enrolled' | 'Not Enrolled';
+  owner?: string;
 };
 
 export type TrustedDeviceOSType = 'Windows' | 'Linux' | 'macOS';


### PR DESCRIPTION
This adds the owner property to our TrustedDevices type to support adding owner to our device trust table in `e`