### PR TITLE
[v17] Add test that executes tsh with no env vars

### DIFF
--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -417,6 +417,7 @@ func TestAlias(t *testing.T) {
 //
 // …plus whatever is set in the launch daemon plist under the EnvironmentVariables key.
 func TestNoEnvVars(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancel)
 

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -407,6 +407,29 @@ func TestAlias(t *testing.T) {
 	}
 }
 
+// TestNoEnvVars checks if tsh is able to work without any env vars provided.
+// This is important for VNet on macOS. When launchd starts VNet's launch daemon, it executes "tsh
+// vnet-daemon" with only the following env vars available:
+//
+// XPC_SERVICE_NAME=com.goteleport.tshdev.vnetd
+// PATH=/usr/bin:/bin:/usr/sbin:/sbin
+// XPC_FLAGS=1
+//
+// …plus whatever is set in the launch daemon plist under the EnvironmentVariables key.
+func TestNoEnvVars(t *testing.T) {
+	testExecutable, err := os.Executable()
+	require.NoError(t, err)
+	// Execute an actual command and not jut `tsh help` which goes through a different code path.
+	cmd := exec.Command(testExecutable, "version", "--client")
+	// Run the command with no env vars except tshBinMainTestEnv, otherwise the test would hang.
+	cmd.Env = []string{fmt.Sprintf("%s=1", tshBinMainTestEnv)}
+
+	t.Logf("running command %v", cmd)
+	output, err := cmd.CombinedOutput()
+	t.Logf("executable output: %v", string(output))
+	require.NoError(t, err)
+}
+
 func TestFailedLogin(t *testing.T) {
 	t.Parallel()
 	tmpHomePath := t.TempDir()

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -423,7 +423,7 @@ func TestNoEnvVars(t *testing.T) {
 
 	testExecutable, err := os.Executable()
 	require.NoError(t, err)
-	// Execute an actual command and not jut `tsh help` which goes through a different code path.
+	// Execute an actual command and not just `tsh help` which goes through a different code path.
 	cmd := exec.CommandContext(ctx, testExecutable, "version", "--client")
 	// Run the command with no env vars except tshBinMainTestEnv, otherwise the test would hang.
 	cmd.Env = []string{fmt.Sprintf("%s=1", tshBinMainTestEnv)}


### PR DESCRIPTION
Backport #49255 to branch/v17