### PR TITLE
readGrpcCert: Remove Promise.any usage

### DIFF
--- a/web/packages/teleterm/src/services/grpcCredentials/files.test.ts
+++ b/web/packages/teleterm/src/services/grpcCredentials/files.test.ts
@@ -36,6 +36,10 @@ afterAll(async () => {
   await fs.rm(tempDir, { recursive: true, force: true });
 });
 
+beforeEach(() => {
+  jest.restoreAllMocks();
+});
+
 describe('readGrpcCert', () => {
   it('reads the file if the file already exists', async () => {
     await fs.writeFile(path.join(tempDir, 'already-exists'), 'foobar');
@@ -63,5 +67,18 @@ describe('readGrpcCert', () => {
     ).rejects.toMatchObject({
       message: expect.stringContaining('within the timeout'),
     });
+  });
+
+  it('returns an error if stat fails', async () => {
+    const expectedError = new Error('Something went wrong');
+    jest.spyOn(fs, 'stat').mockRejectedValue(expectedError);
+
+    await expect(
+      readGrpcCert(
+        tempDir,
+        'non-existent',
+        { timeoutMs: 100 } // Make sure that the test doesn't hang for 10s on failure.
+      )
+    ).rejects.toEqual(expectedError);
   });
 });

--- a/web/packages/teleterm/src/services/grpcCredentials/files.test.ts
+++ b/web/packages/teleterm/src/services/grpcCredentials/files.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import timers from 'node:timers/promises';
+
+import { readGrpcCert } from './files';
+
+let tempDir: string;
+
+beforeAll(async () => {
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'grpc-files-test'));
+});
+
+afterAll(async () => {
+  await fs.rm(tempDir, { recursive: true, force: true });
+});
+
+describe('readGrpcCert', () => {
+  it('reads the file if the file already exists', async () => {
+    await fs.writeFile(path.join(tempDir, 'already-exists'), 'foobar');
+
+    await expect(
+      readGrpcCert(tempDir, 'already-exists').then(buffer => buffer.toString())
+    ).resolves.toEqual('foobar');
+  });
+
+  it('reads the file when the file is created after starting a watcher', async () => {
+    const readGrpcCertPromise = readGrpcCert(
+      tempDir,
+      'created-after-start'
+    ).then(buffer => buffer.toString());
+    await timers.setTimeout(10);
+
+    await fs.writeFile(path.join(tempDir, 'created-after-start'), 'foobar');
+
+    await expect(readGrpcCertPromise).resolves.toEqual('foobar');
+  });
+
+  it('returns an error if the file is not created within the timeout', async () => {
+    await expect(
+      readGrpcCert(tempDir, 'non-existent', { timeoutMs: 1 })
+    ).rejects.toMatchObject({
+      message: expect.stringContaining('within the timeout'),
+    });
+  });
+});

--- a/web/packages/teleterm/src/services/grpcCredentials/files.ts
+++ b/web/packages/teleterm/src/services/grpcCredentials/files.ts
@@ -20,6 +20,8 @@ import path from 'path';
 import { watch } from 'fs';
 import { readFile, writeFile, stat, rename } from 'fs/promises';
 
+import { wait } from 'shared/utils/wait';
+
 import { makeCert } from './makeCert';
 
 /**
@@ -51,11 +53,12 @@ export async function generateAndSaveGrpcCert(
 
 /**
  * Reads a cert with given `certName` in the `certDir`.
- * If the file doesn't exist, it will wait up to 10 seconds for it.
+ * If the file doesn't exist, by default it will wait up to 10 seconds for it.
  */
 export async function readGrpcCert(
   certsDir: string,
-  certName: string
+  certName: string,
+  { timeoutMs = 10_000 } = {}
 ): Promise<Buffer> {
   const fullPath = path.join(certsDir, certName);
   const abortController = new AbortController();
@@ -64,36 +67,40 @@ export async function readGrpcCert(
     return !!(await stat(fullPath)).size;
   }
 
-  function watchForFile(): Promise<Buffer> {
+  function waitForFile(): Promise<Buffer> {
     return new Promise((resolve, reject) => {
-      abortController.signal.onabort = () => {
-        watcher.close();
-        clearTimeout(timeout);
-      };
+      wait(timeoutMs, abortController.signal).then(
+        () =>
+          reject(
+            new Error(
+              `Could not read ${certName} certificate within the timeout.`
+            )
+          ),
+        () => {} // Ignore abort errors.
+      );
 
-      const timeout = setTimeout(() => {
-        reject(
-          `Could not read ${certName} certificate. The operation timed out.`
-        );
-      }, 10_000);
-
-      const watcher = watch(certsDir, async (event, filename) => {
-        if (certName === filename && (await fileExistsAndHasSize())) {
-          resolve(readFile(fullPath));
+      // Watching must be started before checking if the file already exists to avoid race
+      // conditions. If we checked if the file exists and then started the watcher, the file could
+      // in theory be created between those two actions.
+      watch(
+        certsDir,
+        { signal: abortController.signal },
+        async (_, filename) => {
+          if (certName === filename && (await fileExistsAndHasSize())) {
+            resolve(readFile(fullPath));
+          }
         }
-      });
+      );
+
+      fileExistsAndHasSize().then(
+        exists => exists && resolve(readFile(fullPath)),
+        () => {} // Ignore err.
+      );
     });
   }
 
-  async function checkIfFileAlreadyExists(): Promise<Buffer> {
-    if (await fileExistsAndHasSize()) {
-      return readFile(fullPath);
-    }
-  }
-
   try {
-    // watching must be started before checking if the file already exists to avoid race conditions
-    return await Promise.any([watchForFile(), checkIfFileAlreadyExists()]);
+    return await waitForFile();
   } finally {
     abortController.abort();
   }


### PR DESCRIPTION
The problem with [`Promise.any`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/any) is that if all passed promises fail, it returns `AggregateError`. It contains errors from the promises under the `, but unfortunately the default `toString` implementation of that error does not include them. This results in unhelpful error messages, like the one in #50602.

Initially I thought of writing a custom wrapper for `AggregateError` which prints all errors. However, since `Promise.any` is used only in a single place in our codebase, I figured out that it's going to be easier to just get rid of it.

Previously, `Promise.any` was used to launch a watcher _and_ check if the file exists already. Instead of using `Promise.any`, we can start the watcher, then check if the file exists and resolve the promise if it does.

---

The changes can be verified by changing runtime settings so that TCP is always used for gRPC and not just on Windows, then launching the dev app.

https://github.com/gravitational/teleport/blob/873846401ac990a8675676728bdc83f807b7a599/web/packages/teleterm/src/mainProcess/runtimeSettings.ts#L210-L218