### PR TITLE
Fix auto user role grant

### DIFF
--- a/lib/srv/db/postgres/users.go
+++ b/lib/srv/db/postgres/users.go
@@ -430,13 +430,14 @@ func (e *Engine) updateAutoUsersRole(ctx context.Context, conn *pgx.Conn, adminU
 	// support WITH INHERIT FALSE or WITH SET FALSE syntax, so we only specify
 	// WITH ADMIN OPTION.
 	// See: https://www.postgresql.org/docs/16/release-16.html
-	stmt := fmt.Sprintf("grant role %q to %q WITH ADMIN OPTION", teleportAutoUserRole, adminUser)
+	stmt := fmt.Sprintf("grant %q to %q WITH ADMIN OPTION", teleportAutoUserRole, adminUser)
 	_, err = conn.Exec(ctx, stmt)
 	if err != nil {
 		if !strings.Contains(err.Error(), "cannot be granted back") && !strings.Contains(err.Error(), "already") {
 			e.Log.DebugContext(ctx, "Failed to grant required role to the Teleport database admin, user auto-provisioning may not work until the database admin is granted the role by a superuser",
 				"role", teleportAutoUserRole,
 				"database_admin", adminUser,
+				"error", err,
 			)
 		}
 	}


### PR DESCRIPTION
changelog: Fixed a Postgres database-access auto-user provisioning syntax error that caused a misleading debug level error log in most cases, unless the database admin is not a superuser and the database was upgraded from Postgres v15 or lower to Postgres v16 or higher, in which case the role "teleport-auto-user" must be granted to the database admin with the ADMIN option manually.

This fixes a SQL syntax typo that was added in #48949
-  #48949