### PR TITLE
Always create debug socket and expose health endpoints

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -141,6 +141,10 @@ const (
 	// ComponentDiagnostic is a diagnostic service
 	ComponentDiagnostic = "diag"
 
+	// ComponentDiagnosticHealth is the health monitor used by the diagnostic
+	// and debug services.
+	ComponentDiagnosticHealth = "diag:health"
+
 	// ComponentDebug is the debug service, which exposes debugging
 	// configuration over a Unix socket.
 	ComponentDebug = "debug"

--- a/lib/service/diagnostic.go
+++ b/lib/service/diagnostic.go
@@ -1,0 +1,93 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package service
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/gravitational/roundtrip"
+	"github.com/gravitational/trace"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/srv/debug"
+)
+
+type diagnosticHandlerConfig struct {
+	enableMetrics    bool
+	enableProfiling  bool
+	enableHealth     bool
+	enableLogLeveler bool
+}
+
+func (process *TeleportProcess) newDiagnosticHandler(config diagnosticHandlerConfig, logger *slog.Logger) (http.Handler, error) {
+	if process.state == nil {
+		return nil, trace.BadParameter("teleport process state machine has not yet been initialized (this is a bug)")
+	}
+
+	mux := http.NewServeMux()
+
+	if config.enableMetrics {
+		mux.Handle("/metrics", process.newMetricsHandler())
+	}
+
+	if config.enableProfiling {
+		debug.RegisterProfilingHandlers(mux, logger)
+	}
+
+	if config.enableHealth {
+		mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+			roundtrip.ReplyJSON(w, http.StatusOK, map[string]any{"status": "ok"})
+		})
+		mux.HandleFunc("/readyz", process.state.readinessHandler())
+	}
+
+	if config.enableLogLeveler {
+		debug.RegisterLogLevelHandlers(mux, logger, process.Config)
+	}
+
+	return mux, nil
+}
+
+// newMetricsHandler creates a new metrics handler serving metrics both from the global prometheus registry and the
+// in-process one.
+func (process *TeleportProcess) newMetricsHandler() http.Handler {
+	// We gather metrics both from the in-process registry (preferred metrics registration method)
+	// and the global registry (used by some Teleport services and many dependencies).
+	gatherers := prometheus.Gatherers{
+		process.metricsRegistry,
+		prometheus.DefaultGatherer,
+	}
+
+	metricsHandler := promhttp.InstrumentMetricHandler(
+		process.metricsRegistry, promhttp.HandlerFor(gatherers, promhttp.HandlerOpts{
+			// Errors can happen if metrics are registered with identical names in both the local and the global registry.
+			// In this case, we log the error but continue collecting metrics. The first collected metric will win
+			// (the one from the local metrics registry takes precedence).
+			// As we move more things to the local registry, especially in other tools like tbot, we will have less
+			// conflicts in tests.
+			ErrorHandling: promhttp.ContinueOnError,
+			ErrorLog: promHTTPLogAdapter{
+				ctx:    process.ExitContext(),
+				Logger: process.logger.With(teleport.ComponentKey, teleport.ComponentMetrics),
+			},
+		}),
+	)
+	return metricsHandler
+}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -35,7 +35,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
-	"net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -51,11 +50,9 @@ import (
 	awssession "github.com/aws/aws-sdk-go/aws/session"
 	"github.com/google/renameio/v2"
 	"github.com/google/uuid"
-	"github.com/gravitational/roundtrip"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/quic-go/quic-go"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/attribute"
@@ -159,7 +156,6 @@ import (
 	alpncommon "github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 	"github.com/gravitational/teleport/lib/srv/app"
 	"github.com/gravitational/teleport/lib/srv/db"
-	"github.com/gravitational/teleport/lib/srv/debug"
 	"github.com/gravitational/teleport/lib/srv/desktop"
 	"github.com/gravitational/teleport/lib/srv/ingress"
 	"github.com/gravitational/teleport/lib/srv/regular"
@@ -3492,10 +3488,15 @@ func (l promHTTPLogAdapter) Println(v ...interface{}) {
 // initMetricsService starts the metrics service currently serving metrics for
 // prometheus consumption
 func (process *TeleportProcess) initMetricsService() error {
-	mux := http.NewServeMux()
-	mux.Handle("/metrics", process.newMetricsHandler())
-
 	logger := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentMetrics, process.id))
+
+	config := diagnosticHandlerConfig{
+		enableMetrics: true,
+	}
+	mux, err := process.newDiagnosticHandler(config, logger)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 
 	listener, err := process.importOrCreateListener(ListenerMetrics, process.Config.Metrics.ListenAddr.Addr)
 	if err != nil {
@@ -3578,33 +3579,6 @@ func (process *TeleportProcess) initMetricsService() error {
 	return nil
 }
 
-// newMetricsHandler creates a new metrics handler serving metrics both from the global prometheus registry and the
-// in-process one.
-func (process *TeleportProcess) newMetricsHandler() http.Handler {
-	// We gather metrics both from the in-process registry (preferred metrics registration method)
-	// and the global registry (used by some Teleport services and many dependencies).
-	gatherers := prometheus.Gatherers{
-		process.metricsRegistry,
-		prometheus.DefaultGatherer,
-	}
-
-	metricsHandler := promhttp.InstrumentMetricHandler(
-		process.metricsRegistry, promhttp.HandlerFor(gatherers, promhttp.HandlerOpts{
-			// Errors can happen if metrics are registered with identical names in both the local and the global registry.
-			// In this case, we log the error but continue collecting metrics. The first collected metric will win
-			// (the one from the local metrics registry takes precedence).
-			// As we move more things to the local registry, especially in other tools like tbot, we will have less
-			// conflicts in tests.
-			ErrorHandling: promhttp.ContinueOnError,
-			ErrorLog: promHTTPLogAdapter{
-				ctx:    process.ExitContext(),
-				Logger: process.logger.With(teleport.ComponentKey, teleport.ComponentMetrics),
-			},
-		}),
-	)
-	return metricsHandler
-}
-
 // newProcessStateMachine creates a state machine tracking the Teleport process
 // state. The state machine is then used by the diagnostics or the debug service
 // to evaluate the process health.
@@ -3643,46 +3617,22 @@ func (process *TeleportProcess) newProcessStateMachine() (*processState, error) 
 // initDiagnosticService starts diagnostic service currently serving healthz
 // and prometheus endpoints
 func (process *TeleportProcess) initDiagnosticService() error {
-	if process.state == nil {
-		return trace.BadParameter("teleport process state machine has not yet been initialized (this is a bug)")
-	}
 
 	logger := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentDiagnostic, process.id))
 
-	mux := http.NewServeMux()
-
-	// support legacy metrics collection in the diagnostic service.
-	// metrics will otherwise be served by the metrics service if it's enabled
-	// in the config.
-	if !process.Config.Metrics.Enabled {
-		mux.Handle("/metrics", process.newMetricsHandler())
+	config := diagnosticHandlerConfig{
+		// support legacy metrics collection in the diagnostic service.
+		// metrics will otherwise be served by the metrics service if it's enabled
+		// in the config.
+		enableMetrics:    !process.Config.Metrics.Enabled,
+		enableProfiling:  process.Config.Debug,
+		enableHealth:     true,
+		enableLogLeveler: false,
 	}
-
-	if process.Config.Debug {
-		process.logger.InfoContext(process.ExitContext(), "Adding diagnostic debugging handlers. To connect with profiler, use `go tool pprof <listen_address>`.", "listen_address", process.Config.DiagnosticAddr.Addr)
-
-		noWriteTimeout := func(h http.HandlerFunc) http.HandlerFunc {
-			return func(w http.ResponseWriter, r *http.Request) {
-				rc := http.NewResponseController(w) //nolint:bodyclose // bodyclose gets really confused about NewResponseController
-				if err := rc.SetWriteDeadline(time.Time{}); err == nil {
-					// don't let the pprof handlers know about the WriteTimeout
-					r = r.WithContext(context.WithValue(r.Context(), http.ServerContextKey, nil))
-				}
-				h(w, r)
-			}
-		}
-
-		mux.HandleFunc("/debug/pprof/", noWriteTimeout(pprof.Index))
-		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-		mux.HandleFunc("/debug/pprof/profile", noWriteTimeout(pprof.Profile))
-		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-		mux.HandleFunc("/debug/pprof/trace", noWriteTimeout(pprof.Trace))
+	mux, err := process.newDiagnosticHandler(config, logger)
+	if err != nil {
+		return trace.Wrap(err)
 	}
-
-	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-		roundtrip.ReplyJSON(w, http.StatusOK, map[string]any{"status": "ok"})
-	})
-	mux.HandleFunc("/readyz", process.state.readinessHandler())
 
 	listener, err := process.importOrCreateListener(ListenerDiagnostic, process.Config.DiagnosticAddr.Addr)
 	if err != nil {
@@ -3771,19 +3721,16 @@ func (process *TeleportProcess) initDebugService(exposeDebugRoutes bool) error {
 
 	// Users can disable the debug service for compliance reasons but not the health
 	// routes because the updater relies on them.
-	var mux *http.ServeMux
-	if exposeDebugRoutes {
-		mux = debug.NewServeMux(logger, process.Config)
-		mux.Handle("/metrics", process.newMetricsHandler())
-	} else {
-		mux = http.NewServeMux()
+	config := diagnosticHandlerConfig{
+		enableMetrics:    exposeDebugRoutes,
+		enableProfiling:  exposeDebugRoutes,
+		enableHealth:     true,
+		enableLogLeveler: exposeDebugRoutes,
 	}
-
-	// Add healthcheck routes.
-	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-		roundtrip.ReplyJSON(w, http.StatusOK, map[string]any{"status": "ok"})
-	})
-	mux.HandleFunc("/readyz", process.state.readinessHandler())
+	mux, err := process.newDiagnosticHandler(config, logger)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 
 	server := &http.Server{
 		Handler:           mux,

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -669,6 +669,9 @@ type TeleportProcess struct {
 	// Both the metricsRegistry and the default global registry are gathered by
 	// Telepeort's metric service.
 	metricsRegistry *prometheus.Registry
+
+	// state is the process state machine tracking if the process is healthy or not.
+	state *processState
 }
 
 // processIndex is an internal process index
@@ -1331,6 +1334,12 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 
 	serviceStarted := false
 
+	ps, err := process.newProcessStateMachine()
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to initialize process state machine")
+	}
+	process.state = ps
+
 	if !cfg.DiagnosticAddr.IsEmpty() {
 		if err := process.initDiagnosticService(); err != nil {
 			return nil, trace.Wrap(err)
@@ -1349,12 +1358,8 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 		process.initPyroscope(address)
 	}
 
-	if cfg.DebugService.Enabled {
-		if err := process.initDebugService(); err != nil {
-			return nil, trace.Wrap(err)
-		}
-	} else {
-		warnOnErr(process.ExitContext(), process.closeImportedDescriptors(teleport.ComponentDebug), process.logger)
+	if err := process.initDebugService(cfg.DebugService.Enabled); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	// Create a process wide key generator that will be shared. This is so the
@@ -3600,9 +3605,50 @@ func (process *TeleportProcess) newMetricsHandler() http.Handler {
 	return metricsHandler
 }
 
+// newProcessStateMachine creates a state machine tracking the Teleport process
+// state. The state machine is then used by the diagnostics or the debug service
+// to evaluate the process health.
+func (process *TeleportProcess) newProcessStateMachine() (*processState, error) {
+	logger := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentDiagnosticHealth, process.id))
+	// Create a state machine that will process and update the internal state of
+	// Teleport based off Events. Use this state machine to return the
+	// status from the /readyz endpoint.
+	ps, err := newProcessState(process)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	process.RegisterFunc("readyz.monitor", func() error {
+		// Start loop to monitor for events that are used to update Teleport state.
+		ctx, cancel := context.WithCancel(process.GracefulExitContext())
+		defer cancel()
+
+		eventCh := make(chan Event, 1024)
+		process.ListenForEvents(ctx, TeleportDegradedEvent, eventCh)
+		process.ListenForEvents(ctx, TeleportOKEvent, eventCh)
+
+		for {
+			select {
+			case e := <-eventCh:
+				ps.update(e)
+			case <-ctx.Done():
+				logger.DebugContext(process.ExitContext(), "Teleport is exiting, returning.")
+				return nil
+			}
+		}
+	})
+	return ps, nil
+}
+
 // initDiagnosticService starts diagnostic service currently serving healthz
 // and prometheus endpoints
 func (process *TeleportProcess) initDiagnosticService() error {
+	if process.state == nil {
+		return trace.BadParameter("teleport process state machine has not yet been initialized (this is a bug)")
+	}
+
+	logger := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentDiagnostic, process.id))
+
 	mux := http.NewServeMux()
 
 	// support legacy metrics collection in the diagnostic service.
@@ -3634,61 +3680,9 @@ func (process *TeleportProcess) initDiagnosticService() error {
 	}
 
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-		roundtrip.ReplyJSON(w, http.StatusOK, map[string]interface{}{"status": "ok"})
+		roundtrip.ReplyJSON(w, http.StatusOK, map[string]any{"status": "ok"})
 	})
-
-	logger := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentDiagnostic, process.id))
-
-	// Create a state machine that will process and update the internal state of
-	// Teleport based off Events. Use this state machine to return return the
-	// status from the /readyz endpoint.
-	ps, err := newProcessState(process)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	process.RegisterFunc("readyz.monitor", func() error {
-		// Start loop to monitor for events that are used to update Teleport state.
-		ctx, cancel := context.WithCancel(process.GracefulExitContext())
-		defer cancel()
-
-		eventCh := make(chan Event, 1024)
-		process.ListenForEvents(ctx, TeleportDegradedEvent, eventCh)
-		process.ListenForEvents(ctx, TeleportOKEvent, eventCh)
-
-		for {
-			select {
-			case e := <-eventCh:
-				ps.update(e)
-			case <-ctx.Done():
-				logger.DebugContext(process.ExitContext(), "Teleport is exiting, returning.")
-				return nil
-			}
-		}
-	})
-	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
-		switch ps.getState() {
-		// 503
-		case stateDegraded:
-			roundtrip.ReplyJSON(w, http.StatusServiceUnavailable, map[string]interface{}{
-				"status": "teleport is in a degraded state, check logs for details",
-			})
-		// 400
-		case stateRecovering:
-			roundtrip.ReplyJSON(w, http.StatusBadRequest, map[string]interface{}{
-				"status": "teleport is recovering from a degraded state, check logs for details",
-			})
-		case stateStarting:
-			roundtrip.ReplyJSON(w, http.StatusBadRequest, map[string]interface{}{
-				"status": "teleport is starting and hasn't joined the cluster yet",
-			})
-		// 200
-		case stateOK:
-			roundtrip.ReplyJSON(w, http.StatusOK, map[string]interface{}{
-				"status": "ok",
-			})
-		}
-	})
+	mux.HandleFunc("/readyz", process.state.readinessHandler())
 
 	listener, err := process.importOrCreateListener(ListenerDiagnostic, process.Config.DiagnosticAddr.Addr)
 	if err != nil {
@@ -3748,17 +3742,51 @@ func (process *TeleportProcess) initDiagnosticService() error {
 }
 
 // initDebugService starts debug service serving endpoints used for
-// troubleshooting the instance.
-func (process *TeleportProcess) initDebugService() error {
-	logger := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentDebug, process.id))
-
-	listener, err := process.importOrCreateListener(ListenerDebug, filepath.Join(process.Config.DataDir, teleport.DebugServiceSocketName))
-	if err != nil {
-		return trace.Wrap(err)
+// troubleshooting the instance. This service is always active, users can
+// disable its sensitive pprof and log-setting endpoints, but the liveness
+// and readiness ones are always active.
+func (process *TeleportProcess) initDebugService(exposeDebugRoutes bool) error {
+	if process.state == nil {
+		return trace.BadParameter("teleport process state machine has not yet been initialized (this is a bug)")
 	}
 
+	logger := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentDebug, process.id))
+
+	// Unix socket creation can fail on paths too long. Depending on the UNIX implementation,
+	// socket paths cannot exceed 104 or 108 chars.
+	listener, err := process.importOrCreateListener(ListenerDebug, filepath.Join(process.Config.DataDir, teleport.DebugServiceSocketName))
+	if err != nil {
+		// If the debug service is enabled in the config, this is a hard failure
+		if exposeDebugRoutes {
+			return trace.Wrap(err)
+			// If the debug service was disabled in the config, we issue a warning and will have to continue.
+		} else {
+			logger.WarnContext(process.ExitContext(),
+				"Failed to open the debug socket. teleport-update will not be able to accurately check Teleport health.",
+				"error", err,
+			)
+			return nil
+		}
+	}
+
+	// Users can disable the debug service for compliance reasons but not the health
+	// routes because the updater relies on them.
+	var mux *http.ServeMux
+	if exposeDebugRoutes {
+		mux = debug.NewServeMux(logger, process.Config)
+		mux.Handle("/metrics", process.newMetricsHandler())
+	} else {
+		mux = http.NewServeMux()
+	}
+
+	// Add healthcheck routes.
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		roundtrip.ReplyJSON(w, http.StatusOK, map[string]any{"status": "ok"})
+	})
+	mux.HandleFunc("/readyz", process.state.readinessHandler())
+
 	server := &http.Server{
-		Handler:           debug.NewServeMux(logger, process.Config),
+		Handler:           mux,
 		ReadTimeout:       apidefaults.DefaultIOTimeout,
 		ReadHeaderTimeout: defaults.ReadHeadersTimeout,
 		// pprof endpoints support delta profiles and cpu and trace profiling

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3617,7 +3617,6 @@ func (process *TeleportProcess) newProcessStateMachine() (*processState, error) 
 // initDiagnosticService starts diagnostic service currently serving healthz
 // and prometheus endpoints
 func (process *TeleportProcess) initDiagnosticService() error {
-
 	logger := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentDiagnostic, process.id))
 
 	config := diagnosticHandlerConfig{
@@ -3706,11 +3705,11 @@ func (process *TeleportProcess) initDebugService(exposeDebugRoutes bool) error {
 	// socket paths cannot exceed 104 or 108 chars.
 	listener, err := process.importOrCreateListener(ListenerDebug, filepath.Join(process.Config.DataDir, teleport.DebugServiceSocketName))
 	if err != nil {
-		// If the debug service is enabled in the config, this is a hard failure
 		if exposeDebugRoutes {
+			// If the debug service is enabled in the config, this is a hard failure
 			return trace.Wrap(err)
-			// If the debug service was disabled in the config, we issue a warning and will have to continue.
 		} else {
+			// If the debug service was disabled in the config, we issue a warning and will have to continue.
 			logger.WarnContext(process.ExitContext(),
 				"Failed to open the debug socket. teleport-update will not be able to accurately check Teleport health.",
 				"error", err,

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -1611,8 +1611,8 @@ func TestSingleProcessModeResolver(t *testing.T) {
 }
 
 // TestDebugServiceStartSocket ensures the debug service socket starts
-// correctly, and is accessible.
-func TestDebugServiceStartSocket(t *testing.T) {
+// correctly, is accessible, and exposes the healthcheck endpoints.
+func TestDebugService(t *testing.T) {
 	t.Parallel()
 	fakeClock := clockwork.NewFakeClock()
 
@@ -1624,6 +1624,7 @@ func TestDebugServiceStartSocket(t *testing.T) {
 	cfg.DiagnosticAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
 	cfg.SetAuthServerAddress(utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"})
 	cfg.Auth.Enabled = true
+	cfg.Proxy.Enabled = false
 	cfg.Auth.StorageConfig.Params["path"] = dataDir
 	cfg.Auth.ListenAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
 	cfg.SSH.Enabled = false
@@ -1638,6 +1639,11 @@ func TestDebugServiceStartSocket(t *testing.T) {
 		require.NoError(t, process.Wait())
 	})
 
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	t.Cleanup(cancel)
+	_, err = process.WaitForEvent(ctx, TeleportOKEvent)
+	require.NoError(t, err)
+
 	httpClient := &http.Client{
 		Timeout: 10 * time.Second,
 		Transport: &http.Transport{
@@ -1647,11 +1653,52 @@ func TestDebugServiceStartSocket(t *testing.T) {
 		},
 	}
 
+	// Testing the debug listener.
 	// Fetch a random path, it should return 404 error.
 	req, err := httpClient.Get("http://debug/random")
 	require.NoError(t, err)
 	defer req.Body.Close()
 	require.Equal(t, http.StatusNotFound, req.StatusCode)
+
+	// Test the healthcheck endpoints.
+	// Fetch the liveness path
+	req, err = httpClient.Get("http://debug/healthz")
+	require.NoError(t, err)
+	defer req.Body.Close()
+	require.Equal(t, http.StatusOK, req.StatusCode)
+
+	// Fetch the readiness path
+	req, err = httpClient.Get("http://debug/readyz")
+	require.NoError(t, err)
+	defer req.Body.Close()
+	require.Equal(t, http.StatusOK, req.StatusCode)
+
+	// Testing the metrics endpoint.
+	// Test setup: create our test metrics.
+	nonce := strings.ReplaceAll(uuid.NewString(), "-", "")
+	localMetric := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "test",
+		Name:      "local_metric_" + nonce,
+	})
+	globalMetric := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "test",
+		Name:      "global_metric_" + nonce,
+	})
+	require.NoError(t, process.metricsRegistry.Register(localMetric))
+	require.NoError(t, prometheus.Register(globalMetric))
+
+	// Test execution: hit the metrics endpoint.
+	resp, err := httpClient.Get("http://debug/metrics")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	// Test validation: check that the metrics server served both the local and global registry.
+	require.Contains(t, string(body), "local_metric_"+nonce)
+	require.Contains(t, string(body), "global_metric_"+nonce)
 }
 
 type mockInstanceMetadata struct {
@@ -1950,7 +1997,7 @@ func TestAgentRolloutController(t *testing.T) {
 // TestMetricsService tests that the optional metrics service exposes
 // metrics from both the in-process and global metrics registry. When the
 // service is disabled, metrics are served by the diagnostics service
-// (tested in TestMetricsInDiagnosticsService).
+// (tested in TestDiagnosticsService).
 func TestMetricsService(t *testing.T) {
 	t.Parallel()
 	// Test setup: create a listener for the metrics server, get its file descriptor.
@@ -2029,10 +2076,11 @@ func TestMetricsService(t *testing.T) {
 	require.Contains(t, string(body), "global_metric_"+nonce)
 }
 
-// TestMetricsInDiagnosticsService tests that the diagnostics service exposes
+// TestDiagnosticsService tests that the diagnostics service exposes
 // metrics from both the in-process and global metrics registry when the metrics
-// service is disabled.
-func TestMetricsInDiagnosticsService(t *testing.T) {
+// service is disabled. It also checks that the diagnostics service exposes the
+// health routes.
+func TestDiagnosticsService(t *testing.T) {
 	t.Parallel()
 	// Test setup: create a new teleport process
 	dataDir := makeTempDir(t)
@@ -2071,7 +2119,7 @@ func TestMetricsInDiagnosticsService(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	t.Cleanup(cancel)
-	_, err = process.WaitForEvent(ctx, TeleportReadyEvent)
+	_, err = process.WaitForEvent(ctx, TeleportOKEvent)
 	require.NoError(t, err)
 
 	// Test execution: query the metrics endpoint and check the tests metrics are here.
@@ -2091,6 +2139,24 @@ func TestMetricsInDiagnosticsService(t *testing.T) {
 	// Test validation: check that the metrics server served both the local and global registry.
 	require.Contains(t, string(body), "local_metric_"+nonce)
 	require.Contains(t, string(body), "global_metric_"+nonce)
+
+	// Fetch the liveness endpoint
+	healthURL, err := url.Parse("http://" + diagAddr.String())
+	require.NoError(t, err)
+	healthURL.Path = "/healthz"
+	resp, err = http.Get(healthURL.String())
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Fetch the readiness endpoint
+	readinessURL, err := url.Parse("http://" + diagAddr.String())
+	require.NoError(t, err)
+	readinessURL.Path = "/readyz"
+	resp, err = http.Get(readinessURL.String())
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
 // makeTempDir makes a temp dir with a shorter name than t.TempDir() in order to

--- a/lib/service/state.go
+++ b/lib/service/state.go
@@ -179,21 +179,21 @@ func (f *processState) readinessHandler() http.HandlerFunc {
 		switch f.getState() {
 		// 503
 		case stateDegraded:
-			roundtrip.ReplyJSON(w, http.StatusServiceUnavailable, map[string]interface{}{
+			roundtrip.ReplyJSON(w, http.StatusServiceUnavailable, map[string]any{
 				"status": "teleport is in a degraded state, check logs for details",
 			})
 		// 400
 		case stateRecovering:
-			roundtrip.ReplyJSON(w, http.StatusBadRequest, map[string]interface{}{
+			roundtrip.ReplyJSON(w, http.StatusBadRequest, map[string]any{
 				"status": "teleport is recovering from a degraded state, check logs for details",
 			})
 		case stateStarting:
-			roundtrip.ReplyJSON(w, http.StatusBadRequest, map[string]interface{}{
+			roundtrip.ReplyJSON(w, http.StatusBadRequest, map[string]any{
 				"status": "teleport is starting and hasn't joined the cluster yet",
 			})
 		// 200
 		case stateOK:
-			roundtrip.ReplyJSON(w, http.StatusOK, map[string]interface{}{
+			roundtrip.ReplyJSON(w, http.StatusOK, map[string]any{
 				"status": "ok",
 			})
 		}

--- a/lib/service/state.go
+++ b/lib/service/state.go
@@ -20,9 +20,11 @@ package service
 
 import (
 	"fmt"
+	"net/http"
 	"sync"
 	"time"
 
+	"github.com/gravitational/roundtrip"
 	"github.com/gravitational/trace"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -170,4 +172,30 @@ func (f *processState) getState() componentStateEnum {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.getStateLocked()
+}
+
+func (f *processState) readinessHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch f.getState() {
+		// 503
+		case stateDegraded:
+			roundtrip.ReplyJSON(w, http.StatusServiceUnavailable, map[string]interface{}{
+				"status": "teleport is in a degraded state, check logs for details",
+			})
+		// 400
+		case stateRecovering:
+			roundtrip.ReplyJSON(w, http.StatusBadRequest, map[string]interface{}{
+				"status": "teleport is recovering from a degraded state, check logs for details",
+			})
+		case stateStarting:
+			roundtrip.ReplyJSON(w, http.StatusBadRequest, map[string]interface{}{
+				"status": "teleport is starting and hasn't joined the cluster yet",
+			})
+		// 200
+		case stateOK:
+			roundtrip.ReplyJSON(w, http.StatusOK, map[string]interface{}{
+				"status": "ok",
+			})
+		}
+	}
 }

--- a/lib/srv/debug/handlers.go
+++ b/lib/srv/debug/handlers.go
@@ -17,6 +17,7 @@
 package debug
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
@@ -24,6 +25,7 @@ import (
 	"net/http/pprof"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/gravitational/trace"
 
@@ -38,19 +40,34 @@ type LogLeveler interface {
 	SetLogLevel(slog.Level)
 }
 
-// NewServeMux returns a http mux that handles all the debug service endpoints.
-func NewServeMux(logger *slog.Logger, leveler LogLeveler) *http.ServeMux {
-	mux := http.NewServeMux()
+// RegisterProfilingHandlers registers the debug profiling handlers (/debug/pprof/*)
+// to a given multiplexer.
+func RegisterProfilingHandlers(mux *http.ServeMux, logger *slog.Logger) {
+	noWriteTimeout := func(h http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			rc := http.NewResponseController(w) //nolint:bodyclose // bodyclose gets really confused about NewResponseController
+			if err := rc.SetWriteDeadline(time.Time{}); err == nil {
+				// don't let the pprof handlers know about the WriteTimeout
+				r = r.WithContext(context.WithValue(r.Context(), http.ServerContextKey, nil))
+			}
+			h(w, r)
+		}
+	}
+
 	mux.HandleFunc("/debug/pprof/cmdline", pprofMiddleware(logger, "cmdline", pprof.Cmdline))
-	mux.HandleFunc("/debug/pprof/profile", pprofMiddleware(logger, "profile", pprof.Profile))
+	mux.HandleFunc("/debug/pprof/profile", pprofMiddleware(logger, "profile", noWriteTimeout(pprof.Profile)))
 	mux.HandleFunc("/debug/pprof/symbol", pprofMiddleware(logger, "symbol", pprof.Symbol))
-	mux.HandleFunc("/debug/pprof/trace", pprofMiddleware(logger, "trace", pprof.Trace))
+	mux.HandleFunc("/debug/pprof/trace", pprofMiddleware(logger, "trace", noWriteTimeout(pprof.Trace)))
 	mux.HandleFunc("/debug/pprof/{profile}", func(w http.ResponseWriter, r *http.Request) {
-		pprofMiddleware(logger, r.PathValue("profile"), pprof.Index)(w, r)
+		pprofMiddleware(logger, r.PathValue("profile"), noWriteTimeout(pprof.Index))(w, r)
 	})
+}
+
+// RegisterLogLevelHandlers registers log level handlers to a given multiplexer.
+// This allows to dynamically change the process' log level.
+func RegisterLogLevelHandlers(mux *http.ServeMux, logger *slog.Logger, leveler LogLeveler) {
 	mux.Handle("GET /log-level", handleGetLog(logger, leveler))
 	mux.Handle("PUT /log-level", handleSetLog(logger, leveler))
-	return mux
 }
 
 // handleGetLog returns the http get log level handler.

--- a/lib/srv/debug/handlers_test.go
+++ b/lib/srv/debug/handlers_test.go
@@ -95,8 +95,15 @@ func TestCollectProfiles(t *testing.T) {
 
 func makeServer(t *testing.T) (*mockLeveler, *httptest.Server) {
 	leveler := &mockLeveler{}
-	ts := httptest.NewServer(NewServeMux(slog.New(logutils.NewSlogTextHandler(io.Discard, logutils.SlogTextHandlerConfig{})), leveler))
+	logger := slog.New(logutils.NewSlogTextHandler(io.Discard, logutils.SlogTextHandlerConfig{}))
+
+	mux := http.NewServeMux()
+	RegisterProfilingHandlers(mux, logger)
+	RegisterLogLevelHandlers(mux, logger, leveler)
+
+	ts := httptest.NewServer(mux)
 	t.Cleanup(func() { ts.Close() })
+
 	return leveler, ts
 }
 


### PR DESCRIPTION
During automatic update end-to-end tests we realized that Teleport was often in a shadow failure state (process running but Teleport not healthy) and that the updater had a hard time detecting it. The previous updater relied on the Teleport process exporting a file or not when it's healthy but this is a slow process (file created every 40 min, and deleted after 9 minute in a failed state).

This PR adds the `/healthz` and `/readyz` routes to the existing debug service, so the updater can get an accurate representation of the process state. This PR does the following changes:

- Always run the diagnostic service and create the `debug.sock`
- Extract the process state machine so it can be reused by both Diagnostics and Debug services
- Extract the readiness HTTP handler logic so it can be reused by both Diagnostics and Debug services
- Expose the /metrics endpoint via the debug service (this will allow tctl top to work by default, even if diag-addr is not set).
- Enable/Disable the sensitive pprof debug and metrics endpoints using the debug service config (according to https://github.com/gravitational/teleport/pull/38997#discussion_r1520303754 this is required)

Potential issues:
- unix socket can't be disabled -> this was enabled by default already, so is it really a problem?
- unix socket path must be less than 108 chars -> We swallow the error and take the loss if the Diag service is explicitely disabled in the config, else this is a hard failure. The behaviour should be backward compatible.

Other approaches considered:
- creating a new socket called diag.sock only for the diagnostics service
- have Teleport write a file after a successful connection

Part of: [RFD-184](https://github.com/gravitational/teleport/pull/47126)
Goal (internal): https://github.com/gravitational/cloud/issues/10289
Changelog: Teleport agents always create the `debug.sock` UNIX socket. The configuration field `debug_service.enabled` now controls if the debug and metrics endpoints are available via the UNIX socket.
Changelog: The `debug.sock` UNIX socket now exposes the liveness and readiness endpoints.
Changelog: The `debug.sock` UNIX socket now exposes the metrics endpoint.