### PR TITLE
Fix incorrect incompatibility warning in tsh

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -4273,20 +4273,6 @@ Future versions of tsh will fail when incompatible versions are detected.
 			serverVersionWithWildcards, versions.Client, serverVersionWithWildcards), nil
 	}
 
-	// Recent `tsh mfa` changes require at least Teleport v15.
-	const minServerVersion = "15.0.0-aa" // "-aa" matches all development versions
-	if !utils.MeetsMinVersion(versions.Server, minServerVersion) {
-		return fmt.Sprintf(`
-WARNING
-Detected incompatible client and server versions.
-Minimum server version supported by tsh is %v but your server is using %v.
-Please use a tsh version that matches your server.
-You may use the --skip-version-check flag to bypass this check.
-
-`,
-			minServerVersion, versions.Server), nil
-	}
-
 	return "", nil
 }
 

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -4257,8 +4257,17 @@ Future versions of tsh will fail when incompatible versions are detected.
 			versions.MinClient, versions.Client, versions.MinClient), nil
 	}
 
-	if !utils.MeetsMaxVersion(versions.Client, versions.Server) {
-		serverVersionWithWildcards, err := utils.MajorSemverWithWildcards(versions.Server)
+	clientMajorVersion, err := utils.MajorSemver(versions.Client)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	serverMajorVersion, err := utils.MajorSemver(versions.Server)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	if !utils.MeetsMaxVersion(clientMajorVersion, serverMajorVersion) {
+		serverVersionWithWildcards, err := utils.MajorSemverWithWildcards(serverMajorVersion)
 		if err != nil {
 			return "", trace.Wrap(err)
 		}

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -4206,46 +4206,16 @@ func (tc *TeleportClient) Ping(ctx context.Context) (*webclient.PingResponse, er
 
 	// Verify server->client and client->server compatibility.
 	if tc.CheckVersions {
-		if !utils.MeetsMinVersion(teleport.Version, pr.MinClientVersion) {
-			fmt.Fprintf(tc.Stderr, `
-WARNING
-Detected potentially incompatible client and server versions.
-Minimum client version supported by the server is %v but you are using %v.
-Please upgrade tsh to %v or newer or use the --skip-version-check flag to bypass this check.
-Future versions of tsh will fail when incompatible versions are detected.
-
-`,
-				pr.MinClientVersion, teleport.Version, pr.MinClientVersion)
+		warning, err := getClientIncompatibilityWarning(versions{
+			MinClient: pr.MinClientVersion,
+			Client:    teleport.Version,
+			Server:    pr.ServerVersion,
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
-
-		if !utils.MeetsMaxVersion(teleport.Version, pr.ServerVersion) {
-			serverVersionWithWildcards, err := utils.MajorSemverWithWildcards(pr.ServerVersion)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			fmt.Fprintf(tc.Stderr, `
-WARNING
-Detected potentially incompatible client and server versions.
-Maximum client version supported by the server is %v but you are using %v.
-Please downgrade tsh to %v or use the --skip-version-check flag to bypass this check.
-Future versions of tsh will fail when incompatible versions are detected.
-
-`,
-				serverVersionWithWildcards, teleport.Version, serverVersionWithWildcards)
-		}
-
-		// Recent `tsh mfa` changes require at least Teleport v15.
-		const minServerVersion = "15.0.0-aa" // "-aa" matches all development versions
-		if !utils.MeetsMinVersion(pr.ServerVersion, minServerVersion) {
-			fmt.Fprintf(tc.Stderr, `
-WARNING
-Detected incompatible client and server versions.
-Minimum server version supported by tsh is %v but your server is using %v.
-Please use a tsh version that matches your server.
-You may use the --skip-version-check flag to bypass this check.
-
-`,
-				minServerVersion, pr.ServerVersion)
+		if warning != "" {
+			fmt.Fprint(tc.Stderr, warning)
 		}
 	}
 
@@ -4266,6 +4236,58 @@ You may use the --skip-version-check flag to bypass this check.
 	tc.lastPing = pr
 
 	return pr, nil
+}
+
+type versions struct {
+	MinClient string
+	Client    string
+	Server    string
+}
+
+func getClientIncompatibilityWarning(versions versions) (string, error) {
+	if !utils.MeetsMinVersion(versions.Client, versions.MinClient) {
+		return fmt.Sprintf(`
+WARNING
+Detected potentially incompatible client and server versions.
+Minimum client version supported by the server is %v but you are using %v.
+Please upgrade tsh to %v or newer or use the --skip-version-check flag to bypass this check.
+Future versions of tsh will fail when incompatible versions are detected.
+
+`,
+			versions.MinClient, versions.Client, versions.MinClient), nil
+	}
+
+	if !utils.MeetsMaxVersion(versions.Client, versions.Server) {
+		serverVersionWithWildcards, err := utils.MajorSemverWithWildcards(versions.Server)
+		if err != nil {
+			return "", trace.Wrap(err)
+		}
+		return fmt.Sprintf(`
+WARNING
+Detected potentially incompatible client and server versions.
+Maximum client version supported by the server is %v but you are using %v.
+Please downgrade tsh to %v or use the --skip-version-check flag to bypass this check.
+Future versions of tsh will fail when incompatible versions are detected.
+
+`,
+			serverVersionWithWildcards, versions.Client, serverVersionWithWildcards), nil
+	}
+
+	// Recent `tsh mfa` changes require at least Teleport v15.
+	const minServerVersion = "15.0.0-aa" // "-aa" matches all development versions
+	if !utils.MeetsMinVersion(versions.Server, minServerVersion) {
+		return fmt.Sprintf(`
+WARNING
+Detected incompatible client and server versions.
+Minimum server version supported by tsh is %v but your server is using %v.
+Please use a tsh version that matches your server.
+You may use the --skip-version-check flag to bypass this check.
+
+`,
+			minServerVersion, versions.Server), nil
+	}
+
+	return "", nil
 }
 
 // GetCurrentSignatureAlgorithmSuite returns the current signature algorithm


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/49441

When [adding a warning about connecting to a too old cluster from tsh](https://github.com/gravitational/teleport/pull/43461), I mistakenly compared the entire version strings instead of major versions only. This caused the warning to be shown even when the client is on a newer patch version which is compatible. 

I decided to extract `getClientIncompatibilityWarning()` out of `Ping()` for easier testing. The problem was the server version is compared against `teleport.Version` constant which I can't overwrite in tests. 
Additionally, I removed a check requiring at least a v15 cluster. tsh v17 is not compatible with clusters < 17.0.0.

Changelog: Fixed an incorrect warning indicating that tsh v17.0.2 was incompatible with cluster v17.0.1, despite full compatibility