### PR TITLE
[v16] Extend session termination timeout in integration test

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -993,7 +993,7 @@ func testSessionRecordingModes(t *testing.T, suite *integrationTestSuite) {
 	// waitSessionTermination wait until the errCh returns something and assert
 	// it with the provided function.
 	waitSessionTermination := func(t *testing.T, errCh chan error, errorAssertion require.ErrorAssertionFunc) {
-		errorAssertion(t, waitForError(errCh, 10*time.Second))
+		errorAssertion(t, waitForError(errCh, 30*time.Second))
 	}
 
 	// enableDiskFailure changes the OpenFileFunc on filesession package. The


### PR DESCRIPTION
Backport #49964 to branch/v16