### PR TITLE
Fix enterprise webassets path for testing

### DIFF
--- a/lib/web/apiserver_test_utils.go
+++ b/lib/web/apiserver_test_utils.go
@@ -34,7 +34,7 @@ func NewDebugFileSystem(isEnterprise bool) (http.FileSystem, error) {
 	assetsPath := "../../webassets/teleport"
 
 	if isEnterprise {
-		assetsPath = "../../../webassets/teleport"
+		assetsPath = "../../../webassets/e/teleport"
 	}
 
 	// Ensure we have the built assets available before continuing.


### PR DESCRIPTION
wasn't able to get my enterprise testing to pass (https://github.com/gravitational/teleport.e/pull/5818), and realized i didn't include the `e` in the webassets path introduced in https://github.com/gravitational/teleport/pull/50472