### PR TITLE
Variable rate heartbeats

### DIFF
--- a/lib/inventory/controller_test.go
+++ b/lib/inventory/controller_test.go
@@ -247,14 +247,13 @@ func TestSSHServerBasics(t *testing.T) {
 	// set up to induce some failures, but not enough to cause the control
 	// stream to be closed.
 	auth.mu.Lock()
-	auth.failUpserts = 1
-	auth.failKeepAlives = 2
+	auth.failUpserts = 2
 	auth.mu.Unlock()
 
 	// keepalive should fail twice, but since the upsert is already known
 	// to have succeeded, we should not see an upsert failure yet.
 	awaitEvents(t, events,
-		expect(sshKeepAliveErr, sshKeepAliveErr),
+		expect(sshKeepAliveErr, sshKeepAliveErr, sshKeepAliveOk),
 		deny(sshUpsertErr, handlerClose),
 	)
 
@@ -269,6 +268,32 @@ func TestSSHServerBasics(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+
+	// this explicit upsert will not happen since the server is the same, but
+	// keepalives should work
+	awaitEvents(t, events,
+		expect(sshKeepAliveOk),
+		deny(sshKeepAliveErr, sshUpsertErr, sshUpsertRetryOk, handlerClose),
+	)
+
+	err = downstream.Send(ctx, proto.InventoryHeartbeat{
+		SSHServer: &types.ServerV2{
+			Metadata: types.Metadata{
+				Name: serverID,
+				Labels: map[string]string{
+					"changed": "changed",
+				},
+			},
+			Spec: types.ServerSpecV2{
+				Addr: zeroAddr,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	auth.mu.Lock()
+	auth.failUpserts = 1
+	auth.mu.Unlock()
 
 	// we should now see an upsert failure, but no additional
 	// keepalive failures, and the upsert should succeed on retry.


### PR DESCRIPTION
This PR changes the SSH heartbeats to use full upserts rather than a combination of upsert and keepalive, and changes the heartbeat rate for all resources that use the inventory control stream to a variable duration similar to the one used for instance heartbeats; instead of servers being kept alive every 90 seconds on average (with a 6/7th jitter, so an average of 13/14ths the nominal time), the interval will now scale between 90 and 360 seconds (6 minutes), with an expiry time of 15 minutes.

In addition, SSH server announcements coming from the agents (periodically every 6.6(6) jittered minutes, or on any change of the server entry) are going to be ignored unless there's a change in the data. Upserting new data will also reset the interval, reducing writes a bit further at no UX cost. Other resources rely on external deletions and a shared timer to heartbeat and stop heartbeating, so the only change to their behavior is in the TTL and the keepalive rate.

A consequence of this is that UUID collisions will result in SSH server heartbeats flipping between the two colliding servers at the heartbeat/keepalive rate (1.5 to 6 minutes) rather than the announce rate (a little over 6 minutes).

changelog: reduced cluster state storage load in clusters with a large amount of resources