### PR TITLE
Remove any notion of teleport namespace from tsh

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1123,7 +1123,7 @@ func testLeafProxySessionRecording(t *testing.T, suite *integrationTestSuite) {
 				nodeClient, err := tc.ConnectToNode(
 					ctx,
 					clt,
-					client.NodeDetails{Addr: "leaf-zero:0", Namespace: tc.Namespace, Cluster: clt.ClusterName()},
+					client.NodeDetails{Addr: "leaf-zero:0", Cluster: clt.ClusterName()},
 					tc.Config.HostLogin,
 				)
 				assert.NoError(t, err)
@@ -1487,7 +1487,7 @@ func testIPPropagation(t *testing.T, suite *integrationTestSuite) {
 		nodeClient, err := tc.ConnectToNode(
 			ctx,
 			clt,
-			client.NodeDetails{Addr: nodeName, Namespace: tc.Namespace, Cluster: clt.ClusterName()},
+			client.NodeDetails{Addr: nodeName, Cluster: clt.ClusterName()},
 			tc.Config.HostLogin,
 		)
 		require.NoError(t, err)
@@ -1656,7 +1656,7 @@ func verifySessionJoin(t *testing.T, username string, teleport *helpers.TeleInst
 				return
 
 			case <-ticker.C:
-				err := cl.Join(context.TODO(), types.SessionPeerMode, defaults.Namespace, session.ID(sessionID), personB)
+				err := cl.Join(context.TODO(), types.SessionPeerMode, session.ID(sessionID), personB)
 				if err == nil {
 					sessionB <- nil
 					return
@@ -5955,7 +5955,7 @@ func testWindowChange(t *testing.T, suite *integrationTestSuite) {
 		}
 
 		for i := 0; i < 10; i++ {
-			err = cl.Join(ctx, types.SessionPeerMode, defaults.Namespace, session.ID(sessionID), personB)
+			err = cl.Join(ctx, types.SessionPeerMode, session.ID(sessionID), personB)
 			if err == nil || isSSHError(err) {
 				err = nil
 				break
@@ -7871,9 +7871,8 @@ func testModeratedSFTP(t *testing.T, suite *integrationTestSuite) {
 	})
 
 	nodeDetails := client.NodeDetails{
-		Addr:      instance.Config.SSH.Addr.Addr,
-		Namespace: peerClient.Namespace,
-		Cluster:   helpers.Site,
+		Addr:    instance.Config.SSH.Addr.Addr,
+		Cluster: helpers.Site,
 	}
 	peerNodeClient, err := peerClient.ConnectToNode(
 		ctx,
@@ -7936,7 +7935,6 @@ func testModeratedSFTP(t *testing.T, suite *integrationTestSuite) {
 	close(emptyCh)
 	modNodeCli := client.NodeClient{
 		Client:          tracessh.NewClient(modSSHConn, modSSHChans, emptyCh),
-		Namespace:       nodeDetails.Namespace,
 		TC:              modTC,
 		Tracer:          modTC.Tracer,
 		FIPSEnabled:     details.FIPS,
@@ -8133,9 +8131,8 @@ func testSFTP(t *testing.T, suite *integrationTestSuite) {
 		ctx,
 		clusterClient,
 		client.NodeDetails{
-			Addr:      teleport.Config.SSH.Addr.Addr,
-			Namespace: teleportClient.Namespace,
-			Cluster:   helpers.Site,
+			Addr:    teleport.Config.SSH.Addr.Addr,
+			Cluster: helpers.Site,
 		},
 		suite.Me.Username,
 	)
@@ -8338,9 +8335,8 @@ func testAgentlessConn(t *testing.T, tc, joinTC *client.TeleportClient, node *ty
 		ctx,
 		clt,
 		client.NodeDetails{
-			Addr:      uuidAddr,
-			Namespace: tc.Namespace,
-			Cluster:   tc.SiteName,
+			Addr:    uuidAddr,
+			Cluster: tc.SiteName,
 		},
 		tc.Username,
 	)
@@ -8399,7 +8395,7 @@ func testAgentlessConn(t *testing.T, tc, joinTC *client.TeleportClient, node *ty
 	}, 3*time.Second, 100*time.Millisecond)
 
 	// test that attempting to join the session returns an error
-	err = joinTC.Join(ctx, types.SessionPeerMode, tc.Namespace, session.ID(sessTracker.GetSessionID()), nil)
+	err = joinTC.Join(ctx, types.SessionPeerMode, session.ID(sessTracker.GetSessionID()), nil)
 	require.True(t, trace.IsBadParameter(err))
 	require.ErrorContains(t, err, "session joining is only supported for Teleport nodes, not OpenSSH nodes")
 
@@ -9041,7 +9037,7 @@ func testModeratedSessions(t *testing.T, suite *integrationTestSuite) {
 		cl.WebauthnLogin = customWebauthnLogin
 		cl.Stdout = moderatorTerminal
 		cl.Stdin = moderatorTerminal
-		if err := cl.Join(ctx, types.SessionModeratorMode, defaults.Namespace, session.ID(sessionID), moderatorTerminal); err != nil {
+		if err := cl.Join(ctx, types.SessionModeratorMode, session.ID(sessionID), moderatorTerminal); err != nil {
 			cancel(trace.Wrap(err, "moderator session failed"))
 		}
 	}

--- a/lib/benchmark/db/db.go
+++ b/lib/benchmark/db/db.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy"
@@ -61,7 +62,7 @@ func retrieveDatabaseCertificates(ctx context.Context, tc *client.TeleportClient
 // getDatabase loads the database which the name matches.
 func getDatabase(ctx context.Context, tc *client.TeleportClient, serviceName string, protocol string) (types.Database, error) {
 	databases, err := tc.ListDatabases(ctx, &proto.ListResourcesRequest{
-		Namespace:           tc.Namespace,
+		Namespace:           defaults.Namespace,
 		ResourceType:        types.KindDatabaseServer,
 		PredicateExpression: fmt.Sprintf(`name == "%s" && resource.spec.protocol == "%s"`, serviceName, protocol),
 	})

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -209,9 +209,6 @@ type Config struct {
 	// Labels represent host Labels
 	Labels map[string]string
 
-	// Namespace is nodes namespace
-	Namespace string
-
 	// HostLogin is a user login on a remote host
 	HostLogin string
 
@@ -1192,7 +1189,7 @@ func (c *Config) ProxySpecified() bool {
 func (c *Config) ResourceFilter(kind string) *proto.ListResourcesRequest {
 	return &proto.ListResourcesRequest{
 		ResourceType:        kind,
-		Namespace:           c.Namespace,
+		Namespace:           apidefaults.Namespace,
 		Labels:              c.Labels,
 		SearchKeywords:      c.SearchKeywords,
 		PredicateExpression: c.PredicateExpression,
@@ -1260,8 +1257,6 @@ func NewClient(c *Config) (tc *TeleportClient, err error) {
 		}
 		log.InfoContext(context.Background(), "no host login given, using default", "default_host_login", c.HostLogin)
 	}
-
-	c.Namespace = types.ProcessNamespace(c.Namespace)
 
 	if c.Tracer == nil {
 		c.Tracer = tracing.NoopProvider().Tracer(teleport.ComponentTeleport)
@@ -2166,7 +2161,7 @@ func (tc *TeleportClient) runShellOrCommandOnSingleNode(ctx context.Context, clt
 	nodeClient, err := tc.ConnectToNode(
 		ctx,
 		clt,
-		NodeDetails{Addr: nodeAddr, Namespace: tc.Namespace, Cluster: cluster},
+		NodeDetails{Addr: nodeAddr, Cluster: cluster},
 		tc.Config.HostLogin,
 	)
 	if err != nil {
@@ -2284,7 +2279,7 @@ func (tc *TeleportClient) startPortForwarding(ctx context.Context, nodeClient *N
 }
 
 // Join connects to the existing/active SSH session
-func (tc *TeleportClient) Join(ctx context.Context, mode types.SessionParticipantMode, namespace string, sessionID session.ID, input io.Reader) (err error) {
+func (tc *TeleportClient) Join(ctx context.Context, mode types.SessionParticipantMode, sessionID session.ID, input io.Reader) (err error) {
 	ctx, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/Join",
@@ -2296,9 +2291,6 @@ func (tc *TeleportClient) Join(ctx context.Context, mode types.SessionParticipan
 	)
 	defer span.End()
 
-	if namespace == "" {
-		return trace.BadParameter(authclient.MissingNamespaceError)
-	}
 	tc.Stdin = input
 	if sessionID.Check() != nil {
 		return trace.Errorf("Invalid session ID format: %s", string(sessionID))
@@ -2347,7 +2339,7 @@ func (tc *TeleportClient) Join(ctx context.Context, mode types.SessionParticipan
 	// connect to server:
 	nc, err := tc.ConnectToNode(ctx,
 		clt,
-		NodeDetails{Addr: session.GetAddress() + ":0", Namespace: tc.Namespace, Cluster: clt.ClusterName()},
+		NodeDetails{Addr: session.GetAddress() + ":0", Cluster: clt.ClusterName()},
 		tc.Config.HostLogin,
 	)
 	if err != nil {
@@ -2607,9 +2599,8 @@ func (tc *TeleportClient) TransferFiles(ctx context.Context, clt *ClusterClient,
 		ctx,
 		clt,
 		NodeDetails{
-			Addr:      nodeAddr,
-			Namespace: tc.Namespace,
-			Cluster:   clt.ClusterName(),
+			Addr:    nodeAddr,
+			Cluster: clt.ClusterName(),
 		},
 		hostLogin,
 	)
@@ -2946,11 +2937,10 @@ func (tc *TeleportClient) runCommandOnNodes(ctx context.Context, clt *ClusterCli
 				ctx,
 				clt,
 				NodeDetails{
-					Addr:      node.Addr,
-					Namespace: tc.Namespace,
-					Cluster:   cluster,
-					MFACheck:  mfaRequiredCheck,
-					hostname:  node.Hostname,
+					Addr:     node.Addr,
+					Cluster:  cluster,
+					MFACheck: mfaRequiredCheck,
+					hostname: node.Hostname,
 				},
 				tc.Config.HostLogin,
 			)

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -61,7 +61,6 @@ import (
 // NodeClient implements ssh client to a ssh node (teleport or any regular ssh node)
 // NodeClient can run shell and commands or upload and download files.
 type NodeClient struct {
-	Namespace   string
 	Tracer      oteltrace.Tracer
 	Client      *tracessh.Client
 	TC          *TeleportClient
@@ -257,8 +256,6 @@ func nodeName(node TargetNode) string {
 type NodeDetails struct {
 	// Addr is an address to dial
 	Addr string
-	// Namespace is the node namespace
-	Namespace string
 	// Cluster is the name of the target cluster
 	Cluster string
 
@@ -282,10 +279,7 @@ func (n NodeDetails) String() string {
 // ProxyFormat returns the address in the format
 // used by the proxy subsystem
 func (n *NodeDetails) ProxyFormat() string {
-	parts := []string{n.Addr}
-	if n.Namespace != "" {
-		parts = append(parts, n.Namespace)
-	}
+	parts := []string{n.Addr, apidefaults.Namespace}
 	if n.Cluster != "" {
 		parts = append(parts, n.Cluster)
 	}
@@ -351,7 +345,6 @@ func NewNodeClient(ctx context.Context, sshConfig *ssh.ClientConfig, conn net.Co
 
 	nc := &NodeClient{
 		Client:          tracessh.NewClient(sshconn, chans, emptyCh),
-		Namespace:       apidefaults.Namespace,
 		TC:              tc,
 		Tracer:          tc.Tracer,
 		FIPSEnabled:     fipsEnabled,

--- a/lib/client/client_test.go
+++ b/lib/client/client_test.go
@@ -47,8 +47,7 @@ func TestHelperFunctions(t *testing.T) {
 
 func TestNewSession(t *testing.T) {
 	nc := &NodeClient{
-		Namespace: "blue",
-		Tracer:    tracing.NoopProvider().Tracer("test"),
+		Tracer: tracing.NoopProvider().Tracer("test"),
 	}
 
 	ctx := context.Background()
@@ -57,7 +56,6 @@ func TestNewSession(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, ses)
 	require.Equal(t, nc, ses.NodeClient())
-	require.Equal(t, nc.Namespace, ses.namespace)
 	require.NotNil(t, ses.env)
 	require.Equal(t, os.Stderr, ses.terminal.Stderr())
 	require.Equal(t, os.Stdout, ses.terminal.Stdout())

--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -56,9 +56,6 @@ const (
 )
 
 type NodeSession struct {
-	// namespace is a session this namespace belongs to
-	namespace string
-
 	// id is the Teleport session ID
 	id session.ID
 
@@ -129,7 +126,6 @@ func newSession(ctx context.Context,
 	ns := &NodeSession{
 		env:                   env,
 		nodeClient:            client,
-		namespace:             client.Namespace,
 		closer:                utils.NewCloseBroadcaster(),
 		closeWait:             &sync.WaitGroup{},
 		enableEscapeSequences: enableEscapeSequences,
@@ -146,7 +142,6 @@ func newSession(ctx context.Context,
 		}
 
 		ns.id = session.ID(sessionID)
-		ns.namespace = joinSession.GetMetadata().Namespace
 
 		if ns.terminal.IsAttached() {
 			err = ns.terminal.Resize(int16(terminalSize.Width), int16(terminalSize.Height))

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -44,7 +44,6 @@ import (
 
 	"github.com/gravitational/teleport"
 	authproto "github.com/gravitational/teleport/api/client/proto"
-	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/observability/tracing"
 	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
@@ -507,7 +506,6 @@ func (t *TerminalHandler) makeClient(ctx context.Context, stream *terminal.Strea
 
 	clientConfig.HostLogin = t.sessionData.Login
 	clientConfig.ForwardAgent = client.ForwardAgentLocal
-	clientConfig.Namespace = apidefaults.Namespace
 	clientConfig.Stdout = stream
 	clientConfig.Stderr = stderrWriter{stream: stream}
 	clientConfig.Stdin = stream

--- a/tool/tsh/common/db.go
+++ b/tool/tsh/common/db.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
@@ -1131,7 +1132,7 @@ func getDatabaseServers(ctx context.Context, tc *client.TeleportClient, name str
 		logger.DebugContext(ctx, "Listing databases with predicate and labels", "predicate", predicate, "labels", tc.Labels)
 
 		databases, err = tc.ListDatabaseServersWithFilters(ctx, &proto.ListResourcesRequest{
-			Namespace:           tc.Namespace,
+			Namespace:           apidefaults.Namespace,
 			ResourceType:        types.KindDatabaseServer,
 			PredicateExpression: predicate,
 			Labels:              tc.Labels,
@@ -1193,7 +1194,7 @@ func listDatabasesWithPredicate(ctx context.Context, tc *client.TeleportClient, 
 		predicate := makePredicateConjunction(predicate, tc.PredicateExpression)
 		logger.DebugContext(ctx, "Listing databases with predicate and labels", "predicate", predicate, "labels", tc.Labels)
 		databases, err = tc.ListDatabases(ctx, &proto.ListResourcesRequest{
-			Namespace:           tc.Namespace,
+			Namespace:           apidefaults.Namespace,
 			ResourceType:        types.KindDatabaseServer,
 			PredicateExpression: predicate,
 			Labels:              tc.Labels,

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -1170,8 +1170,9 @@ func newKubeLoginCommand(parent *kingpin.CmdClause) *kubeLoginCommand {
 	c.Flag("query", queryHelp).StringVar(&c.predicateExpression)
 	c.Flag("as", "Configure custom Kubernetes user impersonation.").StringVar(&c.impersonateUser)
 	c.Flag("as-groups", "Configure custom Kubernetes group impersonation.").StringsVar(&c.impersonateGroups)
-	// TODO (tigrato): move this back to namespace once teleport drops the namespace flag.
-	c.Flag("kube-namespace", "Configure the default Kubernetes namespace.").Short('n').StringVar(&c.namespace)
+	// kube-namespace exists for backwards compatibility.
+	c.Flag("kube-namespace", "Configure the default Kubernetes namespace.").Hidden().StringVar(&c.namespace)
+	c.Flag("namespace", "Configure the default Kubernetes namespace.").Short('n').StringVar(&c.namespace)
 	c.Flag("all", "Generate a kubeconfig with every cluster the user has access to. Mutually exclusive with --labels or --query.").BoolVar(&c.all)
 	c.Flag("set-context-name", "Define a custom context name. To use it with --all include \"{{.KubeName}}\"").
 		// Use the default context name template if --set-context-name is not set.

--- a/tool/tsh/common/kube_proxy.go
+++ b/tool/tsh/common/kube_proxy.go
@@ -74,8 +74,9 @@ func newProxyKubeCommand(parent *kingpin.CmdClause) *proxyKubeCommand {
 	c.Arg("kube-cluster", "Name of the Kubernetes cluster to proxy. Check 'tsh kube ls' for a list of available clusters. If not specified, all clusters previously logged in through `tsh kube login` will be used.").StringsVar(&c.kubeClusters)
 	c.Flag("as", "Configure custom Kubernetes user impersonation.").StringVar(&c.impersonateUser)
 	c.Flag("as-groups", "Configure custom Kubernetes group impersonation.").StringsVar(&c.impersonateGroups)
-	// TODO (tigrato): move this back to namespace once teleport drops the namespace flag.
-	c.Flag("kube-namespace", "Configure the default Kubernetes namespace.").Short('n').StringVar(&c.namespace)
+	// kube-namespace exists for backwards compatibility.
+	c.Flag("kube-namespace", "Configure the default Kubernetes namespace.").Hidden().StringVar(&c.namespace)
+	c.Flag("namespace", "Configure the default Kubernetes namespace.").Short('n').StringVar(&c.namespace)
 	c.Flag("port", "Specifies the source port used by the proxy listener").Short('p').StringVar(&c.port)
 	c.Flag("format", envVarFormatFlagDescription()).Short('f').Default(envVarDefaultFormat()).EnumVar(&c.format, envVarFormats...)
 	c.Flag("labels", labelHelp).StringVar(&c.labels)


### PR DESCRIPTION
Updates https://github.com/gravitational/teleport/issues/49509.

Most of the places namespaces were already configurable were had been forcing the default namespace. This extends that by removing the ability to pass in a custom namespace and hardcodes the default namespace at the inner most call site to reduce the surface area of namespaces.

With the removal of the `--namespace` flag from the base `tsh` command, kubernetes subcommands have also been updated to use `--namespaces` in addition to `--kube-namespace`. The former should be preferred, while the later exists solely for backward compatibility. 