### PR TITLE
[v16] docs: remove var reference that isn't used in terraform provider

### DIFF
--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/dedicated-server.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/dedicated-server.mdx
@@ -35,8 +35,7 @@ Terraform provider. The daemon stores its identity on the disk and refresh the t
 
 - A Linux host that you wish to run the Teleport Terraform provider onto.
 
-- A Linux user on that host that you wish Terraform and `tbot` to run as. In the guide,
-  we will use <Var name="teleport" /> for this.
+- A Linux user on that host that you wish Terraform and `tbot` to run as.
 
 ## Step 1/4. Install `tbot` on your server
 


### PR DESCRIPTION
Backport #50141 to branch/v16