### PR TITLE
Use loadBalancingConfig instead of loadBalancingPolicy

### DIFF
--- a/lib/proxy/peer/client.go
+++ b/lib/proxy/peer/client.go
@@ -781,7 +781,7 @@ func (c *Client) connect(params connectParams) (internal.ClientConn, error) {
 			Timeout:             peerTimeout,
 			PermitWithoutStream: true,
 		}),
-		grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy":"round_robin"}`),
+		grpc.WithDefaultServiceConfig(`{"loadBalancingConfig": [{"round_robin": {}}]}`),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err, "Error dialing proxy %q", params.peerID)

--- a/lib/srv/discovery/access_graph_aws.go
+++ b/lib/srv/discovery/access_graph_aws.go
@@ -54,7 +54,7 @@ const (
 	// automatically reconnect if the connection is lost without
 	// relying on new events from the auth server to trigger a reconnect.
 	serviceConfig = `{
-		 "loadBalancingPolicy": "round_robin",
+		 "loadBalancingConfig": [{"round_robin": {}}],
 		 "healthCheckConfig": {
 			 "serviceName": ""
 		 }


### PR DESCRIPTION
loadBalancingPolicy is deprecated in favor of loadBalancingConfig.

- https://github.com/grpc/grpc-proto/blob/483f11e91a30de9c11d65d872c09bc529e94e2ee/grpc/service_config/service_config.proto#L567-L569