### PR TITLE
Add go-mod-tidy-all to Makefile and linter hint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -88,7 +88,7 @@ jobs:
           find . -path ./e -prune -o -name go.mod -print | while read f; do
             echo "checking $f"
             pushd $(dirname "$f") > /dev/null;
-            go mod tidy -diff;
+            go mod tidy -diff || (echo "Run 'make go-mod-tidy-all' to resolve" && exit 1);
             popd > /dev/null;
           done
 

--- a/Makefile
+++ b/Makefile
@@ -1839,3 +1839,7 @@ create-github-release:
 	--latest=$(LATEST) \
 	--verify-tag \
 	-F - <<< "$$NOTES"
+
+.PHONY: go-mod-tidy-all
+go-mod-tidy-all:
+	find . -type "f" -name "go.mod" -execdir go mod tidy \;


### PR DESCRIPTION
This will run go mod tidy in every go module directory.
If the go mod diff lint fails, it will provide a hint to run this command.