### PR TITLE
Switch `tctl top` to use charmbracelet/bubbletea

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -105,7 +105,6 @@ require (
 	github.com/fsouza/fake-gcs-server v1.51.0
 	github.com/fxamacker/cbor/v2 v2.7.0
 	github.com/ghodss/yaml v1.0.0
-	github.com/gizak/termui/v3 v3.1.0
 	github.com/go-git/go-git/v5 v5.13.1
 	github.com/go-jose/go-jose/v3 v3.0.3
 	github.com/go-ldap/ldap/v3 v3.4.10
@@ -464,7 +463,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481 // indirect
-	github.com/nsf/termbox-go v1.1.1 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/onsi/ginkgo/v2 v2.19.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1238,8 +1238,6 @@ github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uq
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/gizak/termui/v3 v3.1.0 h1:ZZmVDgwHl7gR7elfKf1xc4IudXZ5qqfDh4wExk4Iajc=
-github.com/gizak/termui/v3 v3.1.0/go.mod h1:bXQEBkJpzxUAKf0+xq9MSWAvWZlE7c+aidmyFlkYTrY=
 github.com/go-asn1-ber/asn1-ber v1.5.7 h1:DTX+lbVTWaTw1hQ+PbZPlnDZPEIs0SS/GCZAl535dDk=
 github.com/go-asn1-ber/asn1-ber v1.5.7/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-chi/chi v4.1.2+incompatible h1:fGFk2Gmi/YKXk0OmGfBh0WgmN3XB8lVnEyNz34tQRec=
@@ -1840,7 +1838,6 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-localereader v0.0.1 h1:ygSAOl7ZXTx4RdPYinUpg6W99U8jWvWi9Ye2JC/oIi4=
 github.com/mattn/go-localereader v0.0.1/go.mod h1:8fBrzywKY7BI3czFoHkuzRoWE9C+EiG4R1k4Cjx5p88=
-github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
@@ -1872,7 +1869,6 @@ github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa1
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
-github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
@@ -1925,9 +1921,6 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481 h1:Up6+btDp321ZG5/zdSLo48H9Iaq0UQGthrhWC6pCxzE=
 github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481/go.mod h1:yKZQO8QE2bHlgozqWDiRVqTFlLQSj30K/6SAK8EeYFw=
-github.com/nsf/termbox-go v0.0.0-20190121233118-02980233997d/go.mod h1:IuKpRQcYE1Tfu+oAQqaLisqDeXgjyyltCfsaoYN18NQ=
-github.com/nsf/termbox-go v1.1.1 h1:nksUPLCb73Q++DwbYUBEglYBRPZyoXJdrj5L+TkjyZY=
-github.com/nsf/termbox-go v1.1.1/go.mod h1:T0cTdVuOwf7pHQNtfhnEbzHbcNyCEcVU4YPpouCbVxo=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/nxadm/tail v1.4.11 h1:8feyoE3OzPrcshW5/MJ4sGESc5cqmGkGCWlco4l0bqY=

--- a/tool/tctl/common/cmds.go
+++ b/tool/tctl/common/cmds.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gravitational/teleport/tool/tctl/common/accessmonitoring"
 	"github.com/gravitational/teleport/tool/tctl/common/loginrule"
 	"github.com/gravitational/teleport/tool/tctl/common/plugin"
+	"github.com/gravitational/teleport/tool/tctl/common/top"
 	"github.com/gravitational/teleport/tool/tctl/sso/configure"
 	"github.com/gravitational/teleport/tool/tctl/sso/tester"
 )
@@ -35,7 +36,7 @@ func Commands() []CLICommand {
 		&TokensCommand{},
 		&AuthCommand{},
 		&StatusCommand{},
-		&TopCommand{},
+		&top.Command{},
 		&AccessRequestCommand{},
 		&AppsCommand{},
 		&DBCommand{},

--- a/tool/tctl/common/top/box.go
+++ b/tool/tctl/common/top/box.go
@@ -1,0 +1,66 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package top
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// boxedView wraps the provided content in a rounded border,
+// with the title embedded in the top. For example, if the
+// content was \t\t\tHello and the title was Some Heading the
+// returned content would be:
+//
+// ╭Some Heading────────╮
+// │                    │
+// │            Hello   │
+// ╰────────────────────╯
+func boxedView(title string, content string, width int) string {
+	rounderBorder := lipgloss.RoundedBorder()
+
+	const borderCorners = 2
+	width = width - borderCorners
+	availableSpace := width - lipgloss.Width(title)
+
+	var filler string
+	if availableSpace > 0 {
+		filler = strings.Repeat(rounderBorder.Top, availableSpace)
+	}
+
+	titleContent := lipgloss.NewStyle().
+		Foreground(selectedColor).
+		Render(title)
+
+	renderedTitle := rounderBorder.TopLeft + titleContent + filler + rounderBorder.TopRight
+
+	// empty out the top border since it
+	// is already manually applied to the title.
+	rounderBorder.TopLeft = ""
+	rounderBorder.Top = ""
+	rounderBorder.TopRight = ""
+
+	contentStyle := lipgloss.NewStyle().
+		BorderStyle(rounderBorder).
+		PaddingLeft(1).
+		PaddingRight(1).
+		Faint(true).
+		Width(width)
+
+	return renderedTitle + contentStyle.Render(content)
+}

--- a/tool/tctl/common/top/command.go
+++ b/tool/tctl/common/top/command.go
@@ -1,0 +1,70 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package top
+
+import (
+	"context"
+	"time"
+
+	"github.com/alecthomas/kingpin/v2"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/gravitational/roundtrip"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/service/servicecfg"
+	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
+	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
+)
+
+// Command is a debug command that consumes the
+// Teleport /metrics endpoint and displays diagnostic
+// information an easy to consume way.
+type Command struct {
+	config        *servicecfg.Config
+	top           *kingpin.CmdClause
+	diagURL       string
+	refreshPeriod time.Duration
+}
+
+// Initialize sets up the "tctl top" command.
+func (c *Command) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags, config *servicecfg.Config) {
+	c.config = config
+	c.top = app.Command("top", "Report diagnostic information.")
+	c.top.Arg("diag-addr", "Diagnostic HTTP URL").Default("http://127.0.0.1:3000").StringVar(&c.diagURL)
+	c.top.Arg("refresh", "Refresh period").Default("5s").DurationVar(&c.refreshPeriod)
+}
+
+// TryRun attempts to run subcommands.
+func (c *Command) TryRun(ctx context.Context, cmd string, _ commonclient.InitFunc) (match bool, err error) {
+	if cmd != c.top.FullCommand() {
+		return false, nil
+	}
+
+	diagClient, err := roundtrip.NewClient(c.diagURL, "")
+	if err != nil {
+		return true, trace.Wrap(err)
+	}
+
+	p := tea.NewProgram(
+		newTopModel(c.refreshPeriod, diagClient),
+		tea.WithAltScreen(),
+		tea.WithContext(ctx),
+	)
+
+	_, err = p.Run()
+	return true, trace.Wrap(err)
+}

--- a/tool/tctl/common/top/model.go
+++ b/tool/tctl/common/top/model.go
@@ -1,0 +1,524 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package top
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/dustin/go-humanize"
+	"github.com/gravitational/roundtrip"
+	"github.com/gravitational/trace"
+	"github.com/guptarohit/asciigraph"
+
+	"github.com/gravitational/teleport/api/constants"
+)
+
+// topModel is a [tea.Model] implementation which
+// displays various tabs and content displayed by
+// the tctl top command.
+type topModel struct {
+	width           int
+	height          int
+	selected        int
+	help            help.Model
+	refreshInterval time.Duration
+	clt             *roundtrip.Client
+	report          *Report
+	reportError     error
+}
+
+func newTopModel(refreshInterval time.Duration, clt *roundtrip.Client) *topModel {
+	return &topModel{
+		help:            help.New(),
+		clt:             clt,
+		refreshInterval: refreshInterval,
+	}
+}
+
+// refresh pulls metrics from Teleport and builds
+// a [Report] according to the configured refresh
+// interval.
+func (m *topModel) refresh() tea.Cmd {
+	return func() tea.Msg {
+		if m.report != nil {
+			<-time.After(m.refreshInterval)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		report, err := fetchAndGenerateReport(ctx, m.clt, m.report, m.refreshInterval)
+		if err != nil {
+			return err
+		}
+
+		return report
+	}
+}
+
+// Init is a noop but required to implement [tea.Model].
+func (m *topModel) Init() tea.Cmd {
+	return m.refresh()
+}
+
+// Update processes messages in order to updated the
+// view based on user input and new metrics data.
+func (m *topModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		h, v := lipgloss.NewStyle().GetFrameSize()
+		m.height = msg.Height - v
+		m.width = msg.Width - h
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "q", "ctrl+c":
+			return m, tea.Quit
+		case "1":
+			m.selected = 0
+		case "2":
+			m.selected = 1
+		case "3":
+			m.selected = 2
+		case "4":
+			m.selected = 3
+		case "right":
+			m.selected = min(m.selected+1, len(tabs)-1)
+		case "left":
+			m.selected = max(m.selected-1, 0)
+		}
+	case *Report:
+		m.report = msg
+		m.reportError = nil
+		return m, m.refresh()
+	case error:
+		m.reportError = msg
+		return m, m.refresh()
+	}
+	return m, nil
+}
+
+// View formats the metrics and draws them to
+// the screen.
+func (m *topModel) View() string {
+	availableHeight := m.height
+	header := headerView(m.selected, m.width)
+	availableHeight -= lipgloss.Height(header)
+
+	footer := m.footerView()
+	availableHeight -= lipgloss.Height(footer)
+
+	content := lipgloss.NewStyle().
+		Height(availableHeight).
+		Width(m.width).
+		Render(m.contentView())
+
+	return lipgloss.JoinVertical(lipgloss.Left,
+		header,
+		content,
+		footer,
+	)
+}
+
+// headerView generates the tab bar displayed at
+// the top of the screen. The selectedTab will be
+// rendered a different color to indicate as such.
+func headerView(selectedTab int, width int) string {
+	tabs := tabView(selectedTab)
+
+	availableSpace := width - lipgloss.Width(tabs)
+
+	var filler string
+	if availableSpace > 0 {
+		filler = strings.Repeat(" ", availableSpace)
+	}
+
+	return tabs + lipgloss.NewStyle().Render(filler) + "\n" + strings.Repeat("‾", width)
+}
+
+// footerView generates the help text displayed at the
+// bottom of the screen.
+func (m *topModel) footerView() string {
+	underscore := lipgloss.NewStyle().Underline(true).Render(" ")
+	underline := strings.Repeat(underscore, m.width)
+
+	var leftContent string
+
+	if m.reportError != nil {
+		if trace.IsConnectionProblem(m.reportError) {
+			leftContent = fmt.Sprintf("Could not connect to metrics service: %v", m.clt.Endpoint())
+		} else {
+			leftContent = fmt.Sprintf("Failed to generate report: %v", m.reportError)
+		}
+	}
+	if leftContent == "" && m.report != nil {
+		leftContent = fmt.Sprintf("Report generated at %s for host %s",
+			m.report.Timestamp.Format(constants.HumanDateFormatSeconds),
+			m.report.Hostname,
+		)
+	}
+	left := lipgloss.NewStyle().
+		Inline(true).
+		Width(len(leftContent)).
+		MaxWidth(100).
+		Render(leftContent)
+
+	right := lipgloss.NewStyle().
+		Inline(true).
+		Width(35).
+		Align(lipgloss.Center).
+		Render(m.help.View(helpKeys))
+
+	center := lipgloss.NewStyle().
+		Inline(true).
+		Width(m.width - len(leftContent) - 35).
+		Align(lipgloss.Center).
+		Render("")
+
+	return underline + "\n" +
+		statusBarStyle.Render(left) +
+		statusBarStyle.Render(center) +
+		statusBarStyle.Render(right)
+}
+
+// contentView generates the appropriate content
+// based on which tab is selected.
+func (m *topModel) contentView() string {
+	if m.report == nil {
+		return ""
+	}
+
+	switch m.selected {
+	case 0:
+		return renderCommon(m.report, m.width)
+	case 1:
+		return renderBackend(m.report, m.height, m.width)
+	case 2:
+		return renderCache(m.report, m.height, m.width)
+	case 3:
+		return renderWatcher(m.report, m.height, m.width)
+	default:
+		return ""
+	}
+}
+
+// renderCommon generates the view for the cluster stats tab.
+func renderCommon(report *Report, width int) string {
+	columnWidth := width / 2
+
+	clusterTable := tableView(
+		columnWidth,
+		column{
+			width: width / 3,
+			content: []string{
+				"Interactive Sessions",
+				"Cert Gen Active Requests",
+				"Cert Gen Requests/sec",
+				"Cert Gen Throttled Requests/sec",
+				"Auth Watcher Queue Size",
+				"Roles",
+				"Active Migrations",
+			},
+		},
+		column{
+			width: columnWidth / 3,
+			content: []string{
+				humanize.FormatFloat("", report.Cluster.InteractiveSessions),
+				humanize.FormatFloat("", report.Cluster.GenerateRequests),
+				humanize.FormatFloat("", report.Cluster.GenerateRequestsCount.GetFreq()),
+				humanize.FormatFloat("", report.Cluster.GenerateRequestsThrottledCount.GetFreq()),
+				humanize.FormatFloat("", report.Cache.QueueSize),
+				humanize.FormatFloat("", report.Cluster.Roles),
+				cmp.Or(strings.Join(report.Cluster.ActiveMigrations, ", "), "None"),
+			},
+		},
+	)
+	clusterContent := boxedView("Cluster Stats", clusterTable, columnWidth)
+
+	processTable := tableView(
+		columnWidth,
+		column{
+			width: columnWidth * 4 / 10,
+			content: []string{
+				"Start Time",
+				"Resident Memory",
+				"CPU Seconds Total",
+				"Open FDs",
+				"Max FDs",
+			},
+		},
+		column{
+			width: columnWidth * 6 / 10,
+			content: []string{
+				report.Process.StartTime.Format(constants.HumanDateFormatSeconds),
+				humanize.Bytes(uint64(report.Process.ResidentMemoryBytes)),
+				humanize.FormatFloat("", report.Process.CPUSecondsTotal),
+				humanize.FormatFloat("", report.Process.OpenFDs),
+				humanize.FormatFloat("", report.Process.MaxFDs),
+			},
+		},
+	)
+	processContent := boxedView("Process Stats", processTable, columnWidth)
+
+	runtimeTable := tableView(
+		columnWidth,
+		column{
+			width: columnWidth / 2,
+			content: []string{
+				"Allocated Memory",
+				"Goroutines",
+				"Threads",
+				"Heap Objects",
+				"Heap Allocated Memory",
+				"Info",
+			},
+		},
+		column{
+			width: columnWidth / 2,
+			content: []string{
+				humanize.Bytes(uint64(report.Go.AllocBytes)),
+				humanize.FormatFloat("", report.Go.Goroutines),
+				humanize.FormatFloat("", report.Go.Threads),
+				humanize.FormatFloat("", report.Go.HeapObjects),
+				humanize.Bytes(uint64(report.Go.HeapAllocBytes)),
+				report.Go.Info,
+			},
+		},
+	)
+	runtimeContent := boxedView("Go Runtime Stats", runtimeTable, columnWidth)
+
+	certLatencyContent := boxedView("Generate Server Certificates Percentiles", "No data", columnWidth)
+
+	style := lipgloss.NewStyle().
+		Width(columnWidth).
+		Padding(0).
+		Margin(0).
+		Align(lipgloss.Left)
+
+	return lipgloss.JoinHorizontal(lipgloss.Left,
+		style.Render(
+			lipgloss.JoinVertical(lipgloss.Left,
+				clusterContent,
+				processContent,
+				runtimeContent,
+			),
+		),
+		style.Render(certLatencyContent),
+	)
+}
+
+// renderBackend generates the view for the backend stats tab.
+func renderBackend(report *Report, height, width int) string {
+	latencyWidth := width / 3
+	requestsWidth := width * 2 / 3
+	topRequestsContent := boxedView("Top Backend Requests", requestsTableView(height, requestsWidth, report.Backend), requestsWidth)
+	readLatentcyContent := boxedView("Backend Read Percentiles", percentileTableView(latencyWidth, report.Backend.Read), latencyWidth)
+	batchReadLatentyContent := boxedView("Backend Batch Read Percentiles", percentileTableView(latencyWidth, report.Backend.BatchRead), latencyWidth)
+	writeLatencyContent := boxedView("Backend Write Percentiles", percentileTableView(latencyWidth, report.Backend.Write), latencyWidth)
+
+	latencyStyle := lipgloss.NewStyle().
+		Width(latencyWidth).
+		Padding(0).
+		Margin(0).
+		Align(lipgloss.Left)
+
+	requestsStyle := lipgloss.NewStyle().
+		Width(requestsWidth).
+		Padding(0).
+		Margin(0).
+		Align(lipgloss.Left)
+
+	return lipgloss.JoinHorizontal(lipgloss.Left,
+		requestsStyle.Render(topRequestsContent),
+		latencyStyle.Render(
+			lipgloss.JoinVertical(lipgloss.Left,
+				readLatentcyContent,
+				batchReadLatentyContent,
+				writeLatencyContent,
+			),
+		),
+	)
+}
+
+// renderCache generates the view for the cache stats tab.
+func renderCache(report *Report, height, width int) string {
+	latencyWidth := width / 3
+	requestsWidth := width * 2 / 3
+
+	topRequestsContent := boxedView("Top Cache Requests", requestsTableView(height, requestsWidth, report.Cache), requestsWidth)
+	readLatentcyContent := boxedView("Cache Read Percentiles", percentileTableView(latencyWidth, report.Cache.Read), latencyWidth)
+	batchReadLatentyContent := boxedView("Cache Batch Read Percentiles", percentileTableView(latencyWidth, report.Cache.BatchRead), latencyWidth)
+	writeLatencyContent := boxedView("Cache Write Percentiles", percentileTableView(latencyWidth, report.Cache.Write), latencyWidth)
+
+	latencyStyle := lipgloss.NewStyle().
+		Width(latencyWidth).
+		Padding(0).
+		Margin(0).
+		Align(lipgloss.Left)
+
+	requestsStyle := lipgloss.NewStyle().
+		Width(requestsWidth).
+		Padding(0).
+		Margin(0).
+		Align(lipgloss.Left)
+
+	return lipgloss.JoinHorizontal(lipgloss.Left,
+		requestsStyle.Render(topRequestsContent),
+		latencyStyle.Render(
+			lipgloss.JoinVertical(lipgloss.Left,
+				readLatentcyContent,
+				batchReadLatentyContent,
+				writeLatencyContent,
+			),
+		),
+	)
+}
+
+// renderWatcher generates the view for the watcher stats tab.
+func renderWatcher(report *Report, height, width int) string {
+	graphWidth := width * 40 / 100
+	graphHeight := height / 3
+	eventsWidth := width * 60 / 100
+
+	topEventsContent := boxedView("Top Events Emitted", eventsTableView(height, eventsWidth, report.Watcher), eventsWidth)
+
+	dataCount := (graphWidth / 2)
+	eventData := report.Watcher.EventsPerSecond.Data(dataCount)
+	if len(eventData) < 1 {
+		eventData = []float64{0, 0}
+	}
+	countPlot := asciigraph.Plot(
+		eventData,
+		asciigraph.Height(graphHeight),
+		asciigraph.Width(graphWidth-15),
+	)
+	eventCountContent := boxedView("Events/Sec", countPlot, graphWidth)
+
+	sizeData := report.Watcher.BytesPerSecond.Data(dataCount)
+	if len(sizeData) < 1 {
+		sizeData = []float64{0, 0}
+	}
+	sizePlot := asciigraph.Plot(
+		sizeData,
+		asciigraph.Height(graphHeight),
+		asciigraph.Width(graphWidth-15),
+	)
+	eventSizeContent := boxedView("Bytes/Sec", sizePlot, graphWidth)
+
+	graphStyle := lipgloss.NewStyle().
+		Width(graphWidth).
+		Padding(0).
+		Margin(0).
+		Align(lipgloss.Left)
+
+	eventsStyle := lipgloss.NewStyle().
+		Width(eventsWidth).
+		Padding(0).
+		Margin(0).
+		Align(lipgloss.Left)
+
+	return lipgloss.JoinHorizontal(lipgloss.Left,
+		eventsStyle.Render(topEventsContent),
+		graphStyle.Render(
+			lipgloss.JoinVertical(lipgloss.Left,
+				eventCountContent,
+				eventSizeContent,
+			),
+		),
+	)
+}
+
+// tabView renders the tabbed content in the header.
+func tabView(selectedTab int) string {
+	output := lipgloss.NewStyle().
+		Underline(true).
+		Render("")
+
+	for i, tab := range tabs {
+		lastItem := i == len(tabs)-1
+		selected := i == selectedTab
+
+		var color lipgloss.Color
+		if selected {
+			color = selectedColor
+		}
+
+		output += lipgloss.NewStyle().
+			Foreground(color).
+			Faint(!selected).
+			Render(tab)
+
+		if !lastItem {
+			output += separator
+		}
+	}
+
+	return output
+}
+
+// keyMap is used to display the help text at
+// the bottom of the screen.
+type keyMap struct {
+	quit  key.Binding
+	right key.Binding
+	left  key.Binding
+}
+
+func (k keyMap) ShortHelp() []key.Binding {
+	return []key.Binding{k.left, k.right, k.quit}
+}
+
+func (k keyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{
+		{k.left, k.right},
+		{k.quit},
+	}
+}
+
+var (
+	helpKeys = keyMap{
+		quit: key.NewBinding(
+			key.WithKeys("q", "esc", "ctrl+c"),
+			key.WithHelp("q", "quit"),
+		),
+		left: key.NewBinding(
+			key.WithKeys("left", "esc"),
+			key.WithHelp("left", "previous"),
+		),
+		right: key.NewBinding(
+			key.WithKeys("right"),
+			key.WithHelp("right", "next"),
+		),
+	}
+
+	statusBarStyle = lipgloss.NewStyle()
+
+	separator = lipgloss.NewStyle().
+			Faint(true).
+			Render(" • ")
+
+	selectedColor = lipgloss.Color("4")
+
+	tabs = []string{"Common", "Backend", "Cache", "Watcher"}
+)

--- a/tool/tctl/common/top/table.go
+++ b/tool/tctl/common/top/table.go
@@ -1,0 +1,179 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+package top
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/dustin/go-humanize"
+)
+
+type column struct {
+	width   int
+	content []string
+}
+
+// tableView renders two columns in a table like view
+// that has no headings. Content lengths of the columns
+// is required to match.
+func tableView(width int, first, second column) string {
+	if len(first.content) != len(second.content) {
+		panic("column content must have equal heights")
+	}
+
+	style := lipgloss.NewStyle().
+		Width(width)
+
+	leftColumn := lipgloss.NewStyle().
+		Width(first.width).
+		Align(lipgloss.Left)
+
+	rightColumn := lipgloss.NewStyle().
+		Width(second.width).
+		Border(lipgloss.RoundedBorder(), false, false, false, true).
+		Align(lipgloss.Left)
+
+	var rows []string
+	for i := 0; i < len(first.content); i++ {
+		rows = append(rows, lipgloss.JoinHorizontal(lipgloss.Left,
+			leftColumn.Render(first.content[i]),
+			rightColumn.Render(second.content[i]),
+		))
+	}
+
+	return style.Render(lipgloss.JoinVertical(lipgloss.Left, rows...))
+}
+
+// percentileTableView renders a dynamic table like view
+// displaying the percentiles of the provided histogram.
+func percentileTableView(width int, hist Histogram) string {
+	firstColumn := column{
+		width: width / 2,
+		content: []string{
+			"Percentile",
+		},
+	}
+
+	secondColumn := column{
+		width: width / 2,
+		content: []string{
+			"Latency",
+		},
+	}
+
+	for p := range hist.Percentiles() {
+		firstColumn.content = append(firstColumn.content, humanize.FormatFloat("#,###", p.Percentile)+"%")
+		secondColumn.content = append(secondColumn.content, fmt.Sprintf("%v", p.Value))
+	}
+
+	return tableView(width, firstColumn, secondColumn)
+}
+
+// requestsTableView renders a table like view
+// displaying information about backend request stats.
+func requestsTableView(height, width int, stats *BackendStats) string {
+	style := lipgloss.NewStyle().
+		Width(width).
+		MaxHeight(height - 10)
+
+	countColumn := lipgloss.NewStyle().
+		Width(10).
+		Border(lipgloss.RoundedBorder(), false, false, false, false).
+		Align(lipgloss.Left)
+
+	frequencyColumn := lipgloss.NewStyle().
+		Width(8).
+		Border(lipgloss.RoundedBorder(), false, false, false, true).
+		Align(lipgloss.Left)
+
+	keyColumn := lipgloss.NewStyle().
+		Width(width-18).
+		Border(lipgloss.RoundedBorder(), false, false, false, true).
+		Align(lipgloss.Left)
+
+	rows := []string{
+		lipgloss.JoinHorizontal(lipgloss.Left,
+			countColumn.Render("Count"),
+			frequencyColumn.Render("Req/Sec"),
+			frequencyColumn.Render("Key"),
+		),
+	}
+
+	for _, req := range stats.SortedTopRequests() {
+		var key string
+		if req.Key.Range {
+			key = "®" + req.Key.Key
+		} else {
+			key = " " + req.Key.Key
+		}
+		rows = append(rows, lipgloss.JoinHorizontal(lipgloss.Left,
+			countColumn.Render(humanize.FormatFloat("", float64(req.Count))),
+			frequencyColumn.Render(humanize.FormatFloat("", req.GetFreq())),
+			keyColumn.Render(key),
+		))
+	}
+
+	return style.Render(lipgloss.JoinVertical(lipgloss.Left, rows...))
+}
+
+// eventsTableView renders a table like view
+// displaying information about watcher event stats.
+func eventsTableView(height, width int, stats *WatcherStats) string {
+	style := lipgloss.NewStyle().
+		Width(width).
+		MaxHeight(height - 10)
+
+	countColumn := lipgloss.NewStyle().
+		Width(10).
+		Border(lipgloss.RoundedBorder(), false, false, false, false).
+		Align(lipgloss.Left)
+
+	frequencyColumn := lipgloss.NewStyle().
+		Width(8).
+		Border(lipgloss.RoundedBorder(), false, false, false, true).
+		Align(lipgloss.Left)
+
+	sizeColumn := lipgloss.NewStyle().
+		Width(8).
+		Border(lipgloss.RoundedBorder(), false, false, false, true).
+		Align(lipgloss.Left)
+
+	resourceColumn := lipgloss.NewStyle().
+		Width(width-18).
+		Border(lipgloss.RoundedBorder(), false, false, false, true).
+		Align(lipgloss.Left)
+
+	rows := []string{
+		lipgloss.JoinHorizontal(lipgloss.Left,
+			countColumn.Render("Count"),
+			frequencyColumn.Render("Req/Sec"),
+			frequencyColumn.Render("Avg Size"),
+			frequencyColumn.Render("Resource"),
+		),
+	}
+
+	for _, event := range stats.SortedTopEvents() {
+		rows = append(rows, lipgloss.JoinHorizontal(lipgloss.Left,
+			countColumn.Render(humanize.FormatFloat("", float64(event.Count))),
+			frequencyColumn.Render(humanize.FormatFloat("", event.GetFreq())),
+			sizeColumn.Render(humanize.FormatFloat("", event.AverageSize())),
+			resourceColumn.Render(event.Resource),
+		))
+	}
+
+	return style.Render(lipgloss.JoinVertical(lipgloss.Left, rows...))
+}


### PR DESCRIPTION
Most of the functionality was untouched, there were only few deviations to the original styling and alignment of components. The most notable changes are as follows:
- The backend and cache tables no longer have a range column, range requests are now indicated by a preceding `®`.
- The watcher graphs are rendered with a different library and no longer have a confusing x axis
- The colors do not match the original version 
- The cluster stats page includes the role count
- Errors retrieving metrics no longer exits the process. The footer is updated to display errors and requires manual intervention to exit. If errors are intermittent future successful reports will restore functionality.