### PR TITLE
[teleport-update] Allow teleport-update uninstall to succeed with non-packaged installs

### DIFF
--- a/lib/autoupdate/agent/installer.go
+++ b/lib/autoupdate/agent/installer.go
@@ -436,6 +436,7 @@ func emptyRevert(_ context.Context) bool {
 
 // LinkSystem links the system (package) version into LinkBinDir and CopyServiceFile.
 // LinkSystem returns ErrInvalid if LinkBinDir is not DefaultLinkDir.
+// This prevents namespaced installations in /opt/teleport from linking to the system package.
 // The revert function restores the previous linking.
 // See Installer interface for additional specs.
 func (li *LocalInstaller) LinkSystem(ctx context.Context) (revert func(context.Context) bool, err error) {

--- a/lib/autoupdate/agent/installer_test.go
+++ b/lib/autoupdate/agent/installer_test.go
@@ -259,7 +259,7 @@ func TestLocalInstaller_Link(t *testing.T) {
 			},
 			installFileMode: 0644,
 
-			errMatch: "no binaries",
+			errMatch: ErrNoBinaries.Error(),
 		},
 		{
 			name: "present with existing links",
@@ -395,13 +395,13 @@ func TestLocalInstaller_Link(t *testing.T) {
 			installFiles: []string{"README"},
 			installDirs:  []string{"bin"},
 
-			errMatch: "no binaries",
+			errMatch: ErrNoBinaries.Error(),
 		},
 		{
 			name:         "no bin directory",
 			installFiles: []string{"README"},
 
-			errMatch: "binary directory",
+			errMatch: ErrNoBinaries.Error(),
 		},
 	}
 
@@ -567,7 +567,7 @@ func TestLocalInstaller_TryLink(t *testing.T) {
 			},
 			installFileMode: 0644,
 
-			errMatch: "no binaries",
+			errMatch: ErrNoBinaries.Error(),
 		},
 		{
 			name: "present with existing links",
@@ -651,13 +651,13 @@ func TestLocalInstaller_TryLink(t *testing.T) {
 			installFiles: []string{"README"},
 			installDirs:  []string{"bin"},
 
-			errMatch: "no binaries",
+			errMatch: ErrNoBinaries.Error(),
 		},
 		{
 			name:         "no bin directory",
 			installFiles: []string{"README"},
 
-			errMatch: "binary directory",
+			errMatch: ErrNoBinaries.Error(),
 		},
 	}
 

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -227,6 +227,8 @@ var (
 	ErrNoBinaries = errors.New("no binaries available to link")
 	// ErrFilePresent is returned when a file is present.
 	ErrFilePresent = errors.New("file present")
+	// ErrInvalid is returned when an operation is invalid.
+	ErrInvalid = errors.New("invalid")
 )
 
 const (
@@ -348,7 +350,7 @@ func (u *Updater) Install(ctx context.Context, override OverrideConfig) error {
 	return trace.Wrap(u.notices(ctx))
 }
 
-// Remove removes everything created by the updater.
+// Remove removes everything created by the updater for the given namespace.
 // Before attempting this, Remove attempts to gracefully recover the system-packaged version of Teleport (if present).
 // This function is idempotent.
 func (u *Updater) Remove(ctx context.Context) error {
@@ -370,7 +372,8 @@ func (u *Updater) Remove(ctx context.Context) error {
 	}
 
 	revert, err := u.Installer.LinkSystem(ctx)
-	if errors.Is(err, ErrNoBinaries) {
+	if errors.Is(err, ErrNoBinaries) ||
+		errors.Is(err, ErrInvalid) {
 		u.Log.InfoContext(ctx, "Updater-managed installation of Teleport detected. Attempting to unlink and remove.")
 		ok, err := isActiveOrEnabled(ctx, u.Process)
 		if err != nil && !errors.Is(err, ErrNotSupported) {
@@ -445,7 +448,7 @@ func (u *Updater) Remove(ctx context.Context) error {
 		}
 		return trace.Wrap(err, "failed to start system package version of Teleport")
 	}
-	u.Log.InfoContext(ctx, "Auto-updating Teleport removed and replaced by Teleport packaged.", "version", active)
+	u.Log.InfoContext(ctx, "Auto-updating Teleport removed and replaced by Teleport package.", "version", active)
 	if err := u.Teardown(ctx); err != nil {
 		return trace.Wrap(err)
 	}
@@ -871,6 +874,8 @@ func (u *Updater) LinkPackage(ctx context.Context) error {
 	if err := u.Installer.TryLinkSystem(ctx); errors.Is(err, ErrLinked) {
 		u.Log.WarnContext(ctx, "Automatic updates is disabled, but a non-package version of Teleport is linked.", activeKey, active)
 		return nil
+	} else if errors.Is(err, ErrInvalid) {
+		return trace.Wrap(err)
 	} else if err != nil {
 		return trace.Wrap(err, "failed to link system package installation")
 	}


### PR DESCRIPTION
This PR allows `teleport-update uninstall` to remove a Teleport installation from `/opt/teleport/[name]` when no system package installation exists in `/opt/teleport/system`.

Currently, this fails with:
```
User Message: failed to link
        failed to find Teleport binary directory
                open /opt/teleport/system/bin: no such file or directory] teleport-update/main.go:212
```

This PR also prevents `teleport-update uninstall --install-suffix test`  from inadvertently linking `/opt/teleport/system` to `/opt/teleport/test/bin` (outside of `/usr/local/bin`).

---

The `teleport-update` binary will be used to enable, disable, and trigger automatic Teleport agent updates. The new auto-updates system manages a local installation of the cluster-specified version of Teleport stored in `/opt/teleport`.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/10289

