### PR TITLE
migrate AWS RDS services to AWS SDK v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.15.23
 	github.com/aws/aws-sdk-go-v2/feature/dynamodbstreams/attributevalue v1.14.58
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.22
+	github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.5.2
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.45
 	github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.34.3
 	github.com/aws/aws-sdk-go-v2/service/athena v1.49.2

--- a/go.sum
+++ b/go.sum
@@ -866,6 +866,8 @@ github.com/aws/aws-sdk-go-v2/feature/dynamodbstreams/attributevalue v1.14.58/go.
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.3/go.mod h1:4Q0UFP0YJf0NrsEuEYHpM9fTSEVnD16Z3uyEF7J9JGM=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.22 h1:kqOrpojG71DxJm/KDPO+Z/y1phm1JlC8/iT+5XRmAn8=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.22/go.mod h1:NtSFajXVVL8TA2QNngagVZmUtXciyrHOt7xgz4faS/M=
+github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.5.2 h1:fo+GuZNME9oGDc7VY+EBT+oCrco6RjRgUp1bKTcaHrU=
+github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.5.2/go.mod h1:fnqb94UO6YCjBIic4WaqDYkNVAEFWOWiReVHitBBWW0=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.45 h1:ZxB8WFVYwolhDZxuZXoesHkl+L9cXLWy0K/G0QkNATc=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.45/go.mod h1:1krrbyoFFDqaNldmltPTP+mK3sAXLHPoaFtISOw2Hkk=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.33/go.mod h1:7i0PF1ME/2eUPFcjkVIwq+DOygHEoK92t5cDqNgYbIw=

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -798,6 +798,8 @@ github.com/aws/aws-sdk-go-v2/feature/dynamodbstreams/attributevalue v1.14.58 h1:
 github.com/aws/aws-sdk-go-v2/feature/dynamodbstreams/attributevalue v1.14.58/go.mod h1:1FDesv+tfF2w5mRnLQbB8P33BPfxrngXtfNcdnrtmjw=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.22 h1:kqOrpojG71DxJm/KDPO+Z/y1phm1JlC8/iT+5XRmAn8=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.22/go.mod h1:NtSFajXVVL8TA2QNngagVZmUtXciyrHOt7xgz4faS/M=
+github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.5.2 h1:fo+GuZNME9oGDc7VY+EBT+oCrco6RjRgUp1bKTcaHrU=
+github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.5.2/go.mod h1:fnqb94UO6YCjBIic4WaqDYkNVAEFWOWiReVHitBBWW0=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.45 h1:ZxB8WFVYwolhDZxuZXoesHkl+L9cXLWy0K/G0QkNATc=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.45/go.mod h1:1krrbyoFFDqaNldmltPTP+mK3sAXLHPoaFtISOw2Hkk=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.26 h1:I/5wmGMffY4happ8NOCuIUEWGUvvFp5NSeQcXl9RHcI=

--- a/lib/cloud/aws/aws.go
+++ b/lib/cloud/aws/aws.go
@@ -22,12 +22,12 @@ import (
 	"slices"
 	"strings"
 
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	redshifttypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/aws/aws-sdk-go/service/memorydb"
 	"github.com/aws/aws-sdk-go/service/opensearchservice"
-	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/coreos/go-semver/semver"
 
 	"github.com/gravitational/teleport/lib/services"
@@ -74,18 +74,51 @@ func IsOpenSearchDomainAvailable(domain *opensearchservice.DomainStatus) bool {
 }
 
 // IsRDSProxyAvailable checks if the RDS Proxy is available.
-func IsRDSProxyAvailable(dbProxy *rds.DBProxy) bool {
-	return IsResourceAvailable(dbProxy, dbProxy.Status)
+func IsRDSProxyAvailable(dbProxy *rdstypes.DBProxy) bool {
+	switch dbProxy.Status {
+	case
+		rdstypes.DBProxyStatusAvailable,
+		rdstypes.DBProxyStatusModifying,
+		rdstypes.DBProxyStatusReactivating:
+		return true
+	case
+		rdstypes.DBProxyStatusCreating,
+		rdstypes.DBProxyStatusDeleting,
+		rdstypes.DBProxyStatusIncompatibleNetwork,
+		rdstypes.DBProxyStatusInsufficientResourceLimits,
+		rdstypes.DBProxyStatusSuspended,
+		rdstypes.DBProxyStatusSuspending:
+		return false
+	}
+	slog.WarnContext(context.Background(), "Assuming RDS Proxy with unknown status is available",
+		"status", dbProxy.Status,
+	)
+	return true
 }
 
 // IsRDSProxyCustomEndpointAvailable checks if the RDS Proxy custom endpoint is available.
-func IsRDSProxyCustomEndpointAvailable(customEndpoint *rds.DBProxyEndpoint) bool {
-	return IsResourceAvailable(customEndpoint, customEndpoint.Status)
+func IsRDSProxyCustomEndpointAvailable(customEndpoint *rdstypes.DBProxyEndpoint) bool {
+	switch customEndpoint.Status {
+	case
+		rdstypes.DBProxyEndpointStatusAvailable,
+		rdstypes.DBProxyEndpointStatusModifying:
+		return true
+	case
+		rdstypes.DBProxyEndpointStatusCreating,
+		rdstypes.DBProxyEndpointStatusDeleting,
+		rdstypes.DBProxyEndpointStatusIncompatibleNetwork,
+		rdstypes.DBProxyEndpointStatusInsufficientResourceLimits:
+		return false
+	}
+	slog.WarnContext(context.Background(), "Assuming RDS Proxy custom endpoint with unknown status is available",
+		"status", customEndpoint.Status,
+	)
+	return true
 }
 
 // IsRDSInstanceSupported returns true if database supports IAM authentication.
 // Currently, only MariaDB is being checked.
-func IsRDSInstanceSupported(instance *rds.DBInstance) bool {
+func IsRDSInstanceSupported(instance *rdstypes.DBInstance) bool {
 	// TODO(jakule): Check other engines.
 	if aws.StringValue(instance.Engine) != services.RDSEngineMariaDB {
 		return true
@@ -105,7 +138,7 @@ func IsRDSInstanceSupported(instance *rds.DBInstance) bool {
 }
 
 // IsRDSClusterSupported checks whether the Aurora cluster is supported.
-func IsRDSClusterSupported(cluster *rds.DBCluster) bool {
+func IsRDSClusterSupported(cluster *rdstypes.DBCluster) bool {
 	switch aws.StringValue(cluster.EngineMode) {
 	// Aurora Serverless v1 does NOT support IAM authentication.
 	// https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless.html#aurora-serverless.limitations
@@ -129,7 +162,7 @@ func IsRDSClusterSupported(cluster *rds.DBCluster) bool {
 }
 
 // AuroraMySQLVersion extracts aurora mysql version from engine version
-func AuroraMySQLVersion(cluster *rds.DBCluster) string {
+func AuroraMySQLVersion(cluster *rdstypes.DBCluster) string {
 	// version guide: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Updates.Versions.html
 	// a list of all the available versions: https://docs.aws.amazon.com/cli/latest/reference/rds/describe-db-engine-versions.html
 	//
@@ -154,7 +187,7 @@ func AuroraMySQLVersion(cluster *rds.DBCluster) string {
 // for this DocumentDB cluster.
 //
 // https://docs.aws.amazon.com/documentdb/latest/developerguide/iam-identity-auth.html
-func IsDocumentDBClusterSupported(cluster *rds.DBCluster) bool {
+func IsDocumentDBClusterSupported(cluster *rdstypes.DBCluster) bool {
 	ver, err := semver.NewVersion(aws.StringValue(cluster.EngineVersion))
 	if err != nil {
 		slog.ErrorContext(context.Background(), "Failed to parse DocumentDB engine version", "version", aws.StringValue(cluster.EngineVersion))

--- a/lib/cloud/aws/tags_helpers_test.go
+++ b/lib/cloud/aws/tags_helpers_test.go
@@ -22,10 +22,10 @@ import (
 	"testing"
 
 	rdsTypesV2 "github.com/aws/aws-sdk-go-v2/service/rds/types"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elasticache"
-	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,7 +33,7 @@ func TestTagsToLabels(t *testing.T) {
 	t.Parallel()
 
 	t.Run("rds", func(t *testing.T) {
-		inputTags := []*rds.Tag{
+		inputTags := []rdstypes.Tag{
 			{
 				Key:   aws.String("Env"),
 				Value: aws.String("dev"),
@@ -134,26 +134,5 @@ func TestLabelsToTags(t *testing.T) {
 
 		actualTags := LabelsToTags[elasticache.Tag](inputLabels)
 		require.Equal(t, expectTags, actualTags)
-	})
-
-	t.Run("rdsV2", func(t *testing.T) {
-		inputLabels := map[string]string{
-			"labelB": "valueB",
-			"labelA": "valueA",
-		}
-
-		expectTags := []rdsTypesV2.Tag{
-			{
-				Key:   aws.String("labelA"),
-				Value: aws.String("valueA"),
-			},
-			{
-				Key:   aws.String("labelB"),
-				Value: aws.String("valueB"),
-			},
-		}
-
-		actualTags := LabelsToRDSV2Tags(inputLabels)
-		require.EqualValues(t, expectTags, actualTags)
 	})
 }

--- a/lib/cloud/awstesthelpers/tags.go
+++ b/lib/cloud/awstesthelpers/tags.go
@@ -22,6 +22,7 @@ import (
 	"maps"
 	"slices"
 
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	redshifttypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
 )
 
@@ -36,6 +37,25 @@ func LabelsToRedshiftTags(labels map[string]string) []redshifttypes.Tag {
 		value := labels[key]
 
 		ret = append(ret, redshifttypes.Tag{
+			Key:   &key,
+			Value: &value,
+		})
+	}
+
+	return ret
+}
+
+// LabelsToRDSTags converts labels into a [rdstypes.Tag] list.
+func LabelsToRDSTags(labels map[string]string) []rdstypes.Tag {
+	keys := slices.Collect(maps.Keys(labels))
+	slices.Sort(keys)
+
+	ret := make([]rdstypes.Tag, 0, len(keys))
+	for _, key := range keys {
+		key := key
+		value := labels[key]
+
+		ret = append(ret, rdstypes.Tag{
 			Key:   &key,
 			Value: &value,
 		})

--- a/lib/cloud/mocks/aws_config.go
+++ b/lib/cloud/mocks/aws_config.go
@@ -29,11 +29,16 @@ import (
 )
 
 type AWSConfigProvider struct {
+	Err                   error
 	STSClient             *STSClient
 	OIDCIntegrationClient awsconfig.OIDCIntegrationClient
 }
 
 func (f *AWSConfigProvider) GetConfig(ctx context.Context, region string, optFns ...awsconfig.OptionsFn) (aws.Config, error) {
+	if f.Err != nil {
+		return aws.Config{}, f.Err
+	}
+
 	stsClt := f.STSClient
 	if stsClt == nil {
 		stsClt = &STSClient{}

--- a/lib/cloud/mocks/aws_rds.go
+++ b/lib/cloud/mocks/aws_rds.go
@@ -19,159 +19,156 @@
 package mocks
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+	rdsv2 "github.com/aws/aws-sdk-go-v2/service/rds"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/service/rds"
-	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 
-	libcloudaws "github.com/gravitational/teleport/lib/cloud/aws"
+	"github.com/gravitational/teleport/lib/cloud/awstesthelpers"
 )
 
-// RDSMock mocks AWS RDS API.
-type RDSMock struct {
-	rdsiface.RDSAPI
-	DBInstances      []*rds.DBInstance
-	DBClusters       []*rds.DBCluster
-	DBProxies        []*rds.DBProxy
-	DBProxyEndpoints []*rds.DBProxyEndpoint
-	DBEngineVersions []*rds.DBEngineVersion
+type RDSClient struct {
+	Unauth bool
+
+	DBInstances      []rdstypes.DBInstance
+	DBClusters       []rdstypes.DBCluster
+	DBProxies        []rdstypes.DBProxy
+	DBProxyEndpoints []rdstypes.DBProxyEndpoint
+	DBEngineVersions []rdstypes.DBEngineVersion
 }
 
-func (m *RDSMock) DescribeDBInstancesWithContext(ctx aws.Context, input *rds.DescribeDBInstancesInput, options ...request.Option) (*rds.DescribeDBInstancesOutput, error) {
-	if err := checkEngineFilters(input.Filters, m.DBEngineVersions); err != nil {
+func (c *RDSClient) DescribeDBInstances(_ context.Context, input *rdsv2.DescribeDBInstancesInput, _ ...func(*rdsv2.Options)) (*rdsv2.DescribeDBInstancesOutput, error) {
+	if c.Unauth {
+		return nil, trace.AccessDenied("unauthorized")
+	}
+
+	if err := checkEngineFilters(input.Filters, c.DBEngineVersions); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	instances, err := applyInstanceFilters(m.DBInstances, input.Filters)
+	instances, err := applyInstanceFilters(c.DBInstances, input.Filters)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	if aws.StringValue(input.DBInstanceIdentifier) == "" {
-		return &rds.DescribeDBInstancesOutput{
+		return &rdsv2.DescribeDBInstancesOutput{
 			DBInstances: instances,
 		}, nil
 	}
 	for _, instance := range instances {
 		if aws.StringValue(instance.DBInstanceIdentifier) == aws.StringValue(input.DBInstanceIdentifier) {
-			return &rds.DescribeDBInstancesOutput{
-				DBInstances: []*rds.DBInstance{instance},
+			return &rdsv2.DescribeDBInstancesOutput{
+				DBInstances: []rdstypes.DBInstance{instance},
 			}, nil
 		}
 	}
 	return nil, trace.NotFound("instance %v not found", aws.StringValue(input.DBInstanceIdentifier))
 }
 
-func (m *RDSMock) DescribeDBInstancesPagesWithContext(ctx aws.Context, input *rds.DescribeDBInstancesInput, fn func(*rds.DescribeDBInstancesOutput, bool) bool, options ...request.Option) error {
-	if err := checkEngineFilters(input.Filters, m.DBEngineVersions); err != nil {
-		return trace.Wrap(err)
+func (c *RDSClient) DescribeDBClusters(_ context.Context, input *rdsv2.DescribeDBClustersInput, _ ...func(*rdsv2.Options)) (*rdsv2.DescribeDBClustersOutput, error) {
+	if c.Unauth {
+		return nil, trace.AccessDenied("unauthorized")
 	}
-	instances, err := applyInstanceFilters(m.DBInstances, input.Filters)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	fn(&rds.DescribeDBInstancesOutput{
-		DBInstances: instances,
-	}, true)
-	return nil
-}
 
-func (m *RDSMock) DescribeDBClustersWithContext(ctx aws.Context, input *rds.DescribeDBClustersInput, options ...request.Option) (*rds.DescribeDBClustersOutput, error) {
-	if err := checkEngineFilters(input.Filters, m.DBEngineVersions); err != nil {
+	if err := checkEngineFilters(input.Filters, c.DBEngineVersions); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	clusters, err := applyClusterFilters(m.DBClusters, input.Filters)
+	clusters, err := applyClusterFilters(c.DBClusters, input.Filters)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	if aws.StringValue(input.DBClusterIdentifier) == "" {
-		return &rds.DescribeDBClustersOutput{
+		return &rdsv2.DescribeDBClustersOutput{
 			DBClusters: clusters,
 		}, nil
 	}
 	for _, cluster := range clusters {
 		if aws.StringValue(cluster.DBClusterIdentifier) == aws.StringValue(input.DBClusterIdentifier) {
-			return &rds.DescribeDBClustersOutput{
-				DBClusters: []*rds.DBCluster{cluster},
+			return &rdsv2.DescribeDBClustersOutput{
+				DBClusters: []rdstypes.DBCluster{cluster},
 			}, nil
 		}
 	}
 	return nil, trace.NotFound("cluster %v not found", aws.StringValue(input.DBClusterIdentifier))
 }
 
-func (m *RDSMock) DescribeDBClustersPagesWithContext(aws aws.Context, input *rds.DescribeDBClustersInput, fn func(*rds.DescribeDBClustersOutput, bool) bool, options ...request.Option) error {
-	if err := checkEngineFilters(input.Filters, m.DBEngineVersions); err != nil {
-		return trace.Wrap(err)
+func (c *RDSClient) ModifyDBInstance(ctx context.Context, input *rdsv2.ModifyDBInstanceInput, optFns ...func(*rdsv2.Options)) (*rdsv2.ModifyDBInstanceOutput, error) {
+	if c.Unauth {
+		return nil, trace.AccessDenied("unauthorized")
 	}
-	clusters, err := applyClusterFilters(m.DBClusters, input.Filters)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	fn(&rds.DescribeDBClustersOutput{
-		DBClusters: clusters,
-	}, true)
-	return nil
-}
 
-func (m *RDSMock) ModifyDBInstanceWithContext(ctx aws.Context, input *rds.ModifyDBInstanceInput, options ...request.Option) (*rds.ModifyDBInstanceOutput, error) {
-	for i, instance := range m.DBInstances {
+	for i, instance := range c.DBInstances {
 		if aws.StringValue(instance.DBInstanceIdentifier) == aws.StringValue(input.DBInstanceIdentifier) {
 			if aws.BoolValue(input.EnableIAMDatabaseAuthentication) {
-				m.DBInstances[i].IAMDatabaseAuthenticationEnabled = aws.Bool(true)
+				c.DBInstances[i].IAMDatabaseAuthenticationEnabled = aws.Bool(true)
 			}
-			return &rds.ModifyDBInstanceOutput{
-				DBInstance: m.DBInstances[i],
+			return &rdsv2.ModifyDBInstanceOutput{
+				DBInstance: &c.DBInstances[i],
 			}, nil
 		}
 	}
 	return nil, trace.NotFound("instance %v not found", aws.StringValue(input.DBInstanceIdentifier))
 }
 
-func (m *RDSMock) ModifyDBClusterWithContext(ctx aws.Context, input *rds.ModifyDBClusterInput, options ...request.Option) (*rds.ModifyDBClusterOutput, error) {
-	for i, cluster := range m.DBClusters {
+func (c *RDSClient) ModifyDBCluster(ctx context.Context, input *rdsv2.ModifyDBClusterInput, optFns ...func(*rdsv2.Options)) (*rdsv2.ModifyDBClusterOutput, error) {
+	if c.Unauth {
+		return nil, trace.AccessDenied("unauthorized")
+	}
+
+	for i, cluster := range c.DBClusters {
 		if aws.StringValue(cluster.DBClusterIdentifier) == aws.StringValue(input.DBClusterIdentifier) {
 			if aws.BoolValue(input.EnableIAMDatabaseAuthentication) {
-				m.DBClusters[i].IAMDatabaseAuthenticationEnabled = aws.Bool(true)
+				c.DBClusters[i].IAMDatabaseAuthenticationEnabled = aws.Bool(true)
 			}
-			return &rds.ModifyDBClusterOutput{
-				DBCluster: m.DBClusters[i],
+			return &rdsv2.ModifyDBClusterOutput{
+				DBCluster: &c.DBClusters[i],
 			}, nil
 		}
 	}
 	return nil, trace.NotFound("cluster %v not found", aws.StringValue(input.DBClusterIdentifier))
 }
 
-func (m *RDSMock) DescribeDBProxiesWithContext(ctx aws.Context, input *rds.DescribeDBProxiesInput, options ...request.Option) (*rds.DescribeDBProxiesOutput, error) {
+func (c *RDSClient) DescribeDBProxies(_ context.Context, input *rdsv2.DescribeDBProxiesInput, _ ...func(*rdsv2.Options)) (*rdsv2.DescribeDBProxiesOutput, error) {
+	if c.Unauth {
+		return nil, trace.AccessDenied("unauthorized")
+	}
+
 	if aws.StringValue(input.DBProxyName) == "" {
-		return &rds.DescribeDBProxiesOutput{
-			DBProxies: m.DBProxies,
+		return &rdsv2.DescribeDBProxiesOutput{
+			DBProxies: c.DBProxies,
 		}, nil
 	}
-	for _, dbProxy := range m.DBProxies {
+	for _, dbProxy := range c.DBProxies {
 		if aws.StringValue(dbProxy.DBProxyName) == aws.StringValue(input.DBProxyName) {
-			return &rds.DescribeDBProxiesOutput{
-				DBProxies: []*rds.DBProxy{dbProxy},
+			return &rdsv2.DescribeDBProxiesOutput{
+				DBProxies: []rdstypes.DBProxy{dbProxy},
 			}, nil
 		}
 	}
 	return nil, trace.NotFound("proxy %v not found", aws.StringValue(input.DBProxyName))
 }
 
-func (m *RDSMock) DescribeDBProxyEndpointsWithContext(ctx aws.Context, input *rds.DescribeDBProxyEndpointsInput, options ...request.Option) (*rds.DescribeDBProxyEndpointsOutput, error) {
+func (c *RDSClient) DescribeDBProxyEndpoints(_ context.Context, input *rdsv2.DescribeDBProxyEndpointsInput, _ ...func(*rdsv2.Options)) (*rdsv2.DescribeDBProxyEndpointsOutput, error) {
+	if c.Unauth {
+		return nil, trace.AccessDenied("unauthorized")
+	}
+
 	inputProxyName := aws.StringValue(input.DBProxyName)
 	inputProxyEndpointName := aws.StringValue(input.DBProxyEndpointName)
 
 	if inputProxyName == "" && inputProxyEndpointName == "" {
-		return &rds.DescribeDBProxyEndpointsOutput{
-			DBProxyEndpoints: m.DBProxyEndpoints,
+		return &rdsv2.DescribeDBProxyEndpointsOutput{
+			DBProxyEndpoints: c.DBProxyEndpoints,
 		}, nil
 	}
 
-	var endpoints []*rds.DBProxyEndpoint
-	for _, dbProxyEndpoiont := range m.DBProxyEndpoints {
+	var endpoints []rdstypes.DBProxyEndpoint
+	for _, dbProxyEndpoiont := range c.DBProxyEndpoints {
 		if inputProxyEndpointName != "" &&
 			inputProxyEndpointName != aws.StringValue(dbProxyEndpoiont.DBProxyEndpointName) {
 			continue
@@ -187,114 +184,15 @@ func (m *RDSMock) DescribeDBProxyEndpointsWithContext(ctx aws.Context, input *rd
 	if len(endpoints) == 0 {
 		return nil, trace.NotFound("proxy endpoint %v not found", aws.StringValue(input.DBProxyEndpointName))
 	}
-	return &rds.DescribeDBProxyEndpointsOutput{DBProxyEndpoints: endpoints}, nil
+	return &rdsv2.DescribeDBProxyEndpointsOutput{DBProxyEndpoints: endpoints}, nil
 }
 
-func (m *RDSMock) DescribeDBProxiesPagesWithContext(ctx aws.Context, input *rds.DescribeDBProxiesInput, fn func(*rds.DescribeDBProxiesOutput, bool) bool, options ...request.Option) error {
-	fn(&rds.DescribeDBProxiesOutput{
-		DBProxies: m.DBProxies,
-	}, true)
-	return nil
-}
-
-func (m *RDSMock) DescribeDBProxyEndpointsPagesWithContext(ctx aws.Context, input *rds.DescribeDBProxyEndpointsInput, fn func(*rds.DescribeDBProxyEndpointsOutput, bool) bool, options ...request.Option) error {
-	fn(&rds.DescribeDBProxyEndpointsOutput{
-		DBProxyEndpoints: m.DBProxyEndpoints,
-	}, true)
-	return nil
-}
-
-func (m *RDSMock) ListTagsForResourceWithContext(ctx aws.Context, input *rds.ListTagsForResourceInput, options ...request.Option) (*rds.ListTagsForResourceOutput, error) {
+func (c *RDSClient) ListTagsForResource(context.Context, *rds.ListTagsForResourceInput, ...func(*rds.Options)) (*rds.ListTagsForResourceOutput, error) {
 	return &rds.ListTagsForResourceOutput{}, nil
 }
 
-// RDSMockUnauth is a mock RDS client that returns access denied to each call.
-type RDSMockUnauth struct {
-	rdsiface.RDSAPI
-}
-
-func (m *RDSMockUnauth) DescribeDBInstancesWithContext(ctx aws.Context, input *rds.DescribeDBInstancesInput, options ...request.Option) (*rds.DescribeDBInstancesOutput, error) {
-	return nil, trace.AccessDenied("unauthorized")
-}
-
-func (m *RDSMockUnauth) DescribeDBClustersWithContext(ctx aws.Context, input *rds.DescribeDBClustersInput, options ...request.Option) (*rds.DescribeDBClustersOutput, error) {
-	return nil, trace.AccessDenied("unauthorized")
-}
-
-func (m *RDSMockUnauth) ModifyDBInstanceWithContext(ctx aws.Context, input *rds.ModifyDBInstanceInput, options ...request.Option) (*rds.ModifyDBInstanceOutput, error) {
-	return nil, trace.AccessDenied("unauthorized")
-}
-
-func (m *RDSMockUnauth) ModifyDBClusterWithContext(ctx aws.Context, input *rds.ModifyDBClusterInput, options ...request.Option) (*rds.ModifyDBClusterOutput, error) {
-	return nil, trace.AccessDenied("unauthorized")
-}
-
-func (m *RDSMockUnauth) DescribeDBInstancesPagesWithContext(ctx aws.Context, input *rds.DescribeDBInstancesInput, fn func(*rds.DescribeDBInstancesOutput, bool) bool, options ...request.Option) error {
-	return trace.AccessDenied("unauthorized")
-}
-
-func (m *RDSMockUnauth) DescribeDBClustersPagesWithContext(aws aws.Context, input *rds.DescribeDBClustersInput, fn func(*rds.DescribeDBClustersOutput, bool) bool, options ...request.Option) error {
-	return trace.AccessDenied("unauthorized")
-}
-
-func (m *RDSMockUnauth) DescribeDBProxiesWithContext(ctx aws.Context, input *rds.DescribeDBProxiesInput, options ...request.Option) (*rds.DescribeDBProxiesOutput, error) {
-	return nil, trace.AccessDenied("unauthorized")
-}
-
-func (m *RDSMockUnauth) DescribeDBProxyEndpointsWithContext(ctx aws.Context, input *rds.DescribeDBProxyEndpointsInput, options ...request.Option) (*rds.DescribeDBProxyEndpointsOutput, error) {
-	return nil, trace.AccessDenied("unauthorized")
-}
-
-func (m *RDSMockUnauth) DescribeDBProxiesPagesWithContext(ctx aws.Context, input *rds.DescribeDBProxiesInput, fn func(*rds.DescribeDBProxiesOutput, bool) bool, options ...request.Option) error {
-	return trace.AccessDenied("unauthorized")
-}
-
-// RDSMockByDBType is a mock RDS client that mocks API calls by DB type
-type RDSMockByDBType struct {
-	rdsiface.RDSAPI
-	DBInstances rdsiface.RDSAPI
-	DBClusters  rdsiface.RDSAPI
-	DBProxies   rdsiface.RDSAPI
-}
-
-func (m *RDSMockByDBType) DescribeDBInstancesWithContext(ctx aws.Context, input *rds.DescribeDBInstancesInput, options ...request.Option) (*rds.DescribeDBInstancesOutput, error) {
-	return m.DBInstances.DescribeDBInstancesWithContext(ctx, input, options...)
-}
-
-func (m *RDSMockByDBType) ModifyDBInstanceWithContext(ctx aws.Context, input *rds.ModifyDBInstanceInput, options ...request.Option) (*rds.ModifyDBInstanceOutput, error) {
-	return m.DBInstances.ModifyDBInstanceWithContext(ctx, input, options...)
-}
-
-func (m *RDSMockByDBType) DescribeDBInstancesPagesWithContext(ctx aws.Context, input *rds.DescribeDBInstancesInput, fn func(*rds.DescribeDBInstancesOutput, bool) bool, options ...request.Option) error {
-	return m.DBInstances.DescribeDBInstancesPagesWithContext(ctx, input, fn, options...)
-}
-
-func (m *RDSMockByDBType) DescribeDBClustersWithContext(ctx aws.Context, input *rds.DescribeDBClustersInput, options ...request.Option) (*rds.DescribeDBClustersOutput, error) {
-	return m.DBClusters.DescribeDBClustersWithContext(ctx, input, options...)
-}
-
-func (m *RDSMockByDBType) ModifyDBClusterWithContext(ctx aws.Context, input *rds.ModifyDBClusterInput, options ...request.Option) (*rds.ModifyDBClusterOutput, error) {
-	return m.DBClusters.ModifyDBClusterWithContext(ctx, input, options...)
-}
-
-func (m *RDSMockByDBType) DescribeDBClustersPagesWithContext(aws aws.Context, input *rds.DescribeDBClustersInput, fn func(*rds.DescribeDBClustersOutput, bool) bool, options ...request.Option) error {
-	return m.DBClusters.DescribeDBClustersPagesWithContext(aws, input, fn, options...)
-}
-
-func (m *RDSMockByDBType) DescribeDBProxiesWithContext(ctx aws.Context, input *rds.DescribeDBProxiesInput, options ...request.Option) (*rds.DescribeDBProxiesOutput, error) {
-	return m.DBProxies.DescribeDBProxiesWithContext(ctx, input, options...)
-}
-
-func (m *RDSMockByDBType) DescribeDBProxyEndpointsWithContext(ctx aws.Context, input *rds.DescribeDBProxyEndpointsInput, options ...request.Option) (*rds.DescribeDBProxyEndpointsOutput, error) {
-	return m.DBProxies.DescribeDBProxyEndpointsWithContext(ctx, input, options...)
-}
-
-func (m *RDSMockByDBType) DescribeDBProxiesPagesWithContext(ctx aws.Context, input *rds.DescribeDBProxiesInput, fn func(*rds.DescribeDBProxiesOutput, bool) bool, options ...request.Option) error {
-	return m.DBProxies.DescribeDBProxiesPagesWithContext(ctx, input, fn, options...)
-}
-
 // checkEngineFilters checks RDS filters to detect unrecognized engine filters.
-func checkEngineFilters(filters []*rds.Filter, engineVersions []*rds.DBEngineVersion) error {
+func checkEngineFilters(filters []rdstypes.Filter, engineVersions []rdstypes.DBEngineVersion) error {
 	if len(filters) == 0 {
 		return nil
 	}
@@ -307,8 +205,8 @@ func checkEngineFilters(filters []*rds.Filter, engineVersions []*rds.DBEngineVer
 			continue
 		}
 		for _, v := range f.Values {
-			if _, ok := recognizedEngines[aws.StringValue(v)]; !ok {
-				return trace.Errorf("unrecognized engine name %q", aws.StringValue(v))
+			if _, ok := recognizedEngines[v]; !ok {
+				return trace.Errorf("unrecognized engine name %q", v)
 			}
 		}
 	}
@@ -316,11 +214,11 @@ func checkEngineFilters(filters []*rds.Filter, engineVersions []*rds.DBEngineVer
 }
 
 // applyInstanceFilters filters RDS DBInstances using the provided RDS filters.
-func applyInstanceFilters(in []*rds.DBInstance, filters []*rds.Filter) ([]*rds.DBInstance, error) {
+func applyInstanceFilters(in []rdstypes.DBInstance, filters []rdstypes.Filter) ([]rdstypes.DBInstance, error) {
 	if len(filters) == 0 {
 		return in, nil
 	}
-	var out []*rds.DBInstance
+	var out []rdstypes.DBInstance
 	efs := engineFilterSet(filters)
 	clusterIDs := clusterIdentifierFilterSet(filters)
 	for _, instance := range in {
@@ -336,11 +234,11 @@ func applyInstanceFilters(in []*rds.DBInstance, filters []*rds.Filter) ([]*rds.D
 }
 
 // applyClusterFilters filters RDS DBClusters using the provided RDS filters.
-func applyClusterFilters(in []*rds.DBCluster, filters []*rds.Filter) ([]*rds.DBCluster, error) {
+func applyClusterFilters(in []rdstypes.DBCluster, filters []rdstypes.Filter) ([]rdstypes.DBCluster, error) {
 	if len(filters) == 0 {
 		return in, nil
 	}
-	var out []*rds.DBCluster
+	var out []rdstypes.DBCluster
 	efs := engineFilterSet(filters)
 	for _, cluster := range in {
 		if clusterEngineMatches(cluster, efs) {
@@ -351,59 +249,59 @@ func applyClusterFilters(in []*rds.DBCluster, filters []*rds.Filter) ([]*rds.DBC
 }
 
 // engineFilterSet builds a string set of engine names from a list of RDS filters.
-func engineFilterSet(filters []*rds.Filter) map[string]struct{} {
+func engineFilterSet(filters []rdstypes.Filter) map[string]struct{} {
 	return filterValues(filters, "engine")
 }
 
 // clusterIdentifierFilterSet builds a string set of ClusterIDs from a list of RDS filters.
-func clusterIdentifierFilterSet(filters []*rds.Filter) map[string]struct{} {
+func clusterIdentifierFilterSet(filters []rdstypes.Filter) map[string]struct{} {
 	return filterValues(filters, "db-cluster-id")
 }
 
-func filterValues(filters []*rds.Filter, filterKey string) map[string]struct{} {
+func filterValues(filters []rdstypes.Filter, filterKey string) map[string]struct{} {
 	out := make(map[string]struct{})
 	for _, f := range filters {
 		if aws.StringValue(f.Name) != filterKey {
 			continue
 		}
 		for _, v := range f.Values {
-			out[aws.StringValue(v)] = struct{}{}
+			out[v] = struct{}{}
 		}
 	}
 	return out
 }
 
 // instanceEngineMatches returns whether an RDS DBInstance engine matches any engine name in a filter set.
-func instanceEngineMatches(instance *rds.DBInstance, filterSet map[string]struct{}) bool {
+func instanceEngineMatches(instance rdstypes.DBInstance, filterSet map[string]struct{}) bool {
 	_, ok := filterSet[aws.StringValue(instance.Engine)]
 	return ok
 }
 
 // instanceClusterIDMatches returns whether an RDS DBInstance ClusterID matches any ClusterID in a filter set.
-func instanceClusterIDMatches(instance *rds.DBInstance, filterSet map[string]struct{}) bool {
+func instanceClusterIDMatches(instance rdstypes.DBInstance, filterSet map[string]struct{}) bool {
 	_, ok := filterSet[aws.StringValue(instance.DBClusterIdentifier)]
 	return ok
 }
 
 // clusterEngineMatches returns whether an RDS DBCluster engine matches any engine name in a filter set.
-func clusterEngineMatches(cluster *rds.DBCluster, filterSet map[string]struct{}) bool {
+func clusterEngineMatches(cluster rdstypes.DBCluster, filterSet map[string]struct{}) bool {
 	_, ok := filterSet[aws.StringValue(cluster.Engine)]
 	return ok
 }
 
-// RDSInstance returns a sample rds.DBInstance.
-func RDSInstance(name, region string, labels map[string]string, opts ...func(*rds.DBInstance)) *rds.DBInstance {
-	instance := &rds.DBInstance{
+// RDSInstance returns a sample rdstypes.DBInstance.
+func RDSInstance(name, region string, labels map[string]string, opts ...func(*rdstypes.DBInstance)) *rdstypes.DBInstance {
+	instance := &rdstypes.DBInstance{
 		DBInstanceArn:        aws.String(fmt.Sprintf("arn:aws:rds:%v:123456789012:db:%v", region, name)),
 		DBInstanceIdentifier: aws.String(name),
 		DbiResourceId:        aws.String(uuid.New().String()),
 		Engine:               aws.String("postgres"),
 		DBInstanceStatus:     aws.String("available"),
-		Endpoint: &rds.Endpoint{
+		Endpoint: &rdstypes.Endpoint{
 			Address: aws.String(fmt.Sprintf("%v.aabbccdd.%v.rds.amazonaws.com", name, region)),
-			Port:    aws.Int64(5432),
+			Port:    aws.Int32(5432),
 		},
-		TagList: libcloudaws.LabelsToTags[rds.Tag](labels),
+		TagList: awstesthelpers.LabelsToRDSTags(labels),
 	}
 	for _, opt := range opts {
 		opt(instance)
@@ -411,9 +309,9 @@ func RDSInstance(name, region string, labels map[string]string, opts ...func(*rd
 	return instance
 }
 
-// RDSCluster returns a sample rds.DBCluster.
-func RDSCluster(name, region string, labels map[string]string, opts ...func(*rds.DBCluster)) *rds.DBCluster {
-	cluster := &rds.DBCluster{
+// RDSCluster returns a sample rdstypes.DBCluster.
+func RDSCluster(name, region string, labels map[string]string, opts ...func(*rdstypes.DBCluster)) *rdstypes.DBCluster {
+	cluster := &rdstypes.DBCluster{
 		DBClusterArn:        aws.String(fmt.Sprintf("arn:aws:rds:%v:123456789012:cluster:%v", region, name)),
 		DBClusterIdentifier: aws.String(name),
 		DbClusterResourceId: aws.String(uuid.New().String()),
@@ -422,9 +320,9 @@ func RDSCluster(name, region string, labels map[string]string, opts ...func(*rds
 		Status:              aws.String("available"),
 		Endpoint:            aws.String(fmt.Sprintf("%v.cluster-aabbccdd.%v.rds.amazonaws.com", name, region)),
 		ReaderEndpoint:      aws.String(fmt.Sprintf("%v.cluster-ro-aabbccdd.%v.rds.amazonaws.com", name, region)),
-		Port:                aws.Int64(3306),
-		TagList:             libcloudaws.LabelsToTags[rds.Tag](labels),
-		DBClusterMembers: []*rds.DBClusterMember{{
+		Port:                aws.Int32(3306),
+		TagList:             awstesthelpers.LabelsToRDSTags(labels),
+		DBClusterMembers: []rdstypes.DBClusterMember{{
 			IsClusterWriter: aws.Bool(true), // One writer by default.
 		}},
 	}
@@ -434,49 +332,49 @@ func RDSCluster(name, region string, labels map[string]string, opts ...func(*rds
 	return cluster
 }
 
-func WithRDSClusterReader(cluster *rds.DBCluster) {
-	cluster.DBClusterMembers = append(cluster.DBClusterMembers, &rds.DBClusterMember{
+func WithRDSClusterReader(cluster *rdstypes.DBCluster) {
+	cluster.DBClusterMembers = append(cluster.DBClusterMembers, rdstypes.DBClusterMember{
 		IsClusterWriter: aws.Bool(false), // Add reader.
 	})
 }
 
-func WithRDSClusterCustomEndpoint(name string) func(*rds.DBCluster) {
-	return func(cluster *rds.DBCluster) {
+func WithRDSClusterCustomEndpoint(name string) func(*rdstypes.DBCluster) {
+	return func(cluster *rdstypes.DBCluster) {
 		parsed, _ := arn.Parse(aws.StringValue(cluster.DBClusterArn))
-		cluster.CustomEndpoints = append(cluster.CustomEndpoints, aws.String(
+		cluster.CustomEndpoints = append(cluster.CustomEndpoints,
 			fmt.Sprintf("%v.cluster-custom-aabbccdd.%v.rds.amazonaws.com", name, parsed.Region),
-		))
+		)
 	}
 }
 
-// RDSProxy returns a sample rds.DBProxy.
-func RDSProxy(name, region, vpcID string) *rds.DBProxy {
-	return &rds.DBProxy{
+// RDSProxy returns a sample rdstypes.DBProxy.
+func RDSProxy(name, region, vpcID string) *rdstypes.DBProxy {
+	return &rdstypes.DBProxy{
 		DBProxyArn:   aws.String(fmt.Sprintf("arn:aws:rds:%s:123456789012:db-proxy:prx-%s", region, name)),
 		DBProxyName:  aws.String(name),
-		EngineFamily: aws.String(rds.EngineFamilyMysql),
+		EngineFamily: aws.String(string(rdstypes.EngineFamilyMysql)),
 		Endpoint:     aws.String(fmt.Sprintf("%s.proxy-aabbccdd.%s.rds.amazonaws.com", name, region)),
 		VpcId:        aws.String(vpcID),
 		RequireTLS:   aws.Bool(true),
-		Status:       aws.String("available"),
+		Status:       "available",
 	}
 }
 
-// RDSProxyCustomEndpoint returns a sample rds.DBProxyEndpoint.
-func RDSProxyCustomEndpoint(rdsProxy *rds.DBProxy, name, region string) *rds.DBProxyEndpoint {
-	return &rds.DBProxyEndpoint{
+// RDSProxyCustomEndpoint returns a sample rdstypes.DBProxyEndpoint.
+func RDSProxyCustomEndpoint(rdsProxy *rdstypes.DBProxy, name, region string) *rdstypes.DBProxyEndpoint {
+	return &rdstypes.DBProxyEndpoint{
 		Endpoint:            aws.String(fmt.Sprintf("%s.endpoint.proxy-aabbccdd.%s.rds.amazonaws.com", name, region)),
 		DBProxyEndpointName: aws.String(name),
 		DBProxyName:         rdsProxy.DBProxyName,
 		DBProxyEndpointArn:  aws.String(fmt.Sprintf("arn:aws:rds:%v:123456789012:db-proxy-endpoint:prx-endpoint-%v", region, name)),
-		TargetRole:          aws.String(rds.DBProxyEndpointTargetRoleReadOnly),
-		Status:              aws.String("available"),
+		TargetRole:          rdstypes.DBProxyEndpointTargetRoleReadOnly,
+		Status:              "available",
 	}
 }
 
-// DocumentDBCluster returns a sample rds.DBCluster for DocumentDB.
-func DocumentDBCluster(name, region string, labels map[string]string, opts ...func(*rds.DBCluster)) *rds.DBCluster {
-	cluster := &rds.DBCluster{
+// DocumentDBCluster returns a sample rdstypes.DBCluster for DocumentDB.
+func DocumentDBCluster(name, region string, labels map[string]string, opts ...func(*rdstypes.DBCluster)) *rdstypes.DBCluster {
+	cluster := &rdstypes.DBCluster{
 		DBClusterArn:        aws.String(fmt.Sprintf("arn:aws:rds:%v:123456789012:cluster:%v", region, name)),
 		DBClusterIdentifier: aws.String(name),
 		DbClusterResourceId: aws.String(uuid.New().String()),
@@ -485,9 +383,9 @@ func DocumentDBCluster(name, region string, labels map[string]string, opts ...fu
 		Status:              aws.String("available"),
 		Endpoint:            aws.String(fmt.Sprintf("%v.cluster-aabbccdd.%v.docdb.amazonaws.com", name, region)),
 		ReaderEndpoint:      aws.String(fmt.Sprintf("%v.cluster-ro-aabbccdd.%v.docdb.amazonaws.com", name, region)),
-		Port:                aws.Int64(27017),
-		TagList:             libcloudaws.LabelsToTags[rds.Tag](labels),
-		DBClusterMembers: []*rds.DBClusterMember{{
+		Port:                aws.Int32(27017),
+		TagList:             awstesthelpers.LabelsToRDSTags(labels),
+		DBClusterMembers: []rdstypes.DBClusterMember{{
 			IsClusterWriter: aws.Bool(true), // One writer by default.
 		}},
 	}
@@ -497,6 +395,6 @@ func DocumentDBCluster(name, region string, labels map[string]string, opts ...fu
 	return cluster
 }
 
-func WithDocumentDBClusterReader(cluster *rds.DBCluster) {
+func WithDocumentDBClusterReader(cluster *rdstypes.DBCluster) {
 	WithRDSClusterReader(cluster)
 }

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -2491,7 +2491,6 @@ func (p *agentParams) setDefaults(c *testContext) {
 	if p.CloudClients == nil {
 		p.CloudClients = &clients.TestCloudClients{
 			STS:                &mocks.STSClientV1{},
-			RDS:                &mocks.RDSMock{},
 			RedshiftServerless: &mocks.RedshiftServerlessMock{},
 			ElastiCache:        p.ElastiCache,
 			MemoryDB:           p.MemoryDB,
@@ -2501,7 +2500,7 @@ func (p *agentParams) setDefaults(c *testContext) {
 		}
 	}
 	if p.AWSConfigProvider == nil {
-		p.AWSConfigProvider = &mocks.AWSConfigProvider{}
+		p.AWSConfigProvider = &mocks.AWSConfigProvider{Err: trace.AccessDenied("AWS SDK clients are disabled for tests by default")}
 	}
 
 	if p.DiscoveryResourceChecker == nil {

--- a/lib/srv/db/cloud/aws.go
+++ b/lib/srv/db/cloud/aws.go
@@ -23,21 +23,24 @@ import (
 	"encoding/json"
 	"log/slog"
 
+	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
-	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 	dbiam "github.com/gravitational/teleport/lib/srv/db/common/iam"
 )
 
 // awsConfig is the config for the client that configures IAM for AWS databases.
 type awsConfig struct {
+	// awsConfigProvider provides [aws.Config] for AWS SDK service clients.
+	awsConfigProvider awsconfig.Provider
 	// clients is an interface for creating AWS clients.
 	clients cloud.Clients
 	// identity is AWS identity this database agent is running as.
@@ -46,6 +49,9 @@ type awsConfig struct {
 	database types.Database
 	// policyName is the name of the inline policy for the identity.
 	policyName string
+	// awsClients is an internal-only AWS SDK client provider that is
+	// only set in tests.
+	awsClients awsClientProvider
 }
 
 // Check validates the config.
@@ -62,6 +68,12 @@ func (c *awsConfig) Check() error {
 	if c.policyName == "" {
 		return trace.BadParameter("missing parameter policy name")
 	}
+	if c.awsConfigProvider == nil {
+		return trace.BadParameter("missing parameter awsConfigProvider")
+	}
+	if c.awsClients == nil {
+		return trace.BadParameter("missing parameter awsClients")
+	}
 	return nil
 }
 
@@ -75,7 +87,7 @@ func newAWS(ctx context.Context, config awsConfig) (*awsClient, error) {
 		teleport.ComponentKey, "aws",
 		"db", config.database.GetName(),
 	)
-	dbConfigurator, err := getDBConfigurator(logger, config.clients, config.database)
+	dbConfigurator, err := getDBConfigurator(logger, config)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -102,10 +114,14 @@ type dbIAMAuthConfigurator interface {
 }
 
 // getDBConfigurator returns a database IAM Auth configurator.
-func getDBConfigurator(logger *slog.Logger, clients cloud.Clients, db types.Database) (dbIAMAuthConfigurator, error) {
-	if db.IsRDS() {
+func getDBConfigurator(logger *slog.Logger, cfg awsConfig) (dbIAMAuthConfigurator, error) {
+	if cfg.database.IsRDS() {
 		// Only setting for RDS instances and Aurora clusters.
-		return &rdsDBConfigurator{clients: clients, logger: logger}, nil
+		return &rdsDBConfigurator{
+			awsConfigProvider: cfg.awsConfigProvider,
+			logger:            logger,
+			awsClients:        cfg.awsClients,
+		}, nil
 	}
 	// IAM Auth for Redshift, ElastiCache, and RDS Proxy is always enabled.
 	return &nopDBConfigurator{}, nil
@@ -303,8 +319,9 @@ func (r *awsClient) detachIAMPolicy(ctx context.Context) error {
 }
 
 type rdsDBConfigurator struct {
-	clients cloud.Clients
-	logger  *slog.Logger
+	awsConfigProvider awsconfig.Provider
+	logger            *slog.Logger
+	awsClients        awsClientProvider
 }
 
 // ensureIAMAuth enables RDS instance IAM auth if it isn't already enabled.
@@ -323,30 +340,34 @@ func (r *rdsDBConfigurator) ensureIAMAuth(ctx context.Context, db types.Database
 func (r *rdsDBConfigurator) enableIAMAuth(ctx context.Context, db types.Database) error {
 	r.logger.DebugContext(ctx, "Enabling IAM auth for RDS")
 	meta := db.GetAWS()
-	rdsClt, err := r.clients.GetAWSRDSClient(ctx, meta.Region,
-		cloud.WithAssumeRoleFromAWSMeta(meta),
-		cloud.WithAmbientCredentials(),
+	if meta.RDS.ClusterID == "" && meta.RDS.InstanceID == "" {
+		return trace.BadParameter("no RDS cluster ID or instance ID for %v", db)
+	}
+	awsCfg, err := r.awsConfigProvider.GetConfig(ctx, meta.Region,
+		awsconfig.WithAssumeRole(meta.AssumeRoleARN, meta.ExternalID),
+		awsconfig.WithAmbientCredentials(),
 	)
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	clt := r.awsClients.getRDSClient(awsCfg)
 	if meta.RDS.ClusterID != "" {
-		_, err = rdsClt.ModifyDBClusterWithContext(ctx, &rds.ModifyDBClusterInput{
+		_, err = clt.ModifyDBCluster(ctx, &rds.ModifyDBClusterInput{
 			DBClusterIdentifier:             aws.String(meta.RDS.ClusterID),
 			EnableIAMDatabaseAuthentication: aws.Bool(true),
 			ApplyImmediately:                aws.Bool(true),
 		})
-		return awslib.ConvertIAMError(err)
+		return awslib.ConvertRequestFailureErrorV2(err)
 	}
 	if meta.RDS.InstanceID != "" {
-		_, err = rdsClt.ModifyDBInstanceWithContext(ctx, &rds.ModifyDBInstanceInput{
+		_, err = clt.ModifyDBInstance(ctx, &rds.ModifyDBInstanceInput{
 			DBInstanceIdentifier:            aws.String(meta.RDS.InstanceID),
 			EnableIAMDatabaseAuthentication: aws.Bool(true),
 			ApplyImmediately:                aws.Bool(true),
 		})
-		return awslib.ConvertIAMError(err)
+		return awslib.ConvertRequestFailureErrorV2(err)
 	}
-	return trace.BadParameter("no RDS cluster ID or instance ID for %v", db)
+	return nil
 }
 
 type nopDBConfigurator struct{}

--- a/lib/srv/db/cloud/meta.go
+++ b/lib/srv/db/cloud/meta.go
@@ -24,14 +24,14 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/aws/aws-sdk-go-v2/service/redshift"
 	redshifttypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/aws/aws-sdk-go/service/elasticache/elasticacheiface"
 	"github.com/aws/aws-sdk-go/service/memorydb"
 	"github.com/aws/aws-sdk-go/service/memorydb/memorydbiface"
-	"github.com/aws/aws-sdk-go/service/rds"
-	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
 	"github.com/aws/aws-sdk-go/service/redshiftserverless"
 	"github.com/aws/aws-sdk-go/service/redshiftserverless/redshiftserverlessiface"
 	"github.com/gravitational/trace"
@@ -45,13 +45,36 @@ import (
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
+// rdsClient defines a subset of the AWS RDS client API.
+type rdsClient interface {
+	rds.DescribeDBClustersAPIClient
+	rds.DescribeDBInstancesAPIClient
+	rds.DescribeDBProxiesAPIClient
+	rds.DescribeDBProxyEndpointsAPIClient
+	ModifyDBCluster(ctx context.Context, params *rds.ModifyDBClusterInput, optFns ...func(*rds.Options)) (*rds.ModifyDBClusterOutput, error)
+	ModifyDBInstance(ctx context.Context, params *rds.ModifyDBInstanceInput, optFns ...func(*rds.Options)) (*rds.ModifyDBInstanceOutput, error)
+}
+
 // redshiftClient defines a subset of the AWS Redshift client API.
 type redshiftClient interface {
 	redshift.DescribeClustersAPIClient
 }
 
-// redshiftClientProviderFunc provides a [redshiftClient].
-type redshiftClientProviderFunc func(cfg aws.Config, optFns ...func(*redshift.Options)) redshiftClient
+// awsClientProvider is an AWS SDK client provider.
+type awsClientProvider interface {
+	getRDSClient(cfg aws.Config, optFns ...func(*rds.Options)) rdsClient
+	getRedshiftClient(cfg aws.Config, optFns ...func(*redshift.Options)) redshiftClient
+}
+
+type defaultAWSClients struct{}
+
+func (defaultAWSClients) getRDSClient(cfg aws.Config, optFns ...func(*rds.Options)) rdsClient {
+	return rds.NewFromConfig(cfg, optFns...)
+}
+
+func (defaultAWSClients) getRedshiftClient(cfg aws.Config, optFns ...func(*redshift.Options)) redshiftClient {
+	return redshift.NewFromConfig(cfg, optFns...)
+}
 
 // MetadataConfig is the cloud metadata service config.
 type MetadataConfig struct {
@@ -60,9 +83,8 @@ type MetadataConfig struct {
 	// AWSConfigProvider provides [aws.Config] for AWS SDK service clients.
 	AWSConfigProvider awsconfig.Provider
 
-	// redshiftClientProviderFn is an internal-only [redshiftClient] provider
-	// func that is only set in tests.
-	redshiftClientProviderFn redshiftClientProviderFunc
+	// awsClients is an SDK client provider.
+	awsClients awsClientProvider
 }
 
 // Check validates the metadata service config.
@@ -78,10 +100,8 @@ func (c *MetadataConfig) Check() error {
 		return trace.BadParameter("missing AWSConfigProvider")
 	}
 
-	if c.redshiftClientProviderFn == nil {
-		c.redshiftClientProviderFn = func(cfg aws.Config, optFns ...func(*redshift.Options)) redshiftClient {
-			return redshift.NewFromConfig(cfg, optFns...)
-		}
+	if c.awsClients == nil {
+		c.awsClients = defaultAWSClients{}
 	}
 	return nil
 }
@@ -147,20 +167,21 @@ func (m *Metadata) updateAWS(ctx context.Context, database types.Database, fetch
 // fetchRDSMetadata fetches metadata for the provided RDS or Aurora database.
 func (m *Metadata) fetchRDSMetadata(ctx context.Context, database types.Database) (*types.AWS, error) {
 	meta := database.GetAWS()
-	rds, err := m.cfg.Clients.GetAWSRDSClient(ctx, meta.Region,
-		cloud.WithAssumeRoleFromAWSMeta(meta),
-		cloud.WithAmbientCredentials(),
+	awsCfg, err := m.cfg.AWSConfigProvider.GetConfig(ctx, meta.Region,
+		awsconfig.WithAssumeRole(meta.AssumeRoleARN, meta.ExternalID),
+		awsconfig.WithAmbientCredentials(),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	clt := m.cfg.awsClients.getRDSClient(awsCfg)
 
 	if meta.RDS.ClusterID != "" {
-		return fetchRDSClusterMetadata(ctx, rds, meta.RDS.ClusterID)
+		return fetchRDSClusterMetadata(ctx, clt, meta.RDS.ClusterID)
 	}
 
 	// Try to fetch the RDS instance fetchedMeta.
-	fetchedMeta, err := fetchRDSInstanceMetadata(ctx, rds, meta.RDS.InstanceID)
+	fetchedMeta, err := fetchRDSInstanceMetadata(ctx, clt, meta.RDS.InstanceID)
 	if err != nil && !trace.IsNotFound(err) && !trace.IsAccessDenied(err) {
 		return nil, trace.Wrap(err)
 	}
@@ -172,11 +193,11 @@ func (m *Metadata) fetchRDSMetadata(ctx context.Context, database types.Database
 		if clusterID == "" {
 			clusterID = meta.RDS.InstanceID
 		}
-		return fetchRDSClusterMetadata(ctx, rds, clusterID)
+		return fetchRDSClusterMetadata(ctx, clt, clusterID)
 	}
 	// If instance was found, it may be a part of an Aurora cluster.
 	if fetchedMeta.RDS.ClusterID != "" {
-		return fetchRDSClusterMetadata(ctx, rds, fetchedMeta.RDS.ClusterID)
+		return fetchRDSClusterMetadata(ctx, clt, fetchedMeta.RDS.ClusterID)
 	}
 	return fetchedMeta, nil
 }
@@ -184,18 +205,19 @@ func (m *Metadata) fetchRDSMetadata(ctx context.Context, database types.Database
 // fetchRDSProxyMetadata fetches metadata for the provided RDS Proxy database.
 func (m *Metadata) fetchRDSProxyMetadata(ctx context.Context, database types.Database) (*types.AWS, error) {
 	meta := database.GetAWS()
-	rds, err := m.cfg.Clients.GetAWSRDSClient(ctx, meta.Region,
-		cloud.WithAssumeRoleFromAWSMeta(meta),
-		cloud.WithAmbientCredentials(),
+	awsCfg, err := m.cfg.AWSConfigProvider.GetConfig(ctx, meta.Region,
+		awsconfig.WithAssumeRole(meta.AssumeRoleARN, meta.ExternalID),
+		awsconfig.WithAmbientCredentials(),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	clt := m.cfg.awsClients.getRDSClient(awsCfg)
 
 	if meta.RDSProxy.CustomEndpointName != "" {
-		return fetchRDSProxyCustomEndpointMetadata(ctx, rds, meta.RDSProxy.CustomEndpointName, database.GetURI())
+		return fetchRDSProxyCustomEndpointMetadata(ctx, clt, meta.RDSProxy.CustomEndpointName, database.GetURI())
 	}
-	return fetchRDSProxyMetadata(ctx, rds, meta.RDSProxy.Name)
+	return fetchRDSProxyMetadata(ctx, clt, meta.RDSProxy.Name)
 }
 
 // fetchRedshiftMetadata fetches metadata for the provided Redshift database.
@@ -208,7 +230,7 @@ func (m *Metadata) fetchRedshiftMetadata(ctx context.Context, database types.Dat
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	redshift := m.cfg.redshiftClientProviderFn(awsCfg)
+	redshift := m.cfg.awsClients.getRedshiftClient(awsCfg)
 	cluster, err := describeRedshiftCluster(ctx, redshift, meta.Redshift.ClusterID)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -275,8 +297,8 @@ func (m *Metadata) fetchMemoryDBMetadata(ctx context.Context, database types.Dat
 }
 
 // fetchRDSInstanceMetadata fetches metadata about specified RDS instance.
-func fetchRDSInstanceMetadata(ctx context.Context, rdsClient rdsiface.RDSAPI, instanceID string) (*types.AWS, error) {
-	rdsInstance, err := describeRDSInstance(ctx, rdsClient, instanceID)
+func fetchRDSInstanceMetadata(ctx context.Context, clt rdsClient, instanceID string) (*types.AWS, error) {
+	rdsInstance, err := describeRDSInstance(ctx, clt, instanceID)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -284,22 +306,22 @@ func fetchRDSInstanceMetadata(ctx context.Context, rdsClient rdsiface.RDSAPI, in
 }
 
 // describeRDSInstance returns AWS RDS instance for the specified ID.
-func describeRDSInstance(ctx context.Context, rdsClient rdsiface.RDSAPI, instanceID string) (*rds.DBInstance, error) {
-	out, err := rdsClient.DescribeDBInstancesWithContext(ctx, &rds.DescribeDBInstancesInput{
+func describeRDSInstance(ctx context.Context, clt rdsClient, instanceID string) (*rdstypes.DBInstance, error) {
+	out, err := clt.DescribeDBInstances(ctx, &rds.DescribeDBInstancesInput{
 		DBInstanceIdentifier: aws.String(instanceID),
 	})
 	if err != nil {
 		return nil, common.ConvertError(err)
 	}
 	if len(out.DBInstances) != 1 {
-		return nil, trace.BadParameter("expected 1 RDS instance for %v, got %+v", instanceID, out.DBInstances)
+		return nil, trace.BadParameter("expected 1 RDS instance for %v, got %d", instanceID, len(out.DBInstances))
 	}
-	return out.DBInstances[0], nil
+	return &out.DBInstances[0], nil
 }
 
 // fetchRDSClusterMetadata fetches metadata about specified Aurora cluster.
-func fetchRDSClusterMetadata(ctx context.Context, rdsClient rdsiface.RDSAPI, clusterID string) (*types.AWS, error) {
-	rdsCluster, err := describeRDSCluster(ctx, rdsClient, clusterID)
+func fetchRDSClusterMetadata(ctx context.Context, clt rdsClient, clusterID string) (*types.AWS, error) {
+	rdsCluster, err := describeRDSCluster(ctx, clt, clusterID)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -307,8 +329,8 @@ func fetchRDSClusterMetadata(ctx context.Context, rdsClient rdsiface.RDSAPI, clu
 }
 
 // describeRDSCluster returns AWS Aurora cluster for the specified ID.
-func describeRDSCluster(ctx context.Context, rdsClient rdsiface.RDSAPI, clusterID string) (*rds.DBCluster, error) {
-	out, err := rdsClient.DescribeDBClustersWithContext(ctx, &rds.DescribeDBClustersInput{
+func describeRDSCluster(ctx context.Context, clt rdsClient, clusterID string) (*rdstypes.DBCluster, error) {
+	out, err := clt.DescribeDBClusters(ctx, &rds.DescribeDBClustersInput{
 		DBClusterIdentifier: aws.String(clusterID),
 	})
 	if err != nil {
@@ -317,7 +339,7 @@ func describeRDSCluster(ctx context.Context, rdsClient rdsiface.RDSAPI, clusterI
 	if len(out.DBClusters) != 1 {
 		return nil, trace.BadParameter("expected 1 RDS cluster for %v, got %+v", clusterID, out.DBClusters)
 	}
-	return out.DBClusters[0], nil
+	return &out.DBClusters[0], nil
 }
 
 // describeRedshiftCluster returns AWS Redshift cluster for the specified ID.
@@ -364,8 +386,8 @@ func describeMemoryDBCluster(ctx context.Context, client memorydbiface.MemoryDBA
 }
 
 // fetchRDSProxyMetadata fetches metadata about specified RDS Proxy name.
-func fetchRDSProxyMetadata(ctx context.Context, rdsClient rdsiface.RDSAPI, proxyName string) (*types.AWS, error) {
-	rdsProxy, err := describeRDSProxy(ctx, rdsClient, proxyName)
+func fetchRDSProxyMetadata(ctx context.Context, clt rdsClient, proxyName string) (*types.AWS, error) {
+	rdsProxy, err := describeRDSProxy(ctx, clt, proxyName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -373,28 +395,28 @@ func fetchRDSProxyMetadata(ctx context.Context, rdsClient rdsiface.RDSAPI, proxy
 }
 
 // describeRDSProxy returns AWS RDS Proxy for the specified RDS Proxy name.
-func describeRDSProxy(ctx context.Context, rdsClient rdsiface.RDSAPI, proxyName string) (*rds.DBProxy, error) {
-	out, err := rdsClient.DescribeDBProxiesWithContext(ctx, &rds.DescribeDBProxiesInput{
+func describeRDSProxy(ctx context.Context, clt rdsClient, proxyName string) (*rdstypes.DBProxy, error) {
+	out, err := clt.DescribeDBProxies(ctx, &rds.DescribeDBProxiesInput{
 		DBProxyName: aws.String(proxyName),
 	})
 	if err != nil {
 		return nil, common.ConvertError(err)
 	}
 	if len(out.DBProxies) != 1 {
-		return nil, trace.BadParameter("expected 1 RDS Proxy for %v, got %s", proxyName, out.DBProxies)
+		return nil, trace.BadParameter("expected 1 RDS Proxy for %v, got %d", proxyName, len(out.DBProxies))
 	}
-	return out.DBProxies[0], nil
+	return &out.DBProxies[0], nil
 }
 
 // fetchRDSProxyCustomEndpointMetadata fetches metadata about specified RDS
 // proxy custom endpoint.
-func fetchRDSProxyCustomEndpointMetadata(ctx context.Context, rdsClient rdsiface.RDSAPI, proxyEndpointName, uri string) (*types.AWS, error) {
-	rdsProxyEndpoint, err := describeRDSProxyCustomEndpointAndFindURI(ctx, rdsClient, proxyEndpointName, uri)
+func fetchRDSProxyCustomEndpointMetadata(ctx context.Context, clt rdsClient, proxyEndpointName, uri string) (*types.AWS, error) {
+	rdsProxyEndpoint, err := describeRDSProxyCustomEndpointAndFindURI(ctx, clt, proxyEndpointName, uri)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	rdsProxy, err := describeRDSProxy(ctx, rdsClient, aws.ToString(rdsProxyEndpoint.DBProxyName))
+	rdsProxy, err := describeRDSProxy(ctx, clt, aws.ToString(rdsProxyEndpoint.DBProxyName))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -404,21 +426,27 @@ func fetchRDSProxyCustomEndpointMetadata(ctx context.Context, rdsClient rdsiface
 
 // describeRDSProxyCustomEndpointAndFindURI returns AWS RDS Proxy endpoint for
 // the specified RDS Proxy custom endpoint.
-func describeRDSProxyCustomEndpointAndFindURI(ctx context.Context, rdsClient rdsiface.RDSAPI, proxyEndpointName, uri string) (*rds.DBProxyEndpoint, error) {
-	out, err := rdsClient.DescribeDBProxyEndpointsWithContext(ctx, &rds.DescribeDBProxyEndpointsInput{
+func describeRDSProxyCustomEndpointAndFindURI(ctx context.Context, clt rdsClient, proxyEndpointName, uri string) (*rdstypes.DBProxyEndpoint, error) {
+	out, err := clt.DescribeDBProxyEndpoints(ctx, &rds.DescribeDBProxyEndpointsInput{
 		DBProxyEndpointName: aws.String(proxyEndpointName),
 	})
 	if err != nil {
 		return nil, common.ConvertError(err)
 	}
-	for _, customEndpoint := range out.DBProxyEndpoints {
+	var endpoints []string
+	for _, e := range out.DBProxyEndpoints {
+		endpoint := aws.ToString(e.Endpoint)
+		if endpoint == "" {
+			continue
+		}
 		// Double check if it has the same URI in case multiple custom
 		// endpoints have the same name.
-		if strings.Contains(uri, aws.ToString(customEndpoint.Endpoint)) {
-			return customEndpoint, nil
+		if strings.Contains(uri, endpoint) {
+			return &e, nil
 		}
+		endpoints = append(endpoints, endpoint)
 	}
-	return nil, trace.BadParameter("could not find RDS Proxy custom endpoint %v with URI %v, got %s", proxyEndpointName, uri, out.DBProxyEndpoints)
+	return nil, trace.BadParameter("could not find RDS Proxy custom endpoint %v with URI %v, got %s", proxyEndpointName, uri, endpoints)
 }
 
 func fetchRedshiftServerlessWorkgroupMetadata(ctx context.Context, client redshiftserverlessiface.RedshiftServerlessAPI, workgroupName string) (*types.AWS, error) {

--- a/lib/srv/db/cloud/resource_checker_url.go
+++ b/lib/srv/db/cloud/resource_checker_url.go
@@ -28,7 +28,6 @@ import (
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/redshift"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
@@ -42,9 +41,8 @@ import (
 type urlChecker struct {
 	// awsConfigProvider provides [aws.Config] for AWS SDK service clients.
 	awsConfigProvider awsconfig.Provider
-	// redshiftClientProviderFn is an internal-only [redshiftClient] provider
-	// func that is only set in tests.
-	redshiftClientProviderFn redshiftClientProviderFunc
+	// awsClients is an SDK client provider.
+	awsClients awsClientProvider
 
 	clients     cloud.Clients
 	logger      *slog.Logger
@@ -61,12 +59,10 @@ type urlChecker struct {
 func newURLChecker(cfg DiscoveryResourceCheckerConfig) *urlChecker {
 	return &urlChecker{
 		awsConfigProvider: cfg.AWSConfigProvider,
-		redshiftClientProviderFn: func(cfg aws.Config, optFns ...func(*redshift.Options)) redshiftClient {
-			return redshift.NewFromConfig(cfg, optFns...)
-		},
-		clients:     cfg.Clients,
-		logger:      cfg.Logger,
-		warnOnError: getWarnOnError(),
+		awsClients:        defaultAWSClients{},
+		clients:           cfg.Clients,
+		logger:            cfg.Logger,
+		warnOnError:       getWarnOnError(),
 	}
 }
 

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -259,9 +259,10 @@ func (c *Config) CheckAndSetDefaults(ctx context.Context) (err error) {
 	}
 	if c.CloudIAM == nil {
 		c.CloudIAM, err = cloud.NewIAM(ctx, cloud.IAMConfig{
-			AccessPoint: c.AccessPoint,
-			Clients:     c.CloudClients,
-			HostID:      c.HostID,
+			AccessPoint:       c.AccessPoint,
+			AWSConfigProvider: c.AWSConfigProvider,
+			Clients:           c.CloudClients,
+			HostID:            c.HostID,
 		})
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/srv/db/watcher_test.go
+++ b/lib/srv/db/watcher_test.go
@@ -320,7 +320,6 @@ func TestWatcherCloudFetchers(t *testing.T) {
 			reconcileCh <- d
 		},
 		CloudClients: &clients.TestCloudClients{
-			RDS: &mocks.RDSMockUnauth{}, // Access denied error should not affect other fetchers.
 			RedshiftServerless: &mocks.RedshiftServerlessMock{
 				Workgroups: []*redshiftserverless.Workgroup{redshiftServerlessWorkgroup},
 			},
@@ -358,7 +357,7 @@ func assertReconciledResource(t *testing.T, ch chan types.Databases, databases t
 			cmpopts.IgnoreFields(types.DatabaseStatusV3{}, "CACert"),
 		))
 	case <-time.After(time.Second):
-		t.Fatal("Didn't receive reconcile event after 1s.")
+		require.FailNow(t, "Didn't receive reconcile event after 1s.")
 	}
 }
 

--- a/lib/srv/discovery/access_graph.go
+++ b/lib/srv/discovery/access_graph.go
@@ -501,6 +501,7 @@ func (s *Server) accessGraphFetchersFromMatchers(ctx context.Context, matchers M
 		fetcher, err := aws_sync.NewAWSFetcher(
 			ctx,
 			aws_sync.Config{
+				AWSConfigProvider:   s.AWSConfigProvider,
 				CloudClients:        s.CloudClients,
 				GetEKSClient:        s.GetAWSSyncEKSClient,
 				GetEC2Client:        s.GetEC2Client,

--- a/lib/srv/discovery/common/database.go
+++ b/lib/srv/discovery/common/database.go
@@ -35,7 +35,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/aws/aws-sdk-go/service/memorydb"
 	"github.com/aws/aws-sdk-go/service/opensearchservice"
-	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/redshiftserverless"
 	"github.com/gravitational/trace"
 
@@ -286,7 +285,7 @@ func NewDatabaseFromAzurePostgresFlexServer(server *armpostgresqlflexibleservers
 }
 
 // NewDatabaseFromRDSInstance creates a database resource from an RDS instance.
-func NewDatabaseFromRDSInstance(instance *rds.DBInstance) (types.Database, error) {
+func NewDatabaseFromRDSInstance(instance *rdstypes.DBInstance) (types.Database, error) {
 	endpoint := instance.Endpoint
 	if endpoint == nil {
 		return nil, trace.BadParameter("empty endpoint")
@@ -307,7 +306,7 @@ func NewDatabaseFromRDSInstance(instance *rds.DBInstance) (types.Database, error
 		}, aws.ToString(instance.DBInstanceIdentifier)),
 		types.DatabaseSpecV3{
 			Protocol: protocol,
-			URI:      fmt.Sprintf("%v:%v", aws.ToString(endpoint.Address), aws.ToInt64(endpoint.Port)),
+			URI:      fmt.Sprintf("%v:%v", aws.ToString(endpoint.Address), aws.ToInt32(endpoint.Port)),
 			AWS:      *metadata,
 		})
 }
@@ -492,7 +491,7 @@ func labelsFromRDSV2Cluster(rdsCluster *rdstypes.DBCluster, meta *types.AWS, end
 }
 
 // NewDatabaseFromRDSCluster creates a database resource from an RDS cluster (Aurora).
-func NewDatabaseFromRDSCluster(cluster *rds.DBCluster, memberInstances []*rds.DBInstance) (types.Database, error) {
+func NewDatabaseFromRDSCluster(cluster *rdstypes.DBCluster, memberInstances []rdstypes.DBInstance) (types.Database, error) {
 	metadata, err := MetadataFromRDSCluster(cluster)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -508,13 +507,13 @@ func NewDatabaseFromRDSCluster(cluster *rds.DBCluster, memberInstances []*rds.DB
 		}, aws.ToString(cluster.DBClusterIdentifier)),
 		types.DatabaseSpecV3{
 			Protocol: protocol,
-			URI:      fmt.Sprintf("%v:%v", aws.ToString(cluster.Endpoint), aws.ToInt64(cluster.Port)),
+			URI:      fmt.Sprintf("%v:%v", aws.ToString(cluster.Endpoint), aws.ToInt32(cluster.Port)),
 			AWS:      *metadata,
 		})
 }
 
 // NewDatabaseFromRDSClusterReaderEndpoint creates a database resource from an RDS cluster reader endpoint (Aurora).
-func NewDatabaseFromRDSClusterReaderEndpoint(cluster *rds.DBCluster, memberInstances []*rds.DBInstance) (types.Database, error) {
+func NewDatabaseFromRDSClusterReaderEndpoint(cluster *rdstypes.DBCluster, memberInstances []rdstypes.DBInstance) (types.Database, error) {
 	metadata, err := MetadataFromRDSCluster(cluster)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -530,13 +529,13 @@ func NewDatabaseFromRDSClusterReaderEndpoint(cluster *rds.DBCluster, memberInsta
 		}, aws.ToString(cluster.DBClusterIdentifier), apiawsutils.RDSEndpointTypeReader),
 		types.DatabaseSpecV3{
 			Protocol: protocol,
-			URI:      fmt.Sprintf("%v:%v", aws.ToString(cluster.ReaderEndpoint), aws.ToInt64(cluster.Port)),
+			URI:      fmt.Sprintf("%v:%v", aws.ToString(cluster.ReaderEndpoint), aws.ToInt32(cluster.Port)),
 			AWS:      *metadata,
 		})
 }
 
 // NewDatabasesFromRDSClusterCustomEndpoints creates database resources from RDS cluster custom endpoints (Aurora).
-func NewDatabasesFromRDSClusterCustomEndpoints(cluster *rds.DBCluster, memberInstances []*rds.DBInstance) (types.Databases, error) {
+func NewDatabasesFromRDSClusterCustomEndpoints(cluster *rdstypes.DBCluster, memberInstances []rdstypes.DBInstance) (types.Databases, error) {
 	metadata, err := MetadataFromRDSCluster(cluster)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -551,7 +550,7 @@ func NewDatabasesFromRDSClusterCustomEndpoints(cluster *rds.DBCluster, memberIns
 	for _, endpoint := range cluster.CustomEndpoints {
 		// RDS custom endpoint format:
 		// <endpointName>.cluster-custom-<customerDnsIdentifier>.<dnsSuffix>
-		endpointDetails, err := apiawsutils.ParseRDSEndpoint(aws.ToString(endpoint))
+		endpointDetails, err := apiawsutils.ParseRDSEndpoint(endpoint)
 		if err != nil {
 			errors = append(errors, trace.Wrap(err))
 			continue
@@ -568,7 +567,7 @@ func NewDatabasesFromRDSClusterCustomEndpoints(cluster *rds.DBCluster, memberIns
 			}, aws.ToString(cluster.DBClusterIdentifier), apiawsutils.RDSEndpointTypeCustom, endpointDetails.ClusterCustomEndpointName),
 			types.DatabaseSpecV3{
 				Protocol: protocol,
-				URI:      fmt.Sprintf("%v:%v", aws.ToString(endpoint), aws.ToInt64(cluster.Port)),
+				URI:      fmt.Sprintf("%v:%v", endpoint, aws.ToInt32(cluster.Port)),
 				AWS:      *metadata,
 
 				// Aurora instances update their certificates upon restart, and thus custom endpoint SAN may not be available right
@@ -588,14 +587,12 @@ func NewDatabasesFromRDSClusterCustomEndpoints(cluster *rds.DBCluster, memberIns
 	return databases, trace.NewAggregate(errors...)
 }
 
-func checkRDSClusterMembers(cluster *rds.DBCluster) (hasWriterInstance, hasReaderInstance bool) {
+func checkRDSClusterMembers(cluster *rdstypes.DBCluster) (hasWriterInstance, hasReaderInstance bool) {
 	for _, clusterMember := range cluster.DBClusterMembers {
-		if clusterMember != nil {
-			if aws.ToBool(clusterMember.IsClusterWriter) {
-				hasWriterInstance = true
-			} else {
-				hasReaderInstance = true
-			}
+		if aws.ToBool(clusterMember.IsClusterWriter) {
+			hasWriterInstance = true
+		} else {
+			hasReaderInstance = true
 		}
 	}
 	return
@@ -603,7 +600,7 @@ func checkRDSClusterMembers(cluster *rds.DBCluster) (hasWriterInstance, hasReade
 
 // NewDatabasesFromRDSCluster creates all database resources from an RDS Aurora
 // cluster.
-func NewDatabasesFromRDSCluster(cluster *rds.DBCluster, memberInstances []*rds.DBInstance) (types.Databases, error) {
+func NewDatabasesFromRDSCluster(cluster *rdstypes.DBCluster, memberInstances []rdstypes.DBInstance) (types.Databases, error) {
 	var errors []error
 	var databases types.Databases
 
@@ -648,7 +645,7 @@ func NewDatabasesFromRDSCluster(cluster *rds.DBCluster, memberInstances []*rds.D
 
 // NewDatabasesFromDocumentDBCluster creates all database resources from a
 // DocumentDB cluster.
-func NewDatabasesFromDocumentDBCluster(cluster *rds.DBCluster) (types.Databases, error) {
+func NewDatabasesFromDocumentDBCluster(cluster *rdstypes.DBCluster) (types.Databases, error) {
 	var errors []error
 	var databases types.Databases
 
@@ -682,7 +679,7 @@ func NewDatabasesFromDocumentDBCluster(cluster *rds.DBCluster) (types.Databases,
 
 // NewDatabaseFromDocumentDBClusterEndpoint creates database resource from
 // DocumentDB cluster endpoint.
-func NewDatabaseFromDocumentDBClusterEndpoint(cluster *rds.DBCluster) (types.Database, error) {
+func NewDatabaseFromDocumentDBClusterEndpoint(cluster *rdstypes.DBCluster) (types.Database, error) {
 	endpointType := apiawsutils.DocumentDBClusterEndpoint
 	metadata, err := MetadataFromDocumentDBCluster(cluster, endpointType)
 	if err != nil {
@@ -695,14 +692,14 @@ func NewDatabaseFromDocumentDBClusterEndpoint(cluster *rds.DBCluster) (types.Dat
 		}, aws.ToString(cluster.DBClusterIdentifier)),
 		types.DatabaseSpecV3{
 			Protocol: types.DatabaseProtocolMongoDB,
-			URI:      fmt.Sprintf("%v:%v", aws.ToString(cluster.Endpoint), aws.ToInt64(cluster.Port)),
+			URI:      fmt.Sprintf("%v:%v", aws.ToString(cluster.Endpoint), aws.ToInt32(cluster.Port)),
 			AWS:      *metadata,
 		})
 }
 
 // NewDatabaseFromDocumentDBReaderEndpoint creates database resource from
 // DocumentDB reader endpoint.
-func NewDatabaseFromDocumentDBReaderEndpoint(cluster *rds.DBCluster) (types.Database, error) {
+func NewDatabaseFromDocumentDBReaderEndpoint(cluster *rdstypes.DBCluster) (types.Database, error) {
 	endpointType := apiawsutils.DocumentDBClusterReaderEndpoint
 	metadata, err := MetadataFromDocumentDBCluster(cluster, endpointType)
 	if err != nil {
@@ -715,13 +712,13 @@ func NewDatabaseFromDocumentDBReaderEndpoint(cluster *rds.DBCluster) (types.Data
 		}, aws.ToString(cluster.DBClusterIdentifier), endpointType),
 		types.DatabaseSpecV3{
 			Protocol: types.DatabaseProtocolMongoDB,
-			URI:      fmt.Sprintf("%v:%v", aws.ToString(cluster.ReaderEndpoint), aws.ToInt64(cluster.Port)),
+			URI:      fmt.Sprintf("%v:%v", aws.ToString(cluster.ReaderEndpoint), aws.ToInt32(cluster.Port)),
 			AWS:      *metadata,
 		})
 }
 
 // NewDatabaseFromRDSProxy creates database resource from RDS Proxy.
-func NewDatabaseFromRDSProxy(dbProxy *rds.DBProxy, tags []*rds.Tag) (types.Database, error) {
+func NewDatabaseFromRDSProxy(dbProxy *rdstypes.DBProxy, tags []rdstypes.Tag) (types.Database, error) {
 	metadata, err := MetadataFromRDSProxy(dbProxy)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -744,7 +741,7 @@ func NewDatabaseFromRDSProxy(dbProxy *rds.DBProxy, tags []*rds.Tag) (types.Datab
 
 // NewDatabaseFromRDSProxyCustomEndpoint creates database resource from RDS
 // Proxy custom endpoint.
-func NewDatabaseFromRDSProxyCustomEndpoint(dbProxy *rds.DBProxy, customEndpoint *rds.DBProxyEndpoint, tags []*rds.Tag) (types.Database, error) {
+func NewDatabaseFromRDSProxyCustomEndpoint(dbProxy *rdstypes.DBProxy, customEndpoint *rdstypes.DBProxyEndpoint, tags []rdstypes.Tag) (types.Database, error) {
 	metadata, err := MetadataFromRDSProxyCustomEndpoint(dbProxy, customEndpoint)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1045,7 +1042,7 @@ func NewDatabaseFromRedshiftServerlessVPCEndpoint(endpoint *redshiftserverless.E
 }
 
 // MetadataFromRDSInstance creates AWS metadata from the provided RDS instance.
-func MetadataFromRDSInstance(rdsInstance *rds.DBInstance) (*types.AWS, error) {
+func MetadataFromRDSInstance(rdsInstance *rdstypes.DBInstance) (*types.AWS, error) {
 	parsedARN, err := arn.Parse(aws.ToString(rdsInstance.DBInstanceArn))
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1063,7 +1060,7 @@ func MetadataFromRDSInstance(rdsInstance *rds.DBInstance) (*types.AWS, error) {
 }
 
 // MetadataFromRDSCluster creates AWS metadata from the provided RDS cluster.
-func MetadataFromRDSCluster(rdsCluster *rds.DBCluster) (*types.AWS, error) {
+func MetadataFromRDSCluster(rdsCluster *rdstypes.DBCluster) (*types.AWS, error) {
 	parsedARN, err := arn.Parse(aws.ToString(rdsCluster.DBClusterArn))
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1081,7 +1078,7 @@ func MetadataFromRDSCluster(rdsCluster *rds.DBCluster) (*types.AWS, error) {
 
 // MetadataFromDocumentDBCluster creates AWS metadata from the provided
 // DocumentDB cluster.
-func MetadataFromDocumentDBCluster(cluster *rds.DBCluster, endpointType string) (*types.AWS, error) {
+func MetadataFromDocumentDBCluster(cluster *rdstypes.DBCluster, endpointType string) (*types.AWS, error) {
 	parsedARN, err := arn.Parse(aws.ToString(cluster.DBClusterArn))
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1097,13 +1094,13 @@ func MetadataFromDocumentDBCluster(cluster *rds.DBCluster, endpointType string) 
 }
 
 // MetadataFromRDSProxy creates AWS metadata from the provided RDS Proxy.
-func MetadataFromRDSProxy(rdsProxy *rds.DBProxy) (*types.AWS, error) {
+func MetadataFromRDSProxy(rdsProxy *rdstypes.DBProxy) (*types.AWS, error) {
 	parsedARN, err := arn.Parse(aws.ToString(rdsProxy.DBProxyArn))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	// rds.DBProxy has no resource ID attribute. The resource ID can be found
+	// rdstypes.DBProxy has no resource ID attribute. The resource ID can be found
 	// in the ARN, e.g.:
 	//
 	// arn:aws:rds:ca-central-1:123456789012:db-proxy:prx-xxxyyyzzz
@@ -1127,7 +1124,7 @@ func MetadataFromRDSProxy(rdsProxy *rds.DBProxy) (*types.AWS, error) {
 
 // MetadataFromRDSProxyCustomEndpoint creates AWS metadata from the provided
 // RDS Proxy custom endpoint.
-func MetadataFromRDSProxyCustomEndpoint(rdsProxy *rds.DBProxy, customEndpoint *rds.DBProxyEndpoint) (*types.AWS, error) {
+func MetadataFromRDSProxyCustomEndpoint(rdsProxy *rdstypes.DBProxy, customEndpoint *rdstypes.DBProxyEndpoint) (*types.AWS, error) {
 	// Using resource ID from the default proxy for IAM policies to gain the
 	// RDS connection access.
 	metadata, err := MetadataFromRDSProxy(rdsProxy)
@@ -1323,12 +1320,12 @@ func rdsEngineToProtocol(engine string) (string, error) {
 
 // rdsEngineFamilyToProtocolAndPort converts RDS engine family to the database protocol and port.
 func rdsEngineFamilyToProtocolAndPort(engineFamily string) (string, int, error) {
-	switch engineFamily {
-	case rds.EngineFamilyMysql:
+	switch rdstypes.EngineFamily(engineFamily) {
+	case rdstypes.EngineFamilyMysql:
 		return defaults.ProtocolMySQL, services.RDSProxyMySQLPort, nil
-	case rds.EngineFamilyPostgresql:
+	case rdstypes.EngineFamilyPostgresql:
 		return defaults.ProtocolPostgres, services.RDSProxyPostgresPort, nil
-	case rds.EngineFamilySqlserver:
+	case rdstypes.EngineFamilySqlserver:
 		return defaults.ProtocolSQLServer, services.RDSProxySQLServerPort, nil
 	}
 	return "", 0, trace.BadParameter("unknown RDS engine family type %q", engineFamily)
@@ -1421,7 +1418,7 @@ func labelsFromAzurePostgresFlexServer(server *armpostgresqlflexibleservers.Serv
 }
 
 // labelsFromRDSInstance creates database labels for the provided RDS instance.
-func labelsFromRDSInstance(rdsInstance *rds.DBInstance, meta *types.AWS) map[string]string {
+func labelsFromRDSInstance(rdsInstance *rdstypes.DBInstance, meta *types.AWS) map[string]string {
 	labels := labelsFromAWSMetadata(meta)
 	labels[types.DiscoveryLabelEngine] = aws.ToString(rdsInstance.Engine)
 	labels[types.DiscoveryLabelEngineVersion] = aws.ToString(rdsInstance.EngineVersion)
@@ -1433,7 +1430,7 @@ func labelsFromRDSInstance(rdsInstance *rds.DBInstance, meta *types.AWS) map[str
 }
 
 // labelsFromRDSCluster creates database labels for the provided RDS cluster.
-func labelsFromRDSCluster(rdsCluster *rds.DBCluster, meta *types.AWS, endpointType string, memberInstances []*rds.DBInstance) map[string]string {
+func labelsFromRDSCluster(rdsCluster *rdstypes.DBCluster, meta *types.AWS, endpointType string, memberInstances []rdstypes.DBInstance) map[string]string {
 	labels := labelsFromAWSMetadata(meta)
 	labels[types.DiscoveryLabelEngine] = aws.ToString(rdsCluster.Engine)
 	labels[types.DiscoveryLabelEngineVersion] = aws.ToString(rdsCluster.EngineVersion)
@@ -1444,7 +1441,7 @@ func labelsFromRDSCluster(rdsCluster *rds.DBCluster, meta *types.AWS, endpointTy
 	return addLabels(labels, libcloudaws.TagsToLabels(rdsCluster.TagList))
 }
 
-func labelsFromDocumentDBCluster(cluster *rds.DBCluster, meta *types.AWS, endpointType string) map[string]string {
+func labelsFromDocumentDBCluster(cluster *rdstypes.DBCluster, meta *types.AWS, endpointType string) map[string]string {
 	labels := labelsFromAWSMetadata(meta)
 	labels[types.DiscoveryLabelEngine] = aws.ToString(cluster.Engine)
 	labels[types.DiscoveryLabelEngineVersion] = aws.ToString(cluster.EngineVersion)
@@ -1453,8 +1450,8 @@ func labelsFromDocumentDBCluster(cluster *rds.DBCluster, meta *types.AWS, endpoi
 }
 
 // labelsFromRDSProxy creates database labels for the provided RDS Proxy.
-func labelsFromRDSProxy(rdsProxy *rds.DBProxy, meta *types.AWS, tags []*rds.Tag) map[string]string {
-	// rds.DBProxy has no TagList.
+func labelsFromRDSProxy(rdsProxy *rdstypes.DBProxy, meta *types.AWS, tags []rdstypes.Tag) map[string]string {
+	// rdstypes.DBProxy has no TagList.
 	labels := labelsFromAWSMetadata(meta)
 	labels[types.DiscoveryLabelVPCID] = aws.ToString(rdsProxy.VpcId)
 	labels[types.DiscoveryLabelEngine] = aws.ToString(rdsProxy.EngineFamily)
@@ -1463,9 +1460,9 @@ func labelsFromRDSProxy(rdsProxy *rds.DBProxy, meta *types.AWS, tags []*rds.Tag)
 
 // labelsFromRDSProxyCustomEndpoint creates database labels for the provided
 // RDS Proxy custom endpoint.
-func labelsFromRDSProxyCustomEndpoint(rdsProxy *rds.DBProxy, customEndpoint *rds.DBProxyEndpoint, meta *types.AWS, tags []*rds.Tag) map[string]string {
+func labelsFromRDSProxyCustomEndpoint(rdsProxy *rdstypes.DBProxy, customEndpoint *rdstypes.DBProxyEndpoint, meta *types.AWS, tags []rdstypes.Tag) map[string]string {
 	labels := labelsFromRDSProxy(rdsProxy, meta, tags)
-	labels[types.DiscoveryLabelEndpointType] = aws.ToString(customEndpoint.TargetRole)
+	labels[types.DiscoveryLabelEndpointType] = string(customEndpoint.TargetRole)
 	return labels
 }
 

--- a/lib/srv/discovery/common/database_test.go
+++ b/lib/srv/discovery/common/database_test.go
@@ -28,11 +28,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql"
 	"github.com/aws/aws-sdk-go-v2/aws"
-	rdsTypesV2 "github.com/aws/aws-sdk-go-v2/service/rds/types"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	redshifttypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/aws/aws-sdk-go/service/memorydb"
-	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/redshiftserverless"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
@@ -217,7 +216,7 @@ func TestDatabaseFromAzureRedisEnterprise(t *testing.T) {
 
 // TestDatabaseFromRDSInstance tests converting an RDS instance to a database resource.
 func TestDatabaseFromRDSInstance(t *testing.T) {
-	instance := &rds.DBInstance{
+	instance := &rdstypes.DBInstance{
 		DBInstanceArn:                    aws.String("arn:aws:rds:us-west-1:123456789012:db:instance-1"),
 		DBInstanceIdentifier:             aws.String("instance-1"),
 		DBClusterIdentifier:              aws.String("cluster-1"),
@@ -225,11 +224,11 @@ func TestDatabaseFromRDSInstance(t *testing.T) {
 		IAMDatabaseAuthenticationEnabled: aws.Bool(true),
 		Engine:                           aws.String(services.RDSEnginePostgres),
 		EngineVersion:                    aws.String("13.0"),
-		Endpoint: &rds.Endpoint{
+		Endpoint: &rdstypes.Endpoint{
 			Address: aws.String("localhost"),
-			Port:    aws.Int64(5432),
+			Port:    aws.Int32(5432),
 		},
-		TagList: []*rds.Tag{{
+		TagList: []rdstypes.Tag{{
 			Key:   aws.String("key"),
 			Value: aws.String("val"),
 		}},
@@ -268,7 +267,7 @@ func TestDatabaseFromRDSInstance(t *testing.T) {
 
 // TestDatabaseFromRDSV2Instance tests converting an RDS instance (from aws sdk v2/rds) to a database resource.
 func TestDatabaseFromRDSV2Instance(t *testing.T) {
-	instance := &rdsTypesV2.DBInstance{
+	instance := &rdstypes.DBInstance{
 		DBInstanceArn:                    aws.String("arn:aws:rds:us-west-1:123456789012:db:instance-1"),
 		DBInstanceIdentifier:             aws.String("instance-1"),
 		DBClusterIdentifier:              aws.String("cluster-1"),
@@ -277,16 +276,16 @@ func TestDatabaseFromRDSV2Instance(t *testing.T) {
 		IAMDatabaseAuthenticationEnabled: aws.Bool(true),
 		Engine:                           aws.String(services.RDSEnginePostgres),
 		EngineVersion:                    aws.String("13.0"),
-		Endpoint: &rdsTypesV2.Endpoint{
+		Endpoint: &rdstypes.Endpoint{
 			Address: aws.String("localhost"),
 			Port:    aws.Int32(5432),
 		},
-		TagList: []rdsTypesV2.Tag{{
+		TagList: []rdstypes.Tag{{
 			Key:   aws.String("key"),
 			Value: aws.String("val"),
 		}},
-		DBSubnetGroup: &rdsTypesV2.DBSubnetGroup{
-			Subnets: []rdsTypesV2.Subnet{
+		DBSubnetGroup: &rdstypes.DBSubnetGroup{
+			Subnets: []rdstypes.Subnet{
 				{SubnetIdentifier: aws.String("")},
 				{SubnetIdentifier: aws.String("subnet-1234567890abcdef0")},
 				{SubnetIdentifier: aws.String("subnet-1234567890abcdef1")},
@@ -294,7 +293,7 @@ func TestDatabaseFromRDSV2Instance(t *testing.T) {
 			},
 			VpcId: aws.String("vpc-asd"),
 		},
-		VpcSecurityGroups: []rdsTypesV2.VpcSecurityGroupMembership{
+		VpcSecurityGroups: []rdstypes.VpcSecurityGroupMembership{
 			{VpcSecurityGroupId: aws.String("")},
 			{VpcSecurityGroupId: aws.String("sg-1")},
 			{VpcSecurityGroupId: aws.String("sg-2")},
@@ -348,7 +347,7 @@ func TestDatabaseFromRDSV2Instance(t *testing.T) {
 			newName := "override-1"
 			instance := instance
 			instance.TagList = append(instance.TagList,
-				rdsTypesV2.Tag{
+				rdstypes.Tag{
 					Key:   aws.String(overrideLabel),
 					Value: aws.String(newName),
 				},
@@ -365,7 +364,7 @@ func TestDatabaseFromRDSV2Instance(t *testing.T) {
 // TestDatabaseFromRDSInstance tests converting an RDS instance to a database resource.
 func TestDatabaseFromRDSInstanceNameOverride(t *testing.T) {
 	for _, overrideLabel := range types.AWSDatabaseNameOverrideLabels {
-		instance := &rds.DBInstance{
+		instance := &rdstypes.DBInstance{
 			DBInstanceArn:                    aws.String("arn:aws:rds:us-west-1:123456789012:db:instance-1"),
 			DBInstanceIdentifier:             aws.String("instance-1"),
 			DBClusterIdentifier:              aws.String("cluster-1"),
@@ -373,11 +372,11 @@ func TestDatabaseFromRDSInstanceNameOverride(t *testing.T) {
 			IAMDatabaseAuthenticationEnabled: aws.Bool(true),
 			Engine:                           aws.String(services.RDSEnginePostgres),
 			EngineVersion:                    aws.String("13.0"),
-			Endpoint: &rds.Endpoint{
+			Endpoint: &rdstypes.Endpoint{
 				Address: aws.String("localhost"),
-				Port:    aws.Int64(5432),
+				Port:    aws.Int32(5432),
 			},
-			TagList: []*rds.Tag{
+			TagList: []rdstypes.Tag{
 				{Key: aws.String("key"), Value: aws.String("val")},
 				{Key: aws.String(overrideLabel), Value: aws.String("override-1")},
 			},
@@ -421,8 +420,8 @@ func TestDatabaseFromRDSInstanceNameOverride(t *testing.T) {
 // TestDatabaseFromRDSCluster tests converting an RDS cluster to a database resource.
 func TestDatabaseFromRDSCluster(t *testing.T) {
 	vpcid := uuid.NewString()
-	dbInstanceMembers := []*rds.DBInstance{{DBSubnetGroup: &rds.DBSubnetGroup{VpcId: aws.String(vpcid)}}}
-	cluster := &rds.DBCluster{
+	dbInstanceMembers := []rdstypes.DBInstance{{DBSubnetGroup: &rdstypes.DBSubnetGroup{VpcId: aws.String(vpcid)}}}
+	cluster := &rdstypes.DBCluster{
 		DBClusterArn:                     aws.String("arn:aws:rds:us-east-1:123456789012:cluster:cluster-1"),
 		DBClusterIdentifier:              aws.String("cluster-1"),
 		DbClusterResourceId:              aws.String("resource-1"),
@@ -431,12 +430,12 @@ func TestDatabaseFromRDSCluster(t *testing.T) {
 		EngineVersion:                    aws.String("8.0.0"),
 		Endpoint:                         aws.String("localhost"),
 		ReaderEndpoint:                   aws.String("reader.host"),
-		Port:                             aws.Int64(3306),
-		CustomEndpoints: []*string{
-			aws.String("myendpoint1.cluster-custom-example.us-east-1.rds.amazonaws.com"),
-			aws.String("myendpoint2.cluster-custom-example.us-east-1.rds.amazonaws.com"),
+		Port:                             aws.Int32(3306),
+		CustomEndpoints: []string{
+			"myendpoint1.cluster-custom-example.us-east-1.rds.amazonaws.com",
+			"myendpoint2.cluster-custom-example.us-east-1.rds.amazonaws.com",
 		},
-		TagList: []*rds.Tag{{
+		TagList: []rdstypes.Tag{{
 			Key:   aws.String("key"),
 			Value: aws.String("val"),
 		}},
@@ -549,9 +548,9 @@ func TestDatabaseFromRDSCluster(t *testing.T) {
 
 	t.Run("bad custom endpoints ", func(t *testing.T) {
 		badCluster := *cluster
-		badCluster.CustomEndpoints = []*string{
-			aws.String("badendpoint1"),
-			aws.String("badendpoint2"),
+		badCluster.CustomEndpoints = []string{
+			"badendpoint1",
+			"badendpoint2",
 		}
 		_, err := NewDatabasesFromRDSClusterCustomEndpoints(&badCluster, dbInstanceMembers)
 		require.Error(t, err)
@@ -561,7 +560,7 @@ func TestDatabaseFromRDSCluster(t *testing.T) {
 // TestDatabaseFromRDSV2Cluster tests converting an RDS cluster to a database resource.
 // It uses the V2 of the aws sdk.
 func TestDatabaseFromRDSV2Cluster(t *testing.T) {
-	cluster := &rdsTypesV2.DBCluster{
+	cluster := &rdstypes.DBCluster{
 		DBClusterArn:                     aws.String("arn:aws:rds:us-east-1:123456789012:cluster:cluster-1"),
 		DBClusterIdentifier:              aws.String("cluster-1"),
 		DbClusterResourceId:              aws.String("resource-1"),
@@ -572,7 +571,7 @@ func TestDatabaseFromRDSV2Cluster(t *testing.T) {
 		Endpoint:                         aws.String("localhost"),
 		ReaderEndpoint:                   aws.String("reader.host"),
 		Port:                             aws.Int32(3306),
-		VpcSecurityGroups: []rdsTypesV2.VpcSecurityGroupMembership{
+		VpcSecurityGroups: []rdstypes.VpcSecurityGroupMembership{
 			{VpcSecurityGroupId: aws.String("")},
 			{VpcSecurityGroupId: aws.String("sg-1")},
 			{VpcSecurityGroupId: aws.String("sg-2")},
@@ -581,7 +580,7 @@ func TestDatabaseFromRDSV2Cluster(t *testing.T) {
 			"myendpoint1.cluster-custom-example.us-east-1.rds.amazonaws.com",
 			"myendpoint2.cluster-custom-example.us-east-1.rds.amazonaws.com",
 		},
-		TagList: []rdsTypesV2.Tag{{
+		TagList: []rdstypes.Tag{{
 			Key:   aws.String("key"),
 			Value: aws.String("val"),
 		}},
@@ -630,7 +629,7 @@ func TestDatabaseFromRDSV2Cluster(t *testing.T) {
 				newName := "override-1"
 
 				cluster.TagList = append(cluster.TagList,
-					rdsTypesV2.Tag{
+					rdstypes.Tag{
 						Key:   aws.String(overrideLabel),
 						Value: aws.String(newName),
 					},
@@ -645,10 +644,10 @@ func TestDatabaseFromRDSV2Cluster(t *testing.T) {
 	})
 
 	t.Run("DB Cluster uses network information from DB Instance when available", func(t *testing.T) {
-		instance := &rdsTypesV2.DBInstance{
-			DBSubnetGroup: &rdsTypesV2.DBSubnetGroup{
+		instance := &rdstypes.DBInstance{
+			DBSubnetGroup: &rdstypes.DBSubnetGroup{
 				VpcId: aws.String("vpc-123"),
-				Subnets: []rdsTypesV2.Subnet{
+				Subnets: []rdstypes.Subnet{
 					{SubnetIdentifier: aws.String("subnet-123")},
 					{SubnetIdentifier: aws.String("subnet-456")},
 				},
@@ -699,9 +698,9 @@ func TestDatabaseFromRDSV2Cluster(t *testing.T) {
 
 // TestDatabaseFromRDSClusterNameOverride tests converting an RDS cluster to a database resource with overridden name.
 func TestDatabaseFromRDSClusterNameOverride(t *testing.T) {
-	dbInstanceMembers := []*rds.DBInstance{{DBSubnetGroup: &rds.DBSubnetGroup{VpcId: aws.String("vpc-123")}}}
+	dbInstanceMembers := []rdstypes.DBInstance{{DBSubnetGroup: &rdstypes.DBSubnetGroup{VpcId: aws.String("vpc-123")}}}
 	for _, overrideLabel := range types.AWSDatabaseNameOverrideLabels {
-		cluster := &rds.DBCluster{
+		cluster := &rdstypes.DBCluster{
 			DBClusterArn:                     aws.String("arn:aws:rds:us-east-1:123456789012:cluster:cluster-1"),
 			DBClusterIdentifier:              aws.String("cluster-1"),
 			DbClusterResourceId:              aws.String("resource-1"),
@@ -710,12 +709,12 @@ func TestDatabaseFromRDSClusterNameOverride(t *testing.T) {
 			EngineVersion:                    aws.String("8.0.0"),
 			Endpoint:                         aws.String("localhost"),
 			ReaderEndpoint:                   aws.String("reader.host"),
-			Port:                             aws.Int64(3306),
-			CustomEndpoints: []*string{
-				aws.String("myendpoint1.cluster-custom-example.us-east-1.rds.amazonaws.com"),
-				aws.String("myendpoint2.cluster-custom-example.us-east-1.rds.amazonaws.com"),
+			Port:                             aws.Int32(3306),
+			CustomEndpoints: []string{
+				"myendpoint1.cluster-custom-example.us-east-1.rds.amazonaws.com",
+				"myendpoint2.cluster-custom-example.us-east-1.rds.amazonaws.com",
 			},
-			TagList: []*rds.Tag{
+			TagList: []rdstypes.Tag{
 				{Key: aws.String("key"), Value: aws.String("val")},
 				{Key: aws.String(overrideLabel), Value: aws.String("mycluster-2")},
 			},
@@ -831,9 +830,9 @@ func TestDatabaseFromRDSClusterNameOverride(t *testing.T) {
 
 		t.Run("bad custom endpoints ", func(t *testing.T) {
 			badCluster := *cluster
-			badCluster.CustomEndpoints = []*string{
-				aws.String("badendpoint1"),
-				aws.String("badendpoint2"),
+			badCluster.CustomEndpoints = []string{
+				"badendpoint1",
+				"badendpoint2",
 			}
 			_, err := NewDatabasesFromRDSClusterCustomEndpoints(&badCluster, dbInstanceMembers)
 			require.Error(t, err)
@@ -896,7 +895,7 @@ func TestNewDatabasesFromDocumentDBCluster(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		inputCluster  *rds.DBCluster
+		inputCluster  *rdstypes.DBCluster
 		wantDatabases types.Databases
 	}{
 		{
@@ -929,26 +928,26 @@ func TestDatabaseFromRDSProxy(t *testing.T) {
 	}{
 		{
 			desc:         "mysql",
-			engineFamily: rds.EngineFamilyMysql,
+			engineFamily: string(rdstypes.EngineFamilyMysql),
 			wantProtocol: "mysql",
 			wantPort:     3306,
 		},
 		{
 			desc:         "postgres",
-			engineFamily: rds.EngineFamilyPostgresql,
+			engineFamily: string(rdstypes.EngineFamilyPostgresql),
 			wantProtocol: "postgres",
 			wantPort:     5432,
 		},
 		{
 			desc:         "sqlserver",
-			engineFamily: rds.EngineFamilySqlserver,
+			engineFamily: string(rdstypes.EngineFamilySqlserver),
 			wantProtocol: "sqlserver",
 			wantPort:     1433,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			dbProxy := &rds.DBProxy{
+			dbProxy := &rdstypes.DBProxy{
 				DBProxyArn:   aws.String("arn:aws:rds:ca-central-1:123456789012:db-proxy:prx-abcdef"),
 				DBProxyName:  aws.String("testproxy"),
 				EngineFamily: aws.String(test.engineFamily),
@@ -956,15 +955,15 @@ func TestDatabaseFromRDSProxy(t *testing.T) {
 				VpcId:        aws.String("test-vpc-id"),
 			}
 
-			dbProxyEndpoint := &rds.DBProxyEndpoint{
+			dbProxyEndpoint := &rdstypes.DBProxyEndpoint{
 				Endpoint:            aws.String("custom.proxy.rds.test"),
 				DBProxyEndpointName: aws.String("custom"),
 				DBProxyName:         aws.String("testproxy"),
 				DBProxyEndpointArn:  aws.String("arn:aws:rds:ca-central-1:123456789012:db-proxy-endpoint:prx-endpoint-abcdef"),
-				TargetRole:          aws.String(rds.DBProxyEndpointTargetRoleReadOnly),
+				TargetRole:          rdstypes.DBProxyEndpointTargetRoleReadOnly,
 			}
 
-			tags := []*rds.Tag{{
+			tags := []rdstypes.Tag{{
 				Key:   aws.String("key"),
 				Value: aws.String("val"),
 			}}
@@ -1059,7 +1058,7 @@ func TestAuroraMySQLVersion(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.engineVersion, func(t *testing.T) {
-			require.Equal(t, test.expectedMySQLVersion, libcloudaws.AuroraMySQLVersion(&rds.DBCluster{EngineVersion: aws.String(test.engineVersion)}))
+			require.Equal(t, test.expectedMySQLVersion, libcloudaws.AuroraMySQLVersion(&rdstypes.DBCluster{EngineVersion: aws.String(test.engineVersion)}))
 		})
 	}
 }
@@ -1099,7 +1098,7 @@ func TestIsRDSClusterSupported(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cluster := &rds.DBCluster{
+			cluster := &rdstypes.DBCluster{
 				DBClusterArn:        aws.String("arn:aws:rds:us-east-1:123456789012:cluster:test"),
 				DBClusterIdentifier: aws.String(test.name),
 				DbClusterResourceId: aws.String(uuid.New().String()),
@@ -1149,7 +1148,7 @@ func TestIsRDSInstanceSupported(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cluster := &rds.DBInstance{
+			cluster := &rdstypes.DBInstance{
 				DBInstanceArn:       aws.String("arn:aws:rds:us-east-1:123456789012:instance:test"),
 				DBClusterIdentifier: aws.String(test.name),
 				DbiResourceId:       aws.String(uuid.New().String()),

--- a/lib/srv/discovery/common/kubernetes_test.go
+++ b/lib/srv/discovery/common/kubernetes_test.go
@@ -98,9 +98,8 @@ func TestNewKubeClusterFromAWSEKS(t *testing.T) {
 			require.NoError(t, err)
 
 			cluster := &ekstypes.Cluster{
-				Name:   aws.String("cluster1"),
-				Arn:    aws.String("arn:aws:eks:eu-west-1:123456789012:cluster/cluster1"),
-				Status: ekstypes.ClusterStatusActive,
+				Name: aws.String("cluster1"),
+				Arn:  aws.String("arn:aws:eks:eu-west-1:123456789012:cluster/cluster1"),
 				Tags: map[string]string{
 					overrideLabel: "override-1",
 					"env":         "prod",

--- a/lib/srv/discovery/common/renaming_test.go
+++ b/lib/srv/discovery/common/renaming_test.go
@@ -28,14 +28,14 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise"
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
 	azureutils "github.com/gravitational/teleport/api/utils/azure"
-	libcloudaws "github.com/gravitational/teleport/lib/cloud/aws"
+	"github.com/gravitational/teleport/lib/cloud/awstesthelpers"
 	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/cloud/gcp"
 	"github.com/gravitational/teleport/lib/services"
@@ -365,7 +365,7 @@ func requireOverrideLabelSkipsRenaming(t *testing.T, r types.ResourceWithLabels,
 
 func makeAuroraPrimaryDB(t *testing.T, name, region, accountID, overrideLabel string) types.Database {
 	t.Helper()
-	cluster := &rds.DBCluster{
+	cluster := &rdstypes.DBCluster{
 		DBClusterArn:                     aws.String(fmt.Sprintf("arn:aws:rds:%s:%s:cluster:%v", region, accountID, name)),
 		DBClusterIdentifier:              aws.String("cluster-1"),
 		DbClusterResourceId:              aws.String("resource-1"),
@@ -373,29 +373,29 @@ func makeAuroraPrimaryDB(t *testing.T, name, region, accountID, overrideLabel st
 		Engine:                           aws.String("aurora-mysql"),
 		EngineVersion:                    aws.String("8.0.0"),
 		Endpoint:                         aws.String("localhost"),
-		Port:                             aws.Int64(3306),
-		TagList: libcloudaws.LabelsToTags[rds.Tag](map[string]string{
+		Port:                             aws.Int32(3306),
+		TagList: awstesthelpers.LabelsToRDSTags(map[string]string{
 			overrideLabel: name,
 		}),
 	}
-	database, err := NewDatabaseFromRDSCluster(cluster, []*rds.DBInstance{})
+	database, err := NewDatabaseFromRDSCluster(cluster, []rdstypes.DBInstance{})
 	require.NoError(t, err)
 	return database
 }
 
 func makeRDSInstanceDB(t *testing.T, name, region, accountID, overrideLabel string) types.Database {
 	t.Helper()
-	instance := &rds.DBInstance{
+	instance := &rdstypes.DBInstance{
 		DBInstanceArn:        aws.String(fmt.Sprintf("arn:aws:rds:%s:%s:db:%v", region, accountID, name)),
 		DBInstanceIdentifier: aws.String(name),
 		DbiResourceId:        aws.String(uuid.New().String()),
 		Engine:               aws.String(services.RDSEnginePostgres),
 		DBInstanceStatus:     aws.String("available"),
-		Endpoint: &rds.Endpoint{
+		Endpoint: &rdstypes.Endpoint{
 			Address: aws.String("localhost"),
-			Port:    aws.Int64(5432),
+			Port:    aws.Int32(5432),
 		},
-		TagList: libcloudaws.LabelsToTags[rds.Tag](map[string]string{
+		TagList: awstesthelpers.LabelsToRDSTags(map[string]string{
 			overrideLabel: name,
 		}),
 	}
@@ -499,9 +499,8 @@ func labelsToAzureTags(labels map[string]string) map[string]*string {
 func makeEKSKubeCluster(t *testing.T, name, region, accountID, overrideLabel string) types.KubeCluster {
 	t.Helper()
 	eksCluster := &ekstypes.Cluster{
-		Name:   aws.String(name),
-		Arn:    aws.String(fmt.Sprintf("arn:aws:eks:%s:%s:cluster/%s", region, accountID, name)),
-		Status: ekstypes.ClusterStatusActive,
+		Name: aws.String(name),
+		Arn:  aws.String(fmt.Sprintf("arn:aws:eks:%s:%s:cluster/%s", region, accountID, name)),
 		Tags: map[string]string{
 			overrideLabel: name,
 		},

--- a/lib/srv/discovery/fetchers/aws-sync/rds.go
+++ b/lib/srv/discovery/fetchers/aws-sync/rds.go
@@ -22,8 +22,9 @@ import (
 	"context"
 	"sync"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/gravitational/trace"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -31,12 +32,18 @@ import (
 	accessgraphv1alpha "github.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha"
 )
 
+// rdsClient defines a subset of the AWS RDS client API.
+type rdsClient interface {
+	rds.DescribeDBClustersAPIClient
+	rds.DescribeDBInstancesAPIClient
+}
+
 // pollAWSRDSDatabases is a function that returns a function that fetches
 // RDS instances and clusters.
 func (a *awsFetcher) pollAWSRDSDatabases(ctx context.Context, result *Resources, collectErr func(error)) func() error {
 	return func() error {
 		var err error
-		result.RDSDatabases, err = a.fetchAWSRDSDatabases(ctx, a.lastResult)
+		result.RDSDatabases, err = a.fetchAWSRDSDatabases(ctx)
 		if err != nil {
 			collectErr(trace.Wrap(err, "failed to fetch databases"))
 		}
@@ -45,7 +52,7 @@ func (a *awsFetcher) pollAWSRDSDatabases(ctx context.Context, result *Resources,
 }
 
 // fetchAWSRDSDatabases fetches RDS databases from all regions.
-func (a *awsFetcher) fetchAWSRDSDatabases(ctx context.Context, existing *Resources) (
+func (a *awsFetcher) fetchAWSRDSDatabases(ctx context.Context) (
 	[]*accessgraphv1alpha.AWSRDSDatabaseV1,
 	error,
 ) {
@@ -59,14 +66,14 @@ func (a *awsFetcher) fetchAWSRDSDatabases(ctx context.Context, existing *Resourc
 	// This is a temporary solution until we have a better way to limit the
 	// number of concurrent requests.
 	eG.SetLimit(5)
-	collectDBs := func(db *accessgraphv1alpha.AWSRDSDatabaseV1, err error) {
+	collectDBs := func(db []*accessgraphv1alpha.AWSRDSDatabaseV1, err error) {
 		hostsMu.Lock()
 		defer hostsMu.Unlock()
 		if err != nil {
 			errs = append(errs, err)
 		}
 		if db != nil {
-			dbs = append(dbs, db)
+			dbs = append(dbs, db...)
 		}
 
 	}
@@ -74,42 +81,14 @@ func (a *awsFetcher) fetchAWSRDSDatabases(ctx context.Context, existing *Resourc
 	for _, region := range a.Regions {
 		region := region
 		eG.Go(func() error {
-			rdsClient, err := a.CloudClients.GetAWSRDSClient(ctx, region, a.getAWSOptions()...)
+			awsCfg, err := a.AWSConfigProvider.GetConfig(ctx, region, a.getAWSV2Options()...)
 			if err != nil {
 				collectDBs(nil, trace.Wrap(err))
 				return nil
 			}
-			err = rdsClient.DescribeDBInstancesPagesWithContext(ctx, &rds.DescribeDBInstancesInput{},
-				func(output *rds.DescribeDBInstancesOutput, lastPage bool) bool {
-					for _, db := range output.DBInstances {
-						// if instance belongs to a cluster, skip it as we want to represent the cluster itself
-						// and we pull it using DescribeDBClustersPagesWithContext instead.
-						if aws.StringValue(db.DBClusterIdentifier) != "" {
-							continue
-						}
-						protoRDS := awsRDSInstanceToRDS(db, region, a.AccountID)
-						collectDBs(protoRDS, nil)
-					}
-					return !lastPage
-				},
-			)
-			if err != nil {
-				collectDBs(nil, trace.Wrap(err))
-			}
-
-			err = rdsClient.DescribeDBClustersPagesWithContext(ctx, &rds.DescribeDBClustersInput{},
-				func(output *rds.DescribeDBClustersOutput, lastPage bool) bool {
-					for _, db := range output.DBClusters {
-						protoRDS := awsRDSClusterToRDS(db, region, a.AccountID)
-						collectDBs(protoRDS, nil)
-					}
-					return !lastPage
-				},
-			)
-			if err != nil {
-				collectDBs(nil, trace.Wrap(err))
-			}
-
+			clt := a.awsClients.getRDSClient(awsCfg)
+			a.collectDBInstances(ctx, clt, region, collectDBs)
+			a.collectDBClusters(ctx, clt, region, collectDBs)
 			return nil
 		})
 	}
@@ -118,60 +97,123 @@ func (a *awsFetcher) fetchAWSRDSDatabases(ctx context.Context, existing *Resourc
 	return dbs, trace.NewAggregate(append(errs, err)...)
 }
 
-// awsRDSInstanceToRDS converts an rds.DBInstance to accessgraphv1alpha.AWSRDSDatabaseV1
+// awsRDSInstanceToRDS converts an rdstypes.DBInstance to accessgraphv1alpha.AWSRDSDatabaseV1
 // representation.
-func awsRDSInstanceToRDS(instance *rds.DBInstance, region, accountID string) *accessgraphv1alpha.AWSRDSDatabaseV1 {
+func awsRDSInstanceToRDS(instance *rdstypes.DBInstance, region, accountID string) *accessgraphv1alpha.AWSRDSDatabaseV1 {
 	var tags []*accessgraphv1alpha.AWSTag
 	for _, v := range instance.TagList {
 		tags = append(tags, &accessgraphv1alpha.AWSTag{
-			Key:   aws.StringValue(v.Key),
+			Key:   aws.ToString(v.Key),
 			Value: strPtrToWrapper(v.Value),
 		})
 	}
 
 	return &accessgraphv1alpha.AWSRDSDatabaseV1{
-		Name:      aws.StringValue(instance.DBInstanceIdentifier),
-		Arn:       aws.StringValue(instance.DBInstanceArn),
+		Name:      aws.ToString(instance.DBInstanceIdentifier),
+		Arn:       aws.ToString(instance.DBInstanceArn),
 		CreatedAt: awsTimeToProtoTime(instance.InstanceCreateTime),
-		Status:    aws.StringValue(instance.DBInstanceStatus),
+		Status:    aws.ToString(instance.DBInstanceStatus),
 		Region:    region,
 		AccountId: accountID,
 		Tags:      tags,
 		EngineDetails: &accessgraphv1alpha.AWSRDSEngineV1{
-			Engine:  aws.StringValue(instance.Engine),
-			Version: aws.StringValue(instance.EngineVersion),
+			Engine:  aws.ToString(instance.Engine),
+			Version: aws.ToString(instance.EngineVersion),
 		},
 		IsCluster:    false,
-		ResourceId:   aws.StringValue(instance.DbiResourceId),
+		ResourceId:   aws.ToString(instance.DbiResourceId),
 		LastSyncTime: timestamppb.Now(),
 	}
 }
 
-// awsRDSInstanceToRDS converts an rds.DBCluster to accessgraphv1alpha.AWSRDSDatabaseV1
+// awsRDSInstanceToRDS converts an rdstypes.DBCluster to accessgraphv1alpha.AWSRDSDatabaseV1
 // representation.
-func awsRDSClusterToRDS(instance *rds.DBCluster, region, accountID string) *accessgraphv1alpha.AWSRDSDatabaseV1 {
+func awsRDSClusterToRDS(instance *rdstypes.DBCluster, region, accountID string) *accessgraphv1alpha.AWSRDSDatabaseV1 {
 	var tags []*accessgraphv1alpha.AWSTag
 	for _, v := range instance.TagList {
 		tags = append(tags, &accessgraphv1alpha.AWSTag{
-			Key:   aws.StringValue(v.Key),
+			Key:   aws.ToString(v.Key),
 			Value: strPtrToWrapper(v.Value),
 		})
 	}
 
 	return &accessgraphv1alpha.AWSRDSDatabaseV1{
-		Name:      aws.StringValue(instance.DBClusterIdentifier),
-		Arn:       aws.StringValue(instance.DBClusterArn),
+		Name:      aws.ToString(instance.DBClusterIdentifier),
+		Arn:       aws.ToString(instance.DBClusterArn),
 		CreatedAt: awsTimeToProtoTime(instance.ClusterCreateTime),
-		Status:    aws.StringValue(instance.Status),
+		Status:    aws.ToString(instance.Status),
 		Region:    region,
 		AccountId: accountID,
 		Tags:      tags,
 		EngineDetails: &accessgraphv1alpha.AWSRDSEngineV1{
-			Engine:  aws.StringValue(instance.Engine),
-			Version: aws.StringValue(instance.EngineVersion),
+			Engine:  aws.ToString(instance.Engine),
+			Version: aws.ToString(instance.EngineVersion),
 		},
 		IsCluster:    true,
-		ResourceId:   aws.StringValue(instance.DbClusterResourceId),
+		ResourceId:   aws.ToString(instance.DbClusterResourceId),
 		LastSyncTime: timestamppb.Now(),
 	}
+}
+
+func (a *awsFetcher) collectDBInstances(ctx context.Context,
+	clt rdsClient,
+	region string,
+	collectDBs func([]*accessgraphv1alpha.AWSRDSDatabaseV1, error),
+) {
+	pager := rds.NewDescribeDBInstancesPaginator(clt,
+		&rds.DescribeDBInstancesInput{},
+		func(ddpo *rds.DescribeDBInstancesPaginatorOptions) {
+			ddpo.StopOnDuplicateToken = true
+		},
+	)
+	var instances []*accessgraphv1alpha.AWSRDSDatabaseV1
+	for pager.HasMorePages() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			old := sliceFilter(a.lastResult.RDSDatabases, func(db *accessgraphv1alpha.AWSRDSDatabaseV1) bool {
+				return !db.IsCluster && db.Region == region && db.AccountId == a.AccountID
+			})
+			collectDBs(old, trace.Wrap(err))
+			return
+		}
+		for _, db := range page.DBInstances {
+			// if instance belongs to a cluster, skip it as we want to represent the cluster itself
+			// and we pull it using DescribeDBClustersPaginator instead.
+			if aws.ToString(db.DBClusterIdentifier) != "" {
+				continue
+			}
+			protoRDS := awsRDSInstanceToRDS(&db, region, a.AccountID)
+			instances = append(instances, protoRDS)
+		}
+	}
+	collectDBs(instances, nil)
+}
+
+func (a *awsFetcher) collectDBClusters(
+	ctx context.Context,
+	clt rdsClient,
+	region string,
+	collectDBs func([]*accessgraphv1alpha.AWSRDSDatabaseV1, error),
+) {
+	pager := rds.NewDescribeDBClustersPaginator(clt, &rds.DescribeDBClustersInput{},
+		func(ddpo *rds.DescribeDBClustersPaginatorOptions) {
+			ddpo.StopOnDuplicateToken = true
+		},
+	)
+	var clusters []*accessgraphv1alpha.AWSRDSDatabaseV1
+	for pager.HasMorePages() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			old := sliceFilter(a.lastResult.RDSDatabases, func(db *accessgraphv1alpha.AWSRDSDatabaseV1) bool {
+				return db.IsCluster && db.Region == region && db.AccountId == a.AccountID
+			})
+			collectDBs(old, trace.Wrap(err))
+			return
+		}
+		for _, db := range page.DBClusters {
+			protoRDS := awsRDSClusterToRDS(&db, region, a.AccountID)
+			clusters = append(clusters, protoRDS)
+		}
+	}
+	collectDBs(clusters, nil)
 }

--- a/lib/srv/discovery/fetchers/aws-sync/rds_test.go
+++ b/lib/srv/discovery/fetchers/aws-sync/rds_test.go
@@ -20,19 +20,19 @@ package aws_sync
 
 import (
 	"context"
-	"sync"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	"github.com/gravitational/teleport/api/types"
 	accessgraphv1alpha "github.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha"
-	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/cloud/mocks"
 )
 
@@ -44,86 +44,117 @@ func TestPollAWSRDS(t *testing.T) {
 		regions = []string{"eu-west-1"}
 	)
 
+	awsOIDCIntegration, err := types.NewIntegrationAWSOIDC(
+		types.Metadata{Name: "integration-test"},
+		&types.AWSOIDCIntegrationSpecV1{
+			RoleARN: "arn:aws:sts::123456789012:role/TestRole",
+		},
+	)
+	require.NoError(t, err)
+
+	resourcesFixture := Resources{
+		RDSDatabases: []*accessgraphv1alpha.AWSRDSDatabaseV1{
+			{
+				Arn:    "arn:us-west1:rds:instance1",
+				Status: string(rdstypes.DBProxyStatusAvailable),
+				Name:   "db1",
+				EngineDetails: &accessgraphv1alpha.AWSRDSEngineV1{
+					Engine:  string(rdstypes.EngineFamilyMysql),
+					Version: "v1.1",
+				},
+				CreatedAt: timestamppb.New(date),
+				Tags: []*accessgraphv1alpha.AWSTag{
+					{
+						Key:   "tag",
+						Value: wrapperspb.String("val"),
+					},
+				},
+				Region:     "eu-west-1",
+				IsCluster:  false,
+				AccountId:  "12345678",
+				ResourceId: "db1",
+			},
+			{
+				Arn:    "arn:us-west1:rds:cluster1",
+				Status: string(rdstypes.DBProxyStatusAvailable),
+				Name:   "cluster1",
+				EngineDetails: &accessgraphv1alpha.AWSRDSEngineV1{
+					Engine:  string(rdstypes.EngineFamilyMysql),
+					Version: "v1.1",
+				},
+				CreatedAt: timestamppb.New(date),
+				Tags: []*accessgraphv1alpha.AWSTag{
+					{
+						Key:   "tag",
+						Value: wrapperspb.String("val"),
+					},
+				},
+				Region:     "eu-west-1",
+				IsCluster:  true,
+				AccountId:  "12345678",
+				ResourceId: "cluster1",
+			},
+		},
+	}
+
 	tests := []struct {
-		name string
-		want *Resources
+		name             string
+		fetcherConfigOpt func(*awsFetcher)
+		want             *Resources
+		checkError       func(*testing.T, error)
 	}{
 		{
 			name: "poll rds databases",
-			want: &Resources{
-				RDSDatabases: []*accessgraphv1alpha.AWSRDSDatabaseV1{
-					{
-						Arn:    "arn:us-west1:rds:instance1",
-						Status: rds.DBProxyStatusAvailable,
-						Name:   "db1",
-						EngineDetails: &accessgraphv1alpha.AWSRDSEngineV1{
-							Engine:  rds.EngineFamilyMysql,
-							Version: "v1.1",
-						},
-						CreatedAt: timestamppb.New(date),
-						Tags: []*accessgraphv1alpha.AWSTag{
-							{
-								Key:   "tag",
-								Value: wrapperspb.String("val"),
-							},
-						},
-						Region:     "eu-west-1",
-						IsCluster:  false,
-						AccountId:  "12345678",
-						ResourceId: "db1",
+			want: &resourcesFixture,
+			fetcherConfigOpt: func(a *awsFetcher) {
+				a.awsClients = fakeAWSClients{
+					rdsClient: &mocks.RDSClient{
+						DBInstances: dbInstances(),
+						DBClusters:  dbClusters(),
 					},
-					{
-						Arn:    "arn:us-west1:rds:cluster1",
-						Status: rds.DBProxyStatusAvailable,
-						Name:   "cluster1",
-						EngineDetails: &accessgraphv1alpha.AWSRDSEngineV1{
-							Engine:  rds.EngineFamilyMysql,
-							Version: "v1.1",
-						},
-						CreatedAt: timestamppb.New(date),
-						Tags: []*accessgraphv1alpha.AWSTag{
-							{
-								Key:   "tag",
-								Value: wrapperspb.String("val"),
-							},
-						},
-						Region:     "eu-west-1",
-						IsCluster:  true,
-						AccountId:  "12345678",
-						ResourceId: "cluster1",
-					},
-				},
+				}
+			},
+			checkError: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "reuse last synced databases on failure",
+			want: &resourcesFixture,
+			fetcherConfigOpt: func(a *awsFetcher) {
+				a.awsClients = fakeAWSClients{
+					rdsClient: &mocks.RDSClient{Unauth: true},
+				}
+				a.lastResult = &resourcesFixture
+			},
+			checkError: func(t *testing.T, err error) {
+				require.Error(t, err)
+				require.ErrorContains(t, err, "failed to fetch databases")
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockedClients := &cloud.TestCloudClients{
-				RDS: &mocks.RDSMock{
-					DBInstances: dbInstances(),
-					DBClusters:  dbClusters(),
-				},
-			}
-
-			var (
-				errs []error
-				mu   sync.Mutex
-			)
-
-			collectErr := func(err error) {
-				mu.Lock()
-				defer mu.Unlock()
-				errs = append(errs, err)
-			}
 			a := &awsFetcher{
 				Config: Config{
-					AccountID:    accountID,
-					CloudClients: mockedClients,
-					Regions:      regions,
-					Integration:  accountID,
+					AccountID: accountID,
+					AWSConfigProvider: &mocks.AWSConfigProvider{
+						OIDCIntegrationClient: &mocks.FakeOIDCIntegrationClient{
+							Integration: awsOIDCIntegration,
+							Token:       "fake-oidc-token",
+						},
+					},
+					Regions:     regions,
+					Integration: awsOIDCIntegration.GetName(),
 				},
 			}
+			if tt.fetcherConfigOpt != nil {
+				tt.fetcherConfigOpt(a)
+			}
 			result := &Resources{}
+			collectErr := func(err error) {
+				tt.checkError(t, err)
+			}
 			execFunc := a.pollAWSRDSDatabases(context.Background(), result, collectErr)
 			require.NoError(t, execFunc())
 			require.Empty(t, cmp.Diff(
@@ -144,16 +175,16 @@ func TestPollAWSRDS(t *testing.T) {
 	}
 }
 
-func dbInstances() []*rds.DBInstance {
-	return []*rds.DBInstance{
+func dbInstances() []rdstypes.DBInstance {
+	return []rdstypes.DBInstance{
 		{
 			DBInstanceIdentifier: aws.String("db1"),
 			DBInstanceArn:        aws.String("arn:us-west1:rds:instance1"),
 			InstanceCreateTime:   aws.Time(date),
-			Engine:               aws.String(rds.EngineFamilyMysql),
-			DBInstanceStatus:     aws.String(rds.DBProxyStatusAvailable),
+			Engine:               aws.String(string(rdstypes.EngineFamilyMysql)),
+			DBInstanceStatus:     aws.String(string(rdstypes.DBProxyStatusAvailable)),
 			EngineVersion:        aws.String("v1.1"),
-			TagList: []*rds.Tag{
+			TagList: []rdstypes.Tag{
 				{
 					Key:   aws.String("tag"),
 					Value: aws.String("val"),
@@ -164,16 +195,16 @@ func dbInstances() []*rds.DBInstance {
 	}
 }
 
-func dbClusters() []*rds.DBCluster {
-	return []*rds.DBCluster{
+func dbClusters() []rdstypes.DBCluster {
+	return []rdstypes.DBCluster{
 		{
 			DBClusterIdentifier: aws.String("cluster1"),
 			DBClusterArn:        aws.String("arn:us-west1:rds:cluster1"),
 			ClusterCreateTime:   aws.Time(date),
-			Engine:              aws.String(rds.EngineFamilyMysql),
-			Status:              aws.String(rds.DBProxyStatusAvailable),
+			Engine:              aws.String(string(rdstypes.EngineFamilyMysql)),
+			Status:              aws.String(string(rdstypes.DBProxyStatusAvailable)),
 			EngineVersion:       aws.String("v1.1"),
-			TagList: []*rds.Tag{
+			TagList: []rdstypes.Tag{
 				{
 					Key:   aws.String("tag"),
 					Value: aws.String("val"),
@@ -182,4 +213,12 @@ func dbClusters() []*rds.DBCluster {
 			DbClusterResourceId: aws.String("cluster1"),
 		},
 	}
+}
+
+type fakeAWSClients struct {
+	rdsClient rdsClient
+}
+
+func (f fakeAWSClients) getRDSClient(cfg aws.Config, optFns ...func(*rds.Options)) rdsClient {
+	return f.rdsClient
 }

--- a/lib/srv/discovery/fetchers/db/aws.go
+++ b/lib/srv/discovery/fetchers/db/aws.go
@@ -23,8 +23,6 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/redshift"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
@@ -74,8 +72,8 @@ type awsFetcherConfig struct {
 	// ie teleport.yaml/discovery_service.<cloud>.<matcher>
 	DiscoveryConfigName string
 
-	// redshiftClientProviderFn provides an AWS Redshift client.
-	redshiftClientProviderFn RedshiftClientProviderFunc
+	// awsClients provides AWS SDK v2 clients.
+	awsClients AWSClientProvider
 }
 
 // CheckAndSetDefaults validates the config and sets defaults.
@@ -109,10 +107,8 @@ func (cfg *awsFetcherConfig) CheckAndSetDefaults(component string) error {
 		)
 	}
 
-	if cfg.redshiftClientProviderFn == nil {
-		cfg.redshiftClientProviderFn = func(cfg aws.Config, optFns ...func(*redshift.Options)) RedshiftClient {
-			return redshift.NewFromConfig(cfg, optFns...)
-		}
+	if cfg.awsClients == nil {
+		cfg.awsClients = defaultAWSClients{}
 	}
 	return nil
 }

--- a/lib/srv/discovery/fetchers/db/aws_docdb.go
+++ b/lib/srv/discovery/fetchers/db/aws_docdb.go
@@ -21,14 +21,14 @@ package db
 import (
 	"context"
 
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/rds"
-	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/cloud"
 	libcloudaws "github.com/gravitational/teleport/lib/cloud/aws"
+	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
 )
 
@@ -39,13 +39,6 @@ func newDocumentDBFetcher(cfg awsFetcherConfig) (common.Fetcher, error) {
 }
 
 // rdsDocumentDBFetcher retrieves DocumentDB clusters.
-//
-// Note that AWS DocumentDB internally uses the RDS APIs:
-// https://github.com/aws/aws-sdk-go/blob/3248e69e16aa601ffa929be53a52439425257e5e/service/docdb/service.go#L33
-// The interfaces/structs in "services/docdb" are usually a subset of those in
-// "services/rds".
-//
-// TODO(greedy52) switch to aws-sdk-go-v2/services/docdb.
 type rdsDocumentDBFetcher struct{}
 
 func (f *rdsDocumentDBFetcher) ComponentShortName() string {
@@ -54,21 +47,22 @@ func (f *rdsDocumentDBFetcher) ComponentShortName() string {
 
 // GetDatabases returns a list of database resources representing DocumentDB endpoints.
 func (f *rdsDocumentDBFetcher) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
-	rdsClient, err := cfg.AWSClients.GetAWSRDSClient(ctx, cfg.Region,
-		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
-		cloud.WithCredentialsMaybeIntegration(cfg.Integration),
+	awsCfg, err := cfg.AWSConfigProvider.GetConfig(ctx, cfg.Region,
+		awsconfig.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
+		awsconfig.WithCredentialsMaybeIntegration(cfg.Integration),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	clusters, err := f.getAllDBClusters(ctx, rdsClient)
+	clt := cfg.awsClients.GetRDSClient(awsCfg)
+	clusters, err := f.getAllDBClusters(ctx, clt)
 	if err != nil {
-		return nil, trace.Wrap(libcloudaws.ConvertRequestFailureError(err))
+		return nil, trace.Wrap(err)
 	}
 
 	databases := make(types.Databases, 0)
 	for _, cluster := range clusters {
-		if !libcloudaws.IsDocumentDBClusterSupported(cluster) {
+		if !libcloudaws.IsDocumentDBClusterSupported(&cluster) {
 			cfg.Logger.DebugContext(ctx, "DocumentDB cluster doesn't support IAM authentication. Skipping.",
 				"cluster", aws.StringValue(cluster.DBClusterIdentifier),
 				"engine_version", aws.StringValue(cluster.EngineVersion))
@@ -82,7 +76,7 @@ func (f *rdsDocumentDBFetcher) GetDatabases(ctx context.Context, cfg *awsFetcher
 			continue
 		}
 
-		dbs, err := common.NewDatabasesFromDocumentDBCluster(cluster)
+		dbs, err := common.NewDatabasesFromDocumentDBCluster(&cluster)
 		if err != nil {
 			cfg.Logger.WarnContext(ctx, "Could not convert DocumentDB cluster to database resources.",
 				"cluster", aws.StringValue(cluster.DBClusterIdentifier),
@@ -93,15 +87,23 @@ func (f *rdsDocumentDBFetcher) GetDatabases(ctx context.Context, cfg *awsFetcher
 	return databases, nil
 }
 
-func (f *rdsDocumentDBFetcher) getAllDBClusters(ctx context.Context, rdsClient rdsiface.RDSAPI) ([]*rds.DBCluster, error) {
-	var pageNum int
-	var clusters []*rds.DBCluster
-	err := rdsClient.DescribeDBClustersPagesWithContext(ctx, &rds.DescribeDBClustersInput{
-		Filters: rdsEngineFilter([]string{"docdb"}),
-	}, func(ddo *rds.DescribeDBClustersOutput, lastPage bool) bool {
-		pageNum++
-		clusters = append(clusters, ddo.DBClusters...)
-		return pageNum <= maxAWSPages
-	})
-	return clusters, trace.Wrap(err)
+func (f *rdsDocumentDBFetcher) getAllDBClusters(ctx context.Context, clt RDSClient) ([]rdstypes.DBCluster, error) {
+	pager := rds.NewDescribeDBClustersPaginator(clt,
+		&rds.DescribeDBClustersInput{
+			Filters: rdsEngineFilter([]string{"docdb"}),
+		},
+		func(pagerOpts *rds.DescribeDBClustersPaginatorOptions) {
+			pagerOpts.StopOnDuplicateToken = true
+		},
+	)
+
+	var clusters []rdstypes.DBCluster
+	for i := 0; i < maxAWSPages && pager.HasMorePages(); i++ {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, trace.Wrap(libcloudaws.ConvertRequestFailureErrorV2(err))
+		}
+		clusters = append(clusters, page.DBClusters...)
+	}
+	return clusters, nil
 }

--- a/lib/srv/discovery/fetchers/db/aws_rds.go
+++ b/lib/srv/discovery/fetchers/db/aws_rds.go
@@ -23,17 +23,26 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/rds"
-	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/cloud"
 	libcloudaws "github.com/gravitational/teleport/lib/cloud/aws"
+	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
 )
+
+// RDSClient is a subset of the AWS RDS API.
+type RDSClient interface {
+	rds.DescribeDBClustersAPIClient
+	rds.DescribeDBInstancesAPIClient
+	rds.DescribeDBProxiesAPIClient
+	rds.DescribeDBProxyEndpointsAPIClient
+	ListTagsForResource(context.Context, *rds.ListTagsForResourceInput, ...func(*rds.Options)) (*rds.ListTagsForResourceOutput, error)
+}
 
 // newRDSDBInstancesFetcher returns a new AWS fetcher for RDS databases.
 func newRDSDBInstancesFetcher(cfg awsFetcherConfig) (common.Fetcher, error) {
@@ -49,40 +58,41 @@ func (f *rdsDBInstancesPlugin) ComponentShortName() string {
 
 // GetDatabases returns a list of database resources representing RDS instances.
 func (f *rdsDBInstancesPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
-	rdsClient, err := cfg.AWSClients.GetAWSRDSClient(ctx, cfg.Region,
-		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
-		cloud.WithCredentialsMaybeIntegration(cfg.Integration),
+	awsCfg, err := cfg.AWSConfigProvider.GetConfig(ctx, cfg.Region,
+		awsconfig.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
+		awsconfig.WithCredentialsMaybeIntegration(cfg.Integration),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	instances, err := getAllDBInstances(ctx, rdsClient, maxAWSPages, cfg.Logger)
+	clt := cfg.awsClients.GetRDSClient(awsCfg)
+	instances, err := getAllDBInstances(ctx, clt, maxAWSPages, cfg.Logger)
 	if err != nil {
-		return nil, trace.Wrap(libcloudaws.ConvertRequestFailureError(err))
+		return nil, trace.Wrap(err)
 	}
 	databases := make(types.Databases, 0, len(instances))
 	for _, instance := range instances {
-		if !libcloudaws.IsRDSInstanceSupported(instance) {
+		if !libcloudaws.IsRDSInstanceSupported(&instance) {
 			cfg.Logger.DebugContext(ctx, "Skipping RDS instance that does not support IAM authentication",
-				"instance", aws.StringValue(instance.DBInstanceIdentifier),
-				"engine_mode", aws.StringValue(instance.Engine),
-				"engine_version", aws.StringValue(instance.EngineVersion),
+				"instance", aws.ToString(instance.DBInstanceIdentifier),
+				"engine_mode", aws.ToString(instance.Engine),
+				"engine_version", aws.ToString(instance.EngineVersion),
 			)
 			continue
 		}
 
 		if !libcloudaws.IsRDSInstanceAvailable(instance.DBInstanceStatus, instance.DBInstanceIdentifier) {
 			cfg.Logger.DebugContext(ctx, "Skipping unavailable RDS instance",
-				"instance", aws.StringValue(instance.DBInstanceIdentifier),
-				"status", aws.StringValue(instance.DBInstanceStatus),
+				"instance", aws.ToString(instance.DBInstanceIdentifier),
+				"status", aws.ToString(instance.DBInstanceStatus),
 			)
 			continue
 		}
 
-		database, err := common.NewDatabaseFromRDSInstance(instance)
+		database, err := common.NewDatabaseFromRDSInstance(&instance)
 		if err != nil {
 			cfg.Logger.WarnContext(ctx, "Could not convert RDS instance to database resource",
-				"instance", aws.StringValue(instance.DBInstanceIdentifier),
+				"instance", aws.ToString(instance.DBInstanceIdentifier),
 				"error", err,
 			)
 		} else {
@@ -94,36 +104,40 @@ func (f *rdsDBInstancesPlugin) GetDatabases(ctx context.Context, cfg *awsFetcher
 
 // getAllDBInstances fetches all RDS instances using the provided client, up
 // to the specified max number of pages.
-func getAllDBInstances(ctx context.Context, rdsClient rdsiface.RDSAPI, maxPages int, logger *slog.Logger) ([]*rds.DBInstance, error) {
-	return getAllDBInstancesWithFilters(ctx, rdsClient, maxPages, rdsInstanceEngines(), rdsEmptyFilter(), logger)
+func getAllDBInstances(ctx context.Context, clt RDSClient, maxPages int, logger *slog.Logger) ([]rdstypes.DBInstance, error) {
+	return getAllDBInstancesWithFilters(ctx, clt, maxPages, rdsInstanceEngines(), rdsEmptyFilter(), logger)
 }
 
 // findDBInstancesForDBCluster returns the DBInstances associated with a given DB Cluster Identifier
-func findDBInstancesForDBCluster(ctx context.Context, rdsClient rdsiface.RDSAPI, maxPages int, dbClusterIdentifier string, logger *slog.Logger) ([]*rds.DBInstance, error) {
-	return getAllDBInstancesWithFilters(ctx, rdsClient, maxPages, auroraEngines(), rdsClusterIDFilter(dbClusterIdentifier), logger)
+func findDBInstancesForDBCluster(ctx context.Context, clt RDSClient, maxPages int, dbClusterIdentifier string, logger *slog.Logger) ([]rdstypes.DBInstance, error) {
+	return getAllDBInstancesWithFilters(ctx, clt, maxPages, auroraEngines(), rdsClusterIDFilter(dbClusterIdentifier), logger)
 }
 
 // getAllDBInstancesWithFilters fetches all RDS instances matching the filters using the provided client, up
 // to the specified max number of pages.
-func getAllDBInstancesWithFilters(ctx context.Context, rdsClient rdsiface.RDSAPI, maxPages int, engines []string, baseFilters []*rds.Filter, logger *slog.Logger) ([]*rds.DBInstance, error) {
-	var instances []*rds.DBInstance
-	err := retryWithIndividualEngineFilters(ctx, logger, engines, func(engineFilters []*rds.Filter) error {
-		var pageNum int
-		var out []*rds.DBInstance
-		err := rdsClient.DescribeDBInstancesPagesWithContext(ctx, &rds.DescribeDBInstancesInput{
-			Filters: append(engineFilters, baseFilters...),
-		}, func(ddo *rds.DescribeDBInstancesOutput, lastPage bool) bool {
-			pageNum++
-			instances = append(instances, ddo.DBInstances...)
-			return pageNum <= maxPages
-		})
-		if err == nil {
-			// only append to instances on nil error, just in case we have to retry.
-			instances = append(instances, out...)
+func getAllDBInstancesWithFilters(ctx context.Context, clt RDSClient, maxPages int, engines []string, baseFilters []rdstypes.Filter, logger *slog.Logger) ([]rdstypes.DBInstance, error) {
+	var out []rdstypes.DBInstance
+	err := retryWithIndividualEngineFilters(ctx, logger, engines, func(engineFilters []rdstypes.Filter) error {
+		pager := rds.NewDescribeDBInstancesPaginator(clt,
+			&rds.DescribeDBInstancesInput{
+				Filters: append(engineFilters, baseFilters...),
+			},
+			func(dcpo *rds.DescribeDBInstancesPaginatorOptions) {
+				dcpo.StopOnDuplicateToken = true
+			},
+		)
+		var instances []rdstypes.DBInstance
+		for i := 0; i < maxPages && pager.HasMorePages(); i++ {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			instances = append(instances, page.DBInstances...)
 		}
-		return trace.Wrap(err)
+		out = instances
+		return nil
 	})
-	return instances, trace.Wrap(err)
+	return out, trace.Wrap(libcloudaws.ConvertRequestFailureErrorV2(err))
 }
 
 // newRDSAuroraClustersFetcher returns a new AWS fetcher for RDS Aurora
@@ -141,48 +155,49 @@ func (f *rdsAuroraClustersPlugin) ComponentShortName() string {
 
 // GetDatabases returns a list of database resources representing RDS clusters.
 func (f *rdsAuroraClustersPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
-	rdsClient, err := cfg.AWSClients.GetAWSRDSClient(ctx, cfg.Region,
-		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
-		cloud.WithCredentialsMaybeIntegration(cfg.Integration),
+	awsCfg, err := cfg.AWSConfigProvider.GetConfig(ctx, cfg.Region,
+		awsconfig.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
+		awsconfig.WithCredentialsMaybeIntegration(cfg.Integration),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	clusters, err := getAllDBClusters(ctx, rdsClient, maxAWSPages, cfg.Logger)
+	clt := cfg.awsClients.GetRDSClient(awsCfg)
+	clusters, err := getAllDBClusters(ctx, clt, maxAWSPages, cfg.Logger)
 	if err != nil {
-		return nil, trace.Wrap(libcloudaws.ConvertRequestFailureError(err))
+		return nil, trace.Wrap(err)
 	}
 	databases := make(types.Databases, 0, len(clusters))
 	for _, cluster := range clusters {
-		if !libcloudaws.IsRDSClusterSupported(cluster) {
+		if !libcloudaws.IsRDSClusterSupported(&cluster) {
 			cfg.Logger.DebugContext(ctx, "Skipping Aurora cluster that does not support IAM authentication",
-				"cluster", aws.StringValue(cluster.DBClusterIdentifier),
-				"engine_mode", aws.StringValue(cluster.EngineMode),
-				"engine_version", aws.StringValue(cluster.EngineVersion),
+				"cluster", aws.ToString(cluster.DBClusterIdentifier),
+				"engine_mode", aws.ToString(cluster.EngineMode),
+				"engine_version", aws.ToString(cluster.EngineVersion),
 			)
 			continue
 		}
 
 		if !libcloudaws.IsDBClusterAvailable(cluster.Status, cluster.DBClusterIdentifier) {
 			cfg.Logger.DebugContext(ctx, "Skipping unavailable Aurora cluster",
-				"instance", aws.StringValue(cluster.DBClusterIdentifier),
-				"status", aws.StringValue(cluster.Status),
+				"instance", aws.ToString(cluster.DBClusterIdentifier),
+				"status", aws.ToString(cluster.Status),
 			)
 			continue
 		}
 
-		rdsDBInstances, err := findDBInstancesForDBCluster(ctx, rdsClient, maxAWSPages, aws.StringValue(cluster.DBClusterIdentifier), cfg.Logger)
+		rdsDBInstances, err := findDBInstancesForDBCluster(ctx, clt, maxAWSPages, aws.ToString(cluster.DBClusterIdentifier), cfg.Logger)
 		if err != nil || len(rdsDBInstances) == 0 {
 			cfg.Logger.WarnContext(ctx, "Could not fetch Member Instance for DB Cluster",
-				"instance", aws.StringValue(cluster.DBClusterIdentifier),
+				"instance", aws.ToString(cluster.DBClusterIdentifier),
 				"error", err,
 			)
 		}
 
-		dbs, err := common.NewDatabasesFromRDSCluster(cluster, rdsDBInstances)
+		dbs, err := common.NewDatabasesFromRDSCluster(&cluster, rdsDBInstances)
 		if err != nil {
 			cfg.Logger.WarnContext(ctx, "Could not convert RDS cluster to database resources",
-				"identifier", aws.StringValue(cluster.DBClusterIdentifier),
+				"identifier", aws.ToString(cluster.DBClusterIdentifier),
 				"error", err,
 			)
 		}
@@ -193,25 +208,30 @@ func (f *rdsAuroraClustersPlugin) GetDatabases(ctx context.Context, cfg *awsFetc
 
 // getAllDBClusters fetches all RDS clusters using the provided client, up to
 // the specified max number of pages.
-func getAllDBClusters(ctx context.Context, rdsClient rdsiface.RDSAPI, maxPages int, logger *slog.Logger) ([]*rds.DBCluster, error) {
-	var clusters []*rds.DBCluster
-	err := retryWithIndividualEngineFilters(ctx, logger, auroraEngines(), func(filters []*rds.Filter) error {
-		var pageNum int
-		var out []*rds.DBCluster
-		err := rdsClient.DescribeDBClustersPagesWithContext(ctx, &rds.DescribeDBClustersInput{
-			Filters: filters,
-		}, func(ddo *rds.DescribeDBClustersOutput, lastPage bool) bool {
-			pageNum++
-			out = append(out, ddo.DBClusters...)
-			return pageNum <= maxPages
-		})
-		if err == nil {
-			// only append to clusters on nil error, just in case we have to retry.
-			clusters = append(clusters, out...)
+func getAllDBClusters(ctx context.Context, clt RDSClient, maxPages int, logger *slog.Logger) ([]rdstypes.DBCluster, error) {
+	var out []rdstypes.DBCluster
+	err := retryWithIndividualEngineFilters(ctx, logger, auroraEngines(), func(filters []rdstypes.Filter) error {
+		pager := rds.NewDescribeDBClustersPaginator(clt,
+			&rds.DescribeDBClustersInput{
+				Filters: filters,
+			},
+			func(pagerOpts *rds.DescribeDBClustersPaginatorOptions) {
+				pagerOpts.StopOnDuplicateToken = true
+			},
+		)
+
+		var clusters []rdstypes.DBCluster
+		for i := 0; i < maxPages && pager.HasMorePages(); i++ {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			clusters = append(clusters, page.DBClusters...)
 		}
-		return trace.Wrap(err)
+		out = clusters
+		return nil
 	})
-	return clusters, trace.Wrap(err)
+	return out, trace.Wrap(libcloudaws.ConvertRequestFailureErrorV2(err))
 }
 
 // rdsInstanceEngines returns engines to make sure DescribeDBInstances call returns
@@ -234,28 +254,28 @@ func auroraEngines() []string {
 }
 
 // rdsEngineFilter is a helper func to construct an RDS filter for engine names.
-func rdsEngineFilter(engines []string) []*rds.Filter {
-	return []*rds.Filter{{
+func rdsEngineFilter(engines []string) []rdstypes.Filter {
+	return []rdstypes.Filter{{
 		Name:   aws.String("engine"),
-		Values: aws.StringSlice(engines),
+		Values: engines,
 	}}
 }
 
 // rdsClusterIDFilter is a helper func to construct an RDS DB Instances for returning Instances of a specific DB Cluster.
-func rdsClusterIDFilter(clusterIdentifier string) []*rds.Filter {
-	return []*rds.Filter{{
+func rdsClusterIDFilter(clusterIdentifier string) []rdstypes.Filter {
+	return []rdstypes.Filter{{
 		Name:   aws.String("db-cluster-id"),
-		Values: aws.StringSlice([]string{clusterIdentifier}),
+		Values: []string{clusterIdentifier},
 	}}
 }
 
 // rdsEmptyFilter is a helper func to construct an empty RDS filter.
-func rdsEmptyFilter() []*rds.Filter {
-	return []*rds.Filter{}
+func rdsEmptyFilter() []rdstypes.Filter {
+	return []rdstypes.Filter{}
 }
 
 // rdsFilterFn is a function that takes RDS filters and performs some operation with them, returning any error encountered.
-type rdsFilterFn func([]*rds.Filter) error
+type rdsFilterFn func([]rdstypes.Filter) error
 
 // retryWithIndividualEngineFilters is a helper error handling function for AWS RDS unrecognized engine name filter errors,
 // that will call the provided RDS querying function with filters, check the returned error,

--- a/lib/srv/discovery/fetchers/db/aws_rds_proxy.go
+++ b/lib/srv/discovery/fetchers/db/aws_rds_proxy.go
@@ -21,14 +21,14 @@ package db
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/rds"
-	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/cloud"
 	libcloudaws "github.com/gravitational/teleport/lib/cloud/aws"
+	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
 )
 
@@ -47,56 +47,57 @@ func (f *rdsDBProxyPlugin) ComponentShortName() string {
 // GetDatabases returns a list of database resources representing RDS
 // Proxies and custom endpoints.
 func (f *rdsDBProxyPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
-	rdsClient, err := cfg.AWSClients.GetAWSRDSClient(ctx, cfg.Region,
-		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
-		cloud.WithCredentialsMaybeIntegration(cfg.Integration),
+	awsCfg, err := cfg.AWSConfigProvider.GetConfig(ctx, cfg.Region,
+		awsconfig.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
+		awsconfig.WithCredentialsMaybeIntegration(cfg.Integration),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	clt := cfg.awsClients.GetRDSClient(awsCfg)
 	// Get a list of all RDS Proxies. Each RDS Proxy has one "default"
 	// endpoint.
-	rdsProxies, err := getRDSProxies(ctx, rdsClient, maxAWSPages)
+	rdsProxies, err := getRDSProxies(ctx, clt, maxAWSPages)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	// Get all RDS Proxy custom endpoints sorted by the name of the RDS Proxy
 	// that owns the custom endpoints.
-	customEndpointsByProxyName, err := getRDSProxyCustomEndpoints(ctx, rdsClient, maxAWSPages)
+	customEndpointsByProxyName, err := getRDSProxyCustomEndpoints(ctx, clt, maxAWSPages)
 	if err != nil {
 		cfg.Logger.DebugContext(ctx, "Failed to get RDS Proxy endpoints", "error", err)
 	}
 
 	var databases types.Databases
 	for _, dbProxy := range rdsProxies {
-		if !aws.BoolValue(dbProxy.RequireTLS) {
-			cfg.Logger.DebugContext(ctx, "Skipping RDS Proxy that doesn't support TLS", "rds_proxy", aws.StringValue(dbProxy.DBProxyName))
+		if !aws.ToBool(dbProxy.RequireTLS) {
+			cfg.Logger.DebugContext(ctx, "Skipping RDS Proxy that doesn't support TLS", "rds_proxy", aws.ToString(dbProxy.DBProxyName))
 			continue
 		}
 
-		if !libcloudaws.IsRDSProxyAvailable(dbProxy) {
+		if !libcloudaws.IsRDSProxyAvailable(&dbProxy) {
 			cfg.Logger.DebugContext(ctx, "Skipping unavailable RDS Proxy",
-				"rds_proxy", aws.StringValue(dbProxy.DBProxyName),
-				"status", aws.StringValue(dbProxy.Status))
+				"rds_proxy", aws.ToString(dbProxy.DBProxyName),
+				"status", dbProxy.Status)
 			continue
 		}
 
-		// rds.DBProxy has no tags information. An extra SDK call is made to
+		// rdstypes.DBProxy has no tags information. An extra SDK call is made to
 		// fetch the tags. If failed, keep going without the tags.
-		tags, err := listRDSResourceTags(ctx, rdsClient, dbProxy.DBProxyArn)
+		tags, err := listRDSResourceTags(ctx, clt, dbProxy.DBProxyArn)
 		if err != nil {
 			cfg.Logger.DebugContext(ctx, "Failed to get tags for RDS Proxy",
-				"rds_proxy", aws.StringValue(dbProxy.DBProxyName),
+				"rds_proxy", aws.ToString(dbProxy.DBProxyName),
 				"error", err,
 			)
 		}
 
 		// Add a database from RDS Proxy (default endpoint).
-		database, err := common.NewDatabaseFromRDSProxy(dbProxy, tags)
+		database, err := common.NewDatabaseFromRDSProxy(&dbProxy, tags)
 		if err != nil {
 			cfg.Logger.DebugContext(ctx, "Could not convert RDS Proxy to database resource",
-				"rds_proxy", aws.StringValue(dbProxy.DBProxyName),
+				"rds_proxy", aws.ToString(dbProxy.DBProxyName),
 				"error", err,
 			)
 		} else {
@@ -104,21 +105,21 @@ func (f *rdsDBProxyPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConf
 		}
 
 		// Add custom endpoints.
-		for _, customEndpoint := range customEndpointsByProxyName[aws.StringValue(dbProxy.DBProxyName)] {
-			if !libcloudaws.IsRDSProxyCustomEndpointAvailable(customEndpoint) {
+		for _, customEndpoint := range customEndpointsByProxyName[aws.ToString(dbProxy.DBProxyName)] {
+			if !libcloudaws.IsRDSProxyCustomEndpointAvailable(&customEndpoint) {
 				cfg.Logger.DebugContext(ctx, "Skipping unavailable custom endpoint of RDS Proxy",
-					"endpoint", aws.StringValue(customEndpoint.DBProxyEndpointName),
-					"rds_proxy", aws.StringValue(customEndpoint.DBProxyName),
-					"status", aws.StringValue(customEndpoint.Status),
+					"endpoint", aws.ToString(customEndpoint.DBProxyEndpointName),
+					"rds_proxy", aws.ToString(customEndpoint.DBProxyName),
+					"status", customEndpoint.Status,
 				)
 				continue
 			}
 
-			database, err = common.NewDatabaseFromRDSProxyCustomEndpoint(dbProxy, customEndpoint, tags)
+			database, err = common.NewDatabaseFromRDSProxyCustomEndpoint(&dbProxy, &customEndpoint, tags)
 			if err != nil {
 				cfg.Logger.DebugContext(ctx, "Could not convert custom endpoint for RDS Proxy to database resource",
-					"endpoint", aws.StringValue(customEndpoint.DBProxyEndpointName),
-					"rds_proxy", aws.StringValue(customEndpoint.DBProxyName),
+					"endpoint", aws.ToString(customEndpoint.DBProxyEndpointName),
+					"rds_proxy", aws.ToString(customEndpoint.DBProxyName),
 					"error", err,
 				)
 				continue
@@ -132,46 +133,54 @@ func (f *rdsDBProxyPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConf
 
 // getRDSProxies fetches all RDS Proxies using the provided client, up to the
 // specified max number of pages.
-func getRDSProxies(ctx context.Context, rdsClient rdsiface.RDSAPI, maxPages int) (rdsProxies []*rds.DBProxy, err error) {
-	var pageNum int
-	err = rdsClient.DescribeDBProxiesPagesWithContext(
-		ctx,
+func getRDSProxies(ctx context.Context, clt RDSClient, maxPages int) ([]rdstypes.DBProxy, error) {
+	pager := rds.NewDescribeDBProxiesPaginator(clt,
 		&rds.DescribeDBProxiesInput{},
-		func(ddo *rds.DescribeDBProxiesOutput, lastPage bool) bool {
-			pageNum++
-			rdsProxies = append(rdsProxies, ddo.DBProxies...)
-			return pageNum <= maxPages
+		func(dcpo *rds.DescribeDBProxiesPaginatorOptions) {
+			dcpo.StopOnDuplicateToken = true
 		},
 	)
-	return rdsProxies, trace.Wrap(libcloudaws.ConvertRequestFailureError(err))
+
+	var rdsProxies []rdstypes.DBProxy
+	for i := 0; i < maxPages && pager.HasMorePages(); i++ {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, trace.Wrap(libcloudaws.ConvertRequestFailureErrorV2(err))
+		}
+		rdsProxies = append(rdsProxies, page.DBProxies...)
+	}
+	return rdsProxies, nil
 }
 
 // getRDSProxyCustomEndpoints fetches all RDS Proxy custom endpoints using the
 // provided client.
-func getRDSProxyCustomEndpoints(ctx context.Context, rdsClient rdsiface.RDSAPI, maxPages int) (map[string][]*rds.DBProxyEndpoint, error) {
-	customEndpointsByProxyName := make(map[string][]*rds.DBProxyEndpoint)
-	var pageNum int
-	err := rdsClient.DescribeDBProxyEndpointsPagesWithContext(
-		ctx,
+func getRDSProxyCustomEndpoints(ctx context.Context, clt RDSClient, maxPages int) (map[string][]rdstypes.DBProxyEndpoint, error) {
+	customEndpointsByProxyName := make(map[string][]rdstypes.DBProxyEndpoint)
+	pager := rds.NewDescribeDBProxyEndpointsPaginator(clt,
 		&rds.DescribeDBProxyEndpointsInput{},
-		func(ddo *rds.DescribeDBProxyEndpointsOutput, lastPage bool) bool {
-			pageNum++
-			for _, customEndpoint := range ddo.DBProxyEndpoints {
-				customEndpointsByProxyName[aws.StringValue(customEndpoint.DBProxyName)] = append(customEndpointsByProxyName[aws.StringValue(customEndpoint.DBProxyName)], customEndpoint)
-			}
-			return pageNum <= maxPages
+		func(ddepo *rds.DescribeDBProxyEndpointsPaginatorOptions) {
+			ddepo.StopOnDuplicateToken = true
 		},
 	)
-	return customEndpointsByProxyName, trace.Wrap(libcloudaws.ConvertRequestFailureError(err))
+	for i := 0; i < maxPages && pager.HasMorePages(); i++ {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, trace.Wrap(libcloudaws.ConvertRequestFailureErrorV2(err))
+		}
+		for _, customEndpoint := range page.DBProxyEndpoints {
+			customEndpointsByProxyName[aws.ToString(customEndpoint.DBProxyName)] = append(customEndpointsByProxyName[aws.ToString(customEndpoint.DBProxyName)], customEndpoint)
+		}
+	}
+	return customEndpointsByProxyName, nil
 }
 
 // listRDSResourceTags returns tags for provided RDS resource.
-func listRDSResourceTags(ctx context.Context, rdsClient rdsiface.RDSAPI, resourceName *string) ([]*rds.Tag, error) {
-	output, err := rdsClient.ListTagsForResourceWithContext(ctx, &rds.ListTagsForResourceInput{
+func listRDSResourceTags(ctx context.Context, clt RDSClient, resourceName *string) ([]rdstypes.Tag, error) {
+	output, err := clt.ListTagsForResource(ctx, &rds.ListTagsForResourceInput{
 		ResourceName: resourceName,
 	})
 	if err != nil {
-		return nil, trace.Wrap(libcloudaws.ConvertRequestFailureError(err))
+		return nil, trace.Wrap(libcloudaws.ConvertRequestFailureErrorV2(err))
 	}
 	return output.TagList, nil
 }

--- a/lib/srv/discovery/fetchers/db/aws_rds_proxy_test.go
+++ b/lib/srv/discovery/fetchers/db/aws_rds_proxy_test.go
@@ -21,11 +21,10 @@ package db
 import (
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/rds"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/cloud/mocks"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
 )
@@ -41,10 +40,12 @@ func TestRDSDBProxyFetcher(t *testing.T) {
 	tests := []awsFetcherTest{
 		{
 			name: "fetch all",
-			inputClients: &cloud.TestCloudClients{
-				RDS: &mocks.RDSMock{
-					DBProxies:        []*rds.DBProxy{rdsProxyVpc1, rdsProxyVpc2},
-					DBProxyEndpoints: []*rds.DBProxyEndpoint{rdsProxyEndpointVpc1, rdsProxyEndpointVpc2},
+			fetcherCfg: AWSFetcherFactoryConfig{
+				AWSClients: fakeAWSClients{
+					rdsClient: &mocks.RDSClient{
+						DBProxies:        []rdstypes.DBProxy{*rdsProxyVpc1, *rdsProxyVpc2},
+						DBProxyEndpoints: []rdstypes.DBProxyEndpoint{*rdsProxyEndpointVpc1, *rdsProxyEndpointVpc2},
+					},
 				},
 			},
 			inputMatchers: makeAWSMatchersForType(types.AWSMatcherRDSProxy, "us-east-1", wildcardLabels),
@@ -52,10 +53,12 @@ func TestRDSDBProxyFetcher(t *testing.T) {
 		},
 		{
 			name: "fetch vpc1",
-			inputClients: &cloud.TestCloudClients{
-				RDS: &mocks.RDSMock{
-					DBProxies:        []*rds.DBProxy{rdsProxyVpc1, rdsProxyVpc2},
-					DBProxyEndpoints: []*rds.DBProxyEndpoint{rdsProxyEndpointVpc1, rdsProxyEndpointVpc2},
+			fetcherCfg: AWSFetcherFactoryConfig{
+				AWSClients: fakeAWSClients{
+					rdsClient: &mocks.RDSClient{
+						DBProxies:        []rdstypes.DBProxy{*rdsProxyVpc1, *rdsProxyVpc2},
+						DBProxyEndpoints: []rdstypes.DBProxyEndpoint{*rdsProxyEndpointVpc1, *rdsProxyEndpointVpc2},
+					},
 				},
 			},
 			inputMatchers: makeAWSMatchersForType(types.AWSMatcherRDSProxy, "us-east-1", map[string]string{"vpc-id": "vpc1"}),
@@ -65,7 +68,7 @@ func TestRDSDBProxyFetcher(t *testing.T) {
 	testAWSFetchers(t, tests...)
 }
 
-func makeRDSProxy(t *testing.T, name, region, vpcID string) (*rds.DBProxy, types.Database) {
+func makeRDSProxy(t *testing.T, name, region, vpcID string) (*rdstypes.DBProxy, types.Database) {
 	rdsProxy := mocks.RDSProxy(name, region, vpcID)
 	rdsProxyDatabase, err := common.NewDatabaseFromRDSProxy(rdsProxy, nil)
 	require.NoError(t, err)
@@ -73,7 +76,7 @@ func makeRDSProxy(t *testing.T, name, region, vpcID string) (*rds.DBProxy, types
 	return rdsProxy, rdsProxyDatabase
 }
 
-func makeRDSProxyCustomEndpoint(t *testing.T, rdsProxy *rds.DBProxy, name, region string) (*rds.DBProxyEndpoint, types.Database) {
+func makeRDSProxyCustomEndpoint(t *testing.T, rdsProxy *rdstypes.DBProxy, name, region string) (*rdstypes.DBProxyEndpoint, types.Database) {
 	rdsProxyEndpoint := mocks.RDSProxyCustomEndpoint(rdsProxy, name, region)
 	rdsProxyEndpointDatabase, err := common.NewDatabaseFromRDSProxyCustomEndpoint(rdsProxy, rdsProxyEndpoint, nil)
 	require.NoError(t, err)

--- a/lib/srv/discovery/fetchers/db/aws_rds_test.go
+++ b/lib/srv/discovery/fetchers/db/aws_rds_test.go
@@ -21,13 +21,13 @@ package db
 import (
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/rds"
-	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+	"github.com/aws/aws-sdk-go-v2/service/redshift"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/cloud/mocks"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
@@ -38,8 +38,8 @@ import (
 func TestRDSFetchers(t *testing.T) {
 	t.Parallel()
 
-	auroraMySQLEngine := &rds.DBEngineVersion{Engine: aws.String(services.RDSEngineAuroraMySQL)}
-	postgresEngine := &rds.DBEngineVersion{Engine: aws.String(services.RDSEnginePostgres)}
+	auroraMySQLEngine := &rdstypes.DBEngineVersion{Engine: aws.String(services.RDSEngineAuroraMySQL)}
+	postgresEngine := &rdstypes.DBEngineVersion{Engine: aws.String(services.RDSEnginePostgres)}
 
 	rdsInstance1, rdsDatabase1 := makeRDSInstance(t, "instance-1", "us-east-1", envProdLabels)
 	rdsInstance2, rdsDatabase2 := makeRDSInstance(t, "instance-2", "us-east-2", envProdLabels)
@@ -58,19 +58,19 @@ func TestRDSFetchers(t *testing.T) {
 	tests := []awsFetcherTest{
 		{
 			name: "fetch all",
-			inputClients: &cloud.TestCloudClients{
-				RDSPerRegion: map[string]rdsiface.RDSAPI{
-					"us-east-1": &mocks.RDSMock{
-						DBInstances:      []*rds.DBInstance{rdsInstance1, rdsInstance3, auroraCluster1MemberInstance},
-						DBClusters:       []*rds.DBCluster{auroraCluster1},
-						DBEngineVersions: []*rds.DBEngineVersion{auroraMySQLEngine, postgresEngine},
+			fetcherCfg: AWSFetcherFactoryConfig{
+				AWSClients: newRegionalFakeRDSClientProvider(map[string]RDSClient{
+					"us-east-1": &mocks.RDSClient{
+						DBInstances:      []rdstypes.DBInstance{*rdsInstance1, *rdsInstance3, *auroraCluster1MemberInstance},
+						DBClusters:       []rdstypes.DBCluster{*auroraCluster1},
+						DBEngineVersions: []rdstypes.DBEngineVersion{*auroraMySQLEngine, *postgresEngine},
 					},
-					"us-east-2": &mocks.RDSMock{
-						DBInstances:      []*rds.DBInstance{rdsInstance2, auroraCluster2MemberInstance, auroraCluster3MemberInstance},
-						DBClusters:       []*rds.DBCluster{auroraCluster2, auroraCluster3},
-						DBEngineVersions: []*rds.DBEngineVersion{auroraMySQLEngine, postgresEngine},
+					"us-east-2": &mocks.RDSClient{
+						DBInstances:      []rdstypes.DBInstance{*rdsInstance2, *auroraCluster2MemberInstance, *auroraCluster3MemberInstance},
+						DBClusters:       []rdstypes.DBCluster{*auroraCluster2, *auroraCluster3},
+						DBEngineVersions: []rdstypes.DBEngineVersion{*auroraMySQLEngine, *postgresEngine},
 					},
-				},
+				}),
 			},
 			inputMatchers: []types.AWSMatcher{
 				{
@@ -91,19 +91,19 @@ func TestRDSFetchers(t *testing.T) {
 		},
 		{
 			name: "fetch different labels for different regions",
-			inputClients: &cloud.TestCloudClients{
-				RDSPerRegion: map[string]rdsiface.RDSAPI{
-					"us-east-1": &mocks.RDSMock{
-						DBInstances:      []*rds.DBInstance{rdsInstance1, rdsInstance3, auroraCluster1MemberInstance},
-						DBClusters:       []*rds.DBCluster{auroraCluster1},
-						DBEngineVersions: []*rds.DBEngineVersion{auroraMySQLEngine, postgresEngine},
+			fetcherCfg: AWSFetcherFactoryConfig{
+				AWSClients: newRegionalFakeRDSClientProvider(map[string]RDSClient{
+					"us-east-1": &mocks.RDSClient{
+						DBInstances:      []rdstypes.DBInstance{*rdsInstance1, *rdsInstance3, *auroraCluster1MemberInstance},
+						DBClusters:       []rdstypes.DBCluster{*auroraCluster1},
+						DBEngineVersions: []rdstypes.DBEngineVersion{*auroraMySQLEngine, *postgresEngine},
 					},
-					"us-east-2": &mocks.RDSMock{
-						DBInstances:      []*rds.DBInstance{rdsInstance2, auroraCluster2MemberInstance, auroraCluster3MemberInstance},
-						DBClusters:       []*rds.DBCluster{auroraCluster2, auroraCluster3},
-						DBEngineVersions: []*rds.DBEngineVersion{auroraMySQLEngine, postgresEngine},
+					"us-east-2": &mocks.RDSClient{
+						DBInstances:      []rdstypes.DBInstance{*rdsInstance2, *auroraCluster2MemberInstance, *auroraCluster3MemberInstance},
+						DBClusters:       []rdstypes.DBCluster{*auroraCluster2, *auroraCluster3},
+						DBEngineVersions: []rdstypes.DBEngineVersion{*auroraMySQLEngine, *postgresEngine},
 					},
-				},
+				}),
 			},
 			inputMatchers: []types.AWSMatcher{
 				{
@@ -124,19 +124,19 @@ func TestRDSFetchers(t *testing.T) {
 		},
 		{
 			name: "skip unrecognized engines",
-			inputClients: &cloud.TestCloudClients{
-				RDSPerRegion: map[string]rdsiface.RDSAPI{
-					"us-east-1": &mocks.RDSMock{
-						DBInstances:      []*rds.DBInstance{rdsInstance1, rdsInstance3, auroraCluster1MemberInstance},
-						DBClusters:       []*rds.DBCluster{auroraCluster1},
-						DBEngineVersions: []*rds.DBEngineVersion{auroraMySQLEngine},
+			fetcherCfg: AWSFetcherFactoryConfig{
+				AWSClients: newRegionalFakeRDSClientProvider(map[string]RDSClient{
+					"us-east-1": &mocks.RDSClient{
+						DBInstances:      []rdstypes.DBInstance{*rdsInstance1, *rdsInstance3, *auroraCluster1MemberInstance},
+						DBClusters:       []rdstypes.DBCluster{*auroraCluster1},
+						DBEngineVersions: []rdstypes.DBEngineVersion{*auroraMySQLEngine},
 					},
-					"us-east-2": &mocks.RDSMock{
-						DBInstances:      []*rds.DBInstance{rdsInstance2, auroraCluster2MemberInstance, auroraCluster3MemberInstance},
-						DBClusters:       []*rds.DBCluster{auroraCluster2, auroraCluster3},
-						DBEngineVersions: []*rds.DBEngineVersion{postgresEngine},
+					"us-east-2": &mocks.RDSClient{
+						DBInstances:      []rdstypes.DBInstance{*rdsInstance2, *auroraCluster2MemberInstance, *auroraCluster3MemberInstance},
+						DBClusters:       []rdstypes.DBCluster{*auroraCluster2, *auroraCluster3},
+						DBEngineVersions: []rdstypes.DBEngineVersion{*postgresEngine},
 					},
-				},
+				}),
 			},
 			inputMatchers: []types.AWSMatcher{
 				{
@@ -154,14 +154,14 @@ func TestRDSFetchers(t *testing.T) {
 		},
 		{
 			name: "skip unsupported databases",
-			inputClients: &cloud.TestCloudClients{
-				RDSPerRegion: map[string]rdsiface.RDSAPI{
-					"us-east-1": &mocks.RDSMock{
-						DBInstances:      []*rds.DBInstance{auroraCluster1MemberInstance},
-						DBClusters:       []*rds.DBCluster{auroraCluster1, auroraClusterUnsupported},
-						DBEngineVersions: []*rds.DBEngineVersion{auroraMySQLEngine},
+			fetcherCfg: AWSFetcherFactoryConfig{
+				AWSClients: newRegionalFakeRDSClientProvider(map[string]RDSClient{
+					"us-east-1": &mocks.RDSClient{
+						DBInstances:      []rdstypes.DBInstance{*auroraCluster1MemberInstance},
+						DBClusters:       []rdstypes.DBCluster{*auroraCluster1, *auroraClusterUnsupported},
+						DBEngineVersions: []rdstypes.DBEngineVersion{*auroraMySQLEngine},
 					},
-				},
+				}),
 			},
 			inputMatchers: []types.AWSMatcher{{
 				Types:   []string{types.AWSMatcherRDS},
@@ -172,11 +172,13 @@ func TestRDSFetchers(t *testing.T) {
 		},
 		{
 			name: "skip unavailable databases",
-			inputClients: &cloud.TestCloudClients{
-				RDS: &mocks.RDSMock{
-					DBInstances:      []*rds.DBInstance{rdsInstance1, rdsInstanceUnavailable, rdsInstanceUnknownStatus, auroraCluster1MemberInstance, auroraClusterUnknownStatusMemberInstance},
-					DBClusters:       []*rds.DBCluster{auroraCluster1, auroraClusterUnavailable, auroraClusterUnknownStatus},
-					DBEngineVersions: []*rds.DBEngineVersion{auroraMySQLEngine, postgresEngine},
+			fetcherCfg: AWSFetcherFactoryConfig{
+				AWSClients: fakeAWSClients{
+					rdsClient: &mocks.RDSClient{
+						DBInstances:      []rdstypes.DBInstance{*rdsInstance1, *rdsInstanceUnavailable, *rdsInstanceUnknownStatus, *auroraCluster1MemberInstance, *auroraClusterUnknownStatusMemberInstance},
+						DBClusters:       []rdstypes.DBCluster{*auroraCluster1, *auroraClusterUnavailable, *auroraClusterUnknownStatus},
+						DBEngineVersions: []rdstypes.DBEngineVersion{*auroraMySQLEngine, *postgresEngine},
+					},
 				},
 			},
 			inputMatchers: []types.AWSMatcher{{
@@ -188,11 +190,13 @@ func TestRDSFetchers(t *testing.T) {
 		},
 		{
 			name: "Aurora cluster without writer",
-			inputClients: &cloud.TestCloudClients{
-				RDS: &mocks.RDSMock{
-					DBClusters:       []*rds.DBCluster{auroraClusterNoWriter},
-					DBInstances:      []*rds.DBInstance{auroraClusterMemberNoWriter},
-					DBEngineVersions: []*rds.DBEngineVersion{auroraMySQLEngine},
+			fetcherCfg: AWSFetcherFactoryConfig{
+				AWSClients: fakeAWSClients{
+					rdsClient: &mocks.RDSClient{
+						DBClusters:       []rdstypes.DBCluster{*auroraClusterNoWriter},
+						DBInstances:      []rdstypes.DBInstance{*auroraClusterMemberNoWriter},
+						DBEngineVersions: []rdstypes.DBEngineVersion{*auroraMySQLEngine},
+					},
 				},
 			},
 			inputMatchers: []types.AWSMatcher{{
@@ -206,7 +210,7 @@ func TestRDSFetchers(t *testing.T) {
 	testAWSFetchers(t, tests...)
 }
 
-func makeRDSInstance(t *testing.T, name, region string, labels map[string]string, opts ...func(*rds.DBInstance)) (*rds.DBInstance, types.Database) {
+func makeRDSInstance(t *testing.T, name, region string, labels map[string]string, opts ...func(*rdstypes.DBInstance)) (*rdstypes.DBInstance, types.Database) {
 	instance := mocks.RDSInstance(name, region, labels, opts...)
 	database, err := common.NewDatabaseFromRDSInstance(instance)
 	require.NoError(t, err)
@@ -214,21 +218,21 @@ func makeRDSInstance(t *testing.T, name, region string, labels map[string]string
 	return instance, database
 }
 
-func makeRDSCluster(t *testing.T, name, region string, labels map[string]string, opts ...func(*rds.DBCluster)) (*rds.DBCluster, *rds.DBInstance, types.Database) {
+func makeRDSCluster(t *testing.T, name, region string, labels map[string]string, opts ...func(*rdstypes.DBCluster)) (*rdstypes.DBCluster, *rdstypes.DBInstance, types.Database) {
 	cluster := mocks.RDSCluster(name, region, labels, opts...)
 	dbInstanceMember := makeRDSMemberForCluster(t, name, region, "vpc-123", *cluster.Engine, labels)
-	database, err := common.NewDatabaseFromRDSCluster(cluster, []*rds.DBInstance{dbInstanceMember})
+	database, err := common.NewDatabaseFromRDSCluster(cluster, []rdstypes.DBInstance{*dbInstanceMember})
 	require.NoError(t, err)
 	common.ApplyAWSDatabaseNameSuffix(database, types.AWSMatcherRDS)
 	return cluster, dbInstanceMember, database
 }
 
-func makeRDSMemberForCluster(t *testing.T, name, region, vpcid, engine string, labels map[string]string) *rds.DBInstance {
-	instanceRDSMember, _ := makeRDSInstance(t, name+"-instance-1", region, labels, func(d *rds.DBInstance) {
+func makeRDSMemberForCluster(t *testing.T, name, region, vpcid, engine string, labels map[string]string) *rdstypes.DBInstance {
+	instanceRDSMember, _ := makeRDSInstance(t, name+"-instance-1", region, labels, func(d *rdstypes.DBInstance) {
 		if d.DBSubnetGroup == nil {
-			d.DBSubnetGroup = &rds.DBSubnetGroup{}
+			d.DBSubnetGroup = &rdstypes.DBSubnetGroup{}
 		}
-		d.DBSubnetGroup.SetVpcId(vpcid)
+		d.DBSubnetGroup.VpcId = aws.String(vpcid)
 		d.DBClusterIdentifier = aws.String(name)
 		d.Engine = aws.String(engine)
 	})
@@ -236,9 +240,9 @@ func makeRDSMemberForCluster(t *testing.T, name, region, vpcid, engine string, l
 	return instanceRDSMember
 }
 
-func makeRDSClusterWithExtraEndpoints(t *testing.T, name, region string, labels map[string]string, hasWriter bool) (*rds.DBCluster, *rds.DBInstance, types.Databases) {
+func makeRDSClusterWithExtraEndpoints(t *testing.T, name, region string, labels map[string]string, hasWriter bool) (*rdstypes.DBCluster, *rdstypes.DBInstance, types.Databases) {
 	cluster := mocks.RDSCluster(name, region, labels,
-		func(cluster *rds.DBCluster) {
+		func(cluster *rdstypes.DBCluster) {
 			// Disable writer by default. If hasWriter, writer endpoint will be added below.
 			cluster.DBClusterMembers = nil
 		},
@@ -249,11 +253,11 @@ func makeRDSClusterWithExtraEndpoints(t *testing.T, name, region string, labels 
 
 	var databases types.Databases
 
-	instanceRDSMember := makeRDSMemberForCluster(t, name, region, "vpc-123", aws.StringValue(cluster.Engine), labels)
-	dbInstanceMembers := []*rds.DBInstance{instanceRDSMember}
+	instanceRDSMember := makeRDSMemberForCluster(t, name, region, "vpc-123", aws.ToString(cluster.Engine), labels)
+	dbInstanceMembers := []rdstypes.DBInstance{*instanceRDSMember}
 
 	if hasWriter {
-		cluster.DBClusterMembers = append(cluster.DBClusterMembers, &rds.DBClusterMember{
+		cluster.DBClusterMembers = append(cluster.DBClusterMembers, rdstypes.DBClusterMember{
 			IsClusterWriter: aws.Bool(true), // Add writer.
 		})
 
@@ -277,22 +281,49 @@ func makeRDSClusterWithExtraEndpoints(t *testing.T, name, region string, labels 
 }
 
 // withRDSInstanceStatus returns an option function for makeRDSInstance to overwrite status.
-func withRDSInstanceStatus(status string) func(*rds.DBInstance) {
-	return func(instance *rds.DBInstance) {
+func withRDSInstanceStatus(status string) func(*rdstypes.DBInstance) {
+	return func(instance *rdstypes.DBInstance) {
 		instance.DBInstanceStatus = aws.String(status)
 	}
 }
 
 // withRDSClusterEngineMode returns an option function for makeRDSCluster to overwrite engine mode.
-func withRDSClusterEngineMode(mode string) func(*rds.DBCluster) {
-	return func(cluster *rds.DBCluster) {
+func withRDSClusterEngineMode(mode string) func(*rdstypes.DBCluster) {
+	return func(cluster *rdstypes.DBCluster) {
 		cluster.EngineMode = aws.String(mode)
 	}
 }
 
 // withRDSClusterStatus returns an option function for makeRDSCluster to overwrite status.
-func withRDSClusterStatus(status string) func(*rds.DBCluster) {
-	return func(cluster *rds.DBCluster) {
+func withRDSClusterStatus(status string) func(*rdstypes.DBCluster) {
+	return func(cluster *rdstypes.DBCluster) {
 		cluster.Status = aws.String(status)
 	}
+}
+
+// provides a client specific to each region, where the map keys are regions.
+func newRegionalFakeRDSClientProvider(cs map[string]RDSClient) fakeRegionalRDSClients {
+	return fakeRegionalRDSClients{rdsClients: cs}
+}
+
+type fakeAWSClients struct {
+	rdsClient      RDSClient
+	redshiftClient RedshiftClient
+}
+
+func (f fakeAWSClients) GetRDSClient(cfg aws.Config, optFns ...func(*rds.Options)) RDSClient {
+	return f.rdsClient
+}
+
+func (f fakeAWSClients) GetRedshiftClient(cfg aws.Config, optFns ...func(*redshift.Options)) RedshiftClient {
+	return f.redshiftClient
+}
+
+type fakeRegionalRDSClients struct {
+	AWSClientProvider
+	rdsClients map[string]RDSClient
+}
+
+func (f fakeRegionalRDSClients) GetRDSClient(cfg aws.Config, optFns ...func(*rds.Options)) RDSClient {
+	return f.rdsClients[cfg.Region]
 }

--- a/lib/srv/discovery/fetchers/db/aws_redshift.go
+++ b/lib/srv/discovery/fetchers/db/aws_redshift.go
@@ -32,9 +32,6 @@ import (
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
 )
 
-// RedshiftClientProviderFunc provides a [RedshiftClient].
-type RedshiftClientProviderFunc func(cfg aws.Config, optFns ...func(*redshift.Options)) RedshiftClient
-
 // RedshiftClient is a subset of the AWS Redshift API.
 type RedshiftClient interface {
 	redshift.DescribeClustersAPIClient
@@ -57,7 +54,7 @@ func (f *redshiftPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	clusters, err := getRedshiftClusters(ctx, cfg.redshiftClientProviderFn(awsCfg))
+	clusters, err := getRedshiftClusters(ctx, cfg.awsClients.GetRedshiftClient(awsCfg))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
This PR migrates all uses of AWS RDS API to AWS SDK v2.

This PR depends on and is stacked on top of another PR:
- #50809

Part of https://github.com/gravitational/teleport/issues/14142
- https://github.com/gravitational/teleport/issues/14142