### PR TITLE
Add navigation to individual aws resource rule tables

### DIFF
--- a/web/packages/design/src/Tabs/Tabs.ts
+++ b/web/packages/design/src/Tabs/Tabs.ts
@@ -1,0 +1,57 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { NavLink } from 'react-router-dom';
+import styled from 'styled-components';
+
+export const TabsContainer = styled.div`
+  position: relative;
+  display: flex;
+  gap: ${p => p.theme.space[5]}px;
+  align-items: center;
+  padding: 0 ${p => p.theme.space[5]}px;
+  border-bottom: 1px solid ${p => p.theme.colors.spotBackground[0]};
+`;
+
+export const TabContainer = styled(NavLink)<{ selected?: boolean }>`
+  padding: ${p => p.theme.space[1] + p.theme.space[2]}px
+    ${p => p.theme.space[2]}px;
+  position: relative;
+  cursor: pointer;
+  z-index: 2;
+  opacity: ${p => (p.selected ? 1 : 0.5)};
+  transition: opacity 0.3s linear;
+  color: ${p => p.theme.colors.text.main};
+  font-weight: 300;
+  font-size: 22px;
+  line-height: ${p => p.theme.space[5]}px;
+  white-space: nowrap;
+  text-decoration: none;
+
+  &:hover {
+    opacity: 1;
+  }
+`;
+
+export const TabBorder = styled.div`
+  position: absolute;
+  bottom: -1px;
+  background: ${p => p.theme.colors.brand};
+  height: 2px;
+  transition: all 0.3s cubic-bezier(0.19, 1, 0.22, 1);
+`;

--- a/web/packages/teleport/src/Integrations/IntegrationList.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationList.tsx
@@ -69,7 +69,7 @@ export function IntegrationList(props: Props) {
   }
 
   function getRowStyle(row: IntegrationLike): React.CSSProperties {
-    if (row.kind !== 'okta') return;
+    if (row.kind !== 'okta' && row.kind !== IntegrationKind.AwsOidc) return;
     return { cursor: 'pointer' };
   }
 

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.story.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.story.tsx
@@ -16,24 +16,37 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { addHours } from 'date-fns';
+import {
+  makeErrorAttempt,
+  makeProcessingAttempt,
+  makeSuccessAttempt,
+} from 'shared/hooks/useAsync';
 
+import cfg from 'teleport/config';
 import { AwsOidcDashboard } from 'teleport/Integrations/status/AwsOidc/AwsOidcDashboard';
 import { MockAwsOidcStatusProvider } from 'teleport/Integrations/status/AwsOidc/testHelpers/mockAwsOidcStatusProvider';
-import { AwsOidcStatusContextState } from 'teleport/Integrations/status/AwsOidc/useAwsOidcStatus';
-import {
-  IntegrationKind,
-  ResourceTypeSummary,
-} from 'teleport/services/integrations';
+import { IntegrationKind } from 'teleport/services/integrations';
+
+import { makeAwsOidcStatusContextState } from './testHelpers/makeAwsOidcStatusContextState';
 
 export default {
   title: 'Teleport/Integrations/AwsOidc',
 };
 
+const setup = {
+  path: cfg.routes.integrationStatus,
+  initialEntries: [
+    cfg.getIntegrationStatusRoute(IntegrationKind.AwsOidc, 'oidc-int'),
+  ],
+};
+
 // Loaded dashboard with data for each aws resource and a navigation header
 export function Dashboard() {
   return (
-    <MockAwsOidcStatusProvider value={makeAwsOidcStatusContextState()}>
+    <MockAwsOidcStatusProvider
+      {...setup}
+      value={makeAwsOidcStatusContextState()}
+    >
       <AwsOidcDashboard />
     </MockAwsOidcStatusProvider>
   );
@@ -42,11 +55,22 @@ export function Dashboard() {
 // Loaded dashboard with missing data for each aws resource and a navigation header
 export function DashboardMissingData() {
   const state = makeAwsOidcStatusContextState();
+  state.statsAttempt.data = undefined;
+  return (
+    <MockAwsOidcStatusProvider {...setup} value={state}>
+      <AwsOidcDashboard />
+    </MockAwsOidcStatusProvider>
+  );
+}
+
+// Loaded dashboard with missing data for each aws resource and a navigation header
+export function DashboardMissingSummary() {
+  const state = makeAwsOidcStatusContextState();
   state.statsAttempt.data.awseks = undefined;
   state.statsAttempt.data.awsrds = undefined;
   state.statsAttempt.data.awsec2 = undefined;
   return (
-    <MockAwsOidcStatusProvider value={state}>
+    <MockAwsOidcStatusProvider {...setup} value={state}>
       <AwsOidcDashboard />
     </MockAwsOidcStatusProvider>
   );
@@ -55,10 +79,10 @@ export function DashboardMissingData() {
 // Loading screen
 export function StatsProcessing() {
   const props = makeAwsOidcStatusContextState({
-    statsAttempt: { status: 'processing', data: null, statusText: '' },
+    statsAttempt: makeProcessingAttempt(),
   });
   return (
-    <MockAwsOidcStatusProvider value={props}>
+    <MockAwsOidcStatusProvider {...setup} value={props}>
       <AwsOidcDashboard />
     </MockAwsOidcStatusProvider>
   );
@@ -67,14 +91,10 @@ export function StatsProcessing() {
 // No header, no loading indicator
 export function IntegrationProcessing() {
   const props = makeAwsOidcStatusContextState({
-    integrationAttempt: {
-      status: 'processing',
-      data: null,
-      statusText: '',
-    },
+    integrationAttempt: makeProcessingAttempt(),
   });
   return (
-    <MockAwsOidcStatusProvider value={props}>
+    <MockAwsOidcStatusProvider {...setup} value={props}>
       <AwsOidcDashboard />
     </MockAwsOidcStatusProvider>
   );
@@ -83,32 +103,39 @@ export function IntegrationProcessing() {
 // Loaded error message
 export function StatsFailed() {
   const props = makeAwsOidcStatusContextState({
-    statsAttempt: {
-      status: 'error',
-      data: null,
-      statusText: 'failed to get stats',
-      error: {},
-    },
+    statsAttempt: makeErrorAttempt(new Error('failed  to get stats')),
   });
   return (
-    <MockAwsOidcStatusProvider value={props}>
+    <MockAwsOidcStatusProvider {...setup} value={props}>
       <AwsOidcDashboard />
     </MockAwsOidcStatusProvider>
   );
 }
 
-// Loaded dashboard with data for each aws resource but no navigation header
+// Loaded error message
 export function IntegrationFailed() {
   const props = makeAwsOidcStatusContextState({
-    integrationAttempt: {
-      status: 'error',
-      data: null,
-      statusText: 'failed  to get integration',
-      error: {},
-    },
+    integrationAttempt: makeErrorAttempt(
+      new Error('failed  to get integration')
+    ),
   });
   return (
-    <MockAwsOidcStatusProvider value={props}>
+    <MockAwsOidcStatusProvider {...setup} value={props}>
+      <AwsOidcDashboard />
+    </MockAwsOidcStatusProvider>
+  );
+}
+
+// Loaded error message
+export function BothFailed() {
+  const props = makeAwsOidcStatusContextState({
+    statsAttempt: makeErrorAttempt(new Error('failed  to get stats')),
+    integrationAttempt: makeErrorAttempt(
+      new Error('failed  to get integration')
+    ),
+  });
+  return (
+    <MockAwsOidcStatusProvider {...setup} value={props}>
       <AwsOidcDashboard />
     </MockAwsOidcStatusProvider>
   );
@@ -117,10 +144,10 @@ export function IntegrationFailed() {
 // Blank screen
 export function StatsNoData() {
   const props = makeAwsOidcStatusContextState({
-    statsAttempt: { status: 'success', data: null, statusText: '' },
+    statsAttempt: makeSuccessAttempt(null),
   });
   return (
-    <MockAwsOidcStatusProvider value={props}>
+    <MockAwsOidcStatusProvider {...setup} value={props}>
       <AwsOidcDashboard />
     </MockAwsOidcStatusProvider>
   );
@@ -129,71 +156,11 @@ export function StatsNoData() {
 // No header, no loading indicator
 export function IntegrationNoData() {
   const props = makeAwsOidcStatusContextState({
-    integrationAttempt: {
-      status: 'success',
-      data: null,
-      statusText: '',
-    },
+    integrationAttempt: makeSuccessAttempt(null),
   });
   return (
-    <MockAwsOidcStatusProvider value={props}>
+    <MockAwsOidcStatusProvider {...setup} value={props}>
       <AwsOidcDashboard />
     </MockAwsOidcStatusProvider>
-  );
-}
-
-function makeAwsOidcStatusContextState(
-  overrides: Partial<AwsOidcStatusContextState> = {}
-): AwsOidcStatusContextState {
-  return Object.assign(
-    {
-      integrationAttempt: {
-        status: 'success',
-        statusText: '',
-        data: {
-          resourceType: 'integration',
-          name: 'integration-one',
-          kind: IntegrationKind.AwsOidc,
-          spec: {
-            roleArn: 'arn:aws:iam::111456789011:role/bar',
-          },
-          statusCode: 1,
-        },
-      },
-      statsAttempt: {
-        status: 'success',
-        statusText: '',
-        data: {
-          name: 'integration-one',
-          subKind: IntegrationKind.AwsOidc,
-          awsoidc: {
-            roleArn: 'arn:aws:iam::111456789011:role/bar',
-          },
-          awsec2: makeResourceTypeSummary(),
-          awsrds: makeResourceTypeSummary(),
-          awseks: makeResourceTypeSummary(),
-        },
-      },
-    },
-    overrides
-  );
-}
-
-function makeResourceTypeSummary(
-  overrides: Partial<ResourceTypeSummary> = {}
-): ResourceTypeSummary {
-  return Object.assign(
-    {
-      rulesCount: Math.floor(Math.random() * 100),
-      resourcesFound: Math.floor(Math.random() * 100),
-      resourcesEnrollmentFailed: Math.floor(Math.random() * 100),
-      resourcesEnrollmentSuccess: Math.floor(Math.random() * 100),
-      discoverLastSync: addHours(
-        new Date().getTime(),
-        -Math.floor(Math.random() * 100)
-      ),
-      ecsDatabaseServiceCount: Math.floor(Math.random() * 100),
-    },
-    overrides
   );
 }

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.test.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.test.tsx
@@ -83,13 +83,20 @@ test('renders header and stats cards', () => {
     </MockAwsOidcStatusProvider>
   );
 
-  expect(screen.getByRole('link', { name: 'back' })).toHaveAttribute(
+  const breadcrumbs = screen.getByTestId('aws-oidc-header');
+  expect(within(breadcrumbs).getByText('integration-one')).toBeInTheDocument();
+
+  const title = screen.getByTestId('aws-oidc-title');
+  expect(within(title).getByRole('link', { name: 'back' })).toHaveAttribute(
     'href',
     '/web/integrations'
   );
-  expect(screen.getByText('integration-one')).toBeInTheDocument();
-  expect(screen.getByLabelText('status')).toHaveAttribute('kind', 'success');
-  expect(screen.getByLabelText('status')).toHaveTextContent('Running');
+  expect(within(title).getByLabelText('status')).toHaveAttribute(
+    'kind',
+    'success'
+  );
+  expect(within(title).getByLabelText('status')).toHaveTextContent('Running');
+  expect(within(title).getByText('integration-one')).toBeInTheDocument();
 
   const ec2 = screen.getByTestId('ec2-stats');
   expect(within(ec2).getByTestId('sync')).toHaveTextContent(
@@ -135,4 +142,67 @@ test('renders header and stats cards', () => {
   expect(within(eks).getByTestId('failed')).toHaveTextContent(
     'Failed Clusters 0'
   );
+});
+
+test('renders enroll cards', () => {
+  const zeroCount = {
+    rulesCount: 0,
+    resourcesFound: 0,
+    resourcesEnrollmentFailed: 0,
+    resourcesEnrollmentSuccess: 0,
+    discoverLastSync: new Date().getTime(),
+    ecsDatabaseServiceCount: 0,
+  };
+
+  render(
+    <MockAwsOidcStatusProvider
+      value={{
+        integrationAttempt: {
+          status: 'success',
+          statusText: '',
+          data: {
+            resourceType: 'integration',
+            name: 'integration-one',
+            kind: IntegrationKind.AwsOidc,
+            spec: {
+              roleArn: 'arn:aws:iam::111456789011:role/bar',
+            },
+            statusCode: 1,
+          },
+        },
+        statsAttempt: {
+          status: 'success',
+          statusText: '',
+          data: {
+            name: 'integration-one',
+            subKind: IntegrationKind.AwsOidc,
+            awsoidc: {
+              roleArn: 'arn:aws:iam::111456789011:role/bar',
+            },
+            awsec2: zeroCount,
+            awsrds: zeroCount,
+            awseks: zeroCount,
+          },
+        },
+      }}
+    >
+      <AwsOidcDashboard />
+    </MockAwsOidcStatusProvider>
+  );
+
+  expect(
+    within(screen.getByTestId('ec2-enroll')).getByRole('button', {
+      name: 'Enroll EC2',
+    })
+  ).toBeInTheDocument();
+  expect(
+    within(screen.getByTestId('rds-enroll')).getByRole('button', {
+      name: 'Enroll RDS',
+    })
+  ).toBeInTheDocument();
+  expect(
+    within(screen.getByTestId('eks-enroll')).getByRole('button', {
+      name: 'Enroll EKS',
+    })
+  ).toBeInTheDocument();
 });

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.test.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.test.tsx
@@ -17,67 +17,65 @@
  */
 
 import { within } from '@testing-library/react';
+import { addHours } from 'date-fns';
 
 import { render, screen } from 'design/utils/testing';
+import { makeSuccessAttempt } from 'shared/hooks/useAsync';
 
-import { addHours } from 'teleport/components/BannerList/useAlerts';
 import { AwsOidcDashboard } from 'teleport/Integrations/status/AwsOidc/AwsOidcDashboard';
 import { MockAwsOidcStatusProvider } from 'teleport/Integrations/status/AwsOidc/testHelpers/mockAwsOidcStatusProvider';
-import { IntegrationKind } from 'teleport/services/integrations';
+import {
+  IntegrationAwsOidc,
+  IntegrationKind,
+  IntegrationWithSummary,
+} from 'teleport/services/integrations';
 
 test('renders header and stats cards', () => {
   render(
     <MockAwsOidcStatusProvider
       value={{
-        integrationAttempt: {
-          status: 'success',
-          statusText: '',
-          data: {
-            resourceType: 'integration',
-            name: 'integration-one',
-            kind: IntegrationKind.AwsOidc,
-            spec: {
-              roleArn: 'arn:aws:iam::111456789011:role/bar',
-            },
-            statusCode: 1,
+        integrationAttempt: makeSuccessAttempt<IntegrationAwsOidc>({
+          resourceType: 'integration',
+          name: 'integration-one',
+          kind: IntegrationKind.AwsOidc,
+          spec: {
+            roleArn: 'arn:aws:iam::111456789011:role/bar',
           },
-        },
-        statsAttempt: {
-          status: 'success',
-          statusText: '',
-          data: {
-            name: 'integration-one',
-            subKind: IntegrationKind.AwsOidc,
-            awsoidc: {
-              roleArn: 'arn:aws:iam::111456789011:role/bar',
-            },
-            awsec2: {
-              rulesCount: 24,
-              resourcesFound: 12,
-              resourcesEnrollmentFailed: 3,
-              resourcesEnrollmentSuccess: 9,
-              discoverLastSync: new Date().getTime(),
-              ecsDatabaseServiceCount: 0, // irrelevant
-            },
-            awsrds: {
-              rulesCount: 14,
-              resourcesFound: 5,
-              resourcesEnrollmentFailed: 5,
-              resourcesEnrollmentSuccess: 0,
-              discoverLastSync: addHours(new Date().getTime(), -4),
-              ecsDatabaseServiceCount: 8, // relevant
-            },
-            awseks: {
-              rulesCount: 33,
-              resourcesFound: 3,
-              resourcesEnrollmentFailed: 0,
-              resourcesEnrollmentSuccess: 3,
-              discoverLastSync: addHours(new Date().getTime(), -48),
-              ecsDatabaseServiceCount: 0, // irrelevant
-            },
+          statusCode: 1,
+        }),
+        statsAttempt: makeSuccessAttempt<IntegrationWithSummary>({
+          name: 'integration-one',
+          subKind: IntegrationKind.AwsOidc,
+          awsoidc: {
+            roleArn: 'arn:aws:iam::111456789011:role/bar',
           },
-        },
+          awsec2: {
+            rulesCount: 24,
+            resourcesFound: 12,
+            resourcesEnrollmentFailed: 3,
+            resourcesEnrollmentSuccess: 9,
+            discoverLastSync: new Date().getTime(),
+            ecsDatabaseServiceCount: 0, // irrelevant
+          },
+          awsrds: {
+            rulesCount: 14,
+            resourcesFound: 5,
+            resourcesEnrollmentFailed: 5,
+            resourcesEnrollmentSuccess: 0,
+            discoverLastSync: addHours(new Date().getTime(), -4).getTime(),
+            ecsDatabaseServiceCount: 8, // relevant
+          },
+          awseks: {
+            rulesCount: 33,
+            resourcesFound: 3,
+            resourcesEnrollmentFailed: 0,
+            resourcesEnrollmentSuccess: 3,
+            discoverLastSync: addHours(new Date().getTime(), -48).getTime(),
+            ecsDatabaseServiceCount: 0, // irrelevant
+          },
+        }),
       }}
+      path=""
     >
       <AwsOidcDashboard />
     </MockAwsOidcStatusProvider>
@@ -157,51 +155,44 @@ test('renders enroll cards', () => {
   render(
     <MockAwsOidcStatusProvider
       value={{
-        integrationAttempt: {
-          status: 'success',
-          statusText: '',
-          data: {
-            resourceType: 'integration',
-            name: 'integration-one',
-            kind: IntegrationKind.AwsOidc,
-            spec: {
-              roleArn: 'arn:aws:iam::111456789011:role/bar',
-            },
-            statusCode: 1,
+        integrationAttempt: makeSuccessAttempt({
+          resourceType: 'integration',
+          name: 'integration-one',
+          kind: IntegrationKind.AwsOidc,
+          spec: {
+            roleArn: 'arn:aws:iam::111456789011:role/bar',
           },
-        },
-        statsAttempt: {
-          status: 'success',
-          statusText: '',
-          data: {
-            name: 'integration-one',
-            subKind: IntegrationKind.AwsOidc,
-            awsoidc: {
-              roleArn: 'arn:aws:iam::111456789011:role/bar',
-            },
-            awsec2: zeroCount,
-            awsrds: zeroCount,
-            awseks: zeroCount,
+          statusCode: 1,
+        }),
+        statsAttempt: makeSuccessAttempt({
+          name: 'integration-one',
+          subKind: IntegrationKind.AwsOidc,
+          awsoidc: {
+            roleArn: 'arn:aws:iam::111456789011:role/bar',
           },
-        },
+          awsec2: zeroCount,
+          awsrds: zeroCount,
+          awseks: zeroCount,
+        }),
       }}
+      path=""
     >
       <AwsOidcDashboard />
     </MockAwsOidcStatusProvider>
   );
 
   expect(
-    within(screen.getByTestId('ec2-enroll')).getByRole('button', {
+    within(screen.getByTestId('ec2-enroll')).getByRole('link', {
       name: 'Enroll EC2',
     })
   ).toBeInTheDocument();
   expect(
-    within(screen.getByTestId('rds-enroll')).getByRole('button', {
+    within(screen.getByTestId('rds-enroll')).getByRole('link', {
       name: 'Enroll RDS',
     })
   ).toBeInTheDocument();
   expect(
-    within(screen.getByTestId('eks-enroll')).getByRole('button', {
+    within(screen.getByTestId('eks-enroll')).getByRole('link', {
       name: 'Enroll EKS',
     })
   ).toBeInTheDocument();

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.tsx
@@ -43,6 +43,10 @@ export function AwsOidcDashboard() {
   }
 
   if (integrationAttempt.status == 'error') {
+    return <Danger>{integrationAttempt.statusText}</Danger>;
+  }
+
+  if (statsAttempt.status == 'error') {
     return <Danger>{statsAttempt.statusText}</Danger>;
   }
 

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.tsx
@@ -16,11 +16,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Flex, H2, Indicator } from 'design';
+import { Box, Flex, H2, Indicator } from 'design';
 import { Danger } from 'design/Alert';
 
 import { FeatureBox } from 'teleport/components/Layout';
 import { AwsOidcHeader } from 'teleport/Integrations/status/AwsOidc/AwsOidcHeader';
+import { AwsOidcTitle } from 'teleport/Integrations/status/AwsOidc/AwsOidcTitle';
 import {
   AwsResource,
   StatCard,
@@ -30,28 +31,51 @@ import { useAwsOidcStatus } from 'teleport/Integrations/status/AwsOidc/useAwsOid
 export function AwsOidcDashboard() {
   const { statsAttempt, integrationAttempt } = useAwsOidcStatus();
 
-  if (statsAttempt.status == 'processing') {
-    return <Indicator />;
+  if (
+    statsAttempt.status == 'processing' ||
+    integrationAttempt.status == 'processing'
+  ) {
+    return (
+      <Box textAlign="center" mt={4}>
+        <Indicator />
+      </Box>
+    );
   }
-  if (statsAttempt.status == 'error') {
+
+  if (integrationAttempt.status == 'error') {
     return <Danger>{statsAttempt.statusText}</Danger>;
   }
-  if (!statsAttempt.data) {
+
+  if (!statsAttempt.data || !integrationAttempt.data) {
     return null;
   }
 
-  // todo (michellescripts) after routing, ensure this view can be sticky
   const { awsec2, awseks, awsrds } = statsAttempt.data;
   const { data: integration } = integrationAttempt;
   return (
-    <FeatureBox css={{ maxWidth: '1400px', paddingTop: '16px' }}>
-      {integration && <AwsOidcHeader integration={integration} />}
-      <H2 my={3}>Auto-Enrollment</H2>
-      <Flex gap={3}>
-        <StatCard resource={AwsResource.ec2} summary={awsec2} />
-        <StatCard resource={AwsResource.rds} summary={awsrds} />
-        <StatCard resource={AwsResource.eks} summary={awseks} />
-      </Flex>
-    </FeatureBox>
+    <>
+      <AwsOidcHeader integration={integration} />
+      <FeatureBox css={{ maxWidth: '1400px', paddingTop: '16px' }}>
+        {integration && <AwsOidcTitle integration={integration} />}
+        <H2 my={3}>Auto-Enrollment</H2>
+        <Flex gap={3}>
+          <StatCard
+            name={integration.name}
+            resource={AwsResource.ec2}
+            summary={awsec2}
+          />
+          <StatCard
+            name={integration.name}
+            resource={AwsResource.eks}
+            summary={awseks}
+          />
+          <StatCard
+            name={integration.name}
+            resource={AwsResource.rds}
+            summary={awsrds}
+          />
+        </Flex>
+      </FeatureBox>
+    </>
   );
 }

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcHeader.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcHeader.tsx
@@ -16,10 +16,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useHistory } from 'react-router';
 import { Link as InternalLink } from 'react-router-dom';
 
-import { ButtonIcon, ButtonText, Flex, Text } from 'design';
+import { ButtonText, Flex, Text } from 'design';
 import { Plugs } from 'design/Icon';
 import { HoverTooltip } from 'design/Tooltip';
 
@@ -29,12 +28,11 @@ import { Integration } from 'teleport/services/integrations';
 
 export function AwsOidcHeader({
   integration,
-  resource = undefined,
+  resource,
 }: {
   integration: Integration;
   resource?: AwsResource;
 }) {
-  const history = useHistory();
   const divider = (
     <Text typography="body3" color="text.slightlyMuted">
       /
@@ -49,10 +47,11 @@ export function AwsOidcHeader({
       width={'100%'}
       pl={5}
       py={1}
+      gap={1}
       data-testid="aws-oidc-header"
     >
       <HoverTooltip position="bottom" tipContent="Back to Integrations">
-        <ButtonIcon
+        <ButtonText
           size="small"
           as={InternalLink}
           to={cfg.routes.integrations}
@@ -60,12 +59,12 @@ export function AwsOidcHeader({
           color="text.slightlyMuted"
         >
           <Plugs size="small" />
-        </ButtonIcon>
+        </ButtonText>
       </HoverTooltip>
       {!resource ? (
         <>
           {divider}
-          <Text typography="body3" color="text.slightlyMuted" ml={2}>
+          <Text typography="body3" color="text.slightlyMuted">
             {integration.name}
           </Text>
         </>
@@ -74,14 +73,11 @@ export function AwsOidcHeader({
           {divider}
           <ButtonText
             size="small"
-            onClick={() =>
-              history.push(
-                cfg.getIntegrationStatusRoute(
-                  integration.kind,
-                  integration.name
-                )
-              )
-            }
+            as={InternalLink}
+            to={cfg.getIntegrationStatusRoute(
+              integration.kind,
+              integration.name
+            )}
           >
             {integration.name}
           </ButtonText>

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcHeader.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcHeader.tsx
@@ -16,39 +16,81 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { useHistory } from 'react-router';
 import { Link as InternalLink } from 'react-router-dom';
 
-import { ButtonIcon, Flex, Label, Text } from 'design';
-import { ArrowLeft } from 'design/Icon';
+import { ButtonIcon, ButtonText, Flex, Text } from 'design';
+import { Plugs } from 'design/Icon';
 import { HoverTooltip } from 'design/Tooltip';
 
 import cfg from 'teleport/config';
-import { getStatusAndLabel } from 'teleport/Integrations/helpers';
-import { IntegrationAwsOidc } from 'teleport/services/integrations';
+import { AwsResource } from 'teleport/Integrations/status/AwsOidc/StatCard';
+import { Integration } from 'teleport/services/integrations';
 
 export function AwsOidcHeader({
   integration,
+  resource = undefined,
 }: {
-  integration: IntegrationAwsOidc;
+  integration: Integration;
+  resource?: AwsResource;
 }) {
-  const { status, labelKind } = getStatusAndLabel(integration);
+  const history = useHistory();
+  const divider = (
+    <Text typography="body3" color="text.slightlyMuted">
+      /
+    </Text>
+  );
+
   return (
-    <Flex alignItems="center">
+    <Flex
+      alignItems="center"
+      borderBottom={1}
+      borderColor="levels.surface"
+      width={'100%'}
+      pl={5}
+      py={1}
+      data-testid="aws-oidc-header"
+    >
       <HoverTooltip position="bottom" tipContent="Back to Integrations">
         <ButtonIcon
+          size="small"
           as={InternalLink}
           to={cfg.routes.integrations}
-          aria-label="back"
+          aria-label="integrations-table"
+          color="text.slightlyMuted"
         >
-          <ArrowLeft size="medium" />
+          <Plugs size="small" />
         </ButtonIcon>
       </HoverTooltip>
-      <Text bold fontSize={6} mx={2}>
-        {integration.name}
-      </Text>
-      <Label kind={labelKind} aria-label="status" px={3}>
-        {status}
-      </Label>
+      {!resource ? (
+        <>
+          {divider}
+          <Text typography="body3" color="text.slightlyMuted" ml={2}>
+            {integration.name}
+          </Text>
+        </>
+      ) : (
+        <>
+          {divider}
+          <ButtonText
+            size="small"
+            onClick={() =>
+              history.push(
+                cfg.getIntegrationStatusRoute(
+                  integration.kind,
+                  integration.name
+                )
+              )
+            }
+          >
+            {integration.name}
+          </ButtonText>
+          {divider}
+          <Text typography="body3" color="text.slightlyMuted" ml={2}>
+            {resource.toUpperCase()}
+          </Text>
+        </>
+      )}
     </Flex>
   );
 }

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcRoutes.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcRoutes.tsx
@@ -18,6 +18,7 @@
 
 import { Route, Switch } from 'teleport/components/Router';
 import cfg from 'teleport/config';
+import { Details } from 'teleport/Integrations/status/AwsOidc/Details/Details';
 import { AwsOidcStatusProvider } from 'teleport/Integrations/status/AwsOidc/useAwsOidcStatus';
 
 import { AwsOidcDashboard } from './AwsOidcDashboard';
@@ -27,7 +28,13 @@ export function AwsOidcRoutes() {
     <AwsOidcStatusProvider>
       <Switch>
         <Route
-          key="aws-oidc-resources-list"
+          key="aws-oidc-resource-table"
+          exact
+          path={cfg.routes.integrationStatusResources}
+          component={Details}
+        />
+        <Route
+          key="aws-oidc-dashboard"
           exact
           path={cfg.routes.integrationStatus}
           component={AwsOidcDashboard}

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcTitle.test.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcTitle.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+
+import { render, screen } from 'design/utils/testing';
+
+import { AwsOidcTitle } from 'teleport/Integrations/status/AwsOidc/AwsOidcTitle';
+import { AwsResource } from 'teleport/Integrations/status/AwsOidc/StatCard';
+import {
+  IntegrationAwsOidc,
+  IntegrationKind,
+  IntegrationStatusCode,
+} from 'teleport/services/integrations';
+
+const testIntegration: IntegrationAwsOidc = {
+  kind: IntegrationKind.AwsOidc,
+  name: 'some-name',
+  resourceType: 'integration',
+  spec: {
+    roleArn: '',
+    issuerS3Bucket: '',
+    issuerS3Prefix: '',
+  },
+  statusCode: IntegrationStatusCode.Running,
+};
+
+test('renders with resource', () => {
+  render(
+    <MemoryRouter>
+      <AwsOidcTitle integration={testIntegration} resource={AwsResource.ec2} />
+    </MemoryRouter>
+  );
+
+  expect(screen.getByRole('link', { name: 'back' })).toHaveAttribute(
+    'href',
+    '/web/integrations/status/aws-oidc/some-name'
+  );
+  expect(screen.getByText('EC2')).toBeInTheDocument();
+  expect(screen.queryByText('some-name')).not.toBeInTheDocument();
+  expect(
+    within(screen.getByLabelText('status')).getByText('Running')
+  ).toBeInTheDocument();
+});
+
+test('renders without resource', () => {
+  render(
+    <MemoryRouter>
+      <AwsOidcTitle integration={testIntegration} />
+    </MemoryRouter>
+  );
+
+  expect(screen.getByRole('link', { name: 'back' })).toHaveAttribute(
+    'href',
+    '/web/integrations'
+  );
+  expect(screen.getByText('some-name')).toBeInTheDocument();
+  expect(
+    within(screen.getByLabelText('status')).getByText('Running')
+  ).toBeInTheDocument();
+});

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcTitle.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcTitle.tsx
@@ -15,7 +15,6 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 import { Link as InternalLink } from 'react-router-dom';
 
 import { ButtonIcon, Flex, Label, Text } from 'design';
@@ -25,24 +24,17 @@ import { HoverTooltip } from 'design/Tooltip';
 import cfg from 'teleport/config';
 import { getStatusAndLabel } from 'teleport/Integrations/helpers';
 import { AwsResource } from 'teleport/Integrations/status/AwsOidc/StatCard';
-import { Integration } from 'teleport/services/integrations';
+import { IntegrationAwsOidc } from 'teleport/services/integrations';
 
 export function AwsOidcTitle({
   integration,
-  resource = undefined,
+  resource,
 }: {
-  integration: Integration;
+  integration: IntegrationAwsOidc;
   resource?: AwsResource;
 }) {
   const { status, labelKind } = getStatusAndLabel(integration);
-
-  const content = {
-    to: !resource
-      ? cfg.routes.integrations
-      : cfg.getIntegrationStatusRoute(integration.kind, integration.name),
-    helper: !resource ? 'Back to integrations' : 'Back to integration',
-    content: !resource ? integration.name : resource.toUpperCase(),
-  };
+  const content = getContent({ resource, integration });
 
   return (
     <Flex alignItems="center" data-testid="aws-oidc-title">
@@ -59,4 +51,29 @@ export function AwsOidcTitle({
       </Label>
     </Flex>
   );
+}
+
+function getContent({
+  resource,
+  integration,
+}: {
+  resource: AwsResource;
+  integration: IntegrationAwsOidc;
+}): {
+  to: string;
+  helper: string;
+  content: string;
+} {
+  if (resource) {
+    return {
+      to: cfg.getIntegrationStatusRoute(integration.kind, integration.name),
+      helper: 'Back to integration',
+      content: resource.toUpperCase(),
+    };
+  }
+  return {
+    to: cfg.routes.integrations,
+    helper: 'Back to integrations',
+    content: integration.name,
+  };
 }

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcTitle.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcTitle.tsx
@@ -1,0 +1,62 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Link as InternalLink } from 'react-router-dom';
+
+import { ButtonIcon, Flex, Label, Text } from 'design';
+import { ArrowLeft } from 'design/Icon';
+import { HoverTooltip } from 'design/Tooltip';
+
+import cfg from 'teleport/config';
+import { getStatusAndLabel } from 'teleport/Integrations/helpers';
+import { AwsResource } from 'teleport/Integrations/status/AwsOidc/StatCard';
+import { Integration } from 'teleport/services/integrations';
+
+export function AwsOidcTitle({
+  integration,
+  resource = undefined,
+}: {
+  integration: Integration;
+  resource?: AwsResource;
+}) {
+  const { status, labelKind } = getStatusAndLabel(integration);
+
+  const content = {
+    to: !resource
+      ? cfg.routes.integrations
+      : cfg.getIntegrationStatusRoute(integration.kind, integration.name),
+    helper: !resource ? 'Back to integrations' : 'Back to integration',
+    content: !resource ? integration.name : resource.toUpperCase(),
+  };
+
+  return (
+    <Flex alignItems="center" data-testid="aws-oidc-title">
+      <HoverTooltip position="bottom" tipContent={content.helper}>
+        <ButtonIcon as={InternalLink} to={content.to} aria-label="back">
+          <ArrowLeft size="medium" />
+        </ButtonIcon>
+      </HoverTooltip>
+      <Text bold fontSize={6} mx={2}>
+        {content.content}
+      </Text>
+      <Label kind={labelKind} aria-label="status" px={3} ml={3}>
+        {status}
+      </Label>
+    </Flex>
+  );
+}

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Agents.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Agents.tsx
@@ -1,0 +1,106 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router';
+
+import { Box, Flex, Indicator } from 'design';
+import { Danger } from 'design/Alert';
+import Table, { LabelCell } from 'design/DataTable';
+import { MultiselectMenu } from 'shared/components/Controls/MultiselectMenu';
+import { useAsync } from 'shared/hooks/useAsync';
+
+import { AwsResource } from 'teleport/Integrations/status/AwsOidc/StatCard';
+import {
+  AWSOIDCDeployedDatabaseService,
+  awsRegionMap,
+  IntegrationKind,
+  integrationService,
+  Regions,
+} from 'teleport/services/integrations';
+
+export function Agents() {
+  const { name, resourceKind } = useParams<{
+    type: IntegrationKind;
+    name: string;
+    resourceKind: AwsResource;
+  }>();
+
+  const [regionFilter, setRegionFilter] = useState<string[]>([]);
+  const [servicesAttempt, fetchServices] = useAsync(() => {
+    return integrationService.fetchAwsOidcDatabaseServices(
+      name,
+      resourceKind,
+      regionFilter
+    );
+  });
+
+  useEffect(() => {
+    fetchServices();
+  }, [regionFilter]);
+
+  if (servicesAttempt.status == 'processing') {
+    return (
+      <Box textAlign="center" mt={4}>
+        <Indicator />
+      </Box>
+    );
+  }
+
+  return (
+    <>
+      {servicesAttempt.status == 'error' && (
+        <Danger>{servicesAttempt.statusText}</Danger>
+      )}
+      <MultiselectMenu
+        options={Object.keys(awsRegionMap).map(r => ({
+          value: r as Regions,
+          label: (
+            <Flex justifyContent="space-between">
+              <div>{awsRegionMap[r]}&nbsp;&nbsp;</div>
+              <div>{r}</div>
+            </Flex>
+          ),
+        }))}
+        onChange={regions => setRegionFilter(regions)}
+        selected={regionFilter}
+        label="Region"
+        tooltip="Filter by region"
+      />
+      <Table<AWSOIDCDeployedDatabaseService>
+        data={servicesAttempt.data?.services || undefined}
+        columns={[
+          {
+            key: 'name',
+            headerText: 'Service Name',
+          },
+          {
+            key: 'matchingLabels',
+            headerText: 'Tags',
+            render: ({ matchingLabels }) => (
+              <LabelCell
+                data={matchingLabels.map(l => `${l.name}:${l.value}`)}
+              />
+            ),
+          },
+        ]}
+        emptyText="No rds agents"
+      />
+    </>
+  );
+}

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Agents.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Agents.tsx
@@ -83,7 +83,7 @@ export function Agents() {
         tooltip="Filter by region"
       />
       <Table<AWSOIDCDeployedDatabaseService>
-        data={servicesAttempt.data?.services || undefined}
+        data={servicesAttempt.data?.services}
         columns={[
           {
             key: 'name',
@@ -99,7 +99,7 @@ export function Agents() {
             ),
           },
         ]}
-        emptyText="No rds agents"
+        emptyText={`No ${resourceKind.toUpperCase()} agents`}
       />
     </>
   );

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Details.story.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Details.story.tsx
@@ -1,0 +1,232 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { http, HttpResponse } from 'msw';
+
+import cfg from 'teleport/config';
+import { Details } from 'teleport/Integrations/status/AwsOidc/Details/Details';
+import { AwsResource } from 'teleport/Integrations/status/AwsOidc/StatCard';
+import { MockAwsOidcStatusProvider } from 'teleport/Integrations/status/AwsOidc/testHelpers/mockAwsOidcStatusProvider';
+import { IntegrationKind } from 'teleport/services/integrations';
+
+import { makeAwsOidcStatusContextState } from '../testHelpers/makeAwsOidcStatusContextState';
+import { makeIntegrationDiscoveryRule } from '../testHelpers/makeIntegrationDiscoveryRule';
+
+export default {
+  title: 'Teleport/Integrations/AwsOidc/Details',
+};
+
+const integrationName = 'integration-story';
+
+// Empty ec2 details table
+export function EC2Empty() {
+  return (
+    <MockAwsOidcStatusProvider
+      value={makeAwsOidcStatusContextState()}
+      initialEntries={[getPath(AwsResource.ec2)]}
+      path={cfg.routes.integrationStatusResources}
+    >
+      <Details />
+    </MockAwsOidcStatusProvider>
+  );
+}
+
+// Populated ec2 details table
+export function EC2() {
+  return (
+    <MockAwsOidcStatusProvider
+      value={makeAwsOidcStatusContextState()}
+      initialEntries={[getPath(AwsResource.ec2)]}
+      path={cfg.routes.integrationStatusResources}
+    >
+      <Details />
+    </MockAwsOidcStatusProvider>
+  );
+}
+
+EC2.parameters = {
+  msw: {
+    handlers: [
+      http.get(
+        cfg.getIntegrationRulesUrl(integrationName, AwsResource.ec2),
+        () => {
+          return HttpResponse.json({
+            rules: rules,
+            nextKey: '1',
+          });
+        }
+      ),
+    ],
+  },
+};
+
+// Empty eks details table
+export function EKSEmpty() {
+  return (
+    <MockAwsOidcStatusProvider
+      value={makeAwsOidcStatusContextState()}
+      initialEntries={[getPath(AwsResource.eks)]}
+      path={cfg.routes.integrationStatusResources}
+    >
+      <Details />
+    </MockAwsOidcStatusProvider>
+  );
+}
+
+// Populated eks details table
+export function EKS() {
+  return (
+    <MockAwsOidcStatusProvider
+      value={makeAwsOidcStatusContextState()}
+      initialEntries={[getPath(AwsResource.eks)]}
+      path={cfg.routes.integrationStatusResources}
+    >
+      <Details />
+    </MockAwsOidcStatusProvider>
+  );
+}
+
+EKS.parameters = {
+  msw: {
+    handlers: [
+      http.get(
+        cfg.getIntegrationRulesUrl(integrationName, AwsResource.eks),
+        () => {
+          return HttpResponse.json({
+            rules: rules,
+            nextKey: '1',
+          });
+        }
+      ),
+    ],
+  },
+};
+
+// Empty rds details table
+export function RDSEmpty() {
+  return (
+    <MockAwsOidcStatusProvider
+      value={makeAwsOidcStatusContextState()}
+      initialEntries={[getPath(AwsResource.rds)]}
+      path={cfg.routes.integrationStatusResources}
+    >
+      <Details />
+    </MockAwsOidcStatusProvider>
+  );
+}
+
+// Populated eks details table
+export function RDS() {
+  return (
+    <MockAwsOidcStatusProvider
+      value={makeAwsOidcStatusContextState()}
+      initialEntries={[getPath(AwsResource.rds)]}
+      path={cfg.routes.integrationStatusResources}
+    >
+      <Details />
+    </MockAwsOidcStatusProvider>
+  );
+}
+
+RDS.parameters = {
+  msw: {
+    handlers: [
+      http.get(
+        cfg.getIntegrationRulesUrl(integrationName, AwsResource.rds),
+        () => {
+          return HttpResponse.json({
+            rules: rules,
+            nextKey: '1',
+          });
+        }
+      ),
+      http.post(
+        cfg.getAwsOidcDatabaseServices(integrationName, AwsResource.rds, []),
+        () => {
+          return HttpResponse.json({
+            services: [
+              {
+                name: 'dev-db',
+                matchingLabels: [{ name: 'region', value: 'us-west-2' }],
+              },
+              {
+                name: 'dev-db',
+                matchingLabels: [
+                  { name: 'region', value: 'us-west-1' },
+                  { name: '*', value: '*' },
+                ],
+              },
+              {
+                name: 'staging-db',
+                matchingLabels: [{ name: '*', value: '*' }],
+              },
+            ],
+          });
+        }
+      ),
+    ],
+  },
+};
+
+function getPath(resource: AwsResource) {
+  return cfg.getIntegrationStatusResourcesRoute(
+    IntegrationKind.AwsOidc,
+    integrationName,
+    resource
+  );
+}
+
+const rules = [
+  makeIntegrationDiscoveryRule({
+    region: 'us-west-2',
+    labelMatcher: [
+      { name: 'env', value: 'prod' },
+      { name: 'key', value: '123' },
+    ],
+  }),
+  makeIntegrationDiscoveryRule({
+    region: 'us-west-2',
+    labelMatcher: [
+      { name: 'env', value: 'prod' },
+      { name: 'key', value: '123' },
+    ],
+  }),
+  makeIntegrationDiscoveryRule({
+    region: 'us-west-2',
+    labelMatcher: [
+      { name: 'env', value: 'prod' },
+      { name: 'key', value: '123' },
+    ],
+  }),
+];

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Details.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Details.tsx
@@ -1,0 +1,54 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useParams } from 'react-router';
+
+import { FeatureBox } from 'teleport/components/Layout';
+import { AwsOidcHeader } from 'teleport/Integrations/status/AwsOidc/AwsOidcHeader';
+import { AwsOidcTitle } from 'teleport/Integrations/status/AwsOidc/AwsOidcTitle';
+import { Rds } from 'teleport/Integrations/status/AwsOidc/Details/Rds';
+import { Rules } from 'teleport/Integrations/status/AwsOidc/Details/Rules';
+import { AwsResource } from 'teleport/Integrations/status/AwsOidc/StatCard';
+import { useAwsOidcStatus } from 'teleport/Integrations/status/AwsOidc/useAwsOidcStatus';
+import { IntegrationKind } from 'teleport/services/integrations';
+
+export function Details() {
+  const { resourceKind } = useParams<{
+    type: IntegrationKind;
+    name: string;
+    resourceKind: AwsResource;
+  }>();
+
+  const { integrationAttempt } = useAwsOidcStatus();
+  const { data: integration } = integrationAttempt;
+  return (
+    <>
+      {integration && (
+        <AwsOidcHeader integration={integration} resource={resourceKind} />
+      )}
+      <FeatureBox css={{ maxWidth: '1400px', paddingTop: '16px', gap: '30px' }}>
+        {integration && (
+          <AwsOidcTitle integration={integration} resource={resourceKind} />
+        )}
+        {resourceKind == AwsResource.ec2 && <Rules />}
+        {resourceKind == AwsResource.eks && <Rules />}
+        {resourceKind == AwsResource.rds && <Rds />}
+      </FeatureBox>
+    </>
+  );
+}

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Details.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Details.tsx
@@ -45,9 +45,7 @@ export function Details() {
         {integration && (
           <AwsOidcTitle integration={integration} resource={resourceKind} />
         )}
-        {resourceKind == AwsResource.ec2 && <Rules />}
-        {resourceKind == AwsResource.eks && <Rules />}
-        {resourceKind == AwsResource.rds && <Rds />}
+        {resourceKind == AwsResource.rds ? <Rds /> : <Rules />}
       </FeatureBox>
     </>
   );

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Rds.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Rds.tsx
@@ -46,6 +46,10 @@ export function Rds() {
   const borderRef = useRef<HTMLDivElement>(null);
   const parentRef = useRef<HTMLDivElement>();
 
+  // todo (michellescripts) the following implementation mimics the implementation of tabs in
+  //  e/web/teleport/src/AccessMonitoring/AccessMonitoring.tsx which is refactored/moved into a shared
+  //  design component, web/packages/design/src/Tabs/Tabs.ts. When refactoring AccessMonitoring to use the shared
+  //  component, consider updating both instances logic to be plain css
   useEffect(() => {
     if (!parentRef.current || !borderRef.current) {
       return;
@@ -94,8 +98,8 @@ export function Rds() {
         </TabContainer>
         <TabBorder ref={borderRef} />
       </TabsContainer>
-      {tab == RdsTab.Rules && <Rules />}
-      {tab == RdsTab.Agents && <Agents />}
+      {tab === RdsTab.Rules && <Rules />}
+      {tab === RdsTab.Agents && <Agents />}
     </>
   );
 }

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Rds.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Rds.tsx
@@ -1,0 +1,101 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useEffect, useRef } from 'react';
+import { useLocation, useParams } from 'react-router';
+
+import { TabBorder, TabContainer, TabsContainer } from 'design/Tabs/Tabs';
+
+import cfg from 'teleport/config';
+import { Agents } from 'teleport/Integrations/status/AwsOidc/Details/Agents';
+import { Rules } from 'teleport/Integrations/status/AwsOidc/Details/Rules';
+import { AwsResource } from 'teleport/Integrations/status/AwsOidc/StatCard';
+import { IntegrationKind } from 'teleport/services/integrations';
+
+export enum RdsTab {
+  Agents = 'agents',
+  Rules = 'rules',
+}
+
+export function Rds() {
+  const { type, name, resourceKind } = useParams<{
+    type: IntegrationKind;
+    name: string;
+    resourceKind: AwsResource;
+  }>();
+
+  const { search } = useLocation();
+  const searchParams = new URLSearchParams(search);
+  const tab = (searchParams.get('tab') as RdsTab) || RdsTab.Rules;
+
+  const borderRef = useRef<HTMLDivElement>(null);
+  const parentRef = useRef<HTMLDivElement>();
+
+  useEffect(() => {
+    if (!parentRef.current || !borderRef.current) {
+      return;
+    }
+
+    const activeElement = parentRef.current.querySelector(
+      `[data-tab-id="${tab}"]`
+    );
+
+    if (activeElement) {
+      const parentBounds = parentRef.current.getBoundingClientRect();
+      const activeBounds = activeElement.getBoundingClientRect();
+
+      const left = activeBounds.left - parentBounds.left;
+      const width = activeBounds.width;
+
+      borderRef.current.style.left = `${left}px`;
+      borderRef.current.style.width = `${width}px`;
+    }
+  }, [tab]);
+
+  return (
+    <>
+      <TabsContainer ref={parentRef}>
+        <TabContainer
+          data-tab-id={RdsTab.Rules}
+          selected={tab === RdsTab.Rules}
+          to={`${cfg.getIntegrationStatusResourcesRoute(
+            type,
+            name,
+            resourceKind
+          )}?tab=${RdsTab.Rules}`}
+        >
+          Enrollment Rules
+        </TabContainer>
+        <TabContainer
+          data-tab-id={RdsTab.Agents}
+          selected={tab === RdsTab.Agents}
+          to={`${cfg.getIntegrationStatusResourcesRoute(
+            type,
+            name,
+            resourceKind
+          )}?tab=${RdsTab.Agents}`}
+        >
+          Agents
+        </TabContainer>
+        <TabBorder ref={borderRef} />
+      </TabsContainer>
+      {tab == RdsTab.Rules && <Rules />}
+      {tab == RdsTab.Agents && <Agents />}
+    </>
+  );
+}

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Rules.test.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Rules.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+
+import { render, screen, waitFor } from 'design/utils/testing';
+
+import { Rules } from 'teleport/Integrations/status/AwsOidc/Details/Rules';
+import {
+  IntegrationDiscoveryRule,
+  integrationService,
+} from 'teleport/services/integrations';
+
+test('renders region & labels from response', async () => {
+  jest.spyOn(integrationService, 'fetchIntegrationRules').mockResolvedValue({
+    rules: [
+      makeIntegrationDiscoveryRule({
+        region: 'us-west-2',
+        labelMatcher: [
+          { name: 'env', value: 'prod' },
+          { name: 'key', value: '123' },
+        ],
+      }),
+      makeIntegrationDiscoveryRule({
+        region: 'us-east-2',
+        labelMatcher: [{ name: 'env', value: 'stage' }],
+      }),
+      makeIntegrationDiscoveryRule({
+        region: 'us-west-1',
+        labelMatcher: [{ name: 'env', value: 'test' }],
+      }),
+      makeIntegrationDiscoveryRule({
+        region: 'us-east-1',
+        labelMatcher: [{ name: 'env', value: 'dev' }],
+      }),
+    ],
+    nextKey: '',
+  });
+  render(
+    <MemoryRouter
+      initialEntries={[
+        `/web/integrations/status/aws-oidc/some-name/resources/eks`,
+      ]}
+    >
+      <Rules />
+    </MemoryRouter>
+  );
+
+  await waitFor(() => {
+    expect(screen.getByText('env:prod')).toBeInTheDocument();
+  });
+
+  expect(getTableCellContents()).toEqual({
+    header: ['Region', 'Labels'],
+    rows: [
+      ['us-west-2', 'env:prodkey:123'],
+      ['us-east-2', 'env:stage'],
+      ['us-west-1', 'env:test'],
+      ['us-east-1', 'env:dev'],
+    ],
+  });
+
+  jest.clearAllMocks();
+});
+
+function makeIntegrationDiscoveryRule(
+  overrides: Partial<IntegrationDiscoveryRule> = {}
+): IntegrationDiscoveryRule {
+  return Object.assign(
+    {
+      resourceType: '',
+      region: '',
+      labelMatcher: [],
+      discoveryConfig: '',
+      lastSync: 0,
+    },
+    overrides
+  );
+}
+
+function getTableCellContents() {
+  const [header, ...rows] = screen.getAllByRole('row');
+  return {
+    header: within(header)
+      .getAllByRole('columnheader')
+      .map(cell => cell.textContent),
+    rows: rows.map(row =>
+      within(row)
+        .getAllByRole('cell')
+        .map(cell => cell.textContent)
+    ),
+  };
+}

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Rules.test.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Rules.test.tsx
@@ -16,16 +16,34 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 import { within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 
 import { render, screen, waitFor } from 'design/utils/testing';
 
+import { Route } from 'teleport/components/Router';
+import cfg from 'teleport/config';
 import { Rules } from 'teleport/Integrations/status/AwsOidc/Details/Rules';
-import {
-  IntegrationDiscoveryRule,
-  integrationService,
-} from 'teleport/services/integrations';
+import { integrationService } from 'teleport/services/integrations';
+
+import { makeIntegrationDiscoveryRule } from '../testHelpers/makeIntegrationDiscoveryRule';
 
 test('renders region & labels from response', async () => {
   jest.spyOn(integrationService, 'fetchIntegrationRules').mockResolvedValue({
@@ -58,7 +76,10 @@ test('renders region & labels from response', async () => {
         `/web/integrations/status/aws-oidc/some-name/resources/eks`,
       ]}
     >
-      <Rules />
+      <Route
+        path={cfg.routes.integrationStatusResources}
+        render={() => <Rules />}
+      />
     </MemoryRouter>
   );
 
@@ -78,21 +99,6 @@ test('renders region & labels from response', async () => {
 
   jest.clearAllMocks();
 });
-
-function makeIntegrationDiscoveryRule(
-  overrides: Partial<IntegrationDiscoveryRule> = {}
-): IntegrationDiscoveryRule {
-  return Object.assign(
-    {
-      resourceType: '',
-      region: '',
-      labelMatcher: [],
-      discoveryConfig: '',
-      lastSync: 0,
-    },
-    overrides
-  );
-}
 
 function getTableCellContents() {
   const [header, ...rows] = screen.getAllByRole('row');

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Rules.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Rules.tsx
@@ -1,0 +1,117 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router';
+
+import { Flex } from 'design';
+import Table, { LabelCell } from 'design/DataTable';
+import { MultiselectMenu } from 'shared/components/Controls/MultiselectMenu';
+
+import { useServerSidePagination } from 'teleport/components/hooks';
+import { AwsResource } from 'teleport/Integrations/status/AwsOidc/StatCard';
+import {
+  awsRegionMap,
+  IntegrationDiscoveryRule,
+  IntegrationKind,
+  integrationService,
+  Regions,
+} from 'teleport/services/integrations';
+
+export function Rules() {
+  const { name, resourceKind } = useParams<{
+    type: IntegrationKind;
+    name: string;
+    resourceKind: AwsResource;
+  }>();
+
+  const [regionFilter, setRegionFilter] = useState<string[]>([]);
+  const serverSidePagination =
+    useServerSidePagination<IntegrationDiscoveryRule>({
+      pageSize: 20,
+      fetchFunc: async () => {
+        // today the rules endpoint requires region. If none are selected, request all.
+        const regions =
+          regionFilter.length === 0 ? Object.keys(awsRegionMap) : regionFilter;
+        const { rules, nextKey } =
+          await integrationService.fetchIntegrationRules(
+            name,
+            resourceKind,
+            regions
+          );
+        return { agents: rules, nextKey };
+      },
+      clusterId: '',
+      params: {},
+    });
+
+  useEffect(() => {
+    serverSidePagination.fetch();
+  }, [regionFilter]);
+
+  return (
+    <>
+      <MultiselectMenu
+        options={Object.keys(awsRegionMap).map(r => ({
+          value: r as Regions,
+          label: (
+            <Flex justifyContent="space-between">
+              <div>{awsRegionMap[r]}&nbsp;&nbsp;</div>
+              <div>{r}</div>
+            </Flex>
+          ),
+        }))}
+        onChange={regions => setRegionFilter(regions)}
+        selected={regionFilter}
+        label="Region"
+        tooltip="Filter by region"
+      />
+      <Table<IntegrationDiscoveryRule>
+        data={serverSidePagination.fetchedData.agents || undefined}
+        columns={[
+          {
+            key: 'region',
+            headerText: 'Region',
+          },
+          {
+            key: 'labelMatcher',
+            headerText: getResourceTerm(resourceKind),
+            render: ({ labelMatcher }) => (
+              <LabelCell data={labelMatcher.map(l => `${l.name}:${l.value}`)} />
+            ),
+          },
+        ]}
+        emptyText={`No ${resourceKind} rules`}
+        fetching={{
+          fetchStatus: serverSidePagination.fetchStatus,
+          onFetchNext: serverSidePagination.fetchNext,
+          onFetchPrev: serverSidePagination.fetchPrev,
+        }}
+      />
+    </>
+  );
+}
+
+function getResourceTerm(resource: AwsResource): string {
+  switch (resource) {
+    case AwsResource.rds:
+      return 'Tags';
+    default:
+      return 'Labels';
+  }
+}

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Rules.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Rules.tsx
@@ -45,14 +45,11 @@ export function Rules() {
     useServerSidePagination<IntegrationDiscoveryRule>({
       pageSize: 20,
       fetchFunc: async () => {
-        // today the rules endpoint requires region. If none are selected, request all.
-        const regions =
-          regionFilter.length === 0 ? Object.keys(awsRegionMap) : regionFilter;
         const { rules, nextKey } =
           await integrationService.fetchIntegrationRules(
             name,
             resourceKind,
-            regions
+            regionFilter
           );
         return { agents: rules, nextKey };
       },
@@ -96,7 +93,7 @@ export function Rules() {
             ),
           },
         ]}
-        emptyText={`No ${resourceKind} rules`}
+        emptyText={`No ${resourceKind.toUpperCase()} rules`}
         fetching={{
           fetchStatus: serverSidePagination.fetchStatus,
           onFetchNext: serverSidePagination.fetchNext,

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/EnrollCard.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/EnrollCard.tsx
@@ -1,0 +1,68 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useHistory } from 'react-router';
+import styled from 'styled-components';
+
+import { ButtonBorder, Card, Flex, H2, ResourceIcon } from 'design';
+
+import cfg from 'teleport/config';
+import { AwsResource } from 'teleport/Integrations/status/AwsOidc/StatCard';
+
+type EnrollCardProps = {
+  resource: AwsResource;
+};
+
+export function EnrollCard({ resource }: EnrollCardProps) {
+  const history = useHistory();
+
+  const handleClick = () => {
+    history.push({
+      pathname: cfg.routes.discover,
+      state: { searchKeywords: resource },
+    });
+  };
+
+  // todo (michellescripts) update enroll design once ready
+  return (
+    <Enroll data-testid={`${resource}-enroll`}>
+      <Flex flexDirection="column" gap={4}>
+        <Flex alignItems="center" mb={2}>
+          <ResourceIcon name={resource} mr={2} width="32px" height="32px" />
+          <H2>{resource.toUpperCase()}</H2>
+        </Flex>
+        <ButtonBorder size="large" onClick={handleClick}>
+          Enroll {resource.toUpperCase()}
+        </ButtonBorder>
+      </Flex>
+    </Enroll>
+  );
+}
+
+const Enroll = styled(Card)`
+  width: 33%;
+  background-color: ${props => props.theme.colors.levels.surface};
+  padding: 12px;
+  border-radius: ${props => props.theme.radii[2]}px;
+  border: ${props => `1px solid ${props.theme.colors.levels.surface}`};
+
+  &:hover {
+    background-color: ${props => props.theme.colors.levels.elevated};
+    box-shadow: ${({ theme }) => theme.boxShadow[2]};
+  }
+`;

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/EnrollCard.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/EnrollCard.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useHistory } from 'react-router';
+import { Link as InternalLink } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { ButtonBorder, Card, Flex, H2, ResourceIcon } from 'design';
@@ -24,20 +24,7 @@ import { ButtonBorder, Card, Flex, H2, ResourceIcon } from 'design';
 import cfg from 'teleport/config';
 import { AwsResource } from 'teleport/Integrations/status/AwsOidc/StatCard';
 
-type EnrollCardProps = {
-  resource: AwsResource;
-};
-
-export function EnrollCard({ resource }: EnrollCardProps) {
-  const history = useHistory();
-
-  const handleClick = () => {
-    history.push({
-      pathname: cfg.routes.discover,
-      state: { searchKeywords: resource },
-    });
-  };
-
+export function EnrollCard({ resource }: { resource: AwsResource }) {
   // todo (michellescripts) update enroll design once ready
   return (
     <Enroll data-testid={`${resource}-enroll`}>
@@ -46,7 +33,14 @@ export function EnrollCard({ resource }: EnrollCardProps) {
           <ResourceIcon name={resource} mr={2} width="32px" height="32px" />
           <H2>{resource.toUpperCase()}</H2>
         </Flex>
-        <ButtonBorder size="large" onClick={handleClick}>
+        <ButtonBorder
+          size="large"
+          as={InternalLink}
+          to={{
+            pathname: cfg.routes.discover,
+            state: { searchKeywords: resource },
+          }}
+        >
           Enroll {resource.toUpperCase()}
         </ButtonBorder>
       </Flex>

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/StatCard.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/StatCard.tsx
@@ -17,6 +17,7 @@
  */
 
 import { formatDistanceStrict } from 'date-fns';
+import { Link as InternalLink } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { Card, Flex, H2, Text } from 'design';
@@ -25,7 +26,6 @@ import { ResourceIcon } from 'design/ResourceIcon';
 
 import cfg from 'teleport/config';
 import { EnrollCard } from 'teleport/Integrations/status/AwsOidc/EnrollCard';
-import history from 'teleport/services/history';
 import {
   IntegrationKind,
   ResourceTypeSummary,
@@ -49,22 +49,19 @@ export function StatCard({ name, resource, summary }: StatCardProps) {
     : undefined;
   const term = getResourceTerm(resource);
 
-  if (!foundResource(summary)) {
+  if (!summary || !foundResource(summary)) {
     return <EnrollCard resource={resource} />;
   }
 
   return (
     <SelectCard
       data-testid={`${resource}-stats`}
-      onClick={() => {
-        history.push(
-          cfg.getIntegrationStatusResourcesRoute(
-            IntegrationKind.AwsOidc,
-            name,
-            resource
-          )
-        );
-      }}
+      as={InternalLink}
+      to={cfg.getIntegrationStatusResourcesRoute(
+        IntegrationKind.AwsOidc,
+        name,
+        resource
+      )}
     >
       <Flex
         flexDirection="column"
@@ -148,6 +145,8 @@ export const SelectCard = styled(Card)`
   border-radius: ${props => props.theme.radii[2]}px;
   border: ${props => `1px solid ${props.theme.colors.levels.surface}`};
   cursor: pointer;
+  text-decoration: none;
+  color: ${props => props.theme.colors.text.main};
 
   &:hover {
     background-color: ${props => props.theme.colors.levels.elevated};

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/testHelpers/makeAwsOidcStatusContextState.ts
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/testHelpers/makeAwsOidcStatusContextState.ts
@@ -1,0 +1,75 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { addHours } from 'date-fns';
+
+import { makeSuccessAttempt } from 'shared/hooks/useAsync';
+
+import { AwsOidcStatusContextState } from 'teleport/Integrations/status/AwsOidc/useAwsOidcStatus';
+import {
+  IntegrationKind,
+  ResourceTypeSummary,
+} from 'teleport/services/integrations';
+
+export function makeAwsOidcStatusContextState(
+  overrides: Partial<AwsOidcStatusContextState> = {}
+): AwsOidcStatusContextState {
+  return Object.assign(
+    {
+      integrationAttempt: makeSuccessAttempt({
+        resourceType: 'integration',
+        name: 'integration-one',
+        kind: IntegrationKind.AwsOidc,
+        spec: {
+          roleArn: 'arn:aws:iam::111456789011:role/bar',
+        },
+        statusCode: 1,
+      }),
+      statsAttempt: makeSuccessAttempt({
+        name: 'integration-one',
+        subKind: IntegrationKind.AwsOidc,
+        awsoidc: {
+          roleArn: 'arn:aws:iam::111456789011:role/bar',
+        },
+        awsec2: makeResourceTypeSummary(),
+        awsrds: makeResourceTypeSummary(),
+        awseks: makeResourceTypeSummary(),
+      }),
+    },
+    overrides
+  );
+}
+
+function makeResourceTypeSummary(
+  overrides: Partial<ResourceTypeSummary> = {}
+): ResourceTypeSummary {
+  return Object.assign(
+    {
+      rulesCount: Math.floor(Math.random() * 100),
+      resourcesFound: Math.floor(Math.random() * 100),
+      resourcesEnrollmentFailed: Math.floor(Math.random() * 100),
+      resourcesEnrollmentSuccess: Math.floor(Math.random() * 100),
+      discoverLastSync: addHours(
+        new Date().getTime(),
+        -Math.floor(Math.random() * 100)
+      ),
+      ecsDatabaseServiceCount: Math.floor(Math.random() * 100),
+    },
+    overrides
+  );
+}

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/testHelpers/makeIntegrationDiscoveryRule.ts
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/testHelpers/makeIntegrationDiscoveryRule.ts
@@ -1,0 +1,34 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { IntegrationDiscoveryRule } from 'teleport/services/integrations';
+
+export function makeIntegrationDiscoveryRule(
+  overrides: Partial<IntegrationDiscoveryRule> = {}
+): IntegrationDiscoveryRule {
+  return Object.assign(
+    {
+      resourceType: '',
+      region: '',
+      labelMatcher: [],
+      discoveryConfig: '',
+      lastSync: 0,
+    },
+    overrides
+  );
+}

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/testHelpers/mockAwsOidcStatusProvider.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/testHelpers/mockAwsOidcStatusProvider.tsx
@@ -20,6 +20,7 @@ import React from 'react';
 import { MemoryRouter } from 'react-router';
 
 import { ContextProvider } from 'teleport';
+import { Route } from 'teleport/components/Router';
 import {
   awsOidcStatusContext,
   AwsOidcStatusContextState,
@@ -29,17 +30,21 @@ import { createTeleportContext } from 'teleport/mocks/contexts';
 export const MockAwsOidcStatusProvider = ({
   children,
   value,
+  initialEntries,
+  path,
 }: {
   children?: React.ReactNode;
   value: AwsOidcStatusContextState;
+  path: string;
+  initialEntries?: string[];
 }) => {
   const ctx = createTeleportContext();
 
   return (
-    <MemoryRouter>
+    <MemoryRouter initialEntries={initialEntries}>
       <ContextProvider ctx={ctx}>
         <awsOidcStatusContext.Provider value={value}>
-          {children}
+          <Route path={path} render={() => <>{children}</>} />
         </awsOidcStatusContext.Provider>
       </ContextProvider>
     </MemoryRouter>

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/useAwsOidcStatus.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/useAwsOidcStatus.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { createContext, useContext, useEffect } from 'react';
+import { createContext, useContext, useEffect } from 'react';
 import { useParams } from 'react-router';
 
 import { Attempt, useAsync } from 'shared/hooks/useAsync';

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -28,6 +28,7 @@ import type {
 } from 'shared/services';
 import { mergeDeep } from 'shared/utils/highbar';
 
+import { AwsResource } from 'teleport/Integrations/status/AwsOidc/StatCard';
 import type { SortType } from 'teleport/services/agents';
 import {
   AwsOidcPolicyPreset,
@@ -204,6 +205,8 @@ const cfg = {
     headlessSso: `/web/headless/:requestId`,
     integrations: '/web/integrations',
     integrationStatus: '/web/integrations/status/:type/:name',
+    integrationStatusResources:
+      '/web/integrations/status/:type/:name/resources/:resourceKind',
     integrationEnroll: '/web/integrations/new/:type?',
     locks: '/web/locks',
     newLock: '/web/locks/new',
@@ -358,6 +361,11 @@ const cfg = {
     integrationsPath: '/v1/webapi/sites/:clusterId/integrations/:name?',
     integrationStatsPath:
       '/v1/webapi/sites/:clusterId/integrations/:name/stats',
+    integrationRulesPath:
+      '/v1/webapi/sites/:clusterId/integrations/:name/discoveryrules?resourceType=:resourceType?&startKey=:startKey?&query=:query?&search=:search?&sort=:sort?&limit=:limit?&regions=:regions?',
+    awsOidcDatabaseServicesPath:
+      '/v1/webapi/sites/:clusterId/integrations/aws-oidc/:name/listdeployeddatabaseservices?resourceType=:resourceType?&regions=:regions?',
+
     thumbprintPath: '/v1/webapi/thumbprint',
     pingAwsOidcIntegrationPath:
       '/v1/webapi/sites/:clusterId/integrations/aws-oidc/:name/ping',
@@ -577,6 +585,18 @@ const cfg = {
 
   getIntegrationStatusRoute(type: PluginKind | IntegrationKind, name: string) {
     return generatePath(cfg.routes.integrationStatus, { type, name });
+  },
+
+  getIntegrationStatusResourcesRoute(
+    type: PluginKind | IntegrationKind,
+    name: string,
+    resourceKind: AwsResource
+  ) {
+    return generatePath(cfg.routes.integrationStatusResources, {
+      type,
+      name,
+      resourceKind,
+    });
   },
 
   getMsTeamsAppZipRoute(clusterId: string, plugin: string) {
@@ -1064,6 +1084,34 @@ const cfg = {
     });
   },
 
+  getIntegrationRulesUrl(
+    name: string,
+    resourceType: AwsResource,
+    regions?: string[]
+  ) {
+    const clusterId = cfg.proxyCluster;
+    return generateResourcePath(cfg.api.integrationRulesPath, {
+      clusterId,
+      name,
+      resourceType,
+      regions,
+    });
+  },
+
+  getAwsOidcDatabaseServices(
+    name: string,
+    resourceType: AwsResource,
+    regions: string[]
+  ) {
+    const clusterId = cfg.proxyCluster;
+    return generateResourcePath(cfg.api.awsOidcDatabaseServicesPath, {
+      clusterId,
+      name,
+      resourceType,
+      regions,
+    });
+  },
+
   getPingAwsOidcIntegrationUrl({
     integrationName,
     clusterId,
@@ -1408,6 +1456,12 @@ export interface UrlKubeResourcesParams {
   kubeNamespace?: string;
   kubeCluster: string;
   kind: Omit<KubeResourceKind, '*'>;
+}
+
+export interface UrlIntegrationParams {
+  name?: string;
+  resourceType?: string;
+  regions?: string[];
 }
 
 export interface UrlDeployServiceIamConfigureScriptParams {

--- a/web/packages/teleport/src/generateResourcePath.ts
+++ b/web/packages/teleport/src/generateResourcePath.ts
@@ -34,6 +34,8 @@ export default function generateResourcePath(
       ].dir.toLowerCase()}`;
     } else if (param === 'kinds') {
       processedParams[param] = (params[param] ?? []).join('&kinds=');
+    } else if (param === 'regions') {
+      processedParams[param] = (params[param] ?? []).join('&regions=');
     } else
       processedParams[param] = params[param]
         ? encodeURIComponent(params[param])
@@ -49,18 +51,23 @@ export default function generateResourcePath(
   }
 
   const output = path
+    // non-param
     .replace(':clusterId', params.clusterId)
-    .replace(':limit?', params.limit || '')
-    .replace(':startKey?', params.startKey || '')
-    .replace(':query?', processedParams.query || '')
-    .replace(':search?', processedParams.search || '')
-    .replace(':searchAsRoles?', processedParams.searchAsRoles || '')
-    .replace(':sort?', processedParams.sort || '')
+    .replace(':name', params.name || '')
+    // param
     .replace(':kind?', processedParams.kind || '')
     .replace(':kinds?', processedParams.kinds || '')
     .replace(':kubeCluster?', processedParams.kubeCluster || '')
     .replace(':kubeNamespace?', processedParams.kubeNamespace || '')
+    .replace(':limit?', params.limit || '')
     .replace(':pinnedOnly?', processedParams.pinnedOnly || '')
+    .replace(':query?', processedParams.query || '')
+    .replace(':resourceType?', params.resourceType || '')
+    .replace(':search?', processedParams.search || '')
+    .replace(':searchAsRoles?', processedParams.searchAsRoles || '')
+    .replace(':sort?', processedParams.sort || '')
+    .replace(':startKey?', params.startKey || '')
+    .replace(':regions?', processedParams.regions || '')
     .replace(
       ':includedResourceMode?',
       processedParams.includedResourceMode || ''

--- a/web/packages/teleport/src/services/integrations/integrations.test.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.test.ts
@@ -17,6 +17,7 @@
  */
 
 import cfg from 'teleport/config';
+import { AwsResource } from 'teleport/Integrations/status/AwsOidc/StatCard';
 import api from 'teleport/services/api';
 
 import { integrationService } from './integrations';
@@ -232,6 +233,54 @@ describe('fetchAwsDatabases() request body formatting', () => {
       );
     }
   );
+});
+
+test('fetch integration rules: fetchIntegrationRules()', async () => {
+  // test a valid response
+  jest.spyOn(api, 'get').mockResolvedValue({
+    rules: [
+      {
+        resourceType: 'eks',
+        region: 'us-west-2',
+        labelMatcher: [{ name: 'env', value: 'dev' }],
+        discoveryConfig: 'cfg',
+        lastSync: 1733782634,
+      },
+    ],
+    nextKey: 'some-key',
+  });
+
+  let response = await integrationService.fetchIntegrationRules(
+    'name',
+    AwsResource.eks
+  );
+  expect(api.get).toHaveBeenCalledWith(
+    cfg.getIntegrationRulesUrl('name', AwsResource.eks)
+  );
+  expect(response).toEqual({
+    nextKey: 'some-key',
+    rules: [
+      {
+        resourceType: 'eks',
+        region: 'us-west-2',
+        labelMatcher: [{ name: 'env', value: 'dev' }],
+        discoveryConfig: 'cfg',
+        lastSync: 1733782634,
+      },
+    ],
+  });
+
+  // test null response
+  jest.spyOn(api, 'get').mockResolvedValue(null);
+
+  response = await integrationService.fetchIntegrationRules(
+    'name',
+    AwsResource.eks
+  );
+  expect(response).toEqual({
+    nextKey: undefined,
+    rules: [],
+  });
 });
 
 const nonAwsOidcIntegration = {

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -353,6 +353,31 @@ export type IntegrationWithSummary = {
   awseks: ResourceTypeSummary;
 };
 
+// IntegrationDiscoveryRules contains the list of discovery rules for a given Integration.
+export type IntegrationDiscoveryRules = {
+  // rules is the list of integration rules.
+  rules: IntegrationDiscoveryRule[];
+  // nextKey is the position to resume listing rules.
+  nextKey: string;
+};
+
+// IntegrationDiscoveryRule describes a discovery rule associated with an integration.
+export type IntegrationDiscoveryRule = {
+  // resourceType indicates the type of resource that this rule targets.
+  // This is the same value that is set in DiscoveryConfig.AWS.<Matcher>.Types
+  // Example: ec2, rds, eks
+  resourceType: string;
+  // region where this rule applies to.
+  region: string;
+  // labelMatcher is the set of labels that are used to filter the resources before trying to auto-enroll them.
+  labelMatcher: Label[];
+  // discoveryConfig is the name of the DiscoveryConfig that created this rule.
+  discoveryConfig: string;
+  // lastSync contains the time when this rule was used.
+  // If empty, it indicates that the rule is not being used.
+  lastSync: number;
+};
+
 // ResourceTypeSummary contains the summary of the enrollment rules and found resources by the integration.
 export type ResourceTypeSummary = {
   // rulesCount is the number of enrollment rules that are using this integration.
@@ -373,6 +398,26 @@ export type ResourceTypeSummary = {
   // ecsDatabaseServiceCount is the total number of DatabaseServices that were deployed into Amazon ECS.
   // Only applicable for AWS RDS resource summary.
   ecsDatabaseServiceCount: number;
+};
+
+// AWSOIDCListDeployedDatabaseServiceResponse is a list of Teleport Database Services that are deployed as ECS Services.
+export type AWSOIDCListDeployedDatabaseServiceResponse = {
+  // services are the ECS Services.
+  services: AWSOIDCDeployedDatabaseService[];
+};
+
+// AWSOIDCDeployedDatabaseService represents a Teleport Database Service that is deployed in Amazon ECS.
+export type AWSOIDCDeployedDatabaseService = {
+  // name is the ECS Service name.
+  name: string;
+  // dashboardUrl is the link to the ECS Service in Amazon Web Console.
+  dashboardUrl: string;
+  // validTeleportConfig returns whether this ECS Service has a valid Teleport Configuration for a deployed Database Service.
+  // ECS Services with non-valid configuration require the user to take action on them.
+  // No MatchingLabels are returned with an invalid configuration.
+  validTeleportConfig: boolean;
+  // matchingLabels are the labels that are used by the Teleport Database Service to know which databases it should proxy.
+  matchingLabels: Label[];
 };
 
 // awsRegionMap maps the AWS regions to it's region name


### PR DESCRIPTION
This PR adds rules tables for each AWS resource

Refactor Notes: 
`web/packages/design/src/Tabs/Tabs.ts` is pulled from `e/web/teleport/src/AccessMonitoring/AccessMonitoring.tsx`. Once merged & backported, we can update the Access Monitoring component to use `/design`.

I also re-wrote `web/packages/teleport/src/generateResourcePath.test.ts` to accept a generic path that contains all parameters rather than using a predetermined path with a subset of params.

https://github.com/user-attachments/assets/3a41135e-93f2-4489-bfa3-e9c3d26a28de

Note:
- there is no search/sort functionality
- table functionality is limited to a region filter (back end updates still merging)
- rules tables are server side pagination with the exception of rds > agents which is client side

Supports https://github.com/gravitational/teleport/issues/49088
Agents endpoint requires https://github.com/gravitational/teleport/pull/51814 to return correctly with region filters
Rules endpoint requires https://github.com/gravitational/teleport/pull/51978 to return correctly when no regions are filtered
