### PR TITLE
Added topologySpreadConstraints as a configuration option and Use .Chart.AppVersion instead of .Chart.Version to determine the Agent version.

### DIFF
--- a/examples/chart/teleport-kube-agent/.lint/topologySpreadConstraints.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/topologySpreadConstraints.yaml
@@ -1,0 +1,11 @@
+authToken: auth-token
+proxyAddr: proxy.example.com:3080
+roles: kube
+kubeClusterName: test-kube-cluster
+topologySpreadConstraints:
+  - labelSelector:
+      matchLabels:
+        app-label: app-name
+    maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway

--- a/examples/chart/teleport-kube-agent/templates/_helpers.tpl
+++ b/examples/chart/teleport-kube-agent/templates/_helpers.tpl
@@ -33,7 +33,7 @@ if serviceAccount is not defined or serviceAccount.name is empty, use .Release.N
 {{- if .Values.teleportVersionOverride -}}
   {{- .Values.teleportVersionOverride -}}
 {{- else -}}
-  {{- .Chart.Version -}}
+  {{- .Chart.AppVersion -}}
 {{- end -}}
 {{- end -}}
 

--- a/examples/chart/teleport-kube-agent/templates/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/deployment.yaml
@@ -49,6 +49,10 @@ spec:
       {{- if .Values.hostAliases }}
       hostAliases: {{- toYaml .Values.hostAliases | nindent 8 }}
       {{- end }}
+      {{- if and .Values.topologySpreadConstraints (gt (int $replicaCount) 1) }}
+      topologySpreadConstraints:
+        {{- toYaml .Values.topologySpreadConstraints | nindent 8 }}
+      {{- end }}
       {{- if or .Values.affinity (gt (int $replicaCount) 1) }}
       affinity:
         {{- if .Values.affinity }}

--- a/examples/chart/teleport-kube-agent/templates/statefulset.yaml
+++ b/examples/chart/teleport-kube-agent/templates/statefulset.yaml
@@ -49,6 +49,10 @@ spec:
       {{- if .Values.podSecurityContext }}
       securityContext: {{- toYaml .Values.podSecurityContext | nindent 8}}
       {{- end }}
+      {{- if and .Values.topologySpreadConstraints (gt (int $replicaCount) 1) }}
+      topologySpreadConstraints:
+        {{- toYaml .Values.topologySpreadConstraints | nindent 8 }}
+      {{- end }}
       {{- if or .Values.affinity (gt (int $replicaCount) 1) }}
       affinity:
         {{- if .Values.affinity }}

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -509,6 +509,11 @@
                 }
             }
         },
+        "topologySpreadConstraints": {
+            "$id": "#/properties/topologySpreadConstraints",
+            "type": "array",
+            "default": []
+        },
         "affinity": {
             "$id": "#/properties/affinity",
             "type": "object",

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -1066,6 +1066,9 @@ log:
 # for more details.
 affinity: {}
 
+# topologySpreadyConstraints -- set the topologySpreadConstraints for any pods created by the chart when provider and the replicaCount is greater than one.
+topologySpreadConstraints: []
+
 # dnsConfig(object) -- contains custom Pod DNS Configuration for the agent pods.
 # This value is useful if you need to reduce the DNS load: set "ndots" to 0 and
 # only use FQDNs to refer to applications and databases.


### PR DESCRIPTION
* Added this topologySpreadConstraints as a configuration point to my company's local copy of this chart and thought it might be a useful change to incorporate into the main repo.
* Updated the `_helpers.tpl` to use `.Chart.AppVersion` instead of `.Chart.Version` since the `NOTES.txt` file mentions this should be the case.