### PR TITLE
Remove unused NewIdentityServiceV2

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -194,7 +194,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 		cfg.Provisioner = local.NewProvisioningService(cfg.Backend)
 	}
 	if cfg.Identity == nil {
-		cfg.Identity, err = local.NewIdentityServiceV2(cfg.Backend)
+		cfg.Identity, err = local.NewIdentityService(cfg.Backend)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -1025,7 +1025,7 @@ func New(config Config) (*Cache, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	identityService, err := local.NewIdentityServiceV2(config.Backend)
+	identityService, err := local.NewIdentityService(config.Backend)
 	if err != nil {
 		cancel()
 		return nil, trace.Wrap(err)

--- a/lib/services/local/headlessauthn_watcher.go
+++ b/lib/services/local/headlessauthn_watcher.go
@@ -106,7 +106,7 @@ func NewHeadlessAuthenticationWatcher(ctx context.Context, cfg HeadlessAuthentic
 		return nil, trace.Wrap(err)
 	}
 
-	identityService, err := NewIdentityServiceV2(cfg.Backend)
+	identityService, err := NewIdentityService(cfg.Backend)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -70,12 +70,6 @@ type IdentityService struct {
 	notificationsSvc *NotificationsService
 }
 
-// TODO(tross): DELETE ONCE e is updated to use  NewIdentityService
-// NewIdentityServiceV2 returns a new instance of IdentityService object
-func NewIdentityServiceV2(backend backend.Backend) (*IdentityService, error) {
-	return NewIdentityService(backend)
-}
-
 // NewIdentityService returns a new instance of IdentityService object
 func NewIdentityService(backend backend.Backend) (*IdentityService, error) {
 	notificationsSvc, err := NewNotificationsService(backend, backend.Clock())
@@ -100,7 +94,7 @@ func NewTestIdentityService(backend backend.Backend) (*IdentityService, error) {
 		panic("Attempted to create a test identity service outside of a test")
 	}
 
-	s, err := NewIdentityServiceV2(backend)
+	s, err := NewIdentityService(backend)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/local/users_test.go
+++ b/lib/services/local/users_test.go
@@ -278,7 +278,7 @@ func TestNotificationCleanupOnUserDelete(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	identitySvc, err := local.NewIdentityServiceV2(backend)
+	identitySvc, err := local.NewIdentityService(backend)
 	require.NoError(t, err)
 	notificationsSvc, err := local.NewNotificationsService(backend, backend.Clock())
 	require.NoError(t, err)


### PR DESCRIPTION
Includes https://github.com/gravitational/teleport.e/pull/5832 which removed the last invocations of the V2 function.