### PR TITLE
[teleport-update] Add proper healthcheck for agents

### DIFF
--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -334,6 +334,8 @@ func (s SystemdService) waitForReady(ctx context.Context, pid int, tickC <-chan 
 			}
 			if !equalOrZero(readiness.PID, pid) {
 				s.Log.ErrorContext(ctx, "Readiness PID response does not match PID file.", unitKey, s.ServiceName, "file_pid", pid, "ready_pid", readiness.PID)
+			} else {
+				s.Log.DebugContext(ctx, "PIDs are not mismatched.", unitKey, s.ServiceName, "file_pid", pid, "ready_pid", readiness.PID)
 			}
 			return ctx.Err()
 		case <-tickC:

--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -178,7 +178,7 @@ func (s SystemdService) monitorPID(ctx context.Context, initPID int, tickC <-cha
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	pidC := make(chan int)
-	g := &errgroup.Group{}
+	var g errgroup.Group
 	g.Go(func() error {
 		return tickFile(ctx, s.PIDPath, pidC, tickC)
 	})

--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -36,7 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/client/debug"
 )
 
-// PID monitoring consts
+// process monitoring consts
 const (
 	// monitorTimeout is the timeout for determining whether the process has started.
 	monitorTimeout = 1 * time.Minute

--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -121,7 +121,10 @@ func (s SystemdService) Reload(ctx context.Context) error {
 	if errors.Is(err, context.DeadlineExceeded) {
 		return trace.Errorf("timed out while waiting for process to start")
 	}
-	return trace.Wrap(err)
+	if err != nil { // already logged
+		return trace.Errorf("failed to monitor process")
+	}
+	return nil
 }
 
 // monitor for a started, healthy process.

--- a/lib/autoupdate/agent/process_test.go
+++ b/lib/autoupdate/agent/process_test.go
@@ -46,6 +46,7 @@ func TestWaitForStablePID(t *testing.T) {
 		maxCrashes int
 		findErrs   map[int]error
 
+		finalPID int
 		errored  bool
 		canceled bool
 	}{
@@ -55,6 +56,7 @@ func TestWaitForStablePID(t *testing.T) {
 			baseline:   1,
 			minStable:  1,
 			maxCrashes: 1,
+			finalPID:   2,
 		},
 		{
 			name: "zero stable",
@@ -66,6 +68,7 @@ func TestWaitForStablePID(t *testing.T) {
 			minStable:  1,
 			maxCrashes: 0,
 			errored:    true,
+			finalPID:   3,
 		},
 		{
 			name:       "no changes times out",
@@ -74,6 +77,7 @@ func TestWaitForStablePID(t *testing.T) {
 			minStable:  3,
 			maxCrashes: 2,
 			canceled:   true,
+			finalPID:   1,
 		},
 		{
 			name:       "baseline restart",
@@ -81,6 +85,7 @@ func TestWaitForStablePID(t *testing.T) {
 			baseline:   1,
 			minStable:  3,
 			maxCrashes: 2,
+			finalPID:   2,
 		},
 		{
 			name:       "one restart then stable",
@@ -88,6 +93,7 @@ func TestWaitForStablePID(t *testing.T) {
 			baseline:   1,
 			minStable:  3,
 			maxCrashes: 2,
+			finalPID:   2,
 		},
 		{
 			name:       "two restarts then stable",
@@ -95,6 +101,7 @@ func TestWaitForStablePID(t *testing.T) {
 			baseline:   1,
 			minStable:  3,
 			maxCrashes: 2,
+			finalPID:   3,
 		},
 		{
 			name:       "three restarts then stable",
@@ -102,6 +109,7 @@ func TestWaitForStablePID(t *testing.T) {
 			baseline:   1,
 			minStable:  3,
 			maxCrashes: 2,
+			finalPID:   4,
 		},
 		{
 			name:       "too many restarts excluding baseline",
@@ -110,6 +118,7 @@ func TestWaitForStablePID(t *testing.T) {
 			minStable:  3,
 			maxCrashes: 2,
 			errored:    true,
+			finalPID:   5,
 		},
 		{
 			name:       "too many restarts including baseline",
@@ -118,6 +127,7 @@ func TestWaitForStablePID(t *testing.T) {
 			minStable:  3,
 			maxCrashes: 2,
 			errored:    true,
+			finalPID:   4,
 		},
 		{
 			name:       "too many restarts slow",
@@ -126,6 +136,7 @@ func TestWaitForStablePID(t *testing.T) {
 			minStable:  3,
 			maxCrashes: 2,
 			errored:    true,
+			finalPID:   4,
 		},
 		{
 			name:       "too many restarts after stable",
@@ -133,6 +144,7 @@ func TestWaitForStablePID(t *testing.T) {
 			baseline:   0,
 			minStable:  3,
 			maxCrashes: 2,
+			finalPID:   3,
 		},
 		{
 			name:       "stable after too many restarts",
@@ -141,6 +153,7 @@ func TestWaitForStablePID(t *testing.T) {
 			minStable:  3,
 			maxCrashes: 2,
 			errored:    true,
+			finalPID:   4,
 		},
 		{
 			name:       "cancel",
@@ -149,6 +162,7 @@ func TestWaitForStablePID(t *testing.T) {
 			minStable:  3,
 			maxCrashes: 2,
 			canceled:   true,
+			finalPID:   1,
 		},
 		{
 			name:       "stale PID crash",
@@ -159,7 +173,8 @@ func TestWaitForStablePID(t *testing.T) {
 			findErrs: map[int]error{
 				2: os.ErrProcessDone,
 			},
-			errored: true,
+			errored:  true,
+			finalPID: 2,
 		},
 		{
 			name:       "stale PID but fixed",
@@ -170,6 +185,7 @@ func TestWaitForStablePID(t *testing.T) {
 			findErrs: map[int]error{
 				2: os.ErrProcessDone,
 			},
+			finalPID: 3,
 		},
 		{
 			name:       "error PID",
@@ -180,7 +196,8 @@ func TestWaitForStablePID(t *testing.T) {
 			findErrs: map[int]error{
 				2: errors.New("bad"),
 			},
-			errored: true,
+			errored:  true,
+			finalPID: 2,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -194,10 +211,11 @@ func TestWaitForStablePID(t *testing.T) {
 					ch <- tick
 				}
 			}()
-			err := svc.waitForStablePID(ctx, tt.minStable, tt.maxCrashes,
+			pid, err := svc.waitForStablePID(ctx, tt.minStable, tt.maxCrashes,
 				tt.baseline, ch, func(pid int) error {
 					return tt.findErrs[pid]
 				})
+			require.Equal(t, tt.finalPID, pid)
 			require.Equal(t, tt.canceled, errors.Is(err, context.Canceled))
 			if !tt.canceled {
 				require.Equal(t, tt.errored, err != nil)

--- a/lib/autoupdate/agent/process_test.go
+++ b/lib/autoupdate/agent/process_test.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net"
 	"os"
 	"path/filepath"
 	"testing"
@@ -291,84 +290,6 @@ func TestTickFile(t *testing.T) {
 			}()
 			err := tickFile(ctx, filePath, ch, tickC)
 			require.Equal(t, tt.errored, err != nil)
-		})
-	}
-}
-
-func TestWaitForSocketPresent(t *testing.T) {
-	t.Parallel()
-
-	for _, tt := range []struct {
-		name      string
-		timeout   time.Duration
-		canceled  bool
-		notSocket bool
-		exists    bool
-
-		matchErr string
-	}{
-		{
-			name:      "missing",
-			timeout:   0,
-			canceled:  false,
-			notSocket: false,
-			exists:    false,
-			matchErr:  os.ErrNotExist.Error(),
-		},
-		{
-			name:      "context timeout",
-			timeout:   10 * time.Second,
-			canceled:  true,
-			notSocket: false,
-			exists:    false,
-			matchErr:  context.Canceled.Error(),
-		},
-		{
-			name:      "not socket",
-			timeout:   0,
-			canceled:  false,
-			notSocket: true,
-			exists:    false,
-			matchErr:  "other file",
-		},
-		{
-			name:      "present",
-			timeout:   0,
-			canceled:  false,
-			notSocket: false,
-			exists:    true,
-		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			tmp := t.TempDir()
-			socketFile := filepath.Join(tmp, "socket")
-			svc := &SystemdService{
-				Log:        slog.Default(),
-				SocketPath: socketFile,
-			}
-			ctx := context.Background()
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
-			if tt.canceled {
-				cancel()
-			}
-			if tt.exists {
-				l, err := net.Listen("unix", socketFile)
-				t.Cleanup(func() { l.Close() })
-				require.NoError(t, err)
-			}
-			if tt.notSocket {
-				err := os.WriteFile(socketFile, []byte("test"), os.ModePerm)
-				require.NoError(t, err)
-			}
-			ch := make(chan time.Time, 1)
-			ch <- time.Time{}
-			err := svc.waitForSocketPresent(ctx, ch, tt.timeout)
-			if tt.matchErr == "" {
-				require.NoError(t, err)
-			} else {
-				require.ErrorContains(t, err, tt.matchErr)
-			}
 		})
 	}
 }

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/lib/autoupdate"
+	"github.com/gravitational/teleport/lib/client/debug"
 	libdefaults "github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/modules"
 	libutils "github.com/gravitational/teleport/lib/utils"
@@ -96,6 +97,7 @@ func NewLocalUpdater(cfg LocalUpdaterConfig, ns *Namespace) (*Updater, error) {
 		cfg.SystemDir = defaultSystemDir
 	}
 	validator := Validator{Log: cfg.Log}
+	debugClient := debug.NewClient(filepath.Join(ns.dataDir, debugSocketFileName))
 	return &Updater{
 		Log:                cfg.Log,
 		Pool:               certPool,
@@ -118,7 +120,7 @@ func NewLocalUpdater(cfg LocalUpdaterConfig, ns *Namespace) (*Updater, error) {
 		Process: &SystemdService{
 			ServiceName: filepath.Base(ns.serviceFile),
 			PIDPath:     ns.pidFile,
-			SocketPath:  filepath.Join(ns.dataDir, debugSocketFileName),
+			Ready:       debugClient,
 			Log:         cfg.Log,
 		},
 		Setup: func(ctx context.Context) error {

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -55,7 +55,9 @@ const (
 	// reservedFreeDisk is the minimum required free space left on disk during downloads.
 	// TODO(sclevine): This value is arbitrary and could be replaced by, e.g., min(1%, 200mb) in the future
 	//   to account for a range of disk sizes.
-	reservedFreeDisk = 10_000_000 // 10 MB
+	reservedFreeDisk = 10_000_000
+	// debugSocketFileName is the name of Teleport's debug socket in the data dir.
+	debugSocketFileName = "debug.sock" // 10 MB
 )
 
 // Log keys
@@ -116,6 +118,7 @@ func NewLocalUpdater(cfg LocalUpdaterConfig, ns *Namespace) (*Updater, error) {
 		Process: &SystemdService{
 			ServiceName: filepath.Base(ns.serviceFile),
 			PIDPath:     ns.pidFile,
+			SocketPath:  filepath.Join(ns.dataDir, debugSocketFileName),
 			Log:         cfg.Log,
 		},
 		Setup: func(ctx context.Context) error {

--- a/lib/client/debug/debug.go
+++ b/lib/client/debug/debug.go
@@ -146,6 +146,7 @@ func (c *Client) CollectProfile(ctx context.Context, profileName string, seconds
 // Readiness describes the readiness of the Teleport instance.
 type Readiness struct {
 	// Ready is true if the instance is ready.
+	// This field is only set by clients, based on status.
 	Ready bool `json:"-"`
 	// Status provides more detail about the readiness status.
 	Status string `json:"status"`

--- a/lib/client/debug/debug.go
+++ b/lib/client/debug/debug.go
@@ -139,14 +139,11 @@ func (c *Client) CollectProfile(ctx context.Context, profileName string, seconds
 	return result, nil
 }
 
+// GetReadiness returns true if the Teleport service is ready.
 func (c *Client) GetReadiness(ctx context.Context) (ready bool, msg string, err error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", "http://debug.sock/readyz", nil)
+	resp, err := c.do(ctx, http.MethodGet, url.URL{Path: "/readyz"}, nil)
 	if err != nil {
-		return false, "", trace.Wrap(err)
-	}
-	resp, err := c.clt.Do(req)
-	if err != nil {
-		return false, " ", err
+		return false, " ", trace.Wrap(err)
 	}
 	defer resp.Body.Close()
 	ready = resp.StatusCode == http.StatusOK

--- a/lib/client/debug/debug.go
+++ b/lib/client/debug/debug.go
@@ -146,11 +146,11 @@ func (c *Client) CollectProfile(ctx context.Context, profileName string, seconds
 func (c *Client) GetReadiness(ctx context.Context) (ready bool, msg string, err error) {
 	resp, err := c.do(ctx, http.MethodGet, url.URL{Path: "/readyz"}, nil)
 	if err != nil {
-		return false, " ", trace.Wrap(err)
+		return false, "", trace.Wrap(err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusNotFound {
-		return ready, "not found", trace.NotFound("readiness endpoint not found")
+		return ready, "", trace.NotFound("readiness endpoint not found")
 	}
 	ready = resp.StatusCode == http.StatusOK
 	var status struct {

--- a/lib/client/debug/debug.go
+++ b/lib/client/debug/debug.go
@@ -146,6 +146,7 @@ func (c *Client) GetReadiness(ctx context.Context) (ready bool, msg string, err 
 		return false, " ", trace.Wrap(err)
 	}
 	defer resp.Body.Close()
+
 	ready = resp.StatusCode == http.StatusOK
 	var status struct {
 		Status string `json:"status"`
@@ -153,6 +154,9 @@ func (c *Client) GetReadiness(ctx context.Context) (ready bool, msg string, err 
 	err = json.NewDecoder(resp.Body).Decode(&status)
 	if err != nil {
 		return ready, "", trace.Wrap(err)
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return ready, status.Status, trace.NotFound("readiness endpoint not found")
 	}
 	return ready, status.Status, nil
 }

--- a/lib/client/debug/debug.go
+++ b/lib/client/debug/debug.go
@@ -146,7 +146,9 @@ func (c *Client) GetReadiness(ctx context.Context) (ready bool, msg string, err 
 		return false, " ", trace.Wrap(err)
 	}
 	defer resp.Body.Close()
-
+	if resp.StatusCode == http.StatusNotFound {
+		return ready, "not found", trace.NotFound("readiness endpoint not found")
+	}
 	ready = resp.StatusCode == http.StatusOK
 	var status struct {
 		Status string `json:"status"`
@@ -154,9 +156,6 @@ func (c *Client) GetReadiness(ctx context.Context) (ready bool, msg string, err 
 	err = json.NewDecoder(resp.Body).Decode(&status)
 	if err != nil {
 		return ready, "", trace.Wrap(err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
-		return ready, status.Status, trace.NotFound("readiness endpoint not found")
 	}
 	return ready, status.Status, nil
 }

--- a/lib/client/debug/debug.go
+++ b/lib/client/debug/debug.go
@@ -61,6 +61,9 @@ func NewClient(socketPath string) *Client {
 					return d.DialContext(ctx, "unix", socketPath)
 				},
 			},
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return trace.Errorf("redirect via socket not allowed")
+			},
 		},
 	}
 }

--- a/lib/client/debug/debug_test.go
+++ b/lib/client/debug/debug_test.go
@@ -56,6 +56,30 @@ func TestSetLogLevel(t *testing.T) {
 	})
 }
 
+func TestGetReadiness(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Success", func(t *testing.T) {
+		socketPath, _ := newSocketMockService(t, http.StatusOK, []byte(`{"status": "OK"}`))
+		clt := NewClient(socketPath)
+
+		ready, msg, err := clt.GetReadiness(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "OK", msg)
+		require.True(t, ready)
+	})
+
+	t.Run("Failure", func(t *testing.T) {
+		socketPath, _ := newSocketMockService(t, http.StatusBadRequest, []byte(`{"status": "BAD"}`))
+		clt := NewClient(socketPath)
+
+		ready, msg, err := clt.GetReadiness(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "BAD", msg)
+		require.False(t, ready)
+	})
+}
+
 func TestCollectProfile(t *testing.T) {
 	ctx := context.Background()
 

--- a/lib/client/debug/debug_test.go
+++ b/lib/client/debug/debug_test.go
@@ -80,12 +80,12 @@ func TestGetReadiness(t *testing.T) {
 	})
 
 	t.Run("Not found", func(t *testing.T) {
-		socketPath, _ := newSocketMockService(t, http.StatusNotFound, []byte(`{"status": "MISSING"}`))
+		socketPath, _ := newSocketMockService(t, http.StatusNotFound, []byte(`404`))
 		clt := NewClient(socketPath)
 
 		ready, msg, err := clt.GetReadiness(ctx)
 		require.True(t, trace.IsNotFound(err))
-		require.Equal(t, "MISSING", msg)
+		require.Equal(t, "not found", msg)
 		require.False(t, ready)
 	})
 }

--- a/lib/client/debug/debug_test.go
+++ b/lib/client/debug/debug_test.go
@@ -60,57 +60,62 @@ func TestGetReadiness(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("Success", func(t *testing.T) {
-		socketPath, _ := newSocketMockService(t, http.StatusOK, []byte(`{"status": "OK"}`))
+		socketPath, _ := newSocketMockService(t, http.StatusOK, []byte(`{"status": "OK", "pid": 1234}`))
 		clt := NewClient(socketPath)
 
-		ready, msg, err := clt.GetReadiness(ctx)
+		out, err := clt.GetReadiness(ctx)
 		require.NoError(t, err)
-		require.Equal(t, "OK", msg)
-		require.True(t, ready)
+		require.Equal(t, "OK", out.Status)
+		require.True(t, out.Ready)
+		require.Equal(t, 1234, out.PID)
 	})
 
 	t.Run("Failure", func(t *testing.T) {
-		socketPath, _ := newSocketMockService(t, http.StatusBadRequest, []byte(`{"status": "BAD"}`))
+		socketPath, _ := newSocketMockService(t, http.StatusBadRequest, []byte(`{"status": "BAD", "pid": 1234}`))
 		clt := NewClient(socketPath)
 
-		ready, msg, err := clt.GetReadiness(ctx)
+		out, err := clt.GetReadiness(ctx)
 		require.NoError(t, err)
-		require.Equal(t, "BAD", msg)
-		require.False(t, ready)
+		require.Equal(t, "BAD", out.Status)
+		require.False(t, out.Ready)
+		require.Equal(t, 1234, out.PID)
 	})
 
 	t.Run("Not found", func(t *testing.T) {
 		socketPath, _ := newSocketMockService(t, http.StatusNotFound, []byte(`404`))
 		clt := NewClient(socketPath)
 
-		ready, msg, err := clt.GetReadiness(ctx)
+		out, err := clt.GetReadiness(ctx)
 		require.True(t, trace.IsNotFound(err))
-		require.Equal(t, "", msg)
-		require.False(t, ready)
+		require.Equal(t, "", out.Status)
+		require.False(t, out.Ready)
+		require.Equal(t, 0, out.PID)
 	})
 
 	t.Run("Closed", func(t *testing.T) {
-		socketPath, closeFn := newSocketMockService(t, http.StatusOK, []byte(`{"status": "OK"}`))
+		socketPath, closeFn := newSocketMockService(t, http.StatusOK, []byte(`{"status": "OK", "pid": 1234}`))
 		closeFn()
 		clt := NewClient(socketPath)
 
-		ready, msg, err := clt.GetReadiness(ctx)
+		out, err := clt.GetReadiness(ctx)
 		var netError net.Error
 		require.ErrorAs(t, err, &netError)
-		require.Equal(t, "", msg)
-		require.False(t, ready)
+		require.Equal(t, "", out.Status)
+		require.False(t, out.Ready)
+		require.Equal(t, 0, out.PID)
 	})
 
 	t.Run("Missing", func(t *testing.T) {
-		socketPath, _ := newSocketMockService(t, http.StatusOK, []byte(`{"status": "OK"}`))
+		socketPath, _ := newSocketMockService(t, http.StatusOK, []byte(`{"status": "OK", "pid": 1234}`))
 		err := os.RemoveAll(socketPath)
 		require.NoError(t, err)
 		clt := NewClient(socketPath)
 
-		ready, msg, err := clt.GetReadiness(ctx)
+		out, err := clt.GetReadiness(ctx)
 		require.ErrorIs(t, err, os.ErrNotExist)
-		require.Equal(t, "", msg)
-		require.False(t, ready)
+		require.Equal(t, "", out.Status)
+		require.False(t, out.Ready)
+		require.Equal(t, 0, out.PID)
 	})
 }
 

--- a/lib/client/debug/debug_test.go
+++ b/lib/client/debug/debug_test.go
@@ -78,6 +78,16 @@ func TestGetReadiness(t *testing.T) {
 		require.Equal(t, "BAD", msg)
 		require.False(t, ready)
 	})
+
+	t.Run("Not found", func(t *testing.T) {
+		socketPath, _ := newSocketMockService(t, http.StatusNotFound, []byte(`{"status": "MISSING"}`))
+		clt := NewClient(socketPath)
+
+		ready, msg, err := clt.GetReadiness(ctx)
+		require.True(t, trace.IsNotFound(err))
+		require.Equal(t, "MISSING", msg)
+		require.False(t, ready)
+	})
 }
 
 func TestCollectProfile(t *testing.T) {

--- a/lib/service/state.go
+++ b/lib/service/state.go
@@ -21,6 +21,7 @@ package service
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"sync"
 	"time"
 
@@ -181,20 +182,24 @@ func (f *processState) readinessHandler() http.HandlerFunc {
 		case stateDegraded:
 			roundtrip.ReplyJSON(w, http.StatusServiceUnavailable, map[string]any{
 				"status": "teleport is in a degraded state, check logs for details",
+				"pid":    os.Getpid(),
 			})
 		// 400
 		case stateRecovering:
 			roundtrip.ReplyJSON(w, http.StatusBadRequest, map[string]any{
 				"status": "teleport is recovering from a degraded state, check logs for details",
+				"pid":    os.Getpid(),
 			})
 		case stateStarting:
 			roundtrip.ReplyJSON(w, http.StatusBadRequest, map[string]any{
 				"status": "teleport is starting and hasn't joined the cluster yet",
+				"pid":    os.Getpid(),
 			})
 		// 200
 		case stateOK:
 			roundtrip.ReplyJSON(w, http.StatusOK, map[string]any{
 				"status": "ok",
+				"pid":    os.Getpid(),
 			})
 		}
 	}

--- a/lib/service/state.go
+++ b/lib/service/state.go
@@ -30,6 +30,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/client/debug"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/observability/metrics"
 )
@@ -180,26 +181,26 @@ func (f *processState) readinessHandler() http.HandlerFunc {
 		switch f.getState() {
 		// 503
 		case stateDegraded:
-			roundtrip.ReplyJSON(w, http.StatusServiceUnavailable, map[string]any{
-				"status": "teleport is in a degraded state, check logs for details",
-				"pid":    os.Getpid(),
+			roundtrip.ReplyJSON(w, http.StatusServiceUnavailable, debug.Readiness{
+				Status: "teleport is in a degraded state, check logs for details",
+				PID:    os.Getpid(),
 			})
 		// 400
 		case stateRecovering:
-			roundtrip.ReplyJSON(w, http.StatusBadRequest, map[string]any{
-				"status": "teleport is recovering from a degraded state, check logs for details",
-				"pid":    os.Getpid(),
+			roundtrip.ReplyJSON(w, http.StatusBadRequest, debug.Readiness{
+				Status: "teleport is recovering from a degraded state, check logs for details",
+				PID:    os.Getpid(),
 			})
 		case stateStarting:
-			roundtrip.ReplyJSON(w, http.StatusBadRequest, map[string]any{
-				"status": "teleport is starting and hasn't joined the cluster yet",
-				"pid":    os.Getpid(),
+			roundtrip.ReplyJSON(w, http.StatusBadRequest, debug.Readiness{
+				Status: "teleport is starting and hasn't joined the cluster yet",
+				PID:    os.Getpid(),
 			})
 		// 200
 		case stateOK:
-			roundtrip.ReplyJSON(w, http.StatusOK, map[string]any{
-				"status": "ok",
-				"pid":    os.Getpid(),
+			roundtrip.ReplyJSON(w, http.StatusOK, debug.Readiness{
+				Status: "ok",
+				PID:    os.Getpid(),
 			})
 		}
 	}


### PR DESCRIPTION
During testing, @hugoShaka found that the PID crash detection logic implemented in teleport-update does not catch various failure scenarios where Teleport will repeatedly attempt to reconnect without crashing due to a bug.

This PR adds a readiness check on Teleport's debug socket. @hugoShaka is working on a separate PR in parallel to prevent the readiness endpoint from being disabled.

Instead of monitoring the PID for 30 seconds, `teleport-update` now waits 60 seconds for the process to start, stabilize, and return 200 from /readyz. If the PID file is missing, socket is missing, or /readyz isn't implemented, the corresponding check is disabled with a warning.

 ---

The `teleport-update` binary will be used to enable, disable, and trigger automatic Teleport agent updates. The new auto-updates system manages a local installation of the cluster-specified version of Teleport stored in `/opt/teleport`.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/10289