### PR TITLE
[v16] Logs: Forward the error from the failing case to emitUsageEvent

### DIFF
--- a/lib/auth/userloginstate/generator.go
+++ b/lib/auth/userloginstate/generator.go
@@ -169,7 +169,7 @@ func (g *Generator) Generate(ctx context.Context, user types.User) (*userloginst
 	if g.usageEvents != nil {
 		// Emit the usage event metadata.
 		if err := g.emitUsageEvent(ctx, user, uls); err != nil {
-			g.log.Debug("Error emitting usage event during user login state generation, skipping")
+			g.log.WithError(err).Debug("Error emitting usage event during user login state generation, skipping")
 		}
 	}
 


### PR DESCRIPTION
backport https://github.com/gravitational/teleport/pull/49237 to v16