### PR TITLE
update license to do logic in teleport configure

### DIFF
--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -888,7 +888,13 @@ func onConfigDump(flags dumpFlags) error {
 		return trace.Wrap(err)
 	}
 
-	configPath, err := dumpConfigFile(flags.output, sfc.DebugDumpToYAML(), sampleConfComment)
+	sampleConfiguration := sampleConfComment
+	if modules.GetModules().IsEnterpriseBuild() && (flags.Roles == "" || strings.Contains(flags.Roles, defaults.RoleAuthService)) {
+
+		sampleConfiguration += thingsToDoConfComment
+	}
+
+	configPath, err := dumpConfigFile(flags.output, sfc.DebugDumpToYAML(), sampleConfiguration)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -888,10 +888,11 @@ func onConfigDump(flags dumpFlags) error {
 		return trace.Wrap(err)
 	}
 
+	// Only include license to do if this is a ent install with auth service enabled
 	sampleConfiguration := sampleConfComment
 	if modules.GetModules().IsEnterpriseBuild() && (flags.Roles == "" || strings.Contains(flags.Roles, defaults.RoleAuthService)) {
 
-		sampleConfiguration += thingsToDoConfComment
+		sampleConfiguration += licenseToDoConfComment
 	}
 
 	configPath, err := dumpConfigFile(flags.output, sfc.DebugDumpToYAML(), sampleConfiguration)

--- a/tool/teleport/common/usage.go
+++ b/tool/teleport/common/usage.go
@@ -141,7 +141,7 @@ const (
 #`
 )
 const (
-	thingsToDoConfComment = `# Things to update:
+	licenseToDoConfComment = `# Things to update:
 #  1. license.pem: Retrieve a license from your Teleport account https://teleport.sh
 #     if you are a self-hosted Enterprise customer.
 #`

--- a/tool/teleport/common/usage.go
+++ b/tool/teleport/common/usage.go
@@ -138,8 +138,11 @@ const (
 	sampleConfComment = `#
 # A Sample Teleport configuration file.
 #
-# Things to update:
+#`
+)
+const (
+	thingsToDoConfComment = `# Things to update:
 #  1. license.pem: Retrieve a license from your Teleport account https://teleport.sh
-#     if you are an Enterprise customer.
+#     if you are a self-hosted Enterprise customer.
 #`
 )


### PR DESCRIPTION
Updates `teleport configure` comments output for:
- not including license install rec unless enterprise build
- not including license install rec if auth service isn't requested
- updating language that the license applies to self-hosted

This provides the following benefit:
- doesn't recommend installing the license when the configure is not related to the auth service
- many ent customers are not self-hosted, rather cloud, so calling this out, to avoid confusion

An example would be if you do a `teleport configure --roles=node` it gives you a to do for the license when only SSH is enabled. This doesn't apply whether you are a ent customer or not. 


Updated outputs:

## `teleport configure` or `teleport configure --roles=proxy,node,auth` in OSS:

```yaml
teleport configure
#
# A Sample Teleport configuration file.
#
#
version: v3
teleport:
  nodename: server.home
  data_dir: /var/lib/teleport
  log:
    output: stderr
    severity: INFO
    format:
      output: text
  ca_pin: ""
  diag_addr: ""
auth_service:
  enabled: "yes"
  listen_addr: 0.0.0.0:3025
  proxy_listener_mode: multiplex
ssh_service:
  enabled: "yes"
proxy_service:
  enabled: "yes"
  https_keypairs: []
  https_keypairs_reload_interval: 0s
  acme: {}
```

## `teleport configure --roles=node` in OSS and ent builds:
```yaml
#
# A Sample Teleport configuration file.
#
#
version: v3
teleport:
  nodename: Stevens-MBP.fios-router.home
  data_dir: /var/lib/teleport
  log:
    output: stderr
    severity: INFO
    format:
      output: text
  ca_pin: ""
  diag_addr: ""
auth_service:
  enabled: "no"
ssh_service:
  enabled: "yes"
proxy_service:
  enabled: "no"
  https_keypairs: []
  https_keypairs_reload_interval: 0s
  acme: {}
```

## License.pem recommended just in ent builds including the auth service on

`teleport configure`:

```yaml
#
# A Sample Teleport configuration file.
#
## Things to update:
#  1. license.pem: Retrieve a license from your Teleport account https://teleport.sh
#     if you are a self-hosted Enterprise customer.
#
version: v3
teleport:
  nodename: Stevens-MBP.fios-router.home
  data_dir: /var/lib/teleport
  log:
    output: stderr
    severity: INFO
    format:
      output: text
  ca_pin: ""
  diag_addr: ""
auth_service:
  enabled: "yes"
  listen_addr: 0.0.0.0:3025
  license_file: /var/lib/teleport/license.pem
  proxy_listener_mode: multiplex
ssh_service:
  enabled: "yes"
proxy_service:
  enabled: "yes"
  https_keypairs: []
  https_keypairs_reload_interval: 0s
  acme: {}
```








