### PR TITLE
[v15] Honor the proxy peering listen address specified in the configuration

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3996,10 +3996,7 @@ func (process *TeleportProcess) setupProxyListeners(networkingConfig types.Clust
 	}
 
 	if !cfg.Proxy.DisableReverseTunnel && tunnelStrategy == types.ProxyPeering {
-		addr, err := process.Config.Proxy.PeerAddr()
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
+		addr := process.Config.Proxy.PeerListenAddr()
 
 		listener, err := process.importOrCreateListener(ListenerProxyPeer, addr.String())
 		if err != nil {

--- a/lib/service/servicecfg/proxy.go
+++ b/lib/service/servicecfg/proxy.go
@@ -209,18 +209,15 @@ func (c ProxyConfig) KubeAddr() (string, error) {
 }
 
 // PublicPeerAddr attempts to returns the public address the proxy advertises
-// for proxy peering clients if available. It falls back to PeerAddr othewise.
+// for proxy peering clients if available; otherwise, it falls back to trying to
+// guess an appropriate public address based on the listen address.
 func (c ProxyConfig) PublicPeerAddr() (*utils.NetAddr, error) {
 	addr := &c.PeerPublicAddr
-	if addr.IsEmpty() || addr.IsHostUnspecified() {
-		return c.PeerAddr()
+	if !addr.IsEmpty() && !addr.IsHostUnspecified() {
+		return addr, nil
 	}
-	return addr, nil
-}
 
-// PeerAddr returns the address the proxy advertises for proxy peering clients.
-func (c ProxyConfig) PeerAddr() (*utils.NetAddr, error) {
-	addr := &c.PeerAddress
+	addr = &c.PeerAddress
 	if addr.IsEmpty() {
 		addr = defaults.ProxyPeeringListenAddr()
 	}
@@ -240,6 +237,15 @@ func (c ProxyConfig) PeerAddr() (*utils.NetAddr, error) {
 	}
 
 	return addr, nil
+}
+
+// PeerListenAddr returns the proxy peering listen address that was configured,
+// or the default one otherwise.
+func (c ProxyConfig) PeerListenAddr() *utils.NetAddr {
+	if c.PeerAddress.IsEmpty() {
+		return defaults.ProxyPeeringListenAddr()
+	}
+	return &c.PeerAddress
 }
 
 // KubeProxyConfig specifies the Kubernetes configuration for Teleport's proxy service


### PR DESCRIPTION
Backport #49586 to branch/v15

changelog: Fixed proxy peering listener not using the exact address specified in `peer_listen_addr`
