### PR TITLE
[teleport-update] Support for Enterprise/FIPS migration

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -283,7 +283,7 @@ const (
 	// ComponentProxySecureGRPC represents a secure gRPC server running on Proxy (used for Kube).
 	ComponentProxySecureGRPC = "proxy:secure-grpc"
 
-	// ComponentUpdater represents the agent updater.
+	// ComponentUpdater represents the teleport-update binary.
 	ComponentUpdater = "updater"
 
 	// VerboseLogsEnvVar forces all logs to be verbose (down to DEBUG level)

--- a/lib/autoupdate/agent/config.go
+++ b/lib/autoupdate/agent/config.go
@@ -170,10 +170,10 @@ func readConfig(path string) (*UpdateConfig, error) {
 		return nil, trace.Wrap(err, "failed to parse")
 	}
 	if k := cfg.Kind; k != updateConfigKind {
-		return nil, trace.Errorf("invalid kind %q", k)
+		return nil, trace.Errorf("invalid kind %s", k)
 	}
 	if v := cfg.Version; v != updateConfigVersion {
-		return nil, trace.Errorf("invalid version %q", v)
+		return nil, trace.Errorf("invalid version %s", v)
 	}
 	return &cfg, nil
 }

--- a/lib/autoupdate/agent/config.go
+++ b/lib/autoupdate/agent/config.go
@@ -19,7 +19,9 @@
 package agent
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"strings"
@@ -67,12 +69,87 @@ type UpdateSpec struct {
 
 // UpdateStatus describes the status field in update.yaml.
 type UpdateStatus struct {
-	// ActiveVersion is the currently active Teleport version.
-	ActiveVersion string `yaml:"active_version"`
-	// BackupVersion is the last working version of Teleport.
-	BackupVersion string `yaml:"backup_version"`
-	// SkipVersion is the last reverted version of Teleport.
-	SkipVersion string `yaml:"skip_version,omitempty"`
+	// Active is the currently active revision of Teleport.
+	Active Revision `yaml:"active"`
+	// Backup is the last working revision of Teleport.
+	Backup *Revision `yaml:"backup,omitempty"`
+	// Skip is the skipped revision of Teleport.
+	// Skipped revisions are not applied because they
+	// are known to crash.
+	Skip *Revision `yaml:"skip,omitempty"`
+}
+
+// Revision is a version and edition of Teleport.
+type Revision struct {
+	// Version is the version of Teleport.
+	Version string `yaml:"version" json:"version"`
+	// Flags describe the edition of Teleport.
+	Flags InstallFlags `yaml:"flags,flow,omitempty" json:"flags,omitempty"`
+}
+
+// NewRevision create a Revision.
+// If version is not set, no flags are returned.
+// This ensures that all Revisions without versions are zero-valued.
+func NewRevision(version string, flags InstallFlags) Revision {
+	if version != "" {
+		return Revision{
+			Version: version,
+			Flags:   flags,
+		}
+	}
+	return Revision{}
+}
+
+// NewRevisionFromDir translates a directory path containing Teleport into a Revision.
+func NewRevisionFromDir(dir string) (Revision, error) {
+	parts := strings.Split(dir, "_")
+	var out Revision
+	if len(parts) == 0 {
+		return out, trace.Errorf("dir name empty")
+	}
+	out.Version = parts[0]
+	if out.Version == "" {
+		return out, trace.Errorf("version missing in dir %s", dir)
+	}
+	switch flags := parts[1:]; len(flags) {
+	case 2:
+		if flags[1] != FlagFIPS.DirFlag() {
+			break
+		}
+		out.Flags |= FlagFIPS
+		fallthrough
+	case 1:
+		if flags[0] != FlagEnterprise.DirFlag() {
+			break
+		}
+		out.Flags |= FlagEnterprise
+		fallthrough
+	case 0:
+		return out, nil
+	}
+	return out, trace.Errorf("invalid flag in %s", dir)
+}
+
+// Dir returns the directory path name of a Revision.
+func (r Revision) Dir() string {
+	// Do not change the order of these statements.
+	// Otherwise, installed versions will no longer match update.yaml.
+	var suffix string
+	if r.Flags&(FlagEnterprise|FlagFIPS) != 0 {
+		suffix += "_" + FlagEnterprise.DirFlag()
+	}
+	if r.Flags&FlagFIPS != 0 {
+		suffix += "_" + FlagFIPS.DirFlag()
+	}
+	return r.Version + suffix
+}
+
+// String returns a human-readable description of a Teleport revision.
+func (r Revision) String() string {
+	if flags := r.Flags.Strings(); len(flags) > 0 {
+		return fmt.Sprintf("%s+%s", r.Version, strings.Join(flags, "+"))
+	}
+	return r.Version
 }
 
 // readConfig reads UpdateConfig from a file.
@@ -155,10 +232,8 @@ type Status struct {
 
 // FindResp summarizes the auto-update status response from cluster.
 type FindResp struct {
-	// Version of Teleport to install
-	TargetVersion string `yaml:"target_version"`
-	// Flags describing the edition of Teleport
-	Flags InstallFlags `yaml:"flags"`
+	// Target revision of Teleport to install
+	Target Revision `yaml:"target"`
 	// InWindow is true when the install should happen now.
 	InWindow bool `yaml:"in_window"`
 	// Jitter duration before an automated install
@@ -175,10 +250,23 @@ const (
 	FlagFIPS
 )
 
-func (i InstallFlags) MarshalYAML() (any, error) {
-	return i.Strings(), nil
+// NewInstallFlagsFromStrings returns InstallFlags given a slice of human-readable strings.
+func NewInstallFlagsFromStrings(s []string) InstallFlags {
+	var out InstallFlags
+	for _, f := range s {
+		for _, flag := range []InstallFlags{
+			FlagEnterprise,
+			FlagFIPS,
+		} {
+			if f == flag.String() {
+				out |= flag
+			}
+		}
+	}
+	return out
 }
 
+// Strings converts InstallFlags to a slice of human-readable strings.
 func (i InstallFlags) Strings() []string {
 	var out []string
 	for _, flag := range []InstallFlags{
@@ -192,6 +280,7 @@ func (i InstallFlags) Strings() []string {
 	return out
 }
 
+// String returns the string representation of a single InstallFlag flag, or "Unknown".
 func (i InstallFlags) String() string {
 	switch i {
 	case 0:
@@ -202,4 +291,37 @@ func (i InstallFlags) String() string {
 		return "FIPS"
 	}
 	return "Unknown"
+}
+
+// DirFlag returns the directory path representation of a single InstallFlag flag, or "unknown".
+func (i InstallFlags) DirFlag() string {
+	switch i {
+	case 0:
+		return ""
+	case FlagEnterprise:
+		return "ent"
+	case FlagFIPS:
+		return "fips"
+	}
+	return "unknown"
+}
+
+func (i InstallFlags) MarshalYAML() (any, error) {
+	return i.Strings(), nil
+}
+
+func (i InstallFlags) MarshalJSON() ([]byte, error) {
+	return json.Marshal(i.Strings())
+}
+
+func (i *InstallFlags) UnmarshalYAML(n *yaml.Node) error {
+	var s []string
+	if err := n.Decode(&s); err != nil {
+		return trace.Wrap(err)
+	}
+	if i == nil {
+		return trace.Errorf("nil install flags while parsing YAML")
+	}
+	*i = NewInstallFlagsFromStrings(s)
+	return nil
 }

--- a/lib/autoupdate/agent/config.go
+++ b/lib/autoupdate/agent/config.go
@@ -320,7 +320,7 @@ func (i *InstallFlags) UnmarshalYAML(n *yaml.Node) error {
 		return trace.Wrap(err)
 	}
 	if i == nil {
-		return trace.Errorf("nil install flags while parsing YAML")
+		return trace.BadParameter("nil install flags while parsing YAML")
 	}
 	*i = NewInstallFlagsFromStrings(s)
 	return nil

--- a/lib/autoupdate/agent/config_test.go
+++ b/lib/autoupdate/agent/config_test.go
@@ -1,3 +1,21 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package agent
 
 import (

--- a/lib/autoupdate/agent/config_test.go
+++ b/lib/autoupdate/agent/config_test.go
@@ -1,0 +1,177 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestNewRevisionFromDir(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name     string
+		dir      string
+		rev      Revision
+		errMatch string
+	}{
+		{
+			name: "version",
+			dir:  "1.2.3",
+			rev: Revision{
+				Version: "1.2.3",
+			},
+		},
+		{
+			name: "full",
+			dir:  "1.2.3_ent_fips",
+			rev: Revision{
+				Version: "1.2.3",
+				Flags:   FlagEnterprise | FlagFIPS,
+			},
+		},
+		{
+			name: "ent",
+			dir:  "1.2.3_ent",
+			rev: Revision{
+				Version: "1.2.3",
+				Flags:   FlagEnterprise,
+			},
+		},
+		{
+			name:     "empty",
+			errMatch: "missing",
+		},
+		{
+			name:     "trailing",
+			dir:      "1.2.3_",
+			errMatch: "invalid",
+		},
+		{
+			name:     "more trailing",
+			dir:      "1.2.3___",
+			errMatch: "invalid",
+		},
+		{
+			name:     "no version",
+			dir:      "_fips",
+			errMatch: "missing",
+		},
+		{
+			name:     "fips no ent",
+			dir:      "1.2.3_fips",
+			errMatch: "invalid",
+		},
+		{
+			name:     "unknown start fips",
+			dir:      "1.2.3_test_fips",
+			errMatch: "invalid",
+		},
+		{
+			name:     "unknown start ent",
+			dir:      "1.2.3_test_ent",
+			errMatch: "invalid",
+		},
+		{
+			name:     "unknown end fips",
+			dir:      "1.2.3_fips_test",
+			errMatch: "invalid",
+		},
+		{
+			name:     "unknown end ent",
+			dir:      "1.2.3_ent_test",
+			errMatch: "invalid",
+		},
+		{
+			name:     "bad order",
+			dir:      "1.2.3_fips_ent",
+			errMatch: "invalid",
+		},
+		{
+			name:     "underscore",
+			dir:      "_",
+			errMatch: "missing",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			rev, err := NewRevisionFromDir(tt.dir)
+			if tt.errMatch != "" {
+				require.ErrorContains(t, err, tt.errMatch)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.rev, rev)
+			require.Equal(t, tt.dir, rev.Dir())
+		})
+	}
+}
+
+func TestInstallFlagsYAML(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name     string
+		yaml     string
+		flags    InstallFlags
+		skipYAML bool
+	}{
+		{
+			name:  "both",
+			yaml:  `["Enterprise", "FIPS"]`,
+			flags: FlagEnterprise | FlagFIPS,
+		},
+		{
+			name:     "order",
+			yaml:     `["FIPS", "Enterprise"]`,
+			flags:    FlagEnterprise | FlagFIPS,
+			skipYAML: true,
+		},
+		{
+			name:     "extra",
+			yaml:     `["FIPS", "Enterprise", "bad"]`,
+			flags:    FlagEnterprise | FlagFIPS,
+			skipYAML: true,
+		},
+		{
+			name:  "enterprise",
+			yaml:  `["Enterprise"]`,
+			flags: FlagEnterprise,
+		},
+		{
+			name:  "fips",
+			yaml:  `["FIPS"]`,
+			flags: FlagFIPS,
+		},
+		{
+			name: "empty",
+			yaml: `[]`,
+		},
+		{
+			name:     "nil",
+			skipYAML: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var flags InstallFlags
+			err := yaml.Unmarshal([]byte(tt.yaml), &flags)
+			require.NoError(t, err)
+			require.Equal(t, tt.flags, flags)
+
+			// verify test YAML
+			var v any
+			err = yaml.Unmarshal([]byte(tt.yaml), &v)
+			require.NoError(t, err)
+			res, err := yaml.Marshal(v)
+			require.NoError(t, err)
+
+			// compare verified YAML to flag output
+			out, err := yaml.Marshal(flags)
+			require.NoError(t, err)
+
+			if !tt.skipYAML {
+				require.Equal(t, string(res), string(out))
+			}
+		})
+	}
+}

--- a/lib/autoupdate/agent/installer.go
+++ b/lib/autoupdate/agent/installer.go
@@ -346,11 +346,11 @@ func (li *LocalInstaller) extract(ctx context.Context, dstDir string, src io.Rea
 	}
 	free, err := utils.FreeDiskWithReserve(dstDir, li.ReservedFreeInstallDisk)
 	if err != nil {
-		return trace.Wrap(err, "failed to calculate free disk in %q", dstDir)
+		return trace.Wrap(err, "failed to calculate free disk in %s", dstDir)
 	}
 	// Bail if there's not enough free disk space at the target
 	if d := int64(free) - max; d < 0 {
-		return trace.Errorf("%q needs %d additional bytes of disk space for decompression", dstDir, -d)
+		return trace.Errorf("%s needs %d additional bytes of disk space for decompression", dstDir, -d)
 	}
 	zr, err := gzip.NewReader(src)
 	if err != nil {

--- a/lib/autoupdate/agent/installer.go
+++ b/lib/autoupdate/agent/installer.go
@@ -91,12 +91,12 @@ type LocalInstaller struct {
 // Remove a Teleport version directory from InstallDir.
 // This function is idempotent.
 // See Installer interface for additional specs.
-func (li *LocalInstaller) Remove(ctx context.Context, version string) error {
+func (li *LocalInstaller) Remove(ctx context.Context, rev Revision) error {
 	// os.RemoveAll is dangerous because it can remove an entire directory tree.
 	// We must validate the version to ensure that we remove only a single path
 	// element under the InstallDir, and not InstallDir or its parents.
-	// versionDir performs these validations.
-	versionDir, err := li.versionDir(version)
+	// revisionDir performs these validations.
+	versionDir, err := li.revisionDir(rev)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -124,15 +124,15 @@ func (li *LocalInstaller) Remove(ctx context.Context, version string) error {
 // Install a Teleport version directory in InstallDir.
 // This function is idempotent.
 // See Installer interface for additional specs.
-func (li *LocalInstaller) Install(ctx context.Context, version, template string, flags InstallFlags) (err error) {
-	versionDir, err := li.versionDir(version)
+func (li *LocalInstaller) Install(ctx context.Context, rev Revision, template string) (err error) {
+	versionDir, err := li.revisionDir(rev)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	sumPath := filepath.Join(versionDir, checksumType)
 
 	// generate download URI from template
-	uri, err := makeURL(template, version, flags)
+	uri, err := makeURL(template, rev)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -147,16 +147,16 @@ func (li *LocalInstaller) Install(ctx context.Context, version, template string,
 	oldSum, err := readChecksum(sumPath)
 	if err == nil {
 		if bytes.Equal(oldSum, newSum) {
-			li.Log.InfoContext(ctx, "Version already present.", "version", version)
+			li.Log.InfoContext(ctx, "Version already present.", "version", rev)
 			return nil
 		}
-		li.Log.WarnContext(ctx, "Removing version that does not match checksum.", "version", version)
-		if err := li.Remove(ctx, version); err != nil {
+		li.Log.WarnContext(ctx, "Removing version that does not match checksum.", "version", rev)
+		if err := li.Remove(ctx, rev); err != nil {
 			return trace.Wrap(err)
 		}
 	} else if !errors.Is(err, os.ErrNotExist) {
-		li.Log.WarnContext(ctx, "Removing version with unreadable checksum.", "version", version, "error", err)
-		if err := li.Remove(ctx, version); err != nil {
+		li.Log.WarnContext(ctx, "Removing version with unreadable checksum.", "version", rev, "error", err)
+		if err := li.Remove(ctx, rev); err != nil {
 			return trace.Wrap(err)
 		}
 	}
@@ -215,7 +215,7 @@ func (li *LocalInstaller) Install(ctx context.Context, version, template string,
 	}()
 
 	// Extract tgz into version directory.
-	if err := li.extract(ctx, versionDir, f, n, flags); err != nil {
+	if err := li.extract(ctx, versionDir, f, n, rev.Flags); err != nil {
 		return trace.Wrap(err, "failed to extract teleport")
 	}
 	// Write the checksum last. This marks the version directory as valid.
@@ -227,7 +227,7 @@ func (li *LocalInstaller) Install(ctx context.Context, version, template string,
 }
 
 // makeURL to download the Teleport tgz.
-func makeURL(uriTmpl, version string, flags InstallFlags) (string, error) {
+func makeURL(uriTmpl string, rev Revision) (string, error) {
 	tmpl, err := template.New("uri").Parse(uriTmpl)
 	if err != nil {
 		return "", trace.Wrap(err)
@@ -238,10 +238,10 @@ func makeURL(uriTmpl, version string, flags InstallFlags) (string, error) {
 		FIPS, Enterprise  bool
 	}{
 		OS:         runtime.GOOS,
-		Version:    version,
+		Version:    rev.Version,
 		Arch:       runtime.GOARCH,
-		FIPS:       flags&FlagFIPS != 0,
-		Enterprise: flags&(FlagEnterprise|FlagFIPS) != 0,
+		FIPS:       rev.Flags&FlagFIPS != 0,
+		Enterprise: rev.Flags&(FlagEnterprise|FlagFIPS) != 0,
 	}
 	err = tmpl.Execute(&uriBuf, params)
 	if err != nil {
@@ -401,7 +401,7 @@ func uncompressedSize(f io.Reader) (int64, error) {
 }
 
 // List installed versions of Teleport.
-func (li *LocalInstaller) List(ctx context.Context) (versions []string, err error) {
+func (li *LocalInstaller) List(ctx context.Context) (revs []Revision, err error) {
 	entries, err := os.ReadDir(li.InstallDir)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -410,17 +410,21 @@ func (li *LocalInstaller) List(ctx context.Context) (versions []string, err erro
 		if !entry.IsDir() {
 			continue
 		}
-		versions = append(versions, entry.Name())
+		rev, err := NewRevisionFromDir(entry.Name())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		revs = append(revs, rev)
 	}
-	return versions, nil
+	return revs, nil
 }
 
 // Link the specified version into the system LinkBinDir and CopyServiceFile.
 // The revert function restores the previous linking.
 // See Installer interface for additional specs.
-func (li *LocalInstaller) Link(ctx context.Context, version string) (revert func(context.Context) bool, err error) {
+func (li *LocalInstaller) Link(ctx context.Context, rev Revision) (revert func(context.Context) bool, err error) {
 	revert = func(context.Context) bool { return true }
-	versionDir, err := li.versionDir(version)
+	versionDir, err := li.revisionDir(rev)
 	if err != nil {
 		return revert, trace.Wrap(err)
 	}
@@ -445,8 +449,8 @@ func (li *LocalInstaller) LinkSystem(ctx context.Context) (revert func(context.C
 // TryLink links the specified version, but only in the case that
 // no installation of Teleport is already linked or partially linked.
 // See Installer interface for additional specs.
-func (li *LocalInstaller) TryLink(ctx context.Context, version string) error {
-	versionDir, err := li.versionDir(version)
+func (li *LocalInstaller) TryLink(ctx context.Context, revision Revision) error {
+	versionDir, err := li.revisionDir(revision)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -465,8 +469,8 @@ func (li *LocalInstaller) TryLinkSystem(ctx context.Context) error {
 
 // Unlink unlinks a version from LinkBinDir and CopyServiceFile.
 // See Installer interface for additional specs.
-func (li *LocalInstaller) Unlink(ctx context.Context, version string) error {
-	versionDir, err := li.versionDir(version)
+func (li *LocalInstaller) Unlink(ctx context.Context, rev Revision) error {
+	versionDir, err := li.revisionDir(rev)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -833,15 +837,15 @@ func needsLink(oldname, newname string) (ok bool, err error) {
 	return false, nil
 }
 
-// versionDir returns the storage directory for a Teleport version.
-// versionDir will fail if the version cannot be used to construct the directory name.
+// revisionDir returns the storage directory for a Teleport revision.
+// revisionDir will fail if the revision cannot be used to construct the directory name.
 // For example, it ensures that ".." cannot be provided to return a system directory.
-func (li *LocalInstaller) versionDir(version string) (string, error) {
+func (li *LocalInstaller) revisionDir(rev Revision) (string, error) {
 	installDir, err := filepath.Abs(li.InstallDir)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
-	versionDir := filepath.Join(installDir, version)
+	versionDir := filepath.Join(installDir, rev.Dir())
 	if filepath.Dir(versionDir) != filepath.Clean(installDir) {
 		return "", trace.Errorf("refusing to link directory outside of version directory")
 	}

--- a/lib/autoupdate/agent/installer_test.go
+++ b/lib/autoupdate/agent/installer_test.go
@@ -124,7 +124,7 @@ func TestLocalInstaller_Install(t *testing.T) {
 				ReservedFreeInstallDisk: tt.reservedInstall,
 			}
 			ctx := context.Background()
-			err := installer.Install(ctx, version, server.URL+"/{{.OS}}/{{.Arch}}/{{.Version}}", tt.flags)
+			err := installer.Install(ctx, NewRevision(version, tt.flags), server.URL+"/{{.OS}}/{{.Arch}}/{{.Version}}")
 			if tt.errMatch != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errMatch)
@@ -406,7 +406,7 @@ func TestLocalInstaller_Link(t *testing.T) {
 				},
 			}
 			ctx := context.Background()
-			revert, err := installer.Link(ctx, version)
+			revert, err := installer.Link(ctx, NewRevision(version, 0))
 			if tt.errMatch != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errMatch)
@@ -659,7 +659,7 @@ func TestLocalInstaller_TryLink(t *testing.T) {
 				},
 			}
 			ctx := context.Background()
-			err = installer.TryLink(ctx, version)
+			err = installer.TryLink(ctx, NewRevision(version, 0))
 			if tt.errMatch != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errMatch)
@@ -809,10 +809,10 @@ func TestLocalInstaller_Remove(t *testing.T) {
 			ctx := context.Background()
 
 			if tt.linkedVersion != "" {
-				_, err = installer.Link(ctx, tt.linkedVersion)
+				_, err = installer.Link(ctx, NewRevision(tt.linkedVersion, 0))
 				require.NoError(t, err)
 			}
-			err = installer.Remove(ctx, tt.removeVersion)
+			err = installer.Remove(ctx, NewRevision(tt.removeVersion, 0))
 			if tt.errMatch != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errMatch)
@@ -981,7 +981,7 @@ func TestLocalInstaller_Unlink(t *testing.T) {
 				},
 			}
 			ctx := context.Background()
-			err = installer.Unlink(ctx, version)
+			err = installer.Unlink(ctx, NewRevision(version, 0))
 			if tt.errMatch != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errMatch)
@@ -1024,7 +1024,10 @@ func TestLocalInstaller_List(t *testing.T) {
 		Log:        slog.Default(),
 	}
 	ctx := context.Background()
-	versions, err := installer.List(ctx)
+	revisions, err := installer.List(ctx)
 	require.NoError(t, err)
-	require.Equal(t, []string{"v1", "v2"}, versions)
+	require.Equal(t, []Revision{
+		NewRevision("v1", 0),
+		NewRevision("v2", 0),
+	}, revisions)
 }

--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -298,14 +298,14 @@ func (s SystemdService) IsEnabled(ctx context.Context) (bool, error) {
 	code := s.systemctl(ctx, slog.LevelDebug, "is-enabled", "--quiet", s.ServiceName)
 	switch {
 	case code < 0:
-		return false, trace.Errorf("unable to determine if systemd service %q is enabled", s.ServiceName)
+		return false, trace.Errorf("unable to determine if systemd service %s is enabled", s.ServiceName)
 	case code == 0:
 		return true, nil
 	}
 	code = s.systemctl(ctx, slog.LevelDebug, "is-active", "--quiet", s.ServiceName)
 	switch {
 	case code < 0:
-		return false, trace.Errorf("unable to determine if systemd service %q is active", s.ServiceName)
+		return false, trace.Errorf("unable to determine if systemd service %s is active", s.ServiceName)
 	case code == 0:
 		return true, nil
 	}

--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -34,9 +34,9 @@ import (
 )
 
 const (
-	// crashMonitorInterval is the polling interval for determining restart times from LastRestartPath.
+	// crashMonitorInterval is the polling interval for determining restart times from PIDFile.
 	crashMonitorInterval = 2 * time.Second
-	// minRunningIntervalsBeforeStable is the number of consecutive intervals with the same running PID detect
+	// minRunningIntervalsBeforeStable is the number of consecutive intervals with the same running PID detected
 	// before the service is determined stable.
 	minRunningIntervalsBeforeStable = 6
 	// maxCrashesBeforeFailure is the number of total crashes detected before the service is marked as crash-looping.

--- a/lib/autoupdate/agent/setup.go
+++ b/lib/autoupdate/agent/setup.go
@@ -107,10 +107,10 @@ var alphanum = regexp.MustCompile("^[a-zA-Z0-9-]*$")
 func NewNamespace(log *slog.Logger, name, dataDir, linkDir string) (*Namespace, error) {
 	if name == defaultNamespace ||
 		name == systemNamespace {
-		return nil, trace.Errorf("namespace %q is reserved", name)
+		return nil, trace.Errorf("namespace %s is reserved", name)
 	}
 	if !alphanum.MatchString(name) {
-		return nil, trace.Errorf("invalid namespace name %q, must be alphanumeric", name)
+		return nil, trace.Errorf("invalid namespace name %s, must be alphanumeric", name)
 	}
 	if name == "" {
 		if dataDir == "" {

--- a/lib/autoupdate/agent/testdata/TestUpdater_Disable/already_disabled.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Disable/already_disabled.golden
@@ -5,5 +5,5 @@ spec:
     enabled: false
     pinned: false
 status:
-    active_version: ""
-    backup_version: ""
+    active:
+        version: ""

--- a/lib/autoupdate/agent/testdata/TestUpdater_Disable/enabled.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Disable/enabled.golden
@@ -5,5 +5,5 @@ spec:
     enabled: false
     pinned: false
 status:
-    active_version: ""
-    backup_version: ""
+    active:
+        version: ""

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/FIPS_and_Enterprise_flags.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/FIPS_and_Enterprise_flags.golden
@@ -5,5 +5,6 @@ spec:
     enabled: false
     pinned: false
 status:
-    active_version: 16.3.0
-    backup_version: ""
+    active:
+        version: 16.3.0
+        flags: [Enterprise, FIPS]

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/backup_version_kept_for_validation.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/backup_version_kept_for_validation.golden
@@ -5,5 +5,7 @@ spec:
     enabled: false
     pinned: false
 status:
-    active_version: 16.3.0
-    backup_version: backup-version
+    active:
+        version: 16.3.0
+    backup:
+        version: backup-version

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/backup_version_removed_on_install.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/backup_version_removed_on_install.golden
@@ -5,5 +5,7 @@ spec:
     enabled: false
     pinned: false
 status:
-    active_version: 16.3.0
-    backup_version: old-version
+    active:
+        version: 16.3.0
+    backup:
+        version: old-version

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/config_does_not_exist.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/config_does_not_exist.golden
@@ -5,5 +5,5 @@ spec:
     enabled: false
     pinned: false
 status:
-    active_version: 16.3.0
-    backup_version: ""
+    active:
+        version: 16.3.0

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/config_from_file.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/config_from_file.golden
@@ -7,5 +7,7 @@ spec:
     enabled: true
     pinned: false
 status:
-    active_version: 16.3.0
-    backup_version: old-version
+    active:
+        version: 16.3.0
+    backup:
+        version: old-version

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/config_from_user.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/config_from_user.golden
@@ -7,5 +7,7 @@ spec:
     enabled: true
     pinned: false
 status:
-    active_version: new-version
-    backup_version: old-version
+    active:
+        version: new-version
+    backup:
+        version: old-version

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/defaults.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/defaults.golden
@@ -5,5 +5,7 @@ spec:
     enabled: false
     pinned: false
 status:
-    active_version: 16.3.0
-    backup_version: old-version
+    active:
+        version: 16.3.0
+    backup:
+        version: old-version

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/insecure_URL.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/insecure_URL.golden
@@ -6,5 +6,5 @@ spec:
     enabled: false
     pinned: false
 status:
-    active_version: ""
-    backup_version: ""
+    active:
+        version: ""

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/install_error.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/install_error.golden
@@ -5,5 +5,5 @@ spec:
     enabled: false
     pinned: false
 status:
-    active_version: ""
-    backup_version: ""
+    active:
+        version: ""

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/invalid_metadata.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/invalid_metadata.golden
@@ -5,5 +5,5 @@ spec:
     enabled: false
     pinned: false
 status:
-    active_version: ""
-    backup_version: ""
+    active:
+        version: ""

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/no_need_to_reload.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/no_need_to_reload.golden
@@ -5,5 +5,5 @@ spec:
     enabled: false
     pinned: false
 status:
-    active_version: 16.3.0
-    backup_version: ""
+    active:
+        version: 16.3.0

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/no_systemd.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/no_systemd.golden
@@ -5,5 +5,5 @@ spec:
     enabled: false
     pinned: false
 status:
-    active_version: 16.3.0
-    backup_version: ""
+    active:
+        version: 16.3.0

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/override_skip.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/override_skip.golden
@@ -5,5 +5,7 @@ spec:
     enabled: false
     pinned: false
 status:
-    active_version: 16.3.0
-    backup_version: old-version
+    active:
+        version: 16.3.0
+    backup:
+        version: old-version

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/version_already_installed.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/version_already_installed.golden
@@ -5,5 +5,5 @@ spec:
     enabled: false
     pinned: false
 status:
-    active_version: 16.3.0
-    backup_version: ""
+    active:
+        version: 16.3.0

--- a/lib/autoupdate/agent/testdata/TestUpdater_Unpin/not_pinned.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Unpin/not_pinned.golden
@@ -5,5 +5,5 @@ spec:
     enabled: false
     pinned: false
 status:
-    active_version: ""
-    backup_version: ""
+    active:
+        version: ""

--- a/lib/autoupdate/agent/testdata/TestUpdater_Unpin/pinned.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Unpin/pinned.golden
@@ -5,5 +5,5 @@ spec:
     enabled: false
     pinned: false
 status:
-    active_version: ""
-    backup_version: ""
+    active:
+        version: ""

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/FIPS_and_Enterprise_flags.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/FIPS_and_Enterprise_flags.golden
@@ -6,5 +6,9 @@ spec:
     enabled: true
     pinned: false
 status:
-    active_version: 16.3.0
-    backup_version: old-version
+    active:
+        version: 16.3.0
+        flags: [Enterprise, FIPS]
+    backup:
+        version: old-version
+        flags: [Enterprise, FIPS]

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/backup_version_kept_when_no_change.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/backup_version_kept_when_no_change.golden
@@ -6,5 +6,7 @@ spec:
     enabled: true
     pinned: false
 status:
-    active_version: 16.3.0
-    backup_version: backup-version
+    active:
+        version: 16.3.0
+    backup:
+        version: backup-version

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/backup_version_removed_on_install.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/backup_version_removed_on_install.golden
@@ -6,5 +6,7 @@ spec:
     enabled: true
     pinned: false
 status:
-    active_version: 16.3.0
-    backup_version: old-version
+    active:
+        version: 16.3.0
+    backup:
+        version: old-version

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/insecure_URL.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/insecure_URL.golden
@@ -6,5 +6,5 @@ spec:
     enabled: true
     pinned: false
 status:
-    active_version: ""
-    backup_version: ""
+    active:
+        version: ""

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/install_error.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/install_error.golden
@@ -5,5 +5,5 @@ spec:
     enabled: true
     pinned: false
 status:
-    active_version: ""
-    backup_version: ""
+    active:
+        version: ""

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/invalid_metadata.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/invalid_metadata.golden
@@ -5,5 +5,5 @@ spec:
     enabled: false
     pinned: false
 status:
-    active_version: ""
-    backup_version: ""
+    active:
+        version: ""

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/pinned_version.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/pinned_version.golden
@@ -6,5 +6,7 @@ spec:
     enabled: true
     pinned: true
 status:
-    active_version: old-version
-    backup_version: backup-version
+    active:
+        version: old-version
+    backup:
+        version: backup-version

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/reload_fails.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/reload_fails.golden
@@ -6,6 +6,9 @@ spec:
     enabled: true
     pinned: false
 status:
-    active_version: old-version
-    backup_version: backup-version
-    skip_version: 16.3.0
+    active:
+        version: old-version
+    backup:
+        version: backup-version
+    skip:
+        version: 16.3.0

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/setup_fails.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/setup_fails.golden
@@ -6,6 +6,9 @@ spec:
     enabled: true
     pinned: false
 status:
-    active_version: old-version
-    backup_version: backup-version
-    skip_version: 16.3.0
+    active:
+        version: old-version
+    backup:
+        version: backup-version
+    skip:
+        version: 16.3.0

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/skip_version.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/skip_version.golden
@@ -6,6 +6,9 @@ spec:
     enabled: true
     pinned: false
 status:
-    active_version: old-version
-    backup_version: backup-version
-    skip_version: 16.3.0
+    active:
+        version: old-version
+    backup:
+        version: backup-version
+    skip:
+        version: 16.3.0

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_disabled_during_window.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_disabled_during_window.golden
@@ -7,5 +7,5 @@ spec:
     enabled: false
     pinned: false
 status:
-    active_version: old-version
-    backup_version: ""
+    active:
+        version: old-version

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_disabled_outside_of_window.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_disabled_outside_of_window.golden
@@ -7,5 +7,5 @@ spec:
     enabled: false
     pinned: false
 status:
-    active_version: old-version
-    backup_version: ""
+    active:
+        version: old-version

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_enabled_during_window.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_enabled_during_window.golden
@@ -7,5 +7,7 @@ spec:
     enabled: true
     pinned: false
 status:
-    active_version: 16.3.0
-    backup_version: old-version
+    active:
+        version: 16.3.0
+    backup:
+        version: old-version

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_enabled_outside_of_window.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_enabled_outside_of_window.golden
@@ -7,5 +7,5 @@ spec:
     enabled: true
     pinned: false
 status:
-    active_version: old-version
-    backup_version: ""
+    active:
+        version: old-version

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/version_already_installed_in_window.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/version_already_installed_in_window.golden
@@ -6,5 +6,5 @@ spec:
     enabled: true
     pinned: false
 status:
-    active_version: 16.3.0
-    backup_version: ""
+    active:
+        version: 16.3.0

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/version_already_installed_outside_of_window.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/version_already_installed_outside_of_window.golden
@@ -6,5 +6,5 @@ spec:
     enabled: true
     pinned: false
 status:
-    active_version: 16.3.0
-    backup_version: ""
+    active:
+        version: 16.3.0


### PR DESCRIPTION
This PR adds support for migrating agents to/from Enterprise or Enterprise FIPS editions of Teleport

This is accomplished by storing install flags in update.yaml, and appending `_ent` or `_ent_fips` to version directories.
```shell
ubuntu@legendary-mite:~$ ./teleport-update status
proxy: example.com
enabled: true
pinned: false
active:
    version: 16.4.7
    flags: [Enterprise]
target:
    version: 16.4.7
    flags: [Enterprise]
in_window: true
jitter: 1m0s
```
---

The `teleport-update` binary will be used to enable, disable, and trigger automatic Teleport agent updates. The new auto-updates system manages a local installation of the cluster-specified version of Teleport stored in `/var/lib/teleport/versions`.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/10289