### PR TITLE
Prevent quoting debug reports

### DIFF
--- a/lib/utils/log/handle_state.go
+++ b/lib/utils/log/handle_state.go
@@ -125,11 +125,13 @@ func (s *handleState) appendAttr(a slog.Attr) bool {
 	}
 
 	// Handle special cases before formatting.
+	var traceError bool
 	if a.Value.Kind() == slog.KindAny {
 		switch v := a.Value.Any().(type) {
 		case *slog.Source:
 			a.Value = slog.StringValue(fmt.Sprintf(" %s:%d", v.File, v.Line))
 		case trace.Error:
+			traceError = true
 			a.Value = slog.StringValue("[" + v.DebugReport() + "]")
 		case error:
 			a.Value = slog.StringValue(fmt.Sprintf("[%v]", v))
@@ -161,18 +163,11 @@ func (s *handleState) appendAttr(a slog.Attr) bool {
 		return true
 	}
 
-	if a.Value.Kind() == slog.KindString && a.Key != slog.LevelKey {
-		val := a.Value.String()
-		if needsQuoting(val) {
-			a.Value = slog.StringValue(strconv.Quote(val))
-		}
-	}
-
 	s.appendKey(a.Key)
 
-	// Write the log key directly to avoid quoting
-	// color formatting that exists.
-	if a.Key == slog.LevelKey {
+	// Write the level key to avoid quoting color formatting that exists or
+	// [trace.Error]s so that the debug report is output in it's entirety.
+	if traceError || a.Key == slog.LevelKey {
 		s.buf.WriteString(a.Value.String())
 	} else {
 		s.appendValue(a.Value)


### PR DESCRIPTION
The refactoring done in #50451 caused the trace.Error debug report to be quoted in log output. This updates the quoting bypass used for log level to also consider trace.Errors in order to restore the previous output.


Changelog: Prevent quoting errors in log messages.