### PR TITLE
[v17] [Web] Fix integration status page 

### DIFF
--- a/web/packages/teleport/src/Navigation/Navigation.tsx
+++ b/web/packages/teleport/src/Navigation/Navigation.tsx
@@ -197,7 +197,10 @@ function getNavSubsectionForRoute(
       })
     );
 
-  if (!feature || (!feature.category && !feature.topMenuItem)) {
+  if (
+    !feature ||
+    (!feature.category && !feature.topMenuItem && !feature.navigationItem)
+  ) {
     return;
   }
 

--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -624,8 +624,6 @@ class FeatureDeviceTrust implements TeleportFeature {
 }
 
 class FeatureIntegrationStatus implements TeleportFeature {
-  category = NavigationCategory.Access;
-
   parent = FeatureIntegrations;
 
   route = {


### PR DESCRIPTION
backport https://github.com/gravitational/teleport/pull/51403 to branch/v17

`e` counterpart: https://github.com/gravitational/teleport.e/pull/5917

Changelog: Fix integrations status page in WebUI