### PR TITLE
Fix prettier-plugin-sort-imports for vscode

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -18,7 +18,7 @@ module.exports = {
   arrowParens: 'avoid',
   printWidth: 80,
   bracketSpacing: true,
-  plugins: [require('@ianvs/prettier-plugin-sort-imports')],
+  plugins: ['@ianvs/prettier-plugin-sort-imports'],
   importOrder: [
     '<BUILTIN_MODULES>',
     '',


### PR DESCRIPTION
Before removing this `require` statement, vscode would log an error when running prettier:

```
["ERROR" - 12:26:19 PM] Invalid prettier configuration file detected.
{}
["ERROR" - 12:26:19 PM] Invalid prettier configuration file detected. See log for details.
```