### PR TITLE
[v16] remove reference to Pro license in AWS Terraform Makefile

### DIFF
--- a/examples/aws/terraform/ha-autoscale-cluster/Makefile
+++ b/examples/aws/terraform/ha-autoscale-cluster/Makefile
@@ -9,8 +9,8 @@ TF_VAR_cluster_name ?=
 # AWS SSH key name to provision in installed instances, should be available in the region
 TF_VAR_key_name ?=
 
-# Full absolute path to the license file for Teleport Enterprise or Pro.
-# This license will be copied into SSM and then pulled down on the auth nodes to enable Enterprise/Pro functionality
+# Full absolute path to the license file for Teleport Enterprise 
+# This license will be copied into SSM and then pulled down on the auth nodes to enable Enterprise functionality
 TF_VAR_license_path ?=
 
 # AMI name contains the version of Teleport to install, and whether to use OSS or Enterprise version


### PR DESCRIPTION
Backport #49200 to branch/v16