### PR TITLE
[v17] Prevent panicing if license expiry is not populated

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1244,7 +1244,7 @@ func (h *Handler) getUserContext(w http.ResponseWriter, r *http.Request, p httpr
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if !pingResp.LicenseExpiry.IsZero() {
+	if pingResp.LicenseExpiry != nil && !pingResp.LicenseExpiry.IsZero() {
 		userContext.Cluster.LicenseExpiry = pingResp.LicenseExpiry
 	}
 


### PR DESCRIPTION
Backport #49844 to branch/v17

changelog: prevent a panic if the auth server does not provide a license expiry
