### PR TITLE
[v17] Refresh resources after dropping an access request 

### DIFF
--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/useAssumedRolesBar.test.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/useAssumedRolesBar.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useEffect } from 'react';
+import { renderHook, act } from '@testing-library/react';
+
+import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
+import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
+import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
+import {
+  ResourcesContextProvider,
+  useResourcesContext,
+} from 'teleterm/ui/DocumentCluster/resourcesContext';
+import { RootClusterUri } from 'teleterm/ui/uri';
+
+import { useAssumedRolesBar } from './useAssumedRolesBar';
+
+test('dropping a request refreshes resources', async () => {
+  const appContext = new MockAppContext();
+  const cluster = makeRootCluster();
+  appContext.workspacesService.setState(draftState => {
+    draftState.rootClusterUri = cluster.uri;
+    draftState.workspaces[cluster.uri] = {
+      localClusterUri: cluster.uri,
+      documents: [],
+      location: undefined,
+      accessRequests: undefined,
+    };
+  });
+  jest.spyOn(appContext.clustersService, 'dropRoles');
+  const refreshListener = jest.fn();
+
+  const wrapper = ({ children }) => (
+    <MockAppContextProvider appContext={appContext}>
+      <ResourcesContextProvider>
+        <RequestRefreshSubscriber onResourcesRefreshRequest={refreshListener} />
+        {children}
+      </ResourcesContextProvider>
+    </MockAppContextProvider>
+  );
+
+  const { result } = renderHook(
+    () =>
+      useAssumedRolesBar({
+        roles: [],
+        id: 'mocked-request-id',
+        expires: new Date(),
+      }),
+    { wrapper }
+  );
+
+  await act(() => result.current.dropRequest());
+  expect(appContext.clustersService.dropRoles).toHaveBeenCalledTimes(1);
+  expect(appContext.clustersService.dropRoles).toHaveBeenCalledWith(
+    cluster.uri,
+    ['mocked-request-id']
+  );
+  expect(refreshListener).toHaveBeenCalledTimes(1);
+  expect(refreshListener).toHaveBeenCalledWith(cluster.uri);
+});
+
+function RequestRefreshSubscriber(props: {
+  onResourcesRefreshRequest: (rootClusterUri: RootClusterUri) => void;
+}) {
+  const { onResourcesRefreshRequest } = useResourcesContext();
+  useEffect(() => {
+    onResourcesRefreshRequest(props.onResourcesRefreshRequest);
+  }, [onResourcesRefreshRequest, props.onResourcesRefreshRequest]);
+
+  return null;
+}

--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/useAssumedRolesBar.test.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/useAssumedRolesBar.test.tsx
@@ -48,7 +48,10 @@ test('dropping a request refreshes resources', async () => {
   const wrapper = ({ children }) => (
     <MockAppContextProvider appContext={appContext}>
       <ResourcesContextProvider>
-        <RequestRefreshSubscriber onResourcesRefreshRequest={refreshListener} />
+        <RequestRefreshSubscriber
+          rootClusterUri={cluster.uri}
+          onResourcesRefreshRequest={refreshListener}
+        />
         {children}
       </ResourcesContextProvider>
     </MockAppContextProvider>
@@ -71,13 +74,15 @@ test('dropping a request refreshes resources', async () => {
     ['mocked-request-id']
   );
   expect(refreshListener).toHaveBeenCalledTimes(1);
-  expect(refreshListener).toHaveBeenCalledWith(cluster.uri);
 });
 
 function RequestRefreshSubscriber(props: {
-  onResourcesRefreshRequest: (rootClusterUri: RootClusterUri) => void;
+  rootClusterUri: RootClusterUri;
+  onResourcesRefreshRequest: () => void;
 }) {
-  const { onResourcesRefreshRequest } = useResourcesContext();
+  const { onResourcesRefreshRequest } = useResourcesContext(
+    props.rootClusterUri
+  );
   useEffect(() => {
     onResourcesRefreshRequest(props.onResourcesRefreshRequest);
   }, [onResourcesRefreshRequest, props.onResourcesRefreshRequest]);

--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/useAssumedRolesBar.ts
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/useAssumedRolesBar.ts
@@ -32,10 +32,12 @@ import { useInterval } from 'shared/hooks';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { retryWithRelogin } from 'teleterm/ui/utils';
 import { AssumedRequest } from 'teleterm/services/tshd/types';
+import { useResourcesContext } from 'teleterm/ui/DocumentCluster/resourcesContext';
 
 export function useAssumedRolesBar(assumedRequest: AssumedRequest) {
   const ctx = useAppContext();
   const rootClusterUri = ctx.workspacesService?.getRootClusterUri();
+  const { requestResourcesRefresh } = useResourcesContext();
 
   const [duration, setDuration] = useState<Duration>(() =>
     getDurationFromNow({
@@ -46,21 +48,18 @@ export function useAssumedRolesBar(assumedRequest: AssumedRequest) {
     getRefreshInterval(duration)
   );
 
-  const [dropRequestAttempt, dropRequest] = useAsync(() => {
-    return retryWithRelogin(
-      ctx,
-      rootClusterUri,
-      () => ctx.clustersService.dropRoles(rootClusterUri, [assumedRequest.id])
-      // TODO(gzdunek): We should refresh the resources,
-      // the same as after assuming a role in `useAssumeAccess`.
-      // Unfortunately, we can't do this because we don't have access to `ResourcesContext`.
-      // Consider moving it into `ResourcesService`.
-    ).catch(err => {
+  const [dropRequestAttempt, dropRequest] = useAsync(async () => {
+    try {
+      await retryWithRelogin(ctx, rootClusterUri, () =>
+        ctx.clustersService.dropRoles(rootClusterUri, [assumedRequest.id])
+      );
+      requestResourcesRefresh(rootClusterUri);
+    } catch (err) {
       ctx.notificationsService.notifyError({
         title: 'Could not switch back the role',
         description: err.message,
       });
-    });
+    }
   });
 
   const updateDurationAndInterval = useCallback(() => {

--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/useAssumedRolesBar.ts
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/useAssumedRolesBar.ts
@@ -37,7 +37,7 @@ import { useResourcesContext } from 'teleterm/ui/DocumentCluster/resourcesContex
 export function useAssumedRolesBar(assumedRequest: AssumedRequest) {
   const ctx = useAppContext();
   const rootClusterUri = ctx.workspacesService?.getRootClusterUri();
-  const { requestResourcesRefresh } = useResourcesContext();
+  const { requestResourcesRefresh } = useResourcesContext(rootClusterUri);
 
   const [duration, setDuration] = useState<Duration>(() =>
     getDurationFromNow({
@@ -53,7 +53,7 @@ export function useAssumedRolesBar(assumedRequest: AssumedRequest) {
       await retryWithRelogin(ctx, rootClusterUri, () =>
         ctx.clustersService.dropRoles(rootClusterUri, [assumedRequest.id])
       );
-      requestResourcesRefresh(rootClusterUri);
+      requestResourcesRefresh();
     } catch (err) {
       ctx.notificationsService.notifyError({
         title: 'Could not switch back the role',

--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/useAssumedRolesBar.ts
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/useAssumedRolesBar.ts
@@ -56,7 +56,7 @@ export function useAssumedRolesBar(assumedRequest: AssumedRequest) {
       requestResourcesRefresh();
     } catch (err) {
       ctx.notificationsService.notifyError({
-        title: 'Could not switch back the role',
+        title: 'Could not drop role',
         description: err.message,
       });
     }

--- a/web/packages/teleterm/src/ui/App.tsx
+++ b/web/packages/teleterm/src/ui/App.tsx
@@ -29,6 +29,7 @@ import AppContext from './appContext';
 import { ThemeProvider } from './ThemeProvider';
 import { VnetContextProvider } from './Vnet/vnetContext';
 import { ConnectionsContextProvider } from './TopBar/Connections/connectionsContext';
+import { ResourcesContextProvider } from './DocumentCluster/resourcesContext';
 
 export const App: React.FC<{ ctx: AppContext }> = ({ ctx }) => {
   return (
@@ -36,13 +37,15 @@ export const App: React.FC<{ ctx: AppContext }> = ({ ctx }) => {
       <StyledApp>
         <DndProvider backend={HTML5Backend}>
           <AppContextProvider value={ctx}>
-            <ConnectionsContextProvider>
-              <VnetContextProvider>
-                <ThemeProvider>
-                  <AppInitializer />
-                </ThemeProvider>
-              </VnetContextProvider>
-            </ConnectionsContextProvider>
+            <ResourcesContextProvider>
+              <ConnectionsContextProvider>
+                <VnetContextProvider>
+                  <ThemeProvider>
+                    <AppInitializer />
+                  </ThemeProvider>
+                </VnetContextProvider>
+              </ConnectionsContextProvider>
+            </ResourcesContextProvider>
           </AppContextProvider>
         </DndProvider>
       </StyledApp>

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Setup.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Setup.tsx
@@ -279,10 +279,10 @@ function AgentSetup() {
           throw error;
         }
 
-        // Now that the node has joined the server, let's refresh all open DocumentCluster instances
-        // to show the new node.
-        requestResourcesRefresh();
-      }, [startAgent, requestResourcesRefresh])
+        // Now that the node has joined the server, let's refresh open DocumentCluster
+        // instances in the workspace to show the new node.
+        requestResourcesRefresh(rootClusterUri);
+      }, [startAgent, requestResourcesRefresh, rootClusterUri])
     );
 
   const steps: SetupStep[] = [

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Setup.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Setup.tsx
@@ -210,7 +210,7 @@ function AgentSetup() {
     setDownloadAgentAttempt,
     agentProcessState,
   } = useConnectMyComputerContext();
-  const { requestResourcesRefresh } = useResourcesContext();
+  const { requestResourcesRefresh } = useResourcesContext(rootClusterUri);
   const rootCluster = ctx.clustersService.findCluster(rootClusterUri);
 
   // The verify agent step checks if we can execute the binary. This triggers OS-level checks, such
@@ -281,8 +281,8 @@ function AgentSetup() {
 
         // Now that the node has joined the server, let's refresh open DocumentCluster
         // instances in the workspace to show the new node.
-        requestResourcesRefresh(rootClusterUri);
-      }, [startAgent, requestResourcesRefresh, rootClusterUri])
+        requestResourcesRefresh();
+      }, [startAgent, requestResourcesRefresh])
     );
 
   const steps: SetupStep[] = [

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.tsx
@@ -322,7 +322,7 @@ export const ConnectMyComputerContextProvider: FC<
       }
 
       if (hasNodeRemovalSucceeded) {
-        requestResourcesRefresh();
+        requestResourcesRefresh(rootClusterUri);
       }
 
       ctx.notificationsService.notifyInfo(

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.tsx
@@ -131,7 +131,7 @@ export const ConnectMyComputerContextProvider: FC<
     workspacesService,
     usageService,
   } = ctx;
-  const { requestResourcesRefresh } = useResourcesContext();
+  const { requestResourcesRefresh } = useResourcesContext(rootClusterUri);
   clustersService.useState();
 
   const [
@@ -322,7 +322,7 @@ export const ConnectMyComputerContextProvider: FC<
       }
 
       if (hasNodeRemovalSucceeded) {
-        requestResourcesRefresh(rootClusterUri);
+        requestResourcesRefresh();
       }
 
       ctx.notificationsService.notifyInfo(

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/RequestList/RequestList.tsx
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/RequestList/RequestList.tsx
@@ -167,7 +167,7 @@ const renderActionCell = (
           onClick={() => assumeRole(request)}
           width="108px"
         >
-          {flags.isAssumed ? 'assumed' : 'assume roles'}
+          {flags.isAssumed ? 'Assumed' : 'Assume Roles'}
         </ButtonPrimary>
       );
     } else {

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/useAssumeAccess.ts
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/useAssumeAccess.ts
@@ -30,13 +30,13 @@ export function useAssumeAccess() {
     rootClusterUri,
     documentsService,
   } = useWorkspaceContext();
-  const { requestResourcesRefresh } = useResourcesContext();
+  const { requestResourcesRefresh } = useResourcesContext(rootClusterUri);
 
   const [assumeRoleAttempt, runAssumeRole] = useAsync((requestId: string) =>
     retryWithRelogin(ctx, clusterUri, async () => {
       await ctx.clustersService.assumeRoles(rootClusterUri, [requestId]);
       // Refresh the current resource tabs in the workspace.
-      requestResourcesRefresh(rootClusterUri);
+      requestResourcesRefresh();
     })
   );
 
@@ -59,7 +59,7 @@ export function useAssumeAccess() {
     }
 
     // Refresh the current resource tabs in the workspace.
-    requestResourcesRefresh(rootClusterUri);
+    requestResourcesRefresh();
 
     // open new cluster tab
     const clusterDocument = documentsService.createClusterDocument({

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/useAssumeAccess.ts
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/useAssumeAccess.ts
@@ -35,8 +35,8 @@ export function useAssumeAccess() {
   const [assumeRoleAttempt, runAssumeRole] = useAsync((requestId: string) =>
     retryWithRelogin(ctx, clusterUri, async () => {
       await ctx.clustersService.assumeRoles(rootClusterUri, [requestId]);
-      // refresh the current resource tabs
-      requestResourcesRefresh();
+      // Refresh the current resource tabs in the workspace.
+      requestResourcesRefresh(rootClusterUri);
     })
   );
 
@@ -58,8 +58,8 @@ export function useAssumeAccess() {
       return;
     }
 
-    // refresh the current resource tabs
-    requestResourcesRefresh();
+    // Refresh the current resource tabs in the workspace.
+    requestResourcesRefresh(rootClusterUri);
 
     // open new cluster tab
     const clusterDocument = documentsService.createClusterDocument({

--- a/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
@@ -332,7 +332,7 @@ const Resources = memo(
         void fetch({ clear: true });
       });
       return cleanup;
-    }, [onResourcesRefreshRequest, fetch, props.clusterUri]);
+    }, [onResourcesRefreshRequest, fetch]);
 
     const { getAccessRequestButton } = props;
     // The action callback in the requestAccess action has access to

--- a/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
@@ -74,7 +74,7 @@ import {
   ConnectAppActionButton,
   AccessRequestButton,
 } from './ActionButtons';
-import { useResourcesContext, ResourcesContext } from './resourcesContext';
+import { useResourcesContext } from './resourcesContext';
 import { useUserPreferences } from './useUserPreferences';
 
 export function UnifiedResources(props: {
@@ -102,7 +102,7 @@ export function UnifiedResources(props: {
       [rootClusterUri]
     )
   );
-  const { onResourcesRefreshRequest } = useResourcesContext();
+  const { onResourcesRefreshRequest } = useResourcesContext(rootClusterUri);
   const loggedInUser = useWorkspaceLoggedInUser();
 
   const { unifiedResourcePreferences } = userPreferences;
@@ -263,7 +263,7 @@ const Resources = memo(
     canAddResources: boolean;
     canUseConnectMyComputer: boolean;
     openConnectMyComputerDocument(): void;
-    onResourcesRefreshRequest: ResourcesContext['onResourcesRefreshRequest'];
+    onResourcesRefreshRequest(listener: () => void): { cleanup(): void };
     discoverUrl: string;
     getAccessRequestButton: (resource: UnifiedResourceResponse) => JSX.Element;
     getAddedItemsCount: () => number;
@@ -328,11 +328,7 @@ const Resources = memo(
 
     const { onResourcesRefreshRequest } = props;
     useEffect(() => {
-      const { cleanup } = onResourcesRefreshRequest(rootClusterUri => {
-        // Refresh root and leaf cluster documents.
-        if (!uri.routing.belongsToProfile(rootClusterUri, props.clusterUri)) {
-          return;
-        }
+      const { cleanup } = onResourcesRefreshRequest(() => {
         void fetch({ clear: true });
       });
       return cleanup;

--- a/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
@@ -328,11 +328,15 @@ const Resources = memo(
 
     const { onResourcesRefreshRequest } = props;
     useEffect(() => {
-      const { cleanup } = onResourcesRefreshRequest(() => {
-        fetch({ clear: true });
+      const { cleanup } = onResourcesRefreshRequest(rootClusterUri => {
+        // Refresh root and leaf cluster documents.
+        if (!uri.routing.belongsToProfile(rootClusterUri, props.clusterUri)) {
+          return;
+        }
+        void fetch({ clear: true });
       });
       return cleanup;
-    }, [onResourcesRefreshRequest, fetch]);
+    }, [onResourcesRefreshRequest, fetch, props.clusterUri]);
 
     const { getAccessRequestButton } = props;
     // The action callback in the requestAccess action has access to

--- a/web/packages/teleterm/src/ui/DocumentCluster/resourcesContext.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/resourcesContext.test.tsx
@@ -19,6 +19,8 @@
 import React from 'react';
 import { renderHook } from '@testing-library/react';
 
+import { rootClusterUri } from 'teleterm/services/tshd/testHelpers';
+
 import {
   ResourcesContextProvider,
   useResourcesContext,
@@ -33,9 +35,10 @@ describe('requestResourcesRefresh', () => {
 
     const listener = jest.fn();
     result.current.onResourcesRefreshRequest(listener);
-    result.current.requestResourcesRefresh();
+    result.current.requestResourcesRefresh(rootClusterUri);
 
     expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(rootClusterUri);
   });
 });
 
@@ -50,7 +53,7 @@ describe('onResourcesRefreshRequest cleanup function', () => {
     const { cleanup } = result.current.onResourcesRefreshRequest(listener);
 
     cleanup();
-    result.current.requestResourcesRefresh();
+    result.current.requestResourcesRefresh(rootClusterUri);
 
     expect(listener).not.toHaveBeenCalled();
   });

--- a/web/packages/teleterm/src/ui/DocumentCluster/resourcesContext.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/resourcesContext.tsx
@@ -18,7 +18,7 @@
 
 import { EventEmitter } from 'events';
 
-import React, {
+import {
   createContext,
   FC,
   PropsWithChildren,
@@ -27,20 +27,26 @@ import React, {
   useRef,
 } from 'react';
 
+import { RootClusterUri } from 'teleterm/ui/uri';
+
 export interface ResourcesContext {
   /**
-   * requestResourcesRefresh makes all DocumentCluster instances within the workspace refresh the
-   * resource list with current filters.
+   * requestResourcesRefresh makes all DocumentCluster instances within the workspace
+   * (specified by `rootClusterUri`) refresh the resource list with current filters.
    *
-   * Its main purpose is to refresh the resource list in existing DocumentCluster tabs after a
-   * Connect My Computer node is set up.
+   * Its purpose is to refresh the resource list in existing DocumentCluster tabs after a
+   * Connect My Computer node is set up, or after assuming/dropping an access request.
    */
-  requestResourcesRefresh: () => void;
+  requestResourcesRefresh: (rootClusterUri: RootClusterUri) => void;
   /**
    * onResourcesRefreshRequest registers a listener that will be called any time a refresh is
    * requested. Typically called from useEffect, for this purpose it returns a cleanup function.
    */
-  onResourcesRefreshRequest: (listener: () => void) => { cleanup: () => void };
+  onResourcesRefreshRequest: (
+    listener: (rootClusterUri: RootClusterUri) => void
+  ) => {
+    cleanup: () => void;
+  };
 }
 
 const ResourcesContext = createContext<ResourcesContext>(null);
@@ -51,24 +57,24 @@ export const ResourcesContextProvider: FC<PropsWithChildren> = props => {
     emitterRef.current = new EventEmitter();
   }
 
-  // This function could be expanded to emit a cluster URI so that a request refresh for a root
-  // cluster doesn't trigger refreshes of leaf DocumentCluster instances and vice versa.
-  // However, the implementation should be good enough for now since it's used only in Connect My
-  // Computer setup anyway.
   const requestResourcesRefresh = useCallback(
-    () => emitterRef.current.emit('refresh'),
+    (rootClusterUri: RootClusterUri) =>
+      emitterRef.current.emit('refresh', rootClusterUri),
     []
   );
 
-  const onResourcesRefreshRequest = useCallback(listener => {
-    emitterRef.current.addListener('refresh', listener);
+  const onResourcesRefreshRequest = useCallback(
+    (listener: (rootClusterUri: RootClusterUri) => void) => {
+      emitterRef.current.addListener('refresh', listener);
 
-    return {
-      cleanup: () => {
-        emitterRef.current.removeListener('refresh', listener);
-      },
-    };
-  }, []);
+      return {
+        cleanup: () => {
+          emitterRef.current.removeListener('refresh', listener);
+        },
+      };
+    },
+    []
+  );
 
   return (
     <ResourcesContext.Provider

--- a/web/packages/teleterm/src/ui/DocumentCluster/resourcesContext.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/resourcesContext.tsx
@@ -84,7 +84,7 @@ export const ResourcesContextProvider: FC<PropsWithChildren> = props => {
   );
 };
 
-export const useResourcesContext = () => {
+export const useResourcesContext = (rootClusterUri: RootClusterUri) => {
   const context = useContext(ResourcesContext);
 
   if (!context) {
@@ -93,5 +93,24 @@ export const useResourcesContext = () => {
     );
   }
 
-  return context;
+  const {
+    requestResourcesRefresh: requestResourcesRefreshContext,
+    onResourcesRefreshRequest: onResourcesRefreshRequestContext,
+  } = context;
+
+  return {
+    requestResourcesRefresh: useCallback(
+      () => requestResourcesRefreshContext(rootClusterUri),
+      [requestResourcesRefreshContext, rootClusterUri]
+    ),
+    onResourcesRefreshRequest: useCallback(
+      (listener: () => void) =>
+        onResourcesRefreshRequestContext(requestedRootClusterUri => {
+          if (requestedRootClusterUri === rootClusterUri) {
+            listener();
+          }
+        }),
+      [onResourcesRefreshRequestContext, rootClusterUri]
+    ),
+  };
 };

--- a/web/packages/teleterm/src/ui/Documents/DocumentsRenderer.tsx
+++ b/web/packages/teleterm/src/ui/Documents/DocumentsRenderer.tsx
@@ -45,8 +45,6 @@ import { DocumentGatewayApp } from 'teleterm/ui/DocumentGatewayApp';
 import Document from 'teleterm/ui/Document';
 import { RootClusterUri, isDatabaseUri, isAppUri } from 'teleterm/ui/uri';
 
-import { ResourcesContextProvider } from '../DocumentCluster/resourcesContext';
-
 import { WorkspaceContextProvider } from './workspaceContext';
 import { KeyboardShortcutsPanel } from './KeyboardShortcutsPanel';
 
@@ -87,25 +85,22 @@ export function DocumentsRenderer(props: {
           key={workspace.rootClusterUri}
         >
           <WorkspaceContextProvider value={workspace}>
-            {/* ConnectMyComputerContext depends on ResourcesContext. */}
-            <ResourcesContextProvider>
-              <ConnectMyComputerContextProvider
-                rootClusterUri={workspace.rootClusterUri}
-              >
-                {workspace.documentsService.getDocuments().length ? (
-                  renderDocuments(workspace.documentsService)
-                ) : (
-                  <KeyboardShortcutsPanel />
+            <ConnectMyComputerContextProvider
+              rootClusterUri={workspace.rootClusterUri}
+            >
+              {workspace.documentsService.getDocuments().length ? (
+                renderDocuments(workspace.documentsService)
+              ) : (
+                <KeyboardShortcutsPanel />
+              )}
+              {workspace.rootClusterUri ===
+                workspacesService.getRootClusterUri() &&
+                props.topBarContainerRef.current &&
+                createPortal(
+                  <ConnectMyComputerNavigationMenu />,
+                  props.topBarContainerRef.current
                 )}
-                {workspace.rootClusterUri ===
-                  workspacesService.getRootClusterUri() &&
-                  props.topBarContainerRef.current &&
-                  createPortal(
-                    <ConnectMyComputerNavigationMenu />,
-                    props.topBarContainerRef.current
-                  )}
-              </ConnectMyComputerContextProvider>
-            </ResourcesContextProvider>
+            </ConnectMyComputerContextProvider>
           </WorkspaceContextProvider>
         </DocumentsContainer>
       ))}

--- a/web/packages/teleterm/src/ui/TabHost/TabHost.test.tsx
+++ b/web/packages/teleterm/src/ui/TabHost/TabHost.test.tsx
@@ -31,6 +31,7 @@ import {
   rootClusterUri,
 } from 'teleterm/services/tshd/testHelpers';
 import { routing } from 'teleterm/ui/uri';
+import { ResourcesContextProvider } from 'teleterm/ui/DocumentCluster/resourcesContext';
 
 function getMockDocuments(): Document[] {
   return [
@@ -86,7 +87,9 @@ async function getTestSetup({ documents }: { documents: Document[] }) {
 
   render(
     <MockAppContextProvider appContext={appContext}>
-      <TabHost ctx={appContext} topBarContainerRef={createRef()} />
+      <ResourcesContextProvider>
+        <TabHost ctx={appContext} topBarContainerRef={createRef()} />
+      </ResourcesContextProvider>
     </MockAppContextProvider>
   );
 


### PR DESCRIPTION
Backport #49125 to branch/v17

changelog: Teleport Connect now refreshes the resources view after dropping an access request
