### PR TITLE
[Web] Add sidenav highlight support for children of features

### DIFF
--- a/web/packages/teleport/src/Login/useLogin.ts
+++ b/web/packages/teleport/src/Login/useLogin.ts
@@ -203,7 +203,6 @@ export type State = ReturnType<typeof useLogin> & {
  * moveToFront returns a copy of an array with the element that matches the condition to the front of it.
  */
 function moveToFront<T>(arr: T[], condition: (item: T) => boolean): T[] {
-  console.log(arr);
   const copy = [...arr];
   const index = copy.findIndex(condition);
 

--- a/web/packages/teleport/src/Navigation/Navigation.tsx
+++ b/web/packages/teleport/src/Navigation/Navigation.tsx
@@ -188,7 +188,7 @@ function getNavSubsectionForRoute(
   features: TeleportFeature[],
   route: history.Location<unknown> | Location
 ): NavigationSubsection {
-  const feature = features
+  let feature = features
     .filter(feature => Boolean(feature.route))
     .find(feature =>
       matchPath(route.pathname, {
@@ -196,6 +196,13 @@ function getNavSubsectionForRoute(
         exact: feature.route.exact,
       })
     );
+
+  // If this is a child feature, use its parent as the subsection instead.
+  // We do this because children of features don't appear as subsections in the sidenav, but we want to highlight
+  // their parent's subsection as active.
+  if (feature?.parent) {
+    feature = features.find(f => f instanceof feature.parent);
+  }
 
   if (
     !feature ||


### PR DESCRIPTION
## Purpose

`e` counterpart: https://github.com/gravitational/teleport.e/pull/5951

This PR adds support for children of features to highlight their parent's subsection in the sidenav. Previously, if a feature did not have a dedicated sidenav section (such as "New Access Request"), being on that page would not highlight any subsection in the sidenav as active. With this change, its parent will be highlighted as a visual indicator.

This PR also removes the existing `FeatureAccessRequests` because it served no purpose and was just a remnant from a topbar implementation, in reality the "Review Requests" page _is_ the "access requests" page (this change is in the `e` counterpart to this PR)

### Demo

#### Before
![image](https://github.com/user-attachments/assets/ba8eb4a2-21bb-436e-b354-239820c3daaa)

#### After

![image](https://github.com/user-attachments/assets/8235049f-1095-464d-8016-39ba09fee7d8)
