### PR TITLE
[buddy] Fix absence of the Symlinks parameter for Destination when using tbot kube credentials

### DIFF
--- a/tool/tbot/kube.go
+++ b/tool/tbot/kube.go
@@ -73,6 +73,10 @@ func onKubeCredentialsCommand(
 		return trace.Wrap(err)
 	}
 
+	if err = destination.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+
 	idData, err := destination.Read(ctx, config.IdentityFilePath)
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
Buddy PR  for #49809

---

The problem is described in the [issue](https://github.com/gravitational/teleport/issues/49802). After the [tbot CLI refactoring](https://github.com/gravitational/teleport/pull/47130), the `bot.Destination` object created for the directory specified in the `--destination-dir` parameter does not have default values set for the `Symlinks` attribute.

Fixes #49802

---

Signed-off-by: Tim Buckley <tim@goteleport.com>
changelog: Fix regression in `tbot` on Linux causing the Kubernetes credential helper to fail