### PR TITLE
Switch rustls to aws-lc-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2400,7 +2400,6 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -42,7 +42,7 @@ picky = { version = "7.0.0-rc.9", default-features = false }
 picky-asn1-der = "0.5.0"
 picky-asn1-x509 = "0.13.0"
 reqwest = { version = "0.12", default-features = false }
-rustls = { version = "0.23.18", default-features = false, features = ["ring"] }
+rustls = { version = "0.23.18", default-features = false, features = ["aws-lc-rs"] }
 
 [build-dependencies]
 cbindgen = "0.27.0"


### PR DESCRIPTION
This PR switches crypto provider for `rustls` from `ring` to `aws-lc-rs`. This reduces number of dependencies we have and simplifies setup