### PR TITLE
Allow absolute links in the changelog

### DIFF
--- a/docs/pages/changelog.mdx
+++ b/docs/pages/changelog.mdx
@@ -2,5 +2,6 @@
 title: Teleport Changelog
 description: The Changelog provides a comprehensive description of the changes introduced by each Teleport release.
 ---
-{/*lint disable messaging*/}
+{/*lint disable absolute-docs-links*/}
+
 (!CHANGELOG.md!)


### PR DESCRIPTION
Disable absolute docs link linting in the changelog. This is because the changelog needs to include absolute docs links in order for our release process to run smoothly, since we need to sync release notes to the changelog.

This change removes the comment that disables the remark messaging linter, since we have removed this custom linter in favor of Vale.