### PR TITLE
[v16] [buddy] feat(charts): Give the possibility to add labels on more resources

### DIFF
--- a/docs/pages/includes/helm-reference/zz_generated.teleport-operator.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.teleport-operator.mdx
@@ -151,6 +151,26 @@ put on the `Pod` resources created by the chart.
 `annotations.serviceAccount` contains the Kubernetes annotations
 put on the `Deployment` resource created by the chart.
 
+## `annotations`
+
+### `labels.deployment`
+
+| Type | Default |
+|------|---------|
+| `object` | `{}` |
+
+`labels.deployment` contains the Kubernetes labels
+put on the `Deployment` resource created by the chart.
+
+### `labels.pod`
+
+| Type | Default |
+|------|---------|
+| `object` | `{}` |
+
+`labels.pod` contains the Kubernetes labels
+put on the `Pod` resources created by the chart.
+
 ## `serviceAccount`
 
 ### `serviceAccount.create`

--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -668,10 +668,10 @@ Kubernetes annotations which should be applied to the `Deployment` created by th
 `values.yaml` example:
 
   ```yaml
-    operator:
-      annotations:
-        deployment:
-          kubernetes.io/annotation: value
+  operator:
+    annotations:
+      deployment:
+        kubernetes.io/annotation: value
   ```
 
 ### `operator.annotations.pod`
@@ -687,10 +687,10 @@ Kubernetes annotations which should be applied to the `Pod` created by the chart
 `values.yaml` example:
 
   ```yaml
-    operator:
-      annotations:
-        pod:
-          kubernetes.io/annotation: value
+  operator:
+    annotations:
+      pod:
+        kubernetes.io/annotation: value
   ```
 
 ### `operator.annotations.serviceAccount`
@@ -706,10 +706,10 @@ Kubernetes annotations which should be applied to the `ServiceAccount` created b
 `values.yaml` example:
 
   ```yaml
-    operator:
-      annotations:
-        serviceAccount:
-          kubernetes.io/annotation: value
+  operator:
+    annotations:
+      serviceAccount:
+        kubernetes.io/annotation: value
   ```
 
 ### `operator.enabled`
@@ -728,7 +728,7 @@ If you are deploying multiple releases of the Helm chart in the same cluster you
 
   ```yaml
   operator:
-   enabled: true
+    enabled: true
   ```
 
 ### `operator.image`
@@ -762,10 +762,10 @@ Kubernetes labels which should be applied to the `Deployment` created by the cha
 `values.yaml` example:
 
   ```yaml
-    operator:
-      labels:
-        deployment:
-          label: value
+  operator:
+    labels:
+      deployment:
+        label: value
   ```
 
 ### `operator.labels.pod`
@@ -781,10 +781,10 @@ Kubernetes labels which should be applied to the `Pod` created by the chart.
 `values.yaml` example:
 
   ```yaml
-    operator:
-      labels:
-        pod:
-          label: value
+  operator:
+    labels:
+      pod:
+        label: value
   ```
 
 ### `operator.resources`

--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -655,6 +655,63 @@ the same Kubernetes cluster or installing the CRDs on your own you should not ha
 
 ## `operator`
 
+### `operator.annotations.deployment`
+
+| Type     | Default value |
+|----------|---------------|
+| `object` | `{}`          |
+
+[Kubernetes reference](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
+
+Kubernetes annotations which should be applied to the `Deployment` created by the chart.
+
+`values.yaml` example:
+
+  ```yaml
+    operator:
+      annotations:
+        deployment:
+          kubernetes.io/annotation: value
+  ```
+
+### `operator.annotations.pod`
+
+| Type     | Default value |
+|----------|---------------|
+| `object` | `{}`          |
+
+[Kubernetes reference](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
+
+Kubernetes annotations which should be applied to the `Pod` created by the chart.
+
+`values.yaml` example:
+
+  ```yaml
+    operator:
+      annotations:
+        pod:
+          kubernetes.io/annotation: value
+  ```
+
+### `operator.annotations.serviceAccount`
+
+| Type     | Default value |
+|----------|---------------|
+| `object` | `{}`          |
+
+[Kubernetes reference](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
+
+Kubernetes annotations which should be applied to the `ServiceAccount` created by the chart.
+
+`values.yaml` example:
+
+  ```yaml
+    operator:
+      annotations:
+        serviceAccount:
+          kubernetes.io/annotation: value
+  ```
+
 ### `operator.enabled`
 
 | Type   | Default value |
@@ -690,6 +747,44 @@ This setting requires [`operator.enabled`](#operatorenabled).
   ```yaml
   operator:
     image: my.docker.registry/teleport-operator-image-name
+  ```
+
+### `operator.labels.deployment`
+
+| Type     | Default value |
+|----------|---------------|
+| `object` | `{}`          |
+
+[Kubernetes reference](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
+
+Kubernetes labels which should be applied to the `Deployment` created by the chart.
+
+`values.yaml` example:
+
+  ```yaml
+    operator:
+      labels:
+        deployment:
+          label: value
+  ```
+
+### `operator.labels.pod`
+
+| Type     | Default value |
+|----------|---------------|
+| `object` | `{}`          |
+
+[Kubernetes reference](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
+
+Kubernetes labels which should be applied to the `Pod` created by the chart.
+
+`values.yaml` example:
+
+  ```yaml
+    operator:
+      labels:
+        pod:
+          label: value
   ```
 
 ### `operator.resources`
@@ -1788,6 +1883,14 @@ is true.
 | `object` | `{}`          |
 
 `extraLabels.job` are labels to set on the Job run by the Helm hook.
+
+### `extraLabels.jobPod`
+
+| Type     | Default value |
+|----------|---------------|
+| `object` | `{}`          |
+
+`extraLabels.jobPod` are labels to set on the Pods created by the Job run by the Helm hook.
 
 ### `extraLabels.persistentVolumeClaim`
 

--- a/examples/chart/teleport-cluster/charts/teleport-operator/.lint/labels.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/.lint/labels.yaml
@@ -1,0 +1,7 @@
+labels:
+  deployment:
+    kubernetes.io/deployment: "test-label"
+    kubernetes.io/deployment-different: 3
+  pod:
+    kubernetes.io/pod: "test-label"
+    kubernetes.io/pod-different: 4

--- a/examples/chart/teleport-cluster/charts/teleport-operator/.lint/labels.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/.lint/labels.yaml
@@ -5,3 +5,6 @@ labels:
   pod:
     kubernetes.io/pod: "test-label"
     kubernetes.io/pod-different: 4
+teleportAddress: "example.teleport.sh:443"
+token: "my-operator-bot"
+teleportClusterName: "example.teleport.sh"

--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/deployment.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     {{- if .Values.labels.deployment }}
     {{- toYaml .Values.labels.deployment | nindent 4 }}
     {{- end }}
+  {{- if .Values.annotations.deployment }}
   annotations: {{- toYaml .Values.annotations.deployment | nindent 4 }}
   {{- end }}
 spec:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/deployment.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/deployment.yaml
@@ -4,8 +4,11 @@ kind: Deployment
 metadata:
   name: {{ include "teleport-cluster.operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "teleport-cluster.operator.labels" . | nindent 4 }}
-  {{- if .Values.annotations.deployment }}
+  labels:
+    {{- include "teleport-cluster.operator.labels" . | nindent 4 }}
+    {{- if .Values.labels.deployment }}
+    {{- toYaml .Values.labels.deployment | nindent 4 }}
+    {{- end }}
   annotations: {{- toYaml .Values.annotations.deployment | nindent 4 }}
   {{- end }}
 spec:
@@ -22,7 +25,11 @@ spec:
   {{- if .Values.annotations.pod }}
       annotations: {{- toYaml .Values.annotations.pod | nindent 8 }}
   {{- end }}
-      labels: {{- include "teleport-cluster.operator.labels" . | nindent 8 }}
+      labels:
+      {{- include "teleport-cluster.operator.labels" . | nindent 8 }}
+      {{- if .Values.labels.pod }}
+      {{- toYaml .Values.labels.pod | nindent 8 }}
+      {{- end }}
     spec:
   {{- if .Values.nodeSelector }}
       nodeSelector: {{- toYaml .Values.nodeSelector | nindent 8 }}

--- a/examples/chart/teleport-cluster/charts/teleport-operator/tests/deployment_test.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/tests/deployment_test.yaml
@@ -61,7 +61,7 @@ tests:
 
   - it: sets labels when specified
     values:
-      - ../.lint/deployment.yaml
+      - ../.lint/labels.yaml
     asserts:
       # Pod labels
       - equal:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/tests/deployment_test.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/tests/deployment_test.yaml
@@ -59,6 +59,25 @@ tests:
           path: metadata.annotations.kubernetes\.io/deployment-different
           value: 3
 
+  - it: sets labels when specified
+    values:
+      - ../.lint/deployment.yaml
+    asserts:
+      # Pod labels
+      - equal:
+          path: spec.template.metadata.labels.kubernetes\.io/pod
+          value: test-label
+      - equal:
+          path: spec.template.metadata.labels.kubernetes\.io/pod-different
+          value: 4
+      # Deployment labels
+      - equal:
+          path: metadata.labels.kubernetes\.io/deployment
+          value: test-label
+      - equal:
+          path: metadata.labels.kubernetes\.io/deployment-different
+          value: 3
+
   - it: should mount tls.existingCASecretName and set environment when set in values
     values:
       - ../.lint/existing-tls-ca.yaml

--- a/examples/chart/teleport-cluster/charts/teleport-operator/values.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/values.yaml
@@ -89,6 +89,15 @@ annotations:
   # put on the `Deployment` resource created by the chart.
   serviceAccount: {}
 
+# annotations --
+labels:
+  # labels.deployment(object) -- contains the Kubernetes labels
+  # put on the `Deployment` resource created by the chart.
+  deployment: {}
+  # labels.pod(object) -- contains the Kubernetes labels
+  # put on the `Pod` resources created by the chart.
+  pod: {}
+
 # serviceAccount --
 serviceAccount:
   # serviceAccount.create(bool) -- controls if the chart should create the Kubernetes

--- a/examples/chart/teleport-cluster/templates/auth/predeploy_job.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/predeploy_job.yaml
@@ -17,6 +17,12 @@ metadata:
 spec:
   backoffLimit: 1
   template:
+    metadata:
+      labels:
+        {{- include "teleport-cluster.auth.labels" . | nindent 8 }}
+        {{- if $auth.extraLabels.jobPod }}
+        {{- toYaml $auth.extraLabels.jobPod | nindent 8 }}
+        {{- end }}
     spec:
 {{- if $auth.affinity }}
       affinity: {{- toYaml $auth.affinity | nindent 8 }}

--- a/examples/chart/teleport-cluster/templates/proxy/predeploy_job.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/predeploy_job.yaml
@@ -17,6 +17,12 @@ metadata:
 spec:
   backoffLimit: 1
   template:
+    metadata:
+      labels:
+        {{- include "teleport-cluster.proxy.labels" . | nindent 8 }}
+        {{- if $proxy.extraLabels.jobPod }}
+        {{- toYaml $proxy.extraLabels.jobPod | nindent 8 }}
+        {{- end }}
     spec:
 {{- if $proxy.affinity }}
       affinity: {{- toYaml $proxy.affinity | nindent 8 }}

--- a/examples/chart/teleport-cluster/tests/predeploy_test.yaml
+++ b/examples/chart/teleport-cluster/tests/predeploy_test.yaml
@@ -133,6 +133,26 @@ tests:
           path: metadata.labels.baz
           value: overridden
 
+  - it: should set extraLabels.jobPod on auth predeploy job when set in values
+    template: auth/predeploy_job.yaml
+    set:
+      clusterName: helm-lint
+      extraLabels:
+        jobPod:
+          foo: bar
+          baz: override-me
+      auth:
+        extraLabels:
+          jobPod:
+            baz: overridden
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.foo
+          value: bar
+      - equal:
+          path: spec.template.metadata.labels.baz
+          value: overridden
+
   - it: should set extraLabels on auth predeploy config when set in values
     template: auth/predeploy_config.yaml
     set:
@@ -152,6 +172,7 @@ tests:
       - equal:
           path: metadata.labels.baz
           value: overridden
+
   - it: should set extraLabels on proxy predeploy job when set in values
     template: proxy/predeploy_job.yaml
     set:
@@ -170,6 +191,26 @@ tests:
           value: bar
       - equal:
           path: metadata.labels.baz
+          value: overridden
+
+  - it: should set extraLabels.jobPod on proxy predeploy job when set in values
+    template: proxy/predeploy_job.yaml
+    set:
+      clusterName: helm-lint
+      extraLabels:
+        jobPod:
+          foo: bar
+          baz: override-me
+      auth:
+        extraLabels:
+          jobPod:
+            baz: overridden
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.foo
+          value: bar
+      - equal:
+          path: spec.template.metadata.labels.baz
           value: overridden
 
   - it: should set extraLabels on proxy predeploy config when set in values

--- a/examples/chart/teleport-cluster/tests/predeploy_test.yaml
+++ b/examples/chart/teleport-cluster/tests/predeploy_test.yaml
@@ -201,7 +201,7 @@ tests:
         jobPod:
           foo: bar
           baz: override-me
-      auth:
+      proxy:
         extraLabels:
           jobPod:
             baz: overridden

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -654,6 +654,9 @@ extraLabels:
   ingress: {}
   # extraLabels.job(object) -- are labels to set on the Job run by the Helm hook.
   job: {}
+  # extraLabels.jobPod(object) -- are labels to set on the Pods created by the
+  # Job run by the Helm hook.
+  jobPod: {}
   # extraLabels.persistentVolumeClaim(object) -- are labels to set on the PersistentVolumeClaim.
   persistentVolumeClaim: {}
   # extraLabels.pod(object) -- are labels to set on the Pods created by the


### PR DESCRIPTION
Backport #49624 to branch/v16

changelog: Add ability to configure resource labels in `teleport-cluster`'s operator sub-chart.
