### PR TITLE
Hostname validation: document invalid hostnames

### DIFF
--- a/docs/pages/admin-guides/management/guides/ec2-tags.mdx
+++ b/docs/pages/admin-guides/management/guides/ec2-tags.mdx
@@ -10,7 +10,7 @@ this way will have the `aws/` prefix. When the Teleport process starts, it fetch
 the instance metadata service and adds them as labels. The process will update the tags every hour, 
 so newly created or deleted tags will be reflected in the labels.
 
-If the tag `TeleportHostname` (case-sensitive) is present, its value will override the node's hostname.
+If the tag `TeleportHostname` is present, its value (must be lower case) will override the node's hostname.
 
 ```code
 $ tsh ls

--- a/docs/pages/admin-guides/management/guides/gcp-tags.mdx
+++ b/docs/pages/admin-guides/management/guides/gcp-tags.mdx
@@ -17,7 +17,7 @@ When the Teleport process starts, it fetches all tags and labels from
 the GCP API and adds them as labels. The process will update the tags every hour, 
 so newly created or deleted tags will be reflected in the labels.
 
-If the GCP label `TeleportHostname` (case-sensitive) is present, its value will override the node's hostname. This
+If the GCP label `TeleportHostname` is present, its value (must be lower case) will override the node's hostname. This
 does not apply to GCP tags.
 
 ```code

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -271,6 +271,16 @@ func TestIsValidHostname(t *testing.T) {
 			assert:   require.True,
 		},
 		{
+			name:     "only lower case works",
+			hostname: "only-lower-case-works",
+			assert:   require.True,
+		},
+		{
+			name:     "mixed upper case fails",
+			hostname: "mixed-UPPER-CASE-fails",
+			assert:   require.False,
+		},
+		{
 			name:     "one component",
 			hostname: "example",
 			assert:   require.True,


### PR DESCRIPTION
The lib we use for validation only accepts lower case hostnames.
Updated the docs accordingly as well as the tests.