### PR TITLE
Explicitly set the session cookie to SameSite=Lax

### DIFF
--- a/lib/web/session/cookie.go
+++ b/lib/web/session/cookie.go
@@ -67,6 +67,7 @@ func SetCookie(w http.ResponseWriter, user, sid string) error {
 		Path:     "/",
 		HttpOnly: true,
 		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
 	}
 	http.SetCookie(w, c)
 	return nil
@@ -80,6 +81,7 @@ func ClearCookie(w http.ResponseWriter) {
 		Path:     "/",
 		HttpOnly: true,
 		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
 	})
 }
 

--- a/lib/web/session/cookie_test.go
+++ b/lib/web/session/cookie_test.go
@@ -48,7 +48,7 @@ func TestCookies(t *testing.T) {
 	require.Len(t, setCookies, 2)
 
 	// SetCookie will store the encoded session in the cookie
-	require.Equal(t, "__Host-session=7b2275736572223a226c6c616d61222c22736964223a223938373635227d; Path=/; HttpOnly; Secure", setCookies[0])
+	require.Equal(t, "__Host-session=7b2275736572223a226c6c616d61222c22736964223a223938373635227d; Path=/; HttpOnly; Secure; SameSite=Lax", setCookies[0])
 	// ClearCookie will add an entry with the cookie value cleared out
-	require.Equal(t, "__Host-session=; Path=/; HttpOnly; Secure", setCookies[1])
+	require.Equal(t, "__Host-session=; Path=/; HttpOnly; Secure; SameSite=Lax", setCookies[1])
 }


### PR DESCRIPTION
Prior to this change, we were not explicitly setting the SameSite mode for our session cookie, which leaves the behavior up to the browser.

Chromium-based browsers have been defaulting to SameSite=Lax since Chrome 80 in February 2020, so this is not a behavior change but rather locking in today's behavior and being explicit about it.

Note that this is for Teleport's session cookie only. App session cookies remain using SameSite=None because the proxied app may itself be using SSO, and we need the app session cookie to make its way through SSO redirects.