### PR TITLE
Hide inaccessible features on dashboards

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1859,6 +1859,11 @@ func (h *Handler) getWebConfig(w http.ResponseWriter, r *http.Request, p httprou
 	// Set entitlements with backwards field compatibility
 	setEntitlementsWithLegacyLogic(&webCfg, clusterFeatures)
 
+	// always hide inaccessible features on dashboards
+	if services.IsDashboard(clusterFeatures) {
+		webCfg.HideInaccessibleFeatures = true
+	}
+
 	resource, err := h.cfg.ProxyClient.GetClusterName()
 	if err != nil {
 		h.logger.WarnContext(r.Context(), "Failed to query cluster name", "error", err)

--- a/web/packages/teleport/src/Users/useUsers.ts
+++ b/web/packages/teleport/src/Users/useUsers.ts
@@ -127,6 +127,7 @@ export default function useUsers({
   const showMauInfo =
     ctx.getFeatureFlags().billing &&
     cfg.isUsageBasedBilling &&
+    !cfg.isDashboard &&
     !storageService.getUsersMauAcknowledged();
 
   const usersAcl = ctx.storeUser.getUserAccess();


### PR DESCRIPTION
This PR sets the web config flag `HideInaccessibleFeatures` to true on all dashboards.

This will prevent the UI from showing fields that we don't want to show on these clusters.


See [Slack thread](https://gravitational.slack.com/archives/C01UV6NKQTS/p1736853013992229).

____

Additionally, this PR also includes a small fix for https://github.com/gravitational/cloud/issues/10944, since MAU is calculated from their actual cluster, not the dashboard, so this was confusing.