### PR TITLE
[v17] Update SSH server expiry on heartbeat

### DIFF
--- a/lib/inventory/controller.go
+++ b/lib/inventory/controller.go
@@ -1127,6 +1127,7 @@ func (c *Controller) keepAliveSSHServer(handle *upstreamHandle, now time.Time) e
 		return nil
 	}
 
+	handle.sshServer.resource.SetExpiry(now.Add(c.serverTTL).UTC())
 	if _, err := c.auth.UpsertNode(c.closeContext, handle.sshServer.resource); err == nil {
 		if handle.sshServer.retryUpsert {
 			c.testEvent(sshUpsertRetryOk)


### PR DESCRIPTION
Backport #50488 to branch/v17

changelog: fixed SSH server heartbeats disappearing after a few minutes (since Teleport v17.1.0)