### PR TITLE
Invert integration resource builder

### DIFF
--- a/web/packages/teleport/src/Discover/SelectResource/SelectResource.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/SelectResource.tsx
@@ -73,8 +73,8 @@ function getDefaultResources(
   includeEnterpriseResources: boolean
 ): ResourceSpec[] {
   const RESOURCES = includeEnterpriseResources
-    ? BASE_RESOURCES
-    : [...BASE_RESOURCES, ...SAML_APPLICATIONS];
+    ? [...BASE_RESOURCES, ...SAML_APPLICATIONS]
+    : BASE_RESOURCES;
   return RESOURCES;
 }
 


### PR DESCRIPTION
This was accidentally setting enterprise to base instead of enterprise resources

I will manually backport this commit with https://github.com/gravitational/teleport/pull/50657