### PR TITLE
(tsh) Add support for request search --format

### DIFF
--- a/tool/tsh/common/access_request.go
+++ b/tool/tsh/common/access_request.go
@@ -600,13 +600,13 @@ func onRequestSearch(cf *CLIConf) error {
 		}
 
 		if len(resourceIDs) > 0 {
-			resourcesStr := strings.Trim(strings.Join(resourceIDs, " --resource "), " ")
+			resourcesStr := strings.Join(resourceIDs, " --resource ")
 			fmt.Fprintf(cf.Stdout(), `
-	To request access to these resources, run
-	> tsh request create --resource %s \
-		--reason <request reason>
+To request access to these resources, run
+> tsh request create --resource %s \
+    --reason <request reason>
 
-	`, resourcesStr)
+`, resourcesStr)
 		}
 	case teleport.JSON, teleport.YAML:
 		output, err := serializeAccessRequestSearchOutput(tableColumns, rows, format)

--- a/tool/tsh/common/access_request.go
+++ b/tool/tsh/common/access_request.go
@@ -436,10 +436,13 @@ func serializeAccessRequestSearchOutput(tableColumns []string, rows [][]string, 
 		rowsToMap.RequestCommand = fmt.Sprintf("tsh request create --resource %s --reason <request reason>", strings.Join(resourceIDs, " --resource "))
 	}
 
-	if format == teleport.JSON {
+	switch format {
+	case teleport.JSON:
 		out, err = utils.FastMarshalIndent(rowsToMap, "", "  ")
-	} else {
+	case teleport.YAML:
 		out, err = yaml.Marshal(rowsToMap)
+	default:
+		return "", trace.BadParameter("unsupported format %q", format)
 	}
 
 	if err != nil {

--- a/tool/tsh/common/access_request_test.go
+++ b/tool/tsh/common/access_request_test.go
@@ -265,14 +265,7 @@ func TestAccessRequestSearch(t *testing.T) {
 			}
 			err := Run(
 				ctx,
-				append([]string{
-					"--insecure",
-					"request",
-					"search",
-					fmt.Sprintf("--kind=%s", tc.args.kind),
-				},
-					tc.args.extraArgs...,
-				),
+				args,
 				setCopyStdout(captureStdout),
 				setHomePath(homePath),
 			)

--- a/tool/tsh/common/access_request_test.go
+++ b/tool/tsh/common/access_request_test.go
@@ -277,9 +277,12 @@ func TestAccessRequestSearch(t *testing.T) {
 				setHomePath(homePath),
 			)
 			require.NoError(t, err)
-			if tc.args.format == "json" || tc.args.format == "yaml" {
-				require.Equal(t, captureStdout.String(), tc.wantOutput())
-			} else {
+			switch tc.args.format {
+			case "json":
+				require.JSONEq(t, tc.wantOutput(), captureStdout.String())
+			case "yaml":
+				require.YAMLEq(t, tc.wantOutput(), captureStdout.String())
+			default:
 				// We append a newline to the expected output to ensure that the table
 				// does not contain any more rows than expected.
 				require.Contains(t, captureStdout.String(), tc.wantOutput()+"\n")

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1386,10 +1386,11 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	reqSearch.Flag("labels", labelHelp).StringVar(&cf.Labels)
 	reqSearch.Flag("kube-cluster", "Kubernetes Cluster to search for Pods.").StringVar(&cf.KubernetesCluster)
 	// kube-namespace exists for backwards compatibility.
-	reqSearch.Flag("kube-namespace", "Kubernetes Namespace to search for Pods.").Hidden().Default(corev1.NamespaceDefault).StringVar(&cf.kubeNamespace)
-	reqSearch.Flag("namespace", "Kubernetes Namespace to search for Pods.").Default(corev1.NamespaceDefault).StringVar(&cf.kubeNamespace)
-	reqSearch.Flag("all-kube-namespaces", "Search Pods in every namespace.").BoolVar(&cf.kubeAllNamespaces)
-	reqSearch.Flag("verbose", "Verbose table output, shows full label output.").Short('v').BoolVar(&cf.Verbose)
+	reqSearch.Flag("kube-namespace", "Kubernetes Namespace to search for Pods").Hidden().Default(corev1.NamespaceDefault).StringVar(&cf.kubeNamespace)
+	reqSearch.Flag("namespace", "Kubernetes Namespace to search for Pods").Default(corev1.NamespaceDefault).StringVar(&cf.kubeNamespace)
+	reqSearch.Flag("all-kube-namespaces", "Search Pods in every namespace").BoolVar(&cf.kubeAllNamespaces)
+	reqSearch.Flag("verbose", "Verbose table output, shows full label output").Short('v').BoolVar(&cf.Verbose)
+	reqSearch.Flag("format", defaults.FormatFlagDescription(defaults.DefaultFormats...)).Short('f').Default(teleport.Text).EnumVar(&cf.Format, defaults.DefaultFormats...)
 
 	// Headless login approval
 	headless := app.Command("headless", "Headless authentication commands.").Interspersed(true)


### PR DESCRIPTION
This PR proposes adding the `--format` argument support to the `tsh request search` command for better consistency with other `tsh` commands and ultimately help with user scripting on top of the access requests feature.

Changelog: add support for tsh request search --format

Closes: https://github.com/gravitational/teleport/issues/41953