### PR TITLE
Disable resetting to the standard model

### DIFF
--- a/web/packages/teleport/src/Roles/RoleEditor/RequiresResetToStandard.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RequiresResetToStandard.tsx
@@ -17,16 +17,13 @@
  */
 
 import { Info } from 'design/Alert/Alert';
-import { ButtonSecondary, Text } from 'design';
+import { Text } from 'design';
 
-export const RequiresResetToStandard = ({ reset }: { reset(): void }) => (
+export const RequiresResetToStandard = () => (
   <Info>
     <Text>
       Some fields were not readable by the standard editor. To continue editing,
-      go back to YAML editor or reset the affected fields to standard settings.
+      go back to YAML editor.
     </Text>
-    <ButtonSecondary size="large" my={2} onClick={reset}>
-      Reset to Standard Settings
-    </ButtonSecondary>
   </Info>
 );

--- a/web/packages/teleport/src/Roles/RoleEditor/RequiresResetToStandard.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RequiresResetToStandard.tsx
@@ -22,8 +22,8 @@ import { Text } from 'design';
 export const RequiresResetToStandard = () => (
   <Info>
     <Text>
-      Some fields were not readable by the standard editor. To continue editing,
-      go back to YAML editor.
+      This role is too complex to be edited in the standard editor. To continue
+      editing, go back to YAML editor.
     </Text>
   </Info>
 );

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
@@ -129,9 +129,7 @@ test('rendering and switching tabs for a non-standard role', async () => {
   expect(screen.getByRole('button', { name: 'Update Role' })).toBeDisabled();
 
   await user.click(getStandardEditorTab());
-  expect(
-    screen.getByText(/Some fields were not readable by the standard editor/)
-  ).toBeVisible();
+  expect(screen.getByText(/This role is too complex/)).toBeVisible();
   expect(screen.getByLabelText('Role Name')).toHaveValue('some-role');
   expect(screen.getByLabelText('Description')).toHaveValue('');
   expect(screen.getByRole('button', { name: 'Update Role' })).toBeDisabled();

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
@@ -175,9 +175,7 @@ test('switching tabs ignores standard model validation for a non-standard role',
   );
   expect(getYamlEditorTab()).toHaveAttribute('aria-selected', 'true');
   await user.click(getStandardEditorTab());
-  expect(
-    screen.getByText(/Some fields were not readable by the standard editor/)
-  ).toBeVisible();
+  expect(screen.getByText(/This role is too complex/)).toBeVisible();
   await user.click(getYamlEditorTab());
   // Proceed, even though our validation would consider the data invalid.
   expect(getYamlEditorTab()).toHaveAttribute('aria-selected', 'true');

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
@@ -130,7 +130,7 @@ test('rendering and switching tabs for a non-standard role', async () => {
 
   await user.click(getStandardEditorTab());
   expect(
-    screen.getByRole('button', { name: 'Reset to Standard Settings' })
+    screen.getByText(/Some fields were not readable by the standard editor/)
   ).toBeVisible();
   expect(screen.getByLabelText('Role Name')).toHaveValue('some-role');
   expect(screen.getByLabelText('Description')).toHaveValue('');
@@ -139,21 +139,6 @@ test('rendering and switching tabs for a non-standard role', async () => {
   await user.click(getYamlEditorTab());
   expect(fromFauxYaml(await getTextEditorContents())).toEqual(originalRole);
   expect(screen.getByRole('button', { name: 'Update Role' })).toBeDisabled();
-
-  // Switch once again, reset to standard
-  await user.click(getStandardEditorTab());
-  expect(screen.getByRole('button', { name: 'Update Role' })).toBeDisabled();
-  await user.click(
-    screen.getByRole('button', { name: 'Reset to Standard Settings' })
-  );
-  expect(screen.getByRole('button', { name: 'Update Role' })).toBeEnabled();
-  await user.type(screen.getByLabelText('Description'), 'some description');
-
-  await user.click(getYamlEditorTab());
-  const editorContents = fromFauxYaml(await getTextEditorContents());
-  expect(editorContents.metadata.description).toBe('some description');
-  expect(editorContents.spec.deny).toEqual({});
-  expect(screen.getByRole('button', { name: 'Update Role' })).toBeEnabled();
 });
 
 test('switching tabs triggers validation', async () => {

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor.tsx
@@ -161,18 +161,6 @@ export const StandardEditor = ({
     });
   }
 
-  /**
-   * Resets the standard editor back into viewable state. The existing model
-   * has been already stripped from unsupported features by the parsing
-   * attempt, the only thing left to do is to set the `requiresReset` flag.
-   */
-  function resetForStandardEditor() {
-    handleChange({
-      ...standardEditorModel.roleModel,
-      requiresReset: false,
-    });
-  }
-
   function addAccessSpec(kind: AccessSpecKind) {
     handleChange({
       ...standardEditorModel.roleModel,
@@ -219,7 +207,7 @@ export const StandardEditor = ({
     <>
       {roleModel.requiresReset && (
         <Box mx={3}>
-          <RequiresResetToStandard reset={resetForStandardEditor} />
+          <RequiresResetToStandard />
         </Box>
       )}
       <EditorWrapper


### PR DESCRIPTION
Until we come up with a more trustworthy user experience, we don't want to risk throwing the users under the bus by performing actions that are not detailed in the UI and that would be difficult to understand for the users because of the level of complication of the editor's model. Just display the message and disable the standard editor UI.

![Screenshot 2024-12-11 at 10 58 17](https://github.com/user-attachments/assets/7023aaa6-c258-4e38-a1eb-be4288c610a4)
