### PR TITLE
Use locally scoped slog loggers instead of default

### DIFF
--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -303,8 +303,7 @@ func NewServer(cfg Config) (reversetunnelclient.Server, error) {
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
 			Component: cfg.Component,
 			Client:    cfg.LocalAccessPoint,
-			// TODO(tross): update this after converting to slog here
-			// Logger:       cfg.Log,
+			Logger:    cfg.Logger,
 		},
 		ProxiesC:    make(chan []types.Server, 10),
 		ProxyGetter: cfg.LocalAccessPoint,
@@ -1211,10 +1210,9 @@ func newRemoteSite(srv *server, domainName string, sconn ssh.Conn) (*remoteSite,
 	remoteSite.remoteAccessPoint = accessPoint
 	nodeWatcher, err := services.NewNodeWatcher(closeContext, services.NodeWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
-			Component: srv.Component,
-			Client:    accessPoint,
-			// TODO(tross) update this after converting to use slog
-			// Logger:          srv.Log,
+			Component:    srv.Component,
+			Client:       accessPoint,
+			Logger:       srv.Logger,
 			MaxStaleness: time.Minute,
 		},
 		NodesGetter: accessPoint,
@@ -1247,10 +1245,9 @@ func newRemoteSite(srv *server, domainName string, sconn ssh.Conn) (*remoteSite,
 	remoteWatcher, err := services.NewCertAuthorityWatcher(srv.ctx, services.CertAuthorityWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
 			Component: teleport.ComponentProxy,
-			// TODO(tross): update this after converting to slog
-			// Logger:       srv.log,
-			Clock:  srv.Clock,
-			Client: remoteSite.remoteAccessPoint,
+			Logger:    srv.logger,
+			Clock:     srv.Clock,
+			Client:    remoteSite.remoteAccessPoint,
 		},
 		Types: []types.CertAuthType{types.HostCA},
 	})

--- a/lib/srv/discovery/database_watcher.go
+++ b/lib/srv/discovery/database_watcher.go
@@ -20,7 +20,6 @@ package discovery
 
 import (
 	"context"
-	"log/slog"
 	"sync"
 
 	"github.com/gravitational/trace"
@@ -54,8 +53,7 @@ func (s *Server) startDatabaseWatchers() error {
 				defer mu.Unlock()
 				return utils.FromSlice(newDatabases, types.Database.GetName)
 			},
-			// TODO(tross): update to use the server logger once it is converted to use slog
-			Logger:   slog.With("kind", types.KindDatabase),
+			Logger:   s.Log.With("kind", types.KindDatabase),
 			OnCreate: s.onDatabaseCreate,
 			OnUpdate: s.onDatabaseUpdate,
 			OnDelete: s.onDatabaseDelete,

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -1869,9 +1869,8 @@ func (s *Server) getAzureSubscriptions(ctx context.Context, subs []string) ([]st
 func (s *Server) initTeleportNodeWatcher() (err error) {
 	s.nodeWatcher, err = services.NewNodeWatcher(s.ctx, services.NodeWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
-			Component: teleport.ComponentDiscovery,
-			// TODO(tross): update this after converting logging to use slog
-			// Logger:          s.Logger,
+			Component:    teleport.ComponentDiscovery,
+			Logger:       s.Log,
 			Client:       s.AccessPoint,
 			MaxStaleness: time.Minute,
 		},

--- a/lib/srv/discovery/kube_services_watcher.go
+++ b/lib/srv/discovery/kube_services_watcher.go
@@ -20,7 +20,6 @@ package discovery
 
 import (
 	"context"
-	"log/slog"
 	"sync"
 	"time"
 
@@ -62,8 +61,7 @@ func (s *Server) startKubeAppsWatchers() error {
 				defer mu.Unlock()
 				return utils.FromSlice(appResources, types.Application.GetName)
 			},
-			// TODO(tross): update to use the server logger once it is converted to use slog
-			Logger:   slog.With("kind", types.KindApp),
+			Logger:   s.Log.With("kind", types.KindApp),
 			OnCreate: s.onAppCreate,
 			OnUpdate: s.onAppUpdate,
 			OnDelete: s.onAppDelete,


### PR DESCRIPTION
Cleans up some todos left during the logrus to slog conversion process.