### PR TITLE
Fix major version check (with missing state)

### DIFF
--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -389,7 +389,7 @@ func initCluster(ctx context.Context, cfg InitConfig, asrv *Server) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if err := validateAndUpdateTeleportVersion(ctx, cfg.VersionStorage, teleport.SemVersion, firstStart); err != nil {
+	if err := validateAndUpdateTeleportVersion(ctx, cfg.VersionStorage, teleport.SemVersion); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/auth/version.go
+++ b/lib/auth/version.go
@@ -38,7 +38,6 @@ func validateAndUpdateTeleportVersion(
 	ctx context.Context,
 	storage VersionStorage,
 	currentVersion *semver.Version,
-	firstTimeStart bool,
 ) error {
 	if skip := os.Getenv(skipVersionUpgradeCheckEnv); skip != "" {
 		return nil
@@ -46,17 +45,6 @@ func validateAndUpdateTeleportVersion(
 
 	lastKnownVersion, err := storage.GetTeleportVersion(ctx)
 	if trace.IsNotFound(err) {
-		// When this is not the first start, we have to ensure that previous versions,
-		// introduced before this check, were also verified. Therefore, not having a version
-		// in the database means the last known version is <v17.
-		if !firstTimeStart {
-			return trace.BadParameter("Unsupported upgrade path detected: to %v. "+
-				"Teleport supports direct upgrades to the next major version only.\n "+
-				"For instance, if you have version 15.x.x, you must upgrade to version 16.x.x first. "+
-				"See compatibility guarantees for details: "+
-				"https://goteleport.com/docs/upgrading/overview/#component-compatibility.",
-				currentVersion.String())
-		}
 		if err := storage.WriteTeleportVersion(ctx, currentVersion); err != nil {
 			return trace.Wrap(err)
 		}


### PR DESCRIPTION
In this PR partially fixed issue reported in https://github.com/gravitational/teleport/issues/49848 for Teleport 18-dev version.

For stateless setups we ignore this check, since we can't persist local database, for the other cases if we able to read the previous version we verify the version.

This is temporary solution until another one implementation replace this with local database