### PR TITLE
[teleport-update] Adjustments for SELinux

### DIFF
--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -294,7 +294,7 @@ func (s SystemdService) Disable(ctx context.Context, now bool) error {
 	return nil
 }
 
-// IsEnabled returns true if the service is enabled, or if it's disabled but still active.
+// IsEnabled returns true if the service is enabled.
 func (s SystemdService) IsEnabled(ctx context.Context) (bool, error) {
 	if err := s.checkSystem(ctx); err != nil {
 		return false, trace.Wrap(err)
@@ -306,7 +306,15 @@ func (s SystemdService) IsEnabled(ctx context.Context) (bool, error) {
 	case code == 0:
 		return true, nil
 	}
-	code = s.systemctl(ctx, slog.LevelDebug, "is-active", "--quiet", s.ServiceName)
+	return false, nil
+}
+
+// IsActive returns true if the service is active.
+func (s SystemdService) IsActive(ctx context.Context) (bool, error) {
+	if err := s.checkSystem(ctx); err != nil {
+		return false, trace.Wrap(err)
+	}
+	code := s.systemctl(ctx, slog.LevelDebug, "is-active", "--quiet", s.ServiceName)
 	switch {
 	case code < 0:
 		return false, trace.Errorf("unable to determine if systemd service %s is active", s.ServiceName)

--- a/lib/autoupdate/agent/setup.go
+++ b/lib/autoupdate/agent/setup.go
@@ -305,15 +305,15 @@ func (ns *Namespace) writeConfigFiles(ctx context.Context) error {
 		UpdaterCommand:    ns.updaterBinFile + args + " update",
 		UpdaterConfigFile: ns.updaterConfigFile,
 	}
-	err := writeTemplate(ns.updaterServiceFile, updateServiceTemplate, params)
+	err := writeSystemTemplate(ns.updaterServiceFile, updateServiceTemplate, params)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	err = writeTemplate(ns.updaterTimerFile, updateTimerTemplate, params)
+	err = writeSystemTemplate(ns.updaterTimerFile, updateTimerTemplate, params)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	err = writeTemplate(ns.dropInFile, teleportDropInTemplate, params)
+	err = writeSystemTemplate(ns.dropInFile, teleportDropInTemplate, params)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -327,7 +327,7 @@ func (ns *Namespace) writeConfigFiles(ctx context.Context) error {
 		return nil
 	}
 	ns.log.InfoContext(ctx, "Disabling needrestart.", unitKey, teleportService)
-	err = writeTemplate(ns.needrestartConfFile, needrestartConfTemplate, params)
+	err = writeSystemTemplate(ns.needrestartConfFile, needrestartConfTemplate, params)
 	if err != nil {
 		ns.log.ErrorContext(ctx, "Unable to disable needrestart.", errorKey, err)
 		return nil
@@ -335,7 +335,9 @@ func (ns *Namespace) writeConfigFiles(ctx context.Context) error {
 	return nil
 }
 
-func writeTemplate(path, t string, values any) error {
+// writeSystemTemplate atomically writes a template to a system file, creating any needed directories.
+// Temporarily files are stored in the target path to ensure the file has needed SELinux contexts.
+func writeSystemTemplate(path, t string, values any) error {
 	dir, file := filepath.Split(path)
 	if err := os.MkdirAll(dir, systemDirMode); err != nil {
 		return trace.Wrap(err)
@@ -343,6 +345,7 @@ func writeTemplate(path, t string, values any) error {
 	opts := []renameio.Option{
 		renameio.WithPermissions(configFileMode),
 		renameio.WithExistingPermissions(),
+		renameio.WithTempDir(dir),
 	}
 	f, err := renameio.NewPendingFile(path, opts...)
 	if err != nil {

--- a/lib/autoupdate/agent/setup.go
+++ b/lib/autoupdate/agent/setup.go
@@ -233,7 +233,7 @@ func (ns *Namespace) Setup(ctx context.Context) error {
 		}
 		// If the old teleport-upgrade script is detected, disable it to ensure they do not interfere.
 		// Note that the schedule is also set to nop by the Teleport agent -- this just prevents restarts.
-		enabled, err := oldTimer.IsEnabled(ctx)
+		enabled, err := isActiveOrEnabled(ctx, oldTimer)
 		if err != nil {
 			return trace.Wrap(err, "failed to determine if deprecated teleport-upgrade systemd timer is enabled")
 		}

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/not_started_or_enabled.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/not_started_or_enabled.golden
@@ -1,0 +1,9 @@
+version: v1
+kind: update_config
+spec:
+    proxy: localhost
+    enabled: false
+    pinned: false
+status:
+    active:
+        version: 16.3.0

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_enabled_now,_not_started_or_enabled.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_enabled_now,_not_started_or_enabled.golden
@@ -3,7 +3,7 @@ kind: update_config
 spec:
     proxy: localhost
     group: group
-    url_template: https://example.com
+    base_url: https://example.com
     enabled: true
     pinned: false
 status:

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_enabled_now,_not_started_or_enabled.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_enabled_now,_not_started_or_enabled.golden
@@ -1,0 +1,13 @@
+version: v1
+kind: update_config
+spec:
+    proxy: localhost
+    group: group
+    url_template: https://example.com
+    enabled: true
+    pinned: false
+status:
+    active:
+        version: 16.3.0
+    backup:
+        version: old-version

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -793,19 +793,22 @@ func (u *Updater) notices(ctx context.Context) error {
 		return trace.Wrap(err, "failed to query Teleport systemd active status")
 	}
 	if !enabled && active {
+		//nolint:sloglint // sum of constants
 		u.Log.WarnContext(ctx, "Teleport is installed and started, but not configured to start on boot.\n"+
 			"After configuring teleport.yaml, you can enable it with:\n"+
-			"\tsystemctl enable teleport") //nolint:sloglint // sum of constants
+			"\tsystemctl enable teleport")
 	}
 	if !active && enabled {
+		//nolint:sloglint // sum of constants
 		u.Log.WarnContext(ctx, "Teleport is installed and enabled at boot, but not running.\n"+
 			"After configuring teleport.yaml, you can start it with:\n"+
-			"\tsystemctl start teleport") //nolint:sloglint // sum of constants
+			"\tsystemctl start teleport")
 	}
 	if !active && !enabled {
+		//nolint:sloglint // sum of constants
 		u.Log.WarnContext(ctx, "Teleport is installed, but not running or enabled at boot.\n"+
 			"After configuring teleport.yaml, you can enable and start it with:\n"+
-			"\tsystemctl enable teleport --now") //nolint:sloglint // sum of constants
+			"\tsystemctl enable teleport --now")
 	}
 	return nil
 }

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -773,13 +773,9 @@ func (u *Updater) update(ctx context.Context, cfg *UpdateConfig, target Revision
 		u.Log.InfoContext(ctx, "Backup version set.", backupKey, r)
 	}
 
-	if err := u.cleanup(ctx, []Revision{
+	return trace.Wrap(u.cleanup(ctx, []Revision{
 		target, active, backup,
-	}); err != nil {
-		return trace.Wrap(err)
-	}
-
-	return trace.Wrap(u.notices(ctx))
+	}))
 }
 
 // notices displays final notices after install or update.
@@ -794,21 +790,18 @@ func (u *Updater) notices(ctx context.Context) error {
 	}
 	if !enabled && active {
 		//nolint:sloglint // sum of constants
-		u.Log.WarnContext(ctx, "Teleport is installed and started, but not configured to start on boot.\n"+
-			"After configuring teleport.yaml, you can enable it with:\n"+
-			"\tsystemctl enable teleport")
+		u.Log.WarnContext(ctx, "Teleport is installed and started, but not configured to start on boot. "+
+			"After configuring teleport.yaml, you can enable it with: systemctl enable teleport")
 	}
 	if !active && enabled {
 		//nolint:sloglint // sum of constants
-		u.Log.WarnContext(ctx, "Teleport is installed and enabled at boot, but not running.\n"+
-			"After configuring teleport.yaml, you can start it with:\n"+
-			"\tsystemctl start teleport")
+		u.Log.WarnContext(ctx, "Teleport is installed and enabled at boot, but not running. "+
+			"After configuring teleport.yaml, you can start it with: systemctl start teleport")
 	}
 	if !active && !enabled {
 		//nolint:sloglint // sum of constants
-		u.Log.WarnContext(ctx, "Teleport is installed, but not running or enabled at boot.\n"+
-			"After configuring teleport.yaml, you can enable and start it with:\n"+
-			"\tsystemctl enable teleport --now")
+		u.Log.WarnContext(ctx, "Teleport is installed, but not running or enabled at boot. "+
+			"After configuring teleport.yaml, you can enable and start it with: systemctl enable teleport --now")
 	}
 	return nil
 }

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -253,8 +253,6 @@ type Process interface {
 	IsEnabled(ctx context.Context) (bool, error)
 }
 
-// TODO(sclevine): add support for need_restart and selinux config
-
 // OverrideConfig contains overrides for individual update operations.
 // If validated, these overrides may be persisted to disk.
 type OverrideConfig struct {

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -789,19 +789,16 @@ func (u *Updater) notices(ctx context.Context) error {
 		return trace.Wrap(err, "failed to query Teleport systemd active status")
 	}
 	if !enabled && active {
-		//nolint:sloglint // sum of constants
-		u.Log.WarnContext(ctx, "Teleport is installed and started, but not configured to start on boot. "+
-			"After configuring teleport.yaml, you can enable it with: systemctl enable teleport")
+		u.Log.WarnContext(ctx, "Teleport is installed and started, but not configured to start on boot.")
+		u.Log.WarnContext(ctx, "After configuring teleport.yaml, you can enable it with: systemctl enable teleport")
 	}
 	if !active && enabled {
-		//nolint:sloglint // sum of constants
-		u.Log.WarnContext(ctx, "Teleport is installed and enabled at boot, but not running. "+
-			"After configuring teleport.yaml, you can start it with: systemctl start teleport")
+		u.Log.WarnContext(ctx, "Teleport is installed and enabled at boot, but not running.")
+		u.Log.WarnContext(ctx, "After configuring teleport.yaml, you can start it with: systemctl start teleport")
 	}
 	if !active && !enabled {
-		//nolint:sloglint // sum of constants
-		u.Log.WarnContext(ctx, "Teleport is installed, but not running or enabled at boot. "+
-			"After configuring teleport.yaml, you can enable and start it with: systemctl enable teleport --now")
+		u.Log.WarnContext(ctx, "Teleport is installed, but not running or enabled at boot.")
+		u.Log.WarnContext(ctx, "After configuring teleport.yaml, you can enable and start it with: systemctl enable teleport --now")
 	}
 	return nil
 }

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -795,17 +795,17 @@ func (u *Updater) notices(ctx context.Context) error {
 	if !enabled && active {
 		u.Log.WarnContext(ctx, "Teleport is installed and started, but not configured to start on boot.\n"+
 			"After configuring teleport.yaml, you can enable it with:\n"+
-			"\tsystemctl enable teleport")
+			"\tsystemctl enable teleport") //nolint:sloglint // sum of constants
 	}
 	if !active && enabled {
 		u.Log.WarnContext(ctx, "Teleport is installed and enabled at boot, but not running.\n"+
 			"After configuring teleport.yaml, you can start it with:\n"+
-			"\tsystemctl start teleport")
+			"\tsystemctl start teleport") //nolint:sloglint // sum of constants
 	}
 	if !active && !enabled {
 		u.Log.WarnContext(ctx, "Teleport is installed, but not running or enabled at boot.\n"+
 			"After configuring teleport.yaml, you can enable and start it with:\n"+
-			"\tsystemctl enable teleport --now")
+			"\tsystemctl enable teleport --now") //nolint:sloglint // sum of constants
 	}
 	return nil
 }

--- a/lib/autoupdate/agent/updater_test.go
+++ b/lib/autoupdate/agent/updater_test.go
@@ -295,9 +295,9 @@ func TestUpdater_Update(t *testing.T) {
 				Version: updateConfigVersion,
 				Kind:    updateConfigKind,
 				Spec: UpdateSpec{
-					Group:       "group",
-					URLTemplate: "https://example.com",
-					Enabled:     true,
+					Group:   "group",
+					BaseURL: "https://example.com",
+					Enabled: true,
 				},
 				Status: UpdateStatus{
 					Active: NewRevision("old-version", 0),
@@ -309,7 +309,7 @@ func TestUpdater_Update(t *testing.T) {
 
 			removedRevisions:  []Revision{NewRevision("unknown-version", 0)},
 			installedRevision: NewRevision("16.3.0", 0),
-			installedTemplate: "https://example.com",
+			installedBaseURL:  "https://example.com",
 			linkedRevision:    NewRevision("16.3.0", 0),
 			requestGroup:      "group",
 			reloadCalls:       1,
@@ -1394,7 +1394,7 @@ func TestUpdater_Install(t *testing.T) {
 			notPresent: true,
 
 			installedRevision: NewRevision("16.3.0", 0),
-			installedTemplate: cdnURITemplate,
+			installedBaseURL:  autoupdate.DefaultBaseURL,
 			linkedRevision:    NewRevision("16.3.0", 0),
 			reloadCalls:       0,
 			revertCalls:       1,
@@ -1407,7 +1407,7 @@ func TestUpdater_Install(t *testing.T) {
 			notActive:  true,
 
 			installedRevision: NewRevision("16.3.0", 0),
-			installedTemplate: cdnURITemplate,
+			installedBaseURL:  autoupdate.DefaultBaseURL,
 			linkedRevision:    NewRevision("16.3.0", 0),
 			reloadCalls:       1,
 			setupCalls:        1,

--- a/lib/autoupdate/agent/updater_test.go
+++ b/lib/autoupdate/agent/updater_test.go
@@ -228,6 +228,8 @@ func TestUpdater_Update(t *testing.T) {
 		installErr error
 		setupErr   error
 		reloadErr  error
+		notActive  bool
+		notEnabled bool
 
 		removedRevisions  []Revision
 		installedRevision Revision
@@ -282,6 +284,32 @@ func TestUpdater_Update(t *testing.T) {
 			removedRevisions:  []Revision{NewRevision("unknown-version", 0)},
 			installedRevision: NewRevision("16.3.0", 0),
 			installedBaseURL:  "https://example.com",
+			linkedRevision:    NewRevision("16.3.0", 0),
+			requestGroup:      "group",
+			reloadCalls:       1,
+			setupCalls:        1,
+		},
+		{
+			name: "updates enabled now, not started or enabled",
+			cfg: &UpdateConfig{
+				Version: updateConfigVersion,
+				Kind:    updateConfigKind,
+				Spec: UpdateSpec{
+					Group:       "group",
+					URLTemplate: "https://example.com",
+					Enabled:     true,
+				},
+				Status: UpdateStatus{
+					Active: NewRevision("old-version", 0),
+				},
+			},
+			now:        true,
+			notEnabled: true,
+			notActive:  true,
+
+			removedRevisions:  []Revision{NewRevision("unknown-version", 0)},
+			installedRevision: NewRevision("16.3.0", 0),
+			installedTemplate: "https://example.com",
 			linkedRevision:    NewRevision("16.3.0", 0),
 			requestGroup:      "group",
 			reloadCalls:       1,
@@ -642,6 +670,15 @@ func TestUpdater_Update(t *testing.T) {
 					reloadCalls++
 					return tt.reloadErr
 				},
+				FuncIsPresent: func(ctx context.Context) (bool, error) {
+					return true, nil
+				},
+				FuncIsEnabled: func(ctx context.Context) (bool, error) {
+					return !tt.notEnabled, nil
+				},
+				FuncIsActive: func(ctx context.Context) (bool, error) {
+					return !tt.notActive, nil
+				},
 			}
 			updater.Setup = func(_ context.Context) error {
 				setupCalls++
@@ -697,6 +734,7 @@ func TestUpdater_LinkPackage(t *testing.T) {
 		cfg              *UpdateConfig // nil -> file not present
 		tryLinkSystemErr error
 		syncErr          error
+		notPresent       bool
 
 		syncCalls          int
 		tryLinkSystemCalls int
@@ -794,6 +832,20 @@ func TestUpdater_LinkPackage(t *testing.T) {
 			syncCalls:          1,
 			syncErr:            ErrNotSupported,
 		},
+		{
+			name: "SELinux blocks service from being read",
+			cfg: &UpdateConfig{
+				Version: updateConfigVersion,
+				Kind:    updateConfigKind,
+				Spec: UpdateSpec{
+					Enabled: false,
+				},
+			},
+			tryLinkSystemCalls: 1,
+			syncCalls:          1,
+			notPresent:         true,
+			errMatch:           "cannot find systemd service",
+		},
 	}
 
 	for _, tt := range tests {
@@ -829,6 +881,9 @@ func TestUpdater_LinkPackage(t *testing.T) {
 				FuncSync: func(_ context.Context) error {
 					syncCalls++
 					return tt.syncErr
+				},
+				FuncIsPresent: func(ctx context.Context) (bool, error) {
+					return !tt.notPresent, nil
 				},
 			}
 
@@ -1055,6 +1110,9 @@ func TestUpdater_Remove(t *testing.T) {
 				FuncIsEnabled: func(_ context.Context) (bool, error) {
 					return tt.processEnabled, tt.isEnabledErr
 				},
+				FuncIsActive: func(_ context.Context) (bool, error) {
+					return false, nil
+				},
 			}
 			updater.Teardown = func(_ context.Context) error {
 				teardownCalls++
@@ -1090,6 +1148,9 @@ func TestUpdater_Install(t *testing.T) {
 		installErr error
 		setupErr   error
 		reloadErr  error
+		notPresent bool
+		notEnabled bool
+		notActive  bool
 
 		removedRevision   Revision
 		installedRevision Revision
@@ -1328,6 +1389,29 @@ func TestUpdater_Install(t *testing.T) {
 			reloadCalls:       1,
 			setupCalls:        1,
 		},
+		{
+			name:       "not present after install",
+			notPresent: true,
+
+			installedRevision: NewRevision("16.3.0", 0),
+			installedTemplate: cdnURITemplate,
+			linkedRevision:    NewRevision("16.3.0", 0),
+			reloadCalls:       0,
+			revertCalls:       1,
+			setupCalls:        1,
+			errMatch:          "cannot find systemd service",
+		},
+		{
+			name:       "not started or enabled",
+			notEnabled: true,
+			notActive:  true,
+
+			installedRevision: NewRevision("16.3.0", 0),
+			installedTemplate: cdnURITemplate,
+			linkedRevision:    NewRevision("16.3.0", 0),
+			reloadCalls:       1,
+			setupCalls:        1,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1407,6 +1491,15 @@ func TestUpdater_Install(t *testing.T) {
 				FuncReload: func(_ context.Context) error {
 					reloadCalls++
 					return tt.reloadErr
+				},
+				FuncIsPresent: func(ctx context.Context) (bool, error) {
+					return !tt.notPresent, nil
+				},
+				FuncIsEnabled: func(ctx context.Context) (bool, error) {
+					return !tt.notEnabled, nil
+				},
+				FuncIsActive: func(ctx context.Context) (bool, error) {
+					return !tt.notActive, nil
 				},
 			}
 			updater.Setup = func(_ context.Context) error {
@@ -1513,6 +1606,8 @@ type testProcess struct {
 	FuncReload    func(ctx context.Context) error
 	FuncSync      func(ctx context.Context) error
 	FuncIsEnabled func(ctx context.Context) (bool, error)
+	FuncIsActive  func(ctx context.Context) (bool, error)
+	FuncIsPresent func(ctx context.Context) (bool, error)
 }
 
 func (tp *testProcess) Reload(ctx context.Context) error {
@@ -1525,4 +1620,12 @@ func (tp *testProcess) Sync(ctx context.Context) error {
 
 func (tp *testProcess) IsEnabled(ctx context.Context) (bool, error) {
 	return tp.FuncIsEnabled(ctx)
+}
+
+func (tp *testProcess) IsActive(ctx context.Context) (bool, error) {
+	return tp.FuncIsActive(ctx)
+}
+
+func (tp *testProcess) IsPresent(ctx context.Context) (bool, error) {
+	return tp.FuncIsPresent(ctx)
 }


### PR DESCRIPTION
This PR adjusts `teleport-update` to avoid issues with default SELinux configuration.

These changes are based on research and testing by @vapopov.

When service files are copied atomically using renameio, the initial temporary location adds SELinux contexts that make the file unreadable by systemctl:
```
# ls -lahZ /lib/systemd/system/teleport.service
-rw-r--r--. 1 root root unconfined_u:object_r:user_tmp_t:s0 436 Jan 22 19:34 /lib/systemd/system/teleport.service
```

This PR adjusts renameio to use the same target directory when this is relevant:
```
# ls -lahZ /lib/systemd/system/teleport.service
-rw-r--r--. 1 root root unconfined_u:object_r:systemd_unit_file_t:s0 436 Jan 23 15:28 /lib/systemd/system/teleport.service
```

These temporarily files are created in the format `/etc/systemd/system/.teleport.service1234`. This does not appear to interfere with systemd or systemctl.

This PR also adds various checks to make sure that the systemd service file is readable during initial install and update.

---

The `teleport-update` binary will be used to enable, disable, and trigger automatic Teleport agent updates. The new auto-updates system manages a local installation of the cluster-specified version of Teleport stored in `/opt/teleport`.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/10289

