### PR TITLE
Web discover minor fixes

### DIFF
--- a/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.tsx
+++ b/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.tsx
@@ -246,7 +246,7 @@ export function AutoDeploy({ toggleDeployMethod }: DeployServiceProp) {
 
             <StyledBox mb={5}>
               <header>
-                <H3>Step 3 (Optional)</H3>
+                <H3>Step 3</H3>
               </header>
               <SelectSecurityGroups
                 selectedSecurityGroups={selectedSecurityGroups}

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/AgentWaitingDialog.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/AgentWaitingDialog.tsx
@@ -94,7 +94,9 @@ export function AgentWaitingDialog({
               - The Teleport Service could not join this Teleport cluster. Check
               the logs for errors by running
               <br />
-              <Mark>kubectl logs -l app=teleport-agent -n teleport-agent</Mark>
+              <Mark>
+                kubectl logs -l app=teleport-kube-agent -n teleport-agent
+              </Mark>
             </Text>
 
             <Text>

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.story.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.story.tsx
@@ -165,7 +165,6 @@ WithAwsPermissionsError.parameters = {
 };
 
 export const WithEnrollmentError = () => <Component />;
-
 WithEnrollmentError.parameters = {
   msw: {
     handlers: [
@@ -194,6 +193,39 @@ WithEnrollmentError.parameters = {
   },
 };
 
+export const WithAlreadyExistsError = () => (
+  <Component devInfoText="select any region, select EKS1 to see already exist error" />
+);
+WithAlreadyExistsError.parameters = {
+  msw: {
+    handlers: [
+      tokenHandler,
+      http.post(cfg.getListEKSClustersUrl(integrationName), () => {
+        {
+          return HttpResponse.json({ clusters: eksClusters });
+        }
+      }),
+      http.get(
+        cfg.getKubernetesUrl(getUserContext().cluster.clusterId, {}),
+        () => {
+          return HttpResponse.json({ items: kubeServers });
+        }
+      ),
+      http.post(cfg.getEnrollEksClusterUrl(integrationName), async () => {
+        await delay(1000);
+        return HttpResponse.json({
+          results: [
+            {
+              clusterName: 'EKS1',
+              error: 'teleport-kube-agent is already installed',
+            },
+          ],
+        });
+      }),
+    ],
+  },
+};
+
 export const WithOtherError = () => <Component />;
 
 WithOtherError.parameters = {
@@ -212,7 +244,7 @@ WithOtherError.parameters = {
   },
 };
 
-const Component = () => {
+const Component = ({ devInfoText = '' }) => {
   const ctx = createTeleportContext();
   const discoverCtx: DiscoverContextState = {
     agentMeta: {
@@ -268,7 +300,9 @@ const Component = () => {
           resourceKind={ResourceKind.Kubernetes}
         >
           <DiscoverProvider mockCtx={discoverCtx}>
-            <Info>Devs: Select any region to see story state</Info>
+            <Info>
+              {devInfoText || 'Devs: Select any region to see story state'}
+            </Info>
             <EnrollEksCluster
               nextStep={discoverCtx.nextStep}
               updateAgentMeta={discoverCtx.updateAgentMeta}

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.story.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.story.tsx
@@ -217,7 +217,7 @@ WithAlreadyExistsError.parameters = {
           results: [
             {
               clusterName: 'EKS1',
-              error: 'teleport-kube-agent is already installed',
+              error: 'teleport-kube-agent is already installed on the cluster',
             },
           ],
         });

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -313,7 +313,11 @@ export function EnrollEksCluster(props: AgentStepProps) {
           status: 'error',
           error: `Cluster enrollment error: ${result.error}`,
         };
-        if (result.error.includes('teleport-kube-agent is already installed')) {
+        if (
+          result.error.includes(
+            'teleport-kube-agent is already installed on the cluster'
+          )
+        ) {
           errorState.status = 'alreadyExists';
         }
         setEnrollmentState(errorState);

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollmentDialog.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollmentDialog.tsx
@@ -63,6 +63,7 @@ export function EnrollmentDialog({
         );
 
       case 'error':
+      case 'alreadyExists':
         return (
           <>
             <Flex mb={5} alignItems="center">
@@ -70,9 +71,11 @@ export function EnrollmentDialog({
               <Text>{error}</Text>
             </Flex>
             <Flex gap={4}>
-              <ButtonPrimary width="50%" onClick={retry}>
-                Retry
-              </ButtonPrimary>
+              {status === 'error' && (
+                <ButtonPrimary width="50%" onClick={retry}>
+                  Retry
+                </ButtonPrimary>
+              )}
               <ButtonSecondary width="50%" onClick={close}>
                 Close
               </ButtonSecondary>


### PR DESCRIPTION
resolves https://github.com/gravitational/teleport/issues/48844
resolves https://github.com/gravitational/teleport/issues/48802

- removes `optional` wording from RDS select security groups (it's required now)
- fixes `kubectl log` command, i suspect this was incorrect from very beginning
- when a teleport-agent already exists in a EKS cluster, show message that it already exists, instead of continously polling for a resource ID we don't know about (and will never resolve)

![image](https://github.com/user-attachments/assets/25ed5bc3-014b-4ceb-bd71-5e8b1bdada30)
