### PR TITLE
Convert lib/multiplexer to use slog

### DIFF
--- a/lib/loglimit/loglimit.go
+++ b/lib/loglimit/loglimit.go
@@ -20,46 +20,47 @@ package loglimit
 
 import (
 	"context"
-	"fmt"
+	"log/slog"
+	"maps"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	log "github.com/sirupsen/logrus"
 )
 
 const (
 	// timeWindow is the time window over which logs are deduplicated.
 	timeWindow = time.Minute
-	// timeWindowCleanupInterval is the interval between cleanups of time
-	// windows that have already ended.
-	// Since the time window is set to 1 minute and the cleanup interval
-	// is set to 10 seconds, time windows can be in fact slightly larger
-	// than 1 minute (i.e., 1 minute and 10 seconds, in the worst case).
-	timeWindowCleanupInterval = 10 * time.Second
+	// sweepInterval is how often the window mapping should be checked
+	// for stale entries.
+	sweepInterval = timeWindow * 3
+	// staleDuration is the amount of time an entry can exist in the
+	// window mapping before being evicted.
+	staleDuration = timeWindow * 2
 )
 
 // Config contains the log limiter config.
 type Config struct {
-	// Context is a context to signal stops, cancellations.
-	Context context.Context
 	// MessageSubstrings contains a list of substrings belonging to the
 	// logs that should be deduplicated.
 	MessageSubstrings []string
 	// Clock is a clock to override in tests, set to real time clock
 	// by default.
 	Clock clockwork.Clock
+	// Handler is the wrapped Handler that processes any messages that
+	// should be sampled.
+	Handler slog.Handler
 }
 
 // checkAndSetDefaults verifies configuration and sets defaults
 func (c *Config) checkAndSetDefaults() error {
-	if c.Context == nil {
-		c.Context = context.Background()
-	}
 	if c.MessageSubstrings == nil {
 		return trace.BadParameter("missing parameter MessageSubstrings")
+	}
+	if c.Handler == nil {
+		return trace.BadParameter("missing parameter Handler")
 	}
 	if c.Clock == nil {
 		c.Clock = clockwork.NewRealClock()
@@ -67,7 +68,8 @@ func (c *Config) checkAndSetDefaults() error {
 	return nil
 }
 
-// LogLimiter deduplicates logs over a certain time window.
+// LogLimiter is a [slog.Handler] that prevents duplicate
+// messages from being emitted over a certain time window.
 type LogLimiter struct {
 	// config is the log limiter config.
 	config Config
@@ -75,26 +77,93 @@ type LogLimiter struct {
 	mu sync.Mutex
 	// windows is a mapping from log substring to an active
 	// time window.
-	windows map[string]*entryInfo
-	// cleanupCh is used in tests to trigger `cleanup`.
-	cleanupCh chan chan struct{}
+	windows map[string]time.Time
+
+	// lastSweep indicates the last time the full windows mapping
+	// was sweeped and purged of expired entries.
+	lastSweep time.Time
 }
 
-// entryInfo contains information about a certain log entry.
-// This is information is used to deduplicate a log entry
-// reported within a certain time window.
-type entryInfo struct {
-	// entry is the logger entry.
-	entry *log.Entry
-	// level is the log level at which this log entry should be logged.
-	level log.Level
-	// message is the message message.
-	message string
-	// time is the at which the log reported.
-	time time.Time
-	// occurrences are the occurrences of logs entries (that share
-	// the same log substring) within a time window.
-	occurrences int
+// Enabled implements slog.Handler.
+func (l *LogLimiter) Enabled(ctx context.Context, level slog.Level) bool {
+	return l.config.Handler.Enabled(ctx, level)
+}
+
+// Handle implements slog.Handler.
+func (l *LogLimiter) Handle(ctx context.Context, record slog.Record) error {
+	deduplicate, messageSubstring := l.shouldDeduplicate(record.Message)
+	if !deduplicate {
+		return trace.Wrap(l.config.Handler.Handle(ctx, record))
+	}
+
+	shouldLog := func(now time.Time) bool {
+		l.mu.Lock()
+		defer func() {
+			// Periodically attempt to clean up the last seen mapping.
+			if now.After(l.lastSweep.Add(sweepInterval)) {
+				for key, lastSeen := range l.windows {
+					if now.After(lastSeen.Add(staleDuration)) {
+						delete(l.windows, key)
+					}
+				}
+			}
+
+			l.lastSweep = l.config.Clock.Now()
+			l.mu.Unlock()
+		}()
+		lastSeen, ok := l.windows[messageSubstring]
+
+		switch {
+		case !ok:
+			// If this is the first occurrence, log the entry and save it.
+			l.windows[messageSubstring] = now
+			return true
+		case now.After(lastSeen.Add(timeWindow)):
+			// If this is NOT the first occurrence BUT the last occurrence,
+			// has expired, then permit the log entry and update the window.
+			l.windows[messageSubstring] = l.config.Clock.Now()
+			return true
+		default:
+			return false
+		}
+	}(l.config.Clock.Now())
+
+	if shouldLog {
+		return trace.Wrap(l.config.Handler.Handle(ctx, record))
+	}
+
+	return nil
+
+}
+
+// WithAttrs implements slog.Handler.
+func (l *LogLimiter) WithAttrs(attrs []slog.Attr) slog.Handler {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	return &LogLimiter{
+		config: Config{
+			MessageSubstrings: l.config.MessageSubstrings,
+			Clock:             l.config.Clock,
+			Handler:           l.config.Handler.WithAttrs(attrs),
+		},
+		windows: maps.Clone(l.windows),
+	}
+}
+
+// WithGroup implements slog.Handler.
+func (l *LogLimiter) WithGroup(name string) slog.Handler {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	return &LogLimiter{
+		config: Config{
+			MessageSubstrings: l.config.MessageSubstrings,
+			Clock:             l.config.Clock,
+			Handler:           l.config.Handler.WithGroup(name),
+		},
+		windows: maps.Clone(l.windows),
+	}
 }
 
 // New creates a new log limiter.
@@ -104,96 +173,11 @@ func New(config Config) (*LogLimiter, error) {
 	}
 
 	l := &LogLimiter{
-		config:    config,
-		windows:   make(map[string]*entryInfo, len(config.MessageSubstrings)),
-		cleanupCh: make(chan chan struct{}),
+		config:  config,
+		windows: make(map[string]time.Time, len(config.MessageSubstrings)),
 	}
-	// Start the goroutine responsible for removing expired time windows.
-	go l.run()
+
 	return l, nil
-}
-
-// Log deduplicates log entries that should be deduplicated.
-func (l *LogLimiter) Log(entry *log.Entry, level log.Level, args ...any) {
-	// Log right away if the log entry should not be deduplicated.
-	message := fmt.Sprint(args...)
-	deduplicate, messageSubstring := l.shouldDeduplicate(message)
-	if !deduplicate {
-		entry.Log(level, message)
-		return
-	}
-
-	l.insert(entry, level, message, messageSubstring)
-}
-
-// Run runs the cleanup of expired time windows periodically.
-func (l *LogLimiter) run() {
-	t := l.config.Clock.NewTicker(timeWindowCleanupInterval)
-	defer t.Stop()
-
-	for {
-		select {
-		case <-t.Chan():
-			l.cleanup()
-		case notifyCh := <-l.cleanupCh:
-			l.cleanup()
-			notifyCh <- struct{}{}
-		case <-l.config.Context.Done():
-			return
-		}
-	}
-}
-
-// insert records the occurrence of a log entry within a certain time window.
-// If it's the first occurrence, it also logs the entry.
-func (l *LogLimiter) insert(entry *log.Entry, level log.Level, message, messageSubstring string) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-
-	// Check if there's an active window for the log entry
-	// (i.e if it has been reported during the past minute).
-	window, ok := l.windows[messageSubstring]
-	if ok {
-		// If the log has already been logged, simply increase the
-		// number of occurrences.
-		window.occurrences++
-	} else {
-		// If this is the first occurrence, log the entry and save it.
-		entry.Log(level, message)
-		l.windows[messageSubstring] = &entryInfo{
-			entry:       entry,
-			level:       level,
-			message:     message,
-			time:        l.config.Clock.Now(),
-			occurrences: 1,
-		}
-	}
-}
-
-// cleanup removes time windows that have ended, logging the first log message
-// again together with the number of occurrences (of logs that share the same
-// log substring) during the window.
-func (l *LogLimiter) cleanup() {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-
-	now := l.config.Clock.Now()
-	for logSubstring, e := range l.windows {
-		if now.After(e.time.Add(timeWindow)) {
-			if e.occurrences > 1 {
-				e.entry.Log(
-					e.level,
-					fmt.Sprintf(
-						"%s (logs containing %q were seen %d times in the past minute)",
-						e.message,
-						logSubstring,
-						e.occurrences,
-					),
-				)
-			}
-			delete(l.windows, logSubstring)
-		}
-	}
 }
 
 // shouldDeduplicate returns true if the log should be deduplicated.

--- a/lib/multiplexer/testproxy.go
+++ b/lib/multiplexer/testproxy.go
@@ -19,14 +19,16 @@
 package multiplexer
 
 import (
+	"context"
 	"io"
+	"log/slog"
 	"net"
 
 	"github.com/gravitational/trace"
-	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/utils"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 // TestProxy is tcp passthrough proxy that sends a proxy-line when connecting
@@ -35,7 +37,7 @@ type TestProxy struct {
 	listener net.Listener
 	target   string
 	closeCh  chan (struct{})
-	log      logrus.FieldLogger
+	log      *slog.Logger
 	v2       bool
 }
 
@@ -50,7 +52,7 @@ func NewTestProxy(target string, v2 bool) (*TestProxy, error) {
 		listener: listener,
 		target:   target,
 		closeCh:  make(chan struct{}),
-		log:      logrus.WithField(teleport.ComponentKey, "test:proxy"),
+		log:      utils.NewSlogLoggerForTests().With(teleport.ComponentKey, "test:proxy"),
 		v2:       v2,
 	}, nil
 }
@@ -67,10 +69,10 @@ func (p *TestProxy) Serve() error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		p.log.Debugf("Accepted connection from %v.", clientConn.RemoteAddr().String())
+		p.log.DebugContext(context.Background(), "Accepted connection", "remote_addr", logutils.StringerAttr(clientConn.RemoteAddr()))
 		go func() {
 			if err := p.handleConnection(clientConn); err != nil {
-				p.log.WithError(err).Error("Failed to handle connection.")
+				p.log.ErrorContext(context.Background(), "Failed to handle connection", "error", err)
 			}
 		}()
 	}
@@ -110,7 +112,7 @@ func (p *TestProxy) handleConnection(clientConn net.Conn) error {
 				errs = append(errs, err)
 			}
 		case <-p.closeCh:
-			p.log.Debug("Closing.")
+			p.log.DebugContext(context.Background(), "Closing")
 			return trace.NewAggregate(errs...)
 		}
 	}
@@ -132,7 +134,10 @@ func (p *TestProxy) sendProxyLine(clientConn, serverConn net.Conn) error {
 		Source:      net.TCPAddr{IP: net.ParseIP(clientAddr.Host()), Port: clientAddr.Port(0)},
 		Destination: net.TCPAddr{IP: net.ParseIP(serverAddr.Host()), Port: serverAddr.Port(0)},
 	}
-	p.log.Debugf("Sending %v to %v.", proxyLine.String(), serverConn.RemoteAddr().String())
+	p.log.DebugContext(context.Background(), "Sending proxy line",
+		"proxy_line", proxyLine.String(),
+		"remote_addr", serverConn.RemoteAddr().String(),
+	)
 	if p.v2 {
 		b, bErr := proxyLine.Bytes()
 		if bErr != nil {

--- a/lib/multiplexer/tls.go
+++ b/lib/multiplexer/tls.go
@@ -23,17 +23,18 @@ import (
 	"crypto/tls"
 	"errors"
 	"io"
+	"log/slog"
 	"net"
 	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/http2"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/utils"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 // TLSListenerConfig specifies listener configuration
@@ -73,9 +74,7 @@ func NewTLSListener(cfg TLSListenerConfig) (*TLSListener, error) {
 	}
 	context, cancel := context.WithCancel(context.TODO())
 	return &TLSListener{
-		log: log.WithFields(log.Fields{
-			teleport.ComponentKey: teleport.Component("mxtls", cfg.ID),
-		}),
+		log:           slog.With(teleport.ComponentKey, teleport.Component("mxtls", cfg.ID)),
 		cfg:           cfg,
 		http2Listener: newListener(context, cfg.Listener.Addr()),
 		httpListener:  newListener(context, cfg.Listener.Addr()),
@@ -89,7 +88,7 @@ func NewTLSListener(cfg TLSListenerConfig) (*TLSListener, error) {
 // and forwards the appropriate responses to either HTTP/1.1 or HTTP/2
 // listeners
 type TLSListener struct {
-	log           *log.Entry
+	log           *slog.Logger
 	cfg           TLSListenerConfig
 	http2Listener *Listener
 	httpListener  *Listener
@@ -115,10 +114,11 @@ func (l *TLSListener) Serve() error {
 			tlsConn, ok := conn.(*tls.Conn)
 			if !ok {
 				conn.Close()
-				l.log.WithFields(log.Fields{
-					"src_addr": conn.RemoteAddr(),
-					"dst_addr": conn.LocalAddr(),
-				}).Errorf("Expected tls.Conn, got %T, internal usage error.", conn)
+				l.log.LogAttrs(l.context, slog.LevelError, "Recevied a non-TLS connection",
+					slog.Any("src_addr", logutils.StringerAttr(conn.RemoteAddr())),
+					slog.Any("dst_addr", logutils.StringerAttr(conn.LocalAddr())),
+					slog.Any("conn_type", logutils.TypeAttr(conn)),
+				)
 				continue
 			}
 			go l.detectAndForward(tlsConn)
@@ -139,7 +139,9 @@ func (l *TLSListener) Serve() error {
 func (l *TLSListener) detectAndForward(conn *tls.Conn) {
 	err := conn.SetReadDeadline(l.cfg.Clock.Now().Add(l.cfg.ReadDeadline))
 	if err != nil {
-		l.log.WithError(err).Debugf("Failed to set connection deadline.")
+		l.log.LogAttrs(l.context, slog.LevelDebug, "Failed to set connection deadline",
+			slog.Any("error", err),
+		)
 		conn.Close()
 		return
 	}
@@ -147,10 +149,11 @@ func (l *TLSListener) detectAndForward(conn *tls.Conn) {
 	start := l.cfg.Clock.Now()
 	if err := conn.HandshakeContext(l.context); err != nil {
 		if !errors.Is(trace.Unwrap(err), io.EOF) {
-			l.log.WithFields(log.Fields{
-				"src_addr": conn.RemoteAddr(),
-				"dst_addr": conn.LocalAddr(),
-			}).WithError(err).Warning("Handshake failed.")
+			l.log.LogAttrs(l.context, slog.LevelWarn, "Handshake failed",
+				slog.Any("src_addr", logutils.StringerAttr(conn.RemoteAddr())),
+				slog.Any("dst_addr", logutils.StringerAttr(conn.LocalAddr())),
+				slog.Any("error", err),
+			)
 		}
 		conn.Close()
 		return
@@ -159,12 +162,16 @@ func (l *TLSListener) detectAndForward(conn *tls.Conn) {
 	// Log warning if TLS handshake takes more than one second to help debug
 	// latency issues.
 	if elapsed := time.Since(start); elapsed > 1*time.Second {
-		l.log.Warnf("Slow TLS handshake from %v, took %v.", conn.RemoteAddr(), time.Since(start))
+		l.log.LogAttrs(l.context, slog.LevelWarn, "Slow TLS handshake",
+			slog.Any("src_addr", logutils.StringerAttr(conn.RemoteAddr())),
+			slog.Any("dst_addr", logutils.StringerAttr(conn.LocalAddr())),
+			slog.Duration("handshake_duration", time.Since(start)),
+		)
 	}
 
 	err = conn.SetReadDeadline(time.Time{})
 	if err != nil {
-		l.log.WithError(err).Warning("Failed to reset read deadline")
+		l.log.WarnContext(l.context, "Failed to reset read deadline", "error", err)
 		conn.Close()
 		return
 	}
@@ -176,10 +183,12 @@ func (l *TLSListener) detectAndForward(conn *tls.Conn) {
 		l.httpListener.HandleConnection(l.context, conn)
 	default:
 		conn.Close()
-		l.log.WithFields(log.Fields{
-			"src_addr": conn.RemoteAddr(),
-			"dst_addr": conn.LocalAddr(),
-		}).WithError(err).Errorf("unsupported protocol: %v", conn.ConnectionState().NegotiatedProtocol)
+		l.log.LogAttrs(l.context, slog.LevelError, "rejecting connection with unsupported protocol",
+			slog.Any("error", err),
+			slog.String("protocol", conn.ConnectionState().NegotiatedProtocol),
+			slog.Any("src_addr", logutils.StringerAttr(conn.RemoteAddr())),
+			slog.Any("dst_addr", logutils.StringerAttr(conn.LocalAddr())),
+		)
 	}
 }
 

--- a/lib/multiplexer/web.go
+++ b/lib/multiplexer/web.go
@@ -23,17 +23,18 @@ import (
 	"crypto/tls"
 	"errors"
 	"io"
+	"log/slog"
 	"net"
 	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
 	dbcommon "github.com/gravitational/teleport/lib/srv/db/dbutils"
 	"github.com/gravitational/teleport/lib/utils"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 // WebListenerConfig is the web listener configuration.
@@ -67,7 +68,7 @@ func NewWebListener(cfg WebListenerConfig) (*WebListener, error) {
 	}
 	context, cancel := context.WithCancel(context.Background())
 	return &WebListener{
-		log:         logrus.WithField(teleport.ComponentKey, "mxweb"),
+		log:         slog.With(teleport.ComponentKey, "mxweb"),
 		cfg:         cfg,
 		webListener: newListener(context, cfg.Listener.Addr()),
 		dbListener:  newListener(context, cfg.Listener.Addr()),
@@ -79,7 +80,7 @@ func NewWebListener(cfg WebListenerConfig) (*WebListener, error) {
 // WebListener multiplexes tls connections between web and database listeners
 // based on the client certificate.
 type WebListener struct {
-	log         logrus.FieldLogger
+	log         *slog.Logger
 	cfg         WebListenerConfig
 	webListener *Listener
 	dbListener  *Listener
@@ -110,17 +111,20 @@ func (l *WebListener) Serve() error {
 			case <-l.context.Done():
 				return trace.Wrap(net.ErrClosed, "listener is closed")
 			case <-time.After(5 * time.Second):
-				l.log.WithError(err).Warn("Backoff on accept error.")
+				l.log.LogAttrs(l.context, slog.LevelWarn, "Backoff on accept error",
+					slog.Any("error", err),
+				)
 			}
 			continue
 		}
 
 		tlsConn, ok := conn.(*tls.Conn)
 		if !ok {
-			l.log.WithFields(logrus.Fields{
-				"src_addr": conn.RemoteAddr(),
-				"dst_addr": conn.LocalAddr(),
-			}).Errorf("Expected *tls.Conn, got %T.", conn)
+			l.log.LogAttrs(l.context, slog.LevelError, "Recevied a non-TLS connection",
+				slog.Any("src_addr", logutils.StringerAttr(conn.RemoteAddr())),
+				slog.Any("dst_addr", logutils.StringerAttr(conn.LocalAddr())),
+				slog.Any("conn_type", logutils.TypeAttr(conn)),
+			)
 			conn.Close()
 			continue
 		}
@@ -132,17 +136,20 @@ func (l *WebListener) Serve() error {
 func (l *WebListener) detectAndForward(conn *tls.Conn) {
 	err := conn.SetReadDeadline(l.cfg.Clock.Now().Add(l.cfg.ReadDeadline))
 	if err != nil {
-		l.log.WithError(err).Warn("Failed to set connection read deadline.")
+		l.log.LogAttrs(l.context, slog.LevelWarn, "Failed to set connection read deadline",
+			slog.Any("error", err),
+		)
 		conn.Close()
 		return
 	}
 
 	if err := conn.HandshakeContext(l.context); err != nil {
 		if !errors.Is(trace.Unwrap(err), io.EOF) {
-			l.log.WithFields(logrus.Fields{
-				"src_addr": conn.RemoteAddr(),
-				"dst_addr": conn.LocalAddr(),
-			}).WithError(err).Warn("Handshake failed.")
+			l.log.LogAttrs(l.context, slog.LevelWarn, "Handshake failed",
+				slog.Any("error", err),
+				slog.Any("src_addr", logutils.StringerAttr(conn.RemoteAddr())),
+				slog.Any("dst_addr", logutils.StringerAttr(conn.LocalAddr())),
+			)
 		}
 		conn.Close()
 		return
@@ -150,7 +157,7 @@ func (l *WebListener) detectAndForward(conn *tls.Conn) {
 
 	err = conn.SetReadDeadline(time.Time{})
 	if err != nil {
-		l.log.WithError(err).Warn("Failed to reset connection read deadline")
+		l.log.WarnContext(l.context, "Failed to reset connection read deadline", "error", err)
 		conn.Close()
 		return
 	}
@@ -161,10 +168,11 @@ func (l *WebListener) detectAndForward(conn *tls.Conn) {
 	// tls listener.
 	isDatabaseConnection, err := dbcommon.IsDatabaseConnection(conn.ConnectionState())
 	if err != nil {
-		l.log.WithFields(logrus.Fields{
-			"src_addr": conn.RemoteAddr(),
-			"dst_addr": conn.LocalAddr(),
-		}).WithError(err).Debug("Failed to check if connection is database connection.")
+		l.log.LogAttrs(l.context, slog.LevelDebug, "Failed to check if connection is database connection",
+			slog.Any("error", err),
+			slog.Any("src_addr", logutils.StringerAttr(conn.RemoteAddr())),
+			slog.Any("dst_addr", logutils.StringerAttr(conn.LocalAddr())),
+		)
 	}
 	if isDatabaseConnection {
 		l.dbListener.HandleConnection(l.context, conn)

--- a/lib/multiplexer/wrappers.go
+++ b/lib/multiplexer/wrappers.go
@@ -195,7 +195,7 @@ func NewPROXYEnabledListener(cfg Config) (*PROXYEnabledListener, error) {
 	muxListener := mux.SSH()
 	go func() {
 		if err := mux.Serve(); err != nil && !utils.IsOKNetworkError(err) {
-			mux.Entry.WithError(err).Error("Mux encountered err serving")
+			mux.logger.ErrorContext(cfg.Context, "Mux encountered err serving", "error", err)
 		}
 	}()
 	pl := &PROXYEnabledListener{

--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -268,7 +268,7 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(logger *slog
 
 		go func() {
 			if err := mux.Serve(); err != nil && !utils.IsOKNetworkError(err) {
-				mux.Entry.WithError(err).Error("mux encountered err serving")
+				process.logger.ErrorContext(process.ExitContext(), "mux encountered error serving", "mux_id", mux.ID, "error", err)
 			}
 		}()
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3116,7 +3116,7 @@ func (process *TeleportProcess) initSSH() error {
 
 			go func() {
 				if err := mux.Serve(); err != nil && !utils.IsOKNetworkError(err) {
-					mux.Entry.WithError(err).Error("node ssh multiplexer terminated unexpectedly")
+					process.logger.ErrorContext(process.ExitContext(), "node ssh multiplexer terminated unexpectedly", "error", err, "mux_id", mux.ID)
 				}
 			}()
 			defer mux.Close()
@@ -3604,7 +3604,7 @@ func (process *TeleportProcess) initDiagnosticService() error {
 		listenerHTTP := muxListener.HTTP()
 		go func() {
 			if err := muxListener.Serve(); err != nil && !utils.IsOKNetworkError(err) {
-				muxListener.Entry.WithError(err).Error("Mux encountered err serving")
+				process.logger.ErrorContext(process.ExitContext(), "Mux encountered error serving", "error", err, "mux_id", muxListener.ID)
 			}
 		}()
 
@@ -4021,7 +4021,7 @@ func (process *TeleportProcess) setupProxyListeners(networkingConfig types.Clust
 		listeners.sshGRPC = mux.TLS()
 		go func() {
 			if err := mux.Serve(); err != nil && !utils.IsOKNetworkError(err) {
-				mux.Entry.WithError(err).Error("Mux encountered err serving")
+				process.logger.ErrorContext(process.ExitContext(), "Mux encountered error serving", "error", err, "mux_id", mux.ID)
 			}
 		}()
 	}
@@ -4117,7 +4117,7 @@ func (process *TeleportProcess) setupProxyListeners(networkingConfig types.Clust
 		}
 		go func() {
 			if err := listeners.mux.Serve(); err != nil && !utils.IsOKNetworkError(err) {
-				listeners.mux.Entry.WithError(err).Error("Mux encountered err serving")
+				process.logger.ErrorContext(process.ExitContext(), "Mux encountered error serving", "error", err, "mux_id", listeners.mux.ID)
 			}
 		}()
 		return &listeners, nil
@@ -4149,7 +4149,7 @@ func (process *TeleportProcess) setupProxyListeners(networkingConfig types.Clust
 		}
 		go func() {
 			if err := listeners.mux.Serve(); err != nil && !utils.IsOKNetworkError(err) {
-				listeners.mux.Entry.WithError(err).Error("Mux encountered err serving")
+				process.logger.ErrorContext(process.ExitContext(), "Mux encountered error serving", "error", err, "mux_id", listeners.mux.ID)
 			}
 		}()
 		return &listeners, nil
@@ -4196,7 +4196,7 @@ func (process *TeleportProcess) setupProxyListeners(networkingConfig types.Clust
 				process.muxPostgresOnWebPort(cfg, &listeners)
 				go func() {
 					if err := listeners.mux.Serve(); err != nil && !utils.IsOKNetworkError(err) {
-						listeners.mux.Entry.WithError(err).Error("Mux encountered err serving")
+						process.logger.ErrorContext(process.ExitContext(), "Mux encountered error serving", "error", err, "mux_id", listeners.mux.ID)
 					}
 				}()
 			} else {

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -8253,7 +8253,7 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 
 	go func() {
 		if err := mux.Serve(); err != nil && !utils.IsOKNetworkError(err) {
-			mux.Entry.WithError(err).Error("Mux encountered err serving")
+			log.WithError(err).Error("Mux encountered err serving")
 		}
 	}()
 


### PR DESCRIPTION
The first commit updates the loglimiter to implement slog.Handler and perform sampling while handling requests instead of relying on an additional goroutine. The second commit updates the multiplexer to use slog and the updated loglimiter.