### PR TITLE
Edit `apt-get` installation instructions

### DIFF
--- a/docs/pages/includes/cloud/install-linux-cloud.mdx
+++ b/docs/pages/includes/cloud/install-linux-cloud.mdx
@@ -6,11 +6,11 @@
   ```code
   # Download Teleport's PGP public key
   $ sudo curl https://apt.releases.teleport.dev/gpg \
-  -o /usr/share/keyrings/teleport-archive-keyring.asc
+  -o /etc/apt/trusted.gpg.d/teleport.asc
   # Source variables about OS version
   $ source /etc/os-release
   # Add the Teleport APT repository for cloud.
-  $ echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] \
+  $ echo "deb [signed-by=/etc/apt/trusted.gpg.d/teleport.asc] \
   https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} stable/cloud" \
   | sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null
 

--- a/docs/pages/includes/cloud/install-linux-cloud.mdx
+++ b/docs/pages/includes/cloud/install-linux-cloud.mdx
@@ -4,13 +4,14 @@
   Add the Teleport repository to your repository list:
 
   ```code
+  $ sudo mkdir -p /etc/apt/keyrings
   # Download Teleport's PGP public key
   $ sudo curl https://apt.releases.teleport.dev/gpg \
-  -o /etc/apt/trusted.gpg.d/teleport.asc
+  -o /etc/apt/keyrings/teleport-archive-keyring.asc
   # Source variables about OS version
   $ source /etc/os-release
   # Add the Teleport APT repository for cloud.
-  $ echo "deb [signed-by=/etc/apt/trusted.gpg.d/teleport.asc] \
+  $ echo "deb [signed-by=/etc/apt/keyrings/teleport-archive-keyring.asc] \
   https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} stable/cloud" \
   | sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null
 

--- a/docs/pages/includes/install-linux-ent-self-hosted.mdx
+++ b/docs/pages/includes/install-linux-ent-self-hosted.mdx
@@ -3,14 +3,15 @@
 <TabItem label="Debian 9+/Ubuntu 16.04+ (apt)">
 
 ```code
+$ mkdir -p /etc/apt/keyrings
 # Download Teleport's PGP public key
 $ sudo curl https://apt.releases.teleport.dev/gpg \
--o /etc/apt/trusted.gpg.d/teleport.asc
+-o /etc/apt/keyrings/teleport-archive-keyring.asc
 # Source variables about OS version
 $ source /etc/os-release
 # Add the Teleport APT repository for v(=teleport.major_version=). You'll need to update this
 # file for each major release of Teleport.
-$ echo "deb [signed-by=/etc/apt/trusted.gpg.d/teleport.asc] \
+$ echo "deb [signed-by=/etc/apt/keyrings/teleport-archive-keyring.asc] \
 https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} stable/v(=teleport.major_version=)" \
 | sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null
 

--- a/docs/pages/includes/install-linux-ent-self-hosted.mdx
+++ b/docs/pages/includes/install-linux-ent-self-hosted.mdx
@@ -5,12 +5,12 @@
 ```code
 # Download Teleport's PGP public key
 $ sudo curl https://apt.releases.teleport.dev/gpg \
--o /usr/share/keyrings/teleport-archive-keyring.asc
+-o /etc/apt/trusted.gpg.d/teleport.asc
 # Source variables about OS version
 $ source /etc/os-release
 # Add the Teleport APT repository for v(=teleport.major_version=). You'll need to update this
 # file for each major release of Teleport.
-$ echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] \
+$ echo "deb [signed-by=/etc/apt/trusted.gpg.d/teleport.asc] \
 https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} stable/v(=teleport.major_version=)" \
 | sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null
 

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -241,12 +241,13 @@ repositories.
    <TabItem label="apt">
 
    ```code
+   $ mkdir -p /etc/apt/keyrings
    # Download the Teleport PGP public key
    $ sudo curl https://apt.releases.teleport.dev/gpg \
-   -o /etc/apt/trusted.gpg.d/teleport.asc
+   -o /etc/apt/keyrings/teleport-archive-keyring.asc
    # Add the Teleport APT repository. You'll need to update this file for each
    # major release of Teleport.
-   $ echo "deb [signed-by=/etc/apt/trusted.gpg.d/teleport.asc] \
+   $ echo "deb [signed-by=/etc/apt/keyrings/teleport-archive-keyring.asc] \
    https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} \
    ${TELEPORT_CHANNEL?}" \
    | sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -243,10 +243,10 @@ repositories.
    ```code
    # Download the Teleport PGP public key
    $ sudo curl https://apt.releases.teleport.dev/gpg \
-   -o /usr/share/keyrings/teleport-archive-keyring.asc
+   -o /etc/apt/trusted.gpg.d/teleport.asc
    # Add the Teleport APT repository. You'll need to update this file for each
    # major release of Teleport.
-   $ echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] \
+   $ echo "deb [signed-by=/etc/apt/trusted.gpg.d/teleport.asc] \
    https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} \
    ${TELEPORT_CHANNEL?}" \
    | sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null


### PR DESCRIPTION
Closes #24564

Show using `/etc/apt/trusted.gpg.d`, a directory that `apt-get` searches automatically, for storing public keys. Edit the three locations where we showed using `/usr/share/keyrings`, including two partials.