### PR TITLE
Default BaseURL only for community / enterprise editions

### DIFF
--- a/integration/autoupdate/tools/updater/modules.go
+++ b/integration/autoupdate/tools/updater/modules.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"crypto"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -35,8 +36,12 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
-// TestPassword is password generated during the test to login in test cluster.
-const TestPassword = "UPDATER_TEST_PASSWORD"
+const (
+	// TestPassword is env var used for setting password generated during the test to login in test cluster.
+	TestPassword = "UPDATER_TEST_PASSWORD"
+	// TestBuild is env var for setting test build type during the test.
+	TestBuild = "UPDATER_TEST_BUILD"
+)
 
 var (
 	version = teleport.Version
@@ -54,17 +59,20 @@ func (p *TestModules) GetSuggestedAccessLists(context.Context, *tlsca.Identity, 
 
 // BuildType returns build type (OSS or Enterprise)
 func (p *TestModules) BuildType() string {
+	if build := os.Getenv(TestBuild); build != "" {
+		return build
+	}
 	return "CLI"
 }
 
 // IsEnterpriseBuild returns false for [TestModules].
 func (p *TestModules) IsEnterpriseBuild() bool {
-	return false
+	return os.Getenv(TestBuild) == modules.BuildEnterprise
 }
 
 // IsOSSBuild returns false for [TestModules].
 func (p *TestModules) IsOSSBuild() bool {
-	return false
+	return os.Getenv(TestBuild) == modules.BuildOSS
 }
 
 // LicenseExpiry returns the expiry date of the enterprise license, if applicable.

--- a/lib/autoupdate/tools/helper.go
+++ b/lib/autoupdate/tools/helper.go
@@ -113,7 +113,7 @@ func updateAndReExec(ctx context.Context, updater *Updater, toolsVersion string,
 	err := updater.UpdateWithLock(ctxUpdate, toolsVersion)
 	if err != nil && errors.Is(err, errNoBaseURL) {
 		// If base URL wasn't defined we have to cancel update and re-execution with warning.
-		slog.WarnContext(ctx, "Client tools updates are disabled because the server is licensed under AGPL "+
+		slog.WarnContext(ctx, "client tools updates are disabled because the server is licensed under AGPL "+
 			"but Teleport-distributed binaries are licensed under Community Edition. To use Community Edition "+
 			"builds or custom binaries, set the 'TELEPORT_CDN_BASE_URL' environment variable.")
 		return nil

--- a/lib/autoupdate/tools/helper.go
+++ b/lib/autoupdate/tools/helper.go
@@ -111,6 +111,13 @@ func updateAndReExec(ctx context.Context, updater *Updater, toolsVersion string,
 	// is required if the user passed in the TELEPORT_TOOLS_VERSION
 	// explicitly.
 	err := updater.UpdateWithLock(ctxUpdate, toolsVersion)
+	if err != nil && errors.Is(err, errNoBaseURL) {
+		// If base URL wasn't defined we have to cancel update and re-execution with warning.
+		slog.WarnContext(ctx, "Client tools updates are disabled because the server is licensed under AGPL "+
+			"but Teleport-distributed binaries are licensed under Community Edition. To use Community Edition "+
+			"builds or custom binaries, set the 'TELEPORT_CDN_BASE_URL' environment variable.")
+		return nil
+	}
 	if err != nil && !errors.Is(err, context.Canceled) {
 		return trace.Wrap(err)
 	}

--- a/lib/autoupdate/tools/helper.go
+++ b/lib/autoupdate/tools/helper.go
@@ -31,6 +31,11 @@ import (
 	stacksignal "github.com/gravitational/teleport/lib/utils/signal"
 )
 
+// warnMessageOSSBuild is warning exposed to the user that build type without base url is disabled.
+const warnMessageOSSBuild = "Client tools updates are disabled because the server is licensed under AGPL " +
+	"but Teleport-distributed binaries are licensed under Community Edition. To use Community Edition " +
+	"builds or custom binaries, set the 'TELEPORT_CDN_BASE_URL' environment variable."
+
 // Variables might to be overridden during compilation time for integration tests.
 var (
 	// version is the current version of the Teleport.
@@ -113,9 +118,7 @@ func updateAndReExec(ctx context.Context, updater *Updater, toolsVersion string,
 	err := updater.UpdateWithLock(ctxUpdate, toolsVersion)
 	if err != nil && errors.Is(err, errNoBaseURL) {
 		// If base URL wasn't defined we have to cancel update and re-execution with warning.
-		slog.WarnContext(ctx, "client tools updates are disabled because the server is licensed under AGPL "+
-			"but Teleport-distributed binaries are licensed under Community Edition. To use Community Edition "+
-			"builds or custom binaries, set the 'TELEPORT_CDN_BASE_URL' environment variable.")
+		slog.WarnContext(ctx, warnMessageOSSBuild)
 		return nil
 	}
 	if err != nil && !errors.Is(err, context.Canceled) {

--- a/lib/autoupdate/tools/helper.go
+++ b/lib/autoupdate/tools/helper.go
@@ -28,13 +28,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/autoupdate"
-	"github.com/gravitational/teleport/lib/modules"
 	stacksignal "github.com/gravitational/teleport/lib/utils/signal"
-)
-
-const (
-	// warningOSSBuild is warning exposed to the user that build type without base url is disabled.
-	warningOSSBuild = "Client tools update is disabled. Use 'TELEPORT_CDN_BASE_URL' environment variable to set CDN base URL"
 )
 
 // Variables might to be overridden during compilation time for integration tests.
@@ -59,14 +53,8 @@ func CheckAndUpdateLocal(ctx context.Context, reExecArgs []string) error {
 		return nil
 	}
 
-	bType := modules.GetModules().BuildType()
-	envBaseURL := os.Getenv(autoupdate.BaseURLEnvVar)
-	if bType == modules.BuildOSS && envBaseURL == "" {
-		slog.WarnContext(ctx, warningOSSBuild)
-		return nil
-	}
 	// Overrides default base URL for custom CDN for downloading updates.
-	if envBaseURL != "" {
+	if envBaseURL := os.Getenv(autoupdate.BaseURLEnvVar); envBaseURL != "" {
 		baseURL = envBaseURL
 	}
 
@@ -98,14 +86,9 @@ func CheckAndUpdateRemote(ctx context.Context, proxy string, insecure bool, reEx
 		slog.WarnContext(ctx, "Client tools update is disabled", "error", err)
 		return nil
 	}
-	bType := modules.GetModules().BuildType()
-	envBaseURL := os.Getenv(autoupdate.BaseURLEnvVar)
-	if bType == modules.BuildOSS && envBaseURL == "" {
-		slog.WarnContext(ctx, warningOSSBuild)
-		return nil
-	}
+
 	// Overrides default base URL for custom CDN for downloading updates.
-	if envBaseURL != "" {
+	if envBaseURL := os.Getenv(autoupdate.BaseURLEnvVar); envBaseURL != "" {
 		baseURL = envBaseURL
 	}
 

--- a/lib/autoupdate/tools/updater.go
+++ b/lib/autoupdate/tools/updater.go
@@ -43,7 +43,6 @@ import (
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/lib/autoupdate"
-	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/packaging"
 )
@@ -58,8 +57,6 @@ const (
 	lockFileName = ".lock"
 	// updatePackageSuffix is directory suffix used for package extraction in tools directory.
 	updatePackageSuffix = "-update-pkg"
-	// warnMessageOSSBuild is warning exposed to the user that build type without base url is disabled.
-	warnMessageOSSBuild = "Client tools update is disabled. Use 'TELEPORT_CDN_BASE_URL' environment variable to set CDN base URL"
 )
 
 var (
@@ -265,13 +262,6 @@ func (u *Updater) UpdateWithLock(ctx context.Context, updateToolsVersion string)
 // Update downloads requested version and replace it with existing one and cleanups the previous downloads
 // with defined updater directory suffix.
 func (u *Updater) Update(ctx context.Context, toolsVersion string) error {
-	// Disable update for the OSS build if custom base URL wasn't set.
-	envBaseURL := os.Getenv(autoupdate.BaseURLEnvVar)
-	if modules.GetModules().BuildType() == modules.BuildOSS && envBaseURL == "" {
-		slog.WarnContext(ctx, warnMessageOSSBuild)
-		return nil
-	}
-
 	// Get platform specific download URLs.
 	packages, err := teleportPackageURLs(u.uriTemplate, u.baseURL, toolsVersion)
 	if err != nil {

--- a/lib/autoupdate/tools/updater.go
+++ b/lib/autoupdate/tools/updater.go
@@ -409,11 +409,6 @@ func (u *Updater) downloadHash(ctx context.Context, url string) ([]byte, error) 
 // downloadArchive downloads the archive package by `url` and writes content to the writer interface,
 // return calculated sha256 hash sum of the content.
 func (u *Updater) downloadArchive(ctx context.Context, url string, f io.Writer) ([]byte, error) {
-	// Display a progress bar before initiating the update request to inform the user that
-	// an update is in progress, allowing them the option to cancel before actual response
-	// which might be delayed with slow internet connection or complete isolation to CDN.
-	pw, finish := newProgressWriter(10)
-	defer finish()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -429,6 +424,8 @@ func (u *Updater) downloadArchive(ctx context.Context, url string, f io.Writer) 
 	if resp.StatusCode != http.StatusOK {
 		return nil, trace.BadParameter("bad status when downloading archive: %v", resp.StatusCode)
 	}
+	pw, finish := newProgressWriter(10)
+	defer finish()
 
 	if resp.ContentLength != -1 {
 		if err := checkFreeSpace(u.toolsDir, uint64(resp.ContentLength)); err != nil {

--- a/lib/autoupdate/tools/updater.go
+++ b/lib/autoupdate/tools/updater.go
@@ -43,6 +43,7 @@ import (
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/lib/autoupdate"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/packaging"
 )
@@ -57,6 +58,8 @@ const (
 	lockFileName = ".lock"
 	// updatePackageSuffix is directory suffix used for package extraction in tools directory.
 	updatePackageSuffix = "-update-pkg"
+	// warnMessageOSSBuild is warning exposed to the user that build type without base url is disabled.
+	warnMessageOSSBuild = "Client tools update is disabled. Use 'TELEPORT_CDN_BASE_URL' environment variable to set CDN base URL"
 )
 
 var (
@@ -262,6 +265,13 @@ func (u *Updater) UpdateWithLock(ctx context.Context, updateToolsVersion string)
 // Update downloads requested version and replace it with existing one and cleanups the previous downloads
 // with defined updater directory suffix.
 func (u *Updater) Update(ctx context.Context, toolsVersion string) error {
+	// Disable update for the OSS build if custom base URL wasn't set.
+	envBaseURL := os.Getenv(autoupdate.BaseURLEnvVar)
+	if modules.GetModules().BuildType() == modules.BuildOSS && envBaseURL == "" {
+		slog.WarnContext(ctx, warnMessageOSSBuild)
+		return nil
+	}
+
 	// Get platform specific download URLs.
 	packages, err := teleportPackageURLs(u.uriTemplate, u.baseURL, toolsVersion)
 	if err != nil {

--- a/lib/autoupdate/tools/utils.go
+++ b/lib/autoupdate/tools/utils.go
@@ -40,6 +40,8 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
+var errNoBaseURL = errors.New("baseURL is not defined")
+
 // Dir returns the path to client tools in $TELEPORT_HOME/bin.
 func Dir() (string, error) {
 	home := os.Getenv(types.HomeEnvVar)
@@ -128,6 +130,11 @@ type packageURL struct {
 
 // teleportPackageURLs returns the URL for the Teleport archive to download.
 func teleportPackageURLs(uriTmpl string, baseURL, version string) ([]packageURL, error) {
+	envBaseURL := os.Getenv(autoupdate.BaseURLEnvVar)
+	if modules.GetModules().BuildType() == modules.BuildOSS && envBaseURL == "" {
+		return nil, errNoBaseURL
+	}
+
 	var flags autoupdate.InstallFlags
 	m := modules.GetModules()
 	if m.IsBoringBinary() {


### PR DESCRIPTION
This PR prevents AGPL editions of Teleport agents from auto-updating to non-AGPL editions of Teleport via {tsh, tctl}.

Also added fix for progress bar for Darwin platform where we download two packages for version <v17, otherwise we always show empty progress bar for second package.

Changelog: Client tools managed updates requires base URL for open source build type.
Changelog: Fixed progress bar for client tools managed updates in darwin platform for not required packages.