### PR TITLE
[v15] Fix auto user role grant

### DIFF
--- a/lib/srv/db/postgres/users.go
+++ b/lib/srv/db/postgres/users.go
@@ -431,11 +431,11 @@ func (e *Engine) initAutoUsers(ctx context.Context, sessionCtx *common.Session, 
 	// WITH ADMIN OPTION.
 	// See: https://www.postgresql.org/docs/16/release-16.html
 	adminUser := sessionCtx.Database.GetAdminUser().Name
-	stmt := fmt.Sprintf("grant role %q to %q WITH ADMIN OPTION", teleportAutoUserRole, adminUser)
+	stmt := fmt.Sprintf("grant %q to %q WITH ADMIN OPTION", teleportAutoUserRole, adminUser)
 	_, err = conn.Exec(ctx, stmt)
 	if err != nil {
 		if !strings.Contains(err.Error(), "cannot be granted back") && !strings.Contains(err.Error(), "already") {
-			e.Log.Debugf("Failed to grant required role %q to the Teleport database admin %q, user auto-provisioning may not work until the database admin is granted the role by a superuser",
+			e.Log.WithError(err).Debugf("Failed to grant required role %q to the Teleport database admin %q, user auto-provisioning may not work until the database admin is granted the role by a superuser",
 				teleportAutoUserRole,
 				adminUser,
 			)


### PR DESCRIPTION
Backport #50744 to branch/v15

changelog: Fixed a Postgres database-access auto-user provisioning syntax error that caused a misleading debug level error log in most cases, unless the database admin is not a superuser and the database was upgraded from Postgres v15 or lower to Postgres v16 or higher, in which case the role "teleport-auto-user" must be granted to the database admin with the ADMIN option manually.
