### PR TITLE
Cache Kubernetes App Discovery port check results

### DIFF
--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -256,7 +256,7 @@ kubernetes matchers are present.`)
 	}
 
 	if c.protocolChecker == nil {
-		c.protocolChecker = fetchers.NewProtoChecker(false)
+		c.protocolChecker = fetchers.NewProtoChecker()
 	}
 
 	if c.PollInterval == 0 {

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -991,7 +991,7 @@ func newMockKubeService(name, namespace, externalName string, labels, annotation
 type noopProtocolChecker struct{}
 
 // CheckProtocol for noopProtocolChecker just returns 'tcp'
-func (*noopProtocolChecker) CheckProtocol(uri string) string {
+func (*noopProtocolChecker) CheckProtocol(service corev1.Service, port corev1.ServicePort) string {
 	return "tcp"
 }
 

--- a/lib/srv/discovery/fetchers/kube_services.go
+++ b/lib/srv/discovery/fetchers/kube_services.go
@@ -20,7 +20,6 @@ package fetchers
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -74,7 +73,7 @@ func (k *KubeAppsFetcherConfig) CheckAndSetDefaults() error {
 		return trace.BadParameter("missing parameter ClusterName")
 	}
 	if k.ProtocolChecker == nil {
-		k.ProtocolChecker = NewProtoChecker(false)
+		k.ProtocolChecker = NewProtoChecker()
 	}
 
 	return nil
@@ -324,8 +323,7 @@ func getServicePorts(s v1.Service) ([]v1.ServicePort, error) {
 }
 
 type ProtoChecker struct {
-	InsecureSkipVerify bool
-	client             *http.Client
+	client *http.Client
 
 	// cacheKubernetesServiceProtocol maps a Kubernetes Service Namespace/Name to a tuple containing the Service's ResourceVersion and the Protocol.
 	// When the Kubernetes Service ResourceVersion changes, then we assume the protocol might've changed as well, so the cache is invalidated.
@@ -344,18 +342,12 @@ type kubernetesNameNamespace struct {
 	name      string
 }
 
-func NewProtoChecker(insecureSkipVerify bool) *ProtoChecker {
+func NewProtoChecker() *ProtoChecker {
 	p := &ProtoChecker{
-		InsecureSkipVerify: insecureSkipVerify,
 		client: &http.Client{
 			// This is a best-effort scenario, where teleport tries to guess which protocol is being used.
 			// Ideally it should either be inferred by the Service's ports or explicitly configured by using annotations on the service.
 			Timeout: 500 * time.Millisecond,
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: insecureSkipVerify,
-				},
-			},
 		},
 		cacheKubernetesServiceProtocol: make(map[kubernetesNameNamespace]appResourceVersionProtocol),
 	}

--- a/lib/srv/discovery/fetchers/kube_services.go
+++ b/lib/srv/discovery/fetchers/kube_services.go
@@ -331,6 +331,7 @@ type ProtoChecker struct {
 	// When the Kubernetes Service ResourceVersion changes, then we assume the protocol might've changed as well, so the cache is invalidated.
 	// Only protocol checkers that require a network connection are cached.
 	cacheKubernetesServiceProtocol map[kubernetesNameNamespace]appResourceVersionProtocol
+	cacheMU                        sync.RWMutex
 }
 
 type appResourceVersionProtocol struct {
@@ -368,10 +369,13 @@ func (p *ProtoChecker) CheckProtocol(service v1.Service, port v1.ServicePort) st
 	}
 
 	key := kubernetesNameNamespace{namespace: service.Namespace, name: service.Name}
-	if versionProtocol, ok := p.cacheKubernetesServiceProtocol[key]; ok {
-		if versionProtocol.resourceVersion == service.ResourceVersion {
-			return versionProtocol.protocol
-		}
+
+	p.cacheMU.RLock()
+	versionProtocol, keyIsCached := p.cacheKubernetesServiceProtocol[key]
+	p.cacheMU.RUnlock()
+
+	if keyIsCached && versionProtocol.resourceVersion == service.ResourceVersion {
+		return versionProtocol.protocol
 	}
 
 	var result string
@@ -391,10 +395,12 @@ func (p *ProtoChecker) CheckProtocol(service v1.Service, port v1.ServicePort) st
 
 	}
 
+	p.cacheMU.Lock()
 	p.cacheKubernetesServiceProtocol[key] = appResourceVersionProtocol{
 		resourceVersion: service.ResourceVersion,
 		protocol:        result,
 	}
+	p.cacheMU.Unlock()
 
 	return result
 }

--- a/lib/srv/discovery/fetchers/kube_services_test.go
+++ b/lib/srv/discovery/fetchers/kube_services_test.go
@@ -24,8 +24,11 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"slices"
+	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -36,6 +39,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -305,7 +309,8 @@ type mockProtocolChecker struct {
 	results map[string]string
 }
 
-func (m *mockProtocolChecker) CheckProtocol(uri string) string {
+func (m *mockProtocolChecker) CheckProtocol(service corev1.Service, port corev1.ServicePort) string {
+	uri := fmt.Sprintf("%s:%d", services.GetServiceFQDN(service), port.Port)
 	if result, ok := m.results[uri]; ok {
 		return result
 	}
@@ -455,16 +460,30 @@ func TestProtoChecker_CheckProtocol(t *testing.T) {
 	t.Parallel()
 	checker := NewProtoChecker(true)
 
+	totalNetworkHits := &atomic.Int32{}
+
 	httpsServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		totalNetworkHits.Add(1)
 		_, _ = fmt.Fprintln(w, "httpsServer")
 	}))
+	httpsServerBaseURL, err := url.Parse(httpsServer.URL)
+	require.NoError(t, err)
+
 	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = fmt.Fprintln(w, "httpServer")
+		// this never gets called because the HTTP server will not accept the HTTPS request.
 	}))
+	httpServerBaseURL, err := url.Parse(httpServer.URL)
+	require.NoError(t, err)
+
 	tcpServer := newTCPServer(t, func(conn net.Conn) {
+		totalNetworkHits.Add(1)
 		_, _ = conn.Write([]byte("tcpServer"))
 		_ = conn.Close()
 	})
+	tcpServerBaseURL := &url.URL{
+		Host: tcpServer.Addr().String(),
+	}
+
 	t.Cleanup(func() {
 		httpsServer.Close()
 		httpServer.Close()
@@ -472,27 +491,55 @@ func TestProtoChecker_CheckProtocol(t *testing.T) {
 	})
 
 	tests := []struct {
-		uri      string
+		host     string
 		expected string
 	}{
 		{
-			uri:      strings.TrimPrefix(httpServer.URL, "http://"),
+			host:     httpServerBaseURL.Host,
 			expected: "http",
 		},
 		{
-			uri:      strings.TrimPrefix(httpsServer.URL, "https://"),
+			host:     httpsServerBaseURL.Host,
 			expected: "https",
 		},
 		{
-			uri:      tcpServer.Addr().String(),
+			host:     tcpServerBaseURL.Host,
 			expected: "tcp",
 		},
 	}
 
 	for _, tt := range tests {
-		res := checker.CheckProtocol(tt.uri)
+		service, servicePort := createServiceAndServicePort(t, tt.expected, tt.host)
+		res := checker.CheckProtocol(service, servicePort)
 		require.Equal(t, tt.expected, res)
 	}
+
+	t.Run("caching prevents more than 1 network request to the same service", func(t *testing.T) {
+		service, servicePort := createServiceAndServicePort(t, "https", httpsServerBaseURL.Host)
+		checker.CheckProtocol(service, servicePort)
+		// There can only be two hits recorded: one for the HTTPS Server and another one for the TCP Server.
+		// The HTTP Server does not generate a network hit. See above.
+		require.Equal(t, int32(2), totalNetworkHits.Load())
+	})
+}
+
+func createServiceAndServicePort(t *testing.T, serviceName, host string) (corev1.Service, corev1.ServicePort) {
+	host, portString, err := net.SplitHostPort(host)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portString)
+	require.NoError(t, err)
+	service := corev1.Service{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      serviceName,
+			Namespace: "default",
+		},
+		Spec: corev1.ServiceSpec{
+			Type:         corev1.ServiceTypeExternalName,
+			ExternalName: host,
+		},
+	}
+	servicePort := corev1.ServicePort{Port: int32(port)}
+	return service, servicePort
 }
 
 func newTCPServer(t *testing.T, handleConn func(net.Conn)) net.Listener {
@@ -579,7 +626,7 @@ func TestAutoProtocolDetection(t *testing.T) {
 				port.AppProtocol = &tt.appProtocol
 			}
 
-			result := autoProtocolDetection("192.1.1.1", port, nil)
+			result := autoProtocolDetection(corev1.Service{}, port, nil)
 
 			require.Equal(t, tt.expected, result)
 		})

--- a/lib/srv/discovery/fetchers/kube_services_test.go
+++ b/lib/srv/discovery/fetchers/kube_services_test.go
@@ -20,6 +20,7 @@ package fetchers
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
@@ -30,6 +31,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
@@ -458,7 +460,14 @@ func TestGetServicePorts(t *testing.T) {
 
 func TestProtoChecker_CheckProtocol(t *testing.T) {
 	t.Parallel()
-	checker := NewProtoChecker(true)
+	checker := NewProtoChecker()
+	// Increasing client Timeout because CI/CD fails with a lower value.
+	checker.client.Timeout = 5 * time.Second
+
+	// Allow connections to HTTPS server created below.
+	checker.client.Transport = &http.Transport{TLSClientConfig: &tls.Config{
+		InsecureSkipVerify: true,
+	}}
 
 	totalNetworkHits := &atomic.Int32{}
 


### PR DESCRIPTION
For the K8S Services that we couldn't auto detect the protocol, after trying to infer the port, cache the result.
Cache is evicted when the K8S Service changes (we check the Service's ResourceVersion).