### PR TITLE
[WebUI] Handle AWS Identity Center app launch URL

### DIFF
--- a/web/packages/shared/components/AwsLaunchButton/AwsLaunchButton.tsx
+++ b/web/packages/shared/components/AwsLaunchButton/AwsLaunchButton.tsx
@@ -48,7 +48,8 @@ export class AwsLaunchButton extends React.Component<Props> {
 
   render() {
     const { open } = this.state;
-    const { awsRoles, getLaunchUrl, onLaunchUrl } = this.props;
+    const { awsRoles, getLaunchUrl, onLaunchUrl, isAwsIdentityCenterApp } =
+      this.props;
     return (
       <>
         <ButtonBorder
@@ -94,6 +95,7 @@ export class AwsLaunchButton extends React.Component<Props> {
             onLaunchUrl={onLaunchUrl}
             closeMenu={this.onClose}
             onChange={this.onChange}
+            isAwsIdentityCenterApp={isAwsIdentityCenterApp}
           />
         </Menu>
       </>
@@ -107,6 +109,7 @@ function RoleItemList({
   closeMenu,
   onChange,
   onLaunchUrl,
+  isAwsIdentityCenterApp,
 }: Props & {
   closeMenu: () => void;
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
@@ -117,6 +120,9 @@ function RoleItemList({
     let text = `${accountId}: ${display}`;
     if (display !== name) {
       text = `${text} (${name})`;
+    }
+    if (isAwsIdentityCenterApp) {
+      text = name;
     }
     return (
       <StyledMenuItem
@@ -181,6 +187,7 @@ type Props = {
   getLaunchUrl(arn: string): string;
   onLaunchUrl?(arn: string): void;
   width?: string;
+  isAwsIdentityCenterApp?: boolean;
 };
 
 const StyledMenuItem = styled(MenuItem)(

--- a/web/packages/teleport/src/UnifiedResources/ResourceActionButton.tsx
+++ b/web/packages/teleport/src/UnifiedResources/ResourceActionButton.tsx
@@ -24,7 +24,7 @@ import {
   MenuLogin,
 } from 'shared/components/MenuLogin';
 import { AwsLaunchButton } from 'shared/components/AwsLaunchButton';
-
+import { AwsRole } from 'shared/services/apps';
 import { UnifiedResource } from 'teleport/services/agents';
 import cfg from 'teleport/config';
 import useTeleport from 'teleport/useTeleport';
@@ -42,7 +42,6 @@ import { DiscoverEventResource } from 'teleport/services/userEvent';
 import { useSamlAppAction } from 'teleport/SamlApplications/useSamlAppActions';
 
 import type { ResourceSpec } from 'teleport/Discover/SelectResource/types';
-import { AwsRole } from 'shared/services/apps';
 
 type Props = {
   resource: UnifiedResource;

--- a/web/packages/teleport/src/services/apps/apps.test.ts
+++ b/web/packages/teleport/src/services/apps/apps.test.ts
@@ -48,6 +48,7 @@ test('correct formatting of apps fetch response', async () => {
         samlApp: false,
         samlAppSsoUrl: '',
         integration: '',
+        permissionSets: [],
       },
       {
         kind: 'app',
@@ -69,6 +70,7 @@ test('correct formatting of apps fetch response', async () => {
         samlApp: false,
         samlAppSsoUrl: '',
         integration: '',
+        permissionSets: [],
       },
       {
         kind: 'app',
@@ -90,6 +92,7 @@ test('correct formatting of apps fetch response', async () => {
         samlApp: false,
         samlAppSsoUrl: '',
         integration: '',
+        permissionSets: [],
       },
       {
         kind: 'app',
@@ -112,6 +115,7 @@ test('correct formatting of apps fetch response', async () => {
         samlAppSsoUrl: 'http://localhost/enterprise/saml-idp/login/saml-app',
         samlAppPreset: 'gcp-workforce',
         integration: '',
+        permissionSets: [],
       },
     ],
     startKey: mockResponse.startKey,

--- a/web/packages/teleport/src/services/apps/makeApps.ts
+++ b/web/packages/teleport/src/services/apps/makeApps.ts
@@ -20,7 +20,7 @@ import { AwsRole } from 'shared/services/apps';
 
 import cfg from 'teleport/config';
 
-import { App } from './types';
+import { App, PermissionSet } from './types';
 
 export default function makeApp(json: any): App {
   json = json || {};
@@ -38,7 +38,6 @@ export default function makeApp(json: any): App {
     integration = '',
     samlAppPreset,
     subKind,
-    permissionSets,
   } = json;
 
   const canCreateUrl = fqdn && clusterId && publicAddr;
@@ -49,6 +48,7 @@ export default function makeApp(json: any): App {
   const labels = json.labels || [];
   const awsRoles: AwsRole[] = json.awsRoles || [];
   const userGroups = json.userGroups || [];
+  const permissionSets: PermissionSet[] = json.permissionSets || [];
 
   const isTcp = uri && uri.startsWith('tcp://');
   const isCloud = uri && uri.startsWith('cloud://');


### PR DESCRIPTION
Updates `AppLaunch` button and `AwsLaunchButton` to support launch URLs for Identity Center account apps.

Depends on https://github.com/gravitational/teleport.e/pull/5692