### PR TITLE
Allow opening multiple gateways for the same app but different target port

### DIFF
--- a/lib/teleterm/daemon/daemon.go
+++ b/lib/teleterm/daemon/daemon.go
@@ -334,6 +334,10 @@ func (s *Service) createGateway(ctx context.Context, params CreateGatewayParams)
 		return gateway, nil
 	}
 
+	if err := s.checkIfGatewayAlreadyExists(targetURI, params); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	clusterClient, err := s.GetCachedClient(ctx, targetURI.GetClusterURI())
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -517,6 +521,13 @@ func (s *Service) SetGatewayTargetSubresourceName(ctx context.Context, gatewayUR
 
 	gateway, err := s.findGateway(gatewayURI)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := s.checkIfGatewayAlreadyExists(gateway.TargetURI(), CreateGatewayParams{
+		TargetURI:             gateway.TargetURI().String(),
+		TargetSubresourceName: targetSubresourceName,
+	}); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/teleterm/daemon/daemon_test.go
+++ b/lib/teleterm/daemon/daemon_test.go
@@ -19,6 +19,7 @@
 package daemon
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"log/slog"
@@ -78,11 +79,13 @@ func (m *mockGatewayCreator) CreateGateway(ctx context.Context, params clusters.
 		KubernetesCluster: params.TargetURI.GetKubeName(),
 	}
 
+	targetURI := params.TargetURI
+
 	config := gateway.Config{
 		LocalPort:             params.LocalPort,
 		TargetURI:             params.TargetURI,
 		TargetUser:            params.TargetUser,
-		TargetName:            params.TargetURI.GetDbName() + params.TargetURI.GetKubeName(),
+		TargetName:            cmp.Or(targetURI.GetDbName(), targetURI.GetKubeName(), targetURI.GetAppName()),
 		TargetSubresourceName: params.TargetSubresourceName,
 		Protocol:              defaults.ProtocolPostgres,
 		Insecure:              true,
@@ -240,6 +243,52 @@ func TestGatewayCRUD(t *testing.T) {
 				})
 				require.NoError(t, err)
 				require.Equal(t, wantGateway, actualGateway)
+			},
+		},
+		{
+			name:                   "CreateGateway returns error if db gateway already exists",
+			gatewayNamesToCreate:   []string{"gateway"},
+			appendGatewayTargetURI: uri.NewClusterURI("foo").AppendDB,
+			testFunc: func(t *testing.T, c *gatewayCRUDTestContext, daemon *Service) {
+				createdGateway := c.nameToGateway["gateway"]
+				_, err := daemon.CreateGateway(context.Background(), CreateGatewayParams{
+					TargetURI:  createdGateway.TargetURI().String(),
+					TargetUser: createdGateway.TargetUser(),
+				})
+				require.Error(t, err)
+				require.True(t, trace.IsAlreadyExists(err))
+			},
+		},
+		{
+			name:                   "CreateGateway returns error if app gateway already exists",
+			gatewayNamesToCreate:   []string{"gateway"},
+			appendGatewayTargetURI: uri.NewClusterURI("foo").AppendApp,
+			testFunc: func(t *testing.T, c *gatewayCRUDTestContext, daemon *Service) {
+				createdGateway := c.nameToGateway["gateway"]
+				_, err := daemon.CreateGateway(context.Background(), CreateGatewayParams{
+					TargetURI:             createdGateway.TargetURI().String(),
+					TargetSubresourceName: createdGateway.TargetSubresourceName(),
+				})
+				require.Error(t, err)
+				require.True(t, trace.IsAlreadyExists(err))
+			},
+		},
+		{
+			name:                   "SetTargetSubresourceName returns error if db gateway already exists",
+			gatewayNamesToCreate:   []string{"gateway"},
+			appendGatewayTargetURI: uri.NewClusterURI("foo").AppendDB,
+			testFunc: func(t *testing.T, c *gatewayCRUDTestContext, daemon *Service) {
+				createdGateway := c.nameToGateway["gateway"]
+				_, err := daemon.CreateGateway(context.Background(), CreateGatewayParams{
+					TargetURI:             createdGateway.TargetURI().String(),
+					TargetSubresourceName: "4242",
+				})
+				require.NoError(t, err)
+
+				_, err = daemon.SetGatewayTargetSubresourceName(context.Background(),
+					createdGateway.URI().String(), "4242")
+				require.Error(t, err)
+				require.True(t, trace.IsAlreadyExists(err))
 			},
 		},
 	}

--- a/lib/teleterm/daemon/gateway.go
+++ b/lib/teleterm/daemon/gateway.go
@@ -1,0 +1,66 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package daemon
+
+import (
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/teleterm/api/uri"
+	"github.com/gravitational/teleport/lib/teleterm/gateway"
+)
+
+func (s *Service) checkIfGatewayAlreadyExists(targetURI uri.ResourceURI, params CreateGatewayParams) error {
+	var resourceParamsCheckFunc func(g gateway.Gateway) error
+
+	switch {
+	case targetURI.IsDB():
+		resourceParamsCheckFunc = func(g gateway.Gateway) error {
+			if g.TargetUser() == params.TargetUser {
+				return trace.AlreadyExists("gateway for database %s and user %s already exists", targetURI.GetDbName(), params.TargetUser)
+			}
+			return nil
+		}
+	case targetURI.IsKube():
+		// Return early for kubes as kube gateways depend on s.shouldReuseGateway.
+		return nil
+	case targetURI.IsApp():
+		resourceParamsCheckFunc = func(g gateway.Gateway) error {
+			if g.TargetSubresourceName() == params.TargetSubresourceName {
+				if params.TargetSubresourceName != "" {
+					return trace.AlreadyExists("gateway for app %s and target port %s already exists", targetURI.GetAppName(), params.TargetSubresourceName)
+				} else {
+					return trace.AlreadyExists("gateway for app %s already exists", targetURI.GetAppName())
+				}
+			}
+			return nil
+		}
+	default:
+		return trace.NotImplemented("gateway not supported for %s", targetURI.String())
+	}
+
+	for _, g := range s.gateways {
+		if g.TargetURI() != targetURI {
+			continue
+		}
+
+		if err := resourceParamsCheckFunc(g); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	return nil
+}

--- a/web/packages/shared/components/MenuLogin/MenuLogin.tsx
+++ b/web/packages/shared/components/MenuLogin/MenuLogin.tsx
@@ -121,18 +121,20 @@ export const MenuLogin = React.forwardRef<MenuLoginHandle, MenuLoginProps>(
       },
     }));
 
+    const ButtonComponent = props.ButtonComponent || ButtonBorder;
+
     return (
       <React.Fragment>
-        <ButtonBorder
+        <ButtonComponent
           width={alignButtonWidthToMenu ? width : null}
           textTransform={props.textTransform}
           size="small"
           setRef={anchorRef}
           onClick={onOpen}
         >
-          Connect
+          {props.buttonText || 'Connect'}
           <ChevronDown ml={1} size="small" color="text.slightlyMuted" />
-        </ButtonBorder>
+        </ButtonComponent>
         <Menu
           anchorOrigin={anchorOrigin}
           transformOrigin={transformOrigin}

--- a/web/packages/shared/components/MenuLogin/types.ts
+++ b/web/packages/shared/components/MenuLogin/types.ts
@@ -16,6 +16,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { ComponentPropsWithRef, ComponentType } from 'react';
+
+import { ButtonBorder } from 'design/Button';
+
 export type LoginItem = {
   url: string;
   login: string;
@@ -42,6 +46,8 @@ export type MenuLoginProps = {
   placeholder?: string;
   required?: boolean;
   width?: string;
+  ButtonComponent?: ComponentType<ComponentPropsWithRef<typeof ButtonBorder>>;
+  buttonText?: string;
 };
 
 export type MenuLoginHandle = {

--- a/web/packages/teleterm/src/services/tshd/app.ts
+++ b/web/packages/teleterm/src/services/tshd/app.ts
@@ -114,10 +114,12 @@ export function getAppAddrWithProtocol(source: App): string {
   return addrWithProtocol;
 }
 
+export const portRangeSeparator = '-';
+
 export const formatPortRange = (portRange: PortRange): string =>
   portRange.endPort === 0
     ? portRange.port.toString()
-    : `${portRange.port}-${portRange.endPort}`;
+    : `${portRange.port}${portRangeSeparator}${portRange.endPort}`;
 
 export const publicAddrWithTargetPort = (routeToApp: RouteToApp): string =>
   routeToApp.targetPort

--- a/web/packages/teleterm/src/services/tshd/gateway.ts
+++ b/web/packages/teleterm/src/services/tshd/gateway.ts
@@ -16,7 +16,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { GatewayTargetUri, routing } from 'teleterm/ui/uri';
+import {
+  GatewayTargetUri,
+  isAppUri,
+  isDatabaseUri,
+  isKubeUri,
+  routing,
+} from 'teleterm/ui/uri';
 
 import { GatewayCLICommand } from './types';
 
@@ -69,4 +75,30 @@ export function getTargetNameFromUri(targetUri: GatewayTargetUri): string {
     routing.parseAppUri(targetUri)?.params['appId'] ||
     targetUri
   );
+}
+
+/**
+ * getGatewayTargetUriKind is used when the callsite needs to distinguish between different kinds
+ * of targets that gateways support when given only its target URI.
+ */
+export function getGatewayTargetUriKind(
+  targetUri: string
+): 'db' | 'kube' | 'app' {
+  if (isDatabaseUri(targetUri)) {
+    return 'db';
+  }
+
+  if (isKubeUri(targetUri)) {
+    return 'kube';
+  }
+
+  if (isAppUri(targetUri)) {
+    return 'app';
+  }
+
+  // TODO(ravicious): Optimally we'd use `targetUri satisfies never` here to have a type error when
+  // DocumentGateway['targetUri'] is changed.
+  //
+  // However, at the moment that field is essentially of type string, so there's not much we can do
+  // with regards to type safety.
 }

--- a/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
@@ -126,7 +126,11 @@ export function ConnectAppActionButton(props: { app: App }): React.JSX.Element {
   }
 
   function setUpGateway(targetPort?: number): void {
-    setUpAppGateway(appContext, props.app, {
+    if (!targetPort && props.app.tcpPorts.length > 0) {
+      targetPort = props.app.tcpPorts[0].port;
+    }
+
+    setUpAppGateway(appContext, props.app.uri, {
       telemetry: { origin: 'resource_table' },
       targetPort,
     });

--- a/web/packages/teleterm/src/ui/DocumentGateway/useGateway.ts
+++ b/web/packages/teleterm/src/ui/DocumentGateway/useGateway.ts
@@ -24,7 +24,10 @@ import { useAsync } from 'shared/hooks/useAsync';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { useWorkspaceContext } from 'teleterm/ui/Documents';
 import { useStoreSelector } from 'teleterm/ui/hooks/useStoreSelector';
-import { DocumentGateway } from 'teleterm/ui/services/workspacesService';
+import {
+  DocumentGateway,
+  getDocumentGatewayTitle,
+} from 'teleterm/ui/services/workspacesService';
 import { isAppUri, isDatabaseUri } from 'teleterm/ui/uri';
 import { retryWithRelogin } from 'teleterm/ui/utils';
 
@@ -120,8 +123,12 @@ export function useGateway(doc: DocumentGateway) {
                 name
               );
 
-            documentsService.update(doc.uri, {
-              targetSubresourceName: updatedGateway.targetSubresourceName,
+            documentsService.update(doc.uri, draft => {
+              const draftDoc = draft as DocumentGateway;
+
+              draftDoc.targetSubresourceName =
+                updatedGateway.targetSubresourceName;
+              draftDoc.title = getDocumentGatewayTitle(draftDoc);
             });
           }),
         [

--- a/web/packages/teleterm/src/ui/DocumentGateway/useGateway.ts
+++ b/web/packages/teleterm/src/ui/DocumentGateway/useGateway.ts
@@ -69,8 +69,9 @@ export function useGateway(doc: DocumentGateway) {
           documentsService.update(doc.uri, { status: 'error' });
           throw error;
         }
-        documentsService.update(doc.uri, {
-          gatewayUri: gw.uri,
+        documentsService.update(doc.uri, draft => {
+          const draftDoc = draft as DocumentGateway;
+          draftDoc.gatewayUri = gw.uri;
           // Set the port on doc to match the one returned from the daemon. By default,
           // createGateway is called with an empty localPort, so the daemon creates a listener on a
           // random port.
@@ -80,11 +81,13 @@ export function useGateway(doc: DocumentGateway) {
           //
           // Alternatively, if createGateway was called from OfflineGateway, this will persist in
           // the doc the local port chosen by the user.
-          port: gw.localPort,
+          draftDoc.port = gw.localPort;
           // targetSubresourceName needs to be updated here in case the createGateway function was
           // called from OfflineGateway.
-          targetSubresourceName: gw.targetSubresourceName,
-          status: 'connected',
+          draftDoc.targetSubresourceName = gw.targetSubresourceName;
+          draftDoc.status = 'connected';
+          // The title might need to be changed if OfflineGateway changed gateway params.
+          draftDoc.title = getDocumentGatewayTitle(draftDoc);
         });
         if (isDatabaseUri(doc.targetUri)) {
           usageService.captureProtocolUse({

--- a/web/packages/teleterm/src/ui/DocumentGatewayApp/AppGateway.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGatewayApp/AppGateway.tsx
@@ -242,7 +242,11 @@ const LabelWithAttemptStatus = (props: {
       // repeated when the user switches to this tab.
       // https://www.w3.org/TR/css-animations-1/#example-4e34d7ba
       <UnmountAfter timeoutMs={disappearanceDelayMs + disappearanceDurationMs}>
-        <DisappearingCheck color="success.main" size="small" />
+        <DisappearingCheck
+          color="success.main"
+          size="small"
+          title={`${props.text} successfully updated`}
+        />
       </UnmountAfter>
     )}
   </Flex>

--- a/web/packages/teleterm/src/ui/DocumentGatewayApp/DocumentGatewayApp.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGatewayApp/DocumentGatewayApp.story.tsx
@@ -170,6 +170,7 @@ export function Story(props: StoryProps) {
     } else {
       let tcpPorts = [
         { port: 1337, endPort: 4242 },
+        { port: 4242, endPort: 0 },
         { port: 17231, endPort: 0 },
         { port: 27381, endPort: 28400 },
       ];

--- a/web/packages/teleterm/src/ui/DocumentGatewayApp/DocumentGatewayApp.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGatewayApp/DocumentGatewayApp.tsx
@@ -15,28 +15,22 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { ComponentProps, useCallback, useEffect } from 'react';
+import { ComponentProps } from 'react';
 import { z } from 'zod';
 
-import { useAsync } from 'shared/hooks/useAsync';
-
-import { useAppContext } from 'teleterm/ui/appContextProvider';
 import Document from 'teleterm/ui/Document';
 import { DocumentGateway } from 'teleterm/ui/services/workspacesService';
 
 import { PortFieldInput } from '../components/FieldInputs';
 import { FormFields, OfflineGateway } from '../components/OfflineGateway';
 import { useGateway } from '../DocumentGateway/useGateway';
-import { retryWithRelogin } from '../utils';
 import { AppGateway } from './AppGateway';
 
 export function DocumentGatewayApp(props: {
   doc: DocumentGateway;
   visible: boolean;
 }) {
-  const { doc, visible } = props;
-  const appCtx = useAppContext();
-  const { tshd } = appCtx;
+  const { doc } = props;
   const {
     gateway,
     defaultPort,
@@ -63,27 +57,6 @@ export function DocumentGatewayApp(props: {
   if (isMultiPort) {
     formSchema = multiPortSchema;
   }
-
-  const [tcpPortsAttempt, getTcpPorts] = useAsync(
-    useCallback(
-      () =>
-        retryWithRelogin(appCtx, doc.targetUri, () =>
-          tshd
-            .getApp({ appUri: doc.targetUri })
-            .then(({ response }) => response.app.tcpPorts)
-        ),
-      [appCtx, doc.targetUri, tshd]
-    )
-  );
-
-  useEffect(() => {
-    // Fetch TCP ports, but only when the gateway points at a multi-port TCP app and when the tab is
-    // visible. This is so that if the user reopens a session with a lot of app gateways, we don't
-    // fetch all ports at once.
-    if (visible && isMultiPort && tcpPortsAttempt.status === '') {
-      void getTcpPorts();
-    }
-  }, [visible, isMultiPort, tcpPortsAttempt, getTcpPorts]);
 
   return (
     <Document
@@ -130,8 +103,6 @@ export function DocumentGatewayApp(props: {
           changeLocalPortAttempt={changeLocalPortAttempt}
           changeTargetPort={changeTargetPort}
           changeTargetPortAttempt={changeTargetPortAttempt}
-          getTcpPorts={getTcpPorts}
-          tcpPortsAttempt={tcpPortsAttempt}
         />
       )}
     </Document>

--- a/web/packages/teleterm/src/ui/DocumentGatewayApp/DocumentGatewayApp.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGatewayApp/DocumentGatewayApp.tsx
@@ -86,7 +86,12 @@ export function DocumentGatewayApp(props: {
   }, [visible, isMultiPort, tcpPortsAttempt, getTcpPorts]);
 
   return (
-    <Document visible={props.visible}>
+    <Document
+      visible={props.visible}
+      // All documents are rendered in the DOM at the same time, but non-visible docs are hidden with
+      // `display: none`. This testid allows us to scope queries only to certain documents.
+      data-testid={doc.uri}
+    >
       {!connected ? (
         <OfflineGateway
           connectAttempt={connectAttempt}

--- a/web/packages/teleterm/src/ui/DocumentGatewayCliClient/DocumentGatewayCliClient.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGatewayCliClient/DocumentGatewayCliClient.tsx
@@ -50,10 +50,10 @@ export const DocumentGatewayCliClient = (props: {
   const { doc, visible } = props;
   const [hasRenderedTerminal, setHasRenderedTerminal] = useState(false);
 
-  const gateway = clustersService.findGatewayByConnectionParams(
-    doc.targetUri,
-    doc.targetUser
-  );
+  const gateway = clustersService.findGatewayByConnectionParams({
+    targetUri: doc.targetUri,
+    targetUser: doc.targetUser,
+  });
 
   // Once we render the terminal, we want to keep it visible. Otherwise removing the gateway would
   // mean that this document would immediately unmount DocumentTerminal and close the PTY.

--- a/web/packages/teleterm/src/ui/DocumentGatewayKube/DocumentGatewayKube.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGatewayKube/DocumentGatewayKube.tsx
@@ -54,10 +54,9 @@ export const DocumentGatewayKube = (props: {
   const ctx = useAppContext();
   const { documentsService } = useWorkspaceContext();
   const { params } = routing.parseKubeUri(doc.targetUri);
-  const gateway = ctx.clustersService.findGatewayByConnectionParams(
-    doc.targetUri,
-    ''
-  );
+  const gateway = ctx.clustersService.findGatewayByConnectionParams({
+    targetUri: doc.targetUri,
+  });
   const connected = !!gateway;
 
   const [connectAttempt, createGateway] = useAsync(async () => {

--- a/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.ts
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.ts
@@ -416,10 +416,10 @@ function createCmd(
   }
 
   if (doc.kind === 'doc.gateway_cli_client') {
-    const gateway = clustersService.findGatewayByConnectionParams(
-      doc.targetUri,
-      doc.targetUser
-    );
+    const gateway = clustersService.findGatewayByConnectionParams({
+      targetUri: doc.targetUri,
+      targetUser: doc.targetUser,
+    });
     if (!gateway) {
       // This shouldn't happen as DocumentGatewayCliClient doesn't render DocumentTerminal before
       // the gateway is found. In any case, if it does happen for some reason, the user will see
@@ -449,10 +449,9 @@ function createCmd(
   }
 
   if (doc.kind === 'doc.gateway_kube') {
-    const gateway = clustersService.findGatewayByConnectionParams(
-      doc.targetUri,
-      ''
-    );
+    const gateway = clustersService.findGatewayByConnectionParams({
+      targetUri: doc.targetUri,
+    });
     if (!gateway) {
       throw new Error(`No gateway found for ${doc.targetUri}`);
     }

--- a/web/packages/teleterm/src/ui/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/ui/fixtures/mocks.ts
@@ -45,18 +45,22 @@ export class MockAppContext extends AppContext {
     });
   }
 
-  addRootClusterWithDoc(cluster: Cluster, doc: Document) {
+  addRootClusterWithDoc(cluster: Cluster, doc: Document | undefined) {
     this.clustersService.setState(draftState => {
       draftState.clusters.set(cluster.uri, cluster);
     });
     this.workspacesService.setState(draftState => {
       draftState.rootClusterUri = cluster.uri;
       draftState.workspaces[cluster.uri] = {
-        documents: [doc],
-        location: doc.uri,
+        documents: [doc].filter(Boolean),
+        location: doc?.uri,
         localClusterUri: cluster.uri,
         accessRequests: undefined,
       };
     });
+  }
+
+  addRootCluster(cluster: Cluster) {
+    this.addRootClusterWithDoc(cluster, undefined);
   }
 }

--- a/web/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.legacy.test.ts
+++ b/web/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.legacy.test.ts
@@ -43,6 +43,8 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
+// TODO(ravicious): Rewrite those tests to use MockAppContext instead of manually mocking everything.
+
 it('removeItemsBelongingToRootCluster removes connections', () => {
   jest.mock('../workspacesService');
 
@@ -75,7 +77,6 @@ it('removeItemsBelongingToRootCluster removes connections', () => {
       targetUser: 'alice',
       targetName: 'test',
       targetSubresourceName: 'pg',
-      gatewayUri: '/gateways/4f68927b-579c-47a8-b965-efa8159203c9',
     },
     {
       kind: 'connection.kube',

--- a/web/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.test.tsx
+++ b/web/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.test.tsx
@@ -1,0 +1,253 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import 'jest-canvas-mock';
+
+import { within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { act, ComponentType, createRef } from 'react';
+
+import { render, screen } from 'design/utils/testing';
+import { App } from 'gen-proto-ts/teleport/lib/teleterm/v1/app_pb';
+
+import Logger, { NullService } from 'teleterm/logger';
+import { MockedUnaryCall } from 'teleterm/services/tshd/cloneableClient';
+import {
+  makeApp,
+  makeAppGateway,
+  makeRootCluster,
+} from 'teleterm/services/tshd/testHelpers';
+import { ResourcesContextProvider } from 'teleterm/ui/DocumentCluster/resourcesContext';
+import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
+import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
+import { DocumentsService } from 'teleterm/ui/services/workspacesService';
+import { TabHost } from 'teleterm/ui/TabHost';
+import { IAppContext } from 'teleterm/ui/types';
+import { unique } from 'teleterm/ui/utils';
+
+import { TrackedGatewayConnection } from './types';
+
+beforeAll(() => {
+  Logger.init(new NullService());
+});
+
+test('updating target port creates new connection', async () => {
+  const user = userEvent.setup();
+  const { ctx, docsService, app, Component } = setupTests();
+
+  const doc1 = docsService.createGatewayDocument({
+    targetName: app.name,
+    targetUri: app.uri,
+    targetUser: undefined,
+    targetSubresourceName: '1337',
+    origin: 'resource_table',
+  });
+  // Add without opening. It's not necessary and it'll be easier to verify activating connections
+  // later if we don't open the doc at this point.
+  docsService.add(doc1);
+
+  render(<Component />);
+
+  // Wait for the gateway to be created.
+  expect(await screen.findByText('Close Connection')).toBeInTheDocument();
+  expect(ctx.connectionTracker.getConnections()).toHaveLength(1);
+  const conn1337 = ctx.connectionTracker.getConnections()[0];
+
+  // Update target port.
+  let targetPortInput = screen.getByLabelText('Target Port');
+  await user.clear(targetPortInput);
+  await user.type(targetPortInput, '4242');
+  // We have to lose focus of that field, otherwise React is going to warn about updates not wrapped
+  // in act when the focus on the page changes after opening a new doc.
+  await user.tab();
+  expect(
+    await screen.findByTitle('Target Port successfully updated', undefined, {
+      // There's a 1s debounce on port fields.
+      timeout: 2000,
+    })
+  ).toBeInTheDocument();
+
+  // Verify connections.
+  expect(ctx.connectionTracker.getConnections()).toHaveLength(2);
+  const conn4242 = ctx.connectionTracker.getConnections()[1];
+  expect(conn4242.id).not.toEqual(conn1337.id);
+
+  await act(async () => {
+    await ctx.connectionTracker.activateItem(conn4242.id, {
+      origin: 'resource_table',
+    });
+  });
+  expect(docsService.getLocation()).toEqual(doc1.uri);
+
+  await act(async () => {
+    await ctx.connectionTracker.activateItem(conn1337.id, {
+      origin: 'resource_table',
+    });
+  });
+  expect(docsService.getDocuments()).toHaveLength(2);
+  expect(docsService.getLocation()).not.toEqual(doc1.uri);
+});
+
+test('updating target port to match connection params of gateway created by other doc is possible', async () => {
+  const user = userEvent.setup();
+  const { ctx, docsService, app, Component } = setupTests();
+
+  const baseDocumentGatewayFields = {
+    targetName: app.name,
+    targetUri: app.uri,
+    targetUser: undefined,
+    origin: 'resource_table' as const,
+  };
+  const doc1 = docsService.createGatewayDocument({
+    ...baseDocumentGatewayFields,
+    targetSubresourceName: '1337',
+  });
+  // Add without opening. It's not necessary and it'll be easier to verify activating connections
+  // later if we don't open the doc at this point.
+  docsService.add(doc1);
+
+  render(<Component />);
+
+  // Wait for the gateways to be created.
+  expect(await screen.findByText('Close Connection')).toBeInTheDocument();
+  expect(ctx.connectionTracker.getConnections()).toHaveLength(1);
+  const conn1337Id = ctx.connectionTracker.getConnections()[0].id;
+
+  // Create a second gateway.
+  const doc2 = docsService.createGatewayDocument({
+    ...baseDocumentGatewayFields,
+    targetSubresourceName: '4242',
+  });
+  await act(async () => {
+    docsService.add(doc2);
+  });
+  const doc2Node = await screen.findByTestId(doc2.uri);
+  expect(
+    await within(doc2Node).findByText('Close Connection')
+  ).toBeInTheDocument();
+  expect(ctx.connectionTracker.getConnections()).toHaveLength(2);
+  const conn4242Id = ctx.connectionTracker.getConnections()[1].id;
+  expect(conn4242Id).not.toEqual(conn1337Id);
+
+  // Close the second gateway.
+  await user.click(within(doc2Node).getByText('Close Connection'));
+  expect(ctx.connectionTracker.findConnection(conn4242Id).connected).toBe(
+    false
+  );
+  expect(ctx.connectionTracker.findConnection(conn1337Id).connected).toBe(true);
+
+  // Update target port from 1337 to 4242.
+  let targetPortInput = screen.getByLabelText('Target Port');
+  await user.clear(targetPortInput);
+  await user.type(targetPortInput, '4242');
+  await user.tab();
+  expect(
+    await screen.findByTitle('Target Port successfully updated', undefined, {
+      // There's a 1s debounce on port fields.
+      timeout: 2000,
+    })
+  ).toBeInTheDocument();
+
+  // Verify that connection for 4242 is now connected and the connection for 1337 went offline.
+  expect(ctx.connectionTracker.getConnections()).toHaveLength(2);
+  const conn4242 = ctx.connectionTracker.findConnection(
+    conn4242Id
+  ) as TrackedGatewayConnection;
+  const conn1337 = ctx.connectionTracker.findConnection(
+    conn1337Id
+  ) as TrackedGatewayConnection;
+  expect(conn4242.connected).toBe(true);
+  expect(conn1337.connected).toBe(false);
+  // The ports are expected to be the same. We just changed doc with port 1337 to port 4242, so the
+  // corresponding connection has changed from conn1337 to conn4242. conn4242 got updated with the
+  // port set on doc1.
+  expect(conn4242).toBeTruthy();
+  expect(conn4242.port).toEqual(conn1337.port);
+
+  await act(async () => {
+    await ctx.connectionTracker.activateItem(conn4242Id, {
+      origin: 'resource_table',
+    });
+  });
+  expect(docsService.getLocation()).toEqual(doc1.uri);
+});
+
+function setupTests(): {
+  ctx: IAppContext;
+  docsService: DocumentsService;
+  app: App;
+  Component: ComponentType;
+} {
+  const ctx = new MockAppContext();
+  const rootCluster = makeRootCluster();
+  ctx.addRootCluster(rootCluster);
+  ctx.workspacesService.setState(draft => {
+    draft.rootClusterUri = rootCluster.uri;
+  });
+
+  const docsService = ctx.workspacesService.getWorkspaceDocumentService(
+    rootCluster.uri
+  );
+
+  const app = makeApp({
+    tcpPorts: [
+      { port: 1337, endPort: 0 },
+      { port: 4242, endPort: 0 },
+    ],
+    endpointUri: 'tcp://localhost',
+  });
+
+  let gatewayLocalPort = 0;
+  jest.spyOn(ctx.tshd, 'createGateway').mockImplementation(async req => {
+    gatewayLocalPort++;
+
+    return new MockedUnaryCall(
+      makeAppGateway({
+        ...req,
+        protocol: 'TCP',
+        uri: `/gateways/${unique()}`,
+        localPort: req.localPort || gatewayLocalPort.toString(),
+      })
+    );
+  });
+  jest
+    .spyOn(ctx.tshd, 'setGatewayTargetSubresourceName')
+    .mockImplementation(async req => {
+      const gateway = ctx.clustersService.findGateway(req.gatewayUri);
+      const updatedGateway = {
+        ...gateway,
+        targetSubresourceName: req.targetSubresourceName,
+      };
+
+      return new MockedUnaryCall(updatedGateway);
+    });
+  jest
+    .spyOn(ctx.tshd, 'getApp')
+    .mockResolvedValue(new MockedUnaryCall({ app }));
+
+  const ref = createRef<HTMLDivElement>();
+  const Component = () => (
+    <MockAppContextProvider appContext={ctx}>
+      <ResourcesContextProvider>
+        <TabHost ctx={ctx} topBarContainerRef={ref} />
+      </ResourcesContextProvider>
+    </MockAppContextProvider>
+  );
+
+  return { ctx, docsService, app, Component };
+}

--- a/web/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.test.tsx
+++ b/web/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.test.tsx
@@ -67,6 +67,7 @@ test('updating target port creates new connection', async () => {
   expect(await screen.findByText('Close Connection')).toBeInTheDocument();
   expect(ctx.connectionTracker.getConnections()).toHaveLength(1);
   const conn1337 = ctx.connectionTracker.getConnections()[0];
+  expect(conn1337.title).toEqual(`${app.name}:1337`);
 
   // Update target port.
   let targetPortInput = screen.getByLabelText('Target Port');
@@ -86,6 +87,7 @@ test('updating target port creates new connection', async () => {
   expect(ctx.connectionTracker.getConnections()).toHaveLength(2);
   const conn4242 = ctx.connectionTracker.getConnections()[1];
   expect(conn4242.id).not.toEqual(conn1337.id);
+  expect(conn4242.title).toEqual(`${app.name}:4242`);
 
   await act(async () => {
     await ctx.connectionTracker.activateItem(conn4242.id, {

--- a/web/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.ts
+++ b/web/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.ts
@@ -203,10 +203,9 @@ export class ConnectionTrackerService extends ImmutableStore<ConnectionTrackerSt
             break;
           }
           case 'connection.kube': {
-            i.connected = !!this._clusterService.findGatewayByConnectionParams(
-              i.kubeUri,
-              ''
-            );
+            i.connected = !!this._clusterService.findGatewayByConnectionParams({
+              targetUri: i.kubeUri,
+            });
             break;
           }
           default: {
@@ -273,10 +272,9 @@ export class ConnectionTrackerService extends ImmutableStore<ConnectionTrackerSt
 
             if (kubeConn) {
               kubeConn.connected =
-                !!this._clusterService.findGatewayByConnectionParams(
-                  doc.targetUri,
-                  ''
-                );
+                !!this._clusterService.findGatewayByConnectionParams({
+                  targetUri: doc.targetUri,
+                });
             } else {
               const newItem = createGatewayKubeConnection(doc);
               draft.connections.push(newItem);

--- a/web/packages/teleterm/src/ui/services/connectionTracker/trackedConnectionOperationsFactory.ts
+++ b/web/packages/teleterm/src/ui/services/connectionTracker/trackedConnectionOperationsFactory.ts
@@ -18,6 +18,7 @@
 
 import { ClustersService } from 'teleterm/ui/services/clusters';
 import {
+  DocumentGateway,
   DocumentOrigin,
   WorkspacesService,
 } from 'teleterm/ui/services/workspacesService';
@@ -120,16 +121,25 @@ export class TrackedConnectionOperationsFactory {
       activate: params => {
         let gwDoc = documentsService
           .getDocuments()
-          .find(getGatewayDocumentByConnection(connection));
+          .find(getGatewayDocumentByConnection(connection)) as DocumentGateway;
 
         if (!gwDoc) {
+          const gw = this._clustersService.findGatewayByConnectionParams({
+            targetUri: connection.targetUri,
+            targetUser: connection.targetUser,
+            targetSubresourceName: connection.targetSubresourceName,
+          });
+
           gwDoc = documentsService.createGatewayDocument({
             targetUri: connection.targetUri,
             targetName: connection.targetName,
             targetUser: connection.targetUser,
             targetSubresourceName: connection.targetSubresourceName,
             title: connection.title,
-            gatewayUri: connection.gatewayUri,
+            // If the doc was closed but the gateway is still running, it's important for the
+            // doc to reopen with the existing gateway URI. Otherwise the doc would attempt to
+            // create a new gateway with the same connection params.
+            gatewayUri: gw?.uri,
             port: connection.port,
             origin: params.origin,
           });
@@ -139,16 +149,22 @@ export class TrackedConnectionOperationsFactory {
         documentsService.open(gwDoc.uri);
       },
       disconnect: async () => {
-        return this._clustersService
-          .removeGateway(connection.gatewayUri)
-          .then(() => {
-            documentsService
-              .getDocuments()
-              .filter(getGatewayDocumentByConnection(connection))
-              .forEach(document => {
-                documentsService.close(document.uri);
-              });
-          });
+        // When disconnecting, assume that the gateway exists. If a gateway doesn't exist, the UI is
+        // supposed to expose the remove operation, not the disconnect operation.
+        const gw = this._clustersService.findGatewayByConnectionParams({
+          targetUri: connection.targetUri,
+          targetUser: connection.targetUser,
+          targetSubresourceName: connection.targetSubresourceName,
+        });
+
+        return this._clustersService.removeGateway(gw.uri).then(() => {
+          documentsService
+            .getDocuments()
+            .filter(getGatewayDocumentByConnection(connection))
+            .forEach(document => {
+              documentsService.close(document.uri);
+            });
+        });
       },
       remove: async () => {},
     };

--- a/web/packages/teleterm/src/ui/services/connectionTracker/trackedConnectionUtils.ts
+++ b/web/packages/teleterm/src/ui/services/connectionTracker/trackedConnectionUtils.ts
@@ -32,6 +32,19 @@ import {
   TrackedServerConnection,
 } from './types';
 
+/*
+ * Getting a connection by a document.
+ */
+
+/**
+ * This function is used in two scenarios. It's used when recreating the list of connections based
+ * on open documents. If there's no connection found that matches DocumentGateway, a new connection
+ * is added to the list.
+ *
+ * It's also used when opening new gateways for databases and apps to find an existing connection
+ * and call it's `activate` handler, which is going to open an existing document. If no existing
+ * connection is found, a new document is added to the workspace.
+ */
 export function getGatewayConnectionByDocument(document: DocumentGateway) {
   return (i: TrackedGatewayConnection) =>
     i.kind === 'connection.gateway' &&
@@ -60,6 +73,22 @@ export function getGatewayKubeConnectionByDocument(
     i.kind === 'connection.kube' && i.kubeUri === document.targetUri;
 }
 
+/*
+ * Getting a document by a connection.
+ */
+
+/**
+ * This function is used in two scenarios. It's used when activating (clicking) a connection in the
+ * connections list to find a document to open if there's already a gateway for the given connection.
+ *
+ * The `activate` handler is also called when the user attempts to open a gateway for a database or
+ * an app. That UI action first prepares a doc with provided gateway parameters. If there's a
+ * connection which matches the gateway parameters from the doc (getGatewayConnectionByDocument),
+ * its `activate` handler is called.
+ *
+ * The second scenario is when disconnecting a connection from the connections list to find a
+ * document which should be closed.
+ */
 export function getGatewayDocumentByConnection(
   connection: TrackedGatewayConnection
 ) {

--- a/web/packages/teleterm/src/ui/services/connectionTracker/types.ts
+++ b/web/packages/teleterm/src/ui/services/connectionTracker/types.ts
@@ -16,13 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {
-  AppUri,
-  DatabaseUri,
-  GatewayUri,
-  KubeUri,
-  ServerUri,
-} from 'teleterm/ui/uri';
+import { AppUri, DatabaseUri, KubeUri, ServerUri } from 'teleterm/ui/uri';
 
 type TrackedConnectionBase = {
   connected: boolean;
@@ -43,7 +37,6 @@ export interface TrackedGatewayConnection extends TrackedConnectionBase {
   targetName: string;
   targetUser?: string;
   port?: string;
-  gatewayUri: GatewayUri;
   targetSubresourceName?: string;
 }
 

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToApp.test.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToApp.test.ts
@@ -132,6 +132,7 @@ describe('setUpAppGateway', () => {
         tcpPorts: [{ port: 1234, endPort: 0 }],
       }),
       expectedTargetSubresourceName: '1234',
+      expectedTitle: 'foo:1234',
     },
     {
       name: 'creates tunnel for a multi-port TCP app with a preselected target port',
@@ -140,6 +141,7 @@ describe('setUpAppGateway', () => {
         tcpPorts: [{ port: 1234, endPort: 0 }],
       }),
       targetPort: 1234,
+      expectedTitle: 'foo:1234',
     },
     {
       name: 'creates tunnel for a web app',
@@ -147,33 +149,41 @@ describe('setUpAppGateway', () => {
         endpointUri: 'http://localhost:3000',
       }),
     },
-  ])('$name', async ({ app, targetPort, expectedTargetSubresourceName }) => {
-    const appContext = new MockAppContext();
-    setTestCluster(appContext);
-
-    await setUpAppGateway(appContext, app, {
-      telemetry: { origin: 'resource_table' },
+  ])(
+    '$name',
+    async ({
+      app,
       targetPort,
-    });
-    const documents = appContext.workspacesService
-      .getActiveWorkspaceDocumentService()
-      .getGatewayDocuments();
-    expect(documents).toHaveLength(1);
-    expect(documents[0]).toEqual({
-      gatewayUri: undefined,
-      kind: 'doc.gateway',
-      origin: 'resource_table',
-      port: undefined,
-      status: '',
-      targetName: 'foo',
-      targetSubresourceName:
-        expectedTargetSubresourceName || targetPort?.toString() || undefined,
-      targetUri: '/clusters/teleport-local/apps/foo',
-      targetUser: '',
-      title: 'foo',
-      uri: expect.any(String),
-    });
-  });
+      expectedTargetSubresourceName,
+      expectedTitle,
+    }) => {
+      const appContext = new MockAppContext();
+      setTestCluster(appContext);
+
+      await setUpAppGateway(appContext, app, {
+        telemetry: { origin: 'resource_table' },
+        targetPort,
+      });
+      const documents = appContext.workspacesService
+        .getActiveWorkspaceDocumentService()
+        .getGatewayDocuments();
+      expect(documents).toHaveLength(1);
+      expect(documents[0]).toEqual({
+        gatewayUri: undefined,
+        kind: 'doc.gateway',
+        origin: 'resource_table',
+        port: undefined,
+        status: '',
+        targetName: 'foo',
+        targetSubresourceName:
+          expectedTargetSubresourceName || targetPort?.toString() || undefined,
+        targetUri: '/clusters/teleport-local/apps/foo',
+        targetUser: '',
+        title: expectedTitle || 'foo',
+        uri: expect.any(String),
+      });
+    }
+  );
 });
 
 test('cloud app triggers alert', async () => {

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToApp.test.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToApp.test.ts
@@ -131,15 +131,6 @@ describe('setUpAppGateway', () => {
         endpointUri: 'tcp://localhost',
         tcpPorts: [{ port: 1234, endPort: 0 }],
       }),
-      expectedTargetSubresourceName: '1234',
-      expectedTitle: 'foo:1234',
-    },
-    {
-      name: 'creates tunnel for a multi-port TCP app with a preselected target port',
-      app: makeApp({
-        endpointUri: 'tcp://localhost',
-        tcpPorts: [{ port: 1234, endPort: 0 }],
-      }),
       targetPort: 1234,
       expectedTitle: 'foo:1234',
     },
@@ -149,41 +140,32 @@ describe('setUpAppGateway', () => {
         endpointUri: 'http://localhost:3000',
       }),
     },
-  ])(
-    '$name',
-    async ({
-      app,
-      targetPort,
-      expectedTargetSubresourceName,
-      expectedTitle,
-    }) => {
-      const appContext = new MockAppContext();
-      setTestCluster(appContext);
+  ])('$name', async ({ app, targetPort, expectedTitle }) => {
+    const appContext = new MockAppContext();
+    setTestCluster(appContext);
 
-      await setUpAppGateway(appContext, app, {
-        telemetry: { origin: 'resource_table' },
-        targetPort,
-      });
-      const documents = appContext.workspacesService
-        .getActiveWorkspaceDocumentService()
-        .getGatewayDocuments();
-      expect(documents).toHaveLength(1);
-      expect(documents[0]).toEqual({
-        gatewayUri: undefined,
-        kind: 'doc.gateway',
-        origin: 'resource_table',
-        port: undefined,
-        status: '',
-        targetName: 'foo',
-        targetSubresourceName:
-          expectedTargetSubresourceName || targetPort?.toString() || undefined,
-        targetUri: '/clusters/teleport-local/apps/foo',
-        targetUser: '',
-        title: expectedTitle || 'foo',
-        uri: expect.any(String),
-      });
-    }
-  );
+    await setUpAppGateway(appContext, app.uri, {
+      telemetry: { origin: 'resource_table' },
+      targetPort,
+    });
+    const documents = appContext.workspacesService
+      .getActiveWorkspaceDocumentService()
+      .getGatewayDocuments();
+    expect(documents).toHaveLength(1);
+    expect(documents[0]).toEqual({
+      gatewayUri: undefined,
+      kind: 'doc.gateway',
+      origin: 'resource_table',
+      port: undefined,
+      status: '',
+      targetName: 'foo',
+      targetSubresourceName: targetPort?.toString(),
+      targetUri: '/clusters/teleport-local/apps/foo',
+      targetUser: '',
+      title: expectedTitle || 'foo',
+      uri: expect.any(String),
+    });
+  });
 });
 
 test('cloud app triggers alert', async () => {

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
@@ -29,6 +29,7 @@ import {
 } from 'teleterm/ui/uri';
 import { unique } from 'teleterm/ui/utils/uid';
 
+import { getDocumentGatewayTitle } from './documentsUtils';
 import {
   CreateAccessRequestDocumentOpts,
   CreateGatewayDocumentOpts,
@@ -155,9 +156,8 @@ export class DocumentsService {
       origin,
     } = opts;
     const uri = routing.getDocUri({ docId: unique() });
-    const title = targetUser ? `${targetUser}@${targetName}` : targetName;
 
-    return {
+    const doc: DocumentGateway = {
       uri,
       kind: 'doc.gateway',
       targetUri,
@@ -165,11 +165,13 @@ export class DocumentsService {
       targetName,
       targetSubresourceName,
       gatewayUri,
-      title,
+      title: undefined,
       port,
       origin,
       status: '',
     };
+    doc.title = getDocumentGatewayTitle(doc);
+    return doc;
   }
 
   createGatewayCliDocument({

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsUtils.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsUtils.ts
@@ -93,3 +93,22 @@ export function getDocumentGatewayTargetUriKind(
   // However, at the moment that field is essentially of type string, so there's not much we can do
   // with regards to type safety.
 }
+
+export function getDocumentGatewayTitle(doc: DocumentGateway): string {
+  const { targetName, targetUri, targetUser, targetSubresourceName } = doc;
+  const targetKind = getDocumentGatewayTargetUriKind(targetUri);
+
+  switch (targetKind) {
+    case 'db': {
+      return targetUser ? `${targetUser}@${targetName}` : targetName;
+    }
+    case 'app': {
+      return targetSubresourceName
+        ? `${targetName}:${targetSubresourceName}`
+        : targetName;
+    }
+    default: {
+      targetKind satisfies never;
+    }
+  }
+}

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsUtils.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsUtils.ts
@@ -16,9 +16,18 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ClusterOrResourceUri, routing } from 'teleterm/ui/uri';
+import {
+  ClusterOrResourceUri,
+  isAppUri,
+  isDatabaseUri,
+  routing,
+} from 'teleterm/ui/uri';
 
-import { Document, isDocumentTshNodeWithServerId } from './types';
+import {
+  Document,
+  DocumentGateway,
+  isDocumentTshNodeWithServerId,
+} from './types';
 
 /**
  * getResourceUri returns the URI of the cluster resource that is the subject of the document.
@@ -61,4 +70,26 @@ export function getResourceUri(
       document satisfies never;
       return undefined;
   }
+}
+
+/**
+ * getDocumentGatewayTargetUriKind is used when the callsite needs to distinguish between different
+ * kinds of targets that DocumentGateway supports when given only its target URI.
+ */
+export function getDocumentGatewayTargetUriKind(
+  targetUri: DocumentGateway['targetUri']
+): 'db' | 'app' {
+  if (isDatabaseUri(targetUri)) {
+    return 'db';
+  }
+
+  if (isAppUri(targetUri)) {
+    return 'app';
+  }
+
+  // TODO(ravicious): Optimally we'd use `targetUri satisfies never` here to have a type error when
+  // DocumentGateway['targetUri'] is changed.
+  //
+  // However, at the moment that field is essentially of type string, so there's not much we can do
+  // with regards to type safety.
 }

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
@@ -101,21 +101,47 @@ export interface DocumentTshKube extends DocumentBase {
   origin: DocumentOrigin;
 }
 
+/**
+ * DocumentGateway is used for database and app gateways. The two are distinguished by the kind of
+ * resource that targetUri points to.
+ */
 export interface DocumentGateway extends DocumentBase {
   kind: 'doc.gateway';
-  // status is used merely to show a progress bar when the gateway is being set up.
+  /** status is used merely to show a progress bar when the gateway is being set up. */
   status: '' | 'connecting' | 'connected' | 'error';
+  /**
+   * gatewayUri is not present until the gateway described by the document is created.
+   */
   gatewayUri?: uri.GatewayUri;
   targetUri: uri.DatabaseUri | uri.AppUri;
+  /**
+   * targetUser is used only for db gateways and must contain the db user. Connect allows only a
+   * single doc.gateway to exist per targetUri + targetUser combo.
+   */
   targetUser: string;
+  /**
+   * targetName contains the name of the target resource as shown in the UI. This field could be
+   * removed in favor of targetUri, which always includes the target name anyway.
+   */
   targetName: string;
   /**
    * targetSubresourceName contains database name for db gateways and target port for TCP app
-   * gateways.
-   * A DocumentGateway created for a multi-port TCP app is expected to always have this field
-   * present.
+   * gateways. A DocumentGateway created for a multi-port TCP app is expected to always have this
+   * field present.
+   *
+   * For app gateways, Connect allows only a single doc.gateway to exist per targetUri +
+   * targetSubresourceName combo.
+   *
+   * For db gateways, targetSubresourceName is not taken into account when considering document
+   * "uniqueness".
    */
   targetSubresourceName: string | undefined;
+  /**
+   * port is the local port on which the gateway accepts connections.
+   *
+   * If empty, tshd is going to created a listener on a random port and then this field will be
+   * updated to match that random port.
+   */
   port?: string;
   origin: DocumentOrigin;
 }


### PR DESCRIPTION
This is the last PR related to multi-port TCP app gateways in Connect.

## tshd changes

First, I made sure it's not possible to create multiple gateways with the same local port in tshd. This is historically something that we've enforced through the UI for db gateways (cannot create multiple gateways for the same db + db user), but we've never enforced that in tshd. Technically there's nothing wrong with creating multiple gateways on different local ports otherwise have the same params. However, it doesn't make much sense and is harder to manage from a UX standpoint.

## Connection tracking changes in UI

Second, remove `gatewayUri` from `TrackedGatewayConnection`. This is related to how [`_refreshState` in `ConnectionTrackerService`](https://github.com/gravitational/teleport/blob/c4d3f18777cef44ef443dbcfe5bb791ee651693a/web/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.ts#L196) works.

In short, the connections in the top left in the app are always based on connections persisted on disk and currently open gateways and documents. When you open a new gateway document and create a gateway, `_refreshState` is called. It sees that there's a new `doc.gateway`, but it's not able to find a matching connection that would have the same gateway params as the doc, so it creates a new connection and stores the gateway URI in `connection.gatewayUri`. Later on whenever the connection needs to refer to the gateway in any way, it just uses this field.

This used to work, because given a connection, you could find the gateway using _either_ gateway URI or gateway params saved on connections. Both fields have never changed – once you created a gateway, you weren't able to change its URI or its params through which it's identified.

However, with the advent of target port in app gateways, you actually are able to change one of the params through which a gateway is identified _after the gateway was created_. This means that we can no longer use gateway URI _or_ gateway params to make a link between a connection in the top left and a gateway. We always have to use gateway params.

### UI properties that come out of this

Terminology:
* local port – a random port on user's device that the gateway listens on
* target port - the new field that I added for multi-port TCP apps

Approaching this problem in this way means that if you open an app gateway and change its target port, you now have two connections in the top left. One for the previous target port which is now marked as offline, and one for the new target port which is marked as online. They both share the same local port, which means if you try to activate the old one, you'll get an error and you'll have to adjust the port.

However, this is mostly going to be a problem for VNet users that are going to continue to use the traditional app gateways for multi-port apps. With VNet support enabled, the only way for you to create more than one gateway is to click three dots -> "Connect without VNet", change the target port to something else, then create another gateway (which uses the first target port from the spec). This new gateway with the default target port won't be created on the first try as the old connection still has the same local port as the original gateway that's currently running.

For users on platforms that do not support VNet (for which this whole feature is made in the first place), I don't expect it to be that much of a problem. I expect them to create gateways through the three dots menu where clicking on a specific target port creates a new gateway with a random local port, which avoids the whole issue I described above.

This should work good enough for the default case and while it could probably be improved in a way, I don't really want to invest more time in what is probably going to be a very niche use case. We don't expect people to use multi-port TCP apps that much on platforms that do not support VNet, simply because it sucks to use them without VNet. VNet is the reason we're adding multi-port support in the first place.

## Considered alternatives

At first I tried to make it so that when operating on connections, we identify documents by `gatewayUri` whenever possible and I wanted to allow for multiple gateways with the same target port. However, operating on connections through "hard links" to gateways is just not feasible because of the reasons I mentioned above. When the target port is changed, the old gateway URI remains in the connection, as well as the old target port, but the gateway now uses a different target port. Connections have to always use "soft links", similar to how we've already been doing that for kube gateways or server connections.

You could use hard links and then simply update the target port of the existing connection, but then you run into the problem where when restoring app state you have two connections for exactly the same gateway params and no hard links to any existing gateway (because you just started the app). So clicking on the first connection would create a new doc, but after that clicking on the second connection would just activate the existing doc. So using soft links seems to be just the better way to manage this.