### PR TITLE
[v17] Docs: remove mention to Teleport 6

### DIFF
--- a/docs/pages/reference/architecture/api-architecture.mdx
+++ b/docs/pages/reference/architecture/api-architecture.mdx
@@ -87,10 +87,9 @@ Here are some more specific details to differentiate them by:
 | - | - | - | - | - |
 | Ease of use | Easy | Easy | Medium | Hard |
 | Supports long-lived certificates | Yes, but must be configured on server side | Yes | Yes | Yes |
-| Supports SSH connections | Yes | Yes (6.1+) | No | No |
+| Supports SSH connections | Yes | Yes | No | No |
 | Automatic Proxy Address discovery | Yes | No | No | No |
 | CLI used | tsh | tctl/tsh | tctl | - |
-| Available in | 6.1+ | 6.0+ | 6.0+ | 6.0+ |
 
 See the [Credentials type](https://pkg.go.dev/github.com/gravitational/teleport/api/client#Credentials)
 on pkg.go.dev for more information and examples for Credentials and Credential Loaders.

--- a/examples/resources/admin.yaml
+++ b/examples/resources/admin.yaml
@@ -1,6 +1,6 @@
 #
 # Example: Legacy Default Admin Role
-# Tip: For 6.0+ clusters, please use 'editor' for configuring Teleport
+# Tip: Use 'editor' for configuring Teleport
 #
 kind: role
 metadata:


### PR DESCRIPTION
Backport #51168 to branch/v17