### PR TITLE
[v17] Permit routing to agentless nodes with non-UUID metadata.name

### DIFF
--- a/api/utils/route.go
+++ b/api/utils/route.go
@@ -180,6 +180,14 @@ func (m *SSHRouteMatcher) RouteToServerScore(server RouteableServer) (score int)
 		score = max(score, matchAddr(addr))
 	}
 
+	// Allow a match on name, even though it may not be a UUID or EC2 ID,
+	// to support agentless hosts that were created without their name being a UUID.
+	// The score however, is lower than a true direct match, to prevent any
+	// breaking changes to routing.
+	if server.GetName() == m.cfg.Host {
+		score = max(score, indirectMatch)
+	}
+
 	return score
 }
 

--- a/api/utils/route_test.go
+++ b/api/utils/route_test.go
@@ -15,6 +15,7 @@
 package utils
 
 import (
+	"cmp"
 	"context"
 	"testing"
 
@@ -273,6 +274,7 @@ func TestSSHRouteMatcherScoring(t *testing.T) {
 	tts := []struct {
 		desc     string
 		hostname string
+		name     string
 		addrs    []string
 		score    int
 	}{
@@ -309,12 +311,23 @@ func TestSSHRouteMatcherScoring(t *testing.T) {
 			},
 			score: notMatch,
 		},
+		{
+			desc:     "non-uuid name",
+			name:     "foo.example.com",
+			hostname: "foo.com",
+			addrs: []string{
+				"0.0.0.0:0",
+				"1.1.1.1:0",
+			},
+			score: indirectMatch,
+		},
 	}
 
 	for _, tt := range tts {
 		t.Run(tt.desc, func(t *testing.T) {
+			name := cmp.Or(tt.name, uuid.NewString())
 			score := matcher.RouteToServerScore(mockRouteableServer{
-				name:       uuid.NewString(),
+				name:       name,
 				hostname:   tt.hostname,
 				publicAddr: tt.addrs,
 			})


### PR DESCRIPTION
Backport #50915 to branch/v17

changelog: Prevent routing issues for agentless nodes that are created with non-UUID `metadata.name` fields.
