### PR TITLE
Add Access Monitoring compatibility docs warning

### DIFF
--- a/docs/pages/admin-guides/access-controls/access-monitoring.mdx
+++ b/docs/pages/admin-guides/access-controls/access-monitoring.mdx
@@ -17,7 +17,7 @@ Users are able to write their own custom access monitoring queries by querying t
 
 <Admonition type="notice">
   Access Monitoring is not currently supported with External Audit Storage
-  in Teleport Enterprise (cloud-hosted). This functionality will be
+  in Teleport Enterprise (Cloud). This functionality will be
   enabled in a future Teleport release.
 </Admonition>
 

--- a/docs/pages/admin-guides/management/external-audit-storage.mdx
+++ b/docs/pages/admin-guides/management/external-audit-storage.mdx
@@ -21,6 +21,12 @@ External Audit Storage is based on Teleport's
 available on Teleport Enterprise Cloud clusters running Teleport v14.2.1 or
 above.
 
+<Admonition type="notice">
+On Teleport Enterprise (Cloud), External Audit
+Storage is not currently supported for users who have Access Monitoring enabled.
+This functionality will be enabled in a future Teleport release.  
+</Admonition>
+
 ## Prerequisites
 
 1. A Teleport Enterprise Cloud account. If you do not have one, [sign


### PR DESCRIPTION
Closes #48745

Add a warning to the External Audit Storage page that this feature is not compatible with Access Monitoring on Teleport Enterprise (Cloud), complementing the warning on the Access Monitoring page.