### PR TITLE
Forbid custom namespaces in various resources

### DIFF
--- a/api/types/kubernetes_test.go
+++ b/api/types/kubernetes_test.go
@@ -30,7 +30,7 @@ func TestKubeClustersSorter(t *testing.T) {
 		servers := make([]KubeCluster, len(testVals))
 		for i := 0; i < len(testVals); i++ {
 			var err error
-			servers[i], err = NewKubernetesClusterV3FromLegacyCluster("_", &KubernetesCluster{
+			servers[i], err = NewKubernetesClusterV3FromLegacyCluster("", &KubernetesCluster{
 				Name: testVals[i],
 			})
 			require.NoError(t, err)

--- a/api/types/namespace.go
+++ b/api/types/namespace.go
@@ -143,3 +143,17 @@ func IsValidNamespace(s string) bool {
 }
 
 var validNamespace = regexp.MustCompile(`^[A-Za-z0-9]+$`)
+
+// ValidateNamespaceDefault ensures that the namespace is the "default"
+// namespace.
+// This is a precursor to a hard-removal of namespaces.
+func ValidateNamespaceDefault(ns string) error {
+	if ns == defaults.Namespace {
+		return nil
+	}
+
+	const message = "" +
+		"namespace %q invalid, custom namespaces are deprecated; " +
+		"the namespace field should be omitted or set to %q"
+	return trace.BadParameter(message, ns, defaults.Namespace)
+}

--- a/api/types/presence.go
+++ b/api/types/presence.go
@@ -70,6 +70,9 @@ func (s *KeepAlive) CheckAndSetDefaults() error {
 	if s.Namespace == "" {
 		s.Namespace = defaults.Namespace
 	}
+	if s.Namespace != defaults.Namespace {
+		return trace.BadParameter("namespace %q invalid, custom namespaces are deprecated", s.Namespace)
+	}
 
 	return nil
 }

--- a/api/types/presence.go
+++ b/api/types/presence.go
@@ -67,11 +67,12 @@ func (s *KeepAlive) CheckAndSetDefaults() error {
 	if s.IsEmpty() {
 		return trace.BadParameter("missing resource name")
 	}
+
 	if s.Namespace == "" {
 		s.Namespace = defaults.Namespace
 	}
-	if s.Namespace != defaults.Namespace {
-		return trace.BadParameter("namespace %q invalid, custom namespaces are deprecated", s.Namespace)
+	if err := ValidateNamespaceDefault(s.Namespace); err != nil {
+		return trace.Wrap(err)
 	}
 
 	return nil

--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -464,8 +464,14 @@ func (m *Metadata) CheckAndSetDefaults() error {
 	if m.Name == "" {
 		return trace.BadParameter("missing parameter Name")
 	}
-	if m.Namespace == "" {
+
+	switch m.Namespace {
+	case "":
 		m.Namespace = defaults.Namespace
+	case defaults.Namespace:
+		// OK, nothing to do.
+	default:
+		return trace.BadParameter("namespace %q invalid, custom namespaces are deprecated", m.Namespace)
 	}
 
 	// adjust expires time to UTC if it's set

--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -465,13 +465,11 @@ func (m *Metadata) CheckAndSetDefaults() error {
 		return trace.BadParameter("missing parameter Name")
 	}
 
-	switch m.Namespace {
-	case "":
+	if m.Namespace == "" {
 		m.Namespace = defaults.Namespace
-	case defaults.Namespace:
-		// OK, nothing to do.
-	default:
-		return trace.BadParameter("namespace %q invalid, custom namespaces are deprecated", m.Namespace)
+	}
+	if err := ValidateNamespaceDefault(m.Namespace); err != nil {
+		return trace.Wrap(err)
 	}
 
 	// adjust expires time to UTC if it's set

--- a/api/types/resource_test.go
+++ b/api/types/resource_test.go
@@ -266,7 +266,7 @@ func TestMatchSearch_ResourceSpecific(t *testing.T) {
 			name:               "kube cluster",
 			matchingSearchVals: []string{"foo", "prod", "env"},
 			newResource: func(t *testing.T) ResourceWithLabels {
-				kc, err := NewKubernetesClusterV3FromLegacyCluster("_", &KubernetesCluster{
+				kc, err := NewKubernetesClusterV3FromLegacyCluster("", &KubernetesCluster{
 					Name:         "foo",
 					StaticLabels: labels,
 				})

--- a/api/types/role.go
+++ b/api/types/role.go
@@ -1071,8 +1071,9 @@ func (r *RoleV6) CheckAndSetDefaults() error {
 	if len(r.Spec.Options.BPF) == 0 {
 		r.Spec.Options.BPF = defaults.EnhancedEvents()
 	}
-	if r.Spec.Allow.Namespaces == nil {
-		r.Spec.Allow.Namespaces = []string{defaults.Namespace}
+	if err := checkAndSetRoleConditionNamespaces(&r.Spec.Allow.Namespaces); err != nil {
+		// Using trace.BadParameter instead of trace.Wrap for a better error message.
+		return trace.BadParameter("allow: %s", err)
 	}
 	if r.Spec.Options.RecordSession == nil {
 		r.Spec.Options.RecordSession = &RecordSession{
@@ -1175,8 +1176,9 @@ func (r *RoleV6) CheckAndSetDefaults() error {
 		return trace.BadParameter("unrecognized role version: %v", r.Version)
 	}
 
-	if r.Spec.Deny.Namespaces == nil {
-		r.Spec.Deny.Namespaces = []string{defaults.Namespace}
+	if err := checkAndSetRoleConditionNamespaces(&r.Spec.Deny.Namespaces); err != nil {
+		// Using trace.BadParameter instead of trace.Wrap for a better error message.
+		return trace.BadParameter("deny: %s", err)
 	}
 
 	// Validate request.kubernetes_resources fields are all valid.
@@ -1316,6 +1318,23 @@ func (r *RoleV6) CheckAndSetDefaults() error {
 		}
 		if err := r.Spec.Deny.Impersonate.CheckAndSetDefaults(); err != nil {
 			return trace.Wrap(err)
+		}
+	}
+
+	return nil
+}
+
+func checkAndSetRoleConditionNamespaces(namespaces *[]string) error {
+	// If nil use the default.
+	// This distinguishes between nil and empty (in accordance to legacy code).
+	if *namespaces == nil {
+		*namespaces = []string{defaults.Namespace}
+		return nil
+	}
+
+	for i, ns := range *namespaces {
+		if ns != defaults.Namespace && ns != Wildcard {
+			return trace.BadParameter("namespaces[%d]: %q invalid: custom namespaces are deprecated", i, ns)
 		}
 	}
 

--- a/api/types/role.go
+++ b/api/types/role.go
@@ -1333,8 +1333,12 @@ func checkAndSetRoleConditionNamespaces(namespaces *[]string) error {
 	}
 
 	for i, ns := range *namespaces {
-		if ns != defaults.Namespace && ns != Wildcard {
-			return trace.BadParameter("namespaces[%d]: %q invalid: custom namespaces are deprecated", i, ns)
+		if ns == Wildcard {
+			continue // OK, wildcard is accepted.
+		}
+		if err := ValidateNamespaceDefault(ns); err != nil {
+			// Using trace.BadParameter instead of trace.Wrap for a better error message.
+			return trace.BadParameter("namespaces[%d]: %s", i, err)
 		}
 	}
 

--- a/lib/services/local/databaseservice.go
+++ b/lib/services/local/databaseservice.go
@@ -44,6 +44,10 @@ func (s *DatabaseServicesService) UpsertDatabaseService(ctx context.Context, ser
 	if err := services.CheckAndSetDefaults(service); err != nil {
 		return nil, trace.Wrap(err)
 	}
+	if err := validateNamespaceDefault(service.GetNamespace()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	rev := service.GetRevision()
 	value, err := services.MarshalDatabaseService(service)
 	if err != nil {

--- a/lib/services/local/databaseservice.go
+++ b/lib/services/local/databaseservice.go
@@ -44,7 +44,7 @@ func (s *DatabaseServicesService) UpsertDatabaseService(ctx context.Context, ser
 	if err := services.CheckAndSetDefaults(service); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err := validateNamespaceDefault(service.GetNamespace()); err != nil {
+	if err := types.ValidateNamespaceDefault(service.GetNamespace()); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -345,10 +345,10 @@ func (s *PresenceService) UpsertNode(ctx context.Context, server types.Server) (
 	if server.GetNamespace() == "" {
 		server.SetNamespace(apidefaults.Namespace)
 	}
-
-	if n := server.GetNamespace(); n != apidefaults.Namespace {
-		return nil, trace.BadParameter("cannot place node in namespace %q, custom namespaces are deprecated", n)
+	if err := validateNamespaceDefault(server.GetNamespace()); err != nil {
+		return nil, trace.Wrap(err)
 	}
+
 	rev := server.GetRevision()
 	value, err := services.MarshalServer(server)
 	if err != nil {
@@ -377,10 +377,10 @@ func (s *PresenceService) UpdateNode(ctx context.Context, server types.Server) (
 	if server.GetNamespace() == "" {
 		server.SetNamespace(apidefaults.Namespace)
 	}
-
-	if n := server.GetNamespace(); n != apidefaults.Namespace {
-		return nil, trace.BadParameter("cannot place node in namespace %q, custom namespaces are deprecated", n)
+	if err := validateNamespaceDefault(server.GetNamespace()); err != nil {
+		return nil, trace.Wrap(err)
 	}
+
 	rev := server.GetRevision()
 	value, err := services.MarshalServer(server)
 	if err != nil {
@@ -1003,6 +1003,10 @@ func (s *PresenceService) UpsertDatabaseServer(ctx context.Context, server types
 	if err := services.CheckAndSetDefaults(server); err != nil {
 		return nil, trace.Wrap(err)
 	}
+	if err := validateNamespaceDefault(server.GetNamespace()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	rev := server.GetRevision()
 	value, err := services.MarshalDatabaseServer(server)
 	if err != nil {
@@ -1096,6 +1100,10 @@ func (s *PresenceService) UpsertApplicationServer(ctx context.Context, server ty
 	if err := services.CheckAndSetDefaults(server); err != nil {
 		return nil, trace.Wrap(err)
 	}
+	if err := validateNamespaceDefault(server.GetNamespace()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	rev := server.GetRevision()
 	value, err := services.MarshalAppServer(server)
 	if err != nil {
@@ -1679,6 +1687,13 @@ func FakePaginate(resources []types.ResourceWithLabels, req FakePaginateParams) 
 		NextKey:    nextKey,
 		TotalCount: totalCount,
 	}, nil
+}
+
+func validateNamespaceDefault(ns string) error {
+	if ns == apidefaults.Namespace {
+		return nil
+	}
+	return trace.BadParameter("namespace %q invalid, custom namespaces are deprecated", ns)
 }
 
 // backendItemToDatabaseServer unmarshals `backend.Item` into a

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -345,7 +345,7 @@ func (s *PresenceService) UpsertNode(ctx context.Context, server types.Server) (
 	if server.GetNamespace() == "" {
 		server.SetNamespace(apidefaults.Namespace)
 	}
-	if err := validateNamespaceDefault(server.GetNamespace()); err != nil {
+	if err := types.ValidateNamespaceDefault(server.GetNamespace()); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -377,7 +377,7 @@ func (s *PresenceService) UpdateNode(ctx context.Context, server types.Server) (
 	if server.GetNamespace() == "" {
 		server.SetNamespace(apidefaults.Namespace)
 	}
-	if err := validateNamespaceDefault(server.GetNamespace()); err != nil {
+	if err := types.ValidateNamespaceDefault(server.GetNamespace()); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -1003,7 +1003,7 @@ func (s *PresenceService) UpsertDatabaseServer(ctx context.Context, server types
 	if err := services.CheckAndSetDefaults(server); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err := validateNamespaceDefault(server.GetNamespace()); err != nil {
+	if err := types.ValidateNamespaceDefault(server.GetNamespace()); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -1100,7 +1100,7 @@ func (s *PresenceService) UpsertApplicationServer(ctx context.Context, server ty
 	if err := services.CheckAndSetDefaults(server); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err := validateNamespaceDefault(server.GetNamespace()); err != nil {
+	if err := types.ValidateNamespaceDefault(server.GetNamespace()); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -1687,13 +1687,6 @@ func FakePaginate(resources []types.ResourceWithLabels, req FakePaginateParams) 
 		NextKey:    nextKey,
 		TotalCount: totalCount,
 	}, nil
-}
-
-func validateNamespaceDefault(ns string) error {
-	if ns == apidefaults.Namespace {
-		return nil
-	}
-	return trace.BadParameter("namespace %q invalid, custom namespaces are deprecated", ns)
 }
 
 // backendItemToDatabaseServer unmarshals `backend.Item` into a

--- a/lib/services/matchers_test.go
+++ b/lib/services/matchers_test.go
@@ -499,7 +499,7 @@ func TestMatchResourceByFilters(t *testing.T) {
 		{
 			name: "kube cluster",
 			resource: func() types.ResourceWithLabels {
-				cluster, err := types.NewKubernetesClusterV3FromLegacyCluster("_", &types.KubernetesCluster{
+				cluster, err := types.NewKubernetesClusterV3FromLegacyCluster("", &types.KubernetesCluster{
 					Name: "foo",
 				})
 				require.NoError(t, err)


### PR DESCRIPTION
Forbid the use of custom namespaces in various resources, akin to commit ae99259. Only "" or "default" (as in apidefaults.Namespace) are allowed.

Namespaces are a vestigial feature from olden Teleport times. It's largely deprecated/unused, but this PR gives us some extra confidence to eventually do a wider cleanup in the future.

(Note: this is not about k8s namespaces.)

#49509