### PR TITLE
Convert lib/services to use aws-sdk-go-v2

### DIFF
--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -31,7 +31,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	jsoniter "github.com/json-iterator/go"


### PR DESCRIPTION
There was only one usage of the legacy sdk, a call to arn.IsARN, which has a direct replacement in the v2 arn package.