### PR TITLE
Fix HTTPS thumbprint lookup test

### DIFF
--- a/lib/integrations/awsoidc/idp_thumbprint_test.go
+++ b/lib/integrations/awsoidc/idp_thumbprint_test.go
@@ -20,6 +20,8 @@ package awsoidc
 
 import (
 	"context"
+	"crypto/sha1"
+	"encoding/hex"
 	"net/http/httptest"
 	"testing"
 
@@ -40,10 +42,8 @@ func TestThumbprint(t *testing.T) {
 	thumbprint, err := ThumbprintIdP(ctx, tlsServer.URL)
 	require.NoError(t, err)
 
-	// The Proxy is started using httptest.NewTLSServer, which uses a hard-coded cert
-	// located at go/src/net/http/internal/testcert/testcert.go
-	// The following value is the sha1 fingerprint of that certificate.
-	expectedThumbprint := "15dbd260c7465ecca6de2c0b2181187f66ee0d1a"
+	serverCertificateSHA1 := sha1.Sum(tlsServer.Certificate().Raw)
+	expectedThumbprint := hex.EncodeToString(serverCertificateSHA1[:])
 
 	require.Equal(t, expectedThumbprint, thumbprint)
 }

--- a/lib/web/oidcidp_test.go
+++ b/lib/web/oidcidp_test.go
@@ -20,6 +20,8 @@ package web
 
 import (
 	"context"
+	"crypto/sha1"
+	"encoding/hex"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -99,10 +101,8 @@ func TestThumbprint(t *testing.T) {
 
 	thumbprint := strings.Trim(string(resp.Bytes()), "\"")
 
-	// The Proxy is started using httptest.NewTLSServer, which uses a hard-coded cert
-	// located at go/src/net/http/internal/testcert/testcert.go
-	// The following value is the sha1 fingerprint of that certificate.
-	expectedThumbprint := "15dbd260c7465ecca6de2c0b2181187f66ee0d1a"
+	serverCertificateSHA1 := sha1.Sum(proxy.web.TLS.Certificates[0].Leaf.Raw)
+	expectedThumbprint := hex.EncodeToString(serverCertificateSHA1[:])
 
 	require.Equal(t, expectedThumbprint, thumbprint)
 }


### PR DESCRIPTION
Go 1.23.5 changed the certificate (added another host), and the thumbprint is now different.
Instead of updating the thumbprint, we now rely on the presented certificate by the TLS Server.

This should ensure the test doesn't break again if the test certificate is changed again.