### PR TITLE
[v17] Grant secret watch permission to the operator

### DIFF
--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/role.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/role.yaml
@@ -66,5 +66,6 @@ rules:
     verbs:
       - "get"
       - "list"
+      - "watch"
 {{- end -}}
 {{- end -}}

--- a/examples/chart/teleport-cluster/charts/teleport-operator/tests/role_test.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/tests/role_test.yaml
@@ -49,4 +49,4 @@ tests:
           content:
             apiGroups: [""]
             resources: ["secrets"]
-            verbs: ["get", "list"]
+            verbs: ["get", "list", "watch"]


### PR DESCRIPTION
Backport #49324 to branch/v17

changelog: fix a bug in the Teleport Operator chart that causes the operator to not be able to watch secrets during secret injection.
