### PR TITLE
[vnet] refactor AppProvider for Windows implementation

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -5292,6 +5292,29 @@ func (tc *TeleportClient) RootClusterCACertPool(ctx context.Context) (*x509.Cert
 	return pool, trace.Wrap(err)
 }
 
+// RootClusterCACertPoolPEM returns a PEM-encoded cert pool with the root cluster CA.
+func (tc *TeleportClient) RootClusterCACertPoolPEM(ctx context.Context) ([]byte, error) {
+	_, span := tc.Tracer.Start(
+		ctx,
+		"teleportClient/RootClusterCACertPoolPEM",
+		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+	)
+	defer span.End()
+
+	keyRing, err := tc.localAgent.GetCoreKeyRing()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	rootClusterName, err := keyRing.RootClusterName()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	pool, err := keyRing.clientCertPoolPEM(rootClusterName)
+	return pool, trace.Wrap(err)
+}
+
 // HeadlessApprove handles approval of a headless authentication request.
 func (tc *TeleportClient) HeadlessApprove(ctx context.Context, headlessAuthenticationID string, confirm bool) error {
 	ctx, span := tc.Tracer.Start(

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -29,6 +29,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"time"
 
@@ -303,21 +304,35 @@ func (k *KeyRing) clientTLSConfig(cipherSuites []uint16, cred TLSCredential, clu
 
 // ClientCertPool returns x509.CertPool containing trusted CA.
 func (k *KeyRing) clientCertPool(clusters ...string) (*x509.CertPool, error) {
+	certPoolPEM, err := k.clientCertPoolPEM(clusters...)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(certPoolPEM) {
+		return nil, trace.BadParameter("failed to parse TLS CA certificate")
+	}
+	return pool, nil
+}
+
+func (k *KeyRing) clientCertPoolPEM(clusters ...string) ([]byte, error) {
+	var certPoolPEM bytes.Buffer
 	for _, caPEM := range k.TLSCAs() {
 		cert, err := tlsca.ParseCertificatePEM(caPEM)
 		if err != nil {
-			return nil, trace.Wrap(err)
+			return nil, trace.Wrap(err, "parsing TLS CA certificate")
 		}
-		for _, k := range clusters {
-			if cert.Subject.CommonName == k {
-				if !pool.AppendCertsFromPEM(caPEM) {
-					return nil, trace.BadParameter("failed to parse TLS CA certificate")
-				}
-			}
+		if !slices.Contains(clusters, cert.Subject.CommonName) {
+			continue
+		}
+		certPoolPEM.Write(caPEM)
+		// PEM files should end with a trailing newline, just double check
+		// before potentially concatenating multiple together.
+		if caPEM[len(caPEM)-1] != '\n' {
+			certPoolPEM.WriteByte('\n')
 		}
 	}
-	return pool, nil
+	return certPoolPEM.Bytes(), nil
 }
 
 // ProxyClientSSHConfig returns an ssh.ClientConfig with SSH credentials from this

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -309,6 +309,10 @@ func (k *KeyRing) clientCertPool(clusters ...string) (*x509.CertPool, error) {
 		return nil, trace.Wrap(err)
 	}
 	pool := x509.NewCertPool()
+	if len(certPoolPEM) == 0 {
+		// It's valid to have no matching CAs and therefore an empty cert pool.
+		return pool, nil
+	}
 	if !pool.AppendCertsFromPEM(certPoolPEM) {
 		return nil, trace.BadParameter("failed to parse TLS CA certificate")
 	}

--- a/lib/teleterm/vnet/service.go
+++ b/lib/teleterm/vnet/service.go
@@ -29,12 +29,11 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils"
 	prehogv1alpha "github.com/gravitational/teleport/gen/proto/go/prehog/v1alpha"
 	apiteleterm "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/vnet/v1"
+	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/teleterm/api/uri"
 	"github.com/gravitational/teleport/lib/teleterm/clusteridcache"
@@ -73,7 +72,8 @@ func New(cfg Config) (*Service, error) {
 	}
 
 	return &Service{
-		cfg: cfg,
+		cfg:                cfg,
+		clusterConfigCache: vnet.NewClusterConfigCache(cfg.Clock),
 	}, nil
 }
 
@@ -125,7 +125,7 @@ func (s *Service) Start(ctx context.Context, req *api.StartRequest) (*api.StartR
 		return nil, trace.AlreadyExists("VNet is already running")
 	}
 
-	appProvider := &appProvider{
+	clientApplication := &clientApplication{
 		daemonService:      s.cfg.DaemonService,
 		insecureSkipVerify: s.cfg.InsecureSkipVerify,
 		usageReporter:      &disabledTelemetryUsageReporter{},
@@ -156,13 +156,11 @@ func (s *Service) Start(ctx context.Context, req *api.StartRequest) (*api.StartR
 				usageReporter.Stop()
 			}
 		}()
-		appProvider.usageReporter = usageReporter
+		clientApplication.usageReporter = usageReporter
 	}
 
-	s.clusterConfigCache = vnet.NewClusterConfigCache(s.cfg.Clock)
 	processManager, err := vnet.RunUserProcess(ctx, &vnet.UserProcessConfig{
-		AppProvider:        appProvider,
-		ClusterConfigCache: s.clusterConfigCache,
+		ClientApplication: clientApplication,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -196,7 +194,7 @@ func (s *Service) Start(ctx context.Context, req *api.StartRequest) (*api.StartR
 	}()
 
 	s.processManager = processManager
-	s.usageReporter = appProvider.usageReporter
+	s.usageReporter = clientApplication.usageReporter
 	s.status = statusRunning
 	return &api.StartResponse{}, nil
 }
@@ -355,37 +353,39 @@ func (s *Service) reportUnexpectedShutdown(ctx context.Context, shutdownErr erro
 	return trace.Wrap(err, "sending shutdown report")
 }
 
-type appProvider struct {
+type clientApplication struct {
 	daemonService      *daemon.Service
 	usageReporter      usageReporter
 	insecureSkipVerify bool
 }
 
-func (p *appProvider) ListProfiles() ([]string, error) {
+func (p *clientApplication) ListProfiles() ([]string, error) {
 	profiles, err := p.daemonService.ListProfileNames()
 	return profiles, trace.Wrap(err)
 }
 
-func (p *appProvider) GetCachedClient(ctx context.Context, profileName, leafClusterName string) (vnet.ClusterClient, error) {
+func (p *clientApplication) GetCachedClient(ctx context.Context, profileName, leafClusterName string) (vnet.ClusterClient, error) {
 	return p.getCachedClient(ctx, profileName, leafClusterName)
 }
 
-func (p *appProvider) getCachedClient(ctx context.Context, profileName, leafClusterName string) (*client.ClusterClient, error) {
+func (p *clientApplication) getCachedClient(ctx context.Context, profileName, leafClusterName string) (*client.ClusterClient, error) {
 	uri := uri.NewClusterURI(profileName).AppendLeafCluster(leafClusterName)
 	client, err := p.daemonService.GetCachedClient(ctx, uri)
 	return client, trace.Wrap(err)
 }
 
-func (p *appProvider) ReissueAppCert(ctx context.Context, profileName, leafClusterName string, routeToApp proto.RouteToApp) (tls.Certificate, error) {
-	clusterURI := uri.NewClusterURI(profileName).AppendLeafCluster(leafClusterName)
-	appURI := clusterURI.AppendApp(routeToApp.Name)
+func (p *clientApplication) ReissueAppCert(ctx context.Context, appInfo *vnetv1.AppInfo, targetPort uint16) (tls.Certificate, error) {
+	appKey := appInfo.GetAppKey()
+	clusterURI := uri.NewClusterURI(appKey.GetProfile()).AppendLeafCluster(appKey.GetLeafCluster())
+	appURI := clusterURI.AppendApp(appKey.GetName())
 
+	routeToApp := vnet.RouteToApp(appInfo, targetPort)
 	apiteletermRouteToApp := apiteleterm.RouteToApp{
 		Name:        routeToApp.Name,
 		PublicAddr:  routeToApp.PublicAddr,
 		ClusterName: routeToApp.ClusterName,
 		Uri:         routeToApp.URI,
-		TargetPort:  routeToApp.TargetPort,
+		TargetPort:  uint32(routeToApp.TargetPort),
 	}
 
 	reloginReq := &apiteleterm.ReloginRequest{
@@ -411,7 +411,7 @@ func (p *appProvider) ReissueAppCert(ctx context.Context, profileName, leafClust
 			return trace.Wrap(err)
 		}
 
-		cert, err = cluster.ReissueAppCert(ctx, client, routeToApp)
+		cert, err = cluster.ReissueAppCert(ctx, client, *routeToApp)
 		return trace.Wrap(err)
 	}
 
@@ -441,19 +441,19 @@ func (p *appProvider) ReissueAppCert(ctx context.Context, profileName, leafClust
 }
 
 // GetDialOptions returns ALPN dial options for the profile.
-func (p *appProvider) GetDialOptions(ctx context.Context, profileName string) (*vnet.DialOptions, error) {
+func (p *clientApplication) GetDialOptions(ctx context.Context, profileName string) (*vnetv1.DialOptions, error) {
 	cluster, tc, err := p.daemonService.ResolveClusterURI(uri.NewClusterURI(profileName))
 	if err != nil {
 		return nil, trace.Wrap(err, "resolving cluster by URI")
 	}
 
-	dialOpts := &vnet.DialOptions{
+	dialOpts := &vnetv1.DialOptions{
 		WebProxyAddr:            cluster.GetProxyHost(),
-		ALPNConnUpgradeRequired: tc.TLSRoutingConnUpgradeRequired,
+		AlpnConnUpgradeRequired: tc.TLSRoutingConnUpgradeRequired,
 		InsecureSkipVerify:      p.insecureSkipVerify,
 	}
-	if dialOpts.ALPNConnUpgradeRequired {
-		dialOpts.RootClusterCACertPool, err = tc.RootClusterCACertPool(ctx)
+	if dialOpts.AlpnConnUpgradeRequired {
+		dialOpts.RootClusterCaCertPool, err = tc.RootClusterCACertPoolPEM(ctx)
 		if err != nil {
 			return nil, trace.Wrap(err, "loading root cluster CA cert pool")
 		}
@@ -461,15 +461,15 @@ func (p *appProvider) GetDialOptions(ctx context.Context, profileName string) (*
 	return dialOpts, nil
 }
 
-// OnNewConnection submits a usage event once per appProvider lifetime.
+// OnNewConnection submits a usage event once per clientApplication lifetime.
 // That is, if a user makes multiple connections to a single app, OnNewConnection submits a single
 // event. This is to mimic how Connect submits events for its app gateways. This lets us compare
 // popularity of VNet and app gateways.
-func (p *appProvider) OnNewConnection(ctx context.Context, profileName, leafClusterName string, routeToApp proto.RouteToApp) error {
+func (p *clientApplication) OnNewConnection(ctx context.Context, appKey *vnetv1.AppKey) error {
 	// Enqueue the event from a separate goroutine since we don't care about errors anyway and we also
 	// don't want to slow down VNet connections.
 	go func() {
-		uri := uri.NewClusterURI(profileName).AppendLeafCluster(leafClusterName).AppendApp(routeToApp.Name)
+		uri := uri.NewClusterURI(appKey.GetProfile()).AppendLeafCluster(appKey.GetLeafCluster()).AppendApp(appKey.GetName())
 
 		// Not passing ctx to ReportApp since ctx is tied to the lifetime of the connection.
 		// If it's a short-lived connection, inheriting its context would interrupt reporting.
@@ -484,13 +484,17 @@ func (p *appProvider) OnNewConnection(ctx context.Context, profileName, leafClus
 
 // OnInvalidLocalPort gets called before VNet refuses to handle a connection to a multi-port TCP app
 // because the provided port does not match any of the TCP ports in the app spec.
-func (p *appProvider) OnInvalidLocalPort(ctx context.Context, profileName, leafClusterName string, routeToApp proto.RouteToApp, tcpPorts types.PortRanges) {
+func (p *clientApplication) OnInvalidLocalPort(ctx context.Context, appInfo *vnetv1.AppInfo, targetPort uint16) {
 	// If something is wrong with the Electron app to the point that it stopped accepting RPCs, return
 	// quickly rather than being blocked on sending a notification.
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 
-	appURI := uri.NewClusterURI(profileName).AppendLeafCluster(leafClusterName).AppendApp(routeToApp.Name)
+	appKey := appInfo.GetAppKey()
+	appURI := uri.NewClusterURI(appKey.GetProfile()).
+		AppendLeafCluster(appKey.GetLeafCluster()).
+		AppendApp(appKey.GetName())
+	routeToApp := vnet.RouteToApp(appInfo, targetPort)
 	apiteletermRouteToApp := apiteleterm.RouteToApp{
 		Name:        routeToApp.Name,
 		PublicAddr:  routeToApp.PublicAddr,
@@ -502,6 +506,7 @@ func (p *appProvider) OnInvalidLocalPort(ctx context.Context, profileName, leafC
 	invalidLocalPort := &apiteleterm.InvalidLocalPort{}
 	// Send ports only if there's less than 10 ranges. A bigger number would be difficult to show in
 	// the UI.
+	tcpPorts := appInfo.GetApp().GetTCPPorts()
 	if len(tcpPorts) <= 10 {
 		apiTCPPorts := make([]*apiteleterm.PortRange, 0, len(tcpPorts))
 		for _, portRange := range tcpPorts {
@@ -523,7 +528,10 @@ func (p *appProvider) OnInvalidLocalPort(ctx context.Context, profileName, leafC
 	})
 	if err != nil {
 		log.ErrorContext(ctx, "Could not notify the Electron app about invalid local port",
-			"notify_error", err, "profile_name", profileName, "leaf_cluster_name", leafClusterName, "route_to_app", routeToApp)
+			"notify_error", err,
+			"profile_name", appKey.GetProfile(),
+			"leaf_cluster_name", appKey.GetLeafCluster(),
+			"route_to_app", routeToApp)
 	}
 }
 

--- a/lib/teleterm/vnet/service.go
+++ b/lib/teleterm/vnet/service.go
@@ -385,7 +385,7 @@ func (p *clientApplication) ReissueAppCert(ctx context.Context, appInfo *vnetv1.
 		PublicAddr:  routeToApp.PublicAddr,
 		ClusterName: routeToApp.ClusterName,
 		Uri:         routeToApp.URI,
-		TargetPort:  uint32(routeToApp.TargetPort),
+		TargetPort:  routeToApp.TargetPort,
 	}
 
 	reloginReq := &apiteleterm.ReloginRequest{

--- a/lib/vnet/app_resolver.go
+++ b/lib/vnet/app_resolver.go
@@ -17,12 +17,9 @@
 package vnet
 
 import (
-	"cmp"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"errors"
-	"fmt"
 	"log/slog"
 	"net"
 	"strings"
@@ -33,298 +30,90 @@ import (
 	"golang.org/x/sync/singleflight"
 
 	"github.com/gravitational/teleport"
-	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth/authclient"
+	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy"
 	alpncommon "github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 )
 
-// AppProvider is an interface providing the necessary methods to log in to apps and get clients able to list
-// apps in all clusters in all current profiles. This should be the minimum necessary interface that needs to
-// be implemented differently for Connect and `tsh vnet`.
-type AppProvider interface {
-	// ListProfiles lists the names of all profiles saved for the user.
-	ListProfiles() ([]string, error)
-
-	// GetCachedClient returns a [*client.ClusterClient] for the given profile and leaf cluster.
-	// [leafClusterName] may be empty when requesting a client for the root cluster. Returned clients are
-	// expected to be cached, as this may be called frequently.
-	GetCachedClient(ctx context.Context, profileName, leafClusterName string) (ClusterClient, error)
-
-	// ReissueAppCert returns a new app certificate for the given app in the named profile and leaf cluster.
-	// Implementations may trigger a re-login to the cluster, but if they do, they MUST clear all cached
-	// clients for that cluster so that new working clients will be returned from [GetCachedClient].
-	ReissueAppCert(ctx context.Context, profileName, leafClusterName string, routeToApp proto.RouteToApp) (tls.Certificate, error)
-
-	// GetDialOptions returns ALPN dial options for the profile.
-	GetDialOptions(ctx context.Context, profileName string) (*DialOptions, error)
-
+// appProvider is an interface for querying app info from an app fqdn, getting
+// certs issued for apps, and reporting connections and errors.
+type appProvider interface {
+	// ResolveAppInfo returns an *AppInfo for the given app fqdn, or an error if
+	// the app is not present in any logged-in cluster.
+	ResolveAppInfo(ctx context.Context, fqdn string) (*vnetv1.AppInfo, error)
+	// ReissueAppCert issues a new cert for the target app.
+	ReissueAppCert(ctx context.Context, appInfo *vnetv1.AppInfo, targetPort uint16) (tls.Certificate, error)
 	// OnNewConnection gets called whenever a new connection is about to be established through VNet.
 	// By the time OnNewConnection, VNet has already verified that the user holds a valid cert for the
 	// app.
 	//
 	// The connection won't be established until OnNewConnection returns. Returning an error prevents
 	// the connection from being made.
-	OnNewConnection(ctx context.Context, profileName, leafClusterName string, routeToApp proto.RouteToApp) error
-
+	OnNewConnection(ctx context.Context, appKey *vnetv1.AppKey) error
 	// OnInvalidLocalPort gets called before VNet refuses to handle a connection to a multi-port TCP app
 	// because the provided port does not match any of the TCP ports in the app spec.
-	OnInvalidLocalPort(ctx context.Context, profileName, leafClusterName string, routeToApp proto.RouteToApp, tcpPorts types.PortRanges)
+	OnInvalidLocalPort(ctx context.Context, appInfo *vnetv1.AppInfo, targetPort uint16)
 }
 
-// ClusterClient is an interface defining the subset of [client.ClusterClient] methods used by [AppProvider].
-type ClusterClient interface {
-	CurrentCluster() authclient.ClientI
-	ClusterName() string
-	RootClusterName() string
-}
-
-// DialOptions holds ALPN dial options for dialing apps.
-type DialOptions struct {
-	// WebProxyAddr is the address to dial.
-	WebProxyAddr string
-	// ALPNConnUpgradeRequired specifies if ALPN connection upgrade is required.
-	ALPNConnUpgradeRequired bool
-	// SNI is a ServerName value set for upstream TLS connection.
-	SNI string
-	// RootClusterCACertPool overrides the x509 certificate pool used to verify the server.
-	RootClusterCACertPool *x509.CertPool
-	// InsecureSkipTLSVerify turns off verification for x509 upstream ALPN proxy service certificate.
-	InsecureSkipVerify bool
-}
-
-// tcpAppResolver implements [tcpHandlerResolver] for Teleport TCP apps.
+// tcpAppResolver implements tcpHandlerResolver for Teleport TCP apps.
 type tcpAppResolver struct {
-	appProvider        AppProvider
-	clusterConfigCache *ClusterConfigCache
-	log                *slog.Logger
-	clock              clockwork.Clock
+	appProvider appProvider
+	log         *slog.Logger
+	clock       clockwork.Clock
 }
 
-// newTCPAppResolver returns a new [*tcpAppResolver] which will resolve full-qualified domain names to
-// [tcpHandler]s that will proxy TCP connection to Teleport TCP apps.
-//
-// It uses [appProvider] to list and retrieve cluster clients which are expected to be cached to avoid
-// repeated/unnecessary dials to the cluster. These clients are then used to list TCP apps that should be
-// handled.
-//
-// [appProvider] is also used to get app certificates used to dial the apps.
-func newTCPAppResolver(appProvider AppProvider, opts ...tcpAppResolverOption) (*tcpAppResolver, error) {
-	r := &tcpAppResolver{
+func newTCPAppResolver(appProvider appProvider, clock clockwork.Clock) *tcpAppResolver {
+	return &tcpAppResolver{
 		appProvider: appProvider,
 		log:         log.With(teleport.ComponentKey, "VNet.AppResolver"),
-	}
-	for _, opt := range opts {
-		opt(r)
-	}
-	r.clock = cmp.Or(r.clock, clockwork.NewRealClock())
-	r.clusterConfigCache = cmp.Or(r.clusterConfigCache, NewClusterConfigCache(r.clock))
-	return r, nil
-}
-
-type tcpAppResolverOption func(*tcpAppResolver)
-
-// withClock is a functional option to override the default clock (for tests).
-func withClock(clock clockwork.Clock) tcpAppResolverOption {
-	return func(r *tcpAppResolver) {
-		r.clock = clock
+		clock:       clock,
 	}
 }
 
-// WithClusterConfigCache is a functional option to override the cluster config cache.
-func WithClusterConfigCache(clusterConfigCache *ClusterConfigCache) tcpAppResolverOption {
-	return func(r *tcpAppResolver) {
-		r.clusterConfigCache = clusterConfigCache
-	}
-}
-
-// resolveTCPHandler resolves a fully-qualified domain name to a [tcpHandlerSpec] for a Teleport TCP app that should
-// be used to handle all future TCP connections to [fqdn].
-// Avoid using [trace.Wrap] on [errNoTCPHandler] to prevent collecting a full stack trace on every unhandled
-// query.
+// resolveTCPHandler resolves a fully-qualified domain name to a tcpHandlerSpec
+// for a Teleport TCP app that should be used to handle all future TCP
+// connections to fqdn.
+//
+// Avoid using [trace.Wrap] on errNoTCPHandler to prevent collecting a full
+// stack trace on every unhandled query.
 func (r *tcpAppResolver) resolveTCPHandler(ctx context.Context, fqdn string) (*tcpHandlerSpec, error) {
-	profileNames, err := r.appProvider.ListProfiles()
+	appInfo, err := r.appProvider.ResolveAppInfo(ctx, fqdn)
 	if err != nil {
-		return nil, trace.Wrap(err, "listing profiles")
+		// Intentionally don't wrap the error, collecting a trace is expensive
+		// and should only be done for unexpected errors
+		return nil, err
 	}
-	for _, profileName := range profileNames {
-		if fqdn == fullyQualify(profileName) {
-			// This is a query for the proxy address, which we'll never want to handle.
-			return nil, errNoTCPHandler
-		}
-
-		clusterClient, err := r.clusterClientForAppFQDN(ctx, profileName, fqdn)
-		if err != nil {
-			if errors.Is(err, errNoMatch) {
-				continue
-			}
-			// The user might be logged out from this one cluster (and retryWithRelogin isn't working). Log
-			// the error but don't return it so that DNS resolution will be forwarded upstream instead of
-			// failing, to avoid breaking e.g. web app access (we don't know if this is a web or TCP app yet
-			// because we can't log in).
-			r.log.ErrorContext(ctx, "Failed to get teleport client.", "error", err)
-			continue
-		}
-
-		leafClusterName := ""
-		clusterName := clusterClient.ClusterName()
-		if clusterName != "" && clusterName != clusterClient.RootClusterName() {
-			leafClusterName = clusterName
-		}
-
-		return r.resolveTCPHandlerForCluster(ctx, clusterClient, profileName, leafClusterName, fqdn)
-	}
-	// fqdn did not match any profile, forward the request upstream.
-	return nil, errNoTCPHandler
-}
-
-var errNoMatch = errors.New("cluster does not match queried FQDN")
-
-func (r *tcpAppResolver) clusterClientForAppFQDN(ctx context.Context, profileName, fqdn string) (ClusterClient, error) {
-	rootClient, err := r.appProvider.GetCachedClient(ctx, profileName, "")
+	appHandler, err := r.newTCPAppHandler(ctx, appInfo)
 	if err != nil {
-		r.log.ErrorContext(ctx, "Failed to get root cluster client, apps in this cluster will not be resolved.", "profile", profileName, "error", err)
-		return nil, errNoMatch
+		return nil, err
 	}
-
-	if isDescendantSubdomain(fqdn, profileName) {
-		// The queried app fqdn is a subdomain of this cluster proxy address.
-		return rootClient, nil
-	}
-
-	leafClusters, err := getLeafClusters(ctx, rootClient)
-	if err != nil {
-		// Good chance we're here because the user is not logged in to the profile.
-		r.log.ErrorContext(ctx, "Failed to list leaf clusters, apps in this cluster will not be resolved.", "profile", profileName, "error", err)
-		return nil, errNoMatch
-	}
-
-	// Prefix with an empty string to represent the root cluster.
-	allClusters := append([]string{""}, leafClusters...)
-	for _, leafClusterName := range allClusters {
-		clusterClient, err := r.appProvider.GetCachedClient(ctx, profileName, leafClusterName)
-		if err != nil {
-			r.log.ErrorContext(ctx, "Failed to get cluster client, apps in this cluster will not be resolved.", "profile", profileName, "leaf_cluster", leafClusterName, "error", err)
-			continue
-		}
-
-		clusterConfig, err := r.clusterConfigCache.GetClusterConfig(ctx, clusterClient)
-		if err != nil {
-			r.log.ErrorContext(ctx, "Failed to get VnetConfig, apps in the cluster will not be resolved.", "profile", profileName, "leaf_cluster", leafClusterName, "error", err)
-			continue
-		}
-		for _, zone := range clusterConfig.DNSZones {
-			if isDescendantSubdomain(fqdn, zone) {
-				return clusterClient, nil
-			}
-		}
-	}
-	return nil, errNoMatch
-}
-
-func getLeafClusters(ctx context.Context, rootClient ClusterClient) ([]string, error) {
-	var leafClusters []string
-	nextPage := ""
-	for {
-		remoteClusters, nextPage, err := rootClient.CurrentCluster().ListRemoteClusters(ctx, 0, nextPage)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		for _, rc := range remoteClusters {
-			leafClusters = append(leafClusters, rc.GetName())
-		}
-		if nextPage == "" {
-			return leafClusters, nil
-		}
-	}
-}
-
-// resolveTCPHandlerForCluster takes a cluster client and resolves [fqdn] to a [tcpHandlerSpec] if a matching
-// app is found in that cluster.
-// Avoid using [trace.Wrap] on [errNoTCPHandler] to prevent collecting a full stack trace on every unhandled
-// query.
-func (r *tcpAppResolver) resolveTCPHandlerForCluster(
-	ctx context.Context,
-	clusterClient ClusterClient,
-	profileName, leafClusterName, fqdn string,
-) (*tcpHandlerSpec, error) {
-	log := r.log.With("profile", profileName, "leaf_cluster", leafClusterName, "fqdn", fqdn)
-	// An app public_addr could technically be full-qualified or not, match either way.
-	expr := fmt.Sprintf(`(resource.spec.public_addr == "%s" || resource.spec.public_addr == "%s") && hasPrefix(resource.spec.uri, "tcp://")`,
-		strings.TrimSuffix(fqdn, "."), fqdn)
-	resp, err := apiclient.GetResourcePage[types.AppServer](ctx, clusterClient.CurrentCluster(), &proto.ListResourcesRequest{
-		ResourceType:        types.KindAppServer,
-		PredicateExpression: expr,
-		Limit:               1,
-	})
-	if err != nil {
-		// Don't return an unexpected error so we can try to find the app in different clusters or forward the
-		// request upstream.
-		log.InfoContext(ctx, "Failed to list application servers.", "error", err)
-		return nil, errNoTCPHandler
-	}
-	if len(resp.Resources) == 0 {
-		// Didn't find any matching app, forward the request upstream.
-		return nil, errNoTCPHandler
-	}
-	app := resp.Resources[0].GetApp()
-	appHandler, err := r.newTCPAppHandler(ctx, profileName, leafClusterName, app)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	clusterConfig, err := r.clusterConfigCache.GetClusterConfig(ctx, clusterClient)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	return &tcpHandlerSpec{
-		ipv4CIDRRange: clusterConfig.IPv4CIDRRange,
+		ipv4CIDRRange: appInfo.GetIpv4CidrRange(),
 		tcpHandler:    appHandler,
 	}, nil
 }
 
 type tcpAppHandler struct {
+	appInfo     *vnetv1.AppInfo
+	appProvider appProvider
 	log         *slog.Logger
-	appProvider AppProvider
 	clock       clockwork.Clock
-	profileName string
-	// clusterName is the name of the cluster that the app belongs to. For root cluster, it is not
-	// necessarily the equivalent of profileName. RouteToApp passed to a local proxy needs to include
-	// the actual root cluster name, not just an empty string (unlike what's often the case with
-	// siteName in lib/client).
-	clusterName      string
-	leafClusterName  string
-	app              types.Application
-	portToLocalProxy map[uint16]*alpnproxy.LocalProxy
+
 	// mu guards access to portToLocalProxy.
-	mu sync.Mutex
+	mu               sync.Mutex
+	portToLocalProxy map[uint16]*alpnproxy.LocalProxy
 }
 
-func (r *tcpAppResolver) newTCPAppHandler(
-	ctx context.Context,
-	profileName string,
-	leafClusterName string,
-	app types.Application,
-) (*tcpAppHandler, error) {
-	clusterClient, err := r.appProvider.GetCachedClient(ctx, profileName, leafClusterName)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
+func (r *tcpAppResolver) newTCPAppHandler(ctx context.Context, appInfo *vnetv1.AppInfo) (*tcpAppHandler, error) {
 	return &tcpAppHandler{
-		appProvider:      r.appProvider,
+		appInfo:     appInfo,
+		appProvider: r.appProvider,
+		log: r.log.With(teleport.ComponentKey, "VNet.tcpAppResolver",
+			"profile", appInfo.GetAppKey().GetProfile(), "leaf_cluster", appInfo.GetAppKey().GetLeafCluster(), "fqdn", appInfo.GetApp().GetPublicAddr()),
 		clock:            r.clock,
-		profileName:      profileName,
-		clusterName:      clusterClient.ClusterName(),
-		leafClusterName:  leafClusterName,
-		app:              app,
 		portToLocalProxy: make(map[uint16]*alpnproxy.LocalProxy),
-		log: r.log.With(teleport.ComponentKey, "VNet.AppHandler",
-			"profile", profileName, "leaf_cluster", leafClusterName, "fqdn", app.GetPublicAddr()),
 	}, nil
 }
 
@@ -333,72 +122,59 @@ func (r *tcpAppResolver) newTCPAppHandler(
 func (h *tcpAppHandler) getOrInitializeLocalProxy(ctx context.Context, localPort uint16) (*alpnproxy.LocalProxy, error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-
 	// Connections to single-port apps need to go through a local proxy that has a cert with TargetPort
 	// set to 0. This ensures that the old behavior is kept for such apps, where the client can dial
 	// the public address of an app on any port and be routed to the port from the URI.
 	//
 	// https://github.com/gravitational/teleport/blob/master/rfd/0182-multi-port-tcp-app-access.md#vnet-with-single-port-apps
-	if len(h.app.GetTCPPorts()) == 0 {
+	if len(h.appInfo.GetApp().GetTCPPorts()) == 0 {
 		localPort = 0
 	}
-
 	lp, ok := h.portToLocalProxy[localPort]
 	if ok {
 		return lp, nil
 	}
-
-	routeToApp := h.routeToApp(localPort)
-	dialOpts, err := h.appProvider.GetDialOptions(ctx, h.profileName)
-	if err != nil {
-		return nil, trace.Wrap(err, "getting dial options for profile %q", h.profileName)
-	}
-
 	appCertIssuer := &appCertIssuer{
-		appProvider:     h.appProvider,
-		profileName:     h.profileName,
-		leafClusterName: h.leafClusterName,
-		routeToApp:      routeToApp,
+		appProvider: h.appProvider,
+		appInfo:     h.appInfo,
+		targetPort:  localPort,
 	}
 	certChecker := client.NewCertChecker(appCertIssuer, h.clock)
 	middleware := &localProxyMiddleware{
-		certChecker:     certChecker,
-		appProvider:     h.appProvider,
-		routeToApp:      routeToApp,
-		profileName:     h.profileName,
-		leafClusterName: h.leafClusterName,
+		certChecker: certChecker,
+		appProvider: h.appProvider,
+		appKey:      h.appInfo.GetAppKey(),
 	}
-
+	dialOptions := h.appInfo.GetDialOptions()
 	localProxyConfig := alpnproxy.LocalProxyConfig{
-		RemoteProxyAddr:         dialOpts.WebProxyAddr,
+		RemoteProxyAddr:         dialOptions.GetWebProxyAddr(),
 		Protocols:               []alpncommon.Protocol{alpncommon.ProtocolTCP},
 		ParentContext:           ctx,
-		SNI:                     dialOpts.SNI,
-		RootCAs:                 dialOpts.RootClusterCACertPool,
-		ALPNConnUpgradeRequired: dialOpts.ALPNConnUpgradeRequired,
+		SNI:                     dialOptions.GetSni(),
+		RootCAs:                 x509.NewCertPool(),
+		ALPNConnUpgradeRequired: dialOptions.GetAlpnConnUpgradeRequired(),
 		Middleware:              middleware,
-		InsecureSkipVerify:      dialOpts.InsecureSkipVerify,
+		InsecureSkipVerify:      dialOptions.GetInsecureSkipVerify(),
 		Clock:                   h.clock,
 	}
-
+	_ = localProxyConfig.RootCAs.AppendCertsFromPEM(dialOptions.GetRootClusterCaCertPool())
 	h.log.DebugContext(ctx, "Creating local proxy", "target_port", localPort)
 	newLP, err := alpnproxy.NewLocalProxy(localProxyConfig)
 	if err != nil {
 		return nil, trace.Wrap(err, "creating local proxy")
 	}
-
 	h.portToLocalProxy[localPort] = newLP
-
 	return newLP, nil
 }
 
 // handleTCPConnector handles an incoming TCP connection from VNet by passing it to the local alpn proxy,
 // which is set up with middleware to automatically handler certificate renewal and re-logins.
 func (h *tcpAppHandler) handleTCPConnector(ctx context.Context, localPort uint16, connector func() (net.Conn, error)) error {
-	if len(h.app.GetTCPPorts()) > 0 {
-		if !h.app.GetTCPPorts().Contains(int(localPort)) {
-			h.appProvider.OnInvalidLocalPort(ctx, h.profileName, h.leafClusterName, h.routeToApp(localPort), h.app.GetTCPPorts())
-			return trace.BadParameter("local port %d is not in TCP ports of app %q", localPort, h.app.GetName())
+	app := h.appInfo.GetApp()
+	if len(app.GetTCPPorts()) > 0 {
+		if !app.GetTCPPorts().Contains(int(localPort)) {
+			h.appProvider.OnInvalidLocalPort(ctx, h.appInfo, localPort)
+			return trace.BadParameter("local port %d is not in TCP ports of app %q", localPort, app.GetName())
 		}
 	}
 
@@ -409,26 +185,12 @@ func (h *tcpAppHandler) handleTCPConnector(ctx context.Context, localPort uint16
 	return trace.Wrap(lp.HandleTCPConnector(ctx, connector), "handling TCP connector")
 }
 
-func (h *tcpAppHandler) routeToApp(localPort uint16) proto.RouteToApp {
-	return proto.RouteToApp{
-		Name:       h.app.GetName(),
-		PublicAddr: h.app.GetPublicAddr(),
-		// ClusterName must _not_ be set to "" when targeting an app from a root cluster. Otherwise the
-		// connection routed through a local proxy will just get lost somewhere in the cluster (with no
-		// clear error being reported) and hang forever.
-		ClusterName: h.clusterName,
-		URI:         h.app.GetURI(),
-		TargetPort:  uint32(localPort),
-	}
-}
-
 // appCertIssuer implements [client.CertIssuer].
 type appCertIssuer struct {
-	appProvider     AppProvider
-	profileName     string
-	leafClusterName string
-	routeToApp      proto.RouteToApp
-	group           singleflight.Group
+	appProvider appProvider
+	appInfo     *vnetv1.AppInfo
+	targetPort  uint16
+	group       singleflight.Group
 }
 
 func (i *appCertIssuer) CheckCert(cert *x509.Certificate) error {
@@ -438,7 +200,7 @@ func (i *appCertIssuer) CheckCert(cert *x509.Certificate) error {
 
 func (i *appCertIssuer) IssueCert(ctx context.Context) (tls.Certificate, error) {
 	cert, err, _ := i.group.Do("", func() (any, error) {
-		return i.appProvider.ReissueAppCert(ctx, i.profileName, i.leafClusterName, i.routeToApp)
+		return i.appProvider.ReissueAppCert(ctx, i.appInfo, i.targetPort)
 	})
 	return cert.(tls.Certificate), trace.Wrap(err)
 }
@@ -460,13 +222,11 @@ func fullyQualify(domain string) string {
 }
 
 // localProxyMiddleware wraps around [client.CertChecker] and additionally makes it so that its
-// OnNewConnection method calls the same method of [AppProvider].
+// OnNewConnection method calls the same method of [appProvider].
 type localProxyMiddleware struct {
-	routeToApp      proto.RouteToApp
-	profileName     string
-	leafClusterName string
-	certChecker     *client.CertChecker
-	appProvider     AppProvider
+	appKey      *vnetv1.AppKey
+	certChecker *client.CertChecker
+	appProvider appProvider
 }
 
 func (m *localProxyMiddleware) OnNewConnection(ctx context.Context, lp *alpnproxy.LocalProxy) error {
@@ -474,10 +234,21 @@ func (m *localProxyMiddleware) OnNewConnection(ctx context.Context, lp *alpnprox
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
-	return trace.Wrap(m.appProvider.OnNewConnection(ctx, m.profileName, m.leafClusterName, m.routeToApp))
+	return trace.Wrap(m.appProvider.OnNewConnection(ctx, m.appKey))
 }
 
 func (m *localProxyMiddleware) OnStart(ctx context.Context, lp *alpnproxy.LocalProxy) error {
 	return trace.Wrap(m.certChecker.OnStart(ctx, lp))
+}
+
+// RouteToApp returns a *proto.RouteToApp populated from appInfo and targetPort.
+func RouteToApp(appInfo *vnetv1.AppInfo, targetPort uint16) *proto.RouteToApp {
+	app := appInfo.GetApp()
+	return &proto.RouteToApp{
+		Name:        app.GetName(),
+		PublicAddr:  app.GetPublicAddr(),
+		ClusterName: appInfo.GetCluster(),
+		URI:         app.GetURI(),
+		TargetPort:  uint32(targetPort),
+	}
 }

--- a/lib/vnet/ipbits.go
+++ b/lib/vnet/ipbits.go
@@ -41,7 +41,7 @@ func NewIPv6Prefix() (tcpip.Address, error) {
 	var bytes [16]byte
 	bytes[0] = 0xfd
 	if _, err := rand.Read(bytes[1:6]); err != nil {
-		return tcpip.Address{}, trace.Wrap(err)
+		return tcpip.Address{}, trace.Wrap(err, "reading random bytes")
 	}
 	return tcpip.AddrFrom16(bytes), nil
 }

--- a/lib/vnet/local_app_provider.go
+++ b/lib/vnet/local_app_provider.go
@@ -137,7 +137,7 @@ func (p *localAppProvider) clusterClientForAppFQDN(ctx context.Context, profileN
 
 		clusterConfig, err := p.clusterConfigCache.GetClusterConfig(ctx, clusterClient)
 		if err != nil {
-			log.ErrorContext(ctx, "Failed to get VnetConfig, apps in the cluster will not be resolved.", "profile", profileName, "leaf_cluster", leafClusterName, "error", err)
+			log.ErrorContext(ctx, "Failed to get VNet config, apps in the cluster will not be resolved.", "profile", profileName, "leaf_cluster", leafClusterName, "error", err)
 			continue
 		}
 		for _, zone := range clusterConfig.DNSZones {

--- a/lib/vnet/local_app_provider.go
+++ b/lib/vnet/local_app_provider.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package vnet
 
 import (

--- a/lib/vnet/local_app_provider.go
+++ b/lib/vnet/local_app_provider.go
@@ -1,0 +1,216 @@
+package vnet
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+
+	apiclient "github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/types"
+	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+)
+
+// ClientApplication is the common interface implemented by each VNet client
+// application: Connect and tsh. It provides methods to list user profiles, get
+// cluster clients, issue app certificates, and report metrics and errors.
+type ClientApplication interface {
+	// ListProfiles lists the names of all profiles saved for the user.
+	ListProfiles() ([]string, error)
+
+	// GetCachedClient returns a [*client.ClusterClient] for the given profile and leaf cluster.
+	// [leafClusterName] may be empty when requesting a client for the root cluster. Returned clients are
+	// expected to be cached, as this may be called frequently.
+	GetCachedClient(ctx context.Context, profileName, leafClusterName string) (ClusterClient, error)
+
+	// ReissueAppCert issues a new cert for the target app.
+	ReissueAppCert(ctx context.Context, appInfo *vnetv1.AppInfo, targetPort uint16) (tls.Certificate, error)
+
+	// GetDialOptions returns ALPN dial options for the profile.
+	GetDialOptions(ctx context.Context, profileName string) (*vnetv1.DialOptions, error)
+
+	// OnNewConnection gets called whenever a new connection is about to be established through VNet.
+	// By the time OnNewConnection, VNet has already verified that the user holds a valid cert for the
+	// app.
+	//
+	// The connection won't be established until OnNewConnection returns. Returning an error prevents
+	// the connection from being made.
+	OnNewConnection(ctx context.Context, appKey *vnetv1.AppKey) error
+
+	// OnInvalidLocalPort gets called before VNet refuses to handle a connection to a multi-port TCP app
+	// because the provided port does not match any of the TCP ports in the app spec.
+	OnInvalidLocalPort(ctx context.Context, appInfo *vnetv1.AppInfo, targetPort uint16)
+}
+
+// ClusterClient is an interface defining the subset of [client.ClusterClient]
+// methods used by via [ClientApplication].
+type ClusterClient interface {
+	CurrentCluster() authclient.ClientI
+	ClusterName() string
+	RootClusterName() string
+}
+
+// localAppProvider implements wraps a [ClientApplication] to implement
+// appProvider.
+type localAppProvider struct {
+	ClientApplication
+	clusterConfigCache *ClusterConfigCache
+}
+
+func newLocalAppProvider(clientApp ClientApplication, clock clockwork.Clock) *localAppProvider {
+	return &localAppProvider{
+		ClientApplication:  clientApp,
+		clusterConfigCache: NewClusterConfigCache(clock),
+	}
+}
+
+// ResolveAppInfo implements [appProvider.ResolveAppInfo].
+func (p *localAppProvider) ResolveAppInfo(ctx context.Context, fqdn string) (*vnetv1.AppInfo, error) {
+	profileNames, err := p.ClientApplication.ListProfiles()
+	if err != nil {
+		return nil, trace.Wrap(err, "listing profiles")
+	}
+	for _, profileName := range profileNames {
+		if fqdn == fullyQualify(profileName) {
+			// This is a query for the proxy address, which we'll never want to handle.
+			return nil, errNoTCPHandler
+		}
+
+		clusterClient, err := p.clusterClientForAppFQDN(ctx, profileName, fqdn)
+		if err != nil {
+			if errors.Is(err, errNoMatch) {
+				continue
+			}
+			// The user might be logged out from this one cluster (and retryWithRelogin isn't working). Log
+			// the error but don't return it so that DNS resolution will be forwarded upstream instead of
+			// failing, to avoid breaking e.g. web app access (we don't know if this is a web or TCP app yet
+			// because we can't log in).
+			log.ErrorContext(ctx, "Failed to get teleport client.", "error", err)
+			continue
+		}
+
+		leafClusterName := ""
+		clusterName := clusterClient.ClusterName()
+		if clusterName != "" && clusterName != clusterClient.RootClusterName() {
+			leafClusterName = clusterName
+		}
+
+		return p.resolveAppInfoForCluster(ctx, clusterClient, profileName, leafClusterName, fqdn)
+	}
+	// fqdn did not match any profile, forward the request upstream.
+	return nil, errNoTCPHandler
+}
+
+func (p *localAppProvider) clusterClientForAppFQDN(ctx context.Context, profileName, fqdn string) (ClusterClient, error) {
+	rootClient, err := p.ClientApplication.GetCachedClient(ctx, profileName, "")
+	if err != nil {
+		log.ErrorContext(ctx, "Failed to get root cluster client, apps in this cluster will not be resolved.", "profile", profileName, "error", err)
+		return nil, errNoMatch
+	}
+
+	if isDescendantSubdomain(fqdn, profileName) {
+		// The queried app fqdn is a subdomain of this cluster proxy address.
+		return rootClient, nil
+	}
+
+	leafClusters, err := getLeafClusters(ctx, rootClient)
+	if err != nil {
+		// Good chance we're here because the user is not logged in to the profile.
+		log.ErrorContext(ctx, "Failed to list leaf clusters, apps in this cluster will not be resolved.", "profile", profileName, "error", err)
+		return nil, errNoMatch
+	}
+
+	// Prefix with an empty string to represent the root cluster.
+	allClusters := append([]string{""}, leafClusters...)
+	for _, leafClusterName := range allClusters {
+		clusterClient, err := p.ClientApplication.GetCachedClient(ctx, profileName, leafClusterName)
+		if err != nil {
+			log.ErrorContext(ctx, "Failed to get cluster client, apps in this cluster will not be resolved.", "profile", profileName, "leaf_cluster", leafClusterName, "error", err)
+			continue
+		}
+
+		clusterConfig, err := p.clusterConfigCache.GetClusterConfig(ctx, clusterClient)
+		if err != nil {
+			log.ErrorContext(ctx, "Failed to get VnetConfig, apps in the cluster will not be resolved.", "profile", profileName, "leaf_cluster", leafClusterName, "error", err)
+			continue
+		}
+		for _, zone := range clusterConfig.DNSZones {
+			if isDescendantSubdomain(fqdn, zone) {
+				return clusterClient, nil
+			}
+		}
+	}
+	return nil, errNoMatch
+}
+
+var errNoMatch = errors.New("cluster does not match queried FQDN")
+
+func getLeafClusters(ctx context.Context, rootClient ClusterClient) ([]string, error) {
+	var leafClusters []string
+	nextPage := ""
+	for {
+		remoteClusters, nextPage, err := rootClient.CurrentCluster().ListRemoteClusters(ctx, 0, nextPage)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		for _, rc := range remoteClusters {
+			leafClusters = append(leafClusters, rc.GetName())
+		}
+		if nextPage == "" {
+			return leafClusters, nil
+		}
+	}
+}
+
+func (p *localAppProvider) resolveAppInfoForCluster(
+	ctx context.Context,
+	clusterClient ClusterClient,
+	profileName, leafClusterName, fqdn string,
+) (*vnetv1.AppInfo, error) {
+	log := log.With("profile", profileName, "leaf_cluster", leafClusterName, "fqdn", fqdn)
+	// An app public_addr could technically be full-qualified or not, match either way.
+	expr := fmt.Sprintf(`(resource.spec.public_addr == "%s" || resource.spec.public_addr == "%s") && hasPrefix(resource.spec.uri, "tcp://")`,
+		strings.TrimSuffix(fqdn, "."), fqdn)
+	resp, err := apiclient.GetResourcePage[types.AppServer](ctx, clusterClient.CurrentCluster(), &proto.ListResourcesRequest{
+		ResourceType:        types.KindAppServer,
+		PredicateExpression: expr,
+		Limit:               1,
+	})
+	if err != nil {
+		// Don't return an unexpected error so we can try to find the app in different clusters or forward the
+		// request upstream.
+		log.InfoContext(ctx, "Failed to list application servers", "error", err)
+		return nil, errNoTCPHandler
+	}
+	if len(resp.Resources) == 0 {
+		// Didn't find any matching app, forward the request upstream.
+		return nil, errNoTCPHandler
+	}
+	clusterConfig, err := p.clusterConfigCache.GetClusterConfig(ctx, clusterClient)
+	if err != nil {
+		log.InfoContext(ctx, "Failed to get cluster VNet config", "error", err)
+		return nil, errNoTCPHandler
+	}
+	dialOpts, err := p.ClientApplication.GetDialOptions(ctx, profileName)
+	if err != nil {
+		log.InfoContext(ctx, "Failed to get cluster dial options", "error", err)
+		return nil, errNoTCPHandler
+	}
+	appInfo := &vnetv1.AppInfo{
+		AppKey: &vnetv1.AppKey{
+			Profile:     profileName,
+			LeafCluster: leafClusterName,
+		},
+		Cluster:       clusterClient.ClusterName(),
+		App:           resp.Resources[0].GetApp().(*types.AppV3),
+		Ipv4CidrRange: clusterConfig.IPv4CIDRRange,
+		DialOptions:   dialOpts,
+	}
+	return appInfo, nil
+}

--- a/lib/vnet/local_app_provider.go
+++ b/lib/vnet/local_app_provider.go
@@ -19,7 +19,10 @@ import (
 
 // ClientApplication is the common interface implemented by each VNet client
 // application: Connect and tsh. It provides methods to list user profiles, get
-// cluster clients, issue app certificates, and report metrics and errors.
+// cluster clients, issue app certificates, and report metrics and errors -
+// anything that uses the user's credentials or a Teleport client.
+// The name "client application" refers to a user-facing client application, in
+// constrast to the MacOS daemon or Windows service.
 type ClientApplication interface {
 	// ListProfiles lists the names of all profiles saved for the user.
 	ListProfiles() ([]string, error)

--- a/lib/vnet/network_stack.go
+++ b/lib/vnet/network_stack.go
@@ -87,25 +87,29 @@ func (c *networkStackConfig) checkAndSetDefaults() error {
 }
 
 // tcpHandlerResolver describes a type that can resolve a fully-qualified domain
-// name to a [tcpHandlerSpec] that defines the CIDR range to assign an IP to
+// name to a tcpHandlerSpec that defines the CIDR range to assign an IP to
 // that handler from, and a handler for all future connections to that IP
 // address.
 //
 // Implementations beware - an FQDN always ends with a '.'.
 type tcpHandlerResolver interface {
-	// resolveTCPHandler decides if [fqdn] should match a TCP handler.
+	// resolveTCPHandler decides if fqdn should match a TCP handler.
 	//
-	// If [fqdn] matches a Teleport-managed TCP app it must return a
-	// [tcpHandlerSpec] defining the range to
-	// assign an IP from, and a handler for future connections to any assigned IPs.
+	// If fqdn matches a Teleport-managed TCP app it must return a
+	// tcpHandlerSpec defining the CIDR range to assign an IP from, and a
+	// handler for future connections to any assigned IPs.
 	//
-	// If [fqdn] does not match it must return ErrNoTCPHandler.
+	// If fqdn does not match it must return errNoTCPHandler. Avoid using
+	// [trace.Wrap] on errNoTCPHandler to prevent collecting a full stack trace
+	// on every unhandled query.
 	resolveTCPHandler(ctx context.Context, fqdn string) (*tcpHandlerSpec, error)
 }
 
-// errNoTCPHandler should be returned by [tcpHandlerResolver]s when no handler matches the FQDN.
-// Avoid using [trace.Wrap] on errNoTCPHandler where possible, this isn't an unexpected error that we would
-// expect to need to debug and [trace.Wrap] incurs overhead to collect a full stack trace.
+// errNoTCPHandler should be returned by tcpHandlerResolvers when no handler
+// matches the FQDN.
+//
+// Avoid using [trace.Wrap] on errNoTCPHandler where possible, this isn't an
+// unexpected error that should require the overhead of collecting a stack trace.
 var errNoTCPHandler = errors.New("no handler for address")
 
 // tcpHandlerSpec specifies a VNet TCP handler.

--- a/lib/vnet/user_process.go
+++ b/lib/vnet/user_process.go
@@ -28,19 +28,17 @@ import (
 
 // UserProcessConfig provides the necessary configuration to run VNet.
 type UserProcessConfig struct {
-	// AppProvider is a required field providing an interface implementation for [AppProvider].
-	AppProvider AppProvider
-	// ClusterConfigCache is an optional field providing [ClusterConfigCache]. If empty, a new cache
-	// will be created.
-	ClusterConfigCache *ClusterConfigCache
+	// ClientApplication is a required field providing an interface implementation for
+	// [ClientApplication].
+	ClientApplication ClientApplication
 	// HomePath is the tsh home used for Teleport clients created by VNet. Resolved using the same
 	// rules as HomeDir in tsh.
 	HomePath string
 }
 
 func (c *UserProcessConfig) checkAndSetDefaults() error {
-	if c.AppProvider == nil {
-		return trace.BadParameter("missing AppProvider")
+	if c.ClientApplication == nil {
+		return trace.BadParameter("missing ClientApplication")
 	}
 	if c.HomePath == "" {
 		c.HomePath = profile.FullProfilePath(os.Getenv(types.HomeEnvVar))

--- a/lib/vnet/user_process_darwin.go
+++ b/lib/vnet/user_process_darwin.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	"golang.zx2c4.com/wireguard/tun"
 
 	"github.com/gravitational/teleport/lib/vnet/daemon"
@@ -31,7 +32,7 @@ import (
 // background. To do this, it also needs to launch an admin process in the
 // background. It returns a [ProcessManager] which controls the lifecycle of
 // both background tasks.
-func runPlatformUserProcess(ctx context.Context, config *UserProcessConfig) (pm *ProcessManager, err error) {
+func runPlatformUserProcess(ctx context.Context, cfg *UserProcessConfig) (pm *ProcessManager, err error) {
 	// Make sure to close the process manager if returning a non-nil error.
 	defer func() {
 		if pm != nil && err != nil {
@@ -65,7 +66,7 @@ func runPlatformUserProcess(ctx context.Context, config *UserProcessConfig) (pm 
 			SocketPath: socketPath,
 			IPv6Prefix: ipv6Prefix.String(),
 			DNSAddr:    dnsIPv6.String(),
-			HomePath:   config.HomePath,
+			HomePath:   cfg.HomePath,
 		}
 		return trace.Wrap(execAdminProcess(processCtx, daemonConfig))
 	})
@@ -106,12 +107,9 @@ func runPlatformUserProcess(ctx context.Context, config *UserProcessConfig) (pm 
 		}
 	}
 
-	appResolver, err := newTCPAppResolver(config.AppProvider,
-		WithClusterConfigCache(config.ClusterConfigCache))
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
+	clock := clockwork.NewRealClock()
+	appProvider := newLocalAppProvider(cfg.ClientApplication, clock)
+	appResolver := newTCPAppResolver(appProvider, clock)
 	ns, err := newNetworkStack(&networkStackConfig{
 		tunDevice:          tun,
 		ipv6Prefix:         ipv6Prefix,

--- a/tool/tsh/common/app.go
+++ b/tool/tsh/common/app.go
@@ -99,7 +99,7 @@ func onAppLogin(cf *CLIConf) error {
 		AccessRequests: appInfo.profile.ActiveRequests.AccessRequests,
 	}
 
-	key, err := appLogin(cf.Context, tc, clusterClient, rootClient, appCertParams)
+	key, err := appLogin(cf.Context, clusterClient, rootClient, appCertParams)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -117,7 +117,6 @@ func onAppLogin(cf *CLIConf) error {
 
 func appLogin(
 	ctx context.Context,
-	tc *client.TeleportClient,
 	clusterClient *client.ClusterClient,
 	rootClient authclient.ClientI,
 	appCertParams client.ReissueParams,

--- a/tool/tsh/common/vnet.go
+++ b/tool/tsh/common/vnet.go
@@ -47,11 +47,13 @@ func newVnetCommand(app *kingpin.Application) *vnetCommand {
 }
 
 func (c *vnetCommand) run(cf *CLIConf) error {
-	appProvider, err := newVnetAppProvider(cf)
+	clientApp, err := newVnetClientApplication(cf)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	processManager, err := vnet.RunUserProcess(cf.Context, &vnet.UserProcessConfig{AppProvider: appProvider})
+	processManager, err := vnet.RunUserProcess(cf.Context, &vnet.UserProcessConfig{
+		ClientApplication: clientApp,
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tsh/common/vnet_other.go
+++ b/tool/tsh/common/vnet_other.go
@@ -24,7 +24,7 @@ import (
 )
 
 // Satisfy unused linter.
-var _ = newVnetAppProvider
+var _ = newVnetClientApplication
 
 func newPlatformVnetAdminSetupCommand(app *kingpin.Application) vnetCLICommand {
 	return vnetCommandNotSupported{}


### PR DESCRIPTION
Part of [RFD 195](https://github.com/gravitational/teleport/pull/50850).

This PR refactors the way that the VNet client applications (Connect and `tsh vnet`) provide teleport clients and other functionality to the VNet library. The goal is to move toward an interface that can be implemented locally OR over gRPC so that the VNet Windows service can interact with the client application from another process.

The current implementation (prior to this change) has both clients implementing an interface called `vnet.AppProvider`. In this PR, each client now implements `vnet.ClientApplication`. `vnet.localAppProvider` now wraps `vnet.ClientApplication` to implement the now-unexported `vnet.appProvider`. In a [following PR](https://github.com/gravitational/teleport/pull/51279), I will add a `vnet.remoteAppProvider` that also implements this interface but interacts with the client application over gRPC.

This is basically a rewrite of lib/vnet/app_resolver.go so the diff may not be very useful there, but the new code on its own should be reviewable.

The parent PR https://github.com/gravitational/teleport/pull/51215 adds the necessary proto files.