### PR TITLE
[v17] Reply database REPL errors to the WebSocket client

### DIFF
--- a/lib/client/db/postgres/repl/repl.go
+++ b/lib/client/db/postgres/repl/repl.go
@@ -82,7 +82,7 @@ func New(_ context.Context, cfg *dbrepl.NewREPLConfig) (dbrepl.REPLInstance, err
 func (r *REPL) Run(ctx context.Context) error {
 	pgConn, err := pgconn.ConnectConfig(ctx, r.connConfig)
 	if err != nil {
-		return trace.Wrap(err)
+		return trace.ConnectionProblem(err, "Unable to connect to database: %v", err)
 	}
 	defer func() {
 		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/lib/client/db/postgres/repl/repl_test.go
+++ b/lib/client/db/postgres/repl/repl_test.go
@@ -175,6 +175,19 @@ func TestClose(t *testing.T) {
 	}
 }
 
+func TestConnectionError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	instance, tc := StartWithServer(t, ctx, WithSkipREPLRun())
+
+	// Force the server to be closed
+	tc.CloseServer()
+
+	err := instance.Run(ctx)
+	require.Error(t, err)
+	require.True(t, trace.IsConnectionProblem(err), "expected run to be a connection error but got %T", err)
+}
+
 func writeLine(t *testing.T, c *testCtx, line string) {
 	t.Helper()
 	data := []byte(line + lineBreak)


### PR DESCRIPTION
Backport #50613 to branch/v17

changelog: Present connection errors to the Web UI terminal during database sessions.
