### PR TITLE
netiq: Expose `GetNetIq` method in `PluginStatus`

### DIFF
--- a/api/types/plugin.go
+++ b/api/types/plugin.go
@@ -134,6 +134,7 @@ type PluginStatus interface {
 	GetEntraId() *PluginEntraIDStatusV1
 	GetOkta() *PluginOktaStatusV1
 	GetAwsIc() *PluginAWSICStatusV1
+	GetNetIq() *PluginNetIQStatusV1
 }
 
 // NewPluginV1 creates a new PluginV1 resource.


### PR DESCRIPTION
This PR exposes the `GetNetIq` method in `PluginStatus` interface to be used in `e`.