### PR TITLE
Conditionally render User edit/delete actions in the web UI

### DIFF
--- a/web/packages/teleport/src/Users/UserList/UserList.tsx
+++ b/web/packages/teleport/src/Users/UserList/UserList.tsx
@@ -20,7 +20,7 @@ import React from 'react';
 import { Cell, LabelCell } from 'design/DataTable';
 import { MenuButton, MenuItem } from 'shared/components/MenuAction';
 
-import { User, UserOrigin } from 'teleport/services/user';
+import { Access, User, UserOrigin } from 'teleport/services/user';
 import { ClientSearcheableTableWithQueryParamSupport } from 'teleport/components/ClientSearcheableTableWithQueryParamSupport';
 
 export default function UserList({
@@ -29,6 +29,7 @@ export default function UserList({
   onEdit,
   onDelete,
   onReset,
+  usersAcl,
 }: Props) {
   return (
     <ClientSearcheableTableWithQueryParamSupport
@@ -72,6 +73,7 @@ export default function UserList({
           altKey: 'options-btn',
           render: user => (
             <ActionCell
+              acl={usersAcl}
               user={user}
               onEdit={onEdit}
               onReset={onReset}
@@ -118,12 +120,21 @@ const ActionCell = ({
   onEdit,
   onReset,
   onDelete,
+  acl,
 }: {
   user: User;
   onEdit: (user: User) => void;
   onReset: (user: User) => void;
   onDelete: (user: User) => void;
+  acl: Access;
 }) => {
+  const canEdit = acl.edit;
+  const canDelete = acl.remove;
+
+  if (!(canEdit || canDelete)) {
+    return <Cell align="right" />;
+  }
+
   if (user.isBot || !user.isLocal) {
     return <Cell align="right" />;
   }
@@ -131,11 +142,15 @@ const ActionCell = ({
   return (
     <Cell align="right">
       <MenuButton>
-        <MenuItem onClick={() => onEdit(user)}>Edit...</MenuItem>
-        <MenuItem onClick={() => onReset(user)}>
-          Reset Authentication...
-        </MenuItem>
-        <MenuItem onClick={() => onDelete(user)}>Delete...</MenuItem>
+        {canEdit && <MenuItem onClick={() => onEdit(user)}>Edit...</MenuItem>}
+        {canEdit && (
+          <MenuItem onClick={() => onReset(user)}>
+            Reset Authentication...
+          </MenuItem>
+        )}
+        {canDelete && (
+          <MenuItem onClick={() => onDelete(user)}>Delete...</MenuItem>
+        )}
       </MenuButton>
     </Cell>
   );
@@ -147,4 +162,7 @@ type Props = {
   onEdit(user: User): void;
   onDelete(user: User): void;
   onReset(user: User): void;
+  // determines if the viewer is able to edit/delete users. This is used
+  // to conditionally render the edit/delete buttons in the ActionCell
+  usersAcl: Access;
 };

--- a/web/packages/teleport/src/Users/Users.story.tsx
+++ b/web/packages/teleport/src/Users/Users.story.tsx
@@ -149,4 +149,12 @@ const sample = {
   EmailPasswordReset: null,
   showMauInfo: false,
   onDismissUsersMauNotice: () => null,
+  canEditUsers: true,
+  usersAcl: {
+    read: true,
+    edit: false,
+    remove: true,
+    list: true,
+    create: true,
+  },
 };

--- a/web/packages/teleport/src/Users/Users.test.tsx
+++ b/web/packages/teleport/src/Users/Users.test.tsx
@@ -18,13 +18,22 @@
 
 import React from 'react';
 import { MemoryRouter } from 'react-router';
-import { render, screen, userEvent } from 'design/utils/testing';
+import { render, screen, userEvent, fireEvent } from 'design/utils/testing';
 
 import { ContextProvider } from 'teleport';
 import { createTeleportContext } from 'teleport/mocks/contexts';
+import { Access } from 'teleport/services/user';
 
 import { Users } from './Users';
 import { State } from './useUsers';
+
+const defaultAcl: Access = {
+  read: true,
+  edit: true,
+  remove: true,
+  list: true,
+  create: true,
+};
 
 describe('invite collaborators integration', () => {
   const ctx = createTeleportContext();
@@ -59,6 +68,7 @@ describe('invite collaborators integration', () => {
       EmailPasswordReset: null,
       showMauInfo: false,
       onDismissUsersMauNotice: () => null,
+      usersAcl: defaultAcl,
     };
   });
 
@@ -138,6 +148,7 @@ test('Users not equal to MAU Notice', async () => {
     EmailPasswordReset: null,
     showMauInfo: true,
     onDismissUsersMauNotice: jest.fn(),
+    usersAcl: defaultAcl,
   };
 
   const user = userEvent.setup();
@@ -192,6 +203,7 @@ describe('email password reset integration', () => {
       EmailPasswordReset: null,
       showMauInfo: false,
       onDismissUsersMauNotice: () => null,
+      usersAcl: defaultAcl,
     };
   });
 
@@ -230,5 +242,160 @@ describe('email password reset integration', () => {
     // dialog itself, and our mock above is trivial, but we can make sure it
     // renders.
     expect(screen.getByTestId('new-reset-ui')).toBeInTheDocument();
+  });
+});
+
+describe('permission handling', () => {
+  const ctx = createTeleportContext();
+
+  let props: State;
+  beforeEach(() => {
+    props = {
+      attempt: {
+        message: 'success',
+        isSuccess: true,
+        isProcessing: false,
+        isFailed: false,
+      },
+      users: [
+        {
+          name: 'tester',
+          roles: [],
+          isLocal: true,
+        },
+      ],
+      fetchRoles: () => Promise.resolve([]),
+      operation: {
+        type: 'reset',
+        user: { name: 'alice@example.com', roles: ['foo'] },
+      },
+
+      onStartCreate: () => undefined,
+      onStartDelete: () => undefined,
+      onStartEdit: () => undefined,
+      onStartReset: () => undefined,
+      onStartInviteCollaborators: () => undefined,
+      onClose: () => undefined,
+      onDelete: () => undefined,
+      onCreate: () => undefined,
+      onUpdate: () => undefined,
+      onReset: () => undefined,
+      onInviteCollaboratorsClose: () => undefined,
+      InviteCollaborators: null,
+      inviteCollaboratorsOpen: false,
+      onEmailPasswordResetClose: () => undefined,
+      EmailPasswordReset: null,
+      showMauInfo: false,
+      onDismissUsersMauNotice: () => null,
+      usersAcl: defaultAcl,
+    };
+  });
+
+  test('displays a disabled Create Users button if lacking permissions', async () => {
+    const testProps = {
+      ...props,
+      usersAcl: {
+        ...defaultAcl,
+        edit: false,
+      },
+    };
+    render(
+      <MemoryRouter>
+        <ContextProvider ctx={ctx}>
+          <Users {...testProps} />
+        </ContextProvider>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('create_new_users_button')).toBeDisabled();
+  });
+
+  test('edit and reset options not available in the menu', async () => {
+    const testProps = {
+      ...props,
+      usersAcl: {
+        ...defaultAcl,
+        edit: false,
+      },
+    };
+    render(
+      <MemoryRouter>
+        <ContextProvider ctx={ctx}>
+          <Users {...testProps} />
+        </ContextProvider>
+      </MemoryRouter>
+    );
+
+    const optionsButton = screen.getByRole('button', { name: /options/i });
+    fireEvent.click(optionsButton);
+    const menuItems = screen.queryAllByRole('menuitem');
+    expect(menuItems).toHaveLength(1);
+    expect(menuItems.some(item => item.textContent.includes('Delete'))).toBe(
+      true
+    );
+  });
+
+  test('all options are available in the menu', async () => {
+    const testProps = {
+      ...props,
+      usersAcl: {
+        read: true,
+        list: true,
+        edit: true,
+        create: true,
+        remove: true,
+      },
+    };
+    render(
+      <MemoryRouter>
+        <ContextProvider ctx={ctx}>
+          <Users {...testProps} />
+        </ContextProvider>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('tester')).toBeInTheDocument();
+    const optionsButton = screen.getByRole('button', { name: /options/i });
+    fireEvent.click(optionsButton);
+    const menuItems = screen.queryAllByRole('menuitem');
+    expect(menuItems).toHaveLength(3);
+    expect(menuItems.some(item => item.textContent.includes('Delete'))).toBe(
+      true
+    );
+    expect(
+      menuItems.some(item => item.textContent.includes('Reset Auth'))
+    ).toBe(true);
+    expect(menuItems.some(item => item.textContent.includes('Edit'))).toBe(
+      true
+    );
+  });
+
+  test('delete is not available in menu', async () => {
+    const testProps = {
+      ...props,
+      usersAcl: {
+        read: true,
+        list: true,
+        edit: true,
+        create: true,
+        remove: false,
+      },
+    };
+    render(
+      <MemoryRouter>
+        <ContextProvider ctx={ctx}>
+          <Users {...testProps} />
+        </ContextProvider>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('tester')).toBeInTheDocument();
+    const optionsButton = screen.getByRole('button', { name: /options/i });
+    fireEvent.click(optionsButton);
+    const menuItems = screen.queryAllByRole('menuitem');
+    expect(menuItems).toHaveLength(2);
+    expect(
+      menuItems.every(item => item.textContent.includes('Delete'))
+    ).not.toBe(true);
   });
 });

--- a/web/packages/teleport/src/Users/Users.tsx
+++ b/web/packages/teleport/src/Users/Users.tsx
@@ -17,7 +17,8 @@
  */
 
 import React from 'react';
-import { Indicator, Box, Alert, Button, Link } from 'design';
+import { Indicator, Text, Flex, Box, Alert, Button, Link } from 'design';
+import { HoverTooltip } from 'shared/components/ToolTip';
 
 import {
   FeatureBox,
@@ -46,6 +47,7 @@ export function Users(props: State) {
     onStartDelete,
     onStartEdit,
     onStartReset,
+    usersAcl,
     showMauInfo,
     onDismissUsersMauNotice,
     onClose,
@@ -60,22 +62,68 @@ export function Users(props: State) {
     EmailPasswordReset,
     onEmailPasswordResetClose,
   } = props;
+
+  const requiredPermissions = Object.entries(usersAcl)
+    .map(([key, value]) => {
+      if (key === 'edit') {
+        return { value, label: 'update' };
+      }
+      if (key === 'create') {
+        return { value, label: 'create' };
+      }
+    })
+    .filter(Boolean);
+
+  const isMissingPermissions = requiredPermissions.some(v => !v.value);
+
   return (
     <FeatureBox>
-      <FeatureHeader>
+      <FeatureHeader justifyContent="space-between">
         <FeatureHeaderTitle>Users</FeatureHeaderTitle>
         {attempt.isSuccess && (
           <>
             {!InviteCollaborators && (
-              <Button
-                intent="primary"
-                fill="border"
-                ml="auto"
-                width="240px"
-                onClick={onStartCreate}
+              <HoverTooltip
+                position="bottom"
+                tipContent={
+                  !isMissingPermissions ? (
+                    ''
+                  ) : (
+                    <Box>
+                      {/* TODO (avatus): extract this into a new "missing permissions" component. This will
+                          require us to change the internals of HoverTooltip to allow more arbitrary styling of the popover.
+                      */}
+                      <Text mb={1}>
+                        You do not have all of the required permissions.
+                      </Text>
+                      <Box mb={1}>
+                        <Text bold>You are missing permissions:</Text>
+                        <Flex gap={2}>
+                          {requiredPermissions
+                            .filter(perm => !perm.value)
+                            .map(perm => (
+                              <Text
+                                key={perm.label}
+                              >{`users.${perm.label}`}</Text>
+                            ))}
+                        </Flex>
+                      </Box>
+                    </Box>
+                  )
+                }
               >
-                Create New User
-              </Button>
+                <Button
+                  intent="primary"
+                  data-testid="create_new_users_button"
+                  fill="border"
+                  disabled={!usersAcl.edit}
+                  ml="auto"
+                  width="240px"
+                  onClick={onStartCreate}
+                >
+                  Create New User
+                </Button>
+              </HoverTooltip>
             )}
             {InviteCollaborators && (
               <Button
@@ -137,6 +185,7 @@ export function Users(props: State) {
       {attempt.isFailed && <Alert kind="danger" children={attempt.message} />}
       {attempt.isSuccess && (
         <UserList
+          usersAcl={usersAcl}
           users={users}
           onEdit={onStartEdit}
           onDelete={onStartDelete}

--- a/web/packages/teleport/src/Users/useUsers.ts
+++ b/web/packages/teleport/src/Users/useUsers.ts
@@ -132,10 +132,13 @@ export default function useUsers({
     cfg.isUsageBasedBilling &&
     !storageService.getUsersMauAcknowledged();
 
+  const usersAcl = ctx.storeUser.getUserAccess();
+
   return {
     attempt,
     users,
     fetchRoles,
+    usersAcl,
     operation,
     onStartCreate,
     onStartDelete,


### PR DESCRIPTION
This will only show the Edit and Reset options in the web UI if the viewing user has permissions to edit. This also hides the Create New User button because, although they can add a user, the action still fails as it tries to "reset" the user to get their first time login token. I thought about trying to decouple this but being able to create a user and not receive a link seems unproductive.

Delete is hidden if the user cannot delete, and the entire option box is removed if a users can't edit or delete

This does not affect the invite collaborators button/menu which emails the users their login info (as this is add only).
![Screenshot 2024-12-02 at 10 18 14 AM](https://github.com/user-attachments/assets/046be23b-fa6c-4f33-9910-e05a64356c0a)
![Screenshot 2024-12-02 at 10 18 17 AM](https://github.com/user-attachments/assets/4af17c90-8e9a-4b29-8f62-fc709068fa14)
![Screenshot 2024-12-02 at 10 36 22 AM](https://github.com/user-attachments/assets/e88e9fbb-5bb1-4b2f-b4fd-5fe5e03f0ec2)

Closes https://github.com/gravitational/teleport/issues/6885