### PR TITLE
tsh: selectively render error messages in color

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2138,7 +2138,7 @@ func applyMetricsConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		if !utils.IsSelfSigned(certificateChain) {
 			if err := utils.VerifyCertificateChain(certificateChain); err != nil {
 				return trace.BadParameter("unable to verify the metrics service certificate chain in %v: %s",
-					p.Certificate, utils.UserMessageFromError(err))
+					p.Certificate, utils.UserMessageFromError(err, false))
 			}
 		}
 

--- a/lib/utils/cli_test.go
+++ b/lib/utils/cli_test.go
@@ -63,7 +63,7 @@ func TestUserMessageFromError(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		message := UserMessageFromError(tt.inError)
+		message := UserMessageFromError(tt.inError, true)
 		require.Contains(t, message, tt.outString)
 	}
 }


### PR DESCRIPTION
Prior to this change, tsh would always render some error messages using ANSI-escape sequences, even in cases where the error is not written to a PTY.

Closes #36929