### PR TITLE
kms: fix panic in aws kms config validation

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1167,13 +1167,15 @@ func applyAWSKMSConfig(kmsConfig *AWSKMS, cfg *servicecfg.Config) error {
 	if kmsConfig.Account == "" {
 		return trace.BadParameter("must set account in ca_key_params.aws_kms")
 	}
-	cfg.Auth.KeyStore.AWSKMS.AWSAccount = kmsConfig.Account
 	if kmsConfig.Region == "" {
 		return trace.BadParameter("must set region in ca_key_params.aws_kms")
 	}
-	cfg.Auth.KeyStore.AWSKMS.AWSRegion = kmsConfig.Region
-	cfg.Auth.KeyStore.AWSKMS.MultiRegion = kmsConfig.MultiRegion
-	cfg.Auth.KeyStore.AWSKMS.Tags = kmsConfig.Tags
+	cfg.Auth.KeyStore.AWSKMS = &servicecfg.AWSKMSConfig{
+		AWSAccount:  kmsConfig.Account,
+		AWSRegion:   kmsConfig.Region,
+		MultiRegion: kmsConfig.MultiRegion,
+		Tags:        kmsConfig.Tags,
+	}
 	return nil
 }
 


### PR DESCRIPTION
missed this panic after changing the kms config to a pointer in #48132