### PR TITLE
[v17] Add database and Windows access sections to the role editor

### DIFF
--- a/web/packages/shared/components/FieldSelect/shared.tsx
+++ b/web/packages/shared/components/FieldSelect/shared.tsx
@@ -202,6 +202,7 @@ export function splitSelectProps<
     onChange,
     onInputChange,
     onKeyDown,
+    openMenuOnClick,
     options,
     placeholder,
     rule,
@@ -239,6 +240,7 @@ export function splitSelectProps<
       onInputChange,
       onKeyDown,
       options,
+      openMenuOnClick,
       placeholder,
       stylesConfig,
       value,
@@ -285,6 +287,7 @@ type KeysRemovedFromOthers =
   | 'onChange'
   | 'onInputChange'
   | 'onKeyDown'
+  | 'openMenuOnClick'
   | 'options'
   | 'placeholder'
   | 'rule'

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor.tsx
@@ -63,6 +63,8 @@ import {
   kubernetesVerbOptions,
   KubernetesResourceModel,
   AppAccessSpec,
+  DatabaseAccessSpec,
+  WindowsDesktopAccessSpec,
 } from './standardmodel';
 import { EditorSaveCancelButton } from './Shared';
 import { RequiresResetToStandard } from './RequiresResetToStandard';
@@ -359,7 +361,13 @@ const Section = ({
 /**
  * All access spec kinds, in order of appearance in the resource kind dropdown.
  */
-const allAccessSpecKinds: AccessSpecKind[] = ['kube_cluster', 'node', 'app'];
+const allAccessSpecKinds: AccessSpecKind[] = [
+  'kube_cluster',
+  'node',
+  'app',
+  'db',
+  'windows_desktop',
+];
 
 /** Maps access specification kind to UI component configuration. */
 const specSections: Record<
@@ -384,6 +392,16 @@ const specSections: Record<
     title: 'Applications',
     tooltip: 'Configures access to applications',
     component: AppAccessSpecSection,
+  },
+  db: {
+    title: 'Databases',
+    tooltip: 'Configures access to databases',
+    component: DatabaseAccessSpecSection,
+  },
+  windows_desktop: {
+    title: 'Windows Desktops',
+    tooltip: 'Configures access to Windows desktops',
+    component: WindowsDesktopAccessSpecSection,
   },
 };
 
@@ -436,6 +454,7 @@ export function ServerAccessSpecSection({
         components={{
           DropdownIndicator: null,
         }}
+        openMenuOnClick={false}
         value={value.logins}
         onChange={logins => onChange?.({ ...value, logins })}
         mt={3}
@@ -460,6 +479,7 @@ export function KubernetesAccessSpecSection({
         components={{
           DropdownIndicator: null,
         }}
+        openMenuOnClick={false}
         value={value.groups}
         onChange={groups => onChange?.({ ...value, groups })}
       />
@@ -633,6 +653,111 @@ export function AppAccessSpecSection({
         onChange={accts => onChange?.({ ...value, gcpServiceAccounts: accts })}
       />
     </Flex>
+  );
+}
+
+export function DatabaseAccessSpecSection({
+  value,
+  isProcessing,
+  onChange,
+}: SectionProps<DatabaseAccessSpec>) {
+  return (
+    <>
+      <Box mb={3}>
+        <Text typography="body3" mb={1}>
+          Labels
+        </Text>
+        <LabelsInput
+          disableBtns={isProcessing}
+          labels={value.labels}
+          setLabels={labels => onChange?.({ ...value, labels })}
+        />
+      </Box>
+      <FieldSelectCreatable
+        isMulti
+        label="Database Names"
+        toolTipContent={
+          <>
+            List of database names that this role is allowed to connect to.
+            Special value <MarkInverse>*</MarkInverse> means any name.
+          </>
+        }
+        isDisabled={isProcessing}
+        formatCreateLabel={label => `Database Name: ${label}`}
+        components={{
+          DropdownIndicator: null,
+        }}
+        openMenuOnClick={false}
+        value={value.names}
+        onChange={names => onChange?.({ ...value, names })}
+      />
+      <FieldSelectCreatable
+        isMulti
+        label="Database Users"
+        toolTipContent={
+          <>
+            List of database users that this role is allowed to connect as.
+            Special value <MarkInverse>*</MarkInverse> means any user.
+          </>
+        }
+        isDisabled={isProcessing}
+        formatCreateLabel={label => `Database User: ${label}`}
+        components={{
+          DropdownIndicator: null,
+        }}
+        openMenuOnClick={false}
+        value={value.users}
+        onChange={users => onChange?.({ ...value, users })}
+      />
+      <FieldSelectCreatable
+        isMulti
+        label="Database Roles"
+        toolTipContent="If automatic user provisioning is available, this is the list of database roles that will be assigned to the database user after it's created"
+        isDisabled={isProcessing}
+        formatCreateLabel={label => `Database Role: ${label}`}
+        components={{
+          DropdownIndicator: null,
+        }}
+        openMenuOnClick={false}
+        value={value.roles}
+        onChange={roles => onChange?.({ ...value, roles })}
+        mb={0}
+      />
+    </>
+  );
+}
+
+export function WindowsDesktopAccessSpecSection({
+  value,
+  isProcessing,
+  onChange,
+}: SectionProps<WindowsDesktopAccessSpec>) {
+  return (
+    <>
+      <Box mb={3}>
+        <Text typography="body3" mb={1}>
+          Labels
+        </Text>
+        <LabelsInput
+          disableBtns={isProcessing}
+          labels={value.labels}
+          setLabels={labels => onChange?.({ ...value, labels })}
+        />
+      </Box>
+      <FieldSelectCreatable
+        isMulti
+        label="Logins"
+        toolTipContent="List of desktop logins that this role is allowed to use"
+        isDisabled={isProcessing}
+        formatCreateLabel={label => `Login: ${label}`}
+        components={{
+          DropdownIndicator: null,
+        }}
+        openMenuOnClick={false}
+        value={value.logins}
+        onChange={logins => onChange?.({ ...value, logins })}
+      />
+    </>
   );
 }
 

--- a/web/packages/teleport/src/Roles/RoleEditor/standardmodel.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/standardmodel.ts
@@ -66,7 +66,9 @@ export type MetadataModel = {
 export type AccessSpec =
   | KubernetesAccessSpec
   | ServerAccessSpec
-  | AppAccessSpec;
+  | AppAccessSpec
+  | DatabaseAccessSpec
+  | WindowsDesktopAccessSpec;
 
 /**
  * A base for all access specification section models. Contains a type
@@ -82,7 +84,12 @@ type AccessSpecBase<T extends AccessSpecKind> = {
   kind: T;
 };
 
-export type AccessSpecKind = 'node' | 'kube_cluster' | 'app';
+export type AccessSpecKind =
+  | 'node'
+  | 'kube_cluster'
+  | 'app'
+  | 'db'
+  | 'windows_desktop';
 
 /** Model for the Kubernetes access specification section. */
 export type KubernetesAccessSpec = AccessSpecBase<'kube_cluster'> & {
@@ -205,7 +212,7 @@ export const kubernetesVerbOptions: KubernetesVerbOption[] = [
     ] as const
   )
     .toSorted((a, b) => a.localeCompare(b))
-    .map(verb => ({ value: verb, label: verb })),
+    .map(stringToOption),
 ];
 
 /** Model for the server access specification section. */
@@ -219,6 +226,18 @@ export type AppAccessSpec = AccessSpecBase<'app'> & {
   awsRoleARNs: string[];
   azureIdentities: string[];
   gcpServiceAccounts: string[];
+};
+
+export type DatabaseAccessSpec = AccessSpecBase<'db'> & {
+  labels: UILabel[];
+  names: readonly Option[];
+  users: readonly Option[];
+  roles: readonly Option[];
+};
+
+export type WindowsDesktopAccessSpec = AccessSpecBase<'windows_desktop'> & {
+  labels: UILabel[];
+  logins: readonly Option[];
 };
 
 const roleVersion = 'v7';
@@ -244,6 +263,10 @@ export function newRole(): Role {
 export function newAccessSpec(kind: 'node'): ServerAccessSpec;
 export function newAccessSpec(kind: 'kube_cluster'): KubernetesAccessSpec;
 export function newAccessSpec(kind: 'app'): AppAccessSpec;
+export function newAccessSpec(kind: 'db'): DatabaseAccessSpec;
+export function newAccessSpec(
+  kind: 'windows_desktop'
+): WindowsDesktopAccessSpec;
 export function newAccessSpec(kind: AccessSpecKind): AppAccessSpec;
 export function newAccessSpec(kind: AccessSpecKind): AccessSpec {
   switch (kind) {
@@ -259,6 +282,10 @@ export function newAccessSpec(kind: AccessSpecKind): AccessSpec {
         azureIdentities: [],
         gcpServiceAccounts: [],
       };
+    case 'db':
+      return { kind: 'db', labels: [], names: [], users: [], roles: [] };
+    case 'windows_desktop':
+      return { kind: 'windows_desktop', labels: [], logins: [] };
     default:
       kind satisfies never;
   }
@@ -334,17 +361,22 @@ function roleConditionsToAccessSpecs(conditions: RoleConditions): {
     aws_role_arns,
     azure_identities,
     gcp_service_accounts,
+
+    db_labels,
+    db_names,
+    db_users,
+    db_roles,
+
+    windows_desktop_labels,
+    windows_desktop_logins,
     ...rest
   } = conditions;
 
   const accessSpecs: AccessSpec[] = [];
 
   const nodeLabelsModel = labelsToModel(node_labels);
-  const nodeLoginsModel = (logins ?? []).map(login => ({
-    label: login,
-    value: login,
-  }));
-  if (nodeLabelsModel.length > 0 || nodeLoginsModel.length > 0) {
+  const nodeLoginsModel = stringsToOptions(logins ?? []);
+  if (someNonEmpty(nodeLabelsModel, nodeLoginsModel)) {
     accessSpecs.push({
       kind: 'node',
       labels: nodeLabelsModel,
@@ -352,17 +384,10 @@ function roleConditionsToAccessSpecs(conditions: RoleConditions): {
     });
   }
 
-  const kubeGroupsModel = (kubernetes_groups ?? []).map(group => ({
-    label: group,
-    value: group,
-  }));
+  const kubeGroupsModel = stringsToOptions(kubernetes_groups ?? []);
   const kubeLabelsModel = labelsToModel(kubernetes_labels);
   const kubeResourcesModel = kubernetesResourcesToModel(kubernetes_resources);
-  if (
-    kubeGroupsModel.length > 0 ||
-    kubeLabelsModel.length > 0 ||
-    kubeResourcesModel.length > 0
-  ) {
+  if (someNonEmpty(kubeGroupsModel, kubeLabelsModel, kubeResourcesModel)) {
     accessSpecs.push({
       kind: 'kube_cluster',
       groups: kubeGroupsModel,
@@ -376,10 +401,12 @@ function roleConditionsToAccessSpecs(conditions: RoleConditions): {
   const azureIdentitiesModel = azure_identities ?? [];
   const gcpServiceAccountsModel = gcp_service_accounts ?? [];
   if (
-    appLabelsModel.length > 0 ||
-    awsRoleARNsModel.length > 0 ||
-    azureIdentitiesModel.length > 0 ||
-    gcpServiceAccountsModel.length > 0
+    someNonEmpty(
+      appLabelsModel,
+      awsRoleARNsModel,
+      azureIdentitiesModel,
+      gcpServiceAccountsModel
+    )
   ) {
     accessSpecs.push({
       kind: 'app',
@@ -390,10 +417,40 @@ function roleConditionsToAccessSpecs(conditions: RoleConditions): {
     });
   }
 
+  const dbLabelsModel = labelsToModel(db_labels);
+  const dbNamesModel = db_names ?? [];
+  const dbUsersModel = db_users ?? [];
+  const dbRolesModel = db_roles ?? [];
+  if (someNonEmpty(dbLabelsModel, dbNamesModel, dbUsersModel, dbRolesModel)) {
+    accessSpecs.push({
+      kind: 'db',
+      labels: dbLabelsModel,
+      names: stringsToOptions(dbNamesModel),
+      users: stringsToOptions(dbUsersModel),
+      roles: stringsToOptions(dbRolesModel),
+    });
+  }
+
+  const windowsDesktopLabelsModel = labelsToModel(windows_desktop_labels);
+  const windowsDesktopLoginsModel = stringsToOptions(
+    windows_desktop_logins ?? []
+  );
+  if (someNonEmpty(windowsDesktopLabelsModel, windowsDesktopLoginsModel)) {
+    accessSpecs.push({
+      kind: 'windows_desktop',
+      labels: windowsDesktopLabelsModel,
+      logins: windowsDesktopLoginsModel,
+    });
+  }
+
   return {
     accessSpecs,
     requiresReset: !isEmpty(rest),
   };
+}
+
+function someNonEmpty(...arr: any[][]): boolean {
+  return arr.some(x => x.length > 0);
 }
 
 /**
@@ -412,6 +469,14 @@ export function labelsToModel(labels: Labels | undefined): UILabel[] {
       return value.map(v => ({ name, value: v }));
     }
   });
+}
+
+function stringToOption<T extends string>(s: T): Option<T> {
+  return { label: s, value: s };
+}
+
+function stringsToOptions<T extends string>(arr: T[]): Option<T>[] {
+  return arr.map(stringToOption);
 }
 
 function kubernetesResourcesToModel(
@@ -462,18 +527,18 @@ export function roleEditorModelToRole(roleModel: RoleEditorModel): Role {
     switch (kind) {
       case 'node':
         role.spec.allow.node_labels = labelsModelToLabels(spec.labels);
-        role.spec.allow.logins = spec.logins.map(opt => opt.value);
+        role.spec.allow.logins = optionsToStrings(spec.logins);
         break;
 
       case 'kube_cluster':
-        role.spec.allow.kubernetes_groups = spec.groups.map(opt => opt.value);
+        role.spec.allow.kubernetes_groups = optionsToStrings(spec.groups);
         role.spec.allow.kubernetes_labels = labelsModelToLabels(spec.labels);
         role.spec.allow.kubernetes_resources = spec.resources.map(
           ({ kind, name, namespace, verbs }) => ({
             kind: kind.value,
             name,
             namespace,
-            verbs: verbs.map(opt => opt.value),
+            verbs: optionsToStrings(verbs),
           })
         );
         break;
@@ -483,6 +548,20 @@ export function roleEditorModelToRole(roleModel: RoleEditorModel): Role {
         role.spec.allow.aws_role_arns = spec.awsRoleARNs;
         role.spec.allow.azure_identities = spec.azureIdentities;
         role.spec.allow.gcp_service_accounts = spec.gcpServiceAccounts;
+        break;
+
+      case 'db':
+        role.spec.allow.db_labels = labelsModelToLabels(spec.labels);
+        role.spec.allow.db_names = optionsToStrings(spec.names);
+        role.spec.allow.db_users = optionsToStrings(spec.users);
+        role.spec.allow.db_roles = optionsToStrings(spec.roles);
+        break;
+
+      case 'windows_desktop':
+        role.spec.allow.windows_desktop_labels = labelsModelToLabels(
+          spec.labels
+        );
+        role.spec.allow.windows_desktop_logins = optionsToStrings(spec.logins);
         break;
 
       default:
@@ -509,6 +588,10 @@ export function labelsModelToLabels(uiLabels: UILabel[]): Labels {
     }
   }
   return labels;
+}
+
+function optionsToStrings(opts: readonly Option[]): string[] {
+  return opts.map(opt => opt.value);
 }
 
 /** Detects if fields were modified by comparing against the original role. */

--- a/web/packages/teleport/src/services/resources/types.ts
+++ b/web/packages/teleport/src/services/resources/types.ts
@@ -75,6 +75,14 @@ export type RoleConditions = {
   aws_role_arns?: string[];
   azure_identities?: string[];
   gcp_service_accounts?: string[];
+
+  db_labels?: Labels;
+  db_names?: string[];
+  db_users?: string[];
+  db_roles?: string[];
+
+  windows_desktop_labels?: Labels;
+  windows_desktop_logins?: string[];
 };
 
 export type Labels = Record<string, string | string[]>;


### PR DESCRIPTION
Backport #47992 to branch/v17

Backported manually only because I forgot to apply the backport label to the original. No manual merges.