### PR TITLE
Add description in UI to AWS OIDC Integrations

### DIFF
--- a/web/packages/teleport/src/Integrations/IntegrationList.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationList.tsx
@@ -108,6 +108,7 @@ export function IntegrationList(props: Props<IntegrationLike>) {
         {
           key: 'details',
           headerText: 'Details',
+          render: item => <DetailsCell item={item} />,
         },
         {
           key: 'statusCode',
@@ -384,6 +385,30 @@ const IconCell = ({ item }: { item: IntegrationLike }) => {
         {icon}
         {formattedText}
       </Flex>
+    </Cell>
+  );
+};
+
+const DetailsCell = ({ item }: { item: IntegrationLike }) => {
+  let formattedText: string;
+
+  switch (item.resourceType) {
+    case 'integration':
+      switch (item.kind) {
+        case 'aws-oidc':
+          formattedText =
+            'Enroll EC2, RDS and EKS resources or enable Web/CLI access to your AWS Account.';
+          break;
+      }
+  }
+
+  if (!formattedText) {
+    return;
+  }
+
+  return (
+    <Cell>
+      <Flex alignItems="center">{formattedText}</Flex>
     </Cell>
   );
 };


### PR DESCRIPTION
We were not showing any description for AWS OIDC Integrations.

This PR changes the description so that it indicates the integration capabilities.

Demo
Before
![image](https://github.com/user-attachments/assets/de3dbc61-2394-4679-9e74-c5cfc3381ec1)

After
![image](https://github.com/user-attachments/assets/db852053-5df2-4cf3-83c6-354fc2ee802a)

I'm not sure about the message yet. We should either add links to it or change it to be more informative.

Fixes: https://github.com/gravitational/teleport/issues/46827