### PR TITLE
Fix missing shadow of resource cards in Connect

### DIFF
--- a/web/packages/teleterm/src/ui/Document/Document.tsx
+++ b/web/packages/teleterm/src/ui/Document/Document.tsx
@@ -34,7 +34,6 @@ const Document: React.FC<{
       tabIndex={visible ? 0 : -1}
       flex="1"
       ref={ref}
-      bg="levels.sunken"
       style={{
         overflow: 'auto',
         display: visible ? 'flex' : 'none',

--- a/web/packages/teleterm/src/ui/Document/Document.tsx
+++ b/web/packages/teleterm/src/ui/Document/Document.tsx
@@ -29,6 +29,9 @@ const Document: React.FC<{
     shouldFocus: visible && !autoFocusDisabled,
   });
 
+  // The background-color of Document is controlled through <body> and it
+  // cannot be set on Document directly because of Chromium issues with z-index.
+  // Read more https://github.com/gravitational/teleport/pull/49351.
   return (
     <Flex
       tabIndex={visible ? 0 : -1}


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/48065

Since the Electron 33.x update, the hover shadow stopped appearing in unified resources in Connect. At first I thought that something changed in Chromium but both the Web UI and storybook looked fine in Chrome. This led me to think that it's a bug in Electron itself. 
However, I was not able to reproduce the issue in Electron Fiddle. I decided to check the story for unified resources one more time in Chrome, and surprise, there was no shadow. I realized that when I checked it for the first time, I opened the "shared" story, not the Connect's one (where unified resources are wrapped in `Document`).

After testing, I fixed the issue by removing the background from `Document`. It seems that Chromium v130 (or 129) changed how it renders stacking contexts, causing the shadow (with `z-index: -1`) to be rendered below `Document`, making it invisible. 
On a side note, the story looked fine in both Safari and Firefox, so I guess it's a bug in Chromium.

Alternatively, we could fix this by setting `z-index: 0` on the unified resources container. However, the background in `Document` is unnecessary (it’s already set on `TabHost`) so I removed it.