### PR TITLE
[teleport-update] Add support for systemd process management

### DIFF
--- a/lib/autoupdate/agent/config.go
+++ b/lib/autoupdate/agent/config.go
@@ -1,0 +1,95 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"text/template"
+
+	"github.com/gravitational/trace"
+)
+
+const (
+	teleportDropinTemplate = `# teleport-update
+[Service]
+ExecStopPost=/bin/bash -c 'date +%%s > {{.DataDir}}/last-restart'
+`
+	updateServiceTemplate = `# teleport-update
+[Unit]
+Description=Teleport update service
+
+[Service]
+Type=oneshot
+ExecStart={{.LinkDir}}/bin/teleport-update update
+`
+	updateTimerTemplate = `# teleport-update
+[Unit]
+Description=Teleport update timer unit
+
+[Timer]
+OnActiveSec=1m
+OnUnitActiveSec=5m
+RandomizedDelaySec=1m
+
+[Install]
+WantedBy=teleport.service
+`
+)
+
+func WriteConfigFiles(linkDir, dataDir string) error {
+	// TODO(sclevine): revert on failure
+
+	dropinPath := filepath.Join(linkDir, serviceDir, serviceName+".d", serviceDropinName)
+	err := writeTemplate(dropinPath, teleportDropinTemplate, linkDir, dataDir)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	servicePath := filepath.Join(linkDir, serviceDir, updateServiceName)
+	err = writeTemplate(servicePath, updateServiceTemplate, linkDir, dataDir)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	timerPath := filepath.Join(linkDir, serviceDir, updateTimerName)
+	err = writeTemplate(timerPath, updateTimerTemplate, linkDir, dataDir)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+func writeTemplate(path, t, linkDir, dataDir string) error {
+	if err := os.MkdirAll(filepath.Dir(path), systemDirMode); err != nil {
+		return trace.Wrap(err)
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, configFileMode)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer f.Close()
+	tmpl, err := template.New(filepath.Base(path)).Parse(t)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = tmpl.Execute(f, struct {
+		LinkDir string
+		DataDir string
+	}{linkDir, dataDir})
+	return trace.Wrap(f.Close())
+}

--- a/lib/autoupdate/agent/config.go
+++ b/lib/autoupdate/agent/config.go
@@ -30,13 +30,9 @@ import (
 )
 
 const (
-	teleportDropinTemplate = `# teleport-update
-[Service]
-ExecStopPost=/bin/bash -c 'date +%%s > {{.DataDir}}/last-restart'
-`
 	updateServiceTemplate = `# teleport-update
 [Unit]
-Description=Teleport update service
+Description=Teleport auto-update service
 
 [Service]
 Type=oneshot
@@ -44,7 +40,7 @@ ExecStart={{.LinkDir}}/bin/teleport-update update
 `
 	updateTimerTemplate = `# teleport-update
 [Unit]
-Description=Teleport update timer unit
+Description=Teleport auto-update timer unit
 
 [Timer]
 OnActiveSec=1m
@@ -82,13 +78,8 @@ func Setup(ctx context.Context, log *slog.Logger, linkDir, dataDir string) error
 func writeConfigFiles(linkDir, dataDir string) error {
 	// TODO(sclevine): revert on failure
 
-	dropinPath := filepath.Join(linkDir, serviceDir, serviceName+".d", serviceDropinName)
-	err := writeTemplate(dropinPath, teleportDropinTemplate, linkDir, dataDir)
-	if err != nil {
-		return trace.Wrap(err)
-	}
 	servicePath := filepath.Join(linkDir, serviceDir, updateServiceName)
-	err = writeTemplate(servicePath, updateServiceTemplate, linkDir, dataDir)
+	err := writeTemplate(servicePath, updateServiceTemplate, linkDir, dataDir)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/autoupdate/agent/config.go
+++ b/lib/autoupdate/agent/config.go
@@ -64,8 +64,8 @@ func Setup(ctx context.Context, log *slog.Logger, linkDir, dataDir string) error
 		ServiceName: "teleport-update.timer",
 		Log:         log,
 	}
-	if err := svc.Reload(ctx); err != nil {
-		return trace.Errorf("failed to reload systemd config: %w", err)
+	if err := svc.Sync(ctx); err != nil {
+		return trace.Errorf("failed to sync systemd config: %w", err)
 	}
 	if err := svc.Enable(ctx, true); err != nil {
 		return trace.Errorf("failed to enable teleport-update systemd timer: %w", err)

--- a/lib/autoupdate/agent/config_test.go
+++ b/lib/autoupdate/agent/config_test.go
@@ -1,0 +1,66 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package agent
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	libdefaults "github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/utils/golden"
+)
+
+func TestWriteConfigFiles(t *testing.T) {
+	t.Parallel()
+	linkDir := t.TempDir()
+	dataDir := t.TempDir()
+	err := WriteConfigFiles(linkDir, dataDir)
+	require.NoError(t, err)
+
+	for _, p := range []string{
+		filepath.Join(linkDir, serviceDir, serviceName+".d", serviceDropinName),
+		filepath.Join(linkDir, serviceDir, updateServiceName),
+		filepath.Join(linkDir, serviceDir, updateTimerName),
+	} {
+		t.Run(filepath.Base(p), func(t *testing.T) {
+			data, err := os.ReadFile(p)
+			require.NoError(t, err)
+			data = replaceValues(data, map[string]string{
+				DefaultLinkDir:      linkDir,
+				libdefaults.DataDir: dataDir,
+			})
+			if golden.ShouldSet() {
+				golden.Set(t, data)
+			}
+			require.Equal(t, string(golden.Get(t)), string(data))
+		})
+	}
+}
+
+func replaceValues(data []byte, m map[string]string) []byte {
+	for k, v := range m {
+		data = bytes.ReplaceAll(data, []byte(v),
+			[]byte(k))
+	}
+	return data
+}

--- a/lib/autoupdate/agent/config_test.go
+++ b/lib/autoupdate/agent/config_test.go
@@ -38,7 +38,6 @@ func TestWriteConfigFiles(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, p := range []string{
-		filepath.Join(linkDir, serviceDir, serviceName+".d", serviceDropinName),
 		filepath.Join(linkDir, serviceDir, updateServiceName),
 		filepath.Join(linkDir, serviceDir, updateTimerName),
 	} {

--- a/lib/autoupdate/agent/config_test.go
+++ b/lib/autoupdate/agent/config_test.go
@@ -34,7 +34,7 @@ func TestWriteConfigFiles(t *testing.T) {
 	t.Parallel()
 	linkDir := t.TempDir()
 	dataDir := t.TempDir()
-	err := WriteConfigFiles(linkDir, dataDir)
+	err := writeConfigFiles(linkDir, dataDir)
 	require.NoError(t, err)
 
 	for _, p := range []string{

--- a/lib/autoupdate/agent/installer.go
+++ b/lib/autoupdate/agent/installer.go
@@ -604,13 +604,6 @@ func forceCopy(dst, src string, n int64) (orig *smallFile, err error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return forceWrite(dst, srcData, n)
-}
-
-func forceWrite(dst string, data []byte, n int64) (orig *smallFile, err error) {
-	if l := len(data); int64(l) > n {
-		return nil, trace.Errorf("data too large for file (%d > %d)", l, n)
-	}
 	fi, err := os.Lstat(dst)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return nil, trace.Wrap(err)
@@ -627,11 +620,11 @@ func forceWrite(dst string, data []byte, n int64) (orig *smallFile, err error) {
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		if bytes.Equal(data, orig.data) {
+		if bytes.Equal(srcData, orig.data) {
 			return nil, trace.Wrap(os.ErrExist)
 		}
 	}
-	err = renameio.WriteFile(dst, data, configFileMode)
+	err = renameio.WriteFile(dst, srcData, configFileMode)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/autoupdate/agent/installer.go
+++ b/lib/autoupdate/agent/installer.go
@@ -788,13 +788,5 @@ func (li *LocalInstaller) isLinked(versionDir string) (bool, error) {
 			return true, nil
 		}
 	}
-	linkData, err := readFileN(filepath.Join(li.LinkServiceDir, serviceName), maxServiceFileSize)
-	if err != nil {
-		return false, nil
-	}
-	versionData, err := readFileN(filepath.Join(versionDir, serviceDir, serviceName), maxServiceFileSize)
-	if err != nil {
-		return false, nil
-	}
-	return bytes.Equal(linkData, versionData), nil
+	return false, nil
 }

--- a/lib/autoupdate/agent/installer.go
+++ b/lib/autoupdate/agent/installer.go
@@ -60,8 +60,6 @@ const (
 	serviceDir = "lib/systemd/system"
 	// serviceName contains the name of the Teleport SystemD service file.
 	serviceName = "teleport.service"
-	// serviceDropinName contains the name of the Teleport Systemd service drop-in to support updates.
-	serviceDropinName = "teleport-update.conf"
 	// updateServiceName contains the name of the Teleport Update Systemd service
 	updateServiceName = "teleport-update.service"
 	// updateTimerName contains the name of the Teleport Update Systemd timer

--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -123,6 +123,7 @@ func (s SystemdService) systemctl(ctx context.Context, errLevel slog.Level, args
 	return code
 }
 
+// LocalExec runs a command locally, logging any output.
 type LocalExec struct {
 	// Log contains a slog logger.
 	// Defaults to slog.Default() if nil.
@@ -133,6 +134,8 @@ type LocalExec struct {
 	OutLevel slog.Level
 }
 
+// Run the command. Same arguments as exec.CommandContext.
+// Outputs the status code, or -1 if out-of-range or unstarted.
 func (c *LocalExec) Run(ctx context.Context, name string, args ...string) (int, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 	stderr := &lineLogger{ctx: ctx, log: c.Log, level: c.ErrLevel}

--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -217,7 +217,7 @@ func readInt(path string) (int, error) {
 
 // tickFile reads the current time on tickC, and outputs the last read int from path on ch for each received tick.
 // If the path cannot be read, tickFile sends 0 on ch.
-// Any error from the last attempt to read path is returned when ctx is cancelled, unless the error is os.ErrNotExist.
+// Any error from the last attempt to read path is returned when ctx is canceled, unless the error is os.ErrNotExist.
 func tickFile(ctx context.Context, path string, ch chan<- int, tickC <-chan time.Time) error {
 	var err error
 	for {

--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -108,7 +108,7 @@ func (s SystemdService) checkSystem(ctx context.Context) error {
 // Output sent to stdout is logged at debug level.
 // Output sent to stderr is logged at the level specified by errLevel.
 func (s SystemdService) systemctl(ctx context.Context, errLevel slog.Level, args ...string) int {
-	cmd := &LocalExec{
+	cmd := &localExec{
 		Log:      s.Log,
 		ErrLevel: errLevel,
 		OutLevel: slog.LevelDebug,
@@ -123,8 +123,8 @@ func (s SystemdService) systemctl(ctx context.Context, errLevel slog.Level, args
 	return code
 }
 
-// LocalExec runs a command locally, logging any output.
-type LocalExec struct {
+// localExec runs a command locally, logging any output.
+type localExec struct {
 	// Log contains a slog logger.
 	// Defaults to slog.Default() if nil.
 	Log *slog.Logger
@@ -136,7 +136,7 @@ type LocalExec struct {
 
 // Run the command. Same arguments as exec.CommandContext.
 // Outputs the status code, or -1 if out-of-range or unstarted.
-func (c *LocalExec) Run(ctx context.Context, name string, args ...string) (int, error) {
+func (c *localExec) Run(ctx context.Context, name string, args ...string) (int, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 	stderr := &lineLogger{ctx: ctx, log: c.Log, level: c.ErrLevel}
 	stdout := &lineLogger{ctx: ctx, log: c.Log, level: c.OutLevel}

--- a/lib/autoupdate/agent/process_test.go
+++ b/lib/autoupdate/agent/process_test.go
@@ -26,7 +26,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"syscall"
 	"testing"
 	"time"
 
@@ -202,7 +201,7 @@ func TestWaitForStablePID(t *testing.T) {
 			minStable:  3,
 			maxCrashes: 2,
 			findErrs: map[int]error{
-				2: syscall.ESRCH,
+				2: os.ErrProcessDone,
 			},
 			errored: true,
 		},
@@ -213,7 +212,7 @@ func TestWaitForStablePID(t *testing.T) {
 			minStable:  3,
 			maxCrashes: 2,
 			findErrs: map[int]error{
-				2: syscall.ESRCH,
+				2: os.ErrProcessDone,
 			},
 		},
 		{

--- a/lib/autoupdate/agent/testdata/TestWriteConfigFiles/teleport-update.conf.golden
+++ b/lib/autoupdate/agent/testdata/TestWriteConfigFiles/teleport-update.conf.golden
@@ -1,3 +1,0 @@
-# teleport-update
-[Service]
-ExecStopPost=/bin/bash -c 'date +%%s > /var/lib/teleport/last-restart'

--- a/lib/autoupdate/agent/testdata/TestWriteConfigFiles/teleport-update.conf.golden
+++ b/lib/autoupdate/agent/testdata/TestWriteConfigFiles/teleport-update.conf.golden
@@ -1,0 +1,3 @@
+# teleport-update
+[Service]
+ExecStopPost=/bin/bash -c 'date +%%s > /var/lib/teleport/last-restart'

--- a/lib/autoupdate/agent/testdata/TestWriteConfigFiles/teleport-update.service.golden
+++ b/lib/autoupdate/agent/testdata/TestWriteConfigFiles/teleport-update.service.golden
@@ -1,6 +1,6 @@
 # teleport-update
 [Unit]
-Description=Teleport update service
+Description=Teleport auto-update service
 
 [Service]
 Type=oneshot

--- a/lib/autoupdate/agent/testdata/TestWriteConfigFiles/teleport-update.service.golden
+++ b/lib/autoupdate/agent/testdata/TestWriteConfigFiles/teleport-update.service.golden
@@ -1,0 +1,7 @@
+# teleport-update
+[Unit]
+Description=Teleport update service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/teleport-update update

--- a/lib/autoupdate/agent/testdata/TestWriteConfigFiles/teleport-update.timer.golden
+++ b/lib/autoupdate/agent/testdata/TestWriteConfigFiles/teleport-update.timer.golden
@@ -1,0 +1,11 @@
+# teleport-update
+[Unit]
+Description=Teleport update timer unit
+
+[Timer]
+OnActiveSec=1m
+OnUnitActiveSec=5m
+RandomizedDelaySec=1m
+
+[Install]
+WantedBy=teleport.service

--- a/lib/autoupdate/agent/testdata/TestWriteConfigFiles/teleport-update.timer.golden
+++ b/lib/autoupdate/agent/testdata/TestWriteConfigFiles/teleport-update.timer.golden
@@ -1,6 +1,6 @@
 # teleport-update
 [Unit]
-Description=Teleport update timer unit
+Description=Teleport auto-update timer unit
 
 [Timer]
 OnActiveSec=1m

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -167,9 +167,9 @@ func NewLocalUpdater(cfg LocalUpdaterConfig) (*Updater, error) {
 			ReservedFreeInstallDisk: reservedFreeDisk,
 		},
 		Process: &SystemdService{
-			ServiceName:     "teleport.service",
-			LastRestartPath: filepath.Join(cfg.DataDir, "last-restart"),
-			Log:             cfg.Log,
+			ServiceName: "teleport.service",
+			PIDPath:     "/run/teleport.pid",
+			Log:         cfg.Log,
 		},
 		Setup: func(ctx context.Context) error {
 			name := filepath.Join(cfg.LinkDir, "bin", BinaryName)

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -27,6 +27,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -171,20 +172,17 @@ func NewLocalUpdater(cfg LocalUpdaterConfig) (*Updater, error) {
 			Log:             cfg.Log,
 		},
 		Setup: func(ctx context.Context) error {
-			exec := &localExec{
-				Log:      cfg.Log,
-				ErrLevel: slog.LevelInfo,
-				OutLevel: slog.LevelDebug,
-			}
 			name := filepath.Join(cfg.LinkDir, "bin", BinaryName)
 			if cfg.SelfSetup {
 				name = "/proc/self/exe"
 			}
-			_, err := exec.Run(ctx, name,
+			cmd := exec.CommandContext(ctx, name,
 				"--data-dir", cfg.DataDir,
 				"--link-dir", cfg.LinkDir,
 				"setup")
-			return err
+			cmd.Stderr = os.Stderr
+			cmd.Stdout = os.Stdout
+			return cmd.Run()
 		},
 	}, nil
 }

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -170,7 +170,7 @@ func NewLocalUpdater(cfg LocalUpdaterConfig) (*Updater, error) {
 			Log:         cfg.Log,
 		},
 		Setup: func(ctx context.Context) error {
-			exec := &LocalExec{
+			exec := &localExec{
 				Log:      cfg.Log,
 				ErrLevel: slog.LevelError,
 				OutLevel: slog.LevelDebug,

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -21,6 +21,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -58,10 +59,8 @@ const (
 )
 
 const (
-	// versionsDirName specifies the name of the subdirectory inside of the Teleport data dir for storing Teleport versions.
-	versionsDirName = "versions"
-	// lockFileName specifies the name of the file inside versionsDirName containing the flock lock preventing concurrent updater execution.
-	lockFileName = ".lock"
+	// lockFileName specifies the name of the file containing the flock lock preventing concurrent updater execution.
+	lockFileName = ".update-lock"
 )
 
 var plog = logutils.NewPackageLogger(teleport.ComponentKey, teleport.ComponentUpdater)
@@ -91,7 +90,7 @@ func Run(args []string) error {
 	ctx := context.Background()
 	ctx, _ = signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 
-	app := libutils.InitCLIParser("teleport-update", appHelp).Interspersed(false)
+	app := libutils.InitCLIParser(autoupdate.BinaryName, appHelp).Interspersed(false)
 	app.Flag("debug", "Verbose logging to stdout.").
 		Short('d').BoolVar(&ccfg.Debug)
 	app.Flag("data-dir", "Teleport data directory. Access to this directory should be limited.").
@@ -103,7 +102,7 @@ func Run(args []string) error {
 
 	app.HelpFlag.Short('h')
 
-	versionCmd := app.Command("version", "Print the version of your teleport-updater binary.")
+	versionCmd := app.Command("version", fmt.Sprintf("Print the version of your %s binary.", autoupdate.BinaryName))
 
 	enableCmd := app.Command("enable", "Enable agent auto-updates and perform initial update.")
 	enableCmd.Flag("proxy", "Address of the Teleport Proxy.").
@@ -121,6 +120,9 @@ func Run(args []string) error {
 	updateCmd := app.Command("update", "Update agent to the latest version, if a new version is available.")
 
 	linkCmd := app.Command("link", "Link the system installation of Teleport from the Teleport package, if auto-updates is disabled.")
+
+	setupCmd := app.Command("setup", "Write configuration files that run the update subcommand on a timer.").
+		Hidden()
 
 	libutils.UpdateAppUsageTemplate(app, args)
 	command, err := app.Parse(args)
@@ -143,6 +145,8 @@ func Run(args []string) error {
 		err = cmdUpdate(ctx, &ccfg)
 	case linkCmd.FullCommand():
 		err = cmdLink(ctx, &ccfg)
+	case setupCmd.FullCommand():
+		err = cmdSetup(ctx, &ccfg)
 	case versionCmd.FullCommand():
 		modules.GetModules().PrintVersion()
 	default:
@@ -172,12 +176,16 @@ func setupLogger(debug bool, format string) error {
 
 // cmdDisable disables updates.
 func cmdDisable(ctx context.Context, ccfg *cliConfig) error {
-	versionsDir := filepath.Join(ccfg.DataDir, versionsDirName)
-	if err := os.MkdirAll(versionsDir, 0755); err != nil {
-		return trace.Errorf("failed to create versions directory: %w", err)
+	updater, err := autoupdate.NewLocalUpdater(autoupdate.LocalUpdaterConfig{
+		DataDir:   ccfg.DataDir,
+		LinkDir:   ccfg.LinkDir,
+		SystemDir: autoupdate.DefaultSystemDir,
+		Log:       plog,
+	})
+	if err != nil {
+		return trace.Errorf("failed to setup updater: %w", err)
 	}
-
-	unlock, err := libutils.FSWriteLock(filepath.Join(versionsDir, lockFileName))
+	unlock, err := libutils.FSWriteLock(filepath.Join(ccfg.DataDir, lockFileName))
 	if err != nil {
 		return trace.Errorf("failed to grab concurrent execution lock: %w", err)
 	}
@@ -186,15 +194,6 @@ func cmdDisable(ctx context.Context, ccfg *cliConfig) error {
 			plog.DebugContext(ctx, "Failed to close lock file", "error", err)
 		}
 	}()
-	updater, err := autoupdate.NewLocalUpdater(autoupdate.LocalUpdaterConfig{
-		VersionsDir: versionsDir,
-		LinkDir:     ccfg.LinkDir,
-		SystemDir:   autoupdate.DefaultSystemDir,
-		Log:         plog,
-	})
-	if err != nil {
-		return trace.Errorf("failed to setup updater: %w", err)
-	}
 	if err := updater.Disable(ctx); err != nil {
 		return trace.Wrap(err)
 	}
@@ -203,13 +202,18 @@ func cmdDisable(ctx context.Context, ccfg *cliConfig) error {
 
 // cmdEnable enables updates and triggers an initial update.
 func cmdEnable(ctx context.Context, ccfg *cliConfig) error {
-	versionsDir := filepath.Join(ccfg.DataDir, versionsDirName)
-	if err := os.MkdirAll(versionsDir, 0755); err != nil {
-		return trace.Errorf("failed to create versions directory: %w", err)
+	updater, err := autoupdate.NewLocalUpdater(autoupdate.LocalUpdaterConfig{
+		DataDir:   ccfg.DataDir,
+		LinkDir:   ccfg.LinkDir,
+		SystemDir: autoupdate.DefaultSystemDir,
+		Log:       plog,
+	})
+	if err != nil {
+		return trace.Errorf("failed to setup updater: %w", err)
 	}
 
 	// Ensure enable can't run concurrently.
-	unlock, err := libutils.FSWriteLock(filepath.Join(versionsDir, lockFileName))
+	unlock, err := libutils.FSWriteLock(filepath.Join(ccfg.DataDir, lockFileName))
 	if err != nil {
 		return trace.Errorf("failed to grab concurrent execution lock: %w", err)
 	}
@@ -218,16 +222,6 @@ func cmdEnable(ctx context.Context, ccfg *cliConfig) error {
 			plog.DebugContext(ctx, "Failed to close lock file", "error", err)
 		}
 	}()
-
-	updater, err := autoupdate.NewLocalUpdater(autoupdate.LocalUpdaterConfig{
-		VersionsDir: versionsDir,
-		LinkDir:     ccfg.LinkDir,
-		SystemDir:   autoupdate.DefaultSystemDir,
-		Log:         plog,
-	})
-	if err != nil {
-		return trace.Errorf("failed to setup updater: %w", err)
-	}
 	if err := updater.Enable(ctx, ccfg.OverrideConfig); err != nil {
 		return trace.Wrap(err)
 	}
@@ -236,13 +230,17 @@ func cmdEnable(ctx context.Context, ccfg *cliConfig) error {
 
 // cmdUpdate updates Teleport to the version specified by cluster reachable at the proxy address.
 func cmdUpdate(ctx context.Context, ccfg *cliConfig) error {
-	versionsDir := filepath.Join(ccfg.DataDir, versionsDirName)
-	if err := os.MkdirAll(versionsDir, 0755); err != nil {
-		return trace.Errorf("failed to create versions directory: %w", err)
+	updater, err := autoupdate.NewLocalUpdater(autoupdate.LocalUpdaterConfig{
+		DataDir:   ccfg.DataDir,
+		LinkDir:   ccfg.LinkDir,
+		SystemDir: autoupdate.DefaultSystemDir,
+		Log:       plog,
+	})
+	if err != nil {
+		return trace.Errorf("failed to setup updater: %w", err)
 	}
-
 	// Ensure update can't run concurrently.
-	unlock, err := libutils.FSWriteLock(filepath.Join(versionsDir, lockFileName))
+	unlock, err := libutils.FSWriteLock(filepath.Join(ccfg.DataDir, lockFileName))
 	if err != nil {
 		return trace.Errorf("failed to grab concurrent execution lock: %w", err)
 	}
@@ -252,15 +250,6 @@ func cmdUpdate(ctx context.Context, ccfg *cliConfig) error {
 		}
 	}()
 
-	updater, err := autoupdate.NewLocalUpdater(autoupdate.LocalUpdaterConfig{
-		VersionsDir: versionsDir,
-		LinkDir:     ccfg.LinkDir,
-		SystemDir:   autoupdate.DefaultSystemDir,
-		Log:         plog,
-	})
-	if err != nil {
-		return trace.Errorf("failed to setup updater: %w", err)
-	}
 	if err := updater.Update(ctx); err != nil {
 		return trace.Wrap(err)
 	}
@@ -269,10 +258,18 @@ func cmdUpdate(ctx context.Context, ccfg *cliConfig) error {
 
 // cmdLink creates system package links if no version is linked and auto-updates is disabled.
 func cmdLink(ctx context.Context, ccfg *cliConfig) error {
-	versionsDir := filepath.Join(ccfg.DataDir, versionsDirName)
+	updater, err := autoupdate.NewLocalUpdater(autoupdate.LocalUpdaterConfig{
+		DataDir:   ccfg.DataDir,
+		LinkDir:   ccfg.LinkDir,
+		SystemDir: autoupdate.DefaultSystemDir,
+		Log:       plog,
+	})
+	if err != nil {
+		return trace.Errorf("failed to setup updater: %w", err)
+	}
 
 	// Skip operation and warn if the updater is currently running.
-	unlock, err := libutils.FSTryReadLock(filepath.Join(versionsDir, lockFileName))
+	unlock, err := libutils.FSTryReadLock(filepath.Join(ccfg.DataDir, lockFileName))
 	if errors.Is(err, libutils.ErrUnsuccessfulLockTry) {
 		plog.WarnContext(ctx, "Updater is currently running. Skipping package linking.")
 		return nil
@@ -285,17 +282,18 @@ func cmdLink(ctx context.Context, ccfg *cliConfig) error {
 			plog.DebugContext(ctx, "Failed to close lock file", "error", err)
 		}
 	}()
-	updater, err := autoupdate.NewLocalUpdater(autoupdate.LocalUpdaterConfig{
-		VersionsDir: versionsDir,
-		LinkDir:     ccfg.LinkDir,
-		SystemDir:   autoupdate.DefaultSystemDir,
-		Log:         plog,
-	})
-	if err != nil {
-		return trace.Errorf("failed to setup updater: %w", err)
-	}
+
 	if err := updater.LinkPackage(ctx); err != nil {
 		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// cmdSetup writes configuration files that are needed to run teleport-update update.
+func cmdSetup(ctx context.Context, ccfg *cliConfig) error {
+	err := autoupdate.WriteConfigFiles(ccfg.LinkDir, ccfg.DataDir)
+	if err != nil {
+		return trace.Errorf("failed to write config files: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR adds more complete systemd process management to the `teleport-update` command.

This include automatically writing/updating a timer and service file for the updater, using the new `teleport-update` binary, during upgrades. This validates the new updater is a valid executable on the target platform, and ensures that the timer/service file match the new updater. Note that the hidden `--self-setup` flag can be passed to exec the same binary, if necessary.

Additionally, this PR adding support for detection of various failures during upgrades. `teleport-update` will rollback the agent immediately in these cases.

This is accomplished by monitoring `/run/teleport.pid` for changes that indicate different failure modes. For example, if Teleport crashes after a soft reload, systemd is unaware, and a stale PID is present with no running process. Alternatively, if Teleport crashes after a hard restart, the PID file is rapidly created/removed with different PID values. Other cases, such as hanging on quit, are covered as well. This catches fatal errors in new versions, as well as client-too-new errors.

Notably, connection failures, including clients rejected by the server for being outdated, do not trigger a revert.

This is the seventh in a series of PRs implementing `teleport-update`:
Link Command: https://github.com/gravitational/teleport/pull/48712
Update Command: https://github.com/gravitational/teleport/pull/48244
Reloading with rollbacks: https://github.com/gravitational/teleport/pull/47929
Linking: https://github.com/gravitational/teleport/pull/47879
Enable Command: https://github.com/gravitational/teleport/pull/47565
Initial scaffolding PR: https://github.com/gravitational/teleport/pull/46418

The `teleport-update` binary will be used to enable, disable, and trigger automatic Teleport agent updates. The new auto-updates system manages a local installation of the cluster-specified version of Teleport stored in `/var/lib/teleport/versions`.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/10289

Example: Upgrading to v17 on a v16 cluster, with successful rollback.

```
Nov 19 02:44:44 legendary-mite systemd[1]: Starting teleport-update.service - Teleport auto-update service...
Nov 19 02:44:45 legendary-mite teleport-update[595947]: 2024-11-19T02:44:45Z INFO [UPDATER]   Update available. Initiating update. target_version:17.0.1 active_version:16.4.7 agent/updater.go:475
Nov 19 02:45:46 legendary-mite teleport-update[595947]: 2024-11-19T02:45:46Z INFO [UPDATER]   Version already present. version:17.0.1 agent/installer.go:153
Nov 19 02:45:46 legendary-mite teleport-update[595947]: 2024-11-19T02:45:46Z INFO [UPDATER]   Executing new teleport-update binary to update configuration. agent/updater.go:185
Nov 19 02:45:46 legendary-mite teleport-update[596859]: 2024-11-19T02:45:46Z INFO [UPDATER]   Systemd configuration synced. agent/process.go:253
Nov 19 02:45:46 legendary-mite teleport-update[596859]: 2024-11-19T02:45:46Z INFO [UPDATER]   Service enabled. unit:teleport-update.timer agent/process.go:270
Nov 19 02:45:46 legendary-mite teleport-update[595947]: 2024-11-19T02:45:46Z INFO [UPDATER]   Finished executing new teleport-update binary. agent/updater.go:187
Nov 19 02:45:47 legendary-mite teleport-update[595947]: 2024-11-19T02:45:47Z INFO [UPDATER]   Systemd configuration synced. agent/process.go:253
Nov 19 02:45:47 legendary-mite teleport-update[595947]: 2024-11-19T02:45:47Z INFO [UPDATER]   Target version successfully installed. target_version:17.0.1 agent/updater.go:568
Nov 19 02:45:47 legendary-mite teleport-update[595947]: 2024-11-19T02:45:47Z INFO [UPDATER]   Gracefully reloaded. unit:teleport.service agent/process.go:110
Nov 19 02:45:47 legendary-mite teleport-update[595947]: 2024-11-19T02:45:47Z INFO [UPDATER]   Monitoring PID file to detect crashes. unit:teleport.service agent/process.go:113
Nov 19 02:45:51 legendary-mite teleport-update[595947]: 2024-11-19T02:45:51Z WARN [UPDATER]   Detected stale PID. unit:teleport.service pid:597038 agent/process.go:194
Nov 19 02:45:57 legendary-mite teleport-update[595947]: 2024-11-19T02:45:57Z ERRO [UPDATER]   Reverting symlinks due to failed restart. agent/updater.go:578
Nov 19 02:45:57 legendary-mite teleport-update[595947]: 2024-11-19T02:45:57Z INFO [UPDATER]   Systemd configuration synced. agent/process.go:253
Nov 19 02:45:57 legendary-mite teleport-update[595947]: 2024-11-19T02:45:57Z ERRO [UPDATER]   [stderr] Job for teleport.service failed. agent/process.go:362
Nov 19 02:45:57 legendary-mite teleport-update[595947]: 2024-11-19T02:45:57Z ERRO [UPDATER]   [stderr] See "systemctl status teleport.service" and "journalctl -xeu teleport.service" for details. agent/process.go:368
Nov 19 02:45:57 legendary-mite teleport-update[595947]: 2024-11-19T02:45:57Z ERRO [UPDATER]   Error running systemctl. args:[reload teleport.service] code:1 agent/process.go:298
Nov 19 02:45:57 legendary-mite teleport-update[595947]: 2024-11-19T02:45:57Z WARN [UPDATER]   Service ungracefully restarted. Connections potentially dropped. unit:teleport.service agent/process.go:108
Nov 19 02:45:57 legendary-mite teleport-update[595947]: 2024-11-19T02:45:57Z INFO [UPDATER]   Monitoring PID file to detect crashes. unit:teleport.service agent/process.go:113
Nov 19 02:46:11 legendary-mite teleport-update[595947]: 2024-11-19T02:46:11Z WARN [UPDATER]   Teleport updater encountered a configuration error and successfully reverted the installation. agent/updater.go:586
Nov 19 02:46:11 legendary-mite teleport-update[595947]: ERROR: failed to start new version "17.0.1" of Teleport: detected crashing process
Nov 19 02:46:11 legendary-mite systemd[1]: teleport-update.service: Main process exited, code=exited, status=1/FAILURE
Nov 19 02:46:11 legendary-mite systemd[1]: teleport-update.service: Failed with result 'exit-code'.
Nov 19 02:46:11 legendary-mite systemd[1]: Failed to start teleport-update.service - Teleport auto-update service.
^C
ubuntu@legendary-mite:~$ ls -la /usr/local/bin/
total 12
drwxr-xr-x  2 root root 4096 Nov 19 02:45 .
drwxr-xr-x 11 root root 4096 Nov 13 01:41 ..
lrwxrwxrwx  1 root root   53 Nov 19 02:45 fdpass-teleport -> /var/lib/teleport/versions/16.4.7/bin/fdpass-teleport
lrwxrwxrwx  1 root root   42 Nov 19 02:45 tbot -> /var/lib/teleport/versions/16.4.7/bin/tbot
lrwxrwxrwx  1 root root   42 Nov 19 02:45 tctl -> /var/lib/teleport/versions/16.4.7/bin/tctl
lrwxrwxrwx  1 root root   46 Nov 19 02:45 teleport -> /var/lib/teleport/versions/16.4.7/bin/teleport
lrwxrwxrwx  1 root root   65 Nov 17 22:29 teleport-update -> /home/ubuntu/mounts/teleport/
ubuntu@legendary-mite:~$ systemctl status teleport
● teleport.service - Teleport Service
     Loaded: loaded (/usr/lib/systemd/system/teleport.service; enabled; preset: enabled)
     Active: active (running) since Tue 2024-11-19 03:09:20 UTC; 4min 42s ago
```