### PR TITLE
[v15] fix a config indentation bug in the tbot chart

### DIFF
--- a/examples/chart/tbot/.lint/full.yaml
+++ b/examples/chart/tbot/.lint/full.yaml
@@ -1,7 +1,7 @@
 clusterName: "test.teleport.sh"
 teleportAuthAddress: "my-auth:3024"
 defaultOutput:
-  enabled: false
+  enabled: true
 token: "my-token"
 joinMethod: "modified-join-method"
 

--- a/examples/chart/tbot/templates/_config.tpl
+++ b/examples/chart/tbot/templates/_config.tpl
@@ -40,10 +40,10 @@ outputs:
       name: {{ include "tbot.defaultOutputName" . }}
 {{- end }}
 {{- if .Values.outputs }}
-{{- toYaml .Values.outputs | nindent 6}}
+{{- toYaml .Values.outputs | nindent 2}}
 {{- end }}
 {{- end }}
 {{- if .Values.services }}
-services: {{- toYaml .Values.services | nindent 6}}
+services: {{- toYaml .Values.services | nindent 2}}
 {{- end }}
 {{- end -}}

--- a/examples/chart/tbot/tests/__snapshot__/config_test.yaml.snap
+++ b/examples/chart/tbot/tests/__snapshot__/config_test.yaml.snap
@@ -35,6 +35,10 @@ should match the snapshot (full):
           join_method: modified-join-method
           token: my-token
         outputs:
+        - destination:
+            name: RELEASE-NAME-tbot-out
+            type: kubernetes_secret
+          type: identity
         - app_name: foo
           destination:
             path: /bar

--- a/examples/chart/tbot/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/tbot/tests/__snapshot__/deployment_test.yaml.snap
@@ -22,7 +22,7 @@ should match the snapshot (full):
       template:
         metadata:
           annotations:
-            checksum/config: 094cdbfc4e4fe3824a33426d8eea4e9e8a4b2711823d4fbb4102e11caa7f62c0
+            checksum/config: 010d3421120a26bed12d1b9df8443e0eeafa362e88bd830e4a81688d13689483
             test-key: test-annotation-pod
           labels:
             app.kubernetes.io/component: tbot


### PR DESCRIPTION
Backport #50518 to branch/v15

changelog: Fix a bug in the `tbot` Helm chart causing invalid configuration when both default and custom outputs were used.
