### PR TITLE
[v15] [web] Include node name or k8s cluster for session started audit entry display

### DIFF
--- a/web/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
+++ b/web/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
@@ -12800,7 +12800,7 @@ exports[`list of all events 1`] = `
         <td
           style="word-break: break-word;"
         >
-          User [admin@example.com] has started a session [56408539-6536-11e9-80a1-427cfde50f5a]
+          User [admin@example.com] has started a session [56408539-6536-11e9-80a1-427cfde50f5a] on node [de3800ea-69d9-4d72-a108-97e57f8eb393]
         </td>
         <td
           style="min-width: 120px;"

--- a/web/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
+++ b/web/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
@@ -12800,7 +12800,7 @@ exports[`list of all events 1`] = `
         <td
           style="word-break: break-word;"
         >
-          User [admin@example.com] has started a session [56408539-6536-11e9-80a1-427cfde50f5a] on node [de3800ea-69d9-4d72-a108-97e57f8eb393]
+          User [admin@example.com] has started a session [56408539-6536-11e9-80a1-427cfde50f5a] on node [de3800ea-69d9-4d72-a108-97e57f8eb393] 
         </td>
         <td
           style="min-width: 120px;"

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -651,8 +651,6 @@ export const formatters: Formatters = {
     desc: 'Session Started',
     format: event => {
       const user = event.user || '';
-      const node =
-        event.server_hostname || event.server_addr || event.server_id;
 
       if (event.proto === 'kube') {
         if (!event.kubernetes_cluster) {
@@ -661,6 +659,8 @@ export const formatters: Formatters = {
         return `User [${user}] has started a session [${event.sid}] on Kubernetes cluster [${event.kubernetes_cluster}]`;
       }
 
+      const node =
+        event.server_hostname || event.server_addr || event.server_id;
       return `User [${user}] has started a session [${event.sid}] on node [${node}] `;
     },
   },

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -649,7 +649,20 @@ export const formatters: Formatters = {
   [eventCodes.SESSION_START]: {
     type: 'session.start',
     desc: 'Session Started',
-    format: ({ user, sid }) => `User [${user}] has started a session [${sid}]`,
+    format: event => {
+      const user = event.user || '';
+      const node =
+        event.server_hostname || event.server_addr || event.server_id;
+
+      if (event.proto === 'kube') {
+        if (!event.kubernetes_cluster) {
+          return `User [${user}] has started a Kubernetes session [${event.sid}]`;
+        }
+        return `User [${user}] has started a session [${event.sid}] on Kubernetes cluster [${event.kubernetes_cluster}]`;
+      }
+
+      return `User [${user}] has started a session [${event.sid}] on node [${node}] `;
+    },
   },
   [eventCodes.SESSION_UPLOAD]: {
     type: 'session.upload',

--- a/web/packages/teleport/src/services/audit/types.ts
+++ b/web/packages/teleport/src/services/audit/types.ts
@@ -573,6 +573,11 @@ export type RawEvents = {
     typeof eventCodes.SESSION_START,
     {
       sid: string;
+      kubernetes_cluster: string;
+      proto: string;
+      server_hostname: string;
+      server_addr: string;
+      server_id: string;
     }
   >;
   [eventCodes.SESSION_REJECT]: RawEvent<


### PR DESCRIPTION
Backport #49479 to branch/v15

changelog: SSH or Kubernetes information included for audit log list for start session events
