### PR TITLE
[v16] Fix TF role preset rule addition logic

### DIFF
--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -591,34 +591,31 @@ func NewPresetTerraformProviderRole() types.Role {
 				NodeLabels:     map[string]apiutils.Strings{types.Wildcard: []string{types.Wildcard}},
 				// Every resource currently supported by the Terraform provider.
 				Rules: []types.Rule{
-					{
-						Resources: []string{
-							types.KindAccessList,
-							types.KindApp,
-							types.KindClusterAuthPreference,
-							types.KindClusterMaintenanceConfig,
-							types.KindClusterNetworkingConfig,
-							types.KindDatabase,
-							types.KindDevice,
-							types.KindGithub,
-							types.KindLoginRule,
-							types.KindNode,
-							types.KindOIDC,
-							types.KindOktaImportRule,
-							types.KindRole,
-							types.KindSAML,
-							types.KindSessionRecordingConfig,
-							types.KindToken,
-							types.KindTrustedCluster,
-							types.KindUser,
-							types.KindBot,
-							types.KindInstaller,
-							types.KindAccessMonitoringRule,
-							types.KindStaticHostUser,
-							types.KindWorkloadIdentity,
-						},
-						Verbs: RW(),
-					},
+					// You must add new resources as separate rules for the
+					// default rule addition logic to work properly.
+					types.NewRule(types.KindAccessList, RW()),
+					types.NewRule(types.KindApp, RW()),
+					types.NewRule(types.KindClusterAuthPreference, RW()),
+					types.NewRule(types.KindClusterMaintenanceConfig, RW()),
+					types.NewRule(types.KindClusterNetworkingConfig, RW()),
+					types.NewRule(types.KindDatabase, RW()),
+					types.NewRule(types.KindDevice, RW()),
+					types.NewRule(types.KindGithub, RW()),
+					types.NewRule(types.KindLoginRule, RW()),
+					types.NewRule(types.KindNode, RW()),
+					types.NewRule(types.KindOIDC, RW()),
+					types.NewRule(types.KindOktaImportRule, RW()),
+					types.NewRule(types.KindRole, RW()),
+					types.NewRule(types.KindSAML, RW()),
+					types.NewRule(types.KindSessionRecordingConfig, RW()),
+					types.NewRule(types.KindToken, RW()),
+					types.NewRule(types.KindTrustedCluster, RW()),
+					types.NewRule(types.KindUser, RW()),
+					types.NewRule(types.KindBot, RW()),
+					types.NewRule(types.KindInstaller, RW()),
+					types.NewRule(types.KindAccessMonitoringRule, RW()),
+					types.NewRule(types.KindStaticHostUser, RW()),
+					types.NewRule(types.KindWorkloadIdentity, RW()),
 				},
 			},
 		},
@@ -649,9 +646,10 @@ func bootstrapRoleMetadataLabels() map[string]map[string]string {
 }
 
 var defaultAllowRulesMap = map[string][]types.Rule{
-	teleport.PresetAuditorRoleName: NewPresetAuditorRole().GetRules(types.Allow),
-	teleport.PresetEditorRoleName:  NewPresetEditorRole().GetRules(types.Allow),
-	teleport.PresetAccessRoleName:  NewPresetAccessRole().GetRules(types.Allow),
+	teleport.PresetAuditorRoleName:           NewPresetAuditorRole().GetRules(types.Allow),
+	teleport.PresetEditorRoleName:            NewPresetEditorRole().GetRules(types.Allow),
+	teleport.PresetAccessRoleName:            NewPresetAccessRole().GetRules(types.Allow),
+	teleport.PresetTerraformProviderRoleName: NewPresetTerraformProviderRole().GetRules(types.Allow),
 }
 
 // defaultAllowRules has the Allow rules that should be set as default when


### PR DESCRIPTION
Manual backport of #51296 to `branch/v17` because `types.WindowsDynamicDesktop` was not added to v16 Terraform.

changelog: FIxes a bug causing the `terraform-provider` preset role to not automatically allow newly supported resources.
