### PR TITLE
feat: Support multiple active CAs in `tctl auth export`

### DIFF
--- a/lib/client/ca_export.go
+++ b/lib/client/ca_export.go
@@ -165,15 +165,6 @@ func ExportAuthorities(ctx context.Context, client authclient.ClientI, req Expor
 	return exportAuthorities(ctx, client, req, ExportAllAuthorities)
 }
 
-// ExportAuthoritiesSecrets is the single-authority variant of
-// [ExportAllAuthoritiesSecrets].
-// Soft-deprecated, prefer using [ExportAllAuthoritiesSecrets] and handling
-// exports with more than one authority gracefully.
-func ExportAuthoritiesSecrets(ctx context.Context, client authclient.ClientI, req ExportAuthoritiesRequest) (string, error) {
-	// TODO(codingllama): Remove ExportAuthoritiesSecrets.
-	return exportAuthorities(ctx, client, req, ExportAllAuthoritiesSecrets)
-}
-
 func exportAuthorities(
 	ctx context.Context,
 	client authclient.ClientI,

--- a/lib/client/ca_export_test.go
+++ b/lib/client/ca_export_test.go
@@ -353,9 +353,6 @@ func TestExportAuthorities(t *testing.T) {
 			t.Run(fmt.Sprintf("%s/ExportAllAuthoritiesSecrets", tt.name), func(t *testing.T) {
 				runTest(t, ExportAllAuthoritiesSecrets, tt.assertSecrets)
 			})
-			t.Run(fmt.Sprintf("%s/ExportAuthoritiesSecrets", tt.name), func(t *testing.T) {
-				runUnaryTest(t, ExportAuthoritiesSecrets, tt.assertSecrets)
-			})
 		})
 	}
 }

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -124,7 +124,7 @@ func (a *AuthCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 		fmt.Sprintf("export certificate type (%v)", strings.Join(allowedCertificateTypes, ", "))).
 		EnumVar(&a.authType, allowedCertificateTypes...)
 	a.authExport.Flag("integration", "Name of the integration. Only applies to \"github\" CAs.").StringVar(&a.integration)
-	a.authExport.Flag("out-prefix", "If set writes exported authorities to files with the given prefix").
+	a.authExport.Flag("out-prefix", "If set writes exported authorities to files with the given path prefix").
 		StringVar(&a.exportOutputPrefix)
 
 	a.authGenerate = auth.Command("gen", "Generate a new SSH keypair.").Hidden()

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -265,12 +265,13 @@ func (a *AuthCommand) ExportAuthorities(ctx context.Context, clt authCommandClie
 			perms = 0600
 		}
 
+		fmt.Fprintf(os.Stderr, "Writing %d files with prefix %q\n", len(authorities), a.output)
 		for i, authority := range authorities {
 			name := fmt.Sprintf("%s%d.cer", a.output, i)
 			if err := os.WriteFile(name, authority.Data, perms); err != nil {
 				return trace.Wrap(err)
 			}
-			fmt.Printf("Wrote %s\n", name)
+			fmt.Println(name)
 		}
 		return nil
 	}


### PR DESCRIPTION
Add multiple active CAs support to `tctl auth export` via the --out flag.

* If a single active CA exists the behavior is the same as before
* If multiple active CAs exist the error message is changed to refer to the --out flag
* Any number of active CAs may be exported using --out without error

tctl before this PR:

```shell
$ tctl auth export --type=tls-user
ERROR: expected one TLS key pair, got 2
```

tctl after this PR:

```shell
$ tctl auth export --type=tls-user
ERROR: found 2 authorities to export, use --out to export all

$ tctl auth export --type=tls-user --out=ca
(stderr) Writing 2 files with prefix "ca"
(stdout) ca0.cer
(stdout) ca1.cer

$ cat ca?.cer
-----BEGIN CERTIFICATE-----
MIIDbTCCAlWgAwIBAgIRAIhXW7vBMC0zFynLPShxFH0wDQYJKoZIhvcNAQELBQAw
(...)
-----END CERTIFICATE-----
-----BEGIN CERTIFICATE-----
MIIDbDCCAlSgAwIBAgIQem9J7psCMl6QSKbClOdbtTANBgkqhkiG9w0BAQsFADBQ
(...)
-----END CERTIFICATE-----
```

Follow up from #51189.

#35444

Changelog: Added support for multiple active CAs in `tctl auth export`