### PR TITLE
fix: disable `wasm-opt` for ironrdp pkg release build

### DIFF
--- a/web/packages/teleport/src/ironrdp/Cargo.toml
+++ b/web/packages/teleport/src/ironrdp/Cargo.toml
@@ -7,6 +7,9 @@ publish.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false
+
 [lib]
 crate-type = ["cdylib"]
 


### PR DESCRIPTION
👋 seeing some release build issue while building the teleport 17.0.5 wrt `wasm-opt`

```
  [INFO]: Optimizing wasm binaries with `wasm-opt`...
  [wasm-validator error in function fastpathprocessor_process\20externref\20shim] unexpected false: table.fill requires bulk-memory [--enable-bulk-memory], on 
  (table.fill $1
   (local.get $8)
   (ref.null noextern)
   (i32.const 4)
  )
  Fatal: error validating input
  Error: failed to execute `wasm-opt`: exited with exit status: 1
    full command: "/tmp/teleport-20241211-7965-9zz4yc/teleport-17.0.5/.brew_home/.cache/.wasm-pack/wasm-opt-1ceaaea8b7b5f7e0/bin/wasm-opt" "src/ironrdp/pkg/ironrdp_bg.wasm" "-o" "src/ironrdp/pkg/ironrdp_bg.wasm-opt.wasm" "-O"
  To disable `wasm-opt`, add `wasm-opt = false` to your package metadata in your `Cargo.toml`.
  Caused by: failed to execute `wasm-opt`: exited with exit status: 1
    full command: "/tmp/teleport-20241211-7965-9zz4yc/teleport-17.0.5/.brew_home/.cache/.wasm-pack/wasm-opt-1ceaaea8b7b5f7e0/bin/wasm-opt" "src/ironrdp/pkg/ironrdp_bg.wasm" "-o" "src/ironrdp/pkg/ironrdp_bg.wasm-opt.wasm" "-O"
  To disable `wasm-opt`, add `wasm-opt = false` to your package metadata in your `Cargo.toml`.
   ELIFECYCLE  Command failed with exit code 1.
  /tmp/teleport-20241211-7965-9zz4yc/teleport-17.0.5/web/packages/teleport:
   ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @gravitational/teleport@1.0.0 build: `pnpm build-wasm && vite build`
  Exit status 1
   ELIFECYCLE  Command failed with exit code 1.
  make[1]: *** [Makefile:1771: build-ui] Error 1
```

Disabling the opt works for my release build.

- relates to https://github.com/Homebrew/homebrew-core/pull/200874
- full release build log, https://github.com/Homebrew/homebrew-core/actions/runs/12304196969/job/34341211291

build setup:
- node: 23.4.0
- go: 1.23.4
- rust: 1.83.0
- wasm-pack: 0.13.1