### PR TITLE
Catch misuses of the Var component

### DIFF
--- a/docs/pages/admin-guides/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform.mdx
@@ -144,7 +144,7 @@ These are regions that support [DynamoDB encryption at rest](https://docs.aws.am
 ### cluster_name
 
 ```code
-$ export TF_VAR_cluster_name="<Var name="teleport-example" />"
+$ export TF_VAR_cluster_name="teleport-example"
 ```
 
 This is the internal Teleport cluster name to use. This should be unique, and not contain spaces, dots (.) or other

--- a/docs/pages/admin-guides/deploy-a-cluster/gcp-kms.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/gcp-kms.mdx
@@ -62,7 +62,7 @@ $ gcloud kms keyrings create "<Var name="teleport-keyring" description="The name
 ## Step 2/5. Create a GCP service account
 
 Teleport needs permissions to create, list, destroy, sign with, and view KMS
-keys in your key ring. Start by creating the following custom IAM role.
+keys in your key ring. Start by defining the following custom IAM role.
 
 ```yaml
 # teleport_kms_role.yaml
@@ -77,6 +77,8 @@ includedPermissions:
 - cloudkms.cryptoKeyVersions.useToSign
 - cloudkms.cryptoKeyVersions.viewPublicKey
 ```
+
+Create the role, assigning <Var name="GCP-Project-ID" /> to your Google Cloud project ID:
 
 ```code
 $ gcloud iam roles create teleport_kms_role \

--- a/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/azure.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/azure.mdx
@@ -53,6 +53,7 @@ $ az aks update --resource-group <Var name="aks-rg" /> --name <Var name="aks-nam
 
 For convenience, we'll create all the resources necessary in a brand new
 resource group; if you want to use an existing one, you can skip this step.
+Assign <Var name="region" /> to your Azure region:
 
 ```code
 $ az group create --name <Var name="teleport-rg" /> --location <Var name="region" />
@@ -90,7 +91,7 @@ access can be restricted to just the AKS outbound address, or the account can be
 made part of the virtual network that the AKS cluster is using.
 
 ```code
-$ az storage account create --resource-group <Var name="teleport-rg" /> --name <Var name="teleport-blob" /> \
+$ az storage account create --resource-group <Var name="teleport-rg" /> --name "teleport-blob" \
     --allow-blob-public-access false
 $ az role assignment create --role "Storage Blob Data Owner" --assignee-principal-type ServicePrincipal \
     --assignee-object-id "$(az identity show --resource-group <Var name="teleport-rg" /> --name teleport-id --query principalId -o tsv)" \

--- a/docs/pages/admin-guides/deploy-a-cluster/hsm.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/hsm.mdx
@@ -33,7 +33,9 @@ to use.
 
 1. Wait for the newly created cluster to enter the "Uninitialized" state.
 
-1. Add an HSM to the new cluster, using the AWS Console or the AWS CLI:
+1. Add an HSM to the new cluster, using the AWS Console or the AWS CLI,
+   assigning <Var name="region"/> to your AWS region and <Var name="availability zone"/>
+   to your availability zone:
 
    ```code
    $ aws --region <Var name="region"/> cloudhsmv2 create-hsm --cluster-id <Var name="cluster ID"/> --availability-zone <Var name="availability zone"/>

--- a/docs/pages/admin-guides/deploy-a-cluster/linux-demo.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/linux-demo.mdx
@@ -164,10 +164,11 @@ Install `tsh` on your local workstation:
 
 (!docs/pages/includes/install-tsh.mdx!)
 
-Log in to receive short-lived certificates from Teleport:
+Log in to receive short-lived certificates from Teleport. Replace 
+<Var name="teleport.example.com" /> with your Teleport cluster's public address
+as configured above:
 
 ```code
-# Replace teleport.example.com with your Teleport cluster's public address as configured above.
 $ tsh login --proxy=<Var name="teleport.example.com" /> --user=teleport-admin
 > Profile URL:        https://teleport.example.com:443
   Logged in as:       teleport-admin

--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/ci-or-cloud.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/ci-or-cloud.mdx
@@ -150,7 +150,8 @@ spec:
 
 (!docs/pages/includes/machine-id/recover-circle-ci-claims.mdx!)
 
-Then, create the following `terraform-bot-token.yaml`:
+Then, create the following `terraform-bot-token.yaml`, replacing <Var
+name="context-id" /> with your context ID:
 
 ```yaml
 kind: token
@@ -163,7 +164,7 @@ spec:
   bot_name: terraform
   circleci:
     organization_id: <Var name="organization-id" />
-    # allow specifies the rules by which the Auth Server determines if `tbot`
+    # allow specifies the rules by which the Auth Service determines if `tbot`
     # should be allowed to join.
     allow:
     - context_id: <Var name="context-id" />

--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/local.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/local.mdx
@@ -32,7 +32,7 @@ verify that you can run `tctl` commands using your current credentials.
 For example:
 
 ```code
-$ tsh login --proxy=<Var name="teleport.example.com:443" /> --user=<Var name="email@example.com" />
+$ tsh login --proxy=teleport.example.com --user=email@example.com
 $ tctl status
 # Cluster  (=teleport.url=)
 # Version  (=teleport.version=)

--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/long-lived-credentials.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/long-lived-credentials.mdx
@@ -119,7 +119,10 @@ To prepare a Terraform configuration file:
 
 1. Create a new file called `main.tf` and open it in an editor.
 
-1. Define an example user and role using Terraform by pasting the following content into the `main.tf` file:
+1. Define an example user and role using Terraform by pasting the following
+   content into the `main.tf` file, replacing 
+   <Var name="teleport.example.com:443" /> with the host and port of the
+   Teleport Proxy Service:
 
    ```hcl
    terraform {

--- a/docs/pages/admin-guides/management/admin/labels.mdx
+++ b/docs/pages/admin-guides/management/admin/labels.mdx
@@ -311,7 +311,7 @@ should be named `si-<name>`.
 
 To add resource-based labels:
 
-1. Run `tctl get node/<Var name="hostname"/>` to get the name of the node resource to apply labels to.
+1. Run `tctl get node/NODE_NAME` to get the name of the node resource to apply labels to.
    You should get output similar to the following:
 
    ```yaml

--- a/docs/pages/admin-guides/management/guides/awsoidc-integration-rds.mdx
+++ b/docs/pages/admin-guides/management/guides/awsoidc-integration-rds.mdx
@@ -113,7 +113,8 @@ teleport.dev/origin:       integration_awsoidc
 teleport.dev/integration:  <Var name="my-integration"/>
 ```
 
-You can also search for AWS resources created by the wizard using the `aws` cli:
+You can also search for AWS resources created by the wizard using the `aws` cli.
+Assign <Var name="us-west-1" /> to the name of an AWS region:
 
 ```code
 $ aws resourcegroupstaggingapi get-resources \

--- a/docs/pages/admin-guides/management/operations/ca-rotation.mdx
+++ b/docs/pages/admin-guides/management/operations/ca-rotation.mdx
@@ -84,7 +84,8 @@ to reflect data held by the Auth Service. This internal data includes the status
 of the `host` CA rotation if one is in progress.
 
 To check the rotation status of an agent or Proxy Service instance, run a
-variation of the following command:
+variation of the following command, assigning <Var name="resource" /> to the
+name of an agent or Proxy Service instance:
 
 ```code
 $ tctl get <Var name="resource" /> --format=json | jq '.[] | {hostname: .spec.hostname, rotation: .spec.rotation.state, phase: .spec.rotation.phase}'

--- a/docs/pages/admin-guides/migrate-plans.mdx
+++ b/docs/pages/admin-guides/migrate-plans.mdx
@@ -93,7 +93,8 @@ Validate connectivity to both the new Teleport Enterprise cluster and your
 original Teleport Enterprise cluster. You should be able to connect to both
 Teleport clusters and execute `tctl` commands using your current credentials.
 
-1. Log in to the original Teleport cluster:
+1. Log in to the original Teleport cluster, replacing 
+   <Var name="enterprise.example.com" /> with the cluster domain name:
 
    ```code
    # Use the --auth flag instead of --user to log in with Single Sign-On.
@@ -101,7 +102,8 @@ Teleport clusters and execute `tctl` commands using your current credentials.
    $ tctl status
    ```
 
-1. Log in to the new Teleport Enterprise cluster:
+1. Log in to the new Teleport Enterprise cluster, replacing <Var
+   name="example.teleport.sh" /> with the domain name of your new cluster:
 
    ```code
    # Use the --auth flag instead of --user to log in with Single Sign-On.

--- a/docs/pages/admin-guides/teleport-policy/integrations/ssh-keys-scan.mdx
+++ b/docs/pages/admin-guides/teleport-policy/integrations/ssh-keys-scan.mdx
@@ -167,7 +167,7 @@ Below are a few example queries demonstrating how the `ssh_keys` view can be use
   ```
 - View insecure access paths and SSH authorized keys for a specific node:
   ```sql
-  SELECT * FROM ssh_keys WHERE resource='<Var name="resource name" />';
+  SELECT * FROM ssh_keys WHERE resource='RESOURCE_NAME';
   ```
 - View insecure access paths and SSH authorized keys for a subset of nodes using labels:
   ```sql

--- a/docs/pages/connect-your-client/gui-clients.mdx
+++ b/docs/pages/connect-your-client/gui-clients.mdx
@@ -21,7 +21,7 @@ work with Teleport.
 - To check that you can connect to your Teleport cluster, sign in with `tsh login`. For example:
 
   ```code
-  $ tsh login --proxy=<Var name="teleport.example.com" /> --user=<Var name="email@example.com" />
+  $ tsh login --proxy=teleport.example.com --user=myuser@example.com
   ```
 
 - The Teleport Database Service configured to access a database. See one of our

--- a/docs/pages/connect-your-client/introduction.mdx
+++ b/docs/pages/connect-your-client/introduction.mdx
@@ -18,8 +18,9 @@ your Teleport cluster:
 <Tabs>
 <TabItem label="Local user">
 
-Authenticate to Teleport as a local user with `tsh login` by 
-assigning <Var name="user"/> to your Teleport username:
+Authenticate to Teleport as a local user with `tsh login` by assigning <Var
+name="user"/> to your Teleport username and <Var name="teleport.example.com" />
+to the domain name of your Teleport cluster:
 
 ```code
 $ tsh login --proxy=<Var name="teleport.example.com" description="Your Teleport Proxy Service or Teleport Cloud tenant address"/> --user=<Var name="user" description="Your Teleport username"/>
@@ -39,8 +40,8 @@ Tap any security key
 <TabItem label="Single sign-on user">
 
 Authenticate to Teleport as a single sign-on (SSO) user by running `tsh login`
-and assigning the `auth` flag to the name of your authentication connector, if
-implemented by your administrators:
+and assigning <Var name="your-idp-connector" /> to the name of your
+authentication connector, if implemented by your administrators:
 
 ```code
 $ tsh login --proxy=<Var name="teleport.example.com"/> --auth=<Var name="your-idp-connector" description="Your Identity Provider connection name, if implemented by your administrators"/>

--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -405,9 +405,8 @@ locks](../admin-guides/access-controls/guides/locking.mdx) on those nodes.
 
 ```code
 $ tctl nodes ls -v --query='labels["teleport.dev/connect-my-computer/owner"] != ""'
-$ tctl lock --server-id=<Var name="Node UUID" /> --message="Using Connect My Computer is forbidden"
+$ tctl lock --server-id=SERVER_UUID --message="Using Connect My Computer is forbidden"
 ```
-
 
 ## Using tsh outside of Teleport Connect
 

--- a/docs/pages/connect-your-client/vnet.mdx
+++ b/docs/pages/connect-your-client/vnet.mdx
@@ -104,7 +104,8 @@ From /var/log/vnet.log:
 INFO  Setting an IP route for the VNet. netmask:100.64.0.0/10 vnet/osconfig_darwin.go:47
 ```
 
-Send a query for a TCP app available in your cluster:
+Send a query for a TCP app available in your cluster, replacing <Var
+name="tcp-app.teleport.example.com" /> with the name of your app:
 
 ```code
 $ dscacheutil -q host -a name <Var name="tcp-app.teleport.example.com" />

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
@@ -307,7 +307,8 @@ Service.
    Application Service.
 
 1. Run the following command to associate the new instance profile with your
-   instance:
+   instance, assigning <Var name="INSTANCE_ID" /> to your instance ID and 
+   <Var name="AWS_REGION" /> to your AWS region:
 
    ```code
    $ aws ec2 associate-iam-instance-profile --iam-instance-profile Name="TeleportAWSAccess" \

--- a/docs/pages/enroll-resources/application-access/cloud-apis/azure-aks-workload-id.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/azure-aks-workload-id.mdx
@@ -135,7 +135,7 @@ Next assign the managed identity desired permissions that the Teleport user
 should have. In this example, the "Reader" role is assigned to the managed
 identity:
 ```code
-$ az role assignment create --role "<Var name="Reader" />" --scope "/subscriptions/${SUBSCRIPTION}" --assignee-object-id $(az identity show --name "<Var name="teleport-reader" />" --resource-group "${RESOURCE_GROUP}" --query principalId --output tsv) --assignee-principal-type ServicePrincipal
+$ az role assignment create --role "Reader" --scope "/subscriptions/${SUBSCRIPTION}" --assignee-object-id $(az identity show --name "<Var name="teleport-reader" />" --resource-group "${RESOURCE_GROUP}" --query principalId --output tsv) --assignee-principal-type ServicePrincipal
 ```
 
 ### Associate the managed identity with the Kubernetes service account

--- a/docs/pages/enroll-resources/application-access/guides/vnet.mdx
+++ b/docs/pages/enroll-resources/application-access/guides/vnet.mdx
@@ -137,7 +137,7 @@ To make a [leaf cluster](../../../admin-guides/management/admin/trustedclusters.
 `public_addr`, you need to follow the same steps while being logged in directly to the leaf cluster.
 
 ```code
-$ tsh login --proxy=<Var name="leaf.example.com" /> --user=<Var name="email@example.com" />
+$ tsh login --proxy=leaf.example.com --user=email@example.com
 ```
 
 ### Accessing web apps through VNet

--- a/docs/pages/enroll-resources/application-access/troubleshooting-apps.mdx
+++ b/docs/pages/enroll-resources/application-access/troubleshooting-apps.mdx
@@ -169,7 +169,7 @@ manually set the `SSL_CERT_FILE` or `SSL_CERT_DIR` environment variable on the
 command line. For example:
 
 ```code
-sudo SSL_CERT_FILE=<Var name="path-to-rootCA-pem" /> teleport start --config=/etc/teleport.yaml
+sudo SSL_CERT_FILE="path/to/rootCA-pem" teleport start --config=/etc/teleport.yaml
 ```
 
 You should specify the `SSL_CERT_FILE` and `SSL_CERT_DIR` environment variables as command-line

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes-applications/get-started.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes-applications/get-started.mdx
@@ -57,7 +57,9 @@ by adding the `kube`, `app`, and `discovery` to roles as shown below.
 <TabItem label="Install a new agent">
 
 Deploy a new Teleport Agent running your configured services by installing the
-`teleport-kube-agent` Helm chart:
+`teleport-kube-agent` Helm chart, assigning <Var name="proxy-address" /> to the
+host and port of your Teleport Proxy Service and <Var name="token" /> to the
+join token you created earlier:
 
 ```code
 $ helm install teleport-agent teleport/teleport-kube-agent \

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/aws.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/aws.mdx
@@ -297,7 +297,7 @@ teleport:
   join_params:
     token_name: "/tmp/token"
     method: token
-  proxy_server: <Var name="teleport.example.com" />:443
+  proxy_server: "teleport.example.com:443"
 auth_service:
   enabled: off
 proxy_service:

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/azure.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/azure.mdx
@@ -234,7 +234,7 @@ teleport:
   join_params:
     token_name: "/tmp/token"
     method: token
-  proxy_server: <Var name="teleport.example.com" />:443    
+  proxy_server: "teleport.example.com:443"
 auth_service:
   enabled: off
 proxy_service:

--- a/docs/pages/enroll-resources/auto-discovery/servers/azure-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/azure-discovery.mdx
@@ -243,7 +243,7 @@ teleport:
   join_params:
     token_name: "/tmp/token"
     method: token
-  proxy_server: "<Var name="teleport.example.com" />:443"
+  proxy_server: "teleport.example.com:443"
 auth_service:
   enabled: off
 proxy_service:

--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery.mdx
@@ -126,7 +126,7 @@ teleport:
   join_params:
     token_name: "/tmp/token"
     method: token
-  proxy_server: "<Var name="teleport.example.com" />:443"
+  proxy_server: "<Var name="teleport.example.com:443" />"
 auth_service:
   enabled: off
 proxy_service:
@@ -222,7 +222,7 @@ mainSteps:
     sourceType: "HTTP"
     destinationPath: "/tmp/installTeleport.sh"
     sourceInfo:
-      url: "https://teleport.example.com:443/webapi/scripts/installer/{{ scriptName }}"
+      url: "https://<Var name="teleport.example.com:443" />/webapi/scripts/installer/{{ scriptName }}"
 - action: aws:runShellScript
   name: runShellScript
   inputs:

--- a/docs/pages/enroll-resources/auto-discovery/servers/gcp-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/gcp-discovery.mdx
@@ -138,8 +138,10 @@ discover instances.
   --role="projects/<Var name="project_id" />/roles/teleport_discovery"
   ```
 
-  If the Discovery Service will run in a GCP compute instance, run the following command to
-  add the service account to the instance:
+  If the Discovery Service will run in a GCP compute instance, run the following
+  command to add the service account to the instance, replacing <Var
+  name="discovery_service_vm_name" /> with the name of the Discovery Service VM:
+
   ```code
   $ gcloud compute instances set-service-account <Var name="discovery_service_vm_name" description="Name of the instance running the Discovery Service" /> \
   --service-account=teleport-discovery@<Var name="project_id" />.iam.gserviceaccount.com \

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-docdb.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-docdb.mdx
@@ -52,13 +52,14 @@ description: How to access Amazon DocumentDB with Teleport database access
 (!docs/pages/includes/install-linux.mdx!)
 
 On the node that is running the Database Service, create a configuration file.
-Use your DocumentDB cluster endpoint and port as the URI:
+Use your DocumentDB cluster endpoint and port as the URI, replacing 
+<Var name="my-docdb.cluster-abcdefghijklm.us-east-1.docdb.amazonaws.com:27017"/>:
 
 ```code
 $ sudo teleport db configure create \
    -o file \
    --name="my-docdb" \
-   --proxy=example.teleport.sh:443 \
+   --proxy=<Var name="example.teleport.sh:443" /> \
    --protocol=mongodb \
    --token=/tmp/token \
    --uri="<Var name="my-docdb.cluster-abcdefghijklm.us-east-1.docdb.amazonaws.com:27017"/>"
@@ -157,7 +158,9 @@ and `Allowed` for the value. Then click **Create Role** to complete the process.
 Log in to your DocumentDB cluster with your master username and password from a
 machine that has network access to the DocumentDB cluster. Create a DocumentDB
 user with the IAM role ARN as username and specify `MONGODB-AWS` in the
-mechanisms for authentication:
+mechanisms for authentication. Replace 
+<Var name="arn:aws:iam::(=aws.aws_account_id=):role/teleport-docdb-user"/> with
+the ARN of your DocumentDB user:
 
 ```code
 use $external;

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-opensearch.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-opensearch.mdx
@@ -197,7 +197,8 @@ your terminal, and manually adjust `/etc/teleport.yaml`.
 
 Generate a configuration file at `/etc/teleport.yaml` for the Database Service.
 Set the `--proxy` command-line option to the address for your Teleport cluster
-and database parameters to your AWS environment.
+and database parameters to your AWS environment. Assign <Var
+name="opensearch-uri" /> to the hostname of your OpenSearch instance:
 
 ```code
 $ sudo teleport db configure create \
@@ -221,7 +222,7 @@ Create a proxy tunnel:
 
 ```code
 $ tsh proxy db --tunnel --port=8000 --db-user=ExampleTeleportOpenSearchRole example-opensearch
-Started authenticated tunnel for the OpenSearch database "example-opensearch" in cluster "teleport.example.com" on 127.0.0.1:8000.
+Started authenticated tunnel for the OpenSearch database "example-opensearch" in cluster <Var name="teleport.example.com" /> on 127.0.0.1:8000.
 
 Use one of the following commands to connect to the database or to the address above using other database GUI/CLI clients:
 
@@ -231,7 +232,7 @@ Use one of the following commands to connect to the database or to the address a
 
   * run request with opensearch-cli:
 
-  $ opensearch-cli --profile teleport --config /Users/alice/.tsh/teleport.example.dev/example-opensearch/opensearch-cli/8a5ce249.yml curl get --path /
+  $ opensearch-cli --profile teleport --config /Users/alice/.tsh/<Var name="teleport.example.com" />/example-opensearch/opensearch-cli/8a5ce249.yml curl get --path /
 
   * run request with curl:
 

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds.mdx
@@ -204,9 +204,10 @@ Token                            Type Labels Expiry Time (UTC)
 Create a Helm values file called `values.yaml`, assigning <Var name="token" />
 to the value of the join token you retrieved above, <Var
 name="example.teleport.sh:443" /> to the host **and port** of your Teleport
-Proxy Service, `enterprise` to false if you are using the community/OSS version,
-and <Var name="endpoint:port" /> to the host **and port** of your RDS
-database (e.g., `myrds.us-east-1.rds.amazonaws.com:5432`):
+Proxy Service, and <Var name="endpoint:port" /> to the host **and port** of your
+RDS database (e.g., `myrds.us-east-1.rds.amazonaws.com:5432`). Assign <Var
+name="aws-account" /> to your AWS account ID. Set `enterprise` to false if you
+are using Teleport Community Edition:
 
 ```yaml
 authToken: <Var name="token" />

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/redshift-serverless.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/redshift-serverless.mdx
@@ -43,9 +43,10 @@ Create an AWS IAM role to provide user access to Redshift Serverless. This role
 will be granted to Teleport users via a corresponding Teleport role. In this
 guide we will give this role the name `teleport-redshift-serverless-access`.
 
-Configure the role's trust policy to trust the AWS account.
-This will be sufficient to allow the Teleport Database Service to assume the
-role, which we'll be setting up in the next step:
+Configure the role's trust policy to trust the AWS account.  This will be
+sufficient to allow the Teleport Database Service to assume the role, which
+we'll be setting up in the next step. Assign <Var name="aws-account-id"/> to
+your AWS account ID:
 
 ```json
 {
@@ -126,24 +127,10 @@ host.
 ### Generate a config file
 
 Update <Var name="REDSHIFT_SERVERLESS_URI" /> to the domain name and port of the
-cluster.
-On the node that is running the Database Service, create a configuration file:
-
-<Tabs>
-<TabItem label="Self-Hosted">
-
-```code
-$ sudo teleport db configure create \
-   -o file \
-   --name="redshift-serverless" \
-   --proxy=teleport.example.com:3080 \
-   --protocol=postgres \
-   --uri=<Var name="REDSHIFT_SERVERLESS_URI" /> \
-   --token=/tmp/token
-```
-
-</TabItem>
-<TabItem label="Teleport Enterprise (Cloud)">
+cluster.  On the node that is running the Database Service, create a
+configuration file, replacing <Var name="example.teleport.sh:443" /> with the
+host and web port of your Teleport Proxy Service (e.g., `example.teleport.sh` if
+using Teleport Cloud):
 
 ```code
 $ sudo teleport db configure create \
@@ -154,9 +141,6 @@ $ sudo teleport db configure create \
    --uri=<Var name="REDSHIFT_SERVERLESS_URI" /> \
    --token=/tmp/token
 ```
-
-</TabItem>
-</Tabs>
 
 The command will generate a Database Service configuration to proxy your AWS
 Redshift Serverless instance and place it at the `/etc/teleport.yaml` location.

--- a/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/mysql-cloudsql.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/mysql-cloudsql.mdx
@@ -185,7 +185,8 @@ access to. See our [RBAC](../rbac.mdx) guide for more details.
 When connecting to the database, use either the database user name or the
 service account's Email ID. Both the user name and the service account's Email
 ID are shown on the Users page of your Cloud SQL instance.
-Retrieve credentials for the "cloudsql" example database and connect to it:
+Retrieve credentials for the "cloudsql" example database and connect to it,
+assigning <Var name="project-id" /> to your Google Cloud project ID:
 
 ```code
 # Connect with the short name of the database user service account:

--- a/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/postgres-cloudsql.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/postgres-cloudsql.mdx
@@ -143,7 +143,8 @@ that you added as an IAM database user
 [above](#step-29-create-a-service-account-for-a-database-user),
 minus the ".gserviceaccount.com" suffix. The database user name is shown on
 the Users page of your Cloud SQL instance.
-Retrieve credentials for the "cloudsql" example database and connect to it:
+Retrieve credentials for the "cloudsql" example database and connect to it,
+assigning <Var name="project-id" /> to your Google Cloud project ID:
 
 ```code
 $ tsh db connect --db-user=cloudsql-user@<Var name="project-id"/>.iam --db-name=postgres cloudsql

--- a/docs/pages/enroll-resources/database-access/enroll-managed-databases/oracle-exadata.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-managed-databases/oracle-exadata.mdx
@@ -187,13 +187,14 @@ Copy the Oracle Database certificate and make it available at
 
 Run the following command to generate a configuration file at
 `/etc/teleport.yaml` for the Database Service. Update 
-<Var name="example.teleport.sh" /> to use the host and port of the Teleport Proxy
+<Var name="example.teleport.sh" /> to use the domain name of the Teleport Proxy
 Service:
+
 ```code
 $ sudo teleport db configure create \
    -o file \
    --token=/tmp/token \
-   --proxy=<Var name="example.teleport.sh:443" /> \
+   --proxy=<Var name="example.teleport.sh" />:443 \
    --name="<Var name="oracle" />" \
    --protocol=oracle \
    --uri="<Var name="10.20.30.40:2484" />" \
@@ -228,13 +229,13 @@ as Teleport using the following command:
 $ kubectl create secret generic db-ca --from-file=ca.pem=/path/to/oracle-server-certificate.crt
 ```
 
-Create a file called `values.yaml` with the following content. Update <Var
-name="example.teleport.sh" /> to use the host and port of the Teleport Proxy
-Service and <Var name="JOIN_TOKEN" /> to the join token you created earlier using the `tctl tokens add` command.
+Create a file called `values.yaml` with the following content. Update 
+<Var name="JOIN_TOKEN" /> to the join token you created earlier using the `tctl
+tokens add` command:
 
 ```yaml
 roles: db
-proxyAddr: <Var name="example.teleport.sh" />
+proxyAddr: <Var name="example.teleport.sh" />:443
 enterprise: true
 authToken: "<Var name="JOIN_TOKEN" />"
 databases:

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/oracle-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/oracle-self-hosted.mdx
@@ -85,12 +85,10 @@ If your Oracle database presents TLS credentials signed by an existing
 certificate authority, take the following steps instead:
 
 1. Export a Teleport CA certificate for Oracle to authenticate traffic from the
-   Teleport Database Service. Replace <Var name="example.teleport.sh:443" />
-   with the host and web port of the Teleport Proxy Service in your cluster. Run
-   the following command on your workstation:
+   Teleport Database Service. Run the following command on your workstation:
 
    ```code
-   $ tctl auth export --type=db-client --auth-server=<Var name="example.teleport.sh:443" /> > server.ca-client.crt
+   $ tctl auth export --type=db-client --auth-server=<Var name="example.teleport.sh" />:443 > server.ca-client.crt
    ```
 
 1. Move `server.ca-client.crt` to a directory in your Oracle server you will use
@@ -227,7 +225,7 @@ Once the Database Service has joined the cluster, log in to see the available
 databases:
 
 ```code
-$ tsh login --proxy=<Var name="mytenant.teleport.sh" /> --user=alice
+$ tsh login --proxy=<Var name="example.teleport.sh" /> --user=alice
 $ tsh db ls
 # Name   Description    Allowed Users Labels  Connect
 # ------ -------------- ------------- ------- -------

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/redis-cluster.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/redis-cluster.mdx
@@ -78,7 +78,9 @@ Install and configure Teleport where you will run the Teleport Database Service:
 ## Step 4/6. Set up mutual TLS
 
 Export your Teleport cluster's `db_client` CA cert and concatenate it with your Redis 
-Cluster's CA cert (in PEM format):
+Cluster's CA cert (in PEM format), assigning <Var name="/path/to/your/ca.crt" />
+to the path to the CA certificate:
+
 ```code
 $ tctl auth export --type=db-client > db-client-ca.crt
 $ cat <Var name="/path/to/your/ca.crt" /> db-client-ca.crt > pem-bundle.cas

--- a/docs/pages/enroll-resources/desktop-access/active-directory.mdx
+++ b/docs/pages/enroll-resources/desktop-access/active-directory.mdx
@@ -602,7 +602,7 @@ To configure Teleport to protect access to Windows desktops:
    ```yaml
    version: v3
    teleport:
-     auth_token: <Var name="path-to-token"/>
+     auth_token: "path/to/token"
      proxy_server: <Var name="teleport.example.com"/> # replace with your proxy address
    windows_desktop_service:
      enabled: yes
@@ -614,7 +614,7 @@ To configure Teleport to protect access to Windows desktops:
        username: "$LDAP_USERNAME"
        sid: "$LDAP_USER_SID"
        # Path to the certificate you exported.
-       der_ca_file: <Var name="path-to-exported-cert"/>
+       der_ca_file: "path/to/exported/cert"
      discovery:
        base_dn: "*"
    auth_service:

--- a/docs/pages/enroll-resources/desktop-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/desktop-access/getting-started.mdx
@@ -40,10 +40,12 @@ To prepare a Windows computer:
 1. Open a Command Prompt (`cmd.exe`) window on the Windows computer you want to enroll.
 
 {/*lint ignore ordered-list-marker-value*/}
-2. Export the Teleport user certificate authority by running the following command using your Teleport cluster address:
+2. Export the Teleport user certificate authority by running the following
+   command, assigning <Var name="teleport.example.com"/> to your
+   Teleport cluster address:
 
    ```code
-   $ curl.exe -fo teleport.cer <Var name="https://teleport.example.com"/>/webapi/auth/export?type=windows
+   $ curl.exe -fo teleport.cer https://<Var name="teleport.example.com"/>/webapi/auth/export?type=windows
    ```
 
 3. Download the Teleport Windows Auth setup program:
@@ -126,8 +128,8 @@ following for the Windows Desktop Service:
    version: v3
    teleport:
      nodename: <Var name="windows.teleport.example.com" />
-     proxy_server: <Var name="teleport.example.com:443" />
-     auth_token: <Var name="/tmp/token" />
+     proxy_server: <Var name="teleport.example.com" />:443
+     auth_token: "/tmp/token"
    windows_desktop_service:
      enabled: yes
      static_hosts:
@@ -164,7 +166,7 @@ following for the Windows Desktop Service:
    ```diff
    version: v3
    teleport:
-     nodename: windows.teleport.example.com
+     nodename: <Var name="windows.teleport.example.com" />
      proxy_server: teleport.example.com:443
      auth_token: /tmp/token
    windows_desktop_service:
@@ -184,7 +186,7 @@ following for the Windows Desktop Service:
    ```diff
    version: v3
    teleport:
-     nodename: windows.teleport.example.com
+     nodename: <Var name="windows.teleport.example.com" />
      proxy_server: teleport-proxy.example.com:443
    windows_desktop_service:
      enabled: yes

--- a/docs/pages/enroll-resources/kubernetes-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/getting-started.mdx
@@ -168,7 +168,9 @@ To set up and test access:
    Kubernetes cluster and verify access through Teleport. Alternatively, run the
    commands shown below:
 
-   Authenticate to your Teleport cluster:
+   Authenticate to your Teleport cluster, assigning 
+   <Var name="teleport.example.com"/> to your cluster domain and 
+   <Var name="admin@example.com"/> to your Teleport username:
 
    ```code
    $ tsh login --proxy=<Var name="teleport.example.com"/>:443 --auth=local --user=<Var name="admin@example.com"/> <Var name="teleport.example.com"/>
@@ -180,7 +182,8 @@ To set up and test access:
    $ tsh kube ls
    ```
 
-   Retrieve credentials to access your Kubernetes cluster:
+   Retrieve credentials to access your Kubernetes cluster, replacing 
+   <Var name="Kubernetes-cluster-name"/> with your Kubernetes cluster name:
 
    ```code
    $ tsh kube login <Var name="Kubernetes-cluster-name"/>

--- a/docs/pages/enroll-resources/kubernetes-access/register-clusters/dynamic-registration.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/register-clusters/dynamic-registration.mdx
@@ -68,18 +68,15 @@ Install the Teleport Kubernetes Service on your Linux host:
 
 On the host where you will run the Teleport Kubernetes Service, run the
 following command to create a base configuration for your Teleport instance,
-assigning `PROXY_SERVICE` to the host and port of your Teleport Proxy Service or
-Teleport Cloud tenant and `TOKEN` to the join token we created earlier:
+assigning <Var name="example.teleport.sh:443" /> to the host and port of your
+Teleport Proxy Service or Teleport Cloud tenant and <Var name="join-token" /> to
+the join token we created earlier:
 
 ```code
-# e.g., teleport.example.com:443
-$ PROXY_SERVICE=<Var name="proxy-addr"/>
-# e.g., (=presets.tokens.first=);
-$ TOKEN=<Var name="join-token"/>;
 $ sudo teleport configure \
---proxy=${PROXY_SERVICE?} \
+--proxy=<Var name="example.teleport.sh:443" /> \
 --roles=kube \
---token=${TOKEN?} \
+--token=<Var name="join-token" /> \
 -o file
 ```
 

--- a/docs/pages/enroll-resources/kubernetes-access/register-clusters/static-kubeconfig.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/register-clusters/static-kubeconfig.mdx
@@ -41,12 +41,12 @@ the correct cluster is selected:
 $ kubectl config get-contexts
 ```
 
-Use this command to switch to the cluster assigned to `CONTEXT_NAME`:
+Use this command to switch to the cluster assigned to 
+<Var name="context-name"/>:
 
 ```code
 # e.g., my-context
-$ CONTEXT_NAME=<Var name="context-name" />
-$ kubectl config use-context ${CONTEXT_NAME?}
+$ kubectl config use-context <Var name="context-name" />}
 ```
 
 ### Run the script
@@ -114,8 +114,9 @@ $ tctl tokens add --type=kube --format=text --ttl=1h
 (=presets.tokens.first=)
 ```
 
-On the host where you are running the Teleport Kubernetes Service, create a
-file called `/tmp/token` that consists only of your token:
+Assign <Var name="join-token" /> to your join token. On the host where you are
+running the Teleport Kubernetes Service, create a file called `/tmp/token` that
+consists only of your token:
 
 ```code
 $ echo <Var name="join-token" /> | sudo tee /tmp/token
@@ -130,8 +131,11 @@ Kubernetes Service:
 
 ### Configure the Teleport Kubernetes Service
 
-On the host where you will run the Teleport Kubernetes Service, create a file at
-`/etc/teleport.yaml` with the following content:
+Assign <Var name="teleport.example.com:443" /> with the host and port of your
+Teleport Proxy Service or Teleport Cloud tenant, e.g.,
+`mytenant.teleport.sh:443`. On the host where you will run the Teleport
+Kubernetes Service, create a file at `/etc/teleport.yaml` with the following
+content:
 
 ```yaml
 version: v3
@@ -139,7 +143,7 @@ teleport:
   join_params:
     token_name: "/tmp/token"
     method: token
-  proxy_server: <Var name="teleport.example.com" />:443
+  proxy_server: <Var name="teleport.example.com:443" />
 auth_service:
   enabled: off
 proxy_service:
@@ -153,9 +157,6 @@ kubernetes_service:
     "region": "us-east1"
 ```
 
-Edit `/etc/teleport.yaml` to replace `teleport.example.com:443` with the host
-and port of your Teleport Proxy Service or Teleport Cloud tenant, e.g.,
-`mytenant.teleport.sh:443`.
 
 <Admonition type="warning" title="Warning" >
 

--- a/docs/pages/enroll-resources/machine-id/deployment/circleci.mdx
+++ b/docs/pages/enroll-resources/machine-id/deployment/circleci.mdx
@@ -135,7 +135,7 @@ workflows:
     jobs:
       - write-run-log:
           context:
-            - <Var name="teleport-access"/>
+            - teleport-access
 ```
 
 `TELEPORT_ANONYMOUS_TELEMETRY` enables the submission of anonymous usage

--- a/docs/pages/enroll-resources/machine-id/deployment/linux-tpm.mdx
+++ b/docs/pages/enroll-resources/machine-id/deployment/linux-tpm.mdx
@@ -96,7 +96,7 @@ kind: token
 version: v2
 metadata:
   # name identifies the token. Try to ensure that this is descriptive.
-  name: <Var name="my-bot-token" />
+  name: my-bot-token
 spec:
   # For Machine ID and TPM joining, roles will always be "Bot" and
   # join_method will always be "tpm".
@@ -105,7 +105,7 @@ spec:
 
   # bot_name specifies the name of the bot that this token will grant access to
   # when it is used.
-  bot_name: <Var name="my-bot" />
+  bot_name: my-bot
 
   # tpm specifies the TPM join method specific configuration for this token.
   tpm:
@@ -132,7 +132,7 @@ spec:
         # and encoded in hexadecimal. This value will also be checked when a TPM
         # has submitted an EKCert, and the public key in the EKCert will be used
         # for this check.
-        ek_public_hash: "<Var name="ek-public-hash" />"
+        ek_public_hash: <Var name="ek-public-hash" />
 ```
 
 If your TPM includes an EKCert and you have obtained the manufacturer's CA,
@@ -157,7 +157,7 @@ version: v2
 proxy_server: example.teleport.sh:443
 onboarding:
   join_method: tpm
-  token: <Var name="my-bot-token" />
+  token: my-bot-token
 storage:
   type: directory
   path: /var/lib/teleport/bot

--- a/docs/pages/enroll-resources/server-access/guides/ansible.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/ansible.mdx
@@ -23,7 +23,7 @@ and run a sample ansible playbook.
 Log into Teleport with `tsh`:
 
 ```code
-$ tsh login --proxy=example.com
+$ tsh login --proxy=<Var name="teleport.example.com" />
 ```
 
 Generate `openssh` configuration using `tsh config` shortcut:

--- a/docs/pages/enroll-resources/server-access/guides/vscode.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/vscode.mdx
@@ -60,10 +60,12 @@ $ tsh.exe config | out-file .ssh\config -encoding utf8 -append
 </TabItem>
 </Tabs>
 
-You should be able to connect to the desired node using following command, replacing `user` with the username you would like to assume on the node.
+You should be able to connect to the desired node using following command,
+replacing <Var name="user" /> with the username you would like to assume on the
+node and <Var name="example-node" /> with the node name:
 
 ```code
-$ ssh user@<Var name="example-node" description="An SSH node in your Teleport cluster"/>.<Var name="teleport.example.com"/>
+$ ssh <Var name="user" />@<Var name="example-node" description="An SSH node in your Teleport cluster"/>.<Var name="teleport.example.com"/>
 ```
 
 <Details scopeOnly={true} scope={["cloud"]} title="Teleport Cloud">

--- a/docs/pages/includes/application-access/app-service-join-token.mdx
+++ b/docs/pages/includes/application-access/app-service-join-token.mdx
@@ -8,7 +8,8 @@ $ tctl tokens add --type=app --ttl=1h --format=text
 (=presets.tokens.first=)
 ```
 
-On the host where you will install the Teleport Application Service, create a
+Assign <Var name="join-token" /> to your token and, on the host where you will
+install the Teleport Application Service, run the following command to create a
 file called `/tmp/token` that consists only of your token:
 
 ```code

--- a/docs/pages/includes/application-access/azure-teleport-role.mdx
+++ b/docs/pages/includes/application-access/azure-teleport-role.mdx
@@ -44,8 +44,9 @@ Teleport, the Teleport Auth Service populates the
 have assigned to the user.
 
 Assign the `teleport-azure` identity to your Teleport user by running the
-following command, pasting in the URI of the Azure identity you copied earlier
-as the value of `--set-azure-identities`:
+following command, assigning <Var name="teleport-user" /> to your Teleport
+username and pasting in the URI of the Azure identity you copied earlier as the
+value of <Var name="azure-identity-uri" />:
 
 ```code
 $ tctl users update <Var name="teleport-user" /> \

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -96,7 +96,8 @@ First, assign environment variables based on your edition:
 
 The following commands show you how to determine the Teleport version to install
 by querying your Teleport Cloud account. This way, the Teleport installation has
-the same major version as the service that manages automatic updates:
+the same major version as the service that manages automatic updates. Assign
+<Var name="example.teleport.sh" /> to your Teleport cluster address:
 
 ```code
 $ TELEPORT_EDITION="cloud"
@@ -153,7 +154,7 @@ repositories.
    has the same major version as the service that conducts automatic updates:
 
    ```code
-   $ export TELEPORT_DOMAIN=<Var name="example.teleport.com" />
+   $ export TELEPORT_DOMAIN=<Var name="example.teleport.sh" />
    $ export TELEPORT_VERSION="$(curl https://$TELEPORT_DOMAIN/v1/webapi/automaticupgrades/channel/stable/cloud/version | sed 's/v//')"
    $ export TELEPORT_PKG="teleport-ent-${TELEPORT_VERSION?} teleport-ent-updater"
    $ export TELEPORT_CHANNEL=stable/cloud

--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -30,7 +30,7 @@ following commands:
 
 ```code
 # Log in to your cluster with tsh so you can use tctl from your local machine.
-$ tsh login --user=myuser --proxy=<Var name="mytenant.teleport.sh" />
+$ tsh login --user=myuser --proxy=example.teleport.sh
 $ tctl get roles
 ```
 

--- a/docs/pages/upgrading/automatic-agent-updates.mdx
+++ b/docs/pages/upgrading/automatic-agent-updates.mdx
@@ -166,17 +166,16 @@ Server ID                            Hostname      Services Version Upgrader
    Service. This way, the Teleport installation has the same major version as
    the automatic updater. 
 
-   Replace <Var name="example.teleport.sh" /> with the domain name of the
-   Teleport Proxy Service and <Var name="stable/cloud" /> with the name of your
-   automatic update channel. For cloud-hosted Teleport Enterprise accounts, this
-   is always `stable/cloud`:
+   Replace <Var name="stable/cloud" /> with the name of your automatic update
+   channel. For cloud-hosted Teleport Enterprise accounts, this is always
+   `stable/cloud`:
 
    ```code
-   $ TELEPORT_VERSION="$(curl https://<Var name="example.teleport.sh" />/v1/webapi/automaticupgrades/channel/<Var name="stable/cloud" />/version | sed 's/v//')"
+   $ TELEPORT_VERSION="$(curl https://<Var name="teleport.example.com:443" />/v1/webapi/automaticupgrades/channel/<Var name="stable/cloud" />/version | sed 's/v//')"
    ```
 
-1. Ensure that the Teleport repository is properly configured to use the <Var
-   name="stable/cloud" /> channel, and install the `teleport-ent-updater`
+1. Ensure that the Teleport repository is properly configured to use the 
+   <Var name="stable/cloud" /> channel, and install the `teleport-ent-updater`
    package. You must install `teleport-ent-updater` on each agent you would like
    to enroll into automatic updates:
 
@@ -291,7 +290,7 @@ This section assumes that the name of your `teleport-kube-agent` release is
    ```code
    $ helm -n <Var name="teleport" />  upgrade <Var name="teleport-agent" /> teleport/teleport-kube-agent \
    --values=values.yaml \
-   --version=<Var name="(=cloud.version=)" />
+   --version="(=cloud.version=)"
    ```
    </TabItem>
    <TabItem label="Self-Hosted">
@@ -299,7 +298,7 @@ This section assumes that the name of your `teleport-kube-agent` release is
    ```code
    $ helm -n <Var name="teleport" />  upgrade <Var name="teleport-agent" /> teleport/teleport-kube-agent \
    --values=values.yaml \
-   --version=<Var name="(=teleport.version=)" />
+   --version="(=teleport.version=)"
    ```
    </TabItem>
    </Tabs>

--- a/docs/pages/upgrading/upgrading-reference.mdx
+++ b/docs/pages/upgrading/upgrading-reference.mdx
@@ -95,18 +95,19 @@ $ teleport-upgrade force
    ```
    
 1. If you changed the agent user to run as non-root, create
-   `/etc/teleport-upgrade.d/schedule` and grant ownership to your Teleport user.
-   Otherwise, you can skip this step:
+   `/etc/teleport-upgrade.d/schedule` and grant ownership to your Teleport user,
+   assigning <Var name="your-teleport-user" /> to the name of your Teleport
+   user. Otherwise, you can skip this step:
    
-   ```code
-   $ sudo touch /etc/teleport-upgrade.d/schedule
-   $ sudo chown <Var name="your-teleport-user" /> /etc/teleport-upgrade.d/schedule
+   ```code 
+   $ sudo touch /etc/teleport-upgrade.d/schedule 
+   $ sudo chown <Var name="your-teleport-user" /> /etc/teleport-upgrade.d/schedule 
    ```
    
-1. Configure the upgrader to connect to your version server and subscribe to the
-   right release channel:
+   1. Configure the upgrader to connect to your version server and subscribe to
+   the right release channel:
    
-   ```code
+   ```code 
    $ echo "<Var name="teleport.example.com:443" />/v1/webapi/automaticupgrades/channel/default" | sudo tee /etc/teleport-upgrade.d/endpoint
    ```
 
@@ -181,7 +182,7 @@ Ensure that you are using the Teleport Enterprise edition of the `teleport-kube-
 chart. You should see the following when you query your `teleport-kube-agent` release:
 
 ```code
-$ helm -n <Var name="teleport" /> get values <Var name="teleport-agent" /> -o json | jq '.enterprise'
+$ helm -n "teleport" get values "teleport-agent" -o json | jq '.enterprise'
 true
 ```
 
@@ -257,10 +258,12 @@ self-hosted clusters, as well as all Teleport agents.
 ### Teleport agents
 
 1. Identify the latest compatible Teleport agent version by querying the
-   `webapi` endpoint of the Teleport Proxy Service:
+   `webapi` endpoint of the Teleport Proxy Service, replacing 
+   <Var name="teleport.example.com:443" /> with the host and port of your
+   Teleport account or Teleport Proxy Service:
 
    ```code
-   $ curl https://<Var name="teleport.example.com" />/webapi/automaticupgrades/channel/stable/cloud/version
+   $ curl https://<Var name="teleport.example.com:443" />/webapi/automaticupgrades/channel/stable/cloud/version
    v15.2.1
    ```
 
@@ -400,7 +403,7 @@ that your `teleport-kube-agent` release is called `teleport-agent`.
 1. Upgrade the Helm release:
 
    ```code
-   $ helm -n <Var name="teleport" /> upgrade teleport-agent teleport/teleport-kube-agent \
+   $ helm -n "teleport" upgrade teleport-agent teleport/teleport-kube-agent \
      --values=values.yaml \
      --version=<Var name="(=teleport.version=)" />
    ```

--- a/docs/vale-styles/structure/var-misuse.yml
+++ b/docs/vale-styles/structure/var-misuse.yml
@@ -1,0 +1,47 @@
+extends: script
+level: warning
+message: This Var is the only one with its name on this page. Var components only make sense when there are more than one with the same name.
+scope: raw
+script: |
+  text := import("text")
+
+  getMatches := func() {
+    // Find all uses of the Var component
+    varMatches := text.re_find(`<\s*Var[^>]+name=["']([^"']+)["']`, scope, -1)
+    if varMatches == undefined {
+      return []
+    }
+
+    // Assemble a map of Var names to their counts and first instances
+    varsToData := {}
+    for i, match in varMatches {
+      matchText := match[1].text
+
+      if varsToData[matchText] != undefined {
+        val := varsToData[matchText]
+        val.count++
+        varsToData[matchText] = val
+        continue
+      }
+
+      varsToData[match[1].text] = {
+        begin: match[1].begin,
+        end: match[1].end,
+        count: 1
+      }
+    }
+
+    // Find Var names that correspond to a single instance
+    matches := []
+    for k, v in varsToData {
+      if v.count == 1 {
+        matches = append(matches, {
+          begin: v.begin,
+          end: v.end
+        })
+      }
+    }
+    return matches
+  }
+
+  matches := getMatches()


### PR DESCRIPTION
Closes #29905

Add a Vale style rule to catch docs pages in which there is a single instance of a Var. This ensures that Vars reuse information as intended.

Also fix single-instance Vars that violate the rule. For the most part, this means either:

- Instructing the user to assign the Var, meaning that there are no easy-to-miss Vars hiding in a configuration snippet
- Removing unnecessary Vars, e.g., if an example command is meant to illustrate a possibility and is not mean to be copied and pasted
- Fixing mistakes in Var usage, e.g., a Proxy Service address variable that has two possible names, `teleport.example.com` and `example.teleport.sh`.