### PR TITLE
Adding web-flow to CLA allowlist

### DIFF
--- a/.github/workflows/cla-assistant.yaml
+++ b/.github/workflows/cla-assistant.yaml
@@ -63,5 +63,8 @@ jobs:
           path-to-document: 'https://github.com/gravitational/teleport/blob/master/CLA.md'
           # branch should not be protected
           branch: 'main'
-          allowlist: 'dependabot[bot],teleport-post-release-automation[bot]'
+          # dependabot: Dependency management tool that keeps us up-to-date on latest releases
+          # teleport-post-release-automation: Creates PRs for updating docs after a release is made
+          # web-flow: GitHub owned user that owns commits that are done through Web APIs
+          allowlist: 'dependabot[bot],teleport-post-release-automation[bot],web-flow'
           lock-pullrequest-aftermerge: false


### PR DESCRIPTION
Adding web-flow to CLA allowlist. The web-flow user is used as part of our automation for post release.

Currently the user is being used for our post-release AMI update commit. For an example see here: https://github.com/gravitational/teleport/pull/50508/commits/25638a2eb4bedc286280fb6ce18c036942c98f52