### PR TITLE
Ensure proxy version getter adds the leading 'v'

### DIFF
--- a/lib/automaticupgrades/version/proxy.go
+++ b/lib/automaticupgrades/version/proxy.go
@@ -28,11 +28,15 @@ import (
 	"github.com/gravitational/teleport/lib/automaticupgrades/constants"
 )
 
-type proxyVersionClient struct {
-	client *webclient.ReusableClient
+type Finder interface {
+	Find() (*webclient.PingResponse, error)
 }
 
-func (b *proxyVersionClient) Get(ctx context.Context) (string, error) {
+type proxyVersionClient struct {
+	client Finder
+}
+
+func (b *proxyVersionClient) Get(_ context.Context) (string, error) {
 	resp, err := b.client.Find()
 	if err != nil {
 		return "", trace.Wrap(err)
@@ -41,7 +45,7 @@ func (b *proxyVersionClient) Get(ctx context.Context) (string, error) {
 	if resp.AutoUpdate.AgentVersion == "" {
 		return "", trace.NotImplemented("proxy does not seem to implement RFD-184")
 	}
-	return resp.AutoUpdate.AgentVersion, nil
+	return EnsureSemver(resp.AutoUpdate.AgentVersion)
 }
 
 // ProxyVersionGetter gets the target version from the Teleport Proxy Service /find endpoint, as
@@ -60,8 +64,7 @@ func (g ProxyVersionGetter) Name() string {
 
 // GetVersion implements Getter
 func (g ProxyVersionGetter) GetVersion(ctx context.Context) (string, error) {
-	result, err := g.cachedGetter(ctx)
-	return result, trace.Wrap(err)
+	return g.cachedGetter(ctx)
 }
 
 // NewProxyVersionGetter creates a ProxyVersionGetter from a webclient.

--- a/lib/automaticupgrades/version/proxy_test.go
+++ b/lib/automaticupgrades/version/proxy_test.go
@@ -1,0 +1,116 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package version
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/client/webclient"
+)
+
+type mockWebClient struct {
+	mock.Mock
+}
+
+func (m *mockWebClient) Find() (*webclient.PingResponse, error) {
+	args := m.Called()
+	return args.Get(0).(*webclient.PingResponse), args.Error(1)
+}
+
+func TestProxyVersionClient(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name            string
+		pong            *webclient.PingResponse
+		pongErr         error
+		expectedVersion string
+		expectErr       require.ErrorAssertionFunc
+	}{
+		{
+			name: "semver without leading v",
+			pong: &webclient.PingResponse{
+				AutoUpdate: webclient.AutoUpdateSettings{
+					AgentVersion: "1.2.3",
+				},
+			},
+			expectedVersion: "v1.2.3",
+			expectErr:       require.NoError,
+		},
+		{
+			name: "semver with leading v",
+			pong: &webclient.PingResponse{
+				AutoUpdate: webclient.AutoUpdateSettings{
+					AgentVersion: "v1.2.3",
+				},
+			},
+			expectedVersion: "v1.2.3",
+			expectErr:       require.NoError,
+		},
+		{
+			name: "semver with prerelease and no leading v",
+			pong: &webclient.PingResponse{
+				AutoUpdate: webclient.AutoUpdateSettings{
+					AgentVersion: "1.2.3-dev.bartmoss.1",
+				},
+			},
+			expectedVersion: "v1.2.3-dev.bartmoss.1",
+			expectErr:       require.NoError,
+		},
+		{
+			name: "invalid semver",
+			pong: &webclient.PingResponse{
+				AutoUpdate: webclient.AutoUpdateSettings{
+					AgentVersion: "v",
+				},
+			},
+			expectedVersion: "",
+			expectErr:       require.Error,
+		},
+		{
+			name:            "empty response",
+			pong:            &webclient.PingResponse{},
+			expectedVersion: "",
+			expectErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorIs(t, err, trace.NotImplemented("proxy does not seem to implement RFD-184"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test setup: create mock and load fixtures.
+			webClient := &mockWebClient{}
+			webClient.On("Find").Once().Return(tt.pong, tt.pongErr)
+
+			// Test execution.
+			clt := proxyVersionClient{client: webClient}
+			v, err := clt.Get(ctx)
+
+			// Test validation.
+			tt.expectErr(t, err)
+			require.Equal(t, tt.expectedVersion, v)
+			webClient.AssertExpectations(t)
+		})
+	}
+}


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/gravitational/teleport/pull/49297. Unlike the other version getters, the proxy getter was not adding the leading "v" to its version. The retrieved version was not semver-valid and this broke the kube-agent updater:

```json
{
  "timestamp": "2025-01-30T23:03:33Z",
  "level": "error",
  "message": "version change is invalid",
  "controller": "statefulset",
  "controllerGroup": "apps",
  "controllerKind": "StatefulSet",
  "StatefulSet": {
    "name": "teleport-agent",
    "namespace": "agent-oss"
  },
  "namespace": "agent-oss",
  "name": "teleport-agent",
  "reconcileID": "7305b090-4ccb-46f9-a19e-72547257a127",
  "namespacedname": "agent-oss/teleport-agent",
  "kind": "StatefulSet",
  "err": "next version is not following semver",
  "current_version": "v18.0.0-dev.hugoau.3",
  "next_version": "18.0.0-dev.hugoau.1"
}
```

Part of: [RFD-184](https://github.com/gravitational/teleport/pull/47126)
Goal (internal): https://github.com/gravitational/cloud/issues/10289