### PR TITLE
Determine the session type based on the events on session events streaming

### DIFF
--- a/api/types/session_tracker.go
+++ b/api/types/session_tracker.go
@@ -39,6 +39,7 @@ const (
 	DatabaseSessionKind       SessionKind = "db"
 	AppSessionKind            SessionKind = "app"
 	WindowsDesktopSessionKind SessionKind = "desktop"
+	UnknownSessionKind        SessionKind = ""
 )
 
 // SessionParticipantMode is the mode that determines what you can do when you join a session.


### PR DESCRIPTION
Related to #49164

**Brief context:** After the changes are made at #47309, when a request for session recording events (playback) is made, we query to find the last event to set the `SessionType` field on the audit log. Depending on the cluster's backend and the volume of audit events, this can cause increased latency.

This PR updates the logic of determining the session type by consuming (peeking) the first event of the stream.

changelog: Improve session playback initial delay caused by an additional events query.