### PR TITLE
Add label and separators for Menu

### DIFF
--- a/web/packages/design/src/Flex/Flex.story.jsx
+++ b/web/packages/design/src/Flex/Flex.story.jsx
@@ -67,3 +67,14 @@ export const Justified = () => (
     </Box>
   </Flex>
 );
+
+export const Inline = () => (
+  <Flex inline gap={5}>
+    <Box width={1 / 2} bg="pink" p={5}>
+      Box one
+    </Box>
+    <Box width={1 / 2} bg="orange" p={5}>
+      Box two
+    </Box>
+  </Flex>
+);

--- a/web/packages/design/src/Flex/Flex.tsx
+++ b/web/packages/design/src/Flex/Flex.tsx
@@ -42,10 +42,15 @@ export interface FlexProps
     FlexWrapProps,
     FlexDirectionProps,
     FlexBasisProps,
-    GapProps {}
+    GapProps {
+  /**
+   * Uses inline-flex instead of just flex as the display property.
+   */
+  inline?: boolean;
+}
 
 const Flex = styled(Box)<FlexProps>`
-  display: flex;
+  display: ${props => (props.inline ? 'inline-flex' : 'flex')};
   ${alignItems}
   ${justifyContent}
   ${flexWrap}

--- a/web/packages/design/src/Menu/Menu.story.tsx
+++ b/web/packages/design/src/Menu/Menu.story.tsx
@@ -22,10 +22,15 @@ import { ButtonPrimary } from '../Button';
 import Box from '../Box';
 import Flex from '../Flex';
 import * as Icons from '../Icon';
+import { H3 } from '../Text';
 
 import MenuItemIcon from './MenuItemIcon';
-import MenuItem from './MenuItem';
+import MenuItem, {
+  MenuItemSectionLabel,
+  MenuItemSectionSeparator,
+} from './MenuItem';
 import Menu from './Menu';
+import MenuList from './MenuList';
 
 export default {
   title: 'Design/Menu',
@@ -34,8 +39,11 @@ export default {
 export const PlacementExample = () => (
   <Flex m={3} gap={8} flexWrap="wrap">
     <SimpleMenu text="Menu to right">
-      <MenuItem>Test</MenuItem>
-      <MenuItem>Test2</MenuItem>
+      <MenuItem>Lorem</MenuItem>
+      <MenuItem>Ipsum</MenuItem>
+      <MenuItem>Dolor</MenuItem>
+      <MenuItem>Sit</MenuItem>
+      <MenuItem>Amet</MenuItem>
     </SimpleMenu>
     <SimpleMenu
       text="Menu in center"
@@ -70,6 +78,35 @@ export const PlacementExample = () => (
       <MenuItem>Test</MenuItem>
       <MenuItem>Test2</MenuItem>
     </SimpleMenu>
+  </Flex>
+);
+
+export const MenuItems = () => (
+  <Flex m={3} gap={8}>
+    <Flex gap={3} flexDirection="column">
+      <H3>Label after separator</H3>
+      <OpenMenu>
+        <MenuItem>Lorem ipsum</MenuItem>
+        <MenuItem>Dolor sit amet</MenuItem>
+        <MenuItemSectionSeparator />
+        <MenuItemSectionLabel>Leo vitae arcu</MenuItemSectionLabel>
+        <MenuItem>Donec volutpat</MenuItem>
+        <MenuItem>Mauris sit</MenuItem>
+        <MenuItem>Amet nisi tempor</MenuItem>
+      </OpenMenu>
+    </Flex>
+    <Flex gap={3} flexDirection="column">
+      <H3>Menu item after separator</H3>
+      <OpenMenu>
+        <MenuItem>Lorem ipsum</MenuItem>
+        <MenuItem>Dolor sit amet</MenuItem>
+        <MenuItemSectionSeparator />
+        <MenuItem>Leo vitae arcu</MenuItem>
+        <MenuItem>Donec volutpat</MenuItem>
+        <MenuItem>Mauris sit</MenuItem>
+        <MenuItem>Amet nisi tempor</MenuItem>
+      </OpenMenu>
+    </Flex>
   </Flex>
 );
 
@@ -133,6 +170,18 @@ const SimpleMenu = (
       >
         {children}
       </Menu>
+    </Box>
+  );
+};
+
+const OpenMenu = (props: PropsWithChildren) => {
+  // MenuList uses a percent value in max-height combined with overflow: hidden, so we have
+  // to wrap it twice here to avoid issues with the menu being cut off.
+  return (
+    <Box>
+      <Box>
+        <MenuList>{props.children}</MenuList>
+      </Box>
     </Box>
   );
 };

--- a/web/packages/design/src/Menu/Menu.story.tsx
+++ b/web/packages/design/src/Menu/Menu.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { PropsWithChildren, useRef, useState } from 'react';
 
 import { ButtonPrimary } from '../Button';
 import Box from '../Box';
@@ -32,7 +32,7 @@ export default {
 };
 
 export const PlacementExample = () => (
-  <Flex justifyContent="space-between">
+  <Flex m={3} gap={8} flexWrap="wrap">
     <SimpleMenu text="Menu to right">
       <MenuItem>Test</MenuItem>
       <MenuItem>Test2</MenuItem>
@@ -100,41 +100,39 @@ export const IconExample = () => (
   </Menu>
 );
 
-class SimpleMenu extends React.Component {
-  state = {
-    anchorEl: null,
+const SimpleMenu = (
+  props: PropsWithChildren<{
+    text: string;
+    anchorOrigin?: any;
+    transformOrigin?: any;
+  }>
+) => {
+  const anchorElRef = useRef(null);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const open = () => {
+    setIsOpen(true);
+  };
+  const close = () => {
+    setIsOpen(false);
   };
 
-  handleClickListItem = event => {
-    this.setState({ anchorEl: event.currentTarget });
-  };
+  const { text, anchorOrigin, transformOrigin, children } = props;
 
-  handleMenuItemClick = () => {
-    this.setState({ anchorEl: null });
-  };
-
-  handleClose = () => {
-    this.setState({ anchorEl: null });
-  };
-
-  render() {
-    const { text, anchorOrigin, transformOrigin, children } = this.props;
-    const { anchorEl } = this.state;
-    return (
-      <Box m={11} textAlign="center">
-        <ButtonPrimary size="small" onClick={this.handleClickListItem}>
-          {text}
-        </ButtonPrimary>
-        <Menu
-          anchorOrigin={anchorOrigin}
-          transformOrigin={transformOrigin}
-          anchorEl={anchorEl}
-          open={Boolean(anchorEl)}
-          onClose={this.handleClose}
-        >
-          {children}
-        </Menu>
-      </Box>
-    );
-  }
-}
+  return (
+    <Box textAlign="center">
+      <ButtonPrimary size="small" setRef={anchorElRef} onClick={open}>
+        {text}
+      </ButtonPrimary>
+      <Menu
+        anchorOrigin={anchorOrigin}
+        transformOrigin={transformOrigin}
+        anchorEl={anchorElRef.current}
+        open={isOpen}
+        onClose={close}
+      >
+        {children}
+      </Menu>
+    </Box>
+  );
+};

--- a/web/packages/design/src/Menu/Menu.story.tsx
+++ b/web/packages/design/src/Menu/Menu.story.tsx
@@ -23,6 +23,7 @@ import Box from '../Box';
 import Flex from '../Flex';
 import * as Icons from '../Icon';
 import { H3 } from '../Text';
+import { Origin } from '../Popover';
 
 import MenuItemIcon from './MenuItemIcon';
 import MenuItem, {
@@ -140,8 +141,8 @@ export const IconExample = () => (
 const SimpleMenu = (
   props: PropsWithChildren<{
     text: string;
-    anchorOrigin?: any;
-    transformOrigin?: any;
+    anchorOrigin?: Origin;
+    transformOrigin?: Origin;
   }>
 ) => {
   const anchorElRef = useRef(null);

--- a/web/packages/design/src/Menu/MenuItem.tsx
+++ b/web/packages/design/src/Menu/MenuItem.tsx
@@ -27,6 +27,7 @@ import {
 } from 'styled-system';
 
 import { Theme } from 'design/theme/themes/types';
+import Flex from 'design/Flex';
 
 const defaultValues = {
   fontSize: 1,
@@ -40,6 +41,70 @@ interface MenuItemProps extends FontSizeProps, SpaceProps, ColorProps {
 interface ThemedMenuItemProps extends MenuItemProps {
   theme: Theme;
 }
+
+// TODO(ravicious): This probably can be simplified when the time comes to do a redesign of Menu.
+// For now it's based on the existing code from fromTheme so that we don't break anything.
+const fromThemeBase = (props: { theme: Theme }) => {
+  const values = {
+    ...defaultValues,
+    ...props,
+  };
+  return {
+    ...fontSize(values),
+    ...space(values),
+    ...color(values),
+    fontWeight: values.theme.regular,
+  };
+};
+
+const MenuItemBase = styled(Flex)`
+  min-height: 40px;
+  box-sizing: border-box;
+  justify-content: flex-start;
+  align-items: center;
+  min-width: 140px;
+  overflow: hidden;
+  text-decoration: none;
+  white-space: nowrap;
+  color: ${props => props.theme.colors.text.main};
+
+  ${fromThemeBase}
+`;
+
+export const MenuItemSectionLabel = styled(MenuItemBase).attrs({
+  px: 2,
+  onClick: event => {
+    // Make sure that clicks on this element don't trigger onClick set on MenuList.
+    event.stopPropagation();
+  },
+})`
+  font-weight: bold;
+  min-height: 16px;
+`;
+
+export const MenuItemSectionSeparator = styled.hr.attrs({
+  onClick: event => {
+    // Make sure that clicks on this element don't trigger onClick set on MenuList.
+    event.stopPropagation();
+  },
+})`
+  background: ${props => props.theme.colors.interactive.tonal.neutral[1]};
+  height: 1px;
+  border: 0;
+  font-size: 0;
+
+  // Add padding to the label for extra visual space, but only when it follows a separator.
+  // If a separator follows a MenuItem, there's already enough visual space, so no extra space is
+  // needed. The hover state of MenuItem highlights everything right from the separator start to the
+  // end of MenuItem.
+  //
+  // Padding is used instead of margin here on purpose, so that there's no empty transparent space
+  // between Separator and Label – otherwise clicking on that space would count as a click on
+  // MenuList and not trigger onClick set on Separator or Label.
+  & + ${MenuItemSectionLabel} {
+    padding-top: ${props => props.theme.space[1]}px;
+  }
+`;
 
 const fromTheme = (props: ThemedMenuItemProps) => {
   const values = {
@@ -64,17 +129,10 @@ const fromTheme = (props: ThemedMenuItemProps) => {
   };
 };
 
-const MenuItem = styled.div.attrs({ role: 'menuitem' })<MenuItemProps>`
-  min-height: 40px;
-  box-sizing: border-box;
+const MenuItem = styled(MenuItemBase).attrs({
+  role: 'menuitem',
+})<MenuItemProps>`
   cursor: ${props => (props.disabled ? 'not-allowed' : 'pointer')};
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
-  min-width: 140px;
-  overflow: hidden;
-  text-decoration: none;
-  white-space: nowrap;
   color: ${props =>
     props.disabled
       ? props.theme.colors.text.disabled

--- a/web/packages/design/src/Menu/MenuList.tsx
+++ b/web/packages/design/src/Menu/MenuList.tsx
@@ -16,22 +16,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import { ComponentProps } from 'react';
+import styled, { StyleFunction } from 'styled-components';
 
-class MenuList extends React.Component {
-  render() {
-    const { children, innerRef, ...other } = this.props;
-    return (
-      <StyledMenuList ref={innerRef} role="menu" {...other}>
-        {children}
-      </StyledMenuList>
-    );
-  }
-}
-
-const StyledMenuList = styled.div`
+// TODO(ravicious): Put MenuList definition next to Menu once Menu is rewritten in TypeScript.
+const MenuList = styled.div.attrs({ role: 'menu' })<{
+  menuListCss?: StyleFunction<ComponentProps<'div'>>;
+}>`
   background-color: ${props => props.theme.colors.levels.elevated};
   border-radius: 4px;
   box-shadow: ${props => props.theme.boxShadow[0]};
@@ -44,17 +35,4 @@ const StyledMenuList = styled.div`
   ${props => props.menuListCss && props.menuListCss(props)}
 `;
 
-MenuList.propTypes = {
-  /**
-   * MenuList contents, normally `MenuItem`s.
-   */
-  children: PropTypes.node,
-  /**
-   * @ignore
-   */
-  menuListCss: PropTypes.func,
-};
-
-export default React.forwardRef((props, ref) => (
-  <MenuList innerRef={ref} {...props} />
-));
+export default MenuList;

--- a/web/packages/design/src/Menu/MenuList.tsx
+++ b/web/packages/design/src/Menu/MenuList.tsx
@@ -29,6 +29,7 @@ const MenuList = styled.div.attrs({ role: 'menu' })<{
   box-sizing: border-box;
   max-height: calc(100% - 96px);
   overflow: hidden;
+  overflow-y: auto;
   position: relative;
   padding: 0;
 

--- a/web/packages/design/src/Popover/Popover.tsx
+++ b/web/packages/design/src/Popover/Popover.tsx
@@ -738,7 +738,12 @@ export class Popover extends Component<Props> {
         BackdropProps={{ invisible: true, ...this.props.backdropProps }}
         {...other}
       >
-        <Transition onEntering={this.handleEntering}>
+        <Transition
+          onEntering={this.handleEntering}
+          enablePaperResizeObserver={this.props.updatePositionOnChildResize}
+          paperRef={this.paperRef}
+          onPaperResize={this.setPositioningStyles}
+        >
           <StyledPopover
             shadow={true}
             popoverCss={popoverCss}
@@ -860,6 +865,15 @@ interface Props extends Omit<ModalProps, 'children' | 'open'> {
    * arrow tips.
    */
   arrowMargin?: number;
+
+  /**
+   * If false (default), positioning styles are updated only on the initial render of the children.
+   *
+   * If true, updates positioning styles of the popover whenever the children are resized.
+   * This is useful in situations where the children are updated asynchronously, e.g., after
+   * receiving a response over network.
+   */
+  updatePositionOnChildResize?: boolean;
 }
 
 export const StyledPopover = styled(Flex)<{

--- a/web/packages/design/src/Popover/Transition.tsx
+++ b/web/packages/design/src/Popover/Transition.tsx
@@ -16,18 +16,33 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useLayoutEffect } from 'react';
+import React, { RefObject, useLayoutEffect } from 'react';
 
+import { useResizeObserver } from 'design/utils/useResizeObserver';
+
+/**
+ * Transition is a helper for firing certain effects from Popover, as it's way easier to use them
+ * this way than integrating with the component lifecycle.
+ */
 export function Transition({
   onEntering,
+  enablePaperResizeObserver,
+  paperRef,
+  onPaperResize,
   children,
 }: React.PropsWithChildren<{
   onEntering: () => void;
+  enablePaperResizeObserver: boolean | undefined;
+  paperRef: RefObject<HTMLElement>;
+  onPaperResize: () => void;
 }>) {
   // Note: useLayoutEffect to prevent flickering improperly positioned popovers.
   // It's especially noticeable on Safari.
-  useLayoutEffect(() => {
-    onEntering();
-  }, []);
+  useLayoutEffect(onEntering, []);
+
+  useResizeObserver(paperRef, onPaperResize, {
+    enabled: enablePaperResizeObserver,
+  });
+
   return children;
 }

--- a/web/packages/design/src/utils/useResizeObserver.ts
+++ b/web/packages/design/src/utils/useResizeObserver.ts
@@ -1,0 +1,61 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { RefObject, useCallback, useLayoutEffect } from 'react';
+
+/**
+ * useResizeObserver sets up a ResizeObserver for ref and calls callback on each resize.
+ *
+ * It does not fire if ref.current.contentRect.height is zero, to account for a special case in
+ * Connect where tabs are hidden using `display: none;`.
+ *
+ * Uses a layout effect underneath. If ref is conditionally rendered, set enabled to false when ref
+ * is null.
+ */
+export function useResizeObserver(
+  ref: RefObject<HTMLElement>,
+  callback: (entry: ResizeObserverEntry) => void,
+  { enabled = true }
+): void {
+  const effect = useCallback(() => {
+    if (!ref.current || !enabled) {
+      return;
+    }
+
+    const observer = new ResizeObserver(entries => {
+      const entry = entries[0];
+
+      // In Connect, when a tab becomes active, its outermost DOM element switches from `display:
+      // none` to `display: flex`. This callback is then fired with the height reported as zero.
+      // To avoid unnecessary calls to callback, return early here.
+      if (entry.contentRect.height === 0) {
+        return;
+      }
+
+      callback(entry);
+    });
+
+    observer.observe(ref.current);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [callback, ref, enabled]);
+
+  useLayoutEffect(effect, [effect]);
+}

--- a/web/packages/shared/components/MenuLogin/MenuLogin.story.tsx
+++ b/web/packages/shared/components/MenuLogin/MenuLogin.story.tsx
@@ -21,7 +21,7 @@ import { Flex, H3 } from 'design';
 import styled from 'styled-components';
 
 import { MenuLogin } from './MenuLogin';
-import { MenuLoginHandle } from './types';
+import { LoginItem, MenuLoginHandle } from './types';
 
 export default {
   title: 'Shared/MenuLogin',
@@ -56,7 +56,11 @@ function MenuLoginExamples() {
       </Example>
       <Example>
         <H3>With logins</H3>
-        <SampleMenu />
+        <SampleMenu loginItems={loginItems} open />
+      </Example>
+      <Example>
+        <H3>With a lot of logins</H3>
+        <SampleMenu loginItems={aLotOfLoginItems} />
       </Example>
     </Flex>
   );
@@ -68,12 +72,20 @@ const Example = styled(Flex).attrs({
   alignItems: 'flex-start',
 })``;
 
-const SampleMenu = () => {
+const SampleMenu = ({
+  loginItems,
+  open = false,
+}: {
+  loginItems: LoginItem[];
+  open?: boolean;
+}) => {
   const menuRef = useRef<MenuLoginHandle>();
 
   useEffect(() => {
-    menuRef.current.open();
-  }, []);
+    if (open) {
+      menuRef.current.open();
+    }
+  }, [open]);
 
   return (
     <MenuLogin
@@ -84,7 +96,61 @@ const SampleMenu = () => {
   );
 };
 
-const loginItems = ['root', 'jazrafiba', 'evubale', 'ipizodu'].map(login => ({
-  url: '',
-  login,
-}));
+const makeLoginItem = (login: string) => ({ url: '', login });
+
+const loginItems = ['root', 'jazrafiba', 'evubale', 'ipizodu'].map(
+  makeLoginItem
+);
+const aLotOfLoginItems = [
+  'root',
+  'nyvpr@freire42.arg',
+  'obo@qngnubfg.pb',
+  'puneyvr@zlqbznva.bet',
+  'qnir@erzbgrobk.pbz',
+  'rir@flfgrzyvax.qri',
+  'senax@pybhqlfcnpr.vb',
+  'tenpr@grpuuho.hf',
+  'unax@frpherybtva.ovm',
+  'vil@argpbaarpg.gi',
+  'wvyy@fnsrnpprff.ceb',
+  'xra@erzbgryno.pb',
+  'yran@qribcf.pybhq',
+  'zvxr@ulcreabqr.bet',
+  'avan@ybtzrva.klm',
+  'bfpne@frpherubfg.arg',
+  'cnhy@dhvpxpbaarpg.pb',
+  'dhvaa@yvaxzr.ceb',
+  'ehgu@snfgqngn.vb',
+  'fgrir@npprffcbvag.qri',
+  'gvan@pbzchgryvax.hf',
+  'htb@frphercbeg.ovm',
+  'iren@freirenpprff.gi',
+  'jnyg@ybtvafgngvba.pbz',
+  'kran@fnsrubfg.arg',
+  'lhev@erzbgrfreire.pb',
+  'mnen@pbaarpgyvax.vb',
+  'nqnz@ploreabqr.pybhq',
+  'orgu@flfgrztngr.bet',
+  'pney@snfgybtva.ceb',
+  'qvan@qngnjbeyq.ovm',
+  'rq@ybtoevqtr.gi',
+  'snl@frpherjnl.qri',
+  'tvy@grpunpprff.hf',
+  'uny@erzbgryvax.arg',
+  'vqn@freirecbvag.pbz',
+  'wnxr@pbaarpgceb.vb',
+  'xnen@ybtfgngvba.bet',
+  'yrb@npprffarg.pb',
+  'znln@ploreyvax.gi',
+  'abnu@erzbgrfcnpr.ovm',
+  'bytn@frpherqngn.ceb',
+  'crgr@dhvpxabqr.qri',
+  'dhvaa@flfgrznpprff.hf',
+  'eurn@ybtabqr.pbz',
+  'fnen@erzbgrnpprff.arg',
+  'gbz@pybhqfgngvba.pb',
+  'hefhyn@ulcreyvax.vb',
+  'ivp@frpheryvax.gi',
+  'jvyy@freiretngr.ceb',
+  'last@item.com',
+].map(makeLoginItem);

--- a/web/packages/shared/components/MenuLogin/MenuLogin.story.tsx
+++ b/web/packages/shared/components/MenuLogin/MenuLogin.story.tsx
@@ -16,8 +16,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-import { Flex } from 'design';
+import { useEffect, useRef } from 'react';
+import { Flex, H3 } from 'design';
+import styled from 'styled-components';
 
 import { MenuLogin } from './MenuLogin';
 import { MenuLoginHandle } from './types';
@@ -31,44 +32,57 @@ export const MenuLoginStory = () => <MenuLoginExamples />;
 function MenuLoginExamples() {
   return (
     <Flex
-      width="400px"
-      height="100px"
-      alignItems="center"
-      justifyContent="space-around"
+      inline
+      p={4}
+      gap="128px"
+      justifyContent="flex-start"
       bg="levels.surface"
     >
-      <MenuLogin
-        getLoginItems={() => []}
-        onSelect={() => null}
-        placeholder="Please provide user name…"
-      />
-      <MenuLogin
-        getLoginItems={() => new Promise(() => {})}
-        placeholder="MenuLogin in processing state"
-        onSelect={() => null}
-      />
-      <SampleMenu />
+      <Example>
+        <H3>No logins</H3>
+        <MenuLogin
+          getLoginItems={() => []}
+          onSelect={() => null}
+          placeholder="Please provide user name…"
+        />
+      </Example>
+      <Example>
+        <H3>Processing state</H3>
+        <MenuLogin
+          getLoginItems={() => new Promise(() => {})}
+          placeholder="MenuLogin in processing state"
+          onSelect={() => null}
+        />
+      </Example>
+      <Example>
+        <H3>With logins</H3>
+        <SampleMenu />
+      </Example>
     </Flex>
   );
 }
 
-class SampleMenu extends React.Component {
-  menuRef = React.createRef<MenuLoginHandle>();
+const Example = styled(Flex).attrs({
+  gap: 2,
+  flexDirection: 'column',
+  alignItems: 'flex-start',
+})``;
 
-  componentDidMount() {
-    this.menuRef.current.open();
-  }
+const SampleMenu = () => {
+  const menuRef = useRef<MenuLoginHandle>();
 
-  render() {
-    return (
-      <MenuLogin
-        ref={this.menuRef}
-        getLoginItems={() => loginItems}
-        onSelect={() => null}
-      />
-    );
-  }
-}
+  useEffect(() => {
+    menuRef.current.open();
+  }, []);
+
+  return (
+    <MenuLogin
+      ref={menuRef}
+      getLoginItems={() => loginItems}
+      onSelect={() => null}
+    />
+  );
+};
 
 const loginItems = ['root', 'jazrafiba', 'evubale', 'ipizodu'].map(login => ({
   url: '',

--- a/web/packages/shared/components/MenuLogin/MenuLogin.tsx
+++ b/web/packages/shared/components/MenuLogin/MenuLogin.tsx
@@ -141,6 +141,9 @@ export const MenuLogin = React.forwardRef<MenuLoginHandle, MenuLoginProps>(
           open={isOpen}
           onClose={onClose}
           getContentAnchorEl={null}
+          // The list of logins is updated asynchronously, so Popover inside Menu needs to account
+          // for LoginItemList changing in size.
+          updatePositionOnChildResize
         >
           <LoginItemList
             getLoginItemsAttempt={getLoginItemsAttempt}
@@ -210,6 +213,8 @@ function getLoginItemListContent(
     case 'processing':
       return (
         <Indicator
+          // Without this margin, <Indicator> would cause a scroll bar to pop up and hide repeatedly.
+          m={1}
           css={`
             align-self: center;
           `}

--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
@@ -85,6 +85,8 @@ export function ResourceCard({
   useLayoutEffect(() => {
     if (!labelsInnerContainer.current) return;
 
+    // TODO(ravicious): Use useResizeObserver instead. Ensure that the callback passed to
+    // useResizeObserver has a stable identity.
     const observer = new ResizeObserver(entries => {
       const container = entries[0];
 

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -399,6 +399,8 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
     unifiedResourcePreferences.labelsViewMode === LabelsViewMode.EXPANDED;
 
   useLayoutEffect(() => {
+    // TODO(ravicious): Use useResizeObserver instead. Ensure that the callback passed to
+    // useResizeObserver has a stable identity.
     const resizeObserver = new ResizeObserver(entries => {
       const container = entries[0];
 

--- a/web/packages/teleport/src/Main/LayoutContext.tsx
+++ b/web/packages/teleport/src/Main/LayoutContext.tsx
@@ -39,6 +39,8 @@ export function LayoutContextProvider(props: PropsWithChildren<unknown>) {
   const containerRef = useRef<HTMLDivElement>();
 
   useEffect(() => {
+    // TODO(ravicious): Use useResizeObserver instead. Ensure that the callback passed to
+    // useResizeObserver has a stable identity.
     const resizeObserver = new ResizeObserver(entries => {
       const container = entries[0];
       setCurrentWidth(container?.contentRect.width || 0);


### PR DESCRIPTION
This PR adds a label and a separator component. Those two can be used to create sections within the menu. I will need them to [show ports for multi-port TCP apps in Connect](https://github.com/gravitational/teleport/blob/master/rfd/0182-multi-port-tcp-app-access.md#ui). FWIW, these were not consulted with the design team.

I also refactored the story (to make it easier to add more stuff in an upcoming PR) and `MenuList` (because I was getting some weird TS errors when the component was written in JS). Also, `Flex` now accepts `inline` as a prop to use `display: inline-flex`.

https://localhost:9002/?path=/story/design-menu--menu-items

<img width="412" alt="label-and-separator" src="https://github.com/user-attachments/assets/41d9bc1e-1510-4fc1-81a3-eb797759d079">

<img width="412" alt="ports in Connect" src="https://github.com/user-attachments/assets/c237e972-0cf6-4f8d-85f0-91fc9d6e91f4">
