### PR TITLE
Grant secret watch permission to the operator

### DIFF
--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/role.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/role.yaml
@@ -66,5 +66,6 @@ rules:
     verbs:
       - "get"
       - "list"
+      - "watch"
 {{- end -}}
 {{- end -}}

--- a/examples/chart/teleport-cluster/charts/teleport-operator/tests/role_test.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/tests/role_test.yaml
@@ -49,4 +49,4 @@ tests:
           content:
             apiGroups: [""]
             resources: ["secrets"]
-            verbs: ["get", "list"]
+            verbs: ["get", "list", "watch"]


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/48896 was missing the `watch` verb

Confirmed that it works now. 

Note: those issues happened because the operator's kube client tries to be smart and maintain a local secret cache. This doesn't happen as long as users don't use secret injection. I don't think it's a bad thing, but some users might see high memory usage if they have thousands of secrets in their namespace. If this happens we'll have to craft another client, not caching secrets.

Changelog: fix a bug in the Teleport Operator chart that causes the operator to not be able to watch secrets during secret injection.