### PR TITLE
Add Kube operator trusted clusters support to upcoming releases

### DIFF
--- a/docs/pages/upcoming-releases.mdx
+++ b/docs/pages/upcoming-releases.mdx
@@ -32,6 +32,11 @@ interact with Github with RBAC and audit logging support.
 
 Oracle Database Access users will be able to use Toad GUI client.
 
+#### Trusted clusters support for Kubernetes operator
+
+Kubernetes operator users will be able to create trusted clusters using
+Kubernetes custom resources.
+
 ## Teleport Policy
 
 | Version | Date          |

--- a/docs/pages/upcoming-releases.mdx
+++ b/docs/pages/upcoming-releases.mdx
@@ -43,13 +43,6 @@ Kubernetes custom resources.
 |---------|---------------|
 | 1.27.0  | January 2025  |
 
-### 1.26.0
-
-#### Role templates
-
-When calculating access paths, Teleport Policy will take user traits and role
-resource labels into account.
-
 ### 1.27.0
 
 #### Azure integration


### PR DESCRIPTION
Feels like it's big enough to include in the minor release notes.

Also remove released access graph version.