### PR TITLE
[v17] Support routing to Kubernetes clusters by request path (#50567)

### DIFF
--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -341,6 +341,10 @@ func NewForwarder(cfg ForwarderConfig) (*Forwarder, error) {
 
 	router.GET("/api/:ver/teleport/join/:session", fwd.withAuthPassthrough(fwd.join))
 
+	for _, method := range allHTTPMethods() {
+		router.Handle(method, "/v1/teleport/:base64Cluster/:base64KubeCluster/*path", fwd.singleCertHandler())
+	}
+
 	router.NotFound = fwd.withAuthStd(fwd.catchAll)
 
 	fwd.router = instrumentHTTPHandler(fwd.cfg.KubeServiceType, router)
@@ -2777,4 +2781,20 @@ func (f formatForwardResponseError) WriteString(s string) (int, error) {
 		return 0, trace.Wrap(err)
 	}
 	return len(s), nil
+}
+
+// allHTTPMethods returns a list of all HTTP methods, useful for creating
+// non-root catch-all handlers.
+func allHTTPMethods() []string {
+	return []string{
+		http.MethodConnect,
+		http.MethodDelete,
+		http.MethodGet,
+		http.MethodHead,
+		http.MethodOptions,
+		http.MethodPatch,
+		http.MethodPost,
+		http.MethodPut,
+		http.MethodTrace,
+	}
 }

--- a/lib/kube/proxy/single_cert_handler.go
+++ b/lib/kube/proxy/single_cert_handler.go
@@ -1,0 +1,191 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package proxy
+
+import (
+	"encoding/base64"
+	"net/http"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/gravitational/trace"
+	"github.com/julienschmidt/httprouter"
+
+	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/httplib"
+	"github.com/gravitational/teleport/lib/tlsca"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
+)
+
+const (
+	// paramTeleportCluster is the path parameter key containing a base64
+	// encoded Teleport cluster name for path-routed forwarding.
+	paramTeleportCluster = "base64Cluster"
+
+	// paramKubernetesCluster is the path parameter key containing a base64
+	// encoded Teleport cluster name for path-routed forwarding.
+	paramKubernetesCluster = "base64KubeCluster"
+)
+
+// parseRouteFromPath extracts route information from the given path parameters
+// using constant-defined parameter keys.
+func parseRouteFromPath(p httprouter.Params) (string, string, error) {
+	encodedTeleportCluster := p.ByName(paramTeleportCluster)
+	if encodedTeleportCluster == "" {
+		return "", "", trace.BadParameter("no Teleport cluster name found in path")
+	}
+
+	decodedTeleportCluster, err := base64.RawURLEncoding.DecodeString(encodedTeleportCluster)
+	if err != nil {
+		return "", "", trace.Wrap(err)
+	}
+
+	encodedKubernetesCluster := p.ByName(paramKubernetesCluster)
+	if encodedKubernetesCluster == "" {
+		return "", "", trace.BadParameter("no Kubernetes cluster name found in path")
+	}
+
+	decodedKubernetesCluster, err := base64.RawURLEncoding.DecodeString(encodedKubernetesCluster)
+	if err != nil {
+		return "", "", trace.Wrap(err)
+	}
+
+	if !utf8.Valid(decodedTeleportCluster) {
+		return "", "", trace.BadParameter("invalid Teleport cluster name")
+	}
+
+	if !utf8.Valid(decodedKubernetesCluster) {
+		return "", "", trace.BadParameter("invalid Kubernetes cluster name")
+	}
+
+	return string(decodedTeleportCluster), string(decodedKubernetesCluster), nil
+}
+
+// ensureRouteNotOverwritten checks that the path routing parameters do not
+// overwrite any existing RouteToCluster or KubernetesCluster fields in the
+// identity, if those fields are set. Additionally, it is valid for the path
+// route to be equal to the existing value.
+//
+// This requirement ensures temporary certs issued for session MFA remain bound
+// to the cluster for which they were initially issued and path routing cannot
+// be used to access a different target cluster. If MFA is required, path routed
+// requests will receive an `ErrSessionMFARequired` as usual and will need to
+// request certificates with identity-based routing information. Once the
+// temporary identity is issued, the request can proceed as usual through this
+// path-based route so long as the path and identity route fields are equal.
+func ensureRouteNotOverwritten(ident *tlsca.Identity, routeToCluster, kubernetesCluster string) error {
+	teleportClusterChanged := ident.RouteToCluster != routeToCluster
+	kubeClusterChanged := ident.KubernetesCluster != kubernetesCluster
+
+	// If session MFA is enabled, either cluster-wide or for the target cluster
+	// via role options, access attempts without an MFA assertion will pass
+	// through here and fail during `CheckAccess()` in `authorize()`. If retried
+	// with an assertion, we should not allow routing parameters to be
+	// overwritten even if somehow empty ("") as that would allow MFA certs to
+	// access any cluster.
+	if ident.MFAVerified != "" && (teleportClusterChanged || kubeClusterChanged) {
+		return trace.AccessDenied("identity routing parameters are required when MFA assertions are present")
+	}
+
+	const overwriteDeniedMsg = "existing route in identity may not be overwritten"
+	if ident.RouteToCluster != "" && teleportClusterChanged {
+		return trace.AccessDenied(overwriteDeniedMsg)
+	}
+	if ident.KubernetesCluster != "" && kubeClusterChanged {
+		return trace.AccessDenied(overwriteDeniedMsg)
+	}
+
+	return nil
+}
+
+// singleCertHandler extracts routing information from base64-encoded URL
+// parameters into the current auth user context and forwards the request back
+// to the main router with the path prefix (and its embedded routing parameters)
+// stripped.
+func (f *Forwarder) singleCertHandler() httprouter.Handle {
+	return httplib.MakeHandlerWithErrorWriter(func(w http.ResponseWriter, req *http.Request, p httprouter.Params) (any, error) {
+		teleportCluster, kubeCluster, err := parseRouteFromPath(p)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		userTypeI, err := authz.UserFromContext(req.Context())
+		if err != nil {
+			f.log.WarnContext(req.Context(), "error getting user from context", "error", err)
+			return nil, trace.AccessDenied(accessDeniedMsg)
+		}
+
+		// Insert the extracted routing information from the path into the
+		// identity. Some implementation notes:
+		// - This still relies on RouteToCluster and KubernetesCluster identity
+		//   fields, even though these fields are not part of the TLS identity
+		//   when using path-based routing.
+		// - If the Teleport+Kube cluster names resolve to the local node, these
+		//   values will be used directly in their proper handlers once the
+		//   request is rewritten.
+		// - If the route resolves to a remote node, the identity is encoded (in
+		//   JSON form) into forwarding headers using
+		//   `auth.IdentityForwardingHeaders`. The destination node's auth
+		//   middleware is configured to extract this identity (due to
+		//   EnableCredentialsForwarding) and implicitly trusts this routing
+		//   data, assuming the request originated from a proxy.
+		// - In either case, the destination node is ultimately responsible for
+		//   authorizing the request, and routing information set in the
+		//   identity should not be implicitly trusted. (This was ideally never
+		//   the case, given access to resources could be revoked via roles
+		//   before certs expired.)
+
+		var userType authz.IdentityGetter
+		switch o := userTypeI.(type) {
+		case authz.LocalUser:
+			if err := ensureRouteNotOverwritten(&o.Identity, teleportCluster, kubeCluster); err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			o.Identity.RouteToCluster = teleportCluster
+			o.Identity.KubernetesCluster = kubeCluster
+			userType = o
+		case authz.RemoteUser:
+			if err := ensureRouteNotOverwritten(&o.Identity, teleportCluster, kubeCluster); err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			o.Identity.RouteToCluster = teleportCluster
+			o.Identity.KubernetesCluster = kubeCluster
+			userType = o
+		default:
+			f.log.WarnContext(req.Context(), "Denying proxy access to unsupported user type", "user_type", logutils.TypeAttr(userTypeI))
+			return nil, trace.AccessDenied(accessDeniedMsg)
+		}
+
+		ctx := authz.ContextWithUser(req.Context(), userType)
+		req = req.Clone(ctx)
+
+		path := p.ByName("path")
+		if !strings.HasPrefix(path, "/") {
+			path = "/" + path
+		}
+
+		req.URL.Path = path
+		req.URL.RawPath = ""
+		req.RequestURI = req.URL.RequestURI()
+
+		f.router.ServeHTTP(w, req)
+		return nil, nil
+	}, f.formatStatusResponseError)
+}

--- a/lib/kube/proxy/single_cert_handler.go
+++ b/lib/kube/proxy/single_cert_handler.go
@@ -29,7 +29,6 @@ import (
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/tlsca"
-	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 const (
@@ -126,7 +125,7 @@ func (f *Forwarder) singleCertHandler() httprouter.Handle {
 
 		userTypeI, err := authz.UserFromContext(req.Context())
 		if err != nil {
-			f.log.WarnContext(req.Context(), "error getting user from context", "error", err)
+			f.log.WithError(err).Warn("error getting user from context")
 			return nil, trace.AccessDenied(accessDeniedMsg)
 		}
 
@@ -169,7 +168,7 @@ func (f *Forwarder) singleCertHandler() httprouter.Handle {
 			o.Identity.KubernetesCluster = kubeCluster
 			userType = o
 		default:
-			f.log.WarnContext(req.Context(), "Denying proxy access to unsupported user type", "user_type", logutils.TypeAttr(userTypeI))
+			f.log.Warningf("Denying proxy access to unsupported user type: %T.", userTypeI)
 			return nil, trace.AccessDenied(accessDeniedMsg)
 		}
 

--- a/lib/kube/proxy/single_cert_handler_test.go
+++ b/lib/kube/proxy/single_cert_handler_test.go
@@ -1,0 +1,221 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package proxy
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/gravitational/teleport/api/types"
+	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
+)
+
+// pathRoutedKubeClient uses the given rest.Config to build a Kubernetes client
+// using path-based routing derived from the provided Teleport and Kubernetes
+// cluster names.
+func pathRoutedKubeClient(t *testing.T, restConfig *rest.Config, teleportCluster, kubeCluster string) *kubernetes.Clientset {
+	t.Helper()
+
+	restConfig = rest.CopyConfig(restConfig)
+	encTeleportCluster := base64.RawURLEncoding.EncodeToString([]byte(teleportCluster))
+	encKubeCluster := base64.RawURLEncoding.EncodeToString([]byte(kubeCluster))
+	restConfig.Host += fmt.Sprintf("/v1/teleport/%s/%s", encTeleportCluster, encKubeCluster)
+
+	client, err := kubernetes.NewForConfig(restConfig)
+	require.NoError(t, err)
+
+	return client
+}
+
+func TestSingleCertRouting(t *testing.T) {
+	kubeMockA, err := testingkubemock.NewKubeAPIMock()
+	require.NoError(t, err)
+	t.Cleanup(func() { kubeMockA.Close() })
+
+	kubeMockB, err := testingkubemock.NewKubeAPIMock(
+		// This endpoint returns a known mock error so we can determine from the
+		// response which cluster the request was routed to.
+		testingkubemock.WithGetPodError(
+			metav1.Status{
+				Status:  metav1.StatusFailure,
+				Message: "cluster b error",
+				Reason:  metav1.StatusReasonInternalError,
+				Code:    http.StatusInternalServerError,
+			},
+		),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { kubeMockB.Close() })
+
+	defaultRoleSpec := RoleSpec{
+		Name:       roleName,
+		KubeUsers:  roleKubeUsers,
+		KubeGroups: roleKubeGroups,
+	}
+
+	const clusterName = "root.example.com"
+
+	tests := []struct {
+		name string
+
+		roleSpec               RoleSpec
+		assert                 func(t *testing.T, restConfig *rest.Config)
+		genKubeCertificateOpts []GenTestKubeClientTLSCertOptions
+	}{
+		{
+			name:     "successful path routing to multiple clusters",
+			roleSpec: defaultRoleSpec,
+			assert: func(t *testing.T, restConfig *rest.Config) {
+				clientB := pathRoutedKubeClient(t, restConfig, clusterName, "b")
+				_, err = clientB.CoreV1().Pods(metav1.NamespaceDefault).List(context.Background(), metav1.ListOptions{})
+				require.NoError(t, err)
+
+				clientA := pathRoutedKubeClient(t, restConfig, clusterName, "a")
+				_, err := clientA.CoreV1().Pods(metav1.NamespaceDefault).List(context.Background(), metav1.ListOptions{})
+				require.NoError(t, err)
+
+			},
+		},
+		{
+			name:     "cannot access nonexistent cluster",
+			roleSpec: defaultRoleSpec,
+			assert: func(t *testing.T, restConfig *rest.Config) {
+				client := pathRoutedKubeClient(t, restConfig, clusterName, "c")
+				_, err = client.CoreV1().Pods(metav1.NamespaceDefault).List(context.Background(), metav1.ListOptions{})
+				require.ErrorContains(t, err, "not found")
+			},
+		},
+		{
+			name: "cannot access cluster denied by roles",
+			roleSpec: RoleSpec{
+				Name:       roleName,
+				KubeUsers:  roleKubeUsers,
+				KubeGroups: roleKubeGroups,
+				SetupRoleFunc: func(r types.Role) {
+					r.SetKubeResources(types.Deny, []types.KubernetesResource{{Kind: types.KindKubePod, Name: types.Wildcard, Namespace: types.Wildcard, Verbs: []string{types.Wildcard}}})
+				},
+			},
+			assert: func(t *testing.T, restConfig *rest.Config) {
+				client := pathRoutedKubeClient(t, restConfig, clusterName, "a")
+				_, err = client.CoreV1().Pods(metav1.NamespaceDefault).List(context.Background(), metav1.ListOptions{})
+				require.ErrorContains(t, err, "cannot list resource")
+			},
+		},
+		{
+			name:     "path route cannot override identity",
+			roleSpec: defaultRoleSpec,
+			genKubeCertificateOpts: []GenTestKubeClientTLSCertOptions{
+				WithIdentityRoute(clusterName, "a"),
+			},
+			assert: func(t *testing.T, restConfig *rest.Config) {
+				client := pathRoutedKubeClient(t, restConfig, clusterName, "b")
+				_, err = client.CoreV1().Pods(metav1.NamespaceDefault).Get(context.Background(), "foo", metav1.GetOptions{})
+				require.ErrorContains(t, err, "existing route in identity may not be overwritten")
+			},
+		},
+		{
+			name: "access is denied with per-session MFA enabled and no verification flag",
+			roleSpec: RoleSpec{
+				Name:       roleName,
+				KubeUsers:  roleKubeUsers,
+				KubeGroups: roleKubeGroups,
+				SetupRoleFunc: func(r types.Role) {
+					r.SetKubeResources(types.Allow, []types.KubernetesResource{{Kind: types.KindKubePod, Name: types.Wildcard, Namespace: types.Wildcard, Verbs: []string{types.Wildcard}}})
+					r.SetOptions(types.RoleOptions{
+						RequireMFAType: types.RequireMFAType_SESSION,
+					})
+				},
+			},
+			genKubeCertificateOpts: []GenTestKubeClientTLSCertOptions{
+				WithIdentityRoute("", ""),
+			},
+			assert: func(t *testing.T, restConfig *rest.Config) {
+				client := pathRoutedKubeClient(t, restConfig, clusterName, "a")
+				_, err = client.CoreV1().Pods(metav1.NamespaceDefault).Get(context.Background(), "foo", metav1.GetOptions{})
+				require.ErrorContains(t, err, "kubernetes cluster \"a\" not found")
+			},
+		},
+		{
+			name: "requires routing parameters when per-session MFA is enabled",
+			roleSpec: RoleSpec{
+				Name:       roleName,
+				KubeUsers:  roleKubeUsers,
+				KubeGroups: roleKubeGroups,
+				SetupRoleFunc: func(r types.Role) {
+					r.SetKubeResources(types.Allow, []types.KubernetesResource{{Kind: types.KindKubePod, Name: types.Wildcard, Namespace: types.Wildcard, Verbs: []string{types.Wildcard}}})
+					r.SetOptions(types.RoleOptions{
+						RequireMFAType: types.RequireMFAType_SESSION,
+					})
+				},
+			},
+			genKubeCertificateOpts: []GenTestKubeClientTLSCertOptions{
+				WithIdentityRoute("", ""),
+				WithMFAVerified(),
+			},
+			assert: func(t *testing.T, restConfig *rest.Config) {
+				// If a user somehow manages to get auth to issue an MFA cert
+				// with no routing parameters, we should refuse to route the
+				// request arbitrarily.
+
+				client := pathRoutedKubeClient(t, restConfig, clusterName, "a")
+				_, err = client.CoreV1().Pods(metav1.NamespaceDefault).Get(context.Background(), "foo", metav1.GetOptions{})
+				require.ErrorContains(t, err, "identity routing parameters are required")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testCtx := SetupTestContext(
+				context.Background(),
+				t,
+				TestConfig{
+					Clusters: []KubeClusterConfig{
+						{Name: "a", APIEndpoint: kubeMockA.URL},
+						{Name: "b", APIEndpoint: kubeMockB.URL},
+					},
+				},
+			)
+			t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
+
+			_, _ = testCtx.CreateUserAndRole(
+				testCtx.Context,
+				t,
+				username,
+				tt.roleSpec)
+
+			_, restConfig := testCtx.GenTestKubeClientTLSCert(
+				t,
+				username,
+				"",
+				tt.genKubeCertificateOpts...,
+			)
+
+			tt.assert(t, restConfig)
+		})
+	}
+
+}

--- a/lib/kube/proxy/utils_testing.go
+++ b/lib/kube/proxy/utils_testing.go
@@ -509,6 +509,23 @@ func WithResourceAccessRequests(r ...types.ResourceID) GenTestKubeClientTLSCertO
 	}
 }
 
+// WithIdentityRoute allows the user to reset the identity's RouteToCluster
+// and KubernetesCluster fields to empty strings. This is useful when the user
+// wants to test path routing.
+func WithIdentityRoute(routeToCluster, kubernetesCluster string) GenTestKubeClientTLSCertOptions {
+	return func(identity *tlsca.Identity) {
+		identity.RouteToCluster = routeToCluster
+		identity.KubernetesCluster = kubernetesCluster
+	}
+}
+
+// WithMFAVerified sets the MFAVerified identity field,
+func WithMFAVerified() GenTestKubeClientTLSCertOptions {
+	return func(i *tlsca.Identity) {
+		i.MFAVerified = "fake"
+	}
+}
+
 // GenTestKubeClientTLSCert generates a kube client to access kube service
 func (c *TestContext) GenTestKubeClientTLSCert(t *testing.T, userName, kubeCluster string, opts ...GenTestKubeClientTLSCertOptions) (*kubernetes.Clientset, *rest.Config) {
 	authServer := c.AuthServer


### PR DESCRIPTION
Backport of #50567 to branch/v17

---

This implements path-based routing for Kubernetes clusters as described by [RFD0185]. A new prefixed path handler is added that accepts base64-encoded Teleport and Kubernetes cluster names. The request is routed to the destination Teleport cluster using these parameters instead of those embedded in the session TLS identity, and then the preexisting handlers check authorization and complete the request as usual.

This removes the need for certificates to be issued per Kubernetes cluster: so long as the incoming identity is granted access to the cluster via its roles, access can succeed, and no `KubernetesCluster` attribute or cert usage restrictions are needed.

[RFD0185]: https://github.com/gravitational/teleport/pull/47436