### PR TITLE
docs: Update preflight docs for building buildboxes

### DIFF
--- a/docs/preflight.md
+++ b/docs/preflight.md
@@ -14,3 +14,12 @@ This checklist is to be run prior to cutting the release branch.
   - [ ] Update the `BUILDBOX_VERSION` in `build.assets/images.mk`. Commit and merge.
   - [ ] Update `e/.github/workflows/build-buildboxes-cron.yaml` to uncomment final pre-release
     job and ensure it has the correct branch names (two places). Commit and merge.
+  - [ ] After the `BUILDBOX_VERSION` update in the `build.assets/images.mk` has
+    merged to master, build the buildboxes for the next `BUILDBOX_VERSION`. The
+    first run will build the "assets" buildbox and the other builds will likely
+    fail. Run again after the first has finished to build the others that use
+    the "assets" buldbox:
+  
+      today=$(LOCALE=C TZ=UTC date +%A)
+      gh workflow run --repo gravitational/teleport.e --field assets-day="${today}" build-buildboxes.yaml
+      gh workflow run --repo gravitational/teleport.e build-buildboxes.yaml


### PR DESCRIPTION
Update the preflight docs to provide instructions for building the
buildboxes for the new version that master becomes. The buildboxes build
on a schedule and that can mean up to a week will need to pass before
the buildboxes are automatically built, given that the assets buildbox
is build only once a week (Sundays) and that is needed to build the
centos7 buildboxes. The updated instructions describe how to kick off
that build automatically.
