### PR TITLE
docs: redirect for role templates page

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -278,6 +278,11 @@
       "source": "/reference/operator-resources/resources.teleport.dev_users/",
       "destination": "/reference/operator-resources/resources-teleport-dev-users/",
       "permanent": true
+    },
+    {
+      "source": "/access-controls/guides/role-templates/",
+      "destination": "/admin-guides/access-controls/guides/role-templates/",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
Per feedback, we have a 404 result from a link in the platform. Updated page is https://goteleport.com/docs/admin-guides/access-controls/guides/role-templates/


