### PR TITLE
Expose Account Assignments via cache

### DIFF
--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -1237,6 +1237,9 @@ type Cache interface {
 	// GetProvisioningState gets a specific provisioning state
 	GetProvisioningState(context.Context, services.DownstreamID, services.ProvisioningStateID) (*provisioningv1.PrincipalState, error)
 
+	// GetAccountAssignment fetches specific IdentityCenter Account Assignment
+	GetAccountAssignment(context.Context, services.IdentityCenterAccountAssignmentID) (services.IdentityCenterAccountAssignment, error)
+
 	// ListAccountAssignments fetches a paginated list of IdentityCenter Account Assignments
 	ListAccountAssignments(context.Context, int, *pagination.PageRequestToken) ([]services.IdentityCenterAccountAssignment, pagination.NextPageToken, error)
 }

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -3560,6 +3560,19 @@ func (c *Cache) GetProvisioningState(ctx context.Context, downstream services.Do
 	return rg.reader.GetProvisioningState(ctx, downstream, id)
 }
 
+func (c *Cache) GetAccountAssignment(ctx context.Context, id services.IdentityCenterAccountAssignmentID) (services.IdentityCenterAccountAssignment, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetAccountAssignment")
+	defer span.End()
+
+	rg, err := readCollectionCache(c, c.collections.identityCenterAccountAssignments)
+	if err != nil {
+		return services.IdentityCenterAccountAssignment{}, trace.Wrap(err)
+	}
+	defer rg.Release()
+
+	return rg.reader.GetAccountAssignment(ctx, id)
+}
+
 // ListAccountAssignments fetches a paginated list of IdentityCenter Account Assignments
 func (c *Cache) ListAccountAssignments(ctx context.Context, pageSize int, pageToken *pagination.PageRequestToken) ([]services.IdentityCenterAccountAssignment, pagination.NextPageToken, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/ListAccountAssignments")


### PR DESCRIPTION
Extends cache to allow consumers to fetch a specific Identity Center account
assignment, rather than just listing them.
