### PR TITLE
[teleport-update] Uninstall subcommand

### DIFF
--- a/lib/autoupdate/agent/installer.go
+++ b/lib/autoupdate/agent/installer.go
@@ -67,10 +67,6 @@ const (
 	updateTimerName = "teleport-update.timer"
 )
 
-var (
-	ErrNoBinaries = errors.New("no binaries available to link")
-)
-
 // LocalInstaller manages the creation and removal of installations
 // of Teleport.
 type LocalInstaller struct {

--- a/lib/autoupdate/agent/installer.go
+++ b/lib/autoupdate/agent/installer.go
@@ -67,6 +67,10 @@ const (
 	updateTimerName = "teleport-update.timer"
 )
 
+var (
+	ErrNoBinaries = errors.New("no binaries available to link")
+)
+
 // LocalInstaller manages the creation and removal of installations
 // of Teleport.
 type LocalInstaller struct {
@@ -575,7 +579,7 @@ func (li *LocalInstaller) forceLinks(ctx context.Context, binDir, svcDir string)
 		linked++
 	}
 	if linked == 0 {
-		return revert, trace.Errorf("no binaries available to link")
+		return revert, trace.Wrap(ErrNoBinaries)
 	}
 
 	// create systemd service file
@@ -784,7 +788,7 @@ func (li *LocalInstaller) tryLinks(ctx context.Context, binDir, svcDir string) e
 	}
 	// bail if no binaries can be linked
 	if linked == 0 {
-		return trace.Errorf("no binaries available to link")
+		return trace.Wrap(ErrNoBinaries)
 	}
 
 	// link binaries that are missing links

--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -22,7 +22,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 	"os"
 	"os/exec"

--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -287,7 +287,7 @@ func (s SystemdService) Disable(ctx context.Context) error {
 	if code != 0 {
 		return trace.Errorf("unable to disable systemd service")
 	}
-	s.Log.InfoContext(ctx, "Service disabled.", unitKey, s.ServiceName)
+	s.Log.InfoContext(ctx, "Systemd service disabled.", unitKey, s.ServiceName)
 	return nil
 }
 

--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -114,7 +114,7 @@ func (s SystemdService) Reload(ctx context.Context) error {
 		s.Log.InfoContext(ctx, "Monitoring PID file to detect crashes.", unitKey, s.ServiceName)
 		err := s.monitor(ctx, initPID)
 		if errors.Is(err, context.DeadlineExceeded) {
-			return fmt.Errorf("timed out while waiting for process to start")
+			return trace.Errorf("timed out while waiting for process to start")
 		}
 		return trace.Wrap(err)
 	}

--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -306,7 +306,7 @@ func (s SystemdService) IsEnabled(ctx context.Context) (bool, error) {
 	code = s.systemctl(ctx, slog.LevelDebug, "is-active", "--quiet", s.ServiceName)
 	switch {
 	case code < 0:
-		return false, trace.Errorf("unable to determine if systemd service is active")
+		return false, trace.Errorf("unable to determine if systemd service %q is active", s.ServiceName)
 	case code == 0:
 		return true, nil
 	}

--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -270,7 +270,7 @@ func (s SystemdService) Enable(ctx context.Context, now bool) error {
 	if now {
 		args = append(args, "--now")
 	}
-	code := s.systemctl(ctx, slog.LevelError, args...)
+	code := s.systemctl(ctx, slog.LevelInfo, args...)
 	if code != 0 {
 		return trace.Errorf("unable to enable systemd service")
 	}
@@ -283,7 +283,7 @@ func (s SystemdService) Disable(ctx context.Context) error {
 	if err := s.checkSystem(ctx); err != nil {
 		return trace.Wrap(err)
 	}
-	code := s.systemctl(ctx, slog.LevelError, "disable", s.ServiceName)
+	code := s.systemctl(ctx, slog.LevelInfo, "disable", s.ServiceName)
 	if code != 0 {
 		return trace.Errorf("unable to disable systemd service")
 	}

--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -299,7 +299,7 @@ func (s SystemdService) IsEnabled(ctx context.Context) (bool, error) {
 	code := s.systemctl(ctx, slog.LevelDebug, "is-enabled", "--quiet", s.ServiceName)
 	switch {
 	case code < 0:
-		return false, trace.Errorf("unable to determine if systemd service is enabled")
+		return false, trace.Errorf("unable to determine if systemd service %q is enabled", s.ServiceName)
 	case code == 0:
 		return true, nil
 	}

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/no_need_to_reload.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/no_need_to_reload.golden
@@ -1,0 +1,9 @@
+version: v1
+kind: update_config
+spec:
+    proxy: localhost
+    enabled: false
+    pinned: false
+status:
+    active_version: 16.3.0
+    backup_version: ""

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/no_systemd.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/no_systemd.golden
@@ -1,0 +1,9 @@
+version: v1
+kind: update_config
+spec:
+    proxy: localhost
+    enabled: false
+    pinned: false
+status:
+    active_version: 16.3.0
+    backup_version: ""

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -150,6 +150,9 @@ func NewLocalUpdater(cfg LocalUpdaterConfig) (*Updater, error) {
 		Revert: func(ctx context.Context) error {
 			return trace.Wrap(Setup(ctx, cfg.Log, cfg.LinkDir, cfg.DataDir))
 		},
+		Teardown: func(ctx context.Context) error {
+			return trace.Wrap(Teardown(ctx, cfg.Log, cfg.LinkDir, cfg.DataDir))
+		},
 	}, nil
 }
 
@@ -191,6 +194,8 @@ type Updater struct {
 	Setup func(ctx context.Context) error
 	// Revert installs the Teleport updater service using the running installation.
 	Revert func(ctx context.Context) error
+	// Teardown removes all traces of the updater and all managed installations.
+	Teardown func(ctx context.Context) error
 }
 
 // Installer provides an API for installing Teleport agents.
@@ -214,8 +219,11 @@ type Installer interface {
 	// Unlike LinkSystem, TryLinkSystem will fail if existing links to other locations are present.
 	// TryLinkSystem must be idempotent.
 	TryLinkSystem(ctx context.Context) error
+	// Unlink unlinks the specified version of Teleport from the linking locations.
+	// Unlink must be idempotent.
+	Unlink(ctx context.Context, version string) error
 	// UnlinkSystem unlinks the system (package) installation of Teleport from the linking locations.
-	// TryLinkSystem must be idempotent.
+	// UnlinkSystem must be idempotent.
 	UnlinkSystem(ctx context.Context) error
 	// List the installed versions of Teleport.
 	List(ctx context.Context) (versions []string, err error)
@@ -254,6 +262,10 @@ type Process interface {
 	// If the type implementing Process does not support the system process manager,
 	// Sync must return ErrNotSupported.
 	Sync(ctx context.Context) error
+	// IsEnabled must return true if the Process is running or is configured to run.
+	// If the type implementing Process does not support the system process manager,
+	// Sync must return ErrNotSupported.
+	IsEnabled(ctx context.Context) (bool, error)
 }
 
 // TODO(sclevine): add support for need_restart and selinux config
@@ -321,6 +333,109 @@ func (u *Updater) Install(ctx context.Context, override OverrideConfig) error {
 		return trace.Errorf("failed to write %s: %w", updateConfigName, err)
 	}
 	u.Log.InfoContext(ctx, "Configuration updated.")
+	return nil
+}
+
+// Remove removes everything created by the updater.
+// Before attempting this, Remove attempts to gracefully recover the system-packaged version of Teleport (if present).
+// This function is idempotent.
+func (u *Updater) Remove(ctx context.Context) error {
+	cfg, err := readConfig(u.ConfigPath)
+	if err != nil {
+		return trace.Errorf("failed to read %s: %w", updateConfigName, err)
+	}
+	if err := validateConfigSpec(&cfg.Spec, OverrideConfig{}); err != nil {
+		return trace.Wrap(err)
+	}
+	activeVersion := cfg.Status.ActiveVersion
+	if activeVersion == "" {
+		u.Log.InfoContext(ctx, "No installation of Teleport managed by the updater. Removing updater configuration.")
+		if err := u.Teardown(ctx); err != nil {
+			return trace.Wrap(err)
+		}
+		u.Log.InfoContext(ctx, "Auto-update configuration for Teleport successfully uninstalled.")
+	}
+
+	revert, err := u.Installer.LinkSystem(ctx)
+	if errors.Is(err, ErrNoBinaries) {
+		u.Log.InfoContext(ctx, "Updater-managed installation of Teleport detected. Attempting to unlink and remove.")
+		ok, err := u.Process.IsEnabled(ctx)
+		if err != nil && !errors.Is(err, ErrNotSupported) {
+			return trace.Wrap(err)
+		}
+		if ok {
+			return trace.Errorf("refusing to remove active installation of Teleport, please disable Teleport first")
+		}
+		if err := u.Installer.Unlink(ctx, activeVersion); err != nil {
+			return trace.Wrap(err)
+		}
+		u.Log.InfoContext(ctx, "Teleport uninstalled.", "version", activeVersion)
+		if err := u.Teardown(ctx); err != nil {
+			return trace.Wrap(err)
+		}
+		u.Log.InfoContext(ctx, "Auto-update configuration for Teleport successfully uninstalled.")
+	}
+	if err != nil {
+		return trace.Errorf("failed to link: %w", err)
+	}
+
+	u.Log.InfoContext(ctx, "Updater-managed installation of Teleport detected. Restoring packaged version of Teleport before removing.")
+
+	revertConfig := func(ctx context.Context) bool {
+		if ok := revert(ctx); !ok {
+			u.Log.ErrorContext(ctx, "Failed to revert Teleport symlinks. Installation likely broken.")
+			return false
+		}
+		if err := u.Process.Sync(ctx); err != nil {
+			u.Log.ErrorContext(ctx, "Failed to revert systemd configuration after failed restart.", errorKey, err)
+			return false
+		}
+		return true
+	}
+
+	// Sync systemd.
+
+	err = u.Process.Sync(ctx)
+	if errors.Is(err, ErrNotSupported) {
+		u.Log.WarnContext(ctx, "Not syncing systemd configuration because systemd is not running.")
+	} else if errors.Is(err, context.Canceled) {
+		return trace.Errorf("sync canceled")
+	} else if err != nil {
+		// If sync fails, we may have left the host in a bad state, so we revert linking and re-Sync.
+		u.Log.ErrorContext(ctx, "Reverting symlinks due to invalid configuration.")
+		if ok := revertConfig(ctx); ok {
+			u.Log.WarnContext(ctx, "Teleport updater encountered a configuration error and successfully reverted the installation.")
+		}
+		return trace.Errorf("failed to validate configuration for system package version of Teleport: %w", err)
+	}
+
+	// Restart Teleport.
+
+	u.Log.InfoContext(ctx, "Teleport package successfully restored.")
+	err = u.Process.Reload(ctx)
+	if errors.Is(err, context.Canceled) {
+		return trace.Errorf("reload canceled")
+	}
+	if err != nil &&
+		!errors.Is(err, ErrNotNeeded) && // no output if restart not needed
+		!errors.Is(err, ErrNotSupported) { // already logged above for Sync
+
+		// If reloading Teleport at the new version fails, revert and reload.
+		u.Log.ErrorContext(ctx, "Reverting symlinks due to failed restart.")
+		if ok := revertConfig(ctx); ok {
+			if err := u.Process.Reload(ctx); err != nil && !errors.Is(err, ErrNotNeeded) {
+				u.Log.ErrorContext(ctx, "Failed to reload Teleport after reverting. Installation likely broken.", errorKey, err)
+			} else {
+				u.Log.WarnContext(ctx, "Teleport updater encountered a configuration error and successfully reverted the installation.")
+			}
+		}
+		return trace.Errorf("failed to start system package version of Teleport: %w", err)
+	}
+	u.Log.InfoContext(ctx, "Auto-updating Teleport removed and replaced by Teleport packaged.", "version", activeVersion)
+	if err := u.Teardown(ctx); err != nil {
+		return trace.Wrap(err)
+	}
+	u.Log.InfoContext(ctx, "Auto-update configuration for Teleport successfully uninstalled.")
 	return nil
 }
 

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -240,6 +240,8 @@ var (
 	ErrNotNeeded = errors.New("not needed")
 	// ErrNotSupported is returned when the operation is not supported on the platform.
 	ErrNotSupported = errors.New("not supported on this platform")
+	// ErrNoBinaries is returned when no binaries are available to be linked.
+	ErrNoBinaries = errors.New("no binaries available to link")
 )
 
 const (

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -349,7 +349,6 @@ func (u *Updater) Remove(ctx context.Context) error {
 	}
 	activeVersion := cfg.Status.ActiveVersion
 	if activeVersion == "" {
-		// should we attempt TryLinkPackage here, just in case?
 		u.Log.InfoContext(ctx, "No installation of Teleport managed by the updater. Removing updater configuration.")
 		if err := u.Teardown(ctx); err != nil {
 			return trace.Wrap(err)

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -349,11 +349,13 @@ func (u *Updater) Remove(ctx context.Context) error {
 	}
 	activeVersion := cfg.Status.ActiveVersion
 	if activeVersion == "" {
+		// should we attempt TryLinkPackage here, just in case?
 		u.Log.InfoContext(ctx, "No installation of Teleport managed by the updater. Removing updater configuration.")
 		if err := u.Teardown(ctx); err != nil {
 			return trace.Wrap(err)
 		}
 		u.Log.InfoContext(ctx, "Auto-update configuration for Teleport successfully uninstalled.")
+		return nil
 	}
 
 	revert, err := u.Installer.LinkSystem(ctx)
@@ -374,6 +376,7 @@ func (u *Updater) Remove(ctx context.Context) error {
 			return trace.Wrap(err)
 		}
 		u.Log.InfoContext(ctx, "Auto-update configuration for Teleport successfully uninstalled.")
+		return nil
 	}
 	if err != nil {
 		return trace.Errorf("failed to link: %w", err)

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -428,7 +428,7 @@ func (u *Updater) Remove(ctx context.Context) error {
 			if err := u.Process.Reload(ctx); err != nil && !errors.Is(err, ErrNotNeeded) {
 				u.Log.ErrorContext(ctx, "Failed to reload Teleport after reverting. Installation likely broken.", errorKey, err)
 			} else {
-				u.Log.WarnContext(ctx, "Teleport updater encountered a configuration error and successfully reverted the installation.")
+				u.Log.WarnContext(ctx, "Teleport updater detected an error with the new installation and successfully reverted it.")
 			}
 		}
 		return trace.Errorf("failed to start system package version of Teleport: %w", err)
@@ -702,7 +702,7 @@ func (u *Updater) update(ctx context.Context, cfg *UpdateConfig, targetVersion s
 				if err := u.Process.Reload(ctx); err != nil && !errors.Is(err, ErrNotNeeded) {
 					u.Log.ErrorContext(ctx, "Failed to reload Teleport after reverting. Installation likely broken.", errorKey, err)
 				} else {
-					u.Log.WarnContext(ctx, "Teleport updater encountered a configuration error and successfully reverted the installation.")
+					u.Log.WarnContext(ctx, "Teleport updater detected an error with the new installation and successfully reverted it.")
 				}
 			}
 			return trace.Errorf("failed to start new version %q of Teleport: %w", targetVersion, err)

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -353,7 +353,7 @@ func (u *Updater) Remove(ctx context.Context) error {
 		if err := u.Teardown(ctx); err != nil {
 			return trace.Wrap(err)
 		}
-		u.Log.InfoContext(ctx, "Auto-update configuration for Teleport successfully uninstalled.")
+		u.Log.InfoContext(ctx, "Automatic update configuration for Teleport successfully uninstalled.")
 		return nil
 	}
 
@@ -374,7 +374,7 @@ func (u *Updater) Remove(ctx context.Context) error {
 		if err := u.Teardown(ctx); err != nil {
 			return trace.Wrap(err)
 		}
-		u.Log.InfoContext(ctx, "Auto-update configuration for Teleport successfully uninstalled.")
+		u.Log.InfoContext(ctx, "Automatic update configuration for Teleport successfully uninstalled.")
 		return nil
 	}
 	if err != nil {
@@ -741,14 +741,18 @@ func (u *Updater) LinkPackage(ctx context.Context) error {
 	}
 	activeVersion := cfg.Status.ActiveVersion
 	if cfg.Spec.Enabled {
-		u.Log.InfoContext(ctx, "Automatic updates enabled. Skipping system package link.", activeVersionKey, activeVersion)
+		u.Log.InfoContext(ctx, "Automatic updates is enabled. Skipping system package link.", activeVersionKey, activeVersion)
+		return nil
+	}
+	if cfg.Spec.Pinned {
+		u.Log.InfoContext(ctx, "Automatic update version is pinned. Skipping system package link.", activeVersionKey, activeVersion)
 		return nil
 	}
 	// If an active version is set, but auto-updates is disabled, try to link the system installation in case the config is stale.
 	// If any links are present, this will return ErrLinked and not create any system links.
 	// This state is important to log as a warning,
 	if err := u.Installer.TryLinkSystem(ctx); errors.Is(err, ErrLinked) {
-		u.Log.WarnContext(ctx, "Automatic updates disabled, but a non-package version of Teleport is linked.", activeVersionKey, activeVersion)
+		u.Log.WarnContext(ctx, "Automatic updates is disabled, but a non-package version of Teleport is linked.", activeVersionKey, activeVersion)
 		return nil
 	} else if err != nil {
 		return trace.Errorf("failed to link system package installation: %w", err)

--- a/lib/autoupdate/agent/updater_test.go
+++ b/lib/autoupdate/agent/updater_test.go
@@ -669,6 +669,19 @@ func TestUpdater_LinkPackage(t *testing.T) {
 			syncCalls:          0,
 		},
 		{
+			name: "pinned",
+			cfg: &UpdateConfig{
+				Version: updateConfigVersion,
+				Kind:    updateConfigKind,
+				Spec: UpdateSpec{
+					Pinned: true,
+				},
+			},
+
+			tryLinkSystemCalls: 0,
+			syncCalls:          0,
+		},
+		{
 			name: "updates disabled",
 			cfg: &UpdateConfig{
 				Version: updateConfigVersion,

--- a/lib/autoupdate/agent/updater_test.go
+++ b/lib/autoupdate/agent/updater_test.go
@@ -765,6 +765,244 @@ func TestUpdater_LinkPackage(t *testing.T) {
 	}
 }
 
+func TestUpdater_Remove(t *testing.T) {
+	t.Parallel()
+
+	const version = "active-version"
+
+	tests := []struct {
+		name           string
+		cfg            *UpdateConfig // nil -> file not present
+		linkSystemErr  error
+		isEnabledErr   error
+		syncErr        error
+		reloadErr      error
+		processEnabled bool
+
+		unlinkedVersion string
+		teardownCalls   int
+		syncCalls       int
+		revertFuncCalls int
+		linkSystemCalls int
+		reloadCalls     int
+		errMatch        string
+	}{
+		{
+			name: "no config",
+			cfg: &UpdateConfig{
+				Version: updateConfigVersion,
+				Kind:    updateConfigKind,
+				Status: UpdateStatus{
+					ActiveVersion: "",
+				},
+			},
+			teardownCalls: 1,
+		},
+		{
+			name: "no active version",
+			cfg: &UpdateConfig{
+				Version: updateConfigVersion,
+				Kind:    updateConfigKind,
+			},
+			teardownCalls: 1,
+		},
+		{
+			name: "no system links, process enabled",
+			cfg: &UpdateConfig{
+				Version: updateConfigVersion,
+				Kind:    updateConfigKind,
+				Status: UpdateStatus{
+					ActiveVersion: version,
+				},
+			},
+			linkSystemErr:   ErrNoBinaries,
+			linkSystemCalls: 1,
+			processEnabled:  true,
+			errMatch:        "refusing to remove",
+		},
+		{
+			name: "no system links, process disabled",
+			cfg: &UpdateConfig{
+				Version: updateConfigVersion,
+				Kind:    updateConfigKind,
+				Status: UpdateStatus{
+					ActiveVersion: version,
+				},
+			},
+			linkSystemErr:   ErrNoBinaries,
+			linkSystemCalls: 1,
+			unlinkedVersion: version,
+			teardownCalls:   1,
+		},
+		{
+			name: "no system links, process disabled, no systemd",
+			cfg: &UpdateConfig{
+				Version: updateConfigVersion,
+				Kind:    updateConfigKind,
+				Status: UpdateStatus{
+					ActiveVersion: version,
+				},
+			},
+			linkSystemErr:   ErrNoBinaries,
+			linkSystemCalls: 1,
+			isEnabledErr:    ErrNotSupported,
+			unlinkedVersion: version,
+			teardownCalls:   1,
+		},
+		{
+			name: "active version",
+			cfg: &UpdateConfig{
+				Version: updateConfigVersion,
+				Kind:    updateConfigKind,
+				Status: UpdateStatus{
+					ActiveVersion: version,
+				},
+			},
+			linkSystemCalls: 1,
+			syncCalls:       1,
+			reloadCalls:     1,
+			teardownCalls:   1,
+		},
+		{
+			name: "active version, no systemd",
+			cfg: &UpdateConfig{
+				Version: updateConfigVersion,
+				Kind:    updateConfigKind,
+				Status: UpdateStatus{
+					ActiveVersion: version,
+				},
+			},
+			linkSystemCalls: 1,
+			syncCalls:       1,
+			reloadCalls:     1,
+			teardownCalls:   1,
+			syncErr:         ErrNotSupported,
+			reloadErr:       ErrNotSupported,
+		},
+		{
+			name: "active version, no reload",
+			cfg: &UpdateConfig{
+				Version: updateConfigVersion,
+				Kind:    updateConfigKind,
+				Status: UpdateStatus{
+					ActiveVersion: version,
+				},
+			},
+			linkSystemCalls: 1,
+			syncCalls:       1,
+			reloadCalls:     1,
+			teardownCalls:   1,
+			reloadErr:       ErrNotNeeded,
+		},
+		{
+			name: "active version, sync error",
+			cfg: &UpdateConfig{
+				Version: updateConfigVersion,
+				Kind:    updateConfigKind,
+				Status: UpdateStatus{
+					ActiveVersion: version,
+				},
+			},
+			linkSystemCalls: 1,
+			syncCalls:       2,
+			revertFuncCalls: 1,
+			syncErr:         errors.New("sync error"),
+			errMatch:        "configuration",
+		},
+		{
+			name: "active version, reload error",
+			cfg: &UpdateConfig{
+				Version: updateConfigVersion,
+				Kind:    updateConfigKind,
+				Status: UpdateStatus{
+					ActiveVersion: version,
+				},
+			},
+			linkSystemCalls: 1,
+			syncCalls:       2,
+			reloadCalls:     2,
+			revertFuncCalls: 1,
+			reloadErr:       errors.New("reload error"),
+			errMatch:        "start",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			cfgPath := filepath.Join(dir, VersionsDirName, "update.yaml")
+
+			updater, err := NewLocalUpdater(LocalUpdaterConfig{
+				InsecureSkipVerify: true,
+				DataDir:            dir,
+			})
+			require.NoError(t, err)
+
+			// Create config file only if provided in test case
+			if tt.cfg != nil {
+				b, err := yaml.Marshal(tt.cfg)
+				require.NoError(t, err)
+				err = os.WriteFile(cfgPath, b, 0600)
+				require.NoError(t, err)
+			}
+
+			var (
+				linkSystemCalls int
+				revertFuncCalls int
+				syncCalls       int
+				reloadCalls     int
+				teardownCalls   int
+				unlinkedVersion string
+			)
+			updater.Installer = &testInstaller{
+				FuncLinkSystem: func(_ context.Context) (revert func(context.Context) bool, err error) {
+					linkSystemCalls++
+					return func(_ context.Context) bool {
+						revertFuncCalls++
+						return true
+					}, tt.linkSystemErr
+				},
+				FuncUnlink: func(_ context.Context, version string) error {
+					unlinkedVersion = version
+					return nil
+				},
+			}
+			updater.Process = &testProcess{
+				FuncSync: func(_ context.Context) error {
+					syncCalls++
+					return tt.syncErr
+				},
+				FuncReload: func(_ context.Context) error {
+					reloadCalls++
+					return tt.reloadErr
+				},
+				FuncIsEnabled: func(_ context.Context) (bool, error) {
+					return tt.processEnabled, tt.isEnabledErr
+				},
+			}
+			updater.Teardown = func(_ context.Context) error {
+				teardownCalls++
+				return nil
+			}
+
+			ctx := context.Background()
+			err = updater.Remove(ctx)
+			if tt.errMatch != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMatch)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.syncCalls, syncCalls)
+			require.Equal(t, tt.reloadCalls, reloadCalls)
+			require.Equal(t, tt.linkSystemCalls, linkSystemCalls)
+			require.Equal(t, tt.revertFuncCalls, revertFuncCalls)
+			require.Equal(t, tt.unlinkedVersion, unlinkedVersion)
+			require.Equal(t, tt.teardownCalls, teardownCalls)
+		})
+	}
+}
+
 func TestUpdater_Install(t *testing.T) {
 	t.Parallel()
 
@@ -995,6 +1233,27 @@ func TestUpdater_Install(t *testing.T) {
 			setupCalls:        1,
 			errMatch:          "reload error",
 		},
+		{
+			name:      "no systemd",
+			reloadErr: ErrNotSupported,
+			setupErr:  ErrNotSupported,
+
+			installedVersion:  "16.3.0",
+			installedTemplate: cdnURITemplate,
+			linkedVersion:     "16.3.0",
+			reloadCalls:       1,
+			setupCalls:        1,
+		},
+		{
+			name:      "no need to reload",
+			reloadErr: ErrNotNeeded,
+
+			installedVersion:  "16.3.0",
+			installedTemplate: cdnURITemplate,
+			linkedVersion:     "16.3.0",
+			reloadCalls:       1,
+			setupCalls:        1,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1135,6 +1394,7 @@ type testInstaller struct {
 	FuncLinkSystem    func(ctx context.Context) (revert func(context.Context) bool, err error)
 	FuncTryLink       func(ctx context.Context, version string) error
 	FuncTryLinkSystem func(ctx context.Context) error
+	FuncUnlink        func(ctx context.Context, version string) error
 	FuncUnlinkSystem  func(ctx context.Context) error
 	FuncList          func(ctx context.Context) (versions []string, err error)
 }
@@ -1163,6 +1423,10 @@ func (ti *testInstaller) TryLinkSystem(ctx context.Context) error {
 	return ti.FuncTryLinkSystem(ctx)
 }
 
+func (ti *testInstaller) Unlink(ctx context.Context, version string) error {
+	return ti.FuncUnlink(ctx, version)
+}
+
 func (ti *testInstaller) UnlinkSystem(ctx context.Context) error {
 	return ti.FuncUnlinkSystem(ctx)
 }
@@ -1172,8 +1436,9 @@ func (ti *testInstaller) List(ctx context.Context) (versions []string, err error
 }
 
 type testProcess struct {
-	FuncReload func(ctx context.Context) error
-	FuncSync   func(ctx context.Context) error
+	FuncReload    func(ctx context.Context) error
+	FuncSync      func(ctx context.Context) error
+	FuncIsEnabled func(ctx context.Context) (bool, error)
 }
 
 func (tp *testProcess) Reload(ctx context.Context) error {
@@ -1182,4 +1447,8 @@ func (tp *testProcess) Reload(ctx context.Context) error {
 
 func (tp *testProcess) Sync(ctx context.Context) error {
 	return tp.FuncSync(ctx)
+}
+
+func (tp *testProcess) IsEnabled(ctx context.Context) (bool, error) {
+	return tp.FuncIsEnabled(ctx)
 }


### PR DESCRIPTION
This PR implements the `teleport-update uninstall` subcommand. This command allows a user to fully disable and remove auto-updates. This includes unlinking and removing all non-packaged versions, and removing all auto-update-related configuration and systemd services.

Notably, if an updater-managed Teleport service is enabled and/or running, and the Teleport system package is installed, `teleport-update uninstall` attempts to gracefully migrate your system back to the packaged version without dropping connections. This ensures that users who discover that they cannot use auto-updates have a painless way to revert.

---

The `teleport-update` binary will be used to enable, disable, and trigger automatic Teleport agent updates. The new auto-updates system manages a local installation of the cluster-specified version of Teleport stored in `/var/lib/teleport/versions`.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/10289

Example (success)

```shell
ubuntu@legendary-mite:~$ sudo ./teleport-update uninstall
2024-11-22T00:16:25Z INFO [UPDATER]   Updater-managed installation of Teleport detected. Restoring system package version of Teleport before removing. agent/updater.go:375
2024-11-22T00:16:26Z INFO [UPDATER]   Systemd configuration synced. unit:teleport.service agent/process.go:260
2024-11-22T00:16:26Z INFO [UPDATER]   Teleport package successfully restored. agent/updater.go:407
2024-11-22T00:16:26Z INFO [UPDATER]   Gracefully reloaded. unit:teleport.service agent/process.go:111
2024-11-22T00:16:26Z INFO [UPDATER]   Monitoring PID file to detect crashes. unit:teleport.service agent/process.go:114
2024-11-22T00:16:40Z INFO [UPDATER]   Service disabled. unit:teleport-update.timer agent/process.go:290
2024-11-22T00:16:40Z INFO [UPDATER]   Systemd configuration synced. unit:teleport-update.timer agent/process.go:260
```

Example (messy revert)

```shell
ubuntu@legendary-mite:~$ sudo ./teleport-update uninstall
2024-11-22T00:12:48Z INFO [UPDATER]   Updater-managed installation of Teleport detected. Restoring system package version of Teleport before removing. agent/updater.go:375
2024-11-22T00:12:48Z INFO [UPDATER]   Systemd configuration synced. unit:teleport.service agent/process.go:260
2024-11-22T00:12:48Z INFO [UPDATER]   Teleport package successfully restored. agent/updater.go:407
2024-11-22T00:12:49Z INFO [UPDATER]   Gracefully reloaded. unit:teleport.service agent/process.go:111
2024-11-22T00:12:49Z INFO [UPDATER]   Monitoring PID file to detect crashes. unit:teleport.service agent/process.go:114
2024-11-22T00:12:53Z WARN [UPDATER]   Detected stale PID. unit:teleport.service pid:3212913 agent/process.go:200
2024-11-22T00:12:59Z ERRO [UPDATER]   Reverting symlinks due to failed restart. agent/updater.go:417
2024-11-22T00:12:59Z INFO [UPDATER]   Systemd configuration synced. unit:teleport.service agent/process.go:260
2024-11-22T00:12:59Z ERRO [UPDATER]   [stderr] Job for teleport.service failed. agent/process.go:393
2024-11-22T00:12:59Z ERRO [UPDATER]   [stderr] See "systemctl status teleport.service" and "journalctl -xeu teleport.service" for details. agent/process.go:393
2024-11-22T00:12:59Z ERRO [UPDATER]   Error running systemctl. args:[reload teleport.service] code:1 agent/process.go:340
2024-11-22T00:12:59Z WARN [UPDATER]   Service ungracefully restarted. Connections potentially dropped. unit:teleport.service agent/process.go:109
2024-11-22T00:12:59Z INFO [UPDATER]   Monitoring PID file to detect crashes. unit:teleport.service agent/process.go:114
2024-11-22T00:13:13Z WARN [UPDATER]   Teleport updater detected an error with the new installation and successfully reverted it. agent/updater.go:422
ERROR: failed to start system package version of Teleport: detected crashing process
```
