### PR TITLE
docs: fix getting started link for k8s app discovery

### DIFF
--- a/docs/pages/enroll-resources/auto-discovery/kubernetes-applications/kubernetes-applications.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes-applications/kubernetes-applications.mdx
@@ -16,7 +16,7 @@ applications, and registers these applications with your cluster. The Teleport
 Application Service then detects the new application resources and proxies user
 traffic to them.
 
-- [Get started](get-started.mdx): Set up automatic
+- [Get started](./get-started.mdx): Set up automatic
   application discovery with the `teleport-kube-agent` Helm chart.
 - [Architecture](../../../reference/architecture/kubernetes-applications-architecture.mdx): Learn how
   automatic application discovery works.


### PR DESCRIPTION
was not linking to the same  dir getting started