### PR TITLE
Add audience for teleport-proxy kubernetes service account token in teleport-cluster chart

### DIFF
--- a/examples/chart/teleport-cluster/templates/proxy/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/deployment.yaml
@@ -289,6 +289,7 @@ spec:
           sources:
             - serviceAccountToken:
                 path: token
+                audience: {{ $proxy.clusterName }}
             - configMap:
                 items:
                 - key: ca.crt

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
@@ -115,6 +115,7 @@ sets clusterDomain on Deployment Pods:
               sources:
               - serviceAccountToken:
                   path: token
+                  audience: helm-lint
               - configMap:
                   items:
                   - key: ca.crt
@@ -275,6 +276,7 @@ should set nodeSelector when set in values:
         sources:
         - serviceAccountToken:
             path: token
+            audience: helm-lint
         - configMap:
             items:
             - key: ca.crt
@@ -398,6 +400,7 @@ should set resources for wait-auth-update initContainer when set in values:
         sources:
         - serviceAccountToken:
             path: token
+            audience: helm-lint
         - configMap:
             items:
             - key: ca.crt
@@ -506,6 +509,7 @@ should set resources when set in values:
         sources:
         - serviceAccountToken:
             path: token
+            audience: helm-lint
         - configMap:
             items:
             - key: ca.crt
@@ -614,6 +618,7 @@ should set securityContext for initContainers when set in values:
         sources:
         - serviceAccountToken:
             path: token
+            audience: helm-lint
         - configMap:
             items:
             - key: ca.crt
@@ -722,6 +727,7 @@ should set securityContext when set in values:
         sources:
         - serviceAccountToken:
             path: token
+            audience: helm-lint
         - configMap:
             items:
             - key: ca.crt

--- a/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
@@ -935,6 +935,7 @@ tests:
               sources:
                 - serviceAccountToken:
                     path: token
+                    audience: helm-lint
                 - configMap:
                     items:
                       - key: ca.crt
@@ -971,6 +972,7 @@ tests:
               sources:
                 - serviceAccountToken:
                     path: token
+                    audience: helm-lint
                 - configMap:
                     items:
                       - key: ca.crt


### PR DESCRIPTION
After [backporting](https://github.com/gravitational/teleport/pull/49556) changes that allow the kubernetes in-cluster joining mechanism to use tokens with the `clusterName` specified in the `audience`, authorization for `teleport-proxy` in GKE (Google Cloud Kubernetes Engine) clusters breaks.

This happens because the `TokenReview` request now includes an `audience` that contains both `https://kubernetes.default.svc` and `clusterName`. However, in GKE, the [default audience](https://cloud.google.com/blog/products/containers-kubernetes/kubernetes-bound-service-account-tokens) for ServiceAccount tokens is `https://container.googleapis.com/v1/projects/PROJECT/locations/LOCATION/clusters/NAME`. As a result, `teleport-auth` rejects the token from `teleport-proxy`.

Fixes #49756