### PR TITLE
Updating OS Package metadata: license and description

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -600,6 +600,7 @@ build-archive: | $(RELEASE_DIR)
 		"$(INSTALL_SCRIPT)" \
 		README.md \
 		CHANGELOG.md \
+		build.assets/LICENSE-community \
 		teleport/
 	echo $(GITTAG) > teleport/VERSION
 	tar $(TAR_FLAGS) -c teleport | gzip -n > $(RELEASE).tar.gz

--- a/build.assets/build-package.sh
+++ b/build.assets/build-package.sh
@@ -74,7 +74,7 @@ FPM_IMAGE_RPM="public.ecr.aws/gravitational/fpm:centos8-1.15.1-1"
 
 # extra package information for linux
 MAINTAINER="info@goteleport.com"
-LICENSE="AGPL-3.0-or-later"
+LICENSE=""
 VENDOR="Gravitational"
 DESCRIPTION="Teleport provides on-demand, least-privileged access to your infrastructure, on a foundation of cryptographic identity and zero trust, with built-in identity and policy governance"
 DOCS_URL="https://goteleport.com/docs"
@@ -195,6 +195,7 @@ if [[ "${TELEPORT_TYPE}" == "ent" ]]; then
         TYPE_DESCRIPTION="[${TEXT_ARCH} Enterprise edition]"
     fi
 else
+    LICENSE="Teleport Community Edition License"
     TARBALL_FILENAME="teleport-v${TELEPORT_VERSION}-${PLATFORM}-${TARBALL_ARCH}${OPTIONAL_TARBALL_SECTION}${OPTIONAL_RUNTIME_SECTION}-bin.tar.gz"
     TAR_PATH="teleport"
     RPM_NAME="teleport"
@@ -204,6 +205,7 @@ else
     else
         TYPE_DESCRIPTION="[${TEXT_ARCH} Open source edition]"
     fi
+    TYPE_DESCRIPTION="${TYPE_DESCRIPTION}\n\nDistributed under the ${LICENSE}"
 fi
 
 # set file list

--- a/build.assets/build-package.sh
+++ b/build.assets/build-package.sh
@@ -74,9 +74,9 @@ FPM_IMAGE_RPM="public.ecr.aws/gravitational/fpm:centos8-1.15.1-1"
 
 # extra package information for linux
 MAINTAINER="info@goteleport.com"
-LICENSE="Apache-2.0"
+LICENSE="AGPL-3.0-or-later"
 VENDOR="Gravitational"
-DESCRIPTION="Teleport is a gateway for managing access to clusters of Linux servers via SSH or the Kubernetes API"
+DESCRIPTION="Teleport provides on-demand, least-privileged access to your infrastructure, on a foundation of cryptographic identity and zero trust, with built-in identity and policy governance"
 DOCS_URL="https://goteleport.com/docs"
 
 # check that curl is installed

--- a/build.assets/build-package.sh
+++ b/build.assets/build-package.sh
@@ -194,6 +194,7 @@ if [[ "${TELEPORT_TYPE}" == "ent" ]]; then
     else
         TYPE_DESCRIPTION="[${TEXT_ARCH} Enterprise edition]"
     fi
+    LICENSE_STANZA=()
 else
     TARBALL_FILENAME="teleport-v${TELEPORT_VERSION}-${PLATFORM}-${TARBALL_ARCH}${OPTIONAL_TARBALL_SECTION}${OPTIONAL_RUNTIME_SECTION}-bin.tar.gz"
     TAR_PATH="teleport"
@@ -204,7 +205,8 @@ else
     else
         TYPE_DESCRIPTION="[${TEXT_ARCH} Open source edition]"
     fi
-    TYPE_DESCRIPTION="${TYPE_DESCRIPTION}\n\nDistributed under the ${LICENSE}"
+    TYPE_DESCRIPTION="${TYPE_DESCRIPTION} Distributed under the ${LICENSE}"
+    LICENSE_STANZA=(--license "${LICENSE}")
 fi
 
 # set file list
@@ -255,7 +257,6 @@ else
         OUTPUT_FILENAME="${TAR_PATH}_${TELEPORT_VERSION}${OPTIONAL_RUNTIME_SECTION}_${DEB_OUTPUT_ARCH}.deb"
         FILE_PERMISSIONS_STANZA="--deb-user root --deb-group root "
     fi
-    LICENSE_STANZA=(--license "${LICENSE}")
 fi
 
 # create a temporary directory and download specified Teleport version

--- a/build.assets/build-package.sh
+++ b/build.assets/build-package.sh
@@ -74,7 +74,7 @@ FPM_IMAGE_RPM="public.ecr.aws/gravitational/fpm:centos8-1.15.1-1"
 
 # extra package information for linux
 MAINTAINER="info@goteleport.com"
-LICENSE=""
+LICENSE="Teleport Community Edition License"
 VENDOR="Gravitational"
 DESCRIPTION="Teleport provides on-demand, least-privileged access to your infrastructure, on a foundation of cryptographic identity and zero trust, with built-in identity and policy governance"
 DOCS_URL="https://goteleport.com/docs"
@@ -256,6 +256,7 @@ else
         OUTPUT_FILENAME="${TAR_PATH}_${TELEPORT_VERSION}${OPTIONAL_RUNTIME_SECTION}_${DEB_OUTPUT_ARCH}.deb"
         FILE_PERMISSIONS_STANZA="--deb-user root --deb-group root "
     fi
+    LICENSE_STANZA=(--license "${LICENSE}")
 fi
 
 # create a temporary directory and download specified Teleport version
@@ -361,7 +362,6 @@ else
         --version "${TELEPORT_VERSION}" \
         --maintainer "${MAINTAINER}" \
         --url "${DOCS_URL}" \
-        --license "${LICENSE}" \
         --vendor "${VENDOR}" \
         --description "${DESCRIPTION} ${TYPE_DESCRIPTION}" \
         --architecture ${PACKAGE_ARCH} \
@@ -374,6 +374,7 @@ else
         --after-upgrade /src/post-upgrade \
         ${CONFIG_FILE_STANZA} \
         ${FILE_PERMISSIONS_STANZA} \
+        "${LICENSE_STANZA[@]}" \
         ${RPM_SIGN_STANZA} .
 
     # copy created package back to current directory

--- a/build.assets/build-package.sh
+++ b/build.assets/build-package.sh
@@ -195,7 +195,6 @@ if [[ "${TELEPORT_TYPE}" == "ent" ]]; then
         TYPE_DESCRIPTION="[${TEXT_ARCH} Enterprise edition]"
     fi
 else
-    LICENSE="Teleport Community Edition License"
     TARBALL_FILENAME="teleport-v${TELEPORT_VERSION}-${PLATFORM}-${TARBALL_ARCH}${OPTIONAL_TARBALL_SECTION}${OPTIONAL_RUNTIME_SECTION}-bin.tar.gz"
     TAR_PATH="teleport"
     RPM_NAME="teleport"


### PR DESCRIPTION
Updates our OS packages (.rpm, .deb, etc) metadata to be up-to-date. Previous to this change it contained out-of-date information for our license and description.

changelog: Our OSS OS packages (rpm, deb, etc) now have up-to-date metadata.