### PR TITLE
Remove timeout for TestUpdate

### DIFF
--- a/integration/autoupdate/tools/updater_test.go
+++ b/integration/autoupdate/tools/updater_test.go
@@ -46,8 +46,7 @@ var (
 // an update to a newer version, expecting it to re-execute with the updated version.
 func TestUpdate(t *testing.T) {
 	t.Setenv(types.HomeEnvVar, t.TempDir())
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
+	ctx := context.Background()
 
 	// Fetch compiled test binary with updater logic and install to $TELEPORT_HOME.
 	updater := tools.NewUpdater(
@@ -88,8 +87,7 @@ func TestUpdate(t *testing.T) {
 // the command with the updated version without any new downloads.
 func TestParallelUpdate(t *testing.T) {
 	t.Setenv(types.HomeEnvVar, t.TempDir())
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
+	ctx := context.Background()
 
 	// Initial fetch the updater binary un-archive and replace.
 	updater := tools.NewUpdater(
@@ -162,8 +160,7 @@ func TestParallelUpdate(t *testing.T) {
 // TestUpdateInterruptSignal verifies the interrupt signal send to the process must stop downloading.
 func TestUpdateInterruptSignal(t *testing.T) {
 	t.Setenv(types.HomeEnvVar, t.TempDir())
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
+	ctx := context.Background()
 
 	// Initial fetch the updater binary un-archive and replace.
 	updater := tools.NewUpdater(


### PR DESCRIPTION
In this PR removed timeout for client tools auto-updates integration tests to use general timeout for all integrations tests.

Previous execution time was about 40+sec, after extending test logic here https://github.com/gravitational/teleport/pull/50228 time increased to almost one minute.

https://github.com/gravitational/teleport/actions/runs/13043343220/job/36390820085?pr=51627