### PR TITLE
migrate AWS Redshift Serverless to AWS SDK v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/organizations v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/rds v1.93.2
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.53.1
+	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.25.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.72.0
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.8
 	github.com/aws/aws-sdk-go-v2/service/sns v1.33.8

--- a/go.sum
+++ b/go.sum
@@ -930,6 +930,8 @@ github.com/aws/aws-sdk-go-v2/service/rds v1.93.2 h1:Fv2//DyCH9n6LqEOvpeIFYYRfIhv
 github.com/aws/aws-sdk-go-v2/service/rds v1.93.2/go.mod h1:QEpwiX4BS6nos2d/ele6gRGalNW0Hzc1TZMmhkywQb0=
 github.com/aws/aws-sdk-go-v2/service/redshift v1.53.1 h1:fpuhuF5DuY26w61bBq8YrMYecLVs6eiQK7JbD9womPI=
 github.com/aws/aws-sdk-go-v2/service/redshift v1.53.1/go.mod h1:Uz+PdLUo8+x/iXFrZGc+j+w/AVAfc7Qmju9XjCiQGHE=
+github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.25.1 h1:anb79RuKbIO8z+SgNiDGCQln5CBI3Edzp9mXTAcZuNg=
+github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.25.1/go.mod h1:u4NPdVb3te3+QB4rdjFGE9Of4V3vPqrPbTk6fAR6qf8=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.72.0 h1:SAfh4pNx5LuTafKKWR02Y+hL3A+3TX8cTKG1OIAJaBk=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.72.0/go.mod h1:r+xl5yzMk9083rMR+sJ5TYj9Tihvf/l1oxzZXDgGj2Q=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.8 h1:WT3EPriVEpHE2jeNqHqj7l43JCIWPoZjNNRluZ7agII=

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -89,6 +89,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/organizations v1.37.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/rds v1.93.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.53.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.25.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.72.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.56.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.24.8 // indirect

--- a/integrations/event-handler/go.sum
+++ b/integrations/event-handler/go.sum
@@ -781,6 +781,8 @@ github.com/aws/aws-sdk-go-v2/service/rds v1.93.2 h1:Fv2//DyCH9n6LqEOvpeIFYYRfIhv
 github.com/aws/aws-sdk-go-v2/service/rds v1.93.2/go.mod h1:QEpwiX4BS6nos2d/ele6gRGalNW0Hzc1TZMmhkywQb0=
 github.com/aws/aws-sdk-go-v2/service/redshift v1.53.1 h1:fpuhuF5DuY26w61bBq8YrMYecLVs6eiQK7JbD9womPI=
 github.com/aws/aws-sdk-go-v2/service/redshift v1.53.1/go.mod h1:Uz+PdLUo8+x/iXFrZGc+j+w/AVAfc7Qmju9XjCiQGHE=
+github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.25.1 h1:anb79RuKbIO8z+SgNiDGCQln5CBI3Edzp9mXTAcZuNg=
+github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.25.1/go.mod h1:u4NPdVb3te3+QB4rdjFGE9Of4V3vPqrPbTk6fAR6qf8=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.72.0 h1:SAfh4pNx5LuTafKKWR02Y+hL3A+3TX8cTKG1OIAJaBk=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.72.0/go.mod h1:r+xl5yzMk9083rMR+sJ5TYj9Tihvf/l1oxzZXDgGj2Q=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.56.2 h1:MOxvXH2kRP5exvqJxAZ0/H9Ar51VmADJh95SgZE8u60=

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -101,6 +101,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/organizations v1.37.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/rds v1.93.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.53.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.25.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.72.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.56.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.24.8 // indirect

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -854,6 +854,8 @@ github.com/aws/aws-sdk-go-v2/service/rds v1.93.2 h1:Fv2//DyCH9n6LqEOvpeIFYYRfIhv
 github.com/aws/aws-sdk-go-v2/service/rds v1.93.2/go.mod h1:QEpwiX4BS6nos2d/ele6gRGalNW0Hzc1TZMmhkywQb0=
 github.com/aws/aws-sdk-go-v2/service/redshift v1.53.1 h1:fpuhuF5DuY26w61bBq8YrMYecLVs6eiQK7JbD9womPI=
 github.com/aws/aws-sdk-go-v2/service/redshift v1.53.1/go.mod h1:Uz+PdLUo8+x/iXFrZGc+j+w/AVAfc7Qmju9XjCiQGHE=
+github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.25.1 h1:anb79RuKbIO8z+SgNiDGCQln5CBI3Edzp9mXTAcZuNg=
+github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.25.1/go.mod h1:u4NPdVb3te3+QB4rdjFGE9Of4V3vPqrPbTk6fAR6qf8=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.72.0 h1:SAfh4pNx5LuTafKKWR02Y+hL3A+3TX8cTKG1OIAJaBk=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.72.0/go.mod h1:r+xl5yzMk9083rMR+sJ5TYj9Tihvf/l1oxzZXDgGj2Q=
 github.com/aws/aws-sdk-go-v2/service/sns v1.33.8 h1:zKokiUMOfbZSrAUVqw+bSjr6gl9u/JcvPzHTmL+tmdQ=

--- a/lib/cloud/aws/errors.go
+++ b/lib/cloud/aws/errors.go
@@ -28,7 +28,6 @@ import (
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/aws/aws-sdk-go/service/redshiftserverless"
 	"github.com/gravitational/trace"
 )
 
@@ -71,7 +70,7 @@ func convertRequestFailureErrorFromStatusCode(statusCode int, requestErr error) 
 	case http.StatusBadRequest:
 		// Some services like memorydb, redshiftserverless may return 400 with
 		// "AccessDeniedException" instead of 403.
-		if strings.Contains(requestErr.Error(), redshiftserverless.ErrCodeAccessDeniedException) {
+		if strings.Contains(requestErr.Error(), "AccessDeniedException") {
 			return trace.AccessDenied(requestErr.Error())
 		}
 

--- a/lib/cloud/aws/tags_helpers.go
+++ b/lib/cloud/aws/tags_helpers.go
@@ -26,12 +26,12 @@ import (
 	ec2TypesV2 "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	redshifttypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
+	rsstypes "github.com/aws/aws-sdk-go-v2/service/redshiftserverless/types"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/aws/aws-sdk-go/service/memorydb"
 	"github.com/aws/aws-sdk-go/service/opensearchservice"
-	"github.com/aws/aws-sdk-go/service/redshiftserverless"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"golang.org/x/exp/maps"
 
@@ -48,7 +48,7 @@ type ResourceTag interface {
 		*ec2.Tag |
 		*elasticache.Tag |
 		*memorydb.Tag |
-		*redshiftserverless.Tag |
+		rsstypes.Tag |
 		*opensearchservice.Tag |
 		*secretsmanager.Tag
 }
@@ -80,7 +80,7 @@ func resourceTagToKeyValue[Tag ResourceTag](tag Tag) (string, string) {
 		return aws.StringValue(v.Key), aws.StringValue(v.Value)
 	case *memorydb.Tag:
 		return aws.StringValue(v.Key), aws.StringValue(v.Value)
-	case *redshiftserverless.Tag:
+	case rsstypes.Tag:
 		return aws.StringValue(v.Key), aws.StringValue(v.Value)
 	case rdstypes.Tag:
 		return aws.StringValue(v.Key), aws.StringValue(v.Value)

--- a/lib/cloud/awstesthelpers/tags.go
+++ b/lib/cloud/awstesthelpers/tags.go
@@ -24,42 +24,38 @@ import (
 
 	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	redshifttypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
+	rsstypes "github.com/aws/aws-sdk-go-v2/service/redshiftserverless/types"
 )
+
+func LabelsToTags[T any](labels map[string]string, convert func(string, string) T) []T {
+	keys := slices.Collect(maps.Keys(labels))
+	slices.Sort(keys)
+	ret := make([]T, 0, len(keys))
+	for _, key := range keys {
+		value := labels[key]
+
+		ret = append(ret, convert(key, value))
+	}
+	return ret
+}
 
 // LabelsToRedshiftTags converts labels into [redshifttypes.Tag] list.
 func LabelsToRedshiftTags(labels map[string]string) []redshifttypes.Tag {
-	keys := slices.Collect(maps.Keys(labels))
-	slices.Sort(keys)
-
-	ret := make([]redshifttypes.Tag, 0, len(keys))
-	for _, key := range keys {
-		key := key
-		value := labels[key]
-
-		ret = append(ret, redshifttypes.Tag{
-			Key:   &key,
-			Value: &value,
-		})
-	}
-
-	return ret
+	return LabelsToTags(labels, func(key, value string) redshifttypes.Tag {
+		return redshifttypes.Tag{Key: &key, Value: &value}
+	})
 }
 
 // LabelsToRDSTags converts labels into a [rdstypes.Tag] list.
 func LabelsToRDSTags(labels map[string]string) []rdstypes.Tag {
-	keys := slices.Collect(maps.Keys(labels))
-	slices.Sort(keys)
+	return LabelsToTags(labels, func(key, value string) rdstypes.Tag {
+		return rdstypes.Tag{Key: &key, Value: &value}
+	})
+}
 
-	ret := make([]rdstypes.Tag, 0, len(keys))
-	for _, key := range keys {
-		key := key
-		value := labels[key]
-
-		ret = append(ret, rdstypes.Tag{
-			Key:   &key,
-			Value: &value,
-		})
-	}
-
-	return ret
+// LabelsToRedshiftServerlessTags converts labels into a [rsstypes.Tag] list.
+func LabelsToRedshiftServerlessTags(labels map[string]string) []rsstypes.Tag {
+	return LabelsToTags(labels, func(key, value string) rsstypes.Tag {
+		return rsstypes.Tag{Key: &key, Value: &value}
+	})
 }

--- a/lib/cloud/clients.go
+++ b/lib/cloud/clients.go
@@ -49,8 +49,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/memorydb/memorydbiface"
 	"github.com/aws/aws-sdk-go/service/opensearchservice"
 	"github.com/aws/aws-sdk-go/service/opensearchservice/opensearchserviceiface"
-	"github.com/aws/aws-sdk-go/service/redshiftserverless"
-	"github.com/aws/aws-sdk-go/service/redshiftserverless/redshiftserverlessiface"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
@@ -107,8 +105,6 @@ type GCPClients interface {
 type AWSClients interface {
 	// GetAWSSession returns AWS session for the specified region and any role(s).
 	GetAWSSession(ctx context.Context, region string, opts ...AWSOptionsFn) (*awssession.Session, error)
-	// GetAWSRedshiftServerlessClient returns AWS Redshift Serverless client for the specified region.
-	GetAWSRedshiftServerlessClient(ctx context.Context, region string, opts ...AWSOptionsFn) (redshiftserverlessiface.RedshiftServerlessAPI, error)
 	// GetAWSElastiCacheClient returns AWS ElastiCache client for the specified region.
 	GetAWSElastiCacheClient(ctx context.Context, region string, opts ...AWSOptionsFn) (elasticacheiface.ElastiCacheAPI, error)
 	// GetAWSMemoryDBClient returns AWS MemoryDB client for the specified region.
@@ -498,15 +494,6 @@ func (c *cloudClients) GetAWSSession(ctx context.Context, region string, opts ..
 		return options.baseSession, nil
 	}
 	return c.getAWSSessionForRole(ctx, region, options)
-}
-
-// GetAWSRedshiftServerlessClient returns AWS Redshift Serverless client for the specified region.
-func (c *cloudClients) GetAWSRedshiftServerlessClient(ctx context.Context, region string, opts ...AWSOptionsFn) (redshiftserverlessiface.RedshiftServerlessAPI, error) {
-	session, err := c.GetAWSSession(ctx, region, opts...)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return redshiftserverless.New(session), nil
 }
 
 // GetAWSElastiCacheClient returns AWS ElastiCache client for the specified region.
@@ -1006,7 +993,6 @@ var _ Clients = (*TestCloudClients)(nil)
 
 // TestCloudClients are used in tests.
 type TestCloudClients struct {
-	RedshiftServerless      redshiftserverlessiface.RedshiftServerlessAPI
 	ElastiCache             elasticacheiface.ElastiCacheAPI
 	OpenSearch              opensearchserviceiface.OpenSearchServiceAPI
 	MemoryDB                memorydbiface.MemoryDBAPI
@@ -1074,15 +1060,6 @@ func (c *TestCloudClients) getAWSSessionForRegion(region string) (*awssession.Se
 		Region:          aws.String(region),
 		UseFIPSEndpoint: useFIPSEndpoint,
 	})
-}
-
-// GetAWSRedshiftServerlessClient returns AWS Redshift Serverless client for the specified region.
-func (c *TestCloudClients) GetAWSRedshiftServerlessClient(ctx context.Context, region string, opts ...AWSOptionsFn) (redshiftserverlessiface.RedshiftServerlessAPI, error) {
-	_, err := c.GetAWSSession(ctx, region, opts...)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return c.RedshiftServerless, nil
 }
 
 // GetAWSElastiCacheClient returns AWS ElastiCache client for the specified region.

--- a/lib/cloud/mocks/aws_redshift_serverless.go
+++ b/lib/cloud/mocks/aws_redshift_serverless.go
@@ -19,123 +19,127 @@
 package mocks
 
 import (
+	"context"
 	"fmt"
 	"time"
 
+	rss "github.com/aws/aws-sdk-go-v2/service/redshiftserverless"
+	rsstypes "github.com/aws/aws-sdk-go-v2/service/redshiftserverless/types"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/service/redshiftserverless"
-	"github.com/aws/aws-sdk-go/service/redshiftserverless/redshiftserverlessiface"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 )
 
-// RedshiftServerlessMock mocks RedshiftServerless API.
-type RedshiftServerlessMock struct {
-	redshiftserverlessiface.RedshiftServerlessAPI
-
+type RedshiftServerlessClient struct {
 	Unauth               bool
-	Workgroups           []*redshiftserverless.Workgroup
-	Endpoints            []*redshiftserverless.EndpointAccess
-	TagsByARN            map[string][]*redshiftserverless.Tag
-	GetCredentialsOutput *redshiftserverless.GetCredentialsOutput
+	Workgroups           []rsstypes.Workgroup
+	Endpoints            []rsstypes.EndpointAccess
+	TagsByARN            map[string][]rsstypes.Tag
+	GetCredentialsOutput *rss.GetCredentialsOutput
 }
 
-func (m RedshiftServerlessMock) GetWorkgroupWithContext(_ aws.Context, input *redshiftserverless.GetWorkgroupInput, _ ...request.Option) (*redshiftserverless.GetWorkgroupOutput, error) {
+func (m RedshiftServerlessClient) GetWorkgroup(_ context.Context, input *rss.GetWorkgroupInput, _ ...func(*rss.Options)) (*rss.GetWorkgroupOutput, error) {
 	if m.Unauth {
 		return nil, trace.AccessDenied("unauthorized")
 	}
 
 	for _, workgroup := range m.Workgroups {
 		if aws.StringValue(workgroup.WorkgroupName) == aws.StringValue(input.WorkgroupName) {
-			return new(redshiftserverless.GetWorkgroupOutput).SetWorkgroup(workgroup), nil
+			return &rss.GetWorkgroupOutput{
+				Workgroup: &workgroup,
+			}, nil
 		}
 	}
 	return nil, trace.NotFound("workgroup %q not found", aws.StringValue(input.WorkgroupName))
 }
-func (m RedshiftServerlessMock) GetEndpointAccessWithContext(_ aws.Context, input *redshiftserverless.GetEndpointAccessInput, _ ...request.Option) (*redshiftserverless.GetEndpointAccessOutput, error) {
+
+func (m RedshiftServerlessClient) GetEndpointAccess(_ context.Context, input *rss.GetEndpointAccessInput, _ ...func(*rss.Options)) (*rss.GetEndpointAccessOutput, error) {
 	if m.Unauth {
 		return nil, trace.AccessDenied("unauthorized")
 	}
 	for _, endpoint := range m.Endpoints {
 		if aws.StringValue(endpoint.EndpointName) == aws.StringValue(input.EndpointName) {
-			return new(redshiftserverless.GetEndpointAccessOutput).SetEndpoint(endpoint), nil
+			return &rss.GetEndpointAccessOutput{
+				Endpoint: &endpoint,
+			}, nil
 		}
 	}
 	return nil, trace.NotFound("endpoint %q not found", aws.StringValue(input.EndpointName))
 }
-func (m RedshiftServerlessMock) ListWorkgroupsPagesWithContext(_ aws.Context, input *redshiftserverless.ListWorkgroupsInput, fn func(*redshiftserverless.ListWorkgroupsOutput, bool) bool, _ ...request.Option) error {
+
+func (m RedshiftServerlessClient) ListWorkgroups(_ context.Context, input *rss.ListWorkgroupsInput, _ ...func(*rss.Options)) (*rss.ListWorkgroupsOutput, error) {
 	if m.Unauth {
-		return trace.AccessDenied("unauthorized")
+		return nil, trace.AccessDenied("unauthorized")
 	}
-	fn(&redshiftserverless.ListWorkgroupsOutput{
+	return &rss.ListWorkgroupsOutput{
 		Workgroups: m.Workgroups,
-	}, true)
-	return nil
+	}, nil
 }
-func (m RedshiftServerlessMock) ListEndpointAccessPagesWithContext(_ aws.Context, input *redshiftserverless.ListEndpointAccessInput, fn func(*redshiftserverless.ListEndpointAccessOutput, bool) bool, _ ...request.Option) error {
+
+func (m RedshiftServerlessClient) ListEndpointAccess(_ context.Context, input *rss.ListEndpointAccessInput, _ ...func(*rss.Options)) (*rss.ListEndpointAccessOutput, error) {
 	if m.Unauth {
-		return trace.AccessDenied("unauthorized")
+		return nil, trace.AccessDenied("unauthorized")
 	}
-	fn(&redshiftserverless.ListEndpointAccessOutput{
+	return &rss.ListEndpointAccessOutput{
 		Endpoints: m.Endpoints,
-	}, true)
-	return nil
+	}, nil
 }
-func (m RedshiftServerlessMock) ListTagsForResourceWithContext(_ aws.Context, input *redshiftserverless.ListTagsForResourceInput, _ ...request.Option) (*redshiftserverless.ListTagsForResourceOutput, error) {
+
+func (m RedshiftServerlessClient) ListTagsForResource(_ context.Context, input *rss.ListTagsForResourceInput, _ ...func(*rss.Options)) (*rss.ListTagsForResourceOutput, error) {
 	if m.Unauth {
 		return nil, trace.AccessDenied("unauthorized")
 	}
 	if m.TagsByARN == nil {
-		return &redshiftserverless.ListTagsForResourceOutput{}, nil
+		return &rss.ListTagsForResourceOutput{}, nil
 	}
-	return &redshiftserverless.ListTagsForResourceOutput{
+	return &rss.ListTagsForResourceOutput{
 		Tags: m.TagsByARN[aws.StringValue(input.ResourceArn)],
 	}, nil
 }
-func (m RedshiftServerlessMock) GetCredentialsWithContext(aws.Context, *redshiftserverless.GetCredentialsInput, ...request.Option) (*redshiftserverless.GetCredentialsOutput, error) {
+
+func (m RedshiftServerlessClient) GetCredentials(context.Context, *rss.GetCredentialsInput, ...func(*rss.Options)) (*rss.GetCredentialsOutput, error) {
 	if m.Unauth || m.GetCredentialsOutput == nil {
 		return nil, trace.AccessDenied("access denied")
 	}
 	return m.GetCredentialsOutput, nil
 }
 
-// RedshiftServerlessWorkgroup returns a sample redshiftserverless.Workgroup.
-func RedshiftServerlessWorkgroup(name, region string) *redshiftserverless.Workgroup {
-	return &redshiftserverless.Workgroup{
-		BaseCapacity: aws.Int64(32),
-		ConfigParameters: []*redshiftserverless.ConfigParameter{{
+// RedshiftServerlessWorkgroup returns a sample rsstypes.Workgroup.
+func RedshiftServerlessWorkgroup(name, region string) *rsstypes.Workgroup {
+	return &rsstypes.Workgroup{
+		BaseCapacity: aws.Int32(32),
+		ConfigParameters: []rsstypes.ConfigParameter{{
 			ParameterKey:   aws.String("max_query_execution_time"),
 			ParameterValue: aws.String("14400"),
 		}},
 		CreationDate: aws.Time(sampleTime),
-		Endpoint: &redshiftserverless.Endpoint{
+		Endpoint: &rsstypes.Endpoint{
 			Address: aws.String(fmt.Sprintf("%v.123456789012.%v.redshift-serverless.amazonaws.com", name, region)),
-			Port:    aws.Int64(5439),
-			VpcEndpoints: []*redshiftserverless.VpcEndpoint{{
+			Port:    aws.Int32(5439),
+			VpcEndpoints: []rsstypes.VpcEndpoint{{
 				VpcEndpointId: aws.String("vpc-endpoint-id"),
 				VpcId:         aws.String("vpc-id"),
 			}},
 		},
 		NamespaceName:      aws.String("my-namespace"),
 		PubliclyAccessible: aws.Bool(true),
-		Status:             aws.String("AVAILABLE"),
+		Status:             rsstypes.WorkgroupStatusAvailable,
 		WorkgroupArn:       aws.String(fmt.Sprintf("arn:aws:redshift-serverless:%v:123456789012:workgroup/some-uuid-for-%v", region, name)),
 		WorkgroupId:        aws.String(fmt.Sprintf("some-uuid-for-%v", name)),
 		WorkgroupName:      aws.String(name),
 	}
 }
 
-// RedshiftServerlessEndpointAccess returns a sample redshiftserverless.EndpointAccess.
-func RedshiftServerlessEndpointAccess(workgroup *redshiftserverless.Workgroup, name, region string) *redshiftserverless.EndpointAccess {
-	return &redshiftserverless.EndpointAccess{
+// RedshiftServerlessEndpointAccess returns a sample rsstypes.EndpointAccess.
+func RedshiftServerlessEndpointAccess(workgroup *rsstypes.Workgroup, name, region string) *rsstypes.EndpointAccess {
+	return &rsstypes.EndpointAccess{
 		Address:            aws.String(fmt.Sprintf("%s-endpoint-xxxyyyzzz.123456789012.%s.redshift-serverless.amazonaws.com", name, region)),
 		EndpointArn:        aws.String(fmt.Sprintf("arn:aws:redshift-serverless:%s:123456789012:managedvpcendpoint/some-uuid-for-%v", region, name)),
 		EndpointCreateTime: aws.Time(sampleTime),
 		EndpointName:       aws.String(name),
 		EndpointStatus:     aws.String("AVAILABLE"),
-		Port:               aws.Int64(5439),
-		VpcEndpoint: &redshiftserverless.VpcEndpoint{
+		Port:               aws.Int32(5439),
+		VpcEndpoint: &rsstypes.VpcEndpoint{
 			VpcEndpointId: aws.String("vpce-id"),
 			VpcId:         aws.String("vpc-id"),
 		},
@@ -144,11 +148,11 @@ func RedshiftServerlessEndpointAccess(workgroup *redshiftserverless.Workgroup, n
 }
 
 // RedshiftServerlessGetCredentialsOutput return a sample redshiftserverless.GetCredentialsOutput.
-func RedshiftServerlessGetCredentialsOutput(user, password string, clock clockwork.Clock) *redshiftserverless.GetCredentialsOutput {
+func RedshiftServerlessGetCredentialsOutput(user, password string, clock clockwork.Clock) *rss.GetCredentialsOutput {
 	if clock == nil {
 		clock = clockwork.NewRealClock()
 	}
-	return &redshiftserverless.GetCredentialsOutput{
+	return &rss.GetCredentialsOutput{
 		DbUser:          aws.String(user),
 		DbPassword:      aws.String(password),
 		Expiration:      aws.Time(clock.Now().Add(15 * time.Minute)),

--- a/lib/srv/db/cloud/resource_checker_url_aws_test.go
+++ b/lib/srv/db/cloud/resource_checker_url_aws_test.go
@@ -24,10 +24,10 @@ import (
 
 	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	redshifttypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
+	rsstypes "github.com/aws/aws-sdk-go-v2/service/redshiftserverless/types"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/aws/aws-sdk-go/service/memorydb"
 	"github.com/aws/aws-sdk-go/service/opensearchservice"
-	"github.com/aws/aws-sdk-go/service/redshiftserverless"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
@@ -121,10 +121,6 @@ func TestURLChecker_AWS(t *testing.T) {
 
 	// Mock cloud clients.
 	mockClients := &cloud.TestCloudClients{
-		RedshiftServerless: &mocks.RedshiftServerlessMock{
-			Workgroups: []*redshiftserverless.Workgroup{redshiftServerlessWorkgroup},
-			Endpoints:  []*redshiftserverless.EndpointAccess{redshiftServerlessVPCEndpoint},
-		},
 		ElastiCache: &mocks.ElastiCacheMock{
 			ReplicationGroups: []*elasticache.ReplicationGroup{elastiCacheClusterConfigurationMode, elastiCacheCluster},
 		},
@@ -137,11 +133,10 @@ func TestURLChecker_AWS(t *testing.T) {
 		STS: &mocks.STSClientV1{},
 	}
 	mockClientsUnauth := &cloud.TestCloudClients{
-		RedshiftServerless: &mocks.RedshiftServerlessMock{Unauth: true},
-		ElastiCache:        &mocks.ElastiCacheMock{Unauth: true},
-		MemoryDB:           &mocks.MemoryDBMock{Unauth: true},
-		OpenSearch:         &mocks.OpenSearchMock{Unauth: true},
-		STS:                &mocks.STSClientV1{},
+		ElastiCache: &mocks.ElastiCacheMock{Unauth: true},
+		MemoryDB:    &mocks.MemoryDBMock{Unauth: true},
+		OpenSearch:  &mocks.OpenSearchMock{Unauth: true},
+		STS:         &mocks.STSClientV1{},
 	}
 
 	// Test both check methods.
@@ -167,6 +162,10 @@ func TestURLChecker_AWS(t *testing.T) {
 				redshiftClient: &mocks.RedshiftClient{
 					Clusters: []redshifttypes.Cluster{redshiftCluster},
 				},
+				rssClient: &mocks.RedshiftServerlessClient{
+					Workgroups: []rsstypes.Workgroup{*redshiftServerlessWorkgroup},
+					Endpoints:  []rsstypes.EndpointAccess{*redshiftServerlessVPCEndpoint},
+				},
 			},
 		},
 		{
@@ -176,6 +175,7 @@ func TestURLChecker_AWS(t *testing.T) {
 			awsClients: fakeAWSClients{
 				rdsClient:      &mocks.RDSClient{Unauth: true},
 				redshiftClient: &mocks.RedshiftClient{Unauth: true},
+				rssClient:      &mocks.RedshiftServerlessClient{Unauth: true},
 			},
 		},
 	}

--- a/lib/srv/db/watcher_test.go
+++ b/lib/srv/db/watcher_test.go
@@ -28,7 +28,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql"
-	"github.com/aws/aws-sdk-go/service/redshiftserverless"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+	"github.com/aws/aws-sdk-go-v2/service/redshift"
+	rss "github.com/aws/aws-sdk-go-v2/service/redshiftserverless"
+	rsstypes "github.com/aws/aws-sdk-go-v2/service/redshiftserverless/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
@@ -41,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
 	discovery "github.com/gravitational/teleport/lib/srv/discovery/common"
+	"github.com/gravitational/teleport/lib/srv/discovery/fetchers/db"
 )
 
 // TestWatcher verifies that database server properly detects and applies
@@ -309,8 +314,7 @@ func setLabels(r types.ResourceWithLabels, newLabels map[string]string) {
 // TestWatcherCloudFetchers tests usage of discovery database fetchers by the
 // database service.
 func TestWatcherCloudFetchers(t *testing.T) {
-	// Test an AWS fetcher. Note that status AWS can be set by Metadata
-	// service.
+	// Test an AWS fetcher.
 	redshiftServerlessWorkgroup := mocks.RedshiftServerlessWorkgroup("discovery-aws", "us-east-1")
 	redshiftServerlessDatabase, err := discovery.NewDatabaseFromRedshiftServerlessWorkgroup(redshiftServerlessWorkgroup, nil)
 	require.NoError(t, err)
@@ -328,6 +332,23 @@ func TestWatcherCloudFetchers(t *testing.T) {
 	ctx := context.Background()
 	testCtx := setupTestContext(ctx, t)
 
+	testCloudClients := &clients.TestCloudClients{
+		AzureSQLServer: azure.NewSQLClientByAPI(&azure.ARMSQLServerMock{
+			AllServers: []*armsql.Server{azSQLServer},
+		}),
+		AzureManagedSQLServer: azure.NewManagedSQLClientByAPI(&azure.ARMSQLManagedServerMock{}),
+	}
+	dbFetcherFactory, err := db.NewAWSFetcherFactory(db.AWSFetcherFactoryConfig{
+		AWSConfigProvider: &mocks.AWSConfigProvider{},
+		CloudClients:      testCloudClients,
+		AWSClients: fakeAWSClients{
+			rdsClient: &mocks.RDSClient{Unauth: true}, // Access denied error should not affect other fetchers.
+			rssClient: &mocks.RedshiftServerlessClient{
+				Workgroups: []rsstypes.Workgroup{*redshiftServerlessWorkgroup},
+			},
+		},
+	})
+	require.NoError(t, err)
 	reconcileCh := make(chan types.Databases)
 	testCtx.setupDatabaseServer(ctx, t, agentParams{
 		// Keep ResourceMatchers as nil to disable resource matchers.
@@ -343,14 +364,12 @@ func TestWatcherCloudFetchers(t *testing.T) {
 		}},
 		CloudClients: &clients.TestCloudClients{
 			STS: &mocks.STSClientV1{},
-			RedshiftServerless: &mocks.RedshiftServerlessMock{
-				Workgroups: []*redshiftserverless.Workgroup{redshiftServerlessWorkgroup},
-			},
 			AzureSQLServer: azure.NewSQLClientByAPI(&azure.ARMSQLServerMock{
 				AllServers: []*armsql.Server{azSQLServer},
 			}),
 			AzureManagedSQLServer: azure.NewManagedSQLClientByAPI(&azure.ARMSQLManagedServerMock{}),
 		},
+		AWSDatabaseFetcherFactory: dbFetcherFactory,
 		AzureMatchers: []types.AzureMatcher{{
 			Subscriptions: []string{"sub"},
 			Types:         []string{types.AzureMatcherSQLServer},
@@ -366,18 +385,21 @@ func TestWatcherCloudFetchers(t *testing.T) {
 	wantDatabases := types.Databases{azSQLServerDatabase, redshiftServerlessDatabase}
 	sort.Sort(wantDatabases)
 
-	assertReconciledResource(t, reconcileCh, wantDatabases)
+	// cloud metadata updater is disabled, so don't check the AWS metadata status.
+	assertReconciledResource(t, reconcileCh, wantDatabases, cmpopts.IgnoreFields(types.DatabaseStatusV3{}, "AWS"))
 }
 
-func assertReconciledResource(t *testing.T, ch chan types.Databases, databases types.Databases) {
+func assertReconciledResource(t *testing.T, ch chan types.Databases, databases types.Databases, opts ...cmp.Option) {
 	t.Helper()
 	select {
 	case d := <-ch:
 		sort.Sort(d)
 		require.Equal(t, len(databases), len(d))
 		require.Empty(t, cmp.Diff(databases, d,
-			cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
-			cmpopts.IgnoreFields(types.DatabaseStatusV3{}, "CACert"),
+			append(cmp.Options{
+				cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+				cmpopts.IgnoreFields(types.DatabaseStatusV3{}, "CACert"),
+			}, opts...),
 		))
 	case <-time.After(time.Second):
 		require.FailNow(t, "Didn't receive reconcile event after 1s.")
@@ -442,4 +464,22 @@ func makeAzureSQLServer(t *testing.T, name, group string) (*armsql.Server, types
 	require.NoError(t, err)
 	discovery.ApplyAzureDatabaseNameSuffix(database, types.AzureMatcherSQLServer)
 	return server, database
+}
+
+type fakeAWSClients struct {
+	rdsClient      db.RDSClient
+	redshiftClient db.RedshiftClient
+	rssClient      db.RSSClient
+}
+
+func (f fakeAWSClients) GetRDSClient(cfg aws.Config, optFns ...func(*rds.Options)) db.RDSClient {
+	return f.rdsClient
+}
+
+func (f fakeAWSClients) GetRedshiftClient(cfg aws.Config, optFns ...func(*redshift.Options)) db.RedshiftClient {
+	return f.redshiftClient
+}
+
+func (f fakeAWSClients) GetRedshiftServerlessClient(cfg aws.Config, optFns ...func(*rss.Options)) db.RSSClient {
+	return f.rssClient
 }

--- a/lib/srv/discovery/common/database_test.go
+++ b/lib/srv/discovery/common/database_test.go
@@ -32,7 +32,6 @@ import (
 	redshifttypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/aws/aws-sdk-go/service/memorydb"
-	"github.com/aws/aws-sdk-go/service/redshiftserverless"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
@@ -42,6 +41,7 @@ import (
 	awsutils "github.com/gravitational/teleport/api/utils/aws"
 	azureutils "github.com/gravitational/teleport/api/utils/azure"
 	libcloudaws "github.com/gravitational/teleport/lib/cloud/aws"
+	"github.com/gravitational/teleport/lib/cloud/awstesthelpers"
 	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/cloud/mocks"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -1658,7 +1658,7 @@ func TestDatabaseFromMemoryDBCluster(t *testing.T) {
 
 func TestDatabaseFromRedshiftServerlessWorkgroup(t *testing.T) {
 	workgroup := mocks.RedshiftServerlessWorkgroup("my-workgroup", "eu-west-2")
-	tags := libcloudaws.LabelsToTags[redshiftserverless.Tag](map[string]string{"env": "prod"})
+	tags := awstesthelpers.LabelsToRedshiftServerlessTags(map[string]string{"env": "prod"})
 	expected, err := types.NewDatabaseV3(types.Metadata{
 		Name:        "my-workgroup",
 		Description: "Redshift Serverless workgroup in eu-west-2",
@@ -1693,7 +1693,7 @@ func TestDatabaseFromRedshiftServerlessWorkgroup(t *testing.T) {
 func TestDatabaseFromRedshiftServerlessVPCEndpoint(t *testing.T) {
 	workgroup := mocks.RedshiftServerlessWorkgroup("my-workgroup", "eu-west-2")
 	endpoint := mocks.RedshiftServerlessEndpointAccess(workgroup, "my-endpoint", "eu-west-2")
-	tags := libcloudaws.LabelsToTags[redshiftserverless.Tag](map[string]string{"env": "prod"})
+	tags := awstesthelpers.LabelsToRedshiftServerlessTags(map[string]string{"env": "prod"})
 	expected, err := types.NewDatabaseV3(types.Metadata{
 		Name:        "my-workgroup-my-endpoint",
 		Description: "Redshift Serverless endpoint in eu-west-2",

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -45,6 +45,7 @@ import (
 	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/aws/aws-sdk-go-v2/service/redshift"
 	redshifttypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
+	rss "github.com/aws/aws-sdk-go-v2/service/redshiftserverless"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/google/go-cmp/cmp"
@@ -3870,6 +3871,7 @@ func newPopulatedGCPProjectsMock() *mockProjectsAPI {
 type fakeAWSClients struct {
 	rdsClient      db.RDSClient
 	redshiftClient db.RedshiftClient
+	rssClient      db.RSSClient
 }
 
 func (f fakeAWSClients) GetRDSClient(cfg aws.Config, optFns ...func(*rds.Options)) db.RDSClient {
@@ -3878,4 +3880,8 @@ func (f fakeAWSClients) GetRDSClient(cfg aws.Config, optFns ...func(*rds.Options
 
 func (f fakeAWSClients) GetRedshiftClient(cfg aws.Config, optFns ...func(*redshift.Options)) db.RedshiftClient {
 	return f.redshiftClient
+}
+
+func (f fakeAWSClients) GetRedshiftServerlessClient(cfg aws.Config, optFns ...func(*rss.Options)) db.RSSClient {
+	return f.rssClient
 }

--- a/lib/srv/discovery/fetchers/db/aws_rds_test.go
+++ b/lib/srv/discovery/fetchers/db/aws_rds_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/aws/aws-sdk-go-v2/service/redshift"
+	rss "github.com/aws/aws-sdk-go-v2/service/redshiftserverless"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
@@ -309,6 +310,7 @@ func newRegionalFakeRDSClientProvider(cs map[string]RDSClient) fakeRegionalRDSCl
 type fakeAWSClients struct {
 	rdsClient      RDSClient
 	redshiftClient RedshiftClient
+	rssClient      RSSClient
 }
 
 func (f fakeAWSClients) GetRDSClient(cfg aws.Config, optFns ...func(*rds.Options)) RDSClient {
@@ -317,6 +319,10 @@ func (f fakeAWSClients) GetRDSClient(cfg aws.Config, optFns ...func(*rds.Options
 
 func (f fakeAWSClients) GetRedshiftClient(cfg aws.Config, optFns ...func(*redshift.Options)) RedshiftClient {
 	return f.redshiftClient
+}
+
+func (f fakeAWSClients) GetRedshiftServerlessClient(cfg aws.Config, optFns ...func(*rss.Options)) RSSClient {
+	return f.rssClient
 }
 
 type fakeRegionalRDSClients struct {

--- a/lib/srv/discovery/fetchers/db/aws_redshift.go
+++ b/lib/srv/discovery/fetchers/db/aws_redshift.go
@@ -89,7 +89,7 @@ func (f *redshiftPlugin) ComponentShortName() string {
 
 // getRedshiftClusters fetches all Reshift clusters using the provided client,
 // up to the specified max number of pages
-func getRedshiftClusters(ctx context.Context, clt redshift.DescribeClustersAPIClient) ([]redshifttypes.Cluster, error) {
+func getRedshiftClusters(ctx context.Context, clt RedshiftClient) ([]redshifttypes.Cluster, error) {
 	pager := redshift.NewDescribeClustersPaginator(clt,
 		&redshift.DescribeClustersInput{},
 		func(dcpo *redshift.DescribeClustersPaginatorOptions) {

--- a/lib/srv/discovery/fetchers/db/aws_redshift_serverless.go
+++ b/lib/srv/discovery/fetchers/db/aws_redshift_serverless.go
@@ -22,16 +22,24 @@ import (
 	"context"
 	"log/slog"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/redshiftserverless"
-	"github.com/aws/aws-sdk-go/service/redshiftserverless/redshiftserverlessiface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	rss "github.com/aws/aws-sdk-go-v2/service/redshiftserverless"
+	rsstypes "github.com/aws/aws-sdk-go-v2/service/redshiftserverless/types"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/cloud"
 	libcloudaws "github.com/gravitational/teleport/lib/cloud/aws"
+	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
 )
+
+// RSSClient is a subset of the AWS Redshift Serverless API.
+type RSSClient interface {
+	rss.ListEndpointAccessAPIClient
+	rss.ListWorkgroupsAPIClient
+
+	ListTagsForResource(context.Context, *rss.ListTagsForResourceInput, ...func(*rss.Options)) (*rss.ListTagsForResourceOutput, error)
+}
 
 // newRedshiftServerlessFetcher returns a new AWS fetcher for Redshift
 // Serverless databases.
@@ -40,9 +48,9 @@ func newRedshiftServerlessFetcher(cfg awsFetcherConfig) (common.Fetcher, error) 
 }
 
 type workgroupWithTags struct {
-	*redshiftserverless.Workgroup
+	*rsstypes.Workgroup
 
-	Tags []*redshiftserverless.Tag
+	Tags []rsstypes.Tag
 }
 
 // redshiftServerlessPlugin retrieves Redshift Serverless databases.
@@ -53,25 +61,23 @@ func (f *redshiftServerlessPlugin) ComponentShortName() string {
 	return "rss<"
 }
 
-// rssAPI is a type alias for brevity alone.
-type rssAPI = redshiftserverlessiface.RedshiftServerlessAPI
-
 // GetDatabases returns Redshift Serverless databases matching the watcher's selectors.
 func (f *redshiftServerlessPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
-	client, err := cfg.AWSClients.GetAWSRedshiftServerlessClient(ctx, cfg.Region,
-		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
-		cloud.WithCredentialsMaybeIntegration(cfg.Integration),
+	awsCfg, err := cfg.AWSConfigProvider.GetConfig(ctx, cfg.Region,
+		awsconfig.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
+		awsconfig.WithCredentialsMaybeIntegration(cfg.Integration),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	databases, workgroups, err := getDatabasesFromWorkgroups(ctx, client, cfg.Logger)
+	clt := cfg.awsClients.GetRedshiftServerlessClient(awsCfg)
+	databases, workgroups, err := getDatabasesFromWorkgroups(ctx, clt, cfg.Logger)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	if len(workgroups) > 0 {
-		vpcEndpointDatabases, err := getDatabasesFromVPCEndpoints(ctx, workgroups, client, cfg.Logger)
+		vpcEndpointDatabases, err := getDatabasesFromVPCEndpoints(ctx, workgroups, clt, cfg.Logger)
 		if err != nil {
 			if trace.IsAccessDenied(err) {
 				cfg.Logger.DebugContext(ctx, "No permission to get Redshift Serverless VPC endpoints", "error", err)
@@ -85,7 +91,7 @@ func (f *redshiftServerlessPlugin) GetDatabases(ctx context.Context, cfg *awsFet
 	return databases, nil
 }
 
-func getDatabasesFromWorkgroups(ctx context.Context, client rssAPI, logger *slog.Logger) (types.Databases, []*workgroupWithTags, error) {
+func getDatabasesFromWorkgroups(ctx context.Context, client RSSClient, logger *slog.Logger) (types.Databases, []*workgroupWithTags, error) {
 	workgroups, err := getRSSWorkgroups(ctx, client)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
@@ -94,19 +100,19 @@ func getDatabasesFromWorkgroups(ctx context.Context, client rssAPI, logger *slog
 	var databases types.Databases
 	var workgroupsWithTags []*workgroupWithTags
 	for _, workgroup := range workgroups {
-		if !libcloudaws.IsResourceAvailable(workgroup, workgroup.Status) {
-			logger.DebugContext(ctx, "Skipping unavailable  Redshift Serverless workgroup",
-				"workgroup", aws.StringValue(workgroup.WorkgroupName),
-				"status", aws.StringValue(workgroup.Status),
+		if !isWorkgroupAvailable(logger, &workgroup) {
+			logger.DebugContext(ctx, "Skipping unavailable Redshift Serverless workgroup",
+				"status", workgroup.Status,
+				"workgroup", aws.ToString(workgroup.WorkgroupName),
 			)
 			continue
 		}
 
 		tags := getRSSResourceTags(ctx, workgroup.WorkgroupArn, client, logger)
-		database, err := common.NewDatabaseFromRedshiftServerlessWorkgroup(workgroup, tags)
+		database, err := common.NewDatabaseFromRedshiftServerlessWorkgroup(&workgroup, tags)
 		if err != nil {
 			logger.InfoContext(ctx, "Could not convert Redshift Serverless workgroup to database resource",
-				"workgroup", aws.StringValue(workgroup.WorkgroupName),
+				"workgroup", aws.ToString(workgroup.WorkgroupName),
 				"error", err,
 			)
 			continue
@@ -114,14 +120,14 @@ func getDatabasesFromWorkgroups(ctx context.Context, client rssAPI, logger *slog
 
 		databases = append(databases, database)
 		workgroupsWithTags = append(workgroupsWithTags, &workgroupWithTags{
-			Workgroup: workgroup,
+			Workgroup: &workgroup,
 			Tags:      tags,
 		})
 	}
 	return databases, workgroupsWithTags, nil
 }
 
-func getDatabasesFromVPCEndpoints(ctx context.Context, workgroups []*workgroupWithTags, client rssAPI, logger *slog.Logger) (types.Databases, error) {
+func getDatabasesFromVPCEndpoints(ctx context.Context, workgroups []*workgroupWithTags, client RSSClient, logger *slog.Logger) (types.Databases, error) {
 	endpoints, err := getRSSVPCEndpoints(ctx, client)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -129,26 +135,26 @@ func getDatabasesFromVPCEndpoints(ctx context.Context, workgroups []*workgroupWi
 
 	var databases types.Databases
 	for _, endpoint := range endpoints {
-		workgroup, found := findWorkgroupWithName(workgroups, aws.StringValue(endpoint.WorkgroupName))
+		workgroup, found := findWorkgroupWithName(workgroups, aws.ToString(endpoint.WorkgroupName))
 		if !found {
-			logger.DebugContext(ctx, "Could not find matching workgroup for Redshift Serverless endpoint", "endpoint", aws.StringValue(endpoint.EndpointName))
+			logger.DebugContext(ctx, "Could not find matching workgroup for Redshift Serverless endpoint", "endpoint", aws.ToString(endpoint.EndpointName))
 			continue
 		}
 
 		if !libcloudaws.IsResourceAvailable(endpoint, endpoint.EndpointStatus) {
 			logger.DebugContext(ctx, "Skipping unavailable Redshift Serverless endpoint",
-				"endpoint", aws.StringValue(endpoint.EndpointName),
-				"status", aws.StringValue(endpoint.EndpointStatus),
+				"endpoint", aws.ToString(endpoint.EndpointName),
+				"status", aws.ToString(endpoint.EndpointStatus),
 			)
 			continue
 		}
 
 		// VPC endpoints do not have resource tags attached to them. Use the
 		// tags from the workgroups instead.
-		database, err := common.NewDatabaseFromRedshiftServerlessVPCEndpoint(endpoint, workgroup.Workgroup, workgroup.Tags)
+		database, err := common.NewDatabaseFromRedshiftServerlessVPCEndpoint(&endpoint, workgroup.Workgroup, workgroup.Tags)
 		if err != nil {
 			logger.InfoContext(ctx, "Could not convert Redshift Serverless endpoint to database resource",
-				"endpoint", aws.StringValue(endpoint.EndpointName),
+				"endpoint", aws.ToString(endpoint.EndpointName),
 				"error", err,
 			)
 			continue
@@ -158,20 +164,20 @@ func getDatabasesFromVPCEndpoints(ctx context.Context, workgroups []*workgroupWi
 	return databases, nil
 }
 
-func getRSSResourceTags(ctx context.Context, arn *string, client rssAPI, logger *slog.Logger) []*redshiftserverless.Tag {
-	output, err := client.ListTagsForResourceWithContext(ctx, &redshiftserverless.ListTagsForResourceInput{
+func getRSSResourceTags(ctx context.Context, arn *string, client RSSClient, logger *slog.Logger) []rsstypes.Tag {
+	output, err := client.ListTagsForResource(ctx, &rss.ListTagsForResourceInput{
 		ResourceArn: arn,
 	})
 	if err != nil {
 		// Log errors here and return nil.
 		if trace.IsAccessDenied(err) {
 			logger.DebugContext(ctx, "No Permission to get Redshift Serverless tags",
-				"arn", aws.StringValue(arn),
+				"arn", aws.ToString(arn),
 				"error", err,
 			)
 		} else {
 			logger.WarnContext(ctx, "Failed to get Redshift Serverless tags",
-				"arn", aws.StringValue(arn),
+				"arn", aws.ToString(arn),
 				"error", err,
 			)
 		}
@@ -180,29 +186,66 @@ func getRSSResourceTags(ctx context.Context, arn *string, client rssAPI, logger 
 	return output.Tags
 }
 
-func getRSSWorkgroups(ctx context.Context, client rssAPI) ([]*redshiftserverless.Workgroup, error) {
-	var pages [][]*redshiftserverless.Workgroup
-	err := client.ListWorkgroupsPagesWithContext(ctx, nil, func(page *redshiftserverless.ListWorkgroupsOutput, lastPage bool) bool {
-		pages = append(pages, page.Workgroups)
-		return len(pages) <= maxAWSPages
-	})
-	return flatten(pages), libcloudaws.ConvertRequestFailureError(err)
+func getRSSWorkgroups(ctx context.Context, clt RSSClient) ([]rsstypes.Workgroup, error) {
+	var out []rsstypes.Workgroup
+	pager := rss.NewListWorkgroupsPaginator(clt,
+		&rss.ListWorkgroupsInput{},
+		func(o *rss.ListWorkgroupsPaginatorOptions) {
+			o.StopOnDuplicateToken = true
+		},
+	)
+	for i := 0; i < maxAWSPages && pager.HasMorePages(); i++ {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, libcloudaws.ConvertRequestFailureErrorV2(err)
+		}
+		out = append(out, page.Workgroups...)
+	}
+	return out, nil
 }
 
-func getRSSVPCEndpoints(ctx context.Context, client rssAPI) ([]*redshiftserverless.EndpointAccess, error) {
-	var pages [][]*redshiftserverless.EndpointAccess
-	err := client.ListEndpointAccessPagesWithContext(ctx, nil, func(page *redshiftserverless.ListEndpointAccessOutput, lastPage bool) bool {
-		pages = append(pages, page.Endpoints)
-		return len(pages) <= maxAWSPages
-	})
-	return flatten(pages), libcloudaws.ConvertRequestFailureError(err)
+func getRSSVPCEndpoints(ctx context.Context, clt RSSClient) ([]rsstypes.EndpointAccess, error) {
+	var out []rsstypes.EndpointAccess
+	pager := rss.NewListEndpointAccessPaginator(clt,
+		&rss.ListEndpointAccessInput{},
+		func(o *rss.ListEndpointAccessPaginatorOptions) {
+			o.StopOnDuplicateToken = true
+		},
+	)
+	for i := 0; i < maxAWSPages && pager.HasMorePages(); i++ {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, libcloudaws.ConvertRequestFailureErrorV2(err)
+		}
+		out = append(out, page.Endpoints...)
+	}
+	return out, nil
 }
 
 func findWorkgroupWithName(workgroups []*workgroupWithTags, name string) (*workgroupWithTags, bool) {
 	for _, workgroup := range workgroups {
-		if aws.StringValue(workgroup.WorkgroupName) == name {
+		if aws.ToString(workgroup.WorkgroupName) == name {
 			return workgroup, true
 		}
 	}
 	return nil, false
+}
+
+func isWorkgroupAvailable(logger *slog.Logger, wg *rsstypes.Workgroup) bool {
+	switch wg.Status {
+	case
+		rsstypes.WorkgroupStatusAvailable,
+		rsstypes.WorkgroupStatusModifying:
+		return true
+	case
+		rsstypes.WorkgroupStatusCreating,
+		rsstypes.WorkgroupStatusDeleting:
+		return false
+	default:
+		logger.WarnContext(context.Background(), "Assuming Redshift Serverless workgroup with an unknown status is available",
+			"status", wg.Status,
+			"workgroup", aws.ToString(wg.NamespaceName),
+		)
+		return true
+	}
 }

--- a/lib/srv/discovery/fetchers/db/db.go
+++ b/lib/srv/discovery/fetchers/db/db.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/redshift"
+	rss "github.com/aws/aws-sdk-go-v2/service/redshiftserverless"
 	"github.com/gravitational/trace"
 	"golang.org/x/exp/maps"
 
@@ -74,6 +75,8 @@ type AWSClientProvider interface {
 	GetRDSClient(cfg aws.Config, optFns ...func(*rds.Options)) RDSClient
 	// GetRedshiftClient provides an [RedshiftClient].
 	GetRedshiftClient(cfg aws.Config, optFns ...func(*redshift.Options)) RedshiftClient
+	// GetRedshiftServerlessClient provides an [RSSClient].
+	GetRedshiftServerlessClient(cfg aws.Config, optFns ...func(*rss.Options)) RSSClient
 }
 
 type defaultAWSClients struct{}
@@ -84,6 +87,10 @@ func (defaultAWSClients) GetRDSClient(cfg aws.Config, optFns ...func(*rds.Option
 
 func (defaultAWSClients) GetRedshiftClient(cfg aws.Config, optFns ...func(*redshift.Options)) RedshiftClient {
 	return redshift.NewFromConfig(cfg, optFns...)
+}
+
+func (defaultAWSClients) GetRedshiftServerlessClient(cfg aws.Config, optFns ...func(*rss.Options)) RSSClient {
+	return rss.NewFromConfig(cfg, optFns...)
 }
 
 // AWSFetcherFactoryConfig is the configuration for an [AWSFetcherFactory].
@@ -210,12 +217,4 @@ func filterDatabasesByLabels(ctx context.Context, databases types.Databases, lab
 		}
 	}
 	return matchedDatabases
-}
-
-// flatten flattens a nested slice [][]T to []T.
-func flatten[T any](s [][]T) (result []T) {
-	for i := range s {
-		result = append(result, s[i]...)
-	}
-	return
 }


### PR DESCRIPTION
This PR migrates all uses of AWS Redshift Serverless clients to AWS SDK v2.

This PR depends on and is stacked on top of another PR:
- #50848

Part of https://github.com/gravitational/teleport/issues/14142
- https://github.com/gravitational/teleport/issues/14142