### PR TITLE
Add note on `HOST_PROC` environment variable

### DIFF
--- a/docs/pages/enroll-resources/workload-identity/workload-attestation.mdx
+++ b/docs/pages/enroll-resources/workload-identity/workload-attestation.mdx
@@ -42,14 +42,15 @@ available to be used when configuring rules for `tbot`'s Workload API service:
 | `unix.uid`        | The effective user ID of the attested workload.                              |
 | `unix.gid`        | The effective primary group ID of the attested workload.                     |
 
-### Support for non-standard /proc mounting
+### Support for non-standard procfs mounting
 
 To resolve information about a process from the PID, the Unix Workload Attestor
-reads information from the `/proc` filesystem.
+reads information from the procfs filesystem. By default, it expects procfs to
+be mounted at `/proc`.
 
-In some cases, the `/proc` filesystem may not be mounted at the default
-location. If this is the case, you can configure the Unix Workload Attestor to
-read from a different location by setting the `HOST_PROC` environment variable.
+If procfs is mounted at a different location, you must configure the Unix
+Workload Attestor to read from that alternative location by setting the
+`HOST_PROC` environment variable.
 
 This is a sensitive configuration option, and you should ensure that it is
 set correctly or not set at all. If misconfigured, an attacker could provide

--- a/docs/pages/enroll-resources/workload-identity/workload-attestation.mdx
+++ b/docs/pages/enroll-resources/workload-identity/workload-attestation.mdx
@@ -37,10 +37,24 @@ available to be used when configuring rules for `tbot`'s Workload API service:
 
 | Field             | Description                                                                  |
 |-------------------|------------------------------------------------------------------------------|
-| `unix.attested` | Indicates that the workload has been attested by the Unix Workload Attestor. |
+| `unix.attested`   | Indicates that the workload has been attested by the Unix Workload Attestor. |
 | `unix.pid`        | The process ID of the attested workload.                                     |
 | `unix.uid`        | The effective user ID of the attested workload.                              |
 | `unix.gid`        | The effective primary group ID of the attested workload.                     |
+
+### Support for non-standard /proc mounting
+
+To resolve information about a process from the PID, the Unix Workload Attestor
+reads information from the `/proc` filesystem.
+
+In some cases, the `/proc` filesystem may not be mounted at the default
+location. If this is the case, you can configure the Unix Workload Attestor to
+read from a different location by setting the `HOST_PROC` environment variable.
+
+This is a sensitive configuration option, and you should ensure that it is
+set correctly or not set at all. If misconfigured, an attacker could provide
+falsified information about processes, and this could lead to the issuance of
+SVIDs to unauthorized workloads.
 
 ## Kubernetes
 


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport-private/issues/1776

Adds information and a warning about the `HOST_PROC` environment variable.