### PR TITLE
Specify TS paths per package

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -17,17 +17,6 @@
     "noEmitHelpers": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "sourceMap": false,
-    "paths": {
-      "shared/*": ["web/packages/shared/*"],
-      "design/*": ["web/packages/design/src/*"],
-      "design": ["web/packages/design/src/"],
-      "teleport/*": ["web/packages/teleport/src/*"],
-      "teleport": ["web/packages/teleport/src/"],
-      "teleterm/*": ["web/packages/teleterm/src/*"],
-      "e-teleport/*": ["e/web/teleport/src/*"],
-      "gen-proto-js/*": ["gen/proto/js/*"],
-      "gen-proto-ts/*": ["gen/proto/ts/*"],
-    }
+    "sourceMap": false
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,18 @@
   "compilerOptions": {
     "outDir": "build.assets/.cache/ts",
     "noEmit": true,
-    "types": ["node", "@types/wicg-file-system-access"]
+    "types": ["node", "@types/wicg-file-system-access"],
+    "paths": {
+      "shared/*": ["web/packages/shared/*"],
+      "design/*": ["web/packages/design/src/*"],
+      "design": ["web/packages/design/src/"],
+      "teleport/*": ["web/packages/teleport/src/*"],
+      "teleport": ["web/packages/teleport/src/"],
+      "teleterm/*": ["web/packages/teleterm/src/*"],
+      "e-teleport/*": ["e/web/teleport/src/*"],
+      "gen-proto-js/*": ["gen/proto/js/*"],
+      "gen-proto-ts/*": ["gen/proto/ts/*"],
+    }
   },
   "exclude": [
     "web/packages/design",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,6 @@
       "teleport": ["web/packages/teleport/src/"],
       "teleterm/*": ["web/packages/teleterm/src/*"],
       "e-teleport/*": ["e/web/teleport/src/*"],
-      "gen-proto-js/*": ["gen/proto/js/*"],
       "gen-proto-ts/*": ["gen/proto/ts/*"],
     }
   },

--- a/web/packages/design/tsconfig.json
+++ b/web/packages/design/tsconfig.json
@@ -7,6 +7,12 @@
     "emitDeclarationOnly": true,
     "declarationMap": true,
     "strict": true,
-    "noImplicitReturns": true
+    "noImplicitReturns": true,
+    "paths": {
+      "design/*": ["web/packages/design/src/*"],
+      "design": ["web/packages/design/src/"],
+      "gen-proto-ts/*": ["gen/proto/ts/*"],
+    }
+
   }
 }


### PR DESCRIPTION
The `design` package should not depend on any other package. We can enforce this by passing a smaller subset of `paths` to its `tsconfig.json`. 

This approach not only ensures proper isolation but also provides clearer error messages when someone attempts to import from the other package, e.g. `teleport`:
```
web/packages/design/src/ToolTip/ToolTip.story.tsx:2 :23 - error TS2307: Cannot find module 'teleport/components/LogoHero/LogoHero' or its corresponding type declarations.

24 import { logos } from 'teleport/components/LogoHero/LogoHero';
```
Currently, that mistake causes the `teleport` package to be checked with strict null checks.

