### PR TITLE
Remove ineffective CSRF check for /webconfirm

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -921,7 +921,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	// Device Trust.
 	// Do not enforce bearer token for /webconfirm, it is called from outside the
 	// Web UI.
-	h.GET("/webapi/devices/webconfirm", h.WithAuthCookieAndCSRF(h.deviceWebConfirm))
+	h.GET("/webapi/devices/webconfirm", h.WithSession(h.deviceWebConfirm))
 
 	// trusted clusters
 	h.POST("/webapi/trustedclusters/validate", h.WithUnauthenticatedLimiter(h.validateTrustedCluster))
@@ -4678,9 +4678,22 @@ func (h *Handler) WithMetaRedirect(fn redirectHandlerFunc) httprouter.Handle {
 }
 
 // WithAuth ensures that a request is authenticated.
+// Authenticated requests require both a session cookie as well as a bearer token.
 func (h *Handler) WithAuth(fn ContextHandler) httprouter.Handle {
 	return httplib.MakeHandler(func(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {
-		sctx, err := h.AuthenticateRequest(w, r, true)
+		sctx, err := h.AuthenticateRequest(w, r, true /* check bearer token */)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return fn(w, r, p, sctx)
+	})
+}
+
+// WithSession ensures that the request provides a session cookie.
+// It does not check for a bearer token.
+func (h *Handler) WithSession(fn ContextHandler) httprouter.Handle {
+	return httplib.MakeHandler(func(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {
+		sctx, err := h.AuthenticateRequest(w, r, false /* check bearer token */)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}


### PR DESCRIPTION
The WithAuthCookieAndCSRF checks only apply CSRF checks for state-changing (ie non-GET) requests. Since /webconfirm is always a GET request, the previous code gave the impression that CSRF tokens were validated which is not the case.

No behavior change here - just being more explicit about what is being checked. There is no exploit due to not checking CSRF here due to the strict session verification performed on the confirmation token.