### PR TITLE
Simplify Lint (Docs)

### DIFF
--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -44,8 +44,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          repository: "gravitational/docs"
-          path: "docs"
+          repository: 'gravitational/teleport'
+          path: 'teleport'
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: 'gravitational/docs'
+          path: 'docs'
 
       # Cache node_modules. Unlike the example in the actions/cache repo, this
       # caches the node_modules directory instead of the yarn cache. This is
@@ -69,6 +75,7 @@ jobs:
         run: yarn install
 
       - name: Prepare docs site configuration
+        working-directory: docs
         # The environment we use for linting the docs differs from the one we
         # use for the live docs site in that we only test a single version of
         # the content.
@@ -83,34 +90,24 @@ jobs:
         # of gravitational/teleport. We override this in order to build only a
         # single version of the docs.
         run: |
-          if [ $GITHUB_EVENT_NAME = "pull_request" ]; then
-            BRANCH=$GITHUB_HEAD_REF;
-          elif [ $GITHUB_EVENT_NAME = "merge_group" ]; then
-            # GitHub populates $GITHUB_REF with:
-            # refs/heads/gh-readonly-queue/<base branch>/pr-<PR number>-<SHA>
-            #
-            # We strip the "refs/heads/" prefix so we can check out the branch.
-            BRANCH=$(echo $GITHUB_REF | sed -E "s|refs/heads/(.*)|\1|")
-          else
-            echo "Unexpected event name: $GITHUB_EVENT_NAME";
-            exit 1;
-          fi
-
-          cd $GITHUB_WORKSPACE/docs
           echo "" > .gitmodules
           rm -rf content/*
           cd content
-          # Add a submodule at docs/content/teleport
-          git submodule add --force -b $BRANCH -- https://github.com/gravitational/teleport
+          # Rather than using a submodule, copy the teleport source into the
+          # content directory.
+          cp -r $GITHUB_WORKSPACE/teleport $GITHUB_WORKSPACE/docs/content
           cd $GITHUB_WORKSPACE/docs
-          echo "{\"versions\": [{\"name\": \"teleport\", \"branch\": \"$BRANCH\", \"deprecated\": false}]}" > $GITHUB_WORKSPACE/docs/config.json
+          echo "{\"versions\": [{\"name\": \"teleport\", \"branch\": \"teleport\", \"deprecated\": false}]}" > $GITHUB_WORKSPACE/docs/config.json
+          cat <<< "$(jq '.scripts."git-update" = "echo Skipping submodule update"' package.json)" > package.json
           yarn build-node
 
       - name: Check spelling
-        run: cd $GITHUB_WORKSPACE/docs && yarn spellcheck content/teleport
+        working-directory: 'docs'
+        run: yarn spellcheck content/teleport
 
-      - name: Lint the docs
-        run: cd $GITHUB_WORKSPACE/docs && yarn markdown-lint
+      - name: Lint docs formatting
+        working-directory: 'docs'
+        run: yarn markdown-lint
 
       - name: Test the docs build
         working-directory: docs


### PR DESCRIPTION
Currently, `Lint (Docs)` configures git submodules for `gravitational/teleport` within a `gravitational/docs` clone based on the value of `$GITHUB_REF` or `$GITHUB_HEAD_REF` so it can fetch the submodules and build the docs.

This change checks out `gravitational/teleport` using `actions/checkout` instead, then copies the `teleport` clone into the `content` directory of the `docs` clone. This way, we don't need to extract a branch name, and can perform multiple checks on the `teleport` clone, e.g., the Vale linter when we add it to `Lint (Docs)`.