### PR TITLE
[v17] Fix prettier-plugin-sort-imports for vscode

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -18,7 +18,7 @@ module.exports = {
   arrowParens: 'avoid',
   printWidth: 80,
   bracketSpacing: true,
-  plugins: [require('@ianvs/prettier-plugin-sort-imports')],
+  plugins: ['@ianvs/prettier-plugin-sort-imports'],
   importOrder: [
     '<BUILTIN_MODULES>',
     '',


### PR DESCRIPTION
Backport #50708 to branch/v17