### PR TITLE
Honor the proxy peering listen address specified in the configuration

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4029,10 +4029,7 @@ func (process *TeleportProcess) setupProxyListeners(networkingConfig types.Clust
 	}
 
 	if !cfg.Proxy.DisableReverseTunnel && tunnelStrategy == types.ProxyPeering {
-		addr, err := process.Config.Proxy.PeerAddr()
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
+		addr := process.Config.Proxy.PeerListenAddr()
 
 		listener, err := process.importOrCreateListener(ListenerProxyPeer, addr.String())
 		if err != nil {

--- a/lib/service/servicecfg/proxy.go
+++ b/lib/service/servicecfg/proxy.go
@@ -210,18 +210,15 @@ func (c ProxyConfig) KubeAddr() (string, error) {
 }
 
 // PublicPeerAddr attempts to returns the public address the proxy advertises
-// for proxy peering clients if available. It falls back to PeerAddr othewise.
+// for proxy peering clients if available; otherwise, it falls back to trying to
+// guess an appropriate public address based on the listen address.
 func (c ProxyConfig) PublicPeerAddr() (*utils.NetAddr, error) {
 	addr := &c.PeerPublicAddr
-	if addr.IsEmpty() || addr.IsHostUnspecified() {
-		return c.PeerAddr()
+	if !addr.IsEmpty() && !addr.IsHostUnspecified() {
+		return addr, nil
 	}
-	return addr, nil
-}
 
-// PeerAddr returns the address the proxy advertises for proxy peering clients.
-func (c ProxyConfig) PeerAddr() (*utils.NetAddr, error) {
-	addr := &c.PeerAddress
+	addr = &c.PeerAddress
 	if addr.IsEmpty() {
 		addr = defaults.ProxyPeeringListenAddr()
 	}
@@ -241,6 +238,15 @@ func (c ProxyConfig) PeerAddr() (*utils.NetAddr, error) {
 	}
 
 	return addr, nil
+}
+
+// PeerListenAddr returns the proxy peering listen address that was configured,
+// or the default one otherwise.
+func (c ProxyConfig) PeerListenAddr() *utils.NetAddr {
+	if c.PeerAddress.IsEmpty() {
+		return defaults.ProxyPeeringListenAddr()
+	}
+	return &c.PeerAddress
 }
 
 // KubeProxyConfig specifies the Kubernetes configuration for Teleport's proxy service


### PR DESCRIPTION
The initial implementation of proxy peering (in #12359) conflated the proxy peering listen address and the advertised proxy peering address; #14905 added a separate configuration option for the advertised address, but didn't change the fact that the Teleport initialization process still tried to guess at some plausible address to listen to.

This PR makes it so that the `peer_listen_addr` specified in the Teleport configuration file is actually used as the address we listen to, unmodified, and it's used as the basis to derive a `peer_public_addr` to advertise if needed.

changelog: Fixed proxy peering listener not using the exact address specified in `peer_listen_addr`