### PR TITLE
fix ID_LIKE mangling the apt source

### DIFF
--- a/assets/install-scripts/install.sh
+++ b/assets/install-scripts/install.sh
@@ -299,6 +299,9 @@ install_teleport() {
     # shellcheck source=/dev/null
     . $OS_RELEASE
   fi
+  # Some $ID_LIKE values include multiple distro names in an arbitrary order, so
+  # evaluate the first one.
+  ID_LIKE="$(echo "${ID_LIKE}" | awk '{print $1}')"
 
   # detect architecture
   ARCH=""
@@ -338,10 +341,8 @@ install_teleport() {
     ;;
   *)
     # before downloading manually, double check if we didn't miss any debian or
-    # rh/fedora derived distros using the ID_LIKE var. Some $ID_LIKE values
-    # include multiple distro names in an arbitrary order, so evaluate the first
-    # one.
-    case "$(echo "$ID_LIKE" | awk '{print $1}')" in
+    # rh/fedora derived distros using the ID_LIKE var.
+    case "${ID_LIKE}" in
     ubuntu | debian)
       install_via_apt_get
       ;;

--- a/assets/install-scripts/install.sh
+++ b/assets/install-scripts/install.sh
@@ -301,7 +301,7 @@ install_teleport() {
   fi
   # Some $ID_LIKE values include multiple distro names in an arbitrary order, so
   # evaluate the first one.
-  ID_LIKE="$(echo "${ID_LIKE}" | awk '{print $1}')"
+  ID_LIKE="${ID_LIKE%% *}"
 
   # detect architecture
   ARCH=""


### PR DESCRIPTION
ID_LIKE in /etc/os-release may contain a string with multiple values, e.g "ubuntu debian" on Pop_OS
This extracts the first value for the apt repo ID, for example "ubuntu".

Fixes `curl https://cdn.teleport.dev/install.sh | bash -s VERSION EDITION` on derived distros like pop_os.