### PR TITLE
[teleport-update] Adjust download progress log output

### DIFF
--- a/lib/autoupdate/agent/logger.go
+++ b/lib/autoupdate/agent/logger.go
@@ -46,8 +46,10 @@ type progressLogger struct {
 func (w *progressLogger) Write(p []byte) (n int, err error) {
 	w.n += len(p)
 	if w.n >= w.max*(w.l+1)/w.lines {
-		msg := fmt.Sprintf("%s - progress: %d%%", w.name, w.n*100/w.max)
-		w.log.Log(w.ctx, w.level, msg) //nolint:sloglint // msg cannot be constant
+		w.log.Log(w.ctx, w.level, "Download progress",
+			"name", w.name,
+			"progress", fmt.Sprintf("%d%%", w.n*100/w.max),
+		)
 		w.l++
 	}
 	return len(p), nil

--- a/lib/autoupdate/agent/logger.go
+++ b/lib/autoupdate/agent/logger.go
@@ -46,7 +46,7 @@ type progressLogger struct {
 func (w *progressLogger) Write(p []byte) (n int, err error) {
 	w.n += len(p)
 	if w.n >= w.max*(w.l+1)/w.lines {
-		w.log.Log(w.ctx, w.level, "Download progress",
+		w.log.Log(w.ctx, w.level, "Downloading",
 			"name", w.name,
 			"progress", fmt.Sprintf("%d%%", w.n*100/w.max),
 		)

--- a/lib/autoupdate/agent/logger.go
+++ b/lib/autoupdate/agent/logger.go
@@ -47,7 +47,7 @@ func (w *progressLogger) Write(p []byte) (n int, err error) {
 	w.n += len(p)
 	if w.n >= w.max*(w.l+1)/w.lines {
 		w.log.Log(w.ctx, w.level, "Downloading",
-			"name", w.name,
+			"file", w.name,
 			"progress", fmt.Sprintf("%d%%", w.n*100/w.max),
 		)
 		w.l++

--- a/lib/autoupdate/agent/logger_test.go
+++ b/lib/autoupdate/agent/logger_test.go
@@ -177,7 +177,7 @@ func TestProgressLogger(t *testing.T) {
 				v, err := io.ReadAll(out)
 				require.NoError(t, err)
 				if len(v) > 0 {
-					e.out = fmt.Sprintf(`msg="test - progress: %s"`+"\n", e.out)
+					e.out = fmt.Sprintf(`msg="Download progress" name=test progress=%s`+"\n", e.out)
 				}
 				require.Equal(t, e.out, string(v))
 			}

--- a/lib/autoupdate/agent/logger_test.go
+++ b/lib/autoupdate/agent/logger_test.go
@@ -177,7 +177,7 @@ func TestProgressLogger(t *testing.T) {
 				v, err := io.ReadAll(out)
 				require.NoError(t, err)
 				if len(v) > 0 {
-					e.out = fmt.Sprintf(`msg="Download progress" name=test progress=%s`+"\n", e.out)
+					e.out = fmt.Sprintf(`msg=Downloading name=test progress=%s`+"\n", e.out)
 				}
 				require.Equal(t, e.out, string(v))
 			}

--- a/lib/autoupdate/agent/logger_test.go
+++ b/lib/autoupdate/agent/logger_test.go
@@ -177,7 +177,7 @@ func TestProgressLogger(t *testing.T) {
 				v, err := io.ReadAll(out)
 				require.NoError(t, err)
 				if len(v) > 0 {
-					e.out = fmt.Sprintf(`msg=Downloading name=test progress=%s`+"\n", e.out)
+					e.out = fmt.Sprintf(`msg=Downloading file=test progress=%s`+"\n", e.out)
 				}
 				require.Equal(t, e.out, string(v))
 			}


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/49805 adding logging for download progress and stats when `teleport-update` downloads Teleport tgz files.

I realized that I copied the log formatting line used by `progressLogger` from `lineLogger`, and I forgot to go back and structure the log before opening the PR. This change correctly structures the log lines.

Old:
```
2024-12-05T03:22:17Z INFO [UPDATER]   teleport-ent-v16.4.3-linux-arm64-bin.tar.gz - progress: 40% agent/logger.go:50
```

New:
```
2024-12-05T03:22:17Z INFO [UPDATER]   Downloading file=teleport-ent-v16.4.3-linux-arm64-bin.tar.gz progress=40% agent/logger.go:50
```
---

The `teleport-update` binary will be used to enable, disable, and trigger automatic Teleport agent updates. The new auto-updates system manages a local installation of the cluster-specified version of Teleport stored in `/opt/teleport`.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/10289
