### PR TITLE
Enable the govet printf linter for e/

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,6 +56,7 @@ issues:
       linters: [staticcheck]
       text: 'grpc.WithReturnConnectionError is deprecated'
     - linters: [govet]
+      path-except: ^e/
       text: 'non-constant format string in call to github.com/gravitational/trace.'
   exclude-use-default: true
   max-same-issues: 0


### PR DESCRIPTION
All printf vet issues on e/ are currently fixed, so enabling the linter should avoid new issues from appearing.

Follow up from https://github.com/gravitational/teleport.e/pull/5741.

This is in preparation for the increased printf linter errors on Go 1.24.

* https://tip.golang.org/doc/go1.24#vet