### PR TITLE
Fix TestDynamicIdentityFileCreds for Go 1.23

### DIFF
--- a/api/client/credentials_test.go
+++ b/api/client/credentials_test.go
@@ -471,6 +471,7 @@ func TestDynamicIdentityFileCreds(t *testing.T) {
 	require.NoError(t, err)
 	wantTLSCert, err := tls.X509KeyPair(tlsCert, keyPEM)
 	require.NoError(t, err)
+	wantTLSCert.Leaf = nil
 	require.Equal(t, wantTLSCert, *gotTLSCert)
 
 	expiry, ok := cred.Expiry()
@@ -529,6 +530,7 @@ func TestDynamicIdentityFileCreds(t *testing.T) {
 	require.NoError(t, err)
 	wantTLSCert, err = tls.X509KeyPair(secondTLSCertPem, keyPEM)
 	require.NoError(t, err)
+	wantTLSCert.Leaf = nil
 	require.Equal(t, wantTLSCert, *gotTLSCert)
 
 	expiry, ok = cred.Expiry()


### PR DESCRIPTION
Go 1.23 changed the behavior of tls.X509KeyPair and tls.LoadX509KeyPair to populate the certificate leaf, which makes the assertions on TestDynamicIdentityFileCreds fail.

The PR changes the test to expect a nil leaf, which matches the behavior of the code under test.

- https://go.dev/doc/go1.23#cryptotlspkgcryptotls
- #45473

Closes #49541.