### PR TITLE
reduce fluentd connection churn during high event-handler load

### DIFF
--- a/integrations/event-handler/cli.go
+++ b/integrations/event-handler/cli.go
@@ -46,6 +46,10 @@ type FluentdConfig struct {
 
 	// FluentdCA is a path to fluentd CA
 	FluentdCA string `help:"fluentd TLS CA file" type:"existingfile" env:"FDWRD_FLUENTD_CA"`
+
+	// FluentdMaxConnections caps the number of connections to fluentd. Defaults to a dynamic value
+	// calculated relative to app-level concurrency.
+	FluentdMaxConnections int `help:"Maximum number of connections to fluentd" env:"FDWRD_MAX_CONNECTIONS"`
 }
 
 // TeleportConfig is Teleport instance configuration
@@ -238,6 +242,11 @@ func (c *StartCmdConfig) Validate() error {
 	c.SkipSessionTypes = lib.SliceToAnonymousMap(c.SkipSessionTypesRaw)
 	c.SkipEventTypes = lib.SliceToAnonymousMap(c.SkipEventTypesRaw)
 
+	if c.FluentdMaxConnections < 1 {
+		// 2x concurrency is effectively uncapped.
+		c.FluentdMaxConnections = c.Concurrency * 2
+	}
+
 	return nil
 }
 
@@ -245,6 +254,7 @@ func (c *StartCmdConfig) Validate() error {
 func (c *StartCmdConfig) Dump(ctx context.Context, log *slog.Logger) {
 	// Log configuration variables
 	log.InfoContext(ctx, "Using batch size", "batch", c.BatchSize)
+	log.InfoContext(ctx, "Using concurrency", "concurrency", c.Concurrency)
 	log.InfoContext(ctx, "Using type filter", "types", c.Types)
 	log.InfoContext(ctx, "Using type exclude filter", "skip_event_types", c.SkipEventTypes)
 	log.InfoContext(ctx, "Skipping session events of type", "types", c.SkipSessionTypes)
@@ -255,6 +265,7 @@ func (c *StartCmdConfig) Dump(ctx context.Context, log *slog.Logger) {
 	log.InfoContext(ctx, "Using Fluentd ca", "ca", c.FluentdCA)
 	log.InfoContext(ctx, "Using Fluentd cert", "cert", c.FluentdCert)
 	log.InfoContext(ctx, "Using Fluentd key", "key", c.FluentdKey)
+	log.InfoContext(ctx, "Using Fluentd max connections", "max_connections", c.FluentdMaxConnections)
 	log.InfoContext(ctx, "Using window size", "window_size", c.WindowSize)
 
 	if c.TeleportIdentityFile != "" {

--- a/integrations/event-handler/cli_test.go
+++ b/integrations/event-handler/cli_test.go
@@ -45,11 +45,12 @@ func TestStartCmdConfig(t *testing.T) {
 				Debug: false,
 				Start: StartCmdConfig{
 					FluentdConfig: FluentdConfig{
-						FluentdURL:        "https://localhost:8888/test.log",
-						FluentdSessionURL: "https://localhost:8888/session",
-						FluentdCert:       filepath.Join(wd, "testdata", "fake-file"),
-						FluentdKey:        filepath.Join(wd, "testdata", "fake-file"),
-						FluentdCA:         filepath.Join(wd, "testdata", "fake-file"),
+						FluentdURL:            "https://localhost:8888/test.log",
+						FluentdSessionURL:     "https://localhost:8888/session",
+						FluentdCert:           filepath.Join(wd, "testdata", "fake-file"),
+						FluentdKey:            filepath.Join(wd, "testdata", "fake-file"),
+						FluentdCA:             filepath.Join(wd, "testdata", "fake-file"),
+						FluentdMaxConnections: 10,
 					},
 					TeleportConfig: TeleportConfig{
 						TeleportAddr:            "localhost:3025",
@@ -83,11 +84,12 @@ func TestStartCmdConfig(t *testing.T) {
 				Debug: true,
 				Start: StartCmdConfig{
 					FluentdConfig: FluentdConfig{
-						FluentdURL:        "https://localhost:8888/test.log",
-						FluentdSessionURL: "https://localhost:8888/session",
-						FluentdCert:       filepath.Join(wd, "testdata", "fake-file"),
-						FluentdKey:        filepath.Join(wd, "testdata", "fake-file"),
-						FluentdCA:         filepath.Join(wd, "testdata", "fake-file"),
+						FluentdURL:            "https://localhost:8888/test.log",
+						FluentdSessionURL:     "https://localhost:8888/session",
+						FluentdCert:           filepath.Join(wd, "testdata", "fake-file"),
+						FluentdKey:            filepath.Join(wd, "testdata", "fake-file"),
+						FluentdCA:             filepath.Join(wd, "testdata", "fake-file"),
+						FluentdMaxConnections: 10,
 					},
 					TeleportConfig: TeleportConfig{
 						TeleportAddr:            "localhost:3025",
@@ -121,11 +123,12 @@ func TestStartCmdConfig(t *testing.T) {
 				Debug: true,
 				Start: StartCmdConfig{
 					FluentdConfig: FluentdConfig{
-						FluentdURL:        "https://localhost:8888/test.log",
-						FluentdSessionURL: "https://localhost:8888/session",
-						FluentdCert:       filepath.Join(wd, "testdata", "fake-file"),
-						FluentdKey:        filepath.Join(wd, "testdata", "fake-file"),
-						FluentdCA:         filepath.Join(wd, "testdata", "fake-file"),
+						FluentdURL:            "https://localhost:8888/test.log",
+						FluentdSessionURL:     "https://localhost:8888/session",
+						FluentdCert:           filepath.Join(wd, "testdata", "fake-file"),
+						FluentdKey:            filepath.Join(wd, "testdata", "fake-file"),
+						FluentdCA:             filepath.Join(wd, "testdata", "fake-file"),
+						FluentdMaxConnections: 10,
 					},
 					TeleportConfig: TeleportConfig{
 						TeleportAddr:            "localhost:3025",

--- a/integrations/event-handler/fake_fluentd_test.go
+++ b/integrations/event-handler/fake_fluentd_test.go
@@ -123,9 +123,10 @@ func (f *FakeFluentd) createServer() error {
 // GetClientConfig returns FlientdConfig to connect to this fake fluentd server instance
 func (f *FakeFluentd) GetClientConfig() FluentdConfig {
 	return FluentdConfig{
-		FluentdCA:   f.caCertPath,
-		FluentdCert: f.clientCertPath,
-		FluentdKey:  f.clientKeyPath,
+		FluentdCA:             f.caCertPath,
+		FluentdCert:           f.clientCertPath,
+		FluentdKey:            f.clientKeyPath,
+		FluentdMaxConnections: 3,
 	}
 }
 

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/peterbourgon/diskv/v3 v3.0.1
 	github.com/sethvargo/go-limiter v1.0.0
 	github.com/stretchr/testify v1.9.0
+	golang.org/x/net v0.30.0
 	golang.org/x/time v0.7.0
 	google.golang.org/protobuf v1.35.1
 )
@@ -283,7 +284,6 @@ require (
 	golang.org/x/crypto v0.28.0 // indirect
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c // indirect
 	golang.org/x/mod v0.21.0 // indirect
-	golang.org/x/net v0.30.0 // indirect
 	golang.org/x/oauth2 v0.23.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/sys v0.26.0 // indirect


### PR DESCRIPTION
This PR fixes an issue where the teleport event handler could cause excess CPU usage and connection reset errors in Fluentd when under load.  Previously, the teleport event handler's Fluentd client would create unlimited outbound connections, but only ever retain a maximum of 2 idle connections.  This lead to frequent creation and destruction of TLS connections when the event handler was trying to send many concurrent events to Fluentd.  With these changes, the Fluentd client now both limits the peak connections, and allows all idle connections to persist up to 30s.

We've been aware for a while that the Fluentd client had a tendency toward connection churn, but it never caused any measurable issues in our performance tuning tests.  It turns out this was likely due to how our performance testing were being performed.  Our performance tuning is generally done with the intent to maximize event throughput for very massive teleport clusters (i.e. clusters with many tens of thousands of events per minute), and for that reason tend to be done with pretty beefy VMs running the exporter and Fluentd.  It seems that for whatever reason, it's only when running on smaller more resource-constrained machines that the churn issue really comes to the fore, causing up to a 4x slowdown in overall event throughput.

changelog: fixed issue resulting in excess cpu usage and connection resets when teleport-event-handler is under moderate to high load.