### PR TITLE
[v16] Refresh resources after dropping an access request

### DIFF
--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/useAssumedRolesBar.test.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/useAssumedRolesBar.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useEffect } from 'react';
+import { renderHook, act } from '@testing-library/react';
+
+import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
+import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
+import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
+import {
+  ResourcesContextProvider,
+  useResourcesContext,
+} from 'teleterm/ui/DocumentCluster/resourcesContext';
+import { RootClusterUri } from 'teleterm/ui/uri';
+
+import { useAssumedRolesBar } from './useAssumedRolesBar';
+
+test('dropping a request refreshes resources', async () => {
+  const appContext = new MockAppContext();
+  const cluster = makeRootCluster();
+  appContext.workspacesService.setState(draftState => {
+    draftState.rootClusterUri = cluster.uri;
+    draftState.workspaces[cluster.uri] = {
+      localClusterUri: cluster.uri,
+      documents: [],
+      location: undefined,
+      accessRequests: undefined,
+    };
+  });
+  jest.spyOn(appContext.clustersService, 'dropRoles');
+  const refreshListener = jest.fn();
+
+  const wrapper = ({ children }) => (
+    <MockAppContextProvider appContext={appContext}>
+      <ResourcesContextProvider>
+        <RequestRefreshSubscriber
+          rootClusterUri={cluster.uri}
+          onResourcesRefreshRequest={refreshListener}
+        />
+        {children}
+      </ResourcesContextProvider>
+    </MockAppContextProvider>
+  );
+
+  const { result } = renderHook(
+    () =>
+      useAssumedRolesBar({
+        roles: [],
+        id: 'mocked-request-id',
+        expires: new Date(),
+      }),
+    { wrapper }
+  );
+
+  await act(() => result.current.dropRequest());
+  expect(appContext.clustersService.dropRoles).toHaveBeenCalledTimes(1);
+  expect(appContext.clustersService.dropRoles).toHaveBeenCalledWith(
+    cluster.uri,
+    ['mocked-request-id']
+  );
+  expect(refreshListener).toHaveBeenCalledTimes(1);
+});
+
+function RequestRefreshSubscriber(props: {
+  rootClusterUri: RootClusterUri;
+  onResourcesRefreshRequest: () => void;
+}) {
+  const { onResourcesRefreshRequest } = useResourcesContext(
+    props.rootClusterUri
+  );
+  useEffect(() => {
+    onResourcesRefreshRequest(props.onResourcesRefreshRequest);
+  }, [onResourcesRefreshRequest, props.onResourcesRefreshRequest]);
+
+  return null;
+}

--- a/web/packages/teleterm/src/ui/App.tsx
+++ b/web/packages/teleterm/src/ui/App.tsx
@@ -29,6 +29,7 @@ import AppContext from './appContext';
 import { ThemeProvider } from './ThemeProvider';
 import { VnetContextProvider } from './Vnet/vnetContext';
 import { ConnectionsContextProvider } from './TopBar/Connections/connectionsContext';
+import { ResourcesContextProvider } from './DocumentCluster/resourcesContext';
 
 export const App: React.FC<{ ctx: AppContext }> = ({ ctx }) => {
   return (
@@ -36,13 +37,15 @@ export const App: React.FC<{ ctx: AppContext }> = ({ ctx }) => {
       <StyledApp>
         <DndProvider backend={HTML5Backend}>
           <AppContextProvider value={ctx}>
-            <ConnectionsContextProvider>
-              <VnetContextProvider>
-                <ThemeProvider>
-                  <AppInitializer />
-                </ThemeProvider>
-              </VnetContextProvider>
-            </ConnectionsContextProvider>
+            <ResourcesContextProvider>
+              <ConnectionsContextProvider>
+                <VnetContextProvider>
+                  <ThemeProvider>
+                    <AppInitializer />
+                  </ThemeProvider>
+                </VnetContextProvider>
+              </ConnectionsContextProvider>
+            </ResourcesContextProvider>
           </AppContextProvider>
         </DndProvider>
       </StyledApp>

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Setup.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Setup.tsx
@@ -212,7 +212,7 @@ function AgentSetup() {
     setDownloadAgentAttempt,
     agentProcessState,
   } = useConnectMyComputerContext();
-  const { requestResourcesRefresh } = useResourcesContext();
+  const { requestResourcesRefresh } = useResourcesContext(rootClusterUri);
   const rootCluster = ctx.clustersService.findCluster(rootClusterUri);
 
   // The verify agent step checks if we can execute the binary. This triggers OS-level checks, such
@@ -281,8 +281,8 @@ function AgentSetup() {
           throw error;
         }
 
-        // Now that the node has joined the server, let's refresh all open DocumentCluster instances
-        // to show the new node.
+        // Now that the node has joined the server, let's refresh open DocumentCluster
+        // instances in the workspace to show the new node.
         requestResourcesRefresh();
       }, [startAgent, requestResourcesRefresh])
     );

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.tsx
@@ -131,7 +131,7 @@ export const ConnectMyComputerContextProvider: FC<
     workspacesService,
     usageService,
   } = ctx;
-  const { requestResourcesRefresh } = useResourcesContext();
+  const { requestResourcesRefresh } = useResourcesContext(rootClusterUri);
   clustersService.useState();
 
   const [

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/RequestList/RequestList.tsx
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/RequestList/RequestList.tsx
@@ -163,7 +163,7 @@ const renderActionCell = (
           onClick={() => assumeRole(request)}
           width="108px"
         >
-          {flags.isAssumed ? 'assumed' : 'assume roles'}
+          {flags.isAssumed ? 'Assumed' : 'Assume Roles'}
         </ButtonPrimary>
       );
     } else {

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/useAssumeAccess.ts
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/useAssumeAccess.ts
@@ -30,12 +30,12 @@ export function useAssumeAccess() {
     rootClusterUri,
     documentsService,
   } = useWorkspaceContext();
-  const { requestResourcesRefresh } = useResourcesContext();
+  const { requestResourcesRefresh } = useResourcesContext(rootClusterUri);
 
   const [assumeRoleAttempt, runAssumeRole] = useAsync((requestId: string) =>
     retryWithRelogin(ctx, clusterUri, async () => {
       await ctx.clustersService.assumeRoles(rootClusterUri, [requestId]);
-      // refresh the current resource tabs
+      // Refresh the current resource tabs in the workspace.
       requestResourcesRefresh();
     })
   );
@@ -58,7 +58,7 @@ export function useAssumeAccess() {
       return;
     }
 
-    // refresh the current resource tabs
+    // Refresh the current resource tabs in the workspace.
     requestResourcesRefresh();
 
     // open new cluster tab

--- a/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.test.tsx
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { useImperativeHandle, forwardRef, createRef } from 'react';
 import { render, screen } from 'design/utils/testing';
 import { mockIntersectionObserver } from 'jsdom-testing-mocks';
 import { act } from '@testing-library/react';
@@ -30,7 +31,10 @@ import { ShowResources } from 'gen-proto-ts/teleport/lib/teleterm/v1/cluster_pb'
 
 import { UnifiedResources } from 'teleterm/ui/DocumentCluster/UnifiedResources';
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
-import { ResourcesContextProvider } from 'teleterm/ui/DocumentCluster/resourcesContext';
+import {
+  ResourcesContextProvider,
+  useResourcesContext,
+} from 'teleterm/ui/DocumentCluster/resourcesContext';
 import { ConnectMyComputerContextProvider } from 'teleterm/ui/ConnectMyComputer';
 import { MockWorkspaceContextProvider } from 'teleterm/ui/fixtures/MockWorkspaceContextProvider';
 import { makeDocumentCluster } from 'teleterm/ui/services/workspacesService/documentsService/testHelpers';
@@ -38,14 +42,15 @@ import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import {
   makeRootCluster,
   rootClusterUri,
+  makeServer,
 } from 'teleterm/services/tshd/testHelpers';
 import { getEmptyPendingAccessRequest } from 'teleterm/ui/services/workspacesService/accessRequestsService';
-
 import { MockedUnaryCall } from 'teleterm/services/tshd/cloneableClient';
+import * as uri from 'teleterm/ui/uri';
 
 const mio = mockIntersectionObserver();
 
-const tests = [
+test.each([
   {
     name: 'fetches only available resources if cluster does not support access requests',
     conditions: {
@@ -166,9 +171,7 @@ const tests = [
       includeRequestable: false,
     },
   },
-];
-
-test.each(tests)('$name', async testCase => {
+])('$name', async testCase => {
   const doc = makeDocumentCluster();
 
   const appContext = new MockAppContext({ platform: 'darwin' });
@@ -269,4 +272,120 @@ test.each(tests)('$name', async testCase => {
     },
     new AbortController().signal
   );
+});
+
+test.each([
+  {
+    name: 'refreshes resources when the document cluster URI matches the requested cluster URI',
+    conditions: {
+      documentClusterUri: '/clusters/teleport-local',
+    },
+    expect: {
+      resourcesRefreshed: true,
+    },
+  },
+  {
+    name: 'refreshes resources when the document cluster URI is a leaf of the requested cluster URI',
+    conditions: {
+      documentClusterUri: '/clusters/teleport-local/leaves/leaf',
+    },
+    expect: {
+      resourcesRefreshed: true,
+    },
+  },
+])('$name', async testCase => {
+  const doc = makeDocumentCluster({
+    clusterUri: testCase.conditions.documentClusterUri,
+  });
+  const rootCluster = makeRootCluster({
+    uri: uri.routing.ensureRootClusterUri(doc.clusterUri),
+  });
+  const serverResource = makeServer();
+  const appContext = new MockAppContext();
+  appContext.clustersService.setState(draft => {
+    draft.clusters.set(rootCluster.uri, rootCluster);
+  });
+
+  appContext.workspacesService.setState(draftState => {
+    draftState.rootClusterUri = rootCluster.uri;
+    draftState.workspaces[rootCluster.uri] = {
+      localClusterUri: rootCluster.uri,
+      documents: [doc],
+      location: doc.uri,
+      accessRequests: {
+        pending: getEmptyPendingAccessRequest(),
+        isBarCollapsed: true,
+      },
+    };
+  });
+
+  jest
+    .spyOn(appContext.resourcesService, 'listUnifiedResources')
+    .mockResolvedValue({
+      resources: [
+        {
+          kind: 'server',
+          resource: serverResource,
+          requiresRequest: false,
+        },
+      ],
+      nextKey: '',
+    });
+
+  const ref = createRef<{
+    requestResourcesRefresh: () => void;
+  }>();
+
+  render(
+    <MockAppContextProvider appContext={appContext}>
+      <MockWorkspaceContextProvider>
+        <ResourcesContextProvider>
+          <ConnectMyComputerContextProvider rootClusterUri={rootCluster.uri}>
+            <Refresher ref={ref} rootClusterUri={rootCluster.uri} />
+            <UnifiedResources
+              clusterUri={doc.clusterUri}
+              docUri={doc.uri}
+              queryParams={doc.queryParams}
+            />
+          </ConnectMyComputerContextProvider>
+        </ResourcesContextProvider>
+      </MockWorkspaceContextProvider>
+    </MockAppContextProvider>
+  );
+
+  act(mio.enterAll);
+
+  // Wait for resources to render.
+  await expect(
+    screen.findByText(serverResource.hostname)
+  ).resolves.toBeInTheDocument();
+  expect(
+    appContext.resourcesService.listUnifiedResources
+  ).toHaveBeenCalledTimes(1);
+
+  act(() => ref.current.requestResourcesRefresh());
+
+  // Wait for resources to (potentially) re-render.
+  await expect(
+    screen.findByText(serverResource.hostname)
+  ).resolves.toBeInTheDocument();
+  expect(
+    appContext.resourcesService.listUnifiedResources
+    // When resources are refreshed, we have two calls to the API.
+  ).toHaveBeenCalledTimes(testCase.expect.resourcesRefreshed ? 2 : 1);
+});
+
+const Refresher = forwardRef<
+  {
+    requestResourcesRefresh: () => void;
+  },
+  {
+    rootClusterUri: uri.RootClusterUri;
+  }
+>((props, ref) => {
+  const resourcesContext = useResourcesContext(props.rootClusterUri);
+  useImperativeHandle(ref, () => ({
+    requestResourcesRefresh: resourcesContext.requestResourcesRefresh,
+  }));
+  return null;
 });

--- a/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
@@ -74,7 +74,7 @@ import {
   ConnectAppActionButton,
   AccessRequestButton,
 } from './ActionButtons';
-import { useResourcesContext, ResourcesContext } from './resourcesContext';
+import { useResourcesContext } from './resourcesContext';
 import { useUserPreferences } from './useUserPreferences';
 
 export function UnifiedResources(props: {
@@ -102,7 +102,7 @@ export function UnifiedResources(props: {
       [rootClusterUri]
     )
   );
-  const { onResourcesRefreshRequest } = useResourcesContext();
+  const { onResourcesRefreshRequest } = useResourcesContext(rootClusterUri);
   const loggedInUser = useWorkspaceLoggedInUser();
 
   const { unifiedResourcePreferences } = userPreferences;
@@ -263,7 +263,7 @@ const Resources = memo(
     canAddResources: boolean;
     canUseConnectMyComputer: boolean;
     openConnectMyComputerDocument(): void;
-    onResourcesRefreshRequest: ResourcesContext['onResourcesRefreshRequest'];
+    onResourcesRefreshRequest(listener: () => void): { cleanup(): void };
     discoverUrl: string;
     getAccessRequestButton: (resource: UnifiedResourceResponse) => JSX.Element;
     getAddedItemsCount: () => number;
@@ -329,7 +329,7 @@ const Resources = memo(
     const { onResourcesRefreshRequest } = props;
     useEffect(() => {
       const { cleanup } = onResourcesRefreshRequest(() => {
-        fetch({ clear: true });
+        void fetch({ clear: true });
       });
       return cleanup;
     }, [onResourcesRefreshRequest, fetch]);

--- a/web/packages/teleterm/src/ui/DocumentCluster/resourcesContext.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/resourcesContext.test.tsx
@@ -19,6 +19,8 @@
 import React from 'react';
 import { renderHook } from '@testing-library/react';
 
+import { rootClusterUri } from 'teleterm/services/tshd/testHelpers';
+
 import {
   ResourcesContextProvider,
   useResourcesContext,
@@ -29,13 +31,28 @@ describe('requestResourcesRefresh', () => {
     const wrapper = ({ children }) => (
       <ResourcesContextProvider>{children}</ResourcesContextProvider>
     );
-    const { result } = renderHook(() => useResourcesContext(), { wrapper });
+    const { result } = renderHook(
+      () => ({
+        clusterUri1: useResourcesContext('/clusters/teleport-local'),
+        clusterUri2: useResourcesContext('/clusters/teleport-remote'),
+      }),
+      {
+        wrapper,
+      }
+    );
 
-    const listener = jest.fn();
-    result.current.onResourcesRefreshRequest(listener);
-    result.current.requestResourcesRefresh();
+    const listener1 = jest.fn();
+    const listener2 = jest.fn();
+    result.current.clusterUri1.onResourcesRefreshRequest(listener1);
+    result.current.clusterUri2.onResourcesRefreshRequest(listener2);
 
-    expect(listener).toHaveBeenCalledTimes(1);
+    result.current.clusterUri1.requestResourcesRefresh();
+    expect(listener1).toHaveBeenCalledTimes(1);
+    expect(listener2).not.toHaveBeenCalled();
+
+    result.current.clusterUri2.requestResourcesRefresh();
+    expect(listener1).toHaveBeenCalledTimes(1); // it has not been called again
+    expect(listener2).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -44,7 +61,9 @@ describe('onResourcesRefreshRequest cleanup function', () => {
     const wrapper = ({ children }) => (
       <ResourcesContextProvider>{children}</ResourcesContextProvider>
     );
-    const { result } = renderHook(() => useResourcesContext(), { wrapper });
+    const { result } = renderHook(() => useResourcesContext(rootClusterUri), {
+      wrapper,
+    });
 
     const listener = jest.fn();
     const { cleanup } = result.current.onResourcesRefreshRequest(listener);

--- a/web/packages/teleterm/src/ui/DocumentCluster/resourcesContext.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/resourcesContext.tsx
@@ -18,7 +18,7 @@
 
 import { EventEmitter } from 'events';
 
-import React, {
+import {
   createContext,
   FC,
   PropsWithChildren,
@@ -27,20 +27,28 @@ import React, {
   useRef,
 } from 'react';
 
+import { RootClusterUri } from 'teleterm/ui/uri';
+
 export interface ResourcesContext {
   /**
-   * requestResourcesRefresh makes all DocumentCluster instances within the workspace refresh the
-   * resource list with current filters.
+   * requestResourcesRefresh makes all DocumentCluster instances within the workspace
+   * (specified by `rootClusterUri`) refresh the resource list with current filters.
    *
-   * Its main purpose is to refresh the resource list in existing DocumentCluster tabs after a
-   * Connect My Computer node is set up.
+   * Its purpose is to refresh the resource list in existing DocumentCluster tabs after a
+   * Connect My Computer node is set up, or after assuming/dropping an access request.
    */
-  requestResourcesRefresh: () => void;
+  requestResourcesRefresh: (rootClusterUri: RootClusterUri) => void;
   /**
    * onResourcesRefreshRequest registers a listener that will be called any time a refresh is
-   * requested. Typically called from useEffect, for this purpose it returns a cleanup function.
+   * requested for a particular rootClusterUri. Typically called from useEffect, for this purpose it
+   * returns a cleanup function.
    */
-  onResourcesRefreshRequest: (listener: () => void) => { cleanup: () => void };
+  onResourcesRefreshRequest: (
+    rootClusterUri: RootClusterUri,
+    listener: () => void
+  ) => {
+    cleanup: () => void;
+  };
 }
 
 const ResourcesContext = createContext<ResourcesContext>(null);
@@ -51,24 +59,32 @@ export const ResourcesContextProvider: FC<PropsWithChildren> = props => {
     emitterRef.current = new EventEmitter();
   }
 
-  // This function could be expanded to emit a cluster URI so that a request refresh for a root
-  // cluster doesn't trigger refreshes of leaf DocumentCluster instances and vice versa.
-  // However, the implementation should be good enough for now since it's used only in Connect My
-  // Computer setup anyway.
   const requestResourcesRefresh = useCallback(
-    () => emitterRef.current.emit('refresh'),
+    (rootClusterUri: RootClusterUri) =>
+      emitterRef.current.emit('refresh', rootClusterUri),
     []
   );
 
-  const onResourcesRefreshRequest = useCallback(listener => {
-    emitterRef.current.addListener('refresh', listener);
+  const onResourcesRefreshRequest = useCallback(
+    (
+      targetRootClusterUri: RootClusterUri,
+      listenerWithoutRootClusterUri: () => void
+    ) => {
+      const listener = (rootClusterUri: RootClusterUri) => {
+        if (rootClusterUri === targetRootClusterUri) {
+          listenerWithoutRootClusterUri();
+        }
+      };
+      emitterRef.current.addListener('refresh', listener);
 
-    return {
-      cleanup: () => {
-        emitterRef.current.removeListener('refresh', listener);
-      },
-    };
-  }, []);
+      return {
+        cleanup: () => {
+          emitterRef.current.removeListener('refresh', listener);
+        },
+      };
+    },
+    []
+  );
 
   return (
     <ResourcesContext.Provider
@@ -78,7 +94,7 @@ export const ResourcesContextProvider: FC<PropsWithChildren> = props => {
   );
 };
 
-export const useResourcesContext = () => {
+export const useResourcesContext = (rootClusterUri: RootClusterUri) => {
   const context = useContext(ResourcesContext);
 
   if (!context) {
@@ -87,5 +103,20 @@ export const useResourcesContext = () => {
     );
   }
 
-  return context;
+  const {
+    requestResourcesRefresh: requestResourcesRefreshContext,
+    onResourcesRefreshRequest: onResourcesRefreshRequestContext,
+  } = context;
+
+  return {
+    requestResourcesRefresh: useCallback(
+      () => requestResourcesRefreshContext(rootClusterUri),
+      [requestResourcesRefreshContext, rootClusterUri]
+    ),
+    onResourcesRefreshRequest: useCallback(
+      (listener: () => void) =>
+        onResourcesRefreshRequestContext(rootClusterUri, listener),
+      [onResourcesRefreshRequestContext, rootClusterUri]
+    ),
+  };
 };

--- a/web/packages/teleterm/src/ui/Documents/DocumentsRenderer.tsx
+++ b/web/packages/teleterm/src/ui/Documents/DocumentsRenderer.tsx
@@ -45,8 +45,6 @@ import { DocumentGatewayApp } from 'teleterm/ui/DocumentGatewayApp';
 import Document from 'teleterm/ui/Document';
 import { RootClusterUri, isDatabaseUri, isAppUri } from 'teleterm/ui/uri';
 
-import { ResourcesContextProvider } from '../DocumentCluster/resourcesContext';
-
 import { WorkspaceContextProvider } from './workspaceContext';
 import { KeyboardShortcutsPanel } from './KeyboardShortcutsPanel';
 
@@ -87,25 +85,22 @@ export function DocumentsRenderer(props: {
           key={workspace.rootClusterUri}
         >
           <WorkspaceContextProvider value={workspace}>
-            {/* ConnectMyComputerContext depends on ResourcesContext. */}
-            <ResourcesContextProvider>
-              <ConnectMyComputerContextProvider
-                rootClusterUri={workspace.rootClusterUri}
-              >
-                {workspace.documentsService.getDocuments().length ? (
-                  renderDocuments(workspace.documentsService)
-                ) : (
-                  <KeyboardShortcutsPanel />
+            <ConnectMyComputerContextProvider
+              rootClusterUri={workspace.rootClusterUri}
+            >
+              {workspace.documentsService.getDocuments().length ? (
+                renderDocuments(workspace.documentsService)
+              ) : (
+                <KeyboardShortcutsPanel />
+              )}
+              {workspace.rootClusterUri ===
+                workspacesService.getRootClusterUri() &&
+                props.topBarContainerRef.current &&
+                createPortal(
+                  <ConnectMyComputerNavigationMenu />,
+                  props.topBarContainerRef.current
                 )}
-                {workspace.rootClusterUri ===
-                  workspacesService.getRootClusterUri() &&
-                  props.topBarContainerRef.current &&
-                  createPortal(
-                    <ConnectMyComputerNavigationMenu />,
-                    props.topBarContainerRef.current
-                  )}
-              </ConnectMyComputerContextProvider>
-            </ResourcesContextProvider>
+            </ConnectMyComputerContextProvider>
           </WorkspaceContextProvider>
         </DocumentsContainer>
       ))}

--- a/web/packages/teleterm/src/ui/TabHost/TabHost.test.tsx
+++ b/web/packages/teleterm/src/ui/TabHost/TabHost.test.tsx
@@ -27,6 +27,7 @@ import { TabContextMenuOptions } from 'teleterm/mainProcess/types';
 import { makeDocumentCluster } from 'teleterm/ui/services/workspacesService/documentsService/testHelpers';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
+import { ResourcesContextProvider } from 'teleterm/ui/DocumentCluster/resourcesContext';
 
 function getMockDocuments(): Document[] {
   return [
@@ -81,7 +82,9 @@ async function getTestSetup({ documents }: { documents: Document[] }) {
 
   render(
     <MockAppContextProvider appContext={appContext}>
-      <TabHost ctx={appContext} topBarContainerRef={createRef()} />
+      <ResourcesContextProvider>
+        <TabHost ctx={appContext} topBarContainerRef={createRef()} />
+      </ResourcesContextProvider>
     </MockAppContextProvider>
   );
 


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/49125 to branch/v16
Manual backport because of conflicts in `TabHost.test.tsx`.

changelog: Teleport Connect now refreshes the resources view after dropping an access request