### PR TITLE
Prevent panicking during shutdown when SQS consumer is disabled

### DIFF
--- a/lib/events/athena/athena.go
+++ b/lib/events/athena/athena.go
@@ -538,7 +538,11 @@ func (l *Log) SearchSessionEvents(ctx context.Context, req events.SearchSessionE
 }
 
 func (l *Log) Close() error {
-	return trace.Wrap(l.consumerCloser.Close())
+	// consumerCloser is nil when consumer is disabled.
+	if l.consumerCloser != nil {
+		return trace.Wrap(l.consumerCloser.Close())
+	}
+	return nil
 }
 
 func (l *Log) IsConsumerDisabled() bool {


### PR DESCRIPTION
Fixing a panic when SQS consumer is disabled and auth is closing the Audit Logger.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x55659d2f4e1a]

goroutine 6295 [running]:
github.com/gravitational/teleport/lib/events/athena.(*Log).Close(0x0?)
        github.com/gravitational/teleport/lib/events/athena/athena.go:546 +0x1a
github.com/gravitational/teleport/lib/events.(*AuditLog).Close(0xc0015f8c00)
        github.com/gravitational/teleport/lib/events/auditlog.go:1075 +0x59
github.com/gravitational/teleport/lib/auth.(*Server).Close(0xc0015b2c08)
        github.com/gravitational/teleport/lib/auth/auth.go:1849 +0x72
github.com/gravitational/teleport/lib/service.(*TeleportProcess).StartShutdown.func1()
        github.com/gravitational/teleport/lib/service/service.go:6012 +0x17f
created by github.com/gravitational/teleport/lib/service.(*TeleportProcess).StartShutdown in goroutine 1
        github.com/gravitational/teleport/lib/service/service.go:6004 +0x2d8
```

Disabling consumer was added in https://github.com/gravitational/teleport/pull/46770.

Changelog: Prevent panicking during shutdown when SQS consumer is disabled