### PR TITLE
Use updateRole only when roleDiffProps exist

### DIFF
--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditorAdapter.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditorAdapter.tsx
@@ -70,7 +70,7 @@ export function RoleEditorAdapter({
   }, [originalContent]);
 
   const onRoleUpdate = useCallback(
-    debounce(roleDiffProps.updateRoleDiff, 500),
+    debounce(role => roleDiffProps?.updateRoleDiff(role), 500),
     []
   );
 


### PR DESCRIPTION
Small fix after https://github.com/gravitational/teleport/pull/51483 went in. Fixes access a method when `roleDiffProps` aren't defined

![screenshot_2025-01-29_at_18 23 26](https://github.com/user-attachments/assets/da3134a3-de14-42ba-8029-3f63da3ee7d3)

will backport together with the rest