### PR TITLE
Allow displaying hardware keys prompts when relogin is in progress

### DIFF
--- a/lib/teleterm/daemon/daemon_headless.go
+++ b/lib/teleterm/daemon/daemon_headless.go
@@ -272,10 +272,10 @@ func (s *Service) sendPendingHeadlessAuthentication(ctx context.Context, ha *typ
 		HeadlessAuthenticationClientIp: ha.ClientIpAddress,
 	}
 
-	if err := s.singleImportantModalSemaphore.Acquire(ctx); err != nil {
+	if err := s.headlessAuthSemaphore.Acquire(ctx); err != nil {
 		return trace.Wrap(err)
 	}
-	defer s.singleImportantModalSemaphore.Release()
+	defer s.headlessAuthSemaphore.Release()
 
 	_, err := s.tshdEventsClient.SendPendingHeadlessAuthentication(ctx, req)
 	return trace.Wrap(err)

--- a/lib/teleterm/daemon/daemon_headless.go
+++ b/lib/teleterm/daemon/daemon_headless.go
@@ -272,10 +272,10 @@ func (s *Service) sendPendingHeadlessAuthentication(ctx context.Context, ha *typ
 		HeadlessAuthenticationClientIp: ha.ClientIpAddress,
 	}
 
-	if err := s.importantModalSemaphore.Acquire(ctx); err != nil {
+	if err := s.singleImportantModalSemaphore.Acquire(ctx); err != nil {
 		return trace.Wrap(err)
 	}
-	defer s.importantModalSemaphore.Release()
+	defer s.singleImportantModalSemaphore.Release()
 
 	_, err := s.tshdEventsClient.SendPendingHeadlessAuthentication(ctx, req)
 	return trace.Wrap(err)

--- a/lib/teleterm/daemon/daemon_test.go
+++ b/lib/teleterm/daemon/daemon_test.go
@@ -522,8 +522,8 @@ func TestImportantModalSemaphore(t *testing.T) {
 	// Claim the important modal semaphore.
 
 	customWaitDuration := 10 * time.Millisecond
-	daemon.importantModalSemaphore.waitDuration = customWaitDuration
-	err = daemon.importantModalSemaphore.Acquire(ctx)
+	daemon.singleImportantModalSemaphore.waitDuration = customWaitDuration
+	err = daemon.singleImportantModalSemaphore.Acquire(ctx)
 	require.NoError(t, err)
 
 	// relogin and sending pending headless authentications should be blocked.
@@ -560,7 +560,7 @@ func TestImportantModalSemaphore(t *testing.T) {
 	// complete successfully after a short delay between each semaphore release.
 
 	releaseTime := time.Now()
-	daemon.importantModalSemaphore.Release()
+	daemon.singleImportantModalSemaphore.Release()
 
 	var otherC chan error
 	select {

--- a/lib/teleterm/daemon/daemon_test.go
+++ b/lib/teleterm/daemon/daemon_test.go
@@ -489,7 +489,7 @@ func TestRetryWithRelogin(t *testing.T) {
 	}
 }
 
-func TestImportantModalSemaphore(t *testing.T) {
+func TestConcurrentHeadlessAuthPrompts(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
@@ -522,54 +522,54 @@ func TestImportantModalSemaphore(t *testing.T) {
 	// Claim the important modal semaphore.
 
 	customWaitDuration := 10 * time.Millisecond
-	daemon.singleImportantModalSemaphore.waitDuration = customWaitDuration
-	err = daemon.singleImportantModalSemaphore.Acquire(ctx)
+	daemon.headlessAuthSemaphore.waitDuration = customWaitDuration
+	err = daemon.headlessAuthSemaphore.Acquire(ctx)
 	require.NoError(t, err)
 
-	// relogin and sending pending headless authentications should be blocked.
+	// Pending headless authentications should be blocked.
 
-	reloginErrC := make(chan error)
+	headlessPromptErr1 := make(chan error)
 	go func() {
-		reloginErrC <- daemon.relogin(ctx, &api.ReloginRequest{})
+		headlessPromptErr1 <- daemon.sendPendingHeadlessAuthentication(ctx, &types.HeadlessAuthentication{}, "")
 	}()
 
-	sphaErrC := make(chan error)
+	headlessPromptErr2 := make(chan error)
 	go func() {
-		sphaErrC <- daemon.sendPendingHeadlessAuthentication(ctx, &types.HeadlessAuthentication{}, "")
+		headlessPromptErr2 <- daemon.sendPendingHeadlessAuthentication(ctx, &types.HeadlessAuthentication{}, "")
 	}()
 
 	select {
-	case <-reloginErrC:
-		t.Error("relogin completed successfully without acquiring the important modal semaphore")
-	case <-sphaErrC:
-		t.Error("sendPendingHeadlessAuthentication completed successfully without acquiring the important modal semaphore")
+	case <-headlessPromptErr1:
+		t.Error("sendPendingHeadlessAuthentication for the first prompt completed successfully without acquiring the semaphore")
+	case <-headlessPromptErr2:
+		t.Error("sendPendingHeadlessAuthentication for the second prompt completed successfully without acquiring the semaphore")
 	case <-time.After(100 * time.Millisecond):
 	}
 
-	// if the request's ctx is canceled, they will unblock and return an error instead.
+	// If the request's ctx is canceled, they will unblock and return an error instead.
 
 	cancelCtx, cancel := context.WithCancel(ctx)
 	cancel()
 
-	err = daemon.relogin(cancelCtx, &api.ReloginRequest{})
+	err = daemon.sendPendingHeadlessAuthentication(cancelCtx, &types.HeadlessAuthentication{}, "")
 	require.Error(t, err)
 	err = daemon.sendPendingHeadlessAuthentication(cancelCtx, &types.HeadlessAuthentication{}, "")
 	require.Error(t, err)
 
-	// Release the semaphore. relogin and sending pending headless authentication should
+	// Release the semaphore. Pending headless authentication should
 	// complete successfully after a short delay between each semaphore release.
 
 	releaseTime := time.Now()
-	daemon.singleImportantModalSemaphore.Release()
+	daemon.headlessAuthSemaphore.Release()
 
 	var otherC chan error
 	select {
-	case err := <-reloginErrC:
+	case err := <-headlessPromptErr1:
 		require.NoError(t, err)
-		otherC = sphaErrC
-	case err := <-sphaErrC:
+		otherC = headlessPromptErr2
+	case err := <-headlessPromptErr2:
 		require.NoError(t, err)
-		otherC = reloginErrC
+		otherC = headlessPromptErr1
 	case <-time.After(time.Second):
 		t.Error("important modal operations failed to acquire unclaimed semaphore")
 	}
@@ -589,8 +589,7 @@ func TestImportantModalSemaphore(t *testing.T) {
 		t.Error("important modal semaphore should not be acquired before waiting the specified duration")
 	}
 
-	require.EqualValues(t, 1, service.reloginCount.Load(), "Unexpected number of calls to service.Relogin")
-	require.EqualValues(t, 1, service.sendPendingHeadlessAuthenticationCount.Load(), "Unexpected number of calls to service.SendPendingHeadlessAuthentication")
+	require.EqualValues(t, 2, service.sendPendingHeadlessAuthenticationCount.Load(), "Unexpected number of calls to service.SendPendingHeadlessAuthentication")
 }
 
 type mockTSHDEventsService struct {

--- a/lib/teleterm/daemon/hardwarekeyprompt.go
+++ b/lib/teleterm/daemon/hardwarekeyprompt.go
@@ -30,8 +30,6 @@ import (
 
 // NewHardwareKeyPromptConstructor returns a new hardware key prompt constructor
 // for this service and the given root cluster URI.
-// Unlike other modals triggered by tshd events, we do not acquire the singleImportantModalSemaphore here.
-// This allows these prompts to show up while a relogin modal is still opened.
 //
 // TODO(gzdunek): Improve multi-cluster and multi-hardware keys support.
 // The code in yubikey.go doesn't really support using multiple hardware keys (like one per cluster):
@@ -46,6 +44,7 @@ import (
 // But I will leave that for the future, it's hard to say how common these scenarios will be in Connect.
 //
 // Because the code in yubikey.go assumes you use a single key, we don't have any mutex here.
+// (unlike other modals triggered by tshd).
 // We don't expect receiving prompts from different hardware keys.
 func (s *Service) NewHardwareKeyPromptConstructor(rootClusterURI uri.ResourceURI) keys.HardwareKeyPrompt {
 	return &hardwareKeyPrompter{s: s, rootClusterURI: rootClusterURI}

--- a/lib/teleterm/daemon/hardwarekeyprompt.go
+++ b/lib/teleterm/daemon/hardwarekeyprompt.go
@@ -30,6 +30,9 @@ import (
 
 // NewHardwareKeyPromptConstructor returns a new hardware key prompt constructor
 // for this service and the given root cluster URI.
+// Unlike other modals triggered by tshd events, we do not acquire the singleImportantModalSemaphore here.
+// This allows these prompts to show up while a relogin modal is still opened.
+//
 // TODO(gzdunek): Improve multi-cluster and multi-hardware keys support.
 // The code in yubikey.go doesn't really support using multiple hardware keys (like one per cluster):
 // 1. We don't offer a choice which key should be used on the initial login.
@@ -42,8 +45,8 @@ import (
 // It seems that the better option would be to have a prompt per physical key, not per cluster.
 // But I will leave that for the future, it's hard to say how common these scenarios will be in Connect.
 //
-// Because of the above, we don't have any mutex here. I don't expect receiving prompts
-// from different hardware keys at the same time.
+// Because the code in yubikey.go assumes you use a single key, we don't have any mutex here.
+// We don't expect receiving prompts from different hardware keys.
 func (s *Service) NewHardwareKeyPromptConstructor(rootClusterURI uri.ResourceURI) keys.HardwareKeyPrompt {
 	return &hardwareKeyPrompter{s: s, rootClusterURI: rootClusterURI}
 }

--- a/lib/teleterm/daemon/hardwarekeyprompt.go
+++ b/lib/teleterm/daemon/hardwarekeyprompt.go
@@ -41,10 +41,10 @@ type hardwareKeyPrompter struct {
 
 // Touch prompts the user to touch the hardware key.
 func (h *hardwareKeyPrompter) Touch(ctx context.Context) error {
-	if err := h.s.importantModalSemaphore.Acquire(ctx); err != nil {
+	if err := h.s.singleImportantModalSemaphore.Acquire(ctx); err != nil {
 		return trace.Wrap(err)
 	}
-	defer h.s.importantModalSemaphore.Release()
+	defer h.s.singleImportantModalSemaphore.Release()
 	_, err := h.s.tshdEventsClient.PromptHardwareKeyTouch(ctx, &api.PromptHardwareKeyTouchRequest{
 		RootClusterUri: h.rootClusterURI.String(),
 	})
@@ -56,10 +56,10 @@ func (h *hardwareKeyPrompter) Touch(ctx context.Context) error {
 
 // AskPIN prompts the user for a PIN.
 func (h *hardwareKeyPrompter) AskPIN(ctx context.Context, requirement keys.PINPromptRequirement) (string, error) {
-	if err := h.s.importantModalSemaphore.Acquire(ctx); err != nil {
+	if err := h.s.singleImportantModalSemaphore.Acquire(ctx); err != nil {
 		return "", trace.Wrap(err)
 	}
-	defer h.s.importantModalSemaphore.Release()
+	defer h.s.singleImportantModalSemaphore.Release()
 	res, err := h.s.tshdEventsClient.PromptHardwareKeyPIN(ctx, &api.PromptHardwareKeyPINRequest{
 		RootClusterUri: h.rootClusterURI.String(),
 		PinOptional:    requirement == keys.PINOptional,
@@ -74,10 +74,10 @@ func (h *hardwareKeyPrompter) AskPIN(ctx context.Context, requirement keys.PINPr
 // The Electron app prompt must handle default values for PIN and PUK,
 // preventing the user from submitting empty/default values.
 func (h *hardwareKeyPrompter) ChangePIN(ctx context.Context) (*keys.PINAndPUK, error) {
-	if err := h.s.importantModalSemaphore.Acquire(ctx); err != nil {
+	if err := h.s.singleImportantModalSemaphore.Acquire(ctx); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	defer h.s.importantModalSemaphore.Release()
+	defer h.s.singleImportantModalSemaphore.Release()
 	res, err := h.s.tshdEventsClient.PromptHardwareKeyPINChange(ctx, &api.PromptHardwareKeyPINChangeRequest{
 		RootClusterUri: h.rootClusterURI.String(),
 	})
@@ -93,10 +93,10 @@ func (h *hardwareKeyPrompter) ChangePIN(ctx context.Context) (*keys.PINAndPUK, e
 
 // ConfirmSlotOverwrite asks the user if the slot's private key and certificate can be overridden.
 func (h *hardwareKeyPrompter) ConfirmSlotOverwrite(ctx context.Context, message string) (bool, error) {
-	if err := h.s.importantModalSemaphore.Acquire(ctx); err != nil {
+	if err := h.s.singleImportantModalSemaphore.Acquire(ctx); err != nil {
 		return false, trace.Wrap(err)
 	}
-	defer h.s.importantModalSemaphore.Release()
+	defer h.s.singleImportantModalSemaphore.Release()
 	res, err := h.s.tshdEventsClient.ConfirmHardwareKeySlotOverwrite(ctx, &api.ConfirmHardwareKeySlotOverwriteRequest{
 		RootClusterUri: h.rootClusterURI.String(),
 		Message:        message,

--- a/lib/teleterm/daemon/hardwarekeyprompt.go
+++ b/lib/teleterm/daemon/hardwarekeyprompt.go
@@ -30,6 +30,20 @@ import (
 
 // NewHardwareKeyPromptConstructor returns a new hardware key prompt constructor
 // for this service and the given root cluster URI.
+// TODO(gzdunek): Improve multi-cluster and multi-hardware keys support.
+// The code in yubikey.go doesn't really support using multiple hardware keys (like one per cluster):
+// 1. We don't offer a choice which key should be used on the initial login.
+// 2. Keys are cached per slot, not per physical key - it's not possible to use different keys with the same slot.
+//
+// Additionally, using the same hardware key for two clusters is not ideal too.
+// Since we cache the keys per slot, if two clusters specify the same one,
+// the user will always see the prompt for the same cluster URI. For example, if you are logged into both
+// cluster-a and cluster-b, the prompt will always say "Unlock hardware key to access cluster-b."
+// It seems that the better option would be to have a prompt per physical key, not per cluster.
+// But I will leave that for the future, it's hard to say how common these scenarios will be in Connect.
+//
+// Because of the above, we don't have any mutex here. I don't expect receiving prompts
+// from different hardware keys at the same time.
 func (s *Service) NewHardwareKeyPromptConstructor(rootClusterURI uri.ResourceURI) keys.HardwareKeyPrompt {
 	return &hardwareKeyPrompter{s: s, rootClusterURI: rootClusterURI}
 }
@@ -41,10 +55,6 @@ type hardwareKeyPrompter struct {
 
 // Touch prompts the user to touch the hardware key.
 func (h *hardwareKeyPrompter) Touch(ctx context.Context) error {
-	if err := h.s.singleImportantModalSemaphore.Acquire(ctx); err != nil {
-		return trace.Wrap(err)
-	}
-	defer h.s.singleImportantModalSemaphore.Release()
 	_, err := h.s.tshdEventsClient.PromptHardwareKeyTouch(ctx, &api.PromptHardwareKeyTouchRequest{
 		RootClusterUri: h.rootClusterURI.String(),
 	})
@@ -56,10 +66,6 @@ func (h *hardwareKeyPrompter) Touch(ctx context.Context) error {
 
 // AskPIN prompts the user for a PIN.
 func (h *hardwareKeyPrompter) AskPIN(ctx context.Context, requirement keys.PINPromptRequirement) (string, error) {
-	if err := h.s.singleImportantModalSemaphore.Acquire(ctx); err != nil {
-		return "", trace.Wrap(err)
-	}
-	defer h.s.singleImportantModalSemaphore.Release()
 	res, err := h.s.tshdEventsClient.PromptHardwareKeyPIN(ctx, &api.PromptHardwareKeyPINRequest{
 		RootClusterUri: h.rootClusterURI.String(),
 		PinOptional:    requirement == keys.PINOptional,
@@ -74,10 +80,6 @@ func (h *hardwareKeyPrompter) AskPIN(ctx context.Context, requirement keys.PINPr
 // The Electron app prompt must handle default values for PIN and PUK,
 // preventing the user from submitting empty/default values.
 func (h *hardwareKeyPrompter) ChangePIN(ctx context.Context) (*keys.PINAndPUK, error) {
-	if err := h.s.singleImportantModalSemaphore.Acquire(ctx); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	defer h.s.singleImportantModalSemaphore.Release()
 	res, err := h.s.tshdEventsClient.PromptHardwareKeyPINChange(ctx, &api.PromptHardwareKeyPINChangeRequest{
 		RootClusterUri: h.rootClusterURI.String(),
 	})
@@ -93,10 +95,6 @@ func (h *hardwareKeyPrompter) ChangePIN(ctx context.Context) (*keys.PINAndPUK, e
 
 // ConfirmSlotOverwrite asks the user if the slot's private key and certificate can be overridden.
 func (h *hardwareKeyPrompter) ConfirmSlotOverwrite(ctx context.Context, message string) (bool, error) {
-	if err := h.s.singleImportantModalSemaphore.Acquire(ctx); err != nil {
-		return false, trace.Wrap(err)
-	}
-	defer h.s.singleImportantModalSemaphore.Release()
 	res, err := h.s.tshdEventsClient.ConfirmHardwareKeySlotOverwrite(ctx, &api.ConfirmHardwareKeySlotOverwriteRequest{
 		RootClusterUri: h.rootClusterURI.String(),
 		Message:        message,

--- a/lib/teleterm/daemon/mfaprompt.go
+++ b/lib/teleterm/daemon/mfaprompt.go
@@ -63,10 +63,8 @@ func (s *Service) NewMFAPrompt(resourceURI uri.ResourceURI, cfg *libmfa.PromptCo
 }
 
 func (s *Service) promptAppMFA(ctx context.Context, in *api.PromptMFARequest) (*api.PromptMFAResponse, error) {
-	if err := s.singleImportantModalSemaphore.Acquire(ctx); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	defer s.singleImportantModalSemaphore.Release()
+	s.mfaMu.Lock()
+	defer s.mfaMu.Unlock()
 
 	return s.tshdEventsClient.PromptMFA(ctx, in)
 }

--- a/lib/teleterm/daemon/mfaprompt.go
+++ b/lib/teleterm/daemon/mfaprompt.go
@@ -63,10 +63,10 @@ func (s *Service) NewMFAPrompt(resourceURI uri.ResourceURI, cfg *libmfa.PromptCo
 }
 
 func (s *Service) promptAppMFA(ctx context.Context, in *api.PromptMFARequest) (*api.PromptMFAResponse, error) {
-	if err := s.importantModalSemaphore.Acquire(ctx); err != nil {
+	if err := s.singleImportantModalSemaphore.Acquire(ctx); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	defer s.importantModalSemaphore.Release()
+	defer s.singleImportantModalSemaphore.Release()
 
 	return s.tshdEventsClient.PromptMFA(ctx, in)
 }

--- a/web/packages/design/src/DialogConfirmation/DialogConfirmation.story.tsx
+++ b/web/packages/design/src/DialogConfirmation/DialogConfirmation.story.tsx
@@ -16,18 +16,27 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { ButtonPrimary } from '../Button';
 
-import { render, fireEvent } from 'design/utils/testing';
+import DialogConfirmation, {
+  DialogHeader,
+  DialogContent,
+  DialogFooter,
+  DialogTitle,
+} from './index';
 
-import DialogConfirmation from './DialogConfirmation';
+export default {
+  title: 'Design/Dialog/Confirmation',
+};
 
-test('onClose is respected', () => {
-  const onClose = jest.fn();
-  const { container } = render(
-    <DialogConfirmation open={true} onClose={onClose} />
-  );
-
-  fireEvent.keyDown(container, { key: 'Escape' });
-  expect(onClose).toHaveBeenCalledTimes(1);
-});
+export const Confirmation = () => (
+  <DialogConfirmation open={true}>
+    <DialogHeader>
+      <DialogTitle>Confirmation Dialog Header</DialogTitle>
+    </DialogHeader>
+    <DialogContent>Simplified dialog for use with confirmations</DialogContent>
+    <DialogFooter>
+      <ButtonPrimary>Save and Close</ButtonPrimary>
+    </DialogFooter>
+  </DialogConfirmation>
+);

--- a/web/packages/design/src/DialogConfirmation/DialogConfirmation.test.tsx
+++ b/web/packages/design/src/DialogConfirmation/DialogConfirmation.test.tsx
@@ -16,29 +16,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { render, fireEvent } from 'design/utils/testing';
 
-import { ButtonPrimary } from '../Button';
+import { DialogConfirmation } from './DialogConfirmation';
 
-import DialogConfirmation, {
-  DialogHeader,
-  DialogContent,
-  DialogFooter,
-  DialogTitle,
-} from './index';
+test('onClose is respected', () => {
+  const onClose = jest.fn();
+  const { container } = render(
+    <DialogConfirmation open={true} onClose={onClose} />
+  );
 
-export default {
-  title: 'Design/Dialog/Confirmation',
-};
-
-export const Confirmation = () => (
-  <DialogConfirmation open={true}>
-    <DialogHeader>
-      <DialogTitle>Confirmation Dialog Header</DialogTitle>
-    </DialogHeader>
-    <DialogContent>Simplified dialog for use with confirmations</DialogContent>
-    <DialogFooter>
-      <ButtonPrimary>Save and Close</ButtonPrimary>
-    </DialogFooter>
-  </DialogConfirmation>
-);
+  fireEvent.keyDown(container, { key: 'Escape' });
+  expect(onClose).toHaveBeenCalledTimes(1);
+});

--- a/web/packages/design/src/DialogConfirmation/DialogConfirmation.tsx
+++ b/web/packages/design/src/DialogConfirmation/DialogConfirmation.tsx
@@ -23,6 +23,11 @@ import Dialog from 'design/Dialog';
 
 export function DialogConfirmation(props: {
   open: boolean;
+  /**
+   * Prevent unmounting the component and its children from the DOM when closed.
+   * Instead, hides it with CSS.
+   */
+  keepMounted?: boolean;
   /** @deprecated This props has no effect, it was never passed down to `Dialog`. */
   disableEscapeKeyDown?: boolean;
   children?: ReactNode;
@@ -38,6 +43,7 @@ export function DialogConfirmation(props: {
       disableEscapeKeyDown={false}
       onClose={props.onClose}
       open={props.open}
+      keepMounted={props.keepMounted}
     >
       {props.children}
     </Dialog>

--- a/web/packages/design/src/DialogConfirmation/DialogConfirmation.tsx
+++ b/web/packages/design/src/DialogConfirmation/DialogConfirmation.tsx
@@ -27,7 +27,7 @@ export function DialogConfirmation(props: {
    * Prevent unmounting the component and its children from the DOM when closed.
    * Instead, hides it with CSS.
    */
-  keepMounted?: boolean;
+  keepInDOMAfterClose?: boolean;
   /** @deprecated This props has no effect, it was never passed down to `Dialog`. */
   disableEscapeKeyDown?: boolean;
   children?: ReactNode;
@@ -43,7 +43,7 @@ export function DialogConfirmation(props: {
       disableEscapeKeyDown={false}
       onClose={props.onClose}
       open={props.open}
-      keepMounted={props.keepMounted}
+      keepInDOMAfterClose={props.keepInDOMAfterClose}
     >
       {props.children}
     </Dialog>

--- a/web/packages/design/src/DialogConfirmation/DialogConfirmation.tsx
+++ b/web/packages/design/src/DialogConfirmation/DialogConfirmation.tsx
@@ -16,13 +16,30 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import DialogConfirmation from './DialogConfirmation';
-import {
-  DialogTitle,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-} from './../Dialog';
+import { ReactNode } from 'react';
+import { StyleFunction } from 'styled-components';
 
-export default DialogConfirmation;
-export { DialogTitle, DialogContent, DialogFooter, DialogHeader };
+import Dialog from 'design/Dialog';
+
+export function DialogConfirmation(props: {
+  open: boolean;
+  /** @deprecated This props has no effect, it was never passed down to `Dialog`. */
+  disableEscapeKeyDown?: boolean;
+  children?: ReactNode;
+  onClose?: (
+    event: KeyboardEvent | React.MouseEvent,
+    reason: 'escapeKeyDown' | 'backdropClick'
+  ) => void;
+  dialogCss?: StyleFunction<any>;
+}) {
+  return (
+    <Dialog
+      dialogCss={props.dialogCss}
+      disableEscapeKeyDown={false}
+      onClose={props.onClose}
+      open={props.open}
+    >
+      {props.children}
+    </Dialog>
+  );
+}

--- a/web/packages/design/src/DialogConfirmation/index.ts
+++ b/web/packages/design/src/DialogConfirmation/index.ts
@@ -16,22 +16,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
-import Dialog from 'design/Dialog';
-
-function DialogConfirmation(props) {
-  const { children, open, onClose, dialogCss } = props;
-  return (
-    <Dialog
-      dialogCss={dialogCss}
-      disableEscapeKeyDown={false}
-      onClose={onClose}
-      open={open}
-    >
-      {children}
-    </Dialog>
-  );
-}
+import { DialogConfirmation } from './DialogConfirmation';
+import {
+  DialogTitle,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+} from './../Dialog';
 
 export default DialogConfirmation;
+export { DialogTitle, DialogContent, DialogFooter, DialogHeader };

--- a/web/packages/design/src/Modal/Modal.test.tsx
+++ b/web/packages/design/src/Modal/Modal.test.tsx
@@ -160,7 +160,7 @@ test('restores focus on close', async () => {
 
 test('closing dialog when attachCustomKeyEventHandler is set only hides it with DOM', async () => {
   const { rerender } = render(
-    <Modal open={true} keepInDOMAfterClose={true}>
+    <Modal open={true} keepInDOMAfterClose>
       <div>Hello</div>
     </Modal>
   );
@@ -168,7 +168,7 @@ test('closing dialog when attachCustomKeyEventHandler is set only hides it with 
   expect(screen.getByText('Hello')).toBeVisible();
 
   rerender(
-    <Modal open={false} keepInDOMAfterClose={true}>
+    <Modal open={false} keepInDOMAfterClose>
       <div>Hello</div>
     </Modal>
   );

--- a/web/packages/design/src/Modal/Modal.test.tsx
+++ b/web/packages/design/src/Modal/Modal.test.tsx
@@ -36,128 +36,144 @@ const escapeKey = {
   key: 'Escape',
 };
 
-describe('design/Modal', () => {
-  it('respects open prop set to false', () => {
-    render(
-      <Modal open={false}>
-        <div>Hello</div>
-      </Modal>
-    );
+test('respects open prop set to false', () => {
+  render(
+    <Modal open={false}>
+      <div>Hello</div>
+    </Modal>
+  );
 
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+});
+
+test('respects onBackdropClick prop', () => {
+  const mockFn = jest.fn();
+
+  renderModal({
+    onBackdropClick: mockFn,
   });
 
-  it('respects onBackdropClick prop', () => {
-    const mockFn = jest.fn();
+  // handlebackdropClick
+  fireEvent.click(screen.getByTestId('backdrop'));
+  expect(mockFn).toHaveBeenCalled();
+});
 
-    renderModal({
-      onBackdropClick: mockFn,
-    });
+test('respects onEscapeKeyDown props', () => {
+  const mockFn = jest.fn();
 
-    // handlebackdropClick
-    fireEvent.click(screen.getByTestId('backdrop'));
-    expect(mockFn).toHaveBeenCalled();
+  const { container } = renderModal({
+    onEscapeKeyDown: mockFn,
   });
 
-  it('respects onEscapeKeyDown props', () => {
-    const mockFn = jest.fn();
+  // handleDocumentKeyDown
+  fireEvent.keyDown(container, escapeKey);
+  expect(mockFn).toHaveBeenCalled();
+});
 
-    const { container } = renderModal({
-      onEscapeKeyDown: mockFn,
-    });
+test('respects onClose prop', () => {
+  const mockFn = jest.fn();
 
-    // handleDocumentKeyDown
-    fireEvent.keyDown(container, escapeKey);
-    expect(mockFn).toHaveBeenCalled();
+  const { container } = renderModal({
+    onClose: mockFn,
   });
 
-  it('respects onClose prop', () => {
-    const mockFn = jest.fn();
+  // handlebackdropClick
+  fireEvent.click(screen.getByTestId('backdrop'));
+  expect(mockFn).toHaveBeenCalled();
 
-    const { container } = renderModal({
-      onClose: mockFn,
-    });
+  // handleDocumentKeyDown
+  fireEvent.keyDown(container, escapeKey);
+  expect(mockFn).toHaveBeenCalled();
+});
 
-    // handlebackdropClick
-    fireEvent.click(screen.getByTestId('backdrop'));
-    expect(mockFn).toHaveBeenCalled();
-
-    // handleDocumentKeyDown
-    fireEvent.keyDown(container, escapeKey);
-    expect(mockFn).toHaveBeenCalled();
+test('respects hideBackDrop prop', () => {
+  renderModal({
+    hideBackdrop: true,
   });
 
-  it('respects hideBackDrop prop', () => {
-    renderModal({
-      hideBackdrop: true,
-    });
+  expect(screen.queryByTestId('backdrop')).not.toBeInTheDocument();
+});
 
-    expect(screen.queryByTestId('backdrop')).not.toBeInTheDocument();
+test('respects disableBackdropClick prop', () => {
+  const mockFn = jest.fn();
+  renderModal({
+    disableBackdropClick: true,
+    onClose: mockFn,
   });
 
-  it('respects disableBackdropClick prop', () => {
-    const mockFn = jest.fn();
-    renderModal({
-      disableBackdropClick: true,
-      onClose: mockFn,
-    });
+  // handleBackdropClick
+  fireEvent.click(screen.getByTestId('backdrop'));
+  expect(mockFn).not.toHaveBeenCalled();
+});
 
-    // handleBackdropClick
-    fireEvent.click(screen.getByTestId('backdrop'));
-    expect(mockFn).not.toHaveBeenCalled();
+test('respects disableEscapeKeyDown prop', () => {
+  const mockFn = jest.fn();
+  const { container } = renderModal({
+    disableEscapeKeyDown: true,
+    onClose: mockFn,
   });
 
-  it('respects disableEscapeKeyDown prop', () => {
-    const mockFn = jest.fn();
-    const { container } = renderModal({
-      disableEscapeKeyDown: true,
-      onClose: mockFn,
-    });
+  // handleDocumentKeyDown
+  fireEvent.keyDown(container, escapeKey);
+  expect(mockFn).not.toHaveBeenCalled();
+});
 
-    // handleDocumentKeyDown
-    fireEvent.keyDown(container, escapeKey);
-    expect(mockFn).not.toHaveBeenCalled();
+test('unmount cleans up event listeners and closes modal', () => {
+  const mockFn = jest.fn();
+  const { container, unmount } = renderModal({
+    onEscapeKeyDown: mockFn,
   });
 
-  test('unmount cleans up event listeners and closes modal', () => {
-    const mockFn = jest.fn();
-    const { container, unmount } = renderModal({
-      onEscapeKeyDown: mockFn,
-    });
+  unmount();
 
-    unmount();
+  expect(screen.queryByTestId('Modal')).not.toBeInTheDocument();
 
-    expect(screen.queryByTestId('Modal')).not.toBeInTheDocument();
+  fireEvent.keyDown(container, escapeKey);
+  expect(mockFn).not.toHaveBeenCalled();
+});
 
-    fireEvent.keyDown(container, escapeKey);
-    expect(mockFn).not.toHaveBeenCalled();
+test('respects backdropProps prop invisible', () => {
+  renderModal({
+    BackdropProps: { invisible: true },
   });
 
-  test('respects backdropProps prop invisible', () => {
-    renderModal({
-      BackdropProps: { invisible: true },
-    });
-
-    expect(screen.getByTestId('backdrop')).toHaveStyle({
-      'background-color': 'transparent',
-    });
+  expect(screen.getByTestId('backdrop')).toHaveStyle({
+    'background-color': 'transparent',
   });
+});
 
-  it('restores focus on close', async () => {
-    const user = userEvent.setup();
-    render(<ToggleableModal />);
-    const toggleModalButton = screen.getByRole('button', { name: 'Toggle' });
+test('restores focus on close', async () => {
+  const user = userEvent.setup();
+  render(<ToggleableModal />);
+  const toggleModalButton = screen.getByRole('button', { name: 'Toggle' });
 
-    await user.click(toggleModalButton);
-    // Type in the input inside the modal to shift focus into another element.
-    const input = screen.getByLabelText('Input in modal');
-    await user.type(input, 'a');
+  await user.click(toggleModalButton);
+  // Type in the input inside the modal to shift focus into another element.
+  const input = screen.getByLabelText('Input in modal');
+  await user.type(input, 'a');
 
-    const closeModal = screen.getByRole('button', { name: 'Close modal' });
-    await user.click(closeModal);
+  const closeModal = screen.getByRole('button', { name: 'Close modal' });
+  await user.click(closeModal);
 
-    expect(toggleModalButton).toHaveFocus();
-  });
+  expect(toggleModalButton).toHaveFocus();
+});
+
+test('closing dialog when keepMounted is set only hides it with DOM', async () => {
+  const { rerender } = render(
+    <Modal open={true} keepMounted={true}>
+      <div>Hello</div>
+    </Modal>
+  );
+
+  expect(screen.getByText('Hello')).toBeVisible();
+
+  rerender(
+    <Modal open={false} keepMounted={true}>
+      <div>Hello</div>
+    </Modal>
+  );
+
+  expect(screen.getByText('Hello')).not.toBeVisible();
 });
 
 const ToggleableModal = () => {

--- a/web/packages/design/src/Modal/Modal.test.tsx
+++ b/web/packages/design/src/Modal/Modal.test.tsx
@@ -158,9 +158,9 @@ test('restores focus on close', async () => {
   expect(toggleModalButton).toHaveFocus();
 });
 
-test('closing dialog when keepMounted is set only hides it with DOM', async () => {
+test('closing dialog when attachCustomKeyEventHandler is set only hides it with DOM', async () => {
   const { rerender } = render(
-    <Modal open={true} keepMounted={true}>
+    <Modal open={true} keepInDOMAfterClose={true}>
       <div>Hello</div>
     </Modal>
   );
@@ -168,7 +168,7 @@ test('closing dialog when keepMounted is set only hides it with DOM', async () =
   expect(screen.getByText('Hello')).toBeVisible();
 
   rerender(
-    <Modal open={false} keepMounted={true}>
+    <Modal open={false} keepInDOMAfterClose={true}>
       <div>Hello</div>
     </Modal>
   );

--- a/web/packages/design/src/Modal/Modal.tsx
+++ b/web/packages/design/src/Modal/Modal.tsx
@@ -29,7 +29,7 @@ export type ModalProps = {
    * Prevent unmounting the component and its children from the DOM when closed.
    * Instead, hides it with CSS.
    */
-  keepMounted?: boolean;
+  keepInDOMAfterClose?: boolean;
 
   className?: string;
 
@@ -212,10 +212,10 @@ export default class Modal extends React.Component<ModalProps> {
       hideBackdrop,
       open,
       className,
-      keepMounted,
+      keepInDOMAfterClose,
     } = this.props;
 
-    if (!open && !keepMounted) {
+    if (!open && !keepInDOMAfterClose) {
       return null;
     }
 

--- a/web/packages/design/src/Modal/Modal.tsx
+++ b/web/packages/design/src/Modal/Modal.tsx
@@ -25,6 +25,11 @@ export type ModalProps = {
    * If `true`, the modal is open.
    */
   open: boolean;
+  /**
+   * Prevent unmounting the component and its children from the DOM when closed.
+   * Instead, hides it with CSS.
+   */
+  keepMounted?: boolean;
 
   className?: string;
 
@@ -200,15 +205,23 @@ export default class Modal extends React.Component<ModalProps> {
   }
 
   render() {
-    const { BackdropProps, children, modalCss, hideBackdrop, open, className } =
-      this.props;
+    const {
+      BackdropProps,
+      children,
+      modalCss,
+      hideBackdrop,
+      open,
+      className,
+      keepMounted,
+    } = this.props;
 
-    if (!open) {
+    if (!open && !keepMounted) {
       return null;
     }
 
     return createPortal(
       <StyledModal
+        hiddenInDom={!open}
         modalCss={modalCss}
         data-testid="Modal"
         ref={this.modalRef}
@@ -261,6 +274,7 @@ const StyledBackdrop = styled.div<BackdropProps>`
 const StyledModal = styled.div<{
   modalCss?: StyleFunction<any>;
   ref: React.RefObject<HTMLElement>;
+  hiddenInDom?: boolean;
 }>`
   position: fixed;
   z-index: 1200;
@@ -268,5 +282,6 @@ const StyledModal = styled.div<{
   bottom: 0;
   top: 0;
   left: 0;
+  ${props => props.hiddenInDom && `display: none;`};
   ${props => props.modalCss?.(props)}
 `;

--- a/web/packages/teleterm/src/ui/AppInitializer/showStartupModalsAndNotifications.test.ts
+++ b/web/packages/teleterm/src/ui/AppInitializer/showStartupModalsAndNotifications.test.ts
@@ -19,7 +19,7 @@
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import Logger, { NullService } from 'teleterm/logger';
 import AppContext from 'teleterm/ui/appContext';
-import { Dialog } from 'teleterm/ui/services/modals';
+import { RegularDialog } from 'teleterm/ui/services/modals';
 
 import { showStartupModalsAndNotifications } from './showStartupModalsAndNotifications';
 
@@ -144,7 +144,7 @@ function mockUsageReportingEnabled(
 
 function mockOpenRegularDialog(
   mockedAppContext: AppContext,
-  implementation?: (dialog: Dialog) => void
+  implementation?: (dialog: RegularDialog) => void
 ) {
   jest
     .spyOn(mockedAppContext.modalsService, 'openRegularDialog')

--- a/web/packages/teleterm/src/ui/AppInitializer/showStartupModalsAndNotifications.test.ts
+++ b/web/packages/teleterm/src/ui/AppInitializer/showStartupModalsAndNotifications.test.ts
@@ -19,7 +19,7 @@
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import Logger, { NullService } from 'teleterm/logger';
 import AppContext from 'teleterm/ui/appContext';
-import { RegularDialog } from 'teleterm/ui/services/modals';
+import { Dialog } from 'teleterm/ui/services/modals';
 
 import { showStartupModalsAndNotifications } from './showStartupModalsAndNotifications';
 
@@ -144,7 +144,7 @@ function mockUsageReportingEnabled(
 
 function mockOpenRegularDialog(
   mockedAppContext: AppContext,
-  implementation?: (dialog: RegularDialog) => void
+  implementation?: (dialog: Dialog) => void
 ) {
   jest
     .spyOn(mockedAppContext.modalsService, 'openRegularDialog')

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterConnect.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterConnect.tsx
@@ -53,7 +53,7 @@ export function ClusterConnect(props: {
       disableEscapeKeyDown={false}
       onClose={props.dialog.onCancel}
       open={!props.hidden}
-      keepInDOMAfterClose={true}
+      keepInDOMAfterClose
     >
       {!clusterUri ? (
         <ClusterAdd

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterConnect.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterConnect.tsx
@@ -53,7 +53,7 @@ export function ClusterConnect(props: {
       disableEscapeKeyDown={false}
       onClose={props.dialog.onCancel}
       open={!props.hidden}
-      keepMounted={true}
+      keepInDOMAfterClose={true}
     >
       {!clusterUri ? (
         <ClusterAdd

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterConnect.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterConnect.tsx
@@ -28,7 +28,10 @@ import { ClusterAdd } from './ClusterAdd';
 import { ClusterLogin } from './ClusterLogin';
 import { dialogCss } from './spacing';
 
-export function ClusterConnect(props: { dialog: DialogClusterConnect }) {
+export function ClusterConnect(props: {
+  dialog: DialogClusterConnect;
+  hidden?: boolean;
+}) {
   const [createdClusterUri, setCreatedClusterUri] = useState<
     RootClusterUri | undefined
   >();
@@ -49,7 +52,8 @@ export function ClusterConnect(props: { dialog: DialogClusterConnect }) {
       dialogCss={dialogCss}
       disableEscapeKeyDown={false}
       onClose={props.dialog.onCancel}
-      open={true}
+      open={!props.hidden}
+      keepMounted={true}
     >
       {!clusterUri ? (
         <ClusterAdd

--- a/web/packages/teleterm/src/ui/ClusterLogout/ClusterLogout.tsx
+++ b/web/packages/teleterm/src/ui/ClusterLogout/ClusterLogout.tsx
@@ -33,17 +33,17 @@ import { RootClusterUri } from 'teleterm/ui/uri';
 
 import { useClusterLogout } from './useClusterLogout';
 
-interface ClusterLogoutProps {
-  clusterTitle: string;
-  clusterUri: RootClusterUri;
-  onClose(): void;
-}
-
 export function ClusterLogout({
   clusterUri,
   onClose,
   clusterTitle,
-}: ClusterLogoutProps) {
+  hidden,
+}: {
+  clusterTitle: string;
+  clusterUri: RootClusterUri;
+  hidden?: boolean;
+  onClose(): void;
+}) {
   const { removeCluster, status, statusText } = useClusterLogout({
     clusterUri,
   });
@@ -57,7 +57,8 @@ export function ClusterLogout({
 
   return (
     <DialogConfirmation
-      open={true}
+      open={!hidden}
+      keepInDOMAfterClose
       onClose={onClose}
       dialogCss={() => ({
         maxWidth: '400px',

--- a/web/packages/teleterm/src/ui/DocumentsReopen/DocumentsReopen.tsx
+++ b/web/packages/teleterm/src/ui/DocumentsReopen/DocumentsReopen.tsx
@@ -31,14 +31,13 @@ import { P } from 'design/Text/Text';
 import { RootClusterUri, routing } from 'teleterm/ui/uri';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 
-interface DocumentsReopenProps {
+export function DocumentsReopen(props: {
   rootClusterUri: RootClusterUri;
   numberOfDocuments: number;
   onCancel(): void;
   onConfirm(): void;
-}
-
-export function DocumentsReopen(props: DocumentsReopenProps) {
+  hidden?: boolean;
+}) {
   const { rootClusterUri } = props;
   const { clustersService } = useAppContext();
   // TODO(ravicious): Use a profile name here from the URI and remove the dependency on
@@ -49,7 +48,8 @@ export function DocumentsReopen(props: DocumentsReopenProps) {
 
   return (
     <DialogConfirmation
-      open={true}
+      open={!history}
+      keepInDOMAfterClose
       onClose={props.onCancel}
       dialogCss={() => ({
         maxWidth: '400px',

--- a/web/packages/teleterm/src/ui/HeadlessAuthn/HeadlessAuthentication.tsx
+++ b/web/packages/teleterm/src/ui/HeadlessAuthn/HeadlessAuthentication.tsx
@@ -36,6 +36,7 @@ interface HeadlessAuthenticationProps {
   skipConfirm: boolean;
   onCancel(): void;
   onSuccess(): void;
+  hidden?: boolean;
 }
 
 export function HeadlessAuthentication(props: HeadlessAuthenticationProps) {
@@ -81,6 +82,7 @@ export function HeadlessAuthentication(props: HeadlessAuthenticationProps) {
 
   return (
     <HeadlessPrompt
+      hidden={props.hidden}
       cluster={cluster}
       clientIp={props.clientIp}
       skipConfirm={props.skipConfirm}

--- a/web/packages/teleterm/src/ui/HeadlessAuthn/HeadlessPrompt/HeadlessPrompt.tsx
+++ b/web/packages/teleterm/src/ui/HeadlessAuthn/HeadlessPrompt/HeadlessPrompt.tsx
@@ -59,6 +59,7 @@ export type HeadlessPromptProps = {
    * reject the request from the Web UI.
    */
   onCancel(): void;
+  hidden?: boolean;
 };
 
 export function HeadlessPrompt({
@@ -71,6 +72,7 @@ export function HeadlessPrompt({
   headlessAuthenticationId,
   updateHeadlessStateAttempt,
   onCancel,
+  hidden,
 }: HeadlessPromptProps) {
   // skipConfirm automatically attempts to approve a headless auth attempt,
   // so let's show waitForMfa from the very beginning in that case.
@@ -78,12 +80,12 @@ export function HeadlessPrompt({
 
   return (
     <DialogConfirmation
+      open={!hidden}
+      keepMounted={true}
       dialogCss={() => ({
         maxWidth: '480px',
         width: '100%',
       })}
-      disableEscapeKeyDown={false}
-      open={true}
     >
       <DialogHeader justifyContent="space-between" mb={0} alignItems="baseline">
         <H2 mb={4}>

--- a/web/packages/teleterm/src/ui/HeadlessAuthn/HeadlessPrompt/HeadlessPrompt.tsx
+++ b/web/packages/teleterm/src/ui/HeadlessAuthn/HeadlessPrompt/HeadlessPrompt.tsx
@@ -81,7 +81,7 @@ export function HeadlessPrompt({
   return (
     <DialogConfirmation
       open={!hidden}
-      keepMounted={true}
+      keepInDOMAfterClose={true}
       dialogCss={() => ({
         maxWidth: '480px',
         width: '100%',

--- a/web/packages/teleterm/src/ui/HeadlessAuthn/HeadlessPrompt/HeadlessPrompt.tsx
+++ b/web/packages/teleterm/src/ui/HeadlessAuthn/HeadlessPrompt/HeadlessPrompt.tsx
@@ -81,7 +81,7 @@ export function HeadlessPrompt({
   return (
     <DialogConfirmation
       open={!hidden}
-      keepInDOMAfterClose={true}
+      keepInDOMAfterClose
       dialogCss={() => ({
         maxWidth: '480px',
         width: '100%',

--- a/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.story.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.story.tsx
@@ -21,9 +21,10 @@ import React from 'react';
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import {
-  DialogClusterLogout,
   DialogDocumentsReopen,
   ModalsService,
+  DialogHardwareKeyTouch,
+  DialogHardwareKeyPin,
 } from 'teleterm/ui/services/modals';
 
 import ModalsHost from './ModalsHost';
@@ -32,10 +33,22 @@ export default {
   title: 'Teleterm/ModalsHost',
 };
 
-const clusterLogoutDialog: DialogClusterLogout = {
-  kind: 'cluster-logout',
-  clusterUri: '/clusters/foo',
-  clusterTitle: 'Foo',
+const hardwareKeyTouchDialog: DialogHardwareKeyTouch = {
+  kind: 'hardware-key-touch',
+  req: {
+    rootClusterUri: '/clusters/foo',
+  },
+  onCancel: () => {},
+};
+
+const hardwareKeyPinDialog: DialogHardwareKeyPin = {
+  kind: 'hardware-key-pin',
+  req: {
+    rootClusterUri: '/clusters/foo',
+    pinOptional: false,
+  },
+  onSuccess: () => {},
+  onCancel: () => {},
 };
 
 const documentsReopenDialog: DialogDocumentsReopen = {
@@ -46,7 +59,7 @@ const documentsReopenDialog: DialogDocumentsReopen = {
   onCancel: () => {},
 };
 
-const importantDialog = clusterLogoutDialog;
+const importantDialog = hardwareKeyTouchDialog;
 const regularDialog = documentsReopenDialog;
 
 export const RegularModal = () => {
@@ -81,6 +94,21 @@ export const ImportantAndRegularModal = () => {
   const modalsService = new ModalsService();
   modalsService.openRegularDialog(regularDialog);
   modalsService.openImportantDialog(importantDialog);
+
+  const appContext = new MockAppContext();
+  appContext.modalsService = modalsService;
+
+  return (
+    <MockAppContextProvider appContext={appContext}>
+      <ModalsHost />
+    </MockAppContextProvider>
+  );
+};
+
+export const TwoImportantModals = () => {
+  const modalsService = new ModalsService();
+  modalsService.openImportantDialog(importantDialog);
+  modalsService.openImportantDialog(hardwareKeyPinDialog);
 
   const appContext = new MockAppContext();
   appContext.modalsService = modalsService;

--- a/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.test.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.test.tsx
@@ -77,8 +77,12 @@ jest.mock('teleterm/ui/ModalsHost/modals/HardwareKeys/Touch', () => ({
 }));
 
 jest.mock('teleterm/ui/DocumentsReopen', () => ({
-  DocumentsReopen: () => (
-    <div data-testid="mocked-dialog" data-dialog-kind="documents-reopen" />
+  DocumentsReopen: props => (
+    <div
+      data-testid="mocked-dialog"
+      data-dialog-kind="documents-reopen"
+      data-dialog-is-hidden={props.hidden}
+    />
   ),
 }));
 
@@ -107,7 +111,9 @@ test('the important dialog is rendered above the regular dialog', () => {
   // The important dialog should be after the regular dialog in the DOM so that it's shown over the
   // regular dialog.
   expect(dialogs[0]).toHaveAttribute('data-dialog-kind', regularDialog.kind);
+  expect(dialogs[0]).toHaveAttribute('data-dialog-is-hidden', 'true');
   expect(dialogs[1]).toHaveAttribute('data-dialog-kind', importantDialog.kind);
+  expect(dialogs[1]).toHaveAttribute('data-dialog-is-hidden', 'false');
 });
 
 test('the second important dialog is rendered above the first important dialog', () => {

--- a/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.test.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.test.tsx
@@ -122,7 +122,8 @@ test('the second important dialog is rendered above the first important dialog',
 
   const modalsService = new ModalsService();
   modalsService.openImportantDialog(importantDialog1);
-  modalsService.openImportantDialog(importantDialog2);
+  const { closeDialog: closeImportantDialog2 } =
+    modalsService.openImportantDialog(importantDialog2);
 
   const appContext = new MockAppContext();
   appContext.modalsService = modalsService;
@@ -146,7 +147,7 @@ test('the second important dialog is rendered above the first important dialog',
   expect(dialogs[1]).toHaveAttribute('data-dialog-kind', importantDialog2.kind);
   expect(dialogs[1]).toHaveAttribute('data-dialog-is-hidden', 'false');
 
-  act(() => modalsService.closeImportantDialog(importantDialog2));
+  act(() => closeImportantDialog2());
 
   dialogs = screen.queryAllByTestId('mocked-dialog');
 

--- a/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.test.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.test.tsx
@@ -18,21 +18,34 @@
 
 import React from 'react';
 import { render, screen } from 'design/utils/testing';
+import { act } from '@testing-library/react';
 
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import {
-  DialogClusterLogout,
-  DialogDocumentsReopen,
   ModalsService,
+  DialogDocumentsReopen,
+  DialogClusterConnect,
+  DialogHardwareKeyTouch,
 } from 'teleterm/ui/services/modals';
 
 import ModalsHost from './ModalsHost';
 
-const clusterLogoutDialog: DialogClusterLogout = {
-  kind: 'cluster-logout',
+const clusterConnectDialog: DialogClusterConnect = {
+  kind: 'cluster-connect',
   clusterUri: '/clusters/foo',
-  clusterTitle: 'Foo',
+  reason: undefined,
+  onCancel: () => {},
+  onSuccess: () => {},
+  prefill: undefined,
+};
+
+const hardwareKeyTouchDialog: DialogHardwareKeyTouch = {
+  kind: 'hardware-key-touch',
+  req: {
+    rootClusterUri: '/clusters/foo',
+  },
+  onCancel: () => {},
 };
 
 const documentsReopenDialog: DialogDocumentsReopen = {
@@ -43,26 +56,34 @@ const documentsReopenDialog: DialogDocumentsReopen = {
   onCancel: () => {},
 };
 
-jest.mock('teleterm/ui/ClusterLogout', () => ({
-  ClusterLogout: () => (
+jest.mock('teleterm/ui/ClusterConnect', () => ({
+  ClusterConnect: props => (
     <div
       data-testid="mocked-dialog"
-      data-dialog-kind={clusterLogoutDialog.kind}
-    ></div>
+      data-dialog-kind="cluster-connect"
+      data-dialog-is-hidden={props.hidden}
+    />
+  ),
+}));
+
+jest.mock('teleterm/ui/ModalsHost/modals/HardwareKeys/Touch', () => ({
+  Touch: props => (
+    <div
+      data-testid="mocked-dialog"
+      data-dialog-kind="hardware-key-touch"
+      data-dialog-is-hidden={props.hidden}
+    />
   ),
 }));
 
 jest.mock('teleterm/ui/DocumentsReopen', () => ({
   DocumentsReopen: () => (
-    <div
-      data-testid="mocked-dialog"
-      data-dialog-kind={documentsReopenDialog.kind}
-    ></div>
+    <div data-testid="mocked-dialog" data-dialog-kind="documents-reopen" />
   ),
 }));
 
 test('the important dialog is rendered above the regular dialog', () => {
-  const importantDialog = clusterLogoutDialog;
+  const importantDialog = clusterConnectDialog;
   const regularDialog = documentsReopenDialog;
 
   const modalsService = new ModalsService();
@@ -87,4 +108,44 @@ test('the important dialog is rendered above the regular dialog', () => {
   // regular dialog.
   expect(dialogs[0]).toHaveAttribute('data-dialog-kind', regularDialog.kind);
   expect(dialogs[1]).toHaveAttribute('data-dialog-kind', importantDialog.kind);
+});
+
+test('the second important dialog is rendered above the first important dialog', () => {
+  const importantDialog1 = clusterConnectDialog;
+  const importantDialog2 = hardwareKeyTouchDialog;
+
+  const modalsService = new ModalsService();
+  modalsService.openImportantDialog(importantDialog1);
+  modalsService.openImportantDialog(importantDialog2);
+
+  const appContext = new MockAppContext();
+  appContext.modalsService = modalsService;
+
+  render(
+    <MockAppContextProvider appContext={appContext}>
+      <ModalsHost />
+    </MockAppContextProvider>
+  );
+
+  // The DOM testing library doesn't really allow us to test actual visibility in terms of the order
+  // of rendering, so we have to fall back to manually checking items in the array.
+  // https://github.com/testing-library/react-testing-library/issues/313
+  let dialogs = screen.queryAllByTestId('mocked-dialog');
+
+  // The second important dialog should be after the regular dialog in the DOM so that it's shown over the
+  // first important dialog.
+  // On top of that, only the important dialog on the top should be visible.
+  expect(dialogs[0]).toHaveAttribute('data-dialog-kind', importantDialog1.kind);
+  expect(dialogs[0]).toHaveAttribute('data-dialog-is-hidden', 'true');
+  expect(dialogs[1]).toHaveAttribute('data-dialog-kind', importantDialog2.kind);
+  expect(dialogs[1]).toHaveAttribute('data-dialog-is-hidden', 'false');
+
+  act(() => modalsService.closeImportantDialog(importantDialog2));
+
+  dialogs = screen.queryAllByTestId('mocked-dialog');
+
+  // The dialog previously on top was closed.
+  // Now the first dialog is visible.
+  expect(dialogs[0]).toHaveAttribute('data-dialog-kind', importantDialog1.kind);
+  expect(dialogs[0]).toHaveAttribute('data-dialog-is-hidden', 'false');
 });

--- a/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.tsx
@@ -50,13 +50,13 @@ export default function ModalsHost() {
         handleClose: closeRegularDialog,
         hidden: !!importantDialogs.length,
       })}
-      {importantDialogs.map((dialog, index) => {
+      {importantDialogs.map(({ dialog, id }, index) => {
         const isLast = index === importantDialogs.length - 1;
         return (
-          <Fragment key={dialog.kind}>
+          <Fragment key={id}>
             {renderDialog({
               dialog: dialog,
-              handleClose: () => modalsService.closeImportantDialog(dialog),
+              handleClose: () => modalsService.closeImportantDialog(id),
               hidden: !isLast,
             })}
           </Fragment>

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/AuthenticateWebDevice/AuthenticateWebDevice.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/AuthenticateWebDevice/AuthenticateWebDevice.tsx
@@ -25,19 +25,19 @@ import { useAsync } from 'shared/hooks/useAsync';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { RootClusterUri, routing } from 'teleterm/ui/uri';
 
-type Props = {
-  rootClusterUri: RootClusterUri;
-  onCancel(): void;
-  onClose(): void;
-  onAuthorize(): Promise<void>;
-};
-
 export const AuthenticateWebDevice = ({
+  hidden,
   onAuthorize,
   onClose,
   onCancel,
   rootClusterUri,
-}: Props) => {
+}: {
+  rootClusterUri: RootClusterUri;
+  onCancel(): void;
+  onClose(): void;
+  onAuthorize(): Promise<void>;
+  hidden?: boolean;
+}) => {
   const [attempt, run] = useAsync(async () => {
     await onAuthorize();
     onClose();
@@ -48,7 +48,7 @@ export const AuthenticateWebDevice = ({
     routing.parseClusterName(rootClusterUri);
 
   return (
-    <Dialog open={true}>
+    <Dialog open={!hidden} keepInDOMAfterClose>
       {/* 400px was used as a way to do our best to get clusterName as the first item on the second line */}
       <DialogContent maxWidth="400px">
         <Text>

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/ChangeAccessRequestKind/ChangeAccessRequestKind.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/ChangeAccessRequestKind/ChangeAccessRequestKind.tsx
@@ -28,13 +28,16 @@ import { P } from 'design/Text/Text';
 export function ChangeAccessRequestKind({
   onCancel,
   onConfirm,
+  hidden,
 }: {
   onCancel(): void;
   onConfirm(): void;
+  hidden?: boolean;
 }) {
   return (
     <DialogConfirmation
-      open={true}
+      open={!hidden}
+      keepInDOMAfterClose
       onClose={onCancel}
       dialogCss={() => ({
         maxWidth: '400px',

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/AskPin.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/AskPin.tsx
@@ -42,7 +42,7 @@ export function AskPin(props: {
   return (
     <DialogConfirmation
       open={!props.hidden}
-      keepInDOMAfterClose={true}
+      keepInDOMAfterClose
       onClose={props.onCancel}
       dialogCss={() => ({
         maxWidth: '450px',

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/AskPin.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/AskPin.tsx
@@ -42,7 +42,7 @@ export function AskPin(props: {
   return (
     <DialogConfirmation
       open={!props.hidden}
-      keepMounted={true}
+      keepInDOMAfterClose={true}
       onClose={props.onCancel}
       dialogCss={() => ({
         maxWidth: '450px',

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/AskPin.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/AskPin.tsx
@@ -35,12 +35,14 @@ export function AskPin(props: {
   req: PromptHardwareKeyPINRequest;
   onCancel(): void;
   onSuccess(pin: string): void;
+  hidden?: boolean;
 }) {
   const [pin, setPin] = useState('');
 
   return (
     <DialogConfirmation
-      open={true}
+      open={!props.hidden}
+      keepMounted={true}
       onClose={props.onCancel}
       dialogCss={() => ({
         maxWidth: '450px',

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/ChangePin.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/ChangePin.tsx
@@ -57,7 +57,7 @@ export function ChangePin(props: {
   return (
     <DialogConfirmation
       open={!props.hidden}
-      keepInDOMAfterClose={true}
+      keepInDOMAfterClose
       onClose={props.onCancel}
       dialogCss={() => ({
         maxWidth: '450px',

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/ChangePin.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/ChangePin.tsx
@@ -57,7 +57,7 @@ export function ChangePin(props: {
   return (
     <DialogConfirmation
       open={!props.hidden}
-      keepMounted={true}
+      keepInDOMAfterClose={true}
       onClose={props.onCancel}
       dialogCss={() => ({
         maxWidth: '450px',

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/ChangePin.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/ChangePin.tsx
@@ -45,6 +45,7 @@ export function ChangePin(props: {
   req: PromptHardwareKeyPINChangeRequest;
   onCancel(): void;
   onSuccess(response: PromptHardwareKeyPINChangeResponse): void;
+  hidden?: boolean;
 }) {
   const [pin, setPin] = useState('');
   const [confirmPin, setConfirmPin] = useState('');
@@ -55,7 +56,8 @@ export function ChangePin(props: {
 
   return (
     <DialogConfirmation
-      open={true}
+      open={!props.hidden}
+      keepMounted={true}
       onClose={props.onCancel}
       dialogCss={() => ({
         maxWidth: '450px',

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/OverwriteSlot.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/OverwriteSlot.tsx
@@ -34,7 +34,7 @@ export function OverwriteSlot(props: {
   return (
     <DialogConfirmation
       open={!props.hidden}
-      keepInDOMAfterClose={true}
+      keepInDOMAfterClose
       onClose={props.onCancel}
       dialogCss={() => ({
         maxWidth: '450px',

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/OverwriteSlot.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/OverwriteSlot.tsx
@@ -34,7 +34,7 @@ export function OverwriteSlot(props: {
   return (
     <DialogConfirmation
       open={!props.hidden}
-      keepMounted={true}
+      keepInDOMAfterClose={true}
       onClose={props.onCancel}
       dialogCss={() => ({
         maxWidth: '450px',

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/OverwriteSlot.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/OverwriteSlot.tsx
@@ -29,10 +29,12 @@ export function OverwriteSlot(props: {
   req: ConfirmHardwareKeySlotOverwriteRequest;
   onCancel(): void;
   onConfirm(): void;
+  hidden?: boolean;
 }) {
   return (
     <DialogConfirmation
-      open={true}
+      open={!props.hidden}
+      keepMounted={true}
       onClose={props.onCancel}
       dialogCss={() => ({
         maxWidth: '450px',

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/Touch.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/Touch.tsx
@@ -34,7 +34,7 @@ export function Touch(props: {
   return (
     <DialogConfirmation
       open={!props.hidden}
-      keepInDOMAfterClose={true}
+      keepInDOMAfterClose
       onClose={props.onCancel}
       dialogCss={() => ({
         maxWidth: '450px',

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/Touch.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/Touch.tsx
@@ -29,10 +29,12 @@ import { CommonHeader } from './CommonHeader';
 export function Touch(props: {
   req: PromptHardwareKeyTouchRequest;
   onCancel(): void;
+  hidden?: boolean;
 }) {
   return (
     <DialogConfirmation
-      open={true}
+      open={!props.hidden}
+      keepMounted={true}
       onClose={props.onCancel}
       dialogCss={() => ({
         maxWidth: '450px',

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/Touch.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/Touch.tsx
@@ -34,7 +34,7 @@ export function Touch(props: {
   return (
     <DialogConfirmation
       open={!props.hidden}
-      keepMounted={true}
+      keepInDOMAfterClose={true}
       onClose={props.onCancel}
       dialogCss={() => ({
         maxWidth: '450px',

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/ReAuthenticate/ReAuthenticate.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/ReAuthenticate/ReAuthenticate.tsx
@@ -91,7 +91,7 @@ export const ReAuthenticate: FC<{
   return (
     <DialogConfirmation
       open={!props.hidden}
-      keepInDOMAfterClose={true}
+      keepInDOMAfterClose
       onClose={props.onCancel}
       dialogCss={() => ({
         maxWidth: '400px',

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/ReAuthenticate/ReAuthenticate.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/ReAuthenticate/ReAuthenticate.tsx
@@ -91,7 +91,7 @@ export const ReAuthenticate: FC<{
   return (
     <DialogConfirmation
       open={!props.hidden}
-      keepMounted={true}
+      keepInDOMAfterClose={true}
       onClose={props.onCancel}
       dialogCss={() => ({
         maxWidth: '400px',

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/ReAuthenticate/ReAuthenticate.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/ReAuthenticate/ReAuthenticate.tsx
@@ -54,6 +54,7 @@ export const ReAuthenticate: FC<{
   onCancel: () => void;
   onOtpSubmit: (otp: string) => void;
   onSsoContinue: (redirectUrl: string) => void;
+  hidden?: boolean;
 }> = props => {
   const { promptMfaRequest: req, onSsoContinue } = props;
 
@@ -89,7 +90,8 @@ export const ReAuthenticate: FC<{
 
   return (
     <DialogConfirmation
-      open={true}
+      open={!props.hidden}
+      keepMounted={true}
       onClose={props.onCancel}
       dialogCss={() => ({
         maxWidth: '400px',

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/UsageData/UsageData.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/UsageData/UsageData.tsx
@@ -26,18 +26,16 @@ import { ButtonIcon, ButtonPrimary, ButtonSecondary, H2, Link } from 'design';
 import { Cross } from 'design/Icon';
 import { P } from 'design/Text/Text';
 
-interface UsageDataProps {
+export function UsageData(props: {
   onCancel(): void;
-
   onAllow(): void;
-
   onDecline(): void;
-}
-
-export function UsageData(props: UsageDataProps) {
+  hidden?: boolean;
+}) {
   return (
     <DialogConfirmation
-      open={true}
+      open={!props.hidden}
+      keepInDOMAfterClose
       onClose={props.onCancel}
       dialogCss={() => ({
         maxWidth: '400px',

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/UserJobRole/UserJobRole.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/UserJobRole/UserJobRole.tsx
@@ -27,12 +27,6 @@ import DialogConfirmation, {
 import { Cross } from 'design/Icon';
 import { RadioGroup } from 'design/RadioGroup';
 
-interface UserJobRoleProps {
-  onCancel(): void;
-
-  onSend(jobRole: string): void;
-}
-
 const JOB_OPTIONS = [
   'Software Engineer',
   'Support Engineer',
@@ -43,7 +37,11 @@ const JOB_OPTIONS = [
 
 const OTHER_JOB_ROLE = 'Other';
 
-export function UserJobRole(props: UserJobRoleProps) {
+export function UserJobRole(props: {
+  onCancel(): void;
+  onSend(jobRole: string): void;
+  hidden?: boolean;
+}) {
   const inputRef = useRef<HTMLInputElement>();
   const [jobRole, setJobRole] = useState<string | null>(null);
   const [otherJobRole, setOtherJobRole] = useState('');
@@ -67,7 +65,8 @@ export function UserJobRole(props: UserJobRoleProps) {
 
   return (
     <DialogConfirmation
-      open={true}
+      open={!props.hidden}
+      keepInDOMAfterClose
       onClose={props.onCancel}
       dialogCss={() => ({
         maxWidth: '400px',

--- a/web/packages/teleterm/src/ui/Search/ResourceSearchErrors.tsx
+++ b/web/packages/teleterm/src/ui/Search/ResourceSearchErrors.tsx
@@ -33,6 +33,7 @@ export function ResourceSearchErrors(props: {
   errors: ResourceSearchError[];
   getClusterName: (resourceUri: uri.ClusterOrResourceUri) => string;
   onCancel: () => void;
+  hidden?: boolean;
 }) {
   const formattedErrorText = props.errors
     .map(error => error.messageAndCauseWithClusterName(props.getClusterName))
@@ -40,7 +41,8 @@ export function ResourceSearchErrors(props: {
 
   return (
     <DialogConfirmation
-      open={true}
+      open={!props.hidden}
+      keepInDOMAfterClose
       onClose={props.onCancel}
       dialogCss={() => ({
         maxWidth: '800px',

--- a/web/packages/teleterm/src/ui/services/modals/modalsService.ts
+++ b/web/packages/teleterm/src/ui/services/modals/modalsService.ts
@@ -39,8 +39,8 @@ type State = {
   // The important dialogs are displayed above the regular one. This is to avoid losing the state of
   // the regular modal if we happen to need to interrupt whatever the user is doing and display an
   // important modal.
-  important: ImportantDialog[];
-  regular: RegularDialog | undefined;
+  important: Dialog[];
+  regular: Dialog | undefined;
 };
 
 export class ModalsService extends ImmutableStore<State> {
@@ -61,7 +61,7 @@ export class ModalsService extends ImmutableStore<State> {
    * The returned closeDialog function can be used to close the dialog and automatically call the
    * dialog's onCancel callback (if present).
    */
-  openRegularDialog(dialog: RegularDialog): { closeDialog: () => void } {
+  openRegularDialog(dialog: Dialog): { closeDialog: () => void } {
     this.state.regular?.['onCancel']?.();
     this.setState(draftState => {
       draftState.regular = dialog;
@@ -92,7 +92,7 @@ export class ModalsService extends ImmutableStore<State> {
    * The returned closeDialog function can be used to close the dialog and automatically call the
    * dialog's onCancel callback (if present).
    */
-  openImportantDialog(dialog: ImportantDialog): { closeDialog: () => void } {
+  openImportantDialog(dialog: Dialog): { closeDialog: () => void } {
     this.setState(draftState => {
       draftState.important.push(dialog);
     });
@@ -111,7 +111,7 @@ export class ModalsService extends ImmutableStore<State> {
     });
   }
 
-  closeImportantDialog(dialog: ImportantDialog) {
+  closeImportantDialog(dialog: Dialog) {
     const index = this.state.important.indexOf(dialog);
     if (index >= 0) {
       this.setState(draftState => {
@@ -246,7 +246,7 @@ export interface DialogHardwareKeySlotOverwrite {
   onCancel(): void;
 }
 
-export type RegularDialog =
+export type Dialog =
   | DialogClusterConnect
   | DialogClusterLogout
   | DialogDocumentsReopen
@@ -254,12 +254,9 @@ export type RegularDialog =
   | DialogUsageData
   | DialogUserJobRole
   | DialogResourceSearchErrors
-  | DialogChangeAccessRequestKind;
-
-export type ImportantDialog =
-  | DialogClusterConnect
   | DialogHeadlessAuthentication
   | DialogReAuthenticate
+  | DialogChangeAccessRequestKind
   | DialogHardwareKeyPin
   | DialogHardwareKeyTouch
   | DialogHardwareKeyPinChange

--- a/web/packages/teleterm/src/ui/services/modals/modalsService.ts
+++ b/web/packages/teleterm/src/ui/services/modals/modalsService.ts
@@ -28,22 +28,25 @@ import { ImmutableStore } from '../immutableStore';
 import type * as uri from 'teleterm/ui/uri';
 
 type State = {
-  // At most two modals can be displayed at the same time.
-  // The important dialog is displayed above the regular one. This is to avoid losing the state of
+  // One regular dialog and multiple important dialogs can be rendered at the same time.
+  // The rule is that the regular dialogs are opened from user actions in the Electron app, while
+  // the important ones are reserved for tshd events.
+  // We allow multiple important dialogs because sometimes completing an action requires
+  // opening another important dialog.
+  // As of now, this happens when the user needs to unlock a hardware key during a relogin process
+  // (initiated from tshd).
+  //
+  // The important dialogs are displayed above the regular one. This is to avoid losing the state of
   // the regular modal if we happen to need to interrupt whatever the user is doing and display an
   // important modal.
-  important: Dialog;
-  regular: Dialog;
+  important: ImportantDialog[];
+  regular: RegularDialog | undefined;
 };
 
 export class ModalsService extends ImmutableStore<State> {
   state: State = {
-    important: {
-      kind: 'none',
-    },
-    regular: {
-      kind: 'none',
-    },
+    important: [],
+    regular: undefined,
   };
 
   /**
@@ -58,8 +61,8 @@ export class ModalsService extends ImmutableStore<State> {
    * The returned closeDialog function can be used to close the dialog and automatically call the
    * dialog's onCancel callback (if present).
    */
-  openRegularDialog(dialog: Dialog): { closeDialog: () => void } {
-    this.state.regular['onCancel']?.();
+  openRegularDialog(dialog: RegularDialog): { closeDialog: () => void } {
+    this.state.regular?.['onCancel']?.();
     this.setState(draftState => {
       draftState.regular = dialog;
     });
@@ -81,22 +84,22 @@ export class ModalsService extends ImmutableStore<State> {
    * One example of such scenario is showing the modal to relogin after the user attempts to make a
    * database connection through a gateway with expired user and db certs.
    *
-   * Calling openImportantDialog while another important dialog is displayed will simply overwrite
-   * the old dialog with the new one.
-   * The old dialog is canceled, if possible.
+   * Calling openImportantDialog while another important dialog is displayed will open it
+   * on top of that dialog.
+   * Dialogs are displayed in the order they arrive, with the most recent one on top.
+   * This allows actions that need further steps to be completed.
    *
    * The returned closeDialog function can be used to close the dialog and automatically call the
    * dialog's onCancel callback (if present).
    */
-  openImportantDialog(dialog: Dialog): { closeDialog: () => void } {
-    this.state.important['onCancel']?.();
+  openImportantDialog(dialog: ImportantDialog): { closeDialog: () => void } {
     this.setState(draftState => {
-      draftState.important = dialog;
+      draftState.important.push(dialog);
     });
 
     return {
       closeDialog: () => {
-        this.closeImportantDialog();
+        this.closeImportantDialog(dialog);
         dialog['onCancel']?.();
       },
     };
@@ -104,27 +107,22 @@ export class ModalsService extends ImmutableStore<State> {
 
   closeRegularDialog() {
     this.setState(draftState => {
-      draftState.regular = {
-        kind: 'none',
-      };
+      draftState.regular = undefined;
     });
   }
 
-  closeImportantDialog() {
-    this.setState(draftState => {
-      draftState.important = {
-        kind: 'none',
-      };
-    });
+  closeImportantDialog(dialog: ImportantDialog) {
+    const index = this.state.important.indexOf(dialog);
+    if (index >= 0) {
+      this.setState(draftState => {
+        draftState.important.splice(index, 1);
+      });
+    }
   }
 
   useState() {
     return useStore(this).state;
   }
-}
-
-export interface DialogNone {
-  kind: 'none';
 }
 
 export interface DialogClusterConnect {
@@ -248,7 +246,7 @@ export interface DialogHardwareKeySlotOverwrite {
   onCancel(): void;
 }
 
-export type Dialog =
+export type RegularDialog =
   | DialogClusterConnect
   | DialogClusterLogout
   | DialogDocumentsReopen
@@ -256,11 +254,13 @@ export type Dialog =
   | DialogUsageData
   | DialogUserJobRole
   | DialogResourceSearchErrors
+  | DialogChangeAccessRequestKind;
+
+export type ImportantDialog =
+  | DialogClusterConnect
   | DialogHeadlessAuthentication
   | DialogReAuthenticate
-  | DialogChangeAccessRequestKind
   | DialogHardwareKeyPin
   | DialogHardwareKeyTouch
   | DialogHardwareKeyPinChange
-  | DialogHardwareKeySlotOverwrite
-  | DialogNone;
+  | DialogHardwareKeySlotOverwrite;


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/48121

To solve the problem of not being able to prompt for the hardware key when an important dialog for relogin is already open, I enabled support for multiple important modals on the Electron side. Dialogs are hidden using CSS to preserve their state.
This allows unblocking the first important modal in the second important modal and then coming back to the first one (sounds like a line from Inception).

The main problem with hiding the dialogs is that I don't have access to parent elements for them. This means that I can't easily hide them from the `ModalsHost` level. Instead, each important dialog must handle its own hiding (by passing a flag to `DialogConfirmation`). To make this easier, I separated regular modals from important ones and added a JSDoc comment.

When it comes to `importantModalSemaphore`, I renamed it to `singleImportantModalSemaphore` to signal that it allows only one modal at a time. Hardware keys prompts don't use it.  

Note to reviewers: best to review commit by commit and this is needed for 17.0.
