### PR TITLE
[v15] Respect client_idle_timeout config in kube proxy forwarder

### DIFF
--- a/lib/kube/proxy/constants.go
+++ b/lib/kube/proxy/constants.go
@@ -28,8 +28,6 @@ const (
 
 	// DefaultStreamCreationTimeout
 	DefaultStreamCreationTimeout = 30 * time.Second
-
-	IdleTimeout = 15 * time.Minute
 )
 
 // These constants are for remote command execution and port forwarding and are

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1638,6 +1638,7 @@ func (f *Forwarder) exec(authCtx *authContext, w http.ResponseWriter, req *http.
 		httpResponseWriter: w,
 		context:            ctx,
 		pingPeriod:         f.cfg.ConnPingPeriod,
+		idleTimeout:        sess.clientIdleTimeout,
 		onResize:           func(remotecommand.TerminalSize) {},
 	}
 
@@ -1782,6 +1783,7 @@ func (f *Forwarder) portForward(authCtx *authContext, w http.ResponseWriter, req
 		onPortForward:      onPortForward,
 		targetDialer:       dialer,
 		pingPeriod:         f.cfg.ConnPingPeriod,
+		idleTimeout:        sess.clientIdleTimeout,
 	}
 	f.log.Debugf("Starting %v.", request)
 	err = runPortForwarding(request)

--- a/lib/kube/proxy/portforward_spdy.go
+++ b/lib/kube/proxy/portforward_spdy.go
@@ -46,6 +46,7 @@ type portForwardRequest struct {
 	context            context.Context
 	targetDialer       httpstream.Dialer
 	pingPeriod         time.Duration
+	idleTimeout        time.Duration
 }
 
 func (p portForwardRequest) String() string {
@@ -103,8 +104,10 @@ func runPortForwardingHTTPStreams(req portForwardRequest) error {
 		targetConn:            targetConn,
 	}
 	defer h.Close()
-	h.Debugf("Setting port forwarding streaming connection idle timeout to %v", IdleTimeout)
-	conn.SetIdleTimeout(IdleTimeout)
+
+	h.Debugf("Setting port forwarding streaming connection idle timeout to %s.", req.idleTimeout)
+	conn.SetIdleTimeout(req.idleTimeout)
+
 	h.run()
 	return nil
 }

--- a/lib/kube/proxy/portforward_websocket.go
+++ b/lib/kube/proxy/portforward_websocket.go
@@ -88,7 +88,8 @@ func runPortForwardingWebSocket(req portForwardRequest) error {
 			Channels: channels,
 		},
 	})
-	conn.SetIdleTimeout(IdleTimeout)
+
+	conn.SetIdleTimeout(req.idleTimeout)
 
 	// Upgrade the request and create the virtual streams.
 	_, streams, err := conn.Open(

--- a/lib/kube/proxy/remotecommand.go
+++ b/lib/kube/proxy/remotecommand.go
@@ -56,6 +56,7 @@ type remoteCommandRequest struct {
 	onResize           resizeCallback
 	context            context.Context
 	pingPeriod         time.Duration
+	idleTimeout        time.Duration
 }
 
 func (req remoteCommandRequest) eventPodMeta(ctx context.Context, creds kubeCreds) apievents.KubernetesPodMetadata {
@@ -153,7 +154,7 @@ func createSPDYStreams(req remoteCommandRequest) (*remoteCommandProxy, error) {
 		return nil, trace.ConnectionProblem(trace.BadParameter("missing connection"), "missing connection")
 	}
 
-	conn.SetIdleTimeout(IdleTimeout)
+	conn.SetIdleTimeout(req.idleTimeout)
 
 	var handler protocolHandler
 	switch protocol {

--- a/lib/kube/proxy/remotecommand_websocket.go
+++ b/lib/kube/proxy/remotecommand_websocket.go
@@ -109,7 +109,9 @@ func createWebSocketStreams(req remoteCommandRequest) (*remoteCommandProxy, erro
 			Channels: channels,
 		},
 	})
-	conn.SetIdleTimeout(IdleTimeout)
+
+	conn.SetIdleTimeout(req.idleTimeout)
+
 	negotiatedProtocol, streams, err := conn.Open(
 		responsewriter.GetOriginal(req.httpResponseWriter),
 		req.httpRequest,


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/49121 to branch/v15

changelog: Support for long-running kube exec/port-forward, respect client_idle_timeout config