### PR TITLE
Fix inventory controller tests after adding additional ping

### DIFF
--- a/lib/inventory/controller.go
+++ b/lib/inventory/controller.go
@@ -104,7 +104,7 @@ const (
 	instanceHeartbeatOk  testEvent = "instance-heartbeat-ok"
 	instanceHeartbeatErr testEvent = "instance-heartbeat-err"
 
-	timeReconciliationOk testEvent = "time-reconciliation-ok"
+	pongOk testEvent = "pong-ok"
 
 	instanceCompareFailed testEvent = "instance-compare-failed"
 
@@ -517,7 +517,6 @@ func (c *Controller) handleControlStream(handle *upstreamHandle) {
 				handle.CloseWithError(err)
 				return
 			}
-			c.testEvent(timeReconciliationOk)
 
 		case now := <-dbKeepAliveDelay.Elapsed():
 			dbKeepAliveDelay.Advance(now)
@@ -631,6 +630,7 @@ func (c *Controller) handlePong(handle *upstreamHandle, msg proto.UpstreamInvent
 
 	pending.rspC <- pong
 	delete(handle.pings, msg.ID)
+	c.testEvent(pongOk)
 }
 
 func (c *Controller) handlePingRequest(handle *upstreamHandle, req pingRequest) error {


### PR DESCRIPTION
Fix for the inventory controller tests identified by flaky tests detector https://github.com/gravitational/teleport.e/actions/runs/12116931575/job/33778324175

After adding additional ping for time reconciliation, many tests which don't have downstream consumer, or consumers expecting only one ping request start failing

Tested with
```bash
inventory % go test . -v -count 500 -race -timeout 0 -failfast
...
ok  	github.com/gravitational/teleport/lib/inventory	1534.162s
```

Related: https://github.com/gravitational/teleport/pull/44489