### PR TITLE
Add a null check to `getMfaChallengeResponse`

### DIFF
--- a/web/packages/teleport/src/Account/ChangePasswordWizard/ChangePasswordWizard.tsx
+++ b/web/packages/teleport/src/Account/ChangePasswordWizard/ChangePasswordWizard.tsx
@@ -65,7 +65,7 @@ export function ChangePasswordWizard({
   const reauthState = useReAuthenticate({
     challengeScope: MfaChallengeScope.CHANGE_PASSWORD,
     onMfaResponse: async mfaResponse =>
-      setWebauthnResponse(mfaResponse.webauthn_response),
+      setWebauthnResponse(mfaResponse?.webauthn_response),
   });
 
   const [reauthMethod, setReauthMethod] = useState<ReauthenticationMethod>();

--- a/web/packages/teleport/src/lib/term/tty.ts
+++ b/web/packages/teleport/src/lib/term/tty.ts
@@ -81,7 +81,7 @@ class Tty extends EventEmitterMfaSender {
     this.socket.send(bytearray.buffer);
   }
 
-  sendChallengeResponse(data: MfaChallengeResponse) {
+  sendChallengeResponse(resp: MfaChallengeResponse) {
     // we want to have the backend listen on a single message type
     // for any responses. so our data will look like data.webauthn, data.sso, etc
     // but to be backward compatible, we need to still spread the existing webauthn only fields
@@ -89,8 +89,8 @@ class Tty extends EventEmitterMfaSender {
     // in 19, we can just pass "data" without this extra step
     // TODO (avatus): DELETE IN 19.0.0
     const backwardCompatibleData = {
-      ...data.webauthn_response,
-      ...data,
+      ...resp?.webauthn_response,
+      ...resp,
     };
     const encoded = this._proto.encodeChallengeResponse(
       JSON.stringify(backwardCompatibleData)

--- a/web/packages/teleport/src/services/auth/auth.ts
+++ b/web/packages/teleport/src/services/auth/auth.ts
@@ -282,6 +282,8 @@ const auth = {
     mfaType?: DeviceType,
     totpCode?: string
   ): Promise<MfaChallengeResponse> {
+    if (!challenge) return;
+
     // TODO(Joerger): If mfaType is not provided by a parent component, use some global context
     // to display a component, similar to the one used in useMfa. For now we just default to
     // whichever method we can succeed with first.

--- a/web/packages/teleport/src/services/auth/auth.ts
+++ b/web/packages/teleport/src/services/auth/auth.ts
@@ -281,7 +281,7 @@ const auth = {
     challenge: MfaAuthenticateChallenge,
     mfaType?: DeviceType,
     totpCode?: string
-  ): Promise<MfaChallengeResponse> {
+  ): Promise<MfaChallengeResponse | undefined> {
     if (!challenge) return;
 
     // TODO(Joerger): If mfaType is not provided by a parent component, use some global context
@@ -312,7 +312,7 @@ const auth = {
     }
 
     // No viable challenge, return empty response.
-    return null;
+    return;
   },
 
   async getWebAuthnChallengeResponse(

--- a/web/packages/teleport/src/services/auth/auth.ts
+++ b/web/packages/teleport/src/services/auth/auth.ts
@@ -240,7 +240,7 @@ const auth = {
       .then(res => {
         const request = {
           action: 'accept',
-          webauthnAssertionResponse: res.webauthn_response,
+          webauthnAssertionResponse: res?.webauthn_response,
         };
 
         return api.put(cfg.getHeadlessSsoPath(transactionId), request);
@@ -441,7 +441,7 @@ const auth = {
     return auth
       .getMfaChallenge({ scope, allowReuse, isMfaRequiredRequest }, abortSignal)
       .then(challenge => auth.getMfaChallengeResponse(challenge, 'webauthn'))
-      .then(res => res.webauthn_response);
+      .then(res => res?.webauthn_response);
   },
 
   getMfaChallengeResponseForAdminAction(allowReuse?: boolean) {

--- a/web/packages/teleport/src/services/mfa/makeMfa.ts
+++ b/web/packages/teleport/src/services/mfa/makeMfa.ts
@@ -63,7 +63,7 @@ export function parseMfaRegistrationChallengeJson(
 // parseMfaChallengeJson formats fetched authenticate challenge JSON.
 export function parseMfaChallengeJson(
   challenge: MfaAuthenticateChallengeJson
-): MfaAuthenticateChallenge {
+): MfaAuthenticateChallenge | undefined {
   if (
     !challenge.sso_challenge &&
     !challenge.webauthn_challenge &&

--- a/web/packages/teleport/src/services/mfa/makeMfa.ts
+++ b/web/packages/teleport/src/services/mfa/makeMfa.ts
@@ -69,7 +69,7 @@ export function parseMfaChallengeJson(
     !challenge.webauthn_challenge &&
     !challenge.totp_challenge
   ) {
-    return null;
+    return;
   }
 
   // WebAuthn challenge contains Base64URL(byte) fields that needs to


### PR DESCRIPTION
Changelog: Fixed a bug in the WebUI that could cause an access denied error when accessing application.

Fix a bug caused by https://github.com/gravitational/teleport/pull/49679 which was meant to check for null/undefined. 

Closes #50556