### PR TITLE
Add missing target to integrations/operator crd

### DIFF
--- a/integrations/operator/Makefile
+++ b/integrations/operator/Makefile
@@ -73,7 +73,7 @@ help: ## Display this help.
 ##@ Development
 
 .PHONY: crd ## Single command to generate anything CRD-related (manifests and docs)
-crd: crdgen crd-docs
+crd: crdgen crd-docs manifests
 
 .PHONY: crdgen
 crdgen: ## Generate CRDs


### PR DESCRIPTION
This ensures that manifests are generated in response to proto changes. Without this the linter will fail, and tell you to run `make -C integrations/operator crd`, but nothing would be generated, see https://github.com/gravitational/teleport/actions/runs/12056106780/job/33618509170?pr=49510.