### PR TITLE
docs: Instruct WSL device trust users to use tsh.exe

### DIFF
--- a/docs/pages/includes/device-trust/prereqs.mdx
+++ b/docs/pages/includes/device-trust/prereqs.mdx
@@ -9,7 +9,11 @@
   - A device with TPM 2.0.
   - A user with permissions to use the /dev/tpmrm0 device (typically done by
     assigning the `tss` group to the user).
-  - `tsh` v15.0.0 or newer. [Install tsh for Linux](../../installation.mdx#linux).
+  - The `tsh` client. [Install tsh for Linux](../../installation.mdx#linux).
+
+    WSL users should use the Windows binary instead.
+    [Download the Windows tsh installer](../../installation.mdx#windows-tsh-and-tctl-clients-only).
+
 - To authenticate a Web UI session you need [Teleport Connect](
   ../../connect-your-client/teleport-connect.mdx#installation--upgrade)
 - Correct end-user IP propagation to your Teleport deployment:


### PR DESCRIPTION
WSL doesn't have access to a TPM in the way the Linux tsh build wants, but the Windows Crypto APIs are available. Using tsh.exe inside WSL will work just fine for device trust.

#51497