### PR TITLE
fix: Update excluded google.golang.org/grpc/stats/opentelemetry versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -581,4 +581,7 @@ replace (
 // least, one of the grpc-go versions above we need to exclude
 // stats/opentelemetry in order to avoid "ambiguous import" errors on build.
 // TODO(codingllama): Remove once no dependencies import stats/opentelemetry.
-exclude google.golang.org/grpc/stats/opentelemetry v0.0.0-20240907200651-3ffb98b2c93a
+exclude (
+	google.golang.org/grpc/stats/opentelemetry v0.0.0-20240907200651-3ffb98b2c93a
+	google.golang.org/grpc/stats/opentelemetry v0.0.0-20241028142157-ada6787961b3
+)

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -351,4 +351,7 @@ replace (
 )
 
 // TODO(codingllama): Remove once no dependencies import stats/opentelemetry.
-exclude google.golang.org/grpc/stats/opentelemetry v0.0.0-20240907200651-3ffb98b2c93a
+exclude (
+	google.golang.org/grpc/stats/opentelemetry v0.0.0-20240907200651-3ffb98b2c93a
+	google.golang.org/grpc/stats/opentelemetry v0.0.0-20241028142157-ada6787961b3
+)

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -413,4 +413,7 @@ replace (
 )
 
 // TODO(codingllama): Remove once no dependencies import stats/opentelemetry.
-exclude google.golang.org/grpc/stats/opentelemetry v0.0.0-20240907200651-3ffb98b2c93a
+exclude (
+	google.golang.org/grpc/stats/opentelemetry v0.0.0-20240907200651-3ffb98b2c93a
+	google.golang.org/grpc/stats/opentelemetry v0.0.0-20241028142157-ada6787961b3
+)


### PR DESCRIPTION
Fixes builds after the recent dependency update batch.