### PR TITLE
Add `JoinMethodBitBucket` to `JoinMethods` validation slice

### DIFF
--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -81,6 +81,7 @@ const (
 
 var JoinMethods = []JoinMethod{
 	JoinMethodAzure,
+	JoinMethodBitbucket,
 	JoinMethodCircleCI,
 	JoinMethodEC2,
 	JoinMethodGCP,

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -48,6 +48,7 @@ var tracer = otel.Tracer("github.com/gravitational/teleport/lib/tbot/config")
 
 var SupportedJoinMethods = []string{
 	string(types.JoinMethodAzure),
+	string(types.JoinMethodBitbucket),
 	string(types.JoinMethodCircleCI),
 	string(types.JoinMethodGCP),
 	string(types.JoinMethodGitHub),
@@ -58,7 +59,6 @@ var SupportedJoinMethods = []string{
 	string(types.JoinMethodToken),
 	string(types.JoinMethodTPM),
 	string(types.JoinMethodTerraformCloud),
-	string(types.JoinMethodBitbucket),
 }
 
 var log = logutils.NewPackageLogger(teleport.ComponentKey, teleport.ComponentTBot)


### PR DESCRIPTION
Looks like this was missed out - this shouldn't have any major impacts but could cause problems with agent joining (which we don't really expect)