### PR TITLE
[web] Default config for `storybook-controls`, add `storybook-actions`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,11 @@
   },
   "devDependencies": {
     "@gravitational/build": "workspace:*",
+    "@storybook/addon-actions": "^8.3.4",
     "@storybook/addon-controls": "^8.3.4",
     "@storybook/addon-toolbars": "^8.3.4",
     "@storybook/components": "^8.3.4",
+    "@storybook/preview-api": "^8.3.4",
     "@storybook/react": "^8.3.4",
     "@storybook/react-vite": "^8.3.4",
     "@storybook/test-runner": "^0.19.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       '@gravitational/build':
         specifier: workspace:*
         version: link:web/packages/build
+      '@storybook/addon-actions':
+        specifier: ^8.3.4
+        version: 8.3.4(storybook@8.3.4)
       '@storybook/addon-controls':
         specifier: ^8.3.4
         version: 8.3.4(storybook@8.3.4)
@@ -105,6 +108,9 @@ importers:
         specifier: ^8.3.4
         version: 8.3.4(storybook@8.3.4)
       '@storybook/components':
+        specifier: ^8.3.4
+        version: 8.3.4(storybook@8.3.4)
+      '@storybook/preview-api':
         specifier: ^8.3.4
         version: 8.3.4(storybook@8.3.4)
       '@storybook/react':
@@ -2177,6 +2183,11 @@ packages:
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
+  '@storybook/addon-actions@8.3.4':
+    resolution: {integrity: sha512-1y0yD3upKcyzNwwA6loAGW2cRDqExwl4oAT7GJQA4tmabI+fNwmANSgU/ezLvvSUf4Qo0eJHg2Zcn8y+Apq2eA==}
+    peerDependencies:
+      storybook: ^8.3.4
+
   '@storybook/addon-controls@8.3.4':
     resolution: {integrity: sha512-qQcaK6dczsb6wXkzGZKOjUYNA7FfKBewRv6NvoVKYY6LfhllGOkmUAtYpdtQG8adsZWTSoZaAOJS2vP2uM67lw==}
     peerDependencies:
@@ -2236,11 +2247,6 @@ packages:
     resolution: {integrity: sha512-tBx7MBfPUrKSlD666zmVjtIvoNArwCciZiW/UJ8IWmomrTJRfFBnVvPVM2gp1lkDIzRHYmz5x9BHbYaEDNcZWQ==}
     peerDependencies:
       storybook: ^8.3.4
-
-  '@storybook/preview-api@8.2.9':
-    resolution: {integrity: sha512-D8/t+a78OJqQAcT/ABa1C4YM/OaLGQ9IvCsp3Q9ruUqDCwuZBj8bG3D4477dlY4owX2ycC0rWYu3VvuK0EmJjA==}
-    peerDependencies:
-      storybook: ^8.2.9
 
   '@storybook/preview-api@8.3.4':
     resolution: {integrity: sha512-/YKQ3QDVSHmtFXXCShf5w0XMlg8wkfTpdYxdGv1CKFV8DU24f3N7KWulAgeWWCWQwBzZClDa9kzxmroKlQqx3A==}
@@ -2670,6 +2676,9 @@ packages:
 
   '@types/triple-beam@1.3.5':
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
+
+  '@types/uuid@9.0.8':
+    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
   '@types/verror@1.10.5':
     resolution: {integrity: sha512-9UjMCHK5GPgQRoNbqdLIAvAy0EInuiqbW0PBMtVP6B5B2HQJlvoJHM+KodPZMEjOa5VkSc+5LH7xy+cUzQdmHw==}
@@ -5671,6 +5680,10 @@ packages:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
     engines: {node: '>=10.4.0'}
 
+  polished@4.3.1:
+    resolution: {integrity: sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==}
+    engines: {node: '>=10'}
+
   possible-typed-array-names@1.0.0:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
     engines: {node: '>= 0.4'}
@@ -6670,6 +6683,10 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
 
   v8-to-istanbul@9.1.3:
@@ -9006,6 +9023,15 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.0
 
+  '@storybook/addon-actions@8.3.4(storybook@8.3.4)':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@types/uuid': 9.0.8
+      dequal: 2.0.3
+      polished: 4.3.1
+      storybook: 8.3.4
+      uuid: 9.0.1
+
   '@storybook/addon-controls@8.3.4(storybook@8.3.4)':
     dependencies:
       '@storybook/global': 5.0.0
@@ -9086,10 +9112,6 @@ snapshots:
     dependencies:
       storybook: 8.3.4
 
-  '@storybook/preview-api@8.2.9(storybook@8.3.4)':
-    dependencies:
-      storybook: 8.3.4
-
   '@storybook/preview-api@8.3.4(storybook@8.3.4)':
     dependencies:
       storybook: 8.3.4
@@ -9162,7 +9184,7 @@ snapshots:
       '@storybook/core-common': 8.2.9(storybook@8.3.4)
       '@storybook/csf': 0.1.11
       '@storybook/csf-tools': 8.2.9(storybook@8.3.4)
-      '@storybook/preview-api': 8.2.9(storybook@8.3.4)
+      '@storybook/preview-api': 8.3.4(storybook@8.3.4)
       '@swc/core': 1.7.26
       '@swc/jest': 0.2.36(@swc/core@1.7.26)
       expect-playwright: 0.8.0
@@ -9599,6 +9621,8 @@ snapshots:
   '@types/tough-cookie@4.0.5': {}
 
   '@types/triple-beam@1.3.5': {}
+
+  '@types/uuid@9.0.8': {}
 
   '@types/verror@1.10.5':
     optional: true
@@ -13417,6 +13441,10 @@ snapshots:
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
+  polished@4.3.1:
+    dependencies:
+      '@babel/runtime': 7.25.6
+
   possible-typed-array-names@1.0.0: {}
 
   postcss-value-parser@4.2.0: {}
@@ -14564,6 +14592,8 @@ snapshots:
   utils-merge@1.0.1: {}
 
   uuid@8.3.2: {}
+
+  uuid@9.0.1: {}
 
   v8-to-istanbul@9.1.3:
     dependencies:

--- a/web/.storybook/main.ts
+++ b/web/.storybook/main.ts
@@ -43,7 +43,11 @@ const config: StorybookConfig = {
     options: { builder: { viteConfigPath: 'web/.storybook/vite.config.mts' } },
   },
   staticDirs: ['public'],
-  addons: ['@storybook/addon-toolbars', '@storybook/addon-controls'],
+  addons: [
+    '@storybook/addon-toolbars',
+    '@storybook/addon-controls',
+    '@storybook/addon-actions',
+  ],
 };
 
 export default config;

--- a/web/.storybook/preview.tsx
+++ b/web/.storybook/preview.tsx
@@ -93,7 +93,9 @@ const preview: Preview = {
         order: ['Teleport', 'TeleportE', 'Teleterm', 'Design', 'Shared'],
       },
     },
+    controls: { expanded: true, disableSaveFromUI: true },
   },
+  argTypes: { userContext: { table: { disable: true } } },
   loaders: [mswLoader],
   decorators: [
     (Story, meta) => (

--- a/web/packages/design/src/Alert/Alert.story.tsx
+++ b/web/packages/design/src/Alert/Alert.story.tsx
@@ -17,6 +17,7 @@
  */
 
 import React from 'react';
+import { action } from '@storybook/addon-actions';
 
 import { Restore } from 'design/Icon';
 
@@ -119,14 +120,10 @@ const commonProps: AlertProps = {
   dismissible: true,
   primaryAction: {
     content: 'Primary Action',
-    onClick: () => {
-      alert('Primary button clicked');
-    },
+    onClick: action('primaryAction.onClick'),
   },
   secondaryAction: {
     content: 'Secondary Action',
-    onClick: () => {
-      alert('Secondary button clicked');
-    },
+    onClick: action('secondaryAction.onClick'),
   },
 };

--- a/web/packages/shared/components/Controls/MultiselectMenu.story.tsx
+++ b/web/packages/shared/components/Controls/MultiselectMenu.story.tsx
@@ -16,18 +16,20 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { action } from '@storybook/addon-actions';
+import { useArgs } from '@storybook/preview-api';
 import { Flex } from 'design';
 
 import { MultiselectMenu } from './MultiselectMenu';
 
+import type { ReactNode } from 'react';
 import type { Meta, StoryFn, StoryObj } from '@storybook/react';
 
 type OptionValue = `option-${number}`;
 
 const options: {
   value: OptionValue;
-  label: string | React.ReactNode;
+  label: string | ReactNode;
   disabled?: boolean;
   disabledTooltip?: string;
 }[] = [
@@ -99,16 +101,22 @@ export default {
   args: {
     label: 'Select Options',
     tooltip: 'Choose multiple options',
+    selected: [],
     buffered: false,
     showIndicator: true,
     showSelectControls: true,
+    onChange: action('onChange'),
   },
-  parameters: { controls: { expanded: true, exclude: ['userContext'] } },
   render: (args => {
-    const [selected, setSelected] = useState<string[]>([]);
+    const [{ selected }, updateArgs] =
+      useArgs<Meta<typeof MultiselectMenu<OptionValue>>['args']>();
+    const onChange = (value: OptionValue[]) => {
+      updateArgs({ selected: value });
+      args.onChange?.(value);
+    };
     return (
       <Flex alignItems="center" minHeight="100px">
-        <MultiselectMenu {...args} selected={selected} onChange={setSelected} />
+        <MultiselectMenu {...args} selected={selected} onChange={onChange} />
       </Flex>
     );
   }) satisfies StoryFn<typeof MultiselectMenu<OptionValue>>,

--- a/web/packages/shared/components/Controls/ViewModeSwitch.story.tsx
+++ b/web/packages/shared/components/Controls/ViewModeSwitch.story.tsx
@@ -16,10 +16,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { action } from '@storybook/addon-actions';
 import { Flex } from 'design';
 
 import { ViewMode } from 'gen-proto-ts/teleport/userpreferences/v1/unified_resource_preferences_pb';
+
+import { useArgs } from '@storybook/preview-api';
 
 import { ViewModeSwitch } from './ViewModeSwitch';
 
@@ -30,9 +32,16 @@ export default {
   component: ViewModeSwitch,
   argTypes: {
     currentViewMode: {
-      control: { type: 'radio', options: [ViewMode.CARD, ViewMode.LIST] },
+      control: {
+        type: 'radio',
+        labels: { [ViewMode.CARD]: 'Card View', [ViewMode.LIST]: 'List View' },
+      },
+      options: [ViewMode.CARD, ViewMode.LIST],
       description: 'Current view mode',
-      table: { defaultValue: { summary: ViewMode.CARD.toString() } },
+      table: {
+        defaultValue: { summary: ViewMode.CARD.toString() },
+        type: { summary: 'ViewMode' },
+      },
     },
     setCurrentViewMode: {
       control: false,
@@ -40,22 +49,28 @@ export default {
       table: { type: { summary: '(newViewMode: ViewMode) => void' } },
     },
   },
-  args: { currentViewMode: ViewMode.CARD },
-  parameters: { controls: { expanded: true, exclude: ['userContext'] } },
-} satisfies Meta<typeof ViewModeSwitch>;
-
-const Default: StoryObj<typeof ViewModeSwitch> = {
-  render: (({ currentViewMode }) => {
-    const [viewMode, setViewMode] = useState(currentViewMode);
+  args: {
+    currentViewMode: ViewMode.CARD,
+    setCurrentViewMode: action('setCurrentViewMode'),
+  },
+  render: (args => {
+    const [{ currentViewMode }, updateArgs] =
+      useArgs<Meta<typeof ViewModeSwitch>['args']>();
+    const setCurrentViewMode = (value: ViewMode) => {
+      updateArgs({ currentViewMode: value });
+      args?.setCurrentViewMode(value);
+    };
     return (
       <Flex alignItems="center" minHeight="100px">
         <ViewModeSwitch
-          currentViewMode={viewMode}
-          setCurrentViewMode={setViewMode}
+          currentViewMode={currentViewMode}
+          setCurrentViewMode={setCurrentViewMode}
         />
       </Flex>
     );
   }) satisfies StoryFn<typeof ViewModeSwitch>,
-};
+} satisfies Meta<typeof ViewModeSwitch>;
+
+const Default: StoryObj<typeof ViewModeSwitch> = { args: {} };
 
 export { Default as ViewModeSwitch };


### PR DESCRIPTION
Follow-up to #49098.

* Set default config for `storybook-controls` add-on to prevent `userContext` Decorator showing as a Control for all Stories.
* Tidy some incorrect types/controls for previously-added `shared/controls/*` stories.
* Add `@storybook/addon-actions` & use in `shared/controls/*` stories to start. Add `@storybook/preview-api`'s `useArgs` helper for syncing story args between components and the Controls UI.
![withActionsAddon](https://github.com/user-attachments/assets/94481664-fd37-4d1f-985b-6d7f11e2f7a2)
