### PR TITLE
RDS Discover flows: mention VPC instead of region

### DIFF
--- a/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/AutoDiscoverToggle.tsx
+++ b/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/AutoDiscoverToggle.tsx
@@ -38,12 +38,12 @@ export function AutoDiscoverToggle({
         disabled={disabled}
       >
         <Box ml={2} mr={1}>
-          Auto-enroll all databases for the selected region
+          Auto-enroll all databases for the selected VPC
         </Box>
         <ToolTipInfo>
           Auto-enroll will automatically identify all RDS databases (e.g.
-          PostgreSQL, MySQL, Aurora) from the selected region and register them
-          as database resources in your infrastructure.
+          PostgreSQL, MySQL, Aurora) from the selected VPC and register them as
+          database resources in your infrastructure.
         </ToolTipInfo>
       </Toggle>
     </Box>

--- a/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/AutoEnrollment.tsx
+++ b/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/AutoEnrollment.tsx
@@ -124,7 +124,7 @@ export function AutoEnrollment({
         }
       );
 
-      // Abort if there were no rds dbs for the selected region.
+      // Abort if there were no rds dbs for the selected region/vpc.
       if (fetchedDbs.length <= 0) {
         onFetchAttempt({ status: 'success' });
         setTableData({ ...data, fetchStatus: 'disabled' });

--- a/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/EnrollRdsDatabase.test.tsx
+++ b/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/EnrollRdsDatabase.test.tsx
@@ -88,7 +88,7 @@ describe('test EnrollRdsDatabase.tsx', () => {
     fireEvent.keyDown(selectEl, { key: 'ArrowDown' });
     fireEvent.keyDown(selectEl, { key: 'Enter' });
 
-    await screen.findByText(/selected region/i);
+    await screen.findByText(/selected VPC/i);
   }
 
   test('without rds database result, does not attempt to fetch db servers', async () => {

--- a/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/SingleEnrollment.tsx
+++ b/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/SingleEnrollment.tsx
@@ -121,7 +121,7 @@ export function SingleEnrollment({
           }
         );
 
-      // Abort early if there were no rds dbs for the selected region.
+      // Abort early if there were no rds dbs for the selected region/vpc.
       if (fetchedDbs.length <= 0) {
         onFetchAttempt({ status: 'success' });
         setTableData({ ...data, fetchStatus: 'disabled' });


### PR DESCRIPTION
RDS flows are now done using a single VPC.