### PR TITLE
Add client-side functions to export multiple authorities

### DIFF
--- a/lib/client/ca_export.go
+++ b/lib/client/ca_export.go
@@ -80,7 +80,8 @@ type ExportedAuthority struct {
 	Data []byte
 }
 
-// ExportAllAuthorities returns authorities in OpenSSH compatible formats.
+// ExportAllAuthorities returns all authorities of a particular type in OpenSSH
+// compatible formats.
 // If the ExportAuthoritiesRequest.AuthType is present only prints keys for CAs of this type,
 // otherwise returns host and user SSH keys.
 //
@@ -111,7 +112,8 @@ func ExportAllAuthorities(ctx context.Context, client authclient.ClientI, req Ex
 	return exportAllAuthorities(ctx, client, req, exportSecrets)
 }
 
-// ExportAllAuthoritiesSecrets exports authority private keys.
+// ExportAllAuthoritiesSecrets exports private keys of all authorities of a
+// particular type.
 // See [ExportAllAuthorities] for more information.
 //
 // At least one authority is guaranteed on success.

--- a/lib/client/ca_export.go
+++ b/lib/client/ca_export.go
@@ -80,10 +80,12 @@ type ExportedAuthority struct {
 	Data []byte
 }
 
-// ExportAllAuthorities returns all authorities of a particular type in OpenSSH
-// compatible formats.
-// If the ExportAuthoritiesRequest.AuthType is present only prints keys for CAs of this type,
-// otherwise returns host and user SSH keys.
+// ExportAllAuthorities exports public keys of all authorities of a particular
+// type. The export format depends on the authority type, see below for
+// details.
+//
+// An empty ExportAuthoritiesRequest.AuthType is interpreted as an export for
+// host and user SSH keys.
 //
 // Exporting using "tls*", "database", "windows" AuthType:
 // Returns the certificate authority public key to be used by systems that rely on TLS.

--- a/lib/client/ca_export.go
+++ b/lib/client/ca_export.go
@@ -71,7 +71,16 @@ func (r *ExportAuthoritiesRequest) shouldExportIntegration(ctx context.Context) 
 	}
 }
 
-// ExportAuthorities returns the list of authorities in OpenSSH compatible formats as a string.
+// ExportedAuthority represents an exported authority certificate, as returned
+// by [ExportAllAuthorities] or [ExportAllAuthoritiesSecrets].
+type ExportedAuthority struct {
+	// Data is the output of the exported authority.
+	// May be an SSH authorized key, an SSH known hosts entry, a DER or a PEM,
+	// depending on the type of the exported authority.
+	Data []byte
+}
+
+// ExportAllAuthorities returns authorities in OpenSSH compatible formats.
 // If the ExportAuthoritiesRequest.AuthType is present only prints keys for CAs of this type,
 // otherwise returns host and user SSH keys.
 //
@@ -95,27 +104,91 @@ func (r *ExportAuthoritiesRequest) shouldExportIntegration(ctx context.Context) 
 // For example:
 // > @cert-authority *.cluster-a ssh-rsa AAA... type=host
 // URL encoding is used to pass the CA type and allowed logins into the comment field.
+//
+// At least one authority is guaranteed on success.
+func ExportAllAuthorities(ctx context.Context, client authclient.ClientI, req ExportAuthoritiesRequest) ([]*ExportedAuthority, error) {
+	const exportSecrets = false
+	return exportAllAuthorities(ctx, client, req, exportSecrets)
+}
+
+// ExportAllAuthoritiesSecrets exports authority private keys.
+// See [ExportAllAuthorities] for more information.
+//
+// At least one authority is guaranteed on success.
+func ExportAllAuthoritiesSecrets(ctx context.Context, client authclient.ClientI, req ExportAuthoritiesRequest) ([]*ExportedAuthority, error) {
+	const exportSecrets = true
+	return exportAllAuthorities(ctx, client, req, exportSecrets)
+}
+
+func exportAllAuthorities(
+	ctx context.Context,
+	client authclient.ClientI,
+	req ExportAuthoritiesRequest,
+	exportSecrets bool,
+) ([]*ExportedAuthority, error) {
+	var authorities []*ExportedAuthority
+	switch isIntegration, err := req.shouldExportIntegration(ctx); {
+	case err != nil:
+		return nil, trace.Wrap(err)
+	case isIntegration && exportSecrets:
+		return nil, trace.NotImplemented("export with secrets is not supported for %q CAs", req.AuthType)
+	case isIntegration:
+		authorities, err = exportAuthForIntegration(ctx, client, req)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	default:
+		authorities, err = exportAuth(ctx, client, req, exportSecrets)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	// Sanity check that we have at least one authority.
+	// Not expected to happen in practice.
+	if len(authorities) == 0 {
+		return nil, trace.BadParameter("export returned zero authorities")
+	}
+
+	return authorities, nil
+}
+
+// ExportAuthorities is the single-authority version of [ExportAllAuthorities].
+// Soft-deprecated, prefer using [ExportAllAuthorities] and handling exports
+// with more than one authority gracefully.
 func ExportAuthorities(ctx context.Context, client authclient.ClientI, req ExportAuthoritiesRequest) (string, error) {
-	if isIntegration, err := req.shouldExportIntegration(ctx); err != nil {
-		return "", trace.Wrap(err)
-	} else if isIntegration {
-		return exportAuthForIntegration(ctx, client, req)
-	}
-	return exportAuth(ctx, client, req, false /* exportSecrets */)
+	// TODO(codingllama): Remove ExportAuthorities.
+	return exportAuthorities(ctx, client, req, ExportAllAuthorities)
 }
 
-// ExportAuthoritiesSecrets exports the Authority Certificate secrets (private keys).
-// See ExportAuthorities for more information.
+// ExportAuthoritiesSecrets is the single-authority variant of
+// [ExportAllAuthoritiesSecrets].
+// Soft-deprecated, prefer using [ExportAllAuthoritiesSecrets] and handling
+// exports with more than one authority gracefully.
 func ExportAuthoritiesSecrets(ctx context.Context, client authclient.ClientI, req ExportAuthoritiesRequest) (string, error) {
-	if isIntegration, err := req.shouldExportIntegration(ctx); err != nil {
-		return "", trace.Wrap(err)
-	} else if isIntegration {
-		return "", trace.NotImplemented("export with secrets is not supported for %q CAs", req.AuthType)
-	}
-	return exportAuth(ctx, client, req, true /* exportSecrets */)
+	// TODO(codingllama): Remove ExportAuthoritiesSecrets.
+	return exportAuthorities(ctx, client, req, ExportAllAuthoritiesSecrets)
 }
 
-func exportAuth(ctx context.Context, client authclient.ClientI, req ExportAuthoritiesRequest, exportSecrets bool) (string, error) {
+func exportAuthorities(
+	ctx context.Context,
+	client authclient.ClientI,
+	req ExportAuthoritiesRequest,
+	exportAllFunc func(context.Context, authclient.ClientI, ExportAuthoritiesRequest) ([]*ExportedAuthority, error),
+) (string, error) {
+	authorities, err := exportAllFunc(ctx, client, req)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	// At least one authority is guaranteed on success by both ExportAll methods.
+	if l := len(authorities); l > 1 {
+		return "", trace.BadParameter("export returned %d authorities, expected exactly one", l)
+	}
+
+	return string(authorities[0].Data), nil
+}
+
+func exportAuth(ctx context.Context, client authclient.ClientI, req ExportAuthoritiesRequest, exportSecrets bool) ([]*ExportedAuthority, error) {
 	var typesToExport []types.CertAuthType
 
 	if exportSecrets {
@@ -123,7 +196,7 @@ func exportAuth(ctx context.Context, client authclient.ClientI, req ExportAuthor
 		if err == nil {
 			ctx = mfa.ContextWithMFAResponse(ctx, mfaResponse)
 		} else if !errors.Is(err, &mfa.ErrMFANotRequired) && !errors.Is(err, &mfa.ErrMFANotSupported) {
-			return "", trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 	}
 
@@ -205,13 +278,13 @@ func exportAuth(ctx context.Context, client authclient.ClientI, req ExportAuthor
 	} else {
 		authType := types.CertAuthType(req.AuthType)
 		if err := authType.Check(); err != nil {
-			return "", trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 		typesToExport = []types.CertAuthType{authType}
 	}
 	localAuthName, err := client.GetDomainName(ctx)
 	if err != nil {
-		return "", trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
 	// fetch authorities via auth API (and only take local CAs, ignoring
@@ -220,7 +293,7 @@ func exportAuth(ctx context.Context, client authclient.ClientI, req ExportAuthor
 	for _, at := range typesToExport {
 		cas, err := client.GetCertAuthorities(ctx, at, exportSecrets)
 		if err != nil {
-			return "", trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 		for _, ca := range cas {
 			if ca.GetClusterName() == localAuthName {
@@ -236,7 +309,7 @@ func exportAuth(ctx context.Context, client authclient.ClientI, req ExportAuthor
 				if req.ExportAuthorityFingerprint != "" {
 					fingerprint, err := sshutils.PrivateKeyFingerprint(key.PrivateKey)
 					if err != nil {
-						return "", trace.Wrap(err)
+						return nil, trace.Wrap(err)
 					}
 
 					if fingerprint != req.ExportAuthorityFingerprint {
@@ -254,7 +327,7 @@ func exportAuth(ctx context.Context, client authclient.ClientI, req ExportAuthor
 			if req.ExportAuthorityFingerprint != "" {
 				fingerprint, err := sshutils.AuthorizedKeyFingerprint(key.PublicKey)
 				if err != nil {
-					return "", trace.Wrap(err)
+					return nil, trace.Wrap(err)
 				}
 
 				if fingerprint != req.ExportAuthorityFingerprint {
@@ -267,7 +340,7 @@ func exportAuth(ctx context.Context, client authclient.ClientI, req ExportAuthor
 			if req.UseCompatVersion {
 				castr, err := hostCAFormat(ca, key.PublicKey, client)
 				if err != nil {
-					return "", trace.Wrap(err)
+					return nil, trace.Wrap(err)
 				}
 
 				ret.WriteString(castr)
@@ -282,10 +355,10 @@ func exportAuth(ctx context.Context, client authclient.ClientI, req ExportAuthor
 			case types.HostCA:
 				castr, err = hostCAFormat(ca, key.PublicKey, client)
 			default:
-				return "", trace.BadParameter("unknown user type: %q", ca.GetType())
+				return nil, trace.BadParameter("unknown user type: %q", ca.GetType())
 			}
 			if err != nil {
-				return "", trace.Wrap(err)
+				return nil, trace.Wrap(err)
 			}
 
 			// write the export friendly string
@@ -293,7 +366,9 @@ func exportAuth(ctx context.Context, client authclient.ClientI, req ExportAuthor
 		}
 	}
 
-	return ret.String(), nil
+	return []*ExportedAuthority{
+		{Data: []byte(ret.String())},
+	}, nil
 }
 
 type exportTLSAuthorityRequest struct {
@@ -302,10 +377,10 @@ type exportTLSAuthorityRequest struct {
 	ExportPrivateKeys bool
 }
 
-func exportTLSAuthority(ctx context.Context, client authclient.ClientI, req exportTLSAuthorityRequest) (string, error) {
+func exportTLSAuthority(ctx context.Context, client authclient.ClientI, req exportTLSAuthorityRequest) ([]*ExportedAuthority, error) {
 	clusterName, err := client.GetDomainName(ctx)
 	if err != nil {
-		return "", trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
 	certAuthority, err := client.GetCertAuthority(
@@ -314,29 +389,33 @@ func exportTLSAuthority(ctx context.Context, client authclient.ClientI, req expo
 		req.ExportPrivateKeys,
 	)
 	if err != nil {
-		return "", trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
-	if l := len(certAuthority.GetActiveKeys().TLS); l != 1 {
-		return "", trace.BadParameter("expected one TLS key pair, got %v", l)
-	}
-	keyPair := certAuthority.GetActiveKeys().TLS[0]
+	activeKeys := certAuthority.GetActiveKeys().TLS
+	// TODO(codingllama): Export AdditionalTrustedKeys as well?
 
-	bytesToExport := keyPair.Cert
-	if req.ExportPrivateKeys {
-		bytesToExport = keyPair.Key
+	authorities := make([]*ExportedAuthority, len(activeKeys))
+	for i, activeKey := range activeKeys {
+		bytesToExport := activeKey.Cert
+		if req.ExportPrivateKeys {
+			bytesToExport = activeKey.Key
+		}
+
+		if req.UnpackPEM {
+			block, _ := pem.Decode(bytesToExport)
+			if block == nil {
+				return nil, trace.BadParameter("invalid PEM data")
+			}
+			bytesToExport = block.Bytes
+		}
+
+		authorities[i] = &ExportedAuthority{
+			Data: bytesToExport,
+		}
 	}
 
-	if !req.UnpackPEM {
-		return string(bytesToExport), nil
-	}
-
-	b, _ := pem.Decode(bytesToExport)
-	if b == nil {
-		return "", trace.BadParameter("invalid PEM data")
-	}
-
-	return string(b.Bytes), nil
+	return authorities, nil
 }
 
 // userCAFormat returns the certificate authority public key exported as a single
@@ -375,21 +454,23 @@ func hostCAFormat(ca types.CertAuthority, keyBytes []byte, client authclient.Cli
 	})
 }
 
-func exportAuthForIntegration(ctx context.Context, client authclient.ClientI, req ExportAuthoritiesRequest) (string, error) {
+func exportAuthForIntegration(ctx context.Context, client authclient.ClientI, req ExportAuthoritiesRequest) ([]*ExportedAuthority, error) {
 	switch req.AuthType {
 	case "github":
 		keySet, err := fetchIntegrationCAKeySet(ctx, client, req.Integration)
 		if err != nil {
-			return "", trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 		ret, err := exportGitHubCAs(keySet, req)
 		if err != nil {
-			return "", trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
-		return ret, nil
+		return []*ExportedAuthority{
+			{Data: []byte(ret)},
+		}, nil
 
 	default:
-		return "", trace.BadParameter("unknown integration CA type %q", req.AuthType)
+		return nil, trace.BadParameter("unknown integration CA type %q", req.AuthType)
 	}
 }
 

--- a/lib/client/ca_export_test.go
+++ b/lib/client/ca_export_test.go
@@ -77,6 +77,8 @@ func (m *mockIntegrationsClient) ExportIntegrationCertAuthorities(ctx context.Co
 }
 
 func TestExportAuthorities(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	const localClusterName = "localcluster"
 
@@ -121,6 +123,17 @@ func TestExportAuthorities(t *testing.T) {
 
 	validateGitHubCAFunc := func(t *testing.T, s string) {
 		require.Contains(t, s, fixtures.SSHCAPublicKey)
+	}
+
+	mockedAuthClient := &mockAuthClient{
+		server: testAuth.AuthServer,
+		integrationsClient: mockIntegrationsClient{
+			caKeySet: &types.CAKeySet{
+				SSH: []*types.SSHKeyPair{{
+					PublicKey: []byte(fixtures.SSHCAPublicKey),
+				}},
+			},
+		},
 	}
 
 	for _, tt := range []struct {
@@ -290,21 +303,26 @@ func TestExportAuthorities(t *testing.T) {
 	} {
 		runTest := func(
 			t *testing.T,
+			exportFunc func(context.Context, authclient.ClientI, ExportAuthoritiesRequest) ([]*ExportedAuthority, error),
+			assertFunc func(t *testing.T, output string),
+		) {
+			authorities, err := exportFunc(ctx, mockedAuthClient, tt.req)
+			tt.errorCheck(t, err)
+			if err != nil {
+				return
+			}
+
+			require.Len(t, authorities, 1, "exported authorities mismatch")
+			exported := string(authorities[0].Data)
+			assertFunc(t, exported)
+		}
+
+		runUnaryTest := func(
+			t *testing.T,
 			exportFunc func(context.Context, authclient.ClientI, ExportAuthoritiesRequest) (string, error),
 			assertFunc func(t *testing.T, output string),
 		) {
-			mockedClient := &mockAuthClient{
-				server: testAuth.AuthServer,
-				integrationsClient: mockIntegrationsClient{
-					caKeySet: &types.CAKeySet{
-						SSH: []*types.SSHKeyPair{{
-							PublicKey: []byte(fixtures.SSHCAPublicKey),
-						}},
-					},
-				},
-			}
-
-			exported, err := exportFunc(ctx, mockedClient, tt.req)
+			exported, err := exportFunc(ctx, mockedAuthClient, tt.req)
 			tt.errorCheck(t, err)
 			if err != nil {
 				return
@@ -313,14 +331,25 @@ func TestExportAuthorities(t *testing.T) {
 			assertFunc(t, exported)
 		}
 
-		t.Run(fmt.Sprintf("%s/ExportAuthorities", tt.name), func(t *testing.T) {
-			runTest(t, ExportAuthorities, tt.assertNoSecrets)
-		})
-		if tt.skipSecrets {
-			continue
-		}
-		t.Run(fmt.Sprintf("%s/ExportAuthoritiesSecrets", tt.name), func(t *testing.T) {
-			runTest(t, ExportAuthoritiesSecrets, tt.assertSecrets)
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			t.Run(fmt.Sprintf("%s/ExportAllAuthorities", tt.name), func(t *testing.T) {
+				runTest(t, ExportAllAuthorities, tt.assertNoSecrets)
+			})
+			t.Run(fmt.Sprintf("%s/ExportAuthorities", tt.name), func(t *testing.T) {
+				runUnaryTest(t, ExportAuthorities, tt.assertNoSecrets)
+			})
+			if tt.skipSecrets {
+				return
+			}
+
+			t.Run(fmt.Sprintf("%s/ExportAllAuthoritiesSecrets", tt.name), func(t *testing.T) {
+				runTest(t, ExportAllAuthoritiesSecrets, tt.assertSecrets)
+			})
+			t.Run(fmt.Sprintf("%s/ExportAuthoritiesSecrets", tt.name), func(t *testing.T) {
+				runUnaryTest(t, ExportAuthoritiesSecrets, tt.assertSecrets)
+			})
 		})
 	}
 }


### PR DESCRIPTION
Add "ExportAll" variants of ExportAuthorities and ExportAuthoritiesSecrets that can gracefully handle multiple active CAs.

ExportAll functions return an []*ExportedAuthority, so future iterations could easily include (and differentiate) [CertAuthoritySpecV2.AdditionalTrustedKeys][], plus whatever other data is necessary.

Subsequent PRs will take advantage of the new functions on both tctl and Web API. After the follow-ups the "unary" Export functions are to be removed.

Similar to #35754 (minus the frontend parts).

#35444

[CertAuthoritySpecV2.AdditionalTrustedKeys]: https://github.com/gravitational/teleport/blob/8bc4b5322fafbd0acf5f70baa8267c7d58bee012/api/proto/teleport/legacy/types/types.proto#L1253