### PR TITLE
Fix Admin MFA required check

### DIFF
--- a/api/mfa/ceremony.go
+++ b/api/mfa/ceremony.go
@@ -137,6 +137,13 @@ func PerformAdminActionMFACeremony(ctx context.Context, mfaCeremony CeremonyFn, 
 		},
 	}
 
-	resp, err := mfaCeremony(ctx, challengeRequest, WithPromptReasonAdminAction())
+	// Remove MFA resp from context if set. This way, the mfa required
+	// check will return true as long as MFA for admin actions is enabled,
+	// even if the current context has a reusable MFA. v18 server will
+	// return this requirement as expected.
+	// TODO(Joerger): DELETE IN v19.0.0
+	ceremonyCtx := ContextWithMFAResponse(ctx, nil)
+
+	resp, err := mfaCeremony(ceremonyCtx, challengeRequest, WithPromptReasonAdminAction())
 	return resp, trace.Wrap(err)
 }

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -5984,15 +5984,15 @@ func (a *ServerWithRoles) IsMFARequired(ctx context.Context, req *proto.IsMFAReq
 	// Check if MFA is required for admin actions. We don't currently have
 	// a reason to check the name of the admin action in question.
 	if _, ok := req.Target.(*proto.IsMFARequiredRequest_AdminAction); ok {
-		if a.context.AdminActionAuthState == authz.AdminActionAuthUnauthorized {
-			return &proto.IsMFARequiredResponse{
-				Required:    true,
-				MFARequired: proto.MFARequired_MFA_REQUIRED_YES,
-			}, nil
-		} else {
+		if a.context.AdminActionAuthState == authz.AdminActionAuthNotRequired {
 			return &proto.IsMFARequiredResponse{
 				Required:    false,
 				MFARequired: proto.MFARequired_MFA_REQUIRED_NO,
+			}, nil
+		} else {
+			return &proto.IsMFARequiredResponse{
+				Required:    true,
+				MFARequired: proto.MFARequired_MFA_REQUIRED_YES,
 			}, nil
 		}
 	}

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -9545,15 +9545,15 @@ func TestIsMFARequired_AdminAction(t *testing.T) {
 			name:                 "mfa verified",
 			adminActionAuthState: authz.AdminActionAuthMFAVerified,
 			expectResp: &proto.IsMFARequiredResponse{
-				Required:    false,
-				MFARequired: proto.MFARequired_MFA_REQUIRED_NO,
+				Required:    true,
+				MFARequired: proto.MFARequired_MFA_REQUIRED_YES,
 			},
 		}, {
 			name:                 "mfa verified with reuse",
 			adminActionAuthState: authz.AdminActionAuthMFAVerifiedWithReuse,
 			expectResp: &proto.IsMFARequiredResponse{
-				Required:    false,
-				MFARequired: proto.MFARequired_MFA_REQUIRED_NO,
+				Required:    true,
+				MFARequired: proto.MFARequired_MFA_REQUIRED_YES,
 			},
 		},
 	} {


### PR DESCRIPTION
The MFA required check for admin actions would take into account whether the `IsMFARequired` (or `CreateAuthenticationChallenge`) request itself was admin-mfa-verified. This could potentially cause two problems:

1. The mfa response is reusable, but we are checking if mfa is required for an endpoint that disallows reuse. `CreateAuthenticationChallenge` will call `IsMFARequired` and incorrectly think that it is already MFA verified.
2. The mfa response is not reusable, so `IsMFARequired` or `CreateAuthenticationChallenge` consumes the MFA response and returns that MFA is not required.

This PR changes `IsMFARequired` now just checks if Admin Action MFA is strictly not required - Whether because it's not enforced (totp allowed), disabled (`TELEPORT_UNSTABLE_DISABLE_MFA_ADMIN_ACTIONS`), or the identity asking is a built role.

There are no bugs presently caused by this issue, but it is needed for some UX improvements like https://github.com/gravitational/teleport/pull/46891.