### PR TITLE
Update the Terraform provider README

### DIFF
--- a/integrations/terraform/README.md
+++ b/integrations/terraform/README.md
@@ -7,22 +7,16 @@ Please, refer to [official documentation](https://goteleport.com/docs/admin-guid
 ## Development
 
 1. Install [`protobuf`](https://grpc.io/docs/protoc-installation/).
-2. Install [`protoc-gen-terraform`](https://github.com/gravitational/protoc-gen-terraform) @v2.2.0.
+2. Install [`protoc-gen-terraform`](https://github.com/gravitational/protoc-gen-terraform).
 
-    ```go install github.com/gravitational/protoc-gen-terraform@08768262d29336b8ae0915ef41bb6d9768518c66```
+    ```go install github.com/gravitational/protoc-gen-terraform@latest```
 
 3. Install [`Terraform`](https://learn.hashicorp.com/tutorials/terraform/install-cli) v1.1.0+. Alternatively, you can use [`tfenv`](https://github.com/tfutils/tfenv). Please note that on Mac M1 you need to specify `TFENV_ARCH` (ex: `TFENV_ARCH=arm64 tfenv install 1.1.6`).
-
-4. Clone the plugin:
-
-    ```bash
-    git clone git@github.com:gravitational/teleport-plugins
-    ```
 
 5. Build and install the plugin:
 
     ```bash
-    cd teleport-plugins/terraform
+    cd integrations/terraform
     make install
     ```
 
@@ -32,7 +26,7 @@ Please, refer to [official documentation](https://goteleport.com/docs/admin-guid
     make test
     ```
 
-    Note: Some tests won't pass without a valid `teleport` binary, enterprise license, etc. 
+    Note: Some tests won't pass without a valid `teleport` binary, enterprise license, etc.
     See [Testing](../TESTING.md) to see how to provide these values to the tests locally.
 
 # Updating the provider


### PR DESCRIPTION
Some of the instructions here were left over from when the provider was part of the teleport-plugins repo.