### PR TITLE
[v15] Changing parker PDEATHSIG to SIGKILL

### DIFF
--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -1282,7 +1282,7 @@ func (o *osWrapper) newParker(ctx context.Context, credential syscall.Credential
 	}
 
 	// Perform OS-specific tweaks to the command.
-	reexecCommandOSTweaks(cmd)
+	parkerCommandOSTweaks(cmd)
 
 	if err := cmd.Start(); err != nil {
 		return trace.Wrap(err)

--- a/lib/srv/reexec_linux.go
+++ b/lib/srv/reexec_linux.go
@@ -82,6 +82,17 @@ func reexecCommandOSTweaks(cmd *exec.Cmd) {
 	}
 }
 
+// if we ever need to run parkers on macOS or other platforms with no PDEATHSIG
+// we should rework the parker to block on a pipe so it can exit when its parent
+// is terminated
+func parkerCommandOSTweaks(cmd *exec.Cmd) {
+	reexecCommandOSTweaks(cmd)
+
+	// parker processes can leak if their PDEATHSIG is SIGQUIT, otherwise we
+	// could just use reexecCommandOSTweaks
+	cmd.SysProcAttr.Pdeathsig = syscall.SIGKILL
+}
+
 func userCommandOSTweaks(cmd *exec.Cmd) {
 	if cmd.SysProcAttr == nil {
 		cmd.SysProcAttr = new(syscall.SysProcAttr)

--- a/lib/srv/reexec_other.go
+++ b/lib/srv/reexec_other.go
@@ -27,6 +27,8 @@ import (
 
 func reexecCommandOSTweaks(cmd *exec.Cmd) {}
 
+func parkerCommandOSTweaks(cmd *exec.Cmd) {}
+
 func userCommandOSTweaks(cmd *exec.Cmd) {}
 
 func setNeutralOOMScore() error { return nil }


### PR DESCRIPTION
Backport #49207 to branch/v15

changelog: Fixed an issue where `teleport park` processes could be leaked causing runaway resource usage.
