### PR TITLE
WebUI MFA methods refactor 

### DIFF
--- a/web/packages/teleport/src/Account/Account.test.tsx
+++ b/web/packages/teleport/src/Account/Account.test.tsx
@@ -243,7 +243,7 @@ test('adding an MFA device', async () => {
   const user = userEvent.setup();
   const ctx = createTeleportContext();
   jest.spyOn(ctx.mfaService, 'fetchDevices').mockResolvedValue([testPasskey]);
-  jest.spyOn(auth, 'getChallenge').mockResolvedValue({
+  jest.spyOn(auth, 'getMfaChallenge').mockResolvedValue({
     webauthnPublicKey: null,
     totpChallenge: true,
     ssoChallenge: null,
@@ -327,7 +327,7 @@ test('removing an MFA method', async () => {
   const user = userEvent.setup();
   const ctx = createTeleportContext();
   jest.spyOn(ctx.mfaService, 'fetchDevices').mockResolvedValue([testMfaMethod]);
-  jest.spyOn(auth, 'getChallenge').mockResolvedValue({
+  jest.spyOn(auth, 'getMfaChallenge').mockResolvedValue({
     webauthnPublicKey: null,
     totpChallenge: false,
     ssoChallenge: null,

--- a/web/packages/teleport/src/Account/ChangePasswordWizard/ChangePasswordWizard.story.tsx
+++ b/web/packages/teleport/src/Account/ChangePasswordWizard/ChangePasswordWizard.story.tsx
@@ -23,10 +23,11 @@ import Dialog from 'design/Dialog';
 import { createTeleportContext } from 'teleport/mocks/contexts';
 import { ContextProvider } from 'teleport';
 
-import { MfaDevice } from 'teleport/services/mfa';
+import { MfaDevice, WebauthnAssertionResponse } from 'teleport/services/mfa';
 
 import {
   ChangePasswordStep,
+  ChangePasswordWizardStepProps,
   ReauthenticateStep,
   createReauthOptions,
 } from './ChangePasswordWizard';
@@ -107,12 +108,16 @@ const stepProps = {
   flowLength: 2,
   refCallback: () => {},
 
-  // Other props
-  reauthOptions: defaultReauthOptions,
-  reauthMethod: defaultReauthOptions[0].value,
-  credential: { id: '', type: '' },
-  onReauthMethodChange() {},
-  onAuthenticated() {},
+  // Shared props
+  reauthMethod: 'mfaDevice',
   onClose() {},
   onSuccess() {},
-};
+
+  // ReauthenticateStepProps
+  reauthOptions: defaultReauthOptions,
+  onReauthMethodChange() {},
+  onWebauthnResponse() {},
+
+  // ChangePasswordStepProps
+  webauthnResponse: {} as WebauthnAssertionResponse,
+} satisfies ChangePasswordWizardStepProps;

--- a/web/packages/teleport/src/Account/ChangePasswordWizard/ChangePasswordWizard.test.tsx
+++ b/web/packages/teleport/src/Account/ChangePasswordWizard/ChangePasswordWizard.test.tsx
@@ -24,13 +24,14 @@ import { userEvent, UserEvent } from '@testing-library/user-event';
 
 import auth, { MfaChallengeScope } from 'teleport/services/auth/auth';
 
+import { MfaChallengeResponse } from 'teleport/services/mfa';
+
 import {
   ChangePasswordWizardProps,
   createReauthOptions,
 } from './ChangePasswordWizard';
 
 import { ChangePasswordWizard } from '.';
-import { MfaChallengeResponse } from 'teleport/services/mfa';
 
 const dummyChallengeResponse: MfaChallengeResponse = {
   webauthn_response: {
@@ -86,7 +87,7 @@ beforeEach(() => {
   onSuccess = jest.fn();
 
   jest
-    .spyOn(auth, 'getWebAuthnChallengeResponse')
+    .spyOn(auth, 'getMfaChallengeResponse')
     .mockResolvedValueOnce(dummyChallengeResponse);
   jest.spyOn(auth, 'changePassword').mockResolvedValueOnce(undefined);
 });
@@ -102,7 +103,7 @@ describe('with passwordless reauthentication', () => {
     );
     await user.click(reauthenticateStep.getByText('Passkey'));
     await user.click(reauthenticateStep.getByText('Next'));
-    expect(auth.getChallenge).toHaveBeenCalledWith({
+    expect(auth.getMfaChallenge).toHaveBeenCalledWith({
       scope: MfaChallengeScope.CHANGE_PASSWORD,
       userVerificationRequirement: 'required',
     });
@@ -193,7 +194,7 @@ describe('with WebAuthn MFA reauthentication', () => {
     );
     await user.click(reauthenticateStep.getByText('MFA Device'));
     await user.click(reauthenticateStep.getByText('Next'));
-    expect(auth.getChallenge).toHaveBeenCalledWith({
+    expect(auth.getMfaChallengeResponse).toHaveBeenCalledWith({
       scope: MfaChallengeScope.CHANGE_PASSWORD,
       userVerificationRequirement: 'discouraged',
     });
@@ -295,7 +296,7 @@ describe('with OTP MFA reauthentication', () => {
     );
     await user.click(reauthenticateStep.getByText('Authenticator App'));
     await user.click(reauthenticateStep.getByText('Next'));
-    expect(auth.getChallenge).not.toHaveBeenCalled();
+    expect(auth.getMfaChallengeResponse).not.toHaveBeenCalled();
   }
 
   it('changes password', async () => {
@@ -419,7 +420,7 @@ describe('without reauthentication', () => {
       'new-pass1234'
     );
     await user.click(changePasswordStep.getByText('Save Changes'));
-    expect(auth.getChallenge).not.toHaveBeenCalled();
+    expect(auth.getMfaChallengeResponse).not.toHaveBeenCalled();
     expect(auth.changePassword).toHaveBeenCalledWith({
       oldPassword: 'current-pass',
       newPassword: 'new-pass1234',

--- a/web/packages/teleport/src/Account/ChangePasswordWizard/ChangePasswordWizard.test.tsx
+++ b/web/packages/teleport/src/Account/ChangePasswordWizard/ChangePasswordWizard.test.tsx
@@ -86,6 +86,7 @@ beforeEach(() => {
   user = userEvent.setup();
   onSuccess = jest.fn();
 
+  jest.spyOn(auth, 'getMfaChallenge').mockResolvedValueOnce(undefined);
   jest
     .spyOn(auth, 'getMfaChallengeResponse')
     .mockResolvedValueOnce(dummyChallengeResponse);
@@ -107,6 +108,7 @@ describe('with passwordless reauthentication', () => {
       scope: MfaChallengeScope.CHANGE_PASSWORD,
       userVerificationRequirement: 'required',
     });
+    expect(auth.getMfaChallengeResponse).toHaveBeenCalled();
   }
 
   it('changes password', async () => {
@@ -127,7 +129,7 @@ describe('with passwordless reauthentication', () => {
       oldPassword: '',
       newPassword: 'new-pass1234',
       secondFactorToken: '',
-      credential: dummyChallengeResponse.webauthn_response,
+      webauthnResponse: dummyChallengeResponse.webauthn_response,
     });
     expect(onSuccess).toHaveBeenCalled();
   });
@@ -194,7 +196,7 @@ describe('with WebAuthn MFA reauthentication', () => {
     );
     await user.click(reauthenticateStep.getByText('MFA Device'));
     await user.click(reauthenticateStep.getByText('Next'));
-    expect(auth.getMfaChallengeResponse).toHaveBeenCalledWith({
+    expect(auth.getMfaChallenge).toHaveBeenCalledWith({
       scope: MfaChallengeScope.CHANGE_PASSWORD,
       userVerificationRequirement: 'discouraged',
     });
@@ -222,7 +224,7 @@ describe('with WebAuthn MFA reauthentication', () => {
       oldPassword: 'current-pass',
       newPassword: 'new-pass1234',
       secondFactorToken: '',
-      credential: dummyChallengeResponse.webauthn_response,
+      webauthnResponse: dummyChallengeResponse.webauthn_response,
     });
     expect(onSuccess).toHaveBeenCalled();
   });
@@ -296,7 +298,7 @@ describe('with OTP MFA reauthentication', () => {
     );
     await user.click(reauthenticateStep.getByText('Authenticator App'));
     await user.click(reauthenticateStep.getByText('Next'));
-    expect(auth.getMfaChallengeResponse).not.toHaveBeenCalled();
+    expect(auth.getMfaChallenge).not.toHaveBeenCalled();
   }
 
   it('changes password', async () => {
@@ -420,11 +422,11 @@ describe('without reauthentication', () => {
       'new-pass1234'
     );
     await user.click(changePasswordStep.getByText('Save Changes'));
-    expect(auth.getMfaChallengeResponse).not.toHaveBeenCalled();
+    expect(auth.getMfaChallenge).not.toHaveBeenCalled();
     expect(auth.changePassword).toHaveBeenCalledWith({
       oldPassword: 'current-pass',
       newPassword: 'new-pass1234',
-      credential: undefined,
+      webauthnResponse: undefined,
       secondFactorToken: '',
     });
     expect(onSuccess).toHaveBeenCalled();

--- a/web/packages/teleport/src/Account/ChangePasswordWizard/ChangePasswordWizard.tsx
+++ b/web/packages/teleport/src/Account/ChangePasswordWizard/ChangePasswordWizard.tsx
@@ -172,13 +172,16 @@ export function ReauthenticateStep({
   const [reauthenticateAttempt, reauthenticate] = useAsync(
     async (m: ReauthenticationMethod) => {
       if (m === 'passwordless' || m === 'mfaDevice') {
-        const res = await auth.getChallenge({
+        const challenge = await auth.getMfaChallenge({
           scope: MfaChallengeScope.CHANGE_PASSWORD,
           userVerificationRequirement:
             m === 'passwordless' ? 'required' : 'discouraged',
         });
-        const challengeResponse = await auth.getWebAuthnChallengeResponse(res);
-        onAuthenticated(challengeResponse.webauthn_response);
+
+        const response = await auth.getMfaChallengeResponse(challenge);
+
+        // TODO(Joerger): handle non-webauthn response.
+        onAuthenticated(response.webauthn_response);
       }
       next();
     }

--- a/web/packages/teleport/src/Account/ChangePasswordWizard/ChangePasswordWizard.tsx
+++ b/web/packages/teleport/src/Account/ChangePasswordWizard/ChangePasswordWizard.tsx
@@ -38,7 +38,7 @@ import Box from 'design/Box';
 
 import { ChangePasswordReq } from 'teleport/services/auth';
 import auth, { MfaChallengeScope } from 'teleport/services/auth/auth';
-import { MfaDevice } from 'teleport/services/mfa';
+import { MfaDevice, WebauthnAssertionResponse } from 'teleport/services/mfa';
 
 export interface ChangePasswordWizardProps {
   /** MFA type setting, as configured in the cluster's configuration. */
@@ -66,7 +66,8 @@ export function ChangePasswordWizard({
   const [reauthMethod, setReauthMethod] = useState<ReauthenticationMethod>(
     reauthOptions[0]?.value
   );
-  const [credential, setCredential] = useState<Credential | undefined>();
+  const [webauthnResponse, setWebauthnResponse] =
+    useState<WebauthnAssertionResponse>();
   const reauthRequired = reauthOptions.length > 0;
 
   return (
@@ -84,9 +85,9 @@ export function ChangePasswordWizard({
         // Step properties
         reauthOptions={reauthOptions}
         reauthMethod={reauthMethod}
-        credential={credential}
         onReauthMethodChange={setReauthMethod}
-        onAuthenticated={setCredential}
+        webauthnResponse={webauthnResponse}
+        onWebauthnResponse={setWebauthnResponse}
         onClose={onClose}
         onSuccess={onSuccess}
       />
@@ -154,7 +155,7 @@ interface ReauthenticateStepProps {
   reauthOptions: ReauthenticationOption[];
   reauthMethod: ReauthenticationMethod;
   onReauthMethodChange(method: ReauthenticationMethod): void;
-  onAuthenticated(res: Credential): void;
+  onWebauthnResponse(res: WebauthnAssertionResponse): void;
   onClose(): void;
 }
 
@@ -166,7 +167,7 @@ export function ReauthenticateStep({
   reauthOptions,
   reauthMethod,
   onReauthMethodChange,
-  onAuthenticated,
+  onWebauthnResponse,
   onClose,
 }: ChangePasswordWizardStepProps) {
   const [reauthenticateAttempt, reauthenticate] = useAsync(
@@ -184,7 +185,7 @@ export function ReauthenticateStep({
         );
 
         // TODO(Joerger): handle non-webauthn response.
-        onAuthenticated(response.webauthn_response);
+        onWebauthnResponse(response.webauthn_response);
       }
       next();
     }
@@ -232,7 +233,7 @@ export function ReauthenticateStep({
 }
 
 interface ChangePasswordStepProps {
-  credential: Credential;
+  webauthnResponse: WebauthnAssertionResponse;
   reauthMethod: ReauthenticationMethod;
   onClose(): void;
   onSuccess(): void;
@@ -243,7 +244,7 @@ export function ChangePasswordStep({
   prev,
   stepIndex,
   flowLength,
-  credential,
+  webauthnResponse,
   reauthMethod,
   onClose,
   onSuccess,
@@ -282,7 +283,7 @@ export function ChangePasswordStep({
       oldPassword,
       newPassword,
       secondFactorToken: authCode,
-      credential,
+      webauthnResponse,
     });
   }
 

--- a/web/packages/teleport/src/Account/ChangePasswordWizard/ChangePasswordWizard.tsx
+++ b/web/packages/teleport/src/Account/ChangePasswordWizard/ChangePasswordWizard.tsx
@@ -172,12 +172,13 @@ export function ReauthenticateStep({
   const [reauthenticateAttempt, reauthenticate] = useAsync(
     async (m: ReauthenticationMethod) => {
       if (m === 'passwordless' || m === 'mfaDevice') {
-        const res = await auth.fetchWebAuthnChallenge({
+        const res = await auth.getChallenge({
           scope: MfaChallengeScope.CHANGE_PASSWORD,
           userVerificationRequirement:
             m === 'passwordless' ? 'required' : 'discouraged',
         });
-        onAuthenticated(res);
+        const challengeResponse = await auth.getWebAuthnChallengeResponse(res);
+        onAuthenticated(challengeResponse.webauthn_response);
       }
       next();
     }

--- a/web/packages/teleport/src/Account/ChangePasswordWizard/ChangePasswordWizard.tsx
+++ b/web/packages/teleport/src/Account/ChangePasswordWizard/ChangePasswordWizard.tsx
@@ -178,7 +178,10 @@ export function ReauthenticateStep({
             m === 'passwordless' ? 'required' : 'discouraged',
         });
 
-        const response = await auth.getMfaChallengeResponse(challenge);
+        const response = await auth.getMfaChallengeResponse(
+          challenge,
+          'webauthn'
+        );
 
         // TODO(Joerger): handle non-webauthn response.
         onAuthenticated(response.webauthn_response);

--- a/web/packages/teleport/src/Account/ChangePasswordWizard/ChangePasswordWizard.tsx
+++ b/web/packages/teleport/src/Account/ChangePasswordWizard/ChangePasswordWizard.tsx
@@ -147,7 +147,7 @@ const wizardFlows = {
   withoutReauthentication: [ChangePasswordStep],
 };
 
-type ChangePasswordWizardStepProps = StepComponentProps &
+export type ChangePasswordWizardStepProps = StepComponentProps &
   ReauthenticateStepProps &
   ChangePasswordStepProps;
 

--- a/web/packages/teleport/src/Account/ManageDevices/useManageDevices.ts
+++ b/web/packages/teleport/src/Account/ManageDevices/useManageDevices.ts
@@ -48,14 +48,15 @@ export default function useManageDevices(ctx: Ctx) {
 
   async function onAddDevice(usage: DeviceUsage) {
     setNewDeviceUsage(usage);
-    const response = await auth.getChallenge({
+    const challenge = await auth.getMfaChallenge({
       scope: MfaChallengeScope.MANAGE_DEVICES,
     });
     // If the user doesn't receieve any challenges from the backend, that means
     // they have no valid devices to be challenged and should instead use a privilege token
     // to add a new device.
     // TODO (avatus): add SSO challenge here as well when we add SSO for MFA
-    if (!response.webauthnPublicKey?.challenge && !response.totpChallenge) {
+    // TODO(Joerger): privilege token is no longer required to add first device.
+    if (!challenge) {
       createRestrictedTokenAttempt.run(() =>
         auth.createRestrictedPrivilegeToken().then(token => {
           setToken(token);

--- a/web/packages/teleport/src/Console/DocumentSsh/useGetScpUrl.ts
+++ b/web/packages/teleport/src/Console/DocumentSsh/useGetScpUrl.ts
@@ -35,15 +35,18 @@ export default function useGetScpUrl(addMfaToScpUrls: boolean) {
         return cfg.getScpUrl(params);
       }
       try {
-        let webauthn = await auth.getWebauthnResponse(
-          MfaChallengeScope.USER_SESSION
-        );
+        const challenge = await auth.getMfaChallenge({
+          scope: MfaChallengeScope.USER_SESSION,
+        });
+
+        const response = await auth.getMfaChallengeResponse(challenge);
+
         setAttempt({
           status: 'success',
           statusText: '',
         });
         return cfg.getScpUrl({
-          webauthn,
+          webauthn: response.webauthn_response,
           ...params,
         });
       } catch (error) {

--- a/web/packages/teleport/src/Console/DocumentSsh/useGetScpUrl.ts
+++ b/web/packages/teleport/src/Console/DocumentSsh/useGetScpUrl.ts
@@ -39,7 +39,10 @@ export default function useGetScpUrl(addMfaToScpUrls: boolean) {
           scope: MfaChallengeScope.USER_SESSION,
         });
 
-        const response = await auth.getMfaChallengeResponse(challenge);
+        const response = await auth.getMfaChallengeResponse(
+          challenge,
+          'webauthn'
+        );
 
         setAttempt({
           status: 'success',

--- a/web/packages/teleport/src/Users/useUsers.ts
+++ b/web/packages/teleport/src/Users/useUsers.ts
@@ -87,16 +87,12 @@ export default function useUsers({
   }
 
   async function onCreate(u: User) {
-    const webauthnResponse = await auth.getWebauthnResponseForAdminAction(true);
+    const mfaResponse = await auth.getMfaChallengeResponseForAdminAction(true);
     return ctx.userService
-      .createUser(u, ExcludeUserField.Traits, webauthnResponse)
+      .createUser(u, ExcludeUserField.Traits, mfaResponse)
       .then(result => setUsers([result, ...users]))
       .then(() =>
-        ctx.userService.createResetPasswordToken(
-          u.name,
-          'invite',
-          webauthnResponse
-        )
+        ctx.userService.createResetPasswordToken(u.name, 'invite', mfaResponse)
       );
   }
 

--- a/web/packages/teleport/src/components/ReAuthenticate/useReAuthenticate.ts
+++ b/web/packages/teleport/src/components/ReAuthenticate/useReAuthenticate.ts
@@ -58,11 +58,10 @@ export default function useReAuthenticate(props: Props) {
 
     if ('onMfaResponse' in props) {
       auth
-        .getWebauthnResponse(props.challengeScope)
-        .then(webauthnResponse =>
-          props.onMfaResponse({ webauthn_response: webauthnResponse })
-        )
+        .getMfaChallenge({ scope: props.challengeScope })
+        .then(auth.getMfaChallengeResponse)
         .catch(handleError);
+
       return;
     }
 

--- a/web/packages/teleport/src/components/ReAuthenticate/useReAuthenticate.ts
+++ b/web/packages/teleport/src/components/ReAuthenticate/useReAuthenticate.ts
@@ -59,7 +59,7 @@ export default function useReAuthenticate(props: Props) {
     if ('onMfaResponse' in props) {
       auth
         .getMfaChallenge({ scope: props.challengeScope })
-        .then(auth.getMfaChallengeResponse)
+        .then(challenge => auth.getMfaChallengeResponse(challenge, 'webauthn'))
         .catch(handleError);
 
       return;

--- a/web/packages/teleport/src/services/api/api.test.ts
+++ b/web/packages/teleport/src/services/api/api.test.ts
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { MfaChallengeResponse } from '../mfa';
+
 import api, {
   MFA_HEADER,
   defaultRequestOptions,
@@ -26,18 +28,20 @@ import api, {
 describe('api.fetch', () => {
   const mockedFetch = jest.spyOn(global, 'fetch').mockResolvedValue({} as any); // we don't care about response
 
-  const webauthnResp = {
-    id: 'some-id',
-    type: 'some-type',
-    extensions: {
-      appid: false,
-    },
-    rawId: 'some-raw-id',
-    response: {
-      authenticatorData: 'authen-data',
-      clientDataJSON: 'client-data-json',
-      signature: 'signature',
-      userHandle: 'user-handle',
+  const mfaResp: MfaChallengeResponse = {
+    webauthn_response: {
+      id: 'some-id',
+      type: 'some-type',
+      extensions: {
+        appid: false,
+      },
+      rawId: 'some-raw-id',
+      response: {
+        authenticatorData: 'authen-data',
+        clientDataJSON: 'client-data-json',
+        signature: 'signature',
+        userHandle: 'user-handle',
+      },
     },
   };
 
@@ -88,7 +92,7 @@ describe('api.fetch', () => {
   });
 
   test('with webauthnResponse', async () => {
-    await api.fetch('/something', undefined, webauthnResp);
+    await api.fetch('/something', undefined, mfaResp);
     expect(mockedFetch).toHaveBeenCalledTimes(1);
 
     const firstCall = mockedFetch.mock.calls[0];
@@ -100,14 +104,14 @@ describe('api.fetch', () => {
         ...defaultRequestOptions.headers,
         ...getAuthHeaders(),
         [MFA_HEADER]: JSON.stringify({
-          webauthnAssertionResponse: webauthnResp,
+          webauthnAssertionResponse: mfaResp.webauthn_response,
         }),
       },
     });
   });
 
   test('with customOptions and webauthnResponse', async () => {
-    await api.fetch('/something', customOpts, webauthnResp);
+    await api.fetch('/something', customOpts, mfaResp);
     expect(mockedFetch).toHaveBeenCalledTimes(1);
 
     const firstCall = mockedFetch.mock.calls[0];
@@ -120,7 +124,7 @@ describe('api.fetch', () => {
         ...customOpts.headers,
         ...getAuthHeaders(),
         [MFA_HEADER]: JSON.stringify({
-          webauthnAssertionResponse: webauthnResp,
+          webauthnAssertionResponse: mfaResp.webauthn_response,
         }),
       },
     });

--- a/web/packages/teleport/src/services/api/api.ts
+++ b/web/packages/teleport/src/services/api/api.ts
@@ -21,7 +21,7 @@ import auth, { MfaChallengeScope } from 'teleport/services/auth/auth';
 import websession from 'teleport/services/websession';
 
 import { storageService } from '../storageService';
-import { MfaChallengeResponse, WebauthnAssertionResponse } from '../mfa';
+import { MfaChallengeResponse } from '../mfa';
 
 import parseError, { ApiError } from './parseError';
 

--- a/web/packages/teleport/src/services/apps/apps.ts
+++ b/web/packages/teleport/src/services/apps/apps.ts
@@ -49,20 +49,23 @@ const service = {
     };
 
     // Prompt for MFA if per-session MFA is required for this app.
-    const webauthnResponse = await auth.getWebauthnResponse(
-      MfaChallengeScope.USER_SESSION,
-      false,
-      {
+    const challenge = await auth.getMfaChallenge({
+      scope: MfaChallengeScope.USER_SESSION,
+      allowReuse: false,
+      isMfaRequiredRequest: {
         app: resolveApp,
-      }
-    );
+      },
+    });
+
+    const resp = await auth.getMfaChallengeResponse(challenge);
 
     const createAppSession = {
       ...resolveApp,
       arn: params.arn,
-      mfa_response: webauthnResponse
+      // TODO(Joerger): Handle non-webauthn response.
+      mfa_response: resp
         ? JSON.stringify({
-            webauthnAssertionResponse: webauthnResponse,
+            webauthnAssertionResponse: resp.webauthn_response,
           })
         : null,
     };

--- a/web/packages/teleport/src/services/auth/auth.ts
+++ b/web/packages/teleport/src/services/auth/auth.ts
@@ -212,14 +212,13 @@ const auth = {
     oldPassword,
     newPassword,
     secondFactorToken,
-    credential,
+    webauthnResponse,
   }: ChangePasswordReq) {
     const data = {
       old_password: base64EncodeUnicode(oldPassword),
       new_password: base64EncodeUnicode(newPassword),
       second_factor_token: secondFactorToken,
-      webauthnAssertionResponse:
-        credential && makeWebauthnAssertionResponse(credential),
+      webauthnAssertionResponse: webauthnResponse,
     };
 
     return api.put(cfg.api.changeUserPasswordPath, data);
@@ -342,9 +341,7 @@ const auth = {
       .then(res =>
         api.post(cfg.api.createPrivilegeTokenPath, {
           // TODO(Joerger): Handle non-webauthn challenges.
-          webauthnAssertionResponse: makeWebauthnAssertionResponse(
-            res.webauthn_response
-          ),
+          webauthnAssertionResponse: res.webauthn_response,
         })
       );
   },
@@ -390,7 +387,7 @@ const auth = {
     return auth
       .getMfaChallenge({ scope, allowReuse, isMfaRequiredRequest }, abortSignal)
       .then(challenge => auth.getMfaChallengeResponse(challenge, 'webauthn'))
-      .then(res => makeWebauthnAssertionResponse(res.webauthn_response));
+      .then(res => res.webauthn_response);
   },
 
   getMfaChallengeResponseForAdminAction(allowReuse?: boolean) {

--- a/web/packages/teleport/src/services/auth/auth.ts
+++ b/web/packages/teleport/src/services/auth/auth.ts
@@ -296,9 +296,9 @@ const auth = {
     // whichever method we can succeed with first.
     if (!mfaType) {
       if (totpCode) {
-        mfaType == 'totp';
+        mfaType = 'totp';
       } else if (challenge.webauthnPublicKey) {
-        mfaType == 'webauthn';
+        mfaType = 'webauthn';
       }
     }
 

--- a/web/packages/teleport/src/services/auth/types.ts
+++ b/web/packages/teleport/src/services/auth/types.ts
@@ -18,7 +18,7 @@
 
 import { EventMeta } from 'teleport/services/userEvent';
 
-import { DeviceUsage } from '../mfa';
+import { DeviceUsage, WebauthnAssertionResponse } from '../mfa';
 
 import { IsMfaRequiredRequest, MfaChallengeScope } from './auth';
 
@@ -74,7 +74,7 @@ export type ChangePasswordReq = {
   oldPassword: string;
   newPassword: string;
   secondFactorToken: string;
-  credential?: Credential;
+  webauthnResponse?: WebauthnAssertionResponse;
 };
 
 export type CreateNewHardwareDeviceRequest = {

--- a/web/packages/teleport/src/services/integrations/integrations.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.ts
@@ -20,7 +20,7 @@ import api from 'teleport/services/api';
 import cfg from 'teleport/config';
 
 import makeNode from '../nodes/makeNode';
-import auth from '../auth/auth';
+import auth, { MfaChallengeScope } from '../auth/auth';
 import { App } from '../apps';
 import makeApp from '../apps/makeApps';
 
@@ -271,14 +271,22 @@ export const integrationService = {
     integrationName,
     req: AwsOidcDeployServiceRequest
   ): Promise<string> {
-    const webauthnResponse = await auth.getWebauthnResponseForAdminAction(true);
+    const challenge = await auth.getMfaChallenge({
+      scope: MfaChallengeScope.ADMIN_ACTION,
+      allowReuse: true,
+      isMfaRequiredRequest: {
+        admin_action: {},
+      },
+    });
+
+    const response = await auth.getMfaChallengeResponse(challenge);
 
     return api
       .post(
         cfg.getAwsDeployTeleportServiceUrl(integrationName),
         req,
         null,
-        webauthnResponse
+        response
       )
       .then(resp => resp.serviceDashboardUrl);
   },
@@ -293,14 +301,14 @@ export const integrationService = {
     integrationName,
     req: AwsOidcDeployDatabaseServicesRequest
   ): Promise<string> {
-    const webauthnResponse = await auth.getWebauthnResponseForAdminAction(true);
+    const mfaResponse = await auth.getMfaChallengeResponseForAdminAction(true);
 
     return api
       .post(
         cfg.getAwsRdsDbsDeployServicesUrl(integrationName),
         req,
         null,
-        webauthnResponse
+        mfaResponse
       )
       .then(resp => resp.clusterDashboardUrl);
   },
@@ -309,13 +317,13 @@ export const integrationService = {
     integrationName: string,
     req: EnrollEksClustersRequest
   ): Promise<EnrollEksClustersResponse> {
-    const webauthnResponse = await auth.getWebauthnResponseForAdminAction(true);
+    const mfaResponse = await auth.getMfaChallengeResponseForAdminAction(true);
 
     return api.post(
       cfg.getEnrollEksClusterUrl(integrationName),
       req,
       null,
-      webauthnResponse
+      mfaResponse
     );
   },
 

--- a/web/packages/teleport/src/services/mfa/makeMfa.ts
+++ b/web/packages/teleport/src/services/mfa/makeMfa.ts
@@ -64,6 +64,14 @@ export function parseMfaRegistrationChallengeJson(
 export function parseMfaChallengeJson(
   challenge: MfaAuthenticateChallengeJson
 ): MfaAuthenticateChallenge {
+  if (
+    !challenge.sso_challenge &&
+    !challenge.webauthn_challenge &&
+    !challenge.totp_challenge
+  ) {
+    return null;
+  }
+
   // WebAuthn challenge contains Base64URL(byte) fields that needs to
   // be converted to ArrayBuffer expected by navigator.credentials.get:
   // - challenge

--- a/web/packages/teleport/src/services/user/user.ts
+++ b/web/packages/teleport/src/services/user/user.ts
@@ -20,7 +20,7 @@ import api from 'teleport/services/api';
 import cfg from 'teleport/config';
 import session from 'teleport/services/websession';
 
-import { MfaChallengeResponse, WebauthnAssertionResponse } from '../mfa';
+import { MfaChallengeResponse } from '../mfa';
 
 import makeUserContext from './makeUserContext';
 import { makeResetToken } from './makeResetToken';

--- a/web/packages/teleport/src/services/user/user.ts
+++ b/web/packages/teleport/src/services/user/user.ts
@@ -20,7 +20,7 @@ import api from 'teleport/services/api';
 import cfg from 'teleport/config';
 import session from 'teleport/services/websession';
 
-import { WebauthnAssertionResponse } from '../mfa';
+import { MfaChallengeResponse, WebauthnAssertionResponse } from '../mfa';
 
 import makeUserContext from './makeUserContext';
 import { makeResetToken } from './makeResetToken';
@@ -86,14 +86,14 @@ const service = {
   createUser(
     user: User,
     excludeUserField: ExcludeUserField,
-    webauthnResponse?: WebauthnAssertionResponse
+    mfaResponse?: MfaChallengeResponse
   ) {
     return api
       .post(
         cfg.getUsersUrl(),
         withExcludedField(user, excludeUserField),
         null,
-        webauthnResponse
+        mfaResponse
       )
       .then(makeUser);
   },
@@ -101,15 +101,10 @@ const service = {
   createResetPasswordToken(
     name: string,
     type: ResetPasswordType,
-    webauthnResponse?: WebauthnAssertionResponse
+    mfaResponse?: MfaChallengeResponse
   ) {
     return api
-      .post(
-        cfg.api.resetPasswordTokenPath,
-        { name, type },
-        null,
-        webauthnResponse
-      )
+      .post(cfg.api.resetPasswordTokenPath, { name, type }, null, mfaResponse)
       .then(makeResetToken);
   },
 


### PR DESCRIPTION
Replace existing MFA methods which handle only `webauthn` or `otp` to handle generic MFA challenges instead. This way we can add SSO MFA support with just one or two small changes.

Depends on https://github.com/gravitational/teleport/pull/49678

Prerequisite for SSO MFA changes (TODO).