### PR TITLE
docs: add warning on using non-uuid name for openssh nodes

### DIFF
--- a/docs/pages/enroll-resources/server-access/openssh/openssh-manual-install.mdx
+++ b/docs/pages/enroll-resources/server-access/openssh/openssh-manual-install.mdx
@@ -104,6 +104,12 @@ The `metadata.name` field isn't mandatory, but setting it here will save you som
 To generate a new universal unique identifier (UUID) suitable for a `node` name, use the `uuidgen`
 on Linux or macOS, or use the `New-Guid` cmdlet in Powershell on Windows.
 
+<Admonition type="warning">
+  Using a non-uuid format `metadata.name` can result in errors in Teleport finding
+  the node in inventory. This could result in issues such as being unable to access the node
+  in the Web UI.
+</Admonition>
+
 Create the node resource:
 
 ```code

--- a/docs/pages/enroll-resources/server-access/openssh/openssh-manual-install.mdx
+++ b/docs/pages/enroll-resources/server-access/openssh/openssh-manual-install.mdx
@@ -105,9 +105,8 @@ To generate a new universal unique identifier (UUID) suitable for a `node` name,
 on Linux or macOS, or use the `New-Guid` cmdlet in Powershell on Windows.
 
 <Admonition type="warning">
-  Using a non-uuid format `metadata.name` can result in errors in Teleport finding
-  the node in inventory. This could result in issues such as being unable to access the node
-  in the Web UI.
+  Using a non-UUID format `metadata.name` will result in errors attempting to access the node in the 
+  Web UI.
 </Admonition>
 
 Create the node resource:

--- a/docs/pages/enroll-resources/server-access/openssh/openssh-manual-install.mdx
+++ b/docs/pages/enroll-resources/server-access/openssh/openssh-manual-install.mdx
@@ -99,9 +99,7 @@ and `spec.hostname` to the name of the node as you would like users to see it in
 
 The `metadata.labels` field labels the SSH Service instance so you can apply RBAC rules to it.
 
-The `metadata.name` field isn't mandatory, but if supplied, it must be a universal unique identifier (UUID).  To generate a new UUID suitable for a `node` name
-
-To generate a new universal unique identifier (UUID) suitable for a `node` name, use the `uuidgen`
+The `metadata.name` field isn't mandatory, but if supplied, it must be a universal unique identifier (UUID).  To generate a new UUID suitable for a `node` name, use the `uuidgen`
 on Linux or macOS, or use the `New-Guid` cmdlet in Powershell on Windows.
 
 Create the node resource:

--- a/docs/pages/enroll-resources/server-access/openssh/openssh-manual-install.mdx
+++ b/docs/pages/enroll-resources/server-access/openssh/openssh-manual-install.mdx
@@ -99,15 +99,11 @@ and `spec.hostname` to the name of the node as you would like users to see it in
 
 The `metadata.labels` field labels the SSH Service instance so you can apply RBAC rules to it.
 
-The `metadata.name` field isn't mandatory, but setting it here will save you some work later.
+The `metadata.name` field isn't mandatory, but setting it here will save you some work later. Using
+a non-UUID name can result in access errors when Teleport finds the node in its inventory.
 
 To generate a new universal unique identifier (UUID) suitable for a `node` name, use the `uuidgen`
 on Linux or macOS, or use the `New-Guid` cmdlet in Powershell on Windows.
-
-<Admonition type="warning">
-  Using a non-UUID format `metadata.name` will result in errors attempting to access the node in the 
-  Web UI.
-</Admonition>
 
 Create the node resource:
 

--- a/docs/pages/enroll-resources/server-access/openssh/openssh-manual-install.mdx
+++ b/docs/pages/enroll-resources/server-access/openssh/openssh-manual-install.mdx
@@ -99,8 +99,7 @@ and `spec.hostname` to the name of the node as you would like users to see it in
 
 The `metadata.labels` field labels the SSH Service instance so you can apply RBAC rules to it.
 
-The `metadata.name` field isn't mandatory, but setting it here will save you some work later. Using
-a non-UUID name can result in access errors when Teleport finds the node in its inventory.
+The `metadata.name` field isn't mandatory, but if supplied, it must be a universal unique identifier (UUID).  To generate a new UUID suitable for a `node` name
 
 To generate a new universal unique identifier (UUID) suitable for a `node` name, use the `uuidgen`
 on Linux or macOS, or use the `New-Guid` cmdlet in Powershell on Windows.


### PR DESCRIPTION
Using a non-uuid can result in the web ui showing this on access attempts

<img width="900" alt="image" src="https://github.com/user-attachments/assets/916ff1d3-6aa7-4001-a602-c24ca5a5908f" />
