### PR TITLE
Reduce Connect macOS entitlements to just allow-jit

### DIFF
--- a/web/packages/teleterm/build_resources/entitlements.mac.plist
+++ b/web/packages/teleterm/build_resources/entitlements.mac.plist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <!-- https://github.com/electron/electron-notarize#prerequisites -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+  </dict>
+</plist>


### PR DESCRIPTION
Closes #51397.

By default, [electron-builder applies three entitlements](https://github.com/electron-userland/electron-builder/blob/121b4736ffc12fb0a7b7e74fe51be04c2bd95a5e/packages/app-builder-lib/templates/entitlements.mac.plist#L8):

* [`com.apple.security.cs.allow-jit`](https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.security.cs.allow-jit?language=objc)
* [`com.apple.security.cs.allow-unsigned-executable-memory`](https://developer.apple.com/documentation/BundleResources/Entitlements/com.apple.security.cs.allow-unsigned-executable-memory?language=objc)
* [`com.apple.security.cs.disable-library-validation`](https://developer.apple.com/documentation/BundleResources/Entitlements/com.apple.security.cs.disable-library-validation?language=objc)

`com.apple.security.cs.allow-jit` is [required for the hardened runtime setting](https://github.com/electron/notarize#prerequisites). AFAIK, this is so that the app is allowed to run uh, basically any JavaScript code since all of it is "JIT-compiled".

notarize's readme later says:

> If you are using Electron 11 or below, you must add the `com.apple.security.cs.allow-unsigned-executable-memory` entitlement too. When using version 12+, this entitlement should not be applied as it increases your app's attack surface.

We're way past Electron 11, it doesn't seem to be needed. On top of that, I found that [this entitlement is a less secure version of `allow-jit`](https://forums.developer.apple.com/forums/thread/757540?answerId=792112022#792112022), so if you have it defined, you don't need `allow-jit` in the first place.

For `com.apple.security.cs.disable-library-validation`, there's a link in electron-builder's entitlement file to https://github.com/electron-userland/electron-builder/issues/3940. This entitlement was enabled by default so that people can run executables that are inside the ASAR archive. I don't think having them in the ASAR archive is a particularly good idea. We don't do it, so we shouldn't need this entitlement.

## Verifying the changes

I built and locally signed Teleport Connect with changes from this branch. Since `disable-library-validation` is now not a thing, I had to build tsh with FIDO2=static. This way FIDO2 is baked into tsh.app and then signed. This is how we build the "production" version of tsh.app anyway.

This means that if you build app locally, you might need to build tsh with `FIDO2=static` too. I think it might turn out to be false, since I don't think entitlements mean much until you sign or notarize the app. I haven't tested it yet though.

However, the app built and signed with just allow-jit seems to work fine. I can access SSH resources, Connect My Computer works too. I'm building [v18.0.0-dev.ravicious.4](https://github.com/gravitational/teleport.e/actions/runs/12933602871) to verify that an app that goes through our usual pipeline (which means signing + notarizing) still works and that the VNet daemon still runs properly (I'm 80% sure it won't impact VNet).

## Backporting

I don't think it's necessary to run it through the whole test plan before backporting, as long as we verify that all types of resources can be accessed and that Connect My Computer and VNet work. The removed entitlements seem to have to do purely with executable code and those features are the only place where we do something unconventional.

tsh.app uses hardened runtime too and has none of the entitlements listed here, so we can be sure that any extra libraries loaded by tsh are baked in the executable and signed, just like the rest of the code.