### PR TITLE
[v15] Use Go 1.22.x as the module version

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,15 +24,6 @@ issues:
     - linters: [testifylint]
       text: "suite-thelper: suite helper method must start with"
       path: 'integrations/.+'
-    # Go 1.22 related warnings.
-    # These are OK because our toolchain is 1.22 or newer.
-    - linters: [govet]
-      text: "stdversion: cmp.Or requires go1.22 or later"
-    - linters: [govet]
-      text: "stdversion: rand.New requires go1.22 or later"
-    - linters: [govet]
-      text: "stdversion: rand.NewPCG requires go1.22 or later"
-
   exclude-use-default: true
   max-same-issues: 0
   max-issues-per-linter: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -157,6 +157,6 @@ linters-settings:
       - suite-thelper
 
 run:
-  go: '1.21'
+  go: '1.22'
   build-tags: []
   timeout: 15m

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/gravitational/teleport
 
-go 1.21
-
-toolchain go1.22.10
+go 1.22.10
 
 require (
 	cloud.google.com/go/cloudsqlconn v1.9.0

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -1,8 +1,6 @@
 module github.com/gravitational/teleport/integrations/event-handler
 
-go 1.21
-
-toolchain go1.22.10
+go 1.22.10
 
 require (
 	github.com/alecthomas/kong v0.9.0

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -1,8 +1,6 @@
 module github.com/gravitational/teleport/integrations/terraform
 
-go 1.21
-
-toolchain go1.22.10
+go 1.22.10
 
 require (
 	github.com/gogo/protobuf v1.3.2


### PR DESCRIPTION
Update the module Go version to 1.22.x, matching the previous toolchain.

As a consequence of #50868 it became clear that branch/v15 already relies on Go 1.22 APIs, so this makes that fact official by bumping the actual module version. This also puts branch/v15 on par with branch/v16.