### PR TITLE
[v16] Add flag to allow s3 virtual style addressing

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -378,6 +378,9 @@ const (
 	// SSEKMSKey is an optional switch to use an KMS CMK key for S3 SSE.
 	SSEKMSKey = "sse_kms_key"
 
+	// S3UseVirtualStyleAddressing is an optional switch to use use a virtual-hosted–style URI.
+	S3UseVirtualStyleAddressing = "use_s3_virtual_style_addressing"
+
 	// SchemeFile configures local disk-based file storage for audit events
 	SchemeFile = "file"
 

--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -650,6 +650,10 @@ Service reads these parameters to configure its interactions with S3:
 - `use_fips_endpoint=true` -  [Configure S3 FIPS
   endpoints](#configuring-aws-fips-endpoints)
 
+- `use_s3_virtual_style_addressing` - Whether to use virtual-host-style instead of path-style URLs for the
+  bucket. Only applies when a custom endpoint is set. Defaults to false when unset. If used
+  without a custom endpoint set, this option has no effect.
+
 ### S3 IAM policy
 
 (!docs/pages/includes/s3-iam-policy.mdx!)

--- a/lib/events/s3sessions/s3handler_config_test.go
+++ b/lib/events/s3sessions/s3handler_config_test.go
@@ -108,6 +108,27 @@ func TestConfig_SetFromURL(t *testing.T) {
 				require.Equal(t, types.ClusterAuditConfigSpecV2_FIPS_DISABLED, config.UseFIPSEndpoint)
 			},
 		},
+		{
+			name: "path style addressing enabled via url",
+			url:  "s3://path/bucket/adit?use_s3_virtual_style_addressing=false",
+			cfgAssertion: func(t *testing.T, config Config) {
+				require.False(t, config.UseVirtualStyleAddressing)
+			},
+		},
+		{
+			name: "path style addressing enabled by default",
+			url:  "s3://path/bucket/audit",
+			cfgAssertion: func(t *testing.T, config Config) {
+				require.False(t, config.UseVirtualStyleAddressing)
+			},
+		},
+		{
+			name: "path style addressing disabled via url",
+			url:  "s3://path/bucket/audit?use_s3_virtual_style_addressing=true",
+			cfgAssertion: func(t *testing.T, config Config) {
+				require.True(t, config.UseVirtualStyleAddressing)
+			},
+		},
 	}
 
 	for _, tt := range cases {


### PR DESCRIPTION
Should be merged after https://github.com/gravitational/teleport/pull/49835

Add ability to disable path-style S3 access for third-party endpoints.

part of: https://github.com/gravitational/teleport/issues/48451
Fixes https://github.com/gravitational/customer-sensitive-requests/issues/346

changelog: Add ability to disable path-style S3 access for third-party endpoints.