### PR TITLE
EKS Auto Enroll: wait a little more for agent to be installed

### DIFF
--- a/lib/integrations/awsoidc/eks_enroll_clusters.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters.go
@@ -565,12 +565,13 @@ func checkAgentAlreadyInstalled(ctx context.Context, actionConfig *action.Config
 	var err error
 	// We setup a little backoff loop because sometimes access entry auth needs a bit more time to propagate and take
 	// effect, so we could get errors when trying to access cluster right after giving us permissions to do so.
+	// From real scenarios, we've seen this taking as long as 20 seconds.
 	for attempt := 1; attempt <= 3; attempt++ {
 		listCmd := action.NewList(actionConfig)
 		releases, err = listCmd.Run()
 		if err != nil {
 			select {
-			case <-time.After(time.Duration(attempt) * time.Second):
+			case <-time.After(time.Duration(attempt*5) * time.Second):
 			case <-ctx.Done():
 				return false, trace.NewAggregate(err, ctx.Err())
 			}


### PR DESCRIPTION
After doing this flow a couple of times, it seems that 6 seconds is not enough.

It should not take longer than 20 seconds.