### PR TITLE
Bump Rust in branch/v16

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -9,7 +9,7 @@ GOLANGCI_LINT_VERSION ?= v1.61.0
 NODE_VERSION ?= 20.18.0
 
 # Run lint-rust check locally before merging code after you bump this.
-RUST_VERSION ?= 1.77.0
+RUST_VERSION ?= 1.81.0
 WASM_PACK_VERSION ?= 0.12.1
 LIBBPF_VERSION ?= 1.2.2
 LIBPCSCLITE_VERSION ?= 1.9.9-teleport


### PR DESCRIPTION
This bumps Rust to 1.81, the same version we use in master, required by IronRDP update.