### PR TITLE
Tweaks to various sloglint overrides

### DIFF
--- a/lib/auth/join/join.go
+++ b/lib/auth/join/join.go
@@ -495,12 +495,12 @@ func getHostAddresses(params RegisterParams) []string {
 // CA on disk. If no CA is found on disk, Teleport will not verify the Auth
 // Server it is connecting to.
 func insecureRegisterClient(ctx context.Context, params RegisterParams) (*authclient.Client, error) {
-	//nolint:sloglint // Conjoined string literals trip up the linter.
-	slog.WarnContext(ctx, "Joining cluster without validating the identity of the Auth "+
-		"Server. This may open you up to a Man-In-The-Middle (MITM) attack if an "+
-		"attacker can gain privileged network access. To remedy this, use the CA pin "+
-		"value provided when join token was generated to validate the identity of "+
-		"the Auth Server or point to a valid Certificate via the CA Path option.")
+	const msg = "Joining cluster without validating the identity of the Auth " +
+		"Server. This may open you up to a Man-In-The-Middle (MITM) attack if an " +
+		"attacker can gain privileged network access. To remedy this, use the CA pin " +
+		"value provided when join token was generated to validate the identity of " +
+		"the Auth Server or point to a valid Certificate via the CA Path option."
+	slog.WarnContext(ctx, msg)
 
 	tlsConfig := utils.TLSConfig(params.CipherSuites)
 	tlsConfig.Time = params.Clock.Now

--- a/lib/autoupdate/agent/logger.go
+++ b/lib/autoupdate/agent/logger.go
@@ -66,7 +66,12 @@ type lineLogger struct {
 }
 
 func (w *lineLogger) out(s string) {
-	w.log.Log(w.ctx, w.level, w.prefix+s) //nolint:sloglint // msg cannot be constant
+	if !w.log.Handler().Enabled(w.ctx, w.level) {
+		return
+	}
+
+	//nolint:sloglint // msg is appended with prefix
+	w.log.Log(w.ctx, w.level, w.prefix+s)
 }
 
 func (w *lineLogger) Write(p []byte) (n int, err error) {

--- a/lib/integrations/awsoidc/eks_enroll_clusters.go
+++ b/lib/integrations/awsoidc/eks_enroll_clusters.go
@@ -591,8 +591,11 @@ func getHelmActionConfig(ctx context.Context, clientGetter genericclioptions.RES
 	// > func(format string, v ...interface{})
 	// slog.Log does not support it, so it must be added
 	debugLogWithFormat := func(format string, v ...interface{}) {
-		formatString := fmt.Sprintf(format, v...)
-		log.DebugContext(ctx, formatString) //nolint:sloglint // message should be a constant but in this case we are creating it at runtime.
+		if !log.Handler().Enabled(ctx, slog.LevelDebug) {
+			return
+		}
+		//nolint:sloglint // message should be a constant but in this case we are creating it at runtime.
+		log.DebugContext(ctx, fmt.Sprintf(format, v...))
 	}
 	if err := actionConfig.Init(clientGetter, agentNamespace, "secret", debugLogWithFormat); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/service/pyroscope.go
+++ b/lib/service/pyroscope.go
@@ -17,6 +17,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -33,16 +34,27 @@ type pyroscopeLogger struct {
 }
 
 func (l pyroscopeLogger) Infof(format string, args ...interface{}) {
+	if !l.l.Handler().Enabled(context.Background(), slog.LevelInfo) {
+		return
+	}
 	//nolint:sloglint // msg cannot be constant
 	l.l.Info(fmt.Sprintf(format, args...))
 }
 
 func (l pyroscopeLogger) Debugf(format string, args ...interface{}) {
+	if !l.l.Handler().Enabled(context.Background(), slog.LevelDebug) {
+		return
+	}
+
 	//nolint:sloglint // msg cannot be constant
 	l.l.Debug(fmt.Sprintf(format, args...))
 }
 
 func (l pyroscopeLogger) Errorf(format string, args ...interface{}) {
+	if !l.l.Handler().Enabled(context.Background(), slog.LevelError) {
+		return
+	}
+
 	//nolint:sloglint // msg cannot be constant
 	l.l.Error(fmt.Sprintf(format, args...))
 }

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3480,6 +3480,10 @@ type promHTTPLogAdapter struct {
 
 // Println implements the promhttp.Logger interface.
 func (l promHTTPLogAdapter) Println(v ...interface{}) {
+	if !l.Handler().Enabled(l.ctx, slog.LevelError) {
+		return
+	}
+
 	//nolint:sloglint // msg cannot be constant
 	l.ErrorContext(l.ctx, fmt.Sprint(v...))
 }

--- a/tool/tbot/spiffe.go
+++ b/tool/tbot/spiffe.go
@@ -36,21 +36,37 @@ type logger struct {
 }
 
 func (l logger) Debugf(format string, args ...interface{}) {
+	if !l.l.Handler().Enabled(context.Background(), slog.LevelDebug) {
+		return
+	}
+
 	//nolint:sloglint // msg cannot be constant
 	l.l.DebugContext(context.Background(), fmt.Sprintf(format, args...))
 }
 
 func (l logger) Infof(format string, args ...interface{}) {
+	if !l.l.Handler().Enabled(context.Background(), slog.LevelInfo) {
+		return
+	}
+
 	//nolint:sloglint // msg cannot be constant
 	l.l.InfoContext(context.Background(), fmt.Sprintf(format, args...))
 }
 
 func (l logger) Warnf(format string, args ...interface{}) {
+	if !l.l.Handler().Enabled(context.Background(), slog.LevelWarn) {
+		return
+	}
+
 	//nolint:sloglint // msg cannot be constant
 	l.l.WarnContext(context.Background(), fmt.Sprintf(format, args...))
 }
 
 func (l logger) Errorf(format string, args ...interface{}) {
+	if !l.l.Handler().Enabled(context.Background(), slog.LevelError) {
+		return
+	}
+
 	//nolint:sloglint // msg cannot be constant
 	l.l.ErrorContext(context.Background(), fmt.Sprintf(format, args...))
 }


### PR DESCRIPTION
This aims to either alter logs to avoid the linter override, or at minimum prevent formatting of messages if the log level is not enabled.