### PR TITLE
[v16] Prevent panicking during shutdown when SQS consumer is disabled

### DIFF
--- a/lib/events/athena/athena.go
+++ b/lib/events/athena/athena.go
@@ -543,7 +543,11 @@ func (l *Log) SearchSessionEvents(ctx context.Context, req events.SearchSessionE
 }
 
 func (l *Log) Close() error {
-	return trace.Wrap(l.consumerCloser.Close())
+	// consumerCloser is nil when consumer is disabled.
+	if l.consumerCloser != nil {
+		return trace.Wrap(l.consumerCloser.Close())
+	}
+	return nil
 }
 
 func (l *Log) IsConsumerDisabled() bool {


### PR DESCRIPTION
Backport #50643 to branch/v16

changelog: Prevent panicking during shutdown when SQS consumer is disabled
