### PR TITLE
Fix Integration Button styles

### DIFF
--- a/web/packages/teleport/src/Integrations/Integrations.tsx
+++ b/web/packages/teleport/src/Integrations/Integrations.tsx
@@ -79,7 +79,7 @@ export function Integrations() {
   return (
     <>
       <FeatureBox>
-        <FeatureHeader>
+        <FeatureHeader justifyContent="space-between">
           <FeatureHeaderTitle>Integrations</FeatureHeaderTitle>
           <IntegrationsAddButton
             requiredPermissions={[

--- a/web/packages/teleport/src/Integrations/IntegrationsAddButton.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationsAddButton.tsx
@@ -36,6 +36,7 @@ export function IntegrationsAddButton({
 
   return (
     <HoverTooltip
+      position="bottom"
       tipContent={
         canCreateIntegrations ? null : (
           <MissingPermissionsTooltip


### PR DESCRIPTION
If a user could list integrations, and they could NOT create integrations, AND integrations existed, this would cause the disabled 'enroll new integration' button to be smashed to the left of the header (this is due to how its wrapped in an optional Hover Tooltip).

This PR just adds some space-between flex property to the header to ensure the button stays on the right side. It also moves the HoverTooltip position to the bottom because it looks better

old:
<img width="461" alt="Screenshot 2024-12-13 at 9 26 08 PM" src="https://github.com/user-attachments/assets/5ab67361-6b4b-4b85-bd31-18242b81a1bf" />

Updated
<img width="801" alt="Screenshot 2024-12-13 at 9 25 40 PM" src="https://github.com/user-attachments/assets/2abfc674-d2a7-44e3-9203-1c72a7f8abd7" />
