### PR TITLE
AWSOIDC integration: Align CreateAWSConfigForIntegration

### DIFF
--- a/lib/integrations/awsoidc/credprovider/credentialscache_test.go
+++ b/lib/integrations/awsoidc/credprovider/credentialscache_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -40,6 +41,7 @@ type fakeSTSClient struct {
 	clock clockwork.Clock
 	err   error
 	sync.Mutex
+	called int32
 }
 
 func (f *fakeSTSClient) setError(err error) {
@@ -55,6 +57,7 @@ func (f *fakeSTSClient) getError() error {
 }
 
 func (f *fakeSTSClient) AssumeRoleWithWebIdentity(ctx context.Context, params *sts.AssumeRoleWithWebIdentityInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleWithWebIdentityOutput, error) {
+	atomic.AddInt32(&f.called, 1)
 	if err := f.getError(); err != nil {
 		return nil, err
 	}

--- a/lib/integrations/awsoidc/credprovider/integration_config_provider.go
+++ b/lib/integrations/awsoidc/credprovider/integration_config_provider.go
@@ -33,10 +33,33 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 )
 
+// Options represents additional options for configuring the AWS credentials provider.
+type Options struct {
+	// WaitForFirstInit indicates whether to wait for the initial credential
+	// generation before returning from CreateAWSConfigForIntegration.
+	WaitForFirstInit bool
+}
+
+// Option is a function that modifies the Options struct for the AWS configuration.
+type Option func(*Options)
+
+// WithWaitForFirstInit configures the provider to wait until the first set of
+// credentials is generated before proceeding. This is useful in cases where
+// immediate credential availability is necessary.
+func WithWaitForFirstInit(wait bool) Option {
+	return func(o *Options) {
+		o.WaitForFirstInit = wait
+	}
+}
+
 // CreateAWSConfigForIntegration returns a new AWS credentials provider that
 // uses the AWS OIDC integration to generate temporary credentials.
 // The provider will periodically refresh the credentials before they expire.
-func CreateAWSConfigForIntegration(ctx context.Context, config Config) (*aws.Config, error) {
+func CreateAWSConfigForIntegration(ctx context.Context, config Config, option ...Option) (*aws.Config, error) {
+	options := Options{}
+	for _, opt := range option {
+		opt(&options)
+	}
 	if err := config.checkAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -52,7 +75,10 @@ func CreateAWSConfigForIntegration(ctx context.Context, config Config) (*aws.Con
 		return nil, trace.Wrap(err)
 	}
 	go credCache.Run(ctx)
-	credCache.WaitForFirstCredsOrErr(ctx)
+
+	if options.WaitForFirstInit {
+		credCache.WaitForFirstCredsOrErr(ctx)
+	}
 
 	awsCfg, err := newAWSConfig(ctx, config.Region, awsConfig.WithCredentialsProvider(credCache))
 	if err != nil {

--- a/lib/integrations/awsoidc/credprovider/integration_config_provider_test.go
+++ b/lib/integrations/awsoidc/credprovider/integration_config_provider_test.go
@@ -1,0 +1,187 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package credprovider
+
+import (
+	"context"
+	"crypto"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/integrations/awsoidc"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local"
+)
+
+const (
+	integrationName = "test-integration1"
+	awsRegion       = " eu-central-1"
+	testUser        = "test-user"
+)
+
+func TestCreateAWSConfigForIntegration(t *testing.T) {
+	deps := newDepsMock(t)
+	ctx := context.Background()
+
+	t.Run("should auto init credentials during retrieve call", func(t *testing.T) {
+		stsClient := &fakeSTSClient{clock: clockwork.NewFakeClock()}
+		config, err := CreateAWSConfigForIntegration(ctx, Config{
+			Region:                awsRegion,
+			IntegrationName:       integrationName,
+			IntegrationGetter:     deps,
+			AWSOIDCTokenGenerator: deps,
+			STSClient:             stsClient,
+		})
+		require.NoError(t, err)
+		require.Equal(t, int32(0), atomic.LoadInt32(&stsClient.called))
+
+		creds, err := config.Credentials.Retrieve(ctx)
+		require.NoError(t, err)
+		require.NotEmpty(t, creds.SecretAccessKey)
+	})
+
+	t.Run("should init creds before retrieve call", func(t *testing.T) {
+		stsClient := &fakeSTSClient{clock: clockwork.NewFakeClock()}
+		config, err := CreateAWSConfigForIntegration(ctx, Config{
+			Region:                awsRegion,
+			IntegrationName:       integrationName,
+			IntegrationGetter:     deps,
+			AWSOIDCTokenGenerator: deps,
+			STSClient:             stsClient,
+		}, WithWaitForFirstInit(true))
+		require.NoError(t, err)
+		require.Equal(t, int32(1), atomic.LoadInt32(&stsClient.called))
+
+		creds, err := config.Credentials.Retrieve(ctx)
+		require.NoError(t, err)
+		require.NotEmpty(t, creds.SecretAccessKey)
+	})
+}
+
+type depsMock struct {
+	*local.CA
+	*local.ClusterConfigurationService
+	*local.IntegrationsService
+	*local.PresenceService
+	proxies []types.Server
+}
+
+func (d *depsMock) GenerateOIDCTokenFn(ctx context.Context, integration string) (string, error) {
+	token, err := awsoidc.GenerateAWSOIDCToken(ctx, d, d, awsoidc.GenerateAWSOIDCTokenRequest{
+		Integration: integrationName,
+		Username:    testUser,
+		Subject:     types.IntegrationAWSOIDCSubject,
+	})
+	return token, trace.Wrap(err)
+}
+
+func (d *depsMock) GenerateAWSOIDCToken(ctx context.Context, integration string) (string, error) {
+	token, err := awsoidc.GenerateAWSOIDCToken(ctx, d, d, awsoidc.GenerateAWSOIDCTokenRequest{
+		Integration: integration,
+		Username:    "test-user",
+		Subject:     types.IntegrationAWSOIDCSubject,
+	})
+	return token, trace.Wrap(err)
+}
+
+func (d *depsMock) GetJWTSigner(ctx context.Context, ca types.CertAuthority) (crypto.Signer, error) {
+	ca, err := d.CA.GetCertAuthority(ctx, ca.GetID(), true)
+	if err != nil {
+		return nil, err
+	}
+	if len(ca.GetTrustedJWTKeyPairs()) == 0 {
+		return nil, trace.BadParameter("no JWT keys found")
+	}
+	return keys.ParsePrivateKey(ca.GetTrustedJWTKeyPairs()[0].PrivateKey)
+}
+
+func (d *depsMock) GetProxies() ([]types.Server, error) {
+	return d.proxies, nil
+}
+
+func (d *depsMock) GetClusterName(opts ...services.MarshalOption) (types.ClusterName, error) {
+	return types.NewClusterName(types.ClusterNameSpecV2{ClusterName: "teleport.example.com", ClusterID: "cluster-id"})
+}
+
+func newDepsMock(t *testing.T) *depsMock {
+	ctx := context.Background()
+	var out depsMock
+	b, err := memory.New(memory.Config{
+		Clock: clockwork.NewFakeClock(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, b.Close())
+	})
+	out.CA = local.NewCAService(b)
+	out.ClusterConfigurationService, err = local.NewClusterConfigurationService(b)
+	require.NoError(t, err)
+	out.IntegrationsService, err = local.NewIntegrationsService(b)
+	require.NoError(t, err)
+	out.PresenceService = local.NewPresenceService(b)
+
+	ca := newCertAuthority(t, types.OIDCIdPCA, "teleport.example.com")
+	require.NoError(t, err)
+
+	err = out.CA.CreateCertAuthority(ctx, ca)
+	require.NoError(t, err)
+
+	oidcIntegration, err := types.NewIntegrationAWSOIDC(
+		types.Metadata{Name: integrationName},
+		&types.AWSOIDCIntegrationSpecV1{
+			RoleARN: "arn:aws:iam::111111111111:role/test-role",
+		},
+	)
+	require.NoError(t, err)
+
+	_, err = out.IntegrationsService.CreateIntegration(context.Background(), oidcIntegration)
+	require.NoError(t, err)
+
+	out.proxies = []types.Server{
+		&types.ServerV2{Spec: types.ServerSpecV2{
+			PublicAddrs: []string{"teleport.example.com"},
+		}},
+	}
+	return &out
+}
+
+func newCertAuthority(t *testing.T, caType types.CertAuthType, domain string) types.CertAuthority {
+	t.Helper()
+	publicKey, privateKey, err := testauthority.New().GenerateJWT()
+	require.NoError(t, err)
+	ca, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
+		Type:        caType,
+		ClusterName: domain,
+		ActiveKeys: types.CAKeySet{
+			JWT: []*types.JWTKeyPair{{
+				PublicKey:      publicKey,
+				PrivateKey:     privateKey,
+				PrivateKeyType: types.PrivateKeyType_RAW,
+			}},
+		},
+	})
+	require.NoError(t, err)
+	return ca
+}


### PR DESCRIPTION
### What

 Improves the `CreateAWSConfigForIntegration` function in the AWS OIDC integration by adding a configurable option for credential initialization. This enhancement provides better control over how and when credentials are generated, allowing users to choose whether to wait for initial credentials before proceeding.
 
Previously, credentials were retrieved during the `CreateAWSConfigForIntegration` call, even if no AWS API call was made.
With this change, AWS credentials will, by default, be lazily evaluated and retrieved only when needed.