### PR TITLE
[teleport-update] update --now

### DIFF
--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_enabled_now.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_enabled_now.golden
@@ -1,0 +1,13 @@
+version: v1
+kind: update_config
+spec:
+    proxy: localhost
+    group: group
+    url_template: https://example.com
+    enabled: true
+    pinned: false
+status:
+    active:
+        version: 16.3.0
+    backup:
+        version: old-version

--- a/lib/autoupdate/agent/updater_test.go
+++ b/lib/autoupdate/agent/updater_test.go
@@ -223,6 +223,7 @@ func TestUpdater_Update(t *testing.T) {
 		cfg        *UpdateConfig // nil -> file not present
 		flags      InstallFlags
 		inWindow   bool
+		now        bool
 		installErr error
 		setupErr   error
 		reloadErr  error
@@ -252,6 +253,30 @@ func TestUpdater_Update(t *testing.T) {
 				},
 			},
 			inWindow: true,
+
+			removedRevisions:  []Revision{NewRevision("unknown-version", 0)},
+			installedRevision: NewRevision("16.3.0", 0),
+			installedTemplate: "https://example.com",
+			linkedRevision:    NewRevision("16.3.0", 0),
+			requestGroup:      "group",
+			reloadCalls:       1,
+			setupCalls:        1,
+		},
+		{
+			name: "updates enabled now",
+			cfg: &UpdateConfig{
+				Version: updateConfigVersion,
+				Kind:    updateConfigKind,
+				Spec: UpdateSpec{
+					Group:       "group",
+					URLTemplate: "https://example.com",
+					Enabled:     true,
+				},
+				Status: UpdateStatus{
+					Active: NewRevision("old-version", 0),
+				},
+			},
+			now: true,
 
 			removedRevisions:  []Revision{NewRevision("unknown-version", 0)},
 			installedRevision: NewRevision("16.3.0", 0),
@@ -627,7 +652,7 @@ func TestUpdater_Update(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			err = updater.Update(ctx)
+			err = updater.Update(ctx, tt.now)
 			if tt.errMatch != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errMatch)

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -80,6 +80,8 @@ type cliConfig struct {
 	InstallSuffix string
 	// SelfSetup mode for using the current version of the teleport-update to setup the update service.
 	SelfSetup bool
+	// UpdateNow forces an immediate update.
+	UpdateNow bool
 }
 
 func Run(args []string) int {
@@ -136,6 +138,8 @@ func Run(args []string) int {
 	unpinCmd := app.Command("unpin", "Unpin the current version, allowing it to be updated.")
 
 	updateCmd := app.Command("update", "Update the agent to the latest version, if a new version is available.")
+	updateCmd.Flag("now", "Force immediate update even if update window is not active.").
+		Short('n').BoolVar(&ccfg.UpdateNow)
 	updateCmd.Flag("self-setup", "Use the current teleport-update binary to create systemd service config for auto-updates.").
 		Short('s').Hidden().BoolVar(&ccfg.SelfSetup)
 
@@ -345,7 +349,7 @@ func cmdUpdate(ctx context.Context, ccfg *cliConfig) error {
 		}
 	}()
 
-	if err := updater.Update(ctx); err != nil {
+	if err := updater.Update(ctx, ccfg.UpdateNow); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil


### PR DESCRIPTION
This PR adds a `--now` flag to the `teleport-update update` subcommand. This flag forces an update to the latest advertised agent version, even outside of an update window. It also skips jitter.

Perhaps confusingly, `teleport-update update --now` does not always update the agent to the latest version. If the upgrade window has not started yet, the agent version advertised by the proxy is the previous version of Teleport. This command may still be useful during and after a scheduled update window.

---

The `teleport-update` binary will be used to enable, disable, and trigger automatic Teleport agent updates. The new auto-updates system manages a local installation of the cluster-specified version of Teleport stored in `/opt/teleport`.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/10289
