### PR TITLE
[v16] Correct postgres retention_period as a fragment instead of a GET param

### DIFF
--- a/docs/pages/includes/config-reference/auth-service.yaml
+++ b/docs/pages/includes/config-reference/auth-service.yaml
@@ -58,7 +58,7 @@ teleport:
         # consume the retention period via a query parameter in the audit_events_uri. See the examples below
         # for how to configure the retention period for other backends.
         # Firestore: firestore://events_table_name?eventRetentionPeriod=10d
-        # Postgres: postgresql://user_name@database-address/teleport_audit?retention_period=10d
+        # Postgres: postgresql://user_name@database-address/teleport_audit#retention_period=240h
         retention_period: 365d
 
         # minimum/maximum read capacity in units


### PR DESCRIPTION
Backport #46898 to branch/v16