### PR TITLE
gha(update-docs-webhook): fix workflow syntax

### DIFF
--- a/.github/workflows/update-docs-webhook.yaml
+++ b/.github/workflows/update-docs-webhook.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Call deployment webhook
         env:
-          WEBHOOK_URL: ${{ secrets["AMPLIFY_DOCS_DEPLOY_HOOK"] }}
+          WEBHOOK_URL: ${{ secrets.AMPLIFY_DOCS_DEPLOY_HOOK }}
         run: |
           if curl -X POST --silent --fail --show-error "$WEBHOOK_URL" > /dev/null; then
             echo "Triggered successfully"

--- a/.github/workflows/update-docs-webhook.yaml
+++ b/.github/workflows/update-docs-webhook.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Call deployment webhook
         env:
-          WEBHOOK_URL: ${{ secrets[AMPLIFY_DOCS_DEPLOY_HOOK] }}
+          WEBHOOK_URL: ${{ secrets["AMPLIFY_DOCS_DEPLOY_HOOK"] }}
         run: |
           if curl -X POST --silent --fail --show-error "$WEBHOOK_URL" > /dev/null; then
             echo "Triggered successfully"


### PR DESCRIPTION
### Summary

Workflow syntax introduced in:
- https://github.com/gravitational/teleport/pull/50579

Currently this action is failing on some of the branches where backports were merged:
- https://github.com/gravitational/teleport/actions/workflows/update-docs-webhook.yaml?query=branch%3Amaster