### PR TITLE
docs: include Oracle Exadata in faq entry

### DIFF
--- a/docs/pages/enroll-resources/database-access/faq.mdx
+++ b/docs/pages/enroll-resources/database-access/faq.mdx
@@ -25,13 +25,14 @@ The Teleport Database Service currently supports the following protocols:
 - Redis
 - Snowflake
 
-For PostgreSQL and MySQL, the following Cloud-hosted versions are supported in addition to self-hosted deployments:
+For PostgreSQL, Oracle and MySQL, the following Cloud-hosted versions are supported in addition to self-hosted deployments:
 
 - Amazon RDS
 - Amazon Aurora (except for Amazon Aurora Serverless, which doesn't support IAM authentication)
 - Amazon Redshift
 - Google Cloud SQL
 - Azure Database
+- Oracle Exadata
 
 See the available [guides](guides/guides.mdx) for all supported configurations.
 


### PR DESCRIPTION
Include Oracle Exadata as a cloud supported item.