### PR TITLE
Link to the status page for cloud

### DIFF
--- a/docs/pages/upcoming-releases.mdx
+++ b/docs/pages/upcoming-releases.mdx
@@ -113,6 +113,10 @@ The key deliverables for Teleport Cloud in the next quarter:
 | June 5th, 2023   | Teleport 13.1 begins to roll out for Cloud customers |
 | June 5th, 2023   | Advanced Audit Log rollout begins                    |
 
+Subscribe to status updates at
+[status.teleport.sh](https://status.teleport.sh/) for regular Cloud upgrade
+notifications.
+
 ## Production readiness
 
 Teleport follows [semantic versioning](https://semver.org) for pre-releases and


### PR DESCRIPTION
For someone unfamiliar with the status page as being the source of truth for scheduled upgrades, the "Teleport Cloud" section on the "Upcoming Releases" document can give a false impression that the next update will be further in the future than it really is.

Adding a link to the status page will help discoverability of the next upcoming change to Cloud, even if it isn't a "key deliverable" for that quarter.