### PR TITLE
Remove S3 params from AWS OIDC IdP set up script

### DIFF
--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -20,13 +20,10 @@ package web
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"maps"
 	"net/http"
-	"net/url"
 	"slices"
 	"strings"
 
@@ -1360,6 +1357,11 @@ func (h *Handler) awsOIDCConfigureIdP(w http.ResponseWriter, r *http.Request, p 
 		return nil, trace.BadParameter("invalid role %q", role)
 	}
 
+	proxyAddr, err := oidc.IssuerFromPublicAddress(h.cfg.PublicProxyAddr, "")
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	// The script must execute the following command:
 	// teleport integration configure awsoidc-idp
 	argsList := []string{
@@ -1367,56 +1369,15 @@ func (h *Handler) awsOIDCConfigureIdP(w http.ResponseWriter, r *http.Request, p 
 		fmt.Sprintf("--cluster=%s", shsprintf.EscapeDefaultContext(clusterName)),
 		fmt.Sprintf("--name=%s", shsprintf.EscapeDefaultContext(integrationName)),
 		fmt.Sprintf("--role=%s", shsprintf.EscapeDefaultContext(role)),
+		fmt.Sprintf("--proxy-public-url=%s", shsprintf.EscapeDefaultContext(proxyAddr)),
 	}
+
 	policyPreset := queryParams.Get("policyPreset")
 	if err := awsoidc.ValidatePolicyPreset(awsoidc.PolicyPreset(policyPreset)); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	if policyPreset != "" {
 		argsList = append(argsList, fmt.Sprintf("--policy-preset=%s", shsprintf.EscapeDefaultContext(policyPreset)))
-	}
-
-	// We have two set up modes:
-	// - use the Proxy HTTP endpoint as Identity Provider
-	// - use an S3 Bucket for storing the public keys
-	//
-	// The script will pick a mode depending on the query params received here.
-	// If the S3 location was defined, then it will use that mode and upload the Public Keys to the S3 Bucket.
-	// Otherwise, it will create an IdP pointing to the current Cluster.
-	//
-	// Whatever the chosen mode, the Proxy HTTP endpoint will always return the public keys.
-	s3Bucket := queryParams.Get("s3Bucket")
-	s3Prefix := queryParams.Get("s3Prefix")
-
-	switch {
-	case s3Bucket == "" && s3Prefix == "":
-		proxyAddr, err := oidc.IssuerFromPublicAddress(h.cfg.PublicProxyAddr, "")
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		argsList = append(argsList,
-			fmt.Sprintf("--proxy-public-url=%s", shsprintf.EscapeDefaultContext(proxyAddr)),
-		)
-
-	default:
-		if s3Bucket == "" || s3Prefix == "" {
-			return nil, trace.BadParameter("s3Bucket and s3Prefix query params are required")
-		}
-		s3URI := url.URL{Scheme: "s3", Host: s3Bucket, Path: s3Prefix}
-
-		jwksContents, err := h.jwks(r.Context(), types.OIDCIdPCA, true)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		jwksJSON, err := json.Marshal(jwksContents)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		argsList = append(argsList,
-			fmt.Sprintf("--s3-bucket-uri=%s", shsprintf.EscapeDefaultContext(s3URI.String())),
-			fmt.Sprintf("--s3-jwks-base64=%s", base64.StdEncoding.EncodeToString(jwksJSON)),
-		)
 	}
 
 	script, err := oneoff.BuildScript(oneoff.OneOffScriptParams{

--- a/lib/web/integrations_awsoidc_test.go
+++ b/lib/web/integrations_awsoidc_test.go
@@ -20,7 +20,6 @@ package web
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -613,11 +612,6 @@ func TestBuildAWSOIDCIdPConfigureScript(t *testing.T) {
 	}
 	scriptEndpoint := publicClt.Endpoint(pathVars...)
 
-	jwksEndpoint := publicClt.Endpoint(".well-known", "jwks-oidc")
-	resp, err := publicClt.Get(ctx, jwksEndpoint, nil)
-	require.NoError(t, err)
-	jwksBase64 := base64.StdEncoding.EncodeToString(resp.Bytes())
-
 	tests := []struct {
 		name                 string
 		reqRelativeURL       string
@@ -631,8 +625,6 @@ func TestBuildAWSOIDCIdPConfigureScript(t *testing.T) {
 				"awsRegion":       []string{"us-east-1"},
 				"role":            []string{"myRole"},
 				"integrationName": []string{"myintegration"},
-				"s3Bucket":        []string{"my-bucket"},
-				"s3Prefix":        []string{"prefix"},
 				"policyPreset":    []string{""},
 			},
 			errCheck: require.NoError,
@@ -640,8 +632,7 @@ func TestBuildAWSOIDCIdPConfigureScript(t *testing.T) {
 				"--cluster=localhost " +
 				"--name=myintegration " +
 				"--role=myRole " +
-				`--s3-bucket-uri=s3://my-bucket/prefix ` +
-				"--s3-jwks-base64=" + jwksBase64,
+				"--proxy-public-url=" + proxyPublicURL.String(),
 		},
 		{
 			name: "valid with proxy endpoint",
@@ -663,16 +654,13 @@ func TestBuildAWSOIDCIdPConfigureScript(t *testing.T) {
 				"awsRegion":       []string{"us-east-1"},
 				"role":            []string{"Test+1=2,3.4@5-6_7"},
 				"integrationName": []string{"myintegration"},
-				"s3Bucket":        []string{"my-bucket"},
-				"s3Prefix":        []string{"prefix"},
 			},
 			errCheck: require.NoError,
 			expectedTeleportArgs: "integration configure awsoidc-idp " +
 				"--cluster=localhost " +
 				"--name=myintegration " +
 				"--role=Test\\+1=2,3.4\\@5-6_7 " +
-				`--s3-bucket-uri=s3://my-bucket/prefix ` +
-				"--s3-jwks-base64=" + jwksBase64,
+				"--proxy-public-url=" + proxyPublicURL.String(),
 		},
 		{
 			name: "valid with supported policy preset",
@@ -687,42 +675,20 @@ func TestBuildAWSOIDCIdPConfigureScript(t *testing.T) {
 				"--cluster=localhost " +
 				"--name=myintegration " +
 				"--role=myRole " +
-				"--policy-preset=aws-identity-center " +
-				"--proxy-public-url=" + proxyPublicURL.String(),
+				"--proxy-public-url=" + proxyPublicURL.String() + " " +
+				"--policy-preset=aws-identity-center",
 		},
 		{
 			name: "missing role",
 			reqQuery: url.Values{
 				"integrationName": []string{"myintegration"},
-				"s3Bucket":        []string{"my-bucket"},
-				"s3Prefix":        []string{"prefix"},
 			},
 			errCheck: isBadParamErrFn,
 		},
 		{
 			name: "missing integration name",
 			reqQuery: url.Values{
-				"role":     []string{"role"},
-				"s3Bucket": []string{"my-bucket"},
-				"s3Prefix": []string{"prefix"},
-			},
-			errCheck: isBadParamErrFn,
-		},
-		{
-			name: "missing s3 bucket",
-			reqQuery: url.Values{
-				"integrationName": []string{"myintegration"},
-				"role":            []string{"role"},
-				"s3Prefix":        []string{"prefix"},
-			},
-			errCheck: isBadParamErrFn,
-		},
-		{
-			name: "missing s3 prefix",
-			reqQuery: url.Values{
-				"integrationName": []string{"myintegration"},
-				"role":            []string{"role"},
-				"s3Bucket":        []string{"my-bucket"},
+				"role": []string{"role"},
 			},
 			errCheck: isBadParamErrFn,
 		},
@@ -731,9 +697,13 @@ func TestBuildAWSOIDCIdPConfigureScript(t *testing.T) {
 			reqQuery: url.Values{
 				"integrationName": []string{"myintegration"},
 				"role":            []string{"role"},
-				"s3Bucket":        []string{"my-bucket"},
 			},
-			errCheck: isBadParamErrFn,
+			expectedTeleportArgs: "integration configure awsoidc-idp " +
+				"--cluster=localhost " +
+				"--name=myintegration " +
+				"--role=role " +
+				"--proxy-public-url=" + proxyPublicURL.String(),
+			errCheck: require.NoError,
 		},
 	}
 

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -1426,8 +1426,6 @@ export interface UrlDeployServiceIamConfigureScriptParams {
 export interface UrlAwsOidcConfigureIdp {
   integrationName: string;
   roleName: string;
-  s3Bucket?: string;
-  s3Prefix?: string;
   policyPreset?: AwsOidcPolicyPreset;
 }
 


### PR DESCRIPTION
This is dead code.
We don't allow setting up the S3 buckets from the UI. They were also being ignored if used in the teleport command.