### PR TITLE
Update install-hardened.sh

### DIFF
--- a/assets/aws/files/install-hardened.sh
+++ b/assets/aws/files/install-hardened.sh
@@ -8,7 +8,7 @@ dnf -y update
 #  - python for certbot
 #  - certbot
 dnf install -y uuid python3 python3-certbot python3-certbot-dns-route53
-ln -s /opt/certbot/bin/certbot-3 /usr/local/bin/certbot
+ln -s /usr/bin/certbot-3 /usr/local/bin/certbot
 
 # Create teleport user. It is helpful to share the same UID
 # to have the same permissions on shared NFS volumes across auth servers and for consistency.

--- a/assets/aws/files/install-hardened.sh
+++ b/assets/aws/files/install-hardened.sh
@@ -6,13 +6,9 @@ dnf -y update
 # Install
 #  - uuid used for random token generation
 #  - python for certbot
-dnf install -y uuid python3
-
-# Install certbot
-python3 -m venv /opt/certbot
-/opt/certbot/bin/pip install --upgrade pip
-/opt/certbot/bin/pip install certbot certbot-dns-route53
-ln -s /opt/certbot/bin/certbot /usr/local/bin/certbot
+#  - certbot
+dnf install -y uuid python3 python3-certbot python3-certbot-dns-route53
+ln -s /opt/certbot/bin/certbot-3 /usr/local/bin/certbot
 
 # Create teleport user. It is helpful to share the same UID
 # to have the same permissions on shared NFS volumes across auth servers and for consistency.


### PR DESCRIPTION
This fixes a new issue where running the command `python3 -m venv /opt/certbot` on AL2023 minimal results in non zero-return:

```
Error: Command '['/opt/certbot/bin/python3', '-Im', 'ensurepip', '--upgrade', '--default-pip']' returned non-zero exit status 1.
```

Here is further output when that command is run manually:

```
/opt/certbot/bin/python3: Error while finding module specification for 'ensurepip.__main__' (ImportError: cannot import name '_bundled' from partially initialized module 'ensurepip' (most likely due to a circular import) (/usr/lib64/python3.9/ensurepip/__init__.py))
```

Installing via AWS' certbot + certbot-dns-route53 package resolves the issue. To be clear the problem here looks like new behavior within AL2023 minimal rather than changes to Teleport deployment process. AFAICT the same issue does not occur in AL2023 standard (but that version isnt used for the "hardened" deployment for Teleport)