### PR TITLE
Update awsoidc deployment updater service

### DIFF
--- a/rfd/0109-cloud-agent-upgrades.md
+++ b/rfd/0109-cloud-agent-upgrades.md
@@ -347,6 +347,7 @@ The logic flow will look like the same as the core update model:
 - If within maintenance window, attempt update
 
 For getting the region, let's iterate over all Databases, filter for RDS ones and extract the AWS.Region.
+Additionally, iterate over all Database Services, filter for the ones with the awsoidc-agent label and extract the region from matcher labels.
 For each unique Region, we will call the APIs (DescribeCluster/DescribeServices)
 
 To query for available ECS clusters Teleport will iterate over all databases filtering for RDS, and then extract the AWS.Region. For each


### PR DESCRIPTION
The updater will now ping the auth server every 30 minutes instead of only once at init time.

If the auth service enables automatic updates then the proxy service will now see that without requiring a restart.
The updater will also check the update version against the latest auth service version instead of the version that was running when the proxy started.

Additionally, the updater will check AWS regions that have a running awsoidc-agent labeled database service.
This means that running ECS agents will still be updated even if all db objects have been deleted.

Finally, more INFO level logging is added in cases where the updater is skipped, which only happens every 30 minutes.