### PR TITLE
Support SSH port forwarding options in the role editor

### DIFF
--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Options.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Options.tsx
@@ -17,13 +17,14 @@
  */
 
 import { memo, useId } from 'react';
+import { components, OptionProps } from 'react-select';
 import styled, { useTheme } from 'styled-components';
 
 import Box from 'design/Box';
 import Input from 'design/Input';
 import LabelInput from 'design/LabelInput';
 import { RadioGroup } from 'design/RadioGroup';
-import { H4 } from 'design/Text';
+import Text, { H4 } from 'design/Text';
 import Select from 'shared/components/Select';
 
 import { SectionProps } from './sections';
@@ -33,6 +34,8 @@ import {
   OptionsModel,
   requireMFATypeOptions,
   sessionRecordingModeOptions,
+  SSHPortForwardingModeOption,
+  sshPortForwardingModeOptions,
 } from './standardmodel';
 
 /**
@@ -53,6 +56,8 @@ export const Options = memo(function Options({
   const createDBUserModeId = `${id}-create-db-user-mode`;
   const defaultSessionRecordingModeId = `${id}-default-session-recording-mode`;
   const sshSessionRecordingModeId = `${id}-ssh-session-recording-mode`;
+  const sshPortForwardingModeId = `${id}-ssh-port-forwarding-mode`;
+
   return (
     <OptionsGridContainer
       border={1}
@@ -140,6 +145,18 @@ export const Options = memo(function Options({
         onChange={m => onChange?.({ ...value, sshSessionRecordingMode: m })}
       />
 
+      <OptionLabel htmlFor={sshPortForwardingModeId}>
+        Port Forwarding Mode
+      </OptionLabel>
+      <Select
+        components={sshPortForwardingModeComponents}
+        inputId={sshPortForwardingModeId}
+        isDisabled={isProcessing}
+        options={sshPortForwardingModeOptions}
+        value={value.sshPortForwardingMode}
+        onChange={m => onChange?.({ ...value, sshPortForwardingMode: m })}
+      />
+
       <OptionsHeader separator>Database</OptionsHeader>
 
       <Box>Create Database User</Box>
@@ -194,6 +211,20 @@ export const Options = memo(function Options({
     </OptionsGridContainer>
   );
 });
+
+const SSHPortForwardingModeOptionComponent = (
+  props: OptionProps<SSHPortForwardingModeOption, false>
+) => {
+  return (
+    <components.Option {...props}>
+      {props.label} <Text typography="body3">{props.data.description}</Text>
+    </components.Option>
+  );
+};
+
+const sshPortForwardingModeComponents = {
+  Option: SSHPortForwardingModeOptionComponent,
+};
 
 const OptionsGridContainer = styled(Box)`
   display: grid;

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/withDefaults.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/withDefaults.ts
@@ -24,7 +24,10 @@ export type DeepPartial<T> = {
 
 /**
  * Returns a "completed" model, emulating what `RoleV6.CheckAndSetDefaults`
- * does on the server side. These two functions must be kept in sync.
+ * does on the server side. These two functions must be kept in sync. Don't add
+ * arbitrary defaults here unless they are returned the same way from the
+ * server side, or the role editor will silently modify these fields on every
+ * role it opens and saves without user intervention.
  */
 export const withDefaults = (role: DeepPartial<Role>): Role => ({
   kind: 'role',
@@ -70,15 +73,6 @@ export const optionsWithDefaults = (
       },
     },
 
-    ssh_port_forwarding: {
-      local: {
-        ...defaults.ssh_port_forwarding.local,
-      },
-      remote: {
-        ...defaults.ssh_port_forwarding.remote,
-      },
-    },
-
     record_session: {
       ...defaults.record_session,
       ...options?.record_session,
@@ -86,6 +80,14 @@ export const optionsWithDefaults = (
   };
 };
 
+/**
+ * Default options, exactly as returned by the server side for the empty
+ * options object. This invariant must be held at all times, since this object
+ * is used to resolve partial responses. Don't add arbitrary defaults here
+ * unless they are returned the same way from the server side, or the role
+ * editor will silently modify these options on every role it opens and saves
+ * without user intervention.
+ */
 export const defaultOptions = (): RoleOptions => ({
   cert_format: 'standard',
   create_db_user: false,
@@ -101,14 +103,6 @@ export const defaultOptions = (): RoleOptions => ({
   },
   max_session_ttl: '30h0m0s',
   pin_source_ip: false,
-  ssh_port_forwarding: {
-    local: {
-      enabled: false,
-    },
-    remote: {
-      enabled: false,
-    },
-  },
   record_session: {
     default: 'best_effort',
     desktop: true,

--- a/web/packages/teleport/src/services/resources/types.ts
+++ b/web/packages/teleport/src/services/resources/types.ts
@@ -351,7 +351,8 @@ export type RoleOptions = {
   };
   max_session_ttl: string;
   pin_source_ip: boolean;
-  ssh_port_forwarding: SSHPortForwarding;
+  ssh_port_forwarding?: SSHPortForwarding;
+  port_forwarding?: boolean;
   record_session: {
     default: SessionRecordingMode;
     ssh?: SessionRecordingMode;
@@ -366,11 +367,11 @@ export type RoleOptions = {
 };
 
 export type SSHPortForwarding = {
-  local: {
-    enabled: boolean;
+  local?: {
+    enabled?: boolean;
   };
-  remote: {
-    enabled: boolean;
+  remote?: {
+    enabled?: boolean;
   };
 };
 


### PR DESCRIPTION
Allows both modern and legacy options. Bails out on malformed options and degrades to YAML mode.

![Screenshot 2025-01-14 at 17 57 13](https://github.com/user-attachments/assets/6099edcc-8907-461e-a2b3-560e90d93e3c)

This change should bring back support for the built-in editor and auditor roles (v7 only so far).