### PR TITLE
[v17] Move the Upcoming Releases page to v17

### DIFF
--- a/docs/pages/upcoming-releases.mdx
+++ b/docs/pages/upcoming-releases.mdx
@@ -1,117 +1,70 @@
 ---
 title: Teleport Upcoming Releases
 description: A timeline of upcoming Teleport releases.
-h1: Upcoming Teleport Releases
 ---
 
-The Teleport team delivers a new major release roughly every 3 months.
+The Teleport team delivers a new major release roughly every 4 months.
 
 ## Teleport
 
-### Teleport 12.3.0
+| Version | Date                        |
+|---------|-----------------------------|
+| 17.2.0  | Week of January 20th, 2024  |
 
-####  Automatic user creation for Desktop Access
+### 17.2.0
 
-Teleport's passwordless access for local users will provide the ability to
-create Windows users on demand, similar to how host-user creation works for SSH
-servers.
+#### Per-session MFA via IdP
 
-#### SFTP UX enhancements
+Teleport users will be able to satisfy per-session MFA checks by authenticating
+with an external identity provider as an alternative to using second factors
+registered with Teleport.
 
-Will include fixes for wildcard patterns, excessive audit logging and PyCharm
-compatibility. [#22748](https://github.com/gravitational/teleport/issues/22748)
-[#21518](https://github.com/gravitational/teleport/issues/21518)
-[#22982](https://github.com/gravitational/teleport/issues/22982)
-[#22263](https://github.com/gravitational/teleport/issues/22263)
-[#20863](https://github.com/gravitational/teleport/issues/20863)
-[#23593](https://github.com/gravitational/teleport/issues/23593)
+*Delayed from Teleport 17.1.0.*
+
+#### GitHub access
+
+Teleport will natively support GitHub access allowing users to transparently
+interact with Github with RBAC and audit logging support.
+
+*Delayed from Teleport 17.1.0.*
+
+#### Oracle Toad client support
+
+Oracle Database Access users will be able to use Toad GUI client.
+
+#### Trusted clusters support for Kubernetes operator
+
+Kubernetes operator users will be able to create trusted clusters using
+Kubernetes custom resources.
+
+## Teleport Policy
 
 | Version | Date          |
 |---------|---------------|
-| 12.3.0  | May 1st, 2023 |
+| 1.27.0  | January 2025  |
 
-### Teleport 13.0.0
+### 1.27.0
 
-| Version        | Date             |
-|----------------|------------------|
-| 13.0.0-alpha.1 | April 17th, 2023 |
-| 13.0.0         | May 8th, 2023    |
+#### Azure integration
 
-####  Automatic updates
+Teleport Policy will support Azure integration allowing users to sync Azure
+resources such as VMs, and visualize access paths to them.
 
-Users will be able to configure Teleport agents to upgrade automatically.
+#### NetIQ integration
 
-####  TLS routing through ALB for server access and Kubernetes access
-
-Teleport will support server access and Kubernetes access through load
-balancers in TLS routing mode.
-
-####  Ability to import applications and groups from Okta to Application Access
-
-Teleport will be able to imports Okta apps and groups and users will be able to
-use Access Requests with Okta apps and groups.
-
-####  AWS OpenSearch support for Database Access
-
-Database access will add support for connecting to AWS OpenSearch.
-
-#### Cross-Cluster Search for Teleport Connect
-
-Teleport Connect will include a new search experience, allowing you to search
-for and connect to resources across all logged-in clusters.
-
-#### Kubernetes access performance improvements
-
-Users will experience better performance when interacting with Kubernetes clusters.
-
-#### Universal binaries (including Apple Silicon) for macOS
-
-Teleport will run natively on ARM Macs, without the need for Rosetta emulation.
-
-#### Simplified RDS onboarding flow in Access Management UI
-
-Teleport Access Management UI will provide ability to connect to AWS account
-and select RDS databases for onboarding.
-
-#### Light theme for Web UI
-
-Teleport's web UI will ship with an optional light theme.
-
-#### Other
-
-In addition, the following improvements
-
-- Improved SQL Server PKINIT Auth support
-- Session recording video export support for Desktop Access
-- Add support for locking to Web UI
-- Device listing in Web UI
-
-### 13.1.0
-
-####  GCP Auto-Discovery for Server Access
-
-Teleport will be able to automatically enroll GCP VM for server access.
-
-####  OpsGenie Access Request Plugin
-
-Teleport will include OpsGenie access plugin.
-
-*Delayed from Teleport 13.0.0.*
-
-| Version | Date           |
-|---------|----------------|
-| 12.3.0  | June 1st, 2023 |
+Teleport Policy will support NetIQ integration, allowing users to
+sync and visualize NetIQ permissions.
 
 ## Teleport Cloud
 
 The key deliverables for Teleport Cloud in the next quarter:
 
-| Week of          | Description                                          |
-|------------------|------------------------------------------------------|
-| April 10th, 2023 | Teleport 12.2 begins to roll out for Cloud customers |
-| May 8th, 2023    | Add support for hosted Access Request plugins        |
-| June 5th, 2023   | Teleport 13.1 begins to roll out for Cloud customers |
-| June 5th, 2023   | Advanced Audit Log rollout begins                    |
+| Week of               | Description                                                    |
+|-----------------------|----------------------------------------------------------------|
+| January 13th, 2024     | Teleport 17.1 will begin rollout on Cloud.                     |
+| January 13th, 2024     | Teleport 17.1 agents will begin rollout to eligible tenants.   |
+| January 27th, 2024     | Teleport 17.2 will begin rollout on Cloud.                     |
+| January 27th, 2024     | Teleport 17.2 agents will begin rollout to eligible tenants.   |
 
 ## Production readiness
 
@@ -151,19 +104,3 @@ minor release, such as (=teleport.major_version=).1.0.
 
 Patch releases contain small bug fixes and can typically be deployed directly
 to production.
-
-## Preview Policy
-
-A product or feature may be marked as "Preview" if any of the following is
-true.
-
-- The product or feature is missing key functionality. For example, Microsoft
-  SQL Server support for database access initially shipped without audit
-  logging support.
-- The product or feature has NOT been adopted by at least 2 existing customers.
-- The product or feature has NOT been through a security audit.
-- The documentation for the product or feature is incomplete.
-- Assets (e.g. binaries) associated with the feature are not published to our
-  official downloads page.
-
-Use preview features in production if the above issues are not a concern.


### PR DESCRIPTION
Add the most up-to-date version of the Upcoming Releases page to v17 to coincide with making v17 the default version of the docs.