### PR TITLE
Deflake `TestAWSOIDCRequiredVPCSHelper_CombinedSubnetsForAVpcID`

### DIFF
--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -1055,7 +1055,7 @@ func awsOIDCListAllDatabases(ctx context.Context, clt authclient.ClientI, integr
 	return fetchedRDSs, nil
 }
 
-func awsOIDCRequiredVPCSHelper(ctx context.Context, clt authclient.ClientI, req ui.AWSOIDCRequiredVPCSRequest, fetchedRDSs []*types.DatabaseV3) (*ui.AWSOIDCRequiredVPCSResponse, error) {
+func awsOIDCRequiredVPCSHelper(ctx context.Context, clt client.GetResourcesClient, req ui.AWSOIDCRequiredVPCSRequest, fetchedRDSs []*types.DatabaseV3) (*ui.AWSOIDCRequiredVPCSResponse, error) {
 	// Get all database services with ecs/fargate metadata label.
 	fetchedDbSvcs, err := fetchAWSOIDCDatabaseServices(ctx, clt)
 	if err != nil {


### PR DESCRIPTION
Instead of creating an entire cluster, just mock the client to return 0 database services (we were not creating any in the cluster anyway).

Fixes https://github.com/gravitational/teleport/issues/50549