### PR TITLE
Fix not found error for web ssh session recordings

### DIFF
--- a/web/packages/teleport/src/Player/DesktopPlayer.tsx
+++ b/web/packages/teleport/src/Player/DesktopPlayer.tsx
@@ -69,7 +69,7 @@ export const DesktopPlayer = ({
     clusterId,
   });
 
-  const isError = playerStatus === StatusEnum.ERROR;
+  const isError = playerStatus === StatusEnum.ERROR || statusText !== '';
   const isLoading = playerStatus === StatusEnum.LOADING;
   const isPlaying = playerStatus === StatusEnum.PLAYING;
   const isComplete = isError || playerStatus === StatusEnum.COMPLETE;

--- a/web/packages/teleport/src/Player/SshPlayer.tsx
+++ b/web/packages/teleport/src/Player/SshPlayer.tsx
@@ -34,7 +34,11 @@ export default function Player({ sid, clusterId, durationMs }) {
     clusterId,
     sid
   );
-  const isError = playerStatus === StatusEnum.ERROR;
+
+  // statusText is currently only set when an error happens, so for now we can assume
+  // if it is not empty, an error occured (even if the player is in COMPLETE state, which gets
+  // set on close)
+  const isError = playerStatus === StatusEnum.ERROR || statusText !== '';
   const isLoading = playerStatus === StatusEnum.LOADING;
   const isPlaying = playerStatus === StatusEnum.PLAYING;
   const isComplete = isError || playerStatus === StatusEnum.COMPLETE;


### PR DESCRIPTION
This adds an error message to the web UI if a session recording isn't found
![Screenshot 2024-11-12 at 1 39 48 PM](https://github.com/user-attachments/assets/ef6eb916-c764-42bd-94fd-bf3828435b84)

Fixes: https://github.com/gravitational/teleport/issues/48395