### PR TITLE
docs: update macos uninstall

### DIFF
--- a/docs/pages/admin-guides/management/admin/uninstall-teleport.mdx
+++ b/docs/pages/admin-guides/management/admin/uninstall-teleport.mdx
@@ -160,7 +160,7 @@ Follow the instructions for your Linux distribution:
   You can use `dirname $(which teleport)` to look this up automatically.
   </Admonition>
 
-  Remove the Teleport binaries from the machine:
+  Remove the Teleport binaries and links to Teleport software from the machine:
 
   ```code
   $ sudo rm -f /usr/local/bin/tbot

--- a/docs/pages/admin-guides/management/admin/uninstall-teleport.mdx
+++ b/docs/pages/admin-guides/management/admin/uninstall-teleport.mdx
@@ -171,10 +171,17 @@ Follow the instructions for your Linux distribution:
   ```
 
   <Admonition type="notice" title="Uninstall macOS client tools">
-  If you installed the macOS `tsh` client-only package and/or Teleport Connect for macOS, you can optionally remove those too:
+
+  You may have Teleport in Applications folder if you:
+  - Installed from a macOS tar ball for v17+ that includes `tsh.app` and `tctl.app`
+  - Installed  macOS `tsh` client-only package for v16 or older versions.
+  - Installed Teleport Connect for macOS  
+     
+  You can remove those with these commands:
 
   ```code
   $ sudo rm -rf /Applications/tsh.app
+  $ sudo rm -rf /Applications/tctl.app
   $ sudo rm -rf /Applications/Teleport\ Connect.app
   ```
   </Admonition>

--- a/docs/pages/admin-guides/management/admin/uninstall-teleport.mdx
+++ b/docs/pages/admin-guides/management/admin/uninstall-teleport.mdx
@@ -172,9 +172,9 @@ Follow the instructions for your Linux distribution:
 
   <Admonition type="notice" title="Uninstall macOS client tools">
 
-  You may have Teleport in Applications folder if you:
-  - Installed from a macOS tar ball for v17+ that includes `tsh.app` and `tctl.app`
-  - Installed  macOS `tsh` client-only package for v16 or older versions.
+  You may have Teleport software in the `/Applications` folder if you:
+  - Installed from a macOS tarball for v17+ that includes `tsh.app` and `tctl.app`
+  - Installed the macOS `tsh` client-only package for v16 or older versions.
   - Installed Teleport Connect for macOS  
      
   You can remove those with these commands:


### PR DESCRIPTION
Update macos uninstall to include the `tctl` app that is now included with tar ball and pkg installation 