### PR TITLE
fix: Corrected postStart examples

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -109,11 +109,13 @@ This is merged with chart-scoped values and takes precedence in case of conflict
 For example, to override the [`postStart`](#postStart) value only for auth pods:
 ```yaml
 # By default all pods postStart command should be "echo starting"
-postStart: ["echo", "starting"]
+postStart:
+  command: ["echo", "starting"]
 
 auth:
   # But we override the `postStart` value specifically for auth pods
-  postStart: ["curl", "http://hook"]
+  postStart:
+    command: ["curl", "http://hook"]
   imagePullPolicy: Always
 ```
 
@@ -193,11 +195,13 @@ For example, to override the [`postStart`](#postStart) value only for Teleport P
 and annotate the Kubernetes Service deployed for the Teleport Proxy Service:
 ```yaml
 # By default all pods postStart command should be "echo starting"
-postStart: ["echo", "starting"]
+postStart:
+  command: ["echo", "starting"]
 
 proxy:
   # But we override the `postStart` value specifically for proxy pods
-  postStart: ["curl", "http://hook"]
+  postStart:
+    command: ["curl", "http://hook"]
   imagePullPolicy: Always
 
   # We also annotate only the Kubernetes Service sending traffic to Proxy Service pods.

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -61,7 +61,8 @@ teleportVersionOverride: ""
 # For example:
 #
 # auth:
-#  postStart: ["curl", "http://hook"]
+#  postStart:
+#    command: ["curl", "http://hook"]
 #  imagePullPolicy: Always
 auth:
   # auth.teleportConfig contains YAML teleport configuration for auth pods
@@ -84,7 +85,8 @@ auth:
 # This is merged with chart-scoped values and takes precedence in case of conflict.
 # For example:
 # proxy:
-#   postStart: ["curl", "http://hook"]
+#   postStart:
+#     command: ["curl", "http://hook"]
 #   imagePullPolicy: Always
 #   annotations:
 #     service:


### PR DESCRIPTION
This PR fixes a wrong `postStart` example in the `teleport-cluster` Helm chart reference documentation and `values.yaml`.