### PR TITLE
Add reference page for tbot Helm chart

### DIFF
--- a/docs/pages/includes/helm-reference/zz_generated.tbot.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.tbot.mdx
@@ -121,7 +121,7 @@ Ignored if `customConfig` is set.
 | `string` | `"kubernetes"` |
 
 `joinMethod` describes how tbot joins the Teleport cluster.
-See [the join method reference](../../join-methods.mdx) for a list fo supported values and detailed explanations.
+See [the join method reference](../join-methods.mdx) for a list fo supported values and detailed explanations.
 Ignored if `customConfig` is set.
 
 ## `token`

--- a/docs/pages/includes/helm-reference/zz_generated.tbot.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.tbot.mdx
@@ -121,7 +121,7 @@ Ignored if `customConfig` is set.
 | `string` | `"kubernetes"` |
 
 `joinMethod` describes how tbot joins the Teleport cluster.
-See [the join method reference](../join-methods.mdx) for a list fo supported values and detailed explanations.
+See [the join method reference](../../reference/join-methods.mdx) for a list fo supported values and detailed explanations.
 Ignored if `customConfig` is set.
 
 ## `token`

--- a/docs/pages/reference/helm-reference/helm-reference.mdx
+++ b/docs/pages/reference/helm-reference/helm-reference.mdx
@@ -15,6 +15,7 @@ layout: tocless-doc
   Teleport Kubernetes Operator.
 - [teleport-access-graph](teleport-access-graph.mdx): Deploy the
   Teleport Policy Access Graph service.
+- [tbot](tbot.mdx): Deploy an instance of TBot, the [MachineID](../../enroll-resources/machine-id/introduction.mdx) agent.
 - [teleport-plugin-event-handler](teleport-plugin-event-handler.mdx):
   Deploy the Teleport Event Handler plugin which sends events and session logs
   to Fluentd.

--- a/docs/pages/reference/helm-reference/tbot.mdx
+++ b/docs/pages/reference/helm-reference/tbot.mdx
@@ -1,0 +1,37 @@
+---
+title: tbot Chart Reference
+description: Values that can be set using the tbot Helm chart
+---
+
+## What the chart deploys
+
+This chart deploys an instance of the [MachineID](../../enroll-resources/machine-id/introduction.mdx) agent,
+TBot, into your Kubernetes cluster.
+
+To use it, you will need to know:
+
+- The address of your Teleport Proxy Service or Auth Service
+- The name of your Teleport cluster
+- The name of a join token configured for Machine ID and your Kubernetes cluster
+  (https://goteleport.com/docs/enroll-resources/machine-id/deployment/kubernetes/)
+
+By default, this chart is designed to use the `kubernetes` join method but it
+can be customised to use any delegated join method. We do not recommend that
+you use the `token` join method with this chart.
+
+## Minimal configuration
+
+This basic configuration will write a Teleport identity file to a secret in
+the deployment namespace called `test-output`.
+
+```yaml
+clusterName: "test.teleport.sh"
+teleportProxyAddress: "test.teleport.sh:443"
+defaultOutput:
+  secretName: "test-output"
+token: "my-token"
+```
+
+## Full reference
+
+(!docs/pages/includes/helm-reference/zz_generated.tbot.mdx!)

--- a/docs/pages/reference/helm-reference/tbot.mdx
+++ b/docs/pages/reference/helm-reference/tbot.mdx
@@ -14,7 +14,7 @@ To use it, you will need to know:
   as described in the [Machine ID on Kubernetes guide](../../enroll-resources/machine-id/deployment/kubernetes.mdx)
 
 By default, this chart is designed to use the `kubernetes` join method but it
-can be customised to use any delegated join method. We do not recommend that
+can be customized to use any delegated join method. We do not recommend that
 you use the `token` join method with this chart.
 
 ## Minimal configuration

--- a/docs/pages/reference/helm-reference/tbot.mdx
+++ b/docs/pages/reference/helm-reference/tbot.mdx
@@ -3,8 +3,6 @@ title: tbot Chart Reference
 description: Values that can be set using the tbot Helm chart
 ---
 
-## What the chart deploys
-
 This chart deploys an instance of the [MachineID](../../enroll-resources/machine-id/introduction.mdx) agent,
 TBot, into your Kubernetes cluster.
 

--- a/docs/pages/reference/helm-reference/tbot.mdx
+++ b/docs/pages/reference/helm-reference/tbot.mdx
@@ -11,7 +11,7 @@ To use it, you will need to know:
 - The address of your Teleport Proxy Service or Auth Service
 - The name of your Teleport cluster
 - The name of a join token configured for Machine ID and your Kubernetes cluster
-  (https://goteleport.com/docs/enroll-resources/machine-id/deployment/kubernetes/)
+  as described in the [Machine ID on Kubernetes guide](../../enroll-resources/machine-id/deployment/kubernetes.mdx)
 
 By default, this chart is designed to use the `kubernetes` join method but it
 can be customised to use any delegated join method. We do not recommend that

--- a/examples/chart/tbot/values.yaml
+++ b/examples/chart/tbot/values.yaml
@@ -70,7 +70,7 @@ outputs: []
 services: []
 
 # joinMethod(string) -- describes how tbot joins the Teleport cluster.
-# See [the join method reference](../join-methods.mdx) for a list fo supported values and detailed explanations.
+# See [the join method reference](../../reference/join-methods.mdx) for a list fo supported values and detailed explanations.
 # Ignored if `customConfig` is set.
 joinMethod: "kubernetes"
 

--- a/examples/chart/tbot/values.yaml
+++ b/examples/chart/tbot/values.yaml
@@ -70,7 +70,7 @@ outputs: []
 services: []
 
 # joinMethod(string) -- describes how tbot joins the Teleport cluster.
-# See [the join method reference](../../join-methods.mdx) for a list fo supported values and detailed explanations.
+# See [the join method reference](../join-methods.mdx) for a list fo supported values and detailed explanations.
 # Ignored if `customConfig` is set.
 joinMethod: "kubernetes"
 


### PR DESCRIPTION
We added a `tbot` chart and generated its reference, but never included it in the docs 🤦 

This PR adds the `tbot` Helm chart reference page to the docs.