### PR TITLE
Init local metrics registry at runtime instead of config

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1006,6 +1006,15 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 		"pid", fmt.Sprintf("%v.%v", os.Getpid(), processID),
 	)
 
+	// Use the custom metrics registry if specified, else create a new one.
+	// We must create the registry in NewTeleport, as opposed to ApplyConfig(),
+	// because some tests are running multiple Teleport instances from the same
+	// config.
+	metricsRegistry := cfg.MetricsRegistry
+	if metricsRegistry == nil {
+		metricsRegistry = prometheus.NewRegistry()
+	}
+
 	// If FIPS mode was requested make sure binary is build against BoringCrypto.
 	if cfg.FIPS {
 		if !modules.GetModules().IsBoringBinary() {
@@ -1189,7 +1198,7 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 		logger:                 cfg.Logger,
 		cloudLabels:            cloudLabels,
 		TracingProvider:        tracing.NoopProvider(),
-		metricsRegistry:        cfg.MetricsRegistry,
+		metricsRegistry:        metricsRegistry,
 	}
 
 	process.registerExpectedServices(cfg)

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -523,10 +523,6 @@ func ApplyDefaults(cfg *Config) {
 		cfg.LoggerLevel = new(slog.LevelVar)
 	}
 
-	if cfg.MetricsRegistry == nil {
-		cfg.MetricsRegistry = prometheus.NewRegistry()
-	}
-
 	// Remove insecure and (borderline insecure) cryptographic primitives from
 	// default configuration. These can still be added back in file configuration by
 	// users, but not supported by default by Teleport. See #1856 for more


### PR DESCRIPTION
It's the metrics registry again 🙄 

This PR makes the local registry init happen in `NewTeleport()` (at run time) instead of `ApplyDefaults()` (config time).

We have some integration tests stopping and starting Teleport processes using the same config. The second startup caused metrics double registration in https://github.com/gravitational/teleport/pull/50807.

Required for: https://github.com/gravitational/teleport/pull/50807

