### PR TITLE
feat(tbot): K8S `Role` creation is optional

### DIFF
--- a/docs/pages/includes/helm-reference/zz_generated.tbot.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.tbot.mdx
@@ -200,6 +200,21 @@ resources.
 used by the chart. By default, the `ServiceAccount` has the name of the
 Helm release.
 
+## `rbac`
+
+`rbac` controls the Kubernetes Role and RoleBinding creation
+used by the serviceAccount
+
+### `rbac.create`
+
+| Type | Default |
+|------|---------|
+| `bool` | `true` |
+
+`rbac.create` controls whether Helm Chart creates the
+Kubernetes `Role` & `RoleBindings` resources for the Kubernetes SA.
+When off, you are responsible for creating the appropriate resources.
+
 ## `imagePullPolicy`
 
 | Type | Default |

--- a/examples/chart/tbot/templates/role.yaml
+++ b/examples/chart/tbot/templates/role.yaml
@@ -1,6 +1,6 @@
 # This role grants the ability to manage secrets within the namespace - this is
 # necessary for the `kubernetes_secret` destination to work correctly.
-{{ if .Values.serviceAccount.create -}}
+{{ if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/examples/chart/tbot/templates/rolebinding.yaml
+++ b/examples/chart/tbot/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.rbac.create -}}
 # Bind the role to the service account created for tbot.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/examples/chart/tbot/tests/role_test.yaml
+++ b/examples/chart/tbot/tests/role_test.yaml
@@ -12,9 +12,9 @@ tests:
       - ../.lint/full.yaml
     asserts:
       - matchSnapshot: {}
-  - it: skips creation when service account disabled
+  - it: skips creation when explictely disabled
     set:
-      serviceAccount.create: false
+      rbac.create: false
     asserts:
       - hasDocuments:
           count: 0

--- a/examples/chart/tbot/tests/rolebinding_test.yaml
+++ b/examples/chart/tbot/tests/rolebinding_test.yaml
@@ -12,9 +12,9 @@ tests:
       - ../.lint/full.yaml
     asserts:
       - matchSnapshot: {}
-  - it: skips creation when service account disabled
+  - it: skips creation when explictely disabled
     set:
-      serviceAccount.create: false
+      rbac.create: false
     asserts:
       - hasDocuments:
           count: 0

--- a/examples/chart/tbot/values.yaml
+++ b/examples/chart/tbot/values.yaml
@@ -116,6 +116,14 @@ serviceAccount:
   # Helm release.
   name: ""
 
+# rbac -- controls the Kubernetes Role and RoleBinding creation
+# used by the serviceAccount
+rbac:
+  # rbac.create(bool) -- controls whether Helm Chart creates the
+  # Kubernetes `Role` & `RoleBindings` resources for the Kubernetes SA.
+  # When off, you are responsible for creating the appropriate resources.
+  create: true
+
 # imagePullPolicy(string) -- sets the pull policy for any pods created by the chart.
 # See [the Kubernetes documentation](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
 # for more details.


### PR DESCRIPTION
# Description

Closing #51181.

K8S `Role` & `RoleBinding` are created by default but their creation does not depend on the `ServiceAccount` creation anymore.