### PR TITLE
migrate alpnproxy to AWS SDK v2

### DIFF
--- a/lib/srv/alpnproxy/helpers_test.go
+++ b/lib/srv/alpnproxy/helpers_test.go
@@ -153,6 +153,7 @@ func (s *Suite) Start(t *testing.T) {
 }
 
 func mustGenSelfSignedCert(t *testing.T) *tlsca.CertAuthority {
+	t.Helper()
 	caKey, caCert, err := tlsca.GenerateSelfSignedCA(pkix.Name{
 		CommonName: "localhost",
 	}, []string{"localhost"}, defaults.CATTL)
@@ -183,6 +184,7 @@ func withClock(clock clockwork.Clock) signOptionsFunc {
 type signOptionsFunc func(o *signOptions)
 
 func mustGenCertSignedWithCA(t *testing.T, ca *tlsca.CertAuthority, opts ...signOptionsFunc) tls.Certificate {
+	t.Helper()
 	options := signOptions{
 		identity: tlsca.Identity{Username: "test-user"},
 		clock:    clockwork.NewRealClock(),
@@ -218,6 +220,7 @@ func mustGenCertSignedWithCA(t *testing.T, ca *tlsca.CertAuthority, opts ...sign
 }
 
 func mustReadFromConnection(t *testing.T, conn net.Conn, want string) {
+	t.Helper()
 	require.NoError(t, conn.SetReadDeadline(time.Now().Add(time.Second*5)))
 	buff, err := io.ReadAll(conn)
 	require.NoError(t, err)
@@ -226,11 +229,13 @@ func mustReadFromConnection(t *testing.T, conn net.Conn, want string) {
 }
 
 func mustCloseConnection(t *testing.T, conn net.Conn) {
+	t.Helper()
 	err := conn.Close()
 	require.NoError(t, err)
 }
 
 func mustCreateLocalListener(t *testing.T) net.Listener {
+	t.Helper()
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -240,6 +245,7 @@ func mustCreateLocalListener(t *testing.T) net.Listener {
 }
 
 func mustCreateCertGenListener(t *testing.T, ca tls.Certificate) net.Listener {
+	t.Helper()
 	listener, err := NewCertGenListener(CertGenListenerConfig{
 		ListenAddr: "localhost:0",
 		CA:         ca,
@@ -253,23 +259,26 @@ func mustCreateCertGenListener(t *testing.T, ca tls.Certificate) net.Listener {
 }
 
 func mustSuccessfullyCallHTTPSServer(t *testing.T, addr string, client http.Client) {
+	t.Helper()
 	mustCallHTTPSServerAndReceiveCode(t, addr, client, http.StatusOK)
 }
 
 func mustCallHTTPSServerAndReceiveCode(t *testing.T, addr string, client http.Client, expectStatusCode int) {
+	t.Helper()
 	resp, err := client.Get(fmt.Sprintf("https://%s", addr))
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	require.Equal(t, expectStatusCode, resp.StatusCode)
 }
 
-func mustStartHTTPServer(t *testing.T, l net.Listener) {
+func mustStartHTTPServer(l net.Listener) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(writer http.ResponseWriter, request *http.Request) {})
 	go http.Serve(l, mux)
 }
 
 func mustStartLocalProxy(t *testing.T, config LocalProxyConfig) {
+	t.Helper()
 	lp, err := NewLocalProxy(config)
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/lib/srv/alpnproxy/local_proxy_test.go
+++ b/lib/srv/alpnproxy/local_proxy_test.go
@@ -33,11 +33,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/session"
-	v4 "github.com/aws/aws-sdk-go/aws/signer/v4"
-	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/gravitational/trace"
 	"github.com/jackc/pgproto3/v2"
 	"github.com/jonboulle/clockwork"
@@ -53,72 +55,62 @@ import (
 // TestHandleAWSAccessSigVerification tests if LocalProxy verifies the AWS SigV4 signature of incoming request.
 func TestHandleAWSAccessSigVerification(t *testing.T) {
 	var (
-		firstAWSCred  = credentials.NewStaticCredentials("userID", "firstSecret", "")
-		secondAWSCred = credentials.NewStaticCredentials("userID", "secondSecret", "")
-		thirdAWSCred  = credentials.NewStaticCredentials("userID2", "firstSecret", "")
+		firstAWSCred  = credentials.NewStaticCredentialsProvider("userID", "firstSecret", "")
+		secondAWSCred = credentials.NewStaticCredentialsProvider("userID", "secondSecret", "")
+		thirdAWSCred  = credentials.NewStaticCredentialsProvider("userID2", "firstSecret", "")
 
-		awsService = "s3"
-		awsRegion  = "eu-central-1"
+		awsRegion = "eu-central-1"
 	)
 
 	testCases := []struct {
 		name       string
-		proxyCred  *credentials.Credentials
-		signFunc   func(*http.Request, io.ReadSeeker, string, string, time.Time) (http.Header, error)
-		wantErr    require.ErrorAssertionFunc
+		proxyCred  aws.CredentialsProvider
+		clientCred aws.CredentialsProvider
+		apiOpts    []func(*middleware.Stack) error
 		wantStatus int
 	}{
 		{
 			name:       "valid signature",
 			proxyCred:  firstAWSCred,
-			signFunc:   v4.NewSigner(firstAWSCred).Sign,
-			wantErr:    require.NoError,
+			clientCred: firstAWSCred,
 			wantStatus: http.StatusOK,
 		},
 		{
 			name:       "different aws secret access key",
 			proxyCred:  secondAWSCred,
-			signFunc:   v4.NewSigner(firstAWSCred).Sign,
+			clientCred: firstAWSCred,
 			wantStatus: http.StatusForbidden,
 		},
 		{
 			name:       "different aws access key ID",
 			proxyCred:  thirdAWSCred,
-			signFunc:   v4.NewSigner(firstAWSCred).Sign,
+			clientCred: firstAWSCred,
 			wantStatus: http.StatusForbidden,
 		},
 		{
-			name:      "unsigned request",
-			proxyCred: firstAWSCred,
-			signFunc: func(*http.Request, io.ReadSeeker, string, string, time.Time) (http.Header, error) {
-				// no-op
-				return nil, nil
-			},
+			name:       "unsigned request",
+			proxyCred:  firstAWSCred,
+			clientCred: nil,
 			wantStatus: http.StatusForbidden,
 		},
 		{
-			name:      "signed with User-Agent header",
-			proxyCred: secondAWSCred,
-			signFunc: func(r *http.Request, body io.ReadSeeker, service, region string, signTime time.Time) (http.Header, error) {
-				// Simulate a case where "User-Agent" is part of the "SignedHeaders".
-				// The signature does not have to be valid as it will not be compared.
-				header, err := v4.NewSigner(firstAWSCred).Sign(r, body, service, region, signTime)
-				if err != nil {
-					return nil, trace.Wrap(err)
-				}
-
-				authHeader := r.Header.Get("Authorization")
-				authHeader = strings.Replace(authHeader, "SignedHeaders=", "SignedHeaders=user-agent;", 1)
-				r.Header.Set("Authorization", authHeader)
-				return header, nil
+			name:       "signed with User-Agent header",
+			proxyCred:  secondAWSCred,
+			clientCred: firstAWSCred,
+			apiOpts: []func(*middleware.Stack) error{
+				func(stack *middleware.Stack) error {
+					stack.Finalize.Insert(
+						addUserAgentSignedHeaderMiddleware{},
+						"Signing",
+						middleware.After,
+					)
+					return nil
+				},
 			},
 			wantStatus: http.StatusOK,
 		},
 	}
 
-	httpClient := &http.Client{
-		Timeout: 5 * time.Second,
-	}
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
@@ -132,45 +124,49 @@ func TestHandleAWSAccessSigVerification(t *testing.T) {
 				Path:   "/",
 			}
 
-			payload := []byte("payload content")
-			req, err := http.NewRequest(http.MethodGet, url.String(), bytes.NewReader(payload))
-			require.NoError(t, err)
+			clt := sts.New(sts.Options{
+				APIOptions:       tc.apiOpts,
+				Region:           awsRegion,
+				Credentials:      tc.clientCred,
+				BaseEndpoint:     aws.String(url.String()),
+				HTTPClient:       &http.Client{Timeout: 5 * time.Second},
+				RetryMaxAttempts: 0,
+			})
+			_, err := clt.GetCallerIdentity(context.Background(), nil)
+			if tc.wantStatus == http.StatusOK {
+				require.NoError(t, err)
+				return
+			}
 
-			tc.signFunc(req, bytes.NewReader(payload), awsService, awsRegion, time.Now())
-
-			resp, err := httpClient.Do(req)
-			require.NoError(t, err)
-			require.Equal(t, tc.wantStatus, resp.StatusCode)
-			require.NoError(t, resp.Body.Close())
+			require.Error(t, err)
+			var serr *awshttp.ResponseError
+			require.ErrorAs(t, err, &serr)
+			require.Equal(t, tc.wantStatus, serr.HTTPStatusCode())
 		})
 	}
 }
 
 // Verifies s3 requests are signed without URL escaping to match AWS SDKs.
 func TestHandleAWSAccessS3Signing(t *testing.T) {
-	cred := credentials.NewStaticCredentials("access-key", "secret-key", "")
-	lp := createAWSAccessProxySuite(t, cred)
+	provider := credentials.NewStaticCredentialsProvider("access-key", "secret-key", "")
+	lp := createAWSAccessProxySuite(t, provider)
 
 	// Avoid loading extra things.
 	t.Setenv("AWS_SDK_LOAD_CONFIG", "false")
 
 	// Create a real AWS SDK s3 client.
-	awsConfig := aws.NewConfig().
-		WithDisableSSL(true).
-		WithRegion("local").
-		WithCredentials(cred).
-		WithEndpoint(lp.GetAddr()).
-		WithS3ForcePathStyle(true)
-
-	s3client := s3.New(session.Must(session.NewSession(awsConfig)),
-		&aws.Config{
-			HTTPClient: &http.Client{Timeout: 5 * time.Second},
-			MaxRetries: aws.Int(0),
-		})
+	s3client := s3.New(s3.Options{
+		Region:           "local",
+		Credentials:      provider,
+		BaseEndpoint:     aws.String("http://" + lp.GetAddr()),
+		UsePathStyle:     true,
+		HTTPClient:       &http.Client{Timeout: 5 * time.Second},
+		RetryMaxAttempts: 0,
+	})
 
 	// Use a bucket name with special charaters. AWS SDK actually signs the
 	// request with the unescaped bucket name.
-	_, err := s3client.ListObjects(&s3.ListObjectsInput{
+	_, err := s3client.ListObjects(context.Background(), &s3.ListObjectsInput{
 		Bucket: aws.String("=bucket=name="),
 	})
 
@@ -628,7 +624,7 @@ func TestKubeMiddleware(t *testing.T) {
 	}
 }
 
-func createAWSAccessProxySuite(t *testing.T, cred *credentials.Credentials) *LocalProxy {
+func createAWSAccessProxySuite(t *testing.T, provider aws.CredentialsProvider) *LocalProxy {
 	hs := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {}))
 
 	lp, err := NewLocalProxy(LocalProxyConfig{
@@ -637,7 +633,7 @@ func createAWSAccessProxySuite(t *testing.T, cred *credentials.Credentials) *Loc
 		Protocols:          []common.Protocol{common.ProtocolHTTP},
 		ParentContext:      context.Background(),
 		InsecureSkipVerify: true,
-		HTTPMiddleware:     &AWSAccessMiddleware{AWSCredentials: cred},
+		HTTPMiddleware:     &AWSAccessMiddleware{AWSCredentialsProvider: provider},
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -766,4 +762,24 @@ func TestGetCertsForConn(t *testing.T) {
 			}
 		})
 	}
+}
+
+type addUserAgentSignedHeaderMiddleware struct {
+}
+
+func (m addUserAgentSignedHeaderMiddleware) ID() string { return "AddUserAgentSignedHeader" }
+func (m addUserAgentSignedHeaderMiddleware) HandleFinalize(
+	ctx context.Context,
+	in middleware.FinalizeInput,
+	next middleware.FinalizeHandler,
+) (out middleware.FinalizeOutput, metadata middleware.Metadata, err error) {
+	req, ok := in.Request.(*smithyhttp.Request)
+	if !ok {
+		return out, metadata, trace.Errorf("unexpected request middleware type %T", in.Request)
+	}
+
+	authHeader := req.Header.Get("Authorization")
+	authHeader = strings.Replace(authHeader, "SignedHeaders=", "SignedHeaders=user-agent;", 1)
+	req.Header.Set("Authorization", authHeader)
+	return next.HandleFinalize(ctx, in)
 }

--- a/lib/srv/alpnproxy/proxy_test.go
+++ b/lib/srv/alpnproxy/proxy_test.go
@@ -328,7 +328,7 @@ func TestProxyHTTPConnection(t *testing.T) {
 
 	lw := NewMuxListenerWrapper(l, suite.serverListener)
 
-	mustStartHTTPServer(t, lw)
+	mustStartHTTPServer(lw)
 
 	suite.router = NewRouter()
 	suite.router.Add(HandlerDecs{
@@ -359,7 +359,7 @@ func TestProxyMakeConnectionHandler(t *testing.T) {
 
 	// Create a HTTP server and register the listener to ALPN server.
 	lw := NewMuxListenerWrapper(nil, suite.serverListener)
-	mustStartHTTPServer(t, lw)
+	mustStartHTTPServer(lw)
 
 	suite.router = NewRouter()
 	suite.router.Add(HandlerDecs{

--- a/lib/utils/aws/aws.go
+++ b/lib/utils/aws/aws.go
@@ -31,15 +31,16 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	v4 "github.com/aws/aws-sdk-go/aws/signer/v4"
-	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/gravitational/trace"
 
 	apievents "github.com/gravitational/teleport/api/types/events"
 	apiawsutils "github.com/gravitational/teleport/api/utils/aws"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/aws/migration"
 )
 
 const (
@@ -75,6 +76,8 @@ const (
 	// used by the AssumeRole call.
 	// https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html
 	MaxRoleSessionNameLength = 64
+
+	iamServiceName = "iam"
 )
 
 // SigV4 contains parsed content of the AWS Authorization header.
@@ -147,6 +150,11 @@ func IsSignedByAWSSigV4(r *http.Request) bool {
 	return strings.HasPrefix(r.Header.Get(AuthorizationHeader), AmazonSigV4AuthorizationPrefix)
 }
 
+// VerifyAWSSignatureV2 is a temporary AWS SDK migration helper.
+func VerifyAWSSignatureV2(req *http.Request, provider aws.CredentialsProvider) error {
+	return VerifyAWSSignature(req, migration.NewCredentialsAdapter(provider))
+}
+
 // VerifyAWSSignature verifies the request signature ensuring that the request originates from tsh aws command execution
 // AWS CLI signs the request with random generated credentials that are passed to LocalProxy by
 // the AWSCredentials LocalProxyConfig configuration.
@@ -212,6 +220,11 @@ func VerifyAWSSignature(req *http.Request, credentials *credentials.Credentials)
 		return trace.AccessDenied("signature verification failed")
 	}
 	return nil
+}
+
+// NewSignerV2 is a temporary AWS SDK migration helper.
+func NewSignerV2(provider aws.CredentialsProvider, signingServiceName string) *v4.Signer {
+	return NewSigner(migration.NewCredentialsAdapter(provider), signingServiceName)
 }
 
 // NewSigner creates a new V4 signer.
@@ -384,7 +397,7 @@ func BuildRoleARN(username, region, accountID string) (string, error) {
 	}
 	roleARN := arn.ARN{
 		Partition: partition,
-		Service:   iam.ServiceName,
+		Service:   iamServiceName,
 		AccountID: accountID,
 		Resource:  resource,
 	}
@@ -424,7 +437,7 @@ func ParseRoleARN(roleARN string) (*arn.ARN, error) {
 // Example role ARN: arn:aws:iam::123456789012:role/some-role-name
 func checkRoleARN(parsed *arn.ARN) error {
 	parts := strings.Split(parsed.Resource, "/")
-	if parts[0] != "role" || parsed.Service != iam.ServiceName {
+	if parts[0] != "role" || parsed.Service != iamServiceName {
 		return trace.BadParameter("%q is not an AWS IAM role ARN", parsed)
 	}
 	if len(parts) < 2 || len(parts[len(parts)-1]) == 0 {

--- a/lib/utils/aws/migration/migration.go
+++ b/lib/utils/aws/migration/migration.go
@@ -27,6 +27,12 @@ import (
 	"github.com/gravitational/trace"
 )
 
+// NewCredentialsAdapter adapts an AWS SDK v2 credentials provider to v1
+// credentials.
+func NewCredentialsAdapter(providerV2 awsv2.CredentialsProvider) *credentials.Credentials {
+	return credentials.NewCredentials(NewProviderAdapter(providerV2))
+}
+
 // NewProviderAdapter returns a [ProviderAdapter] that can be used as an AWS SDK
 // v1 credentials provider.
 func NewProviderAdapter(providerV2 awsv2.CredentialsProvider) *ProviderAdapter {

--- a/tool/tsh/common/app_aws.go
+++ b/tool/tsh/common/app_aws.go
@@ -170,7 +170,7 @@ func (a *awsApp) GetAppName() string {
 // through forward proxy.
 func (a *awsApp) StartLocalProxies(ctx context.Context, opts ...alpnproxy.LocalProxyConfigOpt) error {
 	awsMiddleware := &alpnproxy.AWSAccessMiddleware{
-		AWSCredentialsV2Provider: a.GetAWSCredentialsProvider(),
+		AWSCredentialsProvider: a.GetAWSCredentialsProvider(),
 	}
 
 	// AWS endpoint URL mode


### PR DESCRIPTION
Part of #14142
- #14142

This PR migrates alpnproxy to AWS SDK v2.