### PR TITLE
fix: remove support for configuration of insecure TLS cipher suites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 18.0.0 (xx/xx/xx)
+
+### Breaking changes
+
+#### TLS Cipher Suites
+
+TLS cipher suites with known security issues can no longer be manually
+configured in the Teleport YAML configuration file.
+If you do not explicitly configure any of the listed TLS cipher suites, you are
+not affected by this change.
+Teleport 18 removes support for:
+- `tls-rsa-with-aes-128-cbc-sha`
+- `tls-rsa-with-aes-256-cbc-sha`
+- `tls-rsa-with-aes-128-cbc-sha256`
+- `tls-rsa-with-aes-128-gcm-sha256`
+- `tls-rsa-with-aes-256-gcm-sha384`
+- `tls-ecdhe-ecdsa-with-aes-128-cbc-sha256`
+- `tls-ecdhe-rsa-with-aes-128-cbc-sha256`
+
 ## 16.0.0 (xx/xx/xx)
 
 ### Breaking changes
@@ -37,10 +56,10 @@ more details.
 
 #### Default keyboard shortcuts in Teleport Connect have been changed
 
-On Windows and Linux, some of the default shortcuts conflicted with the default bash or nano shortcuts 
+On Windows and Linux, some of the default shortcuts conflicted with the default bash or nano shortcuts
 (e.g. Ctrl + E, Ctrl + K).
 On those platforms, the default shortcuts have been changed to a combination of Ctrl + Shift + *.
-We also updated the shortcut to open a new terminal on macOS to Control + Shift + \`.  
+We also updated the shortcut to open a new terminal on macOS to Control + Shift + \`.
 See [configuration](docs/pages/connect-your-client/teleport-connect.mdx#configuration)
 for the current list of shortcuts.
 
@@ -152,8 +171,8 @@ or use PAM.
 
 #### Remove restricted sessions for SSH
 
-The restricted session feature for SSH has been deprecated since Teleport 14 and 
-has been removed in Teleport 15. We recommend implementing network restrictions 
+The restricted session feature for SSH has been deprecated since Teleport 14 and
+has been removed in Teleport 15. We recommend implementing network restrictions
 outside of Teleport (iptables, security groups, etc).
 
 #### Packages no longer published to legacy Debian and RPM repos
@@ -200,7 +219,7 @@ throughout the remainder of these releases' lifecycle.
 
 ##### Helm cluster chart FIPS mode changes
 
-The teleport-cluster chart no longer uses versionOverride and extraArgs to set FIPS mode. 
+The teleport-cluster chart no longer uses versionOverride and extraArgs to set FIPS mode.
 
 Instead, you should use the following values file configuration:
 ```
@@ -277,7 +296,7 @@ used with the legacy AMIs has been removed.
 Due to the new separate operator deployment, the operator is deployed by a subchart.
 This causes the following breaking changes:
 - `installCRDs` has been replaced by `operator.installCRDs`
-- `teleportVersionOverride` does not set the operator version anymore, you must 
+- `teleportVersionOverride` does not set the operator version anymore, you must
   use `operator.teleportVersionOverride` to override the operator version.
 
 Note: version overrides are dangerous and not recommended. Each chart version
@@ -290,7 +309,7 @@ The chart configures this for you since v12, unless you disabled `rbac` creation
 
 ##### Helm cluster chart FIPS mode changes
 
-The teleport-cluster chart no longer uses versionOverride and extraArgs to set FIPS mode. 
+The teleport-cluster chart no longer uses versionOverride and extraArgs to set FIPS mode.
 
 Instead, you should use the following values file configuration:
 
@@ -340,7 +359,7 @@ Teleport 14 brings the following new major features and improvements:
 - Support for TLS routing in Terraform deployment examples
 - Discord and ServiceNow hosted plugins
 - Limited passwordless access for local Windows users in Teleport Community
-  Edition 
+  Edition
 - Machine ID: Kubernetes Secret destination
 
 In addition, this release includes several changes that affect existing
@@ -413,7 +432,7 @@ audit logging support.
 
 See documentation on how to configure it in the [Oracle guide](docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/oracle-self-hosted.mdx).
 
-#### Limited passwordless access for local Windows users in Teleport Community Edition 
+#### Limited passwordless access for local Windows users in Teleport Community Edition
 
 In Teleport 14, access to Windows desktops with local Windows users has been
 extended to Community Edition. Teleport will permit users to register and
@@ -3291,7 +3310,7 @@ auth_service:
     #     EXPERIMENTAL *-sync modes: proxy and node send logs directly to S3 or other
     #     storage without storing the records on disk at all. This mode will kill a
     #     connection if network connectivity is lost.
-    #     NOTE: These experimental modes require all Teleport Auth Service instances, 
+    #     NOTE: These experimental modes require all Teleport Auth Service instances,
     #     Proxy Service instances, and nodes to be running Teleport 4.4.
     #
     #     "node-sync" : sessions recording will be streamed from node -> auth -> storage

--- a/lib/utils/tls.go
+++ b/lib/utils/tls.go
@@ -148,17 +148,10 @@ type TLSConn interface {
 // cipherSuiteMapping is the mapping between Teleport formatted cipher
 // suites strings and uint16 IDs.
 var cipherSuiteMapping = map[string]uint16{
-	"tls-rsa-with-aes-128-cbc-sha":            tls.TLS_RSA_WITH_AES_128_CBC_SHA,
-	"tls-rsa-with-aes-256-cbc-sha":            tls.TLS_RSA_WITH_AES_256_CBC_SHA,
-	"tls-rsa-with-aes-128-cbc-sha256":         tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
-	"tls-rsa-with-aes-128-gcm-sha256":         tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
-	"tls-rsa-with-aes-256-gcm-sha384":         tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
 	"tls-ecdhe-ecdsa-with-aes-128-cbc-sha":    tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
 	"tls-ecdhe-ecdsa-with-aes-256-cbc-sha":    tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
 	"tls-ecdhe-rsa-with-aes-128-cbc-sha":      tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
 	"tls-ecdhe-rsa-with-aes-256-cbc-sha":      tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-	"tls-ecdhe-ecdsa-with-aes-128-cbc-sha256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
-	"tls-ecdhe-rsa-with-aes-128-cbc-sha256":   tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
 	"tls-ecdhe-rsa-with-aes-128-gcm-sha256":   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 	"tls-ecdhe-ecdsa-with-aes-128-gcm-sha256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 	"tls-ecdhe-rsa-with-aes-256-gcm-sha384":   tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,

--- a/lib/utils/tls_test.go
+++ b/lib/utils/tls_test.go
@@ -1,0 +1,39 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package utils
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestCipherSuites(t *testing.T) {
+	for _, defaultSuiteID := range DefaultCipherSuites() {
+		for _, insecureSuite := range tls.InsecureCipherSuites() {
+			if defaultSuiteID == insecureSuite.ID {
+				t.Errorf("Default cipher suite %s is considered insecure by crypto/tls", insecureSuite.Name)
+			}
+		}
+	}
+	for teleportSuiteName, teleportSuiteID := range cipherSuiteMapping {
+		for _, insecureSuite := range tls.InsecureCipherSuites() {
+			if teleportSuiteID == insecureSuite.ID {
+				t.Errorf("Configurable cipher suite %s is considered insecure by crypto/tls", teleportSuiteName)
+			}
+		}
+	}
+}


### PR DESCRIPTION
These suites are considered insecure by crypto/tls. We don't ever use them by default, but we currently allow Teleport admins to manually configure them in their configuration file. I propose we remove support for even manually configuring these. Since this is a breaking change I will not backport to any release branches.

Fixes https://github.com/gravitational/teleport/security/code-scanning/1004

changelog: Removed support for manual configuration of insecure TLS cipher suites.