### PR TITLE
update links from helm charts

### DIFF
--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -179,7 +179,7 @@ authentication:
 proxyListenerMode: "separate"
 
 # Optional setting for configuring session recording.
-# See `session_recording` under https://goteleport.com/docs/setup/reference/config/#teleportyaml
+# See `session_recording` under https://goteleport.com/docs/reference/config/#auth-service
 sessionRecording: ""
 
 # By default, Teleport will multiplex Postgres and MongoDB database connections on the same port as the proxy's web listener (443)

--- a/examples/chart/teleport-kube-agent/README.md
+++ b/examples/chart/teleport-kube-agent/README.md
@@ -13,14 +13,7 @@ To use it, you will need:
 - a reachable proxy endpoint (`$PROXY_ENDPOINT` e.g. `teleport.example.com:3080` or `teleport.example.com:443`)
 - a reachable reverse tunnel port on the proxy (e.g. `teleport.example.com:3024`). The address is automatically
   retrieved from the Teleport proxy configuration.
-- either a static or dynamic join token for the Teleport Cluster
-  - a [static join token](https://goteleport.com/docs/setup/admin/adding-nodes/#adding-nodes-to-the-cluster)
-    for this Teleport cluster (`$JOIN_TOKEN`) is used by default.
-  - optionally a [dynamic join token](https://goteleport.com/docs/setup/admin/adding-nodes/#short-lived-dynamic-tokens) can
-    be used on Kubernetes clusters that support persistent volumes. Set `storage.enabled=true` and
-    `storage.storageClassName=<storage class configured in kubernetes>` in the helm configuration to use persistent
-    volumes.
-
+- a join token for the Teleport Cluster. For this Teleport cluster (`$JOIN_TOKEN`) is used by default. See the [join token guide](https://goteleport.com/docs/enroll-resources/agents/join-services-to-your-cluster/join-token/) for information on creating tokens.
 
 ## Combining roles
 

--- a/examples/chart/teleport-kube-agent/README.md
+++ b/examples/chart/teleport-kube-agent/README.md
@@ -13,7 +13,7 @@ To use it, you will need:
 - a reachable proxy endpoint (`$PROXY_ENDPOINT` e.g. `teleport.example.com:3080` or `teleport.example.com:443`)
 - a reachable reverse tunnel port on the proxy (e.g. `teleport.example.com:3024`). The address is automatically
   retrieved from the Teleport proxy configuration.
-- a join token for the Teleport Cluster. For this Teleport cluster (`$JOIN_TOKEN`) is used by default. See the [join token guide](https://goteleport.com/docs/enroll-resources/agents/join-services-to-your-cluster/join-token/) for information on creating tokens.
+- a join token for the Teleport Cluster. For this Teleport cluster (`$JOIN_TOKEN`) is used by default. See the [Join Methods and Token Reference](https://goteleport.com/docs/reference/join-methods/) for supproted join methods and creating tokens.
 
 ## Combining roles
 


### PR DESCRIPTION
Updated links for:
- old adding nodes link for token. Token language also didn't apply anymore
- Link to session configuration info