### PR TITLE
[vnet] refactor osconfig

### DIFF
--- a/lib/vnet/admin_process_darwin.go
+++ b/lib/vnet/admin_process_darwin.go
@@ -48,9 +48,15 @@ func RunDarwinAdminProcess(ctx context.Context, config daemon.Config) error {
 		return trace.Wrap(err)
 	}
 
+	osConfigProvider, err := newProfileOSConfigProvider(tunName, config.IPv6Prefix, config.DNSAddr, config.HomePath, config.ClientCred)
+	if err != nil {
+		return trace.Wrap(err, "creating profileOSConfigProvider")
+	}
+	osConfigurator := newOSConfigurator(osConfigProvider)
+
 	errCh := make(chan error)
 	go func() {
-		errCh <- trace.Wrap(osConfigurationLoop(ctx, tunName, config.IPv6Prefix, config.DNSAddr, config.HomePath, config.ClientCred))
+		errCh <- trace.Wrap(osConfigurator.runOSConfigurationLoop(ctx))
 	}()
 
 	// Stay alive until we get an error on errCh, indicating that the osConfig loop exited.
@@ -104,53 +110,4 @@ func createTUNDevice(ctx context.Context) (tun.Device, string, error) {
 		return nil, "", trace.Wrap(err, "getting TUN device name")
 	}
 	return dev, name, nil
-}
-
-// osConfigurationLoop will keep running until ctx is canceled or an unrecoverable error is encountered, in
-// order to keep the host OS configuration up to date.
-func osConfigurationLoop(ctx context.Context, tunName, ipv6Prefix, dnsAddr, homePath string, clientCred daemon.ClientCred) error {
-	osConfigurator, err := newOSConfigurator(tunName, ipv6Prefix, dnsAddr, homePath, clientCred)
-	if err != nil {
-		return trace.Wrap(err, "creating OS configurator")
-	}
-	defer func() {
-		if err := osConfigurator.close(); err != nil {
-			log.ErrorContext(ctx, "Error while closing OS configurator", "error", err)
-		}
-	}()
-
-	// Clean up any stale configuration left by a previous VNet instance that may have failed to clean up.
-	// This is necessary in case any stale /etc/resolver/<proxy address> entries are still present, we need to
-	// be able to reach the proxy in order to fetch the vnet_config.
-	if err := osConfigurator.deconfigureOS(ctx); err != nil {
-		return trace.Wrap(err, "cleaning up OS configuration on startup")
-	}
-
-	defer func() {
-		// Shutting down, deconfigure OS. Pass context.Background because ctx has likely been canceled
-		// already but we still need to clean up.
-		if err := osConfigurator.deconfigureOS(context.Background()); err != nil {
-			log.ErrorContext(ctx, "Error deconfiguring host OS before shutting down.", "error", err)
-		}
-	}()
-
-	if err := osConfigurator.updateOSConfiguration(ctx); err != nil {
-		return trace.Wrap(err, "applying initial OS configuration")
-	}
-
-	// Re-configure the host OS every 10 seconds. This will pick up any newly logged-in clusters by
-	// reading profiles from TELEPORT_HOME.
-	const osConfigurationInterval = 10 * time.Second
-	ticker := time.NewTicker(osConfigurationInterval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			if err := osConfigurator.updateOSConfiguration(ctx); err != nil {
-				return trace.Wrap(err, "updating OS configuration")
-			}
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-	}
 }

--- a/lib/vnet/osconfig.go
+++ b/lib/vnet/osconfig.go
@@ -14,25 +14,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-// TODO(nklaassen): refactor OS configuration so this file isn't
-// platform-specific.
-//go:build darwin
-// +build darwin
-
 package vnet
 
 import (
 	"context"
-	"net"
+	"time"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
-
-	"github.com/gravitational/teleport/api/profile"
-	"github.com/gravitational/teleport/api/utils"
-	"github.com/gravitational/teleport/lib/client"
-	"github.com/gravitational/teleport/lib/client/clientcache"
-	"github.com/gravitational/teleport/lib/vnet/daemon"
 )
 
 type osConfig struct {
@@ -44,182 +32,33 @@ type osConfig struct {
 	dnsZones   []string
 }
 
+func configureOS(ctx context.Context, osConfig *osConfig) error {
+	return trace.Wrap(platformConfigureOS(ctx, osConfig))
+}
+
+type targetOSConfigProvider interface {
+	targetOSConfig(context.Context) (*osConfig, error)
+}
+
 type osConfigurator struct {
-	clientStore        *client.Store
-	clientCache        *clientcache.Cache
-	clusterConfigCache *ClusterConfigCache
-	// daemonClientCred are the credentials of the process that contacted the daemon.
-	daemonClientCred daemon.ClientCred
-	tunName          string
-	tunIPv6          string
-	dnsAddr          string
-	homePath         string
-	tunIPv4          string
+	targetOSConfigProvider targetOSConfigProvider
 }
 
-func newOSConfigurator(tunName, ipv6Prefix, dnsAddr, homePath string, daemonClientCred daemon.ClientCred) (*osConfigurator, error) {
-	if homePath == "" {
-		// This runs as root so we need to be configured with the user's home path.
-		return nil, trace.BadParameter("homePath must be passed from unprivileged process")
+func newOSConfigurator(targetOSConfigProvider targetOSConfigProvider) *osConfigurator {
+	return &osConfigurator{
+		targetOSConfigProvider: targetOSConfigProvider,
 	}
-
-	// ipv6Prefix always looks like "fdxx:xxxx:xxxx::"
-	// Set the IPv6 address for the TUN to "fdxx:xxxx:xxxx::1", the first valid address in the range.
-	tunIPv6 := ipv6Prefix + "1"
-
-	configurator := &osConfigurator{
-		tunName:          tunName,
-		tunIPv6:          tunIPv6,
-		dnsAddr:          dnsAddr,
-		homePath:         homePath,
-		clientStore:      client.NewFSClientStore(homePath),
-		daemonClientCred: daemonClientCred,
-	}
-	configurator.clusterConfigCache = NewClusterConfigCache(clockwork.NewRealClock())
-
-	clientCache, err := clientcache.New(clientcache.Config{
-		NewClientFunc: configurator.getClient,
-		RetryWithReloginFunc: func(ctx context.Context, tc *client.TeleportClient, fn func() error, opts ...client.RetryWithReloginOption) error {
-			// osConfigurator is ran from a root process, so there's no way for it to relogin.
-			// Instead, osConfigurator depends on the user performing a relogin from another process.
-			return trace.Wrap(fn())
-		},
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	configurator.clientCache = clientCache
-
-	return configurator, nil
 }
 
-func (c *osConfigurator) close() error {
-	return trace.Wrap(c.clientCache.Clear())
-}
-
-// updateOSConfiguration reads tsh profiles out of [c.homePath]. For each profile, it reads the VNet
-// config of the root cluster and of each leaf cluster. Then it proceeds to update the OS based on
-// information from that config.
-//
-// For the duration of reading data from clusters, it drops the root privileges, only to regain them
-// before configuring the OS.
 func (c *osConfigurator) updateOSConfiguration(ctx context.Context) error {
-	var dnsZones []string
-	var cidrRanges []string
-
-	// Drop privileges to ensure that the user who spawned the daemon client has privileges necessary
-	// to access c.homePath that it sent when starting the daemon.
-	// Otherwise a client could make the daemon read a profile out of any directory.
-	if err := c.doWithDroppedRootPrivileges(ctx, func() error {
-		profileNames, err := profile.ListProfileNames(c.homePath)
-		if err != nil {
-			return trace.Wrap(err, "listing user profiles")
-		}
-		for _, profileName := range profileNames {
-			profileDNSZones, profileCIDRRanges := c.getDNSZonesAndCIDRRangesForProfile(ctx, profileName)
-			dnsZones = append(dnsZones, profileDNSZones...)
-			cidrRanges = append(cidrRanges, profileCIDRRanges...)
-		}
-		return nil
-	}); err != nil {
+	desiredOSConfig, err := c.targetOSConfigProvider.targetOSConfig(ctx)
+	if err != nil {
 		return trace.Wrap(err)
 	}
-
-	dnsZones = utils.Deduplicate(dnsZones)
-	cidrRanges = utils.Deduplicate(cidrRanges)
-
-	if c.tunIPv4 == "" && len(cidrRanges) > 0 {
-		// Choose an IPv4 address for the TUN interface from the CIDR range of one arbitrary currently
-		// logged-in cluster. Only one IPv4 address is needed.
-		if err := c.setTunIPv4FromCIDR(cidrRanges[0]); err != nil {
-			return trace.Wrap(err, "setting TUN IPv4 address")
-		}
+	if err := configureOS(ctx, desiredOSConfig); err != nil {
+		return trace.Wrap(err, "configuring OS")
 	}
-
-	err := configureOS(ctx, &osConfig{
-		tunName:    c.tunName,
-		tunIPv6:    c.tunIPv6,
-		tunIPv4:    c.tunIPv4,
-		dnsAddr:    c.dnsAddr,
-		dnsZones:   dnsZones,
-		cidrRanges: cidrRanges,
-	})
-	return trace.Wrap(err, "configuring OS")
-}
-
-// getDNSZonesAndCIDRRangesForProfile returns DNS zones and CIDR ranges for the root cluster and its
-// leaf clusters.
-//
-// It's important for this function to return any data it manages to collect. For example, if it
-// manages to grab DNS zones and CIDR ranges of the root cluster but it fails to list leaf clusters,
-// it should still return the zones and ranges of the root cluster. Hence the use of named return
-// values.
-func (c *osConfigurator) getDNSZonesAndCIDRRangesForProfile(ctx context.Context, profileName string) (dnsZones []string, cidrRanges []string) {
-	shouldClearCacheForRoot := true
-	defer func() {
-		if shouldClearCacheForRoot {
-			if err := c.clientCache.ClearForRoot(profileName); err != nil {
-				log.ErrorContext(ctx, "Error while clearing client cache", "profile", profileName, "error", err)
-			}
-		}
-	}()
-
-	rootClient, err := c.clientCache.Get(ctx, profileName, "" /*leafClusterName*/)
-	if err != nil {
-		log.WarnContext(ctx,
-			"Failed to get root cluster client from cache, profile may be expired, not configuring VNet for this cluster",
-			"profile", profileName, "error", err)
-
-		return
-	}
-	clusterConfig, err := c.clusterConfigCache.GetClusterConfig(ctx, rootClient)
-	if err != nil {
-		log.WarnContext(ctx,
-			"Failed to load VNet configuration, profile may be expired, not configuring VNet for this cluster",
-			"profile", profileName, "error", err)
-
-		return
-	}
-
-	dnsZones = append(dnsZones, clusterConfig.DNSZones...)
-	cidrRanges = append(cidrRanges, clusterConfig.IPv4CIDRRange)
-
-	leafClusters, err := getLeafClusters(ctx, rootClient)
-	if err != nil {
-		log.WarnContext(ctx,
-			"Failed to list leaf clusters, profile may be expired, not configuring VNet for leaf clusters of this cluster",
-			"profile", profileName, "error", err)
-
-		return
-	}
-
-	// getLeafClusters was the last call using the root client. Do not clear cache if any call to
-	// a leaf cluster fails – it might fail because of a problem with the leaf cluster, not because of
-	// an expired cert.
-	shouldClearCacheForRoot = false
-
-	for _, leafClusterName := range leafClusters {
-		clusterClient, err := c.clientCache.Get(ctx, profileName, leafClusterName)
-		if err != nil {
-			log.WarnContext(ctx,
-				"Failed to create leaf cluster client, not configuring VNet for this cluster",
-				"profile", profileName, "leaf_cluster", leafClusterName, "error", err)
-			continue
-		}
-
-		clusterConfig, err := c.clusterConfigCache.GetClusterConfig(ctx, clusterClient)
-		if err != nil {
-			log.WarnContext(ctx,
-				"Failed to load VNet configuration, not configuring VNet for this cluster",
-				"profile", profileName, "leaf_cluster", leafClusterName, "error", err)
-			continue
-		}
-
-		dnsZones = append(dnsZones, clusterConfig.DNSZones...)
-		cidrRanges = append(cidrRanges, clusterConfig.IPv4CIDRRange)
-	}
-
-	return
+	return nil
 }
 
 func (c *osConfigurator) deconfigureOS(ctx context.Context) error {
@@ -227,36 +66,41 @@ func (c *osConfigurator) deconfigureOS(ctx context.Context) error {
 	return trace.Wrap(configureOS(ctx, &osConfig{}))
 }
 
-func (c *osConfigurator) setTunIPv4FromCIDR(cidrRange string) error {
-	if c.tunIPv4 != "" {
-		return nil
+// osConfigurationLoop will keep running until ctx is canceled or an unrecoverable error is encountered, in
+// order to keep the host OS configuration up to date.
+func (c *osConfigurator) runOSConfigurationLoop(ctx context.Context) error {
+	// Clean up any stale configuration left by a previous VNet instance that
+	// may have failed to clean up. This is necessary in case any stale DNS
+	// configuration is still present, we need to make sure the proxy is
+	// reachable without hitting the VNet DNS resolver which is not ready yet.
+	if err := c.deconfigureOS(ctx); err != nil {
+		return trace.Wrap(err, "cleaning up OS configuration on startup")
 	}
 
-	_, ipnet, err := net.ParseCIDR(cidrRange)
-	if err != nil {
-		return trace.Wrap(err, "parsing CIDR %q", cidrRange)
+	if err := c.updateOSConfiguration(ctx); err != nil {
+		return trace.Wrap(err, "applying initial OS configuration")
 	}
 
-	// ipnet.IP is the network address, ending in 0s, like 100.64.0.0
-	// Add 1 to assign the TUN address, like 100.64.0.1
-	tunAddress := ipnet.IP
-	tunAddress[len(tunAddress)-1]++
-	c.tunIPv4 = tunAddress.String()
-	return nil
-}
+	defer func() {
+		// Shutting down, deconfigure OS. Pass context.Background because ctx has likely been canceled
+		// already but we still need to clean up.
+		if err := c.deconfigureOS(context.Background()); err != nil {
+			log.ErrorContext(ctx, "Error deconfiguring host OS before shutting down.", "error", err)
+		}
+	}()
 
-func (c *osConfigurator) getClient(ctx context.Context, profileName, leafClusterName string) (*client.TeleportClient, error) {
-	// This runs in the root process, so obviously we don't have access to the client cache in the user
-	// process. This loads cluster profiles and credentials from TELEPORT_HOME.
-	clientConfig := &client.Config{
-		ClientStore: c.clientStore,
+	// Re-configure the host OS every 10 seconds to pick up any newly logged-in
+	// clusters or updated DNS zones or CIDR ranges.
+	const osConfigurationInterval = 10 * time.Second
+	tick := time.Tick(osConfigurationInterval)
+	for {
+		select {
+		case <-tick:
+			if err := c.updateOSConfiguration(ctx); err != nil {
+				return trace.Wrap(err, "updating OS configuration")
+			}
+		case <-ctx.Done():
+			return trace.Wrap(ctx.Err(), "context canceled, shutting down os configuration loop")
+		}
 	}
-	if err := clientConfig.LoadProfile(c.clientStore, profileName); err != nil {
-		return nil, trace.Wrap(err, "loading client profile")
-	}
-	if leafClusterName != "" {
-		clientConfig.SiteName = leafClusterName
-	}
-	tc, err := client.NewClient(clientConfig)
-	return tc, trace.Wrap(err)
 }

--- a/lib/vnet/osconfig_windows.go
+++ b/lib/vnet/osconfig_windows.go
@@ -1,5 +1,5 @@
 // Teleport
-// Copyright (C) 2024 Gravitational, Inc.
+// Copyright (C) 2025 Gravitational, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -14,25 +14,18 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !darwin && !windows
-// +build !darwin,!windows
-
 package vnet
 
 import (
 	"context"
-	"runtime"
 
 	"github.com/gravitational/trace"
 )
 
-// ErrVnetNotImplemented is an error indicating that VNet is not implemented on the host OS.
-var ErrVnetNotImplemented = &trace.NotImplementedError{Message: "VNet is not implemented on " + runtime.GOOS}
-
-func runPlatformUserProcess(_ context.Context, _ *UserProcessConfig) (*ProcessManager, error) {
-	return nil, trace.Wrap(ErrVnetNotImplemented)
-}
-
+// platformConfigureOS configures the host OS according to cfg. It is safe to
+// call repeatedly, and it is meant to be called with an empty osConfig to
+// deconfigure anything necessary before exiting.
 func platformConfigureOS(ctx context.Context, cfg *osConfig) error {
-	return trace.Wrap(ErrVnetNotImplemented)
+	// TODO(nklaassen): implement platformConfigureOS for Windows.
+	return trace.NotImplemented("platformConfigureOS is not implemented on Windows")
 }

--- a/lib/vnet/profile_osconfig_provider_darwin.go
+++ b/lib/vnet/profile_osconfig_provider_darwin.go
@@ -55,17 +55,17 @@ func newProfileOSConfigProvider(tunName, ipv6Prefix, dnsAddr, homePath string, d
 		// This runs as root so we need to be configured with the user's home path.
 		return nil, trace.BadParameter("homePath must be passed from unprivileged process")
 	}
-
-	// ipv6Prefix always looks like "fdxx:xxxx:xxxx::"
-	// Set the IPv6 address for the TUN to "fdxx:xxxx:xxxx::1", the first valid address in the range.
-	tunIPv6 := ipv6Prefix + "1"
+	tunIP, err := tunIPv6ForPrefix(ipv6Prefix)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 
 	p := &profileOSConfigProvider{
 		clientStore:        client.NewFSClientStore(homePath),
 		clusterConfigCache: NewClusterConfigCache(clockwork.NewRealClock()),
 		daemonClientCred:   daemonClientCred,
 		tunName:            tunName,
-		tunIPv6:            tunIPv6,
+		tunIPv6:            tunIP,
 		dnsAddr:            dnsAddr,
 		homePath:           homePath,
 	}

--- a/lib/vnet/profile_osconfig_provider_darwin.go
+++ b/lib/vnet/profile_osconfig_provider_darwin.go
@@ -1,0 +1,278 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"context"
+	"net"
+	"os"
+	"sync/atomic"
+	"syscall"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport/api/profile"
+	"github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/client/clientcache"
+	"github.com/gravitational/teleport/lib/vnet/daemon"
+)
+
+// profileOSConfigProvider implements targetOSConfigProvider for the MacOS
+// daemon process. It reads all active profiles from the user's TELEPORT_HOME
+// and uses the user certs found there to dial to each cluster to find the
+// current vnet_config resource to compute the current target OS configuration.
+type profileOSConfigProvider struct {
+	clientStore        *client.Store
+	clientCache        *clientcache.Cache
+	clusterConfigCache *ClusterConfigCache
+	// daemonClientCred are the credentials of the process that contacted the daemon.
+	daemonClientCred daemon.ClientCred
+	tunName          string
+	tunIPv6          string
+	dnsAddr          string
+	homePath         string
+	tunIPv4          string
+}
+
+func newProfileOSConfigProvider(tunName, ipv6Prefix, dnsAddr, homePath string, daemonClientCred daemon.ClientCred) (*profileOSConfigProvider, error) {
+	if homePath == "" {
+		// This runs as root so we need to be configured with the user's home path.
+		return nil, trace.BadParameter("homePath must be passed from unprivileged process")
+	}
+
+	// ipv6Prefix always looks like "fdxx:xxxx:xxxx::"
+	// Set the IPv6 address for the TUN to "fdxx:xxxx:xxxx::1", the first valid address in the range.
+	tunIPv6 := ipv6Prefix + "1"
+
+	p := &profileOSConfigProvider{
+		clientStore:        client.NewFSClientStore(homePath),
+		clusterConfigCache: NewClusterConfigCache(clockwork.NewRealClock()),
+		daemonClientCred:   daemonClientCred,
+		tunName:            tunName,
+		tunIPv6:            tunIPv6,
+		dnsAddr:            dnsAddr,
+		homePath:           homePath,
+	}
+	clientCache, err := clientcache.New(clientcache.Config{
+		NewClientFunc: p.getClient,
+		RetryWithReloginFunc: func(ctx context.Context, tc *client.TeleportClient, fn func() error, opts ...client.RetryWithReloginOption) error {
+			// profileOSConfigProvider runs in the MacOS daemon process, there's no way for it to relogin.
+			// Instead, osConfigurator depends on the user performing a relogin from another process.
+			return trace.Wrap(fn())
+		},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	p.clientCache = clientCache
+	return p, nil
+}
+
+func (p *profileOSConfigProvider) targetOSConfig(ctx context.Context) (*osConfig, error) {
+	var (
+		dnsZones   []string
+		cidrRanges []string
+	)
+
+	// Drop privileges to ensure that the user who spawned the daemon client has privileges necessary
+	// to access p.homePath that it sent when starting the daemon.
+	// Otherwise a client could make the daemon read a profile out of any directory.
+	if err := doWithDroppedRootPrivileges(ctx, p.daemonClientCred, func() error {
+		profileNames, err := profile.ListProfileNames(p.homePath)
+		if err != nil {
+			return trace.Wrap(err, "listing user profiles")
+		}
+		for _, profileName := range profileNames {
+			profileDNSZones, profileCIDRRanges := p.getDNSZonesAndCIDRRangesForProfile(ctx, profileName)
+			dnsZones = append(dnsZones, profileDNSZones...)
+			cidrRanges = append(cidrRanges, profileCIDRRanges...)
+		}
+		return nil
+	}); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	dnsZones = utils.Deduplicate(dnsZones)
+	cidrRanges = utils.Deduplicate(cidrRanges)
+
+	if p.tunIPv4 == "" && len(cidrRanges) > 0 {
+		// Choose an IPv4 address for the TUN interface from the CIDR range of one arbitrary currently
+		// logged-in cluster. Only one IPv4 address is needed.
+		if err := p.setTunIPv4FromCIDR(cidrRanges[0]); err != nil {
+			return nil, trace.Wrap(err, "setting TUN IPv4 address")
+		}
+	}
+
+	return &osConfig{
+		tunName:    p.tunName,
+		tunIPv6:    p.tunIPv6,
+		tunIPv4:    p.tunIPv4,
+		dnsAddr:    p.dnsAddr,
+		dnsZones:   dnsZones,
+		cidrRanges: cidrRanges,
+	}, nil
+}
+
+// getDNSZonesAndCIDRRangesForProfile returns DNS zones and CIDR ranges for the root cluster and its
+// leaf clusters.
+//
+// It's important for this function to return any data it manages to collect. For example, if it
+// manages to grab DNS zones and CIDR ranges of the root cluster but it fails to list leaf clusters,
+// it should still return the zones and ranges of the root cluster. Hence the use of named return
+// values.
+func (p *profileOSConfigProvider) getDNSZonesAndCIDRRangesForProfile(ctx context.Context, profileName string) (dnsZones []string, cidrRanges []string) {
+	shouldClearCacheForRoot := true
+	defer func() {
+		if shouldClearCacheForRoot {
+			if err := p.clientCache.ClearForRoot(profileName); err != nil {
+				log.ErrorContext(ctx, "Error while clearing client cache", "profile", profileName, "error", err)
+			}
+		}
+	}()
+
+	rootClient, err := p.clientCache.Get(ctx, profileName, "" /*leafClusterName*/)
+	if err != nil {
+		log.WarnContext(ctx,
+			"Failed to get root cluster client from cache, profile may be expired, not configuring VNet for this cluster",
+			"profile", profileName, "error", err)
+
+		return
+	}
+	clusterConfig, err := p.clusterConfigCache.GetClusterConfig(ctx, rootClient)
+	if err != nil {
+		log.WarnContext(ctx,
+			"Failed to load VNet configuration, profile may be expired, not configuring VNet for this cluster",
+			"profile", profileName, "error", err)
+
+		return
+	}
+
+	dnsZones = append(dnsZones, clusterConfig.DNSZones...)
+	cidrRanges = append(cidrRanges, clusterConfig.IPv4CIDRRange)
+
+	leafClusters, err := getLeafClusters(ctx, rootClient)
+	if err != nil {
+		log.WarnContext(ctx,
+			"Failed to list leaf clusters, profile may be expired, not configuring VNet for leaf clusters of this cluster",
+			"profile", profileName, "error", err)
+
+		return
+	}
+
+	// getLeafClusters was the last call using the root client. Do not clear cache if any call to
+	// a leaf cluster fails – it might fail because of a problem with the leaf cluster, not because of
+	// an expired cert.
+	shouldClearCacheForRoot = false
+
+	for _, leafClusterName := range leafClusters {
+		clusterClient, err := p.clientCache.Get(ctx, profileName, leafClusterName)
+		if err != nil {
+			log.WarnContext(ctx,
+				"Failed to create leaf cluster client, not configuring VNet for this cluster",
+				"profile", profileName, "leaf_cluster", leafClusterName, "error", err)
+			continue
+		}
+
+		clusterConfig, err := p.clusterConfigCache.GetClusterConfig(ctx, clusterClient)
+		if err != nil {
+			log.WarnContext(ctx,
+				"Failed to load VNet configuration, not configuring VNet for this cluster",
+				"profile", profileName, "leaf_cluster", leafClusterName, "error", err)
+			continue
+		}
+
+		dnsZones = append(dnsZones, clusterConfig.DNSZones...)
+		cidrRanges = append(cidrRanges, clusterConfig.IPv4CIDRRange)
+	}
+
+	return
+}
+
+func (p *profileOSConfigProvider) setTunIPv4FromCIDR(cidrRange string) error {
+	if p.tunIPv4 != "" {
+		return nil
+	}
+
+	_, ipnet, err := net.ParseCIDR(cidrRange)
+	if err != nil {
+		return trace.Wrap(err, "parsing CIDR %q", cidrRange)
+	}
+
+	// ipnet.IP is the network address, ending in 0s, like 100.64.0.0
+	// Add 1 to assign the TUN address, like 100.64.0.1
+	tunAddress := ipnet.IP
+	tunAddress[len(tunAddress)-1]++
+	p.tunIPv4 = tunAddress.String()
+	return nil
+}
+
+func (p *profileOSConfigProvider) getClient(ctx context.Context, profileName, leafClusterName string) (*client.TeleportClient, error) {
+	// This runs in the root process, so obviously we don't have access to the client cache in the user
+	// process. This loads cluster profiles and credentials from TELEPORT_HOME.
+	clientConfig := &client.Config{
+		ClientStore: p.clientStore,
+	}
+	if err := clientConfig.LoadProfile(p.clientStore, profileName); err != nil {
+		return nil, trace.Wrap(err, "loading client profile")
+	}
+	if leafClusterName != "" {
+		clientConfig.SiteName = leafClusterName
+	}
+	tc, err := client.NewClient(clientConfig)
+	return tc, trace.Wrap(err)
+}
+
+var hasDroppedPrivileges atomic.Bool
+
+// doWithDroppedRootPrivileges drops the privileges of the current process to those of the client
+// process that called the VNet daemon.
+func doWithDroppedRootPrivileges(ctx context.Context, clientCred daemon.ClientCred, fn func() error) (err error) {
+	if !hasDroppedPrivileges.CompareAndSwap(false, true) {
+		// At the moment of writing, the VNet daemon wasn't expected to do multiple things in parallel
+		// with dropped privileges. If you run into this error, consider if employing a mutex is going
+		// to be enough or if a more elaborate refactoring is required.
+		return trace.CompareFailed("privileges are being temporarily dropped already")
+	}
+	defer hasDroppedPrivileges.Store(false)
+
+	rootEgid := os.Getegid()
+	rootEuid := os.Geteuid()
+
+	log.InfoContext(ctx, "Temporarily dropping root privileges.", "egid", clientCred.Egid, "euid", clientCred.Euid)
+
+	if err := syscall.Setegid(clientCred.Egid); err != nil {
+		panic(trace.Wrap(err, "setting egid"))
+	}
+	if err := syscall.Seteuid(clientCred.Euid); err != nil {
+		panic(trace.Wrap(err, "setting euid"))
+	}
+
+	defer func() {
+		if err := syscall.Seteuid(rootEuid); err != nil {
+			panic(trace.Wrap(err, "reverting euid"))
+		}
+		if err := syscall.Setegid(rootEgid); err != nil {
+			panic(trace.Wrap(err, "reverting egid"))
+		}
+
+		log.InfoContext(ctx, "Restored root privileges.", "egid", rootEgid, "euid", rootEuid)
+	}()
+
+	return trace.Wrap(fn())
+}

--- a/lib/vnet/unsupported_os.go
+++ b/lib/vnet/unsupported_os.go
@@ -47,6 +47,7 @@ var (
 		cidrRanges: nil,
 		dnsZones:   nil,
 	}
+	_ = tunIPv6ForPrefix
 	_ = newOSConfigurator
 	_ = (*osConfigurator).runOSConfigurationLoop
 )

--- a/lib/vnet/unsupported_os.go
+++ b/lib/vnet/unsupported_os.go
@@ -33,6 +33,20 @@ func runPlatformUserProcess(_ context.Context, _ *UserProcessConfig) (*ProcessMa
 	return nil, trace.Wrap(ErrVnetNotImplemented)
 }
 
-func platformConfigureOS(ctx context.Context, cfg *osConfig) error {
+func platformConfigureOS(_ context.Context, _ *osConfig) error {
 	return trace.Wrap(ErrVnetNotImplemented)
 }
+
+// Satisfy unused linter.
+var (
+	_ = osConfig{
+		tunName:    "",
+		tunIPv4:    "",
+		tunIPv6:    "",
+		dnsAddr:    "",
+		cidrRanges: nil,
+		dnsZones:   nil,
+	}
+	_ = newOSConfigurator
+	_ = (*osConfigurator).runOSConfigurationLoop
+)


### PR DESCRIPTION
Part of [RFD 195](https://github.com/gravitational/teleport/pull/50850).

This PR refactors VNet's OS configuration code.
There is now a `osConfigurator` struct that runs the OS configuration loop and calls out to a `targetOSConfigProvider` which determines the current target OS configuration.
This `targetOSConfigProvider` can be implemented for the MacOS daemon process by moving some of the existing code around. In a [following PR](https://github.com/gravitational/teleport/pull/51629) I will implement it for Windows which will call out to the user process to get the current target OS configuration.

This PR doesn't really change any of the logic that runs on MacOS, it just refactors things so that we can swap in a different implementation for Windows.

FYI, after I get the Windows code fully working, I plan to migrate the MacOS code to follow the new way Windows handles things, where the admin process handles all networking and calls out to the user process for everything that uses a Teleport client.
This will unify multiple codepaths and eliminate the profileOSConfigProvider added here.