### PR TITLE
Improve ButtonWithMenu types, add tests for Button types

### DIFF
--- a/web/packages/design/src/Button/Button.test.tsx
+++ b/web/packages/design/src/Button/Button.test.tsx
@@ -16,11 +16,21 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import React, {
+  ComponentPropsWithoutRef,
+  ComponentPropsWithRef,
+  PropsWithChildren,
+} from 'react';
 
-import { render, theme } from 'design/utils/testing';
+import { render, theme, screen } from 'design/utils/testing';
 
-import { Button, ButtonPrimary, ButtonSecondary, ButtonWarning } from './index';
+import {
+  Button,
+  ButtonPrimary,
+  ButtonSecondary,
+  ButtonWarning,
+  ButtonSize,
+} from './index';
 
 describe('design/Button', () => {
   it('renders a <button> and respects default "kind" prop == primary', () => {
@@ -70,5 +80,128 @@ describe('design/Button', () => {
   test('"block" prop renders width 100%', () => {
     const { container } = render(<Button block />);
     expect(container.firstChild).toHaveStyle('width: 100%');
+  });
+
+  describe('types and as prop', () => {
+    test('in regular components', () => {
+      render(
+        <>
+          <ButtonPrimary
+            // @ts-expect-error href does not exist on <button>.
+            href="https://example.com"
+          >
+            Button
+          </ButtonPrimary>
+
+          <ButtonPrimary
+            as="a"
+            href="https://example.com"
+            // @ts-expect-error onClick should accept a mouse event as the first arg.
+            onClick={invalidOnClickHandler}
+          >
+            Link
+          </ButtonPrimary>
+        </>
+      );
+
+      expect(screen.getByText('Button').localName).toEqual('button');
+      expect(screen.getByText('Link').localName).toEqual('a');
+    });
+
+    test('in wrappers with as prop', () => {
+      render(
+        <>
+          <RegularWrapper
+            // @ts-expect-error href does not exist on <button>.
+            href="https://example.com"
+          >
+            Button
+          </RegularWrapper>
+
+          <RegularWrapper
+            as="a"
+            href="https://example.com"
+            // @ts-expect-error onClick should accept a mouse event as the first arg.
+            onClick={invalidOnClickHandler}
+          >
+            Link
+          </RegularWrapper>
+        </>
+      );
+
+      expect(screen.getByText('Button').localName).toEqual('button');
+      expect(screen.getByText('Link').localName).toEqual('a');
+    });
+
+    test('in wrappers with forwardedAs prop', () => {
+      render(
+        <>
+          <ForwardedAsWrapper
+            // @ts-expect-error href does not exist on <button>.
+            href="https://example.com"
+          >
+            Button
+          </ForwardedAsWrapper>
+
+          <ForwardedAsWrapper
+            forwardedAs="a"
+            href="https://example.com"
+            // @ts-expect-error onClick should accept a mouse event as the first arg.
+            onClick={invalidOnClickHandler}
+          >
+            Link
+          </ForwardedAsWrapper>
+        </>
+      );
+
+      expect(screen.getByText('Button').localName).toEqual('button');
+      expect(screen.getByText('Link').localName).toEqual('a');
+    });
+
+    const RegularWrapper = <Element extends React.ElementType = 'button'>(
+      props: PropsWithChildren<{
+        size?: ButtonSize;
+      }> &
+        // For some reason, ComponentPropsWithoutRef or ComponentProps cause types for regular props
+        // such as onClick to not be correctly recognized.
+        ComponentPropsWithRef<typeof ButtonPrimary<Element>>
+    ) => {
+      const { size, children, ...buttonProps } = props;
+
+      return (
+        <ButtonPrimary size={size} {...buttonProps}>
+          {children}
+        </ButtonPrimary>
+      );
+    };
+
+    const ForwardedAsWrapper = <Element extends React.ElementType = 'button'>(
+      props: PropsWithChildren<{
+        size?: ButtonSize;
+        forwardedAs?: Element;
+      }> &
+        // With forwardedAs, WithRef or WithoutRef doesn't seem to make a difference, so we opt for
+        // the variant without the ref.
+        ComponentPropsWithoutRef<typeof ButtonPrimary<Element>>
+    ) => {
+      const { size, children, ...buttonProps } = props;
+
+      return (
+        <ButtonPrimary
+          // The css prop causes the component to require "forwardedAs" instead of just "as".
+          css={`
+            border-top-bottom-radius: 0;
+          `}
+          size={size}
+          {...buttonProps}
+        >
+          {children}
+        </ButtonPrimary>
+      );
+    };
+
+    const invalidOnClickHandler = (foo: string) => {
+      return typeof foo;
+    };
   });
 });

--- a/web/packages/design/src/ButtonWithMenu/ButtonWithMenu.tsx
+++ b/web/packages/design/src/ButtonWithMenu/ButtonWithMenu.tsx
@@ -16,7 +16,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ComponentType, ReactElement, useRef, useState } from 'react';
+import {
+  ComponentPropsWithoutRef,
+  ComponentType,
+  ElementType,
+  ReactElement,
+  useRef,
+  useState,
+} from 'react';
 
 import { ButtonBorder, Flex, Menu, MenuItem } from 'design';
 import * as icons from 'design/Icon';
@@ -46,13 +53,15 @@ import { ButtonSize } from 'design/Button';
  *   <MenuItem>Bar</MenuItem>
  * </ButtonWithMenu>
  */
-export const ButtonWithMenu = (props: {
-  text: string;
-  children: MenuItemComponent | MenuItemComponent[];
-  MenuIcon?: ComponentType<IconProps>;
-  size?: ButtonSize;
-  [buttonBorderProp: string]: any;
-}) => {
+export const ButtonWithMenu = <Element extends ElementType = 'button'>(
+  props: {
+    text: string;
+    children: MenuItemComponent | MenuItemComponent[];
+    MenuIcon?: ComponentType<IconProps>;
+    size?: ButtonSize;
+    forwardedAs?: Element;
+  } & ComponentPropsWithoutRef<typeof ButtonBorder<Element>>
+) => {
   const {
     text,
     MenuIcon = icons.MoreVert,


### PR DESCRIPTION
I was working on a component that was using `ButtonWithMenu`. I noticed that I was able to pass an `onClick` function to it that had a signature which didn't match what's expected from a regular `onClick`.

This was the case because of the type used to describe the rest of the props: `[buttonBorderProp: string]: any`. This makes it so that `ButtonWithMenu` accepts any kind of prop and its type doesn't matter.

I made an attempt to fix that by replacing this with `props: { <known props> } & ButtonProps<'button'>`. This seemed to work well until I found a callsite which uses the `forwardedAs` prop:

https://github.com/gravitational/teleport/blob/76bfe76be99ee978c5c7332f9a8bd9e8c13a64c9/web/packages/teleport/src/UnifiedResources/ResourceActionButton.tsx#L207-L217

The type that I came up with didn't want to allow the `target` and `href` props because they don't exist on `<button>`. So I needed to somehow make TS treat `ButtonWithMenu` as `a` when `forwardedAs` is passed.

After wrestling with the types for an hour, I wrote a simple test which serves two purposes. First, it checks if wrong props are rejected by TS. Second, it checks if the component under tests actually renders as `<button>` or `<a>`. This test case reproduces the problem that I ran into in `ButtonWithMenu`.

I found that depending on whether `forwardedAs` or `as` is needed, I need to use either `ComponentPropsWithoutRef` or `ComponentPropsWithRef` – I can't quite explain why it's the case, but this works for now and the test passes.

As for `forwardedAs` vs `as`, I believe `forwardedAs` is needed because when the `css` prop is used, it creates a wrapper component around the original styled component.

The third idea behind the test is to make it serve as a template whenever someone needs to provide a type for rest props. There's a bunch of other places with types for rest props (see `rg "\[.*\]: any"`) which could use such change in the future.