### PR TITLE
docs: include peer as join session mode in access role ref

### DIFF
--- a/docs/pages/includes/role-spec.mdx
+++ b/docs/pages/includes/role-spec.mdx
@@ -388,7 +388,7 @@ spec:
           # generates a role name from the value capture
           roles: ['$1-admin']
 
-      # Teleport can attach annotations to pending Access Requests. these
+      # Teleport can attach annotations to pending Access Requests. These
       # annotations may be literals, or be variable interpolation expressions,
       # effectively creating a means for propagating selected claims from an
       # external identity provider to the plugin system.
@@ -426,7 +426,7 @@ spec:
         # The different session kinds this policy applies to.
         kinds: ['k8s', 'ssh']
         # The list of session participant modes the role may join the session as.
-        modes: ['moderator', 'observer']
+        modes: ['moderator', 'observer', 'peer']
 
     # spiffe is a list of SPIFFE IDs that the role holder is allowed to request
     # SVIDs for. As long as the request matches one of the blocks within the


### PR DESCRIPTION
`peer` was not included as a mode in the reference.