### PR TITLE
fix: support set.add on nil sets in traits expression parser

### DIFF
--- a/lib/expression/dict.go
+++ b/lib/expression/dict.go
@@ -50,7 +50,9 @@ func (d Dict) addValues(key string, values ...string) Dict {
 		out[key] = NewSet(values...)
 		return out
 	}
-	s.Add(values...)
+	// Calling s.add would do an unnecessary extra copy since we already
+	// cloned the whole Dict. s.s.Add adds to the existing cloned set.
+	s.s.Add(values...)
 	return out
 }
 
@@ -71,7 +73,7 @@ func (d Dict) remove(keys ...string) any {
 func (d Dict) clone() Dict {
 	out := make(Dict, len(d))
 	for key, set := range d {
-		out[key] = Set{set.Clone()}
+		out[key] = set.clone()
 	}
 	return out
 }

--- a/lib/expression/parser.go
+++ b/lib/expression/parser.go
@@ -84,7 +84,7 @@ func DefaultParserSpec[evaluationEnv any]() typical.ParserSpec[evaluationEnv] {
 				}),
 			"email.local": typical.UnaryFunction[evaluationEnv](
 				func(emails Set) (Set, error) {
-					locals, err := parse.EmailLocal(emails.Elements())
+					locals, err := parse.EmailLocal(emails.items())
 					if err != nil {
 						return Set{}, trace.Wrap(err)
 					}
@@ -92,7 +92,7 @@ func DefaultParserSpec[evaluationEnv any]() typical.ParserSpec[evaluationEnv] {
 				}),
 			"regexp.replace": typical.TernaryFunction[evaluationEnv](
 				func(inputs Set, match string, replacement string) (Set, error) {
-					replaced, err := parse.RegexpReplace(inputs.Elements(), match, replacement)
+					replaced, err := parse.RegexpReplace(inputs.items(), match, replacement)
 					if err != nil {
 						return Set{}, trace.Wrap(err)
 					}
@@ -101,7 +101,7 @@ func DefaultParserSpec[evaluationEnv any]() typical.ParserSpec[evaluationEnv] {
 			"strings.split": typical.BinaryFunction[evaluationEnv](
 				func(inputs Set, sep string) (Set, error) {
 					var outputs []string
-					for input := range inputs.Set {
+					for input := range inputs.s {
 						outputs = append(outputs, strings.Split(input, sep)...)
 					}
 					return NewSet(outputs...), nil
@@ -131,8 +131,8 @@ func DefaultParserSpec[evaluationEnv any]() typical.ParserSpec[evaluationEnv] {
 				}),
 			"contains_any": typical.BinaryFunction[evaluationEnv](
 				func(s1, s2 Set) (bool, error) {
-					for v := range s2.Set {
-						if s1.Contains(v) {
+					for v := range s2.s {
+						if s1.contains(v) {
 							return true, nil
 						}
 					}
@@ -140,17 +140,17 @@ func DefaultParserSpec[evaluationEnv any]() typical.ParserSpec[evaluationEnv] {
 				}),
 			"is_empty": typical.UnaryFunction[evaluationEnv](
 				func(s Set) (bool, error) {
-					return len(s.Set) == 0, nil
+					return len(s.s) == 0, nil
 				}),
 		},
 		Methods: map[string]typical.Function{
 			"add": typical.BinaryVariadicFunction[evaluationEnv](
 				func(s Set, values ...string) (Set, error) {
-					return Set{s.Clone().Add(values...)}, nil
+					return s.add(values...), nil
 				}),
 			"contains": typical.BinaryFunction[evaluationEnv](
 				func(s Set, str string) (bool, error) {
-					return s.Contains(str), nil
+					return s.contains(str), nil
 				}),
 			"put": typical.TernaryFunction[evaluationEnv](
 				func(d Dict, key string, value Set) (Dict, error) {
@@ -185,8 +185,8 @@ func DefaultParserSpec[evaluationEnv any]() typical.ParserSpec[evaluationEnv] {
 				}),
 			"contains_any": typical.BinaryFunction[evaluationEnv](
 				func(s1, s2 Set) (bool, error) {
-					for v := range s2.Set {
-						if s1.Contains(v) {
+					for v := range s2.s {
+						if s1.contains(v) {
 							return true, nil
 						}
 					}
@@ -194,7 +194,7 @@ func DefaultParserSpec[evaluationEnv any]() typical.ParserSpec[evaluationEnv] {
 				}),
 			"isempty": typical.UnaryFunction[evaluationEnv](
 				func(s Set) (bool, error) {
-					return len(s.Set) == 0, nil
+					return len(s.s) == 0, nil
 				}),
 		},
 	}
@@ -229,7 +229,7 @@ func traitsMapResultToSet(result any, expr string) (Set, error) {
 func StringSliceMapFromDict(d Dict) map[string][]string {
 	m := make(map[string][]string, len(d))
 	for key, s := range d {
-		m[key] = s.Elements()
+		m[key] = s.items()
 	}
 	return m
 }
@@ -249,7 +249,7 @@ func StringTransform(name string, input any, f func(string) string) (any, error)
 	case string:
 		return f(typedInput), nil
 	case Set:
-		return Set{utils.SetTransform(typedInput.Set, f)}, nil
+		return Set{utils.SetTransform(typedInput.s, f)}, nil
 	default:
 		return nil, trace.BadParameter("failed to evaluate argument to %s: expected string or set, got value of type %T", name, input)
 	}


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport-private/issues/1786

This PR fixes a panic in the parser used for login rules and SAML IdP attribute mapping. The panic occurs when using the `add` method on a `nil` set. It is possible to get a `nil` set when indexing a dict with a key that is not present. For example, `external["groups"].add("example")` would panic if there was no `"groups"` trait.

These expressions can only be written by authenticated Teleport users with permission to create or edit `login_rule` or `saml_idp_service_provider` resources.

Changelog: Fixed a potential panic in login rule and SAML IdP expression parser