### PR TITLE
[v17] Disable peer/quic.TestBasicFunctionality for now

### DIFF
--- a/lib/proxy/peer/quic/quic_test.go
+++ b/lib/proxy/peer/quic/quic_test.go
@@ -221,6 +221,8 @@ func TestCertificateVerification(t *testing.T) {
 }
 
 func TestBasicFunctionality(t *testing.T) {
+	t.Skip("disabled until quic-go/quic-go#4303 is fixed (data race)")
+
 	t.Parallel()
 
 	hostCA := newCA(t)


### PR DESCRIPTION
Backport #50106 to branch/v17