### PR TITLE
[v15] Add Audit Log tab to tctl top

### DIFF
--- a/tool/tsh/common/latency.go
+++ b/tool/tsh/common/latency.go
@@ -151,6 +151,7 @@ func (m *latencyModel) View() string {
 		[][]float64{clientData, serverData},
 		asciigraph.Height(m.h-4),
 		asciigraph.Width(m.w),
+		asciigraph.UpperBound(1),
 		asciigraph.SeriesColors(clientColor, serverColor),
 		asciigraph.Caption(legend),
 	)


### PR DESCRIPTION
Backport #51620 to branch/v15


changelog: Add Audit Log statistics to `tctl top`.