### PR TITLE
Upgrade vite to 6.0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "react-select-event": "^5.5.1",
     "storybook": "^8.4.7",
     "typescript": "^5.7.3",
-    "vite": "^6.0.6"
+    "vite": "^6.0.11"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.18.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,7 +118,7 @@ importers:
         version: 8.4.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7(prettier@3.4.2))(typescript@5.7.3)
       '@storybook/react-vite':
         specifier: ^8.4.7
-        version: 8.4.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.29.1)(storybook@8.4.7(prettier@3.4.2))(typescript@5.7.3)(vite@6.0.6(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1))
+        version: 8.4.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.29.1)(storybook@8.4.7(prettier@3.4.2))(typescript@5.7.3)(vite@6.0.11(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1))
       '@storybook/test-runner':
         specifier: ^0.21.0
         version: 0.21.0(@types/node@20.17.11)(babel-plugin-macros@3.1.0)(storybook@8.4.7(prettier@3.4.2))
@@ -192,8 +192,8 @@ importers:
         specifier: ^5.7.3
         version: 5.7.3
       vite:
-        specifier: ^6.0.6
-        version: 6.0.6(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1)
+        specifier: ^6.0.11
+        version: 6.0.11(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1)
 
   e/web/teleport: {}
 
@@ -228,7 +228,7 @@ importers:
         version: 21.1.7
       '@vitejs/plugin-react-swc':
         specifier: ^3.7.2
-        version: 3.7.2(vite@6.0.6(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1))
+        version: 3.7.2(vite@6.0.11(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1))
       babel-plugin-styled-components:
         specifier: ^2.1.4
         version: 2.1.4(@babel/core@7.26.0)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -270,10 +270,10 @@ importers:
         version: 8.19.0(eslint@9.17.0)(typescript@5.7.3)
       vite-plugin-wasm:
         specifier: ^3.4.1
-        version: 3.4.1(vite@6.0.6(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1))
+        version: 3.4.1(vite@6.0.11(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1))
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.7.3)(vite@6.0.6(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1))
+        version: 5.1.4(typescript@5.7.3)(vite@6.0.11(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1))
 
   web/packages/design:
     dependencies:
@@ -480,7 +480,7 @@ importers:
         version: 25.1.8(electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8))
       electron-vite:
         specifier: ^2.3.0
-        version: 2.3.0(@swc/core@1.10.4)(vite@6.0.6(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1))
+        version: 2.3.0(@swc/core@1.10.4)(vite@6.0.11(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1))
       events:
         specifier: 3.3.0
         version: 3.3.0
@@ -6695,8 +6695,8 @@ packages:
       vite:
         optional: true
 
-  vite@6.0.6:
-    resolution: {integrity: sha512-NSjmUuckPmDU18bHz7QZ+bTYhRR0iA72cs2QAxCqDpafJ0S6qetco0LB3WW2OxlMHS0JmAv+yZ/R3uPmMyGTjQ==}
+  vite@6.0.11:
+    resolution: {integrity: sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -8709,11 +8709,11 @@ snapshots:
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.4.2(typescript@5.7.3)(vite@6.0.6(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.4.2(typescript@5.7.3)(vite@6.0.11(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1))':
     dependencies:
       magic-string: 0.27.0
       react-docgen-typescript: 2.2.2(typescript@5.7.3)
-      vite: 6.0.6(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1)
+      vite: 6.0.11(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1)
     optionalDependencies:
       typescript: 5.7.3
 
@@ -9240,13 +9240,13 @@ snapshots:
     dependencies:
       storybook: 8.4.7(prettier@3.4.2)
 
-  '@storybook/builder-vite@8.4.7(storybook@8.4.7(prettier@3.4.2))(vite@6.0.6(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1))':
+  '@storybook/builder-vite@8.4.7(storybook@8.4.7(prettier@3.4.2))(vite@6.0.11(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1))':
     dependencies:
       '@storybook/csf-plugin': 8.4.7(storybook@8.4.7(prettier@3.4.2))
       browser-assert: 1.2.1
       storybook: 8.4.7(prettier@3.4.2)
       ts-dedent: 2.2.0
-      vite: 6.0.6(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1)
+      vite: 6.0.11(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1)
 
   '@storybook/components@8.4.7(storybook@8.4.7(prettier@3.4.2))':
     dependencies:
@@ -9297,11 +9297,11 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.4.7(prettier@3.4.2)
 
-  '@storybook/react-vite@8.4.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.29.1)(storybook@8.4.7(prettier@3.4.2))(typescript@5.7.3)(vite@6.0.6(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1))':
+  '@storybook/react-vite@8.4.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.29.1)(storybook@8.4.7(prettier@3.4.2))(typescript@5.7.3)(vite@6.0.11(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.4.2(typescript@5.7.3)(vite@6.0.6(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.4.2(typescript@5.7.3)(vite@6.0.11(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1))
       '@rollup/pluginutils': 5.1.3(rollup@4.29.1)
-      '@storybook/builder-vite': 8.4.7(storybook@8.4.7(prettier@3.4.2))(vite@6.0.6(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1))
+      '@storybook/builder-vite': 8.4.7(storybook@8.4.7(prettier@3.4.2))(vite@6.0.11(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1))
       '@storybook/react': 8.4.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7(prettier@3.4.2))(typescript@5.7.3)
       find-up: 5.0.0
       magic-string: 0.30.14
@@ -9311,7 +9311,7 @@ snapshots:
       resolve: 1.22.8
       storybook: 8.4.7(prettier@3.4.2)
       tsconfig-paths: 4.2.0
-      vite: 6.0.6(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1)
+      vite: 6.0.11(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1)
     transitivePeerDependencies:
       - '@storybook/test'
       - rollup
@@ -9850,10 +9850,10 @@ snapshots:
       - '@codemirror/lint'
       - '@codemirror/search'
 
-  '@vitejs/plugin-react-swc@3.7.2(vite@6.0.6(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1))':
+  '@vitejs/plugin-react-swc@3.7.2(vite@6.0.11(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1))':
     dependencies:
       '@swc/core': 1.10.4
-      vite: 6.0.6(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1)
+      vite: 6.0.11(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -11073,7 +11073,7 @@ snapshots:
 
   electron-to-chromium@1.5.67: {}
 
-  electron-vite@2.3.0(@swc/core@1.10.4)(vite@6.0.6(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1)):
+  electron-vite@2.3.0(@swc/core@1.10.4)(vite@6.0.11(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1)):
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-arrow-functions': 7.25.9(@babel/core@7.26.0)
@@ -11081,7 +11081,7 @@ snapshots:
       esbuild: 0.21.5
       magic-string: 0.30.14
       picocolors: 1.1.1
-      vite: 6.0.6(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1)
+      vite: 6.0.11(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1)
     optionalDependencies:
       '@swc/core': 1.10.4
     transitivePeerDependencies:
@@ -14409,22 +14409,22 @@ snapshots:
       extsprintf: 1.4.1
     optional: true
 
-  vite-plugin-wasm@3.4.1(vite@6.0.6(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1)):
+  vite-plugin-wasm@3.4.1(vite@6.0.11(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1)):
     dependencies:
-      vite: 6.0.6(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1)
+      vite: 6.0.11(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1)
 
-  vite-tsconfig-paths@5.1.4(typescript@5.7.3)(vite@6.0.6(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1)):
+  vite-tsconfig-paths@5.1.4(typescript@5.7.3)(vite@6.0.11(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1)):
     dependencies:
       debug: 4.3.7
       globrex: 0.1.2
       tsconfck: 3.1.0(typescript@5.7.3)
     optionalDependencies:
-      vite: 6.0.6(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1)
+      vite: 6.0.11(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@6.0.6(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1):
+  vite@6.0.11(@types/node@20.17.11)(terser@5.31.1)(yaml@2.6.1):
     dependencies:
       esbuild: 0.24.2
       postcss: 8.4.49

--- a/web/packages/build/vite/config.ts
+++ b/web/packages/build/vite/config.ts
@@ -54,9 +54,15 @@ export function createViteConfig(
       }
     }
 
+    const targetHostname =
+      target !== DEFAULT_PROXY_TARGET
+        ? new URL(`http://${target}`).hostname
+        : undefined;
+
     const config: UserConfig = {
       clearScreen: false,
       server: {
+        allowedHosts: targetHostname ? [`.${targetHostname}`] : [],
         fs: {
           allow: [rootDirectory, '.'],
         },


### PR DESCRIPTION
This will upgrade vite. I'm getting an "unmet dep" warning for electron-vite saying it expects a max of vite 5, however we are currently on the latest version of electron-vite so I don't think there is much we can do here. We have already been running vite 6+ for months now tho and electron-vite has been working fine so I think its ok to ignore for now.

@ryanclark , i didn't have any issues with `localhost` and my non-localhost domain that I typically run so I didn't need to update `allowedHosts`, can you confirm?

edit: confirmed we had a few users whos HMR didnt work without `allowedHosts` so Ive updated it