### PR TITLE
Fix UserTask Status not being updated

### DIFF
--- a/lib/auth/usertasks/usertasksv1/service.go
+++ b/lib/auth/usertasks/usertasksv1/service.go
@@ -354,7 +354,7 @@ func (s *Service) updateStatus(ut *usertasksv1.UserTask, existing *usertasksv1.U
 
 	if existing != nil {
 		// Inherit everything from existing UserTask.
-		ut.Status.LastStateChange = cmp.Or(existing.Status.LastStateChange, ut.Status.LastStateChange)
+		ut.Status.LastStateChange = cmp.Or(existing.GetStatus().GetLastStateChange(), ut.Status.LastStateChange)
 
 		// Update specific values.
 		if existing.GetSpec().GetState() != ut.GetSpec().GetState() {

--- a/lib/auth/usertasks/usertasksv1/service.go
+++ b/lib/auth/usertasks/usertasksv1/service.go
@@ -19,6 +19,7 @@
 package usertasksv1
 
 import (
+	"cmp"
 	"context"
 	"log/slog"
 	"time"
@@ -353,7 +354,7 @@ func (s *Service) updateStatus(ut *usertasksv1.UserTask, existing *usertasksv1.U
 
 	if existing != nil {
 		// Inherit everything from existing UserTask.
-		ut.Status = existing.Status
+		ut.Status.LastStateChange = cmp.Or(existing.Status.LastStateChange, ut.Status.LastStateChange)
 
 		// Update specific values.
 		if existing.GetSpec().GetState() != ut.GetSpec().GetState() {

--- a/lib/auth/usertasks/usertasksv1/service.go
+++ b/lib/auth/usertasks/usertasksv1/service.go
@@ -131,7 +131,7 @@ func (s *Service) CreateUserTask(ctx context.Context, req *usertasksv1.CreateUse
 		return nil, trace.Wrap(err)
 	}
 
-	s.updateStatus(req.UserTask)
+	s.updateStatus(req.UserTask, nil /* existing user task */)
 
 	rsp, err := s.backend.CreateUserTask(ctx, req.UserTask)
 	s.emitCreateAuditEvent(ctx, rsp, authCtx, err)
@@ -264,10 +264,7 @@ func (s *Service) UpdateUserTask(ctx context.Context, req *usertasksv1.UpdateUse
 	}
 
 	stateChanged := existingUserTask.GetSpec().GetState() != req.GetUserTask().GetSpec().GetState()
-
-	if stateChanged {
-		s.updateStatus(req.UserTask)
-	}
+	s.updateStatus(req.UserTask, existingUserTask)
 
 	rsp, err := s.backend.UpdateUserTask(ctx, req.UserTask)
 	s.emitUpdateAuditEvent(ctx, existingUserTask, req.GetUserTask(), authCtx, err)
@@ -333,9 +330,7 @@ func (s *Service) UpsertUserTask(ctx context.Context, req *usertasksv1.UpsertUse
 		stateChanged = existingUserTask.GetSpec().GetState() != req.GetUserTask().GetSpec().GetState()
 	}
 
-	if stateChanged {
-		s.updateStatus(req.UserTask)
-	}
+	s.updateStatus(req.UserTask, existingUserTask)
 
 	rsp, err := s.backend.UpsertUserTask(ctx, req.UserTask)
 	s.emitUpsertAuditEvent(ctx, existingUserTask, req.GetUserTask(), authCtx, err)
@@ -350,9 +345,20 @@ func (s *Service) UpsertUserTask(ctx context.Context, req *usertasksv1.UpsertUse
 	return rsp, nil
 }
 
-func (s *Service) updateStatus(ut *usertasksv1.UserTask) {
+func (s *Service) updateStatus(ut *usertasksv1.UserTask, existing *usertasksv1.UserTask) {
+	// Default status for UserTask.
 	ut.Status = &usertasksv1.UserTaskStatus{
 		LastStateChange: timestamppb.New(s.clock.Now()),
+	}
+
+	if existing != nil {
+		// Inherit everything from existing UserTask.
+		ut.Status = existing.Status
+
+		// Update specific values.
+		if existing.GetSpec().GetState() != ut.GetSpec().GetState() {
+			ut.Status.LastStateChange = timestamppb.New(s.clock.Now())
+		}
 	}
 }
 

--- a/lib/web/usertasks_test.go
+++ b/lib/web/usertasks_test.go
@@ -31,6 +31,7 @@ import (
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/usertasks"
+	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/web/ui"
 )
@@ -53,6 +54,8 @@ func TestUserTask(t *testing.T) {
 		})
 	require.NoError(t, err)
 	pack := env.proxies[0].authPack(t, userWithRW, []types.Role{roleRWUserTask})
+	adminClient, err := env.server.NewClient(auth.TestAdmin())
+	require.NoError(t, err)
 
 	getAllEndpoint := pack.clt.Endpoint("webapi", "sites", clusterName, "usertask")
 	singleItemEndpoint := func(name string) string {
@@ -90,7 +93,7 @@ func TestUserTask(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		_, err = env.proxies[0].auth.Auth().CreateUserTask(ctx, userTask)
+		_, err = adminClient.UserTasksServiceClient().CreateUserTask(ctx, userTask)
 		require.NoError(t, err)
 		userTaskForTest = userTask
 	}


### PR DESCRIPTION
The Status field for UserTasks was not being correctly updated when the Spec.State was not changed.