### PR TITLE
Fix TELEPORT_ALLOW_NO_SECOND_FACTOR

### DIFF
--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -28,6 +28,7 @@ import (
 	"log/slog"
 	"os"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -789,7 +790,7 @@ func initializeAuthPreference(ctx context.Context, asrv *Server, newAuthPref typ
 		}
 
 		if !shouldReplace {
-			if os.Getenv(teleport.EnvVarAllowNoSecondFactor) != "true" {
+			if allowNoSecondFactor, _ := strconv.ParseBool(os.Getenv(teleport.EnvVarAllowNoSecondFactor)); allowNoSecondFactor {
 				err := modules.ValidateResource(storedAuthPref)
 				if errors.Is(err, modules.ErrCannotDisableSecondFactor) {
 					return trace.Wrap(err, secondFactorUpgradeInstructions)

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strconv"
 	"sync"
 	"time"
 
@@ -334,9 +335,9 @@ var ErrCannotDisableSecondFactor = errors.New("cannot disable multi-factor authe
 // ValidateResource performs additional resource checks.
 func ValidateResource(res types.Resource) error {
 	// todo(tross): DELETE WHEN ABLE TO [remove env var, leave insecure test mode]
+	allowNoSecondFactor, _ := strconv.ParseBool(os.Getenv(teleport.EnvVarAllowNoSecondFactor))
 	if GetModules().Features().Cloud ||
-		(os.Getenv(teleport.EnvVarAllowNoSecondFactor) != "yes" && !IsInsecureTestMode()) {
-
+		(!allowNoSecondFactor && !IsInsecureTestMode()) {
 		switch r := res.(type) {
 		case types.AuthPreference:
 			if !r.IsSecondFactorEnforced() {


### PR DESCRIPTION
Some parts of Teleport required this env var to be set to "true" while other parts required a value of "yes" - this made it impossible to pass all of the checks.

Use ParseBool instead to be more generous in what values are allowed.