### PR TITLE
Remove unused `React` imports from `packages/teleterm`

### DIFF
--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/AssumedRolesBar.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/AssumedRolesBar.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 import { Box, Flex, Text } from 'design';
 import { pluralize } from 'shared/utils/text';

--- a/web/packages/teleterm/src/ui/AppInitializer/AppInitializer.tsx
+++ b/web/packages/teleterm/src/ui/AppInitializer/AppInitializer.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { Indicator } from 'design';
 

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterAdd/ClusterAdd.story.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterAdd/ClusterAdd.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { PropsWithChildren } from 'react';
+import { PropsWithChildren } from 'react';
 
 import Dialog from 'design/Dialog';
 

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/FormPasswordless/FormPasswordless.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/FormPasswordless/FormPasswordless.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 import { Text, Flex, ButtonText, Box } from 'design';
 import { Key, ArrowForward } from 'design/Icon';

--- a/web/packages/teleterm/src/ui/ClusterLogout/ClusterLogout.story.tsx
+++ b/web/packages/teleterm/src/ui/ClusterLogout/ClusterLogout.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 
 import { ClusterLogout } from './ClusterLogout';

--- a/web/packages/teleterm/src/ui/ClusterLogout/ClusterLogout.tsx
+++ b/web/packages/teleterm/src/ui/ClusterLogout/ClusterLogout.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import DialogConfirmation, {
   DialogContent,
   DialogFooter,

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/CompatibilityPromise.test.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/CompatibilityPromise.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { render } from 'design/utils/testing';
 

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/CompatibilityPromise.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/CompatibilityPromise.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Text, ButtonPrimary, Alert, Flex } from 'design';
 import Link from 'design/Link';
 

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/DocumentConnectMyComputer.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/DocumentConnectMyComputer.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 
 import Indicator from 'design/Indicator';
 

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Setup.story.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Setup.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useRef, useLayoutEffect } from 'react';
+import { useEffect, useRef, useLayoutEffect } from 'react';
 
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Setup.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Setup.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { Box, ButtonPrimary, Flex, Text, Alert, H1 } from 'design';
 import { Attempt, makeEmptyAttempt, useAsync } from 'shared/hooks/useAsync';

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Status.story.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Status.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useLayoutEffect } from 'react';
+import { useLayoutEffect } from 'react';
 
 import {
   makeRootCluster,

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/Logs.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/Logs.tsx
@@ -17,7 +17,6 @@
  */
 
 import { Flex, Text } from 'design';
-import React from 'react';
 
 interface LogsProps {
   logs: string;

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/NavigationMenu.story.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/NavigationMenu.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useRef, useLayoutEffect } from 'react';
+import { useEffect, useRef, useLayoutEffect } from 'react';
 
 import { MockWorkspaceContextProvider } from 'teleterm/ui/fixtures/MockWorkspaceContextProvider';
 import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/NavigationMenu.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/NavigationMenu.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { forwardRef, useRef, useState } from 'react';
+import { forwardRef, useRef, useState } from 'react';
 import styled, { css } from 'styled-components';
 import { Box, Button, Indicator, Menu, MenuItem, blink } from 'design';
 import { Laptop, Warning } from 'design/Icon';

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/UpgradeAgentSuggestion.test.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/UpgradeAgentSuggestion.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { render } from 'design/utils/testing';
 import { screen } from '@testing-library/react';
 

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/UpgradeAgentSuggestion.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/UpgradeAgentSuggestion.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Alert, Text } from 'design';
 import Link from 'design/Link';
 

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/DocumentAccessRequests.tsx
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/DocumentAccessRequests.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Attempt } from 'shared/hooks/useAsync';
 
 import { AccessRequest } from 'shared/services/accessRequests';

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/RequestList/RequestList.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/RequestList/RequestList.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { fireEvent, render, screen } from 'design/utils/testing';
 

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/RequestList/RequestList.tsx
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/RequestList/RequestList.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 
 import { Label, Alert, ButtonBorder, Flex, ButtonPrimary, Box } from 'design';

--- a/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import styled from 'styled-components';
 
 import AppContextProvider from 'teleterm/ui/appContextProvider';

--- a/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { act } from '@testing-library/react';
 import { render, screen } from 'design/utils/testing';
 import { mockIntersectionObserver } from 'jsdom-testing-mocks';

--- a/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import styled from 'styled-components';
 import { Box, ButtonPrimary, Flex, Text, Alert, H2 } from 'design';
 import { useAsync, Attempt } from 'shared/hooks/useAsync';

--- a/web/packages/teleterm/src/ui/DocumentCluster/resourcesContext.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/resourcesContext.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { renderHook } from '@testing-library/react';
 
 import { rootClusterUri } from 'teleterm/services/tshd/testHelpers';

--- a/web/packages/teleterm/src/ui/DocumentGateway/CliCommand.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGateway/CliCommand.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Box, ButtonPrimary, Flex, Indicator } from 'design';
 import { fade } from 'design/theme/utils/colorManipulator';
 import styled from 'styled-components';

--- a/web/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import {
   makeEmptyAttempt,
   makeProcessingAttempt,

--- a/web/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import Document from 'teleterm/ui/Document';
 import * as types from 'teleterm/ui/services/workspacesService';
 

--- a/web/packages/teleterm/src/ui/DocumentGateway/OnlineDocumentGateway.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGateway/OnlineDocumentGateway.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useMemo, useRef } from 'react';
+import { useMemo, useRef } from 'react';
 import { debounce } from 'shared/utils/highbar';
 import { Box, ButtonSecondary, Flex, H1, H2, Link, Text } from 'design';
 import Validation from 'shared/components/Validation';

--- a/web/packages/teleterm/src/ui/DocumentGateway/useDocumentGateway.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGateway/useDocumentGateway.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { renderHook, act, waitFor } from '@testing-library/react';
 
 import {

--- a/web/packages/teleterm/src/ui/DocumentGatewayApp/DocumentGatewayApp.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGatewayApp/DocumentGatewayApp.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { wait } from 'shared/utils/wait';
 
 import { DocumentGatewayApp } from 'teleterm/ui/DocumentGatewayApp/DocumentGatewayApp';

--- a/web/packages/teleterm/src/ui/DocumentGatewayCliClient/DocumentGatewayCliClient.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGatewayCliClient/DocumentGatewayCliClient.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { DocumentGatewayCliClient } from 'teleterm/ui/services/workspacesService';
 
 import { WaitingForGatewayContent } from './DocumentGatewayCliClient';

--- a/web/packages/teleterm/src/ui/DocumentGatewayCliClient/DocumentGatewayCliClient.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGatewayCliClient/DocumentGatewayCliClient.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { Flex, Text, ButtonPrimary } from 'design';
 

--- a/web/packages/teleterm/src/ui/DocumentGatewayKube/DocumentGatewayKube.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGatewayKube/DocumentGatewayKube.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import * as types from 'teleterm/ui/services/workspacesService';
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';

--- a/web/packages/teleterm/src/ui/DocumentGatewayKube/DocumentGatewayKube.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGatewayKube/DocumentGatewayKube.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 import { useAsync } from 'shared/hooks/useAsync';
 

--- a/web/packages/teleterm/src/ui/DocumentTerminal/DocumentTerminal.tsx
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/DocumentTerminal.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import {
   FileTransferActionBar,
   FileTransfer,

--- a/web/packages/teleterm/src/ui/DocumentTerminal/Reconnect.tsx
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/Reconnect.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Flex, Text, ButtonPrimary } from 'design';
 import { Danger } from 'design/Alert';
 import { Attempt } from 'shared/hooks/useAsync';

--- a/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
 import 'jest-canvas-mock';
 

--- a/web/packages/teleterm/src/ui/Documents/KeyboardShortcutsPanel.tsx
+++ b/web/packages/teleterm/src/ui/Documents/KeyboardShortcutsPanel.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Text } from 'design';
 
 import styled from 'styled-components';

--- a/web/packages/teleterm/src/ui/DocumentsReopen/DocumentsReopen.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentsReopen/DocumentsReopen.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 
 import { DocumentsReopen } from './DocumentsReopen';

--- a/web/packages/teleterm/src/ui/DocumentsReopen/DocumentsReopen.tsx
+++ b/web/packages/teleterm/src/ui/DocumentsReopen/DocumentsReopen.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import DialogConfirmation, {
   DialogContent,
   DialogFooter,

--- a/web/packages/teleterm/src/ui/HeadlessAuthn/HeadlessAuthentication.tsx
+++ b/web/packages/teleterm/src/ui/HeadlessAuthn/HeadlessAuthentication.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useRef, useEffect } from 'react';
+import { useRef, useEffect } from 'react';
 
 import { useAsync } from 'shared/hooks/useAsync';
 

--- a/web/packages/teleterm/src/ui/HeadlessAuthn/HeadlessPrompt/HeadlessPrompt.story.tsx
+++ b/web/packages/teleterm/src/ui/HeadlessAuthn/HeadlessPrompt/HeadlessPrompt.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { makeEmptyAttempt } from 'shared/hooks/useAsync';
 
 import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';

--- a/web/packages/teleterm/src/ui/HeadlessAuthn/HeadlessPrompt/HeadlessPrompt.tsx
+++ b/web/packages/teleterm/src/ui/HeadlessAuthn/HeadlessPrompt/HeadlessPrompt.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import * as Alerts from 'design/Alert';
 import {
   ButtonIcon,

--- a/web/packages/teleterm/src/ui/LayoutManager.tsx
+++ b/web/packages/teleterm/src/ui/LayoutManager.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 import { Flex } from 'design';
 
 import { AccessRequestCheckout } from 'teleterm/ui/AccessRequestCheckout';

--- a/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.story.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import {

--- a/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.test.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { render, screen } from 'design/utils/testing';
 import { act } from '@testing-library/react';
 

--- a/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { Fragment } from 'react';
+import { Fragment } from 'react';
 
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/UsageData/UsageData.story.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/UsageData/UsageData.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { UsageData } from './UsageData';
 
 export default {

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/UsageData/UsageData.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/UsageData/UsageData.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import DialogConfirmation, {
   DialogContent,
   DialogFooter,

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/UserJobRole/UserJobRole.story.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/UserJobRole/UserJobRole.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { UserJobRole } from './UserJobRole';
 
 export default {

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/UserJobRole/UserJobRole.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/UserJobRole/UserJobRole.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import styled from 'styled-components';
 import { ButtonIcon, ButtonPrimary, ButtonSecondary, H2, Input } from 'design';
 import DialogConfirmation, {

--- a/web/packages/teleterm/src/ui/Search/ResourceSearchErrors.story.tsx
+++ b/web/packages/teleterm/src/ui/Search/ResourceSearchErrors.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { routing } from 'teleterm/ui/uri';
 import { ResourceSearchError } from 'teleterm/ui/services/resources';
 

--- a/web/packages/teleterm/src/ui/Search/ResourceSearchErrors.tsx
+++ b/web/packages/teleterm/src/ui/Search/ResourceSearchErrors.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import DialogConfirmation, {
   DialogContent,
   DialogFooter,

--- a/web/packages/teleterm/src/ui/Search/SearchBar.test.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchBar.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, screen, waitFor, act } from 'design/utils/testing';
 import { makeSuccessAttempt } from 'shared/hooks/useAsync';

--- a/web/packages/teleterm/src/ui/Search/SearchContext.test.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchContext.test.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { PropsWithChildren } from 'react';
+import { PropsWithChildren } from 'react';
 import '@testing-library/jest-dom';
 import { fireEvent, createEvent, render, screen } from '@testing-library/react';
 import { renderHook, act } from '@testing-library/react';

--- a/web/packages/teleterm/src/ui/Search/SearchContext.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchContext.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, {
+import {
   useContext,
   useState,
   FC,

--- a/web/packages/teleterm/src/ui/Search/pickers/ParameterPicker.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ParameterPicker.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { ReactElement, useCallback, useEffect } from 'react';
+import { ReactElement, useCallback, useEffect } from 'react';
 import { Highlight } from 'shared/components/Highlight';
 import {
   makeSuccessAttempt,

--- a/web/packages/teleterm/src/ui/Search/pickers/results.story.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/results.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { makeSuccessAttempt } from 'shared/hooks/useAsync';
 
 import { Flex } from 'design';

--- a/web/packages/teleterm/src/ui/Search/pickers/useDisplayResults.test.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/useDisplayResults.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { renderHook } from '@testing-library/react';
 
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';

--- a/web/packages/teleterm/src/ui/Search/useSearch.test.tsx
+++ b/web/packages/teleterm/src/ui/Search/useSearch.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { renderHook } from '@testing-library/react';
 
 import { ShowResources } from 'gen-proto-ts/teleport/lib/teleterm/v1/cluster_pb';

--- a/web/packages/teleterm/src/ui/StatusBar/AccessRequestCheckoutButton.tsx
+++ b/web/packages/teleterm/src/ui/StatusBar/AccessRequestCheckoutButton.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { ButtonPrimary, Text } from 'design';
 import { ListAddCheck } from 'design/Icon';
 

--- a/web/packages/teleterm/src/ui/StatusBar/ShareFeedback/ShareFeedback.tsx
+++ b/web/packages/teleterm/src/ui/StatusBar/ShareFeedback/ShareFeedback.tsx
@@ -18,7 +18,7 @@
 
 import { ButtonIcon, Popover } from 'design';
 import { ChatBubble } from 'design/Icon';
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 import styled from 'styled-components';
 
 import { ShareFeedbackForm } from './ShareFeedbackForm';

--- a/web/packages/teleterm/src/ui/StatusBar/ShareFeedback/ShareFeedbackForm.tsx
+++ b/web/packages/teleterm/src/ui/StatusBar/ShareFeedback/ShareFeedbackForm.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { ButtonIcon, ButtonPrimary, Flex, H2, Link } from 'design';
 import Validation from 'shared/components/Validation';
 import { Cross } from 'design/Icon';

--- a/web/packages/teleterm/src/ui/StatusBar/ShareFeedback/ShareFeedbackFormFields.tsx
+++ b/web/packages/teleterm/src/ui/StatusBar/ShareFeedback/ShareFeedbackFormFields.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import FieldInput from 'shared/components/FieldInput';
 import { requiredField } from 'shared/components/Validation/rules';
 import { FieldTextArea } from 'shared/components/FieldTextArea';

--- a/web/packages/teleterm/src/ui/StatusBar/StatusBar.tsx
+++ b/web/packages/teleterm/src/ui/StatusBar/StatusBar.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Flex, Text } from 'design';
 
 import { useActiveDocumentClusterBreadcrumbs } from './useActiveDocumentClusterBreadcrumbs';

--- a/web/packages/teleterm/src/ui/TabHost/ClusterConnectPanel/ClusterConnectPanel.tsx
+++ b/web/packages/teleterm/src/ui/TabHost/ClusterConnectPanel/ClusterConnectPanel.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Box, ButtonPrimary, Flex, H1, ResourceIcon, Text } from 'design';
 import styled from 'styled-components';
 

--- a/web/packages/teleterm/src/ui/TabHost/ClusterConnectPanel/RecentClusters.tsx
+++ b/web/packages/teleterm/src/ui/TabHost/ClusterConnectPanel/RecentClusters.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Box, ButtonBorder, Card, Text, Flex } from 'design';
 
 import { useAppContext } from 'teleterm/ui/appContextProvider';

--- a/web/packages/teleterm/src/ui/Tabs/TabItem.tsx
+++ b/web/packages/teleterm/src/ui/Tabs/TabItem.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 import styled from 'styled-components';
 import * as Icons from 'design/Icon';
 import { ButtonIcon, Text } from 'design';

--- a/web/packages/teleterm/src/ui/Tabs/Tabs.tsx
+++ b/web/packages/teleterm/src/ui/Tabs/Tabs.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 import { typography } from 'design/system';
 import { Box } from 'design';

--- a/web/packages/teleterm/src/ui/TopBar/AdditionalActions.story.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/AdditionalActions.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import * as icons from 'design/Icon';
 
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';

--- a/web/packages/teleterm/src/ui/TopBar/Clusters/ClusterSelector/ClusterSelector.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Clusters/ClusterSelector/ClusterSelector.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import { ChevronUp, ChevronDown } from 'design/Icon';
 import styled from 'styled-components';
 import { Text } from 'design';

--- a/web/packages/teleterm/src/ui/TopBar/Clusters/Clusters.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Clusters/Clusters.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import Popover from 'design/Popover';
 import styled from 'styled-components';
 import { Box } from 'design';

--- a/web/packages/teleterm/src/ui/TopBar/Clusters/ClustersFilterableList/ClustersFilterableList.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Clusters/ClustersFilterableList/ClustersFilterableList.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Box, Text } from 'design';
 
 import { FilterableList } from 'teleterm/ui/components/FilterableList';

--- a/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsIcon/ConnectionsIcon.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsIcon/ConnectionsIcon.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import { Cluster } from 'design/Icon';
 import styled from 'styled-components';
 import { ButtonSecondary } from 'design';

--- a/web/packages/teleterm/src/ui/TopBar/Identity/EmptyIdentityList/EmptyIdentityList.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Identity/EmptyIdentityList/EmptyIdentityList.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { ButtonPrimary, Flex, ResourceIcon, Text } from 'design';
 
 interface EmptyIdentityListProps {

--- a/web/packages/teleterm/src/ui/TopBar/Identity/Identity.story.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Identity/Identity.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useRef, useEffect } from 'react';
+import { useRef, useEffect } from 'react';
 import Flex from 'design/Flex';
 import { TrustedDeviceRequirement } from 'gen-proto-ts/teleport/legacy/types/trusted_device_requirement_pb';
 

--- a/web/packages/teleterm/src/ui/TopBar/Identity/Identity.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Identity/Identity.tsx
@@ -16,7 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, {
+import {
+  forwardRef,
   useCallback,
   useMemo,
   useRef,
@@ -91,7 +92,7 @@ export type IdentityProps = {
   makeTitle: (userWithClusterName: string | undefined) => string;
 };
 
-export const Identity = React.forwardRef<IdentityHandler, IdentityProps>(
+export const Identity = forwardRef<IdentityHandler, IdentityProps>(
   (
     {
       activeRootCluster,

--- a/web/packages/teleterm/src/ui/TopBar/Identity/IdentityList/AddNewClusterItem.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Identity/IdentityList/AddNewClusterItem.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Add } from 'design/Icon';
 
 import styled from 'styled-components';

--- a/web/packages/teleterm/src/ui/TopBar/Identity/IdentitySelector/IdentitySelector.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Identity/IdentitySelector/IdentitySelector.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import { Box } from 'design';
 
 import { getUserWithClusterName } from 'teleterm/ui/utils';

--- a/web/packages/teleterm/src/ui/TopBar/Identity/IdentitySelector/PamIcon.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Identity/IdentitySelector/PamIcon.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 import { Image } from 'design';
 

--- a/web/packages/teleterm/src/ui/TopBar/Identity/IdentitySelector/UserIcon.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Identity/IdentitySelector/UserIcon.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 
 interface UserIconProps {

--- a/web/packages/teleterm/src/ui/components/CatchError/CatchError.jsx
+++ b/web/packages/teleterm/src/ui/components/CatchError/CatchError.jsx
@@ -16,14 +16,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { Component } from 'react';
 
 import { UnhandledCaseError } from 'shared/utils/assertUnreachable';
 
 import { FailedApp } from 'teleterm/ui/components/App';
 import Logger from 'teleterm/logger';
 
-export class CatchError extends React.Component {
+export class CatchError extends Component {
   logger = new Logger('CatchError');
 
   static getDerivedStateFromError(error) {

--- a/web/packages/teleterm/src/ui/components/FieldInputs.tsx
+++ b/web/packages/teleterm/src/ui/components/FieldInputs.tsx
@@ -18,7 +18,7 @@
 
 import FieldInput from 'shared/components/FieldInput';
 import styled from 'styled-components';
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import { FieldInputProps } from 'shared/components/FieldInput';
 
 export const ConfigFieldInput = forwardRef<HTMLInputElement, FieldInputProps>(

--- a/web/packages/teleterm/src/ui/components/FilterableList/FilterableList.test.tsx
+++ b/web/packages/teleterm/src/ui/components/FilterableList/FilterableList.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { screen, within } from '@testing-library/react';
 import { fireEvent, render } from 'design/utils/testing';
 

--- a/web/packages/teleterm/src/ui/components/FilterableList/FilterableList.tsx
+++ b/web/packages/teleterm/src/ui/components/FilterableList/FilterableList.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { Fragment, ReactNode, useMemo, useState } from 'react';
+import { Fragment, ReactNode, useMemo, useState } from 'react';
 import { Input } from 'design';
 import styled from 'styled-components';
 

--- a/web/packages/teleterm/src/ui/components/KeyboardArrowsNavigation/KeyboardArrowsNavigation.test.tsx
+++ b/web/packages/teleterm/src/ui/components/KeyboardArrowsNavigation/KeyboardArrowsNavigation.test.tsx
@@ -16,7 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, {
+import {
+  createRef,
   forwardRef,
   ReactNode,
   useCallback,
@@ -152,7 +153,7 @@ test('activeIndex can be changed manually', () => {
     }
   );
 
-  const ref = React.createRef<any>();
+  const ref = createRef<any>();
 
   const { container } = render(
     <KeyboardArrowsNavigation>

--- a/web/packages/teleterm/src/ui/components/Notifcations/Notifications.story.tsx
+++ b/web/packages/teleterm/src/ui/components/Notifcations/Notifications.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { ButtonPrimary, Flex } from 'design';
 
 import { unique } from 'teleterm/ui/utils/uid';

--- a/web/packages/teleterm/src/ui/components/Notifcations/Notifications.tsx
+++ b/web/packages/teleterm/src/ui/components/Notifcations/Notifications.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 import { Notification } from 'shared/components/Notification';
 

--- a/web/packages/teleterm/src/ui/components/Notifcations/NotificationsHost.tsx
+++ b/web/packages/teleterm/src/ui/components/Notifcations/NotificationsHost.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 
 import { Notifications } from './Notifications';

--- a/web/packages/teleterm/src/ui/components/OfflineGateway.tsx
+++ b/web/packages/teleterm/src/ui/components/OfflineGateway.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { ButtonPrimary, Flex, H2, Text } from 'design';
 
 import * as Alerts from 'design/Alert';

--- a/web/packages/teleterm/src/ui/services/keyboardShortcuts/useKeyboardShortcuts.test.tsx
+++ b/web/packages/teleterm/src/ui/services/keyboardShortcuts/useKeyboardShortcuts.test.tsx
@@ -18,8 +18,6 @@
 
 import renderHook from 'design/utils/renderHook';
 
-import React from 'react';
-
 import AppContextProvider from 'teleterm/ui/appContextProvider';
 
 import AppContext from 'teleterm/ui/appContext';


### PR DESCRIPTION
The next part of https://github.com/gravitational/teleport/pull/50200.