### PR TITLE
Server Auto Discovery: allow pre-releases

### DIFF
--- a/lib/srv/server/installer/autodiscover.go
+++ b/lib/srv/server/installer/autodiscover.go
@@ -33,6 +33,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/google/safetext/shsprintf"
 	"github.com/gravitational/trace"
 
@@ -88,9 +89,14 @@ type AutoDiscoverNodeInstallerConfig struct {
 	// TokenName is the token name to be used by the instance to join the cluster.
 	TokenName string
 
-	// aptPublicKeyEndpoint contains the URL for the APT public key.
-	// Defaults to: https://apt.releases.teleport.dev/gpg
-	aptPublicKeyEndpoint string
+	// defaultVersion is the version used to compute whether the production or development repositories should be used.
+	// If auto upgrades are enabled, then the defaultVersion is ignored.
+	// Defaults to api.SemVersion.
+	defaultVersion *semver.Version
+
+	// aptRepoKeyEndpointOverride contains the URL for the APT public key.
+	// Used for testing.
+	aptRepoKeyEndpointOverride string
 
 	// fsRootPrefix is the prefix to use when reading operating system information and when installing teleport.
 	// Used for testing.
@@ -108,6 +114,10 @@ type AutoDiscoverNodeInstallerConfig struct {
 func (c *AutoDiscoverNodeInstallerConfig) checkAndSetDefaults() error {
 	if c == nil {
 		return trace.BadParameter("install teleport config is required")
+	}
+
+	if c.defaultVersion == nil {
+		c.defaultVersion = api.SemVersion
 	}
 
 	if c.fsRootPrefix == "" {
@@ -407,7 +417,7 @@ func (ani *AutoDiscoverNodeInstaller) installTeleportFromRepo(ctx context.Contex
 		"version_id", linuxInfo.VersionID,
 	)
 
-	packageManager, err := packagemanager.PackageManagerForSystem(linuxInfo, ani.fsRootPrefix, ani.binariesLocation, ani.aptPublicKeyEndpoint)
+	packageManager, err := packagemanager.PackageManagerForSystem(linuxInfo, ani.fsRootPrefix, ani.binariesLocation, ani.aptRepoKeyEndpointOverride)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -429,7 +439,8 @@ func (ani *AutoDiscoverNodeInstaller) installTeleportFromRepo(ctx context.Contex
 	}
 	packagesToInstall = append(packagesToInstall, packagemanager.PackageVersion{Name: ani.TeleportPackage, Version: targetVersion})
 
-	if err := packageManager.AddTeleportRepository(ctx, linuxInfo, ani.RepositoryChannel); err != nil {
+	productionRepo := useProductionRepo(packagesToInstall, ani.defaultVersion)
+	if err := packageManager.AddTeleportRepository(ctx, linuxInfo, ani.RepositoryChannel, productionRepo); err != nil {
 		return trace.BadParameter("failed to add teleport repository to system: %v", err)
 	}
 	if err := packageManager.InstallPackages(ctx, packagesToInstall); err != nil {
@@ -437,6 +448,25 @@ func (ani *AutoDiscoverNodeInstaller) installTeleportFromRepo(ctx context.Contex
 	}
 
 	return nil
+}
+
+// useProductionRepo returns whether this is a production installation.
+// In case of an error, it returns true to default to ensure only production binaries are available.
+func useProductionRepo(packagesToInstall []packagemanager.PackageVersion, defaultVersion *semver.Version) bool {
+	for _, p := range packagesToInstall {
+		if p.Version == "" {
+			continue
+		}
+
+		ver, err := semver.NewVersion(p.Version)
+		if err != nil {
+			return true
+		}
+
+		return ver.PreRelease == ""
+	}
+
+	return defaultVersion.PreRelease == ""
 }
 
 func (ani *AutoDiscoverNodeInstaller) getIMDSClient(ctx context.Context) (imds.Client, error) {

--- a/lib/utils/packagemanager/distro_info.go
+++ b/lib/utils/packagemanager/distro_info.go
@@ -26,7 +26,7 @@ import (
 )
 
 // PackageManagerForSystem returns the PackageManager for the current detected linux distro.
-func PackageManagerForSystem(osRelease *linux.OSRelease, fsRootPrefix string, binariesLocation BinariesLocation, aptPubKeyEndpoint string) (PackageManager, error) {
+func PackageManagerForSystem(osRelease *linux.OSRelease, fsRootPrefix string, binariesLocation BinariesLocation, aptRepoEndpointOverride string) (PackageManager, error) {
 	aptWellKnownIDs := []string{"debian", "ubuntu"}
 	legacyAPT := []string{"xenial", "trusty"}
 
@@ -38,9 +38,9 @@ func PackageManagerForSystem(osRelease *linux.OSRelease, fsRootPrefix string, bi
 	case slices.Contains(aptWellKnownIDs, osRelease.ID):
 		if slices.Contains(legacyAPT, osRelease.VersionCodename) {
 			pm, err := NewAPTLegacy(&APTConfig{
-				fsRootPrefix:         fsRootPrefix,
-				bins:                 binariesLocation,
-				aptPublicKeyEndpoint: aptPubKeyEndpoint,
+				fsRootPrefix:               fsRootPrefix,
+				bins:                       binariesLocation,
+				aptRepoKeyEndpointOverride: aptRepoEndpointOverride,
 			})
 			if err != nil {
 				return nil, trace.Wrap(err)
@@ -49,9 +49,9 @@ func PackageManagerForSystem(osRelease *linux.OSRelease, fsRootPrefix string, bi
 		}
 
 		pm, err := NewAPT(&APTConfig{
-			fsRootPrefix:         fsRootPrefix,
-			bins:                 binariesLocation,
-			aptPublicKeyEndpoint: aptPubKeyEndpoint,
+			fsRootPrefix:               fsRootPrefix,
+			bins:                       binariesLocation,
+			aptRepoKeyEndpointOverride: aptRepoEndpointOverride,
 		})
 		if err != nil {
 			return nil, trace.Wrap(err)
@@ -86,7 +86,7 @@ func PackageManagerForSystem(osRelease *linux.OSRelease, fsRootPrefix string, bi
 // PackageManager describes the required methods to implement a package manager.
 type PackageManager interface {
 	// AddTeleportRepository adds the Teleport repository using a specific channel.
-	AddTeleportRepository(ctx context.Context, ldi *linux.OSRelease, repoChannel string) error
+	AddTeleportRepository(ctx context.Context, ldi *linux.OSRelease, repoChannel string, productionRepo bool) error
 	// InstallPackages installs a list of packages.
 	// If a PackageVersion does not contain the version, then it will install the latest available.
 	InstallPackages(context.Context, []PackageVersion) error

--- a/lib/utils/packagemanager/package_metadata_test.go
+++ b/lib/utils/packagemanager/package_metadata_test.go
@@ -1,0 +1,103 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package packagemanager
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepositoryEndpoint(t *testing.T) {
+	for _, tt := range []struct {
+		name                    string
+		inputProd               bool
+		inputPackageManager     string
+		checkErr                require.ErrorAssertionFunc
+		expectedRepoEndpoint    string
+		expectedRepoKeyEndpoint string
+	}{
+		{
+			name:                    "development apt",
+			inputProd:               false,
+			inputPackageManager:     "apt",
+			checkErr:                require.NoError,
+			expectedRepoEndpoint:    "https://apt.releases.development.teleport.dev/",
+			expectedRepoKeyEndpoint: "https://apt.releases.development.teleport.dev/gpg",
+		},
+		{
+			name:                    "production apt",
+			inputProd:               true,
+			inputPackageManager:     "apt",
+			checkErr:                require.NoError,
+			expectedRepoEndpoint:    "https://apt.releases.teleport.dev/",
+			expectedRepoKeyEndpoint: "https://apt.releases.teleport.dev/gpg",
+		},
+		{
+			name:                    "development yum",
+			inputProd:               false,
+			inputPackageManager:     "yum",
+			checkErr:                require.NoError,
+			expectedRepoEndpoint:    "https://yum.releases.development.teleport.dev/",
+			expectedRepoKeyEndpoint: "https://yum.releases.development.teleport.dev/gpg",
+		},
+		{
+			name:                    "production yum",
+			inputProd:               true,
+			inputPackageManager:     "yum",
+			checkErr:                require.NoError,
+			expectedRepoEndpoint:    "https://yum.releases.teleport.dev/",
+			expectedRepoKeyEndpoint: "https://yum.releases.teleport.dev/gpg",
+		},
+		{
+			name:                    "development zypper",
+			inputProd:               false,
+			inputPackageManager:     "zypper",
+			checkErr:                require.NoError,
+			expectedRepoEndpoint:    "https://zypper.releases.development.teleport.dev/",
+			expectedRepoKeyEndpoint: "https://zypper.releases.development.teleport.dev/gpg",
+		},
+		{
+			name:                    "production zypper",
+			inputProd:               true,
+			inputPackageManager:     "zypper",
+			checkErr:                require.NoError,
+			expectedRepoEndpoint:    "https://zypper.releases.teleport.dev/",
+			expectedRepoKeyEndpoint: "https://zypper.releases.teleport.dev/gpg",
+		},
+		{
+			name:                    "unknown tool",
+			inputProd:               true,
+			inputPackageManager:     "pacman",
+			checkErr:                require.Error,
+			expectedRepoEndpoint:    "",
+			expectedRepoKeyEndpoint: "",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			gotEndpoint, gotKeyEndpoint, err := repositoryEndpoint(tt.inputProd, tt.inputPackageManager)
+			if tt.checkErr != nil {
+				tt.checkErr(t, err)
+			}
+
+			require.Equal(t, tt.expectedRepoEndpoint, gotEndpoint)
+			require.Equal(t, tt.expectedRepoKeyEndpoint, gotKeyEndpoint)
+		})
+	}
+}

--- a/lib/utils/packagemanager/yum.go
+++ b/lib/utils/packagemanager/yum.go
@@ -29,8 +29,6 @@ import (
 	"github.com/gravitational/teleport/lib/linux"
 )
 
-const yumRepoEndpoint = "https://yum.releases.teleport.dev/"
-
 var (
 	// yumDistroMap maps distro IDs that teleport doesn't officially support but are known to work.
 	// The key is the not-officially-supported distro ID and the value is the most similar distro.
@@ -81,7 +79,12 @@ func NewYUM(cfg *YUMConfig) (*YUM, error) {
 }
 
 // AddTeleportRepository adds the Teleport repository to the current system.
-func (pm *YUM) AddTeleportRepository(ctx context.Context, linuxInfo *linux.OSRelease, repoChannel string) error {
+func (pm *YUM) AddTeleportRepository(ctx context.Context, linuxInfo *linux.OSRelease, repoChannel string, productionRepo bool) error {
+	yumRepoEndpoint, _, err := repositoryEndpoint(productionRepo, yum)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	distroID := cmp.Or(yumDistroMap[linuxInfo.ID], linuxInfo.ID)
 
 	// Teleport repo only targets the major version of the target distros.


### PR DESCRIPTION
When using Server Auto Discover with pre-release versions of Teleport,
we were using the default repos anyway:
ie https://apt.releases.teleport.dev/

However, pre-release versions of teleport actually exist on
https://apt.releases.development.teleport.dev/

This PR to the development repository when:
- the target version is a pre-release
- when no target version was set, and the binary's current version is a
  pre-release

This was tested using the pre-release `teleport@v17.2.1-dev.marco-2`.

Given I was using cloud to test this, I had to change the installer to
- disabled automatic upgrades, because those would return a non-pre-release version
- replace `stable/cloud` with `stable/rolling`

ie `tctl edit installer/default-installer`
```yaml
kind: installer
metadata:
  name: default-installer
  revision: f5883947-cfb8-4d10-aaee-5dd867184492
spec:
  script: |
    #!/usr/bin/env sh
    set -eu

    cdnBaseURL='https://cdn.cloud.gravitational.io'
    teleportVersion='v17.2.1-dev.marco-2'
    teleportFlavor='teleport-ent' # teleport or teleport-ent
    successMessage='Teleport is installed and running.'
    teleportArgs='install autodiscover-node --public-proxy-addr={{.PublicProxyAddr}} --teleport-package={{.TeleportPackage}} --repo-channel=stable/rolling --auto-upgrade=false --azure-client-id={{.AzureClientID}}'

```