### PR TITLE
link to troubleshooting help in rds wizard

### DIFF
--- a/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.tsx
+++ b/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.tsx
@@ -545,6 +545,16 @@ const DeployHints = ({
               </AlternateInstructionButton>
             </li>
           </ul>
+          <Text>
+            Refer to the{' '}
+            <Link
+              target="_blank"
+              href="https://goteleport.com/docs/admin-guides/management/guides/awsoidc-integration-rds/#troubleshooting"
+            >
+              troubleshooting documentation
+            </Link>{' '}
+            for more details.
+          </Text>
         </Flex>
       </HintBox>
     );

--- a/web/packages/teleport/src/Discover/Shared/AwsAccount/AwsAccount.test.tsx
+++ b/web/packages/teleport/src/Discover/Shared/AwsAccount/AwsAccount.test.tsx
@@ -129,7 +129,7 @@ test('missing permissions for integrations', async () => {
   renderAwsAccount(ctx, discoverCtx);
 
   expect(
-    screen.getByText(/required permissions for integrating/i)
+    screen.getByText(/permissions required to set up this integration/i)
   ).toBeInTheDocument();
   expect(screen.queryByText(/aws integrations/i)).not.toBeInTheDocument();
 

--- a/web/packages/teleport/src/Discover/Shared/AwsAccount/AwsAccount.tsx
+++ b/web/packages/teleport/src/Discover/Shared/AwsAccount/AwsAccount.tsx
@@ -165,7 +165,7 @@ export function AwsAccount() {
         <Heading />
         <Box maxWidth="700px">
           <Text mt={4}>
-            You don’t have the required permissions for integrating.
+            You don’t have the permissions required to set up this integration.
             <br />
             Ask your Teleport administrator to update your role with the
             following:


### PR DESCRIPTION
Closes #33477
- #33477

This PR links to the troubleshooting section of our new RDS integration wizard guide when the ECS deployment fails to start.