### PR TITLE
Use a Rust toolchain file

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -4,16 +4,16 @@ run-name: Build on Mac OS
 on:
   merge_group:
     paths:
-      - '.github/workflows/build-macos.yaml'
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
-      - '**.rs'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'build.assets/Makefile'
-      - 'build.assets/Dockerfile*'
-      - 'Makefile'
+      - ".github/workflows/build-macos.yaml"
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+      - "**.rs"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "build.assets/Makefile"
+      - "build.assets/Dockerfile*"
+      - "Makefile"
 
 jobs:
   build:
@@ -61,10 +61,6 @@ jobs:
         with:
           cache: false
           go-version: ${{ env.GOLANG_VERSION }}
-
-      - name: Configure Rust Toolchain
-        run: |
-          rustup override set ${{ env.RUST_VERSION }}
 
       - name: Install wasm-pack
         run: make ensure-wasm-deps

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -167,14 +167,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set Rust version
-        run: echo "RUST_VERSION=$(make -s -C build.assets print-rust-version)" >> $GITHUB_ENV
-
       - name: Set up Rust
         run: |
-          echo "Setting up Rust version ${RUST_VERSION}"
-          rustup toolchain install ${RUST_VERSION} --component rustfmt,clippy
-          rustup override set ${RUST_VERSION}
           rustc --version
           cargo --version
           rustfmt --version

--- a/BUILD_macos.md
+++ b/BUILD_macos.md
@@ -26,10 +26,7 @@ PRs with corrections and updates are welcome!
   brew install go
   ````
 
-* `Rust` and `Cargo` version from
-  [build.assets/Makefile](https://github.com/gravitational/teleport/blob/master/build.assets/versions.mk#L11)
-  (search for RUST_VERSION):
-
+* `Rust` and `Cargo`
   * Follow [official instructions](https://www.rust-lang.org/tools/install) to install `rustup`
     * Or install with homebrew:
 
@@ -55,16 +52,6 @@ PRs with corrections and updates are welcome!
   # or open a new shell
   ```
 
-  * Install the required version
-
-  ```shell
-  rustup toolchain install <version from build.assets/versions.mk>
-  cd <teleport.git>
-  rustup override set <version from build.assets/versions.mk>
-  rustc --version
-  # rustc <version from build.assets/versions.mk>
-  ```
-
 * To install `libfido2` (pulls `openssl 3` as dependency)
 
   ```shell
@@ -80,7 +67,7 @@ PRs with corrections and updates are welcome!
 * To install tools for building the UI:
   * `brew install node corepack`
   * `corepack enable pnpm`
-  * The `Rust` and `Cargo` version in [build.assets/Makefile](https://github.com/gravitational/teleport/blob/master/build.assets/versions.mk#L11) (search for `RUST_VERSION`) are required.
+  * `Rust` and `Cargo` are required
   * The [`wasm-pack`](https://github.com/rustwasm/wasm-pack) version in [build.assets/Makefile](https://github.com/gravitational/teleport/blob/master/build.assets/versions.mk#L12) (search for `WASM_PACK_VERSION`) is required:
     `curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh`
 

--- a/Makefile
+++ b/Makefile
@@ -1847,17 +1847,12 @@ build-ui-e: ensure-js-deps ensure-wasm-deps
 docker-ui:
 	$(MAKE) -C build.assets ui
 
-.PHONY: rustup-set-version
-rustup-set-version: RUST_VERSION := $(shell $(MAKE) --no-print-directory -C build.assets print-rust-version)
-rustup-set-version:
-	rustup override set $(RUST_VERSION)
-
 # rustup-install-target-toolchain ensures the required rust compiler is
 # installed to build for $(ARCH)/$(OS) for the version of rust we use, as
-# defined in build.assets/Makefile. It assumes that `rustup` is already
+# defined in rust-toolchain.toml. It assumes that `rustup` is already
 # installed for managing the rust toolchain.
 .PHONY: rustup-install-target-toolchain
-rustup-install-target-toolchain: rustup-set-version
+rustup-install-target-toolchain:
 	rustup target add $(RUST_TARGET_ARCH)
 
 # changelog generates PR changelog between the provided base tag and the tip of

--- a/README.md
+++ b/README.md
@@ -140,21 +140,17 @@ make -C build.assets build-binaries
 Ensure you have installed correct versions of necessary dependencies:
 * `Go` version from
   [go.mod](https://github.com/gravitational/teleport/blob/master/go.mod#L3)
-* If you wish to build the Rust-powered features like Desktop Access, see the
-  `Rust` and `Cargo` versions in
-  [build.assets/Makefile](https://github.com/gravitational/teleport/blob/master/build.assets/Makefile#L21)
-  (search for `RUST_VERSION`)
+* Rust and Cargo should be installed via [rustup](https://rustup.rs/)
 * For `tsh` version > `10.x` with FIDO2 support, you will need `libfido2` and
   `pkg-config` installed locally
 * To build the web UI:
   * [`pnpm`](https://pnpm.io/installation#using-corepack). If you have Node.js installed, run `corepack enable pnpm` to make `pnpm` available.
   * If you prefer not to install/use pnpm, but have docker available, you can run `make docker-ui` instead.
-  * The `Rust` and `Cargo` version in [build.assets/Makefile](https://github.com/gravitational/teleport/blob/master/build.assets/versions.mk#L11) (search for `RUST_VERSION`) are required.
   * The [`wasm-pack`](https://github.com/rustwasm/wasm-pack) version in [build.assets/Makefile](https://github.com/gravitational/teleport/blob/master/build.assets/versions.mk#L12) (search for `WASM_PACK_VERSION`) is required.
   * [`binaryen`](https://github.com/WebAssembly/binaryen) (which contains `wasm-opt`) is required to be installed manually
     on linux aarch64 (64-bit ARM). You can check if it's already installed on your system by running `which wasm-opt`. If not you can install it like `apt-get install binaryen` (for Debian-based Linux). `wasm-pack` will install this automatically on other platforms.
 
-For an example of Dev Environment setup on a Mac, see [these instructions](BUILD_macos.md).
+For an example of dev environment setup on macOS, see [these instructions](BUILD_macos.md).
 
 #### Perform a build
 

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -208,11 +208,9 @@ RUN groupadd ci --gid=$GID -o && \
     mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport
 
 # Install Rust.
-ARG RUST_VERSION
 ENV RUSTUP_HOME=/usr/local/rustup \
-     CARGO_HOME=/usr/local/cargo \
-     PATH=/usr/local/cargo/bin:$PATH \
-     RUST_VERSION=$RUST_VERSION
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
 RUN mkdir -p $RUSTUP_HOME && chmod a+w $RUSTUP_HOME && \
     mkdir -p $CARGO_HOME/registry && chmod -R a+w $CARGO_HOME
 # Install Rust using the ci user, as that is the user that
@@ -220,11 +218,10 @@ RUN mkdir -p $RUSTUP_HOME && chmod a+w $RUSTUP_HOME && \
 # Cross-compilation targets are only installed on amd64, as
 # this image doesn't contain gcc-multilib.
 USER ci
-RUN curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION && \
+RUN curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal && \
     rustup --version && \
     cargo --version && \
     rustc --version && \
-    rustup component add rustfmt clippy && \
     rustup target add wasm32-unknown-unknown && \
     if [ "$BUILDARCH" = "amd64" ]; then rustup target add aarch64-unknown-linux-gnu i686-unknown-linux-gnu; fi
 

--- a/build.assets/Dockerfile-arm
+++ b/build.assets/Dockerfile-arm
@@ -82,17 +82,15 @@ RUN groupadd ci --gid="$GID" -o && \
     chown -R ci /var/lib/teleport
 
 # Install Rust.
-ARG RUST_VERSION
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=$RUST_VERSION
+    PATH=/usr/local/cargo/bin:$PATH
 RUN mkdir -p $RUSTUP_HOME && chmod a+w $RUSTUP_HOME && \
     mkdir -p $CARGO_HOME/registry && chmod -R a+w $CARGO_HOME
 # Install Rust using the ci user, as that is the user that
 # will run builds using the Rust toolchains we install here.
 USER ci
-RUN curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION && \
+RUN curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal && \
     rustup target add arm-unknown-linux-gnueabihf && \
     rustup --version && \
     cargo --version && \

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -259,11 +259,9 @@ COPY pam/ /opt/pam_teleport/
 RUN make -C /opt/pam_teleport install
 
 # Install Rust.
-ARG RUST_VERSION
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=$RUST_VERSION
+    PATH=/usr/local/cargo/bin:$PATH
 
 RUN mkdir -p $RUSTUP_HOME && chmod a+w $RUSTUP_HOME && \
     mkdir -p $CARGO_HOME/registry && chmod -R a+w $CARGO_HOME
@@ -273,7 +271,7 @@ RUN chmod a-w /
 # Install Rust using the ci user, as that is the user that
 # will run builds using the Rust toolchains we install here.
 USER ci
-RUN curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION && \
+RUN curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal && \
     rustup --version && \
     cargo --version && \
     rustc --version && \

--- a/build.assets/Dockerfile-node
+++ b/build.assets/Dockerfile-node
@@ -66,16 +66,14 @@ RUN groupadd ci --gid=$GID -o && \
     useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh
 
 # Install Rust.
-ARG RUST_VERSION
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=$RUST_VERSION
+    PATH=/usr/local/cargo/bin:$PATH
 RUN mkdir -p $RUSTUP_HOME && chmod a+w $RUSTUP_HOME && \
     mkdir -p $CARGO_HOME/registry && chmod -R a+w $CARGO_HOME
 
 USER ci
-RUN curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION && \
+RUN curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal && \
     rustup --version && \
     cargo --version && \
     rustc --version && \

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -151,7 +151,6 @@ buildbox-ng:
 	docker buildx build \
 		--build-arg THIRDPARTY_IMAGE=$(BUILDBOX_THIRDPARTY) \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
-		--build-arg RUST_VERSION=$(RUST_VERSION) \
 		--cache-from $(BUILDBOX_NG) \
 		--cache-to type=inline \
 		$(if $(PUSH),--push,--load) \
@@ -175,7 +174,6 @@ buildbox:
 		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 		--build-arg GOLANGCI_LINT_VERSION=$(GOLANGCI_LINT_VERSION) \
-		--build-arg RUST_VERSION=$(RUST_VERSION) \
 		--build-arg WASM_PACK_VERSION=$(WASM_PACK_VERSION) \
 		--build-arg NODE_VERSION=$(NODE_VERSION) \
 		--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
@@ -218,7 +216,6 @@ buildbox-centos7:
 		--build-arg BUILDARCH=$(HOST_ARCH) \
 		--build-arg TARGETARCH=$(RUNTIME_ARCH) \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
-		--build-arg RUST_VERSION=$(RUST_VERSION) \
 		--build-arg WASM_PACK_VERSION=$(WASM_PACK_VERSION) \
 		--build-arg DEVTOOLSET=$(DEVTOOLSET) \
 		--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
@@ -247,7 +244,6 @@ buildbox-centos7-fips:
 		--build-arg BUILDARCH=$(HOST_ARCH) \
 		--build-arg TARGETARCH=$(RUNTIME_ARCH) \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
-		--build-arg RUST_VERSION=$(RUST_VERSION) \
 		--build-arg WASM_PACK_VERSION=$(WASM_PACK_VERSION) \
 		--build-arg DEVTOOLSET=$(DEVTOOLSET) \
 		--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
@@ -272,7 +268,6 @@ buildbox-arm:
 		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 		--build-arg NODE_VERSION=$(NODE_VERSION) \
-		--build-arg RUST_VERSION=$(RUST_VERSION) \
 		--cache-to type=inline \
 		--cache-from $(BUILDBOX_ARM) \
 		$(if $(PUSH),--push,--load) \
@@ -296,7 +291,6 @@ buildbox-node:
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
 		--build-arg NODE_VERSION=$(NODE_VERSION) \
-		--build-arg RUST_VERSION=$(RUST_VERSION) \
 		--build-arg WASM_PACK_VERSION=$(WASM_PACK_VERSION) \
 		--cache-to type=inline \
 		--cache-from $(BUILDBOX_NODE) \
@@ -729,13 +723,6 @@ print-golangci-lint-version:
 .PHONY:print-buf-version
 print-buf-version:
 	@echo $(BUF_VERSION)
-
-#
-# Print the Rust version used to build Teleport.
-#
-.PHONY:print-rust-version
-print-rust-version:
-	@echo $(RUST_VERSION)
 
 #
 # Print the wasm-pack version used to build Teleport.

--- a/build.assets/buildbox/Dockerfile
+++ b/build.assets/buildbox/Dockerfile
@@ -85,11 +85,10 @@ FROM base AS rust
 RUN install -d -m 0775 -o buildbox -g buildbox /opt/rust
 USER buildbox
 
-ARG RUST_VERSION
 ENV RUSTUP_HOME=/opt/rust
 ENV CARGO_HOME=/opt/rust
 RUN curl --proto =https --tlsv1.2 -fsSL https://sh.rustup.rs | \
-	sh -s -- -y --profile minimal --default-toolchain ${RUST_VERSION} && \
+	sh -s -- -y --profile minimal && \
 	${CARGO_HOME}/bin/rustup --version && \
 	${CARGO_HOME}/bin/cargo --version && \
 	${CARGO_HOME}/bin/rustc --version && \

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -9,8 +9,6 @@ GOLANGCI_LINT_VERSION ?= v2.1.5
 # NOTE: Remember to update engines.node in package.json to match the major version.
 NODE_VERSION ?= 22.14.0
 
-# Run lint-rust check locally before merging code after you bump this.
-RUST_VERSION ?= 1.81.0
 WASM_PACK_VERSION ?= 0.12.1
 LIBBPF_VERSION ?= 1.2.2
 LIBPCSCLITE_VERSION ?= 1.9.9-teleport

--- a/build.assets/windows/build.ps1
+++ b/build.assets/windows/build.ps1
@@ -90,9 +90,7 @@ function Install-Rust {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [string] $ToolchainDir,
-        [Parameter(Mandatory)]
-        [string] $RustVersion
+        [string] $ToolchainDir
     )
     begin {
         Write-Host "::group::Installing Rust $RustVersion to $ToolchainDir..."
@@ -101,7 +99,7 @@ function Install-Rust {
         Invoke-WebRequest -Uri https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-gnu/rustup-init.exe -OutFile $RustupFile
         $Env:RUSTUP_HOME = "$ToolchainDir/rustup"
         $Env:CARGO_HOME = "$ToolchainDir/cargo"
-        & "$ToolchainDir\rustup-init.exe" --profile minimal -y --default-toolchain "$RustVersion-x86_64-pc-windows-gnu"
+        & "$ToolchainDir\rustup-init.exe" --profile minimal -y --target x86_64-pc-windows-gnu
         Enable-Rust -ToolchainDir $ToolchainDir
         Write-Host "::endgroup::"
     }
@@ -340,8 +338,7 @@ function Install-BuildRequirements {
     $CommandDuration = Measure-Block {
         New-Item -Path "$InstallDirectory" -ItemType Directory -Force | Out-Null
 
-        $RustVersion = $(make --no-print-directory -C "$TeleportSourceDirectory/build.assets" print-rust-version).Trim()
-        Install-Rust -RustVersion "$RustVersion" -ToolchainDir "$InstallDirectory"
+        Install-Rust -ToolchainDir "$InstallDirectory"
 
         $NodeVersion = $(make --no-print-directory -C "$TeleportSourceDirectory/build.assets" print-node-version).Trim()
         Install-Node -NodeVersion "$NodeVersion" -ToolchainDir "$InstallDirectory"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "1.81.0"
+profile = "minimal"
+components = [ "rustfmt", "clippy" ]
+

--- a/web/README.md
+++ b/web/README.md
@@ -16,7 +16,7 @@ You can make production builds locally, or you can use Docker to do that.
 
 ### Local Build
 
-Install Node.js (you can take the version by executing 
+Install Node.js (you can take the version by executing
 `make -C build.assets print-node-version` from the root directory).
 After that, run `corepack enable pnpm` to enable installing a package manager.
 
@@ -27,7 +27,7 @@ pnpm install
 ```
 
 You will also need the following tools installed:
-* The `Rust` and `Cargo` version in [build.assets/Makefile](https://github.com/gravitational/teleport/blob/master/build.assets/versions.mk#L11) (search for `RUST_VERSION`) are required.
+* `Rust` and `Cargo` should be installed via [rustup](https://rustup.rs/)
 * The [`wasm-pack`](https://github.com/rustwasm/wasm-pack) version in [build.assets/Makefile](https://github.com/gravitational/teleport/blob/master/build.assets/versions.mk#L12) (search for `WASM_PACK_VERSION`) is required:
   `curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh`
 * [`binaryen`](https://github.com/WebAssembly/binaryen) (which contains `wasm-opt`) is required to be installed manually
@@ -288,7 +288,7 @@ not own.
 We use [pnpm workspaces](https://pnpm.io/workspaces) to manage dependencies.
 
 To add a package to the workspace, run `pnpm --filter=<workspace-name> add <package-name>`.
-Alternatively, you can add a line to the workspace's `package.json` file and then 
+Alternatively, you can add a line to the workspace's `package.json` file and then
 run `pnpm install` (or `pnpm i`) from the root of this repository.
 
 Dependencies should generally be added to the specific workspaces that use them.


### PR DESCRIPTION
This ensures that rustup will automatically use the toolchain version specified in the repo, which will eliminate cases where devs encounter errors after we bump the Rust version.

I might need to break this into a series of smaller PRs in order to merge cleanly, but wanted to open it in a single PR to try a tag-build first.