### PR TITLE
Adding VM location and principals identities

### DIFF
--- a/lib/msgraph/models.go
+++ b/lib/msgraph/models.go
@@ -33,6 +33,12 @@ type DirectoryObject struct {
 	DisplayName *string `json:"displayName,omitempty"`
 }
 
+type ObjectIdentity struct {
+	SignInType       *string `json:"signInType,omitempty"`
+	Issuer           *string `json:"issuer,omitempty"`
+	IssuerAssignedId *string `json:"issuerAssignedId,omitempty"`
+}
+
 type Group struct {
 	DirectoryObject
 	// GroupTypes is a list of group type strings.
@@ -56,11 +62,12 @@ func (g *Group) GetID() *string { return g.ID }
 type User struct {
 	DirectoryObject
 
-	Mail                     *string `json:"mail,omitempty"`
-	OnPremisesSAMAccountName *string `json:"onPremisesSamAccountName,omitempty"`
-	UserPrincipalName        *string `json:"userPrincipalName,omitempty"`
-	Surname                  *string `json:"surname,omitempty"`
-	GivenName                *string `json:"givenName,omitempty"`
+	Mail                     *string            `json:"mail,omitempty"`
+	OnPremisesSAMAccountName *string            `json:"onPremisesSamAccountName,omitempty"`
+	UserPrincipalName        *string            `json:"userPrincipalName,omitempty"`
+	Surname                  *string            `json:"surname,omitempty"`
+	GivenName                *string            `json:"givenName,omitempty"`
+	Identities               *[]*ObjectIdentity `json:"identities,omitempty"`
 }
 
 func (g *User) isGroupMember() {}

--- a/lib/srv/discovery/fetchers/azuresync/memberships.go
+++ b/lib/srv/discovery/fetchers/azuresync/memberships.go
@@ -28,10 +28,10 @@ import (
 	"github.com/gravitational/teleport/lib/msgraph"
 )
 
-const parallelism = 10 //nolint:unused // invoked in a dependent PR
+const parallelism = 10
 
 // expandMemberships adds membership data to AzurePrincipal objects by querying the Graph API for group memberships
-func expandMemberships(ctx context.Context, cli *msgraph.Client, principals []*accessgraphv1alpha.AzurePrincipal) ([]*accessgraphv1alpha.AzurePrincipal, error) { //nolint:unused // invoked in a dependent PR
+func expandMemberships(ctx context.Context, cli *msgraph.Client, principals []*accessgraphv1alpha.AzurePrincipal) ([]*accessgraphv1alpha.AzurePrincipal, error) {
 	// Map principals by ID
 	var principalsMap = make(map[string]*accessgraphv1alpha.AzurePrincipal)
 	for _, principal := range principals {

--- a/lib/srv/discovery/fetchers/azuresync/roleassignments.go
+++ b/lib/srv/discovery/fetchers/azuresync/roleassignments.go
@@ -35,7 +35,7 @@ type RoleAssignmentsClient interface {
 }
 
 // fetchRoleAssignments fetches Azure role assignments using the Azure role assignments API
-func fetchRoleAssignments(ctx context.Context, subscriptionID string, cli RoleAssignmentsClient) ([]*accessgraphv1alpha.AzureRoleAssignment, error) { //nolint:unused // invoked in a dependent PR
+func fetchRoleAssignments(ctx context.Context, subscriptionID string, cli RoleAssignmentsClient) ([]*accessgraphv1alpha.AzureRoleAssignment, error) {
 	// List the role definitions
 	roleAssigns, err := cli.ListRoleAssignments(ctx, fmt.Sprintf("/subscriptions/%s", subscriptionID))
 	if err != nil {

--- a/lib/srv/discovery/fetchers/azuresync/roledefinitions.go
+++ b/lib/srv/discovery/fetchers/azuresync/roledefinitions.go
@@ -35,7 +35,7 @@ type RoleDefinitionsClient interface {
 	ListRoleDefinitions(ctx context.Context, scope string) ([]*armauthorization.RoleDefinition, error)
 }
 
-func fetchRoleDefinitions(ctx context.Context, subscriptionID string, cli RoleDefinitionsClient) ([]*accessgraphv1alpha.AzureRoleDefinition, error) { //nolint:unused // used in a dependent PR
+func fetchRoleDefinitions(ctx context.Context, subscriptionID string, cli RoleDefinitionsClient) ([]*accessgraphv1alpha.AzureRoleDefinition, error) {
 	// List the role definitions
 	roleDefs, err := cli.ListRoleDefinitions(ctx, fmt.Sprintf("/subscriptions/%s", subscriptionID))
 	if err != nil {


### PR DESCRIPTION
Per https://github.com/gravitational/access-graph/issues/640, followup PR for the Azure integration to add VM location and tags, and Graph identities to the principals object.