### PR TITLE
Prevent using custom endpoints if one is not defined

### DIFF
--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -208,7 +208,9 @@ func (cfg *Config) CheckAndSetDefaults() error {
 		cfg.UIDGenerator = utils.NewRealUID()
 	}
 
-	cfg.Endpoint = endpoint.CreateURI(cfg.Endpoint, cfg.Insecure)
+	if cfg.Endpoint != "" {
+		cfg.Endpoint = endpoint.CreateURI(cfg.Endpoint, cfg.Insecure)
+	}
 
 	return nil
 }

--- a/lib/events/s3sessions/s3handler.go
+++ b/lib/events/s3sessions/s3handler.go
@@ -157,7 +157,9 @@ func (s *Config) CheckAndSetDefaults() error {
 		return trace.BadParameter("missing parameter Bucket")
 	}
 
-	s.Endpoint = endpoint.CreateURI(s.Endpoint, s.Insecure)
+	if s.Endpoint != "" {
+		s.Endpoint = endpoint.CreateURI(s.Endpoint, s.Insecure)
+	}
 
 	return nil
 }

--- a/lib/utils/aws/endpoint/endpoint.go
+++ b/lib/utils/aws/endpoint/endpoint.go
@@ -33,7 +33,7 @@ var schemeRegex = regexp.MustCompile("^([^:]+)://")
 // a custom service endpoint, this performs applies the same
 // behavior that the legacy sdk did.
 func CreateURI(endpoint string, insecure bool) string {
-	if !schemeRegex.MatchString(endpoint) {
+	if endpoint != "" && !schemeRegex.MatchString(endpoint) {
 		scheme := "https"
 		if insecure {
 			scheme = "http"

--- a/lib/utils/aws/endpoint/endpoint_test.go
+++ b/lib/utils/aws/endpoint/endpoint_test.go
@@ -32,6 +32,9 @@ func TestCreateURI(t *testing.T) {
 		expected string
 	}{
 		{
+			name: "empty endpoint",
+		},
+		{
 			name:     "valid endpoint",
 			endpoint: "https://test.example.com",
 			expected: "https://test.example.com",


### PR DESCRIPTION
The AWS endpoint sanititazion was inadvertantly being applied all the time, causing configurations not using custom endpoints to be forced into using a custom endpoint instead of AWS.