### PR TITLE
Fix flaky TestAgentRolloutController

### DIFF
--- a/lib/autoupdate/rollout/controller.go
+++ b/lib/autoupdate/rollout/controller.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	reconcilerPeriod = time.Minute
+	defaultReconcilerPeriod = time.Minute
 )
 
 // Controller wakes up every minute to reconcile the autoupdate_agent_rollout resource.
@@ -43,10 +43,14 @@ type Controller struct {
 	reconciler reconciler
 	clock      clockwork.Clock
 	log        *slog.Logger
+	period     time.Duration
 }
 
 // NewController creates a new Controller for the autoupdate_agent_rollout kind.
-func NewController(client Client, log *slog.Logger, clock clockwork.Clock) (*Controller, error) {
+// The period can be specified to control the sync frequency. This is mainly
+// used to speed up tests or for demo purposes. When empty, the controller picks
+// a sane default value.
+func NewController(client Client, log *slog.Logger, clock clockwork.Clock, period time.Duration) (*Controller, error) {
 	if client == nil {
 		return nil, trace.BadParameter("missing client")
 	}
@@ -57,24 +61,29 @@ func NewController(client Client, log *slog.Logger, clock clockwork.Clock) (*Con
 		return nil, trace.BadParameter("missing clock")
 	}
 
+	if period <= 0 {
+		period = defaultReconcilerPeriod
+	}
+
 	return &Controller{
 		clock: clock,
 		log:   log,
 		reconciler: reconciler{
-			clt:               client,
-			log:               log,
+			clt: client,
+			log: log,
 			rolloutStrategies: []rolloutStrategy{
 				// TODO(hugoShaka): add the strategies here as we implement them
 			},
 		},
+		period: period,
 	}, nil
 }
 
 // Run the autoupdate_agent_rollout controller. This function returns only when its context is canceled.
 func (c *Controller) Run(ctx context.Context) error {
 	config := interval.Config{
-		Duration:      reconcilerPeriod,
-		FirstDuration: reconcilerPeriod,
+		Duration:      c.period,
+		FirstDuration: c.period,
 		Jitter:        retryutils.SeventhJitter,
 		Clock:         c.clock,
 	}

--- a/lib/autoupdate/rollout/controller.go
+++ b/lib/autoupdate/rollout/controller.go
@@ -69,8 +69,8 @@ func NewController(client Client, log *slog.Logger, clock clockwork.Clock, perio
 		clock: clock,
 		log:   log,
 		reconciler: reconciler{
-			clt: client,
-			log: log,
+			clt:               client,
+			log:               log,
 			rolloutStrategies: []rolloutStrategy{
 				// TODO(hugoShaka): add the strategies here as we implement them
 			},

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2747,6 +2747,14 @@ func Configure(clf *CommandLineFlags, cfg *servicecfg.Config, legacyAppFlags boo
 		cfg.Proxy.QUICProxyPeering = true
 	}
 
+	if rawPeriod := os.Getenv("TELEPORT_UNSTABLE_AGENT_ROLLOUT_SYNC_PERIOD"); rawPeriod != "" {
+		period, err := time.ParseDuration(rawPeriod)
+		if err != nil {
+			return trace.Wrap(err, "invalid agent rollout period %q: %v", rawPeriod, err)
+		}
+		cfg.Auth.AgentRolloutControllerSyncPeriod = period
+	}
+
 	return nil
 }
 

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2750,7 +2750,7 @@ func Configure(clf *CommandLineFlags, cfg *servicecfg.Config, legacyAppFlags boo
 	if rawPeriod := os.Getenv("TELEPORT_UNSTABLE_AGENT_ROLLOUT_SYNC_PERIOD"); rawPeriod != "" {
 		period, err := time.ParseDuration(rawPeriod)
 		if err != nil {
-			return trace.Wrap(err, "invalid agent rollout period %q: %v", rawPeriod, err)
+			return trace.Wrap(err, "invalid agent rollout period: %q", rawPeriod)
 		}
 		cfg.Auth.AgentRolloutControllerSyncPeriod = period
 	}

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2747,14 +2747,6 @@ func Configure(clf *CommandLineFlags, cfg *servicecfg.Config, legacyAppFlags boo
 		cfg.Proxy.QUICProxyPeering = true
 	}
 
-	if rawPeriod := os.Getenv("TELEPORT_UNSTABLE_AGENT_ROLLOUT_SYNC_PERIOD"); rawPeriod != "" {
-		period, err := time.ParseDuration(rawPeriod)
-		if err != nil {
-			return trace.Wrap(err, "invalid agent rollout period: %q", rawPeriod)
-		}
-		cfg.Auth.AgentRolloutControllerSyncPeriod = period
-	}
-
 	return nil
 }
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2435,7 +2435,7 @@ func (process *TeleportProcess) initAuthService() error {
 		return trace.Wrap(spiffeFedSyncer.Run(process.GracefulExitContext()), "running SPIFFEFederation Syncer")
 	})
 
-	agentRolloutController, err := rollout.NewController(authServer, logger, process.Clock)
+	agentRolloutController, err := rollout.NewController(authServer, logger, process.Clock, cfg.Auth.AgentRolloutControllerSyncPeriod)
 	if err != nil {
 		return trace.Wrap(err, "creating the rollout controller")
 	}

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -1866,7 +1866,7 @@ func TestAgentRolloutController(t *testing.T) {
 	cfg.DebugService.Enabled = false
 	cfg.Auth.StorageConfig.Params["path"] = dataDir
 	cfg.Auth.ListenAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
-	// Speed up the reconciliation period from 1 minute to 200ms for testing purposes
+	// Speed up the reconciliation period for testing purposes.
 	cfg.Auth.AgentRolloutControllerSyncPeriod = 200 * time.Millisecond
 	cfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -1866,6 +1866,8 @@ func TestAgentRolloutController(t *testing.T) {
 	cfg.DebugService.Enabled = false
 	cfg.Auth.StorageConfig.Params["path"] = dataDir
 	cfg.Auth.ListenAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
+	// Speed up the reconciliation period from 1 minute to 200ms for testing purposes
+	cfg.Auth.AgentRolloutControllerSyncPeriod = 200 * time.Millisecond
 	cfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 
 	process, err := NewTeleport(cfg)

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -1854,7 +1854,7 @@ func TestAgentRolloutController(t *testing.T) {
 	dataDir := makeTempDir(t)
 
 	cfg := servicecfg.MakeDefaultConfig()
-	// We use a real clock because too many sevrices are using the clock and it's not possible ot accurately wait for
+	// We use a real clock because too many sevrices are using the clock and it's not possible to accurately wait for
 	// each one of them to reach the point where they wait for the clock to advance. If we add a WaitUntil(X waiters)
 	// check, this will break the next time we add a new waiter.
 	cfg.Clock = clockwork.NewRealClock()

--- a/lib/service/servicecfg/auth.go
+++ b/lib/service/servicecfg/auth.go
@@ -20,6 +20,7 @@ package servicecfg
 
 import (
 	"slices"
+	"time"
 
 	"github.com/dustin/go-humanize"
 	"github.com/gravitational/trace"
@@ -116,6 +117,12 @@ type AuthConfig struct {
 
 	// AccessMonitoring configures access monitoring.
 	AccessMonitoring *AccessMonitoringOptions
+
+	// AgentRolloutControllerSyncPeriod controls the period between two
+	// reconciliations of the agent rollout controller. This value is jittered.
+	// Empty value means the controller uses its default.
+	// Used in tests.
+	AgentRolloutControllerSyncPeriod time.Duration
 }
 
 // AccessMonitoringOptions configures access monitoring.


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/49885

My guess is that the fake clock is advanced before the controller's ticker waits for the clock.
I don't want to rely on `WaitUntil()` because too many things are using the fake clock and the test will become flaky again the next time we add a new service or just a ticker in existing one.