### PR TITLE
disable spanner client metrics in tests

### DIFF
--- a/lib/srv/db/spanner/test.go
+++ b/lib/srv/db/spanner/test.go
@@ -105,7 +105,8 @@ func makeTestClient(ctx context.Context, config common.TestClientConfig, useTLS 
 	}
 
 	clientCfg := spanner.ClientConfig{
-		SessionPoolConfig: spanner.DefaultSessionPoolConfig,
+		DisableNativeMetrics: true,
+		SessionPoolConfig:    spanner.DefaultSessionPoolConfig,
 	}
 	clt, err := spanner.NewClientWithConfig(ctx, databaseID, clientCfg, opts...)
 	if err != nil {


### PR DESCRIPTION
This PR is to unblock the version bump https://github.com/gravitational/teleport/pull/49767
- https://github.com/gravitational/teleport/pull/49767

For context, the "metrics" here in the newer version of the spanner client attempt to load application default credentials even though the test configured insecure test credentials.
The workaround is just to disable these metrics in tests.

I tested against a real spanner instance as well (using the latest spanner client version)  to be sure that we don't need any changes outside of test code.
(in a real deployment you have to actually provide application default credentials anyway)

edit: I'll just add this to the version bump, since this field doesn't exist in the older version of the client.