### PR TITLE
[v17] docs: remove references to enterprise version of tctl

### DIFF
--- a/docs/pages/admin-guides/access-controls/access-request-plugins/opsgenie.mdx
+++ b/docs/pages/admin-guides/access-controls/access-request-plugins/opsgenie.mdx
@@ -20,13 +20,13 @@ Opsgenie.
 
 - A Teleport Enterprise Cloud account.
 
-- The Enterprise `tctl` admin tool and `tsh` client tool version >= (=teleport.version=). 
+- The `tctl` admin tool and `tsh` client tool version >= (=teleport.version=). 
   
   You can verify the tools you have installed by running the following commands:
 
   ```code
   $ tctl version
-  # Teleport Enterprise v(=teleport.version=) go(=teleport.golang=)
+  # Teleport v(=teleport.version=) go(=teleport.golang=)
   
   $ tsh version
   # Teleport v(=teleport.version=) go(=teleport.golang=)

--- a/docs/pages/admin-guides/management/admin/trustedclusters.mdx
+++ b/docs/pages/admin-guides/management/admin/trustedclusters.mdx
@@ -151,13 +151,11 @@ To complete the steps in this guide, verify your environment meets the following
 
 - The `tctl` admin tool and `tsh` client tool version >= (=teleport.version=).
   
-  For Teleport Enterprise and Teleport Enterprise cloud, you should have the
-  Enterprise version of `tctl` and `tsh` installed.  You can verify the tools
-  you have installed by running the following commands:
+  You can verify the tools you have installed by running the following commands:
 
   ```code
   $ tctl version
-  # Teleport Enterprise v(=teleport.version=) go(=teleport.golang=)
+  # Teleport v(=teleport.version=) go(=teleport.golang=)
   
   $ tsh version
   # Teleport v(=teleport.version=) go(=teleport.golang=)

--- a/docs/pages/enroll-resources/kubernetes-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/getting-started.mdx
@@ -22,19 +22,17 @@ For information about other ways to enroll and discover Kubernetes clusters, see
 
 - Access to a running Teleport cluster, `tctl` admin tool, and `tsh` client tool, 
   version >= (=teleport.version=). 
-  
-  For Teleport Enterprise and Teleport Enterprise Cloud, you should
-  use the Enterprise version of `tctl`. 
+
   You can verify the tools you have installed by running the following commands:
 
   ```code
   $ tctl version
-  # Teleport Enterprise v(=teleport.version=) go(=teleport.golang=)
-  
+  # Teleport v(=teleport.version=) go(=teleport.golang=)
+
   $ tsh version
   # Teleport v(=teleport.version=) go(=teleport.golang=)
   ```
-
+  
   You can download these tools by following the appropriate [Installation 
   instructions](../../installation.mdx#linux) for your environment.
 

--- a/docs/pages/reference/cloud-faq.mdx
+++ b/docs/pages/reference/cloud-faq.mdx
@@ -95,7 +95,7 @@ $ tctl nodes add --ttl=5m --roles=node,proxy --token=$(uuid)
 
 ### How can I access the `tctl` admin tool?
 
-Find the appropriate download at [Installation](../installation.mdx). Use the Enterprise version of `tctl`.
+Find the appropriate download at [Installation](../installation.mdx).
 
 After downloading the tools, first log in to your cluster using `tsh`, then use `tctl` remotely:
 


### PR DESCRIPTION
Backport #50419 to branch/v17