### PR TITLE
Enable `allowReuse` in MFA challenge for auth connectors fetch request

### DIFF
--- a/web/packages/teleport/src/services/api/api.ts
+++ b/web/packages/teleport/src/services/api/api.ts
@@ -28,8 +28,16 @@ import parseError, { ApiError, parseProxyVersion } from './parseError';
 export const MFA_HEADER = 'Teleport-Mfa-Response';
 
 const api = {
-  get(url: string, abortSignal?: AbortSignal) {
-    return api.fetchJsonWithMfaAuthnRetry(url, { signal: abortSignal });
+  get(
+    url: string,
+    abortSignal?: AbortSignal,
+    mfaResponse?: MfaChallengeResponse
+  ) {
+    return api.fetchJsonWithMfaAuthnRetry(
+      url,
+      { signal: abortSignal },
+      mfaResponse
+    );
   },
 
   post(url, data?, abortSignal?, mfaResponse?: MfaChallengeResponse) {


### PR DESCRIPTION
## Purpose

This PR fixes an edge case where if MFA for administrative actions is enabled, and the connector set as default in the cluster's auth preferences doesn't exist, the logic in the backend handler for falling back to using another connector as default would fail because it performs two operations and thus needs the MFA challenge to have `allowReuse` enabled.