### PR TITLE
OCI join method - Add server auth ceremony

### DIFF
--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -921,6 +921,9 @@ func (a *ProvisionTokenSpecV2Bitbucket) checkAndSetDefaults() error {
 	return nil
 }
 
+// checkAndSetDefaults checks and sets defaults on the Oracle spec. This only
+// covers basics like the presence of required fields; more complex validation
+// (e.g. requiring the Oracle SDK) is in auth.validateOracleJoinToken.
 func (a *ProvisionTokenSpecV2Oracle) checkAndSetDefaults() error {
 	if len(a.Allow) == 0 {
 		return trace.BadParameter("the %q join method requires at least one allow rule", JoinMethodOracle)

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -236,6 +236,7 @@ require (
 	github.com/okta/okta-sdk-golang/v2 v2.20.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
+	github.com/oracle/oci-go-sdk/v65 v65.81.0 // indirect
 	github.com/patrickmn/go-cache v2.1.1-0.20191004192108-46f407853014+incompatible // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
@@ -257,6 +258,7 @@ require (
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sijms/go-ora/v2 v2.8.23 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
+	github.com/sony/gobreaker v0.5.0 // indirect
 	github.com/spf13/cast v1.7.0 // indirect
 	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/integrations/event-handler/go.sum
+++ b/integrations/event-handler/go.sum
@@ -373,6 +373,7 @@ github.com/gobwas/pool v0.2.1 h1:xfeeEhW7pwmX8nuLVlqbzVc7udMDrwetjEv+TZIz1og=
 github.com/gobwas/pool v0.2.1/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.4.0 h1:CTaoG1tojrh4ucGPcoJFiAQUAsEWekEWvLy7GsVNqGs=
 github.com/gobwas/ws v1.4.0/go.mod h1:G3gNqMNtPppf5XUz7O4shetPpcZ1VJ7zt18dlUeakrc=
+github.com/gofrs/flock v0.8.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gofrs/flock v0.12.1 h1:MTLVXXHf8ekldpJk3AKicLij9MdwOWkZ+a/jHHZby9E=
 github.com/gofrs/flock v0.12.1/go.mod h1:9zxTsyu5xtJ9DK+1tFZyibEV7y3uwDxPPfbxeeHCoD0=
 github.com/golang-jwt/jwt/v4 v4.5.1 h1:JdqV9zKUdtaa9gdPlywC3aeoEsR681PlKC+4F5gQgeo=
@@ -758,6 +759,8 @@ github.com/spiffe/go-spiffe/v2 v2.5.0 h1:N2I01KCUkv1FAjZXJMwh95KK1ZIQLYbPfhaxw8W
 github.com/spiffe/go-spiffe/v2 v2.5.0/go.mod h1:P+NxobPc6wXhVtINNtFjNWGBTreew1GBUCwT2wPmb7g=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -766,6 +769,9 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/thales-e-security/pool v0.0.2 h1:RAPs4q2EbWsTit6tpzuvTFlgFRJ3S8Evf5gtvVDbmPg=

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -52,6 +52,7 @@ import (
 	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/clusterconfig/clusterconfigv1"
+	"github.com/gravitational/teleport/lib/auth/join/oracle"
 	"github.com/gravitational/teleport/lib/auth/okta"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend"
@@ -2392,6 +2393,40 @@ func enforceEnterpriseJoinMethodCreation(token types.ProvisionToken) error {
 	return nil
 }
 
+// validateOracleJoinToken validates the fields in a token using the Oracle
+// join method. It's done here instead of in the client so the client doesn't
+// have to import the Oracle SDK.
+func validateOracleJoinToken(token types.ProvisionToken) error {
+	if token.GetJoinMethod() != types.JoinMethodOracle {
+		return nil
+	}
+
+	tokenV2, ok := token.(*types.ProvisionTokenV2)
+	if !ok {
+		return trace.BadParameter("%v join method requires ProvisionTokenV2", types.JoinMethodOracle)
+	}
+	oracleSpec := tokenV2.Spec.Oracle
+	if oracleSpec == nil {
+		return trace.BadParameter("missing spec")
+	}
+	for _, allow := range oracleSpec.Allow {
+		if _, err := oracle.ParseRegionFromOCID(allow.Tenancy); err != nil {
+			return trace.BadParameter("invalid tenant: %v", allow.Tenancy)
+		}
+		for _, compartment := range allow.ParentCompartments {
+			if _, err := oracle.ParseRegionFromOCID(compartment); err != nil {
+				return trace.BadParameter("invalid compartment: %v", compartment)
+			}
+		}
+		for _, region := range allow.Regions {
+			if canonicalRegion, _ := oracle.ParseRegion(region); canonicalRegion == "" {
+				return trace.BadParameter("invalid region: %v", region)
+			}
+		}
+	}
+	return nil
+}
+
 // emitTokenEvent is called by Create/Upsert Token in order to emit any relevant
 // events.
 func emitTokenEvent(ctx context.Context, e apievents.Emitter, token types.ProvisionToken,
@@ -2429,6 +2464,10 @@ func (a *ServerWithRoles) UpsertToken(ctx context.Context, token types.Provision
 		return trace.Wrap(err)
 	}
 
+	if err := validateOracleJoinToken(token); err != nil {
+		return trace.Wrap(err)
+	}
+
 	if err := a.authServer.UpsertToken(ctx, token); err != nil {
 		return trace.Wrap(err)
 	}
@@ -2447,6 +2486,10 @@ func (a *ServerWithRoles) CreateToken(ctx context.Context, token types.Provision
 	}
 
 	if err := enforceEnterpriseJoinMethodCreation(token); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := validateOracleJoinToken(token); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -10015,3 +10015,88 @@ func paginatedAppPermissionSet(src *identitycenterv1.PermissionSetInfo) *types.I
 		AssignmentID: src.AssignmentId,
 	}
 }
+
+func TestValidateOracleJoinToken(t *testing.T) {
+	t.Parallel()
+	makeToken := func(spec types.ProvisionTokenSpecV2) types.ProvisionToken {
+		spec.JoinMethod = types.JoinMethodOracle
+		spec.Roles = []types.SystemRole{types.RoleNode}
+		token, err := types.NewProvisionTokenFromSpec("foo", time.Now().Add(time.Hour), spec)
+		require.NoError(t, err)
+		return token
+	}
+
+	t.Run("oracle", func(t *testing.T) {
+		tests := []struct {
+			name   string
+			token  types.ProvisionToken
+			assert require.ErrorAssertionFunc
+		}{
+			{
+				name: "ok",
+				token: makeToken(types.ProvisionTokenSpecV2{
+					Oracle: &types.ProvisionTokenSpecV2Oracle{
+						Allow: []*types.ProvisionTokenSpecV2Oracle_Rule{
+							{
+								Tenancy:            makeTenancyID("foo"),
+								ParentCompartments: []string{makeCompartmentID("foo"), makeCompartmentID("bar")},
+								Regions:            []string{"us-phoenix-1", "iad"},
+							},
+						},
+					},
+				}),
+				assert: require.NoError,
+			},
+			{
+				name: "invalid tenant",
+				token: makeToken(types.ProvisionTokenSpecV2{
+					Oracle: &types.ProvisionTokenSpecV2Oracle{
+						Allow: []*types.ProvisionTokenSpecV2Oracle_Rule{
+							{
+								Tenancy:            "foo",
+								ParentCompartments: []string{makeCompartmentID("foo"), makeCompartmentID("bar")},
+								Regions:            []string{"us-phoenix-1", "iad"},
+							},
+						},
+					},
+				}),
+				assert: require.Error,
+			},
+			{
+				name: "invalid compartment",
+				token: makeToken(types.ProvisionTokenSpecV2{
+					Oracle: &types.ProvisionTokenSpecV2Oracle{
+						Allow: []*types.ProvisionTokenSpecV2Oracle_Rule{
+							{
+								Tenancy:            makeTenancyID("foo"),
+								ParentCompartments: []string{"foo", makeCompartmentID("bar")},
+								Regions:            []string{"us-phoenix-1", "iad"},
+							},
+						},
+					},
+				}),
+				assert: require.Error,
+			},
+			{
+				name: "invalid region",
+				token: makeToken(types.ProvisionTokenSpecV2{
+					Oracle: &types.ProvisionTokenSpecV2Oracle{
+						Allow: []*types.ProvisionTokenSpecV2Oracle_Rule{
+							{
+								Tenancy:            makeTenancyID("foo"),
+								ParentCompartments: []string{makeCompartmentID("foo"), makeCompartmentID("bar")},
+								Regions:            []string{"invalid", "iad"},
+							},
+						},
+					},
+				}),
+				assert: require.Error,
+			},
+		}
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				tc.assert(t, validateOracleJoinToken(tc.token))
+			})
+		}
+	})
+}

--- a/lib/auth/join/oracle/oracle_test.go
+++ b/lib/auth/join/oracle/oracle_test.go
@@ -85,7 +85,7 @@ func TestCreateSignedRequest(t *testing.T) {
 		nil,
 	)
 
-	innerHeader, outerHeader, err := createSignedRequest(provider, "challenge")
+	innerHeader, outerHeader, err := CreateSignedRequestWithProvider(provider, "challenge")
 	require.NoError(t, err)
 
 	expectedHeaders := map[string]string{

--- a/lib/auth/join_oracle.go
+++ b/lib/auth/join_oracle.go
@@ -18,12 +18,19 @@ package auth
 
 import (
 	"context"
+	"encoding/base64"
+	"net/http"
+	"slices"
+	"strings"
+	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/join/oracle"
 )
 
 // RegisterUsingOracleMethod registers the caller using the Oracle join method and
@@ -33,5 +40,196 @@ func (a *Server) RegisterUsingOracleMethod(
 	tokenReq *types.RegisterUsingTokenRequest,
 	challengeResponse client.RegisterOracleChallengeResponseFunc,
 ) (certs *proto.Certs, err error) {
-	return nil, trace.NotImplemented("Not implemented")
+	certs, err = a.registerUsingOracleMethod(ctx, tokenReq, challengeResponse, oracle.FetchOraclePrincipalClaims)
+	return certs, trace.Wrap(err)
+}
+
+type oracleClaimsFetcher func(ctx context.Context, req *http.Request) (oracle.Claims, error)
+
+func (a *Server) registerUsingOracleMethod(
+	ctx context.Context,
+	tokenReq *types.RegisterUsingTokenRequest,
+	challengeResponse client.RegisterOracleChallengeResponseFunc,
+	fetchClaims oracleClaimsFetcher,
+) (certs *proto.Certs, err error) {
+	var provisionToken types.ProvisionToken
+	var claims oracle.Claims
+	defer func() {
+		// Emit a log message and audit event on join failure.
+		if err != nil {
+			a.handleJoinFailure(
+				ctx, err, provisionToken, claims, tokenReq,
+			)
+		}
+	}()
+
+	challenge, err := generateOracleChallenge()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	req, err := challengeResponse(challenge)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	provisionToken, err = a.checkTokenJoinRequestCommon(ctx, tokenReq)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	claims, err = a.checkOracleRequest(ctx, challenge, tokenReq, req, fetchClaims)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if tokenReq.Role == types.RoleBot {
+		certs, err := a.generateCertsBot(
+			ctx,
+			provisionToken,
+			tokenReq,
+			claims,
+			nil,
+		)
+		return certs, trace.Wrap(err)
+	}
+	certs, err = a.generateCerts(
+		ctx,
+		provisionToken,
+		tokenReq,
+		claims,
+	)
+	return certs, trace.Wrap(err)
+}
+
+func generateOracleChallenge() (string, error) {
+	challenge, err := generateChallenge(base64.StdEncoding, 32)
+	return challenge, trace.Wrap(err)
+}
+
+func checkHeaders(headers http.Header, challenge string, clock clockwork.Clock) error {
+	// Check that required headers are signed.
+	authHeader := oracle.GetAuthorizationHeaderValues(headers)
+	rawSignedHeaders, ok := authHeader["headers"]
+	if !ok {
+		return trace.BadParameter("missing list of signed headers")
+	}
+	signedHeaders := strings.Split(rawSignedHeaders, " ")
+	if !slices.Contains(signedHeaders, oracle.DateHeader) {
+		return trace.BadParameter("header %s is not signed", oracle.DateHeader)
+	}
+	if !slices.Contains(signedHeaders, oracle.ChallengeHeader) {
+		return trace.BadParameter("header %s is not signed", oracle.ChallengeHeader)
+	}
+
+	// Check X-Date.
+	now := clock.Now().UTC()
+	rawHeaderDate := headers.Get(oracle.DateHeader)
+	if rawHeaderDate == "" {
+		return trace.BadParameter("missing header %v", oracle.DateHeader)
+	}
+	headerDate, err := time.Parse(http.TimeFormat, rawHeaderDate)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if headerDate.Add(5 * time.Minute).Before(now) {
+		return trace.BadParameter("header time is more than 5 minutes from now")
+	}
+
+	// Check challenge.
+	if headers.Get(oracle.ChallengeHeader) != challenge {
+		return trace.BadParameter("challenge does not match")
+	}
+
+	return nil
+}
+
+func checkOracleAllowRules(claims oracle.Claims, token string, allowRules []*types.ProvisionTokenSpecV2Oracle_Rule) error {
+	for _, rule := range allowRules {
+		if rule.Tenancy != claims.TenancyID {
+			continue
+		}
+		if len(rule.ParentCompartments) != 0 && !slices.Contains(rule.ParentCompartments, claims.CompartmentID) {
+			continue
+		}
+		if len(rule.Regions) != 0 && !slices.ContainsFunc(rule.Regions, func(region string) bool {
+			canonicalRegion, _ := oracle.ParseRegion(region)
+			return canonicalRegion == claims.Region()
+		}) {
+			continue
+		}
+		return nil
+	}
+	return trace.AccessDenied("instance %v did not match any allow rules in token %v", claims.InstanceID, token)
+}
+
+func formatHeaderFromMap(m map[string]string) http.Header {
+	header := make(http.Header, len(m))
+	for k, v := range m {
+		header.Set(k, v)
+	}
+	return header
+}
+
+func getRegionFromHost(host string) (string, error) {
+	regionEndpoint, foundAuth := strings.CutPrefix(host, "auth.")
+	rawRegion, foundOracleCloud := strings.CutSuffix(regionEndpoint, ".oraclecloud.com")
+	if !foundAuth || !foundOracleCloud {
+		return "", trace.BadParameter("expected host auth.{region}.oraclecloud.com, got %s", host)
+	}
+	region, _ := oracle.ParseRegion(rawRegion)
+	if region == "" {
+		return "", trace.BadParameter("missing or invalid region")
+	}
+	return region, nil
+}
+
+func (a *Server) checkOracleRequest(
+	ctx context.Context,
+	challenge string,
+	tokenReq *types.RegisterUsingTokenRequest,
+	oracleReq *proto.OracleSignedRequest,
+	fetchClaims oracleClaimsFetcher,
+) (oracle.Claims, error) {
+	// Check shared token parameters.
+	provisionToken, err := a.GetToken(ctx, tokenReq.Token)
+	if err != nil {
+		return oracle.Claims{}, trace.Wrap(err)
+	}
+	if provisionToken.GetJoinMethod() != types.JoinMethodOracle {
+		return oracle.Claims{}, trace.AccessDenied("this token does not support the Oracle join method")
+	}
+
+	// Check signed headers.
+	outerHeaders := formatHeaderFromMap(oracleReq.Headers)
+	innerHeaders := formatHeaderFromMap(oracleReq.PayloadHeaders)
+	if err := checkHeaders(outerHeaders, challenge, a.GetClock()); err != nil {
+		return oracle.Claims{}, trace.Wrap(err)
+	}
+	if err := checkHeaders(innerHeaders, challenge, a.GetClock()); err != nil {
+		return oracle.Claims{}, trace.Wrap(err)
+	}
+
+	// Authenticate request with Oracle.
+	region, err := getRegionFromHost(outerHeaders.Get("host"))
+	if err != nil {
+		return oracle.Claims{}, trace.Wrap(err)
+	}
+	authReq, err := oracle.CreateRequestFromHeaders(region, innerHeaders, outerHeaders)
+	if err != nil {
+		return oracle.Claims{}, trace.Wrap(err)
+	}
+	claims, err := fetchClaims(ctx, authReq)
+	if err != nil {
+		return oracle.Claims{}, trace.Wrap(err)
+	}
+
+	// Check allow rules.
+	tokenV2, ok := provisionToken.(*types.ProvisionTokenV2)
+	if !ok {
+		return oracle.Claims{}, trace.BadParameter("oracle join method only supports ProvisionTokenV2")
+	}
+	if err := checkOracleAllowRules(claims, provisionToken.GetName(), tokenV2.Spec.Oracle.Allow); err != nil {
+		return oracle.Claims{}, trace.Wrap(err)
+	}
+
+	return claims, nil
 }

--- a/lib/auth/join_oracle_test.go
+++ b/lib/auth/join_oracle_test.go
@@ -1,0 +1,437 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/join/oracle"
+	"github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/fixtures"
+)
+
+func TestCheckHeaders(t *testing.T) {
+	t.Parallel()
+	clock := clockwork.NewFakeClock()
+
+	defaultChallenge := "abcd1234"
+	defaultAuthHeader := `Signature headers="x-date x-teleport-challenge"`
+
+	t.Run("ok", func(t *testing.T) {
+		headers := formatHeaderFromMap(map[string]string{
+			"Authorization":        defaultAuthHeader,
+			oracle.DateHeader:      clock.Now().UTC().Format(http.TimeFormat),
+			oracle.ChallengeHeader: defaultChallenge,
+		})
+		require.NoError(t, checkHeaders(headers, defaultChallenge, clock))
+	})
+
+	tests := []struct {
+		name    string
+		headers map[string]string
+	}{
+		{
+			name: "missing signed headers",
+			headers: map[string]string{
+				"Authorization":        `Signature foo="bar"`,
+				oracle.DateHeader:      clock.Now().UTC().Format(http.TimeFormat),
+				oracle.ChallengeHeader: defaultChallenge,
+			},
+		},
+		{
+			name: "date not signed",
+			headers: map[string]string{
+				"Authorization":        `Signature headers="x-teleport-challenge"`,
+				oracle.DateHeader:      clock.Now().UTC().Format(http.TimeFormat),
+				oracle.ChallengeHeader: defaultChallenge,
+			},
+		},
+		{
+			name: "challenge not signed",
+			headers: map[string]string{
+				"Authorization":        `Signature headers="x-date"`,
+				oracle.DateHeader:      clock.Now().UTC().Format(http.TimeFormat),
+				oracle.ChallengeHeader: defaultChallenge,
+			},
+		},
+		{
+			name: "missing date",
+			headers: map[string]string{
+				"Authorization":        defaultAuthHeader,
+				oracle.ChallengeHeader: defaultChallenge,
+			},
+		},
+		{
+			name: "date too early",
+			headers: map[string]string{
+				"Authorization":        defaultAuthHeader,
+				oracle.DateHeader:      clock.Now().Add(-10 * time.Minute).UTC().Format(http.TimeFormat),
+				oracle.ChallengeHeader: defaultChallenge,
+			},
+		},
+		{
+			name: "missing challenge",
+			headers: map[string]string{
+				"Authorization":   defaultAuthHeader,
+				oracle.DateHeader: clock.Now().UTC().Format(http.TimeFormat),
+			},
+		},
+		{
+			name: "challenge does not match",
+			headers: map[string]string{
+				"Authorization":        defaultAuthHeader,
+				oracle.DateHeader:      clock.Now().UTC().Format(http.TimeFormat),
+				oracle.ChallengeHeader: "differentchallenge",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Error(t, checkHeaders(formatHeaderFromMap(tc.headers), defaultChallenge, clock))
+		})
+	}
+}
+
+func makeOCID(resourceType, region, id string) string {
+	return fmt.Sprintf("ocid1.%s.oc1.%s.%s", resourceType, region, id)
+}
+
+func makeTenancyID(id string) string {
+	return makeOCID("tenancy", "", id)
+}
+
+func makeCompartmentID(id string) string {
+	return makeOCID("compartment", "", id)
+}
+
+func makeInstanceID(region, id string) string {
+	return makeOCID("instance", region, id)
+}
+
+func TestCheckOracleAllowRules(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		claims     oracle.Claims
+		allowRules []*types.ProvisionTokenSpecV2Oracle_Rule
+		assert     require.ErrorAssertionFunc
+	}{
+		{
+			name: "ok",
+			claims: oracle.Claims{
+				TenancyID:     makeTenancyID("foo"),
+				CompartmentID: makeCompartmentID("bar"),
+				InstanceID:    makeInstanceID("us-phoenix-1", "baz"),
+			},
+			allowRules: []*types.ProvisionTokenSpecV2Oracle_Rule{
+				{
+					Tenancy:            makeTenancyID("foo"),
+					ParentCompartments: []string{makeCompartmentID("bar")},
+					Regions:            []string{"us-phoenix-1"},
+				},
+			},
+			assert: require.NoError,
+		},
+		{
+			name: "ok with compartment wildcard",
+			claims: oracle.Claims{
+				TenancyID:     makeTenancyID("foo"),
+				CompartmentID: makeCompartmentID("bar"),
+				InstanceID:    makeInstanceID("us-phoenix-1", "baz"),
+			},
+			allowRules: []*types.ProvisionTokenSpecV2Oracle_Rule{
+				{
+					Tenancy: makeTenancyID("foo"),
+					Regions: []string{"us-phoenix-1"},
+				},
+			},
+			assert: require.NoError,
+		},
+		{
+			name: "ok with region wildcard",
+			claims: oracle.Claims{
+				TenancyID:     makeTenancyID("foo"),
+				CompartmentID: makeCompartmentID("bar"),
+				InstanceID:    makeInstanceID("us-phoenix-1", "baz"),
+			},
+			allowRules: []*types.ProvisionTokenSpecV2Oracle_Rule{
+				{
+					Tenancy:            makeTenancyID("foo"),
+					ParentCompartments: []string{makeCompartmentID("bar")},
+				},
+			},
+			assert: require.NoError,
+		},
+		{
+			name: "ok with region abbreviation in id",
+			claims: oracle.Claims{
+				TenancyID:     makeTenancyID("foo"),
+				CompartmentID: makeCompartmentID("bar"),
+				InstanceID:    makeInstanceID("phx", "baz"),
+			},
+			allowRules: []*types.ProvisionTokenSpecV2Oracle_Rule{
+				{
+					Tenancy:            makeTenancyID("foo"),
+					ParentCompartments: []string{makeCompartmentID("bar")},
+					Regions:            []string{"us-phoenix-1"},
+				},
+			},
+			assert: require.NoError,
+		},
+		{
+			name: "ok with region abbreviation in token",
+			claims: oracle.Claims{
+				TenancyID:     makeTenancyID("foo"),
+				CompartmentID: makeCompartmentID("bar"),
+				InstanceID:    makeInstanceID("us-phoenix-1", "baz"),
+			},
+			allowRules: []*types.ProvisionTokenSpecV2Oracle_Rule{
+				{
+					Tenancy:            makeTenancyID("foo"),
+					ParentCompartments: []string{makeCompartmentID("bar")},
+					Regions:            []string{"phx"},
+				},
+			},
+			assert: require.NoError,
+		},
+		{
+			name: "wrong tenancy",
+			claims: oracle.Claims{
+				TenancyID:     makeTenancyID("something-else"),
+				CompartmentID: makeCompartmentID("bar"),
+				InstanceID:    makeInstanceID("us-phoenix-1", "baz"),
+			},
+			allowRules: []*types.ProvisionTokenSpecV2Oracle_Rule{
+				{
+					Tenancy:            makeTenancyID("foo"),
+					ParentCompartments: []string{makeCompartmentID("bar")},
+					Regions:            []string{"us-phoenix-1"},
+				},
+			},
+			assert: require.Error,
+		},
+		{
+			name: "wrong compartment",
+			claims: oracle.Claims{
+				TenancyID:     makeTenancyID("foo"),
+				CompartmentID: makeCompartmentID("something-else"),
+				InstanceID:    makeInstanceID("us-phoenix-1", "baz"),
+			},
+			allowRules: []*types.ProvisionTokenSpecV2Oracle_Rule{
+				{
+					Tenancy:            makeTenancyID("foo"),
+					ParentCompartments: []string{makeCompartmentID("bar")},
+					Regions:            []string{"us-phoenix-1"},
+				},
+			},
+			assert: require.Error,
+		},
+		{
+			name: "wrong region",
+			claims: oracle.Claims{
+				TenancyID:     makeTenancyID("foo"),
+				CompartmentID: makeCompartmentID("bar"),
+				InstanceID:    makeInstanceID("us-ashburn-1", "baz"),
+			},
+			allowRules: []*types.ProvisionTokenSpecV2Oracle_Rule{
+				{
+					Tenancy:            makeTenancyID("foo"),
+					ParentCompartments: []string{makeCompartmentID("bar")},
+					Regions:            []string{"us-phoenix-1"},
+				},
+			},
+			assert: require.Error,
+		},
+		{
+			name: "block match across rules",
+			claims: oracle.Claims{
+				TenancyID:     makeTenancyID("foo"),
+				CompartmentID: makeCompartmentID("bar"),
+				InstanceID:    makeInstanceID("us-phoenix-1", "baz"),
+			},
+			allowRules: []*types.ProvisionTokenSpecV2Oracle_Rule{
+				{
+					Tenancy: makeTenancyID("foo"),
+					Regions: []string{"us-ashburn-1"},
+				},
+				{
+					Tenancy: makeTenancyID("something-else"),
+				},
+			},
+			assert: require.Error,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.assert(t, checkOracleAllowRules(tc.claims, "mytoken", tc.allowRules))
+		})
+	}
+}
+
+func mapFromHeader(header http.Header) map[string]string {
+	out := make(map[string]string, len(header))
+	for k := range header {
+		out[k] = header.Get(k)
+	}
+	return out
+}
+
+func TestRegisterUsingOracleMethod(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	p, err := newTestPack(ctx, t.TempDir())
+	require.NoError(t, err)
+	a := p.a
+
+	pemBytes, ok := fixtures.PEMBytes["rsa"]
+	require.True(t, ok)
+
+	provider := common.NewRawConfigurationProvider(
+		"ocid1.tenancy.oc1..abcd1234",
+		"ocid1.user.oc1..abcd1234",
+		"us-ashburn-1",
+		"fingerprint",
+		string(pemBytes),
+		nil,
+	)
+
+	sshPrivateKey, sshPublicKey, err := testauthority.New().GenerateKeyPair()
+	require.NoError(t, err)
+
+	tlsPublicKey, err := PrivateKeyToPublicKeyTLS(sshPrivateKey)
+	require.NoError(t, err)
+
+	token, err := types.NewProvisionTokenFromSpec(
+		"my-token",
+		time.Now().Add(time.Minute),
+		types.ProvisionTokenSpecV2{
+			JoinMethod: types.JoinMethodOracle,
+			Roles:      []types.SystemRole{types.RoleNode},
+			Oracle: &types.ProvisionTokenSpecV2Oracle{
+				Allow: []*types.ProvisionTokenSpecV2Oracle_Rule{
+					{
+						Tenancy: makeTenancyID("foo"),
+					},
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.NoError(t, a.UpsertToken(ctx, token))
+
+	wrongToken, err := types.NewProvisionToken(
+		"wrong-token",
+		[]types.SystemRole{types.RoleNode},
+		time.Now().Add(time.Minute),
+	)
+	require.NoError(t, err)
+	require.NoError(t, a.UpsertToken(ctx, wrongToken))
+
+	mockFetchClaims := func(_ context.Context, _ *http.Request) (oracle.Claims, error) {
+		return oracle.Claims{
+			TenancyID:     makeTenancyID("foo"),
+			CompartmentID: makeCompartmentID("bar"),
+			InstanceID:    makeInstanceID("us-phoenix-1", "baz"),
+		}, nil
+	}
+
+	tests := []struct {
+		name                string
+		modifyTokenRequest  func(*types.RegisterUsingTokenRequest)
+		modifyOracleRequest func(*proto.OracleSignedRequest)
+		assert              require.ErrorAssertionFunc
+	}{
+		{
+			name:   "ok",
+			assert: require.NoError,
+		},
+		{
+			name: "token not found",
+			modifyTokenRequest: func(req *types.RegisterUsingTokenRequest) {
+				req.Token = "nonexistent"
+			},
+			assert: require.Error,
+		},
+		{
+			name: "wrong join method",
+			modifyTokenRequest: func(req *types.RegisterUsingTokenRequest) {
+				req.Token = "wrong-token"
+			},
+			assert: require.Error,
+		},
+		{
+			name: "wrong host",
+			modifyOracleRequest: func(req *proto.OracleSignedRequest) {
+				req.Headers["Host"] = "somewhere.us-phoenix-1.example.com"
+			},
+			assert: require.Error,
+		},
+		{
+			name: "invalid host region",
+			modifyOracleRequest: func(req *proto.OracleSignedRequest) {
+				req.Headers["Host"] = "auth.foo.oraclecloud.com"
+			},
+			assert: require.Error,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tokenReq := &types.RegisterUsingTokenRequest{
+				Token:        "my-token",
+				HostID:       "test-node",
+				Role:         types.RoleNode,
+				PublicSSHKey: sshPublicKey,
+				PublicTLSKey: tlsPublicKey,
+			}
+			if tc.modifyTokenRequest != nil {
+				tc.modifyTokenRequest(tokenReq)
+			}
+			_, err = a.registerUsingOracleMethod(
+				ctx,
+				tokenReq,
+				func(challenge string) (*proto.OracleSignedRequest, error) {
+					innerHeaders, outerHeaders, err := oracle.CreateSignedRequestWithProvider(provider, challenge)
+					if err != nil {
+						return nil, trace.Wrap(err)
+					}
+					req := &proto.OracleSignedRequest{
+						Headers:        mapFromHeader(outerHeaders),
+						PayloadHeaders: mapFromHeader(innerHeaders),
+					}
+
+					if tc.modifyOracleRequest != nil {
+						tc.modifyOracleRequest(req)
+					}
+					return req, nil
+				},
+				mockFetchClaims,
+			)
+			tc.assert(t, err)
+		})
+	}
+}


### PR DESCRIPTION
This change adds the server side of the auth ceremony for the Oracle join method ([RFD](https://github.com/gravitational/teleport/blob/master/rfd/0192-oci-join.md)).

Part of #41705.
Follows #51445.

Changelog: Added Oracle cloud join method