### PR TITLE
Fix Mattermost guide image path

### DIFF
--- a/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
+++ b/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
@@ -101,8 +101,8 @@ Set the "Username", "Display Name", and "Description" fields according to how
 you would like the Mattermost plugin bot to appear in your workspace. Set "Role"
 to "Member".
 
-You can <a href="../../../../img/enterprise/plugins/teleport_bot@2x.png"
-download>download</a> our avatar to set as your Bot Icon.
+You can [download](../../../../img/enterprise/plugins/teleport_bot@2x.png) our
+avatar to set as your Bot Icon.
 
 Set "post:all" to "Enabled".
 


### PR DESCRIPTION
Use Markdown relative link syntax, since the `a` element leads to a broken image link.