### PR TITLE
postrelease: update PR link

### DIFF
--- a/docs/postrelease.md
+++ b/docs/postrelease.md
@@ -15,10 +15,10 @@ The AWS AMI ID PR can be merged right away.
 ### Major releases only
 
 - [ ] Update support matrix in docs FAQ page
-  - Example: https://github.com/gravitational/teleport/pull/4602
+  - Example: https://github.com/gravitational/teleport/pull/50345
 - [ ] Update the list of OCI images to monitor and rebuild nightly in
   [`monitor-teleport-oci-distroless.yml` on `master`](https://github.com/gravitational/teleport.e/blob/master/.github/workflows/monitor-teleport-oci-distroless.yml) and
   [`rebuild-teleport-oci-distroless-cron.yml` on `master`](https://github.com/gravitational/teleport.e/blob/master/.github/workflows/rebuild-teleport-oci-distroless-cron.yml)
 - [ ] Update `e/.github/workflows/build-buildboxes-cron.yaml` to bump the
-  branches on each job (two per job) and to comment out the final job that only
+  branches on each job and to comment out the final job that only
   exists for the pre-release, and bump the versions for the next release.

--- a/docs/postrelease.md
+++ b/docs/postrelease.md
@@ -20,5 +20,5 @@ The AWS AMI ID PR can be merged right away.
   [`monitor-teleport-oci-distroless.yml` on `master`](https://github.com/gravitational/teleport.e/blob/master/.github/workflows/monitor-teleport-oci-distroless.yml) and
   [`rebuild-teleport-oci-distroless-cron.yml` on `master`](https://github.com/gravitational/teleport.e/blob/master/.github/workflows/rebuild-teleport-oci-distroless-cron.yml)
 - [ ] Update `e/.github/workflows/build-buildboxes-cron.yaml` to bump the
-  branches on each job and to comment out the final job that only
+  branches on each job (two per job) and to comment out the final job that only
   exists for the pre-release, and bump the versions for the next release.


### PR DESCRIPTION
This page linked to an old PR that's not applicable with the latest release tooling. Link to a more modern PR to avoid confusion.