### PR TITLE
Edit the Vercel preview workflow

### DIFF
--- a/.github/workflows/vercel-preview.yaml
+++ b/.github/workflows/vercel-preview.yaml
@@ -61,5 +61,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `🤖 Vercel preview here: ${previewUrl}/docs/ver/preview`
+              body: `🤖 Vercel preview here: ${previewUrl}/docs`
             })


### PR DESCRIPTION
Due to https://github.com/gravitational/docs/pull/504, we can label the default docs version something other than `[0-9]+.x`. As a result, the `preview` submodule maps to the docs root instead of `/ver/preview`. This change edits the message posted by the Vercel preview workflow to accommodate this change.