### PR TITLE
Stop using default aws http client in access plugins

### DIFF
--- a/integrations/access/servicenow/client.go
+++ b/integrations/access/servicenow/client.go
@@ -27,7 +27,6 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws/defaults"
 	"github.com/go-resty/resty/v2"
 	"github.com/gravitational/trace"
 
@@ -101,10 +100,7 @@ func NewClient(conf ClientConfig) (*Client, error) {
 	if err := conf.checkAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	client := resty.NewWithClient(defaults.Config().HTTPClient)
-	client.SetTransport(&http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-	})
+
 	apiURL, err := url.Parse(conf.APIEndpoint)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -117,7 +113,19 @@ func NewClient(conf ClientConfig) (*Client, error) {
 		apiURL.Scheme = "https"
 	}
 
-	client.SetBaseURL(conf.APIEndpoint).
+	const (
+		maxConns      = 100
+		clientTimeout = 10 * time.Second
+	)
+
+	client := resty.NewWithClient(&http.Client{
+		Timeout: clientTimeout,
+		Transport: &http.Transport{
+			MaxConnsPerHost:     maxConns,
+			MaxIdleConnsPerHost: maxConns,
+			Proxy:               http.ProxyFromEnvironment,
+		}}).
+		SetBaseURL(apiURL.String()).
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBasicAuth(conf.Username, conf.APIToken)


### PR DESCRIPTION
Updates the servicenow and opsgenie plugins to create an http client manually like all other access plugins. In addition to unifying client creation, this allows us to remove the dependency on the legacy aws sdk.