### PR TITLE
[v17] chore: Bump rustls to 0.23.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2393,9 +2393,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.13"
+version = "0.23.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
+checksum = "9c9cc1d47e243d655ace55ed38201c19ae02c148ae56412ab8750e8f0166ab7f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -2432,9 +2432,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-webpki"

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -42,7 +42,7 @@ picky = { version = "7.0.0-rc.9", default-features = false }
 picky-asn1-der = "0.5.0"
 picky-asn1-x509 = "0.13.0"
 reqwest = { version = "0.12", default-features = false }
-rustls = { version = "0.23.13", default-features = false, features = ["ring"] }
+rustls = { version = "0.23.18", default-features = false, features = ["ring"] }
 
 [build-dependencies]
 cbindgen = "0.27.0"


### PR DESCRIPTION
(Manually) backport #49415 to branch/v17.

Addresses a dependabot security alert.