### PR TITLE
[v15] chore: Bump Go to v1.22.10

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -3,7 +3,7 @@
 # Keep versions in sync with devbox.json, when applicable.
 
 # Sync with devbox.json.
-GOLANG_VERSION ?= go1.22.9
+GOLANG_VERSION ?= go1.22.10
 GOLANGCI_LINT_VERSION ?= v1.61.0
 
 NODE_VERSION ?= 20.18.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/gravitational/teleport
 
 go 1.21
 
-toolchain go1.22.9
+toolchain go1.22.10
 
 require (
 	cloud.google.com/go/cloudsqlconn v1.9.0

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -2,7 +2,7 @@ module github.com/gravitational/teleport/integrations/event-handler
 
 go 1.21
 
-toolchain go1.22.9
+toolchain go1.22.10
 
 require (
 	github.com/alecthomas/kong v0.9.0

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -2,7 +2,7 @@ module github.com/gravitational/teleport/integrations/terraform
 
 go 1.21
 
-toolchain go1.22.9
+toolchain go1.22.10
 
 require (
 	github.com/gogo/protobuf v1.3.2


### PR DESCRIPTION
Update Go to the latest patch.

* https://go.dev/doc/devel/release#go1.22.10

Changelog: Updated Go to 1.22.10