### PR TITLE
Increase pgevents TTL setting query timeout

### DIFF
--- a/lib/events/pgevents/pgevents.go
+++ b/lib/events/pgevents/pgevents.go
@@ -268,8 +268,9 @@ func New(ctx context.Context, cfg Config) (*Log, error) {
 }
 
 func configureCockroachDBRetention(ctx context.Context, cfg *Config, pool *pgxpool.Pool) error {
-	// Arbitrary timeout to make sure we don't end up hanging for some reason
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	// The first run of this query on multi region setup can sometimes take more than 5 seconds.
+	// The subsequent runs are faster (a couple of seconds at most).
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	var expiryQuery string


### PR DESCRIPTION
5s proved to be too short on some multi region setups.

Changelog: Increase CockroachDB setup timeout from 5 to 30 seconds. This mitigates the Auth Service not being able to configure TTL on slow CockroachDB event backends.