### PR TITLE
fix tctl terraform env integration test

### DIFF
--- a/integration/tctl_terraform_env_test.go
+++ b/integration/tctl_terraform_env_test.go
@@ -52,6 +52,7 @@ import (
 // TestTCTLTerraformCommand_ProxyJoin validates that the command `tctl terraform env` can run against a Teleport Proxy
 // service and generates valid credentials Terraform can use to connect to Teleport.
 func TestTCTLTerraformCommand_ProxyJoin(t *testing.T) {
+	// test is not Parallel because of the metrics black hole
 	testDir := t.TempDir()
 	prometheus.DefaultRegisterer = metricRegistryBlackHole{}
 
@@ -127,7 +128,7 @@ func TestTCTLTerraformCommand_ProxyJoin(t *testing.T) {
 // TestTCTLTerraformCommand_AuthJoin validates that the command `tctl terraform env` can run against a Teleport Auth
 // service and generates valid credentials Terraform can use to connect to Teleport.
 func TestTCTLTerraformCommand_AuthJoin(t *testing.T) {
-	t.Parallel()
+	// test is not Parallel because of the metrics black hole
 	testDir := t.TempDir()
 	prometheus.DefaultRegisterer = metricRegistryBlackHole{}
 


### PR DESCRIPTION
As observed in https://github.com/gravitational/teleport/pull/51206#discussion_r1920911934 the `tctl terraform env` integration tests are not `t.Parallel()`-safe because of the metrics black hole.