### PR TITLE
[v17] Fix Proxy web server middleware order

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4787,9 +4787,9 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			Server: &http.Server{
 				Handler: utils.ChainHTTPMiddlewares(
 					webHandler,
-					makeXForwardedForMiddleware(cfg),
 					limiter.MakeMiddleware(proxyLimiter),
 					httplib.MakeTracingMiddleware(teleport.ComponentProxy),
+					makeXForwardedForMiddleware(cfg),
 				),
 				// Note: read/write timeouts *should not* be set here because it
 				// will break some application access use-cases.


### PR DESCRIPTION
Backport #51386 to branch/v17

changelog: Fix an issue that prevented IPs provided in the X-Forwarded-For header from being honored in some scenarios when TrustXForwardedFor is enabled.