### PR TITLE
[v17] Show active tab name in status bar

### DIFF
--- a/web/packages/teleterm/src/services/tshd/testHelpers.ts
+++ b/web/packages/teleterm/src/services/tshd/testHelpers.ts
@@ -245,7 +245,7 @@ export const makeLoggedInUser = (
 export const makeDatabaseGateway = (
   props: Partial<tsh.Gateway> = {}
 ): tsh.Gateway => ({
-  uri: '/gateways/foo',
+  uri: '/gateways/db',
   targetName: 'sales-production',
   targetUri: databaseUri,
   targetUser: 'alice',
@@ -265,7 +265,7 @@ export const makeDatabaseGateway = (
 export const makeKubeGateway = (
   props: Partial<tsh.Gateway> = {}
 ): tsh.Gateway => ({
-  uri: '/gateways/foo',
+  uri: '/gateways/kube',
   targetName: 'foo',
   targetUri: kubeUri,
   targetUser: '',
@@ -285,7 +285,7 @@ export const makeKubeGateway = (
 export const makeAppGateway = (
   props: Partial<tsh.Gateway> = {}
 ): tsh.Gateway => ({
-  uri: '/gateways/bar',
+  uri: '/gateways/app',
   targetName: 'sales-production',
   targetUri: appUri,
   localAddress: 'localhost',

--- a/web/packages/teleterm/src/ui/AppInitializer/AppInitializer.test.tsx
+++ b/web/packages/teleterm/src/ui/AppInitializer/AppInitializer.test.tsx
@@ -147,10 +147,8 @@ test('activating a workspace via deep link overrides the previously active works
   await userEvent.click(dialogSuccessButton);
 
   // Check if the first activated workspace is the one from the deep link.
-  expect(await screen.findByTitle(/Current cluster:/)).toBeVisible();
-  expect(
-    screen.queryByTitle(`Current cluster: ${deepLinkCluster.name}`)
-  ).toBeVisible();
+  const el = await screen.findByTitle(/Open Profiles/);
+  expect(el.title).toContain(deepLinkCluster.name);
 });
 
 test.each<{

--- a/web/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.tsx
@@ -54,7 +54,7 @@ export function DocumentGateway(props: {
 
   const runCliCommand = () => {
     const command = getCliCommandArgv0(gateway.gatewayCliCommand);
-    const title = `${command} · ${doc.targetUser}@${doc.targetName}`;
+    const title = `${command} · ${doc.targetName} (${doc.targetUser})`;
 
     const cliDoc = documentsService.createGatewayCliDocument({
       title,

--- a/web/packages/teleterm/src/ui/StatusBar/ShareFeedback/ShareFeedback.tsx
+++ b/web/packages/teleterm/src/ui/StatusBar/ShareFeedback/ShareFeedback.tsx
@@ -50,7 +50,7 @@ export function ShareFeedback() {
         onClick={openShareFeedback}
       >
         {!hasBeenShareFeedbackOpened && <NotOpenedYetIndicator />}
-        <ChatBubble size="small" mb={1} />
+        <ChatBubble size="small" />
       </ButtonIcon>
       <Popover
         open={isShareFeedbackOpened}

--- a/web/packages/teleterm/src/ui/StatusBar/StatusBar.tsx
+++ b/web/packages/teleterm/src/ui/StatusBar/StatusBar.tsx
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { Fragment } from 'react';
+
 import { Flex, Text } from 'design';
 
 import { AccessRequestCheckoutButton } from './AccessRequestCheckoutButton';
@@ -23,7 +25,7 @@ import { ShareFeedback } from './ShareFeedback';
 import { useActiveDocumentClusterBreadcrumbs } from './useActiveDocumentClusterBreadcrumbs';
 
 export function StatusBar() {
-  const clusterBreadcrumbs = useActiveDocumentClusterBreadcrumbs();
+  const breadcrumbs = useActiveDocumentClusterBreadcrumbs();
 
   return (
     <Flex
@@ -35,18 +37,46 @@ export function StatusBar() {
       alignItems="center"
       justifyContent="space-between"
       px={2}
+      gap={2}
+      color="text.slightlyMuted"
       overflow="hidden"
     >
-      <Text
-        color="text.slightlyMuted"
-        fontSize="14px"
+      <Flex
         css={`
-          white-space: nowrap;
+          // If the breadcrumbs are wider than the available space,
+          // allow scrolling them horizontally, but do not show the scrollbar.
+          width: 100%;
+          overflow: scroll;
+
+          &::-webkit-scrollbar {
+            display: none;
+          }
         `}
-        title={clusterBreadcrumbs && `Current cluster: ${clusterBreadcrumbs}`}
       >
-        {clusterBreadcrumbs}
-      </Text>
+        {breadcrumbs && (
+          <Flex
+            gap={2}
+            css={`
+              flex-shrink: 0;
+              font-size: 13px;
+            `}
+            title={breadcrumbs.map(({ name }) => name).join(' → ')}
+          >
+            {breadcrumbs.map((breadcrumb, index) => (
+              <Fragment key={`${index}-${breadcrumb.name}`}>
+                {breadcrumb.Icon && (
+                  <breadcrumb.Icon color="text.muted" size="small" mr={-1} />
+                )}
+                <Text>{breadcrumb.name}</Text>
+                {index !== breadcrumbs.length - 1 && (
+                  <Text color="text.disabled">→</Text>
+                )}
+              </Fragment>
+            ))}
+          </Flex>
+        )}
+      </Flex>
+
       <Flex gap={2} alignItems="center">
         <AccessRequestCheckoutButton />
         <ShareFeedback />

--- a/web/packages/teleterm/src/ui/StatusBar/useActiveDocumentClusterBreadcrumbs.ts
+++ b/web/packages/teleterm/src/ui/StatusBar/useActiveDocumentClusterBreadcrumbs.ts
@@ -16,42 +16,57 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useAppContext } from 'teleterm/ui/appContextProvider';
+import { ComponentType, useCallback } from 'react';
+
+import { IconProps } from 'design/Icon/Icon';
+
 import {
   getResourceUri,
-  useWorkspaceServiceState,
+  getStaticNameAndIcon,
 } from 'teleterm/ui/services/workspacesService';
 import { routing } from 'teleterm/ui/uri';
 
-export function useActiveDocumentClusterBreadcrumbs(): string {
-  const ctx = useAppContext();
-  useWorkspaceServiceState();
-  ctx.clustersService.useState();
+import { useStoreSelector } from '../hooks/useStoreSelector';
 
-  const activeDocument = ctx.workspacesService
-    .getActiveWorkspaceDocumentService()
-    ?.getActive();
+interface Breadcrumb {
+  name: string;
+  Icon?: ComponentType<IconProps>;
+}
 
-  if (!activeDocument) {
+export function useActiveDocumentClusterBreadcrumbs(): Breadcrumb[] {
+  const activeDocument = useStoreSelector(
+    'workspacesService',
+    useCallback(state => {
+      const workspace = state.workspaces[state.rootClusterUri];
+      return workspace?.documents.find(d => d.uri === workspace?.location);
+    }, [])
+  );
+  const resourceUri = activeDocument && getResourceUri(activeDocument);
+  const staticNameAndIcon =
+    activeDocument && getStaticNameAndIcon(activeDocument);
+  const clusterUri = resourceUri && routing.ensureClusterUri(resourceUri);
+  const rootClusterUri =
+    resourceUri && routing.ensureRootClusterUri(resourceUri);
+
+  const cluster = useStoreSelector(
+    'clustersService',
+    useCallback(state => state.clusters.get(clusterUri), [clusterUri])
+  );
+  const rootCluster = useStoreSelector(
+    'clustersService',
+    useCallback(state => state.clusters.get(rootClusterUri), [rootClusterUri])
+  );
+
+  if (!cluster || !rootCluster || !staticNameAndIcon) {
     return;
   }
 
-  const resourceUri = getResourceUri(activeDocument);
-  if (!resourceUri) {
-    return;
-  }
-
-  const clusterUri = routing.ensureClusterUri(resourceUri);
-  const rootClusterUri = routing.ensureRootClusterUri(resourceUri);
-
-  const rootCluster = ctx.clustersService.findCluster(rootClusterUri);
-  const leafCluster =
-    clusterUri === rootClusterUri
-      ? undefined
-      : ctx.clustersService.findCluster(clusterUri);
-
-  return [rootCluster, leafCluster]
-    .filter(Boolean)
-    .map(c => c.name)
-    .join(' > ');
+  return [
+    { name: rootCluster.name },
+    clusterUri !== rootClusterUri && { name: cluster.name },
+    {
+      name: staticNameAndIcon.name,
+      Icon: staticNameAndIcon.Icon,
+    },
+  ].filter(Boolean);
 }

--- a/web/packages/teleterm/src/ui/TabHost/TabHost.story.tsx
+++ b/web/packages/teleterm/src/ui/TabHost/TabHost.story.tsx
@@ -1,0 +1,73 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Meta } from '@storybook/react';
+import { createRef } from 'react';
+
+import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
+import { ResourcesContextProvider } from 'teleterm/ui/DocumentCluster/resourcesContext';
+import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
+import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
+import { Document } from 'teleterm/ui/services/workspacesService';
+import {
+  makeDocumentAccessRequests,
+  makeDocumentAuthorizeWebSession,
+  makeDocumentCluster,
+  makeDocumentConnectMyComputer,
+  makeDocumentGatewayApp,
+  makeDocumentGatewayCliClient,
+  makeDocumentGatewayDatabase,
+  makeDocumentGatewayKube,
+  makeDocumentPtySession,
+  makeDocumentTshNode,
+} from 'teleterm/ui/services/workspacesService/documentsService/testHelpers';
+
+import { TabHostContainer } from './TabHost';
+
+const meta: Meta = {
+  title: 'Teleterm/TabHost',
+};
+
+export default meta;
+
+const allDocuments: Document[] = [
+  makeDocumentCluster(),
+  makeDocumentTshNode(),
+  makeDocumentConnectMyComputer(),
+  makeDocumentGatewayDatabase(),
+  makeDocumentGatewayApp(),
+  makeDocumentGatewayCliClient(),
+  makeDocumentGatewayKube(),
+  makeDocumentAccessRequests(),
+  makeDocumentPtySession(),
+  makeDocumentAuthorizeWebSession(),
+];
+
+const cluster = makeRootCluster();
+
+export function Story() {
+  const ctx = new MockAppContext();
+  ctx.addRootClusterWithDoc(cluster, allDocuments);
+  return (
+    <MockAppContextProvider appContext={ctx}>
+      <ResourcesContextProvider>
+        <TabHostContainer topBarContainerRef={createRef()} />
+      </ResourcesContextProvider>
+    </MockAppContextProvider>
+  );
+}

--- a/web/packages/teleterm/src/ui/Tabs/TabItem.tsx
+++ b/web/packages/teleterm/src/ui/Tabs/TabItem.tsx
@@ -16,11 +16,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useRef } from 'react';
+import { ComponentType, useRef } from 'react';
 import styled from 'styled-components';
 
 import { ButtonIcon, Text } from 'design';
 import * as Icons from 'design/Icon';
+import { IconProps } from 'design/Icon/Icon';
 
 import { LinearProgress } from 'teleterm/ui/components/LinearProgress';
 
@@ -29,6 +30,7 @@ import { useTabDnD } from './useTabDnD';
 type TabItemProps = {
   index?: number;
   name?: string;
+  Icon?: ComponentType<IconProps>;
   active?: boolean;
   nextActive?: boolean;
   closeTabTooltip?: string;
@@ -75,24 +77,21 @@ export function TabItem(props: TabItemProps) {
         min-width: 0;
       `}
     >
-      <TabContent
-        ref={ref}
-        active={active}
-        dragging={isDragging}
-        canDrag={canDrag}
-        title={name}
-      >
-        <Title color="inherit" fontWeight={700} fontSize="12px">
+      <TabContent ref={ref} active={active} dragging={isDragging} title={name}>
+        {props.Icon && <props.Icon size="small" pr={1} />}
+        <Title color="inherit" fontWeight={500} fontSize="12px">
           {name}
         </Title>
         {isLoading && active && <LinearProgress transparentBackground={true} />}
         {onClose && (
           <ButtonIcon
+            active={active}
             size={0}
-            mr={1}
+            className="close"
             title={closeTabTooltip}
             css={`
               transition: none;
+              display: ${props => (props.active ? 'flex' : 'none')};
             `}
             onClick={handleClose}
           >
@@ -115,13 +114,7 @@ export function NewTabItem(props: NewTabItemProps) {
   return (
     <RelativeContainer>
       <TabContent active={false}>
-        <ButtonIcon
-          ml="1"
-          mr="2"
-          size={0}
-          title={props.tooltip}
-          onClick={props.onClick}
-        >
+        <ButtonIcon size={0} title={props.tooltip} onClick={props.onClick}>
           <Icons.Add size="small" />
         </ButtonIcon>
       </TabContent>
@@ -141,8 +134,6 @@ const RelativeContainer = styled.div`
 const TabContent = styled.div<{
   dragging?: boolean;
   active?: boolean;
-  // TODO(bl-nero): is this really used? Perhaps remove it.
-  canDrag?: boolean;
 }>`
   display: flex;
   z-index: 1; // covers shadow from the top
@@ -150,6 +141,8 @@ const TabContent = styled.div<{
   min-width: 0;
   width: 100%;
   height: 100%;
+  cursor: pointer;
+  padding-inline: 6px 4px;
   border-radius: 8px 8px 0 0;
   position: relative;
   opacity: ${props => (props.dragging ? 0 : 1)};
@@ -168,21 +161,15 @@ const TabContent = styled.div<{
   &:focus {
     color: ${props => props.theme.colors.text.main};
     transition: color 0.3s;
+
+    > .close {
+      display: flex;
+    }
   }
 `;
 
 const Title = styled(Text)`
-  display: block;
-  cursor: pointer;
-  outline: none;
-  color: inherit;
-  font-family: inherit;
-  line-height: 32px;
-  background-color: transparent;
   white-space: nowrap;
-  padding-left: 12px;
-  border: none;
-  min-width: 0;
   width: 100%;
 `;
 

--- a/web/packages/teleterm/src/ui/Tabs/Tabs.tsx
+++ b/web/packages/teleterm/src/ui/Tabs/Tabs.tsx
@@ -22,7 +22,10 @@ import { Box } from 'design';
 import { typography } from 'design/system';
 import { TypographyProps } from 'design/system/typography';
 
-import { Document } from 'teleterm/ui/services/workspacesService';
+import {
+  Document,
+  getStaticNameAndIcon,
+} from 'teleterm/ui/services/workspacesService';
 
 import { NewTabItem, TabItem } from './TabItem';
 
@@ -50,6 +53,7 @@ export function Tabs(props: Props) {
           index={index}
           name={item.title}
           active={active}
+          Icon={getStaticNameAndIcon(item)?.Icon}
           nextActive={nextActive}
           onClick={() => onSelect(item)}
           onClose={() => onClose(item)}

--- a/web/packages/teleterm/src/ui/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/ui/fixtures/mocks.ts
@@ -45,17 +45,24 @@ export class MockAppContext extends AppContext {
     });
   }
 
-  addRootClusterWithDoc(cluster: Cluster, doc: Document | undefined) {
+  addRootClusterWithDoc(
+    cluster: Cluster,
+    doc: Document[] | Document | undefined
+  ) {
     this.clustersService.setState(draftState => {
       draftState.clusters.set(cluster.uri, cluster);
     });
+    const docs = Array.isArray(doc) ? doc : [doc];
     this.workspacesService.setState(draftState => {
       draftState.rootClusterUri = cluster.uri;
       draftState.workspaces[cluster.uri] = {
-        documents: [doc].filter(Boolean),
-        location: doc?.uri,
+        documents: docs.filter(Boolean),
+        location: docs[0]?.uri,
         localClusterUri: cluster.uri,
-        accessRequests: undefined,
+        accessRequests: {
+          isBarCollapsed: true,
+          pending: { kind: 'role', roles: new Set<string>() },
+        },
       };
     });
   }

--- a/web/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.ts
+++ b/web/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.ts
@@ -265,6 +265,11 @@ export class ConnectionTrackerService extends ImmutableStore<ConnectionTrackerSt
               const newItem = createGatewayConnection(doc);
               draft.connections.push(newItem);
             } else {
+              // In case the document changes, update the gateway title.
+              // Specifically, it addresses a case where we changed a title format
+              // for db gateway documents, and we wanted this change to be reflected
+              // in already created connections.
+              gwConn.title = doc.title;
               gwConn.targetSubresourceName = doc.targetSubresourceName;
               gwConn.port = doc.port;
               gwConn.connected = !!this._clusterService.findGateway(

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsUtils.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsUtils.ts
@@ -16,6 +16,21 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { ComponentType } from 'react';
+
+import {
+  Application,
+  Database,
+  Kubernetes,
+  Laptop,
+  ListAddCheck,
+  Server,
+  ShieldCheck,
+  Table,
+  Terminal,
+} from 'design/Icon';
+import { IconProps } from 'design/Icon/Icon';
+
 import {
   ClusterOrResourceUri,
   isAppUri,
@@ -100,7 +115,7 @@ export function getDocumentGatewayTitle(doc: DocumentGateway): string {
 
   switch (targetKind) {
     case 'db': {
-      return targetUser ? `${targetUser}@${targetName}` : targetName;
+      return targetUser ? `${targetName} (${targetUser})` : targetName;
     }
     case 'app': {
       return targetSubresourceName
@@ -110,5 +125,81 @@ export function getDocumentGatewayTitle(doc: DocumentGateway): string {
     default: {
       targetKind satisfies never;
     }
+  }
+}
+
+/**
+ * Returns a name and icon of the document.
+ * If possible, the name is the title of a document, except for cases
+ * when it contains some additional values like cwd, or a shell name.
+ * At the moment, the name is used only in the status bar.
+ * The icon is used both in the status bar and the tabs.
+ */
+export function getStaticNameAndIcon(
+  document: Document
+): { name: string; Icon: ComponentType<IconProps> } | undefined {
+  switch (document.kind) {
+    case 'doc.cluster':
+      return {
+        name: 'Resources',
+        Icon: Table,
+      };
+    case 'doc.gateway_cli_client':
+      return {
+        name: document.title,
+        Icon: Database,
+      };
+    case 'doc.gateway':
+      if (isDatabaseUri(document.targetUri)) {
+        return {
+          name: document.title,
+          Icon: Database,
+        };
+      }
+      if (isAppUri(document.targetUri)) {
+        return {
+          name: document.title,
+          Icon: Application,
+        };
+      }
+      return;
+    case 'doc.gateway_kube':
+      return {
+        name: routing.parseKubeUri(document.targetUri).params.kubeId,
+        Icon: Kubernetes,
+      };
+    case 'doc.terminal_tsh_node':
+      return isDocumentTshNodeWithServerId(document)
+        ? {
+            name: document.title,
+            Icon: Server,
+          }
+        : undefined;
+    case 'doc.access_requests':
+      return {
+        name: document.title,
+        Icon: ListAddCheck,
+      };
+    case 'doc.terminal_shell':
+      return {
+        name: 'Terminal',
+        Icon: Terminal,
+      };
+    case 'doc.connect_my_computer':
+      return {
+        name: document.title,
+        Icon: Laptop,
+      };
+    case 'doc.authorize_web_session':
+      return {
+        name: document.title,
+        Icon: ShieldCheck,
+      };
+    case 'doc.blank':
+    case 'doc.terminal_tsh_kube':
+      return undefined;
+    default:
+      document satisfies never;
+      return undefined;
   }
 }

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/testHelpers.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/testHelpers.ts
@@ -16,16 +16,32 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
+import {
+  makeAppGateway,
+  makeDatabaseGateway,
+  makeKubeGateway,
+  makeRootCluster,
+  makeServer,
+} from 'teleterm/services/tshd/testHelpers';
 
-import { DocumentCluster } from './types';
+import {
+  DocumentAccessRequests,
+  DocumentAuthorizeWebSession,
+  DocumentCluster,
+  DocumentConnectMyComputer,
+  DocumentGateway,
+  DocumentGatewayCliClient,
+  DocumentGatewayKube,
+  DocumentPtySession,
+  DocumentTshNodeWithServerId,
+} from './types';
 
 export function makeDocumentCluster(
   props?: Partial<DocumentCluster>
 ): DocumentCluster {
   return {
     kind: 'doc.cluster',
-    uri: '/docs/unique-uri',
+    uri: '/docs/cluster',
     title: 'teleport-ent.asteroid.earth',
     clusterUri: makeRootCluster().uri,
     queryParams: {
@@ -36,6 +52,156 @@ export function makeDocumentCluster(
       resourceKinds: [],
       search: '',
       advancedSearchEnabled: false,
+    },
+    ...props,
+  };
+}
+
+export function makeDocumentGatewayDatabase(
+  props?: Partial<DocumentGateway>
+): DocumentGateway {
+  const gw = makeDatabaseGateway();
+  return {
+    kind: 'doc.gateway',
+    uri: '/docs/gateway_database',
+    gatewayUri: '/gateways/db-gateway',
+    title: 'aurora (sre)',
+    targetUri: gw.targetUri,
+    port: gw.localPort,
+    targetName: gw.targetName,
+    targetUser: gw.targetUser,
+    status: '',
+    targetSubresourceName: gw.targetSubresourceName,
+    origin: 'connection_list',
+    ...props,
+  };
+}
+
+export function makeDocumentGatewayApp(
+  props?: Partial<DocumentGateway>
+): DocumentGateway {
+  const gw = makeAppGateway();
+  return {
+    kind: 'doc.gateway',
+    uri: '/docs/gateway_app',
+    title: 'grafana',
+    targetUri: gw.targetUri,
+    gatewayUri: gw.uri,
+    port: gw.localPort,
+    targetName: gw.targetName,
+    targetUser: gw.targetUser,
+    status: '',
+    targetSubresourceName: gw.targetSubresourceName,
+    origin: 'connection_list',
+    ...props,
+  };
+}
+
+export function makeDocumentPtySession(
+  props?: Partial<DocumentPtySession>
+): DocumentPtySession {
+  return {
+    kind: 'doc.terminal_shell',
+    uri: '/docs/terminal_shell',
+    title: '/Users/alice/Documents',
+    rootClusterId: 'teleport-local',
+    ...props,
+  };
+}
+
+export function makeDocumentTshNode(
+  props?: Partial<DocumentTshNodeWithServerId>
+): DocumentTshNodeWithServerId {
+  return {
+    kind: 'doc.terminal_tsh_node',
+    uri: '/docs/terminal_tsh_node',
+    title: 'alice@node',
+    serverUri: makeServer().uri,
+    status: '',
+    rootClusterId: 'teleport-local',
+    leafClusterId: '',
+    origin: 'connection_list',
+    serverId: '1234abcd-1234-abcd-1234-abcd1234abcd',
+    ...props,
+  };
+}
+
+export function makeDocumentGatewayCliClient(
+  props?: Partial<DocumentGatewayCliClient>
+): DocumentGatewayCliClient {
+  const gw = makeDatabaseGateway();
+  return {
+    kind: 'doc.gateway_cli_client',
+    uri: '/docs/gateway_cli_client',
+    title: 'psql · aurora (sre)',
+    rootClusterId: 'teleport-local',
+    leafClusterId: '',
+    targetProtocol: gw.protocol,
+    targetUri: gw.targetUri,
+    targetName: gw.targetName,
+    targetUser: gw.targetUser,
+    status: '',
+    ...props,
+  };
+}
+
+export function makeDocumentGatewayKube(
+  props?: Partial<DocumentGatewayKube>
+): DocumentGatewayKube {
+  const gw = makeKubeGateway();
+  return {
+    kind: 'doc.gateway_kube',
+    uri: '/docs/gateway_kube',
+    title: 'cookie',
+    rootClusterId: 'teleport-local',
+    leafClusterId: '',
+    targetUri: gw.targetUri,
+    status: '',
+    origin: 'connection_list',
+    ...props,
+  };
+}
+
+export function makeDocumentAccessRequests(
+  props?: Partial<DocumentAccessRequests>
+): DocumentAccessRequests {
+  return {
+    kind: 'doc.access_requests',
+    uri: '/docs/access_requests',
+    title: 'Access Requests',
+    clusterUri: makeRootCluster().uri,
+    state: 'browsing',
+    requestId: '1231',
+    ...props,
+  };
+}
+
+export function makeDocumentConnectMyComputer(
+  props?: Partial<DocumentConnectMyComputer>
+): DocumentConnectMyComputer {
+  return {
+    kind: 'doc.connect_my_computer',
+    uri: '/docs/connect-my-computer',
+    rootClusterUri: makeRootCluster().uri,
+    status: '',
+    title: 'Connect My Computer',
+    ...props,
+  };
+}
+
+export function makeDocumentAuthorizeWebSession(
+  props?: Partial<DocumentAuthorizeWebSession>
+): DocumentAuthorizeWebSession {
+  return {
+    kind: 'doc.authorize_web_session',
+    uri: '/docs/authorize-web-session',
+    title: 'Authorize Web Session',
+    rootClusterUri: makeRootCluster().uri,
+    webSessionRequest: {
+      id: '123',
+      username: 'alice',
+      token: 'secret-token',
+      redirectUri: '',
     },
     ...props,
   };

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
@@ -288,6 +288,10 @@ export type Document =
   | DocumentConnectMyComputer
   | DocumentAuthorizeWebSession;
 
+/**
+ * @deprecated DocumentTshNode is supposed to be simplified to just DocumentTshNodeWithServerId.
+ * See the comment for DocumentTshNodeWithLoginHost for more details.
+ */
 export function isDocumentTshNodeWithLoginHost(
   doc: Document
 ): doc is DocumentTshNodeWithLoginHost {
@@ -296,6 +300,10 @@ export function isDocumentTshNodeWithLoginHost(
   return doc.kind === 'doc.terminal_tsh_node' && !('serverId' in doc);
 }
 
+/**
+ * @deprecated DocumentTshNode is supposed to be simplified to just DocumentTshNodeWithServerId.
+ * See the comment for DocumentTshNodeWithLoginHost for more details.
+ */
 export function isDocumentTshNodeWithServerId(
   doc: Document
 ): doc is DocumentTshNodeWithServerId {


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/51108 to branch/v17

changelog: Teleport Connect now shows a resource name in the status bar