### PR TITLE
Document event filtering in the event handler

### DIFF
--- a/docs/pages/includes/plugins/finish-event-handler-config.mdx
+++ b/docs/pages/includes/plugins/finish-event-handler-config.mdx
@@ -15,6 +15,21 @@ namespace = "default"
 # for the default window size.
 # The window size should be specified as a duration string, parsed by Go's time.ParseDuration.
 window-size = "24h"
+# types is a comma-separated list of event types to search when forwarding audit
+# events. For example, to limit forwarded events to user logins
+# and new Access Requests, you can assign this field to
+# "user.login,access_request.create".
+types = ""
+# skip-event-types is a comma-separated list of types of events to skip. For
+# example, to forward all audit events except for new app deletion events, you
+# can include the following assignment:
+# skip-event-types = "app.delete"
+skip-event-types: []
+# skip-session-types is a comma-separated list of session event types to skip.
+# For example, to forward all session events except for malformed SQL packet
+# events, you can include the following assignment:
+# skip-session-types = "db.session.malformed_packet"
+skip-session-types: []
 
 [forward.fluentd]
 ca = "/home/bob/event-handler/ca.crt"
@@ -48,6 +63,20 @@ eventHandler:
   # for the default window size.
   # The window size should be specified as a duration string, parsed by Go's time.ParseDuration.
   windowSize: "24h"
+  # types is a list of event types to search when forwarding audit
+  # events. For example, to limit forwarded events to user logins
+  # and new Access Requests, you can assign this field to:
+  # ["user.login", "access_request.create"]
+  types: []
+  # skipEventTypes lists types of events to skip. For example, to forward all
+  # audit events except for new app deletion events, you can assign this to:
+  # ["app.delete"]
+  skipEventTypes: []
+  # skipSessionTypes lists session event types to skip. For example, to forward
+  # all session events except for malformed SQL packet events, you can assign
+  # this to:
+  # ["db.session.malformed_packet"]
+  skipSessionTypes: []
 
 teleport:
   address: "example.teleport.com:443"


### PR DESCRIPTION
Closes #23277

Document the `types`, `skip-event-types`, and `skip-session-types` event handler configuration fields. The `finish-event-handler-config.mdx` partial is the most appropriate place for this, since it already includes instructions for tailoring the user's event handler configuration.