### PR TITLE
chore: Bump Buf to v1.48.0

### DIFF
--- a/buf-legacy.yaml
+++ b/buf-legacy.yaml
@@ -35,7 +35,3 @@ lint:
     - RPC_REQUEST_RESPONSE_UNIQUE
     - RPC_REQUEST_STANDARD_NAME
     - RPC_RESPONSE_STANDARD_NAME
-
-breaking:
-  use:
-    - "buf-legacy.yaml should not be used for buf breaking"

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -17,7 +17,7 @@ LIBPCSCLITE_VERSION ?= 1.9.9-teleport
 DEVTOOLSET ?= devtoolset-12
 
 # Protogen related versions.
-BUF_VERSION ?= v1.42.0
+BUF_VERSION ?= v1.48.0
 # Keep in sync with api/proto/buf.yaml (and buf.lock).
 GOGO_PROTO_TAG ?= v1.3.2
 NODE_GRPC_TOOLS_VERSION ?= 1.12.4

--- a/gen/proto/ts/google/protobuf/descriptor_pb.ts
+++ b/gen/proto/ts/google/protobuf/descriptor_pb.ts
@@ -1036,12 +1036,13 @@ export interface MessageOptions {
  */
 export interface FieldOptions {
     /**
+     * NOTE: ctype is deprecated. Use `features.(pb.cpp).string_type` instead.
      * The ctype option instructs the C++ code generator to use a different
      * representation of the field than it normally would.  See the specific
      * options below.  This option is only implemented to support use of
      * [ctype=CORD] and [ctype=STRING] (the default) on non-repeated fields of
-     * type "bytes" in the open source release -- sorry, we'll try to include
-     * other types in a future version!
+     * type "bytes" in the open source release.
+     * TODO: make ctype actually deprecated.
      *
      * @generated from protobuf field: optional google.protobuf.FieldOptions.CType ctype = 1;
      */
@@ -1261,8 +1262,6 @@ export enum FieldOptions_JSType {
 }
 /**
  * If set to RETENTION_SOURCE, the option will be omitted from the binary.
- * Note: as of January 2023, support for this is in progress and does not yet
- * have an effect (b/264593489).
  *
  * @generated from protobuf enum google.protobuf.FieldOptions.OptionRetention
  */
@@ -1283,8 +1282,7 @@ export enum FieldOptions_OptionRetention {
 /**
  * This indicates the types of entities that the field may apply to when used
  * as an option. If it is unset, then the field may be freely used as an
- * option on any kind of entity. Note: as of January 2023, support for this is
- * in progress and does not yet have an effect (b/264593489).
+ * option on any kind of entity.
  *
  * @generated from protobuf enum google.protobuf.FieldOptions.OptionTargetType
  */
@@ -2071,7 +2069,7 @@ export enum Edition {
     EDITION_2024 = 1001,
     /**
      * Placeholder editions for testing feature resolution.  These should not be
-     * used or relyed on outside of tests.
+     * used or relied on outside of tests.
      *
      * @generated from protobuf enum value: EDITION_1_TEST_ONLY = 1;
      */


### PR DESCRIPTION
Update Buf to the latest release.

Most recent releases were inconsequential for Teleport (mainly "buf registry" and related commands), hence the large version jump.

* https://github.com/bufbuild/buf/releases/tag/v1.48.0