### PR TITLE
[v17] Fix TestDynamicIdentityFileCreds for Go 1.23

### DIFF
--- a/api/client/credentials_test.go
+++ b/api/client/credentials_test.go
@@ -471,6 +471,7 @@ func TestDynamicIdentityFileCreds(t *testing.T) {
 	require.NoError(t, err)
 	wantTLSCert, err := tls.X509KeyPair(tlsCert, keyPEM)
 	require.NoError(t, err)
+	wantTLSCert.Leaf = nil
 	require.Equal(t, wantTLSCert, *gotTLSCert)
 
 	expiry, ok := cred.Expiry()
@@ -529,6 +530,7 @@ func TestDynamicIdentityFileCreds(t *testing.T) {
 	require.NoError(t, err)
 	wantTLSCert, err = tls.X509KeyPair(secondTLSCertPem, keyPEM)
 	require.NoError(t, err)
+	wantTLSCert.Leaf = nil
 	require.Equal(t, wantTLSCert, *gotTLSCert)
 
 	expiry, ok = cred.Expiry()


### PR DESCRIPTION
Backport #49597 to branch/v17.