### PR TITLE
Disabling BundleIsVersionChecked for pkg installers

### DIFF
--- a/build.assets/build-package.sh
+++ b/build.assets/build-package.sh
@@ -316,9 +316,18 @@ if [[ "${PACKAGE_TYPE}" == "pkg" ]]; then
         done
     fi
 
+    # build the component plist
+    # make it non-relocatable
+    # disable version checking to allow for easier downgrading
+    component_plist="${PACKAGE_TEMPDIR}/${BUNDLE_ID}-component.plist"
+    pkgbuild --analyze --root "${PACKAGE_TEMPDIR}/${TAR_PATH}" "$component_plist"
+    plutil -replace BundleIsRelocatable -bool NO "$component_plist"
+    plutil -replace BundleIsVersionChecked -bool NO "$component_plist"
+
     # build the package for OS X
     pkgbuild \
         --root ${PACKAGE_TEMPDIR}/${TAR_PATH} \
+        --component-plist "$component_plist" \
         --identifier ${BUNDLE_ID} \
         --version ${TELEPORT_VERSION} \
         --install-location /usr/local/bin \

--- a/build.assets/build-pkg-app.sh
+++ b/build.assets/build-pkg-app.sh
@@ -25,6 +25,7 @@ make_non_relocatable_plist() {
 
   pkgbuild --analyze --root "$root" "$component_plist"
   plutil -replace BundleIsRelocatable -bool NO "$component_plist"
+  plutil -replace BundleIsVersionChecked -bool NO "$component_plist"
 }
 
 main() {


### PR DESCRIPTION
## Overview

The package installer utility by default will perform a version check to determine how to handle an already installed package. By default if it determines the version is a downgrade it will not perform any actions.

This can result in some surprising results e.g.:
```console
$ installer -pkg teleport-16.4.7.pkg -target /
$ tsh version
Teleport v16.4.7 git:v16.4.7-0-g15dfef1 go1.22.9
$ installer -pkg teleport-17.0.0-beta.2.pkg -target /
$ tsh version
Teleport v16.4.7 git:v16.4.7-0-g15dfef1 go1.22.9
```

## Implementation

To allow for downgrading we can disable `BundleIsVersionChecked` in the plist for our package installer bundles.

For documentation on the behavior of this attribute you can run the following on a Mac
```
man pkgutil
```

Fixes #41844

changelog: Downgrading Teleport through macOS Package Installers is now supported.