### PR TITLE
[v17] GitHub proxy: role presets and user traits 

### DIFF
--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -405,6 +405,10 @@ const (
 	// TraitHostUserGID is the name of the variable used to specify
 	// the GID to create host user account with.
 	TraitHostUserGID = "host_user_gid"
+
+	// TraitGitHubOrgs is the name of the variable to specify the GitHub
+	// organizations for GitHub integration.
+	TraitGitHubOrgs = "github_orgs"
 )
 
 const (

--- a/constants.go
+++ b/constants.go
@@ -639,6 +639,10 @@ const (
 	// TraitInternalJWTVariable is the variable used to store JWT token for
 	// app sessions.
 	TraitInternalJWTVariable = "{{internal.jwt}}"
+
+	// TraitInternalGitHubOrgs is the variable used to store allowed GitHub
+	// organizations for GitHub integrations.
+	TraitInternalGitHubOrgs = "{{internal.github_orgs}}"
 )
 
 // SCP is Secure Copy.

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -195,6 +195,7 @@ func NewPresetEditorRole() types.Role {
 					types.NewRule(types.KindWorkloadIdentity, RW()),
 					types.NewRule(types.KindAutoUpdateVersion, RW()),
 					types.NewRule(types.KindAutoUpdateConfig, RW()),
+					types.NewRule(types.KindGitServer, RW()),
 				},
 			},
 		},
@@ -251,6 +252,9 @@ func NewPresetAccessRole() types.Role {
 						Verbs:     []string{types.Wildcard},
 					},
 				},
+				GitHubPermissions: []types.GitHubPermission{{
+					Organizations: []string{teleport.TraitInternalGitHubOrgs},
+				}},
 				Rules: []types.Rule{
 					types.NewRule(types.KindEvent, RO()),
 					{
@@ -663,6 +667,7 @@ func NewPresetTerraformProviderRole() types.Role {
 					types.NewRule(types.KindDynamicWindowsDesktop, RW()),
 					types.NewRule(types.KindStaticHostUser, RW()),
 					types.NewRule(types.KindWorkloadIdentity, RW()),
+					types.NewRule(types.KindGitServer, RW()),
 				},
 			},
 		},
@@ -922,6 +927,16 @@ func AddRoleDefaults(role types.Role) (types.Role, error) {
 		}
 	}
 
+	// GitHub permissions.
+	if len(role.GetGitHubPermissions(types.Allow)) == 0 {
+		if githubOrgs := defaultGitHubOrgs()[role.GetName()]; len(githubOrgs) > 0 {
+			role.SetGitHubPermissions(types.Allow, []types.GitHubPermission{{
+				Organizations: githubOrgs,
+			}})
+			changed = true
+		}
+	}
+
 	if !changed {
 		return nil, trace.AlreadyExists("no change")
 	}
@@ -1032,4 +1047,10 @@ func updateAllowLabels(role types.Role, kind string, defaultLabels types.Labels)
 	}
 
 	return changed, nil
+}
+
+func defaultGitHubOrgs() map[string][]string {
+	return map[string][]string{
+		teleport.PresetAccessRoleName: []string{teleport.TraitInternalGitHubOrgs},
+	}
 }

--- a/lib/services/presets_test.go
+++ b/lib/services/presets_test.go
@@ -138,6 +138,9 @@ func TestAddRoleDefaults(t *testing.T) {
 						DatabaseServiceLabels: defaultAllowLabels(false)[teleport.PresetAccessRoleName].DatabaseServiceLabels,
 						DatabaseRoles:         defaultAllowLabels(false)[teleport.PresetAccessRoleName].DatabaseRoles,
 						Rules:                 NewPresetAccessRole().GetRules(types.Allow),
+						GitHubPermissions: []types.GitHubPermission{{
+							Organizations: defaultGitHubOrgs()[teleport.PresetAccessRoleName],
+						}},
 					},
 				},
 			},
@@ -170,6 +173,9 @@ func TestAddRoleDefaults(t *testing.T) {
 						DatabaseServiceLabels: defaultAllowLabels(false)[teleport.PresetAccessRoleName].DatabaseServiceLabels,
 						DatabaseRoles:         defaultAllowLabels(false)[teleport.PresetAccessRoleName].DatabaseRoles,
 						Rules:                 defaultAllowRules()[teleport.PresetAccessRoleName],
+						GitHubPermissions: []types.GitHubPermission{{
+							Organizations: defaultGitHubOrgs()[teleport.PresetAccessRoleName],
+						}},
 					},
 				},
 			},
@@ -185,6 +191,9 @@ func TestAddRoleDefaults(t *testing.T) {
 						DatabaseServiceLabels: defaultAllowLabels(false)[teleport.PresetAccessRoleName].DatabaseServiceLabels,
 						DatabaseRoles:         defaultAllowLabels(false)[teleport.PresetAccessRoleName].DatabaseRoles,
 						Rules:                 defaultAllowRules()[teleport.PresetAccessRoleName],
+						GitHubPermissions: []types.GitHubPermission{{
+							Organizations: defaultGitHubOrgs()[teleport.PresetAccessRoleName],
+						}},
 					},
 				},
 			},
@@ -201,6 +210,9 @@ func TestAddRoleDefaults(t *testing.T) {
 						DatabaseServiceLabels: defaultAllowLabels(false)[teleport.PresetAccessRoleName].DatabaseServiceLabels,
 						DatabaseRoles:         defaultAllowLabels(false)[teleport.PresetAccessRoleName].DatabaseRoles,
 						Rules:                 defaultAllowRules()[teleport.PresetAccessRoleName],
+						GitHubPermissions: []types.GitHubPermission{{
+							Organizations: defaultGitHubOrgs()[teleport.PresetAccessRoleName],
+						}},
 					},
 				},
 			},
@@ -734,6 +746,7 @@ func TestAddRoleDefaults(t *testing.T) {
 							types.NewRule(types.KindDynamicWindowsDesktop, RW()),
 							types.NewRule(types.KindStaticHostUser, RW()),
 							types.NewRule(types.KindWorkloadIdentity, RW()),
+							types.NewRule(types.KindGitServer, RW()),
 						},
 					},
 				},

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -511,6 +511,12 @@ func ApplyTraits(r types.Role, traits map[string][]string) (types.Role, error) {
 		outDbRoles := applyValueTraitsSlice(inDbRoles, traits, "database role")
 		r.SetDatabaseRoles(condition, apiutils.Deduplicate(outDbRoles))
 
+		githubPermissions := r.GetGitHubPermissions(condition)
+		for i, perm := range githubPermissions {
+			githubPermissions[i].Organizations = applyValueTraitsSlice(perm.Organizations, traits, "github organizations")
+		}
+		r.SetGitHubPermissions(condition, githubPermissions)
+
 		var out []types.KubernetesResource
 		// we access the resources in the role using the role conditions
 		// to avoid receiving the compatibility resources added in GetKubernetesResources
@@ -677,7 +683,8 @@ func ApplyValueTraits(val string, traits map[string][]string) ([]string, error) 
 				constants.TraitKubeGroups, constants.TraitKubeUsers,
 				constants.TraitDBNames, constants.TraitDBUsers, constants.TraitDBRoles,
 				constants.TraitAWSRoleARNs, constants.TraitAzureIdentities,
-				constants.TraitGCPServiceAccounts, constants.TraitJWT:
+				constants.TraitGCPServiceAccounts, constants.TraitJWT,
+				constants.TraitGitHubOrgs:
 			default:
 				return trace.BadParameter("unsupported variable %q", name)
 			}

--- a/web/packages/teleport/src/Users/UserAddEdit/TraitsEditor.tsx
+++ b/web/packages/teleport/src/Users/UserAddEdit/TraitsEditor.tsx
@@ -42,6 +42,7 @@ const traitsPreset = [
   'kubernetes_users',
   'logins',
   'windows_logins',
+  'github_orgs',
 ];
 
 /**


### PR DESCRIPTION
backport of #51299 to branch v17

changelog: Role presets now include default values for `github_permissions` and the `git_server` resource kind. `github_permissions` now supports traits.