### PR TITLE
fix connection tester error for Aurora databases

### DIFF
--- a/web/packages/teleport/src/Discover/Database/TestConnection/TestConnection.tsx
+++ b/web/packages/teleport/src/Discover/Database/TestConnection/TestConnection.tsx
@@ -43,7 +43,7 @@ import {
   StyledBox,
   useConnectionDiagnostic,
 } from '../../Shared';
-import { DatabaseEngine } from '../../SelectResource';
+import { DatabaseEngine, getDatabaseProtocol } from '../../SelectResource';
 
 export function TestConnection() {
   const { resourceSpec, agentMeta } = useDiscover();
@@ -186,7 +186,7 @@ export function TestConnection() {
                   attempt.status === 'processing' || nameOpts.length === 0
                 }
                 // Database name is required for Postgres.
-                isClearable={dbEngine !== DatabaseEngine.Postgres}
+                isClearable={!isDbNameRequired(dbEngine)}
               />
               <CustomInputFieldForAsterisks
                 selectedOption={selectedDbName}
@@ -237,4 +237,14 @@ function getInputValue(input: string, inputKind: 'name' | 'user') {
     return inputKind === 'name' ? '<name>' : '<user>';
   }
   return input;
+}
+
+function isDbNameRequired(engine: DatabaseEngine) {
+  const protocol = getDatabaseProtocol(engine);
+  switch (protocol) {
+    case 'postgres':
+      return true;
+    default:
+      return false;
+  }
 }

--- a/web/packages/teleport/src/Discover/Database/TestConnection/TestConnection.tsx
+++ b/web/packages/teleport/src/Discover/Database/TestConnection/TestConnection.tsx
@@ -185,7 +185,6 @@ export function TestConnection() {
                 isDisabled={
                   attempt.status === 'processing' || nameOpts.length === 0
                 }
-                // Database name is required for Postgres.
                 isClearable={!isDbNameRequired(dbEngine)}
               />
               <CustomInputFieldForAsterisks
@@ -242,7 +241,11 @@ function getInputValue(input: string, inputKind: 'name' | 'user') {
 function isDbNameRequired(engine: DatabaseEngine) {
   const protocol = getDatabaseProtocol(engine);
   switch (protocol) {
+    case 'mongodb':
+    case 'oracle':
     case 'postgres':
+    case 'spanner':
+    case 'sqlserver':
       return true;
     default:
       return false;

--- a/web/packages/teleport/src/Discover/SelectResource/databases.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/databases.tsx
@@ -274,7 +274,7 @@ export const DATABASES_UNGUIDED: ResourceSpec[] = [
   {
     dbMeta: {
       location: DatabaseLocation.SelfHosted,
-      engine: DatabaseEngine.CoackroachDb,
+      engine: DatabaseEngine.CockroachDb,
     },
     name: 'CockroachDB',
     keywords: [...selfhostedKeywords, 'cockroachdb'],
@@ -430,7 +430,7 @@ export function getDatabaseProtocol(engine: DatabaseEngine): DbProtocol {
       return 'mongodb';
     case DatabaseEngine.Redis:
       return 'redis';
-    case DatabaseEngine.CoackroachDb:
+    case DatabaseEngine.CockroachDb:
       return 'cockroachdb';
     case DatabaseEngine.SqlServer:
       return 'sqlserver';

--- a/web/packages/teleport/src/Discover/SelectResource/databases.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/databases.tsx
@@ -421,10 +421,27 @@ export function getDatabaseProtocol(engine: DatabaseEngine): DbProtocol {
   switch (engine) {
     case DatabaseEngine.Postgres:
     case DatabaseEngine.AuroraPostgres:
+    case DatabaseEngine.Redshift:
       return 'postgres';
     case DatabaseEngine.MySql:
     case DatabaseEngine.AuroraMysql:
       return 'mysql';
+    case DatabaseEngine.MongoDb:
+      return 'mongodb';
+    case DatabaseEngine.Redis:
+      return 'redis';
+    case DatabaseEngine.CoackroachDb:
+      return 'cockroachdb';
+    case DatabaseEngine.SqlServer:
+      return 'sqlserver';
+    case DatabaseEngine.Snowflake:
+      return 'snowflake';
+    case DatabaseEngine.Cassandra:
+      return 'cassandra';
+    case DatabaseEngine.ElasticSearch:
+      return 'elasticsearch';
+    case DatabaseEngine.DynamoDb:
+      return 'dynamodb';
   }
 
   return '' as any;

--- a/web/packages/teleport/src/Discover/SelectResource/databases.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/databases.tsx
@@ -442,9 +442,11 @@ export function getDatabaseProtocol(engine: DatabaseEngine): DbProtocol {
       return 'elasticsearch';
     case DatabaseEngine.DynamoDb:
       return 'dynamodb';
+    case DatabaseEngine.Doc:
+      return '' as any;
+    default:
+      engine satisfies never;
   }
-
-  return '' as any;
 }
 
 export function getDefaultDatabasePort(engine: DatabaseEngine): string {

--- a/web/packages/teleport/src/Discover/SelectResource/types.ts
+++ b/web/packages/teleport/src/Discover/SelectResource/types.ts
@@ -51,7 +51,7 @@ export enum DatabaseEngine {
   AuroraMysql,
   MongoDb,
   Redis,
-  CoackroachDb,
+  CockroachDb,
   SqlServer,
   Snowflake,
   Cassandra,


### PR DESCRIPTION
Closes #47206

These changes were originally made to fix #47206. The fix for #47206 was preempted by https://github.com/gravitational/teleport/pull/48811 fixing a duplicate issue, but this PR still adds other database engines to the protocol conversion func, so I'm keeping that set of changes.
- #47206 
- https://github.com/gravitational/teleport/pull/48811

Other than that, this PR fixes a related (unreported) issue I came across where a user can try to test connection an Aurora Postgres without a "Database name" - that doesn't work because Aurora postgres requires a database name just like other Postgres protocol engines:

![image](https://github.com/user-attachments/assets/678b9421-ca6f-446b-aa0a-f89be7acd85c)

So this PR makes database name a required field in the connection tester for any "postgres" protocol db.