### PR TITLE
[v17] update ArrayBuffer to ArrayBufferLike

### DIFF
--- a/web/packages/shared/utils/base64/base64-arraybuffer.ts
+++ b/web/packages/shared/utils/base64/base64-arraybuffer.ts
@@ -32,7 +32,7 @@ for (let i = 0; i < chars.length; i++) {
   lookup[chars.charCodeAt(i)] = i;
 }
 
-export const arrayBufferToBase64 = (arraybuffer: ArrayBuffer): string => {
+export const arrayBufferToBase64 = (arraybuffer: ArrayBufferLike): string => {
   return btoa(
     new Uint8Array(arraybuffer).reduce(function (data, byte) {
       return data + String.fromCharCode(byte);

--- a/web/packages/shared/utils/base64/base64url-arraybuffer.ts
+++ b/web/packages/shared/utils/base64/base64url-arraybuffer.ts
@@ -27,7 +27,7 @@ export function base64urlToBuffer(base64url: string): ArrayBuffer {
   return base64ToArrayBuffer(base64String);
 }
 
-export function bufferToBase64url(buffer: ArrayBuffer): string {
+export function bufferToBase64url(buffer: ArrayBufferLike): string {
   const base64str = arrayBufferToBase64(buffer);
 
   // Assuming the base64str is a well-formed url.


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/49974 updates typescript version `5.6.2` to `5.7.2`. This version is not compatible with the arraybuffer (or "arraybufferlike") data as generated for the MFA response transport https://github.com/gravitational/teleport.e/blob/master/web/teleport/src/SAMLIdPLogin/SAMLIdPLogin.tsx#L34C8-L39C79. 

The type error can be seen in this Github action log https://github.com/gravitational/teleport.e/actions/runs/12264912878/job/34269978472?pr=5668#step:8:18

The changes made in this PR is already in master, introduced by https://github.com/gravitational/teleport/pull/49613.

Manually tested the changes by enforcing per session MFA for SAML IdP and a successful redirect to a service provider.