### PR TITLE
[v17] Update Slack integration to link directly to ACL review state

### DIFF
--- a/integrations/access/slack/bot.go
+++ b/integrations/access/slack/bot.go
@@ -291,6 +291,7 @@ func (b Bot) slackAccessListReminderMsgSection(accessList *accesslist.AccessList
 	if b.webProxyURL != nil {
 		reqURL := *b.webProxyURL
 		reqURL.Path = lib.BuildURLPath("web", "accesslists", accessList.Metadata.Name)
+		reqURL.Fragment = "review"
 		link = fmt.Sprintf("*Link*: %s", reqURL.String())
 	}
 


### PR DESCRIPTION
Backport #50247 to branch/v17. Needs [e#5761](https://github.com/gravitational/teleport.e/pull/5761).