### PR TITLE
update tbot missing proxy error

### DIFF
--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -546,7 +546,7 @@ func (b *Bot) preRunChecks(ctx context.Context) (_ func() error, err error) {
 	switch addrKind {
 	case config.AddressKindUnspecified:
 		return nil, trace.BadParameter(
-			"either a proxy or auth address must be set using --proxy, --auth-server or configuration",
+			"either a proxy or auth address must be set using --proxy-server, --auth-server or configuration",
 		)
 	case config.AddressKindAuth:
 		// TODO(noah): DELETE IN V17.0.0


### PR DESCRIPTION
incorrect parameter in error message. it is `--proxy-server`, not `--proxy`.