### PR TITLE
(fix) Access request max_duration using tsh

### DIFF
--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -2633,6 +2633,8 @@ func createAccessRequest(cf *CLIConf) (types.AccessRequest, error) {
 	if cf.MaxDuration > 0 {
 		// Time will be relative to the approval time instead of the request time.
 		req.SetMaxDuration(time.Now().UTC().Add(cf.MaxDuration))
+	} else {
+		req.SetMaxDuration(time.Now().UTC().Add(time.Hour * 24 * 7))
 	}
 
 	if cf.AssumeStartTimeRaw != "" {


### PR DESCRIPTION
Fix scenario 1 in https://github.com/gravitational/teleport/issues/49403

7 days was based on the `max_duration` value in the role definition [here](https://github.com/gravitational/teleport/blob/4102fa523ae160630c1e26958cc4e07031864e9e/docs/pages/includes/role-spec.mdx?plain=1#L376-L380).

Also, when creating an access request and pass  `--max-duration`, the value will always be the shortest between the the defined in the role and the one gave as parameter. 



Same access request described in the issue but after this fix:

![Screenshot 2024-11-25 at 13 41 33](https://github.com/user-attachments/assets/fabb9fc0-7d47-4ca9-adeb-de75bf0b373a)
