### PR TITLE
[v15] ci: Enable auto-merge on post-release workflow PRs

### DIFF
--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -122,4 +122,6 @@ jobs:
           gh pr create --fill "--base=${BASE_BRANCH}" \
              --label=automated --label=documentation --label=no-changelog \
              "--reviewer=${REVIEWER}"
-           echo "Docs PR: $(gh pr view --json url --jq .url)" >> "$GITHUB_STEP_SUMMARY"
+          # enable auto-merge
+          gh pr merge --auto --squash
+          echo "Docs PR: $(gh pr view --json url --jq .url)" >> "$GITHUB_STEP_SUMMARY"

--- a/assets/aws/Makefile
+++ b/assets/aws/Makefile
@@ -51,3 +51,5 @@ create-update-pr: update-ami-ids-terraform
 	git commit -am "[auto] Update AMI IDs for $(TELEPORT_VERSION)"
 	git push --set-upstream origin $(AUTO_BRANCH_NAME)
 	gh pr create --fill --label=automated --label=terraform --label=no-changelog $(if $(AMI_PR_REVIEWER),--reviewer=$(AMI_PR_REVIEWER))
+	# enable auto-merge
+	gh pr merge --auto --squash


### PR DESCRIPTION
Enable auto-merge on the PRs created by the post-release workflow.
Getting these PRs merged manually can often be forgotten that it is
standard to enable auto-merge on them. Let's do that automatically.

Backport: https://github.com/gravitational/teleport/pull/51011
