### PR TITLE
reduce locking test flake

### DIFF
--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -790,7 +790,7 @@ func testWatchersClose(t *testing.T, newBackend Constructor) {
 func testLocking(t *testing.T, newBackend Constructor) {
 	tok1 := "token1"
 	tok2 := "token2"
-	ttl := 5 * time.Second
+	ttl := 30 * time.Second
 
 	uut, clock, err := newBackend()
 	require.NoError(t, err)


### PR DESCRIPTION
The `Locking` backend compliance test was using a TTL of 5s for locks.  TTLs that short have a tendency to produce flaky behavior in our CI due to the resource-constrained nature of the test env.  This PR bumps the TTL to 30s.  This has no effect on the "happy" path of the test, since no part of the test actually waits for a TTL to expire naturally.

Note that it's difficult to prove whether or not the flake we've observed was only due to the short TTL, or if there is some additional unknown case that can manifest as an unexpected expired lock. Even if this change doesn't fully fix flaky `Locking` tests, it should at least let us be more confident that flake is the result of logical errors rather than dust motes settling on the water-logged TI-86 graphing calculator that we use to run our tests.