### PR TITLE
[teleport-update] Protect against disk space leaks

### DIFF
--- a/lib/autoupdate/agent/installer.go
+++ b/lib/autoupdate/agent/installer.go
@@ -103,7 +103,7 @@ func (li *LocalInstaller) Remove(ctx context.Context, version string) error {
 		return trace.Wrap(err)
 	}
 
-	linked, err := li.isLinked(versionDir)
+	linked, err := li.isLinked(filepath.Join(versionDir, "bin"))
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return trace.Errorf("failed to determine if linked: %w", err)
 	}
@@ -849,10 +849,22 @@ func (li *LocalInstaller) versionDir(version string) (string, error) {
 	return versionDir, nil
 }
 
-// isLinked returns true if any binaries or services in versionDir are linked.
-// Returns os.ErrNotExist error if the versionDir does not exist.
-func (li *LocalInstaller) isLinked(versionDir string) (bool, error) {
-	binDir := filepath.Join(versionDir, "bin")
+// IsLinked returns true if the version is linked or partially linked.
+// Returns os.ErrNotExist error if the version does not exist.
+// See Installer interface for additional specs.
+func (li *LocalInstaller) IsLinked(ctx context.Context, version string) (bool, error) {
+	versionDir, err := li.versionDir(version)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	b, err := li.isLinked(filepath.Join(versionDir, "bin"))
+	return b, trace.Wrap(err)
+
+}
+
+// isLinked returns true if any binaries in binDir are linked.
+// Returns os.ErrNotExist error if the binDir does not exist.
+func (li *LocalInstaller) isLinked(binDir string) (bool, error) {
 	entries, err := os.ReadDir(binDir)
 	if err != nil {
 		return false, trace.Wrap(err)

--- a/lib/autoupdate/agent/installer.go
+++ b/lib/autoupdate/agent/installer.go
@@ -849,19 +849,6 @@ func (li *LocalInstaller) versionDir(version string) (string, error) {
 	return versionDir, nil
 }
 
-// IsLinked returns true if the version is linked or partially linked.
-// Returns os.ErrNotExist error if the version does not exist.
-// See Installer interface for additional specs.
-func (li *LocalInstaller) IsLinked(ctx context.Context, version string) (bool, error) {
-	versionDir, err := li.versionDir(version)
-	if err != nil {
-		return false, trace.Wrap(err)
-	}
-	b, err := li.isLinked(filepath.Join(versionDir, "bin"))
-	return b, trace.Wrap(err)
-
-}
-
 // isLinked returns true if any binaries in binDir are linked.
 // Returns os.ErrNotExist error if the binDir does not exist.
 func (li *LocalInstaller) isLinked(binDir string) (bool, error) {

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -742,6 +742,7 @@ func (u *Updater) update(ctx context.Context, cfg *UpdateConfig, targetVersion s
 		}
 		if err != nil {
 			u.Log.WarnContext(ctx, "Failed to remove unused version of Teleport.", errorKey, err, "version", v)
+			continue
 		}
 		u.Log.WarnContext(ctx, "Deleted unused version of Teleport.", "version", v)
 	}

--- a/lib/autoupdate/agent/updater_test.go
+++ b/lib/autoupdate/agent/updater_test.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 
@@ -222,7 +223,7 @@ func TestUpdater_Update(t *testing.T) {
 		setupErr   error
 		reloadErr  error
 
-		removedVersion    string
+		removedVersions   []string
 		installedVersion  string
 		installedTemplate string
 		linkedVersion     string
@@ -248,6 +249,7 @@ func TestUpdater_Update(t *testing.T) {
 			},
 			inWindow: true,
 
+			removedVersions:   []string{"unknown-version"},
 			installedVersion:  "16.3.0",
 			installedTemplate: "https://example.com",
 			linkedVersion:     "16.3.0",
@@ -380,7 +382,7 @@ func TestUpdater_Update(t *testing.T) {
 			installedVersion:  "16.3.0",
 			installedTemplate: "https://example.com",
 			linkedVersion:     "16.3.0",
-			removedVersion:    "backup-version",
+			removedVersions:   []string{"backup-version", "unknown-version"},
 			reloadCalls:       1,
 			setupCalls:        1,
 		},
@@ -423,7 +425,7 @@ func TestUpdater_Update(t *testing.T) {
 			installedVersion:  "16.3.0",
 			installedTemplate: "https://example.com",
 			linkedVersion:     "16.3.0",
-			removedVersion:    "backup-version",
+			removedVersions:   []string{"backup-version", "unknown-version"},
 			reloadCalls:       1,
 			setupCalls:        1,
 		},
@@ -452,7 +454,7 @@ func TestUpdater_Update(t *testing.T) {
 			installedVersion:  "16.3.0",
 			installedTemplate: "https://example.com",
 			linkedVersion:     "16.3.0",
-			removedVersion:    "backup-version",
+			removedVersions:   []string{"backup-version"},
 			reloadCalls:       0,
 			revertCalls:       1,
 			setupCalls:        1,
@@ -478,7 +480,7 @@ func TestUpdater_Update(t *testing.T) {
 			installedVersion:  "16.3.0",
 			installedTemplate: "https://example.com",
 			linkedVersion:     "16.3.0",
-			removedVersion:    "backup-version",
+			removedVersions:   []string{"backup-version"},
 			reloadCalls:       2,
 			revertCalls:       1,
 			setupCalls:        1,
@@ -562,7 +564,7 @@ func TestUpdater_Update(t *testing.T) {
 				installedVersion  string
 				installedTemplate string
 				linkedVersion     string
-				removedVersion    string
+				removedVersions   []string
 				installedFlags    InstallFlags
 				revertFuncCalls   int
 				setupCalls        int
@@ -584,10 +586,14 @@ func TestUpdater_Update(t *testing.T) {
 					}, nil
 				},
 				FuncList: func(_ context.Context) (versions []string, err error) {
-					return []string{"old"}, nil
+					return slices.Compact([]string{
+						installedVersion,
+						tt.cfg.Status.ActiveVersion,
+						"unknown-version",
+					}), nil
 				},
 				FuncRemove: func(_ context.Context, version string) error {
-					removedVersion = version
+					removedVersions = append(removedVersions, version)
 					return nil
 				},
 			}
@@ -617,7 +623,7 @@ func TestUpdater_Update(t *testing.T) {
 			require.Equal(t, tt.installedVersion, installedVersion)
 			require.Equal(t, tt.installedTemplate, installedTemplate)
 			require.Equal(t, tt.linkedVersion, linkedVersion)
-			require.Equal(t, tt.removedVersion, removedVersion)
+			require.Equal(t, tt.removedVersions, removedVersions)
 			require.Equal(t, tt.flags, installedFlags)
 			require.Equal(t, tt.requestGroup, requestedGroup)
 			require.Equal(t, tt.reloadCalls, reloadCalls)
@@ -1335,7 +1341,7 @@ func TestUpdater_Install(t *testing.T) {
 					}, nil
 				},
 				FuncList: func(_ context.Context) (versions []string, err error) {
-					return []string{"old"}, nil
+					return []string{}, nil
 				},
 				FuncRemove: func(_ context.Context, version string) error {
 					removedVersion = version


### PR DESCRIPTION
This PR ensures that `teleport-update` removes installations of Teleport that are no longer referenced by its configuration (`update.yaml`) or linked into `/usr/local/bin`.

Note that the logic avoids removing partially linked installations that are no longer referenced by configuration. This case could occur if a Teleport binary is removed in newer versions of Teleport, as `teleport-update` only atomically replaces (and never deletes) symlinks.

---

The `teleport-update` binary will be used to enable, disable, and trigger automatic Teleport agent updates. The new auto-updates system manages a local installation of the cluster-specified version of Teleport stored in `/var/lib/teleport/versions`.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/10289
