### PR TITLE
Allow custom audience for kubernetes in-cluster joining

### DIFF
--- a/lib/auth/join_kubernetes_test.go
+++ b/lib/auth/join_kubernetes_test.go
@@ -35,7 +35,7 @@ type mockK8STokenReviewValidator struct {
 	tokens map[string]*kubernetestoken.ValidationResult
 }
 
-func (m *mockK8STokenReviewValidator) Validate(_ context.Context, token string) (*kubernetestoken.ValidationResult, error) {
+func (m *mockK8STokenReviewValidator) Validate(_ context.Context, token, _ string) (*kubernetestoken.ValidationResult, error) {
 	result, ok := m.tokens[token]
 	if !ok {
 		return nil, errMockInvalidToken

--- a/lib/kubernetestoken/token_validator_test.go
+++ b/lib/kubernetestoken/token_validator_test.go
@@ -41,6 +41,8 @@ import (
 	"github.com/gravitational/teleport/lib/cryptosuites"
 )
 
+const testClusterName = "teleport.example.com"
+
 var userGroups = []string{"system:serviceaccounts", "system:serviceaccounts:namespace", "system:authenticated"}
 
 var boundTokenKubernetesVersion = version.Info{
@@ -65,6 +67,7 @@ func tokenReviewMock(t *testing.T, reviewResult *v1.TokenReview) func(ctest.Acti
 		require.True(t, ok)
 
 		require.Equal(t, reviewResult.Spec.Token, reviewRequest.Spec.Token)
+		require.ElementsMatch(t, reviewRequest.Spec.Audiences, []string{kubernetesAudience, testClusterName})
 		return true, reviewResult, nil
 	}
 }
@@ -238,7 +241,7 @@ func TestIDTokenValidator_Validate(t *testing.T) {
 			v := TokenReviewValidator{
 				client: client,
 			}
-			result, err := v.Validate(context.Background(), tt.token)
+			result, err := v.Validate(context.Background(), tt.token, testClusterName)
 			if tt.expectedError != nil {
 				require.ErrorIs(t, err, tt.expectedError)
 				return


### PR DESCRIPTION
This PR removes a common in-cluster joining footgun. Before this PR:
- kubernetes in-cluster required the default kubernetes audience
- kubernetes JWKS required a custom audience (the Teleport cluster name)

Many users mistakenly set the cluster name in the audience for in cluster joining, which caused the joining to fail.

After this PR:
- kubernetes in-cluster accepts the default kubernetes audience AND the teleport cluster name
- kubenetes JWKS requires the Teleport cluster name in the audience

This change does not reduces the security of the join. method and makes the tbot chart compatible with in-cluster joining.

Changelog: Kubernetes in-cluster joining now also accepts tokens whose audience is the Teleport cluster name (before it only allowed the default Kubernetes audience). Kubernetes JWKS joining is unchanged and still requires tokens with the cluster name in the audience.

Internal slack thread that started this PR: https://gravitational.slack.com/archives/C01TYKHFVTQ/p1732733525308779