### PR TITLE
Upgrade Vale in the prose check workflow

### DIFF
--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -134,7 +134,7 @@ jobs:
       - name: Run the linter
         uses: errata-ai/vale-action@d89dee975228ae261d22c15adcd03578634d429c # v2.1.1
         with:
-          version: 2.30.0
+          version: 3.9.4
           # Take the comma-separated list of files returned by the "Check for
           # relevant changes" job.
           separator: ","


### PR DESCRIPTION
Include the ability to ignore style rules using comments (https://vale.sh/docs/keys/commentdelimiters), plus catch up with the latest updates.