### PR TITLE
Reduce web SSH session log spam

### DIFF
--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -894,7 +894,7 @@ func (t *TerminalHandler) streamTerminal(ctx context.Context, tc *client.Telepor
 		t.log.WithError(err).Error("Unable to send close event to web client.")
 	}
 
-	if err := t.stream.Close(); err != nil {
+	if err := t.stream.Close(); err != nil && !errors.Is(err, io.EOF) {
 		t.log.WithError(err).Error("Unable to close client web socket.")
 		return
 	}

--- a/lib/web/terminal/terminal.go
+++ b/lib/web/terminal/terminal.go
@@ -115,8 +115,8 @@ func (t *WSStream) WriteMessage(messageType int, data []byte) error {
 
 // WriteError displays an error in the terminal window.
 func (t *WSStream) WriteError(msg string) {
-	if _, writeErr := replacer.WriteString(t, msg); writeErr != nil {
-		t.log.WithError(writeErr).Warnf("Unable to send error to terminal: %v", msg)
+	if _, err := replacer.WriteString(t, msg); err != nil && !errors.Is(err, websocket.ErrCloseSent) {
+		t.log.WithError(err).Warnf("Unable to send error to terminal: %v", msg)
 	}
 }
 


### PR DESCRIPTION
Prevents emitting error log messages when users exit SSH web sessions under normal circumstances.

Closes https://github.com/gravitational/teleport/issues/49394