### PR TITLE
netiq: return type from netiq spec

### DIFF
--- a/api/types/plugin.go
+++ b/api/types/plugin.go
@@ -565,6 +565,8 @@ func (p *PluginV1) GetType() PluginType {
 		return PluginTypeEmail
 	case *PluginSpecV1_Msteams:
 		return PluginTypeMSTeams
+	case *PluginSpecV1_NetIq:
+		return PluginTypeNetIQ
 	default:
 		return PluginTypeUnknown
 	}


### PR DESCRIPTION
This method returns the NetIQ plugin type based on the plugin spec.