### PR TITLE
[v17] Teleport Install scripts: use `/etc/apt/keyrings/` when adding Teleport's public key for DEB packages

### DIFF
--- a/api/types/installers/agentless-installer.sh.tmpl
+++ b/api/types/installers/agentless-installer.sh.tmpl
@@ -123,8 +123,8 @@ install_teleport() {
       echo "deb https://apt.releases.teleport.dev/ubuntu ${VERSION_CODENAME?} {{ .RepoChannel }}" | sudo tee /etc/apt/sources.list.d/teleport.list
       rm /tmp/teleport-pubkey.asc
     else
-      curl https://apt.releases.teleport.dev/gpg | sudo tee /usr/share/keyrings/teleport-archive-keyring.asc
-      echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc]  https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} {{ .RepoChannel }}" | sudo tee /etc/apt/sources.list.d/teleport.list >/dev/null
+      curl https://apt.releases.teleport.dev/gpg | sudo tee /etc/apt/trusted.gpg.d/teleport-archive-keyring.asc
+      echo "deb [signed-by=/etc/apt/trusted.gpg.d/teleport-archive-keyring.asc]  https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} {{ .RepoChannel }}" | sudo tee /etc/apt/sources.list.d/teleport.list >/dev/null
     fi
     sudo apt-get update
 

--- a/api/types/installers/agentless-installer.sh.tmpl
+++ b/api/types/installers/agentless-installer.sh.tmpl
@@ -123,8 +123,9 @@ install_teleport() {
       echo "deb https://apt.releases.teleport.dev/ubuntu ${VERSION_CODENAME?} {{ .RepoChannel }}" | sudo tee /etc/apt/sources.list.d/teleport.list
       rm /tmp/teleport-pubkey.asc
     else
-      curl https://apt.releases.teleport.dev/gpg | sudo tee /etc/apt/trusted.gpg.d/teleport-archive-keyring.asc
-      echo "deb [signed-by=/etc/apt/trusted.gpg.d/teleport-archive-keyring.asc]  https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} {{ .RepoChannel }}" | sudo tee /etc/apt/sources.list.d/teleport.list >/dev/null
+      sudo mkdir -p /etc/apt/keyrings
+      curl https://apt.releases.teleport.dev/gpg | sudo tee /etc/apt/keyrings/teleport-archive-keyring.asc
+      echo "deb [signed-by=/etc/apt/keyrings/teleport-archive-keyring.asc]  https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} {{ .RepoChannel }}" | sudo tee /etc/apt/sources.list.d/teleport.list >/dev/null
     fi
     sudo apt-get update
 

--- a/assets/install-scripts/install-connect.sh
+++ b/assets/install-scripts/install-connect.sh
@@ -129,9 +129,9 @@ add_apt_key() {
     TMP_KEY="$TEMP_DIR/teleport-pubkey.gpg"
     download "https://apt.releases.teleport.dev/gpg" "$TMP_KEY"
     set -x
-    cat $TMP_KEY | $SUDO tee /usr/share/keyrings/teleport-archive-keyring.asc >/dev/null
+    cat $TMP_KEY | $SUDO tee /etc/apt/trusted.gpg.d/teleport-archive-keyring.asc >/dev/null
     set +x
-    TELEPORT_REPO="deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc]  https://apt.releases.teleport.dev/${APT_REPO_ID?} ${APT_REPO_VERSION_CODENAME?} stable/v${MAJOR}"
+    TELEPORT_REPO="deb [signed-by=/etc/apt/trusted.gpg.d/teleport-archive-keyring.asc]  https://apt.releases.teleport.dev/${APT_REPO_ID?} ${APT_REPO_VERSION_CODENAME?} stable/v${MAJOR}"
   fi
 
   set -x

--- a/assets/install-scripts/install-connect.sh
+++ b/assets/install-scripts/install-connect.sh
@@ -129,9 +129,10 @@ add_apt_key() {
     TMP_KEY="$TEMP_DIR/teleport-pubkey.gpg"
     download "https://apt.releases.teleport.dev/gpg" "$TMP_KEY"
     set -x
-    cat $TMP_KEY | $SUDO tee /etc/apt/trusted.gpg.d/teleport-archive-keyring.asc >/dev/null
+    $SUDO mkdir -p /etc/apt/keyrings
+    cat $TMP_KEY | $SUDO tee /etc/apt/keyrings/teleport-archive-keyring.asc >/dev/null
     set +x
-    TELEPORT_REPO="deb [signed-by=/etc/apt/trusted.gpg.d/teleport-archive-keyring.asc]  https://apt.releases.teleport.dev/${APT_REPO_ID?} ${APT_REPO_VERSION_CODENAME?} stable/v${MAJOR}"
+    TELEPORT_REPO="deb [signed-by=/etc/apt/keyrings/teleport-archive-keyring.asc]  https://apt.releases.teleport.dev/${APT_REPO_ID?} ${APT_REPO_VERSION_CODENAME?} stable/v${MAJOR}"
   fi
 
   set -x

--- a/assets/install-scripts/install.sh
+++ b/assets/install-scripts/install.sh
@@ -129,9 +129,9 @@ add_apt_key() {
     TMP_KEY="$TEMP_DIR/teleport-pubkey.gpg"
     download "https://apt.releases.teleport.dev/gpg" "$TMP_KEY"
     set -x
-    $SUDO cp "$TMP_KEY" /usr/share/keyrings/teleport-archive-keyring.asc
+    $SUDO cp "$TMP_KEY" /etc/apt/trusted.gpg.d/teleport-archive-keyring.asc
     set +x
-    TELEPORT_REPO="deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc]  https://apt.releases.teleport.dev/${APT_REPO_ID?} ${APT_REPO_VERSION_CODENAME?} ${CHANNEL}"
+    TELEPORT_REPO="deb [signed-by=/etc/apt/trusted.gpg.d/teleport-archive-keyring.asc]  https://apt.releases.teleport.dev/${APT_REPO_ID?} ${APT_REPO_VERSION_CODENAME?} ${CHANNEL}"
   fi
 
   set -x

--- a/assets/install-scripts/install.sh
+++ b/assets/install-scripts/install.sh
@@ -129,9 +129,10 @@ add_apt_key() {
     TMP_KEY="$TEMP_DIR/teleport-pubkey.gpg"
     download "https://apt.releases.teleport.dev/gpg" "$TMP_KEY"
     set -x
-    $SUDO cp "$TMP_KEY" /etc/apt/trusted.gpg.d/teleport-archive-keyring.asc
+    $SUDO mkdir -p /etc/apt/keyrings
+    $SUDO cp "$TMP_KEY" /etc/apt/keyrings/teleport-archive-keyring.asc
     set +x
-    TELEPORT_REPO="deb [signed-by=/etc/apt/trusted.gpg.d/teleport-archive-keyring.asc]  https://apt.releases.teleport.dev/${APT_REPO_ID?} ${APT_REPO_VERSION_CODENAME?} ${CHANNEL}"
+    TELEPORT_REPO="deb [signed-by=/etc/apt/keyrings/teleport-archive-keyring.asc]  https://apt.releases.teleport.dev/${APT_REPO_ID?} ${APT_REPO_VERSION_CODENAME?} ${CHANNEL}"
   fi
 
   set -x

--- a/lib/srv/server/installer/autodiscover_test.go
+++ b/lib/srv/server/installer/autodiscover_test.go
@@ -745,16 +745,16 @@ func TestAutoDiscoverNode(t *testing.T) {
 // SLES 12, 15
 var wellKnownOS = map[string]map[string]map[string]string{
 	"debian": {
-		"9":  {etcOSReleaseFile: debian9OSRelease, "/usr/share/keyrings/": "", "/etc/apt/sources.list.d/": ""},
-		"10": {etcOSReleaseFile: debian10OSRelease, "/usr/share/keyrings/": "", "/etc/apt/sources.list.d/": ""},
-		"11": {etcOSReleaseFile: debian11OSRelease, "/usr/share/keyrings/": "", "/etc/apt/sources.list.d/": ""},
-		"12": {etcOSReleaseFile: debian12OSRelease, "/usr/share/keyrings/": "", "/etc/apt/sources.list.d/": ""},
+		"9":  {etcOSReleaseFile: debian9OSRelease, "/etc/apt/trusted.gpg.d/": "", "/etc/apt/sources.list.d/": ""},
+		"10": {etcOSReleaseFile: debian10OSRelease, "/etc/apt/trusted.gpg.d/": "", "/etc/apt/sources.list.d/": ""},
+		"11": {etcOSReleaseFile: debian11OSRelease, "/etc/apt/trusted.gpg.d/": "", "/etc/apt/sources.list.d/": ""},
+		"12": {etcOSReleaseFile: debian12OSRelease, "/etc/apt/trusted.gpg.d/": "", "/etc/apt/sources.list.d/": ""},
 	},
 	"ubuntu": {
-		"18.04": {etcOSReleaseFile: ubuntu1804OSRelease, "/usr/share/keyrings/": "", "/etc/apt/sources.list.d/": ""},
-		"20.04": {etcOSReleaseFile: ubuntu2004OSRelease, "/usr/share/keyrings/": "", "/etc/apt/sources.list.d/": ""},
-		"22.04": {etcOSReleaseFile: ubuntu2204OSRelease, "/usr/share/keyrings/": "", "/etc/apt/sources.list.d/": ""},
-		"24.04": {etcOSReleaseFile: ubuntu2404OSRelease, "/usr/share/keyrings/": "", "/etc/apt/sources.list.d/": ""},
+		"18.04": {etcOSReleaseFile: ubuntu1804OSRelease, "/etc/apt/trusted.gpg.d/": "", "/etc/apt/sources.list.d/": ""},
+		"20.04": {etcOSReleaseFile: ubuntu2004OSRelease, "/etc/apt/trusted.gpg.d/": "", "/etc/apt/sources.list.d/": ""},
+		"22.04": {etcOSReleaseFile: ubuntu2204OSRelease, "/etc/apt/trusted.gpg.d/": "", "/etc/apt/sources.list.d/": ""},
+		"24.04": {etcOSReleaseFile: ubuntu2404OSRelease, "/etc/apt/trusted.gpg.d/": "", "/etc/apt/sources.list.d/": ""},
 	},
 	"amzn": {
 		"2":    {etcOSReleaseFile: amzn2OSRelease},

--- a/lib/srv/server/installer/autodiscover_test.go
+++ b/lib/srv/server/installer/autodiscover_test.go
@@ -745,16 +745,16 @@ func TestAutoDiscoverNode(t *testing.T) {
 // SLES 12, 15
 var wellKnownOS = map[string]map[string]map[string]string{
 	"debian": {
-		"9":  {etcOSReleaseFile: debian9OSRelease, "/etc/apt/trusted.gpg.d/": "", "/etc/apt/sources.list.d/": ""},
-		"10": {etcOSReleaseFile: debian10OSRelease, "/etc/apt/trusted.gpg.d/": "", "/etc/apt/sources.list.d/": ""},
-		"11": {etcOSReleaseFile: debian11OSRelease, "/etc/apt/trusted.gpg.d/": "", "/etc/apt/sources.list.d/": ""},
-		"12": {etcOSReleaseFile: debian12OSRelease, "/etc/apt/trusted.gpg.d/": "", "/etc/apt/sources.list.d/": ""},
+		"9":  {etcOSReleaseFile: debian9OSRelease, "/etc/apt/keyrings/": "", "/etc/apt/sources.list.d/": ""},
+		"10": {etcOSReleaseFile: debian10OSRelease, "/etc/apt/keyrings/": "", "/etc/apt/sources.list.d/": ""},
+		"11": {etcOSReleaseFile: debian11OSRelease, "/etc/apt/keyrings/": "", "/etc/apt/sources.list.d/": ""},
+		"12": {etcOSReleaseFile: debian12OSRelease, "/etc/apt/keyrings/": "", "/etc/apt/sources.list.d/": ""},
 	},
 	"ubuntu": {
-		"18.04": {etcOSReleaseFile: ubuntu1804OSRelease, "/etc/apt/trusted.gpg.d/": "", "/etc/apt/sources.list.d/": ""},
-		"20.04": {etcOSReleaseFile: ubuntu2004OSRelease, "/etc/apt/trusted.gpg.d/": "", "/etc/apt/sources.list.d/": ""},
-		"22.04": {etcOSReleaseFile: ubuntu2204OSRelease, "/etc/apt/trusted.gpg.d/": "", "/etc/apt/sources.list.d/": ""},
-		"24.04": {etcOSReleaseFile: ubuntu2404OSRelease, "/etc/apt/trusted.gpg.d/": "", "/etc/apt/sources.list.d/": ""},
+		"18.04": {etcOSReleaseFile: ubuntu1804OSRelease, "/etc/apt/sources.list.d/": ""}, // No /etc/apt/keyrings/ by default
+		"20.04": {etcOSReleaseFile: ubuntu2004OSRelease, "/etc/apt/sources.list.d/": ""}, // No /etc/apt/keyrings/ by default
+		"22.04": {etcOSReleaseFile: ubuntu2204OSRelease, "/etc/apt/keyrings/": "", "/etc/apt/sources.list.d/": ""},
+		"24.04": {etcOSReleaseFile: ubuntu2404OSRelease, "/etc/apt/keyrings/": "", "/etc/apt/sources.list.d/": ""},
 	},
 	"amzn": {
 		"2":    {etcOSReleaseFile: amzn2OSRelease},

--- a/lib/utils/packagemanager/apt.go
+++ b/lib/utils/packagemanager/apt.go
@@ -40,7 +40,7 @@ const (
 	aptRepoEndpoint                = "https://apt.releases.teleport.dev/"
 
 	aptTeleportSourceListFileRelative = "/etc/apt/sources.list.d/teleport.list"
-	aptTeleportPublicKeyFileRelative  = "/usr/share/keyrings/teleport-archive-keyring.asc"
+	aptTeleportPublicKeyFileRelative  = "/etc/apt/trusted.gpg.d/teleport-archive-keyring.asc"
 
 	aptFilePermsRepository = 0o644
 )
@@ -128,7 +128,7 @@ func (pm *APT) AddTeleportRepository(ctx context.Context, linuxInfo *linux.OSRel
 	aptTeleportSourceListFile := filepath.Join(pm.fsRootPrefix, aptTeleportSourceListFileRelative)
 	aptTeleportPublicKeyFile := filepath.Join(pm.fsRootPrefix, aptTeleportPublicKeyFileRelative)
 	// Format for teleport repo entry should look like this:
-	// deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc]  https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} $RepoChannel"
+	// deb [signed-by=/etc/apt/trusted.gpg.d/teleport-archive-keyring.asc]  https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} $RepoChannel"
 	teleportRepoMetadata := fmt.Sprintf("deb [signed-by=%s] %s%s %s %s", aptTeleportPublicKeyFile, aptRepoEndpoint, linuxInfo.ID, linuxInfo.VersionCodename, repoChannel)
 
 	switch {

--- a/lib/utils/packagemanager/apt.go
+++ b/lib/utils/packagemanager/apt.go
@@ -40,10 +40,13 @@ const (
 	aptRepoEndpoint                = "https://apt.releases.teleport.dev/"
 
 	aptTeleportSourceListFileRelative = "/etc/apt/sources.list.d/teleport.list"
-	aptTeleportPublicKeyFileRelative  = "/etc/apt/trusted.gpg.d/teleport-archive-keyring.asc"
 
-	aptFilePermsRepository = 0o644
+	aptKeyringsLocation      = "/etc/apt/keyrings"
+	aptKeyringsLocationPerms = 0o755
+	aptFilePermsRepository   = 0o644
 )
+
+var aptTeleportPublicKeyFileRelative = filepath.Join(aptKeyringsLocation, "teleport-archive-keyring.asc")
 
 // APT is a wrapper for apt package manager.
 // This package manager is used in Debian/Ubuntu and distros based on this distribution.
@@ -128,7 +131,10 @@ func (pm *APT) AddTeleportRepository(ctx context.Context, linuxInfo *linux.OSRel
 	aptTeleportSourceListFile := filepath.Join(pm.fsRootPrefix, aptTeleportSourceListFileRelative)
 	aptTeleportPublicKeyFile := filepath.Join(pm.fsRootPrefix, aptTeleportPublicKeyFileRelative)
 	// Format for teleport repo entry should look like this:
-	// deb [signed-by=/etc/apt/trusted.gpg.d/teleport-archive-keyring.asc]  https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} $RepoChannel"
+	// deb [signed-by=/etc/apt/keyrings/teleport-archive-keyring.asc]  https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} $RepoChannel"
+	if err := os.MkdirAll(filepath.Join(pm.fsRootPrefix, aptKeyringsLocation), aptKeyringsLocationPerms); err != nil {
+		return trace.Wrap(err)
+	}
 	teleportRepoMetadata := fmt.Sprintf("deb [signed-by=%s] %s%s %s %s", aptTeleportPublicKeyFile, aptRepoEndpoint, linuxInfo.ID, linuxInfo.VersionCodename, repoChannel)
 
 	switch {

--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -936,8 +936,8 @@ install_from_repo() {
             echo "deb https://apt.releases.teleport.dev/${ID} ${VERSION_CODENAME} ${REPO_CHANNEL}" > /etc/apt/sources.list.d/teleport.list
         else
             curl -fsSL https://apt.releases.teleport.dev/gpg \
-                -o /usr/share/keyrings/teleport-archive-keyring.asc
-            echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] \
+                -o /etc/apt/trusted.gpg.d/teleport-archive-keyring.asc
+            echo "deb [signed-by=/etc/apt/trusted.gpg.d/teleport-archive-keyring.asc] \
             https://apt.releases.teleport.dev/${ID} ${VERSION_CODENAME} ${REPO_CHANNEL}" > /etc/apt/sources.list.d/teleport.list
         fi
         apt-get update

--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -935,9 +935,10 @@ install_from_repo() {
             curl -fsSL https://apt.releases.teleport.dev/gpg | apt-key add -
             echo "deb https://apt.releases.teleport.dev/${ID} ${VERSION_CODENAME} ${REPO_CHANNEL}" > /etc/apt/sources.list.d/teleport.list
         else
+            mkdir -p /etc/apt/keyrings
             curl -fsSL https://apt.releases.teleport.dev/gpg \
-                -o /etc/apt/trusted.gpg.d/teleport-archive-keyring.asc
-            echo "deb [signed-by=/etc/apt/trusted.gpg.d/teleport-archive-keyring.asc] \
+                -o /etc/apt/keyrings/teleport-archive-keyring.asc
+            echo "deb [signed-by=/etc/apt/keyrings/teleport-archive-keyring.asc] \
             https://apt.releases.teleport.dev/${ID} ${VERSION_CODENAME} ${REPO_CHANNEL}" > /etc/apt/sources.list.d/teleport.list
         fi
         apt-get update

--- a/web/packages/shared/components/TextSelectCopy/TextSelectCopyMulti.story.tsx
+++ b/web/packages/shared/components/TextSelectCopy/TextSelectCopyMulti.story.tsx
@@ -45,7 +45,7 @@ export const BashMultiWithComment = () => {
     <Component
       lines={[
         {
-          text: `sudo curl https://apt.releases.teleport.dev/gpg \\\n-o /usr/share/keyrings/teleport-archive-keyring.asc`,
+          text: `sudo curl https://apt.releases.teleport.dev/gpg \\\n-o /etc/apt/trusted.gpg.d/teleport-archive-keyring.asc`,
           comment: `Download Teleport's PGP public key`,
         },
         {
@@ -53,7 +53,7 @@ export const BashMultiWithComment = () => {
         },
         {
           text:
-            `echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] \\\n` +
+            `echo "deb [signed-by=/etc/apt/trusted.gpg.d/teleport-archive-keyring.asc] \\\n` +
             `https://apt.releases.teleport.dev/stable/v10" \\\n` +
             `| sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null`,
           comment:

--- a/web/packages/shared/components/TextSelectCopy/TextSelectCopyMulti.story.tsx
+++ b/web/packages/shared/components/TextSelectCopy/TextSelectCopyMulti.story.tsx
@@ -45,7 +45,7 @@ export const BashMultiWithComment = () => {
     <Component
       lines={[
         {
-          text: `sudo curl https://apt.releases.teleport.dev/gpg \\\n-o /etc/apt/trusted.gpg.d/teleport-archive-keyring.asc`,
+          text: `sudo curl https://apt.releases.teleport.dev/gpg \\\n-o /etc/apt/keyrings/teleport-archive-keyring.asc`,
           comment: `Download Teleport's PGP public key`,
         },
         {
@@ -53,7 +53,7 @@ export const BashMultiWithComment = () => {
         },
         {
           text:
-            `echo "deb [signed-by=/etc/apt/trusted.gpg.d/teleport-archive-keyring.asc] \\\n` +
+            `echo "deb [signed-by=/etc/apt/keyrings/teleport-archive-keyring.asc] \\\n` +
             `https://apt.releases.teleport.dev/stable/v10" \\\n` +
             `| sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null`,
           comment:


### PR DESCRIPTION
Backport #50273 to branch/v17