### PR TITLE
fix: allow CredentialCache.Retrieve to return before initialization

### DIFF
--- a/lib/events/s3sessions/s3handler.go
+++ b/lib/events/s3sessions/s3handler.go
@@ -42,6 +42,7 @@ import (
 	"go.opentelemetry.io/otel"
 
 	"github.com/gravitational/teleport"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
@@ -425,7 +426,7 @@ func (h *Handler) fromPath(p string) session.ID {
 func (h *Handler) ensureBucket(ctx context.Context) error {
 	// Use a short timeout for the HeadBucket call in case it takes too long, in
 	// #50747 this call would hang.
-	shortCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	shortCtx, cancel := context.WithTimeout(ctx, apidefaults.DefaultIOTimeout)
 	defer cancel()
 	_, err := h.client.HeadBucket(shortCtx, &s3.HeadBucketInput{
 		Bucket: aws.String(h.Bucket),

--- a/lib/integrations/awsoidc/credprovider/credentialscache_test.go
+++ b/lib/integrations/awsoidc/credprovider/credentialscache_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -34,13 +33,13 @@ import (
 
 	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 type fakeSTSClient struct {
 	clock clockwork.Clock
 	err   error
 	sync.Mutex
-	called int32
 }
 
 func (f *fakeSTSClient) setError(err error) {
@@ -56,7 +55,6 @@ func (f *fakeSTSClient) getError() error {
 }
 
 func (f *fakeSTSClient) AssumeRoleWithWebIdentity(ctx context.Context, params *sts.AssumeRoleWithWebIdentityInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleWithWebIdentityOutput, error) {
-	atomic.AddInt32(&f.called, 1)
 	if err := f.getError(); err != nil {
 		return nil, err
 	}
@@ -95,6 +93,9 @@ func TestCredentialsCache(t *testing.T) {
 		STSClient:   stsClient,
 		Integration: "test",
 		Clock:       clock,
+		GenerateOIDCTokenFn: func(ctx context.Context, integration string) (string, error) {
+			return uuid.NewString(), nil
+		},
 	})
 	require.NoError(t, err)
 	require.NotNil(t, cacheUnderTest)
@@ -106,12 +107,6 @@ func TestCredentialsCache(t *testing.T) {
 		clock.BlockUntil(1)
 		clock.Advance(d)
 	}
-
-	// Set the GenerateOIDCTokenFn to a dumb faked function.
-	cacheUnderTest.SetGenerateOIDCTokenFn(
-		func(ctx context.Context, integration string) (string, error) {
-			return uuid.NewString(), nil
-		})
 
 	checkRetrieveCredentials := func(t require.TestingT, expectErr error) {
 		_, err := cacheUnderTest.Retrieve(ctx)
@@ -223,4 +218,51 @@ func TestCredentialsCache(t *testing.T) {
 			checkRetrieveCredentials(t, nil)
 		}
 	})
+}
+
+func TestCredentialsCacheRetrieveBeforeInit(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clock := clockwork.NewFakeClock()
+	stsClient := &fakeSTSClient{
+		clock: clock,
+	}
+	cache, err := NewCredentialsCache(CredentialsCacheOptions{
+		STSClient:               stsClient,
+		Integration:             "test",
+		Clock:                   clock,
+		AllowRetrieveBeforeInit: true,
+	})
+	require.NoError(t, err)
+
+	utils.RunTestBackgroundTask(ctx, t, &utils.TestBackgroundTask{
+		Name: "cache.Run",
+		Task: func(ctx context.Context) error {
+			cache.Run(ctx)
+			return nil
+		},
+		Terminate: func() error {
+			cancel()
+			return nil
+		},
+	})
+
+	// cache.Retrieve should return immediately with errNotReady if
+	// SetGenerateOIDCTokenFn has not been called yet.
+	_, err = cache.Retrieve(ctx)
+	require.ErrorIs(t, err, errNotReady)
+
+	// The GenerateOIDCTokenFn can be set after the cache has been initialized.
+	cache.SetGenerateOIDCTokenFn(func(ctx context.Context, integration string) (string, error) {
+		return uuid.NewString(), nil
+	})
+	// WaitForFirstCredsOrErr should usually be called after
+	// SetGenerateOIDCTokenFn to make sure credentials are ready before they
+	// will be relied upon.
+	cache.WaitForFirstCredsOrErr(ctx)
+	// Now cache.Retrieve should not return an error.
+	creds, err := cache.Retrieve(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, creds.SecretAccessKey)
 }

--- a/lib/integrations/awsoidc/credprovider/integration_config_provider.go
+++ b/lib/integrations/awsoidc/credprovider/integration_config_provider.go
@@ -34,7 +34,8 @@ import (
 )
 
 // Options represents additional options for configuring the AWS credentials provider.
-// There are currently no options.
+// There are currently no options but this type is still referenced from
+// teleport.e.
 type Options struct{}
 
 // Option is a function that modifies the Options struct for the AWS configuration.

--- a/lib/integrations/awsoidc/credprovider/integration_config_provider_test.go
+++ b/lib/integrations/awsoidc/credprovider/integration_config_provider_test.go
@@ -19,7 +19,6 @@ package credprovider
 import (
 	"context"
 	"crypto"
-	"sync/atomic"
 	"testing"
 
 	"github.com/gravitational/trace"
@@ -55,24 +54,6 @@ func TestCreateAWSConfigForIntegration(t *testing.T) {
 			STSClient:             stsClient,
 		})
 		require.NoError(t, err)
-		require.Equal(t, int32(0), atomic.LoadInt32(&stsClient.called))
-
-		creds, err := config.Credentials.Retrieve(ctx)
-		require.NoError(t, err)
-		require.NotEmpty(t, creds.SecretAccessKey)
-	})
-
-	t.Run("should init creds before retrieve call", func(t *testing.T) {
-		stsClient := &fakeSTSClient{clock: clockwork.NewFakeClock()}
-		config, err := CreateAWSConfigForIntegration(ctx, Config{
-			Region:                awsRegion,
-			IntegrationName:       integrationName,
-			IntegrationGetter:     deps,
-			AWSOIDCTokenGenerator: deps,
-			STSClient:             stsClient,
-		}, WithWaitForFirstInit(true))
-		require.NoError(t, err)
-		require.Equal(t, int32(1), atomic.LoadInt32(&stsClient.called))
 
 		creds, err := config.Credentials.Retrieve(ctx)
 		require.NoError(t, err)
@@ -88,19 +69,10 @@ type depsMock struct {
 	proxies []types.Server
 }
 
-func (d *depsMock) GenerateOIDCTokenFn(ctx context.Context, integration string) (string, error) {
-	token, err := awsoidc.GenerateAWSOIDCToken(ctx, d, d, awsoidc.GenerateAWSOIDCTokenRequest{
-		Integration: integrationName,
-		Username:    testUser,
-		Subject:     types.IntegrationAWSOIDCSubject,
-	})
-	return token, trace.Wrap(err)
-}
-
 func (d *depsMock) GenerateAWSOIDCToken(ctx context.Context, integration string) (string, error) {
 	token, err := awsoidc.GenerateAWSOIDCToken(ctx, d, d, awsoidc.GenerateAWSOIDCTokenRequest{
 		Integration: integration,
-		Username:    "test-user",
+		Username:    testUser,
 		Subject:     types.IntegrationAWSOIDCSubject,
 	})
 	return token, trace.Wrap(err)

--- a/lib/integrations/externalauditstorage/configurator_test.go
+++ b/lib/integrations/externalauditstorage/configurator_test.go
@@ -231,17 +231,12 @@ func TestCredentialsCache(t *testing.T) {
 	})
 
 	provider := c.CredentialsProvider()
-	providerV1 := c.CredentialsProviderSDKV1()
 
 	checkRetrieveCredentials := func(t require.TestingT, expectErr error) {
-		_, err = providerV1.RetrieveWithContext(ctx)
-		assert.ErrorIs(t, err, expectErr)
 		_, err := provider.Retrieve(ctx)
 		assert.ErrorIs(t, err, expectErr)
 	}
 	checkRetrieveCredentialsWithExpiry := func(t require.TestingT, expectExpiry time.Time) {
-		_, err = providerV1.RetrieveWithContext(ctx)
-		assert.NoError(t, err)
 		creds, err := provider.Retrieve(ctx)
 		assert.NoError(t, err)
 		if err == nil {


### PR DESCRIPTION
Fixes #50747

This PR adds an option to allow `CredentialsCache.Retrieve` to return with an error before `CredentialsCache.SetGenerateOIDCTokenFn` has been called. We have been relying on this behaviour for Auth service startup, because the credential cache is a dependency for the audit storage, which is a dependency for the auth server, which is a dependency for the credential cache's `GenerateOIDCTokenFn`. Some non-critical checks during auth startup must fail instead of hanging on blocking the process from successfully starting.

No changelog because this only affects cloud auth services, and we won't roll v17 out to cloud until this is fixed