### PR TITLE
[Web] Hide access request promoted notification quick action button if the user is already part of the access list

### DIFF
--- a/web/packages/teleport/src/Login/useLogin.ts
+++ b/web/packages/teleport/src/Login/useLogin.ts
@@ -97,6 +97,7 @@ export default function useLogin() {
 
   function onLogin(email, password, token) {
     attemptActions.start();
+    storageService.clearLoginTime();
     auth
       .login(email, password, token)
       .then(onSuccess)
@@ -107,6 +108,7 @@ export default function useLogin() {
 
   function onLoginWithWebauthn(creds?: UserCredentials) {
     attemptActions.start();
+    storageService.clearLoginTime();
     auth
       .loginWithWebauthn(creds)
       .then(onSuccess)
@@ -117,6 +119,7 @@ export default function useLogin() {
 
   function onLoginWithSso(provider: AuthProvider) {
     attemptActions.start();
+    storageService.clearLoginTime();
     const appStartRoute = getEntryRoute();
     const ssoUri = cfg.getSsoUrl(provider.url, provider.name, appStartRoute);
     history.push(ssoUri, true);

--- a/web/packages/teleport/src/components/Authenticated/Authenticated.tsx
+++ b/web/packages/teleport/src/components/Authenticated/Authenticated.tsx
@@ -67,6 +67,7 @@ const Authenticated: React.FC<PropsWithChildren> = ({ children }) => {
         if (result.requiresDeviceTrust === TrustedDeviceRequirement.REQUIRED) {
           session.setDeviceTrustRequired();
         }
+        storageService.setLoginTimeOnce();
         setAttempt({ status: 'success' });
       } catch (e) {
         if (e instanceof ApiError && e.response?.status == 403) {

--- a/web/packages/teleport/src/services/storageService/storageService.ts
+++ b/web/packages/teleport/src/services/storageService/storageService.ts
@@ -102,6 +102,23 @@ export const storageService = {
     return time ? time : 0;
   },
 
+  setLoginTimeOnce() {
+    const existingTime = window.localStorage.getItem(KeysEnum.LOGIN_TIME);
+    // Only set the login time if it doesn't already exist.
+    if (!existingTime) {
+      window.localStorage.setItem(KeysEnum.LOGIN_TIME, `${Date.now()}`);
+    }
+  },
+
+  getLoginTime(): Date {
+    const time = Number(window.localStorage.getItem(KeysEnum.LOGIN_TIME));
+    return time && !Number.isNaN(time) ? new Date(time) : new Date(0);
+  },
+
+  clearLoginTime() {
+    window.localStorage.removeItem(KeysEnum.LOGIN_TIME);
+  },
+
   // setOnboardDiscover persists states used to determine if a user should
   // be onboarded to use the discovery wizard or not. User should only
   // be onboarded once upon login.

--- a/web/packages/teleport/src/services/storageService/types.ts
+++ b/web/packages/teleport/src/services/storageService/types.ts
@@ -38,6 +38,7 @@ export const KeysEnum = {
     'grv_users_not_equal_to_mau_acknowledged',
   LOCAL_NOTIFICATION_STATES: 'grv_teleport_notification_states',
   RECENT_HISTORY: 'grv_teleport_sidenav_recent_history',
+  LOGIN_TIME: 'grv_teleport_login_time',
 
   // TODO(bl-nero): Remove once the new role editor is in acceptable state.
   USE_NEW_ROLE_EDITOR: 'grv_teleport_use_new_role_editor',


### PR DESCRIPTION
## Purpose

`e` counterpart: https://github.com/gravitational/teleport.e/pull/5893

This PR fixes a UX bug which caused users to still see the "Log in again to gain access" button on their access request promoted notification even if they had already done so. 

The logic simply works by keeping track of when the user logged in, if they logged in before the access request was promoted, then they will be shown the button to log in again.

## Demo


https://github.com/user-attachments/assets/88f5532f-2a33-4a9d-aa37-e6c461dc9588
