### PR TITLE
[v15] Log debug error if user cleanup is a not found error from missing `getent` binaries

### DIFF
--- a/lib/utils/host/hostusers.go
+++ b/lib/utils/host/hostusers.go
@@ -129,7 +129,7 @@ func SetUserGroups(username string, groups []string) (exitCode int, err error) {
 func UserDel(username string) (exitCode int, err error) {
 	userdelBin, err := exec.LookPath("userdel")
 	if err != nil {
-		return -1, trace.Wrap(err, "cant find userdel binary")
+		return -1, trace.NotFound("cant find userdel binary: %s", err)
 	}
 	u, err := user.Lookup(username)
 	if err != nil {
@@ -151,7 +151,7 @@ func UserDel(username string) (exitCode int, err error) {
 func GetAllUsers() ([]string, int, error) {
 	getentBin, err := exec.LookPath("getent")
 	if err != nil {
-		return nil, -1, trace.Wrap(err, "cant find getent binary")
+		return nil, -1, trace.NotFound("cant find getent binary: %s", err)
 	}
 	// getent passwd
 	cmd := exec.Command(getentBin, "passwd")


### PR DESCRIPTION
Backport #42373 to branch/v15

Closes #41918