### PR TITLE
Azure join method - use subscription ID from attested data

### DIFF
--- a/lib/auth/join_azure.go
+++ b/lib/auth/join_azure.go
@@ -83,11 +83,13 @@ type accessTokenClaims struct {
 
 type azureVerifyTokenFunc func(ctx context.Context, rawIDToken string) (*accessTokenClaims, error)
 
+type vmClientGetter func(subscriptionID string, token *azure.StaticCredential) (azure.VirtualMachinesClient, error)
+
 type azureRegisterConfig struct {
 	clock                  clockwork.Clock
 	certificateAuthorities []*x509.Certificate
 	verify                 azureVerifyTokenFunc
-	vmClient               azure.VirtualMachinesClient
+	getVMClient            vmClientGetter
 }
 
 func azureVerifyFuncFromOIDCVerifier(cfg *oidc.Config) azureVerifyTokenFunc {
@@ -140,6 +142,12 @@ func (cfg *azureRegisterConfig) CheckAndSetDefaults(ctx context.Context) error {
 		}
 		cfg.certificateAuthorities = certs
 	}
+	if cfg.getVMClient == nil {
+		cfg.getVMClient = func(subscriptionID string, token *azure.StaticCredential) (azure.VirtualMachinesClient, error) {
+			client, err := azure.NewVirtualMachinesClient(subscriptionID, token, nil)
+			return client, trace.Wrap(err)
+		}
+	}
 	return nil
 }
 
@@ -148,42 +156,42 @@ type azureRegisterOption func(cfg *azureRegisterConfig)
 // parseAndVeryAttestedData verifies that an attested data document was signed
 // by Azure. If verification is successful, it returns the ID of the VM that
 // produced the document.
-func parseAndVerifyAttestedData(ctx context.Context, adBytes []byte, challenge string, certs []*x509.Certificate) (string, error) {
+func parseAndVerifyAttestedData(ctx context.Context, adBytes []byte, challenge string, certs []*x509.Certificate) (subscriptionID, vmID string, err error) {
 	var signedAD signedAttestedData
 	if err := utils.FastUnmarshal(adBytes, &signedAD); err != nil {
-		return "", trace.Wrap(err)
+		return "", "", trace.Wrap(err)
 	}
 	if signedAD.Encoding != "pkcs7" {
-		return "", trace.AccessDenied("unsupported signature type: %v", signedAD.Encoding)
+		return "", "", trace.AccessDenied("unsupported signature type: %v", signedAD.Encoding)
 	}
 
 	sigPEM := "-----BEGIN PKCS7-----\n" + signedAD.Signature + "\n-----END PKCS7-----"
 	sigBER, _ := pem.Decode([]byte(sigPEM))
 	if sigBER == nil {
-		return "", trace.AccessDenied("unable to decode attested data document")
+		return "", "", trace.AccessDenied("unable to decode attested data document")
 	}
 
 	p7, err := pkcs7.Parse(sigBER.Bytes)
 	if err != nil {
-		return "", trace.Wrap(err)
+		return "", "", trace.Wrap(err)
 	}
 	var ad attestedData
 	if err := utils.FastUnmarshal(p7.Content, &ad); err != nil {
-		return "", trace.Wrap(err)
+		return "", "", trace.Wrap(err)
 	}
 	if ad.Nonce != challenge {
-		return "", trace.AccessDenied("challenge is missing or does not match")
+		return "", "", trace.AccessDenied("challenge is missing or does not match")
 	}
 
 	if len(p7.Certificates) == 0 {
-		return "", trace.AccessDenied("no certificates for signature")
+		return "", "", trace.AccessDenied("no certificates for signature")
 	}
 	fixAzureSigningAlgorithm(p7)
 
 	// Azure only sends the leaf cert, so we have to fetch the intermediate.
 	intermediate, err := getAzureIssuerCert(ctx, p7.Certificates[0])
 	if err != nil {
-		return "", trace.Wrap(err)
+		return "", "", trace.Wrap(err)
 	}
 	if intermediate != nil {
 		p7.Certificates = append(p7.Certificates, intermediate)
@@ -195,15 +203,15 @@ func parseAndVerifyAttestedData(ctx context.Context, adBytes []byte, challenge s
 	}
 
 	if err := p7.VerifyWithChain(pool); err != nil {
-		return "", trace.Wrap(err)
+		return "", "", trace.Wrap(err)
 	}
 
-	return ad.ID, nil
+	return ad.SubscriptionID, ad.ID, nil
 }
 
 // verifyVMIdentity verifies that the provided access token came from the
 // correct Azure VM.
-func verifyVMIdentity(ctx context.Context, cfg *azureRegisterConfig, accessToken, vmID string, requestStart time.Time) (*azure.VirtualMachine, error) {
+func verifyVMIdentity(ctx context.Context, cfg *azureRegisterConfig, accessToken, subscriptionID, vmID string, requestStart time.Time) (*azure.VirtualMachine, error) {
 	tokenClaims, err := cfg.verify(ctx, accessToken)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -231,22 +239,13 @@ func verifyVMIdentity(ctx context.Context, cfg *azureRegisterConfig, accessToken
 		return nil, trace.Wrap(err)
 	}
 
-	rsID, err := arm.ParseResourceID(tokenClaims.ResourceID)
+	tokenCredential := azure.NewStaticCredential(azcore.AccessToken{
+		Token:     accessToken,
+		ExpiresOn: tokenClaims.Expiry.Time(),
+	})
+	vmClient, err := cfg.getVMClient(subscriptionID, tokenCredential)
 	if err != nil {
 		return nil, trace.Wrap(err)
-	}
-
-	vmClient := cfg.vmClient
-	if vmClient == nil {
-		tokenCredential := azure.NewStaticCredential(azcore.AccessToken{
-			Token:     accessToken,
-			ExpiresOn: tokenClaims.Expiry.Time(),
-		})
-		var err error
-		vmClient, err = azure.NewVirtualMachinesClient(rsID.SubscriptionID, tokenCredential, nil)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
 	}
 
 	resourceID, err := arm.ParseResourceID(tokenClaims.ResourceID)
@@ -324,12 +323,12 @@ func (a *Server) checkAzureRequest(ctx context.Context, challenge string, req *p
 		return trace.AccessDenied("this token does not support the Azure join method")
 	}
 
-	vmID, err := parseAndVerifyAttestedData(ctx, req.AttestedData, challenge, cfg.certificateAuthorities)
+	subID, vmID, err := parseAndVerifyAttestedData(ctx, req.AttestedData, challenge, cfg.certificateAuthorities)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	vm, err := verifyVMIdentity(ctx, cfg, req.AccessToken, vmID, requestStart)
+	vm, err := verifyVMIdentity(ctx, cfg, req.AccessToken, subID, vmID, requestStart)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
This change updates the Azure join method to lookup VMs based on the subscription ID provided in the VM's attested data, rather than the subscription ID derived from its access token. This allows Azure VMs to join a cluster even if their managed identity is from a different subscription than the VM itself.

Changelog: Allow Azure VMs to join from a different subscription than their managed identity