### PR TITLE
Store profile color in workspace

### DIFF
--- a/web/packages/build/jest/jest-environment-patched-jsdom.js
+++ b/web/packages/build/jest/jest-environment-patched-jsdom.js
@@ -66,6 +66,20 @@ export default class PatchedJSDOMEnvironment extends JSDOMEnvironment {
       global.AbortSignal = AbortSignal;
       global.AbortController = AbortController;
     }
+    // TODO(gzdunek): Remove when JSDOM supports Set.prototype.difference.
+    // After the update to Node.js 22, we can replace the implementation with
+    // global.Set.prototype.difference = Set.prototype.difference.
+    if (!global.Set.difference) {
+      global.Set.prototype.difference = function (otherSet) {
+        const result = new Set();
+        for (const value of this) {
+          if (!otherSet.has(value)) {
+            result.add(value);
+          }
+        }
+        return result;
+      };
+    }
   }
 }
 export const TestEnvironment = PatchedJSDOMEnvironment;

--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/useAssumedRolesBar.test.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/useAssumedRolesBar.test.tsx
@@ -33,15 +33,7 @@ import { useAssumedRolesBar } from './useAssumedRolesBar';
 test('dropping a request refreshes resources', async () => {
   const appContext = new MockAppContext();
   const cluster = makeRootCluster();
-  appContext.workspacesService.setState(draftState => {
-    draftState.rootClusterUri = cluster.uri;
-    draftState.workspaces[cluster.uri] = {
-      localClusterUri: cluster.uri,
-      documents: [],
-      location: undefined,
-      accessRequests: undefined,
-    };
-  });
+  appContext.addRootCluster(cluster);
   jest.spyOn(appContext.clustersService, 'dropRoles');
   const refreshListener = jest.fn();
 

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterAdd/ClusterAdd.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterAdd/ClusterAdd.tsx
@@ -35,11 +35,12 @@ export function ClusterAdd(props: {
   onSuccess(clusterUri: string): void;
   prefill: { clusterAddress: string };
 }) {
-  const { clustersService } = useAppContext();
+  const { clustersService, workspacesService } = useAppContext();
   const [{ status, statusText }, addCluster] = useAsync(
     async (addr: string) => {
       const proxyAddr = parseClusterProxyWebAddr(addr);
       const cluster = await clustersService.addRootCluster(proxyAddr);
+      workspacesService.addWorkspace(cluster.uri);
       return props.onSuccess(cluster.uri);
     }
   );

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Setup.story.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Setup.story.tsx
@@ -27,7 +27,6 @@ import { ResourcesContextProvider } from 'teleterm/ui/DocumentCluster/resourcesC
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import { MockWorkspaceContextProvider } from 'teleterm/ui/fixtures/MockWorkspaceContextProvider';
-import { IAppContext } from 'teleterm/ui/types';
 
 import { ConnectMyComputerContextProvider } from '../connectMyComputerContext';
 import { Setup } from './Setup';
@@ -153,20 +152,11 @@ function ShowState({
   clickStartSetup = true,
 }: {
   cluster: Cluster;
-  appContext: IAppContext;
+  appContext: MockAppContext;
   clickStartSetup?: boolean;
 }) {
   if (!appContext.clustersService.state.clusters.get(cluster.uri)) {
-    appContext.clustersService.state.clusters.set(cluster.uri, cluster);
-    appContext.workspacesService.setState(draftState => {
-      draftState.rootClusterUri = cluster.uri;
-      draftState.workspaces[cluster.uri] = {
-        localClusterUri: cluster.uri,
-        documents: [],
-        location: undefined,
-        accessRequests: undefined,
-      };
-    });
+    appContext.addRootCluster(cluster);
   }
 
   useLayoutEffect(() => {

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Setup.test.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Setup.test.tsx
@@ -131,16 +131,7 @@ function setupAppContext(): {
   const appContext = new MockAppContext({
     appVersion: cluster.proxyVersion,
   });
-  appContext.clustersService.state.clusters.set(cluster.uri, cluster);
-  appContext.workspacesService.setState(draftState => {
-    draftState.rootClusterUri = cluster.uri;
-    draftState.workspaces[cluster.uri] = {
-      localClusterUri: cluster.uri,
-      documents: [],
-      location: undefined,
-      accessRequests: undefined,
-    };
-  });
+  appContext.addRootCluster(cluster);
 
   jest
     .spyOn(appContext.mainProcessClient, 'isAgentConfigFileCreated')

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Status.story.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Status.story.tsx
@@ -236,7 +236,7 @@ export function UpgradeAgentSuggestion() {
 
 function ShowState(props: {
   agentProcessState: AgentProcessState;
-  appContext?: AppContext;
+  appContext?: MockAppContext;
   proxyVersion?: string;
   autoStart?: boolean;
 }) {
@@ -248,18 +248,7 @@ function ShowState(props: {
     new MockAppContext({ appVersion: cluster.proxyVersion });
 
   appContext.mainProcessClient.getAgentState = () => props.agentProcessState;
-  appContext.clustersService.state.clusters.set(cluster.uri, cluster);
-  appContext.workspacesService.setState(draftState => {
-    draftState.rootClusterUri = cluster.uri;
-    draftState.workspaces = {
-      [cluster.uri]: {
-        localClusterUri: cluster.uri,
-        documents: [],
-        location: '/docs/1234',
-        accessRequests: undefined,
-      },
-    };
-  });
+  appContext.addRootCluster(cluster);
 
   if (props.autoStart) {
     appContext.workspacesService.setConnectMyComputerAutoStart(

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Status.story.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Status.story.tsx
@@ -25,7 +25,6 @@ import {
   makeRootCluster,
   makeServer,
 } from 'teleterm/services/tshd/testHelpers';
-import AppContext from 'teleterm/ui/appContext';
 import { ResourcesContextProvider } from 'teleterm/ui/DocumentCluster/resourcesContext';
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/NavigationMenu.story.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/NavigationMenu.story.tsx
@@ -32,7 +32,7 @@ export default {
   title: 'Teleterm/ConnectMyComputer/NavigationMenu',
 };
 
-export function AgenNotConfigured() {
+export function AgentNotConfigured() {
   return (
     <ShowState
       agentProcessState={{ status: 'not-started' }}
@@ -161,16 +161,7 @@ function ShowState({
   const cluster = makeRootCluster({
     proxyVersion: '17.0.0',
   });
-  appContext.clustersService.state.clusters.set(cluster.uri, cluster);
-  appContext.workspacesService.setState(draftState => {
-    draftState.rootClusterUri = cluster.uri;
-    draftState.workspaces[cluster.uri] = {
-      localClusterUri: cluster.uri,
-      documents: [],
-      location: undefined,
-      accessRequests: undefined,
-    };
-  });
+  appContext.addRootCluster(cluster);
 
   appContext.mainProcessClient.getAgentState = () => agentProcessState;
   appContext.connectMyComputerService.isAgentConfigFileCreated =

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.test.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.test.tsx
@@ -65,19 +65,7 @@ function getMocks() {
   const appContext = new MockAppContext({
     appVersion: rootCluster.proxyVersion,
   });
-
-  appContext.clustersService.setState(draftState => {
-    draftState.clusters.set(rootCluster.uri, rootCluster);
-  });
-  appContext.workspacesService.setState(draftState => {
-    draftState.rootClusterUri = rootCluster.uri;
-    draftState.workspaces[rootCluster.uri] = {
-      documents: [],
-      location: undefined,
-      localClusterUri: rootCluster.uri,
-      accessRequests: undefined,
-    };
-  });
+  appContext.addRootCluster(rootCluster);
 
   return { appContext, rootCluster };
 }

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/DocumentAccessRequests.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/DocumentAccessRequests.story.tsx
@@ -27,7 +27,6 @@ import { ResourcesContextProvider } from 'teleterm/ui/DocumentCluster/resourcesC
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import { MockWorkspaceContextProvider } from 'teleterm/ui/fixtures/MockWorkspaceContextProvider';
 import * as types from 'teleterm/ui/services/workspacesService';
-import { getEmptyPendingAccessRequest } from 'teleterm/ui/services/workspacesService/accessRequestsService';
 
 const rootCluster = makeRootCluster();
 
@@ -89,18 +88,7 @@ export function Browsing() {
       startKey: '',
       requests: [mockedAccessRequest],
     });
-  appContext.workspacesService.setState(draftState => {
-    draftState.rootClusterUri = rootCluster.uri;
-    draftState.workspaces[rootCluster.uri] = {
-      localClusterUri: doc.clusterUri,
-      documents: [doc],
-      location: doc.uri,
-      accessRequests: {
-        pending: getEmptyPendingAccessRequest(),
-        isBarCollapsed: true,
-      },
-    };
-  });
+  appContext.addRootClusterWithDoc(rootCluster, [doc]);
 
   return (
     <AppContextProvider value={appContext}>
@@ -117,21 +105,7 @@ export function BrowsingError() {
   const appContext = new MockAppContext();
   appContext.tshd.getAccessRequests = () =>
     new MockedUnaryCall(null, new Error('network error'));
-  appContext.workspacesService.setState(draftState => {
-    draftState.rootClusterUri = rootCluster.uri;
-    draftState.workspaces[rootCluster.uri] = {
-      localClusterUri: doc.clusterUri,
-      documents: [doc],
-      location: doc.uri,
-      accessRequests: {
-        pending: getEmptyPendingAccessRequest(),
-        isBarCollapsed: true,
-      },
-    };
-  });
-  appContext.clustersService.setState(draftState => {
-    draftState.clusters.set(rootCluster.uri, rootCluster);
-  });
+  appContext.addRootClusterWithDoc(rootCluster, [doc]);
 
   return (
     <AppContextProvider value={appContext}>
@@ -156,24 +130,13 @@ export function CreatingWhenUnifiedResourcesShowOnlyAccessibleResources() {
       startKey: '',
       requests: [mockedAccessRequest],
     });
-  appContext.workspacesService.setState(draftState => {
-    draftState.rootClusterUri = rootCluster.uri;
-    draftState.workspaces[rootCluster.uri] = {
-      localClusterUri: docCreating.clusterUri,
-      documents: [docCreating],
-      location: docCreating.uri,
-      accessRequests: {
-        pending: getEmptyPendingAccessRequest(),
-        isBarCollapsed: true,
-      },
-    };
-  });
-  appContext.clustersService.setState(draftState => {
-    draftState.clusters.set(rootCluster.uri, {
+  appContext.addRootClusterWithDoc(
+    {
       ...rootCluster,
       showResources: ShowResources.ACCESSIBLE_ONLY,
-    });
-  });
+    },
+    [doc]
+  );
 
   return (
     <AppContextProvider value={appContext}>
@@ -198,24 +161,13 @@ export function CreatingWhenUnifiedResourcesShowRequestableAndAccessibleResource
       startKey: '',
       requests: [mockedAccessRequest],
     });
-  appContext.workspacesService.setState(draftState => {
-    draftState.rootClusterUri = rootCluster.uri;
-    draftState.workspaces[rootCluster.uri] = {
-      localClusterUri: docCreating.clusterUri,
-      documents: [docCreating],
-      location: docCreating.uri,
-      accessRequests: {
-        pending: getEmptyPendingAccessRequest(),
-        isBarCollapsed: true,
-      },
-    };
-  });
-  appContext.clustersService.setState(draftState => {
-    draftState.clusters.set(rootCluster.uri, {
+  appContext.addRootClusterWithDoc(
+    {
       ...rootCluster,
       showResources: ShowResources.REQUESTABLE,
-    });
-  });
+    },
+    [doc]
+  );
 
   return (
     <AppContextProvider value={appContext}>

--- a/web/packages/teleterm/src/ui/DocumentAuthorizeWebSession/DocumentAuthorizeWebSession.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentAuthorizeWebSession/DocumentAuthorizeWebSession.test.tsx
@@ -95,17 +95,7 @@ test('authorizing a session opens its URL and closes document', async () => {
     loggedInUser: makeLoggedInUser({ isDeviceTrusted: true }),
   });
   const appContext = new MockAppContext();
-  appContext.clustersService.setState(draftState => {
-    draftState.clusters.set(rootCluster.uri, rootCluster);
-  });
-  appContext.workspacesService.setState(draftState => {
-    draftState.workspaces[rootCluster.uri] = {
-      localClusterUri: rootCluster.uri,
-      documents: [doc],
-      location: undefined,
-      accessRequests: undefined,
-    };
-  });
+  appContext.addRootClusterWithDoc(rootCluster, doc);
 
   render(
     <MockAppContextProvider appContext={appContext}>

--- a/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.story.tsx
@@ -35,16 +35,10 @@ import AppContextProvider from 'teleterm/ui/appContextProvider';
 import { ConnectMyComputerContextProvider } from 'teleterm/ui/ConnectMyComputer';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import { MockWorkspaceContextProvider } from 'teleterm/ui/fixtures/MockWorkspaceContextProvider';
-import {
-  ClustersServiceState,
-  createClusterServiceState,
-} from 'teleterm/ui/services/clusters';
 import { ResourcesService } from 'teleterm/ui/services/resources';
-import { getEmptyPendingAccessRequest } from 'teleterm/ui/services/workspacesService/accessRequestsService';
 import { makeDocumentCluster } from 'teleterm/ui/services/workspacesService/documentsService/testHelpers';
 import * as docTypes from 'teleterm/ui/services/workspacesService/documentsService/types';
 import { ConnectionsContextProvider } from 'teleterm/ui/TopBar/Connections/connectionsContext';
-import { routing } from 'teleterm/ui/uri';
 import { VnetContextProvider } from 'teleterm/ui/Vnet';
 
 import DocumentCluster from './DocumentCluster';
@@ -65,16 +59,10 @@ const leafClusterDoc = makeDocumentCluster({
 });
 
 export const OnlineLoadedResources = () => {
-  const state = createClusterServiceState();
-  state.clusters.set(
-    rootClusterDoc.clusterUri,
-    makeRootCluster({
-      uri: rootClusterDoc.clusterUri,
-    })
-  );
-
   return renderState({
-    state,
+    cluster: makeRootCluster({
+      uri: rootClusterDoc.clusterUri,
+    }),
     doc: rootClusterDoc,
     listUnifiedResources: () =>
       Promise.resolve({
@@ -161,10 +149,8 @@ export const OnlineLoadedResources = () => {
 };
 
 export const OnlineEmptyResourcesAndCanAddResourcesAndConnectComputer = () => {
-  const state = createClusterServiceState();
-  state.clusters.set(
-    rootClusterDoc.clusterUri,
-    makeRootCluster({
+  return renderState({
+    cluster: makeRootCluster({
       uri: rootClusterDoc.clusterUri,
       loggedInUser: makeLoggedInUser({
         userType: tsh.LoggedInUser_UserType.LOCAL,
@@ -179,11 +165,7 @@ export const OnlineEmptyResourcesAndCanAddResourcesAndConnectComputer = () => {
           },
         }),
       }),
-    })
-  );
-
-  return renderState({
-    state,
+    }),
     doc: rootClusterDoc,
     platform: 'darwin',
     listUnifiedResources: () =>
@@ -197,10 +179,8 @@ export const OnlineEmptyResourcesAndCanAddResourcesAndConnectComputer = () => {
 
 export const OnlineEmptyResourcesAndCanAddResourcesButCannotConnectComputer =
   () => {
-    const state = createClusterServiceState();
-    state.clusters.set(
-      rootClusterDoc.clusterUri,
-      makeRootCluster({
+    return renderState({
+      cluster: makeRootCluster({
         uri: rootClusterDoc.clusterUri,
         loggedInUser: makeLoggedInUser({
           userType: tsh.LoggedInUser_UserType.SSO,
@@ -215,11 +195,7 @@ export const OnlineEmptyResourcesAndCanAddResourcesButCannotConnectComputer =
             },
           }),
         }),
-      })
-    );
-
-    return renderState({
-      state,
+      }),
       doc: rootClusterDoc,
       platform: 'win32',
       listUnifiedResources: () =>
@@ -232,10 +208,8 @@ export const OnlineEmptyResourcesAndCanAddResourcesButCannotConnectComputer =
   };
 
 export const OnlineEmptyResourcesAndCannotAddResources = () => {
-  const state = createClusterServiceState();
-  state.clusters.set(
-    rootClusterDoc.clusterUri,
-    makeRootCluster({
+  return renderState({
+    cluster: makeRootCluster({
       uri: rootClusterDoc.clusterUri,
       loggedInUser: makeLoggedInUser({
         acl: makeAcl({
@@ -249,11 +223,7 @@ export const OnlineEmptyResourcesAndCannotAddResources = () => {
           },
         }),
       }),
-    })
-  );
-
-  return renderState({
-    state,
+    }),
     doc: rootClusterDoc,
     listUnifiedResources: () =>
       Promise.resolve({
@@ -265,14 +235,6 @@ export const OnlineEmptyResourcesAndCannotAddResources = () => {
 };
 
 export const OnlineLoadingResources = () => {
-  const state = createClusterServiceState();
-  state.clusters.set(
-    rootClusterDoc.clusterUri,
-    makeRootCluster({
-      uri: rootClusterDoc.clusterUri,
-    })
-  );
-
   let rejectPromise: (error: Error) => void;
   const promiseRejectedOnUnmount = new Promise<any>((resolve, reject) => {
     rejectPromise = reject;
@@ -285,23 +247,19 @@ export const OnlineLoadingResources = () => {
   }, [rejectPromise]);
 
   return renderState({
-    state,
+    cluster: makeRootCluster({
+      uri: rootClusterDoc.clusterUri,
+    }),
     doc: rootClusterDoc,
     listUnifiedResources: () => promiseRejectedOnUnmount,
   });
 };
 
 export const OnlineErrorLoadingResources = () => {
-  const state = createClusterServiceState();
-  state.clusters.set(
-    rootClusterDoc.clusterUri,
-    makeRootCluster({
-      uri: rootClusterDoc.clusterUri,
-    })
-  );
-
   return renderState({
-    state,
+    cluster: makeRootCluster({
+      uri: rootClusterDoc.clusterUri,
+    }),
     doc: rootClusterDoc,
     listUnifiedResources: () =>
       Promise.reject(new Error('Whoops, something went wrong, sorry!')),
@@ -309,58 +267,38 @@ export const OnlineErrorLoadingResources = () => {
 };
 
 export const Offline = () => {
-  const state = createClusterServiceState();
-  state.clusters.set(
-    rootClusterDoc.clusterUri,
-    makeRootCluster({
+  return renderState({
+    cluster: makeRootCluster({
       connected: false,
       uri: rootClusterDoc.clusterUri,
-    })
-  );
-
-  return renderState({ state, doc: rootClusterDoc });
+    }),
+    doc: rootClusterDoc,
+  });
 };
 
 export const Notfound = () => {
-  const state = createClusterServiceState();
-  state.clusters.set(
-    rootClusterDoc.clusterUri,
-    makeRootCluster({
+  return renderState({
+    cluster: makeRootCluster({
       uri: rootClusterDoc.clusterUri,
-    })
-  );
-  return renderState({ state, doc: leafClusterDoc });
+    }),
+    doc: leafClusterDoc,
+  });
 };
 
 function renderState({
-  state,
+  cluster,
   doc,
   listUnifiedResources,
   platform = 'darwin',
 }: {
-  state: ClustersServiceState;
+  cluster: tsh.Cluster;
   doc: docTypes.DocumentCluster;
   listUnifiedResources?: ResourcesService['listUnifiedResources'];
   platform?: NodeJS.Platform;
   userType?: tsh.LoggedInUser_UserType;
 }) {
   const appContext = new MockAppContext({ platform });
-  appContext.clustersService.state = state;
-
-  const rootClusterUri = routing.ensureRootClusterUri(doc.clusterUri);
-  appContext.workspacesService.setState(draftState => {
-    draftState.rootClusterUri = rootClusterUri;
-    draftState.workspaces[rootClusterUri] = {
-      localClusterUri: doc.clusterUri,
-      documents: [doc],
-      location: doc.uri,
-      accessRequests: {
-        pending: getEmptyPendingAccessRequest(),
-        isBarCollapsed: true,
-      },
-    };
-  });
-
+  appContext.addRootClusterWithDoc(cluster, doc);
   appContext.resourcesService.listUnifiedResources = (params, abortSignal) =>
     listUnifiedResources
       ? listUnifiedResources(params, abortSignal)

--- a/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.test.tsx
@@ -31,7 +31,6 @@ import { ConnectMyComputerContextProvider } from 'teleterm/ui/ConnectMyComputer'
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import { MockWorkspaceContextProvider } from 'teleterm/ui/fixtures/MockWorkspaceContextProvider';
-import { getEmptyPendingAccessRequest } from 'teleterm/ui/services/workspacesService/accessRequestsService';
 import { makeDocumentCluster } from 'teleterm/ui/services/workspacesService/documentsService/testHelpers';
 
 import DocumentCluster from './DocumentCluster';
@@ -43,41 +42,25 @@ it('displays a button for Connect My Computer in the empty state if the user can
   const doc = makeDocumentCluster();
 
   const appContext = new MockAppContext({ platform: 'darwin' });
-  appContext.clustersService.setState(draft => {
-    draft.clusters.set(
-      doc.clusterUri,
-      makeRootCluster({
-        uri: doc.clusterUri,
-        loggedInUser: makeLoggedInUser({
-          userType: tsh.LoggedInUser_UserType.LOCAL,
-          acl: makeAcl({
-            tokens: {
-              create: true,
-              list: true,
-              edit: true,
-              delete: true,
-              read: true,
-              use: true,
-            },
-          }),
+  appContext.addRootClusterWithDoc(
+    makeRootCluster({
+      uri: doc.clusterUri,
+      loggedInUser: makeLoggedInUser({
+        userType: tsh.LoggedInUser_UserType.LOCAL,
+        acl: makeAcl({
+          tokens: {
+            create: true,
+            list: true,
+            edit: true,
+            delete: true,
+            read: true,
+            use: true,
+          },
         }),
-      })
-    );
-  });
-
-  appContext.workspacesService.setState(draftState => {
-    const rootClusterUri = doc.clusterUri;
-    draftState.rootClusterUri = rootClusterUri;
-    draftState.workspaces[rootClusterUri] = {
-      localClusterUri: doc.clusterUri,
-      documents: [doc],
-      location: doc.uri,
-      accessRequests: {
-        pending: getEmptyPendingAccessRequest(),
-        isBarCollapsed: true,
-      },
-    };
-  });
+      }),
+    }),
+    doc
+  );
 
   const emptyResponse = {
     resources: [],
@@ -116,41 +99,25 @@ it('does not display a button for Connect My Computer in the empty state if the 
   });
 
   const appContext = new MockAppContext({ platform: 'linux' });
-  appContext.clustersService.setState(draft => {
-    draft.clusters.set(
-      doc.clusterUri,
-      makeRootCluster({
-        uri: doc.clusterUri,
-        loggedInUser: makeLoggedInUser({
-          userType: tsh.LoggedInUser_UserType.LOCAL,
-          acl: makeAcl({
-            tokens: {
-              create: false,
-              list: true,
-              edit: true,
-              delete: true,
-              read: true,
-              use: true,
-            },
-          }),
+  appContext.addRootClusterWithDoc(
+    makeRootCluster({
+      uri: doc.clusterUri,
+      loggedInUser: makeLoggedInUser({
+        userType: tsh.LoggedInUser_UserType.LOCAL,
+        acl: makeAcl({
+          tokens: {
+            create: false,
+            list: true,
+            edit: true,
+            delete: true,
+            read: true,
+            use: true,
+          },
         }),
-      })
-    );
-  });
-
-  appContext.workspacesService.setState(draftState => {
-    const rootClusterUri = doc.clusterUri;
-    draftState.rootClusterUri = rootClusterUri;
-    draftState.workspaces[rootClusterUri] = {
-      localClusterUri: doc.clusterUri,
-      documents: [doc],
-      location: doc.uri,
-      accessRequests: {
-        pending: getEmptyPendingAccessRequest(),
-        isBarCollapsed: true,
-      },
-    };
-  });
+      }),
+    }),
+    doc
+  );
 
   const emptyResponse = {
     resources: [],

--- a/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.test.tsx
@@ -44,7 +44,6 @@ import { UnifiedResources } from 'teleterm/ui/DocumentCluster/UnifiedResources';
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import { MockWorkspaceContextProvider } from 'teleterm/ui/fixtures/MockWorkspaceContextProvider';
-import { getEmptyPendingAccessRequest } from 'teleterm/ui/services/workspacesService/accessRequestsService';
 import { makeDocumentCluster } from 'teleterm/ui/services/workspacesService/documentsService/testHelpers';
 import * as uri from 'teleterm/ui/uri';
 
@@ -175,39 +174,25 @@ test.each([
   const doc = makeDocumentCluster();
 
   const appContext = new MockAppContext({ platform: 'darwin' });
-  appContext.clustersService.setState(draft => {
-    draft.clusters.set(
-      doc.clusterUri,
-      makeRootCluster({
-        uri: doc.clusterUri,
-        features: {
-          advancedAccessWorkflows:
-            testCase.conditions.isClusterSupportingAccessRequests,
-          isUsageBasedBilling: false,
-        },
-        showResources: testCase.conditions.showResources,
-      })
-    );
-  });
-
+  appContext.addRootClusterWithDoc(
+    makeRootCluster({
+      uri: doc.clusterUri,
+      features: {
+        advancedAccessWorkflows:
+          testCase.conditions.isClusterSupportingAccessRequests,
+        isUsageBasedBilling: false,
+      },
+      showResources: testCase.conditions.showResources,
+    }),
+    doc
+  );
   appContext.workspacesService.setState(draftState => {
-    const rootClusterUri = doc.clusterUri;
-    draftState.rootClusterUri = rootClusterUri;
-    draftState.workspaces[rootClusterUri] = {
-      localClusterUri: doc.clusterUri,
-      documents: [doc],
-      location: doc.uri,
-      unifiedResourcePreferences: {
-        defaultTab: DefaultTab.ALL,
-        viewMode: ViewMode.CARD,
-        labelsViewMode: LabelsViewMode.COLLAPSED,
-        availableResourceMode:
-          testCase.conditions.availableResourceModePreference,
-      },
-      accessRequests: {
-        pending: getEmptyPendingAccessRequest(),
-        isBarCollapsed: true,
-      },
+    draftState.workspaces[doc.clusterUri].unifiedResourcePreferences = {
+      defaultTab: DefaultTab.ALL,
+      viewMode: ViewMode.CARD,
+      labelsViewMode: LabelsViewMode.COLLAPSED,
+      availableResourceMode:
+        testCase.conditions.availableResourceModePreference,
     };
   });
 
@@ -302,22 +287,7 @@ test.each([
   });
   const serverResource = makeServer();
   const appContext = new MockAppContext();
-  appContext.clustersService.setState(draft => {
-    draft.clusters.set(rootCluster.uri, rootCluster);
-  });
-
-  appContext.workspacesService.setState(draftState => {
-    draftState.rootClusterUri = rootCluster.uri;
-    draftState.workspaces[rootCluster.uri] = {
-      localClusterUri: rootCluster.uri,
-      documents: [doc],
-      location: doc.uri,
-      accessRequests: {
-        pending: getEmptyPendingAccessRequest(),
-        isBarCollapsed: true,
-      },
-    };
-  });
+  appContext.addRootClusterWithDoc(rootCluster, doc);
 
   jest
     .spyOn(appContext.resourcesService, 'listUnifiedResources')

--- a/web/packages/teleterm/src/ui/DocumentGateway/useGateway.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGateway/useGateway.test.tsx
@@ -126,18 +126,7 @@ const testSetup = () => {
     title: '',
     status: '',
   };
-  appContext.clustersService.setState(draftState => {
-    draftState.clusters.set(cluster.uri, cluster);
-  });
-  appContext.workspacesService.setState(draftState => {
-    draftState.rootClusterUri = cluster.uri;
-    draftState.workspaces[cluster.uri] = {
-      documents: [doc],
-      location: doc.uri,
-      localClusterUri: cluster.uri,
-      accessRequests: undefined,
-    };
-  });
+  appContext.addRootClusterWithDoc(cluster, doc);
   const workspaceContext = {
     rootClusterUri: cluster.uri,
     localClusterUri: cluster.uri,

--- a/web/packages/teleterm/src/ui/DocumentGatewayApp/DocumentGatewayApp.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGatewayApp/DocumentGatewayApp.story.tsx
@@ -22,7 +22,11 @@ import { Flex } from 'design';
 import { usePromiseRejectedOnUnmount, wait } from 'shared/utils/wait';
 
 import { MockedUnaryCall } from 'teleterm/services/tshd/cloneableClient';
-import { makeApp, makeAppGateway } from 'teleterm/services/tshd/testHelpers';
+import {
+  makeApp,
+  makeAppGateway,
+  makeRootCluster,
+} from 'teleterm/services/tshd/testHelpers';
 import { DocumentGatewayApp } from 'teleterm/ui/DocumentGatewayApp/DocumentGatewayApp';
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
@@ -80,7 +84,7 @@ const meta: Meta<StoryProps> = {
 export default meta;
 
 export function Story(props: StoryProps) {
-  const rootClusterUri = '/clusters/bar';
+  const rootCluster = makeRootCluster({ uri: '/clusters/bar' });
   const gateway = makeAppGateway();
   if (props.appType === 'tcp') {
     gateway.protocol = 'TCP';
@@ -111,15 +115,7 @@ export function Story(props: StoryProps) {
   const infinitePromise = usePromiseRejectedOnUnmount();
 
   const appContext = new MockAppContext();
-  appContext.workspacesService.setState(draftState => {
-    draftState.rootClusterUri = rootClusterUri;
-    draftState.workspaces[rootClusterUri] = {
-      localClusterUri: rootClusterUri,
-      documents: [documentGateway],
-      location: documentGateway.uri,
-      accessRequests: undefined,
-    };
-  });
+  appContext.addRootClusterWithDoc(rootCluster, documentGateway);
   if (props.online) {
     appContext.clustersService.createGateway = () => Promise.resolve(gateway);
     appContext.clustersService.setState(draftState => {

--- a/web/packages/teleterm/src/ui/DocumentGatewayKube/DocumentGatewayKube.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGatewayKube/DocumentGatewayKube.story.tsx
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import { MockWorkspaceContextProvider } from 'teleterm/ui/fixtures/MockWorkspaceContextProvider';
@@ -27,38 +28,28 @@ export default {
   title: 'Teleterm/DocumentGatewayKube',
 };
 
-const offlineDocumentGatewayProps: types.DocumentGatewayKube = {
+const rootCluster = makeRootCluster();
+const offlineDocumentGateway: types.DocumentGatewayKube = {
   kind: 'doc.gateway_kube',
   rootClusterId: '',
   leafClusterId: '',
-  targetUri: '/clusters/bar/kubes/quux',
+  targetUri: `${rootCluster.uri}/kubes/quux`,
   origin: 'resource_table',
   status: '',
   uri: '/docs/123',
   title: 'quux',
 };
 
-const rootClusterUri = '/clusters/bar';
-
 export function Offline() {
   const appContext = new MockAppContext();
   appContext.clustersService.createGateway = () =>
     Promise.reject(new Error('failed to create gateway'));
-
-  appContext.workspacesService.setState(draftState => {
-    draftState.rootClusterUri = rootClusterUri;
-    draftState.workspaces[rootClusterUri] = {
-      localClusterUri: rootClusterUri,
-      documents: [offlineDocumentGatewayProps],
-      location: offlineDocumentGatewayProps.uri,
-      accessRequests: undefined,
-    };
-  });
+  appContext.addRootClusterWithDoc(rootCluster, offlineDocumentGateway);
 
   return (
     <MockAppContextProvider appContext={appContext}>
       <MockWorkspaceContextProvider>
-        <DocumentGatewayKube doc={offlineDocumentGatewayProps} visible={true} />
+        <DocumentGatewayKube doc={offlineDocumentGateway} visible={true} />
       </MockWorkspaceContextProvider>
     </MockAppContextProvider>
   );

--- a/web/packages/teleterm/src/ui/Search/SearchBar.test.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchBar.test.tsx
@@ -31,7 +31,7 @@ import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import ModalsHost from 'teleterm/ui/ModalsHost';
 import { ResourceSearchError } from 'teleterm/ui/services/resources';
 import { ConnectionsContextProvider } from 'teleterm/ui/TopBar/Connections/connectionsContext';
-import { ClusterUri } from 'teleterm/ui/uri';
+import { ClusterUri, routing } from 'teleterm/ui/uri';
 import { VnetContextProvider } from 'teleterm/ui/Vnet';
 
 import { SearchAction } from './actions';
@@ -411,16 +411,11 @@ const getMockedSearchContext = (): SearchContext.SearchContext => ({
 
 const setUpContext = (clusterUri: ClusterUri) => {
   const appContext = new MockAppContext();
-  appContext.workspacesService.setState(draft => {
-    draft.rootClusterUri = clusterUri;
-    draft.workspaces = {
-      [clusterUri]: {
-        documents: [],
-        location: undefined,
-        localClusterUri: clusterUri,
-        accessRequests: undefined,
-      },
-    };
-  });
+  appContext.addRootCluster(
+    makeRootCluster({
+      uri: clusterUri,
+      name: routing.parseClusterUri(clusterUri).params.rootClusterId,
+    })
+  );
   return appContext;
 };

--- a/web/packages/teleterm/src/ui/Search/SearchContext.test.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchContext.test.tsx
@@ -29,6 +29,7 @@ import {
   screen,
 } from '@testing-library/react';
 
+import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import { IAppContext } from 'teleterm/ui/types';
@@ -233,17 +234,10 @@ describe('closeWithoutRestoringFocus', () => {
 });
 
 test('search bar state is adjusted to the active document', () => {
-  const rootClusterUri = '/clusters/localhost';
+  const rootCluster = makeRootCluster({ uri: '/clusters/localhost' });
   const appContext = new MockAppContext();
-  appContext.workspacesService.setState(draftState => {
-    draftState.rootClusterUri = rootClusterUri;
-    draftState.workspaces[rootClusterUri] = {
-      localClusterUri: rootClusterUri,
-      documents: [],
-      location: undefined,
-      accessRequests: undefined,
-    };
-  });
+  appContext.addRootCluster(rootCluster);
+
   const docService =
     appContext.workspacesService.getActiveWorkspaceDocumentService();
   const { result } = renderHook(() => useSearchContext(), {
@@ -260,7 +254,7 @@ test('search bar state is adjusted to the active document', () => {
   // document changes to the cluster document
   act(() => {
     const clusterDoc = docService.createClusterDocument({
-      clusterUri: rootClusterUri,
+      clusterUri: rootCluster.uri,
       queryParams: {
         search: 'foo',
         resourceKinds: ['db'],
@@ -281,7 +275,7 @@ test('search bar state is adjusted to the active document', () => {
   // document changes to another cluster document
   act(() => {
     const clusterDoc = docService.createClusterDocument({
-      clusterUri: rootClusterUri,
+      clusterUri: rootCluster.uri,
       queryParams: {
         search: 'bar',
         resourceKinds: ['kube_cluster'],
@@ -316,7 +310,7 @@ test('search bar state is adjusted to the active document', () => {
   // document changes to a cluster document
   act(() => {
     const clusterDoc = docService.createClusterDocument({
-      clusterUri: rootClusterUri,
+      clusterUri: rootCluster.uri,
       queryParams: {
         search: 'bar',
         resourceKinds: ['kube_cluster'],

--- a/web/packages/teleterm/src/ui/Search/pickers/useDisplayResults.test.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/useDisplayResults.test.tsx
@@ -18,6 +18,7 @@
 
 import { renderHook } from '@testing-library/react';
 
+import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import { makeDocumentCluster } from 'teleterm/ui/services/workspacesService/documentsService/testHelpers';
@@ -30,17 +31,10 @@ const documentCluster = makeDocumentCluster({
 
 test('if the cluster document is active, the search results should be shown in it', () => {
   const appContext = new MockAppContext();
-  appContext.workspacesService.setState(draftState => {
-    draftState.workspaces = {
-      '/clusters/teleport-a': {
-        localClusterUri: '/clusters/teleport-a',
-        location: documentCluster.uri,
-        accessRequests: undefined,
-        documents: [documentCluster],
-      },
-    };
-    draftState.rootClusterUri = '/clusters/teleport-a';
-  });
+  appContext.addRootClusterWithDoc(
+    makeRootCluster({ uri: '/clusters/teleport-a' }),
+    documentCluster
+  );
 
   const { result } = renderHook(
     () =>
@@ -65,17 +59,10 @@ test('if the cluster document is active, the search results should be shown in i
 
 test('if the cluster filter does not match the document cluster, the results should be opened in a new document', () => {
   const appContext = new MockAppContext();
-  appContext.workspacesService.setState(draftState => {
-    draftState.workspaces = {
-      '/clusters/teleport-a': {
-        localClusterUri: '/clusters/teleport-a',
-        location: '/docs/abc',
-        accessRequests: undefined,
-        documents: [documentCluster],
-      },
-    };
-    draftState.rootClusterUri = '/clusters/teleport-a';
-  });
+  appContext.addRootClusterWithDoc(
+    makeRootCluster({ uri: '/clusters/teleport-a' }),
+    documentCluster
+  );
 
   const { result } = renderHook(
     () =>
@@ -101,17 +88,7 @@ test('if the cluster filter does not match the document cluster, the results sho
 
 test('if the cluster document is not active, the results should be opened in a new document', () => {
   const appContext = new MockAppContext();
-  appContext.workspacesService.setState(draftState => {
-    draftState.workspaces = {
-      '/clusters/teleport-a': {
-        localClusterUri: '/clusters/teleport-a',
-        location: '/docs/abc',
-        accessRequests: undefined,
-        documents: [],
-      },
-    };
-    draftState.rootClusterUri = '/clusters/teleport-a';
-  });
+  appContext.addRootCluster(makeRootCluster({ uri: '/clusters/teleport-a' }));
 
   const { result } = renderHook(
     () =>

--- a/web/packages/teleterm/src/ui/TabHost/TabHost.test.tsx
+++ b/web/packages/teleterm/src/ui/TabHost/TabHost.test.tsx
@@ -54,27 +54,7 @@ async function getTestSetup({ documents }: { documents: Document[] }) {
   const appContext = new MockAppContext();
   jest.spyOn(appContext.mainProcessClient, 'openTabContextMenu');
 
-  appContext.clustersService.setState(draft => {
-    draft.clusters.set(
-      rootClusterUri,
-      makeRootCluster({
-        uri: rootClusterUri,
-      })
-    );
-  });
-
-  appContext.workspacesService.setState(draft => {
-    draft.rootClusterUri = rootClusterUri;
-    draft.workspaces[rootClusterUri] = {
-      documents,
-      location: documents[0]?.uri,
-      localClusterUri: rootClusterUri,
-      accessRequests: {
-        isBarCollapsed: true,
-        pending: { kind: 'resource', resources: new Map() },
-      },
-    };
-  });
+  appContext.addRootClusterWithDoc(makeRootCluster(), documents);
 
   const docsService =
     appContext.workspacesService.getActiveWorkspaceDocumentService();

--- a/web/packages/teleterm/src/ui/TabHost/useTabShortcuts.test.tsx
+++ b/web/packages/teleterm/src/ui/TabHost/useTabShortcuts.test.tsx
@@ -20,6 +20,7 @@ import { PropsWithChildren } from 'react';
 
 import renderHook from 'design/utils/renderHook';
 
+import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
 import AppContextProvider from 'teleterm/ui/appContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import {
@@ -107,15 +108,7 @@ function getTestSetup({ documents }: { documents: Document[] }) {
       eventEmitter = null;
     });
 
-  appContext.workspacesService.setState(draft => {
-    draft.rootClusterUri = rootClusterUri;
-    draft.workspaces[rootClusterUri] = {
-      documents,
-      location: documents[0]?.uri,
-      localClusterUri: rootClusterUri,
-      accessRequests: undefined,
-    };
-  });
+  appContext.addRootClusterWithDoc(makeRootCluster(), documents);
 
   const docsService =
     appContext.workspacesService.getActiveWorkspaceDocumentService();

--- a/web/packages/teleterm/src/ui/TopBar/Identity/Identity.test.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Identity/Identity.test.tsx
@@ -25,7 +25,6 @@ import { TrustedDeviceRequirement } from 'gen-proto-ts/teleport/legacy/types/tru
 import {
   makeLoggedInUser,
   makeRootCluster,
-  rootClusterUri,
 } from 'teleterm/services/tshd/testHelpers';
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
@@ -73,28 +72,11 @@ test.each([
   },
 ])('$name', async testCase => {
   const appContext = new MockAppContext();
-  appContext.clustersService.setState(draft => {
-    draft.clusters.set(
-      rootClusterUri,
-      makeRootCluster({
-        uri: rootClusterUri,
-        loggedInUser: testCase.user,
-      })
-    );
-  });
-
-  appContext.workspacesService.setState(draft => {
-    draft.rootClusterUri = rootClusterUri;
-    draft.workspaces[rootClusterUri] = {
-      localClusterUri: rootClusterUri,
-      documents: [],
-      location: undefined,
-      accessRequests: {
-        isBarCollapsed: true,
-        pending: { kind: 'resource', resources: new Map() },
-      },
-    };
-  });
+  appContext.addRootCluster(
+    makeRootCluster({
+      loggedInUser: testCase.user,
+    })
+  );
 
   render(
     <MockAppContextProvider appContext={appContext}>

--- a/web/packages/teleterm/src/ui/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/ui/fixtures/mocks.ts
@@ -53,17 +53,11 @@ export class MockAppContext extends AppContext {
       draftState.clusters.set(cluster.uri, cluster);
     });
     const docs = Array.isArray(doc) ? doc : [doc];
+    this.workspacesService.addWorkspace(cluster.uri);
     this.workspacesService.setState(draftState => {
       draftState.rootClusterUri = cluster.uri;
-      draftState.workspaces[cluster.uri] = {
-        documents: docs.filter(Boolean),
-        location: docs[0]?.uri,
-        localClusterUri: cluster.uri,
-        accessRequests: {
-          isBarCollapsed: true,
-          pending: { kind: 'role', roles: new Set<string>() },
-        },
-      };
+      draftState.workspaces[cluster.uri].documents = docs.filter(Boolean);
+      draftState.workspaces[cluster.uri].location = docs[0]?.uri;
     });
   }
 

--- a/web/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.legacy.test.ts
+++ b/web/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.legacy.test.ts
@@ -272,6 +272,7 @@ function getTestSetupWithMockedDocuments(documents: Document[]) {
   // Insert the documents.
   workspacesService.setState(draftState => {
     draftState.workspaces['/clusters/localhost'] = {
+      color: 'purple',
       accessRequests: {
         pending: getEmptyPendingAccessRequest(),
         isBarCollapsed: false,

--- a/web/packages/teleterm/src/ui/services/statePersistence/statePersistenceService.ts
+++ b/web/packages/teleterm/src/ui/services/statePersistence/statePersistenceService.ts
@@ -19,8 +19,8 @@
 import { FileStorage } from 'teleterm/types';
 import { ConnectionTrackerState } from 'teleterm/ui/services/connectionTracker';
 import {
-  ProfileColor,
   Workspace,
+  WorkspaceColor,
   WorkspacesState,
 } from 'teleterm/ui/services/workspacesService';
 
@@ -41,7 +41,7 @@ export type PersistedWorkspace = Omit<
   'accessRequests' | 'documentsRestoredOrDiscarded' | 'color'
 > & // TODO(gzdunek) DELETE IN v19.0.0: Make the field required by removing the type below and omitted 'color' above.
 // This expresses that existing persisted state from older versions might not have color defined.
-{ color?: ProfileColor };
+{ color?: WorkspaceColor };
 
 export type WorkspacesPersistedState = Omit<
   WorkspacesState,

--- a/web/packages/teleterm/src/ui/services/statePersistence/statePersistenceService.ts
+++ b/web/packages/teleterm/src/ui/services/statePersistence/statePersistenceService.ts
@@ -39,9 +39,11 @@ interface UsageReportingState {
 export type PersistedWorkspace = Omit<
   Workspace,
   'accessRequests' | 'documentsRestoredOrDiscarded' | 'color'
-> & // TODO(gzdunek) DELETE IN v19.0.0: Make the field required by removing the type below and omitted 'color' above.
-// This expresses that existing persisted state from older versions might not have color defined.
-{ color?: WorkspaceColor };
+> & {
+  // TODO(gzdunek) DELETE IN v19.0.0: Make the field required by removing the 'color' type below and the omitted 'color' above.
+  // This only expresses that existing persisted state from older versions might not have color defined.
+  color?: WorkspaceColor;
+};
 
 export type WorkspacesPersistedState = Omit<
   WorkspacesState,

--- a/web/packages/teleterm/src/ui/services/statePersistence/statePersistenceService.ts
+++ b/web/packages/teleterm/src/ui/services/statePersistence/statePersistenceService.ts
@@ -39,7 +39,9 @@ interface UsageReportingState {
 export type PersistedWorkspace = Omit<
   Workspace,
   'accessRequests' | 'documentsRestoredOrDiscarded' | 'color'
-> & { color?: ProfileColor };
+> & // TODO(gzdunek) DELETE IN v19.0.0: Make the field required by removing the type below and omitted 'color' above.
+// This expresses that existing persisted state from older versions might not have color defined.
+{ color?: ProfileColor };
 
 export type WorkspacesPersistedState = Omit<
   WorkspacesState,

--- a/web/packages/teleterm/src/ui/services/statePersistence/statePersistenceService.ts
+++ b/web/packages/teleterm/src/ui/services/statePersistence/statePersistenceService.ts
@@ -19,6 +19,7 @@
 import { FileStorage } from 'teleterm/types';
 import { ConnectionTrackerState } from 'teleterm/ui/services/connectionTracker';
 import {
+  ProfileColor,
   Workspace,
   WorkspacesState,
 } from 'teleterm/ui/services/workspacesService';
@@ -31,14 +32,20 @@ interface UsageReportingState {
   askedForUserJobRole: boolean;
 }
 
+/**
+ * Expected shape of the persisted workspaces.
+ * In the future, it should come from zod.
+ */
+export type PersistedWorkspace = Omit<
+  Workspace,
+  'accessRequests' | 'documentsRestoredOrDiscarded' | 'color'
+> & { color?: ProfileColor };
+
 export type WorkspacesPersistedState = Omit<
   WorkspacesState,
   'workspaces' | 'isInitialized'
 > & {
-  workspaces: Record<
-    string,
-    Omit<Workspace, 'accessRequests' | 'documentsRestoredOrDiscarded'>
-  >;
+  workspaces: Record<string, PersistedWorkspace>;
 };
 
 export interface StatePersistenceState {

--- a/web/packages/teleterm/src/ui/services/workspacesService/color.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/color.ts
@@ -20,9 +20,9 @@ import { z } from 'zod';
 
 import Logger from 'teleterm/logger';
 
-export type ProfileColor = z.infer<typeof profileColors>;
+export type WorkspaceColor = z.infer<typeof workspaceColors>;
 
-export const profileColors = z.enum([
+export const workspaceColors = z.enum([
   'purple',
   'green',
   'yellow',
@@ -33,21 +33,21 @@ export const profileColors = z.enum([
 ]);
 
 // TODO(gzdunek): Parse the entire workspace state read from disk like below.
-export function parseProfileColor(
+export function parseWorkspaceColor(
   color: unknown,
   workspaces: Record<
     string,
     {
-      color: ProfileColor;
+      color: WorkspaceColor;
     }
   >
-): ProfileColor {
-  const getDefault = () => getNextProfileColor(workspaces);
-  return profileColors
+): WorkspaceColor {
+  const getDefault = () => getNextWorkspaceColor(workspaces);
+  return workspaceColors
     .default(getDefault)
     .catch(ctx => {
       new Logger('WorkspacesService').error(
-        'Failed to read profile color preference',
+        'Failed to read workspace color preference',
         ctx.error
       );
       return getDefault();
@@ -59,11 +59,11 @@ export function parseProfileColor(
  * Determines the next available unused color across all workspaces.
  * If all colors are already in use, it defaults to returning purple.
  */
-function getNextProfileColor(
-  workspaces: Record<string, { color: ProfileColor }>
-): ProfileColor {
+function getNextWorkspaceColor(
+  workspaces: Record<string, { color: WorkspaceColor }>
+): WorkspaceColor {
   const takenColors = new Set(Object.values(workspaces).map(w => w.color));
-  const allColors = new Set(profileColors.options);
+  const allColors = new Set(workspaceColors.options);
   const unusedColors = allColors.difference(takenColors);
   return unusedColors.size > 0 ? [...unusedColors][0] : 'purple';
 }

--- a/web/packages/teleterm/src/ui/services/workspacesService/index.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/index.ts
@@ -18,3 +18,4 @@
 
 export * from './workspacesService';
 export * from './documentsService';
+export * from './profileColor';

--- a/web/packages/teleterm/src/ui/services/workspacesService/index.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/index.ts
@@ -18,4 +18,4 @@
 
 export * from './workspacesService';
 export * from './documentsService';
-export * from './profileColor';
+export * from './color';

--- a/web/packages/teleterm/src/ui/services/workspacesService/profileColor.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/profileColor.ts
@@ -42,13 +42,15 @@ export function parseProfileColor(
     }
   >
 ): ProfileColor {
+  const getDefault = () => getNextProfileColor(workspaces);
   return profileColors
+    .default(getDefault)
     .catch(ctx => {
       new Logger('WorkspacesService').error(
         'Failed to read profile color preference',
         ctx.error
       );
-      return getNextProfileColor(workspaces);
+      return getDefault();
     })
     .parse(color);
 }

--- a/web/packages/teleterm/src/ui/services/workspacesService/profileColor.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/profileColor.ts
@@ -1,7 +1,3 @@
-import { z } from 'zod';
-
-import Logger from 'teleterm/logger';
-
 /**
  * Teleport
  * Copyright (C) 2025 Gravitational, Inc.
@@ -19,6 +15,10 @@ import Logger from 'teleterm/logger';
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
+import { z } from 'zod';
+
+import Logger from 'teleterm/logger';
 
 export type ProfileColor = z.infer<typeof profileColors>;
 
@@ -65,5 +65,5 @@ function getNextProfileColor(
   const takenColors = new Set(Object.values(workspaces).map(w => w.color));
   const allColors = new Set(profileColors.options);
   const unusedColors = allColors.difference(takenColors);
-  return unusedColors.size >= 0 ? [...unusedColors][0] : 'purple';
+  return unusedColors.size > 0 ? [...unusedColors][0] : 'purple';
 }

--- a/web/packages/teleterm/src/ui/services/workspacesService/profileColor.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/profileColor.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod';
+
+import Logger from 'teleterm/logger';
+
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export type ProfileColor = z.infer<typeof profileColors>;
+
+export const profileColors = z.enum([
+  'purple',
+  'green',
+  'yellow',
+  'red',
+  'cyan',
+  'pink',
+  'blue',
+]);
+
+// TODO(gzdunek): Parse the entire workspace state read from disk like below.
+export function parseProfileColor(
+  color: unknown,
+  workspaces: Record<
+    string,
+    {
+      color: ProfileColor;
+    }
+  >
+): ProfileColor {
+  return profileColors
+    .catch(ctx => {
+      new Logger('WorkspacesService').error(
+        'Failed to read profile color preference',
+        ctx.error
+      );
+      return getNextProfileColor(workspaces);
+    })
+    .parse(color);
+}
+
+/**
+ * Determines the next available unused color across all workspaces.
+ * If all colors are already in use, it defaults to returning purple.
+ */
+function getNextProfileColor(
+  workspaces: Record<string, { color: ProfileColor }>
+): ProfileColor {
+  const takenColors = new Set(Object.values(workspaces).map(w => w.color));
+  const allColors = new Set(profileColors.options);
+  const unusedColors = allColors.difference(takenColors);
+  return unusedColors.size >= 0 ? [...unusedColors][0] : 'purple';
+}

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.test.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.test.ts
@@ -81,6 +81,7 @@ describe('restoring workspace', () => {
           },
           isBarCollapsed: false,
         },
+        color: 'purple',
         localClusterUri: testWorkspace.localClusterUri,
         documents: [expect.objectContaining({ kind: 'doc.cluster' })],
         location: expect.any(String),
@@ -117,6 +118,7 @@ describe('restoring workspace', () => {
             resources: new Map(),
           },
         },
+        color: 'purple',
         localClusterUri: cluster.uri,
         documents: [expect.objectContaining({ kind: 'doc.cluster' })],
         location: expect.any(String),
@@ -132,6 +134,43 @@ describe('restoring workspace', () => {
     });
     expect(workspacesService.getRestoredState().workspaces).toStrictEqual({});
   });
+
+  it('restores profile color from state or assignes if empty', async () => {
+    const clusterFoo = makeRootCluster({ uri: '/clusters/foo' });
+    const workspaceFoo: PersistedWorkspace = {
+      color: 'blue',
+      localClusterUri: clusterFoo.uri,
+      documents: [],
+      location: undefined,
+    };
+    const clusterBar = makeRootCluster({ uri: '/clusters/bar' });
+    const workspaceBar: PersistedWorkspace = {
+      localClusterUri: clusterBar.uri,
+      documents: [],
+      location: undefined,
+    };
+    const clusterBaz = makeRootCluster({ uri: '/clusters/baz' });
+    const workspaceBaz: PersistedWorkspace = {
+      localClusterUri: clusterBaz.uri,
+      documents: [],
+      location: undefined,
+    };
+
+    const { workspacesService } = getTestSetup({
+      cluster: [clusterFoo, clusterBar, clusterBaz],
+      persistedWorkspaces: {
+        [clusterFoo.uri]: workspaceFoo,
+        [clusterBar.uri]: workspaceBar,
+        [clusterBaz.uri]: workspaceBaz,
+      },
+    });
+
+    workspacesService.restorePersistedState();
+
+    expect(workspacesService.getWorkspace(clusterFoo.uri).color).toBe('blue'); // read from disk
+    expect(workspacesService.getWorkspace(clusterBar.uri).color).toBe('purple'); // the first unused color
+    expect(workspacesService.getWorkspace(clusterBaz.uri).color).toBe('green'); // the second unused color
+  });
 });
 
 describe('state persistence', () => {
@@ -146,6 +185,7 @@ describe('state persistence', () => {
             isBarCollapsed: true,
             pending: getEmptyPendingAccessRequest(),
           },
+          color: 'purple',
           localClusterUri: cluster.uri,
           documents: [
             {

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.test.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.test.ts
@@ -135,7 +135,7 @@ describe('restoring workspace', () => {
     expect(workspacesService.getRestoredState().workspaces).toStrictEqual({});
   });
 
-  it('restores profile color from state or assignes if empty', async () => {
+  it('restores profile color from state or assigns if empty', async () => {
     const clusterFoo = makeRootCluster({ uri: '/clusters/foo' });
     const workspaceFoo: PersistedWorkspace = {
       color: 'blue',
@@ -155,13 +155,57 @@ describe('restoring workspace', () => {
       documents: [],
       location: undefined,
     };
+    const clusterQux = makeRootCluster({ uri: '/clusters/qux' });
+    const workspaceQux: PersistedWorkspace = {
+      localClusterUri: clusterQux.uri,
+      documents: [],
+      location: undefined,
+    };
+    const clusterWaldo = makeRootCluster({ uri: '/clusters/waldo' });
+    const workspaceWaldo: PersistedWorkspace = {
+      localClusterUri: clusterWaldo.uri,
+      documents: [],
+      location: undefined,
+    };
+    const clusterFred = makeRootCluster({ uri: '/clusters/fred' });
+    const workspaceFred: PersistedWorkspace = {
+      localClusterUri: clusterFred.uri,
+      documents: [],
+      location: undefined,
+    };
+    const clusterGrault = makeRootCluster({ uri: '/clusters/grault' });
+    const workspaceGrault: PersistedWorkspace = {
+      localClusterUri: clusterGrault.uri,
+      documents: [],
+      location: undefined,
+    };
+    const clusterPlugh = makeRootCluster({ uri: '/clusters/plugh' });
+    const workspacePlugh: PersistedWorkspace = {
+      localClusterUri: clusterPlugh.uri,
+      documents: [],
+      location: undefined,
+    };
 
     const { workspacesService } = getTestSetup({
-      cluster: [clusterFoo, clusterBar, clusterBaz],
+      cluster: [
+        clusterFoo,
+        clusterBar,
+        clusterBaz,
+        clusterQux,
+        clusterWaldo,
+        clusterFred,
+        clusterGrault,
+        clusterPlugh,
+      ],
       persistedWorkspaces: {
         [clusterFoo.uri]: workspaceFoo,
         [clusterBar.uri]: workspaceBar,
         [clusterBaz.uri]: workspaceBaz,
+        [clusterQux.uri]: workspaceQux,
+        [clusterWaldo.uri]: workspaceWaldo,
+        [clusterFred.uri]: workspaceFred,
+        [clusterGrault.uri]: workspaceGrault,
+        [clusterPlugh.uri]: workspacePlugh,
       },
     });
 
@@ -169,7 +213,16 @@ describe('restoring workspace', () => {
 
     expect(workspacesService.getWorkspace(clusterFoo.uri).color).toBe('blue'); // read from disk
     expect(workspacesService.getWorkspace(clusterBar.uri).color).toBe('purple'); // the first unused color
-    expect(workspacesService.getWorkspace(clusterBaz.uri).color).toBe('green'); // the second unused color
+    expect(workspacesService.getWorkspace(clusterBaz.uri).color).toBe('green');
+    expect(workspacesService.getWorkspace(clusterQux.uri).color).toBe('yellow');
+    expect(workspacesService.getWorkspace(clusterWaldo.uri).color).toBe('red');
+    expect(workspacesService.getWorkspace(clusterFred.uri).color).toBe('cyan');
+    expect(workspacesService.getWorkspace(clusterGrault.uri).color).toBe(
+      'pink'
+    );
+    expect(workspacesService.getWorkspace(clusterPlugh.uri).color).toBe(
+      'purple'
+    ); // we have run out of colors, assign the default purple color
   });
 });
 

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.test.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.test.ts
@@ -31,14 +31,14 @@ import { makeDocumentCluster } from 'teleterm/ui/services/workspacesService/docu
 import { ClustersService } from '../clusters';
 import { ModalsService } from '../modals';
 import { NotificationsService } from '../notifications';
-import { StatePersistenceService } from '../statePersistence';
+import {
+  PersistedWorkspace,
+  StatePersistenceService,
+  WorkspacesPersistedState,
+} from '../statePersistence';
 import { getEmptyPendingAccessRequest } from './accessRequestsService';
 import { DocumentCluster, DocumentsService } from './documentsService';
-import {
-  Workspace,
-  WorkspacesService,
-  WorkspacesState,
-} from './workspacesService';
+import { WorkspacesService, WorkspacesState } from './workspacesService';
 
 beforeAll(() => {
   Logger.init(new NullService());
@@ -51,11 +51,7 @@ beforeEach(() => {
 describe('restoring workspace', () => {
   it('restores the workspace if there is a persisted state for given clusterUri', () => {
     const cluster = makeRootCluster();
-    const testWorkspace: Workspace = {
-      accessRequests: {
-        isBarCollapsed: true,
-        pending: getEmptyPendingAccessRequest(),
-      },
+    const testWorkspace: PersistedWorkspace = {
       localClusterUri: cluster.uri,
       documents: [
         {
@@ -309,11 +305,7 @@ describe('setActiveWorkspace', () => {
 
   it('sets location to first document if location points to non-existing document when reopening documents', async () => {
     const cluster = makeRootCluster();
-    const testWorkspace: Workspace = {
-      accessRequests: {
-        isBarCollapsed: true,
-        pending: getEmptyPendingAccessRequest(),
-      },
+    const testWorkspace: PersistedWorkspace = {
       localClusterUri: cluster.uri,
       documents: [
         {
@@ -374,11 +366,7 @@ describe('setActiveWorkspace', () => {
   it('ongoing setActive call is canceled when the method is called again', async () => {
     const clusterFoo = makeRootCluster({ uri: '/clusters/foo' });
     const clusterBar = makeRootCluster({ uri: '/clusters/bar' });
-    const workspace1: Workspace = {
-      accessRequests: {
-        isBarCollapsed: true,
-        pending: getEmptyPendingAccessRequest(),
-      },
+    const workspace1: PersistedWorkspace = {
       localClusterUri: clusterFoo.uri,
       documents: [
         {
@@ -410,7 +398,7 @@ describe('setActiveWorkspace', () => {
 
 function getTestSetup(options: {
   cluster: tshd.Cluster | tshd.Cluster[] | undefined;
-  persistedWorkspaces: Record<string, Workspace>;
+  persistedWorkspaces: WorkspacesPersistedState['workspaces'];
 }) {
   const { cluster } = options;
 

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
@@ -385,6 +385,8 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
       }
     }
     // If we don't have a workspace for this cluster, add it.
+    // TODO(gzdunek): Creating a workspace here might not be necessary
+    // after we started calling workspacesService.addWorkspace in ClusterAdd.
     this.setState(draftState => {
       if (!draftState.workspaces[clusterUri]) {
         draftState.workspaces[clusterUri] = getWorkspaceDefaultState(

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
@@ -55,6 +55,7 @@ import {
   getEmptyPendingAccessRequest,
   PendingAccessRequest,
 } from './accessRequestsService';
+import { parseWorkspaceColor, WorkspaceColor } from './color';
 import {
   createClusterDocument,
   Document,
@@ -65,7 +66,6 @@ import {
   DocumentTshNode,
   getDefaultDocumentClusterQueryParams,
 } from './documentsService';
-import { parseProfileColor, ProfileColor } from './profileColor';
 
 export interface WorkspacesState {
   rootClusterUri?: RootClusterUri;
@@ -84,7 +84,7 @@ export interface WorkspacesState {
 
 export interface Workspace {
   localClusterUri: ClusterUri;
-  color: ProfileColor;
+  color: WorkspaceColor;
   documents: Document[];
   location: DocumentUri | undefined;
   accessRequests: {
@@ -179,9 +179,9 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
     });
   }
 
-  changeProfileColor(
+  changeWorkspaceColor(
     rootClusterUri: RootClusterUri,
-    color: ProfileColor
+    color: WorkspaceColor
   ): void {
     this.setState(draftState => {
       draftState.workspaces[rootClusterUri].color = color;
@@ -676,7 +676,7 @@ function getWorkspaceDefaultState(
     hasDocumentsToReopen: false,
     localClusterUri: rootClusterUri,
     unifiedResourcePreferences: parseUnifiedResourcePreferences(undefined),
-    color: parseProfileColor(undefined, workspaces),
+    color: parseWorkspaceColor(undefined, workspaces),
   };
   if (!restoredWorkspace) {
     return defaultWorkspace;
@@ -686,7 +686,7 @@ function getWorkspaceDefaultState(
   defaultWorkspace.unifiedResourcePreferences = parseUnifiedResourcePreferences(
     restoredWorkspace.unifiedResourcePreferences
   );
-  defaultWorkspace.color = parseProfileColor(
+  defaultWorkspace.color = parseWorkspaceColor(
     restoredWorkspace.color,
     workspaces
   );


### PR DESCRIPTION
This is the part 1/2 of the redesigned profile switcher. It adds an API to storing a profile color in workspaces. The color is generated when we add a new workspace or when we restore persisted state and don't find a color in the workspace.
I prepared a list of 7 colors, I don't think people have more clusters than that.

Adding a new property to the workspace state wasn't too nice - I got about 30 TS errors about a missing property in or stories/tests. To fix this for good, I replaced all the places where we construct a workspace manually with a new `addRootClusterWithDoc` helper. Kudos to Rafał for adding it, it helped me a lot!