### PR TITLE
[v17] postrelease: automatically update the Go version

### DIFF
--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -94,12 +94,17 @@ jobs:
           git config --global user.email "noreply@github.com"
           git config --global user.name "GitHub"
 
+          # get Go version from go.mod
+          GO_VERSION=$(go mod edit -json | jq -r .Go)
+
           # update versions in docs/config.json
           # for docker images replace version number after <docker image name>:
           jq --arg major "${MAJOR_VERSION}" \
              --arg version "${FULL_VERSION}" \
+             --arg go_version "${GO_VERSION}" \
              '.variables.teleport.major_version |= $major |
               .variables.teleport.version |= $version |
+              .variables.teleport.golang |= $go_version |
               .variables.teleport.plugin.version |= $version |
               .variables.teleport.latest_oss_docker_image |= sub(":.*";":")+$version |
               .variables.teleport.latest_oss_debug_docker_image |= sub(":.*";":")+$version |


### PR DESCRIPTION
Extract the Go version from go.mod and use it when we update the version numbers used throughout the docs.

This has several advantages:
1. We no longer need to remember to periodically update this variable. For example, Teleport 17 was built with Go 1.23 but the docs still (incorrectly) mention Go 1.22.
2. We get even more precision, as we'll start using the full patch version of Go instead of only the minor.

Backports #49116