### PR TITLE
Update aws-console.mdx to include DNS and TLS requirements

### DIFF
--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
@@ -430,7 +430,7 @@ Application Service:
 
    The `app_service` field configures the Teleport Application Service. Each
    item within `app_service.apps` is an application configuration. If self-hosting
-   the Teleport cluster, you must have [DNS and a TLS certificate](../getting-started.mdx/#subdomains-and-applications)
+   the Teleport cluster, you must have [DNS and a TLS certificate](../getting-started.mdx#subdomains-and-applications)
    configured for the application domain name associated with the Teleport 
    Proxy Service, e.g., `awsconsole.teleport.example.com`.
 

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
@@ -429,7 +429,10 @@ Application Service:
    `example.teleport.sh:443`.
 
    The `app_service` field configures the Teleport Application Service. Each
-   item within `app_service.apps` is an application configuration. 
+   item within `app_service.apps` is an application configuration. If self-hosting
+   the Teleport cluster, you must have DNS and a TLS certificate configured for the 
+   application domain name associated with the Teleport Proxy Service, e.g., 
+   `awsconsole.teleport.example.com`
 
 </TabItem>
 <TabItem label="EKS">

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
@@ -430,9 +430,9 @@ Application Service:
 
    The `app_service` field configures the Teleport Application Service. Each
    item within `app_service.apps` is an application configuration. If self-hosting
-   the Teleport cluster, you must have DNS and a TLS certificate configured for the 
-   application domain name associated with the Teleport Proxy Service, e.g., 
-   `awsconsole.teleport.example.com`
+   the Teleport cluster, you must have [DNS and a TLS certificate](../getting-started.mdx/#subdomains-and-applications)
+   configured for the application domain name associated with the Teleport 
+   Proxy Service, e.g., `awsconsole.teleport.example.com`.
 
 </TabItem>
 <TabItem label="EKS">


### PR DESCRIPTION
Based on customer feedback, adding in mention that DNS and TLS are required for the AWS console app subdomain