### PR TITLE
Remove k8s.io ignore from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,8 +21,6 @@ updates:
       - dependency-name: github.com/microsoft/go-mssqldb
       - dependency-name: github.com/redis/go-redis/v9
       - dependency-name: github.com/vulcand/predicate
-      # Ignore until kube libs are upgraded. See https://github.com/kubernetes-sigs/controller-runtime/issues/2788.
-      - dependency-name: k8s.io/*
     open-pull-requests-limit: 20
     groups:
       go:


### PR DESCRIPTION
Remove ignores since we are already past the affected versions and the linked issue is resolved.