### PR TITLE
set rollout start date and don't start updating if rollout just changed

### DIFF
--- a/api/gen/proto/go/teleport/autoupdate/v1/autoupdate.pb.go
+++ b/api/gen/proto/go/teleport/autoupdate/v1/autoupdate.pb.go
@@ -997,6 +997,7 @@ type AutoUpdateAgentRolloutStatus struct {
 	// For example, a group updates every day between 13:00 and 14:00. If the target version changes to 13:30, the group
 	// will not start updating to the new version directly. The controller sees that the group theoretical start time is
 	// before the rollout start time and the maintenance window belongs to the previous rollout.
+	// When the timestamp is nil, the controller will ignore the start time and check and allow groups to activate.
 	StartTime     *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=start_time,json=startTime,proto3" json:"start_time,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/api/proto/teleport/autoupdate/v1/autoupdate.proto
+++ b/api/proto/teleport/autoupdate/v1/autoupdate.proto
@@ -180,6 +180,7 @@ message AutoUpdateAgentRolloutStatus {
   // For example, a group updates every day between 13:00 and 14:00. If the target version changes to 13:30, the group
   // will not start updating to the new version directly. The controller sees that the group theoretical start time is
   // before the rollout start time and the maintenance window belongs to the previous rollout.
+  // When the timestamp is nil, the controller will ignore the start time and check and allow groups to activate.
   google.protobuf.Timestamp start_time = 3;
 }
 

--- a/lib/autoupdate/rollout/controller.go
+++ b/lib/autoupdate/rollout/controller.go
@@ -71,6 +71,7 @@ func NewController(client Client, log *slog.Logger, clock clockwork.Clock, perio
 		reconciler: reconciler{
 			clt:               client,
 			log:               log,
+			clock:             clock,
 			rolloutStrategies: []rolloutStrategy{
 				// TODO(hugoShaka): add the strategies here as we implement them
 			},


### PR DESCRIPTION
Part of: [RFD-184](https://github.com/gravitational/teleport/pull/47126)

Goal (internal): https://github.com/gravitational/cloud/issues/10289

This PR does two changes:
- the controller now sets the rollout start time when resetting the rollout
- the controller will not start a group if the rollout changed during the maintenance window (checks if the rollout start time is in the window)