### PR TITLE
HTTP Endpoint to return Integration Summary (Dashboard)

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -978,6 +978,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.GET("/webapi/sites/:site/integrations", h.WithClusterAuth(h.integrationsList))
 	h.POST("/webapi/sites/:site/integrations", h.WithClusterAuth(h.integrationsCreate))
 	h.GET("/webapi/sites/:site/integrations/:name", h.WithClusterAuth(h.integrationsGet))
+	h.GET("/webapi/sites/:site/integrationdashboard/:name", h.WithClusterAuth(h.integrationDashboard))
 	h.PUT("/webapi/sites/:site/integrations/:name", h.WithClusterAuth(h.integrationsUpdate))
 	h.DELETE("/webapi/sites/:site/integrations/:name_or_subkind", h.WithClusterAuth(h.integrationsDelete))
 

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -978,8 +978,8 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.GET("/webapi/sites/:site/integrations", h.WithClusterAuth(h.integrationsList))
 	h.POST("/webapi/sites/:site/integrations", h.WithClusterAuth(h.integrationsCreate))
 	h.GET("/webapi/sites/:site/integrations/:name", h.WithClusterAuth(h.integrationsGet))
-	h.GET("/webapi/sites/:site/integrationdashboard/:name", h.WithClusterAuth(h.integrationDashboard))
 	h.PUT("/webapi/sites/:site/integrations/:name", h.WithClusterAuth(h.integrationsUpdate))
+	h.GET("/webapi/sites/:site/integrations/:name/stats", h.WithClusterAuth(h.integrationStats))
 	h.DELETE("/webapi/sites/:site/integrations/:name_or_subkind", h.WithClusterAuth(h.integrationsDelete))
 
 	// GET the Microsoft Teams plugin app.zip file.

--- a/lib/web/integrations.go
+++ b/lib/web/integrations.go
@@ -19,14 +19,18 @@
 package web
 
 import (
+	"context"
 	"net/http"
 	"net/url"
+	"slices"
+	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
 
 	pluginspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/plugins/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	"github.com/gravitational/teleport/integrations/access/msteams"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/httplib"
@@ -195,6 +199,122 @@ func (h *Handler) integrationsGet(w http.ResponseWriter, r *http.Request, p http
 	}
 
 	return uiIg, nil
+}
+
+// integrationDashboard returns the integration summary.
+func (h *Handler) integrationDashboard(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
+	integrationName := p.ByName("name")
+	if integrationName == "" {
+		return nil, trace.BadParameter("an integration name is required")
+	}
+
+	clt, err := sctx.GetUserClient(r.Context(), site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ig, err := clt.GetIntegration(r.Context(), integrationName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	summary, err := collectAWSOIDCAutoDiscoverStats(r.Context(), ig, clt.DiscoveryConfigClient())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return summary, nil
+}
+
+func collectAWSOIDCAutoDiscoverStats(
+	ctx context.Context,
+	integration types.Integration,
+	clt interface {
+		ListDiscoveryConfigs(ctx context.Context, pageSize int, nextToken string) ([]*discoveryconfig.DiscoveryConfig, string, error)
+	},
+) (ui.IntegrationWithSummary, error) {
+	var ret ui.IntegrationWithSummary
+
+	uiIg, err := ui.MakeIntegration(integration)
+	if err != nil {
+		return ret, err
+	}
+	ret.Integration = uiIg
+
+	var nextPage string
+	for {
+		discoveryConfigs, nextToken, err := clt.ListDiscoveryConfigs(ctx, 0, nextPage)
+		if err != nil {
+			return ret, trace.Wrap(err)
+		}
+		for _, dc := range discoveryConfigs {
+			discoveredResources, ok := dc.Status.IntegrationDiscoveredResources[integration.GetName()]
+			if !ok {
+				continue
+			}
+
+			if matchers := matchersWithIntegration(dc, types.AWSMatcherEC2, integration.GetName()); matchers != 0 {
+				ret.AWSEC2.RulesCount = ret.AWSEC2.RulesCount + matchers
+				ret.AWSEC2.DiscoverLastSync = lastSync(ret.AWSEC2.DiscoverLastSync, dc.Status.LastSyncTime)
+				ret.AWSEC2.ResourcesFound = ret.AWSEC2.ResourcesFound + int(discoveredResources.AwsEc2.Found)
+				ret.AWSEC2.ResourcesEnrollmentSuccess = ret.AWSEC2.ResourcesEnrollmentSuccess + int(discoveredResources.AwsEc2.Enrolled)
+				ret.AWSEC2.ResourcesEnrollmentFailed = ret.AWSEC2.ResourcesEnrollmentFailed + int(discoveredResources.AwsEc2.Failed)
+			}
+
+			if matchers := matchersWithIntegration(dc, types.AWSMatcherRDS, integration.GetName()); matchers != 0 {
+				ret.AWSRDS.RulesCount = ret.AWSRDS.RulesCount + matchers
+				ret.AWSRDS.DiscoverLastSync = lastSync(ret.AWSRDS.DiscoverLastSync, dc.Status.LastSyncTime)
+				ret.AWSRDS.ResourcesFound = ret.AWSRDS.ResourcesFound + int(discoveredResources.AwsRds.Found)
+				ret.AWSRDS.ResourcesEnrollmentSuccess = ret.AWSRDS.ResourcesEnrollmentSuccess + int(discoveredResources.AwsRds.Enrolled)
+				ret.AWSRDS.ResourcesEnrollmentFailed = ret.AWSRDS.ResourcesEnrollmentFailed + int(discoveredResources.AwsRds.Failed)
+			}
+
+			if matchers := matchersWithIntegration(dc, types.AWSMatcherEKS, integration.GetName()); matchers != 0 {
+				ret.AWSEKS.RulesCount = ret.AWSEKS.RulesCount + matchers
+				ret.AWSEKS.DiscoverLastSync = lastSync(ret.AWSEKS.DiscoverLastSync, dc.Status.LastSyncTime)
+				ret.AWSEKS.ResourcesFound = ret.AWSEKS.ResourcesFound + int(discoveredResources.AwsEks.Found)
+				ret.AWSEKS.ResourcesEnrollmentSuccess = ret.AWSEKS.ResourcesEnrollmentSuccess + int(discoveredResources.AwsEks.Enrolled)
+				ret.AWSEKS.ResourcesEnrollmentFailed = ret.AWSEKS.ResourcesEnrollmentFailed + int(discoveredResources.AwsEks.Failed)
+			}
+		}
+
+		if nextToken == "" {
+			break
+		}
+		nextPage = nextToken
+	}
+
+	// TODO(marco): add total number of ECS Database Services.
+	ret.AWSRDS.ECSDatabaseServiceCount = 0
+
+	return ret, nil
+}
+
+func lastSync(current *time.Time, new time.Time) *time.Time {
+	if current == nil {
+		return &new
+	}
+
+	if current.Before(new) {
+		return &new
+	}
+
+	return current
+}
+
+func matchersWithIntegration(dc *discoveryconfig.DiscoveryConfig, matcherType string, integration string) int {
+	ret := 0
+
+	for _, matcher := range dc.Spec.AWS {
+		if matcher.Integration != integration {
+			continue
+		}
+		if !slices.Contains(matcher.Types, matcherType) {
+			continue
+		}
+		ret += len(matcher.Regions)
+	}
+	return ret
 }
 
 // integrationsList returns a page of Integrations

--- a/lib/web/integrations.go
+++ b/lib/web/integrations.go
@@ -253,7 +253,7 @@ func collectAWSOIDCAutoDiscoverStats(
 				continue
 			}
 
-			if matchers := matchersWithIntegration(dc, types.AWSMatcherEC2, integration.GetName()); matchers != 0 {
+			if matchers := rulesWithIntegration(dc, types.AWSMatcherEC2, integration.GetName()); matchers != 0 {
 				ret.AWSEC2.RulesCount = ret.AWSEC2.RulesCount + matchers
 				ret.AWSEC2.DiscoverLastSync = lastSync(ret.AWSEC2.DiscoverLastSync, dc.Status.LastSyncTime)
 				ret.AWSEC2.ResourcesFound = ret.AWSEC2.ResourcesFound + int(discoveredResources.AwsEc2.Found)
@@ -261,7 +261,7 @@ func collectAWSOIDCAutoDiscoverStats(
 				ret.AWSEC2.ResourcesEnrollmentFailed = ret.AWSEC2.ResourcesEnrollmentFailed + int(discoveredResources.AwsEc2.Failed)
 			}
 
-			if matchers := matchersWithIntegration(dc, types.AWSMatcherRDS, integration.GetName()); matchers != 0 {
+			if matchers := rulesWithIntegration(dc, types.AWSMatcherRDS, integration.GetName()); matchers != 0 {
 				ret.AWSRDS.RulesCount = ret.AWSRDS.RulesCount + matchers
 				ret.AWSRDS.DiscoverLastSync = lastSync(ret.AWSRDS.DiscoverLastSync, dc.Status.LastSyncTime)
 				ret.AWSRDS.ResourcesFound = ret.AWSRDS.ResourcesFound + int(discoveredResources.AwsRds.Found)
@@ -269,7 +269,7 @@ func collectAWSOIDCAutoDiscoverStats(
 				ret.AWSRDS.ResourcesEnrollmentFailed = ret.AWSRDS.ResourcesEnrollmentFailed + int(discoveredResources.AwsRds.Failed)
 			}
 
-			if matchers := matchersWithIntegration(dc, types.AWSMatcherEKS, integration.GetName()); matchers != 0 {
+			if matchers := rulesWithIntegration(dc, types.AWSMatcherEKS, integration.GetName()); matchers != 0 {
 				ret.AWSEKS.RulesCount = ret.AWSEKS.RulesCount + matchers
 				ret.AWSEKS.DiscoverLastSync = lastSync(ret.AWSEKS.DiscoverLastSync, dc.Status.LastSyncTime)
 				ret.AWSEKS.ResourcesFound = ret.AWSEKS.ResourcesFound + int(discoveredResources.AwsEks.Found)
@@ -302,7 +302,10 @@ func lastSync(current *time.Time, new time.Time) *time.Time {
 	return current
 }
 
-func matchersWithIntegration(dc *discoveryconfig.DiscoveryConfig, matcherType string, integration string) int {
+// rulesWithIntegration returns the number of Rules for a given integration and matcher type in the DiscoveryConfig.
+// A Rule is similar to a DiscoveryConfig's Matcher, eg DiscoveryConfig.Spec.AWS.[<Matcher>], however, a Rule has a single region.
+// This means that the number of Rules for a given Matcher is equal to the number of regions on that Matcher.
+func rulesWithIntegration(dc *discoveryconfig.DiscoveryConfig, matcherType string, integration string) int {
 	ret := 0
 
 	for _, matcher := range dc.Spec.AWS {

--- a/lib/web/integrations.go
+++ b/lib/web/integrations.go
@@ -201,8 +201,8 @@ func (h *Handler) integrationsGet(w http.ResponseWriter, r *http.Request, p http
 	return uiIg, nil
 }
 
-// integrationDashboard returns the integration summary.
-func (h *Handler) integrationDashboard(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
+// integrationStats returns the integration stats.
+func (h *Handler) integrationStats(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	integrationName := p.ByName("name")
 	if integrationName == "" {
 		return nil, trace.BadParameter("an integration name is required")

--- a/lib/web/intgrations_test.go
+++ b/lib/web/intgrations_test.go
@@ -22,10 +22,13 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
+	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/web/ui"
 )
@@ -87,4 +90,132 @@ func TestIntegrationsCreateWithAudience(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestCollectAWSOIDCAutoDiscoverStats(t *testing.T) {
+	ctx := context.Background()
+	integrationName := "my-integration"
+	integration, err := types.NewIntegrationAWSOIDC(
+		types.Metadata{Name: integrationName},
+		&types.AWSOIDCIntegrationSpecV1{
+			RoleARN: "arn:role",
+		},
+	)
+	require.NoError(t, err)
+
+	t.Run("without discovery configs, returns just the integration", func(t *testing.T) {
+		clt := &mockDiscoveryConfigsGetter{
+			discoveryConfigs: make([]*discoveryconfig.DiscoveryConfig, 0),
+		}
+
+		gotSummary, err := collectAWSOIDCAutoDiscoverStats(ctx, integration, clt)
+		require.NoError(t, err)
+		expectedSummary := ui.IntegrationWithSummary{
+			Integration: &ui.Integration{
+				Name:    integrationName,
+				SubKind: "aws-oidc",
+				AWSOIDC: &ui.IntegrationAWSOIDCSpec{RoleARN: "arn:role"},
+			},
+		}
+		require.Equal(t, expectedSummary, gotSummary)
+	})
+
+	t.Run("collects multiple discovery configs", func(t *testing.T) {
+		syncTime := time.Now()
+		dcForEC2 := &discoveryconfig.DiscoveryConfig{
+			Spec: discoveryconfig.Spec{AWS: []types.AWSMatcher{{
+				Integration: integrationName,
+				Types:       []string{"ec2"},
+				Regions:     []string{"us-east-1"},
+			}}},
+			Status: discoveryconfig.Status{
+				LastSyncTime:        syncTime,
+				DiscoveredResources: 2,
+				IntegrationDiscoveredResources: map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+					integrationName: {
+						AwsEc2: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 2, Enrolled: 1, Failed: 1},
+					},
+				},
+			},
+		}
+		dcForRDS := &discoveryconfig.DiscoveryConfig{
+			Spec: discoveryconfig.Spec{AWS: []types.AWSMatcher{{
+				Integration: integrationName,
+				Types:       []string{"rds"},
+				Regions:     []string{"us-east-1", "us-east-2"},
+			}}},
+			Status: discoveryconfig.Status{
+				LastSyncTime:        syncTime,
+				DiscoveredResources: 2,
+				IntegrationDiscoveredResources: map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+					integrationName: {
+						AwsRds: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 2, Enrolled: 1, Failed: 1},
+					},
+				},
+			},
+		}
+		dcForEKS := &discoveryconfig.DiscoveryConfig{
+			Spec: discoveryconfig.Spec{AWS: []types.AWSMatcher{{
+				Integration: integrationName,
+				Types:       []string{"eks"},
+				Regions:     []string{"us-east-1"},
+			}}},
+			Status: discoveryconfig.Status{
+				LastSyncTime:        syncTime,
+				DiscoveredResources: 2,
+				IntegrationDiscoveredResources: map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+					integrationName: {
+						AwsEks: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 4, Enrolled: 0, Failed: 0},
+					},
+				},
+			},
+		}
+		clt := &mockDiscoveryConfigsGetter{
+			discoveryConfigs: []*discoveryconfig.DiscoveryConfig{
+				dcForEC2,
+				dcForRDS,
+				dcForEKS,
+			},
+		}
+
+		gotSummary, err := collectAWSOIDCAutoDiscoverStats(ctx, integration, clt)
+		require.NoError(t, err)
+		expectedSummary := ui.IntegrationWithSummary{
+			Integration: &ui.Integration{
+				Name:    integrationName,
+				SubKind: "aws-oidc",
+				AWSOIDC: &ui.IntegrationAWSOIDCSpec{RoleARN: "arn:role"},
+			},
+			AWSEC2: ui.ResourceTypeSummary{
+				RulesCount:                 1,
+				ResourcesFound:             2,
+				ResourcesEnrollmentFailed:  1,
+				ResourcesEnrollmentSuccess: 1,
+				DiscoverLastSync:           &syncTime,
+			},
+			AWSRDS: ui.ResourceTypeSummary{
+				RulesCount:                 2,
+				ResourcesFound:             2,
+				ResourcesEnrollmentFailed:  1,
+				ResourcesEnrollmentSuccess: 1,
+				DiscoverLastSync:           &syncTime,
+			},
+			AWSEKS: ui.ResourceTypeSummary{
+				RulesCount:                 1,
+				ResourcesFound:             4,
+				ResourcesEnrollmentFailed:  0,
+				ResourcesEnrollmentSuccess: 0,
+				DiscoverLastSync:           &syncTime,
+			},
+		}
+		require.Equal(t, expectedSummary, gotSummary)
+	})
+}
+
+type mockDiscoveryConfigsGetter struct {
+	discoveryConfigs []*discoveryconfig.DiscoveryConfig
+}
+
+func (m *mockDiscoveryConfigsGetter) ListDiscoveryConfigs(ctx context.Context, pageSize int, nextToken string) ([]*discoveryconfig.DiscoveryConfig, string, error) {
+	return m.discoveryConfigs, "", nil
 }

--- a/lib/web/ui/integration.go
+++ b/lib/web/ui/integration.go
@@ -21,6 +21,7 @@ package ui
 import (
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/gravitational/trace"
 
@@ -60,6 +61,39 @@ func (r *IntegrationAWSOIDCSpec) CheckAndSetDefaults() error {
 	}
 
 	return nil
+}
+
+// IntegrationWithSummary describes Integration fields and the fields required to return the summary.
+type IntegrationWithSummary struct {
+	*Integration
+	// AWSEC2 contains the summary for the AWS EC2 resources for this integration.
+	AWSEC2 ResourceTypeSummary `json:"awsec2,omitempty"`
+	// AWSRDS contains the summary for the AWS RDS resources and agents for this integration.
+	AWSRDS ResourceTypeSummary `json:"awsrds,omitempty"`
+	// AWSEKS contains the summary for the AWS EKS resources for this integration.
+	AWSEKS ResourceTypeSummary `json:"awseks,omitempty"`
+}
+
+// ResourceTypeSummary contains the summary of the enrollment rules and found resources by the integration.
+type ResourceTypeSummary struct {
+	// RulesCount is the number of enrollment rules that are using this integration.
+	// A rule is a matcher in a DiscoveryConfig that is being processed by a DiscoveryService.
+	// If the DiscoveryService is not reporting any Status, it means it is not being processed and it doesn't count for the number of rules.
+	// Example 1: a DiscoveryConfig with a matcher whose Type is "EC2" for two regions count as two EC2 rules.
+	// Example 2: a DiscoveryConfig with a matcher whose Types is "EC2,RDS" for one regions count as one EC2 rule.
+	// Example 3: a DiscoveryConfig with a matcher whose Types is "EC2,RDS", but has no DiscoveryService using it, it counts as 0 rules.
+	RulesCount int `json:"rulesCount,omitempty"`
+	// ResourcesFound contains the count of resources found by this integration.
+	ResourcesFound int `json:"resourcesFound,omitempty"`
+	// ResourcesEnrollmentFailed contains the count of resources that failed to enroll into the cluster.
+	ResourcesEnrollmentFailed int `json:"resourcesEnrollmentFailed,omitempty"`
+	// ResourcesEnrollmentSuccess contains the count of resources that succeeded to enroll into the cluster.
+	ResourcesEnrollmentSuccess int `json:"resourcesEnrollmentSuccess,omitempty"`
+	// DiscoverLastSync contains the time when this integration tried to auto-enroll resources.
+	DiscoverLastSync *time.Time `json:"discoverLastSync,omitempty"`
+	// ECSDatabaseServiceCount is the total number of DatabaseServices that were deployed into Amazon ECS.
+	// Only applicable for AWS RDS resource summary.
+	ECSDatabaseServiceCount int `json:"ecsDatabaseServiceCount,omitempty"`
 }
 
 // Integration describes Integration fields


### PR DESCRIPTION
This PR adds a new endpoint which returns the summary of an integration:
- EC2, RDS and EKS found and enrolled resources

It will be used to let the user know about what's the current state of
the integration.

PS: the number of deployed ECS agents is not yet filled, but will be as
soon as the other PR lands.


Demo:
`curl 'https://proxy.example.com/v1/webapi/sites/proxy.example.com/integrations/teleportdev/stats' --silent ... | jq`
```json
{
  "name": "teleportdev",
  "subKind": "aws-oidc",
  "awsoidc": {
    "roleArn": "arn:aws:iam::278576220453:role/MarcoLocalClusterIntegration"
  },
  "awsec2": {
    "rulesCount": 1,
    "resourcesFound": 15,
    "resourcesEnrollmentFailed": 2,
    "resourcesEnrollmentSuccess": 13,
    "discoverLastSync": "2024-11-25T12:11:08.879068Z"
  },
  "awsrds": {
    "rulesCount": 1,
    "resourcesFound": 2,
    "resourcesEnrollmentSuccess": 2,
    "discoverLastSync": "2024-11-25T12:11:08.306076Z"
  },
  "awseks": {
    "rulesCount": 1,
    "resourcesFound": 3,
    "resourcesEnrollmentFailed": 2,
    "discoverLastSync": "2024-11-25T12:11:42.83482Z"
  }
}
```