### PR TITLE
Fix a mistake causing document reopen dialog to be always hidden

### DIFF
--- a/web/packages/teleterm/src/ui/DocumentsReopen/DocumentsReopen.tsx
+++ b/web/packages/teleterm/src/ui/DocumentsReopen/DocumentsReopen.tsx
@@ -48,7 +48,7 @@ export function DocumentsReopen(props: {
 
   return (
     <DialogConfirmation
-      open={!history}
+      open={!props.hidden}
       keepInDOMAfterClose
       onClose={props.onCancel}
       dialogCss={() => ({


### PR DESCRIPTION
I wanted to type `hidden` and autocomplete changed it to `history` and I didn't notice it 🤦 
I verified other dialogs, they are fine.