### PR TITLE
[v15] [buddy] feat(helm-teleport-cluster): allow to override enterprise license name

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -606,6 +606,22 @@ $ kubectl --namespace teleport create secret generic license --from-file=/path/t
   enterprise: true
   ```
 
+### `licenseSecretName`
+
+| Type     | Default value  |
+|----------|----------------|
+| `string` | `license`      |
+
+`licenseSecretName` controls Kubernetes secret name for the Enterprise license.
+
+By using this value you will update the Kubernetes volume specification to mount Secret based volume to the container using custom name.
+
+`values.yaml` example:
+
+  ```yaml
+  licenseSecretName: enterprise-license
+  ```
+
 ## `installCRDs`
 
 | Type   | Default value |

--- a/examples/chart/teleport-cluster/.lint/auth-enterprise-license.yaml
+++ b/examples/chart/teleport-cluster/.lint/auth-enterprise-license.yaml
@@ -1,0 +1,4 @@
+clusterName: helm-lint
+enterprise: true
+licenseSecretName: enterprise-license
+

--- a/examples/chart/teleport-cluster/templates/auth/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/deployment.yaml
@@ -266,7 +266,7 @@ spec:
 {{- if $auth.enterprise }}
       - name: license
         secret:
-          secretName: "license"
+          secretName: {{ $auth.licenseSecretName | quote }}
 {{- end }}
 {{- if and ($auth.gcp.credentialSecretName) (eq $auth.chartMode "gcp") }}
       - name: gcp-credentials

--- a/examples/chart/teleport-cluster/templates/auth/predeploy_job.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/predeploy_job.yaml
@@ -84,7 +84,7 @@ spec:
 {{- if .Values.enterprise }}
       - name: license
         secret:
-          secretName: "license"
+          secretName: {{ .Values.licenseSecretName | quote }}
 {{- end }}
 {{- if and (.Values.gcp.credentialSecretName) (eq .Values.chartMode "gcp") }}
       - name: gcp-credentials

--- a/examples/chart/teleport-cluster/tests/auth_deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_deployment_test.yaml
@@ -215,6 +215,30 @@ tests:
             secret:
               secretName: license
 
+  - it: should use enterprise image and mount license with custom secret name when enterprise is set in values
+    template: auth/deployment.yaml
+    set:
+      clusterName: helm-lint.example.com
+      enterprise: true
+      licenseSecretName: enterprise-license
+      teleportVersionOverride: 12.2.1
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: public.ecr.aws/gravitational/teleport-ent-distroless:12.2.1
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /var/lib/license
+            name: "license"
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: license
+            secret:
+              secretName: enterprise-license
+
   - it: should use OSS image and not mount license when enterprise is not set in values
     template: auth/deployment.yaml
     set:

--- a/examples/chart/teleport-cluster/values.schema.json
+++ b/examples/chart/teleport-cluster/values.schema.json
@@ -286,6 +286,11 @@
             "type": "boolean",
             "default": false
         },
+        "licenseSecretName": {
+            "$id": "#/properties/licenseSecretName",
+            "type": "string",
+            "default": "license"
+        },
         "installCRDs": {
             "$id": "#/properties/installCRDs",
             "type": "boolean"

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -245,7 +245,8 @@ acmeURI: ""
 # You will need to download your Enterprise license from the Teleport dashboard and create a secret to use this:
 # kubectl -n ${TELEPORT_NAMESPACE?} create secret generic license --from-file=/path/to/downloaded/license.pem
 enterprise: false
-
+# Override default Enterprise license name
+licenseSecretName: "license"
 # CRDs are installed by default when the operator is enabled. This manual override allows to disable CRD installation
 # when deploying multiple releases in the same cluster.
 # installCRDs:


### PR DESCRIPTION
Backport #48874 to branch/v15

changelog: Allow to override Teleport license secret name when using `teleport-cluster` Helm chart.
