### PR TITLE
fix missing secret list permission for operator

### DIFF
--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/role.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/role.yaml
@@ -65,5 +65,6 @@ rules:
       - "secrets"
     verbs:
       - "get"
+      - "list"
 {{- end -}}
 {{- end -}}

--- a/examples/chart/teleport-cluster/charts/teleport-operator/tests/role_test.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/tests/role_test.yaml
@@ -49,4 +49,4 @@ tests:
           content:
             apiGroups: [""]
             resources: ["secrets"]
-            verbs: ["get"]
+            verbs: ["get", "list"]


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/48858

Changelog: fix a bug in the Teleport Operator chart that causes the operator to not be able to list secrets during secret injection.