### PR TITLE
[v17] Make Teleport Connect use TCP connection mode for Oracle

### DIFF
--- a/lib/teleterm/cmd/db.go
+++ b/lib/teleterm/cmd/db.go
@@ -71,6 +71,7 @@ func newDBCLICommandWithExecer(ctx context.Context, cluster *clusters.Cluster, g
 		dbcmd.WithNoTLS(),
 		dbcmd.WithTolerateMissingCLIClient(),
 		dbcmd.WithExecer(execer),
+		dbcmd.WithOracleOpts(true, true),
 		dbcmd.WithGetDatabaseFunc(func(ctx context.Context, _ *client.TeleportClient, _ string) (types.Database, error) {
 			getDatabaseOnce.Do(func() {
 				database, getDatabaseError = cluster.GetDatabase(ctx, authClient, gateway.TargetURI())

--- a/lib/teleterm/cmd/db.go
+++ b/lib/teleterm/cmd/db.go
@@ -71,7 +71,7 @@ func newDBCLICommandWithExecer(ctx context.Context, cluster *clusters.Cluster, g
 		dbcmd.WithNoTLS(),
 		dbcmd.WithTolerateMissingCLIClient(),
 		dbcmd.WithExecer(execer),
-		dbcmd.WithOracleOpts(true, true),
+		dbcmd.WithOracleOpts(true /* can use TCP */, true /* has TCP servers */),
 		dbcmd.WithGetDatabaseFunc(func(ctx context.Context, _ *client.TeleportClient, _ string) (types.Database, error) {
 			getDatabaseOnce.Do(func() {
 				database, getDatabaseError = cluster.GetDatabase(ctx, authClient, gateway.TargetURI())


### PR DESCRIPTION
Backport #50903 to branch/v17

changelog: Fix Teleport Connect Oracle support. Requires updated Teleport database agents (v17.2.0+).
