### PR TITLE
postrelease: prefer the Go version in go.mod's toolchain directive

### DIFF
--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -94,8 +94,8 @@ jobs:
           git config --global user.email "noreply@github.com"
           git config --global user.name "GitHub"
 
-          # get Go version from go.mod
-          GO_VERSION=$(go mod edit -json | jq -r .Go)
+          # get Go version from go.mod (preferring the toolchain directive if it's present)
+          GO_VERSION=$(go mod edit -json | jq -r 'if has("Toolchain") then .Toolchain | sub("go"; "") else .Go end')
 
           # update versions in docs/config.json
           # for docker images replace version number after <docker image name>:


### PR DESCRIPTION
The go tool will automatically remove the toolchain directive if it happens to be the same as the go directive. This means in order to reliably get the version of Go that is used to build, we need to first check the toolchain directive, and fall back to the go directive only if the toolchain is not specified.

Additionally, the toolchain directive is prefixed with "go", so we need to strip that to get consistent output.