### PR TITLE
[v15] Fix HTTPS thumbprint lookup test

### DIFF
--- a/lib/integrations/awsoidc/idp_thumbprint_test.go
+++ b/lib/integrations/awsoidc/idp_thumbprint_test.go
@@ -20,6 +20,8 @@ package awsoidc
 
 import (
 	"context"
+	"crypto/sha1"
+	"encoding/hex"
 	"net/http/httptest"
 	"testing"
 
@@ -40,10 +42,8 @@ func TestThumbprint(t *testing.T) {
 	thumbprint, err := ThumbprintIdP(ctx, tlsServer.URL)
 	require.NoError(t, err)
 
-	// The Proxy is started using httptest.NewTLSServer, which uses a hard-coded cert
-	// located at go/src/net/http/internal/testcert/testcert.go
-	// The following value is the sha1 fingerprint of that certificate.
-	expectedThumbprint := "15dbd260c7465ecca6de2c0b2181187f66ee0d1a"
+	serverCertificateSHA1 := sha1.Sum(tlsServer.Certificate().Raw)
+	expectedThumbprint := hex.EncodeToString(serverCertificateSHA1[:])
 
 	require.Equal(t, expectedThumbprint, thumbprint)
 }

--- a/lib/web/oidcidp_test.go
+++ b/lib/web/oidcidp_test.go
@@ -20,6 +20,8 @@ package web
 
 import (
 	"context"
+	"crypto/sha1"
+	"encoding/hex"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -103,10 +105,8 @@ func TestThumbprint(t *testing.T) {
 
 	thumbprint := strings.Trim(string(resp.Bytes()), "\"")
 
-	// The Proxy is started using httptest.NewTLSServer, which uses a hard-coded cert
-	// located at go/src/net/http/internal/testcert/testcert.go
-	// The following value is the sha1 fingerprint of that certificate.
-	expectedThumbprint := "15dbd260c7465ecca6de2c0b2181187f66ee0d1a"
+	serverCertificateSHA1 := sha1.Sum(proxy.web.TLS.Certificates[0].Leaf.Raw)
+	expectedThumbprint := hex.EncodeToString(serverCertificateSHA1[:])
 
 	require.Equal(t, expectedThumbprint, thumbprint)
 }

--- a/lib/web/oidcidp_test.go
+++ b/lib/web/oidcidp_test.go
@@ -105,7 +105,9 @@ func TestThumbprint(t *testing.T) {
 
 	thumbprint := strings.Trim(string(resp.Bytes()), "\"")
 
-	serverCertificateSHA1 := sha1.Sum(proxy.web.TLS.Certificates[0].Leaf.Raw)
+	require.NotEmpty(t, proxy.web.TLS.Certificates, "missing web tls certificates")
+	require.NotEmpty(t, proxy.web.TLS.Certificates[0].Certificate, "missing web tls certificates")
+	serverCertificateSHA1 := sha1.Sum(proxy.web.TLS.Certificates[0].Certificate[0])
 	expectedThumbprint := hex.EncodeToString(serverCertificateSHA1[:])
 
 	require.Equal(t, expectedThumbprint, thumbprint)


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/51152 to v15