### PR TITLE
Disable peer/quic.TestBasicFunctionality for now

### DIFF
--- a/lib/proxy/peer/quic/quic_test.go
+++ b/lib/proxy/peer/quic/quic_test.go
@@ -221,6 +221,8 @@ func TestCertificateVerification(t *testing.T) {
 }
 
 func TestBasicFunctionality(t *testing.T) {
+	t.Skip("disabled until quic-go/quic-go#4303 is fixed (data race)")
+
 	t.Parallel()
 
 	hostCA := newCA(t)


### PR DESCRIPTION
This PR skips `lib/proxy/peer/quic.TestBasicFunctionality` as it [occasionally makes tests fail](https://github.com/gravitational/teleport/actions/runs/12285332132/job/34283074875) due to a data race bug in quic-go (see quic-go/quic-go#4303). Seeing as QUIC proxy peering is unstable functionality anyway, there's no reason to risk CI failures for now.