### PR TITLE
[v17] Adds RBAC support for Identity Center Accounts

### DIFF
--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -5768,11 +5768,18 @@ func TestUnifiedResources_IdentityCenter(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	t.Run("access denied", func(t *testing.T) {
-		// Asserts that, with no RBAC or matchers in place, acces to IC Accounts
-		// is denied by default
+	setAccountAssignment := func(role types.Role) {
+		r := role.(*types.RoleV6)
+		r.Spec.Allow.AccountAssignments = []types.IdentityCenterAccountAssignment{
+			{
+				Account:       "11111111",
+				PermissionSet: "some:arn",
+			},
+		}
+	}
 
-		userNoAccess, _, err := CreateUserAndRole(srv.Auth(), "test", nil, nil)
+	t.Run("no access", func(t *testing.T) {
+		userNoAccess, _, err := CreateUserAndRole(srv.Auth(), "no-access", nil, nil)
 		require.NoError(t, err)
 
 		identity := TestUser(userNoAccess.GetName())
@@ -5780,16 +5787,83 @@ func TestUnifiedResources_IdentityCenter(t *testing.T) {
 		require.NoError(t, err)
 		defer clt.Close()
 
-		_, err = clt.ListResources(ctx, proto.ListResourcesRequest{
+		resp, err := clt.ListResources(ctx, proto.ListResourcesRequest{
 			ResourceType: types.KindIdentityCenterAccount,
 			Labels: map[string]string{
 				types.OriginLabel: apicommon.OriginAWSIdentityCenter,
 			},
 		})
-		require.True(t, trace.IsAccessDenied(err))
+		require.NoError(t, err)
+		require.Empty(t, resp.Resources)
 	})
 
-	// TODO(tcsc): Add other tests one RBAC implemented
+	t.Run("access via generic kind", func(t *testing.T) {
+		user, _, err := CreateUserAndRole(srv.Auth(), "read-generic", nil,
+			[]types.Rule{
+				types.NewRule(types.KindIdentityCenter, services.RO()),
+			},
+			WithRoleMutator(setAccountAssignment))
+		require.NoError(t, err)
+
+		identity := TestUser(user.GetName())
+		clt, err := srv.NewClient(identity)
+		require.NoError(t, err)
+		defer clt.Close()
+
+		resp, err := clt.ListResources(ctx, proto.ListResourcesRequest{
+			ResourceType: types.KindIdentityCenterAccount,
+			Labels: map[string]string{
+				types.OriginLabel: apicommon.OriginAWSIdentityCenter,
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Resources, 1)
+	})
+
+	t.Run("access via specific kind", func(t *testing.T) {
+		user, _, err := CreateUserAndRole(srv.Auth(), "read-specific", nil,
+			[]types.Rule{
+				types.NewRule(types.KindIdentityCenterAccount, services.RO()),
+			},
+			WithRoleMutator(setAccountAssignment))
+		require.NoError(t, err)
+
+		identity := TestUser(user.GetName())
+		clt, err := srv.NewClient(identity)
+		require.NoError(t, err)
+		defer clt.Close()
+
+		resp, err := clt.ListResources(ctx, proto.ListResourcesRequest{
+			ResourceType: types.KindIdentityCenterAccount,
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Resources, 1)
+	})
+
+	t.Run("denied via specific kind beats allow via generic kind", func(t *testing.T) {
+		user, _, err := CreateUserAndRole(srv.Auth(), "specific-beats-generic", nil,
+			[]types.Rule{
+				types.NewRule(types.KindIdentityCenter, services.RO()),
+			},
+			WithRoleMutator(func(r types.Role) {
+				setAccountAssignment(r)
+				r.SetRules(types.Deny, []types.Rule{
+					types.NewRule(types.KindIdentityCenterAccount, services.RO()),
+				})
+			}))
+		require.NoError(t, err)
+
+		identity := TestUser(user.GetName())
+		clt, err := srv.NewClient(identity)
+		require.NoError(t, err)
+		defer clt.Close()
+
+		_, err = clt.ListResources(ctx, proto.ListResourcesRequest{
+			ResourceType: types.KindIdentityCenterAccount,
+		})
+		require.True(t, trace.IsAccessDenied(err),
+			"Expected Access Denied, got %v", err)
+	})
 }
 
 func BenchmarkListUnifiedResourcesFilter(b *testing.B) {

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -444,6 +444,18 @@ func (a *accessChecker) CheckAccess(r AccessCheckable, state AccessState, matche
 	if err := a.checkAllowedResources(r); err != nil {
 		return trace.Wrap(err)
 	}
+
+	switch rr := r.(type) {
+	case types.Resource153Unwrapper:
+		switch urr := rr.Unwrap().(type) {
+		case IdentityCenterAccount:
+			matchers = append(matchers, NewIdentityCenterAccountMatcher(urr))
+
+		case IdentityCenterAccountAssignment:
+			matchers = append(matchers, NewIdentityCenterAccountAssignmentMatcher(urr))
+		}
+	}
+
 	return trace.Wrap(a.RoleSet.checkAccess(r, a.info.Traits, state, matchers...))
 }
 

--- a/lib/services/identitycenter_test.go
+++ b/lib/services/identitycenter_test.go
@@ -95,3 +95,297 @@ func TestIdentityCenterAccountAssignmentClone(t *testing.T) {
 	require.NotEqual(t, src, dst)
 	require.Equal(t, "original name", dst.Spec.PermissionSet.Name)
 }
+
+func TestIdentityCenterAccountMatcher(t *testing.T) {
+	testCases := []struct {
+		name            string
+		roleAssignments []types.IdentityCenterAccountAssignment
+		condition       types.RoleConditionType
+		matcher         RoleMatcher
+		expectMatch     require.BoolAssertionFunc
+	}{
+		{
+			name:            "empty nonmatch",
+			roleAssignments: nil,
+			condition:       types.Allow,
+			matcher: &IdentityCenterAccountMatcher{
+				accountID: "11111111",
+			},
+			expectMatch: require.False,
+		},
+		{
+			name: "simple account match",
+			roleAssignments: []types.IdentityCenterAccountAssignment{{
+				Account:       "11111111",
+				PermissionSet: "some:arn",
+			}},
+			condition: types.Allow,
+			matcher: &IdentityCenterAccountMatcher{
+				accountID: "11111111",
+			},
+			expectMatch: require.True,
+		},
+		{
+			name: "multiple account assignments match",
+			roleAssignments: []types.IdentityCenterAccountAssignment{
+				{
+					Account:       "00000000",
+					PermissionSet: "some:arn",
+				},
+				{
+					Account:       "11111111",
+					PermissionSet: "some:arn",
+				},
+			},
+			condition: types.Allow,
+			matcher: &IdentityCenterAccountMatcher{
+				accountID: "11111111",
+			},
+			expectMatch: require.True,
+		},
+		{
+			name: "simple account nonmatch",
+			roleAssignments: []types.IdentityCenterAccountAssignment{{
+				Account:       "11111111",
+				PermissionSet: "some:arn",
+			}},
+			condition: types.Allow,
+			matcher: &IdentityCenterAccountMatcher{
+				accountID: "potato",
+			},
+			expectMatch: require.False,
+		},
+		{
+			name: "multiple account assignments match",
+			roleAssignments: []types.IdentityCenterAccountAssignment{
+				{
+					Account:       "00000000",
+					PermissionSet: "some:arn",
+				},
+				{
+					Account:       "11111111",
+					PermissionSet: "some:arn",
+				},
+			},
+			condition: types.Allow,
+			matcher: &IdentityCenterAccountMatcher{
+				accountID: "66666666",
+			},
+			expectMatch: require.False,
+		},
+		{
+			name: "account glob match",
+			roleAssignments: []types.IdentityCenterAccountAssignment{{
+				Account:       "*",
+				PermissionSet: "some:arn",
+			}},
+			condition: types.Allow,
+			matcher: &IdentityCenterAccountMatcher{
+				accountID: "potato",
+			},
+			expectMatch: require.True,
+		},
+		{
+			name: "account glob nonmatch",
+			roleAssignments: []types.IdentityCenterAccountAssignment{{
+				Account:       "*!",
+				PermissionSet: "some:arn",
+			}},
+			condition: types.Allow,
+			matcher: &IdentityCenterAccountMatcher{
+				accountID: "potato",
+			},
+			expectMatch: require.False,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			roleSpec := types.RoleSpecV6{}
+			condition := &roleSpec.Deny
+			if testCase.condition == types.Allow {
+				condition = &roleSpec.Allow
+			}
+			condition.AccountAssignments = append(condition.AccountAssignments,
+				testCase.roleAssignments...)
+
+			r, err := types.NewRole("test", roleSpec)
+			require.NoError(t, err)
+
+			match, err := testCase.matcher.Match(r, testCase.condition)
+			require.NoError(t, err)
+
+			testCase.expectMatch(t, match)
+		})
+	}
+}
+
+func TestIdentityCenterAccountAssignmentMatcher(t *testing.T) {
+	testCases := []struct {
+		name            string
+		roleAssignments []types.IdentityCenterAccountAssignment
+		condition       types.RoleConditionType
+		matcher         RoleMatcher
+		expectMatch     require.BoolAssertionFunc
+	}{
+		{
+			name:            "empty nonmatch",
+			roleAssignments: nil,
+			condition:       types.Allow,
+			matcher: &IdentityCenterAccountAssignmentMatcher{
+				accountID:        "11111111",
+				permissionSetARN: "some:arn",
+			},
+			expectMatch: require.False,
+		},
+		{
+			name: "simple match",
+			roleAssignments: []types.IdentityCenterAccountAssignment{{
+				Account:       "11111111",
+				PermissionSet: "some:arn",
+			}},
+			condition: types.Allow,
+			matcher: &IdentityCenterAccountAssignmentMatcher{
+				accountID:        "11111111",
+				permissionSetARN: "some:arn",
+			},
+			expectMatch: require.True,
+		},
+		{
+			name: "multiple match",
+			roleAssignments: []types.IdentityCenterAccountAssignment{
+				{
+					Account:       "00000000",
+					PermissionSet: "some:arn",
+				},
+				{
+					Account:       "11111111",
+					PermissionSet: "some:arn",
+				},
+			},
+			condition: types.Allow,
+			matcher: &IdentityCenterAccountAssignmentMatcher{
+				accountID:        "11111111",
+				permissionSetARN: "some:arn",
+			},
+			expectMatch: require.True,
+		},
+		{
+			name: "multiple nonmatch",
+			roleAssignments: []types.IdentityCenterAccountAssignment{
+				{
+					Account:       "00000000",
+					PermissionSet: "some:arn",
+				},
+				{
+					Account:       "11111111",
+					PermissionSet: "some:arn",
+				},
+			},
+			condition: types.Allow,
+			matcher: &IdentityCenterAccountAssignmentMatcher{
+				accountID:        "66666666",
+				permissionSetARN: "some:other:arn",
+			},
+			expectMatch: require.False,
+		},
+		{
+			name: "account glob",
+			roleAssignments: []types.IdentityCenterAccountAssignment{{
+				Account:       "*1",
+				PermissionSet: "some:arn",
+			}},
+			condition: types.Allow,
+			matcher: &IdentityCenterAccountAssignmentMatcher{
+				accountID:        "11111111",
+				permissionSetARN: "some:arn",
+			},
+			expectMatch: require.True,
+		},
+		{
+			name: "account glob nonmatch",
+			roleAssignments: []types.IdentityCenterAccountAssignment{{
+				Account:       "*!!!!",
+				PermissionSet: "some:arn",
+			}},
+			condition: types.Allow,
+			matcher: &IdentityCenterAccountAssignmentMatcher{
+				accountID:        "11111111",
+				permissionSetARN: "some:arn",
+			},
+			expectMatch: require.False,
+		},
+		{
+			name: "globbed",
+			roleAssignments: []types.IdentityCenterAccountAssignment{{
+				Account:       "*",
+				PermissionSet: "*",
+			}},
+			condition: types.Allow,
+			matcher: &IdentityCenterAccountAssignmentMatcher{
+				accountID:        "11111111",
+				permissionSetARN: "some:arn",
+			},
+			expectMatch: require.True,
+		},
+		{
+			name: "globbed nonmatch",
+			roleAssignments: []types.IdentityCenterAccountAssignment{{
+				Account:       "*",
+				PermissionSet: ":not:an:arn:*",
+			}},
+			condition: types.Allow,
+			matcher: &IdentityCenterAccountAssignmentMatcher{
+				accountID:        "11111111",
+				permissionSetARN: "some:arn",
+			},
+			expectMatch: require.False,
+		},
+		{
+			name: "bad account",
+			roleAssignments: []types.IdentityCenterAccountAssignment{{
+				Account:       "11111111",
+				PermissionSet: "some:arn",
+			}},
+			condition: types.Allow,
+			matcher: &IdentityCenterAccountAssignmentMatcher{
+				accountID:        "potato",
+				permissionSetARN: "some:arn",
+			},
+			expectMatch: require.False,
+		},
+		{
+			name: "bad permissionset arn",
+			roleAssignments: []types.IdentityCenterAccountAssignment{{
+				Account:       "11111111",
+				PermissionSet: "some:arn",
+			}},
+			condition: types.Allow,
+			matcher: &IdentityCenterAccountAssignmentMatcher{
+				accountID:        "11111111",
+				permissionSetARN: "banana",
+			},
+			expectMatch: require.False,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			roleSpec := types.RoleSpecV6{}
+			condition := &roleSpec.Deny
+			if testCase.condition == types.Allow {
+				condition = &roleSpec.Allow
+			}
+			condition.AccountAssignments = append(condition.AccountAssignments,
+				testCase.roleAssignments...)
+
+			r, err := types.NewRole("test", roleSpec)
+			require.NoError(t, err)
+
+			match, err := testCase.matcher.Match(r, testCase.condition)
+			require.NoError(t, err)
+
+			testCase.expectMatch(t, match)
+		})
+	}
+}

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -2555,7 +2555,7 @@ func rbacDebugLogger() (debugEnabled bool, debugf func(format string, args ...in
 	return
 }
 
-// resourceRequiresLabelMatching decides if a resource requires lapel matching
+// resourceRequiresLabelMatching decides if a resource requires label matching
 // when making RBAC access decisions.
 func resourceRequiresLabelMatching(r AccessCheckable) bool {
 	// Some resources do not need label matching when assessing whether the user

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -2555,6 +2555,19 @@ func rbacDebugLogger() (debugEnabled bool, debugf func(format string, args ...in
 	return
 }
 
+// resourceRequiresLabelMatching decides if a resource requires lapel matching
+// when making RBAC access decisions.
+func resourceRequiresLabelMatching(r AccessCheckable) bool {
+	// Some resources do not need label matching when assessing whether the user
+	// should be granted access. Enable it by default, but turn it off in the
+	// special cases.
+	switch r.GetKind() {
+	case types.KindIdentityCenterAccount, types.KindIdentityCenterAccountAssignment:
+		return false
+	}
+	return true
+}
+
 func (set RoleSet) checkAccess(r AccessCheckable, traits wrappers.Traits, state AccessState, matchers ...RoleMatcher) error {
 	// Note: logging in this function only happens in debug mode. This is because
 	// adding logging to this function (which is called on every resource returned
@@ -2566,6 +2579,7 @@ func (set RoleSet) checkAccess(r AccessCheckable, traits wrappers.Traits, state 
 		return ErrSessionMFARequired
 	}
 
+	requiresLabelMatching := resourceRequiresLabelMatching(r)
 	namespace := types.ProcessNamespace(r.GetMetadata().Namespace)
 
 	// Additional message depending on kind of resource
@@ -2588,18 +2602,20 @@ func (set RoleSet) checkAccess(r AccessCheckable, traits wrappers.Traits, state 
 		if !matchNamespace {
 			continue
 		}
-
-		matchLabels, labelsMessage, err := checkRoleLabelsMatch(types.Deny, role, traits, r, isDebugEnabled)
-		if err != nil {
-			return trace.Wrap(err)
+		if requiresLabelMatching {
+			matchLabels, labelsMessage, err := checkRoleLabelsMatch(types.Deny, role, traits, r, isDebugEnabled)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			if matchLabels {
+				debugf("Access to %v %q denied, deny rule in role %q matched; match(namespace=%v, %s)",
+					r.GetKind(), r.GetName(), role.GetName(), namespaceMessage, labelsMessage)
+				return trace.AccessDenied("access to %v denied. User does not have permissions. %v",
+					r.GetKind(), additionalDeniedMessage)
+			}
+		} else {
+			debugf("Role label matching skipped for %v %q", r.GetKind(), r.GetName())
 		}
-		if matchLabels {
-			debugf("Access to %v %q denied, deny rule in role %q matched; match(namespace=%v, %s)",
-				r.GetKind(), r.GetName(), role.GetName(), namespaceMessage, labelsMessage)
-			return trace.AccessDenied("access to %v denied. User does not have permissions. %v",
-				r.GetKind(), additionalDeniedMessage)
-		}
-
 		// Deny rules are greedy on purpose. They will always match if
 		// at least one of the matchers returns true.
 		matchMatchers, matchersMessage, err := RoleMatchers(matchers).MatchAny(role, types.Deny)
@@ -2633,17 +2649,21 @@ func (set RoleSet) checkAccess(r AccessCheckable, traits wrappers.Traits, state 
 			continue
 		}
 
-		matchLabels, labelsMessage, err := checkRoleLabelsMatch(types.Allow, role, traits, r, isDebugEnabled)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-
-		if !matchLabels {
-			if isDebugEnabled {
-				errs = append(errs, trace.AccessDenied("role=%v, match(%s)",
-					role.GetName(), labelsMessage))
+		if requiresLabelMatching {
+			matchLabels, labelsMessage, err := checkRoleLabelsMatch(types.Allow, role, traits, r, isDebugEnabled)
+			if err != nil {
+				return trace.Wrap(err)
 			}
-			continue
+
+			if !matchLabels {
+				if isDebugEnabled {
+					errs = append(errs, trace.AccessDenied("role=%v, match(%s)",
+						role.GetName(), labelsMessage))
+				}
+				continue
+			}
+		} else {
+			debugf("Role label matching skipped for %v %q", r.GetKind(), r.GetName())
 		}
 
 		// Allow rules are not greedy. They will match only if all of the


### PR DESCRIPTION
Backports #49808

 - Adds custom RoleMatchers for Identity Center resources
 - Disables label checking for Identity Center Account resources
 - Adds custom action checker that understands the generic
   `KindIdentityCenter` resource kind, and falls back from the
   requested resource kind to the generic one if not explicitly
   denied.
