### PR TITLE
Disallow parallel `setActiveWorkspace` calls

### DIFF
--- a/web/packages/build/jest/jest-environment-patched-jsdom.js
+++ b/web/packages/build/jest/jest-environment-patched-jsdom.js
@@ -59,6 +59,13 @@ export default class PatchedJSDOMEnvironment extends JSDOMEnvironment {
     if (!global.TransformStream) {
       global.TransformStream = TransformStream;
     }
+    // TODO(gzdunek): JSDOM doesn't support AbortSignal.any().
+    // Overwriting only this function doesn't help much, something between
+    // AbortSignal and AbortController is missing.
+    if (!global.AbortSignal.any) {
+      global.AbortSignal = AbortSignal;
+      global.AbortController = AbortController;
+    }
   }
 }
 export const TestEnvironment = PatchedJSDOMEnvironment;

--- a/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.tsx
@@ -40,22 +40,21 @@ export default function ModalsHost() {
   const { regular: regularDialog, important: importantDialogs } =
     modalsService.useState();
 
-  const closeRegularDialog = () => modalsService.closeRegularDialog();
-
   return (
     <>
-      {renderDialog({
-        dialog: regularDialog,
-        handleClose: closeRegularDialog,
-        hidden: !!importantDialogs.length,
-      })}
-      {importantDialogs.map(({ dialog, id }, index) => {
+      {regularDialog &&
+        renderDialog({
+          dialog: regularDialog.dialog,
+          handleClose: regularDialog.close,
+          hidden: !!importantDialogs.length,
+        })}
+      {importantDialogs.map(({ dialog, id, close }, index) => {
         const isLast = index === importantDialogs.length - 1;
         return (
           <Fragment key={id}>
             {renderDialog({
               dialog: dialog,
-              handleClose: () => modalsService.closeImportantDialog(id),
+              handleClose: close,
               hidden: !isLast,
             })}
           </Fragment>

--- a/web/packages/teleterm/src/ui/services/deepLinks/deepLinksService.ts
+++ b/web/packages/teleterm/src/ui/services/deepLinks/deepLinksService.ts
@@ -74,6 +74,14 @@ export class DeepLinksService {
       return;
     }
 
+    // Before we start, let's close any open dialogs, for a few reasons:
+    // 1. Activating a deep link may require changing the workspace, and we don't
+    // want to see dialogs from the previous one.
+    // 2. A login dialog could be covered by an important dialog.
+    // 3. The user could be confused, since Connect My Computer or Authorize Web
+    // Session documents would be displayed below a dialog.
+    this.modalsService.cancelAndCloseAll();
+
     // launchDeepLink cannot throw if it receives a pathname that doesn't match any supported
     // pathnames. The user might simply be using a version of Connect that doesn't support the given
     // pathname yet. Generally, such cases should be caught outside of DeepLinksService by

--- a/web/packages/teleterm/src/ui/services/modals/modalsService.test.ts
+++ b/web/packages/teleterm/src/ui/services/modals/modalsService.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
+
+import { ModalsService, DialogClusterConnect } from './modalsService';
+
+const rootCluster = makeRootCluster();
+
+function makeDialogClusterConnect(): DialogClusterConnect {
+  return {
+    kind: 'cluster-connect',
+    clusterUri: rootCluster.uri,
+    reason: undefined,
+    prefill: undefined,
+    onSuccess: jest.fn(),
+    onCancel: jest.fn(),
+  };
+}
+
+test('closing all dialogs', () => {
+  const dialogClusterConnect1 = makeDialogClusterConnect();
+  const dialogClusterConnect2 = makeDialogClusterConnect();
+  const modalsService = new ModalsService();
+
+  modalsService.openRegularDialog(dialogClusterConnect1);
+  modalsService.openImportantDialog(dialogClusterConnect2);
+  expect(modalsService.state.regular).toStrictEqual(dialogClusterConnect1);
+  expect(modalsService.state.important).toHaveLength(1);
+  expect(modalsService.state.important[0].dialog).toStrictEqual(
+    dialogClusterConnect2
+  );
+
+  modalsService.cancelAndCloseAll();
+  expect(modalsService.state.regular).toStrictEqual(undefined);
+  expect(modalsService.state.important).toHaveLength(0);
+  expect(dialogClusterConnect1.onCancel).toHaveBeenCalledTimes(1);
+  expect(dialogClusterConnect2.onCancel).toHaveBeenCalledTimes(1);
+});
+
+test('closing regular dialog with abort signal', () => {
+  const dialogClusterConnect = makeDialogClusterConnect();
+  const modalsService = new ModalsService();
+  const controller = new AbortController();
+
+  modalsService.openRegularDialog(dialogClusterConnect, controller.signal);
+  expect(modalsService.state.regular).toStrictEqual(dialogClusterConnect);
+  controller.abort();
+  expect(modalsService.state.regular).toStrictEqual(undefined);
+  expect(dialogClusterConnect.onCancel).toHaveBeenCalledTimes(1);
+});
+
+test('closing important dialog with abort signal', () => {
+  const dialogClusterConnect1 = makeDialogClusterConnect();
+  const dialogClusterConnect2 = makeDialogClusterConnect();
+  const modalsService = new ModalsService();
+  const controller1 = new AbortController();
+  const controller2 = new AbortController();
+
+  modalsService.openImportantDialog(dialogClusterConnect1, controller1.signal);
+  modalsService.openImportantDialog(dialogClusterConnect2, controller2.signal);
+  expect(modalsService.state.important).toHaveLength(2);
+  expect(modalsService.state.important[0].dialog).toStrictEqual(
+    dialogClusterConnect1
+  );
+  expect(modalsService.state.important[1].dialog).toStrictEqual(
+    dialogClusterConnect2
+  );
+
+  controller1.abort();
+  expect(modalsService.state.important).toHaveLength(1);
+  expect(modalsService.state.important[0].dialog).toStrictEqual(
+    dialogClusterConnect2
+  );
+  expect(dialogClusterConnect1.onCancel).toHaveBeenCalledTimes(1);
+
+  controller2.abort();
+  expect(modalsService.state.important).toHaveLength(0);
+  expect(dialogClusterConnect2.onCancel).toHaveBeenCalledTimes(1);
+});
+
+test('dialogs opened with aborted signal return immediately', () => {
+  const dialogClusterConnect = makeDialogClusterConnect();
+  const modalsService = new ModalsService();
+  const controller = new AbortController();
+  controller.abort();
+
+  modalsService.openRegularDialog(dialogClusterConnect, controller.signal);
+  expect(modalsService.state.regular).toStrictEqual(undefined);
+  expect(dialogClusterConnect.onCancel).toHaveBeenCalledTimes(1);
+
+  modalsService.openImportantDialog(dialogClusterConnect, controller.signal);
+  expect(modalsService.state.important).toHaveLength(0);
+  expect(dialogClusterConnect.onCancel).toHaveBeenCalledTimes(2);
+});

--- a/web/packages/teleterm/src/ui/services/modals/modalsService.ts
+++ b/web/packages/teleterm/src/ui/services/modals/modalsService.ts
@@ -20,11 +20,12 @@ import { useStore } from 'shared/libs/stores';
 import * as tshdEventsApi from 'gen-proto-ts/teleport/lib/teleterm/v1/tshd_events_service_pb';
 
 import * as types from 'teleterm/services/tshd/types';
-import type * as uri from 'teleterm/ui/uri';
 import { RootClusterUri } from 'teleterm/ui/uri';
 import { ResourceSearchError } from 'teleterm/ui/services/resources';
 
 import { ImmutableStore } from '../immutableStore';
+
+import type * as uri from 'teleterm/ui/uri';
 
 type State = {
   // One regular dialog and multiple important dialogs can be rendered at the same time.

--- a/web/packages/teleterm/src/ui/services/modals/modalsService.ts
+++ b/web/packages/teleterm/src/ui/services/modals/modalsService.ts
@@ -136,26 +136,18 @@ export class ModalsService extends ImmutableStore<State> {
    */
   openImportantDialog(dialog: Dialog): { closeDialog: () => void; id: string } {
     const onCancelDialog = () => dialog['onCancel']?.();
-    const sharedSignal = this.allDialogsController.signal;
-
+    const allDialogsSignal = this.allDialogsController.signal;
     const id = crypto.randomUUID();
-    if (sharedSignal.aborted) {
-      onCancelDialog();
-      return {
-        id,
-        closeDialog: () => {},
-      };
-    }
 
     const close = () => {
-      sharedSignal.removeEventListener('abort', cancelAndClose);
+      allDialogsSignal.removeEventListener('abort', cancelAndClose);
       this.closeImportantDialog(id);
     };
     const cancelAndClose = () => {
       close();
       onCancelDialog();
     };
-    sharedSignal.addEventListener('abort', cancelAndClose);
+    allDialogsSignal.addEventListener('abort', cancelAndClose);
     this.setState(draftState => {
       draftState.important.push({ dialog, id, close });
     });

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
@@ -122,6 +122,11 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
    * When a workspace is removed, it's removed from the restored state too.
    */
   private restoredState?: Immutable<WorkspacesPersistedState>;
+  /**
+   * Ensures `setActiveWorkspace` calls are not executed in parallel.
+   * An ongoing call is canceled when a new one is initiated.
+   */
+  private setActiveWorkspaceAbortController = new AbortController();
 
   constructor(
     private modalsService: ModalsService,
@@ -277,6 +282,7 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
    * If the root cluster doesn't have a workspace yet, setActiveWorkspace creates a default
    * workspace state for the cluster and then asks the user about restoring documents from the
    * previous session if there are any.
+   * Only one call can be executed at a time. Any ongoing call is canceled when a new one is initiated.
    *
    * setActiveWorkspace never returns a rejected promise on its own.
    */
@@ -303,6 +309,10 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
      */
     isAtDesiredWorkspace: boolean;
   }> {
+    this.setActiveWorkspaceAbortController.abort();
+    this.setActiveWorkspaceAbortController = new AbortController();
+    const abortSignal = this.setActiveWorkspaceAbortController.signal;
+
     if (!clusterUri) {
       this.setState(draftState => {
         draftState.rootClusterUri = undefined;
@@ -323,7 +333,7 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
     }
 
     if (cluster.profileStatusError) {
-      await this.clustersService.syncRootClustersAndCatchErrors();
+      await this.clustersService.syncRootClustersAndCatchErrors(abortSignal);
       // Update the cluster.
       cluster = this.clustersService.findCluster(clusterUri);
       // If the problem persists (because, for example, the user still hasn't
@@ -346,14 +356,17 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
 
     if (!cluster.connected) {
       const connected = await new Promise<boolean>(resolve =>
-        this.modalsService.openRegularDialog({
-          kind: 'cluster-connect',
-          clusterUri,
-          reason: undefined,
-          prefill,
-          onCancel: () => resolve(false),
-          onSuccess: () => resolve(true),
-        })
+        this.modalsService.openRegularDialog(
+          {
+            kind: 'cluster-connect',
+            clusterUri,
+            reason: undefined,
+            prefill,
+            onCancel: () => resolve(false),
+            onSuccess: () => resolve(true),
+          },
+          abortSignal
+        )
       );
       if (!connected) {
         return { isAtDesiredWorkspace: false };
@@ -385,14 +398,17 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
     const documentsReopen = await new Promise<
       'confirmed' | 'discarded' | 'canceled'
     >(resolve =>
-      this.modalsService.openRegularDialog({
-        kind: 'documents-reopen',
-        rootClusterUri: clusterUri,
-        numberOfDocuments: restoredWorkspace.documents.length,
-        onConfirm: () => resolve('confirmed'),
-        onDiscard: () => resolve('discarded'),
-        onCancel: () => resolve('canceled'),
-      })
+      this.modalsService.openRegularDialog(
+        {
+          kind: 'documents-reopen',
+          rootClusterUri: clusterUri,
+          numberOfDocuments: restoredWorkspace.documents.length,
+          onConfirm: () => resolve('confirmed'),
+          onDiscard: () => resolve('discarded'),
+          onCancel: () => resolve('canceled'),
+        },
+        abortSignal
+      )
     );
     switch (documentsReopen) {
       case 'confirmed':


### PR DESCRIPTION
(part of https://github.com/gravitational/teleport/pull/50063)

This PR implements two things:
* allowing only one execution of `setActiveWorkspace` at a time (a new call cancels the previous one),
* closing all dialogs when launching a deep link.

We allow only one `setActiveWorkspace` at a time because it's called from different contexts and needs safeguards to prevent invalid states. For example, if a user logs into workspace `foo` but doesn't reopen documents, then launches a deep link to workspace `bar` (where they're already logged in), they would be switched to `bar` immediately, but the dialog from the previous `setActiveWorkspace` call would still be visible.

Later I realized that problem is not only about dialogs opened by `setActiveWorkspace`. When launching a deep link, we should close all of them upfront, since they can conflict with the new content. 

These two functionalities are overlapping a bit, since if you close all dialogs, it will also close the ones in `setActiveWorkspace`. However, all the dialogs are closed only when launching a deep link, so having a separate safeguard in `setActiveWorkspace` is probably still reasonable. 

I opened this as a separate PR to make it easier to review.