### PR TITLE
WebDiscover: allow setting labels when enrolling aws app

### DIFF
--- a/web/packages/teleport/src/Discover/AwsMangementConsole/CreateAppAccess/CreateAppAccess.story.tsx
+++ b/web/packages/teleport/src/Discover/AwsMangementConsole/CreateAppAccess/CreateAppAccess.story.tsx
@@ -45,7 +45,7 @@ export const Success = () => <Component />;
 Success.parameters = {
   msw: {
     handlers: [
-      http.post(cfg.api.awsAppAccessPath, () =>
+      http.post(cfg.api.awsAppAccess.createV2, () =>
         HttpResponse.json({ name: 'app-1' })
       ),
     ],
@@ -59,7 +59,10 @@ export const Loading = () => {
 Loading.parameters = {
   msw: {
     handlers: [
-      http.post(cfg.api.awsAppAccessPath, async () => await delay('infinite')),
+      http.post(
+        cfg.api.awsAppAccess.createV2,
+        async () => await delay('infinite')
+      ),
     ],
   },
 };
@@ -68,7 +71,7 @@ export const Failed = () => <Component />;
 Failed.parameters = {
   msw: {
     handlers: [
-      http.post(cfg.api.awsAppAccessPath, () =>
+      http.post(cfg.api.awsAppAccess.createV2, () =>
         HttpResponse.json(
           {
             message: 'Some kind of error message',

--- a/web/packages/teleport/src/Discover/Shared/LabelsCreater/LabelsCreater.tsx
+++ b/web/packages/teleport/src/Discover/Shared/LabelsCreater/LabelsCreater.tsx
@@ -192,7 +192,6 @@ export function LabelsCreater({
         label={labels.length === 0 ? 'Add a Label' : 'Add Another Label'}
         onClick={addLabel}
         disabled={disableBtns}
-        iconSize="small"
       />
     </>
   );

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -361,8 +361,12 @@ const cfg = {
     awsSubnetListPath:
       '/v1/webapi/sites/:clusterId/integrations/aws-oidc/:name/subnets',
 
-    awsAppAccessPath:
-      '/v1/webapi/sites/:clusterId/integrations/aws-oidc/:name/aws-app-access',
+    awsAppAccess: {
+      create:
+        '/v1/webapi/sites/:clusterId/integrations/aws-oidc/:name/aws-app-access',
+      createV2:
+        '/v2/webapi/sites/:clusterId/integrations/aws-oidc/:name/aws-app-access',
+    },
     awsConfigureIamAppAccessPath:
       '/v1/webapi/scripts/integrations/configure/aws-app-access-iam.sh?role=:iamRoleName&awsAccountID=:accountID',
 
@@ -1057,7 +1061,16 @@ const cfg = {
   getAwsAppAccessUrl(integrationName: string) {
     const clusterId = cfg.proxyCluster;
 
-    return generatePath(cfg.api.awsAppAccessPath, {
+    return generatePath(cfg.api.awsAppAccess.create, {
+      clusterId,
+      name: integrationName,
+    });
+  },
+
+  getAwsAppAccessUrlV2(integrationName: string) {
+    const clusterId = cfg.proxyCluster;
+
+    return generatePath(cfg.api.awsAppAccess.createV2, {
       clusterId,
       name: integrationName,
     });

--- a/web/packages/teleport/src/services/integrations/integrations.test.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.test.ts
@@ -244,32 +244,6 @@ test('enrollEksClusters with labels calls v2', async () => {
   );
 });
 
-test('createAwsAppAccess without labels calls v1', async () => {
-  jest.spyOn(api, 'post').mockResolvedValue({});
-
-  await integrationService.createAwsAppAccess('integration', {});
-
-  expect(api.post).toHaveBeenCalledWith(
-    cfg.getAwsAppAccessUrl('integration'),
-    {}
-  );
-});
-
-test('createAwsAppAccess with labels calls v2', async () => {
-  jest.spyOn(api, 'post').mockResolvedValue({});
-
-  await integrationService.createAwsAppAccess('integration', {
-    labels: { env: 'staging' },
-  });
-
-  expect(api.post).toHaveBeenCalledWith(
-    cfg.getAwsAppAccessUrlV2('integration'),
-    {
-      labels: { env: 'staging' },
-    }
-  );
-});
-
 describe('fetchAwsDatabases() request body formatting', () => {
   test.each`
     protocol             | expectedEngines          | expectedRdsType

--- a/web/packages/teleport/src/services/integrations/integrations.test.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.test.ts
@@ -244,6 +244,32 @@ test('enrollEksClusters with labels calls v2', async () => {
   );
 });
 
+test('createAwsAppAccess without labels calls v1', async () => {
+  jest.spyOn(api, 'post').mockResolvedValue({});
+
+  await integrationService.createAwsAppAccess('integration', {});
+
+  expect(api.post).toHaveBeenCalledWith(
+    cfg.getAwsAppAccessUrl('integration'),
+    {}
+  );
+});
+
+test('createAwsAppAccess with labels calls v2', async () => {
+  jest.spyOn(api, 'post').mockResolvedValue({});
+
+  await integrationService.createAwsAppAccess('integration', {
+    labels: { env: 'staging' },
+  });
+
+  expect(api.post).toHaveBeenCalledWith(
+    cfg.getAwsAppAccessUrlV2('integration'),
+    {
+      labels: { env: 'staging' },
+    }
+  );
+});
+
 describe('fetchAwsDatabases() request body formatting', () => {
   test.each`
     protocol             | expectedEngines          | expectedRdsType

--- a/web/packages/teleport/src/services/integrations/integrations.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.ts
@@ -32,6 +32,7 @@ import {
   AwsOidcPingRequest,
   AwsOidcPingResponse,
   AwsRdsDatabase,
+  CreateAwsAppAccessRequest,
   DeployEc2InstanceConnectEndpointRequest,
   DeployEc2InstanceConnectEndpointResponse,
   Ec2InstanceConnectEndpoint,
@@ -292,10 +293,24 @@ export const integrationService = {
       .then(resp => resp.serviceDashboardUrl);
   },
 
-  async createAwsAppAccess(integrationName): Promise<App> {
-    return api
-      .post(cfg.getAwsAppAccessUrl(integrationName), null)
-      .then(makeApp);
+  async createAwsAppAccess(
+    integrationName,
+    req: CreateAwsAppAccessRequest
+  ): Promise<App> {
+    // TODO(kimlisa): DELETE IN 19.0 - replaced by v2 endpoint.
+    if (!req.labels || !Object.keys(req.labels).length) {
+      return api
+        .post(cfg.getAwsAppAccessUrl(integrationName), req)
+        .then(makeApp);
+    }
+
+    return (
+      api
+        .post(cfg.getAwsAppAccessUrlV2(integrationName), req)
+        .then(makeApp)
+        // TODO(kimlisa): DELETE IN 19.0
+        .catch(withUnsupportedLabelFeatureErrorConversion)
+    );
   },
 
   async deployDatabaseServices(

--- a/web/packages/teleport/src/services/integrations/integrations.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.ts
@@ -293,17 +293,10 @@ export const integrationService = {
       .then(resp => resp.serviceDashboardUrl);
   },
 
-  async createAwsAppAccess(
+  async createAwsAppAccessV2(
     integrationName,
     req: CreateAwsAppAccessRequest
   ): Promise<App> {
-    // TODO(kimlisa): DELETE IN 19.0 - replaced by v2 endpoint.
-    if (!req.labels || !Object.keys(req.labels).length) {
-      return api
-        .post(cfg.getAwsAppAccessUrl(integrationName), req)
-        .then(makeApp);
-    }
-
     return (
       api
         .post(cfg.getAwsAppAccessUrlV2(integrationName), req)
@@ -311,6 +304,14 @@ export const integrationService = {
         // TODO(kimlisa): DELETE IN 19.0
         .catch(withUnsupportedLabelFeatureErrorConversion)
     );
+  },
+
+  // TODO(kimlisa): DELETE IN 19.0
+  // replaced by createAwsAppAccessV2 that accepts request body
+  async createAwsAppAccess(integrationName): Promise<App> {
+    return api
+      .post(cfg.getAwsAppAccessUrl(integrationName), null)
+      .then(makeApp);
   },
 
   async deployDatabaseServices(

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -759,3 +759,7 @@ export type AwsDatabaseVpcsResponse = {
   vpcs: Vpc[];
   nextToken: string;
 };
+
+export type CreateAwsAppAccessRequest = {
+  labels?: Record<string, string>;
+};

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -760,6 +760,15 @@ export type AwsDatabaseVpcsResponse = {
   nextToken: string;
 };
 
+/**
+ * Object that contains request fields for
+ * when requesting to create an AWS console app.
+ *
+ * This request object is only supported with v2 endpoint.
+ */
 export type CreateAwsAppAccessRequest = {
+  /**
+   * resource labels that will be set as app_server's labels
+   */
   labels?: Record<string, string>;
 };

--- a/web/packages/teleport/src/services/version/unsupported.ts
+++ b/web/packages/teleport/src/services/version/unsupported.ts
@@ -18,6 +18,8 @@
 
 import { ApiError } from '../api/parseError';
 
+export const ProxyRequiresUpgrade = 'Ensure all proxies are upgraded';
+
 export function withUnsupportedLabelFeatureErrorConversion(
   err: unknown
 ): never {
@@ -26,7 +28,7 @@ export function withUnsupportedLabelFeatureErrorConversion(
       'We could not complete your request. ' +
         'Your proxy may be behind the minimum required version ' +
         `(v17.2.0) to support adding resource labels. ` +
-        'Ensure all proxies are upgraded or remove labels and try again.'
+        `${ProxyRequiresUpgrade} or remove labels and try again.`
     );
   }
   throw err;


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/46976

requires https://github.com/gravitational/teleport/pull/50975

<img width="869" alt="image" src="https://github.com/user-attachments/assets/08d545e7-ea31-4152-9643-7a95db97f8da" />

with some labels

<img width="839" alt="image" src="https://github.com/user-attachments/assets/02cf3549-ea5a-4886-bd94-b03b11b61c98" />

changelog: Adds support for defining labels in the web UI for AWS console access application