### PR TITLE
Prevent github.com/cloudflare/cfssl from being imported

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -113,6 +113,8 @@ linters-settings:
             desc: 'use "golang.org/x/mod/semver" or "coreos/go-semver/semver" instead'
           - pkg: github.com/microsoftgraph/msgraph-sdk-go
             desc: 'use "github.com/gravitational/teleport/lib/msgraph" instead'
+          - pkg: github.com/cloudflare/cfssl
+            desc: 'use "crypto" or "x/crypto" instead'
       # Prevent logrus from being imported by api and e. Once everything in teleport has been converted
       # to use log/slog this should be moved into the main block above.
       logrus:


### PR DESCRIPTION
Updates the depguard rules to deny the dependency in favor of using crypto or x/crypto and their subpackages instead.