### PR TITLE
[v15] Document the --out flag on `tctl auth export`

### DIFF
--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -268,6 +268,7 @@ $ tctl auth export [<flags>]
 | `--fingerprint` | none | **string** e.g. `SHA256:<fingerprint>` | filter authority by fingerprint |
 | `--compat` | none | version number | export certificates compatible with specific version of Teleport |
 | `--type` | none | `user`, `host`, `tls-host`, `tls-user`, `tls-user-der`, `windows`, `db`, `openssh`, `saml-idp` | certificate type |
+| `--out` | none | filepath | if set writes exported authorities to files with the given path prefix |
 
 ### Global flags
 


### PR DESCRIPTION
Backport #51373 to branch/v15.

#35444