### PR TITLE
[v17] [web] update user participants for k8s non-interactive in recorded sessions

### DIFF
--- a/web/packages/teleport/src/services/recordings/makeRecording.ts
+++ b/web/packages/teleport/src/services/recordings/makeRecording.ts
@@ -66,7 +66,7 @@ function makeDesktopRecording({
 
 function makeSshOrKubeRecording({
   participants,
-  kubernetes_users,
+  user,
   time,
   session_start,
   session_stop,
@@ -90,8 +90,8 @@ function makeSshOrKubeRecording({
   // For Kubernetes sessions, put the full pod name as 'hostname'.
   if (proto === 'kube') {
     hostname = `${kubernetes_cluster}/${kubernetes_pod_namespace}/${kubernetes_pod_name}`;
-    // For non-interactive k8s sessions the user participants are in kubernetes_users
-    if (!interactive) userParticipants = kubernetes_users;
+    // For non-interactive k8s sessions the participant is the Teleport user running the command
+    if (!interactive) userParticipants = [user];
   }
 
   // Description set to play for interactive so users can search by "play".

--- a/web/packages/teleport/src/services/recordings/makeRecording.ts
+++ b/web/packages/teleport/src/services/recordings/makeRecording.ts
@@ -85,7 +85,7 @@ function makeSshOrKubeRecording({
   );
 
   let hostname = server_hostname || 'N/A';
-  // SSH interactive/non-interactive and k8s interative sessions user participants are in the participants field.
+  // SSH interactive/non-interactive and k8s interactive sessions user participants are in the participants field.
   let userParticipants = participants;
   // For Kubernetes sessions, put the full pod name as 'hostname'.
   if (proto === 'kube') {

--- a/web/packages/teleport/src/services/recordings/makeRecording.ts
+++ b/web/packages/teleport/src/services/recordings/makeRecording.ts
@@ -66,6 +66,7 @@ function makeDesktopRecording({
 
 function makeSshOrKubeRecording({
   participants,
+  kubernetes_users,
   time,
   session_start,
   session_stop,
@@ -84,9 +85,13 @@ function makeSshOrKubeRecording({
   );
 
   let hostname = server_hostname || 'N/A';
+  // SSH interactive/non-interactive and k8s interative sessions user participants are in the participants field.
+  let userParticipants = participants;
   // For Kubernetes sessions, put the full pod name as 'hostname'.
   if (proto === 'kube') {
     hostname = `${kubernetes_cluster}/${kubernetes_pod_namespace}/${kubernetes_pod_name}`;
+    // For non-interactive k8s sessions the user participants are in kubernetes_users
+    if (!interactive) userParticipants = kubernetes_users;
   }
 
   // Description set to play for interactive so users can search by "play".
@@ -101,7 +106,7 @@ function makeSshOrKubeRecording({
     durationText,
     sid,
     createdDate: new Date(time),
-    users: participants ? participants.join(', ') : [],
+    users: userParticipants ? userParticipants.join(', ') : [],
     hostname,
     description,
     recordingType: kubernetes_cluster ? 'k8s' : 'ssh',

--- a/web/packages/teleport/src/services/recordings/recordings.test.ts
+++ b/web/packages/teleport/src/services/recordings/recordings.test.ts
@@ -51,7 +51,7 @@ test('fetch session recordings, response formatting', async () => {
         playable: false,
         recordingType: 'k8s',
         sid: '456b933c-4ec4-59f1-862c-90ca9f7648b1',
-        users: 'wov@esde.ro',
+        users: 'onuweeme@wiuke.mh',
       },
     ],
     startKey: '',

--- a/web/packages/teleport/src/services/recordings/recordings.test.ts
+++ b/web/packages/teleport/src/services/recordings/recordings.test.ts
@@ -51,7 +51,7 @@ test('fetch session recordings, response formatting', async () => {
         playable: false,
         recordingType: 'k8s',
         sid: '456b933c-4ec4-59f1-862c-90ca9f7648b1',
-        users: [],
+        users: 'wov@esde.ro',
       },
     ],
     startKey: '',


### PR DESCRIPTION
Backport #49257 to branch/v17

changelog: Fixed missing user participants in session recordings listing for non-interactive Kubernetes recordings.
