### PR TITLE
update access request errors to not repeat cluster names

### DIFF
--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -120,6 +120,11 @@ func ValidateAccessRequestClusterNames(cg ClusterGetter, ar types.AccessRequest)
 		}
 	}
 	if len(invalidClusters) > 0 {
+                // Multiple resources are requestable with the same or different cluster names.
+                // Prior to showing the error message, sort the list and remove duplicates so
+                // the same cluster name isn't repeated.
+                slices.Sort(invalidClusters)
+                invalidClusters = slices.Compact(invalidClusters)
 		return trace.NotFound("access request contains invalid or unknown cluster names: %v",
 			strings.Join(invalidClusters, ", "))
 	}

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -121,7 +121,7 @@ func ValidateAccessRequestClusterNames(cg ClusterGetter, ar types.AccessRequest)
 	}
 	if len(invalidClusters) > 0 {
 		return trace.NotFound("access request contains invalid or unknown cluster names: %v",
-			strings.Join(utils.Deduplicate(invalidClusters), ", "))
+			strings.Join(apiutils.Deduplicate(invalidClusters), ", "))
 	}
 	return nil
 }

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -120,11 +120,11 @@ func ValidateAccessRequestClusterNames(cg ClusterGetter, ar types.AccessRequest)
 		}
 	}
 	if len(invalidClusters) > 0 {
-                // Multiple resources are requestable with the same or different cluster names.
-                // Prior to showing the error message, sort the list and remove duplicates so
-                // the same cluster name isn't repeated.
-                slices.Sort(invalidClusters)
-                invalidClusters = slices.Compact(invalidClusters)
+		// Multiple resources are requestable with the same or different cluster names.
+		// Prior to showing the error message, sort the list and remove duplicates so
+		// the same cluster name isn't repeated.
+		slices.Sort(invalidClusters)
+		invalidClusters = slices.Compact(invalidClusters)
 		return trace.NotFound("access request contains invalid or unknown cluster names: %v",
 			strings.Join(invalidClusters, ", "))
 	}

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -120,13 +120,8 @@ func ValidateAccessRequestClusterNames(cg ClusterGetter, ar types.AccessRequest)
 		}
 	}
 	if len(invalidClusters) > 0 {
-		// Multiple resources are requestable with the same or different cluster names.
-		// Prior to showing the error message, sort the list and remove duplicates so
-		// the same cluster name isn't repeated.
-		slices.Sort(invalidClusters)
-		invalidClusters = slices.Compact(invalidClusters)
 		return trace.NotFound("access request contains invalid or unknown cluster names: %v",
-			strings.Join(invalidClusters, ", "))
+			strings.Join(utils.Deduplicate(invalidClusters), ", "))
 	}
 	return nil
 }


### PR DESCRIPTION
Currently Teleport will repeat the same invalid cluster name with access requests error message. This updates to output only the unique cluster names. 

from
```bash
$ tsh request create --resource /teleport.example.com/node/e5409159-f127-46e2-a8fb-1f4515573f8f --resource /teleport.example.com/node/e5409159-f127-46e2-a8fb-1f4515573f8a --resource /othercluster.example.com/node/e5409159-f127-46e2-a8fb-1f4515573f8c --resource /teleport.example.com/node/e5409159-f127-46e2-a8fb-1f4515573f8e
Creating request...
ERROR: access request contains invalid or unknown cluster names: teleport.example.com, teleport.example.com, othercluster.example.com, teleport.example.com
```

to just the unique invalid cluster names

```bash
Creating request...
ERROR: access request contains invalid or unknown cluster names: othercluster.example.com, teleport.example.com
```
