### PR TITLE
kube: fix transport being incorrectly cached by kube service

### DIFF
--- a/lib/kube/proxy/kube_creds.go
+++ b/lib/kube/proxy/kube_creds.go
@@ -236,7 +236,7 @@ func newDynamicKubeCreds(ctx context.Context, cfg dynamicCredsConfig) (*dynamicK
 func (d *dynamicKubeCreds) getTLSConfig() *tls.Config {
 	d.RLock()
 	defer d.RUnlock()
-	return d.staticCreds.tlsConfig
+	return d.staticCreds.getTLSConfig()
 }
 
 func (d *dynamicKubeCreds) getTransportConfig() *transport.Config {

--- a/lib/kube/proxy/transport.go
+++ b/lib/kube/proxy/transport.go
@@ -59,6 +59,15 @@ type dialContextFunc func(context.Context, string, string) (net.Conn, error)
 // The transport is cached in the forwarder so that it can be reused for future
 // requests. If the transport is not cached, a new one is created and cached.
 func (f *Forwarder) transportForRequestWithImpersonation(sess *clusterSession) (http.RoundTripper, *tls.Config, error) {
+	// If the session has a kube API credentials, it means that the next hop is
+	// a Kubernetes API server. In this case, we can use the provided credentials
+	// to dial the next hop directly and never cache the transport.
+	if sess.kubeAPICreds != nil {
+		// If agent is running in agent mode, get the transport from the configured cluster
+		// credentials.
+		return sess.kubeAPICreds.getTransport(), sess.kubeAPICreds.getTLSConfig(), nil
+	}
+
 	// If the cluster is remote, the key is the teleport cluster name.
 	// If the cluster is local, the key is the teleport cluster name and the kubernetes
 	// cluster name: <teleport-cluster-name>/<kubernetes-cluster-name>.
@@ -73,10 +82,6 @@ func (f *Forwarder) transportForRequestWithImpersonation(sess *clusterSession) (
 		if sess.teleportCluster.isRemote {
 			// If the cluster is remote, create a new transport for the remote cluster.
 			httpTransport, tlsConfig, err = f.newRemoteClusterTransport(sess.teleportCluster.name)
-		} else if sess.kubeAPICreds != nil {
-			// If agent is running in agent mode, get the transport from the configured cluster
-			// credentials.
-			httpTransport, tlsConfig = sess.kubeAPICreds.getTransport(), sess.kubeAPICreds.getTLSConfig()
 		} else if f.cfg.ReverseTunnelSrv != nil {
 			// If agent is running in proxy mode, create a new transport for the local cluster.
 			httpTransport, tlsConfig, err = f.newLocalClusterTransport(sess.kubeClusterName)


### PR DESCRIPTION
PR #46899 introduced a subtle change in Kubernetes service behavior, where the direct transport—kube agent to Kubernetes API—is now cached for five hours.  

This disrupts auto-discovery because tokens are only valid for 15 minutes, while the HTTP transport that applies them remains valid for five hours. As a result, the Kubernetes service continues using the same expired token for 4 hours and 45 minutes.  

This PR resolves the issue by preventing token caching altogether.

Fixes #51639

Changelog: Fixes a regression that caused the Kubernetes Service to reuse expired tokens when accessing EKS, GKE and AKS clusters using dynamic credentials.