### PR TITLE
Prevent panicing if license expiry is not populated

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1226,7 +1226,7 @@ func (h *Handler) getUserContext(w http.ResponseWriter, r *http.Request, p httpr
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if !pingResp.LicenseExpiry.IsZero() {
+	if pingResp.LicenseExpiry != nil && !pingResp.LicenseExpiry.IsZero() {
 		userContext.Cluster.LicenseExpiry = pingResp.LicenseExpiry
 	}
 


### PR DESCRIPTION
Panic was caught by a customer running 16.4.9

```
http: panic serving [2a13:5947:111:20::1c86:2e30]:49995: runtime error: invalid memory address or nil pointer dereference goroutine 597943 [running]:
net/http.(*conn).serve.func1()
    net/http/server.go:1903 +0xbe
panic({0x556eb28d1e60?, 0x556eb95ef2d0?})
    runtime/panic.go:770 +0x132
github.com/gravitational/teleport/lib/web.(*Handler).getUserContext(0xc002599408, {0xc002599408?, 0xc00bb18b40?}, 0xc00f4859e0, {0x1?, 0x1?, 0xc00bb18b40?}, 0xc00bb18b40, {0x556eb3eeb8f8, 0xc001af2f20})
    github.com/gravitational/teleport/lib/web/apiserver.go:1230 +0x6ef
github.com/gravitational/teleport/lib/web.(*Handler).bindDefaultEndpoints.(*Handler).WithClusterAuth.func50({0x556eb3ea4940, 0xc00d6158c0}, 0xc00f4859e0, {0xc00d615920, 0x1, 0x3})
```

changelog: prevent a panic if the auth server does not provide a license expiry