### PR TITLE
Adding bots to allowlist for CLA Assistant

### DIFF
--- a/.github/workflows/cla-assistant.yaml
+++ b/.github/workflows/cla-assistant.yaml
@@ -63,5 +63,5 @@ jobs:
           path-to-document: 'https://github.com/gravitational/teleport/blob/master/CLA.md'
           # branch should not be protected
           branch: 'main'
-          allowlist: '*[bot]'
+          allowlist: 'dependabot[bot],teleport-post-release-automation[bot]'
           lock-pullrequest-aftermerge: false


### PR DESCRIPTION
Adding bots to CLA Assistant allowlist so that they are ignored. Currently pull requests created by these bots will fail the check which could block merges in the future.