### PR TITLE
Fix flaky `TestInitDatabaseService/enabled_invalid_databases`

### DIFF
--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -1829,15 +1829,22 @@ func TestInitDatabaseService(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 			defer cancel()
 
+			// Arbitrary channel size to avoid blocking.
+			// We should not receive more than 1024 events as we have less than 1024 services.
+			serviceExitedEvents := make(chan Event, 1024)
+
 			var eg errgroup.Group
 			process, err := NewTeleport(cfg)
 			require.NoError(t, err)
+			process.ListenForEvents(ctx, ServiceExitedWithErrorEvent, serviceExitedEvents)
 			require.NoError(t, process.Start())
 			eg.Go(func() error { return process.WaitForSignals(ctx, nil) })
 			// Ensures the process is closed in failure scenarios.
 			t.Cleanup(func() {
 				cancel()
 				_ = eg.Wait()
+				_ = process.Close()
+				require.NoError(t, process.Wait())
 			})
 
 			if !test.expectErr {
@@ -1846,15 +1853,24 @@ func TestInitDatabaseService(t *testing.T) {
 				require.NoError(t, process.Close())
 				// Expect Teleport to shutdown without reporting any issue.
 				require.NoError(t, eg.Wait())
+				require.NoError(t, process.Wait())
 				return
 			}
 
-			event, err := process.WaitForEvent(ctx, ServiceExitedWithErrorEvent)
-			require.NoError(t, err)
-			require.NotNil(t, event)
-			exitPayload, ok := event.Payload.(ExitEventPayload)
-			require.True(t, ok, "expected ExitEventPayload but got %T", event.Payload)
-			require.Equal(t, "db.init", exitPayload.Service.Name())
+			// The first service to exit should be the db one, with a "db.init" event.
+			// We can't use WaitForEvents because it only returns the last event for this type.
+			// As the test causes Teleport to crash, other services might exit in error before
+			// we get the event, causing the test to fail.
+			select {
+			case event := <-serviceExitedEvents:
+				require.NotNil(t, event)
+				exitPayload, ok := event.Payload.(ExitEventPayload)
+				require.True(t, ok, "expected ExitEventPayload but got %T", event.Payload)
+				require.Equal(t, "db.init", exitPayload.Service.Name(), "expected db init failure, got instead %q with error %q", exitPayload.Service.Name(), exitPayload.Error)
+			case <-ctx.Done():
+				require.Fail(t, "context timed out, we never received the failed db.init event")
+			}
+
 			// Database service init is a critical service, meaning failures on
 			// it should cause the process to exit with error.
 			require.Error(t, eg.Wait())


### PR DESCRIPTION
Fixes the flaky test https://github.com/gravitational/teleport.e/actions/runs/12580662865/job/35063002827#step:7:598

Explanation:
- when an event is broadcast, we update the `Supervisor.events` map, if there was already an event with the same name, we override it. Last event wins.
- when `Supervisor.WaitForEvent` is invoked, it looks at `events[name]` and immediately returns the event value if not empty
- the test is waiting for "service exit in error" event
- after the DB service fails, the supervisor cancels the context, every service exits with ContextCancelledErr (which also emits a "service exit in error" event)
- if the test routine is not fast enough, it will miss the "db.init" event and will get one from another service, once we miss the event, we can't recover it

The fix is to create an event listener before starting the sevrices, so it can't miss any event, and look at the first failure instead of the last one.

Fixes: https://github.com/gravitational/teleport/issues/42963