### PR TITLE
Don't emit SSO failures to audit log for illegitimate requests

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -4175,7 +4175,14 @@ func (a *ServerWithRoles) CreateGithubAuthRequest(ctx context.Context, req types
 
 	githubReq, err := a.authServer.CreateGithubAuthRequest(ctx, req)
 	if err != nil {
-		emitSSOLoginFailureEvent(a.authServer.closeCtx, a.authServer.emitter, events.LoginMethodGithub, err, req.SSOTestFlow)
+		if trace.IsNotFound(err) {
+			// This flow is triggered via an unauthenticated endpoint, so it's not unusual to see
+			// attempts to hit this API with an invalid connector ID. These are not legitimate SSO
+			// attempts, so avoid cluttering the audit log with them.
+			a.authServer.logger.InfoContext(ctx, "rejecting invalid GitHub auth request", "connector", req.ConnectorID)
+		} else {
+			emitSSOLoginFailureEvent(a.authServer.closeCtx, a.authServer.emitter, events.LoginMethodGithub, err, req.SSOTestFlow)
+		}
 		return nil, trace.Wrap(err)
 	}
 


### PR DESCRIPTION
SSO flows are initiated via unauthenticated APIs, so it's not uncommon to see spam from security tools or malicious bots probing. If we can tell that these are not legitimate SSO attempts then we avoid emitting failures that clutter the audit log.

To test, run a command like this (note the invalid value for the `connector_id` query param):

```
curl 'https://proxy.example.com/v1/webapi/github/login/web?connector_id=xyzdoesnotexist&redirect_url=https:%2F%2Fproxy.example.com%2Fweb' \
  -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8' \
  -H 'Cookie: __Host-grv_csrf=789f3a84f7bb96f4ced9163da45933a82ce68cf9988a8d5a3814be1b06193caa; __Host-session=' 
```

Prior to this change, the audit log would show an SSO failed event. After the change we log the bad request but don't emit an audit event.