### PR TITLE
initial transition of ssh enforcement logic to use sshca.Identity & removal of ssh certs from most enforcement logic

### DIFF
--- a/api/types/authority.go
+++ b/api/types/authority.go
@@ -549,14 +549,6 @@ func (s *RotationSchedule) CheckAndSetDefaults(now time.Time) error {
 	return nil
 }
 
-// CertRoles defines certificate roles
-type CertRoles struct {
-	// Version is current version of the roles
-	Version string `json:"version"`
-	// Roles is a list of roles
-	Roles []string `json:"roles"`
-}
-
 // Clone returns a deep copy of TLSKeyPair that can be mutated without
 // modifying the original.
 func (k *TLSKeyPair) Clone() *TLSKeyPair {

--- a/lib/agentless/agentless.go
+++ b/lib/agentless/agentless.go
@@ -33,7 +33,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/cryptosuites"
-	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/sshca"
 )
 
 // AuthProvider is a subset of the full Auth API that must be connected
@@ -59,13 +59,13 @@ type LocalAccessPoint interface {
 // with an agentless node.
 type SignerCreator func(ctx context.Context, localAccessPoint LocalAccessPoint, certGen CertGenerator) (ssh.Signer, error)
 
-// SignerFromSSHCertificate returns a function that attempts to
+// SignerFromSSHIdentity returns a function that attempts to
 // create a [ssh.Signer] for the Identity in the provided [ssh.Certificate]
 // that is signed with the OpenSSH CA and can be used to authenticate to agentless nodes.
 // authClient must be connected to the root cluster, and the CertGenerator
 // passed into the returned function must be connected to the same cluster
 // as the target node.
-func SignerFromSSHCertificate(cert *ssh.Certificate, authClient AuthProvider, clusterName, teleportUser string) SignerCreator {
+func SignerFromSSHIdentity(ident *sshca.Identity, authClient AuthProvider, clusterName, teleportUser string) SignerCreator {
 	return func(ctx context.Context, localAccessPoint LocalAccessPoint, certGen CertGenerator) (ssh.Signer, error) {
 		u, err := authClient.GetUser(ctx, teleportUser, false)
 		if err != nil {
@@ -76,26 +76,17 @@ func SignerFromSSHCertificate(cert *ssh.Certificate, authClient AuthProvider, cl
 			return nil, trace.BadParameter("unsupported user type %T", u)
 		}
 
-		// set the user's roles and traits so impersonation will work correctly
-		roleNames, err := services.ExtractRolesFromCert(cert)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		traits, err := services.ExtractTraitsFromCert(cert)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		user.SetRoles(roleNames)
-		user.SetTraits(traits)
+		user.SetRoles(ident.Roles)
+		user.SetTraits(ident.Traits)
 
 		// fetch local roles so if the certificate is generated on a leaf
 		// cluster it won't have to lookup unknown roles
-		roles, err := getRoles(ctx, authClient, roleNames)
+		roles, err := getRoles(ctx, authClient, ident.Roles)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
-		validBefore := time.Unix(int64(cert.ValidBefore), 0)
+		validBefore := time.Unix(int64(ident.ValidBefore), 0)
 		ttl := time.Until(validBefore)
 		params := certParams{
 			clusterName:  clusterName,

--- a/lib/auth/access_request_test.go
+++ b/lib/auth/access_request_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
+	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
@@ -1364,6 +1365,8 @@ func checkCerts(t *testing.T,
 	// Parse SSH cert.
 	sshCert, err := sshutils.ParseCertificate(certs.SSH)
 	require.NoError(t, err)
+	sshIdentity, err := sshca.DecodeIdentity(sshCert)
+	require.NoError(t, err)
 
 	// Parse TLS cert.
 	tlsCert, err := tlsca.ParseCertificatePEM(certs.TLS)
@@ -1372,14 +1375,11 @@ func checkCerts(t *testing.T,
 	require.NoError(t, err)
 
 	// Make sure both certs have the expected roles.
-	rawSSHCertRoles := sshCert.Permissions.Extensions[teleport.CertExtensionTeleportRoles]
-	sshCertRoles, err := services.UnmarshalCertRoles(rawSSHCertRoles)
-	require.NoError(t, err)
-	assert.ElementsMatch(t, roles, sshCertRoles)
+	assert.ElementsMatch(t, roles, sshIdentity.Roles)
 	assert.ElementsMatch(t, roles, tlsIdentity.Groups)
 
 	// Make sure both certs have the expected logins/principals.
-	for _, certLogins := range [][]string{sshCert.ValidPrincipals, tlsIdentity.Principals} {
+	for _, certLogins := range [][]string{sshIdentity.Principals, tlsIdentity.Principals} {
 		// filter out invalid logins placed in the cert
 		validCertLogins := []string{}
 		for _, certLogin := range certLogins {
@@ -1391,12 +1391,7 @@ func checkCerts(t *testing.T,
 	}
 
 	// Make sure both certs have the expected access requests, if any.
-	rawSSHCertAccessRequests := sshCert.Permissions.Extensions[teleport.CertExtensionTeleportActiveRequests]
-	sshCertAccessRequests := services.RequestIDs{}
-	if len(rawSSHCertAccessRequests) > 0 {
-		require.NoError(t, sshCertAccessRequests.Unmarshal([]byte(rawSSHCertAccessRequests)))
-	}
-	assert.ElementsMatch(t, accessRequests, sshCertAccessRequests.AccessRequests)
+	assert.ElementsMatch(t, accessRequests, sshIdentity.ActiveRequests)
 	assert.ElementsMatch(t, accessRequests, tlsIdentity.ActiveRequests)
 
 	// Make sure both certs have the expected allowed resources, if any.

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2762,7 +2762,7 @@ func (a *Server) AugmentWebSessionCertificates(ctx context.Context, opts *Augmen
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	accessInfo, err := services.AccessInfoFromLocalIdentity(*x509Identity, a)
+	accessInfo, err := services.AccessInfoFromLocalTLSIdentity(*x509Identity, a)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -4368,7 +4368,7 @@ func (a *Server) ExtendWebSession(ctx context.Context, req authclient.WebSession
 		return nil, trace.NotFound("web session has expired")
 	}
 
-	accessInfo, err := services.AccessInfoFromLocalIdentity(identity, a)
+	accessInfo, err := services.AccessInfoFromLocalTLSIdentity(identity, a)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -82,6 +82,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/services/suite"
+	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -2757,9 +2758,10 @@ func TestGenerateUserCertWithUserLoginState(t *testing.T) {
 	sshCert, err := sshutils.ParseCertificate(resp.SSH)
 	require.NoError(t, err)
 
-	roles, err := services.UnmarshalCertRoles(sshCert.Extensions[teleport.CertExtensionTeleportRoles])
+	sshIdent, err := sshca.DecodeIdentity(sshCert)
 	require.NoError(t, err)
-	require.Equal(t, []string{role.GetName()}, roles)
+
+	require.Equal(t, []string{role.GetName()}, sshIdent.Roles)
 
 	traits := wrappers.Traits{}
 	err = wrappers.UnmarshalTraits([]byte(sshCert.Extensions[teleport.CertExtensionTeleportTraits]), &traits)
@@ -2816,9 +2818,9 @@ func TestGenerateUserCertWithUserLoginState(t *testing.T) {
 	sshCert, err = sshutils.ParseCertificate(resp.SSH)
 	require.NoError(t, err)
 
-	roles, err = services.UnmarshalCertRoles(sshCert.Extensions[teleport.CertExtensionTeleportRoles])
+	sshIdent, err = sshca.DecodeIdentity(sshCert)
 	require.NoError(t, err)
-	require.Equal(t, []string{role.GetName(), "uls-role1", "uls-role2"}, roles)
+	require.Equal(t, []string{role.GetName(), "uls-role1", "uls-role2"}, sshIdent.Roles)
 
 	traits = wrappers.Traits{}
 	err = wrappers.UnmarshalTraits([]byte(sshCert.Extensions[teleport.CertExtensionTeleportTraits]), &traits)

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3027,7 +3027,7 @@ func (a *ServerWithRoles) desiredAccessInfoForUser(ctx context.Context, req *pro
 	// considering new or dropped access requests. This will include roles from
 	// currently assumed role access requests, and allowed resources from
 	// currently assumed resource access requests.
-	accessInfo, err := services.AccessInfoFromLocalIdentity(currentIdentity, a.authServer)
+	accessInfo, err := services.AccessInfoFromLocalTLSIdentity(currentIdentity, a.authServer)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -74,6 +74,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
+	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils/pagination"
 )
@@ -1306,33 +1307,28 @@ func TestGenerateUserCertsWithRoleRequest(t *testing.T) {
 			userCert, err := sshutils.ParseCertificate(certs.SSH)
 			require.NoError(t, err)
 
-			roles, ok := userCert.Extensions[teleport.CertExtensionTeleportRoles]
-			require.True(t, ok)
-
-			parsedRoles, err := services.UnmarshalCertRoles(roles)
+			userIdent, err := sshca.DecodeIdentity(userCert)
 			require.NoError(t, err)
 
 			if len(tt.expectPrincipals) > 0 {
 				expectPrincipals := append(tt.expectPrincipals, teleport.SSHSessionJoinPrincipal)
-				require.ElementsMatch(t, expectPrincipals, userCert.ValidPrincipals, "principals must match")
+				require.ElementsMatch(t, expectPrincipals, userIdent.Principals, "principals must match")
 			}
 
 			if tt.expectRoles != nil {
-				require.ElementsMatch(t, tt.expectRoles, parsedRoles, "granted roles must match expected values")
+				require.ElementsMatch(t, tt.expectRoles, userIdent.Roles, "granted roles must match expected values")
 			} else {
-				require.ElementsMatch(t, tt.roleRequests, parsedRoles, "granted roles must match requests")
+				require.ElementsMatch(t, tt.roleRequests, userIdent.Roles, "granted roles must match requests")
 			}
 
-			_, disallowReissue := userCert.Extensions[teleport.CertExtensionDisallowReissue]
 			if len(tt.roleRequests) > 0 {
-				impersonator, ok := userCert.Extensions[teleport.CertExtensionImpersonator]
-				require.True(t, ok, "impersonator must be set if any role requests exist")
-				require.Equal(t, tt.username, impersonator, "certificate must show self-impersonation")
+				require.NotEmpty(t, userIdent.Impersonator, "impersonator must be set if any role requests exist")
+				require.Equal(t, tt.username, userIdent.Impersonator, "certificate must show self-impersonation")
 
-				require.True(t, disallowReissue)
+				require.True(t, userIdent.DisallowReissue)
 				require.True(t, impersonatedIdent.DisallowReissue)
 			} else {
-				require.False(t, disallowReissue)
+				require.False(t, userIdent.DisallowReissue)
 				require.False(t, impersonatedIdent.DisallowReissue)
 			}
 		})

--- a/lib/auth/test/suite.go
+++ b/lib/auth/test/suite.go
@@ -35,7 +35,6 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/sshutils"
-	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/sshca"
 )
 
@@ -180,12 +179,12 @@ func (s *AuthSuite) GenerateUserCert(t *testing.T) {
 	require.NoError(t, err)
 	parsedCert, err := sshutils.ParseCertificate(cert)
 	require.NoError(t, err)
-	outRoles, err := services.UnmarshalCertRoles(parsedCert.Extensions[teleport.CertExtensionTeleportRoles])
-	require.NoError(t, err)
-	require.Empty(t, cmp.Diff(outRoles, inRoles))
 
-	outImpersonator := parsedCert.Extensions[teleport.CertExtensionImpersonator]
-	require.Empty(t, cmp.Diff(outImpersonator, impersonator))
+	parsedIdent, err := sshca.DecodeIdentity(parsedCert)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(parsedIdent.Roles, inRoles))
+
+	require.Empty(t, cmp.Diff(parsedIdent.Impersonator, impersonator))
 
 	// Check that MFAVerified and PreviousIdentityExpires are encoded into ssh cert
 	clock := clockwork.NewFakeClock()

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -71,6 +71,7 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/suite"
+	"github.com/gravitational/teleport/lib/sshca"
 	libsshutils "github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -1784,14 +1785,12 @@ func TestWebSessionMultiAccessRequests(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, baseWebClient.Close()) })
 
 	expectRolesAndResources := func(t *testing.T, sess types.WebSession, expectRoles []string, expectResources []types.ResourceID) {
-		sshCert, err := sshutils.ParseCertificate(sess.GetPub())
+		sshcert, err := sshutils.ParseCertificate(sess.GetPub())
 		require.NoError(t, err)
-		gotRoles, err := services.ExtractRolesFromCert(sshCert)
+		ident, err := sshca.DecodeIdentity(sshcert)
 		require.NoError(t, err)
-		gotResources, err := services.ExtractAllowedResourcesFromCert(sshCert)
-		require.NoError(t, err)
-		assert.ElementsMatch(t, expectRoles, gotRoles)
-		assert.ElementsMatch(t, expectResources, gotResources)
+		assert.ElementsMatch(t, expectRoles, ident.Roles)
+		assert.ElementsMatch(t, expectResources, ident.AllowedResourceIDs)
 	}
 
 	type extendSessionFunc func(*testing.T, *authclient.Client, types.WebSession) (*authclient.Client, types.WebSession)
@@ -1976,13 +1975,13 @@ func TestWebSessionWithApprovedAccessRequestAndSwitchback(t *testing.T) {
 	require.NoError(t, err)
 
 	// Roles extracted from cert should contain the initial role and the role assigned with access request.
-	roles, err := services.ExtractRolesFromCert(sshcert)
+	ident, err := sshca.DecodeIdentity(sshcert)
 	require.NoError(t, err)
-	require.Len(t, roles, 2)
+	require.Len(t, ident.Roles, 2)
 
 	mappedRole := map[string]string{
-		roles[0]: "",
-		roles[1]: "",
+		ident.Roles[0]: "",
+		ident.Roles[1]: "",
 	}
 
 	_, hasRole := mappedRole[initialRole]
@@ -2017,9 +2016,9 @@ func TestWebSessionWithApprovedAccessRequestAndSwitchback(t *testing.T) {
 	sshcert, err = sshutils.ParseCertificate(sess2.GetPub())
 	require.NoError(t, err)
 
-	roles, err = services.ExtractRolesFromCert(sshcert)
+	ident, err = sshca.DecodeIdentity(sshcert)
 	require.NoError(t, err)
-	require.Empty(t, cmp.Diff(roles, []string{initialRole}))
+	require.Empty(t, cmp.Diff(ident.Roles, []string{initialRole}))
 
 	require.Empty(t, certRequests(sess2.GetTLSCert()))
 }
@@ -2082,13 +2081,12 @@ func TestExtendWebSessionWithReloadUser(t *testing.T) {
 	// Check traits has been updated to latest.
 	sshcert, err := sshutils.ParseCertificate(sess1.GetPub())
 	require.NoError(t, err)
-	traits, err := services.ExtractTraitsFromCert(sshcert)
+
+	ident, err := sshca.DecodeIdentity(sshcert)
 	require.NoError(t, err)
-	roles, err := services.ExtractRolesFromCert(sshcert)
-	require.NoError(t, err)
-	require.Equal(t, []string{"apple", "banana"}, traits[constants.TraitLogins])
-	require.Equal(t, []string{"llama", "alpaca"}, traits[constants.TraitDBUsers])
-	require.Contains(t, roles, newRoleName)
+	require.Equal(t, []string{"apple", "banana"}, ident.Traits[constants.TraitLogins])
+	require.Equal(t, []string{"llama", "alpaca"}, ident.Traits[constants.TraitDBUsers])
+	require.Contains(t, ident.Roles, newRoleName)
 }
 
 func TestExtendWebSessionWithMaxDuration(t *testing.T) {

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -693,7 +693,7 @@ func (a *authorizer) authorizeRemoteUser(ctx context.Context, u RemoteUser) (*Co
 		return nil, trace.Wrap(err)
 	}
 
-	accessInfo, err := services.AccessInfoFromRemoteIdentity(u.Identity, ca.CombinedMapping())
+	accessInfo, err := services.AccessInfoFromRemoteTLSIdentity(u.Identity, ca.CombinedMapping())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1344,7 +1344,7 @@ func ContextForLocalUser(ctx context.Context, u LocalUser, accessPoint Authorize
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	accessInfo, err := services.AccessInfoFromLocalIdentity(u.Identity, accessPoint)
+	accessInfo, err := services.AccessInfoFromLocalTLSIdentity(u.Identity, accessPoint)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/benchmark/db/db.go
+++ b/lib/benchmark/db/db.go
@@ -49,7 +49,7 @@ func retrieveDatabaseCertificates(ctx context.Context, tc *client.TeleportClient
 			Username:    dbUser,
 			Database:    dbName,
 		},
-		AccessRequests: profile.ActiveRequests.AccessRequests,
+		AccessRequests: profile.ActiveRequests,
 	})
 	if err != nil {
 		return tls.Certificate{}, trace.Wrap(err)

--- a/lib/client/cluster_client.go
+++ b/lib/client/cluster_client.go
@@ -352,7 +352,7 @@ func (c *ClusterClient) prepareUserCertsRequest(ctx context.Context, params Reis
 		if err != nil && !trace.IsNotFound(err) {
 			return nil, nil, trace.Wrap(err)
 		}
-		params.AccessRequests = activeRequests.AccessRequests
+		params.AccessRequests = activeRequests
 	}
 
 	// newUserKeys holds new subject keys per-protocol so that the keyring can

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -37,14 +37,13 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/cryptosuites"
-	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -386,17 +385,13 @@ func (k *KeyRing) CertRoles() ([]string, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	// Extract roles from certificate. Note, if the certificate is in old format,
-	// this will be empty.
-	var roles []string
-	rawRoles, ok := cert.Extensions[teleport.CertExtensionTeleportRoles]
-	if ok {
-		roles, err = services.UnmarshalCertRoles(rawRoles)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
+
+	ident, err := sshca.DecodeIdentity(cert)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
-	return roles, nil
+
+	return ident.Roles, nil
 }
 
 const (
@@ -588,19 +583,18 @@ func (k *KeyRing) SSHCert() (*ssh.Certificate, error) {
 }
 
 // ActiveRequests gets the active requests associated with this key.
-func (k *KeyRing) ActiveRequests() (services.RequestIDs, error) {
-	var activeRequests services.RequestIDs
+func (k *KeyRing) ActiveRequests() ([]string, error) {
 	sshCert, err := k.SSHCert()
 	if err != nil {
-		return activeRequests, trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-	rawRequests, ok := sshCert.Extensions[teleport.CertExtensionTeleportActiveRequests]
-	if ok {
-		if err := activeRequests.Unmarshal([]byte(rawRequests)); err != nil {
-			return activeRequests, trace.Wrap(err)
-		}
+
+	ident, err := sshca.DecodeIdentity(sshCert)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
-	return activeRequests, nil
+
+	return ident.ActiveRequests, nil
 }
 
 // CheckCert makes sure the key's SSH certificate is valid.

--- a/lib/client/local_proxy_middleware.go
+++ b/lib/client/local_proxy_middleware.go
@@ -214,7 +214,7 @@ func (c *DBCertIssuer) IssueCert(ctx context.Context) (tls.Certificate, error) {
 	if profile, err := c.Client.ProfileStatus(); err != nil {
 		log.WarnContext(ctx, "unable to load profile, requesting database certs without access requests", "error", err)
 	} else {
-		accessRequests = profile.ActiveRequests.AccessRequests
+		accessRequests = profile.ActiveRequests
 	}
 
 	var keyRing *KeyRing
@@ -286,7 +286,7 @@ func (c *AppCertIssuer) IssueCert(ctx context.Context) (tls.Certificate, error) 
 	if profile, err := c.Client.ProfileStatus(); err != nil {
 		log.WarnContext(ctx, "unable to load profile, requesting app certs without access requests", "error", err)
 	} else {
-		accessRequests = profile.ActiveRequests.AccessRequests
+		accessRequests = profile.ActiveRequests
 	}
 
 	var keyRing *KeyRing

--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"sync"
 	"time"
@@ -35,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/teleport/api/utils/keypaths"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -216,7 +218,7 @@ type ProfileStatus struct {
 
 	// ActiveRequests tracks the privilege escalation requests applied
 	// during certificate construction.
-	ActiveRequests services.RequestIDs
+	ActiveRequests []string
 
 	// AWSRoleARNs is a list of allowed AWS role ARNs user can assume.
 	AWSRolesARNs []string
@@ -278,45 +280,18 @@ func profileStatusFromKeyRing(keyRing *KeyRing, opts profileOptions) (*ProfileSt
 		return nil, trace.Wrap(err)
 	}
 
-	// Extract from the certificate how much longer it will be valid for.
-	validUntil := time.Unix(int64(sshCert.ValidBefore), 0)
-
-	// Extract roles from certificate. Note, if the certificate is in old format,
-	// this will be empty.
-	var roles []string
-	rawRoles, ok := sshCert.Extensions[teleport.CertExtensionTeleportRoles]
-	if ok {
-		roles, err = services.UnmarshalCertRoles(rawRoles)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-	}
-	sort.Strings(roles)
-
-	// Extract traits from the certificate. Note if the certificate is in the
-	// old format, this will be empty.
-	var traits wrappers.Traits
-	rawTraits, ok := sshCert.Extensions[teleport.CertExtensionTeleportTraits]
-	if ok {
-		err = wrappers.UnmarshalTraits([]byte(rawTraits), &traits)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-	}
-
-	var activeRequests services.RequestIDs
-	rawRequests, ok := sshCert.Extensions[teleport.CertExtensionTeleportActiveRequests]
-	if ok {
-		if err := activeRequests.Unmarshal([]byte(rawRequests)); err != nil {
-			return nil, trace.Wrap(err)
-		}
-	}
-
-	allowedResourcesStr := sshCert.Extensions[teleport.CertExtensionAllowedResources]
-	allowedResourceIDs, err := types.ResourceIDsFromString(allowedResourcesStr)
+	sshIdent, err := sshca.DecodeIdentity(sshCert)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	// Extract from the certificate how much longer it will be valid for.
+	validUntil := time.Unix(int64(sshIdent.ValidBefore), 0)
+
+	// Extract roles from certificate. Note, if the certificate is in old format,
+	// this will be empty.
+	roles := slices.Clone(sshIdent.Roles)
+	sort.Strings(roles)
 
 	// Extract extensions from certificate. This lists the abilities of the
 	// certificate (like can the user request a PTY, port forwarding, etc.)
@@ -365,13 +340,12 @@ func profileStatusFromKeyRing(keyRing *KeyRing, opts profileOptions) (*ProfileSt
 	}
 
 	var gitHubIdentity *GitHubIdentity
-	if gitHubUserID := sshCert.Extensions[teleport.CertExtensionGitHubUserID]; gitHubUserID != "" {
+	if sshIdent.GitHubUserID != "" {
 		gitHubIdentity = &GitHubIdentity{
-			UserID:   gitHubUserID,
-			Username: sshCert.Extensions[teleport.CertExtensionGitHubUsername],
+			UserID:   sshIdent.GitHubUserID,
+			Username: sshIdent.GitHubUsername,
 		}
 	}
-
 	return &ProfileStatus{
 		Name: opts.ProfileName,
 		Dir:  opts.ProfileDir,
@@ -386,8 +360,8 @@ func profileStatusFromKeyRing(keyRing *KeyRing, opts profileOptions) (*ProfileSt
 		CriticalOptions:         sshCert.CriticalOptions,
 		Roles:                   roles,
 		Cluster:                 opts.SiteName,
-		Traits:                  traits,
-		ActiveRequests:          activeRequests,
+		Traits:                  sshIdent.Traits,
+		ActiveRequests:          sshIdent.ActiveRequests,
 		KubeEnabled:             opts.KubeProxyAddr != "",
 		KubeUsers:               tlsID.KubernetesUsers,
 		KubeGroups:              tlsID.KubernetesGroups,
@@ -397,7 +371,7 @@ func profileStatusFromKeyRing(keyRing *KeyRing, opts profileOptions) (*ProfileSt
 		AzureIdentities:         tlsID.AzureIdentities,
 		GCPServiceAccounts:      tlsID.GCPServiceAccounts,
 		IsVirtual:               opts.IsVirtual,
-		AllowedResourceIDs:      allowedResourceIDs,
+		AllowedResourceIDs:      sshIdent.AllowedResourceIDs,
 		SAMLSingleLogoutEnabled: opts.SAMLSingleLogoutEnabled,
 		SSOHost:                 opts.SSOHost,
 		GitHubIdentity:          gitHubIdentity,

--- a/lib/devicetrust/authz/authz_test.go
+++ b/lib/devicetrust/authz/authz_test.go
@@ -24,13 +24,13 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/devicetrust/authz"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
@@ -40,19 +40,15 @@ func TestIsTLSDeviceVerified(t *testing.T) {
 
 func TestIsSSHDeviceVerified(t *testing.T) {
 	testIsDeviceVerified(t, "IsSSHDeviceVerified", func(ext *tlsca.DeviceExtensions) bool {
-		var cert *ssh.Certificate
+		var ident *sshca.Identity
 		if ext != nil {
-			cert = &ssh.Certificate{
-				Permissions: ssh.Permissions{
-					Extensions: map[string]string{
-						teleport.CertExtensionDeviceID:           ext.DeviceID,
-						teleport.CertExtensionDeviceAssetTag:     ext.AssetTag,
-						teleport.CertExtensionDeviceCredentialID: ext.CredentialID,
-					},
-				},
+			ident = &sshca.Identity{
+				DeviceID:           ext.DeviceID,
+				DeviceAssetTag:     ext.AssetTag,
+				DeviceCredentialID: ext.CredentialID,
 			}
 		}
-		return authz.IsSSHDeviceVerified(cert)
+		return authz.IsSSHDeviceVerified(ident)
 	})
 }
 
@@ -141,15 +137,10 @@ func TestVerifyTLSUser(t *testing.T) {
 
 func TestVerifySSHUser(t *testing.T) {
 	runVerifyUserTest(t, "VerifySSHUser", func(dt *types.DeviceTrust, ext *tlsca.DeviceExtensions) error {
-		return authz.VerifySSHUser(context.Background(), dt, &ssh.Certificate{
-			KeyId: "llama",
-			Permissions: ssh.Permissions{
-				Extensions: map[string]string{
-					teleport.CertExtensionDeviceID:           ext.DeviceID,
-					teleport.CertExtensionDeviceAssetTag:     ext.AssetTag,
-					teleport.CertExtensionDeviceCredentialID: ext.CredentialID,
-				},
-			},
+		return authz.VerifySSHUser(context.Background(), dt, &sshca.Identity{
+			DeviceID:           ext.DeviceID,
+			DeviceAssetTag:     ext.AssetTag,
+			DeviceCredentialID: ext.CredentialID,
 		})
 	})
 }

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -893,39 +893,39 @@ func (s *server) keyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (perm *ssh.Pe
 		return nil, trace.BadParameter("server doesn't support provided key type")
 	}
 
+	ident, err := sshca.DecodeIdentity(cert)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	var clusterName, certRole, certType string
 	var caType types.CertAuthType
-	switch cert.CertType {
+	switch ident.CertType {
 	case ssh.HostCert:
-		var ok bool
-		clusterName, ok = cert.Extensions[utils.CertExtensionAuthority]
-		if !ok || clusterName == "" {
+		if ident.ClusterName == "" {
 			return nil, trace.BadParameter("certificate missing %q extension; this SSH host certificate was not issued by Teleport or issued by an older version of Teleport; try upgrading your Teleport nodes/proxies", utils.CertExtensionAuthority)
 		}
-		certRole, ok = cert.Extensions[utils.CertExtensionRole]
-		if !ok || certRole == "" {
+		clusterName = ident.ClusterName
+
+		if ident.SystemRole == "" {
 			return nil, trace.BadParameter("certificate missing %q extension; this SSH host certificate was not issued by Teleport or issued by an older version of Teleport; try upgrading your Teleport nodes/proxies", utils.CertExtensionRole)
 		}
+		certRole = string(ident.SystemRole)
 		certType = utils.ExtIntCertTypeHost
 		caType = types.HostCA
 	case ssh.UserCert:
-		var ok bool
-		clusterName, ok = cert.Extensions[teleport.CertExtensionTeleportRouteToCluster]
-		if !ok || clusterName == "" {
-			clusterName = s.ClusterName
+		if ident.RouteToCluster != "" && ident.RouteToCluster != s.ClusterName {
+			return nil, trace.BadParameter("this endpoint does not support cross-cluster routing (cannot route from %q to %q)", s.ClusterName, ident.RouteToCluster)
 		}
-		encRoles, ok := cert.Extensions[teleport.CertExtensionTeleportRoles]
-		if !ok || encRoles == "" {
-			return nil, trace.BadParameter("certificate missing %q extension; this SSH user certificate was not issued by Teleport or issued by an older version of Teleport; try upgrading your Teleport proxies/auth servers and logging in again (or exporting an identity file, if that's what you used)", teleport.CertExtensionTeleportRoles)
-		}
-		roles, err := services.UnmarshalCertRoles(encRoles)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		if len(roles) == 0 {
+
+		// only support certs signed by local user CA here. user certs don't encode the clustername of origin, but we can
+		// effectively limit ourselves to only supporting local users by only checking the cert against local CAs.
+		clusterName = s.ClusterName
+
+		if len(ident.Roles) == 0 {
 			return nil, trace.BadParameter("certificate missing roles in %q extension; make sure your user has some roles assigned (or ask your Teleport admin to) and log in again (or export an identity file, if that's what you used)", teleport.CertExtensionTeleportRoles)
 		}
-		certRole = roles[0]
+		certRole = ident.Roles[0]
 		certType = utils.ExtIntCertTypeUser
 		caType = types.UserCA
 	default:

--- a/lib/reversetunnel/srv_test.go
+++ b/lib/reversetunnel/srv_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -42,16 +43,16 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-func TestServerKeyAuth(t *testing.T) {
+func newCAAndSigner(t *testing.T, caType types.CertAuthType, name string) (types.CertAuthority, ssh.Signer) {
 	ta := testauthority.New()
 	priv, pub, err := ta.GenerateKeyPair()
 	require.NoError(t, err)
-	caSigner, err := ssh.ParsePrivateKey(priv)
+	signer, err := ssh.ParsePrivateKey(priv)
 	require.NoError(t, err)
 
 	ca, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
-		Type:        types.HostCA,
-		ClusterName: "cluster-name",
+		Type:        caType,
+		ClusterName: name,
 		ActiveKeys: types.CAKeySet{
 			SSH: []*types.SSHKeyPair{{
 				PrivateKey:     priv,
@@ -62,13 +63,32 @@ func TestServerKeyAuth(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	return ca, signer
+}
+
+// newPubKey generates a new public key for testing.
+func newPubKey(t *testing.T) []byte {
+	_, pub, err := testauthority.New().GenerateKeyPair()
+	require.NoError(t, err)
+	return pub
+}
+
+func TestServerKeyAuth(t *testing.T) {
+	hostCA, hostCASigner := newCAAndSigner(t, types.HostCA, "root")
+	userCA, userCASigner := newCAAndSigner(t, types.UserCA, "root")
+	leafHostCA, leafHostCASigner := newCAAndSigner(t, types.HostCA, "leaf")
+	leafUserCA, leafUserCASigner := newCAAndSigner(t, types.UserCA, "leaf")
+
 	s := &server{
 		logger: utils.NewSlogLoggerForTests(),
-		Config: Config{Clock: clockwork.NewRealClock()},
+		Config: Config{Clock: clockwork.NewRealClock(), ClusterName: "root"},
 		localAccessPoint: mockAccessPoint{
-			ca: ca,
+			cas: []types.CertAuthority{hostCA, userCA, leafHostCA, leafUserCA},
 		},
 	}
+
+	ta := testauthority.New()
+
 	con := mockSSHConnMetadata{}
 	tests := []struct {
 		desc           string
@@ -77,15 +97,15 @@ func TestServerKeyAuth(t *testing.T) {
 		wantErr        require.ErrorAssertionFunc
 	}{
 		{
-			desc: "host cert",
+			desc: "root host cert",
 			key: func() ssh.PublicKey {
 				rawCert, err := ta.GenerateHostCert(sshca.HostCertificateRequest{
-					CASigner:      caSigner,
-					PublicHostKey: pub,
-					HostID:        "host-id",
+					CASigner:      hostCASigner,
+					PublicHostKey: newPubKey(t),
+					HostID:        "root-host-id",
 					NodeName:      con.User(),
 					Identity: sshca.Identity{
-						ClusterName: "host-cluster-name",
+						ClusterName: "root",
 						SystemRole:  types.RoleNode,
 					},
 				})
@@ -98,23 +118,22 @@ func TestServerKeyAuth(t *testing.T) {
 				extHost:              con.User(),
 				utils.ExtIntCertType: utils.ExtIntCertTypeHost,
 				extCertRole:          string(types.RoleNode),
-				extAuthority:         "host-cluster-name",
+				extAuthority:         "root",
 			},
 			wantErr: require.NoError,
 		},
 		{
-			desc: "user cert",
+			desc: "root user cert",
 			key: func() ssh.PublicKey {
 				rawCert, err := ta.GenerateUserCert(sshca.UserCertificateRequest{
-					CASigner:          caSigner,
-					PublicUserKey:     pub,
+					CASigner:          userCASigner,
+					PublicUserKey:     newPubKey(t),
 					CertificateFormat: constants.CertificateFormatStandard,
 					TTL:               time.Minute,
 					Identity: sshca.Identity{
-						Username:       con.User(),
-						Principals:     []string{con.User()},
-						Roles:          []string{"dev", "admin"},
-						RouteToCluster: "user-cluster-name",
+						Username:   con.User(),
+						Principals: []string{con.User()},
+						Roles:      []string{"dev", "admin"},
 					},
 				})
 				require.NoError(t, err)
@@ -126,14 +145,129 @@ func TestServerKeyAuth(t *testing.T) {
 				extHost:              con.User(),
 				utils.ExtIntCertType: utils.ExtIntCertTypeUser,
 				extCertRole:          "dev",
-				extAuthority:         "user-cluster-name",
+				extAuthority:         "root",
 			},
 			wantErr: require.NoError,
 		},
 		{
+			desc: "leaf host cert",
+			key: func() ssh.PublicKey {
+				rawCert, err := ta.GenerateHostCert(sshca.HostCertificateRequest{
+					CASigner:      leafHostCASigner,
+					PublicHostKey: newPubKey(t),
+					HostID:        "leaf-host-id",
+					NodeName:      con.User(),
+					Identity: sshca.Identity{
+						ClusterName: "leaf",
+						SystemRole:  types.RoleNode,
+					},
+				})
+				require.NoError(t, err)
+				key, _, _, _, err := ssh.ParseAuthorizedKey(rawCert)
+				require.NoError(t, err)
+				return key
+			}(),
+			wantExtensions: map[string]string{
+				extHost:              con.User(),
+				utils.ExtIntCertType: utils.ExtIntCertTypeHost,
+				extCertRole:          string(types.RoleNode),
+				extAuthority:         "leaf",
+			},
+			wantErr: require.NoError,
+		},
+		{
+			desc: "leaf user cert",
+			key: func() ssh.PublicKey {
+				rawCert, err := ta.GenerateUserCert(sshca.UserCertificateRequest{
+					CASigner:          leafUserCASigner,
+					PublicUserKey:     newPubKey(t),
+					CertificateFormat: constants.CertificateFormatStandard,
+					TTL:               time.Minute,
+					Identity: sshca.Identity{
+						Username:   con.User(),
+						Principals: []string{con.User()},
+						Roles:      []string{"dev", "admin"},
+					},
+				})
+				require.NoError(t, err)
+				key, _, _, _, err := ssh.ParseAuthorizedKey(rawCert)
+				require.NoError(t, err)
+				return key
+			}(),
+			// leaf user certs are not supported by this endpoint
+			wantErr: require.Error,
+		},
+		{
+			desc: "root user cert with cluster routing directive",
+			key: func() ssh.PublicKey {
+				rawCert, err := ta.GenerateUserCert(sshca.UserCertificateRequest{
+					CASigner:          userCASigner,
+					PublicUserKey:     newPubKey(t),
+					CertificateFormat: constants.CertificateFormatStandard,
+					TTL:               time.Minute,
+					Identity: sshca.Identity{
+						Username:       con.User(),
+						Principals:     []string{con.User()},
+						Roles:          []string{"dev", "admin"},
+						RouteToCluster: "leaf",
+					},
+				})
+				require.NoError(t, err)
+				key, _, _, _, err := ssh.ParseAuthorizedKey(rawCert)
+				require.NoError(t, err)
+				return key
+			}(),
+			// this endpoint does not support cross-cluster routing
+			wantErr: require.Error,
+		},
+		{
+			desc: "host cert with incorrect cluster name",
+			key: func() ssh.PublicKey {
+				rawCert, err := ta.GenerateHostCert(sshca.HostCertificateRequest{
+					CASigner:      hostCASigner, // signer of root
+					PublicHostKey: newPubKey(t),
+					HostID:        "root-host-id",
+					NodeName:      con.User(),
+					Identity: sshca.Identity{
+						ClusterName: "leaf", // cluster name of leaf
+						SystemRole:  types.RoleNode,
+					},
+				})
+				require.NoError(t, err)
+				key, _, _, _, err := ssh.ParseAuthorizedKey(rawCert)
+				require.NoError(t, err)
+				return key
+			}(),
+			// cluster name mismatch should result in cert validation failure
+			wantErr: require.Error,
+		},
+		{
+
+			desc: "user cert with incorrect principals",
+			key: func() ssh.PublicKey {
+				rawCert, err := ta.GenerateUserCert(sshca.UserCertificateRequest{
+					CASigner:          userCASigner,
+					PublicUserKey:     newPubKey(t),
+					CertificateFormat: constants.CertificateFormatStandard,
+					TTL:               time.Minute,
+					Identity: sshca.Identity{
+						Username:   con.User(),
+						Principals: []string{"not-the-user"},
+						Roles:      []string{"dev", "admin"},
+					},
+				})
+				require.NoError(t, err)
+				key, _, _, _, err := ssh.ParseAuthorizedKey(rawCert)
+				require.NoError(t, err)
+				return key
+			}(),
+			// principal mismatch should result in cert validation failure
+			wantErr: require.Error,
+		},
+		{
 			desc: "not a cert",
 			key: func() ssh.PublicKey {
-				key, _, _, _, err := ssh.ParseAuthorizedKey(pub)
+				key, _, _, _, err := ssh.ParseAuthorizedKey(newPubKey(t))
 				require.NoError(t, err)
 				return key
 			}(),
@@ -161,11 +295,16 @@ func (mockSSHConnMetadata) RemoteAddr() net.Addr { return &net.TCPAddr{} }
 
 type mockAccessPoint struct {
 	authclient.ProxyAccessPoint
-	ca types.CertAuthority
+	cas []types.CertAuthority
 }
 
 func (ap mockAccessPoint) GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error) {
-	return ap.ca, nil
+	for _, ca := range ap.cas {
+		if id == ca.GetID() {
+			return ca, nil
+		}
+	}
+	return nil, trace.NotFound("no cert authority matching %+v", id)
 }
 
 func Test_ParseDialReq(t *testing.T) {

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
-	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
@@ -37,6 +36,7 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/services/readonly"
+	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
@@ -1220,90 +1220,62 @@ func (a *accessChecker) HostSudoers(s types.Server) ([]string, error) {
 	return sudoers, nil
 }
 
-// AccessInfoFromLocalCertificate returns a new AccessInfo populated from the
-// given ssh certificate. Should only be used for cluster local users as roles
+// AccessInfoFromLocalSSHIdentity returns a new AccessInfo populated from the
+// given sshca.Identity. Should only be used for cluster local users as roles
 // will not be mapped.
-func AccessInfoFromLocalCertificate(cert *ssh.Certificate) (*AccessInfo, error) {
-	traits, err := ExtractTraitsFromCert(cert)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	roles, err := ExtractRolesFromCert(cert)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	allowedResourceIDs, err := ExtractAllowedResourcesFromCert(cert)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
+func AccessInfoFromLocalSSHIdentity(ident *sshca.Identity) *AccessInfo {
 	return &AccessInfo{
-		Username:           cert.KeyId,
-		Roles:              roles,
-		Traits:             traits,
-		AllowedResourceIDs: allowedResourceIDs,
-	}, nil
+		Username:           ident.Username,
+		Roles:              ident.Roles,
+		Traits:             ident.Traits,
+		AllowedResourceIDs: ident.AllowedResourceIDs,
+	}
 }
 
-// AccessInfoFromRemoteCertificate returns a new AccessInfo populated from the
-// given remote cluster user's ssh certificate. Remote roles will be mapped to
+// AccessInfoFromRemoteSSHIdentity returns a new AccessInfo populated from the
+// given remote cluster user's ssh identity. Remote roles will be mapped to
 // local roles based on the given roleMap.
-func AccessInfoFromRemoteCertificate(cert *ssh.Certificate, roleMap types.RoleMap) (*AccessInfo, error) {
-	// Old-style SSH certificates don't have traits in metadata.
-	traits, err := ExtractTraitsFromCert(cert)
-	if err != nil && !trace.IsNotFound(err) {
-		return nil, trace.AccessDenied("failed to parse certificate traits: %v", err)
+func AccessInfoFromRemoteSSHIdentity(unmappedIdentity *sshca.Identity, roleMap types.RoleMap) (*AccessInfo, error) {
+	// make a shallow copy of traits to avoid modifying the original
+	traits := make(map[string][]string, len(unmappedIdentity.Traits)+1)
+	for k, v := range unmappedIdentity.Traits {
+		traits[k] = v
 	}
-	if traits == nil {
-		traits = make(map[string][]string)
-	}
+
 	// Prior to Teleport 6.2 the only trait passed to the remote cluster
 	// was the "logins" trait set to the SSH certificate principals.
 	//
 	// Keep backwards-compatible behavior and set it in addition to the
 	// traits extracted from the certificate.
-	traits[constants.TraitLogins] = cert.ValidPrincipals
+	traits[constants.TraitLogins] = unmappedIdentity.Principals
 
-	unmappedRoles, err := ExtractRolesFromCert(cert)
+	roles, err := MapRoles(roleMap, unmappedIdentity.Roles)
 	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	roles, err := MapRoles(roleMap, unmappedRoles)
-	if err != nil {
-		return nil, trace.AccessDenied("failed to map roles for user with remote roles %v: %v", unmappedRoles, err)
+		return nil, trace.AccessDenied("failed to map roles for user with remote roles %v: %v", unmappedIdentity.Roles, err)
 	}
 	if len(roles) == 0 {
-		return nil, trace.AccessDenied("no roles mapped for user with remote roles %v", unmappedRoles)
+		return nil, trace.AccessDenied("no roles mapped for user with remote roles %v", unmappedIdentity.Roles)
 	}
 	slog.DebugContext(context.Background(), "Mapped remote roles to local roles and traits",
-		"remote_roles", unmappedRoles,
+		"remote_roles", unmappedIdentity.Roles,
 		"local_roles", roles,
 		"traits", traits,
 	)
 
-	allowedResourceIDs, err := ExtractAllowedResourcesFromCert(cert)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	return &AccessInfo{
-		Username:           cert.KeyId,
+		Username:           unmappedIdentity.Username,
 		Roles:              roles,
 		Traits:             traits,
-		AllowedResourceIDs: allowedResourceIDs,
+		AllowedResourceIDs: unmappedIdentity.AllowedResourceIDs,
 	}, nil
 }
 
-// AccessInfoFromLocalIdentity returns a new AccessInfo populated from the given
+// AccessInfoFromLocalTLSIdentity returns a new AccessInfo populated from the given
 // tlsca.Identity. Should only be used for cluster local users as roles will not
 // be mapped.
-func AccessInfoFromLocalIdentity(identity tlsca.Identity, access UserGetter) (*AccessInfo, error) {
+func AccessInfoFromLocalTLSIdentity(identity tlsca.Identity, access UserGetter) (*AccessInfo, error) {
 	roles := identity.Groups
 	traits := identity.Traits
-	allowedResourceIDs := identity.AllowedResourceIDs
 
 	// Legacy certs are not encoded with roles or traits,
 	// so we fallback to the traits and roles in the backend.
@@ -1327,14 +1299,14 @@ func AccessInfoFromLocalIdentity(identity tlsca.Identity, access UserGetter) (*A
 		Username:           identity.Username,
 		Roles:              roles,
 		Traits:             traits,
-		AllowedResourceIDs: allowedResourceIDs,
+		AllowedResourceIDs: identity.AllowedResourceIDs,
 	}, nil
 }
 
-// AccessInfoFromRemoteIdentity returns a new AccessInfo populated from the
+// AccessInfoFromRemoteTLSIdentity returns a new AccessInfo populated from the
 // given remote cluster user's tlsca.Identity. Remote roles will be mapped to
 // local roles based on the given roleMap.
-func AccessInfoFromRemoteIdentity(identity tlsca.Identity, roleMap types.RoleMap) (*AccessInfo, error) {
+func AccessInfoFromRemoteTLSIdentity(identity tlsca.Identity, roleMap types.RoleMap) (*AccessInfo, error) {
 	// Set internal traits for the remote user. This allows Teleport to work by
 	// passing exact logins, Kubernetes users/groups, database users/names, and
 	// AWS Role ARNs to the remote cluster.
@@ -1376,13 +1348,11 @@ func AccessInfoFromRemoteIdentity(identity tlsca.Identity, roleMap types.RoleMap
 		"traits", traits,
 	)
 
-	allowedResourceIDs := identity.AllowedResourceIDs
-
 	return &AccessInfo{
 		Username:           identity.Username,
 		Roles:              roles,
 		Traits:             traits,
-		AllowedResourceIDs: allowedResourceIDs,
+		AllowedResourceIDs: identity.AllowedResourceIDs,
 	}, nil
 }
 

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -145,40 +145,6 @@ func NewAccessRequestWithResources(user string, roles []string, resourceIDs []ty
 	return req, nil
 }
 
-// RequestIDs is a collection of IDs for privilege escalation requests.
-type RequestIDs struct {
-	AccessRequests []string `json:"access_requests,omitempty"`
-}
-
-func (r *RequestIDs) Marshal() ([]byte, error) {
-	data, err := utils.FastMarshal(r)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return data, nil
-}
-
-func (r *RequestIDs) Unmarshal(data []byte) error {
-	if err := utils.FastUnmarshal(data, r); err != nil {
-		return trace.Wrap(err)
-	}
-	return trace.Wrap(r.Check())
-}
-
-func (r *RequestIDs) Check() error {
-	for _, id := range r.AccessRequests {
-		_, err := uuid.Parse(id)
-		if err != nil {
-			return trace.BadParameter("invalid request id %q", id)
-		}
-	}
-	return nil
-}
-
-func (r *RequestIDs) IsEmpty() bool {
-	return len(r.AccessRequests) < 1
-}
-
 // AccessRequestGetter defines the interface for fetching access request resources.
 type AccessRequestGetter interface {
 	// GetAccessRequests gets all currently active access requests.

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -22,7 +22,6 @@ import (
 	"crypto"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/json"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
@@ -316,24 +315,6 @@ func CertPool(ca types.CertAuthority) (*x509.CertPool, error) {
 		certPool.AddCert(cert)
 	}
 	return certPool, nil
-}
-
-// MarshalCertRoles marshal roles list to OpenSSH
-func MarshalCertRoles(roles []string) (string, error) {
-	out, err := json.Marshal(types.CertRoles{Version: types.V1, Roles: roles})
-	if err != nil {
-		return "", trace.Wrap(err)
-	}
-	return string(out), err
-}
-
-// UnmarshalCertRoles marshals roles list to OpenSSH format
-func UnmarshalCertRoles(data string) ([]string, error) {
-	var certRoles types.CertRoles
-	if err := utils.FastUnmarshal([]byte(data), &certRoles); err != nil {
-		return nil, trace.BadParameter("%s", err)
-	}
-	return certRoles.Roles, nil
 }
 
 // UnmarshalCertAuthority unmarshals the CertAuthority resource to JSON.

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -46,6 +46,7 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/fixtures"
+	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
@@ -3873,26 +3874,26 @@ func TestExtractFrom(t *testing.T) {
 
 	// At this point, services.User and the certificate/identity are still in
 	// sync. The roles and traits returned should be the same as the original.
-	roles, traits, err := ExtractFromCertificate(cert)
+	ident, err := sshca.DecodeIdentity(cert)
 	require.NoError(t, err)
-	require.Equal(t, roles, origRoles)
-	require.Equal(t, traits, origTraits)
+	require.Equal(t, origRoles, ident.Roles)
+	require.Equal(t, origTraits, ident.Traits)
 
-	roles, traits, err = ExtractFromIdentity(ctx, &userGetter{
+	roles, traits, err := ExtractFromIdentity(ctx, &userGetter{
 		roles:  origRoles,
 		traits: origTraits,
 	}, *identity)
 	require.NoError(t, err)
-	require.Equal(t, roles, origRoles)
-	require.Equal(t, traits, origTraits)
+	require.Equal(t, origRoles, roles)
+	require.Equal(t, origTraits, traits)
 
 	// The backend now returns new roles and traits, however because the roles
 	// and traits are extracted from the certificate/identity, the original
 	// roles and traits will be returned.
-	roles, traits, err = ExtractFromCertificate(cert)
+	ident, err = sshca.DecodeIdentity(cert)
 	require.NoError(t, err)
-	require.Equal(t, roles, origRoles)
-	require.Equal(t, traits, origTraits)
+	require.Equal(t, origRoles, ident.Roles)
+	require.Equal(t, origTraits, ident.Traits)
 
 	roles, traits, err = ExtractFromIdentity(ctx, &userGetter{
 		roles:  origRoles,

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -20,14 +20,11 @@ package srv
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net"
-	"strconv"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/prometheus/client_golang/prometheus"
@@ -43,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -151,9 +149,25 @@ func NewAuthHandlers(config *AuthHandlerConfig) (*AuthHandlers, error) {
 // CreateIdentityContext returns an IdentityContext populated with information
 // about the logged in user on the connection.
 func (h *AuthHandlers) CreateIdentityContext(sconn *ssh.ServerConn) (IdentityContext, error) {
-	identity := IdentityContext{
-		TeleportUser: sconn.Permissions.Extensions[utils.CertTeleportUser],
-		Login:        sconn.User(),
+	certRaw := []byte(sconn.Permissions.Extensions[utils.CertTeleportUserCertificate])
+	certificate, err := apisshutils.ParseCertificate(certRaw)
+	if err != nil {
+		return IdentityContext{}, trace.Wrap(err)
+	}
+
+	unmappedIdentity, err := sshca.DecodeIdentity(certificate)
+	if err != nil {
+		return IdentityContext{}, trace.Wrap(err)
+	}
+
+	var certValidBefore time.Time
+	if unmappedIdentity.ValidBefore != 0 {
+		certValidBefore = time.Unix(int64(unmappedIdentity.ValidBefore), 0)
+	}
+
+	certAuthority, err := h.authorityForCert(types.UserCA, certificate.SignatureKey)
+	if err != nil {
+		return IdentityContext{}, trace.Wrap(err)
 	}
 
 	clusterName, err := h.c.AccessPoint.GetClusterName()
@@ -161,78 +175,34 @@ func (h *AuthHandlers) CreateIdentityContext(sconn *ssh.ServerConn) (IdentityCon
 		return IdentityContext{}, trace.Wrap(err)
 	}
 
-	certRaw := []byte(sconn.Permissions.Extensions[utils.CertTeleportUserCertificate])
-	certificate, err := apisshutils.ParseCertificate(certRaw)
+	accessInfo, err := fetchAccessInfo(unmappedIdentity, certAuthority, clusterName.GetClusterName())
 	if err != nil {
 		return IdentityContext{}, trace.Wrap(err)
 	}
-	identity.Certificate = certificate
-	identity.RouteToCluster = certificate.Extensions[teleport.CertExtensionTeleportRouteToCluster]
-	if certificate.ValidBefore != 0 {
-		identity.CertValidBefore = time.Unix(int64(certificate.ValidBefore), 0)
-	}
-	certAuthority, err := h.authorityForCert(types.UserCA, certificate.SignatureKey)
-	if err != nil {
-		return IdentityContext{}, trace.Wrap(err)
-	}
-	identity.CertAuthority = certAuthority
-
-	identity.UnmappedRoles, err = services.ExtractRolesFromCert(certificate)
+	accessChecker, err := services.NewAccessChecker(accessInfo, clusterName.GetClusterName(), h.c.AccessPoint)
 	if err != nil {
 		return IdentityContext{}, trace.Wrap(err)
 	}
 
-	accessInfo, err := fetchAccessInfo(certificate, certAuthority, identity.TeleportUser, clusterName.GetClusterName())
-	if err != nil {
-		return IdentityContext{}, trace.Wrap(err)
-	}
-	identity.AllowedResourceIDs = accessInfo.AllowedResourceIDs
-	identity.AccessChecker, err = services.NewAccessChecker(accessInfo, clusterName.GetClusterName(), h.c.AccessPoint)
-	if err != nil {
-		return IdentityContext{}, trace.Wrap(err)
-	}
-
-	identity.Impersonator = certificate.Extensions[teleport.CertExtensionImpersonator]
-	accessRequestIDs, err := ParseAccessRequestIDs(certificate.Extensions[teleport.CertExtensionTeleportActiveRequests])
-	if err != nil {
-		return IdentityContext{}, trace.Wrap(err)
-	}
-	identity.ActiveRequests = accessRequestIDs
-	if _, ok := certificate.Extensions[teleport.CertExtensionDisallowReissue]; ok {
-		identity.DisallowReissue = true
-	}
-	if _, ok := certificate.Extensions[teleport.CertExtensionRenewable]; ok {
-		identity.Renewable = true
-	}
-	if botName, ok := certificate.Extensions[teleport.CertExtensionBotName]; ok {
-		identity.BotName = botName
-	}
-	if botInstanceID, ok := certificate.Extensions[teleport.CertExtensionBotInstanceID]; ok {
-		identity.BotInstanceID = botInstanceID
-	}
-	if generationStr, ok := certificate.Extensions[teleport.CertExtensionGeneration]; ok {
-		generation, err := strconv.ParseUint(generationStr, 10, 64)
-		if err != nil {
-			return IdentityContext{}, trace.Wrap(err)
-		}
-		identity.Generation = generation
-	}
-	if allowedResourcesStr, ok := certificate.Extensions[teleport.CertExtensionAllowedResources]; ok {
-		allowedResourceIDs, err := types.ResourceIDsFromString(allowedResourcesStr)
-		if err != nil {
-			return IdentityContext{}, trace.Wrap(err)
-		}
-		identity.AllowedResourceIDs = allowedResourceIDs
-	}
-	if previousIdentityExpires, ok := certificate.Extensions[teleport.CertExtensionPreviousIdentityExpires]; ok {
-		asTime, err := time.Parse(time.RFC3339, previousIdentityExpires)
-		if err != nil {
-			return IdentityContext{}, trace.Wrap(err)
-		}
-		identity.PreviousIdentityExpires = asTime
-	}
-
-	return identity, nil
+	return IdentityContext{
+		UnmappedIdentity:        unmappedIdentity,
+		Login:                   sconn.User(),
+		CertAuthority:           certAuthority,
+		AccessChecker:           accessChecker,
+		TeleportUser:            unmappedIdentity.Username,
+		RouteToCluster:          unmappedIdentity.RouteToCluster,
+		UnmappedRoles:           unmappedIdentity.Roles,
+		CertValidBefore:         certValidBefore,
+		AllowedResourceIDs:      unmappedIdentity.AllowedResourceIDs,
+		Impersonator:            unmappedIdentity.Impersonator,
+		ActiveRequests:          unmappedIdentity.ActiveRequests,
+		DisallowReissue:         unmappedIdentity.DisallowReissue,
+		Renewable:               unmappedIdentity.Renewable,
+		BotName:                 unmappedIdentity.BotName,
+		BotInstanceID:           unmappedIdentity.BotInstanceID,
+		Generation:              unmappedIdentity.Generation,
+		PreviousIdentityExpires: unmappedIdentity.PreviousIdentityExpires,
+	}, nil
 }
 
 // CheckAgentForward checks if agent forwarding is allowed for the users RoleSet.
@@ -340,9 +310,12 @@ func (h *AuthHandlers) UserKeyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*s
 		log.DebugContext(ctx, "rejecting auth attempt without valid key ID")
 		return nil, trace.BadParameter("need a valid key for key %v", fingerprint)
 	}
-	teleportUser := cert.KeyId
 
-	connectionDiagnosticID := cert.Extensions[teleport.CertExtensionConnectionDiagnosticID]
+	ident, err := sshca.DecodeIdentity(cert)
+	if err != nil {
+		log.WarnContext(ctx, "failed to decode ssh identity from cert", "error", err)
+		return nil, trace.BadParameter("failed to decode ssh identity from cert: %v", fingerprint)
+	}
 
 	// only failed attempts are logged right now
 	recordFailedLogin := func(err error) {
@@ -362,7 +335,7 @@ func (h *AuthHandlers) UserKeyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*s
 			//
 			// The only way this could happen is if the backend state got updated between fetching the
 			// logins from the role and actually performing the test.
-			connectMyComputerRoleName := connectmycomputer.GetRoleNameForUser(teleportUser)
+			connectMyComputerRoleName := connectmycomputer.GetRoleNameForUser(ident.Username)
 
 			message = fmt.Sprintf("Principal %q is not allowed by this certificate. Ensure that the role %q includes %q in the 'login' property. ",
 				principal, connectMyComputerRoleName, principal) +
@@ -377,8 +350,8 @@ func (h *AuthHandlers) UserKeyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*s
 				// types.ConnectMyComputerNodeOwnerLabel. If a role denies access to the Connect My Computer
 				// node through node_labels, the user would never be able to see that the node has joined
 				// the cluster and would not be able to get to the connection test step.
-				connectMyComputerRoleName := connectmycomputer.GetRoleNameForUser(teleportUser)
-				nodeLabel := fmt.Sprintf("%s: %s", types.ConnectMyComputerNodeOwnerLabel, teleportUser)
+				connectMyComputerRoleName := connectmycomputer.GetRoleNameForUser(ident.Username)
+				nodeLabel := fmt.Sprintf("%s: %s", types.ConnectMyComputerNodeOwnerLabel, ident.Username)
 				message = fmt.Sprintf(
 					"You are not authorized to access this node. Ensure that you hold the role %q and that "+
 						"no role denies you access to the login %q and to nodes labeled with %q.",
@@ -388,7 +361,7 @@ func (h *AuthHandlers) UserKeyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*s
 			traceType = types.ConnectionDiagnosticTrace_RBAC_NODE
 		}
 
-		if err := h.maybeAppendDiagnosticTrace(ctx, connectionDiagnosticID,
+		if err := h.maybeAppendDiagnosticTrace(ctx, ident.ConnectionDiagnosticID,
 			traceType,
 			message,
 			err,
@@ -403,8 +376,8 @@ func (h *AuthHandlers) UserKeyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*s
 			},
 			UserMetadata: apievents.UserMetadata{
 				Login:         principal,
-				User:          teleportUser,
-				TrustedDevice: eventDeviceMetadataFromCert(cert),
+				User:          ident.Username,
+				TrustedDevice: eventDeviceMetadataFromIdentity(ident),
 			},
 			ConnectionMetadata: apievents.ConnectionMetadata{
 				LocalAddr:  conn.LocalAddr().String(),
@@ -420,7 +393,7 @@ func (h *AuthHandlers) UserKeyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*s
 
 		auditdMsg := auditd.Message{
 			SystemUser:   principal,
-			TeleportUser: teleportUser,
+			TeleportUser: ident.Username,
 			ConnAddress:  conn.RemoteAddr().String(),
 		}
 
@@ -455,11 +428,11 @@ func (h *AuthHandlers) UserKeyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*s
 
 	// this is the only way we know of to pass valid additional data about the
 	// connection to the handlers
-	permissions.Extensions[utils.CertTeleportUser] = teleportUser
+	permissions.Extensions[utils.CertTeleportUser] = ident.Username
 	permissions.Extensions[utils.CertTeleportClusterName] = clusterName.GetClusterName()
 	permissions.Extensions[utils.CertTeleportUserCertificate] = string(ssh.MarshalAuthorizedKey(cert))
 
-	switch cert.CertType {
+	switch ident.CertType {
 	case ssh.UserCert:
 		permissions.Extensions[utils.ExtIntCertType] = utils.ExtIntCertTypeUser
 	case ssh.HostCert:
@@ -491,11 +464,11 @@ func (h *AuthHandlers) UserKeyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*s
 		// Otherwise if the target node does not exist the node is
 		// probably an unregistered SSH node; do not preform an RBAC check
 		if h.c.TargetServer != nil && h.c.TargetServer.IsOpenSSHNode() {
-			err = h.canLoginWithRBAC(cert, ca, clusterName.GetClusterName(), h.c.TargetServer, teleportUser, conn.User())
+			err = h.canLoginWithRBAC(ident, ca, clusterName.GetClusterName(), h.c.TargetServer, conn.User())
 		}
 	} else {
 		// the SSH server is a Teleport node, preform an RBAC check now
-		err = h.canLoginWithRBAC(cert, ca, clusterName.GetClusterName(), h.c.Server.GetInfo(), teleportUser, conn.User())
+		err = h.canLoginWithRBAC(ident, ca, clusterName.GetClusterName(), h.c.Server.GetInfo(), conn.User())
 	}
 	if err != nil {
 		log.ErrorContext(ctx, "Permission denied", "error", err)
@@ -503,7 +476,7 @@ func (h *AuthHandlers) UserKeyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*s
 		return nil, trace.Wrap(err)
 	}
 
-	if err := h.maybeAppendDiagnosticTrace(ctx, connectionDiagnosticID,
+	if err := h.maybeAppendDiagnosticTrace(ctx, ident.ConnectionDiagnosticID,
 		types.ConnectionDiagnosticTrace_RBAC_NODE,
 		"You have access to the Node.",
 		nil,
@@ -511,7 +484,7 @@ func (h *AuthHandlers) UserKeyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*s
 		return nil, trace.Wrap(err)
 	}
 
-	if err := h.maybeAppendDiagnosticTrace(ctx, connectionDiagnosticID,
+	if err := h.maybeAppendDiagnosticTrace(ctx, ident.ConnectionDiagnosticID,
 		types.ConnectionDiagnosticTrace_CONNECTIVITY,
 		"Node is alive and reachable.",
 		nil,
@@ -519,7 +492,7 @@ func (h *AuthHandlers) UserKeyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*s
 		return nil, trace.Wrap(err)
 	}
 
-	if err := h.maybeAppendDiagnosticTrace(ctx, connectionDiagnosticID,
+	if err := h.maybeAppendDiagnosticTrace(ctx, ident.ConnectionDiagnosticID,
 		types.ConnectionDiagnosticTrace_RBAC_PRINCIPAL,
 		"The requested principal is allowed.",
 		nil,
@@ -618,7 +591,7 @@ type loginChecker interface {
 	// canLoginWithRBAC checks the given certificate (supplied by a connected
 	// client) to see if this certificate can be allowed to login as user:login
 	// pair to requested server and if RBAC rules allow login.
-	canLoginWithRBAC(cert *ssh.Certificate, ca types.CertAuthority, clusterName string, target types.Server, teleportUser, osUser string) error
+	canLoginWithRBAC(ident *sshca.Identity, ca types.CertAuthority, clusterName string, target types.Server, osUser string) error
 }
 
 type ahLoginChecker struct {
@@ -629,14 +602,14 @@ type ahLoginChecker struct {
 // canLoginWithRBAC checks the given certificate (supplied by a connected
 // client) to see if this certificate can be allowed to login as user:login
 // pair to requested server and if RBAC rules allow login.
-func (a *ahLoginChecker) canLoginWithRBAC(cert *ssh.Certificate, ca types.CertAuthority, clusterName string, target types.Server, teleportUser, osUser string) error {
+func (a *ahLoginChecker) canLoginWithRBAC(ident *sshca.Identity, ca types.CertAuthority, clusterName string, target types.Server, osUser string) error {
 	// Use the server's shutdown context.
 	ctx := a.c.Server.Context()
 
-	a.log.DebugContext(ctx, "Checking permissions to login to node with RBAC checks", "teleport_user", teleportUser, "os_user", osUser)
+	a.log.DebugContext(ctx, "Checking permissions to login to node with RBAC checks", "teleport_user", ident.Username, "os_user", osUser)
 
 	// get roles assigned to this user
-	accessInfo, err := fetchAccessInfo(cert, ca, teleportUser, clusterName)
+	accessInfo, err := fetchAccessInfo(ident, ca, clusterName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -645,7 +618,7 @@ func (a *ahLoginChecker) canLoginWithRBAC(cert *ssh.Certificate, ca types.CertAu
 		return trace.Wrap(err)
 	}
 
-	state, err := services.AccessStateFromSSHCertificate(ctx, cert, accessChecker, a.c.AccessPoint)
+	state, err := services.AccessStateFromSSHIdentity(ctx, ident, accessChecker, a.c.AccessPoint)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -673,7 +646,7 @@ func (a *ahLoginChecker) canLoginWithRBAC(cert *ssh.Certificate, ca types.CertAu
 		services.NewLoginMatcher(osUser),
 	); err != nil {
 		return trace.AccessDenied("user %s@%s is not authorized to login as %v@%s: %v",
-			teleportUser, ca.GetClusterName(), osUser, clusterName, err)
+			ident.Username, ca.GetClusterName(), osUser, clusterName, err)
 	}
 
 	return nil
@@ -682,13 +655,13 @@ func (a *ahLoginChecker) canLoginWithRBAC(cert *ssh.Certificate, ca types.CertAu
 // fetchAccessInfo fetches the services.AccessChecker (after role mapping)
 // together with the original roles (prior to role mapping) assigned to a
 // Teleport user.
-func fetchAccessInfo(cert *ssh.Certificate, ca types.CertAuthority, teleportUser string, clusterName string) (*services.AccessInfo, error) {
+func fetchAccessInfo(ident *sshca.Identity, ca types.CertAuthority, clusterName string) (*services.AccessInfo, error) {
 	var accessInfo *services.AccessInfo
 	var err error
 	if clusterName == ca.GetClusterName() {
-		accessInfo, err = services.AccessInfoFromLocalCertificate(cert)
+		accessInfo = services.AccessInfoFromLocalSSHIdentity(ident)
 	} else {
-		accessInfo, err = services.AccessInfoFromRemoteCertificate(cert, ca.CombinedMapping())
+		accessInfo, err = services.AccessInfoFromRemoteSSHIdentity(ident, ca.CombinedMapping())
 	}
 	return accessInfo, trace.Wrap(err)
 }
@@ -742,33 +715,4 @@ func (h *AuthHandlers) authorityForCert(caType types.CertAuthType, key ssh.Publi
 // isProxy returns true if it's a regular SSH proxy.
 func (h *AuthHandlers) isProxy() bool {
 	return h.c.Component == teleport.ComponentProxy
-}
-
-// AccessRequests are the access requests associated with a session
-type AccessRequests struct {
-	IDs []string `json:"access_requests"`
-}
-
-func ParseAccessRequestIDs(str string) ([]string, error) {
-	var accessRequestIDs []string
-	var ar AccessRequests
-
-	if str == "" {
-		return []string{}, nil
-	}
-	err := json.Unmarshal([]byte(str), &ar)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	for _, v := range ar.IDs {
-		id, err := uuid.Parse(v)
-		if err != nil {
-			return nil, trace.WrapWithMessage(err, "failed to parse access request ID")
-		}
-		if fmt.Sprintf("%v", id) == "" {
-			return nil, trace.Errorf("invalid uuid: %v", id)
-		}
-		accessRequestIDs = append(accessRequestIDs, v)
-	}
-	return accessRequestIDs, nil
 }

--- a/lib/srv/authhandlers_test.go
+++ b/lib/srv/authhandlers_test.go
@@ -62,7 +62,7 @@ type mockLoginChecker struct {
 	rbacChecked bool
 }
 
-func (m *mockLoginChecker) canLoginWithRBAC(_ *ssh.Certificate, _ types.CertAuthority, _ string, _ types.Server, _, _ string) error {
+func (m *mockLoginChecker) canLoginWithRBAC(_ *sshca.Identity, _ types.CertAuthority, _ string, _ types.Server, _ string) error {
 	m.rbacChecked = true
 	return nil
 }
@@ -408,7 +408,10 @@ func TestRBACJoinMFA(t *testing.T) {
 			cert, err := sshutils.ParseCertificate(c)
 			require.NoError(t, err)
 
-			err = ah.canLoginWithRBAC(cert, userCA, clusterName, node, username, teleport.SSHSessionJoinPrincipal)
+			ident, err := sshca.DecodeIdentity(cert)
+			require.NoError(t, err)
+
+			err = ah.canLoginWithRBAC(ident, userCA, clusterName, node, teleport.SSHSessionJoinPrincipal)
 			tt.testError(t, err)
 		})
 	}

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -49,6 +49,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	rsession "github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/srv/uacc"
+	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/sshutils/x11"
 	"github.com/gravitational/teleport/lib/utils"
@@ -189,6 +190,10 @@ type Server interface {
 // IdentityContext holds all identity information associated with the user
 // logged on the connection.
 type IdentityContext struct {
+	// UnmappedIdentity is the base identity of the user derived from the cert, without any
+	// cross-cluster mapping applied.
+	UnmappedIdentity *sshca.Identity
+
 	// TeleportUser is the Teleport user associated with the connection.
 	TeleportUser string
 
@@ -197,10 +202,6 @@ type IdentityContext struct {
 
 	// Login is the operating system user associated with the connection.
 	Login string
-
-	// Certificate is the SSH user certificate bytes marshaled in the OpenSSH
-	// authorized_keys format.
-	Certificate *ssh.Certificate
 
 	// CertAuthority is the Certificate Authority that signed the Certificate.
 	CertAuthority types.CertAuthority
@@ -974,11 +975,6 @@ func getPAMConfig(c *ServerContext) (*PAMConfig, error) {
 	environment["TELEPORT_LOGIN"] = c.Identity.Login
 	environment["TELEPORT_ROLES"] = strings.Join(roleNames, " ")
 	if localPAMConfig.Environment != nil {
-		traits, err := services.ExtractTraitsFromCert(c.Identity.Certificate)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
 		for key, value := range localPAMConfig.Environment {
 			expr, err := parse.NewTraitsTemplateExpression(value)
 			if err != nil {
@@ -992,7 +988,7 @@ func getPAMConfig(c *ServerContext) (*PAMConfig, error) {
 				return nil
 			}
 
-			result, err := expr.Interpolate(varValidation, traits)
+			result, err := expr.Interpolate(varValidation, c.Identity.UnmappedIdentity.Traits)
 			if err != nil {
 				// If the trait isn't passed by the IdP due to misconfiguration
 				// we fallback to setting a value which will indicate this.
@@ -1070,22 +1066,19 @@ func (c *ServerContext) ExecCommand() (*ExecCommand, error) {
 	}, nil
 }
 
-func eventDeviceMetadataFromCert(cert *ssh.Certificate) *apievents.DeviceMetadata {
-	if cert == nil {
+func eventDeviceMetadataFromIdentity(ident *sshca.Identity) *apievents.DeviceMetadata {
+	if ident == nil {
 		return nil
 	}
 
-	devID := cert.Extensions[teleport.CertExtensionDeviceID]
-	assetTag := cert.Extensions[teleport.CertExtensionDeviceAssetTag]
-	credID := cert.Extensions[teleport.CertExtensionDeviceCredentialID]
-	if devID == "" && assetTag == "" && credID == "" {
+	if ident.DeviceID == "" && ident.DeviceAssetTag == "" && ident.DeviceCredentialID == "" {
 		return nil
 	}
 
 	return &apievents.DeviceMetadata{
-		DeviceId:     devID,
-		AssetTag:     assetTag,
-		CredentialId: credID,
+		DeviceId:     ident.DeviceID,
+		AssetTag:     ident.DeviceAssetTag,
+		CredentialId: ident.DeviceCredentialID,
 	}
 }
 
@@ -1100,7 +1093,7 @@ func (id *IdentityContext) GetUserMetadata() apievents.UserMetadata {
 		User:           id.TeleportUser,
 		Impersonator:   id.Impersonator,
 		AccessRequests: id.ActiveRequests,
-		TrustedDevice:  eventDeviceMetadataFromCert(id.Certificate),
+		TrustedDevice:  eventDeviceMetadataFromIdentity(id.UnmappedIdentity),
 		UserKind:       userKind,
 		BotName:        id.BotName,
 		BotInstanceID:  id.BotInstanceID,
@@ -1199,10 +1192,10 @@ func ComputeLockTargets(clusterName, serverID string, id IdentityContext) []type
 		{Node: serverID, ServerID: serverID},
 		{Node: authclient.HostFQDN(serverID, clusterName), ServerID: authclient.HostFQDN(serverID, clusterName)},
 	}
-	if mfaDevice := id.Certificate.Extensions[teleport.CertExtensionMFAVerified]; mfaDevice != "" {
+	if mfaDevice := id.UnmappedIdentity.MFAVerified; mfaDevice != "" {
 		lockTargets = append(lockTargets, types.LockTarget{MFADevice: mfaDevice})
 	}
-	if trustedDevice := id.Certificate.Extensions[teleport.CertExtensionDeviceID]; trustedDevice != "" {
+	if trustedDevice := id.UnmappedIdentity.DeviceID; trustedDevice != "" {
 		lockTargets = append(lockTargets, types.LockTarget{Device: trustedDevice})
 	}
 	roles := apiutils.Deduplicate(append(id.AccessChecker.RoleNames(), id.UnmappedRoles...))
@@ -1264,8 +1257,8 @@ func (c *ServerContext) GetExecRequest() (Exec, error) {
 func (c *ServerContext) GetSessionMetadata() apievents.SessionMetadata {
 	return apievents.SessionMetadata{
 		SessionID:        string(c.SessionID()),
-		WithMFA:          c.Identity.Certificate.Extensions[teleport.CertExtensionMFAVerified],
-		PrivateKeyPolicy: c.Identity.Certificate.Extensions[teleport.CertExtensionPrivateKeyPolicy],
+		WithMFA:          c.Identity.UnmappedIdentity.MFAVerified,
+		PrivateKeyPolicy: string(c.Identity.UnmappedIdentity.PrivateKeyPolicy),
 	}
 }
 

--- a/lib/srv/ctx_test.go
+++ b/lib/srv/ctx_test.go
@@ -25,14 +25,13 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/crypto/ssh"
 	"google.golang.org/protobuf/testing/protocmp"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/services"
 	rsession "github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/sshutils"
 )
 
@@ -193,17 +192,14 @@ func TestIdentityContext_GetUserMetadata(t *testing.T) {
 		{
 			name: "device metadata",
 			idCtx: IdentityContext{
+				UnmappedIdentity: &sshca.Identity{
+					Username:           "alpaca",
+					DeviceID:           "deviceid1",
+					DeviceAssetTag:     "assettag1",
+					DeviceCredentialID: "credentialid1",
+				},
 				TeleportUser: "alpaca",
 				Login:        "alpaca1",
-				Certificate: &ssh.Certificate{
-					Permissions: ssh.Permissions{
-						Extensions: map[string]string{
-							teleport.CertExtensionDeviceID:           "deviceid1",
-							teleport.CertExtensionDeviceAssetTag:     "assettag1",
-							teleport.CertExtensionDeviceCredentialID: "credentialid1",
-						},
-					},
-				},
 			},
 			want: apievents.UserMetadata{
 				User:  "alpaca",
@@ -255,17 +251,14 @@ func TestComputeLockTargets(t *testing.T) {
 		accessRequests := []string{"access-request-1", "access-request-2"}
 
 		identityCtx := IdentityContext{
+			UnmappedIdentity: &sshca.Identity{
+				Username:    "llama",
+				MFAVerified: mfaDevice,
+				DeviceID:    trustedDevice,
+			},
 			TeleportUser: "llama",
 			Impersonator: "alpaca",
 			Login:        "camel",
-			Certificate: &ssh.Certificate{
-				Permissions: ssh.Permissions{
-					Extensions: map[string]string{
-						teleport.CertExtensionMFAVerified: mfaDevice,
-						teleport.CertExtensionDeviceID:    trustedDevice,
-					},
-				},
-			},
 			AccessChecker: &fixedRolesChecker{
 				roleNames: mappedRoles,
 			},

--- a/lib/srv/mock.go
+++ b/lib/srv/mock.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	rsession "github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/clocki"
@@ -55,6 +56,9 @@ func newTestServerContext(t *testing.T, srv Server, roleSet services.RoleSet) *S
 	require.NoError(t, err)
 
 	cert, err := apisshutils.ParseCertificate([]byte(fixtures.UserCertificateStandard))
+	require.NoError(t, err)
+
+	ident, err := sshca.DecodeIdentity(cert)
 	require.NoError(t, err)
 
 	sshConn := &mockSSHConn{}
@@ -76,9 +80,9 @@ func newTestServerContext(t *testing.T, srv Server, roleSet services.RoleSet) *S
 		srv:                    srv,
 		sessionID:              rsession.NewID(),
 		Identity: IdentityContext{
-			Login:        usr.Username,
-			TeleportUser: "teleportUser",
-			Certificate:  cert,
+			UnmappedIdentity: ident,
+			Login:            usr.Username,
+			TeleportUser:     "teleportUser",
 			// roles do not actually exist in mock backend, just need a non-nil
 			// access checker to avoid panic
 			AccessChecker: services.NewAccessCheckerWithRoleSet(

--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -249,7 +249,8 @@ func (t *proxySubsys) proxyToHost(ctx context.Context, ch ssh.Channel, clientSrc
 	}
 	identity := t.ctx.Identity
 
-	signer := agentless.SignerFromSSHCertificate(identity.Certificate, authClient, t.clusterName, identity.TeleportUser)
+	signer := agentless.SignerFromSSHIdentity(identity.UnmappedIdentity, authClient, t.clusterName, identity.TeleportUser)
+
 	aGetter := t.ctx.StartAgentChannel
 	conn, err := t.router.DialHost(ctx, clientSrcAddr, clientDstAddr, t.host, t.port, t.clusterName, t.ctx.Identity.AccessChecker, aGetter, signer)
 	if err != nil {

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -858,7 +858,7 @@ func newSession(ctx context.Context, id rsession.ID, r *SessionRegistry, scx *Se
 		serverCtx:                      scx.srv.Context(),
 		access:                         &access,
 		scx:                            scx,
-		presenceEnabled:                scx.Identity.Certificate.Extensions[teleport.CertExtensionMFAVerified] != "",
+		presenceEnabled:                scx.Identity.UnmappedIdentity.MFAVerified != "",
 		io:                             NewTermManager(),
 		doneCh:                         make(chan struct{}),
 		initiator:                      scx.Identity.TeleportUser,

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -52,49 +52,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-func TestParseAccessRequestIDs(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		input     string
-		comment   string
-		result    []string
-		assertErr require.ErrorAssertionFunc
-	}{
-		{
-			input:     `{"access_requests":["1a7483e0-575a-4bd1-9faa-022500a49325","30b344f5-d1ba-49fc-b2aa-b04234d0a4ec"]}`,
-			comment:   "complete valid input",
-			assertErr: require.NoError,
-			result:    []string{"1a7483e0-575a-4bd1-9faa-022500a49325", "30b344f5-d1ba-49fc-b2aa-b04234d0a4ec"},
-		},
-		{
-			input:     `{"access_requests":["1a7483e0-575a-4bd1-9faa-022500a49325","30b344f5-d1ba-49fc-b2aa"]}`,
-			comment:   "invalid uuid",
-			assertErr: require.Error,
-			result:    nil,
-		},
-		{
-			input:     `{"access_requests":[nil,"30b344f5-d1ba-49fc-b2aa-b04234d0a4ec"]}`,
-			comment:   "invalid value, value in slice is nil",
-			assertErr: require.Error,
-			result:    nil,
-		},
-		{
-			input:     `{"access_requests":nil}`,
-			comment:   "invalid value, whole value is nil",
-			assertErr: require.Error,
-			result:    nil,
-		},
-	}
-	for _, tt := range testCases {
-		t.Run(tt.comment, func(t *testing.T) {
-			out, err := ParseAccessRequestIDs(tt.input)
-			tt.assertErr(t, err)
-			require.Equal(t, out, tt.result)
-		})
-	}
-}
-
 func TestIsApprovedFileTransfer(t *testing.T) {
 	// set enterprise for tests
 	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})

--- a/lib/srv/session_control_test.go
+++ b/lib/srv/session_control_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
@@ -38,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/sshca"
 )
 
 type mockLockEnforcer struct {
@@ -131,11 +131,11 @@ func TestSessionController_AcquireSessionContext(t *testing.T) {
 	}
 
 	minimalIdentity := IdentityContext{
+		UnmappedIdentity: &sshca.Identity{
+			Username: "alpaca",
+		},
 		TeleportUser: "alpaca",
 		Login:        "alpaca",
-		Certificate: &ssh.Certificate{
-			KeyId: "alpaca",
-		},
 		AccessChecker: &mockAccessChecker{
 			keyPolicy: keys.PrivateKeyPolicyNone,
 		},
@@ -150,17 +150,12 @@ func TestSessionController_AcquireSessionContext(t *testing.T) {
 		return cfg
 	}
 	identityWithDeviceExtensions := func() IdentityContext {
+		ident := *minimalIdentity.UnmappedIdentity
 		idCtx := minimalIdentity
-		idCtx.Certificate = &ssh.Certificate{
-			KeyId: "alpaca",
-			Permissions: ssh.Permissions{
-				Extensions: map[string]string{
-					teleport.CertExtensionDeviceID:           "deviceid1",
-					teleport.CertExtensionDeviceAssetTag:     "assettag1",
-					teleport.CertExtensionDeviceCredentialID: "credentialid1",
-				},
-			},
-		}
+		idCtx.UnmappedIdentity = &ident
+		idCtx.UnmappedIdentity.DeviceID = "deviceid1"
+		idCtx.UnmappedIdentity.DeviceAssetTag = "assettag1"
+		idCtx.UnmappedIdentity.DeviceCredentialID = "credentialid1"
 		return idCtx
 	}
 	assertTrustedDeviceRequired := func(t *testing.T, _ context.Context, err error, _ *eventstest.MockRecorderEmitter) {
@@ -194,15 +189,12 @@ func TestSessionController_AcquireSessionContext(t *testing.T) {
 				ServerID:     "1234",
 			},
 			identity: IdentityContext{
+				UnmappedIdentity: &sshca.Identity{
+					Username:         "alpaca",
+					PrivateKeyPolicy: keys.PrivateKeyPolicyNone,
+				},
 				TeleportUser: "alpaca",
 				Login:        "alpaca",
-				Certificate: &ssh.Certificate{
-					Permissions: ssh.Permissions{
-						Extensions: map[string]string{
-							teleport.CertExtensionPrivateKeyPolicy: string(keys.PrivateKeyPolicyNone),
-						},
-					},
-				},
 				AccessChecker: mockAccessChecker{
 					keyPolicy:      keys.PrivateKeyPolicyNone,
 					maxConnections: 1,
@@ -245,15 +237,12 @@ func TestSessionController_AcquireSessionContext(t *testing.T) {
 				ServerID:     "1234",
 			},
 			identity: IdentityContext{
+				UnmappedIdentity: &sshca.Identity{
+					Username:         "alpaca",
+					PrivateKeyPolicy: keys.PrivateKeyPolicyNone,
+				},
 				TeleportUser: "alpaca",
 				Login:        "alpaca",
-				Certificate: &ssh.Certificate{
-					Permissions: ssh.Permissions{
-						Extensions: map[string]string{
-							teleport.CertExtensionPrivateKeyPolicy: string(keys.PrivateKeyPolicyNone),
-						},
-					},
-				},
 				AccessChecker: mockAccessChecker{
 					keyPolicy:      keys.PrivateKeyPolicyNone,
 					maxConnections: 1,
@@ -286,15 +275,12 @@ func TestSessionController_AcquireSessionContext(t *testing.T) {
 				ServerID:  "1234",
 			},
 			identity: IdentityContext{
+				UnmappedIdentity: &sshca.Identity{
+					Username:         "alpaca",
+					PrivateKeyPolicy: keys.PrivateKeyPolicyNone,
+				},
 				TeleportUser: "alpaca",
 				Login:        "alpaca",
-				Certificate: &ssh.Certificate{
-					Permissions: ssh.Permissions{
-						Extensions: map[string]string{
-							teleport.CertExtensionPrivateKeyPolicy: string(keys.PrivateKeyPolicyNone),
-						},
-					},
-				},
 				AccessChecker: mockAccessChecker{
 					keyPolicy:      keys.PrivateKeyPolicyNone,
 					maxConnections: 1,
@@ -332,15 +318,12 @@ func TestSessionController_AcquireSessionContext(t *testing.T) {
 				ServerID:     "1234",
 			},
 			identity: IdentityContext{
+				UnmappedIdentity: &sshca.Identity{
+					Username:         "alpaca",
+					PrivateKeyPolicy: keys.PrivateKeyPolicyNone,
+				},
 				TeleportUser: "alpaca",
 				Login:        "alpaca",
-				Certificate: &ssh.Certificate{
-					Permissions: ssh.Permissions{
-						Extensions: map[string]string{
-							teleport.CertExtensionPrivateKeyPolicy: string(keys.PrivateKeyPolicyNone),
-						},
-					},
-				},
 				AccessChecker: mockAccessChecker{
 					keyPolicy:      keys.PrivateKeyPolicyHardwareKey,
 					maxConnections: 1,
@@ -379,15 +362,12 @@ func TestSessionController_AcquireSessionContext(t *testing.T) {
 				ServerID:     "1234",
 			},
 			identity: IdentityContext{
+				UnmappedIdentity: &sshca.Identity{
+					Username:         "alpaca",
+					PrivateKeyPolicy: keys.PrivateKeyPolicyNone,
+				},
 				TeleportUser: "alpaca",
 				Login:        "alpaca",
-				Certificate: &ssh.Certificate{
-					Permissions: ssh.Permissions{
-						Extensions: map[string]string{
-							teleport.CertExtensionPrivateKeyPolicy: string(keys.PrivateKeyPolicyNone),
-						},
-					},
-				},
 				AccessChecker: mockAccessChecker{
 					keyPolicy:      keys.PrivateKeyPolicyNone,
 					maxConnections: 1,
@@ -434,15 +414,12 @@ func TestSessionController_AcquireSessionContext(t *testing.T) {
 				ServerID:     "1234",
 			},
 			identity: IdentityContext{
+				UnmappedIdentity: &sshca.Identity{
+					Username:         "alpaca",
+					PrivateKeyPolicy: keys.PrivateKeyPolicyNone,
+				},
 				TeleportUser: "alpaca",
 				Login:        "alpaca",
-				Certificate: &ssh.Certificate{
-					Permissions: ssh.Permissions{
-						Extensions: map[string]string{
-							teleport.CertExtensionPrivateKeyPolicy: string(keys.PrivateKeyPolicyNone),
-						},
-					},
-				},
 				AccessChecker: mockAccessChecker{
 					keyPolicy:      keys.PrivateKeyPolicyNone,
 					maxConnections: 0,

--- a/lib/sshca/encoding_helpers.go
+++ b/lib/sshca/encoding_helpers.go
@@ -1,0 +1,65 @@
+/*
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package sshca
+
+import (
+	"encoding/json"
+
+	"github.com/gravitational/trace"
+)
+
+// requestIDs is a collection of IDs for privilege escalation requests. This type is used
+// for serialization/deserialization of request IDs for embedding in certificates. Most usecases
+// should prefer representing request IDs as a slice of strings.
+type requestIDs struct {
+	AccessRequests []string `json:"access_requests,omitempty"`
+}
+
+// Marshal encodes requestIDs into the canonical JSON format expected for teleport certificates.
+func (r *requestIDs) Marshal() ([]byte, error) {
+	data, err := json.Marshal(r)
+	return data, trace.Wrap(err)
+}
+
+// Unmarshal decodes requestIDs from the canonical JSON format expected for teleport certificates.
+func (r *requestIDs) Unmarshal(data []byte) error {
+	return trace.Wrap(json.Unmarshal(data, r))
+}
+
+// IsEmpty returns true if the requestIDs is empty.
+func (r *requestIDs) IsEmpty() bool {
+	return len(r.AccessRequests) < 1
+}
+
+// certRoles is a helper for marshaling and unmarshaling roles list to the format
+// used by the teleport ssh certificate role extension.
+type certRoles struct {
+	// Roles is a list of roles
+	Roles []string `json:"roles"`
+}
+
+// Marshal marshals roles to the format used by the teleport ssh certificate role extension.
+func (r *certRoles) Marshal() ([]byte, error) {
+	data, err := json.Marshal(r)
+	return data, trace.Wrap(err)
+}
+
+// Unmarshal unmarshals roles from the teleport ssh certificate role extension format.
+func (r *certRoles) Unmarshal(data []byte) error {
+	return trace.Wrap(json.Unmarshal(data, r))
+}

--- a/lib/sshca/identity.go
+++ b/lib/sshca/identity.go
@@ -34,7 +34,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/teleport/api/utils/keys"
-	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -280,24 +279,27 @@ func (i *Identity) Encode(certFormat string) (*ssh.Certificate, error) {
 			cert.Permissions.Extensions[teleport.CertExtensionTeleportTraits] = string(traits)
 		}
 		if len(i.Roles) != 0 {
-			roles, err := services.MarshalCertRoles(i.Roles)
+			roles := certRoles{
+				Roles: i.Roles,
+			}
+			rolesExt, err := roles.Marshal()
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
-			cert.Permissions.Extensions[teleport.CertExtensionTeleportRoles] = roles
+			cert.Permissions.Extensions[teleport.CertExtensionTeleportRoles] = string(rolesExt)
 		}
 		if i.RouteToCluster != "" {
 			cert.Permissions.Extensions[teleport.CertExtensionTeleportRouteToCluster] = i.RouteToCluster
 		}
 		if len(i.ActiveRequests) != 0 {
-			reqs := services.RequestIDs{
+			reqs := requestIDs{
 				AccessRequests: i.ActiveRequests,
 			}
-			requests, err := reqs.Marshal()
+			reqsExt, err := reqs.Marshal()
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
-			cert.Permissions.Extensions[teleport.CertExtensionTeleportActiveRequests] = string(requests)
+			cert.Permissions.Extensions[teleport.CertExtensionTeleportActiveRequests] = string(reqsExt)
 		}
 	}
 
@@ -412,17 +414,17 @@ func DecodeIdentity(cert *ssh.Certificate) (*Identity, error) {
 	}
 
 	if v, ok := takeExtension(teleport.CertExtensionTeleportRoles); ok {
-		roles, err := services.UnmarshalCertRoles(v)
-		if err != nil {
+		var roles certRoles
+		if err := roles.Unmarshal([]byte(v)); err != nil {
 			return nil, trace.BadParameter("failed to unmarshal value %q for extension %q as roles: %v", v, teleport.CertExtensionTeleportRoles, err)
 		}
-		ident.Roles = roles
+		ident.Roles = roles.Roles
 	}
 
 	ident.RouteToCluster = takeValue(teleport.CertExtensionTeleportRouteToCluster)
 
 	if v, ok := takeExtension(teleport.CertExtensionTeleportActiveRequests); ok {
-		var reqs services.RequestIDs
+		var reqs requestIDs
 		if err := reqs.Unmarshal([]byte(v)); err != nil {
 			return nil, trace.BadParameter("failed to unmarshal value %q for extension %q as active requests: %v", v, teleport.CertExtensionTeleportActiveRequests, err)
 		}

--- a/lib/sshca/identity_test.go
+++ b/lib/sshca/identity_test.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 
@@ -51,7 +50,7 @@ func TestIdentityConversion(t *testing.T) {
 		Roles:                   []string{"role1", "role2"},
 		RouteToCluster:          "cluster",
 		Traits:                  wrappers.Traits{"trait1": []string{"value1"}, "trait2": []string{"value2"}},
-		ActiveRequests:          []string{uuid.NewString()},
+		ActiveRequests:          []string{"some-request"},
 		MFAVerified:             "mfa",
 		PreviousIdentityExpires: time.Unix(12345, 0),
 		LoginIP:                 "127.0.0.1",

--- a/lib/teleterm/clusters/cluster.go
+++ b/lib/teleterm/clusters/cluster.go
@@ -309,7 +309,7 @@ func (c *Cluster) GetLoggedInUser() LoggedInUser {
 		Name:           c.status.Username,
 		SSHLogins:      c.status.Logins,
 		Roles:          c.status.Roles,
-		ActiveRequests: c.status.ActiveRequests.AccessRequests,
+		ActiveRequests: c.status.ActiveRequests,
 	}
 }
 

--- a/lib/teleterm/clusters/cluster_access_requests.go
+++ b/lib/teleterm/clusters/cluster_access_requests.go
@@ -221,7 +221,7 @@ func (c *Cluster) AssumeRole(ctx context.Context, rootClient *client.ClusterClie
 		}
 
 		// keep existing access requests that aren't included in the droprequests
-		for _, reqID := range c.status.ActiveRequests.AccessRequests {
+		for _, reqID := range c.status.ActiveRequests {
 			if !slices.Contains(req.DropRequestIds, reqID) {
 				params.AccessRequests = append(params.AccessRequests, reqID)
 			}

--- a/lib/teleterm/clusters/cluster_apps.go
+++ b/lib/teleterm/clusters/cluster_apps.go
@@ -84,7 +84,7 @@ func (c *Cluster) ReissueAppCert(ctx context.Context, clusterClient *client.Clus
 	// Refresh the certs to account for clusterClient.SiteName pointing at a leaf cluster.
 	err := clusterClient.ReissueUserCerts(ctx, client.CertCacheKeep, client.ReissueParams{
 		RouteToCluster: c.clusterClient.SiteName,
-		AccessRequests: c.status.ActiveRequests.AccessRequests,
+		AccessRequests: c.status.ActiveRequests,
 	})
 	if err != nil {
 		return tls.Certificate{}, trace.Wrap(err)
@@ -93,7 +93,7 @@ func (c *Cluster) ReissueAppCert(ctx context.Context, clusterClient *client.Clus
 	keyRing, _, err := clusterClient.IssueUserCertsWithMFA(ctx, client.ReissueParams{
 		RouteToCluster: c.clusterClient.SiteName,
 		RouteToApp:     routeToApp,
-		AccessRequests: c.status.ActiveRequests.AccessRequests,
+		AccessRequests: c.status.ActiveRequests,
 		RequesterName:  proto.UserCertsRequest_TSH_APP_LOCAL_PROXY,
 		TTL:            c.clusterClient.KeyTTL,
 	})

--- a/lib/teleterm/clusters/cluster_databases.go
+++ b/lib/teleterm/clusters/cluster_databases.go
@@ -85,7 +85,7 @@ func (c *Cluster) reissueDBCerts(ctx context.Context, clusterClient *client.Clus
 	// Refresh the certs to account for clusterClient.SiteName pointing at a leaf cluster.
 	err := clusterClient.ReissueUserCerts(ctx, client.CertCacheKeep, client.ReissueParams{
 		RouteToCluster: c.clusterClient.SiteName,
-		AccessRequests: c.status.ActiveRequests.AccessRequests,
+		AccessRequests: c.status.ActiveRequests,
 	})
 	if err != nil {
 		return tls.Certificate{}, trace.Wrap(err)
@@ -98,7 +98,7 @@ func (c *Cluster) reissueDBCerts(ctx context.Context, clusterClient *client.Clus
 			Protocol:    routeToDatabase.Protocol,
 			Username:    routeToDatabase.Username,
 		},
-		AccessRequests: c.status.ActiveRequests.AccessRequests,
+		AccessRequests: c.status.ActiveRequests,
 		RequesterName:  proto.UserCertsRequest_TSH_DB_LOCAL_PROXY_TUNNEL,
 		TTL:            c.clusterClient.KeyTTL,
 	})

--- a/lib/teleterm/clusters/cluster_kubes.go
+++ b/lib/teleterm/clusters/cluster_kubes.go
@@ -48,7 +48,7 @@ func (c *Cluster) reissueKubeCert(ctx context.Context, clusterClient *client.Clu
 	// Refresh the certs to account for clusterClient.SiteName pointing at a leaf cluster.
 	err := clusterClient.ReissueUserCerts(ctx, client.CertCacheKeep, client.ReissueParams{
 		RouteToCluster: c.clusterClient.SiteName,
-		AccessRequests: c.status.ActiveRequests.AccessRequests,
+		AccessRequests: c.status.ActiveRequests,
 	})
 	if err != nil {
 		return tls.Certificate{}, trace.Wrap(err)

--- a/lib/web/files.go
+++ b/lib/web/files.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/sshutils/sftp"
 	"github.com/gravitational/teleport/lib/teleagent"
 	"github.com/gravitational/teleport/lib/utils"
@@ -178,7 +179,13 @@ func (h *Handler) transferFile(w http.ResponseWriter, r *http.Request, p httprou
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	signer := agentless.SignerFromSSHCertificate(cert, h.auth.accessPoint, tc.SiteName, tc.Username)
+
+	ident, err := sshca.DecodeIdentity(cert)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	signer := agentless.SignerFromSSHIdentity(ident, h.auth.accessPoint, tc.SiteName, tc.Username)
 
 	conn, err := h.cfg.Router.DialHost(
 		ctx,

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -59,6 +59,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
 	alpncommon "github.com/gravitational/teleport/lib/srv/alpnproxy/common"
+	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -511,10 +512,12 @@ func (c *SessionContext) GetUserAccessChecker() (services.AccessChecker, error) 
 		return nil, trace.Wrap(err)
 	}
 
-	accessInfo, err := services.AccessInfoFromLocalCertificate(cert)
+	ident, err := sshca.DecodeIdentity(cert)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	accessInfo := services.AccessInfoFromLocalSSHIdentity(ident)
 
 	accessChecker, err := services.NewAccessChecker(accessInfo, c.cfg.RootClusterName, c.cfg.UnsafeCachedAuthClient)
 	return accessChecker, trace.Wrap(err)

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -61,6 +61,7 @@ import (
 	"github.com/gravitational/teleport/lib/proxy"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/teleagent"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/diagnostics/latency"
@@ -690,7 +691,13 @@ func (t *sshBaseHandler) connectToHost(ctx context.Context, ws terminal.WSConn, 
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	signer := agentless.SignerFromSSHCertificate(cert, t.localAccessPoint, tc.SiteName, tc.Username)
+
+	ident, err := sshca.DecodeIdentity(cert)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	signer := agentless.SignerFromSSHIdentity(ident, t.localAccessPoint, tc.SiteName, tc.Username)
 
 	type clientRes struct {
 		clt *client.NodeClient

--- a/tool/tsh/common/app.go
+++ b/tool/tsh/common/app.go
@@ -96,7 +96,7 @@ func onAppLogin(cf *CLIConf) error {
 	appCertParams := client.ReissueParams{
 		RouteToCluster: tc.SiteName,
 		RouteToApp:     routeToApp,
-		AccessRequests: appInfo.profile.ActiveRequests.AccessRequests,
+		AccessRequests: appInfo.profile.ActiveRequests,
 	}
 
 	key, err := appLogin(cf.Context, clusterClient, rootClient, appCertParams)

--- a/tool/tsh/common/db.go
+++ b/tool/tsh/common/db.go
@@ -324,7 +324,7 @@ func databaseLogin(cf *CLIConf, tc *client.TeleportClient, dbInfo *databaseInfo)
 					Database:    dbInfo.Database,
 					Roles:       dbInfo.Roles,
 				},
-				AccessRequests: profile.ActiveRequests.AccessRequests,
+				AccessRequests: profile.ActiveRequests,
 			})
 			return trace.Wrap(err)
 		}); err != nil {

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1993,7 +1993,7 @@ func onLogin(cf *CLIConf, reExecArgs ...string) error {
 			}
 			// trigger reissue, preserving any active requests.
 			err = tc.ReissueUserCerts(cf.Context, client.CertCacheKeep, client.ReissueParams{
-				AccessRequests: profile.ActiveRequests.AccessRequests,
+				AccessRequests: profile.ActiveRequests,
 				RouteToCluster: cf.SiteName,
 			})
 			if err != nil {
@@ -5119,7 +5119,7 @@ func makeProfileInfo(p *client.ProfileStatus, env map[string]string, isActive bo
 	out := &profileInfo{
 		ProxyURL:           p.ProxyURL.String(),
 		Username:           p.Username,
-		ActiveRequests:     p.ActiveRequests.AccessRequests,
+		ActiveRequests:     p.ActiveRequests,
 		Cluster:            p.Cluster,
 		Roles:              p.Roles,
 		Traits:             p.Traits,
@@ -5326,7 +5326,7 @@ func reissueWithRequests(cf *CLIConf, tc *client.TeleportClient, newRequests []s
 		RouteToCluster:     cf.SiteName,
 	}
 	// If the certificate already had active requests, add them to our inputs parameters.
-	for _, reqID := range profile.ActiveRequests.AccessRequests {
+	for _, reqID := range profile.ActiveRequests {
 		if !slices.Contains(dropRequests, reqID) {
 			params.AccessRequests = append(params.AccessRequests, reqID)
 		}

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -4646,7 +4646,7 @@ func TestSerializeProfiles(t *testing.T) {
 	activeProfile := &client.ProfileStatus{
 		ProxyURL:       *p,
 		Username:       "test",
-		ActiveRequests: services.RequestIDs{AccessRequests: []string{"1", "2", "3"}},
+		ActiveRequests: []string{"1", "2", "3"},
 		Cluster:        "main",
 		Roles:          []string{"a", "b", "c"},
 		Traits:         wrappers.Traits{"a": []string{"1", "2", "3"}},

--- a/tool/tsh/common/vnet_client_application.go
+++ b/tool/tsh/common/vnet_client_application.go
@@ -198,7 +198,7 @@ func (p *vnetClientApplication) reissueAppCert(ctx context.Context, tc *client.T
 	appCertParams := client.ReissueParams{
 		RouteToCluster: leafClusterName,
 		RouteToApp:     *routeToApp,
-		AccessRequests: profile.ActiveRequests.AccessRequests,
+		AccessRequests: profile.ActiveRequests,
 		RequesterName:  proto.UserCertsRequest_TSH_APP_LOCAL_PROXY,
 	}
 


### PR DESCRIPTION
Reworks ssh decision/enforcement logic and related helpers to not use certificates directly and instead use `sshca.Identity`.  This is a prerequisite for moving much of this logic behind the PDP API, and is easier to reason about/review if done separately.

Generally, this PR strives to make no changes in behavior/logic.  It is intended purely as a refactor.  There are two cases I know of where logic has been subtly changed by this PR:

1. We were inconsistent about whether we treated the `MFAVerified` certificate extension as being "true" if it were present at all, or only if it were present and non-empty.  Our issuing logic never sets the `MFAVerified` extension unless the string value is non-empty, so this PR standardizes on considering only a non-empty `MFAVerified` as "true".  Since the issuing logic never issued certs with an empty extension, this should have no impact.

2. We were inconsistent about whether or not agent-side logic would reject access request IDs from certs that are not valid UUIDs.  Agent-side logic only ever used the access request IDs on certs for audit logging purposes, and as such I think there is no particular reason for it to care about their format, so agents now never reject a cert for having non-uuid strings in the active requests extension field.

Note that this PR does leave `srv.IdentityContext` in a bit of a funny state, since many of its top-level fields are now just duplicates of the members of the new `IdentityContext.UnmappedIdentity` field.  A lot of logic that currently accesses those fields could instead be switched over to accessing the equivalent fields in `UnmappedIdentity`.  I've decided to leave as-is for now.  First, because a lot of those sites need to be reworked to use `decision.SSHAccessPermit` as their source of truth once that gets put into place anyway, and second because I'm not sure its good practice to have unmapped identity fields being leaned on too heavily in the codebase.  Increases the likelihood that someone might accidentally rely on a field like `IdentityContext.UnmappedIdentity.Roles` when they aught to be using `IdentityContext.Roles`.

*EDIT*: During the course of addressing feedback on this PR I discovered that the logic by which we were loading CAs in `reversetunnel.server.keyAuth` was incorrect and would cause handshakes to fail for any user cert issued with a `route-to-cluster` directive and/or for a cluster other than the local cluster.  Rather than "fix" this issue, I've reworked the logic so that it now "officially" does what it was doing accidentally before since it has worked this way for many years without negatively impacting teleport functionality.  Test coverage for the function was also incorrect, effectively hiding the problem by hard-coding the CA returned from CA resolution causing operations that should have failed to succeed.  Test coverage has been updated to correctly exercise CA resolution and to explicitly cover supported and unsupported scenarios.