### PR TITLE
[web] update device type for enrolled/not enrolled

### DIFF
--- a/web/packages/teleport/src/DeviceTrust/types.ts
+++ b/web/packages/teleport/src/DeviceTrust/types.ts
@@ -22,7 +22,7 @@ export type TrustedDevice = {
   id: string;
   assetTag: string;
   osType: TrustedDeviceOSType;
-  enrollStatus: 'Enrolled' | 'Not Enrolled';
+  enrollStatus: 'enrolled' | 'not enrolled';
   owner: string;
 };
 


### PR DESCRIPTION
The device status is lower case for enrolled and not enrolled.  This impacts https://github.com/gravitational/teleport.e/pull/5405 so it uses the right strings.