### PR TITLE
[v16] build: Fix "make create-github-release"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1725,10 +1725,10 @@ rustup-install-target-toolchain: rustup-set-version
 # usage: BASE_BRANCH=branch/v13 BASE_TAG=v13.2.0 make changelog
 #
 # BASE_BRANCH and BASE_TAG will be automatically determined if not specified.
-CHANGELOG = github.com/gravitational/shared-workflows/tools/changelog@latest
 .PHONY: changelog
 changelog:
-	@go run $(CHANGELOG) --base-branch="$(BASE_BRANCH)" --base-tag="$(BASE_TAG)" ./
+	@go run github.com/gravitational/shared-workflows/tools/changelog@latest \
+		--base-branch="$(BASE_BRANCH)" --base-tag="$(BASE_TAG)" ./
 
 # create-github-release will generate release notes from the CHANGELOG.md and will
 # create release notes from them.
@@ -1742,12 +1742,14 @@ changelog:
 #
 # For more information on release notes generation see: 
 #   https://github.com/gravitational/shared-workflows/tree/gus/release-notes/tools/release-notes#readme
-RELEASE_NOTES_GEN = go run github.com/gravitational/shared-workflows/tools/release-notes@latest
 .PHONY: create-github-release
 create-github-release: LATEST = false
 create-github-release: GITHUB_RELEASE_LABELS = ""
 create-github-release:
-	@NOTES=$$($(RELEASE_NOTES_GEN) --labels=$(GITHUB_RELEASE_LABELS) $(VERSION) CHANGELOG.md) && gh release create v$(VERSION) \
+	@NOTES=$$( \
+		go run github.com/gravitational/shared-workflows/tools/release-notes@latest \
+			--labels=$(GITHUB_RELEASE_LABELS) $(VERSION) CHANGELOG.md \
+	) && gh release create v$(VERSION) \
 	-t "Teleport $(VERSION)" \
 	--latest=$(LATEST) \
 	--verify-tag \

--- a/Makefile
+++ b/Makefile
@@ -1742,7 +1742,7 @@ changelog:
 #
 # For more information on release notes generation see: 
 #   https://github.com/gravitational/shared-workflows/tree/gus/release-notes/tools/release-notes#readme
-RELEASE_NOTES_GEN = github.com/gravitational/shared-workflows/tools/release-notes@latest
+RELEASE_NOTES_GEN = go run github.com/gravitational/shared-workflows/tools/release-notes@latest
 .PHONY: create-github-release
 create-github-release: LATEST = false
 create-github-release: GITHUB_RELEASE_LABELS = ""


### PR DESCRIPTION
Fix the `create-github-release` make target to use "go run" to run the
tool that creates the github release. This used to run a tool in this
repository that was pre-built, so the "go run" was not needed before.
Now the tool has moved to a separate repository, this is required.

Backport: https://github.com/gravitational/teleport/pull/49111