### PR TITLE
[web] Align integration/plugin icons and titles

### DIFF
--- a/web/packages/teleport/src/Bots/Add/AddBotsPicker.tsx
+++ b/web/packages/teleport/src/Bots/Add/AddBotsPicker.tsx
@@ -49,7 +49,12 @@ type BotIntegration = {
   kind: IntegrationEnrollKind;
 };
 
-const StyledResourceIcon = styled(ResourceIcon).attrs({ width: '80px' })``;
+const StyledResourceIcon = styled(ResourceIcon)`
+  margin: 0 auto;
+  height: 100%;
+  min-width: 0;
+  max-width: 80px;
+`;
 
 const integrations: BotIntegration[] = [
   {
@@ -83,7 +88,7 @@ const integrations: BotIntegration[] = [
   {
     title: 'Ansible',
     link: 'https://goteleport.com/docs/machine-id/access-guides/ansible/',
-    icon: <ResourceIcon name="ansible" />,
+    icon: <StyledResourceIcon name="ansible" />,
     kind: IntegrationEnrollKind.MachineIDAnsible,
     guided: false,
   },
@@ -118,7 +123,7 @@ const integrations: BotIntegration[] = [
   {
     title: 'Kubernetes',
     link: 'https://goteleport.com/docs/machine-id/deployment/kubernetes/',
-    icon: <ResourceIcon name="kube" />,
+    icon: <StyledResourceIcon name="kube" />,
     kind: IntegrationEnrollKind.MachineIDKubernetes,
     guided: false,
   },
@@ -252,9 +257,7 @@ export function DisplayTile({
 function TileContent({ icon, title }) {
   return (
     <>
-      <Box mt={3} mb={2}>
-        {icon}
-      </Box>
+      <Flex flexBasis={100}>{icon}</Flex>
       <Text>{title}</Text>
     </>
   );

--- a/web/packages/teleport/src/Integrations/Enroll/IntegrationTiles.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/IntegrationTiles.tsx
@@ -53,9 +53,9 @@ export function IntegrationTiles({
         data-testid="tile-aws-oidc"
       >
         <Flex flexBasis={100}>
-          <IntegrationIcon name="aws" />
+          <IntegrationIcon name="aws" size={80} />
         </Flex>
-        <Flex flexBasis={50}>
+        <Flex>
           <Text>AWS OIDC Identity Provider</Text>
         </Flex>
         {!hasIntegrationAccess && (
@@ -84,9 +84,9 @@ export function IntegrationTiles({
           data-testid="tile-external-audit-storage"
         >
           <Flex flexBasis={100}>
-            <IntegrationIcon name="aws" />
+            <IntegrationIcon name="aws" size={80} />
           </Flex>
-          <Flex flexBasis={50}>
+          <Flex>
             <Text>AWS External Audit Storage</Text>
           </Flex>
           {renderExternalAuditStorageBadge(

--- a/web/packages/teleport/src/Integrations/Enroll/common.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/common.tsx
@@ -31,14 +31,17 @@ export const IntegrationTile = styled(Flex)<{
   align-items: center;
   justify-content: center;
   position: relative;
-  border-radius: 4px;
-  padding: 15px 10px 6px 10px;
+  border-radius: ${({ theme }) => theme.radii[2]}px;
+  padding: ${({ theme }) => theme.space[3]}px;
+  gap: ${({ theme }) => theme.space[3]}px;
   height: 170px;
   width: 170px;
   background-color: ${({ theme }) => theme.colors.buttons.secondary.default};
   text-align: center;
   cursor: ${({ disabled, $exists }) =>
-    disabled || $exists ? 'default' : 'pointer'};
+    disabled || $exists ? 'not-allowed' : 'pointer'};
+  transition: background-color 200ms ease;
+
   ${props => {
     if (props.$exists) {
       return;
@@ -46,7 +49,8 @@ export const IntegrationTile = styled(Flex)<{
 
     return `
     opacity: ${props.disabled ? '0.45' : '1'};
-    &:hover {
+    &:hover,
+    &:focus-visible {
       background-color: ${props.theme.colors.buttons.secondary.hover};
     }
     `;
@@ -69,10 +73,8 @@ export const NoCodeIntegrationDescription = () => (
  */
 export const IntegrationIcon = styled(ResourceIcon)<{ size?: number }>`
   display: inline-block;
+  margin: 0 auto;
   height: 100%;
-  ${({ size }) =>
-    size &&
-    `
-    max-height: ${size}px;
-  `}
+  min-width: 0;
+  ${({ size }) => size && `max-width: ${size}px;`}
 `;


### PR DESCRIPTION
Small fix - prevent overflow of integration/plugin icons. Centre-align icons, use consistent size between sections.
