### PR TITLE
Add database User Agent to session start usage event

### DIFF
--- a/lib/usagereporter/teleport/audit.go
+++ b/lib/usagereporter/teleport/audit.go
@@ -110,6 +110,7 @@ func ConvertAuditEvent(event apievents.AuditEvent) Anonymizable {
 				DbType:     e.DatabaseType,
 				DbProtocol: e.DatabaseProtocol,
 				DbOrigin:   e.DatabaseOrigin,
+				UserAgent:  e.UserAgent,
 			},
 			UserKind: prehogUserKindFromEventKind(e.UserKind),
 		}

--- a/lib/usagereporter/teleport/audit_test.go
+++ b/lib/usagereporter/teleport/audit_test.go
@@ -238,6 +238,45 @@ func TestConvertAuditEvent(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "DatabaseSessionStart",
+			event: &apievents.DatabaseSessionStart{
+				UserMetadata: apievents.UserMetadata{User: "alice"},
+				DatabaseMetadata: apievents.DatabaseMetadata{
+					DatabaseService:  "postgres-local",
+					DatabaseProtocol: "postgres",
+					DatabaseName:     "postgres",
+					DatabaseUser:     "alice",
+					DatabaseType:     "self-hosted",
+					DatabaseOrigin:   "config-file",
+				},
+				ClientMetadata: apievents.ClientMetadata{UserAgent: "psql"},
+			},
+			expected: &SessionStartEvent{
+				SessionType: string(types.DatabaseSessionKind),
+				Database: &prehogv1a.SessionStartDatabaseMetadata{
+					DbType:     "self-hosted",
+					DbProtocol: "postgres",
+					DbOrigin:   "config-file",
+					UserAgent:  "psql",
+				},
+				UserName: "alice",
+			},
+			expectedAnonymized: &prehogv1a.SubmitEventRequest{
+				Event: &prehogv1a.SubmitEventRequest_SessionStartV2{
+					SessionStartV2: &prehogv1a.SessionStartEvent{
+						SessionType: string(types.DatabaseSessionKind),
+						Database: &prehogv1a.SessionStartDatabaseMetadata{
+							DbType:     "self-hosted",
+							DbProtocol: "postgres",
+							DbOrigin:   "config-file",
+							UserAgent:  "psql",
+						},
+						UserName: anonymizer.AnonymizeString("alice"),
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range cases {

--- a/lib/usagereporter/teleport/types.go
+++ b/lib/usagereporter/teleport/types.go
@@ -104,6 +104,7 @@ func (u *SessionStartEvent) Anonymize(a utils.Anonymizer) prehogv1a.SubmitEventR
 			DbType:     u.Database.DbType,
 			DbProtocol: u.Database.DbProtocol,
 			DbOrigin:   u.Database.DbOrigin,
+			UserAgent:  u.Database.UserAgent,
 		}
 	}
 	if u.Desktop != nil {


### PR DESCRIPTION
Adds the `ClientMetadata.UsageAgent` contents from database session start to PreHog database session start usage User agent property (https://github.com/gravitational/cloud/pull/11699).

The field is already being populated for PostgreSQL databases.