### PR TITLE
Navigate to aws status dash from integrations list

### DIFF
--- a/web/packages/teleport/src/Integrations/IntegrationList.test.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationList.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { fireEvent, render, screen, userEvent } from 'design/utils/testing';
+
+import { Router } from 'react-router';
+
+import { createMemoryHistory } from 'history';
+
+import { IntegrationList } from 'teleport/Integrations/IntegrationList';
+import {
+  IntegrationKind,
+  IntegrationStatusCode,
+} from 'teleport/services/integrations';
+
+test('integration list shows edit and view action menu for aws-oidc, row click navigates', async () => {
+  const history = createMemoryHistory();
+  history.push = jest.fn();
+
+  render(
+    <Router history={history}>
+      <IntegrationList
+        list={[
+          {
+            resourceType: 'integration',
+            name: 'aws-integration',
+            kind: IntegrationKind.AwsOidc,
+            statusCode: IntegrationStatusCode.Running,
+            spec: { roleArn: '', issuerS3Prefix: '', issuerS3Bucket: '' },
+          },
+        ]}
+      />
+    </Router>
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: 'Options' }));
+  expect(screen.getByText('View Status')).toBeInTheDocument();
+  expect(screen.getByText('View Status')).toHaveAttribute(
+    'href',
+    '/web/integrations/status/aws-oidc/aws-integration'
+  );
+  expect(screen.getByText('Edit...')).toBeInTheDocument();
+  expect(screen.getByText('Delete...')).toBeInTheDocument();
+
+  await userEvent.click(screen.getAllByRole('row')[1]);
+  expect(history.push).toHaveBeenCalledWith(
+    '/web/integrations/status/aws-oidc/aws-integration'
+  );
+});

--- a/web/packages/teleport/src/Integrations/IntegrationList.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationList.tsx
@@ -66,7 +66,7 @@ export function IntegrationList(props: Props<IntegrationLike>) {
   const history = useHistory();
 
   function handleRowClick(row: IntegrationLike) {
-    if (row.kind !== 'okta') return;
+    if (row.kind !== 'okta' && row.kind !== IntegrationKind.AwsOidc) return;
     history.push(cfg.getIntegrationStatusRoute(row.kind, row.name));
   }
 
@@ -154,15 +154,26 @@ export function IntegrationList(props: Props<IntegrationLike>) {
               return (
                 <Cell align="right">
                   <MenuButton>
-                    {/* Currently, only AWSOIDC supports editing. */}
+                    {/* Currently, only AWS OIDC supports editing & status dash */}
                     {item.kind === IntegrationKind.AwsOidc && (
-                      <MenuItem
-                        onClick={() =>
-                          props.integrationOps.onEditIntegration(item)
-                        }
-                      >
-                        Edit...
-                      </MenuItem>
+                      <>
+                        <MenuItem
+                          as={InternalRouteLink}
+                          to={cfg.getIntegrationStatusRoute(
+                            item.kind,
+                            item.name
+                          )}
+                        >
+                          View Status
+                        </MenuItem>
+                        <MenuItem
+                          onClick={() =>
+                            props.integrationOps.onEditIntegration(item)
+                          }
+                        >
+                          Edit...
+                        </MenuItem>
+                      </>
                     )}
                     <MenuItem
                       onClick={() =>

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -24,6 +24,13 @@ import generateResourcePath from './generateResourcePath';
 
 import { defaultEntitlements } from './entitlement';
 
+import {
+  AwsOidcPolicyPreset,
+  IntegrationKind,
+  PluginKind,
+  Regions,
+} from './services/integrations';
+
 import type {
   Auth2faType,
   AuthProvider,
@@ -35,11 +42,6 @@ import type {
 import type { SortType } from 'teleport/services/agents';
 import type { RecordingType } from 'teleport/services/recordings';
 import type { WebauthnAssertionResponse } from './services/mfa';
-import type {
-  PluginKind,
-  Regions,
-  AwsOidcPolicyPreset,
-} from './services/integrations';
 import type { ParticipantMode } from 'teleport/services/session';
 import type { YamlSupportedResourceKind } from './services/yaml/types';
 import type { KubeResourceKind } from './services/kube/types';
@@ -534,7 +536,7 @@ const cfg = {
     return generatePath(cfg.routes.integrationEnroll, { type });
   },
 
-  getIntegrationStatusRoute(type: PluginKind, name: string) {
+  getIntegrationStatusRoute(type: PluginKind | IntegrationKind, name: string) {
     return generatePath(cfg.routes.integrationStatus, { type, name });
   },
 


### PR DESCRIPTION
Adds a menu item to aws-oidc integrations to "view status." This will navigate users to the aws oidc dashboard.

<img width="1280" alt="Screenshot 2024-12-05 at 2 05 21 PM" src="https://github.com/user-attachments/assets/1007046b-1868-457f-9979-35cd97d15424">


Closes https://github.com/gravitational/teleport/issues/49087