### PR TITLE
[v17] Relax `validServerHostname` to accept `--` or `..`

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -5641,7 +5641,7 @@ func (a *Server) KeepAliveServer(ctx context.Context, h types.KeepAlive) error {
 
 const (
 	serverHostnameMaxLen       = 256
-	serverHostnameRegexPattern = `^[a-zA-Z0-9]?[a-zA-Z0-9\.-]*$`
+	serverHostnameRegexPattern = `^[a-zA-Z0-9]+[a-zA-Z0-9\.-]*$`
 	replacedHostnameLabel      = types.TeleportInternalLabelPrefix + "invalid-hostname"
 )
 

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1512,17 +1512,13 @@ func (a *Server) runPeriodicOperations() {
 									if _, err := a.Services.UpdateNode(a.closeCtx, srv); err != nil && !trace.IsCompareFailed(err) {
 										logger.WarnContext(a.closeCtx, "failed to update SSH server hostname", "error", err)
 									}
-								}
-
-								// If the hostname has been replaced by a sanitized version, revert it back to the original
-								// if the original is valid under the most recent rules.
-								if oldHostname, ok := srv.GetLabel(replacedHostnameLabel); ok && validServerHostname(oldHostname) {
-									switch s := srv.(type) {
-									case *types.ServerV2:
-										s.Spec.Hostname = oldHostname
-										delete(s.Metadata.Labels, replacedHostnameLabel)
-									default:
-										return false, trace.BadParameter("invalid server provided")
+								} else if oldHostname, ok := srv.GetLabel(replacedHostnameLabel); ok && validServerHostname(oldHostname) {
+									// If the hostname has been replaced by a sanitized version, revert it back to the original
+									// if the original is valid under the most recent rules.
+									logger := a.logger.With("server", srv.GetName(), "old_hostname", oldHostname, "sanitized_hostname", srv.GetHostname())
+									if err := restoreSanitizedHostname(srv); err != nil {
+										logger.WarnContext(a.closeCtx, "failed to restore sanitized static SSH server hostname", "error", err)
+										return false, nil
 									}
 									if _, err := a.Services.UpdateNode(a.closeCtx, srv); err != nil && !trace.IsCompareFailed(err) {
 										log.Warnf("Failed to update node hostname: %v", err)
@@ -5681,6 +5677,26 @@ func sanitizeHostname(server types.Server) error {
 		}
 
 		s.Metadata.Labels[replacedHostnameLabel] = invalidHostname
+	default:
+		return trace.BadParameter("invalid server provided")
+	}
+
+	return nil
+}
+
+// restoreSanitizedHostname restores the original hostname of a server and removes the label.
+func restoreSanitizedHostname(server types.Server) error {
+	oldHostname, ok := server.GetLabels()[replacedHostnameLabel]
+	// if the label is not present or the hostname is invalid under the most recent rules, do nothing.
+	if !ok || !validServerHostname(oldHostname) {
+		return nil
+	}
+
+	switch s := server.(type) {
+	case *types.ServerV2:
+		// restore the original hostname and remove the label.
+		s.Spec.Hostname = oldHostname
+		delete(s.Metadata.Labels, replacedHostnameLabel)
 	default:
 		return trace.BadParameter("invalid server provided")
 	}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1515,7 +1515,7 @@ func (a *Server) runPeriodicOperations() {
 								}
 
 								// If the hostname has been replaced by a sanitized version, revert it back to the original
-								// if the original is valid under the new rules.
+								// if the original is valid under the most recent rules.
 								if oldHostname, ok := srv.GetLabel(replacedHostnameLabel); ok && validServerHostname(oldHostname) {
 									switch s := srv.(type) {
 									case *types.ServerV2:

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -5627,7 +5627,7 @@ func (a *Server) KeepAliveServer(ctx context.Context, h types.KeepAlive) error {
 
 const (
 	serverHostnameMaxLen       = 256
-	serverHostnameRegexPattern = `^[a-zA-Z0-9]([\.-]?[a-zA-Z0-9]+)*$`
+	serverHostnameRegexPattern = `^[a-zA-Z0-9]?[a-zA-Z0-9\.-]*$`
 	replacedHostnameLabel      = types.TeleportInternalLabelPrefix + "invalid-hostname"
 )
 
@@ -5635,7 +5635,7 @@ var serverHostnameRegex = regexp.MustCompile(serverHostnameRegexPattern)
 
 // validServerHostname returns false if the hostname is longer than 256 characters or
 // does not entirely consist of alphanumeric characters as well as '-' and '.'. A valid hostname also
-// cannot begin with a symbol, and a symbol cannot be followed immediately by another symbol.
+// cannot begin with a symbol.
 func validServerHostname(hostname string) bool {
 	return len(hostname) <= serverHostnameMaxLen && serverHostnameRegex.MatchString(hostname)
 }

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -4479,6 +4479,10 @@ func TestServerHostnameSanitization(t *testing.T) {
 			hostname: uuid.NewString() + ".example.com",
 		},
 		{
+			name:     "valid dns hostname with multi-dots",
+			hostname: "llama..example.com",
+		},
+		{
 			name:            "empty hostname",
 			hostname:        "",
 			invalidHostname: true,
@@ -4486,11 +4490,6 @@ func TestServerHostnameSanitization(t *testing.T) {
 		{
 			name:            "exceptionally long hostname",
 			hostname:        strings.Repeat("a", serverHostnameMaxLen*2),
-			invalidHostname: true,
-		},
-		{
-			name:            "invalid dns hostname",
-			hostname:        "llama..example.com",
 			invalidHostname: true,
 		},
 		{
@@ -4617,6 +4616,11 @@ func TestValidServerHostname(t *testing.T) {
 		{
 			name:     "hostname with ;",
 			hostname: "llama;example.com",
+			want:     false,
+		},
+		{
+			name:     "empty hostname",
+			hostname: "",
 			want:     false,
 		},
 	}

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -4563,6 +4563,7 @@ func TestServerHostnameSanitization(t *testing.T) {
 }
 
 func TestValidServerHostname(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		hostname string

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -4562,3 +4562,68 @@ func TestServerHostnameSanitization(t *testing.T) {
 		})
 	}
 }
+
+func TestValidServerHostname(t *testing.T) {
+	tests := []struct {
+		name     string
+		hostname string
+		want     bool
+	}{
+		{
+			name:     "valid dns hostname",
+			hostname: "llama.example.com",
+			want:     true,
+		},
+		{
+			name:     "valid friendly hostname",
+			hostname: "llama",
+			want:     true,
+		},
+		{
+			name:     "uuid hostname",
+			hostname: uuid.NewString(),
+			want:     true,
+		},
+		{
+			name:     "valid hostname with multi-dashes",
+			hostname: "llama--example.com",
+			want:     true,
+		},
+		{
+			name:     "valid hostname with multi-dots",
+			hostname: "llama..example.com",
+			want:     true,
+		},
+		{
+			name:     "valid hostname with numbers",
+			hostname: "llama9",
+			want:     true,
+		},
+		{
+			name:     "hostname with invalid characters",
+			hostname: "llama?!$",
+			want:     false,
+		},
+		{
+			name:     "super long hostname",
+			hostname: strings.Repeat("a", serverHostnameMaxLen*2),
+			want:     false,
+		},
+		{
+			name:     "hostname with spaces",
+			hostname: "the quick brown fox jumps over the lazy dog",
+			want:     false,
+		},
+		{
+			name:     "hostname with ;",
+			hostname: "llama;example.com",
+			want:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := validServerHostname(tt.hostname)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Backport #50386 to branch/v17

changelog: Enable multiple consecutive occurrences of `-` and `.` in SSH server hostnames.
