### PR TITLE
[v17] tctl alerts ls: encode empty array instead of null

### DIFF
--- a/tool/tctl/common/alert_command.go
+++ b/tool/tctl/common/alert_command.go
@@ -20,8 +20,8 @@ package common
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/utils"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
 )
@@ -261,12 +262,7 @@ func calculateTTL(expiration *time.Time) time.Duration {
 }
 
 func displayAlertsJSON(alerts []types.ClusterAlert) error {
-	out, err := json.MarshalIndent(alerts, "", "  ")
-	if err != nil {
-		return trace.Wrap(err, "failed to marshal alerts")
-	}
-	fmt.Println(string(out))
-	return nil
+	return utils.WriteJSONArray(os.Stdout, alerts)
 }
 
 func (c *AlertCommand) Create(ctx context.Context, client *authclient.Client) error {


### PR DESCRIPTION
Backport #51211 to branch/v17