### PR TITLE
[v17] Logs: Forward the error from the failing case to emitUsageEvent

### DIFF
--- a/lib/auth/userloginstate/generator.go
+++ b/lib/auth/userloginstate/generator.go
@@ -162,7 +162,7 @@ func (g *Generator) Generate(ctx context.Context, user types.User) (*userloginst
 	if g.usageEvents != nil {
 		// Emit the usage event metadata.
 		if err := g.emitUsageEvent(ctx, user, uls, inheritedRoles, inheritedTraits); err != nil {
-			g.log.Debug("Error emitting usage event during user login state generation, skipping")
+			g.log.WithError(err).Debug("Error emitting usage event during user login state generation, skipping")
 		}
 	}
 


### PR DESCRIPTION
Backport #49237 to branch/v17