### PR TITLE
WebAPI: List Rules - add regions filter

### DIFF
--- a/lib/web/integrations.go
+++ b/lib/web/integrations.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -348,6 +349,10 @@ func rulesWithIntegration(dc *discoveryconfig.DiscoveryConfig, matcherType strin
 // integrationDiscoveryRules returns the Discovery Rules that are using a given integration.
 // A Discovery Rule is just like a DiscoveryConfig Matcher, except that it breaks down by region.
 // So, if a Matcher exists for two regions, that will be represented as two Rules.
+// Accepts the following query params:
+// startKey: indicator for pagination, should be the value of the last reponse's `nextItem`, or absent for a the starting page
+// resourceType: which resource type to return, one of ec2, eks, rds
+// regionPrefix: only rules for regions prefixed with this value are returned (eg us, us-east, us-east-1)
 func (h *Handler) integrationDiscoveryRules(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	integrationName := p.ByName("name")
 	if integrationName == "" {
@@ -357,6 +362,7 @@ func (h *Handler) integrationDiscoveryRules(w http.ResponseWriter, r *http.Reque
 	values := r.URL.Query()
 	startKey := values.Get("startKey")
 	resourceType := values.Get("resourceType")
+	regionPrefix := values.Get("regionPrefix")
 
 	clt, err := sctx.GetUserClient(r.Context(), site)
 	if err != nil {
@@ -368,7 +374,7 @@ func (h *Handler) integrationDiscoveryRules(w http.ResponseWriter, r *http.Reque
 		return nil, trace.Wrap(err)
 	}
 
-	rules, err := collectAutoDiscoveryRules(r.Context(), ig.GetName(), startKey, resourceType, clt.DiscoveryConfigClient())
+	rules, err := collectAutoDiscoveryRules(r.Context(), ig.GetName(), startKey, resourceType, regionPrefix, clt.DiscoveryConfigClient())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -377,7 +383,7 @@ func (h *Handler) integrationDiscoveryRules(w http.ResponseWriter, r *http.Reque
 }
 
 // collectAutoDiscoveryRules will iterate over all DiscoveryConfigs's Matchers and collect the Discovery Rules that exist in them for the given integration.
-// It can also be filtered by Matcher Type (eg ec2, rds, eks)
+// It can also be filtered by Matcher Type (eg ec2, rds, eks) and a region prefix (eg, us, us-east, us-east-1)
 // A Discovery Rule is a close match to a DiscoveryConfig's Matcher, except that it will count as many rules as regions exist.
 // Eg if a DiscoveryConfig's Matcher has two regions, then it will output two (almost equal) Rules, one for each Region.
 func collectAutoDiscoveryRules(
@@ -385,6 +391,7 @@ func collectAutoDiscoveryRules(
 	integrationName string,
 	nextPage string,
 	resourceTypeFilter string,
+	regionPrefixFilter string,
 	clt interface {
 		ListDiscoveryConfigs(ctx context.Context, pageSize int, nextToken string) ([]*discoveryconfig.DiscoveryConfig, string, error)
 	},
@@ -399,45 +406,12 @@ func collectAutoDiscoveryRules(
 			return ret, trace.Wrap(err)
 		}
 		for _, dc := range discoveryConfigs {
-			lastSync := &dc.Status.LastSyncTime
-			if lastSync.IsZero() {
-				lastSync = nil
-			}
-
-			for _, matcher := range dc.Spec.AWS {
-				if matcher.Integration != integrationName {
-					continue
-				}
-
-				for _, resourceType := range matcher.Types {
-					if resourceTypeFilter != "" && resourceType != resourceTypeFilter {
-						continue
-					}
-
-					for _, region := range matcher.Regions {
-						uiLables := make([]libui.Label, 0, len(matcher.Tags))
-						for labelKey, labelValues := range matcher.Tags {
-							for _, labelValue := range labelValues {
-								uiLables = append(uiLables, libui.Label{
-									Name:  labelKey,
-									Value: labelValue,
-								})
-							}
-						}
-						ret.Rules = append(ret.Rules, ui.IntegrationDiscoveryRule{
-							ResourceType:    resourceType,
-							Region:          region,
-							LabelMatcher:    uiLables,
-							DiscoveryConfig: dc.GetName(),
-							LastSync:        lastSync,
-						})
-					}
-				}
-			}
+			ret.Rules = append(ret.Rules,
+				collectAutoDiscoveryRulesFromDiscoveryConfig(dc, integrationName, resourceTypeFilter, regionPrefixFilter)...,
+			)
 		}
 
 		ret.NextKey = nextToken
-
 		if nextToken == "" || len(ret.Rules) > maxPerPage {
 			break
 		}
@@ -446,6 +420,52 @@ func collectAutoDiscoveryRules(
 	}
 
 	return ret, nil
+}
+
+func collectAutoDiscoveryRulesFromDiscoveryConfig(dc *discoveryconfig.DiscoveryConfig, integrationName, resourceTypeFilter, regionPrefixFilter string) []ui.IntegrationDiscoveryRule {
+	var ret []ui.IntegrationDiscoveryRule
+
+	lastSync := &dc.Status.LastSyncTime
+	if lastSync.IsZero() {
+		lastSync = nil
+	}
+
+	for _, matcher := range dc.Spec.AWS {
+		if matcher.Integration != integrationName {
+			continue
+		}
+
+		for _, resourceType := range matcher.Types {
+			if resourceTypeFilter != "" && resourceType != resourceTypeFilter {
+				continue
+			}
+
+			for _, region := range matcher.Regions {
+				if regionPrefixFilter != "" && !strings.HasPrefix(region, regionPrefixFilter) {
+					continue
+				}
+
+				uiLables := make([]libui.Label, 0, len(matcher.Tags))
+				for labelKey, labelValues := range matcher.Tags {
+					for _, labelValue := range labelValues {
+						uiLables = append(uiLables, libui.Label{
+							Name:  labelKey,
+							Value: labelValue,
+						})
+					}
+				}
+				ret = append(ret, ui.IntegrationDiscoveryRule{
+					ResourceType:    resourceType,
+					Region:          region,
+					LabelMatcher:    uiLables,
+					DiscoveryConfig: dc.GetName(),
+					LastSync:        lastSync,
+				})
+			}
+		}
+	}
+
+	return ret
 }
 
 // integrationsList returns a page of Integrations

--- a/lib/web/integrations_test.go
+++ b/lib/web/integrations_test.go
@@ -314,7 +314,7 @@ func TestCollectAutoDiscoveryRules(t *testing.T) {
 			discoveryConfigs: make([]*discoveryconfig.DiscoveryConfig, 0),
 		}
 
-		gotRules, err := collectAutoDiscoveryRules(ctx, integrationName, "", "", "", clt)
+		gotRules, err := collectAutoDiscoveryRules(ctx, integrationName, "", "", nil, clt)
 		require.NoError(t, err)
 		expectedRules := ui.IntegrationDiscoveryRules{}
 		require.Equal(t, expectedRules, gotRules)
@@ -386,7 +386,7 @@ func TestCollectAutoDiscoveryRules(t *testing.T) {
 			},
 		}
 
-		got, err := collectAutoDiscoveryRules(ctx, integrationName, "", "", "", clt)
+		got, err := collectAutoDiscoveryRules(ctx, integrationName, "", "", nil, clt)
 		require.NoError(t, err)
 		expectedRules := []ui.IntegrationDiscoveryRule{
 			{
@@ -479,7 +479,7 @@ func TestCollectAutoDiscoveryRules(t *testing.T) {
 			},
 		}
 
-		got, err := collectAutoDiscoveryRules(ctx, integrationName, "", "ec2", "", clt)
+		got, err := collectAutoDiscoveryRules(ctx, integrationName, "", "ec2", nil, clt)
 		require.NoError(t, err)
 		expectedRules := []ui.IntegrationDiscoveryRule{
 			{
@@ -520,7 +520,7 @@ func TestCollectAutoDiscoveryRules(t *testing.T) {
 			},
 		}
 
-		got, err := collectAutoDiscoveryRules(ctx, integrationName, "", "", "us-east", clt)
+		got, err := collectAutoDiscoveryRules(ctx, integrationName, "", "", []string{"us-east-1", "us-east-2"}, clt)
 		require.NoError(t, err)
 		expectedRules := []ui.IntegrationDiscoveryRule{
 			{
@@ -578,7 +578,7 @@ func TestCollectAutoDiscoveryRules(t *testing.T) {
 		nextKey := ""
 		rulesCounter := 0
 		for {
-			got, err := collectAutoDiscoveryRules(ctx, integrationName, nextKey, "", "", clt)
+			got, err := collectAutoDiscoveryRules(ctx, integrationName, nextKey, "", nil, clt)
 			require.NoError(t, err)
 			rulesCounter += len(got.Rules)
 			nextKey = got.NextKey

--- a/lib/web/integrations_test.go
+++ b/lib/web/integrations_test.go
@@ -314,7 +314,7 @@ func TestCollectAutoDiscoveryRules(t *testing.T) {
 			discoveryConfigs: make([]*discoveryconfig.DiscoveryConfig, 0),
 		}
 
-		gotRules, err := collectAutoDiscoveryRules(ctx, integrationName, "", "", clt)
+		gotRules, err := collectAutoDiscoveryRules(ctx, integrationName, "", "", "", clt)
 		require.NoError(t, err)
 		expectedRules := ui.IntegrationDiscoveryRules{}
 		require.Equal(t, expectedRules, gotRules)
@@ -386,7 +386,7 @@ func TestCollectAutoDiscoveryRules(t *testing.T) {
 			},
 		}
 
-		got, err := collectAutoDiscoveryRules(ctx, integrationName, "", "", clt)
+		got, err := collectAutoDiscoveryRules(ctx, integrationName, "", "", "", clt)
 		require.NoError(t, err)
 		expectedRules := []ui.IntegrationDiscoveryRule{
 			{
@@ -438,5 +438,154 @@ func TestCollectAutoDiscoveryRules(t *testing.T) {
 		}
 		require.Empty(t, got.NextKey)
 		require.ElementsMatch(t, expectedRules, got.Rules)
+	})
+
+	t.Run("filters resource type", func(t *testing.T) {
+		syncTime := time.Now()
+		dcForEC2 := &discoveryconfig.DiscoveryConfig{
+			ResourceHeader: header.ResourceHeader{Metadata: header.Metadata{
+				Name: uuid.NewString(),
+			}},
+			Spec: discoveryconfig.Spec{AWS: []types.AWSMatcher{{
+				Integration: integrationName,
+				Types:       []string{"ec2"},
+				Regions:     []string{"us-east-1"},
+				Tags:        types.Labels{"*": []string{"*"}},
+			}}},
+			Status: discoveryconfig.Status{
+				LastSyncTime: syncTime,
+			},
+		}
+		dcForRDS := &discoveryconfig.DiscoveryConfig{
+			ResourceHeader: header.ResourceHeader{Metadata: header.Metadata{
+				Name: uuid.NewString(),
+			}},
+			Spec: discoveryconfig.Spec{AWS: []types.AWSMatcher{{
+				Integration: integrationName,
+				Types:       []string{"rds"},
+				Regions:     []string{"us-east-1", "us-east-2"},
+				Tags: types.Labels{
+					"env": []string{"dev", "prod"},
+				},
+			}}},
+			Status: discoveryconfig.Status{
+				LastSyncTime: syncTime,
+			},
+		}
+		clt := &mockRelevantAWSRegionsClient{
+			discoveryConfigs: []*discoveryconfig.DiscoveryConfig{
+				dcForEC2,
+				dcForRDS,
+			},
+		}
+
+		got, err := collectAutoDiscoveryRules(ctx, integrationName, "", "ec2", "", clt)
+		require.NoError(t, err)
+		expectedRules := []ui.IntegrationDiscoveryRule{
+			{
+				ResourceType: "ec2",
+				Region:       "us-east-1",
+				LabelMatcher: []libui.Label{
+					{Name: "*", Value: "*"},
+				},
+				DiscoveryConfig: dcForEC2.GetName(),
+				LastSync:        &syncTime,
+			},
+		}
+		require.Empty(t, got.NextKey)
+		require.ElementsMatch(t, expectedRules, got.Rules)
+	})
+
+	t.Run("filters by region", func(t *testing.T) {
+		syncTime := time.Now()
+		dcForRDS := &discoveryconfig.DiscoveryConfig{
+			ResourceHeader: header.ResourceHeader{Metadata: header.Metadata{
+				Name: uuid.NewString(),
+			}},
+			Spec: discoveryconfig.Spec{AWS: []types.AWSMatcher{{
+				Integration: integrationName,
+				Types:       []string{"rds"},
+				Regions:     []string{"us-east-1", "us-east-2", "us-west-2"},
+				Tags: types.Labels{
+					"env": []string{"dev", "prod"},
+				},
+			}}},
+			Status: discoveryconfig.Status{
+				LastSyncTime: syncTime,
+			},
+		}
+		clt := &mockRelevantAWSRegionsClient{
+			discoveryConfigs: []*discoveryconfig.DiscoveryConfig{
+				dcForRDS,
+			},
+		}
+
+		got, err := collectAutoDiscoveryRules(ctx, integrationName, "", "", "us-east", clt)
+		require.NoError(t, err)
+		expectedRules := []ui.IntegrationDiscoveryRule{
+			{
+				ResourceType: "rds",
+				Region:       "us-east-1",
+				LabelMatcher: []libui.Label{
+					{Name: "env", Value: "dev"},
+					{Name: "env", Value: "prod"},
+				},
+				DiscoveryConfig: dcForRDS.GetName(),
+				LastSync:        &syncTime,
+			},
+			{
+				ResourceType: "rds",
+				Region:       "us-east-2",
+				LabelMatcher: []libui.Label{
+					{Name: "env", Value: "dev"},
+					{Name: "env", Value: "prod"},
+				},
+				DiscoveryConfig: dcForRDS.GetName(),
+				LastSync:        &syncTime,
+			},
+		}
+		require.Empty(t, got.NextKey)
+		require.ElementsMatch(t, expectedRules, got.Rules)
+	})
+
+	t.Run("pagination", func(t *testing.T) {
+		syncTime := time.Now()
+		totalRules := 1000
+
+		discoveryConfigs := make([]*discoveryconfig.DiscoveryConfig, 0, totalRules)
+		for range totalRules {
+			discoveryConfigs = append(discoveryConfigs,
+				&discoveryconfig.DiscoveryConfig{
+					ResourceHeader: header.ResourceHeader{Metadata: header.Metadata{
+						Name: uuid.NewString(),
+					}},
+					Spec: discoveryconfig.Spec{AWS: []types.AWSMatcher{{
+						Integration: integrationName,
+						Types:       []string{"ec2"},
+						Regions:     []string{"us-east-1"},
+						Tags:        types.Labels{"*": []string{"*"}},
+					}}},
+					Status: discoveryconfig.Status{
+						LastSyncTime: syncTime,
+					},
+				},
+			)
+		}
+		clt := &mockRelevantAWSRegionsClient{
+			discoveryConfigs: discoveryConfigs,
+		}
+
+		nextKey := ""
+		rulesCounter := 0
+		for {
+			got, err := collectAutoDiscoveryRules(ctx, integrationName, nextKey, "", "", clt)
+			require.NoError(t, err)
+			rulesCounter += len(got.Rules)
+			nextKey = got.NextKey
+			if nextKey == "" {
+				break
+			}
+		}
+		require.Equal(t, totalRules, rulesCounter)
 	})
 }


### PR DESCRIPTION
This PR adds a new query para to the Integration's List Discovery Rules API: regions list