### PR TITLE
Migrate AWS MemoryDB clients to AWS SDK v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/iam v1.38.3
 	github.com/aws/aws-sdk-go-v2/service/identitystore v1.27.8
 	github.com/aws/aws-sdk-go-v2/service/kms v1.37.8
+	github.com/aws/aws-sdk-go-v2/service/memorydb v1.25.2
 	github.com/aws/aws-sdk-go-v2/service/organizations v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/rds v1.93.2
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.53.1

--- a/go.sum
+++ b/go.sum
@@ -926,6 +926,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.7 h1:Hi0KGbrnr57bEH
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.7/go.mod h1:wKNgWgExdjjrm4qvfbTorkvocEstaoDl4WCvGfeCy9c=
 github.com/aws/aws-sdk-go-v2/service/kms v1.37.8 h1:KbLZjYqhQ9hyB4HwXiheiflTlYQa0+Fz0Ms/rh5f3mk=
 github.com/aws/aws-sdk-go-v2/service/kms v1.37.8/go.mod h1:ANs9kBhK4Ghj9z1W+bsr3WsNaPF71qkgd6eE6Ekol/Y=
+github.com/aws/aws-sdk-go-v2/service/memorydb v1.25.2 h1:Tfb2AAJ+GHU/RdBX7BPw6c7jTaL5SuDcCbGItCYOVeU=
+github.com/aws/aws-sdk-go-v2/service/memorydb v1.25.2/go.mod h1:IIpB6tUlFZLx7n/cqlfJGAAABXxx0YQ+fR1Aa4m5Czk=
 github.com/aws/aws-sdk-go-v2/service/organizations v1.37.0 h1:VlfFFYSLuS7MPNyF7wf1gANoLQLhEj+Kq7ifVzl7gog=
 github.com/aws/aws-sdk-go-v2/service/organizations v1.37.0/go.mod h1:5ThtlWQYo2b4sghzFmzDelaJtsW7hOct5MnpbaG8ZeU=
 github.com/aws/aws-sdk-go-v2/service/rds v1.93.2 h1:Fv2//DyCH9n6LqEOvpeIFYYRfIhvjhrLk5qhrYMjDGE=

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -87,6 +87,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/kms v1.37.8 // indirect
+	github.com/aws/aws-sdk-go-v2/service/memorydb v1.25.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/organizations v1.37.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/rds v1.93.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.53.1 // indirect

--- a/integrations/event-handler/go.sum
+++ b/integrations/event-handler/go.sum
@@ -170,6 +170,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.7 h1:Hi0KGbrnr57bEH
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.7/go.mod h1:wKNgWgExdjjrm4qvfbTorkvocEstaoDl4WCvGfeCy9c=
 github.com/aws/aws-sdk-go-v2/service/kms v1.37.8 h1:KbLZjYqhQ9hyB4HwXiheiflTlYQa0+Fz0Ms/rh5f3mk=
 github.com/aws/aws-sdk-go-v2/service/kms v1.37.8/go.mod h1:ANs9kBhK4Ghj9z1W+bsr3WsNaPF71qkgd6eE6Ekol/Y=
+github.com/aws/aws-sdk-go-v2/service/memorydb v1.25.2 h1:Tfb2AAJ+GHU/RdBX7BPw6c7jTaL5SuDcCbGItCYOVeU=
+github.com/aws/aws-sdk-go-v2/service/memorydb v1.25.2/go.mod h1:IIpB6tUlFZLx7n/cqlfJGAAABXxx0YQ+fR1Aa4m5Czk=
 github.com/aws/aws-sdk-go-v2/service/organizations v1.37.0 h1:VlfFFYSLuS7MPNyF7wf1gANoLQLhEj+Kq7ifVzl7gog=
 github.com/aws/aws-sdk-go-v2/service/organizations v1.37.0/go.mod h1:5ThtlWQYo2b4sghzFmzDelaJtsW7hOct5MnpbaG8ZeU=
 github.com/aws/aws-sdk-go-v2/service/rds v1.93.2 h1:Fv2//DyCH9n6LqEOvpeIFYYRfIhvjhrLk5qhrYMjDGE=

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -99,6 +99,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/kms v1.37.8 // indirect
+	github.com/aws/aws-sdk-go-v2/service/memorydb v1.25.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/organizations v1.37.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/rds v1.93.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.53.1 // indirect

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -274,6 +274,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.7 h1:Hi0KGbrnr57bEH
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.7/go.mod h1:wKNgWgExdjjrm4qvfbTorkvocEstaoDl4WCvGfeCy9c=
 github.com/aws/aws-sdk-go-v2/service/kms v1.37.8 h1:KbLZjYqhQ9hyB4HwXiheiflTlYQa0+Fz0Ms/rh5f3mk=
 github.com/aws/aws-sdk-go-v2/service/kms v1.37.8/go.mod h1:ANs9kBhK4Ghj9z1W+bsr3WsNaPF71qkgd6eE6Ekol/Y=
+github.com/aws/aws-sdk-go-v2/service/memorydb v1.25.2 h1:Tfb2AAJ+GHU/RdBX7BPw6c7jTaL5SuDcCbGItCYOVeU=
+github.com/aws/aws-sdk-go-v2/service/memorydb v1.25.2/go.mod h1:IIpB6tUlFZLx7n/cqlfJGAAABXxx0YQ+fR1Aa4m5Czk=
 github.com/aws/aws-sdk-go-v2/service/organizations v1.37.0 h1:VlfFFYSLuS7MPNyF7wf1gANoLQLhEj+Kq7ifVzl7gog=
 github.com/aws/aws-sdk-go-v2/service/organizations v1.37.0/go.mod h1:5ThtlWQYo2b4sghzFmzDelaJtsW7hOct5MnpbaG8ZeU=
 github.com/aws/aws-sdk-go-v2/service/rds v1.93.2 h1:Fv2//DyCH9n6LqEOvpeIFYYRfIhvjhrLk5qhrYMjDGE=

--- a/lib/cloud/aws/aws.go
+++ b/lib/cloud/aws/aws.go
@@ -24,9 +24,9 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ectypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	memorydbtypes "github.com/aws/aws-sdk-go-v2/service/memorydb/types"
 	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	redshifttypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
-	"github.com/aws/aws-sdk-go/service/memorydb"
 	"github.com/aws/aws-sdk-go/service/opensearchservice"
 	"github.com/coreos/go-semver/semver"
 
@@ -64,7 +64,7 @@ func IsElastiCacheClusterAvailable(cluster *ectypes.ReplicationGroup) bool {
 }
 
 // IsMemoryDBClusterAvailable checks if the MemoryDB cluster is available.
-func IsMemoryDBClusterAvailable(cluster *memorydb.Cluster) bool {
+func IsMemoryDBClusterAvailable(cluster *memorydbtypes.Cluster) bool {
 	return IsResourceAvailable(cluster, cluster.Status)
 }
 
@@ -204,7 +204,7 @@ func IsElastiCacheClusterSupported(cluster *ectypes.ReplicationGroup) bool {
 }
 
 // IsMemoryDBClusterSupported checks whether the MemoryDB cluster is supported.
-func IsMemoryDBClusterSupported(cluster *memorydb.Cluster) bool {
+func IsMemoryDBClusterSupported(cluster *memorydbtypes.Cluster) bool {
 	return aws.ToBool(cluster.TLSEnabled)
 }
 

--- a/lib/cloud/aws/tags_helpers.go
+++ b/lib/cloud/aws/tags_helpers.go
@@ -25,10 +25,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	ectypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	memorydbtypes "github.com/aws/aws-sdk-go-v2/service/memorydb/types"
 	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	redshifttypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
 	rsstypes "github.com/aws/aws-sdk-go-v2/service/redshiftserverless/types"
-	"github.com/aws/aws-sdk-go/service/memorydb"
 	"github.com/aws/aws-sdk-go/service/opensearchservice"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 
@@ -43,7 +43,7 @@ type ResourceTag interface {
 		ec2types.Tag |
 		redshifttypes.Tag |
 		ectypes.Tag |
-		*memorydb.Tag |
+		memorydbtypes.Tag |
 		rsstypes.Tag |
 		*opensearchservice.Tag |
 		*secretsmanager.Tag
@@ -72,7 +72,7 @@ func resourceTagToKeyValue[Tag ResourceTag](tag Tag) (string, string) {
 	switch v := any(tag).(type) {
 	case ectypes.Tag:
 		return aws.ToString(v.Key), aws.ToString(v.Value)
-	case *memorydb.Tag:
+	case memorydbtypes.Tag:
 		return aws.ToString(v.Key), aws.ToString(v.Value)
 	case rsstypes.Tag:
 		return aws.ToString(v.Key), aws.ToString(v.Value)

--- a/lib/cloud/awstesthelpers/tags.go
+++ b/lib/cloud/awstesthelpers/tags.go
@@ -23,6 +23,7 @@ import (
 	"slices"
 
 	ectypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	memorydbtypes "github.com/aws/aws-sdk-go-v2/service/memorydb/types"
 	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	redshifttypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
 	rsstypes "github.com/aws/aws-sdk-go-v2/service/redshiftserverless/types"
@@ -65,5 +66,12 @@ func LabelsToRedshiftServerlessTags(labels map[string]string) []rsstypes.Tag {
 func LabelsToElastiCacheTags(labels map[string]string) []ectypes.Tag {
 	return LabelsToTags(labels, func(key, value string) ectypes.Tag {
 		return ectypes.Tag{Key: &key, Value: &value}
+	})
+}
+
+// LabelsToMemoryDBTags converts labels into a [memorydbtypes.Tag] list.
+func LabelsToMemoryDBTags(labels map[string]string) []memorydbtypes.Tag {
+	return LabelsToTags(labels, func(key, value string) memorydbtypes.Tag {
+		return memorydbtypes.Tag{Key: &key, Value: &value}
 	})
 }

--- a/lib/cloud/clients.go
+++ b/lib/cloud/clients.go
@@ -41,8 +41,6 @@ import (
 	awssession "github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/aws/aws-sdk-go/service/kms/kmsiface"
-	"github.com/aws/aws-sdk-go/service/memorydb"
-	"github.com/aws/aws-sdk-go/service/memorydb/memorydbiface"
 	"github.com/aws/aws-sdk-go/service/opensearchservice"
 	"github.com/aws/aws-sdk-go/service/opensearchservice/opensearchserviceiface"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -101,8 +99,6 @@ type GCPClients interface {
 type AWSClients interface {
 	// GetAWSSession returns AWS session for the specified region and any role(s).
 	GetAWSSession(ctx context.Context, region string, opts ...AWSOptionsFn) (*awssession.Session, error)
-	// GetAWSMemoryDBClient returns AWS MemoryDB client for the specified region.
-	GetAWSMemoryDBClient(ctx context.Context, region string, opts ...AWSOptionsFn) (memorydbiface.MemoryDBAPI, error)
 	// GetAWSOpenSearchClient returns AWS OpenSearch client for the specified region.
 	GetAWSOpenSearchClient(ctx context.Context, region string, opts ...AWSOptionsFn) (opensearchserviceiface.OpenSearchServiceAPI, error)
 	// GetAWSSecretsManagerClient returns AWS Secrets Manager client for the specified region.
@@ -495,15 +491,6 @@ func (c *cloudClients) GetAWSOpenSearchClient(ctx context.Context, region string
 		return nil, trace.Wrap(err)
 	}
 	return opensearchservice.New(session), nil
-}
-
-// GetAWSMemoryDBClient returns AWS MemoryDB client for the specified region.
-func (c *cloudClients) GetAWSMemoryDBClient(ctx context.Context, region string, opts ...AWSOptionsFn) (memorydbiface.MemoryDBAPI, error) {
-	session, err := c.GetAWSSession(ctx, region, opts...)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return memorydb.New(session), nil
 }
 
 // GetAWSSecretsManagerClient returns AWS Secrets Manager client for the specified region.
@@ -968,7 +955,6 @@ var _ Clients = (*TestCloudClients)(nil)
 // TestCloudClients are used in tests.
 type TestCloudClients struct {
 	OpenSearch              opensearchserviceiface.OpenSearchServiceAPI
-	MemoryDB                memorydbiface.MemoryDBAPI
 	SecretsManager          secretsmanageriface.SecretsManagerAPI
 	STS                     stsiface.STSAPI
 	GCPSQL                  gcp.SQLAdminClient
@@ -1041,15 +1027,6 @@ func (c *TestCloudClients) GetAWSOpenSearchClient(ctx context.Context, region st
 		return nil, trace.Wrap(err)
 	}
 	return c.OpenSearch, nil
-}
-
-// GetAWSMemoryDBClient returns AWS MemoryDB client for the specified region.
-func (c *TestCloudClients) GetAWSMemoryDBClient(ctx context.Context, region string, opts ...AWSOptionsFn) (memorydbiface.MemoryDBAPI, error) {
-	_, err := c.GetAWSSession(ctx, region, opts...)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return c.MemoryDB, nil
 }
 
 // GetAWSSecretsManagerClient returns AWS Secrets Manager client for the specified region.

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -2439,8 +2439,6 @@ type agentParams struct {
 	NoStart bool
 	// GCPSQL defines the GCP Cloud SQL mock to use for GCP API calls.
 	GCPSQL *mocks.GCPSQLAdminClientMock
-	// MemoryDB defines the AWS MemoryDB mock to use for MemoryDB API calls.
-	MemoryDB *mocks.MemoryDBMock
 	// OnHeartbeat defines a heartbeat function that generates heartbeat events.
 	OnHeartbeat func(error)
 	// CADownloader defines the CA downloader.
@@ -2479,9 +2477,6 @@ func (p *agentParams) setDefaults(c *testContext) {
 			},
 		}
 	}
-	if p.MemoryDB == nil {
-		p.MemoryDB = &mocks.MemoryDBMock{}
-	}
 	if p.CADownloader == nil {
 		p.CADownloader = &fakeDownloader{
 			cert: []byte(fixtures.TLSCACertPEM),
@@ -2491,7 +2486,6 @@ func (p *agentParams) setDefaults(c *testContext) {
 	if p.CloudClients == nil {
 		p.CloudClients = &clients.TestCloudClients{
 			STS:            &mocks.STSClientV1{},
-			MemoryDB:       p.MemoryDB,
 			SecretsManager: secrets.NewMockSecretsManagerClient(secrets.MockSecretsManagerClientConfig{}),
 			GCPSQL:         p.GCPSQL,
 		}

--- a/lib/srv/db/cloud/iam_test.go
+++ b/lib/srv/db/cloud/iam_test.go
@@ -122,7 +122,7 @@ func TestAWSIAM(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	memorydb, err := types.NewDatabaseV3(types.Metadata{
+	memDB, err := types.NewDatabaseV3(types.Metadata{
 		Name: "aws-memorydb",
 	}, types.DatabaseSpecV3{
 		Protocol: "redis",
@@ -223,8 +223,8 @@ func TestAWSIAM(t *testing.T) {
 			},
 		},
 		"MemoryDB": {
-			database:           memorydb,
-			wantPolicyContains: memorydb.GetAWS().MemoryDB.ClusterName,
+			database:           memDB,
+			wantPolicyContains: memDB.GetAWS().MemoryDB.ClusterName,
 			getIAMAuthEnabled: func() bool {
 				return true // it always is for MemoryDB.
 			},

--- a/lib/srv/db/cloud/meta_test.go
+++ b/lib/srv/db/cloud/meta_test.go
@@ -26,13 +26,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	ectypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/memorydb"
+	memorydbtypes "github.com/aws/aws-sdk-go-v2/service/memorydb/types"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/aws/aws-sdk-go-v2/service/redshift"
 	redshifttypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
 	rss "github.com/aws/aws-sdk-go-v2/service/redshiftserverless"
 	rsstypes "github.com/aws/aws-sdk-go-v2/service/redshiftserverless/types"
-	"github.com/aws/aws-sdk-go/service/memorydb"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
@@ -111,8 +112,8 @@ func TestAWSMetadata(t *testing.T) {
 	}
 
 	// Configure MemoryDB API mock.
-	memorydb := &mocks.MemoryDBMock{
-		Clusters: []*memorydb.Cluster{
+	mdbClient := &mocks.MemoryDBClient{
+		Clusters: []memorydbtypes.Cluster{
 			{
 				ARN:        aws.String("arn:aws:memorydb:us-west-1:123456789012:cluster:my-cluster"),
 				Name:       aws.String("my-cluster"),
@@ -135,13 +136,13 @@ func TestAWSMetadata(t *testing.T) {
 	// Create metadata fetcher.
 	metadata, err := NewMetadata(MetadataConfig{
 		Clients: &cloud.TestCloudClients{
-			MemoryDB: memorydb,
-			STS:      &fakeSTS.STSClientV1,
+			STS: &fakeSTS.STSClientV1,
 		},
 		AWSConfigProvider: &mocks.AWSConfigProvider{
 			STSClient: fakeSTS,
 		},
 		awsClients: fakeAWSClients{
+			mdbClient:      mdbClient,
 			ecClient:       ecClient,
 			rdsClient:      rdsClt,
 			redshiftClient: redshiftClt,
@@ -413,10 +414,6 @@ func TestAWSMetadata(t *testing.T) {
 // TestAWSMetadataNoPermissions verifies that lack of AWS permissions does not
 // cause an error.
 func TestAWSMetadataNoPermissions(t *testing.T) {
-	// Create unauthorized mocks.
-	rdsClt := &mocks.RDSClient{Unauth: true}
-	redshiftClt := &mocks.RedshiftClient{Unauth: true}
-
 	fakeSTS := &mocks.STSClient{}
 
 	// Create metadata fetcher.
@@ -428,8 +425,10 @@ func TestAWSMetadataNoPermissions(t *testing.T) {
 			STSClient: fakeSTS,
 		},
 		awsClients: fakeAWSClients{
-			rdsClient:      rdsClt,
-			redshiftClient: redshiftClt,
+			ecClient:       &mocks.ElastiCacheClient{Unauth: true},
+			mdbClient:      &mocks.MemoryDBClient{Unauth: true},
+			rdsClient:      &mocks.RDSClient{Unauth: true},
+			redshiftClient: &mocks.RedshiftClient{Unauth: true},
 		},
 	})
 	require.NoError(t, err)
@@ -506,6 +505,7 @@ func TestAWSMetadataNoPermissions(t *testing.T) {
 type fakeAWSClients struct {
 	ecClient       elasticacheClient
 	iamClient      iamClient
+	mdbClient      memoryDBClient
 	rdsClient      rdsClient
 	redshiftClient redshiftClient
 	rssClient      rssClient
@@ -517,6 +517,10 @@ func (f fakeAWSClients) getElastiCacheClient(cfg aws.Config, optFns ...func(*ela
 
 func (f fakeAWSClients) getIAMClient(aws.Config, ...func(*iam.Options)) iamClient {
 	return f.iamClient
+}
+
+func (f fakeAWSClients) getMemoryDBClient(cfg aws.Config, optFns ...func(*memorydb.Options)) memoryDBClient {
+	return f.mdbClient
 }
 
 func (f fakeAWSClients) getRDSClient(aws.Config, ...func(*rds.Options)) rdsClient {

--- a/lib/srv/db/cloud/resource_checker_url.go
+++ b/lib/srv/db/cloud/resource_checker_url.go
@@ -129,13 +129,8 @@ func requireDatabaseIsEndpoint(ctx context.Context, database types.Database, isE
 	return trace.Wrap(convIsEndpoint(isEndpoint)(ctx, database))
 }
 
-// TODO(gavin): remove the generic type parameter after all callers are migrated from AWS SDK v1 (uses *int64) to SDK v2 (uses *int32).
-func requireDatabaseAddressPort[T ~int32 | ~int64](database types.Database, wantURLHost *string, wantURLPort *T) error {
-	var port int
-	if wantURLPort != nil {
-		port = int(*wantURLPort)
-	}
-	wantURL := fmt.Sprintf("%v:%v", aws.ToString(wantURLHost), port)
+func requireDatabaseAddressPort(database types.Database, wantURLHost *string, wantURLPort *int32) error {
+	wantURL := fmt.Sprintf("%v:%v", aws.ToString(wantURLHost), aws.ToInt32(wantURLPort))
 	if database.GetURI() != wantURL {
 		return trace.BadParameter("expect database URL %q but got %q for database %q", wantURL, database.GetURI(), database.GetName())
 	}

--- a/lib/srv/db/cloud/resource_checker_url_aws_test.go
+++ b/lib/srv/db/cloud/resource_checker_url_aws_test.go
@@ -23,10 +23,10 @@ import (
 	"testing"
 
 	ectypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	memorydbtypes "github.com/aws/aws-sdk-go-v2/service/memorydb/types"
 	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	redshifttypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
 	rsstypes "github.com/aws/aws-sdk-go-v2/service/redshiftserverless/types"
-	"github.com/aws/aws-sdk-go/service/memorydb"
 	"github.com/aws/aws-sdk-go/service/opensearchservice"
 	"github.com/stretchr/testify/require"
 
@@ -121,16 +121,12 @@ func TestURLChecker_AWS(t *testing.T) {
 
 	// Mock cloud clients.
 	mockClients := &cloud.TestCloudClients{
-		MemoryDB: &mocks.MemoryDBMock{
-			Clusters: []*memorydb.Cluster{memoryDBCluster},
-		},
 		OpenSearch: &mocks.OpenSearchMock{
 			Domains: []*opensearchservice.DomainStatus{openSearchDomain, openSearchVPCDomain},
 		},
 		STS: &mocks.STSClientV1{},
 	}
 	mockClientsUnauth := &cloud.TestCloudClients{
-		MemoryDB:   &mocks.MemoryDBMock{Unauth: true},
 		OpenSearch: &mocks.OpenSearchMock{Unauth: true},
 		STS:        &mocks.STSClientV1{},
 	}
@@ -149,6 +145,9 @@ func TestURLChecker_AWS(t *testing.T) {
 			clients:           mockClients,
 			awsConfigProvider: &mocks.AWSConfigProvider{},
 			awsClients: fakeAWSClients{
+				mdbClient: &mocks.MemoryDBClient{
+					Clusters: []memorydbtypes.Cluster{*memoryDBCluster},
+				},
 				ecClient: &mocks.ElastiCacheClient{
 					ReplicationGroups: []ectypes.ReplicationGroup{*elastiCacheClusterConfigurationMode, *elastiCacheCluster},
 				},
@@ -173,6 +172,7 @@ func TestURLChecker_AWS(t *testing.T) {
 			awsConfigProvider: &mocks.AWSConfigProvider{},
 			awsClients: fakeAWSClients{
 				ecClient:       &mocks.ElastiCacheClient{Unauth: true},
+				mdbClient:      &mocks.MemoryDBClient{Unauth: true},
 				rdsClient:      &mocks.RDSClient{Unauth: true},
 				redshiftClient: &mocks.RedshiftClient{Unauth: true},
 				rssClient:      &mocks.RedshiftServerlessClient{Unauth: true},

--- a/lib/srv/db/cloud/users/elasticache.go
+++ b/lib/srv/db/cloud/users/elasticache.go
@@ -34,6 +34,13 @@ import (
 	libutils "github.com/gravitational/teleport/lib/utils"
 )
 
+type elasticacheClient interface {
+	elasticache.DescribeUsersAPIClient
+
+	ListTagsForResource(ctx context.Context, in *elasticache.ListTagsForResourceInput, optFns ...func(*elasticache.Options)) (*elasticache.ListTagsForResourceOutput, error)
+	ModifyUser(ctx context.Context, in *elasticache.ModifyUserInput, optFns ...func(*elasticache.Options)) (*elasticache.ModifyUserOutput, error)
+}
+
 // elastiCacheFetcher is a fetcher for discovering ElastiCache users.
 type elastiCacheFetcher struct {
 	cfg   Config

--- a/lib/srv/db/cloud/users/memorydb.go
+++ b/lib/srv/db/cloud/users/memorydb.go
@@ -22,18 +22,25 @@ import (
 	"context"
 	"slices"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/memorydb"
-	"github.com/aws/aws-sdk-go/service/memorydb/memorydbiface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	memorydb "github.com/aws/aws-sdk-go-v2/service/memorydb"
+	memorydbtypes "github.com/aws/aws-sdk-go-v2/service/memorydb/types"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/cloud"
 	libaws "github.com/gravitational/teleport/lib/cloud/aws"
+	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	libsecrets "github.com/gravitational/teleport/lib/srv/db/secrets"
 	libutils "github.com/gravitational/teleport/lib/utils"
 )
+
+type memoryDBClient interface {
+	memorydb.DescribeUsersAPIClient
+
+	ListTags(ctx context.Context, in *memorydb.ListTagsInput, optFns ...func(*memorydb.Options)) (*memorydb.ListTagsOutput, error)
+	UpdateUser(ctx context.Context, in *memorydb.UpdateUserInput, optFns ...func(*memorydb.Options)) (*memorydb.UpdateUserOutput, error)
+}
 
 // memoryDBFetcher is a fetcher for discovering MemoryDB users.
 type memoryDBFetcher struct {
@@ -75,13 +82,14 @@ func (f *memoryDBFetcher) FetchDatabaseUsers(ctx context.Context, database types
 		return nil, nil
 	}
 
-	client, err := f.cfg.Clients.GetAWSMemoryDBClient(ctx, meta.Region,
-		cloud.WithAssumeRoleFromAWSMeta(meta),
-		cloud.WithAmbientCredentials(),
+	awsCfg, err := f.cfg.AWSConfigProvider.GetConfig(ctx, meta.Region,
+		awsconfig.WithAssumeRole(meta.AssumeRoleARN, meta.ExternalID),
+		awsconfig.WithAmbientCredentials(),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	clt := f.cfg.awsClients.getMemoryDBClient(awsCfg)
 
 	secrets, err := newSecretStore(ctx, database, f.cfg.Clients, f.cfg.ClusterName)
 	if err != nil {
@@ -89,13 +97,13 @@ func (f *memoryDBFetcher) FetchDatabaseUsers(ctx context.Context, database types
 	}
 
 	users := []User{}
-	mdbUsers, err := f.getManagedUsersForACL(ctx, meta.Region, meta.MemoryDB.ACLName, client)
+	mdbUsers, err := f.getManagedUsersForACL(ctx, meta.Region, meta.MemoryDB.ACLName, clt)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	for _, mdbUser := range mdbUsers {
-		user, err := f.createUser(mdbUser, client, secrets)
+		user, err := f.createUser(&mdbUser, clt, secrets)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -106,33 +114,33 @@ func (f *memoryDBFetcher) FetchDatabaseUsers(ctx context.Context, database types
 }
 
 // getManagedUsersForACL returns all managed users for specified ACL.
-func (f *memoryDBFetcher) getManagedUsersForACL(ctx context.Context, region, aclName string, client memorydbiface.MemoryDBAPI) ([]*memorydb.User, error) {
+func (f *memoryDBFetcher) getManagedUsersForACL(ctx context.Context, region, aclName string, client memoryDBClient) ([]memorydbtypes.User, error) {
 	allUsers, err := f.getUsersForRegion(ctx, region, client)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	managedUsers := []*memorydb.User{}
+	managedUsers := []memorydbtypes.User{}
 	for _, user := range allUsers {
 		// Match ACL.
-		if !slices.Contains(aws.StringValueSlice(user.ACLNames), aclName) {
+		if !slices.Contains(user.ACLNames, aclName) {
 			continue
 		}
 
 		// Match special Teleport "managed" tag.
 		// If failed to get tags for some users, log the errors instead of failing the function.
-		userTags, err := f.getUserTags(ctx, user, client)
+		userTags, err := f.getUserTags(ctx, &user, client)
 		if err != nil {
 			if trace.IsAccessDenied(err) {
-				f.cfg.Log.DebugContext(ctx, "No Permission to get tags.", "user", aws.StringValue(user.ARN), "error", err)
+				f.cfg.Log.DebugContext(ctx, "No Permission to get tags.", "user", aws.ToString(user.ARN), "error", err)
 			} else {
-				f.cfg.Log.WarnContext(ctx, "Failed to get tags.", "user", aws.StringValue(user.ARN), "error", err)
+				f.cfg.Log.WarnContext(ctx, "Failed to get tags.", "user", aws.ToString(user.ARN), "error", err)
 			}
 			continue
 		}
 		for _, tag := range userTags {
-			if aws.StringValue(tag.Key) == libaws.TagKeyTeleportManaged &&
-				libaws.IsTagValueTrue(aws.StringValue(tag.Value)) {
+			if aws.ToString(tag.Key) == libaws.TagKeyTeleportManaged &&
+				libaws.IsTagValueTrue(aws.ToString(tag.Value)) {
 				managedUsers = append(managedUsers, user)
 				break
 			}
@@ -142,22 +150,21 @@ func (f *memoryDBFetcher) getManagedUsersForACL(ctx context.Context, region, acl
 }
 
 // getUsersForRegion discovers all MemoryDB users for provided region.
-func (f *memoryDBFetcher) getUsersForRegion(ctx context.Context, region string, client memorydbiface.MemoryDBAPI) ([]*memorydb.User, error) {
-	getFunc := func(ctx context.Context) ([]*memorydb.User, error) {
-		var users []*memorydb.User
-		var nextToken *string
-		for pageNum := 0; pageNum < common.MaxPages; pageNum++ {
-			output, err := client.DescribeUsersWithContext(ctx, &memorydb.DescribeUsersInput{
-				NextToken: nextToken,
-			})
+func (f *memoryDBFetcher) getUsersForRegion(ctx context.Context, region string, client memoryDBClient) ([]memorydbtypes.User, error) {
+	getFunc := func(ctx context.Context) ([]memorydbtypes.User, error) {
+		pager := memorydb.NewDescribeUsersPaginator(client,
+			&memorydb.DescribeUsersInput{},
+			func(opts *memorydb.DescribeUsersPaginatorOptions) {
+				opts.StopOnDuplicateToken = true
+			},
+		)
+		var users []memorydbtypes.User
+		for i := 0; i < common.MaxPages && pager.HasMorePages(); i++ {
+			page, err := pager.NextPage(ctx)
 			if err != nil {
-				return nil, trace.Wrap(libaws.ConvertRequestFailureError(err))
+				return nil, trace.Wrap(libaws.ConvertRequestFailureErrorV2(err))
 			}
-
-			users = append(users, output.Users...)
-			if nextToken = output.NextToken; nextToken == nil {
-				break
-			}
+			users = append(users, page.Users...)
 		}
 		return users, nil
 	}
@@ -171,18 +178,18 @@ func (f *memoryDBFetcher) getUsersForRegion(ctx context.Context, region string, 
 }
 
 // getUserTags discovers resource tags for provided user.
-func (f *memoryDBFetcher) getUserTags(ctx context.Context, user *memorydb.User, client memorydbiface.MemoryDBAPI) ([]*memorydb.Tag, error) {
-	getFunc := func(ctx context.Context) ([]*memorydb.Tag, error) {
-		output, err := client.ListTagsWithContext(ctx, &memorydb.ListTagsInput{
+func (f *memoryDBFetcher) getUserTags(ctx context.Context, user *memorydbtypes.User, client memoryDBClient) ([]memorydbtypes.Tag, error) {
+	getFunc := func(ctx context.Context) ([]memorydbtypes.Tag, error) {
+		output, err := client.ListTags(ctx, &memorydb.ListTagsInput{
 			ResourceArn: user.ARN,
 		})
 		if err != nil {
-			return nil, trace.Wrap(libaws.ConvertRequestFailureError(err))
+			return nil, trace.Wrap(libaws.ConvertRequestFailureErrorV2(err))
 		}
 		return output.TagList, nil
 	}
 
-	userTags, err := libutils.FnCacheGet(ctx, f.cache, aws.StringValue(user.ARN), getFunc)
+	userTags, err := libutils.FnCacheGet(ctx, f.cache, aws.ToString(user.ARN), getFunc)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -191,8 +198,8 @@ func (f *memoryDBFetcher) getUserTags(ctx context.Context, user *memorydb.User, 
 }
 
 // createUser creates an MemoryDB User.
-func (f *memoryDBFetcher) createUser(mdbUser *memorydb.User, client memorydbiface.MemoryDBAPI, secrets libsecrets.Secrets) (User, error) {
-	secretKey, err := secretKeyFromAWSARN(aws.StringValue(mdbUser.ARN))
+func (f *memoryDBFetcher) createUser(mdbUser *memorydbtypes.User, client memoryDBClient, secrets libsecrets.Secrets) (User, error) {
+	secretKey, err := secretKeyFromAWSARN(aws.ToString(mdbUser.ARN))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -202,7 +209,7 @@ func (f *memoryDBFetcher) createUser(mdbUser *memorydb.User, client memorydbifac
 		secretKey:                   secretKey,
 		secrets:                     secrets,
 		secretTTL:                   f.cfg.Interval,
-		databaseUsername:            aws.StringValue(mdbUser.Name),
+		databaseUsername:            aws.ToString(mdbUser.Name),
 		clock:                       f.cfg.Clock,
 		maxPasswordLength:           128,
 		usePreviousPasswordForLogin: true,
@@ -219,30 +226,25 @@ func (f *memoryDBFetcher) createUser(mdbUser *memorydb.User, client memorydbifac
 
 // memoryDBUserResource implements cloudResource interface for a MemoryDB user.
 type memoryDBUserResource struct {
-	user   *memorydb.User
-	client memorydbiface.MemoryDBAPI
+	user   *memorydbtypes.User
+	client memoryDBClient
 }
 
 // ModifyUserPassword updates passwords of an MemoryDB user.
 func (r *memoryDBUserResource) ModifyUserPassword(ctx context.Context, oldPassword, newPassword string) error {
 	input := &memorydb.UpdateUserInput{
-		UserName:           r.user.Name,
-		AuthenticationMode: &memorydb.AuthenticationMode{},
+		UserName: r.user.Name,
+		AuthenticationMode: &memorydbtypes.AuthenticationMode{
+			Type: memorydbtypes.InputAuthenticationTypePassword,
+		},
 	}
 	if oldPassword != "" {
-		input.AuthenticationMode.Passwords = append(input.AuthenticationMode.Passwords, aws.String(oldPassword))
+		input.AuthenticationMode.Passwords = append(input.AuthenticationMode.Passwords, oldPassword)
 	}
-	if newPassword != "" {
-		input.AuthenticationMode.Passwords = append(input.AuthenticationMode.Passwords, aws.String(newPassword))
-	}
-	if len(input.AuthenticationMode.Passwords) == 0 {
-		input.AuthenticationMode.SetType("no-password")
-	} else {
-		input.AuthenticationMode.SetType("password")
-	}
+	input.AuthenticationMode.Passwords = append(input.AuthenticationMode.Passwords, newPassword)
 
-	if _, err := r.client.UpdateUserWithContext(ctx, input); err != nil {
-		return trace.Wrap(libaws.ConvertRequestFailureError(err))
+	if _, err := r.client.UpdateUser(ctx, input); err != nil {
+		return trace.Wrap(libaws.ConvertRequestFailureErrorV2(err))
 	}
 	return nil
 }

--- a/lib/srv/db/cloud/users/users.go
+++ b/lib/srv/db/cloud/users/users.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	elasticache "github.com/aws/aws-sdk-go-v2/service/elasticache"
+	memorydb "github.com/aws/aws-sdk-go-v2/service/memorydb"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 
@@ -61,19 +62,17 @@ type Config struct {
 // awsClientProvider is an AWS SDK client provider.
 type awsClientProvider interface {
 	getElastiCacheClient(cfg aws.Config, optFns ...func(*elasticache.Options)) elasticacheClient
-}
-
-type elasticacheClient interface {
-	elasticache.DescribeUsersAPIClient
-
-	ListTagsForResource(ctx context.Context, in *elasticache.ListTagsForResourceInput, optFns ...func(*elasticache.Options)) (*elasticache.ListTagsForResourceOutput, error)
-	ModifyUser(ctx context.Context, in *elasticache.ModifyUserInput, optFns ...func(*elasticache.Options)) (*elasticache.ModifyUserOutput, error)
+	getMemoryDBClient(cfg aws.Config, optFns ...func(*memorydb.Options)) memoryDBClient
 }
 
 type defaultAWSClients struct{}
 
 func (defaultAWSClients) getElastiCacheClient(cfg aws.Config, optFns ...func(*elasticache.Options)) elasticacheClient {
 	return elasticache.NewFromConfig(cfg, optFns...)
+}
+
+func (defaultAWSClients) getMemoryDBClient(cfg aws.Config, optFns ...func(*memorydb.Options)) memoryDBClient {
+	return memorydb.NewFromConfig(cfg, optFns...)
 }
 
 // CheckAndSetDefaults validates the config and set defaults.

--- a/lib/srv/db/redis/client.go
+++ b/lib/srv/db/redis/client.go
@@ -182,7 +182,7 @@ func fetchCredentialsOnConnect(closeCtx context.Context, sessionCtx *common.Sess
 }
 
 // managedUserCredFetchFunc fetches user password on the fly.
-func managedUserCredFetchFunc(sessionCtx *common.Session, auth common.Auth, users common.Users) fetchCredentialsFunc {
+func managedUserCredFetchFunc(sessionCtx *common.Session, users common.Users) fetchCredentialsFunc {
 	return func(ctx context.Context) (string, string, error) {
 		username := sessionCtx.DatabaseUser
 		password, err := users.GetPassword(ctx, sessionCtx.Database, username)

--- a/lib/srv/db/redis/engine.go
+++ b/lib/srv/db/redis/engine.go
@@ -32,14 +32,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	elasticache "github.com/aws/aws-sdk-go-v2/service/elasticache"
 	ectypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
-	"github.com/aws/aws-sdk-go/service/memorydb"
+	memorydb "github.com/aws/aws-sdk-go-v2/service/memorydb"
+	memorydbtypes "github.com/aws/aws-sdk-go-v2/service/memorydb/types"
 	"github.com/gravitational/trace"
 	"github.com/redis/go-redis/v9"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	apiawsutils "github.com/gravitational/teleport/api/utils/aws"
-	"github.com/gravitational/teleport/lib/cloud"
 	libaws "github.com/gravitational/teleport/lib/cloud/aws"
 	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 	"github.com/gravitational/teleport/lib/cloud/azure"
@@ -89,8 +89,10 @@ type Engine struct {
 
 // AWSClientProvider provides AWS service API clients.
 type AWSClientProvider interface {
-	// GetElastiCacheClient provides an [ElasticacheClient].
+	// GetElastiCacheClient provides an [ElastiCacheClient].
 	GetElastiCacheClient(cfg aws.Config, optFns ...func(*elasticache.Options)) ElastiCacheClient
+	// GetMemoryDBClient provides an [MemoryDBClient].
+	GetMemoryDBClient(cfg aws.Config, optFns ...func(*memorydb.Options)) MemoryDBClient
 }
 
 // ElastiCacheClient is a subset of the AWS ElastiCache API.
@@ -98,10 +100,19 @@ type ElastiCacheClient interface {
 	elasticache.DescribeUsersAPIClient
 }
 
+// MemoryDBClient is a subset of the AWS MemoryDB API.
+type MemoryDBClient interface {
+	memorydb.DescribeUsersAPIClient
+}
+
 type defaultAWSClients struct{}
 
 func (defaultAWSClients) GetElastiCacheClient(cfg aws.Config, optFns ...func(*elasticache.Options)) ElastiCacheClient {
 	return elasticache.NewFromConfig(cfg, optFns...)
+}
+
+func (defaultAWSClients) GetMemoryDBClient(cfg aws.Config, optFns ...func(*memorydb.Options)) MemoryDBClient {
+	return memorydb.NewFromConfig(cfg, optFns...)
 }
 
 // InitializeConnection initializes the database connection.
@@ -354,7 +365,7 @@ func (e *Engine) createCredentialsProvider(ctx context.Context, sessionCtx *comm
 	// ensures the correct password is used for each shard connection when
 	// Redis is in cluster mode.
 	case slices.Contains(sessionCtx.Database.GetManagedUsers(), sessionCtx.DatabaseUser):
-		credFetchFn := managedUserCredFetchFunc(sessionCtx, e.Auth, e.Users)
+		credFetchFn := managedUserCredFetchFunc(sessionCtx, e.Users)
 		return fetchCredentialsOnConnect(e.Context, sessionCtx, e.Audit, credFetchFn), nil
 
 	// AWS ElastiCache has limited support for IAM authentication.
@@ -424,7 +435,7 @@ func (e *Engine) checkUserIAMAuthIsEnabled(ctx context.Context, sessionCtx *comm
 	case types.DatabaseTypeElastiCache:
 		return e.checkElastiCacheUserIAMAuthIsEnabled(ctx, sessionCtx.Database.GetAWS(), username)
 	case types.DatabaseTypeMemoryDB:
-		return checkMemoryDBUserIAMAuthIsEnabled(ctx, e.CloudClients, sessionCtx.Database.GetAWS(), username)
+		return e.checkMemoryDBUserIAMAuthIsEnabled(ctx, sessionCtx.Database.GetAWS(), username)
 	default:
 		return false, nil
 	}
@@ -454,24 +465,25 @@ func (e *Engine) checkElastiCacheUserIAMAuthIsEnabled(ctx context.Context, awsMe
 	return ectypes.AuthenticationTypeIam == authType, nil
 }
 
-func checkMemoryDBUserIAMAuthIsEnabled(ctx context.Context, clients cloud.Clients, awsMeta types.AWS, username string) (bool, error) {
-	client, err := clients.GetAWSMemoryDBClient(ctx, awsMeta.Region,
-		cloud.WithAssumeRoleFromAWSMeta(awsMeta),
-		cloud.WithAmbientCredentials(),
+func (e *Engine) checkMemoryDBUserIAMAuthIsEnabled(ctx context.Context, awsMeta types.AWS, username string) (bool, error) {
+	awsCfg, err := e.AWSConfigProvider.GetConfig(ctx, awsMeta.Region,
+		awsconfig.WithAssumeRole(awsMeta.AssumeRoleARN, awsMeta.ExternalID),
+		awsconfig.WithAmbientCredentials(),
 	)
 	if err != nil {
 		return false, trace.Wrap(err)
 	}
+	client := e.AWSClients.GetMemoryDBClient(awsCfg)
 	input := memorydb.DescribeUsersInput{UserName: aws.String(username)}
-	out, err := client.DescribeUsersWithContext(ctx, &input)
+	out, err := client.DescribeUsers(ctx, &input)
 	if err != nil {
-		return false, trace.Wrap(libaws.ConvertRequestFailureError(err))
+		return false, trace.Wrap(libaws.ConvertRequestFailureErrorV2(err))
 	}
 	if len(out.Users) < 1 || out.Users[0].Authentication == nil {
 		return false, nil
 	}
-	authType := aws.ToString(out.Users[0].Authentication.Type)
-	return memorydb.AuthenticationTypeIam == authType, nil
+	authType := out.Users[0].Authentication.Type
+	return memorydbtypes.AuthenticationTypeIam == authType, nil
 }
 
 // reconnect closes the current Redis server connection and creates a new one pre-authenticated

--- a/lib/srv/db/watcher_test.go
+++ b/lib/srv/db/watcher_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	elasticache "github.com/aws/aws-sdk-go-v2/service/elasticache"
+	"github.com/aws/aws-sdk-go-v2/service/memorydb"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/redshift"
 	rss "github.com/aws/aws-sdk-go-v2/service/redshiftserverless"
@@ -478,6 +479,7 @@ func makeAzureSQLServer(t *testing.T, name, group string) (*armsql.Server, types
 }
 
 type fakeAWSClients struct {
+	mdbClient      db.MemoryDBClient
 	ecClient       db.ElastiCacheClient
 	rdsClient      db.RDSClient
 	redshiftClient db.RedshiftClient
@@ -486,6 +488,10 @@ type fakeAWSClients struct {
 
 func (f fakeAWSClients) GetElastiCacheClient(cfg aws.Config, optFns ...func(*elasticache.Options)) db.ElastiCacheClient {
 	return f.ecClient
+}
+
+func (f fakeAWSClients) GetMemoryDBClient(cfg aws.Config, optFns ...func(*memorydb.Options)) db.MemoryDBClient {
+	return f.mdbClient
 }
 
 func (f fakeAWSClients) GetRDSClient(cfg aws.Config, optFns ...func(*rds.Options)) db.RDSClient {

--- a/lib/srv/discovery/common/database_test.go
+++ b/lib/srv/discovery/common/database_test.go
@@ -29,9 +29,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ectypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	memorydbtypes "github.com/aws/aws-sdk-go-v2/service/memorydb/types"
 	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	redshifttypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
-	"github.com/aws/aws-sdk-go/service/memorydb"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
@@ -1612,15 +1612,15 @@ func TestDatabaseFromElastiCacheNodeGroupsNameOverride(t *testing.T) {
 }
 
 func TestDatabaseFromMemoryDBCluster(t *testing.T) {
-	cluster := &memorydb.Cluster{
+	cluster := &memorydbtypes.Cluster{
 		ARN:        aws.String("arn:aws:memorydb:us-east-1:123456789012:cluster:my-cluster"),
 		Name:       aws.String("my-cluster"),
 		Status:     aws.String("available"),
 		TLSEnabled: aws.Bool(true),
 		ACLName:    aws.String("my-user-group"),
-		ClusterEndpoint: &memorydb.Endpoint{
+		ClusterEndpoint: &memorydbtypes.Endpoint{
 			Address: aws.String("memorydb.localhost"),
-			Port:    aws.Int64(6379),
+			Port:    6379,
 		},
 	}
 	extraLabels := map[string]string{"key": "value"}
@@ -1733,15 +1733,15 @@ func TestDatabaseFromRedshiftServerlessVPCEndpoint(t *testing.T) {
 func TestDatabaseFromMemoryDBClusterNameOverride(t *testing.T) {
 	for _, overrideLabel := range types.AWSDatabaseNameOverrideLabels {
 		t.Run("via "+overrideLabel, func(t *testing.T) {
-			cluster := &memorydb.Cluster{
+			cluster := &memorydbtypes.Cluster{
 				ARN:        aws.String("arn:aws:memorydb:us-east-1:123456789012:cluster:my-cluster"),
 				Name:       aws.String("my-cluster"),
 				Status:     aws.String("available"),
 				TLSEnabled: aws.Bool(true),
 				ACLName:    aws.String("my-user-group"),
-				ClusterEndpoint: &memorydb.Endpoint{
+				ClusterEndpoint: &memorydbtypes.Endpoint{
 					Address: aws.String("memorydb.localhost"),
-					Port:    aws.Int64(6379),
+					Port:    6379,
 				},
 			}
 			extraLabels := map[string]string{
@@ -1884,13 +1884,14 @@ func TestExtraElastiCacheLabels(t *testing.T) {
 }
 
 func TestExtraMemoryDBLabels(t *testing.T) {
-	cluster := &memorydb.Cluster{
+	cluster := &memorydbtypes.Cluster{
 		Name:            aws.String("my-cluster"),
 		SubnetGroupName: aws.String("my-subnet-group"),
+		Engine:          aws.String("redis"),
 		EngineVersion:   aws.String("6.6.6"),
 	}
 
-	allSubnetGroups := []*memorydb.SubnetGroup{
+	allSubnetGroups := []memorydbtypes.SubnetGroup{
 		{
 			Name:  aws.String("other-subnet-group"),
 			VpcId: aws.String("other-vpc-id"),
@@ -1901,7 +1902,7 @@ func TestExtraMemoryDBLabels(t *testing.T) {
 		},
 	}
 
-	resourceTags := []*memorydb.Tag{
+	resourceTags := []memorydbtypes.Tag{
 		{Key: aws.String("key1"), Value: aws.String("value1")},
 		{Key: aws.String("key2"), Value: aws.String("value2")},
 	}
@@ -1909,6 +1910,7 @@ func TestExtraMemoryDBLabels(t *testing.T) {
 	expected := map[string]string{
 		"key1":           "value1",
 		"key2":           "value2",
+		"engine":         "redis",
 		"engine-version": "6.6.6",
 		"vpc-id":         "my-vpc-id",
 	}

--- a/lib/srv/discovery/fetchers/db/aws_memorydb.go
+++ b/lib/srv/discovery/fetchers/db/aws_memorydb.go
@@ -21,16 +21,24 @@ package db
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/memorydb"
-	"github.com/aws/aws-sdk-go/service/memorydb/memorydbiface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	memorydb "github.com/aws/aws-sdk-go-v2/service/memorydb"
+	memorydbtypes "github.com/aws/aws-sdk-go-v2/service/memorydb/types"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/cloud"
 	libcloudaws "github.com/gravitational/teleport/lib/cloud/aws"
+	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
 )
+
+// MemoryDBClient is a subset of the AWS MemoryDB API.
+type MemoryDBClient interface {
+	memorydb.DescribeClustersAPIClient
+	memorydb.DescribeSubnetGroupsAPIClient
+
+	ListTags(ctx context.Context, in *memorydb.ListTagsInput, optFns ...func(*memorydb.Options)) (*memorydb.ListTagsOutput, error)
+}
 
 // memoryDBPlugin retrieves MemoryDB Redis databases.
 type memoryDBPlugin struct{}
@@ -46,29 +54,30 @@ func (f *memoryDBPlugin) ComponentShortName() string {
 
 // GetDatabases returns MemoryDB databases matching the watcher's selectors.
 func (f *memoryDBPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig) (types.Databases, error) {
-	memDBClient, err := cfg.AWSClients.GetAWSMemoryDBClient(ctx, cfg.Region,
-		cloud.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
-		cloud.WithCredentialsMaybeIntegration(cfg.Integration),
+	awsCfg, err := cfg.AWSConfigProvider.GetConfig(ctx, cfg.Region,
+		awsconfig.WithAssumeRole(cfg.AssumeRole.RoleARN, cfg.AssumeRole.ExternalID),
+		awsconfig.WithCredentialsMaybeIntegration(cfg.Integration),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	clusters, err := getMemoryDBClusters(ctx, memDBClient)
+	clt := cfg.awsClients.GetMemoryDBClient(awsCfg)
+	clusters, err := getMemoryDBClusters(ctx, clt)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	var eligibleClusters []*memorydb.Cluster
+	var eligibleClusters []memorydbtypes.Cluster
 	for _, cluster := range clusters {
-		if !libcloudaws.IsMemoryDBClusterSupported(cluster) {
-			cfg.Logger.DebugContext(ctx, "Skipping unsupported MemoryDB cluster", "cluster", aws.StringValue(cluster.Name))
+		if !libcloudaws.IsMemoryDBClusterSupported(&cluster) {
+			cfg.Logger.DebugContext(ctx, "Skipping unsupported MemoryDB cluster", "cluster", aws.ToString(cluster.Name))
 			continue
 		}
 
-		if !libcloudaws.IsMemoryDBClusterAvailable(cluster) {
+		if !libcloudaws.IsMemoryDBClusterAvailable(&cluster) {
 			cfg.Logger.DebugContext(ctx, "Skipping unavailable MemoryDB cluster",
-				"cluster", aws.StringValue(cluster.Name),
-				"status", aws.StringValue(cluster.Status),
+				"cluster", aws.ToString(cluster.Name),
+				"status", aws.ToString(cluster.Status),
 			)
 			continue
 		}
@@ -82,7 +91,7 @@ func (f *memoryDBPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig
 
 	// Fetch more information to provide extra labels. Do not fail because some
 	// of these labels are missing.
-	allSubnetGroups, err := getMemoryDBSubnetGroups(ctx, memDBClient)
+	allSubnetGroups, err := getMemoryDBSubnetGroups(ctx, clt)
 	if err != nil {
 		if trace.IsAccessDenied(err) {
 			cfg.Logger.DebugContext(ctx, "No permissions to describe subnet groups", "error", err)
@@ -93,24 +102,24 @@ func (f *memoryDBPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig
 
 	var databases types.Databases
 	for _, cluster := range eligibleClusters {
-		tags, err := getMemoryDBResourceTags(ctx, memDBClient, cluster.ARN)
+		tags, err := getMemoryDBResourceTags(ctx, clt, cluster.ARN)
 		if err != nil {
 			if trace.IsAccessDenied(err) {
 				cfg.Logger.DebugContext(ctx, "No permissions to list resource tags", "error", err)
 			} else {
 				cfg.Logger.InfoContext(ctx, "Failed to list resource tags for MemoryDB cluster ",
 					"error", err,
-					"cluster", aws.StringValue(cluster.Name),
+					"cluster", aws.ToString(cluster.Name),
 				)
 			}
 		}
 
-		extraLabels := common.ExtraMemoryDBLabels(cluster, tags, allSubnetGroups)
-		database, err := common.NewDatabaseFromMemoryDBCluster(cluster, extraLabels)
+		extraLabels := common.ExtraMemoryDBLabels(&cluster, tags, allSubnetGroups)
+		database, err := common.NewDatabaseFromMemoryDBCluster(&cluster, extraLabels)
 		if err != nil {
 			cfg.Logger.InfoContext(ctx, "Could not convert memorydb cluster configuration endpoint to database resource",
 				"error", err,
-				"cluster", aws.StringValue(cluster.Name),
+				"cluster", aws.ToString(cluster.Name),
 			)
 		} else {
 			databases = append(databases, database)
@@ -120,56 +129,44 @@ func (f *memoryDBPlugin) GetDatabases(ctx context.Context, cfg *awsFetcherConfig
 }
 
 // getMemoryDBClusters fetches all MemoryDB clusters.
-func getMemoryDBClusters(ctx context.Context, client memorydbiface.MemoryDBAPI) ([]*memorydb.Cluster, error) {
-	var clusters []*memorydb.Cluster
-	var nextToken *string
-
-	// MemoryDBAPI does NOT have "page" version of the describe API so use the
-	// NextToken from the output in a loop.
-	for pageNum := 0; pageNum < maxAWSPages; pageNum++ {
-		output, err := client.DescribeClustersWithContext(ctx,
-			&memorydb.DescribeClustersInput{
-				NextToken: nextToken,
-			},
-		)
+func getMemoryDBClusters(ctx context.Context, client MemoryDBClient) ([]memorydbtypes.Cluster, error) {
+	var out []memorydbtypes.Cluster
+	pager := memorydb.NewDescribeClustersPaginator(client,
+		&memorydb.DescribeClustersInput{},
+		func(opts *memorydb.DescribeClustersPaginatorOptions) {
+			opts.StopOnDuplicateToken = true
+		},
+	)
+	for i := 0; i < maxAWSPages && pager.HasMorePages(); i++ {
+		page, err := pager.NextPage(ctx)
 		if err != nil {
-			return nil, trace.Wrap(libcloudaws.ConvertRequestFailureError(err))
+			return nil, trace.Wrap(libcloudaws.ConvertRequestFailureErrorV2(err))
 		}
-
-		clusters = append(clusters, output.Clusters...)
-		if nextToken = output.NextToken; nextToken == nil {
-			break
-		}
+		out = append(out, page.Clusters...)
 	}
-	return clusters, nil
+	return out, nil
 }
 
 // getMemoryDBSubnetGroups fetches all MemoryDB subnet groups.
-func getMemoryDBSubnetGroups(ctx context.Context, client memorydbiface.MemoryDBAPI) ([]*memorydb.SubnetGroup, error) {
-	var subnetGroups []*memorydb.SubnetGroup
-	var nextToken *string
-
-	for pageNum := 0; pageNum < maxAWSPages; pageNum++ {
-		output, err := client.DescribeSubnetGroupsWithContext(ctx,
-			&memorydb.DescribeSubnetGroupsInput{
-				NextToken: nextToken,
-			},
-		)
+func getMemoryDBSubnetGroups(ctx context.Context, client MemoryDBClient) ([]memorydbtypes.SubnetGroup, error) {
+	var out []memorydbtypes.SubnetGroup
+	pager := memorydb.NewDescribeSubnetGroupsPaginator(client,
+		&memorydb.DescribeSubnetGroupsInput{},
+		func(opts *memorydb.DescribeSubnetGroupsPaginatorOptions) { opts.StopOnDuplicateToken = true },
+	)
+	for i := 0; i < maxAWSPages && pager.HasMorePages(); i++ {
+		page, err := pager.NextPage(ctx)
 		if err != nil {
-			return nil, trace.Wrap(libcloudaws.ConvertRequestFailureError(err))
+			return nil, trace.Wrap(libcloudaws.ConvertRequestFailureErrorV2(err))
 		}
-
-		subnetGroups = append(subnetGroups, output.SubnetGroups...)
-		if nextToken = output.NextToken; nextToken == nil {
-			break
-		}
+		out = append(out, page.SubnetGroups...)
 	}
-	return subnetGroups, nil
+	return out, nil
 }
 
 // getMemoryDBResourceTags fetches resource tags for provided ARN.
-func getMemoryDBResourceTags(ctx context.Context, client memorydbiface.MemoryDBAPI, resourceARN *string) ([]*memorydb.Tag, error) {
-	output, err := client.ListTagsWithContext(ctx, &memorydb.ListTagsInput{
+func getMemoryDBResourceTags(ctx context.Context, client MemoryDBClient, resourceARN *string) ([]memorydbtypes.Tag, error) {
+	output, err := client.ListTags(ctx, &memorydb.ListTagsInput{
 		ResourceArn: resourceARN,
 	})
 	if err != nil {

--- a/lib/srv/discovery/fetchers/db/aws_memorydb_test.go
+++ b/lib/srv/discovery/fetchers/db/aws_memorydb_test.go
@@ -21,12 +21,11 @@ package db
 import (
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/memorydb"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	memorydbtypes "github.com/aws/aws-sdk-go-v2/service/memorydb/types"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/cloud/mocks"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
 )
@@ -34,28 +33,30 @@ import (
 func TestMemoryDBFetcher(t *testing.T) {
 	t.Parallel()
 
-	memorydbProd, memorydbDatabaseProd, memorydbProdTags := makeMemoryDBCluster(t, "memory1", "us-east-1", "prod")
+	memorydbProd, memorydbDatabaseProd, memorydbProdTags := makeMemoryDBCluster(t, "memory1", "us-east-1", "prod", withMemoryDBEngine("valkey"))
 	memorydbTest, memorydbDatabaseTest, memorydbTestTags := makeMemoryDBCluster(t, "memory2", "us-east-1", "test")
-	memorydbUnavailable, _, memorydbUnavailableTags := makeMemoryDBCluster(t, "memory3", "us-east-1", "prod", func(cluster *memorydb.Cluster) {
+	memorydbUnavailable, _, memorydbUnavailableTags := makeMemoryDBCluster(t, "memory3", "us-east-1", "prod", func(cluster *memorydbtypes.Cluster) {
 		cluster.Status = aws.String("deleting")
 	})
-	memorydbUnsupported, _, memorydbUnsupportedTags := makeMemoryDBCluster(t, "memory4", "us-east-1", "prod", func(cluster *memorydb.Cluster) {
+	memorydbUnsupported, _, memorydbUnsupportedTags := makeMemoryDBCluster(t, "memory4", "us-east-1", "prod", func(cluster *memorydbtypes.Cluster) {
 		cluster.TLSEnabled = aws.Bool(false)
 	})
-	memorydbTagsByARN := map[string][]*memorydb.Tag{
-		aws.StringValue(memorydbProd.ARN):        memorydbProdTags,
-		aws.StringValue(memorydbTest.ARN):        memorydbTestTags,
-		aws.StringValue(memorydbUnavailable.ARN): memorydbUnavailableTags,
-		aws.StringValue(memorydbUnsupported.ARN): memorydbUnsupportedTags,
+	memorydbTagsByARN := map[string][]memorydbtypes.Tag{
+		aws.ToString(memorydbProd.ARN):        memorydbProdTags,
+		aws.ToString(memorydbTest.ARN):        memorydbTestTags,
+		aws.ToString(memorydbUnavailable.ARN): memorydbUnavailableTags,
+		aws.ToString(memorydbUnsupported.ARN): memorydbUnsupportedTags,
 	}
 
 	tests := []awsFetcherTest{
 		{
 			name: "fetch all",
-			inputClients: &cloud.TestCloudClients{
-				MemoryDB: &mocks.MemoryDBMock{
-					Clusters:  []*memorydb.Cluster{memorydbProd, memorydbTest},
-					TagsByARN: memorydbTagsByARN,
+			fetcherCfg: AWSFetcherFactoryConfig{
+				AWSClients: fakeAWSClients{
+					mdbClient: &mocks.MemoryDBClient{
+						Clusters:  []memorydbtypes.Cluster{*memorydbProd, *memorydbTest},
+						TagsByARN: memorydbTagsByARN,
+					},
 				},
 			},
 			inputMatchers: makeAWSMatchersForType(types.AWSMatcherMemoryDB, "us-east-1", wildcardLabels),
@@ -63,10 +64,12 @@ func TestMemoryDBFetcher(t *testing.T) {
 		},
 		{
 			name: "fetch prod",
-			inputClients: &cloud.TestCloudClients{
-				MemoryDB: &mocks.MemoryDBMock{
-					Clusters:  []*memorydb.Cluster{memorydbProd, memorydbTest},
-					TagsByARN: memorydbTagsByARN,
+			fetcherCfg: AWSFetcherFactoryConfig{
+				AWSClients: fakeAWSClients{
+					mdbClient: &mocks.MemoryDBClient{
+						Clusters:  []memorydbtypes.Cluster{*memorydbProd, *memorydbTest},
+						TagsByARN: memorydbTagsByARN,
+					},
 				},
 			},
 			inputMatchers: makeAWSMatchersForType(types.AWSMatcherMemoryDB, "us-east-1", envProdLabels),
@@ -74,10 +77,12 @@ func TestMemoryDBFetcher(t *testing.T) {
 		},
 		{
 			name: "skip unavailable",
-			inputClients: &cloud.TestCloudClients{
-				MemoryDB: &mocks.MemoryDBMock{
-					Clusters:  []*memorydb.Cluster{memorydbProd, memorydbUnavailable},
-					TagsByARN: memorydbTagsByARN,
+			fetcherCfg: AWSFetcherFactoryConfig{
+				AWSClients: fakeAWSClients{
+					mdbClient: &mocks.MemoryDBClient{
+						Clusters:  []memorydbtypes.Cluster{*memorydbProd, *memorydbUnavailable},
+						TagsByARN: memorydbTagsByARN,
+					},
 				},
 			},
 			inputMatchers: makeAWSMatchersForType(types.AWSMatcherMemoryDB, "us-east-1", wildcardLabels),
@@ -85,10 +90,12 @@ func TestMemoryDBFetcher(t *testing.T) {
 		},
 		{
 			name: "skip unsupported",
-			inputClients: &cloud.TestCloudClients{
-				MemoryDB: &mocks.MemoryDBMock{
-					Clusters:  []*memorydb.Cluster{memorydbProd, memorydbUnsupported},
-					TagsByARN: memorydbTagsByARN,
+			fetcherCfg: AWSFetcherFactoryConfig{
+				AWSClients: fakeAWSClients{
+					mdbClient: &mocks.MemoryDBClient{
+						Clusters:  []memorydbtypes.Cluster{*memorydbProd, *memorydbUnsupported},
+						TagsByARN: memorydbTagsByARN,
+					},
 				},
 			},
 			inputMatchers: makeAWSMatchersForType(types.AWSMatcherMemoryDB, "us-east-1", wildcardLabels),
@@ -98,10 +105,10 @@ func TestMemoryDBFetcher(t *testing.T) {
 	testAWSFetchers(t, tests...)
 }
 
-func makeMemoryDBCluster(t *testing.T, name, region, env string, opts ...func(*memorydb.Cluster)) (*memorydb.Cluster, types.Database, []*memorydb.Tag) {
+func makeMemoryDBCluster(t *testing.T, name, region, env string, opts ...func(*memorydbtypes.Cluster)) (*memorydbtypes.Cluster, types.Database, []memorydbtypes.Tag) {
 	cluster := mocks.MemoryDBCluster(name, region, opts...)
 
-	tags := []*memorydb.Tag{{
+	tags := []memorydbtypes.Tag{{
 		Key:   aws.String("env"),
 		Value: aws.String(env),
 	}}
@@ -111,4 +118,10 @@ func makeMemoryDBCluster(t *testing.T, name, region, env string, opts ...func(*m
 	require.NoError(t, err)
 	common.ApplyAWSDatabaseNameSuffix(database, types.AWSMatcherMemoryDB)
 	return cluster, database, tags
+}
+
+func withMemoryDBEngine(engine string) func(*memorydbtypes.Cluster) {
+	return func(c *memorydbtypes.Cluster) {
+		c.Engine = &engine
+	}
 }

--- a/lib/srv/discovery/fetchers/db/aws_rds_test.go
+++ b/lib/srv/discovery/fetchers/db/aws_rds_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	elasticache "github.com/aws/aws-sdk-go-v2/service/elasticache"
+	memorydb "github.com/aws/aws-sdk-go-v2/service/memorydb"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/aws/aws-sdk-go-v2/service/redshift"
@@ -310,6 +311,7 @@ func newRegionalFakeRDSClientProvider(cs map[string]RDSClient) fakeRegionalRDSCl
 
 type fakeAWSClients struct {
 	ecClient       ElastiCacheClient
+	mdbClient      MemoryDBClient
 	rdsClient      RDSClient
 	redshiftClient RedshiftClient
 	rssClient      RSSClient
@@ -317,6 +319,10 @@ type fakeAWSClients struct {
 
 func (f fakeAWSClients) GetElastiCacheClient(cfg aws.Config, optFns ...func(*elasticache.Options)) ElastiCacheClient {
 	return f.ecClient
+}
+
+func (f fakeAWSClients) GetMemoryDBClient(cfg aws.Config, optFns ...func(*memorydb.Options)) MemoryDBClient {
+	return f.mdbClient
 }
 
 func (f fakeAWSClients) GetRDSClient(cfg aws.Config, optFns ...func(*rds.Options)) RDSClient {

--- a/lib/srv/discovery/fetchers/db/db.go
+++ b/lib/srv/discovery/fetchers/db/db.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
+	"github.com/aws/aws-sdk-go-v2/service/memorydb"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/redshift"
 	rss "github.com/aws/aws-sdk-go-v2/service/redshiftserverless"
@@ -72,8 +73,10 @@ func IsAzureMatcherType(matcherType string) bool {
 
 // AWSClientProvider provides AWS service API clients.
 type AWSClientProvider interface {
-	// GetElastiCacheClient provides an [ElasticacheClient].
+	// GetElastiCacheClient provides an [ElastiCacheClient].
 	GetElastiCacheClient(cfg aws.Config, optFns ...func(*elasticache.Options)) ElastiCacheClient
+	// GetMemoryDBClient provides an [MemoryDBClient].
+	GetMemoryDBClient(cfg aws.Config, optFns ...func(*memorydb.Options)) MemoryDBClient
 	// GetRDSClient provides an [RDSClient].
 	GetRDSClient(cfg aws.Config, optFns ...func(*rds.Options)) RDSClient
 	// GetRedshiftClient provides an [RedshiftClient].
@@ -86,6 +89,10 @@ type defaultAWSClients struct{}
 
 func (defaultAWSClients) GetElastiCacheClient(cfg aws.Config, optFns ...func(*elasticache.Options)) ElastiCacheClient {
 	return elasticache.NewFromConfig(cfg, optFns...)
+}
+
+func (defaultAWSClients) GetMemoryDBClient(cfg aws.Config, optFns ...func(*memorydb.Options)) MemoryDBClient {
+	return memorydb.NewFromConfig(cfg, optFns...)
 }
 
 func (defaultAWSClients) GetRDSClient(cfg aws.Config, optFns ...func(*rds.Options)) RDSClient {


### PR DESCRIPTION
This PR migrates all uses of AWS MemoryDB clients to AWS SDK v2.

This PR depends on and is stacked on top of another PR:
- #51050

Part of https://github.com/gravitational/teleport/issues/14142
- https://github.com/gravitational/teleport/issues/14142
