### PR TITLE
[v17] chore: Upgrade buildbox gci to 0.13.5

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -318,7 +318,7 @@ RUN go install "github.com/gogo/protobuf/protoc-gen-gogofast@$GOGO_PROTO_TAG"
 RUN go install github.com/google/addlicense@v1.0.0
 
 # Install GCI.
-RUN go install github.com/daixiang0/gci@v0.12.3
+RUN go install github.com/daixiang0/gci@v0.13.5
 
 # Install gotestsum.
 RUN go install gotest.tools/gotestsum@v1.10.1


### PR DESCRIPTION
Backport #48657 to branch/v17