### PR TITLE
Update SSH server expiry on heartbeat

### DIFF
--- a/lib/inventory/controller.go
+++ b/lib/inventory/controller.go
@@ -1174,6 +1174,7 @@ func (c *Controller) keepAliveSSHServer(handle *upstreamHandle, now time.Time) e
 		return nil
 	}
 
+	handle.sshServer.resource.SetExpiry(now.Add(c.serverTTL).UTC())
 	if _, err := c.auth.UpsertNode(c.closeContext, handle.sshServer.resource); err == nil {
 		if handle.sshServer.retryUpsert {
 			c.testEvent(sshUpsertRetryOk)


### PR DESCRIPTION
No tests so we can get a release out ASAP, will followup with a PR that adds checks for what gets actually written to the backend in `lib/inventory.Test{SSH,App,Database,Kubernetes}ServerBasics`.

changelog: fixed SSH server heartbeats disappearing after a few minutes