### PR TITLE
Add `wildcard-workload-identity-issuer` preset role

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -714,6 +714,12 @@ const (
 	// that grants a user access to AWS Identity Center resources via
 	// Access Requests.
 	SystemIdentityCenterAccessRoleName = "aws-ic-access"
+
+	// PresetWildcardWorkloadIdentityIssuerRoleName is a name of a preset role
+	// that includes the permissions necessary to issue workload identity
+	// credentials using any workload_identity resource. This exists to simplify
+	// Day 0 UX experience with workload identity.
+	PresetWildcardWorkloadIdentityIssuerRoleName = "wildcard-workload-identity-issuer"
 )
 
 var PresetRoles = []string{PresetEditorRoleName, PresetAccessRoleName, PresetAuditorRoleName}

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -1039,6 +1039,7 @@ func GetPresetRoles() []types.Role {
 		services.NewSystemOktaRequesterRole(),
 		services.NewPresetTerraformProviderRole(),
 		services.NewSystemIdentityCenterAccessRole(),
+		services.NewPresetWildcardWorkloadIdentityIssuerRole(),
 	}
 
 	// Certain `New$FooRole()` functions will return a nil role if the

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -780,6 +780,7 @@ func TestPresets(t *testing.T) {
 		teleport.PresetAccessRoleName,
 		teleport.PresetAuditorRoleName,
 		teleport.PresetTerraformProviderRoleName,
+		teleport.PresetWildcardWorkloadIdentityIssuerRoleName,
 	}
 
 	t.Run("EmptyCluster", func(t *testing.T) {

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -516,6 +516,34 @@ func NewPresetRequireTrustedDeviceRole() types.Role {
 	}
 }
 
+// NewPresetWildcardWorkloadIdentityIssuerRole returns a new pre-defined role
+// for issuing workload identities.
+func NewPresetWildcardWorkloadIdentityIssuerRole() types.Role {
+	role := &types.RoleV6{
+		Kind:    types.KindRole,
+		Version: types.V7,
+		Metadata: types.Metadata{
+			Name:        teleport.PresetWildcardWorkloadIdentityIssuerRoleName,
+			Namespace:   apidefaults.Namespace,
+			Description: "Issue workload identities",
+			Labels: map[string]string{
+				types.TeleportInternalResourceType: types.PresetResource,
+			},
+		},
+		Spec: types.RoleSpecV6{
+			Allow: types.RoleConditions{
+				WorkloadIdentityLabels: types.Labels{
+					types.Wildcard: []string{types.Wildcard},
+				},
+				Rules: []types.Rule{
+					types.NewRule(types.KindWorkloadIdentity, RO()),
+				},
+			},
+		},
+	}
+	return role
+}
+
 // SystemOktaAccessRoleName is the name of the system role that allows
 // access to Okta resources. This will be used by the Okta requester role to
 // search for Okta resources.


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport/issues/44006

This'll let us simplify guides/wizards by skipping the creation of a role. This role is also suitable for small production usage, as the WorkloadIdentity resource itself includes authorization rules.

changelog: Added `wildcard-workload-identity-issuer` preset role to improve Day 0 experience with configuring Teleport Workload Identity.