### PR TITLE
examples/teleport-usage: Bump Go to 1.22 for math/rand/v2

### DIFF
--- a/examples/teleport-usage/Dockerfile
+++ b/examples/teleport-usage/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=gcr.io/distroless/static-debian12
 
-FROM golang:1.21-bookworm as builder
+FROM golang:1.22-bookworm as builder
 
 WORKDIR /go/src/github.com/gravitational/teleport/examples/teleport-usage
 

--- a/examples/teleport-usage/go.mod
+++ b/examples/teleport-usage/go.mod
@@ -1,6 +1,6 @@
 module usage-script
 
-go 1.19
+go 1.22
 
 require (
 	github.com/aws/aws-sdk-go v1.47.4


### PR DESCRIPTION
Bump Go to 1.22 in `go.mod` and the `Dockerfile` as that is the first
version with `math/rand/v2`. bcbfa8192e4c60c33599fb7e38016804d26f958d
changed this package to use `math/rand/v2` but the docker build failed
because it uses Go 1.21.
