### PR TITLE
[v16] Add owner property to TrustedDevices type

### DIFF
--- a/web/packages/teleport/src/DeviceTrust/types.ts
+++ b/web/packages/teleport/src/DeviceTrust/types.ts
@@ -22,7 +22,8 @@ export type TrustedDevice = {
   id: string;
   assetTag: string;
   osType: TrustedDeviceOSType;
-  enrollStatus: string;
+  enrollStatus: 'enrolled' | 'not enrolled';
+  owner?: string;
 };
 
 export type TrustedDeviceOSType = 'Windows' | 'Linux' | 'macOS';


### PR DESCRIPTION
Backport
Supports https://github.com/gravitational/teleport.e/pull/5543
This adds the owner property to our TrustedDevices type to support adding owner to our device trust table in `e`