### PR TITLE
Web: add aws oidc integration health check before editing and when selecting in discover

### DIFF
--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -1454,6 +1454,10 @@ func (h *Handler) awsOIDCPing(w http.ResponseWriter, r *http.Request, p httprout
 		return nil, trace.Wrap(err)
 	}
 
+	if req.RoleARN != "" {
+		integrationName = ""
+	}
+
 	pingResp, err := clt.IntegrationAWSOIDCClient().Ping(ctx, &integrationv1.PingRequest{
 		Integration: integrationName,
 		RoleArn:     req.RoleARN,

--- a/web/packages/teleport/src/Discover/Shared/AwsAccount/AwsAccount.test.tsx
+++ b/web/packages/teleport/src/Discover/Shared/AwsAccount/AwsAccount.test.tsx
@@ -18,7 +18,7 @@
 
 import React from 'react';
 import { MemoryRouter } from 'react-router';
-import { render, screen, userEvent } from 'design/utils/testing';
+import { render, screen, fireEvent } from 'design/utils/testing';
 
 import { ContextProvider } from 'teleport';
 import {
@@ -46,7 +46,6 @@ import { ResourceSpec } from 'teleport/Discover/SelectResource';
 import { ResourceKind } from '../ResourceKind';
 
 import { AwsAccount } from './AwsAccount';
-import { findByText, fireEvent } from '@testing-library/react';
 
 beforeEach(() => {
   jest.spyOn(integrationService, 'fetchIntegrations').mockResolvedValue({

--- a/web/packages/teleport/src/Discover/Shared/AwsAccount/AwsAccount.tsx
+++ b/web/packages/teleport/src/Discover/Shared/AwsAccount/AwsAccount.tsx
@@ -70,7 +70,11 @@ export function AwsAccount() {
     eventState,
     resourceSpec,
     currentStep,
+    emitErrorEvent,
   } = useDiscover();
+
+  const [selectedAwsIntegration, setSelectedAwsIntegration] =
+    useState<Option>();
 
   // if true, requires an additional step where we fetch for
   // apps matching fetched aws integrations to determine
@@ -97,6 +101,18 @@ export function AwsAccount() {
       }
       return response;
     }, [clusterId, isAddingAwsApp])
+  );
+
+  const [healthCheckAttempt, healthCheckSelectedIntegration] = useAsync(
+    async () => {
+      await integrationService.pingAwsOidcIntegration(
+        {
+          clusterId,
+          integrationName: selectedAwsIntegration.value.name,
+        },
+        { roleArn: '' }
+      );
+    }
   );
 
   const integrationAccess = storeUser.getIntegrationsAccess();
@@ -136,9 +152,6 @@ export function AwsAccount() {
       appAccess.list &&
       appAccess.read;
   }
-
-  const [selectedAwsIntegration, setSelectedAwsIntegration] =
-    useState<Option>();
 
   useEffect(() => {
     if (hasAccess && attempt.status === '') {
@@ -193,8 +206,14 @@ export function AwsAccount() {
     );
   }
 
-  function proceedWithExistingIntegration(validator: Validator) {
+  async function proceedWithExistingIntegration(validator: Validator) {
     if (!validator.validate()) {
+      return;
+    }
+
+    const [, err] = await healthCheckSelectedIntegration();
+    if (err) {
+      emitErrorEvent(`failed to health check selected aws integration: ${err}`);
       return;
     }
 
@@ -250,6 +269,12 @@ export function AwsAccount() {
   return (
     <Box maxWidth="700px">
       <Heading />
+      {healthCheckAttempt.status === 'error' && (
+        <Alert
+          kind="danger"
+          children={`Health check failed for the selected AWS integration: ${healthCheckAttempt.statusText}`}
+        />
+      )}
       <Box mb={3}>
         <Validation>
           {({ validator }) => (
@@ -289,7 +314,11 @@ export function AwsAccount() {
               <ActionButtons
                 onPrev={prevStep}
                 onProceed={() => proceedWithExistingIntegration(validator)}
-                disableProceed={!hasAwsIntegrations || !selectedAwsIntegration}
+                disableProceed={
+                  !hasAwsIntegrations ||
+                  !selectedAwsIntegration ||
+                  healthCheckAttempt.status === 'processing'
+                }
               />
             </>
           )}

--- a/web/packages/teleport/src/Integrations/EditAwsOidcIntegrationDialog.test.tsx
+++ b/web/packages/teleport/src/Integrations/EditAwsOidcIntegrationDialog.test.tsx
@@ -15,16 +15,21 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { useEffect } from 'react';
 import { render, screen, fireEvent, waitFor } from 'design/utils/testing';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
 
 import {
   Integration,
   IntegrationKind,
+  integrationService,
   IntegrationStatusCode,
 } from 'teleport/services/integrations';
+import cfg from 'teleport/config';
 
 import { EditAwsOidcIntegrationDialog } from './EditAwsOidcIntegrationDialog';
+import { useIntegrationOperation } from './Operations';
 
 test('user acknowledging script was ran when reconfiguring', async () => {
   render(
@@ -95,6 +100,46 @@ test('user acknowledging script was ran when reconfiguring', async () => {
   await waitFor(() =>
     expect(screen.getByRole('button', { name: /reconfigure/i })).toBeEnabled()
   );
+});
+
+test('health check is called before calling update', async () => {
+  const spyPing = jest
+    .spyOn(integrationService, 'pingAwsOidcIntegration')
+    .mockResolvedValue({} as any); // response doesn't matter
+
+  const spyUpdate = jest
+    .spyOn(integrationService, 'updateIntegration')
+    .mockResolvedValue({} as any); // response doesn't matter
+
+  render(
+    <MemoryRouter initialEntries={[cfg.getClusterRoute('some-cluster')]}>
+      <ComponentWithEditOperation />
+    </MemoryRouter>
+  );
+
+  // change role arn
+  fireEvent.change(screen.getByPlaceholderText(/arn:aws:iam:/i), {
+    target: { value: 'arn:aws:iam::123456789011:role/other' },
+  });
+
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: /reconfigure/i })).toBeEnabled()
+  );
+  await userEvent.click(screen.getByRole('button', { name: /reconfigure/i }));
+
+  // Click on checkbox to enable save button.
+  await userEvent.click(screen.getByRole('checkbox'));
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: /save/i })).toBeEnabled()
+  );
+  await userEvent.click(screen.getByRole('button', { name: /save/i }));
+
+  await waitFor(() => expect(spyPing).toHaveBeenCalledTimes(1));
+  await waitFor(() => expect(spyUpdate).toHaveBeenCalledTimes(1));
+
+  const pingOrder = spyPing.mock.invocationCallOrder[0];
+  const createOrder = spyUpdate.mock.invocationCallOrder[0];
+  expect(pingOrder).toBeLessThan(createOrder);
 });
 
 test('render warning when s3 buckets are present', async () => {
@@ -205,7 +250,7 @@ test('edit submit called with proper fields', async () => {
   await userEvent.click(screen.getByRole('button', { name: /save/i }));
   await waitFor(() => expect(mockEditFn).toHaveBeenCalledTimes(1));
 
-  expect(mockEditFn).toHaveBeenCalledWith({
+  expect(mockEditFn).toHaveBeenCalledWith(integration, {
     roleArn: 'arn:aws:iam::123456789011:role/other',
   });
 });
@@ -221,3 +266,18 @@ const integration: Integration = {
   },
   statusCode: IntegrationStatusCode.Running,
 };
+
+function ComponentWithEditOperation() {
+  const integrationOps = useIntegrationOperation();
+  useEffect(() => {
+    integrationOps.onEdit(integration);
+  }, []);
+
+  return (
+    <EditAwsOidcIntegrationDialog
+      close={() => null}
+      edit={(integration, req) => integrationOps.edit(integration, req).then()}
+      integration={integration}
+    />
+  );
+}

--- a/web/packages/teleport/src/Integrations/EditAwsOidcIntegrationDialog.tsx
+++ b/web/packages/teleport/src/Integrations/EditAwsOidcIntegrationDialog.tsx
@@ -34,13 +34,13 @@ import Dialog, {
   DialogFooter,
 } from 'design/DialogConfirmation';
 import { OutlineInfo, OutlineWarn } from 'design/Alert/Alert';
-import useAttempt from 'shared/hooks/useAttemptNext';
 import FieldInput from 'shared/components/FieldInput';
 import Validation, { Validator } from 'shared/components/Validation';
 import { requiredRoleArn } from 'shared/components/Validation/rules';
 import { TextSelectCopyMulti } from 'shared/components/TextSelectCopy';
 
 import { FieldCheckbox } from 'shared/components/FieldCheckbox';
+import { useAsync } from 'shared/hooks/useAsync';
 
 import {
   Integration,
@@ -54,24 +54,26 @@ import { S3BucketConfiguration } from './Enroll/AwsOidc/S3BucketConfiguration';
 
 type Props = {
   close(): void;
-  edit(req: EditableIntegrationFields): Promise<void>;
+  edit(integration: Integration, req: EditableIntegrationFields): Promise<void>;
   integration: Integration;
 };
 
 export function EditAwsOidcIntegrationDialog(props: Props) {
   const { close, edit, integration } = props;
-  const { attempt, run } = useAttempt();
+  const [updateAttempt, runUpdate] = useAsync(async () => {
+    await edit(integration, { roleArn });
+  });
 
   const [roleArn, setRoleArn] = useState(integration.spec.roleArn);
   const [scriptUrl, setScriptUrl] = useState('');
   const [confirmed, setConfirmed] = useState(false);
 
-  function handleEdit(validator: Validator) {
+  async function handleEdit(validator: Validator) {
     if (!validator.validate()) {
       return;
     }
 
-    run(() => edit({ roleArn }));
+    await runUpdate();
   }
 
   function generateAwsOidcConfigIdpScript(
@@ -100,7 +102,7 @@ export function EditAwsOidcIntegrationDialog(props: Props) {
   const s3Prefix = integration.spec.issuerS3Prefix;
   const showReadonlyS3Fields = s3Bucket || s3Prefix;
 
-  const isProcessing = attempt.status === 'processing';
+  const isProcessing = updateAttempt.status === 'processing';
   const showGenerateCommand =
     integration.spec.roleArn !== roleArn || showReadonlyS3Fields;
 
@@ -122,8 +124,8 @@ export function EditAwsOidcIntegrationDialog(props: Props) {
             <DialogTitle>Edit Integration</DialogTitle>
           </DialogHeader>
           <DialogContent width="650px">
-            {attempt.status === 'failed' && (
-              <Alert children={attempt.statusText} />
+            {updateAttempt.status === 'error' && (
+              <Alert children={updateAttempt.statusText} />
             )}
             <FieldInput
               label="Integration Name"
@@ -238,6 +240,7 @@ export function EditAwsOidcIntegrationDialog(props: Props) {
                 onChange={e => {
                   setConfirmed(e.target.checked);
                 }}
+                disabled={isProcessing}
               />
             )}
             <ButtonPrimary

--- a/web/packages/teleport/src/Integrations/Enroll/AwsOidc/useAwsOidcIntegration.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsOidc/useAwsOidcIntegration.tsx
@@ -19,7 +19,11 @@
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router';
 import { Validator } from 'shared/components/Validation';
-import { useAsync } from 'shared/hooks/useAsync';
+import {
+  makeErrorAttempt,
+  makeProcessingAttempt,
+  useAsync,
+} from 'shared/hooks/useAsync';
 
 import { DiscoverUrlLocationState } from 'teleport/Discover/useDiscover';
 import {
@@ -36,6 +40,8 @@ import {
   integrationService,
   AwsOidcPolicyPreset,
 } from 'teleport/services/integrations';
+import useStickyClusterId from 'teleport/useStickyClusterId';
+import { ApiError } from 'teleport/services/api/parseError';
 
 type integrationConfig = {
   name: string;
@@ -53,6 +59,7 @@ export function useAwsOidcIntegration() {
   );
   const [scriptUrl, setScriptUrl] = useState('');
   const [createdIntegration, setCreatedIntegration] = useState<Integration>();
+  const { clusterId } = useStickyClusterId();
 
   const location = useLocation<DiscoverUrlLocationState>();
 
@@ -80,17 +87,46 @@ export function useAwsOidcIntegration() {
     });
   }
 
-  const [createIntegrationAttempt, runCreateIntegration] = useAsync(
-    async (req: IntegrationCreateRequest) => {
-      const resp = await integrationService.createIntegration(req);
-      setCreatedIntegration(resp);
-      return resp;
-    }
-  );
+  const [
+    createIntegrationAttempt,
+    runCreateIntegration,
+    setCreateIntegrationAttempt,
+  ] = useAsync(async (req: IntegrationCreateRequest) => {
+    const resp = await integrationService.createIntegration(req);
+    setCreatedIntegration(resp);
+    return resp;
+  });
 
   async function handleOnCreate(validator: Validator) {
     if (!validator.validate()) {
       return;
+    }
+    setCreateIntegrationAttempt(makeProcessingAttempt());
+
+    try {
+      await integrationService.pingAwsOidcIntegration(
+        {
+          integrationName: integrationConfig.name,
+          clusterId,
+        },
+        { roleArn: integrationConfig.roleArn }
+      );
+    } catch (err) {
+      // DELETE IN v18.0
+      // Ignore not found error and just allow it to create which
+      // is how it used to work before anyways.
+      //
+      // If this request went to an older proxy, that didn't set the
+      // the integrationName empty if roleArn isn't empty, then the backend
+      // will never be able to successfully health check b/c it expects
+      // integration to exist first before creating.
+      const isNotFoundErr =
+        err instanceof ApiError && err.response.status === 404;
+
+      if (!isNotFoundErr) {
+        setCreateIntegrationAttempt(makeErrorAttempt(err));
+        return;
+      }
     }
 
     const [, err] = await runCreateIntegration({

--- a/web/packages/teleport/src/Integrations/Integrations.tsx
+++ b/web/packages/teleport/src/Integrations/Integrations.tsx
@@ -61,8 +61,11 @@ export function Integrations() {
     });
   }
 
-  function editIntegration(req: EditableIntegrationFields) {
-    return integrationOps.edit(req).then(updatedIntegration => {
+  function editIntegration(
+    integration: Integration,
+    req: EditableIntegrationFields
+  ) {
+    return integrationOps.edit(integration, req).then(updatedIntegration => {
       const updatedItems = items.map(item => {
         if (item.name == integrationOps.item.name) {
           return updatedIntegration;

--- a/web/packages/teleport/src/Integrations/Operations/IntegrationOperations.tsx
+++ b/web/packages/teleport/src/Integrations/Operations/IntegrationOperations.tsx
@@ -32,7 +32,7 @@ type Props = {
   operation: OperationType;
   integration: Integration;
   close(): void;
-  edit(req: EditableIntegrationFields): Promise<void>;
+  edit(integration: Integration, req: EditableIntegrationFields): Promise<void>;
   remove(): Promise<void>;
 };
 

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -314,6 +314,8 @@ const cfg = {
 
     integrationsPath: '/v1/webapi/sites/:clusterId/integrations/:name?',
     thumbprintPath: '/v1/webapi/thumbprint',
+    pingAwsOidcIntegrationPath:
+      '/v1/webapi/sites/:clusterId/integrations/aws-oidc/:name/ping',
 
     awsConfigureIamScriptOidcIdpPath:
       '/v1/webapi/scripts/integrations/configure/awsoidc-idp.sh?integrationName=:integrationName&role=:roleName&policyPreset=:policyPreset?',
@@ -953,6 +955,19 @@ const cfg = {
     // Currently you can only create integrations at the root cluster.
     const clusterId = cfg.proxyCluster;
     return generatePath(cfg.api.integrationsPath, {
+      clusterId,
+      name: integrationName,
+    });
+  },
+
+  getPingAwsOidcIntegrationUrl({
+    integrationName,
+    clusterId,
+  }: {
+    integrationName: string;
+    clusterId: string;
+  }) {
+    return generatePath(cfg.api.pingAwsOidcIntegrationPath, {
       clusterId,
       name: integrationName,
     });

--- a/web/packages/teleport/src/services/integrations/integrations.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.ts
@@ -57,6 +57,8 @@ import {
   ListAwsSubnetsResponse,
   Subnet,
   AwsDatabaseVpcsResponse,
+  AwsOidcPingResponse,
+  AwsOidcPingRequest,
 } from './types';
 
 export const integrationService = {
@@ -76,6 +78,16 @@ export const integrationService = {
 
   createIntegration(req: IntegrationCreateRequest): Promise<Integration> {
     return api.post(cfg.getIntegrationsUrl(), req).then(makeIntegration);
+  },
+
+  pingAwsOidcIntegration(
+    urlParams: {
+      integrationName: string;
+      clusterId: string;
+    },
+    req: AwsOidcPingRequest
+  ): Promise<AwsOidcPingResponse> {
+    return api.post(cfg.getPingAwsOidcIntegrationUrl(urlParams), req);
   },
 
   updateIntegration(

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -83,6 +83,23 @@ export type IntegrationSpecAwsOidc = {
   audience?: IntegrationAudience;
 };
 
+export type AwsOidcPingRequest = {
+  // Define roleArn if the ping request should
+  // use this potentially new roleArn to test the
+  // connection works, typically used with updates.
+  //
+  // Leave empty if the ping request should
+  // use the roleArn stored in the integration resource,
+  // typically used when checking integration still works.
+  roleArn?: string;
+};
+
+export type AwsOidcPingResponse = {
+  accountId: string;
+  arn: string;
+  userId: string;
+};
+
 export enum IntegrationStatusCode {
   Unknown = 0,
   Running = 1,


### PR DESCRIPTION
resolves https://github.com/gravitational/teleport/issues/45703

- Adds health check with the edited `roleArn` to validate that this new `roleArn` connection works. If it fails, the edits are not saved
- Adds health check after user clicks `next` after `selecting` an existing aws oidc integration from a drop down for discover flows that requires this integration. If it fails, it prevents user from going to the next step (and also emits error event)
- Adds health check before user `creates` an integration. If it fails, integration will not be created. There is a caveat: the backend expects an empty integration name if we want to health check a non-existing integration. Older proxies will NOT set this field empty, so I also put a check in frontend that if health check returned a `404` we ignore this error and just let the integration be created.

demo of editing and selecting non-working aws integration:

https://github.com/user-attachments/assets/a6cd18eb-f405-43f9-83c1-b234b09b4935

tested with my staging that:
- using an older proxy, pinging returns 404, but still allows me to create
- using the newer proxy, ping error prevents me from creating
- using the newer proxy, successful ping allows me to create and use integration
