### PR TITLE
Show cluster management page on dashboards

### DIFF
--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -569,7 +569,7 @@ export class FeatureClusters implements TeleportFeature {
   };
 
   hasAccess(flags: FeatureFlags) {
-    return flags.trustedClusters;
+    return cfg.isDashboard || flags.trustedClusters;
   }
 
   navigationItem = {


### PR DESCRIPTION
This PR updates the condition on which the `Manage Clusters` menu item shows to make it always show up on dashboards.

This is so dashboard users are able to edit the business and security contacts.

In the future, I plan to improve the UX for dashboards so it is easier to find and we don't have to expose this page, this is a future task on the goal issue https://github.com/gravitational/cloud/issues/10491.

I'm opting for this approach instead of giving dashboard roles permissions to read trusted clusters because:

- this would also give access to the `Trusted Root Cluster` menu item
- we want to keep the dashboard roles permissions to a minimum

## Screenshot

Example of a `dashboard-admin` menu:


> Note that the v17 UI is not ready for dashboards, that's why the header spacing is off. This is known and being fixed.

![Screenshot 2024-12-20 at 11 18 29](https://github.com/user-attachments/assets/e5940d8d-189e-4e13-9ec0-fd44f46d2a9d)


Contributes to https://github.com/gravitational/cloud/issues/10491