### PR TITLE
Pass port from VNet to local proxy

### DIFF
--- a/lib/vnet/app_resolver.go
+++ b/lib/vnet/app_resolver.go
@@ -40,7 +40,6 @@ import (
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy"
 	alpncommon "github.com/gravitational/teleport/lib/srv/alpnproxy/common"
-	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 // AppProvider is an interface providing the necessary methods to log in to apps and get clients able to list
@@ -111,7 +110,7 @@ type TCPAppResolver struct {
 func NewTCPAppResolver(appProvider AppProvider, opts ...tcpAppResolverOption) (*TCPAppResolver, error) {
 	r := &TCPAppResolver{
 		appProvider: appProvider,
-		log:         logutils.NewPackageLogger(teleport.ComponentKey, "VNet.AppResolver"),
+		log:         log.With(teleport.ComponentKey, "VNet.AppResolver"),
 	}
 	for _, opt := range opts {
 		opt(r)

--- a/lib/vnet/app_resolver.go
+++ b/lib/vnet/app_resolver.go
@@ -325,6 +325,8 @@ func (h *tcpAppHandler) getOrInitializeLocalProxy(ctx context.Context, localPort
 	if len(h.app.GetTCPPorts()) == 0 {
 		localPort = 0
 	}
+	// TODO(ravicious): For multi-port apps, check if localPort is valid and surface the error in UI.
+	// https://github.com/gravitational/teleport/blob/master/rfd/0182-multi-port-tcp-app-access.md#incorrect-port
 
 	lp, ok := h.portToLocalProxy[localPort]
 	if ok {

--- a/lib/vnet/app_resolver.go
+++ b/lib/vnet/app_resolver.go
@@ -265,7 +265,7 @@ func (r *TCPAppResolver) resolveTCPHandlerForCluster(
 		return nil, ErrNoTCPHandler
 	}
 	app := resp.Resources[0].GetApp()
-	appHandler, err := r.newTCPAppHandler(ctx, log, profileName, leafClusterName, app)
+	appHandler, err := r.newTCPAppHandler(ctx, profileName, leafClusterName, app)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -295,7 +295,6 @@ type tcpAppHandler struct {
 
 func (r *TCPAppResolver) newTCPAppHandler(
 	ctx context.Context,
-	log *slog.Logger,
 	profileName string,
 	leafClusterName string,
 	app types.Application,
@@ -307,7 +306,8 @@ func (r *TCPAppResolver) newTCPAppHandler(
 		leafClusterName:  leafClusterName,
 		app:              app,
 		portToLocalProxy: make(map[uint16]*alpnproxy.LocalProxy),
-		log:              log.With(teleport.ComponentKey, "VNet.AppHandler"),
+		log: r.log.With(teleport.ComponentKey, "VNet.AppHandler",
+			"profile", profileName, "leaf_cluster", leafClusterName, "fqdn", app.GetPublicAddr()),
 	}, nil
 }
 

--- a/lib/vnet/vnet.go
+++ b/lib/vnet/vnet.go
@@ -117,7 +117,7 @@ type TCPHandlerSpec struct {
 // [connector] to complete the TCP handshake and get the TCP conn. This is so that clients will see that the
 // TCP connection was refused, instead of seeing a successful TCP dial that is immediately closed.
 type TCPHandler interface {
-	HandleTCPConnector(ctx context.Context, connector func() (net.Conn, error)) error
+	HandleTCPConnector(ctx context.Context, localPort uint16, connector func() (net.Conn, error)) error
 }
 
 // UDPHandler defines the behavior for handling UDP connections from VNet.
@@ -423,7 +423,7 @@ func (ns *NetworkStack) handleTCP(req *tcp.ForwarderRequest) {
 		return conn, nil
 	}
 
-	if err := handler.HandleTCPConnector(ctx, connector); err != nil {
+	if err := handler.HandleTCPConnector(ctx, id.LocalPort, connector); err != nil {
 		if errors.Is(err, context.Canceled) {
 			slog.DebugContext(ctx, "TCP connection handler returned early due to canceled context.")
 		} else {

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -242,7 +242,7 @@ func (n noUpstreamNameservers) UpstreamNameservers(ctx context.Context) ([]strin
 }
 
 type appSpec struct {
-	// publicAddr is used bothas the name of the app and its public address in the final spec.
+	// publicAddr is used both as the name of the app and its public address in the final spec.
 	publicAddr string
 	tcpPorts   []*types.PortRange
 }

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -491,21 +491,11 @@ func TestDialFakeApp(t *testing.T) {
 	appProvider := newEchoAppProvider(map[string]testClusterSpec{
 		"root1.example.com": {
 			apps: []appSpec{
-				appSpec{
-					publicAddr: "echo1.root1.example.com",
-				},
-				appSpec{
-					publicAddr: "echo2.root1.example.com",
-				},
-				appSpec{
-					publicAddr: "echo.myzone.example.com",
-				},
-				appSpec{
-					publicAddr: "echo.nested.myzone.example.com",
-				},
-				appSpec{
-					publicAddr: "not.in.a.custom.zone",
-				},
+				appSpec{publicAddr: "echo1.root1.example.com"},
+				appSpec{publicAddr: "echo2.root1.example.com"},
+				appSpec{publicAddr: "echo.myzone.example.com"},
+				appSpec{publicAddr: "echo.nested.myzone.example.com"},
+				appSpec{publicAddr: "not.in.a.custom.zone"},
 				appSpec{
 					publicAddr: "multi-port.root1.example.com",
 					tcpPorts: []*types.PortRange{
@@ -525,9 +515,7 @@ func TestDialFakeApp(t *testing.T) {
 			leafClusters: map[string]testClusterSpec{
 				"leaf1.example.com": {
 					apps: []appSpec{
-						appSpec{
-							publicAddr: "echo1.leaf1.example.com",
-						},
+						appSpec{publicAddr: "echo1.leaf1.example.com"},
 						appSpec{
 							publicAddr: "multi-port.leaf1.example.com",
 							tcpPorts: []*types.PortRange{
@@ -543,28 +531,20 @@ func TestDialFakeApp(t *testing.T) {
 				},
 				"leaf2.example.com": {
 					apps: []appSpec{
-						appSpec{
-							publicAddr: "echo1.leaf2.example.com",
-						},
+						appSpec{publicAddr: "echo1.leaf2.example.com"},
 					},
 				},
 			},
 		},
 		"root2.example.com": {
 			apps: []appSpec{
-				appSpec{
-					publicAddr: "echo1.root2.example.com",
-				},
-				appSpec{
-					publicAddr: "echo2.root2.example.com",
-				},
+				appSpec{publicAddr: "echo1.root2.example.com"},
+				appSpec{publicAddr: "echo2.root2.example.com"},
 			},
 			leafClusters: map[string]testClusterSpec{
 				"leaf3.example.com": {
 					apps: []appSpec{
-						appSpec{
-							publicAddr: "echo1.leaf3.example.com",
-						},
+						appSpec{publicAddr: "echo1.leaf3.example.com"},
 					},
 				},
 			},
@@ -733,9 +713,7 @@ func TestOnNewConnection(t *testing.T) {
 	appProvider := newEchoAppProvider(map[string]testClusterSpec{
 		"root1.example.com": {
 			apps: []appSpec{
-				appSpec{
-					publicAddr: "echo1",
-				},
+				appSpec{publicAddr: "echo1"},
 			},
 			cidrRange:    "192.168.2.0/24",
 			leafClusters: map[string]testClusterSpec{},


### PR DESCRIPTION
* Part of #46758.

Depends on #49047 and #49349. This PR implements the section of the RFD called [Passing the port number from VNet to the client](https://github.com/gravitational/teleport/blob/master/rfd/0182-multi-port-tcp-app-access.md#passing-the-port-number-from-vnet-to-the-client).

The way VNet used to work was that when a DNS query came in for an FQDN that matched the public address of an app in the cluster, VNet would create a virtual IP for it and a local proxy (ala `tsh proxy app`). Then the TCP connection would be routed through that proxy to the URI specified in the app spec.

Adding multi-port support means that if we have an app spec such as this:

```yaml
- name: multi-port-example
  uri: tcp://localhost
  tcp_ports:
    - port: 5434 # Postgres
    - port: 8765 # HTTP echo
```

then a user should be able to start VNet and do `curl http://multi-port-example.cluster.example.com:8765` on their computer. This connection should be then routed to `localhost:8765` on the machine that's running the app service.

The backend part was implemented in #49047. This PR makes it so that when a TCP connection comes in, VNet reads the port and only then creates a local proxy with a proper `TargetPort` set in `RouteToApp`.

## Implementation details

`lib/vnet/vnet.go` has `NetworkStack.handleTCP` which gets called on a new TCP connection. At that point, VNet grabs a `tcpAppHandler`, which is still created when a DNS query comes in – a handler is still associated with an FQDN of an app.

However, the underlying proxy is not created at the time when `tcpAppHandler` is initialized. Instead, from `NetworkStack.handleTCP` we pass the local port to `tcpAppHandler.HandleTCPConnector` which then gets or initializes a local proxy associated with that local port. The local proxy has `RouteToApp.TargetPort` set to the local port.

The tests are completely removed from how Teleport does routing or cert generation. So to verify that multi-port support works correctly within VNet, we verify if `lib/vnet.AppProvider.ReissueAppCert` is called with correct port in `RouteToApp`.

## How to test this

First compile teleport and tsh from this branch. Then add a TCP app like in the snippet above. I use `mendhak/http-https-echo` Docker image for the HTTP echo.

```yaml
  http-https-echo:
    container_name: teleport-local-http-https-echo
    image: mendhak/http-https-echo:35
    ports:
      - "8765:8080"
```

Then start VNet with `tsh vnet -d` and connect to either of the ports using an appropriate client. If you're using a local cluster, make sure `<app-name>.<cluster-address>` is not in `/etc/hosts`.