### PR TITLE
Complete CSRF cleanup for Teleport 18

### DIFF
--- a/integration/appaccess/pack.go
+++ b/integration/appaccess/pack.go
@@ -49,7 +49,6 @@ import (
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/events"
-	"github.com/gravitational/teleport/lib/httplib/csrf"
 	"github.com/gravitational/teleport/lib/httplib/reverseproxy"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/service"
@@ -251,15 +250,9 @@ func (p *Pack) initWebSession(t *testing.T) {
 	req, err := http.NewRequest(http.MethodPost, u.String(), bytes.NewBuffer(csReq))
 	require.NoError(t, err)
 
-	// Attach CSRF token in cookie and header.
-	csrfToken, err := utils.CryptoRandomHex(32)
-	require.NoError(t, err)
-	req.AddCookie(&http.Cookie{
-		Name:  csrf.CookieName,
-		Value: csrfToken,
-	})
+	// Set Content-Type header, otherwise Teleport's CSRF protection will
+	// reject the request.
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
-	req.Header.Set(csrf.HeaderName, csrfToken)
 
 	// Issue request.
 	client := &http.Client{

--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -60,7 +60,6 @@ import (
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
-	"github.com/gravitational/teleport/lib/httplib/csrf"
 	"github.com/gravitational/teleport/lib/observability/tracing"
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -1531,18 +1530,7 @@ func CreateWebSession(proxyHost, user, password string) (*web.CreateSessionRespo
 		return nil, nil, trace.Wrap(err)
 	}
 
-	// Attach CSRF token in cookie and header.
-	csrfToken, err := utils.CryptoRandomHex(32)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-
-	req.AddCookie(&http.Cookie{
-		Name:  csrf.CookieName,
-		Value: csrfToken,
-	})
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
-	req.Header.Set(csrf.HeaderName, csrfToken)
 
 	// Issue request.
 	httpClient := &http.Client{

--- a/integration/helpers/web.go
+++ b/integration/helpers/web.go
@@ -34,8 +34,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/lib/client"
-	"github.com/gravitational/teleport/lib/httplib/csrf"
-	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/web"
 	websession "github.com/gravitational/teleport/lib/web/session"
 	"github.com/gravitational/teleport/lib/web/ui"
@@ -68,15 +66,7 @@ func LoginWebClient(t *testing.T, host, username, password string) *WebClientPac
 	req, err := http.NewRequest(http.MethodPost, u.String(), bytes.NewBuffer(csReq))
 	require.NoError(t, err)
 
-	// Attach CSRF token in cookie and header.
-	csrfToken, err := utils.CryptoRandomHex(32)
-	require.NoError(t, err)
-	req.AddCookie(&http.Cookie{
-		Name:  csrf.CookieName,
-		Value: csrfToken,
-	})
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
-	req.Header.Set(csrf.HeaderName, csrfToken)
 
 	// Issue request.
 	client := &http.Client{

--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -21,9 +21,7 @@ package client
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
 	"crypto/x509"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -50,7 +48,6 @@ import (
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/httplib"
-	"github.com/gravitational/teleport/lib/httplib/csrf"
 	websession "github.com/gravitational/teleport/lib/web/session"
 )
 
@@ -913,12 +910,6 @@ func SSHAgentLoginWeb(ctx context.Context, login SSHLoginDirect) (*WebClient, ty
 		return nil, nil, trace.Wrap(err)
 	}
 
-	token := make([]byte, 32)
-	if _, err := rand.Read(token); err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-
-	csrfToken := hex.EncodeToString(token)
 	resp, err := httplib.ConvertResponse(clt.RoundTrip(func() (*http.Response, error) {
 		var buf bytes.Buffer
 		if err := json.NewEncoder(&buf).Encode(&CreateWebSessionReq{
@@ -934,15 +925,7 @@ func SSHAgentLoginWeb(ctx context.Context, login SSHLoginDirect) (*WebClient, ty
 			return nil, err
 		}
 
-		cookie := &http.Cookie{
-			Name:  csrf.CookieName,
-			Value: csrfToken,
-		}
-
-		req.AddCookie(cookie)
-
 		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set(csrf.HeaderName, csrfToken)
 		return clt.HTTPClient().Do(req)
 	}))
 	if err != nil {

--- a/lib/httplib/csrf/csrf.go
+++ b/lib/httplib/csrf/csrf.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+// Package csrf is used to protect against login CSRF in Teleport's SSO flows.
 package csrf
 
 import (
@@ -29,70 +30,33 @@ import (
 )
 
 const (
-	// CookieName is the name of the CSRF cookie. It's prefixed with "__Host-" as
-	// an additional defense in depth measure. It makes sure it is sent from a
-	// secure page (HTTPS), won't be sent to subdomains, and the path attribute
-	// is set to /.
+	// CookieName is the name of the CSRF cookie used to protect against login
+	// CSRF in Teleport's SSO flows.
+	//
+	// It's prefixed with "__Host-" as an additional defense in depth measure.
+	// This makes sure the cookie is sent from a secure page (HTTPS),
+	// won't be sent to subdomains, and the path attribute is set to /.
 	CookieName = "__Host-grv_csrf"
 	// HeaderName is the default HTTP request header to inspect.
 	HeaderName = "X-CSRF-Token"
-	// FormFieldName is the default form field to inspect.
-	FormFieldName = "csrf_token"
-	// tokenLenBytes is CSRF token length in bytes.
-	tokenLenBytes = 32
-	// defaultMaxAge is the default MaxAge for cookies.
-	defaultMaxAge = 0
 )
 
-// GenerateToken generates a random CSRF token.
-func GenerateToken() (string, error) {
-	return utils.CryptoRandomHex(tokenLenBytes)
-}
+// tokenLenBytes is the length of a raw CSRF token prior to encoding
+const tokenLenBytes = 32
 
-// AddCSRFProtection adds CSRF token into the user session via secure cookie,
-// it implements "double submit cookie" approach to check against CSRF attacks
-// https://www.owasp.org/index.php/Cross-Site_Request_Forgery_%28CSRF%29_Prevention_Cheat_Sheet#Double_Submit_Cookie
+// AddCSRFProtection adds CSRF token into the user session via a secure cookie.
+// This CSRF token is used to protect against login CSRF in Teleport's SSO flows.
 func AddCSRFProtection(w http.ResponseWriter, r *http.Request) (string, error) {
 	token, err := ExtractTokenFromCookie(r)
 	// if there was an error retrieving the token, the token doesn't exist
 	if err != nil || len(token) == 0 {
-		token, err = GenerateToken()
+		token, err = utils.CryptoRandomHex(tokenLenBytes)
 		if err != nil {
 			return "", trace.Wrap(err)
 		}
 	}
 	save(token, w)
 	return token, nil
-}
-
-// VerifyHTTPHeader checks if HTTP header value matches the cookie.
-func VerifyHTTPHeader(r *http.Request) error {
-	token := r.Header.Get(HeaderName)
-	if len(token) == 0 {
-		return trace.BadParameter("cannot retrieve CSRF token from HTTP header %q", HeaderName)
-	}
-
-	err := VerifyToken(token, r)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	return nil
-}
-
-// VerifyFormField checks if HTTP form value matches the cookie.
-func VerifyFormField(r *http.Request) error {
-	token := r.FormValue(FormFieldName)
-	if len(token) == 0 {
-		return trace.BadParameter("cannot retrieve CSRF token from form field %q", FormFieldName)
-	}
-
-	err := VerifyToken(token, r)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	return nil
 }
 
 // VerifyToken validates given token based on HTTP request cookie
@@ -112,7 +76,7 @@ func VerifyToken(token string, r *http.Request) error {
 		return trace.Wrap(err, "unable to decode cookie CSRF token")
 	}
 
-	if !compareTokens(decodedTokenA, decodedTokenB) {
+	if subtle.ConstantTimeCompare(decodedTokenA, decodedTokenB) != 1 {
 		return trace.BadParameter("CSRF tokens do not match")
 	}
 
@@ -129,7 +93,7 @@ func ExtractTokenFromCookie(r *http.Request) (string, error) {
 	return cookie.Value, nil
 }
 
-// decode decodes a cookie using base64.
+// decode decodes a hex-encoded CSRF token.
 func decode(token string) ([]byte, error) {
 	decoded, err := hex.DecodeString(token)
 	if err != nil {
@@ -143,17 +107,11 @@ func decode(token string) ([]byte, error) {
 	return decoded, nil
 }
 
-// compareTokens securely (constant-time) compares CSRF tokens
-func compareTokens(a, b []byte) bool {
-	return subtle.ConstantTimeCompare(a, b) == 1
-}
-
 // save stores encoded CSRF token in the session cookie.
 func save(encodedToken string, w http.ResponseWriter) string {
 	cookie := &http.Cookie{
-		Name:   CookieName,
-		Value:  encodedToken,
-		MaxAge: defaultMaxAge,
+		Name:  CookieName,
+		Value: encodedToken,
 		// Set SameSite to none so browsers preserve gravitational CSRF cookie
 		// while processing SSO providers redirects.
 		SameSite: http.SameSiteNoneMode,

--- a/lib/httplib/csrf/csrf.go
+++ b/lib/httplib/csrf/csrf.go
@@ -29,17 +29,13 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-const (
-	// CookieName is the name of the CSRF cookie used to protect against login
-	// CSRF in Teleport's SSO flows.
-	//
-	// It's prefixed with "__Host-" as an additional defense in depth measure.
-	// This makes sure the cookie is sent from a secure page (HTTPS),
-	// won't be sent to subdomains, and the path attribute is set to /.
-	CookieName = "__Host-grv_csrf"
-	// HeaderName is the default HTTP request header to inspect.
-	HeaderName = "X-CSRF-Token"
-)
+// CookieName is the name of the CSRF cookie used to protect against login
+// CSRF in Teleport's SSO flows.
+//
+// It's prefixed with "__Host-" as an additional defense in depth measure.
+// This makes sure the cookie is sent from a secure page (HTTPS),
+// won't be sent to subdomains, and the path attribute is set to /.
+const CookieName = "__Host-grv_csrf"
 
 // tokenLenBytes is the length of a raw CSRF token prior to encoding
 const tokenLenBytes = 32


### PR DESCRIPTION
This is the last OSS PR planned to simplify our CSRF package going forward.

Best to review commit-by-commit.

- The first commit is a partial revert that restores the use of CSRF tokens in SSO flows.
  SSO flows are the one case where we need to rely on a cookie with a CSRF token because
  a bearer token is not available to users prior to authenticating.
- The 2nd commit removes some unused code and makes it clear that our CSRF package is now
  focused solely on protecting against _login CSRF_.
- The final commit cleans up some tests that no longer need to provide a CSRF cookie
  and expands our godocs in a few important areas.