### PR TITLE
Show kube cluster name at the beginning of kube tabs

### DIFF
--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
@@ -425,7 +425,7 @@ export class DocumentsService {
     if (doc.kind === 'doc.gateway_kube') {
       const { params } = routing.parseKubeUri(doc.targetUri);
       this.update(doc.uri, {
-        title: [shellBinName, cwd, params.kubeId].filter(Boolean).join(' · '),
+        title: [params.kubeId, shellBinName].filter(Boolean).join(' · '),
       });
     }
   }


### PR DESCRIPTION
A few months ago, [we added a possibility](https://github.com/gravitational/teleport/pull/45152) to change the shell in local tabs. During that work, we also unified `doc.terminal_shell` and `doc.gateway_kube` tab names, making them show cwd, shell, and then resource name. 
It turns out that this was not a good change for kube sessions, as we show the most important information at the very end, making it invisible when there are more tabs.
I could only change the order, but after a short discussion with @lcharkiewicz, I decided to completely remove cwd, as it is often truncated, which doesn't make it useful. Moreover, cwd doesn't seem to be essential information for kube sessions, so we can avoid cluttering the tab name.

changelog: Reverted a change that caused the Kubernetes cluster name to be displayed at the end of the tab title in Teleport Connect