### PR TITLE
[v16] fix: support set.add on nil sets in traits expression parser

### DIFF
--- a/lib/expression/set.go
+++ b/lib/expression/set.go
@@ -35,6 +35,9 @@ func NewSet(values ...string) Set {
 }
 
 func (s Set) add(values ...string) Set {
+	if len(s) == 0 {
+		return NewSet(values...)
+	}
 	out := s.clone()
 	for _, value := range values {
 		out[value] = struct{}{}


### PR DESCRIPTION
Backport #49385 to branch/v16

This is a manual backport and a much smaller and more targeted change than the original PR, because in this branch lib/expression.Set has not been converted to use lib/utils.Set.

Changelog: Fixed a potential panic in login rule and SAML IdP expression parser