### PR TITLE
Fix proto resource 153 marshalling for autoupdate_* resources

### DIFF
--- a/api/types/resource_153.go
+++ b/api/types/resource_153.go
@@ -368,8 +368,6 @@ type protoResource153ToLegacyAdapter struct {
 
 // MarshalJSON adds support for marshaling the wrapped resource (instead of
 // marshaling the adapter itself).
-// If the resource153 is implemented by a protobuf type, we use
-// protojson.Marshal instead.
 func (r *protoResource153ToLegacyAdapter) MarshalJSON() ([]byte, error) {
 	return protojson.MarshalOptions{
 		UseProtoNames: true,

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -1908,7 +1908,7 @@ type autoUpdateConfigCollection struct {
 }
 
 func (c *autoUpdateConfigCollection) resources() []types.Resource {
-	return []types.Resource{types.Resource153ToLegacyV2(c.config)}
+	return []types.Resource{types.ProtoResource153ToLegacy(c.config)}
 }
 
 func (c *autoUpdateConfigCollection) writeText(w io.Writer, verbose bool) error {
@@ -1926,7 +1926,7 @@ type autoUpdateVersionCollection struct {
 }
 
 func (c *autoUpdateVersionCollection) resources() []types.Resource {
-	return []types.Resource{types.Resource153ToLegacyV2(c.version)}
+	return []types.Resource{types.ProtoResource153ToLegacy(c.version)}
 }
 
 func (c *autoUpdateVersionCollection) writeText(w io.Writer, verbose bool) error {
@@ -1944,7 +1944,7 @@ type autoUpdateAgentRolloutCollection struct {
 }
 
 func (c *autoUpdateAgentRolloutCollection) resources() []types.Resource {
-	return []types.Resource{types.Resource153ToLegacyV2(c.rollout)}
+	return []types.Resource{types.ProtoResource153ToLegacy(c.rollout)}
 }
 
 func (c *autoUpdateAgentRolloutCollection) writeText(w io.Writer, verbose bool) error {

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -1908,7 +1908,7 @@ type autoUpdateConfigCollection struct {
 }
 
 func (c *autoUpdateConfigCollection) resources() []types.Resource {
-	return []types.Resource{types.Resource153ToLegacy(c.config)}
+	return []types.Resource{types.Resource153ToLegacyV2(c.config)}
 }
 
 func (c *autoUpdateConfigCollection) writeText(w io.Writer, verbose bool) error {
@@ -1926,7 +1926,7 @@ type autoUpdateVersionCollection struct {
 }
 
 func (c *autoUpdateVersionCollection) resources() []types.Resource {
-	return []types.Resource{types.Resource153ToLegacy(c.version)}
+	return []types.Resource{types.Resource153ToLegacyV2(c.version)}
 }
 
 func (c *autoUpdateVersionCollection) writeText(w io.Writer, verbose bool) error {
@@ -1944,7 +1944,7 @@ type autoUpdateAgentRolloutCollection struct {
 }
 
 func (c *autoUpdateAgentRolloutCollection) resources() []types.Resource {
-	return []types.Resource{types.Resource153ToLegacy(c.rollout)}
+	return []types.Resource{types.Resource153ToLegacyV2(c.rollout)}
 }
 
 func (c *autoUpdateAgentRolloutCollection) writeText(w io.Writer, verbose bool) error {

--- a/tool/tctl/common/collection_test.go
+++ b/tool/tctl/common/collection_test.go
@@ -27,13 +27,19 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/durationpb"
+	kyaml "k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/gravitational/teleport/api"
+	autoupdatev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	dbobjectv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobject/v1"
 	dbobjectimportrulev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobjectimportrule/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/autoupdate"
 	"github.com/gravitational/teleport/api/types/label"
 	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/db/common/databaseobject"
 	"github.com/gravitational/teleport/lib/srv/db/common/databaseobjectimportrule"
 	"github.com/gravitational/teleport/tool/common"
@@ -430,4 +436,45 @@ func makeTestLabels(extraStaticLabels map[string]string) map[string]string {
 	maps.Copy(labels, staticLabelsFixture)
 	maps.Copy(labels, extraStaticLabels)
 	return labels
+}
+
+// This test makes sure we marshal and unmarshal proto-based Resource153 properly.
+// We had a bug where types.Resource153 implemented by protobuf structs were not
+// marshaled properly (they should be marshaled using protojson). This test
+// checks we can do a round-trip with one of those proto-struct resource.
+func TestRoundTripProtoResource153(t *testing.T) {
+	// Test setup: generate fixture.
+	initial, err := autoupdate.NewAutoUpdateConfig(&autoupdatev1pb.AutoUpdateConfigSpec{
+		Tools: nil,
+		Agents: &autoupdatev1pb.AutoUpdateConfigSpecAgents{
+			Mode:                      autoupdate.AgentsUpdateModeEnabled,
+			Strategy:                  autoupdate.AgentsStrategyTimeBased,
+			MaintenanceWindowDuration: durationpb.New(1 * time.Hour),
+			Schedules: &autoupdatev1pb.AgentAutoUpdateSchedules{
+				Regular: []*autoupdatev1pb.AgentAutoUpdateGroup{
+					{
+						Name: "group1",
+						Days: []string{types.Wildcard},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Test execution: dump the resource into a YAML manifest.
+	collection := &autoUpdateConfigCollection{config: initial}
+	buf := &bytes.Buffer{}
+	require.NoError(t, writeYAML(collection, buf))
+	t.Log(buf.String())
+
+	// Test execution: load the YAML manifest back.
+	decoder := kyaml.NewYAMLOrJSONDecoder(buf, defaults.LookaheadBufSize)
+	var raw services.UnknownResource
+	require.NoError(t, decoder.Decode(&raw))
+	result, err := services.UnmarshalProtoResource[*autoupdatev1pb.AutoUpdateConfig](raw.Raw)
+	require.NoError(t, err)
+
+	// Test validation: check that the loaded content matches what we had before.
+	require.Equal(t, result, initial)
 }

--- a/tool/tctl/common/collection_test.go
+++ b/tool/tctl/common/collection_test.go
@@ -445,7 +445,6 @@ func makeTestLabels(extraStaticLabels map[string]string) map[string]string {
 func TestRoundTripProtoResource153(t *testing.T) {
 	// Test setup: generate fixture.
 	initial, err := autoupdate.NewAutoUpdateConfig(&autoupdatev1pb.AutoUpdateConfigSpec{
-		Tools: nil,
 		Agents: &autoupdatev1pb.AutoUpdateConfigSpecAgents{
 			Mode:                      autoupdate.AgentsUpdateModeEnabled,
 			Strategy:                  autoupdate.AgentsStrategyTimeBased,

--- a/tool/tctl/common/collection_test.go
+++ b/tool/tctl/common/collection_test.go
@@ -439,7 +439,7 @@ func makeTestLabels(extraStaticLabels map[string]string) map[string]string {
 }
 
 // autoUpdateConfigBrokenCollection is an intentionally broken version of the
-// autoUpdateConfigCollection that is not marshalling resources properly because
+// autoUpdateConfigCollection that is not marshaling resources properly because
 // it's doing json marshaling instead of protojson marshaling.
 type autoUpdateConfigBrokenCollection struct {
 	autoUpdateConfigCollection
@@ -497,6 +497,6 @@ func TestRoundTripProtoResource153(t *testing.T) {
 	// Test execution: load the YAML manifest back and see that we can't unmarshal it.
 	decoder = kyaml.NewYAMLOrJSONDecoder(buf, defaults.LookaheadBufSize)
 	require.NoError(t, decoder.Decode(&raw))
-	result, err = services.UnmarshalProtoResource[*autoupdatev1pb.AutoUpdateConfig](raw.Raw)
+	_, err = services.UnmarshalProtoResource[*autoupdatev1pb.AutoUpdateConfig](raw.Raw)
 	require.Error(t, err)
 }

--- a/tool/tctl/common/collection_test.go
+++ b/tool/tctl/common/collection_test.go
@@ -466,7 +466,6 @@ func TestRoundTripProtoResource153(t *testing.T) {
 	collection := &autoUpdateConfigCollection{config: initial}
 	buf := &bytes.Buffer{}
 	require.NoError(t, writeYAML(collection, buf))
-	t.Log(buf.String())
 
 	// Test execution: load the YAML manifest back.
 	decoder := kyaml.NewYAMLOrJSONDecoder(buf, defaults.LookaheadBufSize)

--- a/tool/tctl/common/helpers_test.go
+++ b/tool/tctl/common/helpers_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
+	kyaml "k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/gravitational/teleport/api/breaker"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
@@ -43,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/lib/config"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
@@ -151,6 +153,13 @@ func mustDecodeJSON[T any](t *testing.T, r io.Reader) T {
 	err := json.NewDecoder(r).Decode(&out)
 	require.NoError(t, err)
 	return out
+}
+
+func mustTranscodeYAMLToJSON(t *testing.T, r io.Reader) []byte {
+	decoder := kyaml.NewYAMLToJSONDecoder(r)
+	var resource services.UnknownResource
+	require.NoError(t, decoder.Decode(&resource))
+	return resource.Raw
 }
 
 func mustDecodeYAMLDocuments[T any](t *testing.T, r io.Reader, out *[]T) {

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -2349,6 +2349,8 @@ version: v1
 	require.NoError(t, err)
 
 	buf, err := runResourceCommand(t, clt, []string{"get", types.KindAutoUpdateConfig, "--format=json"})
+	require.NoError(t, err)
+
 	rawResources := mustDecodeJSON[[]services.UnknownResource](t, buf)
 	require.Len(t, rawResources, 1)
 	var resource autoupdate.AutoUpdateConfig
@@ -2392,6 +2394,8 @@ version: v1
 	require.NoError(t, err)
 
 	buf, err := runResourceCommand(t, clt, []string{"get", types.KindAutoUpdateVersion, "--format=json"})
+	require.NoError(t, err)
+
 	rawResources := mustDecodeJSON[[]services.UnknownResource](t, buf)
 	require.Len(t, rawResources, 1)
 	var resource autoupdate.AutoUpdateVersion

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -1373,7 +1373,7 @@ func TestCreateResources(t *testing.T) {
 	rootClient := testenv.MakeDefaultAuthClient(t, process)
 
 	// tctlGetAllValidations allows tests to register post-test validations to validate
-	// that their resource is present in "ttcl get all" output.
+	// that their resource is present in "tctl get all" output.
 	// This allows running test rows instead of the whole test table.
 	var tctlGetAllValidations []func(t *testing.T, out string)
 

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/testing/protocmp"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
@@ -1371,17 +1372,29 @@ func TestCreateResources(t *testing.T) {
 	process := testenv.MakeTestServer(t, testenv.WithLogger(utils.NewSlogLoggerForTests()))
 	rootClient := testenv.MakeDefaultAuthClient(t, process)
 
+	// tctlGetAllValidations allows tests to register post-test validations to validate
+	// that their resource is present in "ttcl get all" output.
+	// This allows running test rows instead of the whole test table.
+	var tctlGetAllValidations []func(t *testing.T, out string)
+
 	tests := []struct {
-		kind   string
-		create func(t *testing.T, clt *authclient.Client)
+		kind        string
+		create      func(t *testing.T, clt *authclient.Client)
+		getAllCheck func(t *testing.T, out string)
 	}{
 		{
 			kind:   types.KindGithubConnector,
 			create: testCreateGithubConnector,
+			getAllCheck: func(t *testing.T, s string) {
+				assert.Contains(t, s, "kind: github")
+			},
 		},
 		{
 			kind:   types.KindRole,
 			create: testCreateRole,
+			getAllCheck: func(t *testing.T, s string) {
+				assert.Contains(t, s, "kind: role")
+			},
 		},
 		{
 			kind:   types.KindServerInfo,
@@ -1390,6 +1403,9 @@ func TestCreateResources(t *testing.T) {
 		{
 			kind:   types.KindUser,
 			create: testCreateUser,
+			getAllCheck: func(t *testing.T, s string) {
+				assert.Contains(t, s, "kind: user")
+			},
 		},
 		{
 			kind:   types.KindDatabaseObjectImportRule,
@@ -1402,10 +1418,16 @@ func TestCreateResources(t *testing.T) {
 		{
 			kind:   types.KindClusterNetworkingConfig,
 			create: testCreateClusterNetworkingConfig,
+			getAllCheck: func(t *testing.T, s string) {
+				assert.Contains(t, s, "kind: cluster_networking_config")
+			},
 		},
 		{
 			kind:   types.KindClusterAuthPreference,
 			create: testCreateAuthPreference,
+			getAllCheck: func(t *testing.T, s string) {
+				assert.Contains(t, s, "kind: cluster_auth_preference")
+			},
 		},
 		{
 			kind:   types.KindSessionRecordingConfig,
@@ -1440,6 +1462,9 @@ func TestCreateResources(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.kind, func(t *testing.T) {
 			test.create(t, rootClient)
+			if test.getAllCheck != nil {
+				tctlGetAllValidations = append(tctlGetAllValidations, test.getAllCheck)
+			}
 		})
 	}
 
@@ -1447,12 +1472,9 @@ func TestCreateResources(t *testing.T) {
 	out, err := runResourceCommand(t, rootClient, []string{"get", "all"})
 	require.NoError(t, err)
 	s := out.String()
-	require.NotEmpty(t, s)
-	assert.Contains(t, s, "kind: github")
-	assert.Contains(t, s, "kind: cluster_auth_preference")
-	assert.Contains(t, s, "kind: cluster_networking_config")
-	assert.Contains(t, s, "kind: user")
-	assert.Contains(t, s, "kind: role")
+	for _, validateGetAll := range tctlGetAllValidations {
+		validateGetAll(t, s)
+	}
 }
 
 func testCreateGithubConnector(t *testing.T, clt *authclient.Client) {
@@ -2326,18 +2348,19 @@ version: v1
 	_, err = runResourceCommand(t, clt, []string{"create", resourceYAMLPath})
 	require.NoError(t, err)
 
-	// Get the resource
 	buf, err := runResourceCommand(t, clt, []string{"get", types.KindAutoUpdateConfig, "--format=json"})
-	require.NoError(t, err)
-	resources := mustDecodeJSON[[]*autoupdate.AutoUpdateConfig](t, buf)
-	require.Len(t, resources, 1)
+	rawResources := mustDecodeJSON[[]services.UnknownResource](t, buf)
+	require.Len(t, rawResources, 1)
+	var resource autoupdate.AutoUpdateConfig
+	require.NoError(t, protojson.Unmarshal(rawResources[0].Raw, &resource))
 
 	var expected autoupdate.AutoUpdateConfig
-	require.NoError(t, yaml.Unmarshal([]byte(resourceYAML), &expected))
+	expectedJSON := mustTranscodeYAMLToJSON(t, bytes.NewReader([]byte(resourceYAML)))
+	require.NoError(t, protojson.Unmarshal(expectedJSON, &expected))
 
 	require.Empty(t, cmp.Diff(
-		[]*autoupdate.AutoUpdateConfig{&expected},
-		resources,
+		&expected,
+		&resource,
 		protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
 		protocmp.Transform(),
 	))
@@ -2368,18 +2391,19 @@ version: v1
 	_, err = runResourceCommand(t, clt, []string{"create", resourceYAMLPath})
 	require.NoError(t, err)
 
-	// Get the resource
 	buf, err := runResourceCommand(t, clt, []string{"get", types.KindAutoUpdateVersion, "--format=json"})
-	require.NoError(t, err)
-	resources := mustDecodeJSON[[]*autoupdate.AutoUpdateVersion](t, buf)
-	require.Len(t, resources, 1)
+	rawResources := mustDecodeJSON[[]services.UnknownResource](t, buf)
+	require.Len(t, rawResources, 1)
+	var resource autoupdate.AutoUpdateVersion
+	require.NoError(t, protojson.Unmarshal(rawResources[0].Raw, &resource))
 
 	var expected autoupdate.AutoUpdateVersion
-	require.NoError(t, yaml.Unmarshal([]byte(resourceYAML), &expected))
+	expectedJSON := mustTranscodeYAMLToJSON(t, bytes.NewReader([]byte(resourceYAML)))
+	require.NoError(t, protojson.Unmarshal(expectedJSON, &expected))
 
 	require.Empty(t, cmp.Diff(
-		[]*autoupdate.AutoUpdateVersion{&expected},
-		resources,
+		&expected,
+		&resource,
 		protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
 		protocmp.Transform(),
 	))
@@ -2423,15 +2447,19 @@ version: v1
 	// Get the resource
 	buf, err := runResourceCommand(t, clt, []string{"get", types.KindAutoUpdateAgentRollout, "--format=json"})
 	require.NoError(t, err)
-	resources := mustDecodeJSON[[]*autoupdate.AutoUpdateAgentRollout](t, buf)
-	require.Len(t, resources, 1)
+
+	rawResources := mustDecodeJSON[[]services.UnknownResource](t, buf)
+	require.Len(t, rawResources, 1)
+	var resource autoupdate.AutoUpdateAgentRollout
+	require.NoError(t, protojson.Unmarshal(rawResources[0].Raw, &resource))
 
 	var expected autoupdate.AutoUpdateAgentRollout
-	require.NoError(t, yaml.Unmarshal([]byte(resourceYAML), &expected))
+	expectedJSON := mustTranscodeYAMLToJSON(t, bytes.NewReader([]byte(resourceYAML)))
+	require.NoError(t, protojson.Unmarshal(expectedJSON, &expected))
 
 	require.Empty(t, cmp.Diff(
-		[]*autoupdate.AutoUpdateAgentRollout{&expected},
-		resources,
+		&expected,
+		&resource,
 		protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
 		protocmp.Transform(),
 	))


### PR DESCRIPTION
This PR adds `types.Resource153ToLegacyV2()` which acts exactly like `types.Resource153ToLegacy()` but detects if the underlying resource153 implementation is a proto struct and uses `protojson` instead of regular json marshaling.

This fixes improper marshaling for resources `autoupdate_config`, `autoupdate_version`, and `autoupdate_agent_rollout`.

This is a band-aid solution, the proper way to address this would be to have the proto structs implement `json.Marshaler`.

This PR does not change `types.Resource153ToLegacy()` because:
- I have no idea what implications this will have for other resources, this might change how the resource is written on disk, exported audit logs, ...
- Automatic updates will need to be backported, we cannot retroactively change how teleport marshals resources.

Goal (internal): https://github.com/gravitational/cloud/issues/10289