### PR TITLE
Refactor DocumentGateway and DocumentGatewayApp

### DIFF
--- a/web/packages/shared/hooks/useAsync.ts
+++ b/web/packages/shared/hooks/useAsync.ts
@@ -91,7 +91,7 @@ export function useAsync<Args extends unknown[], AttemptData>(
   const isMounted = useIsMounted();
   const asyncTask = useRef<Promise<AttemptData>>();
 
-  const run = useCallback(
+  const run: (...args: Args) => RunFuncReturnValue<AttemptData> = useCallback(
     (...args: Args) => {
       setState(prevState => ({
         status: 'processing',
@@ -311,3 +311,5 @@ export function useDelayedRepeatedAttempt<Data>(
 
   return currentAttempt;
 }
+
+export type RunFuncReturnValue<AttemptData> = Promise<[AttemptData, Error]>;

--- a/web/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.story.tsx
@@ -36,6 +36,7 @@ type StoryProps = {
   longValues: boolean;
   dbNameAttempt: 'not-started' | 'processing' | 'error';
   portAttempt: 'not-started' | 'processing' | 'error';
+  disconnectAttempt: 'not-started' | 'error';
   // Offline props.
   connectAttempt: 'not-started' | 'processing' | 'error';
 };
@@ -56,6 +57,11 @@ const meta: Meta<StoryProps> = {
       control: { type: 'radio' },
       options: ['not-started', 'processing', 'error'],
     },
+    disconnectAttempt: {
+      if: { arg: 'online' },
+      control: { type: 'radio' },
+      options: ['not-started', 'error'],
+    },
     // Offline props.
     connectAttempt: {
       if: { arg: 'online', truthy: false },
@@ -69,6 +75,7 @@ const meta: Meta<StoryProps> = {
     longValues: false,
     dbNameAttempt: 'not-started',
     portAttempt: 'not-started',
+    disconnectAttempt: 'not-started',
     // Offline props.
     connectAttempt: 'not-started',
   },
@@ -143,6 +150,7 @@ export function Story(props: StoryProps) {
     changeDbNameAttempt: makeEmptyAttempt(),
     changePort: async () => [undefined, null],
     changePortAttempt: makeEmptyAttempt(),
+    disconnectAttempt: makeEmptyAttempt(),
   };
 
   if (props.dbNameAttempt === 'error') {
@@ -161,6 +169,12 @@ export function Story(props: StoryProps) {
   }
   if (props.portAttempt === 'processing') {
     onlineDocumentGatewayProps.changePortAttempt = makeProcessingAttempt();
+  }
+
+  if (props.disconnectAttempt === 'error') {
+    onlineDocumentGatewayProps.disconnectAttempt = makeErrorAttempt(
+      new Error('Something went wrong with closing connection.')
+    );
   }
 
   return (

--- a/web/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.tsx
@@ -24,47 +24,52 @@ import { OfflineGateway } from '../components/OfflineGateway';
 import { useDocumentGateway } from './useDocumentGateway';
 import { OnlineDocumentGateway } from './OnlineDocumentGateway';
 
-type Props = {
+export function DocumentGateway(props: {
   visible: boolean;
   doc: types.DocumentGateway;
-};
-
-export default function Container(props: Props) {
+}) {
   const { doc, visible } = props;
-  const state = useDocumentGateway(doc);
-  return (
-    <Document visible={visible}>
-      <DocumentGateway {...state} targetName={doc.targetName} />
-    </Document>
-  );
-}
+  const {
+    connected,
+    // Needed for OfflineGateway.
+    connectAttempt,
+    reconnect,
+    defaultPort,
+    // Needed for OnlineDocumentGateway.
+    disconnect,
+    changeDbName,
+    changeDbNameAttempt,
+    changePortAttempt,
+    gateway,
+    changePort,
+    runCliCommand,
+  } = useDocumentGateway(doc);
 
-export type DocumentGatewayProps = ReturnType<typeof useDocumentGateway> & {
-  targetName: string;
-};
-
-export function DocumentGateway(props: DocumentGatewayProps) {
-  if (!props.connected) {
+  if (!connected) {
     return (
-      <OfflineGateway
-        connectAttempt={props.connectAttempt}
-        reconnect={props.reconnect}
-        gatewayPort={{ isSupported: true, defaultPort: props.defaultPort }}
-        targetName={props.targetName}
-        gatewayKind="database"
-      />
+      <Document visible={visible}>
+        <OfflineGateway
+          connectAttempt={connectAttempt}
+          reconnect={reconnect}
+          gatewayPort={{ isSupported: true, defaultPort }}
+          targetName={doc.targetName}
+          gatewayKind="database"
+        />
+      </Document>
     );
   }
 
   return (
-    <OnlineDocumentGateway
-      disconnect={props.disconnect}
-      changeDbName={props.changeDbName}
-      changeDbNameAttempt={props.changeDbNameAttempt}
-      changePortAttempt={props.changePortAttempt}
-      gateway={props.gateway}
-      changePort={props.changePort}
-      runCliCommand={props.runCliCommand}
-    />
+    <Document visible={visible}>
+      <OnlineDocumentGateway
+        disconnect={disconnect}
+        changeDbName={changeDbName}
+        changeDbNameAttempt={changeDbNameAttempt}
+        changePortAttempt={changePortAttempt}
+        gateway={gateway}
+        changePort={changePort}
+        runCliCommand={runCliCommand}
+      />
+    </Document>
   );
 }

--- a/web/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.tsx
@@ -41,8 +41,8 @@ export function DocumentGateway(props: {
     defaultPort,
     // Needed for OnlineDocumentGateway.
     gateway,
-    // TODO(ravicious): Show disconnectAttempt errors in UI.
     disconnect,
+    disconnectAttempt,
     changePort,
     changePortAttempt,
     changeTargetSubresourceNameAttempt: changeDbNameAttempt,
@@ -82,6 +82,7 @@ export function DocumentGateway(props: {
     <Document visible={visible}>
       <OnlineDocumentGateway
         disconnect={disconnect}
+        disconnectAttempt={disconnectAttempt}
         changeDbName={changeDbName}
         changeDbNameAttempt={changeDbNameAttempt}
         changePortAttempt={changePortAttempt}

--- a/web/packages/teleterm/src/ui/DocumentGateway/OnlineDocumentGateway.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGateway/OnlineDocumentGateway.tsx
@@ -18,7 +18,7 @@
 
 import { useMemo, useRef } from 'react';
 import { debounce } from 'shared/utils/highbar';
-import { Box, ButtonSecondary, Flex, H1, H2, Link, Text } from 'design';
+import { Alert, Box, ButtonSecondary, Flex, H1, H2, Link, Text } from 'design';
 import Validation from 'shared/components/Validation';
 import * as Alerts from 'design/Alert';
 
@@ -36,6 +36,7 @@ export function OnlineDocumentGateway(props: {
   changePort: (port: string) => RunFuncReturnValue<void>;
   changePortAttempt: Attempt<void>;
   disconnect: () => RunFuncReturnValue<void>;
+  disconnectAttempt: Attempt<void>;
   gateway: Gateway;
   runCliCommand: () => void;
 }) {
@@ -85,6 +86,13 @@ export function OnlineDocumentGateway(props: {
           Close Connection
         </ButtonSecondary>
       </Flex>
+
+      {props.disconnectAttempt.status === 'error' && (
+        <Alert details={props.disconnectAttempt.statusText}>
+          Could not close the connection
+        </Alert>
+      )}
+
       <H2 mb={2}>Connect with CLI</H2>
       <Flex as="form" ref={formRef}>
         <Validation>
@@ -110,6 +118,7 @@ export function OnlineDocumentGateway(props: {
         onButtonClick={props.runCliCommand}
       />
       {$errors}
+
       <H2 mt={3} mb={2}>
         Connect with GUI
       </H2>

--- a/web/packages/teleterm/src/ui/DocumentGateway/OnlineDocumentGateway.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGateway/OnlineDocumentGateway.tsx
@@ -22,23 +22,23 @@ import { Box, ButtonSecondary, Flex, H1, H2, Link, Text } from 'design';
 import Validation from 'shared/components/Validation';
 import * as Alerts from 'design/Alert';
 
+import { Attempt, RunFuncReturnValue } from 'shared/hooks/useAsync';
+
+import { Gateway } from 'gen-proto-ts/teleport/lib/teleterm/v1/gateway_pb';
+
 import { ConfigFieldInput, PortFieldInput } from '../components/FieldInputs';
 
 import { CliCommand } from './CliCommand';
-import { DocumentGatewayProps } from './DocumentGateway';
 
-type OnlineDocumentGatewayProps = Pick<
-  DocumentGatewayProps,
-  | 'changeDbNameAttempt'
-  | 'changePortAttempt'
-  | 'disconnect'
-  | 'changeDbName'
-  | 'changePort'
-  | 'gateway'
-  | 'runCliCommand'
->;
-
-export function OnlineDocumentGateway(props: OnlineDocumentGatewayProps) {
+export function OnlineDocumentGateway(props: {
+  changeDbName: (name: string) => RunFuncReturnValue<void>;
+  changeDbNameAttempt: Attempt<void>;
+  changePort: (port: string) => RunFuncReturnValue<void>;
+  changePortAttempt: Attempt<void>;
+  disconnect: () => RunFuncReturnValue<void>;
+  gateway: Gateway;
+  runCliCommand: () => void;
+}) {
   const isPortOrDbNameProcessing =
     props.changeDbNameAttempt.status === 'processing' ||
     props.changePortAttempt.status === 'processing';

--- a/web/packages/teleterm/src/ui/DocumentGateway/index.ts
+++ b/web/packages/teleterm/src/ui/DocumentGateway/index.ts
@@ -16,5 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import DocumentGateway from './DocumentGateway';
-export default DocumentGateway;
+export { DocumentGateway } from './DocumentGateway';

--- a/web/packages/teleterm/src/ui/DocumentGateway/useDocumentGateway.ts
+++ b/web/packages/teleterm/src/ui/DocumentGateway/useDocumentGateway.ts
@@ -19,13 +19,13 @@
 import { useEffect } from 'react';
 
 import { useAsync } from 'shared/hooks/useAsync';
+import { Gateway } from 'gen-proto-ts/teleport/lib/teleterm/v1/gateway_pb';
 
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import * as types from 'teleterm/ui/services/workspacesService';
 import { useWorkspaceContext } from 'teleterm/ui/Documents';
 import { retryWithRelogin } from 'teleterm/ui/utils';
 import * as tshdGateway from 'teleterm/services/tshd/gateway';
-import { Gateway } from 'teleterm/services/tshd/types';
 import { isDatabaseUri, isAppUri } from 'teleterm/ui/uri';
 
 export function useGateway(doc: types.DocumentGateway) {

--- a/web/packages/teleterm/src/ui/DocumentGateway/useGateway.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGateway/useGateway.test.tsx
@@ -29,7 +29,7 @@ import { DatabaseUri } from 'teleterm/ui/uri';
 import { WorkspaceContextProvider } from '../Documents';
 import { MockAppContextProvider } from '../fixtures/MockAppContextProvider';
 
-import { useDocumentGateway } from './useDocumentGateway';
+import { useGateway } from './useGateway';
 
 beforeEach(() => {
   jest.restoreAllMocks();
@@ -47,7 +47,7 @@ it('creates a gateway on mount if it does not exist already', async () => {
       return gateway;
     });
 
-  const { result } = renderHook(() => useDocumentGateway(doc), {
+  const { result } = renderHook(() => useGateway(doc), {
     wrapper: $wrapper,
   });
 
@@ -71,7 +71,7 @@ it('does not create a gateway on mount if the gateway already exists', async () 
   });
   jest.spyOn(appContext.clustersService, 'createGateway');
 
-  renderHook(() => useDocumentGateway(doc), {
+  renderHook(() => useGateway(doc), {
     wrapper: $wrapper,
   });
 
@@ -96,7 +96,7 @@ it('does not attempt to create a gateway immediately after closing it if the gat
     .spyOn(appContext.clustersService, 'createGateway')
     .mockResolvedValue(gateway);
 
-  const { result } = renderHook(() => useDocumentGateway(doc), {
+  const { result } = renderHook(() => useGateway(doc), {
     wrapper: $wrapper,
   });
 

--- a/web/packages/teleterm/src/ui/DocumentGateway/useGateway.ts
+++ b/web/packages/teleterm/src/ui/DocumentGateway/useGateway.ts
@@ -16,21 +16,21 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 
 import { useAsync } from 'shared/hooks/useAsync';
 import { Gateway } from 'gen-proto-ts/teleport/lib/teleterm/v1/gateway_pb';
 
 import { useAppContext } from 'teleterm/ui/appContextProvider';
-import * as types from 'teleterm/ui/services/workspacesService';
+import { DocumentGateway } from 'teleterm/ui/services/workspacesService';
 import { useWorkspaceContext } from 'teleterm/ui/Documents';
 import { retryWithRelogin } from 'teleterm/ui/utils';
-import * as tshdGateway from 'teleterm/services/tshd/gateway';
 import { isDatabaseUri, isAppUri } from 'teleterm/ui/uri';
+import { useStoreSelector } from 'teleterm/ui/hooks/useStoreSelector';
 
-export function useGateway(doc: types.DocumentGateway) {
+export function useGateway(doc: DocumentGateway) {
   const ctx = useAppContext();
-  const { documentsService: workspaceDocumentsService } = useWorkspaceContext();
+  const { documentsService } = useWorkspaceContext();
   // The port to show as default in the input field in case creating a gateway fails.
   // This is typically the case if someone reopens the app and the port of the gateway is already
   // occupied.
@@ -39,11 +39,14 @@ export function useGateway(doc: types.DocumentGateway) {
   // input to a controlled one once `doc.port` gets set. The backend will handle converting an empty
   // string to '0'.
   const defaultPort = doc.port || '';
-  const gateway = ctx.clustersService.findGateway(doc.gatewayUri);
+  const gateway = useStoreSelector(
+    'clustersService',
+    useCallback(state => state.gateways.get(doc.gatewayUri), [doc.gatewayUri])
+  );
   const connected = !!gateway;
 
   const [connectAttempt, createGateway] = useAsync(async (port: string) => {
-    workspaceDocumentsService.update(doc.uri, { status: 'connecting' });
+    documentsService.update(doc.uri, { status: 'connecting' });
     let gw: Gateway;
 
     try {
@@ -56,10 +59,10 @@ export function useGateway(doc: types.DocumentGateway) {
         })
       );
     } catch (error) {
-      workspaceDocumentsService.update(doc.uri, { status: 'error' });
+      documentsService.update(doc.uri, { status: 'error' });
       throw error;
     }
-    workspaceDocumentsService.update(doc.uri, {
+    documentsService.update(doc.uri, {
       gatewayUri: gw.uri,
       // Set the port on doc to match the one returned from the daemon. Teleterm doesn't let the
       // user provide a port for the gateway, so instead we have to let the daemon use a random
@@ -90,7 +93,7 @@ export function useGateway(doc: types.DocumentGateway) {
 
   const [disconnectAttempt, disconnect] = useAsync(async () => {
     await ctx.clustersService.removeGateway(doc.gatewayUri);
-    workspaceDocumentsService.close(doc.uri);
+    documentsService.close(doc.uri);
   });
 
   const [changeTargetSubresourceNameAttempt, changeTargetSubresourceName] =
@@ -101,7 +104,7 @@ export function useGateway(doc: types.DocumentGateway) {
           name
         );
 
-      workspaceDocumentsService.update(doc.uri, {
+      documentsService.update(doc.uri, {
         targetSubresourceName: updatedGateway.targetSubresourceName,
       });
     });
@@ -112,7 +115,7 @@ export function useGateway(doc: types.DocumentGateway) {
       port
     );
 
-    workspaceDocumentsService.update(doc.uri, {
+    documentsService.update(doc.uri, {
       targetSubresourceName: updatedGateway.targetSubresourceName,
       port: updatedGateway.localPort,
     });
@@ -143,59 +146,5 @@ export function useGateway(doc: types.DocumentGateway) {
     changeTargetSubresourceNameAttempt,
     changePort,
     changePortAttempt,
-  };
-}
-
-//TODO(gzdunek): Refactor DocumentGateway so the hook below is no longer needed.
-// We should move away from using one big hook per component.
-export function useDocumentGateway(doc: types.DocumentGateway) {
-  const { documentsService: workspaceDocumentsService } = useWorkspaceContext();
-
-  const {
-    gateway,
-    reconnect,
-    connectAttempt,
-    disconnectAttempt,
-    disconnect,
-    connected,
-    changePort,
-    changePortAttempt,
-    changeTargetSubresourceNameAttempt,
-    changeTargetSubresourceName,
-    defaultPort,
-  } = useGateway(doc);
-
-  const runCliCommand = () => {
-    if (!isDatabaseUri(doc.targetUri)) {
-      return;
-    }
-    const command = tshdGateway.getCliCommandArgv0(gateway.gatewayCliCommand);
-    const title = `${command} · ${doc.targetUser}@${doc.targetName}`;
-
-    const cliDoc = workspaceDocumentsService.createGatewayCliDocument({
-      title,
-      targetUri: doc.targetUri,
-      targetUser: doc.targetUser,
-      targetName: doc.targetName,
-      targetProtocol: gateway.protocol,
-    });
-    workspaceDocumentsService.add(cliDoc);
-    workspaceDocumentsService.setLocation(cliDoc.uri);
-  };
-
-  return {
-    reconnect,
-    connectAttempt,
-    // TODO(ravicious): Show disconnectAttempt errors in UI.
-    disconnectAttempt,
-    disconnect,
-    connected,
-    gateway,
-    changeDbNameAttempt: changeTargetSubresourceNameAttempt,
-    changePort,
-    changePortAttempt,
-    changeDbName: changeTargetSubresourceName,
-    defaultPort,
-    runCliCommand,
   };
 }

--- a/web/packages/teleterm/src/ui/DocumentGatewayApp/AppGateway.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGatewayApp/AppGateway.tsx
@@ -32,10 +32,8 @@ import {
 import Validation from 'shared/components/Validation';
 import { Attempt } from 'shared/hooks/useAsync';
 import { debounce } from 'shared/utils/highbar';
-
 import { TextSelectCopy } from 'shared/components/TextSelectCopy';
-
-import { Gateway } from 'teleterm/services/tshd/types';
+import { Gateway } from 'gen-proto-ts/teleport/lib/teleterm/v1/gateway_pb';
 
 import { PortFieldInput } from '../components/FieldInputs';
 
@@ -46,6 +44,7 @@ export function AppGateway(props: {
   changePortAttempt: Attempt<void>;
   disconnect(): void;
 }) {
+  const { gateway } = props;
   const formRef = useRef<HTMLFormElement>();
 
   const { changePort } = props;
@@ -57,7 +56,10 @@ export function AppGateway(props: {
     }, 1000);
   }, [changePort]);
 
-  const link = `${props.gateway.protocol.toLowerCase()}://${props.gateway.localAddress}:${props.gateway.localPort}`;
+  let address = `${gateway.localAddress}:${gateway.localPort}`;
+  if (gateway.protocol === 'HTTP') {
+    address = `http://${address}`;
+  }
 
   return (
     <Box maxWidth="680px" width="100%" mx="auto" mt="4" px="5">
@@ -76,7 +78,7 @@ export function AppGateway(props: {
         <Validation>
           <PortFieldInput
             label="Port"
-            defaultValue={props.gateway.localPort}
+            defaultValue={gateway.localPort}
             onChange={e => handleChangePort(e.target.value)}
             mb={2}
           />
@@ -92,7 +94,7 @@ export function AppGateway(props: {
         )}
       </Flex>
       <Text>Access the app at:</Text>
-      <TextSelectCopy my={1} text={link} bash={false} />
+      <TextSelectCopy my={1} text={address} bash={false} />
       {props.changePortAttempt.status === 'error' && (
         <Alert details={props.changePortAttempt.statusText}>
           Could not change the port number

--- a/web/packages/teleterm/src/ui/DocumentGatewayApp/AppGateway.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGatewayApp/AppGateway.tsx
@@ -65,15 +65,17 @@ export function AppGateway(props: {
     <Box maxWidth="680px" width="100%" mx="auto" mt="4" px="5">
       <Flex justifyContent="space-between" mb="3" flexWrap="wrap" gap={2}>
         <H1>App Connection</H1>
-        {props.disconnectAttempt.status === 'error' && (
-          <Alert details={props.disconnectAttempt.statusText}>
-            Could not close the connection
-          </Alert>
-        )}
         <ButtonSecondary size="small" onClick={props.disconnect}>
           Close Connection
         </ButtonSecondary>
       </Flex>
+
+      {props.disconnectAttempt.status === 'error' && (
+        <Alert details={props.disconnectAttempt.statusText}>
+          Could not close the connection
+        </Alert>
+      )}
+
       <Flex as="form" ref={formRef} gap={2}>
         <Validation>
           <PortFieldInput
@@ -93,13 +95,16 @@ export function AppGateway(props: {
           />
         )}
       </Flex>
+
       <Text>Access the app at:</Text>
       <TextSelectCopy my={1} text={address} bash={false} />
+
       {props.changePortAttempt.status === 'error' && (
         <Alert details={props.changePortAttempt.statusText}>
           Could not change the port number
         </Alert>
       )}
+
       <Text>
         The connection is made through an authenticated proxy so no extra
         credentials are necessary. See{' '}

--- a/web/packages/teleterm/src/ui/DocumentGatewayApp/DocumentGatewayApp.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGatewayApp/DocumentGatewayApp.tsx
@@ -15,12 +15,10 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { DocumentGateway } from 'teleterm/ui/services/workspacesService';
 import Document from 'teleterm/ui/Document';
 
-import { useDocumentGateway } from '../DocumentGateway/useDocumentGateway';
+import { useGateway } from '../DocumentGateway/useGateway';
 
 import { OfflineGateway } from '../components/OfflineGateway';
 
@@ -30,7 +28,7 @@ export function DocumentGatewayApp(props: {
   doc: DocumentGateway;
   visible: boolean;
 }) {
-  const ctx = useAppContext();
+  const { doc } = props;
   const {
     gateway,
     changePort,
@@ -40,9 +38,7 @@ export function DocumentGatewayApp(props: {
     disconnect,
     disconnectAttempt,
     reconnect,
-  } = useDocumentGateway(props.doc);
-
-  ctx.clustersService.useState();
+  } = useGateway(doc);
 
   return (
     <Document visible={props.visible}>
@@ -50,8 +46,8 @@ export function DocumentGatewayApp(props: {
         <OfflineGateway
           connectAttempt={connectAttempt}
           gatewayKind="app"
-          targetName={props.doc.targetName}
-          gatewayPort={{ isSupported: true, defaultPort: props.doc.port }}
+          targetName={doc.targetName}
+          gatewayPort={{ isSupported: true, defaultPort: doc.port }}
           reconnect={reconnect}
         />
       ) : (

--- a/web/packages/teleterm/src/ui/Documents/DocumentsRenderer.tsx
+++ b/web/packages/teleterm/src/ui/Documents/DocumentsRenderer.tsx
@@ -32,7 +32,7 @@ import {
   Workspace,
 } from 'teleterm/ui/services/workspacesService';
 import DocumentCluster from 'teleterm/ui/DocumentCluster';
-import DocumentGateway from 'teleterm/ui/DocumentGateway';
+import { DocumentGateway } from 'teleterm/ui/DocumentGateway';
 import { DocumentTerminal } from 'teleterm/ui/DocumentTerminal';
 import {
   ConnectMyComputerContextProvider,

--- a/web/packages/teleterm/src/ui/components/FieldInputs.tsx
+++ b/web/packages/teleterm/src/ui/components/FieldInputs.tsx
@@ -16,32 +16,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import FieldInput from 'shared/components/FieldInput';
-import styled from 'styled-components';
+import FieldInput, { FieldInputProps } from 'shared/components/FieldInput';
 import { forwardRef } from 'react';
-import { FieldInputProps } from 'shared/components/FieldInput';
 
 export const ConfigFieldInput = forwardRef<HTMLInputElement, FieldInputProps>(
   (props, ref) => <FieldInput size="small" ref={ref} {...props} />
 );
 
-const ConfigFieldInputWithoutStepper = styled(ConfigFieldInput)`
-  input {
-    ::-webkit-inner-spin-button {
-      -webkit-appearance: none;
-      margin: 0;
-    }
-
-    ::-webkit-outer-spin-button {
-      -webkit-appearance: none;
-      margin: 0;
-    }
-  }
-`;
-
 export const PortFieldInput = forwardRef<HTMLInputElement, FieldInputProps>(
   (props, ref) => (
-    <ConfigFieldInputWithoutStepper
+    <ConfigFieldInput
       type="number"
       min={1}
       max={65535}


### PR DESCRIPTION
A bunch of improvements that I've made while working on adding multi-port support to local proxies in Connect.

I completely removed `useDocumentGateway`. It was shared between db and app gateways, it already had a bunch of db-specific things and I needed to add some app-specific stuff.