### PR TITLE
Show summary stats on aws-oidc dashboard

### DIFF
--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.story.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.story.tsx
@@ -18,34 +18,184 @@
 
 import React from 'react';
 
+import { addHours } from 'date-fns';
+
 import { AwsOidcDashboard } from 'teleport/Integrations/status/AwsOidc/AwsOidcDashboard';
 import { MockAwsOidcStatusProvider } from 'teleport/Integrations/status/AwsOidc/testHelpers/mockAwsOidcStatusProvider';
-import { IntegrationKind } from 'teleport/services/integrations';
+import {
+  IntegrationKind,
+  ResourceTypeSummary,
+} from 'teleport/services/integrations';
+import { AwsOidcStatusContextState } from 'teleport/Integrations/status/AwsOidc/useAwsOidcStatus';
 
 export default {
   title: 'Teleport/Integrations/AwsOidc',
 };
 
+// Loaded dashboard with data for each aws resource and a navigation header
 export function Dashboard() {
   return (
-    <MockAwsOidcStatusProvider
-      value={{
-        attempt: {
-          status: 'success',
-          data: {
-            resourceType: 'integration',
-            name: 'integration-one',
-            kind: IntegrationKind.AwsOidc,
-            spec: {
-              roleArn: 'arn:aws:iam::111456789011:role/bar',
-            },
-            statusCode: 1,
-          },
-          statusText: '',
-        },
-      }}
-    >
+    <MockAwsOidcStatusProvider value={makeAwsOidcStatusContextState()}>
       <AwsOidcDashboard />
     </MockAwsOidcStatusProvider>
+  );
+}
+
+// Loaded dashboard with missing data for each aws resource and a navigation header
+export function DashboardMissingData() {
+  const state = makeAwsOidcStatusContextState();
+  state.statsAttempt.data.awseks = undefined;
+  state.statsAttempt.data.awsrds = undefined;
+  state.statsAttempt.data.awsec2 = undefined;
+  return (
+    <MockAwsOidcStatusProvider value={state}>
+      <AwsOidcDashboard />
+    </MockAwsOidcStatusProvider>
+  );
+}
+
+// Loading screen
+export function StatsProcessing() {
+  const props = makeAwsOidcStatusContextState({
+    statsAttempt: { status: 'processing', data: null, statusText: '' },
+  });
+  return (
+    <MockAwsOidcStatusProvider value={props}>
+      <AwsOidcDashboard />
+    </MockAwsOidcStatusProvider>
+  );
+}
+
+// No header, no loading indicator
+export function IntegrationProcessing() {
+  const props = makeAwsOidcStatusContextState({
+    integrationAttempt: {
+      status: 'processing',
+      data: null,
+      statusText: '',
+    },
+  });
+  return (
+    <MockAwsOidcStatusProvider value={props}>
+      <AwsOidcDashboard />
+    </MockAwsOidcStatusProvider>
+  );
+}
+
+// Loaded error message
+export function StatsFailed() {
+  const props = makeAwsOidcStatusContextState({
+    statsAttempt: {
+      status: 'error',
+      data: null,
+      statusText: 'failed to get stats',
+      error: {},
+    },
+  });
+  return (
+    <MockAwsOidcStatusProvider value={props}>
+      <AwsOidcDashboard />
+    </MockAwsOidcStatusProvider>
+  );
+}
+
+// Loaded dashboard with data for each aws resource but no navigation header
+export function IntegrationFailed() {
+  const props = makeAwsOidcStatusContextState({
+    integrationAttempt: {
+      status: 'error',
+      data: null,
+      statusText: 'failed  to get integration',
+      error: {},
+    },
+  });
+  return (
+    <MockAwsOidcStatusProvider value={props}>
+      <AwsOidcDashboard />
+    </MockAwsOidcStatusProvider>
+  );
+}
+
+// Blank screen
+export function StatsNoData() {
+  const props = makeAwsOidcStatusContextState({
+    statsAttempt: { status: 'success', data: null, statusText: '' },
+  });
+  return (
+    <MockAwsOidcStatusProvider value={props}>
+      <AwsOidcDashboard />
+    </MockAwsOidcStatusProvider>
+  );
+}
+
+// No header, no loading indicator
+export function IntegrationNoData() {
+  const props = makeAwsOidcStatusContextState({
+    integrationAttempt: {
+      status: 'success',
+      data: null,
+      statusText: '',
+    },
+  });
+  return (
+    <MockAwsOidcStatusProvider value={props}>
+      <AwsOidcDashboard />
+    </MockAwsOidcStatusProvider>
+  );
+}
+
+function makeAwsOidcStatusContextState(
+  overrides: Partial<AwsOidcStatusContextState> = {}
+): AwsOidcStatusContextState {
+  return Object.assign(
+    {
+      integrationAttempt: {
+        status: 'success',
+        statusText: '',
+        data: {
+          resourceType: 'integration',
+          name: 'integration-one',
+          kind: IntegrationKind.AwsOidc,
+          spec: {
+            roleArn: 'arn:aws:iam::111456789011:role/bar',
+          },
+          statusCode: 1,
+        },
+      },
+      statsAttempt: {
+        status: 'success',
+        statusText: '',
+        data: {
+          name: 'integration-one',
+          subKind: IntegrationKind.AwsOidc,
+          awsoidc: {
+            roleArn: 'arn:aws:iam::111456789011:role/bar',
+          },
+          awsec2: makeResourceTypeSummary(),
+          awsrds: makeResourceTypeSummary(),
+          awseks: makeResourceTypeSummary(),
+        },
+      },
+    },
+    overrides
+  );
+}
+
+function makeResourceTypeSummary(
+  overrides: Partial<ResourceTypeSummary> = {}
+): ResourceTypeSummary {
+  return Object.assign(
+    {
+      rulesCount: Math.floor(Math.random() * 100),
+      resourcesFound: Math.floor(Math.random() * 100),
+      resourcesEnrollmentFailed: Math.floor(Math.random() * 100),
+      resourcesEnrollmentSuccess: Math.floor(Math.random() * 100),
+      discoverLastSync: addHours(
+        new Date().getTime(),
+        -Math.floor(Math.random() * 100)
+      ),
+      ecsDatabaseServiceCount: Math.floor(Math.random() * 100),
+    },
+    overrides
   );
 }

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.test.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.test.tsx
@@ -19,16 +19,20 @@
 import React from 'react';
 import { render, screen } from 'design/utils/testing';
 
+import { within } from '@testing-library/react';
+
 import { AwsOidcDashboard } from 'teleport/Integrations/status/AwsOidc/AwsOidcDashboard';
 import { MockAwsOidcStatusProvider } from 'teleport/Integrations/status/AwsOidc/testHelpers/mockAwsOidcStatusProvider';
 import { IntegrationKind } from 'teleport/services/integrations';
+import { addHours } from 'teleport/components/BannerList/useAlerts';
 
-test('renders header', () => {
+test('renders header and stats cards', () => {
   render(
     <MockAwsOidcStatusProvider
       value={{
-        attempt: {
+        integrationAttempt: {
           status: 'success',
+          statusText: '',
           data: {
             resourceType: 'integration',
             name: 'integration-one',
@@ -38,7 +42,41 @@ test('renders header', () => {
             },
             statusCode: 1,
           },
+        },
+        statsAttempt: {
+          status: 'success',
           statusText: '',
+          data: {
+            name: 'integration-one',
+            subKind: IntegrationKind.AwsOidc,
+            awsoidc: {
+              roleArn: 'arn:aws:iam::111456789011:role/bar',
+            },
+            awsec2: {
+              rulesCount: 24,
+              resourcesFound: 12,
+              resourcesEnrollmentFailed: 3,
+              resourcesEnrollmentSuccess: 9,
+              discoverLastSync: new Date().getTime(),
+              ecsDatabaseServiceCount: 0, // irrelevant
+            },
+            awsrds: {
+              rulesCount: 14,
+              resourcesFound: 5,
+              resourcesEnrollmentFailed: 5,
+              resourcesEnrollmentSuccess: 0,
+              discoverLastSync: addHours(new Date().getTime(), -4),
+              ecsDatabaseServiceCount: 8, // relevant
+            },
+            awseks: {
+              rulesCount: 33,
+              resourcesFound: 3,
+              resourcesEnrollmentFailed: 0,
+              resourcesEnrollmentSuccess: 3,
+              discoverLastSync: addHours(new Date().getTime(), -48),
+              ecsDatabaseServiceCount: 0, // irrelevant
+            },
+          },
         },
       }}
     >
@@ -53,4 +91,49 @@ test('renders header', () => {
   expect(screen.getByText('integration-one')).toBeInTheDocument();
   expect(screen.getByLabelText('status')).toHaveAttribute('kind', 'success');
   expect(screen.getByLabelText('status')).toHaveTextContent('Running');
+
+  const ec2 = screen.getByTestId('ec2-stats');
+  expect(within(ec2).getByTestId('sync')).toHaveTextContent(
+    'Last Sync: 0 seconds ago'
+  );
+  expect(within(ec2).getByTestId('rules')).toHaveTextContent(
+    'Enrollment Rules 24'
+  );
+  expect(within(ec2).queryByTestId('rds-agents')).not.toBeInTheDocument();
+  expect(within(ec2).getByTestId('enrolled')).toHaveTextContent(
+    'Enrolled Instances 9'
+  );
+  expect(within(ec2).getByTestId('failed')).toHaveTextContent(
+    'Failed Instances 3'
+  );
+
+  const rds = screen.getByTestId('rds-stats');
+  expect(within(rds).getByTestId('sync')).toHaveTextContent(
+    'Last Sync: 4 hours ago'
+  );
+  expect(within(rds).getByTestId('rules')).toHaveTextContent(
+    'Enrollment Rules 14'
+  );
+  expect(within(rds).getByTestId('rds-agents')).toHaveTextContent('Agents 8');
+  expect(within(rds).getByTestId('enrolled')).toHaveTextContent(
+    'Enrolled Databases 0'
+  );
+  expect(within(rds).getByTestId('failed')).toHaveTextContent(
+    'Failed Databases 5'
+  );
+
+  const eks = screen.getByTestId('eks-stats');
+  expect(within(eks).getByTestId('sync')).toHaveTextContent(
+    'Last Sync: 2 days ago'
+  );
+  expect(within(eks).getByTestId('rules')).toHaveTextContent(
+    'Enrollment Rules 33'
+  );
+  expect(within(eks).queryByTestId('rds-agents')).not.toBeInTheDocument();
+  expect(within(eks).getByTestId('enrolled')).toHaveTextContent(
+    'Enrolled Clusters 3'
+  );
+  expect(within(eks).getByTestId('failed')).toHaveTextContent(
+    'Failed Clusters 0'
+  );
 });

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.tsx
@@ -18,18 +18,43 @@
 
 import React from 'react';
 
+import { Flex, H2, Indicator } from 'design';
+
+import { Danger } from 'design/Alert';
+
 import { AwsOidcHeader } from 'teleport/Integrations/status/AwsOidc/AwsOidcHeader';
 import { useAwsOidcStatus } from 'teleport/Integrations/status/AwsOidc/useAwsOidcStatus';
 import { FeatureBox } from 'teleport/components/Layout';
+import {
+  AwsResource,
+  StatCard,
+} from 'teleport/Integrations/status/AwsOidc/StatCard';
 
-// todo (michellescripts) after routing, ensure this view can be sticky
 export function AwsOidcDashboard() {
-  const { attempt } = useAwsOidcStatus();
+  const { statsAttempt, integrationAttempt } = useAwsOidcStatus();
 
+  if (statsAttempt.status == 'processing') {
+    return <Indicator />;
+  }
+  if (statsAttempt.status == 'error') {
+    return <Danger>{statsAttempt.statusText}</Danger>;
+  }
+  if (!statsAttempt.data) {
+    return null;
+  }
+
+  // todo (michellescripts) after routing, ensure this view can be sticky
+  const { awsec2, awseks, awsrds } = statsAttempt.data;
+  const { data: integration } = integrationAttempt;
   return (
     <FeatureBox css={{ maxWidth: '1400px', paddingTop: '16px' }}>
-      {attempt.data && <AwsOidcHeader integration={attempt.data} />}
-      Status for integration type aws-oidc is not supported
+      {integration && <AwsOidcHeader integration={integration} />}
+      <H2 my={3}>Auto-Enrollment</H2>
+      <Flex gap={3}>
+        <StatCard resource={AwsResource.ec2} summary={awsec2} />
+        <StatCard resource={AwsResource.rds} summary={awsrds} />
+        <StatCard resource={AwsResource.eks} summary={awseks} />
+      </Flex>
     </FeatureBox>
   );
 }

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcHeader.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcHeader.tsx
@@ -40,7 +40,7 @@ export function AwsOidcHeader({ integration }: { integration: Integration }) {
           <ArrowLeft size="medium" />
         </ButtonIcon>
       </HoverTooltip>
-      <Text bold fontSize={6} mr={2}>
+      <Text bold fontSize={6} mx={2}>
         {integration.name}
       </Text>
       <Label kind={labelKind} aria-label="status" px={3}>

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/StatCard.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/StatCard.tsx
@@ -1,0 +1,115 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+
+import { Card, Flex, H2, Text } from 'design';
+import { ResourceIcon } from 'design/ResourceIcon';
+
+import * as Icons from 'design/Icon';
+
+import { formatDistanceStrict } from 'date-fns';
+
+import { ResourceTypeSummary } from 'teleport/services/integrations';
+
+export enum AwsResource {
+  ec2 = 'ec2',
+  eks = 'eks',
+  rds = 'rds',
+}
+
+type StatCardProps = {
+  resource: AwsResource;
+  summary?: ResourceTypeSummary;
+};
+
+export function StatCard({ resource, summary }: StatCardProps) {
+  const updated = summary?.discoverLastSync
+    ? new Date(summary?.discoverLastSync)
+    : undefined;
+  const term = getResourceTerm(resource);
+
+  return (
+    <Card
+      width="33%"
+      p={3}
+      bg="levels.surface"
+      data-testid={`${resource}-stats`}
+    >
+      <Flex
+        flexDirection="column"
+        justifyContent="space-between"
+        minHeight="220px"
+      >
+        <Flex flexDirection="column" gap={2}>
+          <Flex alignItems="center" mb={2}>
+            <ResourceIcon name={resource} mr={2} width="32px" height="32px" />
+            <H2>{resource.toUpperCase()}</H2>
+          </Flex>
+          <Flex justifyContent="space-between" data-testid="rules">
+            <Text>Enrollment Rules </Text>
+            <Text>{summary?.rulesCount || 0}</Text>
+          </Flex>
+          {resource == AwsResource.rds && (
+            <Flex justifyContent="space-between" data-testid="rds-agents">
+              <Text>Agents </Text>
+              <Text>{summary?.ecsDatabaseServiceCount || 0}</Text>
+            </Flex>
+          )}
+          <Flex justifyContent="space-between" data-testid="enrolled">
+            <Text>Enrolled {term} </Text>
+            <Text>{summary?.resourcesEnrollmentSuccess || 0}</Text>
+          </Flex>
+          <Flex justifyContent="space-between" data-testid="failed">
+            <Text ml={4}>Failed {term} </Text>
+            <Flex gap={1}>
+              <Text>{summary?.resourcesEnrollmentFailed || 0}</Text>
+              {summary?.resourcesEnrollmentFailed > 0 && (
+                <Icons.Warning size="large" color="error.main" />
+              )}
+            </Flex>
+          </Flex>
+        </Flex>
+        {updated && (
+          <Text
+            typography="body3"
+            color="text.slightlyMuted"
+            data-testid="sync"
+          >
+            Last Sync:{' '}
+            {formatDistanceStrict(new Date(updated), new Date(), {
+              addSuffix: true,
+            })}
+          </Text>
+        )}
+      </Flex>
+    </Card>
+  );
+}
+
+function getResourceTerm(resource: AwsResource): string {
+  switch (resource) {
+    case AwsResource.rds:
+      return 'Databases';
+    case AwsResource.eks:
+      return 'Clusters';
+    case AwsResource.ec2:
+    default:
+      return 'Instances';
+  }
+}

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/useAwsOidcStatus.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/useAwsOidcStatus.tsx
@@ -24,12 +24,14 @@ import {
   Integration,
   IntegrationKind,
   integrationService,
+  IntegrationWithSummary,
 } from 'teleport/services/integrations';
 
 import useTeleport from 'teleport/useTeleport';
 
 export interface AwsOidcStatusContextState {
-  attempt: Attempt<Integration>;
+  statsAttempt: Attempt<IntegrationWithSummary>;
+  integrationAttempt: Attempt<Integration>;
 }
 
 export const awsOidcStatusContext =
@@ -44,18 +46,24 @@ export function AwsOidcStatusProvider({ children }: React.PropsWithChildren) {
   const integrationAccess = ctx.storeUser.getIntegrationsAccess();
   const hasIntegrationReadAccess = integrationAccess.read;
 
-  const [attempt, fetchIntegration] = useAsync(() =>
+  const [stats, fetchIntegrationStats] = useAsync(() =>
+    integrationService.fetchIntegrationStats(name)
+  );
+
+  const [integration, fetchIntegration] = useAsync(() =>
     integrationService.fetchIntegration(name)
   );
 
   useEffect(() => {
     if (hasIntegrationReadAccess) {
+      fetchIntegrationStats();
       fetchIntegration();
     }
   }, []);
 
   const value: AwsOidcStatusContextState = {
-    attempt,
+    statsAttempt: stats,
+    integrationAttempt: integration,
   };
 
   return (

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -319,6 +319,8 @@ const cfg = {
     headlessLogin: '/v1/webapi/headless/:headless_authentication_id',
 
     integrationsPath: '/v1/webapi/sites/:clusterId/integrations/:name?',
+    integrationStatsPath:
+      '/v1/webapi/sites/:clusterId/integrations/:name/stats',
     thumbprintPath: '/v1/webapi/thumbprint',
     pingAwsOidcIntegrationPath:
       '/v1/webapi/sites/:clusterId/integrations/aws-oidc/:name/ping',
@@ -963,6 +965,14 @@ const cfg = {
     return generatePath(cfg.api.integrationsPath, {
       clusterId,
       name: integrationName,
+    });
+  },
+
+  getIntegrationStatsUrl(name: string) {
+    const clusterId = cfg.proxyCluster;
+    return generatePath(cfg.api.integrationStatsPath, {
+      clusterId,
+      name,
     });
   },
 

--- a/web/packages/teleport/src/services/integrations/integrations.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.ts
@@ -59,6 +59,7 @@ import {
   AwsDatabaseVpcsResponse,
   AwsOidcPingResponse,
   AwsOidcPingRequest,
+  IntegrationWithSummary,
 } from './types';
 
 export const integrationService = {
@@ -420,6 +421,12 @@ export const integrationService = {
           nextToken: json?.nextToken,
         };
       });
+  },
+
+  fetchIntegrationStats(name: string): Promise<IntegrationWithSummary> {
+    return api.get(cfg.getIntegrationStatsUrl(name)).then(resp => {
+      return resp;
+    });
   },
 };
 

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -285,6 +285,41 @@ export type IntegrationListResponse = {
   nextKey?: string;
 };
 
+// IntegrationWithSummary describes Integration fields and the fields required to return the summary.
+export type IntegrationWithSummary = {
+  name: string;
+  subKind: string;
+  awsoidc: IntegrationSpecAwsOidc;
+  // AWSEC2 contains the summary for the AWS EC2 resources for this integration.
+  awsec2: ResourceTypeSummary;
+  // AWSRDS contains the summary for the AWS RDS resources and agents for this integration.
+  awsrds: ResourceTypeSummary;
+  // AWSEKS contains the summary for the AWS EKS resources for this integration.
+  awseks: ResourceTypeSummary;
+};
+
+// ResourceTypeSummary contains the summary of the enrollment rules and found resources by the integration.
+export type ResourceTypeSummary = {
+  // rulesCount is the number of enrollment rules that are using this integration.
+  // A rule is a matcher in a DiscoveryConfig that is being processed by a DiscoveryService.
+  // If the DiscoveryService is not reporting any Status, it means it is not being processed and it doesn't count for the number of rules.
+  // Example 1: a DiscoveryConfig with a matcher whose Type is "EC2" for two regions count as two EC2 rules.
+  // Example 2: a DiscoveryConfig with a matcher whose Types is "EC2,RDS" for one regions count as one EC2 rule.
+  // Example 3: a DiscoveryConfig with a matcher whose Types is "EC2,RDS", but has no DiscoveryService using it, it counts as 0 rules.
+  rulesCount: number;
+  // resourcesFound contains the count of resources found by this integration.
+  resourcesFound: number;
+  // resourcesEnrollmentFailed contains the count of resources that failed to enroll into the cluster.
+  resourcesEnrollmentFailed: number;
+  // resourcesEnrollmentSuccess contains the count of resources that succeeded to enroll into the cluster.
+  resourcesEnrollmentSuccess: number;
+  // discoverLastSync contains the time when this integration tried to auto-enroll resources.
+  discoverLastSync: number;
+  // ecsDatabaseServiceCount is the total number of DatabaseServices that were deployed into Amazon ECS.
+  // Only applicable for AWS RDS resource summary.
+  ecsDatabaseServiceCount: number;
+};
+
 // awsRegionMap maps the AWS regions to it's region name
 // as defined in (omitted gov cloud regions):
 // https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html


### PR DESCRIPTION
Adds stats cards to the aws oidc dashboard page. Currently not hooked into nav, a future PR will plumb this through.

<img width="1279" alt="Screenshot 2024-12-02 at 4 06 23 PM" src="https://github.com/user-attachments/assets/36475ce2-e88d-40d6-ad85-38b14d056a4d">

Supports https://github.com/gravitational/teleport/issues/49087
