### PR TITLE
Remove 'Origin: aws-identity-center' that is crashing v16 agents

### DIFF
--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -29,7 +29,6 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/types/common"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/utils"
@@ -597,7 +596,11 @@ func NewSystemIdentityCenterAccessRole() types.Role {
 			Description: "Access AWS IAM Identity Center resources",
 			Labels: map[string]string{
 				types.TeleportInternalResourceType: types.SystemResource,
-				types.OriginLabel:                  common.OriginAWSIdentityCenter,
+				// OriginLabel should not be set to AWS Identity center because:
+				// - identity center is not the one owning this role, this role
+				//   is part of the Teleport system requirements
+				// - setting the label to a value not support in older agents
+				//   (v16) will cause them to crash.
 			},
 		},
 		Spec: types.RoleSpecV6{
@@ -687,6 +690,11 @@ func bootstrapRoleMetadataLabels() map[string]map[string]string {
 		teleport.SystemOktaRequesterRoleName: {
 			types.TeleportInternalResourceType: types.SystemResource,
 			types.OriginLabel:                  types.OriginOkta,
+		},
+		// We unset the OriginLabel on the system AWS IC role because this value
+		// was not supported on v16 agents and this crashes them.
+		teleport.SystemIdentityCenterAccessRoleName: {
+			types.TeleportInternalResourceType: types.SystemResource,
 		},
 		// Group access, reviewer and requester are intentionally not added here as there may be
 		// existing customer defined roles that have these labels.


### PR DESCRIPTION
Removes the origin label in the aws ic preset role introduced in https://github.com/gravitational/teleport/pull/49565

This label is unknown to v16 agents, this causes the role's CheckAndSetDefaults to fail, which breaks the local cache of every v16 teleport streaming Role resources from a v17 auth (Apps, Databases, Proxy, Windows Desktop, Kubernetes, Discovery, ...).

Updates #50654

Changelog: fixes a bug where v16 Teleport cannot connect to v17.1.0, v17.1.1 and v17.1.2 clusters.