### PR TITLE
Allow querying of Membership-only Access List grants

### DIFF
--- a/lib/accesslists/hierarchy_test.go
+++ b/lib/accesslists/hierarchy_test.go
@@ -593,6 +593,16 @@ func TestGetInheritedGrants(t *testing.T) {
 	grants, err := GetInheritedGrants(ctx, acl2, accessListAndMembersGetter)
 	require.NoError(t, err)
 	require.Equal(t, expectedGrants, grants)
+
+	expectedMemberGrants := &accesslist.Grants{
+		Traits: map[string][]string{
+			"1-member-trait": {"1-member-value"},
+		},
+		Roles: []string{"1-member-role"},
+	}
+	memberGrants, err := GetInheritedMemberGrants(ctx, acl2, accessListAndMembersGetter)
+	require.NoError(t, err)
+	require.Equal(t, expectedMemberGrants, memberGrants)
 }
 
 func newAccessList(t *testing.T, name string, clock clockwork.Clock) *accesslist.AccessList {


### PR DESCRIPTION
The exitsting Access List grant query combines the grants from
both the owner and and member-of Access Lists hierarchies. At present
the AWS Identity Center Integration does not consider owner grants
when provisoning account assignments into AWS, and so it needs a way
to query grants just from the Access List membership hierarchy.

This patch adds a `GetInheritedMemberGrants()` function to the
accesslist package to allow such a query.
