### PR TITLE
Fix flaky TestAutoUpdateAgentShouldUpdate

### DIFF
--- a/lib/web/apiserver_ping_test.go
+++ b/lib/web/apiserver_ping_test.go
@@ -459,6 +459,7 @@ func TestPing_autoUpdateResources(t *testing.T) {
 			// expire the fn cache to force the next answer to be fresh
 			for _, proxy := range env.proxies {
 				proxy.clock.Advance(2 * findEndpointCacheTTL)
+				proxy.handler.handler.findEndpointCache.RemoveExpired()
 			}
 
 			resp, err := client.NewInsecureWebClient().Do(req)

--- a/lib/web/apiserver_ping_test.go
+++ b/lib/web/apiserver_ping_test.go
@@ -459,7 +459,6 @@ func TestPing_autoUpdateResources(t *testing.T) {
 			// expire the fn cache to force the next answer to be fresh
 			for _, proxy := range env.proxies {
 				proxy.clock.Advance(2 * findEndpointCacheTTL)
-				proxy.handler.handler.findEndpointCache.RemoveExpired()
 			}
 
 			resp, err := client.NewInsecureWebClient().Do(req)

--- a/lib/web/autoupdate_common_test.go
+++ b/lib/web/autoupdate_common_test.go
@@ -167,10 +167,10 @@ func TestAutoUpdateAgentShouldUpdate(t *testing.T) {
 		}))
 	t.Cleanup(brokenChannelUpstream.Close)
 
-	clock := clockwork.NewFakeClock()
+	cacheClock := clockwork.NewFakeClock()
 	cmcCache, err := utils.NewFnCache(utils.FnCacheConfig{
 		TTL:         findEndpointCacheTTL,
-		Clock:       clock,
+		Clock:       cacheClock,
 		Context:     ctx,
 		ReloadOnErr: false,
 	})
@@ -179,6 +179,9 @@ func TestAutoUpdateAgentShouldUpdate(t *testing.T) {
 		cmcCache.Shutdown(ctx)
 	})
 
+	// We use a separate clock than the cache because we are advancing the cache clock to invalidate the cmc cache and
+	// this would interfere with the test logic
+	clock := clockwork.NewFakeClock()
 	activeUpgradeWindow := types.AgentUpgradeWindow{UTCStartHour: uint32(clock.Now().Hour())}
 	inactiveUpgradeWindow := types.AgentUpgradeWindow{UTCStartHour: uint32(clock.Now().Add(2 * time.Hour).Hour())}
 	tests := []struct {
@@ -321,8 +324,8 @@ func TestAutoUpdateAgentShouldUpdate(t *testing.T) {
 			cmc := types.NewClusterMaintenanceConfig()
 			cmc.SetAgentUpgradeWindow(tt.upgradeWindow)
 			require.NoError(t, tt.channel.CheckAndSetDefaults())
-			// Advance clock to invalidate cache
-			clock.Advance(2 * findEndpointCacheTTL)
+			// Advance cache clock to expire cached cmc
+			cacheClock.Advance(2 * findEndpointCacheTTL)
 			h := &Handler{
 				cfg: Config{
 					AccessPoint: &fakeRolloutAccessPoint{

--- a/lib/web/autoupdate_common_test.go
+++ b/lib/web/autoupdate_common_test.go
@@ -179,7 +179,7 @@ func TestAutoUpdateAgentShouldUpdate(t *testing.T) {
 		cmcCache.Shutdown(ctx)
 	})
 
-	// We use a separate clock than the cache because we are advancing the cache clock to invalidate the cmc cache and
+	// We don't use the cache clock because we are advancing it to invalidate the cmc cache and
 	// this would interfere with the test logic
 	clock := clockwork.NewFakeClock()
 	activeUpgradeWindow := types.AgentUpgradeWindow{UTCStartHour: uint32(clock.Now().Hour())}


### PR DESCRIPTION
Fix [flaky TestAutoUpdateAgentShouldUpdate](https://github.com/gravitational/teleport.e/actions/runs/12196784137/job/34025086755).

The issue was  using the same clock for 2 different purposes (maintenance window logic and FnCache). Advancing the clock to invalidate the cache potentially put us outside of the maintenance window and failed the test.