### PR TITLE
Allow custom domains in Vite's allowedHosts

### DIFF
--- a/web/packages/build/vite/config.ts
+++ b/web/packages/build/vite/config.ts
@@ -57,7 +57,7 @@ export function createViteConfig(
     const config: UserConfig = {
       clearScreen: false,
       server: {
-        allowedHosts: resolveAllowedHost(target),
+        allowedHosts: resolveAllowedHosts(target),
         fs: {
           allow: [rootDirectory, '.'],
         },
@@ -196,18 +196,22 @@ export function createViteConfig(
   });
 }
 
-function resolveAllowedHost(target: string) {
+function resolveAllowedHosts(target: string) {
+  const allowedHosts = new Set<string>();
+
   if (process.env.VITE_HOST) {
-    return [process.env.VITE_HOST];
+    const { hostname } = new URL(`https://${process.env.VITE_HOST}`);
+
+    allowedHosts.add(hostname);
   }
 
   if (target !== DEFAULT_PROXY_TARGET) {
-    const { hostname } = new URL(`http://${target}`);
+    const { hostname } = new URL(`https://${target}`);
 
-    return [hostname];
+    allowedHosts.add(hostname);
   }
 
-  return [];
+  return Array.from(allowedHosts);
 }
 
 function resolveTargetURL(url: string) {

--- a/web/packages/build/vite/config.ts
+++ b/web/packages/build/vite/config.ts
@@ -54,15 +54,10 @@ export function createViteConfig(
       }
     }
 
-    const targetHostname =
-      target !== DEFAULT_PROXY_TARGET
-        ? new URL(`http://${target}`).hostname
-        : undefined;
-
     const config: UserConfig = {
       clearScreen: false,
       server: {
-        allowedHosts: targetHostname ? [`.${targetHostname}`] : [],
+        allowedHosts: resolveAllowedHost(target),
         fs: {
           allow: [rootDirectory, '.'],
         },
@@ -172,6 +167,7 @@ export function createViteConfig(
           secure: false,
         },
       };
+
       if (process.env.VITE_HTTPS_KEY && process.env.VITE_HTTPS_CERT) {
         config.server.https = {
           key: readFileSync(process.env.VITE_HTTPS_KEY),
@@ -198,6 +194,20 @@ export function createViteConfig(
 
     return config;
   });
+}
+
+function resolveAllowedHost(target: string) {
+  if (process.env.VITE_HOST) {
+    return [process.env.VITE_HOST];
+  }
+
+  if (target !== DEFAULT_PROXY_TARGET) {
+    const { hostname } = new URL(`http://${target}`);
+
+    return [hostname];
+  }
+
+  return [];
 }
 
 function resolveTargetURL(url: string) {


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/51356 introduces the change of setting `allowedHost` to whatever the domain of the proxy target is, if it isn't localhost. That doesn't really work for my setup, and possibly others, as I use a different domain than localhost _and_ the proxy target. This allows the option of setting a `VITE_HOST` environment variable (I followed the same convention in TAG), so we're not allowing all hosts.