### PR TITLE
[v17] Use RouteToApp instead of types.Application in lib/teleterm and lib/vnet

### DIFF
--- a/lib/teleterm/vnet/service.go
+++ b/lib/teleterm/vnet/service.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils"
 	prehogv1alpha "github.com/gravitational/teleport/gen/proto/go/prehog/v1alpha"
 	apiteleterm "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
@@ -453,11 +452,11 @@ func (p *appProvider) GetDialOptions(ctx context.Context, profileName string) (*
 // That is, if a user makes multiple connections to a single app, OnNewConnection submits a single
 // event. This is to mimic how Connect submits events for its app gateways. This lets us compare
 // popularity of VNet and app gateways.
-func (p *appProvider) OnNewConnection(ctx context.Context, profileName, leafClusterName string, app types.Application) error {
+func (p *appProvider) OnNewConnection(ctx context.Context, profileName, leafClusterName string, routeToApp proto.RouteToApp) error {
 	// Enqueue the event from a separate goroutine since we don't care about errors anyway and we also
 	// don't want to slow down VNet connections.
 	go func() {
-		uri := uri.NewClusterURI(profileName).AppendLeafCluster(leafClusterName).AppendApp(app.GetName())
+		uri := uri.NewClusterURI(profileName).AppendLeafCluster(leafClusterName).AppendApp(routeToApp.Name)
 
 		// Not passing ctx to ReportApp since ctx is tied to the lifetime of the connection.
 		// If it's a short-lived connection, inheriting its context would interrupt reporting.

--- a/lib/vnet/app_resolver.go
+++ b/lib/vnet/app_resolver.go
@@ -284,7 +284,6 @@ func (r *TCPAppResolver) resolveTCPHandlerForCluster(
 type tcpAppHandler struct {
 	profileName     string
 	leafClusterName string
-	app             types.Application
 	lp              *alpnproxy.LocalProxy
 }
 
@@ -334,7 +333,6 @@ func (r *TCPAppResolver) newTCPAppHandler(
 	return &tcpAppHandler{
 		profileName:     profileName,
 		leafClusterName: leafClusterName,
-		app:             app,
 		lp:              lp,
 	}, nil
 }

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -350,7 +350,7 @@ func (p *echoAppProvider) GetVnetConfig(ctx context.Context, profileName, leafCl
 	return cfg, nil
 }
 
-func (p *echoAppProvider) OnNewConnection(ctx context.Context, profileName, leafClusterName string, app types.Application) error {
+func (p *echoAppProvider) OnNewConnection(ctx context.Context, profileName, leafClusterName string, routeToApp proto.RouteToApp) error {
 	p.onNewConnectionCallCount.Add(1)
 	return nil
 }

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -291,7 +291,7 @@ func (p *echoAppProvider) GetCachedClient(ctx context.Context, profileName, leaf
 	}, nil
 }
 
-func (p *echoAppProvider) ReissueAppCert(ctx context.Context, profileName, leafClusterName string, app types.Application) (tls.Certificate, error) {
+func (p *echoAppProvider) ReissueAppCert(ctx context.Context, profileName, leafClusterName string, routeToApp proto.RouteToApp) (tls.Certificate, error) {
 	return p.reissueAppCert(), nil
 }
 

--- a/tool/tsh/common/vnet_common.go
+++ b/tool/tsh/common/vnet_common.go
@@ -80,7 +80,7 @@ func (p *vnetAppProvider) GetCachedClient(ctx context.Context, profileName, leaf
 // was shorter than the cluster cert lifetime, or if the user has already re-logged in to the cluster.
 // If a cluster relogin is completed, the cluster client cache will be cleared for the root cluster and all
 // leaf clusters of that root.
-func (p *vnetAppProvider) ReissueAppCert(ctx context.Context, profileName, leafClusterName string, app types.Application) (tls.Certificate, error) {
+func (p *vnetAppProvider) ReissueAppCert(ctx context.Context, profileName, leafClusterName string, routeToApp proto.RouteToApp) (tls.Certificate, error) {
 	tc, err := p.newTeleportClient(ctx, profileName, leafClusterName)
 	if err != nil {
 		return tls.Certificate{}, trace.Wrap(err)
@@ -89,7 +89,7 @@ func (p *vnetAppProvider) ReissueAppCert(ctx context.Context, profileName, leafC
 	var cert tls.Certificate
 	err = p.retryWithRelogin(ctx, tc, func() error {
 		var err error
-		cert, err = p.reissueAppCert(ctx, tc, profileName, leafClusterName, app)
+		cert, err = p.reissueAppCert(ctx, tc, profileName, leafClusterName, routeToApp)
 		return trace.Wrap(err, "reissuing app cert")
 	})
 	return cert, trace.Wrap(err)
@@ -170,15 +170,8 @@ func (p *vnetAppProvider) retryWithRelogin(ctx context.Context, tc *client.Telep
 	return client.RetryWithRelogin(ctx, tc, fn, opts...)
 }
 
-func (p *vnetAppProvider) reissueAppCert(ctx context.Context, tc *client.TeleportClient, profileName, leafClusterName string, app types.Application) (tls.Certificate, error) {
-	slog.InfoContext(ctx, "Reissuing cert for app.", "app_name", app.GetName(), "profile", profileName, "leaf_cluster", leafClusterName)
-
-	routeToApp := proto.RouteToApp{
-		Name:        app.GetName(),
-		PublicAddr:  app.GetPublicAddr(),
-		ClusterName: tc.SiteName,
-		URI:         app.GetURI(),
-	}
+func (p *vnetAppProvider) reissueAppCert(ctx context.Context, tc *client.TeleportClient, profileName, leafClusterName string, routeToApp proto.RouteToApp) (tls.Certificate, error) {
+	slog.InfoContext(ctx, "Reissuing cert for app.", "app_name", routeToApp.Name, "profile", profileName, "leaf_cluster", leafClusterName)
 
 	profile, err := tc.ProfileStatus()
 	if err != nil {
@@ -193,6 +186,9 @@ func (p *vnetAppProvider) reissueAppCert(ctx context.Context, tc *client.Telepor
 		TTL:            tc.KeyTTL,
 	}
 
+	// leafClusterName cannot be replaced with routeToApp.ClusterName here. That's because when
+	// routeToApp points to an app in the root cluster, routeToApp.ClusterName uses the actual root
+	// cluster name which is not necessarily equal to profileName.
 	clusterClient, err := p.clientCache.Get(ctx, profileName, leafClusterName)
 	if err != nil {
 		return tls.Certificate{}, trace.Wrap(err, "getting cached cluster client")
@@ -207,7 +203,7 @@ func (p *vnetAppProvider) reissueAppCert(ctx context.Context, tc *client.Telepor
 		return tls.Certificate{}, trace.Wrap(err, "logging in to app")
 	}
 
-	cert, err := keyRing.AppTLSCert(app.GetName())
+	cert, err := keyRing.AppTLSCert(routeToApp.Name)
 	if err != nil {
 		return tls.Certificate{}, trace.Wrap(err, "getting TLS cert from key")
 	}

--- a/tool/tsh/common/vnet_common.go
+++ b/tool/tsh/common/vnet_common.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/client/clientcache"
 	"github.com/gravitational/teleport/lib/utils"
@@ -117,7 +116,7 @@ func (p *vnetAppProvider) GetDialOptions(ctx context.Context, profileName string
 
 // OnNewConnection gets called before each VNet connection. It's a noop as tsh doesn't need to do
 // anything extra here.
-func (p *vnetAppProvider) OnNewConnection(ctx context.Context, profileName, leafClusterName string, app types.Application) error {
+func (p *vnetAppProvider) OnNewConnection(ctx context.Context, profileName, leafClusterName string, routeToApp proto.RouteToApp) error {
 	return nil
 }
 


### PR DESCRIPTION
Backport #49349 to branch/v17