### PR TITLE
Validate autoupdate_config and autoupdate_agent_rollout

### DIFF
--- a/api/types/autoupdate/rollout.go
+++ b/api/types/autoupdate/rollout.go
@@ -72,5 +72,32 @@ func ValidateAutoUpdateAgentRollout(v *autoupdate.AutoUpdateAgentRollout) error 
 		return trace.Wrap(err, "validating spec.strategy")
 	}
 
+	groups := v.GetStatus().GetGroups()
+	seenGroups := make(map[string]int, len(groups))
+	for i, group := range groups {
+		if group.Name == "" {
+			return trace.BadParameter("status.groups[%d].name is empty", i)
+		}
+		if _, err := types.ParseWeekdays(group.ConfigDays); err != nil {
+			return trace.BadParameter("status.groups[%d].config_days is invalid", i)
+		}
+		if group.ConfigStartHour > 23 || group.ConfigStartHour < 0 {
+			return trace.BadParameter("spec.agents.schedules.regular[%d].start_hour must be less than or equal to 23", i)
+		}
+		if group.ConfigWaitHours < 0 {
+			return trace.BadParameter("status.schedules.groups[%d].config_wait_hours cannot be negative", i)
+		}
+		if v.Spec.Strategy == AgentsStrategyTimeBased && group.ConfigWaitHours != 0 {
+			return trace.BadParameter("status.schedules.groups[%d].config_wait_hours must be zero when strategy is %s", i, AgentsStrategyTimeBased)
+		}
+		if v.Spec.Strategy == AgentsStrategyHaltOnError && i == 0 && group.ConfigWaitHours != 0 {
+			return trace.BadParameter("status.schedules.groups[0].config_wait_hours must be zero as it's the first group")
+		}
+		if conflictingGroup, ok := seenGroups[group.Name]; ok {
+			return trace.BadParameter("spec.agents.schedules.regular contains groups with the same name %q at indices %d and %d", group.Name, conflictingGroup, i)
+		}
+		seenGroups[group.Name] = i
+	}
+
 	return nil
 }

--- a/api/types/autoupdate/utils.go
+++ b/api/types/autoupdate/utils.go
@@ -51,10 +51,8 @@ func checkToolsMode(mode string) error {
 
 func checkScheduleName(schedule string) error {
 	switch schedule {
-	case AgentsScheduleImmediate:
+	case AgentsScheduleImmediate, AgentsScheduleRegular:
 		return nil
-	case AgentsScheduleRegular:
-		return trace.BadParameter("regular schedule is not implemented yet")
 	default:
 		return trace.BadParameter("unsupported schedule type: %q", schedule)
 	}

--- a/api/types/maintenance_test.go
+++ b/api/types/maintenance_test.go
@@ -271,3 +271,83 @@ func TestWithinUpgradeWindow(t *testing.T) {
 		})
 	}
 }
+
+func TestParseWeekdays(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		input       []string
+		expect      map[time.Weekday]struct{}
+		expectError require.ErrorAssertionFunc
+	}{
+		{
+			name:        "Nil slice",
+			input:       nil,
+			expect:      nil,
+			expectError: require.Error,
+		},
+		{
+			name:        "Empty slice",
+			input:       []string{},
+			expect:      nil,
+			expectError: require.Error,
+		},
+		{
+			name:  "Few valid days",
+			input: []string{"Mon", "Tuesday", "WEDNESDAY"},
+			expect: map[time.Weekday]struct{}{
+				time.Monday:    {},
+				time.Tuesday:   {},
+				time.Wednesday: {},
+			},
+			expectError: require.NoError,
+		},
+		{
+			name:  "Every day",
+			input: []string{"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"},
+			expect: map[time.Weekday]struct{}{
+				time.Monday:    {},
+				time.Tuesday:   {},
+				time.Wednesday: {},
+				time.Thursday:  {},
+				time.Friday:    {},
+				time.Saturday:  {},
+				time.Sunday:    {},
+			},
+			expectError: require.NoError,
+		},
+		{
+			name:  "Wildcard",
+			input: []string{"*"},
+			expect: map[time.Weekday]struct{}{
+				time.Monday:    {},
+				time.Tuesday:   {},
+				time.Wednesday: {},
+				time.Thursday:  {},
+				time.Friday:    {},
+				time.Saturday:  {},
+				time.Sunday:    {},
+			},
+			expectError: require.NoError,
+		},
+		{
+			name:        "Duplicated day",
+			input:       []string{"Mon", "Monday"},
+			expect:      nil,
+			expectError: require.Error,
+		},
+		{
+			name:        "Invalid days",
+			input:       []string{"Mon", "Tuesday", "frurfday"},
+			expect:      nil,
+			expectError: require.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ParseWeekdays(tt.input)
+			tt.expectError(t, err)
+			require.Equal(t, tt.expect, result)
+		})
+	}
+}

--- a/lib/auth/autoupdate/autoupdatev1/service.go
+++ b/lib/auth/autoupdate/autoupdatev1/service.go
@@ -21,12 +21,14 @@ package autoupdatev1
 import (
 	"context"
 	"log/slog"
+	"maps"
 
 	"github.com/gravitational/trace"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	"github.com/gravitational/teleport/api/types"
+	update "github.com/gravitational/teleport/api/types/autoupdate"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
@@ -122,6 +124,10 @@ func (s *Service) CreateAutoUpdateConfig(ctx context.Context, req *autoupdate.Cr
 		return nil, trace.Wrap(err)
 	}
 
+	if err := validateServerSideAgentConfig(req.Config); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	config, err := s.backend.CreateAutoUpdateConfig(ctx, req.Config)
 	var errMsg string
 	if err != nil {
@@ -162,6 +168,10 @@ func (s *Service) UpdateAutoUpdateConfig(ctx context.Context, req *autoupdate.Up
 		return nil, trace.Wrap(err)
 	}
 
+	if err := validateServerSideAgentConfig(req.Config); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	config, err := s.backend.UpdateAutoUpdateConfig(ctx, req.Config)
 	var errMsg string
 	if err != nil {
@@ -199,6 +209,10 @@ func (s *Service) UpsertAutoUpdateConfig(ctx context.Context, req *autoupdate.Up
 	}
 
 	if err := authCtx.AuthorizeAdminActionAllowReusedMFA(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := validateServerSideAgentConfig(req.Config); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -493,10 +507,11 @@ func (s *Service) CreateAutoUpdateAgentRollout(ctx context.Context, req *autoupd
 
 	// Editing the AU agent plan is restricted to cluster administrators. As of today we don't have any way of having
 	// resources that can only be edited by Teleport Cloud (when running cloud-hosted).
-	// The workaround is to check if the caller has the auth system role.
-	// This is not ideal as it forces local tctl usage. In the future, if we expand the permission system and make cloud
+	// The workaround is to check if the caller has the auth/admin system role.
+	// This is not ideal as it forces local tctl usage and can be bypassed if the user is very creative.
+	// In the future, if we expand the permission system and make cloud
 	// a first class citizen, we'll want to update this permission check.
-	if !authz.HasBuiltinRole(*authCtx, string(types.RoleAuth)) {
+	if !(authz.HasBuiltinRole(*authCtx, string(types.RoleAuth)) || authz.HasBuiltinRole(*authCtx, string(types.RoleAdmin))) {
 		return nil, trace.AccessDenied("this request can be only executed by an auth server")
 	}
 
@@ -521,10 +536,11 @@ func (s *Service) UpdateAutoUpdateAgentRollout(ctx context.Context, req *autoupd
 
 	// Editing the AU agent plan is restricted to cluster administrators. As of today we don't have any way of having
 	// resources that can only be edited by Teleport Cloud (when running cloud-hosted).
-	// The workaround is to check if the caller has the auth system role.
-	// This is not ideal as it forces local tctl usage. In the future, if we expand the permission system and make cloud
+	// The workaround is to check if the caller has the auth/admin system role.
+	// This is not ideal as it forces local tctl usage and can be bypassed if the user is very creative.
+	// In the future, if we expand the permission system and make cloud
 	// a first class citizen, we'll want to update this permission check.
-	if !authz.HasBuiltinRole(*authCtx, string(types.RoleAuth)) {
+	if !(authz.HasBuiltinRole(*authCtx, string(types.RoleAuth)) || authz.HasBuiltinRole(*authCtx, string(types.RoleAdmin))) {
 		return nil, trace.AccessDenied("this request can be only executed by an auth server")
 	}
 
@@ -549,10 +565,11 @@ func (s *Service) UpsertAutoUpdateAgentRollout(ctx context.Context, req *autoupd
 
 	// Editing the AU agent plan is restricted to cluster administrators. As of today we don't have any way of having
 	// resources that can only be edited by Teleport Cloud (when running cloud-hosted).
-	// The workaround is to check if the caller has the auth system role.
-	// This is not ideal as it forces local tctl usage. In the future, if we expand the permission system and make cloud
+	// The workaround is to check if the caller has the auth/admin system role.
+	// This is not ideal as it forces local tctl usage and can be bypassed if the user is very creative.
+	// In the future, if we expand the permission system and make cloud
 	// a first class citizen, we'll want to update this permission check.
-	if !authz.HasBuiltinRole(*authCtx, string(types.RoleAuth)) {
+	if !(authz.HasBuiltinRole(*authCtx, string(types.RoleAuth)) || authz.HasBuiltinRole(*authCtx, string(types.RoleAdmin))) {
 		return nil, trace.AccessDenied("this request can be only executed by an auth server")
 	}
 
@@ -577,10 +594,11 @@ func (s *Service) DeleteAutoUpdateAgentRollout(ctx context.Context, req *autoupd
 
 	// Editing the AU agent plan is restricted to cluster administrators. As of today we don't have any way of having
 	// resources that can only be edited by Teleport Cloud (when running cloud-hosted).
-	// The workaround is to check if the caller has the auth system role.
-	// This is not ideal as it forces local tctl usage. In the future, if we expand the permission system and make cloud
+	// The workaround is to check if the caller has the auth/admin system role.
+	// This is not ideal as it forces local tctl usage and can be bypassed if the user is very creative.
+	// In the future, if we expand the permission system and make cloud
 	// a first class citizen, we'll want to update this permission check.
-	if !authz.HasBuiltinRole(*authCtx, string(types.RoleAuth)) {
+	if !(authz.HasBuiltinRole(*authCtx, string(types.RoleAuth)) || authz.HasBuiltinRole(*authCtx, string(types.RoleAdmin))) {
 		return nil, trace.AccessDenied("this request can be only executed by an auth server")
 	}
 
@@ -616,4 +634,132 @@ func checkAdminCloudAccess(authCtx *authz.Context) error {
 			types.KindAutoUpdateVersion, types.KindAutoUpdateConfig)
 	}
 	return nil
+}
+
+// Those values are arbitrary, we will want to increase them as we test. We will also want to modulate them based on the
+// cluster context. We don't want people to craft schedules that can't realistically finish within a week on Cloud as
+// we usually do weekly updates. However, self-hosted users can craft more complex schedules, slower rollouts, and shoot
+// themselves in the foot if they want.
+const (
+	maxGroupsTimeBasedStrategy        = 20
+	maxGroupsHaltOnErrorStrategy      = 10
+	maxGroupsHaltOnErrorStrategyCloud = 4
+	maxRolloutDurationCloudHours      = 72
+)
+
+var (
+	cloudGroupUpdateDays = []string{"Mon", "Tue", "Wed", "Thu"}
+)
+
+// validateServerSideAgentConfig validates that the autoupdate_config.agent spec meets the cluster rules.
+// Rules may vary based on the cluster, and over time.
+//
+// This function should not be confused with api/types/autoupdate.ValidateAutoUpdateConfig which validates the integrity
+// of the resource and does not enforce potentially changing rules.
+func validateServerSideAgentConfig(config *autoupdate.AutoUpdateConfig) error {
+	agentsSpec := config.GetSpec().GetAgents()
+	if agentsSpec == nil {
+		return nil
+	}
+	// We must check resource integrity before, because it makes no sense to try to enforce rules on an invalid resource.
+	// The generic backend service will likely check integrity again, but it's not a large performance problem.
+	err := update.ValidateAutoUpdateConfig(config)
+	if err != nil {
+		return trace.Wrap(err, "validating autoupdate config")
+	}
+
+	var maxGroups int
+	isCloud := modules.GetModules().Features().Cloud
+
+	switch {
+	case isCloud && agentsSpec.GetStrategy() == update.AgentsStrategyHaltOnError:
+		maxGroups = maxGroupsHaltOnErrorStrategyCloud
+	case agentsSpec.GetStrategy() == update.AgentsStrategyHaltOnError:
+		maxGroups = maxGroupsHaltOnErrorStrategy
+	case agentsSpec.GetStrategy() == update.AgentsStrategyTimeBased:
+		maxGroups = maxGroupsTimeBasedStrategy
+	default:
+		return trace.BadParameter("unknown max group for strategy %v", agentsSpec.GetStrategy())
+	}
+
+	if len(agentsSpec.GetSchedules().GetRegular()) > maxGroups {
+		return trace.BadParameter("max groups (%d) exceeded for strategy %s, %s schedule contains %d groups", maxGroups, agentsSpec.GetStrategy(), update.AgentsScheduleRegular, len(agentsSpec.GetSchedules().GetRegular()))
+	}
+
+	if !isCloud {
+		return nil
+	}
+
+	cloudWeekdays, err := types.ParseWeekdays(cloudGroupUpdateDays)
+	if err != nil {
+		return trace.Wrap(err, "parsing cloud weekdays")
+	}
+
+	for i, group := range agentsSpec.GetSchedules().GetRegular() {
+		weekdays, err := types.ParseWeekdays(group.Days)
+		if err != nil {
+			return trace.Wrap(err, "parsing weekdays from group %d", i)
+		}
+
+		if !maps.Equal(cloudWeekdays, weekdays) {
+			return trace.BadParameter("weekdays must be set to %v in cloud", cloudGroupUpdateDays)
+		}
+
+	}
+
+	if duration := computeMinRolloutTime(agentsSpec.GetSchedules().GetRegular()); duration > maxRolloutDurationCloudHours {
+		return trace.BadParameter("rollout takes more than %d hours to complete: estimated completion time is %d hours", maxRolloutDurationCloudHours, duration)
+	}
+
+	return nil
+}
+
+func computeMinRolloutTime(groups []*autoupdate.AgentAutoUpdateGroup) int {
+	if len(groups) == 0 {
+		return 0
+	}
+
+	// We start the rollout at the first group hour, and we wait for the group to update (1 hour).
+	hours := groups[0].StartHour + 1
+
+	for _, group := range groups[1:] {
+		previousStartHour := (hours - 1) % 24
+		previousEndHour := hours % 24
+
+		// compute the difference between the current hour and the group start hour
+		// we then check if it's less than the WaitHours, in this case we wait a day
+		diff := hourDifference(previousStartHour, group.StartHour)
+		if diff < group.WaitHours%24 {
+			hours += 24 + hourDifference(previousEndHour, group.StartHour)
+		} else {
+			hours += hourDifference(previousEndHour, group.StartHour)
+		}
+
+		// Handle the case where WaitHours is > 24
+		// This is an integer division
+		waitDays := group.WaitHours / 24
+		// There's a special case where the difference modulo 24 is zero, the
+		// wait hours are non-null, but we already waited 23 hours.
+		// To avoid double counting we reduce the number of wait days by 1 if
+		// it's not zero already.
+		if diff == 0 {
+			waitDays = max(waitDays-1, 0)
+		}
+		hours += waitDays * 24
+
+		// We assume the group took an hour to update
+		hours += 1
+	}
+
+	// We remove the group start hour we added initially
+	return int(hours - groups[0].StartHour)
+}
+
+// hourDifference computed the difference between two hours.
+func hourDifference(a, b int32) int32 {
+	diff := b - a
+	if diff < 0 {
+		diff = diff + 24
+	}
+	return diff
 }

--- a/lib/auth/autoupdate/autoupdatev1/service_test.go
+++ b/lib/auth/autoupdate/autoupdatev1/service_test.go
@@ -20,10 +20,13 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	autoupdatev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -33,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend/memory"
 	libevents "github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/utils"
@@ -449,4 +453,330 @@ func newServiceWithStorage(t *testing.T, authState authz.AdminActionAuthState, c
 	})
 	require.NoError(t, err)
 	return service
+}
+
+func TestComputeMinRolloutTime(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		groups        []*autoupdatev1pb.AgentAutoUpdateGroup
+		expectedHours int
+	}{
+		{
+			name:          "nil groups",
+			groups:        nil,
+			expectedHours: 0,
+		},
+		{
+			name:          "empty groups",
+			groups:        []*autoupdatev1pb.AgentAutoUpdateGroup{},
+			expectedHours: 0,
+		},
+		{
+			name: "single group",
+			groups: []*autoupdatev1pb.AgentAutoUpdateGroup{
+				{
+					Name: "g1",
+				},
+			},
+			expectedHours: 1,
+		},
+		{
+			name: "two groups, same day, different start hour, no wait time",
+			groups: []*autoupdatev1pb.AgentAutoUpdateGroup{
+				{
+					Name:      "g1",
+					StartHour: 2,
+				},
+				{
+					Name:      "g2",
+					StartHour: 4,
+				},
+			},
+			// g1 updates from 2:00 to 3:00, g2 updates from 4:00 to 5:00, rollout updates from 2:00 to 5:00.
+			expectedHours: 3,
+		},
+		{
+			name: "two groups, same day, same start hour, no wait time",
+			groups: []*autoupdatev1pb.AgentAutoUpdateGroup{
+				{
+					Name:      "g1",
+					StartHour: 2,
+				},
+				{
+					Name:      "g2",
+					StartHour: 2,
+				},
+			},
+			// g1 and g2 can't update at the same time, the g1 updates from 2:00 to 3:00 days one,
+			// and g2 updates from 2:00 to 3:00 the next day. Total update spans from 2:00 day 1, to 3:00 day 2
+			expectedHours: 25,
+		},
+		{
+			name: "two groups, cannot happen on the same day because of wait_hours",
+			groups: []*autoupdatev1pb.AgentAutoUpdateGroup{
+				{
+					Name:      "g1",
+					StartHour: 2,
+				},
+				{
+					Name:      "g2",
+					StartHour: 4,
+					WaitHours: 6,
+				},
+			},
+			// g1 updates from 2:00 to 3:00. At 4:00 g2 can't update yet, so we wait the next day.
+			// On day 2, g2 updates from 4:00 to 5:00. Rollout spans from 2:00 day on to 7:00 day 2.
+			expectedHours: 27,
+		},
+		{
+			name: "two groups, wait hours is several days",
+			groups: []*autoupdatev1pb.AgentAutoUpdateGroup{
+				{
+					Name:      "g1",
+					StartHour: 2,
+				},
+				{
+					Name:      "g2",
+					StartHour: 4,
+					WaitHours: 48,
+				},
+			},
+			// g1 updates from 2:00 to 3:00. At 4:00 g2 can't update yet, so we wait 2 days.
+			// On day 3, g2 updates from 4:00 to 5:00. Rollout spans from 2:00 day on to 7:00 day 3.
+			expectedHours: 51,
+		},
+		{
+			name: "two groups, one wait hour",
+			groups: []*autoupdatev1pb.AgentAutoUpdateGroup{
+				{
+					Name:      "g1",
+					StartHour: 2,
+				},
+				{
+					Name:      "g2",
+					StartHour: 3,
+					WaitHours: 1,
+				},
+			},
+			expectedHours: 2,
+		},
+		{
+			name: "two groups different days",
+			groups: []*autoupdatev1pb.AgentAutoUpdateGroup{
+				{
+					Name:      "g1",
+					StartHour: 23,
+				},
+				{
+					Name:      "g2",
+					StartHour: 1,
+				},
+			},
+			expectedHours: 3,
+		},
+		{
+			name: "two groups different days, hour diff == wait hours == 1 day",
+			groups: []*autoupdatev1pb.AgentAutoUpdateGroup{
+				{
+					Name:      "g1",
+					StartHour: 12,
+				},
+				{
+					Name:      "g2",
+					StartHour: 12,
+					WaitHours: 24,
+				},
+			},
+			expectedHours: 25,
+		},
+		{
+			name: "two groups different days, hour diff == wait hours",
+			groups: []*autoupdatev1pb.AgentAutoUpdateGroup{
+				{
+					Name:      "g1",
+					StartHour: 12,
+				},
+				{
+					Name:      "g2",
+					StartHour: 11,
+					WaitHours: 23,
+				},
+			},
+			expectedHours: 24,
+		},
+		{
+			name: "everything at once",
+			groups: []*autoupdatev1pb.AgentAutoUpdateGroup{
+				{
+					Name:      "g1",
+					StartHour: 23,
+				},
+				{
+					Name:      "g2",
+					StartHour: 1,
+					WaitHours: 4,
+				},
+				{
+					Name:      "g3",
+					StartHour: 1,
+				},
+				{
+					Name:      "g4",
+					StartHour: 10,
+					WaitHours: 6,
+				},
+			},
+			expectedHours: 60,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expectedHours, computeMinRolloutTime(tt.groups))
+		})
+	}
+}
+
+func generateGroups(n int, days []string) []*autoupdatev1pb.AgentAutoUpdateGroup {
+	groups := make([]*autoupdatev1pb.AgentAutoUpdateGroup, n)
+	for i := range groups {
+		groups[i] = &autoupdatev1pb.AgentAutoUpdateGroup{
+			Name:      strconv.Itoa(i),
+			Days:      days,
+			StartHour: int32(i % 24),
+		}
+	}
+	return groups
+}
+
+func TestValidateServerSideAgentConfig(t *testing.T) {
+	cloudModules := &modules.TestModules{
+		TestFeatures: modules.Features{
+			Cloud: true,
+		},
+	}
+	selfHostedModules := &modules.TestModules{
+		TestFeatures: modules.Features{
+			Cloud: false,
+		},
+	}
+	tests := []struct {
+		name      string
+		config    *autoupdatev1pb.AutoUpdateConfigSpecAgents
+		modules   modules.Modules
+		expectErr require.ErrorAssertionFunc
+	}{
+		{
+			name:      "empty agent config",
+			modules:   selfHostedModules,
+			config:    nil,
+			expectErr: require.NoError,
+		},
+		{
+			name:    "over max groups time-based",
+			modules: selfHostedModules,
+			config: &autoupdatev1pb.AutoUpdateConfigSpecAgents{
+				Mode:                      autoupdate.AgentsUpdateModeEnabled,
+				Strategy:                  autoupdate.AgentsStrategyTimeBased,
+				MaintenanceWindowDuration: durationpb.New(time.Hour),
+				Schedules: &autoupdatev1pb.AgentAutoUpdateSchedules{
+					Regular: generateGroups(maxGroupsTimeBasedStrategy+1, cloudGroupUpdateDays),
+				},
+			},
+			expectErr: require.Error,
+		},
+		{
+			name:    "over max groups halt-on-error",
+			modules: selfHostedModules,
+			config: &autoupdatev1pb.AutoUpdateConfigSpecAgents{
+				Mode:     autoupdate.AgentsUpdateModeEnabled,
+				Strategy: autoupdate.AgentsStrategyHaltOnError,
+				Schedules: &autoupdatev1pb.AgentAutoUpdateSchedules{
+					Regular: generateGroups(maxGroupsHaltOnErrorStrategy+1, cloudGroupUpdateDays),
+				},
+			},
+			expectErr: require.Error,
+		},
+		{
+			name:    "over max groups halt-on-error cloud",
+			modules: cloudModules,
+			config: &autoupdatev1pb.AutoUpdateConfigSpecAgents{
+				Mode:     autoupdate.AgentsUpdateModeEnabled,
+				Strategy: autoupdate.AgentsStrategyHaltOnError,
+				Schedules: &autoupdatev1pb.AgentAutoUpdateSchedules{
+					Regular: generateGroups(maxGroupsHaltOnErrorStrategyCloud+1, cloudGroupUpdateDays),
+				},
+			},
+			expectErr: require.Error,
+		},
+		{
+			name:    "cloud should reject custom weekdays",
+			modules: cloudModules,
+			config: &autoupdatev1pb.AutoUpdateConfigSpecAgents{
+				Mode:     autoupdate.AgentsUpdateModeEnabled,
+				Strategy: autoupdate.AgentsStrategyHaltOnError,
+				Schedules: &autoupdatev1pb.AgentAutoUpdateSchedules{
+					Regular: generateGroups(maxGroupsHaltOnErrorStrategyCloud, []string{"Mon"}),
+				},
+			},
+			expectErr: require.Error,
+		},
+		{
+			name:    "self-hosted should allow custom weekdays",
+			modules: selfHostedModules,
+			config: &autoupdatev1pb.AutoUpdateConfigSpecAgents{
+				Mode:     autoupdate.AgentsUpdateModeEnabled,
+				Strategy: autoupdate.AgentsStrategyHaltOnError,
+				Schedules: &autoupdatev1pb.AgentAutoUpdateSchedules{
+					Regular: generateGroups(maxGroupsHaltOnErrorStrategyCloud, []string{"Mon"}),
+				},
+			},
+			expectErr: require.NoError,
+		},
+		{
+			name:    "cloud should reject long rollouts",
+			modules: cloudModules,
+			config: &autoupdatev1pb.AutoUpdateConfigSpecAgents{
+				Mode:     autoupdate.AgentsUpdateModeEnabled,
+				Strategy: autoupdate.AgentsStrategyHaltOnError,
+				Schedules: &autoupdatev1pb.AgentAutoUpdateSchedules{
+					Regular: []*autoupdatev1pb.AgentAutoUpdateGroup{
+						{Name: "g1", Days: cloudGroupUpdateDays},
+						{Name: "g2", Days: cloudGroupUpdateDays, WaitHours: maxRolloutDurationCloudHours},
+					},
+				},
+			},
+			expectErr: require.Error,
+		},
+		{
+			name:    "self-hosted should allow long rollouts",
+			modules: selfHostedModules,
+			config: &autoupdatev1pb.AutoUpdateConfigSpecAgents{
+				Mode:     autoupdate.AgentsUpdateModeEnabled,
+				Strategy: autoupdate.AgentsStrategyHaltOnError,
+				Schedules: &autoupdatev1pb.AgentAutoUpdateSchedules{
+					Regular: []*autoupdatev1pb.AgentAutoUpdateGroup{
+						{Name: "g1", Days: cloudGroupUpdateDays},
+						{Name: "g2", Days: cloudGroupUpdateDays, WaitHours: maxRolloutDurationCloudHours},
+					},
+				},
+			},
+			expectErr: require.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test setup: crafing a config and setting modules
+			config, err := autoupdate.NewAutoUpdateConfig(
+				&autoupdatev1pb.AutoUpdateConfigSpec{
+					Tools:  nil,
+					Agents: tt.config,
+				})
+			require.NoError(t, err)
+			modules.SetTestModules(t, tt.modules)
+
+			// Test execution.
+			tt.expectErr(t, validateServerSideAgentConfig(config))
+		})
+	}
 }

--- a/lib/autoupdate/rollout/reconciler.go
+++ b/lib/autoupdate/rollout/reconciler.go
@@ -47,6 +47,7 @@ const (
 )
 
 var (
+	// defaultUpdateDays is the default list of days when groups can be updated.
 	defaultUpdateDays = []string{"Mon", "Tue", "Wed", "Thu"}
 )
 


### PR DESCRIPTION
Part of: [RFD-184](https://github.com/gravitational/teleport/pull/47126)

Goal (internal): https://github.com/gravitational/cloud/issues/10289

This PR removes the restrictions of the `autoupdate_agent_rollout` and `autoupdate_config` schedules but adds groups validation.

It also adds some optional server-side validation that should not be enforced at the resource level.