### PR TITLE
Enroll EKS Cluster from Discover: wait for access entry

### DIFF
--- a/lib/integrations/awsoidc/eks_enroll_clusters.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters.go
@@ -565,13 +565,13 @@ func checkAgentAlreadyInstalled(ctx context.Context, actionConfig *action.Config
 	var err error
 	// We setup a little backoff loop because sometimes access entry auth needs a bit more time to propagate and take
 	// effect, so we could get errors when trying to access cluster right after giving us permissions to do so.
-	// From real scenarios, we've seen this taking as long as 20 seconds.
-	for attempt := 1; attempt <= 3; attempt++ {
+	// From real scenarios, we've seen this taking as long as 30 seconds.
+	for attempt := 1; attempt <= 6; attempt++ {
 		listCmd := action.NewList(actionConfig)
 		releases, err = listCmd.Run()
 		if err != nil {
 			select {
-			case <-time.After(time.Duration(attempt*5) * time.Second):
+			case <-time.After(10 * time.Second):
 			case <-ctx.Done():
 				return false, trace.NewAggregate(err, ctx.Err())
 			}


### PR DESCRIPTION
After running this flow a couple more times, we discovered that some times it takes longer than 25s.
From multiple tests we found out that it can take up to 30s. Instead of setting that as the wait time, we add a little more to ensure we are more resilient.