### PR TITLE
Remove unused `React` imports from `packages/design`

### DIFF
--- a/web/packages/design/src/Alert/Alert.story.tsx
+++ b/web/packages/design/src/Alert/Alert.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { action } from '@storybook/addon-actions';
 
 import { Restore } from 'design/Icon';

--- a/web/packages/design/src/Alert/Alert.test.tsx
+++ b/web/packages/design/src/Alert/Alert.test.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { render, screen, theme, userEvent } from 'design/utils/testing';
 
 import { Alert, Banner } from '.';

--- a/web/packages/design/src/AnimatedProgressBar/AnimatedProgressBar.story.tsx
+++ b/web/packages/design/src/AnimatedProgressBar/AnimatedProgressBar.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { AnimatedProgressBar as Component } from './AnimatedProgressBar';
 
 export default {

--- a/web/packages/design/src/AnimatedProgressBar/AnimatedProgressBar.tsx
+++ b/web/packages/design/src/AnimatedProgressBar/AnimatedProgressBar.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 
 import Flex from '../Flex';

--- a/web/packages/design/src/Box/Box.story.tsx
+++ b/web/packages/design/src/Box/Box.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import styled from 'styled-components';
 
 import Box from './Box';

--- a/web/packages/design/src/Button/buttons.story.tsx
+++ b/web/packages/design/src/Button/buttons.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { Fragment } from 'react';
 
 import styled from 'styled-components';
 
@@ -66,7 +66,7 @@ export const Buttons = () => {
         </thead>
         <tbody>
           {fills.map(fill => (
-            <React.Fragment key={fill}>
+            <Fragment key={fill}>
               <tr>
                 <th rowSpan={4}>{fill}</th>
                 <th>neutral</th>
@@ -84,7 +84,7 @@ export const Buttons = () => {
                 <th>success</th>
                 <ButtonTableCells fill={fill} intent="success" />
               </tr>
-            </React.Fragment>
+            </Fragment>
           ))}
         </tbody>
       </Table>{' '}

--- a/web/packages/design/src/ButtonIcon/ButtonIcon.jsx
+++ b/web/packages/design/src/ButtonIcon/ButtonIcon.jsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 
 import { space, color, alignSelf } from 'design/system';

--- a/web/packages/design/src/ButtonIcon/ButtonIcon.test.jsx
+++ b/web/packages/design/src/ButtonIcon/ButtonIcon.test.jsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { render } from 'design/utils/testing';
 
 import ButtonIcon from './index';

--- a/web/packages/design/src/ButtonLink/ButtonLink.test.tsx
+++ b/web/packages/design/src/ButtonLink/ButtonLink.test.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { render } from 'design/utils/testing';
 
 import ButtonLink from './index';

--- a/web/packages/design/src/ButtonLink/ButtonLink.tsx
+++ b/web/packages/design/src/ButtonLink/ButtonLink.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 
 import { Button, ButtonProps } from 'design/Button';

--- a/web/packages/design/src/Card/Card.story.tsx
+++ b/web/packages/design/src/Card/Card.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Flex, Text } from '..';
 
 import Card from '.';

--- a/web/packages/design/src/CardError/CardError.jsx
+++ b/web/packages/design/src/CardError/CardError.jsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 

--- a/web/packages/design/src/CardError/CardError.story.jsx
+++ b/web/packages/design/src/CardError/CardError.story.jsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import * as CardError from './CardError';
 
 const message = 'some error message';

--- a/web/packages/design/src/CardIcon/CardIcon.jsx
+++ b/web/packages/design/src/CardIcon/CardIcon.jsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import Card from 'design/Card';
 import { H1 } from 'design';
 

--- a/web/packages/design/src/CardIcon/CardIcon.story.jsx
+++ b/web/packages/design/src/CardIcon/CardIcon.story.jsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Apple } from '../Icon';
 
 import CardIcon from './index';

--- a/web/packages/design/src/CardSuccess/CardSuccess.jsx
+++ b/web/packages/design/src/CardSuccess/CardSuccess.jsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import CardIcon from 'design/CardIcon';
 import { CircleCheck } from 'design/Icon';
 

--- a/web/packages/design/src/CardSuccess/CardSuccess.story.jsx
+++ b/web/packages/design/src/CardSuccess/CardSuccess.story.jsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import CardSuccess, { CardSuccessLogin } from './index';
 
 export default {

--- a/web/packages/design/src/Checkbox/Checkbox.story.tsx
+++ b/web/packages/design/src/Checkbox/Checkbox.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import styled from 'styled-components';
 
 import { Flex } from '..';

--- a/web/packages/design/src/DataTable/InputSearch/InputSearch.tsx
+++ b/web/packages/design/src/DataTable/InputSearch/InputSearch.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { JSX, FormEvent } from 'react';
+import { JSX, FormEvent } from 'react';
 import styled from 'styled-components';
 
 import {

--- a/web/packages/design/src/DataTable/Pager/ClientSidePager/ClientSidePager.tsx
+++ b/web/packages/design/src/DataTable/Pager/ClientSidePager/ClientSidePager.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Flex } from 'design';
 import { CircleArrowLeft, CircleArrowRight } from 'design/Icon';
 import { PageIndicatorText } from 'design/DataTable/Pager/PageIndicatorText';

--- a/web/packages/design/src/DataTable/Pager/PageIndicatorText.tsx
+++ b/web/packages/design/src/DataTable/Pager/PageIndicatorText.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Text } from 'design';
 
 export function PageIndicatorText({

--- a/web/packages/design/src/DataTable/Pager/ServerSidePager.tsx
+++ b/web/packages/design/src/DataTable/Pager/ServerSidePager.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Flex } from 'design';
 import { CircleArrowLeft, CircleArrowRight } from 'design/Icon';
 

--- a/web/packages/design/src/DataTable/Table.test.tsx
+++ b/web/packages/design/src/DataTable/Table.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/web/packages/design/src/Dialog/Dialog.story.jsx
+++ b/web/packages/design/src/Dialog/Dialog.story.jsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { ButtonPrimary, Input, LabelInput } from './..';
 
 import Dialog, {

--- a/web/packages/design/src/Dialog/DialogHeader.jsx
+++ b/web/packages/design/src/Dialog/DialogHeader.jsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import styled from 'styled-components';
 
 import { typography } from 'design/system';

--- a/web/packages/design/src/Dialog/DialogTitle.jsx
+++ b/web/packages/design/src/Dialog/DialogTitle.jsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { H2 } from 'design';
 
 export default function DialogTitle(props) {

--- a/web/packages/design/src/Flex/Flex.story.jsx
+++ b/web/packages/design/src/Flex/Flex.story.jsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import styled from 'styled-components';
 
 import Box from '../Box';

--- a/web/packages/design/src/Icon/Icons/Add.tsx
+++ b/web/packages/design/src/Icon/Icons/Add.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/AddCircle.tsx
+++ b/web/packages/design/src/Icon/Icons/AddCircle.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/AddUsers.tsx
+++ b/web/packages/design/src/Icon/Icons/AddUsers.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/AlarmRing.tsx
+++ b/web/packages/design/src/Icon/Icons/AlarmRing.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/AmazonAws.tsx
+++ b/web/packages/design/src/Icon/Icons/AmazonAws.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Apartment.tsx
+++ b/web/packages/design/src/Icon/Icons/Apartment.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Apple.tsx
+++ b/web/packages/design/src/Icon/Icons/Apple.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Application.tsx
+++ b/web/packages/design/src/Icon/Icons/Application.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Archive.tsx
+++ b/web/packages/design/src/Icon/Icons/Archive.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/ArrowBack.tsx
+++ b/web/packages/design/src/Icon/Icons/ArrowBack.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/ArrowDown.tsx
+++ b/web/packages/design/src/Icon/Icons/ArrowDown.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/ArrowFatLinesUp.tsx
+++ b/web/packages/design/src/Icon/Icons/ArrowFatLinesUp.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/ArrowForward.tsx
+++ b/web/packages/design/src/Icon/Icons/ArrowForward.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/ArrowLeft.tsx
+++ b/web/packages/design/src/Icon/Icons/ArrowLeft.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/ArrowLineLeft.tsx
+++ b/web/packages/design/src/Icon/Icons/ArrowLineLeft.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/ArrowRight.tsx
+++ b/web/packages/design/src/Icon/Icons/ArrowRight.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/ArrowSquareOut.tsx
+++ b/web/packages/design/src/Icon/Icons/ArrowSquareOut.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/ArrowUp.tsx
+++ b/web/packages/design/src/Icon/Icons/ArrowUp.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/ArrowsIn.tsx
+++ b/web/packages/design/src/Icon/Icons/ArrowsIn.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/ArrowsOut.tsx
+++ b/web/packages/design/src/Icon/Icons/ArrowsOut.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/BellRinging.tsx
+++ b/web/packages/design/src/Icon/Icons/BellRinging.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/BookOpenText.tsx
+++ b/web/packages/design/src/Icon/Icons/BookOpenText.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Bots.tsx
+++ b/web/packages/design/src/Icon/Icons/Bots.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Broadcast.tsx
+++ b/web/packages/design/src/Icon/Icons/Broadcast.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/BroadcastSlash.tsx
+++ b/web/packages/design/src/Icon/Icons/BroadcastSlash.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Bubble.tsx
+++ b/web/packages/design/src/Icon/Icons/Bubble.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/CCAmex.tsx
+++ b/web/packages/design/src/Icon/Icons/CCAmex.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/CCDiscover.tsx
+++ b/web/packages/design/src/Icon/Icons/CCDiscover.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/CCMasterCard.tsx
+++ b/web/packages/design/src/Icon/Icons/CCMasterCard.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/CCStripe.tsx
+++ b/web/packages/design/src/Icon/Icons/CCStripe.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/CCVisa.tsx
+++ b/web/packages/design/src/Icon/Icons/CCVisa.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/CSSVisa.tsx
+++ b/web/packages/design/src/Icon/Icons/CSSVisa.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Calendar.tsx
+++ b/web/packages/design/src/Icon/Icons/Calendar.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Camera.tsx
+++ b/web/packages/design/src/Icon/Icons/Camera.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/CardView.tsx
+++ b/web/packages/design/src/Icon/Icons/CardView.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Cash.tsx
+++ b/web/packages/design/src/Icon/Icons/Cash.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Chart.tsx
+++ b/web/packages/design/src/Icon/Icons/Chart.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/ChatBubble.tsx
+++ b/web/packages/design/src/Icon/Icons/ChatBubble.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/ChatCircleSparkle.tsx
+++ b/web/packages/design/src/Icon/Icons/ChatCircleSparkle.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Check.tsx
+++ b/web/packages/design/src/Icon/Icons/Check.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/CheckThick.tsx
+++ b/web/packages/design/src/Icon/Icons/CheckThick.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Checks.tsx
+++ b/web/packages/design/src/Icon/Icons/Checks.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/ChevronCircleDown.tsx
+++ b/web/packages/design/src/Icon/Icons/ChevronCircleDown.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/ChevronCircleLeft.tsx
+++ b/web/packages/design/src/Icon/Icons/ChevronCircleLeft.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/ChevronCircleRight.tsx
+++ b/web/packages/design/src/Icon/Icons/ChevronCircleRight.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/ChevronCircleUp.tsx
+++ b/web/packages/design/src/Icon/Icons/ChevronCircleUp.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/ChevronDown.tsx
+++ b/web/packages/design/src/Icon/Icons/ChevronDown.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/ChevronLeft.tsx
+++ b/web/packages/design/src/Icon/Icons/ChevronLeft.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/ChevronRight.tsx
+++ b/web/packages/design/src/Icon/Icons/ChevronRight.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/ChevronUp.tsx
+++ b/web/packages/design/src/Icon/Icons/ChevronUp.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/ChevronsVertical.tsx
+++ b/web/packages/design/src/Icon/Icons/ChevronsVertical.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/CircleArrowLeft.tsx
+++ b/web/packages/design/src/Icon/Icons/CircleArrowLeft.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/CircleArrowRight.tsx
+++ b/web/packages/design/src/Icon/Icons/CircleArrowRight.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/CircleCheck.tsx
+++ b/web/packages/design/src/Icon/Icons/CircleCheck.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/CircleCross.tsx
+++ b/web/packages/design/src/Icon/Icons/CircleCross.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/CirclePause.tsx
+++ b/web/packages/design/src/Icon/Icons/CirclePause.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/CirclePlay.tsx
+++ b/web/packages/design/src/Icon/Icons/CirclePlay.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/CircleStop.tsx
+++ b/web/packages/design/src/Icon/Icons/CircleStop.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Cli.tsx
+++ b/web/packages/design/src/Icon/Icons/Cli.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Clipboard.tsx
+++ b/web/packages/design/src/Icon/Icons/Clipboard.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/ClipboardUser.tsx
+++ b/web/packages/design/src/Icon/Icons/ClipboardUser.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Clock.tsx
+++ b/web/packages/design/src/Icon/Icons/Clock.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Cloud.tsx
+++ b/web/packages/design/src/Icon/Icons/Cloud.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Cluster.tsx
+++ b/web/packages/design/src/Icon/Icons/Cluster.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Code.tsx
+++ b/web/packages/design/src/Icon/Icons/Code.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Cog.tsx
+++ b/web/packages/design/src/Icon/Icons/Cog.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Config.tsx
+++ b/web/packages/design/src/Icon/Icons/Config.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Contract.tsx
+++ b/web/packages/design/src/Icon/Icons/Contract.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Copy.tsx
+++ b/web/packages/design/src/Icon/Icons/Copy.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/CreditCard.tsx
+++ b/web/packages/design/src/Icon/Icons/CreditCard.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Cross.tsx
+++ b/web/packages/design/src/Icon/Icons/Cross.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Crown.tsx
+++ b/web/packages/design/src/Icon/Icons/Crown.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Database.tsx
+++ b/web/packages/design/src/Icon/Icons/Database.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Desktop.tsx
+++ b/web/packages/design/src/Icon/Icons/Desktop.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/DeviceMobileCamera.tsx
+++ b/web/packages/design/src/Icon/Icons/DeviceMobileCamera.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Devices.tsx
+++ b/web/packages/design/src/Icon/Icons/Devices.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Download.tsx
+++ b/web/packages/design/src/Icon/Icons/Download.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Earth.tsx
+++ b/web/packages/design/src/Icon/Icons/Earth.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Edit.tsx
+++ b/web/packages/design/src/Icon/Icons/Edit.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Ellipsis.tsx
+++ b/web/packages/design/src/Icon/Icons/Ellipsis.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/EmailSolid.tsx
+++ b/web/packages/design/src/Icon/Icons/EmailSolid.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/EnvelopeOpen.tsx
+++ b/web/packages/design/src/Icon/Icons/EnvelopeOpen.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Equalizer.tsx
+++ b/web/packages/design/src/Icon/Icons/Equalizer.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/EqualizerVertical.tsx
+++ b/web/packages/design/src/Icon/Icons/EqualizerVertical.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/EqualizersVertical.tsx
+++ b/web/packages/design/src/Icon/Icons/EqualizersVertical.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Expand.tsx
+++ b/web/packages/design/src/Icon/Icons/Expand.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Facebook.tsx
+++ b/web/packages/design/src/Icon/Icons/Facebook.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Fingerprint.tsx
+++ b/web/packages/design/src/Icon/Icons/Fingerprint.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/FingerprintSimple.tsx
+++ b/web/packages/design/src/Icon/Icons/FingerprintSimple.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Floppy.tsx
+++ b/web/packages/design/src/Icon/Icons/Floppy.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/FlowArrow.tsx
+++ b/web/packages/design/src/Icon/Icons/FlowArrow.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/FolderPlus.tsx
+++ b/web/packages/design/src/Icon/Icons/FolderPlus.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/FolderShared.tsx
+++ b/web/packages/design/src/Icon/Icons/FolderShared.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/GitHub.tsx
+++ b/web/packages/design/src/Icon/Icons/GitHub.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Google.tsx
+++ b/web/packages/design/src/Icon/Icons/Google.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Graph.tsx
+++ b/web/packages/design/src/Icon/Icons/Graph.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Hashtag.tsx
+++ b/web/packages/design/src/Icon/Icons/Hashtag.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Headset.tsx
+++ b/web/packages/design/src/Icon/Icons/Headset.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Home.tsx
+++ b/web/packages/design/src/Icon/Icons/Home.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Hometemp.tsx
+++ b/web/packages/design/src/Icon/Icons/Hometemp.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { SVGIcon, SVGIconProps } from 'design/SVGIcon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Info.tsx
+++ b/web/packages/design/src/Icon/Icons/Info.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/InfoFilled.tsx
+++ b/web/packages/design/src/Icon/Icons/InfoFilled.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { SVGIcon, SVGIconProps } from 'design/SVGIcon';
 
 export function InfoFilled({ size = 24, fill }: SVGIconProps) {

--- a/web/packages/design/src/Icon/Icons/Integrations.tsx
+++ b/web/packages/design/src/Icon/Icons/Integrations.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Invoices.tsx
+++ b/web/packages/design/src/Icon/Icons/Invoices.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Key.tsx
+++ b/web/packages/design/src/Icon/Icons/Key.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/KeyHole.tsx
+++ b/web/packages/design/src/Icon/Icons/KeyHole.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Keyboard.tsx
+++ b/web/packages/design/src/Icon/Icons/Keyboard.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Keypair.tsx
+++ b/web/packages/design/src/Icon/Icons/Keypair.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Kubernetes.tsx
+++ b/web/packages/design/src/Icon/Icons/Kubernetes.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Label.tsx
+++ b/web/packages/design/src/Icon/Icons/Label.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Lan.tsx
+++ b/web/packages/design/src/Icon/Icons/Lan.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Laptop.tsx
+++ b/web/packages/design/src/Icon/Icons/Laptop.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Layout.tsx
+++ b/web/packages/design/src/Icon/Icons/Layout.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/License.tsx
+++ b/web/packages/design/src/Icon/Icons/License.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/LineSegment.tsx
+++ b/web/packages/design/src/Icon/Icons/LineSegment.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/LineSegments.tsx
+++ b/web/packages/design/src/Icon/Icons/LineSegments.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Link.tsx
+++ b/web/packages/design/src/Icon/Icons/Link.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Linkedin.tsx
+++ b/web/packages/design/src/Icon/Icons/Linkedin.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Linux.tsx
+++ b/web/packages/design/src/Icon/Icons/Linux.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/ListAddCheck.tsx
+++ b/web/packages/design/src/Icon/Icons/ListAddCheck.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/ListMagnifyingGlass.tsx
+++ b/web/packages/design/src/Icon/Icons/ListMagnifyingGlass.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/ListThin.tsx
+++ b/web/packages/design/src/Icon/Icons/ListThin.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/ListView.tsx
+++ b/web/packages/design/src/Icon/Icons/ListView.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Lock.tsx
+++ b/web/packages/design/src/Icon/Icons/Lock.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/LockKey.tsx
+++ b/web/packages/design/src/Icon/Icons/LockKey.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Logout.tsx
+++ b/web/packages/design/src/Icon/Icons/Logout.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Magnifier.tsx
+++ b/web/packages/design/src/Icon/Icons/Magnifier.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/MagnifyingMinus.tsx
+++ b/web/packages/design/src/Icon/Icons/MagnifyingMinus.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/MagnifyingPlus.tsx
+++ b/web/packages/design/src/Icon/Icons/MagnifyingPlus.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Memory.tsx
+++ b/web/packages/design/src/Icon/Icons/Memory.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Minus.tsx
+++ b/web/packages/design/src/Icon/Icons/Minus.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/MobileCamera.tsx
+++ b/web/packages/design/src/Icon/Icons/MobileCamera.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Moon.tsx
+++ b/web/packages/design/src/Icon/Icons/Moon.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/MoreHoriz.tsx
+++ b/web/packages/design/src/Icon/Icons/MoreHoriz.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/MoreVert.tsx
+++ b/web/packages/design/src/Icon/Icons/MoreVert.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Mute.tsx
+++ b/web/packages/design/src/Icon/Icons/Mute.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/NewTab.tsx
+++ b/web/packages/design/src/Icon/Icons/NewTab.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/NoteAdded.tsx
+++ b/web/packages/design/src/Icon/Icons/NoteAdded.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Notification.tsx
+++ b/web/packages/design/src/Icon/Icons/Notification.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/NotificationsActive.tsx
+++ b/web/packages/design/src/Icon/Icons/NotificationsActive.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/PaperPlane.tsx
+++ b/web/packages/design/src/Icon/Icons/PaperPlane.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Password.tsx
+++ b/web/packages/design/src/Icon/Icons/Password.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Pencil.tsx
+++ b/web/packages/design/src/Icon/Icons/Pencil.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Person.tsx
+++ b/web/packages/design/src/Icon/Icons/Person.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/PersonAdd.tsx
+++ b/web/packages/design/src/Icon/Icons/PersonAdd.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Planet.tsx
+++ b/web/packages/design/src/Icon/Icons/Planet.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Plugs.tsx
+++ b/web/packages/design/src/Icon/Icons/Plugs.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/PlugsConnected.tsx
+++ b/web/packages/design/src/Icon/Icons/PlugsConnected.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Plus.tsx
+++ b/web/packages/design/src/Icon/Icons/Plus.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/PowerSwitch.tsx
+++ b/web/packages/design/src/Icon/Icons/PowerSwitch.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Printer.tsx
+++ b/web/packages/design/src/Icon/Icons/Printer.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Profile.tsx
+++ b/web/packages/design/src/Icon/Icons/Profile.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/PushPin.tsx
+++ b/web/packages/design/src/Icon/Icons/PushPin.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/PushPinFilled.tsx
+++ b/web/packages/design/src/Icon/Icons/PushPinFilled.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Question.tsx
+++ b/web/packages/design/src/Icon/Icons/Question.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Refresh.tsx
+++ b/web/packages/design/src/Icon/Icons/Refresh.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Restore.tsx
+++ b/web/packages/design/src/Icon/Icons/Restore.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Rows.tsx
+++ b/web/packages/design/src/Icon/Icons/Rows.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Ruler.tsx
+++ b/web/packages/design/src/Icon/Icons/Ruler.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Run.tsx
+++ b/web/packages/design/src/Icon/Icons/Run.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Scan.tsx
+++ b/web/packages/design/src/Icon/Icons/Scan.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Server.tsx
+++ b/web/packages/design/src/Icon/Icons/Server.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Share.tsx
+++ b/web/packages/design/src/Icon/Icons/Share.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/ShieldCheck.tsx
+++ b/web/packages/design/src/Icon/Icons/ShieldCheck.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/ShieldWarning.tsx
+++ b/web/packages/design/src/Icon/Icons/ShieldWarning.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Sliders.tsx
+++ b/web/packages/design/src/Icon/Icons/Sliders.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/SlidersVertical.tsx
+++ b/web/packages/design/src/Icon/Icons/SlidersVertical.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Speed.tsx
+++ b/web/packages/design/src/Icon/Icons/Speed.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Spinner.tsx
+++ b/web/packages/design/src/Icon/Icons/Spinner.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/SquaresFour.tsx
+++ b/web/packages/design/src/Icon/Icons/SquaresFour.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Stars.tsx
+++ b/web/packages/design/src/Icon/Icons/Stars.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Sun.tsx
+++ b/web/packages/design/src/Icon/Icons/Sun.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/SyncAlt.tsx
+++ b/web/packages/design/src/Icon/Icons/SyncAlt.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Table.tsx
+++ b/web/packages/design/src/Icon/Icons/Table.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Tablet.tsx
+++ b/web/packages/design/src/Icon/Icons/Tablet.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Tags.tsx
+++ b/web/packages/design/src/Icon/Icons/Tags.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Terminal.tsx
+++ b/web/packages/design/src/Icon/Icons/Terminal.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Trash.tsx
+++ b/web/packages/design/src/Icon/Icons/Trash.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Twitter.tsx
+++ b/web/packages/design/src/Icon/Icons/Twitter.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Unarchive.tsx
+++ b/web/packages/design/src/Icon/Icons/Unarchive.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Unlink.tsx
+++ b/web/packages/design/src/Icon/Icons/Unlink.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Unlock.tsx
+++ b/web/packages/design/src/Icon/Icons/Unlock.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Upload.tsx
+++ b/web/packages/design/src/Icon/Icons/Upload.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/UsbDrive.tsx
+++ b/web/packages/design/src/Icon/Icons/UsbDrive.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/User.tsx
+++ b/web/packages/design/src/Icon/Icons/User.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/UserAdd.tsx
+++ b/web/packages/design/src/Icon/Icons/UserAdd.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/UserCircleGear.tsx
+++ b/web/packages/design/src/Icon/Icons/UserCircleGear.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/UserFocus.tsx
+++ b/web/packages/design/src/Icon/Icons/UserFocus.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/UserIdBadge.tsx
+++ b/web/packages/design/src/Icon/Icons/UserIdBadge.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/UserList.tsx
+++ b/web/packages/design/src/Icon/Icons/UserList.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Users.tsx
+++ b/web/packages/design/src/Icon/Icons/Users.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/UsersTriple.tsx
+++ b/web/packages/design/src/Icon/Icons/UsersTriple.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Vault.tsx
+++ b/web/packages/design/src/Icon/Icons/Vault.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/VideoGame.tsx
+++ b/web/packages/design/src/Icon/Icons/VideoGame.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/VolumeUp.tsx
+++ b/web/packages/design/src/Icon/Icons/VolumeUp.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/VpnKey.tsx
+++ b/web/packages/design/src/Icon/Icons/VpnKey.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Wand.tsx
+++ b/web/packages/design/src/Icon/Icons/Wand.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Warning.tsx
+++ b/web/packages/design/src/Icon/Icons/Warning.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/WarningCircle.tsx
+++ b/web/packages/design/src/Icon/Icons/WarningCircle.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Wifi.tsx
+++ b/web/packages/design/src/Icon/Icons/Wifi.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Windows.tsx
+++ b/web/packages/design/src/Icon/Icons/Windows.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Wrench.tsx
+++ b/web/packages/design/src/Icon/Icons/Wrench.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Icon/Icons/Youtube.tsx
+++ b/web/packages/design/src/Icon/Icons/Youtube.tsx
@@ -40,8 +40,6 @@ SOFTWARE.
 
 */
 
-import React from 'react';
-
 import { Icon, IconProps } from '../Icon';
 
 /*

--- a/web/packages/design/src/Image/Image.story.jsx
+++ b/web/packages/design/src/Image/Image.story.jsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import teleportSvg from './../assets/images/enterprise-dark.svg';
 
 import Image from '.';

--- a/web/packages/design/src/Indicator/Indicator.test.tsx
+++ b/web/packages/design/src/Indicator/Indicator.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 
 import { render } from 'design/utils/testing';

--- a/web/packages/design/src/Input/Input.story.tsx
+++ b/web/packages/design/src/Input/Input.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import * as Icon from 'design/Icon';
 import { H2 } from 'design/Text';
 import Flex from 'design/Flex';

--- a/web/packages/design/src/Input/Input.test.tsx
+++ b/web/packages/design/src/Input/Input.test.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { render, screen, theme } from 'design/utils/testing';
 
 import Input from './Input';

--- a/web/packages/design/src/Label/Label.test.jsx
+++ b/web/packages/design/src/Label/Label.test.jsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { render, theme } from 'design/utils/testing';
 
 import Label, { Primary, Secondary, Warning, Danger } from './Label';

--- a/web/packages/design/src/LabelState/LabelState.test.jsx
+++ b/web/packages/design/src/LabelState/LabelState.test.jsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { render, theme } from 'design/utils/testing';
 
 import LabelState, {

--- a/web/packages/design/src/LabelState/LabelState.tsx
+++ b/web/packages/design/src/LabelState/LabelState.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 
 import {

--- a/web/packages/design/src/Link/Link.jsx
+++ b/web/packages/design/src/Link/Link.jsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 
 import { space, color } from 'design/system';

--- a/web/packages/design/src/Mark/Mark.story.tsx
+++ b/web/packages/design/src/Mark/Mark.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import Box from 'design/Box';
 
 import { Mark as M } from './Mark';

--- a/web/packages/design/src/Menu/Menu.jsx
+++ b/web/packages/design/src/Menu/Menu.jsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { createRef } from 'react';
+import { Component, createRef } from 'react';
 import PropTypes from 'prop-types';
 
 import Popover from '../Popover';
@@ -29,7 +29,7 @@ const POSITION = {
   horizontal: 'right',
 };
 
-class Menu extends React.Component {
+class Menu extends Component {
   menuListRef = createRef();
 
   getContentAnchorEl = () => this.menuListRef.current?.firstChild;

--- a/web/packages/design/src/Menu/Menu.story.test.tsx
+++ b/web/packages/design/src/Menu/Menu.story.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 
 import { render } from 'design/utils/testing';

--- a/web/packages/design/src/MultiRowBox/MultiRowBox.story.tsx
+++ b/web/packages/design/src/MultiRowBox/MultiRowBox.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { MultiRowBox, Row, SingleRowBox } from './MultiRowBox';
 
 export default {

--- a/web/packages/design/src/MultiRowBox/MultiRowBox.tsx
+++ b/web/packages/design/src/MultiRowBox/MultiRowBox.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 import styled from 'styled-components';
 

--- a/web/packages/design/src/Pill/Pill.story.tsx
+++ b/web/packages/design/src/Pill/Pill.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Pill } from './Pill';
 
 export default {

--- a/web/packages/design/src/Pill/Pill.test.tsx
+++ b/web/packages/design/src/Pill/Pill.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 
 import { render, fireEvent } from 'design/utils/testing';

--- a/web/packages/design/src/Popover/Popover.story.test.tsx
+++ b/web/packages/design/src/Popover/Popover.story.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 
 import { render, fireEvent } from 'design/utils/testing';

--- a/web/packages/design/src/Popover/Popover.story.tsx
+++ b/web/packages/design/src/Popover/Popover.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState, MouseEvent } from 'react';
+import { Component, useState, MouseEvent } from 'react';
 import styled from 'styled-components';
 
 import { ButtonPrimary, Box, Flex, Text, H2 } from '..';
@@ -47,7 +47,7 @@ type SimplePopoverState = {
   contentMultiplier: number;
 };
 
-class SimplePopover extends React.Component<any, SimplePopoverState> {
+class SimplePopover extends Component<any, SimplePopoverState> {
   btnRef: Element | null = null;
   growContentTimer: ReturnType<typeof setInterval> | undefined;
 
@@ -219,7 +219,7 @@ class SimplePopover extends React.Component<any, SimplePopoverState> {
   }
 }
 
-class MouseOverPopover extends React.Component {
+class MouseOverPopover extends Component {
   state = {
     anchorEl: null,
   };

--- a/web/packages/design/src/RadioButton/RadioButton.story.tsx
+++ b/web/packages/design/src/RadioButton/RadioButton.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import styled from 'styled-components';
 
 import { Flex } from '..';

--- a/web/packages/design/src/RadioGroup/RadioGroup.story.tsx
+++ b/web/packages/design/src/RadioGroup/RadioGroup.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Box, Flex } from 'design';
 
 import { RadioGroup } from './RadioGroup';

--- a/web/packages/design/src/RadioGroup/RadioGroup.tsx
+++ b/web/packages/design/src/RadioGroup/RadioGroup.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 import { FieldRadio } from 'design/FieldRadio';
 

--- a/web/packages/design/src/ResourceIcon/index.tsx
+++ b/web/packages/design/src/ResourceIcon/index.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { ComponentProps } from 'react';
+import { ComponentProps } from 'react';
 import { useTheme } from 'styled-components';
 
 import { Image } from 'design';

--- a/web/packages/design/src/SVGIcon/TeleportGearIcon.tsx
+++ b/web/packages/design/src/SVGIcon/TeleportGearIcon.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { useTheme } from 'styled-components';
 
 import { SVGIcon } from './SVGIcon';

--- a/web/packages/design/src/ShimmerBox/ShimmerBox.story.jsx
+++ b/web/packages/design/src/ShimmerBox/ShimmerBox.story.jsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Box, Flex } from 'design';
 
 import { ShimmerBox } from './ShimmerBox';

--- a/web/packages/design/src/ShimmerBox/ShimmerBox.tsx
+++ b/web/packages/design/src/ShimmerBox/ShimmerBox.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled, { keyframes } from 'styled-components';
 
 import Box, { BoxProps } from 'design/Box';

--- a/web/packages/design/src/SlideTabs/SlideTabs.story.tsx
+++ b/web/packages/design/src/SlideTabs/SlideTabs.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import * as Icon from 'design/Icon';
 import Flex from 'design/Flex';

--- a/web/packages/design/src/SlideTabs/SlideTabs.test.tsx
+++ b/web/packages/design/src/SlideTabs/SlideTabs.test.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { screen } from '@testing-library/react';
 
 import { render, userEvent } from 'design/utils/testing';

--- a/web/packages/design/src/StepSlider/StepHeader.tsx
+++ b/web/packages/design/src/StepSlider/StepHeader.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import Box from 'design/Box';
 import Text, { H2 } from 'design/Text';
 

--- a/web/packages/design/src/StepSlider/StepSlider.story.tsx
+++ b/web/packages/design/src/StepSlider/StepSlider.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import styled from 'styled-components';
 
 import { Box, ButtonLink, ButtonPrimary, Text, Card, H1, H2 } from 'design';

--- a/web/packages/design/src/StepSlider/StepSlider.test.tsx
+++ b/web/packages/design/src/StepSlider/StepSlider.test.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { render, fireEvent, screen } from 'design/utils/testing';
 
 import {

--- a/web/packages/design/src/Text/Text.story.tsx
+++ b/web/packages/design/src/Text/Text.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import Box from 'design/Box';
 
 import Text, { H1, H2, H3, H4, P1, P2 } from '.';

--- a/web/packages/design/src/TextArea/TextArea.story.tsx
+++ b/web/packages/design/src/TextArea/TextArea.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { H2 } from 'design/Text/Text';
 import Flex from 'design/Flex';
 import Box from 'design/Box';

--- a/web/packages/design/src/ThemeProvider/index.tsx
+++ b/web/packages/design/src/ThemeProvider/index.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import {
   WebTarget,
   StyleSheetManager,

--- a/web/packages/design/src/Toggle/Toggle.story.tsx
+++ b/web/packages/design/src/Toggle/Toggle.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import Text from '../Text';
 import Flex from '../Flex';

--- a/web/packages/design/src/Toggle/Toggle.tsx
+++ b/web/packages/design/src/Toggle/Toggle.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import styled from 'styled-components';
 
 export function Toggle({

--- a/web/packages/design/src/Tooltip/IconTooltip.story.tsx
+++ b/web/packages/design/src/Tooltip/IconTooltip.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import styled, { useTheme } from 'styled-components';
 
 import { Text, Flex, ButtonPrimary } from 'design';

--- a/web/packages/design/src/TopNav/TopNav.jsx
+++ b/web/packages/design/src/TopNav/TopNav.jsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import Flex from 'design/Flex';
 
 export default function TopNav(props) {

--- a/web/packages/design/src/TopNav/TopNav.story.jsx
+++ b/web/packages/design/src/TopNav/TopNav.story.jsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import TopNav from './TopNav';
 import TopNavItem from './TopNavItem';
 

--- a/web/packages/design/src/assets/images/Assets.story.tsx
+++ b/web/packages/design/src/assets/images/Assets.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from "react";
-
 import Image from "design/Image";
 import teleportLogo from "design/assets/images/enterprise-light.svg";
 import cloudCity from "design/assets/images/backgrounds/cloud-city.png"

--- a/web/packages/design/src/labels.story.jsx
+++ b/web/packages/design/src/labels.story.jsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import Label from './Label';
 import LabelState from './LabelState';
 import Flex from './Flex';

--- a/web/packages/design/src/theme/palette.story.jsx
+++ b/web/packages/design/src/theme/palette.story.jsx
@@ -18,8 +18,6 @@
 
 /*eslint import/namespace: ['error', { allowComputed: true }]*/
 
-import React from 'react';
-
 import { Flex, Box } from '..';
 
 import * as colors from './palette';

--- a/web/packages/design/src/theme/themeColors.story.tsx
+++ b/web/packages/design/src/theme/themeColors.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { useTheme } from 'styled-components';
 
 import Text, { H1, H2 } from '../Text';

--- a/web/packages/design/src/theme/typography.story.jsx
+++ b/web/packages/design/src/theme/typography.story.jsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Text, Box } from '..';
 
 import typography from './typography';


### PR DESCRIPTION
Contributes to https://github.com/gravitational/teleport/issues/35039
Since we use auto JSX transform, we don't need to import React. I will adjust the eslint rule once all workspaces are converted.

Imports were removed using this codemod https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#removing-unused-react-imports.

Note: When this codemod finds type imports from React namespace (like `React.FC`), it replaces imports from:
```ts
import React from 'react';
```
to 
```ts
import * as React from 'react';
```

I thought it could destructure it to `import { FC } from 'react'` :) But since it can't do it, I reverted these imports back to the original form for simplicity.