### PR TITLE
[prometheus] Initialize metrics

### DIFF
--- a/lib/backend/report.go
+++ b/lib/backend/report.go
@@ -118,6 +118,12 @@ func NewReporter(cfg ReporterConfig) (*Reporter, error) {
 		topRequestsCache:    cache,
 		slowRangeLogLimiter: rate.NewLimiter(rate.Every(time.Minute), 12),
 	}
+
+	// metrics that need to be initialized for use later, this makes it easier on the consumer of these metrics (Grafana dashboards, for one)
+	readRequestsFailed.WithLabelValues(r.Component)
+	writeRequestsFailed.WithLabelValues(r.Component)
+	writeRequestsFailedPrecondition.WithLabelValues(r.Component)
+
 	return r, nil
 }
 

--- a/lib/backend/report.go
+++ b/lib/backend/report.go
@@ -601,7 +601,8 @@ func (s *Reporter) trackRequest(opType types.OpType, key Key, endKey Key) {
 		s.topRequestsCache.Get(cacheKey)
 	}
 
-	counter, err := requests.GetMetricWithLabelValues(s.Component, keyLabel, rangeSuffix)
+	counter, err := s.requests.GetMetricWithLabelValues(s.Component, keyLabel, rangeSuffix)
+
 	if err != nil {
 		log.Warningf("Failed to get counter: %v", err)
 		return


### PR DESCRIPTION
When Teleport starts up there's no initial counter for the `backend_read_requests_failed_total` metric.  This makes visualizations on these metrics (ex. Grafana) more complicated than they need to be.  Ideally these would initialize with labels and a `0` value.  This is possible with the write metrics as well but I haven't seen it yet since there's usually some errors on startup that initialize the metric.

Changelog: Initialize backend read and requests metrics.

## Testing
![Screenshot 2024-12-11 at 2 11 18 PM](https://github.com/user-attachments/assets/2f7643cb-ebe0-4f6f-80d6-d7c7f1846d32)
