### PR TITLE
[v16] Fix flaky integration tests caused by prometheus metrics conficts

### DIFF
--- a/integration/tctl_terraform_env_test.go
+++ b/integration/tctl_terraform_env_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -51,6 +52,7 @@ import (
 // service and generates valid credentials Terraform can use to connect to Teleport.
 func TestTCTLTerraformCommand_ProxyJoin(t *testing.T) {
 	testDir := t.TempDir()
+	prometheus.DefaultRegisterer = metricRegistryBlackHole{}
 
 	// Test setup: creating a teleport instance running auth and proxy
 	clusterName := "root.example.com"
@@ -126,6 +128,7 @@ func TestTCTLTerraformCommand_ProxyJoin(t *testing.T) {
 func TestTCTLTerraformCommand_AuthJoin(t *testing.T) {
 	t.Parallel()
 	testDir := t.TempDir()
+	prometheus.DefaultRegisterer = metricRegistryBlackHole{}
 
 	// Test setup: creating a teleport instance running auth and proxy
 	clusterName := "root.example.com"
@@ -346,4 +349,21 @@ func connectWithCredentialsFromVars(t *testing.T, vars map[string]string, clt *a
 	require.NoError(t, err)
 	_, err = botClt.Ping(ctx)
 	require.NoError(t, err)
+}
+
+// metricRegistryBlackHole is a fake prometheus.Registerer that accepts every metric and do nothing.
+// This is a workaround for different teleport component using the global registry but registering incompatible metrics.
+// Those issues can surface during integration tests starting Teleport auth, proxy, and tbot.
+// The long-term fix is to have every component use its own registry instead of the global one.
+type metricRegistryBlackHole struct {
+}
+
+func (m metricRegistryBlackHole) Register(_ prometheus.Collector) error {
+	return nil
+}
+
+func (m metricRegistryBlackHole) MustRegister(_ ...prometheus.Collector) {}
+
+func (m metricRegistryBlackHole) Unregister(_ prometheus.Collector) bool {
+	return true
 }


### PR DESCRIPTION
Manual backport of #48248 to `branch/v16` due to minimal conflicts.

Fixes: https://github.com/gravitational/teleport/issues/44944