### PR TITLE
Deflake teleport/Welcome/Welcome.test.tsx

### DIFF
--- a/web/packages/teleport/src/Welcome/Welcome.test.tsx
+++ b/web/packages/teleport/src/Welcome/Welcome.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter, Route, Router } from 'react-router';
 import { createMemoryHistory } from 'history';
 import { fireEvent, render, screen, waitFor } from 'design/utils/testing';
@@ -89,7 +88,7 @@ describe('teleport/components/Welcome', () => {
       expect(auth.fetchPasswordToken).toHaveBeenCalled();
     });
 
-    expect(screen.getByText(/confirm password/i)).toBeInTheDocument();
+    expect(await screen.findByText(/confirm password/i)).toBeInTheDocument();
   });
 
   it('should have correct welcome prompt flow for reset', async () => {
@@ -123,7 +122,7 @@ describe('teleport/components/Welcome', () => {
     });
     expect(auth.fetchPasswordToken).toHaveBeenCalled();
 
-    expect(screen.getByText(/submit/i)).toBeInTheDocument();
+    expect(await screen.findByText(/submit/i)).toBeInTheDocument();
   });
 
   it('reset password', async () => {
@@ -217,7 +216,7 @@ describe('teleport/components/Welcome', () => {
     });
 
     // Trigger submit.
-    await user.click(screen.getByText(/submit/i));
+    await user.click(await screen.findByText(/submit/i));
 
     expect(auth.resetPasswordWithWebauthn).toHaveBeenCalledWith(
       expect.objectContaining({


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/41403.

I had ["teleport/components/Welcome › should have correct welcome prompt flow for reset" fail](https://github.com/gravitational/teleport/actions/runs/12178362119/job/33968184345#step:7:819) because `screen.getByText(/submit/i)` failed to find such element in the DOM.

The tests in this file depend on checking if some service method was called, but they don't wait for the UI to process the response. Instead of depending on a method being called, they should rather check the UI state and confirm that an operation was finished before proceeding. As I don't have time to fully rewrite the tests, I changed them so that after any `expect(foo).toHaveBeenCalled()` they use `findByText` rather than `getByText`. The difference is that `getByText` fails immediately, while `findByText` waits up to 1 second for the element to show up, see [Types of Queries](https://testing-library.com/docs/queries/about/#types-of-queries).