### PR TITLE
Add Role Diff Visual to Role editor

### DIFF
--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditorAdapter.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditorAdapter.tsx
@@ -16,13 +16,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useTheme } from 'styled-components';
 
 import { Danger } from 'design/Alert';
 import Flex from 'design/Flex';
 import { Indicator } from 'design/Indicator';
 import { useAsync } from 'shared/hooks/useAsync';
+import { debounce } from 'shared/utils/highbar';
 
 import { State as ResourcesState } from 'teleport/components/useResources';
 import { Role, RoleWithYaml } from 'teleport/services/resources';
@@ -68,6 +69,11 @@ export function RoleEditorAdapter({
     convertToRole(originalContent);
   }, [originalContent]);
 
+  const onRoleUpdate = useCallback(
+    debounce(roleDiffProps.updateRoleDiff, 500),
+    []
+  );
+
   return (
     <Flex flex="1">
       <Flex
@@ -90,26 +96,29 @@ export function RoleEditorAdapter({
         {convertAttempt.status === 'error' && (
           <Danger>{convertAttempt.statusText}</Danger>
         )}
+        {roleDiffProps?.errorMessage && (
+          <Danger>{roleDiffProps.errorMessage}</Danger>
+        )}
         {convertAttempt.status === 'success' && (
           <RoleEditor
             originalRole={convertAttempt.data}
             onCancel={onCancel}
             onSave={onSave}
+            onRoleUpdate={onRoleUpdate}
           />
         )}
       </Flex>
-      <Flex flex="1" alignItems="center" justifyContent="center" m={3}>
-        {/* TODO (avatus) this component will not be rendered until the Access Diff feature is implemented */}
-        {roleDiffProps ? (
-          <roleDiffProps.RoleDiffComponent />
-        ) : (
+      {roleDiffProps ? (
+        roleDiffProps.roleDiffElement
+      ) : (
+        <Flex flex="1" alignItems="center" justifyContent="center" m={3}>
           <PolicyPlaceholder
             currentFlow={
               resources.status === 'creating' ? 'creating' : 'updating'
             }
           />
-        )}
-      </Flex>
+        </Flex>
+      )}
     </Flex>
   );
 }

--- a/web/packages/teleport/src/Roles/RoleEditor/Shared.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/Shared.tsx
@@ -25,13 +25,17 @@ import useTeleport from 'teleport/useTeleport';
 
 export const EditorSaveCancelButton = ({
   onSave,
+  onPreview,
   onCancel,
-  disabled,
+  saveDisabled,
+  previewDisabled = true,
   isEditing,
 }: {
   onSave?(): void;
+  onPreview?(): void;
   onCancel?(): void;
-  disabled: boolean;
+  saveDisabled: boolean;
+  previewDisabled?: boolean;
   isEditing?: boolean;
 }) => {
   const ctx = useTeleport();
@@ -45,6 +49,36 @@ export const EditorSaveCancelButton = ({
     hoverTooltipContent = 'You do not have access to create roles';
   }
 
+  const saveButton = (
+    <Box width="50%">
+      <HoverTooltip tipContent={hoverTooltipContent}>
+        <ButtonPrimary
+          width="100%"
+          size="large"
+          onClick={onSave}
+          disabled={
+            saveDisabled ||
+            (isEditing && !roleAccess.edit) ||
+            (!isEditing && !roleAccess.create)
+          }
+        >
+          {isEditing ? 'Save Changes' : 'Create Role'}
+        </ButtonPrimary>
+      </HoverTooltip>
+    </Box>
+  );
+  const cancelButton = (
+    <ButtonSecondary width="50%" onClick={onCancel}>
+      Cancel
+    </ButtonSecondary>
+  );
+
+  const previewButton = (
+    <ButtonPrimary width="50%" onClick={onPreview} disabled={previewDisabled}>
+      Preview
+    </ButtonPrimary>
+  );
+
   return (
     <Flex
       gap={2}
@@ -52,25 +86,8 @@ export const EditorSaveCancelButton = ({
       borderTop={1}
       borderColor={theme.colors.interactive.tonal.neutral[0]}
     >
-      <Box width="50%">
-        <HoverTooltip tipContent={hoverTooltipContent}>
-          <ButtonPrimary
-            width="100%"
-            size="large"
-            onClick={onSave}
-            disabled={
-              disabled ||
-              (isEditing && !roleAccess.edit) ||
-              (!isEditing && !roleAccess.create)
-            }
-          >
-            {isEditing ? 'Save Changes' : 'Create Role'}
-          </ButtonPrimary>
-        </HoverTooltip>
-      </Box>
-      <ButtonSecondary width="50%" onClick={onCancel}>
-        Cancel
-      </ButtonSecondary>
+      {saveButton}
+      {onPreview ? previewButton : cancelButton}
     </Flex>
   );
 };

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.tsx
@@ -214,7 +214,7 @@ export const StandardEditor = ({
       <EditorSaveCancelButton
         onSave={() => handleSave()}
         onCancel={onCancel}
-        disabled={
+        saveDisabled={
           isProcessing ||
           standardEditorModel.roleModel.requiresReset ||
           !standardEditorModel.isDirty

--- a/web/packages/teleport/src/Roles/Roles.test.tsx
+++ b/web/packages/teleport/src/Roles/Roles.test.tsx
@@ -271,19 +271,25 @@ test('renders the role diff component', async () => {
       list: true,
     },
   });
-  const RoleDiffComponent = () => <div>i am rendered</div>;
+  const roleDiffElement = <div>i am rendered</div>;
+
   render(
     <MemoryRouter>
       <ContextProvider ctx={ctx}>
         <Roles
           {...defaultState()}
-          roleDiffProps={{ RoleDiffComponent, updateRoleDiff: () => null }}
+          roleDiffProps={{
+            roleDiffElement,
+            updateRoleDiff: () => null,
+            errorMessage: 'there is an error here',
+          }}
         />
       </ContextProvider>
     </MemoryRouter>
   );
   await openEditor();
   expect(screen.getByText('i am rendered')).toBeInTheDocument();
+  expect(screen.getByText('there is an error here')).toBeInTheDocument();
 });
 
 async function openEditor() {

--- a/web/packages/teleport/src/Roles/Roles.tsx
+++ b/web/packages/teleport/src/Roles/Roles.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ComponentType, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { Alert, Box, Button, Flex, H3, Link } from 'design';
@@ -50,8 +50,9 @@ import { State, useRoles } from './useRoles';
 
 // RoleDiffProps are an optional set of props to render the role diff visualizer.
 type RoleDiffProps = {
-  RoleDiffComponent: ComponentType;
-  updateRoleDiff: (role: Role) => Promise<void>;
+  roleDiffElement: React.ReactNode;
+  updateRoleDiff: (role: Role) => void;
+  errorMessage: string;
 };
 
 export type RolesProps = {

--- a/web/packages/teleport/src/services/storageService/storageService.ts
+++ b/web/packages/teleport/src/services/storageService/storageService.ts
@@ -265,6 +265,13 @@ export const storageService = {
     return this.getParsedJSONValue(KeysEnum.ACCESS_GRAPH_SQL_ENABLED, false);
   },
 
+  getAccessGraphRoleTesterEnabled(): boolean {
+    return this.getParsedJSONValue(
+      KeysEnum.ACCESS_GRAPH_ROLE_TESTER_ENABLED,
+      false
+    );
+  },
+
   getExternalAuditStorageCtaDisabled(): boolean {
     return this.getParsedJSONValue(
       KeysEnum.EXTERNAL_AUDIT_STORAGE_CTA_DISABLED,

--- a/web/packages/teleport/src/services/storageService/types.ts
+++ b/web/packages/teleport/src/services/storageService/types.ts
@@ -30,6 +30,8 @@ export const KeysEnum = {
   ACCESS_GRAPH_QUERY: 'grv_teleport_access_graph_query',
   ACCESS_GRAPH_ENABLED: 'grv_teleport_access_graph_enabled',
   ACCESS_GRAPH_SQL_ENABLED: 'grv_teleport_access_graph_sql_enabled',
+  ACCESS_GRAPH_ROLE_TESTER_ENABLED:
+    'grv_teleport_access_graph_role_tester_enabled',
   ACCESS_LIST_PREFERENCES: 'grv_teleport_access_list_preferences',
   EXTERNAL_AUDIT_STORAGE_CTA_DISABLED:
     'grv_teleport_external_audit_storage_disabled',


### PR DESCRIPTION
This will enable a role diff viewer from Teleport Policy if the client has Teleport policy enabled

https://github.com/user-attachments/assets/494b8ca9-7648-4ea1-9b19-b9f6a4db984f


TODO
Add a few more tests, however, most of the work is from the Diff component which we get pulled in from "over the wire" from TAG so, testing won't work too well there. There are already tests added to test the RoleDiffComponent and role editor conditional rendering so this PR is mostly just using existing work.