### PR TITLE
docs: update tsh pkg install instructs for v17+

### DIFF
--- a/docs/pages/includes/enterprise/install-macos-ent.mdx
+++ b/docs/pages/includes/enterprise/install-macos-ent.mdx
@@ -3,7 +3,6 @@
   |Link|Binaries|
   |-|-|
   |[`teleport-ent-(=teleport.version=).pkg`](https://cdn.teleport.dev/teleport-ent-(=teleport.version=).pkg)|`teleport`<br/>`tctl`<br/>`tsh`<br/>`tbot`|
-  |[`tsh-(=teleport.version=).pkg`](https://cdn.teleport.dev/tsh-(=teleport.version=).pkg)|`tsh`|
 
   You can also fetch an installer via the command line:
 

--- a/docs/pages/includes/enterprise/install-macos.mdx
+++ b/docs/pages/includes/enterprise/install-macos.mdx
@@ -3,7 +3,6 @@
   | Link                                                                                                      | Binaries                                   |
   |-----------------------------------------------------------------------------------------------------------|--------------------------------------------|
   | [`teleport-ent-(=teleport.version=).pkg`](https://cdn.teleport.dev/teleport-ent-(=teleport.version=).pkg) | `teleport`<br/>`tctl`<br/>`tsh`<br/>`tbot`<br/>`fdpass-teleport`|
-  | [`tsh-(=teleport.version=).pkg`](https://cdn.teleport.dev/tsh-(=teleport.version=).pkg)                   | `tsh`                                      |
 
   You can also fetch an installer from the command line:
 

--- a/docs/pages/includes/install-tsh.mdx
+++ b/docs/pages/includes/install-tsh.mdx
@@ -1,9 +1,9 @@
 <Tabs>
   <TabItem label="Mac">
-    Download the signed macOS .pkg installer for `tsh`. In Finder double-click the `pkg` file to install it:
+    Download the signed macOS .pkg installer for Teleport including `tsh`. In Finder double-click the `pkg` file to install it:
 
     ```code
-    $ curl -O https://cdn.teleport.dev/tsh-(=teleport.version=).pkg
+    $ curl -O https://cdn.teleport.dev/teleport-(=teleport.version=).pkg
     ```
 
   </TabItem>

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -838,7 +838,6 @@ You can download one of the following .pkg installers for macOS:
   |Link|Binaries|
   |-|-|
   |[`teleport-(=teleport.version=).pkg`](https://cdn.teleport.dev/teleport-(=teleport.version=).pkg)|`teleport`<br/>`tctl`<br/>`tsh`<br/>`tbot`<br/>`fdpass-teleport`|
-  |[`tsh-(=teleport.version=).pkg`](https://cdn.teleport.dev/tsh-(=teleport.version=).pkg)|`tsh`|
 
   You can also fetch an installer via the command line:
 


### PR DESCRIPTION
v17+ no longer has a `tsh` pkg, just Teleport pkg that has all binaries and apps. Note that the cloud install includes will need updating once cloud goes to v17.