### PR TITLE
Fix flaky test `TestIntegrations/X11Forwarding`

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -4853,12 +4853,15 @@ func testX11Forwarding(t *testing.T, suite *integrationTestSuite) {
 							assert.Eventually(t, func() bool {
 								output, err := os.ReadFile(tmpFile.Name())
 								if err == nil && len(output) != 0 {
-									display <- strings.TrimSpace(string(output))
+									select {
+									case display <- strings.TrimSpace(string(output)):
+									default:
+									}
 									return true
 								}
 								return false
 							}, time.Second, 100*time.Millisecond, "failed to read display")
-						}, 10*time.Second, 2*time.Second)
+						}, 10*time.Second, 1*time.Second)
 
 						// Make a new connection to the XServer proxy to confirm that forwarding is working.
 						serverDisplay, err := x11.ParseDisplay(<-display)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -4858,7 +4858,7 @@ func testX11Forwarding(t *testing.T, suite *integrationTestSuite) {
 								}
 								return false
 							}, time.Second, 100*time.Millisecond, "failed to read display")
-						}, 10*time.Second, time.Second)
+						}, 10*time.Second, 2*time.Second)
 
 						// Make a new connection to the XServer proxy to confirm that forwarding is working.
 						serverDisplay, err := x11.ParseDisplay(<-display)


### PR DESCRIPTION
This test suffered from the same data race explained in https://github.com/gravitational/teleport/pull/48045, except that the race could now result in an `assert.Eventually` attempt sending display (and blocking the channel) after the outer `require.EventuallyWithT` had already moved on to a new `assert.Eventually` attempt with the next tick. The latter attempt would then block on `display <- ...` and end up failing.

The fix I chose is to stagger the outer eventually to ensure the inner eventually attempt has ample time to complete before moving on to another attempt.