### PR TITLE
Use consistent naming in the standard role editor

### DIFF
--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/AccessRules.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/AccessRules.tsx
@@ -38,7 +38,7 @@ import {
   RuleModel,
   verbOptions,
 } from './standardmodel';
-import { Section, SectionProps } from './sections';
+import { SectionBox, SectionProps } from './sections';
 
 export function AccessRules({
   value,
@@ -86,7 +86,7 @@ function AccessRule({
 }) {
   const { resources, verbs } = value;
   return (
-    <Section
+    <SectionBox
       title="Access Rule"
       tooltip="A rule that gives users access to certain kinds of resources"
       removable
@@ -114,7 +114,7 @@ function AccessRule({
         rule={precomputed(validation.fields.verbs)}
         mb={0}
       />
-    </Section>
+    </SectionBox>
   );
 }
 

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/MetadataSection.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/MetadataSection.tsx
@@ -24,7 +24,7 @@ import { LabelsInput } from 'teleport/components/LabelsInput';
 
 import Text from 'design/Text';
 
-import { Section, SectionProps } from './sections';
+import { SectionBox, SectionProps } from './sections';
 import { MetadataModel } from './standardmodel';
 import { MetadataValidationResult } from './validation';
 
@@ -34,7 +34,7 @@ export const MetadataSection = ({
   validation,
   onChange,
 }: SectionProps<MetadataModel, MetadataValidationResult>) => (
-  <Section
+  <SectionBox
     title="Role Metadata"
     tooltip="Basic information about the role resource"
     isProcessing={isProcessing}
@@ -66,5 +66,5 @@ export const MetadataSection = ({
       setLabels={labels => onChange?.({ ...value, labels })}
       rule={precomputed(validation.fields.labels)}
     />
-  </Section>
+  </SectionBox>
 );

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.test.tsx
@@ -22,36 +22,39 @@ import { Validator } from 'shared/components/Validation';
 import selectEvent from 'react-select-event';
 
 import {
-  AppAccessSpec,
-  DatabaseAccessSpec,
-  KubernetesAccessSpec,
-  newAccessSpec,
-  ServerAccessSpec,
-  WindowsDesktopAccessSpec,
+  ServerAccess,
+  newResourceAccess,
+  KubernetesAccess,
+  AppAccess,
+  DatabaseAccess,
+  WindowsDesktopAccess,
 } from './standardmodel';
-import { AccessSpecValidationResult, validateAccessSpec } from './validation';
 import {
-  ServerAccessSpecSection,
-  KubernetesAccessSpecSection,
-  AppAccessSpecSection,
-  DatabaseAccessSpecSection,
-  WindowsDesktopAccessSpecSection,
+  ResourceAccessValidationResult,
+  validateResourceAccess,
+} from './validation';
+import {
+  ServerAccessSection,
+  KubernetesAccessSection,
+  AppAccessSection,
+  DatabaseAccessSection,
+  WindowsDesktopAccessSection,
 } from './Resources';
 import { StatefulSection } from './StatefulSection';
 
-describe('ServerAccessSpecSection', () => {
+describe('ServerAccessSection', () => {
   const setup = () => {
     const onChange = jest.fn();
     let validator: Validator;
     render(
-      <StatefulSection<ServerAccessSpec, AccessSpecValidationResult>
-        component={ServerAccessSpecSection}
-        defaultValue={newAccessSpec('node')}
+      <StatefulSection<ServerAccess, ResourceAccessValidationResult>
+        component={ServerAccessSection}
+        defaultValue={newResourceAccess('node')}
         onChange={onChange}
         validatorRef={v => {
           validator = v;
         }}
-        validate={validateAccessSpec}
+        validate={validateResourceAccess}
       />
     );
     return { user: userEvent.setup(), onChange, validator };
@@ -80,7 +83,7 @@ describe('ServerAccessSpecSection', () => {
         expect.objectContaining({ label: 'root', value: 'root' }),
         expect.objectContaining({ label: 'some-user', value: 'some-user' }),
       ],
-    } as ServerAccessSpec);
+    } as ServerAccess);
   });
 
   test('validation', async () => {
@@ -99,25 +102,25 @@ describe('ServerAccessSpecSection', () => {
   });
 });
 
-describe('KubernetesAccessSpecSection', () => {
+describe('KubernetesAccessSection', () => {
   const setup = () => {
     const onChange = jest.fn();
     let validator: Validator;
     render(
-      <StatefulSection<KubernetesAccessSpec, AccessSpecValidationResult>
-        component={KubernetesAccessSpecSection}
-        defaultValue={newAccessSpec('kube_cluster')}
+      <StatefulSection<KubernetesAccess, ResourceAccessValidationResult>
+        component={KubernetesAccessSection}
+        defaultValue={newResourceAccess('kube_cluster')}
         onChange={onChange}
         validatorRef={v => {
           validator = v;
         }}
-        validate={validateAccessSpec}
+        validate={validateResourceAccess}
       />
     );
     return { user: userEvent.setup(), onChange, validator };
   };
 
-  test('editing the spec', async () => {
+  test('editing', async () => {
     const { user, onChange } = setup();
 
     await selectEvent.create(screen.getByLabelText('Groups'), 'group1', {
@@ -167,7 +170,7 @@ describe('KubernetesAccessSpecSection', () => {
           ],
         },
       ],
-    } as KubernetesAccessSpec);
+    } as KubernetesAccess);
   });
 
   test('adding and removing resources', async () => {
@@ -242,19 +245,19 @@ describe('KubernetesAccessSpecSection', () => {
   });
 });
 
-describe('AppAccessSpecSection', () => {
+describe('AppAccessSection', () => {
   const setup = () => {
     const onChange = jest.fn();
     let validator: Validator;
     render(
-      <StatefulSection<AppAccessSpec, AccessSpecValidationResult>
-        component={AppAccessSpecSection}
-        defaultValue={newAccessSpec('app')}
+      <StatefulSection<AppAccess, ResourceAccessValidationResult>
+        component={AppAccessSection}
+        defaultValue={newResourceAccess('app')}
         onChange={onChange}
         validatorRef={v => {
           validator = v;
         }}
-        validate={validateAccessSpec}
+        validate={validateResourceAccess}
       />
     );
     return { user: userEvent.setup(), onChange, validator };
@@ -314,7 +317,7 @@ describe('AppAccessSpecSection', () => {
         '{{internal.gcp_service_accounts}}',
         'admin@some-project.iam.gserviceaccount.com',
       ],
-    } as AppAccessSpec);
+    } as AppAccess);
   });
 
   test('validation', async () => {
@@ -348,19 +351,19 @@ describe('AppAccessSpecSection', () => {
   });
 });
 
-describe('DatabaseAccessSpecSection', () => {
+describe('DatabaseAccessSection', () => {
   const setup = () => {
     const onChange = jest.fn();
     let validator: Validator;
     render(
-      <StatefulSection<DatabaseAccessSpec, AccessSpecValidationResult>
-        component={DatabaseAccessSpecSection}
-        defaultValue={newAccessSpec('db')}
+      <StatefulSection<DatabaseAccess, ResourceAccessValidationResult>
+        component={DatabaseAccessSection}
+        defaultValue={newResourceAccess('db')}
         onChange={onChange}
         validatorRef={v => {
           validator = v;
         }}
-        validate={validateAccessSpec}
+        validate={validateResourceAccess}
       />
     );
     return { user: userEvent.setup(), onChange, validator };
@@ -395,7 +398,7 @@ describe('DatabaseAccessSpecSection', () => {
         expect.objectContaining({ value: '{{internal.db_users}}' }),
         expect.objectContaining({ label: 'mary', value: 'mary' }),
       ],
-    } as DatabaseAccessSpec);
+    } as DatabaseAccess);
   });
 
   test('validation', async () => {
@@ -414,19 +417,19 @@ describe('DatabaseAccessSpecSection', () => {
   });
 });
 
-describe('WindowsDesktopAccessSpecSection', () => {
+describe('WindowsDesktopAccessSection', () => {
   const setup = () => {
     const onChange = jest.fn();
     let validator: Validator;
     render(
-      <StatefulSection<WindowsDesktopAccessSpec, AccessSpecValidationResult>
-        component={WindowsDesktopAccessSpecSection}
-        defaultValue={newAccessSpec('windows_desktop')}
+      <StatefulSection<WindowsDesktopAccess, ResourceAccessValidationResult>
+        component={WindowsDesktopAccessSection}
+        defaultValue={newResourceAccess('windows_desktop')}
         onChange={onChange}
         validatorRef={v => {
           validator = v;
         }}
-        validate={validateAccessSpec}
+        validate={validateResourceAccess}
       />
     );
     return { user: userEvent.setup(), onChange, validator };
@@ -447,7 +450,7 @@ describe('WindowsDesktopAccessSpecSection', () => {
         expect.objectContaining({ value: '{{internal.windows_logins}}' }),
         expect.objectContaining({ label: 'julio', value: 'julio' }),
       ],
-    } as WindowsDesktopAccessSpec);
+    } as WindowsDesktopAccess);
   });
 
   test('validation', async () => {

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.tsx
@@ -32,33 +32,33 @@ import { precomputed } from 'shared/components/Validation/rules';
 import styled, { useTheme } from 'styled-components';
 import { LabelsInput } from 'teleport/components/LabelsInput';
 
-import { SectionProps, Section } from './sections';
+import { SectionProps, SectionBox } from './sections';
 import {
-  AccessSpecKind,
-  AccessSpec,
-  ServerAccessSpec,
-  KubernetesAccessSpec,
+  ResourceAccessKind,
+  ResourceAccess,
+  ServerAccess,
+  KubernetesAccess,
   newKubernetesResourceModel,
   KubernetesResourceModel,
   kubernetesResourceKindOptions,
   kubernetesVerbOptions,
-  AppAccessSpec,
-  DatabaseAccessSpec,
-  WindowsDesktopAccessSpec,
+  AppAccess,
+  DatabaseAccess,
+  WindowsDesktopAccess,
 } from './standardmodel';
 import {
-  AccessSpecValidationResult,
-  ServerSpecValidationResult,
-  KubernetesSpecValidationResult,
+  ResourceAccessValidationResult,
+  ServerAccessValidationResult,
+  KubernetesAccessValidationResult,
   KubernetesResourceValidationResult,
-  AppSpecValidationResult,
-  DatabaseSpecValidationResult,
-  WindowsDesktopSpecValidationResult,
+  AppAccessValidationResult,
+  DatabaseAccessValidationResult,
+  WindowsDesktopAccessValidationResult,
 } from './validation';
 
-/** Maps access specification kind to UI component configuration. */
-export const specSections: Record<
-  AccessSpecKind,
+/** Maps resource access kind to UI component configuration. */
+export const resourceAccessSections: Record<
+  ResourceAccessKind,
   {
     title: string;
     tooltip: string;
@@ -68,37 +68,37 @@ export const specSections: Record<
   kube_cluster: {
     title: 'Kubernetes',
     tooltip: 'Configures access to Kubernetes clusters',
-    component: KubernetesAccessSpecSection,
+    component: KubernetesAccessSection,
   },
   node: {
     title: 'Servers',
     tooltip: 'Configures access to SSH servers',
-    component: ServerAccessSpecSection,
+    component: ServerAccessSection,
   },
   app: {
     title: 'Applications',
     tooltip: 'Configures access to applications',
-    component: AppAccessSpecSection,
+    component: AppAccessSection,
   },
   db: {
     title: 'Databases',
     tooltip: 'Configures access to databases',
-    component: DatabaseAccessSpecSection,
+    component: DatabaseAccessSection,
   },
   windows_desktop: {
     title: 'Windows Desktops',
     tooltip: 'Configures access to Windows desktops',
-    component: WindowsDesktopAccessSpecSection,
+    component: WindowsDesktopAccessSection,
   },
 };
 
 /**
- * A generic access spec section. Details are rendered by components from the
- * `specSections` map.
+ * A generic resource section. Details are rendered by components from the
+ * `resourceAccessSections` map.
  */
-export const AccessSpecSection = <
-  T extends AccessSpec,
-  V extends AccessSpecValidationResult,
+export const ResourceAccessSection = <
+  T extends ResourceAccess,
+  V extends ResourceAccessValidationResult,
 >({
   value,
   isProcessing,
@@ -108,9 +108,13 @@ export const AccessSpecSection = <
 }: SectionProps<T, V> & {
   onRemove?(): void;
 }) => {
-  const { component: Body, title, tooltip } = specSections[value.kind];
+  const {
+    component: Body,
+    title,
+    tooltip,
+  } = resourceAccessSections[value.kind];
   return (
-    <Section
+    <SectionBox
       title={title}
       removable
       onRemove={onRemove}
@@ -124,16 +128,16 @@ export const AccessSpecSection = <
         validation={validation}
         onChange={onChange}
       />
-    </Section>
+    </SectionBox>
   );
 };
 
-export function ServerAccessSpecSection({
+export function ServerAccessSection({
   value,
   isProcessing,
   validation,
   onChange,
-}: SectionProps<ServerAccessSpec, ServerSpecValidationResult>) {
+}: SectionProps<ServerAccess, ServerAccessValidationResult>) {
   return (
     <>
       <Text typography="body3" mb={1}>
@@ -164,12 +168,12 @@ export function ServerAccessSpecSection({
   );
 }
 
-export function KubernetesAccessSpecSection({
+export function KubernetesAccessSection({
   value,
   isProcessing,
   validation,
   onChange,
-}: SectionProps<KubernetesAccessSpec, KubernetesSpecValidationResult>) {
+}: SectionProps<KubernetesAccess, KubernetesAccessValidationResult>) {
   return (
     <>
       <FieldSelectCreatable
@@ -324,12 +328,12 @@ function KubernetesResourceView({
   );
 }
 
-export function AppAccessSpecSection({
+export function AppAccessSection({
   value,
   validation,
   isProcessing,
   onChange,
-}: SectionProps<AppAccessSpec, AppSpecValidationResult>) {
+}: SectionProps<AppAccess, AppAccessValidationResult>) {
   return (
     <Flex flexDirection="column" gap={3}>
       <Box>
@@ -368,12 +372,12 @@ export function AppAccessSpecSection({
   );
 }
 
-export function DatabaseAccessSpecSection({
+export function DatabaseAccessSection({
   value,
   isProcessing,
   validation,
   onChange,
-}: SectionProps<DatabaseAccessSpec, DatabaseSpecValidationResult>) {
+}: SectionProps<DatabaseAccess, DatabaseAccessValidationResult>) {
   return (
     <>
       <Box mb={3}>
@@ -442,12 +446,12 @@ export function DatabaseAccessSpecSection({
   );
 }
 
-export function WindowsDesktopAccessSpecSection({
+export function WindowsDesktopAccessSection({
   value,
   isProcessing,
   validation,
   onChange,
-}: SectionProps<WindowsDesktopAccessSpec, WindowsDesktopSpecValidationResult>) {
+}: SectionProps<WindowsDesktopAccess, WindowsDesktopAccessValidationResult>) {
   return (
     <>
       <Box mb={3}>

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.test.tsx
@@ -59,7 +59,7 @@ test('adding and removing sections', async () => {
   expect(getAllSectionNames()).toEqual([]);
 
   await user.click(
-    screen.getByRole('button', { name: 'Add New Specifications' })
+    screen.getByRole('button', { name: 'Add New Resource Access' })
   );
   expect(getAllMenuItemNames()).toEqual([
     'Kubernetes',
@@ -73,7 +73,7 @@ test('adding and removing sections', async () => {
   expect(getAllSectionNames()).toEqual(['Servers']);
 
   await user.click(
-    screen.getByRole('button', { name: 'Add New Specifications' })
+    screen.getByRole('button', { name: 'Add New Resource Access' })
   );
   expect(getAllMenuItemNames()).toEqual([
     'Kubernetes',

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.tsx
@@ -32,16 +32,16 @@ import {
   hasModifiedFields,
   RoleEditorModel,
   StandardEditorModel,
-  AccessSpecKind,
-  AccessSpec,
-  newAccessSpec,
+  ResourceAccessKind,
+  ResourceAccess,
+  newResourceAccess,
   RuleModel,
   OptionsModel,
 } from './standardmodel';
 import { validateRoleEditorModel } from './validation';
 import { RequiresResetToStandard } from './RequiresResetToStandard';
 import { MetadataSection } from './MetadataSection';
-import { AccessSpecSection, specSections } from './Resources';
+import { ResourceAccessSection, resourceAccessSections } from './Resources';
 import { AccessRules } from './AccessRules';
 import { Options } from './Options';
 
@@ -70,9 +70,9 @@ export const StandardEditor = ({
   const { roleModel } = standardEditorModel;
   const validation = validateRoleEditorModel(roleModel);
 
-  /** All spec kinds except those that are already in the role. */
-  const allowedSpecKinds = allAccessSpecKinds.filter(k =>
-    roleModel.accessSpecs.every(as => as.kind !== k)
+  /** All resource access kinds except those that are already in the role. */
+  const allowedResourceAccessKinds = allResourceAccessKinds.filter(k =>
+    roleModel.resources.every(as => as.kind !== k)
   );
 
   enum StandardEditorTab {
@@ -111,29 +111,29 @@ export const StandardEditor = ({
     });
   }
 
-  function addAccessSpec(kind: AccessSpecKind) {
+  function addResourceAccess(kind: ResourceAccessKind) {
     handleChange({
       ...standardEditorModel.roleModel,
-      accessSpecs: [
-        ...standardEditorModel.roleModel.accessSpecs,
-        newAccessSpec(kind),
+      resources: [
+        ...standardEditorModel.roleModel.resources,
+        newResourceAccess(kind),
       ],
     });
   }
 
-  function removeAccessSpec(kind: AccessSpecKind) {
+  function removeResourceAccess(kind: ResourceAccessKind) {
     handleChange({
       ...standardEditorModel.roleModel,
-      accessSpecs: standardEditorModel.roleModel.accessSpecs.filter(
+      resources: standardEditorModel.roleModel.resources.filter(
         s => s.kind !== kind
       ),
     });
   }
 
-  function setAccessSpec(value: AccessSpec) {
+  function setResourceAccess(value: ResourceAccess) {
     handleChange({
       ...standardEditorModel.roleModel,
-      accessSpecs: standardEditorModel.roleModel.accessSpecs.map(original =>
+      resources: standardEditorModel.roleModel.resources.map(original =>
         original.kind === value.kind ? value : original
       ),
     });
@@ -184,7 +184,7 @@ export const StandardEditor = ({
                 controls: resourcesTabId,
                 status:
                   validator.state.validating &&
-                  validation.accessSpecs.some(s => !s.valid)
+                  validation.resources.some(s => !s.valid)
                     ? validationErrorTabStatus
                     : undefined,
               },
@@ -237,16 +237,16 @@ export const StandardEditor = ({
             }}
           >
             <Flex flexDirection="column" gap={3} my={2}>
-              {roleModel.accessSpecs.map((spec, i) => {
-                const validationResult = validation.accessSpecs[i];
+              {roleModel.resources.map((res, i) => {
+                const validationResult = validation.resources[i];
                 return (
-                  <AccessSpecSection
-                    key={spec.kind}
-                    value={spec}
+                  <ResourceAccessSection
+                    key={res.kind}
+                    value={res}
                     isProcessing={isProcessing}
                     validation={validationResult}
-                    onChange={value => setAccessSpec(value)}
-                    onRemove={() => removeAccessSpec(spec.kind)}
+                    onChange={value => setResourceAccess(value)}
+                    onRemove={() => removeResourceAccess(res.kind)}
                   />
                 );
               })}
@@ -265,18 +265,22 @@ export const StandardEditor = ({
                   buttonText={
                     <>
                       <Icon.Plus size="small" mr={2} />
-                      Add New Specifications
+                      Add New Resource Access
                     </>
                   }
                   buttonProps={{
                     size: 'medium',
                     fill: 'filled',
-                    disabled: isProcessing || allowedSpecKinds.length === 0,
+                    disabled:
+                      isProcessing || allowedResourceAccessKinds.length === 0,
                   }}
                 >
-                  {allowedSpecKinds.map(kind => (
-                    <MenuItem key={kind} onClick={() => addAccessSpec(kind)}>
-                      {specSections[kind].title}
+                  {allowedResourceAccessKinds.map(kind => (
+                    <MenuItem
+                      key={kind}
+                      onClick={() => addResourceAccess(kind)}
+                    >
+                      {resourceAccessSections[kind].title}
                     </MenuItem>
                   ))}
                 </MenuButton>
@@ -331,9 +335,10 @@ const validationErrorTabStatus = {
 } as const;
 
 /**
- * All access spec kinds, in order of appearance in the resource kind dropdown.
+ * All resource access kinds, in order of appearance in the resource kind
+ * dropdown.
  */
-const allAccessSpecKinds: AccessSpecKind[] = [
+const allResourceAccessKinds: ResourceAccessKind[] = [
   'kube_cluster',
   'node',
   'app',

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StatefulSection.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StatefulSection.tsx
@@ -23,20 +23,20 @@ import Validation, { Validator } from 'shared/components/Validation';
 import { SectionProps } from './sections';
 
 /** A helper for testing editor section components. */
-export function StatefulSection<Spec, ValidationResult>({
+export function StatefulSection<Model, ValidationResult>({
   defaultValue,
   component: Component,
   onChange,
   validatorRef,
   validate,
 }: {
-  defaultValue: Spec;
-  component: React.ComponentType<SectionProps<Spec, any>>;
-  onChange(spec: Spec): void;
+  defaultValue: Model;
+  component: React.ComponentType<SectionProps<Model, any>>;
+  onChange(model: Model): void;
   validatorRef?(v: Validator): void;
-  validate(arg: Spec): ValidationResult;
+  validate(arg: Model): ValidationResult;
 }) {
-  const [model, setModel] = useState<Spec>(defaultValue);
+  const [model, setModel] = useState<Model>(defaultValue);
   const validation = validate(model);
   return (
     <Validation>
@@ -47,9 +47,9 @@ export function StatefulSection<Spec, ValidationResult>({
             value={model}
             validation={validation}
             isProcessing={false}
-            onChange={spec => {
-              setModel(spec);
-              onChange(spec);
+            onChange={model => {
+              setModel(model);
+              onChange(model);
             }}
           />
         );

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/sections.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/sections.tsx
@@ -38,7 +38,7 @@ export type SectionProps<Model, ValidationResult> = {
  * A wrapper for editor section. Its responsibility is rendering a header,
  * expanding, collapsing, and removing the section.
  */
-export const Section = ({
+export const SectionBox = ({
   title,
   tooltip,
   children,

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.test.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.test.ts
@@ -32,7 +32,7 @@ import { Label as UILabel } from 'teleport/components/LabelsInput/LabelsInput';
 import { Labels } from 'teleport/services/resources';
 
 import {
-  KubernetesAccessSpec,
+  KubernetesAccess,
   labelsModelToLabels,
   labelsToModel,
   RoleEditorModel,
@@ -46,7 +46,7 @@ const minimalRole = () =>
 
 const minimalRoleModel = (): RoleEditorModel => ({
   metadata: { name: 'foobar', labels: [] },
-  accessSpecs: [],
+  resources: [],
   rules: [],
   requiresReset: false,
   options: {
@@ -102,7 +102,7 @@ describe.each<{ name: string; role: Role; model: RoleEditorModel }>([
   },
 
   {
-    name: 'server access spec',
+    name: 'server access',
     role: {
       ...minimalRole(),
       spec: {
@@ -115,7 +115,7 @@ describe.each<{ name: string; role: Role; model: RoleEditorModel }>([
     },
     model: {
       ...minimalRoleModel(),
-      accessSpecs: [
+      resources: [
         {
           kind: 'node',
           labels: [{ name: 'foo', value: 'bar' }],
@@ -130,7 +130,7 @@ describe.each<{ name: string; role: Role; model: RoleEditorModel }>([
   },
 
   {
-    name: 'app access spec',
+    name: 'app access',
     role: {
       ...minimalRole(),
       spec: {
@@ -154,7 +154,7 @@ describe.each<{ name: string; role: Role; model: RoleEditorModel }>([
     },
     model: {
       ...minimalRoleModel(),
-      accessSpecs: [
+      resources: [
         {
           kind: 'app',
           labels: [{ name: 'foo', value: 'bar' }],
@@ -176,7 +176,7 @@ describe.each<{ name: string; role: Role; model: RoleEditorModel }>([
   },
 
   {
-    name: 'database access spec',
+    name: 'database access',
     role: {
       ...minimalRole(),
       spec: {
@@ -191,7 +191,7 @@ describe.each<{ name: string; role: Role; model: RoleEditorModel }>([
     },
     model: {
       ...minimalRoleModel(),
-      accessSpecs: [
+      resources: [
         {
           kind: 'db',
           labels: [{ name: 'env', value: 'prod' }],
@@ -213,7 +213,7 @@ describe.each<{ name: string; role: Role; model: RoleEditorModel }>([
   },
 
   {
-    name: 'Windows desktop access spec',
+    name: 'Windows desktop access',
     role: {
       ...minimalRole(),
       spec: {
@@ -226,7 +226,7 @@ describe.each<{ name: string; role: Role; model: RoleEditorModel }>([
     },
     model: {
       ...minimalRoleModel(),
-      accessSpecs: [
+      resources: [
         {
           kind: 'windows_desktop',
           labels: [{ name: 'os', value: 'WindowsForWorkgroups' }],
@@ -305,8 +305,8 @@ describe('roleToRoleEditorModel', () => {
     ...minimalRoleModel(),
     requiresReset: true,
   };
-  // Same as newAccessSpec('kube_cluster'), but without default groups.
-  const newKubeClusterAccessSpec = (): KubernetesAccessSpec => ({
+  // Same as newResourceAccess('kube_cluster'), but without default groups.
+  const newKubeClusterResourceAccess = (): KubernetesAccess => ({
     kind: 'kube_cluster',
     groups: [],
     labels: [],
@@ -362,9 +362,9 @@ describe('roleToRoleEditorModel', () => {
       } as Role,
       model: {
         ...roleModelWithReset,
-        accessSpecs: [
+        resources: [
           {
-            ...newKubeClusterAccessSpec(),
+            ...newKubeClusterResourceAccess(),
             resources: [expect.any(Object)],
           },
         ],
@@ -388,9 +388,9 @@ describe('roleToRoleEditorModel', () => {
       } as Role,
       model: {
         ...roleModelWithReset,
-        accessSpecs: [
+        resources: [
           {
-            ...newKubeClusterAccessSpec(),
+            ...newKubeClusterResourceAccess(),
             resources: [
               expect.objectContaining({ kind: { value: 'job', label: 'Job' } }),
             ],
@@ -418,9 +418,9 @@ describe('roleToRoleEditorModel', () => {
       } as Role,
       model: {
         ...roleModelWithReset,
-        accessSpecs: [
+        resources: [
           {
-            ...newKubeClusterAccessSpec(),
+            ...newKubeClusterResourceAccess(),
             resources: [
               expect.objectContaining({
                 verbs: [{ value: 'get', label: 'get' }],
@@ -697,7 +697,7 @@ describe('roleToRoleEditorModel', () => {
 
   // This case has to be tested separately because of dynamic resource ID
   // generation.
-  it('creates a Kubernetes access spec', () => {
+  it('creates Kubernetes access', () => {
     const minRole = minimalRole();
     expect(
       roleToRoleEditorModel({
@@ -725,7 +725,7 @@ describe('roleToRoleEditorModel', () => {
       })
     ).toEqual({
       ...minimalRoleModel(),
-      accessSpecs: [
+      resources: [
         {
           kind: 'kube_cluster',
           groups: [
@@ -758,7 +758,7 @@ describe('roleToRoleEditorModel', () => {
   });
 
   // Make sure that some fields are optional.
-  it('creates a minimal app access spec', () => {
+  it('creates minimal app access', () => {
     const minRole = minimalRole();
     expect(
       roleToRoleEditorModel({
@@ -772,7 +772,7 @@ describe('roleToRoleEditorModel', () => {
       })
     ).toEqual({
       ...minimalRoleModel(),
-      accessSpecs: [
+      resources: [
         {
           kind: 'app',
           labels: [{ name: 'foo', value: 'bar' }],
@@ -858,12 +858,12 @@ describe('roleEditorModelToRole', () => {
 
   // This case has to be tested separately because of dynamic resource ID
   // generation.
-  it('converts a Kubernetes access spec', () => {
+  it('converts Kubernetes access', () => {
     const minRole = minimalRole();
     expect(
       roleEditorModelToRole({
         ...minimalRoleModel(),
-        accessSpecs: [
+        resources: [
           {
             kind: 'kube_cluster',
             groups: [


### PR DESCRIPTION
- Rename the term "access spec" to "resource access" to conform to the UI terminology and prevent confusion with the "spec" pattern (and the `Role.spec` field in particular).
- Rename `Section` to `SectionBox` to make it clear that `SectionProps` type doesn't apply to it.

No functional changes expected.

Requires https://github.com/gravitational/teleport/pull/50350