### PR TITLE
Correct Vale lint errors in partials

### DIFF
--- a/docs/pages/includes/application-access/aws-database-prerequisites.mdx
+++ b/docs/pages/includes/application-access/aws-database-prerequisites.mdx
@@ -14,6 +14,6 @@ If you have not yet deployed the Auth Service and Proxy Service, you should foll
 
 We will assume your Teleport cluster is accessible at `teleport.example.com` and `*.teleport.example.com`. You can substitute the address of your Teleport Proxy Service. (For Teleport Cloud customers, this will be similar to `mytenant.teleport.sh`.)
 
-<Admonition type="note" title="Application Access and DNS" scope={["oss", "enterprise"]} scopeOnly>
+<Admonition type="note" title="DNS and Teleport-protected applications" scope={["oss", "enterprise"]} scopeOnly>
 (!docs/pages/includes/dns-app-access.mdx!)
 </Admonition>

--- a/docs/pages/includes/database-access/azure-configure-service-principal.mdx
+++ b/docs/pages/includes/database-access/azure-configure-service-principal.mdx
@@ -4,10 +4,10 @@ resources:
 - The Database Service can run on an Azure VM with attached managed identity. This
   is the recommended way of deploying the Database Service in production since
   it eliminates the need to manage Azure credentials.
-- The Database Service can be registered as an Azure AD application (via AD's "App
-  registrations") and configured with its credentials. This is only recommended
-  for development and testing purposes since it requires Azure credentials to
-  be present in the Database Service's environment.
+- The Database Service can be registered as a Microsoft Entra ID application
+  (via "App registrations") and configured with its credentials. This is only
+  recommended for development and testing purposes since it requires Azure
+  credentials to be present in the Database Service's environment.
 
 <Tabs>
 <TabItem label="Using managed identity">
@@ -35,14 +35,15 @@ resources:
 </TabItem>
 <TabItem label="Using app registrations">
   <Admonition type="note">
-    Registering the Database Service as Azure AD application is suitable for
-    test and development scenarios, or if your Database Service does not run on
-    an Azure VM. For production scenarios prefer to use the managed identity
+    Registering the Database Service as a Microsoft Entra ID application is
+    suitable for test and development scenarios, or if your Database Service
+    does not run on an Azure VM. For production scenarios prefer to use the
+    managed identity
     approach.
   </Admonition>
 
   Go to the [App registrations](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/RegisteredApps)
-  page of your Azure Active Directory and click on *New registration*:
+  page of Microsoft Entra ID and click on *New registration*:
 
   ![App registrations](../../../img/azure/app-registrations@2x.png)
 

--- a/docs/pages/includes/database-access/db-helm-install.mdx
+++ b/docs/pages/includes/database-access/db-helm-install.mdx
@@ -42,7 +42,7 @@ $ helm install teleport-kube-agent teleport/teleport-kube-agent \
 </TabItem>
 </Tabs>
 
-Make sure that the Teleport agent pod is running. You should see one
+Make sure that the Teleport Agent pod is running. You should see one
 `teleport-kube-agent` pod with a single ready container:
 
 ```code

--- a/docs/pages/includes/database-access/self-hosted-db-helm-install.mdx
+++ b/docs/pages/includes/database-access/self-hosted-db-helm-install.mdx
@@ -1,5 +1,5 @@
 {{ dbName="test" }}
-Install a Teleport agent into your Kubernetes Cluster with the Teleport Database
+Install a Teleport Agent into your Kubernetes Cluster with the Teleport Database
 Service configuration. 
 
 Create a file called `values.yaml` with the following content. Update <Var
@@ -68,7 +68,7 @@ To configure the Teleport Database Service to trust a custom CA:
      -f values.yaml
    ```
 
-1. Make sure that the Teleport agent pod is running. You should see one
+1. Make sure that the Teleport Agent pod is running. You should see one
 `teleport-kube-agent` pod with a single ready container:
 
    ```code

--- a/docs/pages/includes/database-access/sql-server-connect-note.mdx
+++ b/docs/pages/includes/database-access/sql-server-connect-note.mdx
@@ -11,6 +11,6 @@ your SQL Server client:
 $ tsh proxy db --db-user=teleport --tunnel sqlserver
 ```
 
-Read the [Database Access GUI Clients](../../connect-your-client/gui-clients.mdx#sql-server-with-azure-data-studio) 
+Read the [Database GUI Clients](../../connect-your-client/gui-clients.mdx#sql-server-with-azure-data-studio) 
 guide for how to connect your DB GUI client to the local proxy.
 </Admonition>

--- a/docs/pages/includes/device-trust/support-notice.mdx
+++ b/docs/pages/includes/device-trust/support-notice.mdx
@@ -2,7 +2,7 @@
   Device Trust supports all platforms and clients, including `tsh`, Teleport
   Connect and the Web UI (requires Teleport Connect to be installed).
 
-  The following resources are protected by device trust:
+  The following resources are protected by Device Trust:
 
   - Role-based enforcement only: Apps and Desktops
   - Cluster and role-based enforcement: SSH nodes, databases, and Kubernetes

--- a/docs/pages/includes/device-trust/troubleshooting.mdx
+++ b/docs/pages/includes/device-trust/troubleshooting.mdx
@@ -77,7 +77,7 @@ follow the steps below:
    URL handler).
 3. Make sure Teleport Connect can access the same resource you are trying to
    access on the Web
-4. Ask your cluster administrator if device trust is enabled (cluster mode
+4. Ask your cluster administrator if Device Trust is enabled (cluster mode
    "optional" or higher)
 
 After the steps above are done try logging out from the Web UI and logging in

--- a/docs/pages/includes/discovery/database-service-troubleshooting.mdx
+++ b/docs/pages/includes/discovery/database-service-troubleshooting.mdx
@@ -63,9 +63,9 @@ and then try the connection again.
 Check the Teleport Database Service logs with DEBUG level logging enabled and
 look for network or permissions errors.
 
-Refer to
-[Troubleshooting Database Access](../../enroll-resources/database-access/troubleshooting.mdx)
-for more general troubleshooting steps.
+Refer to the [Database Service troubleshooting
+guide](../../enroll-resources/database-access/troubleshooting.mdx) for more
+general troubleshooting steps.
 
 Additionally, a guide specific to the type of database in
 [Enroll AWS Databases](../../enroll-resources/database-access/enroll-aws-databases/enroll-aws-databases.mdx).

--- a/docs/pages/includes/edition-comparison.mdx
+++ b/docs/pages/includes/edition-comparison.mdx
@@ -45,12 +45,12 @@ _Available as an add-on to Teleport Enterprise_
 ||Community Edition|Enterprise|Cloud|
 |---|---|---|---|
 |Agentless Integration with [OpenSSH Servers](../enroll-resources/server-access/openssh/openssh-agentless.mdx)|✔|✔|✔|
-|[Application Access](../enroll-resources/application-access/getting-started.mdx)|✔|✔|✔|
-|[Database Access](../enroll-resources/database-access/getting-started.mdx)|✔|✔|✔|
-|[Desktop Access](../enroll-resources/desktop-access/introduction.mdx)|✔|✔|✔|
-|[Kubernetes Access](../enroll-resources/kubernetes-access/getting-started.mdx)|✔|✔|✔|
+|[Protecting Applications](../enroll-resources/application-access/getting-started.mdx)|✔|✔|✔|
+|[Protecting Databases](../enroll-resources/database-access/getting-started.mdx)|✔|✔|✔|
+|[Protecting Windows Desktops](../enroll-resources/desktop-access/introduction.mdx)|✔|✔|✔|
+|[Protecting Kubernetes Clusters](../enroll-resources/kubernetes-access/getting-started.mdx)|✔|✔|✔|
 |[Machine ID](../enroll-resources/machine-id/getting-started.mdx)|✔|✔|✔|
-|[Server Access](../enroll-resources/server-access/getting-started.mdx)|✔|✔|✔|
+|[Protecting Linux Servers](../enroll-resources/server-access/getting-started.mdx)|✔|✔|✔|
 
 ### Licensing and usage management
 

--- a/docs/pages/includes/enterprise/hsm-warning.mdx
+++ b/docs/pages/includes/enterprise/hsm-warning.mdx
@@ -1,5 +1,5 @@
 <Admonition type="warning" opened={true} scopeOnly={true} title="Compatibility Warning">
-Teleport Cloud and Teleport Open Source do not currently support HSMs or 
+Teleport Cloud and Teleport Community Edition do not currently support HSMs or 
 Key Management Services.
 
 </Admonition>

--- a/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
@@ -77,7 +77,7 @@ roles `App` and `Kube`.
 
 ## `joinParams`
 
-`joinParams` controls how the Teleport agent joins the Teleport cluster.
+`joinParams` controls how the Teleport Agent joins the Teleport cluster.
 These sub-values must be configured for the agent to connect to a cluster.
 
 This value serves the same purpose as [`authToken`](#authToken) but supports
@@ -131,7 +131,7 @@ is provided through an existing Kubernetes Secret, see
 | `string` | `""` |
 
 `kubeClusterName` sets the name used for the Kubernetes cluster proxied by
-the Teleport agent. This name will be shown to Teleport users connecting to
+the Teleport Agent. This name will be shown to Teleport users connecting to
 the cluster.
 
 This setting is required if the chart `roles` contains `kube`.
@@ -372,7 +372,7 @@ databases:
 ```
 
 <Admonition type="tip" title="Supported values">
-  You can see a list of all the supported [values which can be used in a Teleport database service configuration here](../../reference/agent-services/database-access-reference/configuration.mdx).
+  You can see a list of all the supported [values which can be used in a Teleport Database Service configuration here](../../reference/agent-services/database-access-reference/configuration.mdx).
 </Admonition>
 
 <Admonition type="tip" title="Trusting Database CA">
@@ -917,7 +917,7 @@ labels:
 ## `highAvailability`
 
 `highAvailability` contains settings controlling the availability of the
-Teleport agent deployed by the chart.
+Teleport Agent deployed by the chart.
 
 The availability can be increased by:
 - running more replicas with `replicaCount`
@@ -1112,24 +1112,25 @@ cluster role binding.
 |------|---------|
 | `string` | `"public.ecr.aws/gravitational/teleport-distroless"` |
 
-`image` sets the container image used for Teleport OSS agent pods
-created by the chart.
+`image` sets the container image used for Teleport Community Edition
+Agent pods created by the chart.
 
-You can override this to use your own Teleport image rather than a Teleport-published image.
+You can override this to use your own Teleport image rather than a
+Teleport-published image.
 
 <Admonition type="warning" title="Interaction with Teleport Kube Agent Updater">
-  When using the Teleport Kube Agent Updater, you must ensure the image is
-  available before the updater version target gets updated and Kubernetes tries
-  to pull the image.
+When using the Teleport Kube Agent Updater, you must ensure the
+image is available before the updater version target gets updated and
+Kubernetes tries to pull the image.
 
-  For this reason, it is strongly discouraged to set a custom image when
-  using automatic updates. Teleport Cloud uses automatic updates by default.
+For this reason, it is strongly discouraged to set a custom image when using
+automatic updates. Teleport Cloud uses automatic updates by default.
 </Admonition>
 
-Since version 13, hardened distroless images are used by default.
-You can use the deprecated debian-based images by setting the value to
-`public.ecr.aws/gravitational/teleport`. Those images will be
-removed with teleport 15.
+Since version 13, hardened distroless images are used by default.  You can use
+the deprecated debian-based images by setting the value to
+`public.ecr.aws/gravitational/teleport`. Those images will be removed with
+teleport 15.
 
 This setting only takes effect when [`enterprise`](#enterprise) is `false`.
 When running an enterprise version, you must use

--- a/docs/pages/includes/helm-reference/zz_generated.teleport-operator.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.teleport-operator.mdx
@@ -52,8 +52,8 @@ For example:
 | `list[string]` | `[]` |
 
 `caPins` is a list of Teleport CA fingerprints that is used by the operator to
-validate the identity of the Teleport Auth server. This is only used when joining
-an Auth server directly (on port `3025`) and is ignored when joining through a Proxy
+validate the identity of the Teleport Auth Service. This is only used when joining
+an Auth Service directly (on port `3025`) and is ignored when joining through a Proxy
 (port `443` or `3080`).
 
 ## `joinMethod`

--- a/docs/pages/includes/kubernetes-access/helm/teleport-cluster-cloud-warning.mdx
+++ b/docs/pages/includes/kubernetes-access/helm/teleport-cluster-cloud-warning.mdx
@@ -3,9 +3,10 @@ intended to help you get started with Teleport by deploying the Auth Service and
 Proxy Service in a Kubernetes cluster so you can access that cluster via the
 Kubernetes Service.
 
-Since the Auth and Proxy Services are fully managed in Teleport Cloud, you should
-install our `teleport-kube-agent` chart, which is intended for deployments where
-the Auth Service and Proxy Service run outside your Kubernetes cluster.
+Since the Auth Service and Proxy Service are fully managed in Teleport Cloud,
+you should install our `teleport-kube-agent` chart, which is intended for
+deployments where the Auth Service and Proxy Service run outside your Kubernetes
+cluster.
 
 You can use the `teleport-kube-agent` chart to enable the Application Service
 and Database Service in addition to the Kubernetes Service.

--- a/docs/pages/includes/metrics.mdx
+++ b/docs/pages/includes/metrics.mdx
@@ -133,10 +133,10 @@
 | `teleport_db_connection_setup_time_seconds` | histogram | Teleport Database Service | Initial time to setup DB connection, before any requests are handled.  |
 | `teleport_db_errors_total`                  | counter   | Teleport Database Service | Number of synthetic DB errors sent to the client.                      |
 
-### Kubernetes Access
+### Kubernetes access
 
-The following tables identify all metrics available in the proxy service if
-Kubernetes access is enabled.
+The following tables identify all metrics available in the Teleport Proxy
+Service if at least one Kubernetes cluster is enrolled in your Teleport cluster.
 
 #### Client
 

--- a/docs/pages/includes/permission-warning.mdx
+++ b/docs/pages/includes/permission-warning.mdx
@@ -14,7 +14,7 @@
     For example, don't assign users the built-in `access,editor` roles, which give
     them permissions to access and edit all cluster resources. Instead, define roles 
     with the minimum required permissions for each user and configure
-    **access requests** to provide temporary elevated permissions.
+    **Access Requests** to provide temporary elevated permissions.
   - When you enroll Teleport resources—for example, new databases or applications—you 
     should save the invitation token to a file.
     If you enter the token directly on the command line, a malicious user could view

--- a/docs/pages/includes/soc2.mdx
+++ b/docs/pages/includes/soc2.mdx
@@ -2,7 +2,7 @@ We undergo an annual SOC 2 Type II audit of the Teleport Access Platform.
 
 The audit report covers:
 
-- Teleport Open Source
+- Teleport Community Edition
 - Teleport Enterprise, self-hosted
 - Teleport Enterprise, cloud-hosted (SaaS)
 

--- a/examples/chart/teleport-cluster/charts/teleport-operator/values.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/values.yaml
@@ -28,8 +28,8 @@ installCRDs: "dynamic"
 teleportAddress: ""
 
 # caPins(list[string]) -- is a list of Teleport CA fingerprints that is used by the operator to
-# validate the identity of the Teleport Auth server. This is only used when joining
-# an Auth server directly (on port `3025`) and is ignored when joining through a Proxy
+# validate the identity of the Teleport Auth Service. This is only used when joining
+# an Auth Service directly (on port `3025`) and is ignored when joining through a Proxy
 # (port `443` or `3080`).
 caPins: []
 

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -56,7 +56,7 @@ enterprise: false
 # roles `App` and `Kube`.
 authToken: ""
 
-# joinParams -- controls how the Teleport agent joins the Teleport cluster.
+# joinParams -- controls how the Teleport Agent joins the Teleport cluster.
 # These sub-values must be configured for the agent to connect to a cluster.
 #
 # This value serves the same purpose as [`authToken`](#authToken) but supports
@@ -98,7 +98,7 @@ joinParams:
 ################################################################
 
 # kubeClusterName(string) -- sets the name used for the Kubernetes cluster proxied by
-# the Teleport agent. This name will be shown to Teleport users connecting to
+# the Teleport Agent. This name will be shown to Teleport users connecting to
 # the cluster.
 #
 # This setting is required if the chart `roles` contains `kube`.
@@ -320,7 +320,7 @@ azureDatabases: []
 # ```
 #
 # <Admonition type="tip" title="Supported values">
-#   You can see a list of all the supported [values which can be used in a Teleport database service configuration here](../../reference/agent-services/database-access-reference/configuration.mdx).
+#   You can see a list of all the supported [values which can be used in a Teleport Database Service configuration here](../../reference/agent-services/database-access-reference/configuration.mdx).
 # </Admonition>
 #
 # <Admonition type="tip" title="Trusting Database CA">
@@ -748,7 +748,7 @@ podSecurityPolicy:
 labels: {}
 
 # highAvailability -- contains settings controlling the availability of the
-# Teleport agent deployed by the chart.
+# Teleport Agent deployed by the chart.
 #
 # The availability can be increased by:
 # - running more replicas with `replicaCount`
@@ -876,24 +876,25 @@ adminClusterRoleBinding:
 # Values that you shouldn't need to change.
 ################################################################
 
-# image(string) -- sets the container image used for Teleport OSS agent pods
-# created by the chart.
+# image(string) -- sets the container image used for Teleport Community Edition
+# Agent pods created by the chart.
 #
-# You can override this to use your own Teleport image rather than a Teleport-published image.
+# You can override this to use your own Teleport image rather than a
+# Teleport-published image.
 #
-# <Admonition type="warning" title="Interaction with Teleport Kube Agent Updater">
-#   When using the Teleport Kube Agent Updater, you must ensure the image is
-#   available before the updater version target gets updated and Kubernetes tries
-#   to pull the image.
+# <Admonition type="warning" title="Interaction with Teleport Kube Agent Updater"> 
+# When using the Teleport Kube Agent Updater, you must ensure the
+# image is available before the updater version target gets updated and
+# Kubernetes tries to pull the image.
 #
-#   For this reason, it is strongly discouraged to set a custom image when
-#   using automatic updates. Teleport Cloud uses automatic updates by default.
+# For this reason, it is strongly discouraged to set a custom image when using
+# automatic updates. Teleport Cloud uses automatic updates by default.
 # </Admonition>
 #
-# Since version 13, hardened distroless images are used by default.
-# You can use the deprecated debian-based images by setting the value to
-# `public.ecr.aws/gravitational/teleport`. Those images will be
-# removed with teleport 15.
+# Since version 13, hardened distroless images are used by default.  You can use
+# the deprecated debian-based images by setting the value to
+# `public.ecr.aws/gravitational/teleport`. Those images will be removed with
+# teleport 15.
 #
 # This setting only takes effect when [`enterprise`](#enterprise) is `false`.
 # When running an enterprise version, you must use


### PR DESCRIPTION
One edge case is the `structure.architecture-h2` warning in `docs/pages/includes/database-access/rds-proxy.mdx`. This is technically correct, since the "How it works" section is before the "Prerequisites" section. We can determine whether this is a bug to fix in a separate change.