### PR TITLE
Fix rendering MenuLogin with a long list of items

### DIFF
--- a/web/packages/design/src/Menu/MenuList.tsx
+++ b/web/packages/design/src/Menu/MenuList.tsx
@@ -29,6 +29,7 @@ const MenuList = styled.div.attrs({ role: 'menu' })<{
   box-sizing: border-box;
   max-height: calc(100% - 96px);
   overflow: hidden;
+  overflow-y: auto;
   position: relative;
   padding: 0;
 

--- a/web/packages/design/src/Popover/Popover.tsx
+++ b/web/packages/design/src/Popover/Popover.tsx
@@ -738,7 +738,12 @@ export class Popover extends Component<Props> {
         BackdropProps={{ invisible: true, ...this.props.backdropProps }}
         {...other}
       >
-        <Transition onEntering={this.handleEntering}>
+        <Transition
+          onEntering={this.handleEntering}
+          enablePaperResizeObserver={this.props.updatePositionOnChildResize}
+          paperRef={this.paperRef}
+          onPaperResize={this.setPositioningStyles}
+        >
           <StyledPopover
             shadow={true}
             popoverCss={popoverCss}
@@ -860,6 +865,15 @@ interface Props extends Omit<ModalProps, 'children' | 'open'> {
    * arrow tips.
    */
   arrowMargin?: number;
+
+  /**
+   * If false (default), positioning styles are updated only on the initial render of the children.
+   *
+   * If true, updates positioning styles of the popover whenever the children are resized.
+   * This is useful in situations where the children are updated asynchronously, e.g., after
+   * receiving a response over network.
+   */
+  updatePositionOnChildResize?: boolean;
 }
 
 export const StyledPopover = styled(Flex)<{

--- a/web/packages/design/src/Popover/Transition.tsx
+++ b/web/packages/design/src/Popover/Transition.tsx
@@ -16,18 +16,32 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useLayoutEffect } from 'react';
+import React, { RefObject, useLayoutEffect } from 'react';
 
+import { useResizeObserver } from 'design/utils/useResizeObserver';
+
+/**
+ * Transition is a helper for firing certain effects from Popover, as it's way easier to use them
+ * this way than integrating with the component lifecycle.
+ */
 export function Transition({
   onEntering,
+  enablePaperResizeObserver,
+  paperRef,
+  onPaperResize,
   children,
 }: React.PropsWithChildren<{
   onEntering: () => void;
+  enablePaperResizeObserver: boolean | undefined;
+  paperRef: RefObject<HTMLElement>;
+  onPaperResize: () => void;
 }>) {
   // Note: useLayoutEffect to prevent flickering improperly positioned popovers.
   // It's especially noticeable on Safari.
-  useLayoutEffect(() => {
-    onEntering();
-  }, []);
+  useLayoutEffect(onEntering, [onEntering]);
+  useResizeObserver(paperRef, onPaperResize, {
+    enabled: enablePaperResizeObserver,
+  });
+
   return children;
 }

--- a/web/packages/design/src/Popover/Transition.tsx
+++ b/web/packages/design/src/Popover/Transition.tsx
@@ -38,7 +38,8 @@ export function Transition({
 }>) {
   // Note: useLayoutEffect to prevent flickering improperly positioned popovers.
   // It's especially noticeable on Safari.
-  useLayoutEffect(onEntering, [onEntering]);
+  useLayoutEffect(onEntering, []);
+
   useResizeObserver(paperRef, onPaperResize, {
     enabled: enablePaperResizeObserver,
   });

--- a/web/packages/design/src/utils/useResizeObserver.ts
+++ b/web/packages/design/src/utils/useResizeObserver.ts
@@ -1,0 +1,60 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { RefObject, useCallback, useLayoutEffect } from 'react';
+
+/**
+ * useResizeObserver sets up a ResizeObserver for ref and calls callback on each resize.
+ *
+ * It does not fire if ref.current.contentRect.height is zero, to account for a special case in
+ * Connect where tabs are hidden using `display: none;`.
+ *
+ * Uses a layout effect underneath.
+ */
+export function useResizeObserver(
+  ref: RefObject<HTMLElement>,
+  callback: () => void,
+  { enabled = true }
+): void {
+  const effect = useCallback(() => {
+    if (!ref.current || !enabled) {
+      return;
+    }
+
+    const observer = new ResizeObserver(entries => {
+      const element = entries[0];
+
+      // In Connect, when a tab becomes active, its outermost DOM element switches from `display:
+      // none` to `display: flex`. This callback is then fired with the height reported as zero.
+      // To avoid unnecessary calls to callback, return early here.
+      if (element.contentRect.height === 0) {
+        return;
+      }
+
+      callback();
+    });
+
+    observer.observe(ref.current);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [callback, ref, enabled]);
+
+  useLayoutEffect(effect, [effect]);
+}

--- a/web/packages/design/src/utils/useResizeObserver.ts
+++ b/web/packages/design/src/utils/useResizeObserver.ts
@@ -24,11 +24,12 @@ import { RefObject, useCallback, useLayoutEffect } from 'react';
  * It does not fire if ref.current.contentRect.height is zero, to account for a special case in
  * Connect where tabs are hidden using `display: none;`.
  *
- * Uses a layout effect underneath.
+ * Uses a layout effect underneath. If ref is conditionally rendered, set enabled to false when ref
+ * is null.
  */
 export function useResizeObserver(
   ref: RefObject<HTMLElement>,
-  callback: () => void,
+  callback: (entry: ResizeObserverEntry) => void,
   { enabled = true }
 ): void {
   const effect = useCallback(() => {
@@ -37,16 +38,16 @@ export function useResizeObserver(
     }
 
     const observer = new ResizeObserver(entries => {
-      const element = entries[0];
+      const entry = entries[0];
 
       // In Connect, when a tab becomes active, its outermost DOM element switches from `display:
       // none` to `display: flex`. This callback is then fired with the height reported as zero.
       // To avoid unnecessary calls to callback, return early here.
-      if (element.contentRect.height === 0) {
+      if (entry.contentRect.height === 0) {
         return;
       }
 
-      callback();
+      callback(entry);
     });
 
     observer.observe(ref.current);

--- a/web/packages/shared/components/MenuLogin/MenuLogin.story.tsx
+++ b/web/packages/shared/components/MenuLogin/MenuLogin.story.tsx
@@ -21,7 +21,7 @@ import { Flex, H3 } from 'design';
 import styled from 'styled-components';
 
 import { MenuLogin } from './MenuLogin';
-import { MenuLoginHandle } from './types';
+import { LoginItem, MenuLoginHandle } from './types';
 
 export default {
   title: 'Shared/MenuLogin',
@@ -56,7 +56,11 @@ function MenuLoginExamples() {
       </Example>
       <Example>
         <H3>With logins</H3>
-        <SampleMenu />
+        <SampleMenu loginItems={loginItems} open />
+      </Example>
+      <Example>
+        <H3>With a lot of logins</H3>
+        <SampleMenu loginItems={aLotOfLoginItems} />
       </Example>
     </Flex>
   );
@@ -68,12 +72,20 @@ const Example = styled(Flex).attrs({
   alignItems: 'flex-start',
 })``;
 
-const SampleMenu = () => {
+const SampleMenu = ({
+  loginItems,
+  open = false,
+}: {
+  loginItems: LoginItem[];
+  open?: boolean;
+}) => {
   const menuRef = useRef<MenuLoginHandle>();
 
   useEffect(() => {
-    menuRef.current.open();
-  }, []);
+    if (open) {
+      menuRef.current.open();
+    }
+  }, [open]);
 
   return (
     <MenuLogin
@@ -84,7 +96,61 @@ const SampleMenu = () => {
   );
 };
 
-const loginItems = ['root', 'jazrafiba', 'evubale', 'ipizodu'].map(login => ({
-  url: '',
-  login,
-}));
+const makeLoginItem = (login: string) => ({ url: '', login });
+
+const loginItems = ['root', 'jazrafiba', 'evubale', 'ipizodu'].map(
+  makeLoginItem
+);
+const aLotOfLoginItems = [
+  'root',
+  'nyvpr@freire42.arg',
+  'obo@qngnubfg.pb',
+  'puneyvr@zlqbznva.bet',
+  'qnir@erzbgrobk.pbz',
+  'rir@flfgrzyvax.qri',
+  'senax@pybhqlfcnpr.vb',
+  'tenpr@grpuuho.hf',
+  'unax@frpherybtva.ovm',
+  'vil@argpbaarpg.gi',
+  'wvyy@fnsrnpprff.ceb',
+  'xra@erzbgryno.pb',
+  'yran@qribcf.pybhq',
+  'zvxr@ulcreabqr.bet',
+  'avan@ybtzrva.klm',
+  'bfpne@frpherubfg.arg',
+  'cnhy@dhvpxpbaarpg.pb',
+  'dhvaa@yvaxzr.ceb',
+  'ehgu@snfgqngn.vb',
+  'fgrir@npprffcbvag.qri',
+  'gvan@pbzchgryvax.hf',
+  'htb@frphercbeg.ovm',
+  'iren@freirenpprff.gi',
+  'jnyg@ybtvafgngvba.pbz',
+  'kran@fnsrubfg.arg',
+  'lhev@erzbgrfreire.pb',
+  'mnen@pbaarpgyvax.vb',
+  'nqnz@ploreabqr.pybhq',
+  'orgu@flfgrztngr.bet',
+  'pney@snfgybtva.ceb',
+  'qvan@qngnjbeyq.ovm',
+  'rq@ybtoevqtr.gi',
+  'snl@frpherjnl.qri',
+  'tvy@grpunpprff.hf',
+  'uny@erzbgryvax.arg',
+  'vqn@freirecbvag.pbz',
+  'wnxr@pbaarpgceb.vb',
+  'xnen@ybtfgngvba.bet',
+  'yrb@npprffarg.pb',
+  'znln@ploreyvax.gi',
+  'abnu@erzbgrfcnpr.ovm',
+  'bytn@frpherqngn.ceb',
+  'crgr@dhvpxabqr.qri',
+  'dhvaa@flfgrznpprff.hf',
+  'eurn@ybtabqr.pbz',
+  'fnen@erzbgrnpprff.arg',
+  'gbz@pybhqfgngvba.pb',
+  'hefhyn@ulcreyvax.vb',
+  'ivp@frpheryvax.gi',
+  'jvyy@freiretngr.ceb',
+  'last@item.com',
+].map(makeLoginItem);

--- a/web/packages/shared/components/MenuLogin/MenuLogin.tsx
+++ b/web/packages/shared/components/MenuLogin/MenuLogin.tsx
@@ -141,6 +141,9 @@ export const MenuLogin = React.forwardRef<MenuLoginHandle, MenuLoginProps>(
           open={isOpen}
           onClose={onClose}
           getContentAnchorEl={null}
+          // The list of logins is updated asynchronously, so Popover inside Menu needs to account
+          // for LoginItemList changing in size.
+          updatePositionOnChildResize
         >
           <LoginItemList
             getLoginItemsAttempt={getLoginItemsAttempt}
@@ -210,6 +213,8 @@ function getLoginItemListContent(
     case 'processing':
       return (
         <Indicator
+          // Without this margin, <Indicator> would cause a scroll bar to pop up and hide repeatedly.
+          m={1}
           css={`
             align-self: center;
           `}

--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
@@ -85,6 +85,7 @@ export function ResourceCard({
   useLayoutEffect(() => {
     if (!labelsInnerContainer.current) return;
 
+    // TODO(ravicious): Use useResizeObserver instead.
     const observer = new ResizeObserver(entries => {
       const container = entries[0];
 

--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
@@ -85,7 +85,8 @@ export function ResourceCard({
   useLayoutEffect(() => {
     if (!labelsInnerContainer.current) return;
 
-    // TODO(ravicious): Use useResizeObserver instead.
+    // TODO(ravicious): Use useResizeObserver instead. Ensure that the callback passed to
+    // useResizeObserver has a stable identity.
     const observer = new ResizeObserver(entries => {
       const container = entries[0];
 

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -399,6 +399,7 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
     unifiedResourcePreferences.labelsViewMode === LabelsViewMode.EXPANDED;
 
   useLayoutEffect(() => {
+    // TODO(ravicious): Use useResizeObserver instead.
     const resizeObserver = new ResizeObserver(entries => {
       const container = entries[0];
 

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -399,7 +399,8 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
     unifiedResourcePreferences.labelsViewMode === LabelsViewMode.EXPANDED;
 
   useLayoutEffect(() => {
-    // TODO(ravicious): Use useResizeObserver instead.
+    // TODO(ravicious): Use useResizeObserver instead. Ensure that the callback passed to
+    // useResizeObserver has a stable identity.
     const resizeObserver = new ResizeObserver(entries => {
       const container = entries[0];
 

--- a/web/packages/teleport/src/Main/LayoutContext.tsx
+++ b/web/packages/teleport/src/Main/LayoutContext.tsx
@@ -39,6 +39,7 @@ export function LayoutContextProvider(props: PropsWithChildren<unknown>) {
   const containerRef = useRef<HTMLDivElement>();
 
   useEffect(() => {
+    // TODO(ravicious): Use useResizeObserver instead.
     const resizeObserver = new ResizeObserver(entries => {
       const container = entries[0];
       setCurrentWidth(container?.contentRect.width || 0);

--- a/web/packages/teleport/src/Main/LayoutContext.tsx
+++ b/web/packages/teleport/src/Main/LayoutContext.tsx
@@ -39,7 +39,8 @@ export function LayoutContextProvider(props: PropsWithChildren<unknown>) {
   const containerRef = useRef<HTMLDivElement>();
 
   useEffect(() => {
-    // TODO(ravicious): Use useResizeObserver instead.
+    // TODO(ravicious): Use useResizeObserver instead. Ensure that the callback passed to
+    // useResizeObserver has a stable identity.
     const resizeObserver = new ResizeObserver(entries => {
       const container = entries[0];
       setCurrentWidth(container?.contentRect.width || 0);


### PR DESCRIPTION
Depends on #49625.

After #46835, there are two problems with `MenuLogin`:

1. It doesn't show a scrollbar when the list gets very long.
2. The menu is incorrectly positioned on the first render. It gets into a correct position only on the second render.

<details>
<summary>Demo of incorrectly positioned menu</summary>

https://github.com/user-attachments/assets/c63e07db-b45d-4206-b39e-99c7332b29f9
</details>

I wasn't able to establish why there's no scrollbar. This is a similar issue to #48964, where we had to add extra styles to make a consumer of `Popover` behave correctly.

I do have an explanation for the incorrect position though. `MenuLogin` always fetches logins asynchronously, so on the first render there's just a spinner. That's when `Popover` sets its positioning styles. At that point in time, it sees that `MenuLogin` is only about 50px tall. The list gets updated soon after and now the content of `Popover` is a lot taller. But `Popover` updates its positioning styles only when it gets opened.

I don't know exactly why it used to work before. Before #46835, the code behind setting the positioning styles used component lifecycle methods. So my naive explanation (which I haven't confirmed) would be that `MenuLogin` would manage to update its list before `Popover` had a chance to set the positioning styles.

But how do we fix it now that we use hooks? Maybe there's a smarter way to do this, but after talking with Bartosz the only thing that came to our minds is to use `ResizeObserver` to update the positioning styles whenever the size of the child changes. This is now an opt-in behavior of `Popover`. I didn't want to risk introducing regressions in other parts of the app which don't necessarily need this behavior.