### PR TITLE
[web] include git servers as option in filters

### DIFF
--- a/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
+++ b/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
@@ -44,7 +44,7 @@ const kindToLabel: Record<SharedUnifiedResource['resource']['kind'], string> = {
   kube_cluster: 'Kubernetes',
   node: 'Server',
   user_group: 'User group',
-  git_server: 'Git',
+  git_server: 'Git Server',
 };
 
 const sortFieldOptions = [

--- a/web/packages/teleport/src/Navigation/ResourcesSection.tsx
+++ b/web/packages/teleport/src/Navigation/ResourcesSection.tsx
@@ -148,6 +148,11 @@ function getResourcesSubsections({
     kinds: ['node'],
     pinnedOnly: false,
   });
+  const gitOnlyRoute = encodeUrlQueryParamsWithTypedKinds({
+    pathname: baseRoute,
+    kinds: ['git_server'],
+    pinnedOnly: false,
+  });
 
   return [
     {
@@ -212,6 +217,17 @@ function getResourcesSubsections({
       category: NavigationCategory.Resources,
       exact: false,
       customRouteMatchFn: () => isKindActive('windows_desktop'),
+      onClick: () => setPinnedUserPreference(false),
+      subCategory: CustomNavigationSubcategory.FilteredViews,
+    },
+    {
+      title: 'Git Servers',
+      icon: Icons.GitHub,
+      route: gitOnlyRoute,
+      searchableTags: ['resources', 'git', 'github', 'git servers'],
+      category: NavigationCategory.Resources,
+      exact: false,
+      customRouteMatchFn: () => isKindActive('git_server'),
       onClick: () => setPinnedUserPreference(false),
       subCategory: CustomNavigationSubcategory.FilteredViews,
     },


### PR DESCRIPTION
Git Servers are in the resource types but weren't in the filtered view.

This adds in 

<img width="327" alt="image" src="https://github.com/user-attachments/assets/aa18b230-a421-48a2-a15a-1d4c65dc3b6e" />
