### PR TITLE
Unify styling of filter dropdowns in unified resources

### DIFF
--- a/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
+++ b/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
@@ -263,9 +263,6 @@ const IncludedResourcesSelector = ({
       <HoverTooltip tipContent={'Filter by resource availability'}>
         <ButtonSecondary
           px={2}
-          css={`
-            border-color: ${props => props.theme.colors.spotBackground[0]};
-          `}
           textTransform="none"
           size="small"
           onClick={handleOpen}


### PR DESCRIPTION
Small UI improvement. The issue doesn't happen on v16.

Before:
<img width="805" alt="image" src="https://github.com/user-attachments/assets/5f9217a7-c2c3-4828-9407-b4f7f39ab738">

 
After:
<img width="805" alt="image" src="https://github.com/user-attachments/assets/7b3859a8-5a68-4ab6-958b-2ae3f629dfdd">
