### PR TITLE
Add unique notification identifier resource and CRUD methods

### DIFF
--- a/api/gen/proto/go/teleport/notifications/v1/notifications.pb.go
+++ b/api/gen/proto/go/teleport/notifications/v1/notifications.pb.go
@@ -914,6 +914,139 @@ func (x *UserLastSeenNotificationStatus) GetLastSeenTime() *timestamppb.Timestam
 	return nil
 }
 
+// UniqueNotificationIdentifier represents a unique notification identifier.
+// This is a resource whose existence is used to keep track of whether a particular notification has already been created, in order to prevent duplicate notifications.
+// For example, if the unique identifier is "unique_notification_identifier/access_list_30d_reminder/1234", when a caller attempts to create a notification
+// for a 30 day reminder to review access list 1234, it will create this identifier resource as well, and any subsequent times it attempts to create the notification,
+// it will detect that the identifier already exists, and thus know not to create a duplicate.
+// Note that using this system does not always guarantee accuracy/concurrency, so this shouldn't be used for security critical notifications.
+type UniqueNotificationIdentifier struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// kind is the resource kind ("unique_notification_identifier").
+	Kind string `protobuf:"bytes,1,opt,name=kind,proto3" json:"kind,omitempty"`
+	// version is the resource version.
+	Version string `protobuf:"bytes,2,opt,name=version,proto3" json:"version,omitempty"`
+	// metadata is the unique notification identifier metadata.
+	Metadata *v1.Metadata `protobuf:"bytes,3,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	// spec is the unique notification identifier spec.
+	Spec          *UniqueNotificationIdentifierSpec `protobuf:"bytes,5,opt,name=spec,proto3" json:"spec,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UniqueNotificationIdentifier) Reset() {
+	*x = UniqueNotificationIdentifier{}
+	mi := &file_teleport_notifications_v1_notifications_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UniqueNotificationIdentifier) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UniqueNotificationIdentifier) ProtoMessage() {}
+
+func (x *UniqueNotificationIdentifier) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_notifications_v1_notifications_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UniqueNotificationIdentifier.ProtoReflect.Descriptor instead.
+func (*UniqueNotificationIdentifier) Descriptor() ([]byte, []int) {
+	return file_teleport_notifications_v1_notifications_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *UniqueNotificationIdentifier) GetKind() string {
+	if x != nil {
+		return x.Kind
+	}
+	return ""
+}
+
+func (x *UniqueNotificationIdentifier) GetVersion() string {
+	if x != nil {
+		return x.Version
+	}
+	return ""
+}
+
+func (x *UniqueNotificationIdentifier) GetMetadata() *v1.Metadata {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+func (x *UniqueNotificationIdentifier) GetSpec() *UniqueNotificationIdentifierSpec {
+	if x != nil {
+		return x.Spec
+	}
+	return nil
+}
+
+// UniqueNotificationIdentifierSpec is the unique notification identifier specification.
+type UniqueNotificationIdentifierSpec struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// unique_identifier is the unique identifier string. This is what is used to keep track of the unique notification and what is used in the resource's backend key.
+	UniqueIdentifier string `protobuf:"bytes,1,opt,name=unique_identifier,json=uniqueIdentifier,proto3" json:"unique_identifier,omitempty"`
+	// unique_identifier_prefix is the prefix for this unique notiifcation identifier, this is used to group notification identifiers together, eg. "access_list_30d_reminder"
+	UniqueIdentifierPrefix string `protobuf:"bytes,2,opt,name=unique_identifier_prefix,json=uniqueIdentifierPrefix,proto3" json:"unique_identifier_prefix,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
+}
+
+func (x *UniqueNotificationIdentifierSpec) Reset() {
+	*x = UniqueNotificationIdentifierSpec{}
+	mi := &file_teleport_notifications_v1_notifications_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UniqueNotificationIdentifierSpec) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UniqueNotificationIdentifierSpec) ProtoMessage() {}
+
+func (x *UniqueNotificationIdentifierSpec) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_notifications_v1_notifications_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UniqueNotificationIdentifierSpec.ProtoReflect.Descriptor instead.
+func (*UniqueNotificationIdentifierSpec) Descriptor() ([]byte, []int) {
+	return file_teleport_notifications_v1_notifications_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *UniqueNotificationIdentifierSpec) GetUniqueIdentifier() string {
+	if x != nil {
+		return x.UniqueIdentifier
+	}
+	return ""
+}
+
+func (x *UniqueNotificationIdentifierSpec) GetUniqueIdentifierPrefix() string {
+	if x != nil {
+		return x.UniqueIdentifierPrefix
+	}
+	return ""
+}
+
 var File_teleport_notifications_v1_notifications_proto protoreflect.FileDescriptor
 
 var file_teleport_notifications_v1_notifications_proto_rawDesc = []byte{
@@ -1056,21 +1189,44 @@ var file_teleport_notifications_v1_notifications_proto_rawDesc = []byte{
 	0x61, 0x73, 0x74, 0x5f, 0x73, 0x65, 0x65, 0x6e, 0x5f, 0x74, 0x69, 0x6d, 0x65, 0x18, 0x01, 0x20,
 	0x01, 0x28, 0x0b, 0x32, 0x1a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
 	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x52,
-	0x0c, 0x6c, 0x61, 0x73, 0x74, 0x53, 0x65, 0x65, 0x6e, 0x54, 0x69, 0x6d, 0x65, 0x2a, 0x79, 0x0a,
-	0x11, 0x4e, 0x6f, 0x74, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x53, 0x74, 0x61,
-	0x74, 0x65, 0x12, 0x22, 0x0a, 0x1e, 0x4e, 0x4f, 0x54, 0x49, 0x46, 0x49, 0x43, 0x41, 0x54, 0x49,
-	0x4f, 0x4e, 0x5f, 0x53, 0x54, 0x41, 0x54, 0x45, 0x5f, 0x55, 0x4e, 0x53, 0x50, 0x45, 0x43, 0x49,
-	0x46, 0x49, 0x45, 0x44, 0x10, 0x00, 0x12, 0x1e, 0x0a, 0x1a, 0x4e, 0x4f, 0x54, 0x49, 0x46, 0x49,
-	0x43, 0x41, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x53, 0x54, 0x41, 0x54, 0x45, 0x5f, 0x43, 0x4c, 0x49,
-	0x43, 0x4b, 0x45, 0x44, 0x10, 0x01, 0x12, 0x20, 0x0a, 0x1c, 0x4e, 0x4f, 0x54, 0x49, 0x46, 0x49,
-	0x43, 0x41, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x53, 0x54, 0x41, 0x54, 0x45, 0x5f, 0x44, 0x49, 0x53,
-	0x4d, 0x49, 0x53, 0x53, 0x45, 0x44, 0x10, 0x02, 0x42, 0x5e, 0x5a, 0x5c, 0x67, 0x69, 0x74, 0x68,
-	0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x67, 0x72, 0x61, 0x76, 0x69, 0x74, 0x61, 0x74, 0x69,
-	0x6f, 0x6e, 0x61, 0x6c, 0x2f, 0x74, 0x65, 0x6c, 0x65, 0x70, 0x6f, 0x72, 0x74, 0x2f, 0x61, 0x70,
-	0x69, 0x2f, 0x67, 0x65, 0x6e, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x67, 0x6f, 0x2f, 0x74,
-	0x65, 0x6c, 0x65, 0x70, 0x6f, 0x72, 0x74, 0x2f, 0x6e, 0x6f, 0x74, 0x69, 0x66, 0x69, 0x63, 0x61,
-	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2f, 0x76, 0x31, 0x3b, 0x6e, 0x6f, 0x74, 0x69, 0x66, 0x69, 0x63,
-	0x61, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x76, 0x31, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x0c, 0x6c, 0x61, 0x73, 0x74, 0x53, 0x65, 0x65, 0x6e, 0x54, 0x69, 0x6d, 0x65, 0x22, 0xd7, 0x01,
+	0x0a, 0x1c, 0x55, 0x6e, 0x69, 0x71, 0x75, 0x65, 0x4e, 0x6f, 0x74, 0x69, 0x66, 0x69, 0x63, 0x61,
+	0x74, 0x69, 0x6f, 0x6e, 0x49, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x72, 0x12, 0x12,
+	0x0a, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6b, 0x69,
+	0x6e, 0x64, 0x12, 0x18, 0x0a, 0x07, 0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x18, 0x02, 0x20,
+	0x01, 0x28, 0x09, 0x52, 0x07, 0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x12, 0x38, 0x0a, 0x08,
+	0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1c,
+	0x2e, 0x74, 0x65, 0x6c, 0x65, 0x70, 0x6f, 0x72, 0x74, 0x2e, 0x68, 0x65, 0x61, 0x64, 0x65, 0x72,
+	0x2e, 0x76, 0x31, 0x2e, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x52, 0x08, 0x6d, 0x65,
+	0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x12, 0x4f, 0x0a, 0x04, 0x73, 0x70, 0x65, 0x63, 0x18, 0x05,
+	0x20, 0x01, 0x28, 0x0b, 0x32, 0x3b, 0x2e, 0x74, 0x65, 0x6c, 0x65, 0x70, 0x6f, 0x72, 0x74, 0x2e,
+	0x6e, 0x6f, 0x74, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x76, 0x31,
+	0x2e, 0x55, 0x6e, 0x69, 0x71, 0x75, 0x65, 0x4e, 0x6f, 0x74, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74,
+	0x69, 0x6f, 0x6e, 0x49, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x72, 0x53, 0x70, 0x65,
+	0x63, 0x52, 0x04, 0x73, 0x70, 0x65, 0x63, 0x22, 0x89, 0x01, 0x0a, 0x20, 0x55, 0x6e, 0x69, 0x71,
+	0x75, 0x65, 0x4e, 0x6f, 0x74, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x49, 0x64,
+	0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x72, 0x53, 0x70, 0x65, 0x63, 0x12, 0x2b, 0x0a, 0x11,
+	0x75, 0x6e, 0x69, 0x71, 0x75, 0x65, 0x5f, 0x69, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65,
+	0x72, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x10, 0x75, 0x6e, 0x69, 0x71, 0x75, 0x65, 0x49,
+	0x64, 0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x72, 0x12, 0x38, 0x0a, 0x18, 0x75, 0x6e, 0x69,
+	0x71, 0x75, 0x65, 0x5f, 0x69, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x72, 0x5f, 0x70,
+	0x72, 0x65, 0x66, 0x69, 0x78, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x16, 0x75, 0x6e, 0x69,
+	0x71, 0x75, 0x65, 0x49, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x72, 0x50, 0x72, 0x65,
+	0x66, 0x69, 0x78, 0x2a, 0x79, 0x0a, 0x11, 0x4e, 0x6f, 0x74, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74,
+	0x69, 0x6f, 0x6e, 0x53, 0x74, 0x61, 0x74, 0x65, 0x12, 0x22, 0x0a, 0x1e, 0x4e, 0x4f, 0x54, 0x49,
+	0x46, 0x49, 0x43, 0x41, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x53, 0x54, 0x41, 0x54, 0x45, 0x5f, 0x55,
+	0x4e, 0x53, 0x50, 0x45, 0x43, 0x49, 0x46, 0x49, 0x45, 0x44, 0x10, 0x00, 0x12, 0x1e, 0x0a, 0x1a,
+	0x4e, 0x4f, 0x54, 0x49, 0x46, 0x49, 0x43, 0x41, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x53, 0x54, 0x41,
+	0x54, 0x45, 0x5f, 0x43, 0x4c, 0x49, 0x43, 0x4b, 0x45, 0x44, 0x10, 0x01, 0x12, 0x20, 0x0a, 0x1c,
+	0x4e, 0x4f, 0x54, 0x49, 0x46, 0x49, 0x43, 0x41, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x53, 0x54, 0x41,
+	0x54, 0x45, 0x5f, 0x44, 0x49, 0x53, 0x4d, 0x49, 0x53, 0x53, 0x45, 0x44, 0x10, 0x02, 0x42, 0x5e,
+	0x5a, 0x5c, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x67, 0x72, 0x61,
+	0x76, 0x69, 0x74, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x61, 0x6c, 0x2f, 0x74, 0x65, 0x6c, 0x65, 0x70,
+	0x6f, 0x72, 0x74, 0x2f, 0x61, 0x70, 0x69, 0x2f, 0x67, 0x65, 0x6e, 0x2f, 0x70, 0x72, 0x6f, 0x74,
+	0x6f, 0x2f, 0x67, 0x6f, 0x2f, 0x74, 0x65, 0x6c, 0x65, 0x70, 0x6f, 0x72, 0x74, 0x2f, 0x6e, 0x6f,
+	0x74, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2f, 0x76, 0x31, 0x3b, 0x6e,
+	0x6f, 0x74, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x76, 0x31, 0x62, 0x06,
+	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -1086,48 +1242,52 @@ func file_teleport_notifications_v1_notifications_proto_rawDescGZIP() []byte {
 }
 
 var file_teleport_notifications_v1_notifications_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_teleport_notifications_v1_notifications_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
+var file_teleport_notifications_v1_notifications_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
 var file_teleport_notifications_v1_notifications_proto_goTypes = []any{
-	(NotificationState)(0),                 // 0: teleport.notifications.v1.NotificationState
-	(*Notification)(nil),                   // 1: teleport.notifications.v1.Notification
-	(*NotificationSpec)(nil),               // 2: teleport.notifications.v1.NotificationSpec
-	(*GlobalNotification)(nil),             // 3: teleport.notifications.v1.GlobalNotification
-	(*GlobalNotificationSpec)(nil),         // 4: teleport.notifications.v1.GlobalNotificationSpec
-	(*ByPermissions)(nil),                  // 5: teleport.notifications.v1.ByPermissions
-	(*ByRoles)(nil),                        // 6: teleport.notifications.v1.ByRoles
-	(*UserNotificationState)(nil),          // 7: teleport.notifications.v1.UserNotificationState
-	(*UserNotificationStateSpec)(nil),      // 8: teleport.notifications.v1.UserNotificationStateSpec
-	(*UserNotificationStateStatus)(nil),    // 9: teleport.notifications.v1.UserNotificationStateStatus
-	(*UserLastSeenNotification)(nil),       // 10: teleport.notifications.v1.UserLastSeenNotification
-	(*UserLastSeenNotificationSpec)(nil),   // 11: teleport.notifications.v1.UserLastSeenNotificationSpec
-	(*UserLastSeenNotificationStatus)(nil), // 12: teleport.notifications.v1.UserLastSeenNotificationStatus
-	(*v1.Metadata)(nil),                    // 13: teleport.header.v1.Metadata
-	(*timestamppb.Timestamp)(nil),          // 14: google.protobuf.Timestamp
-	(*types.RoleConditions)(nil),           // 15: types.RoleConditions
+	(NotificationState)(0),                   // 0: teleport.notifications.v1.NotificationState
+	(*Notification)(nil),                     // 1: teleport.notifications.v1.Notification
+	(*NotificationSpec)(nil),                 // 2: teleport.notifications.v1.NotificationSpec
+	(*GlobalNotification)(nil),               // 3: teleport.notifications.v1.GlobalNotification
+	(*GlobalNotificationSpec)(nil),           // 4: teleport.notifications.v1.GlobalNotificationSpec
+	(*ByPermissions)(nil),                    // 5: teleport.notifications.v1.ByPermissions
+	(*ByRoles)(nil),                          // 6: teleport.notifications.v1.ByRoles
+	(*UserNotificationState)(nil),            // 7: teleport.notifications.v1.UserNotificationState
+	(*UserNotificationStateSpec)(nil),        // 8: teleport.notifications.v1.UserNotificationStateSpec
+	(*UserNotificationStateStatus)(nil),      // 9: teleport.notifications.v1.UserNotificationStateStatus
+	(*UserLastSeenNotification)(nil),         // 10: teleport.notifications.v1.UserLastSeenNotification
+	(*UserLastSeenNotificationSpec)(nil),     // 11: teleport.notifications.v1.UserLastSeenNotificationSpec
+	(*UserLastSeenNotificationStatus)(nil),   // 12: teleport.notifications.v1.UserLastSeenNotificationStatus
+	(*UniqueNotificationIdentifier)(nil),     // 13: teleport.notifications.v1.UniqueNotificationIdentifier
+	(*UniqueNotificationIdentifierSpec)(nil), // 14: teleport.notifications.v1.UniqueNotificationIdentifierSpec
+	(*v1.Metadata)(nil),                      // 15: teleport.header.v1.Metadata
+	(*timestamppb.Timestamp)(nil),            // 16: google.protobuf.Timestamp
+	(*types.RoleConditions)(nil),             // 17: types.RoleConditions
 }
 var file_teleport_notifications_v1_notifications_proto_depIdxs = []int32{
-	13, // 0: teleport.notifications.v1.Notification.metadata:type_name -> teleport.header.v1.Metadata
+	15, // 0: teleport.notifications.v1.Notification.metadata:type_name -> teleport.header.v1.Metadata
 	2,  // 1: teleport.notifications.v1.Notification.spec:type_name -> teleport.notifications.v1.NotificationSpec
-	14, // 2: teleport.notifications.v1.NotificationSpec.created:type_name -> google.protobuf.Timestamp
-	13, // 3: teleport.notifications.v1.GlobalNotification.metadata:type_name -> teleport.header.v1.Metadata
+	16, // 2: teleport.notifications.v1.NotificationSpec.created:type_name -> google.protobuf.Timestamp
+	15, // 3: teleport.notifications.v1.GlobalNotification.metadata:type_name -> teleport.header.v1.Metadata
 	4,  // 4: teleport.notifications.v1.GlobalNotification.spec:type_name -> teleport.notifications.v1.GlobalNotificationSpec
 	5,  // 5: teleport.notifications.v1.GlobalNotificationSpec.by_permissions:type_name -> teleport.notifications.v1.ByPermissions
 	6,  // 6: teleport.notifications.v1.GlobalNotificationSpec.by_roles:type_name -> teleport.notifications.v1.ByRoles
 	1,  // 7: teleport.notifications.v1.GlobalNotificationSpec.notification:type_name -> teleport.notifications.v1.Notification
-	15, // 8: teleport.notifications.v1.ByPermissions.role_conditions:type_name -> types.RoleConditions
-	13, // 9: teleport.notifications.v1.UserNotificationState.metadata:type_name -> teleport.header.v1.Metadata
+	17, // 8: teleport.notifications.v1.ByPermissions.role_conditions:type_name -> types.RoleConditions
+	15, // 9: teleport.notifications.v1.UserNotificationState.metadata:type_name -> teleport.header.v1.Metadata
 	8,  // 10: teleport.notifications.v1.UserNotificationState.spec:type_name -> teleport.notifications.v1.UserNotificationStateSpec
 	9,  // 11: teleport.notifications.v1.UserNotificationState.status:type_name -> teleport.notifications.v1.UserNotificationStateStatus
 	0,  // 12: teleport.notifications.v1.UserNotificationStateStatus.notification_state:type_name -> teleport.notifications.v1.NotificationState
-	13, // 13: teleport.notifications.v1.UserLastSeenNotification.metadata:type_name -> teleport.header.v1.Metadata
+	15, // 13: teleport.notifications.v1.UserLastSeenNotification.metadata:type_name -> teleport.header.v1.Metadata
 	11, // 14: teleport.notifications.v1.UserLastSeenNotification.spec:type_name -> teleport.notifications.v1.UserLastSeenNotificationSpec
 	12, // 15: teleport.notifications.v1.UserLastSeenNotification.status:type_name -> teleport.notifications.v1.UserLastSeenNotificationStatus
-	14, // 16: teleport.notifications.v1.UserLastSeenNotificationStatus.last_seen_time:type_name -> google.protobuf.Timestamp
-	17, // [17:17] is the sub-list for method output_type
-	17, // [17:17] is the sub-list for method input_type
-	17, // [17:17] is the sub-list for extension type_name
-	17, // [17:17] is the sub-list for extension extendee
-	0,  // [0:17] is the sub-list for field type_name
+	16, // 16: teleport.notifications.v1.UserLastSeenNotificationStatus.last_seen_time:type_name -> google.protobuf.Timestamp
+	15, // 17: teleport.notifications.v1.UniqueNotificationIdentifier.metadata:type_name -> teleport.header.v1.Metadata
+	14, // 18: teleport.notifications.v1.UniqueNotificationIdentifier.spec:type_name -> teleport.notifications.v1.UniqueNotificationIdentifierSpec
+	19, // [19:19] is the sub-list for method output_type
+	19, // [19:19] is the sub-list for method input_type
+	19, // [19:19] is the sub-list for extension type_name
+	19, // [19:19] is the sub-list for extension extendee
+	0,  // [0:19] is the sub-list for field type_name
 }
 
 func init() { file_teleport_notifications_v1_notifications_proto_init() }
@@ -1146,7 +1306,7 @@ func file_teleport_notifications_v1_notifications_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_teleport_notifications_v1_notifications_proto_rawDesc,
 			NumEnums:      1,
-			NumMessages:   12,
+			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/notifications/v1/notifications.proto
+++ b/api/proto/teleport/notifications/v1/notifications.proto
@@ -167,3 +167,28 @@ message UserLastSeenNotificationStatus {
   // last_seen_time is the timestamp of the last notification that the user has seen.
   google.protobuf.Timestamp last_seen_time = 1;
 }
+
+// UniqueNotificationIdentifier represents a unique notification identifier.
+// This is a resource whose existence is used to keep track of whether a particular notification has already been created, in order to prevent duplicate notifications.
+// For example, if the unique identifier is "unique_notification_identifier/access_list_30d_reminder/1234", when a caller attempts to create a notification
+// for a 30 day reminder to review access list 1234, it will create this identifier resource as well, and any subsequent times it attempts to create the notification,
+// it will detect that the identifier already exists, and thus know not to create a duplicate.
+// Note that using this system does not always guarantee accuracy/concurrency, so this shouldn't be used for security critical notifications.
+message UniqueNotificationIdentifier {
+  // kind is the resource kind ("unique_notification_identifier").
+  string kind = 1;
+  // version is the resource version.
+  string version = 2;
+  // metadata is the unique notification identifier metadata.
+  teleport.header.v1.Metadata metadata = 3;
+  // spec is the unique notification identifier spec.
+  UniqueNotificationIdentifierSpec spec = 5;
+}
+
+// UniqueNotificationIdentifierSpec is the unique notification identifier specification.
+message UniqueNotificationIdentifierSpec {
+  // unique_identifier is the unique identifier string. This is what is used to keep track of the unique notification and what is used in the resource's backend key.
+  string unique_identifier = 1;
+  // unique_identifier_prefix is the prefix for this unique notiifcation identifier, this is used to group notification identifiers together, eg. "access_list_30d_reminder"
+  string unique_identifier_prefix = 2;
+}

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -556,6 +556,8 @@ const (
 	KindUserLastSeenNotification = "user_last_seen_notification"
 	// KindUserNotificationState is a resource which tracks whether a user has clicked on or dismissed a notification.
 	KindUserNotificationState = "user_notification_state"
+	// KindUniqueNotificationIdentifier is a resource which tracks a unique identifier for a notification and is used to prevent duplicate notifications in certain cases.
+	KindUniqueNotificationIdentifier = "unique_notification_identifier"
 
 	// KindAccessGraphSecretAuthorizedKey is a authorized key entry found in
 	// a Teleport SSH node type.

--- a/lib/auth/authclient/clt.go
+++ b/lib/auth/authclient/clt.go
@@ -825,6 +825,26 @@ func (c *Client) ListNotificationStatesForAllUsers(ctx context.Context, pageSize
 	return nil, "", trace.NotImplemented(notImplementedMessage)
 }
 
+// CreateUniqueNotificationIdentifier not implemented: can only be called locally.
+func (c *Client) CreateUniqueNotificationIdentifier(ctx context.Context, prefix string, identifier string) (*notificationsv1.UniqueNotificationIdentifier, error) {
+	return nil, trace.NotImplemented(notImplementedMessage)
+}
+
+// GetUniqueNotificationIdentifier not implemented: can only be called locally.
+func (c *Client) GetUniqueNotificationIdentifier(ctx context.Context, prefix string, identifier string) (*notificationsv1.UniqueNotificationIdentifier, error) {
+	return nil, trace.NotImplemented(notImplementedMessage)
+}
+
+// DeleteUniqueNotificationIdentifier not implemented: can only be called locally.
+func (c *Client) DeleteUniqueNotificationIdentifier(ctx context.Context, prefix string, identifier string) error {
+	return trace.NotImplemented(notImplementedMessage)
+}
+
+// ListUniqueNotificationIdentifiersForPrefix not implemented: can only be called locally.
+func (c *Client) ListUniqueNotificationIdentifiersForPrefix(ctx context.Context, prefix string, pageSize int, startKey string) ([]*notificationsv1.UniqueNotificationIdentifier, string, error) {
+	return nil, "", trace.NotImplemented(notImplementedMessage)
+}
+
 // GetAccessGraphSettings gets the access graph settings from the backend.
 func (c *Client) GetAccessGraphSettings(context.Context) (*clusterconfigpb.AccessGraphSettings, error) {
 	return nil, trace.NotImplemented(notImplementedMessage)

--- a/lib/services/local/notifications.go
+++ b/lib/services/local/notifications.go
@@ -38,11 +38,12 @@ import (
 
 // NotificationsService manages notification resources in the backend.
 type NotificationsService struct {
-	clock                           clockwork.Clock
-	userNotificationService         *generic.ServiceWrapper[*notificationsv1.Notification]
-	globalNotificationService       *generic.ServiceWrapper[*notificationsv1.GlobalNotification]
-	userNotificationStateService    *generic.ServiceWrapper[*notificationsv1.UserNotificationState]
-	userLastSeenNotificationService *generic.ServiceWrapper[*notificationsv1.UserLastSeenNotification]
+	clock                               clockwork.Clock
+	userNotificationService             *generic.ServiceWrapper[*notificationsv1.Notification]
+	globalNotificationService           *generic.ServiceWrapper[*notificationsv1.GlobalNotification]
+	userNotificationStateService        *generic.ServiceWrapper[*notificationsv1.UserNotificationState]
+	userLastSeenNotificationService     *generic.ServiceWrapper[*notificationsv1.UserLastSeenNotification]
+	uniqueNotificationIdentifierService *generic.ServiceWrapper[*notificationsv1.UniqueNotificationIdentifier]
 }
 
 // NewNotificationsService returns a new instance of the NotificationService.
@@ -96,12 +97,26 @@ func NewNotificationsService(backend backend.Backend, clock clockwork.Clock) (*N
 		return nil, trace.Wrap(err)
 	}
 
+	uniqueNotificationIdentifierService, err := generic.NewServiceWrapper[*notificationsv1.UniqueNotificationIdentifier](
+		generic.ServiceWrapperConfig[*notificationsv1.UniqueNotificationIdentifier]{
+			Backend:       backend,
+			ResourceKind:  types.KindUniqueNotificationIdentifier,
+			BackendPrefix: notificationUniqueIdentifierPrefix,
+			MarshalFunc:   services.MarshalUniqueNotificationIdentifier,
+			UnmarshalFunc: services.UnmarshalUniqueNotificationIdentifier,
+			ValidateFunc:  services.ValidateUniqueNotificationIdentifier,
+		})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	return &NotificationsService{
-		clock:                           clock,
-		userNotificationService:         userNotificationService,
-		globalNotificationService:       globalNotificationService,
-		userNotificationStateService:    userNotificationStateService,
-		userLastSeenNotificationService: userLastSeenNotificationService,
+		clock:                               clock,
+		userNotificationService:             userNotificationService,
+		globalNotificationService:           globalNotificationService,
+		userNotificationStateService:        userNotificationStateService,
+		userLastSeenNotificationService:     userLastSeenNotificationService,
+		uniqueNotificationIdentifierService: uniqueNotificationIdentifierService,
 	}, nil
 }
 
@@ -171,7 +186,7 @@ func (s *NotificationsService) CreateUserNotification(ctx context.Context, notif
 	}
 	notification.Metadata.Name = uuid.String()
 
-	if err := CheckAndSetExpiry(notification, s.clock); err != nil {
+	if err := CheckAndSetExpiry(notification.Metadata, s.clock); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -259,7 +274,7 @@ func (s *NotificationsService) CreateGlobalNotification(ctx context.Context, glo
 		return nil, trace.Wrap(err)
 	}
 
-	if err := CheckAndSetExpiry(globalNotification.Spec.Notification, s.clock); err != nil {
+	if err := CheckAndSetExpiry(globalNotification.Spec.Notification.Metadata, s.clock); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -411,13 +426,85 @@ func (s *NotificationsService) DeleteUserLastSeenNotification(ctx context.Contex
 	return trace.Wrap(err)
 }
 
+// ListUniqueNotificationIdentifiersForPrefix returns unique notification identifiers with a given prefix
+func (s *NotificationsService) ListUniqueNotificationIdentifiersForPrefix(ctx context.Context, prefix string, pageSize int, startKey string) ([]*notificationsv1.UniqueNotificationIdentifier, string, error) {
+	if prefix == "" {
+		return nil, "", trace.BadParameter("prefix is missing")
+	}
+
+	serviceWithPrefix := s.uniqueNotificationIdentifierService.WithPrefix(prefix)
+
+	identifiers, nextKey, err := serviceWithPrefix.ListResources(ctx, pageSize, startKey)
+	return identifiers, nextKey, trace.Wrap(err)
+}
+
+// CreateUniqueNotificationIdentifier creates a unique notification identifier resource.
+func (s *NotificationsService) CreateUniqueNotificationIdentifier(ctx context.Context, prefix string, identifier string) (*notificationsv1.UniqueNotificationIdentifier, error) {
+	if prefix == "" {
+		return nil, trace.BadParameter("prefix is missing")
+	}
+	if identifier == "" {
+		return nil, trace.BadParameter("identifier is missing")
+	}
+
+	uniqueNotificationIdentifier := &notificationsv1.UniqueNotificationIdentifier{
+		Spec: &notificationsv1.UniqueNotificationIdentifierSpec{
+			UniqueIdentifier:       identifier,
+			UniqueIdentifierPrefix: prefix,
+		},
+		Metadata: &headerv1.Metadata{
+			// the service adapter uses `getName()` to determine the backend key
+			Name: identifier,
+		},
+		Kind:    types.KindUniqueNotificationIdentifier,
+		Version: types.V1,
+	}
+
+	if err := CheckAndSetExpiry(uniqueNotificationIdentifier.Metadata, s.clock); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	serviceWithPrefix := s.uniqueNotificationIdentifierService.WithPrefix(prefix)
+
+	created, err := serviceWithPrefix.CreateResource(ctx, uniqueNotificationIdentifier)
+	return created, trace.Wrap(err)
+}
+
+// GetUniqueNotificationIdentifier returns a unique notification identifier resource.
+func (s *NotificationsService) GetUniqueNotificationIdentifier(ctx context.Context, prefix string, identifier string) (*notificationsv1.UniqueNotificationIdentifier, error) {
+	if prefix == "" {
+		return nil, trace.BadParameter("prefix is missing")
+	}
+	if identifier == "" {
+		return nil, trace.BadParameter("identifier is missing")
+	}
+
+	serviceWithPrefix := s.uniqueNotificationIdentifierService.WithPrefix(prefix)
+
+	return serviceWithPrefix.GetResource(ctx, identifier)
+}
+
+// DeleteUniqueNotificationIdentifier deletes a unique notification identifier resource.
+func (s *NotificationsService) DeleteUniqueNotificationIdentifier(ctx context.Context, prefix string, identifier string) error {
+	if prefix == "" {
+		return trace.BadParameter("prefix is missing")
+	}
+	if identifier == "" {
+		return trace.BadParameter("identifier is missing")
+	}
+
+	serviceWithPrefix := s.uniqueNotificationIdentifierService.WithPrefix(prefix)
+
+	return serviceWithPrefix.DeleteResource(ctx, identifier)
+}
+
 // CheckAndSetExpiry checks and sets the default expiry for a notification.
-func CheckAndSetExpiry(notification *notificationsv1.Notification, clock clockwork.Clock) error {
+func CheckAndSetExpiry(metadata *headerv1.Metadata, clock clockwork.Clock) error {
 	// If the expiry hasn't been provided, set the default to 30 days from now.
-	if notification.Metadata.Expires == nil {
+	if metadata.Expires == nil {
 		now := clock.Now()
 		futureTime := now.Add(defaultExpiry)
-		notification.Metadata.Expires = timestamppb.New(futureTime)
+		metadata.Expires = timestamppb.New(futureTime)
 		return nil
 	}
 
@@ -426,7 +513,7 @@ func CheckAndSetExpiry(notification *notificationsv1.Notification, clock clockwo
 	now := clock.Now()
 	timeOfMaxExpiry := now.Add(maxExpiry)
 
-	if (*notification.Metadata.Expires).AsTime().After(timeOfMaxExpiry) {
+	if metadata.Expires.AsTime().After(timeOfMaxExpiry) {
 		return trace.BadParameter("notification expiry cannot be more than %d days from its creation", int(maxExpiry.Hours()/24))
 	}
 
@@ -434,10 +521,11 @@ func CheckAndSetExpiry(notification *notificationsv1.Notification, clock clockwo
 }
 
 var (
-	notificationsGlobalPrefix       = backend.NewKey("notifications", "global")    // notifications/global/<notification id>
-	notificationsUserSpecificPrefix = backend.NewKey("notifications", "user")      // notifications/user/<username>/<notification id>
-	notificationsStatePrefix        = backend.NewKey("notifications", "states")    // notifications/states/<username>/<notification id>
-	notificationsUserLastSeenPrefix = backend.NewKey("notifications", "last_seen") // notifications/last_seen/<username>
+	notificationsGlobalPrefix          = backend.NewKey("notifications", "global")        // notifications/global/<notification id>
+	notificationsUserSpecificPrefix    = backend.NewKey("notifications", "user")          // notifications/user/<username>/<notification id>
+	notificationsStatePrefix           = backend.NewKey("notifications", "states")        // notifications/states/<username>/<notification id>
+	notificationsUserLastSeenPrefix    = backend.NewKey("notifications", "last_seen")     // notifications/last_seen/<username>
+	notificationUniqueIdentifierPrefix = backend.NewKey("notification_unique_identifier") // notification_unique_identifier/<key>
 )
 
 const (

--- a/lib/services/notifications.go
+++ b/lib/services/notifications.go
@@ -48,6 +48,13 @@ type Notifications interface {
 	UpsertUserLastSeenNotification(ctx context.Context, username string, ulsn *notificationsv1.UserLastSeenNotification) (*notificationsv1.UserLastSeenNotification, error)
 	GetUserLastSeenNotification(ctx context.Context, username string) (*notificationsv1.UserLastSeenNotification, error)
 	DeleteUserLastSeenNotification(ctx context.Context, username string) error
+
+	// UniqueNotificationIdentifier methods should not be exposed to the client since they should only ever be used internally.
+
+	CreateUniqueNotificationIdentifier(ctx context.Context, prefix string, identifier string) (*notificationsv1.UniqueNotificationIdentifier, error)
+	ListUniqueNotificationIdentifiersForPrefix(ctx context.Context, prefix string, pageSize int, startKey string) ([]*notificationsv1.UniqueNotificationIdentifier, string, error)
+	GetUniqueNotificationIdentifier(ctx context.Context, prefix string, identifier string) (*notificationsv1.UniqueNotificationIdentifier, error)
+	DeleteUniqueNotificationIdentifier(ctx context.Context, prefix string, identifier string) error
 }
 
 // ValidateNotification verifies that the necessary fields are configured for a notification object.
@@ -168,4 +175,27 @@ func MarshalUserLastSeenNotification(userLastSeenNotification *notificationsv1.U
 // UnmarshalUserLastSeenNotification unmarshals a UserLastSeenNotification resource from JSON.
 func UnmarshalUserLastSeenNotification(data []byte, opts ...MarshalOption) (*notificationsv1.UserLastSeenNotification, error) {
 	return FastUnmarshalProtoResourceDeprecated[*notificationsv1.UserLastSeenNotification](data, opts...)
+}
+
+// ValidateUniqueNotificationIdentifier verifies that the necessary fields are configured for a unique notification identifier object.
+func ValidateUniqueNotificationIdentifier(uni *notificationsv1.UniqueNotificationIdentifier) error {
+	if uni.Spec.UniqueIdentifier == "" {
+		return trace.BadParameter("unique notification identifier key is missing")
+	}
+
+	return nil
+}
+
+// MarshalUniqueNotificationIdentifier marshals a UniqueNotificationIdentifier resource to JSON.
+func MarshalUniqueNotificationIdentifier(uni *notificationsv1.UniqueNotificationIdentifier, opts ...MarshalOption) ([]byte, error) {
+	if err := ValidateUniqueNotificationIdentifier(uni); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return FastMarshalProtoResourceDeprecated(uni, opts...)
+}
+
+// UnmarshalUniqueNotificationIdentifier unmarshals a UniqueNotificationIdentifier resource from JSON.
+func UnmarshalUniqueNotificationIdentifier(data []byte, opts ...MarshalOption) (*notificationsv1.UniqueNotificationIdentifier, error) {
+	return FastUnmarshalProtoResourceDeprecated[*notificationsv1.UniqueNotificationIdentifier](data, opts...)
 }


### PR DESCRIPTION
## Purpose

This PR adds a new "unique notification identifier" resource to the backend as well as CRUD methods for it. This resource will be used as a reference to prevent duplicate notifications. 

For context, one of the shortcomings of the notifications system as it is now is that it is not possible to keep track of whether a notification for a particular event has already been created. This means that if we want to create a notification as a result of repetitive logic (such as a periodic check), it would keep creating a new duplicate notification every time it is run. 

With this new resource, notifications that fall into this category can be tied to a unique notification identifier resource. The first time the notification is created, it will create a unique identifier resource tied to it via some type of metadata as the identifier, for example, a 30 day access list review reminder notification would create an identifier with a key like `unique_notification_identifier/access_list_30d_reminder/<access-list-id>`, then every time we detect that an access list is due for review in less than 30 days, we can first check for the existence of this unique identifier resource in order to know whether to avoid creating a duplicate notification.