### PR TITLE
[teleport-update] Fix duplicate teleport-update short command

### DIFF
--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -101,7 +101,7 @@ func Run(args []string) int {
 	app.Flag("log-format", "Controls the format of output logs. Can be `json` or `text`. Defaults to `text`.").
 		Default(libutils.LogFormatText).EnumVar(&ccfg.LogFormat, libutils.LogFormatJSON, libutils.LogFormatText)
 	app.Flag("install-suffix", "Suffix for creating an agent installation outside of the default $PATH. Note: this changes the default data directory.").
-		Short('n').StringVar(&ccfg.InstallSuffix)
+		Short('i').StringVar(&ccfg.InstallSuffix)
 	app.Flag("link-dir", "Directory to link the active Teleport installation's binaries into.").
 		Default(autoupdate.DefaultLinkDir).IsSetByUser(&userLinkDir).Hidden().StringVar(&ccfg.LinkDir)
 


### PR DESCRIPTION
Small fix of the command duplicate, found here

https://github.com/gravitational/teleport.e/actions/runs/12324674733/job/34409189487

```
    amazon-ebs.teleport-aws-linux: + install -m 755 /tmp/teleport/examples/systemd/teleport.service /opt/teleport/system/lib/systemd/system
    amazon-ebs.teleport-aws-linux: + /opt/teleport/system/bin/teleport-update link-package
    amazon-ebs.teleport-aws-linux: teleport-update: error: duplicate short flag -n
```
related: https://github.com/gravitational/cloud/issues/10289