### PR TITLE
[v15] Look for a license in the default location if no config is provided

### DIFF
--- a/docs/pages/includes/config-reference/auth-service.yaml
+++ b/docs/pages/includes/config-reference/auth-service.yaml
@@ -356,8 +356,7 @@ auth_service:
     routing_strategy: unambiguous_match
 
     # License file to start auth server with. Note that this setting is ignored
-    # in the Teleport Community Edition and is required only for Teleport Pro, Business
-    # and Enterprise subscription plans.
+    # in the Teleport Community Edition and is required only for Teleport Enterprise.
     #
     # The path can be either absolute or relative to the configured `data_dir`
     # and should point to the license file obtained from Teleport Download

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -1923,11 +1923,6 @@ func TestLicenseFile(t *testing.T) {
 
 	cfg := servicecfg.MakeDefaultConfig()
 
-	// the license file should be empty by default, as we can only fill
-	// in the default (<datadir>/license.pem) after we know what the
-	// data dir is supposed to be
-	require.Empty(t, cfg.Auth.LicenseFile)
-
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("test%d", i), func(t *testing.T) {
 			fc := new(FileConfig)
@@ -1939,6 +1934,12 @@ func TestLicenseFile(t *testing.T) {
 			require.Equal(t, tc.result, cfg.Auth.LicenseFile)
 		})
 	}
+}
+
+func TestLicenseFileNoConfig(t *testing.T) {
+	cfg := servicecfg.MakeDefaultConfig()
+	require.NoError(t, Configure(new(CommandLineFlags), cfg, false /* legacy app flags */))
+	require.Equal(t, filepath.Join(defaults.DataDir, defaults.LicenseFile), cfg.Auth.LicenseFile)
 }
 
 // TestFIPS makes sure configuration is correctly updated/enforced when in

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -564,6 +564,7 @@ func ApplyDefaults(cfg *Config) {
 	cfg.Auth.NetworkingConfig = types.DefaultClusterNetworkingConfig()
 	cfg.Auth.SessionRecordingConfig = types.DefaultSessionRecordingConfig()
 	cfg.Auth.Preference = types.DefaultAuthPreference()
+	cfg.Auth.LicenseFile = filepath.Join(cfg.DataDir, defaults.LicenseFile)
 	defaults.ConfigureLimiter(&cfg.Auth.Limiter)
 
 	cfg.Proxy.WebAddr = *defaults.ProxyWebListenAddr()

--- a/lib/service/servicecfg/config_test.go
+++ b/lib/service/servicecfg/config_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -90,6 +91,7 @@ func TestDefaultConfig(t *testing.T) {
 	require.Equal(t, defaults.LimiterMaxConcurrentUsers, auth.Limiter.MaxNumberOfUsers)
 	require.Equal(t, lite.GetName(), config.Auth.StorageConfig.Type)
 	require.Empty(t, auth.StorageConfig.Params[defaults.BackendPath])
+	require.Equal(t, filepath.Join(defaults.DataDir, defaults.LicenseFile), config.Auth.LicenseFile)
 
 	// SSH section
 	ssh := config.SSH


### PR DESCRIPTION
Backport #49122 to branch/v15

changelog: Fix an issue loading the license file when Teleport is started without a configuration file.
