### PR TITLE
reduce db connection test timeout

### DIFF
--- a/integration/conntest/database_test.go
+++ b/integration/conntest/database_test.go
@@ -134,12 +134,12 @@ func TestDiagnoseConnectionForPostgresDatabases(t *testing.T) {
 				{
 					Type:    types.ConnectionDiagnosticTrace_RBAC_DATABASE,
 					Status:  types.ConnectionDiagnosticTrace_SUCCESS,
-					Details: "A Database Agent is available to proxy the connection to the Database.",
+					Details: "A Teleport Database Service is available to proxy the connection to the Database.",
 				},
 				{
 					Type:    types.ConnectionDiagnosticTrace_CONNECTIVITY,
 					Status:  types.ConnectionDiagnosticTrace_SUCCESS,
-					Details: "Database is accessible from the Database Agent.",
+					Details: "Database is accessible from the Teleport Database Service.",
 				},
 				{
 					Type:    types.ConnectionDiagnosticTrace_RBAC_DATABASE_LOGIN,
@@ -175,8 +175,8 @@ func TestDiagnoseConnectionForPostgresDatabases(t *testing.T) {
 					Status: types.ConnectionDiagnosticTrace_FAILED,
 					Details: "Database not found. " +
 						"Ensure your role grants access by adding it to the 'db_labels' property. " +
-						"This can also happen when you don't have a Database Agent proxying the database - " +
-						"you can fix that by adding the database labels to the 'db_service.resources.labels' in 'teleport.yaml' file of the database agent.",
+						"This can also happen when you don't have a Teleport Database Service proxying the database - " +
+						"you can fix that by adding the database labels to the 'db_service.resources.labels' in 'teleport.yaml' file of the Database Service.",
 				},
 			},
 		},


### PR DESCRIPTION
Closes #48649
- #48649

This PR reduces the db connection test timeout to 10 seconds, instead of whatever the browser's response timeout default is (my browser waited 2+ minutes before it gave up, see the issue for some more details).

To test this I intentionally blocked traffic to the database from my db service using security groups.

With this PR it times out after ~10 seconds rather than 2+ minutes, and still provides a helpful error message about the cause:

![image](https://github.com/user-attachments/assets/f7624b81-799d-47de-9efc-8f27123929f6)

I also reworded the diagnostic messages a bit to align with current terminology where we use "service" not "agent".
