### PR TITLE
Add field for changing target port if app gateway fails to start

### DIFF
--- a/web/.storybook/preview.tsx
+++ b/web/.storybook/preview.tsx
@@ -26,6 +26,7 @@ import { Theme } from '../packages/design/src/theme/themes/types';
 import { ConfiguredThemeProvider } from '../packages/design/src/ThemeProvider';
 import history from '../packages/teleport/src/services/history/history';
 import { UserContextProvider } from '../packages/teleport/src/User';
+import Logger, { ConsoleService } from '../packages/teleterm/src/logger';
 import { StaticThemeProvider as TeletermThemeProvider } from '../packages/teleterm/src/ui/ThemeProvider';
 import {
   darkTheme as teletermDarkTheme,
@@ -35,6 +36,8 @@ import {
 initialize();
 
 history.init();
+
+Logger.init(new ConsoleService());
 
 interface ThemeDecoratorProps {
   theme: string;

--- a/web/packages/teleterm/src/logger.ts
+++ b/web/packages/teleterm/src/logger.ts
@@ -69,3 +69,19 @@ export class NullService implements LoggerService {
   }
   /* eslint-enable @typescript-eslint/no-unused-vars */
 }
+
+export class ConsoleService implements LoggerService {
+  createLogger(loggerName: string): types.Logger {
+    return {
+      warn(...args: any[]) {
+        console.warn(loggerName, ...args);
+      },
+      info(...args: any[]) {
+        console.info(loggerName, ...args);
+      },
+      error(...args: any[]) {
+        console.error(loggerName, ...args);
+      },
+    };
+  }
+}

--- a/web/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.story.tsx
@@ -28,6 +28,10 @@ import {
 import { makeDatabaseGateway } from 'teleterm/services/tshd/testHelpers';
 
 import { OfflineGateway } from '../components/OfflineGateway';
+import {
+  formSchema,
+  makeRenderFormControlsFromDefaultPort,
+} from './DocumentGateway';
 import { OnlineDocumentGateway } from './OnlineDocumentGateway';
 
 type StoryProps = {
@@ -99,9 +103,10 @@ export function Story(props: StoryProps) {
     const offlineGatewayProps: ComponentProps<typeof OfflineGateway> = {
       connectAttempt: makeEmptyAttempt(),
       reconnect: () => {},
-      gatewayPort: { isSupported: true, defaultPort: '1337' },
       targetName: gateway.targetName,
       gatewayKind: 'database',
+      formSchema,
+      renderFormControls: makeRenderFormControlsFromDefaultPort('1337'),
     };
 
     if (props.connectAttempt === 'error') {

--- a/web/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import userEvent from '@testing-library/user-event';
+
+import { render, screen } from 'design/utils/testing';
+
+import { MockedUnaryCall } from 'teleterm/services/tshd/cloneableClient';
+import {
+  makeDatabaseGateway,
+  makeRootCluster,
+} from 'teleterm/services/tshd/testHelpers';
+import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
+import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
+import type * as docs from 'teleterm/ui/services/workspacesService';
+import { DatabaseUri } from 'teleterm/ui/uri';
+
+import { MockWorkspaceContextProvider } from '../fixtures/MockWorkspaceContextProvider';
+import { DocumentGateway } from './DocumentGateway';
+
+test('it allows reconnecting when the gateway fails to be created', async () => {
+  const user = userEvent.setup();
+
+  const appContext = new MockAppContext();
+  const cluster = makeRootCluster();
+  const gateway = makeDatabaseGateway();
+  const doc: docs.DocumentGateway = {
+    uri: '/docs/1',
+    kind: 'doc.gateway',
+    targetName: gateway.targetName,
+    targetUri: gateway.targetUri as DatabaseUri,
+    targetUser: gateway.targetUser,
+    targetSubresourceName: gateway.targetSubresourceName,
+    gatewayUri: gateway.uri,
+    origin: 'resource_table',
+    title: '',
+    status: '',
+  };
+  appContext.addRootClusterWithDoc(cluster, doc);
+
+  jest
+    .spyOn(appContext.tshd, 'createGateway')
+    .mockReturnValueOnce(
+      new MockedUnaryCall(undefined, new Error('Something went wrong'))
+    )
+    .mockReturnValueOnce(new MockedUnaryCall(gateway));
+
+  render(
+    <MockAppContextProvider appContext={appContext}>
+      <MockWorkspaceContextProvider>
+        <DocumentGateway visible doc={doc} />
+      </MockWorkspaceContextProvider>
+    </MockAppContextProvider>
+  );
+
+  expect(
+    await screen.findByText('Could not establish the connection')
+  ).toBeInTheDocument();
+
+  await user.click(screen.getByText('Reconnect'));
+
+  expect(await screen.findByText('Close Connection')).toBeInTheDocument();
+});

--- a/web/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.tsx
@@ -16,11 +16,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { useMemo } from 'react';
+import { z } from 'zod';
+
 import { getCliCommandArgv0 } from 'teleterm/services/tshd/gateway';
 import Document from 'teleterm/ui/Document';
 import * as types from 'teleterm/ui/services/workspacesService';
 
-import { OfflineGateway } from '../components/OfflineGateway';
+import { PortFieldInput } from '../components/FieldInputs';
+import { FormFields, OfflineGateway } from '../components/OfflineGateway';
 import { useWorkspaceContext } from '../Documents';
 import { OnlineDocumentGateway } from './OnlineDocumentGateway';
 import { useGateway } from './useGateway';
@@ -63,15 +67,21 @@ export function DocumentGateway(props: {
     documentsService.setLocation(cliDoc.uri);
   };
 
+  const renderFormControls = useMemo(
+    () => makeRenderFormControlsFromDefaultPort(defaultPort),
+    [defaultPort]
+  );
+
   if (!connected) {
     return (
       <Document visible={visible}>
         <OfflineGateway
           connectAttempt={connectAttempt}
           reconnect={reconnect}
-          gatewayPort={{ isSupported: true, defaultPort }}
           targetName={doc.targetName}
           gatewayKind="database"
+          formSchema={formSchema}
+          renderFormControls={renderFormControls}
         />
       </Document>
     );
@@ -92,3 +102,16 @@ export function DocumentGateway(props: {
     </Document>
   );
 }
+
+export const formSchema = z.object({ [FormFields.LocalPort]: z.string() });
+
+export const makeRenderFormControlsFromDefaultPort =
+  (defaultPort: string) => (isProcessing: boolean) => (
+    <PortFieldInput
+      name={FormFields.LocalPort}
+      label="Port (optional)"
+      defaultValue={defaultPort}
+      mb={0}
+      readonly={isProcessing}
+    />
+  );

--- a/web/packages/teleterm/src/ui/DocumentGateway/useGateway.ts
+++ b/web/packages/teleterm/src/ui/DocumentGateway/useGateway.ts
@@ -30,7 +30,7 @@ import { retryWithRelogin } from 'teleterm/ui/utils';
 
 export function useGateway(doc: DocumentGateway) {
   const ctx = useAppContext();
-  const { clustersService } = ctx;
+  const { clustersService, usageService } = ctx;
   const { documentsService } = useWorkspaceContext();
   // The port to show as default in the input field in case creating a gateway fails.
   // This is typically the case if someone reopens the app and the port of the gateway is already
@@ -46,51 +46,56 @@ export function useGateway(doc: DocumentGateway) {
   );
   const connected = !!gateway;
 
-  const [connectAttempt, createGateway] = useAsync(async (port: string) => {
-    documentsService.update(doc.uri, { status: 'connecting' });
-    let gw: Gateway;
+  const [connectAttempt, createGateway] = useAsync(
+    useCallback(
+      async (args: { localPort?: string }) => {
+        documentsService.update(doc.uri, { status: 'connecting' });
+        let gw: Gateway;
 
-    try {
-      gw = await retryWithRelogin(ctx, doc.targetUri, () =>
-        clustersService.createGateway({
-          targetUri: doc.targetUri,
-          localPort: port,
-          targetUser: doc.targetUser,
-          targetSubresourceName: doc.targetSubresourceName,
-        })
-      );
-    } catch (error) {
-      documentsService.update(doc.uri, { status: 'error' });
-      throw error;
-    }
-    documentsService.update(doc.uri, {
-      gatewayUri: gw.uri,
-      // Set the port on doc to match the one returned from the daemon. Teleterm doesn't let the
-      // user provide a port for the gateway, so instead we have to let the daemon use a random
-      // one.
-      //
-      // Setting it here makes it so that on app restart, Teleterm will restart the proxy with the
-      // same port number.
-      port: gw.localPort,
-      status: 'connected',
-    });
-    if (isDatabaseUri(doc.targetUri)) {
-      ctx.usageService.captureProtocolUse({
-        uri: doc.targetUri,
-        protocol: 'db',
-        origin: doc.origin,
-        accessThrough: 'local_proxy',
-      });
-    }
-    if (isAppUri(doc.targetUri)) {
-      ctx.usageService.captureProtocolUse({
-        uri: doc.targetUri,
-        protocol: 'app',
-        origin: doc.origin,
-        accessThrough: 'local_proxy',
-      });
-    }
-  });
+        try {
+          gw = await retryWithRelogin(ctx, doc.targetUri, () =>
+            clustersService.createGateway({
+              targetUri: doc.targetUri,
+              localPort: args.localPort,
+              targetUser: doc.targetUser,
+              targetSubresourceName: doc.targetSubresourceName,
+            })
+          );
+        } catch (error) {
+          documentsService.update(doc.uri, { status: 'error' });
+          throw error;
+        }
+        documentsService.update(doc.uri, {
+          gatewayUri: gw.uri,
+          // Set the port on doc to match the one returned from the daemon. Teleterm doesn't let the
+          // user provide a port for the gateway, so instead we have to let the daemon use a random
+          // one.
+          //
+          // Setting it here makes it so that on app restart, Teleterm will restart the proxy with the
+          // same port number.
+          port: gw.localPort,
+          status: 'connected',
+        });
+        if (isDatabaseUri(doc.targetUri)) {
+          usageService.captureProtocolUse({
+            uri: doc.targetUri,
+            protocol: 'db',
+            origin: doc.origin,
+            accessThrough: 'local_proxy',
+          });
+        }
+        if (isAppUri(doc.targetUri)) {
+          usageService.captureProtocolUse({
+            uri: doc.targetUri,
+            protocol: 'app',
+            origin: doc.origin,
+            accessThrough: 'local_proxy',
+          });
+        }
+      },
+      [clustersService, ctx, doc, documentsService, usageService]
+    )
+  );
 
   const [disconnectAttempt, disconnect] = useAsync(async () => {
     await clustersService.removeGateway(doc.gatewayUri);
@@ -146,7 +151,7 @@ export function useGateway(doc: DocumentGateway) {
       // to open DocumentGateway while the gateway is already running. In that scenario, we must
       // not attempt to create a gateway.
       if (!gateway && connectAttempt.status === '') {
-        createGateway(doc.port);
+        createGateway({ localPort: doc.port });
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/web/packages/teleterm/src/ui/DocumentGatewayApp/DocumentGatewayApp.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGatewayApp/DocumentGatewayApp.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import userEvent from '@testing-library/user-event';
+
+import { render, screen } from 'design/utils/testing';
+import { Gateway } from 'gen-proto-ts/teleport/lib/teleterm/v1/gateway_pb';
+
+import { MockedUnaryCall } from 'teleterm/services/tshd/cloneableClient';
+import {
+  makeAppGateway,
+  makeRootCluster,
+} from 'teleterm/services/tshd/testHelpers';
+import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
+import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
+import { MockWorkspaceContextProvider } from 'teleterm/ui/fixtures/MockWorkspaceContextProvider';
+import type * as docs from 'teleterm/ui/services/workspacesService';
+import { AppUri } from 'teleterm/ui/uri';
+
+import { DocumentGatewayApp } from './DocumentGatewayApp';
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('reconnecting when the gateway fails to be created', () => {
+  const tests: Array<{
+    name: string;
+    gateway: Gateway;
+  }> = [
+    {
+      name: 'web app',
+      gateway: makeAppGateway({
+        protocol: 'HTTP',
+        targetSubresourceName: undefined,
+      }),
+    },
+    {
+      name: 'single-port TCP app',
+      gateway: makeAppGateway({
+        protocol: 'TCP',
+        targetSubresourceName: undefined,
+      }),
+    },
+    {
+      name: 'multi-port TCP app',
+      gateway: makeAppGateway({
+        protocol: 'TCP',
+        targetSubresourceName: '1337',
+      }),
+    },
+  ];
+
+  test.each(tests)('$name', async ({ gateway }) => {
+    const user = userEvent.setup();
+
+    const appContext = new MockAppContext();
+    const cluster = makeRootCluster();
+    const doc: docs.DocumentGateway = {
+      uri: '/docs/1',
+      kind: 'doc.gateway',
+      targetName: gateway.targetName,
+      targetUri: gateway.targetUri as AppUri,
+      targetUser: gateway.targetUser,
+      targetSubresourceName: gateway.targetSubresourceName,
+      gatewayUri: gateway.uri,
+      origin: 'resource_table',
+      title: '',
+      status: '',
+    };
+    appContext.addRootClusterWithDoc(cluster, doc);
+
+    jest
+      .spyOn(appContext.tshd, 'createGateway')
+      .mockReturnValueOnce(
+        new MockedUnaryCall(undefined, new Error('Something went wrong'))
+      )
+      .mockReturnValueOnce(new MockedUnaryCall(gateway));
+
+    render(
+      <MockAppContextProvider appContext={appContext}>
+        <MockWorkspaceContextProvider>
+          <DocumentGatewayApp visible doc={doc} />
+        </MockWorkspaceContextProvider>
+      </MockAppContextProvider>
+    );
+
+    expect(
+      await screen.findByText('Could not establish the connection')
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByText('Reconnect'));
+
+    expect(await screen.findByText('Close Connection')).toBeInTheDocument();
+  });
+
+  it('allows changing the target port for multi-port TCP apps', async () => {
+    const user = userEvent.setup();
+
+    const appContext = new MockAppContext();
+    const cluster = makeRootCluster();
+    const gateway = makeAppGateway({
+      protocol: 'TCP',
+      targetSubresourceName: '1337',
+    });
+    const doc: docs.DocumentGateway = {
+      uri: '/docs/1',
+      kind: 'doc.gateway',
+      targetName: gateway.targetName,
+      targetUri: gateway.targetUri as AppUri,
+      targetUser: gateway.targetUser,
+      targetSubresourceName: '1337',
+      gatewayUri: gateway.uri,
+      origin: 'resource_table',
+      title: '',
+      status: '',
+    };
+    appContext.addRootClusterWithDoc(cluster, doc);
+
+    jest
+      .spyOn(appContext.tshd, 'createGateway')
+      .mockReturnValueOnce(
+        new MockedUnaryCall(undefined, new Error('Something went wrong'))
+      )
+      .mockImplementationOnce(
+        async req => new MockedUnaryCall({ ...gateway, ...req })
+      );
+
+    render(
+      <MockAppContextProvider appContext={appContext}>
+        <MockWorkspaceContextProvider>
+          <DocumentGatewayApp visible doc={doc} />
+        </MockWorkspaceContextProvider>
+      </MockAppContextProvider>
+    );
+
+    expect(
+      await screen.findByText('Could not establish the connection')
+    ).toBeInTheDocument();
+
+    const targetPortInput = screen.getByLabelText('Target Port');
+    await user.clear(targetPortInput);
+    await user.type(targetPortInput, '4242');
+    await user.click(screen.getByText('Reconnect'));
+
+    expect(await screen.findByText('Close Connection')).toBeInTheDocument();
+    expect(screen.getByLabelText('Target Port')).toHaveValue(4242);
+
+    expect(appContext.tshd.createGateway).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        targetSubresourceName: '4242',
+      })
+    );
+  });
+});

--- a/web/packages/teleterm/src/ui/DocumentGatewayApp/DocumentGatewayApp.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGatewayApp/DocumentGatewayApp.tsx
@@ -15,10 +15,14 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { ComponentProps } from 'react';
+import { z } from 'zod';
+
 import Document from 'teleterm/ui/Document';
 import { DocumentGateway } from 'teleterm/ui/services/workspacesService';
 
-import { OfflineGateway } from '../components/OfflineGateway';
+import { PortFieldInput } from '../components/FieldInputs';
+import { FormFields, OfflineGateway } from '../components/OfflineGateway';
 import { useGateway } from '../DocumentGateway/useGateway';
 import { AppGateway } from './AppGateway';
 
@@ -29,6 +33,7 @@ export function DocumentGatewayApp(props: {
   const { doc } = props;
   const {
     gateway,
+    defaultPort,
     changePort: changeLocalPort,
     changePortAttempt: changeLocalPortAttempt,
     connected,
@@ -40,6 +45,19 @@ export function DocumentGatewayApp(props: {
     changeTargetSubresourceNameAttempt: changeTargetPortAttempt,
   } = useGateway(doc);
 
+  const isMultiPort = !!doc.targetSubresourceName;
+  // TypeScript doesn't seem to be able to properly infer a simpler construct such as
+  //
+  //     isMultiPort ? multiPortSchema : singlePortSchema
+  //
+  // This code would always infer formSchema to be that of the simpler type (singlePortSchema), so
+  // any errors in multiPortSchema would not be caught.
+  let formSchema: ComponentProps<typeof OfflineGateway>['formSchema'] =
+    singlePortSchema;
+  if (isMultiPort) {
+    formSchema = multiPortSchema;
+  }
+
   return (
     <Document visible={props.visible}>
       {!connected ? (
@@ -47,9 +65,29 @@ export function DocumentGatewayApp(props: {
           connectAttempt={connectAttempt}
           gatewayKind="app"
           targetName={doc.targetName}
-          gatewayPort={{ isSupported: true, defaultPort: doc.port }}
           reconnect={reconnect}
-          portFieldLabel="Local Port (optional)"
+          formSchema={formSchema}
+          renderFormControls={(isProcessing: boolean) => (
+            <>
+              <PortFieldInput
+                name={FormFields.LocalPort}
+                label="Local Port (optional)"
+                defaultValue={defaultPort}
+                mb={0}
+                readonly={isProcessing}
+              />
+              {isMultiPort && (
+                <PortFieldInput
+                  name={FormFields.TargetSubresourceName}
+                  label="Target Port"
+                  defaultValue={doc.targetSubresourceName}
+                  required
+                  mb={0}
+                  readonly={isProcessing}
+                />
+              )}
+            </>
+          )}
         />
       ) : (
         <AppGateway
@@ -65,3 +103,8 @@ export function DocumentGatewayApp(props: {
     </Document>
   );
 }
+
+const singlePortSchema = z.object({ [FormFields.LocalPort]: z.string() });
+const multiPortSchema = singlePortSchema.extend({
+  [FormFields.TargetSubresourceName]: z.string(),
+});

--- a/web/packages/teleterm/src/ui/DocumentGatewayKube/DocumentGatewayKube.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGatewayKube/DocumentGatewayKube.test.tsx
@@ -78,5 +78,7 @@ test('it allows reconnecting when the gateway fails to be created', async () => 
 
   await user.click(screen.getByText('Reconnect'));
 
+  // Verify that the gateway was created by checking if the terminal was rendered.
+  // "Terminal input" is an ARIA label added by xterm.js.
   expect(await screen.findByLabelText('Terminal input')).toBeInTheDocument();
 });

--- a/web/packages/teleterm/src/ui/DocumentGatewayKube/DocumentGatewayKube.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGatewayKube/DocumentGatewayKube.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import 'jest-canvas-mock';
+
+import userEvent from '@testing-library/user-event';
+
+import { render, screen } from 'design/utils/testing';
+
+import Logger, { NullService } from 'teleterm/logger';
+import { MockedUnaryCall } from 'teleterm/services/tshd/cloneableClient';
+import {
+  makeKubeGateway,
+  makeRootCluster,
+} from 'teleterm/services/tshd/testHelpers';
+import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
+import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
+import type * as docs from 'teleterm/ui/services/workspacesService';
+import { KubeUri, routing } from 'teleterm/ui/uri';
+
+import { MockWorkspaceContextProvider } from '../fixtures/MockWorkspaceContextProvider';
+import { DocumentGatewayKube } from './DocumentGatewayKube';
+
+beforeAll(() => {
+  Logger.init(new NullService());
+});
+
+test('it allows reconnecting when the gateway fails to be created', async () => {
+  const user = userEvent.setup();
+
+  const appContext = new MockAppContext();
+  const cluster = makeRootCluster();
+  const gateway = makeKubeGateway();
+  const doc: docs.DocumentGatewayKube = {
+    uri: '/docs/1',
+    kind: 'doc.gateway_kube',
+    targetUri: gateway.targetUri as KubeUri,
+    rootClusterId: routing.parseClusterUri(cluster.uri).params['rootClusterId'],
+    leafClusterId: undefined,
+    origin: 'resource_table',
+    title: '',
+    status: '',
+  };
+  appContext.addRootClusterWithDoc(cluster, doc);
+
+  jest
+    .spyOn(appContext.tshd, 'createGateway')
+    .mockReturnValueOnce(
+      new MockedUnaryCall(undefined, new Error('Something went wrong'))
+    )
+    .mockReturnValueOnce(new MockedUnaryCall(gateway));
+
+  render(
+    <MockAppContextProvider appContext={appContext}>
+      <MockWorkspaceContextProvider>
+        <DocumentGatewayKube visible doc={doc} />
+      </MockWorkspaceContextProvider>
+    </MockAppContextProvider>
+  );
+
+  expect(
+    await screen.findByText('Could not establish the connection')
+  ).toBeInTheDocument();
+
+  await user.click(screen.getByText('Reconnect'));
+
+  expect(await screen.findByLabelText('Terminal input')).toBeInTheDocument();
+});

--- a/web/packages/teleterm/src/ui/DocumentGatewayKube/DocumentGatewayKube.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGatewayKube/DocumentGatewayKube.tsx
@@ -28,7 +28,7 @@ import * as types from 'teleterm/ui/services/workspacesService';
 import { routing } from 'teleterm/ui/uri';
 import { retryWithRelogin } from 'teleterm/ui/utils';
 
-import { OfflineGateway } from '../components/OfflineGateway';
+import { emptyFormSchema, OfflineGateway } from '../components/OfflineGateway';
 
 /**
  * DocumentGatewayKube creates a terminal session that presets KUBECONFIG env
@@ -96,8 +96,8 @@ export const DocumentGatewayKube = (props: {
           connectAttempt={connectAttempt}
           targetName={params.kubeId}
           gatewayKind="kube"
+          formSchema={emptyFormSchema}
           reconnect={createGateway}
-          gatewayPort={{ isSupported: false }}
         />
       </Document>
     );

--- a/web/packages/teleterm/src/ui/components/OfflineGateway.tsx
+++ b/web/packages/teleterm/src/ui/components/OfflineGateway.tsx
@@ -26,9 +26,11 @@ import { Attempt } from 'shared/hooks/useAsync';
 
 import { useLogger } from 'teleterm/ui/hooks/useLogger';
 
-export function OfflineGateway(props: {
+export function OfflineGateway<
+  FormFieldsT extends Partial<Record<FormFieldNames, string>>,
+>(props: {
   connectAttempt: Attempt<void>;
-  reconnect(args: { localPort?: string }): void;
+  reconnect(args: FormFieldsT): void;
   /** Gateway target displayed in the UI, for example, 'cockroachdb'. */
   targetName: string;
   /** Gateway kind displayed in the UI, for example, 'database'. */
@@ -39,7 +41,7 @@ export function OfflineGateway(props: {
    * emptyFormSchema. We cannot do params.formSchema || emptyFormSchema, as that would mess with
    * type inference.
    */
-  formSchema: z.ZodType<Partial<Record<FormFieldNames, string>>>;
+  formSchema: z.ZodType<FormFieldsT>;
   /**
    * renderFormControls allows each consumer to provide its own form fields with specific HTML form
    * validation rules. The form fields are read through FormData – names on the inputs must match

--- a/web/packages/teleterm/src/ui/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/ui/fixtures/mocks.ts
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { Cluster } from 'gen-proto-ts/teleport/lib/teleterm/v1/cluster_pb';
+
 import { MockMainProcessClient } from 'teleterm/mainProcess/fixtures/mocks';
 import { MockPtyServiceClient } from 'teleterm/services/pty/fixtures/mocks';
 import {
@@ -24,6 +26,7 @@ import {
 } from 'teleterm/services/tshd/fixtures/mocks';
 import { RuntimeSettings } from 'teleterm/types';
 import AppContext from 'teleterm/ui/appContext';
+import { Document } from 'teleterm/ui/services/workspacesService';
 
 export class MockAppContext extends AppContext {
   constructor(runtimeSettings?: Partial<RuntimeSettings>) {
@@ -39,6 +42,21 @@ export class MockAppContext extends AppContext {
       ptyServiceClient,
       setupTshdEventContextBridgeService: () => {},
       getPathForFile: () => '',
+    });
+  }
+
+  addRootClusterWithDoc(cluster: Cluster, doc: Document) {
+    this.clustersService.setState(draftState => {
+      draftState.clusters.set(cluster.uri, cluster);
+    });
+    this.workspacesService.setState(draftState => {
+      draftState.rootClusterUri = cluster.uri;
+      draftState.workspaces[cluster.uri] = {
+        documents: [doc],
+        location: doc.uri,
+        localClusterUri: cluster.uri,
+        accessRequests: undefined,
+      };
     });
   }
 }

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
@@ -112,6 +112,8 @@ export interface DocumentGateway extends DocumentBase {
   /**
    * targetSubresourceName contains database name for db gateways and target port for TCP app
    * gateways.
+   * A DocumentGateway created for a multi-port TCP app is expected to always have this field
+   * present.
    */
   targetSubresourceName: string | undefined;
   port?: string;


### PR DESCRIPTION
This builds on #50912. One of the issues that I haven't taken care of in that PR is that if a target port you created a gateway for is no longer defined in the app spec, then when restoring tabs Connect wouldn't be able to create such gateway, as tshd would return an error about the port not being valid.

This PR adds a Target Port field next to the existing Local Port field. When a gateway fails to start, the user is able to change the target port, just like they're able to change the local port today.

To achieve this, I refactored `OfflineGateway`. It used to support a prop which dictated whether the Local Port is going to be shown or not, along with another prop to set the default port and another for the label for the input field. Now it expects its callers to pass uncontrolled form fields through `renderFormControls` and `formSchema`. When the form is submitted, `OfflineGateway` runs the form data through the schema and then passes the result to `createGateway`. This way each caller is able to specify by themselves what fields its going to use and how it's going to validate the form:

* `DocumentGatewayKube` doesn't use any fields.
* `DocumentGateway` (db gateways) shows just the local port field which is optional.
* `DocumentGatewayApp` shows the local port field. If the app is a multi-port TCP app, it also shows the target port field.
   * The local port field is optional, but the target port field is required if it's being shown. An invariant of the gateway doc for multi-port apps is that `targetSubresourceName` is always present, since that's how we can tell gateway docs for multi-port apps from single-port apps.

## zod usage

Uncontrolled forms are naturally not "typeable" since it's just a bunch of strings, so I used zod to transform form data into an object with the expected fields. As long as the form schema is properly defined, the component is going to throw an error if the form is missing one of the fields.

I have to say that I just now realized that using zod with strict null checks off is suboptimal, as in that scenario it's impossible to make zod return a type with non-optional fields. It's not that big of an issue here, but it might be if we use this approach elsewhere. On top of that, zod's errors require some extra work if we want to show them in the UI. For now I just skipped this work since all errors here are the result of a programmer error, not the user submitting invalid data. But in the future, our form components could be adjusted to show zod errors.

## Considered alternatives

### Another prop for target port field

Just like `OfflineGateway` had `gatewayPort: { isSupported: boolean, defaultPort: string }`, it could have an equivalent of this prop for the target subresource name that stores the target port for app gateways. I ruled out this solution as different gateways treat target subresource name in different ways and this design wouldn't be very flexible.

### Controlled forms

Instead of using zod and uncontrolled forms, `renderFormControls` could receive `useState` return values for each field and then build form controls using that. However, `OfflineGateway` would still need to receive props with defaults for each field, as it'd be controlling the fields.

Honestly, maybe it wouldn't be that bad. The extra props for default values seem kinda off, but otherwise we wouldn't need to deal with zod. While it'd be impossible to introduce bugs stemming from incorrect input names, this design introduces a potential issue where `renderFormControls` does not render an expected field and there's no error about it. But in the end it just means that it'd required tests, just like the zod implementation does to ensure that the form schemas are in sync with the forms.

### Button for removing the gateway

This is probably the solution I should've went with in the first place. The target port being no longer valid is probably going to be such a niche use case that it feels wrong to dedicate so much time and code to taking care of it. Just remove the gateway and let user create a new one, this time with a correct port.

But well, I've already invested the time and code into this. 🥲 I suppose if we ever find ourselves in need of extending gateway support, e.g. choosing kube namespaces, maybe parts of this implementation will make things easier.