### PR TITLE
[kube-agent-updater] fix `kube-agent-updater` builds

### DIFF
--- a/integrations/kube-agent-updater/Dockerfile
+++ b/integrations/kube-agent-updater/Dockerfile
@@ -17,6 +17,7 @@ RUN go mod download
 
 # Copy in code
 COPY lib/ lib/
+COPY *.go ./
 COPY integrations/kube-agent-updater/ integrations/kube-agent-updater/
 
 ARG TARGETOS


### PR DESCRIPTION
This PR copies the teleport root module from the container build context into the build container.