### PR TITLE
tsh: remove noisy debug log

### DIFF
--- a/lib/client/client_store.go
+++ b/lib/client/client_store.go
@@ -127,11 +127,11 @@ func (s *Store) GetKeyRing(idx KeyRingIndex, opts ...CertOption) (*KeyRing, erro
 		return nil, trace.Wrap(err)
 	}
 
-	tlsCertExpiration, err := keyRing.TeleportTLSCertValidBefore()
+	// verify that the key ring has a TLS certificate
+	_, err = keyRing.TeleportTLSCertValidBefore()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	s.log.Debugf("Teleport TLS certificate valid until %q.", tlsCertExpiration)
 
 	// Validate the SSH certificate.
 	if keyRing.Cert != nil {

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -5871,11 +5871,11 @@ func TestLogout(t *testing.T) {
 			err = Run(context.Background(), []string{"logout"}, setHomePath(tmpHomePath))
 			require.NoError(t, err, trace.DebugReport(err))
 
-			// direcory should be empty.
+			// directory should be empty.
 			f, err := os.Open(tmpHomePath)
 			require.NoError(t, err)
-			_, err = f.Readdir(1)
-			require.ErrorIs(t, err, io.EOF)
+			entries, err := f.ReadDir(1)
+			require.ErrorIs(t, err, io.EOF, "expected empty directory, but found %v", entries)
 		})
 	}
 }


### PR DESCRIPTION
```
Teleport TLS certificate valid until "2024-12-11 04:35:25 +0000 UTC"
```

This log line is not super helpful and adds a lot of noise to tsh debug logs because it is repeated many times.

We don't need it, because:
- it doesn't tell you _what_ certificate is valid
- encountering a valid certificate is expected behavior and not something that we expect to help when debugging an issue