### PR TITLE
[sshkeys] reset expiration timer when it was triggered

### DIFF
--- a/lib/secretsscanner/authorizedkeys/authorized_keys.go
+++ b/lib/secretsscanner/authorizedkeys/authorized_keys.go
@@ -229,13 +229,13 @@ func (w *Watcher) start(ctx context.Context) error {
 			expirationTimerInterval = maxInitialDelay
 		}
 
-		// reset the mandatory report flag.
-		requiresReportToExtendTTL = false
-
 		// If the keys were reported, reset the expiration timer.
-		if keysReported {
+		if keysReported || requiresReportToExtendTTL {
 			resetTimer(expirationTimer, expirationTimerInterval)
 		}
+
+		// reset the mandatory report flag.
+		requiresReportToExtendTTL = false
 
 		resetTimer(monitorTimer, monitorTimerInterval)
 


### PR DESCRIPTION
This PR resets the expiration timer when it was triggered to ensure it will always fire after a certain amount of time.