### PR TITLE
[v17] GitHub proxy: download GitHub server keys

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -285,6 +285,10 @@ const (
 	// ComponentUpdater represents the agent updater.
 	ComponentUpdater = "updater"
 
+
+	// ComponentGit represents git proxy related services.
+	ComponentGit = "git"
+
 	// ComponentForwardingGit represents the SSH proxy that forwards Git commands.
 	ComponentForwardingGit = "git:forward"
 

--- a/constants.go
+++ b/constants.go
@@ -285,7 +285,6 @@ const (
 	// ComponentUpdater represents the agent updater.
 	ComponentUpdater = "updater"
 
-
 	// ComponentGit represents git proxy related services.
 	ComponentGit = "git"
 

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -394,6 +394,7 @@ func (s *localSite) dialAndForwardGit(params reversetunnelclient.DialParams) (_ 
 		HostUUID:        s.srv.ID,
 		TargetServer:    params.TargetServer,
 		Clock:           s.clock,
+		KeyManager:      s.srv.gitKeyManager,
 	}
 	remoteServer, err := git.NewForwardServer(serverConfig)
 	if err != nil {

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -50,6 +50,7 @@ import (
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/readonly"
+	"github.com/gravitational/teleport/lib/srv/git"
 	"github.com/gravitational/teleport/lib/srv/ingress"
 	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/sshutils"
@@ -123,6 +124,9 @@ type server struct {
 
 	// proxySigner is used to sign PROXY headers to securely propagate client IP information
 	proxySigner multiplexer.PROXYHeaderSigner
+
+	// gitKeyManager manages keys for git proxies.
+	gitKeyManager *git.KeyManager
 }
 
 // Config is a reverse tunnel server configuration
@@ -320,6 +324,16 @@ func NewServer(cfg Config) (reversetunnelclient.Server, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	gitKeyManager, err := git.NewKeyManager(&git.KeyManagerConfig{
+		ParentContext: ctx,
+		AuthClient:    cfg.LocalAuthClient,
+		AccessPoint:   cfg.LocalAccessPoint,
+	})
+	if err != nil {
+		cancel()
+		return nil, trace.Wrap(err)
+	}
+
 	srv := &server{
 		Config:           cfg,
 		localAuthClient:  cfg.LocalAuthClient,
@@ -332,6 +346,7 @@ func NewServer(cfg Config) (reversetunnelclient.Server, error) {
 		log:              cfg.Log,
 		offlineThreshold: offlineThreshold,
 		proxySigner:      cfg.PROXYSigner,
+		gitKeyManager:    gitKeyManager,
 	}
 
 	localSite, err := newLocalSite(srv, cfg.ClusterName, cfg.LocalAuthAddresses)

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -1710,6 +1710,10 @@ func (*oktaAssignmentCollector) notifyStale() {}
 type GitServerWatcherConfig struct {
 	GitServerGetter
 	ResourceWatcherConfig
+
+	// EnableUpdateBroadcast turns on emitting updates on changes. Broadcast is
+	// opt-in for Git Server watcher.
+	EnableUpdateBroadcast bool
 }
 
 // NewGitServerWatcher returns a new instance of Git server watcher.
@@ -1737,7 +1741,7 @@ func NewGitServerWatcher(ctx context.Context, cfg GitServerWatcherConfig) (*Gene
 			return all, nil
 		},
 		ResourceKey:            types.Server.GetName,
-		DisableUpdateBroadcast: true,
+		DisableUpdateBroadcast: !cfg.EnableUpdateBroadcast,
 		CloneFunc:              types.Server.DeepCopy,
 	})
 	return w, trace.Wrap(err)

--- a/lib/srv/git/forward_test.go
+++ b/lib/srv/git/forward_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 
+	"github.com/gravitational/teleport/api/client/gitserver"
 	"github.com/gravitational/teleport/api/constants"
 	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
 	"github.com/gravitational/teleport/api/types"
@@ -223,6 +224,8 @@ func TestForwardServer(t *testing.T) {
 				LockWatcher:     makeLockWatcher(t),
 				SrcAddr:         utils.MustParseAddr("127.0.0.1:12345"),
 				DstAddr:         utils.MustParseAddr("127.0.0.1:2222"),
+				// Not used in test, yet.
+				KeyManager: new(KeyManager),
 			})
 			require.NoError(t, err)
 
@@ -324,6 +327,7 @@ type mockGitHostingService struct {
 	*sshutils.Reply
 	receivedExec sshutils.ExecReq
 	exitCode     int
+	hostKey      ssh.PublicKey
 }
 
 func newMockGitHostingService(t *testing.T, caSigner ssh.Signer) *mockGitHostingService {
@@ -331,7 +335,8 @@ func newMockGitHostingService(t *testing.T, caSigner ssh.Signer) *mockGitHosting
 	hostCert, err := apisshutils.MakeRealHostCert(caSigner)
 	require.NoError(t, err)
 	m := &mockGitHostingService{
-		Reply: &sshutils.Reply{},
+		Reply:   &sshutils.Reply{},
+		hostKey: hostCert.PublicKey(),
 	}
 	server, err := sshutils.NewServer(
 		"git.test",
@@ -387,12 +392,21 @@ func (m *mockGitHostingService) HandleNewChan(ctx context.Context, ccx *sshutils
 
 type mockAuthClient struct {
 	authclient.ClientI
+	events types.Events
+}
+
+func (m mockAuthClient) NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error) {
+	if m.events == nil {
+		return nil, trace.AccessDenied("unauthorized")
+	}
+	return m.events.NewWatcher(ctx, watch)
 }
 
 type mockAccessPoint struct {
 	srv.AccessPoint
 	ca               ssh.Signer
 	allowedGitHubOrg string
+	services.GitServers
 }
 
 func (m mockAccessPoint) GetClusterName(...services.MarshalOption) (types.ClusterName, error) {
@@ -436,4 +450,7 @@ func (m mockAccessPoint) GetCertAuthorities(_ context.Context, caType types.Cert
 		return nil, trace.Wrap(err)
 	}
 	return []types.CertAuthority{ca}, nil
+}
+func (m mockAccessPoint) GitServerReadOnlyClient() gitserver.ReadOnlyClient {
+	return m.GitServers
 }

--- a/lib/srv/git/key_manager.go
+++ b/lib/srv/git/key_manager.go
@@ -1,0 +1,159 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package git
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/client/gitserver"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+// AccessPoint defines a subset of functions needed by git services.
+type AccessPoint interface {
+	services.AuthPreferenceGetter
+	GitServerReadOnlyClient() gitserver.ReadOnlyClient
+}
+
+// KeyManagerConfig is the config used for KeyManager.
+type KeyManagerConfig struct {
+	// ParentContext is the parent's context. All background tasks started by
+	// KeyManager will be stopped when ParentContext is closed.
+	ParentContext context.Context
+	// AuthClient is a client connected to the Auth server of this local cluster.
+	AuthClient authclient.ClientI
+	// AccessPoint is a caching client that provides access to this local cluster.
+	AccessPoint AccessPoint
+	// Logger is the slog.Logger
+	Logger *slog.Logger
+
+	githubServerKeys *githubKeyDownloader
+}
+
+// CheckAndSetDefaults checks and sets default values for any missing fields.
+func (c *KeyManagerConfig) CheckAndSetDefaults() error {
+	if c.ParentContext == nil {
+		return trace.BadParameter("missing parameter ParentContext")
+	}
+	if c.AuthClient == nil {
+		return trace.BadParameter("missing parameter AuthClient")
+	}
+	if c.AccessPoint == nil {
+		return trace.BadParameter("missing parameter AccessPoint")
+	}
+	if c.Logger == nil {
+		c.Logger = slog.With(teleport.ComponentKey, teleport.ComponentGit)
+	}
+	if c.githubServerKeys == nil {
+		c.githubServerKeys = newGitHubKeyDownloader()
+	}
+	return nil
+}
+
+// KeyManager manages and caches remote server keys.
+type KeyManager struct {
+	cfg *KeyManagerConfig
+}
+
+// NewKeyManager creates a service that manages and caches remote server keys.
+// TODO(greedy52) move user cert generation here with caching.
+func NewKeyManager(cfg *KeyManagerConfig) (*KeyManager, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	m := &KeyManager{
+		cfg: cfg,
+	}
+
+	if err := m.startWatcher(cfg.ParentContext); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return m, nil
+}
+
+func (m *KeyManager) startWatcher(ctx context.Context) error {
+	watcher, err := services.NewGitServerWatcher(ctx, services.GitServerWatcherConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Component: teleport.ComponentGit,
+			Logger:    m.cfg.Logger,
+			Client:    m.cfg.AuthClient,
+		},
+		GitServerGetter:       m.cfg.AccessPoint.GitServerReadOnlyClient(),
+		EnableUpdateBroadcast: true,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Start background downloads only when git_servers are found.
+	// TODO(greedy52) use a reconciler and start downloader by type.
+	go func() {
+		defer m.cfg.Logger.DebugContext(ctx, "Git server resource watcher done.")
+		defer watcher.Close()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case resources := <-watcher.ResourcesC:
+				m.cfg.Logger.DebugContext(ctx, "Received git server resources from watcher", "len", len(resources))
+				if len(resources) > 0 {
+					go m.cfg.githubServerKeys.Start(ctx)
+					return
+				}
+			}
+		}
+	}()
+	return nil
+}
+
+// HostKeyCallback creates an ssh.HostKeyCallback for verifying the target git-hosting service.
+func (m *KeyManager) HostKeyCallback(targetServer types.Server) (ssh.HostKeyCallback, error) {
+	switch targetServer.GetSubKind() {
+	case types.SubKindGitHub:
+		return m.verifyGitHub, nil
+	default:
+		return nil, trace.BadParameter("unsupported subkind %q", targetServer.GetSubKind())
+	}
+}
+
+func (m *KeyManager) verifyGitHub(_ string, _ net.Addr, key ssh.PublicKey) error {
+	knownKeys, err := m.cfg.githubServerKeys.GetKnownKeys()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	marshaledKey := key.Marshal()
+	for _, knownKey := range knownKeys {
+		if knownKey.Type() == key.Type() {
+			if bytes.Equal(knownKey.Marshal(), marshaledKey) {
+				return nil
+			}
+		}
+	}
+	return trace.BadParameter("cannot verify github.com")
+}

--- a/lib/srv/git/key_manager_test.go
+++ b/lib/srv/git/key_manager_test.go
@@ -1,0 +1,117 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package git
+
+import (
+	"context"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+
+	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/services/local"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+func TestKeyManager_verify_github(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	bk, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	caSigner, err := apisshutils.MakeTestSSHCA()
+	require.NoError(t, err)
+	gitService, err := local.NewGitServerService(bk)
+	require.NoError(t, err)
+	githubServer := makeGitServer(t, "org")
+	_, err = gitService.CreateGitServer(ctx, githubServer)
+	require.NoError(t, err)
+
+	// Prep mock servers and point things to them.
+	// If TELEPORT_GIT_TEST_REAL_GITHUB=true, use local SSH agent to connect
+	// against "github.com:22".
+	var clientAuth []ssh.AuthMethod
+	var targetAddress string
+	githubServerKeys := newGitHubKeyDownloader()
+	switch os.Getenv("TELEPORT_GIT_TEST_REAL_GITHUB") {
+	case "true", "1":
+		targetAddress = "github.com:22"
+		t.Log("Verifying against real", targetAddress)
+
+		sock, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK"))
+		require.NoError(t, err)
+		defer sock.Close()
+		agentClient := agent.NewClient(sock)
+		clientAuth = append(clientAuth, ssh.PublicKeysCallback(agentClient.Signers))
+	default:
+		mockGitHubSSHServer := newMockGitHostingService(t, caSigner)
+		targetAddress = mockGitHubSSHServer.Addr()
+		githubServerKeys.apiEndpoint = newMockGitHubMetaAPIServer(t, mockGitHubSSHServer.hostKey).URL
+	}
+
+	m, err := NewKeyManager(&KeyManagerConfig{
+		ParentContext: ctx,
+		AuthClient: mockAuthClient{
+			events: local.NewEventsService(bk),
+		},
+		AccessPoint: &mockAccessPoint{
+			GitServers: gitService,
+		},
+		githubServerKeys: githubServerKeys,
+	})
+	require.NoError(t, err)
+
+	t.Run("connect and verify", func(t *testing.T) {
+		hostKeyCallback, err := m.HostKeyCallback(githubServer)
+		require.NoError(t, err)
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			conn, err := ssh.Dial("tcp", targetAddress, &ssh.ClientConfig{
+				User:            "git",
+				Auth:            clientAuth,
+				HostKeyCallback: hostKeyCallback,
+			})
+			assert.NoError(collect, err)
+			if conn != nil {
+				conn.Close()
+			}
+		}, time.Second*5, time.Millisecond*200, "failed to connect and verify GitHub")
+	})
+
+	t.Run("unknown key", func(t *testing.T) {
+		hostKeyCallback, err := m.HostKeyCallback(githubServer)
+		require.NoError(t, err)
+		unknownHostKey, err := apisshutils.MakeRealHostCert(caSigner)
+		require.NoError(t, err)
+		require.Error(t, hostKeyCallback("github.com", utils.MustParseAddr(targetAddress), unknownHostKey.PublicKey()))
+	})
+
+	t.Run("unknown Git server type", func(t *testing.T) {
+		unsupported := githubServer.DeepCopy()
+		unsupported.SetSubKind("unsupported")
+		_, err := m.HostKeyCallback(unsupported)
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
backport of  #50891 to branch/v17

changelog: GitHub proxy now fetches server keys from the GitHub API for SSH host key verification