### PR TITLE
Polish Kubernetes and Postgres connection dialogs

### DIFF
--- a/web/packages/shared/components/UnifiedResources/shared/viewItemsFactory.ts
+++ b/web/packages/shared/components/UnifiedResources/shared/viewItemsFactory.ts
@@ -203,7 +203,7 @@ function formatNodeSubKind(subKind: NodeSubKind): string {
   }
 }
 
-function getDatabaseIconName(protocol: DbProtocol): ResourceIconName {
+export function getDatabaseIconName(protocol: DbProtocol): ResourceIconName {
   switch (protocol) {
     case 'postgres':
       return 'postgres';

--- a/web/packages/teleport/src/Databases/ConnectDialog/ConnectDialog.tsx
+++ b/web/packages/teleport/src/Databases/ConnectDialog/ConnectDialog.tsx
@@ -16,7 +16,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Box, ButtonPrimary, ButtonSecondary, Link, Text } from 'design';
+import {
+  Box,
+  ButtonPrimary,
+  ButtonSecondary,
+  Flex,
+  H3,
+  Link,
+  Text,
+} from 'design';
 import Dialog, {
   DialogContent,
   DialogFooter,
@@ -24,6 +32,8 @@ import Dialog, {
   DialogTitle,
 } from 'design/Dialog';
 import { NewTab as NewTabIcon } from 'design/Icon';
+import { ResourceIcon } from 'design/ResourceIcon';
+import { getDatabaseIconName } from 'shared/components/UnifiedResources/shared/viewItemsFactory';
 import { DbProtocol } from 'shared/services/databases';
 
 import TextSelectCopy from 'teleport/components/TextSelectCopy';
@@ -91,8 +101,21 @@ export default function ConnectDialog({
       open={true}
     >
       <DialogHeader mb={4}>
-        <DialogTitle>Connect To Database</DialogTitle>
+        <DialogTitle>
+          <Flex gap={2}>
+            Connect to:
+            <Flex gap={1}>
+              <ResourceIcon
+                name={getDatabaseIconName(dbProtocol)}
+                width="24px"
+                height="24px"
+              />
+              {dbName}
+            </Flex>
+          </Flex>
+        </DialogTitle>
       </DialogHeader>
+
       <DialogContent minHeight="240px" flex="0 0 auto">
         {supportsInteractive && (
           <Box borderBottom={1} mb={4} pb={4}>
@@ -106,6 +129,11 @@ export default function ConnectDialog({
           </Box>
         )}
         <Box mb={4}>
+          {supportsInteractive && (
+            <H3 mt={1} mb={2}>
+              Or connect in the CLI using tsh:
+            </H3>
+          )}
           <Text bold as="span">
             Step 1
           </Text>

--- a/web/packages/teleport/src/Kubes/ConnectDialog/ConnectDialog.tsx
+++ b/web/packages/teleport/src/Kubes/ConnectDialog/ConnectDialog.tsx
@@ -23,6 +23,8 @@ import Dialog, {
   DialogHeader,
   DialogTitle,
 } from 'design/Dialog';
+import { NewTab as NewTabIcon } from 'design/Icon';
+import { ResourceIcon } from 'design/ResourceIcon';
 
 import TextSelectCopy from 'teleport/components/TextSelectCopy';
 import cfg from 'teleport/config';
@@ -55,13 +57,30 @@ function ConnectDialog(props: Props) {
       onClose={onClose}
       open={true}
     >
-      <DialogHeader>
-        <DialogTitle>Connect to Kubernetes Cluster</DialogTitle>
+      <DialogHeader mb={4}>
+        <DialogTitle>
+          <Flex gap={2}>
+            Connect to:
+            <Flex gap={1}>
+              <ResourceIcon name="kube" width="24px" height="24px" />
+              {kubeConnectName}
+            </Flex>
+          </Flex>
+        </DialogTitle>
       </DialogHeader>
-      <DialogContent>
+      <DialogContent minHeight="240px" flex="0 0 auto">
+        <Box borderBottom={1} mb={4} pb={4}>
+          <Text mb={3} bold>
+            Open Teleport-authenticated session in the browser:
+          </Text>
+          <ButtonPrimary size="large" gap={2} onClick={startKubeExecSession}>
+            Exec in the browser
+            <NewTabIcon />
+          </ButtonPrimary>
+        </Box>
         <Box mb={4}>
           <H3 mt={1} mb={2}>
-            Connect in the CLI using tsh and kubectl
+            Or connect in the CLI using tsh and kubectl:
           </H3>
           <Text bold as="span">
             Step 1
@@ -111,14 +130,6 @@ function ConnectDialog(props: Props) {
             <TextSelectCopy mt="2" text={`tsh request drop`} />
           </Box>
         )}
-        <Box borderTop={1} mb={4} mt={4}>
-          <Flex mt={4} flex-direction="row" justifyContent="space-between">
-            <Text mt={1} bold>
-              Or exec into a pod on this Kubernetes cluster in Web UI
-            </Text>
-            <ButtonPrimary onClick={startKubeExecSession}>Exec</ButtonPrimary>
-          </Flex>
-        </Box>
       </DialogContent>
       <DialogFooter>
         <ButtonSecondary onClick={onClose}>Close</ButtonSecondary>


### PR DESCRIPTION
This aims to add a few additional touches and unify the modals displayed in the web ui in response to clicking Connect for a kubernetes cluster or a database.

Both prompts now present connecting in the web ui as the primary option. The CLI text is secondary, and the Postgres CLI instructions now have the same `Or connect in the CLI using tsh` copy that the Kubernetes prompt did.

The wording was unified across the two prompts where appropriate and the headings were tweaked to include resource information instead of a generic Connect to Kubernetes/Postgres title.