### PR TITLE
Fix tempdir failure in TestInitDatabaseService

### DIFF
--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -105,7 +105,6 @@ func TestAdditionalExpectedRoles(t *testing.T) {
 				cfg := servicecfg.MakeDefaultConfig()
 				cfg.DataDir = makeTempDir(t)
 				cfg.SetAuthServerAddress(utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"})
-				cfg.Auth.StorageConfig.Params["path"] = t.TempDir()
 				cfg.DiagnosticAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
 				cfg.Auth.ListenAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
 
@@ -136,7 +135,6 @@ func TestAdditionalExpectedRoles(t *testing.T) {
 				cfg := servicecfg.MakeDefaultConfig()
 				cfg.DataDir = makeTempDir(t)
 				cfg.SetAuthServerAddress(utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"})
-				cfg.Auth.StorageConfig.Params["path"] = t.TempDir()
 				cfg.DiagnosticAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
 				cfg.Auth.ListenAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
 
@@ -280,7 +278,6 @@ func TestMonitor(t *testing.T) {
 	cfg.DiagnosticAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
 	cfg.SetAuthServerAddress(utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"})
 	cfg.Auth.Enabled = true
-	cfg.Auth.StorageConfig.Params["path"] = t.TempDir()
 	cfg.Auth.ListenAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
 	cfg.Proxy.Enabled = false
 	cfg.SSH.Enabled = false
@@ -1742,7 +1739,6 @@ func TestInstanceMetadata(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := newCfg()
 			cfg.DataDir = makeTempDir(t)
-			cfg.Auth.StorageConfig.Params["path"] = t.TempDir()
 			cfg.InstanceMetadataClient = tc.imClient
 
 			process, err := NewTeleport(cfg)

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -1807,12 +1807,10 @@ func TestInitDatabaseService(t *testing.T) {
 			cfg.DebugService = servicecfg.DebugConfig{
 				Enabled: false,
 			}
-			cfg.Auth.StorageConfig.Params["path"] = t.TempDir()
 			cfg.Hostname = "default.example.com"
 			cfg.Auth.Enabled = true
 			cfg.SetAuthServerAddress(utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"})
 			cfg.Auth.ListenAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
-			cfg.Auth.StorageConfig.Params["path"] = t.TempDir()
 			cfg.Auth.SessionRecordingConfig.SetMode(types.RecordOff)
 			cfg.Proxy.Enabled = true
 			cfg.Proxy.DisableWebInterface = true


### PR DESCRIPTION
Setting auth's `DataDir` to `t.TempDir()` and then setting the storage config path to a `t.TempDir()` ends up creating two totally separate temporary directories, and the behavior that Teleport generally expects is that the auth audit storage is a subdirectory of auth's data dir.

Since #48247 merged it is no longer necessary to set the audit storage at all, the default behavior will be to put it in a subdirectory of the data dir.

```
 ➜ untilfail go test -race -failfast -count=10 -run TestInitDatabaseService ./lib/service
ok      github.com/gravitational/teleport/lib/service   26.720s
ok      github.com/gravitational/teleport/lib/service   27.293s
--- FAIL: TestInitDatabaseService (0.00s)
    --- FAIL: TestInitDatabaseService/enabled_valid_databases (2.09s)
        testing.go:1232: TempDir RemoveAll cleanup: unlinkat /var/folders/nq/cvbdfp8936791spb0cg91yrc0000gn/T/TestInitDatabaseServiceenabled_valid_databases726236108/002: directory not empty
FAIL
FAIL    github.com/gravitational/teleport/lib/service   22.311s
FAIL
```