### PR TITLE
Migrate AWS SecretsManager clients to AWS SDK v2

### DIFF
--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -94,6 +94,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.53.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.25.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.72.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.56.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.24.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.29.8 // indirect

--- a/integrations/event-handler/go.sum
+++ b/integrations/event-handler/go.sum
@@ -184,6 +184,8 @@ github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.25.1 h1:anb79RuKbIO8z
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.25.1/go.mod h1:u4NPdVb3te3+QB4rdjFGE9Of4V3vPqrPbTk6fAR6qf8=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.72.0 h1:SAfh4pNx5LuTafKKWR02Y+hL3A+3TX8cTKG1OIAJaBk=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.72.0/go.mod h1:r+xl5yzMk9083rMR+sJ5TYj9Tihvf/l1oxzZXDgGj2Q=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.8 h1:WT3EPriVEpHE2jeNqHqj7l43JCIWPoZjNNRluZ7agII=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.8/go.mod h1:By/yiMzR0yfhPaqRWE3GrT9B/Z6871z1GfWGc+vf4Y8=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.56.2 h1:MOxvXH2kRP5exvqJxAZ0/H9Ar51VmADJh95SgZE8u60=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.56.2/go.mod h1:RKWoqC9FlgMCkrfVOtgfqfwdaUIaq8H93UAt4xNaR0A=
 github.com/aws/aws-sdk-go-v2/service/sso v1.24.8 h1:CvuUmnXI7ebaUAhbJcDy9YQx8wHR69eZ9I7q5hszt/g=

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -106,6 +106,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.53.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.25.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.72.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.56.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.24.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.29.8 // indirect

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -288,6 +288,8 @@ github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.25.1 h1:anb79RuKbIO8z
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.25.1/go.mod h1:u4NPdVb3te3+QB4rdjFGE9Of4V3vPqrPbTk6fAR6qf8=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.72.0 h1:SAfh4pNx5LuTafKKWR02Y+hL3A+3TX8cTKG1OIAJaBk=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.72.0/go.mod h1:r+xl5yzMk9083rMR+sJ5TYj9Tihvf/l1oxzZXDgGj2Q=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.8 h1:WT3EPriVEpHE2jeNqHqj7l43JCIWPoZjNNRluZ7agII=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.8/go.mod h1:By/yiMzR0yfhPaqRWE3GrT9B/Z6871z1GfWGc+vf4Y8=
 github.com/aws/aws-sdk-go-v2/service/sns v1.33.8 h1:zKokiUMOfbZSrAUVqw+bSjr6gl9u/JcvPzHTmL+tmdQ=
 github.com/aws/aws-sdk-go-v2/service/sns v1.33.8/go.mod h1:Nf9YEyqE51C+Dyj0DWSATxvsr39jBFIss6Jee9Hyqx4=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.37.4 h1:WpoMCoS4+qOkkuWQommvDRboKYzK91En6eXO/k5dXr0=

--- a/lib/cloud/aws/tags_helpers.go
+++ b/lib/cloud/aws/tags_helpers.go
@@ -30,7 +30,7 @@ import (
 	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	redshifttypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
 	rsstypes "github.com/aws/aws-sdk-go-v2/service/redshiftserverless/types"
-	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
 
 	"github.com/gravitational/teleport/api/types"
 )
@@ -46,7 +46,7 @@ type ResourceTag interface {
 		memorydbtypes.Tag |
 		rsstypes.Tag |
 		opensearchtypes.Tag |
-		*secretsmanager.Tag
+		smtypes.Tag
 }
 
 // TagsToLabels converts a list of AWS resource tags to a label map.
@@ -84,7 +84,7 @@ func resourceTagToKeyValue[Tag ResourceTag](tag Tag) (string, string) {
 		return aws.ToString(v.Key), aws.ToString(v.Value)
 	case opensearchtypes.Tag:
 		return aws.ToString(v.Key), aws.ToString(v.Value)
-	case *secretsmanager.Tag:
+	case smtypes.Tag:
 		return aws.ToString(v.Key), aws.ToString(v.Value)
 	default:
 		return "", ""

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -91,7 +91,6 @@ import (
 	"github.com/gravitational/teleport/lib/srv/db/postgres"
 	"github.com/gravitational/teleport/lib/srv/db/redis"
 	redisprotocol "github.com/gravitational/teleport/lib/srv/db/redis/protocol"
-	"github.com/gravitational/teleport/lib/srv/db/secrets"
 	"github.com/gravitational/teleport/lib/srv/db/snowflake"
 	"github.com/gravitational/teleport/lib/srv/db/spanner"
 	"github.com/gravitational/teleport/lib/srv/db/sqlserver"
@@ -2484,9 +2483,8 @@ func (p *agentParams) setDefaults(c *testContext) {
 
 	if p.CloudClients == nil {
 		p.CloudClients = &clients.TestCloudClients{
-			STS:            &mocks.STSClientV1{},
-			SecretsManager: secrets.NewMockSecretsManagerClient(secrets.MockSecretsManagerClientConfig{}),
-			GCPSQL:         p.GCPSQL,
+			STS:    &mocks.STSClientV1{},
+			GCPSQL: p.GCPSQL,
 		}
 	}
 	if p.AWSConfigProvider == nil {

--- a/lib/srv/db/cloud/users/elasticache.go
+++ b/lib/srv/db/cloud/users/elasticache.go
@@ -88,22 +88,23 @@ func (f *elastiCacheFetcher) FetchDatabaseUsers(ctx context.Context, database ty
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	client := f.cfg.awsClients.getElastiCacheClient(awsCfg)
 
-	secrets, err := newSecretStore(ctx, database, f.cfg.Clients, f.cfg.ClusterName)
+	smClt := f.cfg.awsClients.getSecretsManagerClient(awsCfg)
+	secrets, err := newSecretStore(database.GetSecretStore(), smClt, f.cfg.ClusterName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
+	ecClient := f.cfg.awsClients.getElastiCacheClient(awsCfg)
 	users := []User{}
 	for _, userGroupID := range meta.ElastiCache.UserGroupIDs {
-		managedUsers, err := f.getManagedUsersForGroup(ctx, meta.Region, userGroupID, client)
+		managedUsers, err := f.getManagedUsersForGroup(ctx, meta.Region, userGroupID, ecClient)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
 		for _, managedUser := range managedUsers {
-			user, err := f.createUser(&managedUser, client, secrets)
+			user, err := f.createUser(&managedUser, ecClient, secrets)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}

--- a/lib/srv/db/cloud/users/helpers.go
+++ b/lib/srv/db/cloud/users/helpers.go
@@ -19,15 +19,13 @@
 package users
 
 import (
-	"context"
 	"strings"
 	"sync"
 
-	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/srv/db/secrets"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -166,21 +164,10 @@ func genRandomPassword(length int) (string, error) {
 }
 
 // newSecretStore create a new secrets store helper for provided database.
-func newSecretStore(ctx context.Context, database types.Database, clients cloud.Clients, clusterName string) (secrets.Secrets, error) {
-	secretStoreConfig := database.GetSecretStore()
-
-	meta := database.GetAWS()
-	client, err := clients.GetAWSSecretsManagerClient(ctx, meta.Region,
-		cloud.WithAssumeRoleFromAWSMeta(meta),
-		cloud.WithAmbientCredentials(),
-	)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
+func newSecretStore(ss types.SecretStore, client secrets.SecretsManagerClient, clusterName string) (secrets.Secrets, error) {
 	return secrets.NewAWSSecretsManager(secrets.AWSSecretsManagerConfig{
-		KeyPrefix:   secretStoreConfig.KeyPrefix,
-		KMSKeyID:    secretStoreConfig.KMSKeyID,
+		KeyPrefix:   ss.KeyPrefix,
+		KMSKeyID:    ss.KMSKeyID,
 		Client:      client,
 		ClusterName: clusterName,
 	})

--- a/lib/srv/db/cloud/users/memorydb.go
+++ b/lib/srv/db/cloud/users/memorydb.go
@@ -89,19 +89,20 @@ func (f *memoryDBFetcher) FetchDatabaseUsers(ctx context.Context, database types
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	clt := f.cfg.awsClients.getMemoryDBClient(awsCfg)
 
-	secrets, err := newSecretStore(ctx, database, f.cfg.Clients, f.cfg.ClusterName)
+	smClt := f.cfg.awsClients.getSecretsManagerClient(awsCfg)
+	secrets, err := newSecretStore(database.GetSecretStore(), smClt, f.cfg.ClusterName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	users := []User{}
+	clt := f.cfg.awsClients.getMemoryDBClient(awsCfg)
 	mdbUsers, err := f.getManagedUsersForACL(ctx, meta.Region, meta.MemoryDB.ACLName, clt)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
+	users := []User{}
 	for _, mdbUser := range mdbUsers {
 		user, err := f.createUser(&mdbUser, clt, secrets)
 		if err != nil {

--- a/lib/srv/db/cloud/users/user_test.go
+++ b/lib/srv/db/cloud/users/user_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/lib/cloud/mocks"
 	libsecrets "github.com/gravitational/teleport/lib/srv/db/secrets"
 )
 
@@ -39,7 +40,7 @@ func TestBaseUser(t *testing.T) {
 	mockCloudResource := newMockCloudResource()
 
 	secrets, err := libsecrets.NewAWSSecretsManager(libsecrets.AWSSecretsManagerConfig{
-		Client: libsecrets.NewMockSecretsManagerClient(libsecrets.MockSecretsManagerClientConfig{
+		Client: mocks.NewSecretsManagerClient(mocks.SecretsManagerClientConfig{
 			Clock: clock,
 		}),
 		ClusterName: "example.teleport.sh",

--- a/lib/srv/db/cloud/users/users.go
+++ b/lib/srv/db/cloud/users/users.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	elasticache "github.com/aws/aws-sdk-go-v2/service/elasticache"
 	memorydb "github.com/aws/aws-sdk-go-v2/service/memorydb"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 
@@ -34,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/cloud/awsconfig"
+	"github.com/gravitational/teleport/lib/srv/db/secrets"
 	"github.com/gravitational/teleport/lib/utils/interval"
 )
 
@@ -63,6 +65,7 @@ type Config struct {
 type awsClientProvider interface {
 	getElastiCacheClient(cfg aws.Config, optFns ...func(*elasticache.Options)) elasticacheClient
 	getMemoryDBClient(cfg aws.Config, optFns ...func(*memorydb.Options)) memoryDBClient
+	getSecretsManagerClient(cfg aws.Config, optFns ...func(*secretsmanager.Options)) secrets.SecretsManagerClient
 }
 
 type defaultAWSClients struct{}
@@ -73,6 +76,10 @@ func (defaultAWSClients) getElastiCacheClient(cfg aws.Config, optFns ...func(*el
 
 func (defaultAWSClients) getMemoryDBClient(cfg aws.Config, optFns ...func(*memorydb.Options)) memoryDBClient {
 	return memorydb.NewFromConfig(cfg, optFns...)
+}
+
+func (defaultAWSClients) getSecretsManagerClient(cfg aws.Config, optFns ...func(*secretsmanager.Options)) secrets.SecretsManagerClient {
+	return secretsmanager.NewFromConfig(cfg, optFns...)
 }
 
 // CheckAndSetDefaults validates the config and set defaults.

--- a/lib/srv/db/cloud/users/users_test.go
+++ b/lib/srv/db/cloud/users/users_test.go
@@ -30,6 +30,7 @@ import (
 	ectypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
 	memorydb "github.com/aws/aws-sdk-go-v2/service/memorydb"
 	memorydbtypes "github.com/aws/aws-sdk-go-v2/service/memorydb/types"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
@@ -39,7 +40,7 @@ import (
 	libaws "github.com/gravitational/teleport/lib/cloud/aws"
 	"github.com/gravitational/teleport/lib/cloud/mocks"
 	"github.com/gravitational/teleport/lib/defaults"
-	libsecrets "github.com/gravitational/teleport/lib/srv/db/secrets"
+	"github.com/gravitational/teleport/lib/srv/db/secrets"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -60,7 +61,7 @@ func TestUsers(t *testing.T) {
 	t.Cleanup(cancel)
 
 	clock := clockwork.NewFakeClock()
-	smMock := libsecrets.NewMockSecretsManagerClient(libsecrets.MockSecretsManagerClientConfig{
+	smMock := mocks.NewSecretsManagerClient(mocks.SecretsManagerClientConfig{
 		Clock: clock,
 	})
 	ecMock := &mocks.ElastiCacheClient{}
@@ -84,10 +85,8 @@ func TestUsers(t *testing.T) {
 
 	users, err := NewUsers(Config{
 		AWSConfigProvider: &mocks.AWSConfigProvider{},
-		Clients: &clients.TestCloudClients{
-			SecretsManager: smMock,
-		},
-		Clock: clock,
+		Clients:           &clients.TestCloudClients{},
+		Clock:             clock,
 		UpdateMeta: func(_ context.Context, database types.Database) error {
 			// Update db1 to group3 when setupAllDatabases.
 			if database == db1 {
@@ -101,6 +100,7 @@ func TestUsers(t *testing.T) {
 		awsClients: fakeAWSClients{
 			ecClient:  ecMock,
 			mdbClient: mdbMock,
+			smClient:  smMock,
 		},
 	})
 	require.NoError(t, err)
@@ -218,8 +218,9 @@ func memoryDBUser(name string, aclNames ...string) memorydbtypes.User {
 }
 
 type fakeAWSClients struct {
-	mdbClient memoryDBClient
 	ecClient  elasticacheClient
+	mdbClient memoryDBClient
+	smClient  secrets.SecretsManagerClient
 }
 
 func (f fakeAWSClients) getElastiCacheClient(cfg aws.Config, optFns ...func(*elasticache.Options)) elasticacheClient {
@@ -228,4 +229,8 @@ func (f fakeAWSClients) getElastiCacheClient(cfg aws.Config, optFns ...func(*ela
 
 func (f fakeAWSClients) getMemoryDBClient(cfg aws.Config, optFns ...func(*memorydb.Options)) memoryDBClient {
 	return f.mdbClient
+}
+
+func (f fakeAWSClients) getSecretsManagerClient(cfg aws.Config, optFns ...func(*secretsmanager.Options)) secrets.SecretsManagerClient {
+	return f.smClient
 }

--- a/lib/srv/db/secrets/aws_secrets_manager_test.go
+++ b/lib/srv/db/secrets/aws_secrets_manager_test.go
@@ -23,16 +23,18 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/cloud/mocks"
 )
 
 func TestAWSSecretsManager(t *testing.T) {
 	createFunc := func(_ context.Context) (Secrets, error) {
 		secrets, err := NewAWSSecretsManager(AWSSecretsManagerConfig{
-			Client:      NewMockSecretsManagerClient(MockSecretsManagerClientConfig{}),
+			Client:      mocks.NewSecretsManagerClient(mocks.SecretsManagerClientConfig{}),
 			ClusterName: "example.teleport.sh",
 		})
 		if err != nil {
@@ -69,7 +71,7 @@ func TestAWSSecretsManager(t *testing.T) {
 		t.Cleanup(cancel)
 
 		// Create secret for the first time with default KMS.
-		client := NewMockSecretsManagerClient(MockSecretsManagerClientConfig{})
+		client := mocks.NewSecretsManagerClient(mocks.SecretsManagerClientConfig{})
 		secrets, err := NewAWSSecretsManager(AWSSecretsManagerConfig{
 			Client:      client,
 			ClusterName: "example.teleport.sh",
@@ -77,11 +79,11 @@ func TestAWSSecretsManager(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, secrets.CreateOrUpdate(ctx, "key", "value"))
 
-		output1, err := client.DescribeSecretWithContext(ctx, &secretsmanager.DescribeSecretInput{
+		output1, err := client.DescribeSecret(ctx, &secretsmanager.DescribeSecretInput{
 			SecretId: aws.String("teleport/key"),
 		})
 		require.NoError(t, err)
-		require.Equal(t, "arn:aws:kms:us-east-1:123456789012:alias/aws/secretsmanager", aws.StringValue(output1.KmsKeyId))
+		require.Equal(t, "arn:aws:kms:us-east-1:123456789012:alias/aws/secretsmanager", aws.ToString(output1.KmsKeyId))
 
 		// Create secret for the second time with custom KMS. Create returns
 		// IsAlreadyExists but KMSKeyID should be updated.
@@ -93,11 +95,11 @@ func TestAWSSecretsManager(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, trace.IsAlreadyExists(secrets.CreateOrUpdate(ctx, "key", "value")))
 
-		output2, err := client.DescribeSecretWithContext(ctx, &secretsmanager.DescribeSecretInput{
+		output2, err := client.DescribeSecret(ctx, &secretsmanager.DescribeSecretInput{
 			SecretId: aws.String("teleport/key"),
 		})
 		require.NoError(t, err)
-		require.Equal(t, "customKMS", aws.StringValue(output2.KmsKeyId))
+		require.Equal(t, "customKMS", aws.ToString(output2.KmsKeyId))
 
 		// Verify the versions are kept.
 		require.Equal(t, output1.VersionIdsToStages, output2.VersionIdsToStages)


### PR DESCRIPTION
This PR migrates all uses of AWS SecretsManager clients to AWS SDK v2.

This PR depends on and is stacked on top of another PR:
- #51052

Part of https://github.com/gravitational/teleport/issues/14142
- https://github.com/gravitational/teleport/issues/14142
