### PR TITLE
Extend session termination timeout in integration test

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -930,7 +930,7 @@ func testSessionRecordingModes(t *testing.T, suite *integrationTestSuite) {
 	// waitSessionTermination wait until the errCh returns something and assert
 	// it with the provided function.
 	waitSessionTermination := func(t *testing.T, errCh chan error, errorAssertion require.ErrorAssertionFunc) {
-		errorAssertion(t, waitForError(errCh, 10*time.Second))
+		errorAssertion(t, waitForError(errCh, 30*time.Second))
 	}
 
 	// enableDiskFailure changes the OpenFileFunc on filesession package. The


### PR DESCRIPTION
This PR extends the timeout when waiting for session termination to 30 seconds to allow for slower execution times when running in a resource constrained environment.
