### PR TITLE
Fix the fieldset structure

### DIFF
--- a/web/packages/teleport/src/components/LabelsInput/LabelsInput.tsx
+++ b/web/packages/teleport/src/components/LabelsInput/LabelsInput.tsx
@@ -146,46 +146,42 @@ export function LabelsInput({
   const width = `${inputWidth}px`;
   const inputSize = 'medium';
   return (
-    <Fieldset gap={labels.length > 0 ? 2 : 1}>
-      <Stack gap={1}>
-        {legend && (
-          <Legend>
-            {tooltipContent ? (
-              <>
-                <span
-                  css={{
-                    marginRight: '4px',
-                    verticalAlign: 'middle',
-                  }}
-                >
-                  {legend}
-                </span>
-                <IconTooltip children={tooltipContent} />
-              </>
-            ) : (
-              legend
-            )}
-          </Legend>
-        )}
-        {labels.length > 0 && (
-          <Flex>
-            <Box width={width} mr="3">
-              <Text typography="body3">
-                {labelKey.fieldName} (required field)
-              </Text>
-            </Box>
+    <Fieldset>
+      {legend && (
+        <Legend>
+          {tooltipContent ? (
+            <>
+              <span
+                css={{
+                  marginRight: '4px',
+                  verticalAlign: 'middle',
+                }}
+              >
+                {legend}
+              </span>
+              <IconTooltip children={tooltipContent} />
+            </>
+          ) : (
+            legend
+          )}
+        </Legend>
+      )}
+      {labels.length > 0 && (
+        <Flex mt={legend ? 1 : 0} mb={1}>
+          <Box width={width} mr="3">
             <Text typography="body3">
-              {labelVal.fieldName} (required field)
+              {labelKey.fieldName} (required field)
             </Text>
-          </Flex>
-        )}
-      </Stack>
-      <Stack gap={2}>
+          </Box>
+          <Text typography="body3">{labelVal.fieldName} (required field)</Text>
+        </Flex>
+      )}
+      <Box>
         {labels.map((label, index) => {
           const validationItem: LabelValidationResult | undefined =
             validationResult.results?.[index];
           return (
-            <Box key={index}>
+            <Box mb={2} key={index}>
               <Flex alignItems="start">
                 <FieldInput
                   size={inputSize}
@@ -245,7 +241,7 @@ export function LabelsInput({
             </Box>
           );
         })}
-      </Stack>
+      </Box>
       <ButtonSecondary
         onClick={e => {
           e.preventDefault();
@@ -274,21 +270,14 @@ export const nonEmptyLabels: LabelsRule = labels => () => {
   };
 };
 
-const Stack = styled(Flex).attrs({
-  flexDirection: 'column',
-  alignItems: 'start',
-})``;
-
-const Fieldset = styled(Stack).attrs({
-  as: 'fieldset',
-})`
+const Fieldset = styled.fieldset`
   border: none;
   margin: 0;
   padding: 0;
 `;
 
 const Legend = styled.legend`
-  margin: 0;
+  margin: 0 0 ${props => props.theme.space[1]}px 0;
   padding: 0;
   ${props => props.theme.typography.body3}
 `;


### PR DESCRIPTION
This PR reverts a change that was implemented during the code review of https://github.com/gravitational/teleport/pull/51457, because it broke the semantic structure of fieldset and legend. The tests of the follow-up PR https://github.com/gravitational/teleport/pull/51458 relied on this structure to identify fields by the legend.

This PR is intended to be backported to v17, v16, and v15 manually along with the backports of #51457.