### PR TITLE
Fix editor type switching bug for non-standard roles

### DIFF
--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.tsx
@@ -130,7 +130,7 @@ export const RoleEditor = ({
     // requires model to be valid. However, if it's OK, we reset the validator.
     // We don't want it to be validating at this point, since the user didn't
     // attempt to submit the form.
-    if (!validator.validate()) return;
+    if (!standardModel.roleModel.requiresReset && !validator.validate()) return;
     validator.reset();
 
     switch (activeIndex) {


### PR DESCRIPTION
This fixes a case where we start with a non-standard role that even after resetting would cause a validation error, then go to the standard editor only to be stuck there by the validation requirement, while the editor UI is itself blocked.

In this context, a "non-standard" role means a role whose definition contains element not yet supported by the standard editor. Not all non-standard roles will cause the validation to fail, but there are some known cases where attempting a model reset, which is done during model conversion, leaves some fields empty. (This is by design; we're replacing unknown data with no data.)

Contributes to #46612