### PR TITLE
[v17] [buddy] Fix absence of the Symlinks parameter for Destination when using tbot kube credentials

### DIFF
--- a/tool/tbot/kube.go
+++ b/tool/tbot/kube.go
@@ -73,6 +73,10 @@ func onKubeCredentialsCommand(
 		return trace.Wrap(err)
 	}
 
+	if err = destination.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+
 	idData, err := destination.Read(ctx, config.IdentityFilePath)
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
Backport #50370 to branch/v17

changelog: Fix regression in `tbot` on Linux causing the Kubernetes credential helper to fail
