### PR TITLE
Fix typo

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -6245,7 +6245,7 @@ func (a *Server) CreateAccessListReminderNotifications(ctx context.Context) {
 			daysDiff := int(timeDiff.Hours() / 24)
 
 			if threshold.days < 0 {
-				if daysDiff <= -threshold.days {
+				if daysDiff <= threshold.days {
 					relevantLists = append(relevantLists, al)
 				}
 			} else {


### PR DESCRIPTION
Fixes a typo in the access list logic for creating overdue notifications, I had changed the threshold to accept negative days but forgot to remove this.