### PR TITLE
Wait for process to exit before terminating tests

### DIFF
--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -295,7 +295,10 @@ func TestMonitor(t *testing.T) {
 	process.BroadcastEvent(Event{Name: TeleportOKEvent, Payload: teleport.ComponentAuth})
 
 	require.NoError(t, process.Start())
-	t.Cleanup(func() { require.NoError(t, process.Close()) })
+	t.Cleanup(func() {
+		require.NoError(t, process.Close())
+		require.NoError(t, process.Wait())
+	})
 
 	diagAddr, err := process.DiagnosticAddr()
 	require.NoError(t, err)
@@ -1632,7 +1635,10 @@ func TestDebugServiceStartSocket(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, process.Start())
-	t.Cleanup(func() { require.NoError(t, process.Close()) })
+	t.Cleanup(func() {
+		require.NoError(t, process.Close())
+		require.NoError(t, process.Wait())
+	})
 
 	httpClient := &http.Client{
 		Timeout: 10 * time.Second,
@@ -1746,6 +1752,7 @@ func TestInstanceMetadata(t *testing.T) {
 			require.NoError(t, err)
 			t.Cleanup(func() {
 				require.NoError(t, process.Close())
+				require.NoError(t, process.Wait())
 			})
 
 			if tc.expectCloudLabels {


### PR DESCRIPTION
This attempts to reduce the flakiness of tests caused by failing to clean up the data dir:

```
 testing.go:1232: TempDir RemoveAll cleanup: unlinkat /tmp/TestMonitor3923075621/001: directory not empty
```

The root cause of the flakiness is that the tests are exiting prior to the Teleport process terminating. All places that Close was called now include a Wait call to ensure things have all exited before returning from the test.