### PR TITLE
[v17] Make `tsh puttyconfig` disable GSSApi auth

### DIFF
--- a/tool/tsh/common/putty_config_windows.go
+++ b/tool/tsh/common/putty_config_windows.go
@@ -52,6 +52,8 @@ const puttyDwordProxyLogToTerm = `00000002` // only until session starts
 const puttyPermitRSASHA1 = `00000000`
 const puttyPermitRSASHA256 = `00000001`
 const puttyPermitRSASHA512 = `00000001`
+const puttyAuthGSSAPI = `00000000`
+const puttyAuthGSSAPIKEX = `00000000`
 
 // despite the strings/ints in struct, these are stored in the registry as DWORDs
 type puttyRegistrySessionDwords struct {
@@ -60,6 +62,8 @@ type puttyRegistrySessionDwords struct {
 	ProxyPort      int    // dword
 	ProxyMethod    string // dword
 	ProxyLogToTerm string // dword
+	AuthGSSAPI     string // dword
+	AuthGSSAPIKEX  string // dword
 }
 
 type puttyRegistrySessionStrings struct {
@@ -93,6 +97,8 @@ func addPuTTYSession(proxyHostname string, hostname string, port int, login stri
 		ProxyPort:      puttyDefaultProxyPort,
 		ProxyMethod:    puttyDwordProxyMethod,
 		ProxyLogToTerm: puttyDwordProxyLogToTerm,
+		AuthGSSAPI:     puttyAuthGSSAPI,
+		AuthGSSAPIKEX:  puttyAuthGSSAPIKEX,
 	}
 
 	sessionStrings := puttyRegistrySessionStrings{
@@ -128,6 +134,12 @@ func addPuTTYSession(proxyHostname string, hostname string, port int, login stri
 		return trace.Wrap(err)
 	}
 	if err := registry.WriteDword(pk, "ProxyLogToTerm", sessionDwords.ProxyLogToTerm); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := registry.WriteDword(pk, "AuthGSSAPI", sessionDwords.AuthGSSAPI); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := registry.WriteDword(pk, "AuthGSSAPIKEX", sessionDwords.AuthGSSAPIKEX); err != nil {
 		return trace.Wrap(err)
 	}
 


### PR DESCRIPTION
Backport #48323 to branch/v17

changelog: The `tsh puttyconfig` command now disables GSSAPI auth settings to avoid a "Not Responding" condition in PuTTY
