### PR TITLE
fix: check if plugin type is identity center before SAML app and OIDC integration deletion

### DIFF
--- a/lib/fixtures/plugins.go
+++ b/lib/fixtures/plugins.go
@@ -1,0 +1,85 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package fixtures
+
+import (
+	"testing"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+// NewIdentityCenterPlugin returns a new types.PluginV1 with PluginSpecV1_AwsIc settings.
+func NewIdentityCenterPlugin(t *testing.T, serviceProviderName, integrationName string) *types.PluginV1 {
+	t.Helper()
+	return &types.PluginV1{
+		Metadata: types.Metadata{
+			Name: types.PluginTypeAWSIdentityCenter,
+			Labels: map[string]string{
+				types.HostedPluginLabel: "true",
+			},
+		},
+		Spec: types.PluginSpecV1{
+			Settings: &types.PluginSpecV1_AwsIc{
+				AwsIc: &types.PluginAWSICSettings{
+					IntegrationName:         integrationName,
+					Region:                  "test-region",
+					Arn:                     "test-arn",
+					AccessListDefaultOwners: []string{"user1", "user2"},
+					ProvisioningSpec: &types.AWSICProvisioningSpec{
+						BaseUrl: "https://example.com",
+					},
+					SamlIdpServiceProviderName: serviceProviderName,
+				},
+			},
+		},
+	}
+}
+
+// NewIdentityCenterPlugin returns a new types.PluginV1 with PluginSpecV1_Mattermost settings.
+func NewMattermostPlugin(t *testing.T) *types.PluginV1 {
+	t.Helper()
+	return &types.PluginV1{
+		SubKind: types.PluginSubkindAccess,
+		Metadata: types.Metadata{
+			Labels: map[string]string{
+				"teleport.dev/hosted-plugin": "true",
+			},
+			Name: types.PluginTypeMattermost,
+		},
+		Spec: types.PluginSpecV1{
+			Settings: &types.PluginSpecV1_Mattermost{
+				Mattermost: &types.PluginMattermostSettings{
+					ServerUrl:     "https://example.com",
+					Channel:       "test_channel",
+					Team:          "test_team",
+					ReportToEmail: "test@example.com",
+				},
+			},
+		},
+		Credentials: &types.PluginCredentialsV1{
+			Credentials: &types.PluginCredentialsV1_StaticCredentialsRef{
+				StaticCredentialsRef: &types.PluginStaticCredentialsRef{
+					Labels: map[string]string{
+						"plugin": "mattermost",
+					},
+				},
+			},
+		},
+	}
+}

--- a/lib/services/local/integrations.go
+++ b/lib/services/local/integrations.go
@@ -212,9 +212,11 @@ func integrationReferencedByAWSICPlugin(ctx context.Context, bk backend.Backend,
 		if !ok {
 			continue
 		}
-
-		if pluginV1.GetType() == types.PluginType(types.PluginTypeAWSIdentityCenter) {
-			switch pluginV1.Spec.GetAwsIc().IntegrationName {
+		if pluginV1.GetType() != types.PluginType(types.PluginTypeAWSIdentityCenter) {
+			continue
+		}
+		if awsIC := pluginV1.Spec.GetAwsIc(); awsIC != nil {
+			switch awsIC.IntegrationName {
 			case name:
 				return nil, trace.BadParameter("cannot delete AWS OIDC integration currently referenced by AWS Identity Center integration %q", pluginV1.GetName())
 			default:

--- a/lib/services/local/saml_idp_service_provider.go
+++ b/lib/services/local/saml_idp_service_provider.go
@@ -419,9 +419,13 @@ func spReferencedByAWSICPlugin(ctx context.Context, bk backend.Backend, serviceP
 		if !ok {
 			continue
 		}
-
-		if pluginV1.Spec.GetAwsIc().SamlIdpServiceProviderName == serviceProviderName {
-			return trace.BadParameter("cannot delete SAML service provider currently referenced by AWS Identity Center integration %q", pluginV1.GetName())
+		if pluginV1.GetType() != types.PluginType(types.PluginTypeAWSIdentityCenter) {
+			continue
+		}
+		if awsIC := pluginV1.Spec.GetAwsIc(); awsIC != nil {
+			if awsIC.SamlIdpServiceProviderName == serviceProviderName {
+				return trace.BadParameter("cannot delete SAML service provider currently referenced by AWS Identity Center integration %q", pluginV1.GetName())
+			}
 		}
 	}
 


### PR DESCRIPTION
changelog: Prevents panic in SAML app or OIDC integration deletion when a plugin type is not `PluginTypeAWSIdentityCenter` or `PluginAWSICSettings` is nil.