### PR TITLE
Refactor tctl InitFunc to return an authclient.ClientI

### DIFF
--- a/lib/auth/authclient/clt.go
+++ b/lib/auth/authclient/clt.go
@@ -20,6 +20,7 @@ package authclient
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net"
@@ -41,8 +42,10 @@ import (
 	"github.com/gravitational/teleport/api/client/usertask"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	accessgraphsecretsv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessgraph/v1"
+	autoupdatev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
 	dbobjectimportrulev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobjectimportrule/v1"
+	decisionv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/decision/v1alpha1"
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	identitycenterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/identitycenter/v1"
 	integrationv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
@@ -56,6 +59,7 @@ import (
 	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	userspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/users/v1"
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
+	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	userpreferencesv1 "github.com/gravitational/teleport/api/gen/proto/go/userpreferences/v1"
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
@@ -1826,6 +1830,9 @@ type ClientI interface {
 	// when calling this method, but all RPCs will return "not implemented" errors
 	// (as per the default gRPC behavior).
 	WorkloadIdentityServiceClient() machineidv1pb.WorkloadIdentityServiceClient
+	SPIFFEFederationServiceClient() machineidv1pb.SPIFFEFederationServiceClient
+	WorkloadIdentityResourceServiceClient() workloadidentityv1pb.WorkloadIdentityResourceServiceClient
+	WorkloadIdentityIssuanceClient() workloadidentityv1pb.WorkloadIdentityIssuanceServiceClient
 
 	// NotificationServiceClient returns a notification service client.
 	// Clients connecting to  older Teleport versions, still get a client
@@ -1903,4 +1910,29 @@ type ClientI interface {
 
 	// GitServerReadOnlyClient returns the read-only client for Git servers.
 	GitServerReadOnlyClient() gitserver.ReadOnlyClient
+
+	DecisionClient() decisionv1.DecisionServiceClient
+
+	SetMFAPromptConstructor(pc mfa.PromptConstructor)
+
+	CreateAutoUpdateConfig(ctx context.Context, config *autoupdatev1pb.AutoUpdateConfig) (*autoupdatev1pb.AutoUpdateConfig, error)
+	UpdateAutoUpdateConfig(ctx context.Context, config *autoupdatev1pb.AutoUpdateConfig) (*autoupdatev1pb.AutoUpdateConfig, error)
+	UpsertAutoUpdateConfig(ctx context.Context, config *autoupdatev1pb.AutoUpdateConfig) (*autoupdatev1pb.AutoUpdateConfig, error)
+	DeleteAutoUpdateConfig(ctx context.Context) error
+
+	CreateAutoUpdateVersion(ctx context.Context, config *autoupdatev1pb.AutoUpdateVersion) (*autoupdatev1pb.AutoUpdateVersion, error)
+	UpdateAutoUpdateVersion(ctx context.Context, config *autoupdatev1pb.AutoUpdateVersion) (*autoupdatev1pb.AutoUpdateVersion, error)
+	UpsertAutoUpdateVersion(ctx context.Context, config *autoupdatev1pb.AutoUpdateVersion) (*autoupdatev1pb.AutoUpdateVersion, error)
+	DeleteAutoUpdateVersion(ctx context.Context) error
+
+	CreateAutoUpdateAgentRollout(ctx context.Context, config *autoupdatev1pb.AutoUpdateAgentRollout) (*autoupdatev1pb.AutoUpdateAgentRollout, error)
+	UpdateAutoUpdateAgentRollout(ctx context.Context, config *autoupdatev1pb.AutoUpdateAgentRollout) (*autoupdatev1pb.AutoUpdateAgentRollout, error)
+	UpsertAutoUpdateAgentRollout(ctx context.Context, config *autoupdatev1pb.AutoUpdateAgentRollout) (*autoupdatev1pb.AutoUpdateAgentRollout, error)
+	DeleteAutoUpdateAgentRollout(cxt context.Context) error
+
+	GetDesktopBootstrapScript(ctx context.Context) (string, error)
+
+	CrownJewelsClient() services.CrownJewels
+	UserTasksClient() services.UserTasks
+	Config() *tls.Config
 }

--- a/tool/tctl/common/accessmonitoring/command.go
+++ b/tool/tctl/common/accessmonitoring/command.go
@@ -114,7 +114,7 @@ func (c *Command) initAuditReportsCommands(auditCmd *kingpin.CmdClause, cfg *ser
 	})
 }
 
-type runFunc func(context.Context, *authclient.Client) error
+type runFunc func(context.Context, authclient.ClientI) error
 
 func (c *Command) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
 	handler, ok := c.innerCmdMap[cmd]
@@ -136,7 +136,7 @@ func (c *Command) TryRun(ctx context.Context, cmd string, clientFunc commonclien
 	}
 }
 
-func (c *cmdHandler) onAuditQueryExec(ctx context.Context, authClient *authclient.Client) error {
+func (c *cmdHandler) onAuditQueryExec(ctx context.Context, authClient authclient.ClientI) error {
 	if c.auditQuery == "" {
 		buff, err := io.ReadAll(os.Stdin)
 		if err != nil {
@@ -154,7 +154,7 @@ func (c *cmdHandler) onAuditQueryExec(ctx context.Context, authClient *authclien
 	return nil
 }
 
-func (c *cmdHandler) onAuditQueryGet(ctx context.Context, authClient *authclient.Client) error {
+func (c *cmdHandler) onAuditQueryGet(ctx context.Context, authClient authclient.ClientI) error {
 	auditQuery, err := authClient.SecReportsClient().GetSecurityAuditQuery(ctx, c.name)
 	if err != nil {
 		return trace.Wrap(err)
@@ -165,7 +165,7 @@ func (c *cmdHandler) onAuditQueryGet(ctx context.Context, authClient *authclient
 	return nil
 }
 
-func (c *cmdHandler) onAuditQueryLs(ctx context.Context, authClient *authclient.Client) error {
+func (c *cmdHandler) onAuditQueryLs(ctx context.Context, authClient authclient.ClientI) error {
 	auditQueries, err := authClient.SecReportsClient().GetSecurityAuditQueries(ctx)
 	if err != nil {
 		return trace.Wrap(err)
@@ -176,14 +176,14 @@ func (c *cmdHandler) onAuditQueryLs(ctx context.Context, authClient *authclient.
 	return nil
 }
 
-func (c *cmdHandler) onAuditQueryRm(ctx context.Context, authClient *authclient.Client) error {
+func (c *cmdHandler) onAuditQueryRm(ctx context.Context, authClient authclient.ClientI) error {
 	if err := authClient.SecReportsClient().DeleteSecurityAuditQuery(ctx, c.name); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
 }
 
-func (c *cmdHandler) onAuditQuerySchema(ctx context.Context, authClient *authclient.Client) error {
+func (c *cmdHandler) onAuditQuerySchema(ctx context.Context, authClient authclient.ClientI) error {
 	resp, err := authClient.SecReportsClient().GetSchema(ctx)
 	if err != nil {
 		return trace.Wrap(err)
@@ -201,7 +201,7 @@ func (c *cmdHandler) onAuditQuerySchema(ctx context.Context, authClient *authcli
 	return nil
 }
 
-func (c *cmdHandler) onAuditQueryCreate(ctx context.Context, authClient *authclient.Client) error {
+func (c *cmdHandler) onAuditQueryCreate(ctx context.Context, authClient authclient.ClientI) error {
 	if c.auditQuery == "" {
 		return trace.BadParameter("audit query required")
 	}
@@ -221,7 +221,7 @@ func (c *cmdHandler) onAuditQueryCreate(ctx context.Context, authClient *authcli
 	return nil
 }
 
-func (c *cmdHandler) onAuditReportLs(ctx context.Context, authClient *authclient.Client) error {
+func (c *cmdHandler) onAuditReportLs(ctx context.Context, authClient authclient.ClientI) error {
 	reports, err := authClient.SecReportsClient().GetSecurityReports(ctx)
 	if err != nil {
 		return trace.Wrap(err)
@@ -232,7 +232,7 @@ func (c *cmdHandler) onAuditReportLs(ctx context.Context, authClient *authclient
 	return trace.Wrap(err)
 }
 
-func (c *cmdHandler) onAuditReportGet(ctx context.Context, authClient *authclient.Client) error {
+func (c *cmdHandler) onAuditReportGet(ctx context.Context, authClient authclient.ClientI) error {
 	details, err := authClient.SecReportsClient().GetSecurityReportResult(ctx, c.name, c.days)
 	if err != nil {
 		return trace.Wrap(err)
@@ -243,7 +243,7 @@ func (c *cmdHandler) onAuditReportGet(ctx context.Context, authClient *authclien
 	return nil
 }
 
-func (c *cmdHandler) onAuditReportRun(ctx context.Context, authClient *authclient.Client) error {
+func (c *cmdHandler) onAuditReportRun(ctx context.Context, authClient authclient.ClientI) error {
 	err := authClient.SecReportsClient().RunSecurityReport(ctx, c.name, c.days)
 	if err != nil {
 		return trace.Wrap(err)
@@ -251,7 +251,7 @@ func (c *cmdHandler) onAuditReportRun(ctx context.Context, authClient *authclien
 	return nil
 }
 
-func (c *cmdHandler) onAuditReportState(ctx context.Context, authClient *authclient.Client) error {
+func (c *cmdHandler) onAuditReportState(ctx context.Context, authClient authclient.ClientI) error {
 	state, err := authClient.SecReportsClient().GetSecurityReportExecutionState(ctx, c.name, int32(c.days))
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/acl_command.go
+++ b/tool/tctl/common/acl_command.go
@@ -96,7 +96,7 @@ func (c *ACLCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFl
 
 // TryRun takes the CLI command as an argument (like "acl ls") and executes it.
 func (c *ACLCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
-	var commandFunc func(ctx context.Context, client *authclient.Client) error
+	var commandFunc func(ctx context.Context, client authclient.ClientI) error
 	switch cmd {
 	case c.ls.FullCommand():
 		commandFunc = c.List
@@ -122,7 +122,7 @@ func (c *ACLCommand) TryRun(ctx context.Context, cmd string, clientFunc commoncl
 }
 
 // List will list access lists visible to the user.
-func (c *ACLCommand) List(ctx context.Context, client *authclient.Client) error {
+func (c *ACLCommand) List(ctx context.Context, client authclient.ClientI) error {
 	var accessLists []*accesslist.AccessList
 	var nextKey string
 	for {
@@ -149,7 +149,7 @@ func (c *ACLCommand) List(ctx context.Context, client *authclient.Client) error 
 }
 
 // Get will display information about an access list visible to the user.
-func (c *ACLCommand) Get(ctx context.Context, client *authclient.Client) error {
+func (c *ACLCommand) Get(ctx context.Context, client authclient.ClientI) error {
 	accessList, err := client.AccessListClient().GetAccessList(ctx, c.accessListName)
 	if err != nil {
 		return trace.Wrap(err)
@@ -159,7 +159,7 @@ func (c *ACLCommand) Get(ctx context.Context, client *authclient.Client) error {
 }
 
 // UsersAdd will add a user to an access list.
-func (c *ACLCommand) UsersAdd(ctx context.Context, client *authclient.Client) error {
+func (c *ACLCommand) UsersAdd(ctx context.Context, client authclient.ClientI) error {
 	var expires time.Time
 	if c.expires != "" {
 		var err error
@@ -205,7 +205,7 @@ func (c *ACLCommand) UsersAdd(ctx context.Context, client *authclient.Client) er
 }
 
 // UsersRemove will remove a user to an access list.
-func (c *ACLCommand) UsersRemove(ctx context.Context, client *authclient.Client) error {
+func (c *ACLCommand) UsersRemove(ctx context.Context, client authclient.ClientI) error {
 	err := client.AccessListClient().DeleteAccessListMember(ctx, c.accessListName, c.userName)
 	if err != nil {
 		return trace.Wrap(err)
@@ -217,7 +217,7 @@ func (c *ACLCommand) UsersRemove(ctx context.Context, client *authclient.Client)
 }
 
 // UsersList will list the users in an access list.
-func (c *ACLCommand) UsersList(ctx context.Context, client *authclient.Client) error {
+func (c *ACLCommand) UsersList(ctx context.Context, client authclient.ClientI) error {
 	var (
 		allMembers []*accesslist.AccessListMember
 		nextToken  string

--- a/tool/tctl/common/admin_action_test.go
+++ b/tool/tctl/common/admin_action_test.go
@@ -1163,7 +1163,7 @@ func runTestCase(t *testing.T, ctx context.Context, client *authclient.Client, t
 	commandName, err := app.Parse(args)
 	require.NoError(t, err)
 
-	match, err := tc.cliCommand.TryRun(ctx, commandName, func(context.Context) (*authclient.Client, func(context.Context), error) {
+	match, err := tc.cliCommand.TryRun(ctx, commandName, func(context.Context) (authclient.ClientI, func(context.Context), error) {
 		return client, func(context.Context) {}, nil
 	})
 	require.True(t, match)

--- a/tool/tctl/common/alert_command.go
+++ b/tool/tctl/common/alert_command.go
@@ -96,7 +96,7 @@ func (c *AlertCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLI
 
 // TryRun takes the CLI command as an argument (like "alerts ls") and executes it.
 func (c *AlertCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
-	var commandFunc func(ctx context.Context, client *authclient.Client) error
+	var commandFunc func(ctx context.Context, client authclient.ClientI) error
 	switch cmd {
 	case c.alertList.FullCommand():
 		commandFunc = c.List
@@ -117,7 +117,7 @@ func (c *AlertCommand) TryRun(ctx context.Context, cmd string, clientFunc common
 	return true, trace.Wrap(err)
 }
 
-func (c *AlertCommand) ListAck(ctx context.Context, client *authclient.Client) error {
+func (c *AlertCommand) ListAck(ctx context.Context, client authclient.ClientI) error {
 	acks, err := client.GetAlertAcks(ctx)
 	if err != nil {
 		return trace.Wrap(err)
@@ -135,7 +135,7 @@ func (c *AlertCommand) ListAck(ctx context.Context, client *authclient.Client) e
 	return nil
 }
 
-func (c *AlertCommand) Ack(ctx context.Context, client *authclient.Client) error {
+func (c *AlertCommand) Ack(ctx context.Context, client authclient.ClientI) error {
 	if c.clear {
 		return c.ClearAck(ctx, client)
 	}
@@ -164,7 +164,7 @@ func (c *AlertCommand) Ack(ctx context.Context, client *authclient.Client) error
 	return nil
 }
 
-func (c *AlertCommand) ClearAck(ctx context.Context, client *authclient.Client) error {
+func (c *AlertCommand) ClearAck(ctx context.Context, client authclient.ClientI) error {
 	req := proto.ClearAlertAcksRequest{
 		AlertID: c.alertID,
 	}
@@ -178,7 +178,7 @@ func (c *AlertCommand) ClearAck(ctx context.Context, client *authclient.Client) 
 	return nil
 }
 
-func (c *AlertCommand) List(ctx context.Context, client *authclient.Client) error {
+func (c *AlertCommand) List(ctx context.Context, client authclient.ClientI) error {
 	labels, err := libclient.ParseLabelSpec(c.labels)
 	if err != nil {
 		return trace.Wrap(err)
@@ -269,7 +269,7 @@ func displayAlertsJSON(alerts []types.ClusterAlert) error {
 	return nil
 }
 
-func (c *AlertCommand) Create(ctx context.Context, client *authclient.Client) error {
+func (c *AlertCommand) Create(ctx context.Context, client authclient.ClientI) error {
 	labels, err := libclient.ParseLabelSpec(c.labels)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/app_command.go
+++ b/tool/tctl/common/app_command.go
@@ -71,7 +71,7 @@ func (c *AppsCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 
 // TryRun attempts to run subcommands like "apps ls".
 func (c *AppsCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
-	var commandFunc func(ctx context.Context, client *authclient.Client) error
+	var commandFunc func(ctx context.Context, client authclient.ClientI) error
 	switch cmd {
 	case c.appsList.FullCommand():
 		commandFunc = c.ListApps
@@ -90,7 +90,7 @@ func (c *AppsCommand) TryRun(ctx context.Context, cmd string, clientFunc commonc
 
 // ListApps prints the list of applications that have recently sent heartbeats
 // to the cluster.
-func (c *AppsCommand) ListApps(ctx context.Context, clt *authclient.Client) error {
+func (c *AppsCommand) ListApps(ctx context.Context, clt authclient.ClientI) error {
 	labels, err := libclient.ParseLabelSpec(c.labels)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/autoupdate_command_test.go
+++ b/tool/tctl/common/autoupdate_command_test.go
@@ -111,7 +111,7 @@ func runAutoUpdateCommand(t *testing.T, client *authclient.Client, args []string
 	selectedCmd, err := app.Parse(append([]string{"autoupdate"}, args...))
 	require.NoError(t, err)
 
-	_, err = command.TryRun(context.Background(), selectedCmd, func(ctx context.Context) (*authclient.Client, func(context.Context), error) {
+	_, err = command.TryRun(context.Background(), selectedCmd, func(ctx context.Context) (authclient.ClientI, func(context.Context), error) {
 		return client, func(context.Context) {}, nil
 	})
 	return &stdoutBuff, err

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -134,7 +134,7 @@ func (c *BotsCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 
 // TryRun attempts to run subcommands.
 func (c *BotsCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
-	var commandFunc func(ctx context.Context, client *authclient.Client) error
+	var commandFunc func(ctx context.Context, client authclient.ClientI) error
 	switch cmd {
 	case c.botsList.FullCommand():
 		commandFunc = c.ListBots
@@ -167,7 +167,7 @@ func (c *BotsCommand) TryRun(ctx context.Context, cmd string, clientFunc commonc
 
 // ListBots writes a listing of the cluster's certificate renewal bots
 // to standard out.
-func (c *BotsCommand) ListBots(ctx context.Context, client *authclient.Client) error {
+func (c *BotsCommand) ListBots(ctx context.Context, client authclient.ClientI) error {
 	var bots []*machineidv1pb.Bot
 	req := &machineidv1pb.ListBotsRequest{}
 	for {
@@ -249,7 +249,7 @@ Please note:
 `))
 
 // AddBot adds a new certificate renewal bot to the cluster.
-func (c *BotsCommand) AddBot(ctx context.Context, client *authclient.Client) error {
+func (c *BotsCommand) AddBot(ctx context.Context, client authclient.ClientI) error {
 	// Prompt for admin action MFA if required, allowing reuse for UpsertToken and CreateBot.
 	mfaResponse, err := mfa.PerformAdminActionMFACeremony(ctx, client.PerformMFACeremony, true /*allowReuse*/)
 	if err == nil {
@@ -330,7 +330,7 @@ func (c *BotsCommand) AddBot(ctx context.Context, client *authclient.Client) err
 	return trace.Wrap(outputToken(c.stdout, c.format, client, bot, token))
 }
 
-func (c *BotsCommand) RemoveBot(ctx context.Context, client *authclient.Client) error {
+func (c *BotsCommand) RemoveBot(ctx context.Context, client authclient.ClientI) error {
 	_, err := client.BotServiceClient().DeleteBot(ctx, &machineidv1pb.DeleteBotRequest{
 		BotName: c.botName,
 	})
@@ -343,7 +343,7 @@ func (c *BotsCommand) RemoveBot(ctx context.Context, client *authclient.Client) 
 	return nil
 }
 
-func (c *BotsCommand) LockBot(ctx context.Context, client *authclient.Client) error {
+func (c *BotsCommand) LockBot(ctx context.Context, client authclient.ClientI) error {
 	lockExpiry, err := computeLockExpiry(c.lockExpires, c.lockTTL)
 	if err != nil {
 		return trace.Wrap(err)
@@ -496,7 +496,7 @@ func (c *BotsCommand) updateBotRoles(ctx context.Context, client clientRoleGette
 }
 
 // UpdateBot performs various updates to existing bot users and roles.
-func (c *BotsCommand) UpdateBot(ctx context.Context, client *authclient.Client) error {
+func (c *BotsCommand) UpdateBot(ctx context.Context, client authclient.ClientI) error {
 	bot, err := client.BotServiceClient().GetBot(ctx, &machineidv1pb.GetBotRequest{
 		BotName: c.botName,
 	})
@@ -540,7 +540,7 @@ func (c *BotsCommand) UpdateBot(ctx context.Context, client *authclient.Client) 
 }
 
 // ListBotInstances lists bot instances, possibly filtering for a specific bot
-func (c *BotsCommand) ListBotInstances(ctx context.Context, client *authclient.Client) error {
+func (c *BotsCommand) ListBotInstances(ctx context.Context, client authclient.ClientI) error {
 	var instances []*machineidv1pb.BotInstance
 	req := &machineidv1pb.ListBotInstancesRequest{}
 
@@ -647,7 +647,7 @@ func (c *BotsCommand) ListBotInstances(ctx context.Context, client *authclient.C
 }
 
 // AddBotInstance begins onboarding a new instance of an existing bot.
-func (c *BotsCommand) AddBotInstance(ctx context.Context, client *authclient.Client) error {
+func (c *BotsCommand) AddBotInstance(ctx context.Context, client authclient.ClientI) error {
 	// A bit of a misnomer but makes the terminology a bit more consistent. This
 	// doesn't directly create a bot instance, but creates token that allows a
 	// bot to join, which creates a new instance.
@@ -730,7 +730,7 @@ To onboard a new instance for this bot, run:
 > {{.executable}} bots instances add {{.instance.Spec.BotName}}
 `))
 
-func (c *BotsCommand) ShowBotInstance(ctx context.Context, client *authclient.Client) error {
+func (c *BotsCommand) ShowBotInstance(ctx context.Context, client authclient.ClientI) error {
 	botName, instanceID, err := parseInstanceID(c.instanceID)
 	if err != nil {
 		return trace.Wrap(err)
@@ -783,7 +783,7 @@ type botJSONResponse struct {
 }
 
 // outputToken writes token information to stdout, depending on the token format.
-func outputToken(wr io.Writer, format string, client *authclient.Client, bot *machineidv1pb.Bot, token types.ProvisionToken) error {
+func outputToken(wr io.Writer, format string, client authclient.ClientI, bot *machineidv1pb.Bot, token types.ProvisionToken) error {
 	if format == teleport.JSON {
 		tokenTTL := time.Duration(0)
 		if exp := token.Expiry(); !exp.IsZero() {

--- a/tool/tctl/common/client/auth.go
+++ b/tool/tctl/common/client/auth.go
@@ -44,11 +44,11 @@ import (
 // InitFunc initiates connection to auth service, makes ping request and return the client instance.
 // If the function does not return an error, the caller is responsible for calling the client close function
 // once it does not need the client anymore.
-type InitFunc func(ctx context.Context) (client *authclient.Client, close func(context.Context), err error)
+type InitFunc func(ctx context.Context) (client authclient.ClientI, close func(context.Context), err error)
 
 // GetInitFunc wraps lazy loading auth init function for commands which requires the auth client.
 func GetInitFunc(ccf tctlcfg.GlobalCLIFlags, cfg *servicecfg.Config) InitFunc {
-	return func(ctx context.Context) (*authclient.Client, func(context.Context), error) {
+	return func(ctx context.Context) (authclient.ClientI, func(context.Context), error) {
 		clientConfig, err := tctlcfg.ApplyConfig(&ccf, cfg)
 		if err != nil {
 			return nil, nil, trace.Wrap(err)

--- a/tool/tctl/common/db_command.go
+++ b/tool/tctl/common/db_command.go
@@ -71,7 +71,7 @@ func (c *DBCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFla
 
 // TryRun attempts to run subcommands like "db ls".
 func (c *DBCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
-	var commandFunc func(ctx context.Context, client *authclient.Client) error
+	var commandFunc func(ctx context.Context, client authclient.ClientI) error
 	switch cmd {
 	case c.dbList.FullCommand():
 		commandFunc = c.ListDatabases
@@ -90,7 +90,7 @@ func (c *DBCommand) TryRun(ctx context.Context, cmd string, clientFunc commoncli
 
 // ListDatabases prints the list of database proxies that have recently sent
 // heartbeats to the cluster.
-func (c *DBCommand) ListDatabases(ctx context.Context, clt *authclient.Client) error {
+func (c *DBCommand) ListDatabases(ctx context.Context, clt authclient.ClientI) error {
 	labels, err := libclient.ParseLabelSpec(c.labels)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/desktop_command.go
+++ b/tool/tctl/common/desktop_command.go
@@ -66,7 +66,7 @@ func (c *DesktopCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalC
 
 // TryRun attempts to run subcommands like "desktop ls".
 func (c *DesktopCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
-	var commandFunc func(ctx context.Context, client *authclient.Client) error
+	var commandFunc func(ctx context.Context, client authclient.ClientI) error
 	switch cmd {
 	case c.desktopList.FullCommand():
 		commandFunc = c.ListDesktop
@@ -86,7 +86,7 @@ func (c *DesktopCommand) TryRun(ctx context.Context, cmd string, clientFunc comm
 
 // ListDesktop prints the list of desktops that have recently sent heartbeats
 // to the cluster.
-func (c *DesktopCommand) ListDesktop(ctx context.Context, client *authclient.Client) error {
+func (c *DesktopCommand) ListDesktop(ctx context.Context, client authclient.ClientI) error {
 	desktops, err := client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
 	if err != nil {
 		return trace.Wrap(err)
@@ -107,7 +107,7 @@ func (c *DesktopCommand) ListDesktop(ctx context.Context, client *authclient.Cli
 }
 
 // BootstrapAD generates a PowerShell script that can be used to bootstrap Active Directory.
-func (c *DesktopCommand) BootstrapAD(ctx context.Context, client *authclient.Client) error {
+func (c *DesktopCommand) BootstrapAD(ctx context.Context, client authclient.ClientI) error {
 	script, err := client.GetDesktopBootstrapScript(ctx)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/devices.go
+++ b/tool/tctl/common/devices.go
@@ -111,7 +111,7 @@ func (c *DevicesCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalC
 
 // runner is used as a simple interface for subcommands.
 type runner interface {
-	Run(context.Context, *authclient.Client) error
+	Run(context.Context, authclient.ClientI) error
 }
 
 func (c *DevicesCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
@@ -147,7 +147,7 @@ type deviceAddCommand struct {
 	enrollTTL time.Duration
 }
 
-func (c *deviceAddCommand) Run(ctx context.Context, authClient *authclient.Client) error {
+func (c *deviceAddCommand) Run(ctx context.Context, authClient authclient.ClientI) error {
 	if _, err := c.setCurrentDevice(); err != nil {
 		return trace.Wrap(err)
 	}
@@ -215,7 +215,7 @@ tsh device enroll --token=%v
 
 type deviceListCommand struct{}
 
-func (c *deviceListCommand) Run(ctx context.Context, authClient *authclient.Client) error {
+func (c *deviceListCommand) Run(ctx context.Context, authClient authclient.ClientI) error {
 	devices := authClient.DevicesClient()
 
 	// List all devices.
@@ -274,7 +274,7 @@ type deviceRemoveCommand struct {
 	deviceID string
 }
 
-func (c *deviceRemoveCommand) Run(ctx context.Context, authClient *authclient.Client) error {
+func (c *deviceRemoveCommand) Run(ctx context.Context, authClient authclient.ClientI) error {
 	switch ok, err := c.setCurrentDevice(); {
 	case err != nil:
 		return trace.Wrap(err)
@@ -314,7 +314,7 @@ type deviceEnrollCommand struct {
 	ttl      time.Duration
 }
 
-func (c *deviceEnrollCommand) Run(ctx context.Context, authClient *authclient.Client) error {
+func (c *deviceEnrollCommand) Run(ctx context.Context, authClient authclient.ClientI) error {
 	switch ok, err := c.setCurrentDevice(); {
 	case err != nil:
 		return trace.Wrap(err)
@@ -362,7 +362,7 @@ type deviceLockCommand struct {
 	ttl      time.Duration
 }
 
-func (c *deviceLockCommand) Run(ctx context.Context, authClient *authclient.Client) error {
+func (c *deviceLockCommand) Run(ctx context.Context, authClient authclient.ClientI) error {
 	switch ok, err := c.setCurrentDevice(); {
 	case err != nil:
 		return trace.Wrap(err)

--- a/tool/tctl/common/edit_command.go
+++ b/tool/tctl/common/edit_command.go
@@ -104,7 +104,7 @@ func (e *EditCommand) runEditor(ctx context.Context, name string) error {
 	return nil
 }
 
-func (e *EditCommand) editResource(ctx context.Context, client *authclient.Client) error {
+func (e *EditCommand) editResource(ctx context.Context, client authclient.ClientI) error {
 	f, err := os.CreateTemp("", "teleport-resource*.yaml")
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/externalauditstorage_command.go
+++ b/tool/tctl/common/externalauditstorage_command.go
@@ -58,7 +58,7 @@ func (c *ExternalAuditStorageCommand) Initialize(app *kingpin.Application, _ *tc
 
 // TryRun attempts to run subcommands.
 func (c *ExternalAuditStorageCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
-	var commandFunc func(ctx context.Context, client *authclient.Client) error
+	var commandFunc func(ctx context.Context, client authclient.ClientI) error
 	switch cmd {
 	case c.promote.FullCommand():
 		commandFunc = c.Promote
@@ -78,13 +78,13 @@ func (c *ExternalAuditStorageCommand) TryRun(ctx context.Context, cmd string, cl
 
 // Promote calls PromoteToClusterExternalAuditStorage, which results in enabling
 // External Audit Storage in the cluster based on existing draft.
-func (c *ExternalAuditStorageCommand) Promote(ctx context.Context, clt *authclient.Client) error {
+func (c *ExternalAuditStorageCommand) Promote(ctx context.Context, clt authclient.ClientI) error {
 	return trace.Wrap(clt.ExternalAuditStorageClient().PromoteToClusterExternalAuditStorage(ctx))
 }
 
 // Generate creates an External Audit Storage configuration with randomized
 // resource names and saves it as the current draft.
-func (c *ExternalAuditStorageCommand) Generate(ctx context.Context, clt *authclient.Client) error {
+func (c *ExternalAuditStorageCommand) Generate(ctx context.Context, clt authclient.ClientI) error {
 	_, err := clt.ExternalAuditStorageClient().GenerateDraftExternalAuditStorage(ctx, c.integrationName, c.region)
 	return trace.Wrap(err)
 }

--- a/tool/tctl/common/helpers_test.go
+++ b/tool/tctl/common/helpers_test.go
@@ -77,7 +77,7 @@ func runCommand(t *testing.T, client *authclient.Client, cmd cliCommand, args []
 	selectedCmd, err := app.Parse(args)
 	require.NoError(t, err)
 
-	_, err = cmd.TryRun(context.Background(), selectedCmd, func(ctx context.Context) (*authclient.Client, func(context.Context), error) {
+	_, err = cmd.TryRun(context.Background(), selectedCmd, func(ctx context.Context) (authclient.ClientI, func(context.Context), error) {
 		return client, func(context.Context) {}, nil
 	})
 	return err

--- a/tool/tctl/common/idp_command.go
+++ b/tool/tctl/common/idp_command.go
@@ -147,7 +147,7 @@ type testAttributeMapping struct {
 	outFormat       string
 }
 
-func (t *testAttributeMapping) run(ctx context.Context, c *authclient.Client) error {
+func (t *testAttributeMapping) run(ctx context.Context, c authclient.ClientI) error {
 	serviceProvider, err := parseSPFile(t.serviceProvider)
 	if err != nil {
 		return trace.Wrap(err)
@@ -225,7 +225,7 @@ func parseSPFile(fileName string) (types.SAMLIdPServiceProviderV1, error) {
 }
 
 // getUsersFromAPIOrFile parses user from spec file. If file is not found, it fetches user from backend.
-func getUsersFromAPIOrFile(ctx context.Context, usernamesOrFileNames []string, c *authclient.Client) ([]*types.UserV2, error) {
+func getUsersFromAPIOrFile(ctx context.Context, usernamesOrFileNames []string, c authclient.ClientI) ([]*types.UserV2, error) {
 	flattenedUsernamesOrFileNames := flattenSlice(usernamesOrFileNames)
 	var users []*types.UserV2
 

--- a/tool/tctl/common/inventory_command.go
+++ b/tool/tctl/common/inventory_command.go
@@ -88,7 +88,7 @@ func (c *InventoryCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Globa
 
 // TryRun takes the CLI command as an argument (like "inventory status") and executes it.
 func (c *InventoryCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
-	var commandFunc func(ctx context.Context, client *authclient.Client) error
+	var commandFunc func(ctx context.Context, client authclient.ClientI) error
 	switch cmd {
 	case c.inventoryStatus.FullCommand():
 		commandFunc = c.Status
@@ -109,7 +109,7 @@ func (c *InventoryCommand) TryRun(ctx context.Context, cmd string, clientFunc co
 	return true, trace.Wrap(err)
 }
 
-func (c *InventoryCommand) Status(ctx context.Context, client *authclient.Client) error {
+func (c *InventoryCommand) Status(ctx context.Context, client authclient.ClientI) error {
 	rsp, err := client.GetInventoryStatus(ctx, proto.InventoryStatusRequest{
 		Connected: c.getConnected,
 	})
@@ -184,7 +184,7 @@ func printHierarchicalData(data map[string]any, indent string, depth int) {
 	}
 }
 
-func (c *InventoryCommand) List(ctx context.Context, client *authclient.Client) error {
+func (c *InventoryCommand) List(ctx context.Context, client authclient.ClientI) error {
 	var services []types.SystemRole
 	var err error
 	var omitControlPlane bool
@@ -272,7 +272,7 @@ func (c *InventoryCommand) List(ctx context.Context, client *authclient.Client) 
 	}
 }
 
-func (c *InventoryCommand) Ping(ctx context.Context, client *authclient.Client) error {
+func (c *InventoryCommand) Ping(ctx context.Context, client authclient.ClientI) error {
 	rsp, err := client.PingInventory(ctx, proto.InventoryPingRequest{
 		ServerID:   c.serverID,
 		ControlLog: c.controlLog,

--- a/tool/tctl/common/kube_command.go
+++ b/tool/tctl/common/kube_command.go
@@ -71,7 +71,7 @@ func (c *KubeCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 
 // TryRun attempts to run subcommands like "kube ls".
 func (c *KubeCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
-	var commandFunc func(ctx context.Context, client *authclient.Client) error
+	var commandFunc func(ctx context.Context, client authclient.ClientI) error
 	switch cmd {
 	case c.kubeList.FullCommand():
 		commandFunc = c.ListKube
@@ -89,7 +89,7 @@ func (c *KubeCommand) TryRun(ctx context.Context, cmd string, clientFunc commonc
 
 // ListKube prints the list of kube clusters that have recently sent heartbeats
 // to the cluster.
-func (c *KubeCommand) ListKube(ctx context.Context, clt *authclient.Client) error {
+func (c *KubeCommand) ListKube(ctx context.Context, clt authclient.ClientI) error {
 	labels, err := libclient.ParseLabelSpec(c.labels)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/loadtest_command.go
+++ b/tool/tctl/common/loadtest_command.go
@@ -98,7 +98,7 @@ func (c *LoadtestCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Global
 
 // TryRun takes the CLI command as an argument (like "loadtest node-heartbeats") and executes it.
 func (c *LoadtestCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
-	var commandFunc func(ctx context.Context, client *authclient.Client) error
+	var commandFunc func(ctx context.Context, client authclient.ClientI) error
 	switch cmd {
 	case c.nodeHeartbeats.FullCommand():
 		commandFunc = c.NodeHeartbeats
@@ -118,7 +118,7 @@ func (c *LoadtestCommand) TryRun(ctx context.Context, cmd string, clientFunc com
 	return true, trace.Wrap(err)
 }
 
-func (c *LoadtestCommand) NodeHeartbeats(ctx context.Context, client *authclient.Client) error {
+func (c *LoadtestCommand) NodeHeartbeats(ctx context.Context, client authclient.ClientI) error {
 	infof := func(format string, args ...any) {
 		fmt.Fprintf(os.Stderr, "[i] "+format+"\n", args...)
 	}
@@ -238,7 +238,7 @@ func (c *LoadtestCommand) NodeHeartbeats(ctx context.Context, client *authclient
 	}
 }
 
-func (c *LoadtestCommand) Watch(ctx context.Context, client *authclient.Client) error {
+func (c *LoadtestCommand) Watch(ctx context.Context, client authclient.ClientI) error {
 	var kinds []types.WatchKind
 	for _, kind := range strings.Split(c.kind, ",") {
 		kind = strings.TrimSpace(kind)
@@ -345,7 +345,7 @@ Outer:
 	}
 }
 
-func (c *LoadtestCommand) AuditEvents(ctx context.Context, client *authclient.Client) error {
+func (c *LoadtestCommand) AuditEvents(ctx context.Context, client authclient.ClientI) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/tool/tctl/common/lock_command.go
+++ b/tool/tctl/common/lock_command.go
@@ -63,7 +63,7 @@ func (c *LockCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 
 // TryRun attempts to run subcommands.
 func (c *LockCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
-	var commandFunc func(ctx context.Context, client *authclient.Client) error
+	var commandFunc func(ctx context.Context, client authclient.ClientI) error
 	switch cmd {
 	case c.mainCmd.FullCommand():
 		commandFunc = c.CreateLock
@@ -81,7 +81,7 @@ func (c *LockCommand) TryRun(ctx context.Context, cmd string, clientFunc commonc
 }
 
 // CreateLock creates a lock for the main `tctl lock` command.
-func (c *LockCommand) CreateLock(ctx context.Context, client *authclient.Client) error {
+func (c *LockCommand) CreateLock(ctx context.Context, client authclient.ClientI) error {
 	lockExpiry, err := computeLockExpiry(c.expires, c.ttl)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/loginrule/command.go
+++ b/tool/tctl/common/loginrule/command.go
@@ -131,7 +131,7 @@ func (t *testCommand) tryRun(ctx context.Context, selectedCommand string, client
 	return true, trace.Wrap(t.run(ctx, client))
 }
 
-func (t *testCommand) run(ctx context.Context, c *authclient.Client) error {
+func (t *testCommand) run(ctx context.Context, c authclient.ClientI) error {
 	loginRules, err := parseLoginRuleFiles(t.inputResourceFiles)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/node_command.go
+++ b/tool/tctl/common/node_command.go
@@ -102,7 +102,7 @@ func (c *NodeCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 
 // TryRun takes the CLI command as an argument (like "nodes ls") and executes it.
 func (c *NodeCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
-	var commandFunc func(ctx context.Context, client *authclient.Client) error
+	var commandFunc func(ctx context.Context, client authclient.ClientI) error
 	switch cmd {
 	case c.nodeAdd.FullCommand():
 		commandFunc = c.Invite
@@ -145,7 +145,7 @@ Please note:
 
 // Invite generates a token which can be used to add another SSH node
 // to a cluster
-func (c *NodeCommand) Invite(ctx context.Context, client *authclient.Client) error {
+func (c *NodeCommand) Invite(ctx context.Context, client authclient.ClientI) error {
 	// parse --roles flag
 	roles, err := types.ParseTeleportRoles(c.roles)
 	if err != nil {
@@ -238,7 +238,7 @@ func (c *NodeCommand) Invite(ctx context.Context, client *authclient.Client) err
 
 // ListActive retrieves the list of nodes who recently sent heartbeats to
 // to a cluster and prints it to stdout
-func (c *NodeCommand) ListActive(ctx context.Context, clt *authclient.Client) error {
+func (c *NodeCommand) ListActive(ctx context.Context, clt authclient.ClientI) error {
 	labels, err := libclient.ParseLabelSpec(c.labels)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/notification_command.go
+++ b/tool/tctl/common/notification_command.go
@@ -101,7 +101,7 @@ func (n *NotificationCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Gl
 
 // TryRun takes the CLI command as an argument and executes it.
 func (n *NotificationCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
-	var commandFunc func(ctx context.Context, client *authclient.Client) error
+	var commandFunc func(ctx context.Context, client authclient.ClientI) error
 	switch cmd {
 	case n.create.FullCommand():
 		commandFunc = n.Create
@@ -122,7 +122,7 @@ func (n *NotificationCommand) TryRun(ctx context.Context, cmd string, clientFunc
 }
 
 // Create creates a new notification.
-func (n *NotificationCommand) Create(ctx context.Context, client *authclient.Client) error {
+func (n *NotificationCommand) Create(ctx context.Context, client authclient.ClientI) error {
 	labels, err := libclient.ParseLabelSpec(n.labels)
 	if err != nil {
 		return trace.Wrap(err)
@@ -239,7 +239,7 @@ func (n *NotificationCommand) Create(ctx context.Context, client *authclient.Cli
 	return nil
 }
 
-func (n *NotificationCommand) List(ctx context.Context, client *authclient.Client) error {
+func (n *NotificationCommand) List(ctx context.Context, client authclient.ClientI) error {
 	labels, err := libclient.ParseLabelSpec(n.labels)
 	if err != nil {
 		return trace.Wrap(err)
@@ -316,7 +316,7 @@ func displayNotifications(format string, notifications []*notificationspb.Notifi
 }
 
 // Remove removes a notification.
-func (n *NotificationCommand) Remove(ctx context.Context, client *authclient.Client) error {
+func (n *NotificationCommand) Remove(ctx context.Context, client authclient.ClientI) error {
 	// Prompt for admin action MFA re-auth.
 	mfaResponse, err := mfa.PerformAdminActionMFACeremony(ctx, client.PerformMFACeremony, true /*allowReuse*/)
 	if err == nil {

--- a/tool/tctl/common/proxy_command.go
+++ b/tool/tctl/common/proxy_command.go
@@ -51,7 +51,7 @@ func (p *ProxyCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLI
 }
 
 // ListProxies prints currently connected proxies
-func (p *ProxyCommand) ListProxies(ctx context.Context, clusterAPI *authclient.Client) error {
+func (p *ProxyCommand) ListProxies(ctx context.Context, clusterAPI authclient.ClientI) error {
 	proxies, err := clusterAPI.GetProxies()
 	if err != nil {
 		return trace.Wrap(err)
@@ -75,7 +75,7 @@ func (p *ProxyCommand) ListProxies(ctx context.Context, clusterAPI *authclient.C
 
 // TryRun runs the proxy command
 func (p *ProxyCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
-	var commandFunc func(ctx context.Context, client *authclient.Client) error
+	var commandFunc func(ctx context.Context, client authclient.ClientI) error
 	switch cmd {
 	case p.lsCmd.FullCommand():
 		commandFunc = p.ListProxies

--- a/tool/tctl/common/recordings_command.go
+++ b/tool/tctl/common/recordings_command.go
@@ -71,7 +71,7 @@ func (c *RecordingsCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Glob
 
 // TryRun attempts to run subcommands like "recordings ls".
 func (c *RecordingsCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
-	var commandFunc func(ctx context.Context, client *authclient.Client) error
+	var commandFunc func(ctx context.Context, client authclient.ClientI) error
 	switch cmd {
 	case c.recordingsList.FullCommand():
 		commandFunc = c.ListRecordings
@@ -88,7 +88,7 @@ func (c *RecordingsCommand) TryRun(ctx context.Context, cmd string, clientFunc c
 	return true, trace.Wrap(err)
 }
 
-func (c *RecordingsCommand) ListRecordings(ctx context.Context, tc *authclient.Client) error {
+func (c *RecordingsCommand) ListRecordings(ctx context.Context, tc authclient.ClientI) error {
 	fromUTC, toUTC, err := defaults.SearchSessionRange(clockwork.NewRealClock(), c.fromUTC, c.toUTC, c.recordingsSince)
 	if err != nil {
 		return trace.Errorf("cannot request recordings: %v", err)

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -81,7 +81,7 @@ import (
 )
 
 // ResourceCreateHandler is the generic implementation of a resource creation handler
-type ResourceCreateHandler func(context.Context, *authclient.Client, services.UnknownResource) error
+type ResourceCreateHandler func(context.Context, authclient.ClientI, services.UnknownResource) error
 
 // ResourceKind is the string form of a resource, i.e. "oidc"
 type ResourceKind string
@@ -248,7 +248,7 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Globa
 // TryRun takes the CLI command as an argument (like "auth gen") and executes it
 // or returns match=false if 'cmd' does not belong to it
 func (rc *ResourceCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
-	var commandFunc func(ctx context.Context, client *authclient.Client) error
+	var commandFunc func(ctx context.Context, client authclient.ClientI) error
 	switch cmd {
 	// tctl get
 	case rc.getCmd.FullCommand():
@@ -287,7 +287,7 @@ func (rc *ResourceCommand) GetRef() services.Ref {
 }
 
 // Get prints one or many resources of a certain type
-func (rc *ResourceCommand) Get(ctx context.Context, client *authclient.Client) error {
+func (rc *ResourceCommand) Get(ctx context.Context, client authclient.ClientI) error {
 	if rc.refs.IsAll() {
 		return rc.GetAll(ctx, client)
 	}
@@ -313,7 +313,7 @@ func (rc *ResourceCommand) Get(ctx context.Context, client *authclient.Client) e
 	return trace.BadParameter("unsupported format")
 }
 
-func (rc *ResourceCommand) GetMany(ctx context.Context, client *authclient.Client) error {
+func (rc *ResourceCommand) GetMany(ctx context.Context, client authclient.ClientI) error {
 	if rc.format != teleport.YAML {
 		return trace.BadParameter("mixed resource types only support YAML formatting")
 	}
@@ -332,7 +332,7 @@ func (rc *ResourceCommand) GetMany(ctx context.Context, client *authclient.Clien
 	return nil
 }
 
-func (rc *ResourceCommand) GetAll(ctx context.Context, client *authclient.Client) error {
+func (rc *ResourceCommand) GetAll(ctx context.Context, client authclient.ClientI) error {
 	rc.withSecrets = true
 	allKinds := services.GetResourceMarshalerKinds()
 	allRefs := make([]services.Ref, 0, len(allKinds))
@@ -347,7 +347,7 @@ func (rc *ResourceCommand) GetAll(ctx context.Context, client *authclient.Client
 }
 
 // Create updates or inserts one or many resources
-func (rc *ResourceCommand) Create(ctx context.Context, client *authclient.Client) (err error) {
+func (rc *ResourceCommand) Create(ctx context.Context, client authclient.ClientI) (err error) {
 	var reader io.Reader
 	if rc.filename == "" {
 		reader = os.Stdin
@@ -392,7 +392,7 @@ func (rc *ResourceCommand) Create(ctx context.Context, client *authclient.Client
 }
 
 // createTrustedCluster implements `tctl create cluster.yaml` command
-func (rc *ResourceCommand) createTrustedCluster(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createTrustedCluster(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	tc, err := services.UnmarshalTrustedCluster(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -433,7 +433,7 @@ func (rc *ResourceCommand) createTrustedCluster(ctx context.Context, client *aut
 }
 
 // createCertAuthority creates certificate authority
-func (rc *ResourceCommand) createCertAuthority(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createCertAuthority(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	certAuthority, err := services.UnmarshalCertAuthority(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -446,7 +446,7 @@ func (rc *ResourceCommand) createCertAuthority(ctx context.Context, client *auth
 }
 
 // createGithubConnector creates a Github connector
-func (rc *ResourceCommand) createGithubConnector(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createGithubConnector(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	connector, err := services.UnmarshalGithubConnector(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -476,7 +476,7 @@ func (rc *ResourceCommand) createGithubConnector(ctx context.Context, client *au
 }
 
 // updateGithubConnector updates an existing Github connector.
-func (rc *ResourceCommand) updateGithubConnector(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) updateGithubConnector(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	connector, err := services.UnmarshalGithubConnector(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -490,7 +490,7 @@ func (rc *ResourceCommand) updateGithubConnector(ctx context.Context, client *au
 }
 
 // createRole implements `tctl create role.yaml` command.
-func (rc *ResourceCommand) createRole(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createRole(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	role, err := services.UnmarshalRole(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -525,7 +525,7 @@ func (rc *ResourceCommand) createRole(ctx context.Context, client *authclient.Cl
 	return nil
 }
 
-func (rc *ResourceCommand) updateRole(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) updateRole(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	role, err := services.UnmarshalRole(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -585,7 +585,7 @@ func warnAboutDynamicLabelsInDenyRule(ctx context.Context, logger *slog.Logger, 
 }
 
 // createUser implements `tctl create user.yaml` command.
-func (rc *ResourceCommand) createUser(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createUser(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	user, err := services.UnmarshalUser(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -622,7 +622,7 @@ func (rc *ResourceCommand) createUser(ctx context.Context, client *authclient.Cl
 	return nil
 }
 
-func (rc *ResourceCommand) createBot(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createBot(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	bot := &machineidv1pb.Bot{}
 	if err := protojson.Unmarshal(raw.Raw, bot); err != nil {
 		return trace.Wrap(err)
@@ -648,7 +648,7 @@ func (rc *ResourceCommand) createBot(ctx context.Context, client *authclient.Cli
 	return nil
 }
 
-func (rc *ResourceCommand) createDatabaseObjectImportRule(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createDatabaseObjectImportRule(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	rule, err := databaseobjectimportrule.UnmarshalJSON(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -673,7 +673,7 @@ func (rc *ResourceCommand) createDatabaseObjectImportRule(ctx context.Context, c
 	return nil
 }
 
-func (rc *ResourceCommand) createDatabaseObject(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createDatabaseObject(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	object, err := databaseobject.UnmarshalJSON(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -695,7 +695,7 @@ func (rc *ResourceCommand) createDatabaseObject(ctx context.Context, client *aut
 }
 
 // updateUser implements `tctl create user.yaml` command.
-func (rc *ResourceCommand) updateUser(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) updateUser(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	user, err := services.UnmarshalUser(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -710,7 +710,7 @@ func (rc *ResourceCommand) updateUser(ctx context.Context, client *authclient.Cl
 }
 
 // createAuthPreference implements `tctl create cap.yaml` command.
-func (rc *ResourceCommand) createAuthPreference(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createAuthPreference(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	newAuthPref, err := services.UnmarshalAuthPreference(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -731,7 +731,7 @@ func (rc *ResourceCommand) createAuthPreference(ctx context.Context, client *aut
 	return nil
 }
 
-func (rc *ResourceCommand) updateAuthPreference(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) updateAuthPreference(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	newAuthPref, err := services.UnmarshalAuthPreference(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -753,7 +753,7 @@ func (rc *ResourceCommand) updateAuthPreference(ctx context.Context, client *aut
 }
 
 // createClusterNetworkingConfig implements `tctl create netconfig.yaml` command.
-func (rc *ResourceCommand) createClusterNetworkingConfig(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createClusterNetworkingConfig(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	newNetConfig, err := services.UnmarshalClusterNetworkingConfig(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -775,7 +775,7 @@ func (rc *ResourceCommand) createClusterNetworkingConfig(ctx context.Context, cl
 }
 
 // updateClusterNetworkingConfig
-func (rc *ResourceCommand) updateClusterNetworkingConfig(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) updateClusterNetworkingConfig(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	newNetConfig, err := services.UnmarshalClusterNetworkingConfig(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -796,7 +796,7 @@ func (rc *ResourceCommand) updateClusterNetworkingConfig(ctx context.Context, cl
 	return nil
 }
 
-func (rc *ResourceCommand) createClusterMaintenanceConfig(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createClusterMaintenanceConfig(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	var cmc types.ClusterMaintenanceConfigV1
 	if err := utils.FastUnmarshal(raw.Raw, &cmc); err != nil {
 		return trace.Wrap(err)
@@ -820,7 +820,7 @@ func (rc *ResourceCommand) createClusterMaintenanceConfig(ctx context.Context, c
 }
 
 // createSessionRecordingConfig implements `tctl create recconfig.yaml` command.
-func (rc *ResourceCommand) createSessionRecordingConfig(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createSessionRecordingConfig(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	newRecConfig, err := services.UnmarshalSessionRecordingConfig(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -841,7 +841,7 @@ func (rc *ResourceCommand) createSessionRecordingConfig(ctx context.Context, cli
 	return nil
 }
 
-func (rc *ResourceCommand) updateSessionRecordingConfig(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) updateSessionRecordingConfig(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	newRecConfig, err := services.UnmarshalSessionRecordingConfig(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -863,7 +863,7 @@ func (rc *ResourceCommand) updateSessionRecordingConfig(ctx context.Context, cli
 }
 
 // createExternalAuditStorage implements `tctl create external_audit_storage` command.
-func (rc *ResourceCommand) createExternalAuditStorage(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createExternalAuditStorage(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	draft, err := services.UnmarshalExternalAuditStorage(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -884,7 +884,7 @@ func (rc *ResourceCommand) createExternalAuditStorage(ctx context.Context, clien
 }
 
 // createLock implements `tctl create lock.yaml` command.
-func (rc *ResourceCommand) createLock(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createLock(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	lock, err := services.UnmarshalLock(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -910,7 +910,7 @@ func (rc *ResourceCommand) createLock(ctx context.Context, client *authclient.Cl
 }
 
 // createNetworkRestrictions implements `tctl create net_restrict.yaml` command.
-func (rc *ResourceCommand) createNetworkRestrictions(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createNetworkRestrictions(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	newNetRestricts, err := services.UnmarshalNetworkRestrictions(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -923,7 +923,7 @@ func (rc *ResourceCommand) createNetworkRestrictions(ctx context.Context, client
 	return nil
 }
 
-func (rc *ResourceCommand) createWindowsDesktop(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createWindowsDesktop(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	wd, err := services.UnmarshalWindowsDesktop(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -937,7 +937,7 @@ func (rc *ResourceCommand) createWindowsDesktop(ctx context.Context, client *aut
 	return nil
 }
 
-func (rc *ResourceCommand) createDynamicWindowsDesktop(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createDynamicWindowsDesktop(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	wd, err := services.UnmarshalDynamicWindowsDesktop(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -961,7 +961,7 @@ func (rc *ResourceCommand) createDynamicWindowsDesktop(ctx context.Context, clie
 	return nil
 }
 
-func (rc *ResourceCommand) updateDynamicWindowsDesktop(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) updateDynamicWindowsDesktop(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	wd, err := services.UnmarshalDynamicWindowsDesktop(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -976,7 +976,7 @@ func (rc *ResourceCommand) updateDynamicWindowsDesktop(ctx context.Context, clie
 	return nil
 }
 
-func (rc *ResourceCommand) createAppServer(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createAppServer(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	appServer, err := services.UnmarshalAppServer(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -991,7 +991,7 @@ func (rc *ResourceCommand) createAppServer(ctx context.Context, client *authclie
 	return nil
 }
 
-func (rc *ResourceCommand) createApp(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createApp(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	app, err := services.UnmarshalApp(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1013,7 +1013,7 @@ func (rc *ResourceCommand) createApp(ctx context.Context, client *authclient.Cli
 	return nil
 }
 
-func (rc *ResourceCommand) createKubeCluster(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createKubeCluster(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	cluster, err := services.UnmarshalKubeCluster(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1035,7 +1035,7 @@ func (rc *ResourceCommand) createKubeCluster(ctx context.Context, client *authcl
 	return nil
 }
 
-func (rc *ResourceCommand) createCrownJewel(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createCrownJewel(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	crownJewel, err := services.UnmarshalCrownJewel(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1057,7 +1057,7 @@ func (rc *ResourceCommand) createCrownJewel(ctx context.Context, client *authcli
 	return nil
 }
 
-func (rc *ResourceCommand) createUserTask(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createUserTask(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	resource, err := services.UnmarshalUserTask(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1079,7 +1079,7 @@ func (rc *ResourceCommand) createUserTask(ctx context.Context, client *authclien
 	return nil
 }
 
-func (rc *ResourceCommand) createSPIFFEFederation(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createSPIFFEFederation(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	in, err := services.UnmarshalSPIFFEFederation(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1096,7 +1096,7 @@ func (rc *ResourceCommand) createSPIFFEFederation(ctx context.Context, client *a
 	return nil
 }
 
-func (rc *ResourceCommand) createWorkloadIdentity(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createWorkloadIdentity(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	in, err := services.UnmarshalWorkloadIdentity(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1122,7 +1122,7 @@ func (rc *ResourceCommand) createWorkloadIdentity(ctx context.Context, client *a
 	return nil
 }
 
-func (rc *ResourceCommand) updateCrownJewel(ctx context.Context, client *authclient.Client, resource services.UnknownResource) error {
+func (rc *ResourceCommand) updateCrownJewel(ctx context.Context, client authclient.ClientI, resource services.UnknownResource) error {
 	in, err := services.UnmarshalCrownJewel(resource.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1134,7 +1134,7 @@ func (rc *ResourceCommand) updateCrownJewel(ctx context.Context, client *authcli
 	return nil
 }
 
-func (rc *ResourceCommand) updateUserTask(ctx context.Context, client *authclient.Client, resource services.UnknownResource) error {
+func (rc *ResourceCommand) updateUserTask(ctx context.Context, client authclient.ClientI, resource services.UnknownResource) error {
 	in, err := services.UnmarshalUserTask(resource.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1146,7 +1146,7 @@ func (rc *ResourceCommand) updateUserTask(ctx context.Context, client *authclien
 	return nil
 }
 
-func (rc *ResourceCommand) createDatabase(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createDatabase(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	database, err := services.UnmarshalDatabase(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1169,7 +1169,7 @@ func (rc *ResourceCommand) createDatabase(ctx context.Context, client *authclien
 	return nil
 }
 
-func (rc *ResourceCommand) createToken(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createToken(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	token, err := services.UnmarshalProvisionToken(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1183,7 +1183,7 @@ func (rc *ResourceCommand) createToken(ctx context.Context, client *authclient.C
 	return nil
 }
 
-func (rc *ResourceCommand) createInstaller(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createInstaller(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	inst, err := services.UnmarshalInstaller(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1197,7 +1197,7 @@ func (rc *ResourceCommand) createInstaller(ctx context.Context, client *authclie
 	return nil
 }
 
-func (rc *ResourceCommand) createUIConfig(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createUIConfig(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	uic, err := services.UnmarshalUIConfig(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1210,7 +1210,7 @@ func (rc *ResourceCommand) createUIConfig(ctx context.Context, client *authclien
 	return nil
 }
 
-func (rc *ResourceCommand) createNode(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createNode(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	server, err := services.UnmarshalServer(raw.Raw, types.KindNode)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1238,7 +1238,7 @@ func (rc *ResourceCommand) createNode(ctx context.Context, client *authclient.Cl
 	return nil
 }
 
-func (rc *ResourceCommand) createOIDCConnector(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createOIDCConnector(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	conn, err := services.UnmarshalOIDCConnector(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1267,7 +1267,7 @@ func (rc *ResourceCommand) createOIDCConnector(ctx context.Context, client *auth
 }
 
 // updateGithubConnector updates an existing OIDC connector.
-func (rc *ResourceCommand) updateOIDCConnector(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) updateOIDCConnector(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	connector, err := services.UnmarshalOIDCConnector(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1280,7 +1280,7 @@ func (rc *ResourceCommand) updateOIDCConnector(ctx context.Context, client *auth
 	return nil
 }
 
-func (rc *ResourceCommand) createSAMLConnector(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createSAMLConnector(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	// Create services.SAMLConnector from raw YAML to extract the connector name.
 	conn, err := services.UnmarshalSAMLConnector(raw.Raw)
 	if err != nil {
@@ -1312,7 +1312,7 @@ func (rc *ResourceCommand) createSAMLConnector(ctx context.Context, client *auth
 	return nil
 }
 
-func (rc *ResourceCommand) updateSAMLConnector(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) updateSAMLConnector(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	// Create services.SAMLConnector from raw YAML to extract the connector name.
 	conn, err := services.UnmarshalSAMLConnector(raw.Raw)
 	if err != nil {
@@ -1326,7 +1326,7 @@ func (rc *ResourceCommand) updateSAMLConnector(ctx context.Context, client *auth
 	return nil
 }
 
-func (rc *ResourceCommand) createLoginRule(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createLoginRule(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	rule, err := loginrule.UnmarshalLoginRule(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1353,7 +1353,7 @@ func (rc *ResourceCommand) createLoginRule(ctx context.Context, client *authclie
 	return nil
 }
 
-func (rc *ResourceCommand) createSAMLIdPServiceProvider(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createSAMLIdPServiceProvider(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	// Create services.SAMLIdPServiceProvider from raw YAML to extract the service provider name.
 	sp, err := services.UnmarshalSAMLIdPServiceProvider(raw.Raw)
 	if err != nil {
@@ -1393,7 +1393,7 @@ func (rc *ResourceCommand) createSAMLIdPServiceProvider(ctx context.Context, cli
 	return nil
 }
 
-func (rc *ResourceCommand) createDevice(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createDevice(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	res, err := services.UnmarshalDevice(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1433,7 +1433,7 @@ func (rc *ResourceCommand) createDevice(ctx context.Context, client *authclient.
 	return nil
 }
 
-func (rc *ResourceCommand) createOktaImportRule(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createOktaImportRule(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	importRule, err := services.UnmarshalOktaImportRule(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1454,7 +1454,7 @@ func (rc *ResourceCommand) createOktaImportRule(ctx context.Context, client *aut
 	return nil
 }
 
-func (rc *ResourceCommand) createIntegration(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createIntegration(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	integration, err := services.UnmarshalIntegration(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1504,7 +1504,7 @@ func (rc *ResourceCommand) createIntegration(ctx context.Context, client *authcl
 	return nil
 }
 
-func (rc *ResourceCommand) createDiscoveryConfig(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createDiscoveryConfig(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	discoveryConfig, err := services.UnmarshalDiscoveryConfig(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1529,7 +1529,7 @@ func (rc *ResourceCommand) createDiscoveryConfig(ctx context.Context, client *au
 	return nil
 }
 
-func (rc *ResourceCommand) createAccessList(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createAccessList(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	accessList, err := services.UnmarshalAccessList(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1553,7 +1553,7 @@ func (rc *ResourceCommand) createAccessList(ctx context.Context, client *authcli
 	return nil
 }
 
-func (rc *ResourceCommand) createServerInfo(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createServerInfo(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	si, err := services.UnmarshalServerInfo(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1581,7 +1581,7 @@ func (rc *ResourceCommand) createServerInfo(ctx context.Context, client *authcli
 	return nil
 }
 
-func (rc *ResourceCommand) createStaticHostUser(ctx context.Context, client *authclient.Client, resource services.UnknownResource) error {
+func (rc *ResourceCommand) createStaticHostUser(ctx context.Context, client authclient.ClientI, resource services.UnknownResource) error {
 	hostUser, err := services.UnmarshalProtoResource[*userprovisioningpb.StaticHostUser](resource.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1602,7 +1602,7 @@ func (rc *ResourceCommand) createStaticHostUser(ctx context.Context, client *aut
 	return nil
 }
 
-func (rc *ResourceCommand) updateStaticHostUser(ctx context.Context, client *authclient.Client, resource services.UnknownResource) error {
+func (rc *ResourceCommand) updateStaticHostUser(ctx context.Context, client authclient.ClientI, resource services.UnknownResource) error {
 	hostUser, err := services.UnmarshalProtoResource[*userprovisioningpb.StaticHostUser](resource.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1615,7 +1615,7 @@ func (rc *ResourceCommand) updateStaticHostUser(ctx context.Context, client *aut
 }
 
 // Delete deletes resource by name
-func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client) (err error) {
+func (rc *ResourceCommand) Delete(ctx context.Context, client authclient.ClientI) (err error) {
 	singletonResources := []string{
 		types.KindClusterAuthPreference,
 		types.KindClusterMaintenanceConfig,
@@ -2060,7 +2060,7 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 	return nil
 }
 
-func resetAuthPreference(ctx context.Context, client *authclient.Client) error {
+func resetAuthPreference(ctx context.Context, client authclient.ClientI) error {
 	storedAuthPref, err := client.GetAuthPreference(ctx)
 	if err != nil {
 		return trace.Wrap(err)
@@ -2074,7 +2074,7 @@ func resetAuthPreference(ctx context.Context, client *authclient.Client) error {
 	return trace.Wrap(client.ResetAuthPreference(ctx))
 }
 
-func resetClusterNetworkingConfig(ctx context.Context, client *authclient.Client) error {
+func resetClusterNetworkingConfig(ctx context.Context, client authclient.ClientI) error {
 	storedNetConfig, err := client.GetClusterNetworkingConfig(ctx)
 	if err != nil {
 		return trace.Wrap(err)
@@ -2088,7 +2088,7 @@ func resetClusterNetworkingConfig(ctx context.Context, client *authclient.Client
 	return trace.Wrap(client.ResetClusterNetworkingConfig(ctx))
 }
 
-func resetSessionRecordingConfig(ctx context.Context, client *authclient.Client) error {
+func resetSessionRecordingConfig(ctx context.Context, client authclient.ClientI) error {
 	storedRecConfig, err := client.GetSessionRecordingConfig(ctx)
 	if err != nil {
 		return trace.Wrap(err)
@@ -2102,12 +2102,12 @@ func resetSessionRecordingConfig(ctx context.Context, client *authclient.Client)
 	return trace.Wrap(client.ResetSessionRecordingConfig(ctx))
 }
 
-func resetNetworkRestrictions(ctx context.Context, client *authclient.Client) error {
+func resetNetworkRestrictions(ctx context.Context, client authclient.ClientI) error {
 	return trace.Wrap(client.DeleteNetworkRestrictions(ctx))
 }
 
 // UpdateFields updates select resource fields: expiry and labels
-func (rc *ResourceCommand) UpdateFields(ctx context.Context, clt *authclient.Client) error {
+func (rc *ResourceCommand) UpdateFields(ctx context.Context, clt authclient.ClientI) error {
 	if rc.ref.Kind == "" || rc.ref.Name == "" {
 		return trace.BadParameter("provide a full resource name to update, for example:\n$ tctl update rc/remote --set-labels=env=prod\n")
 	}
@@ -2164,7 +2164,7 @@ func (rc *ResourceCommand) IsForced() bool {
 }
 
 // getCollection lists all resources of a given type
-func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient.Client) (ResourceCollection, error) {
+func (rc *ResourceCommand) getCollection(ctx context.Context, client authclient.ClientI) (ResourceCollection, error) {
 	if rc.ref.Kind == "" {
 		return nil, trace.BadParameter("specify resource to list, e.g. 'tctl get roles'")
 	}
@@ -3345,7 +3345,7 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 	return nil, trace.BadParameter("getting %q is not supported", rc.ref.String())
 }
 
-func getSAMLConnectors(ctx context.Context, client *authclient.Client, name string, withSecrets bool) ([]types.SAMLConnector, error) {
+func getSAMLConnectors(ctx context.Context, client authclient.ClientI, name string, withSecrets bool) ([]types.SAMLConnector, error) {
 	if name == "" {
 		connectors, err := client.GetSAMLConnectors(ctx, withSecrets)
 		if err != nil {
@@ -3360,7 +3360,7 @@ func getSAMLConnectors(ctx context.Context, client *authclient.Client, name stri
 	return []types.SAMLConnector{connector}, nil
 }
 
-func getOIDCConnectors(ctx context.Context, client *authclient.Client, name string, withSecrets bool) ([]types.OIDCConnector, error) {
+func getOIDCConnectors(ctx context.Context, client authclient.ClientI, name string, withSecrets bool) ([]types.OIDCConnector, error) {
 	if name == "" {
 		connectors, err := client.GetOIDCConnectors(ctx, withSecrets)
 		if err != nil {
@@ -3375,7 +3375,7 @@ func getOIDCConnectors(ctx context.Context, client *authclient.Client, name stri
 	return []types.OIDCConnector{connector}, nil
 }
 
-func getGithubConnectors(ctx context.Context, client *authclient.Client, name string, withSecrets bool) ([]types.GithubConnector, error) {
+func getGithubConnectors(ctx context.Context, client authclient.ClientI, name string, withSecrets bool) ([]types.GithubConnector, error) {
 	if name == "" {
 		connectors, err := client.GetGithubConnectors(ctx, withSecrets)
 		if err != nil {
@@ -3539,7 +3539,7 @@ $ tctl rm %s`,
 		ref.String(), resDesc, strings.Join(names, "\n"), exampleRef.String())
 }
 
-func (rc *ResourceCommand) createAuditQuery(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createAuditQuery(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	in, err := services.UnmarshalAuditQuery(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -3555,7 +3555,7 @@ func (rc *ResourceCommand) createAuditQuery(ctx context.Context, client *authcli
 	return nil
 }
 
-func (rc *ResourceCommand) createSecurityReport(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createSecurityReport(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	in, err := services.UnmarshalSecurityReport(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -3571,7 +3571,7 @@ func (rc *ResourceCommand) createSecurityReport(ctx context.Context, client *aut
 	return nil
 }
 
-func (rc *ResourceCommand) createAccessMonitoringRule(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createAccessMonitoringRule(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	in, err := services.UnmarshalAccessMonitoringRule(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -3593,7 +3593,7 @@ func (rc *ResourceCommand) createAccessMonitoringRule(ctx context.Context, clien
 	return nil
 }
 
-func (rc *ResourceCommand) updateAccessMonitoringRule(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) updateAccessMonitoringRule(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	in, err := services.UnmarshalAccessMonitoringRule(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -3605,7 +3605,7 @@ func (rc *ResourceCommand) updateAccessMonitoringRule(ctx context.Context, clien
 	return nil
 }
 
-func (rc *ResourceCommand) createVnetConfig(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createVnetConfig(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	vnetConfig, err := services.UnmarshalProtoResource[*vnet.VnetConfig](raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -3624,7 +3624,7 @@ func (rc *ResourceCommand) createVnetConfig(ctx context.Context, client *authcli
 	return nil
 }
 
-func (rc *ResourceCommand) updateVnetConfig(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) updateVnetConfig(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	vnetConfig, err := services.UnmarshalProtoResource[*vnet.VnetConfig](raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -3636,7 +3636,7 @@ func (rc *ResourceCommand) updateVnetConfig(ctx context.Context, client *authcli
 	return nil
 }
 
-func (rc *ResourceCommand) updatePlugin(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) updatePlugin(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	item := pluginResourceWrapper{PluginV1: types.PluginV1{}}
 	if err := utils.FastUnmarshal(raw.Raw, &item); err != nil {
 		return trace.Wrap(err)
@@ -3647,7 +3647,7 @@ func (rc *ResourceCommand) updatePlugin(ctx context.Context, client *authclient.
 	return nil
 }
 
-func (rc *ResourceCommand) createPlugin(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createPlugin(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	item := pluginResourceWrapper{
 		PluginV1: types.PluginV1{},
 	}
@@ -3665,7 +3665,7 @@ func (rc *ResourceCommand) createPlugin(ctx context.Context, client *authclient.
 	return nil
 }
 
-func (rc *ResourceCommand) upsertAccessGraphSettings(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) upsertAccessGraphSettings(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	settings, err := clusterconfigrec.UnmarshalAccessGraphSettings(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -3679,7 +3679,7 @@ func (rc *ResourceCommand) upsertAccessGraphSettings(ctx context.Context, client
 	return nil
 }
 
-func (rc *ResourceCommand) updateAccessGraphSettings(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) updateAccessGraphSettings(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	settings, err := clusterconfigrec.UnmarshalAccessGraphSettings(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -3692,7 +3692,7 @@ func (rc *ResourceCommand) updateAccessGraphSettings(ctx context.Context, client
 	return nil
 }
 
-func (rc *ResourceCommand) createAutoUpdateConfig(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createAutoUpdateConfig(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	config, err := services.UnmarshalProtoResource[*autoupdatev1pb.AutoUpdateConfig](raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -3711,7 +3711,7 @@ func (rc *ResourceCommand) createAutoUpdateConfig(ctx context.Context, client *a
 	return nil
 }
 
-func (rc *ResourceCommand) updateAutoUpdateConfig(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) updateAutoUpdateConfig(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	config, err := services.UnmarshalProtoResource[*autoupdatev1pb.AutoUpdateConfig](raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -3723,7 +3723,7 @@ func (rc *ResourceCommand) updateAutoUpdateConfig(ctx context.Context, client *a
 	return nil
 }
 
-func (rc *ResourceCommand) createAutoUpdateVersion(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createAutoUpdateVersion(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	version, err := services.UnmarshalProtoResource[*autoupdatev1pb.AutoUpdateVersion](raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -3742,7 +3742,7 @@ func (rc *ResourceCommand) createAutoUpdateVersion(ctx context.Context, client *
 	return nil
 }
 
-func (rc *ResourceCommand) updateAutoUpdateVersion(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) updateAutoUpdateVersion(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	version, err := services.UnmarshalProtoResource[*autoupdatev1pb.AutoUpdateVersion](raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -3754,7 +3754,7 @@ func (rc *ResourceCommand) updateAutoUpdateVersion(ctx context.Context, client *
 	return nil
 }
 
-func (rc *ResourceCommand) createAutoUpdateAgentRollout(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createAutoUpdateAgentRollout(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	version, err := services.UnmarshalProtoResource[*autoupdatev1pb.AutoUpdateAgentRollout](raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -3773,7 +3773,7 @@ func (rc *ResourceCommand) createAutoUpdateAgentRollout(ctx context.Context, cli
 	return nil
 }
 
-func (rc *ResourceCommand) updateAutoUpdateAgentRollout(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) updateAutoUpdateAgentRollout(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	version, err := services.UnmarshalProtoResource[*autoupdatev1pb.AutoUpdateAgentRollout](raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -3785,7 +3785,7 @@ func (rc *ResourceCommand) updateAutoUpdateAgentRollout(ctx context.Context, cli
 	return nil
 }
 
-func (rc *ResourceCommand) createGitServer(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) createGitServer(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	server, err := services.UnmarshalGitServer(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)
@@ -3801,7 +3801,7 @@ func (rc *ResourceCommand) createGitServer(ctx context.Context, client *authclie
 	fmt.Printf("git server %q has been created\n", server.GetName())
 	return nil
 }
-func (rc *ResourceCommand) updateGitServer(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+func (rc *ResourceCommand) updateGitServer(ctx context.Context, client authclient.ClientI, raw services.UnknownResource) error {
 	server, err := services.UnmarshalGitServer(raw.Raw)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/saml_command.go
+++ b/tool/tctl/common/saml_command.go
@@ -66,7 +66,7 @@ func (cmd *SAMLCommand) TryRun(ctx context.Context, selectedCommand string, clie
 }
 
 // export executes 'tctl saml export <connector_name>'
-func (cmd *SAMLCommand) export(ctx context.Context, c *authclient.Client) error {
+func (cmd *SAMLCommand) export(ctx context.Context, c authclient.ClientI) error {
 	sc, err := c.GetSAMLConnector(ctx, cmd.connectorName, false)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/status_command.go
+++ b/tool/tctl/common/status_command.go
@@ -63,7 +63,7 @@ func (c *StatusCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCL
 
 // TryRun takes the CLI command as an argument (like "nodes ls") and executes it.
 func (c *StatusCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
-	var commandFunc func(ctx context.Context, client *authclient.Client) error
+	var commandFunc func(ctx context.Context, client authclient.ClientI) error
 	switch cmd {
 	case c.status.FullCommand():
 		commandFunc = c.Status
@@ -81,7 +81,7 @@ func (c *StatusCommand) TryRun(ctx context.Context, cmd string, clientFunc commo
 }
 
 // Status is called to execute "status" CLI command.
-func (c *StatusCommand) Status(ctx context.Context, client *authclient.Client) error {
+func (c *StatusCommand) Status(ctx context.Context, client authclient.ClientI) error {
 	pingResp, err := client.Ping(ctx)
 	if err != nil {
 		return trace.Wrap(err)
@@ -102,7 +102,7 @@ type statusModel struct {
 	authorities []*authorityStatusModel
 }
 
-func newStatusModel(ctx context.Context, client *authclient.Client, pingResp proto.PingResponse) (*statusModel, error) {
+func newStatusModel(ctx context.Context, client authclient.ClientI, pingResp proto.PingResponse) (*statusModel, error) {
 	var authorities []types.CertAuthority
 	for _, caType := range types.CertAuthTypes {
 		cas, err := client.GetCertAuthorities(ctx, caType, false)

--- a/tool/tctl/common/tctl_test.go
+++ b/tool/tctl/common/tctl_test.go
@@ -60,7 +60,7 @@ func TestCommandMatchBeforeAuthConnect(t *testing.T) {
 	testError := errors.New("auth client must not be initialized before match")
 
 	ctx := context.Background()
-	clientFunc := func(ctx context.Context) (client *authclient.Client, close func(context.Context), err error) {
+	clientFunc := func(ctx context.Context) (client authclient.ClientI, close func(context.Context), err error) {
 		return nil, nil, testError
 	}
 

--- a/tool/tctl/common/terraform_command.go
+++ b/tool/tctl/common/terraform_command.go
@@ -131,7 +131,7 @@ func (c *TerraformCommand) TryRun(ctx context.Context, cmd string, clientFunc co
 // - exports certificates and Terraform configuration in environment variables
 // envOutput and userOutput parameters are respectively stdout and stderr,
 // except during tests where we want to catch the command output.
-func (c *TerraformCommand) RunEnvCommand(ctx context.Context, client *authclient.Client, envOutput, userOutput io.Writer) error {
+func (c *TerraformCommand) RunEnvCommand(ctx context.Context, client authclient.ClientI, envOutput, userOutput io.Writer) error {
 	// If we're not actively debugging, suppress any kind of logging from other teleport components
 	if !c.cfg.Debug {
 		utils.InitLogger(utils.LoggingForCLI, slog.LevelError)
@@ -217,7 +217,7 @@ If you got a role granted recently, you might have to run "tsh logout" and login
 // createTransientBotAndToken creates a Bot resource and a secret Token.
 // The token is single use (secret tokens are consumed on MachineID join)
 // and the bot expires after the given TTL.
-func (c *TerraformCommand) createTransientBotAndToken(ctx context.Context, client *authclient.Client, roleName string) (string, error) {
+func (c *TerraformCommand) createTransientBotAndToken(ctx context.Context, client authclient.ClientI, roleName string) (string, error) {
 	// Create token and bot name
 	suffix, err := utils.CryptoRandomHex(4)
 	if err != nil {
@@ -295,7 +295,7 @@ func (c *TerraformCommand) checkIfRoleExists(ctx context.Context, client roleCli
 // Later, the Terraform provider will read those environment variables to build its Teleport client.
 // Note: the function also returns the SSH Host CA cert encoded in the known host format.
 // The identity.Identity uses a different format (authorized keys).
-func (c *TerraformCommand) useBotToObtainIdentity(ctx context.Context, addr utils.NetAddr, token string, clt *authclient.Client) (*identity.Identity, [][]byte, error) {
+func (c *TerraformCommand) useBotToObtainIdentity(ctx context.Context, addr utils.NetAddr, token string, clt authclient.ClientI) (*identity.Identity, [][]byte, error) {
 	credential := &config.UnstableClientCredentialOutput{}
 	cfg := &config.BotConfig{
 		Version: "",

--- a/tool/tctl/common/token_command.go
+++ b/tool/tctl/common/token_command.go
@@ -151,7 +151,7 @@ func (c *TokensCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCL
 
 // TryRun takes the CLI command as an argument (like "nodes ls") and executes it.
 func (c *TokensCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
-	var commandFunc func(ctx context.Context, client *authclient.Client) error
+	var commandFunc func(ctx context.Context, client authclient.ClientI) error
 	switch cmd {
 	case c.tokenAdd.FullCommand():
 		commandFunc = c.Add
@@ -173,7 +173,7 @@ func (c *TokensCommand) TryRun(ctx context.Context, cmd string, clientFunc commo
 }
 
 // Add is called to execute "tokens add ..." command.
-func (c *TokensCommand) Add(ctx context.Context, client *authclient.Client) error {
+func (c *TokensCommand) Add(ctx context.Context, client authclient.ClientI) error {
 	// Parse string to see if it's a type of role that Teleport supports.
 	roles, err := types.ParseTeleportRoles(c.tokenType)
 	if err != nil {
@@ -375,7 +375,7 @@ func (c *TokensCommand) Add(ctx context.Context, client *authclient.Client) erro
 }
 
 // Del is called to execute "tokens del ..." command.
-func (c *TokensCommand) Del(ctx context.Context, client *authclient.Client) error {
+func (c *TokensCommand) Del(ctx context.Context, client authclient.ClientI) error {
 	if c.value == "" {
 		return trace.Errorf("Need an argument: token")
 	}
@@ -387,7 +387,7 @@ func (c *TokensCommand) Del(ctx context.Context, client *authclient.Client) erro
 }
 
 // List is called to execute "tokens ls" command.
-func (c *TokensCommand) List(ctx context.Context, client *authclient.Client) error {
+func (c *TokensCommand) List(ctx context.Context, client authclient.ClientI) error {
 	labels, err := libclient.ParseLabelSpec(c.labels)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/user_command.go
+++ b/tool/tctl/common/user_command.go
@@ -156,7 +156,7 @@ func (u *UserCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 
 // TryRun takes the CLI command as an argument (like "users add") and executes it.
 func (u *UserCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
-	var commandFunc func(ctx context.Context, client *authclient.Client) error
+	var commandFunc func(ctx context.Context, client authclient.ClientI) error
 	switch cmd {
 	case u.userAdd.FullCommand():
 		commandFunc = u.Add
@@ -182,7 +182,7 @@ func (u *UserCommand) TryRun(ctx context.Context, cmd string, clientFunc commonc
 }
 
 // ResetPassword resets user password and generates a token to setup new password
-func (u *UserCommand) ResetPassword(ctx context.Context, client *authclient.Client) error {
+func (u *UserCommand) ResetPassword(ctx context.Context, client authclient.ClientI) error {
 	req := authclient.CreateUserTokenRequest{
 		Name: u.login,
 		TTL:  u.ttl,
@@ -244,7 +244,7 @@ func (u *UserCommand) printResetPasswordToken(token types.UserToken, messageForm
 
 // Add implements `tctl users add` for the enterprise edition. Unlike the OSS
 // version, this one requires --roles flag to be set
-func (u *UserCommand) Add(ctx context.Context, client *authclient.Client) error {
+func (u *UserCommand) Add(ctx context.Context, client authclient.ClientI) error {
 	u.allowedRoles = flattenSlice(u.allowedRoles)
 	u.allowedLogins = flattenSlice(u.allowedLogins)
 	u.allowedWindowsLogins = flattenSlice(u.allowedWindowsLogins)
@@ -374,7 +374,7 @@ func printTokenAsText(token types.UserToken, messageFormat string) error {
 }
 
 // Update updates existing user
-func (u *UserCommand) Update(ctx context.Context, client *authclient.Client) error {
+func (u *UserCommand) Update(ctx context.Context, client authclient.ClientI) error {
 	user, err := client.GetUser(ctx, u.login, false)
 	if err != nil {
 		return trace.Wrap(err)
@@ -500,7 +500,7 @@ func (u *UserCommand) Update(ctx context.Context, client *authclient.Client) err
 }
 
 // List prints all existing user accounts
-func (u *UserCommand) List(ctx context.Context, client *authclient.Client) error {
+func (u *UserCommand) List(ctx context.Context, client authclient.ClientI) error {
 	users, err := client.GetUsers(ctx, false)
 	if err != nil {
 		return trace.Wrap(err)
@@ -529,7 +529,7 @@ func (u *UserCommand) List(ctx context.Context, client *authclient.Client) error
 
 // Delete deletes teleport user(s). User IDs are passed as a comma-separated
 // list in UserCommand.login
-func (u *UserCommand) Delete(ctx context.Context, client *authclient.Client) error {
+func (u *UserCommand) Delete(ctx context.Context, client authclient.ClientI) error {
 	for _, l := range strings.Split(u.login, ",") {
 		if err := client.DeleteUser(ctx, l); err != nil {
 			return trace.Wrap(err)

--- a/tool/tctl/common/workload_identity_command.go
+++ b/tool/tctl/common/workload_identity_command.go
@@ -88,7 +88,7 @@ func (c *WorkloadIdentityCommand) Initialize(
 func (c *WorkloadIdentityCommand) TryRun(
 	ctx context.Context, cmd string, clientFunc commonclient.InitFunc,
 ) (match bool, err error) {
-	var commandFunc func(ctx context.Context, client *authclient.Client) error
+	var commandFunc func(ctx context.Context, client authclient.ClientI) error
 	switch cmd {
 	case c.listCmd.FullCommand():
 		commandFunc = c.ListWorkloadIdentities
@@ -110,7 +110,7 @@ func (c *WorkloadIdentityCommand) TryRun(
 
 func (c *WorkloadIdentityCommand) DeleteWorkloadIdentity(
 	ctx context.Context,
-	client *authclient.Client,
+	client authclient.ClientI,
 ) error {
 	workloadIdentityClient := client.WorkloadIdentityResourceServiceClient()
 	_, err := workloadIdentityClient.DeleteWorkloadIdentity(
@@ -132,7 +132,7 @@ func (c *WorkloadIdentityCommand) DeleteWorkloadIdentity(
 
 // ListWorkloadIdentities writes a listing of the WorkloadIdentity resources
 func (c *WorkloadIdentityCommand) ListWorkloadIdentities(
-	ctx context.Context, client *authclient.Client,
+	ctx context.Context, client authclient.ClientI,
 ) error {
 	workloadIdentityClient := client.WorkloadIdentityResourceServiceClient()
 	var workloadIdentities []*workloadidentityv1pb.WorkloadIdentity

--- a/tool/tctl/sso/configure/command.go
+++ b/tool/tctl/sso/configure/command.go
@@ -45,7 +45,7 @@ type SSOConfigureCommand struct {
 
 type AuthKindCommand struct {
 	Parsed bool
-	Run    func(ctx context.Context, clt *authclient.Client) error
+	Run    func(ctx context.Context, clt authclient.ClientI) error
 }
 
 // Initialize allows a caller-defined command to plug itself into CLI

--- a/tool/tctl/sso/configure/github.go
+++ b/tool/tctl/sso/configure/github.go
@@ -87,7 +87,7 @@ Examples:
   Generate the configuration and immediately test it using "tctl sso test" command.`)
 
 	preset := &AuthKindCommand{
-		Run: func(ctx context.Context, clt *authclient.Client) error { return ghRunFunc(ctx, cmd, &spec, gh, clt) },
+		Run: func(ctx context.Context, clt authclient.ClientI) error { return ghRunFunc(ctx, cmd, &spec, gh, clt) },
 	}
 
 	sub.Action(func(ctx *kingpin.ParseContext) error {
@@ -98,7 +98,7 @@ Examples:
 	return preset
 }
 
-func ghRunFunc(ctx context.Context, cmd *SSOConfigureCommand, spec *types.GithubConnectorSpecV3, flags *ghExtraFlags, clt *authclient.Client) error {
+func ghRunFunc(ctx context.Context, cmd *SSOConfigureCommand, spec *types.GithubConnectorSpecV3, flags *ghExtraFlags, clt authclient.ClientI) error {
 	if err := specCheckRoles(ctx, cmd.Logger, spec, flags.ignoreMissingRoles, clt); err != nil {
 		return trace.Wrap(err)
 	}
@@ -115,7 +115,7 @@ func ghRunFunc(ctx context.Context, cmd *SSOConfigureCommand, spec *types.Github
 }
 
 // ResolveCallbackURL deals with common pattern of resolving callback URL for IdP to use.
-func ResolveCallbackURL(ctx context.Context, logger *slog.Logger, clt *authclient.Client, fieldName string, callbackPattern string) string {
+func ResolveCallbackURL(ctx context.Context, logger *slog.Logger, clt authclient.ClientI, fieldName string, callbackPattern string) string {
 	var callbackURL string
 
 	logger.InfoContext(ctx, "resolving callback url automatically", "field_name", fieldName)
@@ -142,7 +142,7 @@ func ResolveCallbackURL(ctx context.Context, logger *slog.Logger, clt *authclien
 	return callbackURL
 }
 
-func specCheckRoles(ctx context.Context, logger *slog.Logger, spec *types.GithubConnectorSpecV3, ignoreMissingRoles bool, clt *authclient.Client) error {
+func specCheckRoles(ctx context.Context, logger *slog.Logger, spec *types.GithubConnectorSpecV3, ignoreMissingRoles bool, clt authclient.ClientI) error {
 	allRoles, err := clt.GetRoles(ctx)
 	if err != nil {
 		logger.WarnContext(ctx, "Unable to get roles list, skipping teams-to-roles sanity checks", "error", err)

--- a/tool/tctl/sso/configure/oidc.go
+++ b/tool/tctl/sso/configure/oidc.go
@@ -206,7 +206,7 @@ Examples:
   Generate the configuration and immediately test it using "tctl sso test" command.`, presets))
 
 	preset := &AuthKindCommand{
-		Run: func(ctx context.Context, clt *authclient.Client) error {
+		Run: func(ctx context.Context, clt authclient.ClientI) error {
 			return oidcRunFunc(ctx, cmd, &spec, extra, clt)
 		},
 	}
@@ -219,7 +219,7 @@ Examples:
 	return preset
 }
 
-func oidcRunFunc(ctx context.Context, cmd *SSOConfigureCommand, spec *types.OIDCConnectorSpecV3, flags *oidcExtraFlags, clt *authclient.Client) error {
+func oidcRunFunc(ctx context.Context, cmd *SSOConfigureCommand, spec *types.OIDCConnectorSpecV3, flags *oidcExtraFlags, clt authclient.ClientI) error {
 	if flags.googleID != "" {
 		if spec.ClientID != "" {
 			return trace.BadParameter("Conflicting flags: --id and --google-id. Provide only one.")

--- a/tool/tctl/sso/configure/saml.go
+++ b/tool/tctl/sso/configure/saml.go
@@ -153,7 +153,7 @@ Examples:
 `, presets))
 
 	preset := &AuthKindCommand{
-		Run: func(ctx context.Context, clt *authclient.Client) error {
+		Run: func(ctx context.Context, clt authclient.ClientI) error {
 			return samlRunFunc(ctx, cmd, &spec, saml, clt)
 		},
 	}
@@ -171,7 +171,7 @@ func samlRunFunc(
 	cmd *SSOConfigureCommand,
 	spec *types.SAMLConnectorSpecV2,
 	flags *samlExtraFlags,
-	clt *authclient.Client,
+	clt authclient.ClientI,
 ) error {
 	// apply preset, if chosen
 	p := samlPresets.getPreset(flags.chosenPreset)

--- a/tool/tctl/sso/tester/command.go
+++ b/tool/tctl/sso/tester/command.go
@@ -55,7 +55,7 @@ type SSOTestCommand struct {
 	connectorFileName string
 
 	// Handlers is a mapping between auth kind and appropriate handling function
-	Handlers map[string]func(c *authclient.Client, connBytes []byte) (*AuthRequestInfo, error)
+	Handlers map[string]func(c authclient.ClientI, connBytes []byte) (*AuthRequestInfo, error)
 	// GetDiagInfoFields provides auth kind-specific diagnostic info fields.
 	GetDiagInfoFields map[string]func(diag *types.SSODiagnosticInfo, debug bool) []string
 	// Browser to use in login flow.
@@ -86,7 +86,7 @@ Examples:
 
   > tctl sso configure github ... | tee connector.yaml | tctl sso test`)
 
-	cmd.Handlers = map[string]func(c *authclient.Client, connBytes []byte) (*AuthRequestInfo, error){
+	cmd.Handlers = map[string]func(c authclient.ClientI, connBytes []byte) (*AuthRequestInfo, error){
 		types.KindGithubConnector: handleGithubConnector,
 		types.KindSAMLConnector:   handleSAMLConnector,
 		types.KindOIDCConnector:   handleOIDCConnector,
@@ -109,7 +109,7 @@ func (cmd *SSOTestCommand) getSupportedKinds() []string {
 	return kinds
 }
 
-func (cmd *SSOTestCommand) ssoTestCommand(ctx context.Context, c *authclient.Client) error {
+func (cmd *SSOTestCommand) ssoTestCommand(ctx context.Context, c authclient.ClientI) error {
 	reader := os.Stdin
 	if cmd.connectorFileName != "" {
 		f, err := utils.OpenFileAllowingUnsafeLinks(cmd.connectorFileName)
@@ -185,7 +185,7 @@ type AuthRequestInfo struct {
 // SSOLoginConsoleRequestFn allows customizing issuance of SSOLoginConsoleReq. Optional.
 type SSOLoginConsoleRequestFn func(req client.SSOLoginConsoleReq) (*client.SSOLoginConsoleResponse, error)
 
-func (cmd *SSOTestCommand) runSSOLoginFlow(ctx context.Context, connectorType string, c *authclient.Client, initiateSSOLoginFn SSOLoginConsoleRequestFn) (*authclient.SSHLoginResponse, error) {
+func (cmd *SSOTestCommand) runSSOLoginFlow(ctx context.Context, connectorType string, c authclient.ClientI, initiateSSOLoginFn SSOLoginConsoleRequestFn) (*authclient.SSHLoginResponse, error) {
 	proxies, err := c.GetProxies()
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/tool/tctl/sso/tester/github.go
+++ b/tool/tctl/sso/tester/github.go
@@ -31,7 +31,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 )
 
-func githubTest(c *authclient.Client, connector types.GithubConnector) (*AuthRequestInfo, error) {
+func githubTest(c authclient.ClientI, connector types.GithubConnector) (*AuthRequestInfo, error) {
 	ctx := context.Background()
 	// get connector spec
 	var spec types.GithubConnectorSpecV3
@@ -79,7 +79,7 @@ func githubTest(c *authclient.Client, connector types.GithubConnector) (*AuthReq
 	return requestInfo, nil
 }
 
-func handleGithubConnector(c *authclient.Client, connBytes []byte) (*AuthRequestInfo, error) {
+func handleGithubConnector(c authclient.ClientI, connBytes []byte) (*AuthRequestInfo, error) {
 	conn, err := services.UnmarshalGithubConnector(connBytes)
 	if err != nil {
 		return nil, trace.Wrap(err, "Unable to load GitHub connector. Correct the definition and try again.")

--- a/tool/tctl/sso/tester/oidc.go
+++ b/tool/tctl/sso/tester/oidc.go
@@ -29,7 +29,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 )
 
-func handleOIDCConnector(c *authclient.Client, connBytes []byte) (*AuthRequestInfo, error) {
+func handleOIDCConnector(c authclient.ClientI, connBytes []byte) (*AuthRequestInfo, error) {
 	conn, err := services.UnmarshalOIDCConnector(connBytes)
 	if err != nil {
 		return nil, trace.Wrap(err, "Unable to load OIDC connector. Correct the definition and try again.")
@@ -42,7 +42,7 @@ func handleOIDCConnector(c *authclient.Client, connBytes []byte) (*AuthRequestIn
 	return requestInfo, nil
 }
 
-func oidcTest(c *authclient.Client, connector types.OIDCConnector) (*AuthRequestInfo, error) {
+func oidcTest(c authclient.ClientI, connector types.OIDCConnector) (*AuthRequestInfo, error) {
 	ctx := context.Background()
 	// get connector spec
 	var spec types.OIDCConnectorSpecV3

--- a/tool/tctl/sso/tester/saml.go
+++ b/tool/tctl/sso/tester/saml.go
@@ -29,7 +29,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 )
 
-func handleSAMLConnector(c *authclient.Client, connBytes []byte) (*AuthRequestInfo, error) {
+func handleSAMLConnector(c authclient.ClientI, connBytes []byte) (*AuthRequestInfo, error) {
 	conn, err := services.UnmarshalSAMLConnector(connBytes)
 	if err != nil {
 		return nil, trace.Wrap(err, "Unable to load SAML connector. Correct the definition and try again.")
@@ -42,7 +42,7 @@ func handleSAMLConnector(c *authclient.Client, connBytes []byte) (*AuthRequestIn
 	return requestInfo, nil
 }
 
-func samlTest(c *authclient.Client, samlConnector types.SAMLConnector) (*AuthRequestInfo, error) {
+func samlTest(c authclient.ClientI, samlConnector types.SAMLConnector) (*AuthRequestInfo, error) {
 	ctx := context.Background()
 	// get connector spec
 	var spec types.SAMLConnectorSpecV2


### PR DESCRIPTION
Returning the interface from the InitFunc allows tests to better mock the auth client, which permits tests to be run without an actual teleport process being launched.

The ClientI interface was also extended with additional methods that tctl was already relying on.

Motivation for this change is to permit writing tests for tctl commands that do not require a teleport process be running. For instance, tests that only exist to validate output of a tctl command given different configurations are now able to do so by mocking out response from auth instead of starting a process and updating the cluster auth preference for each test case.