### PR TITLE
Prevent logging exception due to nil attribute

### DIFF
--- a/lib/events/filelog.go
+++ b/lib/events/filelog.go
@@ -345,7 +345,11 @@ func getCheckpointFromEvent(event apievents.AuditEvent) (string, error) {
 }
 
 func (l *FileLog) SearchSessionEvents(ctx context.Context, req SearchSessionEventsRequest) ([]apievents.AuditEvent, string, error) {
-	l.logger.DebugContext(ctx, "SearchSessionEvents", "from", req.From, "to", req.To, "order", req.Order, "limit", req.Limit, "cond", logutils.StringerAttr(req.Cond))
+	var whereExp types.WhereExpr
+	if req.Cond != nil {
+		whereExp = *req.Cond
+	}
+	l.logger.DebugContext(ctx, "SearchSessionEvents", "from", req.From, "to", req.To, "order", req.Order, "limit", req.Limit, "cond", logutils.StringerAttr(whereExp))
 	filter := searchEventsFilter{eventTypes: SessionRecordingEvents}
 	if req.Cond != nil {
 		condFn, err := utils.ToFieldsCondition(req.Cond)


### PR DESCRIPTION
The where condition being logged in SearchSession events is nil even though it's not nil, thanks Go, causing additional log spam. This addresses the issue by only passing in the condition if it was populated in the request.

```bash
2024-11-18T13:04:02-05:00 DEBU [AUDIT]     SearchSessionEvents from:2024-11-18 05:00:00 +0000 UTC to:2024-11-19 04:59:59.999 +0000 UTC order:1 limit:5000 error:[LogValue panicked
called from runtime.panicwrap (runtime/error.go:355)
called from github.com/gravitational/teleport/api/types.(*WhereExpr).String (<autogenerated>:1)
called from github.com/gravitational/teleport/lib/utils/log.stringerAttr.LogValue (github.com/gravitational/teleport/lib/utils/log/slog_handler.go:662)
called from log/slog.Value.Resolve (log/slog/value.go:512)
called from github.com/gravitational/teleport/lib/utils/log.(*SlogTextHandler).appendAttr (github.com/gravitational/teleport/lib/utils/log/slog_handler.go:140)
(rest of stack elided)
] trace_id:42463c70955f653d0f992286feae738e span_id:a4e9b13d53f8f7d8 events/filelog.go:348
```