### PR TITLE
Remove direct zap dependecy in operator and kube-agent-updater

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -200,7 +200,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.33.0
 	go.opentelemetry.io/otel/trace v1.33.0
 	go.opentelemetry.io/proto/otlp v1.5.0
-	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.32.0
 	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8
 	golang.org/x/mod v0.22.0
@@ -347,7 +346,6 @@ require (
 	github.com/go-gorp/gorp/v3 v3.1.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-openapi/analysis v0.23.0 // indirect
 	github.com/go-openapi/errors v0.22.0 // indirect
@@ -543,6 +541,7 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/mock v0.4.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/tools v0.29.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240716161551-93cc26a95ae9 // indirect
 	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 // indirect

--- a/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
+++ b/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
@@ -113,8 +113,7 @@ func main() {
 
 	// Now that we parsed the flags, we can tune the log level.
 	var lvl slog.Level
-	err = (&lvl).UnmarshalText([]byte(logLevel))
-	if err != nil {
+	if err := (&lvl).UnmarshalText([]byte(logLevel)); err != nil {
 		ctrl.Log.Error(err, "Failed to parse log level", "level", logLevel)
 		os.Exit(1)
 	}

--- a/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
+++ b/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
@@ -21,12 +21,14 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/distribution/reference"
+	"github.com/go-logr/logr"
 	"github.com/gravitational/trace"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -37,7 +39,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	kubeversionupdater "github.com/gravitational/teleport/integrations/kube-agent-updater"
@@ -46,6 +47,7 @@ import (
 	podmaintenance "github.com/gravitational/teleport/integrations/kube-agent-updater/pkg/maintenance"
 	"github.com/gravitational/teleport/lib/automaticupgrades/maintenance"
 	"github.com/gravitational/teleport/lib/automaticupgrades/version"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 var (
@@ -57,8 +59,24 @@ func init() {
 	utilruntime.Must(v1.AddToScheme(scheme))
 }
 
+var extraFields = []string{logutils.LevelField, logutils.ComponentField, logutils.TimestampField}
+
 func main() {
 	ctx := ctrl.SetupSignalHandler()
+
+	// Setup early logger, using INFO level by default.
+	slogLogger, slogLeveler, err := logutils.Initialize(logutils.Config{
+		Severity:    slog.LevelInfo.String(),
+		Format:      "json",
+		ExtraFields: extraFields,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to initialize logs: %v\n", err)
+		os.Exit(1)
+	}
+
+	logger := logr.FromSlogHandler(slogLogger.Handler())
+	ctrl.SetLogger(logger)
 
 	var agentName string
 	var agentNamespace string
@@ -72,6 +90,7 @@ func main() {
 	var insecureNoResolve bool
 	var disableLeaderElection bool
 	var credSource string
+	var logLevel string
 
 	flag.StringVar(&agentName, "agent-name", "", "The name of the agent that should be updated. This is mandatory.")
 	flag.StringVar(&agentNamespace, "agent-namespace", "", "The namespace of the agent that should be updated. This is mandatory.")
@@ -89,14 +108,17 @@ func main() {
 			img.DockerCredentialSource, img.GoogleCredentialSource, img.AmazonCredentialSource, img.NoCredentialSource,
 		),
 	)
-
-	opts := zap.Options{
-		Development: false,
-	}
-	opts.BindFlags(flag.CommandLine)
+	flag.StringVar(&logLevel, "log-level", "INFO", "Log level (DEBUG, INFO, WARN, ERROR).")
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	// Now that we parsed the flags, we can tune the log level.
+	var lvl slog.Level
+	err = (&lvl).UnmarshalText([]byte(logLevel))
+	if err != nil {
+		ctrl.Log.Error(err, "Failed to parse log level", "level", logLevel)
+		os.Exit(1)
+	}
+	slogLeveler.Set(lvl)
 
 	if agentName == "" {
 		ctrl.Log.Error(trace.BadParameter("--agent-name empty"), "agent-name must be provided")

--- a/integrations/lib/embeddedtbot/bot_test.go
+++ b/integrations/lib/embeddedtbot/bot_test.go
@@ -41,11 +41,12 @@ func TestBotJoinAuth(t *testing.T) {
 	// Configure and start Teleport server
 	clusterName := "root.example.com"
 	ctx := context.Background()
+	logger := utils.NewSlogLoggerForTests()
 	teleportServer := helpers.NewInstance(t, helpers.InstanceConfig{
 		ClusterName: clusterName,
 		HostID:      uuid.New().String(),
 		NodeName:    helpers.Loopback,
-		Logger:      utils.NewSlogLoggerForTests(),
+		Logger:      logger,
 	})
 
 	rcConf := servicecfg.MakeDefaultConfig()
@@ -128,7 +129,7 @@ func TestBotJoinAuth(t *testing.T) {
 		Oneshot:         true,
 		Debug:           true,
 	}
-	bot, err := New(botConfig)
+	bot, err := New(botConfig, logger)
 	require.NoError(t, err)
 	pong, err := bot.Preflight(ctx)
 	require.NoError(t, err)

--- a/integrations/operator/config.go
+++ b/integrations/operator/config.go
@@ -35,6 +35,7 @@ type operatorConfig struct {
 	leaderElectionID string
 	syncPeriod       time.Duration
 	namespace        string
+	logLevel         string
 }
 
 // BindFlags binds operatorConfig fields to CLI flags.
@@ -50,6 +51,7 @@ func (c *operatorConfig) BindFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.leaderElectionID, "leader-election-id", "431e83f4.teleport.dev", "Leader Election Id to use.")
 	fs.StringVar(&c.namespace, "namespace", "", "The namespace containing the Teleport CRs.")
 	fs.DurationVar(&c.syncPeriod, "sync-period", defaultSyncPeriod, "Operator sync period (format: https://pkg.go.dev/time#ParseDuration)")
+	fs.StringVar(&c.logLevel, "log-level", "INFO", "Log level (DEBUG, INFO, WARN, ERROR).")
 }
 
 // CheckAndSetDefaults checks the operatorConfig and populates unspecified

--- a/integrations/operator/controllers/resources/testlib/env.go
+++ b/integrations/operator/controllers/resources/testlib/env.go
@@ -28,10 +28,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -42,7 +42,6 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
@@ -58,6 +57,7 @@ import (
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 // scheme is our own test-specific scheme to avoid using the global
@@ -185,6 +185,7 @@ type TestSetup struct {
 	OperatorCancel           context.CancelFunc
 	OperatorName             string
 	stepByStepReconciliation bool
+	log                      *slog.Logger
 }
 
 // StartKubernetesOperator creates and start a new operator
@@ -206,8 +207,14 @@ func (s *TestSetup) StartKubernetesOperator(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	setupLog := ctrl.Log.WithName("setup")
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.Level(zapcore.DebugLevel)))
+	slogLogger := s.log
+	if slogLogger == nil {
+		slogLogger = utils.NewSlogLoggerForTests()
+	}
+
+	logger := logr.FromSlogHandler(slogLogger.Handler())
+	ctrl.SetLogger(logger)
+	setupLog := logger.WithName("setup")
 
 	pong, err := s.TeleportClient.Ping(context.Background())
 	require.NoError(t, err)

--- a/integrations/operator/main.go
+++ b/integrations/operator/main.go
@@ -75,8 +75,7 @@ func main() {
 
 	// Now that we parsed the flags, we can tune the log level.
 	var logLevel slog.Level
-	err = (&logLevel).UnmarshalText([]byte(config.logLevel))
-	if err != nil {
+	if err := (&logLevel).UnmarshalText([]byte(config.logLevel)); err != nil {
 		setupLog.Error(err, "Failed to parse log level", "level", config.logLevel)
 		os.Exit(1)
 	}

--- a/integrations/operator/main.go
+++ b/integrations/operator/main.go
@@ -21,9 +21,12 @@ package main
 
 import (
 	"flag"
+	"fmt"
+	"log/slog"
 	"os"
 	"time"
 
+	"github.com/go-logr/logr"
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -31,41 +34,61 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/integrations/lib/embeddedtbot"
 	"github.com/gravitational/teleport/integrations/operator/controllers"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 var (
-	scheme   = controllers.Scheme
-	setupLog = ctrl.Log.WithName("setup")
+	scheme = controllers.Scheme
 )
+
+var extraFields = []string{logutils.LevelField, logutils.ComponentField, logutils.TimestampField}
 
 func main() {
 	ctx := ctrl.SetupSignalHandler()
 
+	// Setup early logger, using INFO level by default.
+	slogLogger, slogLeveler, err := logutils.Initialize(logutils.Config{
+		Severity:    slog.LevelInfo.String(),
+		Format:      "json",
+		ExtraFields: extraFields,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to initialize logs: %v\n", err)
+		os.Exit(1)
+	}
+
+	logger := logr.FromSlogHandler(slogLogger.Handler())
+	ctrl.SetLogger(logger)
+	setupLog := logger.WithName("setup")
+
 	config := &operatorConfig{}
 	config.BindFlags(flag.CommandLine)
-	opts := zap.Options{
-		Development: true,
-	}
-	opts.BindFlags(flag.CommandLine)
 	botConfig := &embeddedtbot.BotConfig{}
 	botConfig.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	// Now that we parsed the flags, we can tune the log level.
+	var logLevel slog.Level
+	err = (&logLevel).UnmarshalText([]byte(config.logLevel))
+	if err != nil {
+		setupLog.Error(err, "Failed to parse log level", "level", config.logLevel)
+		os.Exit(1)
+	}
+	slogLeveler.Set(logLevel)
 
-	err := config.CheckAndSetDefaults()
+	err = config.CheckAndSetDefaults()
 	if err != nil {
 		setupLog.Error(err, "invalid configuration")
 		os.Exit(1)
 	}
 
-	bot, err := embeddedtbot.New(botConfig)
+	bot, err := embeddedtbot.New(botConfig, slogLogger.With(teleport.ComponentLabel, "embedded-tbot"))
 	if err != nil {
 		setupLog.Error(err, "unable to build tbot")
 		os.Exit(1)

--- a/integrations/terraform/provider/credentials.go
+++ b/integrations/terraform/provider/credentials.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"log/slog"
 	"strings"
 	"text/template"
 	"time"
@@ -524,7 +525,8 @@ See https://goteleport.com/docs/reference/join-methods for more details.`)
 		CertificateTTL:  time.Hour,
 		RenewalInterval: 20 * time.Minute,
 	}
-	bot, err := embeddedtbot.New(botConfig)
+	// slog default logger has been configured during the provider init.
+	bot, err := embeddedtbot.New(botConfig, slog.Default())
 	if err != nil {
 		return nil, trace.Wrap(err, "Failed to create bot configuration, this is a provider bug, please open a GitHub issue.")
 	}


### PR DESCRIPTION
This PR removes the direct zap dependency from the operator and kube-agent-updater.

This is a breaking change and must not be backported as the `-zap-*` CLI flags are removed. Those flags were not documented nor used directly, but users might have set them via the `extraArgs` chart value.

I switched logs by default to JSON and did not add a --log-format flag. I add such flag if you think this is necessary.

Changelog: Remove the `zap-log-level`, `zap-devel`, `zap-encoder` and `zap-stacktrace-level` flags in the operator. Use `--log-level` instead.
Changelog: Remove the `zap-log-level`, `zap-devel`, `zap-encoder` and `zap-stacktrace-level` flags in the teleport-kube-agent-updater. Use `--log-level` instead.
Changelog: The operator now logs using JSON by default.
Changelog: The kube-agent-updater now logs using JSON by default.