### PR TITLE
Fix yarn installation issues

### DIFF
--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -70,9 +70,11 @@ jobs:
       - name: Install docs site dependencies
         working-directory: docs
         if: ${{ steps.yarn-cache.outputs.cache-hit != 'true' }}
-        # Prevent occasional `yarn install` executions that run indefinitely
         timeout-minutes: 10
-        run: yarn install
+        run: |
+          git config --global url."https://github".insteadOf ssh://git@github
+          git config --global url."https://github.com/".insteadOf git@github.com:
+          yarn install
 
       - name: Prepare docs site configuration
         working-directory: docs

--- a/e2e/config/run-tests.sh
+++ b/e2e/config/run-tests.sh
@@ -23,6 +23,8 @@ set -e
 cp /etc/teleport/certs/rootCA.pem /usr/local/share/ca-certificates/teleport.crt
 update-ca-certificates
 
+git config --global url."https://github".insteadOf ssh://git@github
+git config --global url."https://github.com/".insteadOf git@github.com:s
 yarn install
 
 # Wait for the Teleport to be up and initialized.


### PR DESCRIPTION
Configures yarn to use https instead of ssh for git clone operations.

GH appears to have released either a regression, or yet another breaking change with no announcement. This works around the issue while GH sorts their problems out.