### PR TITLE
[teleport-update] Add --overwrite flag to replace tarball installations

### DIFF
--- a/lib/autoupdate/agent/installer.go
+++ b/lib/autoupdate/agent/installer.go
@@ -413,7 +413,7 @@ func (li *LocalInstaller) List(ctx context.Context) (revs []Revision, err error)
 // Link the specified version into the system LinkBinDir and CopyServiceFile.
 // The revert function restores the previous linking.
 // See Installer interface for additional specs.
-func (li *LocalInstaller) Link(ctx context.Context, rev Revision) (revert func(context.Context) bool, err error) {
+func (li *LocalInstaller) Link(ctx context.Context, rev Revision, force bool) (revert func(context.Context) bool, err error) {
 	revert = func(context.Context) bool { return true }
 	versionDir, err := li.revisionDir(rev)
 	if err != nil {
@@ -422,6 +422,7 @@ func (li *LocalInstaller) Link(ctx context.Context, rev Revision) (revert func(c
 	revert, err = li.forceLinks(ctx,
 		filepath.Join(versionDir, "bin"),
 		filepath.Join(versionDir, serviceDir, serviceName),
+		force,
 	)
 	if err != nil {
 		return revert, trace.Wrap(err)
@@ -430,10 +431,11 @@ func (li *LocalInstaller) Link(ctx context.Context, rev Revision) (revert func(c
 }
 
 // LinkSystem links the system (package) version into LinkBinDir and CopyServiceFile.
+// LinkSystem returns ErrInvalid if LinkBinDir is not DefaultLinkDir.
 // The revert function restores the previous linking.
 // See Installer interface for additional specs.
 func (li *LocalInstaller) LinkSystem(ctx context.Context) (revert func(context.Context) bool, err error) {
-	revert, err = li.forceLinks(ctx, li.SystemBinDir, li.SystemServiceFile)
+	revert, err = li.forceLinks(ctx, li.SystemBinDir, li.SystemServiceFile, false)
 	return revert, trace.Wrap(err)
 }
 
@@ -453,6 +455,7 @@ func (li *LocalInstaller) TryLink(ctx context.Context, revision Revision) error 
 
 // TryLinkSystem links the system installation, but only in the case that
 // no installation of Teleport is already linked or partially linked.
+// TryLinkSystem returns ErrInvalid if LinkBinDir is not DefaultLinkDir.
 // See Installer interface for additional specs.
 func (li *LocalInstaller) TryLinkSystem(ctx context.Context) error {
 	return trace.Wrap(li.tryLinks(ctx, li.SystemBinDir, li.SystemServiceFile))
@@ -494,7 +497,7 @@ type smallFile struct {
 // forceLinks will revert any overridden links or files if it hits an error.
 // If successful, forceLinks may also be reverted after it returns by calling revert.
 // The revert function returns true if reverting succeeds.
-func (li *LocalInstaller) forceLinks(ctx context.Context, binDir, svcPath string) (revert func(context.Context) bool, err error) {
+func (li *LocalInstaller) forceLinks(ctx context.Context, binDir, svcPath string, force bool) (revert func(context.Context) bool, err error) {
 	// setup revert function
 	var (
 		revertLinks []symlink
@@ -562,7 +565,7 @@ func (li *LocalInstaller) forceLinks(ctx context.Context, binDir, svcPath string
 		if !exec {
 			continue
 		}
-		orig, err := forceLink(oldname, newname)
+		orig, err := forceLink(oldname, newname, force)
 		if err != nil && !errors.Is(err, os.ErrExist) {
 			return revert, trace.Wrap(err, "failed to create symlink for %s", entry.Name())
 		}
@@ -602,16 +605,18 @@ func (li *LocalInstaller) forceCopyService(dst, src string, n int64) (orig *smal
 }
 
 // forceLink attempts to create a symlink, atomically replacing an existing link if already present.
-// If a non-symlink file or directory exists in newname already, forceLink errors.
+// If a non-symlink file or directory exists in newname already, forceLink errors with ErrFilePresent.
 // If the link is already present with the desired oldname, forceLink returns os.ErrExist.
-func forceLink(oldname, newname string) (orig string, err error) {
+func forceLink(oldname, newname string, force bool) (orig string, err error) {
 	orig, err = os.Readlink(newname)
 	if errors.Is(err, os.ErrInvalid) ||
 		errors.Is(err, syscall.EINVAL) { // workaround missing ErrInvalid wrapper
-		// important: do not attempt to replace a non-linked install of Teleport
-		return "", trace.Errorf("refusing to replace file at %s", newname)
-	}
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		if force {
+			return "", trace.Wrap(renameio.Symlink(oldname, newname))
+		}
+		// important: do not attempt to replace a non-linked install of Teleport without force
+		return "", trace.Wrap(ErrFilePresent, "refusing to replace file at %s", newname)
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return "", trace.Wrap(err)
 	}
 	if orig == oldname {
@@ -796,14 +801,14 @@ func (li *LocalInstaller) tryLinks(ctx context.Context, binDir, svcPath string) 
 }
 
 // needsLink returns true when a symlink from oldname to newname needs to be created, or false if it exists.
-// If a non-symlink file or directory exists at newname, needsLink errors.
+// If a non-symlink file or directory exists at newname, needsLink errors with ErrFilePresent.
 // If a symlink to a different location exists, needsLink errors with ErrLinked.
 func needsLink(oldname, newname string) (ok bool, err error) {
 	orig, err := os.Readlink(newname)
 	if errors.Is(err, os.ErrInvalid) ||
 		errors.Is(err, syscall.EINVAL) { // workaround missing ErrInvalid wrapper
 		// important: do not attempt to replace a non-linked install of Teleport
-		return false, trace.Errorf("refusing to replace file at %s", newname)
+		return false, trace.Wrap(ErrFilePresent, "refusing to replace file at %s", newname)
 	}
 	if errors.Is(err, os.ErrNotExist) {
 		return true, nil

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -323,7 +323,8 @@ func (u *Updater) Install(ctx context.Context, override OverrideConfig) error {
 
 	if err := u.update(ctx, cfg, target, override.AllowOverwrite); err != nil {
 		if errors.Is(err, ErrFilePresent) && !override.AllowOverwrite {
-			u.Log.WarnContext(ctx, "Use --overwrite to force removal of existing binaries.")
+			u.Log.WarnContext(ctx, "Use --overwrite to force removal of existing binaries installed via script.")
+			u.Log.WarnContext(ctx, "If a teleport rpm or deb package is installed, upgrade it to the latest version and retry. DO NOT USE --overwrite.")
 		}
 		return trace.Wrap(err)
 	}

--- a/lib/autoupdate/agent/updater_test.go
+++ b/lib/autoupdate/agent/updater_test.go
@@ -618,7 +618,7 @@ func TestUpdater_Update(t *testing.T) {
 					installedBaseURL = baseURL
 					return tt.installErr
 				},
-				FuncLink: func(_ context.Context, rev Revision) (revert func(context.Context) bool, err error) {
+				FuncLink: func(_ context.Context, rev Revision, force bool) (revert func(context.Context) bool, err error) {
 					linkedRevision = rev
 					return func(_ context.Context) bool {
 						revertFuncCalls++
@@ -1388,7 +1388,7 @@ func TestUpdater_Install(t *testing.T) {
 					installedBaseURL = baseURL
 					return tt.installErr
 				},
-				FuncLink: func(_ context.Context, rev Revision) (revert func(context.Context) bool, err error) {
+				FuncLink: func(_ context.Context, rev Revision, force bool) (revert func(context.Context) bool, err error) {
 					linkedRevision = rev
 					return func(_ context.Context) bool {
 						revertFuncCalls++
@@ -1464,7 +1464,7 @@ func blankTestAddr(s []byte) []byte {
 type testInstaller struct {
 	FuncInstall       func(ctx context.Context, rev Revision, baseURL string) error
 	FuncRemove        func(ctx context.Context, rev Revision) error
-	FuncLink          func(ctx context.Context, rev Revision) (revert func(context.Context) bool, err error)
+	FuncLink          func(ctx context.Context, rev Revision, force bool) (revert func(context.Context) bool, err error)
 	FuncLinkSystem    func(ctx context.Context) (revert func(context.Context) bool, err error)
 	FuncTryLink       func(ctx context.Context, rev Revision) error
 	FuncTryLinkSystem func(ctx context.Context) error
@@ -1481,8 +1481,8 @@ func (ti *testInstaller) Remove(ctx context.Context, rev Revision) error {
 	return ti.FuncRemove(ctx, rev)
 }
 
-func (ti *testInstaller) Link(ctx context.Context, rev Revision) (revert func(context.Context) bool, err error) {
-	return ti.FuncLink(ctx, rev)
+func (ti *testInstaller) Link(ctx context.Context, rev Revision, force bool) (revert func(context.Context) bool, err error) {
+	return ti.FuncLink(ctx, rev, force)
 }
 
 func (ti *testInstaller) LinkSystem(ctx context.Context) (revert func(context.Context) bool, err error) {

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -115,6 +115,8 @@ func Run(args []string) int {
 		Short('g').Envar(updateGroupEnvVar).StringVar(&ccfg.Group)
 	enableCmd.Flag("base-url", "Base URL used to override the Teleport download URL.").
 		Short('b').Envar(common.BaseURLEnvVar).StringVar(&ccfg.BaseURL)
+	enableCmd.Flag("overwrite", "Allow existing installed Teleport binaries to be overwritten.").
+		Short('o').BoolVar(&ccfg.AllowOverwrite)
 	enableCmd.Flag("force-version", "Force the provided version instead of using the version provided by the Teleport cluster.").
 		Short('f').Envar(updateVersionEnvVar).Hidden().StringVar(&ccfg.ForceVersion)
 	enableCmd.Flag("self-setup", "Use the current teleport-update binary to create systemd service config for auto-updates.").


### PR DESCRIPTION
This PR allows `teleport-update enable` to remove an existing tarball-based installation of Teleport by overwriting it with symlinks to the auto-updating version.

If an existing tarball-based (non deb/rpm)  installation already exists, `teleport-update enable` will output a clear error that suggests using `--overwrite`.

Notably, if `teleport-update enable --overwrite` fails to restart Teleport successfully, it will not be able to revert the installation.

---

The `teleport-update` binary will be used to enable, disable, and trigger automatic Teleport agent updates. The new auto-updates system manages a local installation of the cluster-specified version of Teleport stored in `/opt/teleport`.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/10289

