### PR TITLE
Prevent race creating test logger

### DIFF
--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -117,8 +117,10 @@ var initTestLoggerOnce = sync.Once{}
 // InitLoggerForTests initializes the standard logger for tests.
 func InitLoggerForTests() {
 	initTestLoggerOnce.Do(func() {
-		// Parse flags to check testing.Verbose().
-		flag.Parse()
+		if !flag.Parsed() {
+			// Parse flags to check testing.Verbose().
+			flag.Parse()
+		}
 
 		if !testing.Verbose() {
 			slog.SetDefault(slog.New(logutils.DiscardHandler{}))


### PR DESCRIPTION
Avoids parsing flags of the go test command more than once to prevent the following race:

```
 ==================
WARNING: DATA RACE
Write at 0x00c0006c401f by goroutine 57:
  flag.(*boolValue).Set()
      /go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.11.linux-amd64/src/flag/flag.go:138 +0x26b
  flag.(*FlagSet).parseOne()
      /go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.11.linux-amd64/src/flag/flag.go:1124 +0x781
  flag.(*FlagSet).Parse()
      /go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.11.linux-amd64/src/flag/flag.go:1157 +0xa4
  flag.Parse()
      /go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.11.linux-amd64/src/flag/flag.go:1188 +0x8e
  github.com/gravitational/teleport/lib/utils.NewLoggerForTests.InitLoggerForTests.func1()
      /code/teleport/lib/utils/cli.go:164 +0x2b
  sync.(*Once).doSlow()
      /go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.11.linux-amd64/src/sync/once.go:74 +0xf0
  sync.(*Once).Do()
      /go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.11.linux-amd64/src/sync/once.go:65 +0x44
  github.com/gravitational/teleport/lib/utils.InitLoggerForTests()
      /code/teleport/lib/utils/cli.go:162 +0x2b
  github.com/gravitational/teleport/lib/utils.NewLoggerForTests()
      /code/teleport/lib/utils/cli.go:185 +0x18
  github.com/gravitational/teleport/lib/kube/proxy.TestGetKubeCreds()
      /code/teleport/lib/kube/proxy/auth_test.go:143 +0x497
  testing.tRunner()
      /go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.11.linux-amd64/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.11.linux-amd64/src/testing/testing.go:1742 +0x44
Previous read at 0x00c0006c401f by goroutine 1156:
  testing.shouldFailFast()
      /go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.11.linux-amd64/src/testing/testing.go:2408 +0x12b
  testing.(*T).Run()
      /go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.11.linux-amd64/src/testing/testing.go:1710 +0xfd
  github.com/gravitational/teleport/lib/kube/proxy.Test_DynamicKubeCreds()
      /code/teleport/lib/kube/proxy/kube_creds_test.go:296 +0x26b4
  testing.tRunner()
      /go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.11.linux-amd64/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.11.linux-amd64/src/testing/testing.go:1742 +0x44
Goroutine 57 (running) created at:
  testing.(*T).Run()
      /go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.11.linux-amd64/src/testing/testing.go:1742 +0x825
  testing.runTests.func1()
      /go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.11.linux-amd64/src/testing/testing.go:2161 +0x85
  testing.tRunner()
      /go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.11.linux-amd64/src/testing/testing.go:1689 +0x21e
  testing.runTests()
      /go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.11.linux-amd64/src/testing/testing.go:2159 +0x8be
  testing.(*M).Run()
      /go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.11.linux-amd64/src/testing/testing.go:2027 +0xf17
  github.com/gravitational/teleport/lib/kube/proxy.TestMain()
      /code/teleport/lib/kube/proxy/forwarder_test.go:100 +0x30
  main.main()
      _testmain.go:129 +0x2d4
Goroutine 1156 (finished) created at:
  testing.(*T).Run()
      /go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.11.linux-amd64/src/testing/testing.go:1742 +0x825
  testing.runTests.func1()
      /go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.11.linux-amd64/src/testing/testing.go:2161 +0x85
  testing.tRunner()
      /go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.11.linux-amd64/src/testing/testing.go:1689 +0x21e
  testing.runTests()
      /go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.11.linux-amd64/src/testing/testing.go:2159 +0x8be
  testing.(*M).Run()
      /go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.11.linux-amd64/src/testing/testing.go:2027 +0xf17
  github.com/gravitational/teleport/lib/kube/proxy.TestMain()
      /code/teleport/lib/kube/proxy/forwarder_test.go:100 +0x30
  main.main()
      _testmain.go:129 +0x2d4
==================
```