### PR TITLE
[teleport-update] Only use CDN for community / enterprise editions

### DIFF
--- a/lib/autoupdate/agent/config.go
+++ b/lib/autoupdate/agent/config.go
@@ -239,4 +239,6 @@ type FindResp struct {
 	InWindow bool `yaml:"in_window"`
 	// Jitter duration before an automated install
 	Jitter time.Duration `yaml:"jitter"`
+	// AGPL installations cannot use the official CDN.
+	AGPL bool `yaml:"agpl,omitempty"`
 }

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/agpl_requires_base_URL.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/agpl_requires_base_URL.golden
@@ -1,0 +1,9 @@
+version: v1
+kind: update_config
+spec:
+    proxy: ""
+    enabled: false
+    pinned: false
+status:
+    active:
+        version: ""

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/agpl_requires_base_URL.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/agpl_requires_base_URL.golden
@@ -1,0 +1,11 @@
+version: v1
+kind: update_config
+spec:
+    proxy: localhost
+    enabled: true
+    pinned: false
+status:
+    active:
+        version: old-version
+    backup:
+        version: backup-version

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -669,7 +669,7 @@ func (u *Updater) update(ctx context.Context, cfg *UpdateConfig, target Revision
 	baseURL := cfg.Spec.BaseURL
 	if baseURL == "" {
 		if agpl {
-			return trace.Errorf("base URL must be specified for AGPL edition of Teleport")
+			return trace.Errorf("--base-url flag must be specified for AGPL edition of Teleport")
 		}
 		baseURL = autoupdate.DefaultBaseURL
 	}

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -327,7 +327,7 @@ func (u *Updater) Install(ctx context.Context, override OverrideConfig) error {
 		u.Log.InfoContext(ctx, "Initiating installation.", targetKey, target, activeKey, active)
 	}
 
-	if err := u.update(ctx, cfg, target, override.AllowOverwrite); err != nil {
+	if err := u.update(ctx, cfg, target, override.AllowOverwrite, resp.AGPL); err != nil {
 		if errors.Is(err, ErrFilePresent) && !override.AllowOverwrite {
 			u.Log.WarnContext(ctx, "Use --overwrite to force removal of existing binaries installed via script.")
 			u.Log.WarnContext(ctx, "If a teleport rpm or deb package is installed, upgrade it to the latest version and retry. DO NOT USE --overwrite.")
@@ -608,7 +608,7 @@ func (u *Updater) Update(ctx context.Context, now bool) error {
 		time.Sleep(resp.Jitter)
 	}
 
-	updateErr := u.update(ctx, cfg, target, false)
+	updateErr := u.update(ctx, cfg, target, false, resp.AGPL)
 	writeErr := writeConfig(u.ConfigPath, cfg)
 	if writeErr != nil {
 		writeErr = trace.Wrap(writeErr, "failed to write %s", updateConfigName)
@@ -642,12 +642,16 @@ func (u *Updater) find(ctx context.Context, cfg *UpdateConfig) (FindResp, error)
 		return FindResp{}, trace.Wrap(err, "failed to request version from proxy")
 	}
 	var flags autoupdate.InstallFlags
+	var agpl bool
 	switch resp.Edition {
 	case modules.BuildEnterprise:
 		flags |= autoupdate.FlagEnterprise
-	case modules.BuildOSS, modules.BuildCommunity:
+	case modules.BuildCommunity:
+	case modules.BuildOSS:
+		agpl = true
 	default:
-		u.Log.WarnContext(ctx, "Unknown edition detected, defaulting to community.", "edition", resp.Edition)
+		agpl = true
+		u.Log.WarnContext(ctx, "Unknown edition detected, defaulting to OSS.", "edition", resp.Edition)
 	}
 	if resp.FIPS {
 		flags |= autoupdate.FlagFIPS
@@ -657,10 +661,19 @@ func (u *Updater) find(ctx context.Context, cfg *UpdateConfig) (FindResp, error)
 		Target:   NewRevision(resp.AutoUpdate.AgentVersion, flags),
 		InWindow: resp.AutoUpdate.AgentAutoUpdate,
 		Jitter:   time.Duration(jitterSec) * time.Second,
+		AGPL:     agpl,
 	}, nil
 }
 
-func (u *Updater) update(ctx context.Context, cfg *UpdateConfig, target Revision, force bool) error {
+func (u *Updater) update(ctx context.Context, cfg *UpdateConfig, target Revision, force, agpl bool) error {
+	baseURL := cfg.Spec.BaseURL
+	if baseURL == "" {
+		if agpl {
+			return trace.Errorf("base URL must be specified for AGPL edition of Teleport")
+		}
+		baseURL = autoupdate.DefaultBaseURL
+	}
+
 	active := cfg.Status.Active
 	backup := deref(cfg.Status.Backup)
 	switch backup {
@@ -679,10 +692,6 @@ func (u *Updater) update(ctx context.Context, cfg *UpdateConfig, target Revision
 
 	// Install and link the desired version (or validate existing installation)
 
-	baseURL := cfg.Spec.BaseURL
-	if baseURL == "" {
-		baseURL = autoupdate.DefaultBaseURL
-	}
 	err := u.Installer.Install(ctx, target, baseURL)
 	if err != nil {
 		return trace.Wrap(err, "failed to install")


### PR DESCRIPTION
This PR prevents AGPL editions of Teleport agents from auto-updating to non-AGPL editions of Teleport via the `teleport-update` command.

This PR also explicitly advertises when you're targeting an AGPL version of Teleport via the `teleport-update status` command.

 ---

The `teleport-update` binary will be used to enable, disable, and trigger automatic Teleport agent updates. The new auto-updates system manages a local installation of the cluster-specified version of Teleport stored in `/opt/teleport`.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/10289