### PR TITLE
[v17] Support AMR notification routing with email plugins

### DIFF
--- a/integrations/access/accessrequest/app.go
+++ b/integrations/access/accessrequest/app.go
@@ -181,12 +181,12 @@ func (a *App) onWatcherEvent(ctx context.Context, event types.Event) error {
 	case types.KindAccessMonitoringRule:
 		return trace.Wrap(a.accessMonitoringRules.HandleAccessMonitoringRule(ctx, event))
 	case types.KindAccessRequest:
-		return trace.Wrap(a.handleAcessRequest(ctx, event))
+		return trace.Wrap(a.handleAccessRequest(ctx, event))
 	}
 	return trace.BadParameter("unexpected kind %s", event.Resource.GetKind())
 }
 
-func (a *App) handleAcessRequest(ctx context.Context, event types.Event) error {
+func (a *App) handleAccessRequest(ctx context.Context, event types.Event) error {
 	op := event.Type
 	reqID := event.Resource.GetName()
 	ctx, _ = logger.WithField(ctx, "request_id", reqID)

--- a/integrations/access/email/client.go
+++ b/integrations/access/email/client.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integrations/access/common"
 	"github.com/gravitational/teleport/integrations/lib"
 	"github.com/gravitational/teleport/integrations/lib/logger"
 )
@@ -85,20 +86,20 @@ func (c *Client) CheckHealth(ctx context.Context) error {
 }
 
 // SendNewThreads sends emails on new requests. Returns EmailData.
-func (c *Client) SendNewThreads(ctx context.Context, recipients []string, reqID string, reqData RequestData) ([]EmailThread, error) {
+func (c *Client) SendNewThreads(ctx context.Context, recipients []common.Recipient, reqID string, reqData RequestData) ([]EmailThread, error) {
 	var threads []EmailThread
 	var errors []error
 
 	body := c.buildBody(reqID, reqData, "You have a new Role Request")
 
-	for _, email := range recipients {
-		id, err := c.mailer.Send(ctx, reqID, email, body, "")
+	for _, recipient := range recipients {
+		id, err := c.mailer.Send(ctx, reqID, recipient.ID, body, "")
 		if err != nil {
 			errors = append(errors, err)
 			continue
 		}
 
-		threads = append(threads, EmailThread{Email: email, Timestamp: time.Now().String(), MessageID: id})
+		threads = append(threads, EmailThread{Email: recipient.ID, Timestamp: time.Now().String(), MessageID: id})
 	}
 
 	return threads, trace.NewAggregate(errors...)

--- a/integrations/access/email/testlib/suite.go
+++ b/integrations/access/email/testlib/suite.go
@@ -31,7 +31,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	accessmonitoringrulesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessmonitoringrules/v1"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integrations/access/common"
 	"github.com/gravitational/teleport/integrations/access/email"
 	"github.com/gravitational/teleport/integrations/lib"
 	"github.com/gravitational/teleport/integrations/lib/logger"
@@ -229,6 +232,132 @@ func (s *EmailSuiteOSS) TestDenial() {
 	require.Contains(t, recipients, integration.Reviewer1UserName)
 
 	require.Contains(t, messages[0].Body, "Status: ❌ DENIED (not okay)")
+}
+
+// TestRecipientsFromAccessMonitoringRule tests access monitoring rules are
+// applied to the recipient selection process.
+func (s *EmailSuiteOSS) TestRecipientsFromAccessMonitoringRule() {
+	t := s.T()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	t.Cleanup(cancel)
+
+	_, err := s.ClientByName(integration.RulerUserName).
+		AccessMonitoringRulesClient().
+		CreateAccessMonitoringRule(ctx, &accessmonitoringrulesv1.AccessMonitoringRule{
+			Kind:    types.KindAccessMonitoringRule,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: "test-email-amr",
+			},
+			Spec: &accessmonitoringrulesv1.AccessMonitoringRuleSpec{
+				Subjects:  []string{types.KindAccessRequest},
+				Condition: "!is_empty(access_request.spec.roles)",
+				Notification: &accessmonitoringrulesv1.Notification{
+					Name: "email",
+					Recipients: []string{
+						integration.Reviewer1UserName,
+					},
+				},
+			},
+		})
+	require.NoError(t, err)
+
+	// Test execution: create an access request
+	req := s.CreateAccessRequest(ctx, integration.RequesterOSSUserName, nil)
+	pluginData := s.checkPluginData(ctx, req.GetName(), func(data email.PluginData) bool {
+		return len(data.EmailThreads) > 0
+	})
+	require.Len(t, pluginData.EmailThreads, 1)
+
+	messages := s.getMessages(ctx, t, 1)
+	require.Len(t, messages, 1)
+	require.Equal(t, integration.Reviewer1UserName, messages[0].Recipient)
+
+	require.NoError(t, s.ClientByName(integration.RulerUserName).
+		AccessMonitoringRulesClient().DeleteAccessMonitoringRule(ctx, "test-email-amr"))
+}
+
+// TestRecipientsFromAccessMonitoringRuleAfterUpdate tests access monitoring
+// rules are respected after the rule is updated.
+func (s *EmailSuiteOSS) TestRecipientsFromAccessMonitoringRuleAfterUpdate() {
+	t := s.T()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	t.Cleanup(cancel)
+
+	// Setup base config to ensure access monitoring rule recipient take precidence
+	s.appConfig.RoleToRecipients = common.RawRecipientsMap{
+		types.Wildcard: []string{
+			integration.Reviewer2UserName,
+		},
+	}
+
+	_, err := s.ClientByName(integration.RulerUserName).
+		AccessMonitoringRulesClient().
+		CreateAccessMonitoringRule(ctx, &accessmonitoringrulesv1.AccessMonitoringRule{
+			Kind:    types.KindAccessMonitoringRule,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: "test-email-amr-2",
+			},
+			Spec: &accessmonitoringrulesv1.AccessMonitoringRuleSpec{
+				Subjects:  []string{types.KindAccessRequest},
+				Condition: "!is_empty(access_request.spec.roles)",
+				Notification: &accessmonitoringrulesv1.Notification{
+					Name: "email",
+					Recipients: []string{
+						integration.Reviewer1UserName,
+					},
+				},
+			},
+		})
+	require.NoError(t, err)
+
+	// Test execution: create an access request
+	req := s.CreateAccessRequest(ctx, integration.RequesterOSSUserName, nil)
+	pluginData := s.checkPluginData(ctx, req.GetName(), func(data email.PluginData) bool {
+		return len(data.EmailThreads) > 0
+	})
+	require.Len(t, pluginData.EmailThreads, 1)
+
+	messages := s.getMessages(ctx, t, 1)
+	require.Len(t, messages, 1)
+	require.Equal(t, integration.Reviewer1UserName, messages[0].Recipient)
+
+	// Update the Access Monitoring Rule so it is no longer applied
+	_, err = s.ClientByName(integration.RulerUserName).
+		AccessMonitoringRulesClient().
+		UpdateAccessMonitoringRule(ctx, &accessmonitoringrulesv1.AccessMonitoringRule{
+			Kind:    types.KindAccessMonitoringRule,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: "test-email-amr-2",
+			},
+			Spec: &accessmonitoringrulesv1.AccessMonitoringRuleSpec{
+				Subjects:  []string{"someOtherKind"},
+				Condition: "!is_empty(access_request.spec.roles)",
+				Notification: &accessmonitoringrulesv1.Notification{
+					Name: "email",
+					Recipients: []string{
+						integration.Reviewer1UserName,
+					},
+				},
+			},
+		})
+	require.NoError(t, err)
+
+	// Test execution: create an access request
+	req = s.CreateAccessRequest(ctx, integration.RequesterOSSUserName, nil)
+	pluginData = s.checkPluginData(ctx, req.GetName(), func(data email.PluginData) bool {
+		return len(data.EmailThreads) > 0
+	})
+	require.Len(t, pluginData.EmailThreads, 1)
+
+	messages = s.getMessages(ctx, t, 1)
+	require.Len(t, messages, 1)
+	require.Equal(t, allRecipient, messages[0].Recipient)
+
+	require.NoError(t, s.ClientByName(integration.RulerUserName).
+		AccessMonitoringRulesClient().DeleteAccessMonitoringRule(ctx, "test-email-amr-2"))
 }
 
 // TestReviewReplies tests that a followup email is sent after the access request


### PR DESCRIPTION
Backport #49038 to branch/v17

changelog: Support Email Plugin notification routing using Access Monitoring Rules.
