### PR TITLE
[v17] Remove unused `React` imports from `packages/teleport`

### DIFF
--- a/web/.storybook/preview.tsx
+++ b/web/.storybook/preview.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { ComponentType, PropsWithChildren } from 'react';
+import { ComponentType, PropsWithChildren } from 'react';
 import { bblpTheme, darkTheme, lightTheme } from '../packages/design/src/theme';
 import { ConfiguredThemeProvider } from '../packages/design/src/ThemeProvider';
 import Box from '../packages/design/src/Box';

--- a/web/packages/teleport/src/AccessRequests/AccessRequests.story.tsx
+++ b/web/packages/teleport/src/AccessRequests/AccessRequests.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { LockedAccessRequests } from 'teleport/AccessRequests/LockedAccessRequests/LockedAccessRequests';
 import { ContextProvider } from 'teleport';
 import { createTeleportContext } from 'teleport/mocks/contexts';

--- a/web/packages/teleport/src/Account/Account.story.tsx
+++ b/web/packages/teleport/src/Account/Account.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 import { PasswordState } from 'teleport/services/user';
 

--- a/web/packages/teleport/src/Account/ManageDevices/AuthDeviceList/AuthDeviceList.story.tsx
+++ b/web/packages/teleport/src/Account/ManageDevices/AuthDeviceList/AuthDeviceList.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import * as Icon from 'design/Icon';
 
 import { ActionButtonSecondary, Header } from 'teleport/Account/Header';

--- a/web/packages/teleport/src/Account/ManageDevices/AuthDeviceList/AuthDeviceList.test.tsx
+++ b/web/packages/teleport/src/Account/ManageDevices/AuthDeviceList/AuthDeviceList.test.tsx
@@ -18,7 +18,6 @@
 
 import { render, screen } from 'design/utils/testing';
 import { within } from '@testing-library/react';
-import React from 'react';
 
 import { MfaDevice } from 'teleport/services/mfa';
 

--- a/web/packages/teleport/src/Account/ManageDevices/wizards/DeleteAuthDeviceWizard.test.tsx
+++ b/web/packages/teleport/src/Account/ManageDevices/wizards/DeleteAuthDeviceWizard.test.tsx
@@ -17,7 +17,6 @@
  */
 
 import { render, screen } from 'design/utils/testing';
-import React from 'react';
 
 import { within } from '@testing-library/react';
 import { userEvent, UserEvent } from '@testing-library/user-event';

--- a/web/packages/teleport/src/Account/PasswordBox.tsx
+++ b/web/packages/teleport/src/Account/PasswordBox.tsx
@@ -18,7 +18,7 @@
 
 import { Box, Flex } from 'design';
 import { SingleRowBox } from 'design/MultiRowBox';
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import * as Icon from 'design/Icon';
 

--- a/web/packages/teleport/src/Account/StatePill.tsx
+++ b/web/packages/teleport/src/Account/StatePill.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled, { css } from 'styled-components';
 
 /** State of an authentication method (password, MFA method, or passkey). */

--- a/web/packages/teleport/src/AppLauncher/AppLauncher.story.tsx
+++ b/web/packages/teleport/src/AppLauncher/AppLauncher.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { AppLauncherAccessDenied, AppLauncherProcessing } from './AppLauncher';
 
 export default {

--- a/web/packages/teleport/src/AppLauncher/AppLauncher.test.tsx
+++ b/web/packages/teleport/src/AppLauncher/AppLauncher.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { render, waitFor, screen } from 'design/utils/testing';
 import { createMemoryHistory } from 'history';
 import { Router } from 'react-router';

--- a/web/packages/teleport/src/AppLauncher/AppLauncher.tsx
+++ b/web/packages/teleport/src/AppLauncher/AppLauncher.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 
 import { useLocation, useParams } from 'react-router';
 

--- a/web/packages/teleport/src/Apps/AddApp/AddApp.story.tsx
+++ b/web/packages/teleport/src/Apps/AddApp/AddApp.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { AddApp } from './AddApp';
 
 export default {

--- a/web/packages/teleport/src/Apps/AddApp/AddApp.tsx
+++ b/web/packages/teleport/src/Apps/AddApp/AddApp.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Flex } from 'design';
 import Dialog, { DialogTitle } from 'design/Dialog';
 

--- a/web/packages/teleport/src/Apps/AddApp/Automatically.test.tsx
+++ b/web/packages/teleport/src/Apps/AddApp/Automatically.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { fireEvent, render, screen } from 'design/utils/testing';
 
 import { act } from '@testing-library/react';

--- a/web/packages/teleport/src/Apps/AddApp/Automatically.tsx
+++ b/web/packages/teleport/src/Apps/AddApp/Automatically.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { KeyboardEvent } from 'react';
+import { useState, useEffect, KeyboardEvent } from 'react';
 import {
   Link,
   Text,
@@ -38,11 +38,11 @@ import { State } from './useAddApp';
 export function Automatically(props: Props) {
   const { onClose, attempt, token } = props;
 
-  const [name, setName] = React.useState('');
-  const [uri, setUri] = React.useState('');
-  const [cmd, setCmd] = React.useState('');
+  const [name, setName] = useState('');
+  const [uri, setUri] = useState('');
+  const [cmd, setCmd] = useState('');
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (name && uri) {
       const cmd = createAppBashCommand(token.id, name, uri);
       setCmd(cmd);

--- a/web/packages/teleport/src/Apps/AddApp/Manually.test.tsx
+++ b/web/packages/teleport/src/Apps/AddApp/Manually.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { render, screen } from 'design/utils/testing';
 
 import { Manually } from './Manually';

--- a/web/packages/teleport/src/Apps/AddApp/Manually.tsx
+++ b/web/packages/teleport/src/Apps/AddApp/Manually.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import {
   Text,
   Box,

--- a/web/packages/teleport/src/Audit/Audit.story.tsx
+++ b/web/packages/teleport/src/Audit/Audit.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Router } from 'react-router';
 import { createMemoryHistory } from 'history';
 

--- a/web/packages/teleport/src/Audit/Audit.tsx
+++ b/web/packages/teleport/src/Audit/Audit.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { Danger } from 'design/Alert';
 import { Indicator, Box } from 'design';

--- a/web/packages/teleport/src/Audit/EventDialog/EventDialog.tsx
+++ b/web/packages/teleport/src/Audit/EventDialog/EventDialog.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import PropTypes from 'prop-types';
 import TextEditor from 'shared/components/TextEditor';
 import Dialog, {

--- a/web/packages/teleport/src/Audit/EventList/EventList.tsx
+++ b/web/packages/teleport/src/Audit/EventList/EventList.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { ButtonBorder, Flex } from 'design';
 import Table, { Cell } from 'design/DataTable';
 import { dateTimeMatcher } from 'design/utils/match';

--- a/web/packages/teleport/src/Audit/EventList/EventListCells.tsx
+++ b/web/packages/teleport/src/Audit/EventList/EventListCells.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Cell } from 'design/DataTable';
 import { ButtonBorder } from 'design';
 import { displayDateTime } from 'design/datetime';

--- a/web/packages/teleport/src/Audit/EventList/EventTypeCell.tsx
+++ b/web/packages/teleport/src/Audit/EventList/EventTypeCell.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 import { Cell } from 'design/DataTable';
 import * as Icons from 'design/Icon';

--- a/web/packages/teleport/src/Audit/EventList/ViewInPolicyButton.tsx
+++ b/web/packages/teleport/src/Audit/EventList/ViewInPolicyButton.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 
 import { ButtonBorder } from 'design';
 import { NavLink } from 'react-router-dom';

--- a/web/packages/teleport/src/AuthConnectors/AuthConnectors.story.tsx
+++ b/web/packages/teleport/src/AuthConnectors/AuthConnectors.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { ContextProvider } from 'teleport';
 import { createTeleportContext } from 'teleport/mocks/contexts';
 

--- a/web/packages/teleport/src/AuthConnectors/AuthConnectors.tsx
+++ b/web/packages/teleport/src/AuthConnectors/AuthConnectors.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Alert, Box, Flex, H3, Indicator, Link } from 'design';
 
 import { P } from 'design/Text/Text';

--- a/web/packages/teleport/src/AuthConnectors/ConnectorList/ConnectorList.tsx
+++ b/web/packages/teleport/src/AuthConnectors/ConnectorList/ConnectorList.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Box, ButtonPrimary, Flex, ResourceIcon, Text } from 'design';
 import { MenuIcon, MenuItem } from 'shared/components/MenuAction';
 

--- a/web/packages/teleport/src/AuthConnectors/DeleteConnectorDialog/DeleteConnectorDialog.story.tsx
+++ b/web/packages/teleport/src/AuthConnectors/DeleteConnectorDialog/DeleteConnectorDialog.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import DeleteDialog from './DeleteConnectorDialog';
 
 export default {

--- a/web/packages/teleport/src/AuthConnectors/DeleteConnectorDialog/DeleteConnectorDialog.tsx
+++ b/web/packages/teleport/src/AuthConnectors/DeleteConnectorDialog/DeleteConnectorDialog.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import useAttempt from 'shared/hooks/useAttemptNext';
 import { ButtonWarning, ButtonSecondary, Text, Alert, P1 } from 'design';
 import Dialog, {

--- a/web/packages/teleport/src/AuthConnectors/EmptyList/EmptyList.tsx
+++ b/web/packages/teleport/src/AuthConnectors/EmptyList/EmptyList.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Card, Flex, H1, ResourceIcon, Text } from 'design';
 import { AuthProviderType } from 'shared/services';
 

--- a/web/packages/teleport/src/AuthConnectors/ssoIcons/getSsoIcon.tsx
+++ b/web/packages/teleport/src/AuthConnectors/ssoIcons/getSsoIcon.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 import { AuthProviderType } from 'shared/services';
 import { Box, Flex, ResourceIcon } from 'design';

--- a/web/packages/teleport/src/Bots/Add/AddBots.tsx
+++ b/web/packages/teleport/src/Bots/Add/AddBots.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Switch, Route } from 'teleport/components/Router';
 import cfg from 'teleport/config';
 

--- a/web/packages/teleport/src/Bots/Add/AddBotsPicker.story.tsx
+++ b/web/packages/teleport/src/Bots/Add/AddBotsPicker.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 
 import { ContextProvider } from 'teleport';

--- a/web/packages/teleport/src/Bots/Add/AddBotsPicker.tsx
+++ b/web/packages/teleport/src/Bots/Add/AddBotsPicker.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 

--- a/web/packages/teleport/src/Bots/Add/GitHubActions/AddBotToWorkflow.story.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActions/AddBotToWorkflow.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 
 import { ContextProvider } from 'teleport';

--- a/web/packages/teleport/src/Bots/Add/GitHubActions/AddBotToWorkflow.test.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActions/AddBotToWorkflow.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { render, screen } from 'design/utils/testing';
 import { MemoryRouter } from 'react-router-dom';
 

--- a/web/packages/teleport/src/Bots/Add/GitHubActions/AddBotToWorkflow.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActions/AddBotToWorkflow.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import Box from 'design/Box';
 import { Text } from 'design';
 import TextEditor from 'shared/components/TextEditor';

--- a/web/packages/teleport/src/Bots/Add/GitHubActions/ConfigureBot.story.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActions/ConfigureBot.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 
 import { ContextProvider } from 'teleport';

--- a/web/packages/teleport/src/Bots/Add/GitHubActions/ConfigureBot.test.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActions/ConfigureBot.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { render, screen, userEvent } from 'design/utils/testing';
 

--- a/web/packages/teleport/src/Bots/Add/GitHubActions/ConfigureBot.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActions/ConfigureBot.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import styled from 'styled-components';
 
 import Box from 'design/Box';

--- a/web/packages/teleport/src/Bots/Add/GitHubActions/ConnectGitHub.story.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActions/ConnectGitHub.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 
 import { ContextProvider } from 'teleport';

--- a/web/packages/teleport/src/Bots/Add/GitHubActions/ConnectGitHub.test.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActions/ConnectGitHub.test.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { MemoryRouter } from 'react-router';
 
 import { render, screen } from 'design/utils/testing';

--- a/web/packages/teleport/src/Bots/Add/GitHubActions/ConnectGitHub.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActions/ConnectGitHub.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import styled from 'styled-components';
 
 import Box from 'design/Box';

--- a/web/packages/teleport/src/Bots/Add/GitHubActions/Finish.test.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActions/Finish.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { render, screen } from 'design/utils/testing';
 

--- a/web/packages/teleport/src/Bots/Add/GitHubActions/Finish.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActions/Finish.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Link } from 'react-router-dom';
 
 import Flex from 'design/Flex';

--- a/web/packages/teleport/src/Bots/Add/GitHubActions/GitHubActions.test.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActions/GitHubActions.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { render, screen, userEvent } from 'design/utils/testing';
 

--- a/web/packages/teleport/src/Bots/Add/Shared/FlowButtons.test.tsx
+++ b/web/packages/teleport/src/Bots/Add/Shared/FlowButtons.test.tsx
@@ -19,7 +19,6 @@
 import { render, screen, userEvent } from 'design/utils/testing';
 import { createMemoryHistory } from 'history';
 import { Router, MemoryRouter } from 'react-router';
-import React from 'react';
 
 import cfg from 'teleport/config';
 

--- a/web/packages/teleport/src/Bots/Add/Shared/FlowButtons.tsx
+++ b/web/packages/teleport/src/Bots/Add/Shared/FlowButtons.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 
 import { ButtonPrimary, ButtonSecondary } from 'design/Button';

--- a/web/packages/teleport/src/Bots/Add/Shared/GuidedFlow.tsx
+++ b/web/packages/teleport/src/Bots/Add/Shared/GuidedFlow.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import Flex from 'design/Flex';
 import { Text, H1 } from 'design';

--- a/web/packages/teleport/src/Bots/DeleteBot.tsx
+++ b/web/packages/teleport/src/Bots/DeleteBot.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Alert, ButtonSecondary, ButtonWarning, P1, Text } from 'design';
 import Dialog, {
   DialogContent,

--- a/web/packages/teleport/src/Bots/EditBot.tsx
+++ b/web/packages/teleport/src/Bots/EditBot.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Alert, ButtonSecondary, ButtonWarning } from 'design';
 import Dialog, {
   DialogContent,

--- a/web/packages/teleport/src/Bots/List/ActionCell.tsx
+++ b/web/packages/teleport/src/Bots/List/ActionCell.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Cell } from 'design/DataTable';
 import { MenuButton, MenuItem } from 'shared/components/MenuAction';
 

--- a/web/packages/teleport/src/Bots/List/BotList.tsx
+++ b/web/packages/teleport/src/Bots/List/BotList.tsx
@@ -18,7 +18,7 @@
 
 import Table, { LabelCell } from 'design/DataTable';
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { BotOptionsCell } from 'teleport/Bots/List/ActionCell';
 

--- a/web/packages/teleport/src/Bots/List/Bots.story.tsx
+++ b/web/packages/teleport/src/Bots/List/Bots.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 
 import { botsFixture } from 'teleport/Bots/fixtures';

--- a/web/packages/teleport/src/Bots/List/Bots.test.tsx
+++ b/web/packages/teleport/src/Bots/List/Bots.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { render, screen, userEvent, waitFor } from 'design/utils/testing';
 

--- a/web/packages/teleport/src/Bots/List/Bots.tsx
+++ b/web/packages/teleport/src/Bots/List/Bots.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useAttemptNext } from 'shared/hooks';
 import { Link } from 'react-router-dom';
 import { HoverTooltip } from 'design/Tooltip';

--- a/web/packages/teleport/src/Bots/List/EmptyState/EmptyState.tsx
+++ b/web/packages/teleport/src/Bots/List/EmptyState/EmptyState.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import styled, { useTheme } from 'styled-components';
 import { Link } from 'react-router-dom';
 import { ResourceIcon } from 'design/ResourceIcon';

--- a/web/packages/teleport/src/Bots/ViewBot.story.tsx
+++ b/web/packages/teleport/src/Bots/ViewBot.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { BotUiFlow } from 'teleport/services/bot/types';
 
 import { ContextProvider } from 'teleport';

--- a/web/packages/teleport/src/Bots/ViewBot.tsx
+++ b/web/packages/teleport/src/Bots/ViewBot.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { ButtonSecondary, Flex, Text } from 'design';
 import Dialog, {
   DialogContent,

--- a/web/packages/teleport/src/Clusters/Clusters.story.tsx
+++ b/web/packages/teleport/src/Clusters/Clusters.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Router } from 'react-router';
 import { createMemoryHistory } from 'history';
 

--- a/web/packages/teleport/src/Clusters/Clusters.tsx
+++ b/web/packages/teleport/src/Clusters/Clusters.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Box, Indicator } from 'design';
 import { Danger } from 'design/Alert';
 

--- a/web/packages/teleport/src/Console/ActionBar/ActionBar.tsx
+++ b/web/packages/teleport/src/Console/ActionBar/ActionBar.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { LatencyDiagnostic } from 'shared/components/LatencyDiagnostic';
 
 import { Flex } from 'design';

--- a/web/packages/teleport/src/Console/Console.story.tsx
+++ b/web/packages/teleport/src/Console/Console.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { useState } from 'react';
 import { Flex } from 'design';
 import { createMemoryHistory } from 'history';
 import { Router, Route } from 'react-router';
@@ -60,11 +60,11 @@ ConsoleStory.parameters = {
 };
 
 export function TestLayout(props: PropType) {
-  const [context] = React.useState((): ConsoleContext => {
+  const [context] = useState((): ConsoleContext => {
     return props.ctx || new ConsoleContext();
   });
 
-  const [history] = React.useState((): any => {
+  const [history] = useState((): any => {
     const history =
       props.history ||
       createMemoryHistory({

--- a/web/packages/teleport/src/Console/Console.tsx
+++ b/web/packages/teleport/src/Console/Console.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { useEffect, useMemo } from 'react';
 import styled from 'styled-components';
 import { Box, Flex, Indicator } from 'design';
 import { Danger } from 'design/Alert';
@@ -52,7 +52,7 @@ export default function Console() {
   const hasSshSessions = storeDocs.getSshDocuments().length > 0;
   const { attempt, run } = useAttempt();
 
-  React.useEffect(() => {
+  useEffect(() => {
     run(() => consoleCtx.initStoreUser());
   }, []);
 
@@ -134,7 +134,7 @@ export default function Console() {
  */
 function MemoizedDocument(props: { doc: stores.Document; visible: boolean }) {
   const { doc, visible } = props;
-  return React.useMemo(() => {
+  return useMemo(() => {
     switch (doc.kind) {
       case 'terminal':
         return <DocumentSsh doc={doc} visible={visible} />;

--- a/web/packages/teleport/src/Console/DocumentBlank/DocumentBlank.story.tsx
+++ b/web/packages/teleport/src/Console/DocumentBlank/DocumentBlank.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import DocumentBlank from './DocumentBlank';
 import { TestLayout } from './../Console.story';
 

--- a/web/packages/teleport/src/Console/DocumentBlank/DocumentBlank.tsx
+++ b/web/packages/teleport/src/Console/DocumentBlank/DocumentBlank.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Flex, ButtonPrimary } from 'design';
 import * as Icons from 'design/Icon';
 

--- a/web/packages/teleport/src/Console/DocumentDb/ConnectDialog.tsx
+++ b/web/packages/teleport/src/Console/DocumentDb/ConnectDialog.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Dialog, {
   DialogContent,
   DialogFooter,

--- a/web/packages/teleport/src/Console/DocumentDb/DocumentDb.story.tsx
+++ b/web/packages/teleport/src/Console/DocumentDb/DocumentDb.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { createTeleportContext } from 'teleport/mocks/contexts';
 import ConsoleCtx from 'teleport/Console/consoleContext';
 

--- a/web/packages/teleport/src/Console/DocumentDb/DocumentDb.test.tsx
+++ b/web/packages/teleport/src/Console/DocumentDb/DocumentDb.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 
 import '@testing-library/jest-dom';

--- a/web/packages/teleport/src/Console/DocumentDb/DocumentDb.tsx
+++ b/web/packages/teleport/src/Console/DocumentDb/DocumentDb.tsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import React, { useRef, useEffect } from 'react';
+import { useRef, useEffect } from 'react';
 
 import { useTheme } from 'styled-components';
 import { Box, Indicator } from 'design';

--- a/web/packages/teleport/src/Console/DocumentDb/useDbSession.tsx
+++ b/web/packages/teleport/src/Console/DocumentDb/useDbSession.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { useRef, useState, useEffect } from 'react';
 
 import { context, trace } from '@opentelemetry/api';
 
@@ -34,10 +34,10 @@ const tracer = trace.getTracer('TTY');
 export function useDbSession(doc: DocumentDb) {
   const { clusterId, sid } = doc;
   const ctx = useConsoleContext();
-  const ttyRef = React.useRef<Tty>(null);
+  const ttyRef = useRef<Tty>(null);
   const tty = ttyRef.current;
-  const [session, setSession] = React.useState<Session>(null);
-  const [status, setStatus] = React.useState<Status>('loading');
+  const [session, setSession] = useState<Session>(null);
+  const [status, setStatus] = useState<Status>('loading');
 
   function closeDocument() {
     ctx.closeTab(doc);
@@ -51,7 +51,7 @@ export function useDbSession(doc: DocumentDb) {
     setStatus('initialized');
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     const session: Session = {
       kind: 'db',
       clusterId,

--- a/web/packages/teleport/src/Console/DocumentKubeExec/DocumentKubeExec.story.tsx
+++ b/web/packages/teleport/src/Console/DocumentKubeExec/DocumentKubeExec.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { createTeleportContext } from 'teleport/mocks/contexts';
 import ConsoleCtx from 'teleport/Console/consoleContext';
 

--- a/web/packages/teleport/src/Console/DocumentKubeExec/DocumentKubeExec.test.tsx
+++ b/web/packages/teleport/src/Console/DocumentKubeExec/DocumentKubeExec.test.tsx
@@ -15,7 +15,6 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
 import { screen } from '@testing-library/react';
 
 import '@testing-library/jest-dom';

--- a/web/packages/teleport/src/Console/DocumentKubeExec/DocumentKubeExec.tsx
+++ b/web/packages/teleport/src/Console/DocumentKubeExec/DocumentKubeExec.tsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import React, { useRef, useEffect } from 'react';
+import { useRef, useEffect } from 'react';
 
 import { useTheme } from 'styled-components';
 import { Box, Indicator } from 'design';

--- a/web/packages/teleport/src/Console/DocumentKubeExec/KubeExecDataDialog.tsx
+++ b/web/packages/teleport/src/Console/DocumentKubeExec/KubeExecDataDialog.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import Dialog, {
   DialogContent,
   DialogFooter,

--- a/web/packages/teleport/src/Console/DocumentKubeExec/useKubeExecSession.tsx
+++ b/web/packages/teleport/src/Console/DocumentKubeExec/useKubeExecSession.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { useRef, useState, useEffect } from 'react';
 
 import { context, trace } from '@opentelemetry/api';
 
@@ -38,10 +38,10 @@ const tracer = trace.getTracer('TTY');
 export default function useKubeExecSession(doc: DocumentKubeExec) {
   const { clusterId, sid, kubeCluster, mode } = doc;
   const ctx = useConsoleContext();
-  const ttyRef = React.useRef<Tty>(null);
+  const ttyRef = useRef<Tty>(null);
   const tty = ttyRef.current as ReturnType<typeof ctx.createTty>;
-  const [session, setSession] = React.useState<Session>(null);
-  const [status, setStatus] = React.useState<Status>('loading');
+  const [session, setSession] = useState<Session>(null);
+  const [status, setStatus] = useState<Status>('loading');
 
   function closeDocument() {
     ctx.closeTab(doc);
@@ -73,7 +73,7 @@ export default function useKubeExecSession(doc: DocumentKubeExec) {
     setStatus('initialized');
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     function initTty(session, mode?: ParticipantMode) {
       tracer.startActiveSpan(
         'initTTY',

--- a/web/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.tsx
+++ b/web/packages/teleport/src/Console/DocumentNodes/DocumentNodes.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Node } from 'teleport/services/nodes/types';
 
 import DocumentNodes from './DocumentNodes';

--- a/web/packages/teleport/src/Console/DocumentSsh/DocumentSsh.story.tsx
+++ b/web/packages/teleport/src/Console/DocumentSsh/DocumentSsh.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { ContextProvider } from 'teleport';
 
 import { createTeleportContext } from 'teleport/mocks/contexts';

--- a/web/packages/teleport/src/Console/DocumentSsh/DocumentSsh.tsx
+++ b/web/packages/teleport/src/Console/DocumentSsh/DocumentSsh.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useRef, useEffect, useState, useCallback } from 'react';
+import { useRef, useEffect, useState, useCallback } from 'react';
 import { useTheme } from 'styled-components';
 
 import { Indicator, Box } from 'design';

--- a/web/packages/teleport/src/Console/DocumentSsh/ShareSession/ShareSession.story.tsx
+++ b/web/packages/teleport/src/Console/DocumentSsh/ShareSession/ShareSession.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import Component from './ShareSession';
 
 export default {

--- a/web/packages/teleport/src/Console/DocumentSsh/ShareSession/ShareSession.tsx
+++ b/web/packages/teleport/src/Console/DocumentSsh/ShareSession/ShareSession.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Text, ButtonSecondary } from 'design';
 import Dialog, {
   DialogHeader,

--- a/web/packages/teleport/src/Console/DocumentSsh/useSshSession.ts
+++ b/web/packages/teleport/src/Console/DocumentSsh/useSshSession.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { useRef, useState, useEffect } from 'react';
 
 import { context, trace } from '@opentelemetry/api';
 
@@ -38,16 +38,16 @@ const tracer = trace.getTracer('TTY');
 export default function useSshSession(doc: DocumentSsh) {
   const { clusterId, sid, serverId, login, mode } = doc;
   const ctx = useConsoleContext();
-  const ttyRef = React.useRef<Tty>(null);
+  const ttyRef = useRef<Tty>(null);
   const tty = ttyRef.current as ReturnType<typeof ctx.createTty>;
-  const [session, setSession] = React.useState<Session>(null);
-  const [status, setStatus] = React.useState<Status>('loading');
+  const [session, setSession] = useState<Session>(null);
+  const [status, setStatus] = useState<Status>('loading');
 
   function closeDocument() {
     ctx.closeTab(doc);
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     function initTty(session, mode?: ParticipantMode) {
       tracer.startActiveSpan(
         'initTTY',

--- a/web/packages/teleport/src/Console/Tabs/JoinedUsers/JoinedUsers.jsx
+++ b/web/packages/teleport/src/Console/Tabs/JoinedUsers/JoinedUsers.jsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { useRef, useState, useMemo } from 'react';
 import styled from 'styled-components';
 import Popover from 'design/Popover';
 import { Box } from 'design';
@@ -24,10 +24,10 @@ import { debounce } from 'shared/utils/highbar';
 
 export default function JoinedUsers(props) {
   const { active, users, open = false, ml, mr } = props;
-  const ref = React.useRef(null);
-  const [isOpen, setIsOpen] = React.useState(open);
+  const ref = useRef(null);
+  const [isOpen, setIsOpen] = useState(open);
 
-  const handleOpen = React.useMemo(() => {
+  const handleOpen = useMemo(() => {
     return debounce(() => setIsOpen(true), 300);
   }, []);
 

--- a/web/packages/teleport/src/Console/Tabs/JoinedUsers/JoinedUsers.story.jsx
+++ b/web/packages/teleport/src/Console/Tabs/JoinedUsers/JoinedUsers.story.jsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import Component from './JoinedUsers';
 
 export default {

--- a/web/packages/teleport/src/Console/Tabs/TabItem.tsx
+++ b/web/packages/teleport/src/Console/Tabs/TabItem.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 import { Cross as CloseIcon } from 'design/Icon';
 import { space } from 'design/system';

--- a/web/packages/teleport/src/Console/Tabs/Tabs.story.tsx
+++ b/web/packages/teleport/src/Console/Tabs/Tabs.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import Tabs from './Tabs';
 import { TestLayout } from './../Console.story';
 

--- a/web/packages/teleport/src/Console/Tabs/Tabs.tsx
+++ b/web/packages/teleport/src/Console/Tabs/Tabs.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 import { typography } from 'design/system';
 

--- a/web/packages/teleport/src/Console/index.tsx
+++ b/web/packages/teleport/src/Console/index.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { useState } from 'react';
 
 import Console from './Console';
 import ConsoleContext from './consoleContext';
@@ -25,7 +25,7 @@ import ConsoleContextProvider from './consoleContextProvider';
 // Main entry point to Console where it initializes ContextProvider with the
 // instance of ConsoleContext.
 export function ConsoleWithContext() {
-  const [ctx] = React.useState(() => {
+  const [ctx] = useState(() => {
     return new ConsoleContext();
   });
 

--- a/web/packages/teleport/src/Console/useKeyboardNav.ts
+++ b/web/packages/teleport/src/Console/useKeyboardNav.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { useEffect } from 'react';
 
 import { getPlatformType } from 'design/platform';
 
@@ -56,7 +56,7 @@ export function getMappedAction(event) {
  * @param ctx data that is shared between Console related components
  */
 const useKeyboardNav = (ctx: ConsoleContext) => {
-  React.useEffect(() => {
+  useEffect(() => {
     const handleKeydown = event => {
       const { tabSwitch } = getMappedAction(event);
       if (!tabSwitch) {

--- a/web/packages/teleport/src/Console/useOnExitConfirmation.ts
+++ b/web/packages/teleport/src/Console/useOnExitConfirmation.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { useEffect } from 'react';
 
 import session from 'teleport/services/websession';
 
@@ -35,7 +35,7 @@ const TAB_MIN_AGE = 30000;
  * @param ctx data that is shared between Console related components.
  */
 function useOnExitConfirmation(ctx: ConsoleContext) {
-  React.useEffect(() => {
+  useEffect(() => {
     /**
      * handleBeforeUnload listens for browser closes and refreshes.
      * Checks if users need to be notified before closing based on type

--- a/web/packages/teleport/src/Console/usePageTitle.tsx
+++ b/web/packages/teleport/src/Console/usePageTitle.tsx
@@ -16,14 +16,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { useEffect } from 'react';
 
 import * as stores from './stores/types';
 
 export default function usePageTitle(doc: stores.Document) {
   const title =
     doc && doc.title ? `${doc.title} • ${doc.clusterId}` : 'Console';
-  React.useEffect(() => {
+  useEffect(() => {
     document.title = title;
   }, [title]);
 }

--- a/web/packages/teleport/src/Console/useTabRouting.test.tsx
+++ b/web/packages/teleport/src/Console/useTabRouting.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { createMemoryHistory } from 'history';
 import { Router } from 'react-router';
 import renderHook from 'design/utils/renderHook';

--- a/web/packages/teleport/src/Console/useTabRouting.ts
+++ b/web/packages/teleport/src/Console/useTabRouting.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { useMemo } from 'react';
 import { useRouteMatch, useParams, useLocation } from 'react-router';
 
 import cfg, {
@@ -44,7 +44,7 @@ export default function useRouting(ctx: ConsoleContext) {
   );
 
   // Ensure that each URL has corresponding document
-  React.useMemo(() => {
+  useMemo(() => {
     if (ctx.getActiveDocId(pathname) !== -1) {
       return;
     }

--- a/web/packages/teleport/src/Databases/ConnectDialog/ConnectDialog.story.tsx
+++ b/web/packages/teleport/src/Databases/ConnectDialog/ConnectDialog.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import ConnectDialog from './ConnectDialog';
 
 export default {

--- a/web/packages/teleport/src/Databases/ConnectDialog/ConnectDialog.test.tsx
+++ b/web/packages/teleport/src/Databases/ConnectDialog/ConnectDialog.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { render, screen } from 'design/utils/testing';
 
 import ConnectDialog, { Props } from './ConnectDialog';

--- a/web/packages/teleport/src/Databases/ConnectDialog/ConnectDialog.tsx
+++ b/web/packages/teleport/src/Databases/ConnectDialog/ConnectDialog.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Text, Box, ButtonSecondary, Link, ButtonPrimary } from 'design';
 import Dialog, {
   DialogHeader,

--- a/web/packages/teleport/src/DesktopSession/ActionMenu.tsx
+++ b/web/packages/teleport/src/DesktopSession/ActionMenu.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MenuIcon, MenuItem, MenuItemIcon } from 'shared/components/MenuAction';
 import * as Icons from 'design/Icon';
 import { Flex } from 'design';

--- a/web/packages/teleport/src/DesktopSession/AlertDropdown.tsx
+++ b/web/packages/teleport/src/DesktopSession/AlertDropdown.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { Flex, Button, Card, ButtonIcon, H3 } from 'design';
 import styled, { useTheme } from 'styled-components';
 import { Notification } from 'shared/components/Notification';

--- a/web/packages/teleport/src/DesktopSession/DesktopSession.story.tsx
+++ b/web/packages/teleport/src/DesktopSession/DesktopSession.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { ButtonPrimary } from 'design/Button';
 import { NotificationItem } from 'shared/components/Notification';
 import { throttle } from 'shared/utils/highbar';

--- a/web/packages/teleport/src/DesktopSession/DesktopSession.tsx
+++ b/web/packages/teleport/src/DesktopSession/DesktopSession.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Indicator, Box, Flex, ButtonSecondary, ButtonPrimary } from 'design';
 import { Info } from 'design/Alert';
 import Dialog, {

--- a/web/packages/teleport/src/DesktopSession/TopBar.tsx
+++ b/web/packages/teleport/src/DesktopSession/TopBar.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { useTheme } from 'styled-components';
 import { Text, TopNav, Flex } from 'design';
 import { Clipboard, FolderShared } from 'design/Icon';

--- a/web/packages/teleport/src/DeviceTrust/DeviceTrustLocked.tsx
+++ b/web/packages/teleport/src/DeviceTrust/DeviceTrustLocked.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 
 import { Box, Flex, Link } from 'design';

--- a/web/packages/teleport/src/Discover/AwsMangementConsole/CreateAppAccess/AppCreatedDialog.tsx
+++ b/web/packages/teleport/src/Discover/AwsMangementConsole/CreateAppAccess/AppCreatedDialog.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Text, Flex, ButtonPrimary } from 'design';
 import * as Icons from 'design/Icon';
 import Dialog, { DialogContent } from 'design/DialogConfirmation';

--- a/web/packages/teleport/src/Discover/AwsMangementConsole/CreateAppAccess/CreateAppAccess.story.tsx
+++ b/web/packages/teleport/src/Discover/AwsMangementConsole/CreateAppAccess/CreateAppAccess.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { delay, http, HttpResponse } from 'msw';
 import { Info } from 'design/Alert';

--- a/web/packages/teleport/src/Discover/AwsMangementConsole/CreateAppAccess/CreateAppAccess.test.tsx
+++ b/web/packages/teleport/src/Discover/AwsMangementConsole/CreateAppAccess/CreateAppAccess.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { render, screen, userEvent } from 'design/utils/testing';
 

--- a/web/packages/teleport/src/Discover/AwsMangementConsole/CreateAppAccess/CreateAppAccess.tsx
+++ b/web/packages/teleport/src/Discover/AwsMangementConsole/CreateAppAccess/CreateAppAccess.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 import { Box, Flex, Link, Mark, H3 } from 'design';
 import TextEditor from 'shared/components/TextEditor';

--- a/web/packages/teleport/src/Discover/AwsMangementConsole/TestConnection/TestConnection.story.tsx
+++ b/web/packages/teleport/src/Discover/AwsMangementConsole/TestConnection/TestConnection.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 
 import { ContextProvider } from 'teleport';

--- a/web/packages/teleport/src/Discover/AwsMangementConsole/TestConnection/TestConnection.tsx
+++ b/web/packages/teleport/src/Discover/AwsMangementConsole/TestConnection/TestConnection.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Box, Link, Mark, H3 } from 'design';
 import Select from 'shared/components/Select';
 import { OutlineInfo } from 'design/Alert/Alert';

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.story.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { http, HttpResponse } from 'msw';
 import { withoutQuery } from 'web/packages/build/storybook';

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useCallback, useState, useRef } from 'react';
+import { useEffect, useCallback, useState, useRef } from 'react';
 import { Link } from 'react-router-dom';
 
 import { ButtonSecondary } from 'design/Button';

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.story.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/TestConnection/TestConnection.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { http, HttpResponse, delay } from 'msw';
 

--- a/web/packages/teleport/src/Discover/Database/CreateDatabase/CreateDatabase.story.tsx
+++ b/web/packages/teleport/src/Discover/Database/CreateDatabase/CreateDatabase.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 
 import { DatabaseEngine, DatabaseLocation } from '../../SelectResource';

--- a/web/packages/teleport/src/Discover/Database/CreateDatabase/CreateDatabase.tsx
+++ b/web/packages/teleport/src/Discover/Database/CreateDatabase/CreateDatabase.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Text, Box, Flex, Mark } from 'design';
 
 import Validation, { Validator } from 'shared/components/Validation';

--- a/web/packages/teleport/src/Discover/Database/CreateDatabase/CreateDatabaseDialog.story.tsx
+++ b/web/packages/teleport/src/Discover/Database/CreateDatabase/CreateDatabaseDialog.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Info } from 'design/Alert';
 
 import {

--- a/web/packages/teleport/src/Discover/Database/CreateDatabase/CreateDatabaseDialog.tsx
+++ b/web/packages/teleport/src/Discover/Database/CreateDatabase/CreateDatabaseDialog.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import {
   Text,
   Flex,

--- a/web/packages/teleport/src/Discover/Database/CreateDatabase/useCreateDatabase.test.tsx
+++ b/web/packages/teleport/src/Discover/Database/CreateDatabase/useCreateDatabase.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { renderHook, act, waitFor } from '@testing-library/react';
 

--- a/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.story.tsx
+++ b/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { delay, http, HttpResponse } from 'msw';
 
 import cfg from 'teleport/config';

--- a/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.test.tsx
+++ b/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { act, fireEvent, render, screen } from 'design/utils/testing';
 

--- a/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.tsx
+++ b/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import styled, { useTheme } from 'styled-components';
 import {
   Box,

--- a/web/packages/teleport/src/Discover/Database/DeployService/DeployService.tsx
+++ b/web/packages/teleport/src/Discover/Database/DeployService/DeployService.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { ServiceDeployMethod } from '../common';
 

--- a/web/packages/teleport/src/Discover/Database/DeployService/ManualDeploy/ManualDeploy.story.tsx
+++ b/web/packages/teleport/src/Discover/Database/DeployService/ManualDeploy/ManualDeploy.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { http, HttpResponse } from 'msw';
 

--- a/web/packages/teleport/src/Discover/Database/DeployService/ManualDeploy/ManualDeploy.tsx
+++ b/web/packages/teleport/src/Discover/Database/DeployService/ManualDeploy/ManualDeploy.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { Suspense, useState, useEffect } from 'react';
+import { Suspense, useState, useEffect } from 'react';
 import { Box, ButtonSecondary, Text, Mark, H3 } from 'design';
 import * as Icons from 'design/Icon';
 import Validation, { Validator } from 'shared/components/Validation';

--- a/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/AutoDiscoverToggle.tsx
+++ b/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/AutoDiscoverToggle.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Box, Toggle } from 'design';
 
 import { IconTooltip } from 'design/Tooltip';

--- a/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/AutoEnrollment.tsx
+++ b/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/AutoEnrollment.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Text } from 'design';
 import { FetchStatus } from 'design/DataTable/types';
 import useAttempt, { Attempt } from 'shared/hooks/useAttemptNext';

--- a/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/EnrollRdsDatabase.story.tsx
+++ b/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/EnrollRdsDatabase.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { MemoryRouter } from 'react-router';
 import { http, HttpResponse, delay } from 'msw';
 import { Info } from 'design/Alert';

--- a/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/EnrollRdsDatabase.test.tsx
+++ b/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/EnrollRdsDatabase.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { render, screen, fireEvent, act } from 'design/utils/testing';
 
 import {

--- a/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/EnrollRdsDatabase.tsx
+++ b/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/EnrollRdsDatabase.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Box, Indicator } from 'design';
 import { Danger } from 'design/Alert';
 import useAttempt from 'shared/hooks/useAttemptNext';

--- a/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/RdsDatabaseList.tsx
+++ b/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/RdsDatabaseList.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import Table from 'design/DataTable';
 import { FetchStatus } from 'design/DataTable/types';
 

--- a/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/SingleEnrollment.tsx
+++ b/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/SingleEnrollment.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Text } from 'design';
 import { FetchStatus } from 'design/DataTable/types';
 import { Attempt } from 'shared/hooks/useAttemptNext';

--- a/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/VpcSelector.tsx
+++ b/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/VpcSelector.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { components } from 'react-select';
 import { Box, Flex, LabelInput, Link, ButtonIcon } from 'design';
 import Select from 'shared/components/Select';

--- a/web/packages/teleport/src/Discover/Database/IamPolicy/IamPolicy.story.tsx
+++ b/web/packages/teleport/src/Discover/Database/IamPolicy/IamPolicy.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 
 import { IamPolicyView } from './IamPolicy';

--- a/web/packages/teleport/src/Discover/Database/IamPolicy/IamPolicy.tsx
+++ b/web/packages/teleport/src/Discover/Database/IamPolicy/IamPolicy.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Text, Box, Flex, Indicator, Link, H3 } from 'design';
 import * as Icons from 'design/Icon';
 

--- a/web/packages/teleport/src/Discover/Database/MutualTls/MutualTls.story.tsx
+++ b/web/packages/teleport/src/Discover/Database/MutualTls/MutualTls.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 
 import { DatabaseEngine } from '../../SelectResource';

--- a/web/packages/teleport/src/Discover/Database/MutualTls/MutualTls.tsx
+++ b/web/packages/teleport/src/Discover/Database/MutualTls/MutualTls.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Text, Box, Flex, Link, Mark } from 'design';
 import { Danger } from 'design/Alert';
 import { Info } from 'design/Icon';

--- a/web/packages/teleport/src/Discover/Database/SetupAccess/SetupAccess.story.tsx
+++ b/web/packages/teleport/src/Discover/Database/SetupAccess/SetupAccess.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { http, HttpResponse } from 'msw';
 
 import { noAccess, getAcl } from 'teleport/mocks/contexts';

--- a/web/packages/teleport/src/Discover/Database/TestConnection/TestConnection.test.tsx
+++ b/web/packages/teleport/src/Discover/Database/TestConnection/TestConnection.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { render, screen, userEvent } from 'design/utils/testing';
 
 import { userEventService } from 'teleport/services/userEvent';

--- a/web/packages/teleport/src/Discover/Database/TestConnection/TestConnection.tsx
+++ b/web/packages/teleport/src/Discover/Database/TestConnection/TestConnection.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Box, LabelInput, H3, Subtitle3 } from 'design';
 
 import Select, { Option } from 'shared/components/Select';

--- a/web/packages/teleport/src/Discover/Database/common.tsx
+++ b/web/packages/teleport/src/Discover/Database/common.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Box, Label as Pill, Mark } from 'design';
 import * as Icons from 'design/Icon';
 

--- a/web/packages/teleport/src/Discover/Discover.test.tsx
+++ b/web/packages/teleport/src/Discover/Discover.test.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { MemoryRouter } from 'react-router';
 
 import { render, screen } from 'design/utils/testing';

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/AgentWaitingDialog.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/AgentWaitingDialog.tsx
@@ -24,7 +24,7 @@ import {
   Flex,
   Mark,
 } from 'design';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 import * as Icons from 'design/Icon';
 

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/Dialogs.story.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/Dialogs.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { MemoryRouter } from 'react-router';
 import { http, HttpResponse, delay } from 'msw';
 

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EksClustersList.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EksClustersList.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import Table from 'design/DataTable';
 import { FetchStatus } from 'design/DataTable/types';
 

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEKSCluster.test.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEKSCluster.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { render, screen, fireEvent, act } from 'design/utils/testing';
 
 import {

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.story.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.story.tsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 import { MemoryRouter } from 'react-router';
 

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEksCluster.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import {
   Box,
   ButtonPrimary,

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollmentDialog.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollmentDialog.tsx
@@ -15,7 +15,6 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
 import {
   AnimatedProgressBar,
   ButtonPrimary,

--- a/web/packages/teleport/src/Discover/Kubernetes/HelmChart/HelmChart.story.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/HelmChart/HelmChart.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { StoryObj } from '@storybook/react';
 import { withoutQuery } from 'web/packages/build/storybook';

--- a/web/packages/teleport/src/Discover/Kubernetes/HelmChart/HelmChart.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/HelmChart/HelmChart.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { Suspense, useState } from 'react';
+import { Suspense, useState } from 'react';
 import styled from 'styled-components';
 import { Box, ButtonSecondary, Link, Text, Mark, H3, Subtitle3 } from 'design';
 import * as Icons from 'design/Icon';

--- a/web/packages/teleport/src/Discover/Kubernetes/SetupAccess/SetupAccess.story.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/SetupAccess/SetupAccess.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 
 import { initSelectedOptionsHelper } from 'teleport/Discover/Shared/SetupAccess';

--- a/web/packages/teleport/src/Discover/Kubernetes/TestConnection/TestConnection.story.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/TestConnection/TestConnection.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 
 import { TestConnection } from './TestConnection';

--- a/web/packages/teleport/src/Discover/Kubernetes/TestConnection/TestConnection.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/TestConnection/TestConnection.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Box, H3, Subtitle3 } from 'design';
 import Validation, { Validator } from 'shared/components/Validation';
 import FieldInput from 'shared/components/FieldInput';

--- a/web/packages/teleport/src/Discover/SelectResource/PermissionsErrorMessage.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/PermissionsErrorMessage.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Text, Box } from 'design';
 
 import { ResourceKind } from '../Shared';

--- a/web/packages/teleport/src/Discover/SelectResource/SelectResource.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/SelectResource.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useHistory, useLocation } from 'react-router';
 
 import * as Icons from 'design/Icon';

--- a/web/packages/teleport/src/Discover/SelectResource/icons.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/icons.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { ResourceIcon, ResourceIconName } from 'design/ResourceIcon';
 
 interface DiscoverIconProps {

--- a/web/packages/teleport/src/Discover/Server/CreateEc2Ice/CreateEc2Ice.story.tsx
+++ b/web/packages/teleport/src/Discover/Server/CreateEc2Ice/CreateEc2Ice.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 
 import { http, HttpResponse, delay } from 'msw';

--- a/web/packages/teleport/src/Discover/Server/CreateEc2Ice/CreateEc2IceDialog.tsx
+++ b/web/packages/teleport/src/Discover/Server/CreateEc2Ice/CreateEc2IceDialog.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Text,
   Flex,

--- a/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigCreatedDialog.tsx
+++ b/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigCreatedDialog.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Text, Flex, ButtonPrimary, Box } from 'design';
 import * as Icons from 'design/Icon';
 import Dialog, { DialogContent } from 'design/DialogConfirmation';

--- a/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigSsm.story.tsx
+++ b/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigSsm.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { MemoryRouter } from 'react-router';
 import { http, HttpResponse, delay } from 'msw';
 import { Info } from 'design/Alert';

--- a/web/packages/teleport/src/Discover/Server/DownloadScript/DownloadScript.story.tsx
+++ b/web/packages/teleport/src/Discover/Server/DownloadScript/DownloadScript.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { StoryObj } from '@storybook/react';
 import { withoutQuery } from 'web/packages/build/storybook';

--- a/web/packages/teleport/src/Discover/Server/EnrollEc2Instance/Ec2InstanceList.tsx
+++ b/web/packages/teleport/src/Discover/Server/EnrollEc2Instance/Ec2InstanceList.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Text } from 'design';
 import Table from 'design/DataTable';
 import { FetchStatus } from 'design/DataTable/types';

--- a/web/packages/teleport/src/Discover/Server/EnrollEc2Instance/EnrollEc2Instance.story.tsx
+++ b/web/packages/teleport/src/Discover/Server/EnrollEc2Instance/EnrollEc2Instance.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { MemoryRouter } from 'react-router';
 
 import { http, HttpResponse, delay } from 'msw';

--- a/web/packages/teleport/src/Discover/Server/EnrollEc2Instance/EnrollEc2Instance.test.tsx
+++ b/web/packages/teleport/src/Discover/Server/EnrollEc2Instance/EnrollEc2Instance.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 import {
   render,

--- a/web/packages/teleport/src/Discover/Server/EnrollEc2Instance/EnrollEc2Instance.tsx
+++ b/web/packages/teleport/src/Discover/Server/EnrollEc2Instance/EnrollEc2Instance.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Box, Link as ExternalLink, Text, Toggle } from 'design';
 import { Link as InternalLink } from 'react-router-dom';
 import { FetchStatus } from 'design/DataTable/types';

--- a/web/packages/teleport/src/Discover/Server/EnrollEc2Instance/NoEc2IceRequiredDialog.tsx
+++ b/web/packages/teleport/src/Discover/Server/EnrollEc2Instance/NoEc2IceRequiredDialog.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Text, Flex, ButtonPrimary, Mark } from 'design';
 import * as Icons from 'design/Icon';
 import Dialog, { DialogContent } from 'design/DialogConfirmation';

--- a/web/packages/teleport/src/Discover/Server/SetupAccess/SetupAccess.story.tsx
+++ b/web/packages/teleport/src/Discover/Server/SetupAccess/SetupAccess.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 
 import { initSelectedOptionsHelper } from 'teleport/Discover/Shared/SetupAccess';

--- a/web/packages/teleport/src/Discover/Server/Shared.tsx
+++ b/web/packages/teleport/src/Discover/Server/Shared.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Link as InternalLink } from 'react-router-dom';
 import { OutlineInfo } from 'design/Alert/Alert';
 import { Mark } from 'design';

--- a/web/packages/teleport/src/Discover/Server/TestConnection/TestConnection.story.tsx
+++ b/web/packages/teleport/src/Discover/Server/TestConnection/TestConnection.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 
 import { ContextProvider } from 'teleport';

--- a/web/packages/teleport/src/Discover/Server/TestConnection/TestConnection.tsx
+++ b/web/packages/teleport/src/Discover/Server/TestConnection/TestConnection.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { ButtonSecondary, Box, LabelInput, H3, Subtitle3 } from 'design';
 import Select from 'shared/components/Select';
 

--- a/web/packages/teleport/src/Discover/Shared/Aws/ConfigureIamPerms.story.tsx
+++ b/web/packages/teleport/src/Discover/Shared/Aws/ConfigureIamPerms.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { ConfigureIamPerms } from './ConfigureIamPerms';
 
 export default {

--- a/web/packages/teleport/src/Discover/Shared/Aws/ConfigureIamPerms.tsx
+++ b/web/packages/teleport/src/Discover/Shared/Aws/ConfigureIamPerms.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 import { Flex, Link, Box, H3 } from 'design';
 import { assertUnreachable } from 'shared/utils/assertUnreachable';

--- a/web/packages/teleport/src/Discover/Shared/Aws/Labels.tsx
+++ b/web/packages/teleport/src/Discover/Shared/Aws/Labels.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Flex, Label as Pill } from 'design';
 
 import { Label } from 'teleport/types';

--- a/web/packages/teleport/src/Discover/Shared/Aws/RadioCell.tsx
+++ b/web/packages/teleport/src/Discover/Shared/Aws/RadioCell.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Flex } from 'design';
 
 import { DisableableCell } from './DisableableCell';

--- a/web/packages/teleport/src/Discover/Shared/Aws/StatusCell.tsx
+++ b/web/packages/teleport/src/Discover/Shared/Aws/StatusCell.tsx
@@ -17,7 +17,6 @@
  */
 
 import { Flex } from 'design';
-import React from 'react';
 
 import { DisableableCell as Cell } from 'teleport/Discover/Shared';
 

--- a/web/packages/teleport/src/Discover/Shared/AwsAccount/AwsAccount.story.tsx
+++ b/web/packages/teleport/src/Discover/Shared/AwsAccount/AwsAccount.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 
 import { http, HttpResponse, delay } from 'msw';

--- a/web/packages/teleport/src/Discover/Shared/AwsAccount/AwsAccount.test.tsx
+++ b/web/packages/teleport/src/Discover/Shared/AwsAccount/AwsAccount.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { render, screen, fireEvent } from 'design/utils/testing';
 

--- a/web/packages/teleport/src/Discover/Shared/AwsAccount/AwsAccount.tsx
+++ b/web/packages/teleport/src/Discover/Shared/AwsAccount/AwsAccount.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import {
   Box,

--- a/web/packages/teleport/src/Discover/Shared/AwsRegionSelector/AwsRegionSelector.story.tsx
+++ b/web/packages/teleport/src/Discover/Shared/AwsRegionSelector/AwsRegionSelector.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Text } from 'design';
 
 import { AwsRegionSelector } from './AwsRegionSelector';

--- a/web/packages/teleport/src/Discover/Shared/ConfigureDiscoveryService/ConfigureDiscoveryService.story.tsx
+++ b/web/packages/teleport/src/Discover/Shared/ConfigureDiscoveryService/ConfigureDiscoveryService.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { http, HttpResponse } from 'msw';
 import { MemoryRouter } from 'react-router';
 import { Info } from 'design/Alert';

--- a/web/packages/teleport/src/Discover/Shared/ConfigureDiscoveryService/ConfigureDiscoveryService.tsx
+++ b/web/packages/teleport/src/Discover/Shared/ConfigureDiscoveryService/ConfigureDiscoveryService.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Link as InternalLink } from 'react-router-dom';
 import { Box, Text, Mark } from 'design';
 import { OutlineInfo } from 'design/Alert/Alert';

--- a/web/packages/teleport/src/Discover/Shared/ConfigureDiscoveryService/ConfigureDiscoveryServiceDirections.tsx
+++ b/web/packages/teleport/src/Discover/Shared/ConfigureDiscoveryService/ConfigureDiscoveryServiceDirections.tsx
@@ -20,8 +20,6 @@ import styled from 'styled-components';
 
 import { IconTooltip } from 'design/Tooltip';
 
-import React from 'react';
-
 import { P } from 'design/Text/Text';
 
 import { TextSelectCopyMulti } from 'teleport/components/TextSelectCopy';

--- a/web/packages/teleport/src/Discover/Shared/ConfigureDiscoveryService/CreatedDiscoveryConfigDialog.story.tsx
+++ b/web/packages/teleport/src/Discover/Shared/ConfigureDiscoveryService/CreatedDiscoveryConfigDialog.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { CreatedDiscoveryConfigDialog } from './CreatedDiscoveryConfigDialog';
 
 export default {

--- a/web/packages/teleport/src/Discover/Shared/ConfigureDiscoveryService/CreatedDiscoveryConfigDialog.tsx
+++ b/web/packages/teleport/src/Discover/Shared/ConfigureDiscoveryService/CreatedDiscoveryConfigDialog.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import {
   Text,
   Flex,

--- a/web/packages/teleport/src/Discover/Shared/ConnectionDiagnostic/ConnectionDiagnosticResult.story.tsx
+++ b/web/packages/teleport/src/Discover/Shared/ConnectionDiagnostic/ConnectionDiagnosticResult.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { ConnectionDiagnosticResult } from './ConnectionDiagnosticResult';
 
 import type { Props } from './ConnectionDiagnosticResult';

--- a/web/packages/teleport/src/Discover/Shared/ConnectionDiagnostic/ConnectionDiagnosticResult.tsx
+++ b/web/packages/teleport/src/Discover/Shared/ConnectionDiagnostic/ConnectionDiagnosticResult.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import styled from 'styled-components';
 import {
   ButtonSecondary,

--- a/web/packages/teleport/src/Discover/Shared/CustomInputFieldForAsterisks.tsx
+++ b/web/packages/teleport/src/Discover/Shared/CustomInputFieldForAsterisks.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import FieldInput from 'shared/components/FieldInput';
 import { requiredField } from 'shared/components/Validation/rules';
 import { Option } from 'shared/components/Select';

--- a/web/packages/teleport/src/Discover/Shared/Finished/Finished.story.tsx
+++ b/web/packages/teleport/src/Discover/Shared/Finished/Finished.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Finished as Component } from './Finished';
 
 import type { AgentStepProps } from '../../types';

--- a/web/packages/teleport/src/Discover/Shared/Finished/Finished.tsx
+++ b/web/packages/teleport/src/Discover/Shared/Finished/Finished.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 import { ButtonPrimary, Text, Flex, ButtonSecondary, Image, H2 } from 'design';
 

--- a/web/packages/teleport/src/Discover/Shared/LabelsCreater/LabelsCreater.story.tsx
+++ b/web/packages/teleport/src/Discover/Shared/LabelsCreater/LabelsCreater.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import Validation from 'shared/components/Validation';
 

--- a/web/packages/teleport/src/Discover/Shared/SecurityGroupPicker/SecurityGroupRulesDialog.tsx
+++ b/web/packages/teleport/src/Discover/Shared/SecurityGroupPicker/SecurityGroupRulesDialog.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 
 import { ButtonSecondary, H2, Text } from 'design';

--- a/web/packages/teleport/src/Discover/Shared/SelectCreatable/SelectCreatable.story.tsx
+++ b/web/packages/teleport/src/Discover/Shared/SelectCreatable/SelectCreatable.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { SelectCreatable as Component, Option } from './SelectCreatable';
 

--- a/web/packages/teleport/src/Discover/Shared/SetupAccess/SetupAccessWrapper.story.tsx
+++ b/web/packages/teleport/src/Discover/Shared/SetupAccess/SetupAccessWrapper.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 
 import { SetupAccessWrapper } from './SetupAccessWrapper';

--- a/web/packages/teleport/src/Discover/Shared/SetupAccess/useUserTraits.test.tsx
+++ b/web/packages/teleport/src/Discover/Shared/SetupAccess/useUserTraits.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { AwsRole } from 'shared/services/apps';

--- a/web/packages/teleport/src/Discover/Shared/Step.tsx
+++ b/web/packages/teleport/src/Discover/Shared/Step.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 
 import { Text } from 'design';

--- a/web/packages/teleport/src/Discover/Shared/Timeout.tsx
+++ b/web/packages/teleport/src/Discover/Shared/Timeout.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 interface TimeoutProps {
   timeout: number; // ms

--- a/web/packages/teleport/src/Discover/useDiscover.test.tsx
+++ b/web/packages/teleport/src/Discover/useDiscover.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { renderHook, act } from '@testing-library/react';
 

--- a/web/packages/teleport/src/HeadlessRequest/Cards.story.tsx
+++ b/web/packages/teleport/src/HeadlessRequest/Cards.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { CardAccept, CardDenied } from './Cards';
 
 export default {

--- a/web/packages/teleport/src/HeadlessRequest/Cards.tsx
+++ b/web/packages/teleport/src/HeadlessRequest/Cards.tsx
@@ -18,7 +18,6 @@
 
 import { Card, CardSuccess, H1 } from 'design';
 import { CircleStop } from 'design/Icon';
-import React from 'react';
 
 export function CardDenied({ title, children }) {
   return (

--- a/web/packages/teleport/src/HeadlessRequest/HeadlessRequest.test.tsx
+++ b/web/packages/teleport/src/HeadlessRequest/HeadlessRequest.test.tsx
@@ -17,7 +17,6 @@
  */
 
 import { render, screen } from 'design/utils/testing';
-import React from 'react';
 import { Route, Router } from 'react-router';
 import { createMemoryHistory } from 'history';
 

--- a/web/packages/teleport/src/HeadlessRequest/HeadlessRequest.tsx
+++ b/web/packages/teleport/src/HeadlessRequest/HeadlessRequest.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { Spinner } from 'design/Icon';

--- a/web/packages/teleport/src/Integrations/EditAwsOidcIntegrationDialog.tsx
+++ b/web/packages/teleport/src/Integrations/EditAwsOidcIntegrationDialog.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import styled from 'styled-components';
 import {
   ButtonSecondary,

--- a/web/packages/teleport/src/Integrations/Enroll/AwsOidc/AwsOidc.story.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsOidc/AwsOidc.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 
 import { AwsOidc } from './AwsOidc';

--- a/web/packages/teleport/src/Integrations/Enroll/AwsOidc/ConfigureAwsOidcSummary.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsOidc/ConfigureAwsOidcSummary.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 import { Flex, Box, H3, Text } from 'design';
 import TextEditor from 'shared/components/TextEditor';

--- a/web/packages/teleport/src/Integrations/Enroll/AwsOidc/FinishDialog.story.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsOidc/FinishDialog.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 
 import {

--- a/web/packages/teleport/src/Integrations/Enroll/AwsOidc/S3BucketConfiguration.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsOidc/S3BucketConfiguration.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Text, Flex } from 'design';
 import FieldInput from 'shared/components/FieldInput';
 import { IconTooltip } from 'design/Tooltip';

--- a/web/packages/teleport/src/Integrations/Enroll/IntegrationEnroll.story.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/IntegrationEnroll.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 
 import { ContextProvider } from 'teleport';

--- a/web/packages/teleport/src/Integrations/Enroll/IntegrationEnroll.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/IntegrationEnroll.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Flex } from 'design';
 
 import {

--- a/web/packages/teleport/src/Integrations/Enroll/IntegrationRoute.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/IntegrationRoute.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import cfg from 'teleport/config';
 import { Route } from 'teleport/components/Router';
 import { IntegrationKind } from 'teleport/services/integrations';

--- a/web/packages/teleport/src/Integrations/Enroll/IntegrationTiles.test.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/IntegrationTiles.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { render, screen, userEvent } from 'design/utils/testing';
 

--- a/web/packages/teleport/src/Integrations/Enroll/IntegrationTiles.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/IntegrationTiles.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Link } from 'react-router-dom';
 import { Text, Flex } from 'design';
 

--- a/web/packages/teleport/src/Integrations/Enroll/MachineIDIntegrationSection.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/MachineIDIntegrationSection.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Box, H2 } from 'design';
 
 import { P } from 'design/Text/Text';

--- a/web/packages/teleport/src/Integrations/Enroll/common.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/common.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Box, Flex, H2, ResourceIcon } from 'design';
 import styled from 'styled-components';
 import { P } from 'design/Text/Text';

--- a/web/packages/teleport/src/Integrations/IntegrationStatus.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationStatus.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { useParams } from 'react-router';
 
 import { IntegrationKind, PluginKind } from 'teleport/services/integrations';

--- a/web/packages/teleport/src/Integrations/Integrations.story.tsx
+++ b/web/packages/teleport/src/Integrations/Integrations.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 
 import {

--- a/web/packages/teleport/src/Integrations/Integrations.tsx
+++ b/web/packages/teleport/src/Integrations/Integrations.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import useAttempt from 'shared/hooks/useAttemptNext';
 import { Indicator, Box, Alert } from 'design';
 

--- a/web/packages/teleport/src/Integrations/IntegrationsAddButton.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationsAddButton.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Link } from 'react-router-dom';
 import { Button } from 'design';
 import { HoverTooltip } from 'design/Tooltip';

--- a/web/packages/teleport/src/Integrations/Operations/IntegrationOperations.tsx
+++ b/web/packages/teleport/src/Integrations/Operations/IntegrationOperations.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Integration } from 'teleport/services/integrations';
 
 import { DeleteIntegrationDialog } from '../RemoveIntegrationDialog';

--- a/web/packages/teleport/src/Integrations/RemoveIntegrationDialog.tsx
+++ b/web/packages/teleport/src/Integrations/RemoveIntegrationDialog.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { ButtonSecondary, ButtonWarning, Text, Alert, P1 } from 'design';
 import Dialog, {
   DialogHeader,

--- a/web/packages/teleport/src/JoinTokens/JoinTokenForms.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokenForms.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Flex, Text, ButtonIcon, ButtonText } from 'design';
 import { Plus, Trash } from 'design/Icon';
 import { requiredField } from 'shared/components/Validation/rules';

--- a/web/packages/teleport/src/JoinTokens/JoinTokens.story.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokens.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { http, HttpResponse } from 'msw';
 

--- a/web/packages/teleport/src/Kubes/ConnectDialog/ConnectDialog.story.tsx
+++ b/web/packages/teleport/src/Kubes/ConnectDialog/ConnectDialog.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import Component from './ConnectDialog';
 
 export default {

--- a/web/packages/teleport/src/Kubes/ConnectDialog/ConnectDialog.tsx
+++ b/web/packages/teleport/src/Kubes/ConnectDialog/ConnectDialog.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import Dialog, {
   DialogFooter,
   DialogHeader,

--- a/web/packages/teleport/src/LocksV2/Locks/DeleteLockDialogue.tsx
+++ b/web/packages/teleport/src/LocksV2/Locks/DeleteLockDialogue.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { ButtonSecondary, ButtonWarning, P1 } from 'design';
 import { Danger } from 'design/Alert';
 import useAttempt from 'shared/hooks/useAttemptNext';

--- a/web/packages/teleport/src/LocksV2/Locks/Locks.test.tsx
+++ b/web/packages/teleport/src/LocksV2/Locks/Locks.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { render, fireEvent, screen } from 'design/utils/testing';
 

--- a/web/packages/teleport/src/LocksV2/Locks/Locks.tsx
+++ b/web/packages/teleport/src/LocksV2/Locks/Locks.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState, useEffect } from 'react';
+import { Fragment, useState, useEffect } from 'react';
 import { useLocation, useHistory } from 'react-router';
 import { formatRelative } from 'date-fns';
 import { Danger } from 'design/Alert';
@@ -207,10 +207,10 @@ export function Pills({ targets }: { targets: LockTarget[] }) {
   const pills = targets.map((target, index) => {
     const labelText = `${target.kind}: ${target.name}`;
     return (
-      <React.Fragment key={`${target.kind}${target.name}${index}`}>
+      <Fragment key={`${target.kind}${target.name}${index}`}>
         {index > 0 && ' '}
         <Pill kind="secondary">{labelText}</Pill>
-      </React.Fragment>
+      </Fragment>
     );
   });
 

--- a/web/packages/teleport/src/LocksV2/NewLock/NewLock.tsx
+++ b/web/packages/teleport/src/LocksV2/NewLock/NewLock.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { Prompt } from 'react-router';
 import { Link } from 'react-router-dom';
 import { Transition } from 'react-transition-group';

--- a/web/packages/teleport/src/LocksV2/NewLock/ResourceList/ServerSideSupportedList/Desktops.tsx
+++ b/web/packages/teleport/src/LocksV2/NewLock/ResourceList/ServerSideSupportedList/Desktops.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { ClickableLabelCell } from 'design/DataTable';
 
 import { Desktop } from 'teleport/services/desktops';

--- a/web/packages/teleport/src/LocksV2/NewLock/ResourceList/ServerSideSupportedList/Nodes.tsx
+++ b/web/packages/teleport/src/LocksV2/NewLock/ResourceList/ServerSideSupportedList/Nodes.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Cell, ClickableLabelCell } from 'design/DataTable';
 
 import { Node } from 'teleport/services/nodes';

--- a/web/packages/teleport/src/LocksV2/NewLock/ResourceList/ServerSideSupportedList/Roles.tsx
+++ b/web/packages/teleport/src/LocksV2/NewLock/ResourceList/ServerSideSupportedList/Roles.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import Table from 'design/DataTable';
 
 import { RoleResource } from 'teleport/services/resources';

--- a/web/packages/teleport/src/LocksV2/NewLock/ResourceList/ServerSideSupportedList/ServerSideSupportedList.tsx
+++ b/web/packages/teleport/src/LocksV2/NewLock/ResourceList/ServerSideSupportedList/ServerSideSupportedList.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { SortType } from 'design/DataTable/types';
 import { Flex } from 'design';
 import { StyledPanel } from 'design/DataTable/StyledTable';

--- a/web/packages/teleport/src/LocksV2/NewLock/ResourceList/SimpleList/MfaDevices.tsx
+++ b/web/packages/teleport/src/LocksV2/NewLock/ResourceList/SimpleList/MfaDevices.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Text } from 'design';
 import Table, { Cell } from 'design/DataTable';
 import { dateMatcher } from 'design/utils/match';

--- a/web/packages/teleport/src/LocksV2/NewLock/ResourceList/SimpleList/Users.tsx
+++ b/web/packages/teleport/src/LocksV2/NewLock/ResourceList/SimpleList/Users.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import Table, { Cell, LabelCell } from 'design/DataTable';
 
 import { User } from 'teleport/services/user';

--- a/web/packages/teleport/src/LocksV2/NewLock/ResourceList/common.tsx
+++ b/web/packages/teleport/src/LocksV2/NewLock/ResourceList/common.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 import { Box, ButtonPrimary, ButtonBorder } from 'design';
 import Table, { Cell } from 'design/DataTable';

--- a/web/packages/teleport/src/Login/CardTerminal/CardTerminal.story.tsx
+++ b/web/packages/teleport/src/Login/CardTerminal/CardTerminal.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { MemoryRouter } from 'react-router';
 
 import cfg from 'teleport/config';

--- a/web/packages/teleport/src/Login/Login.story.tsx
+++ b/web/packages/teleport/src/Login/Login.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 import { MemoryRouter } from 'react-router';
 

--- a/web/packages/teleport/src/Login/Login.test.tsx
+++ b/web/packages/teleport/src/Login/Login.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { userEvent, UserEvent } from '@testing-library/user-event';
 import selectEvent from 'react-select-event';
 import { render, fireEvent, screen, waitFor } from 'design/utils/testing';

--- a/web/packages/teleport/src/Login/Login.tsx
+++ b/web/packages/teleport/src/Login/Login.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import styled from 'styled-components';
 
 import { Box, Text, Link, Flex, ButtonPrimary, H1 } from 'design';

--- a/web/packages/teleport/src/Login/LoginClose.tsx
+++ b/web/packages/teleport/src/Login/LoginClose.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { Card } from 'design';
 
 export function LoginClose() {

--- a/web/packages/teleport/src/Login/LoginFailed.tsx
+++ b/web/packages/teleport/src/Login/LoginFailed.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { LoginFailed as CardFailed } from 'design/CardError';
 
 import { Route, Switch } from 'teleport/components/Router';

--- a/web/packages/teleport/src/Login/LoginSuccess.tsx
+++ b/web/packages/teleport/src/Login/LoginSuccess.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { CardSuccessLogin } from 'design';
 
 import { LogoHero } from 'teleport/components/LogoHero';

--- a/web/packages/teleport/src/Login/LoginTerminalRedirect.tsx
+++ b/web/packages/teleport/src/Login/LoginTerminalRedirect.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { LogoHero } from 'teleport/components/LogoHero';
 
 import { CardTerminal } from './CardTerminal';

--- a/web/packages/teleport/src/Login/Motd/Motd.tsx
+++ b/web/packages/teleport/src/Login/Motd/Motd.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 
 import { Card, Box, Text, ButtonPrimary } from 'design';

--- a/web/packages/teleport/src/Main/LayoutContext.tsx
+++ b/web/packages/teleport/src/Main/LayoutContext.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, {
+import {
   createContext,
   PropsWithChildren,
   useContext,

--- a/web/packages/teleport/src/Main/Main.test.tsx
+++ b/web/packages/teleport/src/Main/Main.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { render, screen } from 'design/utils/testing';
 

--- a/web/packages/teleport/src/Main/OnboardDiscover/OnboardDiscover.story.tsx
+++ b/web/packages/teleport/src/Main/OnboardDiscover/OnboardDiscover.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { OnboardDiscover } from './OnboardDiscover';
 
 export default {

--- a/web/packages/teleport/src/Main/OnboardDiscover/OnboardDiscover.tsx
+++ b/web/packages/teleport/src/Main/OnboardDiscover/OnboardDiscover.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { ButtonPrimary, ButtonText, Image, Text } from 'design';
 import Dialog, {
   DialogContent,

--- a/web/packages/teleport/src/Navigation/Navigation.tsx
+++ b/web/packages/teleport/src/Navigation/Navigation.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled, { useTheme } from 'styled-components';
 import { matchPath, useLocation, useHistory } from 'react-router';
 import { Box, Text, Flex } from 'design';

--- a/web/packages/teleport/src/Navigation/NavigationCategoryContainer.tsx
+++ b/web/packages/teleport/src/Navigation/NavigationCategoryContainer.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 
 import {

--- a/web/packages/teleport/src/Navigation/NavigationItem.test.tsx
+++ b/web/packages/teleport/src/Navigation/NavigationItem.test.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { render, screen } from 'design/utils/testing';
 
 import { Server } from 'design/Icon';

--- a/web/packages/teleport/src/Navigation/NavigationSection.tsx
+++ b/web/packages/teleport/src/Navigation/NavigationSection.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 
 import { NavigationItem } from 'teleport/Navigation/NavigationItem';

--- a/web/packages/teleport/src/Navigation/RecentHistory.tsx
+++ b/web/packages/teleport/src/Navigation/RecentHistory.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import { matchPath } from 'react-router';
 import { NavLink } from 'react-router-dom';

--- a/web/packages/teleport/src/Navigation/SideNavigation/CategoryIcon.tsx
+++ b/web/packages/teleport/src/Navigation/SideNavigation/CategoryIcon.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import * as Icons from 'design/Icon';
 
 import {

--- a/web/packages/teleport/src/Navigation/SideNavigation/ResourcesSection.tsx
+++ b/web/packages/teleport/src/Navigation/SideNavigation/ResourcesSection.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 import { matchPath } from 'react-router';
 

--- a/web/packages/teleport/src/Navigation/utils.tsx
+++ b/web/packages/teleport/src/Navigation/utils.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import {
   Icon,
   NavigationItemSize,

--- a/web/packages/teleport/src/Notifications/Notification.story.tsx
+++ b/web/packages/teleport/src/Notifications/Notification.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { subSeconds, subMinutes, subHours, subDays } from 'date-fns';
 import { http, HttpResponse, delay } from 'msw';

--- a/web/packages/teleport/src/Notifications/Notifications.test.tsx
+++ b/web/packages/teleport/src/Notifications/Notifications.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { subMinutes, subSeconds } from 'date-fns';
 import { createMemoryHistory } from 'history';
 import { Router } from 'react-router';

--- a/web/packages/teleport/src/Player/ActionBar/ActionBar.tsx
+++ b/web/packages/teleport/src/Player/ActionBar/ActionBar.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { NavLink } from 'react-router-dom';
 import { Flex, ButtonPrimary } from 'design';
 import { MenuIcon, MenuItem, MenuItemIcon } from 'shared/components/MenuAction';

--- a/web/packages/teleport/src/Player/DesktopPlayer.tsx
+++ b/web/packages/teleport/src/Player/DesktopPlayer.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState, useMemo, useCallback, useEffect } from 'react';
+import { useState, useMemo, useCallback, useEffect } from 'react';
 import styled from 'styled-components';
 import { Indicator, Box, Alert, Flex } from 'design';
 

--- a/web/packages/teleport/src/Player/Player.story.tsx
+++ b/web/packages/teleport/src/Player/Player.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Flex } from 'design';
 
 import { createMemoryHistory } from 'history';

--- a/web/packages/teleport/src/Player/Player.tsx
+++ b/web/packages/teleport/src/Player/Player.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 
 import { Flex, Box } from 'design';

--- a/web/packages/teleport/src/Player/PlayerTabs/PlayerTabs.tsx
+++ b/web/packages/teleport/src/Player/PlayerTabs/PlayerTabs.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 import { typography } from 'design/system';
 import { Flex, Box } from 'design';

--- a/web/packages/teleport/src/Player/ProgressBar/ProgressBar.story.tsx
+++ b/web/packages/teleport/src/Player/ProgressBar/ProgressBar.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { useState } from 'react';
 
 import ProgressBar from './ProgressBar';
 
@@ -25,7 +25,7 @@ export default {
 };
 
 export const Playing = () => {
-  const [state, setState] = React.useState(() => ({
+  const [state, setState] = useState(() => ({
     isPlaying: true,
     current: 100,
     min: 1,

--- a/web/packages/teleport/src/Player/ProgressBar/Slider/Slider.jsx
+++ b/web/packages/teleport/src/Player/ProgressBar/Slider/Slider.jsx
@@ -23,7 +23,7 @@ THE SOFTWARE.
 
 */
 
-import React from 'react';
+import { Children, createElement } from 'react';
 import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
 
@@ -269,7 +269,7 @@ const ReactSlider = createReactClass({
   // equally.
   // TODO: better name? better solution?
   _or: function (value, defaultValue) {
-    var count = React.Children.count(this.props.children);
+    var count = Children.count(this.props.children);
     switch (count) {
       case 0:
         return value.length > 0 ? value : defaultValue;
@@ -788,7 +788,7 @@ const ReactSlider = createReactClass({
       ' ' +
       (this.state.index === i ? this.props.handleActiveClassName : '');
 
-    return React.createElement(
+    return createElement(
       'div',
       {
         ref: function (r) {
@@ -824,8 +824,8 @@ const ReactSlider = createReactClass({
 
     var res = [];
     var renderHandle = this._renderHandle;
-    if (React.Children.count(this.props.children) > 0) {
-      React.Children.forEach(this.props.children, function (child, i) {
+    if (Children.count(this.props.children) > 0) {
+      Children.forEach(this.props.children, function (child, i) {
         res[i] = renderHandle(styles[i], child, i);
       });
     } else {
@@ -838,7 +838,7 @@ const ReactSlider = createReactClass({
 
   _renderBar: function (i, offsetFrom, offsetTo) {
     var self = this;
-    return React.createElement('div', {
+    return createElement('div', {
       key: 'bar' + i,
       ref: function (r) {
         self['bar' + i] = r;
@@ -917,7 +917,7 @@ const ReactSlider = createReactClass({
     var bars = props.withBars ? this._renderBars(offset) : null;
     var handles = this._renderHandles(offset);
 
-    return React.createElement(
+    return createElement(
       'div',
       {
         ref: function (r) {

--- a/web/packages/teleport/src/Player/SshPlayer.tsx
+++ b/web/packages/teleport/src/Player/SshPlayer.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import styled from 'styled-components';
 import { Indicator, Flex, Box } from 'design';
 import { Danger } from 'design/Alert';
@@ -100,11 +100,11 @@ const StyledPlayer = styled.div`
 `;
 
 function useStreamingSshPlayer(clusterId: string, sid: string) {
-  const [playerStatus, setPlayerStatus] = React.useState(StatusEnum.LOADING);
-  const [statusText, setStatusText] = React.useState('');
-  const [time, setTime] = React.useState(0);
+  const [playerStatus, setPlayerStatus] = useState(StatusEnum.LOADING);
+  const [statusText, setStatusText] = useState('');
+  const [time, setTime] = useState(0);
 
-  const tty = React.useMemo(() => {
+  const tty = useMemo(() => {
     const url = cfg.api.ttyPlaybackWsAddr
       .replace(':fqdn', getHostName())
       .replace(':clusterId', clusterId)
@@ -113,7 +113,7 @@ function useStreamingSshPlayer(clusterId: string, sid: string) {
     return new TtyPlayer({ url, setPlayerStatus, setStatusText, setTime });
   }, [clusterId, sid, setPlayerStatus, setStatusText, setTime]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     tty.connect();
     tty.play();
 

--- a/web/packages/teleport/src/Player/Xterm/Xterm.tsx
+++ b/web/packages/teleport/src/Player/Xterm/Xterm.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useCallback, useRef, useState } from 'react';
+import { useEffect, useCallback, useRef, useState } from 'react';
 
 import { getPlatformType } from 'design/platform';
 import styled, { useTheme } from 'styled-components';

--- a/web/packages/teleport/src/Recordings/Recordings.story.tsx
+++ b/web/packages/teleport/src/Recordings/Recordings.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Router } from 'react-router';
 import { createMemoryHistory } from 'history';
 

--- a/web/packages/teleport/src/Recordings/Recordings.tsx
+++ b/web/packages/teleport/src/Recordings/Recordings.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { Danger } from 'design/Alert';
 import { Indicator, Box } from 'design';

--- a/web/packages/teleport/src/Recordings/RecordingsList.tsx
+++ b/web/packages/teleport/src/Recordings/RecordingsList.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { ButtonPrimary } from 'design';
 import Table, { Cell, TextCell } from 'design/DataTable';
 import { dateTimeMatcher } from 'design/utils/match';

--- a/web/packages/teleport/src/Roles/DeleteRole/DeleteRole.story.tsx
+++ b/web/packages/teleport/src/Roles/DeleteRole/DeleteRole.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import DeleteRole from './DeleteRole';
 
 export default {

--- a/web/packages/teleport/src/Roles/DeleteRole/DeleteRole.tsx
+++ b/web/packages/teleport/src/Roles/DeleteRole/DeleteRole.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { ButtonSecondary, ButtonWarning, Text, Alert, P1 } from 'design';
 import Dialog, {
   DialogHeader,

--- a/web/packages/teleport/src/Roles/RoleEditor/EditorHeader.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/EditorHeader.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Flex, H2, Indicator, Box, ButtonIcon } from 'design';
 import { Cross } from 'design/Icon';
 

--- a/web/packages/teleport/src/Roles/RoleEditor/EditorTabs.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/EditorTabs.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { SlideTabs } from 'design/SlideTabs';
 import * as Icon from 'design/Icon';
 

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.story.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { StoryObj } from '@storybook/react';
 import { delay, http, HttpResponse } from 'msw';
 import { Info } from 'design/Alert';

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { render, screen, userEvent } from 'design/utils/testing';
 import { within } from '@testing-library/react';
 import { UserEvent } from '@testing-library/user-event';

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.tsx
@@ -17,7 +17,7 @@
  */
 
 import { Alert, Box, Flex } from 'design';
-import React, { useId, useState } from 'react';
+import { useId, useState } from 'react';
 import { useAsync } from 'shared/hooks/useAsync';
 
 import Validation, { Validator } from 'shared/components/Validation';

--- a/web/packages/teleport/src/Roles/RoleEditor/YamlEditor.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/YamlEditor.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Flex } from 'design';
 import TextEditor from 'shared/components/TextEditor';
 

--- a/web/packages/teleport/src/Roles/RoleList/RoleList.tsx
+++ b/web/packages/teleport/src/Roles/RoleList/RoleList.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import Table, { Cell } from 'design/DataTable';
 import { MenuButton, MenuItem } from 'shared/components/MenuAction';
 

--- a/web/packages/teleport/src/Roles/Roles.story.tsx
+++ b/web/packages/teleport/src/Roles/Roles.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { Roles } from './Roles';
 

--- a/web/packages/teleport/src/Roles/Roles.tsx
+++ b/web/packages/teleport/src/Roles/Roles.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Alert, Box, Button, Flex, H3, Link } from 'design';
 import { P } from 'design/Text/Text';
 import { MissingPermissionsTooltip } from 'shared/components/MissingPermissionsTooltip';

--- a/web/packages/teleport/src/Sessions/SessionList/SessionJoinBtn.test.tsx
+++ b/web/packages/teleport/src/Sessions/SessionList/SessionJoinBtn.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { fireEvent, render, screen } from 'design/utils/testing';
 
 import { ContextProvider } from 'teleport';

--- a/web/packages/teleport/src/Sessions/SessionList/SessionList.tsx
+++ b/web/packages/teleport/src/Sessions/SessionList/SessionList.tsx
@@ -18,7 +18,6 @@
 
 import Table, { Cell } from 'design/DataTable';
 import * as Icons from 'design/Icon';
-import React from 'react';
 import styled from 'styled-components';
 
 import { Participant, Session, SessionKind } from 'teleport/services/session';

--- a/web/packages/teleport/src/Sessions/Sessions.story.tsx
+++ b/web/packages/teleport/src/Sessions/Sessions.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 
 import { ContextProvider } from 'teleport';

--- a/web/packages/teleport/src/Sessions/Sessions.tsx
+++ b/web/packages/teleport/src/Sessions/Sessions.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Box, Indicator } from 'design';
 import { Danger } from 'design/Alert';
 import { ClusterDropdown } from 'shared/components/ClusterDropdown/ClusterDropdown';

--- a/web/packages/teleport/src/SingleLogoutFailed/SingleLogoutFailed.story.tsx
+++ b/web/packages/teleport/src/SingleLogoutFailed/SingleLogoutFailed.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Router } from 'react-router';
 import { createMemoryHistory } from 'history';
 

--- a/web/packages/teleport/src/SingleLogoutFailed/SingleLogoutFailed.tsx
+++ b/web/packages/teleport/src/SingleLogoutFailed/SingleLogoutFailed.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { useLocation } from 'react-router';
 import { LogoutFailed } from 'design/CardError';
 

--- a/web/packages/teleport/src/Support/Support.story.tsx
+++ b/web/packages/teleport/src/Support/Support.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 
 import { ContextProvider } from 'teleport';

--- a/web/packages/teleport/src/ThemeProvider.tsx
+++ b/web/packages/teleport/src/ThemeProvider.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState, useEffect, ReactNode } from 'react';
+import { useState, useEffect, ReactNode } from 'react';
 import { ConfiguredThemeProvider } from 'design/ThemeProvider';
 import { bblpTheme, lightTheme, darkTheme, Theme } from 'design/theme';
 import { Theme as ThemePreference } from 'gen-proto-ts/teleport/userpreferences/v1/theme_pb';

--- a/web/packages/teleport/src/TopBar/ClusterSelector/ClusterSelector.story.tsx
+++ b/web/packages/teleport/src/TopBar/ClusterSelector/ClusterSelector.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Flex } from 'design';
 
 import ClusterSelector from './ClusterSelector';

--- a/web/packages/teleport/src/TopBar/ClusterSelector/ClusterSelector.tsx
+++ b/web/packages/teleport/src/TopBar/ClusterSelector/ClusterSelector.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { useState } from 'react';
 import { components, ValueContainerProps } from 'react-select';
 import styled from 'styled-components';
 import { Box, Flex, Text } from 'design';
@@ -43,8 +43,8 @@ export default function ClusterSelector({
   defaultMenuIsOpen = false,
   ...styles
 }) {
-  const [errorMessage, setError] = React.useState(null);
-  const [options, setOptions] = React.useState<Option[]>([]);
+  const [errorMessage, setError] = useState(null);
+  const [options, setOptions] = useState<Option[]>([]);
 
   const selectedOption = {
     value,

--- a/web/packages/teleport/src/TopBar/TopBar.story.tsx
+++ b/web/packages/teleport/src/TopBar/TopBar.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Router } from 'react-router';
 import { createMemoryHistory } from 'history';
 

--- a/web/packages/teleport/src/TopBar/TopBar.test.tsx
+++ b/web/packages/teleport/src/TopBar/TopBar.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { act } from '@testing-library/react';
 import { subSeconds, subMinutes } from 'date-fns';
 import { render, screen, userEvent } from 'design/utils/testing';

--- a/web/packages/teleport/src/TrustedClusters/DeleteTrust/DeleteTrust.story.tsx
+++ b/web/packages/teleport/src/TrustedClusters/DeleteTrust/DeleteTrust.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import DeleteTrustedCluster from './DeleteTrust';
 
 export default {

--- a/web/packages/teleport/src/TrustedClusters/DeleteTrust/DeleteTrust.tsx
+++ b/web/packages/teleport/src/TrustedClusters/DeleteTrust/DeleteTrust.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { ButtonSecondary, ButtonWarning, P1, Text } from 'design';
 import * as Alerts from 'design/Alert';
 import useAttempt from 'shared/hooks/useAttemptNext';

--- a/web/packages/teleport/src/TrustedClusters/TrustedClusters.story.tsx
+++ b/web/packages/teleport/src/TrustedClusters/TrustedClusters.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import * as teleport from 'teleport';
 
 import TrustedClusters from './TrustedClusters';

--- a/web/packages/teleport/src/TrustedClusters/TrustedClusters.tsx
+++ b/web/packages/teleport/src/TrustedClusters/TrustedClusters.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Danger } from 'design/Alert';
 import { Indicator, Box, Flex, ButtonPrimary, Link, Button, H3 } from 'design';
 import Card from 'design/Card';

--- a/web/packages/teleport/src/TrustedClusters/TrustedList/TrustedList.tsx
+++ b/web/packages/teleport/src/TrustedClusters/TrustedList/TrustedList.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Flex } from 'design';
 
 import TrustedListItem from './TrustedListItem';

--- a/web/packages/teleport/src/TrustedClusters/TrustedList/TrustedListItem.tsx
+++ b/web/packages/teleport/src/TrustedClusters/TrustedList/TrustedListItem.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Text, Flex, ButtonPrimary } from 'design';
 import * as Icons from 'design/Icon';
 import { MenuIcon, MenuItem } from 'shared/components/MenuAction';

--- a/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useState, useMemo } from 'react';
+import { useCallback, useState, useMemo } from 'react';
 
 import { Flex } from 'design';
 import { Danger } from 'design/Alert';

--- a/web/packages/teleport/src/User/UserContext.test.tsx
+++ b/web/packages/teleport/src/User/UserContext.test.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { setupServer } from 'msw/node';
 import { http, HttpResponse } from 'msw';
 import { MemoryRouter } from 'react-router';

--- a/web/packages/teleport/src/User/UserContext.tsx
+++ b/web/packages/teleport/src/User/UserContext.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, {
+import {
   createContext,
   PropsWithChildren,
   useCallback,

--- a/web/packages/teleport/src/Users/UserAddEdit/TraitsEditor.test.tsx
+++ b/web/packages/teleport/src/Users/UserAddEdit/TraitsEditor.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { fireEvent, render, screen } from 'design/utils/testing';
 
 import Validation from 'shared/components/Validation';

--- a/web/packages/teleport/src/Users/UserAddEdit/TraitsEditor.tsx
+++ b/web/packages/teleport/src/Users/UserAddEdit/TraitsEditor.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { Dispatch, SetStateAction } from 'react';
+import { Dispatch, SetStateAction } from 'react';
 import { ButtonBorder, Box, Flex, Text, ButtonIcon } from 'design';
 import { Add, Trash } from 'design/Icon';
 import { FieldSelectCreatable } from 'shared/components/FieldSelect';

--- a/web/packages/teleport/src/Users/UserAddEdit/UserAddEdit.story.tsx
+++ b/web/packages/teleport/src/Users/UserAddEdit/UserAddEdit.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { AllUserTraits } from 'teleport/services/user';
 

--- a/web/packages/teleport/src/Users/UserAddEdit/UserAddEdit.tsx
+++ b/web/packages/teleport/src/Users/UserAddEdit/UserAddEdit.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { ButtonPrimary, ButtonSecondary, Alert, Box } from 'design';
 import Dialog, {
   DialogHeader,

--- a/web/packages/teleport/src/Users/UserDelete/UserDelete.story.tsx
+++ b/web/packages/teleport/src/Users/UserDelete/UserDelete.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { UserDelete } from './UserDelete';
 
 export default {

--- a/web/packages/teleport/src/Users/UserDelete/UserDelete.tsx
+++ b/web/packages/teleport/src/Users/UserDelete/UserDelete.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { ButtonWarning, ButtonSecondary, Text, Alert } from 'design';
 import Dialog, {
   DialogHeader,

--- a/web/packages/teleport/src/Users/UserList/UserList.tsx
+++ b/web/packages/teleport/src/Users/UserList/UserList.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Cell, LabelCell } from 'design/DataTable';
 import { MenuButton, MenuItem } from 'shared/components/MenuAction';
 

--- a/web/packages/teleport/src/Users/UserReset/UserReset.story.tsx
+++ b/web/packages/teleport/src/Users/UserReset/UserReset.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { UserReset } from './UserReset';
 
 export default {

--- a/web/packages/teleport/src/Users/UserReset/UserReset.tsx
+++ b/web/packages/teleport/src/Users/UserReset/UserReset.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { useState } from 'react';
 import { ButtonPrimary, ButtonSecondary, Text, Alert } from 'design';
 import Dialog, {
   DialogHeader,
@@ -85,7 +85,7 @@ export function UserReset({
 
 function useDialog(props: Props) {
   const { attempt, run } = useAttemptNext();
-  const [token, setToken] = React.useState<ResetToken>(null);
+  const [token, setToken] = useState<ResetToken>(null);
 
   function onReset() {
     run(() => props.onReset(props.username).then(setToken));

--- a/web/packages/teleport/src/Users/UserTokenLink/UserTokenLink.story.tsx
+++ b/web/packages/teleport/src/Users/UserTokenLink/UserTokenLink.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import Dialog from './UserTokenLink';
 
 export default {

--- a/web/packages/teleport/src/Users/UserTokenLink/UserTokenLink.tsx
+++ b/web/packages/teleport/src/Users/UserTokenLink/UserTokenLink.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { formatDistanceStrict } from 'date-fns';
 
 import { ButtonSecondary, Text } from 'design';

--- a/web/packages/teleport/src/Users/Users.story.tsx
+++ b/web/packages/teleport/src/Users/Users.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 
 import { Users } from './Users';

--- a/web/packages/teleport/src/Users/Users.test.tsx
+++ b/web/packages/teleport/src/Users/Users.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { render, screen, userEvent, fireEvent } from 'design/utils/testing';
 

--- a/web/packages/teleport/src/Welcome/CardWelcome.tsx
+++ b/web/packages/teleport/src/Welcome/CardWelcome.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { ButtonPrimary, H2, Subtitle2 } from 'design';
 
 import { OnboardCard } from 'teleport/components/Onboard';

--- a/web/packages/teleport/src/Welcome/NewCredentials/Expired.tsx
+++ b/web/packages/teleport/src/Welcome/NewCredentials/Expired.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 import { H2, P1 } from 'design';
 

--- a/web/packages/teleport/src/Welcome/NewCredentials/NewCredentials.story.tsx
+++ b/web/packages/teleport/src/Welcome/NewCredentials/NewCredentials.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { WelcomeWrapper } from 'teleport/components/Onboard';
 
 import {

--- a/web/packages/teleport/src/Welcome/NewCredentials/NewCredentials.test.tsx
+++ b/web/packages/teleport/src/Welcome/NewCredentials/NewCredentials.test.tsx
@@ -19,7 +19,6 @@
 import { Attempt } from 'shared/hooks/useAttemptNext';
 
 import { render, screen } from 'design/utils/testing';
-import React from 'react';
 
 import { RecoveryCodes, ResetToken } from 'teleport/services/auth';
 import { NewCredentialsProps } from 'teleport/Welcome/NewCredentials/types';

--- a/web/packages/teleport/src/Welcome/NewCredentials/NewCredentials.tsx
+++ b/web/packages/teleport/src/Welcome/NewCredentials/NewCredentials.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { NewFlow, StepSlider } from 'design/StepSlider';
 import { Box } from 'design';
 

--- a/web/packages/teleport/src/Welcome/NewCredentials/NewMfaDevice.tsx
+++ b/web/packages/teleport/src/Welcome/NewCredentials/NewMfaDevice.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import {
   SliderProps,
   UseTokenState,

--- a/web/packages/teleport/src/Welcome/NewCredentials/Success.tsx
+++ b/web/packages/teleport/src/Welcome/NewCredentials/Success.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { ButtonPrimary, Flex, H2, Image, Text } from 'design';
 
 import { OnboardCard } from 'teleport/components/Onboard';

--- a/web/packages/teleport/src/Welcome/Welcome.story.tsx
+++ b/web/packages/teleport/src/Welcome/Welcome.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
 import { WelcomeWrapper } from 'teleport/components/Onboard';

--- a/web/packages/teleport/src/Welcome/Welcome.tsx
+++ b/web/packages/teleport/src/Welcome/Welcome.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { WelcomeWrapper } from 'teleport/components/Onboard';
 
 import {

--- a/web/packages/teleport/src/boot.tsx
+++ b/web/packages/teleport/src/boot.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { createRoot } from 'react-dom/client';
 
 import history from 'teleport/services/history';

--- a/web/packages/teleport/src/components/AgentButtonAdd/AgentButtonAdd.story.tsx
+++ b/web/packages/teleport/src/components/AgentButtonAdd/AgentButtonAdd.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 
 import { SearchResource } from 'teleport/Discover/SelectResource';

--- a/web/packages/teleport/src/components/AgentButtonAdd/AgentButtonAdd.tsx
+++ b/web/packages/teleport/src/components/AgentButtonAdd/AgentButtonAdd.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Link } from 'react-router-dom';
 
 import { Button } from 'design';

--- a/web/packages/teleport/src/components/AgentErrorMessage/AgentErrorMessage.story.tsx
+++ b/web/packages/teleport/src/components/AgentErrorMessage/AgentErrorMessage.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import AgentErrorMessage from './AgentErrorMessage';
 
 export default {

--- a/web/packages/teleport/src/components/AgentErrorMessage/AgentErrorMessage.tsx
+++ b/web/packages/teleport/src/components/AgentErrorMessage/AgentErrorMessage.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Link } from 'design';
 import { Danger } from 'design/Alert';
 

--- a/web/packages/teleport/src/components/AjaxPoller/AjaxPoller.jsx
+++ b/web/packages/teleport/src/components/AjaxPoller/AjaxPoller.jsx
@@ -16,11 +16,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { Component } from 'react';
 
 const DEFAULT_INTERVAL = 3000; // every 3 sec
 
-export default class AjaxPoller extends React.Component {
+export default class AjaxPoller extends Component {
   _timerId = null;
   _request = null;
 

--- a/web/packages/teleport/src/components/Authenticated/Authenticated.test.tsx
+++ b/web/packages/teleport/src/components/Authenticated/Authenticated.test.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { render, screen, waitFor } from 'design/utils/testing';
 
 import session from 'teleport/services/websession';

--- a/web/packages/teleport/src/components/Authenticated/ErrorDialogue.story.tsx
+++ b/web/packages/teleport/src/components/Authenticated/ErrorDialogue.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { ErrorDialog } from './ErrorDialogue';
 
 export default {

--- a/web/packages/teleport/src/components/Authenticated/ErrorDialogue.tsx
+++ b/web/packages/teleport/src/components/Authenticated/ErrorDialogue.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Text, Alert, ButtonSecondary } from 'design';
 import Dialog, {
   DialogHeader,

--- a/web/packages/teleport/src/components/AuthnDialog/AuthnDialog.story.tsx
+++ b/web/packages/teleport/src/components/AuthnDialog/AuthnDialog.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { makeDefaultMfaState } from 'teleport/lib/useMfa';
 
 import AuthnDialog, { Props } from './AuthnDialog';

--- a/web/packages/teleport/src/components/AuthnDialog/AuthnDialog.test.tsx
+++ b/web/packages/teleport/src/components/AuthnDialog/AuthnDialog.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { render, screen, fireEvent } from 'design/utils/testing';
 
 import { makeDefaultMfaState, MfaState } from 'teleport/lib/useMfa';

--- a/web/packages/teleport/src/components/AuthnDialog/AuthnDialog.tsx
+++ b/web/packages/teleport/src/components/AuthnDialog/AuthnDialog.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import Dialog, { DialogContent } from 'design/Dialog';
 import { Danger } from 'design/Alert';
 import { FingerprintSimple, Cross } from 'design/Icon';

--- a/web/packages/teleport/src/components/BannerList/BannerList.story.tsx
+++ b/web/packages/teleport/src/components/BannerList/BannerList.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { BannerList } from './BannerList';
 
 export default {

--- a/web/packages/teleport/src/components/BannerList/BannerList.tsx
+++ b/web/packages/teleport/src/components/BannerList/BannerList.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Box } from 'design';
 

--- a/web/packages/teleport/src/components/BannerList/StandardBanner.test.tsx
+++ b/web/packages/teleport/src/components/BannerList/StandardBanner.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { fireEvent, render, screen, theme } from 'design/utils/testing';
 
 import { userEventService } from 'teleport/services/userEvent';

--- a/web/packages/teleport/src/components/BannerList/StandardBanner.tsx
+++ b/web/packages/teleport/src/components/BannerList/StandardBanner.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Banner } from 'design';
 
 import { Action } from 'design/Alert';

--- a/web/packages/teleport/src/components/CardEmpty/CardEmpty.jsx
+++ b/web/packages/teleport/src/components/CardEmpty/CardEmpty.jsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Box, H2 } from 'design';
 
 export default function CardEmpty(props) {

--- a/web/packages/teleport/src/components/DownloadLinks/DownloadLinks.tsx
+++ b/web/packages/teleport/src/components/DownloadLinks/DownloadLinks.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Box, Link } from 'design';
 
 import getDownloadLink from 'teleport/services/links';

--- a/web/packages/teleport/src/components/Empty/Empty.test.tsx
+++ b/web/packages/teleport/src/components/Empty/Empty.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { render, screen } from 'design/utils/testing';
 import { MemoryRouter } from 'react-router';
 

--- a/web/packages/teleport/src/components/Empty/Empty.tsx
+++ b/web/packages/teleport/src/components/Empty/Empty.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Link } from 'react-router-dom';
 
 import {

--- a/web/packages/teleport/src/components/EventRangePicker/Custom/Custom.tsx
+++ b/web/packages/teleport/src/components/EventRangePicker/Custom/Custom.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState, forwardRef } from 'react';
+import { useState, forwardRef } from 'react';
 import { isAfter, endOfDay, startOfDay, isSameDay } from 'date-fns';
 import { DayPicker, addToRange, DateRange } from 'react-day-picker';
 import 'react-day-picker/dist/style.css';

--- a/web/packages/teleport/src/components/EventRangePicker/EventRangePicker.story.tsx
+++ b/web/packages/teleport/src/components/EventRangePicker/EventRangePicker.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import RangePicker from './EventRangePicker';
 

--- a/web/packages/teleport/src/components/EventRangePicker/EventRangePicker.tsx
+++ b/web/packages/teleport/src/components/EventRangePicker/EventRangePicker.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { components, ValueContainerProps } from 'react-select';
 import 'react-day-picker/dist/style.css';
 import { Text, Box } from 'design';

--- a/web/packages/teleport/src/components/ExternalAuditStorageCta/ExternalAuditStorageCta.test.tsx
+++ b/web/packages/teleport/src/components/ExternalAuditStorageCta/ExternalAuditStorageCta.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { render, screen } from 'design/utils/testing';
 

--- a/web/packages/teleport/src/components/ExternalAuditStorageCta/ExternalAuditStorageCta.tsx
+++ b/web/packages/teleport/src/components/ExternalAuditStorageCta/ExternalAuditStorageCta.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import Box from 'design/Box';

--- a/web/packages/teleport/src/components/FormLogin/FormLogin.story.tsx
+++ b/web/packages/teleport/src/components/FormLogin/FormLogin.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import FormLogin, { Props } from './FormLogin';
 
 const props: Props = {

--- a/web/packages/teleport/src/components/FormLogin/FormLogin.test.tsx
+++ b/web/packages/teleport/src/components/FormLogin/FormLogin.test.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { render, fireEvent, screen } from 'design/utils/testing';
 
 import history from 'teleport/services/history';

--- a/web/packages/teleport/src/components/FormLogin/SsoButtons.tsx
+++ b/web/packages/teleport/src/components/FormLogin/SsoButtons.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import { Flex, Text } from 'design';
 import ButtonSso, { guessProviderType } from 'shared/components/ButtonSso';
 import { AuthProvider } from 'shared/services';

--- a/web/packages/teleport/src/components/HeadlessRequestDialog/HeadlessRequestDialog.tsx
+++ b/web/packages/teleport/src/components/HeadlessRequestDialog/HeadlessRequestDialog.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import Dialog, {
   DialogContent,
   DialogFooter,

--- a/web/packages/teleport/src/components/InputSearch/InputSearch.jsx
+++ b/web/packages/teleport/src/components/InputSearch/InputSearch.jsx
@@ -16,12 +16,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { Component } from 'react';
 import { debounce } from 'shared/utils/highbar';
 import styled from 'styled-components';
 import { height, space, color } from 'design/system';
 
-class InputSearch extends React.Component {
+class InputSearch extends Component {
   constructor(props) {
     super(props);
     this.debouncedNotify = debounce(() => {

--- a/web/packages/teleport/src/components/LabelSelector/LabelSelector.story.tsx
+++ b/web/packages/teleport/src/components/LabelSelector/LabelSelector.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { LabelSelector } from './LabelSelector';
 

--- a/web/packages/teleport/src/components/LabelSelector/LabelSelector.test.tsx
+++ b/web/packages/teleport/src/components/LabelSelector/LabelSelector.test.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { render, screen, fireEvent } from 'design/utils/testing';
 
 import { LabelSelector } from './LabelSelector';

--- a/web/packages/teleport/src/components/LabelSelector/LabelSelector.tsx
+++ b/web/packages/teleport/src/components/LabelSelector/LabelSelector.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 import { Box, Flex, Pill, Popover, Link, Text } from 'design';

--- a/web/packages/teleport/src/components/LabelsInput/LabelsInput.story.tsx
+++ b/web/packages/teleport/src/components/LabelsInput/LabelsInput.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import Validation from 'shared/components/Validation';
 import { ButtonSecondary } from 'design/Button';
 

--- a/web/packages/teleport/src/components/LogoHero/LogoHero.tsx
+++ b/web/packages/teleport/src/components/LogoHero/LogoHero.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { useTheme } from 'styled-components';
 import Image from 'design/Image';
 import AGPLLogoLight from 'design/assets/images/agpl-light.svg';

--- a/web/packages/teleport/src/components/MfaDeviceList/MfaDeviceList.tsx
+++ b/web/packages/teleport/src/components/MfaDeviceList/MfaDeviceList.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 import { ButtonBorder, Text } from 'design';
 import Table, { Cell } from 'design/DataTable';

--- a/web/packages/teleport/src/components/MfaDeviceList/RemoveDialog/RemoveDialog.tsx
+++ b/web/packages/teleport/src/components/MfaDeviceList/RemoveDialog/RemoveDialog.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { ButtonSecondary, ButtonWarning, P1, Text } from 'design';
 import { Danger } from 'design/Alert';
 import Dialog, { DialogContent, DialogFooter } from 'design/DialogConfirmation';

--- a/web/packages/teleport/src/components/NewMfaDeviceForm/NewMfaDeviceForm.test.tsx
+++ b/web/packages/teleport/src/components/NewMfaDeviceForm/NewMfaDeviceForm.test.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { render, screen, userEvent } from 'design/utils/testing';
 
 import { NewMfaDeviceForm, NewMfaDeviceFormProps } from './NewMfaDeviceForm';

--- a/web/packages/teleport/src/components/Onboard/OnboardFooter.story.tsx
+++ b/web/packages/teleport/src/components/Onboard/OnboardFooter.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { OnboardFooter } from './OnboardFooter';
 
 export default {

--- a/web/packages/teleport/src/components/Onboard/OnboardFooter.test.tsx
+++ b/web/packages/teleport/src/components/Onboard/OnboardFooter.test.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { render, screen } from 'design/utils/testing';
 
 import { OnboardFooter } from './OnboardFooter';

--- a/web/packages/teleport/src/components/Onboard/OnboardFooter.tsx
+++ b/web/packages/teleport/src/components/Onboard/OnboardFooter.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import styled from 'styled-components';
 
 import { Flex, Link, Text } from 'design';

--- a/web/packages/teleport/src/components/Onboard/WelcomeWrapper.story.tsx
+++ b/web/packages/teleport/src/components/Onboard/WelcomeWrapper.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Text } from 'design';
 
 import { WelcomeWrapper } from './WelcomeWrapper';

--- a/web/packages/teleport/src/components/Onboard/WelcomeWrapper.tsx
+++ b/web/packages/teleport/src/components/Onboard/WelcomeWrapper.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import styled from 'styled-components';
 
 import { Box, Flex } from 'design';

--- a/web/packages/teleport/src/components/Passkeys/PasskeyBlurb.tsx
+++ b/web/packages/teleport/src/components/Passkeys/PasskeyBlurb.tsx
@@ -17,7 +17,6 @@
  */
 
 import Box from 'design/Box';
-import React from 'react';
 
 import { PasskeyIcons } from 'teleport/components/Passkeys';
 

--- a/web/packages/teleport/src/components/Passkeys/PasskeyIcons.tsx
+++ b/web/packages/teleport/src/components/Passkeys/PasskeyIcons.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 import * as Icon from 'design/Icon';
 

--- a/web/packages/teleport/src/components/RecoveryCodes/RecoveryCodes.story.tsx
+++ b/web/packages/teleport/src/components/RecoveryCodes/RecoveryCodes.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import Component from './RecoveryCodes';
 
 export default {

--- a/web/packages/teleport/src/components/RecoveryCodes/RecoveryCodes.tsx
+++ b/web/packages/teleport/src/components/RecoveryCodes/RecoveryCodes.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 import styled from 'styled-components';
 import { Box, ButtonPrimary, Card, Flex, Text } from 'design';
 import { copyToClipboard } from 'design/utils/copyToClipboard';

--- a/web/packages/teleport/src/components/ResourceEditor/ResourceEditor.story.jsx
+++ b/web/packages/teleport/src/components/ResourceEditor/ResourceEditor.story.jsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import ResourceEditor from './ResourceEditor';
 
 export default {

--- a/web/packages/teleport/src/components/Router/Router.jsx
+++ b/web/packages/teleport/src/components/Router/Router.jsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { useEffect } from 'react';
 import {
   useRouteMatch,
   useParams,
@@ -46,7 +46,7 @@ const Route = props => {
   const { title = '', ...rest } = props;
   const { clusterId } = useParams();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (title && clusterId) {
       document.title = `${clusterId} • ${title}`;
     } else if (title) {

--- a/web/packages/teleport/src/components/SelectFilters/Pager.tsx
+++ b/web/packages/teleport/src/components/SelectFilters/Pager.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 import { CircleArrowLeft, CircleArrowRight } from 'design/Icon';
 import { Text, Flex } from 'design';

--- a/web/packages/teleport/src/components/SelectFilters/SelectFilters.story.tsx
+++ b/web/packages/teleport/src/components/SelectFilters/SelectFilters.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import SelectFilter, { Props } from './SelectFilters';
 
 export default {

--- a/web/packages/teleport/src/components/SelectFilters/usePages.ts
+++ b/web/packages/teleport/src/components/SelectFilters/usePages.ts
@@ -16,13 +16,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { useState, useEffect } from 'react';
 
 export default function usePages({ pageSize, data }) {
-  const [startFrom, setFrom] = React.useState(0);
+  const [startFrom, setFrom] = useState(0);
 
   // set current page to 0 when data source length changes
-  React.useEffect(() => {
+  useEffect(() => {
     setFrom(0);
   }, [data.length]);
 

--- a/web/packages/teleport/src/components/ServersideSearchPanel/ServersideSearchPanel.tsx
+++ b/web/packages/teleport/src/components/ServersideSearchPanel/ServersideSearchPanel.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Flex } from 'design';
 
 import { AdvancedSearchToggle } from 'shared/components/AdvancedSearchToggle';

--- a/web/packages/teleport/src/components/ServersideSearchPanel/ServersideSearchPanelWithPageIndicator.tsx
+++ b/web/packages/teleport/src/components/ServersideSearchPanel/ServersideSearchPanelWithPageIndicator.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Flex } from 'design';
 import { PageIndicatorText } from 'design/DataTable/Pager/PageIndicatorText';
 

--- a/web/packages/teleport/src/components/TabIcon/TabIcon.tsx
+++ b/web/packages/teleport/src/components/TabIcon/TabIcon.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 import { H3 } from 'design';
 

--- a/web/packages/teleport/src/components/Tabs/Tabs.story.tsx
+++ b/web/packages/teleport/src/components/Tabs/Tabs.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { TextSelectCopyMulti } from '../TextSelectCopy';
 
 import { Tabs } from './Tabs';

--- a/web/packages/teleport/src/components/Tabs/Tabs.tsx
+++ b/web/packages/teleport/src/components/Tabs/Tabs.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import { Fragment, useState } from 'react';
 import { Box, Flex } from 'design';
 
 export function Tabs({ tabs }: Props) {
@@ -37,7 +37,7 @@ export function Tabs({ tabs }: Props) {
         {tabs.map((tab, index) => {
           const isActive = index === currContentIndex;
           return (
-            <React.Fragment key={index}>
+            <Fragment key={index}>
               {isActive ? (
                 <Box
                   as="button"
@@ -82,7 +82,7 @@ export function Tabs({ tabs }: Props) {
                   {tab.title}
                 </Box>
               )}
-            </React.Fragment>
+            </Fragment>
           );
         })}
       </Flex>

--- a/web/packages/teleport/src/components/TdpClientCanvas/TdpClientCanvas.tsx
+++ b/web/packages/teleport/src/components/TdpClientCanvas/TdpClientCanvas.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { memo, useEffect, useRef } from 'react';
+import { memo, useEffect, useRef } from 'react';
 import { DebouncedFunc } from 'shared/utils/highbar';
 
 import { TdpClientEvent, TdpClient } from 'teleport/lib/tdp';

--- a/web/packages/teleport/src/components/ToolTipBadge/ToolTipBadge.story.tsx
+++ b/web/packages/teleport/src/components/ToolTipBadge/ToolTipBadge.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 import { Box } from 'design';
 

--- a/web/packages/teleport/src/components/ToolTipBadge/ToolTipBadge.test.tsx
+++ b/web/packages/teleport/src/components/ToolTipBadge/ToolTipBadge.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 
 import { render, screen, userEvent } from 'design/utils/testing';

--- a/web/packages/teleport/src/components/ToolTipNoPermBadge/ToolTipNoPermBadge.story.tsx
+++ b/web/packages/teleport/src/components/ToolTipNoPermBadge/ToolTipNoPermBadge.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 import { Box } from 'design';
 

--- a/web/packages/teleport/src/components/ToolTipNoPermBadge/ToolTipNoPermBadge.test.tsx
+++ b/web/packages/teleport/src/components/ToolTipNoPermBadge/ToolTipNoPermBadge.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import styled from 'styled-components';
 import { render, screen, userEvent } from 'design/utils/testing';
 

--- a/web/packages/teleport/src/components/UserMenuNav/UserMenuNav.story.tsx
+++ b/web/packages/teleport/src/components/UserMenuNav/UserMenuNav.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 import * as Icons from 'design/Icon';
 

--- a/web/packages/teleport/src/components/UserMenuNav/UserMenuNav.test.tsx
+++ b/web/packages/teleport/src/components/UserMenuNav/UserMenuNav.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { MemoryRouter } from 'react-router';
 
 import {

--- a/web/packages/teleport/src/components/Wizard/Navigation/Bullet.tsx
+++ b/web/packages/teleport/src/components/Wizard/Navigation/Bullet.tsx
@@ -17,7 +17,6 @@
  */
 
 import Flex from 'design/Flex';
-import React from 'react';
 import styled from 'styled-components';
 
 export type Props = {

--- a/web/packages/teleport/src/components/Wizard/Navigation/Navigation.story.tsx
+++ b/web/packages/teleport/src/components/Wizard/Navigation/Navigation.story.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Box } from 'design';
 
 import { addIndexToViews } from '../flow';

--- a/web/packages/teleport/src/components/Wizard/Navigation/Navigation.test.tsx
+++ b/web/packages/teleport/src/components/Wizard/Navigation/Navigation.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { render, screen } from 'design/utils/testing';
 
 import { Navigation } from './Navigation';

--- a/web/packages/teleport/src/components/Wizard/Navigation/Navigation.tsx
+++ b/web/packages/teleport/src/components/Wizard/Navigation/Navigation.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { Flex } from 'design';
 
 import { BaseView } from '../flow';

--- a/web/packages/teleport/src/components/Wizard/Navigation/StepItem.tsx
+++ b/web/packages/teleport/src/components/Wizard/Navigation/StepItem.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import {
   StepTitle,
   StepsContainer,

--- a/web/packages/teleport/src/components/Wizard/Navigation/StepList.tsx
+++ b/web/packages/teleport/src/components/Wizard/Navigation/StepList.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import { BaseView } from '../flow';
 
 import { StepItem } from './StepItem';

--- a/web/packages/teleport/src/components/Wizard/flow.test.tsx
+++ b/web/packages/teleport/src/components/Wizard/flow.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { render, screen } from 'design/utils/testing';
 
 import { Navigation } from './Navigation';

--- a/web/packages/teleport/src/components/hooks/useUrlFiltering/useUrlFiltering.test.tsx
+++ b/web/packages/teleport/src/components/hooks/useUrlFiltering/useUrlFiltering.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
 import { Router } from 'react-router';
 import { createMemoryHistory } from 'history';
 import renderHook from 'design/utils/renderHook';

--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-
 import {
   Bots as BotsIcon,
   CirclePlay,

--- a/web/packages/teleport/src/useTeleport.ts
+++ b/web/packages/teleport/src/useTeleport.ts
@@ -16,12 +16,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { useContext } from 'react';
 
 import { ReactContext } from './TeleportContextProvider';
 
 export default function useTeleport() {
-  const teleportContext = React.useContext(ReactContext);
+  const teleportContext = useContext(ReactContext);
   if (!teleportContext) {
     throw new Error('Unable to retrieve Teleport Context');
   }

--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/AccessRequestCheckout.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/AccessRequestCheckout.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 import { Transition } from 'react-transition-group';
 
 import {


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/50325 to branch/v17