### PR TITLE
[v16] Add template for client tools auto-update download url

### DIFF
--- a/integration/autoupdate/tools/main_test.go
+++ b/integration/autoupdate/tools/main_test.go
@@ -83,7 +83,7 @@ func TestMain(m *testing.M) {
 	}))
 	baseURL = server.URL
 	for _, version := range testVersions {
-		if err := buildAndArchiveApps(ctx, tmp, toolsDir, version, server.URL); err != nil {
+		if err := buildAndArchiveApps(ctx, tmp, version, server.URL); err != nil {
 			log.Fatalf("failed to build testing app binary archive: %v", err)
 		}
 	}
@@ -131,7 +131,7 @@ func serve256File(w http.ResponseWriter, _ *http.Request, filePath string) {
 }
 
 // buildAndArchiveApps compiles the updater integration and pack it depends on platform is used.
-func buildAndArchiveApps(ctx context.Context, path string, toolsDir string, version string, baseURL string) error {
+func buildAndArchiveApps(ctx context.Context, path string, version string, baseURL string) error {
 	versionPath := filepath.Join(path, version)
 	for _, app := range []string{"tsh", "tctl"} {
 		output := filepath.Join(versionPath, app)
@@ -141,7 +141,7 @@ func buildAndArchiveApps(ctx context.Context, path string, toolsDir string, vers
 		case constants.DarwinOS:
 			output = filepath.Join(versionPath, app+".app", "Contents", "MacOS", app)
 		}
-		if err := buildBinary(output, toolsDir, version, baseURL, app); err != nil {
+		if err := buildBinary(output, version, baseURL, app); err != nil {
 			return trace.Wrap(err)
 		}
 	}
@@ -159,7 +159,7 @@ func buildAndArchiveApps(ctx context.Context, path string, toolsDir string, vers
 }
 
 // buildBinary executes command to build client tool binary with updater logic for testing.
-func buildBinary(output string, toolsDir string, version string, baseURL string, app string) error {
+func buildBinary(output string, version string, baseURL string, app string) error {
 	cmd := exec.Command(
 		"go", "build", "-o", output,
 		"-ldflags", strings.Join([]string{

--- a/lib/autoupdate/package_url.go
+++ b/lib/autoupdate/package_url.go
@@ -1,0 +1,82 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package autoupdate
+
+import (
+	"bytes"
+	"runtime"
+	"text/template"
+
+	"github.com/gravitational/trace"
+)
+
+// InstallFlags sets flags for the Teleport installation.
+type InstallFlags int
+
+const (
+	// FlagEnterprise installs enterprise Teleport.
+	FlagEnterprise InstallFlags = 1 << iota
+	// FlagFIPS installs FIPS Teleport
+	FlagFIPS
+)
+
+const (
+	// DefaultBaseURL is CDN URL for downloading official Teleport packages.
+	DefaultBaseURL = "https://cdn.teleport.dev"
+	// DefaultPackage is the name of Teleport package.
+	DefaultPackage = "teleport"
+	// DefaultCDNURITemplate is the default template for the Teleport CDN download URL.
+	DefaultCDNURITemplate = `{{ .BaseURL }}/
+	{{- if eq .OS "darwin" }}
+	{{- .Package }}{{ if and .Enterprise (eq .Package "teleport") }}-ent{{ end }}-{{ .Version }}.pkg
+	{{- else if eq .OS "windows" }}
+	{{- .Package }}-v{{ .Version }}-{{ .OS }}-amd64-bin.zip
+	{{- else }}
+	{{- .Package }}{{ if .Enterprise }}-ent{{ end }}-v{{ .Version }}-{{ .OS }}-{{ .Arch }}{{ if .FIPS }}-fips{{ end }}-bin.tar.gz
+	{{- end }}`
+	// BaseURLEnvVar allows to override base URL for the Teleport package URL via env var.
+	BaseURLEnvVar = "TELEPORT_CDN_BASE_URL"
+)
+
+// MakeURL constructs the package download URL from template, base URL and revision.
+func MakeURL(uriTmpl string, baseURL string, pkg string, version string, flags InstallFlags) (string, error) {
+	tmpl, err := template.New("uri").Parse(uriTmpl)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	var uriBuf bytes.Buffer
+	params := struct {
+		BaseURL, OS, Version, Arch, Package string
+		FIPS, Enterprise                    bool
+	}{
+		BaseURL:    baseURL,
+		OS:         runtime.GOOS,
+		Version:    version,
+		Arch:       runtime.GOARCH,
+		FIPS:       flags&FlagFIPS != 0,
+		Enterprise: flags&(FlagEnterprise|FlagFIPS) != 0,
+		Package:    pkg,
+	}
+	err = tmpl.Execute(&uriBuf, params)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	return uriBuf.String(), nil
+}

--- a/lib/autoupdate/tools/utils.go
+++ b/lib/autoupdate/tools/utils.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/autoupdate"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -125,41 +126,36 @@ type packageURL struct {
 	Optional bool
 }
 
-// teleportPackageURLs returns the URL for the Teleport archive to download. The format is:
-// https://cdn.teleport.dev/teleport-{, ent-}v15.3.0-{linux, darwin, windows}-{amd64,arm64,arm,386}-{fips-}bin.tar.gz
-func teleportPackageURLs(baseURL, toolsVersion string) ([]packageURL, error) {
-	switch runtime.GOOS {
-	case "darwin":
-		tsh := baseURL + "/tsh-" + toolsVersion + ".pkg"
-		teleport := baseURL + "/teleport-" + toolsVersion + ".pkg"
-		return []packageURL{
-			{Archive: teleport, Hash: teleport + ".sha256"},
-			{Archive: tsh, Hash: tsh + ".sha256", Optional: true},
-		}, nil
-	case "windows":
-		archive := baseURL + "/teleport-v" + toolsVersion + "-windows-amd64-bin.zip"
-		return []packageURL{
-			{Archive: archive, Hash: archive + ".sha256"},
-		}, nil
-	case "linux":
-		m := modules.GetModules()
-		var b strings.Builder
-		b.WriteString(baseURL + "/teleport-")
-		if m.IsEnterpriseBuild() || m.IsBoringBinary() {
-			b.WriteString("ent-")
-		}
-		b.WriteString("v" + toolsVersion + "-" + runtime.GOOS + "-" + runtime.GOARCH + "-")
-		if m.IsBoringBinary() {
-			b.WriteString("fips-")
-		}
-		b.WriteString("bin.tar.gz")
-		archive := b.String()
-		return []packageURL{
-			{Archive: archive, Hash: archive + ".sha256"},
-		}, nil
-	default:
-		return nil, trace.BadParameter("unsupported runtime: %v", runtime.GOOS)
+// teleportPackageURLs returns the URL for the Teleport archive to download.
+func teleportPackageURLs(uriTmpl string, baseURL, version string) ([]packageURL, error) {
+	var flags autoupdate.InstallFlags
+	m := modules.GetModules()
+	if m.IsBoringBinary() {
+		flags |= autoupdate.FlagFIPS
 	}
+	if m.IsEnterpriseBuild() || m.IsBoringBinary() {
+		flags |= autoupdate.FlagEnterprise
+	}
+
+	teleportURL, err := autoupdate.MakeURL(uriTmpl, baseURL, autoupdate.DefaultPackage, version, flags)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if runtime.GOOS == constants.DarwinOS {
+		tshURL, err := autoupdate.MakeURL(uriTmpl, baseURL, "tsh", version, flags)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		return []packageURL{
+			{Archive: teleportURL, Hash: teleportURL + ".sha256"},
+			{Archive: tshURL, Hash: tshURL + ".sha256", Optional: true},
+		}, nil
+	}
+
+	return []packageURL{
+		{Archive: teleportURL, Hash: teleportURL + ".sha256"},
+	}, nil
 }
 
 // toolName returns the path to {tsh, tctl} for the executable that started


### PR DESCRIPTION
Backport #51210 to branch/v16

changelog: Added support for customizing the base URL for downloading Teleport packages used in client tools managed updates