### PR TITLE
Add user task table

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -396,6 +396,9 @@ importers:
       events:
         specifier: 3.3.0
         version: 3.3.0
+      react-markdown:
+        specifier: ^9.0.3
+        version: 9.0.3(@types/react@18.3.12)(react@18.3.1)
     devDependencies:
       '@gravitational/build':
         specifier: workspace:*
@@ -484,7 +487,7 @@ importers:
         version: 34.1.1
       electron-builder:
         specifier: ^25.1.8
-        version: 25.1.8(electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8))
+        version: 25.1.8(electron-builder-squirrel-windows@25.1.8)
       electron-vite:
         specifier: ^2.3.0
         version: 2.3.0(@swc/core@1.10.12)(vite@6.0.11(@types/node@20.17.16)(terser@5.31.1)(yaml@2.7.0))
@@ -2762,6 +2765,9 @@ packages:
   '@types/doctrine@0.0.9':
     resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
 
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
@@ -2770,6 +2776,9 @@ packages:
 
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
+
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
   '@types/history@4.7.11':
     resolution: {integrity: sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==}
@@ -2801,6 +2810,9 @@ packages:
   '@types/keyv@4.2.0':
     resolution: {integrity: sha512-xoBtGl5R9jeKUhc8ZqeYaRDx04qqJ10yhhXYGmJ4Jr8qKpvMsDQQrNUvF/wUJ4klOtmJeJM+p2Xo3zp9uaC3tw==}
     deprecated: This is a stub types definition. keyv provides its own type definitions, so you do not need this installed.
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
   '@types/ms@0.7.34':
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
@@ -2872,6 +2884,12 @@ packages:
 
   '@types/triple-beam@1.3.5':
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@types/uuid@9.0.8':
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
@@ -2978,6 +2996,9 @@ packages:
       codemirror: '>=6.0.0'
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
   '@vitejs/plugin-react-swc@3.7.2':
     resolution: {integrity: sha512-y0byko2b2tSVVf5Gpng1eEhX1OvPC7x8yns1Fx8jDzlJp4LS6CMkCPfLw47cjyoMrshQDoQw4qcgjsU9VvlCew==}
@@ -3291,6 +3312,9 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -3432,6 +3456,9 @@ packages:
   caniuse-lite@1.0.30001696:
     resolution: {integrity: sha512-pDCPkvzfa39ehJtJ+OwGT/2yvT2SbjfHhiIW2LWOAcMQ7BzwxT/XuyUp4OTOd0XFWA6BKw0JalnBHgSi5DGJBQ==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chalk-template@1.1.0:
     resolution: {integrity: sha512-T2VJbcDuZQ0Tb2EWwSotMPJjgpy1/tGee1BTpUNsGZ/qgNjV2t7Mvu+d4600U564nbLesN1x2dPL+xii174Ekg==}
     engines: {node: '>=14.16'}
@@ -3459,6 +3486,18 @@ packages:
   char-regex@2.0.2:
     resolution: {integrity: sha512-cbGOjAptfM2LVmWhwRFHEKTPkLwNddVmuqYZQt895yXwAsWsXObCG+YN4DGQ/JBtT4GP1a1lPPdio2z413LmTg==}
     engines: {node: '>=12.20'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
@@ -3550,6 +3589,9 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
@@ -3810,6 +3852,9 @@ packages:
   decimal.js@10.4.3:
     resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
 
+  decode-named-character-reference@1.0.2:
+    resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
+
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
@@ -3873,6 +3918,9 @@ packages:
 
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
@@ -4180,6 +4228,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
@@ -4212,6 +4263,9 @@ packages:
 
   exponential-backoff@3.1.1:
     resolution: {integrity: sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   extract-zip@2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
@@ -4561,6 +4615,12 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-jsx-runtime@2.3.2:
+    resolution: {integrity: sha512-1ngXYb+V9UT5h+PxNRa1O1FYguZK/XL+gkeqvp7EdHlB9oHUG0eYRo/vY5inBdcqo3RkPMC58/H94HvkbfGdyg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
@@ -4594,6 +4654,9 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   htmlparser2@3.10.1:
     resolution: {integrity: sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==}
@@ -4687,6 +4750,9 @@ packages:
     resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  inline-style-parser@0.2.4:
+    resolution: {integrity: sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==}
+
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
@@ -4701,6 +4767,12 @@ packages:
   ip-address@9.0.5:
     resolution: {integrity: sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==}
     engines: {node: '>= 12'}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
   is-arguments@1.2.0:
     resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
@@ -4748,6 +4820,9 @@ packages:
     resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
     engines: {node: '>= 0.4'}
 
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
   is-docker@2.2.1:
     resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
     engines: {node: '>=8'}
@@ -4777,6 +4852,9 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
   is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
@@ -4798,6 +4876,10 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -5277,6 +5359,9 @@ packages:
   long@5.2.4:
     resolution: {integrity: sha512-qtzLbJE8hq7VabR3mISmVGtoXP8KGc2Z/AT8OuqlYD7JTR3oqrgwdjnk07wpj1twXxYmgDXgoKVWUG/fReSzHg==}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -5333,6 +5418,30 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-from-markdown@2.0.2:
+    resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.0:
+    resolution: {integrity: sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
   memoize-one@6.0.0:
     resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
 
@@ -5342,6 +5451,69 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  micromark-core-commonmark@2.0.2:
+    resolution: {integrity: sha512-FKjQKbxd1cibWMM1P9N+H8TwlgGgSkWZMmfuVucLCHaYqeSvJ0hFeHsIa65pA2nYbes0f8LDHPMrd9X7Ujxg9w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.0.4:
+    resolution: {integrity: sha512-N6hXjrin2GTJDe3MVjf5FuXpm12PGm80BrUAeub9XFXca8JZbP+oIwY4LJSVwFUCL1IPm/WwSVUN7goFHmSGGQ==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.1:
+    resolution: {integrity: sha512-534m2WhVTddrcKVepwmVEVnUAmtrx9bfIjNoQHRqfnvdaHQiFytEhJoTgpWJvDEXCO5gLTQh3wYC1PgOJA4NSQ==}
+
+  micromark@4.0.1:
+    resolution: {integrity: sha512-eBPdkcoCNvYcxQOAKAlceo5SNdzZWfF+FcSupREAzdAh9rRmE239CEQAiTwIgblwnoM8zzj35sZ5ZwvSEOF6Kw==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -5656,6 +5828,9 @@ packages:
     resolution: {integrity: sha512-uo0Z9JJeWzv8BG+tRcapBKNJ0dro9cLyczGzulS6EfeyAdeC9sbojtW6XwvYxJkEne9En+J2XEl4zyglVeIwFg==}
     engines: {node: '>=8'}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
@@ -5806,6 +5981,9 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  property-information@6.5.0:
+    resolution: {integrity: sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==}
+
   protobufjs@7.4.0:
     resolution: {integrity: sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==}
     engines: {node: '>=12.0.0'}
@@ -5885,6 +6063,12 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-markdown@9.0.3:
+    resolution: {integrity: sha512-Yk7Z94dbgYTOrdk41Z74GoKA7rThnsbbqBTRYuxoe08qvfQ9tJVhmAKw6BJS/ZORG7kTy/s1QvYzSuaoBA1qfw==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
 
   react-router-dom@5.3.4:
     resolution: {integrity: sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==}
@@ -5975,6 +6159,12 @@ packages:
   release-zalgo@1.0.0:
     resolution: {integrity: sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==}
     engines: {node: '>=4'}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.1:
+    resolution: {integrity: sha512-g/osARvjkBXb6Wo0XvAeXQohVta8i84ACbenPpoSsxTOQH/Ae0/RGP4WZgnMH5pMLpsj4FG7OHmcIcXxpza8eQ==}
 
   repeat-string@1.6.1:
     resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
@@ -6253,6 +6443,9 @@ packages:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
     engines: {node: '>= 8'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   spawn-wrap@2.0.0:
     resolution: {integrity: sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==}
     engines: {node: '>=8'}
@@ -6345,6 +6538,9 @@ packages:
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -6379,6 +6575,9 @@ packages:
 
   style-mod@4.1.2:
     resolution: {integrity: sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==}
+
+  style-to-object@1.0.8:
+    resolution: {integrity: sha512-xT47I/Eo0rwJmaXC4oilDGDWLohVhR6o/xAQcPQN8q6QBuZVL8qMYL85kLmST5cPjAorwvqIA4qXTRQoYHaL6g==}
 
   styled-components@6.1.14:
     resolution: {integrity: sha512-KtfwhU5jw7UoxdM0g6XU9VZQFV4do+KrM8idiVCH5h4v49W+3p3yMe0icYwJgZQZepa5DbH04Qv8P0/RdcLcgg==}
@@ -6502,8 +6701,14 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
   triple-beam@1.3.0:
     resolution: {integrity: sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
   truncate-utf8-bytes@1.0.2:
     resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
@@ -6620,6 +6825,9 @@ packages:
     resolution: {integrity: sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==}
     engines: {node: '>=4'}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
   unique-filename@2.0.1:
     resolution: {integrity: sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -6627,6 +6835,21 @@ packages:
   unique-slug@3.0.0:
     resolution: {integrity: sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
+  unist-util-is@6.0.0:
+    resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.1:
+    resolution: {integrity: sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==}
+
+  unist-util-visit@5.0.0:
+    resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -6698,6 +6921,12 @@ packages:
   verror@1.10.1:
     resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
     engines: {node: '>=0.6.0'}
+
+  vfile-message@4.0.2:
+    resolution: {integrity: sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite-plugin-wasm@3.4.1:
     resolution: {integrity: sha512-ja3nSo2UCkVeitltJGkS3pfQHAanHv/DqGatdI39ja6McgABlpsZ5hVgl6wuR8Qx5etY3T5qgDQhOWzc5RReZA==}
@@ -6986,6 +7215,9 @@ packages:
 
   zone.js@0.15.0:
     resolution: {integrity: sha512-9oxn0IIjbCZkJ67L+LkhYWRyAy7axphb3VgE2MBDlOqnmHMPWGYMxJxBYFueFq/JGY2GMwS0rU+UCLunEmy5UA==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -9578,6 +9810,10 @@ snapshots:
 
   '@types/doctrine@0.0.9': {}
 
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.6
+
   '@types/estree@1.0.6': {}
 
   '@types/fs-extra@9.0.13':
@@ -9587,6 +9823,10 @@ snapshots:
   '@types/graceful-fs@4.1.9':
     dependencies:
       '@types/node': 20.17.16
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
 
   '@types/history@4.7.11': {}
 
@@ -9624,6 +9864,10 @@ snapshots:
   '@types/keyv@4.2.0':
     dependencies:
       keyv: 5.2.3
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
 
   '@types/ms@0.7.34': {}
 
@@ -9703,6 +9947,10 @@ snapshots:
   '@types/tough-cookie@4.0.5': {}
 
   '@types/triple-beam@1.3.5': {}
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
 
   '@types/uuid@9.0.8': {}
 
@@ -9844,6 +10092,8 @@ snapshots:
       - '@codemirror/lint'
       - '@codemirror/search'
 
+  '@ungap/structured-clone@1.3.0': {}
+
   '@vitejs/plugin-react-swc@3.7.2(vite@6.0.11(@types/node@20.17.16)(terser@5.31.1)(yaml@2.7.0))':
     dependencies:
       '@swc/core': 1.10.12
@@ -9961,7 +10211,7 @@ snapshots:
 
   app-builder-bin@5.0.0-alpha.10: {}
 
-  app-builder-lib@25.1.8(dmg-builder@25.1.8(electron-builder-squirrel-windows@25.1.8))(electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8)):
+  app-builder-lib@25.1.8(dmg-builder@25.1.8)(electron-builder-squirrel-windows@25.1.8):
     dependencies:
       '@develar/schema-utils': 2.6.5
       '@electron/notarize': 2.5.0
@@ -10261,6 +10511,8 @@ snapshots:
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.1.0(@babel/core@7.26.7)
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
   bare-events@2.5.4:
@@ -10452,6 +10704,8 @@ snapshots:
 
   caniuse-lite@1.0.30001696: {}
 
+  ccount@2.0.1: {}
+
   chalk-template@1.1.0:
     dependencies:
       chalk: 5.4.1
@@ -10477,6 +10731,14 @@ snapshots:
   char-regex@1.0.2: {}
 
   char-regex@2.0.2: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   chownr@2.0.0: {}
 
@@ -10571,6 +10833,8 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@13.1.0: {}
 
@@ -10889,6 +11153,10 @@ snapshots:
 
   decimal.js@10.4.3: {}
 
+  decode-named-character-reference@1.0.2:
+    dependencies:
+      character-entities: 2.0.2
+
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
@@ -10938,6 +11206,10 @@ snapshots:
   detect-node@2.1.0:
     optional: true
 
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+
   diff-sequences@29.6.3: {}
 
   diffable-html@4.1.0:
@@ -10951,7 +11223,7 @@ snapshots:
 
   dmg-builder@25.1.8(electron-builder-squirrel-windows@25.1.8):
     dependencies:
-      app-builder-lib: 25.1.8(dmg-builder@25.1.8(electron-builder-squirrel-windows@25.1.8))(electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8))
+      app-builder-lib: 25.1.8(dmg-builder@25.1.8)(electron-builder-squirrel-windows@25.1.8)
       builder-util: 25.1.7
       builder-util-runtime: 9.2.10
       fs-extra: 10.1.0
@@ -11041,7 +11313,7 @@ snapshots:
 
   electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8):
     dependencies:
-      app-builder-lib: 25.1.8(dmg-builder@25.1.8(electron-builder-squirrel-windows@25.1.8))(electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8))
+      app-builder-lib: 25.1.8(dmg-builder@25.1.8)(electron-builder-squirrel-windows@25.1.8)
       archiver: 5.3.2
       builder-util: 25.1.7
       fs-extra: 10.1.0
@@ -11050,9 +11322,9 @@ snapshots:
       - dmg-builder
       - supports-color
 
-  electron-builder@25.1.8(electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8)):
+  electron-builder@25.1.8(electron-builder-squirrel-windows@25.1.8):
     dependencies:
-      app-builder-lib: 25.1.8(dmg-builder@25.1.8(electron-builder-squirrel-windows@25.1.8))(electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8))
+      app-builder-lib: 25.1.8(dmg-builder@25.1.8)(electron-builder-squirrel-windows@25.1.8)
       builder-util: 25.1.7
       builder-util-runtime: 9.2.10
       chalk: 4.1.2
@@ -11433,6 +11705,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-util-is-identifier-name@3.0.0: {}
+
   estree-walker@2.0.2: {}
 
   esutils@2.0.3: {}
@@ -11468,6 +11742,8 @@ snapshots:
       jest-util: 29.7.0
 
   exponential-backoff@3.1.1: {}
+
+  extend@3.0.2: {}
 
   extract-zip@2.0.1:
     dependencies:
@@ -11842,6 +12118,30 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-jsx-runtime@2.3.2:
+    dependencies:
+      '@types/estree': 1.0.6
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 6.5.0
+      space-separated-tokens: 2.0.2
+      style-to-object: 1.0.8
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   headers-polyfill@4.0.3: {}
 
   highlight-words-core@1.2.3: {}
@@ -11878,6 +12178,8 @@ snapshots:
       whatwg-encoding: 3.1.1
 
   html-escaper@2.0.2: {}
+
+  html-url-attributes@3.0.1: {}
 
   htmlparser2@3.10.1:
     dependencies:
@@ -11982,6 +12284,8 @@ snapshots:
 
   ini@4.1.1: {}
 
+  inline-style-parser@0.2.4: {}
+
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -11996,6 +12300,13 @@ snapshots:
     dependencies:
       jsbn: 1.1.0
       sprintf-js: 1.1.3
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
 
   is-arguments@1.2.0:
     dependencies:
@@ -12050,6 +12361,8 @@ snapshots:
       call-bound: 1.0.3
       has-tostringtag: 1.0.2
 
+  is-decimal@2.0.1: {}
+
   is-docker@2.2.1: {}
 
   is-extglob@2.1.1: {}
@@ -12073,6 +12386,8 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-hexadecimal@2.0.1: {}
+
   is-interactive@1.0.0: {}
 
   is-lambda@1.0.1: {}
@@ -12087,6 +12402,8 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-number@7.0.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -12832,6 +13149,8 @@ snapshots:
 
   long@5.2.4: {}
 
+  longest-streak@3.1.0: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -12901,11 +13220,233 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mdast-util-from-markdown@2.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.0.2
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.1
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.0
+
+  mdast-util-to-hast@13.2.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.0.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.0.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
   memoize-one@6.0.0: {}
 
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  micromark-core-commonmark@2.0.2:
+    dependencies:
+      decode-named-character-reference: 1.0.2
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.0.4
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.1
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.1
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.1
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.1
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.1
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.1
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.1
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.1
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.1
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.0.2
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.1
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.0.4:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.1
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.1: {}
+
+  micromark@4.0.1:
+    dependencies:
+      '@types/debug': 4.1.12
+      debug: 4.4.0
+      decode-named-character-reference: 1.0.2
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.2
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.0.4
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.8:
     dependencies:
@@ -13261,6 +13802,16 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.0.2
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   parse-json@5.2.0:
     dependencies:
       '@babel/code-frame': 7.26.2
@@ -13389,6 +13940,8 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  property-information@6.5.0: {}
+
   protobufjs@7.4.0:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -13480,6 +14033,23 @@ snapshots:
   react-is@17.0.2: {}
 
   react-is@18.3.1: {}
+
+  react-markdown@9.0.3(@types/react@18.3.12)(react@18.3.1):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/react': 18.3.12
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.2
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.0
+      react: 18.3.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.1
+      unified: 11.0.5
+      unist-util-visit: 5.0.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   react-router-dom@5.3.4(react@18.3.1):
     dependencies:
@@ -13632,6 +14202,23 @@ snapshots:
   release-zalgo@1.0.0:
     dependencies:
       es6-error: 4.1.1
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.2
+      micromark-util-types: 2.0.1
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.0
+      unified: 11.0.5
+      vfile: 6.0.3
 
   repeat-string@1.6.1: {}
 
@@ -13932,6 +14519,8 @@ snapshots:
 
   source-map@0.7.4: {}
 
+  space-separated-tokens@2.0.2: {}
+
   spawn-wrap@2.0.0:
     dependencies:
       foreground-child: 2.0.0
@@ -14063,6 +14652,11 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -14088,6 +14682,10 @@ snapshots:
   strip-json-comments@3.1.1: {}
 
   style-mod@4.1.2: {}
+
+  style-to-object@1.0.8:
+    dependencies:
+      inline-style-parser: 0.2.4
 
   styled-components@6.1.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -14253,7 +14851,11 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
+  trim-lines@3.0.1: {}
+
   triple-beam@1.3.0: {}
+
+  trough@2.2.0: {}
 
   truncate-utf8-bytes@1.0.2:
     dependencies:
@@ -14365,6 +14967,16 @@ snapshots:
 
   unicode-property-aliases-ecmascript@2.1.0: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
   unique-filename@2.0.1:
     dependencies:
       unique-slug: 3.0.0
@@ -14372,6 +14984,29 @@ snapshots:
   unique-slug@3.0.0:
     dependencies:
       imurmurhash: 0.1.4
+
+  unist-util-is@6.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.0
+
+  unist-util-visit@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.0
+      unist-util-visit-parents: 6.0.1
 
   universalify@0.1.2: {}
 
@@ -14440,6 +15075,16 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.4.1
     optional: true
+
+  vfile-message@4.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.2
 
   vite-plugin-wasm@3.4.1(vite@6.0.11(@types/node@20.17.16)(terser@5.31.1)(yaml@2.7.0)):
     dependencies:
@@ -14726,3 +15371,5 @@ snapshots:
   zod@3.24.1: {}
 
   zone.js@0.15.0: {}
+
+  zwitch@2.0.4: {}

--- a/web/__mocks__/react-markdown.js
+++ b/web/__mocks__/react-markdown.js
@@ -1,0 +1,7 @@
+// Manually mocks react-markdown for testing due to ES modules
+// https://jestjs.io/docs/manual-mocks
+function ReactMarkdown({ children }) {
+  return <>{children}</>;
+}
+
+export default ReactMarkdown;

--- a/web/packages/teleport/package.json
+++ b/web/packages/teleport/package.json
@@ -39,7 +39,8 @@
     "@xterm/addon-webgl": "^0.18.0",
     "@xterm/xterm": "^5.5.0",
     "create-react-class": "^15.6.3",
-    "events": "3.3.0"
+    "events": "3.3.0",
+    "react-markdown": "^9.0.3"
   },
   "devDependencies": {
     "@gravitational/build": "workspace:*",

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.tsx
@@ -26,14 +26,15 @@ import {
   AwsResource,
   StatCard,
 } from 'teleport/Integrations/status/AwsOidc/StatCard';
+import { TaskAlert } from 'teleport/Integrations/status/AwsOidc/Tasks/TaskAlert';
 import { useAwsOidcStatus } from 'teleport/Integrations/status/AwsOidc/useAwsOidcStatus';
 
 export function AwsOidcDashboard() {
   const { statsAttempt, integrationAttempt } = useAwsOidcStatus();
 
   if (
-    statsAttempt.status == 'processing' ||
-    integrationAttempt.status == 'processing'
+    statsAttempt.status === 'processing' ||
+    integrationAttempt.status === 'processing'
   ) {
     return (
       <Box textAlign="center" mt={4}>
@@ -42,11 +43,11 @@ export function AwsOidcDashboard() {
     );
   }
 
-  if (integrationAttempt.status == 'error') {
+  if (integrationAttempt.status === 'error') {
     return <Danger>{integrationAttempt.statusText}</Danger>;
   }
 
-  if (statsAttempt.status == 'error') {
+  if (statsAttempt.status === 'error') {
     return <Danger>{statsAttempt.statusText}</Danger>;
   }
 
@@ -59,8 +60,14 @@ export function AwsOidcDashboard() {
   return (
     <>
       <AwsOidcHeader integration={integration} />
-      <FeatureBox css={{ maxWidth: '1400px', paddingTop: '16px' }}>
-        {integration && <AwsOidcTitle integration={integration} />}
+      <FeatureBox css={{ maxWidth: '1400px', paddingTop: '16px', gap: '16px' }}>
+        {integration && (
+          <>
+            <AwsOidcTitle integration={integration} />
+            <TaskAlert name={integration.name} />
+          </>
+        )}
+
         <H2 my={3}>Auto-Enrollment</H2>
         <Flex gap={3}>
           <StatCard

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcHeader.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcHeader.tsx
@@ -29,9 +29,11 @@ import { Integration } from 'teleport/services/integrations';
 export function AwsOidcHeader({
   integration,
   resource,
+  tasks = false,
 }: {
   integration: Integration;
   resource?: AwsResource;
+  tasks?: boolean;
 }) {
   const divider = (
     <Text typography="body3" color="text.slightlyMuted">
@@ -48,6 +50,7 @@ export function AwsOidcHeader({
       pl={5}
       py={1}
       gap={1}
+      my={2}
       data-testid="aws-oidc-header"
     >
       <HoverTooltip position="bottom" tipContent="Back to Integrations">
@@ -61,7 +64,7 @@ export function AwsOidcHeader({
           <Plugs size="small" />
         </ButtonText>
       </HoverTooltip>
-      {!resource ? (
+      {!resource && !tasks ? (
         <>
           {divider}
           <Text typography="body3" color="text.slightlyMuted">
@@ -81,9 +84,21 @@ export function AwsOidcHeader({
           >
             {integration.name}
           </ButtonText>
+        </>
+      )}
+      {resource && (
+        <>
           {divider}
           <Text typography="body3" color="text.slightlyMuted" ml={2}>
             {resource.toUpperCase()}
+          </Text>
+        </>
+      )}
+      {tasks && (
+        <>
+          {divider}
+          <Text typography="body3" color="text.slightlyMuted" ml={2}>
+            Pending Tasks
           </Text>
         </>
       )}

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcRoutes.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcRoutes.tsx
@@ -19,6 +19,7 @@
 import { Route, Switch } from 'teleport/components/Router';
 import cfg from 'teleport/config';
 import { Details } from 'teleport/Integrations/status/AwsOidc/Details/Details';
+import { Tasks } from 'teleport/Integrations/status/AwsOidc/Tasks/Tasks';
 import { AwsOidcStatusProvider } from 'teleport/Integrations/status/AwsOidc/useAwsOidcStatus';
 
 import { AwsOidcDashboard } from './AwsOidcDashboard';
@@ -32,6 +33,12 @@ export function AwsOidcRoutes() {
           exact
           path={cfg.routes.integrationStatusResources}
           component={Details}
+        />
+        <Route
+          key="aws-oidc-task-table"
+          exact
+          path={cfg.routes.integrationTasks}
+          component={Tasks}
         />
         <Route
           key="aws-oidc-dashboard"

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcTitle.test.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcTitle.test.tsx
@@ -74,3 +74,20 @@ test('renders without resource', () => {
     within(screen.getByLabelText('status')).getByText('Running')
   ).toBeInTheDocument();
 });
+
+test('renders tasks', () => {
+  render(
+    <MemoryRouter>
+      <AwsOidcTitle integration={testIntegration} tasks={true} />
+    </MemoryRouter>
+  );
+
+  expect(screen.getByRole('link', { name: 'back' })).toHaveAttribute(
+    'href',
+    '/web/integrations/status/aws-oidc/some-name'
+  );
+  expect(screen.getByText('Pending Tasks')).toBeInTheDocument();
+  expect(
+    within(screen.getByLabelText('status')).getByText('Running')
+  ).toBeInTheDocument();
+});

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcTitle.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcTitle.tsx
@@ -29,12 +29,14 @@ import { IntegrationAwsOidc } from 'teleport/services/integrations';
 export function AwsOidcTitle({
   integration,
   resource,
+  tasks,
 }: {
   integration: IntegrationAwsOidc;
   resource?: AwsResource;
+  tasks?: boolean;
 }) {
   const { status, labelKind } = getStatusAndLabel(integration);
-  const content = getContent({ resource, integration });
+  const content = getContent(integration, resource, tasks);
 
   return (
     <Flex alignItems="center" data-testid="aws-oidc-title">
@@ -53,17 +55,11 @@ export function AwsOidcTitle({
   );
 }
 
-function getContent({
-  resource,
-  integration,
-}: {
-  resource: AwsResource;
-  integration: IntegrationAwsOidc;
-}): {
-  to: string;
-  helper: string;
-  content: string;
-} {
+function getContent(
+  integration: IntegrationAwsOidc,
+  resource?: AwsResource,
+  tasks?: boolean
+): { to: string; helper: string; content: string } {
   if (resource) {
     return {
       to: cfg.getIntegrationStatusRoute(integration.kind, integration.name),
@@ -71,6 +67,15 @@ function getContent({
       content: resource.toUpperCase(),
     };
   }
+
+  if (tasks) {
+    return {
+      to: cfg.getIntegrationStatusRoute(integration.kind, integration.name),
+      helper: 'Back to integration',
+      content: 'Pending Tasks',
+    };
+  }
+
   return {
     to: cfg.routes.integrations,
     helper: 'Back to integrations',

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Agents.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Agents.tsx
@@ -54,7 +54,7 @@ export function Agents() {
     fetchServices();
   }, [regionFilter]);
 
-  if (servicesAttempt.status == 'processing') {
+  if (servicesAttempt.status === 'processing') {
     return (
       <Box textAlign="center" mt={4}>
         <Indicator />
@@ -64,7 +64,7 @@ export function Agents() {
 
   return (
     <>
-      {servicesAttempt.status == 'error' && (
+      {servicesAttempt.status === 'error' && (
         <Danger>{servicesAttempt.statusText}</Danger>
       )}
       <MultiselectMenu

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Details.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Details.tsx
@@ -24,6 +24,7 @@ import { AwsOidcTitle } from 'teleport/Integrations/status/AwsOidc/AwsOidcTitle'
 import { Rds } from 'teleport/Integrations/status/AwsOidc/Details/Rds';
 import { Rules } from 'teleport/Integrations/status/AwsOidc/Details/Rules';
 import { AwsResource } from 'teleport/Integrations/status/AwsOidc/StatCard';
+import { TaskAlert } from 'teleport/Integrations/status/AwsOidc/Tasks/TaskAlert';
 import { useAwsOidcStatus } from 'teleport/Integrations/status/AwsOidc/useAwsOidcStatus';
 import { IntegrationKind } from 'teleport/services/integrations';
 
@@ -41,11 +42,16 @@ export function Details() {
       {integration && (
         <AwsOidcHeader integration={integration} resource={resourceKind} />
       )}
-      <FeatureBox css={{ maxWidth: '1400px', paddingTop: '16px', gap: '30px' }}>
-        {integration && (
-          <AwsOidcTitle integration={integration} resource={resourceKind} />
-        )}
-        {resourceKind == AwsResource.rds ? <Rds /> : <Rules />}
+      <FeatureBox css={{ maxWidth: '1400px', paddingTop: '16px', gap: '16px' }}>
+        <>
+          {integration && (
+            <>
+              <AwsOidcTitle integration={integration} resource={resourceKind} />
+              <TaskAlert name={integration.name} />
+            </>
+          )}
+        </>
+        {resourceKind === AwsResource.rds ? <Rds /> : <Rules />}
       </FeatureBox>
     </>
   );

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Rules.test.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Rules.test.tsx
@@ -16,23 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/**
- * Teleport
- * Copyright (C) 2024 Gravitational, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
 import { within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Rules.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Rules.tsx
@@ -79,7 +79,7 @@ export function Rules() {
         tooltip="Filter by region"
       />
       <Table<IntegrationDiscoveryRule>
-        data={serverSidePagination.fetchedData.agents || undefined}
+        data={serverSidePagination?.fetchedData?.agents}
         columns={[
           {
             key: 'region',
@@ -94,6 +94,7 @@ export function Rules() {
           },
         ]}
         emptyText={`No ${resourceKind.toUpperCase()} rules`}
+        pagination={{ pageSize: serverSidePagination.pageSize }}
         fetching={{
           fetchStatus: serverSidePagination.fetchStatus,
           onFetchNext: serverSidePagination.fetchNext,

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/StatCard.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/StatCard.tsx
@@ -77,7 +77,7 @@ export function StatCard({ name, resource, summary }: StatCardProps) {
             <Text>Enrollment Rules </Text>
             <Text>{summary?.rulesCount || 0}</Text>
           </Flex>
-          {resource == AwsResource.rds && (
+          {resource === AwsResource.rds && (
             <Flex justifyContent="space-between" data-testid="rds-agents">
               <Text>Agents </Text>
               <Text>{summary?.ecsDatabaseServiceCount || 0}</Text>
@@ -127,7 +127,7 @@ function getResourceTerm(resource: AwsResource): string {
 }
 
 function foundResource(resource: ResourceTypeSummary): boolean {
-  if (Object.keys(resource).length == 0) {
+  if (!resource || Object.keys(resource).length === 0) {
     return false;
   }
 

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/SidePanel.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/SidePanel.tsx
@@ -1,0 +1,62 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React, { PropsWithChildren } from 'react';
+import styled from 'styled-components';
+
+import { Box, ButtonIcon, Flex } from 'design';
+import { Cross } from 'design/Icon';
+
+export const SidePanel = ({
+  onClose,
+  header,
+  disabled = false,
+  children,
+}: PropsWithChildren & {
+  onClose: () => void;
+  header?: React.ReactNode;
+  disabled?: boolean;
+}) => {
+  return (
+    <Flex width="500px" flexDirection="column">
+      <Flex
+        alignItems="center"
+        mb={3}
+        justifyContent="space-between"
+        maxWidth="500px"
+        borderBottom={1}
+        borderColor="levels.surface"
+        py={1}
+      >
+        {header}
+        <ButtonIcon onClick={onClose} disabled={disabled}>
+          <Cross size="medium" />
+        </ButtonIcon>
+      </Flex>
+      <ScrollContent>{children}</ScrollContent>
+    </Flex>
+  );
+};
+
+const ScrollContent = styled(Box)`
+  max-height: calc(
+    100vh - ${props => props.theme.space[9]}px -
+      ${props => props.theme.topBarHeight[1]}px
+  );
+  overflow: auto;
+`;

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Task.test.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Task.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { within } from '@testing-library/react';
+
+import { render, screen } from 'design/utils/testing';
+
+import { ContextProvider } from 'teleport/index';
+import { Task } from 'teleport/Integrations/status/AwsOidc/Tasks/Task';
+import { integrationService } from 'teleport/services/integrations';
+import TeleportContext from 'teleport/teleportContext';
+
+test('renders ec2 impacts', async () => {
+  const ctx = new TeleportContext();
+  jest.spyOn(integrationService, 'fetchUserTask').mockResolvedValue({
+    name: 'df4d8288-7106-5a50-bb50-4b5858e48ad5',
+    taskType: 'discover-ec2',
+    state: 'OPEN',
+    integration: '',
+    lastStateChange: '2025-02-11T20:32:19.482607921Z',
+    issueType: 'ec2-ssm-invocation-failure',
+    description:
+      'Teleport failed to access the SSM Agent to auto enroll the instance.\nSome instances failed to communicate with the AWS Systems Manager service to execute the install script.\n\nUsually this happens when:\n\n**Missing policies**\n\nThe IAM Role used by the integration might be missing some required permissions.\nEnsure the following actions are allowed in the IAM Role used by the integration:\n- `ec2:DescribeInstances`\n- `ssm:DescribeInstanceInformation`\n- `ssm:GetCommandInvocation`\n- `ssm:ListCommandInvocations`\n- `ssm:SendCommand`\n\n**SSM Document is invalid**\n\nTeleport uses an SSM Document to run an installation script.\nIf the document is changed or removed, it might no longer work.',
+    discoverEks: undefined,
+    discoverRds: undefined,
+    discoverEc2: {
+      region: 'us-east-2',
+      accountId: undefined,
+      ssmDocument: undefined,
+      installerScript: undefined,
+      instances: {
+        'i-016e32a5882f5ee81': {
+          instance_id: 'i-016e32a5882f5ee81',
+          name: undefined,
+          invocationUrl: undefined,
+          discoveryConfig: undefined,
+          discoveryGroup: undefined,
+          syncTime: undefined,
+        },
+        'i-065818031835365cc': {
+          instance_id: 'i-065818031835365cc',
+          name: 'aws-test',
+          invocationUrl: undefined,
+          discoveryConfig: undefined,
+          discoveryGroup: undefined,
+          syncTime: undefined,
+        },
+      },
+    },
+  });
+
+  render(
+    <ContextProvider ctx={ctx}>
+      <Task name="task-001" close={() => {}} />
+    </ContextProvider>
+  );
+
+  await screen.findByText('Details');
+
+  expect(getTableCellContents()).toEqual({
+    header: ['Instance ID', 'Instance Name'],
+    rows: [
+      ['i-016e32a5882f5ee81', ''],
+      ['i-065818031835365cc', 'aws-test'],
+    ],
+  });
+
+  jest.resetAllMocks();
+});
+
+test('renders eks impacts', async () => {
+  const ctx = new TeleportContext();
+  jest.spyOn(integrationService, 'fetchUserTask').mockResolvedValue({
+    name: 'df4d8288-7106-5a50-bb50-4b5858e48ad5',
+    taskType: 'discover-eks',
+    state: 'OPEN',
+    integration: 'integration-001',
+    lastStateChange: '2025-02-11T20:32:19.482607921Z',
+    issueType: 'eks-failure',
+    description:
+      'Only EKS Clusters whose status is active can be automatically enrolled into teleport.\n',
+    discoverEc2: undefined,
+    discoverRds: undefined,
+    discoverEks: {
+      accountId: undefined,
+      region: undefined,
+      appAutoDiscover: false,
+      clusters: {
+        'i-016e32a5882f5ee81': {
+          name: 'i-016e32a5882f5ee81',
+          discoveryConfig: undefined,
+          discoveryGroup: undefined,
+          syncTime: undefined,
+        },
+        'i-065818031835365cc': {
+          name: 'i-065818031835365cc',
+          discoveryConfig: undefined,
+          discoveryGroup: undefined,
+          syncTime: undefined,
+        },
+      },
+    },
+  });
+
+  render(
+    <ContextProvider ctx={ctx}>
+      <Task name="task-001" close={() => {}} />
+    </ContextProvider>
+  );
+
+  await screen.findByText('Details');
+
+  expect(getTableCellContents()).toEqual({
+    header: ['Name'],
+    rows: [['i-016e32a5882f5ee81'], ['i-065818031835365cc']],
+  });
+  jest.resetAllMocks();
+});
+
+test('renders rds impacts', async () => {
+  const ctx = new TeleportContext();
+  jest.spyOn(integrationService, 'fetchUserTask').mockResolvedValue({
+    name: 'df4d8288-7106-5a50-bb50-4b5858e48ad5',
+    taskType: 'discover-rds',
+    state: 'OPEN',
+    integration: 'integration-001',
+    lastStateChange: '2025-02-11T20:32:19.482607921Z',
+    issueType: 'rds-failure',
+    description:
+      'The Teleport Database Service uses [IAM authentication](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html) to communicate with RDS.\n',
+    discoverEks: undefined,
+    discoverEc2: undefined,
+    discoverRds: {
+      accountId: undefined,
+      region: undefined,
+      databases: {
+        'i-016e32a5882f5ee81': {
+          name: 'i-016e32a5882f5ee81',
+          isCluster: undefined,
+          engine: undefined,
+          discoveryConfig: undefined,
+          discoveryGroup: undefined,
+          syncTime: undefined,
+        },
+        'i-065818031835365cc': {
+          name: 'i-065818031835365cc',
+          isCluster: undefined,
+          engine: undefined,
+          discoveryConfig: undefined,
+          discoveryGroup: undefined,
+          syncTime: undefined,
+        },
+      },
+    },
+  });
+
+  render(
+    <ContextProvider ctx={ctx}>
+      <Task name="task-001" close={() => {}} />
+    </ContextProvider>
+  );
+
+  await screen.findByText('Details');
+
+  expect(getTableCellContents()).toEqual({
+    header: ['Name'],
+    rows: [['i-016e32a5882f5ee81'], ['i-065818031835365cc']],
+  });
+  jest.resetAllMocks();
+});
+
+function getTableCellContents() {
+  const [header, ...rows] = screen.getAllByRole('row');
+  return {
+    header: within(header)
+      .getAllByRole('columnheader')
+      .map(cell => cell.textContent),
+    rows: rows.map(row =>
+      within(row)
+        .getAllByRole('cell')
+        .map(cell => cell.textContent)
+    ),
+  };
+}

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Task.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Task.tsx
@@ -1,0 +1,237 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { PropsWithChildren, useEffect } from 'react';
+import ReactMarkdown from 'react-markdown';
+
+import { Alert, ButtonBorder, Flex, H2 } from 'design';
+import { Danger } from 'design/Alert';
+import Table from 'design/DataTable';
+import { TableColumn } from 'design/DataTable/types';
+import { H3, P2, Subtitle2 } from 'design/Text';
+import { useAsync } from 'shared/hooks/useAsync';
+import useAttempt from 'shared/hooks/useAttemptNext';
+
+import { getResourceType } from 'teleport/Integrations/status/AwsOidc/helpers';
+import {
+  DiscoverEc2,
+  DiscoverEc2Instance,
+  DiscoverEks,
+  DiscoverEksCluster,
+  DiscoverRds,
+  DiscoverRdsDatabase,
+  integrationService,
+  UserTaskDetail,
+} from 'teleport/services/integrations';
+
+import { AwsResource } from '../StatCard';
+import { SidePanel } from './SidePanel';
+
+export function Task({
+  name,
+  close,
+}: {
+  name: string;
+  close: (resolved: boolean) => void;
+}) {
+  const { attempt, setAttempt } = useAttempt('');
+
+  const [taskAttempt, fetchTask] = useAsync(() =>
+    integrationService.fetchUserTask(name)
+  );
+
+  useEffect(() => {
+    fetchTask();
+  }, []);
+
+  if (taskAttempt.status === 'error') {
+    return (
+      <SidePanel onClose={() => close(false)}>
+        <Danger>{taskAttempt.statusText}</Danger>
+      </SidePanel>
+    );
+  }
+
+  if (!taskAttempt.data) {
+    return null;
+  }
+
+  // todo (michellescripts) implement either success view or confirmation based on design sync
+  function resolve() {
+    setAttempt({ status: 'processing' });
+    integrationService
+      .resolveUserTask(name)
+      .then(() => {
+        setAttempt({ status: '', statusText: '' });
+        close(true);
+      })
+      .catch((err: Error) =>
+        setAttempt({ status: 'failed', statusText: err.message })
+      );
+  }
+
+  const impactedInstances = getImpactedInstances(taskAttempt.data);
+  const { resourceType, resource, impacts } = impactedInstances;
+  const table = makeImpactsTable(impactedInstances);
+
+  return (
+    <SidePanel
+      onClose={() => close(false)}
+      header={
+        <ButtonBorder
+          intent="success"
+          onClick={resolve}
+          disabled={attempt.status === 'processing'}
+        >
+          Mark as Resolved
+        </ButtonBorder>
+      }
+      disabled={attempt.status === 'processing'}
+    >
+      <H2 mb={2}>{taskAttempt.data.issueType}</H2>
+      {attempt.status === 'failed' && (
+        <Alert kind="danger" details={attempt.statusText}>
+          Unable to resolve task
+        </Alert>
+      )}
+      <Attribute title="Integration Name">
+        {taskAttempt.data.integration}
+      </Attribute>
+      <Attribute title="Resource Type">{resourceType.toUpperCase()}</Attribute>
+      <Attribute title="Region">{resource.region}</Attribute>
+      <H3 my={2}>Details</H3>
+      <ReactMarkdown>{taskAttempt.data.description}</ReactMarkdown>
+      <H3 my={2}>Impacted instances ({Object.keys(impacts).length})</H3>
+      <Table
+        data={table.data}
+        columns={table.columns}
+        emptyText={`No impacted instances`}
+      />
+    </SidePanel>
+  );
+}
+
+type TableInstance = {
+  instanceId?: string;
+  name: string;
+};
+
+function makeImpactsTable(instances: ImpactedInstances): {
+  columns: TableColumn<TableInstance>[];
+  data: TableInstance[];
+} {
+  const { resourceType, impacts } = instances;
+  switch (resourceType) {
+    case AwsResource.ec2:
+      return {
+        columns: [
+          {
+            key: 'instanceId',
+            headerText: 'Instance ID',
+          },
+          {
+            key: 'name',
+            headerText: 'Instance Name',
+          },
+        ],
+        data: Object.keys(impacts).map(i => ({
+          instanceId: impacts[i].instance_id,
+          name: impacts[i].name,
+        })),
+      };
+    case AwsResource.eks:
+    case AwsResource.rds:
+      return {
+        columns: [
+          {
+            key: 'name',
+            headerText: 'Name',
+          },
+        ],
+        data: Object.keys(impacts).map(i => ({
+          name: impacts[i].name,
+        })),
+      };
+    default:
+      resourceType satisfies never;
+  }
+}
+
+type ImpactedInstances =
+  | {
+      resourceType: AwsResource.ec2;
+      resource: DiscoverEc2;
+      impacts: Record<string, DiscoverEc2Instance>;
+    }
+  | {
+      resourceType: AwsResource.eks;
+      resource: DiscoverEks;
+      impacts: Record<string, DiscoverEksCluster>;
+    }
+  | {
+      resourceType: AwsResource.rds;
+      resource: DiscoverRds;
+      impacts: Record<string, DiscoverRdsDatabase>;
+    };
+
+function getImpactedInstances(task: UserTaskDetail): ImpactedInstances {
+  const resourceType = getResourceType(task.taskType);
+
+  switch (resourceType) {
+    case AwsResource.ec2:
+      return {
+        resourceType: resourceType,
+        resource: task.discoverEc2,
+        impacts: task.discoverEc2?.instances,
+      };
+    case AwsResource.eks:
+      return {
+        resourceType: resourceType,
+        resource: task.discoverEks,
+        impacts: task.discoverEks?.clusters,
+      };
+    case AwsResource.rds:
+    default:
+      return {
+        resourceType: resourceType,
+        resource: task.discoverRds,
+        impacts: task.discoverRds?.databases,
+      };
+  }
+}
+
+const Attribute = ({
+  title = '',
+  children,
+}: PropsWithChildren<{ title: string }>) => (
+  <Flex mb={1} alignItems="center">
+    <Subtitle2 style={{ minWidth: '150px' }}>{title}:</Subtitle2>
+    <P2
+      style={{
+        whiteSpace: 'pre',
+        textWrap: 'wrap',
+        width: '100%',
+        wordBreak: 'break-all',
+        margin: 0,
+      }}
+      data-testid={title}
+    >
+      {children || `N/A`}
+    </P2>
+  </Flex>
+);

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/TaskAlert.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/TaskAlert.tsx
@@ -1,0 +1,76 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { useEffect } from 'react';
+import { useHistory } from 'react-router';
+
+import { Alert } from 'design';
+import { ArrowForward, BellRinging } from 'design/Icon';
+import { useAsync } from 'shared/hooks/useAsync';
+
+import cfg from 'teleport/config';
+import { TaskState } from 'teleport/Integrations/status/AwsOidc/Tasks/constants';
+import {
+  IntegrationKind,
+  integrationService,
+} from 'teleport/services/integrations';
+
+export function TaskAlert({
+  name,
+  kind = IntegrationKind.AwsOidc,
+}: {
+  name: string;
+  kind?: IntegrationKind;
+}) {
+  const history = useHistory();
+  // todo (michellescripts) should we show the banner if there is an error
+  const [tasksAttempt, fetchTasks] = useAsync(() =>
+    integrationService.fetchIntegrationUserTasksList(name, TaskState.Open)
+  );
+
+  useEffect(() => {
+    fetchTasks();
+  }, []);
+
+  const pendingTasksCount =
+    (tasksAttempt.status === 'success' &&
+      tasksAttempt.data.items?.filter(t => t.state === TaskState.Open)
+        .length) ||
+    0;
+
+  if (!pendingTasksCount) {
+    return null;
+  }
+
+  return (
+    <Alert
+      kind="warning"
+      icon={BellRinging}
+      primaryAction={{
+        content: (
+          <>
+            Resolve Now
+            <ArrowForward size={18} ml={2} />
+          </>
+        ),
+        onClick: () => history.push(cfg.getIntegrationTasksRoute(kind, name)),
+      }}
+    >
+      {pendingTasksCount} Pending Tasks
+    </Alert>
+  );
+}

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.story.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.story.tsx
@@ -1,0 +1,193 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { http, HttpResponse } from 'msw';
+
+import cfg from 'teleport/config';
+import { TaskState } from 'teleport/Integrations/status/AwsOidc/Tasks/constants';
+import { MockAwsOidcStatusProvider } from 'teleport/Integrations/status/AwsOidc/testHelpers/mockAwsOidcStatusProvider';
+import { IntegrationKind } from 'teleport/services/integrations';
+
+import { makeAwsOidcStatusContextState } from '../testHelpers/makeAwsOidcStatusContextState';
+import { Tasks } from './Tasks';
+
+export default {
+  title: 'Teleport/Integrations/AwsOidc/Tasks',
+};
+
+const integrationName = 'integration-story';
+
+// Empty tasks table
+export function TasksEmpty() {
+  return (
+    <MockAwsOidcStatusProvider
+      value={makeAwsOidcStatusContextState()}
+      initialEntries={[
+        cfg.getIntegrationTasksRoute(IntegrationKind.AwsOidc, integrationName),
+      ]}
+      path={cfg.routes.integrationTasks}
+    >
+      <Tasks />
+    </MockAwsOidcStatusProvider>
+  );
+}
+
+// Populated tasks table
+export function TaskView() {
+  return (
+    <MockAwsOidcStatusProvider
+      value={makeAwsOidcStatusContextState()}
+      initialEntries={[
+        cfg.getIntegrationTasksRoute(IntegrationKind.AwsOidc, integrationName),
+      ]}
+      path={cfg.routes.integrationTasks}
+    >
+      <Tasks />
+    </MockAwsOidcStatusProvider>
+  );
+}
+
+TaskView.parameters = {
+  msw: {
+    handlers: [
+      http.get(
+        cfg.getIntegrationUserTasksListUrl(integrationName, TaskState.Open),
+        () => {
+          return HttpResponse.json({
+            items: [
+              {
+                name: 'rds-detail',
+                taskType: 'discover-rds',
+                state: TaskState.Open,
+                issueType: 'rds-generic',
+                integration: integrationName,
+                lastStateChange: '2022-02-12T20:32:19.482607921Z',
+              },
+              {
+                name: 'ec2-detail',
+                taskType: 'discover-ec2',
+                state: TaskState.Open,
+                issueType: 'ec2-ssm-invocation-failure',
+                integration: integrationName,
+                lastStateChange: '2025-02-11T20:32:19.482607921Z',
+              },
+              {
+                name: 'ec2-detail',
+                taskType: 'discover-ec2',
+                state: TaskState.Open,
+                issueType: 'ec2-ssm-agent-not-registered',
+                integration: integrationName,
+                lastStateChange: '2025-02-11T20:32:13.61608091Z',
+              },
+              {
+                name: 'no match',
+                state: TaskState.Open,
+                issueType: 'side panel error',
+                integration: integrationName,
+                lastStateChange: '0',
+              },
+              {
+                name: 'eks-detail',
+                taskType: 'discover-eks',
+                state: TaskState.Open,
+                issueType: 'eks-failure',
+                integration: integrationName,
+                lastStateChange: '2025-02-11T20:32:13.61608091Z',
+              },
+            ],
+            nextKey: '1',
+          });
+        }
+      ),
+      http.get(cfg.getUserTaskUrl('ec2-detail'), () => {
+        return HttpResponse.json(ec2Detail);
+      }),
+      http.get(cfg.getUserTaskUrl('rds-detail'), () => {
+        return HttpResponse.json(rdsDetail);
+      }),
+      http.get(cfg.getUserTaskUrl('eks-detail'), () => {
+        return HttpResponse.json(eksDetail);
+      }),
+    ],
+  },
+};
+
+const ec2Detail = {
+  name: 'df4d8288-7106-5a50-bb50-4b5858e48ad5',
+  taskType: 'discover-ec2',
+  state: 'OPEN',
+  integration: integrationName,
+  lastStateChange: '2025-02-11T20:32:19.482607921Z',
+  issueType: 'ec2-ssm-invocation-failure',
+  description:
+    'Teleport failed to access the SSM Agent to auto enroll the instance.\nSome instances failed to communicate with the AWS Systems Manager service to execute the install script.\n\nUsually this happens when:\n\n**Missing policies**\n\nThe IAM Role used by the integration might be missing some required permissions.\nEnsure the following actions are allowed in the IAM Role used by the integration:\n- `ec2:DescribeInstances`\n- `ssm:DescribeInstanceInformation`\n- `ssm:GetCommandInvocation`\n- `ssm:ListCommandInvocations`\n- `ssm:SendCommand`\n\n**SSM Document is invalid**\n\nTeleport uses an SSM Document to run an installation script.\nIf the document is changed or removed, it might no longer work.',
+  discoverEc2: {
+    region: 'us-east-2',
+    instances: {
+      'i-016e32a5882f5ee81': {
+        instance_id: 'i-016e32a5882f5ee81',
+      },
+      'i-065818031835365cc': {
+        instance_id: 'i-065818031835365cc',
+        name: 'aws-test',
+      },
+    },
+  },
+};
+
+const rdsDetail = {
+  name: 'df4d8288-7106-5a50-bb50-4b5858e48ad5',
+  taskType: 'discover-rds',
+  state: 'OPEN',
+  integration: integrationName,
+  lastStateChange: '2025-02-11T20:32:19.482607921Z',
+  issueType: 'rds-failure',
+  description:
+    'The Teleport Database Service uses [IAM authentication](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html) to communicate with RDS.\n',
+  discoverRds: {
+    databases: {
+      'i-016e32a5882f5ee81': {
+        name: 'i-016e32a5882f5ee81',
+      },
+      'i-065818031835365cc': {
+        name: 'i-065818031835365cc',
+      },
+    },
+  },
+};
+
+const eksDetail = {
+  name: 'df4d8288-7106-5a50-bb50-4b5858e48ad5',
+  taskType: 'discover-eks',
+  state: 'OPEN',
+  integration: integrationName,
+  lastStateChange: '2025-02-11T20:32:19.482607921Z',
+  issueType: 'eks-failure',
+  description:
+    'Only EKS Clusters whose status is active can be automatically enrolled into teleport.\n',
+  discoverEks: {
+    clusters: {
+      'i-016e32a5882f5ee81': {
+        name: 'i-016e32a5882f5ee81',
+      },
+      'i-065818031835365cc': {
+        name: 'i-065818031835365cc',
+      },
+    },
+  },
+};

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.tsx
@@ -1,0 +1,163 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useEffect, useState } from 'react';
+
+import { ButtonBorder, Flex, Indicator } from 'design';
+import { Danger } from 'design/Alert';
+import Table, { Cell } from 'design/DataTable';
+
+import { useServerSidePagination } from 'teleport/components/hooks';
+import { FeatureBox } from 'teleport/components/Layout';
+import { AwsOidcHeader } from 'teleport/Integrations/status/AwsOidc/AwsOidcHeader';
+import { AwsOidcTitle } from 'teleport/Integrations/status/AwsOidc/AwsOidcTitle';
+import { getResourceType } from 'teleport/Integrations/status/AwsOidc/helpers';
+import { TaskState } from 'teleport/Integrations/status/AwsOidc/Tasks/constants';
+import { Task } from 'teleport/Integrations/status/AwsOidc/Tasks/Task';
+import { useAwsOidcStatus } from 'teleport/Integrations/status/AwsOidc/useAwsOidcStatus';
+import { integrationService, UserTask } from 'teleport/services/integrations';
+
+export function Tasks() {
+  const { integrationAttempt } = useAwsOidcStatus();
+  const { data: integration } = integrationAttempt;
+  const [showTask, setShowTask] = useState<UserTask>(undefined);
+
+  const serverSidePagination = useServerSidePagination<UserTask>({
+    pageSize: 20,
+    fetchFunc: async () => {
+      const { items, nextKey } =
+        await integrationService.fetchIntegrationUserTasksList(
+          integration.name,
+          TaskState.Open
+        );
+      return { agents: items, nextKey };
+    },
+    clusterId: '',
+    params: {},
+  });
+
+  useEffect(() => {
+    serverSidePagination.fetch();
+  }, [integration]);
+
+  if (integrationAttempt.status === 'processing') {
+    return <Indicator />;
+  }
+
+  if (serverSidePagination.attempt.status === 'processing') {
+    return <Indicator />;
+  }
+
+  if (integrationAttempt.status === 'error') {
+    return <Danger>{integrationAttempt.statusText}</Danger>;
+  }
+
+  if (serverSidePagination.attempt.status === 'failed') {
+    return <Danger>{serverSidePagination.attempt.statusText}</Danger>;
+  }
+
+  function close(resolved: boolean) {
+    if (resolved) {
+      serverSidePagination.modifyFetchedData(p => ({
+        ...p,
+        agents: p.agents.filter(t => t.name !== showTask.name),
+      }));
+    }
+    setShowTask(undefined);
+  }
+
+  return (
+    <Flex>
+      <Flex
+        flexDirection="column"
+        css={`
+          flex-grow: 1;
+        `}
+      >
+        {integration && (
+          <AwsOidcHeader integration={integration} tasks={true} />
+        )}
+        <FeatureBox
+          css={{ maxWidth: '1400px', paddingTop: '16px', gap: '30px' }}
+        >
+          {integration && (
+            <AwsOidcTitle integration={integration} tasks={true} />
+          )}
+          <Table<UserTask>
+            data={serverSidePagination.fetchedData?.agents || []}
+            row={{
+              onClick: row => {
+                if (showTask === undefined) {
+                  setShowTask(row);
+                }
+              },
+              getStyle: () => {
+                if (showTask === undefined) {
+                  return { cursor: 'pointer' };
+                }
+              },
+            }}
+            columns={[
+              {
+                key: 'taskType',
+                headerText: 'Type',
+                render: item => (
+                  <Cell>{getResourceType(item.taskType).toUpperCase()}</Cell>
+                ),
+              },
+              {
+                key: 'issueType',
+                headerText: 'Issue Details',
+              },
+              {
+                key: 'lastStateChange',
+                headerText: 'Timestamp (UTC)',
+                render: item => (
+                  <Cell>{new Date(item.lastStateChange).toISOString()}</Cell>
+                ),
+              },
+              {
+                altKey: 'action',
+                headerText: 'Actions',
+                render: item => (
+                  <Cell>
+                    <ButtonBorder
+                      onClick={() => setShowTask(item)}
+                      disabled={showTask != undefined}
+                      size="small"
+                    >
+                      View
+                    </ButtonBorder>
+                  </Cell>
+                ),
+              },
+            ]}
+            emptyText={`No pending tasks`}
+            pagination={{ pageSize: serverSidePagination.pageSize }}
+            fetching={{
+              fetchStatus: serverSidePagination.fetchStatus,
+              onFetchNext: serverSidePagination.fetchNext,
+              onFetchPrev: serverSidePagination.fetchPrev,
+            }}
+          />
+        </FeatureBox>
+      </Flex>
+      {showTask && <Task name={showTask.name} close={close} />}
+    </Flex>
+  );
+}

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/constants.ts
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/constants.ts
@@ -1,0 +1,22 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export enum TaskState {
+  Open = 'OPEN',
+  Resolved = 'RESOLVED',
+}

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/helpers.ts
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/helpers.ts
@@ -1,0 +1,34 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { AwsResource } from 'teleport/Integrations/status/AwsOidc/StatCard';
+
+export function getResourceType(type: string): AwsResource {
+  switch (type) {
+    case 'ec2':
+    case 'discover-ec2':
+      return AwsResource.ec2;
+    case 'eks':
+    case 'discover-eks':
+      return AwsResource.eks;
+    case 'rds':
+    case 'discover-rds':
+    default:
+      return AwsResource.rds;
+  }
+}

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -29,6 +29,7 @@ import type {
 import { mergeDeep } from 'shared/utils/highbar';
 
 import { AwsResource } from 'teleport/Integrations/status/AwsOidc/StatCard';
+import { TaskState } from 'teleport/Integrations/status/AwsOidc/Tasks/constants';
 import type { SortType } from 'teleport/services/agents';
 import {
   AwsOidcPolicyPreset,
@@ -205,6 +206,7 @@ const cfg = {
     headlessSso: `/web/headless/:requestId`,
     integrations: '/web/integrations',
     integrationStatus: '/web/integrations/status/:type/:name/:subPage?',
+    integrationTasks: '/web/integrations/status/:type/:name/tasks',
     integrationStatusResources:
       '/web/integrations/status/:type/:name/resources/:resourceKind',
     integrationEnroll: '/web/integrations/new/:type?/:subPage?',
@@ -365,6 +367,10 @@ const cfg = {
       '/v1/webapi/sites/:clusterId/integrations/:name/discoveryrules?resourceType=:resourceType?&startKey=:startKey?&query=:query?&search=:search?&sort=:sort?&limit=:limit?&regions=:regions?',
     awsOidcDatabaseServicesPath:
       '/v1/webapi/sites/:clusterId/integrations/aws-oidc/:name/listdeployeddatabaseservices?resourceType=:resourceType?&regions=:regions?',
+    userTaskListByIntegrationPath:
+      '/v1/webapi/sites/:clusterId/usertask?integration=:name?&state=:state?',
+    userTaskPath: '/v1/webapi/sites/:clusterId/usertask/:name',
+    resolveUserTaskPath: '/v1/webapi/sites/:clusterId/usertask/:name/state',
 
     thumbprintPath: '/v1/webapi/thumbprint',
     pingAwsOidcIntegrationPath:
@@ -616,6 +622,10 @@ const cfg = {
       name,
       resourceKind,
     });
+  },
+
+  getIntegrationTasksRoute(type: PluginKind | IntegrationKind, name: string) {
+    return generatePath(cfg.routes.integrationTasks, { type, name });
   },
 
   getMsTeamsAppZipRoute(clusterId: string, plugin: string) {
@@ -1128,6 +1138,31 @@ const cfg = {
       name,
       resourceType,
       regions,
+    });
+  },
+
+  getIntegrationUserTasksListUrl(name: string, state: TaskState) {
+    const clusterId = cfg.proxyCluster;
+    return generatePath(cfg.api.userTaskListByIntegrationPath, {
+      clusterId,
+      name,
+      state,
+    });
+  },
+
+  getUserTaskUrl(name: string) {
+    const clusterId = cfg.proxyCluster;
+    return generatePath(cfg.api.userTaskPath, {
+      clusterId,
+      name,
+    });
+  },
+
+  getResolveUserTaskUrl(name: string) {
+    const clusterId = cfg.proxyCluster;
+    return generatePath(cfg.api.resolveUserTaskPath, {
+      clusterId,
+      name,
     });
   },
 

--- a/web/packages/teleport/src/services/integrations/integrations.test.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.test.ts
@@ -18,6 +18,7 @@
 
 import cfg from 'teleport/config';
 import { AwsResource } from 'teleport/Integrations/status/AwsOidc/StatCard';
+import { TaskState } from 'teleport/Integrations/status/AwsOidc/Tasks/constants';
 import api from 'teleport/services/api';
 
 import { integrationService } from './integrations';
@@ -255,7 +256,7 @@ test('fetch integration rules: fetchIntegrationRules()', async () => {
     AwsResource.eks
   );
   expect(api.get).toHaveBeenCalledWith(
-    cfg.getIntegrationRulesUrl('name', AwsResource.eks)
+    cfg.getIntegrationRulesUrl('name', AwsResource.eks, [])
   );
   expect(response).toEqual({
     nextKey: 'some-key',
@@ -280,6 +281,54 @@ test('fetch integration rules: fetchIntegrationRules()', async () => {
   expect(response).toEqual({
     nextKey: undefined,
     rules: [],
+  });
+});
+
+test('fetch integration user task list: fetchIntegrationUserTasksList()', async () => {
+  // test a valid response
+  jest.spyOn(api, 'get').mockResolvedValue({
+    items: [
+      {
+        name: 'task-name',
+        taskType: 'task-type',
+        state: 'task-state',
+        issueType: 'issue-type',
+        integration: 'name',
+      },
+    ],
+    nextKey: 'some-key',
+  });
+
+  let response = await integrationService.fetchIntegrationUserTasksList(
+    'name',
+    TaskState.Open
+  );
+  expect(api.get).toHaveBeenCalledWith(
+    cfg.getIntegrationUserTasksListUrl('name', TaskState.Open)
+  );
+  expect(response).toEqual({
+    nextKey: 'some-key',
+    items: [
+      {
+        name: 'task-name',
+        taskType: 'task-type',
+        state: 'task-state',
+        issueType: 'issue-type',
+        integration: 'name',
+      },
+    ],
+  });
+
+  // test null response
+  jest.spyOn(api, 'get').mockResolvedValue(null);
+
+  response = await integrationService.fetchIntegrationUserTasksList(
+    'name',
+    TaskState.Open
+  );
+  expect(response).toEqual({
+    nextKey: undefined,
+    items: [],
   });
 });
 

--- a/web/packages/teleport/src/services/integrations/integrations.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.ts
@@ -18,6 +18,7 @@
 
 import cfg from 'teleport/config';
 import { AwsResource } from 'teleport/Integrations/status/AwsOidc/StatCard';
+import { TaskState } from 'teleport/Integrations/status/AwsOidc/Tasks/constants';
 import api from 'teleport/services/api';
 
 import { App } from '../apps';
@@ -61,6 +62,9 @@ import {
   SecurityGroup,
   SecurityGroupRule,
   Subnet,
+  UserTask,
+  UserTaskDetail,
+  UserTasksListResponse,
 } from './types';
 
 export const integrationService = {
@@ -470,13 +474,76 @@ export const integrationService = {
         return { services: makeDatabaseServices(resp) };
       });
   },
+
+  fetchIntegrationUserTasksList(
+    name: string,
+    state: TaskState
+  ): Promise<UserTasksListResponse> {
+    return api
+      .get(cfg.getIntegrationUserTasksListUrl(name, state))
+      .then(resp => {
+        return {
+          items: resp?.items || [],
+          nextKey: resp?.nextKey,
+        };
+      });
+  },
+
+  fetchUserTask(name: string): Promise<UserTaskDetail> {
+    return api.get(cfg.getUserTaskUrl(name)).then(resp => {
+      return {
+        name: resp.name,
+        taskType: resp.taskType,
+        state: resp.state,
+        issueType: resp.issueType,
+        integration: resp.integration,
+        lastStateChange: resp.lastStateChange,
+        description: resp.description,
+        discoverEc2: {
+          instances: resp.discoverEc2?.instances,
+          accountId: resp.discoverEc2?.accountId,
+          region: resp.discoverEc2?.region,
+          ssmDocument: resp.discoverEc2?.ssmDocument,
+          installerScript: resp.discoverEc2?.installerScript,
+        },
+        discoverEks: {
+          clusters: resp.discoverEks?.instances,
+          accountId: resp.discoverEks?.accountId,
+          region: resp.discoverEks?.region,
+          appAutoDiscover: resp.discoverEks?.appAutoDiscover,
+        },
+        discoverRds: {
+          databases: resp.discoverRds?.instances,
+          accountId: resp.discoverRds?.accountId,
+          region: resp.discoverRds?.region,
+        },
+      };
+    });
+  },
+
+  resolveUserTask(name: string): Promise<UserTask> {
+    return api
+      .put(cfg.getResolveUserTaskUrl(name), {
+        state: TaskState.Resolved,
+      })
+      .then(resp => {
+        return {
+          name: resp.name,
+          taskType: resp.taskType,
+          state: resp.state,
+          issueType: resp.issueType,
+          integration: resp.integration,
+          lastStateChange: resp.lastStateChange,
+        };
+      });
+  },
 };
 
 function makeDatabaseServices(json: any): AWSOIDCDeployedDatabaseService[] {
   json = json ?? {};
   const { services } = json;
 
-  return services.map((service: AWSOIDCDeployedDatabaseService) => ({
+  return services?.map((service: AWSOIDCDeployedDatabaseService) => ({
     name: service.name ?? '',
     dashboardUrl: service.dashboardUrl ?? '',
     validTeleportConfig: service.validTeleportConfig ?? false,

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -392,6 +392,134 @@ export type IntegrationDiscoveryRules = {
   nextKey: string;
 };
 
+// UserTasksListResponse contains a list of UserTasks.
+// In case of exceeding the pagination limit (either via query param `limit` or the default 1000)
+// a `nextToken` is provided and should be used to obtain the next page (as a query param `startKey`)
+export type UserTasksListResponse = {
+  // items is a list of resources retrieved.
+  items: UserTask[];
+  // nextKey is the position to resume listing events.
+  nextKey: string;
+};
+
+// UserTask describes UserTask fields.
+// Used for listing User Tasks without receiving all the details.
+export type UserTask = {
+  // name is the UserTask name.
+  name: string;
+  // taskType identifies this task's type.
+  taskType: string;
+  // state is the state for the User Task.
+  state: string;
+  // issueType identifies this task's issue type.
+  issueType: string;
+  // integration is the Integration Name this User Task refers to.
+  integration: string;
+  // lastStateChange indicates when the current's user task state was last changed.
+  lastStateChange: string;
+};
+
+// UserTaskDetail contains all the details for a User Task.
+export type UserTaskDetail = UserTask & {
+  // description is a markdown document that explains the issue and how to fix it.
+  description: string;
+  // discoverEc2 contains the task details for the DiscoverEc2 tasks.
+  discoverEc2: DiscoverEc2;
+  // discoverEKS contains the task details for the DiscoverEKS tasks.
+  discoverEks: DiscoverEks;
+  // discoverRDS contains the task details for the DiscoverRDS tasks.
+  discoverRds: DiscoverRds;
+};
+
+// DiscoverEc2 contains the instances that failed to auto-enroll into the cluster.
+export type DiscoverEc2 = {
+  // instances maps an instance id to the result of enrolling that instance into teleport.
+  instances: Record<string, DiscoverEc2Instance>;
+  // accountID is the AWS Account ID for the instances.
+  accountId: string;
+  // region is the AWS Region where Teleport failed to enroll EC2 instances.
+  region: string;
+  // ssmDocument is the Amazon Systems Manager SSM Document name that was used to install teleport on the instance.
+  // In Amazon console, the document is at:
+  // https://REGION.console.aws.amazon.com/systems-manager/documents/SSM_DOCUMENT/description
+  ssmDocument: string;
+  // installerScript is the Teleport installer script that was used to install teleport on the instance.
+  installerScript: string;
+};
+
+// DiscoverEc2Instance contains the result of enrolling an AWS EC2 Instance.
+export type DiscoverEc2Instance = {
+  // instanceID is the EC2 Instance ID that uniquely identifies the instance.
+  instance_id: string;
+  // name is the instance Name.
+  // Might be empty, if the instance doesn't have the Name tag.
+  name: string;
+  // invocationUrl is the url that points to the invocation.
+  // Empty if there was an error before installing the
+  invocationUrl: string;
+  // discoveryConfig is the discovery config name that originated this instance enrollment.
+  discoveryConfig: string;
+  // discoveryGroup is the DiscoveryGroup name that originated this task.
+  discoveryGroup: string;
+  // syncTime is the timestamp when the error was produced.
+  syncTime: number;
+};
+
+// DiscoverEks contains the clusters that failed to auto-enroll into the cluster.
+export type DiscoverEks = {
+  // clusters maps a cluster name to the result of enrolling that cluster into teleport.
+  clusters: Record<string, DiscoverEksCluster>;
+  // accountId is the AWS Account ID for the cluster.
+  accountId: string;
+  // region is the AWS Region where Teleport failed to enroll EKS Clusters.
+  region: string;
+  // appAutoDiscover indicates whether the Kubernetes agent should auto enroll HTTP services as Teleport Apps.
+  appAutoDiscover: boolean;
+};
+
+// DiscoverEksCluster contains the result of enrolling an AWS EKS Cluster.
+export type DiscoverEksCluster = {
+  // name is the cluster Name.
+  name: string;
+  // discoveryConfig is the discovery config name that originated this cluster enrollment.
+  discoveryConfig: string;
+  // discoveryGroup is the DiscoveryGroup name that originated this task.
+  discoveryGroup: string;
+  // syncTime is the timestamp when the error was produced.
+  syncTime: number;
+};
+
+// DiscoverRds contains the databases that failed to auto-enroll into teleport.
+export type DiscoverRds = {
+  // databases maps a database resource id to the result of enrolling that database into teleport.
+  // For RDS Aurora Clusters, this is the DBClusterIdentifier.
+  // For other RDS databases, this is the DBInstanceIdentifier.
+  databases: Record<string, DiscoverRdsDatabase>;
+  // accountId is the AWS Account ID for the database.
+  accountId: string;
+  // region is the AWS Region where Teleport failed to enroll RDS databases.
+  region: string;
+};
+
+// DiscoverRdsDatabase contains the result of enrolling an AWS RDS database.
+export type DiscoverRdsDatabase = {
+  // name is the database identifier.
+  // For RDS Aurora Clusters, this is the DBClusterIdentifier.
+  // For other RDS databases, this is the DBInstanceIdentifier.
+  name: string;
+  // isCluster indicates whether this database is a cluster or a single instance.
+  isCluster: boolean;
+  // engine indicates the engine name for this RDS.
+  // Eg, aurora-postgresql, postgresql
+  engine: string;
+  // discoveryConfig is the discovery config name that originated this database enrollment.
+  discoveryConfig: string;
+  // discoveryGroup is the DiscoveryGroup name that originated this task.
+  discoveryGroup: string;
+  // syncTime is the timestamp when the error was produced.
+  syncTime: number;
+};
+
 // IntegrationDiscoveryRule describes a discovery rule associated with an integration.
 export type IntegrationDiscoveryRule = {
   // resourceType indicates the type of resource that this rule targets.


### PR DESCRIPTION
This PR adds the user tasks table. If present, an alert banner is shown on the aws oidc dashboard, and all children tables (ec2 rules, eks rules, rds agents, rds rules). The alert banner takes you to the table. You can see individual task information, and mark a task as resolved. Note: if the task is not resolved the next time the discovery instance runs, the task will reappear.

https://github.com/user-attachments/assets/7b50988d-19d7-4685-adf8-8772efd75862

Supports https://github.com/gravitational/teleport/issues/49089
Requires https://github.com/gravitational/teleport/pull/52191
