### PR TITLE
Add test that executes tsh with no env vars

### DIFF
--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -417,6 +417,7 @@ func TestAlias(t *testing.T) {
 //
 // …plus whatever is set in the launch daemon plist under the EnvironmentVariables key.
 func TestNoEnvVars(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancel)
 

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -407,6 +407,29 @@ func TestAlias(t *testing.T) {
 	}
 }
 
+// TestNoEnvVars checks if tsh is able to work without any env vars provided.
+// This is important for VNet on macOS. When launchd starts VNet's launch daemon, it executes "tsh
+// vnet-daemon" with only the following env vars available:
+//
+// XPC_SERVICE_NAME=com.goteleport.tshdev.vnetd
+// PATH=/usr/bin:/bin:/usr/sbin:/sbin
+// XPC_FLAGS=1
+//
+// …plus whatever is set in the launch daemon plist under the EnvironmentVariables key.
+func TestNoEnvVars(t *testing.T) {
+	testExecutable, err := os.Executable()
+	require.NoError(t, err)
+	// Execute an actual command and not jut `tsh help` which goes through a different code path.
+	cmd := exec.Command(testExecutable, "version", "--client")
+	// Run the command with no env vars except tshBinMainTestEnv, otherwise the test would hang.
+	cmd.Env = []string{fmt.Sprintf("%s=1", tshBinMainTestEnv)}
+
+	t.Logf("running command %v", cmd)
+	output, err := cmd.CombinedOutput()
+	t.Logf("executable output: %v", string(output))
+	require.NoError(t, err)
+}
+
 func TestFailedLogin(t *testing.T) {
 	t.Parallel()
 	tmpHomePath := t.TempDir()

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -423,7 +423,7 @@ func TestNoEnvVars(t *testing.T) {
 
 	testExecutable, err := os.Executable()
 	require.NoError(t, err)
-	// Execute an actual command and not jut `tsh help` which goes through a different code path.
+	// Execute an actual command and not just `tsh help` which goes through a different code path.
 	cmd := exec.CommandContext(ctx, testExecutable, "version", "--client")
 	// Run the command with no env vars except tshBinMainTestEnv, otherwise the test would hang.
 	cmd.Env = []string{fmt.Sprintf("%s=1", tshBinMainTestEnv)}


### PR DESCRIPTION
Recently we introduced a regression in VNet where the tsh auto-updater would assume that `$HOME` is present when running tsh (https://github.com/gravitational/teleport/pull/47815#discussion_r1846868965). It turns out that when launchd starts [VNet's launch daemon](https://goteleport.com/docs/connect-your-client/vnet/#step-23-start-vnet) and executes `tsh vnet-daemon`, it does so without providing any of the "regular" env variables.

This has been fixed in #49159. This PR adds a test which hopefully catches similar regressions in the future.

This test fails on the parent commit of #49159 with:

```
=== RUN   TestNoEnvVars
    tsh_test.go:426: running command /var/folders/kz/2d_vhlks21l3g0s4g5yytlwr0000gn/T/go-build927609993/b001/common.test version --client
    tsh_test.go:428: executable output: ERROR: $HOME is not defined

    tsh_test.go:429:
        	Error Trace:	/Users/rav/src/teleport/tool/tsh/common/tsh_test.go:429
        	Error:      	Received unexpected error:
        	            	exit status 1
        	Test:       	TestNoEnvVars
--- FAIL: TestNoEnvVars (2.54s)
FAIL
FAIL	github.com/gravitational/teleport/tool/tsh/common	8.264s
FAIL
```