### PR TITLE
Fix Azure join method throttling

### DIFF
--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -711,7 +711,7 @@ func TestRegisterBot_RemoteAddr(t *testing.T) {
 		rsID := vmResourceID(subID, resourceGroup, "test-vm")
 		vmID := "vmID"
 
-		accessToken, err := makeToken(rsID, a.clock.Now())
+		accessToken, err := makeToken(rsID, "", a.clock.Now())
 		require.NoError(t, err)
 
 		// add token to auth server

--- a/lib/auth/join_azure.go
+++ b/lib/auth/join_azure.go
@@ -170,6 +170,8 @@ func (cfg *azureRegisterConfig) CheckAndSetDefaults(ctx context.Context) error {
 	}
 	if cfg.getVMClient == nil {
 		cfg.getVMClient = func(subscriptionID string, token *azure.StaticCredential) (azure.VirtualMachinesClient, error) {
+			// The User-Agent is added for debugging purposes. It helps identify
+			// and isolate teleport traffic.
 			opts := &armpolicy.ClientOptions{
 				ClientOptions: policy.ClientOptions{
 					Telemetry: policy.TelemetryOptions{

--- a/lib/auth/join_azure_test.go
+++ b/lib/auth/join_azure_test.go
@@ -104,12 +104,16 @@ func withChallengeAzure(challenge string) azureChallengeResponseOption {
 }
 
 func vmResourceID(subscription, resourceGroup, name string) string {
-	return resourceID("virtualMachines", subscription, resourceGroup, name)
+	return resourceID("Microsoft.Compute/virtualMachines", subscription, resourceGroup, name)
+}
+
+func identityResourceID(subscription, resourceGroup, name string) string {
+	return resourceID("Microsoft.ManagedIdentity/userAssignedIdentities", subscription, resourceGroup, name)
 }
 
 func resourceID(resourceType, subscription, resourceGroup, name string) string {
 	return fmt.Sprintf(
-		"/subscriptions/%v/resourcegroups/%v/providers/Microsoft.Compute/%v/%v",
+		"/subscriptions/%v/resourcegroups/%v/providers/%v/%v",
 		subscription, resourceGroup, resourceType, name,
 	)
 }
@@ -131,7 +135,7 @@ func mockVerifyToken(err error) azureVerifyTokenFunc {
 	}
 }
 
-func makeToken(resourceID string, issueTime time.Time) (string, error) {
+func makeToken(managedIdentityResourceID, azureResourceID string, issueTime time.Time) (string, error) {
 	sig, err := jose.NewSigner(jose.SigningKey{
 		Algorithm: jose.HS256,
 		Key:       []byte("test-key"),
@@ -149,9 +153,10 @@ func makeToken(resourceID string, issueTime time.Time) (string, error) {
 			Expiry:    jwt.NewNumericDate(issueTime.Add(time.Minute)),
 			ID:        "id",
 		},
-		ResourceID: resourceID,
-		TenantID:   "test-tenant-id",
-		Version:    "1.0",
+		ManangedIdentityResourceID: managedIdentityResourceID,
+		AzureResourceID:            azureResourceID,
+		TenantID:                   "test-tenant-id",
+		Version:                    "1.0",
 	}
 	raw, err := jwt.Signed(sig).Claims(claims).CompactSerialize()
 	if err != nil {
@@ -189,28 +194,28 @@ func TestAuth_RegisterUsingAzureMethod(t *testing.T) {
 	isBadParameter := func(t require.TestingT, err error, _ ...any) {
 		require.True(t, trace.IsBadParameter(err), "expected Bad Parameter error, actual error: %v", err)
 	}
-	isNotFound := func(t require.TestingT, err error, _ ...any) {
-		require.True(t, trace.IsNotFound(err), "expected Not Found error, actual error: %v", err)
-	}
 
 	defaultSubscription := uuid.NewString()
 	defaultResourceGroup := "my-resource-group"
-	defaultName := "test-vm"
+	defaultVMName := "test-vm"
+	defaultIdentityName := "test-id"
 	defaultVMID := "my-vm-id"
-	defaultResourceID := vmResourceID(defaultSubscription, defaultResourceGroup, defaultName)
+	defaultVMResourceID := vmResourceID(defaultSubscription, defaultResourceGroup, defaultVMName)
+	defaultIdentityResourceID := identityResourceID(defaultSubscription, defaultResourceGroup, defaultIdentityName)
 
 	tests := []struct {
-		name                     string
-		tokenResourceID          string
-		tokenSubscription        string
-		tokenVMID                string
-		requestTokenName         string
-		tokenSpec                types.ProvisionTokenSpecV2
-		challengeResponseOptions []azureChallengeResponseOption
-		challengeResponseErr     error
-		certs                    []*x509.Certificate
-		verify                   azureVerifyTokenFunc
-		assertError              require.ErrorAssertionFunc
+		name                           string
+		tokenManagedIdentityResourceID string
+		tokenAzureResourceID           string
+		tokenSubscription              string
+		tokenVMID                      string
+		requestTokenName               string
+		tokenSpec                      types.ProvisionTokenSpecV2
+		challengeResponseOptions       []azureChallengeResponseOption
+		challengeResponseErr           error
+		certs                          []*x509.Certificate
+		verify                         azureVerifyTokenFunc
+		assertError                    require.ErrorAssertionFunc
 	}{
 		{
 			name:              "basic passing case",
@@ -380,10 +385,11 @@ func TestAuth_RegisterUsingAzureMethod(t *testing.T) {
 			assertError: require.Error,
 		},
 		{
-			name:              "attested data and access token from different VMs",
-			requestTokenName:  "test-token",
-			tokenSubscription: defaultSubscription,
-			tokenVMID:         "some-other-vm-id",
+			name:                           "attested data and access token from different VMs",
+			requestTokenName:               "test-token",
+			tokenSubscription:              defaultSubscription,
+			tokenVMID:                      "some-other-vm-id",
+			tokenManagedIdentityResourceID: defaultIdentityResourceID,
 			tokenSpec: types.ProvisionTokenSpecV2{
 				Roles: []types.SystemRole{types.RoleNode},
 				Azure: &types.ProvisionTokenSpecV2Azure{
@@ -400,11 +406,11 @@ func TestAuth_RegisterUsingAzureMethod(t *testing.T) {
 			assertError: isAccessDenied,
 		},
 		{
-			name:              "vm not found",
-			requestTokenName:  "test-token",
-			tokenSubscription: defaultSubscription,
-			tokenVMID:         defaultVMID,
-			tokenResourceID:   vmResourceID(defaultSubscription, "nonexistent-group", defaultName),
+			name:                           "vm not found",
+			requestTokenName:               "test-token",
+			tokenSubscription:              defaultSubscription,
+			tokenVMID:                      "invalid-id",
+			tokenManagedIdentityResourceID: identityResourceID(defaultSubscription, defaultResourceGroup, "invalid-vm"),
 			tokenSpec: types.ProvisionTokenSpecV2{
 				Roles: []types.SystemRole{types.RoleNode},
 				Azure: &types.ProvisionTokenSpecV2Azure{
@@ -418,14 +424,14 @@ func TestAuth_RegisterUsingAzureMethod(t *testing.T) {
 			},
 			verify:      mockVerifyToken(nil),
 			certs:       []*x509.Certificate{tlsConfig.Certificate},
-			assertError: isNotFound,
+			assertError: isAccessDenied,
 		},
 		{
-			name:              "lookup vm by id",
-			requestTokenName:  "test-token",
-			tokenSubscription: defaultSubscription,
-			tokenVMID:         defaultVMID,
-			tokenResourceID:   resourceID("some.other.provider", defaultSubscription, defaultResourceGroup, defaultName),
+			name:                           "lookup vm by id",
+			requestTokenName:               "test-token",
+			tokenSubscription:              defaultSubscription,
+			tokenVMID:                      defaultVMID,
+			tokenManagedIdentityResourceID: defaultIdentityResourceID,
 			tokenSpec: types.ProvisionTokenSpecV2{
 				Roles: []types.SystemRole{types.RoleNode},
 				Azure: &types.ProvisionTokenSpecV2Azure{
@@ -442,11 +448,11 @@ func TestAuth_RegisterUsingAzureMethod(t *testing.T) {
 			assertError: require.NoError,
 		},
 		{
-			name:              "vm is in a different subscription than the token it provides",
-			requestTokenName:  "test-token",
-			tokenSubscription: defaultSubscription,
-			tokenVMID:         defaultVMID,
-			tokenResourceID:   resourceID("some.other.provider", "some-other-subscription", defaultResourceGroup, defaultName),
+			name:                           "vm is in a different subscription than the token it provides",
+			requestTokenName:               "test-token",
+			tokenSubscription:              defaultSubscription,
+			tokenVMID:                      defaultVMID,
+			tokenManagedIdentityResourceID: identityResourceID("some-other-subscription", defaultResourceGroup, defaultVMName),
 			tokenSpec: types.ProvisionTokenSpecV2{
 				Roles: []types.SystemRole{types.RoleNode},
 				Azure: &types.ProvisionTokenSpecV2Azure{
@@ -476,24 +482,299 @@ func TestAuth_RegisterUsingAzureMethod(t *testing.T) {
 				require.NoError(t, a.DeleteToken(ctx, token.GetName()))
 			})
 
-			rsID := tc.tokenResourceID
-			if rsID == "" {
-				rsID = vmResourceID(defaultSubscription, defaultResourceGroup, defaultName)
+			mirID := tc.tokenManagedIdentityResourceID
+			if mirID == "" {
+				mirID = vmResourceID(defaultSubscription, defaultResourceGroup, defaultVMName)
 			}
 
-			accessToken, err := makeToken(rsID, a.clock.Now())
+			accessToken, err := makeToken(mirID, "", a.clock.Now())
 			require.NoError(t, err)
 
 			vmClient := &mockAzureVMClient{
 				vms: map[string]*azure.VirtualMachine{
-					defaultResourceID: {
-						ID:            defaultResourceID,
-						Name:          defaultName,
+					defaultVMResourceID: {
+						ID:            defaultVMResourceID,
+						Name:          defaultVMName,
 						Subscription:  defaultSubscription,
 						ResourceGroup: defaultResourceGroup,
 						VMID:          defaultVMID,
 					},
 				},
+			}
+			getVMClient := makeVMClientGetter(map[string]*mockAzureVMClient{
+				defaultSubscription: vmClient,
+			})
+
+			_, err = a.RegisterUsingAzureMethodWithOpts(context.Background(), func(challenge string) (*proto.RegisterUsingAzureMethodRequest, error) {
+				cfg := &azureChallengeResponseConfig{Challenge: challenge}
+				for _, opt := range tc.challengeResponseOptions {
+					opt(cfg)
+				}
+
+				ad := attestedData{
+					Nonce:          cfg.Challenge,
+					SubscriptionID: tc.tokenSubscription,
+					ID:             tc.tokenVMID,
+				}
+				adBytes, err := json.Marshal(&ad)
+				require.NoError(t, err)
+				s, err := pkcs7.NewSignedData(adBytes)
+				require.NoError(t, err)
+				require.NoError(t, s.AddSigner(tlsConfig.Certificate, pkey, pkcs7.SignerInfoConfig{}))
+				signature, err := s.Finish()
+				require.NoError(t, err)
+				signedAD := signedAttestedData{
+					Encoding:  "pkcs7",
+					Signature: base64.StdEncoding.EncodeToString(signature),
+				}
+				signedADBytes, err := json.Marshal(&signedAD)
+				require.NoError(t, err)
+
+				req := &proto.RegisterUsingAzureMethodRequest{
+					RegisterUsingTokenRequest: &types.RegisterUsingTokenRequest{
+						Token:        tc.requestTokenName,
+						HostID:       "test-node",
+						Role:         types.RoleNode,
+						PublicSSHKey: sshPublicKey,
+						PublicTLSKey: tlsPublicKey,
+					},
+					AttestedData: signedADBytes,
+					AccessToken:  accessToken,
+				}
+				return req, tc.challengeResponseErr
+			}, withCerts(tc.certs), withVerifyFunc(tc.verify), withVMClientGetter(getVMClient))
+			tc.assertError(t, err)
+		})
+	}
+}
+
+// TestAuth_RegisterUsingAzureClaims tests the Azure join method by verifying
+// joining VMs by the token claims rather than from the Azure VM API.
+func TestAuth_RegisterUsingAzureClaims(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	p, err := newTestPack(ctx, t.TempDir())
+	require.NoError(t, err)
+	a := p.a
+
+	sshPrivateKey, sshPublicKey, err := testauthority.New().GenerateKeyPair()
+	require.NoError(t, err)
+
+	tlsConfig, err := fixtures.LocalTLSConfig()
+	require.NoError(t, err)
+
+	block, _ := pem.Decode(fixtures.LocalhostKey)
+	pkey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	require.NoError(t, err)
+
+	tlsPublicKey, err := PrivateKeyToPublicKeyTLS(sshPrivateKey)
+	require.NoError(t, err)
+
+	isAccessDenied := func(t require.TestingT, err error, _ ...any) {
+		require.True(t, trace.IsAccessDenied(err), "expected Access Denied error, actual error: %v", err)
+	}
+	defaultSubscription := uuid.NewString()
+	defaultResourceGroup := "my-resource-group"
+	defaultVMName := "test-vm"
+	defaultIdentityName := "test-id"
+	defaultVMID := "my-vm-id"
+
+	tests := []struct {
+		name                           string
+		tokenManagedIdentityResourceID string
+		tokenAzureResourceID           string
+		tokenSubscription              string
+		tokenVMID                      string
+		requestTokenName               string
+		tokenSpec                      types.ProvisionTokenSpecV2
+		challengeResponseOptions       []azureChallengeResponseOption
+		challengeResponseErr           error
+		certs                          []*x509.Certificate
+		verify                         azureVerifyTokenFunc
+		assertError                    require.ErrorAssertionFunc
+	}{
+		{
+			name:                           "system-managed identity ok",
+			requestTokenName:               "test-token",
+			tokenSubscription:              "system-managed-test",
+			tokenVMID:                      defaultVMID,
+			tokenManagedIdentityResourceID: vmResourceID("system-managed-test", "system-managed-test", defaultVMName),
+			tokenSpec: types.ProvisionTokenSpecV2{
+				Roles: []types.SystemRole{types.RoleNode},
+				Azure: &types.ProvisionTokenSpecV2Azure{
+					Allow: []*types.ProvisionTokenSpecV2Azure_Rule{
+						{
+							Subscription:   "system-managed-test",
+							ResourceGroups: []string{"system-managed-test"},
+						},
+					},
+				},
+				JoinMethod: types.JoinMethodAzure,
+			},
+			verify:      mockVerifyToken(nil),
+			certs:       []*x509.Certificate{tlsConfig.Certificate},
+			assertError: require.NoError,
+		},
+		{
+			name:                           "system-managed identity with wrong subscription",
+			requestTokenName:               "test-token",
+			tokenSubscription:              "system-managed-test",
+			tokenVMID:                      defaultVMID,
+			tokenManagedIdentityResourceID: vmResourceID("system-managed-test", "system-managed-test", defaultVMName),
+			tokenSpec: types.ProvisionTokenSpecV2{
+				Roles: []types.SystemRole{types.RoleNode},
+				Azure: &types.ProvisionTokenSpecV2Azure{
+					Allow: []*types.ProvisionTokenSpecV2Azure_Rule{
+						{
+							Subscription:   defaultSubscription,
+							ResourceGroups: []string{"system-managed-test"},
+						},
+					},
+				},
+				JoinMethod: types.JoinMethodAzure,
+			},
+			verify:      mockVerifyToken(nil),
+			certs:       []*x509.Certificate{tlsConfig.Certificate},
+			assertError: isAccessDenied,
+		},
+		{
+			name:                           "system-managed identity with wrong resource group",
+			requestTokenName:               "test-token",
+			tokenSubscription:              "system-managed-test",
+			tokenVMID:                      defaultVMID,
+			tokenManagedIdentityResourceID: vmResourceID("system-managed-test", "system-managed-test", defaultVMName),
+			tokenSpec: types.ProvisionTokenSpecV2{
+				Roles: []types.SystemRole{types.RoleNode},
+				Azure: &types.ProvisionTokenSpecV2Azure{
+					Allow: []*types.ProvisionTokenSpecV2Azure_Rule{
+						{
+							Subscription:   "system-managed-test",
+							ResourceGroups: []string{defaultResourceGroup},
+						},
+					},
+				},
+				JoinMethod: types.JoinMethodAzure,
+			},
+			verify:      mockVerifyToken(nil),
+			certs:       []*x509.Certificate{tlsConfig.Certificate},
+			assertError: isAccessDenied,
+		},
+		{
+			name:                           "user-managed identity ok",
+			requestTokenName:               "test-token",
+			tokenSubscription:              "user-managed-test",
+			tokenVMID:                      defaultVMID,
+			tokenManagedIdentityResourceID: identityResourceID("user-managed-test", "user-managed-test", defaultIdentityName),
+			tokenAzureResourceID:           vmResourceID("user-managed-test", "user-managed-test", defaultVMName),
+			tokenSpec: types.ProvisionTokenSpecV2{
+				Roles: []types.SystemRole{types.RoleNode},
+				Azure: &types.ProvisionTokenSpecV2Azure{
+					Allow: []*types.ProvisionTokenSpecV2Azure_Rule{
+						{
+							Subscription:   "user-managed-test",
+							ResourceGroups: []string{"user-managed-test"},
+						},
+					},
+				},
+				JoinMethod: types.JoinMethodAzure,
+			},
+			verify:      mockVerifyToken(nil),
+			certs:       []*x509.Certificate{tlsConfig.Certificate},
+			assertError: require.NoError,
+		},
+		{
+			name:                           "user-managed identity with wrong subscription",
+			requestTokenName:               "test-token",
+			tokenSubscription:              "user-managed-test",
+			tokenVMID:                      defaultVMID,
+			tokenManagedIdentityResourceID: identityResourceID("user-managed-test", "user-managed-test", defaultIdentityName),
+			tokenAzureResourceID:           vmResourceID("user-managed-test", "user-managed-test", defaultVMName),
+			tokenSpec: types.ProvisionTokenSpecV2{
+				Roles: []types.SystemRole{types.RoleNode},
+				Azure: &types.ProvisionTokenSpecV2Azure{
+					Allow: []*types.ProvisionTokenSpecV2Azure_Rule{
+						{
+							Subscription:   defaultSubscription,
+							ResourceGroups: []string{"user-managed-test"},
+						},
+					},
+				},
+				JoinMethod: types.JoinMethodAzure,
+			},
+			verify:      mockVerifyToken(nil),
+			certs:       []*x509.Certificate{tlsConfig.Certificate},
+			assertError: isAccessDenied,
+		},
+		{
+			name:                           "user-managed identity with wrong resource group",
+			requestTokenName:               "test-token",
+			tokenSubscription:              "user-managed-test",
+			tokenVMID:                      defaultVMID,
+			tokenManagedIdentityResourceID: identityResourceID("user-managed-test", "user-managed-test", defaultIdentityName),
+			tokenAzureResourceID:           vmResourceID("user-managed-test", "user-managed-test", defaultVMName),
+			tokenSpec: types.ProvisionTokenSpecV2{
+				Roles: []types.SystemRole{types.RoleNode},
+				Azure: &types.ProvisionTokenSpecV2Azure{
+					Allow: []*types.ProvisionTokenSpecV2Azure_Rule{
+						{
+							Subscription:   "user-managed-test",
+							ResourceGroups: []string{defaultResourceGroup},
+						},
+					},
+				},
+				JoinMethod: types.JoinMethodAzure,
+			},
+			verify:      mockVerifyToken(nil),
+			certs:       []*x509.Certificate{tlsConfig.Certificate},
+			assertError: isAccessDenied,
+		},
+		{
+			name:                           "user-managed identity from different subscription",
+			requestTokenName:               "test-token",
+			tokenSubscription:              "user-managed-test",
+			tokenVMID:                      defaultVMID,
+			tokenManagedIdentityResourceID: identityResourceID("invalid-user-managed-test", "invalid-user-managed-test", defaultIdentityName),
+			tokenAzureResourceID:           vmResourceID("user-managed-test", "user-managed-test", defaultVMName),
+			tokenSpec: types.ProvisionTokenSpecV2{
+				Roles: []types.SystemRole{types.RoleNode},
+				Azure: &types.ProvisionTokenSpecV2Azure{
+					Allow: []*types.ProvisionTokenSpecV2Azure_Rule{
+						{
+							Subscription:   "user-managed-test",
+							ResourceGroups: []string{"user-managed-test"},
+						},
+					},
+				},
+				JoinMethod: types.JoinMethodAzure,
+			},
+			verify:      mockVerifyToken(nil),
+			certs:       []*x509.Certificate{tlsConfig.Certificate},
+			assertError: require.NoError,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			token, err := types.NewProvisionTokenFromSpec(
+				"test-token",
+				time.Now().Add(time.Minute),
+				tc.tokenSpec)
+			require.NoError(t, err)
+			require.NoError(t, a.UpsertToken(ctx, token))
+			t.Cleanup(func() {
+				require.NoError(t, a.DeleteToken(ctx, token.GetName()))
+			})
+
+			mirID := tc.tokenManagedIdentityResourceID
+			azrID := tc.tokenAzureResourceID
+			accessToken, err := makeToken(mirID, azrID, a.clock.Now())
+			require.NoError(t, err)
+
+			vmClient := &mockAzureVMClient{
+				vms: map[string]*azure.VirtualMachine{},
 			}
 			getVMClient := makeVMClientGetter(map[string]*mockAzureVMClient{
 				defaultSubscription: vmClient,


### PR DESCRIPTION
Supports https://github.com/gravitational/teleport.e/issues/2164

The current implementation of the Azure join method requires Teleport to list all VMs in an Azure subscription in order to verify the joining VM. This is problematic when there are a large number of VMs in an Azure subscription, and in some cases causes throttling due to Azure API rate limits.

This PR modifies the validation step of the Azure join method. Validation no longer requests the VM instance from the Azure API. Instead, Teleport validates the joining VM using the optional claims provided in the JWT. This removes the need to query the Azure VM API and the risk of throttling. If the validation with claims method fails, Teleport will fallback to previous validation method using the VM.

~Todo: Attempt VM validation using Resource Graph API before attempting VM validation with ListAllVMs API.~
Changelog: Fixes an issue causing Azure join method to fail due to throttling.