### PR TITLE
[v16] kube: properly return the reason for connection disruption

### DIFF
--- a/lib/kube/proxy/portforward_spdy.go
+++ b/lib/kube/proxy/portforward_spdy.go
@@ -106,7 +106,7 @@ func runPortForwardingHTTPStreams(req portForwardRequest) error {
 	defer h.Close()
 
 	h.Debugf("Setting port forwarding streaming connection idle timeout to %s.", req.idleTimeout)
-	conn.SetIdleTimeout(req.idleTimeout)
+	conn.SetIdleTimeout(adjustIdleTimeoutForConn(req.idleTimeout))
 
 	h.run()
 	return nil

--- a/lib/kube/proxy/portforward_websocket.go
+++ b/lib/kube/proxy/portforward_websocket.go
@@ -93,7 +93,7 @@ func runPortForwardingWebSocket(req portForwardRequest) error {
 		},
 	})
 
-	conn.SetIdleTimeout(req.idleTimeout)
+	conn.SetIdleTimeout(adjustIdleTimeoutForConn(req.idleTimeout))
 
 	// Upgrade the request and create the virtual streams.
 	_, streams, err := conn.Open(
@@ -355,7 +355,7 @@ func runPortForwardingTunneledHTTPStreams(req portForwardRequest) error {
 	defer h.Close()
 
 	h.Debugf("Setting port forwarding streaming connection idle timeout to %s.", req.idleTimeout)
-	spdyConn.SetIdleTimeout(req.idleTimeout)
+	spdyConn.SetIdleTimeout(adjustIdleTimeoutForConn(req.idleTimeout))
 
 	h.run()
 	return nil

--- a/lib/kube/proxy/remotecommand_websocket.go
+++ b/lib/kube/proxy/remotecommand_websocket.go
@@ -19,6 +19,8 @@ limitations under the License.
 package proxy
 
 import (
+	"time"
+
 	"github.com/go-logr/logr"
 	"github.com/gravitational/trace"
 	"k8s.io/apimachinery/pkg/util/httpstream/wsstream"
@@ -110,7 +112,7 @@ func createWebSocketStreams(req remoteCommandRequest) (*remoteCommandProxy, erro
 		},
 	})
 
-	conn.SetIdleTimeout(req.idleTimeout)
+	conn.SetIdleTimeout(adjustIdleTimeoutForConn(req.idleTimeout))
 
 	negotiatedProtocol, streams, err := conn.Open(
 		responsewriter.GetOriginal(req.httpResponseWriter),
@@ -162,4 +164,20 @@ func createWebSocketStreams(req remoteCommandRequest) (*remoteCommandProxy, erro
 	}
 
 	return proxy, nil
+}
+
+// adjustIdleTimeoutForConn adjusts the idle timeout for the connection
+// to be 5 seconds longer than the requested idle timeout.
+// This is done to prevent the connection from being closed by the server
+// before the connection monitor has a chance to close it and write the
+// status code.
+// If the idle timeout is 0, this function returns 0 because it means the
+// connection will never be closed by the server due to idleness.
+func adjustIdleTimeoutForConn(idleTimeout time.Duration) time.Duration {
+	// If the idle timeout is 0, we don't need to adjust it because it
+	// means the connection will never be closed by the server due to idleness.
+	if idleTimeout != 0 {
+		idleTimeout += 5 * time.Second
+	}
+	return idleTimeout
 }

--- a/lib/srv/monitor.go
+++ b/lib/srv/monitor.go
@@ -238,6 +238,8 @@ type MonitorConfig struct {
 	Entry log.FieldLogger
 	// IdleTimeoutMessage is sent to the client when the idle timeout expires.
 	IdleTimeoutMessage string
+	// CertificateExpiredMessage is sent to the client when the certificate expires.
+	CertificateExpiredMessage string
 	// MessageWriter wraps a channel to send text messages to the client. Use
 	// for disconnection messages, etc.
 	MessageWriter io.StringWriter
@@ -417,6 +419,15 @@ func (w *Monitor) start(lockWatch types.Watcher) {
 
 func (w *Monitor) disconnectClientOnExpiredCert() {
 	reason := fmt.Sprintf("client certificate expired at %v", w.Clock.Now().UTC())
+	if w.MessageWriter != nil {
+		msg := w.CertificateExpiredMessage
+		if msg == "" {
+			msg = reason
+		}
+		if _, err := w.MessageWriter.WriteString(msg); err != nil {
+			w.Logger.WarnContext(w.Context, "Failed to send certificate expiration message", "error", err)
+		}
+	}
 	w.disconnectClient(reason)
 }
 

--- a/lib/srv/monitor.go
+++ b/lib/srv/monitor.go
@@ -425,7 +425,7 @@ func (w *Monitor) disconnectClientOnExpiredCert() {
 			msg = reason
 		}
 		if _, err := w.MessageWriter.WriteString(msg); err != nil {
-			w.Logger.WarnContext(w.Context, "Failed to send certificate expiration message", "error", err)
+			w.Entry.WithError(err).Warn("Failed to send certificate expiration message")
 		}
 	}
 	w.disconnectClient(reason)


### PR DESCRIPTION
Backport #51398 to branch/v16


Changelog: Improved handling of client session termination during Kubernetes Exec sessions. The disconnection reason is now accurately returned for cases such as certificate expiration, forced lock activation, or idle timeout.