### PR TITLE
[v14] Remove CI-specific UID/GID to appease GH's breaking change

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -42,22 +42,7 @@ ifneq ("$(KUBECONFIG)","")
 DOCKERFLAGS := $(DOCKERFLAGS) -v $(KUBECONFIG):/mnt/kube/config -e KUBECONFIG=/mnt/kube/config -e TEST_KUBE=$(TEST_KUBE)
 endif
 
-# conditionally force the use of UID/GID 1000:1000 if we're running in Drone or Github Actions (in which case CI env var will be set)
-ifeq ("$(DRONE)","true")
-CI := true
-endif
 ifeq ("$(CI)","true")
-# The UID/GID of the runner user on ARC runners is 1001, not 1000
-# This var is currently only set for ARC runners via https://github.com/gravitational/cloud-terraform/pull/2473
-ifeq ("$(CI_SYSTEM)","ARC")
-UID := 1001
-GID := 1001
-NOROOT := -u 1001:1001
-else
-UID := 1000
-GID := 1000
-NOROOT := -u 1000:1000
-endif
 # if running in CI and the GOCACHE environment variable is not set, set it to a sensible default
 ifeq ("$(GOCACHE)",)
 GOCACHE := /go/cache


### PR DESCRIPTION

GitHub unexpectedly made a breaking change to the `runner` user used in
GHA pipelines. This works around the issue by removing the hard-coded
uid/gid values in our makefile.

Backport: https://github.com/gravitational/teleport/pull/50176
