### PR TITLE
Update DiscoveryConfigStatus with EKS and RDS enrollment summary

### DIFF
--- a/lib/srv/discovery/common/watcher.go
+++ b/lib/srv/discovery/common/watcher.go
@@ -96,10 +96,22 @@ type Watcher struct {
 	ctx context.Context
 	// resourcesC is a channel where fetched resourcess are sent.
 	resourcesC chan (types.ResourcesWithLabels)
+	// preFetchHookFn is called before starting a new fetch cycle.
+	preFetchHookFn func()
+}
+
+// WatcherOption is a functional option for the Watcher.
+type WatcherOption func(*Watcher)
+
+// WithPreFetchHookFn sets a function that gets called before each new iteration.
+func WithPreFetchHookFn(f func()) WatcherOption {
+	return func(w *Watcher) {
+		w.preFetchHookFn = f
+	}
 }
 
 // NewWatcher returns a new instance of a common discovery watcher.
-func NewWatcher(ctx context.Context, config WatcherConfig) (*Watcher, error) {
+func NewWatcher(ctx context.Context, config WatcherConfig, options ...WatcherOption) (*Watcher, error) {
 	if err := config.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -108,6 +120,11 @@ func NewWatcher(ctx context.Context, config WatcherConfig) (*Watcher, error) {
 		ctx:        ctx,
 		resourcesC: make(chan types.ResourcesWithLabels),
 	}
+
+	for _, opt := range options {
+		opt(watcher)
+	}
+
 	return watcher, nil
 }
 
@@ -141,6 +158,10 @@ func (w *Watcher) Start() {
 
 // fetchAndSend fetches resources from all fetchers and sends them to the channel.
 func (w *Watcher) fetchAndSend() {
+	if w.preFetchHookFn != nil {
+		w.preFetchHookFn()
+	}
+
 	var (
 		newFetcherResources = make(types.ResourcesWithLabels, 0, 50)
 		fetchersLock        sync.Mutex

--- a/lib/srv/discovery/common/watcher_test.go
+++ b/lib/srv/discovery/common/watcher_test.go
@@ -63,16 +63,15 @@ func TestWatcher(t *testing.T) {
 
 	clock := clockwork.NewFakeClock()
 	fetchIterations := atomic.Uint32{}
-	watcher, err := NewWatcher(ctx,
-		WatcherConfig{
-			FetchersFn: StaticFetchers([]Fetcher{appFetcher, noAuthFetcher, dbFetcher}),
-			Interval:   time.Hour,
-			Clock:      clock,
-			Origin:     types.OriginCloud,
-		},
-		WithPreFetchHookFn(func() {
+	watcher, err := NewWatcher(ctx, WatcherConfig{
+		FetchersFn: StaticFetchers([]Fetcher{appFetcher, noAuthFetcher, dbFetcher}),
+		Interval:   time.Hour,
+		Clock:      clock,
+		Origin:     types.OriginCloud,
+		PreFetchHookFn: func() {
 			fetchIterations.Add(1)
-		}))
+		},
+	})
 	require.NoError(t, err)
 	go watcher.Start()
 

--- a/lib/srv/discovery/database_watcher.go
+++ b/lib/srv/discovery/database_watcher.go
@@ -64,15 +64,20 @@ func (s *Server) startDatabaseWatchers() error {
 		return trace.Wrap(err)
 	}
 
-	watcher, err := common.NewWatcher(s.ctx, common.WatcherConfig{
-		FetchersFn:     s.getAllDatabaseFetchers,
-		Log:            s.LegacyLogger.WithField("kind", types.KindDatabase),
-		DiscoveryGroup: s.DiscoveryGroup,
-		Interval:       s.PollInterval,
-		TriggerFetchC:  s.newDiscoveryConfigChangedSub(),
-		Origin:         types.OriginCloud,
-		Clock:          s.clock,
-	})
+	watcher, err := common.NewWatcher(s.ctx,
+		common.WatcherConfig{
+			FetchersFn:     s.getAllDatabaseFetchers,
+			Log:            s.LegacyLogger.WithField("kind", types.KindDatabase),
+			DiscoveryGroup: s.DiscoveryGroup,
+			Interval:       s.PollInterval,
+			TriggerFetchC:  s.newDiscoveryConfigChangedSub(),
+			Origin:         types.OriginCloud,
+			Clock:          s.clock,
+		},
+		common.WithPreFetchHookFn(func() {
+			s.awsRDSResourcesStatus.reset()
+		}),
+	)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -80,6 +85,9 @@ func (s *Server) startDatabaseWatchers() error {
 
 	go func() {
 		for {
+			discoveryConfigsChanged := map[string]struct{}{}
+			resourcesFoundByGroup := make(map[awsResourceGroup]int)
+
 			select {
 			case newResources := <-watcher.ResourcesC():
 				dbs := make([]types.Database, 0, len(newResources))
@@ -89,20 +97,45 @@ func (s *Server) startDatabaseWatchers() error {
 						continue
 					}
 
+					resourceGroup := awsResourceGroupFromLabels(db.GetStaticLabels())
+					resourcesFoundByGroup[resourceGroup] = resourcesFoundByGroup[resourceGroup] + 1
+					discoveryConfigsChanged[resourceGroup.discoveryConfig] = struct{}{}
+
 					dbs = append(dbs, db)
 				}
 				mu.Lock()
 				newDatabases = dbs
 				mu.Unlock()
 
+				for group, count := range resourcesFoundByGroup {
+					s.awsRDSResourcesStatus.incrementFound(group, count)
+				}
+
 				if err := reconciler.Reconcile(s.ctx); err != nil {
 					s.Log.WarnContext(s.ctx, "Unable to reconcile database resources", "error", err)
-				} else if s.onDatabaseReconcile != nil {
+
+					// When reconcile fails, it is assumed that everything failed.
+					for group, count := range resourcesFoundByGroup {
+						s.awsRDSResourcesStatus.incrementFailed(group, count)
+					}
+
+					break
+				}
+
+				for group, count := range resourcesFoundByGroup {
+					s.awsRDSResourcesStatus.incrementEnrolled(group, count)
+				}
+
+				if s.onDatabaseReconcile != nil {
 					s.onDatabaseReconcile()
 				}
 
 			case <-s.ctx.Done():
 				return
+			}
+
+			for dc := range discoveryConfigsChanged {
+				s.updateDiscoveryConfigStatus(dc)
 			}
 		}
 	}()

--- a/lib/srv/discovery/database_watcher.go
+++ b/lib/srv/discovery/database_watcher.go
@@ -98,7 +98,7 @@ func (s *Server) startDatabaseWatchers() error {
 					}
 
 					resourceGroup := awsResourceGroupFromLabels(db.GetStaticLabels())
-					resourcesFoundByGroup[resourceGroup] = resourcesFoundByGroup[resourceGroup] + 1
+					resourcesFoundByGroup[resourceGroup] += 1
 					discoveryConfigsChanged[resourceGroup.discoveryConfig] = struct{}{}
 
 					dbs = append(dbs, db)

--- a/lib/srv/discovery/database_watcher.go
+++ b/lib/srv/discovery/database_watcher.go
@@ -73,10 +73,10 @@ func (s *Server) startDatabaseWatchers() error {
 			TriggerFetchC:  s.newDiscoveryConfigChangedSub(),
 			Origin:         types.OriginCloud,
 			Clock:          s.clock,
+			PreFetchHookFn: func() {
+				s.awsRDSResourcesStatus.reset()
+			},
 		},
-		common.WithPreFetchHookFn(func() {
-			s.awsRDSResourcesStatus.reset()
-		}),
 	)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -377,6 +377,8 @@ type Server struct {
 
 	awsSyncStatus         awsSyncStatus
 	awsEC2ResourcesStatus awsResourcesStatus
+	awsRDSResourcesStatus awsResourcesStatus
+	awsEKSResourcesStatus awsResourcesStatus
 	awsEC2Tasks           awsEC2Tasks
 
 	// caRotationCh receives nodes that need to have their CAs rotated.
@@ -411,6 +413,9 @@ func New(ctx context.Context, cfg *Config) (*Server, error) {
 		dynamicTAGSyncFetchers:     make(map[string][]aws_sync.AWSSync),
 		dynamicDiscoveryConfig:     make(map[string]*discoveryconfig.DiscoveryConfig),
 		awsSyncStatus:              awsSyncStatus{},
+		awsEC2ResourcesStatus:      newAWSResourceStatusCollector(types.AWSMatcherEC2),
+		awsRDSResourcesStatus:      newAWSResourceStatusCollector(types.AWSMatcherRDS),
+		awsEKSResourcesStatus:      newAWSResourceStatusCollector(types.AWSMatcherEKS),
 	}
 	s.discardUnsupportedMatchers(&s.Matchers)
 

--- a/lib/srv/discovery/kube_integration_watcher.go
+++ b/lib/srv/discovery/kube_integration_watcher.go
@@ -72,7 +72,12 @@ func (s *Server) startKubeIntegrationWatchers() error {
 		DiscoveryGroup: s.DiscoveryGroup,
 		Interval:       s.PollInterval,
 		Origin:         types.OriginCloud,
-	})
+		TriggerFetchC:  s.newDiscoveryConfigChangedSub(),
+	},
+		common.WithPreFetchHookFn(func() {
+			s.awsEKSResourcesStatus.reset()
+		}),
+	)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -80,6 +85,10 @@ func (s *Server) startKubeIntegrationWatchers() error {
 
 	go func() {
 		for {
+			discoveryConfigsChanged := map[string]struct{}{}
+			resourcesFoundByGroup := make(map[awsResourceGroup]int)
+			resourcesEnrolledByGroup := make(map[awsResourceGroup]int)
+
 			select {
 			case resources := <-watcher.ResourcesC():
 				if len(resources) == 0 {
@@ -98,15 +107,29 @@ func (s *Server) startKubeIntegrationWatchers() error {
 					continue
 				}
 
+				agentVersion, err := s.getKubeAgentVersion(releaseChannels)
+				if err != nil {
+					s.Log.WarnContext(s.ctx, "Could not get agent version to enroll EKS clusters", "error", err)
+					continue
+				}
+
 				var newClusters []types.DiscoveredEKSCluster
 				mu.Lock()
 				for _, r := range resources {
 					newCluster, ok := r.(types.DiscoveredEKSCluster)
-					if !ok ||
-						enrollingClusters[newCluster.GetAWSConfig().Name] ||
+					if !ok {
+						continue
+					}
+
+					resourceGroup := awsResourceGroupFromLabels(newCluster.GetStaticLabels())
+					resourcesFoundByGroup[resourceGroup] = resourcesFoundByGroup[resourceGroup] + 1
+					discoveryConfigsChanged[resourceGroup.discoveryConfig] = struct{}{}
+
+					if enrollingClusters[newCluster.GetAWSConfig().Name] ||
 						slices.ContainsFunc(existingServers, func(c types.KubeServer) bool { return c.GetName() == newCluster.GetName() }) ||
 						slices.ContainsFunc(existingClusters, func(c types.KubeCluster) bool { return c.GetName() == newCluster.GetName() }) {
 
+						resourcesEnrolledByGroup[resourceGroup] = resourcesEnrolledByGroup[resourceGroup] + 1
 						continue
 					}
 
@@ -114,26 +137,26 @@ func (s *Server) startKubeIntegrationWatchers() error {
 				}
 				mu.Unlock()
 
-				if len(newClusters) == 0 {
-					continue
+				for group, count := range resourcesFoundByGroup {
+					s.awsEKSResourcesStatus.incrementFound(group, count)
 				}
 
-				agentVersion, err := s.getKubeAgentVersion(releaseChannels)
-				if err != nil {
-					s.Log.WarnContext(s.ctx, "Could not get agent version to enroll EKS clusters", "error", err)
-					continue
+				if len(newClusters) == 0 {
+					break
 				}
 
 				// When enrolling EKS clusters, client for enrollment depends on the region and integration used.
 				type regionIntegrationMapKey struct {
-					region      string
-					integration string
+					region          string
+					integration     string
+					discoveryConfig string
 				}
 				clustersByRegionAndIntegration := map[regionIntegrationMapKey][]types.DiscoveredEKSCluster{}
 				for _, c := range newClusters {
 					mapKey := regionIntegrationMapKey{
-						region:      c.GetAWSConfig().Region,
-						integration: c.GetIntegration(),
+						region:          c.GetAWSConfig().Region,
+						integration:     c.GetIntegration(),
+						discoveryConfig: c.GetStaticLabels()[types.TeleportInternalDiscoveryConfigName],
 					}
 					clustersByRegionAndIntegration[mapKey] = append(clustersByRegionAndIntegration[mapKey], c)
 
@@ -141,18 +164,26 @@ func (s *Server) startKubeIntegrationWatchers() error {
 
 				for key, val := range clustersByRegionAndIntegration {
 					key, val := key, val
-					go s.enrollEKSClusters(key.region, key.integration, val, agentVersion, &mu, enrollingClusters)
+					go s.enrollEKSClusters(key.region, key.integration, key.discoveryConfig, val, agentVersion, &mu, enrollingClusters)
 				}
 
 			case <-s.ctx.Done():
 				return
+			}
+
+			for group, count := range resourcesEnrolledByGroup {
+				s.awsEKSResourcesStatus.incrementEnrolled(group, count)
+			}
+
+			for dc := range discoveryConfigsChanged {
+				s.updateDiscoveryConfigStatus(dc)
 			}
 		}
 	}()
 	return nil
 }
 
-func (s *Server) enrollEKSClusters(region, integration string, clusters []types.DiscoveredEKSCluster, agentVersion string, mu *sync.Mutex, enrollingClusters map[string]bool) {
+func (s *Server) enrollEKSClusters(region, integration, discoveryConfig string, clusters []types.DiscoveredEKSCluster, agentVersion string, mu *sync.Mutex, enrollingClusters map[string]bool) {
 	mu.Lock()
 	for _, c := range clusters {
 		if _, ok := enrollingClusters[c.GetAWSConfig().Name]; !ok {
@@ -167,6 +198,8 @@ func (s *Server) enrollEKSClusters(region, integration string, clusters []types.
 			delete(enrollingClusters, c.GetAWSConfig().Name)
 		}
 		mu.Unlock()
+
+		s.updateDiscoveryConfigStatus(discoveryConfig)
 	}()
 
 	// We sort input clusters into two batches - one that has Kubernetes App Discovery
@@ -195,12 +228,20 @@ func (s *Server) enrollEKSClusters(region, integration string, clusters []types.
 			AgentVersion:       agentVersion,
 		})
 		if err != nil {
+			s.awsEKSResourcesStatus.incrementFailed(awsResourceGroup{
+				discoveryConfig: discoveryConfig,
+				integration:     integration,
+			}, len(clusterNames))
 			s.Log.ErrorContext(ctx, "Failed to enroll EKS clusters", "cluster_names", clusterNames, "error", err)
 			continue
 		}
 
 		for _, r := range rsp.Results {
 			if r.Error != "" {
+				s.awsEKSResourcesStatus.incrementFailed(awsResourceGroup{
+					discoveryConfig: discoveryConfig,
+					integration:     integration,
+				}, 1)
 				if !strings.Contains(r.Error, "teleport-kube-agent is already installed on the cluster") {
 					s.Log.ErrorContext(ctx, "Failed to enroll EKS cluster", "cluster_name", r.EksClusterName, "error", err)
 				} else {

--- a/lib/srv/discovery/kube_integration_watcher.go
+++ b/lib/srv/discovery/kube_integration_watcher.go
@@ -121,14 +121,14 @@ func (s *Server) startKubeIntegrationWatchers() error {
 					}
 
 					resourceGroup := awsResourceGroupFromLabels(newCluster.GetStaticLabels())
-					resourcesFoundByGroup[resourceGroup] = resourcesFoundByGroup[resourceGroup] + 1
+					resourcesFoundByGroup[resourceGroup] += 1
 					discoveryConfigsChanged[resourceGroup.discoveryConfig] = struct{}{}
 
 					if enrollingClusters[newCluster.GetAWSConfig().Name] ||
 						slices.ContainsFunc(existingServers, func(c types.KubeServer) bool { return c.GetName() == newCluster.GetName() }) ||
 						slices.ContainsFunc(existingClusters, func(c types.KubeCluster) bool { return c.GetName() == newCluster.GetName() }) {
 
-						resourcesEnrolledByGroup[resourceGroup] = resourcesEnrolledByGroup[resourceGroup] + 1
+						resourcesEnrolledByGroup[resourceGroup] += 1
 						continue
 					}
 

--- a/lib/srv/discovery/kube_integration_watcher.go
+++ b/lib/srv/discovery/kube_integration_watcher.go
@@ -73,11 +73,10 @@ func (s *Server) startKubeIntegrationWatchers() error {
 		Interval:       s.PollInterval,
 		Origin:         types.OriginCloud,
 		TriggerFetchC:  s.newDiscoveryConfigChangedSub(),
-	},
-		common.WithPreFetchHookFn(func() {
+		PreFetchHookFn: func() {
 			s.awsEKSResourcesStatus.reset()
-		}),
-	)
+		},
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
This PR changes the DiscoveryService to add a new status report for RDS
and EKS Clusters.

It will, for each DiscoveryConfig/Integration, report how many resources
were found, enrolled and failed to enroll.

Demo
![image](https://github.com/user-attachments/assets/51d128bd-7cb6-4ef8-8616-18fb0a1aca1f)
