### PR TITLE
Remove extra awaits from useAccessRequestCheckout tests

### DIFF
--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.test.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.test.tsx
@@ -135,7 +135,7 @@ test(`fetching requestable roles for a kube cluster's namespaces only creates re
       resource: kube2,
     });
 
-  await appContext.workspacesService
+  appContext.workspacesService
     .getWorkspaceAccessRequestsService(rootClusterUri)
     .updateNamespacesForKubeCluster(
       [
@@ -230,14 +230,14 @@ test('after creating an access request, pending requests and specifiable fields 
     wrapper,
   });
 
-  await act(() =>
+  act(() =>
     result.current.setSelectedReviewers([{ value: 'bob', label: 'bob' }])
   );
   expect(result.current.selectedReviewers).toEqual([
     { value: 'bob', label: 'bob' },
   ]);
 
-  await act(() =>
+  act(() =>
     result.current.setSelectedResourceRequestRoles(['apple', 'banana'])
   );
   expect(result.current.selectedResourceRequestRoles).toEqual([
@@ -335,6 +335,18 @@ test('updating kube namespaces', async () => {
     wrapper,
   });
 
+  // useAccessRequestCheckout has an effect which fires each time pendingAccessRequestRequest is
+  // updated. This means that after every call to updateNamespacesForKubeCluster we have to wait for
+  // fetchResourceRolesAttempt to finish, otherwise we get errors about state updates not being
+  // wrapped in act.
+  const waitForFetchingResourceRoles = () =>
+    waitFor(() => {
+      expect(result.current.fetchResourceRolesAttempt.status).toEqual(
+        'success'
+      );
+    });
+  await waitForFetchingResourceRoles();
+
   const kubeItem: PendingListKubeClusterWithOriginalItem = {
     kind: 'kube_cluster',
     clusterName: 'local',
@@ -349,7 +361,7 @@ test('updating kube namespaces', async () => {
   };
 
   // Test order of request are retained.
-  await act(() =>
+  act(() =>
     result.current.updateNamespacesForKubeCluster(
       [
         {
@@ -377,13 +389,14 @@ test('updating kube namespaces', async () => {
       kubeItem
     )
   );
+  await waitForFetchingResourceRoles();
   let savedRequestIds = result.current.pendingAccessRequests
     .filter(r => r.kind === 'namespace')
     .map(r => r.subResourceName);
   expect(savedRequestIds).toEqual(['n3', 'n2', 'n1']);
 
   // Test order of request are retained a second time.
-  await act(() =>
+  act(() =>
     result.current.updateNamespacesForKubeCluster(
       [
         {
@@ -411,39 +424,40 @@ test('updating kube namespaces', async () => {
       kubeItem
     )
   );
+  await waitForFetchingResourceRoles();
   savedRequestIds = result.current.pendingAccessRequests
     .filter(r => r.kind === 'namespace')
     .map(r => r.subResourceName);
   expect(savedRequestIds).toEqual(['n2', 'n1', 'n3']);
 
   // Test empty request clears request.
-  await act(() => result.current.updateNamespacesForKubeCluster([], kubeItem));
+  act(() => result.current.updateNamespacesForKubeCluster([], kubeItem));
+  await waitForFetchingResourceRoles();
   savedRequestIds = result.current.pendingAccessRequests
     .filter(r => r.kind === 'namespace')
     .map(r => r.subResourceName);
   expect(savedRequestIds).toEqual([]);
 
   // Test invalid request.
-  await expect(
-    async () =>
-      await result.current.updateNamespacesForKubeCluster(
-        [
-          {
-            kind: 'namespace',
-            clusterName: 'local',
-            id: kube1.name,
-            name: 'n2',
-            subResourceName: 'n2',
-          },
-          {
-            kind: 'namespace',
-            clusterName: 'local',
-            id: 'some-id-of-different-kube-cluster-which-is-invalid',
-            name: 'n1',
-            subResourceName: 'n1',
-          },
-        ],
-        kubeItem
-      )
-  ).rejects.toThrow();
+  expect(() => {
+    result.current.updateNamespacesForKubeCluster(
+      [
+        {
+          kind: 'namespace',
+          clusterName: 'local',
+          id: kube1.name,
+          name: 'n2',
+          subResourceName: 'n2',
+        },
+        {
+          kind: 'namespace',
+          clusterName: 'local',
+          id: 'some-id-of-different-kube-cluster-which-is-invalid',
+          name: 'n1',
+          subResourceName: 'n1',
+        },
+      ],
+      kubeItem
+    );
+  }).toThrow(/the same requested kube cluster can be updated/);
 });


### PR DESCRIPTION
A little change as described in https://github.com/gravitational/teleport/pull/48786#discussion_r1840285100.