### PR TITLE
[teleport-update] Remove warning when running Teleport on platforms without systemd

### DIFF
--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -330,12 +330,27 @@ func (s SystemdService) IsPresent(ctx context.Context) (bool, error) {
 
 // checkSystem returns an error if the system is not compatible with this process manager.
 func (s SystemdService) checkSystem(ctx context.Context) error {
-	_, err := os.Stat("/run/systemd/system")
-	if errors.Is(err, os.ErrNotExist) {
+	present, err := hasSystemD()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if !present {
 		s.Log.ErrorContext(ctx, "This system does not support systemd, which is required by the updater.")
 		return trace.Wrap(ErrNotSupported)
 	}
-	return trace.Wrap(err)
+	return nil
+
+}
+
+func hasSystemD() (bool, error) {
+	_, err := os.Stat("/run/systemd/system")
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	return true, nil
 }
 
 // systemctl returns a systemctl subcommand, converting the output to logs.

--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -342,6 +342,7 @@ func (s SystemdService) checkSystem(ctx context.Context) error {
 
 }
 
+// hasSystemD returns true if the system uses the SystemD process manager.
 func hasSystemD() (bool, error) {
 	_, err := os.Stat("/run/systemd/system")
 	if errors.Is(err, os.ErrNotExist) {

--- a/lib/autoupdate/agent/telemetry.go
+++ b/lib/autoupdate/agent/telemetry.go
@@ -21,9 +21,12 @@ package agent
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/constants"
 )
 
 // IsManagedByUpdater returns true if the local Teleport binary is managed by teleport-update.
@@ -31,6 +34,12 @@ import (
 // The binary is considered managed if it lives under /opt/teleport, but not within the package
 // path at /opt/teleport/system.
 func IsManagedByUpdater() (bool, error) {
+	if runtime.GOOS != constants.LinuxOS {
+		return false, nil
+	}
+	if ok, err := hasSystemD(); err != nil || !ok {
+		return false, nil
+	}
 	teleportPath, err := os.Readlink("/proc/self/exe")
 	if err != nil {
 		return false, trace.Wrap(err, "cannot find Teleport binary")
@@ -52,6 +61,12 @@ func IsManagedByUpdater() (bool, error) {
 // and the default installation (with teleport.service as the unit file name).
 // The binary is considered managed and default if it lives within /opt/teleport/default.
 func IsManagedAndDefault() (bool, error) {
+	if runtime.GOOS != constants.LinuxOS {
+		return false, nil
+	}
+	if ok, err := hasSystemD(); err != nil || !ok {
+		return false, nil
+	}
 	teleportPath, err := os.Readlink("/proc/self/exe")
 	if err != nil {
 		return false, trace.Wrap(err, "cannot find Teleport binary")

--- a/lib/autoupdate/agent/telemetry.go
+++ b/lib/autoupdate/agent/telemetry.go
@@ -37,7 +37,11 @@ func IsManagedByUpdater() (bool, error) {
 	if runtime.GOOS != constants.LinuxOS {
 		return false, nil
 	}
-	if ok, err := hasSystemD(); err != nil || !ok {
+	systemd, err := hasSystemD()
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	if !systemd {
 		return false, nil
 	}
 	teleportPath, err := os.Readlink("/proc/self/exe")
@@ -64,7 +68,11 @@ func IsManagedAndDefault() (bool, error) {
 	if runtime.GOOS != constants.LinuxOS {
 		return false, nil
 	}
-	if ok, err := hasSystemD(); err != nil || !ok {
+	systemd, err := hasSystemD()
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	if !systemd {
 		return false, nil
 	}
 	teleportPath, err := os.Readlink("/proc/self/exe")

--- a/lib/autoupdate/agent/telemetry.go
+++ b/lib/autoupdate/agent/telemetry.go
@@ -21,12 +21,9 @@ package agent
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/gravitational/trace"
-
-	"github.com/gravitational/teleport/api/constants"
 )
 
 // IsManagedByUpdater returns true if the local Teleport binary is managed by teleport-update.
@@ -34,9 +31,6 @@ import (
 // The binary is considered managed if it lives under /opt/teleport, but not within the package
 // path at /opt/teleport/system.
 func IsManagedByUpdater() (bool, error) {
-	if runtime.GOOS != constants.LinuxOS {
-		return false, nil
-	}
 	systemd, err := hasSystemD()
 	if err != nil {
 		return false, trace.Wrap(err)
@@ -65,9 +59,6 @@ func IsManagedByUpdater() (bool, error) {
 // and the default installation (with teleport.service as the unit file name).
 // The binary is considered managed and default if it lives within /opt/teleport/default.
 func IsManagedAndDefault() (bool, error) {
-	if runtime.GOOS != constants.LinuxOS {
-		return false, nil
-	}
 	systemd, err := hasSystemD()
 	if err != nil {
 		return false, trace.Wrap(err)


### PR DESCRIPTION
This PR fixes an extraneous warning introduced in https://github.com/gravitational/teleport/pull/50266 on platforms running the Teleport agent that do not run SystemD.

---

The `teleport-update` binary will be used to enable, disable, and trigger automatic Teleport agent updates. The new auto-updates system manages a local installation of the cluster-specified version of Teleport stored in `/opt/teleport`.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/10289