### PR TITLE
fix: Don't attempt to renew sessions that are about to expire

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2367,6 +2367,8 @@ type CreateSessionResponse struct {
 	Token string `json:"token"`
 	// TokenExpiresIn sets seconds before this token is not valid
 	TokenExpiresIn int `json:"expires_in"`
+	// SessionExpiresIn is the seconds before the session itself expires.
+	SessionExpiresIn int `json:"sessionExpiresIn,omitempty"`
 	// SessionExpires is when this session expires.
 	SessionExpires time.Time `json:"sessionExpires,omitempty"`
 	// SessionInactiveTimeoutMS specifies how long in milliseconds
@@ -2398,10 +2400,15 @@ func newSessionResponse(sctx *SessionContext) (*CreateSessionResponse, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	now := sctx.cfg.Parent.clock.Now()
+	sessionExpiryTime := sctx.cfg.Session.GetExpiryTime()
+
 	return &CreateSessionResponse{
 		TokenType:                roundtrip.AuthBearer,
 		Token:                    token.GetName(),
-		TokenExpiresIn:           int(token.Expiry().Sub(sctx.cfg.Parent.clock.Now()) / time.Second),
+		TokenExpiresIn:           int(token.Expiry().Sub(now) / time.Second),
+		SessionExpiresIn:         int(sessionExpiryTime.Sub(now) / time.Second),
+		SessionExpires:           sessionExpiryTime,
 		SessionInactiveTimeoutMS: int(sctx.cfg.Session.GetIdleTimeout().Milliseconds()),
 		DeviceWebToken:           sctx.cfg.Session.GetDeviceWebToken(),
 		TrustedDeviceRequirement: int32(sctx.cfg.Session.GetTrustedDeviceRequirement()),
@@ -2466,12 +2473,7 @@ func (h *Handler) createWebSession(w http.ResponseWriter, r *http.Request, p htt
 	}
 
 	res, err := newSessionResponse(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	res.SessionExpires = webSession.GetExpiryTime()
-
-	return res, nil
+	return res, trace.Wrap(err)
 }
 
 func clientMetaFromReq(r *http.Request) *authclient.ForwardedClientMetadata {
@@ -2589,12 +2591,7 @@ func (h *Handler) renewWebSession(w http.ResponseWriter, r *http.Request, params
 	}
 
 	res, err := newSessionResponse(newContext)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	res.SessionExpires = newSession.GetExpiryTime()
-
-	return res, nil
+	return res, trace.Wrap(err)
 }
 
 type changeUserAuthenticationRequest struct {

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -715,20 +715,17 @@ func (s *WebSuite) authPack(t *testing.T, user string, roles ...string) *authPac
 		otpSecret: otpSecret,
 	})
 
-	sess, err := sessionResp.response()
-	require.NoError(t, err)
-
 	jar, err := cookiejar.New(nil)
 	require.NoError(t, err)
 
-	clt := s.client(t, roundtrip.BearerAuth(sess.Token), roundtrip.CookieJar(jar))
+	clt := s.client(t, roundtrip.BearerAuth(sessionResp.Token), roundtrip.CookieJar(jar))
 	jar.SetCookies(s.url(), httpResp.Cookies())
 
 	return &authPack{
 		otpSecret: otpSecret,
 		user:      user,
 		login:     login,
-		session:   sess,
+		session:   sessionResp,
 		clt:       clt,
 		cookies:   httpResp.Cookies(),
 	}
@@ -801,19 +798,16 @@ func (s *WebSuite) authPackWithMFA(t *testing.T, name string, roles ...types.Rol
 		authenticator: device,
 	})
 
-	sess, err := sessionResp.response()
-	require.NoError(t, err)
-
 	jar, err := cookiejar.New(nil)
 	require.NoError(t, err)
 
-	clt = s.client(t, roundtrip.BearerAuth(sess.Token), roundtrip.CookieJar(jar))
+	clt = s.client(t, roundtrip.BearerAuth(sessionResp.Token), roundtrip.CookieJar(jar))
 	jar.SetCookies(s.url(), httpResp.Cookies())
 
 	return &authPack{
 		user:    name,
 		login:   s.user,
-		session: sess,
+		session: sessionResp,
 		clt:     clt,
 		cookies: httpResp.Cookies(),
 		device:  &auth.TestDevice{Key: device},
@@ -5730,15 +5724,28 @@ func TestNewSessionResponseWithRenewSession(t *testing.T) {
 	proxy := env.proxies[0]
 	pack := proxy.authPack(t, "foo", nil /* roles */)
 
-	var ns *CreateSessionResponse
-	resp := pack.renewSession(context.Background(), t)
-	require.NoError(t, json.Unmarshal(resp.Bytes(), &ns))
+	assertSession := func(t *testing.T, session *CreateSessionResponse) {
+		t.Helper()
 
-	require.Equal(t, int(duration.Milliseconds()), ns.SessionInactiveTimeoutMS)
-	require.Equal(t, roundtrip.AuthBearer, ns.TokenType)
-	require.NotEmpty(t, ns.SessionExpires)
-	require.NotEmpty(t, ns.Token)
-	require.NotEmpty(t, ns.TokenExpiresIn)
+		assert.Equal(t, roundtrip.AuthBearer, session.TokenType, "token type mismatch")
+		assert.NotEmpty(t, session.Token, "token")
+		assert.NotZero(t, session.TokenExpiresIn, "expires_in")
+		assert.GreaterOrEqual(t, session.SessionExpiresIn, session.TokenExpiresIn, "sessionExpiresIn must be >= expires_in")
+		assert.NotZero(t, session.SessionExpires, "sessionExpires")
+		assert.Equal(t, int(duration.Milliseconds()), session.SessionInactiveTimeoutMS, "sessionInactiveTimeout")
+	}
+
+	t.Run("pack.session", func(t *testing.T) {
+		assertSession(t, pack.session)
+	})
+
+	t.Run("renew", func(t *testing.T) {
+		resp := pack.renewSession(context.Background(), t)
+
+		session := &CreateSessionResponse{}
+		require.NoError(t, json.Unmarshal(resp.Bytes(), &session), "unmarshal renewed session")
+		assertSession(t, session)
+	})
 }
 
 // TestWebSessionsRenewDoesNotBreakExistingTerminalSession validates that the
@@ -7993,10 +8000,6 @@ func decodeSessionCookie(t *testing.T, value string) (sessionID string) {
 	return cookie.SessionID
 }
 
-func (r CreateSessionResponse) response() (*CreateSessionResponse, error) {
-	return &CreateSessionResponse{TokenType: r.TokenType, Token: r.Token, TokenExpiresIn: r.TokenExpiresIn, SessionInactiveTimeoutMS: r.SessionInactiveTimeoutMS}, nil
-}
-
 func newWebPack(t *testing.T, numProxies int, opts ...proxyOption) *webPack {
 	ctx := context.Background()
 	clock := clockwork.NewFakeClockAt(time.Now())
@@ -8546,20 +8549,17 @@ func (r *testProxy) authPack(t *testing.T, teleportUser string, roles []types.Ro
 		otpSecret: otpSecret,
 	})
 
-	session, err := sessionResp.response()
-	require.NoError(t, err)
-
 	jar, err := cookiejar.New(nil)
 	require.NoError(t, err)
 
-	clt := r.newClient(t, roundtrip.BearerAuth(session.Token), roundtrip.CookieJar(jar))
+	clt := r.newClient(t, roundtrip.BearerAuth(sessionResp.Token), roundtrip.CookieJar(jar))
 	jar.SetCookies(&r.webURL, httpResp.Cookies())
 
 	return &authPack{
 		otpSecret: otpSecret,
 		user:      teleportUser,
 		login:     loginUser,
-		session:   session,
+		session:   sessionResp,
 		clt:       clt,
 		cookies:   httpResp.Cookies(),
 		password:  pass,
@@ -8584,6 +8584,9 @@ func (r *testProxy) authPackFromPack(t *testing.T, pack *authPack) *authPack {
 func (r *testProxy) authPackFromResponse(t *testing.T, httpResp *roundtrip.Response) *authPack {
 	var resp *CreateSessionResponse
 	require.NoError(t, json.Unmarshal(httpResp.Bytes(), &resp))
+	if resp.TokenExpiresIn < 0 {
+		t.Errorf("Expected expiry time to be in the future but got %v", resp.TokenExpiresIn)
+	}
 
 	jar, err := cookiejar.New(nil)
 	require.NoError(t, err)
@@ -8591,13 +8594,8 @@ func (r *testProxy) authPackFromResponse(t *testing.T, httpResp *roundtrip.Respo
 	clt := r.newClient(t, roundtrip.BearerAuth(resp.Token), roundtrip.CookieJar(jar))
 	jar.SetCookies(&r.webURL, httpResp.Cookies())
 
-	session, err := resp.response()
-	require.NoError(t, err)
-	if session.TokenExpiresIn < 0 {
-		t.Errorf("Expected expiry time to be in the future but got %v", session.TokenExpiresIn)
-	}
 	return &authPack{
-		session: session,
+		session: resp,
 		clt:     clt,
 		cookies: httpResp.Cookies(),
 	}

--- a/web/packages/teleport/src/services/websession/makeBearerToken.ts
+++ b/web/packages/teleport/src/services/websession/makeBearerToken.ts
@@ -24,6 +24,7 @@ export default function makeBearerToken(json: any): BearerToken {
     expiresIn: json.expires_in,
     created: new Date().getTime(),
     sessionExpires: json.sessionExpires,
+    sessionExpiresIn: json.sessionExpiresIn,
     sessionInactiveTimeout: json.sessionInactiveTimeout,
   };
 }

--- a/web/packages/teleport/src/services/websession/types.ts
+++ b/web/packages/teleport/src/services/websession/types.ts
@@ -27,5 +27,6 @@ export type BearerToken = {
   expiresIn: string;
   created: number;
   sessionExpires: Date;
+  sessionExpiresIn: number;
   sessionInactiveTimeout: number;
 };

--- a/web/packages/teleport/src/services/websession/websession.ts
+++ b/web/packages/teleport/src/services/websession/websession.ts
@@ -146,7 +146,34 @@ const session = {
       return false;
     }
 
-    // Renew session if token expiry time is less than 3 minutes.
+    const token = this._getBearerToken();
+    var expiresIn, sessionExpiresIn;
+    if (token) {
+      // Convert seconds to millis.
+      if (token.expiresIn) {
+        expiresIn = token.expiresIn * 1000;
+      }
+      if (token.sessionExpiresIn) {
+        sessionExpiresIn = token.sessionExpiresIn * 1000;
+      }
+    }
+
+    // Session TTL decreases on every renewal, up to a point where it doesn't
+    // make sense to renew anymore, as we won't gain any extra time from it.
+    // Once values are low enough both expiresIn (token expiration) and
+    // sessionExpiresIn are set in lockstep.
+    if (
+      expiresIn > 0 &&
+      sessionExpiresIn > 0 &&
+      expiresIn >= sessionExpiresIn &&
+      sessionExpiresIn <= RENEW_TOKEN_TIME
+    ) {
+      logger.warn(
+        `Session TTL is only ${sessionExpiresIn}ms, the session will expire soon.`
+      );
+      return false;
+    }
+
     // Browsers have js timer throttling behavior in inactive tabs that can go
     // up to 100s between timer calls from testing. 3 minutes seems to be a safe number
     // with extra padding.

--- a/web/packages/teleport/src/services/websession/websession.ts
+++ b/web/packages/teleport/src/services/websession/websession.ts
@@ -147,16 +147,12 @@ const session = {
     }
 
     const token = this._getBearerToken();
-    var expiresIn, sessionExpiresIn;
-    if (token) {
-      // Convert seconds to millis.
-      if (token.expiresIn) {
-        expiresIn = token.expiresIn * 1000;
-      }
-      if (token.sessionExpiresIn) {
-        sessionExpiresIn = token.sessionExpiresIn * 1000;
-      }
+    if (!token) {
+      return false;
     }
+    // Convert seconds to millis.
+    const expiresIn = (token.expiresIn ?? 0) * 1000;
+    const sessionExpiresIn = (token.sessionExpiresIn ?? 0) * 1000;
 
     // Session TTL decreases on every renewal, up to a point where it doesn't
     // make sense to renew anymore, as we won't gain any extra time from it.


### PR DESCRIPTION
Avoid attempting to renew sessions that are about to expire, which previously would cause a tight (and pointless) renewal loop, up until the session finally expires.

Renewing a session may increase the bearer token expiration [up to a point][1] ("expiresIn" in the frontend code), but it does not increase the underlying session expiration ("sessionExpiresIn"). Once enough renewals happen the session TTL is going to be less than RENEW_TOKEN_TIME - at this point we should stop trying.

Follow up from #51592. 

#49629

[1]: https://github.com/gravitational/teleport/blob/b69d49b2a223dd1833bdd0861831c87dc77dc66f/lib/auth/sessions.go#L314

Changelog: Do not attempt to renew sessions that are about to expire