### PR TITLE
Remove `var` labels in code snippets

### DIFF
--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/ci-or-cloud.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/ci-or-cloud.mdx
@@ -242,7 +242,7 @@ To do this you need:
 
 Create this minimal `main.tf` file:
 
-```var
+```hcl
 terraform {
   required_providers {
     teleport = {

--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/local.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/local.mdx
@@ -85,7 +85,7 @@ You can run the Teleport Terraform provider from this shell.
 
 1. Create a `main.tf` file containing this minimal Terraform code:
 
-   ```var
+   ```hcl
    terraform {
      required_providers {
        teleport = {

--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/long-lived-credentials.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/long-lived-credentials.mdx
@@ -118,8 +118,10 @@ cluster. You will create a local Teleport user for this purpose.
 To prepare a Terraform configuration file:
 
 1. Create a new file called `main.tf` and open it in an editor.
+
 1. Define an example user and role using Terraform by pasting the following content into the `main.tf` file:
-   ```var
+
+   ```hcl
    terraform {
       required_providers {
          teleport = {

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds.mdx
@@ -207,7 +207,7 @@ name="example.teleport.sh:443" /> to the host **and port** of your Teleport
 Proxy Service, and <Var name="endpoint:port" /> to the host **and port** of your RDS
 database (e.g., `myrds.us-east-1.rds.amazonaws.com:5432`):
 
-```var
+```yaml
 authToken: <Var name="token" />
 proxyAddr: <Var name="example.teleport.sh:443" />
 roles: db


### PR DESCRIPTION
This label is no longer necessary now that we have a custom plugin to add Var components to syntax-highlighted code snippets.