### PR TITLE
[entraid] set all optional claims to avoid weird behavior

### DIFF
--- a/lib/integrations/azureoidc/provision_sso.go
+++ b/lib/integrations/azureoidc/provision_sso.go
@@ -52,6 +52,18 @@ func setupSSO(ctx context.Context, graphClient *msgraph.Client, appObjectID stri
 	*securityGroups = "SecurityGroup"
 	app.GroupMembershipClaims = securityGroups
 
+	claimName := "groups"
+	optionalClaim := []msgraph.OptionalClaim{
+		{
+			Name: &claimName,
+		},
+	}
+	app.OptionalClaims = &msgraph.OptionalClaims{
+		IDToken:     optionalClaim,
+		SAML2Token:  optionalClaim,
+		AccessToken: optionalClaim,
+	}
+
 	err = graphClient.UpdateApplication(ctx, appObjectID, app)
 
 	if err != nil {

--- a/lib/msgraph/client_test.go
+++ b/lib/msgraph/client_test.go
@@ -536,6 +536,8 @@ func TestGetApplication(t *testing.T) {
 		GroupMembershipClaims: toPtr("SecurityGroup"),
 		IdentifierURIs:        &[]string{"goteleport.com"},
 		OptionalClaims: &OptionalClaims{
+			AccessToken: []OptionalClaim{},
+			IDToken:     []OptionalClaim{},
 			SAML2Token: []OptionalClaim{
 				{
 					AdditionalProperties: []string{"sam_account_name"},

--- a/lib/msgraph/models.go
+++ b/lib/msgraph/models.go
@@ -109,9 +109,10 @@ type OptionalClaim struct {
 }
 
 // OptionalClaims represents optional claims in a token.
-// Currently, only SAML2 tokens are supported.
 type OptionalClaims struct {
-	SAML2Token []OptionalClaim `json:"saml2Token,omitempty"`
+	IDToken     []OptionalClaim `json:"idToken,omitempty"`
+	AccessToken []OptionalClaim `json:"accessToken,omitempty"`
+	SAML2Token  []OptionalClaim `json:"saml2Token,omitempty"`
 }
 
 type WebApplication struct {


### PR DESCRIPTION
Entra sometimes sends the OptionClaims when retrieving a certain application if only SAML2Token is set, other times it doesn't return them.

This PR fills all id and access token values so entra doesn't fail to send the optional token value.