### PR TITLE
[v15] docs: Instruct WSL device trust users to use tsh.exe

### DIFF
--- a/docs/pages/includes/device-trust/prereqs.mdx
+++ b/docs/pages/includes/device-trust/prereqs.mdx
@@ -12,4 +12,4 @@
   - The `tsh` client. [Install tsh for Linux](../../installation.mdx#linux).
 
     WSL users should use the Windows binary instead.
-    [Download the Windows tsh installer](../../installation.mdx#windows-tsh-and-tctl-clients-only).
+    [Download the Windows tsh installer](../../installation.mdx#windows-tsh-client-only).

--- a/docs/pages/includes/device-trust/prereqs.mdx
+++ b/docs/pages/includes/device-trust/prereqs.mdx
@@ -9,4 +9,7 @@
   - A device with TPM 2.0.
   - A user with permissions to use the /dev/tpmrm0 device (typically done by
     assigning the `tss` group to the user).
-  - `tsh` v15.0.0 or newer. [Install tsh for Linux](../../installation.mdx#linux).
+  - The `tsh` client. [Install tsh for Linux](../../installation.mdx#linux).
+
+    WSL users should use the Windows binary instead.
+    [Download the Windows tsh installer](../../installation.mdx#windows-tsh-and-tctl-clients-only).


### PR DESCRIPTION
Backport #51551 to branch/v15.