### PR TITLE
Complete lib/srv/app conversion to slog

### DIFF
--- a/lib/httplib/reverseproxy/reverse_proxy.go
+++ b/lib/httplib/reverseproxy/reverse_proxy.go
@@ -19,16 +19,17 @@
 package reverseproxy
 
 import (
+	"log"
+	"log/slog"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"time"
 
 	"github.com/gravitational/trace"
-	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport/lib/defaults"
-	"github.com/gravitational/teleport/lib/utils"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 // X-* Header names.
@@ -61,7 +62,7 @@ type Forwarder struct {
 	passHostHeader bool
 	headerRewriter Rewriter
 	*httputil.ReverseProxy
-	log       logrus.FieldLogger
+	logger    *slog.Logger
 	transport http.RoundTripper
 }
 
@@ -74,8 +75,9 @@ func New(opts ...Option) (*Forwarder, error) {
 		headerRewriter: NewHeaderRewriter(),
 		ReverseProxy: &httputil.ReverseProxy{
 			ErrorHandler: DefaultHandler.ServeHTTP,
+			ErrorLog:     log.Default(),
 		},
-		log: utils.NewLogger(),
+		logger: slog.Default(),
 	}
 	// Apply options.
 	for _, opt := range opts {
@@ -102,7 +104,7 @@ func New(opts ...Option) (*Forwarder, error) {
 	}
 	// Set the transport for the reverse proxy to use a round tripper
 	// that logs the request and response.
-	fwd.ReverseProxy.Transport = &roundTripperWithLogger{transport: fwd.transport, log: fwd.log}
+	fwd.ReverseProxy.Transport = &roundTripperWithLogger{transport: fwd.transport, logger: fwd.logger}
 
 	return fwd, nil
 }
@@ -117,11 +119,10 @@ func WithFlushInterval(interval time.Duration) Option {
 	}
 }
 
-// WithLogger sets the logger for the forwarder. It uses the logger.Writer()
-// method to get the io.Writer to use for the stdlib logger.
-func WithLogger(logger logrus.FieldLogger) Option {
+// WithLogger sets the logger for the forwarder.
+func WithLogger(logger *slog.Logger) Option {
 	return func(rp *Forwarder) {
-		rp.log = logger
+		rp.logger = logger
 	}
 }
 
@@ -194,7 +195,7 @@ func getURLFromRequest(req *http.Request) *url.URL {
 }
 
 type roundTripperWithLogger struct {
-	log       logrus.FieldLogger
+	logger    *slog.Logger
 	transport http.RoundTripper
 }
 
@@ -215,20 +216,34 @@ func (r *roundTripperWithLogger) RoundTrip(req *http.Request) (*http.Response, e
 	start := time.Now()
 	rsp, err := r.transport.RoundTrip(req)
 	if err != nil {
-		r.log.Errorf("Error forwarding to %v, err: %v", req.URL, err)
+		r.logger.ErrorContext(req.Context(), "Error forwarding request",
+			"method", req.Method,
+			"url", logutils.StringerAttr(req.URL),
+			"error", err,
+		)
 		return rsp, err
 	}
 
 	if req.TLS != nil {
-		r.log.Infof("Round trip: %v %v, code: %v, duration: %v tls:version: %x, tls:resume:%t, tls:csuite:%x, tls:server:%v",
-			req.Method, req.URL, rsp.StatusCode, time.Now().UTC().Sub(start),
-			req.TLS.Version,
-			req.TLS.DidResume,
-			req.TLS.CipherSuite,
-			req.TLS.ServerName)
+		r.logger.InfoContext(req.Context(), "Round trip completed",
+			slog.String("method", req.Method),
+			slog.Any("url", logutils.StringerAttr(req.URL)),
+			slog.Int("code", rsp.StatusCode),
+			slog.Duration("duration", time.Now().UTC().Sub(start)),
+			slog.Group("tls",
+				"version", req.TLS.Version,
+				"resume", req.TLS.DidResume,
+				"csuite", req.TLS.CipherSuite,
+				"server", req.TLS.ServerName,
+			),
+		)
 	} else {
-		r.log.Infof("Round trip: %v %v, code: %v, duration: %v",
-			req.Method, req.URL, rsp.StatusCode, time.Now().UTC().Sub(start))
+		r.logger.InfoContext(req.Context(), "Round trip completed",
+			"method", req.Method,
+			"url", logutils.StringerAttr(req.URL),
+			"code", rsp.StatusCode,
+			"duration", time.Now().UTC().Sub(start),
+		)
 	}
 
 	return rsp, nil

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -2550,7 +2550,8 @@ func (f *Forwarder) makeSessionForwarder(sess *clusterSession) (*reverseproxy.Fo
 	opts := []reverseproxy.Option{
 		reverseproxy.WithFlushInterval(100 * time.Millisecond),
 		reverseproxy.WithRoundTripper(transport),
-		reverseproxy.WithLogger(f.log),
+		// TODO(tross): convert this to use f.log once it has been converted to use slog
+		reverseproxy.WithLogger(slog.Default()),
 		reverseproxy.WithErrorHandler(f.formatForwardResponseError),
 	}
 	if sess.isLocalKubernetesCluster {

--- a/lib/srv/app/aws/handler.go
+++ b/lib/srv/app/aws/handler.go
@@ -31,7 +31,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -54,10 +53,6 @@ type signerHandler struct {
 
 // SignerHandlerConfig is the awsSignerHandler configuration.
 type SignerHandlerConfig struct {
-	// LegacyLogger is the old logger.
-	// Should be removed gradually.
-	// Deprecated: use Log instead.
-	LegacyLogger logrus.FieldLogger
 	// Log is a logger for the handler.
 	Log *slog.Logger
 	// RoundTripper is an http.RoundTripper instance used for requests.
@@ -81,9 +76,6 @@ func (cfg *SignerHandlerConfig) CheckAndSetDefaults() error {
 			return trace.Wrap(err)
 		}
 		cfg.RoundTripper = tr
-	}
-	if cfg.LegacyLogger == nil {
-		cfg.LegacyLogger = logrus.WithField(teleport.ComponentKey, "aws:signer")
 	}
 	if cfg.Log == nil {
 		cfg.Log = slog.With(teleport.ComponentKey, "aws:signer")
@@ -114,7 +106,7 @@ func NewAWSSignerHandler(ctx context.Context, config SignerHandlerConfig) (http.
 	var err error
 	handler.fwd, err = reverseproxy.New(
 		reverseproxy.WithRoundTripper(config.RoundTripper),
-		reverseproxy.WithLogger(config.LegacyLogger),
+		reverseproxy.WithLogger(config.Log),
 		reverseproxy.WithErrorHandler(handler.formatForwardResponseError),
 	)
 

--- a/lib/srv/app/azure/handler.go
+++ b/lib/srv/app/azure/handler.go
@@ -31,7 +31,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
@@ -51,10 +50,6 @@ const ComponentKey = "azure:fwd"
 type HandlerConfig struct {
 	// RoundTripper is the underlying transport given to an oxy Forwarder.
 	RoundTripper http.RoundTripper
-	// LegacyLogger is the old logger.
-	// Should be removed gradually.
-	// Deprecated: use Log instead.
-	LegacyLogger logrus.FieldLogger
 	// Log is a logger for the handler.
 	Log *slog.Logger
 	// Clock is used to override time in tests.
@@ -75,9 +70,6 @@ func (s *HandlerConfig) CheckAndSetDefaults(ctx context.Context) error {
 	}
 	if s.Clock == nil {
 		s.Clock = clockwork.NewRealClock()
-	}
-	if s.LegacyLogger == nil {
-		s.LegacyLogger = logrus.WithField(teleport.ComponentKey, ComponentKey)
 	}
 	if s.Log == nil {
 		s.Log = slog.With(teleport.ComponentKey, ComponentKey)
@@ -128,7 +120,7 @@ func newAzureHandler(ctx context.Context, config HandlerConfig) (*handler, error
 
 	svc.fwd, err = reverseproxy.New(
 		reverseproxy.WithRoundTripper(config.RoundTripper),
-		reverseproxy.WithLogger(config.LegacyLogger),
+		reverseproxy.WithLogger(config.Log),
 		reverseproxy.WithErrorHandler(svc.formatForwardResponseError),
 	)
 

--- a/lib/srv/app/connections_handler.go
+++ b/lib/srv/app/connections_handler.go
@@ -26,6 +26,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"log"
 	"log/slog"
 	"net"
 	"net/http"
@@ -35,7 +36,6 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
@@ -170,9 +170,6 @@ type ConnectionsHandler struct {
 	cfg *ConnectionsHandlerConfig
 	log *slog.Logger
 
-	// TODO(marco): convert everything to log/slog
-	legacyLogger *logrus.Entry
-
 	closeContext context.Context
 
 	httpServer *http.Server
@@ -244,7 +241,6 @@ func NewConnectionsHandler(closeContext context.Context, cfg *ConnectionsHandler
 		gcpHandler:   gcpHandler,
 		connAuth:     make(map[net.Conn]error),
 		log:          slog.With(teleport.ComponentKey, cfg.ServiceComponent),
-		legacyLogger: logrus.WithFields(logrus.Fields{teleport.ComponentKey: cfg.ServiceComponent}),
 		getAppByPublicAddress: func(ctx context.Context, s string) (types.Application, error) {
 			return nil, trace.NotFound("no applications are being proxied")
 		},
@@ -281,7 +277,7 @@ func NewConnectionsHandler(closeContext context.Context, cfg *ConnectionsHandler
 
 	// Make copy of server's TLS configuration and update it with the specific
 	// functionality this server needs, like requiring client certificates.
-	c.tlsConfig = CopyAndConfigureTLS(c.legacyLogger, c.cfg.AccessPoint, c.cfg.TLSConfig)
+	c.tlsConfig = CopyAndConfigureTLS(c.log, c.cfg.AccessPoint, c.cfg.TLSConfig)
 
 	// Figure out the port the proxy is running on.
 	c.proxyPort = c.getProxyPort()
@@ -665,7 +661,7 @@ func (c *ConnectionsHandler) newHTTPServer(clusterName string) *http.Server {
 		Handler:           httplib.MakeTracingHandler(c.authMiddleware, c.cfg.ServiceComponent),
 		ReadHeaderTimeout: defaults.ReadHeadersTimeout,
 		IdleTimeout:       apidefaults.DefaultIdleTimeout,
-		ErrorLog:          utils.NewStdlogger(c.legacyLogger.Error, c.cfg.ServiceComponent),
+		ErrorLog:          log.Default(),
 		ConnContext: func(ctx context.Context, c net.Conn) context.Context {
 			return context.WithValue(ctx, connContextKey, c)
 		},
@@ -753,10 +749,10 @@ func (c *ConnectionsHandler) deleteConnAuth(conn net.Conn) {
 
 // CopyAndConfigureTLS can be used to copy and modify an existing *tls.Config
 // for Teleport application proxy servers.
-func CopyAndConfigureTLS(log logrus.FieldLogger, client authclient.AccessCache, config *tls.Config) *tls.Config {
+func CopyAndConfigureTLS(log *slog.Logger, client authclient.AccessCache, config *tls.Config) *tls.Config {
 	tlsConfig := config.Clone()
 	if log == nil {
-		log = logrus.StandardLogger()
+		log = slog.Default()
 	}
 
 	// Require clients to present a certificate
@@ -771,7 +767,7 @@ func CopyAndConfigureTLS(log logrus.FieldLogger, client authclient.AccessCache, 
 	return tlsConfig
 }
 
-func newGetConfigForClientFn(log logrus.FieldLogger, client authclient.AccessCache, tlsConfig *tls.Config) func(*tls.ClientHelloInfo) (*tls.Config, error) {
+func newGetConfigForClientFn(log *slog.Logger, client authclient.AccessCache, tlsConfig *tls.Config) func(*tls.ClientHelloInfo) (*tls.Config, error) {
 	return func(info *tls.ClientHelloInfo) (*tls.Config, error) {
 		var clusterName string
 		var err error
@@ -781,7 +777,7 @@ func newGetConfigForClientFn(log logrus.FieldLogger, client authclient.AccessCac
 			clusterName, err = apiutils.DecodeClusterName(info.ServerName)
 			if err != nil {
 				if !trace.IsNotFound(err) {
-					log.Debugf("Ignoring unsupported cluster name %q.", info.ServerName)
+					log.DebugContext(info.Context(), "Ignoring unsupported cluster name", "cluster_name", info.ServerName)
 				}
 			}
 		}
@@ -791,8 +787,7 @@ func newGetConfigForClientFn(log logrus.FieldLogger, client authclient.AccessCac
 		pool, _, err := authclient.DefaultClientCertPool(info.Context(), client, clusterName)
 		if err != nil {
 			// If this request fails, return nil and fallback to the default ClientCAs.
-
-			log.Debugf("Failed to retrieve client pool: %v.", trace.DebugReport(err))
+			log.DebugContext(info.Context(), "Failed to retrieve client pool", "error", err)
 			return nil, nil
 		}
 

--- a/lib/srv/app/gcp/handler.go
+++ b/lib/srv/app/gcp/handler.go
@@ -31,7 +31,6 @@ import (
 	"github.com/googleapis/gax-go/v2"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/utils/gcp"
@@ -69,10 +68,6 @@ var _ cloudClientGCP = (*cloudClientGCPImpl[iamCredentialsClient])(nil)
 type HandlerConfig struct {
 	// RoundTripper is the underlying transport given to an oxy Forwarder.
 	RoundTripper http.RoundTripper
-	// LegacyLogger is the old logger.
-	// Should be removed gradually.
-	// Deprecated: use Log instead.
-	LegacyLogger logrus.FieldLogger
 	// Log is a logger for the handler.
 	Log *slog.Logger
 	// Clock is used to override time in tests.
@@ -95,9 +90,6 @@ func (s *HandlerConfig) CheckAndSetDefaults() error {
 	}
 	if s.Log == nil {
 		s.Log = slog.With(teleport.ComponentKey, "gcp:fwd")
-	}
-	if s.LegacyLogger == nil {
-		s.LegacyLogger = logrus.WithField(teleport.ComponentKey, "gcp:fwd")
 	}
 	if s.cloudClientGCP == nil {
 		clients, err := cloud.NewClients()
@@ -149,7 +141,7 @@ func newGCPHandler(ctx context.Context, config HandlerConfig) (*handler, error) 
 
 	svc.fwd, err = reverseproxy.New(
 		reverseproxy.WithRoundTripper(config.RoundTripper),
-		reverseproxy.WithLogger(config.LegacyLogger),
+		reverseproxy.WithLogger(config.Log),
 		reverseproxy.WithErrorHandler(svc.formatForwardResponseError),
 	)
 	return svc, trace.Wrap(err)

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/gravitational/teleport"
@@ -133,9 +132,8 @@ func (c *Config) CheckAndSetDefaults() error {
 // Server is an application server. It authenticates requests from the web
 // proxy and forwards th to internal applications.
 type Server struct {
-	c         *Config
-	legacyLog *logrus.Entry
-	log       *slog.Logger
+	c   *Config
+	log *slog.Logger
 
 	closeContext context.Context
 	closeFunc    context.CancelFunc
@@ -200,11 +198,7 @@ func New(ctx context.Context, c *Config) (*Server, error) {
 	}()
 
 	s := &Server{
-		c: c,
-		// TODO(greedy52) replace with slog from Config.Logger.
-		legacyLog: logrus.WithFields(logrus.Fields{
-			teleport.ComponentKey: teleport.ComponentApp,
-		}),
+		c:             c,
 		log:           slog.With(teleport.ComponentKey, teleport.ComponentApp),
 		heartbeats:    make(map[string]srv.HeartbeatI),
 		dynamicLabels: make(map[string]*labels.Dynamic),

--- a/lib/srv/app/session.go
+++ b/lib/srv/app/session.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
-	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
@@ -85,8 +84,6 @@ type sessionChunk struct {
 	closeTimeout time.Duration
 
 	log *slog.Logger
-
-	legacyLogger *logrus.Entry
 }
 
 // sessionOpt defines an option function for creating sessionChunk.
@@ -103,7 +100,6 @@ func (c *ConnectionsHandler) newSessionChunk(ctx context.Context, identity *tlsc
 		inflightCond: sync.NewCond(&sync.Mutex{}),
 		closeTimeout: sessionChunkCloseTimeout,
 		log:          c.log,
-		legacyLogger: c.legacyLogger,
 	}
 
 	sess.log.DebugContext(ctx, "Creating app session chunk", "session_id", sess.id)
@@ -202,7 +198,7 @@ func (c *ConnectionsHandler) withJWTTokenForwarder(ctx context.Context, sess *se
 	sess.handler, err = reverseproxy.New(
 		reverseproxy.WithFlushInterval(100*time.Millisecond),
 		reverseproxy.WithRoundTripper(transport),
-		reverseproxy.WithLogger(sess.legacyLogger),
+		reverseproxy.WithLogger(sess.log),
 		reverseproxy.WithRewriter(common.NewHeaderRewriter(delegate)),
 	)
 	if err != nil {

--- a/lib/srv/app/session_test.go
+++ b/lib/srv/app/session_test.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/lib/events"
@@ -38,7 +37,6 @@ func newSessionChunk(timeout time.Duration) *sessionChunk {
 		closeC:       make(chan struct{}),
 		inflightCond: sync.NewCond(&sync.Mutex{}),
 		closeTimeout: timeout,
-		legacyLogger: logrus.NewEntry(logrus.StandardLogger()),
 		log:          utils.NewSlogLoggerForTests(),
 		streamCloser: events.NewDiscardRecorder(),
 	}

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -25,6 +25,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -34,7 +35,6 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/julienschmidt/httprouter"
-	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
@@ -103,7 +103,7 @@ type Handler struct {
 
 	clusterName string
 
-	log *logrus.Entry
+	logger *slog.Logger
 }
 
 // NewHandler returns a new application handler.
@@ -116,9 +116,7 @@ func NewHandler(ctx context.Context, c *HandlerConfig) (*Handler, error) {
 	h := &Handler{
 		c:            c,
 		closeContext: ctx,
-		log: logrus.WithFields(logrus.Fields{
-			teleport.ComponentKey: teleport.ComponentAppProxy,
-		}),
+		logger:       slog.With(teleport.ComponentKey, teleport.ComponentAppProxy),
 	}
 
 	// Create a new session cache, this holds sessions that can be used to
@@ -336,7 +334,7 @@ func (h *Handler) handleForwardError(w http.ResponseWriter, req *http.Request, e
 func (h *Handler) authenticate(ctx context.Context, r *http.Request) (*session, error) {
 	ws, err := h.getAppSession(r)
 	if err != nil {
-		h.log.Warnf("Failed to fetch application session: %v.", err)
+		h.logger.WarnContext(ctx, "Failed to fetch application session", "error", err)
 		return nil, trace.AccessDenied("invalid session")
 	}
 
@@ -344,7 +342,7 @@ func (h *Handler) authenticate(ctx context.Context, r *http.Request) (*session, 
 	// process has seen.
 	session, err := h.getSession(ctx, ws)
 	if err != nil {
-		h.log.Warnf("Failed to get session: %v.", err)
+		h.logger.WarnContext(ctx, "Failed to get session", "error", err)
 		return nil, trace.AccessDenied("invalid session")
 	}
 
@@ -357,7 +355,7 @@ func (h *Handler) authenticate(ctx context.Context, r *http.Request) (*session, 
 func (h *Handler) renewSession(r *http.Request) (*session, error) {
 	ws, err := h.getAppSession(r)
 	if err != nil {
-		h.log.Debugf("Failed to fetch application session: not found.")
+		h.logger.DebugContext(r.Context(), "Failed to fetch application session: not found")
 		return nil, trace.AccessDenied("invalid session")
 	}
 
@@ -368,7 +366,7 @@ func (h *Handler) renewSession(r *http.Request) (*session, error) {
 	// Fetches a new session using the same flow as `authenticate`.
 	session, err := h.getSession(r.Context(), ws)
 	if err != nil {
-		h.log.Warnf("Failed to get session: %v.", err)
+		h.logger.WarnContext(r.Context(), "Failed to get session", "error", err)
 		return nil, trace.AccessDenied("invalid session")
 	}
 
@@ -387,7 +385,7 @@ func (h *Handler) getAppSession(r *http.Request) (ws types.WebSession, err error
 		ws, err = h.getAppSessionFromCookie(r)
 	}
 	if err != nil {
-		h.log.Warnf("Failed to get session: %v.", err)
+		h.logger.WarnContext(r.Context(), "Failed to get session", "error", err)
 		return nil, trace.AccessDenied("invalid session")
 	}
 	return ws, nil

--- a/lib/web/app/middleware.go
+++ b/lib/web/app/middleware.go
@@ -75,10 +75,10 @@ func (h *Handler) redirectToLauncher(w http.ResponseWriter, r *http.Request, p l
 	if h.c.WebPublicAddr == "" {
 		// The error below tends to be swallowed by the Web UI, so log a warning for
 		// admins as well.
-		h.log.Error("" +
-			"Application Service requires public_addr to be set in the Teleport Proxy Service configuration. " +
+		const msg = "Application Service requires public_addr to be set in the Teleport Proxy Service configuration. " +
 			"Please contact your Teleport cluster administrator or refer to " +
-			"https://goteleport.com/docs/application-access/guides/connecting-apps/#start-authproxy-service.")
+			"https://goteleport.com/docs/application-access/guides/connecting-apps/#start-authproxy-service."
+		h.logger.ErrorContext(r.Context(), msg)
 		return trace.BadParameter("public address of the proxy is not set")
 	}
 

--- a/lib/web/app/session.go
+++ b/lib/web/app/session.go
@@ -79,7 +79,7 @@ func (h *Handler) newSession(ctx context.Context, ws types.WebSession) (*session
 
 	// Create a rewriting transport that will be used to forward requests.
 	transport, err := newTransport(&transportConfig{
-		log:                   h.log,
+		log:                   h.logger,
 		clock:                 h.c.Clock,
 		proxyClient:           h.c.ProxyClient,
 		accessPoint:           h.c.AccessPoint,
@@ -104,7 +104,7 @@ func (h *Handler) newSession(ctx context.Context, ws types.WebSession) (*session
 		reverseproxy.WithPassHostHeader(),
 		reverseproxy.WithFlushInterval(100*time.Millisecond),
 		reverseproxy.WithRoundTripper(transport),
-		reverseproxy.WithLogger(h.log),
+		reverseproxy.WithLogger(h.logger),
 		reverseproxy.WithErrorHandler(h.handleForwardError),
 		reverseproxy.WithRewriter(hr),
 	)

--- a/lib/web/app/transport.go
+++ b/lib/web/app/transport.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -30,7 +31,6 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
@@ -62,7 +62,7 @@ type transportConfig struct {
 	servers      []types.AppServer
 	ws           types.WebSession
 	clusterName  string
-	log          logrus.FieldLogger
+	log          *slog.Logger
 	clock        clockwork.Clock
 
 	// integrationAppHandler is used to handle App proxy requests for Apps that are configured to use an Integration.
@@ -97,7 +97,7 @@ func (c *transportConfig) Check() error {
 		return trace.BadParameter("integration app handler missing")
 	}
 	if c.log == nil {
-		c.log = logrus.New()
+		c.log = slog.Default()
 	}
 	if c.clock == nil {
 		c.clock = clockwork.NewRealClock()
@@ -265,7 +265,7 @@ func (t *transport) rewriteRequest(r *http.Request) error {
 				// Service should fail to parse the JWT and reject the request,
 				// but rejecting here could cause forward compatibility issues,
 				// if for example we add new types of JWT tokens.
-				t.c.log.WithError(err).Debug("failed to re-sign azure JWT")
+				t.c.log.DebugContext(r.Context(), "failed to re-sign azure JWT", "error", err)
 			}
 
 			break
@@ -363,8 +363,7 @@ func (t *transport) DialContext(ctx context.Context, _, _ string) (conn net.Conn
 
 		conn, err = dialAppServer(ctx, t.c.proxyClient, t.c.identity.RouteToApp.ClusterName, appServer)
 		if err != nil && isReverseTunnelDownError(err) {
-			t.c.log.WithFields(logrus.Fields{"app_server": appServer.GetName()}).
-				Warnf("Failed to connect to application server: %v", err)
+			t.c.log.WarnContext(ctx, "Failed to connect to application server", "app_server", appServer.GetName(), "error", err)
 			// Continue to the next server if there is an issue
 			// establishing a connection because the tunnel is not
 			// healthy. Reset the error to avoid returning it if

--- a/lib/web/app/transport_test.go
+++ b/lib/web/app/transport_test.go
@@ -239,7 +239,7 @@ func TestTransport_DialContextNoServersAvailable(t *testing.T) {
 				&types.AppServerV3{Spec: types.AppServerSpecV3{App: &types.AppV3{}}},
 				&types.AppServerV3{Spec: types.AppServerSpecV3{App: &types.AppV3{}}},
 			},
-			log: utils.NewLoggerForTests(),
+			log: utils.NewSlogLoggerForTests(),
 		},
 	}
 


### PR DESCRIPTION
This converts lib/httplib and lib/httplib/reverseproxy to use slog so that the remaining use of logrus in srv/app could be removed.