### PR TITLE
[v16] Quote KUBECONFIG output by tsh proxy kube

### DIFF
--- a/tool/tsh/common/proxy.go
+++ b/tool/tsh/common/proxy.go
@@ -786,13 +786,13 @@ func envVarDefaultFormat() string {
 func envVarCommand(format, key, value string) (string, error) {
 	switch format {
 	case envVarFormatUnix:
-		return fmt.Sprintf("export %s=%s", key, value), nil
+		return fmt.Sprintf(`export %s="%s"`, key, value), nil
 
 	case envVarFormatWindowsCommandPrompt:
 		return fmt.Sprintf("set %s=%s", key, value), nil
 
 	case envVarFormatWindowsPowershell:
-		return fmt.Sprintf("$Env:%s=\"%s\"", key, value), nil
+		return fmt.Sprintf(`$Env:%s="%s"`, key, value), nil
 
 	case envVarFormatText:
 		return fmt.Sprintf("%s=%s", key, value), nil

--- a/tool/tsh/common/proxy_test.go
+++ b/tool/tsh/common/proxy_test.go
@@ -816,7 +816,7 @@ func TestEnvVarCommand(t *testing.T) {
 			inputFormat:  envVarFormatUnix,
 			inputKey:     "key",
 			inputValue:   "value",
-			expectOutput: "export key=value",
+			expectOutput: `export key="value"`,
 		},
 		{
 			inputFormat:  envVarFormatWindowsCommandPrompt,
@@ -828,7 +828,7 @@ func TestEnvVarCommand(t *testing.T) {
 			inputFormat:  envVarFormatWindowsPowershell,
 			inputKey:     "key",
 			inputValue:   "value",
-			expectOutput: "$Env:key=\"value\"",
+			expectOutput: `$Env:key="value"`,
 		},
 		{
 			inputFormat: "unknown",


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/51509 to branch/v16

changelog: Quote the KUBECONFIG environment variable output by the tsh proxy kube command