### PR TITLE
UserTasks for Discover EKS: create tasks when auto enrolling fails

### DIFF
--- a/lib/auth/integration/integrationv1/awsoidc.go
+++ b/lib/auth/integration/integrationv1/awsoidc.go
@@ -549,6 +549,7 @@ func (s *AWSOIDCService) EnrollEKSClusters(ctx context.Context, req *integration
 			EksClusterName: r.ClusterName,
 			ResourceId:     r.ResourceId,
 			Error:          trace.UserMessage(r.Error),
+			IssueType:      r.IssueType,
 		})
 	}
 

--- a/lib/auth/usertasks/usertasksv1/service.go
+++ b/lib/auth/usertasks/usertasksv1/service.go
@@ -174,8 +174,11 @@ func userTaskToUserTaskStateEvent(ut *usertasksv1.UserTask) *usagereporter.UserT
 		IssueType: ut.GetSpec().GetIssueType(),
 		State:     ut.GetSpec().GetState(),
 	}
-	if ut.GetSpec().GetTaskType() == usertasks.TaskTypeDiscoverEC2 {
+	switch ut.GetSpec().GetTaskType() {
+	case usertasks.TaskTypeDiscoverEC2:
 		ret.InstancesCount = int32(len(ut.GetSpec().GetDiscoverEc2().GetInstances()))
+	case usertasks.TaskTypeDiscoverEKS:
+		ret.InstancesCount = int32(len(ut.GetSpec().GetDiscoverEks().GetClusters()))
 	}
 	return ret
 }

--- a/lib/integrations/awsoidc/eks_enroll_clusters.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters.go
@@ -51,6 +51,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/usertasks"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -85,6 +86,8 @@ type EnrollEKSClusterResult struct {
 	ResourceId string
 	// Error contains an error that happened during enrollment, if there was one.
 	Error error
+	// IssueType contains the UserTask issue type for well-known errors.
+	IssueType string
 }
 
 // EnrollEKSClusterResponse contains result for enrollment .
@@ -93,8 +96,8 @@ type EnrollEKSClusterResponse struct {
 	Results []EnrollEKSClusterResult
 }
 
-// EnrollEKSCLusterClient defines functions required for EKS cluster enrollment.
-type EnrollEKSCLusterClient interface {
+// EnrollEKSClusterClient defines functions required for EKS cluster enrollment.
+type EnrollEKSClusterClient interface {
 	// CreateAccessEntry creates an access entry. An access entry allows an IAM principal to access an EKS cluster.
 	CreateAccessEntry(ctx context.Context, params *eks.CreateAccessEntryInput, optFns ...func(*eks.Options)) (*eks.CreateAccessEntryOutput, error)
 
@@ -209,7 +212,7 @@ func (d *defaultEnrollEKSClustersClient) CreateToken(ctx context.Context, token 
 type TokenCreator func(ctx context.Context, token types.ProvisionToken) error
 
 // NewEnrollEKSClustersClient returns new client that can be used to enroll EKS clusters into Teleport.
-func NewEnrollEKSClustersClient(ctx context.Context, req *AWSClientRequest, tokenCreator TokenCreator) (EnrollEKSCLusterClient, error) {
+func NewEnrollEKSClustersClient(ctx context.Context, req *AWSClientRequest, tokenCreator TokenCreator) (EnrollEKSClusterClient, error) {
 	eksClient, err := newEKSClient(ctx, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -293,7 +296,7 @@ func (e *EnrollEKSClustersRequest) CheckAndSetDefaults() error {
 // During enrollment we create access entry for an EKS cluster if needed and cluster admin policy is associated with that entry,
 // so our AWS integration can access the target EKS cluster during the chart installation. After enrollment is done we remove
 // the access entry (if it was created by us), since we don't need it anymore.
-func EnrollEKSClusters(ctx context.Context, log *slog.Logger, clock clockwork.Clock, proxyAddr string, clt EnrollEKSCLusterClient, req EnrollEKSClustersRequest) (*EnrollEKSClusterResponse, error) {
+func EnrollEKSClusters(ctx context.Context, log *slog.Logger, clock clockwork.Clock, proxyAddr string, clt EnrollEKSClusterClient, req EnrollEKSClustersRequest) (*EnrollEKSClusterResponse, error) {
 	var mu sync.Mutex
 	var results []EnrollEKSClusterResult
 
@@ -308,17 +311,23 @@ func EnrollEKSClusters(ctx context.Context, log *slog.Logger, clock clockwork.Cl
 		eksClusterName := eksClusterName
 
 		group.Go(func() error {
-			resourceId, err := enrollEKSCluster(ctx, log, clock, clt, proxyAddr, eksClusterName, req)
+			resourceId, issueType, err := enrollEKSCluster(ctx, log, clock, clt, proxyAddr, eksClusterName, req)
 			if err != nil {
 				log.WarnContext(ctx, "Failed to enroll EKS cluster",
 					"error", err,
 					"cluster", eksClusterName,
+					"issue_type", issueType,
 				)
 			}
 
 			mu.Lock()
 			defer mu.Unlock()
-			results = append(results, EnrollEKSClusterResult{ClusterName: eksClusterName, ResourceId: resourceId, Error: trace.Wrap(err)})
+			results = append(results, EnrollEKSClusterResult{
+				ClusterName: eksClusterName,
+				ResourceId:  resourceId,
+				Error:       trace.Wrap(err),
+				IssueType:   issueType,
+			})
 
 			return nil
 		})
@@ -362,22 +371,28 @@ func presignCallerIdentityURL(ctx context.Context, stsClient *sts.Client, cluste
 	return presigned.URL, nil
 }
 
-func enrollEKSCluster(ctx context.Context, log *slog.Logger, clock clockwork.Clock, clt EnrollEKSCLusterClient, proxyAddr, clusterName string, req EnrollEKSClustersRequest) (string, error) {
+// enrollEKSCluster tries to enroll a single EKS cluster using the EnrollEKSClusterClient.
+// Returns the resource id or an error and an issue type which identifies the class of the error that occurred.
+func enrollEKSCluster(ctx context.Context, log *slog.Logger, clock clockwork.Clock, clt EnrollEKSClusterClient, proxyAddr, clusterName string, req EnrollEKSClustersRequest) (string, string, error) {
 	eksClusterInfo, err := clt.DescribeCluster(ctx, &eks.DescribeClusterInput{
 		Name: aws.String(clusterName),
 	})
 	if err != nil {
-		return "", trace.Wrap(err, "unable to describe EKS cluster")
+		return "", "", trace.Wrap(err, "unable to describe EKS cluster")
 	}
 	eksCluster := eksClusterInfo.Cluster
 
 	if eksCluster.Status != eksTypes.ClusterStatusActive {
-		return "", trace.BadParameter(`can't enroll EKS cluster %q - expected "ACTIVE" state, got %q.`, clusterName, eksCluster.Status)
+		return "",
+			usertasks.AutoDiscoverEKSIssueStatusNotActive,
+			trace.BadParameter(`can't enroll EKS cluster %q - expected "ACTIVE" state, got %q.`, clusterName, eksCluster.Status)
 	}
 
 	// We can't discover private EKS clusters for cloud clients, since we know that auth server is running in our VPC.
 	if req.IsCloud && !eksCluster.ResourcesVpcConfig.EndpointPublicAccess {
-		return "", trace.AccessDenied(`can't enroll %q because it is not accessible from Teleport Cloud, please enable endpoint public access in your EKS cluster and try again.`, clusterName)
+		return "",
+			usertasks.AutoDiscoverEKSIssueMissingEndpoingPublicAccess,
+			trace.AccessDenied(`can't enroll %q because it is not accessible from Teleport Cloud, please enable endpoint public access in your EKS cluster and try again.`, clusterName)
 	}
 
 	// When clusters are using CONFIG_MAP, API is not acessible and thus Teleport can't install the Teleport's Helm chart.
@@ -387,19 +402,21 @@ func enrollEKSCluster(ctx context.Context, log *slog.Logger, clock clockwork.Clo
 		eksTypes.AuthenticationModeApiAndConfigMap,
 	}
 	if !slices.Contains(allowedAuthModes, eksCluster.AccessConfig.AuthenticationMode) {
-		return "", trace.BadParameter("can't enroll %q because its access config's authentication mode is %q, only %v are supported", clusterName, eksCluster.AccessConfig.AuthenticationMode, allowedAuthModes)
+		return "",
+			usertasks.AutoDiscoverEKSIssueAuthenticationModeUnsupported,
+			trace.BadParameter("can't enroll %q because its access config's authentication mode is %q, only %v are supported", clusterName, eksCluster.AccessConfig.AuthenticationMode, allowedAuthModes)
 	}
 
 	principalArn, err := getAccessEntryPrincipalArn(ctx, clt.GetCallerIdentity)
 	if err != nil {
-		return "", trace.Wrap(err)
+		return "", "", trace.Wrap(err)
 	}
 
 	ownershipTags := tags.DefaultResourceCreationTags(req.TeleportClusterName, req.IntegrationName)
 
 	wasAdded, err := maybeAddAccessEntry(ctx, log, clusterName, principalArn, clt, ownershipTags)
 	if err != nil {
-		return "", trace.Wrap(err)
+		return "", "", trace.Wrap(err)
 	}
 	if wasAdded {
 		// If we added access entry, we'll clean it up when function stops executing.
@@ -427,37 +444,57 @@ func enrollEKSCluster(ctx context.Context, log *slog.Logger, clock clockwork.Clo
 		PrincipalArn: aws.String(principalArn),
 	})
 	if err != nil {
-		return "", trace.Wrap(err, "unable to associate EKS Access Policy to cluster %q", clusterName)
+		return "", "", trace.Wrap(err, "unable to associate EKS Access Policy to cluster %q", clusterName)
 	}
 
 	presignedURL, err := clt.PresignGetCallerIdentityURL(ctx, clusterName)
 	if err != nil {
-		return "", trace.Wrap(err)
+		return "", "", trace.Wrap(err)
 	}
 
 	kubeClientGetter, err := getKubeClientGetter(presignedURL,
 		aws.ToString(eksCluster.CertificateAuthority.Data), aws.ToString(eksCluster.Endpoint))
 	if err != nil {
-		return "", trace.Wrap(err, "unable to build kubernetes client for EKS cluster %q", clusterName)
+		return "", "", trace.Wrap(err, "unable to build kubernetes client for EKS cluster %q", clusterName)
 	}
 
 	if alreadyInstalled, err := clt.CheckAgentAlreadyInstalled(ctx, kubeClientGetter, log); err != nil {
-		return "", trace.Wrap(err, "could not check if teleport-kube-agent is already installed.")
+		return "",
+			issueTypeFromCheckAgentInstalledError(err),
+			trace.Wrap(err, "could not check if teleport-kube-agent is already installed.")
+
 	} else if alreadyInstalled {
-		// Web UI relies on the text of this error message. If changed, sync with EnrollEksCluster.tsx
-		return "", trace.AlreadyExists("teleport-kube-agent is already installed on the cluster %q", clusterName)
+		return "",
+			// When using EKS Auto Discovery, after the Kube Agent connects to the Teleport cluster, it is ignored in next discovery iterations.
+			// Given that this iteration is still hitting this EKS Cluster, it means that the agent can't connect to the Teleport Cluster or is taking too long.
+			usertasks.AutoDiscoverEKSIssueAgentNotConnecting,
+			// Web UI relies on the text of this error message. If changed, sync with EnrollEksCluster.tsx
+			trace.AlreadyExists("teleport-kube-agent is already installed on the cluster %q", clusterName)
 	}
 
 	joinToken, resourceId, err := getToken(ctx, clock, clt.CreateToken)
 	if err != nil {
-		return "", trace.Wrap(err)
+		return "", "", trace.Wrap(err)
 	}
 
 	if err := clt.InstallKubeAgent(ctx, eksCluster, proxyAddr, joinToken, resourceId, kubeClientGetter, log, req); err != nil {
-		return "", trace.Wrap(err)
+		return "", "", trace.Wrap(err)
 	}
 
-	return resourceId, nil
+	return resourceId, "", nil
+}
+
+func issueTypeFromCheckAgentInstalledError(checkErr error) string {
+	// When the Auth Service fails to reach the EKS Cluster, it usually means that, either:
+	// - EKS does not have EndpointPublicAccess
+	// - EKS is not reachable by the Teleport Auth Service
+	// In the first case, it should be handled in a pre-install check, however, for the second one, we'll get the following message:
+	// > Kubernetes cluster unreachable: Get \"https://<longid>.gr7.<region>.eks.amazonaws.com/version\": dial tcp: lookup <longid>.gr7.<region>.eks.amazonaws.com: no such host"
+	if strings.Contains(checkErr.Error(), "Kubernetes cluster unreachable: Get") && strings.Contains(checkErr.Error(), "eks.amazonaws.com: no such host") {
+		return usertasks.AutoDiscoverEKSIssueClusterUnreachable
+	}
+
+	return ""
 }
 
 // IdentityGetter returns AWS identity of the caller.
@@ -479,7 +516,7 @@ func getAccessEntryPrincipalArn(ctx context.Context, identityGetter IdentityGett
 
 // maybeAddAccessEntry checks list of access entries for the EKS cluster and adds one for Teleport if it's missing.
 // If access entry was added by this function it will return true as a first value.
-func maybeAddAccessEntry(ctx context.Context, log *slog.Logger, clusterName, roleArn string, clt EnrollEKSCLusterClient, ownershipTags tags.AWSTags) (bool, error) {
+func maybeAddAccessEntry(ctx context.Context, log *slog.Logger, clusterName, roleArn string, clt EnrollEKSClusterClient, ownershipTags tags.AWSTags) (bool, error) {
 	entries, err := clt.ListAccessEntries(ctx, &eks.ListAccessEntriesInput{
 		ClusterName: aws.String(clusterName),
 	})

--- a/lib/integrations/awsoidc/eks_enroll_clusters_test.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters_test.go
@@ -118,7 +118,7 @@ func TestEnrollEKSClusters(t *testing.T) {
 		},
 	}
 
-	baseClient := func(t *testing.T, clusters []eksTypes.Cluster) EnrollEKSCLusterClient {
+	baseClient := func(t *testing.T, clusters []eksTypes.Cluster) EnrollEKSClusterClient {
 		clt := &mockEnrollEKSClusterClient{}
 		clt.describeCluster = func(ctx context.Context, params *eks.DescribeClusterInput, optFns ...func(*eks.Options)) (*eks.DescribeClusterOutput, error) {
 			for _, cluster := range clusters {
@@ -155,7 +155,7 @@ func TestEnrollEKSClusters(t *testing.T) {
 
 	testCases := []struct {
 		name                string
-		enrollClient        func(*testing.T, []eksTypes.Cluster) EnrollEKSCLusterClient
+		enrollClient        func(*testing.T, []eksTypes.Cluster) EnrollEKSClusterClient
 		eksClusters         []eksTypes.Cluster
 		request             EnrollEKSClustersRequest
 		requestClusterNames []string
@@ -171,6 +171,7 @@ func TestEnrollEKSClusters(t *testing.T) {
 				require.Len(t, response.Results, 1)
 				require.Equal(t, "EKS1", response.Results[0].ClusterName)
 				require.NoError(t, response.Results[0].Error)
+				require.Empty(t, response.Results[0].IssueType)
 				require.NotEmpty(t, response.Results[0].ResourceId)
 			},
 		},
@@ -187,9 +188,11 @@ func TestEnrollEKSClusters(t *testing.T) {
 				})
 				require.Equal(t, "EKS1", response.Results[0].ClusterName)
 				require.NoError(t, response.Results[0].Error)
+				require.Empty(t, response.Results[0].IssueType)
 				require.NotEmpty(t, response.Results[0].ResourceId)
 				require.Equal(t, "EKS2", response.Results[1].ClusterName)
 				require.NoError(t, response.Results[1].Error)
+				require.Empty(t, response.Results[1].IssueType)
 				require.NotEmpty(t, response.Results[1].ResourceId)
 			},
 		},
@@ -242,6 +245,7 @@ func TestEnrollEKSClusters(t *testing.T) {
 				require.Len(t, response.Results, 1)
 				require.ErrorContains(t, response.Results[0].Error,
 					`can't enroll EKS cluster "EKS1" - expected "ACTIVE" state, got "PENDING".`)
+				require.Equal(t, "eks-status-not-active", response.Results[0].IssueType)
 			},
 		},
 		{
@@ -265,6 +269,7 @@ func TestEnrollEKSClusters(t *testing.T) {
 				require.Len(t, response.Results, 1)
 				require.ErrorContains(t, response.Results[0].Error,
 					`can't enroll "EKS1" because its access config's authentication mode is "CONFIG_MAP", only [API API_AND_CONFIG_MAP] are supported`)
+				require.Equal(t, "eks-authentication-mode-unsupported", response.Results[0].IssueType)
 			},
 		},
 		{
@@ -297,6 +302,7 @@ func TestEnrollEKSClusters(t *testing.T) {
 				require.Len(t, response.Results, 1)
 				require.ErrorContains(t, response.Results[0].Error,
 					`can't enroll "EKS3" because it is not accessible from Teleport Cloud, please enable endpoint public access in your EKS cluster and try again.`)
+				require.Equal(t, "eks-missing-endpoint-public-access", response.Results[0].IssueType)
 			},
 		},
 		{
@@ -331,7 +337,7 @@ func TestEnrollEKSClusters(t *testing.T) {
 		},
 		{
 			name: "cluster with already present agent is not enrolled",
-			enrollClient: func(t *testing.T, clusters []eksTypes.Cluster) EnrollEKSCLusterClient {
+			enrollClient: func(t *testing.T, clusters []eksTypes.Cluster) EnrollEKSClusterClient {
 				clt := baseClient(t, clusters)
 				mockClt, ok := clt.(*mockEnrollEKSClusterClient)
 				require.True(t, ok)
@@ -347,11 +353,12 @@ func TestEnrollEKSClusters(t *testing.T) {
 				require.Len(t, response.Results, 1)
 				require.ErrorContains(t, response.Results[0].Error,
 					`teleport-kube-agent is already installed on the cluster "EKS1"`)
+				require.Equal(t, "eks-agent-not-connecting", response.Results[0].IssueType)
 			},
 		},
 		{
 			name: "if access entry is already present we don't create another one and don't delete it",
-			enrollClient: func(t *testing.T, clusters []eksTypes.Cluster) EnrollEKSCLusterClient {
+			enrollClient: func(t *testing.T, clusters []eksTypes.Cluster) EnrollEKSClusterClient {
 				clt := baseClient(t, clusters)
 				mockClt, ok := clt.(*mockEnrollEKSClusterClient)
 				require.True(t, ok)
@@ -621,7 +628,7 @@ func (m *mockEnrollEKSClusterClient) PresignGetCallerIdentityURL(ctx context.Con
 	return "", nil
 }
 
-var _ EnrollEKSCLusterClient = &mockEnrollEKSClusterClient{}
+var _ EnrollEKSClusterClient = &mockEnrollEKSClusterClient{}
 
 func TestKubeAgentLabels(t *testing.T) {
 	kubeClusterLabels := map[string]string{

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -395,6 +395,7 @@ type Server struct {
 	awsRDSResourcesStatus awsResourcesStatus
 	awsEKSResourcesStatus awsResourcesStatus
 	awsEC2Tasks           awsEC2Tasks
+	awsEKSTasks           awsEKSTasks
 
 	// caRotationCh receives nodes that need to have their CAs rotated.
 	caRotationCh chan []types.Server

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -266,9 +266,9 @@ func TestDiscoveryServer(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	discoveryConfigForUserTaskTestName := uuid.NewString()
-	discoveryConfigForUserTaskTest, err := discoveryconfig.NewDiscoveryConfig(
-		header.Metadata{Name: discoveryConfigForUserTaskTestName},
+	discoveryConfigForUserTaskEC2TestName := uuid.NewString()
+	discoveryConfigForUserTaskEC2Test, err := discoveryconfig.NewDiscoveryConfig(
+		header.Metadata{Name: discoveryConfigForUserTaskEC2TestName},
 		discoveryconfig.Spec{
 			DiscoveryGroup: defaultDiscoveryGroup,
 			AWS: []types.AWSMatcher{{
@@ -286,6 +286,21 @@ func TestDiscoveryServer(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	discoveryConfigForUserTaskEKSTestName := uuid.NewString()
+	discoveryConfigForUserTaskEKSTest, err := discoveryconfig.NewDiscoveryConfig(
+		header.Metadata{Name: discoveryConfigForUserTaskEKSTestName},
+		discoveryconfig.Spec{
+			DiscoveryGroup: defaultDiscoveryGroup,
+			AWS: []types.AWSMatcher{{
+				Types:       []string{"eks"},
+				Regions:     []string{"eu-west-2"},
+				Tags:        map[string]utils.Strings{"RunDiscover": {"Please"}},
+				Integration: "my-integration",
+			}},
+		},
+	)
+	require.NoError(t, err)
+
 	tcs := []struct {
 		name string
 		// presentInstances is a list of servers already present in teleport
@@ -293,11 +308,13 @@ func TestDiscoveryServer(t *testing.T) {
 		foundEC2Instances         []ec2types.Instance
 		ssm                       *mockSSMClient
 		emitter                   *mockEmitter
+		eksEnroller               eksClustersEnroller
 		discoveryConfig           *discoveryconfig.DiscoveryConfig
 		staticMatchers            Matchers
 		wantInstalledInstances    []string
 		wantDiscoveryConfigStatus *discoveryconfig.Status
-		userTasksDiscoverEC2Check require.ValueAssertionFunc
+		userTasksDiscoverCheck    require.ValueAssertionFunc
+		cloudClients              cloud.Clients
 		ssmRunError               error
 	}{
 		{
@@ -602,9 +619,9 @@ func TestDiscoveryServer(t *testing.T) {
 				},
 			},
 			staticMatchers:         Matchers{},
-			discoveryConfig:        discoveryConfigForUserTaskTest,
+			discoveryConfig:        discoveryConfigForUserTaskEC2Test,
 			wantInstalledInstances: []string{},
-			userTasksDiscoverEC2Check: func(tt require.TestingT, i1 interface{}, i2 ...interface{}) {
+			userTasksDiscoverCheck: func(tt require.TestingT, i1 interface{}, i2 ...interface{}) {
 				existingTasks, ok := i1.([]*usertasksv1.UserTask)
 				require.True(t, ok, "failed to get existing tasks: %T", i1)
 				require.Len(t, existingTasks, 1)
@@ -621,8 +638,78 @@ func TestDiscoveryServer(t *testing.T) {
 				taskInstance := taskInstances["instance-id-1"]
 
 				require.Equal(t, "instance-id-1", taskInstance.InstanceId)
-				require.Equal(t, discoveryConfigForUserTaskTestName, taskInstance.DiscoveryConfig)
+				require.Equal(t, discoveryConfigForUserTaskEC2TestName, taskInstance.DiscoveryConfig)
 				require.Equal(t, defaultDiscoveryGroup, taskInstance.DiscoveryGroup)
+			},
+		},
+		{
+			name:              "multiple EKS clusters failed to autoenroll and user tasks are created",
+			presentInstances:  []types.Server{},
+			foundEC2Instances: []ec2types.Instance{},
+			ssm:               &mockSSMClient{},
+			cloudClients: &cloud.TestCloudClients{
+				STS: &mocks.STSMock{},
+				EKS: &mocks.EKSMock{
+					Clusters: []*eks.Cluster{
+						{
+							Name:   aws.String("cluster01"),
+							Arn:    aws.String("arn:aws:eks:us-west-2:123456789012:cluster/cluster01"),
+							Status: aws.String(eks.ClusterStatusActive),
+							Tags: map[string]*string{
+								"RunDiscover": aws.String("Please"),
+							},
+						},
+						{
+							Name:   aws.String("cluster02"),
+							Arn:    aws.String("arn:aws:eks:us-west-2:123456789012:cluster/cluster02"),
+							Status: aws.String(eks.ClusterStatusActive),
+							Tags: map[string]*string{
+								"RunDiscover": aws.String("Please"),
+							},
+						},
+					},
+				},
+			},
+			eksEnroller: &mockEKSClusterEnroller{
+				resp: &integrationpb.EnrollEKSClustersResponse{
+					Results: []*integrationpb.EnrollEKSClusterResult{
+						{
+							EksClusterName: "cluster01",
+							Error:          "access endpoint is not reachable",
+							IssueType:      "eks-cluster-unreachable",
+						},
+						{
+							EksClusterName: "cluster02",
+							Error:          "access endpoint is not reachable",
+							IssueType:      "eks-cluster-unreachable",
+						},
+					},
+				},
+				err: nil,
+			},
+			emitter:                &mockEmitter{},
+			staticMatchers:         Matchers{},
+			discoveryConfig:        discoveryConfigForUserTaskEKSTest,
+			wantInstalledInstances: []string{},
+			userTasksDiscoverCheck: func(tt require.TestingT, i1 interface{}, i2 ...interface{}) {
+				existingTasks, ok := i1.([]*usertasksv1.UserTask)
+				require.True(t, ok, "failed to get existing tasks: %T", i1)
+				require.Len(t, existingTasks, 1)
+				existingTask := existingTasks[0]
+
+				require.Equal(t, "OPEN", existingTask.GetSpec().State)
+				require.Equal(t, "my-integration", existingTask.GetSpec().Integration)
+				require.Equal(t, "eks-cluster-unreachable", existingTask.GetSpec().IssueType)
+				require.Equal(t, "123456789012", existingTask.GetSpec().GetDiscoverEks().GetAccountId())
+				require.Equal(t, "us-west-2", existingTask.GetSpec().GetDiscoverEks().GetRegion())
+
+				taskClusters := existingTask.GetSpec().GetDiscoverEks().Clusters
+				require.Contains(t, taskClusters, "cluster01")
+				taskCluster := taskClusters["cluster01"]
+
+				require.Equal(t, "cluster01", taskCluster.Name)
+				require.Equal(t, discoveryConfigForUserTaskEKSTestName, taskCluster.DiscoveryConfig)
+				require.Equal(t, defaultDiscoveryGroup, taskCluster.DiscoveryGroup)
 			},
 		},
 	}
@@ -679,6 +766,11 @@ func TestDiscoveryServer(t *testing.T) {
 				require.NoError(t, err)
 			}
 
+			var eksEnroller eksClustersEnroller = authClient.IntegrationAWSOIDCClient()
+			if tc.eksEnroller != nil {
+				eksEnroller = tc.eksEnroller
+			}
+
 			server, err := New(authz.ContextWithUser(context.Background(), identity.I), &Config{
 				GetEC2Client: func(ctx context.Context, region string, opts ...config.AWSOptionsFn) (ec2.DescribeInstancesAPIClient, error) {
 					return ec2Client, nil
@@ -688,12 +780,13 @@ func TestDiscoveryServer(t *testing.T) {
 				},
 				ClusterFeatures:  func() proto.Features { return proto.Features{} },
 				KubernetesClient: fake.NewSimpleClientset(),
-				AccessPoint:      getDiscoveryAccessPoint(tlsServer.Auth(), authClient),
+				AccessPoint:      getDiscoveryAccessPointWithEKSEnroller(tlsServer.Auth(), authClient, eksEnroller),
 				Matchers:         tc.staticMatchers,
 				Emitter:          tc.emitter,
 				Log:              logger,
 				LegacyLogger:     legacyLogger,
 				DiscoveryGroup:   defaultDiscoveryGroup,
+				CloudClients:     tc.cloudClients,
 				clock:            fakeClock,
 			})
 			require.NoError(t, err)
@@ -731,7 +824,7 @@ func TestDiscoveryServer(t *testing.T) {
 					return true
 				}, 500*time.Millisecond, 50*time.Millisecond)
 			}
-			if tc.userTasksDiscoverEC2Check != nil {
+			if tc.userTasksDiscoverCheck != nil {
 				var allUserTasks []*usertasksv1.UserTask
 				var nextToken string
 				for {
@@ -743,7 +836,7 @@ func TestDiscoveryServer(t *testing.T) {
 						break
 					}
 				}
-				tc.userTasksDiscoverEC2Check(t, allUserTasks)
+				tc.userTasksDiscoverCheck(t, allUserTasks)
 			}
 		})
 	}
@@ -3280,6 +3373,15 @@ type eksClustersEnroller interface {
 	EnrollEKSClusters(context.Context, *integrationpb.EnrollEKSClustersRequest, ...grpc.CallOption) (*integrationpb.EnrollEKSClustersResponse, error)
 }
 
+type mockEKSClusterEnroller struct {
+	resp *integrationpb.EnrollEKSClustersResponse
+	err  error
+}
+
+func (m *mockEKSClusterEnroller) EnrollEKSClusters(context.Context, *integrationpb.EnrollEKSClustersRequest, ...grpc.CallOption) (*integrationpb.EnrollEKSClustersResponse, error) {
+	return m.resp, m.err
+}
+
 type combinedDiscoveryClient struct {
 	*auth.Server
 	eksClustersEnroller
@@ -3302,9 +3404,12 @@ func (d *combinedDiscoveryClient) UpdateDiscoveryConfigStatus(ctx context.Contex
 	return nil, trace.BadParameter("not implemented.")
 }
 
+func getDiscoveryAccessPointWithEKSEnroller(authServer *auth.Server, authClient authclient.ClientI, eksEnroller eksClustersEnroller) authclient.DiscoveryAccessPoint {
+	return &combinedDiscoveryClient{Server: authServer, eksClustersEnroller: eksEnroller, discoveryConfigStatusUpdater: authClient.DiscoveryConfigClient()}
+}
+
 func getDiscoveryAccessPoint(authServer *auth.Server, authClient authclient.ClientI) authclient.DiscoveryAccessPoint {
 	return &combinedDiscoveryClient{Server: authServer, eksClustersEnroller: authClient.IntegrationAWSOIDCClient(), discoveryConfigStatusUpdater: authClient.DiscoveryConfigClient()}
-
 }
 
 type fakeAccessPoint struct {

--- a/lib/srv/discovery/kube_integration_watcher_test.go
+++ b/lib/srv/discovery/kube_integration_watcher_test.go
@@ -586,4 +586,4 @@ func (m *mockEnrollEKSClusterClient) PresignGetCallerIdentityURL(ctx context.Con
 	return "", nil
 }
 
-var _ awsoidc.EnrollEKSCLusterClient = &mockEnrollEKSClusterClient{}
+var _ awsoidc.EnrollEKSClusterClient = &mockEnrollEKSClusterClient{}


### PR DESCRIPTION
This PRs changes the DiscoveryService to ensure it creates UserTasks when EKS Clusters fail to auto-enroll.

Demo:
`tctl get user_tasks`
```yaml
kind: user_task
metadata:
  expires:
    nanos: 62859000
    seconds: 1733832779
  name: 66ab3b42-6c41-5923-9e27-bfda6c767127
  revision: 9f9de9e6-39f8-469e-8c89-1fda10abd69b
spec:
  discover_eks:
    account_id: "123456789012"
    app_auto_discover: true
    clusters:
      MarcoUserTasks01:
        discovery_config: b118fe1b-4db6-4705-80cd-a7142063ff78
        discovery_group: aws-prod
        name: MarcoUserTasks01
        sync_time:
          nanos: 59118000
          seconds: 1733832179
      MarcoUserTasks03:
        discovery_config: b118fe1b-4db6-4705-80cd-a7142063ff78
        discovery_group: aws-prod
        name: MarcoUserTasks03
        sync_time:
          nanos: 40327000
          seconds: 1733832179
    region: eu-west-2
  integration: teleportdev
  issue_type: eks-agent-not-connecting
  state: OPEN
  task_type: discover-eks
version: v1
---
kind: user_task
metadata:
  expires:
    nanos: 70007000
    seconds: 1733832779
  name: dd4d668c-5cea-591d-a2e8-0f0c125db479
  revision: c9887168-0b80-4323-8551-7e1ebe98c8a4
spec:
  discover_eks:
    account_id: "123456789012"
    app_auto_discover: true
    clusters:
      MarcoUserTasks02:
        discovery_config: b118fe1b-4db6-4705-80cd-a7142063ff78
        discovery_group: aws-prod
        name: MarcoUserTasks02
        sync_time:
          nanos: 68190000
          seconds: 1733832179
    region: eu-west-2
  integration: teleportdev
  issue_type: eks-cluster-unreachable
  state: OPEN
  task_type: discover-eks
version: v1
```