### PR TITLE
Fix `useMfa` error handling

### DIFF
--- a/web/packages/teleport/src/components/AuthnDialog/AuthnDialog.tsx
+++ b/web/packages/teleport/src/components/AuthnDialog/AuthnDialog.tsx
@@ -33,9 +33,9 @@ export type Props = {
 };
 
 export default function AuthnDialog({
-  mfaState: { options, challenge, submit, attempt, resetAttempt },
+  mfaState: { options, challenge, submit, attempt, cancelAttempt },
   replaceErrorText,
-  onClose,
+  onClose = () => {},
 }: Props) {
   if (!challenge && attempt.status !== 'error') return;
 
@@ -50,7 +50,7 @@ export default function AuthnDialog({
         <ButtonIcon
           data-testid="close-dialog"
           onClick={() => {
-            resetAttempt();
+            cancelAttempt();
             onClose();
           }}
         >

--- a/web/packages/teleport/src/components/AuthnDialog/AuthnDialog.tsx
+++ b/web/packages/teleport/src/components/AuthnDialog/AuthnDialog.tsx
@@ -29,6 +29,8 @@ import { MFA_OPTION_TOTP } from 'teleport/services/mfa';
 export type Props = {
   mfaState: MfaState;
   replaceErrorText?: string;
+  // onClose is an optional function to perform additional operations
+  // upon closing the dialog. e.g. close a shell session
   onClose?: () => void;
 };
 
@@ -37,12 +39,10 @@ export default function AuthnDialog({
   replaceErrorText,
   onClose = () => {},
 }: Props) {
-  const showMfaDialog =
-    !!challenge ||
-    (attempt.status === 'error' &&
-      !(attempt.error instanceof MfaCanceledError));
+  const showError =
+    attempt.status === 'error' && !(attempt.error instanceof MfaCanceledError);
 
-  if (!showMfaDialog) return;
+  if (!challenge && !showError) return;
 
   // TODO(Joerger): TOTP should be pretty easy to support here with a small button -> form flow.
   const onlyTotpAvailable =

--- a/web/packages/teleport/src/components/AuthnDialog/AuthnDialog.tsx
+++ b/web/packages/teleport/src/components/AuthnDialog/AuthnDialog.tsx
@@ -23,7 +23,7 @@ import { Cross, FingerprintSimple } from 'design/Icon';
 import { guessProviderType } from 'shared/components/ButtonSso';
 import { SSOIcon } from 'shared/components/ButtonSso/ButtonSso';
 
-import { MfaState } from 'teleport/lib/useMfa';
+import { MfaCanceledError, MfaState } from 'teleport/lib/useMfa';
 import { MFA_OPTION_TOTP } from 'teleport/services/mfa';
 
 export type Props = {
@@ -37,7 +37,12 @@ export default function AuthnDialog({
   replaceErrorText,
   onClose = () => {},
 }: Props) {
-  if (!challenge && attempt.status !== 'error') return;
+  const showMfaDialog =
+    !!challenge ||
+    (attempt.status === 'error' &&
+      !(attempt.error instanceof MfaCanceledError));
+
+  if (!showMfaDialog) return;
 
   // TODO(Joerger): TOTP should be pretty easy to support here with a small button -> form flow.
   const onlyTotpAvailable =

--- a/web/packages/teleport/src/lib/useMfa.test.tsx
+++ b/web/packages/teleport/src/lib/useMfa.test.tsx
@@ -236,9 +236,6 @@ describe('useMfa', () => {
 
     await expect(respPromise).rejects.toThrow(new MfaCanceledError());
 
-    // If the user cancels the MFA attempt and closes the dialog, the mfa status
-    // should be 'success', or else the dialog would remain open to display the error.
-    // This error is meant to be handled by the caller.
     await waitFor(() => {
       expect(mfa.current.attempt.status).toEqual('error');
     });

--- a/web/packages/teleport/src/lib/useMfa.test.tsx
+++ b/web/packages/teleport/src/lib/useMfa.test.tsx
@@ -27,7 +27,7 @@ import {
   MfaChallengeResponse,
 } from 'teleport/services/mfa';
 
-import { useMfa } from './useMfa';
+import { MfaCanceledError, useMfa } from './useMfa';
 
 const mockChallenge: MfaAuthenticateChallenge = {
   webauthnPublicKey: {} as PublicKeyCredentialRequestOptions,
@@ -234,15 +234,16 @@ describe('useMfa', () => {
 
     mfa.current.cancelAttempt();
 
-    await expect(respPromise).rejects.toThrow(
-      new Error('User canceled MFA attempt')
-    );
+    await expect(respPromise).rejects.toThrow(new MfaCanceledError());
 
     // If the user cancels the MFA attempt and closes the dialog, the mfa status
     // should be 'success', or else the dialog would remain open to display the error.
     // This error is meant to be handled by the caller.
     await waitFor(() => {
-      expect(mfa.current.attempt.status).toEqual('success');
+      expect(mfa.current.attempt.status).toEqual('error');
     });
+    expect(
+      mfa.current.attempt.status === 'error' && mfa.current.attempt.error
+    ).toEqual(new MfaCanceledError());
   });
 });

--- a/web/packages/teleport/src/lib/useMfa.test.tsx
+++ b/web/packages/teleport/src/lib/useMfa.test.tsx
@@ -232,14 +232,17 @@ describe('useMfa', () => {
       expect(auth.getMfaChallenge).toHaveBeenCalled();
     });
 
-    mfa.current.resetAttempt();
+    mfa.current.cancelAttempt();
 
     await expect(respPromise).rejects.toThrow(
-      new Error('MFA attempt cancelled by user')
+      new Error('User canceled MFA attempt')
     );
 
+    // If the user cancels the MFA attempt and closes the dialog, the mfa status
+    // should be 'success', or else the dialog would remain open to display the error.
+    // This error is meant to be handled by the caller.
     await waitFor(() => {
-      expect(mfa.current.attempt.status).toEqual('error');
+      expect(mfa.current.attempt.status).toEqual('success');
     });
   });
 });


### PR DESCRIPTION
The original error is now displayed in the MFA dialog, and the `MFA canclled by user` error is displayed at the top level after the MFA dialog is closed:

![Screenshot 2025-01-07 at 12 22 32 PM](https://github.com/user-attachments/assets/eaa45240-56cd-458b-9ca9-eac723abe113)
![Screenshot 2025-01-07 at 12 23 37 PM](https://github.com/user-attachments/assets/e52f749a-8c58-4e9b-b6be-c659eaa87667)

Fixes https://github.com/gravitational/teleport/issues/50582

This will be backported with https://github.com/gravitational/teleport/pull/50529