### PR TITLE
Revert helm version update to fix local builds

### DIFF
--- a/build.assets/tooling/go.mod
+++ b/build.assets/tooling/go.mod
@@ -15,7 +15,7 @@ require (
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/mod v0.22.0
 	golang.org/x/oauth2 v0.25.0
-	helm.sh/helm/v3 v3.17.0
+	helm.sh/helm/v3 v3.16.4
 	howett.net/plist v1.0.1
 	k8s.io/apiextensions-apiserver v0.32.1
 )


### PR DESCRIPTION
Revert the helm version update in https://github.com/gravitational/teleport/pull/51260 as this broke local builds on master.

```
> make build/tsh
GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 CGO_CFLAGS=-mmacosx-version-min=11.0 go build -tags " libfido2  piv  kustomize_disable_go_plugin_support" -o build/tsh  -ldflags '-w -s -X k8s.io/component-base/version.gitVersion=v1.32.0 -extldflags=-ld_classic' -trimpath -buildmode=pie ./tool/tsh
# sigs.k8s.io/kustomize/api/internal/plugins/fnplugin
../../../code/go/pkg/mod/github.com/gravitational/kustomize/api@v0.16.0-teleport.1/internal/plugins/fnplugin/fnplugin.go:80:4: unknown field EnableStarlark in struct literal of type runfn.RunFns
make: *** [build/tsh] Error 1
```

To reintroduce this update, we may need to update our [kustomize fork](https://github.com/gravitational/kustomize) or otherwise sync versions across our tooling.