### PR TITLE
Fix unmarshalling of CreateDatabaseUserMode

### DIFF
--- a/api/types/role.go
+++ b/api/types/role.go
@@ -2253,8 +2253,23 @@ func (h CreateDatabaseUserMode) encode() (string, error) {
 func (h *CreateDatabaseUserMode) decode(val any) error {
 	var str string
 	switch val := val.(type) {
+	case int32:
+		return trace.Wrap(h.setFromEnum(val))
+	case int64:
+		return trace.Wrap(h.setFromEnum(int32(val)))
+	case int:
+		return trace.Wrap(h.setFromEnum(int32(val)))
+	case float64:
+		return trace.Wrap(h.setFromEnum(int32(val)))
+	case float32:
+		return trace.Wrap(h.setFromEnum(int32(val)))
 	case string:
 		str = val
+	case bool:
+		if val {
+			return trace.BadParameter("create_database_user_mode cannot be true, got %v", val)
+		}
+		str = createHostUserModeOffString
 	default:
 		return trace.BadParameter("bad value type %T, expected string", val)
 	}
@@ -2272,6 +2287,15 @@ func (h *CreateDatabaseUserMode) decode(val any) error {
 		return trace.BadParameter("invalid database user mode %v", val)
 	}
 
+	return nil
+}
+
+// setFromEnum sets the value from enum value as int32.
+func (h *CreateDatabaseUserMode) setFromEnum(val int32) error {
+	if _, ok := CreateDatabaseUserMode_name[val]; !ok {
+		return trace.BadParameter("invalid database user creation mode %v", val)
+	}
+	*h = CreateDatabaseUserMode(val)
 	return nil
 }
 

--- a/api/types/role_test.go
+++ b/api/types/role_test.go
@@ -641,6 +641,49 @@ func TestUnmarshallCreateHostUserModeYAML(t *testing.T) {
 	}
 }
 
+func TestUnmarshallCreateDatabaseUserModeJSON(t *testing.T) {
+	for _, tc := range []struct {
+		expected CreateDatabaseUserMode
+		input    any
+	}{
+		{expected: CreateDatabaseUserMode_DB_USER_MODE_UNSPECIFIED, input: "\"\""},
+		{expected: CreateDatabaseUserMode_DB_USER_MODE_OFF, input: "\"off\""},
+		{expected: CreateDatabaseUserMode_DB_USER_MODE_KEEP, input: "\"keep\""},
+		{expected: CreateDatabaseUserMode_DB_USER_MODE_BEST_EFFORT_DROP, input: "\"best_effort_drop\""},
+		{expected: CreateDatabaseUserMode_DB_USER_MODE_UNSPECIFIED, input: 0},
+		{expected: CreateDatabaseUserMode_DB_USER_MODE_OFF, input: 1},
+		{expected: CreateDatabaseUserMode_DB_USER_MODE_KEEP, input: 2},
+		{expected: CreateDatabaseUserMode_DB_USER_MODE_BEST_EFFORT_DROP, input: 3},
+	} {
+		var got CreateDatabaseUserMode
+		err := json.Unmarshal([]byte(fmt.Sprintf("%v", tc.input)), &got)
+		require.NoError(t, err)
+		require.Equalf(t, tc.expected, got, "for input: %v", tc.input)
+	}
+}
+
+func TestUnmarshallCreateDatabaseUserModeYAML(t *testing.T) {
+	for _, tc := range []struct {
+		expected CreateDatabaseUserMode
+		input    any
+	}{
+		{expected: CreateDatabaseUserMode_DB_USER_MODE_UNSPECIFIED, input: "\"\""},
+		{expected: CreateDatabaseUserMode_DB_USER_MODE_OFF, input: "\"off\""},
+		{expected: CreateDatabaseUserMode_DB_USER_MODE_OFF, input: "off"},
+		{expected: CreateDatabaseUserMode_DB_USER_MODE_KEEP, input: "\"keep\""},
+		{expected: CreateDatabaseUserMode_DB_USER_MODE_BEST_EFFORT_DROP, input: "\"best_effort_drop\""},
+		{expected: CreateDatabaseUserMode_DB_USER_MODE_UNSPECIFIED, input: 0},
+		{expected: CreateDatabaseUserMode_DB_USER_MODE_OFF, input: 1},
+		{expected: CreateDatabaseUserMode_DB_USER_MODE_KEEP, input: 2},
+		{expected: CreateDatabaseUserMode_DB_USER_MODE_BEST_EFFORT_DROP, input: 3},
+	} {
+		var got CreateDatabaseUserMode
+		err := yaml.Unmarshal([]byte(fmt.Sprintf("%v", tc.input)), &got)
+		require.NoError(t, err)
+		require.Equalf(t, tc.expected, got, "for input: %v", tc.input)
+	}
+}
+
 func TestRoleV6_CheckAndSetDefaults(t *testing.T) {
 	t.Parallel()
 	requireBadParameterContains := func(contains string) require.ErrorAssertionFunc {

--- a/api/types/role_test.go
+++ b/api/types/role_test.go
@@ -593,8 +593,8 @@ func TestMarshallCreateHostUserModeYAML(t *testing.T) {
 		input    CreateHostUserMode
 		expected string
 	}{
-		{input: CreateHostUserMode_HOST_USER_MODE_OFF, expected: "\"off\""},
-		{input: CreateHostUserMode_HOST_USER_MODE_UNSPECIFIED, expected: "\"\""},
+		{input: CreateHostUserMode_HOST_USER_MODE_OFF, expected: `"off"`},
+		{input: CreateHostUserMode_HOST_USER_MODE_UNSPECIFIED, expected: `""`},
 		{input: CreateHostUserMode_HOST_USER_MODE_KEEP, expected: "keep"},
 		{input: CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP, expected: "insecure-drop"},
 	} {
@@ -606,15 +606,15 @@ func TestMarshallCreateHostUserModeYAML(t *testing.T) {
 
 func TestUnmarshallCreateHostUserModeJSON(t *testing.T) {
 	for _, tc := range []struct {
-		expected CreateHostUserMode
 		input    any
+		expected CreateHostUserMode
 	}{
-		{expected: CreateHostUserMode_HOST_USER_MODE_OFF, input: "\"off\""},
-		{expected: CreateHostUserMode_HOST_USER_MODE_UNSPECIFIED, input: "\"\""},
-		{expected: CreateHostUserMode_HOST_USER_MODE_KEEP, input: "\"keep\""},
-		{expected: CreateHostUserMode_HOST_USER_MODE_KEEP, input: 3},
-		{expected: CreateHostUserMode_HOST_USER_MODE_OFF, input: 1},
-		{expected: CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP, input: 4},
+		{input: `"off"`, expected: CreateHostUserMode_HOST_USER_MODE_OFF},
+		{input: `""`, expected: CreateHostUserMode_HOST_USER_MODE_UNSPECIFIED},
+		{input: `"keep"`, expected: CreateHostUserMode_HOST_USER_MODE_KEEP},
+		{input: 3, expected: CreateHostUserMode_HOST_USER_MODE_KEEP},
+		{input: 1, expected: CreateHostUserMode_HOST_USER_MODE_OFF},
+		{input: 4, expected: CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP},
 	} {
 		var got CreateHostUserMode
 		err := json.Unmarshal([]byte(fmt.Sprintf("%v", tc.input)), &got)
@@ -625,14 +625,14 @@ func TestUnmarshallCreateHostUserModeJSON(t *testing.T) {
 
 func TestUnmarshallCreateHostUserModeYAML(t *testing.T) {
 	for _, tc := range []struct {
-		expected CreateHostUserMode
 		input    string
+		expected CreateHostUserMode
 	}{
-		{expected: CreateHostUserMode_HOST_USER_MODE_OFF, input: "\"off\""},
-		{expected: CreateHostUserMode_HOST_USER_MODE_OFF, input: "off"},
-		{expected: CreateHostUserMode_HOST_USER_MODE_UNSPECIFIED, input: "\"\""},
-		{expected: CreateHostUserMode_HOST_USER_MODE_KEEP, input: "keep"},
-		{expected: CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP, input: "insecure-drop"},
+		{input: `"off"`, expected: CreateHostUserMode_HOST_USER_MODE_OFF},
+		{input: "off", expected: CreateHostUserMode_HOST_USER_MODE_OFF},
+		{input: `""`, expected: CreateHostUserMode_HOST_USER_MODE_UNSPECIFIED},
+		{input: "keep", expected: CreateHostUserMode_HOST_USER_MODE_KEEP},
+		{input: "insecure-drop", expected: CreateHostUserMode_HOST_USER_MODE_INSECURE_DROP},
 	} {
 		var got CreateHostUserMode
 		err := yaml.Unmarshal([]byte(tc.input), &got)
@@ -643,17 +643,17 @@ func TestUnmarshallCreateHostUserModeYAML(t *testing.T) {
 
 func TestUnmarshallCreateDatabaseUserModeJSON(t *testing.T) {
 	for _, tc := range []struct {
-		expected CreateDatabaseUserMode
 		input    any
+		expected CreateDatabaseUserMode
 	}{
-		{expected: CreateDatabaseUserMode_DB_USER_MODE_UNSPECIFIED, input: "\"\""},
-		{expected: CreateDatabaseUserMode_DB_USER_MODE_OFF, input: "\"off\""},
-		{expected: CreateDatabaseUserMode_DB_USER_MODE_KEEP, input: "\"keep\""},
-		{expected: CreateDatabaseUserMode_DB_USER_MODE_BEST_EFFORT_DROP, input: "\"best_effort_drop\""},
-		{expected: CreateDatabaseUserMode_DB_USER_MODE_UNSPECIFIED, input: 0},
-		{expected: CreateDatabaseUserMode_DB_USER_MODE_OFF, input: 1},
-		{expected: CreateDatabaseUserMode_DB_USER_MODE_KEEP, input: 2},
-		{expected: CreateDatabaseUserMode_DB_USER_MODE_BEST_EFFORT_DROP, input: 3},
+		{input: `""`, expected: CreateDatabaseUserMode_DB_USER_MODE_UNSPECIFIED},
+		{input: `"off"`, expected: CreateDatabaseUserMode_DB_USER_MODE_OFF},
+		{input: `"keep"`, expected: CreateDatabaseUserMode_DB_USER_MODE_KEEP},
+		{input: `"best_effort_drop"`, expected: CreateDatabaseUserMode_DB_USER_MODE_BEST_EFFORT_DROP},
+		{input: 0, expected: CreateDatabaseUserMode_DB_USER_MODE_UNSPECIFIED},
+		{input: 1, expected: CreateDatabaseUserMode_DB_USER_MODE_OFF},
+		{input: 2, expected: CreateDatabaseUserMode_DB_USER_MODE_KEEP},
+		{input: 3, expected: CreateDatabaseUserMode_DB_USER_MODE_BEST_EFFORT_DROP},
 	} {
 		var got CreateDatabaseUserMode
 		err := json.Unmarshal([]byte(fmt.Sprintf("%v", tc.input)), &got)
@@ -664,18 +664,18 @@ func TestUnmarshallCreateDatabaseUserModeJSON(t *testing.T) {
 
 func TestUnmarshallCreateDatabaseUserModeYAML(t *testing.T) {
 	for _, tc := range []struct {
-		expected CreateDatabaseUserMode
 		input    any
+		expected CreateDatabaseUserMode
 	}{
-		{expected: CreateDatabaseUserMode_DB_USER_MODE_UNSPECIFIED, input: "\"\""},
-		{expected: CreateDatabaseUserMode_DB_USER_MODE_OFF, input: "\"off\""},
-		{expected: CreateDatabaseUserMode_DB_USER_MODE_OFF, input: "off"},
-		{expected: CreateDatabaseUserMode_DB_USER_MODE_KEEP, input: "\"keep\""},
-		{expected: CreateDatabaseUserMode_DB_USER_MODE_BEST_EFFORT_DROP, input: "\"best_effort_drop\""},
-		{expected: CreateDatabaseUserMode_DB_USER_MODE_UNSPECIFIED, input: 0},
-		{expected: CreateDatabaseUserMode_DB_USER_MODE_OFF, input: 1},
-		{expected: CreateDatabaseUserMode_DB_USER_MODE_KEEP, input: 2},
-		{expected: CreateDatabaseUserMode_DB_USER_MODE_BEST_EFFORT_DROP, input: 3},
+		{input: `""`, expected: CreateDatabaseUserMode_DB_USER_MODE_UNSPECIFIED},
+		{input: `"off"`, expected: CreateDatabaseUserMode_DB_USER_MODE_OFF},
+		{input: "off", expected: CreateDatabaseUserMode_DB_USER_MODE_OFF},
+		{input: `"keep"`, expected: CreateDatabaseUserMode_DB_USER_MODE_KEEP},
+		{input: `"best_effort_drop"`, expected: CreateDatabaseUserMode_DB_USER_MODE_BEST_EFFORT_DROP},
+		{input: 0, expected: CreateDatabaseUserMode_DB_USER_MODE_UNSPECIFIED},
+		{input: 1, expected: CreateDatabaseUserMode_DB_USER_MODE_OFF},
+		{input: 2, expected: CreateDatabaseUserMode_DB_USER_MODE_KEEP},
+		{input: 3, expected: CreateDatabaseUserMode_DB_USER_MODE_BEST_EFFORT_DROP},
 	} {
 		var got CreateDatabaseUserMode
 		err := yaml.Unmarshal([]byte(fmt.Sprintf("%v", tc.input)), &got)


### PR DESCRIPTION
This is required to support this field in the new role editor, since data returned from `/webapi/yaml/stringify` contains numeric enum values. When fed into `PUT /webapi/roles:name`, it then resulted in an error.