### PR TITLE
Refactor: Extract ErrProxyPublicAddressNotFound

### DIFF
--- a/lib/utils/oidc/issuer.go
+++ b/lib/utils/oidc/issuer.go
@@ -28,7 +28,11 @@ import (
 	"github.com/gravitational/teleport/api/types"
 )
 
-// ProxyGetter is a service that gets proxies.
+// ErrProxyPublicAddressNotFound is returned when the proxy public address is not found.
+// during IssuerForCluster call.
+var ErrProxyPublicAddressNotFound = trace.BadParameter("failed to get Proxy Public Address")
+
+// ProxiesGetter is a service that gets proxies.
 type ProxiesGetter interface {
 	// GetProxies returns a list of registered proxies.
 	GetProxies() ([]types.Server, error)
@@ -50,7 +54,7 @@ func IssuerForCluster(ctx context.Context, clt ProxiesGetter, path string) (stri
 		}
 	}
 
-	return "", trace.BadParameter("failed to get Proxy Public Address")
+	return "", ErrProxyPublicAddressNotFound
 }
 
 // IssuerFromPublicAddress is the address for an OIDC Provider.


### PR DESCRIPTION
### What

Extract the `ErrProxyPublicAddressNotFound` from the OIDC token generation error when the proxy is not available.

This is a corner case that can occur on a local, non-HA setup when plugin initialization (in an auth and proxy single-process setup) happens before the proxy service registers itself with the Teleport backend.

As a follow-up, the [GenerateAWSOIDCToken](https://github.com/gravitational/teleport/blob/master/lib/integrations/awsoidc/token_generator.go#L125) method should distinguish this error, attempt a retry, and handle it gracefully.