### PR TITLE
[v15] Update Electron to 33.1.0 and Node.js to 20.18.0

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -6,7 +6,7 @@
 GOLANG_VERSION ?= go1.22.9
 GOLANGCI_LINT_VERSION ?= v1.61.0
 
-NODE_VERSION ?= 20.17.0
+NODE_VERSION ?= 20.18.0
 
 # Run lint-rust check locally before merging code after you bump this.
 RUST_VERSION ?= 1.77.0

--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -45,7 +45,7 @@
     "@types/node-forge": "^1.0.4",
     "@types/tar-fs": "^2.0.1",
     "@types/whatwg-url": "^11.0.1",
-    "electron": "32.1.2",
+    "electron": "33.0.2",
     "electron-vite": "^2.0.0",
     "google-protobuf": "^3.21.2",
     "immer": "^10.1.1",

--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -45,7 +45,7 @@
     "@types/node-forge": "^1.0.4",
     "@types/tar-fs": "^2.0.1",
     "@types/whatwg-url": "^11.0.1",
-    "electron": "33.0.2",
+    "electron": "33.1.0",
     "electron-vite": "^2.0.0",
     "google-protobuf": "^3.21.2",
     "immer": "^10.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12035,9 +12035,9 @@ no-case@^3.0.4:
     tslib "^2.0.3"
 
 node-abi@^3.45.0:
-  version "3.65.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.65.0.tgz#ca92d559388e1e9cab1680a18c1a18757cdac9d3"
-  integrity sha512-ThjYBfoDNr08AWx6hGaRbfPwxKV9kVzAzOzlLKbk2CuqXE2xnCh+cbAGnwM3t8Lq4v9rUB7VfondlkBckcJrVA==
+  version "3.71.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.71.0.tgz#52d84bbcd8575efb71468fbaa1f9a49b2c242038"
+  integrity sha512-SZ40vRiy/+wRTf21hxkkEjPJZpARzUMVcJoQse2EF8qkUWbbO2z7vd5oA/H6bVH6SZQ5STGcu0KRDS7biNRfxw==
   dependencies:
     semver "^7.3.5"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7507,10 +7507,10 @@ electron-vite@^2.0.0:
     magic-string "^0.30.5"
     picocolors "^1.0.0"
 
-electron@32.1.2:
-  version "32.1.2"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-32.1.2.tgz#84d1efd95d41224e58a6a9bbd1db4ba80154fc02"
-  integrity sha512-CXe6doFzhmh1U7daOvUzmF6Cj8hssdYWMeEPRnRO6rB9/bbwMlWctcQ7P8NJXhLQ88/vYUJQrJvlJPh8qM0BRQ==
+electron@33.1.0:
+  version "33.1.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-33.1.0.tgz#c86042e71fa964a054b3306810a3c451aada98f7"
+  integrity sha512-7KiY6MtRo1fVFLPGyHS7Inh8yZfrbUTy43nNwUgMD2CBk729BgSwOC2WhmcptNJVlzHJpVxSWkiVi2hp9mH/bw==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^20.9.0"


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/47891 and https://github.com/gravitational/teleport/pull/48503 to branch/v15