### PR TITLE
Add OSS integration status

### DIFF
--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.tsx
@@ -28,7 +28,7 @@ export function AwsOidcDashboard() {
 
   return (
     <FeatureBox css={{ maxWidth: '1400px', paddingTop: '16px' }}>
-      <AwsOidcHeader integration={attempt.data} />
+      {attempt.data && <AwsOidcHeader integration={attempt.data} />}
       Status for integration type aws-oidc is not supported
     </FeatureBox>
   );

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcHeader.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcHeader.tsx
@@ -27,11 +27,7 @@ import cfg from 'teleport/config';
 import { getStatusAndLabel } from 'teleport/Integrations/helpers';
 import { Integration } from 'teleport/services/integrations';
 
-export function AwsOidcHeader({
-  integration,
-}: {
-  integration: Integration | null;
-}) {
+export function AwsOidcHeader({ integration }: { integration: Integration }) {
   const { status, labelKind } = getStatusAndLabel(integration);
   return (
     <Flex alignItems="center">
@@ -45,7 +41,7 @@ export function AwsOidcHeader({
         </ButtonIcon>
       </HoverTooltip>
       <Text bold fontSize={6} mr={2}>
-        {integration?.name}
+        {integration.name}
       </Text>
       <Label kind={labelKind} aria-label="status" px={3}>
         {status}

--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -47,6 +47,8 @@ import {
 import { NavigationCategory as SideNavigationCategory } from 'teleport/Navigation/SideNavigation/categories';
 import { IntegrationEnroll } from '@gravitational/teleport/src/Integrations/Enroll';
 
+import { IntegrationStatus } from 'teleport/Integrations/IntegrationStatus';
+
 import { NavTitle } from './types';
 
 import { AuditContainer as Audit } from './Audit';
@@ -628,6 +630,22 @@ class FeatureDeviceTrust implements TeleportFeature {
   };
 }
 
+class FeatureIntegrationStatus implements TeleportFeature {
+  category = NavigationCategory.Management;
+
+  parent = FeatureIntegrations;
+
+  route = {
+    title: 'Integration Status',
+    path: cfg.routes.integrationStatus,
+    component: IntegrationStatus,
+  };
+
+  hasAccess() {
+    return true;
+  }
+}
+
 // ****************************
 // Other Features
 // ****************************
@@ -702,6 +720,7 @@ export function getOSSFeatures(): TeleportFeature[] {
     new FeatureIntegrations(),
     new FeatureClusters(),
     new FeatureTrust(),
+    new FeatureIntegrationStatus(),
 
     // - Identity
     new AccessRequests(),


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/49094 Added an OSS status page for enterprise to fall back to, and this PR adds it as a first class OSS route.

- Add to OSS features
- Move header null check to parent

