### PR TITLE
Add TF reference sidebar titles

### DIFF
--- a/docs/pages/reference/terraform-provider/data-sources/access_list.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/access_list.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_access_list Terraform data-source
+sidebar_label: access_list
 description: This page describes the supported values of the teleport_access_list data-source of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/data-sources/access_monitoring_rule.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/access_monitoring_rule.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_access_monitoring_rule Terraform data-source
+sidebar_label: access_monitoring_rule
 description: This page describes the supported values of the teleport_access_monitoring_rule data-source of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/data-sources/app.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/app.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_app Terraform data-source
+sidebar_label: app
 description: This page describes the supported values of the teleport_app data-source of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/data-sources/auth_preference.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/auth_preference.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_auth_preference Terraform data-source
+sidebar_label: auth_preference
 description: This page describes the supported values of the teleport_auth_preference data-source of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/data-sources/cluster_maintenance_config.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/cluster_maintenance_config.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_cluster_maintenance_config Terraform data-source
+sidebar_label: cluster_maintenance_config
 description: This page describes the supported values of the teleport_cluster_maintenance_config data-source of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/data-sources/cluster_networking_config.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/cluster_networking_config.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_cluster_networking_config Terraform data-source
+sidebar_label: cluster_networking_config
 description: This page describes the supported values of the teleport_cluster_networking_config data-source of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/data-sources/database.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/database.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_database Terraform data-source
+sidebar_label: database
 description: This page describes the supported values of the teleport_database data-source of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/data-sources/dynamic_windows_desktop.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/dynamic_windows_desktop.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_dynamic_windows_desktop Terraform data-source
+sidebar_label: dynamic_windows_desktop
 description: This page describes the supported values of the teleport_dynamic_windows_desktop data-source of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/data-sources/github_connector.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/github_connector.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_github_connector Terraform data-source
+sidebar_label: github_connector
 description: This page describes the supported values of the teleport_github_connector data-source of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/data-sources/installer.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/installer.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_installer Terraform data-source
+sidebar_label: installer
 description: This page describes the supported values of the teleport_installer data-source of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/data-sources/login_rule.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/login_rule.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_login_rule Terraform data-source
+sidebar_label: login_rule
 description: This page describes the supported values of the teleport_login_rule data-source of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/data-sources/oidc_connector.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/oidc_connector.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_oidc_connector Terraform data-source
+sidebar_label: oidc_connector
 description: This page describes the supported values of the teleport_oidc_connector data-source of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/data-sources/okta_import_rule.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/okta_import_rule.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_okta_import_rule Terraform data-source
+sidebar_label: okta_import_rule
 description: This page describes the supported values of the teleport_okta_import_rule data-source of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/data-sources/provision_token.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/provision_token.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_provision_token Terraform data-source
+sidebar_label: provision_token
 description: This page describes the supported values of the teleport_provision_token data-source of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/data-sources/role.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/role.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_role Terraform data-source
+sidebar_label: role
 description: This page describes the supported values of the teleport_role data-source of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/data-sources/saml_connector.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/saml_connector.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_saml_connector Terraform data-source
+sidebar_label: saml_connector
 description: This page describes the supported values of the teleport_saml_connector data-source of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/data-sources/session_recording_config.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/session_recording_config.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_session_recording_config Terraform data-source
+sidebar_label: session_recording_config
 description: This page describes the supported values of the teleport_session_recording_config data-source of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/data-sources/static_host_user.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/static_host_user.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_static_host_user Terraform data-source
+sidebar_label: static_host_user
 description: This page describes the supported values of the teleport_static_host_user data-source of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/data-sources/trusted_cluster.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/trusted_cluster.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_trusted_cluster Terraform data-source
+sidebar_label: trusted_cluster
 description: This page describes the supported values of the teleport_trusted_cluster data-source of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/data-sources/trusted_device.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/trusted_device.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_trusted_device Terraform data-source
+sidebar_label: trusted_device
 description: This page describes the supported values of the teleport_trusted_device data-source of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/data-sources/user.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/user.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_user Terraform data-source
+sidebar_label: user
 description: This page describes the supported values of the teleport_user data-source of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/resources/access_list.mdx
+++ b/docs/pages/reference/terraform-provider/resources/access_list.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_access_list Terraform resource
+sidebar_label: access_list
 description: This page describes the supported values of the teleport_access_list resource of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/resources/access_monitoring_rule.mdx
+++ b/docs/pages/reference/terraform-provider/resources/access_monitoring_rule.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_access_monitoring_rule Terraform resource
+sidebar_label: access_monitoring_rule
 description: This page describes the supported values of the teleport_access_monitoring_rule resource of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/resources/app.mdx
+++ b/docs/pages/reference/terraform-provider/resources/app.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_app Terraform resource
+sidebar_label: app
 description: This page describes the supported values of the teleport_app resource of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/resources/auth_preference.mdx
+++ b/docs/pages/reference/terraform-provider/resources/auth_preference.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_auth_preference Terraform resource
+sidebar_label: auth_preference
 description: This page describes the supported values of the teleport_auth_preference resource of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/resources/bot.mdx
+++ b/docs/pages/reference/terraform-provider/resources/bot.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_bot Terraform resource
+sidebar_label: bot
 description: This page describes the supported values of the teleport_bot resource of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/resources/cluster_maintenance_config.mdx
+++ b/docs/pages/reference/terraform-provider/resources/cluster_maintenance_config.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_cluster_maintenance_config Terraform resource
+sidebar_label: cluster_maintenance_config
 description: This page describes the supported values of the teleport_cluster_maintenance_config resource of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/resources/cluster_networking_config.mdx
+++ b/docs/pages/reference/terraform-provider/resources/cluster_networking_config.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_cluster_networking_config Terraform resource
+sidebar_label: cluster_networking_config
 description: This page describes the supported values of the teleport_cluster_networking_config resource of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/resources/database.mdx
+++ b/docs/pages/reference/terraform-provider/resources/database.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_database Terraform resource
+sidebar_label: database
 description: This page describes the supported values of the teleport_database resource of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/resources/dynamic_windows_desktop.mdx
+++ b/docs/pages/reference/terraform-provider/resources/dynamic_windows_desktop.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_dynamic_windows_desktop Terraform resource
+sidebar_label: dynamic_windows_desktop
 description: This page describes the supported values of the teleport_dynamic_windows_desktop resource of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/resources/github_connector.mdx
+++ b/docs/pages/reference/terraform-provider/resources/github_connector.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_github_connector Terraform resource
+sidebar_label: github_connector
 description: This page describes the supported values of the teleport_github_connector resource of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/resources/installer.mdx
+++ b/docs/pages/reference/terraform-provider/resources/installer.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_installer Terraform resource
+sidebar_label: installer
 description: This page describes the supported values of the teleport_installer resource of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/resources/login_rule.mdx
+++ b/docs/pages/reference/terraform-provider/resources/login_rule.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_login_rule Terraform resource
+sidebar_label: login_rule
 description: This page describes the supported values of the teleport_login_rule resource of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/resources/oidc_connector.mdx
+++ b/docs/pages/reference/terraform-provider/resources/oidc_connector.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_oidc_connector Terraform resource
+sidebar_label: oidc_connector
 description: This page describes the supported values of the teleport_oidc_connector resource of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/resources/okta_import_rule.mdx
+++ b/docs/pages/reference/terraform-provider/resources/okta_import_rule.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_okta_import_rule Terraform resource
+sidebar_label: okta_import_rule
 description: This page describes the supported values of the teleport_okta_import_rule resource of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/resources/provision_token.mdx
+++ b/docs/pages/reference/terraform-provider/resources/provision_token.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_provision_token Terraform resource
+sidebar_label: provision_token
 description: This page describes the supported values of the teleport_provision_token resource of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/resources/role.mdx
+++ b/docs/pages/reference/terraform-provider/resources/role.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_role Terraform resource
+sidebar_label: role
 description: This page describes the supported values of the teleport_role resource of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/resources/saml_connector.mdx
+++ b/docs/pages/reference/terraform-provider/resources/saml_connector.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_saml_connector Terraform resource
+sidebar_label: saml_connector
 description: This page describes the supported values of the teleport_saml_connector resource of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/resources/server.mdx
+++ b/docs/pages/reference/terraform-provider/resources/server.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_server Terraform resource
+sidebar_label: server
 description: This page describes the supported values of the teleport_server resource of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/resources/session_recording_config.mdx
+++ b/docs/pages/reference/terraform-provider/resources/session_recording_config.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_session_recording_config Terraform resource
+sidebar_label: session_recording_config
 description: This page describes the supported values of the teleport_session_recording_config resource of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/resources/static_host_user.mdx
+++ b/docs/pages/reference/terraform-provider/resources/static_host_user.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_static_host_user Terraform resource
+sidebar_label: static_host_user
 description: This page describes the supported values of the teleport_static_host_user resource of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/resources/trusted_cluster.mdx
+++ b/docs/pages/reference/terraform-provider/resources/trusted_cluster.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_trusted_cluster Terraform resource
+sidebar_label: trusted_cluster
 description: This page describes the supported values of the teleport_trusted_cluster resource of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/resources/trusted_device.mdx
+++ b/docs/pages/reference/terraform-provider/resources/trusted_device.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_trusted_device Terraform resource
+sidebar_label: trusted_device
 description: This page describes the supported values of the teleport_trusted_device resource of the Teleport Terraform provider.
 ---
 

--- a/docs/pages/reference/terraform-provider/resources/user.mdx
+++ b/docs/pages/reference/terraform-provider/resources/user.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference for the teleport_user Terraform resource
+sidebar_label: user
 description: This page describes the supported values of the teleport_user resource of the Teleport Terraform provider.
 ---
 

--- a/integrations/terraform/templates/data-sources.md.tmpl
+++ b/integrations/terraform/templates/data-sources.md.tmpl
@@ -1,5 +1,6 @@
 ---
 title: Reference for the {{.Name}} Terraform data-source
+sidebar_label: {{ slice .Name (len "teleport_") }}
 description: This page describes the supported values of the {{.Name}} data-source of the Teleport Terraform provider.
 ---
 

--- a/integrations/terraform/templates/resources.md.tmpl
+++ b/integrations/terraform/templates/resources.md.tmpl
@@ -1,5 +1,6 @@
 ---
 title: Reference for the {{.Name}} Terraform resource
+sidebar_label: {{ slice .Name (len "teleport_") }}
 description: This page describes the supported values of the {{.Name}} resource of the Teleport Terraform provider.
 ---
 


### PR DESCRIPTION
Add the `sidebar_label` frontmatter field so the titles of the Terraform data source and resource pages render on a single line within the auto-generated Docusaurus sidebar. Trim the `teleport_` prefix from sidebar labels to prevent them from overflowing the sidebar.

Closes gravitational/docs-website#10