### PR TITLE
Update awsconfig

### DIFF
--- a/lib/cloud/awsconfig/awsconfig_test.go
+++ b/lib/cloud/awsconfig/awsconfig_test.go
@@ -18,9 +18,15 @@ package awsconfig
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 )
@@ -29,18 +35,60 @@ type mockCredentialProvider struct {
 	cred aws.Credentials
 }
 
-func (m *mockCredentialProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
+func (m *mockCredentialProvider) Retrieve(_ context.Context) (aws.Credentials, error) {
 	return m.cred, nil
+}
+
+type mockAssumeRoleAPIClient struct{}
+
+func (m *mockAssumeRoleAPIClient) AssumeRole(_ context.Context, params *sts.AssumeRoleInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleOutput, error) {
+	fakeKeyID := fmt.Sprintf("role: %s, externalID: %s", aws.ToString(params.RoleArn), aws.ToString(params.ExternalId))
+	return &sts.AssumeRoleOutput{
+		AssumedRoleUser: &ststypes.AssumedRoleUser{
+			Arn:           params.RoleArn,
+			AssumedRoleId: aws.String("role-id"),
+		},
+		Credentials: &ststypes.Credentials{
+			AccessKeyId:     aws.String(fakeKeyID),
+			Expiration:      aws.Time(time.Time{}),
+			SecretAccessKey: aws.String("fake-secret-access-key"),
+			SessionToken:    aws.String("fake-session-token"),
+		},
+	}, nil
 }
 
 func TestGetConfigIntegration(t *testing.T) {
 	t.Parallel()
+
+	cache, err := NewCache()
+	require.NoError(t, err)
+	tests := []struct {
+		desc string
+		Provider
+	}{
+		{
+			desc:     "uncached",
+			Provider: ProviderFunc(GetConfig),
+		},
+		{
+			desc:     "cached",
+			Provider: cache,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			testGetConfigIntegration(t, test.Provider)
+		})
+	}
+}
+
+func testGetConfigIntegration(t *testing.T, provider Provider) {
 	dummyIntegration := "integration-test"
 	dummyRegion := "test-region-123"
 
 	t.Run("without an integration credential provider, must return missing credential provider error", func(t *testing.T) {
 		ctx := context.Background()
-		_, err := GetConfig(ctx, dummyRegion, WithCredentialsMaybeIntegration(dummyIntegration))
+		_, err := provider.GetConfig(ctx, dummyRegion, WithCredentialsMaybeIntegration(dummyIntegration))
 		require.True(t, trace.IsBadParameter(err), "unexpected error: %v", err)
 		require.ErrorContains(t, err, "missing aws integration credential provider")
 	})
@@ -48,7 +96,7 @@ func TestGetConfigIntegration(t *testing.T) {
 	t.Run("with an integration credential provider, must return the credentials", func(t *testing.T) {
 		ctx := context.Background()
 
-		cfg, err := GetConfig(ctx, dummyRegion,
+		cfg, err := provider.GetConfig(ctx, dummyRegion,
 			WithCredentialsMaybeIntegration(dummyIntegration),
 			WithIntegrationCredentialProvider(func(ctx context.Context, region, integration string) (aws.CredentialsProvider, error) {
 				if region == dummyRegion && integration == dummyIntegration {
@@ -66,10 +114,68 @@ func TestGetConfigIntegration(t *testing.T) {
 		require.Equal(t, "foo-bar", creds.SessionToken)
 	})
 
+	t.Run("with an integration credential provider assuming a role, must return assumed role credentials", func(t *testing.T) {
+		ctx := context.Background()
+
+		cfg, err := provider.GetConfig(ctx, dummyRegion,
+			WithCredentialsMaybeIntegration(dummyIntegration),
+			WithIntegrationCredentialProvider(func(ctx context.Context, region, integration string) (aws.CredentialsProvider, error) {
+				if region == dummyRegion && integration == dummyIntegration {
+					return &mockCredentialProvider{
+						cred: aws.Credentials{
+							SessionToken: "foo-bar",
+						},
+					}, nil
+				}
+				return nil, trace.NotFound("no creds in region %q with integration %q", region, integration)
+			}),
+			WithAssumeRole("roleA", "abc123"),
+			WithAssumeRoleClientProviderFunc(func(cfg aws.Config) stscreds.AssumeRoleAPIClient {
+				creds, err := cfg.Credentials.Retrieve(context.Background())
+				require.NoError(t, err)
+				require.Equal(t, "foo-bar", creds.SessionToken)
+				return &mockAssumeRoleAPIClient{}
+			}),
+		)
+		require.NoError(t, err)
+		creds, err := cfg.Credentials.Retrieve(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "role: roleA, externalID: abc123", creds.AccessKeyID)
+		require.Equal(t, "fake-session-token", creds.SessionToken)
+	})
+
+	t.Run("with an integration credential provider assuming a role, must limit role chain length", func(t *testing.T) {
+		ctx := context.Background()
+		_, err := provider.GetConfig(ctx, dummyRegion,
+			WithCredentialsMaybeIntegration(dummyIntegration),
+			WithIntegrationCredentialProvider(func(ctx context.Context, region, integration string) (aws.CredentialsProvider, error) {
+				if region == dummyRegion && integration == dummyIntegration {
+					return &mockCredentialProvider{
+						cred: aws.Credentials{
+							SessionToken: "foo-bar",
+						},
+					}, nil
+				}
+				return nil, trace.NotFound("no creds in region %q with integration %q", region, integration)
+			}),
+			WithAssumeRole("roleA", "abc123"),
+			WithAssumeRole("roleB", "abc123"),
+			WithAssumeRole("roleC", "abc123"),
+			WithAssumeRoleClientProviderFunc(func(cfg aws.Config) stscreds.AssumeRoleAPIClient {
+				creds, err := cfg.Credentials.Retrieve(context.Background())
+				require.NoError(t, err)
+				require.Equal(t, "foo-bar", creds.SessionToken)
+				return &mockAssumeRoleAPIClient{}
+			}),
+		)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "role chain contains more than 2 roles")
+	})
+
 	t.Run("with an integration credential provider, but using an empty integration falls back to ambient credentials", func(t *testing.T) {
 		ctx := context.Background()
 
-		_, err := GetConfig(ctx, dummyRegion,
+		_, err := provider.GetConfig(ctx, dummyRegion,
 			WithCredentialsMaybeIntegration(""),
 			WithIntegrationCredentialProvider(func(ctx context.Context, region, integration string) (aws.CredentialsProvider, error) {
 				require.Fail(t, "this function should not be called")
@@ -81,7 +187,7 @@ func TestGetConfigIntegration(t *testing.T) {
 	t.Run("with an integration credential provider, but using ambient credentials", func(t *testing.T) {
 		ctx := context.Background()
 
-		_, err := GetConfig(ctx, dummyRegion,
+		_, err := provider.GetConfig(ctx, dummyRegion,
 			WithAmbientCredentials(),
 			WithIntegrationCredentialProvider(func(ctx context.Context, region, integration string) (aws.CredentialsProvider, error) {
 				require.Fail(t, "this function should not be called")
@@ -93,7 +199,7 @@ func TestGetConfigIntegration(t *testing.T) {
 	t.Run("with an integration credential provider, but no credential source", func(t *testing.T) {
 		ctx := context.Background()
 
-		_, err := GetConfig(ctx, dummyRegion,
+		_, err := provider.GetConfig(ctx, dummyRegion,
 			WithIntegrationCredentialProvider(func(ctx context.Context, region, integration string) (aws.CredentialsProvider, error) {
 				require.Fail(t, "this function should not be called")
 				return nil, nil
@@ -101,4 +207,17 @@ func TestGetConfigIntegration(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorContains(t, err, "missing credentials source")
 	})
+}
+
+func TestNewCacheKey(t *testing.T) {
+	roleChain := []AssumeRole{
+		{RoleARN: "roleA"},
+		{RoleARN: "roleB", ExternalID: "abc123"},
+	}
+	got, err := newCacheKey("integration-name", roleChain...)
+	require.NoError(t, err)
+	want := strings.TrimSpace(`
+{"integration":"integration-name","role_chain":[{"role_arn":"roleA","external_id":""},{"role_arn":"roleB","external_id":"abc123"}]}
+`)
+	require.Equal(t, want, got)
 }

--- a/lib/cloud/awsconfig/cache.go
+++ b/lib/cloud/awsconfig/cache.go
@@ -1,0 +1,147 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package awsconfig
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+func awsCredentialsCacheOptions(opts *aws.CredentialsCacheOptions) {
+	// expire early to avoid expiration race.
+	opts.ExpiryWindow = 2 * time.Minute
+}
+
+// Cache is an AWS config [Provider] that caches credentials by integration and
+// role.
+type Cache struct {
+	awsConfigCache *utils.FnCache
+}
+
+// NewCache returns a new [Cache].
+func NewCache() (*Cache, error) {
+	c, err := utils.NewFnCache(utils.FnCacheConfig{
+		TTL:         15 * time.Minute,
+		ReloadOnErr: true,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &Cache{
+		awsConfigCache: c,
+	}, nil
+}
+
+// GetConfig returns an [aws.Config] for the given region and options.
+func (c *Cache) GetConfig(ctx context.Context, region string, optFns ...OptionsFn) (aws.Config, error) {
+	opts, err := buildOptions(optFns...)
+	if err != nil {
+		return aws.Config{}, trace.Wrap(err)
+	}
+
+	cfg, err := c.getBaseConfig(ctx, region, opts)
+	if err != nil {
+		return aws.Config{}, trace.Wrap(err)
+	}
+	cfg, err = c.getConfigForRoleChain(ctx, cfg, opts)
+	if err != nil {
+		return aws.Config{}, trace.Wrap(err)
+	}
+	return cfg, nil
+}
+
+func (c *Cache) getBaseConfig(ctx context.Context, region string, opts *options) (aws.Config, error) {
+	// The AWS SDK combines config loading with default credential chain
+	// loading.
+	// We cache the entire config by integration name, which is empty for
+	// non-integration config, but only use credentials from it on cache hit.
+	cacheKey, err := newCacheKey(opts.integration)
+	if err != nil {
+		return aws.Config{}, trace.Wrap(err)
+	}
+	var reloaded bool
+	cfg, err := utils.FnCacheGet(ctx, c.awsConfigCache, cacheKey,
+		func(ctx context.Context) (aws.Config, error) {
+			reloaded = true
+			cfg, err := getBaseConfig(ctx, region, opts)
+			return cfg, trace.Wrap(err)
+		})
+	if err != nil {
+		return aws.Config{}, trace.Wrap(err)
+	}
+
+	if reloaded {
+		// If the cache reload func was called, then the config we got back has
+		// already applied our options so we can return the config itself.
+		return cfg, nil
+	}
+
+	// On cache hit we just take the credentials from the cached config.
+	// Then, we apply those credentials while loading config with current
+	// options.
+	cfg, err = loadDefaultConfig(ctx, region, cfg.Credentials, opts)
+	return cfg, trace.Wrap(err)
+}
+
+func (c *Cache) getConfigForRoleChain(ctx context.Context, cfg aws.Config, opts *options) (aws.Config, error) {
+	for i, r := range opts.assumeRoles {
+		// cache credentials by integration and assumed-role chain.
+		cacheKey, err := newCacheKey(opts.integration, opts.assumeRoles[:i+1]...)
+		if err != nil {
+			return aws.Config{}, trace.Wrap(err)
+		}
+		credProvider, err := utils.FnCacheGet(ctx, c.awsConfigCache, cacheKey,
+			func(ctx context.Context) (aws.CredentialsProvider, error) {
+				clt := opts.assumeRoleClientProvider(cfg)
+				credProvider := getAssumeRoleProvider(ctx, clt, r)
+				cc := aws.NewCredentialsCache(credProvider,
+					awsCredentialsCacheOptions,
+				)
+				if _, err := cc.Retrieve(ctx); err != nil {
+					return nil, trace.Wrap(err)
+				}
+				return cc, nil
+			})
+		if err != nil {
+			return aws.Config{}, trace.Wrap(err)
+		}
+		cfg.Credentials = credProvider
+	}
+	return cfg, nil
+}
+
+// newCacheKey returns a cache key for AWS credentials.
+// The cache key can be used to get role credentials without calling AWS STS.
+// Therefore, we marshal the key as JSON to be sure the input cannot be
+// manipulated to retrieve other credentials.
+func newCacheKey(integrationName string, roleChain ...AssumeRole) (string, error) {
+	type configCacheKey struct {
+		Integration string       `json:"integration"`
+		RoleChain   []AssumeRole `json:"role_chain"`
+	}
+	out, err := json.Marshal(configCacheKey{
+		Integration: integrationName,
+		RoleChain:   roleChain,
+	})
+	return string(out), trace.Wrap(err)
+}

--- a/lib/cloud/awsconfig/provider.go
+++ b/lib/cloud/awsconfig/provider.go
@@ -1,0 +1,37 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package awsconfig
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+)
+
+// Provider provides an [aws.Config].
+type Provider interface {
+	// GetConfig returns an [aws.Config] for the given region and options.
+	GetConfig(ctx context.Context, region string, optFns ...OptionsFn) (aws.Config, error)
+}
+
+// ProviderFunc is a [Provider] adapter for functions.
+type ProviderFunc func(ctx context.Context, region string, optFns ...OptionsFn) (aws.Config, error)
+
+// GetConfig returns an [aws.Config] for the given region and options.
+func (fn ProviderFunc) GetConfig(ctx context.Context, region string, optFns ...OptionsFn) (aws.Config, error) {
+	return fn(ctx, region, optFns...)
+}


### PR DESCRIPTION
* Add a Cache for caching credentials, similar to SDK v1 session cache.
* Add a Provider interface that provides aws.Config
* Simplified role chaining options

Unlike our SDK v1 session cache, the SDK v2 implementation in this PR does not include region as a cache key.
There are regional AWS STS endpoints for lower latency calls, but the lowest latency path is to just grab credentials from the cache if we already have them - the region they were originally taken from doesn't matter.