### PR TITLE
Add isValid field to standard model validationResult

### DIFF
--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/validation.test.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/validation.test.ts
@@ -47,6 +47,7 @@ describe('validateRoleEditorModel', () => {
     expect(result.metadata.valid).toBe(true);
     expect(result.resources).toEqual([]);
     expect(result.rules).toEqual([]);
+    expect(result.isValid).toBe(true);
   });
 
   test('valid complex model', () => {
@@ -103,6 +104,7 @@ describe('validateRoleEditorModel', () => {
     expect(result.metadata.valid).toBe(true);
     expect(validity(result.resources)).toEqual([true, true, true, true, true]);
     expect(validity(result.rules)).toEqual([true]);
+    expect(result.isValid).toBe(true);
   });
 
   test('invalid metadata', () => {
@@ -110,6 +112,7 @@ describe('validateRoleEditorModel', () => {
     model.metadata.name = '';
     const result = validateRoleEditorModel(model, undefined, undefined);
     expect(result.metadata.valid).toBe(false);
+    expect(result.isValid).toBe(false);
   });
 
   test('invalid resource', () => {
@@ -123,6 +126,7 @@ describe('validateRoleEditorModel', () => {
     ];
     const result = validateRoleEditorModel(model, undefined, undefined);
     expect(validity(result.resources)).toEqual([false]);
+    expect(result.isValid).toBe(false);
   });
 
   test('invalid access rule', () => {
@@ -136,6 +140,7 @@ describe('validateRoleEditorModel', () => {
     ];
     const result = validateRoleEditorModel(model, undefined, undefined);
     expect(validity(result.rules)).toEqual([false]);
+    expect(result.isValid).toBe(false);
   });
 
   it('reuses previously computed section results', () => {
@@ -145,6 +150,7 @@ describe('validateRoleEditorModel', () => {
     expect(result2.metadata).toBe(result1.metadata);
     expect(result2.resources).toBe(result1.resources);
     expect(result2.rules).toBe(result1.rules);
+    expect(result2.isValid).toBe(result1.isValid);
   });
 });
 

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/validation.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/validation.ts
@@ -49,6 +49,10 @@ export type RoleEditorModelValidationResult = {
   metadata: MetadataValidationResult;
   resources: ResourceAccessValidationResult[];
   rules: AccessRuleValidationResult[];
+  /**
+   * isValid is true if all the fields in the validation result are valid.
+   */
+  isValid: boolean;
 };
 
 /**
@@ -72,22 +76,32 @@ export function validateRoleEditorModel(
   previousModel: RoleEditorModel | undefined,
   previousResult: RoleEditorModelValidationResult | undefined
 ): RoleEditorModelValidationResult {
+  const metadataResult = validateMetadata(
+    model.metadata,
+    previousModel?.metadata,
+    previousResult?.metadata
+  );
+
+  const resourcesResult = validateResourceAccessList(
+    model.resources,
+    previousModel?.resources,
+    previousResult?.resources
+  );
+
+  const rulesResult = validateAccessRuleList(
+    model.rules,
+    previousModel?.rules,
+    previousResult?.rules
+  );
+
   return {
-    metadata: validateMetadata(
-      model.metadata,
-      previousModel?.metadata,
-      previousResult?.metadata
-    ),
-    resources: validateResourceAccessList(
-      model.resources,
-      previousModel?.resources,
-      previousResult?.resources
-    ),
-    rules: validateAccessRuleList(
-      model.rules,
-      previousModel?.rules,
-      previousResult?.rules
-    ),
+    isValid:
+      metadataResult.valid &&
+      resourcesResult.every(r => r.valid) &&
+      rulesResult.every(r => r.valid),
+    metadata: metadataResult,
+    resources: resourcesResult,
+    rules: rulesResult,
   };
 }
 


### PR DESCRIPTION
This doesn't change much except aggregates the validation results into a neat field, to help us easier access this value when we update the standard model in the StandardEditor. 

This supports an upcoming PR to fetch diffs from access graph based on when the editor is in a "valid" state (not the UI validation, but before that happens)