### PR TITLE
[vnet] configure split DNS for VNet on Windows

### DIFF
--- a/lib/vnet/client_application_service_client.go
+++ b/lib/vnet/client_application_service_client.go
@@ -86,6 +86,11 @@ func (c *clientApplicationServiceClient) ResolveAppInfo(ctx context.Context, fqd
 	resp, err := c.clt.ResolveAppInfo(ctx, &vnetv1.ResolveAppInfoRequest{
 		Fqdn: fqdn,
 	})
+	// Convert NotFound errors to errNoTCPHandler, which is what the network
+	// stack is looking for. Avoid wrapping, no need to collect a stack trace.
+	if trace.IsNotFound(err) {
+		return nil, errNoTCPHandler
+	}
 	if err != nil {
 		return nil, trace.Wrap(err, "calling ResolveAppInfo rpc")
 	}

--- a/lib/vnet/remote_app_provider.go
+++ b/lib/vnet/remote_app_provider.go
@@ -21,6 +21,7 @@ import (
 	"crypto"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"io"
 
 	"github.com/gravitational/trace"
@@ -43,6 +44,10 @@ func newRemoteAppProvider(clt *clientApplicationServiceClient) *remoteAppProvide
 // ResolveAppInfo implements [appProvider.ResolveAppInfo].
 func (p *remoteAppProvider) ResolveAppInfo(ctx context.Context, fqdn string) (*vnetv1.AppInfo, error) {
 	appInfo, err := p.clt.ResolveAppInfo(ctx, fqdn)
+	// Avoid wrapping errNoTCPHandler, no need to collect a stack trace.
+	if errors.Is(err, errNoTCPHandler) {
+		return nil, errNoTCPHandler
+	}
 	return appInfo, trace.Wrap(err)
 }
 


### PR DESCRIPTION
Part of [RFD 195](https://github.com/gravitational/teleport/pull/50850).

With these changes, VNet now configures split DNS on Windows so that queries for all VNet DNS zones are handled by VNet's DNS nameserver.

At this point, `tsh vnet` actually works on Windows. You still have to manually install the Windows service and wintun.dll, but this will be handled in the Connect installer later on.