### PR TITLE
[v15] Fix CHANGELOG rendering issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Fix tsh ssh -Y when jumping between multiple servers. [#50034](https://github.com/gravitational/teleport/pull/50034)
 * Reduce Auth memory consumption when agents join using the azure join method. [#50000](https://github.com/gravitational/teleport/pull/50000)
 * Tsh correctly respects the --no-allow-passwordless flag. [#49935](https://github.com/gravitational/teleport/pull/49935)
-* Client tools {tctl,tsh} auto-updates controlled by cluster configuration. [#48648](https://github.com/gravitational/teleport/pull/48648)
+* Auto-updates for client tools (`tctl` and `tsh`) are controlled by cluster configuration. [#48648](https://github.com/gravitational/teleport/pull/48648)
 
 ## 15.4.23 (12/5/2024)
 


### PR DESCRIPTION
Backports #49889

Remove the `{}` syntax in a note about automatic updates for client tools. The docs engine interprets this syntax as a JavaScript expression.