### PR TITLE
Migrate S3 and KMS in lib/cloud/clients to SDK v2

### DIFF
--- a/lib/cloud/clients.go
+++ b/lib/cloud/clients.go
@@ -39,12 +39,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/request"
 	awssession "github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/kms"
-	"github.com/aws/aws-sdk-go/service/kms/kmsiface"
 	"github.com/aws/aws-sdk-go/service/opensearchservice"
 	"github.com/aws/aws-sdk-go/service/opensearchservice/opensearchserviceiface"
-	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
 	"github.com/aws/aws-sdk-go/service/sts"
@@ -105,10 +101,6 @@ type AWSClients interface {
 	GetAWSSecretsManagerClient(ctx context.Context, region string, opts ...AWSOptionsFn) (secretsmanageriface.SecretsManagerAPI, error)
 	// GetAWSSTSClient returns AWS STS client for the specified region.
 	GetAWSSTSClient(ctx context.Context, region string, opts ...AWSOptionsFn) (stsiface.STSAPI, error)
-	// GetAWSKMSClient returns AWS KMS client for the specified region.
-	GetAWSKMSClient(ctx context.Context, region string, opts ...AWSOptionsFn) (kmsiface.KMSAPI, error)
-	// GetAWSS3Client returns AWS S3 client.
-	GetAWSS3Client(ctx context.Context, region string, opts ...AWSOptionsFn) (s3iface.S3API, error)
 }
 
 // AzureClients is an interface for Azure-specific API clients
@@ -502,15 +494,6 @@ func (c *cloudClients) GetAWSSecretsManagerClient(ctx context.Context, region st
 	return secretsmanager.New(session), nil
 }
 
-// GetAWSS3Client returns AWS S3 client.
-func (c *cloudClients) GetAWSS3Client(ctx context.Context, region string, opts ...AWSOptionsFn) (s3iface.S3API, error) {
-	session, err := c.GetAWSSession(ctx, region, opts...)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return s3.New(session), nil
-}
-
 // GetAWSSTSClient returns AWS STS client for the specified region.
 func (c *cloudClients) GetAWSSTSClient(ctx context.Context, region string, opts ...AWSOptionsFn) (stsiface.STSAPI, error) {
 	session, err := c.GetAWSSession(ctx, region, opts...)
@@ -518,15 +501,6 @@ func (c *cloudClients) GetAWSSTSClient(ctx context.Context, region string, opts 
 		return nil, trace.Wrap(err)
 	}
 	return sts.New(session), nil
-}
-
-// GetAWSKMSClient returns AWS KMS client for the specified region.
-func (c *cloudClients) GetAWSKMSClient(ctx context.Context, region string, opts ...AWSOptionsFn) (kmsiface.KMSAPI, error) {
-	session, err := c.GetAWSSession(ctx, region, opts...)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return kms.New(session), nil
 }
 
 // GetGCPIAMClient returns GCP IAM client.
@@ -962,8 +936,6 @@ type TestCloudClients struct {
 	GCPProjects             gcp.ProjectsClient
 	GCPInstances            gcp.InstancesClient
 	InstanceMetadata        imds.Client
-	KMS                     kmsiface.KMSAPI
-	S3                      s3iface.S3API
 	AzureMySQL              azure.DBServersClient
 	AzureMySQLPerSub        map[string]azure.DBServersClient
 	AzurePostgres           azure.DBServersClient
@@ -1038,15 +1010,6 @@ func (c *TestCloudClients) GetAWSSecretsManagerClient(ctx context.Context, regio
 	return c.SecretsManager, nil
 }
 
-// GetAWSS3Client returns AWS S3 client.
-func (c *TestCloudClients) GetAWSS3Client(ctx context.Context, region string, opts ...AWSOptionsFn) (s3iface.S3API, error) {
-	_, err := c.GetAWSSession(ctx, region, opts...)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return c.S3, nil
-}
-
 // GetAWSSTSClient returns AWS STS client for the specified region.
 func (c *TestCloudClients) GetAWSSTSClient(ctx context.Context, region string, opts ...AWSOptionsFn) (stsiface.STSAPI, error) {
 	_, err := c.GetAWSSession(ctx, region, opts...)
@@ -1054,15 +1017,6 @@ func (c *TestCloudClients) GetAWSSTSClient(ctx context.Context, region string, o
 		return nil, trace.Wrap(err)
 	}
 	return c.STS, nil
-}
-
-// GetAWSKMSClient returns AWS KMS client for the specified region.
-func (c *TestCloudClients) GetAWSKMSClient(ctx context.Context, region string, opts ...AWSOptionsFn) (kmsiface.KMSAPI, error) {
-	_, err := c.GetAWSSession(ctx, region, opts...)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return c.KMS, nil
 }
 
 // GetGCPIAMClient returns GCP IAM client.

--- a/lib/cloud/mocks/aws_s3.go
+++ b/lib/cloud/mocks/aws_s3.go
@@ -19,92 +19,91 @@
 package mocks
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/gravitational/trace"
 )
 
-// S3Mock mocks AWS S3 API.
-type S3Mock struct {
-	s3iface.S3API
-	Buckets            []*s3.Bucket
+// S3Client mocks AWS S3 API.
+type S3Client struct {
+	Buckets            []s3types.Bucket
 	BucketPolicy       map[string]string
-	BucketPolicyStatus map[string]*s3.PolicyStatus
-	BucketACL          map[string][]*s3.Grant
-	BucketTags         map[string][]*s3.Tag
-	BucketLocations    map[string]string
+	BucketPolicyStatus map[string]s3types.PolicyStatus
+	BucketACL          map[string][]s3types.Grant
+	BucketTags         map[string][]s3types.Tag
+	BucketLocations    map[string]s3types.BucketLocationConstraint
 }
 
-func (m *S3Mock) ListBucketsWithContext(_ aws.Context, _ *s3.ListBucketsInput, _ ...request.Option) (*s3.ListBucketsOutput, error) {
+func (m *S3Client) ListBuckets(_ context.Context, _ *s3.ListBucketsInput, _ ...func(*s3.Options)) (*s3.ListBucketsOutput, error) {
 	return &s3.ListBucketsOutput{
 		Buckets: m.Buckets,
 	}, nil
 }
 
-func (m *S3Mock) GetBucketPolicyWithContext(_ aws.Context, input *s3.GetBucketPolicyInput, _ ...request.Option) (*s3.GetBucketPolicyOutput, error) {
-	if aws.StringValue(input.Bucket) == "" {
+func (m *S3Client) GetBucketPolicy(_ context.Context, input *s3.GetBucketPolicyInput, _ ...func(*s3.Options)) (*s3.GetBucketPolicyOutput, error) {
+	if aws.ToString(input.Bucket) == "" {
 		return nil, trace.BadParameter("incorrect bucket name")
 	}
-	policy, ok := m.BucketPolicy[aws.StringValue(input.Bucket)]
+	policy, ok := m.BucketPolicy[aws.ToString(input.Bucket)]
 	if !ok {
-		return nil, trace.NotFound("bucket %v not found", aws.StringValue(input.Bucket))
+		return nil, trace.NotFound("bucket %v not found", aws.ToString(input.Bucket))
 	}
 	return &s3.GetBucketPolicyOutput{
 		Policy: aws.String(policy),
 	}, nil
 }
 
-func (m *S3Mock) GetBucketPolicyStatusWithContext(_ aws.Context, input *s3.GetBucketPolicyStatusInput, _ ...request.Option) (*s3.GetBucketPolicyStatusOutput, error) {
-	if aws.StringValue(input.Bucket) == "" {
+func (m *S3Client) GetBucketPolicyStatus(_ context.Context, input *s3.GetBucketPolicyStatusInput, _ ...func(*s3.Options)) (*s3.GetBucketPolicyStatusOutput, error) {
+	if aws.ToString(input.Bucket) == "" {
 		return nil, trace.BadParameter("incorrect bucket name")
 	}
-	policyStatus, ok := m.BucketPolicyStatus[aws.StringValue(input.Bucket)]
+	policyStatus, ok := m.BucketPolicyStatus[aws.ToString(input.Bucket)]
 	if !ok {
-		return nil, trace.NotFound("bucket %v not found", aws.StringValue(input.Bucket))
+		return nil, trace.NotFound("bucket %v not found", aws.ToString(input.Bucket))
 	}
 	return &s3.GetBucketPolicyStatusOutput{
-		PolicyStatus: policyStatus,
+		PolicyStatus: &policyStatus,
 	}, nil
 }
 
-func (m *S3Mock) GetBucketAclWithContext(_ aws.Context, input *s3.GetBucketAclInput, _ ...request.Option) (*s3.GetBucketAclOutput, error) {
-	if aws.StringValue(input.Bucket) == "" {
+func (m *S3Client) GetBucketAcl(_ context.Context, input *s3.GetBucketAclInput, _ ...func(*s3.Options)) (*s3.GetBucketAclOutput, error) {
+	if aws.ToString(input.Bucket) == "" {
 		return nil, trace.BadParameter("incorrect bucket name")
 	}
-	grants, ok := m.BucketACL[aws.StringValue(input.Bucket)]
+	grants, ok := m.BucketACL[aws.ToString(input.Bucket)]
 	if !ok {
-		return nil, trace.NotFound("bucket %v not found", aws.StringValue(input.Bucket))
+		return nil, trace.NotFound("bucket %v not found", aws.ToString(input.Bucket))
 	}
 	return &s3.GetBucketAclOutput{
 		Grants: grants,
 	}, nil
 }
 
-func (m *S3Mock) GetBucketTaggingWithContext(_ aws.Context, input *s3.GetBucketTaggingInput, _ ...request.Option) (*s3.GetBucketTaggingOutput, error) {
-	if aws.StringValue(input.Bucket) == "" {
+func (m *S3Client) GetBucketTagging(_ context.Context, input *s3.GetBucketTaggingInput, _ ...func(*s3.Options)) (*s3.GetBucketTaggingOutput, error) {
+	if aws.ToString(input.Bucket) == "" {
 		return nil, trace.BadParameter("incorrect bucket name")
 	}
-	tags, ok := m.BucketTags[aws.StringValue(input.Bucket)]
+	tags, ok := m.BucketTags[aws.ToString(input.Bucket)]
 	if !ok {
-		return nil, awserr.New("NoSuchTagSet", "The specified bucket does not have a tag set", nil)
+		return nil, trace.NotFound("The specified bucket does not have a tag set")
 	}
 	return &s3.GetBucketTaggingOutput{
 		TagSet: tags,
 	}, nil
 }
 
-func (m *S3Mock) GetBucketLocationWithContext(_ aws.Context, input *s3.GetBucketLocationInput, _ ...request.Option) (*s3.GetBucketLocationOutput, error) {
-	if aws.StringValue(input.Bucket) == "" {
+func (m *S3Client) GetBucketLocation(_ context.Context, input *s3.GetBucketLocationInput, _ ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error) {
+	if aws.ToString(input.Bucket) == "" {
 		return nil, trace.BadParameter("incorrect bucket name")
 	}
-	location, ok := m.BucketLocations[aws.StringValue(input.Bucket)]
+	location, ok := m.BucketLocations[aws.ToString(input.Bucket)]
 	if !ok {
-		return nil, trace.NotFound("bucket %v not found", aws.StringValue(input.Bucket))
+		return nil, trace.NotFound("bucket %v not found", aws.ToString(input.Bucket))
 	}
 	return &s3.GetBucketLocationOutput{
-		LocationConstraint: aws.String(location),
+		LocationConstraint: location,
 	}, nil
 }

--- a/lib/srv/db/secrets/aws_secrets_manager.go
+++ b/lib/srv/db/secrets/aws_secrets_manager.go
@@ -26,7 +26,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
 	"github.com/google/uuid"
@@ -290,7 +289,7 @@ func defaultKMSKeyID(secretARN string) (string, error) {
 	// arn:aws:kms:us-east-1:1234567890:alias/aws/secretsmanager
 	arn := arn.ARN{
 		Partition: parsed.Partition,
-		Service:   kms.ServiceName,
+		Service:   "kms",
 		Region:    parsed.Region,
 		AccountID: parsed.AccountID,
 		Resource:  "alias/aws/secretsmanager",

--- a/lib/srv/discovery/fetchers/aws-sync/aws-sync.go
+++ b/lib/srv/discovery/fetchers/aws-sync/aws-sync.go
@@ -28,6 +28,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/gravitational/trace"
@@ -111,6 +112,8 @@ type awsClientProvider interface {
 	getIAMClient(cfg aws.Config, optFns ...func(*iam.Options)) iamClient
 	// getRDSClient provides an [rdsClient].
 	getRDSClient(cfg aws.Config, optFns ...func(*rds.Options)) rdsClient
+	// getS3Client provides an [s3Client].
+	getS3Client(cfg aws.Config, optFns ...func(*s3.Options)) s3Client
 }
 
 type defaultAWSClients struct{}
@@ -121,6 +124,10 @@ func (defaultAWSClients) getIAMClient(cfg aws.Config, optFns ...func(*iam.Option
 
 func (defaultAWSClients) getRDSClient(cfg aws.Config, optFns ...func(*rds.Options)) rdsClient {
 	return rds.NewFromConfig(cfg, optFns...)
+}
+
+func (defaultAWSClients) getS3Client(cfg aws.Config, optFns ...func(*s3.Options)) s3Client {
+	return s3.NewFromConfig(cfg, optFns...)
 }
 
 // AssumeRole is the configuration for assuming an AWS role.

--- a/lib/srv/discovery/fetchers/aws-sync/rds_test.go
+++ b/lib/srv/discovery/fetchers/aws-sync/rds_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -219,6 +220,7 @@ func dbClusters() []rdstypes.DBCluster {
 type fakeAWSClients struct {
 	iamClient iamClient
 	rdsClient rdsClient
+	s3Client  s3Client
 }
 
 func (f fakeAWSClients) getIAMClient(cfg aws.Config, optFns ...func(*iam.Options)) iamClient {
@@ -227,4 +229,8 @@ func (f fakeAWSClients) getIAMClient(cfg aws.Config, optFns ...func(*iam.Options
 
 func (f fakeAWSClients) getRDSClient(cfg aws.Config, optFns ...func(*rds.Options)) rdsClient {
 	return f.rdsClient
+}
+
+func (f fakeAWSClients) getS3Client(cfg aws.Config, optFns ...func(*s3.Options)) s3Client {
+	return f.s3Client
 }

--- a/lib/srv/discovery/fetchers/aws-sync/s3.go
+++ b/lib/srv/discovery/fetchers/aws-sync/s3.go
@@ -24,8 +24,9 @@ import (
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
 	"github.com/gravitational/trace"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/proto"
@@ -34,6 +35,17 @@ import (
 	accessgraphv1alpha "github.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha"
 	awsutil "github.com/gravitational/teleport/lib/utils/aws"
 )
+
+// s3Client defines a subset of the AWS S3 client API.
+type s3Client interface {
+	s3.ListBucketsAPIClient
+
+	GetBucketAcl(context.Context, *s3.GetBucketAclInput, ...func(*s3.Options)) (*s3.GetBucketAclOutput, error)
+	GetBucketLocation(context.Context, *s3.GetBucketLocationInput, ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error)
+	GetBucketPolicy(context.Context, *s3.GetBucketPolicyInput, ...func(*s3.Options)) (*s3.GetBucketPolicyOutput, error)
+	GetBucketPolicyStatus(context.Context, *s3.GetBucketPolicyStatusInput, ...func(*s3.Options)) (*s3.GetBucketPolicyStatusOutput, error)
+	GetBucketTagging(context.Context, *s3.GetBucketTaggingInput, ...func(*s3.Options)) (*s3.GetBucketTaggingOutput, error)
+}
 
 // pollAWSS3Buckets is a function that returns a function that fetches
 // AWS s3 buckets and their inline and attached policies.
@@ -145,18 +157,18 @@ func awsS3Bucket(name string,
 	return s3
 }
 
-func awsACLsToProtoACLs(grants []*s3.Grant) []*accessgraphv1alpha.AWSS3BucketACL {
+func awsACLsToProtoACLs(grants []s3types.Grant) []*accessgraphv1alpha.AWSS3BucketACL {
 	var acls []*accessgraphv1alpha.AWSS3BucketACL
 	for _, grant := range grants {
 		acls = append(acls, &accessgraphv1alpha.AWSS3BucketACL{
 			Grantee: &accessgraphv1alpha.AWSS3BucketACLGrantee{
 				Id:           aws.ToString(grant.Grantee.ID),
 				DisplayName:  aws.ToString(grant.Grantee.DisplayName),
-				Type:         aws.ToString(grant.Grantee.Type),
+				Type:         string(grant.Grantee.Type),
 				Uri:          aws.ToString(grant.Grantee.URI),
 				EmailAddress: aws.ToString(grant.Grantee.EmailAddress),
 			},
-			Permission: aws.ToString(grant.Permission),
+			Permission: string(grant.Permission),
 		})
 	}
 	return acls
@@ -201,16 +213,12 @@ type s3Details struct {
 	tags         *s3.GetBucketTaggingOutput
 }
 
-func (a *awsFetcher) getS3BucketDetails(ctx context.Context, bucket *s3.Bucket, bucketRegion string) (s3Details, failedRequests, []error) {
+func (a *awsFetcher) getS3BucketDetails(ctx context.Context, bucket s3types.Bucket, bucketRegion string) (s3Details, failedRequests, []error) {
 	var failedReqs failedRequests
 	var errs []error
 	var details s3Details
 
-	s3Client, err := a.CloudClients.GetAWSS3Client(
-		ctx,
-		bucketRegion,
-		a.getAWSOptions()...,
-	)
+	awsCfg, err := a.AWSConfigProvider.GetConfig(ctx, bucketRegion, a.getAWSV2Options()...)
 	if err != nil {
 		errs = append(errs,
 			trace.Wrap(err, "failed to create s3 client for bucket %q", aws.ToString(bucket.Name)),
@@ -224,8 +232,9 @@ func (a *awsFetcher) getS3BucketDetails(ctx context.Context, bucket *s3.Bucket, 
 				failedTags:         true,
 			}, errs
 	}
+	s3Client := a.awsClients.getS3Client(awsCfg)
 
-	details.policy, err = s3Client.GetBucketPolicyWithContext(ctx, &s3.GetBucketPolicyInput{
+	details.policy, err = s3Client.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{
 		Bucket: bucket.Name,
 	})
 	if err != nil && !isS3BucketPolicyNotFound(err) {
@@ -235,7 +244,7 @@ func (a *awsFetcher) getS3BucketDetails(ctx context.Context, bucket *s3.Bucket, 
 		failedReqs.policyFailed = true
 	}
 
-	details.policyStatus, err = s3Client.GetBucketPolicyStatusWithContext(ctx, &s3.GetBucketPolicyStatusInput{
+	details.policyStatus, err = s3Client.GetBucketPolicyStatus(ctx, &s3.GetBucketPolicyStatusInput{
 		Bucket: bucket.Name,
 	})
 	if err != nil && !isS3BucketPolicyNotFound(err) {
@@ -245,7 +254,7 @@ func (a *awsFetcher) getS3BucketDetails(ctx context.Context, bucket *s3.Bucket, 
 		failedReqs.failedPolicyStatus = true
 	}
 
-	details.acls, err = s3Client.GetBucketAclWithContext(ctx, &s3.GetBucketAclInput{
+	details.acls, err = s3Client.GetBucketAcl(ctx, &s3.GetBucketAclInput{
 		Bucket: bucket.Name,
 	})
 	if err != nil {
@@ -255,7 +264,7 @@ func (a *awsFetcher) getS3BucketDetails(ctx context.Context, bucket *s3.Bucket, 
 		failedReqs.failedAcls = true
 	}
 
-	details.tags, err = s3Client.GetBucketTaggingWithContext(ctx, &s3.GetBucketTaggingInput{
+	details.tags, err = s3Client.GetBucketTagging(ctx, &s3.GetBucketTaggingInput{
 		Bucket: bucket.Name,
 	})
 	if err != nil && !isS3BucketNoTagSet(err) {
@@ -268,38 +277,41 @@ func (a *awsFetcher) getS3BucketDetails(ctx context.Context, bucket *s3.Bucket, 
 	return details, failedReqs, errs
 }
 
+func isAPIErrorCode(err error, code string) bool {
+	var ae smithy.APIError
+	if errors.As(err, &ae) {
+		return ae.ErrorCode() == code
+	}
+	return false
+}
+
 func isS3BucketPolicyNotFound(err error) bool {
-	var awsErr awserr.Error
-	return errors.As(err, &awsErr) && awsErr.Code() == "NoSuchBucketPolicy"
+	return isAPIErrorCode(err, "NoSuchBucketPolicy")
 }
 
 func isS3BucketNoTagSet(err error) bool {
-	var awsErr awserr.Error
-	return errors.As(err, &awsErr) && awsErr.Code() == "NoSuchTagSet"
+	return isAPIErrorCode(err, "NoSuchTagSet")
 }
 
-func (a *awsFetcher) listS3Buckets(ctx context.Context) ([]*s3.Bucket, func(*string) (string, error), error) {
+func (a *awsFetcher) listS3Buckets(ctx context.Context) ([]s3types.Bucket, func(*string) (string, error), error) {
 	region := awsutil.GetKnownRegions()[0]
 	if len(a.Regions) > 0 {
 		region = a.Regions[0]
 	}
 
 	// use any region to list buckets
-	s3Client, err := a.CloudClients.GetAWSS3Client(
-		ctx,
-		region,
-		a.getAWSOptions()...,
-	)
+	awsCfg, err := a.AWSConfigProvider.GetConfig(ctx, region, a.getAWSV2Options()...)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
-	rsp, err := s3Client.ListBucketsWithContext(ctx, &s3.ListBucketsInput{})
+	s3Client := a.awsClients.getS3Client(awsCfg)
+	rsp, err := s3Client.ListBuckets(ctx, &s3.ListBucketsInput{})
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 	return rsp.Buckets,
 		func(bucket *string) (string, error) {
-			rsp, err := s3Client.GetBucketLocationWithContext(
+			rsp, err := s3Client.GetBucketLocation(
 				ctx,
 				&s3.GetBucketLocationInput{
 					Bucket: bucket,
@@ -308,9 +320,9 @@ func (a *awsFetcher) listS3Buckets(ctx context.Context) ([]*s3.Bucket, func(*str
 			if err != nil {
 				return "", trace.Wrap(err, "failed to fetch bucket %q region", aws.ToString(bucket))
 			}
-			if rsp.LocationConstraint == nil {
+			if rsp.LocationConstraint == "" {
 				return "us-east-1", nil
 			}
-			return aws.ToString(rsp.LocationConstraint), nil
+			return string(rsp.LocationConstraint), nil
 		}, nil
 }

--- a/lib/srv/discovery/fetchers/aws-sync/s3_test.go
+++ b/lib/srv/discovery/fetchers/aws-sync/s3_test.go
@@ -25,16 +25,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/gravitational/teleport/api/types"
 	accessgraphv1alpha "github.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha"
-	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/cloud/mocks"
 )
 
@@ -45,6 +45,14 @@ func TestPollAWSS3(t *testing.T) {
 		})
 	}
 
+	awsOIDCIntegration, err := types.NewIntegrationAWSOIDC(
+		types.Metadata{Name: "integration-test"},
+		&types.AWSOIDCIntegrationSpecV1{
+			RoleARN: "arn:aws:sts::123456789012:role/TestRole",
+		},
+	)
+	require.NoError(t, err)
+
 	const (
 		accountID       = "12345678"
 		bucketName      = "bucket1"
@@ -52,20 +60,20 @@ func TestPollAWSS3(t *testing.T) {
 		missingBucket   = "missing_perm_bucket"
 	)
 	var (
-		regions       = []string{"eu-west-1"}
-		mockedClients = &cloud.TestCloudClients{
-			S3: &mocks.S3Mock{
+		regions      = []string{"eu-west-1"}
+		fakedClients = fakeAWSClients{
+			s3Client: &mocks.S3Client{
 				Buckets: s3Buckets(bucketName, otherBucketName, missingBucket),
-				BucketLocations: map[string]string{
-					bucketName:      "eu-west-1",
-					otherBucketName: "eu-west-1",
-					missingBucket:   "eu-west-1",
+				BucketLocations: map[string]s3types.BucketLocationConstraint{
+					bucketName:      s3types.BucketLocationConstraintEuWest1,
+					otherBucketName: s3types.BucketLocationConstraintEuWest1,
+					missingBucket:   s3types.BucketLocationConstraintEuWest1,
 				},
 				BucketPolicy: map[string]string{
 					bucketName:      "policy",
 					otherBucketName: "otherPolicy",
 				},
-				BucketPolicyStatus: map[string]*s3.PolicyStatus{
+				BucketPolicyStatus: map[string]s3types.PolicyStatus{
 					bucketName: {
 						IsPublic: aws.Bool(true),
 					},
@@ -73,25 +81,25 @@ func TestPollAWSS3(t *testing.T) {
 						IsPublic: aws.Bool(false),
 					},
 				},
-				BucketACL: map[string][]*s3.Grant{
+				BucketACL: map[string][]s3types.Grant{
 					bucketName: {
 						{
-							Grantee: &s3.Grantee{
+							Grantee: &s3types.Grantee{
 								ID: aws.String("id"),
 							},
-							Permission: aws.String("READ"),
+							Permission: s3types.PermissionRead,
 						},
 					},
 					otherBucketName: {
 						{
-							Grantee: &s3.Grantee{
+							Grantee: &s3types.Grantee{
 								ID: aws.String("id"),
 							},
-							Permission: aws.String("READ"),
+							Permission: s3types.PermissionRead,
 						},
 					},
 				},
-				BucketTags: map[string][]*s3.Tag{
+				BucketTags: map[string][]s3types.Tag{
 					bucketName: {
 						{
 							Key:   aws.String("tag"),
@@ -168,10 +176,16 @@ func TestPollAWSS3(t *testing.T) {
 			}
 			a := &awsFetcher{
 				Config: Config{
-					AccountID:    accountID,
-					CloudClients: mockedClients,
-					Regions:      regions,
-					Integration:  accountID,
+					AWSConfigProvider: &mocks.AWSConfigProvider{
+						OIDCIntegrationClient: &mocks.FakeOIDCIntegrationClient{
+							Integration: awsOIDCIntegration,
+							Token:       "fake-oidc-token",
+						},
+					},
+					AccountID:   accountID,
+					Regions:     regions,
+					Integration: awsOIDCIntegration.GetName(),
+					awsClients:  fakedClients,
 				},
 				lastResult: &Resources{},
 			}
@@ -200,10 +214,10 @@ func TestPollAWSS3(t *testing.T) {
 	}
 }
 
-func s3Buckets(bucketNames ...string) []*s3.Bucket {
-	var output []*s3.Bucket
+func s3Buckets(bucketNames ...string) []s3types.Bucket {
+	var output []s3types.Bucket
 	for _, name := range bucketNames {
-		output = append(output, &s3.Bucket{
+		output = append(output, s3types.Bucket{
 			Name:         aws.String(name),
 			CreationDate: aws.Time(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
 		})


### PR DESCRIPTION
This PR removes the S3 and KMS client getters from lib/cloud/clients.
The only package that depended on the S3 client getter was in aws-sync, which was migrated to use SDK v2 clients.
The KMS client getter was not used anywhere.

Part of https://github.com/gravitational/teleport/issues/14142
- https://github.com/gravitational/teleport/issues/14142