### PR TITLE
Web: Add MarkInverse and ResourceLabelTooltip contents

### DIFF
--- a/web/packages/design/src/Mark/Mark.story.tsx
+++ b/web/packages/design/src/Mark/Mark.story.tsx
@@ -19,7 +19,7 @@
 import Box from 'design/Box';
 import { IconTooltip } from 'design/Tooltip';
 
-import { Mark as M, MarkForToolTip } from './Mark';
+import { Mark as M, MarkInverse } from './Mark';
 
 export default {
   title: 'Design/Mark',
@@ -39,8 +39,6 @@ export const SampleText = () => {
         <b>necessitatibus</b>
       </M>{' '}
       obcaecati asperiores neque.
-      <br />
-      <br />
     </Box>
   );
 };
@@ -48,8 +46,8 @@ export const SampleText = () => {
 export const MarkInsideTooltip = () => {
   return (
     <IconTooltip>
-      Example of <MarkForToolTip>MarkForToolTip</MarkForToolTip>. Note the{' '}
-      <MarkForToolTip>inversed</MarkForToolTip> background and text color.
+      Example of <MarkInverse>MarkForToolTip</MarkInverse>. Note the{' '}
+      <MarkInverse>inversed</MarkInverse> background and text color.
     </IconTooltip>
   );
 };

--- a/web/packages/design/src/Mark/Mark.story.tsx
+++ b/web/packages/design/src/Mark/Mark.story.tsx
@@ -17,8 +17,9 @@
  */
 
 import Box from 'design/Box';
+import { IconTooltip } from 'design/Tooltip';
 
-import { Mark as M } from './Mark';
+import { Mark as M, MarkForToolTip } from './Mark';
 
 export default {
   title: 'Design/Mark',
@@ -38,6 +39,17 @@ export const SampleText = () => {
         <b>necessitatibus</b>
       </M>{' '}
       obcaecati asperiores neque.
+      <br />
+      <br />
     </Box>
+  );
+};
+
+export const MarkInsideTooltip = () => {
+  return (
+    <IconTooltip>
+      Example of <MarkForToolTip>MarkForToolTip</MarkForToolTip>. Note the{' '}
+      <MarkForToolTip>inversed</MarkForToolTip> background and text color.
+    </IconTooltip>
   );
 };

--- a/web/packages/design/src/Mark/Mark.story.tsx
+++ b/web/packages/design/src/Mark/Mark.story.tsx
@@ -46,7 +46,7 @@ export const SampleText = () => {
 export const MarkInsideTooltip = () => {
   return (
     <IconTooltip>
-      Example of <MarkInverse>MarkForToolTip</MarkInverse>. Note the{' '}
+      Example of <MarkInverse>MarkInverse</MarkInverse> component. Note the{' '}
       <MarkInverse>inversed</MarkInverse> background and text color.
     </IconTooltip>
   );

--- a/web/packages/design/src/Mark/Mark.tsx
+++ b/web/packages/design/src/Mark/Mark.tsx
@@ -26,3 +26,8 @@ export const Mark = styled.mark`
   background-color: ${p => p.theme.colors.interactive.tonal.neutral[2]};
   color: inherit;
 `;
+
+export const MarkForToolTip = styled(Mark)`
+  background-color: ${p => p.theme.colors.tooltip.inverseBackground};
+  color: ${p => p.theme.colors.text.main};
+`;

--- a/web/packages/design/src/Mark/Mark.tsx
+++ b/web/packages/design/src/Mark/Mark.tsx
@@ -27,7 +27,7 @@ export const Mark = styled.mark`
   color: inherit;
 `;
 
-export const MarkForToolTip = styled(Mark)`
+export const MarkInverse = styled(Mark)`
   background-color: ${p => p.theme.colors.tooltip.inverseBackground};
   color: ${p => p.theme.colors.text.main};
 `;

--- a/web/packages/design/src/Mark/Mark.tsx
+++ b/web/packages/design/src/Mark/Mark.tsx
@@ -27,6 +27,14 @@ export const Mark = styled.mark`
   color: inherit;
 `;
 
+/**
+ * Returns a MarkInverse that inverts the colors from its parent Mark.
+ * For example, if current theme is dark theme, parent Mark would use
+ * light colors, but MarkInverse will use dark colors.
+ *
+ * Intended for use in tooltips since tooltips uses inverse background
+ * color of the current theme.
+ */
 export const MarkInverse = styled(Mark)`
   background-color: ${p => p.theme.colors.tooltip.inverseBackground};
   color: ${p => p.theme.colors.text.main};

--- a/web/packages/design/src/Mark/index.ts
+++ b/web/packages/design/src/Mark/index.ts
@@ -16,4 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export { Mark, MarkForToolTip } from './Mark';
+export { Mark, MarkInverse } from './Mark';

--- a/web/packages/design/src/Mark/index.ts
+++ b/web/packages/design/src/Mark/index.ts
@@ -16,4 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export { Mark } from './Mark';
+export { Mark, MarkForToolTip } from './Mark';

--- a/web/packages/design/src/theme/themes/bblpTheme.ts
+++ b/web/packages/design/src/theme/themes/bblpTheme.ts
@@ -204,6 +204,7 @@ const colors: ThemeColors = {
 
   tooltip: {
     background: 'rgba(255, 255, 255, 0.8)',
+    inverseBackground: 'rgba(0, 0, 0, 0.5)',
   },
 
   progressBarColor: '#00BFA5',

--- a/web/packages/design/src/theme/themes/darkTheme.ts
+++ b/web/packages/design/src/theme/themes/darkTheme.ts
@@ -203,6 +203,7 @@ const colors: ThemeColors = {
 
   tooltip: {
     background: 'rgba(255, 255, 255, 0.8)',
+    inverseBackground: 'rgba(0, 0, 0, 0.5)',
   },
 
   progressBarColor: '#00BFA5',

--- a/web/packages/design/src/theme/themes/lightTheme.ts
+++ b/web/packages/design/src/theme/themes/lightTheme.ts
@@ -202,6 +202,7 @@ const colors: ThemeColors = {
 
   tooltip: {
     background: 'rgba(0, 0, 0, 0.80)',
+    inverseBackground: 'rgba(255, 255, 255, 0.5)',
   },
 
   progressBarColor: '#007D6B',

--- a/web/packages/design/src/theme/themes/types.ts
+++ b/web/packages/design/src/theme/themes/types.ts
@@ -141,6 +141,7 @@ export type ThemeColors = {
 
   tooltip: {
     background: string;
+    inverseBackground: string;
   };
 
   progressBarColor: string;

--- a/web/packages/shared/components/ButtonTextWithAddIcon/ButtonTextWithAddIcon.tsx
+++ b/web/packages/shared/components/ButtonTextWithAddIcon/ButtonTextWithAddIcon.tsx
@@ -33,7 +33,7 @@ export const ButtonTextWithAddIcon = ({
   iconSize?: IconSize;
 }) => {
   return (
-    <ButtonText onClick={onClick} disabled={disabled} compact>
+    <ButtonText onClick={onClick} disabled={disabled} compact pr={2}>
       <AddIcon
         className="icon-add"
         size={iconSize}

--- a/web/packages/teleport/src/Discover/Shared/ResourceLabelTooltip/ResourceLabelTooltip.story.tsx
+++ b/web/packages/teleport/src/Discover/Shared/ResourceLabelTooltip/ResourceLabelTooltip.story.tsx
@@ -1,0 +1,29 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ResourceLabelTooltip } from './ResourceLabelTooltip';
+
+export default {
+  title: 'Teleport/Discover/Shared/ResourceLabelTooltip',
+};
+
+export const RDS = () => <ResourceLabelTooltip resourceKind="rds" />;
+export const EKS = () => <ResourceLabelTooltip resourceKind="eks" />;
+export const Server = () => <ResourceLabelTooltip resourceKind="server" />;
+export const Database = () => <ResourceLabelTooltip resourceKind="db" />;
+export const Kube = () => <ResourceLabelTooltip resourceKind="kube" />;

--- a/web/packages/teleport/src/Discover/Shared/ResourceLabelTooltip/ResourceLabelTooltip.tsx
+++ b/web/packages/teleport/src/Discover/Shared/ResourceLabelTooltip/ResourceLabelTooltip.tsx
@@ -17,7 +17,7 @@
  */
 
 import Link from 'design/Link';
-import { MarkForToolTip } from 'design/Mark';
+import { MarkInverse } from 'design/Mark';
 import { Position } from 'design/Popover/Popover';
 import { IconTooltip } from 'design/Tooltip';
 import styled from 'styled-components';
@@ -48,8 +48,8 @@ export function ResourceLabelTooltip({
               >
                 Teleport RBAC
               </Link>
-              . Only roles with <MarkForToolTip>node_labels</MarkForToolTip>{' '}
-              that match these labels will be allowed to access this server.
+              . Only roles with <MarkInverse>node_labels</MarkInverse> that
+              match these labels will be allowed to access this server.
             </li>
           </Ul>
         </>
@@ -74,9 +74,9 @@ export function ResourceLabelTooltip({
               >
                 Teleport RBAC
               </Link>
-              . Only roles with{' '}
-              <MarkForToolTip>kubernetes_labels</MarkForToolTip> that match
-              these labels will be allowed to access this Kubernetes cluster.
+              . Only roles with <MarkInverse>kubernetes_labels</MarkInverse>{' '}
+              that match these labels will be allowed to access this Kubernetes
+              cluster.
             </li>
             {resourceKind === 'eks' && (
               <li>
@@ -106,8 +106,8 @@ export function ResourceLabelTooltip({
               >
                 Teleport RBAC
               </Link>
-              . Only roles with <MarkForToolTip>db_labels</MarkForToolTip> that
-              match these labels will be allowed to access this database.
+              . Only roles with <MarkInverse>db_labels</MarkInverse> that match
+              these labels will be allowed to access this database.
             </li>
             {resourceKind === 'rds' && (
               <li>

--- a/web/packages/teleport/src/Discover/Shared/ResourceLabelTooltip/ResourceLabelTooltip.tsx
+++ b/web/packages/teleport/src/Discover/Shared/ResourceLabelTooltip/ResourceLabelTooltip.tsx
@@ -1,0 +1,137 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Link from 'design/Link';
+import { MarkForToolTip } from 'design/Mark';
+import { Position } from 'design/Popover/Popover';
+import { IconTooltip } from 'design/Tooltip';
+import styled from 'styled-components';
+
+export function ResourceLabelTooltip({
+  resourceKind,
+  toolTipPosition,
+}: {
+  resourceKind: 'server' | 'eks' | 'rds' | 'kube' | 'db';
+  toolTipPosition?: Position;
+}) {
+  let tip;
+
+  switch (resourceKind) {
+    case 'server': {
+      tip = (
+        <>
+          Labels allow you to do the following:
+          <Ul>
+            <li>
+              Filter servers by labels when using tsh, tctl, or the web UI
+            </li>
+            <li>
+              Restrict access to this server with{' '}
+              <Link
+                target="_blank"
+                href="https://goteleport.com/docs/enroll-resources/server-access/rbac/"
+              >
+                Teleport RBAC
+              </Link>
+              . Only roles with <MarkForToolTip>node_labels</MarkForToolTip>{' '}
+              that match these labels will be allowed to access this server.
+            </li>
+          </Ul>
+        </>
+      );
+      break;
+    }
+    case 'kube':
+    case 'eks': {
+      tip = (
+        <>
+          Labels allow you to do the following:
+          <Ul>
+            <li>
+              Filter Kubernetes clusters by labels when using tsh, tctl, or the
+              web UI
+            </li>
+            <li>
+              Restrict access to this Kubernetes cluster with{' '}
+              <Link
+                target="_blank"
+                href="https://goteleport.com/docs/enroll-resources/kubernetes-access/controls/"
+              >
+                Teleport RBAC
+              </Link>
+              . Only roles with{' '}
+              <MarkForToolTip>kubernetes_labels</MarkForToolTip> that match
+              these labels will be allowed to access this Kubernetes cluster.
+            </li>
+            {resourceKind === 'eks' && (
+              <li>
+                All the AWS tags from the selected EKS will be included upon
+                enrollment.
+              </li>
+            )}
+          </Ul>
+        </>
+      );
+      break;
+    }
+    case 'rds':
+    case 'db': {
+      tip = (
+        <>
+          Labels allow you to do the following:
+          <Ul>
+            <li>
+              Filter databases by labels when using tsh, tctl, or the web UI
+            </li>
+            <li>
+              Restrict access to this database with{' '}
+              <Link
+                target="_blank"
+                href="https://goteleport.com/docs/enroll-resources/database-access/rbac/"
+              >
+                Teleport RBAC
+              </Link>
+              . Only roles with <MarkForToolTip>db_labels</MarkForToolTip> that
+              match these labels will be allowed to access this database.
+            </li>
+            {resourceKind === 'rds' && (
+              <li>
+                All the AWS tags from the selected RDS will be included upon
+                enrollment.
+              </li>
+            )}
+          </Ul>
+        </>
+      );
+      break;
+    }
+    default:
+      resourceKind satisfies never;
+  }
+
+  return (
+    <IconTooltip sticky={true} position={toolTipPosition}>
+      {tip}
+    </IconTooltip>
+  );
+}
+
+const Ul = styled.ul`
+  margin: 0;
+  padding-left: ${p => p.theme.space[4]}px;
+`;

--- a/web/packages/teleport/src/Discover/Shared/ResourceLabelTooltip/ResourceLabelTooltip.tsx
+++ b/web/packages/teleport/src/Discover/Shared/ResourceLabelTooltip/ResourceLabelTooltip.tsx
@@ -22,6 +22,16 @@ import { Position } from 'design/Popover/Popover';
 import { IconTooltip } from 'design/Tooltip';
 import styled from 'styled-components';
 
+/**
+ * Returns a IconTooltip component with its tip contents
+ * set to the requested resource kind.
+ *
+ * @param resourceKind - the tip contents differ slightly depending
+ * on the resource kind
+ * @param toolTipPosition (opt) - the position which the tooltip should
+ * render (see type Position)
+ * @returns JSX Element
+ */
 export function ResourceLabelTooltip({
   resourceKind,
   toolTipPosition,
@@ -38,7 +48,7 @@ export function ResourceLabelTooltip({
           Labels allow you to do the following:
           <Ul>
             <li>
-              Filter servers by labels when using tsh, tctl, or the web UI
+              Filter servers by labels when using tsh, tctl, or the web UI.
             </li>
             <li>
               Restrict access to this server with{' '}
@@ -64,7 +74,7 @@ export function ResourceLabelTooltip({
           <Ul>
             <li>
               Filter Kubernetes clusters by labels when using tsh, tctl, or the
-              web UI
+              web UI.
             </li>
             <li>
               Restrict access to this Kubernetes cluster with{' '}
@@ -96,7 +106,7 @@ export function ResourceLabelTooltip({
           Labels allow you to do the following:
           <Ul>
             <li>
-              Filter databases by labels when using tsh, tctl, or the web UI
+              Filter databases by labels when using tsh, tctl, or the web UI.
             </li>
             <li>
               Restrict access to this database with{' '}

--- a/web/packages/teleport/src/Discover/Shared/ResourceLabelTooltip/index.ts
+++ b/web/packages/teleport/src/Discover/Shared/ResourceLabelTooltip/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export { ResourceLabelTooltip } from './ResourceLabelTooltip';


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/46976

This PR
- adds an inverse version of `Mark` to be used inside `Tooltips`, otherwise `Mark` is invisible. Tooltips uses inverse background color of main theme (eg: tooltips for dark theme uses light background and vice versa). 
- adds a single place to get tooltip content to explain user provided labels

Screenshots
RDS - dark theme
<img width="398" alt="image" src="https://github.com/user-attachments/assets/63eae036-41b1-416c-9086-8775f0d64d5a" />

EKS - dark theme
<img width="403" alt="image" src="https://github.com/user-attachments/assets/6728cbae-0377-4875-998a-250893fc08b5" />

SERVER - light theme
<img width="412" alt="image" src="https://github.com/user-attachments/assets/cdb53b9c-9f28-4d32-a1f9-c219f6cc1488" />

DATABASE - light theme
<img width="414" alt="image" src="https://github.com/user-attachments/assets/1a8acdd1-b190-4954-ae12-bb2fe51632df" />

KUBE - bblp theme
<img width="415" alt="image" src="https://github.com/user-attachments/assets/c071bf14-3796-4ad5-9415-042c04c2d69f" />
