### PR TITLE
[teleport-update] Show warning instead of return error for link/unlink

### DIFF
--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -749,7 +749,9 @@ func (u *Updater) LinkPackage(ctx context.Context) error {
 	} else if err != nil {
 		return trace.Errorf("failed to link system package installation: %w", err)
 	}
-	if err := u.Process.Sync(ctx); err != nil {
+	if err := u.Process.Sync(ctx); errors.Is(err, ErrNotSupported) {
+		u.Log.WarnContext(ctx, "SystemD is not installed, skip sync")
+	} else if err != nil {
 		return trace.Errorf("failed to sync systemd configuration: %w", err)
 	}
 	u.Log.InfoContext(ctx, "Successfully linked system package installation.")
@@ -762,7 +764,9 @@ func (u *Updater) UnlinkPackage(ctx context.Context) error {
 	if err := u.Installer.UnlinkSystem(ctx); err != nil {
 		return trace.Errorf("failed to unlink system package installation: %w", err)
 	}
-	if err := u.Process.Sync(ctx); err != nil {
+	if err := u.Process.Sync(ctx); errors.Is(err, ErrNotSupported) {
+		u.Log.WarnContext(ctx, "SystemD is not installed, skip sync")
+	} else if err != nil {
 		return trace.Errorf("failed to sync systemd configuration: %w", err)
 	}
 	u.Log.InfoContext(ctx, "Successfully unlinked system package installation.")

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -750,7 +750,7 @@ func (u *Updater) LinkPackage(ctx context.Context) error {
 		return trace.Errorf("failed to link system package installation: %w", err)
 	}
 	if err := u.Process.Sync(ctx); errors.Is(err, ErrNotSupported) {
-		u.Log.WarnContext(ctx, "SystemD is not installed, skip sync")
+		u.Log.WarnContext(ctx, "Systemd is not installed. Skipping sync.")
 	} else if err != nil {
 		return trace.Errorf("failed to sync systemd configuration: %w", err)
 	}
@@ -765,7 +765,7 @@ func (u *Updater) UnlinkPackage(ctx context.Context) error {
 		return trace.Errorf("failed to unlink system package installation: %w", err)
 	}
 	if err := u.Process.Sync(ctx); errors.Is(err, ErrNotSupported) {
-		u.Log.WarnContext(ctx, "SystemD is not installed, skip sync")
+		u.Log.WarnContext(ctx, "Systemd is not installed. Skipping sync.")
 	} else if err != nil {
 		return trace.Errorf("failed to sync systemd configuration: %w", err)
 	}

--- a/lib/autoupdate/agent/updater_test.go
+++ b/lib/autoupdate/agent/updater_test.go
@@ -650,6 +650,7 @@ func TestUpdater_LinkPackage(t *testing.T) {
 		name             string
 		cfg              *UpdateConfig // nil -> file not present
 		tryLinkSystemErr error
+		syncErr          error
 
 		syncCalls          int
 		tryLinkSystemCalls int
@@ -715,6 +716,25 @@ func TestUpdater_LinkPackage(t *testing.T) {
 			tryLinkSystemCalls: 1,
 			syncCalls:          1,
 		},
+		{
+			name:               "systemd is not installed",
+			tryLinkSystemCalls: 1,
+			syncCalls:          1,
+			syncErr:            ErrNotSupported,
+		},
+		{
+			name: "systemd is not installed, already linked",
+			cfg: &UpdateConfig{
+				Version: updateConfigVersion,
+				Kind:    updateConfigKind,
+				Spec: UpdateSpec{
+					Enabled: false,
+				},
+			},
+			tryLinkSystemCalls: 1,
+			syncCalls:          1,
+			syncErr:            ErrNotSupported,
+		},
 	}
 
 	for _, tt := range tests {
@@ -747,7 +767,7 @@ func TestUpdater_LinkPackage(t *testing.T) {
 			updater.Process = &testProcess{
 				FuncSync: func(_ context.Context) error {
 					syncCalls++
-					return nil
+					return tt.syncErr
 				},
 			}
 


### PR DESCRIPTION
In this PR added fix to make `link-package` and `unlink-package` less strict to have `systemd` installed, related to deb, rpm installation tests

https://github.com/gravitational/teleport.e/actions/runs/11935999685/job/33269358902