### PR TITLE
[v17] docs: update doc verbiage for usage of 'its'

### DIFF
--- a/docs/pages/admin-guides/access-controls/idps/saml-attribute-mapping.mdx
+++ b/docs/pages/admin-guides/access-controls/idps/saml-attribute-mapping.mdx
@@ -73,7 +73,7 @@ Attribute mapping that points to a non-existent value will not be included in SA
 Predicate expressions for attribute mapping are evaluated against user attributes that can be accessed using
 evaluation context listed above.
 
-The supported functions and methods are listed below, along with the usage syntax and it's result, evaluated 
+The supported functions and methods are listed below, along with the usage syntax and its result, evaluated 
 against the following reference user spec file:
 ```yaml
 # reference user spec file

--- a/docs/pages/admin-guides/access-controls/idps/saml-guide.mdx
+++ b/docs/pages/admin-guides/access-controls/idps/saml-guide.mdx
@@ -141,7 +141,7 @@ $ tctl create iamshowcase.yaml
 </Details>
 
 <Admonition type="important">
-If an `entity_descriptor` is provided, it's content takes preference over values provided in `entity_id` and `acs_url`.
+If an `entity_descriptor` is provided, its content takes preference over values provided in `entity_id` and `acs_url`.
 
 Teleport only tries to fetch or generate entity descriptor when service provider is created for the first time.
 Subsequent updates require an entity descriptor to be present in the service provider spec. As such, when updating

--- a/docs/pages/enroll-resources/machine-id/deployment/azure.mdx
+++ b/docs/pages/enroll-resources/machine-id/deployment/azure.mdx
@@ -12,7 +12,7 @@ On the Azure platform, virtual machines can be assigned a managed identity. The
 Azure platform will then make available to the virtual machine an attested
 data document and JWT that allows the virtual machine to act as this identity.
 This identity can be validated by a third party by attempting to use this token
-to fetch it's own identity from the Azure identity service.
+to fetch its own identity from the Azure identity service.
 
 The `azure` join method instructs the bot to use this attested data document and
 JWT to prove its identity to the Teleport Auth Server. This allows joining to

--- a/docs/pages/enroll-resources/server-access/openssh/openssh-manual-install.mdx
+++ b/docs/pages/enroll-resources/server-access/openssh/openssh-manual-install.mdx
@@ -224,7 +224,7 @@ $ tctl get node/openssh-node
 
 When creating host certificates, it is important to specify all the domain names
 and addresses that refer to your node. If you try to connect to a node with a
-name or address that was not specified when creating it's host certificate,
+name or address that was not specified when creating its host certificate,
 Teleport will reject the SSH connection.
 
 On your local machine, assign the IP address, fully qualified domain name of

--- a/docs/pages/reference/architecture/trustedclusters.mdx
+++ b/docs/pages/reference/architecture/trustedclusters.mdx
@@ -29,7 +29,7 @@ databases behind a firewall.
 In the example below, there are three independent clusters:
 
 - Cluster `sso.example.com` is a root cluster. This cluster can be used as a single-sign-on entry point
-for your organization. It can have it's own independent resources connected to it, or be used just for audit
+for your organization. It can have its own independent resources connected to it, or be used just for audit
 logs collection and single-sign-on.
 - Clusters `us-east-1a` and `us-east-1b` are two independent clusters in different availability zones.
 


### PR DESCRIPTION
Backport #50897 to branch/v17