### PR TITLE
[teleport-update] Fix usage of trace

### DIFF
--- a/lib/autoupdate/agent/config.go
+++ b/lib/autoupdate/agent/config.go
@@ -85,12 +85,12 @@ func readConfig(path string) (*UpdateConfig, error) {
 		}, nil
 	}
 	if err != nil {
-		return nil, trace.Errorf("failed to open: %w", err)
+		return nil, trace.Wrap(err, "failed to open")
 	}
 	defer f.Close()
 	var cfg UpdateConfig
 	if err := yaml.NewDecoder(f).Decode(&cfg); err != nil {
-		return nil, trace.Errorf("failed to parse: %w", err)
+		return nil, trace.Wrap(err, "failed to parse")
 	}
 	if k := cfg.Kind; k != updateConfigKind {
 		return nil, trace.Errorf("invalid kind %q", k)

--- a/lib/autoupdate/agent/setup.go
+++ b/lib/autoupdate/agent/setup.go
@@ -180,17 +180,17 @@ func (ns *Namespace) Init() (lockFile string, err error) {
 func (ns *Namespace) Setup(ctx context.Context) error {
 	err := ns.writeConfigFiles()
 	if err != nil {
-		return trace.Errorf("failed to write teleport-update systemd config files: %w", err)
+		return trace.Wrap(err, "failed to write teleport-update systemd config files")
 	}
 	svc := &SystemdService{
 		ServiceName: filepath.Base(ns.updaterTimerFile),
 		Log:         ns.log,
 	}
 	if err := svc.Sync(ctx); err != nil {
-		return trace.Errorf("failed to sync systemd config: %w", err)
+		return trace.Wrap(err, "failed to sync systemd config")
 	}
 	if err := svc.Enable(ctx, true); err != nil {
-		return trace.Errorf("failed to enable teleport-update systemd timer: %w", err)
+		return trace.Wrap(err, "failed to enable teleport-update systemd timer")
 	}
 	return nil
 }
@@ -202,19 +202,19 @@ func (ns *Namespace) Teardown(ctx context.Context) error {
 		Log:         ns.log,
 	}
 	if err := svc.Disable(ctx); err != nil {
-		return trace.Errorf("failed to disable teleport-update systemd timer: %w", err)
+		return trace.Wrap(err, "failed to disable teleport-update systemd timer")
 	}
 	if err := os.Remove(ns.updaterServiceFile); err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return trace.Errorf("failed to remove teleport-update systemd service: %w", err)
+		return trace.Wrap(err, "failed to remove teleport-update systemd service")
 	}
 	if err := os.Remove(ns.updaterTimerFile); err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return trace.Errorf("failed to remove teleport-update systemd timer: %w", err)
+		return trace.Wrap(err, "failed to remove teleport-update systemd timer")
 	}
 	if err := svc.Sync(ctx); err != nil {
-		return trace.Errorf("failed to sync systemd config: %w", err)
+		return trace.Wrap(err, "failed to sync systemd config")
 	}
 	if err := os.RemoveAll(ns.versionsDir); err != nil {
-		return trace.Errorf("failed to remove versions directory: %w", err)
+		return trace.Wrap(err, "failed to remove versions directory")
 	}
 	return nil
 }

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -199,7 +199,7 @@ func Run(args []string) int {
 		modules.GetModules().PrintVersion()
 	default:
 		// This should only happen when there's a missing switch case above.
-		err = trace.Errorf("command %q not configured", command)
+		err = trace.Errorf("command %s not configured", command)
 	}
 	if errors.Is(err, autoupdate.ErrNotSupported) {
 		return autoupdate.CodeNotSupported
@@ -447,7 +447,7 @@ func cmdUninstall(ctx context.Context, ccfg *cliConfig) error {
 	// Ensure update can't run concurrently.
 	unlock, err := libutils.FSWriteLock(lockFile)
 	if err != nil {
-		return trace.Wrap(err, "failed to grab concurrent execution lock %q", lockFile)
+		return trace.Wrap(err, "failed to grab concurrent execution lock %s", lockFile)
 	}
 	defer func() {
 		if err := unlock(); err != nil {

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -260,11 +260,11 @@ func statusConfig(ccfg *cliConfig) (*autoupdate.Updater, error) {
 func cmdDisable(ctx context.Context, ccfg *cliConfig) error {
 	updater, lockFile, err := initConfig(ccfg)
 	if err != nil {
-		return trace.Errorf("failed to initialize updater: %w", err)
+		return trace.Wrap(err, "failed to initialize updater")
 	}
 	unlock, err := libutils.FSWriteLock(lockFile)
 	if err != nil {
-		return trace.Errorf("failed to grab concurrent execution lock: %w", err)
+		return trace.Wrap(err, "failed to grab concurrent execution lock %s", lockFile)
 	}
 	defer func() {
 		if err := unlock(); err != nil {
@@ -281,11 +281,11 @@ func cmdDisable(ctx context.Context, ccfg *cliConfig) error {
 func cmdUnpin(ctx context.Context, ccfg *cliConfig) error {
 	updater, lockFile, err := initConfig(ccfg)
 	if err != nil {
-		return trace.Errorf("failed to setup updater: %w", err)
+		return trace.Wrap(err, "failed to setup updater")
 	}
 	unlock, err := libutils.FSWriteLock(lockFile)
 	if err != nil {
-		return trace.Errorf("failed to grab concurrent execution lock: %w", err)
+		return trace.Wrap(err, "failed to grab concurrent execution lock %n", lockFile)
 	}
 	defer func() {
 		if err := unlock(); err != nil {
@@ -309,13 +309,13 @@ func cmdInstall(ctx context.Context, ccfg *cliConfig) error {
 	}
 	updater, lockFile, err := initConfig(ccfg)
 	if err != nil {
-		return trace.Errorf("failed to initialize updater: %w", err)
+		return trace.Wrap(err, "failed to initialize updater")
 	}
 
 	// Ensure enable can't run concurrently.
 	unlock, err := libutils.FSWriteLock(lockFile)
 	if err != nil {
-		return trace.Errorf("failed to grab concurrent execution lock: %w", err)
+		return trace.Wrap(err, "failed to grab concurrent execution lock %s", lockFile)
 	}
 	defer func() {
 		if err := unlock(); err != nil {
@@ -332,12 +332,12 @@ func cmdInstall(ctx context.Context, ccfg *cliConfig) error {
 func cmdUpdate(ctx context.Context, ccfg *cliConfig) error {
 	updater, lockFile, err := initConfig(ccfg)
 	if err != nil {
-		return trace.Errorf("failed to initialize updater: %w", err)
+		return trace.Wrap(err, "failed to initialize updater")
 	}
 	// Ensure update can't run concurrently.
 	unlock, err := libutils.FSWriteLock(lockFile)
 	if err != nil {
-		return trace.Errorf("failed to grab concurrent execution lock: %w", err)
+		return trace.Wrap(err, "failed to grab concurrent execution lock %s", lockFile)
 	}
 	defer func() {
 		if err := unlock(); err != nil {
@@ -355,7 +355,7 @@ func cmdUpdate(ctx context.Context, ccfg *cliConfig) error {
 func cmdLinkPackage(ctx context.Context, ccfg *cliConfig) error {
 	updater, lockFile, err := initConfig(ccfg)
 	if err != nil {
-		return trace.Errorf("failed to initialize updater: %w", err)
+		return trace.Wrap(err, "failed to initialize updater")
 	}
 
 	// Skip operation and warn if the updater is currently running.
@@ -365,7 +365,7 @@ func cmdLinkPackage(ctx context.Context, ccfg *cliConfig) error {
 		return nil
 	}
 	if err != nil {
-		return trace.Errorf("failed to grab concurrent execution lock: %w", err)
+		return trace.Wrap(err, "failed to grab concurrent execution lock %q", lockFile)
 	}
 	defer func() {
 		if err := unlock(); err != nil {
@@ -383,16 +383,17 @@ func cmdLinkPackage(ctx context.Context, ccfg *cliConfig) error {
 func cmdUnlinkPackage(ctx context.Context, ccfg *cliConfig) error {
 	updater, lockFile, err := initConfig(ccfg)
 	if err != nil {
-		return trace.Errorf("failed to setup updater: %w", err)
+		return trace.Wrap(err, "failed to setup updater")
 	}
 
 	// Error if the updater is running. We could remove its links by accident.
 	unlock, err := libutils.FSTryWriteLock(lockFile)
 	if errors.Is(err, libutils.ErrUnsuccessfulLockTry) {
-		return trace.Errorf("updater is currently running")
+		plog.WarnContext(ctx, "Updater is currently running. Skipping package unlinking.")
+		return nil
 	}
 	if err != nil {
-		return trace.Errorf("failed to grab concurrent execution lock: %w", err)
+		return trace.Wrap(err, "failed to grab concurrent execution lock %q", lockFile)
 	}
 	defer func() {
 		if err := unlock(); err != nil {
@@ -418,7 +419,7 @@ func cmdSetup(ctx context.Context, ccfg *cliConfig) error {
 		return trace.Wrap(err)
 	}
 	if err != nil {
-		return trace.Errorf("failed to setup teleport-update service: %w", err)
+		return trace.Wrap(err, "failed to setup teleport-update service")
 	}
 	return nil
 }
@@ -427,11 +428,11 @@ func cmdSetup(ctx context.Context, ccfg *cliConfig) error {
 func cmdStatus(ctx context.Context, ccfg *cliConfig) error {
 	updater, err := statusConfig(ccfg)
 	if err != nil {
-		return trace.Errorf("failed to initialize updater: %w", err)
+		return trace.Wrap(err, "failed to initialize updater")
 	}
 	status, err := updater.Status(ctx)
 	if err != nil {
-		return trace.Errorf("failed to get status: %w", err)
+		return trace.Wrap(err, "failed to get status")
 	}
 	enc := yaml.NewEncoder(os.Stdout)
 	return trace.Wrap(enc.Encode(status))
@@ -441,12 +442,12 @@ func cmdStatus(ctx context.Context, ccfg *cliConfig) error {
 func cmdUninstall(ctx context.Context, ccfg *cliConfig) error {
 	updater, lockFile, err := initConfig(ccfg)
 	if err != nil {
-		return trace.Errorf("failed to initialize updater: %w", err)
+		return trace.Wrap(err, "failed to initialize updater")
 	}
 	// Ensure update can't run concurrently.
 	unlock, err := libutils.FSWriteLock(lockFile)
 	if err != nil {
-		return trace.Errorf("failed to grab concurrent execution lock: %w", err)
+		return trace.Wrap(err, "failed to grab concurrent execution lock %q", lockFile)
 	}
 	defer func() {
 		if err := unlock(); err != nil {


### PR DESCRIPTION
@hugoShaka pointed out to me that `trace.Errorf` does not accurately record stack traces when used to wrap errors. This PR migrates `teleport-update` from `trace.Errorf` to `trace.Wrap` for error wrapping.

---

The `teleport-update` binary will be used to enable, disable, and trigger automatic Teleport agent updates. The new auto-updates system manages a local installation of the cluster-specified version of Teleport stored in `/var/lib/teleport/versions`.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/10289