### PR TITLE
update tbot init error message

### DIFF
--- a/tool/tbot/init.go
+++ b/tool/tbot/init.go
@@ -451,7 +451,7 @@ func onInit(globals *cli.GlobalArgs, init *cli.InitCommand) error {
 			}
 		}
 		if target == nil {
-			return trace.NotFound("Could not find specified destination %q", init.InitDir)
+			return trace.NotFound("Initial directory %q must match a destination directory from the configuration file or --destination-dir parameter", init.InitDir)
 		}
 	}
 


### PR DESCRIPTION
Updates error message to be more specific that a destination dir must be configured or parameter to match the specified init dir. 

If a user had no config file they get 

```bash
$ tbot init --init-dir /tmp/test
ERROR: Could not find specified destination /tmp/test
```

This isn't clear it's looking for the dest dir as a config not whether the dir exists on the file system.

Updated to

```bash
ERROR: Initial directory "/tmp/test" must match a destination directory from the configuration file or --destination-dir parameter
```

