### PR TITLE
chore: Bump golangci-lint to v1.62.2

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -4,7 +4,7 @@
 
 # Sync with devbox.json.
 GOLANG_VERSION ?= go1.23.3
-GOLANGCI_LINT_VERSION ?= v1.62.0
+GOLANGCI_LINT_VERSION ?= v1.62.2
 
 NODE_VERSION ?= 20.18.0
 


### PR DESCRIPTION
Update to the latest patch.

* https://github.com/golangci/golangci-lint/releases/tag/v1.62.2
