### PR TITLE
Improved error logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -126,7 +126,7 @@ require (
 	github.com/gravitational/license v0.0.0-20240313232707-8312e719d624
 	github.com/gravitational/roundtrip v1.0.2
 	github.com/gravitational/teleport/api v0.0.0
-	github.com/gravitational/trace v1.4.0
+	github.com/gravitational/trace v1.4.1-0.20241128213428-353656d83c45
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0
 	github.com/guptarohit/asciigraph v0.7.3

--- a/go.sum
+++ b/go.sum
@@ -1536,6 +1536,8 @@ github.com/gravitational/saml v0.4.15-teleport.1 h1:kYSLpxEBEc7JLJJ+VjsZU8PbWI4g
 github.com/gravitational/saml v0.4.15-teleport.1/go.mod h1:S4+611dxnKt8z/ulbvaJzcgSHsuhjVc1QHNTcr1R7Fw=
 github.com/gravitational/trace v1.4.0 h1:TtTeMElVwMX21Udb1nmK2tpWYAAMJoyjevzKOaxIFZQ=
 github.com/gravitational/trace v1.4.0/go.mod h1:g79NZzwCjWS/VVubYowaFAQsTjVTohGi0hFbIWSyGoY=
+github.com/gravitational/trace v1.4.1-0.20241128213428-353656d83c45 h1:bHx88VKuCfy7ALJ0YZ5RSC7KJAbncaz3277Kr2ONLaE=
+github.com/gravitational/trace v1.4.1-0.20241128213428-353656d83c45/go.mod h1:g79NZzwCjWS/VVubYowaFAQsTjVTohGi0hFbIWSyGoY=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 h1:pdN6V1QBWetyv/0+wjACpqVH+eVULgEjkurDLq3goeM=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1 h1:qnpSQwGEnkcRpTqNOIR6bJbR0gAorgP9CSALpRcKoAA=

--- a/lib/utils/log/slog_handler.go
+++ b/lib/utils/log/slog_handler.go
@@ -107,13 +107,21 @@ func CompactErrors(groups []string, a slog.Attr) slog.Attr {
 	return a
 }
 
+func funcTraceOnly(traces trace.Traces) []string {
+	s := make([]string, len(traces))
+	for i, t := range traces {
+		s[i] = t.Func
+	}
+	return s
+}
+
 func CompactErrorsWithStackTrace(groups []string, a slog.Attr) slog.Attr {
 	if err, ok := a.Value.Any().(error); ok {
 		var traceErr trace.Error
 		if errors.As(err, &traceErr) {
 			return slog.Group("",
 				a.Key, traceErr.CompactUserMessage(), // display single-lien error
-				a.Key+"_trace", traceErr.StackTraceReport(), // enrich with stacktrace
+				a.Key+"_trace", funcTraceOnly(traceErr.StackTraceReport()), // enrich with stacktrace
 			)
 		}
 		return slog.Attr{Key: a.Key, Value: slog.StringValue(err.Error())}


### PR DESCRIPTION
Depends on https://github.com/gravitational/trace/pull/110

Demo code:
```go
err := trace.Errorf("oh no, it's broken")
log.Info("hello", "error", trace.Wrap(err, "callsite info"))
```

JSON log output:
```
# without stacktrace
{"timestamp":"2024-11-28T18:00:06-05:00","level":"info","caller":"log/slog_handler_test.go:50","message":"hello","error":"callsite info: oh no, it's broken"}

# with stacktrace
{"timestamp":"2024-11-28T19:45:00-05:00","level":"info","caller":"log/slog_handler_test.go:50","message":"hello","error":"callsite info: oh no, it's broken","error_trace":["github.com/gravitational/teleport/lib/utils/log.TestHugo","testing.tRunner","runtime.goexit"]}
```

Text output
```
# without stacktrace
time:2024-11-28 19:53:19.250706 -0500 EST INFO  hello error:callsite info: oh no, it's broken log/slog_handler_test.go:50

# with stacktrace
time:2024-11-28 19:50:04.904607 -0500 EST INFO  hello error:callsite info: oh no, it's broken error_trace:[github.com/gravitational/teleport/lib/utils/log.TestHugo testing.tRunner runtime.goexit] log/slog_handler_test.go:50
```

I'm not satisfied with the text output but I don't think a text-specific ReplaceAttr would make sense. Sny string containing whitespace currently leads to confusing logs and we might want to fix this issue more generally.