### PR TITLE
SAML: Validate SSO URL matches the one in entity descriptor if both set

### DIFF
--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -102,7 +102,15 @@ func ValidateSAMLConnector(sc types.SAMLConnector, rg RoleGetter) error {
 
 		sc.SetIssuer(md.EntityID)
 		if md.IDPSSODescriptor != nil && len(md.IDPSSODescriptor.SingleSignOnServices) > 0 {
-			sc.SetSSO(md.IDPSSODescriptor.SingleSignOnServices[0].Location)
+			metadataSsoUrl := md.IDPSSODescriptor.SingleSignOnServices[0].Location
+			if sc.GetSSO() != "" && sc.GetSSO() != metadataSsoUrl {
+				slog.WarnContext(
+					context.Background(),
+					"Connector has set SSO URL, but it does not match the one found in IDP metadata. Overwriting with the IDP metadata SSO URL.",
+					"connector_name", sc.GetName(), "connector_sso_url", sc.GetSSO(), "idp_metadata_sso_url", metadataSsoUrl,
+				)
+			}
+			sc.SetSSO(metadataSsoUrl)
 		}
 	}
 


### PR DESCRIPTION
Some safety measure I figured would be good to add while working on https://github.com/gravitational/teleport.e/pull/5990