### PR TITLE
DiscoveryConfigStatus: update counters once per iteration

### DIFF
--- a/lib/srv/discovery/database_watcher.go
+++ b/lib/srv/discovery/database_watcher.go
@@ -85,7 +85,6 @@ func (s *Server) startDatabaseWatchers() error {
 
 	go func() {
 		for {
-			discoveryConfigsChanged := map[string]struct{}{}
 			resourcesFoundByGroup := make(map[awsResourceGroup]int)
 
 			select {
@@ -99,7 +98,6 @@ func (s *Server) startDatabaseWatchers() error {
 
 					resourceGroup := awsResourceGroupFromLabels(db.GetStaticLabels())
 					resourcesFoundByGroup[resourceGroup] += 1
-					discoveryConfigsChanged[resourceGroup.discoveryConfigName] = struct{}{}
 
 					dbs = append(dbs, db)
 
@@ -136,9 +134,6 @@ func (s *Server) startDatabaseWatchers() error {
 				return
 			}
 
-			for dc := range discoveryConfigsChanged {
-				s.updateDiscoveryConfigStatus(dc)
-			}
 			s.upsertTasksForAWSRDSFailedEnrollments()
 		}
 	}()
@@ -203,16 +198,15 @@ func (s *Server) databaseWatcherIterationStarted() {
 		},
 	)
 
-	for _, g := range awsResultGroups {
-		s.awsRDSResourcesStatus.iterationStarted(g)
-	}
-
 	discoveryConfigs := slices.FilterMapUnique(awsResultGroups, func(g awsResourceGroup) (s string, include bool) {
 		return g.discoveryConfigName, true
 	})
 	s.updateDiscoveryConfigStatus(discoveryConfigs...)
-
 	s.awsRDSResourcesStatus.reset()
+	for _, g := range awsResultGroups {
+		s.awsRDSResourcesStatus.iterationStarted(g)
+	}
+
 	s.awsRDSTasks.reset()
 }
 

--- a/lib/srv/discovery/status.go
+++ b/lib/srv/discovery/status.go
@@ -355,8 +355,6 @@ func (s *Server) ReportEC2SSMInstallationResult(ctx context.Context, result *ser
 		integration:         result.IntegrationName,
 	}, 1)
 
-	s.updateDiscoveryConfigStatus(result.DiscoveryConfigName)
-
 	s.awsEC2Tasks.addFailedEnrollment(
 		awsEC2TaskKey{
 			integration:     result.IntegrationName,

--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 
 	usageeventsv1 "github.com/gravitational/teleport/api/gen/proto/go/usageevents/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -86,6 +87,7 @@ func NewAzureWatcher(ctx context.Context, fetchersFn func() []Fetcher, opts ...O
 		ctx:           cancelCtx,
 		cancel:        cancelFn,
 		pollInterval:  time.Minute,
+		clock:         clockwork.NewRealClock(),
 		triggerFetchC: make(<-chan struct{}),
 		InstancesC:    make(chan Instances),
 	}

--- a/lib/srv/server/ec2_watcher.go
+++ b/lib/srv/server/ec2_watcher.go
@@ -28,6 +28,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 
 	usageeventsv1 "github.com/gravitational/teleport/api/gen/proto/go/usageevents/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -177,6 +178,7 @@ func NewEC2Watcher(ctx context.Context, fetchersFn func() []Fetcher, missedRotat
 		fetchersFn:     fetchersFn,
 		ctx:            cancelCtx,
 		cancel:         cancelFn,
+		clock:          clockwork.NewRealClock(),
 		pollInterval:   time.Minute,
 		triggerFetchC:  make(<-chan struct{}),
 		InstancesC:     make(chan Instances),

--- a/lib/srv/server/gcp_watcher.go
+++ b/lib/srv/server/gcp_watcher.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 
 	usageeventsv1 "github.com/gravitational/teleport/api/gen/proto/go/usageevents/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -78,6 +79,7 @@ func NewGCPWatcher(ctx context.Context, fetchersFn func() []Fetcher, opts ...Opt
 		fetchersFn:    fetchersFn,
 		ctx:           cancelCtx,
 		cancel:        cancelFn,
+		clock:         clockwork.NewRealClock(),
 		pollInterval:  time.Minute,
 		triggerFetchC: make(<-chan struct{}),
 		InstancesC:    make(chan Instances),

--- a/lib/srv/server/watcher.go
+++ b/lib/srv/server/watcher.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 
 	"github.com/gravitational/teleport/api/types"
 )
@@ -64,6 +65,13 @@ func WithPreFetchHookFn(f func()) Option {
 	}
 }
 
+// WithClock sets a clock that is used to periodically fetch new resources.
+func WithClock(clock clockwork.Clock) Option {
+	return func(w *Watcher) {
+		w.clock = clock
+	}
+}
+
 // Watcher allows callers to discover cloud instances matching specified filters.
 type Watcher struct {
 	// InstancesC can be used to consume newly discovered instances.
@@ -72,6 +80,7 @@ type Watcher struct {
 
 	fetchersFn     func() []Fetcher
 	pollInterval   time.Duration
+	clock          clockwork.Clock
 	triggerFetchC  <-chan struct{}
 	ctx            context.Context
 	cancel         context.CancelFunc
@@ -107,7 +116,7 @@ func (w *Watcher) fetchAndSubmit() {
 
 // Run starts the watcher's main watch loop.
 func (w *Watcher) Run() {
-	pollTimer := time.NewTimer(w.pollInterval)
+	pollTimer := w.clock.NewTimer(w.pollInterval)
 	defer pollTimer.Stop()
 
 	if w.triggerFetchC == nil {
@@ -123,7 +132,7 @@ func (w *Watcher) Run() {
 				w.sendInstancesOrLogError(fetcher.GetMatchingInstances(insts, true))
 			}
 
-		case <-pollTimer.C:
+		case <-pollTimer.Chan():
 			w.fetchAndSubmit()
 			pollTimer.Reset(w.pollInterval)
 
@@ -132,7 +141,7 @@ func (w *Watcher) Run() {
 
 			// stop and drain timer
 			if !pollTimer.Stop() {
-				<-pollTimer.C
+				<-pollTimer.Chan()
 			}
 			pollTimer.Reset(w.pollInterval)
 


### PR DESCRIPTION
DiscoveryService can process DiscoveryConfig matchers and will update its Status field depending on the number of found resources.

Currently, it was updating them in real-time-ish: every time it found a new resource, it would update the counter in memory and propagate that change into the cluster shared storage.

However, this resulted in counters flutuating a lot and causing confusion from the user's point of view (being at 0 every couple of minutes).

Instead, this PR, ensures we update the values only once per iteration cycle (happens at discovery_service.poll_interval - defaults to 5 miunutes).
This means we lose real-time observation of the counters, but we gain stability on the values which should help UX.