### PR TITLE
Update depguard rules to prevent importing test code outside tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -128,6 +128,123 @@ linters-settings:
             desc: 'use "log/slog" instead'
           - pkg: golang.org/x/exp/slog
             desc: 'use "log/slog" instead'
+      # Prevent importing testify in production code.
+      testify:
+        files:
+          # Tests can import testify
+          - '!$test'
+          # Exceptions
+          # Remove these once they are complaint.
+          - '!**/api/testhelpers/**'
+          - '!**/e/lib/auth/ssotestlib.go'
+          - '!**/e/lib/aws/identitycenter/test/**'
+          - '!**/e/lib/idp/saml/testenv/**'
+          - '!**/e/lib/operatortest/**'
+          - '!**/e/tests/**'
+          - '!**/lib/automaticupgrades/basichttp/servermock.go'
+          - '!**/lib/auth/helpers.go'
+          - '!**/lib/auth/keystore/testhelpers.go'
+          - '!**/lib/auth/test/**'
+          - '!**/lib/backend/test/**'
+          - '!**/lib/events/athena/test.go'
+          - '!**/lib/events/test/**'
+          - '!**/lib/kube/proxy/utils_testing.go'
+          - '!**/lib/services/suite/**'
+          - '!**/lib/srv/mock.go'
+          - '!**/lib/srv/db/redis/test.go'
+          - '!**/lib/teleterm/gatewaytest/**'
+          - '!**/lib/utils/testhelpers.go'
+          - '!**/lib/utils/testutils/**'
+          - '!**/integration/appaccess/fixtures.go'
+          - '!**/integration/appaccess/jwt.go'
+          - '!**/integration/appaccess/pack.go'
+          - '!**/integration/db/fixture.go'
+          - '!**/integration/hsm/helpers.go'
+          - '!**/integration/helpers/**'
+          - '!**/integration/proxy/proxy_helpers.go'
+          - '!**/integrations/access/email/testlib/**'
+          - '!**/integrations/access/datadog/testlib/**'
+          - '!**/integrations/access/discord/testlib/**'
+          - '!**/integrations/access/jira/testlib/**'
+          - '!**/integrations/access/mattermost/testlib/**'
+          - '!**/integrations/access/msteams/testlib/**'
+          - '!**/integrations/access/opsgenie/testlib/**'
+          - '!**/integrations/access/pagerduty/testlib/**'
+          - '!**/integrations/access/servicenow/testlib/**'
+          - '!**/integrations/access/slack/testlib/**'
+          - '!**/integrations/lib/testing/integration/accessrequestsuite.go'
+          - '!**/integrations/lib/testing/integration/app.go'
+          - '!**/integrations/lib/testing/integration/authhelper.go'
+          - '!**/integrations/lib/testing/integration/suite.go'
+          - '!**/integrations/operator/controllers/resources/testlib/**'
+          - '!**/tool/teleport/testenv/**'
+        deny:
+          - pkg: github.com/stretchr/testify
+            desc: 'testify should not be imported outside of test code'
+      # Prevent importing integration test helpers in production code.
+      integration:
+        files:
+          # Tests can do anything
+          - '!$test'
+          - '!**/integration/**'
+          - '!**/e/tests/**'
+          - '!**/integrations/operator/controllers/resources/testlib/**'
+        deny:
+          - pkg: github.com/gravitational/teleport/integration
+            desc: 'integration test should not be imported outside of intergation tests'
+        allow:
+          # integrations is explicitly allowed becuase the deny rule above
+          # will match both integration and integrations, however only
+          # integration should be denied.
+          - github.com/gravitational/teleport/integrations
+        list-mode: lax
+      # Prevent importing testing in production code.
+      testing:
+        files:
+          # Tests can do anything
+          - '!$test'
+          # Exceptions
+          # Remove these once they are complaint.
+          - '!**/api/testhelpers/**'
+          - '!**/e/lib/auth/ssotestlib.go'
+          - '!**/e/lib/aws/identitycenter/test/**'
+          - '!**/e/lib/devicetrust/testenv/**'
+          - '!**/e/lib/devicetrust/storage/storage.go'
+          - '!**/e/lib/idp/saml/testenv/**'
+          - '!**/e/lib/jamf/testenv/**'
+          - '!**/e/lib/okta/api/oktaapitest/**'
+          - '!**/e/lib/operatortest/**'
+          - '!**/e/tests/**'
+          - '!**/integration/**'
+          - '!**/integrations/access/email/testlib/**'
+          - '!**/integrations/access/msteams/testlib/**'
+          - '!**/integrations/access/slack/testlib/**'
+          - '!**/integrations/operator/controllers/resources/testlib/**'
+          - '!**/lib/auth/helpers.go'
+          - '!**/lib/auth/keystore/testhelpers.go'
+          - '!**/lib/auth/test/**'
+          - '!**/lib/automaticupgrades/basichttp/servermock.go'
+          - '!**/lib/backend/test/**'
+          - '!**/lib/cryptosuites/precompute.go'
+          - '!**/lib/cryptosuites/internal/rsa/rsa.go'
+          - '!**/lib/events/test/**'
+          - '!**/lib/events/athena/test.go'
+          - '!**/lib/fixtures/**'
+          - '!**/lib/kube/proxy/utils_testing.go'
+          - '!**/lib/modules/test.go'
+          - '!**/lib/service/service.go'
+          - '!**/lib/services/local/users.go'
+          - '!**/lib/services/suite/**'
+          - '!**/lib/srv/mock.go'
+          - '!**/lib/srv/db/redis/test.go'
+          - '!**/lib/teleterm/gatewaytest/**'
+          - '!**/lib/utils/cli.go'
+          - '!**/lib/utils/testhelpers.go'
+          - '!**/lib/utils/testutils/**'
+          - '!**/tool/teleport/testenv/**'
+        deny:
+          - pkg: testing
+            desc: 'testing should not be imported outside of tests'
       # Prevent importing internal packages in client tools or packages containing
       # common interfaces consumed by them that are known to bloat binaries or break builds
       # because they only support a single platform.


### PR DESCRIPTION
There is a lot of shared test code defined outside of _test.go files scattered through out the code base. Dead code detection in Go is not that great and cannot detect that these test helpers are only consumed in tests. While this doesn't remediate anything, it should hopeful avoid any future code from making it harder to separate test and production code.


```bash
strings build/teleport | rg testify
github.com/stretchr/testify/assert.init
github.com/stretchr/testify/assert.uint32Type
go:link.pkghashbytes.github.com/stretchr/testify/assert
github.com/stretchr/testify/assert.int64Type
github.com/stretchr/testify/assert.uintptrType
go:link.pkghashbytes.github.com/stretchr/testify/require
github.com/stretchr/testify/assert.stringType
github.com/stretchr/testify/assert.float32Type
github.com/stretchr/testify/assert.bytesType
github.com/stretchr/testify/assert.intType
go:link.pkghashbytes.github.com/stretchr/testify/assert/yaml
github.com/stretchr/testify/assert.float64Type
github.com/stretchr/testify/assert..inittask
github.com/stretchr/testify/assert.int32Type
github.com/stretchr/testify/assert.uint16Type
github.com/stretchr/testify/assert.int8Type
github.com/stretchr/testify/assert.uint64Type
github.com/stretchr/testify/assert.uintType
github.com/stretchr/testify/assert.uint8Type
go:link.pkghash.github.com/stretchr/testify/assert/yaml
github.com/stretchr/testify/assert.int16Type
go:link.pkghash.github.com/stretchr/testify/require
go:link.pkghash.github.com/stretchr/testify/assert
github.com/stretchr/testify/assert.timeType
dep     github.com/stretchr/testify     v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
github.com/stretchr/testify/assert.init
github.com/stretchr/testify@v1.10.0/assert/assertion_compare.go
dep     github.com/stretchr/testify     v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=



strings build/teleport | rg testing
testing
*testing.T
*[]*testing.T
*testing.common
*testing.matcher
testingOnlyDidHRR
*testing.indenter
*func(*testing.T)
testingOnlyCurveID
*testing.filterMatch
*testing.testContext
*testing.chattyPrinter
*testing.highPrecisionTime
$*func(string, func(*testing.T)) bool
)*struct { F uintptr; X0 *testing.common }
+google.golang.org/protobuf/testing/protocmp
9*struct { F uintptr; X0 *testing.T; X1 func(*testing.T) }
<*func(*testing.T, types.SystemRole) (*state.Identity, error)
B*struct { F uintptr; X0 *testing.common; X1 []uintptr; X2 func() }
testing.init
testing.(*matcher).fullName
testing.(*matcher).fullName.deferwrap2
testing.(*matcher).fullName.deferwrap1
testing.(*matcher).unique
testing.parseSubtestNumber
testing.rewrite
testing.isSpace
testing.(*chattyPrinter).Updatef
testing.(*chattyPrinter).prefix
testing.(*chattyPrinter).Updatef.deferwrap1
testing.(*chattyPrinter).Printf
testing.(*chattyPrinter).Printf.deferwrap1
testing.(*common).frameSkip
testing.(*common).frameSkip.func1
testing.(*common).decorate
testing.(*common).flushToParent
testing.(*common).flushToParent.deferwrap2
testing.(*common).flushToParent.deferwrap1
testing.indenter.Write
testing.fmtDuration
testing.(*common).Name
testing.(*common).setRan
testing.(*common).setRan.deferwrap1
testing.(*common).Fail
testing.(*common).Fail.deferwrap1
testing.(*common).Failed
testing.(*common).Failed.deferwrap1
testing.(*common).FailNow
testing.(*common).checkFuzzFn
testing.(*common).logDepth
testing.(*common).logDepth.deferwrap2
testing.(*common).logDepth.deferwrap1
testing.(*common).Log
testing.(*common).log
testing.(*common).Logf
testing.(*common).Error
testing.(*common).Errorf
testing.(*common).Fatal
testing.(*common).Fatalf
testing.(*common).Skip
testing.(*common).Skipf
testing.(*common).SkipNow
testing.(*common).Skipped
testing.(*common).Skipped.deferwrap1
testing.(*common).Helper
testing.(*common).Helper.deferwrap1
testing.(*common).Cleanup
testing.(*common).Cleanup.deferwrap1
testing.(*common).Cleanup.func1
testing.(*common).Cleanup.func1.1
testing.(*common).Cleanup.func1.1.deferwrap1
testing.(*common).TempDir
testing.(*common).TempDir.func2
testing.removeAll
testing.(*common).Setenv
testing.(*common).Setenv.func2
testing.(*common).Setenv.func1
testing.(*common).runCleanup
testing.(*common).runCleanup.func2
testing.(*common).runCleanup.func1
testing.(*common).runCleanup.deferwrap1
testing.(*common).resetRaces
testing.(*common).checkRaces
testing.callerName
testing.pcToName
testing.(*T).Parallel
testing.highPrecisionTimeSince
testing.highPrecisionTimeNow
testing.(*T).Setenv
testing.tRunner
testing.tRunner.func2
testing.tRunner.func1
testing.tRunner.func1.2
testing.tRunner.func1.1
testing.(*T).Run
testing.shouldFailFast
testing.(*T).Run.gowrap1
testing.(*T).Deadline
testing.(*testContext).waitParallel
testing.(*testContext).release
testing.(*T).report
testing.(*common).TempDir.func1
type:.eq.testing.chattyPrinter
type:.eq.testing.testContext
testing.(*T).Cleanup
testing.(*T).Error
testing.(*T).Errorf
testing.(*T).Fail
testing.(*T).FailNow
testing.(*T).Failed
testing.(*T).Fatal
testing.(*T).Fatalf
testing.(*T).Helper
testing.(*T).Log
testing.(*T).Logf
testing.(*T).Name
testing.(*T).Skip
testing.(*T).SkipNow
testing.(*T).Skipf
testing.(*T).Skipped
testing.(*T).TempDir
testing.(*indenter).Write
testing.Testing
testing/fuzz.go
testing/match.go
testing/testing.go
testing/testing_other.go
```

Updates https://github.com/gravitational/teleport/issues/51023.