### PR TITLE
[v17] Use DB Client CA when connecting to SQL Server using PKINIT

### DIFF
--- a/lib/auth/db_test.go
+++ b/lib/auth/db_test.go
@@ -153,6 +153,7 @@ func TestDBCertSigning(t *testing.T) {
 	tests := []struct {
 		name           string
 		requester      proto.DatabaseCertRequest_Requester
+		extensions     proto.DatabaseCertRequest_Extensions
 		wantCertSigner []byte
 		wantCACerts    [][]byte
 		wantKeyUsage   []x509.ExtKeyUsage
@@ -170,16 +171,32 @@ func TestDBCertSigning(t *testing.T) {
 			wantCACerts:    [][]byte{activeDBClientCACert, newDBClientCACert},
 			wantKeyUsage:   []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		},
+		{
+			name:           "DB service request for SQL Server databases is signed by active db client and trusts db client CAs",
+			extensions:     proto.DatabaseCertRequest_WINDOWS_SMARTCARD,
+			wantCertSigner: activeDBClientCACert,
+			wantCACerts:    [][]byte{activeDBClientCACert, newDBClientCACert},
+			wantKeyUsage:   []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		},
+		{
+			name:           "tctl request for SQL Server databases is signed by new db CA and trusts db client CAs",
+			requester:      proto.DatabaseCertRequest_TCTL,
+			extensions:     proto.DatabaseCertRequest_WINDOWS_SMARTCARD,
+			wantCertSigner: newDBCACert,
+			wantCACerts:    [][]byte{activeDBClientCACert, newDBClientCACert},
+			wantKeyUsage:   []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			certResp, err := authServer.AuthServer.GenerateDatabaseCert(ctx, &proto.DatabaseCertRequest{
-				CSR:           csr,
-				ServerName:    "localhost",
-				TTL:           proto.Duration(time.Hour),
-				RequesterName: tt.requester,
+				CSR:                   csr,
+				ServerName:            "localhost",
+				TTL:                   proto.Duration(time.Hour),
+				RequesterName:         tt.requester,
+				CertificateExtensions: tt.extensions,
 			})
 			require.NoError(t, err)
 			require.Equal(t, tt.wantCACerts, certResp.CACerts)


### PR DESCRIPTION
Backport #48772 to branch/v17

changelog: Fixed users not being able to connect to SQL server instances with PKINIT integration when the cluster is configured with different CAs for database access.
