### PR TITLE
docs: update identity file instructions for plugin dir path

### DIFF
--- a/docs/pages/includes/plugins/identity-export.mdx
+++ b/docs/pages/includes/plugins/identity-export.mdx
@@ -46,7 +46,7 @@ If you are running the {{ client }} on a Linux server, create a data directory
 to hold certificate files for the {{ client }}:
 
 ```code
-$ sudo mkdir -p /var/lib/teleport/api-credentials
+$ sudo mkdir -p /var/lib/teleport/plugins/api-credentials
 $ sudo mv identity /var/lib/teleport/plugins/api-credentials
 ```
 


### PR DESCRIPTION
Correct dir path for creating plugin path and moving identity file. These have to be the same.