### PR TITLE
[teleport-update] Add unlink-package command

### DIFF
--- a/lib/autoupdate/agent/installer.go
+++ b/lib/autoupdate/agent/installer.go
@@ -443,6 +443,46 @@ func (li *LocalInstaller) LinkSystem(ctx context.Context) (revert func(context.C
 	return revert, trace.Wrap(err)
 }
 
+// TryLink links the specified version, but only in the case that
+// no installation of Teleport is already linked or partially linked.
+// See Installer interface for additional specs.
+func (li *LocalInstaller) TryLink(ctx context.Context, version string) error {
+	versionDir, err := li.versionDir(version)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(li.tryLinks(ctx,
+		filepath.Join(versionDir, "bin"),
+		filepath.Join(versionDir, serviceDir),
+	))
+}
+
+// TryLinkSystem links the system installation, but only in the case that
+// no installation of Teleport is already linked or partially linked.
+// See Installer interface for additional specs.
+func (li *LocalInstaller) TryLinkSystem(ctx context.Context) error {
+	return trace.Wrap(li.tryLinks(ctx, li.SystemBinDir, li.SystemServiceDir))
+}
+
+// Unlink unlinks a version from LinkBinDir and LinkServiceDir.
+// See Installer interface for additional specs.
+func (li *LocalInstaller) Unlink(ctx context.Context, version string) error {
+	versionDir, err := li.versionDir(version)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(li.removeLinks(ctx,
+		filepath.Join(versionDir, "bin"),
+		filepath.Join(versionDir, serviceDir),
+	))
+}
+
+// UnlinkSystem unlinks the system (package) version from LinkBinDir and LinkServiceDir.
+// See Installer interface for additional specs.
+func (li *LocalInstaller) UnlinkSystem(ctx context.Context) error {
+	return trace.Wrap(li.removeLinks(ctx, li.SystemBinDir, li.SystemServiceDir))
+}
+
 // symlink from oldname to newname
 type symlink struct {
 	oldname, newname string
@@ -640,25 +680,66 @@ func readFileN(name string, n int64) ([]byte, error) {
 	return data, trace.Wrap(err)
 }
 
-// TryLink links the specified version, but only in the case that
-// no installation of Teleport is already linked or partially linked.
-// See Installer interface for additional specs.
-func (li *LocalInstaller) TryLink(ctx context.Context, version string) error {
-	versionDir, err := li.versionDir(version)
+func (li *LocalInstaller) removeLinks(ctx context.Context, binDir, svcDir string) error {
+	removeService := false
+	entries, err := os.ReadDir(binDir)
+	if err != nil {
+		return trace.Errorf("failed to find Teleport binary directory: %w", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		oldname := filepath.Join(binDir, entry.Name())
+		newname := filepath.Join(li.LinkBinDir, entry.Name())
+		v, err := os.Readlink(newname)
+		if errors.Is(err, os.ErrNotExist) ||
+			errors.Is(err, os.ErrInvalid) ||
+			errors.Is(err, syscall.EINVAL) {
+			li.Log.DebugContext(ctx, "Link not present.", "oldname", oldname, "newname", newname)
+			continue
+		}
+		if err != nil {
+			return trace.Errorf("error reading link for %s: %w", filepath.Base(newname), err)
+		}
+		if v != oldname {
+			li.Log.DebugContext(ctx, "Skipping link to different binary.", "oldname", oldname, "newname", newname)
+			continue
+		}
+		if err := os.Remove(newname); err != nil {
+			return trace.Errorf("error removing link for %s: %w", filepath.Base(newname), err)
+		}
+		if filepath.Dir(newname) == "teleport" {
+			removeService = true
+		}
+	}
+	// only remove service if teleport was removed
+	if !removeService {
+		li.Log.DebugContext(ctx, "Teleport binary not unlinked. Skipping removal of teleport.service.")
+		return nil
+	}
+	src := filepath.Join(svcDir, serviceName)
+	srcBytes, err := readFileN(src, maxServiceFileSize)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return trace.Wrap(li.tryLinks(ctx,
-		filepath.Join(versionDir, "bin"),
-		filepath.Join(versionDir, serviceDir),
-	))
-}
-
-// TryLinkSystem links the system installation, but only in the case that
-// no installation of Teleport is already linked or partially linked.
-// See Installer interface for additional specs.
-func (li *LocalInstaller) TryLinkSystem(ctx context.Context) error {
-	return trace.Wrap(li.tryLinks(ctx, li.SystemBinDir, li.SystemServiceDir))
+	dst := filepath.Join(li.LinkServiceDir, serviceName)
+	dstBytes, err := readFileN(dst, maxServiceFileSize)
+	if errors.Is(err, os.ErrNotExist) {
+		li.Log.DebugContext(ctx, "Service not present.", "path", dst)
+		return nil
+	}
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if !bytes.Equal(srcBytes, dstBytes) {
+		li.Log.WarnContext(ctx, "Removed teleport binary link, but skipping removal of custom teleport.service.")
+		return nil
+	}
+	if err := os.Remove(dst); err != nil {
+		return trace.Errorf("error removing copy of %s: %w", filepath.Base(dst), err)
+	}
+	return nil
 }
 
 // tryLinks create binary and service links for files in binDir and svcDir if links are not already present.

--- a/lib/autoupdate/agent/installer.go
+++ b/lib/autoupdate/agent/installer.go
@@ -707,9 +707,10 @@ func (li *LocalInstaller) removeLinks(ctx context.Context, binDir, svcDir string
 			continue
 		}
 		if err := os.Remove(newname); err != nil {
-			return trace.Errorf("error removing link for %s: %w", filepath.Base(newname), err)
+			li.Log.ErrorContext(ctx, "Unable to remove link.", "oldname", oldname, "newname", newname, errorKey, err)
+			continue
 		}
-		if filepath.Dir(newname) == "teleport" {
+		if filepath.Base(newname) == "teleport" {
 			removeService = true
 		}
 	}

--- a/lib/autoupdate/agent/installer.go
+++ b/lib/autoupdate/agent/installer.go
@@ -39,6 +39,7 @@ import (
 	"github.com/google/renameio/v2"
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -710,7 +711,7 @@ func (li *LocalInstaller) removeLinks(ctx context.Context, binDir, svcDir string
 			li.Log.ErrorContext(ctx, "Unable to remove link.", "oldname", oldname, "newname", newname, errorKey, err)
 			continue
 		}
-		if filepath.Base(newname) == "teleport" {
+		if filepath.Base(newname) == teleport.ComponentTeleport {
 			removeService = true
 		}
 	}

--- a/lib/autoupdate/agent/installer.go
+++ b/lib/autoupdate/agent/installer.go
@@ -735,7 +735,7 @@ func (li *LocalInstaller) removeLinks(ctx context.Context, binDir, svcDir string
 		return trace.Wrap(err)
 	}
 	if !bytes.Equal(srcBytes, dstBytes) {
-		li.Log.WarnContext(ctx, "Removed teleport binary link, but skipping removal of custom teleport.service.")
+		li.Log.WarnContext(ctx, "Removed teleport binary link, but skipping removal of custom teleport.service: the service file does not match the reference file for this version. The file might have been manually edited.")
 		return nil
 	}
 	if err := os.Remove(dst); err != nil {

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -255,10 +255,13 @@ type Installer interface {
 	// Unlike Link, TryLink will fail if existing links to other locations are present.
 	// TryLink must be idempotent.
 	TryLink(ctx context.Context, version string) error
-	// TryLinkSystem links the system installation of Teleport into the linking locations.
+	// TryLinkSystem links the system (package) installation of Teleport into the linking locations.
 	// Unlike LinkSystem, TryLinkSystem will fail if existing links to other locations are present.
 	// TryLinkSystem must be idempotent.
 	TryLinkSystem(ctx context.Context) error
+	// UnlinkSystem unlinks the system (package) installation of Teleport from the linking locations.
+	// TryLinkSystem must be idempotent.
+	UnlinkSystem(ctx context.Context) error
 	// List the installed versions of Teleport.
 	List(ctx context.Context) (versions []string, err error)
 	// Remove the Teleport agent at version.
@@ -709,6 +712,20 @@ func (u *Updater) LinkPackage(ctx context.Context) error {
 		return nil
 	} else if err != nil {
 		return trace.Errorf("failed to link system package installation: %w", err)
+	}
+	// TODO(sclevine): only if systemd files change
+	if err := u.Process.Sync(ctx); err != nil {
+		return trace.Errorf("failed to validate configuration for packaged installation of Teleport: %w", err)
+	}
+	u.Log.InfoContext(ctx, "Successfully linked system package installation.")
+	return nil
+}
+
+// UnlinkPackage removes links from the system (package) installation of Teleport, if they are present.
+// This function is idempotent.
+func (u *Updater) UnlinkPackage(ctx context.Context) error {
+	if err := u.Installer.UnlinkSystem(ctx); err != nil {
+		return trace.Errorf("failed to unlink system package installation: %w", err)
 	}
 	// TODO(sclevine): only if systemd files change
 	if err := u.Process.Sync(ctx); err != nil {

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -713,9 +713,8 @@ func (u *Updater) LinkPackage(ctx context.Context) error {
 	} else if err != nil {
 		return trace.Errorf("failed to link system package installation: %w", err)
 	}
-	// TODO(sclevine): only if systemd files change
 	if err := u.Process.Sync(ctx); err != nil {
-		return trace.Errorf("failed to validate configuration for packaged installation of Teleport: %w", err)
+		return trace.Errorf("failed to sync systemd configuration: %w", err)
 	}
 	u.Log.InfoContext(ctx, "Successfully linked system package installation.")
 	return nil
@@ -727,10 +726,9 @@ func (u *Updater) UnlinkPackage(ctx context.Context) error {
 	if err := u.Installer.UnlinkSystem(ctx); err != nil {
 		return trace.Errorf("failed to unlink system package installation: %w", err)
 	}
-	// TODO(sclevine): only if systemd files change
 	if err := u.Process.Sync(ctx); err != nil {
-		return trace.Errorf("failed to validate configuration for packaged installation of Teleport: %w", err)
+		return trace.Errorf("failed to sync systemd configuration: %w", err)
 	}
-	u.Log.InfoContext(ctx, "Successfully linked system package installation.")
+	u.Log.InfoContext(ctx, "Successfully unlinked system package installation.")
 	return nil
 }

--- a/lib/autoupdate/agent/updater_test.go
+++ b/lib/autoupdate/agent/updater_test.go
@@ -996,6 +996,7 @@ type testInstaller struct {
 	FuncLinkSystem    func(ctx context.Context) (revert func(context.Context) bool, err error)
 	FuncTryLink       func(ctx context.Context, version string) error
 	FuncTryLinkSystem func(ctx context.Context) error
+	FuncUnlinkSystem  func(ctx context.Context) error
 	FuncList          func(ctx context.Context) (versions []string, err error)
 }
 
@@ -1021,6 +1022,10 @@ func (ti *testInstaller) TryLink(ctx context.Context, version string) error {
 
 func (ti *testInstaller) TryLinkSystem(ctx context.Context) error {
 	return ti.FuncTryLinkSystem(ctx)
+}
+
+func (ti *testInstaller) UnlinkSystem(ctx context.Context) error {
+	return ti.FuncUnlinkSystem(ctx)
 }
 
 func (ti *testInstaller) List(ctx context.Context) (versions []string, err error) {

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -126,6 +126,7 @@ func Run(args []string) error {
 		Short('s').Hidden().BoolVar(&ccfg.SelfSetup)
 
 	linkCmd := app.Command("link-package", "Link the system installation of Teleport from the Teleport package, if auto-updates is disabled.")
+	unlinkCmd := app.Command("unlink-package", "Unlink the system installation of Teleport from the Teleport package.")
 
 	setupCmd := app.Command("setup", "Write configuration files that run the update subcommand on a timer.").
 		Hidden()
@@ -151,6 +152,8 @@ func Run(args []string) error {
 		err = cmdUpdate(ctx, &ccfg)
 	case linkCmd.FullCommand():
 		err = cmdLink(ctx, &ccfg)
+	case unlinkCmd.FullCommand():
+		err = cmdUnlink(ctx, &ccfg)
 	case setupCmd.FullCommand():
 		err = cmdSetup(ctx, &ccfg)
 	case versionCmd.FullCommand():
@@ -294,6 +297,39 @@ func cmdLink(ctx context.Context, ccfg *cliConfig) error {
 	}()
 
 	if err := updater.LinkPackage(ctx); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// cmdUnlink remove system package links.
+func cmdUnlink(ctx context.Context, ccfg *cliConfig) error {
+	updater, err := autoupdate.NewLocalUpdater(autoupdate.LocalUpdaterConfig{
+		DataDir:   ccfg.DataDir,
+		LinkDir:   ccfg.LinkDir,
+		SystemDir: autoupdate.DefaultSystemDir,
+		SelfSetup: ccfg.SelfSetup,
+		Log:       plog,
+	})
+	if err != nil {
+		return trace.Errorf("failed to setup updater: %w", err)
+	}
+
+	// Error if the updater is running. We could remove its links by accident.
+	unlock, err := libutils.FSTryReadLock(filepath.Join(ccfg.DataDir, lockFileName))
+	if errors.Is(err, libutils.ErrUnsuccessfulLockTry) {
+		return trace.Errorf("updater is currently running")
+	}
+	if err != nil {
+		return trace.Errorf("failed to grab concurrent execution lock: %w", err)
+	}
+	defer func() {
+		if err := unlock(); err != nil {
+			plog.DebugContext(ctx, "Failed to close lock file", "error", err)
+		}
+	}()
+
+	if err := updater.UnlinkPackage(ctx); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -316,7 +316,7 @@ func cmdUnlink(ctx context.Context, ccfg *cliConfig) error {
 	}
 
 	// Error if the updater is running. We could remove its links by accident.
-	unlock, err := libutils.FSTryReadLock(filepath.Join(ccfg.DataDir, lockFileName))
+	unlock, err := libutils.FSTryWriteLock(filepath.Join(ccfg.DataDir, lockFileName))
 	if errors.Is(err, libutils.ErrUnsuccessfulLockTry) {
 		return trace.Errorf("updater is currently running")
 	}


### PR DESCRIPTION
This PR adds the `unlink-package` subcommand to the `teleport-update` command.

This subcommand reverses the linking created in https://github.com/gravitational/teleport/pull/48712, to support removal of deb/rpm packages.

The `link-package` subcommand will allow the `teleport` RPM and DEB packages to co-exist with versions of Teleport that are installed by the `teleport-update` binary, by ensuring that Teleport binaries installed by the package into `/usr/local/teleport-system` are always linked to `/usr/local` when no `teleport-update`-managed installation is present.

**Note that the Teleport package will have its files moved into `/usr/local/teleport-system` in a future PR. This command is not useful until this packaging change is complete.**

The `teleport-update` binary will be used to enable, disable, and trigger automatic Teleport agent updates. The new auto-updates system manages a local installation of the cluster-specified version of Teleport stored in `/var/lib/teleport/versions`.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/10289

Examples:

```shell
ubuntu@legendary-mite:~$ sudo ./teleport-update link-package
2024-11-20T06:40:30Z INFO [UPDATER]   Systemd configuration synced. unit:teleport.service agent/process.go:255
2024-11-20T06:40:30Z INFO [UPDATER]   Successfully linked system package installation. agent/updater.go:718
ubuntu@legendary-mite:~$ ls -la /usr/local/bin/
total 8
drwxr-xr-x  2 root root 4096 Nov 20 06:39 .
drwxr-xr-x 11 root root 4096 Nov 13 01:41 ..
lrwxrwxrwx  1 root root   46 Nov 20 06:39 fdpass-teleport -> /usr/local/teleport-system/bin/fdpass-teleport
lrwxrwxrwx  1 root root   35 Nov 20 06:39 tbot -> /usr/local/teleport-system/bin/tbot
lrwxrwxrwx  1 root root   35 Nov 20 06:39 tctl -> /usr/local/teleport-system/bin/tctl
lrwxrwxrwx  1 root root   39 Nov 20 06:39 teleport -> /usr/local/teleport-system/bin/teleport
lrwxrwxrwx  1 root root   34 Nov 20 06:39 tsh -> /usr/local/teleport-system/bin/tsh
ubuntu@legendary-mite:~$ sudo ./teleport-update unlink-package
2024-11-20T06:41:28Z INFO [UPDATER]   Systemd configuration synced. unit:teleport.service agent/process.go:255
2024-11-20T06:41:28Z INFO [UPDATER]   Successfully unlinked system package installation. agent/updater.go:732
ubuntu@legendary-mite:~$ cat /lib/systemd/system/teleport.service 
cat: /lib/systemd/system/teleport.service: No such file or directory
ubuntu@legendary-mite:~$ ls -la /usr/local/bin/
total 8
drwxr-xr-x  2 root root 4096 Nov 20 06:41 .
drwxr-xr-x 11 root root 4096 Nov 13 01:41 ..
```
