### PR TITLE
Remove deprecated slack plugin credentials

### DIFF
--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -3670,10 +3670,6 @@ func TestAuthHostedPlugins(t *testing.T) {
 			applyErr: require.NoError,
 			assert: func(t *testing.T, p servicecfg.HostedPluginsConfig) {
 				require.True(t, p.Enabled)
-				require.NotNil(t, p.OAuthProviders.Slack)
-				require.Equal(t, "foo", p.OAuthProviders.Slack.ID)
-				require.Equal(t, "bar", p.OAuthProviders.Slack.Secret)
-
 				require.NotNil(t, p.OAuthProviders.SlackCredentials)
 				require.Equal(t, "foo", p.OAuthProviders.SlackCredentials.ClientID)
 				require.Equal(t, "bar", p.OAuthProviders.SlackCredentials.ClientSecret)

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -33,7 +33,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/coreos/go-oidc/oauth2"
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/acme"
@@ -1320,10 +1319,6 @@ func (p *PluginOAuthProviders) Parse() (servicecfg.PluginOAuthProviders, error) 
 		slack, err := p.Slack.Parse()
 		if err != nil {
 			return out, trace.Wrap(err)
-		}
-		out.Slack = &oauth2.ClientCredentials{
-			ID:     slack.ClientID,
-			Secret: slack.ClientSecret,
 		}
 		out.SlackCredentials = slack
 	}

--- a/lib/service/servicecfg/auth.go
+++ b/lib/service/servicecfg/auth.go
@@ -21,7 +21,6 @@ package servicecfg
 import (
 	"slices"
 
-	"github.com/coreos/go-oidc/oauth2"
 	"github.com/dustin/go-humanize"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -178,10 +177,6 @@ type HostedPluginsConfig struct {
 // PluginOAuthProviders holds application credentials for each
 // 3rd party API provider
 type PluginOAuthProviders struct {
-	// TODO(tross) delete once teleport.e has been converted.
-	// Deprecated: use SlackCredentials instead.
-	Slack *oauth2.ClientCredentials
-
 	SlackCredentials *OAuthClientCredentials
 }
 


### PR DESCRIPTION
Follow up to https://github.com/gravitational/teleport/pull/48596 to remove the deprecated field now that
https://github.com/gravitational/teleport.e/pull/5373 has removed the last usages.