### PR TITLE
Increase the number of times CI runs benchmarks

### DIFF
--- a/.github/workflows/benchmark-code-nonroot.yaml
+++ b/.github/workflows/benchmark-code-nonroot.yaml
@@ -59,7 +59,7 @@ jobs:
       # Run benchmarks once to make sure they don't break
       # Must be run separate since gotestsum is not compatible with benchmark output
       - name: Run Benchmarks Once
-        timeout-minutes: 5
+        timeout-minutes: 25
         shell: bash # Overriding default shell which is `sh -e`
         run: make test-go-bench | sed -u -E "s/^(FAIL\s+github)/::error title=Benchmark Failed::\1/"
 

--- a/.github/workflows/benchmark-code-root.yaml
+++ b/.github/workflows/benchmark-code-root.yaml
@@ -59,7 +59,7 @@ jobs:
       # Run benchmarks once to make sure they don't break
       # Must be run separate since gotestsum is not compatible with benchmark output
       - name: Run Benchmarks Once
-        timeout-minutes: 5
+        timeout-minutes: 25
         shell: bash # Overriding default shell which is `sh -e`
         run: make test-go-bench-root | sed -u -E "s/^(FAIL\s+github)/::error title=Benchmark Failed::\1/"
 

--- a/Makefile
+++ b/Makefile
@@ -943,14 +943,14 @@ endif
 test-go-bench: PACKAGES = $(shell grep --exclude-dir api --include "*_test.go" -lr testing.B .  | xargs dirname | xargs go list | sort -u)
 test-go-bench: BENCHMARK_SKIP_PATTERN = "^BenchmarkRoot"
 test-go-bench: | $(TEST_LOG_DIR)
-	go test -run ^$$ -bench . -skip $(BENCHMARK_SKIP_PATTERN) -count=6 -benchtime 1x $(PACKAGES) \
+	go test -run ^$$ -bench . -skip $(BENCHMARK_SKIP_PATTERN) -count=6 $(PACKAGES) \
 		| tee $(TEST_LOG_DIR)/bench.txt
 
 test-go-bench-root: PACKAGES = $(shell grep --exclude-dir api --include "*_test.go" -lr BenchmarkRoot .  | xargs dirname | xargs go list | sort -u)
 test-go-bench-root: BENCHMARK_PATTERN = "^BenchmarkRoot"
 test-go-bench-root: BENCHMARK_SKIP_PATTERN = ""
 test-go-bench-root: | $(TEST_LOG_DIR)
-	go test -run ^$$ -bench $(BENCHMARK_PATTERN) -skip $(BENCHMARK_SKIP_PATTERN) -count=6 -benchtime 1x $(PACKAGES) \
+	go test -run ^$$ -bench $(BENCHMARK_PATTERN) -skip $(BENCHMARK_SKIP_PATTERN) -count=6 $(PACKAGES) \
 		| tee $(TEST_LOG_DIR)/bench.txt
 
 # Make sure untagged vnetdaemon code build/tests.

--- a/Makefile
+++ b/Makefile
@@ -943,14 +943,14 @@ endif
 test-go-bench: PACKAGES = $(shell grep --exclude-dir api --include "*_test.go" -lr testing.B .  | xargs dirname | xargs go list | sort -u)
 test-go-bench: BENCHMARK_SKIP_PATTERN = "^BenchmarkRoot"
 test-go-bench: | $(TEST_LOG_DIR)
-	go test -run ^$$ -bench . -skip $(BENCHMARK_SKIP_PATTERN) -benchtime 1x $(PACKAGES) \
+	go test -run ^$$ -bench . -skip $(BENCHMARK_SKIP_PATTERN) -count=6 -benchtime 1x $(PACKAGES) \
 		| tee $(TEST_LOG_DIR)/bench.txt
 
 test-go-bench-root: PACKAGES = $(shell grep --exclude-dir api --include "*_test.go" -lr BenchmarkRoot .  | xargs dirname | xargs go list | sort -u)
 test-go-bench-root: BENCHMARK_PATTERN = "^BenchmarkRoot"
 test-go-bench-root: BENCHMARK_SKIP_PATTERN = ""
 test-go-bench-root: | $(TEST_LOG_DIR)
-	go test -run ^$$ -bench $(BENCHMARK_PATTERN) -skip $(BENCHMARK_SKIP_PATTERN) -benchtime 1x $(PACKAGES) \
+	go test -run ^$$ -bench $(BENCHMARK_PATTERN) -skip $(BENCHMARK_SKIP_PATTERN) -count=6 -benchtime 1x $(PACKAGES) \
 		| tee $(TEST_LOG_DIR)/bench.txt
 
 # Make sure untagged vnetdaemon code build/tests.

--- a/Makefile
+++ b/Makefile
@@ -943,14 +943,14 @@ endif
 test-go-bench: PACKAGES = $(shell grep --exclude-dir api --include "*_test.go" -lr testing.B .  | xargs dirname | xargs go list | sort -u)
 test-go-bench: BENCHMARK_SKIP_PATTERN = "^BenchmarkRoot"
 test-go-bench: | $(TEST_LOG_DIR)
-	go test -run ^$$ -bench . -skip $(BENCHMARK_SKIP_PATTERN) -count=6 $(PACKAGES) \
+	go test -run ^$$ -bench . -skip $(BENCHMARK_SKIP_PATTERN) -benchtime=6x $(PACKAGES) \
 		| tee $(TEST_LOG_DIR)/bench.txt
 
 test-go-bench-root: PACKAGES = $(shell grep --exclude-dir api --include "*_test.go" -lr BenchmarkRoot .  | xargs dirname | xargs go list | sort -u)
 test-go-bench-root: BENCHMARK_PATTERN = "^BenchmarkRoot"
 test-go-bench-root: BENCHMARK_SKIP_PATTERN = ""
 test-go-bench-root: | $(TEST_LOG_DIR)
-	go test -run ^$$ -bench $(BENCHMARK_PATTERN) -skip $(BENCHMARK_SKIP_PATTERN) -count=6 $(PACKAGES) \
+	go test -run ^$$ -bench $(BENCHMARK_PATTERN) -skip $(BENCHMARK_SKIP_PATTERN) -benchtime=6x $(PACKAGES) \
 		| tee $(TEST_LOG_DIR)/bench.txt
 
 # Make sure untagged vnetdaemon code build/tests.


### PR DESCRIPTION
This is in an attempt to provide more reliable test results. 6 was chosen as that's the minimum number benchstat requires for a 95% confidence interval.


Example of warning emitted from benchstat in CI: https://github.com/gravitational/teleport/actions/runs/11862270592