### PR TITLE
[v16] Support sticky tooltips in FieldInput and legend in LabelsInput

### DIFF
--- a/web/packages/shared/components/FieldInput/FieldInput.tsx
+++ b/web/packages/shared/components/FieldInput/FieldInput.tsx
@@ -42,6 +42,7 @@ const FieldInput = forwardRef<HTMLInputElement, FieldInputProps>(
       inputMode = 'text',
       readonly = false,
       toolTipContent = null,
+      tooltipSticky = false,
       disabled = false,
       markAsError = false,
       ...styles
@@ -88,7 +89,7 @@ const FieldInput = forwardRef<HTMLInputElement, FieldInputProps>(
                   {labelText}
                   {labelTip && <LabelTip text={labelTip} />}
                 </span>
-                <ToolTipInfo children={toolTipContent} />
+                <ToolTipInfo sticky={tooltipSticky} children={toolTipContent} />
               </>
             ) : (
               <>
@@ -131,6 +132,7 @@ export type FieldInputProps = {
   min?: number;
   max?: number;
   toolTipContent?: React.ReactNode;
+  tooltipSticky?: boolean;
   disabled?: boolean;
   // markAsError is a flag to highlight an
   // input box as error color before validator

--- a/web/packages/teleport/src/components/LabelsInput/LabelsInput.story.tsx
+++ b/web/packages/teleport/src/components/LabelsInput/LabelsInput.story.tsx
@@ -60,6 +60,8 @@ export const Custom = () => {
       <LabelsInput
         labels={labels}
         setLabels={setLables}
+        legend="List of Labels"
+        tooltipContent="List of labels, 'nuff said"
         labelKey={{
           fieldName: 'Custom Key Name',
           placeholder: 'custom key placeholder',

--- a/web/packages/teleport/src/components/LabelsInput/LabelsInput.tsx
+++ b/web/packages/teleport/src/components/LabelsInput/LabelsInput.tsx
@@ -109,44 +109,40 @@ export function LabelsInput({
 
   const width = `${inputWidth}px`;
   return (
-    <Fieldset gap={labels.length > 0 ? 2 : 1}>
-      <Stack gap={1}>
-        {legend && (
-          <Legend>
-            {tooltipContent ? (
-              <>
-                <span
-                  css={{
-                    marginRight: '4px',
-                    verticalAlign: 'middle',
-                  }}
-                >
-                  {legend}
-                </span>
-                <ToolTipInfo children={tooltipContent} />
-              </>
-            ) : (
-              legend
-            )}
-          </Legend>
-        )}
-        {labels.length > 0 && (
-          <Flex>
-            <Box width={width} mr="3">
-              <Text typography="body2">
-                {labelKey.fieldName} (required field)
-              </Text>
-            </Box>
+    <Fieldset>
+      {legend && (
+        <Legend>
+          {tooltipContent ? (
+            <>
+              <span
+                css={{
+                  marginRight: '4px',
+                  verticalAlign: 'middle',
+                }}
+              >
+                {legend}
+              </span>
+              <ToolTipInfo children={tooltipContent} />
+            </>
+          ) : (
+            legend
+          )}
+        </Legend>
+      )}
+      {labels.length > 0 && (
+        <Flex mt={legend ? 1 : 0} mb={1}>
+          <Box width={width} mr="3">
             <Text typography="body2">
-              {labelVal.fieldName} (required field)
+              {labelKey.fieldName} (required field)
             </Text>
-          </Flex>
-        )}
-      </Stack>
-      <Stack gap={2}>
+          </Box>
+          <Text typography="body2">{labelVal.fieldName} (required field)</Text>
+        </Flex>
+      )}
+      <Box>
         {labels.map((label, index) => {
           return (
-            <Box key={index}>
+            <Box mb={2} key={index}>
               <Flex alignItems="center">
                 <FieldInput
                   Input
@@ -188,7 +184,7 @@ export function LabelsInput({
             </Box>
           );
         })}
-      </Stack>
+      </Box>
       <ButtonSecondary
         onClick={e => {
           e.preventDefault();
@@ -216,21 +212,14 @@ export function LabelsInput({
   );
 }
 
-const Stack = styled(Flex).attrs({
-  flexDirection: 'column',
-  alignItems: 'start',
-})``;
-
-const Fieldset = styled(Stack).attrs({
-  as: 'fieldset',
-})`
+const Fieldset = styled.fieldset`
   border: none;
   margin: 0;
   padding: 0;
 `;
 
 const Legend = styled.legend`
-  margin: 0;
+  margin: 0 0 ${props => props.theme.space[1]}px 0;
   padding: 0;
   ${props => props.theme.typography.body2}
 `;

--- a/web/packages/teleport/src/components/LabelsInput/LabelsInput.tsx
+++ b/web/packages/teleport/src/components/LabelsInput/LabelsInput.tsx
@@ -18,9 +18,10 @@
 
 import styled from 'styled-components';
 
-import { Box, ButtonIcon, ButtonSecondary, Flex } from 'design';
+import { Box, ButtonIcon, ButtonSecondary, Flex, Text } from 'design';
 import * as Icons from 'design/Icon';
 import FieldInput from 'shared/components/FieldInput';
+import { ToolTipInfo } from 'shared/components/ToolTip';
 import { useValidation, Validator } from 'shared/components/Validation';
 import { requiredField } from 'shared/components/Validation/rules';
 
@@ -35,6 +36,8 @@ export type LabelInputTexts = {
 };
 
 export function LabelsInput({
+  legend,
+  tooltipContent,
   labels = [],
   setLabels,
   disableBtns = false,
@@ -45,6 +48,8 @@ export function LabelsInput({
   labelVal = { fieldName: 'Value', placeholder: 'label value' },
   inputWidth = 200,
 }: {
+  legend?: string;
+  tooltipContent?: string;
   labels: Label[];
   setLabels(l: Label[]): void;
   disableBtns?: boolean;
@@ -104,21 +109,44 @@ export function LabelsInput({
 
   const width = `${inputWidth}px`;
   return (
-    <>
-      {labels.length > 0 && (
-        <Flex mt={2}>
-          <Box width={width} mr="3">
-            {labelKey.fieldName} <SmallText>(required field)</SmallText>
-          </Box>
-          <Box>
-            {labelVal.fieldName} <SmallText>(required field)</SmallText>
-          </Box>
-        </Flex>
-      )}
-      <Box>
+    <Fieldset gap={labels.length > 0 ? 2 : 1}>
+      <Stack gap={1}>
+        {legend && (
+          <Legend>
+            {tooltipContent ? (
+              <>
+                <span
+                  css={{
+                    marginRight: '4px',
+                    verticalAlign: 'middle',
+                  }}
+                >
+                  {legend}
+                </span>
+                <ToolTipInfo children={tooltipContent} />
+              </>
+            ) : (
+              legend
+            )}
+          </Legend>
+        )}
+        {labels.length > 0 && (
+          <Flex>
+            <Box width={width} mr="3">
+              <Text typography="body2">
+                {labelKey.fieldName} (required field)
+              </Text>
+            </Box>
+            <Text typography="body2">
+              {labelVal.fieldName} (required field)
+            </Text>
+          </Flex>
+        )}
+      </Stack>
+      <Stack gap={2}>
         {labels.map((label, index) => {
           return (
-            <Box mb={2} key={index}>
+            <Box key={index}>
               <Flex alignItems="center">
                 <FieldInput
                   Input
@@ -160,7 +188,7 @@ export function LabelsInput({
             </Box>
           );
         })}
-      </Box>
+      </Stack>
       <ButtonSecondary
         onClick={e => {
           e.preventDefault();
@@ -184,11 +212,25 @@ export function LabelsInput({
         <Icons.Add className="icon-add" disabled={disableBtns} size="small" />
         {labels.length > 0 ? `Add another ${adjective}` : `Add a ${adjective}`}
       </ButtonSecondary>
-    </>
+    </Fieldset>
   );
 }
 
-const SmallText = styled.span`
-  font-size: ${p => p.theme.fontSizes[1]}px;
-  font-weight: lighter;
+const Stack = styled(Flex).attrs({
+  flexDirection: 'column',
+  alignItems: 'start',
+})``;
+
+const Fieldset = styled(Stack).attrs({
+  as: 'fieldset',
+})`
+  border: none;
+  margin: 0;
+  padding: 0;
+`;
+
+const Legend = styled.legend`
+  margin: 0;
+  padding: 0;
+  ${props => props.theme.typography.body2}
 `;


### PR DESCRIPTION
Backport #51457 to branch/v16

Both `FieldInput` and `LabelsInput` had to be manually resolved. Results verified on Storybook and the **New Bot** page.