### PR TITLE
Relax `validServerHostname` to accept `--` or `..`

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1529,7 +1529,7 @@ func (a *Server) runPeriodicOperations() {
 								}
 
 								// If the hostname has been replaced by a sanitized version, revert it back to the original
-								// if the original is valid under the new rules.
+								// if the original is valid under the most recent rules.
 								if oldHostname, ok := srv.GetLabel(replacedHostnameLabel); ok && validServerHostname(oldHostname) {
 									switch s := srv.(type) {
 									case *types.ServerV2:

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -5664,7 +5664,7 @@ func (a *Server) KeepAliveServer(ctx context.Context, h types.KeepAlive) error {
 
 const (
 	serverHostnameMaxLen       = 256
-	serverHostnameRegexPattern = `^[a-zA-Z0-9]?[a-zA-Z0-9\.-]*$`
+	serverHostnameRegexPattern = `^[a-zA-Z0-9]+[a-zA-Z0-9\.-]*$`
 	replacedHostnameLabel      = types.TeleportInternalLabelPrefix + "invalid-hostname"
 )
 

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1508,12 +1508,11 @@ func (a *Server) runPeriodicOperations() {
 									heartbeatsMissedByAuth.Inc()
 								}
 
+								if srv.GetSubKind() != types.SubKindOpenSSHNode {
+									return false, nil
+								}
 								// TODO(tross) DELETE in v20.0.0 - all invalid hostnames should have been sanitized by then.
 								if !validServerHostname(srv.GetHostname()) {
-									if srv.GetSubKind() != types.SubKindOpenSSHNode {
-										return false, nil
-									}
-
 									logger := a.logger.With("server", srv.GetName(), "hostname", srv.GetHostname())
 
 									logger.DebugContext(a.closeCtx, "sanitizing invalid static SSH server hostname")
@@ -1526,6 +1525,21 @@ func (a *Server) runPeriodicOperations() {
 
 									if _, err := a.Services.UpdateNode(a.closeCtx, srv); err != nil && !trace.IsCompareFailed(err) {
 										logger.WarnContext(a.closeCtx, "failed to update SSH server hostname", "error", err)
+									}
+								}
+
+								// If the hostname has been replaced by a sanitized version, revert it back to the original
+								// if the original is valid under the new rules.
+								if oldHostname, ok := srv.GetLabel(replacedHostnameLabel); ok && validServerHostname(oldHostname) {
+									switch s := srv.(type) {
+									case *types.ServerV2:
+										s.Spec.Hostname = oldHostname
+										delete(s.Metadata.Labels, replacedHostnameLabel)
+									default:
+										return false, trace.BadParameter("invalid server provided")
+									}
+									if _, err := a.Services.UpdateNode(a.closeCtx, srv); err != nil && !trace.IsCompareFailed(err) {
+										log.Warnf("Failed to update node hostname: %v", err)
 									}
 								}
 

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -5650,7 +5650,7 @@ func (a *Server) KeepAliveServer(ctx context.Context, h types.KeepAlive) error {
 
 const (
 	serverHostnameMaxLen       = 256
-	serverHostnameRegexPattern = `^[a-zA-Z0-9]([\.-]?[a-zA-Z0-9]+)*$`
+	serverHostnameRegexPattern = `^[a-zA-Z0-9]?[a-zA-Z0-9\.-]*$`
 	replacedHostnameLabel      = types.TeleportInternalLabelPrefix + "invalid-hostname"
 )
 
@@ -5658,7 +5658,7 @@ var serverHostnameRegex = regexp.MustCompile(serverHostnameRegexPattern)
 
 // validServerHostname returns false if the hostname is longer than 256 characters or
 // does not entirely consist of alphanumeric characters as well as '-' and '.'. A valid hostname also
-// cannot begin with a symbol, and a symbol cannot be followed immediately by another symbol.
+// cannot begin with a symbol.
 func validServerHostname(hostname string) bool {
 	return len(hostname) <= serverHostnameMaxLen && serverHostnameRegex.MatchString(hostname)
 }

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -4479,6 +4479,10 @@ func TestServerHostnameSanitization(t *testing.T) {
 			hostname: uuid.NewString() + ".example.com",
 		},
 		{
+			name:     "valid dns hostname with multi-dots",
+			hostname: "llama..example.com",
+		},
+		{
 			name:            "empty hostname",
 			hostname:        "",
 			invalidHostname: true,
@@ -4486,11 +4490,6 @@ func TestServerHostnameSanitization(t *testing.T) {
 		{
 			name:            "exceptionally long hostname",
 			hostname:        strings.Repeat("a", serverHostnameMaxLen*2),
-			invalidHostname: true,
-		},
-		{
-			name:            "invalid dns hostname",
-			hostname:        "llama..example.com",
 			invalidHostname: true,
 		},
 		{
@@ -4617,6 +4616,11 @@ func TestValidServerHostname(t *testing.T) {
 		{
 			name:     "hostname with ;",
 			hostname: "llama;example.com",
+			want:     false,
+		},
+		{
+			name:     "empty hostname",
+			hostname: "",
 			want:     false,
 		},
 	}

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -4563,6 +4563,7 @@ func TestServerHostnameSanitization(t *testing.T) {
 }
 
 func TestValidServerHostname(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		hostname string

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -4562,3 +4562,68 @@ func TestServerHostnameSanitization(t *testing.T) {
 		})
 	}
 }
+
+func TestValidServerHostname(t *testing.T) {
+	tests := []struct {
+		name     string
+		hostname string
+		want     bool
+	}{
+		{
+			name:     "valid dns hostname",
+			hostname: "llama.example.com",
+			want:     true,
+		},
+		{
+			name:     "valid friendly hostname",
+			hostname: "llama",
+			want:     true,
+		},
+		{
+			name:     "uuid hostname",
+			hostname: uuid.NewString(),
+			want:     true,
+		},
+		{
+			name:     "valid hostname with multi-dashes",
+			hostname: "llama--example.com",
+			want:     true,
+		},
+		{
+			name:     "valid hostname with multi-dots",
+			hostname: "llama..example.com",
+			want:     true,
+		},
+		{
+			name:     "valid hostname with numbers",
+			hostname: "llama9",
+			want:     true,
+		},
+		{
+			name:     "hostname with invalid characters",
+			hostname: "llama?!$",
+			want:     false,
+		},
+		{
+			name:     "super long hostname",
+			hostname: strings.Repeat("a", serverHostnameMaxLen*2),
+			want:     false,
+		},
+		{
+			name:     "hostname with spaces",
+			hostname: "the quick brown fox jumps over the lazy dog",
+			want:     false,
+		},
+		{
+			name:     "hostname with ;",
+			hostname: "llama;example.com",
+			want:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := validServerHostname(tt.hostname)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
This PR updates the regex used by `validServerHostname` to permit consecutive symbols (`-` and `.`) in server hostnames.

Changelog: Enable multiple consecutive occurrences of `-` and `.` in SSH server hostnames.