### PR TITLE
GitHub proxy: git to prompt for password when tsh session expires

### DIFF
--- a/api/utils/prompt/stdin.go
+++ b/api/utils/prompt/stdin.go
@@ -89,21 +89,23 @@ func maybeUseStdinTerminalFallbackLocked(original *ContextReader) *ContextReader
 		return original
 	}
 
+	ctx := context.Background()
+
 	// File /dev/tty is the controlling tty of the current terminal. Not
 	// available on Windows.
 	// https://tldp.org/HOWTO/Text-Terminal-HOWTO-7.html
 	devTTY, err := os.Open("/dev/tty")
 	if err != nil {
-		slog.DebugContext(context.Background(), "Failed to open /dev/tty", "error", err)
+		slog.DebugContext(ctx, "Failed to open /dev/tty", "error", err)
 		return original
 	}
 
 	fallback := NewContextReader(devTTY)
 	if !fallback.IsTerminal() {
-		slog.DebugContext(context.Background(), "/dev/tty is not a terminal")
+		slog.DebugContext(ctx, "/dev/tty is not a terminal")
 		return original
 	}
 
-	slog.DebugContext(context.Background(), "Using /dev/tty for prompt")
+	slog.DebugContext(ctx, "Using /dev/tty for prompt")
 	return fallback
 }

--- a/api/utils/prompt/stdin.go
+++ b/api/utils/prompt/stdin.go
@@ -91,7 +91,7 @@ func maybeUseStdinTerminalFallbackLocked(original *ContextReader) *ContextReader
 
 	// File /dev/tty is the controlling tty of the current terminal. Not
 	// available on Windows.
-	// https://man7.org/linux/man-pages/man4/tty.4.html
+	// https://tldp.org/HOWTO/Text-Terminal-HOWTO-7.html
 	devTTY, err := os.Open("/dev/tty")
 	if err != nil {
 		slog.DebugContext(context.Background(), "Failed to open /dev/tty", "error", err)

--- a/tool/tsh/common/git_ssh.go
+++ b/tool/tsh/common/git_ssh.go
@@ -27,7 +27,9 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/prompt"
 	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 // gitSSHCommand implements `tsh git ssh`.
@@ -55,15 +57,24 @@ func newGitSSHCommand(parent *kingpin.CmdClause) *gitSSHCommand {
 	return cmd
 }
 
-func (c *gitSSHCommand) run(cf *CLIConf) error {
+func (c *gitSSHCommand) run(cf *CLIConf) (err error) {
 	_, host, ok := strings.Cut(c.userHost, "@")
 	if !ok || host != "github.com" {
 		return trace.BadParameter("user-host %q is not GitHub", c.userHost)
 	}
 
-	// TODO(greedy52) when git calls tsh, tsh cannot prompt for password (e.g.
-	// user session expired) using provided stdin pipe. `tc.Login` should try
-	// hijacking "/dev/tty" and replace `prompt.Stdin` temporarily.
+	// This command is invoked by "git" and it can be invoked when the user
+	// session is expired. Stdin piped by "git" is likely not the terminal so
+	// try some hacks to do the prompt. In cases the prompt is still not
+	// available (e.g. Windows, GUI tools, etc.), print a user-friendly message
+	// instead of "ssh: cert has expired".
+	prompt.EnableStdinTerminalFallback()
+	defer func() {
+		if utils.IsCertExpiredError(err) {
+			err = trace.AccessDenied("Your Teleport session has expired. Please login using 'tsh login'.")
+		}
+	}()
+
 	identity, err := getGitHubIdentity(cf, c.gitHubOrg)
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
changelog: Git proxy commands executed in terminals now support interactive login prompts when the `tsh` session expires

related:
- #48762 

End up adding a flag to do this in the prompt lib. Open to ideas on how to do this better. Did not add a unit test since it's difficult to mock. 

Sample log before the change:
```
2025-01-21T14:35:49.858-05:00 DEBU [CLIENT]    Relogin is not available in this environment error:[
ERROR REPORT:
Original Error: *errors.errorString underlying reader is not a terminal
Stack Trace:
	github.com/gravitational/teleport/lib/client/api.go:4873 github.com/gravitational/teleport/lib/client.(*TeleportClient).AskPassword
	github.com/gravitational/teleport/lib/client/api.go:4111 github.com/gravitational/teleport/lib/client.(*TeleportClient).localLogin
	github.com/gravitational/teleport/lib/client/api.go:3717 github.com/gravitational/teleport/lib/client.(*TeleportClient).getSSHLoginFunc.func2
	github.com/gravitational/teleport/lib/client/api.go:3909 github.com/gravitational/teleport/lib/client.(*TeleportClient).SSHLogin.func1
	github.com/gravitational/teleport/lib/client/api.go:3962 github.com/gravitational/teleport/lib/client.(*TeleportClient).loginWithHardwareKeyRetry
	github.com/gravitational/teleport/lib/client/api.go:3907 github.com/gravitational/teleport/lib/client.(*TeleportClient).SSHLogin
	github.com/gravitational/teleport/lib/client/api.go:3497 github.com/gravitational/teleport/lib/client.(*TeleportClient).Login
	github.com/gravitational/teleport/lib/client/api.go:675 github.com/gravitational/teleport/lib/client.RetryWithRelogin
	github.com/gravitational/teleport/tool/tsh/common/git_ssh.go:83 github.com/gravitational/teleport/tool/tsh/common.(*gitSSHCommand).run
	github.com/gravitational/teleport/tool/tsh/common/tsh.go:1656 github.com/gravitational/teleport/tool/tsh/common.Run
	github.com/gravitational/teleport/tool/tsh/common/tsh.go:644 github.com/gravitational/teleport/tool/tsh/common.Main
	github.com/gravitational/teleport/tool/tsh/main.go:26 main.main
	runtime/proc.go:272 runtime.main
	runtime/asm_arm64.s:1223 runtime.goexit
User Message: cannot perform password login without a terminal
	underlying reader is not a terminal] trace_id:a7b8b7690ed59e49842906951f2d57a3 span_id:96231e274f9c4507 client/api.go:678
```

After this change (tested on mac and amazon linux)
```
$ git fetch
Enter password for Teleport user admin:
Available MFA methods [WEBAUTHN, OTP]. Continuing with WEBAUTHN.
If you wish to perform MFA with another method, specify with flag --mfa-mode=<sso,otp>.

Tap any security key
Detected security key tap
```