### PR TITLE
[teleport-update] Fix installer error if some binary is missing in tarball

### DIFF
--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -840,7 +840,9 @@ install_from_file() {
         tar -xzf "${TEMP_DIR}/${DOWNLOAD_FILENAME}" -C "${TEMP_DIR}"
         # install binaries to /usr/local/bin
         for BINARY in ${TELEPORT_BINARY_LIST}; do
-            ${COPY_COMMAND} "${TELEPORT_ARCHIVE_PATH}/${BINARY}" "${TELEPORT_BINARY_DIR}/"
+            if [ -e "${TELEPORT_ARCHIVE_PATH}/${BINARY}" ]; then
+                ${COPY_COMMAND} "${TELEPORT_ARCHIVE_PATH}/${BINARY}" "${TELEPORT_BINARY_DIR}/"
+            fi
         done
     elif [[ ${TELEPORT_FORMAT} == "deb" ]]; then
         # convert teleport arch to deb arch


### PR DESCRIPTION
Installer might be used with older teleport version tarballs without `teleport-update` binary, we must not exit with error if binary not in the package

```bash
Enter Teleport version to install (without v): 16.4.6
Enter target hostname to connect to: localhost
Enter target port to connect to [443]: 9443
Enter Teleport join token as provided: test
Would you like to enable and configure Teleport's app_service, to use Teleport as a reverse proxy for a web application? [y/n, default: n]
2024-12-17 15:32:09 PST [teleport-installer] TELEPORT_VERSION: 16.4.6
2024-12-17 15:32:09 PST [teleport-installer] TARGET_HOSTNAME: localhost
2024-12-17 15:32:09 PST [teleport-installer] TARGET_PORT: 9443
2024-12-17 15:32:09 PST [teleport-installer] JOIN_TOKEN: test
2024-12-17 15:32:10 PST [teleport-installer] CA_PIN_HASHES: {{.caPinsOld}}
2024-12-17 15:32:10 PST [teleport-installer] Checking TCP connectivity to Teleport server (localhost:9443)
2024-12-17 15:32:10 PST [teleport-installer] Connectivity to Teleport server (via nc) looks good
2024-12-17 15:32:10 PST [teleport-installer] Detected host: darwin23, using Teleport binary type darwin
2024-12-17 15:32:10 PST [teleport-installer] Detected macOS arm64 architecture, using Teleport arch arm64
2024-12-17 15:32:10 PST [teleport-installer] Using Teleport distribution: tarball
2024-12-17 15:32:10 PST [teleport-installer] Created temp dir /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/teleport-XXXXXXXXXX.boinlMakZl
2024-12-17 15:32:10 PST [teleport-installer] Installing from binary file.
2024-12-17 15:32:10 PST [teleport-installer] Downloading Teleport tarball release 16.4.6
2024-12-17 15:32:10 PST [teleport-installer] Running curl -fsSL --retry 5 --retry-delay 5 https://cdn.teleport.dev/teleport-v16.4.6-darwin-arm64-bin.tar.gz
2024-12-17 15:32:10 PST [teleport-installer] Downloading to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/teleport-XXXXXXXXXX.boinlMakZl/teleport-v16.4.6-darwin-arm64-bin.tar.gz
2024-12-17 15:36:41 PST [teleport-installer] Downloaded file size: 153830972 bytes
2024-12-17 15:36:41 PST [teleport-installer] Will use shasum -a 256 to validate the checksum of the downloaded file
2024-12-17 15:36:42 PST [teleport-installer] The downloaded file's checksum validated correctly
2024-12-17 15:36:47 PST [teleport-installer] Found: Teleport v16.4.6 git:v16.4.6-0-g3104d1a go1.22.8
2024-12-17 15:36:47 PST [teleport-installer] Writing Teleport node service config to /etc/teleport.yaml
```

```bash
% ls -la /usr/local/bin
drwxr-xr-x  18 root  wheel        576 Dec 17 15:36 .
drwxr-xr-x   8 root  wheel        256 Jun 18  2024 ..
-rwxr-xr-x   1 root  wheel   92493584 Dec 17 15:36 tctl
-rwxr-xr-x   1 root  wheel  302908800 Dec 17 15:36 teleport
-rwxr-xr-x   1 root  wheel  103472144 Dec 17 15:36 tsh
```

[discussion](https://gravitational.slack.com/archives/C0DF0TPMY/p1734474664214449)