### PR TITLE
Fix AWS ListDeployedDatabaseServices when there's no ECS Cluster

### DIFF
--- a/lib/cloud/aws/errors.go
+++ b/lib/cloud/aws/errors.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
@@ -55,6 +56,10 @@ func ConvertRequestFailureErrorV2(err error) error {
 	return err
 }
 
+var (
+	ecsClusterNotFoundException *ecstypes.ClusterNotFoundException
+)
+
 func convertRequestFailureErrorFromStatusCode(statusCode int, requestErr error) error {
 	switch statusCode {
 	case http.StatusForbidden:
@@ -68,6 +73,10 @@ func convertRequestFailureErrorFromStatusCode(statusCode int, requestErr error) 
 		// "AccessDeniedException" instead of 403.
 		if strings.Contains(requestErr.Error(), redshiftserverless.ErrCodeAccessDeniedException) {
 			return trace.AccessDenied(requestErr.Error())
+		}
+
+		if strings.Contains(requestErr.Error(), ecsClusterNotFoundException.ErrorCode()) {
+			return trace.NotFound(requestErr.Error())
 		}
 	}
 

--- a/lib/cloud/aws/errors_test.go
+++ b/lib/cloud/aws/errors_test.go
@@ -85,6 +85,18 @@ func TestConvertRequestFailureError(t *testing.T) {
 			},
 			wantIsError: trace.IsNotFound,
 		},
+		{
+			name: "v2 sdk error for ecs ClusterNotFoundException",
+			inputError: &awshttp.ResponseError{
+				ResponseError: &smithyhttp.ResponseError{
+					Response: &smithyhttp.Response{Response: &http.Response{
+						StatusCode: http.StatusBadRequest,
+					}},
+					Err: trace.Errorf("ClusterNotFoundException"),
+				},
+			},
+			wantIsError: trace.IsNotFound,
+		},
 	}
 
 	for _, test := range tests {

--- a/lib/integrations/awsoidc/listdeployeddatabaseservice.go
+++ b/lib/integrations/awsoidc/listdeployeddatabaseservice.go
@@ -27,6 +27,7 @@ import (
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/gravitational/trace"
 
+	awslib "github.com/gravitational/teleport/lib/cloud/aws"
 	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
 )
 
@@ -139,6 +140,11 @@ func ListDeployedDatabaseServices(ctx context.Context, clt ListDeployedDatabaseS
 
 	listServicesOutput, err := clt.ListServices(ctx, listServicesInput)
 	if err != nil {
+		convertedError := awslib.ConvertRequestFailureErrorV2(err)
+		if trace.IsNotFound(convertedError) {
+			return &ListDeployedDatabaseServicesResponse{}, nil
+		}
+
 		return nil, trace.Wrap(err)
 	}
 


### PR DESCRIPTION
Calling the AWS API `ecs:ListServices` with a non-existent ECS Cluster name will return a 400 w/ ClusterNotFoundException.

The existing code was not handling that error and a raw error was returned.

This PR changes the logic to ensure that case is handled and that the ListDeployedDatabaseServices returns an empty list.

An alternative would be to call the ListClusters beforehand, but that would increase the number of API calls we do to external services.