### PR TITLE
[v16] Add xterm/image-addon to web terminal

### DIFF
--- a/lib/httplib/httpheaders.go
+++ b/lib/httplib/httpheaders.go
@@ -198,6 +198,10 @@ var desktopSessionRe = regexp.MustCompile(`^/web/cluster/[^/]+/desktops/[^/]+/[^
 // which is a route to a desktop recording that uses WASM.
 var recordingRe = regexp.MustCompile(`^/web/cluster/[^/]+/session/[^/]+$`)
 
+// regex for the ssh terminal endpoint /web/cluster/:clusterId/console/node/:sid/:login
+// which is a route to a ssh session that uses WASM.
+var sshSessionRe = regexp.MustCompile(`^/web/cluster/[^/]+/console/node/[^/]+/[^/]+$`)
+
 var indexCSPStringCache *cspCache = newCSPCache()
 
 func getIndexContentSecurityPolicyString(cfg proto.Features, urlPath string) string {
@@ -209,7 +213,7 @@ func getIndexContentSecurityPolicyString(cfg proto.Features, urlPath string) str
 	}
 
 	// Nothing found in cache, calculate regex and result
-	withWasm := desktopSessionRe.MatchString(urlPath) || recordingRe.MatchString(urlPath)
+	withWasm := desktopSessionRe.MatchString(urlPath) || recordingRe.MatchString(urlPath) || sshSessionRe.MatchString(urlPath)
 	cspString := GetContentSecurityPolicyString(
 		getIndexContentSecurityPolicy(withStripe, withWasm),
 	)

--- a/lib/httplib/httplib_test.go
+++ b/lib/httplib/httplib_test.go
@@ -346,7 +346,24 @@ func TestSetIndexContentSecurityPolicy(t *testing.T) {
 			},
 		},
 		{
-			name:     "for cloud based usage & desktop session, Stripe managed product (with stripe, with wasm)",
+			name:     "for web ssh session (with wasm)",
+			features: proto.Features{},
+			urlPath:  "/web/cluster/:clusterId/console/node/:sessionId/:username",
+			expectedCspVals: map[string]string{
+				"default-src":     "'self'",
+				"base-uri":        "'self'",
+				"form-action":     "'self'",
+				"frame-ancestors": "'none'",
+				"object-src":      "'none'",
+				"script-src":      "'self' 'wasm-unsafe-eval'",
+				"style-src":       "'self' 'unsafe-inline'",
+				"img-src":         "'self' data: blob:",
+				"font-src":        "'self' data:",
+				"connect-src":     "'self' wss:",
+			},
+		},
+		{
+			name:     "for cloud based usage & desktop session, with wasm",
 			features: proto.Features{Cloud: true, IsUsageBased: true, IsStripeManaged: true},
 			urlPath:  "/web/cluster/:clusterId/desktops/:desktopName/:username",
 			expectedCspVals: map[string]string{

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,6 +363,9 @@ importers:
       '@xterm/addon-fit':
         specifier: ^0.10.0
         version: 0.10.0(@xterm/xterm@5.5.0)
+      '@xterm/addon-image':
+        specifier: ^0.8.0
+        version: 0.8.0(@xterm/xterm@5.5.0)
       '@xterm/addon-web-links':
         specifier: ^0.11.0
         version: 0.11.0(@xterm/xterm@5.5.0)
@@ -2930,6 +2933,11 @@ packages:
     resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
     peerDependencies:
       '@xterm/xterm': ^5.0.0
+
+  '@xterm/addon-image@0.8.0':
+    resolution: {integrity: sha512-b/dqpFn3jUad2pUP5UpF4scPIh0WdxRQL/1qyiahGfUI85XZTCXo0py9G6AcOR2QYUw8eJ8EowGspT7BQcgw6A==}
+    peerDependencies:
+      '@xterm/xterm': ^5.2.0
 
   '@xterm/addon-web-links@0.11.0':
     resolution: {integrity: sha512-nIHQ38pQI+a5kXnRaTgwqSHnX7KE6+4SVoceompgHL26unAxdfP6IPqUTSYPQgSwM56hsElfoNrrW5V7BUED/Q==}
@@ -11895,6 +11903,10 @@ snapshots:
       '@xterm/xterm': 5.5.0
 
   '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
+    dependencies:
+      '@xterm/xterm': 5.5.0
+
+  '@xterm/addon-image@0.8.0(@xterm/xterm@5.5.0)':
     dependencies:
       '@xterm/xterm': 5.5.0
 

--- a/web/packages/teleport/package.json
+++ b/web/packages/teleport/package.json
@@ -32,11 +32,12 @@
     "@opentelemetry/sdk-trace-base": "1.25.1",
     "@opentelemetry/sdk-trace-web": "1.25.1",
     "@opentelemetry/semantic-conventions": "1.25.1",
-    "@xterm/xterm": "^5.5.0",
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-image": "^0.8.0",
     "@xterm/addon-web-links": "^0.11.0",
     "@xterm/addon-webgl": "^0.18.0",
+    "@xterm/xterm": "^5.5.0",
     "create-react-class": "^15.6.3",
     "events": "3.3.0"
   },

--- a/web/packages/teleport/src/lib/term/terminal.ts
+++ b/web/packages/teleport/src/lib/term/terminal.ts
@@ -19,6 +19,7 @@
 import '@xterm/xterm/css/xterm.css';
 import { ITheme, Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
+import { ImageAddon } from '@xterm/addon-image';
 import { WebglAddon } from '@xterm/addon-webgl';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import { CanvasAddon } from '@xterm/addon-canvas';
@@ -50,6 +51,7 @@ export default class TtyTerminal {
   _convertEol: boolean;
   _debouncedResize: DebouncedFunc<() => void>;
   _fitAddon = new FitAddon();
+  _imageAddon = new ImageAddon();
   _webLinksAddon = new WebLinksAddon();
   _webglAddon: WebglAddon;
   _canvasAddon = new CanvasAddon();
@@ -88,6 +90,7 @@ export default class TtyTerminal {
 
     this.term.loadAddon(this._fitAddon);
     this.term.loadAddon(this._webLinksAddon);
+    this.term.loadAddon(this._imageAddon);
     // handle context loss and load webgl addon
     try {
       // try to create a new WebglAddon. If webgl is not supported, this
@@ -155,6 +158,7 @@ export default class TtyTerminal {
     this._disconnect();
     this._debouncedResize.cancel();
     this._fitAddon.dispose();
+    this._imageAddon.dispose();
     this._webglAddon?.dispose();
     this._canvasAddon?.dispose();
     this._el.innerHTML = null;


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/48780 and https://github.com/gravitational/teleport/pull/48849

changelog: The web terminal now supports SIXEL and IIP image protocols.