### PR TITLE
[v16] chore: Bump golangci-lint to v1.63.4

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,6 +61,7 @@ issues:
   exclude-use-default: true
   max-same-issues: 0
   max-issues-per-linter: 0
+  uniq-by-line: false
 
 linters:
   disable-all: true
@@ -194,9 +195,6 @@ linters-settings:
       - len
       - suite-extra-assert-call
       - suite-thelper
-
-output:
-  uniq-by-line: false
 
 run:
   go: '1.22'

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -4,7 +4,7 @@
 
 # Sync with devbox.json.
 GOLANG_VERSION ?= go1.22.10
-GOLANGCI_LINT_VERSION ?= v1.61.0
+GOLANGCI_LINT_VERSION ?= v1.63.4
 
 NODE_VERSION ?= 20.18.0
 

--- a/lib/integrations/awsoidc/eks_enroll_clusters_test.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters_test.go
@@ -171,7 +171,7 @@ func TestEnrollEKSClusters(t *testing.T) {
 			responseCheck: func(t *testing.T, response *EnrollEKSClusterResponse) {
 				require.Len(t, response.Results, 1)
 				require.Equal(t, "EKS1", response.Results[0].ClusterName)
-				require.Empty(t, response.Results[0].Error)
+				require.NoError(t, response.Results[0].Error)
 				require.NotEmpty(t, response.Results[0].ResourceId)
 			},
 		},
@@ -187,10 +187,10 @@ func TestEnrollEKSClusters(t *testing.T) {
 					return strings.Compare(a.ClusterName, b.ClusterName)
 				})
 				require.Equal(t, "EKS1", response.Results[0].ClusterName)
-				require.Empty(t, response.Results[0].Error)
+				require.NoError(t, response.Results[0].Error)
 				require.NotEmpty(t, response.Results[0].ResourceId)
 				require.Equal(t, "EKS2", response.Results[1].ClusterName)
-				require.Empty(t, response.Results[1].Error)
+				require.NoError(t, response.Results[1].Error)
 				require.NotEmpty(t, response.Results[1].ResourceId)
 			},
 		},

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -842,7 +842,7 @@ func TestAccessListReviewCRUD(t *testing.T) {
 
 	// Verify that access lists reviews are gone.
 	_, _, err = service.ListAccessListReviews(ctx, accessList1.GetName(), 0, "")
-	require.Empty(t, err)
+	require.NoError(t, err)
 }
 
 func TestAccessListRequiresEqual(t *testing.T) {

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -1090,7 +1090,7 @@ func TestValidateRole(t *testing.T) {
 			require.NoError(t, err, trace.DebugReport(err))
 
 			if len(tc.expectWarnings) == 0 {
-				require.Empty(t, warning)
+				require.NoError(t, warning)
 			}
 			for _, msg := range tc.expectWarnings {
 				require.ErrorContains(t, warning, msg)


### PR DESCRIPTION
Backport #50846 to branch/v16.