### PR TITLE
[v17] Show kube cluster name at the beginning of kube tabs

### DIFF
--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
@@ -425,7 +425,7 @@ export class DocumentsService {
     if (doc.kind === 'doc.gateway_kube') {
       const { params } = routing.parseKubeUri(doc.targetUri);
       this.update(doc.uri, {
-        title: [shellBinName, cwd, params.kubeId].filter(Boolean).join(' · '),
+        title: [params.kubeId, shellBinName].filter(Boolean).join(' · '),
       });
     }
   }


### PR DESCRIPTION
Backport #50376 to branch/v17

changelog: Reverted a change that caused the Kubernetes cluster name to be displayed at the end of the tab title in Teleport Connect
