### PR TITLE
[v16] Fix inaccurate docs URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Here is why you might use Teleport:
 
 Teleport works with SSH, Kubernetes, databases, RDP, and web services.
 
-* Architecture: https://goteleport.com/docs/architecture/
+* Architecture: https://goteleport.com/docs/reference/architecture/architecture
 * Getting Started: https://goteleport.com/docs/getting-started/
 
 <div align="center">

--- a/lib/tbot/config/migrate_test.go
+++ b/lib/tbot/config/migrate_test.go
@@ -304,7 +304,7 @@ destinations:
 		},
 		// Backwards compat with guides
 		{
-			name: "backwards compat with https://goteleport.com/docs/machine-id/guides/jenkins/",
+			name: "backwards compat with https://goteleport.com/docs/enroll-resources/machine-id/deployment/jenkins/",
 			input: `
 auth_server: "auth.example.com:3025"
 onboarding:

--- a/web/packages/teleport/src/Discover/SelectResource/databases.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/databases.tsx
@@ -26,24 +26,11 @@ import { ResourceKind } from '../Shared/ResourceKind';
 
 import { ResourceSpec, DatabaseLocation, DatabaseEngine } from './types';
 
-enum DatabaseGuideSection {
-  Aws = 'enroll-aws-databases',
-  Azure = 'enroll-azure-databases',
-  Gcp = 'enroll-google-cloud-databases',
-  Managed = 'enroll-managed-databases',
-  SelfHosted = 'enroll-self-hosted-databases',
-  Guides = 'guides',
-}
-
 const baseDatabaseKeywords = 'db database databases';
 const awsKeywords = baseDatabaseKeywords + 'aws amazon web services';
 const gcpKeywords = baseDatabaseKeywords + 'gcp google cloud provider';
 const selfhostedKeywords = baseDatabaseKeywords + 'self hosted self-hosted';
 const azureKeywords = baseDatabaseKeywords + 'microsoft azure';
-
-function getDbAccessDocLink(subsection: DatabaseGuideSection, guide: string) {
-  return `https://goteleport.com/docs/enroll-resources/database-access/${subsection}/${guide}`;
-}
 
 // DATABASES_UNGUIDED_DOC are documentations that is not specific
 // to one type of database.
@@ -54,10 +41,8 @@ export const DATABASES_UNGUIDED_DOC: ResourceSpec[] = [
     keywords: awsKeywords + 'rds proxy postgresql',
     kind: ResourceKind.Database,
     icon: 'aws',
-    unguidedLink: getDbAccessDocLink(
-      DatabaseGuideSection.Aws,
-      'rds-proxy-postgres'
-    ),
+    unguidedLink:
+      'https://goteleport.com/docs/enroll-resources/database-access/enroll-aws-databases/rds-proxy-postgres',
     // TODO(lisa): add a new usage event
     event: DiscoverEventResource.DatabaseDocRdsProxy,
   },
@@ -67,10 +52,8 @@ export const DATABASES_UNGUIDED_DOC: ResourceSpec[] = [
     keywords: awsKeywords + 'rds proxy sql server sqlserver',
     kind: ResourceKind.Database,
     icon: 'aws',
-    unguidedLink: getDbAccessDocLink(
-      DatabaseGuideSection.Aws,
-      'rds-proxy-sqlserver'
-    ),
+    unguidedLink:
+      'https://goteleport.com/docs/enroll-resources/database-access/enroll-aws-databases/rds-proxy-sqlserver',
     // TODO(lisa): add a new usage event
     event: DiscoverEventResource.DatabaseDocRdsProxy,
   },
@@ -80,10 +63,8 @@ export const DATABASES_UNGUIDED_DOC: ResourceSpec[] = [
     keywords: awsKeywords + 'rds proxy mariadb mysql',
     kind: ResourceKind.Database,
     icon: 'aws',
-    unguidedLink: getDbAccessDocLink(
-      DatabaseGuideSection.Aws,
-      'rds-proxy-mysql'
-    ),
+    unguidedLink:
+      'https://goteleport.com/docs/enroll-resources/database-access/enroll-aws-databases/rds-proxy-mysql',
     // TODO(lisa): add a new usage event
     event: DiscoverEventResource.DatabaseDocRdsProxy,
   },
@@ -93,7 +74,8 @@ export const DATABASES_UNGUIDED_DOC: ResourceSpec[] = [
     keywords: baseDatabaseKeywords + 'high availability ha',
     kind: ResourceKind.Database,
     icon: 'database',
-    unguidedLink: getDbAccessDocLink(DatabaseGuideSection.Guides, 'ha'),
+    unguidedLink:
+      'https://goteleport.com/docs/enroll-resources/database-access/guides/ha',
     event: DiscoverEventResource.DatabaseDocHighAvailability,
   },
   {
@@ -102,10 +84,8 @@ export const DATABASES_UNGUIDED_DOC: ResourceSpec[] = [
     keywords: baseDatabaseKeywords + 'dynamic registration',
     kind: ResourceKind.Database,
     icon: 'database',
-    unguidedLink: getDbAccessDocLink(
-      DatabaseGuideSection.Guides,
-      'dynamic-registration'
-    ),
+    unguidedLink:
+      'https://goteleport.com/docs/enroll-resources/database-access/guides/dynamic-registration',
     event: DiscoverEventResource.DatabaseDocDynamicRegistration,
   },
 ];
@@ -117,7 +97,8 @@ export const DATABASES_UNGUIDED: ResourceSpec[] = [
     keywords: awsKeywords + 'dynamodb',
     kind: ResourceKind.Database,
     icon: 'dynamo',
-    unguidedLink: getDbAccessDocLink(DatabaseGuideSection.Aws, 'aws-dynamodb'),
+    unguidedLink:
+      'https://goteleport.com/docs/enroll-resources/database-access/enroll-aws-databases/aws-dynamodb',
     event: DiscoverEventResource.DatabaseDynamoDb,
   },
   {
@@ -126,7 +107,8 @@ export const DATABASES_UNGUIDED: ResourceSpec[] = [
     keywords: awsKeywords + 'elasticache memorydb redis',
     kind: ResourceKind.Database,
     icon: 'aws',
-    unguidedLink: getDbAccessDocLink(DatabaseGuideSection.Aws, 'redis-aws'),
+    unguidedLink:
+      'https://goteleport.com/docs/enroll-resources/database-access/enroll-aws-databases/redis-aws',
     event: DiscoverEventResource.DatabaseRedisElasticache,
   },
   {
@@ -138,10 +120,8 @@ export const DATABASES_UNGUIDED: ResourceSpec[] = [
     keywords: awsKeywords + 'keyspaces apache cassandra',
     kind: ResourceKind.Database,
     icon: 'aws',
-    unguidedLink: getDbAccessDocLink(
-      DatabaseGuideSection.Aws,
-      'aws-cassandra-keyspaces'
-    ),
+    unguidedLink:
+      'https://goteleport.com/docs/enroll-resources/database-access/enroll-aws-databases/aws-cassandra-keyspaces',
     event: DiscoverEventResource.DatabaseCassandraKeyspaces,
   },
   {
@@ -150,10 +130,8 @@ export const DATABASES_UNGUIDED: ResourceSpec[] = [
     keywords: awsKeywords + 'redshift postgresql',
     kind: ResourceKind.Database,
     icon: 'redshift',
-    unguidedLink: getDbAccessDocLink(
-      DatabaseGuideSection.Aws,
-      'postgres-redshift'
-    ),
+    unguidedLink:
+      'https://goteleport.com/docs/enroll-resources/database-access/enroll-aws-databases/postgres-redshift',
     event: DiscoverEventResource.DatabasePostgresRedshift,
   },
   {
@@ -162,10 +140,8 @@ export const DATABASES_UNGUIDED: ResourceSpec[] = [
     keywords: awsKeywords + 'redshift serverless postgresql',
     kind: ResourceKind.Database,
     icon: 'redshift',
-    unguidedLink: getDbAccessDocLink(
-      DatabaseGuideSection.Aws,
-      'redshift-serverless'
-    ),
+    unguidedLink:
+      'https://goteleport.com/docs/enroll-resources/database-access/enroll-aws-databases/redshift-serverless',
     event: DiscoverEventResource.DatabasePostgresRedshiftServerless,
   },
   {
@@ -174,7 +150,8 @@ export const DATABASES_UNGUIDED: ResourceSpec[] = [
     keywords: azureKeywords + 'cache redis',
     kind: ResourceKind.Database,
     icon: 'azure',
-    unguidedLink: getDbAccessDocLink(DatabaseGuideSection.Azure, 'azure-redis'),
+    unguidedLink:
+      'https://goteleport.com/docs/enroll-resources/database-access/enroll-azure-databases/azure-redis',
     event: DiscoverEventResource.DatabaseRedisAzureCache,
   },
   {
@@ -186,10 +163,8 @@ export const DATABASES_UNGUIDED: ResourceSpec[] = [
     keywords: azureKeywords + 'postgresql',
     kind: ResourceKind.Database,
     icon: 'azure',
-    unguidedLink: getDbAccessDocLink(
-      DatabaseGuideSection.Azure,
-      'azure-postgres-mysql'
-    ),
+    unguidedLink:
+      'https://goteleport.com/docs/enroll-resources/database-access/enroll-azure-databases/azure-postgres-mysql',
     event: DiscoverEventResource.DatabasePostgresAzure,
   },
   {
@@ -198,10 +173,8 @@ export const DATABASES_UNGUIDED: ResourceSpec[] = [
     keywords: azureKeywords + 'mysql',
     kind: ResourceKind.Database,
     icon: 'azure',
-    unguidedLink: getDbAccessDocLink(
-      DatabaseGuideSection.Azure,
-      'azure-postgres-mysql'
-    ),
+    unguidedLink:
+      'https://goteleport.com/docs/enroll-resources/database-access/enroll-azure-databases/azure-postgres-mysql',
     event: DiscoverEventResource.DatabaseMysqlAzure,
   },
   {
@@ -214,10 +187,8 @@ export const DATABASES_UNGUIDED: ResourceSpec[] = [
       azureKeywords + 'active directory ad sql server sqlserver preview',
     kind: ResourceKind.Database,
     icon: 'azure',
-    unguidedLink: getDbAccessDocLink(
-      DatabaseGuideSection.Azure,
-      'azure-sql-server-ad'
-    ),
+    unguidedLink:
+      'https://goteleport.com/docs/enroll-resources/database-access/enroll-azure-databases/azure-sql-server-ad',
     event: DiscoverEventResource.DatabaseSqlServerAzure,
     platform: Platform.Windows,
   },
@@ -232,7 +203,8 @@ export const DATABASES_UNGUIDED: ResourceSpec[] = [
       'rds microsoft active directory ad sql server sqlserver preview',
     kind: ResourceKind.Database,
     icon: 'aws',
-    unguidedLink: getDbAccessDocLink(DatabaseGuideSection.Aws, 'sql-server-ad'),
+    unguidedLink:
+      'https://goteleport.com/docs/enroll-resources/database-access/enroll-aws-databases/sql-server-ad',
     event: DiscoverEventResource.DatabaseSqlServerMicrosoft,
     platform: Platform.Windows,
   },
@@ -242,10 +214,8 @@ export const DATABASES_UNGUIDED: ResourceSpec[] = [
     keywords: gcpKeywords + 'mysql',
     kind: ResourceKind.Database,
     icon: 'googlecloud',
-    unguidedLink: getDbAccessDocLink(
-      DatabaseGuideSection.Gcp,
-      'mysql-cloudsql'
-    ),
+    unguidedLink:
+      'https://goteleport.com/docs/enroll-resources/database-access/enroll-google-cloud-databases/mysql-cloudsql',
     event: DiscoverEventResource.DatabaseMysqlGcp,
   },
   {
@@ -254,10 +224,8 @@ export const DATABASES_UNGUIDED: ResourceSpec[] = [
     keywords: gcpKeywords + 'postgresql',
     kind: ResourceKind.Database,
     icon: 'googlecloud',
-    unguidedLink: getDbAccessDocLink(
-      DatabaseGuideSection.Gcp,
-      'postgres-cloudsql'
-    ),
+    unguidedLink:
+      'https://goteleport.com/docs/enroll-resources/database-access/enroll-google-cloud-databases/postgres-cloudsql',
     event: DiscoverEventResource.DatabasePostgresGcp,
   },
   {
@@ -269,10 +237,8 @@ export const DATABASES_UNGUIDED: ResourceSpec[] = [
     keywords: baseDatabaseKeywords + 'mongodb atlas',
     kind: ResourceKind.Database,
     icon: 'mongo',
-    unguidedLink: getDbAccessDocLink(
-      DatabaseGuideSection.Managed,
-      'mongodb-atlas'
-    ),
+    unguidedLink:
+      'https://goteleport.com/docs/enroll-resources/database-access/enroll-managed-databases/mongodb-atlas',
     event: DiscoverEventResource.DatabaseMongodbAtlas,
   },
   {
@@ -284,10 +250,8 @@ export const DATABASES_UNGUIDED: ResourceSpec[] = [
     keywords: selfhostedKeywords + 'cassandra scylladb',
     kind: ResourceKind.Database,
     icon: 'selfhosted',
-    unguidedLink: getDbAccessDocLink(
-      DatabaseGuideSection.SelfHosted,
-      'cassandra-self-hosted'
-    ),
+    unguidedLink:
+      'https://goteleport.com/docs/enroll-resources/database-access/enroll-self-hosted-databases/cassandra-self-hosted',
     event: DiscoverEventResource.DatabaseCassandraSelfHosted,
   },
   {
@@ -299,10 +263,8 @@ export const DATABASES_UNGUIDED: ResourceSpec[] = [
     keywords: selfhostedKeywords + 'cockroachdb',
     kind: ResourceKind.Database,
     icon: 'cockroach',
-    unguidedLink: getDbAccessDocLink(
-      DatabaseGuideSection.SelfHosted,
-      'cockroachdb-self-hosted'
-    ),
+    unguidedLink:
+      'https://goteleport.com/docs/enroll-resources/database-access/enroll-self-hosted-databases/cockroachdb-self-hosted',
     event: DiscoverEventResource.DatabaseCockroachDbSelfHosted,
   },
   {
@@ -314,10 +276,8 @@ export const DATABASES_UNGUIDED: ResourceSpec[] = [
     keywords: selfhostedKeywords + 'elasticsearch',
     kind: ResourceKind.Database,
     icon: 'selfhosted',
-    unguidedLink: getDbAccessDocLink(
-      DatabaseGuideSection.SelfHosted,
-      'elastic'
-    ),
+    unguidedLink:
+      'https://goteleport.com/docs/enroll-resources/database-access/enroll-self-hosted-databases/elastic',
     event: DiscoverEventResource.DatabaseElasticSearchSelfHosted,
   },
   {
@@ -329,10 +289,8 @@ export const DATABASES_UNGUIDED: ResourceSpec[] = [
     keywords: selfhostedKeywords + 'mongodb',
     kind: ResourceKind.Database,
     icon: 'mongo',
-    unguidedLink: getDbAccessDocLink(
-      DatabaseGuideSection.SelfHosted,
-      'mongodb-self-hosted'
-    ),
+    unguidedLink:
+      'https://goteleport.com/docs/enroll-resources/database-access/enroll-self-hosted-databases/mongodb-self-hosted',
     event: DiscoverEventResource.DatabaseMongodbSelfHosted,
   },
   {
@@ -344,7 +302,8 @@ export const DATABASES_UNGUIDED: ResourceSpec[] = [
     keywords: selfhostedKeywords + 'redis',
     kind: ResourceKind.Database,
     icon: 'selfhosted',
-    unguidedLink: getDbAccessDocLink(DatabaseGuideSection.SelfHosted, 'redis'),
+    unguidedLink:
+      'https://goteleport.com/docs/enroll-resources/database-access/enroll-self-hosted-databases/redis',
     event: DiscoverEventResource.DatabaseRedisSelfHosted,
   },
   {
@@ -356,10 +315,8 @@ export const DATABASES_UNGUIDED: ResourceSpec[] = [
     keywords: selfhostedKeywords + 'redis cluster',
     kind: ResourceKind.Database,
     icon: 'selfhosted',
-    unguidedLink: getDbAccessDocLink(
-      DatabaseGuideSection.SelfHosted,
-      'redis-cluster'
-    ),
+    unguidedLink:
+      'https://goteleport.com/docs/enroll-resources/database-access/enroll-self-hosted-databases/redis-cluster',
     event: DiscoverEventResource.DatabaseRedisClusterSelfHosted,
   },
   {
@@ -371,7 +328,8 @@ export const DATABASES_UNGUIDED: ResourceSpec[] = [
     keywords: baseDatabaseKeywords + 'snowflake preview',
     kind: ResourceKind.Database,
     icon: 'snowflake',
-    unguidedLink: getDbAccessDocLink(DatabaseGuideSection.Managed, 'snowflake'),
+    unguidedLink:
+      'https://goteleport.com/docs/enroll-resources/database-access/enroll-managed-databases/snowflake',
     event: DiscoverEventResource.DatabaseSnowflake,
   },
 ];


### PR DESCRIPTION
Backports #49001

Closes #48788

Fix docs URLs in `gravitational/teleport` pages that correspond to neither:
- A redirect source on the default version of the docs site
- A page on the current version of the docs site

In `web/packages/teleport/src/Discover/SelectResource/databases.tsx`, use literal strings instead of templated strings for docs URLs so we can check these URLs for inaccuracies.