### PR TITLE
[v16] Add gap in Bots permissions banner

### DIFF
--- a/web/packages/teleport/src/Bots/List/Bots.tsx
+++ b/web/packages/teleport/src/Bots/List/Bots.tsx
@@ -20,7 +20,7 @@ import React, { useEffect, useState } from 'react';
 import { useAttemptNext } from 'shared/hooks';
 import { Link } from 'react-router-dom';
 import { HoverTooltip } from 'shared/components/ToolTip';
-import { Alert, Box, ButtonPrimary, Indicator } from 'design';
+import { Alert, Flex, Box, ButtonPrimary, Indicator, Text } from 'design';
 
 import {
   FeatureBox,
@@ -129,8 +129,10 @@ export function Bots() {
       <FeatureBox>
         {!canListBots && (
           <Alert kind="info" mt={4}>
-            You do not have permission to access Bots. Missing role permissions:{' '}
-            <code>bot.list</code>
+            <Flex gap={1}>
+              You do not have permission to access Bots. Missing role
+              permissions: <Text bold>bot.list</Text>
+            </Flex>
           </Alert>
         )}
         <EmptyState />


### PR DESCRIPTION
The text "bot.list" was a little squished. The new banners dont have this problem but the old ones in v16 need a little help

old
<img width="418" alt="Screenshot 2024-12-13 at 9 08 33 PM" src="https://github.com/user-attachments/assets/1f1675e3-793f-4051-85b9-0fc3b4d9fdd9" />


new

<img width="326" alt="Screenshot 2024-12-13 at 9 08 39 PM" src="https://github.com/user-attachments/assets/8200b45a-e10e-4e66-832b-e584b2c055cd" />
