### PR TITLE
Enable strategies in the autoupdate rollout controller

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -288,6 +288,9 @@ const (
 	// ComponentUpdater represents the teleport-update binary.
 	ComponentUpdater = "updater"
 
+	// ComponentRolloutController represents the autoupdate_agent_rollout controller.
+	ComponentRolloutController = "rollout-controller"
+
 	// VerboseLogsEnvVar forces all logs to be verbose (down to DEBUG level)
 	VerboseLogsEnvVar = "TELEPORT_DEBUG"
 


### PR DESCRIPTION
This PR enables the time-based and halt-on-error strategies in the autoupdate_agent_rollout controller. This turns on logic that was introduced in https://github.com/gravitational/teleport/pull/49737 and https://github.com/gravitational/teleport/pull/49736.

It also adds the rollout controller component in structured logs.

Part of: [RFD-184](https://github.com/gravitational/teleport/pull/47126)

Goal (internal): https://github.com/gravitational/cloud/issues/10289

Depends on https://github.com/gravitational/teleport/pull/50634