### PR TITLE
Migrate AWS Cassandra (Keyspaces) authenticator initialization to AWS SDK V2

### DIFF
--- a/lib/srv/db/cassandra/engine.go
+++ b/lib/srv/db/cassandra/engine.go
@@ -309,8 +309,8 @@ func (e *Engine) getAuth(sessionCtx *common.Session) (handshakeHandler, error) {
 	switch {
 	case sessionCtx.Database.IsAWSHosted():
 		return &authAWSSigV4Auth{
-			cloudClients: e.CloudClients,
-			ses:          sessionCtx,
+			ses:       sessionCtx,
+			awsConfig: e.AWSConfigProvider,
 		}, nil
 	default:
 		return &basicHandshake{ses: sessionCtx}, nil

--- a/lib/srv/db/cassandra/handshake.go
+++ b/lib/srv/db/cassandra/handshake.go
@@ -200,9 +200,16 @@ func (a *authAWSSigV4Auth) getSigV4Authenticator(ctx context.Context) (gocql.Aut
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	// ExternalID should only be used in one of the assumed roles. If the
+	// configuration doesn't specify the AssumeRoleARN, it should be used for
+	// the database role.
+	var dbRoleExternalID string
+	if meta.AssumeRoleARN == "" {
+		dbRoleExternalID = meta.ExternalID
+	}
 	awsCfg, err := a.awsConfig.GetConfig(ctx, meta.Region,
 		awsconfig.WithAssumeRole(meta.AssumeRoleARN, meta.ExternalID),
-		awsconfig.WithAssumeRole(roleARN, meta.ExternalID),
+		awsconfig.WithAssumeRole(roleARN, dbRoleExternalID),
 		awsconfig.WithAmbientCredentials(),
 	)
 	if err != nil {

--- a/lib/srv/db/cassandra/handshake.go
+++ b/lib/srv/db/cassandra/handshake.go
@@ -28,7 +28,7 @@ import (
 	"github.com/gocql/gocql"
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/lib/cloud"
+	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 	"github.com/gravitational/teleport/lib/srv/db/cassandra/protocol"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	awsutils "github.com/gravitational/teleport/lib/utils/aws"
@@ -190,8 +190,8 @@ func sendAuthenticationErrorMessage(authErr error, clientConn *protocol.Conn, in
 
 // authHandler is a handler that performs the Cassandra authentication flow.
 type authAWSSigV4Auth struct {
-	ses          *common.Session
-	cloudClients cloud.Clients
+	ses       *common.Session
+	awsConfig awsconfig.Provider
 }
 
 func (a *authAWSSigV4Auth) getSigV4Authenticator(ctx context.Context) (gocql.Authenticator, error) {
@@ -200,25 +200,15 @@ func (a *authAWSSigV4Auth) getSigV4Authenticator(ctx context.Context) (gocql.Aut
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	baseSession, err := a.cloudClients.GetAWSSession(ctx, meta.Region,
-		cloud.WithAssumeRoleFromAWSMeta(meta),
-		cloud.WithAmbientCredentials(),
+	awsCfg, err := a.awsConfig.GetConfig(ctx, meta.Region,
+		awsconfig.WithAssumeRole(meta.AssumeRoleARN, meta.ExternalID),
+		awsconfig.WithAssumeRole(roleARN, meta.ExternalID),
+		awsconfig.WithAmbientCredentials(),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	var externalID string
-	if meta.AssumeRoleARN == "" {
-		externalID = meta.ExternalID
-	}
-	session, err := a.cloudClients.GetAWSSession(ctx, meta.Region,
-		cloud.WithChainedAssumeRole(baseSession, roleARN, externalID),
-		cloud.WithAmbientCredentials(),
-	)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	cred, err := session.Config.Credentials.GetWithContext(ctx)
+	cred, err := awsCfg.Credentials.Retrieve(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
Related #14142

This PR migrated the AWS Cassandra (Keyspaces) authenticator generation to AWS SDK V2. This only updates the Teleport side of the authenticator (initialization). The [authenticator](https://github.com/aws/aws-sigv4-auth-cassandra-gocql-driver-plugin) still uses the SDK V1.

Note about testing: To be able to write unit tests for this flow, we would need to implement our handshake handler for the server and simulate the AWS Keyspace authentication. Although possible, it doesn't fit this PR, so I'm leaving this for a future change. For this change, testing will be done manually (including on the test plan).