### PR TITLE
Hide specific features from nav is dashboard tenant

### DIFF
--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -45,6 +45,7 @@ import generateResourcePath from './generateResourcePath';
 import type { MfaChallengeResponse } from './services/mfa';
 import { KindAuthConnectors } from './services/resources';
 
+export type Cfg = typeof cfg;
 const cfg = {
   /** @deprecated Use cfg.edition instead. */
   isEnterprise: false,

--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -37,7 +37,7 @@ import {
 } from 'design/Icon';
 
 import { IntegrationEnroll } from '@gravitational/teleport/src/Integrations/Enroll';
-import cfg from 'teleport/config';
+import cfg, { Cfg } from 'teleport/config';
 import { IntegrationStatus } from 'teleport/Integrations/IntegrationStatus';
 import {
   ManagementSection,
@@ -66,6 +66,13 @@ import { TrustedClusters } from './TrustedClusters';
 import { NavTitle, type FeatureFlags, type TeleportFeature } from './types';
 import { UnifiedResources } from './UnifiedResources';
 import { Users } from './Users';
+
+// to promote feature discoverability, most features should be visible in the navigation even if a user doesnt have access.
+// However, there are some cases where hiding the feature is explicitly requested. Use this as a backdoor to hide the features that
+// are usually "always visible"
+export function shouldHideFromNavigation(cfg: Cfg) {
+  return cfg.isDashboard || cfg.hideInaccessibleFeatures;
+}
 
 class AccessRequests implements TeleportFeature {
   category = NavigationCategory.Resources;
@@ -243,7 +250,7 @@ export class FeatureBots implements TeleportFeature {
   hasAccess(flags: FeatureFlags) {
     // if feature hiding is enabled, only show
     // if the user has access
-    if (cfg.hideInaccessibleFeatures) {
+    if (shouldHideFromNavigation(cfg)) {
       return flags.listBots;
     }
     return true;
@@ -435,7 +442,7 @@ export class FeatureIntegrations implements TeleportFeature {
   hasAccess(flags: FeatureFlags) {
     // if feature hiding is enabled, only show
     // if the user has access
-    if (cfg.hideInaccessibleFeatures) {
+    if (shouldHideFromNavigation(cfg)) {
       return flags.integrations;
     }
     return true;
@@ -476,7 +483,7 @@ export class FeatureIntegrationEnroll implements TeleportFeature {
   };
 
   hasAccess(flags: FeatureFlags) {
-    if (cfg.hideInaccessibleFeatures) {
+    if (shouldHideFromNavigation(cfg)) {
       return flags.enrollIntegrations;
     }
     return true;
@@ -622,7 +629,7 @@ class FeatureDeviceTrust implements TeleportFeature {
   };
 
   hasAccess(flags: FeatureFlags) {
-    if (cfg.hideInaccessibleFeatures) {
+    if (shouldHideFromNavigation(cfg)) {
       return flags.deviceTrust;
     }
     return true;


### PR DESCRIPTION
This PR makes an update to our logic to the "backdoor" that would _keep_ things hidden after making updates to show most of the features to promote discoverability. Currently, we only continued to hide them if their license specified it, but this incorrectly ignored dashboard, usage based, and team tenants as well.