### PR TITLE
[v16] devicetrust: don't invoke powershell when reading system information

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -178,6 +178,7 @@ require (
 	github.com/ucarion/urlpath v0.0.0-20200424170820-7ccc79b76bbb
 	github.com/vulcand/predicate v1.2.0 // replaced
 	github.com/xanzy/go-gitlab v0.103.0
+	github.com/yusufpapurcu/wmi v1.2.4
 	go.etcd.io/etcd/api/v3 v3.5.13
 	go.etcd.io/etcd/client/v3 v3.5.13
 	go.mongodb.org/mongo-driver v1.14.0
@@ -505,7 +506,6 @@ require (
 	github.com/xlab/treeprint v1.2.0 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
-	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	github.com/zeebo/errs v1.3.0 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect
 	github.com/zmap/zcrypto v0.0.0-20230310154051-c8b263fd8300 // indirect


### PR DESCRIPTION
The device trust web flow can result in a web browser launching Teleport Connect (which launches tsh, which in turn launches powershell).

Some antivirus solutions flag cases where a powershell process is a descendent of a web browser process. In order to avoid being blocked by the antivirus software, we want to read system information directly instead of via powershell.

Backports #50372

Changelog: Fixed an issue that could cause some antivirus tools to block Teleport's Device Trust feature on Windows machines.