### PR TITLE
Add route and header for aws oidc dashboard

### DIFF
--- a/web/packages/design/src/Label/Label.tsx
+++ b/web/packages/design/src/Label/Label.tsx
@@ -59,7 +59,12 @@ const kind = ({ kind, theme }: { kind?: LabelKind; theme: Theme }) => {
   };
 };
 
-type LabelKind = 'primary' | 'secondary' | 'warning' | 'danger' | 'success';
+export type LabelKind =
+  | 'primary'
+  | 'secondary'
+  | 'warning'
+  | 'danger'
+  | 'success';
 
 interface LabelProps extends SpaceProps {
   kind?: LabelKind;

--- a/web/packages/design/src/Label/index.ts
+++ b/web/packages/design/src/Label/index.ts
@@ -1,6 +1,6 @@
-/**
+/*
  * Teleport
- * Copyright (C) 2024  Gravitational, Inc.
+ * Copyright (C) 2023  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,20 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-import { useParams } from 'react-router';
+import Label, { Danger, Primary, Secondary, Warning } from './Label';
 
-import { IntegrationKind, PluginKind } from 'teleport/services/integrations';
-import { AwsOidcRoutes } from 'teleport/Integrations/status/AwsOidc/AwsOidcRoutes';
-
-export function IntegrationStatus() {
-  const { type: integrationType } = useParams<{
-    type: PluginKind | IntegrationKind;
-  }>();
-
-  if (integrationType === 'aws-oidc') {
-    return <AwsOidcRoutes />;
-  }
-
-  return <>Status for integration type {integrationType} is not supported</>;
-}
+export default Label;
+export { Primary, Secondary, Warning, Danger };
+export type { LabelKind } from './Label';

--- a/web/packages/teleport/src/Integrations/IntegrationList.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationList.tsx
@@ -33,15 +33,17 @@ import useStickyClusterId from 'teleport/useStickyClusterId';
 import api from 'teleport/services/api';
 
 import {
+  ExternalAuditStorageIntegration,
   getStatusCodeDescription,
   getStatusCodeTitle,
   Integration,
-  IntegrationStatusCode,
   IntegrationKind,
+  IntegrationStatusCode,
   Plugin,
-  ExternalAuditStorageIntegration,
 } from 'teleport/services/integrations';
 import cfg from 'teleport/config';
+
+import { getStatus } from 'teleport/Integrations/helpers';
 
 import { ExternalAuditStorageOpType } from './Operations/useIntegrationOperation';
 
@@ -55,7 +57,10 @@ type Props<IntegrationLike> = {
   onDeleteExternalAuditStorage?(opType: ExternalAuditStorageOpType): void;
 };
 
-type IntegrationLike = Integration | Plugin | ExternalAuditStorageIntegration;
+export type IntegrationLike =
+  | Integration
+  | Plugin
+  | ExternalAuditStorageIntegration;
 
 export function IntegrationList(props: Props<IntegrationLike>) {
   const history = useHistory();
@@ -254,38 +259,10 @@ const StatusCell = ({ item }: { item: IntegrationLike }) => {
   );
 };
 
-enum Status {
+export enum Status {
   Success,
   Warning,
   Error,
-}
-
-function getStatus(item: IntegrationLike): Status | null {
-  if (item.resourceType === 'integration') {
-    return Status.Success;
-  }
-
-  if (item.resourceType === 'external-audit-storage') {
-    switch (item.statusCode) {
-      case IntegrationStatusCode.Draft:
-        return Status.Warning;
-      default:
-        return Status.Success;
-    }
-  }
-
-  switch (item.statusCode) {
-    case IntegrationStatusCode.Unknown:
-      return null;
-    case IntegrationStatusCode.Running:
-      return Status.Success;
-    case IntegrationStatusCode.SlackNotInChannel:
-      return Status.Warning;
-    case IntegrationStatusCode.Draft:
-      return Status.Warning;
-    default:
-      return Status.Error;
-  }
 }
 
 const StatusLight = styled(Box)<{ status: Status }>`

--- a/web/packages/teleport/src/Integrations/helpers.test.ts
+++ b/web/packages/teleport/src/Integrations/helpers.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  Integration,
+  IntegrationStatusCode,
+} from 'teleport/services/integrations';
+import { getStatus, getStatusAndLabel } from 'teleport/Integrations/helpers';
+import { IntegrationLike, Status } from 'teleport/Integrations/IntegrationList';
+
+test.each`
+  type                        | code                                       | expected
+  ${'integration'}            | ${IntegrationStatusCode.Draft}             | ${Status.Success}
+  ${'integration'}            | ${IntegrationStatusCode.Running}           | ${Status.Success}
+  ${'integration'}            | ${IntegrationStatusCode.Unauthorized}      | ${Status.Success}
+  ${'integration'}            | ${IntegrationStatusCode.SlackNotInChannel} | ${Status.Success}
+  ${'integration'}            | ${IntegrationStatusCode.Unknown}           | ${Status.Success}
+  ${'integration'}            | ${IntegrationStatusCode.OtherError}        | ${Status.Success}
+  ${'external-audit-storage'} | ${IntegrationStatusCode.Draft}             | ${Status.Warning}
+  ${'external-audit-storage'} | ${IntegrationStatusCode.Running}           | ${Status.Success}
+  ${'external-audit-storage'} | ${IntegrationStatusCode.Unauthorized}      | ${Status.Success}
+  ${'external-audit-storage'} | ${IntegrationStatusCode.SlackNotInChannel} | ${Status.Success}
+  ${'external-audit-storage'} | ${IntegrationStatusCode.Unknown}           | ${Status.Success}
+  ${'external-audit-storage'} | ${IntegrationStatusCode.OtherError}        | ${Status.Success}
+  ${'any'}                    | ${IntegrationStatusCode.Draft}             | ${Status.Warning}
+  ${'any'}                    | ${IntegrationStatusCode.Running}           | ${Status.Success}
+  ${'any'}                    | ${IntegrationStatusCode.Unauthorized}      | ${Status.Error}
+  ${'any'}                    | ${IntegrationStatusCode.SlackNotInChannel} | ${Status.Warning}
+  ${'any'}                    | ${IntegrationStatusCode.Unknown}           | ${null}
+  ${'any'}                    | ${IntegrationStatusCode.OtherError}        | ${Status.Error}
+`(
+  'getStatus type $type with code $code returns $expected',
+  async ({ type, code, expected }) => {
+    const item: IntegrationLike = {
+      name: '',
+      kind: undefined,
+      resourceType: type,
+      statusCode: code,
+    };
+    const status = getStatus(item);
+    expect(status).toBe(expected);
+  }
+);
+
+test.each`
+  type                        | code                                       | expectedLabelKind | expectedTitle
+  ${'integration'}            | ${IntegrationStatusCode.Draft}             | ${'success'}      | ${'Draft'}
+  ${'integration'}            | ${IntegrationStatusCode.Running}           | ${'success'}      | ${'Running'}
+  ${'integration'}            | ${IntegrationStatusCode.Unauthorized}      | ${'success'}      | ${'Unauthorized'}
+  ${'integration'}            | ${IntegrationStatusCode.SlackNotInChannel} | ${'success'}      | ${'Bot not invited to channel'}
+  ${'integration'}            | ${IntegrationStatusCode.Unknown}           | ${'success'}      | ${'Unknown'}
+  ${'integration'}            | ${IntegrationStatusCode.OtherError}        | ${'success'}      | ${'Unknown error'}
+  ${'external-audit-storage'} | ${IntegrationStatusCode.Draft}             | ${'warning'}      | ${'Draft'}
+  ${'external-audit-storage'} | ${IntegrationStatusCode.Running}           | ${'success'}      | ${'Running'}
+  ${'external-audit-storage'} | ${IntegrationStatusCode.Unauthorized}      | ${'success'}      | ${'Unauthorized'}
+  ${'external-audit-storage'} | ${IntegrationStatusCode.SlackNotInChannel} | ${'success'}      | ${'Bot not invited to channel'}
+  ${'external-audit-storage'} | ${IntegrationStatusCode.Unknown}           | ${'success'}      | ${'Unknown'}
+  ${'external-audit-storage'} | ${IntegrationStatusCode.OtherError}        | ${'success'}      | ${'Unknown error'}
+  ${'any'}                    | ${IntegrationStatusCode.Draft}             | ${'warning'}      | ${'Draft'}
+  ${'any'}                    | ${IntegrationStatusCode.Running}           | ${'success'}      | ${'Running'}
+  ${'any'}                    | ${IntegrationStatusCode.Unauthorized}      | ${'danger'}       | ${'Unauthorized'}
+  ${'any'}                    | ${IntegrationStatusCode.SlackNotInChannel} | ${'warning'}      | ${'Bot not invited to channel'}
+  ${'any'}                    | ${IntegrationStatusCode.Unknown}           | ${'secondary'}    | ${'Unknown'}
+  ${'any'}                    | ${IntegrationStatusCode.OtherError}        | ${'danger'}       | ${'Unknown error'}
+`(
+  'getStatusAndLabel type $type with code $code returns expected',
+  async ({ type, code, expectedLabelKind, expectedTitle }) => {
+    const item: Integration = {
+      name: '',
+      kind: undefined,
+      resourceType: type,
+      statusCode: code,
+    };
+    const status = getStatusAndLabel(item);
+    expect(status.status).toBe(expectedTitle);
+    expect(status.labelKind).toBe(expectedLabelKind);
+  }
+);

--- a/web/packages/teleport/src/Integrations/helpers.ts
+++ b/web/packages/teleport/src/Integrations/helpers.ts
@@ -1,0 +1,74 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { LabelKind } from 'design/Label';
+
+import {
+  getStatusCodeTitle,
+  Integration,
+  IntegrationStatusCode,
+} from 'teleport/services/integrations';
+import { IntegrationLike, Status } from 'teleport/Integrations/IntegrationList';
+
+export function getStatus(item: IntegrationLike): Status {
+  if (item.resourceType === 'integration') {
+    return Status.Success;
+  }
+
+  if (item.resourceType === 'external-audit-storage') {
+    switch (item.statusCode) {
+      case IntegrationStatusCode.Draft:
+        return Status.Warning;
+      default:
+        return Status.Success;
+    }
+  }
+
+  switch (item.statusCode) {
+    case IntegrationStatusCode.Unknown:
+      return null;
+    case IntegrationStatusCode.Running:
+      return Status.Success;
+    case IntegrationStatusCode.SlackNotInChannel:
+      return Status.Warning;
+    case IntegrationStatusCode.Draft:
+      return Status.Warning;
+    default:
+      return Status.Error;
+  }
+}
+
+export function getStatusAndLabel(integration: Integration): {
+  labelKind: LabelKind;
+  status: string;
+} {
+  const modifiedStatus = getStatus(integration);
+  const statusCode = integration.statusCode;
+  const title = getStatusCodeTitle(statusCode);
+
+  switch (modifiedStatus) {
+    case Status.Success:
+      return { labelKind: 'success', status: title };
+    case Status.Error:
+      return { labelKind: 'danger', status: title };
+    case Status.Warning:
+      return { labelKind: 'warning', status: title };
+    default:
+      return { labelKind: 'secondary', status: title };
+  }
+}

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.story.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.story.tsx
@@ -1,0 +1,51 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+
+import { AwsOidcDashboard } from 'teleport/Integrations/status/AwsOidc/AwsOidcDashboard';
+import { MockAwsOidcStatusProvider } from 'teleport/Integrations/status/AwsOidc/testHelpers/mockAwsOidcStatusProvider';
+import { IntegrationKind } from 'teleport/services/integrations';
+
+export default {
+  title: 'Teleport/Integrations/AwsOidc',
+};
+
+export function Dashboard() {
+  return (
+    <MockAwsOidcStatusProvider
+      value={{
+        attempt: {
+          status: 'success',
+          data: {
+            resourceType: 'integration',
+            name: 'integration-one',
+            kind: IntegrationKind.AwsOidc,
+            spec: {
+              roleArn: 'arn:aws:iam::111456789011:role/bar',
+            },
+            statusCode: 1,
+          },
+          statusText: '',
+        },
+      }}
+    >
+      <AwsOidcDashboard />
+    </MockAwsOidcStatusProvider>
+  );
+}

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.test.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { render, screen } from 'design/utils/testing';
+
+import { AwsOidcDashboard } from 'teleport/Integrations/status/AwsOidc/AwsOidcDashboard';
+import { MockAwsOidcStatusProvider } from 'teleport/Integrations/status/AwsOidc/testHelpers/mockAwsOidcStatusProvider';
+import { IntegrationKind } from 'teleport/services/integrations';
+
+test('renders header', () => {
+  render(
+    <MockAwsOidcStatusProvider
+      value={{
+        attempt: {
+          status: 'success',
+          data: {
+            resourceType: 'integration',
+            name: 'integration-one',
+            kind: IntegrationKind.AwsOidc,
+            spec: {
+              roleArn: 'arn:aws:iam::111456789011:role/bar',
+            },
+            statusCode: 1,
+          },
+          statusText: '',
+        },
+      }}
+    >
+      <AwsOidcDashboard />
+    </MockAwsOidcStatusProvider>
+  );
+
+  expect(screen.getByRole('link', { name: 'back' })).toHaveAttribute(
+    'href',
+    '/web/integrations'
+  );
+  expect(screen.getByText('integration-one')).toBeInTheDocument();
+  expect(screen.getByLabelText('status')).toHaveAttribute('kind', 'success');
+  expect(screen.getByLabelText('status')).toHaveTextContent('Running');
+});

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.tsx
@@ -1,6 +1,6 @@
-/*
+/**
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2024 Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,6 +16,20 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import Label, { Primary, Secondary, Warning, Danger } from './Label';
-export default Label;
-export { Primary, Secondary, Warning, Danger };
+import React from 'react';
+
+import { AwsOidcHeader } from 'teleport/Integrations/status/AwsOidc/AwsOidcHeader';
+import { useAwsOidcStatus } from 'teleport/Integrations/status/AwsOidc/useAwsOidcStatus';
+import { FeatureBox } from 'teleport/components/Layout';
+
+// todo (michellescripts) after routing, ensure this view can be sticky
+export function AwsOidcDashboard() {
+  const { attempt } = useAwsOidcStatus();
+
+  return (
+    <FeatureBox css={{ maxWidth: '1400px', paddingTop: '16px' }}>
+      <AwsOidcHeader integration={attempt.data} />
+      Status for integration type aws-oidc is not supported
+    </FeatureBox>
+  );
+}

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcHeader.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcHeader.tsx
@@ -1,0 +1,55 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { Link as InternalLink } from 'react-router-dom';
+
+import { ButtonIcon, Flex, Label, Text } from 'design';
+import { ArrowLeft } from 'design/Icon';
+import { HoverTooltip } from 'shared/components/ToolTip';
+
+import cfg from 'teleport/config';
+import { getStatusAndLabel } from 'teleport/Integrations/helpers';
+import { Integration } from 'teleport/services/integrations';
+
+export function AwsOidcHeader({
+  integration,
+}: {
+  integration: Integration | null;
+}) {
+  const { status, labelKind } = getStatusAndLabel(integration);
+  return (
+    <Flex alignItems="center">
+      <HoverTooltip position="bottom" tipContent="Back to Integrations">
+        <ButtonIcon
+          as={InternalLink}
+          to={cfg.routes.integrations}
+          aria-label="back"
+        >
+          <ArrowLeft size="medium" />
+        </ButtonIcon>
+      </HoverTooltip>
+      <Text bold fontSize={6} mr={2}>
+        {integration?.name}
+      </Text>
+      <Label kind={labelKind} aria-label="status" px={3}>
+        {status}
+      </Label>
+    </Flex>
+  );
+}

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcRoutes.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcRoutes.tsx
@@ -1,6 +1,6 @@
 /**
  * Teleport
- * Copyright (C) 2024  Gravitational, Inc.
+ * Copyright (C) 2024 Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -17,19 +17,25 @@
  */
 
 import React from 'react';
-import { useParams } from 'react-router';
 
-import { IntegrationKind, PluginKind } from 'teleport/services/integrations';
-import { AwsOidcRoutes } from 'teleport/Integrations/status/AwsOidc/AwsOidcRoutes';
+import { Route, Switch } from 'teleport/components/Router';
+import cfg from 'teleport/config';
 
-export function IntegrationStatus() {
-  const { type: integrationType } = useParams<{
-    type: PluginKind | IntegrationKind;
-  }>();
+import { AwsOidcStatusProvider } from 'teleport/Integrations/status/AwsOidc/useAwsOidcStatus';
 
-  if (integrationType === 'aws-oidc') {
-    return <AwsOidcRoutes />;
-  }
+import { AwsOidcDashboard } from './AwsOidcDashboard';
 
-  return <>Status for integration type {integrationType} is not supported</>;
+export function AwsOidcRoutes() {
+  return (
+    <AwsOidcStatusProvider>
+      <Switch>
+        <Route
+          key="aws-oidc-resources-list"
+          exact
+          path={cfg.routes.integrationStatus}
+          component={AwsOidcDashboard}
+        />
+      </Switch>
+    </AwsOidcStatusProvider>
+  );
 }

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/testHelpers/mockAwsOidcStatusProvider.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/testHelpers/mockAwsOidcStatusProvider.tsx
@@ -1,0 +1,48 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+
+import { MemoryRouter } from 'react-router';
+
+import {
+  awsOidcStatusContext,
+  AwsOidcStatusContextState,
+} from 'teleport/Integrations/status/AwsOidc/useAwsOidcStatus';
+import { ContextProvider } from 'teleport';
+import { createTeleportContext } from 'teleport/mocks/contexts';
+
+export const MockAwsOidcStatusProvider = ({
+  children,
+  value,
+}: {
+  children?: React.ReactNode;
+  value: AwsOidcStatusContextState;
+}) => {
+  const ctx = createTeleportContext();
+
+  return (
+    <MemoryRouter>
+      <ContextProvider ctx={ctx}>
+        <awsOidcStatusContext.Provider value={value}>
+          {children}
+        </awsOidcStatusContext.Provider>
+      </ContextProvider>
+    </MemoryRouter>
+  );
+};

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/useAwsOidcStatus.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/useAwsOidcStatus.tsx
@@ -1,0 +1,76 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React, { createContext, useContext, useEffect } from 'react';
+import { useParams } from 'react-router';
+import { Attempt, useAsync } from 'shared/hooks/useAsync';
+
+import {
+  Integration,
+  IntegrationKind,
+  integrationService,
+} from 'teleport/services/integrations';
+
+import useTeleport from 'teleport/useTeleport';
+
+export interface AwsOidcStatusContextState {
+  attempt: Attempt<Integration>;
+}
+
+export const awsOidcStatusContext =
+  createContext<AwsOidcStatusContextState>(null);
+
+export function AwsOidcStatusProvider({ children }: React.PropsWithChildren) {
+  const { name } = useParams<{
+    type: IntegrationKind;
+    name: string;
+  }>();
+  const ctx = useTeleport();
+  const integrationAccess = ctx.storeUser.getIntegrationsAccess();
+  const hasIntegrationReadAccess = integrationAccess.read;
+
+  const [attempt, fetchIntegration] = useAsync(() =>
+    integrationService.fetchIntegration(name)
+  );
+
+  useEffect(() => {
+    if (hasIntegrationReadAccess) {
+      fetchIntegration();
+    }
+  }, []);
+
+  const value: AwsOidcStatusContextState = {
+    attempt,
+  };
+
+  return (
+    <awsOidcStatusContext.Provider value={value}>
+      {children}
+    </awsOidcStatusContext.Provider>
+  );
+}
+
+export function useAwsOidcStatus(): AwsOidcStatusContextState {
+  const context = useContext(awsOidcStatusContext);
+  if (!context) {
+    throw new Error(
+      'useAwsOidcStatus must be used within a AwsOidcStatusProvider'
+    );
+  }
+  return context;
+}


### PR DESCRIPTION
This PR sets up routing for an aws oidc status page. For now, it renders the header with integration name, status, and a "return button" with the same _not implemented_ text as before.

I moved types & helper methods related to the status pill to a helpers file and added tests.

Iterative PR to setup some scaffolding, future work will implement the dashboard UX

Before
<img width="1547" alt="Screenshot 2024-11-18 at 3 07 12 PM" src="https://github.com/user-attachments/assets/7904dcd4-b8cc-4665-a640-2572700a5d35">


After
<img width="1551" alt="Screenshot 2024-11-18 at 3 06 20 PM" src="https://github.com/user-attachments/assets/f4eb8a23-ebcf-4d96-95fe-94cc96b1e6dc">

Supports https://github.com/gravitational/teleport/issues/49087
