### PR TITLE
Lint import order

### DIFF
--- a/lib/devicetrust/native/device_windows.go
+++ b/lib/devicetrust/native/device_windows.go
@@ -30,13 +30,13 @@ import (
 	"time"
 
 	"github.com/google/go-attestation/attest"
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 	"github.com/yusufpapurcu/wmi"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sys/windows"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/gravitational/teleport"
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	"github.com/gravitational/teleport/lib/windowsexec"
 )


### PR DESCRIPTION
I'm unsure how this passed the CI but the file imports are not correctly ordered. This might have to do something with the file being windows-specific.

Import order changed in https://github.com/gravitational/teleport/pull/50458.