### PR TITLE
[v17] chore: Bump Go to v1.23.4

### DIFF
--- a/build.assets/tooling/go.mod
+++ b/build.assets/tooling/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/build.assets/tooling
 
-go 1.23.3
+go 1.23.4
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -3,7 +3,7 @@
 # Keep versions in sync with devbox.json, when applicable.
 
 # Sync with devbox.json.
-GOLANG_VERSION ?= go1.23.3
+GOLANG_VERSION ?= go1.23.4
 GOLANGCI_LINT_VERSION ?= v1.61.0
 
 NODE_VERSION ?= 20.18.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport
 
-go 1.23.3
+go 1.23.4
 
 require (
 	cloud.google.com/go/cloudsqlconn v1.12.1

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/event-handler
 
-go 1.23.3
+go 1.23.4
 
 require (
 	github.com/alecthomas/kong v1.2.1

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/terraform
 
-go 1.23.3
+go 1.23.4
 
 // Doc generation tooling
 require github.com/hashicorp/terraform-plugin-docs v0.0.0 // replaced


### PR DESCRIPTION
Update Go to the latest patch.

* https://go.dev/doc/devel/release#go1.23.4

Changelog: Updated Go to 1.23.4