### PR TITLE
Fix Proxy web server middleware order

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4984,9 +4984,9 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			Server: &http.Server{
 				Handler: utils.ChainHTTPMiddlewares(
 					webHandler,
-					makeXForwardedForMiddleware(cfg),
 					limiter.MakeMiddleware(proxyLimiter),
 					httplib.MakeTracingMiddleware(teleport.ComponentProxy),
+					makeXForwardedForMiddleware(cfg),
 				),
 				// Note: read/write timeouts *should not* be set here because it
 				// will break some application access use-cases.


### PR DESCRIPTION
The limiter middleware was being executed prior to the middleware responsible updating the client IP from X-Forwarded-For headers. This results in erroneously enforcing connection limits in NAT environments.


changelog: Fix an issue that prevented IPs provided in the X-Forwarded-For header from being honored in some scenarios when TrustXForwardedFor is enabled.