### PR TITLE
docs: Update example Machine ID Kubernetes role to version v7

### DIFF
--- a/docs/pages/enroll-resources/machine-id/access-guides/kubernetes.mdx
+++ b/docs/pages/enroll-resources/machine-id/access-guides/kubernetes.mdx
@@ -70,7 +70,7 @@ Create a file called `role.yaml` with the following content:
 
 ```yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: example-role
 spec:
@@ -83,6 +83,7 @@ spec:
     - kind: "*"
       namespace: "*"
       name: "*"
+      verbs: ["*"]
 ```
 
 Replace `example-role` with a descriptive name related to your use case.


### PR DESCRIPTION
A prospect followed the docs as written but had to switch to `version: v7` instead of `version: v6`, as there is an error trying to create a v6 role with `kubernetes_resources`:

![Screenshot 2025-01-06 at 10 44 46](https://github.com/user-attachments/assets/8504515d-fddd-41fb-8dbf-704f375171ff)

As such, this updates the role to use the required version v7 with the required `verbs` section.