### PR TITLE
docs: include google and azure session storage in recorded sessions desc

### DIFF
--- a/docs/pages/reference/monitoring/audit.mdx
+++ b/docs/pages/reference/monitoring/audit.mdx
@@ -159,7 +159,7 @@ For desktop sessions the recording includes the contents of the screen.
 <Tabs>
 <TabItem scope={["enterprise", "oss"]} label="Self-Hosted">
 
-Teleport can store the recorded sessions in an [AWS S3 bucket](../backends.mdx)
+Teleport can store the recorded sessions in a [AWS S3 bucket, Google Cloud storage, Azure Blob Storage](../backends.mdx), 
 or in a local filesystem (including NFS).
 
 The recorded sessions are stored as raw bytes in the `sessions` directory under


### PR DESCRIPTION
Update from only AWS S3 mentioned