### PR TITLE
Add Integration and DiscoveryConfig as labels to auto discovered RDS/EKS

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -1031,6 +1031,16 @@ const (
 	// that belong to different discovery services that operate on different sets of resources.
 	TeleportInternalDiscoveryGroupName = TeleportInternalLabelPrefix + "discovery-group-name"
 
+	// TeleportInternalDiscoveryIntegrationName is the label used to store the name of the integration
+	// whose credentials were used to discover the resource.
+	// It is used to report stats for a given Integration / DiscoveryConfig.
+	TeleportInternalDiscoveryIntegrationName = TeleportInternalLabelPrefix + "discovery-integration-name"
+
+	// TeleportInternalDiscoveryConfigName is the label used to store the name of the discovery config
+	// whose matchers originated the resource.
+	// It is used to report stats for a given Integration / DiscoveryConfig.
+	TeleportInternalDiscoveryConfigName = TeleportInternalLabelPrefix + "discovery-config-name"
+
 	// TeleportDowngradedLabel identifies resources that have been automatically
 	// downgraded before being returned to clients on older versions that do not
 	// support one or more features enabled in that resource.

--- a/lib/srv/db/watcher.go
+++ b/lib/srv/db/watcher.go
@@ -114,7 +114,7 @@ func (s *Server) startCloudWatcher(ctx context.Context) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	azureFetchers, err := dbfetchers.MakeAzureFetchers(s.cfg.CloudClients, s.cfg.AzureMatchers)
+	azureFetchers, err := dbfetchers.MakeAzureFetchers(s.cfg.CloudClients, s.cfg.AzureMatchers, "" /* discovery config */)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/db/watcher.go
+++ b/lib/srv/db/watcher.go
@@ -110,7 +110,7 @@ func (s *Server) startResourceWatcher(ctx context.Context) (*services.GenericWat
 // startCloudWatcher starts fetching cloud databases according to the
 // selectors and register/unregister them appropriately.
 func (s *Server) startCloudWatcher(ctx context.Context) error {
-	awsFetchers, err := dbfetchers.MakeAWSFetchers(ctx, s.cfg.CloudClients, s.cfg.AWSMatchers)
+	awsFetchers, err := dbfetchers.MakeAWSFetchers(ctx, s.cfg.CloudClients, s.cfg.AWSMatchers, "" /* discovery config */)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/discovery/common/interfaces.go
+++ b/lib/srv/discovery/common/interfaces.go
@@ -33,6 +33,13 @@ type Fetcher interface {
 	// FetcherType identifies the Fetcher Type (cloud resource name).
 	// Eg, ec2, rds, aks, gce
 	FetcherType() string
+	// IntegrationName identifies the integration name whose credentials were used to fetch the resources.
+	// Might be empty when the fetcher is using ambient credentials.
+	IntegrationName() string
+	// DiscoveryConfigName is the name of the discovery config which originated the resource.
+	// Might be empty when the fetcher is using static matchers:
+	// ie teleport.yaml/discovery_service.<cloud>.<matcher>
+	DiscoveryConfigName() string
 	// Cloud returns the cloud the fetcher is operating.
 	Cloud() string
 }

--- a/lib/srv/discovery/common/watcher.go
+++ b/lib/srv/discovery/common/watcher.go
@@ -20,6 +20,7 @@ package common
 
 import (
 	"context"
+	"maps"
 	"sync"
 	"time"
 
@@ -95,18 +96,37 @@ type Watcher struct {
 	ctx context.Context
 	// resourcesC is a channel where fetched resourcess are sent.
 	resourcesC chan (types.ResourcesWithLabels)
+	// preFetchHookFn is called before starting a new poll.
+	preFetchHookFn func()
+}
+
+// Option is a functional option for the Watcher.
+type Option func(*Watcher)
+
+// WithPreFetchHookFn sets a function that gets called before each new iteration.
+func WithPreFetchHookFn(f func()) Option {
+	return func(w *Watcher) {
+		w.preFetchHookFn = f
+	}
 }
 
 // NewWatcher returns a new instance of a common discovery watcher.
-func NewWatcher(ctx context.Context, config WatcherConfig) (*Watcher, error) {
+func NewWatcher(ctx context.Context, config WatcherConfig, options ...Option) (*Watcher, error) {
 	if err := config.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return &Watcher{
-		cfg:        config,
-		ctx:        ctx,
-		resourcesC: make(chan types.ResourcesWithLabels),
-	}, nil
+	watcher := &Watcher{
+		cfg:            config,
+		ctx:            ctx,
+		resourcesC:     make(chan types.ResourcesWithLabels),
+		preFetchHookFn: func() {},
+	}
+
+	for _, opt := range options {
+		opt(watcher)
+	}
+
+	return watcher, nil
 }
 
 // Start starts fetching cloud resources and sending them to the channel.
@@ -139,6 +159,8 @@ func (w *Watcher) Start() {
 
 // fetchAndSend fetches resources from all fetchers and sends them to the channel.
 func (w *Watcher) fetchAndSend() {
+	w.preFetchHookFn()
+
 	var (
 		newFetcherResources = make(types.ResourcesWithLabels, 0, 50)
 		fetchersLock        sync.Mutex
@@ -163,29 +185,41 @@ func (w *Watcher) fetchAndSend() {
 				return nil
 			}
 
+			fetcherLabels := make(map[string]string, 0)
+
+			if lFetcher.IntegrationName() != "" {
+				// Add the integration name to the static labels for each resource.
+				fetcherLabels[types.TeleportInternalDiscoveryIntegrationName] = lFetcher.IntegrationName()
+			}
+			if lFetcher.DiscoveryConfigName() != "" {
+				// Add the discovery config name to the static labels of each resource.
+				fetcherLabels[types.TeleportInternalDiscoveryConfigName] = lFetcher.DiscoveryConfigName()
+			}
+
+			if w.cfg.DiscoveryGroup != "" {
+				// Add the discovery group name to the static labels of each resource.
+				fetcherLabels[types.TeleportInternalDiscoveryGroupName] = w.cfg.DiscoveryGroup
+			}
+
+			// Set the discovery type label to provide information about the
+			// matcher type that matched the resource.
+			if t := lFetcher.FetcherType(); t != "" {
+				fetcherLabels[types.DiscoveryTypeLabel] = t
+			}
+
+			// Set the origin label to provide information where resource comes from
+			fetcherLabels[types.OriginLabel] = w.cfg.Origin
+			if c := lFetcher.Cloud(); c != "" {
+				fetcherLabels[types.CloudLabel] = c
+			}
+
 			for _, r := range resources {
 				staticLabels := r.GetStaticLabels()
 				if staticLabels == nil {
 					staticLabels = make(map[string]string)
 				}
 
-				if w.cfg.DiscoveryGroup != "" {
-					// Add the discovery group name to the static labels of each resource.
-					staticLabels[types.TeleportInternalDiscoveryGroupName] = w.cfg.DiscoveryGroup
-				}
-
-				// Set the origin label to provide information where resource comes from
-				staticLabels[types.OriginLabel] = w.cfg.Origin
-				if c := lFetcher.Cloud(); c != "" {
-					staticLabels[types.CloudLabel] = c
-				}
-
-				// Set the discovery type label to provide information about the
-				// matcher type that matched the resource.
-				if t := lFetcher.FetcherType(); t != "" {
-					staticLabels[types.DiscoveryTypeLabel] = t
-				}
-
+				maps.Copy(staticLabels, fetcherLabels)
 				r.SetStaticLabels(staticLabels)
 			}
 

--- a/lib/srv/discovery/common/watcher_test.go
+++ b/lib/srv/discovery/common/watcher_test.go
@@ -167,6 +167,13 @@ func (m *mockFetcher) FetcherType() string {
 	return "empty"
 }
 
+func (m *mockFetcher) IntegrationName() string {
+	return ""
+}
+
+func (m *mockFetcher) DiscoveryConfigName() string {
+	return ""
+}
 func (m *mockFetcher) Cloud() string {
 	return m.cloud
 }

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -614,7 +614,7 @@ func (s *Server) databaseFetchersFromMatchers(matchers Matchers, discoveryConfig
 	// Azure
 	azureDatabaseMatchers, _ := splitMatchers(matchers.Azure, db.IsAzureMatcherType)
 	if len(azureDatabaseMatchers) > 0 {
-		databaseFetchers, err := db.MakeAzureFetchers(s.CloudClients, azureDatabaseMatchers)
+		databaseFetchers, err := db.MakeAzureFetchers(s.CloudClients, azureDatabaseMatchers, discoveryConfig)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -385,7 +385,7 @@ func New(ctx context.Context, cfg *Config) (*Server, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	databaseFetchers, err := s.databaseFetchersFromMatchers(cfg.Matchers)
+	databaseFetchers, err := s.databaseFetchersFromMatchers(cfg.Matchers, "" /* discovery config */)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -509,7 +509,7 @@ func (s *Server) initAWSWatchers(matchers []types.AWSMatcher) error {
 	_, otherMatchers = splitMatchers(otherMatchers, db.IsAWSMatcherType)
 
 	// Add non-integration kube fetchers.
-	kubeFetchers, err := fetchers.MakeEKSFetchersFromAWSMatchers(s.LegacyLogger, s.CloudClients, otherMatchers)
+	kubeFetchers, err := fetchers.MakeEKSFetchersFromAWSMatchers(s.LegacyLogger, s.CloudClients, otherMatchers, "" /* discovery config */)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -598,13 +598,13 @@ func (s *Server) gcpServerFetchersFromMatchers(ctx context.Context, matchers []t
 }
 
 // databaseFetchersFromMatchers converts Matchers into a set of Database Fetchers.
-func (s *Server) databaseFetchersFromMatchers(matchers Matchers) ([]common.Fetcher, error) {
+func (s *Server) databaseFetchersFromMatchers(matchers Matchers, discoveryConfig string) ([]common.Fetcher, error) {
 	var fetchers []common.Fetcher
 
 	// AWS
 	awsDatabaseMatchers, _ := splitMatchers(matchers.AWS, db.IsAWSMatcherType)
 	if len(awsDatabaseMatchers) > 0 {
-		databaseFetchers, err := db.MakeAWSFetchers(s.ctx, s.CloudClients, awsDatabaseMatchers)
+		databaseFetchers, err := db.MakeAWSFetchers(s.ctx, s.CloudClients, awsDatabaseMatchers, discoveryConfig)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -627,7 +627,7 @@ func (s *Server) databaseFetchersFromMatchers(matchers Matchers) ([]common.Fetch
 	return fetchers, nil
 }
 
-func (s *Server) kubeFetchersFromMatchers(matchers Matchers) ([]common.Fetcher, error) {
+func (s *Server) kubeFetchersFromMatchers(matchers Matchers, discoveryConfig string) ([]common.Fetcher, error) {
 	var result []common.Fetcher
 
 	// AWS
@@ -635,7 +635,7 @@ func (s *Server) kubeFetchersFromMatchers(matchers Matchers) ([]common.Fetcher, 
 		return matcherType == types.AWSMatcherEKS
 	})
 	if len(awsKubeMatchers) > 0 {
-		eksFetchers, err := fetchers.MakeEKSFetchersFromAWSMatchers(s.LegacyLogger, s.CloudClients, awsKubeMatchers)
+		eksFetchers, err := fetchers.MakeEKSFetchersFromAWSMatchers(s.LegacyLogger, s.CloudClients, awsKubeMatchers, discoveryConfig)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -1656,7 +1656,7 @@ func (s *Server) upsertDynamicMatchers(ctx context.Context, dc *discoveryconfig.
 	s.dynamicServerGCPFetchers[dc.GetName()] = gcpServerFetchers
 	s.muDynamicServerGCPFetchers.Unlock()
 
-	databaseFetchers, err := s.databaseFetchersFromMatchers(matchers)
+	databaseFetchers, err := s.databaseFetchersFromMatchers(matchers, dc.GetName())
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1675,7 +1675,7 @@ func (s *Server) upsertDynamicMatchers(ctx context.Context, dc *discoveryconfig.
 	s.dynamicTAGSyncFetchers[dc.GetName()] = awsSyncMatchers
 	s.muDynamicTAGSyncFetchers.Unlock()
 
-	kubeFetchers, err := s.kubeFetchersFromMatchers(matchers)
+	kubeFetchers, err := s.kubeFetchersFromMatchers(matchers, dc.GetName())
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1684,7 +1684,7 @@ func (s *Server) upsertDynamicMatchers(ctx context.Context, dc *discoveryconfig.
 	s.dynamicKubeFetchers[dc.GetName()] = kubeFetchers
 	s.muDynamicKubeFetchers.Unlock()
 
-	// TODO(marco): add other fetchers: Kube Clusters and Kube Resources (Apps)
+	// TODO(marco): add other fetchers: Kube Resources (Apps)
 	return nil
 }
 

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -1100,8 +1100,8 @@ func TestDiscoveryInCloudKube(t *testing.T) {
 				},
 			},
 			expectedClustersToExistInAuth: []types.KubeCluster{
-				mustConvertEKSToKubeCluster(t, eksMockClusters[0], mainDiscoveryGroup),
-				mustConvertEKSToKubeCluster(t, eksMockClusters[1], mainDiscoveryGroup),
+				mustConvertEKSToKubeCluster(t, eksMockClusters[0], rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup}),
+				mustConvertEKSToKubeCluster(t, eksMockClusters[1], rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup}),
 			},
 			wantEvents: 2,
 		},
@@ -1129,8 +1129,8 @@ func TestDiscoveryInCloudKube(t *testing.T) {
 				},
 			},
 			expectedClustersToExistInAuth: []types.KubeCluster{
-				mustConvertEKSToKubeCluster(t, eksMockClusters[0], mainDiscoveryGroup),
-				mustConvertEKSToKubeCluster(t, eksMockClusters[1], mainDiscoveryGroup),
+				mustConvertEKSToKubeCluster(t, eksMockClusters[0], rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup}),
+				mustConvertEKSToKubeCluster(t, eksMockClusters[1], rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup}),
 			},
 			expectedAssumedRoles: []string{"arn:aws:iam::123456789012:role/teleport-role", "arn:aws:iam::123456789012:role/teleport-role2"},
 			expectedExternalIDs:  []string{"external-id", "external-id2"},
@@ -1147,15 +1147,15 @@ func TestDiscoveryInCloudKube(t *testing.T) {
 				},
 			},
 			expectedClustersToExistInAuth: []types.KubeCluster{
-				mustConvertEKSToKubeCluster(t, eksMockClusters[2], mainDiscoveryGroup),
-				mustConvertEKSToKubeCluster(t, eksMockClusters[3], mainDiscoveryGroup),
+				mustConvertEKSToKubeCluster(t, eksMockClusters[2], rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup}),
+				mustConvertEKSToKubeCluster(t, eksMockClusters[3], rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup}),
 			},
 			wantEvents: 2,
 		},
 		{
 			name: "1 cluster in auth server not updated + import 1 prod cluster from EKS",
 			existingKubeClusters: []types.KubeCluster{
-				mustConvertEKSToKubeCluster(t, eksMockClusters[0], mainDiscoveryGroup),
+				mustConvertEKSToKubeCluster(t, eksMockClusters[0], rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup}),
 			},
 			awsMatchers: []types.AWSMatcher{
 				{
@@ -1165,16 +1165,16 @@ func TestDiscoveryInCloudKube(t *testing.T) {
 				},
 			},
 			expectedClustersToExistInAuth: []types.KubeCluster{
-				mustConvertEKSToKubeCluster(t, eksMockClusters[0], mainDiscoveryGroup),
-				mustConvertEKSToKubeCluster(t, eksMockClusters[1], mainDiscoveryGroup),
+				mustConvertEKSToKubeCluster(t, eksMockClusters[0], rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup}),
+				mustConvertEKSToKubeCluster(t, eksMockClusters[1], rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup}),
 			},
-			clustersNotUpdated: []string{mustConvertEKSToKubeCluster(t, eksMockClusters[0], mainDiscoveryGroup).GetName()},
+			clustersNotUpdated: []string{mustConvertEKSToKubeCluster(t, eksMockClusters[0], rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup}).GetName()},
 			wantEvents:         1,
 		},
 		{
 			name: "1 cluster in auth that belongs the same discovery group but has unmatched labels + import 2 prod clusters from EKS",
 			existingKubeClusters: []types.KubeCluster{
-				mustConvertEKSToKubeCluster(t, eksMockClusters[3], mainDiscoveryGroup),
+				mustConvertEKSToKubeCluster(t, eksMockClusters[3], rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup}),
 			},
 			awsMatchers: []types.AWSMatcher{
 				{
@@ -1184,8 +1184,8 @@ func TestDiscoveryInCloudKube(t *testing.T) {
 				},
 			},
 			expectedClustersToExistInAuth: []types.KubeCluster{
-				mustConvertEKSToKubeCluster(t, eksMockClusters[0], mainDiscoveryGroup),
-				mustConvertEKSToKubeCluster(t, eksMockClusters[1], mainDiscoveryGroup),
+				mustConvertEKSToKubeCluster(t, eksMockClusters[0], rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup}),
+				mustConvertEKSToKubeCluster(t, eksMockClusters[1], rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup}),
 			},
 			clustersNotUpdated: []string{},
 			wantEvents:         2,
@@ -1193,7 +1193,7 @@ func TestDiscoveryInCloudKube(t *testing.T) {
 		{
 			name: "1 cluster in auth that belongs to a different discovery group + import 2 prod clusters from EKS",
 			existingKubeClusters: []types.KubeCluster{
-				mustConvertEKSToKubeCluster(t, eksMockClusters[3], otherDiscoveryGroup),
+				mustConvertEKSToKubeCluster(t, eksMockClusters[3], rewriteDiscoveryLabelsParams{discoveryGroup: otherDiscoveryGroup}),
 			},
 			awsMatchers: []types.AWSMatcher{
 				{
@@ -1203,9 +1203,9 @@ func TestDiscoveryInCloudKube(t *testing.T) {
 				},
 			},
 			expectedClustersToExistInAuth: []types.KubeCluster{
-				mustConvertEKSToKubeCluster(t, eksMockClusters[3], otherDiscoveryGroup),
-				mustConvertEKSToKubeCluster(t, eksMockClusters[0], mainDiscoveryGroup),
-				mustConvertEKSToKubeCluster(t, eksMockClusters[1], mainDiscoveryGroup),
+				mustConvertEKSToKubeCluster(t, eksMockClusters[3], rewriteDiscoveryLabelsParams{discoveryGroup: otherDiscoveryGroup}),
+				mustConvertEKSToKubeCluster(t, eksMockClusters[0], rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup}),
+				mustConvertEKSToKubeCluster(t, eksMockClusters[1], rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup}),
 			},
 			clustersNotUpdated: []string{},
 			wantEvents:         2,
@@ -1214,7 +1214,7 @@ func TestDiscoveryInCloudKube(t *testing.T) {
 			name: "1 cluster in auth that must be updated + import 1 prod clusters from EKS",
 			existingKubeClusters: []types.KubeCluster{
 				// add an extra static label to force update in auth server
-				modifyKubeCluster(mustConvertEKSToKubeCluster(t, eksMockClusters[1], mainDiscoveryGroup)),
+				modifyKubeCluster(mustConvertEKSToKubeCluster(t, eksMockClusters[1], rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup})),
 			},
 			awsMatchers: []types.AWSMatcher{
 				{
@@ -1224,8 +1224,8 @@ func TestDiscoveryInCloudKube(t *testing.T) {
 				},
 			},
 			expectedClustersToExistInAuth: []types.KubeCluster{
-				mustConvertEKSToKubeCluster(t, eksMockClusters[0], mainDiscoveryGroup),
-				mustConvertEKSToKubeCluster(t, eksMockClusters[1], mainDiscoveryGroup),
+				mustConvertEKSToKubeCluster(t, eksMockClusters[0], rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup}),
+				mustConvertEKSToKubeCluster(t, eksMockClusters[1], rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup}),
 			},
 			clustersNotUpdated: []string{},
 			wantEvents:         1,
@@ -1234,8 +1234,8 @@ func TestDiscoveryInCloudKube(t *testing.T) {
 			name: "2 clusters in auth that matches but one must be updated +  import 2 prod clusters, 1 from EKS and other from AKS",
 			existingKubeClusters: []types.KubeCluster{
 				// add an extra static label to force update in auth server
-				modifyKubeCluster(mustConvertEKSToKubeCluster(t, eksMockClusters[1], mainDiscoveryGroup)),
-				mustConvertAKSToKubeCluster(t, aksMockClusters["group1"][0], mainDiscoveryGroup),
+				modifyKubeCluster(mustConvertEKSToKubeCluster(t, eksMockClusters[1], rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup})),
+				mustConvertAKSToKubeCluster(t, aksMockClusters["group1"][0], rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup}),
 			},
 			awsMatchers: []types.AWSMatcher{
 				{
@@ -1254,12 +1254,12 @@ func TestDiscoveryInCloudKube(t *testing.T) {
 				},
 			},
 			expectedClustersToExistInAuth: []types.KubeCluster{
-				mustConvertEKSToKubeCluster(t, eksMockClusters[0], mainDiscoveryGroup),
-				mustConvertEKSToKubeCluster(t, eksMockClusters[1], mainDiscoveryGroup),
-				mustConvertAKSToKubeCluster(t, aksMockClusters["group1"][0], mainDiscoveryGroup),
-				mustConvertAKSToKubeCluster(t, aksMockClusters["group1"][1], mainDiscoveryGroup),
+				mustConvertEKSToKubeCluster(t, eksMockClusters[0], rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup}),
+				mustConvertEKSToKubeCluster(t, eksMockClusters[1], rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup}),
+				mustConvertAKSToKubeCluster(t, aksMockClusters["group1"][0], rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup}),
+				mustConvertAKSToKubeCluster(t, aksMockClusters["group1"][1], rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup}),
 			},
-			clustersNotUpdated: []string{mustConvertAKSToKubeCluster(t, aksMockClusters["group1"][0], mainDiscoveryGroup).GetName()},
+			clustersNotUpdated: []string{mustConvertAKSToKubeCluster(t, aksMockClusters["group1"][0], rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup}).GetName()},
 			wantEvents:         2,
 		},
 		{
@@ -1274,8 +1274,8 @@ func TestDiscoveryInCloudKube(t *testing.T) {
 				},
 			},
 			expectedClustersToExistInAuth: []types.KubeCluster{
-				mustConvertGKEToKubeCluster(t, gkeMockClusters[0], mainDiscoveryGroup),
-				mustConvertGKEToKubeCluster(t, gkeMockClusters[1], mainDiscoveryGroup),
+				mustConvertGKEToKubeCluster(t, gkeMockClusters[0], rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup}),
+				mustConvertGKEToKubeCluster(t, gkeMockClusters[1], rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup}),
 			},
 			wantEvents: 2,
 		},
@@ -1291,9 +1291,9 @@ func TestDiscoveryInCloudKube(t *testing.T) {
 				},
 			},
 			expectedClustersToExistInAuth: []types.KubeCluster{
-				mustConvertGKEToKubeCluster(t, gkeMockClusters[0], mainDiscoveryGroup),
-				mustConvertGKEToKubeCluster(t, gkeMockClusters[1], mainDiscoveryGroup),
-				mustConvertGKEToKubeCluster(t, gkeMockClusters[4], mainDiscoveryGroup),
+				mustConvertGKEToKubeCluster(t, gkeMockClusters[0], rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup}),
+				mustConvertGKEToKubeCluster(t, gkeMockClusters[1], rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup}),
+				mustConvertGKEToKubeCluster(t, gkeMockClusters[4], rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup}),
 			},
 			wantEvents: 3,
 		},
@@ -1700,17 +1700,19 @@ var eksMockClusters = []*eks.Cluster{
 	},
 }
 
-func mustConvertEKSToKubeCluster(t *testing.T, eksCluster *eks.Cluster, discoveryGroup string) types.KubeCluster {
+func mustConvertEKSToKubeCluster(t *testing.T, eksCluster *eks.Cluster, discoveryParams rewriteDiscoveryLabelsParams) types.KubeCluster {
 	cluster, err := common.NewKubeClusterFromAWSEKS(aws.StringValue(eksCluster.Name), aws.StringValue(eksCluster.Arn), eksCluster.Tags)
 	require.NoError(t, err)
-	rewriteCloudResource(t, cluster, discoveryGroup, types.AWSMatcherEKS)
+	discoveryParams.matcherType = types.AWSMatcherEKS
+	rewriteCloudResource(t, cluster, discoveryParams)
 	return cluster
 }
 
-func mustConvertAKSToKubeCluster(t *testing.T, azureCluster *azure.AKSCluster, discoveryGroup string) types.KubeCluster {
+func mustConvertAKSToKubeCluster(t *testing.T, azureCluster *azure.AKSCluster, discoveryParams rewriteDiscoveryLabelsParams) types.KubeCluster {
 	cluster, err := common.NewKubeClusterFromAzureAKS(azureCluster)
 	require.NoError(t, err)
-	rewriteCloudResource(t, cluster, discoveryGroup, types.AzureMatcherKubernetes)
+	discoveryParams.matcherType = types.AzureMatcherKubernetes
+	rewriteCloudResource(t, cluster, discoveryParams)
 	return cluster
 }
 
@@ -1812,10 +1814,11 @@ var gkeMockClusters = []gcp.GKECluster{
 	},
 }
 
-func mustConvertGKEToKubeCluster(t *testing.T, gkeCluster gcp.GKECluster, discoveryGroup string) types.KubeCluster {
+func mustConvertGKEToKubeCluster(t *testing.T, gkeCluster gcp.GKECluster, discoveryParams rewriteDiscoveryLabelsParams) types.KubeCluster {
 	cluster, err := common.NewKubeClusterFromGCPGKE(gkeCluster)
 	require.NoError(t, err)
-	rewriteCloudResource(t, cluster, discoveryGroup, types.GCPMatcherKubernetes)
+	discoveryParams.matcherType = types.GCPMatcherKubernetes
+	rewriteCloudResource(t, cluster, discoveryParams)
 	return cluster
 }
 
@@ -1838,11 +1841,16 @@ func (m *mockGKEAPI) ListClusters(ctx context.Context, projectID string, locatio
 
 func TestDiscoveryDatabase(t *testing.T) {
 	const (
-		mainDiscoveryGroup = "main"
+		mainDiscoveryGroup  = "main"
+		integrationName     = "my-integration"
+		discoveryConfigName = "my-discovery-config"
 	)
-	awsRedshiftResource, awsRedshiftDB := makeRedshiftCluster(t, "aws-redshift", "us-east-1", mainDiscoveryGroup)
-	awsRDSInstance, awsRDSDB := makeRDSInstance(t, "aws-rds", "us-west-1", mainDiscoveryGroup)
-	azRedisResource, azRedisDB := makeAzureRedisServer(t, "az-redis", "sub1", "group1", "East US", mainDiscoveryGroup)
+	awsRedshiftResource, awsRedshiftDB := makeRedshiftCluster(t, "aws-redshift", "us-east-1", rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup})
+	_, awsRedshiftDBWithIntegration := makeRedshiftCluster(t, "aws-redshift", "us-east-1", rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup, integration: integrationName})
+	_, awsRedshiftDBWithIntegrationAndDiscoveryConfig := makeRedshiftCluster(t, "aws-redshift", "us-east-1", rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup, integration: integrationName, discoveryConfig: discoveryConfigName})
+	_, awsRedshiftDBWithDiscoveryConfig := makeRedshiftCluster(t, "aws-redshift", "us-east-1", rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup, discoveryConfig: discoveryConfigName})
+	awsRDSInstance, awsRDSDB := makeRDSInstance(t, "aws-rds", "us-west-1", rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup})
+	azRedisResource, azRedisDB := makeAzureRedisServer(t, "az-redis", "sub1", "group1", "East US", rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup})
 
 	role := types.AssumeRole{RoleARN: "arn:aws:iam::123456789012:role/test-role", ExternalID: "test123"}
 	awsRDSDBWithRole := awsRDSDB.Copy()
@@ -1851,7 +1859,7 @@ func TestDiscoveryDatabase(t *testing.T) {
 
 	matcherForDiscoveryConfigFn := func(t *testing.T, discoveryGroup string, m Matchers) *discoveryconfig.DiscoveryConfig {
 		dc, err := discoveryconfig.NewDiscoveryConfig(
-			header.Metadata{Name: uuid.NewString()},
+			header.Metadata{Name: discoveryConfigName},
 			discoveryconfig.Spec{
 				DiscoveryGroup: discoveryGroup,
 				AWS:            m.AWS,
@@ -2047,7 +2055,7 @@ func TestDiscoveryDatabase(t *testing.T) {
 		},
 		{
 			name:            "discover AWS database using dynamic matchers",
-			expectDatabases: []types.Database{awsRedshiftDB},
+			expectDatabases: []types.Database{awsRedshiftDBWithDiscoveryConfig},
 			discoveryConfigs: func(t *testing.T) []*discoveryconfig.DiscoveryConfig {
 				dc1 := matcherForDiscoveryConfigFn(t, mainDiscoveryGroup, Matchers{
 					AWS: []types.AWSMatcher{{
@@ -2078,14 +2086,14 @@ func TestDiscoveryDatabase(t *testing.T) {
 		},
 		{
 			name:            "running in integrations-only-mode with a dynamic matcher with an integration, must find 1 database",
-			expectDatabases: []types.Database{awsRedshiftDB},
+			expectDatabases: []types.Database{awsRedshiftDBWithIntegrationAndDiscoveryConfig},
 			discoveryConfigs: func(t *testing.T) []*discoveryconfig.DiscoveryConfig {
 				dc1 := matcherForDiscoveryConfigFn(t, mainDiscoveryGroup, Matchers{
 					AWS: []types.AWSMatcher{{
 						Types:       []string{types.AWSMatcherRedshift},
 						Tags:        map[string]utils.Strings{types.Wildcard: {types.Wildcard}},
 						Regions:     []string{"us-east-1"},
-						Integration: "xyz",
+						Integration: integrationName,
 					}},
 				})
 				return []*discoveryconfig.DiscoveryConfig{dc1}
@@ -2099,9 +2107,9 @@ func TestDiscoveryDatabase(t *testing.T) {
 				Types:       []string{types.AWSMatcherRedshift},
 				Tags:        map[string]utils.Strings{types.Wildcard: {types.Wildcard}},
 				Regions:     []string{"us-east-1"},
-				Integration: "xyz",
+				Integration: integrationName,
 			}},
-			expectDatabases: []types.Database{awsRedshiftDB},
+			expectDatabases: []types.Database{awsRedshiftDBWithIntegration},
 			wantEvents:      1,
 		},
 	}
@@ -2212,8 +2220,10 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 	const mainDiscoveryGroup = "main"
 
 	clock := clockwork.NewFakeClock()
+	dc1Name := uuid.NewString()
+	dc2Name := uuid.NewString()
 
-	awsRDSInstance, awsRDSDB := makeRDSInstance(t, "aws-rds", "us-west-1", mainDiscoveryGroup)
+	awsRDSInstance, awsRDSDB := makeRDSInstance(t, "aws-rds", "us-west-1", rewriteDiscoveryLabelsParams{discoveryConfig: dc2Name, discoveryGroup: mainDiscoveryGroup})
 
 	testCloudClients := &cloud.TestCloudClients{
 		STS: &mocks.STSMock{},
@@ -2277,7 +2287,7 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 	t.Run("DiscoveryGroup does not match: matcher is not loaded", func(t *testing.T) {
 		// Create a Dynamic matcher
 		dc1, err := discoveryconfig.NewDiscoveryConfig(
-			header.Metadata{Name: uuid.NewString()},
+			header.Metadata{Name: dc1Name},
 			discoveryconfig.Spec{
 				DiscoveryGroup: "another-discovery-group",
 				AWS: []types.AWSMatcher{{
@@ -2301,8 +2311,8 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 
 	t.Run("New DiscoveryConfig with valid Group", func(t *testing.T) {
 		// Create a Dynamic matcher
-		dc1, err := discoveryconfig.NewDiscoveryConfig(
-			header.Metadata{Name: uuid.NewString()},
+		dc2, err := discoveryconfig.NewDiscoveryConfig(
+			header.Metadata{Name: dc2Name},
 			discoveryconfig.Spec{
 				DiscoveryGroup: mainDiscoveryGroup,
 				AWS: []types.AWSMatcher{{
@@ -2315,7 +2325,7 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Zero(t, reporter.DiscoveryFetchEventCount())
-		_, err = tlsServer.Auth().DiscoveryConfigs.CreateDiscoveryConfig(ctx, dc1)
+		_, err = tlsServer.Auth().DiscoveryConfigs.CreateDiscoveryConfig(ctx, dc2)
 		require.NoError(t, err)
 
 		// Check for new resource in reconciler
@@ -2345,7 +2355,7 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 
 		t.Run("removing the DiscoveryConfig: fetcher is removed and database is removed", func(t *testing.T) {
 			// Remove DiscoveryConfig
-			err = tlsServer.Auth().DiscoveryConfigs.DeleteDiscoveryConfig(ctx, dc1.GetName())
+			err = tlsServer.Auth().DiscoveryConfigs.DeleteDiscoveryConfig(ctx, dc2.GetName())
 			require.NoError(t, err)
 
 			currentEmittedEvents := reporter.DiscoveryFetchEventCount()
@@ -2364,7 +2374,7 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 	})
 }
 
-func makeRDSInstance(t *testing.T, name, region string, discoveryGroup string) (*rds.DBInstance, types.Database) {
+func makeRDSInstance(t *testing.T, name, region string, discoveryParams rewriteDiscoveryLabelsParams) (*rds.DBInstance, types.Database) {
 	instance := &rds.DBInstance{
 		DBInstanceArn:        aws.String(fmt.Sprintf("arn:aws:rds:%v:123456789012:db:%v", region, name)),
 		DBInstanceIdentifier: aws.String(name),
@@ -2378,11 +2388,12 @@ func makeRDSInstance(t *testing.T, name, region string, discoveryGroup string) (
 	}
 	database, err := common.NewDatabaseFromRDSInstance(instance)
 	require.NoError(t, err)
-	rewriteCloudResource(t, database, discoveryGroup, types.AWSMatcherRDS)
+	discoveryParams.matcherType = types.AWSMatcherRDS
+	rewriteCloudResource(t, database, discoveryParams)
 	return instance, database
 }
 
-func makeRedshiftCluster(t *testing.T, name, region string, discoveryGroup string) (*redshift.Cluster, types.Database) {
+func makeRedshiftCluster(t *testing.T, name, region string, discoveryParams rewriteDiscoveryLabelsParams) (*redshift.Cluster, types.Database) {
 	t.Helper()
 	cluster := &redshift.Cluster{
 		ClusterIdentifier:   aws.String(name),
@@ -2396,11 +2407,12 @@ func makeRedshiftCluster(t *testing.T, name, region string, discoveryGroup strin
 
 	database, err := common.NewDatabaseFromRedshiftCluster(cluster)
 	require.NoError(t, err)
-	rewriteCloudResource(t, database, discoveryGroup, types.AWSMatcherRedshift)
+	discoveryParams.matcherType = types.AWSMatcherRedshift
+	rewriteCloudResource(t, database, discoveryParams)
 	return cluster, database
 }
 
-func makeAzureRedisServer(t *testing.T, name, subscription, group, region string, discoveryGroup string) (*armredis.ResourceInfo, types.Database) {
+func makeAzureRedisServer(t *testing.T, name, subscription, group, region string, discoveryParams rewriteDiscoveryLabelsParams) (*armredis.ResourceInfo, types.Database) {
 	t.Helper()
 	resourceInfo := &armredis.ResourceInfo{
 		Name:     to.Ptr(name),
@@ -2415,7 +2427,8 @@ func makeAzureRedisServer(t *testing.T, name, subscription, group, region string
 
 	database, err := common.NewDatabaseFromAzureRedis(resourceInfo)
 	require.NoError(t, err)
-	rewriteCloudResource(t, database, discoveryGroup, types.AzureMatcherRedis)
+	discoveryParams.matcherType = types.AzureMatcherRedis
+	rewriteCloudResource(t, database, discoveryParams)
 	return resourceInfo, database
 }
 
@@ -3040,8 +3053,8 @@ func TestServer_onCreate(t *testing.T) {
 
 	t.Run("onCreate update kube", func(t *testing.T) {
 		// With cloud origin and an empty discovery group, it should update.
-		accessPoint.kube = mustConvertEKSToKubeCluster(t, eksMockClusters[0], "" /* empty discovery group */)
-		err := s.onKubeCreate(context.Background(), mustConvertEKSToKubeCluster(t, eksMockClusters[0], "test-cluster"))
+		accessPoint.kube = mustConvertEKSToKubeCluster(t, eksMockClusters[0], rewriteDiscoveryLabelsParams{})
+		err := s.onKubeCreate(context.Background(), mustConvertEKSToKubeCluster(t, eksMockClusters[0], rewriteDiscoveryLabelsParams{discoveryGroup: "test-cluster"}))
 		require.NoError(t, err)
 		require.True(t, accessPoint.updatedKube)
 
@@ -3049,7 +3062,7 @@ func TestServer_onCreate(t *testing.T) {
 		// non-cloud origin. It should not update.
 		accessPoint.updatedKube = false
 		accessPoint.kube.SetOrigin(types.OriginDynamic)
-		err = s.onKubeCreate(context.Background(), mustConvertEKSToKubeCluster(t, eksMockClusters[0], "test-cluster"))
+		err = s.onKubeCreate(context.Background(), mustConvertEKSToKubeCluster(t, eksMockClusters[0], rewriteDiscoveryLabelsParams{discoveryGroup: "test-cluster"}))
 		require.Error(t, err)
 		require.False(t, accessPoint.updatedKube)
 
@@ -3057,22 +3070,22 @@ func TestServer_onCreate(t *testing.T) {
 		// an empty origin. It should not update.
 		accessPoint.updatedKube = false
 		accessPoint.kube.SetOrigin("")
-		err = s.onKubeCreate(context.Background(), mustConvertEKSToKubeCluster(t, eksMockClusters[0], "test-cluster"))
+		err = s.onKubeCreate(context.Background(), mustConvertEKSToKubeCluster(t, eksMockClusters[0], rewriteDiscoveryLabelsParams{discoveryGroup: "test-cluster"}))
 		require.Error(t, err)
 		require.False(t, accessPoint.updatedKube)
 
 		// Reset the update flag and set the registered kube cluster to have
 		// a non-empty discovery group. It should not update.
 		accessPoint.updatedKube = false
-		accessPoint.kube = mustConvertEKSToKubeCluster(t, eksMockClusters[0], "nonEmpty")
-		err = s.onKubeCreate(context.Background(), mustConvertEKSToKubeCluster(t, eksMockClusters[0], "test-cluster"))
+		accessPoint.kube = mustConvertEKSToKubeCluster(t, eksMockClusters[0], rewriteDiscoveryLabelsParams{discoveryGroup: "non-empty"})
+		err = s.onKubeCreate(context.Background(), mustConvertEKSToKubeCluster(t, eksMockClusters[0], rewriteDiscoveryLabelsParams{discoveryGroup: "test-cluster"}))
 		require.Error(t, err)
 		require.False(t, accessPoint.updatedKube)
 	})
 
 	t.Run("onCreate update database", func(t *testing.T) {
-		_, awsRedshiftDB := makeRedshiftCluster(t, "aws-redshift", "us-east-1", "test")
-		_, awsRedshiftDBEmptyDiscoveryGroup := makeRedshiftCluster(t, "aws-redshift", "us-east-1", "" /* empty discovery group */)
+		_, awsRedshiftDB := makeRedshiftCluster(t, "aws-redshift", "us-east-1", rewriteDiscoveryLabelsParams{discoveryGroup: "test"})
+		_, awsRedshiftDBEmptyDiscoveryGroup := makeRedshiftCluster(t, "aws-redshift", "us-east-1", rewriteDiscoveryLabelsParams{})
 
 		// With cloud origin and an empty discovery group, it should update.
 		accessPoint.database = awsRedshiftDBEmptyDiscoveryGroup
@@ -3350,13 +3363,30 @@ func (m fakeWatcher) Error() error {
 	return nil
 }
 
+type rewriteDiscoveryLabelsParams struct {
+	matcherType     string
+	discoveryConfig string
+	discoveryGroup  string
+	integration     string
+}
+
 // rewriteCloudResource is a test helper func that rewrites an expected cloud
 // resource to include all the metadata we expect to be added by discovery.
-func rewriteCloudResource(t *testing.T, r types.ResourceWithLabels, discoveryGroup, matcherType string) {
+func rewriteCloudResource(t *testing.T, r types.ResourceWithLabels, discoveryParams rewriteDiscoveryLabelsParams) {
 	r.SetOrigin(types.OriginCloud)
 	staticLabels := r.GetStaticLabels()
-	staticLabels[types.TeleportInternalDiscoveryGroupName] = discoveryGroup
-	staticLabels[types.DiscoveryTypeLabel] = matcherType
+	if discoveryParams.matcherType != "" {
+		staticLabels[types.DiscoveryTypeLabel] = discoveryParams.matcherType
+	}
+	if discoveryParams.discoveryConfig != "" {
+		staticLabels[types.TeleportInternalDiscoveryConfigName] = discoveryParams.discoveryConfig
+	}
+	if discoveryParams.discoveryGroup != "" {
+		staticLabels[types.TeleportInternalDiscoveryGroupName] = discoveryParams.discoveryGroup
+	}
+	if discoveryParams.integration != "" {
+		staticLabels[types.TeleportInternalDiscoveryIntegrationName] = discoveryParams.integration
+	}
 	r.SetStaticLabels(staticLabels)
 
 	switch r := r.(type) {
@@ -3365,9 +3395,9 @@ func rewriteCloudResource(t *testing.T, r types.ResourceWithLabels, discoveryGro
 		require.True(t, ok, "cloud resources should have a label identifying the cloud they came from")
 		switch cloudLabel {
 		case types.CloudAWS:
-			common.ApplyAWSDatabaseNameSuffix(r, matcherType)
+			common.ApplyAWSDatabaseNameSuffix(r, discoveryParams.matcherType)
 		case types.CloudAzure:
-			common.ApplyAzureDatabaseNameSuffix(r, matcherType)
+			common.ApplyAzureDatabaseNameSuffix(r, discoveryParams.matcherType)
 		case types.CloudGCP:
 			require.FailNow(t, "GCP database discovery is not supported", cloudLabel)
 		default:

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -1851,6 +1851,7 @@ func TestDiscoveryDatabase(t *testing.T) {
 	_, awsRedshiftDBWithDiscoveryConfig := makeRedshiftCluster(t, "aws-redshift", "us-east-1", rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup, discoveryConfig: discoveryConfigName})
 	awsRDSInstance, awsRDSDB := makeRDSInstance(t, "aws-rds", "us-west-1", rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup})
 	azRedisResource, azRedisDB := makeAzureRedisServer(t, "az-redis", "sub1", "group1", "East US", rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup})
+	_, azRedisDBWithDiscoveryConfig := makeAzureRedisServer(t, "az-redis", "sub1", "group1", "East US", rewriteDiscoveryLabelsParams{discoveryGroup: mainDiscoveryGroup, discoveryConfig: discoveryConfigName})
 
 	role := types.AssumeRole{RoleARN: "arn:aws:iam::123456789012:role/test-role", ExternalID: "test123"}
 	awsRDSDBWithRole := awsRDSDB.Copy()
@@ -2038,7 +2039,7 @@ func TestDiscoveryDatabase(t *testing.T) {
 		},
 		{
 			name:            "discover Azure database using dynamic matchers",
-			expectDatabases: []types.Database{azRedisDB},
+			expectDatabases: []types.Database{azRedisDBWithDiscoveryConfig},
 			discoveryConfigs: func(t *testing.T) []*discoveryconfig.DiscoveryConfig {
 				dc1 := matcherForDiscoveryConfigFn(t, mainDiscoveryGroup, Matchers{
 					Azure: []types.AzureMatcher{{

--- a/lib/srv/discovery/fetchers/aks.go
+++ b/lib/srv/discovery/fetchers/aks.go
@@ -152,6 +152,14 @@ func (a *aksFetcher) Cloud() string {
 	return types.CloudAzure
 }
 
+func (a *aksFetcher) IntegrationName() string {
+	return ""
+}
+
+func (a *aksFetcher) DiscoveryConfigName() string {
+	return ""
+}
+
 func (a *aksFetcher) FetcherType() string {
 	return types.AzureMatcherKubernetes
 }

--- a/lib/srv/discovery/fetchers/db/aws.go
+++ b/lib/srv/discovery/fetchers/db/aws.go
@@ -64,6 +64,10 @@ type awsFetcherConfig struct {
 	// Integration is the integration name to be used to fetch credentials.
 	// When present, it will use this integration and discard any local credentials.
 	Integration string
+	// DiscoveryConfigName is the name of the discovery config which originated the resource.
+	// Might be empty when the fetcher is using static matchers:
+	// ie teleport.yaml/discovery_service.<cloud>.<matcher>
+	DiscoveryConfig string
 }
 
 // CheckAndSetDefaults validates the config and sets defaults.
@@ -165,6 +169,16 @@ func (f *awsFetcher) applyAssumeRole(db types.Database) {
 // Cloud returns the cloud the fetcher is operating.
 func (f *awsFetcher) Cloud() string {
 	return types.CloudAWS
+}
+
+// IntegrationName returns the integration name whose credentials are used to fetch the resources.
+func (f *awsFetcher) IntegrationName() string {
+	return f.cfg.Integration
+}
+
+// DiscoveryConfigName returns the discovery config name whose matchers are used to fetch the resources.
+func (f *awsFetcher) DiscoveryConfigName() string {
+	return f.cfg.DiscoveryConfig
 }
 
 // ResourceType identifies the resource type the fetcher is returning.

--- a/lib/srv/discovery/fetchers/db/azure.go
+++ b/lib/srv/discovery/fetchers/db/azure.go
@@ -150,6 +150,20 @@ func (f *azureFetcher[DBType, ListClient]) FetcherType() string {
 	return f.cfg.Type
 }
 
+// IntegrationName returns the integration name.
+// There are no integrations supporting Azure Discovery fetchers, so this returns an empty string.
+func (f *azureFetcher[DBType, ListClient]) IntegrationName() string {
+	return ""
+}
+
+// DiscoveryConfigName is the name of the discovery config which originated the resource.
+// It is used to report stats for a given discovery config.
+// Might be empty when the fetcher is using static matchers:
+// ie teleport.yaml/discovery_service.<cloud>.<matcher>
+func (f *azureFetcher[DBType, ListClient]) DiscoveryConfigName() string {
+	return ""
+}
+
 // Get returns Azure DB servers matching the watcher's selectors.
 func (f *azureFetcher[DBType, ListClient]) Get(ctx context.Context) (types.ResourcesWithLabels, error) {
 	databases, err := f.getDatabases(ctx)

--- a/lib/srv/discovery/fetchers/db/azure.go
+++ b/lib/srv/discovery/fetchers/db/azure.go
@@ -91,6 +91,8 @@ type azureFetcherConfig struct {
 	Regions []string
 	// regionSet is a set of regions, used for efficient region match lookup.
 	regionSet map[string]struct{}
+	// DiscoveryConfig is the name of the discovery config which originated the resource.
+	DiscoveryConfig string
 }
 
 // regionMatches returns whether a given region matches the configured Regions selector
@@ -151,8 +153,8 @@ func (f *azureFetcher[DBType, ListClient]) FetcherType() string {
 }
 
 // IntegrationName returns the integration name.
-// There are no integrations supporting Azure Discovery fetchers, so this returns an empty string.
 func (f *azureFetcher[DBType, ListClient]) IntegrationName() string {
+	// There is currently no integration that supports Auto Discover for Azure resources.
 	return ""
 }
 
@@ -161,7 +163,7 @@ func (f *azureFetcher[DBType, ListClient]) IntegrationName() string {
 // Might be empty when the fetcher is using static matchers:
 // ie teleport.yaml/discovery_service.<cloud>.<matcher>
 func (f *azureFetcher[DBType, ListClient]) DiscoveryConfigName() string {
-	return ""
+	return f.cfg.DiscoveryConfig
 }
 
 // Get returns Azure DB servers matching the watcher's selectors.

--- a/lib/srv/discovery/fetchers/db/db.go
+++ b/lib/srv/discovery/fetchers/db/db.go
@@ -65,7 +65,7 @@ func IsAzureMatcherType(matcherType string) bool {
 }
 
 // MakeAWSFetchers creates new AWS database fetchers.
-func MakeAWSFetchers(ctx context.Context, clients cloud.AWSClients, matchers []types.AWSMatcher) (result []common.Fetcher, err error) {
+func MakeAWSFetchers(ctx context.Context, clients cloud.AWSClients, matchers []types.AWSMatcher, discoveryConfig string) (result []common.Fetcher, err error) {
 	for _, matcher := range matchers {
 		assumeRole := types.AssumeRole{}
 		if matcher.AssumeRole != nil {
@@ -80,12 +80,13 @@ func MakeAWSFetchers(ctx context.Context, clients cloud.AWSClients, matchers []t
 			for _, makeFetcher := range makeFetchers {
 				for _, region := range matcher.Regions {
 					fetcher, err := makeFetcher(awsFetcherConfig{
-						AWSClients:  clients,
-						Type:        matcherType,
-						AssumeRole:  assumeRole,
-						Labels:      matcher.Tags,
-						Region:      region,
-						Integration: matcher.Integration,
+						AWSClients:      clients,
+						Type:            matcherType,
+						AssumeRole:      assumeRole,
+						Labels:          matcher.Tags,
+						Region:          region,
+						Integration:     matcher.Integration,
+						DiscoveryConfig: discoveryConfig,
 					})
 					if err != nil {
 						return nil, trace.Wrap(err)

--- a/lib/srv/discovery/fetchers/db/db.go
+++ b/lib/srv/discovery/fetchers/db/db.go
@@ -100,7 +100,7 @@ func MakeAWSFetchers(ctx context.Context, clients cloud.AWSClients, matchers []t
 }
 
 // MakeAzureFetchers creates new Azure database fetchers.
-func MakeAzureFetchers(clients cloud.AzureClients, matchers []types.AzureMatcher) (result []common.Fetcher, err error) {
+func MakeAzureFetchers(clients cloud.AzureClients, matchers []types.AzureMatcher, discoveryConfig string) (result []common.Fetcher, err error) {
 	for _, matcher := range services.SimplifyAzureMatchers(matchers) {
 		for _, matcherType := range matcher.Types {
 			makeFetchers, found := makeAzureFetcherFuncs[matcherType]
@@ -112,12 +112,13 @@ func MakeAzureFetchers(clients cloud.AzureClients, matchers []types.AzureMatcher
 				for _, sub := range matcher.Subscriptions {
 					for _, group := range matcher.ResourceGroups {
 						fetcher, err := makeFetcher(azureFetcherConfig{
-							AzureClients:  clients,
-							Type:          matcherType,
-							Subscription:  sub,
-							ResourceGroup: group,
-							Labels:        matcher.ResourceTags,
-							Regions:       matcher.Regions,
+							AzureClients:    clients,
+							Type:            matcherType,
+							Subscription:    sub,
+							ResourceGroup:   group,
+							Labels:          matcher.ResourceTags,
+							Regions:         matcher.Regions,
+							DiscoveryConfig: discoveryConfig,
 						})
 						if err != nil {
 							return nil, trace.Wrap(err)

--- a/lib/srv/discovery/fetchers/db/helpers_test.go
+++ b/lib/srv/discovery/fetchers/db/helpers_test.go
@@ -53,10 +53,10 @@ func makeAWSMatchersForType(matcherType, region string, tags map[string]string) 
 	}}
 }
 
-func mustMakeAWSFetchers(t *testing.T, clients cloud.AWSClients, matchers []types.AWSMatcher) []common.Fetcher {
+func mustMakeAWSFetchers(t *testing.T, clients cloud.AWSClients, matchers []types.AWSMatcher, discoveryConfig string) []common.Fetcher {
 	t.Helper()
 
-	fetchers, err := MakeAWSFetchers(context.Background(), clients, matchers)
+	fetchers, err := MakeAWSFetchers(context.Background(), clients, matchers, discoveryConfig)
 	require.NoError(t, err)
 	require.NotEmpty(t, fetchers)
 
@@ -126,14 +126,14 @@ func testAWSFetchers(t *testing.T, tests ...awsFetcherTest) {
 		test.inputClients.STS = stsMock
 		t.Run(test.name, func(t *testing.T) {
 			t.Helper()
-			fetchers := mustMakeAWSFetchers(t, test.inputClients, test.inputMatchers)
+			fetchers := mustMakeAWSFetchers(t, test.inputClients, test.inputMatchers, "" /* discovery config */)
 			require.ElementsMatch(t, test.wantDatabases, mustGetDatabases(t, fetchers))
 		})
 		t.Run(test.name+" with assume role", func(t *testing.T) {
 			t.Helper()
 			matchers := copyAWSMatchersWithAssumeRole(testAssumeRole, test.inputMatchers...)
 			wantDBs := copyDatabasesWithAWSAssumeRole(testAssumeRole, test.wantDatabases...)
-			fetchers := mustMakeAWSFetchers(t, test.inputClients, matchers)
+			fetchers := mustMakeAWSFetchers(t, test.inputClients, matchers, "" /* discovery config */)
 			require.ElementsMatch(t, wantDBs, mustGetDatabases(t, fetchers))
 			require.Equal(t, []string{testAssumeRole.RoleARN}, stsMock.GetAssumedRoleARNs())
 			require.Equal(t, []string{testAssumeRole.ExternalID}, stsMock.GetAssumedRoleExternalIDs())

--- a/lib/srv/discovery/fetchers/db/helpers_test.go
+++ b/lib/srv/discovery/fetchers/db/helpers_test.go
@@ -70,7 +70,7 @@ func mustMakeAWSFetchers(t *testing.T, clients cloud.AWSClients, matchers []type
 func mustMakeAzureFetchers(t *testing.T, clients cloud.AzureClients, matchers []types.AzureMatcher) []common.Fetcher {
 	t.Helper()
 
-	fetchers, err := MakeAzureFetchers(clients, matchers)
+	fetchers, err := MakeAzureFetchers(clients, matchers, "" /* discovery config */)
 	require.NoError(t, err)
 	require.NotEmpty(t, fetchers)
 

--- a/lib/srv/discovery/fetchers/gke.go
+++ b/lib/srv/discovery/fetchers/gke.go
@@ -148,6 +148,13 @@ func (a *gkeFetcher) Cloud() string {
 	return types.CloudGCP
 }
 
+func (a *gkeFetcher) IntegrationName() string {
+	return ""
+}
+func (a *gkeFetcher) DiscoveryConfigName() string {
+	return ""
+}
+
 func (a *gkeFetcher) String() string {
 	return fmt.Sprintf("gkeFetcher(ProjectID=%v, Location=%v, FilterLabels=%v)",
 		a.ProjectID, a.Location, a.FilterLabels)

--- a/lib/srv/discovery/fetchers/gke.go
+++ b/lib/srv/discovery/fetchers/gke.go
@@ -48,6 +48,8 @@ type GKEFetcherConfig struct {
 	FilterLabels types.Labels
 	// Log is the logger.
 	Log logrus.FieldLogger
+	// DiscoveryConfig is the name of the discovery config which originated the resource.
+	DiscoveryConfig string
 }
 
 // CheckAndSetDefaults validates and sets the defaults values.
@@ -149,10 +151,11 @@ func (a *gkeFetcher) Cloud() string {
 }
 
 func (a *gkeFetcher) IntegrationName() string {
+	// There is currently no integration that supports Auto Discover for GCP resources.
 	return ""
 }
 func (a *gkeFetcher) DiscoveryConfigName() string {
-	return ""
+	return a.DiscoveryConfig
 }
 
 func (a *gkeFetcher) String() string {

--- a/lib/srv/discovery/fetchers/kube_services.go
+++ b/lib/srv/discovery/fetchers/kube_services.go
@@ -233,6 +233,14 @@ func (f *KubeAppFetcher) Cloud() string {
 	return ""
 }
 
+func (f *KubeAppFetcher) IntegrationName() string {
+	return ""
+}
+
+func (f *KubeAppFetcher) DiscoveryConfigName() string {
+	return ""
+}
+
 func (f *KubeAppFetcher) FetcherType() string {
 	return types.KubernetesMatchersApp
 }

--- a/lib/srv/discovery/fetchers/kube_services.go
+++ b/lib/srv/discovery/fetchers/kube_services.go
@@ -54,6 +54,8 @@ type KubeAppsFetcherConfig struct {
 	Log logrus.FieldLogger
 	// ProtocolChecker inspects port to find your whether they are HTTP/HTTPS or not.
 	ProtocolChecker ProtocolChecker
+	// DiscoveryConfig is the name of the discovery config which originated the resource.
+	DiscoveryConfig string
 }
 
 // CheckAndSetDefaults validates and sets the defaults values.
@@ -234,11 +236,12 @@ func (f *KubeAppFetcher) Cloud() string {
 }
 
 func (f *KubeAppFetcher) IntegrationName() string {
+	// KubeAppFetcher does not have an integration.
 	return ""
 }
 
 func (f *KubeAppFetcher) DiscoveryConfigName() string {
-	return ""
+	return f.DiscoveryConfig
 }
 
 func (f *KubeAppFetcher) FetcherType() string {


### PR DESCRIPTION
This PR adds two new labels to RDS and EKS resources:
- Integration
- DiscoveryConfig

Those labels help identify which Integration and DiscoveryConfig were used to auto enroll the resources.