### PR TITLE
Remove unused `React` imports from `packages/shared`

### DIFF
--- a/web/packages/shared/components/AccessRequests/AccessDuration/AccessDurationRequest.tsx
+++ b/web/packages/shared/components/AccessRequests/AccessDuration/AccessDurationRequest.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Flex, LabelInput, Text } from 'design';
 
 import { IconTooltip } from 'design/Tooltip';

--- a/web/packages/shared/components/AccessRequests/AccessDuration/AccessDurationReview.tsx
+++ b/web/packages/shared/components/AccessRequests/AccessDuration/AccessDurationReview.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Flex, Text } from 'design';
 
 import { IconTooltip } from 'design/Tooltip';

--- a/web/packages/shared/components/AccessRequests/AssumeStartTime/AssumeStartTime.story.tsx
+++ b/web/packages/shared/components/AccessRequests/AssumeStartTime/AssumeStartTime.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { Box, Text } from 'design';
 

--- a/web/packages/shared/components/AccessRequests/NewRequest/CheckableOption.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/CheckableOption.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Flex, Text } from 'design';
 import { components, OptionProps } from 'react-select';
 

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/AdditionalOptions.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/AdditionalOptions.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Flex, Text, ButtonIcon, Box, LabelInput } from 'design';
 import * as Icon from 'design/Icon';
 

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.story.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { MemoryRouter, Link } from 'react-router-dom';
 
 import { Box, ButtonPrimary, ButtonText } from 'design';

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/SelectReviewers.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/SelectReviewers.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState, useRef } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { components } from 'react-select';
 import ReactSelectCreatable from 'react-select/creatable';
 import styled from 'styled-components';
@@ -40,7 +40,7 @@ export function SelectReviewers({
     () => reviewers.map(r => ({ value: r, label: r, isDisabled: true }))
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     // When editing reviewers, auto focus on input box.
     if (editReviewers) {
       reactSelectRef.current.focus();

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestDelete/RequestDelete.story.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestDelete/RequestDelete.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import {
   makeEmptyAttempt,
   makeProcessingAttempt,

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestDelete/RequestDelete.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestDelete/RequestDelete.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { ButtonWarning, ButtonSecondary, Flex, Alert } from 'design';
 import TextSelectCopy from 'teleport/components/TextSelectCopy';
 

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestReview/RequestReview.story.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestReview/RequestReview.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import {
   makeSuccessAttempt,
   makeEmptyAttempt,

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.story.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import {
   makeSuccessAttempt,
   makeEmptyAttempt,

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { Fragment } from 'react';
 import styled from 'styled-components';
 import {
   Alert,
@@ -617,7 +617,7 @@ function Reviews({ reviews }: { reviews: AccessRequestReview[] }) {
       review;
 
     return (
-      <React.Fragment key={index}>
+      <Fragment key={index}>
         <Timestamp
           author={author}
           state={state}
@@ -632,7 +632,7 @@ function Reviews({ reviews }: { reviews: AccessRequestReview[] }) {
             createdDuration={createdDuration}
           />
         )}
-      </React.Fragment>
+      </Fragment>
     );
   });
 

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RolesRequested.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RolesRequested.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Box, Label } from 'design';
 
 export default function RolesRequested({ roles }: { roles: string[] }) {

--- a/web/packages/shared/components/AccessRequests/Shared/Shared.tsx
+++ b/web/packages/shared/components/AccessRequests/Shared/Shared.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { ButtonPrimary, Text, Box, ButtonIcon, Menu } from 'design';
 import { Info } from 'design/Icon';
 import { displayDateWithPrefixedTime } from 'design/datetime';

--- a/web/packages/shared/components/AdvancedSearchToggle/AdvancedSearchToggle.story.tsx
+++ b/web/packages/shared/components/AdvancedSearchToggle/AdvancedSearchToggle.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { AdvancedSearchToggle } from './AdvancedSearchToggle';
 

--- a/web/packages/shared/components/AdvancedSearchToggle/AdvancedSearchToggle.tsx
+++ b/web/packages/shared/components/AdvancedSearchToggle/AdvancedSearchToggle.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Text, Toggle, Link, Flex, H2 } from 'design';
 
 import { P } from 'design/Text/Text';

--- a/web/packages/shared/components/AnimatedTerminal/AnimatedTerminal.tsx
+++ b/web/packages/shared/components/AnimatedTerminal/AnimatedTerminal.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   KeywordHighlight,

--- a/web/packages/shared/components/AnimatedTerminal/TerminalContent.tsx
+++ b/web/packages/shared/components/AnimatedTerminal/TerminalContent.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useLayoutEffect, useRef } from 'react';
+import { Fragment, useEffect, useLayoutEffect, useRef } from 'react';
 import styled from 'styled-components';
 
 import { BufferEntry } from 'shared/components/AnimatedTerminal/content';
@@ -125,14 +125,14 @@ function renderLines(lines: BufferEntry[], highlights?: KeywordHighlight[]) {
   }
 
   const result = lines.map(line => (
-    <React.Fragment key={line.id}>
+    <Fragment key={line.id}>
       {line.isCommand ? (
         <Prompt>${line.text.length > 0 ? ' ' : ''}</Prompt>
       ) : null}
       {formatText(line.text, line.isCommand, highlights)}
       {line.isCurrent && line.isCommand ? <Cursor /> : null}
       <br />
-    </React.Fragment>
+    </Fragment>
   ));
 
   return result;
@@ -193,7 +193,7 @@ function formatText(
   outer: for (const [index, word] of words.entries()) {
     if (!isCommand && /(https?:\/\/\S+)/g.test(word)) {
       result.push(
-        <React.Fragment key={index}>
+        <Fragment key={index}>
           <a
             key={index}
             style={{ color: '#feaa01', textDecoration: 'underline' }}
@@ -203,7 +203,7 @@ function formatText(
           >
             {word}
           </a>{' '}
-        </React.Fragment>
+        </Fragment>
       );
 
       continue;

--- a/web/packages/shared/components/ButtonSso/ButtonSso.story.tsx
+++ b/web/packages/shared/components/ButtonSso/ButtonSso.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import ButtonSso from './ButtonSso';
 
 export default {

--- a/web/packages/shared/components/ButtonSso/ButtonSso.test.tsx
+++ b/web/packages/shared/components/ButtonSso/ButtonSso.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 
 import { render } from 'design/utils/testing';

--- a/web/packages/shared/components/ButtonSso/ButtonSso.tsx
+++ b/web/packages/shared/components/ButtonSso/ButtonSso.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import * as Icons from 'design/Icon';
 
 import { ButtonProps, ButtonSecondary } from 'design/Button';

--- a/web/packages/shared/components/ButtonTextWithAddIcon/ButtonTextWithAddIcon.story.tsx
+++ b/web/packages/shared/components/ButtonTextWithAddIcon/ButtonTextWithAddIcon.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import Flex from 'design/Flex';
 
 import { ButtonTextWithAddIcon } from './ButtonTextWithAddIcon';

--- a/web/packages/shared/components/ButtonTextWithAddIcon/ButtonTextWithAddIcon.test.tsx
+++ b/web/packages/shared/components/ButtonTextWithAddIcon/ButtonTextWithAddIcon.test.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { render, fireEvent, screen } from 'design/utils/testing';
 
 import { ButtonTextWithAddIcon } from './ButtonTextWithAddIcon';

--- a/web/packages/shared/components/ButtonTextWithAddIcon/ButtonTextWithAddIcon.tsx
+++ b/web/packages/shared/components/ButtonTextWithAddIcon/ButtonTextWithAddIcon.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { ButtonText } from 'design';
 import { Add as AddIcon } from 'design/Icon';
 

--- a/web/packages/shared/components/ClusterDropdown/ClusterDropdown.story.tsx
+++ b/web/packages/shared/components/ClusterDropdown/ClusterDropdown.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 
 import { Cluster } from 'teleport/services/clusters';

--- a/web/packages/shared/components/Controls/ViewModeSwitch.tsx
+++ b/web/packages/shared/components/Controls/ViewModeSwitch.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 import { Rows, SquaresFour } from 'design/Icon';
 

--- a/web/packages/shared/components/DownloadConnect/DownloadConnect.story.tsx
+++ b/web/packages/shared/components/DownloadConnect/DownloadConnect.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Box, Text } from 'design';
 import { Platform } from 'design/platform';
 

--- a/web/packages/shared/components/Editor/Tabs.tsx
+++ b/web/packages/shared/components/Editor/Tabs.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 
 import * as Icons from 'design/Icon';

--- a/web/packages/shared/components/FieldCheckbox/FieldCheckbox.story.tsx
+++ b/web/packages/shared/components/FieldCheckbox/FieldCheckbox.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import Box from 'design/Box';
 
 import { FieldCheckbox } from '.';

--- a/web/packages/shared/components/FieldInput/FieldInput.story.tsx
+++ b/web/packages/shared/components/FieldInput/FieldInput.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { ButtonPrimary, Text } from 'design';
 
 import { EmailSolid } from 'design/Icon';

--- a/web/packages/shared/components/FieldInput/FieldInput.test.tsx
+++ b/web/packages/shared/components/FieldInput/FieldInput.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 
 import { render, fireEvent } from 'design/utils/testing';

--- a/web/packages/shared/components/FieldMultiInput/FieldMultiInput.story.tsx
+++ b/web/packages/shared/components/FieldMultiInput/FieldMultiInput.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import Box from 'design/Box';
 

--- a/web/packages/shared/components/FieldMultiInput/FieldMultiInput.test.tsx
+++ b/web/packages/shared/components/FieldMultiInput/FieldMultiInput.test.tsx
@@ -17,7 +17,7 @@
  */
 
 import userEvent from '@testing-library/user-event';
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { act, render, screen } from 'design/utils/testing';
 

--- a/web/packages/shared/components/FieldSelect/FieldSelect.test.tsx
+++ b/web/packages/shared/components/FieldSelect/FieldSelect.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 
 import { render, fireEvent } from 'design/utils/testing';

--- a/web/packages/shared/components/FieldSelect/FieldSelectCreatable.test.tsx
+++ b/web/packages/shared/components/FieldSelect/FieldSelectCreatable.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 
 import { render } from 'design/utils/testing';

--- a/web/packages/shared/components/FieldTextArea/FieldTextArea.story.tsx
+++ b/web/packages/shared/components/FieldTextArea/FieldTextArea.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { ButtonPrimary, Text } from 'design';
 
 import Validation from '../../components/Validation';

--- a/web/packages/shared/components/FileTransfer/FileTransfer.test.tsx
+++ b/web/packages/shared/components/FileTransfer/FileTransfer.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import {
   act,
   fireEvent,

--- a/web/packages/shared/components/FileTransfer/FileTransfer.tsx
+++ b/web/packages/shared/components/FileTransfer/FileTransfer.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { useFileTransferContext } from './FileTransferContextProvider';
 import {
   FileTransferDialogDirection,

--- a/web/packages/shared/components/FileTransfer/FileTransferActionBar.tsx
+++ b/web/packages/shared/components/FileTransfer/FileTransferActionBar.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Flex, ButtonIcon, Text } from 'design';
 import * as Icons from 'design/Icon';
 import { HoverTooltip } from 'design/Tooltip';

--- a/web/packages/shared/components/FileTransfer/FileTransferContextProvider.tsx
+++ b/web/packages/shared/components/FileTransfer/FileTransferContextProvider.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, {
+import {
   useContext,
   useState,
   FC,

--- a/web/packages/shared/components/FileTransfer/FileTransferRequests.story.tsx
+++ b/web/packages/shared/components/FileTransfer/FileTransferRequests.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import ConsoleContextProvider from 'teleport/Console/consoleContextProvider';
 import ConsoleContext from 'teleport/Console/consoleContext';
 import { FileTransferRequest } from 'teleport/Console/DocumentSsh/useFileTransfer';

--- a/web/packages/shared/components/FileTransfer/FileTransferRequests.tsx
+++ b/web/packages/shared/components/FileTransfer/FileTransferRequests.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 import { ButtonBorder, Box, Flex, Text, Button } from 'design';
 import * as Icons from 'design/Icon';

--- a/web/packages/shared/components/FileTransfer/FileTransferStateless/DownloadForm/DownloadForm.test.tsx
+++ b/web/packages/shared/components/FileTransfer/FileTransferStateless/DownloadForm/DownloadForm.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { fireEvent, render, screen } from 'design/utils/testing';
 
 import { DownloadForm } from './DownloadForm';

--- a/web/packages/shared/components/FileTransfer/FileTransferStateless/DownloadForm/DownloadForm.tsx
+++ b/web/packages/shared/components/FileTransfer/FileTransferStateless/DownloadForm/DownloadForm.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useId, useState } from 'react';
+import { useId, useState } from 'react';
 import { Flex, LabelInput } from 'design';
 import { ButtonPrimary } from 'design/Button';
 

--- a/web/packages/shared/components/FileTransfer/FileTransferStateless/FileList/FileList.test.tsx
+++ b/web/packages/shared/components/FileTransfer/FileTransferStateless/FileList/FileList.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { fireEvent, render, screen } from 'design/utils/testing';
 
 import { TransferredFile } from '../types';

--- a/web/packages/shared/components/FileTransfer/FileTransferStateless/FileList/FileList.tsx
+++ b/web/packages/shared/components/FileTransfer/FileTransferStateless/FileList/FileList.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 
 import { TransferredFile } from '../types';

--- a/web/packages/shared/components/FileTransfer/FileTransferStateless/FileList/FileListItem.tsx
+++ b/web/packages/shared/components/FileTransfer/FileTransferStateless/FileList/FileListItem.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { FC, PropsWithChildren, useEffect } from 'react';
+import { FC, PropsWithChildren, useEffect } from 'react';
 import styled from 'styled-components';
 import { ButtonIcon, Flex, Text } from 'design';
 import { CircleCheck, Cross, Warning } from 'design/Icon';

--- a/web/packages/shared/components/FileTransfer/FileTransferStateless/FileTransferStateless.story.tsx
+++ b/web/packages/shared/components/FileTransfer/FileTransferStateless/FileTransferStateless.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { FileTransferContainer } from '../FileTransferContainer';
 
 import {

--- a/web/packages/shared/components/FileTransfer/FileTransferStateless/FileTransferStateless.tsx
+++ b/web/packages/shared/components/FileTransfer/FileTransferStateless/FileTransferStateless.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 import { ButtonIcon, Flex, Text } from 'design';
 import { Cross as CloseIcon } from 'design/Icon';

--- a/web/packages/shared/components/FileTransfer/FileTransferStateless/UploadForm/UploadForm.test.tsx
+++ b/web/packages/shared/components/FileTransfer/FileTransferStateless/UploadForm/UploadForm.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { fireEvent, render, screen } from 'design/utils/testing';
 
 import { UploadForm } from './UploadForm';

--- a/web/packages/shared/components/Highlight/Highlight.story.tsx
+++ b/web/packages/shared/components/Highlight/Highlight.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 import { Flex, Text } from 'design';
 

--- a/web/packages/shared/components/Highlight/Highlight.tsx
+++ b/web/packages/shared/components/Highlight/Highlight.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { findAll } from 'highlight-words-core';
 
 /**

--- a/web/packages/shared/components/MenuAction/MenuAction.story.tsx
+++ b/web/packages/shared/components/MenuAction/MenuAction.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Flex } from 'design';
 import { Cog } from 'design/Icon';
 

--- a/web/packages/shared/components/MenuAction/MenuAction.test.tsx
+++ b/web/packages/shared/components/MenuAction/MenuAction.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 
 import { render, fireEvent } from 'design/utils/testing';

--- a/web/packages/shared/components/MenuLogin/MenuLogin.test.tsx
+++ b/web/packages/shared/components/MenuLogin/MenuLogin.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { render, fireEvent, screen, waitFor } from 'design/utils/testing';
 
 import { MenuLogin } from './MenuLogin';

--- a/web/packages/shared/components/Notification/Notification.story.tsx
+++ b/web/packages/shared/components/Notification/Notification.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Bots } from 'design/Icon';
 import Flex from 'design/Flex';
 

--- a/web/packages/shared/components/Search/SearchPagination.tsx
+++ b/web/packages/shared/components/Search/SearchPagination.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Flex } from 'design';
 import { StyledPanel } from 'design/DataTable/StyledTable';
 import { StyledArrowBtn } from 'design/DataTable/Pager/StyledPager';

--- a/web/packages/shared/components/Search/SearchPanel.tsx
+++ b/web/packages/shared/components/Search/SearchPanel.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { Flex } from 'design';
 import InputSearch from 'design/DataTable/InputSearch';

--- a/web/packages/shared/components/Select/Select.tsx
+++ b/web/packages/shared/components/Select/Select.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import ReactSelect, {
   ClearIndicatorProps,
   DropdownIndicatorProps,

--- a/web/packages/shared/components/Select/SelectCreatable.story.tsx
+++ b/web/packages/shared/components/Select/SelectCreatable.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { useState } from 'react';
 import { Flex, Box } from 'design';
 
 import { SelectCreatable, Option } from '../Select';
@@ -26,10 +26,10 @@ export default {
 };
 
 export const Selects = () => {
-  const [input, setInput] = React.useState('');
-  const [inputMulti, setInputMulti] = React.useState('');
-  const [selected, setSelected] = React.useState<Option>();
-  const [selectedMulti, setSelectedMulti] = React.useState<readonly Option[]>();
+  const [input, setInput] = useState('');
+  const [inputMulti, setInputMulti] = useState('');
+  const [selected, setSelected] = useState<Option>();
+  const [selectedMulti, setSelectedMulti] = useState<readonly Option[]>();
 
   return (
     // Note that these examples don't provide for great UX. Implementations

--- a/web/packages/shared/components/TextEditor/TextEditor.jsx
+++ b/web/packages/shared/components/TextEditor/TextEditor.jsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { Component } from 'react';
 import styled from 'styled-components';
 import ace from 'ace-builds/src-min-noconflict/ace';
 
@@ -34,7 +34,7 @@ import StyledTextEditor from './StyledTextEditor';
 
 const { UndoManager } = ace.require('ace/undomanager');
 
-class TextEditor extends React.Component {
+class TextEditor extends Component {
   onChange = () => {
     const isClean = this.editor.session.getUndoManager().isClean();
     if (this.props.onDirty) {

--- a/web/packages/shared/components/TextEditor/TextEditor.story.tsx
+++ b/web/packages/shared/components/TextEditor/TextEditor.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import Flex from 'design/Flex';
 
 import TextEditor from './TextEditor';

--- a/web/packages/shared/components/TextEditor/TextEditor.test.tsx
+++ b/web/packages/shared/components/TextEditor/TextEditor.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { render, userEvent, screen } from 'design/utils/testing';
 import * as copyModule from 'design/utils/copyToClipboard';
 

--- a/web/packages/shared/components/TextSelectCopy/TextSelectCopy.story.tsx
+++ b/web/packages/shared/components/TextSelectCopy/TextSelectCopy.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { TextSelectCopy as Component } from './TextSelectCopy';
 
 export default {

--- a/web/packages/shared/components/TextSelectCopy/TextSelectCopyMulti.story.tsx
+++ b/web/packages/shared/components/TextSelectCopy/TextSelectCopyMulti.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { TextSelectCopyMulti as Component } from './TextSelectCopyMulti';
 
 export default {

--- a/web/packages/shared/components/TextSelectCopy/TextSelectCopyMulti.test.tsx
+++ b/web/packages/shared/components/TextSelectCopy/TextSelectCopyMulti.test.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { render, screen, userEvent } from 'design/utils/testing';
 
 import { TextSelectCopyMulti } from './TextSelectCopyMulti';

--- a/web/packages/shared/components/TextSelectCopy/TextSelectCopyMulti.tsx
+++ b/web/packages/shared/components/TextSelectCopy/TextSelectCopyMulti.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 import styled from 'styled-components';
 
 import { copyToClipboard } from 'design/utils/copyToClipboard';

--- a/web/packages/shared/components/UnifiedResources/CardsView/CardsView.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/CardsView.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 
 import { Flex } from 'design';

--- a/web/packages/shared/components/UnifiedResources/CardsView/LoadingCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/LoadingCard.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Flex, Box } from 'design';
 import { ShimmerBox } from 'design/ShimmerBox';
 

--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 
 import styled from 'styled-components';

--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState, useEffect, useLayoutEffect, useRef } from 'react';
+import { useState, useEffect, useLayoutEffect, useRef } from 'react';
 import styled, { css } from 'styled-components';
 
 import { Box, ButtonLink, Flex, Label, Text } from 'design';

--- a/web/packages/shared/components/UnifiedResources/ListView/ListView.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ListView.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Flex } from 'design';
 
 import { ResourceViewProps } from '../types';

--- a/web/packages/shared/components/UnifiedResources/ListView/LoadingListItem.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/LoadingListItem.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import styled from 'styled-components';
 
 import { Box, Flex } from 'design';

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 
 import { ButtonBorder, Flex } from 'design';

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { Box, ButtonIcon, Flex, Label, Text } from 'design';

--- a/web/packages/shared/components/UnifiedResources/ResourceTab.tsx
+++ b/web/packages/shared/components/UnifiedResources/ResourceTab.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 import { Box, Text } from 'design';
 

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { ButtonBorder } from 'design';
 

--- a/web/packages/shared/components/UnifiedResources/shared/CopyButton.tsx
+++ b/web/packages/shared/components/UnifiedResources/shared/CopyButton.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect } from 'react';
 
 import ButtonIcon from 'design/ButtonIcon';
 import { Check, Copy } from 'design/Icon';

--- a/web/packages/shared/components/UnifiedResources/shared/LoadingSkeleton.tsx
+++ b/web/packages/shared/components/UnifiedResources/shared/LoadingSkeleton.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState, useEffect, Fragment, ReactElement } from 'react';
+import { useState, useEffect, Fragment, ReactElement } from 'react';
 
 const DISPLAY_SKELETON_AFTER_MS = 150;
 

--- a/web/packages/shared/components/UnifiedResources/shared/PinButton.tsx
+++ b/web/packages/shared/components/UnifiedResources/shared/PinButton.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 
 import { PushPinFilled, PushPin } from 'design/Icon';
 import ButtonIcon from 'design/ButtonIcon';

--- a/web/packages/shared/components/Validation/Validation.test.tsx
+++ b/web/packages/shared/components/Validation/Validation.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { render, fireEvent, screen, act } from 'design/utils/testing';
 
 import Validator, { Result, Validation, useValidation } from './Validation';

--- a/web/packages/shared/components/Validation/useRule.js
+++ b/web/packages/shared/components/Validation/useRule.js
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { useState, useEffect } from 'react';
 
 import Logger from '../../libs/logger';
 
@@ -33,11 +33,11 @@ export default function useRule(cb) {
     return;
   }
 
-  const [, rerender] = React.useState();
+  const [, rerender] = useState();
   const validator = useValidation();
 
   // register to validation context to be called on cb()
-  React.useEffect(() => {
+  useEffect(() => {
     function onValidate() {
       if (validator.state.validating) {
         const result = cb();

--- a/web/packages/shared/components/Validation/useRule.test.js
+++ b/web/packages/shared/components/Validation/useRule.test.js
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { render, fireEvent, screen } from 'design/utils/testing';
 
 import Validation, { useRule } from '.';

--- a/web/packages/shared/components/Window/WindowTitleBar.tsx
+++ b/web/packages/shared/components/Window/WindowTitleBar.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import {
   WindowTitleBarButton,
   WindowTitleBarButtons,

--- a/web/packages/shared/hooks/useAttempt.ts
+++ b/web/packages/shared/hooks/useAttempt.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { useState, useMemo } from 'react';
 
 import Logger from 'shared/libs/logger';
 const logger = Logger.create('shared/hooks/useAttempt');
@@ -31,11 +31,11 @@ const defaultState = {
 export default function useAttempt(
   initialState: Partial<State>
 ): [State, Actions] {
-  const [attempt, setState] = React.useState(() => ({
+  const [attempt, setState] = useState(() => ({
     ...defaultState,
     ...initialState,
   }));
-  const actions = React.useMemo(() => makeActions(setState), [setState]);
+  const actions = useMemo(() => makeActions(setState), [setState]);
   return [attempt, actions];
 }
 

--- a/web/packages/shared/hooks/useAttemptNext.ts
+++ b/web/packages/shared/hooks/useAttemptNext.ts
@@ -16,14 +16,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback } from 'react';
+import { useState, useCallback } from 'react';
 
 import Logger from 'shared/libs/logger';
 const logger = Logger.create('shared/hooks/useAttempt');
 
 // This is the next version of existing useAttempt hook
 export default function useAttemptNext(status = '' as Attempt['status']) {
-  const [attempt, setAttempt] = React.useState<Attempt>(() => ({
+  const [attempt, setAttempt] = useState<Attempt>(() => ({
     status,
     statusText: '',
   }));

--- a/web/packages/shared/hooks/useInfiniteScroll/useInfiniteScroll.test.tsx
+++ b/web/packages/shared/hooks/useInfiniteScroll/useInfiniteScroll.test.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { renderHook, act } from '@testing-library/react';
 import { render, screen } from 'design/utils/testing';
 import { mockIntersectionObserver } from 'jsdom-testing-mocks';

--- a/web/packages/shared/hooks/useRefAutoFocus/useRefAutoFocus.test.tsx
+++ b/web/packages/shared/hooks/useRefAutoFocus/useRefAutoFocus.test.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { DependencyList } from 'react';
+import { DependencyList } from 'react';
 
 import { render } from 'design/utils/testing';
 

--- a/web/packages/shared/hooks/useRefClickOutside/useRefClickOutside.test.tsx
+++ b/web/packages/shared/hooks/useRefClickOutside/useRefClickOutside.test.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { render, screen, fireEvent } from 'design/utils/testing';
 

--- a/web/packages/shared/libs/mergeRefs.test.tsx
+++ b/web/packages/shared/libs/mergeRefs.test.tsx
@@ -20,14 +20,14 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. */
 
-import * as React from 'react';
+import React, { useImperativeHandle, forwardRef } from 'react';
 import { render } from '@testing-library/react';
 
 import { mergeRefs } from './mergeRefs';
 
 test('mergeRefs', () => {
-  const Dummy = React.forwardRef(function Dummy(_, ref) {
-    React.useImperativeHandle(ref, () => 'refValue');
+  const Dummy = forwardRef(function Dummy(_, ref) {
+    useImperativeHandle(ref, () => 'refValue');
     return null;
   });
   const refAsFunc = jest.fn();
@@ -46,8 +46,8 @@ test('mergeRefs', () => {
 });
 
 test('mergeRefs with undefined and null refs', () => {
-  const Dummy = React.forwardRef(function Dummy(_, ref) {
-    React.useImperativeHandle(ref, () => 'refValue');
+  const Dummy = forwardRef(function Dummy(_, ref) {
+    useImperativeHandle(ref, () => 'refValue');
     return null;
   });
   const refAsFunc = jest.fn();

--- a/web/packages/shared/libs/stores/useStore.test.tsx
+++ b/web/packages/shared/libs/stores/useStore.test.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { act, render } from 'design/utils/testing';
 
 import useStore from './useStore';

--- a/web/packages/shared/libs/stores/useStore.ts
+++ b/web/packages/shared/libs/stores/useStore.ts
@@ -16,17 +16,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { useState, useMemo, useEffect } from 'react';
 
 import Store from './store';
 
 // This is the primary method to subscribe to store updates
 // using React hooks mechanism.
 export default function useStore<T extends Store<any>>(store: T): T {
-  const [, rerender] = React.useState<any>();
-  const memoizedState = React.useMemo(() => store.state, [store.state]);
+  const [, rerender] = useState<any>();
+  const memoizedState = useMemo(() => store.state, [store.state]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     function syncState() {
       // do not re-render if state has not changed since last call
       if (memoizedState !== store.state) {


### PR DESCRIPTION
The next part of https://github.com/gravitational/teleport/pull/50200.