### PR TITLE
Add kubernetes enrichment option with pyroscope

### DIFF
--- a/lib/service/pyroscope.go
+++ b/lib/service/pyroscope.go
@@ -24,9 +24,9 @@ import (
 	"time"
 
 	"github.com/grafana/pyroscope-go"
+	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/trace"
 )
 
 // TODO: Replace logger when pyroscope uses slog

--- a/lib/service/pyroscope.go
+++ b/lib/service/pyroscope.go
@@ -111,7 +111,7 @@ func createPyroscopeConfig(ctx context.Context, address string) (pyroscope.Confi
 func (process *TeleportProcess) initPyroscope(address string) {
 	config, err := createPyroscopeConfig(process.ExitContext(), address)
 	if err != nil {
-		slog.ErrorContext(process.ExitContext(), "failed to create Pyroscope config", "address", address, "error", err)
+		process.logger.ErrorContext(process.ExitContext(), "failed to create Pyroscope config", "address", address, "error", err)
 		return
 	}
 

--- a/lib/service/pyroscope.go
+++ b/lib/service/pyroscope.go
@@ -26,6 +26,7 @@ import (
 	"github.com/grafana/pyroscope-go"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/trace"
 )
 
 // TODO: Replace logger when pyroscope uses slog
@@ -51,7 +52,7 @@ func (l pyroscopeLogger) Errorf(format string, args ...interface{}) {
 // createPyroscopeConfig generates the Pyroscope configuration for the Teleport process.
 func createPyroscopeConfig(ctx context.Context, address string) (pyroscope.Config, error) {
 	if address == "" {
-		return pyroscope.Config{}, fmt.Errorf("pyroscope address is empty")
+		return pyroscope.Config{}, trace.BadParameter("pyroscope address is empty")
 	}
 
 	hostname, err := os.Hostname()

--- a/lib/service/pyroscope.go
+++ b/lib/service/pyroscope.go
@@ -17,6 +17,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -48,7 +49,7 @@ func (l pyroscopeLogger) Errorf(format string, args ...interface{}) {
 }
 
 // createPyroscopeConfig generates the Pyroscope configuration for the Teleport process.
-func (process *TeleportProcess) createPyroscopeConfig(address string) (pyroscope.Config, error) {
+func createPyroscopeConfig(ctx context.Context, address string) (pyroscope.Config, error) {
 	if address == "" {
 		return pyroscope.Config{}, fmt.Errorf("pyroscope address is empty")
 	}
@@ -71,22 +72,22 @@ func (process *TeleportProcess) createPyroscopeConfig(address string) (pyroscope
 
 	// Evaluate if profile configuration is customized
 	if p := getPyroscopeProfileTypesFromEnv(); len(p) == 0 {
-		slog.InfoContext(process.ExitContext(), "No profile types enabled, using default")
+		slog.InfoContext(ctx, "No profile types enabled, using default")
 	} else {
 		config.ProfileTypes = p
-		slog.InfoContext(process.ExitContext(), "Pyroscope will configure profiles from env")
+		slog.InfoContext(ctx, "Pyroscope will configure profiles from env")
 	}
 
 	var uploadRate *time.Duration
 	if rate := os.Getenv("TELEPORT_PYROSCOPE_UPLOAD_RATE"); rate != "" {
 		parsedRate, err := time.ParseDuration(rate)
 		if err != nil {
-			slog.InfoContext(process.ExitContext(), "invalid TELEPORT_PYROSCOPE_UPLOAD_RATE, ignoring value", "provided_value", rate, "error", err)
+			slog.InfoContext(ctx, "invalid TELEPORT_PYROSCOPE_UPLOAD_RATE, ignoring value", "provided_value", rate, "error", err)
 		} else {
 			uploadRate = &parsedRate
 		}
 	} else {
-		slog.InfoContext(process.ExitContext(), "TELEPORT_PYROSCOPE_UPLOAD_RATE not specified, using default")
+		slog.InfoContext(ctx, "TELEPORT_PYROSCOPE_UPLOAD_RATE not specified, using default")
 	}
 
 	// Set UploadRate or fall back to defaults
@@ -107,7 +108,7 @@ func (process *TeleportProcess) createPyroscopeConfig(address string) (pyroscope
 
 // initPyroscope instruments Teleport to run with continuous profiling for Pyroscope
 func (process *TeleportProcess) initPyroscope(address string) {
-	config, err := process.createPyroscopeConfig(address)
+	config, err := createPyroscopeConfig(process.ExitContext(), address)
 	if err != nil {
 		slog.ErrorContext(process.ExitContext(), "failed to create Pyroscope config", "address", address, "error", err)
 		return

--- a/lib/service/pyroscope.go
+++ b/lib/service/pyroscope.go
@@ -139,30 +139,3 @@ func getPyroscopeProfileTypesFromEnv() []pyroscope.ProfileType {
 
 	return profileTypes
 }
-
-// isKubeEnvVarSet checks if metadata tags should be processed.
-func isKubeEnvVarSet() bool {
-	for _, env := range os.Environ() {
-		if strings.HasPrefix(env, "TELEPORT_PYROSCOPE_KUBE_") {
-			return true
-		}
-	}
-	return false
-}
-
-// getTagsFromKubeEnv extracts Kubernetes metadata passed from downward API and returns them if set.
-func addKubeTagsFromEnv(tags map[string]string) map[string]string {
-
-	env := map[string]string{
-		"component": "TELEPORT_PYROSCOPE_KUBE_COMPONENT",
-		"namespace": "TELEPORT_PYROSCOPE_KUBE_NAMESPACE",
-	}
-
-	for k, v := range env {
-		if value, isSet := os.LookupEnv(v); isSet {
-			tags[k] = value
-		}
-	}
-
-	return tags
-}

--- a/lib/service/pyroscope.go
+++ b/lib/service/pyroscope.go
@@ -96,9 +96,12 @@ func (process *TeleportProcess) initPyroscope(address string) {
 		config.UploadRate = *uploadRate
 	}
 
-	if isKubeEnvVarSet() {
-		config.Tags = addKubeTagsFromEnv(config.Tags)
-		slog.InfoContext(process.ExitContext(), "Configuring additional tags for Kubernetes if set.")
+	if value, isSet := os.LookupEnv("TELEPORT_PYROSCOPE_KUBE_COMPONENT"); isSet {
+		config.Tags["component"] = value
+	}
+		
+	if value, isSet := os.LookupEnv("TELEPORT_PYROSCOPE_KUBE_NAMESPACE"); isSet {
+		config.Tags["namespace"] = value
 	}
 
 	profiler, err := pyroscope.Start(config)

--- a/lib/service/pyroscope.go
+++ b/lib/service/pyroscope.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/grafana/pyroscope-go"
@@ -48,10 +47,10 @@ func (l pyroscopeLogger) Errorf(format string, args ...interface{}) {
 	l.l.Error(fmt.Sprintf(format, args...))
 }
 
-// initPyroscope instruments Teleport to run with continuous profiling for Pyroscope
-func (process *TeleportProcess) initPyroscope(address string) {
+// createPyroscopeConfig generates the Pyroscope configuration for the Teleport process.
+func (process *TeleportProcess) createPyroscopeConfig(address string) (pyroscope.Config, error) {
 	if address == "" {
-		return
+		return pyroscope.Config{}, fmt.Errorf("pyroscope address is empty")
 	}
 
 	hostname, err := os.Hostname()
@@ -59,7 +58,6 @@ func (process *TeleportProcess) initPyroscope(address string) {
 		hostname = "unknown"
 	}
 
-	// Build pyroscope config
 	config := pyroscope.Config{
 		ApplicationName: teleport.ComponentTeleport,
 		ServerAddress:   address,
@@ -99,14 +97,25 @@ func (process *TeleportProcess) initPyroscope(address string) {
 	if value, isSet := os.LookupEnv("TELEPORT_PYROSCOPE_KUBE_COMPONENT"); isSet {
 		config.Tags["component"] = value
 	}
-		
+
 	if value, isSet := os.LookupEnv("TELEPORT_PYROSCOPE_KUBE_NAMESPACE"); isSet {
 		config.Tags["namespace"] = value
 	}
 
+	return config, nil
+}
+
+// initPyroscope instruments Teleport to run with continuous profiling for Pyroscope
+func (process *TeleportProcess) initPyroscope(address string) {
+	config, err := process.createPyroscopeConfig(address)
+	if err != nil {
+		slog.ErrorContext(process.ExitContext(), "failed to create Pyroscope config", "address", address, "error", err)
+		return
+	}
+
 	profiler, err := pyroscope.Start(config)
 	if err != nil {
-		slog.ErrorContext(process.ExitContext(), "error starting pyroscope profiler", "error", err)
+		slog.ErrorContext(process.ExitContext(), "error starting pyroscope profiler", "address", address, "error", err)
 	} else {
 		process.OnExit("pyroscope.profiler", func(payload any) {
 			profiler.Flush(payload == nil)

--- a/lib/service/pyroscope.go
+++ b/lib/service/pyroscope.go
@@ -75,6 +75,7 @@ func (process *TeleportProcess) initPyroscope(address string) {
 		slog.InfoContext(process.ExitContext(), "No profile types enabled, using default")
 	} else {
 		config.ProfileTypes = p
+		slog.InfoContext(process.ExitContext(), "Pyroscope will configure profiles from env")
 	}
 
 	var uploadRate *time.Duration
@@ -92,6 +93,12 @@ func (process *TeleportProcess) initPyroscope(address string) {
 	// Set UploadRate or fall back to defaults
 	if uploadRate != nil {
 		config.UploadRate = *uploadRate
+	}
+
+	// If set, check for Kubernetes enrichment from downward API
+	if os.Getenv("TELEPORT_PYROSCOPE_KUBE_ENV") == "true" {
+		config.Tags = addKubeTagsFromEnv(config.Tags)
+		slog.InfoContext(process.ExitContext(), "Pyroscope will configure tags for Kubernetes env if set.")
 	}
 
 	profiler, err := pyroscope.Start(config)
@@ -128,4 +135,24 @@ func getPyroscopeProfileTypesFromEnv() []pyroscope.ProfileType {
 	}
 
 	return profileTypes
+}
+
+// getTagsFromKubeEnv extracts Kubernetes metadata passed from downward API and returns them if set.
+func addKubeTagsFromEnv(tags map[string]string) map[string]string {
+
+	env := map[string]string{
+		"name":      "TELEPORT_PYROSCOPE_KUBE_NAME",
+		"instance":  "TELEPORT_PYROSCOPE_KUBE_INSTANCE",
+		"component": "TELEPORT_PYROSCOPE_KUBE_COMPONENT",
+		"namespace": "TELEPORT_PYROSCOPE_KUBE_NAMESPACE",
+		"region":    "TELEPORT_PYROSCOPE_KUBE_REGION",
+	}
+
+	for k, v := range env {
+		if value, isSet := os.LookupEnv(v); isSet {
+			tags[k] = value
+		}
+	}
+
+	return tags
 }

--- a/lib/service/pyroscope_test.go
+++ b/lib/service/pyroscope_test.go
@@ -83,12 +83,6 @@ func TestPyroscopeConfig(t *testing.T) {
 			for k, v := range tt.envVars {
 				t.Setenv(k, v)
 			}
-			p := &TeleportProcess{
-				logger: slog.Default(),
-				Supervisor: &LocalSupervisor{
-					exitContext: context.Background(),
-				},
-			}
 			got, err := createPyroscopeConfig(p.ExitContext(), tt.address)
 			tt.errorAssertion(t, err)
 

--- a/lib/service/pyroscope_test.go
+++ b/lib/service/pyroscope_test.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package service
 
 import (
@@ -100,19 +116,13 @@ func TestAddKubeTagsFromEnv(t *testing.T) {
 		{
 			name: "Kubernetes env variables set",
 			envVars: map[string]string{
-				"TELEPORT_PYROSCOPE_KUBE_NAME":      "test-name",
-				"TELEPORT_PYROSCOPE_KUBE_INSTANCE":  "test-instance",
-				"TELEPORT_PYROSCOPE_KUBE_COMPONENT": "test-component",
+				"TELEPORT_PYROSCOPE_KUBE_COMPONENT": "auth",
 				"TELEPORT_PYROSCOPE_KUBE_NAMESPACE": "test-namespace",
-				"TELEPORT_PYROSCOPE_KUBE_REGION":    "us-east-1",
 			},
 			initialTags: map[string]string{},
 			wantTags: map[string]string{
-				"name":      "test-name",
-				"instance":  "test-instance",
-				"component": "test-component",
+				"component": "auth",
 				"namespace": "test-namespace",
-				"region":    "us-east-1",
 			},
 		},
 	}

--- a/lib/service/pyroscope_test.go
+++ b/lib/service/pyroscope_test.go
@@ -1,0 +1,135 @@
+package service
+
+import (
+	"os"
+	"testing"
+
+	"github.com/grafana/pyroscope-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPyroscopeProfileTypesFromEnv(t *testing.T) {
+	tests := []struct {
+		name    string
+		envVars map[string]string
+		want    []pyroscope.ProfileType
+	}{
+		{
+			name:    "No profiles enabled",
+			envVars: map[string]string{},
+			want:    []pyroscope.ProfileType{},
+		},
+		{
+			name: "Memory profiles enabled",
+			envVars: map[string]string{
+				"TELEPORT_PYROSCOPE_PROFILE_MEMORY_ENABLED": "true",
+			},
+			want: []pyroscope.ProfileType{
+				pyroscope.ProfileAllocObjects,
+				pyroscope.ProfileAllocSpace,
+				pyroscope.ProfileInuseObjects,
+				pyroscope.ProfileInuseSpace,
+			},
+		},
+		{
+			name: "CPU profiles enabled",
+			envVars: map[string]string{
+				"TELEPORT_PYROSCOPE_PROFILE_CPU_ENABLED": "true",
+			},
+			want: []pyroscope.ProfileType{
+				pyroscope.ProfileCPU,
+			},
+		},
+		{
+			name: "Goroutine profiles enabled",
+			envVars: map[string]string{
+				"TELEPORT_PYROSCOPE_PROFILE_GOROUTINES_ENABLED": "true",
+			},
+			want: []pyroscope.ProfileType{
+				pyroscope.ProfileGoroutines,
+			},
+		},
+		{
+			name: "Multiple profiles enabled",
+			envVars: map[string]string{
+				"TELEPORT_PYROSCOPE_PROFILE_MEMORY_ENABLED":     "true",
+				"TELEPORT_PYROSCOPE_PROFILE_CPU_ENABLED":        "true",
+				"TELEPORT_PYROSCOPE_PROFILE_GOROUTINES_ENABLED": "true",
+			},
+			want: []pyroscope.ProfileType{
+				pyroscope.ProfileAllocObjects,
+				pyroscope.ProfileAllocSpace,
+				pyroscope.ProfileInuseObjects,
+				pyroscope.ProfileInuseSpace,
+				pyroscope.ProfileCPU,
+				pyroscope.ProfileGoroutines,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.envVars {
+				os.Setenv(k, v)
+			}
+			defer func() {
+				for k := range tc.envVars {
+					os.Unsetenv(k)
+				}
+			}()
+
+			got := getPyroscopeProfileTypesFromEnv()
+			assert.ElementsMatch(t, tc.want, got)
+		})
+	}
+}
+
+func TestAddKubeTagsFromEnv(t *testing.T) {
+	tests := []struct {
+		name        string
+		envVars     map[string]string
+		initialTags map[string]string
+		wantTags    map[string]string
+	}{
+		{
+			name:        "No Kubernetes env variables set",
+			envVars:     map[string]string{},
+			initialTags: map[string]string{},
+			wantTags:    map[string]string{},
+		},
+		{
+			name: "Kubernetes env variables set",
+			envVars: map[string]string{
+				"TELEPORT_PYROSCOPE_KUBE_NAME":      "test-name",
+				"TELEPORT_PYROSCOPE_KUBE_INSTANCE":  "test-instance",
+				"TELEPORT_PYROSCOPE_KUBE_COMPONENT": "test-component",
+				"TELEPORT_PYROSCOPE_KUBE_NAMESPACE": "test-namespace",
+				"TELEPORT_PYROSCOPE_KUBE_REGION":    "us-east-1",
+			},
+			initialTags: map[string]string{},
+			wantTags: map[string]string{
+				"name":      "test-name",
+				"instance":  "test-instance",
+				"component": "test-component",
+				"namespace": "test-namespace",
+				"region":    "us-east-1",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.envVars {
+				os.Setenv(k, v)
+			}
+			defer func() {
+				for k := range tc.envVars {
+					os.Unsetenv(k)
+				}
+			}()
+
+			gotTags := addKubeTagsFromEnv(tc.initialTags)
+			assert.Equal(t, tc.wantTags, gotTags)
+		})
+	}
+}

--- a/lib/service/pyroscope_test.go
+++ b/lib/service/pyroscope_test.go
@@ -83,7 +83,7 @@ func TestPyroscopeConfig(t *testing.T) {
 			for k, v := range tt.envVars {
 				t.Setenv(k, v)
 			}
-			got, err := createPyroscopeConfig(p.ExitContext(), tt.address)
+			got, err := createPyroscopeConfig(context.Background(), slog.Default(), tt.address)
 			tt.errorAssertion(t, err)
 
 			require.Equal(t, tt.want.ProfileTypes, got.ProfileTypes)


### PR DESCRIPTION
Using Pyroscope push doesn't allow any label enrichment since transcoding happens in the teleport service itself. To get Kubernetes metadata the recommended approach is to pass it via the [downward API](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/).

When `TELEPORT_PYROSCOPE_KUBE_ENV` is enabled, have pyroscope check for specific Kubernetes metadata.  This is especially helpful when running multiple deployments of Teleport in Kubernetes.  This PR also adds tests for the pyroscope service.
