### PR TITLE
[entraid] parse user's given name and surname

### DIFF
--- a/lib/msgraph/client_test.go
+++ b/lib/msgraph/client_test.go
@@ -227,9 +227,13 @@ func TestIterateUsers(t *testing.T) {
 	require.Equal(t, "alice@example.com", *users[0].Mail)
 	require.Equal(t, "Alice Alison", *users[0].DisplayName)
 	require.Equal(t, "alice@example.com", *users[0].UserPrincipalName)
+	require.Nil(t, users[0].Surname)
+	require.Nil(t, users[0].GivenName)
 
 	require.Equal(t, "bob@example.com", *users[1].Mail)
 	require.Equal(t, "bob@example.com", *users[1].UserPrincipalName)
+	require.Equal(t, "Bobert", *users[1].Surname)
+	require.Equal(t, "Bob", *users[1].GivenName)
 
 	require.Equal(t, "admin@example.com", *users[2].Mail)
 	require.Equal(t, "admin@example.com", *users[2].UserPrincipalName)

--- a/lib/msgraph/models.go
+++ b/lib/msgraph/models.go
@@ -59,6 +59,8 @@ type User struct {
 	Mail                     *string `json:"mail,omitempty"`
 	OnPremisesSAMAccountName *string `json:"onPremisesSamAccountName,omitempty"`
 	UserPrincipalName        *string `json:"userPrincipalName,omitempty"`
+	Surname                  *string `json:"surname,omitempty"`
+	GivenName                *string `json:"givenName,omitempty"`
 }
 
 func (g *User) isGroupMember() {}


### PR DESCRIPTION
To populate the given name and surname traits, we must parse them from Entra ID responses. This PR parses the given name and surname artifacts from the json response.

Part of https://github.com/gravitational/teleport/issues/49376