### PR TITLE
Update types for TestAuthServerConfig

### DIFF
--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -79,7 +79,7 @@ type TestAuthServerConfig struct {
 	// CipherSuites is the list of ciphers that the server supports.
 	CipherSuites []uint16
 	// Clock is used to control time in tests.
-	Clock clockwork.FakeClock
+	Clock clockwork.Clock
 	// ClusterNetworkingConfig allows a test to change the default
 	// networking configuration.
 	ClusterNetworkingConfig types.ClusterNetworkingConfig


### PR DESCRIPTION
* Allow accepting a RealClock instead of only a FakeClock.

Related to [#5530](https://github.com/gravitational/teleport.e/pull/5530).
