### PR TITLE
fix: Move testGatewayConnectionFunc to proxy_helpers.go

### DIFF
--- a/integration/proxy/proxy_helpers.go
+++ b/integration/proxy/proxy_helpers.go
@@ -724,6 +724,8 @@ func mustConnectWebAppGateway(ctx context.Context, t *testing.T, _ *daemon.Servi
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
+type testGatewayConnectionFunc func(context.Context, *testing.T, *daemon.Service, gateway.Gateway)
+
 func makeMustConnectMultiPortTCPAppGateway(wantMessage string, otherTargetPort int, otherWantMessage string) testGatewayConnectionFunc {
 	return func(ctx context.Context, t *testing.T, d *daemon.Service, gw gateway.Gateway) {
 		t.Helper()

--- a/integration/proxy/teleterm_test.go
+++ b/integration/proxy/teleterm_test.go
@@ -186,8 +186,6 @@ func testDBGatewayCertRenewal(ctx context.Context, t *testing.T, params dbGatewa
 	)
 }
 
-type testGatewayConnectionFunc func(context.Context, *testing.T, *daemon.Service, gateway.Gateway)
-
 type generateAndSetupUserCredsFunc func(t *testing.T, tc *libclient.TeleportClient, ttl time.Duration)
 
 type gatewayCertRenewalParams struct {


### PR DESCRIPTION
testGatewayConnectionFunc is used by non-test files but declared in a _test.go file, which causes a build breakage.

Fixes breakage introduced by #50912.