### PR TITLE
Adding actions:write to cla assistant workflow

### DIFF
--- a/.github/workflows/cla-assistant.yaml
+++ b/.github/workflows/cla-assistant.yaml
@@ -9,7 +9,7 @@ on:
       - synchronize # Run on any diff changes to the PR (e.g. code updates)
 # explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
 permissions:
-  actions: read
+  actions: write # needed so that issue comments can rerun status check
   contents: read # this can be 'read' if the signatures are in remote repository
   pull-requests: write
 jobs:


### PR DESCRIPTION
CLA Assistant will rerun itself on issue comments and therefore needs actions:write permissions. This is because jobs from pull request comments (which are issue comments) are not considered for status checks. This will allow it to rerun the previously failed job.