### PR TITLE
Web: Fix v1 fallback with v2 endpoints

### DIFF
--- a/web/packages/teleport/src/Apps/AddApp/useAddApp.test.tsx
+++ b/web/packages/teleport/src/Apps/AddApp/useAddApp.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Teleport
- * Copyright (C) 2024  Gravitational, Inc.
+ * Copyright (C) 2025  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -38,7 +38,7 @@ afterEach(() => {
   jest.resetAllMocks();
 });
 
-test('create token', async () => {
+test('create token without labels', async () => {
   jest
     .spyOn(ctx.joinTokenService, 'fetchJoinTokenV2')
     .mockResolvedValue(tokenResp);
@@ -58,7 +58,7 @@ test('create token', async () => {
   expect(result.current.token).toEqual(tokenResp);
 });
 
-test('create token with v1 fallback', async () => {
+test('create token without labels with v1 fallback', async () => {
   jest
     .spyOn(ctx.joinTokenService, 'fetchJoinTokenV2')
     .mockRejectedValueOnce(new Error(ProxyRequiresUpgrade));

--- a/web/packages/teleport/src/Apps/AddApp/useAddApp.test.tsx
+++ b/web/packages/teleport/src/Apps/AddApp/useAddApp.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { ContextProvider } from 'teleport/index';
+import { userContext } from 'teleport/Main/fixtures';
+import { ProxyRequiresUpgrade } from 'teleport/services/version/unsupported';
+import TeleportContext from 'teleport/teleportContext';
+
+import useAddApp from './useAddApp';
+
+const ctx = new TeleportContext();
+
+beforeEach(() => {
+  ctx.storeUser.setState({ ...userContext });
+  jest
+    .spyOn(ctx.joinTokenService, 'fetchJoinToken')
+    .mockResolvedValue(tokenResp);
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test('create token', async () => {
+  jest
+    .spyOn(ctx.joinTokenService, 'fetchJoinTokenV2')
+    .mockResolvedValue(tokenResp);
+
+  const wrapper = ({ children }) => (
+    <ContextProvider ctx={ctx}>{children}</ContextProvider>
+  );
+
+  let { result } = renderHook(() => useAddApp(ctx), { wrapper });
+
+  await waitFor(() => {
+    expect(result.current.token).not.toBeUndefined();
+  });
+
+  expect(ctx.joinTokenService.fetchJoinTokenV2).toHaveBeenCalledTimes(1);
+  expect(ctx.joinTokenService.fetchJoinToken).not.toHaveBeenCalled();
+  expect(result.current.token).toEqual(tokenResp);
+});
+
+test('create token with v1 fallback', async () => {
+  jest
+    .spyOn(ctx.joinTokenService, 'fetchJoinTokenV2')
+    .mockRejectedValueOnce(new Error(ProxyRequiresUpgrade));
+
+  const wrapper = ({ children }) => (
+    <ContextProvider ctx={ctx}>{children}</ContextProvider>
+  );
+
+  let { result } = renderHook(() => useAddApp(ctx), { wrapper });
+
+  await waitFor(() => {
+    expect(result.current.token).not.toBeUndefined();
+  });
+
+  expect(ctx.joinTokenService.fetchJoinTokenV2).toHaveBeenCalledTimes(1);
+  expect(ctx.joinTokenService.fetchJoinToken).toHaveBeenCalledTimes(1);
+  expect(result.current.token).toEqual(tokenResp);
+});
+
+const tokenResp = {
+  allow: undefined,
+  bot_name: undefined,
+  content: undefined,
+  expiry: null,
+  expiryText: '',
+  gcp: undefined,
+  id: undefined,
+  isStatic: undefined,
+  method: undefined,
+  internalResourceId: 'abc',
+  roles: ['Application'],
+  safeName: undefined,
+  suggestedLabels: [],
+};

--- a/web/packages/teleport/src/Apps/AddApp/useAddApp.ts
+++ b/web/packages/teleport/src/Apps/AddApp/useAddApp.ts
@@ -21,7 +21,8 @@ import { useEffect, useState } from 'react';
 import useAttempt from 'shared/hooks/useAttemptNext';
 
 import { ResourceLabel } from 'teleport/services/agents';
-import type { JoinToken } from 'teleport/services/joinToken';
+import type { JoinToken, JoinTokenRequest } from 'teleport/services/joinToken';
+import { useV1Fallback } from 'teleport/services/version/unsupported';
 import TeleportContext from 'teleport/teleportContext';
 
 export default function useAddApp(ctx: TeleportContext) {
@@ -33,6 +34,9 @@ export default function useAddApp(ctx: TeleportContext) {
   const [automatic, setAutomatic] = useState(isEnterprise);
   const [token, setToken] = useState<JoinToken>();
   const [labels, setLabels] = useState<ResourceLabel[]>([]);
+
+  // TODO(kimlisa): DELETE IN 19.0
+  const { tryV1Fallback } = useV1Fallback();
 
   useEffect(() => {
     // We don't want to create token on first render
@@ -48,12 +52,24 @@ export default function useAddApp(ctx: TeleportContext) {
     }
   }, [automatic]);
 
+  async function fetchJoinToken() {
+    const req: JoinTokenRequest = { roles: ['App'], suggestedLabels: labels };
+    let resp: JoinToken;
+    try {
+      resp = await ctx.joinTokenService.fetchJoinTokenV2(req);
+    } catch (err) {
+      resp = await tryV1Fallback({
+        kind: 'create-join-token',
+        err,
+        req,
+        ctx,
+      });
+    }
+    return resp;
+  }
+
   function createToken() {
-    return run(() =>
-      ctx.joinTokenService
-        .fetchJoinToken({ roles: ['App'], suggestedLabels: labels })
-        .then(setToken)
-    );
+    return run(() => fetchJoinToken().then(setToken));
   }
 
   return {

--- a/web/packages/teleport/src/Discover/AwsMangementConsole/CreateAppAccess/CreateAppAccess.test.tsx
+++ b/web/packages/teleport/src/Discover/AwsMangementConsole/CreateAppAccess/CreateAppAccess.test.tsx
@@ -56,6 +56,8 @@ afterEach(() => {
 });
 
 test('create app access', async () => {
+  jest.spyOn(integrationService, 'createAwsAppAccess').mockResolvedValue(app);
+
   const { ctx, discoverCtx } = getMockedContexts();
 
   renderCreateAppAccess(ctx, discoverCtx);
@@ -64,9 +66,10 @@ test('create app access', async () => {
   await userEvent.click(screen.getByRole('button', { name: /next/i }));
   await screen.findByText(/aws-console/i);
   expect(integrationService.createAwsAppAccessV2).toHaveBeenCalledTimes(1);
+  expect(integrationService.createAwsAppAccess).not.toHaveBeenCalled();
 });
 
-test('create app access with v1 endpoint', async () => {
+test('create app access with v1 endpoint auto retry', async () => {
   jest
     .spyOn(integrationService, 'createAwsAppAccessV2')
     .mockRejectedValueOnce(new Error(ProxyRequiresUpgrade));
@@ -78,10 +81,9 @@ test('create app access with v1 endpoint', async () => {
   await screen.findByText(/bash/i);
 
   await userEvent.click(screen.getByRole('button', { name: /next/i }));
-  await screen.findByText(ProxyRequiresUpgrade);
-
-  await userEvent.click(screen.getByRole('button', { name: /next/i }));
   await screen.findByText(/aws-console/i);
+
+  expect(integrationService.createAwsAppAccessV2).toHaveBeenCalledTimes(1);
   expect(integrationService.createAwsAppAccess).toHaveBeenCalledTimes(1);
 });
 

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEKSCluster.test.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEKSCluster.test.tsx
@@ -185,7 +185,7 @@ describe('test EnrollEksCluster.tsx', () => {
     expect(integrationService.enrollEksClustersV2).not.toHaveBeenCalled();
   });
 
-  test('auto enroll disabled, enrolls cluster', async () => {
+  test('auto enroll disabled, enrolls cluster without labels', async () => {
     jest.spyOn(integrationService, 'fetchEksClusters').mockResolvedValue({
       clusters: mockEKSClusters,
     });
@@ -218,7 +218,7 @@ describe('test EnrollEksCluster.tsx', () => {
     expect(integrationService.enrollEksClusters).not.toHaveBeenCalled();
   });
 
-  test('enroll eks with v1 fallback', async () => {
+  test('enroll eks without labels with v1 fallback', async () => {
     jest.spyOn(integrationService, 'fetchEksClusters').mockResolvedValue({
       clusters: mockEKSClusters,
     });

--- a/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEKSCluster.test.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/EnrollEKSCluster/EnrollEKSCluster.test.tsx
@@ -20,6 +20,7 @@ import { act, fireEvent, render, screen } from 'design/utils/testing';
 
 import cfg from 'teleport/config';
 import { ComponentWrapper } from 'teleport/Discover/Fixtures/kubernetes';
+import auth from 'teleport/services/auth';
 import * as discoveryService from 'teleport/services/discovery/discovery';
 import {
   DEFAULT_DISCOVERY_GROUP_NON_CLOUD,
@@ -31,6 +32,7 @@ import {
 } from 'teleport/services/integrations';
 import KubeService from 'teleport/services/kube/kube';
 import { userEventService } from 'teleport/services/userEvent';
+import { ProxyRequiresUpgrade } from 'teleport/services/version/unsupported';
 
 import { EnrollEksCluster } from './EnrollEksCluster';
 
@@ -46,6 +48,9 @@ describe('test EnrollEksCluster.tsx', () => {
     jest
       .spyOn(userEventService, 'captureDiscoverEvent')
       .mockResolvedValue(undefined as never);
+    jest
+      .spyOn(auth, 'getMfaChallengeResponseForAdminAction')
+      .mockResolvedValue(undefined);
     createDiscoveryConfig = jest
       .spyOn(discoveryService, 'createDiscoveryConfig')
       .mockResolvedValue({
@@ -57,7 +62,7 @@ describe('test EnrollEksCluster.tsx', () => {
 
   afterEach(() => {
     cfg.isCloud = defaultIsCloud;
-    jest.restoreAllMocks();
+    jest.resetAllMocks();
   });
 
   test('without EKS clusters available, does not attempt to fetch kube clusters', async () => {
@@ -104,7 +109,7 @@ describe('test EnrollEksCluster.tsx', () => {
     jest.spyOn(integrationService, 'fetchEksClusters').mockResolvedValue({
       clusters: mockEKSClusters,
     });
-    jest.spyOn(integrationService, 'enrollEksClusters');
+    jest.spyOn(integrationService, 'enrollEksClustersV2');
 
     render(<Component />);
 
@@ -136,7 +141,7 @@ describe('test EnrollEksCluster.tsx', () => {
       DISCOVERY_GROUP_CLOUD
     );
 
-    expect(integrationService.enrollEksClusters).not.toHaveBeenCalled();
+    expect(integrationService.enrollEksClustersV2).not.toHaveBeenCalled();
   });
 
   test('auto enroll (self-hosted) is on by default', async () => {
@@ -144,7 +149,7 @@ describe('test EnrollEksCluster.tsx', () => {
     jest.spyOn(integrationService, 'fetchEksClusters').mockResolvedValue({
       clusters: mockEKSClusters,
     });
-    jest.spyOn(integrationService, 'enrollEksClusters');
+    jest.spyOn(integrationService, 'enrollEksClustersV2');
 
     render(<Component />);
 
@@ -177,13 +182,19 @@ describe('test EnrollEksCluster.tsx', () => {
       DEFAULT_DISCOVERY_GROUP_NON_CLOUD
     );
 
-    expect(integrationService.enrollEksClusters).not.toHaveBeenCalled();
+    expect(integrationService.enrollEksClustersV2).not.toHaveBeenCalled();
   });
+
   test('auto enroll disabled, enrolls cluster', async () => {
     jest.spyOn(integrationService, 'fetchEksClusters').mockResolvedValue({
       clusters: mockEKSClusters,
     });
-    jest.spyOn(integrationService, 'enrollEksClusters');
+    jest
+      .spyOn(integrationService, 'enrollEksClustersV2')
+      .mockResolvedValue({} as any); // value doesn't matter
+    jest
+      .spyOn(integrationService, 'enrollEksClusters')
+      .mockResolvedValue({} as any); // value doesn't matter
 
     render(<Component />);
 
@@ -199,8 +210,41 @@ describe('test EnrollEksCluster.tsx', () => {
 
     act(() => screen.getByText('Enroll EKS Cluster').click());
 
+    await screen.findByTestId('dialogbox');
+
     expect(discoveryService.createDiscoveryConfig).not.toHaveBeenCalled();
     expect(KubeService.prototype.fetchKubernetes).toHaveBeenCalledTimes(1);
+    expect(integrationService.enrollEksClustersV2).toHaveBeenCalledTimes(1);
+    expect(integrationService.enrollEksClusters).not.toHaveBeenCalled();
+  });
+
+  test('enroll eks with v1 fallback', async () => {
+    jest.spyOn(integrationService, 'fetchEksClusters').mockResolvedValue({
+      clusters: mockEKSClusters,
+    });
+    jest
+      .spyOn(integrationService, 'enrollEksClustersV2')
+      .mockRejectedValueOnce(new Error(ProxyRequiresUpgrade));
+    jest.spyOn(integrationService, 'enrollEksClusters');
+
+    render(<Component />);
+
+    // select a region from selector.
+    const selectEl = screen.getByLabelText(/aws region/i);
+    fireEvent.focus(selectEl);
+    fireEvent.keyDown(selectEl, { key: 'ArrowDown', keyCode: 40 });
+    fireEvent.click(screen.getByText('us-east-2'));
+
+    await screen.findByText(/eks1/i);
+
+    act(() => screen.getByRole('radio').click());
+    act(() => screen.getByText('Enroll EKS Cluster').click());
+
+    expect(integrationService.enrollEksClustersV2).toHaveBeenCalledTimes(1);
+
+    await screen.findByTestId('dialogbox');
+
+    expect(integrationService.enrollEksClustersV2).toHaveBeenCalledTimes(1);
     expect(integrationService.enrollEksClusters).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/packages/teleport/src/Discover/Shared/useJoinTokenSuspender.test.tsx
+++ b/web/packages/teleport/src/Discover/Shared/useJoinTokenSuspender.test.tsx
@@ -45,7 +45,7 @@ afterEach(() => {
   clearCachedJoinTokenResult([ResourceKind.Server]);
 });
 
-test('create join token', async () => {
+test('create join token without labels', async () => {
   const ctx = new TeleportContext();
 
   jest
@@ -78,7 +78,7 @@ test('create join token', async () => {
   expect(result.current.joinToken).toEqual(tokenResp);
 });
 
-test('create join token with v1 fallback', async () => {
+test('create join token without labels with v1 fallback', async () => {
   const ctx = new TeleportContext();
 
   jest

--- a/web/packages/teleport/src/Discover/Shared/useJoinTokenSuspender.test.tsx
+++ b/web/packages/teleport/src/Discover/Shared/useJoinTokenSuspender.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+
+import { ContextProvider } from 'teleport/index';
+import {
+  DiscoverEventResource,
+  userEventService,
+} from 'teleport/services/userEvent';
+import { ProxyRequiresUpgrade } from 'teleport/services/version/unsupported';
+import TeleportContext from 'teleport/teleportContext';
+
+import { DiscoverContextState, DiscoverProvider } from '../useDiscover';
+import { ResourceKind } from './ResourceKind';
+import {
+  clearCachedJoinTokenResult,
+  useJoinTokenSuspender,
+} from './useJoinTokenSuspender';
+
+beforeEach(() => {
+  jest
+    .spyOn(userEventService, 'captureDiscoverEvent')
+    .mockResolvedValue(undefined as never);
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+  clearCachedJoinTokenResult([ResourceKind.Server]);
+});
+
+test('create join token', async () => {
+  const ctx = new TeleportContext();
+
+  jest
+    .spyOn(ctx.joinTokenService, 'fetchJoinTokenV2')
+    .mockResolvedValue(tokenResp);
+
+  jest
+    .spyOn(ctx.joinTokenService, 'fetchJoinToken')
+    .mockResolvedValue(tokenResp);
+
+  const wrapper = ({ children }) => (
+    <MemoryRouter>
+      <ContextProvider ctx={ctx}>
+        <DiscoverProvider mockCtx={discoverCtx}>{children}</DiscoverProvider>
+      </ContextProvider>
+    </MemoryRouter>
+  );
+
+  let { result } = renderHook(
+    () => useJoinTokenSuspender({ resourceKinds: [ResourceKind.Server] }),
+    { wrapper }
+  );
+
+  await waitFor(() => {
+    expect(result.current.joinToken).not.toBeNull();
+  });
+
+  expect(ctx.joinTokenService.fetchJoinTokenV2).toHaveBeenCalledTimes(1);
+  expect(ctx.joinTokenService.fetchJoinToken).not.toHaveBeenCalled();
+  expect(result.current.joinToken).toEqual(tokenResp);
+});
+
+test('create join token with v1 fallback', async () => {
+  const ctx = new TeleportContext();
+
+  jest
+    .spyOn(ctx.joinTokenService, 'fetchJoinTokenV2')
+    .mockRejectedValueOnce(new Error(ProxyRequiresUpgrade));
+
+  jest
+    .spyOn(ctx.joinTokenService, 'fetchJoinToken')
+    .mockResolvedValue(tokenResp);
+
+  const wrapper = ({ children }) => (
+    <MemoryRouter>
+      <ContextProvider ctx={ctx}>
+        <DiscoverProvider mockCtx={discoverCtx}>{children}</DiscoverProvider>
+      </ContextProvider>
+    </MemoryRouter>
+  );
+
+  let { result } = renderHook(
+    () =>
+      useJoinTokenSuspender({
+        resourceKinds: [ResourceKind.Server],
+        suggestedLabels: [],
+      }),
+    { wrapper }
+  );
+
+  await waitFor(() => {
+    expect(result.current.joinToken).not.toBeNull();
+  });
+
+  expect(ctx.joinTokenService.fetchJoinTokenV2).toHaveBeenCalledTimes(1);
+  expect(ctx.joinTokenService.fetchJoinToken).toHaveBeenCalledTimes(1);
+  expect(result.current.joinToken).toEqual(tokenResp);
+});
+
+const discoverCtx: DiscoverContextState = {
+  agentMeta: {},
+  currentStep: 0,
+  nextStep: () => null,
+  prevStep: () => null,
+  onSelectResource: () => null,
+  resourceSpec: {
+    name: 'Eks',
+    kind: ResourceKind.Kubernetes,
+    icon: 'eks',
+    keywords: [],
+    event: DiscoverEventResource.KubernetesEks,
+  },
+  exitFlow: () => null,
+  viewConfig: null,
+  indexedViews: [],
+  setResourceSpec: () => null,
+  updateAgentMeta: () => null,
+  emitErrorEvent: () => null,
+  emitEvent: () => null,
+  eventState: null,
+};
+
+const tokenResp = {
+  allow: undefined,
+  bot_name: undefined,
+  content: undefined,
+  expiry: null,
+  expiryText: '',
+  gcp: undefined,
+  id: undefined,
+  isStatic: undefined,
+  method: undefined,
+  internalResourceId: 'abc',
+  roles: ['Application'],
+  safeName: undefined,
+  suggestedLabels: [],
+};

--- a/web/packages/teleport/src/Discover/Shared/useJoinTokenSuspender.ts
+++ b/web/packages/teleport/src/Discover/Shared/useJoinTokenSuspender.ts
@@ -1,6 +1,6 @@
 /**
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2025  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/web/packages/teleport/src/Discover/Shared/useJoinTokenSuspender.ts
+++ b/web/packages/teleport/src/Discover/Shared/useJoinTokenSuspender.ts
@@ -25,6 +25,7 @@ import {
 } from 'teleport/Discover/Shared/ResourceKind';
 import type { ResourceLabel } from 'teleport/services/agents';
 import type { JoinMethod, JoinToken } from 'teleport/services/joinToken';
+import { useV1Fallback } from 'teleport/services/version/unsupported';
 
 import { useDiscover } from '../useDiscover';
 
@@ -68,24 +69,44 @@ export function useJoinTokenSuspender({
 
   const [, rerender] = useState(0);
 
+  // TODO(kimlisa): DELETE IN 19.0
+  const { tryV1Fallback } = useV1Fallback();
+
   const kindsKey = resourceKinds.sort().join();
 
   function run() {
     abortController = new AbortController();
 
+    async function fetchJoinToken() {
+      const req = {
+        roles: resourceKinds.map(resourceKindToJoinRole),
+        method: joinMethod,
+        suggestedAgentMatcherLabels,
+        suggestedLabels,
+      };
+
+      let resp: JoinToken;
+      try {
+        resp = await ctx.joinTokenService.fetchJoinTokenV2(
+          req,
+          abortController.signal
+        );
+      } catch (err) {
+        resp = await tryV1Fallback({
+          kind: 'create-join-token',
+          err,
+          req,
+          abortSignal: abortController.signal,
+          ctx,
+        });
+      }
+      return resp;
+    }
+
     const result: SuspendResult = {
       response: null,
       error: null,
-      promise: ctx.joinTokenService
-        .fetchJoinToken(
-          {
-            roles: resourceKinds.map(resourceKindToJoinRole),
-            method: joinMethod,
-            suggestedAgentMatcherLabels,
-            suggestedLabels,
-          },
-          abortController.signal
-        )
+      promise: fetchJoinToken()
         .then(token => {
           // Probably will never happen, but just in case, otherwise
           // querying for the resource can return a false positive.

--- a/web/packages/teleport/src/services/integrations/integrations.test.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.test.ts
@@ -200,50 +200,6 @@ test('fetchAwsDatabases response', async () => {
   });
 });
 
-test('enrollEksClusters without labels calls v1', async () => {
-  jest.spyOn(api, 'post').mockResolvedValue({});
-
-  await integrationService.enrollEksClusters('integration', {
-    region: 'us-east-1',
-    enableAppDiscovery: false,
-    clusterNames: ['cluster'],
-  });
-
-  expect(api.post).toHaveBeenCalledWith(
-    cfg.getEnrollEksClusterUrl('integration'),
-    {
-      clusterNames: ['cluster'],
-      enableAppDiscovery: false,
-      region: 'us-east-1',
-    },
-    null,
-    undefined
-  );
-});
-
-test('enrollEksClusters with labels calls v2', async () => {
-  jest.spyOn(api, 'post').mockResolvedValue({});
-
-  await integrationService.enrollEksClusters('integration', {
-    region: 'us-east-1',
-    enableAppDiscovery: false,
-    clusterNames: ['cluster'],
-    extraLabels: [{ name: 'env', value: 'staging' }],
-  });
-
-  expect(api.post).toHaveBeenCalledWith(
-    cfg.getEnrollEksClusterUrlV2('integration'),
-    {
-      clusterNames: ['cluster'],
-      enableAppDiscovery: false,
-      region: 'us-east-1',
-      extraLabels: [{ name: 'env', value: 'staging' }],
-    },
-    null,
-    undefined
-  );
-});
-
 describe('fetchAwsDatabases() request body formatting', () => {
   test.each`
     protocol             | expectedEngines          | expectedRdsType

--- a/web/packages/teleport/src/services/integrations/integrations.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.ts
@@ -330,21 +330,11 @@ export const integrationService = {
       .then(resp => resp.clusterDashboardUrl);
   },
 
-  async enrollEksClusters(
+  async enrollEksClustersV2(
     integrationName: string,
     req: EnrollEksClustersRequest
   ): Promise<EnrollEksClustersResponse> {
     const mfaResponse = await auth.getMfaChallengeResponseForAdminAction(true);
-
-    // TODO(kimlisa): DELETE IN 19.0 - replaced by v2 endpoint.
-    if (!req.extraLabels?.length) {
-      return api.post(
-        cfg.getEnrollEksClusterUrl(integrationName),
-        req,
-        null,
-        mfaResponse
-      );
-    }
 
     return (
       api
@@ -356,6 +346,22 @@ export const integrationService = {
         )
         // TODO(kimlisa): DELETE IN 19.0
         .catch(withUnsupportedLabelFeatureErrorConversion)
+    );
+  },
+
+  // TODO(kimlisa): DELETE IN 19.0 - replaced by v2 endpoint.
+  // replaced by enrollEksClustersV2 that accepts labels.
+  async enrollEksClusters(
+    integrationName: string,
+    req: Omit<EnrollEksClustersRequest, 'extraLabels'>
+  ): Promise<EnrollEksClustersResponse> {
+    const mfaResponse = await auth.getMfaChallengeResponseForAdminAction(true);
+
+    return api.post(
+      cfg.getEnrollEksClusterUrl(integrationName),
+      req,
+      null,
+      mfaResponse
     );
   },
 

--- a/web/packages/teleport/src/services/joinToken/joinToken.test.ts
+++ b/web/packages/teleport/src/services/joinToken/joinToken.test.ts
@@ -33,12 +33,13 @@ test('fetchJoinToken with an empty request properly sets defaults', () => {
   // Test with all empty fields.
   svc.fetchJoinTokenV2({} as any);
   expect(api.post).toHaveBeenCalledWith(
-    cfg.api.discoveryJoinToken.create,
+    cfg.api.discoveryJoinToken.createV2,
     {
       roles: undefined,
       join_method: 'token',
       allow: [],
       suggested_agent_matcher_labels: {},
+      suggested_labels: {},
     },
     null
   );
@@ -56,12 +57,13 @@ test('fetchJoinToken request fields are set as requested', () => {
   };
   svc.fetchJoinTokenV2(mock);
   expect(api.post).toHaveBeenCalledWith(
-    cfg.api.discoveryJoinToken.create,
+    cfg.api.discoveryJoinToken.createV2,
     {
       roles: ['Node'],
       join_method: 'iam',
       allow: [{ aws_account: '1234', aws_arn: 'xxxx' }],
       suggested_agent_matcher_labels: { env: ['dev'] },
+      suggested_labels: {},
     },
     null
   );

--- a/web/packages/teleport/src/services/joinToken/joinToken.test.ts
+++ b/web/packages/teleport/src/services/joinToken/joinToken.test.ts
@@ -31,7 +31,7 @@ test('fetchJoinToken with an empty request properly sets defaults', () => {
   jest.spyOn(api, 'post').mockResolvedValue(null);
 
   // Test with all empty fields.
-  svc.fetchJoinToken({} as any);
+  svc.fetchJoinTokenV2({} as any);
   expect(api.post).toHaveBeenCalledWith(
     cfg.api.discoveryJoinToken.create,
     {
@@ -54,7 +54,7 @@ test('fetchJoinToken request fields are set as requested', () => {
     method: 'iam',
     suggestedAgentMatcherLabels: [{ name: 'env', value: 'dev' }],
   };
-  svc.fetchJoinToken(mock);
+  svc.fetchJoinTokenV2(mock);
   expect(api.post).toHaveBeenCalledWith(
     cfg.api.discoveryJoinToken.create,
     {
@@ -62,26 +62,6 @@ test('fetchJoinToken request fields are set as requested', () => {
       join_method: 'iam',
       allow: [{ aws_account: '1234', aws_arn: 'xxxx' }],
       suggested_agent_matcher_labels: { env: ['dev'] },
-    },
-    null
-  );
-});
-
-test('fetchJoinToken with labels calls v2 endpoint', () => {
-  const svc = new JoinTokenService();
-  jest.spyOn(api, 'post').mockResolvedValue(null);
-
-  const mock: JoinTokenRequest = {
-    suggestedLabels: [{ name: 'env', value: 'testing' }],
-  };
-  svc.fetchJoinToken(mock);
-  expect(api.post).toHaveBeenCalledWith(
-    cfg.api.discoveryJoinToken.createV2,
-    {
-      suggested_labels: { env: ['testing'] },
-      suggested_agent_matcher_labels: {},
-      join_method: 'token',
-      allow: [],
     },
     null
   );

--- a/web/packages/teleport/src/services/joinToken/joinToken.ts
+++ b/web/packages/teleport/src/services/joinToken/joinToken.ts
@@ -28,28 +28,10 @@ const TeleportTokenNameHeader = 'X-Teleport-TokenName';
 
 class JoinTokenService {
   // TODO (avatus) refactor this code to eventually use `createJoinToken`
-  fetchJoinToken(
+  fetchJoinTokenV2(
     req: JoinTokenRequest,
     signal: AbortSignal = null
   ): Promise<JoinToken> {
-    // TODO(kimlisa): DELETE IN 19.0 - replaced by v2 endpoint.
-    if (!req.suggestedLabels?.length) {
-      return api
-        .post(
-          cfg.api.discoveryJoinToken.create,
-          {
-            roles: req.roles,
-            join_method: req.method || 'token',
-            allow: makeAllowField(req.rules || []),
-            suggested_agent_matcher_labels: makeLabelMapOfStrArrs(
-              req.suggestedAgentMatcherLabels
-            ),
-          },
-          signal
-        )
-        .then(makeJoinToken);
-    }
-
     return (
       api
         .post(
@@ -69,6 +51,28 @@ class JoinTokenService {
         // TODO(kimlisa): DELETE IN 19.0
         .catch(withUnsupportedLabelFeatureErrorConversion)
     );
+  }
+
+  // TODO(kimlisa): DELETE IN 19.0
+  // replaced by fetchJoinTokenV2 that accepts labels.
+  fetchJoinToken(
+    req: Omit<JoinTokenRequest, 'suggestedLabels'>,
+    signal: AbortSignal = null
+  ): Promise<JoinToken> {
+    return api
+      .post(
+        cfg.api.discoveryJoinToken.create,
+        {
+          roles: req.roles,
+          join_method: req.method || 'token',
+          allow: makeAllowField(req.rules || []),
+          suggested_agent_matcher_labels: makeLabelMapOfStrArrs(
+            req.suggestedAgentMatcherLabels
+          ),
+        },
+        signal
+      )
+      .then(makeJoinToken);
   }
 
   upsertJoinTokenYAML(

--- a/web/packages/teleport/src/services/version/unsupported.test.ts
+++ b/web/packages/teleport/src/services/version/unsupported.test.ts
@@ -1,6 +1,6 @@
 /**
  * Teleport
- * Copyright (C) 2024  Gravitational, Inc.
+ * Copyright (C) 2025  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/web/packages/teleport/src/services/version/unsupported.test.ts
+++ b/web/packages/teleport/src/services/version/unsupported.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { renderHook } from '@testing-library/react';
+
+import { app } from 'teleport/Discover/AwsMangementConsole/fixtures';
+
+import { integrationService } from '../integrations';
+import { ProxyRequiresUpgrade, useV1Fallback } from './unsupported';
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test('with non upgrade proxy related error, re-throws error', async () => {
+  jest.spyOn(integrationService, 'createAwsAppAccess');
+
+  let { result } = renderHook(() => useV1Fallback());
+
+  const err = new Error('some error');
+  await expect(
+    result.current.tryV1Fallback({
+      kind: 'create-app-access',
+      err,
+      req: {},
+      integrationName: 'foo',
+    })
+  ).rejects.toThrow(err);
+  expect(integrationService.createAwsAppAccess).not.toHaveBeenCalled();
+});
+
+test('with upgrade proxy error, with labels, re-throws error', async () => {
+  jest.spyOn(integrationService, 'createAwsAppAccess');
+
+  let { result } = renderHook(() => useV1Fallback());
+
+  const err = new Error(ProxyRequiresUpgrade);
+  await expect(
+    result.current.tryV1Fallback({
+      kind: 'create-app-access',
+      err,
+      req: { labels: { env: 'dev' } },
+      integrationName: 'foo',
+    })
+  ).rejects.toThrow(err);
+  expect(integrationService.createAwsAppAccess).not.toHaveBeenCalled();
+});
+
+test('with upgrade proxy error, without labels, runs fallback', async () => {
+  jest.spyOn(integrationService, 'createAwsAppAccess').mockResolvedValue(app);
+
+  let { result } = renderHook(() => useV1Fallback());
+
+  const err = new Error(ProxyRequiresUpgrade);
+  const resp = await result.current.tryV1Fallback({
+    kind: 'create-app-access',
+    err,
+    req: { labels: {} },
+    integrationName: 'foo',
+  });
+
+  expect(resp).toEqual(app);
+  expect(integrationService.createAwsAppAccess).toHaveBeenCalledTimes(1);
+});

--- a/web/packages/teleport/src/services/version/unsupported.ts
+++ b/web/packages/teleport/src/services/version/unsupported.ts
@@ -52,7 +52,7 @@ type CreateJoinToken = Base & {
   kind: 'create-join-token';
   req: JoinTokenRequest;
   ctx: TeleportContext;
-  abortSignal: AbortSignal;
+  abortSignal?: AbortSignal;
 };
 
 type EnrollEks = Base & {

--- a/web/packages/teleport/src/services/version/unsupported.ts
+++ b/web/packages/teleport/src/services/version/unsupported.ts
@@ -16,7 +16,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { App } from 'teleport/services/apps/types';
+import {
+  CreateAwsAppAccessRequest,
+  EnrollEksClustersRequest,
+  EnrollEksClustersResponse,
+  integrationService,
+} from 'teleport/services/integrations';
+import TeleportContext from 'teleport/teleportContext';
+
 import { ApiError } from '../api/parseError';
+import { JoinToken, JoinTokenRequest } from '../joinToken';
 
 export const ProxyRequiresUpgrade = 'Ensure all proxies are upgraded';
 
@@ -32,4 +42,98 @@ export function withUnsupportedLabelFeatureErrorConversion(
     );
   }
   throw err;
+}
+
+type Base = {
+  err: Error;
+};
+
+type CreateJoinToken = Base & {
+  kind: 'create-join-token';
+  req: JoinTokenRequest;
+  ctx: TeleportContext;
+  abortSignal: AbortSignal;
+};
+
+type EnrollEks = Base & {
+  kind: 'enroll-eks';
+  req: EnrollEksClustersRequest;
+  integrationName: string;
+};
+
+type CreateAppAccess = Base & {
+  kind: 'create-app-access';
+  req: CreateAwsAppAccessRequest;
+  integrationName: string;
+};
+
+type FallbackProps = CreateJoinToken | EnrollEks | CreateAppAccess;
+
+/**
+ * TODO(kimlisa): DELETE IN 19.0
+ *
+ * Used to fetch with v1 endpoints as a fallback, if its v2 equivalent
+ * endpoint failed.
+ *
+ * Only supports v1 endpoints with equivalent v2 endpoints related to
+ * setting resource labels. Related v1 endpoints does not support labels.
+ *
+ * Fetch is only performed if the v2 error (passed in as a retry prop for
+ * function "tryV1Fallback") is a result of requiring a proxy upgrade:
+ *  - if api request does not contain any labels,
+ *    it will retry with the v1 endpoint without user knowledge
+ *  - if api request includes labels, then it will re-throw the error
+ *
+ * Any other errors will get re-thrown.
+ *
+ * @returns type FallbackProps
+ */
+export function useV1Fallback() {
+  function hasLabels(props: FallbackProps): number {
+    if (props.kind === 'enroll-eks') {
+      return props.req.extraLabels.length;
+    }
+    if (props.kind === 'create-app-access') {
+      return props.req.labels && Object.keys(props.req.labels).length;
+    }
+    if (props.kind === 'create-join-token') {
+      return props.req.suggestedLabels.length;
+    }
+  }
+
+  async function tryV1Fallback(props: CreateAppAccess): Promise<App>;
+
+  async function tryV1Fallback(
+    props: EnrollEks
+  ): Promise<EnrollEksClustersResponse>;
+
+  async function tryV1Fallback(props: CreateJoinToken): Promise<JoinToken>;
+
+  async function tryV1Fallback(props: FallbackProps) {
+    if (!props.err.message.includes(ProxyRequiresUpgrade) || hasLabels(props)) {
+      throw props.err;
+    }
+
+    if (props.kind === 'enroll-eks') {
+      return integrationService.enrollEksClusters(
+        props.integrationName,
+        props.req
+      );
+    }
+
+    if (props.kind === 'create-app-access') {
+      return integrationService.createAwsAppAccess(props.integrationName);
+    }
+
+    if (props.kind === 'create-join-token') {
+      return props.ctx.joinTokenService.fetchJoinToken(
+        props.req,
+        props.abortSignal
+      );
+    }
+  }
+
+  return {
+    tryV1Fallback,
+  };
 }


### PR DESCRIPTION
recommend reviewing by commit

part of https://github.com/gravitational/teleport/issues/46976

There was an issue with how the fallback was handled. If a user attempted a request `without labels`, it may call the v2 endpoint from an older proxy, and a confusing error will render, that basically tells users to remove label and try again (but there were no labels).

Each api call will always try the `v2` endpoint and then considering the error and presence of labels in request: 

- if no labels, error is `endpoint not found`, then silently re-try the v1 endpoint for the user (no other action necessary)
- if there are labels, error is `endpoint not found`, then show user the error that tells them to remove labels and try again 

Applied fixes to all applicable endpoints

This bug was only in master, nothing got backported yet