### PR TITLE
Release 17.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 17.1.0 (12/18/24)
+## 17.1.0 (12/19/24)
 
 ### Access requests support for AWS Identity Center
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,14 +42,11 @@ Teleport now allows cluster administrators to enable local and remote port forwa
 * Switched to a new role editor UI. [#50030](https://github.com/gravitational/teleport/pull/50030)
 * Added support for multiple ports to TCP applications. [#49711](https://github.com/gravitational/teleport/pull/49711)
 * Allow multiple consecutive occurrences of `-` and `.` in SSH server hostnames.  [#50410](https://github.com/gravitational/teleport/pull/50410)
+* Fixed bug causing users to see notifications for their own access requests in some cases. [#50076](https://github.com/gravitational/teleport/pull/50076)
+* Improved the cluster initialization process's ability to recovery from errors. [#49966](https://github.com/gravitational/teleport/pull/49966)
 
 Enterprise:
 * Adds AWS Account name to Identity Center Roles and resources. Some manual cleanup may be required where users and Access Lists have been assigned the obsolete roles.
-
-## 17.0.6 (12/12/24)
-
-* Fixed bug causing users to see notifications for their own access requests in some cases. [#50076](https://github.com/gravitational/teleport/pull/50076)
-* Improved the cluster initialization process's ability to recovery from errors. [#49966](https://github.com/gravitational/teleport/pull/49966)
 
 ## 17.0.5 (12/11/24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ AWS Identity Center integration now allows users to request short or long term a
 
 Database access users can now connect to PostgreSQL databases connected to Teleport right from the web UI and use psql-style interface to query the database.
 
-### Hosted email plugin for access requests
+### Hosted email plugin for Access Requests
 
-Users now have the ability to setup Mailgun or generic SMTP server for access request notifications using Teleport web UI without needing to self-host the email plugin.
+Users now have the ability to setup Mailgun or generic SMTP server for Access Request notifications using Teleport web UI without needing to self-host the email plugin.
 
 ### Multi-port support for VNet
 
@@ -30,7 +30,7 @@ Teleport now allows cluster administrators to enable local and remote port forwa
 
 * Updated golang.org/x/net to v0.33.0 (addresses CVE-2024-45338). [#50397](https://github.com/gravitational/teleport/pull/50397)
 * Fixed an issue causing panics in SAML app or OIDC integration deletion relating to AWS Identity Center integration. [#50360](https://github.com/gravitational/teleport/pull/50360)
-* Fix missing roles in access lists causing users to be locked out of their account. [#50298](https://github.com/gravitational/teleport/pull/50298)
+* Fix missing roles in Access Lists causing users to be locked out of their account. [#50298](https://github.com/gravitational/teleport/pull/50298)
 * Added support for connecting to PostgreSQL databases using WebUI. [#50287](https://github.com/gravitational/teleport/pull/50287)
 * Improved the performance of Teleport agents serving a large number of resources in Kubernetes. [#50279](https://github.com/gravitational/teleport/pull/50279)
 * Improve performance of Kubernetes App Auto Discover. [#50269](https://github.com/gravitational/teleport/pull/50269)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,34 @@
 
 ## 17.1.0 (12/18/24)
 
+### Access requests support for AWS Identity Center
+
+AWS Identity Center integration will allow users to request short or long term access to permission sets via Access Requests.
+
+### Database access for PostgreSQL via web UI
+
+Database access users will be able to connect to PostgreSQL databases connected to Teleport right from the web UI and use psql-style interface to query the database.
+
+### Hosted email plugin for access requests
+
+Users will be able to setup Mailgun or generic SMTP server for access request notifications using Teleport web UI without needing to self-host the email plugin.
+
+### Multi-port support for VNet
+
+Users will be able to support multiple ports (or a range of ports) with a single TCP application, and Teleport VNet will make all of the application's ports accessible on the virtual network.
+
+### Graphical Role Editor
+
+Teleport's web UI will include a new role editor that allows users to create and modify roles without resorting to a raw YAML editor.
+
+### Granular SSH port forwarding controls
+
+Teleport will allow cluster administrators to enable local and remote port forwarding separately rather than grouping both types of port forwarding behind a single option.
+
+### Other improvements and fixes
+
 * Updated golang.org/x/net to v0.33.0 (addresses CVE-2024-45338). [#50397](https://github.com/gravitational/teleport/pull/50397)
-* Prevents panic in SAML app or OIDC integration deletion when a plugin type is not `PluginTypeAWSIdentityCenter` or `PluginAWSICSettings` is nil. [#50360](https://github.com/gravitational/teleport/pull/50360)
+* Fixed an issue causing panics in SAML app or OIDC integration deletion relating to AWS Identity Center integration. [#50360](https://github.com/gravitational/teleport/pull/50360)
 * Fix missing roles in access lists causing users to be locked out of their account. [#50298](https://github.com/gravitational/teleport/pull/50298)
 * Added support for connecting to PostgreSQL databases using WebUI. [#50287](https://github.com/gravitational/teleport/pull/50287)
 * Improved the performance of Teleport agents serving a large number of resources in Kubernetes. [#50279](https://github.com/gravitational/teleport/pull/50279)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 17.1.0 (12/18/24)
+
+* Updated golang.org/x/net to v0.33.0 (addresses CVE-2024-45338). [#50397](https://github.com/gravitational/teleport/pull/50397)
+* Prevents panic in SAML app or OIDC integration deletion when a plugin type is not `PluginTypeAWSIdentityCenter` or `PluginAWSICSettings` is nil. [#50360](https://github.com/gravitational/teleport/pull/50360)
+* Fix missing roles in access lists causing users to be locked out of their account. [#50298](https://github.com/gravitational/teleport/pull/50298)
+* Added support for connecting to PostgreSQL databases using WebUI. [#50287](https://github.com/gravitational/teleport/pull/50287)
+* Improved the performance of Teleport agents serving a large number of resources in Kubernetes. [#50279](https://github.com/gravitational/teleport/pull/50279)
+* Improve performance of Kubernetes App Auto Discover. [#50269](https://github.com/gravitational/teleport/pull/50269)
+* Added more granular access controls for SSH port forwarding. Access to remote or local port forwarding can now be controlled individually using the new `ssh_port_forwarding` role option. [#50241](https://github.com/gravitational/teleport/pull/50241)
+* Properly close ssh port forwarding connections to prevent requests hanging indefinitely. [#50238](https://github.com/gravitational/teleport/pull/50238)
+* Teleport's RDP client now sets the load balancing cookie to improve compatibility with local traffic managers. [#50226](https://github.com/gravitational/teleport/pull/50226)
+* Fixes an intermittent EKS authentication failure when dealing with EKS auto-discovery. [#50197](https://github.com/gravitational/teleport/pull/50197)
+* Expose /.well-known/jwks-okta public endpoint for Okta API services type App. [#50177](https://github.com/gravitational/teleport/pull/50177)
+* Switched to a new role editor UI. [#50030](https://github.com/gravitational/teleport/pull/50030)
+* Added support for multiple ports to TCP applications. [#49711](https://github.com/gravitational/teleport/pull/49711)
+
+Enterprise:
+* Adds AWS Account name to Identity Center Roles and resources. Some manual cleanup may be required where users and Access Lists have been assigned the obsolete roles.
+
 ## 17.0.6 (12/12/24)
 
 * Fixed bug causing users to see notifications for their own access requests in some cases. [#50076](https://github.com/gravitational/teleport/pull/50076)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,19 +8,19 @@ AWS Identity Center integration now allows users to request short or long term a
 
 ### Database access for PostgreSQL via web UI
 
-Database access users will be able to connect to PostgreSQL databases connected to Teleport right from the web UI and use psql-style interface to query the database.
+Database access users can now connect to PostgreSQL databases connected to Teleport right from the web UI and use psql-style interface to query the database.
 
 ### Hosted email plugin for access requests
 
-Users will be able to setup Mailgun or generic SMTP server for access request notifications using Teleport web UI without needing to self-host the email plugin.
+Users now have the ability to setup Mailgun or generic SMTP server for access request notifications using Teleport web UI without needing to self-host the email plugin.
 
 ### Multi-port support for VNet
 
-Users will be able to support multiple ports (or a range of ports) with a single TCP application, and Teleport VNet will make all of the application's ports accessible on the virtual network.
+Users now supports multiple ports (or a range of ports) with a single TCP application, and Teleport VNet will make all of the application's ports accessible on the virtual network.
 
 ### Graphical Role Editor
 
-Teleport's web UI will include a new role editor that allows users to create and modify roles without resorting to a raw YAML editor.
+Teleport's web UI includes a new role editor that allows users to create and modify roles without resorting to a raw YAML editor.
 
 ### Granular SSH port forwarding controls
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Access requests support for AWS Identity Center
 
-AWS Identity Center integration will allow users to request short or long term access to permission sets via Access Requests.
+AWS Identity Center integration now allows users to request short or long term access to permission sets via Access Requests.
 
 ### Database access for PostgreSQL via web UI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Teleport will allow cluster administrators to enable local and remote port forwa
 * Expose /.well-known/jwks-okta public endpoint for Okta API services type App. [#50177](https://github.com/gravitational/teleport/pull/50177)
 * Switched to a new role editor UI. [#50030](https://github.com/gravitational/teleport/pull/50030)
 * Added support for multiple ports to TCP applications. [#49711](https://github.com/gravitational/teleport/pull/49711)
+* Allow multiple consecutive occurrences of `-` and `.` in SSH server hostnames.  [#50410](https://github.com/gravitational/teleport/pull/50410)
 
 Enterprise:
 * Adds AWS Account name to Identity Center Roles and resources. Some manual cleanup may be required where users and Access Lists have been assigned the obsolete roles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Teleport's web UI will include a new role editor that allows users to create and
 
 ### Granular SSH port forwarding controls
 
-Teleport will allow cluster administrators to enable local and remote port forwarding separately rather than grouping both types of port forwarding behind a single option.
+Teleport now allows cluster administrators to enable local and remote port forwarding separately rather than grouping both types of port forwarding behind a single option.
 
 ### Other improvements and fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Teleport now allows cluster administrators to enable local and remote port forwa
 
 ### Other improvements and fixes
 
+* Fixed an issue that could cause some antivirus tools to block Teleport's Device Trust feature on Windows machines. [#50453](https://github.com/gravitational/teleport/pull/50453)
+* Updates the UI login redirection service to honor redirection to `enterprise/saml-idp/sso` path even if user is already authenticated with Teleport. [#50442](https://github.com/gravitational/teleport/pull/50442)
+* Reduced cluster state storage load in clusters with a large amount of resources. [#50430](https://github.com/gravitational/teleport/pull/50430)
 * Updated golang.org/x/net to v0.33.0 (addresses CVE-2024-45338). [#50397](https://github.com/gravitational/teleport/pull/50397)
 * Fixed an issue causing panics in SAML app or OIDC integration deletion relating to AWS Identity Center integration. [#50360](https://github.com/gravitational/teleport/pull/50360)
 * Fix missing roles in Access Lists causing users to be locked out of their account. [#50298](https://github.com/gravitational/teleport/pull/50298)

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 #   Stable releases:   "1.0.0"
 #   Pre-releases:      "1.0.0-alpha.1", "1.0.0-beta.2", "1.0.0-rc.3"
 #   Master/dev branch: "1.0.0-dev"
-VERSION=17.1.0-rc.1
+VERSION=17.1.0
 
 DOCKER_IMAGE ?= teleport
 

--- a/api/version.go
+++ b/api/version.go
@@ -3,6 +3,6 @@ package api
 
 import "github.com/coreos/go-semver/semver"
 
-const Version = "17.1.0-rc.1"
+const Version = "17.1.0"
 
 var SemVersion = semver.New(Version)

--- a/build.assets/macos/tsh/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tsh/tsh.app/Contents/Info.plist
@@ -19,13 +19,13 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>1.0</string>
+		<string>17.1.0</string>
 		<key>CFBundleSupportedPlatforms</key>
 		<array>
 			<string>MacOSX</string>
 		</array>
 		<key>CFBundleVersion</key>
-		<string>1.0</string>
+		<string>17.1.0</string>
 		<key>DTCompiler</key>
 		<string>com.apple.compilers.llvm.clang.1_0</string>
 		<key>DTPlatformBuild</key>

--- a/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
@@ -17,13 +17,13 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>1.0</string>
+		<string>17.1.0</string>
 		<key>CFBundleSupportedPlatforms</key>
 		<array>
 			<string>MacOSX</string>
 		</array>
 		<key>CFBundleVersion</key>
-		<string>1.0</string>
+		<string>17.1.0</string>
 		<key>DTCompiler</key>
 		<string>com.apple.compilers.llvm.clang.1_0</string>
 		<key>DTPlatformBuild</key>

--- a/examples/chart/access/datadog/Chart.yaml
+++ b/examples/chart/access/datadog/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.1.0-rc.1"
+.version: &version "17.1.0"
 
 apiVersion: v2
 name: teleport-plugin-datadog

--- a/examples/chart/access/datadog/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/datadog/tests/__snapshot__/configmap_test.yaml.snap
@@ -26,6 +26,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-datadog
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-plugin-datadog-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-plugin-datadog-17.1.0
       name: RELEASE-NAME-teleport-plugin-datadog

--- a/examples/chart/access/datadog/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/datadog/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-datadog
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-plugin-datadog-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-plugin-datadog-17.1.0
       name: RELEASE-NAME-teleport-plugin-datadog
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-datadog
-            app.kubernetes.io/version: 17.1.0-rc.1
-            helm.sh/chart: teleport-plugin-datadog-17.1.0-rc.1
+            app.kubernetes.io/version: 17.1.0
+            helm.sh/chart: teleport-plugin-datadog-17.1.0
         spec:
           containers:
           - command:

--- a/examples/chart/access/discord/Chart.yaml
+++ b/examples/chart/access/discord/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.1.0-rc.1"
+.version: &version "17.1.0"
 
 apiVersion: v2
 name: teleport-plugin-discord

--- a/examples/chart/access/discord/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/discord/tests/__snapshot__/configmap_test.yaml.snap
@@ -24,6 +24,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-discord
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-plugin-discord-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-plugin-discord-17.1.0
       name: RELEASE-NAME-teleport-plugin-discord

--- a/examples/chart/access/discord/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/discord/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-discord
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-plugin-discord-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-plugin-discord-17.1.0
       name: RELEASE-NAME-teleport-plugin-discord
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-discord
-            app.kubernetes.io/version: 17.1.0-rc.1
-            helm.sh/chart: teleport-plugin-discord-17.1.0-rc.1
+            app.kubernetes.io/version: 17.1.0
+            helm.sh/chart: teleport-plugin-discord-17.1.0
         spec:
           containers:
           - command:

--- a/examples/chart/access/email/Chart.yaml
+++ b/examples/chart/access/email/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.1.0-rc.1"
+.version: &version "17.1.0"
 
 apiVersion: v2
 name: teleport-plugin-email

--- a/examples/chart/access/email/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/email/tests/__snapshot__/configmap_test.yaml.snap
@@ -26,8 +26,8 @@ should match the snapshot (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-plugin-email-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-plugin-email-17.1.0
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on):
   1: |
@@ -59,8 +59,8 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-plugin-email-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-plugin-email-17.1.0
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, no starttls):
   1: |
@@ -92,8 +92,8 @@ should match the snapshot (smtp on, no starttls):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-plugin-email-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-plugin-email-17.1.0
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, password file):
   1: |
@@ -125,8 +125,8 @@ should match the snapshot (smtp on, password file):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-plugin-email-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-plugin-email-17.1.0
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, roleToRecipients set):
   1: |
@@ -161,8 +161,8 @@ should match the snapshot (smtp on, roleToRecipients set):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-plugin-email-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-plugin-email-17.1.0
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, starttls disabled):
   1: |
@@ -194,6 +194,6 @@ should match the snapshot (smtp on, starttls disabled):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-plugin-email-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-plugin-email-17.1.0
       name: RELEASE-NAME-teleport-plugin-email

--- a/examples/chart/access/email/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/email/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should be possible to override volume name (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-plugin-email-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-plugin-email-17.1.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should be possible to override volume name (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 17.1.0-rc.1
-            helm.sh/chart: teleport-plugin-email-17.1.0-rc.1
+            app.kubernetes.io/version: 17.1.0
+            helm.sh/chart: teleport-plugin-email-17.1.0
         spec:
           containers:
           - command:
@@ -34,7 +34,7 @@ should be possible to override volume name (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:17.1.0-rc.1
+            image: public.ecr.aws/gravitational/teleport-plugin-email:17.1.0
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -75,8 +75,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-plugin-email-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-plugin-email-17.1.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -90,8 +90,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 17.1.0-rc.1
-            helm.sh/chart: teleport-plugin-email-17.1.0-rc.1
+            app.kubernetes.io/version: 17.1.0
+            helm.sh/chart: teleport-plugin-email-17.1.0
         spec:
           containers:
           - command:
@@ -136,8 +136,8 @@ should match the snapshot (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-plugin-email-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-plugin-email-17.1.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -151,8 +151,8 @@ should match the snapshot (mailgun on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 17.1.0-rc.1
-            helm.sh/chart: teleport-plugin-email-17.1.0-rc.1
+            app.kubernetes.io/version: 17.1.0
+            helm.sh/chart: teleport-plugin-email-17.1.0
         spec:
           containers:
           - command:
@@ -163,7 +163,7 @@ should match the snapshot (mailgun on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:17.1.0-rc.1
+            image: public.ecr.aws/gravitational/teleport-plugin-email:17.1.0
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -204,8 +204,8 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-plugin-email-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-plugin-email-17.1.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -219,8 +219,8 @@ should match the snapshot (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 17.1.0-rc.1
-            helm.sh/chart: teleport-plugin-email-17.1.0-rc.1
+            app.kubernetes.io/version: 17.1.0
+            helm.sh/chart: teleport-plugin-email-17.1.0
         spec:
           containers:
           - command:
@@ -231,7 +231,7 @@ should match the snapshot (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:17.1.0-rc.1
+            image: public.ecr.aws/gravitational/teleport-plugin-email:17.1.0
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -272,8 +272,8 @@ should mount external secret (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-plugin-email-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-plugin-email-17.1.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -287,8 +287,8 @@ should mount external secret (mailgun on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 17.1.0-rc.1
-            helm.sh/chart: teleport-plugin-email-17.1.0-rc.1
+            app.kubernetes.io/version: 17.1.0
+            helm.sh/chart: teleport-plugin-email-17.1.0
         spec:
           containers:
           - command:
@@ -299,7 +299,7 @@ should mount external secret (mailgun on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:17.1.0-rc.1
+            image: public.ecr.aws/gravitational/teleport-plugin-email:17.1.0
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -340,8 +340,8 @@ should mount external secret (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-plugin-email-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-plugin-email-17.1.0
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -355,8 +355,8 @@ should mount external secret (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 17.1.0-rc.1
-            helm.sh/chart: teleport-plugin-email-17.1.0-rc.1
+            app.kubernetes.io/version: 17.1.0
+            helm.sh/chart: teleport-plugin-email-17.1.0
         spec:
           containers:
           - command:
@@ -367,7 +367,7 @@ should mount external secret (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:17.1.0-rc.1
+            image: public.ecr.aws/gravitational/teleport-plugin-email:17.1.0
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:

--- a/examples/chart/access/jira/Chart.yaml
+++ b/examples/chart/access/jira/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.1.0-rc.1"
+.version: &version "17.1.0"
 
 apiVersion: v2
 name: teleport-plugin-jira

--- a/examples/chart/access/jira/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/jira/tests/__snapshot__/configmap_test.yaml.snap
@@ -32,6 +32,6 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-jira
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-plugin-jira-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-plugin-jira-17.1.0
       name: RELEASE-NAME-teleport-plugin-jira

--- a/examples/chart/access/jira/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/jira/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-jira
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-plugin-jira-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-plugin-jira-17.1.0
       name: RELEASE-NAME-teleport-plugin-jira
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-jira
-            app.kubernetes.io/version: 17.1.0-rc.1
-            helm.sh/chart: teleport-plugin-jira-17.1.0-rc.1
+            app.kubernetes.io/version: 17.1.0
+            helm.sh/chart: teleport-plugin-jira-17.1.0
         spec:
           containers:
           - command:

--- a/examples/chart/access/mattermost/Chart.yaml
+++ b/examples/chart/access/mattermost/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.1.0-rc.1"
+.version: &version "17.1.0"
 
 apiVersion: v2
 name: teleport-plugin-mattermost

--- a/examples/chart/access/mattermost/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/mattermost/tests/__snapshot__/configmap_test.yaml.snap
@@ -22,6 +22,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-plugin-mattermost-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-plugin-mattermost-17.1.0
       name: RELEASE-NAME-teleport-plugin-mattermost

--- a/examples/chart/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-plugin-mattermost-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-plugin-mattermost-17.1.0
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 17.1.0-rc.1
-            helm.sh/chart: teleport-plugin-mattermost-17.1.0-rc.1
+            app.kubernetes.io/version: 17.1.0
+            helm.sh/chart: teleport-plugin-mattermost-17.1.0
         spec:
           containers:
           - command:
@@ -75,8 +75,8 @@ should mount external secret:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-plugin-mattermost-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-plugin-mattermost-17.1.0
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -90,8 +90,8 @@ should mount external secret:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 17.1.0-rc.1
-            helm.sh/chart: teleport-plugin-mattermost-17.1.0-rc.1
+            app.kubernetes.io/version: 17.1.0
+            helm.sh/chart: teleport-plugin-mattermost-17.1.0
         spec:
           containers:
           - command:
@@ -102,7 +102,7 @@ should mount external secret:
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:17.1.0-rc.1
+            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:17.1.0
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
             ports:
@@ -143,8 +143,8 @@ should override volume name:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-plugin-mattermost-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-plugin-mattermost-17.1.0
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -158,8 +158,8 @@ should override volume name:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 17.1.0-rc.1
-            helm.sh/chart: teleport-plugin-mattermost-17.1.0-rc.1
+            app.kubernetes.io/version: 17.1.0
+            helm.sh/chart: teleport-plugin-mattermost-17.1.0
         spec:
           containers:
           - command:
@@ -170,7 +170,7 @@ should override volume name:
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:17.1.0-rc.1
+            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:17.1.0
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
             ports:

--- a/examples/chart/access/msteams/Chart.yaml
+++ b/examples/chart/access/msteams/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.1.0-rc.1"
+.version: &version "17.1.0"
 
 apiVersion: v2
 name: teleport-plugin-msteams

--- a/examples/chart/access/msteams/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/msteams/tests/__snapshot__/configmap_test.yaml.snap
@@ -29,6 +29,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-msteams
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-plugin-msteams-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-plugin-msteams-17.1.0
       name: RELEASE-NAME-teleport-plugin-msteams

--- a/examples/chart/access/msteams/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/msteams/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-msteams
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-plugin-msteams-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-plugin-msteams-17.1.0
       name: RELEASE-NAME-teleport-plugin-msteams
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-msteams
-            app.kubernetes.io/version: 17.1.0-rc.1
-            helm.sh/chart: teleport-plugin-msteams-17.1.0-rc.1
+            app.kubernetes.io/version: 17.1.0
+            helm.sh/chart: teleport-plugin-msteams-17.1.0
         spec:
           containers:
           - command:

--- a/examples/chart/access/pagerduty/Chart.yaml
+++ b/examples/chart/access/pagerduty/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.1.0-rc.1"
+.version: &version "17.1.0"
 
 apiVersion: v2
 name: teleport-plugin-pagerduty

--- a/examples/chart/access/pagerduty/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/pagerduty/tests/__snapshot__/configmap_test.yaml.snap
@@ -21,6 +21,6 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-pagerduty
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-plugin-pagerduty-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-plugin-pagerduty-17.1.0
       name: RELEASE-NAME-teleport-plugin-pagerduty

--- a/examples/chart/access/pagerduty/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/pagerduty/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-pagerduty
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-plugin-pagerduty-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-plugin-pagerduty-17.1.0
       name: RELEASE-NAME-teleport-plugin-pagerduty
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-pagerduty
-            app.kubernetes.io/version: 17.1.0-rc.1
-            helm.sh/chart: teleport-plugin-pagerduty-17.1.0-rc.1
+            app.kubernetes.io/version: 17.1.0
+            helm.sh/chart: teleport-plugin-pagerduty-17.1.0
         spec:
           containers:
           - command:

--- a/examples/chart/access/slack/Chart.yaml
+++ b/examples/chart/access/slack/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.1.0-rc.1"
+.version: &version "17.1.0"
 
 apiVersion: v2
 name: teleport-plugin-slack

--- a/examples/chart/access/slack/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/slack/tests/__snapshot__/configmap_test.yaml.snap
@@ -24,6 +24,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-slack
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-plugin-slack-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-plugin-slack-17.1.0
       name: RELEASE-NAME-teleport-plugin-slack

--- a/examples/chart/access/slack/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/slack/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-slack
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-plugin-slack-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-plugin-slack-17.1.0
       name: RELEASE-NAME-teleport-plugin-slack
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-slack
-            app.kubernetes.io/version: 17.1.0-rc.1
-            helm.sh/chart: teleport-plugin-slack-17.1.0-rc.1
+            app.kubernetes.io/version: 17.1.0
+            helm.sh/chart: teleport-plugin-slack-17.1.0
         spec:
           containers:
           - command:

--- a/examples/chart/event-handler/Chart.yaml
+++ b/examples/chart/event-handler/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.1.0-rc.1"
+.version: &version "17.1.0"
 
 apiVersion: v2
 name: teleport-plugin-event-handler

--- a/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
@@ -26,6 +26,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-plugin-event-handler-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-plugin-event-handler-17.1.0
       name: RELEASE-NAME-teleport-plugin-event-handler

--- a/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-plugin-event-handler-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-plugin-event-handler-17.1.0
       name: RELEASE-NAME-teleport-plugin-event-handler
     spec:
       replicas: 1
@@ -82,7 +82,7 @@ should mount tls.existingCASecretName and set environment when set in values:
         value: "true"
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-plugin-event-handler:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-plugin-event-handler:17.1.0
       imagePullPolicy: IfNotPresent
       name: teleport-plugin-event-handler
       ports:

--- a/examples/chart/tbot/Chart.yaml
+++ b/examples/chart/tbot/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.1.0-rc.1"
+.version: &version "17.1.0"
 
 name: tbot
 apiVersion: v2

--- a/examples/chart/tbot/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/tbot/tests/__snapshot__/deployment_test.yaml.snap
@@ -29,7 +29,7 @@ should match the snapshot (full):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: tbot
-            helm.sh/chart: tbot-17.1.0-rc.1
+            helm.sh/chart: tbot-17.1.0
             test-key: test-label-pod
         spec:
           affinity:
@@ -68,7 +68,7 @@ should match the snapshot (full):
               value: "1"
             - name: TEST_ENV
               value: test-value
-            image: public.ecr.aws/gravitational/tbot-distroless:17.1.0-rc.1
+            image: public.ecr.aws/gravitational/tbot-distroless:17.1.0
             imagePullPolicy: Always
             livenessProbe:
               failureThreshold: 6
@@ -154,7 +154,7 @@ should match the snapshot (simple):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: tbot
-            helm.sh/chart: tbot-17.1.0-rc.1
+            helm.sh/chart: tbot-17.1.0
         spec:
           containers:
           - args:
@@ -176,7 +176,7 @@ should match the snapshot (simple):
                   fieldPath: spec.nodeName
             - name: KUBERNETES_TOKEN_PATH
               value: /var/run/secrets/tokens/join-sa-token
-            image: public.ecr.aws/gravitational/tbot-distroless:17.1.0-rc.1
+            image: public.ecr.aws/gravitational/tbot-distroless:17.1.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6

--- a/examples/chart/teleport-cluster/Chart.yaml
+++ b/examples/chart/teleport-cluster/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.1.0-rc.1"
+.version: &version "17.1.0"
 
 name: teleport-cluster
 apiVersion: v2

--- a/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.1.0-rc.1"
+.version: &version "17.1.0"
 
 name: teleport-operator
 apiVersion: v2

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_clusterrole_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_clusterrole_test.yaml.snap
@@ -8,8 +8,8 @@ adds operator permissions to ClusterRole:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-cluster-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-cluster-17.1.0
         teleport.dev/majorVersion: "17"
       name: RELEASE-NAME
     rules:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
@@ -1848,8 +1848,8 @@ sets clusterDomain on Configmap:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-cluster-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-cluster-17.1.0
         teleport.dev/majorVersion: "17"
       name: RELEASE-NAME-auth
       namespace: NAMESPACE

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
@@ -8,7 +8,7 @@
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -141,7 +141,7 @@ should set nodeSelector when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -238,7 +238,7 @@ should set resources when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -324,7 +324,7 @@ should set securityContext when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_config_test.yaml.snap
@@ -567,8 +567,8 @@ sets clusterDomain on Configmap:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-cluster-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-cluster-17.1.0
         teleport.dev/majorVersion: "17"
       name: RELEASE-NAME-proxy
       namespace: NAMESPACE

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
@@ -11,8 +11,8 @@ sets clusterDomain on Deployment Pods:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 17.1.0-rc.1
-        helm.sh/chart: teleport-cluster-17.1.0-rc.1
+        app.kubernetes.io/version: 17.1.0
+        helm.sh/chart: teleport-cluster-17.1.0
         teleport.dev/majorVersion: "17"
       name: RELEASE-NAME-proxy
       namespace: NAMESPACE
@@ -26,7 +26,7 @@ sets clusterDomain on Deployment Pods:
       template:
         metadata:
           annotations:
-            checksum/config: 3a0c6b4a98b7a921573ad5e3d0075e201d4a295df3c95e179bcf86a66680784d
+            checksum/config: 09b4b67858b6bc8ebde3a7392d736f48509d46aa0cb4ecd7d5df4ebafcf2bd93
             kubernetes.io/pod: test-annotation
             kubernetes.io/pod-different: 4
           labels:
@@ -34,8 +34,8 @@ sets clusterDomain on Deployment Pods:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-cluster
-            app.kubernetes.io/version: 17.1.0-rc.1
-            helm.sh/chart: teleport-cluster-17.1.0-rc.1
+            app.kubernetes.io/version: 17.1.0
+            helm.sh/chart: teleport-cluster-17.1.0
             teleport.dev/majorVersion: "17"
         spec:
           affinity:
@@ -44,7 +44,7 @@ sets clusterDomain on Deployment Pods:
           containers:
           - args:
             - --diag-addr=0.0.0.0:3000
-            image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+            image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
             imagePullPolicy: IfNotPresent
             lifecycle:
               preStop:
@@ -105,7 +105,7 @@ sets clusterDomain on Deployment Pods:
             - wait
             - no-resolve
             - RELEASE-NAME-auth-v16.NAMESPACE.svc.test.com
-            image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+            image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
             name: wait-auth-update
           serviceAccountName: RELEASE-NAME-proxy
           terminationGracePeriodSeconds: 60
@@ -137,7 +137,7 @@ should provision initContainer correctly when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v16.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       name: wait-auth-update
       resources:
         limits:
@@ -201,7 +201,7 @@ should set nodeSelector when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -262,7 +262,7 @@ should set nodeSelector when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v16.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       name: wait-auth-update
     nodeSelector:
       environment: security
@@ -313,7 +313,7 @@ should set resources for wait-auth-update initContainer when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -381,7 +381,7 @@ should set resources for wait-auth-update initContainer when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v16.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       name: wait-auth-update
       resources:
         limits:
@@ -421,7 +421,7 @@ should set resources when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -489,7 +489,7 @@ should set resources when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v16.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       name: wait-auth-update
       resources:
         limits:
@@ -529,7 +529,7 @@ should set securityContext for initContainers when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -597,7 +597,7 @@ should set securityContext for initContainers when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v16.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       name: wait-auth-update
       securityContext:
         allowPrivilegeEscalation: false
@@ -637,7 +637,7 @@ should set securityContext when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -705,7 +705,7 @@ should set securityContext when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v16.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       name: wait-auth-update
       securityContext:
         allowPrivilegeEscalation: false

--- a/examples/chart/teleport-kube-agent/Chart.yaml
+++ b/examples/chart/teleport-kube-agent/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.1.0-rc.1"
+.version: &version "17.1.0"
 
 name: teleport-kube-agent
 apiVersion: v2

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
@@ -32,7 +32,7 @@ sets Deployment annotations when specified if action is Upgrade:
               value: "true"
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+            image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -109,7 +109,7 @@ sets Deployment labels when specified if action is Upgrade:
             value: "true"
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-          image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+          image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -173,7 +173,7 @@ sets Pod annotations when specified if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -237,7 +237,7 @@ sets Pod labels when specified if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -322,7 +322,7 @@ should add emptyDir for data when existingDataVolume is not set if action is Upg
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -387,7 +387,7 @@ should add insecureSkipProxyTLSVerify to args when set in values if action is Up
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -451,7 +451,7 @@ should correctly configure existingDataVolume when set if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -513,7 +513,7 @@ should expose diag port if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -589,7 +589,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -665,7 +665,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -729,7 +729,7 @@ should have one replica when replicaCount is not set if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -793,7 +793,7 @@ should mount extraVolumes and extraVolumeMounts if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -862,7 +862,7 @@ should mount jamfCredentialsSecret if it already exists and when role is jamf an
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -932,7 +932,7 @@ should mount jamfCredentialsSecret.name when role is jamf and action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1004,7 +1004,7 @@ should mount tls.existingCASecretName and set environment when set in values if 
         value: cluster.local
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1078,7 +1078,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: http://username:password@my.proxy.host:3128
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1148,7 +1148,7 @@ should provision initContainer correctly when set in values if action is Upgrade
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1270,7 +1270,7 @@ should set affinity when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1334,7 +1334,7 @@ should set default serviceAccountName when not set in values if action is Upgrad
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1411,7 +1411,7 @@ should set environment when extraEnv set in values if action is Upgrade:
         value: cluster.local
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1539,7 +1539,7 @@ should set imagePullPolicy when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -1603,7 +1603,7 @@ should set nodeSelector if set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1669,7 +1669,7 @@ should set not set priorityClassName when not set in values if action is Upgrade
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1745,7 +1745,7 @@ should set preferred affinity when more than one replica is used if action is Up
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1809,7 +1809,7 @@ should set priorityClassName when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1874,7 +1874,7 @@ should set probeTimeoutSeconds when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1948,7 +1948,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set if
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2012,7 +2012,7 @@ should set resources when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2083,7 +2083,7 @@ should set serviceAccountName when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2147,7 +2147,7 @@ should set tolerations when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
@@ -25,7 +25,7 @@ should create ServiceAccount for post-delete hook by default:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -108,7 +108,7 @@ should not create ServiceAccount for post-delete hook if serviceAccount.create i
                   fieldPath: metadata.namespace
             - name: RELEASE_NAME
               value: RELEASE-NAME
-            image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+            image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
             imagePullPolicy: IfNotPresent
             name: post-delete-job
             securityContext:
@@ -138,7 +138,7 @@ should not create ServiceAccount, Role or RoleBinding for post-delete hook if se
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -168,7 +168,7 @@ should set nodeSelector in post-delete hook:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -200,7 +200,7 @@ should set resources in the Job's pod spec if resources is set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       resources:

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
@@ -18,7 +18,7 @@ sets Pod annotations when specified:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -91,7 +91,7 @@ sets Pod labels when specified:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -188,7 +188,7 @@ sets StatefulSet labels when specified:
               value: RELEASE-NAME
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+            image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -293,7 +293,7 @@ should add insecureSkipProxyTLSVerify to args when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -366,7 +366,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and action
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -459,7 +459,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and is Fre
               value: RELEASE-NAME
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+            image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -542,7 +542,7 @@ should add volumeMount for data volume when using StatefulSet:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -615,7 +615,7 @@ should expose diag port:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -688,7 +688,7 @@ should generate Statefulset when storage is disabled and mode is a Upgrade:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -775,7 +775,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -860,7 +860,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -933,7 +933,7 @@ should have one replica when replicaCount is not set:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1006,7 +1006,7 @@ should install Statefulset when storage is disabled and mode is a Fresh Install:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1081,7 +1081,7 @@ should mount extraVolumes and extraVolumeMounts:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1159,7 +1159,7 @@ should mount jamfCredentialsSecret if it already exists and when role is jamf:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1240,7 +1240,7 @@ should mount jamfCredentialsSecret.name when role is jamf:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1323,7 +1323,7 @@ should mount tls.existingCASecretName and set environment when set in values:
         value: cluster.local
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1408,7 +1408,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: /etc/teleport-tls-ca/ca.pem
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1489,7 +1489,7 @@ should not add emptyDir for data when using StatefulSet:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1562,7 +1562,7 @@ should provision initContainer correctly when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1693,7 +1693,7 @@ should set affinity when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1766,7 +1766,7 @@ should set default serviceAccountName when not set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1852,7 +1852,7 @@ should set environment when extraEnv set in values:
         value: cluster.local
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1998,7 +1998,7 @@ should set imagePullPolicy when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -2071,7 +2071,7 @@ should set nodeSelector if set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2158,7 +2158,7 @@ should set preferred affinity when more than one replica is used:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2231,7 +2231,7 @@ should set probeTimeoutSeconds when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2314,7 +2314,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2387,7 +2387,7 @@ should set resources when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2467,7 +2467,7 @@ should set serviceAccountName when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2540,7 +2540,7 @@ should set storage.requests when set in values and action is an Upgrade:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2613,7 +2613,7 @@ should set storage.storageClassName when set in values and action is an Upgrade:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2686,7 +2686,7 @@ should set tolerations when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
@@ -27,7 +27,7 @@ sets the affinity:
       - --base-image=public.ecr.aws/gravitational/teleport-distroless
       - --version-server=https://my-custom-version-server/v1
       - --version-channel=custom/preview
-      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -73,7 +73,7 @@ sets the tolerations:
       - --base-image=public.ecr.aws/gravitational/teleport-distroless
       - --version-server=https://my-custom-version-server/v1
       - --version-channel=custom/preview
-      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:17.1.0-rc.1
+      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:17.1.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6


### PR DESCRIPTION

* Updated golang.org/x/net to v0.33.0 (addresses CVE-2024-45338). [#50397](https://github.com/gravitational/teleport/pull/50397)
* Prevents panic in SAML app or OIDC integration deletion when a plugin type is not `PluginTypeAWSIdentityCenter` or `PluginAWSICSettings` is nil. [#50360](https://github.com/gravitational/teleport/pull/50360)
* Fix missing roles in access lists causing users to be locked out of their account. [#50298](https://github.com/gravitational/teleport/pull/50298)
* Added support for connecting to PostgreSQL databases using WebUI. [#50287](https://github.com/gravitational/teleport/pull/50287)
* Improved the performance of Teleport agents serving a large number of resources in Kubernetes. [#50279](https://github.com/gravitational/teleport/pull/50279)
* Improve performance of Kubernetes App Auto Discover. [#50269](https://github.com/gravitational/teleport/pull/50269)
* Added more granular access controls for SSH port forwarding. Access to remote or local port forwarding can now be controlled individually using the new `ssh_port_forwarding` role option. [#50241](https://github.com/gravitational/teleport/pull/50241)
* Properly close ssh port forwarding connections to prevent requests hanging indefinitely. [#50238](https://github.com/gravitational/teleport/pull/50238)
* Teleport's RDP client now sets the load balancing cookie to improve compatibility with local traffic managers. [#50226](https://github.com/gravitational/teleport/pull/50226)
* Fixes an intermittent EKS authentication failure when dealing with EKS auto-discovery. [#50197](https://github.com/gravitational/teleport/pull/50197)
* Expose /.well-known/jwks-okta public endpoint for Okta API services type App. [#50177](https://github.com/gravitational/teleport/pull/50177)
* Switched to a new role editor UI. [#50030](https://github.com/gravitational/teleport/pull/50030)
* Added support for multiple ports to TCP applications. [#49711](https://github.com/gravitational/teleport/pull/49711)

Enterprise:
* Adds AWS Account name to Identity Center Roles and resources. Some manual cleanup may be required where users and Access Lists have been assigned the obsolete roles.