### PR TITLE
Support more fields in the role editor

### DIFF
--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -104,6 +104,10 @@ func NewSystemAutomaticAccessBotUser() types.User {
 // NewPresetEditorRole returns a new pre-defined role for cluster
 // editors who can edit cluster configuration resources.
 func NewPresetEditorRole() types.Role {
+	// IMPORTANT: Before adding new defaults, please make sure that the
+	// underlying field is supported by the standard role editor UI. This role
+	// should be editable with a rich UI, without requiring the user to dive into
+	// YAML.
 	role := &types.RoleV6{
 		Kind:    types.KindRole,
 		Version: types.V7,
@@ -116,6 +120,10 @@ func NewPresetEditorRole() types.Role {
 			},
 		},
 		Spec: types.RoleSpecV6{
+			// IMPORTANT: Before adding new defaults, please make sure that the
+			// underlying field is supported by the standard role editor UI. This role
+			// should be editable with a rich UI, without requiring the user to dive into
+			// YAML.
 			Options: types.RoleOptions{
 				CertificateFormat: constants.CertificateFormatStandard,
 				MaxSessionTTL:     types.NewDuration(apidefaults.MaxCertDuration),
@@ -133,6 +141,10 @@ func NewPresetEditorRole() types.Role {
 					Desktop: types.NewBoolOption(false),
 				},
 			},
+			// IMPORTANT: Before adding new defaults, please make sure that the
+			// underlying field is supported by the standard role editor UI. This role
+			// should be editable with a rich UI, without requiring the user to dive into
+			// YAML.
 			Allow: types.RoleConditions{
 				Namespaces: []string{apidefaults.Namespace},
 				Rules: []types.Rule{
@@ -208,6 +220,10 @@ func NewPresetEditorRole() types.Role {
 // NewPresetAccessRole creates a role for users who are allowed to initiate
 // interactive sessions.
 func NewPresetAccessRole() types.Role {
+	// IMPORTANT: Before adding new defaults, please make sure that the
+	// underlying field is supported by the standard role editor UI. This role
+	// should be editable with a rich UI, without requiring the user to dive into
+	// YAML.
 	role := &types.RoleV6{
 		Kind:    types.KindRole,
 		Version: types.V7,
@@ -220,6 +236,10 @@ func NewPresetAccessRole() types.Role {
 			},
 		},
 		Spec: types.RoleSpecV6{
+			// IMPORTANT: Before adding new defaults, please make sure that the
+			// underlying field is supported by the standard role editor UI. This role
+			// should be editable with a rich UI, without requiring the user to dive into
+			// YAML.
 			Options: types.RoleOptions{
 				CertificateFormat: constants.CertificateFormatStandard,
 				MaxSessionTTL:     types.NewDuration(apidefaults.MaxCertDuration),
@@ -235,6 +255,10 @@ func NewPresetAccessRole() types.Role {
 				BPF:           apidefaults.EnhancedEvents(),
 				RecordSession: &types.RecordSession{Desktop: types.NewBoolOption(true)},
 			},
+			// IMPORTANT: Before adding new defaults, please make sure that the
+			// underlying field is supported by the standard role editor UI. This role
+			// should be editable with a rich UI, without requiring the user to dive into
+			// YAML.
 			Allow: types.RoleConditions{
 				Namespaces:            []string{apidefaults.Namespace},
 				NodeLabels:            types.Labels{types.Wildcard: []string{types.Wildcard}},
@@ -270,6 +294,10 @@ func NewPresetAccessRole() types.Role {
 			},
 		},
 	}
+	// IMPORTANT: Before adding new defaults, please make sure that the
+	// underlying field is supported by the standard role editor UI. This role
+	// should be editable with a rich UI, without requiring the user to dive into
+	// YAML.
 	role.SetLogins(types.Allow, []string{teleport.TraitInternalLoginsVariable})
 	role.SetWindowsLogins(types.Allow, []string{teleport.TraitInternalWindowsLoginsVariable})
 	role.SetKubeUsers(types.Allow, []string{teleport.TraitInternalKubeUsersVariable})
@@ -284,6 +312,10 @@ func NewPresetAccessRole() types.Role {
 // auditor - someone who can review cluster events and replay sessions,
 // but can't initiate interactive sessions or modify configuration.
 func NewPresetAuditorRole() types.Role {
+	// IMPORTANT: Before adding new defaults, please make sure that the
+	// underlying field is supported by the standard role editor UI. This role
+	// should be editable with a rich UI, without requiring the user to dive into
+	// YAML.
 	role := &types.RoleV6{
 		Kind:    types.KindRole,
 		Version: types.V7,

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/AccessRules.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/AccessRules.test.tsx
@@ -58,7 +58,7 @@ describe('AccessRules', () => {
       'list',
       'read',
     ]);
-    await user.type(screen.getByLabelText('Condition'), 'some-condition');
+    await user.type(screen.getByLabelText('Filter'), 'some-filter');
     expect(modelRef).toHaveBeenLastCalledWith([
       {
         id: expect.any(String),
@@ -70,7 +70,7 @@ describe('AccessRules', () => {
           { label: 'list', value: 'list' },
           { label: 'read', value: 'read' },
         ],
-        where: 'some-condition',
+        where: 'some-filter',
       },
     ] as RuleModel[]);
   });

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/AccessRules.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/AccessRules.test.tsx
@@ -58,6 +58,7 @@ describe('AccessRules', () => {
       'list',
       'read',
     ]);
+    await user.type(screen.getByLabelText('Condition'), 'some-condition');
     expect(modelRef).toHaveBeenLastCalledWith([
       {
         id: expect.any(String),
@@ -69,6 +70,7 @@ describe('AccessRules', () => {
           { label: 'list', value: 'list' },
           { label: 'read', value: 'read' },
         ],
+        where: 'some-condition',
       },
     ] as RuleModel[]);
   });

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/AccessRules.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/AccessRules.tsx
@@ -117,10 +117,11 @@ const AccessRule = memo(function AccessRule({
         rule={precomputed(validation.fields.verbs)}
       />
       <FieldInput
-        label="Condition"
+        label="Filter"
         toolTipContent={
           <>
-            Additional condition, expressed using the{' '}
+            Optional condition that further limits the list of resources
+            affected by this rule, expressed using the{' '}
             <Text
               as="a"
               href="https://goteleport.com/docs/reference/predicate-language/"

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/AccessRules.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/AccessRules.tsx
@@ -18,12 +18,14 @@
 
 import { memo } from 'react';
 import { components, MultiValueProps } from 'react-select';
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 
 import { ButtonSecondary } from 'design/Button';
 import Flex from 'design/Flex';
 import { Plus } from 'design/Icon';
+import Text from 'design/Text';
 import { HoverTooltip } from 'design/Tooltip';
+import FieldInput from 'shared/components/FieldInput';
 import {
   FieldSelect,
   FieldSelectCreatable,
@@ -78,7 +80,8 @@ const AccessRule = memo(function AccessRule({
   validation,
   dispatch,
 }: SectionPropsWithDispatch<RuleModel, AccessRuleValidationResult>) {
-  const { id, resources, verbs } = value;
+  const { id, resources, verbs, where } = value;
+  const theme = useTheme();
   function setRule(rule: RuleModel) {
     dispatch({ type: 'set-access-rule', payload: rule });
   }
@@ -112,6 +115,26 @@ const AccessRule = memo(function AccessRule({
         value={verbs}
         onChange={v => setRule({ ...value, verbs: v })}
         rule={precomputed(validation.fields.verbs)}
+      />
+      <FieldInput
+        label="Condition"
+        toolTipContent={
+          <>
+            Additional condition, expressed using the{' '}
+            <Text
+              as="a"
+              href="https://goteleport.com/docs/reference/predicate-language/"
+              target="_blank"
+              color={theme.colors.interactive.solid.accent.default}
+            >
+              Teleport predicate language
+            </Text>
+          </>
+        }
+        tooltipSticky
+        disabled={isProcessing}
+        value={where}
+        onChange={e => setRule({ ...value, where: e.target.value })}
         mb={0}
       />
     </SectionBox>

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.tsx
@@ -242,6 +242,7 @@ export function ServerAccessSection({
       <FieldSelectCreatable
         isMulti
         label="Logins"
+        placeholder="Type a login and press Enter"
         isDisabled={isProcessing}
         formatCreateLabel={label => `Login: ${label}`}
         components={{
@@ -269,6 +270,7 @@ export function KubernetesAccessSection({
       <FieldSelectCreatable
         isMulti
         label="Groups"
+        placeholder="Type a group name and press Enter"
         isDisabled={isProcessing}
         formatCreateLabel={label => `Group: ${label}`}
         components={{
@@ -282,6 +284,7 @@ export function KubernetesAccessSection({
       <FieldSelectCreatable
         isMulti
         label="Users"
+        placeholder="Type a user name and press Enter"
         isDisabled={isProcessing}
         formatCreateLabel={label => `User: ${label}`}
         components={{
@@ -485,6 +488,7 @@ export function DatabaseAccessSection({
       <Box mb={3}>
         <LabelsInput
           legend="Labels"
+          tooltipContent="Access to databases with these labels will be affected by this role"
           disableBtns={isProcessing}
           labels={value.labels}
           setLabels={labels => onChange?.({ ...value, labels })}
@@ -494,6 +498,7 @@ export function DatabaseAccessSection({
       <FieldSelectCreatable
         isMulti
         label="Database Names"
+        placeholder="Type a database name and press Enter"
         toolTipContent={
           <>
             List of database names that this role is allowed to connect to.
@@ -512,6 +517,7 @@ export function DatabaseAccessSection({
       <FieldSelectCreatable
         isMulti
         label="Database Users"
+        placeholder="Type a user name and press Enter"
         toolTipContent={
           <>
             List of database users that this role is allowed to connect as.
@@ -530,6 +536,7 @@ export function DatabaseAccessSection({
       <FieldSelectCreatable
         isMulti
         label="Database Roles"
+        placeholder="Type a role name and press Enter"
         toolTipContent="If automatic user provisioning is available, this is the list of database roles that will be assigned to the database user after it's created"
         isDisabled={isProcessing}
         formatCreateLabel={label => `Database Role: ${label}`}
@@ -543,7 +550,7 @@ export function DatabaseAccessSection({
       />
       <LabelsInput
         legend="Database Service Labels"
-        tooltipContent="The database service labels have no influence on which databases' access is controlled by this role. Instead, they control which database services are discoverable while enrolling a new database."
+        tooltipContent="The database service labels control which Database Services (Teleport Agents) are visible to the user, which is required when adding Databases in the Enroll New Resource wizard. Access to Databases themselves is controlled by the Database Labels field."
         disableBtns={isProcessing}
         labels={value.dbServiceLabels}
         setLabels={dbServiceLabels => onChange?.({ ...value, dbServiceLabels })}
@@ -573,6 +580,7 @@ export function WindowsDesktopAccessSection({
       <FieldSelectCreatable
         isMulti
         label="Logins"
+        placeholder="Type a login and press Enter"
         toolTipContent="List of desktop logins that this role is allowed to use"
         isDisabled={isProcessing}
         formatCreateLabel={label => `Login: ${label}`}

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.tsx
@@ -25,7 +25,7 @@ import ButtonIcon from 'design/ButtonIcon';
 import Flex from 'design/Flex';
 import { Add, Plus, Trash } from 'design/Icon';
 import { Mark } from 'design/Mark';
-import Text, { H4 } from 'design/Text';
+import { H4 } from 'design/Text';
 import FieldInput from 'shared/components/FieldInput';
 import { FieldMultiInput } from 'shared/components/FieldMultiInput/FieldMultiInput';
 import {
@@ -232,10 +232,8 @@ export function ServerAccessSection({
 }: SectionProps<ServerAccess, ServerAccessValidationResult>) {
   return (
     <>
-      <Text typography="body3" mb={1}>
-        Labels
-      </Text>
       <LabelsInput
+        legend="Labels"
         disableBtns={isProcessing}
         labels={value.labels}
         setLabels={labels => onChange?.({ ...value, labels })}
@@ -281,10 +279,21 @@ export function KubernetesAccessSection({
         onChange={groups => onChange?.({ ...value, groups })}
       />
 
-      <Text typography="body3" mb={1}>
-        Labels
-      </Text>
+      <FieldSelectCreatable
+        isMulti
+        label="Users"
+        isDisabled={isProcessing}
+        formatCreateLabel={label => `User: ${label}`}
+        components={{
+          DropdownIndicator: null,
+        }}
+        openMenuOnClick={false}
+        value={value.users}
+        onChange={users => onChange?.({ ...value, users })}
+      />
+
       <LabelsInput
+        legend="Labels"
         disableBtns={isProcessing}
         labels={value.labels}
         rule={precomputed(validation.fields.labels)}
@@ -433,17 +442,13 @@ export function AppAccessSection({
 }: SectionProps<AppAccess, AppAccessValidationResult>) {
   return (
     <Flex flexDirection="column" gap={3}>
-      <Box>
-        <Text typography="body3" mb={1}>
-          Labels
-        </Text>
-        <LabelsInput
-          disableBtns={isProcessing}
-          labels={value.labels}
-          setLabels={labels => onChange?.({ ...value, labels })}
-          rule={precomputed(validation.fields.labels)}
-        />
-      </Box>
+      <LabelsInput
+        legend="Labels"
+        disableBtns={isProcessing}
+        labels={value.labels}
+        setLabels={labels => onChange?.({ ...value, labels })}
+        rule={precomputed(validation.fields.labels)}
+      />
       <FieldMultiInput
         label="AWS Role ARNs"
         disabled={isProcessing}
@@ -478,10 +483,8 @@ export function DatabaseAccessSection({
   return (
     <>
       <Box mb={3}>
-        <Text typography="body3" mb={1}>
-          Labels
-        </Text>
         <LabelsInput
+          legend="Labels"
           disableBtns={isProcessing}
           labels={value.labels}
           setLabels={labels => onChange?.({ ...value, labels })}
@@ -537,7 +540,14 @@ export function DatabaseAccessSection({
         value={value.roles}
         onChange={roles => onChange?.({ ...value, roles })}
         rule={precomputed(validation.fields.roles)}
-        mb={0}
+      />
+      <LabelsInput
+        legend="Database Service Labels"
+        tooltipContent="The database service labels have no influence on which databases' access is controlled by this role. Instead, they control which database services are discoverable while enrolling a new database."
+        disableBtns={isProcessing}
+        labels={value.dbServiceLabels}
+        setLabels={dbServiceLabels => onChange?.({ ...value, dbServiceLabels })}
+        rule={precomputed(validation.fields.dbServiceLabels)}
       />
     </>
   );
@@ -552,10 +562,8 @@ export function WindowsDesktopAccessSection({
   return (
     <>
       <Box mb={3}>
-        <Text typography="body3" mb={1}>
-          Labels
-        </Text>
         <LabelsInput
+          legend="Labels"
           disableBtns={isProcessing}
           labels={value.labels}
           setLabels={labels => onChange?.({ ...value, labels })}

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.test.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.test.ts
@@ -197,6 +197,7 @@ describe.each<{ name: string; role: Role; model: RoleEditorModel }>([
           db_names: ['stuff', 'knickknacks'],
           db_users: ['joe', 'mary'],
           db_roles: ['admin', 'auditor'],
+          db_service_labels: { foo: 'bar' },
         },
       },
     },
@@ -218,6 +219,7 @@ describe.each<{ name: string; role: Role; model: RoleEditorModel }>([
             { label: 'admin', value: 'admin' },
             { label: 'auditor', value: 'auditor' },
           ],
+          dbServiceLabels: [{ name: 'foo', value: 'bar' }],
         },
       ],
     },
@@ -440,6 +442,7 @@ describe('roleToRoleEditorModel', () => {
     groups: [],
     labels: [],
     resources: [],
+    users: [],
     roleVersion: defaultRoleVersion,
   });
 
@@ -868,6 +871,7 @@ describe('roleToRoleEditorModel', () => {
                 name: 'some-node',
               },
             ],
+            kubernetes_users: ['alice', 'bob'],
           },
         },
       })
@@ -901,6 +905,10 @@ describe('roleToRoleEditorModel', () => {
               verbs: [],
               roleVersion: defaultRoleVersion,
             },
+          ],
+          users: [
+            { label: 'alice', value: 'alice' },
+            { label: 'bob', value: 'bob' },
           ],
           roleVersion: defaultRoleVersion,
         },
@@ -948,6 +956,11 @@ describe('roleToRoleEditorModel', () => {
                 verbs: ['read', 'list'],
               },
               { resources: [ResourceKind.Lock], verbs: ['create'] },
+              {
+                resources: [ResourceKind.Session],
+                verbs: ['read', 'list'],
+                where: 'contains(session.participants, user.metadata.name)',
+              },
             ],
           },
         },
@@ -962,11 +975,19 @@ describe('roleToRoleEditorModel', () => {
             resourceKindOptionsMap.get(ResourceKind.DatabaseService),
           ],
           verbs: [verbOptionsMap.get('read'), verbOptionsMap.get('list')],
+          where: '',
         },
         {
           id: expect.any(String),
           resources: [resourceKindOptionsMap.get(ResourceKind.Lock)],
           verbs: [verbOptionsMap.get('create')],
+          where: '',
+        },
+        {
+          id: expect.any(String),
+          resources: [resourceKindOptionsMap.get(ResourceKind.Session)],
+          verbs: [verbOptionsMap.get('read'), verbOptionsMap.get('list')],
+          where: 'contains(session.participants, user.metadata.name)',
         },
       ],
     } as RoleEditorModel);
@@ -1042,6 +1063,10 @@ describe('roleEditorModelToRole', () => {
                 roleVersion: defaultRoleVersion,
               },
             ],
+            users: [
+              { label: 'alice', value: 'alice' },
+              { label: 'bob', value: 'bob' },
+            ],
             roleVersion: defaultRoleVersion,
           },
         ],
@@ -1067,6 +1092,7 @@ describe('roleEditorModelToRole', () => {
               verbs: [],
             },
           ],
+          kubernetes_users: ['alice', 'bob'],
         },
       },
     } as Role);
@@ -1084,11 +1110,19 @@ describe('roleEditorModelToRole', () => {
               resourceKindOptionsMap.get(ResourceKind.DatabaseService),
             ],
             verbs: [verbOptionsMap.get('read'), verbOptionsMap.get('list')],
+            where: '',
           },
           {
             id: 'dummy-id-2',
             resources: [resourceKindOptionsMap.get(ResourceKind.Lock)],
             verbs: [verbOptionsMap.get('create')],
+            where: '',
+          },
+          {
+            id: expect.any(String),
+            resources: [resourceKindOptionsMap.get(ResourceKind.Session)],
+            verbs: [verbOptionsMap.get('read'), verbOptionsMap.get('list')],
+            where: 'contains(session.participants, user.metadata.name)',
           },
         ],
       })
@@ -1100,6 +1134,11 @@ describe('roleEditorModelToRole', () => {
           rules: [
             { resources: ['user', 'db_service'], verbs: ['read', 'list'] },
             { resources: ['lock'], verbs: ['create'] },
+            {
+              resources: ['session'],
+              verbs: ['read', 'list'],
+              where: 'contains(session.participants, user.metadata.name)',
+            },
           ],
         },
       },

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/validation.test.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/validation.test.ts
@@ -66,6 +66,7 @@ describe('validateRoleEditorModel', () => {
         kind: 'kube_cluster',
         labels: [{ name: 'foo', value: 'bar' }],
         groups: [],
+        users: [],
         resources: [
           {
             id: 'dummy-id',
@@ -96,6 +97,7 @@ describe('validateRoleEditorModel', () => {
         roles: [{ label: 'some-role', value: 'some-role' }],
         names: [],
         users: [],
+        dbServiceLabels: [{ name: 'asdf', value: 'qwer' }],
       },
       {
         kind: 'windows_desktop',
@@ -108,6 +110,7 @@ describe('validateRoleEditorModel', () => {
         id: 'dummy-id',
         resources: [{ label: ResourceKind.Node, value: ResourceKind.Node }],
         verbs: [{ label: '*', value: '*' }],
+        where: '',
       },
     ];
     const result = validateRoleEditorModel(model, undefined, undefined);
@@ -146,6 +149,7 @@ describe('validateRoleEditorModel', () => {
         kind: 'kube_cluster',
         groups: [],
         labels: [],
+        users: [],
         resources: [
           {
             ...newKubernetesResourceModel(defaultRoleVersion),
@@ -178,6 +182,7 @@ describe('validateRoleEditorModel', () => {
           kind: 'kube_cluster',
           groups: [],
           labels: [],
+          users: [],
           roleVersion,
           resources: [
             {
@@ -214,6 +219,7 @@ describe('validateRoleEditorModel', () => {
         id: 'dummy-id',
         resources: [],
         verbs: [{ label: '*', value: '*' }],
+        where: '',
       },
     ];
     const result = validateRoleEditorModel(model, undefined, undefined);
@@ -243,7 +249,12 @@ describe('validateResourceAccess', () => {
 
 describe('validateAccessRule', () => {
   it('reuses previously computed results', () => {
-    const rule: RuleModel = { id: 'some-id', resources: [], verbs: [] };
+    const rule: RuleModel = {
+      id: 'some-id',
+      resources: [],
+      verbs: [],
+      where: '',
+    };
     const result1 = validateAccessRule(rule, undefined, undefined);
     const result2 = validateAccessRule(rule, rule, result1);
     expect(result2).toBe(result1);

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/validation.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/validation.ts
@@ -287,6 +287,7 @@ export type AppAccessValidationResult = RuleSetValidationResult<
 const databaseAccessValidationRules = {
   labels: nonEmptyLabels,
   roles: noWildcardOptions('Wildcard is not allowed in database roles'),
+  dbServiceLabels: nonEmptyLabels,
 };
 export type DatabaseAccessValidationResult = RuleSetValidationResult<
   typeof databaseAccessValidationRules

--- a/web/packages/teleport/src/services/resources/types.ts
+++ b/web/packages/teleport/src/services/resources/types.ts
@@ -80,6 +80,7 @@ export type RoleConditions = {
   kubernetes_groups?: string[];
   kubernetes_labels?: Labels;
   kubernetes_resources?: KubernetesResource[];
+  kubernetes_users?: string[];
 
   app_labels?: Labels;
   aws_role_arns?: string[];
@@ -90,6 +91,7 @@ export type RoleConditions = {
   db_names?: string[];
   db_users?: string[];
   db_roles?: string[];
+  db_service_labels?: Labels;
 
   windows_desktop_labels?: Labels;
   windows_desktop_logins?: string[];
@@ -163,6 +165,7 @@ export type KubernetesVerb =
 export type Rule = {
   resources?: ResourceKind[];
   verbs?: Verb[];
+  where?: string;
 };
 
 export enum ResourceKind {


### PR DESCRIPTION
This PR adds the following fields:
- DB service labels
- Kubernetes users
- `where` clause in access rules. I took liberty to call it "Condition" in the UI, so please voice your opinion on whether this is a good choice. My line of reasoning is that without understanding the underlying YAML model, the name "Where" would be confusing.

The intent behind this PR was to fully support the `access` role in the rich UI, but it turned out that one more field was added to it, so we still miss the target. However, I added warnings to the Go codebase now, so hopefully, this will make it easier to prevent these situations in future.

![Screenshot 2025-01-24 at 13 59 46](https://github.com/user-attachments/assets/9027c855-8880-4816-986d-ce5f69333f71)
![Screenshot 2025-01-24 at 13 59 24](https://github.com/user-attachments/assets/3da222e3-aa72-4ae7-8cfa-113cd6b1832b)
![Screenshot 2025-01-24 at 13 59 07](https://github.com/user-attachments/assets/a0bb19e3-6add-41ce-8030-a1ec1923c473)

Requires https://github.com/gravitational/teleport/pull/51457