### PR TITLE
fix flaky hsm test race

### DIFF
--- a/integration/hsm/helpers.go
+++ b/integration/hsm/helpers.go
@@ -71,7 +71,7 @@ func newTeleportService(ctx context.Context, config *servicecfg.Config, name str
 	}
 	go func() {
 		defer close(t.errC)
-		t.err = svc.WaitForSignals(ctx, nil)
+		t.err = svc.Wait()
 	}()
 	t.process = svc
 


### PR DESCRIPTION
Fixes #47301
- #47301

I wasn't able to reproduce the data race locally, but I think we just need to wait for the supervisor services to exit, otherwise the auth service heartbeat can fire in one goroutine while we restart the cluster in another goroutine, leading to the data race when we read/write cfg.HostUUID.
