### PR TITLE
[teleport-update] Extended binary validations

### DIFF
--- a/lib/autoupdate/agent/installer.go
+++ b/lib/autoupdate/agent/installer.go
@@ -86,6 +86,9 @@ type LocalInstaller struct {
 	ReservedFreeInstallDisk uint64
 	// TransformService transforms the systemd service during copying.
 	TransformService func([]byte) []byte
+	// ValidateBinary returns true if a file is a linkable binary, or
+	// false if a file should not be linked.
+	ValidateBinary func(ctx context.Context, path string) (bool, error)
 }
 
 // Remove a Teleport version directory from InstallDir.
@@ -560,9 +563,16 @@ func (li *LocalInstaller) forceLinks(ctx context.Context, binDir, svcPath string
 		}
 		oldname := filepath.Join(binDir, entry.Name())
 		newname := filepath.Join(li.LinkBinDir, entry.Name())
+		exec, err := li.ValidateBinary(ctx, oldname)
+		if err != nil {
+			return revert, trace.Wrap(err)
+		}
+		if !exec {
+			continue
+		}
 		orig, err := forceLink(oldname, newname)
 		if err != nil && !errors.Is(err, os.ErrExist) {
-			return revert, trace.Wrap(err, "failed to create symlink for %s", filepath.Base(oldname))
+			return revert, trace.Wrap(err, "failed to create symlink for %s", entry.Name())
 		}
 		if orig != "" {
 			revertLinks = append(revertLinks, symlink{
@@ -592,7 +602,7 @@ func (li *LocalInstaller) forceLinks(ctx context.Context, binDir, svcPath string
 // The contents of both src and dst must be smaller than n.
 // See forceCopy for more details.
 func (li *LocalInstaller) forceCopyService(dst, src string, n int64) (orig *smallFile, err error) {
-	srcData, err := readFileN(src, n)
+	srcData, err := readFileAtMost(src, n)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -603,13 +613,6 @@ func (li *LocalInstaller) forceCopyService(dst, src string, n int64) (orig *smal
 // If a non-symlink file or directory exists in newname already, forceLink errors.
 // If the link is already present with the desired oldname, forceLink returns os.ErrExist.
 func forceLink(oldname, newname string) (orig string, err error) {
-	exec, err := isExecutable(oldname)
-	if err != nil {
-		return "", trace.Wrap(err)
-	}
-	if !exec {
-		return "", trace.Errorf("%s is not a regular executable file", oldname)
-	}
 	orig, err = os.Readlink(newname)
 	if errors.Is(err, os.ErrInvalid) ||
 		errors.Is(err, syscall.EINVAL) { // workaround missing ErrInvalid wrapper
@@ -627,17 +630,6 @@ func forceLink(oldname, newname string) (orig string, err error) {
 		return "", trace.Wrap(err)
 	}
 	return orig, nil
-}
-
-// isExecutable returns true for regular files that are executable by all users (0111).
-func isExecutable(path string) (bool, error) {
-	fi, err := os.Lstat(path)
-	if err != nil {
-		return false, trace.Wrap(err)
-	}
-	// TODO(sclevine): verify path is valid binary
-	return fi.Mode().IsRegular() &&
-		fi.Mode()&0111 == 0111, nil
 }
 
 // forceCopy atomically copies a file from srcData to dst, replacing an existing file at dst if needed.
@@ -658,7 +650,7 @@ func forceCopy(dst string, srcData []byte, n int64) (orig *smallFile, err error)
 		if !orig.mode.IsRegular() {
 			return nil, trace.Errorf("refusing to replace irregular file at %s", dst)
 		}
-		orig.data, err = readFileN(dst, n)
+		orig.data, err = readFileAtMost(dst, n)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -673,8 +665,8 @@ func forceCopy(dst string, srcData []byte, n int64) (orig *smallFile, err error)
 	return orig, nil
 }
 
-// readFileN reads a file up to n, or errors if it is too large.
-func readFileN(name string, n int64) ([]byte, error) {
+// readFileAtMost reads a file up to n, or errors if it is too large.
+func readFileAtMost(name string, n int64) ([]byte, error) {
 	f, err := os.Open(name)
 	if err != nil {
 		return nil, err
@@ -723,11 +715,11 @@ func (li *LocalInstaller) removeLinks(ctx context.Context, binDir, svcPath strin
 		li.Log.DebugContext(ctx, "Teleport binary not unlinked. Skipping removal of teleport.service.")
 		return nil
 	}
-	srcBytes, err := readFileN(svcPath, maxServiceFileSize)
+	srcBytes, err := readFileAtMost(svcPath, maxServiceFileSize)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	dstBytes, err := readFileN(li.CopyServiceFile, maxServiceFileSize)
+	dstBytes, err := readFileAtMost(li.CopyServiceFile, maxServiceFileSize)
 	if errors.Is(err, os.ErrNotExist) {
 		li.Log.DebugContext(ctx, "Service not present.", "path", li.CopyServiceFile)
 		return nil
@@ -774,6 +766,13 @@ func (li *LocalInstaller) tryLinks(ctx context.Context, binDir, svcPath string) 
 		}
 		oldname := filepath.Join(binDir, entry.Name())
 		newname := filepath.Join(li.LinkBinDir, entry.Name())
+		exec, err := li.ValidateBinary(ctx, oldname)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if !exec {
+			continue
+		}
 		ok, err := needsLink(oldname, newname)
 		if err != nil {
 			return trace.Wrap(err, "error evaluating link for %s", filepath.Base(oldname))
@@ -808,13 +807,6 @@ func (li *LocalInstaller) tryLinks(ctx context.Context, binDir, svcPath string) 
 // If a non-symlink file or directory exists at newname, needsLink errors.
 // If a symlink to a different location exists, needsLink errors with ErrLinked.
 func needsLink(oldname, newname string) (ok bool, err error) {
-	exec, err := isExecutable(oldname)
-	if err != nil {
-		return false, trace.Wrap(err)
-	}
-	if !exec {
-		return false, trace.Errorf("%s is not a regular executable file", oldname)
-	}
 	orig, err := os.Readlink(newname)
 	if errors.Is(err, os.ErrInvalid) ||
 		errors.Is(err, syscall.EINVAL) { // workaround missing ErrInvalid wrapper

--- a/lib/autoupdate/agent/installer_test.go
+++ b/lib/autoupdate/agent/installer_test.go
@@ -255,7 +255,7 @@ func TestLocalInstaller_Link(t *testing.T) {
 			},
 			installFileMode: 0644,
 
-			errMatch: "executable",
+			errMatch: "no binaries",
 		},
 		{
 			name: "present with existing links",
@@ -396,6 +396,7 @@ func TestLocalInstaller_Link(t *testing.T) {
 				require.NoError(t, err)
 			}
 
+			validator := Validator{Log: slog.Default()}
 			installer := &LocalInstaller{
 				InstallDir:      versionsDir,
 				LinkBinDir:      filepath.Join(linkDir, "bin"),
@@ -404,6 +405,7 @@ func TestLocalInstaller_Link(t *testing.T) {
 				TransformService: func(b []byte) []byte {
 					return []byte("[transform]" + string(b))
 				},
+				ValidateBinary: validator.IsExecutable,
 			}
 			ctx := context.Background()
 			revert, err := installer.Link(ctx, version)
@@ -523,7 +525,7 @@ func TestLocalInstaller_TryLink(t *testing.T) {
 			},
 			installFileMode: 0644,
 
-			errMatch: "executable",
+			errMatch: "no binaries",
 		},
 		{
 			name: "present with existing links",
@@ -649,6 +651,7 @@ func TestLocalInstaller_TryLink(t *testing.T) {
 				require.NoError(t, err)
 			}
 
+			validator := Validator{Log: slog.Default()}
 			installer := &LocalInstaller{
 				InstallDir:      versionsDir,
 				LinkBinDir:      filepath.Join(linkDir, "bin"),
@@ -657,6 +660,7 @@ func TestLocalInstaller_TryLink(t *testing.T) {
 				TransformService: func(b []byte) []byte {
 					return []byte("[transform]" + string(b))
 				},
+				ValidateBinary: validator.IsExecutable,
 			}
 			ctx := context.Background()
 			err = installer.TryLink(ctx, version)
@@ -797,6 +801,7 @@ func TestLocalInstaller_Remove(t *testing.T) {
 
 			linkDir := t.TempDir()
 
+			validator := Validator{Log: slog.Default()}
 			installer := &LocalInstaller{
 				InstallDir:      versionsDir,
 				LinkBinDir:      filepath.Join(linkDir, "bin"),
@@ -805,6 +810,7 @@ func TestLocalInstaller_Remove(t *testing.T) {
 				TransformService: func(b []byte) []byte {
 					return []byte("[transform]" + string(b))
 				},
+				ValidateBinary: validator.IsExecutable,
 			}
 			ctx := context.Background()
 

--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -210,7 +210,7 @@ func (s SystemdService) waitForStablePID(ctx context.Context, minStable, maxCras
 
 // readInt reads an integer from a file.
 func readInt(path string) (int, error) {
-	p, err := readFileN(path, 32)
+	p, err := readFileAtMost(path, 32)
 	if err != nil {
 		return 0, trace.Wrap(err)
 	}
@@ -368,13 +368,6 @@ func (c *localExec) Run(ctx context.Context, name string, args ...string) (int, 
 	stderr.Flush()
 	stdout.Flush()
 	code := cmd.ProcessState.ExitCode()
-
-	// Treat out-of-range exit code (255) as an error executing the command.
-	// This allows callers to treat codes that are more likely OS-related as execution errors
-	// instead of intentionally returned error codes.
-	if code == 255 {
-		code = -1
-	}
 	return code, trace.Wrap(err)
 }
 

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -94,6 +94,7 @@ func NewLocalUpdater(cfg LocalUpdaterConfig, ns *Namespace) (*Updater, error) {
 	if cfg.SystemDir == "" {
 		cfg.SystemDir = defaultSystemDir
 	}
+	validator := Validator{Log: cfg.Log}
 	return &Updater{
 		Log:                cfg.Log,
 		Pool:               certPool,
@@ -110,6 +111,7 @@ func NewLocalUpdater(cfg LocalUpdaterConfig, ns *Namespace) (*Updater, error) {
 			ReservedFreeTmpDisk:     reservedFreeDisk,
 			ReservedFreeInstallDisk: reservedFreeDisk,
 			TransformService:        ns.replaceTeleportService,
+			ValidateBinary:          validator.IsBinary,
 		},
 		Process: &SystemdService{
 			ServiceName: filepath.Base(ns.serviceFile),

--- a/lib/autoupdate/agent/validate.go
+++ b/lib/autoupdate/agent/validate.go
@@ -1,0 +1,130 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package agent
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"unicode"
+
+	"github.com/gravitational/trace"
+)
+
+const (
+	// fileHeaderSniffBytes is the max size to read to determine a file's MIME type
+	fileHeaderSniffBytes = 512 // MIME standard size
+	// execModeMask is the minimum required set of bits to consider a file executable.
+	execModeMask = 0111
+)
+
+// Validator validates filesystem paths.
+type Validator struct {
+	Log *slog.Logger
+}
+
+// IsBinary returns true for working binaries that are executable by all users.
+// If the file is irregular, non-executable, or a shell script, IsBinary returns false and logs a warning.
+// IsBinary errors if lstat fails, a regular file is unreadable, or an executable file does not execute.
+func (v *Validator) IsBinary(ctx context.Context, path string) (bool, error) {
+	// The behavior of this method is intended to protect against executable files
+	// being adding to the Teleport tgz that should not be made available on PATH,
+	// and additionally, should not cause installation to fail.
+	// While known copies of these files (e.g., "install") are excluded during extraction,
+	// it is safer to assume others could be present in past or future tgzs.
+
+	if exec, err := v.IsExecutable(ctx, path); err != nil || !exec {
+		return exec, trace.Wrap(err)
+	}
+	name := filepath.Base(path)
+	d, err := readFileLimit(path, fileHeaderSniffBytes)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	// Refuse to test or link shell scripts
+	if isTextScript(d) {
+		v.Log.WarnContext(ctx, "Found unexpected shell script", "name", name)
+		return false, nil
+	}
+	v.Log.InfoContext(ctx, "Validating binary", "name", name)
+	r := localExec{
+		Log:      v.Log,
+		ErrLevel: slog.LevelDebug,
+		OutLevel: slog.LevelInfo, // always show version
+	}
+	code, err := r.Run(ctx, path, "version")
+	if code < 0 {
+		return false, trace.Wrap(err, "error validating binary %s", name)
+	}
+	if code > 0 {
+		v.Log.InfoContext(ctx, "Binary does not support version command", "name", name)
+	}
+	return true, nil
+}
+
+// IsExecutable returns true for regular, executable files.
+func (v *Validator) IsExecutable(ctx context.Context, path string) (bool, error) {
+	name := filepath.Base(path)
+	fi, err := os.Lstat(path)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	if !fi.Mode().IsRegular() {
+		v.Log.WarnContext(ctx, "Found unexpected irregular file", "name", name)
+		return false, nil
+	}
+	if fi.Mode()&execModeMask != execModeMask {
+		v.Log.WarnContext(ctx, "Found unexpected non-executable file", "name", name)
+		return false, nil
+	}
+	return true, nil
+}
+
+func isTextScript(data []byte) bool {
+	data = bytes.TrimLeftFunc(data, unicode.IsSpace)
+	if !bytes.HasPrefix(data, []byte("#!")) {
+		return false
+	}
+	// Assume presence of MIME binary data bytes means binary:
+	//   https://mimesniff.spec.whatwg.org/#terminology
+	for _, b := range data {
+		switch {
+		case b <= 0x08, b == 0x0B,
+			0x0E <= b && b <= 0x1A,
+			0x1C <= b && b <= 0x1F:
+			return false
+		}
+	}
+	return true
+}
+
+// readFileLimit the first n bytes of a file.
+func readFileLimit(name string, n int64) ([]byte, error) {
+	f, err := os.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, io.LimitReader(f, n))
+	return buf.Bytes(), trace.Wrap(err)
+}

--- a/lib/autoupdate/agent/validate_test.go
+++ b/lib/autoupdate/agent/validate_test.go
@@ -1,0 +1,102 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package agent
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidator_IsBinary(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		mode     os.FileMode
+		contents string
+
+		valid    bool
+		errMatch string
+		logMatch string
+	}{
+		{
+			name:     "missing",
+			errMatch: "no such",
+		},
+		{
+			name:     "non-executable",
+			contents: "test",
+			mode:     0666,
+			logMatch: "non-executable",
+		},
+		{
+			name:     "shell script",
+			contents: "  #!bash  ",
+			mode:     0777,
+			logMatch: "unexpected shell",
+		},
+		{
+			name:     "unqualified shell script",
+			contents: "  #!bash" + string([]byte{0x0B}),
+			mode:     0777,
+			errMatch: "validating binary",
+		},
+		{
+			name:     "exit 0",
+			contents: "#!/bin/sh\nexit 0\n" + string([]byte{0x0B}),
+			mode:     0777,
+			valid:    true,
+		},
+		{
+			name:     "exit 1",
+			contents: "#!/bin/sh\nexit 1\n" + string([]byte{0x0B}),
+			mode:     0777,
+			valid:    true,
+			logMatch: "version command",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			opts := &slog.HandlerOptions{AddSource: true}
+			log := slog.New(slog.NewTextHandler(&buf, opts))
+			v := Validator{Log: log}
+			ctx := context.Background()
+			path := filepath.Join(t.TempDir(), "file")
+			if tt.contents != "" {
+				os.WriteFile(path, []byte(tt.contents), tt.mode)
+			}
+			val, err := v.IsBinary(ctx, path)
+			if tt.logMatch != "" {
+				require.Contains(t, buf.String(), tt.logMatch)
+			}
+			if tt.errMatch != "" {
+				require.Error(t, err)
+				require.False(t, val)
+				require.Contains(t, err.Error(), tt.errMatch)
+				return
+			}
+			require.Equal(t, tt.valid, val)
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds additional validations on binaries downloaded by `teleport-update` before their are linked into system locations.

The following conditions will result in a warning and skip the file:
- Irregular file
- Non-executable regular file
- Shell script

The following conditions will error:
- Unreadable file
- Executable binary that cannot execute on the host (run with `version` as argv[1])

This makes `teleport-update` resilient to unknown non-binary files that may be present in the teleport tgz in past or future releases (e.g., other `install` scripts).

Example:

```shell
ubuntu@legendary-mite:~$ sudo ./teleport-update enable --force-version=16.4.7
2024-12-04T06:37:53Z INFO [UPDATER]   Initiating installation. target_version:16.4.7 active_version: agent/updater.go:304
2024-12-04T06:37:54Z INFO [UPDATER]   Downloading Teleport tarball. url:https://cdn.teleport.dev/teleport-ent-v16.4.7-linux-arm64-bin.tar.gz size:162964120 agent/installer.go:324
2024-12-04T06:38:00Z INFO [UPDATER]   Extracting Teleport tarball. path:/opt/teleport/default/versions/16.4.7 size:648448000 agent/installer.go:362
2024-12-04T06:38:03Z INFO [UPDATER]   Validating binary name:fdpass-teleport agent/validate.go:68
2024-12-04T06:38:03Z INFO [UPDATER]   Binary does not support version command name:fdpass-teleport agent/validate.go:79
2024-12-04T06:38:03Z INFO [UPDATER]   Validating binary name:tbot agent/validate.go:68
2024-12-04T06:38:03Z INFO [UPDATER]   [stdout] Teleport v16.4.7 git:v16.4.7-0-g15dfef1 go1.22.9 agent/process.go:385
2024-12-04T06:38:03Z INFO [UPDATER]   Validating binary name:tctl agent/validate.go:68
2024-12-04T06:38:03Z INFO [UPDATER]   [stdout] Teleport v16.4.7 git:v16.4.7-0-g15dfef1 go1.22.9 agent/process.go:385
2024-12-04T06:38:03Z INFO [UPDATER]   Validating binary name:teleport agent/validate.go:68
2024-12-04T06:38:03Z INFO [UPDATER]   [stdout] Teleport Enterprise v16.4.7 git:v16.4.7-0-g15dfef1 go1.22.9 agent/process.go:385
2024-12-04T06:38:03Z INFO [UPDATER]   Validating binary name:tsh agent/validate.go:68
2024-12-04T06:38:03Z INFO [UPDATER]   [stdout] Teleport v16.4.7 git:v16.4.7-0-g15dfef1 go1.22.9 agent/process.go:385
2024-12-04T06:38:03Z INFO [UPDATER]   Executing new teleport-update binary to update configuration. agent/updater.go:133
2024-12-04T06:38:04Z INFO [UPDATER]   Systemd configuration synced. unit:teleport-update.timer agent/process.go:259
2024-12-04T06:38:04Z INFO [UPDATER]   Service enabled. unit:teleport-update.timer agent/process.go:276
2024-12-04T06:38:04Z INFO [UPDATER]   Finished executing new teleport-update binary. agent/updater.go:139
2024-12-04T06:38:04Z INFO [UPDATER]   Target version successfully installed. target_version:16.4.7 agent/updater.go:676
2024-12-04T06:38:05Z INFO [UPDATER]   Gracefully reloaded. unit:teleport.service agent/process.go:110
2024-12-04T06:38:05Z INFO [UPDATER]   Monitoring PID file to detect crashes. unit:teleport.service agent/process.go:113
2024-12-04T06:38:19Z INFO [UPDATER]   Configuration updated. agent/updater.go:320
```

---

The `teleport-update` binary will be used to enable, disable, and trigger automatic Teleport agent updates. The new auto-updates system manages a local installation of the cluster-specified version of Teleport stored in `/opt/teleport`.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/10289
