### PR TITLE
Discover RDS Flow: fix mfa required check

### DIFF
--- a/web/packages/teleport/src/Discover/SelectResource/databases.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/databases.tsx
@@ -462,8 +462,10 @@ export const DATABASES: ResourceSpec[] = [
 export function getDatabaseProtocol(engine: DatabaseEngine): DbProtocol {
   switch (engine) {
     case DatabaseEngine.Postgres:
+    case DatabaseEngine.AuroraPostgres:
       return 'postgres';
     case DatabaseEngine.MySql:
+    case DatabaseEngine.AuroraMysql:
       return 'mysql';
   }
 


### PR DESCRIPTION
Aurora based RDS instances (mysql or postgres) were not being correctly parsed and would cause the isMFARequired check to fail because it was lacking the protocol.

This PR fixes it.

Demo:
![image](https://github.com/user-attachments/assets/ac4d32fd-f5c9-45c9-95d7-ee5d85592756)

Fixes: https://github.com/gravitational/teleport/issues/48803