### PR TITLE
[Web] Fix integration status page

### DIFF
--- a/web/packages/teleport/src/Navigation/Navigation.tsx
+++ b/web/packages/teleport/src/Navigation/Navigation.tsx
@@ -197,7 +197,10 @@ function getNavSubsectionForRoute(
       })
     );
 
-  if (!feature || (!feature.category && !feature.topMenuItem)) {
+  if (
+    !feature ||
+    (!feature.category && !feature.topMenuItem && !feature.navigationItem)
+  ) {
     return;
   }
 

--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -624,8 +624,6 @@ class FeatureDeviceTrust implements TeleportFeature {
 }
 
 class FeatureIntegrationStatus implements TeleportFeature {
-  category = NavigationCategory.Access;
-
   parent = FeatureIntegrations;
 
   route = {


### PR DESCRIPTION
## Purpose

`e` counterpart: https://github.com/gravitational/teleport.e/pull/5916

This PR fixes the integration status page in the UI after a regression introduced in https://github.com/gravitational/teleport/pull/51237

When deleting the old navigation, only the features which previously had a `sideNavCategory` should have a `category` now. Additionally, I've added an additional check to the navigation component logic to prevent this in the future

Changelog: Fix integrations status page in WebUI