### PR TITLE
migrate AWS Redshift services to AWS SDK v2

### DIFF
--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -87,6 +87,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/kms v1.37.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/organizations v1.36.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/rds v1.92.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/redshift v1.53.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.71.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.56.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.24.7 // indirect

--- a/integrations/event-handler/go.sum
+++ b/integrations/event-handler/go.sum
@@ -777,6 +777,8 @@ github.com/aws/aws-sdk-go-v2/service/organizations v1.36.0 h1:CVHfN8ZVvWzDkAf/Qj
 github.com/aws/aws-sdk-go-v2/service/organizations v1.36.0/go.mod h1:SVY+doFrL3KTvVMWzFLKvD7KYQ6GQfwNRPSQS7eA3cA=
 github.com/aws/aws-sdk-go-v2/service/rds v1.92.0 h1:W0gUYAjO24u/M6tpR041wMHJWGzleOhxtCnNLImdrZs=
 github.com/aws/aws-sdk-go-v2/service/rds v1.92.0/go.mod h1:ADD2uROOoEIXjbjDPEvDDZWnGmfKFYMddgKwG5RlBGw=
+github.com/aws/aws-sdk-go-v2/service/redshift v1.53.0 h1:4/hmROBioc89sKlMVjHgOaH92zAkrAAMZR3BIvYwyD0=
+github.com/aws/aws-sdk-go-v2/service/redshift v1.53.0/go.mod h1:UydVhUJOB/DaCJWiaBkPlvuzvWVcUlgbS2Bxn33bcKI=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.71.0 h1:nyuzXooUNJexRT0Oy0UQY6AhOzxPxhtt4DcBIHyCnmw=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.71.0/go.mod h1:sT/iQz8JK3u/5gZkT+Hmr7GzVZehUMkRZpOaAwYXeGY=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.56.1 h1:cfVjoEwOMOJOI6VoRQua0nI0KjZV9EAnR8bKaMeSppE=

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -100,6 +100,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/kms v1.37.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/organizations v1.36.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/rds v1.92.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/redshift v1.53.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.71.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.56.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.24.7 // indirect

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -848,6 +848,8 @@ github.com/aws/aws-sdk-go-v2/service/organizations v1.36.0 h1:CVHfN8ZVvWzDkAf/Qj
 github.com/aws/aws-sdk-go-v2/service/organizations v1.36.0/go.mod h1:SVY+doFrL3KTvVMWzFLKvD7KYQ6GQfwNRPSQS7eA3cA=
 github.com/aws/aws-sdk-go-v2/service/rds v1.92.0 h1:W0gUYAjO24u/M6tpR041wMHJWGzleOhxtCnNLImdrZs=
 github.com/aws/aws-sdk-go-v2/service/rds v1.92.0/go.mod h1:ADD2uROOoEIXjbjDPEvDDZWnGmfKFYMddgKwG5RlBGw=
+github.com/aws/aws-sdk-go-v2/service/redshift v1.53.0 h1:4/hmROBioc89sKlMVjHgOaH92zAkrAAMZR3BIvYwyD0=
+github.com/aws/aws-sdk-go-v2/service/redshift v1.53.0/go.mod h1:UydVhUJOB/DaCJWiaBkPlvuzvWVcUlgbS2Bxn33bcKI=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.71.0 h1:nyuzXooUNJexRT0Oy0UQY6AhOzxPxhtt4DcBIHyCnmw=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.71.0/go.mod h1:sT/iQz8JK3u/5gZkT+Hmr7GzVZehUMkRZpOaAwYXeGY=
 github.com/aws/aws-sdk-go-v2/service/sns v1.33.7 h1:N3o8mXK6/MP24BtD9sb51omEO9J9cgPM3Ughc293dZc=

--- a/lib/cloud/aws/aws.go
+++ b/lib/cloud/aws/aws.go
@@ -22,12 +22,12 @@ import (
 	"slices"
 	"strings"
 
+	redshifttypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/aws/aws-sdk-go/service/memorydb"
 	"github.com/aws/aws-sdk-go/service/opensearchservice"
 	"github.com/aws/aws-sdk-go/service/rds"
-	"github.com/aws/aws-sdk-go/service/redshift"
 	"github.com/coreos/go-semver/semver"
 
 	"github.com/gravitational/teleport/lib/services"
@@ -244,7 +244,7 @@ func IsDBClusterAvailable(clusterStatus, clusterIndetifier *string) bool {
 }
 
 // IsRedshiftClusterAvailable checks if the Redshift cluster is available.
-func IsRedshiftClusterAvailable(cluster *redshift.Cluster) bool {
+func IsRedshiftClusterAvailable(cluster *redshifttypes.Cluster) bool {
 	// For a full list of status values, see:
 	// https://docs.aws.amazon.com/redshift/latest/mgmt/working-with-clusters.html#rs-mgmt-cluster-status
 	//

--- a/lib/cloud/aws/errors.go
+++ b/lib/cloud/aws/errors.go
@@ -31,14 +31,23 @@ import (
 	"github.com/gravitational/trace"
 )
 
-// ConvertRequestFailureError converts `error` into AWS RequestFailure errors
-// to trace errors. If the provided error is not an `RequestFailure` it returns
-// the error without modifying it.
+// ConvertRequestFailureError converts `err` into AWS errors to trace errors.
+// If the provided error is not a [awserr.RequestFailure] it delegates
+// error conversion to [ConvertRequestFailureErrorV2] for SDK v2 compatibility.
+// Prefer using [ConvertRequestFailureErrorV2] directly for AWS SDK v2 client
+// errors.
 func ConvertRequestFailureError(err error) error {
 	var requestErr awserr.RequestFailure
 	if errors.As(err, &requestErr) {
 		return convertRequestFailureErrorFromStatusCode(requestErr.StatusCode(), requestErr)
 	}
+	return ConvertRequestFailureErrorV2(err)
+}
+
+// ConvertRequestFailureErrorV2 converts AWS SDK v2 errors to trace errors.
+// If the provided error is not a [awshttp.ResponseError] it returns the error
+// without modifying it.
+func ConvertRequestFailureErrorV2(err error) error {
 	var re *awshttp.ResponseError
 	if errors.As(err, &re) {
 		return convertRequestFailureErrorFromStatusCode(re.HTTPStatusCode(), re.Err)

--- a/lib/cloud/aws/tags_helpers.go
+++ b/lib/cloud/aws/tags_helpers.go
@@ -25,13 +25,13 @@ import (
 
 	ec2TypesV2 "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	rdsTypesV2 "github.com/aws/aws-sdk-go-v2/service/rds/types"
+	redshifttypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/aws/aws-sdk-go/service/memorydb"
 	"github.com/aws/aws-sdk-go/service/opensearchservice"
 	"github.com/aws/aws-sdk-go/service/rds"
-	"github.com/aws/aws-sdk-go/service/redshift"
 	"github.com/aws/aws-sdk-go/service/redshiftserverless"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"golang.org/x/exp/maps"
@@ -45,9 +45,9 @@ type ResourceTag interface {
 	//  here and use a type switch for now.
 	rdsTypesV2.Tag |
 		ec2TypesV2.Tag |
+		redshifttypes.Tag |
 		*ec2.Tag |
 		*rds.Tag |
-		*redshift.Tag |
 		*elasticache.Tag |
 		*memorydb.Tag |
 		*redshiftserverless.Tag |
@@ -80,8 +80,6 @@ func resourceTagToKeyValue[Tag ResourceTag](tag Tag) (string, string) {
 		return aws.StringValue(v.Key), aws.StringValue(v.Value)
 	case *ec2.Tag:
 		return aws.StringValue(v.Key), aws.StringValue(v.Value)
-	case *redshift.Tag:
-		return aws.StringValue(v.Key), aws.StringValue(v.Value)
 	case *elasticache.Tag:
 		return aws.StringValue(v.Key), aws.StringValue(v.Value)
 	case *memorydb.Tag:
@@ -91,6 +89,8 @@ func resourceTagToKeyValue[Tag ResourceTag](tag Tag) (string, string) {
 	case rdsTypesV2.Tag:
 		return aws.StringValue(v.Key), aws.StringValue(v.Value)
 	case ec2TypesV2.Tag:
+		return aws.StringValue(v.Key), aws.StringValue(v.Value)
+	case redshifttypes.Tag:
 		return aws.StringValue(v.Key), aws.StringValue(v.Value)
 	case *opensearchservice.Tag:
 		return aws.StringValue(v.Key), aws.StringValue(v.Value)

--- a/lib/cloud/awstesthelpers/tags.go
+++ b/lib/cloud/awstesthelpers/tags.go
@@ -1,0 +1,45 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awstesthelpers
+
+import (
+	"maps"
+	"slices"
+
+	redshifttypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
+)
+
+// LabelsToRedshiftTags converts labels into [redshifttypes.Tag] list.
+func LabelsToRedshiftTags(labels map[string]string) []redshifttypes.Tag {
+	keys := slices.Collect(maps.Keys(labels))
+	slices.Sort(keys)
+
+	ret := make([]redshifttypes.Tag, 0, len(keys))
+	for _, key := range keys {
+		key := key
+		value := labels[key]
+
+		ret = append(ret, redshifttypes.Tag{
+			Key:   &key,
+			Value: &value,
+		})
+	}
+
+	return ret
+}

--- a/lib/cloud/clients.go
+++ b/lib/cloud/clients.go
@@ -53,8 +53,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/opensearchservice/opensearchserviceiface"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
-	"github.com/aws/aws-sdk-go/service/redshift"
-	"github.com/aws/aws-sdk-go/service/redshift/redshiftiface"
 	"github.com/aws/aws-sdk-go/service/redshiftserverless"
 	"github.com/aws/aws-sdk-go/service/redshiftserverless/redshiftserverlessiface"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -115,8 +113,6 @@ type AWSClients interface {
 	GetAWSSession(ctx context.Context, region string, opts ...AWSOptionsFn) (*awssession.Session, error)
 	// GetAWSRDSClient returns AWS RDS client for the specified region.
 	GetAWSRDSClient(ctx context.Context, region string, opts ...AWSOptionsFn) (rdsiface.RDSAPI, error)
-	// GetAWSRedshiftClient returns AWS Redshift client for the specified region.
-	GetAWSRedshiftClient(ctx context.Context, region string, opts ...AWSOptionsFn) (redshiftiface.RedshiftAPI, error)
 	// GetAWSRedshiftServerlessClient returns AWS Redshift Serverless client for the specified region.
 	GetAWSRedshiftServerlessClient(ctx context.Context, region string, opts ...AWSOptionsFn) (redshiftserverlessiface.RedshiftServerlessAPI, error)
 	// GetAWSElastiCacheClient returns AWS ElastiCache client for the specified region.
@@ -515,15 +511,6 @@ func (c *cloudClients) GetAWSRDSClient(ctx context.Context, region string, opts 
 		return nil, trace.Wrap(err)
 	}
 	return rds.New(session), nil
-}
-
-// GetAWSRedshiftClient returns AWS Redshift client for the specified region.
-func (c *cloudClients) GetAWSRedshiftClient(ctx context.Context, region string, opts ...AWSOptionsFn) (redshiftiface.RedshiftAPI, error) {
-	session, err := c.GetAWSSession(ctx, region, opts...)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return redshift.New(session), nil
 }
 
 // GetAWSRedshiftServerlessClient returns AWS Redshift Serverless client for the specified region.
@@ -1033,7 +1020,6 @@ var _ Clients = (*TestCloudClients)(nil)
 type TestCloudClients struct {
 	RDS                     rdsiface.RDSAPI
 	RDSPerRegion            map[string]rdsiface.RDSAPI
-	Redshift                redshiftiface.RedshiftAPI
 	RedshiftServerless      redshiftserverlessiface.RedshiftServerlessAPI
 	ElastiCache             elasticacheiface.ElastiCacheAPI
 	OpenSearch              opensearchserviceiface.OpenSearchServiceAPI
@@ -1113,15 +1099,6 @@ func (c *TestCloudClients) GetAWSRDSClient(ctx context.Context, region string, o
 		return c.RDSPerRegion[region], nil
 	}
 	return c.RDS, nil
-}
-
-// GetAWSRedshiftClient returns AWS Redshift client for the specified region.
-func (c *TestCloudClients) GetAWSRedshiftClient(ctx context.Context, region string, opts ...AWSOptionsFn) (redshiftiface.RedshiftAPI, error) {
-	_, err := c.GetAWSSession(ctx, region, opts...)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return c.Redshift, nil
 }
 
 // GetAWSRedshiftServerlessClient returns AWS Redshift Serverless client for the specified region.

--- a/lib/cloud/mocks/aws.go
+++ b/lib/cloud/mocks/aws.go
@@ -37,8 +37,8 @@ import (
 	"github.com/gravitational/trace"
 )
 
-// STSMock mocks AWS STS API.
-type STSMock struct {
+// STSClientV1 mocks AWS STS API for AWS SDK v1.
+type STSClientV1 struct {
 	stsiface.STSAPI
 	ARN                    string
 	URL                    *url.URL
@@ -47,36 +47,36 @@ type STSMock struct {
 	mu                     sync.Mutex
 }
 
-func (m *STSMock) GetAssumedRoleARNs() []string {
+func (m *STSClientV1) GetAssumedRoleARNs() []string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.assumedRoleARNs
 }
 
-func (m *STSMock) GetAssumedRoleExternalIDs() []string {
+func (m *STSClientV1) GetAssumedRoleExternalIDs() []string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.assumedRoleExternalIDs
 }
 
-func (m *STSMock) ResetAssumeRoleHistory() {
+func (m *STSClientV1) ResetAssumeRoleHistory() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.assumedRoleARNs = nil
 	m.assumedRoleExternalIDs = nil
 }
 
-func (m *STSMock) GetCallerIdentityWithContext(aws.Context, *sts.GetCallerIdentityInput, ...request.Option) (*sts.GetCallerIdentityOutput, error) {
+func (m *STSClientV1) GetCallerIdentityWithContext(aws.Context, *sts.GetCallerIdentityInput, ...request.Option) (*sts.GetCallerIdentityOutput, error) {
 	return &sts.GetCallerIdentityOutput{
 		Arn: aws.String(m.ARN),
 	}, nil
 }
 
-func (m *STSMock) AssumeRole(in *sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error) {
+func (m *STSClientV1) AssumeRole(in *sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error) {
 	return m.AssumeRoleWithContext(context.Background(), in)
 }
 
-func (m *STSMock) AssumeRoleWithContext(ctx aws.Context, in *sts.AssumeRoleInput, _ ...request.Option) (*sts.AssumeRoleOutput, error) {
+func (m *STSClientV1) AssumeRoleWithContext(ctx aws.Context, in *sts.AssumeRoleInput, _ ...request.Option) (*sts.AssumeRoleOutput, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if !slices.Contains(m.assumedRoleARNs, aws.StringValue(in.RoleArn)) {
@@ -94,7 +94,7 @@ func (m *STSMock) AssumeRoleWithContext(ctx aws.Context, in *sts.AssumeRoleInput
 	}, nil
 }
 
-func (m *STSMock) GetCallerIdentityRequest(req *sts.GetCallerIdentityInput) (*request.Request, *sts.GetCallerIdentityOutput) {
+func (m *STSClientV1) GetCallerIdentityRequest(req *sts.GetCallerIdentityInput) (*request.Request, *sts.GetCallerIdentityOutput) {
 	return &request.Request{
 		HTTPRequest: &http.Request{
 			Header: http.Header{},

--- a/lib/cloud/mocks/aws_config.go
+++ b/lib/cloud/mocks/aws_config.go
@@ -1,0 +1,42 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mocks
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+
+	"github.com/gravitational/teleport/lib/cloud/awsconfig"
+)
+
+type AWSConfigProvider struct {
+	STSClient *STSClient
+}
+
+func (f *AWSConfigProvider) GetConfig(ctx context.Context, region string, optFns ...awsconfig.OptionsFn) (aws.Config, error) {
+	stsClt := f.STSClient
+	if stsClt == nil {
+		stsClt = &STSClient{}
+	}
+	optFns = append(optFns, awsconfig.WithAssumeRoleClientProviderFunc(
+		newAssumeRoleClientProviderFunc(stsClt),
+	))
+	return awsconfig.GetConfig(ctx, region, optFns...)
+}

--- a/lib/cloud/mocks/aws_sts.go
+++ b/lib/cloud/mocks/aws_sts.go
@@ -1,0 +1,111 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mocks
+
+import (
+	"context"
+	"slices"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/cloud/awsconfig"
+)
+
+// STSClient mocks the AWS STS API for AWS SDK v1 and v2.
+// Callers can use it in tests for both the v1 and v2 interfaces.
+// This is useful when some services still use SDK v1 while others use v2 SDK,
+// so that all assumed roles can be recorded in one place.
+// For example:
+//
+// clt := &STSClient{}
+// a.stsClientV1 = &clt.STSClientV1
+// b.stsClientV2 = clt
+// ...
+// gotRoles := clt.GetAssumedRoleARNs() // returns roles that were assumed with either v1 or v2 client.
+type STSClient struct {
+	STSClientV1
+
+	// credentialProvider is only set when a chain of assumed roles is used.
+	credentialProvider aws.CredentialsProvider
+	// recordFn records the role and external ID when a role is assumed.
+	// It is only set when a chain of assumed roles is used, so that all assumed
+	// roles can be centralized and observed in tests.
+	recordFn func(roleARN, externalID string)
+}
+
+func (m *STSClient) AssumeRole(ctx context.Context, in *sts.AssumeRoleInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleOutput, error) {
+	// Retrieve credentials if we have a credential provider, so that all
+	// assume-role providers in a role chain are triggered to call AssumeRole.
+	if m.credentialProvider != nil {
+		_, err := m.credentialProvider.Retrieve(ctx)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+	m.record(aws.ToString(in.RoleArn), aws.ToString(in.ExternalId))
+
+	expiry := time.Now().Add(60 * time.Minute)
+	return &sts.AssumeRoleOutput{
+		Credentials: &ststypes.Credentials{
+			AccessKeyId:     in.RoleArn,
+			SecretAccessKey: aws.String("secret"),
+			SessionToken:    aws.String("token"),
+			Expiration:      &expiry,
+		},
+	}, nil
+}
+
+// record is a helper function that records the role ARN and external ID for an
+// assumed role.
+// It delegates to the configured recordFn, if it has one, so that all assumed
+// role recordings are centralized for observation in tests.
+func (m *STSClient) record(roleARN, externalID string) {
+	if m.recordFn != nil {
+		m.recordFn(roleARN, externalID)
+		return
+	}
+	m.STSClientV1.mu.Lock()
+	defer m.STSClientV1.mu.Unlock()
+	if !slices.Contains(m.assumedRoleARNs, roleARN) {
+		m.assumedRoleARNs = append(m.assumedRoleARNs, roleARN)
+		m.assumedRoleExternalIDs = append(m.assumedRoleExternalIDs, externalID)
+	}
+}
+
+func newAssumeRoleClientProviderFunc(base *STSClient) awsconfig.AssumeRoleClientProviderFunc {
+	return func(cfg aws.Config) stscreds.AssumeRoleAPIClient {
+		if cfg.Credentials != nil {
+			if _, ok := cfg.Credentials.(*stscreds.AssumeRoleProvider); ok {
+				// Create a new fake client linked to the old one.
+				// Only do this for AssumeRoleProvider to avoid attempting
+				// to load the real credential chain.
+				return &STSClient{
+					credentialProvider: cfg.Credentials,
+					recordFn:           base.record,
+				}
+			}
+		}
+		return base
+	}
+}

--- a/lib/kube/proxy/kube_creds_test.go
+++ b/lib/kube/proxy/kube_creds_test.go
@@ -105,7 +105,7 @@ func Test_DynamicKubeCreds(t *testing.T) {
 		Host:   "sts.amazonaws.com",
 		Path:   "/?Action=GetCallerIdentity&Version=2011-06-15",
 	}
-	sts := &mocks.STSMock{
+	sts := &mocks.STSClientV1{
 		// u is used to presign the request
 		// here we just verify the pre-signed request includes this url.
 		URL: u,

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -61,6 +61,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/authz"
 	clients "github.com/gravitational/teleport/lib/cloud"
+	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 	"github.com/gravitational/teleport/lib/cloud/mocks"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -2447,6 +2448,8 @@ type agentParams struct {
 	CADownloader CADownloader
 	// CloudClients is the cloud API clients for database service.
 	CloudClients clients.Clients
+	// AWSConfigProvider provides [aws.Config] for AWS SDK service clients.
+	AWSConfigProvider awsconfig.Provider
 	// AWSMatchers is a list of AWS databases matchers.
 	AWSMatchers []types.AWSMatcher
 	// AzureMatchers is a list of Azure databases matchers.
@@ -2487,9 +2490,8 @@ func (p *agentParams) setDefaults(c *testContext) {
 
 	if p.CloudClients == nil {
 		p.CloudClients = &clients.TestCloudClients{
-			STS:                &mocks.STSMock{},
+			STS:                &mocks.STSClientV1{},
 			RDS:                &mocks.RDSMock{},
-			Redshift:           &mocks.RedshiftMock{},
 			RedshiftServerless: &mocks.RedshiftServerlessMock{},
 			ElastiCache:        p.ElastiCache,
 			MemoryDB:           p.MemoryDB,
@@ -2497,6 +2499,9 @@ func (p *agentParams) setDefaults(c *testContext) {
 			IAM:                &mocks.IAMMock{},
 			GCPSQL:             p.GCPSQL,
 		}
+	}
+	if p.AWSConfigProvider == nil {
+		p.AWSConfigProvider = &mocks.AWSConfigProvider{}
 	}
 
 	if p.DiscoveryResourceChecker == nil {
@@ -2530,10 +2535,11 @@ func (c *testContext) setupDatabaseServer(ctx context.Context, t testing.TB, p a
 
 	// Create test database auth tokens generator.
 	testAuth, err := newTestAuth(common.AuthConfig{
-		AuthClient:  c.authClient,
-		AccessPoint: c.authClient,
-		Clients:     &clients.TestCloudClients{},
-		Clock:       c.clock,
+		AuthClient:        c.authClient,
+		AccessPoint:       c.authClient,
+		Clients:           &clients.TestCloudClients{},
+		Clock:             c.clock,
+		AWSConfigProvider: &mocks.AWSConfigProvider{},
 	})
 	require.NoError(t, err)
 
@@ -2602,6 +2608,7 @@ func (c *testContext) setupDatabaseServer(ctx context.Context, t testing.TB, p a
 		OnReconcile:              p.OnReconcile,
 		ConnectionMonitor:        connMonitor,
 		CloudClients:             p.CloudClients,
+		AWSConfigProvider:        p.AWSConfigProvider,
 		AWSMatchers:              p.AWSMatchers,
 		AzureMatchers:            p.AzureMatchers,
 		ShutdownPollPeriod:       100 * time.Millisecond,

--- a/lib/srv/db/cloud/aws.go
+++ b/lib/srv/db/cloud/aws.go
@@ -75,7 +75,7 @@ func newAWS(ctx context.Context, config awsConfig) (*awsClient, error) {
 		teleport.ComponentKey, "aws",
 		"db", config.database.GetName(),
 	)
-	dbConfigurator, err := getDBConfigurator(ctx, logger, config.clients, config.database)
+	dbConfigurator, err := getDBConfigurator(logger, config.clients, config.database)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -102,7 +102,7 @@ type dbIAMAuthConfigurator interface {
 }
 
 // getDBConfigurator returns a database IAM Auth configurator.
-func getDBConfigurator(ctx context.Context, logger *slog.Logger, clients cloud.Clients, db types.Database) (dbIAMAuthConfigurator, error) {
+func getDBConfigurator(logger *slog.Logger, clients cloud.Clients, db types.Database) (dbIAMAuthConfigurator, error) {
 	if db.IsRDS() {
 		// Only setting for RDS instances and Aurora clusters.
 		return &rdsDBConfigurator{clients: clients, logger: logger}, nil

--- a/lib/srv/db/cloud/iam_test.go
+++ b/lib/srv/db/cloud/iam_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/rds"
-	"github.com/aws/aws-sdk-go/service/redshift"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
@@ -59,23 +58,14 @@ func TestAWSIAM(t *testing.T) {
 		DbClusterResourceId: aws.String("cluster-xyz"),
 	}
 
-	redshiftCluster := &redshift.Cluster{
-		ClusterNamespaceArn: aws.String("arn:aws:redshift:us-east-2:123456789012:namespace:namespace-xyz"),
-		ClusterIdentifier:   aws.String("redshift-cluster-1"),
-	}
-
 	// Configure mocks.
-	stsClient := &mocks.STSMock{
+	stsClient := &mocks.STSClientV1{
 		ARN: "arn:aws:iam::123456789012:role/test-role",
 	}
 
 	rdsClient := &mocks.RDSMock{
 		DBInstances: []*rds.DBInstance{rdsInstance},
 		DBClusters:  []*rds.DBCluster{auroraCluster},
-	}
-
-	redshiftClient := &mocks.RedshiftMock{
-		Clusters: []*redshift.Cluster{redshiftCluster},
 	}
 
 	iamClient := &mocks.IAMMock{}
@@ -163,10 +153,9 @@ func TestAWSIAM(t *testing.T) {
 	configurator, err := NewIAM(ctx, IAMConfig{
 		AccessPoint: &mockAccessPoint{},
 		Clients: &clients.TestCloudClients{
-			RDS:      rdsClient,
-			Redshift: redshiftClient,
-			STS:      stsClient,
-			IAM:      iamClient,
+			RDS: rdsClient,
+			STS: stsClient,
+			IAM: iamClient,
 		},
 		HostID: "host-id",
 		onProcessedTask: func(iamTask, error) {
@@ -294,7 +283,7 @@ func TestAWSIAMNoPermissions(t *testing.T) {
 	t.Cleanup(cancel)
 
 	// Create unauthorized mocks for AWS services.
-	stsClient := &mocks.STSMock{
+	stsClient := &mocks.STSClientV1{
 		ARN: "arn:aws:iam::123456789012:role/test-role",
 	}
 	// Make configurator.
@@ -347,7 +336,6 @@ func TestAWSIAMNoPermissions(t *testing.T) {
 			name: "Redshift cluster",
 			meta: types.AWS{Region: "localhost", AccountID: "123456789012", Redshift: types.Redshift{ClusterID: "redshift-cluster-1"}},
 			clients: &clients.TestCloudClients{
-				Redshift: &mocks.RedshiftMockUnauth{},
 				IAM: &mocks.IAMErrorMock{
 					Error: trace.AccessDenied("unauthorized"),
 				},
@@ -371,7 +359,6 @@ func TestAWSIAMNoPermissions(t *testing.T) {
 			name: "IAM UnmodifiableEntityException",
 			meta: types.AWS{Region: "localhost", AccountID: "123456789012", Redshift: types.Redshift{ClusterID: "redshift-cluster-1"}},
 			clients: &clients.TestCloudClients{
-				Redshift: &mocks.RedshiftMockUnauth{},
 				IAM: &mocks.IAMErrorMock{
 					Error: awserr.New(iam.ErrCodeUnmodifiableEntityException, "unauthorized", fmt.Errorf("unauthorized")),
 				},

--- a/lib/srv/db/cloud/meta.go
+++ b/lib/srv/db/cloud/meta.go
@@ -23,15 +23,15 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/redshift"
+	redshifttypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/aws/aws-sdk-go/service/elasticache/elasticacheiface"
 	"github.com/aws/aws-sdk-go/service/memorydb"
 	"github.com/aws/aws-sdk-go/service/memorydb/memorydbiface"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
-	"github.com/aws/aws-sdk-go/service/redshift"
-	"github.com/aws/aws-sdk-go/service/redshift/redshiftiface"
 	"github.com/aws/aws-sdk-go/service/redshiftserverless"
 	"github.com/aws/aws-sdk-go/service/redshiftserverless/redshiftserverlessiface"
 	"github.com/gravitational/trace"
@@ -39,15 +39,30 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud"
+	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	discoverycommon "github.com/gravitational/teleport/lib/srv/discovery/common"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
+// redshiftClient defines a subset of the AWS Redshift client API.
+type redshiftClient interface {
+	redshift.DescribeClustersAPIClient
+}
+
+// redshiftClientProviderFunc provides a [redshiftClient].
+type redshiftClientProviderFunc func(cfg aws.Config, optFns ...func(*redshift.Options)) redshiftClient
+
 // MetadataConfig is the cloud metadata service config.
 type MetadataConfig struct {
 	// Clients is an interface for retrieving cloud clients.
 	Clients cloud.Clients
+	// AWSConfigProvider provides [aws.Config] for AWS SDK service clients.
+	AWSConfigProvider awsconfig.Provider
+
+	// redshiftClientProviderFn is an internal-only [redshiftClient] provider
+	// func that is only set in tests.
+	redshiftClientProviderFn redshiftClientProviderFunc
 }
 
 // Check validates the metadata service config.
@@ -58,6 +73,15 @@ func (c *MetadataConfig) Check() error {
 			return trace.Wrap(err)
 		}
 		c.Clients = cloudClients
+	}
+	if c.AWSConfigProvider == nil {
+		return trace.BadParameter("missing AWSConfigProvider")
+	}
+
+	if c.redshiftClientProviderFn == nil {
+		c.redshiftClientProviderFn = func(cfg aws.Config, optFns ...func(*redshift.Options)) redshiftClient {
+			return redshift.NewFromConfig(cfg, optFns...)
+		}
 	}
 	return nil
 }
@@ -177,13 +201,14 @@ func (m *Metadata) fetchRDSProxyMetadata(ctx context.Context, database types.Dat
 // fetchRedshiftMetadata fetches metadata for the provided Redshift database.
 func (m *Metadata) fetchRedshiftMetadata(ctx context.Context, database types.Database) (*types.AWS, error) {
 	meta := database.GetAWS()
-	redshift, err := m.cfg.Clients.GetAWSRedshiftClient(ctx, meta.Region,
-		cloud.WithAssumeRoleFromAWSMeta(meta),
-		cloud.WithAmbientCredentials(),
+	awsCfg, err := m.cfg.AWSConfigProvider.GetConfig(ctx, meta.Region,
+		awsconfig.WithAssumeRole(meta.AssumeRoleARN, meta.ExternalID),
+		awsconfig.WithAmbientCredentials(),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	redshift := m.cfg.redshiftClientProviderFn(awsCfg)
 	cluster, err := describeRedshiftCluster(ctx, redshift, meta.Redshift.ClusterID)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -296,8 +321,8 @@ func describeRDSCluster(ctx context.Context, rdsClient rdsiface.RDSAPI, clusterI
 }
 
 // describeRedshiftCluster returns AWS Redshift cluster for the specified ID.
-func describeRedshiftCluster(ctx context.Context, redshiftClient redshiftiface.RedshiftAPI, clusterID string) (*redshift.Cluster, error) {
-	out, err := redshiftClient.DescribeClustersWithContext(ctx, &redshift.DescribeClustersInput{
+func describeRedshiftCluster(ctx context.Context, clt redshiftClient, clusterID string) (*redshifttypes.Cluster, error) {
+	out, err := clt.DescribeClusters(ctx, &redshift.DescribeClustersInput{
 		ClusterIdentifier: aws.String(clusterID),
 	})
 	if err != nil {
@@ -306,7 +331,7 @@ func describeRedshiftCluster(ctx context.Context, redshiftClient redshiftiface.R
 	if len(out.Clusters) != 1 {
 		return nil, trace.BadParameter("expected 1 Redshift cluster for %v, got %+v", clusterID, out.Clusters)
 	}
-	return out.Clusters[0], nil
+	return &out.Clusters[0], nil
 }
 
 // describeElastiCacheCluster returns AWS ElastiCache Redis cluster for the
@@ -369,7 +394,7 @@ func fetchRDSProxyCustomEndpointMetadata(ctx context.Context, rdsClient rdsiface
 		return nil, trace.Wrap(err)
 	}
 
-	rdsProxy, err := describeRDSProxy(ctx, rdsClient, aws.StringValue(rdsProxyEndpoint.DBProxyName))
+	rdsProxy, err := describeRDSProxy(ctx, rdsClient, aws.ToString(rdsProxyEndpoint.DBProxyName))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -389,7 +414,7 @@ func describeRDSProxyCustomEndpointAndFindURI(ctx context.Context, rdsClient rds
 	for _, customEndpoint := range out.DBProxyEndpoints {
 		// Double check if it has the same URI in case multiple custom
 		// endpoints have the same name.
-		if strings.Contains(uri, aws.StringValue(customEndpoint.Endpoint)) {
+		if strings.Contains(uri, aws.ToString(customEndpoint.Endpoint)) {
 			return customEndpoint, nil
 		}
 	}
@@ -408,7 +433,7 @@ func fetchRedshiftServerlessVPCEndpointMetadata(ctx context.Context, client reds
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	workgroup, err := describeRedshiftServerlessWorkgroup(ctx, client, aws.StringValue(endpoint.WorkgroupName))
+	workgroup, err := describeRedshiftServerlessWorkgroup(ctx, client, aws.ToString(endpoint.WorkgroupName))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/db/cloud/resource_checker.go
+++ b/lib/srv/db/cloud/resource_checker.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud"
+	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -40,6 +41,8 @@ type DiscoveryResourceChecker interface {
 
 // DiscoveryResourceCheckerConfig is the config for DiscoveryResourceChecker.
 type DiscoveryResourceCheckerConfig struct {
+	// AWSConfigProvider provides [aws.Config] for AWS SDK service clients.
+	AWSConfigProvider awsconfig.Provider
 	// ResourceMatchers is a list of database resource matchers.
 	ResourceMatchers []services.ResourceMatcher
 	// Clients is an interface for retrieving cloud clients.
@@ -58,6 +61,9 @@ func (c *DiscoveryResourceCheckerConfig) CheckAndSetDefaults() error {
 			return trace.Wrap(err)
 		}
 		c.Clients = cloudClients
+	}
+	if c.AWSConfigProvider == nil {
+		return trace.BadParameter("missing AWSConfigProvider")
 	}
 	if c.Context == nil {
 		c.Context = context.Background()

--- a/lib/srv/db/cloud/resource_checker_url.go
+++ b/lib/srv/db/cloud/resource_checker_url.go
@@ -27,17 +27,25 @@ import (
 	"slices"
 	"sync"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/redshift"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils"
 	apiawsutils "github.com/gravitational/teleport/api/utils/aws"
 	"github.com/gravitational/teleport/lib/cloud"
+	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 )
 
 // urlChecker validates the database has the correct URL.
 type urlChecker struct {
+	// awsConfigProvider provides [aws.Config] for AWS SDK service clients.
+	awsConfigProvider awsconfig.Provider
+	// redshiftClientProviderFn is an internal-only [redshiftClient] provider
+	// func that is only set in tests.
+	redshiftClientProviderFn redshiftClientProviderFunc
+
 	clients     cloud.Clients
 	logger      *slog.Logger
 	warnOnError bool
@@ -52,6 +60,10 @@ type urlChecker struct {
 
 func newURLChecker(cfg DiscoveryResourceCheckerConfig) *urlChecker {
 	return &urlChecker{
+		awsConfigProvider: cfg.AWSConfigProvider,
+		redshiftClientProviderFn: func(cfg aws.Config, optFns ...func(*redshift.Options)) redshiftClient {
+			return redshift.NewFromConfig(cfg, optFns...)
+		},
 		clients:     cfg.Clients,
 		logger:      cfg.Logger,
 		warnOnError: getWarnOnError(),
@@ -121,8 +133,13 @@ func requireDatabaseIsEndpoint(ctx context.Context, database types.Database, isE
 	return trace.Wrap(convIsEndpoint(isEndpoint)(ctx, database))
 }
 
-func requireDatabaseAddressPort(database types.Database, wantURLHost *string, wantURLPort *int64) error {
-	wantURL := fmt.Sprintf("%v:%v", aws.StringValue(wantURLHost), aws.Int64Value(wantURLPort))
+// TODO(gavin): remove the generic type parameter after all callers are migrated from AWS SDK v1 (uses *int64) to SDK v2 (uses *int32).
+func requireDatabaseAddressPort[T ~int32 | ~int64](database types.Database, wantURLHost *string, wantURLPort *T) error {
+	var port int
+	if wantURLPort != nil {
+		port = int(*wantURLPort)
+	}
+	wantURL := fmt.Sprintf("%v:%v", aws.ToString(wantURLHost), port)
 	if database.GetURI() != wantURL {
 		return trace.BadParameter("expect database URL %q but got %q for database %q", wantURL, database.GetURI(), database.GetName())
 	}

--- a/lib/srv/db/common/errors.go
+++ b/lib/srv/db/common/errors.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/gravitational/trace"
@@ -66,12 +67,15 @@ func ConvertError(err error) error {
 
 	var googleAPIErr *googleapi.Error
 	var awsRequestFailureErr awserr.RequestFailure
+	var awsRequestFailureErrV2 *awshttp.ResponseError
 	var azResponseErr *azcore.ResponseError
 	var pgError *pgconn.PgError
 	var myError *mysql.MyError
 	switch err := trace.Unwrap(err); {
 	case errors.As(err, &googleAPIErr):
 		return convertGCPError(googleAPIErr)
+	case errors.As(err, &awsRequestFailureErrV2):
+		return awslib.ConvertRequestFailureErrorV2(awsRequestFailureErrV2)
 	case errors.As(err, &awsRequestFailureErr):
 		return awslib.ConvertRequestFailureError(awsRequestFailureErr)
 	case errors.As(err, &azResponseErr):

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/authz"
 	clients "github.com/gravitational/teleport/lib/cloud"
+	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/inventory"
@@ -68,6 +69,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv/db/spanner"
 	"github.com/gravitational/teleport/lib/srv/db/sqlserver"
 	discoverycommon "github.com/gravitational/teleport/lib/srv/discovery/common"
+	"github.com/gravitational/teleport/lib/srv/discovery/fetchers/db"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -138,6 +140,10 @@ type Config struct {
 	CADownloader CADownloader
 	// CloudClients creates cloud API clients.
 	CloudClients clients.Clients
+	// AWSConfigProvider provides [aws.Config] for AWS SDK service clients.
+	AWSConfigProvider awsconfig.Provider
+	// AWSDatabaseFetcherFactory provides AWS database fetchers
+	AWSDatabaseFetcherFactory *db.AWSFetcherFactory
 	// CloudMeta fetches cloud metadata for cloud hosted databases.
 	CloudMeta *cloud.Metadata
 	// CloudIAM configures IAM for cloud hosted databases.
@@ -192,12 +198,30 @@ func (c *Config) CheckAndSetDefaults(ctx context.Context) (err error) {
 		}
 		c.CloudClients = cloudClients
 	}
+	if c.AWSConfigProvider == nil {
+		provider, err := awsconfig.NewCache()
+		if err != nil {
+			return trace.Wrap(err, "unable to create AWS config provider cache")
+		}
+		c.AWSConfigProvider = provider
+	}
+	if c.AWSDatabaseFetcherFactory == nil {
+		factory, err := db.NewAWSFetcherFactory(db.AWSFetcherFactoryConfig{
+			CloudClients:      c.CloudClients,
+			AWSConfigProvider: c.AWSConfigProvider,
+		})
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		c.AWSDatabaseFetcherFactory = factory
+	}
 	if c.Auth == nil {
 		c.Auth, err = common.NewAuth(common.AuthConfig{
-			AuthClient:  c.AuthClient,
-			AccessPoint: c.AccessPoint,
-			Clock:       c.Clock,
-			Clients:     c.CloudClients,
+			AuthClient:        c.AuthClient,
+			AccessPoint:       c.AccessPoint,
+			Clock:             c.Clock,
+			Clients:           c.CloudClients,
+			AWSConfigProvider: c.AWSConfigProvider,
 		})
 		if err != nil {
 			return trace.Wrap(err)
@@ -226,7 +250,8 @@ func (c *Config) CheckAndSetDefaults(ctx context.Context) (err error) {
 	}
 	if c.CloudMeta == nil {
 		c.CloudMeta, err = cloud.NewMetadata(cloud.MetadataConfig{
-			Clients: c.CloudClients,
+			Clients:           c.CloudClients,
+			AWSConfigProvider: c.AWSConfigProvider,
 		})
 		if err != nil {
 			return trace.Wrap(err)
@@ -282,9 +307,10 @@ func (c *Config) CheckAndSetDefaults(ctx context.Context) (err error) {
 
 	if c.discoveryResourceChecker == nil {
 		c.discoveryResourceChecker, err = cloud.NewDiscoveryResourceChecker(cloud.DiscoveryResourceCheckerConfig{
-			ResourceMatchers: c.ResourceMatchers,
-			Clients:          c.CloudClients,
-			Context:          ctx,
+			ResourceMatchers:  c.ResourceMatchers,
+			Clients:           c.CloudClients,
+			AWSConfigProvider: c.AWSConfigProvider,
+			Context:           ctx,
 		})
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/srv/db/watcher.go
+++ b/lib/srv/db/watcher.go
@@ -110,7 +110,7 @@ func (s *Server) startResourceWatcher(ctx context.Context) (*services.GenericWat
 // startCloudWatcher starts fetching cloud databases according to the
 // selectors and register/unregister them appropriately.
 func (s *Server) startCloudWatcher(ctx context.Context) error {
-	awsFetchers, err := dbfetchers.MakeAWSFetchers(ctx, s.cfg.CloudClients, s.cfg.AWSMatchers, "" /* discovery config */)
+	awsFetchers, err := s.cfg.AWSDatabaseFetcherFactory.MakeFetchers(ctx, s.cfg.AWSMatchers, "" /* discovery config */)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/discovery/common/database_test.go
+++ b/lib/srv/discovery/common/database_test.go
@@ -27,12 +27,12 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	rdsTypesV2 "github.com/aws/aws-sdk-go-v2/service/rds/types"
-	"github.com/aws/aws-sdk-go/aws"
+	redshifttypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/aws/aws-sdk-go/service/memorydb"
 	"github.com/aws/aws-sdk-go/service/rds"
-	"github.com/aws/aws-sdk-go/service/redshift"
 	"github.com/aws/aws-sdk-go/service/redshiftserverless"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
@@ -1182,14 +1182,14 @@ func TestAzureTagsToLabels(t *testing.T) {
 // TestDatabaseFromRedshiftCluster tests converting an Redshift cluster to a database resource.
 func TestDatabaseFromRedshiftCluster(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		cluster := &redshift.Cluster{
+		cluster := &redshifttypes.Cluster{
 			ClusterIdentifier:   aws.String("mycluster"),
 			ClusterNamespaceArn: aws.String("arn:aws:redshift:us-east-1:123456789012:namespace:u-u-i-d"),
-			Endpoint: &redshift.Endpoint{
+			Endpoint: &redshifttypes.Endpoint{
 				Address: aws.String("localhost"),
-				Port:    aws.Int64(5439),
+				Port:    aws.Int32(5439),
 			},
-			Tags: []*redshift.Tag{
+			Tags: []redshifttypes.Tag{
 				{
 					Key:   aws.String("key"),
 					Value: aws.String("val"),
@@ -1231,14 +1231,14 @@ func TestDatabaseFromRedshiftCluster(t *testing.T) {
 
 	for _, overrideLabel := range types.AWSDatabaseNameOverrideLabels {
 		t.Run("success with name override via"+overrideLabel, func(t *testing.T) {
-			cluster := &redshift.Cluster{
+			cluster := &redshifttypes.Cluster{
 				ClusterIdentifier:   aws.String("mycluster"),
 				ClusterNamespaceArn: aws.String("arn:aws:redshift:us-east-1:123456789012:namespace:u-u-i-d"),
-				Endpoint: &redshift.Endpoint{
+				Endpoint: &redshifttypes.Endpoint{
 					Address: aws.String("localhost"),
-					Port:    aws.Int64(5439),
+					Port:    aws.Int32(5439),
 				},
-				Tags: []*redshift.Tag{
+				Tags: []redshifttypes.Tag{
 					{
 						Key:   aws.String("key"),
 						Value: aws.String("val"),
@@ -1284,7 +1284,7 @@ func TestDatabaseFromRedshiftCluster(t *testing.T) {
 		})
 
 		t.Run("missing endpoint", func(t *testing.T) {
-			_, err := NewDatabaseFromRedshiftCluster(&redshift.Cluster{
+			_, err := NewDatabaseFromRedshiftCluster(&redshifttypes.Cluster{
 				ClusterIdentifier: aws.String("still-creating"),
 			})
 			require.Error(t, err)

--- a/lib/srv/discovery/config_test.go
+++ b/lib/srv/discovery/config_test.go
@@ -50,6 +50,8 @@ func TestConfigCheckAndSetDefaults(t *testing.T) {
 			cfgChange:     func(c *Config) {},
 			postCheckAndSetDefaultsFunc: func(t *testing.T, c *Config) {
 				require.NotNil(t, c.CloudClients)
+				require.NotNil(t, c.AWSConfigProvider)
+				require.NotNil(t, c.AWSDatabaseFetcherFactory)
 				require.NotNil(t, c.Log)
 				require.NotNil(t, c.clock)
 				require.NotNil(t, c.TriggerFetchC)

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -115,6 +115,10 @@ type gcpInstaller interface {
 type Config struct {
 	// CloudClients is an interface for retrieving cloud clients.
 	CloudClients cloud.Clients
+	// AWSConfigProvider provides [aws.Config] for AWS SDK service clients.
+	AWSConfigProvider awsconfig.Provider
+	// AWSDatabaseFetcherFactory provides AWS database fetchers
+	AWSDatabaseFetcherFactory *db.AWSFetcherFactory
 	// GetEC2Client gets an AWS EC2 client for the given region.
 	GetEC2Client server.EC2ClientGetter
 	// GetSSMClient gets an AWS SSM client for the given region.
@@ -219,6 +223,24 @@ kubernetes matchers are present.`)
 		}
 		c.CloudClients = cloudClients
 	}
+	if c.AWSConfigProvider == nil {
+		provider, err := awsconfig.NewCache()
+		if err != nil {
+			return trace.Wrap(err, "unable to create AWS config provider cache")
+		}
+		c.AWSConfigProvider = provider
+	}
+	if c.AWSDatabaseFetcherFactory == nil {
+		factory, err := db.NewAWSFetcherFactory(db.AWSFetcherFactoryConfig{
+			CloudClients:                    c.CloudClients,
+			AWSConfigProvider:               c.AWSConfigProvider,
+			IntegrationCredentialProviderFn: c.getIntegrationCredentialProviderFn(),
+		})
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		c.AWSDatabaseFetcherFactory = factory
+	}
 	if c.GetEC2Client == nil {
 		c.GetEC2Client = func(ctx context.Context, region string, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
 			cfg, err := c.getAWSConfig(ctx, region, opts...)
@@ -290,7 +312,13 @@ kubernetes matchers are present.`)
 }
 
 func (c *Config) getAWSConfig(ctx context.Context, region string, opts ...awsconfig.OptionsFn) (aws.Config, error) {
-	opts = append(opts, awsconfig.WithIntegrationCredentialProvider(func(ctx context.Context, region, integrationName string) (aws.CredentialsProvider, error) {
+	opts = append(opts, awsconfig.WithIntegrationCredentialProvider(c.getIntegrationCredentialProviderFn()))
+	cfg, err := c.AWSConfigProvider.GetConfig(ctx, region, opts...)
+	return cfg, trace.Wrap(err)
+}
+
+func (c *Config) getIntegrationCredentialProviderFn() awsconfig.IntegrationCredentialProviderFunc {
+	return func(ctx context.Context, region, integrationName string) (aws.CredentialsProvider, error) {
 		integration, err := c.AccessPoint.GetIntegration(ctx, integrationName)
 		if err != nil {
 			return nil, trace.Wrap(err)
@@ -308,9 +336,7 @@ func (c *Config) getAWSConfig(ctx context.Context, region string, opts ...awscon
 			Region:  region,
 		})
 		return cred, trace.Wrap(err)
-	}))
-	cfg, err := awsconfig.GetConfig(ctx, region, opts...)
-	return cfg, trace.Wrap(err)
+	}
 }
 
 // Server is a discovery server, used to discover cloud resources for
@@ -682,7 +708,7 @@ func (s *Server) databaseFetchersFromMatchers(matchers Matchers, discoveryConfig
 	// AWS
 	awsDatabaseMatchers, _ := splitMatchers(matchers.AWS, db.IsAWSMatcherType)
 	if len(awsDatabaseMatchers) > 0 {
-		databaseFetchers, err := db.MakeAWSFetchers(s.ctx, s.CloudClients, awsDatabaseMatchers, discoveryConfigName)
+		databaseFetchers, err := s.AWSDatabaseFetcherFactory.MakeFetchers(s.ctx, awsDatabaseMatchers, discoveryConfigName)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -37,8 +37,11 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3"
 	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/redshift"
+	redshifttypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/aws/aws-sdk-go/aws"
@@ -46,7 +49,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/aws/aws-sdk-go/service/eks/eksiface"
 	"github.com/aws/aws-sdk-go/service/rds"
-	"github.com/aws/aws-sdk-go/service/redshift"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
@@ -85,6 +87,7 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
+	"github.com/gravitational/teleport/lib/srv/discovery/fetchers/db"
 	"github.com/gravitational/teleport/lib/srv/server"
 	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
 	libutils "github.com/gravitational/teleport/lib/utils"
@@ -692,7 +695,7 @@ func TestDiscoveryServer(t *testing.T) {
 			foundEC2Instances: []ec2types.Instance{},
 			ssm:               &mockSSMClient{},
 			cloudClients: &cloud.TestCloudClients{
-				STS: &mocks.STSMock{},
+				STS: &mocks.STSClientV1{},
 				EKS: &mocks.EKSMock{
 					Clusters: []*eks.Cluster{
 						{
@@ -1441,7 +1444,7 @@ func TestDiscoveryInCloudKube(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			sts := &mocks.STSMock{}
+			sts := &mocks.STSClientV1{}
 
 			testCloudClients := &cloud.TestCloudClients{
 				STS:            sts,
@@ -1587,7 +1590,7 @@ func TestDiscoveryServer_New(t *testing.T) {
 	}{
 		{
 			desc:         "no matchers error",
-			cloudClients: &cloud.TestCloudClients{STS: &mocks.STSMock{}},
+			cloudClients: &cloud.TestCloudClients{STS: &mocks.STSClientV1{}},
 			matchers:     Matchers{},
 			errAssertion: func(t require.TestingT, err error, i ...interface{}) {
 				require.ErrorIs(t, err, &trace.BadParameterError{Message: "no matchers or discovery group configured for discovery"})
@@ -1596,7 +1599,7 @@ func TestDiscoveryServer_New(t *testing.T) {
 		},
 		{
 			desc:         "success with EKS matcher",
-			cloudClients: &cloud.TestCloudClients{STS: &mocks.STSMock{}, EKS: &mocks.EKSMock{}},
+			cloudClients: &cloud.TestCloudClients{STS: &mocks.STSClientV1{}, EKS: &mocks.EKSMock{}},
 			matchers: Matchers{
 				AWS: []types.AWSMatcher{
 					{
@@ -1621,7 +1624,7 @@ func TestDiscoveryServer_New(t *testing.T) {
 		{
 			desc: "EKS fetcher is skipped on initialization error (missing region)",
 			cloudClients: &cloud.TestCloudClients{
-				STS: &mocks.STSMock{},
+				STS: &mocks.STSClientV1{},
 				EKS: &mocks.EKSMock{},
 			},
 			matchers: Matchers{
@@ -2010,7 +2013,7 @@ func TestDiscoveryDatabase(t *testing.T) {
 	}
 
 	testCloudClients := &cloud.TestCloudClients{
-		STS: &mocks.STSMock{},
+		STS: &mocks.STSClientV1{},
 		RDS: &mocks.RDSMock{
 			DBInstances: []*rds.DBInstance{awsRDSInstance},
 			DBEngineVersions: []*rds.DBEngineVersion{
@@ -2018,9 +2021,6 @@ func TestDiscoveryDatabase(t *testing.T) {
 			},
 		},
 		MemoryDB: &mocks.MemoryDBMock{},
-		Redshift: &mocks.RedshiftMock{
-			Clusters: []*redshift.Cluster{awsRedshiftResource},
-		},
 		AzureRedis: azure.NewRedisClientByAPI(&azure.ARMRedisMock{
 			Servers: []*armredis.ResourceInfo{azRedisResource},
 		}),
@@ -2032,6 +2032,18 @@ func TestDiscoveryDatabase(t *testing.T) {
 			Clusters: []*eks.Cluster{eksAWSResource},
 		},
 	}
+	fakeConfigProvider := &mocks.AWSConfigProvider{}
+	dbFetcherFactory, err := db.NewAWSFetcherFactory(db.AWSFetcherFactoryConfig{
+		AWSConfigProvider: fakeConfigProvider,
+		CloudClients:      testCloudClients,
+		IntegrationCredentialProviderFn: func(_ context.Context, _, _ string) (awsv2.CredentialsProvider, error) {
+			return credentials.NewStaticCredentialsProvider("key", "secret", "session"), nil
+		},
+		RedshiftClientProviderFn: newFakeRedshiftClientProvider(&mocks.RedshiftClient{
+			Clusters: []redshifttypes.Cluster{*awsRedshiftResource},
+		}),
+	})
+	require.NoError(t, err)
 
 	tcs := []struct {
 		name                        string
@@ -2342,6 +2354,8 @@ func TestDiscoveryDatabase(t *testing.T) {
 				&Config{
 					IntegrationOnlyCredentials: integrationOnlyCredential,
 					CloudClients:               testCloudClients,
+					AWSDatabaseFetcherFactory:  dbFetcherFactory,
+					AWSConfigProvider:          fakeConfigProvider,
 					ClusterFeatures:            func() proto.Features { return proto.Features{} },
 					KubernetesClient:           fake.NewSimpleClientset(),
 					AccessPoint:                getDiscoveryAccessPoint(tlsServer.Auth(), authClient),
@@ -2422,7 +2436,7 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 	awsRDSInstance, awsRDSDB := makeRDSInstance(t, "aws-rds", "us-west-1", rewriteDiscoveryLabelsParams{discoveryConfigName: dc2Name, discoveryGroup: mainDiscoveryGroup})
 
 	testCloudClients := &cloud.TestCloudClients{
-		STS: &mocks.STSMock{},
+		STS: &mocks.STSClientV1{},
 		RDS: &mocks.RDSMock{
 			DBInstances: []*rds.DBInstance{awsRDSInstance},
 			DBEngineVersions: []*rds.DBEngineVersion{
@@ -2606,15 +2620,15 @@ func makeRDSInstance(t *testing.T, name, region string, discoveryParams rewriteD
 	return instance, database
 }
 
-func makeRedshiftCluster(t *testing.T, name, region string, discoveryParams rewriteDiscoveryLabelsParams) (*redshift.Cluster, types.Database) {
+func makeRedshiftCluster(t *testing.T, name, region string, discoveryParams rewriteDiscoveryLabelsParams) (*redshifttypes.Cluster, types.Database) {
 	t.Helper()
-	cluster := &redshift.Cluster{
+	cluster := &redshifttypes.Cluster{
 		ClusterIdentifier:   aws.String(name),
 		ClusterNamespaceArn: aws.String(fmt.Sprintf("arn:aws:redshift:%s:123456789012:namespace:%s", region, name)),
 		ClusterStatus:       aws.String("available"),
-		Endpoint: &redshift.Endpoint{
+		Endpoint: &redshifttypes.Endpoint{
 			Address: aws.String("localhost"),
-			Port:    aws.Int64(5439),
+			Port:    aws.Int32(5439),
 		},
 	}
 
@@ -3662,5 +3676,11 @@ func newPopulatedGCPProjectsMock() *mockProjectsAPI {
 				Name: "project2",
 			},
 		},
+	}
+}
+
+func newFakeRedshiftClientProvider(c redshift.DescribeClustersAPIClient) db.RedshiftClientProviderFunc {
+	return func(cfg awsv2.Config, optFns ...func(*redshift.Options)) db.RedshiftClient {
+		return c
 	}
 }

--- a/lib/srv/discovery/fetchers/db/aws_redshift.go
+++ b/lib/srv/discovery/fetchers/db/aws_redshift.go
@@ -21,16 +21,24 @@ package db
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/redshift"
-	"github.com/aws/aws-sdk-go/service/redshift/redshiftiface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/redshift"
+	redshifttypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/cloud"
 	libcloudaws "github.com/gravitational/teleport/lib/cloud/aws"
+	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
 )
+
+// RedshiftClientProviderFunc provides a [RedshiftClient].
+type RedshiftClientProviderFunc func(cfg aws.Config, optFns ...func(*redshift.Options)) RedshiftClient
+
+// RedshiftClient is a subset of the AWS Redshift API.
+type RedshiftClient interface {
+	redshift.DescribeClustersAPIClient
+}
 
 // newRedshiftFetcher returns a new AWS fetcher for Redshift databases.
 func newRedshiftFetcher(cfg awsFetcherConfig) (common.Fetcher, error) {
@@ -42,32 +50,33 @@ type redshiftPlugin struct{}
 
 // GetDatabases returns Redshift databases matching the watcher's selectors.
 func (f *redshiftPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
-	redshiftClient, err := cfg.AWSClients.GetAWSRedshiftClient(ctx, cfg.Region,
-		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
-		cloud.WithCredentialsMaybeIntegration(cfg.Integration),
+	awsCfg, err := cfg.AWSConfigProvider.GetConfig(ctx, cfg.Region,
+		awsconfig.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
+		awsconfig.WithCredentialsMaybeIntegration(cfg.Integration),
+		awsconfig.WithIntegrationCredentialProvider(cfg.IntegrationCredentialProviderFn),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	clusters, err := getRedshiftClusters(ctx, redshiftClient)
+	clusters, err := getRedshiftClusters(ctx, cfg.redshiftClientProviderFn(awsCfg))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	var databases types.Databases
 	for _, cluster := range clusters {
-		if !libcloudaws.IsRedshiftClusterAvailable(cluster) {
+		if !libcloudaws.IsRedshiftClusterAvailable(&cluster) {
 			cfg.Logger.DebugContext(ctx, "Skipping unavailable Redshift cluster",
-				"cluster", aws.StringValue(cluster.ClusterIdentifier),
-				"status", aws.StringValue(cluster.ClusterStatus),
+				"cluster", aws.ToString(cluster.ClusterIdentifier),
+				"status", aws.ToString(cluster.ClusterStatus),
 			)
 			continue
 		}
 
-		database, err := common.NewDatabaseFromRedshiftCluster(cluster)
+		database, err := common.NewDatabaseFromRedshiftCluster(&cluster)
 		if err != nil {
 			cfg.Logger.InfoContext(ctx, "Could not convert Redshift cluster to database resource",
-				"cluster", aws.StringValue(cluster.ClusterIdentifier),
+				"cluster", aws.ToString(cluster.ClusterIdentifier),
 				"error", err,
 			)
 			continue
@@ -84,17 +93,20 @@ func (f *redshiftPlugin) ComponentShortName() string {
 
 // getRedshiftClusters fetches all Reshift clusters using the provided client,
 // up to the specified max number of pages
-func getRedshiftClusters(ctx context.Context, redshiftClient redshiftiface.RedshiftAPI) ([]*redshift.Cluster, error) {
-	var clusters []*redshift.Cluster
-	var pageNum int
-	err := redshiftClient.DescribeClustersPagesWithContext(
-		ctx,
+func getRedshiftClusters(ctx context.Context, clt redshift.DescribeClustersAPIClient) ([]redshifttypes.Cluster, error) {
+	pager := redshift.NewDescribeClustersPaginator(clt,
 		&redshift.DescribeClustersInput{},
-		func(page *redshift.DescribeClustersOutput, lastPage bool) bool {
-			pageNum++
-			clusters = append(clusters, page.Clusters...)
-			return pageNum <= maxAWSPages
+		func(dcpo *redshift.DescribeClustersPaginatorOptions) {
+			dcpo.StopOnDuplicateToken = true
 		},
 	)
-	return clusters, trace.Wrap(libcloudaws.ConvertRequestFailureError(err))
+	var clusters []redshifttypes.Cluster
+	for pageNum := 0; pageNum < maxAWSPages && pager.HasMorePages(); pageNum++ {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, libcloudaws.ConvertRequestFailureErrorV2(err)
+		}
+		clusters = append(clusters, page.Clusters...)
+	}
+	return clusters, nil
 }

--- a/lib/srv/discovery/fetchers/db/db.go
+++ b/lib/srv/discovery/fetchers/db/db.go
@@ -22,11 +22,14 @@ import (
 	"context"
 	"log/slog"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/redshift"
 	"github.com/gravitational/trace"
 	"golang.org/x/exp/maps"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud"
+	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
 )
@@ -64,8 +67,53 @@ func IsAzureMatcherType(matcherType string) bool {
 	return len(makeAzureFetcherFuncs[matcherType]) > 0
 }
 
-// MakeAWSFetchers creates new AWS database fetchers.
-func MakeAWSFetchers(ctx context.Context, clients cloud.AWSClients, matchers []types.AWSMatcher, discoveryConfigName string) (result []common.Fetcher, err error) {
+// AWSFetcherFactoryConfig is the configuration for an [AWSFetcherFactory].
+type AWSFetcherFactoryConfig struct {
+	// AWSConfigProvider provides [aws.Config] for AWS SDK service clients.
+	AWSConfigProvider awsconfig.Provider
+	// CloudClients is an interface for retrieving AWS SDK v1 cloud clients.
+	CloudClients cloud.AWSClients
+	// IntegrationCredentialProviderFn is an optional function that provides
+	// credentials via AWS OIDC integration.
+	IntegrationCredentialProviderFn awsconfig.IntegrationCredentialProviderFunc
+	// RedshiftClientProviderFn is an optional function that provides
+	RedshiftClientProviderFn RedshiftClientProviderFunc
+}
+
+func (c *AWSFetcherFactoryConfig) checkAndSetDefaults() error {
+	if c.CloudClients == nil {
+		return trace.BadParameter("missing CloudClients")
+	}
+	if c.AWSConfigProvider == nil {
+		return trace.BadParameter("missing AWSConfigProvider")
+	}
+	if c.RedshiftClientProviderFn == nil {
+		c.RedshiftClientProviderFn = func(cfg aws.Config, optFns ...func(*redshift.Options)) RedshiftClient {
+			return redshift.NewFromConfig(cfg, optFns...)
+		}
+	}
+	return nil
+}
+
+// AWSFetcherFactory makes AWS database fetchers.
+type AWSFetcherFactory struct {
+	cfg AWSFetcherFactoryConfig
+}
+
+// NewAWSFetcherFactory checks the given config and returns a new fetcher
+// provider.
+func NewAWSFetcherFactory(cfg AWSFetcherFactoryConfig) (*AWSFetcherFactory, error) {
+	if err := cfg.checkAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &AWSFetcherFactory{
+		cfg: cfg,
+	}, nil
+}
+
+// MakeFetchers returns AWS database fetchers for each matcher given.
+func (f *AWSFetcherFactory) MakeFetchers(ctx context.Context, matchers []types.AWSMatcher, discoveryConfigName string) ([]common.Fetcher, error) {
+	var result []common.Fetcher
 	for _, matcher := range matchers {
 		assumeRole := types.AssumeRole{}
 		if matcher.AssumeRole != nil {
@@ -80,13 +128,16 @@ func MakeAWSFetchers(ctx context.Context, clients cloud.AWSClients, matchers []t
 			for _, makeFetcher := range makeFetchers {
 				for _, region := range matcher.Regions {
 					fetcher, err := makeFetcher(awsFetcherConfig{
-						AWSClients:          clients,
-						Type:                matcherType,
-						AssumeRole:          assumeRole,
-						Labels:              matcher.Tags,
-						Region:              region,
-						Integration:         matcher.Integration,
-						DiscoveryConfigName: discoveryConfigName,
+						AWSClients:                      f.cfg.CloudClients,
+						Type:                            matcherType,
+						AssumeRole:                      assumeRole,
+						Labels:                          matcher.Tags,
+						Region:                          region,
+						Integration:                     matcher.Integration,
+						DiscoveryConfigName:             discoveryConfigName,
+						AWSConfigProvider:               f.cfg.AWSConfigProvider,
+						IntegrationCredentialProviderFn: f.cfg.IntegrationCredentialProviderFn,
+						redshiftClientProviderFn:        f.cfg.RedshiftClientProviderFn,
 					})
 					if err != nil {
 						return nil, trace.Wrap(err)

--- a/lib/srv/discovery/fetchers/db/helpers_test.go
+++ b/lib/srv/discovery/fetchers/db/helpers_test.go
@@ -53,10 +53,12 @@ func makeAWSMatchersForType(matcherType, region string, tags map[string]string) 
 	}}
 }
 
-func mustMakeAWSFetchers(t *testing.T, clients cloud.AWSClients, matchers []types.AWSMatcher, discoveryConfigName string) []common.Fetcher {
+func mustMakeAWSFetchers(t *testing.T, cfg AWSFetcherFactoryConfig, matchers []types.AWSMatcher, discoveryConfigName string) []common.Fetcher {
 	t.Helper()
 
-	fetchers, err := MakeAWSFetchers(context.Background(), clients, matchers, discoveryConfigName)
+	fetcherFactory, err := NewAWSFetcherFactory(cfg)
+	require.NoError(t, err)
+	fetchers, err := fetcherFactory.MakeFetchers(context.Background(), matchers, discoveryConfigName)
 	require.NoError(t, err)
 	require.NotEmpty(t, fetchers)
 
@@ -111,6 +113,7 @@ var testAssumeRole = types.AssumeRole{
 type awsFetcherTest struct {
 	name          string
 	inputClients  *cloud.TestCloudClients
+	fetcherCfg    AWSFetcherFactoryConfig
 	inputMatchers []types.AWSMatcher
 	wantDatabases types.Databases
 }
@@ -121,22 +124,30 @@ func testAWSFetchers(t *testing.T, tests ...awsFetcherTest) {
 	t.Helper()
 	for _, test := range tests {
 		test := test
-		require.Nil(t, test.inputClients.STS, "testAWSFetchers injects an STS mock itself, but test input had already configured it. This is a test configuration error.")
-		stsMock := &mocks.STSMock{}
-		test.inputClients.STS = stsMock
+		fakeSTS := &mocks.STSClient{}
+		if test.inputClients != nil {
+			require.Nil(t, test.inputClients.STS, "testAWSFetchers injects an STS mock itself, but test input had already configured it. This is a test configuration error.")
+			test.inputClients.STS = &fakeSTS.STSClientV1
+		}
+		test.fetcherCfg.CloudClients = test.inputClients
+		require.Nil(t, test.fetcherCfg.AWSConfigProvider, "testAWSFetchers injects a fake AWSConfigProvider, but the test input had already configured it. This is a test configuration error.")
+		test.fetcherCfg.AWSConfigProvider = &mocks.AWSConfigProvider{
+			STSClient: fakeSTS,
+		}
 		t.Run(test.name, func(t *testing.T) {
 			t.Helper()
-			fetchers := mustMakeAWSFetchers(t, test.inputClients, test.inputMatchers, "" /* discovery config */)
+			fetchers := mustMakeAWSFetchers(t, test.fetcherCfg, test.inputMatchers, "" /* discovery config */)
 			require.ElementsMatch(t, test.wantDatabases, mustGetDatabases(t, fetchers))
 		})
 		t.Run(test.name+" with assume role", func(t *testing.T) {
 			t.Helper()
+			fakeSTS.ResetAssumeRoleHistory()
 			matchers := copyAWSMatchersWithAssumeRole(testAssumeRole, test.inputMatchers...)
 			wantDBs := copyDatabasesWithAWSAssumeRole(testAssumeRole, test.wantDatabases...)
-			fetchers := mustMakeAWSFetchers(t, test.inputClients, matchers, "" /* discovery config */)
+			fetchers := mustMakeAWSFetchers(t, test.fetcherCfg, matchers, "" /* discovery config */)
 			require.ElementsMatch(t, wantDBs, mustGetDatabases(t, fetchers))
-			require.Equal(t, []string{testAssumeRole.RoleARN}, stsMock.GetAssumedRoleARNs())
-			require.Equal(t, []string{testAssumeRole.ExternalID}, stsMock.GetAssumedRoleExternalIDs())
+			require.Equal(t, []string{testAssumeRole.RoleARN}, fakeSTS.GetAssumedRoleARNs())
+			require.Equal(t, []string{testAssumeRole.ExternalID}, fakeSTS.GetAssumedRoleExternalIDs())
 		})
 	}
 }

--- a/lib/srv/discovery/kube_integration_watcher_test.go
+++ b/lib/srv/discovery/kube_integration_watcher_test.go
@@ -56,19 +56,19 @@ import (
 
 func TestServer_getKubeFetchers(t *testing.T) {
 	eks1, err := fetchers.NewEKSFetcher(fetchers.EKSFetcherConfig{
-		ClientGetter: &cloud.TestCloudClients{STS: &mocks.STSMock{}},
+		ClientGetter: &cloud.TestCloudClients{STS: &mocks.STSClientV1{}},
 		FilterLabels: types.Labels{"l1": []string{"v1"}},
 		Region:       "region1",
 	})
 	require.NoError(t, err)
 	eks2, err := fetchers.NewEKSFetcher(fetchers.EKSFetcherConfig{
-		ClientGetter: &cloud.TestCloudClients{STS: &mocks.STSMock{}},
+		ClientGetter: &cloud.TestCloudClients{STS: &mocks.STSClientV1{}},
 		FilterLabels: types.Labels{"l1": []string{"v1"}},
 		Region:       "region1",
 		Integration:  "aws1"})
 	require.NoError(t, err)
 	eks3, err := fetchers.NewEKSFetcher(fetchers.EKSFetcherConfig{
-		ClientGetter: &cloud.TestCloudClients{STS: &mocks.STSMock{}},
+		ClientGetter: &cloud.TestCloudClients{STS: &mocks.STSClientV1{}},
 		FilterLabels: types.Labels{"l1": []string{"v1"}},
 		Region:       "region1",
 		Integration:  "aws1"})
@@ -314,7 +314,7 @@ func TestDiscoveryKubeIntegrationEKS(t *testing.T) {
 			t.Parallel()
 
 			testCloudClients := &cloud.TestCloudClients{
-				STS: &mocks.STSMock{},
+				STS: &mocks.STSClientV1{},
 				EKS: &mockEKSAPI{
 					clusters: eksMockClusters[:2],
 				},


### PR DESCRIPTION
This PR migrates all uses of AWS Redshift API to AWS SDK v2.

The PR depends on and is stacked on top of another PR for credential caching
- https://github.com/gravitational/teleport/pull/50561

Part of https://github.com/gravitational/teleport/issues/14142
- https://github.com/gravitational/teleport/issues/14142