### PR TITLE
Switching web to `ssh_port_forwarding` instead of `port_forwarding`

### DIFF
--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.story.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.story.tsx
@@ -342,7 +342,11 @@ spec:
         enabled: true
     max_session_ttl: 30h0m0s
     pin_source_ip: false
-    port_forwarding: true
+    ssh_port_forwarding:
+      remote:
+        enabled: false
+      local:
+        enabled: false
     record_session:
       default: best_effort
       desktop: true
@@ -374,7 +378,11 @@ spec:
         enabled: true
     max_session_ttl: 30h0m0s
     pin_source_ip: false
-    port_forwarding: true
+    ssh_port_forwarding:
+      remote:
+        enabled: false
+      local:
+        enabled: false
     record_session:
       default: best_effort
       desktop: true

--- a/web/packages/teleport/src/Roles/RoleEditor/standardmodel.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/standardmodel.ts
@@ -700,7 +700,7 @@ function optionsToModel(options: RoleOptions): {
     enhanced_recording,
     idp,
     pin_source_ip,
-    port_forwarding,
+    ssh_port_forwarding,
     ssh_file_copy,
 
     ...unsupported
@@ -756,7 +756,7 @@ function optionsToModel(options: RoleOptions): {
       !equalsDeep(enhanced_recording, defaultOpts.enhanced_recording) ||
       !equalsDeep(idp, defaultOpts.idp) ||
       pin_source_ip !== defaultOpts.pin_source_ip ||
-      port_forwarding !== defaultOpts.port_forwarding ||
+      !equalsDeep(ssh_port_forwarding, defaultOpts.ssh_port_forwarding) ||
       ssh_file_copy !== defaultOpts.ssh_file_copy ||
       requireMFATypeOption === undefined ||
       createHostUserModeOption === undefined ||

--- a/web/packages/teleport/src/Roles/RoleEditor/withDefaults.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/withDefaults.ts
@@ -70,6 +70,15 @@ export const optionsWithDefaults = (
       },
     },
 
+    ssh_port_forwarding: {
+      local: {
+        ...defaults.ssh_port_forwarding.local,
+      },
+      remote: {
+        ...defaults.ssh_port_forwarding.remote,
+      },
+    },
+
     record_session: {
       ...defaults.record_session,
       ...options?.record_session,
@@ -92,7 +101,14 @@ export const defaultOptions = (): RoleOptions => ({
   },
   max_session_ttl: '30h0m0s',
   pin_source_ip: false,
-  port_forwarding: true,
+  ssh_port_forwarding: {
+    local: {
+      enabled: false,
+    },
+    remote: {
+      enabled: false,
+    },
+  },
   record_session: {
     default: 'best_effort',
     desktop: true,

--- a/web/packages/teleport/src/Roles/Roles.story.tsx
+++ b/web/packages/teleport/src/Roles/Roles.story.tsx
@@ -61,7 +61,7 @@ const roles = [
     name: '@teleadmin',
     displayName: '@teleadmin',
     content:
-      "kind: role\nmetadata:\n  labels:\n    gravitational.io/system: \"true\"\n  name: '@teleadmin'\nspec:\n  allow:\n    kubernetes_groups:\n    - admin\n    logins:\n    - root\n    node_labels:\n      '*': '*'\n    rules:\n    - resources:\n      - '*'\n      verbs:\n      - '*'\n  deny: {}\n  options:\n    cert_format: standard\n    client_idle_timeout: 0s\n    disconnect_expired_cert: false\n    forward_agent: false\n    max_session_ttl: 30h0m0s\n    port_forwarding: true\nversion: v3\n",
+      "kind: role\nmetadata:\n  labels:\n    gravitational.io/system: \"true\"\n  name: '@teleadmin'\nspec:\n  allow:\n    kubernetes_groups:\n    - admin\n    logins:\n    - root\n    node_labels:\n      '*': '*'\n    rules:\n    - resources:\n      - '*'\n      verbs:\n      - '*'\n  deny: {}\n  options:\n    cert_format: standard\n    client_idle_timeout: 0s\n    disconnect_expired_cert: false\n    forward_agent: false\n    max_session_ttl: 30h0m0s\n    ssh_port_forwarding:\n      remote:\n        enabled: false\n      local:\n        enabled: false\nversion: v3\n",
   },
   {
     id: 'role:admin',
@@ -69,7 +69,7 @@ const roles = [
     name: 'admin',
     displayName: 'admin',
     content:
-      "kind: role\nmetadata:\n  name: admin\nspec:\n  allow:\n    kubernetes_groups:\n    - '{{internal.kubernetes_groups}}'\n    logins:\n    - '{{internal.logins}}'\n    - root\n    node_labels:\n      '*': '*'\n    rules:\n    - resources:\n      - role\n      verbs:\n      - list\n      - create\n      - read\n      - update\n      - delete\n    - resources:\n      - auth_connector\n      verbs:\n      - list\n      - create\n      - read\n      - update\n      - delete\n    - resources:\n      - session\n      verbs:\n      - list\n      - read\n    - resources:\n      - trusted_cluster\n      verbs:\n      - list\n      - create\n      - read\n      - update\n      - delete\n  deny: {}\n  options:\n    cert_format: standard\n    client_idle_timeout: 0s\n    disconnect_expired_cert: false\n    forward_agent: true\n    max_session_ttl: 30h0m0s\n    port_forwarding: true\nversion: v3\n",
+      "kind: role\nmetadata:\n  name: admin\nspec:\n  allow:\n    kubernetes_groups:\n    - '{{internal.kubernetes_groups}}'\n    logins:\n    - '{{internal.logins}}'\n    - root\n    node_labels:\n      '*': '*'\n    rules:\n    - resources:\n      - role\n      verbs:\n      - list\n      - create\n      - read\n      - update\n      - delete\n    - resources:\n      - auth_connector\n      verbs:\n      - list\n      - create\n      - read\n      - update\n      - delete\n    - resources:\n      - session\n      verbs:\n      - list\n      - read\n    - resources:\n      - trusted_cluster\n      verbs:\n      - list\n      - create\n      - read\n      - update\n      - delete\n  deny: {}\n  options:\n    cert_format: standard\n    client_idle_timeout: 0s\n    disconnect_expired_cert: false\n    forward_agent: true\n    max_session_ttl: 30h0m0s\n    ssh_port_forwarding:\n      remote:\n        enabled: false\n      local:\n        enabled: false\nversion: v3\n",
   },
 ];
 

--- a/web/packages/teleport/src/TrustedClusters/TrustedClusters.story.tsx
+++ b/web/packages/teleport/src/TrustedClusters/TrustedClusters.story.tsx
@@ -80,7 +80,7 @@ const trustedClusters = [
     name: '@teleadmin',
     displayName: '@teleadmin',
     content:
-      "kind: role\nmetadata:\n  labels:\n    gravitational.io/system: \"true\"\n  name: '@teleadmin'\nspec:\n  allow:\n    kubernetes_groups:\n    - admin\n    logins:\n    - root\n    node_labels:\n      '*': '*'\n    rules:\n    - resources:\n      - '*'\n      verbs:\n      - '*'\n  deny: {}\n  options:\n    cert_format: standard\n    client_idle_timeout: 0s\n    disconnect_expired_cert: false\n    forward_agent: false\n    max_session_ttl: 30h0m0s\n    port_forwarding: true\nversion: v3\n",
+      "kind: role\nmetadata:\n  labels:\n    gravitational.io/system: \"true\"\n  name: '@teleadmin'\nspec:\n  allow:\n    kubernetes_groups:\n    - admin\n    logins:\n    - root\n    node_labels:\n      '*': '*'\n    rules:\n    - resources:\n      - '*'\n      verbs:\n      - '*'\n  deny: {}\n  options:\n    cert_format: standard\n    client_idle_timeout: 0s\n    disconnect_expired_cert: false\n    forward_agent: false\n    max_session_ttl: 30h0m0s\n    ssh_port_forwarding:\n      remote:\n        enabled: false\n      local:\n        enabled: false\nversion: v3\n",
   },
   {
     id: 'role:admin',
@@ -88,6 +88,6 @@ const trustedClusters = [
     name: 'georgewashington.gravitational.io',
     displayName: 'georgewashington.gravitational.io',
     content:
-      "kind: role\nmetadata:\n  name: admin\nspec:\n  allow:\n    kubernetes_groups:\n    - '{{internal.kubernetes_groups}}'\n    logins:\n    - '{{internal.logins}}'\n    - root\n    node_labels:\n      '*': '*'\n    rules:\n    - resources:\n      - role\n      verbs:\n      - list\n      - create\n      - read\n      - update\n      - delete\n    - resources:\n      - auth_connector\n      verbs:\n      - list\n      - create\n      - read\n      - update\n      - delete\n    - resources:\n      - session\n      verbs:\n      - list\n      - read\n    - resources:\n      - trusted_cluster\n      verbs:\n      - list\n      - create\n      - read\n      - update\n      - delete\n  deny: {}\n  options:\n    cert_format: standard\n    client_idle_timeout: 0s\n    disconnect_expired_cert: false\n    forward_agent: true\n    max_session_ttl: 30h0m0s\n    port_forwarding: true\nversion: v3\n",
+      "kind: role\nmetadata:\n  name: admin\nspec:\n  allow:\n    kubernetes_groups:\n    - '{{internal.kubernetes_groups}}'\n    logins:\n    - '{{internal.logins}}'\n    - root\n    node_labels:\n      '*': '*'\n    rules:\n    - resources:\n      - role\n      verbs:\n      - list\n      - create\n      - read\n      - update\n      - delete\n    - resources:\n      - auth_connector\n      verbs:\n      - list\n      - create\n      - read\n      - update\n      - delete\n    - resources:\n      - session\n      verbs:\n      - list\n      - read\n    - resources:\n      - trusted_cluster\n      verbs:\n      - list\n      - create\n      - read\n      - update\n      - delete\n  deny: {}\n  options:\n    cert_format: standard\n    client_idle_timeout: 0s\n    disconnect_expired_cert: false\n    forward_agent: true\n    max_session_ttl: 30h0m0s\n    ssh_port_forwarding:\n      remote:\n        enabled: false\n      local:\n        enabled: false\nversion: v3\n",
   },
 ];

--- a/web/packages/teleport/src/services/resources/types.ts
+++ b/web/packages/teleport/src/services/resources/types.ts
@@ -351,7 +351,7 @@ export type RoleOptions = {
   };
   max_session_ttl: string;
   pin_source_ip: boolean;
-  port_forwarding: boolean;
+  ssh_port_forwarding: SSHPortForwarding;
   record_session: {
     default: SessionRecordingMode;
     ssh?: SessionRecordingMode;
@@ -363,6 +363,15 @@ export type RoleOptions = {
   require_session_mfa?: RequireMFAType;
   create_host_user_mode?: CreateHostUserMode;
   create_db_user_mode?: CreateDBUserMode;
+};
+
+export type SSHPortForwarding = {
+  local: {
+    enabled: boolean;
+  };
+  remote: {
+    enabled: boolean;
+  };
 };
 
 export type RequireMFAType =


### PR DESCRIPTION
This PR updates references to `port_forwarding` in the role editor to `ssh_port_forwarding`. This is in support of moving to more granular SSH port forwarding controls:
#49165
#49417
#50043