### PR TITLE
[vnet] windows ip and route configuration

### DIFF
--- a/lib/vnet/admin_process_windows.go
+++ b/lib/vnet/admin_process_windows.go
@@ -27,6 +27,10 @@ import (
 	"golang.zx2c4.com/wireguard/tun"
 )
 
+const (
+	tunInterfaceName = "TeleportVNet"
+)
+
 type windowsAdminProcessConfig struct {
 	// clientApplicationServiceAddr is the local TCP address of the client
 	// application gRPC service.
@@ -50,7 +54,7 @@ func runWindowsAdminProcess(ctx context.Context, cfg *windowsAdminProcessConfig)
 		return trace.Wrap(err, "authenticating user process")
 	}
 
-	device, err := tun.CreateTUN("TeleportVNet", mtu)
+	device, err := tun.CreateTUN(tunInterfaceName, mtu)
 	if err != nil {
 		return trace.Wrap(err, "creating TUN device")
 	}

--- a/lib/vnet/osconfig_windows.go
+++ b/lib/vnet/osconfig_windows.go
@@ -18,14 +18,108 @@ package vnet
 
 import (
 	"context"
+	"net"
+	"slices"
+	"strconv"
 
 	"github.com/gravitational/trace"
 )
 
+// platformOSConfigState holds state about which addresses and routes have
+// already been configured in the OS. Experimentally, IP routing seems to be
+// flaky/broken on Windows when the same routes are repeatedly configured, as we
+// currently do on MacOS. Avoid this by only configuring each IP or route once.
+//
+// TODO(nklaassen): it would probably be better to read the current routing
+// table from the OS, compute a diff, and reconcile the routes that we need.
+// This works for now but if something else overwrites our deletes our routes,
+// we'll never reset them.
+type platformOSConfigState struct {
+	configuredV4Address bool
+	configuredV6Address bool
+	configuredRanges    []string
+
+	ifaceIndex string
+}
+
+func (p *platformOSConfigState) getIfaceIndex() (string, error) {
+	if p.ifaceIndex != "" {
+		return p.ifaceIndex, nil
+	}
+	iface, err := net.InterfaceByName(tunInterfaceName)
+	if err != nil {
+		return "", trace.Wrap(err, "looking up TUN interface by name %s", tunInterfaceName)
+	}
+	p.ifaceIndex = strconv.Itoa(iface.Index)
+	return p.ifaceIndex, nil
+}
+
 // platformConfigureOS configures the host OS according to cfg. It is safe to
 // call repeatedly, and it is meant to be called with an empty osConfig to
 // deconfigure anything necessary before exiting.
-func platformConfigureOS(ctx context.Context, cfg *osConfig) error {
-	// TODO(nklaassen): implement platformConfigureOS for Windows.
-	return trace.NotImplemented("platformConfigureOS is not implemented on Windows")
+func platformConfigureOS(ctx context.Context, cfg *osConfig, state *platformOSConfigState) error {
+	// There is no need to remove IP addresses or routes, they will automatically be cleaned up when the
+	// process exits and the TUN is deleted.
+
+	if cfg.tunIPv4 != "" {
+		if !state.configuredV4Address {
+			log.InfoContext(ctx, "Setting IPv4 address for the TUN device",
+				"device", cfg.tunName, "address", cfg.tunIPv4)
+			if err := runCommand(ctx,
+				"netsh", "interface", "ip", "set", "address", cfg.tunName, "static", cfg.tunIPv4,
+			); err != nil {
+				return trace.Wrap(err)
+			}
+			state.configuredV4Address = true
+		}
+		for _, cidrRange := range cfg.cidrRanges {
+			if slices.Contains(state.configuredRanges, cidrRange) {
+				continue
+			}
+			log.InfoContext(ctx, "Routing CIDR range to the TUN IP",
+				"device", cfg.tunName, "range", cidrRange)
+			ifaceIndex, err := state.getIfaceIndex()
+			if err != nil {
+				return trace.Wrap(err, "getting index for TUN interface")
+			}
+			addr, mask, err := addrMaskForCIDR(cidrRange)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			if err := runCommand(ctx,
+				"route", "add", addr, "mask", mask, cfg.tunIPv4, "if", ifaceIndex,
+			); err != nil {
+				return trace.Wrap(err)
+			}
+			state.configuredRanges = append(state.configuredRanges, cidrRange)
+		}
+	}
+
+	if cfg.tunIPv6 != "" && !state.configuredV6Address {
+		// It looks like we don't need to explicitly set a route for the IPv6
+		// ULA prefix, assigning the address to the interface is enough.
+		log.InfoContext(ctx, "Setting IPv6 address for the TUN device.",
+			"device", cfg.tunName, "address", cfg.tunIPv6)
+		if err := runCommand(ctx,
+			"netsh", "interface", "ipv6", "set", "address", cfg.tunName, cfg.tunIPv6,
+		); err != nil {
+			return trace.Wrap(err)
+		}
+		state.configuredV6Address = true
+	}
+
+	// TODO(nklaassen): configure DNS on Windows.
+
+	return nil
+}
+
+// addrMaskForCIDR returns the base address and the bitmask for a given CIDR
+// range. The "route add" command wants the mask in dotted decimal format, e.g.
+// for 100.64.0.0/10 the mask should be 255.192.0.0
+func addrMaskForCIDR(cidr string) (string, string, error) {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", "", trace.Wrap(err, "parsing CIDR range %s", cidr)
+	}
+	return ipNet.IP.String(), net.IP(ipNet.Mask).String(), nil
 }

--- a/lib/vnet/unsupported_os.go
+++ b/lib/vnet/unsupported_os.go
@@ -33,7 +33,9 @@ func runPlatformUserProcess(_ context.Context, _ *UserProcessConfig) (*ProcessMa
 	return nil, trace.Wrap(ErrVnetNotImplemented)
 }
 
-func platformConfigureOS(_ context.Context, _ *osConfig) error {
+type platformOSConfigState struct{}
+
+func platformConfigureOS(_ context.Context, _ *osConfig, _ *platformOSConfigState) error {
 	return trace.Wrap(ErrVnetNotImplemented)
 }
 
@@ -41,4 +43,5 @@ func platformConfigureOS(_ context.Context, _ *osConfig) error {
 var (
 	_ = newOSConfigurator
 	_ = (*osConfigurator).runOSConfigurationLoop
+	_ = runCommand
 )


### PR DESCRIPTION
Part of [RFD 195](https://github.com/gravitational/teleport/pull/50850).

This PR adds OS configuration for VNet on Windows. Specifically, the TUN interface is now configured with a V6 and V4 IP address, and IP routes are configured so that IP packets in the VNet IP ranges for each cluster are routed to the TUN interface and handled by VNet.

This PR does *not* configure the VNet DNS nameserver on Windows, that will come in a following PR.

With these changes, VNet kind of works, without DNS. You can manually query the IP address of VNet's DNS server and get back a v4 and v6 address for the app. TCP connections to either of these addresses then work for connecting to the app.