### PR TITLE
[Web] Fix availability filter on unified resources not updating results immediately

### DIFF
--- a/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
@@ -132,15 +132,18 @@ export function ClusterResources({
   const canCreate = teleCtx.storeUser.getTokenAccess().create;
   const [loadClusterError, setLoadClusterError] = useState('');
 
-  const { params, setParams, replaceHistory, pathname } = useUrlFiltering({
-    sort: {
-      fieldName: 'name',
-      dir: 'ASC',
+  const { params, setParams, replaceHistory, pathname } = useUrlFiltering(
+    {
+      sort: {
+        fieldName: 'name',
+        dir: 'ASC',
+      },
+      pinnedOnly:
+        preferences?.unifiedResourcePreferences?.defaultTab ===
+        DefaultTab.PINNED,
     },
-    includedResourceMode: availabilityFilter?.mode,
-    pinnedOnly:
-      preferences?.unifiedResourcePreferences?.defaultTab === DefaultTab.PINNED,
-  });
+    availabilityFilter?.mode
+  );
 
   const getCurrentClusterPinnedResources = useCallback(
     () => getClusterPinnedResources(clusterId),

--- a/web/packages/teleport/src/components/hooks/useUrlFiltering/useUrlFiltering.ts
+++ b/web/packages/teleport/src/components/hooks/useUrlFiltering/useUrlFiltering.ts
@@ -21,6 +21,7 @@ import { useLocation } from 'react-router';
 import { SortType } from 'design/DataTable/types';
 
 import { makeAdvancedSearchQueryForLabel } from 'shared/utils/advancedSearchLabelQuery';
+import { IncludedResourceMode } from 'shared/components/UnifiedResources';
 
 import history from 'teleport/services/history';
 import { ResourceFilter, ResourceLabel } from 'teleport/services/agents';
@@ -38,8 +39,11 @@ export interface UrlFilteringState {
   search: string;
 }
 
+type URLResourceFilter = Omit<ResourceFilter, 'includedResourceMode'>;
+
 export function useUrlFiltering(
-  initialParams: Partial<ResourceFilter>
+  initialParams: URLResourceFilter,
+  includedResourceMode?: IncludedResourceMode
 ): UrlFilteringState {
   const { search, pathname } = useLocation();
 
@@ -66,14 +70,15 @@ export function useUrlFiltering(
     return {
       ...initialParamsState,
       ...urlParams,
+      includedResourceMode,
       pinnedOnly:
         urlParams.pinnedOnly !== undefined
           ? urlParams.pinnedOnly
           : initialParamsState.pinnedOnly,
     };
-  }, [search]);
+  }, [search, includedResourceMode]);
 
-  function setParams(newParams: ResourceFilter) {
+  function setParams(newParams: URLResourceFilter) {
     replaceHistory(
       encodeUrlQueryParams({
         pathname,


### PR DESCRIPTION
## Purpose

This PR resolves https://github.com/gravitational/teleport/issues/48469

Fixes a bug where changing the "Show requestable resources" filter on the unified resources page would not update results immediately. This was because recent changes to the `useUrlFiltering` logic relied entirely on the URL as the source of truth,  but this particular filter is not stored in the URL query params.