### PR TITLE
[v17] fix: Randomly derive UUIDs from non-conformant session IDs

### DIFF
--- a/lib/events/pgevents/pgevents.go
+++ b/lib/events/pgevents/pgevents.go
@@ -622,7 +622,6 @@ func (l *Log) deriveSessionID(ctx context.Context, sessionID string) uuid.UUID {
 	l.log.DebugContext(ctx,
 		"Failed to parse event session ID, using derived ID",
 		"error", err,
-		"session_id", sessionID,
 		"derived_id", derived,
 	)
 	return derived

--- a/lib/events/pgevents/pgevents.go
+++ b/lib/events/pgevents/pgevents.go
@@ -612,6 +612,10 @@ func (l *Log) deriveSessionID(ctx context.Context, sessionID string) uuid.UUID {
 	// To avoid dropping the event while conforming to the existing schema we
 	// deterministically derive an UUID from the session ID.
 	//
+	// Note that derived IDs are UUIDv5 (instead of the usual UUIDv4 from
+	// uuid.Parse), so that could be used as a hint to which UUIDs are original or
+	// derived.
+	//
 	// * https://github.com/gravitational/teleport/blob/63537e3da5a22b61d9218863f1ed535a31d229ea/lib/auth/sessions.go#L521
 	derived := uuid.NewSHA1(sessionIDBase, []byte(sessionID))
 

--- a/lib/events/pgevents/pgevents.go
+++ b/lib/events/pgevents/pgevents.go
@@ -72,7 +72,7 @@ const (
 const (
 	// A note on "session_id uuid NOT NULL":
 	//
-	// Some session IDs aren't UUIDs. See Log.deriveSessionID for an example.
+	// Some session IDs aren't UUIDs. See [Log.deriveSessionID] for an example.
 	// The wiser choice of type would be "session_id text", ie, handling session
 	// IDs as an opaque identifier.
 	//
@@ -591,7 +591,7 @@ func (l *Log) SearchSessionEvents(ctx context.Context, req events.SearchSessionE
 }
 
 // sessionIDBase is a randomly-generated UUID used as the basis for deriving
-// an UUID from session IDs. See Log.deriveSessionID.
+// an UUID from session IDs. See [Log.deriveSessionID].
 var sessionIDBase = uuid.MustParse("e481e221-77b0-4b9e-be98-bc2e486b751b")
 
 func (l *Log) deriveSessionID(ctx context.Context, sessionID string) uuid.UUID {

--- a/lib/events/pgevents/pgevents.go
+++ b/lib/events/pgevents/pgevents.go
@@ -592,7 +592,7 @@ func (l *Log) SearchSessionEvents(ctx context.Context, req events.SearchSessionE
 
 // sessionIDBase is a randomly-generated UUID used as the basis for deriving
 // an UUID from session IDs. See Log.deriveSessionID.
-var sessionIDBase = uuid.MustParse(`e481e221-77b0-4b9e-be98-bc2e486b751b`)
+var sessionIDBase = uuid.MustParse("e481e221-77b0-4b9e-be98-bc2e486b751b")
 
 func (l *Log) deriveSessionID(ctx context.Context, sessionID string) uuid.UUID {
 	if sessionID == "" {

--- a/lib/events/pgevents/pgevents.go
+++ b/lib/events/pgevents/pgevents.go
@@ -70,6 +70,14 @@ const (
 )
 
 const (
+	// A note on "session_id uuid NOT NULL":
+	//
+	// Some session IDs aren't UUIDs. See Log.deriveSessionID for an example.
+	// The wiser choice of type would be "session_id text", ie, handling session
+	// IDs as an opaque identifier.
+	//
+	// If you are writing a new backend and stumbled on this comment, do not use
+	// a storage UUID type for session IDs. Use a string type.
 	schemaV1Table = `CREATE TABLE events (
 		event_time timestamptz NOT NULL,
 		event_id uuid NOT NULL,
@@ -360,14 +368,6 @@ var _ events.AuditLogger = (*Log)(nil)
 // EmitAuditEvent implements [events.AuditLogger].
 func (l *Log) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
 	ctx = context.WithoutCancel(ctx)
-	var sessionID uuid.UUID
-	if s := events.GetSessionID(event); s != "" {
-		u, err := uuid.Parse(s)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		sessionID = u
-	}
 
 	eventJSON, err := utils.FastMarshal(event)
 	if err != nil {
@@ -375,6 +375,7 @@ func (l *Log) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) er
 	}
 
 	eventID := uuid.New()
+	sessionID := l.deriveSessionID(ctx, events.GetSessionID(event))
 
 	start := time.Now()
 	// if an event with the same event_id exists, it means that we inserted it
@@ -412,15 +413,6 @@ func (l *Log) searchEvents(
 	eventTypes []string, cond *types.WhereExpr, sessionID string,
 	limit int, order types.EventOrder, startKey string,
 ) ([]apievents.AuditEvent, string, error) {
-	var sessionUUID uuid.UUID
-	if sessionID != "" {
-		var err error
-		sessionUUID, err = uuid.Parse(sessionID)
-		if err != nil {
-			return nil, "", trace.Wrap(err)
-		}
-	}
-
 	if limit <= 0 {
 		limit = defaults.EventsIterationLimit
 	}
@@ -446,6 +438,8 @@ func (l *Log) searchEvents(
 			return nil, "", trace.Wrap(err)
 		}
 	}
+
+	sessionUUID := l.deriveSessionID(ctx, sessionID)
 
 	var qb strings.Builder
 	qb.WriteString("DECLARE cur CURSOR FOR SELECT" +
@@ -594,4 +588,38 @@ func (l *Log) GetEventExportChunks(ctx context.Context, req *auditlogpb.GetEvent
 // SearchSessionEvents implements [events.AuditLogger].
 func (l *Log) SearchSessionEvents(ctx context.Context, req events.SearchSessionEventsRequest) ([]apievents.AuditEvent, string, error) {
 	return l.searchEvents(ctx, req.From, req.To, events.SessionRecordingEvents, req.Cond, req.SessionID, req.Limit, req.Order, req.StartKey)
+}
+
+// sessionIDBase is a randomly-generated UUID used as the basis for deriving
+// an UUID from session IDs. See Log.deriveSessionID.
+var sessionIDBase = uuid.MustParse(`e481e221-77b0-4b9e-be98-bc2e486b751b`)
+
+func (l *Log) deriveSessionID(ctx context.Context, sessionID string) uuid.UUID {
+	if sessionID == "" {
+		return uuid.Nil // return zero UUID for backwards compat
+	}
+
+	u, err := uuid.Parse(sessionID)
+	if err == nil {
+		return u
+	}
+
+	// Some session IDs aren't UUIDs. For example, App session IDs are 32-byte
+	// values encoded as hex. Whether the assumption of UUIDs is philosophically
+	// correct is immaterial, what matters is that we do not drop the audit
+	// event.
+	//
+	// To avoid dropping the event while conforming to the existing schema we
+	// deterministically derive an UUID from the session ID.
+	//
+	// * https://github.com/gravitational/teleport/blob/63537e3da5a22b61d9218863f1ed535a31d229ea/lib/auth/sessions.go#L521
+	derived := uuid.NewSHA1(sessionIDBase, []byte(sessionID))
+
+	l.log.DebugContext(ctx,
+		"Failed to parse event session ID, using derived ID",
+		"error", err,
+		"session_id", sessionID,
+		"derived_id", derived,
+	)
+	return derived
 }


### PR DESCRIPTION
Backport #51571 to branch/v17

changelog: Fixes issue where the Postgres backend would drop App Access events
