### PR TITLE
Prevent activation of previous workspace when launching Connect via deep link to a different cluster

### DIFF
--- a/web/packages/build/jest/jest-environment-patched-jsdom.js
+++ b/web/packages/build/jest/jest-environment-patched-jsdom.js
@@ -59,6 +59,13 @@ export default class PatchedJSDOMEnvironment extends JSDOMEnvironment {
     if (!global.TransformStream) {
       global.TransformStream = TransformStream;
     }
+    // TODO(gzdunek): JSDOM doesn't support AbortSignal.any().
+    // Overwriting only this function doesn't help much, something between
+    // AbortSignal and AbortController is missing.
+    if (!global.AbortSignal.any) {
+      global.AbortSignal = AbortSignal;
+      global.AbortController = AbortController;
+    }
   }
 }
 export const TestEnvironment = PatchedJSDOMEnvironment;

--- a/web/packages/teleterm/src/ui/AppInitializer/AppInitializer.test.tsx
+++ b/web/packages/teleterm/src/ui/AppInitializer/AppInitializer.test.tsx
@@ -176,12 +176,11 @@ test.each<{
     name: 'overwriting document reopen dialog with another regular dialog does not discard documents',
     action: async appContext => {
       act(() => {
-        const { closeDialog } = appContext.modalsService.openRegularDialog({
+        appContext.modalsService.openRegularDialog({
           kind: 'change-access-request-kind',
           onConfirm() {},
           onCancel() {},
         });
-        closeDialog();
       });
     },
     expectDocumentsRestoredOrDiscarded: false,

--- a/web/packages/teleterm/src/ui/AppInitializer/AppInitializer.test.tsx
+++ b/web/packages/teleterm/src/ui/AppInitializer/AppInitializer.test.tsx
@@ -154,14 +154,14 @@ test('activating a workspace via deep link overrides the previously active works
 test.each<{
   name: string;
   action(appContext: IAppContext): Promise<void>;
-  expectDocumentsRestoredOrDiscarded: boolean;
+  expectCanReopenDocuments: boolean;
 }>([
   {
     name: 'closing documents reopen dialog via close button discards previous documents',
     action: async () => {
       await userEvent.click(await screen.findByTitle('Close'));
     },
-    expectDocumentsRestoredOrDiscarded: true,
+    expectCanReopenDocuments: false,
   },
   {
     name: 'starting new session in document reopen dialog discards previous documents',
@@ -170,7 +170,7 @@ test.each<{
         await screen.findByRole('button', { name: 'Start New Session' })
       );
     },
-    expectDocumentsRestoredOrDiscarded: true,
+    expectCanReopenDocuments: false,
   },
   {
     name: 'overwriting document reopen dialog with another regular dialog does not discard documents',
@@ -183,7 +183,7 @@ test.each<{
         });
       });
     },
-    expectDocumentsRestoredOrDiscarded: false,
+    expectCanReopenDocuments: true,
   },
 ])('$name', async testCase => {
   const rootCluster = makeRootCluster();
@@ -241,6 +241,6 @@ test.each<{
 
   expect(
     appContext.workspacesService.getWorkspace(rootCluster.uri)
-      .documentsRestoredOrDiscarded
-  ).toBe(testCase.expectDocumentsRestoredOrDiscarded);
+      .canRestoreDocuments
+  ).toBe(testCase.expectCanReopenDocuments);
 });

--- a/web/packages/teleterm/src/ui/AppInitializer/AppInitializer.test.tsx
+++ b/web/packages/teleterm/src/ui/AppInitializer/AppInitializer.test.tsx
@@ -154,14 +154,14 @@ test('activating a workspace via deep link overrides the previously active works
 test.each<{
   name: string;
   action(appContext: IAppContext): Promise<void>;
-  expectCanReopenDocuments: boolean;
+  expectHasDocumentsToReopen: boolean;
 }>([
   {
     name: 'closing documents reopen dialog via close button discards previous documents',
     action: async () => {
       await userEvent.click(await screen.findByTitle('Close'));
     },
-    expectCanReopenDocuments: false,
+    expectHasDocumentsToReopen: false,
   },
   {
     name: 'starting new session in document reopen dialog discards previous documents',
@@ -170,7 +170,7 @@ test.each<{
         await screen.findByRole('button', { name: 'Start New Session' })
       );
     },
-    expectCanReopenDocuments: false,
+    expectHasDocumentsToReopen: false,
   },
   {
     name: 'overwriting document reopen dialog with another regular dialog does not discard documents',
@@ -183,7 +183,7 @@ test.each<{
         });
       });
     },
-    expectCanReopenDocuments: true,
+    expectHasDocumentsToReopen: true,
   },
 ])('$name', async testCase => {
   const rootCluster = makeRootCluster();
@@ -241,6 +241,6 @@ test.each<{
 
   expect(
     appContext.workspacesService.getWorkspace(rootCluster.uri)
-      .canRestoreDocuments
-  ).toBe(testCase.expectCanReopenDocuments);
+      .hasDocumentsToReopen
+  ).toBe(testCase.expectHasDocumentsToReopen);
 });

--- a/web/packages/teleterm/src/ui/AppInitializer/AppInitializer.test.tsx
+++ b/web/packages/teleterm/src/ui/AppInitializer/AppInitializer.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import 'jest-canvas-mock';
+import { render } from 'design/utils/testing';
+import { screen, act, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
+import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
+import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
+import { ConnectionsContextProvider } from 'teleterm/ui/TopBar/Connections/connectionsContext';
+import { VnetContextProvider } from 'teleterm/ui/Vnet';
+import Logger, { NullService } from 'teleterm/logger';
+import { MockedUnaryCall } from 'teleterm/services/tshd/cloneableClient';
+import { ResourcesContextProvider } from 'teleterm/ui/DocumentCluster/resourcesContext';
+
+import { AppInitializer } from './AppInitializer';
+
+beforeAll(() => {
+  Logger.init(new NullService());
+});
+
+jest.mock('teleterm/ui/ClusterConnect', () => ({
+  ClusterConnect: props => (
+    <div
+      data-testid="mocked-dialog"
+      data-dialog-kind="cluster-connect"
+      data-dialog-is-hidden={props.hidden}
+    >
+      <button onClick={props.dialog.onSuccess}>Connect to cluster</button>
+    </div>
+  ),
+}));
+
+test('activating a workspace via deep link overrides the previously active workspace', async () => {
+  // Before closing the app, both clusters were present in the state, with previouslyActiveCluster being active.
+  // However, the user clicked a deep link pointing to deepLinkCluster.
+  // The app should prioritize the user's intent by activating the workspace for the deep link,
+  // rather than reactivating the previously active cluster.
+  const previouslyActiveCluster = makeRootCluster({
+    uri: '/clusters/teleport-previously-active',
+    proxyHost: 'teleport-previously-active:3080',
+    name: 'teleport-previously-active',
+    connected: false,
+  });
+  const deepLinkCluster = makeRootCluster({
+    uri: '/clusters/teleport-deep-link',
+    proxyHost: 'teleport-deep-link:3080',
+    name: 'teleport-deep-link',
+    connected: false,
+  });
+  const appContext = new MockAppContext();
+  jest
+    .spyOn(appContext.statePersistenceService, 'getWorkspacesState')
+    .mockReturnValue({
+      rootClusterUri: previouslyActiveCluster.uri,
+      workspaces: {
+        [previouslyActiveCluster.uri]: {
+          localClusterUri: previouslyActiveCluster.uri,
+          documents: [],
+          location: undefined,
+        },
+        [deepLinkCluster.uri]: {
+          localClusterUri: deepLinkCluster.uri,
+          documents: [],
+          location: undefined,
+        },
+      },
+    });
+  appContext.mainProcessClient.configService.set(
+    'usageReporting.enabled',
+    false
+  );
+  jest.spyOn(appContext.tshd, 'listRootClusters').mockReturnValue(
+    new MockedUnaryCall({
+      clusters: [deepLinkCluster, previouslyActiveCluster],
+    })
+  );
+  jest.spyOn(appContext.modalsService, 'openRegularDialog');
+  const userInterfaceReady = withPromiseResolver();
+  jest
+    .spyOn(appContext.mainProcessClient, 'signalUserInterfaceReadiness')
+    .mockImplementation(() => userInterfaceReady.resolve());
+
+  render(
+    <MockAppContextProvider appContext={appContext}>
+      <ConnectionsContextProvider>
+        <VnetContextProvider>
+          <ResourcesContextProvider>
+            <AppInitializer />
+          </ResourcesContextProvider>
+        </VnetContextProvider>
+      </ConnectionsContextProvider>
+    </MockAppContextProvider>
+  );
+
+  // Wait for the app to finish initialization.
+  await act(() => userInterfaceReady.promise);
+  // Launch a deep link and do not wait for the result.
+  act(() => {
+    void appContext.deepLinksService.launchDeepLink({
+      status: 'success',
+      url: {
+        host: deepLinkCluster.proxyHost,
+        hostname: deepLinkCluster.name,
+        port: '1234',
+        pathname: '/authenticate_web_device',
+        username: deepLinkCluster.loggedInUser.name,
+        searchParams: {
+          id: '123',
+          redirect_uri: '',
+          token: 'abc',
+        },
+      },
+    });
+  });
+
+  // The cluster-connect dialog should be opened two times.
+  // The first one comes from restoring the previous session, but it is
+  // immediately canceled and replaced with a dialog to the cluster from
+  // the deep link.
+  await waitFor(
+    () => {
+      expect(appContext.modalsService.openRegularDialog).toHaveBeenCalledTimes(
+        2
+      );
+    },
+    // A small timeout to prevent potential race conditions.
+    { timeout: 10 }
+  );
+  expect(appContext.modalsService.openRegularDialog).toHaveBeenNthCalledWith(
+    1,
+    expect.objectContaining({
+      kind: 'cluster-connect',
+      clusterUri: previouslyActiveCluster.uri,
+    })
+  );
+  expect(appContext.modalsService.openRegularDialog).toHaveBeenNthCalledWith(
+    2,
+    expect.objectContaining({
+      kind: 'cluster-connect',
+      clusterUri: deepLinkCluster.uri,
+    })
+  );
+
+  // We blindly confirm the current cluster-connect dialog.
+  const dialogSuccessButton = await screen.findByRole('button', {
+    name: 'Connect to cluster',
+  });
+  await userEvent.click(dialogSuccessButton);
+
+  // Check if the first activated workspace is the one from the deep link.
+  expect(await screen.findByTitle(/Current cluster:/)).toBeVisible();
+  expect(
+    screen.queryByTitle(`Current cluster: ${deepLinkCluster.name}`)
+  ).toBeVisible();
+});
+
+//TODO(gzdunek): Replace with Promise.withResolvers after upgrading to Node.js 22.
+function withPromiseResolver() {
+  let resolver: () => void;
+  const promise = new Promise<void>(resolve => (resolver = resolve));
+  return {
+    resolve: resolver,
+    promise,
+  };
+}

--- a/web/packages/teleterm/src/ui/AppInitializer/AppInitializer.tsx
+++ b/web/packages/teleterm/src/ui/AppInitializer/AppInitializer.tsx
@@ -38,6 +38,13 @@ export const AppInitializer = () => {
       await appContext.pullInitialState();
       setShouldShowUi(true);
       await showStartupModalsAndNotifications(appContext);
+      // If there's a workspace that was active before closing the app,
+      // activate it.
+      const rootClusterUri =
+        appContext.workspacesService.getRestoredState()?.rootClusterUri;
+      if (rootClusterUri) {
+        void appContext.workspacesService.setActiveWorkspace(rootClusterUri);
+      }
       appContext.mainProcessClient.signalUserInterfaceReadiness({
         success: true,
       });

--- a/web/packages/teleterm/src/ui/AppInitializer/showStartupModalsAndNotifications.ts
+++ b/web/packages/teleterm/src/ui/AppInitializer/showStartupModalsAndNotifications.ts
@@ -45,11 +45,6 @@ export async function showStartupModalsAndNotifications(
   // "User job role" dialog is shown on the second launch (only if user agreed to reporting earlier).
   await setUpUsageReporting(configService, ctx.modalsService);
 
-  // If there's a workspace that was active before the user closed the app, restorePersistedState
-  // will block until the user interacts with the login modal (if the cert is not valid anymore) and
-  // the modal for restoring documents.
-  await ctx.workspacesService.restorePersistedState();
-
   notifyAboutConfigErrors(configService, ctx.notificationsService);
   notifyAboutDuplicatedShortcutsCombinations(
     ctx.keyboardShortcutsService,

--- a/web/packages/teleterm/src/ui/DocumentsReopen/DocumentsReopen.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentsReopen/DocumentsReopen.story.tsx
@@ -33,7 +33,7 @@ export const Story = () => {
         rootClusterUri="/clusters/foo.cloud.gravitational.io"
         numberOfDocuments={8}
         onConfirm={() => {}}
-        onCancel={() => {}}
+        onDiscard={() => {}}
       />
     </MockAppContextProvider>
   );
@@ -46,7 +46,7 @@ export const OneTab = () => {
         rootClusterUri="/clusters/foo.cloud.gravitational.io"
         numberOfDocuments={1}
         onConfirm={() => {}}
-        onCancel={() => {}}
+        onDiscard={() => {}}
       />
     </MockAppContextProvider>
   );
@@ -59,7 +59,7 @@ export const LongClusterName = () => {
         rootClusterUri="/clusters/foo.bar.baz.quux.cloud.gravitational.io"
         numberOfDocuments={42}
         onConfirm={() => {}}
-        onCancel={() => {}}
+        onDiscard={() => {}}
       />
     </MockAppContextProvider>
   );
@@ -75,7 +75,7 @@ export const LongContinuousClusterName = () => {
           .join('')}`}
         numberOfDocuments={680}
         onConfirm={() => {}}
-        onCancel={() => {}}
+        onDiscard={() => {}}
       />
     </MockAppContextProvider>
   );

--- a/web/packages/teleterm/src/ui/DocumentsReopen/DocumentsReopen.tsx
+++ b/web/packages/teleterm/src/ui/DocumentsReopen/DocumentsReopen.tsx
@@ -71,6 +71,7 @@ export function DocumentsReopen(props: {
           <ButtonIcon
             type="button"
             onClick={props.onDiscard}
+            title="Close"
             color="text.slightlyMuted"
           >
             <Cross size="medium" />

--- a/web/packages/teleterm/src/ui/DocumentsReopen/DocumentsReopen.tsx
+++ b/web/packages/teleterm/src/ui/DocumentsReopen/DocumentsReopen.tsx
@@ -34,7 +34,7 @@ import { useAppContext } from 'teleterm/ui/appContextProvider';
 export function DocumentsReopen(props: {
   rootClusterUri: RootClusterUri;
   numberOfDocuments: number;
-  onCancel(): void;
+  onDiscard(): void;
   onConfirm(): void;
   hidden?: boolean;
 }) {
@@ -50,7 +50,7 @@ export function DocumentsReopen(props: {
     <DialogConfirmation
       open={!props.hidden}
       keepInDOMAfterClose
-      onClose={props.onCancel}
+      onClose={props.onDiscard}
       dialogCss={() => ({
         maxWidth: '400px',
         width: '100%',
@@ -70,7 +70,7 @@ export function DocumentsReopen(props: {
           <H2 mb={4}>Reopen previous session</H2>
           <ButtonIcon
             type="button"
-            onClick={props.onCancel}
+            onClick={props.onDiscard}
             color="text.slightlyMuted"
           >
             <Cross size="medium" />
@@ -105,7 +105,7 @@ export function DocumentsReopen(props: {
           <ButtonPrimary autoFocus mr={3} type="submit">
             Reopen
           </ButtonPrimary>
-          <ButtonSecondary type="button" onClick={props.onCancel}>
+          <ButtonSecondary type="button" onClick={props.onDiscard}>
             Start New Session
           </ButtonSecondary>
         </DialogFooter>

--- a/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.story.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.story.tsx
@@ -56,6 +56,7 @@ const documentsReopenDialog: DialogDocumentsReopen = {
   rootClusterUri: '/clusters/foo',
   numberOfDocuments: 1,
   onConfirm: () => {},
+  onDiscard: () => {},
   onCancel: () => {},
 };
 

--- a/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.tsx
@@ -40,22 +40,21 @@ export default function ModalsHost() {
   const { regular: regularDialog, important: importantDialogs } =
     modalsService.useState();
 
-  const closeRegularDialog = () => modalsService.closeRegularDialog();
-
   return (
     <>
-      {renderDialog({
-        dialog: regularDialog,
-        handleClose: closeRegularDialog,
-        hidden: !!importantDialogs.length,
-      })}
-      {importantDialogs.map(({ dialog, id }, index) => {
+      {regularDialog &&
+        renderDialog({
+          dialog: regularDialog.dialog,
+          handleClose: regularDialog.close,
+          hidden: !!importantDialogs.length,
+        })}
+      {importantDialogs.map(({ dialog, id, close }, index) => {
         const isLast = index === importantDialogs.length - 1;
         return (
           <Fragment key={id}>
             {renderDialog({
               dialog: dialog,
-              handleClose: () => modalsService.closeImportantDialog(id),
+              handleClose: close,
               hidden: !isLast,
             })}
           </Fragment>

--- a/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.tsx
@@ -120,9 +120,9 @@ function renderDialog({
           hidden={hidden}
           rootClusterUri={dialog.rootClusterUri}
           numberOfDocuments={dialog.numberOfDocuments}
-          onCancel={() => {
+          onDiscard={() => {
             handleClose();
-            dialog.onCancel();
+            dialog.onDiscard();
           }}
           onConfirm={() => {
             handleClose();

--- a/web/packages/teleterm/src/ui/StatusBar/StatusBar.tsx
+++ b/web/packages/teleterm/src/ui/StatusBar/StatusBar.tsx
@@ -44,7 +44,7 @@ export function StatusBar() {
         css={`
           white-space: nowrap;
         `}
-        title={clusterBreadcrumbs}
+        title={clusterBreadcrumbs && `Current cluster: ${clusterBreadcrumbs}`}
       >
         {clusterBreadcrumbs}
       </Text>

--- a/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
@@ -123,6 +123,8 @@ export const VnetContextProvider: FC<PropsWithChildren> = props => {
       if (
         isSupported &&
         autoStart &&
+        // Accessing resources through VNet might trigger the MFA modal,
+        // so we have to wait for the tshd events service to be initialized.
         isWorkspaceStateInitialized &&
         startAttempt.status === ''
       ) {

--- a/web/packages/teleterm/src/ui/appContext.ts
+++ b/web/packages/teleterm/src/ui/appContext.ts
@@ -179,6 +179,9 @@ export default class AppContext implements IAppContext {
     void this.clustersService.syncGatewaysAndCatchErrors();
     await this.clustersService.syncRootClustersAndCatchErrors();
     this.workspacesService.restorePersistedState();
+    // The app has been initialized (callbacks are set up, state is restored).
+    // The UI is visible.
+    this.workspacesService.markAsInitialized();
   }
 
   /**

--- a/web/packages/teleterm/src/ui/appContext.ts
+++ b/web/packages/teleterm/src/ui/appContext.ts
@@ -176,8 +176,9 @@ export default class AppContext implements IAppContext {
 
     this.subscribeToDeepLinkLaunch();
     this.notifyMainProcessAboutClusterListChanges();
-    this.clustersService.syncGatewaysAndCatchErrors();
+    void this.clustersService.syncGatewaysAndCatchErrors();
     await this.clustersService.syncRootClustersAndCatchErrors();
+    this.workspacesService.restorePersistedState();
   }
 
   /**

--- a/web/packages/teleterm/src/ui/services/deepLinks/deepLinksService.ts
+++ b/web/packages/teleterm/src/ui/services/deepLinks/deepLinksService.ts
@@ -164,6 +164,15 @@ export class DeepLinksService {
       }
   > {
     const currentlyActiveWorkspace = this.workspacesService.getRootClusterUri();
+    // If we closed the dialog to reopen documents when launching a deep link,
+    // setting the active workspace again will reopen it.
+    const reopenCurrentlyActiveWorkspace = async () => {
+      if (currentlyActiveWorkspace) {
+        await this.workspacesService.setActiveWorkspace(
+          currentlyActiveWorkspace
+        );
+      }
+    };
     const rootClusterId = url.hostname;
     const clusterAddress = url.host;
     const prefill = {
@@ -187,6 +196,7 @@ export class DeepLinksService {
       });
 
       if (canceled) {
+        await reopenCurrentlyActiveWorkspace();
         return {
           isAtDesiredWorkspace: false,
         };
@@ -206,12 +216,7 @@ export class DeepLinksService {
       return { isAtDesiredWorkspace: true, rootClusterUri };
     }
 
-    // We failed to change the workspace.
-    // If we closed the documents reopen dialog when launching a deep link,
-    // setting the active workspace again will reopen it.
-    if (currentlyActiveWorkspace) {
-      await this.workspacesService.setActiveWorkspace(currentlyActiveWorkspace);
-    }
+    await reopenCurrentlyActiveWorkspace();
     return { isAtDesiredWorkspace: false };
   }
 }

--- a/web/packages/teleterm/src/ui/services/deepLinks/deepLinksService.ts
+++ b/web/packages/teleterm/src/ui/services/deepLinks/deepLinksService.ts
@@ -163,6 +163,7 @@ export class DeepLinksService {
         rootClusterUri: RootClusterUri;
       }
   > {
+    const currentlyActiveWorkspace = this.workspacesService.getRootClusterUri();
     const rootClusterId = url.hostname;
     const clusterAddress = url.host;
     const prefill = {
@@ -201,6 +202,16 @@ export class DeepLinksService {
         prefill
       );
 
-    return { isAtDesiredWorkspace, rootClusterUri };
+    if (isAtDesiredWorkspace) {
+      return { isAtDesiredWorkspace: true, rootClusterUri };
+    }
+
+    // We failed to change the workspace.
+    // If we closed the documents reopen dialog when launching a deep link,
+    // setting the active workspace again will reopen it.
+    if (currentlyActiveWorkspace) {
+      await this.workspacesService.setActiveWorkspace(currentlyActiveWorkspace);
+    }
+    return { isAtDesiredWorkspace: false };
   }
 }

--- a/web/packages/teleterm/src/ui/services/deepLinks/deepLinksService.ts
+++ b/web/packages/teleterm/src/ui/services/deepLinks/deepLinksService.ts
@@ -74,6 +74,14 @@ export class DeepLinksService {
       return;
     }
 
+    // Before we start, let's close any open dialogs, for a few reasons:
+    // 1. Activating a deep link may require changing the workspace, and we don't
+    // want to see dialogs from the previous one.
+    // 2. A login dialog could be covered by an important dialog.
+    // 3. The user could be confused, since Connect My Computer or Authorize Web
+    // Session documents would be displayed below a dialog.
+    this.modalsService.cancelAndCloseAll();
+
     // launchDeepLink cannot throw if it receives a pathname that doesn't match any supported
     // pathnames. The user might simply be using a version of Connect that doesn't support the given
     // pathname yet. Generally, such cases should be caught outside of DeepLinksService by

--- a/web/packages/teleterm/src/ui/services/modals/modalsService.test.ts
+++ b/web/packages/teleterm/src/ui/services/modals/modalsService.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
+
+import { ModalsService, DialogClusterConnect } from './modalsService';
+
+const rootCluster = makeRootCluster();
+
+function makeDialogClusterConnect(): DialogClusterConnect {
+  return {
+    kind: 'cluster-connect',
+    clusterUri: rootCluster.uri,
+    reason: undefined,
+    prefill: undefined,
+    onSuccess: jest.fn(),
+    onCancel: jest.fn(),
+  };
+}
+
+test('closing all dialogs', () => {
+  const dialogClusterConnect1 = makeDialogClusterConnect();
+  const dialogClusterConnect2 = makeDialogClusterConnect();
+  const modalsService = new ModalsService();
+
+  modalsService.openRegularDialog(dialogClusterConnect1);
+  modalsService.openImportantDialog(dialogClusterConnect2);
+  expect(modalsService.state.regular.dialog).toStrictEqual(
+    dialogClusterConnect1
+  );
+  expect(modalsService.state.important).toHaveLength(1);
+  expect(modalsService.state.important[0].dialog).toStrictEqual(
+    dialogClusterConnect2
+  );
+
+  modalsService.cancelAndCloseAll();
+  expect(modalsService.state.regular).toStrictEqual(undefined);
+  expect(modalsService.state.important).toHaveLength(0);
+  expect(dialogClusterConnect1.onCancel).toHaveBeenCalledTimes(1);
+  expect(dialogClusterConnect2.onCancel).toHaveBeenCalledTimes(1);
+});
+
+test('closing regular dialog with abort signal', () => {
+  const dialogClusterConnect = makeDialogClusterConnect();
+  const modalsService = new ModalsService();
+  const controller = new AbortController();
+
+  modalsService.openRegularDialog(dialogClusterConnect, controller.signal);
+  expect(modalsService.state.regular.dialog).toStrictEqual(
+    dialogClusterConnect
+  );
+  controller.abort();
+  expect(modalsService.state.regular).toStrictEqual(undefined);
+  expect(dialogClusterConnect.onCancel).toHaveBeenCalledTimes(1);
+});
+
+test('aborting dialog is ignored after it has been closed', () => {
+  const dialogClusterConnect1 = makeDialogClusterConnect();
+  const modalsService = new ModalsService();
+  const controller = new AbortController();
+
+  modalsService.openRegularDialog(dialogClusterConnect1, controller.signal);
+  expect(modalsService.state.regular.dialog).toStrictEqual(
+    dialogClusterConnect1
+  );
+  dialogClusterConnect1.onSuccess('');
+
+  const dialogClusterConnect2 = makeDialogClusterConnect();
+  modalsService.openRegularDialog(dialogClusterConnect2);
+  expect(modalsService.state.regular.dialog).toStrictEqual(
+    dialogClusterConnect2
+  );
+
+  controller.abort();
+  // The currently open dialog is not closed.
+  expect(modalsService.state.regular.dialog).toStrictEqual(
+    dialogClusterConnect2
+  );
+});
+
+test('opening a new regular dialog while another is active invokes onCancel callback of the previous one', () => {
+  const dialogClusterConnect1 = makeDialogClusterConnect();
+  const dialogClusterConnect2 = makeDialogClusterConnect();
+  const modalsService = new ModalsService();
+
+  modalsService.openRegularDialog(dialogClusterConnect1);
+  expect(modalsService.state.regular.dialog).toStrictEqual(
+    dialogClusterConnect1
+  );
+  modalsService.openRegularDialog(dialogClusterConnect2);
+  expect(dialogClusterConnect1.onCancel).toHaveBeenCalledTimes(1);
+});
+
+test('when dialog is canceled in multiple ways, onCancel callback is invoked once', () => {
+  const dialogClusterConnect = makeDialogClusterConnect();
+  const modalsService = new ModalsService();
+  const controller = new AbortController();
+
+  const { closeDialog } = modalsService.openRegularDialog(
+    dialogClusterConnect,
+    controller.signal
+  );
+  expect(modalsService.state.regular.dialog).toStrictEqual(
+    dialogClusterConnect
+  );
+  closeDialog();
+  controller.abort();
+  expect(dialogClusterConnect.onCancel).toHaveBeenCalledTimes(1);
+});
+
+test('dialog opened with aborted signal returns immediately', () => {
+  const dialogClusterConnect = makeDialogClusterConnect();
+  const modalsService = new ModalsService();
+  const controller = new AbortController();
+  controller.abort();
+
+  modalsService.openRegularDialog(dialogClusterConnect, controller.signal);
+  expect(modalsService.state.regular).toStrictEqual(undefined);
+  expect(dialogClusterConnect.onCancel).toHaveBeenCalledTimes(1);
+});

--- a/web/packages/teleterm/src/ui/services/modals/modalsService.ts
+++ b/web/packages/teleterm/src/ui/services/modals/modalsService.ts
@@ -39,8 +39,9 @@ type State = {
   // The important dialogs are displayed above the regular one. This is to avoid losing the state of
   // the regular modal if we happen to need to interrupt whatever the user is doing and display an
   // important modal.
-  important: { dialog: Dialog; id: string }[];
-  regular: Dialog | undefined;
+  // `close` function closes the dialog and unregisters event listeners.
+  important: { dialog: Dialog; id: string; close(): void }[];
+  regular: { dialog: Dialog; close(): void } | undefined;
 };
 
 export class ModalsService extends ImmutableStore<State> {
@@ -48,6 +49,15 @@ export class ModalsService extends ImmutableStore<State> {
     important: [],
     regular: undefined,
   };
+
+  private allDialogsController = new AbortController();
+
+  private getSharedAbortSignal(dialogSignal?: AbortSignal): AbortSignal {
+    if (!dialogSignal) {
+      return this.allDialogsController.signal;
+    }
+    return AbortSignal.any([dialogSignal, this.allDialogsController.signal]);
+  }
 
   /**
    * openRegularDialog opens the given dialog as a regular dialog. A regular dialog can get covered
@@ -58,20 +68,52 @@ export class ModalsService extends ImmutableStore<State> {
    * old dialog with the new one.
    * The old dialog is canceled, if possible.
    *
-   * The returned closeDialog function can be used to close the dialog and automatically call the
-   * dialog's onCancel callback (if present).
+   * The passed `abortSignal` or the returned `closeDialog` function can be used to close the dialog
+   * and automatically call the dialog's onCancel callback (if present).
+   * The onCancel function can be called without a user interaction. As of now,
+   * this happens when the user launches a deep link while a regular dialog is open.
+   * As such, if the dialog presents the user with a decision, onCancel should be
+   * treated as no decision being made.
+   * If possible, the user should be prompted again to make the decision later on.
    */
-  openRegularDialog(dialog: Dialog): { closeDialog: () => void } {
-    this.state.regular?.['onCancel']?.();
+  openRegularDialog(
+    dialog: Dialog,
+    abortSignal?: AbortSignal
+  ): {
+    closeDialog: () => void;
+  } {
+    const onCancelDialog = () => dialog['onCancel']?.();
+    const sharedSignal = this.getSharedAbortSignal(abortSignal);
+    if (sharedSignal.aborted) {
+      onCancelDialog();
+      return {
+        closeDialog: () => {},
+      };
+    }
+
+    // If there's a previous dialog, cancel and close it.
+    const previousDialog = this.state.regular;
+    if (previousDialog) {
+      previousDialog.dialog['onCancel']?.();
+      previousDialog.close();
+    }
+
+    const close = () => {
+      sharedSignal.removeEventListener('abort', cancelAndClose);
+      this.closeRegularDialog();
+    };
+    const cancelAndClose = () => {
+      close();
+      onCancelDialog();
+    };
+    sharedSignal.addEventListener('abort', cancelAndClose);
+
     this.setState(draftState => {
-      draftState.regular = dialog;
+      draftState.regular = { dialog, close };
     });
 
     return {
-      closeDialog: () => {
-        this.closeRegularDialog();
-        dialog['onCancel']?.();
-      },
+      closeDialog: cancelAndClose,
     };
   }
 
@@ -93,33 +135,47 @@ export class ModalsService extends ImmutableStore<State> {
    * dialog's onCancel callback (if present).
    */
   openImportantDialog(dialog: Dialog): { closeDialog: () => void; id: string } {
+    const onCancelDialog = () => dialog['onCancel']?.();
+    const allDialogsSignal = this.allDialogsController.signal;
     const id = crypto.randomUUID();
+
+    const close = () => {
+      allDialogsSignal.removeEventListener('abort', cancelAndClose);
+      this.closeImportantDialog(id);
+    };
+    const cancelAndClose = () => {
+      close();
+      onCancelDialog();
+    };
+    allDialogsSignal.addEventListener('abort', cancelAndClose);
     this.setState(draftState => {
-      draftState.important.push({ dialog, id });
+      draftState.important.push({ dialog, id, close });
     });
 
     return {
       id,
-      closeDialog: () => {
-        this.closeImportantDialog(id);
-        dialog['onCancel']?.();
-      },
+      closeDialog: cancelAndClose,
     };
   }
 
-  closeRegularDialog() {
+  private closeRegularDialog() {
     this.setState(draftState => {
       draftState.regular = undefined;
     });
   }
 
-  closeImportantDialog(id: string) {
+  private closeImportantDialog(id: string) {
     this.setState(draftState => {
       const index = draftState.important.findIndex(d => d.id === id);
       if (index >= 0) {
         draftState.important.splice(index, 1);
       }
     });
+  }
+
+  cancelAndCloseAll(): void {
+    this.allDialogsController.abort();
+    this.allDialogsController = new AbortController();
   }
 
   useState() {

--- a/web/packages/teleterm/src/ui/services/modals/modalsService.ts
+++ b/web/packages/teleterm/src/ui/services/modals/modalsService.ts
@@ -167,6 +167,8 @@ export interface DialogDocumentsReopen {
   rootClusterUri: RootClusterUri;
   numberOfDocuments: number;
   onConfirm?(): void;
+  onDiscard?(): void;
+  /** Cancels the dialog, without discarding documents. */
   onCancel?(): void;
 }
 

--- a/web/packages/teleterm/src/ui/services/statePersistence/statePersistenceService.ts
+++ b/web/packages/teleterm/src/ui/services/statePersistence/statePersistenceService.ts
@@ -35,7 +35,10 @@ export type WorkspacesPersistedState = Omit<
   WorkspacesState,
   'workspaces' | 'isInitialized'
 > & {
-  workspaces: Record<string, Omit<Workspace, 'accessRequests'>>;
+  workspaces: Record<
+    string,
+    Omit<Workspace, 'accessRequests' | 'documentsRestoredOrDiscarded'>
+  >;
 };
 
 export interface StatePersistenceState {

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
@@ -85,7 +85,7 @@ export class DocumentsService {
     };
   }
 
-  /** @deprecated Use createClusterDocument directly. */
+  /** @deprecated Use createClusterDocument function instead of the method on DocumentsService. */
   createClusterDocument(opts: {
     clusterUri: uri.ClusterUri;
     queryParams?: DocumentClusterQueryParams;

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
@@ -85,19 +85,12 @@ export class DocumentsService {
     };
   }
 
+  /** @deprecated Use createClusterDocument directly. */
   createClusterDocument(opts: {
     clusterUri: uri.ClusterUri;
     queryParams?: DocumentClusterQueryParams;
   }): DocumentCluster {
-    const uri = routing.getDocUri({ docId: unique() });
-    const clusterName = routing.parseClusterName(opts.clusterUri);
-    return {
-      uri,
-      clusterUri: opts.clusterUri,
-      title: clusterName,
-      kind: 'doc.cluster',
-      queryParams: opts.queryParams || getDefaultDocumentClusterQueryParams(),
-    };
+    return createClusterDocument(opts);
   }
 
   /**
@@ -507,6 +500,21 @@ export class DocumentsService {
       draft.documents.splice(newIndex, 0, doc);
     });
   }
+}
+
+export function createClusterDocument(opts: {
+  clusterUri: uri.ClusterUri;
+  queryParams?: DocumentClusterQueryParams;
+}): DocumentCluster {
+  const uri = routing.getDocUri({ docId: unique() });
+  const clusterName = routing.parseClusterName(opts.clusterUri);
+  return {
+    uri,
+    clusterUri: opts.clusterUri,
+    title: clusterName,
+    kind: 'doc.cluster',
+    queryParams: opts.queryParams || getDefaultDocumentClusterQueryParams(),
+  };
 }
 
 export function getDefaultDocumentClusterQueryParams(): DocumentClusterQueryParams {

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.test.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.test.ts
@@ -313,7 +313,7 @@ describe('setActiveWorkspace', () => {
     expect(workspacesService.getRootClusterUri()).toBeUndefined();
   });
 
-  it('location is set to first document if it points to non-existing document when reopening documents', async () => {
+  it('sets location to first document if location points to non-existing document when reopening documents', async () => {
     const cluster = makeRootCluster();
     const testWorkspace: Workspace = {
       accessRequests: {

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.test.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.test.ts
@@ -90,7 +90,7 @@ describe('restoring workspace', () => {
         localClusterUri: testWorkspace.localClusterUri,
         documents: [expect.objectContaining({ kind: 'doc.cluster' })],
         location: expect.any(String),
-        canRestoreDocuments: true,
+        hasDocumentsToReopen: true,
         connectMyComputer: undefined,
         unifiedResourcePreferences: {
           defaultTab: DefaultTab.ALL,
@@ -126,7 +126,7 @@ describe('restoring workspace', () => {
         localClusterUri: cluster.uri,
         documents: [expect.objectContaining({ kind: 'doc.cluster' })],
         location: expect.any(String),
-        canRestoreDocuments: false,
+        hasDocumentsToReopen: false,
         connectMyComputer: undefined,
         unifiedResourcePreferences: {
           defaultTab: DefaultTab.ALL,

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.test.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.test.ts
@@ -90,7 +90,7 @@ describe('restoring workspace', () => {
         localClusterUri: testWorkspace.localClusterUri,
         documents: [expect.objectContaining({ kind: 'doc.cluster' })],
         location: expect.any(String),
-        documentsRestoredOrDiscarded: false,
+        canRestoreDocuments: true,
         connectMyComputer: undefined,
         unifiedResourcePreferences: {
           defaultTab: DefaultTab.ALL,
@@ -126,7 +126,7 @@ describe('restoring workspace', () => {
         localClusterUri: cluster.uri,
         documents: [expect.objectContaining({ kind: 'doc.cluster' })],
         location: expect.any(String),
-        documentsRestoredOrDiscarded: false,
+        canRestoreDocuments: false,
         connectMyComputer: undefined,
         unifiedResourcePreferences: {
           defaultTab: DefaultTab.ALL,

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.test.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.test.ts
@@ -76,11 +76,8 @@ describe('restoring workspace', () => {
       persistedWorkspaces: persistedWorkspace,
     });
 
-    expect(workspacesService.state.isInitialized).toEqual(false);
-
     workspacesService.restorePersistedState();
 
-    expect(workspacesService.state.isInitialized).toEqual(true);
     expect(workspacesService.getWorkspaces()).toStrictEqual({
       [cluster.uri]: {
         accessRequests: {
@@ -115,11 +112,8 @@ describe('restoring workspace', () => {
       persistedWorkspaces: {},
     });
 
-    expect(workspacesService.state.isInitialized).toEqual(false);
-
     workspacesService.restorePersistedState();
 
-    expect(workspacesService.state.isInitialized).toEqual(true);
     expect(workspacesService.getWorkspaces()).toStrictEqual({
       [cluster.uri]: {
         accessRequests: {

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.test.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.test.ts
@@ -69,7 +69,7 @@ describe('restoring workspace', () => {
       location: '/docs/some_uri',
     };
 
-    const { workspacesService, clusterDocument } = getTestSetup({
+    const { workspacesService } = getTestSetup({
       cluster,
       persistedWorkspaces: { [cluster.uri]: testWorkspace },
     });
@@ -89,8 +89,8 @@ describe('restoring workspace', () => {
           isBarCollapsed: false,
         },
         localClusterUri: testWorkspace.localClusterUri,
-        documents: [clusterDocument],
-        location: clusterDocument.uri,
+        documents: [expect.objectContaining({ kind: 'doc.cluster' })],
+        location: expect.any(String),
         previous: {
           documents: testWorkspace.documents,
           location: testWorkspace.location,
@@ -108,7 +108,7 @@ describe('restoring workspace', () => {
 
   it('creates empty workspace if there is no persisted state for given clusterUri', async () => {
     const cluster = makeRootCluster();
-    const { workspacesService, clusterDocument } = getTestSetup({
+    const { workspacesService } = getTestSetup({
       cluster,
       persistedWorkspaces: {},
     });
@@ -128,8 +128,8 @@ describe('restoring workspace', () => {
           },
         },
         localClusterUri: cluster.uri,
-        documents: [clusterDocument],
-        location: clusterDocument.uri,
+        documents: [expect.objectContaining({ kind: 'doc.cluster' })],
+        location: expect.any(String),
         previous: undefined,
         connectMyComputer: undefined,
         unifiedResourcePreferences: {
@@ -413,7 +413,6 @@ function getTestSetup(options: {
 
   return {
     workspacesService,
-    clusterDocument,
     modalsService,
     notificationsService,
     statePersistenceService,

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
@@ -646,7 +646,10 @@ function parseUnifiedResourcePreferences(
       unifiedResourcePreferences
     ) as UnifiedResourcePreferencesSchemaAsRequired;
   } catch (e) {
-    new Logger().error('Failed to parse unified resource preferences', e);
+    new Logger('WorkspacesService').error(
+      'Failed to parse unified resource preferences',
+      e
+    );
   }
 }
 

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
@@ -94,6 +94,12 @@ export interface Workspace {
   // This requires updating many of tests
   // where we construct the workspace manually.
   unifiedResourcePreferences?: UnifiedResourcePreferences;
+  /**
+   * Tracks whether the user has restored or discarded documents from a previous session.
+   * This is used to ensure that the prompt to restore a previous session is shown only once.
+   *
+   * This field is not persisted to disk.
+   */
   documentsRestoredOrDiscarded?: boolean;
 }
 
@@ -108,6 +114,11 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
     workspaces: {},
     isInitialized: false,
   };
+  /**
+   * Keeps the state restored when the app was launched.
+   * This state is not processed in any way, so it may, for example,
+   * contain clusters that are no longer available.
+   */
   private restoredState?: WorkspacesPersistedState;
 
   constructor(

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
@@ -71,9 +71,9 @@ export interface WorkspacesState {
   rootClusterUri?: RootClusterUri;
   workspaces: Record<RootClusterUri, Workspace>;
   /**
-   * isInitialized signifies whether WorkspacesState has finished state restoration during the start
-   * of the app. It is useful in places that want to wait for the state to be restored before
-   * proceeding.
+   * isInitialized signifies whether the app has finished setting up
+   * callbacks and restoring state during the start of the app.
+   * This also means that the UI is visible.
    *
    * This field is not persisted to disk.
    */
@@ -452,6 +452,11 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
 
     this.setState(draftState => {
       draftState.workspaces = restoredWorkspaces;
+    });
+  }
+
+  markAsInitialized(): void {
+    this.setState(draftState => {
       draftState.isInitialized = true;
     });
   }

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
@@ -116,7 +116,7 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
     isInitialized: false,
   };
   /**
-   * Keeps the state restored when the app was launched.
+   * Keeps the state that was restored from the disk when the app was launched.
    * This state is not processed in any way, so it may, for example,
    * contain clusters that are no longer available.
    */

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
@@ -98,12 +98,12 @@ export interface Workspace {
   // where we construct the workspace manually.
   unifiedResourcePreferences?: UnifiedResourcePreferences;
   /**
-   * Tracks whether the user can restore documents from a previous session.
+   * Tracks whether the user has documents to reopen from a previous session.
    * This is used to ensure that the prompt to restore a previous session is shown only once.
    *
    * This field is not persisted to disk.
    */
-  canRestoreDocuments?: boolean;
+  hasDocumentsToReopen?: boolean;
 }
 
 export class WorkspacesService extends ImmutableStore<WorkspacesState> {
@@ -370,8 +370,8 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
       draftState.rootClusterUri = clusterUri;
     });
 
-    const { canRestoreDocuments } = this.getWorkspace(clusterUri);
-    if (!canRestoreDocuments) {
+    const { hasDocumentsToReopen } = this.getWorkspace(clusterUri);
+    if (!hasDocumentsToReopen) {
       return { isAtDesiredWorkspace: true };
     }
 
@@ -521,14 +521,14 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
         reopen.documents,
         reopen.location
       );
-      workspace.canRestoreDocuments = false;
+      workspace.hasDocumentsToReopen = false;
     });
   }
 
   private discardPreviousDocuments(clusterUri: RootClusterUri): void {
     this.setState(draftState => {
       const workspace = draftState.workspaces[clusterUri];
-      workspace.canRestoreDocuments = false;
+      workspace.hasDocumentsToReopen = false;
     });
   }
 
@@ -630,7 +630,7 @@ function getWorkspaceDefaultState(
     location: defaultDocument.uri,
     documents: [defaultDocument],
     connectMyComputer: undefined,
-    canRestoreDocuments: false,
+    hasDocumentsToReopen: false,
     localClusterUri: rootClusterUri,
     unifiedResourcePreferences: parseUnifiedResourcePreferences(undefined),
   };
@@ -643,7 +643,7 @@ function getWorkspaceDefaultState(
     restoredWorkspace.unifiedResourcePreferences
   );
   defaultWorkspace.connectMyComputer = restoredWorkspace.connectMyComputer;
-  defaultWorkspace.canRestoreDocuments = hasDocumentsToReopen({
+  defaultWorkspace.hasDocumentsToReopen = hasDocumentsToReopen({
     previousDocuments: restoredWorkspace.documents,
     currentDocuments: defaultWorkspace.documents,
   });

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
@@ -624,14 +624,15 @@ function getWorkspaceDefaultState(
     localClusterUri: rootClusterUri,
     unifiedResourcePreferences: parseUnifiedResourcePreferences(undefined),
   };
-  if (restoredWorkspace) {
-    defaultWorkspace.localClusterUri = restoredWorkspace.localClusterUri;
-    defaultWorkspace.unifiedResourcePreferences =
-      parseUnifiedResourcePreferences(
-        restoredWorkspace.unifiedResourcePreferences
-      );
-    defaultWorkspace.connectMyComputer = restoredWorkspace.connectMyComputer;
+  if (!restoredWorkspace) {
+    return defaultWorkspace;
   }
+
+  defaultWorkspace.localClusterUri = restoredWorkspace.localClusterUri;
+  defaultWorkspace.unifiedResourcePreferences = parseUnifiedResourcePreferences(
+    restoredWorkspace.unifiedResourcePreferences
+  );
+  defaultWorkspace.connectMyComputer = restoredWorkspace.connectMyComputer;
 
   return defaultWorkspace;
 }

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
@@ -73,7 +73,9 @@ export interface WorkspacesState {
   /**
    * isInitialized signifies whether the app has finished setting up
    * callbacks and restoring state during the start of the app.
-   * This also means that the UI is visible.
+   * This also means that the UI can be considered visible, because soon after
+   * isInitialized is flipped to true, AppInitializer removes the loading indicator
+   * and shows the usual app UI.
    *
    * This field is not persisted to disk.
    */

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
@@ -119,6 +119,7 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
    * Keeps the state that was restored from the disk when the app was launched.
    * This state is not processed in any way, so it may, for example,
    * contain clusters that are no longer available.
+   * When a workspace is removed, it's removed from the restored state too.
    */
   private restoredState?: Immutable<WorkspacesPersistedState>;
 
@@ -415,6 +416,9 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
     this.setState(draftState => {
       delete draftState.workspaces[clusterUri];
     });
+    this.restoredState = produce(this.restoredState, draftState => {
+      delete draftState.workspaces[clusterUri];
+    });
   }
 
   getConnectedWorkspacesClustersUri() {
@@ -427,6 +431,7 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
    * Returns the state that was restored when the app was launched.
    * This state is not processed in any way, so it may, for example,
    * contain clusters that are no longer available.
+   * When a workspace is removed, it's removed from the restored state too.
    */
   getRestoredState(): Immutable<WorkspacesPersistedState> | undefined {
     return this.restoredState;

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
@@ -82,7 +82,7 @@ export interface WorkspacesState {
 export interface Workspace {
   localClusterUri: ClusterUri;
   documents: Document[];
-  location: DocumentUri;
+  location: DocumentUri | undefined;
   accessRequests: {
     isBarCollapsed: boolean;
     pending: PendingAccessRequest;


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/40962

## Problem 
Connect always tries to restore the previous workspace, even when it is run via a deep link. This is incorrect behavior- if the user wants to authorize a session for cluster A, we shouldn't force him to log in to a cluster B first.

## Solution

Currently, restoring the workspaces from disk also actives the previously active workspace (this includes showing a login dialog if certs expired). Opening a deep link waits for that state to be restored, so it also waits for that dialog to be completed.
We don't want this, so we need to decouple workspace restoration from activating the previously active workspace. This will allow us to signal the frontend interface readiness before the login dialog finishes. When the frontend is ready, a deep link can be processed to activate its corresponding workspace.
Our modal service allows only one regular dialog is active at any time, so opening a new dialog will automatically cancel an existing one.

In other words:
1. The user has workspaces A and B, with workspace B previously active.
2. The user launches a deep link to cluster A.
3. The app restores the state (workspaces A and B) and starts an attempt to set workspace B as active. This attempt does not block the app's initialization.
4. Since the app is initialized, the deep link is processed, immediately replacing the dialog for activating workspace B with one for activating workspace A. This transition happens so quickly that the user doesn’t see the initial dialog.

While working on this fix, I cleaned up some code in `workspacesService` and `documentsService`: 
* `setActiveWorkspace` had a mix of async/await and `.then`, it has been rewritten to the newer syntax. 
* I moved some methods that do not need state outside the services.
* I got rid of `previous` field in the workspace state. Instead, I store the entire restored state in a separate variable. I needed this, because if we don't restore the previous `rootClusterUri` immediately, it is overwritten with `undefined` in `setState`. I think this approach is actually simpler than what we had before.