### PR TITLE
Reply database REPL errors to the WebSocket client

### DIFF
--- a/lib/client/db/postgres/repl/repl.go
+++ b/lib/client/db/postgres/repl/repl.go
@@ -82,7 +82,7 @@ func New(_ context.Context, cfg *dbrepl.NewREPLConfig) (dbrepl.REPLInstance, err
 func (r *REPL) Run(ctx context.Context) error {
 	pgConn, err := pgconn.ConnectConfig(ctx, r.connConfig)
 	if err != nil {
-		return trace.Wrap(err)
+		return trace.ConnectionProblem(err, "Unable to connect to database: %v", err)
 	}
 	defer func() {
 		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/lib/client/db/postgres/repl/repl_test.go
+++ b/lib/client/db/postgres/repl/repl_test.go
@@ -175,6 +175,19 @@ func TestClose(t *testing.T) {
 	}
 }
 
+func TestConnectionError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	instance, tc := StartWithServer(t, ctx, WithSkipREPLRun())
+
+	// Force the server to be closed
+	tc.CloseServer()
+
+	err := instance.Run(ctx)
+	require.Error(t, err)
+	require.True(t, trace.IsConnectionProblem(err), "expected run to be a connection error but got %T", err)
+}
+
 func writeLine(t *testing.T, c *testCtx, line string) {
 	t.Helper()
 	data := []byte(line + lineBreak)


### PR DESCRIPTION
Relate to #50221

Currently, when there is an error on the database REPL, those errors are logged but not returned to the client. Here is an example with a connect error:

![Screenshot 2024-12-30 at 13 08 13](https://github.com/user-attachments/assets/243d4645-f55a-499d-a7b4-773f6b9cf92d)

This PR updates the database web socket handler to avoid closing the connection (and terminal stream) when there is a session error. The [middleware can send the handler error](https://github.com/gravitational/teleport/blob/e356649f3c61f8d94c6f9b59e1858d813eaef157/lib/web/apiserver.go#L4459-L4461) to the client when the connection is opened. In addition to this change, we're updating the connect error message from PostgreSQL REPL.

With this change, errors will propagate to the client and be presented to users, for example, the connect error:

![Screenshot 2024-12-30 at 13 02 56](https://github.com/user-attachments/assets/a44d2e66-9b10-4146-b723-243da4b7c5c3)

changelog: Present connection errors to the Web UI terminal during database sessions.