### PR TITLE
Add info about MFA methods to user reset modal

### DIFF
--- a/web/packages/teleport/src/Users/UserReset/UserReset.story.tsx
+++ b/web/packages/teleport/src/Users/UserReset/UserReset.story.tsx
@@ -17,11 +17,18 @@
  */
 
 import { Meta } from '@storybook/react';
-import { UserReset } from './UserReset';
+
 import { Attempt } from 'shared/hooks/useAttemptNext';
+import { useEffect, useState } from 'react';
+
+import cfg from 'teleport/config';
+
+import { UserReset } from './UserReset';
 
 type StoryProps = {
   status: 'processing' | 'success' | 'error';
+  isMfaEnabled: boolean;
+  allowPasswordless: boolean;
 };
 
 const meta: Meta<StoryProps> = {
@@ -35,6 +42,8 @@ const meta: Meta<StoryProps> = {
   },
   args: {
     status: 'processing',
+    isMfaEnabled: true,
+    allowPasswordless: true,
   },
 };
 
@@ -46,6 +55,18 @@ export function Story(props: StoryProps) {
     success: { status: 'success' },
     error: { status: 'failed', statusText: 'some server error' },
   };
+  const [, setState] = useState({});
+
+  useEffect(() => {
+    const defaultAuth = structuredClone(cfg.auth);
+    cfg.auth.second_factor = props.isMfaEnabled ? 'on' : 'off';
+    cfg.auth.allowPasswordless = props.allowPasswordless;
+    setState({}); // Force re-render of the component with new cfg.
+
+    return () => {
+      cfg.auth = defaultAuth;
+    };
+  }, [props.isMfaEnabled, props.allowPasswordless]);
 
   return (
     <UserReset

--- a/web/packages/teleport/src/Users/UserReset/UserReset.story.tsx
+++ b/web/packages/teleport/src/Users/UserReset/UserReset.story.tsx
@@ -16,40 +16,48 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { Meta } from '@storybook/react';
 import { UserReset } from './UserReset';
+import { Attempt } from 'shared/hooks/useAttemptNext';
 
-export default {
+type StoryProps = {
+  status: 'processing' | 'success' | 'error';
+};
+
+const meta: Meta<StoryProps> = {
   title: 'Teleport/Users/UserReset',
+  component: Story,
+  argTypes: {
+    status: {
+      control: { type: 'radio' },
+      options: ['processing', 'success', 'error'],
+    },
+  },
+  args: {
+    status: 'processing',
+  },
 };
 
-export const Processing = () => {
-  return <UserReset {...props} attempt={{ status: 'processing' }} />;
-};
+export default meta;
 
-export const Success = () => {
-  return <UserReset {...props} attempt={{ status: 'success' }} />;
-};
+export function Story(props: StoryProps) {
+  const statusToAttempt: Record<StoryProps['status'], Attempt> = {
+    processing: { status: 'processing' },
+    success: { status: 'success' },
+    error: { status: 'failed', statusText: 'some server error' },
+  };
 
-export const Failed = () => {
   return (
     <UserReset
-      {...props}
-      attempt={{ status: 'failed', statusText: 'some server error' }}
+      username="smith"
+      token={{
+        value: '0c536179038b386728dfee6602ca297f',
+        expires: new Date('2021-04-08T07:30:00Z'),
+        username: 'Lester',
+      }}
+      onReset={() => {}}
+      onClose={() => {}}
+      attempt={statusToAttempt[props.status]}
     />
   );
-};
-
-const props = {
-  username: 'smith',
-  token: {
-    value: '0c536179038b386728dfee6602ca297f',
-    expires: new Date('2021-04-08T07:30:00Z'),
-    username: 'Lester',
-  },
-  onReset() {},
-  onClose() {},
-  attempt: {
-    status: 'processing',
-    statusText: '',
-  },
-};
+}

--- a/web/packages/teleport/src/Users/UserReset/UserReset.tsx
+++ b/web/packages/teleport/src/Users/UserReset/UserReset.tsx
@@ -17,7 +17,7 @@
  */
 
 import { useState } from 'react';
-import { ButtonPrimary, ButtonSecondary, Text, Alert } from 'design';
+import { ButtonPrimary, ButtonSecondary, Text, Alert, P2 } from 'design';
 import Dialog, {
   DialogHeader,
   DialogTitle,
@@ -26,6 +26,7 @@ import Dialog, {
 } from 'design/Dialog';
 import { useAttemptNext } from 'shared/hooks';
 
+import cfg from 'teleport/config';
 import { ResetToken } from 'teleport/services/user';
 
 import UserTokenLink from './../UserTokenLink';
@@ -58,16 +59,31 @@ export function UserReset({
       </DialogHeader>
       <DialogContent>
         {attempt.status === 'failed' && (
-          <Alert kind="danger" children={attempt.statusText} />
+          <Alert kind="danger">{attempt.statusText}</Alert>
         )}
-        <Text mb={4} mt={1}>
-          You are about to reset authentication for user
-          <Text bold as="span">
-            {` ${username} `}
+        <P2>
+          You are about to reset authentication for user{' '}
+          <Text bold as="strong">
+            {username}
           </Text>
-          . This will generate a temporary URL which can be used to set up new
-          authentication.
-        </Text>
+          . This will generate a&nbsp;temporary URL which can be used to set up
+          new authentication.
+        </P2>
+        {cfg.isMfaEnabled() && (
+          <P2>
+            All{' '}
+            {cfg.isPasswordlessEnabled()
+              ? 'passkeys and MFA methods'
+              : 'MFA methods'}{' '}
+            of this user will be removed. The user will be able to set up{' '}
+            {cfg.isPasswordlessEnabled() ? (
+              <>a&nbsp;new passkey or an MFA method</>
+            ) : (
+              <>a&nbsp;new method</>
+            )}{' '}
+            after following the URL.
+          </P2>
+        )}
       </DialogContent>
       <DialogFooter>
         <ButtonPrimary
@@ -75,7 +91,7 @@ export function UserReset({
           disabled={attempt.status === 'processing'}
           onClick={onReset}
         >
-          Generate reset url
+          Generate Reset URL
         </ButtonPrimary>
         <ButtonSecondary onClick={onClose}>Cancel</ButtonSecondary>
       </DialogFooter>


### PR DESCRIPTION
Neither the docs nor the UI mention what happens with passkeys and MFA methods when you reset auth for a user. This PR adds that information and takes into account whether MFA and passwordless are enabled in the cluster.

| Before | After |
| --- | --- |
| <img width="614" alt="before" src="https://github.com/user-attachments/assets/384a9ff5-97c2-4ec0-9dd0-600d0f6d06ae" /> | <img width="614" alt="after" src="https://github.com/user-attachments/assets/50de26f4-05d5-4c54-8cf7-cacf188eacf4" /> |
