### PR TITLE
[v17] [web] Include node name or k8s cluster for session started audit entry display

### DIFF
--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -505,7 +505,20 @@ export const formatters: Formatters = {
   [eventCodes.SESSION_START]: {
     type: 'session.start',
     desc: 'Session Started',
-    format: ({ user, sid }) => `User [${user}] has started a session [${sid}]`,
+    format: event => {
+      const user = event.user || '';
+      const node =
+        event.server_hostname || event.server_addr || event.server_id;
+
+      if (event.proto === 'kube') {
+        if (!event.kubernetes_cluster) {
+          return `User [${user}] has started a Kubernetes session [${event.sid}]`;
+        }
+        return `User [${user}] has started a session [${event.sid}] on Kubernetes cluster [${event.kubernetes_cluster}]`;
+      }
+
+      return `User [${user}] has started a session [${event.sid}] on node [${node}] `;
+    },
   },
   [eventCodes.SESSION_UPLOAD]: {
     type: 'session.upload',

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -507,8 +507,6 @@ export const formatters: Formatters = {
     desc: 'Session Started',
     format: event => {
       const user = event.user || '';
-      const node =
-        event.server_hostname || event.server_addr || event.server_id;
 
       if (event.proto === 'kube') {
         if (!event.kubernetes_cluster) {
@@ -517,6 +515,8 @@ export const formatters: Formatters = {
         return `User [${user}] has started a session [${event.sid}] on Kubernetes cluster [${event.kubernetes_cluster}]`;
       }
 
+      const node =
+        event.server_hostname || event.server_addr || event.server_id;
       return `User [${user}] has started a session [${event.sid}] on node [${node}] `;
     },
   },

--- a/web/packages/teleport/src/services/audit/types.ts
+++ b/web/packages/teleport/src/services/audit/types.ts
@@ -530,6 +530,11 @@ export type RawEvents = {
     typeof eventCodes.SESSION_START,
     {
       sid: string;
+      kubernetes_cluster: string;
+      proto: string;
+      server_hostname: string;
+      server_addr: string;
+      server_id: string;
     }
   >;
   [eventCodes.SESSION_REJECT]: RawEvent<


### PR DESCRIPTION
Backport #49479 to branch/v17

changelog: SSH or Kubernetes information included for audit log list for start session events
