### PR TITLE
Use Web MFA dialog for admin actions

### DIFF
--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEKSCluster.test.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEKSCluster.test.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { act, fireEvent, render, screen } from 'design/utils/testing';
+import { act, fireEvent, render, screen, waitFor } from 'design/utils/testing';
 
 import cfg from 'teleport/config';
 import { ComponentWrapper } from 'teleport/Discover/Fixtures/kubernetes';
@@ -179,6 +179,7 @@ describe('test EnrollEksCluster.tsx', () => {
 
     expect(integrationService.enrollEksClusters).not.toHaveBeenCalled();
   });
+
   test('auto enroll disabled, enrolls cluster', async () => {
     jest.spyOn(integrationService, 'fetchEksClusters').mockResolvedValue({
       clusters: mockEKSClusters,
@@ -197,7 +198,9 @@ describe('test EnrollEksCluster.tsx', () => {
 
     act(() => screen.getByRole('radio').click());
 
-    act(() => screen.getByText('Enroll EKS Cluster').click());
+    await waitFor(() => {
+      screen.getByText('Enroll EKS Cluster').click();
+    });
 
     expect(discoveryService.createDiscoveryConfig).not.toHaveBeenCalled();
     expect(KubeService.prototype.fetchKubernetes).toHaveBeenCalledTimes(1);

--- a/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
@@ -54,6 +54,7 @@ import {
 } from 'teleport/components/Layout';
 import ResourceEditor from 'teleport/components/ResourceEditor';
 import useResources from 'teleport/components/useResources';
+import { useMfaContext } from 'teleport/MFAContext/MFAContext';
 import { JoinToken } from 'teleport/services/joinToken';
 import { KindJoinToken, Resource } from 'teleport/services/resources';
 
@@ -70,11 +71,15 @@ function makeTokenResource(token: JoinToken): Resource<KindJoinToken> {
 
 export const JoinTokens = () => {
   const ctx = useTeleport();
+  const mfa = useMfaContext();
   const [creatingToken, setCreatingToken] = useState(false);
   const [editingToken, setEditingToken] = useState<JoinToken | null>(null);
   const [tokenToDelete, setTokenToDelete] = useState<JoinToken | null>(null);
   const [joinTokensAttempt, runJoinTokensAttempt, setJoinTokensAttempt] =
-    useAsync(async () => await ctx.joinTokenService.fetchJoinTokens());
+    useAsync(async () => {
+      const mfaResponse = await mfa.getAdminActionMfaResponse();
+      return ctx.joinTokenService.fetchJoinTokens(null, mfaResponse);
+    });
 
   const resources = useResources(
     joinTokensAttempt.data?.items.map(makeTokenResource) || [],

--- a/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
@@ -75,9 +75,7 @@ export const JoinTokens = () => {
   const [editingToken, setEditingToken] = useState<JoinToken | null>(null);
   const [tokenToDelete, setTokenToDelete] = useState<JoinToken | null>(null);
   const [joinTokensAttempt, runJoinTokensAttempt, setJoinTokensAttempt] =
-    useAsync(async () => {
-      return ctx.joinTokenService.fetchJoinTokens(null);
-    });
+    useAsync(() => ctx.joinTokenService.fetchJoinTokens(null));
 
   const resources = useResources(
     joinTokensAttempt.data?.items.map(makeTokenResource) || [],

--- a/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
@@ -75,7 +75,7 @@ export const JoinTokens = () => {
   const [editingToken, setEditingToken] = useState<JoinToken | null>(null);
   const [tokenToDelete, setTokenToDelete] = useState<JoinToken | null>(null);
   const [joinTokensAttempt, runJoinTokensAttempt, setJoinTokensAttempt] =
-    useAsync(() => ctx.joinTokenService.fetchJoinTokens(null));
+    useAsync(() => ctx.joinTokenService.fetchJoinTokens());
 
   const resources = useResources(
     joinTokensAttempt.data?.items.map(makeTokenResource) || [],

--- a/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
@@ -54,7 +54,6 @@ import {
 } from 'teleport/components/Layout';
 import ResourceEditor from 'teleport/components/ResourceEditor';
 import useResources from 'teleport/components/useResources';
-import { useMfaContext } from 'teleport/MFAContext/MFAContext';
 import { JoinToken } from 'teleport/services/joinToken';
 import { KindJoinToken, Resource } from 'teleport/services/resources';
 
@@ -71,14 +70,13 @@ function makeTokenResource(token: JoinToken): Resource<KindJoinToken> {
 
 export const JoinTokens = () => {
   const ctx = useTeleport();
-  const mfa = useMfaContext();
+
   const [creatingToken, setCreatingToken] = useState(false);
   const [editingToken, setEditingToken] = useState<JoinToken | null>(null);
   const [tokenToDelete, setTokenToDelete] = useState<JoinToken | null>(null);
   const [joinTokensAttempt, runJoinTokensAttempt, setJoinTokensAttempt] =
     useAsync(async () => {
-      const mfaResponse = await mfa.getAdminActionMfaResponse();
-      return ctx.joinTokenService.fetchJoinTokens(null, mfaResponse);
+      return ctx.joinTokenService.fetchJoinTokens(null);
     });
 
   const resources = useResources(

--- a/web/packages/teleport/src/MFAContext/MFAContext.tsx
+++ b/web/packages/teleport/src/MFAContext/MFAContext.tsx
@@ -1,11 +1,18 @@
-import { PropsWithChildren, createContext, useContext } from 'react';
+import {
+  PropsWithChildren,
+  createContext,
+  useCallback,
+  useContext,
+  useRef,
+} from 'react';
 
 import AuthnDialog from 'teleport/components/AuthnDialog';
-import { MfaState, useMfa } from 'teleport/lib/useMfa';
+import { useMfa } from 'teleport/lib/useMfa';
 import { MfaChallengeScope } from 'teleport/services/auth/auth';
+import { MfaChallengeResponse } from 'teleport/services/mfa';
 
 export interface MFAContextValue {
-  adminMfa: MfaState;
+  getAdminActionMfaResponse(reusable?: boolean): Promise<MfaChallengeResponse>;
 }
 
 export const MFAContext = createContext<MFAContextValue>(null);
@@ -15,17 +22,27 @@ export const useMfaContext = () => {
 };
 
 export const MFAContextProvider = ({ children }: PropsWithChildren) => {
+  const allowReuse = useRef(false);
   const adminMfa = useMfa({
     req: {
       scope: MfaChallengeScope.ADMIN_ACTION,
+      allowReuse: allowReuse.current,
       isMfaRequiredRequest: {
         admin_action: {},
       },
     },
   });
 
+  const getAdminActionMfaResponse = useCallback(
+    async (reusable: boolean = false) => {
+      allowReuse.current = reusable;
+      return adminMfa.getChallengeResponse();
+    },
+    [adminMfa, allowReuse]
+  );
+
   return (
-    <MFAContext.Provider value={{ adminMfa }}>
+    <MFAContext.Provider value={{ getAdminActionMfaResponse }}>
       <AuthnDialog {...adminMfa}></AuthnDialog>
       {children}
     </MFAContext.Provider>

--- a/web/packages/teleport/src/MFAContext/MFAContext.tsx
+++ b/web/packages/teleport/src/MFAContext/MFAContext.tsx
@@ -1,18 +1,19 @@
 import { PropsWithChildren, createContext, useCallback, useRef } from 'react';
 import AuthnDialog from 'teleport/components/AuthnDialog';
 import { useMfa } from 'teleport/lib/useMfa';
+import api from 'teleport/services/api';
 import { MfaChallengeScope } from 'teleport/services/auth/auth';
 import { MfaChallengeResponse } from 'teleport/services/mfa';
 
 import { useTeleport } from '..';
 
-export interface MFAContextValue {
+export interface MfaContextValue {
   getAdminActionMfaResponse(reusable?: boolean): Promise<MfaChallengeResponse>;
 }
 
-export const MFAContext = createContext<MFAContextValue>(null);
+export const MfaContext = createContext<MfaContextValue>(null);
 
-export const MFAContextProvider = ({ children }: PropsWithChildren) => {
+export const MfaContextProvider = ({ children }: PropsWithChildren) => {
   const allowReuse = useRef(false);
   const adminMfa = useMfa({
     req: {
@@ -36,11 +37,12 @@ export const MFAContextProvider = ({ children }: PropsWithChildren) => {
 
   const ctx = useTeleport();
   ctx.joinTokenService.setMfaContext(mfaCtx);
+  api.setMfaContext(mfaCtx);
 
   return (
-    <MFAContext.Provider value={mfaCtx}>
+    <MfaContext.Provider value={mfaCtx}>
       <AuthnDialog {...adminMfa}></AuthnDialog>
       {children}
-    </MFAContext.Provider>
+    </MfaContext.Provider>
   );
 };

--- a/web/packages/teleport/src/MFAContext/MFAContext.tsx
+++ b/web/packages/teleport/src/MFAContext/MFAContext.tsx
@@ -38,7 +38,7 @@ export const MfaContextProvider = ({ children }: PropsWithChildren) => {
 
   return (
     <MfaContext.Provider value={mfaCtx}>
-      <AuthnDialog {...adminMfa}></AuthnDialog>
+      <AuthnDialog mfaState={adminMfa}></AuthnDialog>
       {children}
     </MfaContext.Provider>
   );

--- a/web/packages/teleport/src/MFAContext/MFAContext.tsx
+++ b/web/packages/teleport/src/MFAContext/MFAContext.tsx
@@ -1,0 +1,33 @@
+import { PropsWithChildren, createContext, useContext } from 'react';
+
+import AuthnDialog from 'teleport/components/AuthnDialog';
+import { MfaState, useMfa } from 'teleport/lib/useMfa';
+import { MfaChallengeScope } from 'teleport/services/auth/auth';
+
+export interface MFAContextValue {
+  adminMfa: MfaState;
+}
+
+export const MFAContext = createContext<MFAContextValue>(null);
+
+export const useMfaContext = () => {
+  return useContext(MFAContext);
+};
+
+export const MFAContextProvider = ({ children }: PropsWithChildren) => {
+  const adminMfa = useMfa({
+    req: {
+      scope: MfaChallengeScope.ADMIN_ACTION,
+      isMfaRequiredRequest: {
+        admin_action: {},
+      },
+    },
+  });
+
+  return (
+    <MFAContext.Provider value={{ adminMfa }}>
+      <AuthnDialog {...adminMfa}></AuthnDialog>
+      {children}
+    </MFAContext.Provider>
+  );
+};

--- a/web/packages/teleport/src/MFAContext/MFAContext.tsx
+++ b/web/packages/teleport/src/MFAContext/MFAContext.tsx
@@ -1,11 +1,8 @@
 import { PropsWithChildren, createContext, useCallback, useRef } from 'react';
 import AuthnDialog from 'teleport/components/AuthnDialog';
 import { useMfa } from 'teleport/lib/useMfa';
-import api from 'teleport/services/api';
-import { MfaChallengeScope } from 'teleport/services/auth/auth';
+import auth, { MfaChallengeScope } from 'teleport/services/auth/auth';
 import { MfaChallengeResponse } from 'teleport/services/mfa';
-
-import { useTeleport } from '..';
 
 export interface MfaContextValue {
   getAdminActionMfaResponse(reusable?: boolean): Promise<MfaChallengeResponse>;
@@ -33,11 +30,11 @@ export const MfaContextProvider = ({ children }: PropsWithChildren) => {
     [adminMfa, allowReuse]
   );
 
-  const mfaCtx = { getAdminActionMfaResponse };
-
-  const ctx = useTeleport();
-  ctx.joinTokenService.setMfaContext(mfaCtx);
-  api.setMfaContext(mfaCtx);
+  const mfaCtx = {
+    getAdminActionMfaResponse,
+    useMfa,
+  };
+  auth.setMfaContext(mfaCtx);
 
   return (
     <MfaContext.Provider value={mfaCtx}>

--- a/web/packages/teleport/src/MFAContext/MFAContext.tsx
+++ b/web/packages/teleport/src/MFAContext/MFAContext.tsx
@@ -38,14 +38,12 @@ export const MfaContextProvider = ({ children }: PropsWithChildren) => {
     [adminMfa]
   );
 
-  const [mfaCtx, setMfaCtx] = useState<MfaContextValue>();
-
-  if (!mfaCtx) {
+  const [mfaCtx] = useState<MfaContextValue>(() => {
     const mfaCtx = { getMfaChallengeResponse };
-    setMfaCtx(mfaCtx);
     auth.setMfaContext(mfaCtx);
     api.setMfaContext(mfaCtx);
-  }
+    return mfaCtx;
+  });
 
   return (
     <MfaContext.Provider value={mfaCtx}>

--- a/web/packages/teleport/src/MFAContext/MFAContext.tsx
+++ b/web/packages/teleport/src/MFAContext/MFAContext.tsx
@@ -2,6 +2,7 @@ import { createContext, PropsWithChildren, useCallback, useState } from 'react';
 
 import AuthnDialog from 'teleport/components/AuthnDialog';
 import { useMfa } from 'teleport/lib/useMfa';
+import api from 'teleport/services/api/api';
 import { CreateAuthenticateChallengeRequest } from 'teleport/services/auth';
 import auth from 'teleport/services/auth/auth';
 import { MfaChallengeResponse } from 'teleport/services/mfa';
@@ -43,6 +44,7 @@ export const MfaContextProvider = ({ children }: PropsWithChildren) => {
     const mfaCtx = { getMfaChallengeResponse };
     setMfaCtx(mfaCtx);
     auth.setMfaContext(mfaCtx);
+    api.setMfaContext(mfaCtx);
   }
 
   return (

--- a/web/packages/teleport/src/Teleport.tsx
+++ b/web/packages/teleport/src/Teleport.tsx
@@ -38,12 +38,16 @@ import { LoginClose } from './Login/LoginClose';
 import { LoginFailedComponent as LoginFailed } from './Login/LoginFailed';
 import { LoginSuccess } from './Login/LoginSuccess';
 import { LoginTerminalRedirect } from './Login/LoginTerminalRedirect';
-import { Main } from './Main';
-import { Player } from './Player';
 import { SingleLogoutFailed } from './SingleLogoutFailed';
+import { Welcome } from './Welcome';
+
+import { Player } from './Player';
+
+import { MFAContextProvider } from './MFAContext/MFAContext';
+
+import { Main } from './Main';
 import TeleportContext from './teleportContext';
 import TeleportContextProvider from './TeleportContextProvider';
-import { Welcome } from './Welcome';
 
 const Teleport: React.FC<Props> = props => {
   const { ctx, history } = props;
@@ -86,13 +90,15 @@ const Teleport: React.FC<Props> = props => {
                   <Authenticated>
                     <UserContextProvider>
                       <TeleportContextProvider ctx={ctx}>
-                        <Switch>
-                          <Route
-                            path={cfg.routes.appLauncher}
-                            component={AppLauncher}
-                          />
-                          <Route>{createPrivateRoutes()}</Route>
-                        </Switch>
+                        <MFAContextProvider>
+                          <Switch>
+                            <Route
+                              path={cfg.routes.appLauncher}
+                              component={AppLauncher}
+                            />
+                            <Route>{createPrivateRoutes()}</Route>
+                          </Switch>
+                        </MFAContextProvider>
                       </TeleportContextProvider>
                     </UserContextProvider>
                   </Authenticated>

--- a/web/packages/teleport/src/Teleport.tsx
+++ b/web/packages/teleport/src/Teleport.tsx
@@ -43,7 +43,7 @@ import { Welcome } from './Welcome';
 
 import { Player } from './Player';
 
-import { MFAContextProvider } from './MFAContext/MFAContext';
+import { MfaContextProvider } from './MFAContext/MFAContext';
 
 import { Main } from './Main';
 import TeleportContext from './teleportContext';
@@ -90,7 +90,7 @@ const Teleport: React.FC<Props> = props => {
                   <Authenticated>
                     <UserContextProvider>
                       <TeleportContextProvider ctx={ctx}>
-                        <MFAContextProvider>
+                        <MfaContextProvider>
                           <Switch>
                             <Route
                               path={cfg.routes.appLauncher}
@@ -98,7 +98,7 @@ const Teleport: React.FC<Props> = props => {
                             />
                             <Route>{createPrivateRoutes()}</Route>
                           </Switch>
-                        </MFAContextProvider>
+                        </MfaContextProvider>
                       </TeleportContextProvider>
                     </UserContextProvider>
                   </Authenticated>

--- a/web/packages/teleport/src/Teleport.tsx
+++ b/web/packages/teleport/src/Teleport.tsx
@@ -38,16 +38,13 @@ import { LoginClose } from './Login/LoginClose';
 import { LoginFailedComponent as LoginFailed } from './Login/LoginFailed';
 import { LoginSuccess } from './Login/LoginSuccess';
 import { LoginTerminalRedirect } from './Login/LoginTerminalRedirect';
-import { SingleLogoutFailed } from './SingleLogoutFailed';
-import { Welcome } from './Welcome';
-
-import { Player } from './Player';
-
-import { MfaContextProvider } from './MFAContext/MFAContext';
-
 import { Main } from './Main';
+import { MfaContextProvider } from './MFAContext/MFAContext';
+import { Player } from './Player';
+import { SingleLogoutFailed } from './SingleLogoutFailed';
 import TeleportContext from './teleportContext';
 import TeleportContextProvider from './TeleportContextProvider';
+import { Welcome } from './Welcome';
 
 const Teleport: React.FC<Props> = props => {
   const { ctx, history } = props;

--- a/web/packages/teleport/src/Users/useUsers.ts
+++ b/web/packages/teleport/src/Users/useUsers.ts
@@ -89,12 +89,17 @@ export default function useUsers({
 
   async function onCreate(u: User) {
     const mfaResponse = await auth.getAdminActionMfaResponse(true);
-    return ctx.userService
-      .createUser(u, ExcludeUserField.Traits, mfaResponse)
-      .then(result => setUsers([result, ...users]))
-      .then(() =>
-        ctx.userService.createResetPasswordToken(u.name, 'invite', mfaResponse)
-      );
+    const result = await ctx.userService.createUser(
+      u,
+      ExcludeUserField.Traits,
+      mfaResponse
+    );
+    setUsers([result, ...users]);
+    return ctx.userService.createResetPasswordToken(
+      u.name,
+      'invite',
+      mfaResponse
+    );
   }
 
   function onInviteCollaboratorsClose() {

--- a/web/packages/teleport/src/Users/useUsers.ts
+++ b/web/packages/teleport/src/Users/useUsers.ts
@@ -88,7 +88,7 @@ export default function useUsers({
   }
 
   async function onCreate(u: User) {
-    const mfaResponse = await auth.getMfaChallengeResponseForAdminAction(true);
+    const mfaResponse = await auth.getAdminActionMfaResponse(true);
     return ctx.userService
       .createUser(u, ExcludeUserField.Traits, mfaResponse)
       .then(result => setUsers([result, ...users]))

--- a/web/packages/teleport/src/lib/useMfa.test.tsx
+++ b/web/packages/teleport/src/lib/useMfa.test.tsx
@@ -234,9 +234,10 @@ describe('useMfa', () => {
 
     mfa.current.cancelAttempt();
 
-    await expect(respPromise).rejects.toThrow(
-      new Error('User canceled MFA attempt')
+    const expectErr = new Error(
+      'User cancelled MFA attempt. This is an admin-level API request and requires MFA verification. Please try again with a registered MFA device. If you do not have an MFA device registered, you can add one in the account settings page.'
     );
+    await expect(respPromise).rejects.toThrow(expectErr);
 
     // If the user cancels the MFA attempt and closes the dialog, the mfa status
     // should be 'success', or else the dialog would remain open to display the error.

--- a/web/packages/teleport/src/lib/useMfa.ts
+++ b/web/packages/teleport/src/lib/useMfa.ts
@@ -108,7 +108,11 @@ export function useMfa({ req, isMfaRequired }: MfaProps): MfaState {
 
   const cancelAttempt = () => {
     if (mfaResponseRef.current) {
-      mfaResponseRef.current.resolve(new Error('User canceled MFA attempt'));
+      mfaResponseRef.current.resolve(
+        new Error(
+          'User cancelled MFA attempt. This is an admin-level API request and requires MFA verification. Please try again with a registered MFA device. If you do not have an MFA device registered, you can add one in the account settings page.'
+        )
+      );
     }
   };
 

--- a/web/packages/teleport/src/services/api/api.ts
+++ b/web/packages/teleport/src/services/api/api.ts
@@ -28,8 +28,16 @@ import parseError, { ApiError } from './parseError';
 export const MFA_HEADER = 'Teleport-Mfa-Response';
 
 const api = {
-  get(url: string, abortSignal?: AbortSignal) {
-    return api.fetchJsonWithMfaAuthnRetry(url, { signal: abortSignal });
+  get(
+    url: string,
+    abortSignal?: AbortSignal,
+    mfaResponse?: MfaChallengeResponse
+  ) {
+    return api.fetchJsonWithMfaAuthnRetry(
+      url,
+      { signal: abortSignal },
+      mfaResponse
+    );
   },
 
   post(url, data?, abortSignal?, mfaResponse?: MfaChallengeResponse) {

--- a/web/packages/teleport/src/services/api/api.ts
+++ b/web/packages/teleport/src/services/api/api.ts
@@ -21,22 +21,15 @@ import 'whatwg-fetch';
 import websession from 'teleport/services/websession';
 import 'whatwg-fetch';
 
-import { MfaContextValue } from 'teleport/MFAContext/MFAContext';
-
 import { MfaChallengeResponse } from '../mfa';
 import { storageService } from '../storageService';
+import auth from '../auth/auth';
 
 import parseError, { ApiError } from './parseError';
 
 export const MFA_HEADER = 'Teleport-Mfa-Response';
 
-let mfaContext: MfaContextValue;
-
 const api = {
-  setMfaContext(mfa: MfaContextValue) {
-    mfaContext = mfa;
-  },
-
   get(
     url: string,
     abortSignal?: AbortSignal,
@@ -198,7 +191,7 @@ const api = {
 
     let mfaResponseForRetry;
     try {
-      mfaResponseForRetry = await mfaContext.getAdminActionMfaResponse();
+      mfaResponseForRetry = await auth.getAdminActionMfaResponse();
     } catch {
       throw new Error(
         'Failed to fetch MFA challenge. Please connect a registered hardware key and try again. If you do not have a hardware key registered, you can add one from your account settings page.'

--- a/web/packages/teleport/src/services/api/api.ts
+++ b/web/packages/teleport/src/services/api/api.ts
@@ -18,16 +18,25 @@
 
 import 'whatwg-fetch';
 
-import auth, { MfaChallengeScope } from 'teleport/services/auth/auth';
 import websession from 'teleport/services/websession';
+import 'whatwg-fetch';
+
+import { MfaContextValue } from 'teleport/MFAContext/MFAContext';
 
 import { MfaChallengeResponse } from '../mfa';
 import { storageService } from '../storageService';
+
 import parseError, { ApiError } from './parseError';
 
 export const MFA_HEADER = 'Teleport-Mfa-Response';
 
+let mfaContext: MfaContextValue;
+
 const api = {
+  setMfaContext(mfa: MfaContextValue) {
+    mfaContext = mfa;
+  },
+
   get(
     url: string,
     abortSignal?: AbortSignal,
@@ -189,10 +198,7 @@ const api = {
 
     let mfaResponseForRetry;
     try {
-      const challenge = await auth.getMfaChallenge({
-        scope: MfaChallengeScope.ADMIN_ACTION,
-      });
-      mfaResponseForRetry = await auth.getMfaChallengeResponse(challenge);
+      mfaResponseForRetry = await mfaContext.getAdminActionMfaResponse();
     } catch {
       throw new Error(
         'Failed to fetch MFA challenge. Please connect a registered hardware key and try again. If you do not have a hardware key registered, you can add one from your account settings page.'

--- a/web/packages/teleport/src/services/api/api.ts
+++ b/web/packages/teleport/src/services/api/api.ts
@@ -194,14 +194,7 @@ const api = {
       throw new ApiError(parseError(json), response, undefined, json.messages);
     }
 
-    let mfaResponseForRetry;
-    try {
-      mfaResponseForRetry = await api.getAdminActionMfaResponse();
-    } catch {
-      throw new Error(
-        'This is an admin-level API request and requires MFA verification. Please try again with a registered MFA device. If you do not have an MFA device registered, you can add one in the account settings page.'
-      );
-    }
+    const mfaResponseForRetry = await api.getAdminActionMfaResponse();
 
     return api.fetchJsonWithMfaAuthnRetry(
       url,
@@ -217,21 +210,24 @@ const api = {
     // before this has a chance of being called). This conditional is not expected to
     // be hit, but will catch any major issues that could arise from this solution.
     if (!mfaContext) {
-      setTimeout(() => {
-        if (!mfaContext)
-          throw new Error(
-            'Failed to set up MFA prompt for admin action. This is a bug.'
-          );
-      }, 1000);
+      throw new Error(
+        'Failed to set up MFA prompt for admin action. Please try refreshing the page to try again. If the issue persists, contact support as this is likely a bug.'
+      );
     }
 
-    return mfaContext.getMfaChallengeResponse({
-      scope: MfaChallengeScope.ADMIN_ACTION,
-      allowReuse,
-      isMfaRequiredRequest: {
-        admin_action: {},
-      },
-    });
+    try {
+      return mfaContext.getMfaChallengeResponse({
+        scope: MfaChallengeScope.ADMIN_ACTION,
+        allowReuse,
+        isMfaRequiredRequest: {
+          admin_action: {},
+        },
+      });
+    } catch {
+      throw new Error(
+        'This is an admin-level API request and requires MFA verification. Please try again with a registered MFA device. If you do not have an MFA device registered, you can add one in the account settings page.'
+      );
+    }
   },
 
   /**

--- a/web/packages/teleport/src/services/auth/auth.ts
+++ b/web/packages/teleport/src/services/auth/auth.ts
@@ -436,13 +436,13 @@ const auth = {
       .then(res => res?.webauthn_response);
   },
 
-  getAdminActionMfaResponse(allowReuse?: boolean) {
+  async getAdminActionMfaResponse(allowReuse?: boolean) {
     return mfaContext.getAdminActionMfaResponse(allowReuse);
   },
 
   // TODO(Joerger): Delete in favor of getMfaChallengeResponseForAdminAction once /e is updated.
-  getWebauthnResponseForAdminAction(allowReuse?: boolean) {
-    return mfaContext.getAdminActionMfaResponse(allowReuse);
+  async getWebauthnResponseForAdminAction(allowReuse?: boolean) {
+    return auth.getAdminActionMfaResponse(allowReuse);
   },
 };
 

--- a/web/packages/teleport/src/services/auth/auth.ts
+++ b/web/packages/teleport/src/services/auth/auth.ts
@@ -461,7 +461,7 @@ const auth = {
     }
   },
 
-  // TODO(Joerger): Delete in favor of getMfaChallengeResponseForAdminAction once /e is updated.
+  // TODO(Joerger): Delete in favor of getAdminActionMfaResponse once /e is updated.
   getWebauthnResponseForAdminAction(allowReuse?: boolean) {
     return auth.getAdminActionMfaResponse(allowReuse);
   },

--- a/web/packages/teleport/src/services/integrations/integrations.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.ts
@@ -23,7 +23,6 @@ import { App } from '../apps';
 import makeApp from '../apps/makeApps';
 import auth from '../auth/auth';
 import makeNode from '../nodes/makeNode';
-
 import {
   AwsDatabaseVpcsResponse,
   AwsOidcDeployDatabaseServicesRequest,
@@ -272,15 +271,14 @@ export const integrationService = {
     integrationName,
     req: AwsOidcDeployServiceRequest
   ): Promise<string> {
-    const response = await auth.getAdminActionMfaResponse(true);
-    return api
-      .post(
-        cfg.getAwsDeployTeleportServiceUrl(integrationName),
-        req,
-        null,
-        response
-      )
-      .then(resp => resp.serviceDashboardUrl);
+    const mfaResp = await auth.getAdminActionMfaResponse(true);
+    const resp = await api.post(
+      cfg.getAwsDeployTeleportServiceUrl(integrationName),
+      req,
+      null,
+      mfaResp
+    );
+    return resp.serviceDashboardUrl;
   },
 
   async createAwsAppAccess(integrationName): Promise<App> {
@@ -294,14 +292,13 @@ export const integrationService = {
     req: AwsOidcDeployDatabaseServicesRequest
   ): Promise<string> {
     const mfaResponse = await auth.getAdminActionMfaResponse(true);
-    return api
-      .post(
-        cfg.getAwsRdsDbsDeployServicesUrl(integrationName),
-        req,
-        null,
-        mfaResponse
-      )
-      .then(resp => resp.clusterDashboardUrl);
+    const resp = await api.post(
+      cfg.getAwsRdsDbsDeployServicesUrl(integrationName),
+      req,
+      null,
+      mfaResponse
+    );
+    return resp.clusterDashboardUrl;
   },
 
   async enrollEksClusters(

--- a/web/packages/teleport/src/services/integrations/integrations.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.ts
@@ -21,8 +21,9 @@ import api from 'teleport/services/api';
 
 import { App } from '../apps';
 import makeApp from '../apps/makeApps';
-import auth, { MfaChallengeScope } from '../auth/auth';
+import auth from '../auth/auth';
 import makeNode from '../nodes/makeNode';
+
 import {
   AwsDatabaseVpcsResponse,
   AwsOidcDeployDatabaseServicesRequest,
@@ -271,16 +272,7 @@ export const integrationService = {
     integrationName,
     req: AwsOidcDeployServiceRequest
   ): Promise<string> {
-    const challenge = await auth.getMfaChallenge({
-      scope: MfaChallengeScope.ADMIN_ACTION,
-      allowReuse: true,
-      isMfaRequiredRequest: {
-        admin_action: {},
-      },
-    });
-
-    const response = await auth.getMfaChallengeResponse(challenge);
-
+    const response = await auth.getAdminActionMfaResponse(true);
     return api
       .post(
         cfg.getAwsDeployTeleportServiceUrl(integrationName),
@@ -301,8 +293,7 @@ export const integrationService = {
     integrationName,
     req: AwsOidcDeployDatabaseServicesRequest
   ): Promise<string> {
-    const mfaResponse = await auth.getMfaChallengeResponseForAdminAction(true);
-
+    const mfaResponse = await auth.getAdminActionMfaResponse(true);
     return api
       .post(
         cfg.getAwsRdsDbsDeployServicesUrl(integrationName),
@@ -317,7 +308,7 @@ export const integrationService = {
     integrationName: string,
     req: EnrollEksClustersRequest
   ): Promise<EnrollEksClustersResponse> {
-    const mfaResponse = await auth.getMfaChallengeResponseForAdminAction(true);
+    const mfaResponse = await auth.getAdminActionMfaResponse(true);
 
     return api.post(
       cfg.getEnrollEksClusterUrl(integrationName),

--- a/web/packages/teleport/src/services/joinToken/joinToken.test.ts
+++ b/web/packages/teleport/src/services/joinToken/joinToken.test.ts
@@ -20,9 +20,9 @@ import cfg from 'teleport/config';
 import api from 'teleport/services/api';
 
 import auth from '../auth/auth';
-
 import JoinTokenService from './joinToken';
 import type { JoinTokenRequest } from './types';
+
 test('fetchJoinToken with an empty request properly sets defaults', async () => {
   const svc = new JoinTokenService();
   jest.spyOn(api, 'post').mockResolvedValue(null);

--- a/web/packages/teleport/src/services/joinToken/joinToken.test.ts
+++ b/web/packages/teleport/src/services/joinToken/joinToken.test.ts
@@ -19,15 +19,17 @@
 import cfg from 'teleport/config';
 import api from 'teleport/services/api';
 
+import auth from '../auth/auth';
+
 import JoinTokenService from './joinToken';
 import type { JoinTokenRequest } from './types';
-
-test('fetchJoinToken with an empty request properly sets defaults', () => {
+test('fetchJoinToken with an empty request properly sets defaults', async () => {
   const svc = new JoinTokenService();
   jest.spyOn(api, 'post').mockResolvedValue(null);
+  jest.spyOn(auth, 'getAdminActionMfaResponse').mockResolvedValue(null);
 
   // Test with all empty fields.
-  svc.fetchJoinToken({} as any);
+  await svc.fetchJoinToken({} as any);
   expect(api.post).toHaveBeenCalledWith(
     cfg.getJoinTokenUrl(),
     {
@@ -36,13 +38,15 @@ test('fetchJoinToken with an empty request properly sets defaults', () => {
       allow: [],
       suggested_agent_matcher_labels: {},
     },
+    null,
     null
   );
 });
 
-test('fetchJoinToken request fields are set as requested', () => {
+test('fetchJoinToken request fields are set as requested', async () => {
   const svc = new JoinTokenService();
   jest.spyOn(api, 'post').mockResolvedValue(null);
+  jest.spyOn(auth, 'getAdminActionMfaResponse').mockResolvedValue(null);
 
   const mock: JoinTokenRequest = {
     roles: ['Node'],
@@ -50,7 +54,8 @@ test('fetchJoinToken request fields are set as requested', () => {
     method: 'iam',
     suggestedAgentMatcherLabels: [{ name: 'env', value: 'dev' }],
   };
-  svc.fetchJoinToken(mock);
+  await svc.fetchJoinToken(mock);
+
   expect(api.post).toHaveBeenCalledWith(
     cfg.getJoinTokenUrl(),
     {
@@ -59,6 +64,7 @@ test('fetchJoinToken request fields are set as requested', () => {
       allow: [{ aws_account: '1234', aws_arn: 'xxxx' }],
       suggested_agent_matcher_labels: { env: ['dev'] },
     },
+    null,
     null
   );
 });

--- a/web/packages/teleport/src/services/joinToken/joinToken.ts
+++ b/web/packages/teleport/src/services/joinToken/joinToken.ts
@@ -17,7 +17,7 @@
  */
 
 import cfg from 'teleport/config';
-import { MFAContextValue } from 'teleport/MFAContext/MFAContext';
+import { MfaContextValue } from 'teleport/MFAContext/MFAContext';
 import api from 'teleport/services/api';
 
 import { makeLabelMapOfStrArrs } from '../agents/make';
@@ -29,8 +29,8 @@ const TeleportTokenNameHeader = 'X-Teleport-TokenName';
 
 class JoinTokenService {
   // MFA context is set late by the MFA Context provider.
-  mfa: MFAContextValue;
-  setMfaContext(mfa: MFAContextValue) {
+  mfa: MfaContextValue;
+  setMfaContext(mfa: MfaContextValue) {
     this.mfa = mfa;
   }
 

--- a/web/packages/teleport/src/services/joinToken/joinToken.ts
+++ b/web/packages/teleport/src/services/joinToken/joinToken.ts
@@ -33,21 +33,20 @@ class JoinTokenService {
     signal: AbortSignal = null
   ): Promise<JoinToken> {
     const mfaResponse = await auth.getAdminActionMfaResponse();
-    return api
-      .post(
-        cfg.getJoinTokenUrl(),
-        {
-          roles: req.roles,
-          join_method: req.method || 'token',
-          allow: makeAllowField(req.rules || []),
-          suggested_agent_matcher_labels: makeLabelMapOfStrArrs(
-            req.suggestedAgentMatcherLabels
-          ),
-        },
-        signal,
-        mfaResponse
-      )
-      .then(makeJoinToken);
+    const resp = await api.post(
+      cfg.getJoinTokenUrl(),
+      {
+        roles: req.roles,
+        join_method: req.method || 'token',
+        allow: makeAllowField(req.rules || []),
+        suggested_agent_matcher_labels: makeLabelMapOfStrArrs(
+          req.suggestedAgentMatcherLabels
+        ),
+      },
+      signal,
+      mfaResponse
+    );
+    return makeJoinToken(resp);
   }
 
   async upsertJoinTokenYAML(
@@ -55,26 +54,24 @@ class JoinTokenService {
     tokenName: string
   ): Promise<JoinToken> {
     const mfaResponse = await auth.getAdminActionMfaResponse();
-    return api
-      .putWithHeaders(
-        cfg.getJoinTokenYamlUrl(),
-        {
-          content: req.content,
-        },
-        {
-          [TeleportTokenNameHeader]: tokenName,
-          'Content-Type': 'application/json',
-        },
-        mfaResponse
-      )
-      .then(makeJoinToken);
+    const resp = await api.putWithHeaders(
+      cfg.getJoinTokenYamlUrl(),
+      {
+        content: req.content,
+      },
+      {
+        [TeleportTokenNameHeader]: tokenName,
+        'Content-Type': 'application/json',
+      },
+      mfaResponse
+    );
+    return makeJoinToken(resp);
   }
 
   async createJoinToken(req: JoinTokenRequest): Promise<JoinToken> {
     const mfaResponse = await auth.getAdminActionMfaResponse();
-    return api
-      .post(cfg.getJoinTokensUrl(), req, mfaResponse)
-      .then(makeJoinToken);
+    const resp = api.post(cfg.getJoinTokensUrl(), req, mfaResponse);
+    return makeJoinToken(resp);
   }
 
   async fetchJoinTokens(

--- a/web/packages/teleport/src/services/joinToken/joinToken.ts
+++ b/web/packages/teleport/src/services/joinToken/joinToken.ts
@@ -20,6 +20,8 @@ import cfg from 'teleport/config';
 import api from 'teleport/services/api';
 
 import { makeLabelMapOfStrArrs } from '../agents/make';
+import { MfaChallengeResponse } from '../mfa';
+
 import makeJoinToken from './makeJoinToken';
 import { JoinRule, JoinToken, JoinTokenRequest } from './types';
 
@@ -69,8 +71,11 @@ class JoinTokenService {
     return api.post(cfg.getJoinTokensUrl(), req).then(makeJoinToken);
   }
 
-  fetchJoinTokens(signal: AbortSignal = null): Promise<{ items: JoinToken[] }> {
-    return api.get(cfg.getJoinTokensUrl(), signal).then(resp => {
+  fetchJoinTokens(
+    signal: AbortSignal = null,
+    mfaResponse?: MfaChallengeResponse
+  ): Promise<{ items: JoinToken[] }> {
+    return api.get(cfg.getJoinTokensUrl(), signal, mfaResponse).then(resp => {
       return {
         items: resp.items?.map(makeJoinToken) || [],
       };

--- a/web/packages/teleport/src/services/joinToken/joinToken.ts
+++ b/web/packages/teleport/src/services/joinToken/joinToken.ts
@@ -21,7 +21,6 @@ import api from 'teleport/services/api';
 
 import { makeLabelMapOfStrArrs } from '../agents/make';
 import auth from '../auth/auth';
-
 import makeJoinToken from './makeJoinToken';
 import { JoinRule, JoinToken, JoinTokenRequest } from './types';
 


### PR DESCRIPTION
Changelog: Add MFA dialog in the WebUI for Admin actions instead of automatically opening up a webauthn/sso pop up.

Adds a global MFA context for prompting MFA from non-react contexts. Currently this is only used for admin actions, which prompts for MFA from basic API requests.

Depends on https://github.com/gravitational/teleport/pull/49794