### PR TITLE
Update the helm command in the tctl tokens add output

### DIFF
--- a/tool/tctl/common/kube_command.go
+++ b/tool/tctl/common/kube_command.go
@@ -137,10 +137,11 @@ helm repo update
   --set proxyAddr={{.auth_server}} \
   --set authToken={{.token}} \
   --create-namespace \
-  --namespace=teleport-agent
-        
+  --namespace=teleport-agent \
+  --version={{.version}}
+
 Please note:
-        
+
   - This invitation token will expire in {{.minutes}} minutes.
   - {{.auth_server}} must be reachable from Kubernetes cluster.
   - The token is usable in a standalone Linux server with kubernetes_service.

--- a/tool/tctl/common/token_command.go
+++ b/tool/tctl/common/token_command.go
@@ -287,6 +287,7 @@ func (c *TokensCommand) Add(ctx context.Context, client *authclient.Client) erro
 				"token":       token,
 				"minutes":     c.ttl.Minutes(),
 				"set_roles":   setRoles,
+				"version":     proxies[0].GetTeleportVersion(),
 			})
 	case roles.Include(types.RoleApp):
 		proxies, err := client.GetProxies()


### PR DESCRIPTION
This ensures that the advice tctl prints will work with the current version of the Teleport cluster.

Closes #50317