### PR TITLE
Fix Per-session MFA for desktops

### DIFF
--- a/web/packages/teleport/src/Console/DocumentDb/DocumentDb.tsx
+++ b/web/packages/teleport/src/Console/DocumentDb/DocumentDb.tsx
@@ -24,7 +24,7 @@ import AuthnDialog from 'teleport/components/AuthnDialog';
 import Document from 'teleport/Console/Document';
 import { Terminal, TerminalRef } from 'teleport/Console/DocumentSsh/Terminal';
 import * as stores from 'teleport/Console/stores/types';
-import { useMfaTty } from 'teleport/lib/useMfa';
+import { useMfaEmitter } from 'teleport/lib/useMfa';
 
 import { ConnectDialog } from './ConnectDialog';
 import { useDbSession } from './useDbSession';
@@ -37,7 +37,7 @@ type Props = {
 export function DocumentDb({ doc, visible }: Props) {
   const terminalRef = useRef<TerminalRef>();
   const { tty, status, closeDocument, sendDbConnectData } = useDbSession(doc);
-  const mfa = useMfaTty(tty);
+  const mfa = useMfaEmitter(tty);
   useEffect(() => {
     // when switching tabs or closing tabs, focus on visible terminal
     terminalRef.current?.focus();

--- a/web/packages/teleport/src/Console/DocumentKubeExec/DocumentKubeExec.tsx
+++ b/web/packages/teleport/src/Console/DocumentKubeExec/DocumentKubeExec.tsx
@@ -25,7 +25,7 @@ import Document from 'teleport/Console/Document';
 import useKubeExecSession from 'teleport/Console/DocumentKubeExec/useKubeExecSession';
 import { Terminal, TerminalRef } from 'teleport/Console/DocumentSsh/Terminal';
 import * as stores from 'teleport/Console/stores/types';
-import { useMfaTty } from 'teleport/lib/useMfa';
+import { useMfaEmitter } from 'teleport/lib/useMfa';
 
 import KubeExecData from './KubeExecDataDialog';
 
@@ -38,7 +38,7 @@ export default function DocumentKubeExec({ doc, visible }: Props) {
   const terminalRef = useRef<TerminalRef>();
   const { tty, status, closeDocument, sendKubeExecData } =
     useKubeExecSession(doc);
-  const mfa = useMfaTty(tty);
+  const mfa = useMfaEmitter(tty);
   useEffect(() => {
     // when switching tabs or closing tabs, focus on visible terminal
     terminalRef.current?.focus();

--- a/web/packages/teleport/src/Console/DocumentSsh/DocumentSsh.tsx
+++ b/web/packages/teleport/src/Console/DocumentSsh/DocumentSsh.tsx
@@ -30,7 +30,7 @@ import { TerminalSearch } from 'shared/components/TerminalSearch';
 
 import AuthnDialog from 'teleport/components/AuthnDialog';
 import * as stores from 'teleport/Console/stores';
-import { useMfa, useMfaTty } from 'teleport/lib/useMfa';
+import { useMfa, useMfaEmitter } from 'teleport/lib/useMfa';
 import { MfaChallengeScope } from 'teleport/services/auth/auth';
 
 import { useConsoleContext } from '../consoleContextProvider';
@@ -54,7 +54,7 @@ function DocumentSsh({ doc, visible }: PropTypes) {
   const { tty, status, closeDocument, session } = useSshSession(doc);
   const [showSearch, setShowSearch] = useState(false);
 
-  const ttyMfa = useMfaTty(tty);
+  const ttyMfa = useMfaEmitter(tty);
   const ftMfa = useMfa({
     isMfaRequired: ttyMfa.required,
     req: {

--- a/web/packages/teleport/src/DesktopSession/useDesktopSession.tsx
+++ b/web/packages/teleport/src/DesktopSession/useDesktopSession.tsx
@@ -24,7 +24,7 @@ import useAttempt from 'shared/hooks/useAttemptNext';
 
 import type { UrlDesktopParams } from 'teleport/config';
 import { ButtonState } from 'teleport/lib/tdp';
-import { useMfaTty } from 'teleport/lib/useMfa';
+import { useMfaEmitter } from 'teleport/lib/useMfa';
 import desktopService from 'teleport/services/desktops';
 import userService from 'teleport/services/user';
 
@@ -129,7 +129,7 @@ export default function useDesktopSession() {
   });
   const tdpClient = clientCanvasProps.tdpClient;
 
-  const mfa = useMfaTty(tdpClient);
+  const mfa = useMfaEmitter(tdpClient);
 
   const onShareDirectory = () => {
     try {

--- a/web/packages/teleport/src/lib/tdp/client.ts
+++ b/web/packages/teleport/src/lib/tdp/client.ts
@@ -25,6 +25,7 @@ import init, {
 import { AuthenticatedWebSocket } from 'teleport/lib/AuthenticatedWebSocket';
 import { EventEmitterMfaSender } from 'teleport/lib/EventEmitterMfaSender';
 import { TermEvent, WebsocketCloseCode } from 'teleport/lib/term/enums';
+import { MfaChallengeResponse } from 'teleport/services/mfa';
 
 import Codec, {
   FileType,
@@ -617,6 +618,14 @@ export default class Client extends EventEmitterMfaSender {
 
   sendClipboardData(clipboardData: ClipboardData) {
     this.send(this.codec.encodeClipboardData(clipboardData));
+  }
+
+  sendChallengeResponse(data: MfaChallengeResponse) {
+    const msg = this.codec.encodeMfaJson({
+      mfaType: 'n',
+      jsonString: JSON.stringify(data),
+    });
+    this.send(msg);
   }
 
   addSharedDirectory(sharedDirectory: FileSystemDirectoryHandle) {

--- a/web/packages/teleport/src/lib/useMfa.ts
+++ b/web/packages/teleport/src/lib/useMfa.ts
@@ -172,7 +172,7 @@ export function useMfa({ req, isMfaRequired }: MfaProps): MfaState {
   };
 }
 
-export function useMfaTty(emitterSender: EventEmitterMfaSender): MfaState {
+export function useMfaEmitter(emitterSender: EventEmitterMfaSender): MfaState {
   const [mfaRequired, setMfaRequired] = useState(false);
 
   const mfa = useMfa({ isMfaRequired: mfaRequired });


### PR DESCRIPTION
Restore `EventEmitterMfaSender` implementation for desktop access [mistakenly removed](https://github.com/gravitational/teleport/pull/49794/files#r1907853997) in https://github.com/gravitational/teleport/pull/49794.

This will be backported in https://github.com/gravitational/teleport/pull/50529

Closes https://github.com/gravitational/teleport/issues/50557