### PR TITLE
[web] Add `ACCESS_LIST_PREFERENCES` localStorage key

### DIFF
--- a/web/packages/teleport/src/services/storageService/storageService.ts
+++ b/web/packages/teleport/src/services/storageService/storageService.ts
@@ -38,6 +38,7 @@ import type { RecommendFeature } from 'teleport/types';
 const KEEP_LOCALSTORAGE_KEYS_ON_LOGOUT = [
   KeysEnum.THEME,
   KeysEnum.USER_PREFERENCES,
+  KeysEnum.ACCESS_LIST_PREFERENCES,
   KeysEnum.RECOMMEND_FEATURE,
   KeysEnum.LICENSE_ACKNOWLEDGED,
   KeysEnum.USERS_NOT_EQUAL_TO_MAU_ACKNOWLEDGED,

--- a/web/packages/teleport/src/services/storageService/types.ts
+++ b/web/packages/teleport/src/services/storageService/types.ts
@@ -30,6 +30,7 @@ export const KeysEnum = {
   ACCESS_GRAPH_QUERY: 'grv_teleport_access_graph_query',
   ACCESS_GRAPH_ENABLED: 'grv_teleport_access_graph_enabled',
   ACCESS_GRAPH_SQL_ENABLED: 'grv_teleport_access_graph_sql_enabled',
+  ACCESS_LIST_PREFERENCES: 'grv_teleport_access_list_preferences',
   EXTERNAL_AUDIT_STORAGE_CTA_DISABLED:
     'grv_teleport_external_audit_storage_disabled',
   LICENSE_ACKNOWLEDGED: 'grv_teleport_license_acknowledged',


### PR DESCRIPTION
Related to [#5075](https://github.com/gravitational/teleport.e/pull/5075). Add localStorage key for Access List-related view options, persist on logout.