### PR TITLE
Use new autoupdate APIs in discovery service

### DIFF
--- a/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
+++ b/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
@@ -202,7 +202,7 @@ func main() {
 			"proxy_version", pong.ServerVersion,
 		)
 
-		versionGetters = append(versionGetters, version.NewProxyVersionGetter("proxy update protocol", proxyClt))
+		versionGetters = append(versionGetters, version.NewProxyVersionGetter(proxyClt))
 
 		// In RFD 184, the server is driving the update, so both regular maintenances and
 		// critical ones are fetched from the proxy. Using the same trigger ensures we hit the cache if both triggers

--- a/lib/automaticupgrades/version/proxy.go
+++ b/lib/automaticupgrades/version/proxy.go
@@ -53,13 +53,7 @@ func (b *proxyVersionClient) Get(_ context.Context) (string, error) {
 // The Getter returns trace.NotImplementedErr when running against a proxy that does not seem to
 // expose automatic update instructions over the /find endpoint (proxy too old).
 type ProxyVersionGetter struct {
-	name         string
 	cachedGetter func(context.Context) (string, error)
-}
-
-// Name implements Getter
-func (g ProxyVersionGetter) Name() string {
-	return g.name
 }
 
 // GetVersion implements Getter
@@ -69,10 +63,10 @@ func (g ProxyVersionGetter) GetVersion(ctx context.Context) (string, error) {
 
 // NewProxyVersionGetter creates a ProxyVersionGetter from a webclient.
 // The answer is cached for a minute.
-func NewProxyVersionGetter(name string, clt *webclient.ReusableClient) Getter {
+func NewProxyVersionGetter(clt *webclient.ReusableClient) Getter {
 	versionClient := &proxyVersionClient{
 		client: clt,
 	}
 
-	return ProxyVersionGetter{name, cache.NewTimedMemoize[string](versionClient.Get, constants.CacheDuration).Get}
+	return ProxyVersionGetter{cache.NewTimedMemoize[string](versionClient.Get, constants.CacheDuration).Get}
 }

--- a/lib/kube/utils/utils.go
+++ b/lib/kube/utils/utils.go
@@ -33,7 +33,6 @@ import (
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/automaticupgrades"
 	"github.com/gravitational/teleport/lib/automaticupgrades/version"
 )
 
@@ -227,7 +226,7 @@ type Pinger interface {
 
 // GetKubeAgentVersion returns a version of the Kube agent appropriate for this Teleport cluster. Used for example when deciding version
 // for enrolling EKS clusters.
-func GetKubeAgentVersion(ctx context.Context, pinger Pinger, clusterFeatures proto.Features, releaseChannels automaticupgrades.Channels) (string, error) {
+func GetKubeAgentVersion(ctx context.Context, pinger Pinger, clusterFeatures proto.Features, versionGetter version.Getter) (string, error) {
 	pingResponse, err := pinger.Ping(ctx)
 	if err != nil {
 		return "", trace.Wrap(err)
@@ -235,7 +234,7 @@ func GetKubeAgentVersion(ctx context.Context, pinger Pinger, clusterFeatures pro
 	agentVersion := pingResponse.ServerVersion
 
 	if clusterFeatures.GetAutomaticUpgrades() && clusterFeatures.GetCloud() {
-		defaultVersion, err := releaseChannels.DefaultVersion(ctx)
+		defaultVersion, err := versionGetter.GetVersion(ctx)
 		if err == nil {
 			agentVersion = defaultVersion
 		} else if !errors.Is(err, &version.NoNewVersionError{}) {

--- a/lib/kube/utils/utils_test.go
+++ b/lib/kube/utils/utils_test.go
@@ -145,12 +145,11 @@ func TestGetAgentVersion(t *testing.T) {
 				err := channel.CheckAndSetDefaults()
 				require.NoError(t, err)
 			}
-			releaseChannels := automaticupgrades.Channels{automaticupgrades.DefaultChannelName: channel}
 
-			version, err := GetKubeAgentVersion(ctx, p, tt.clusterFeatures, releaseChannels)
+			result, err := GetKubeAgentVersion(ctx, p, tt.clusterFeatures, channel)
 
 			tt.errorAssert(t, err)
-			require.Equal(t, tt.expectedVersion, version)
+			require.Equal(t, tt.expectedVersion, result)
 		})
 	}
 }

--- a/lib/srv/discovery/kube_integration_watcher.go
+++ b/lib/srv/discovery/kube_integration_watcher.go
@@ -20,9 +20,9 @@ package discovery
 
 import (
 	"context"
-	"fmt"
 	"maps"
 	"net/url"
+	"path"
 	"slices"
 	"strings"
 	"sync"

--- a/lib/srv/discovery/kube_integration_watcher.go
+++ b/lib/srv/discovery/kube_integration_watcher.go
@@ -76,7 +76,7 @@ func (s *Server) startKubeIntegrationWatchers() error {
 	} else {
 		versionGetter, err = versionGetterForProxy(s.ctx, proxyPublicAddr)
 		if err != nil {
-			s.Log.ErrorContext(s.ctx,
+			s.Log.WarnContext(s.ctx,
 				"Failed to build a version client, falling back to Discovery service Teleport version.",
 				"error", err,
 				"version", teleport.Version)

--- a/lib/srv/discovery/kube_integration_watcher.go
+++ b/lib/srv/discovery/kube_integration_watcher.go
@@ -69,12 +69,17 @@ func (s *Server) startKubeIntegrationWatchers() error {
 		// If there are no proxy services running, we might fail to get the proxy URL and build a client.
 		// In this case we "gracefully" fallback to our own version.
 		// This is not supposed to happen outside of tests as the discovery service must join via a proxy.
-		s.Log.WarnContext(s.ctx, "Failed to determine proxy public address, agents will install our own Teleport version instead of the one advertised by the proxy.")
+		s.Log.WarnContext(s.ctx,
+			"Failed to determine proxy public address, agents will install our own Teleport version instead of the one advertised by the proxy.",
+			"version", teleport.Version)
 		versionGetter = version.NewStaticGetter(teleport.Version, nil)
 	} else {
 		versionGetter, err = versionGetterForProxy(s.ctx, proxyPublicAddr)
 		if err != nil {
-			s.Log.ErrorContext(s.ctx, "Failed to build a version client, falling back to Discovery service Teleport version.")
+			s.Log.ErrorContext(s.ctx,
+				"Failed to build a version client, falling back to Discovery service Teleport version.",
+				"error", err,
+				"version", teleport.Version)
 			versionGetter = version.NewStaticGetter(teleport.Version, nil)
 		}
 	}

--- a/lib/srv/discovery/kube_integration_watcher.go
+++ b/lib/srv/discovery/kube_integration_watcher.go
@@ -389,7 +389,11 @@ func versionGetterForProxy(ctx context.Context, proxyPublicAddr string) (version
 		return nil, trace.Wrap(err, "failed to build proxy client")
 	}
 
-	baseURL, err := url.Parse(fmt.Sprintf("https://%s/webapi/automaticupgrades/channel/%s", proxyPublicAddr, automaticupgrades.DefaultChannelName))
+	baseURL := &url.URL{
+		Scheme:  "https",
+		Host:    proxyPublicAddr,
+		RawPath: path.Join("/webapi/automaticupgrades/channel", automaticupgrades.DefaultChannelName),
+	}
 	if err != nil {
 		return nil, trace.Wrap(err, "crafting the channel base URL (this is a bug)")
 	}

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1844,10 +1844,13 @@ func (h *Handler) getWebConfig(w http.ResponseWriter, r *http.Request, p httprou
 	automaticUpgradesEnabled := clusterFeatures.GetAutomaticUpgrades()
 	var automaticUpgradesTargetVersion string
 	if automaticUpgradesEnabled {
-		automaticUpgradesTargetVersion, err = h.cfg.AutomaticUpgradesChannels.DefaultVersion(r.Context())
+		const group, updaterUUID = "", ""
+		agentVersion, err := h.autoUpdateAgentVersion(r.Context(), group, updaterUUID)
 		if err != nil {
-			h.logger.ErrorContext(r.Context(), "Cannot read target version", "error", err)
+			h.logger.ErrorContext(r.Context(), "Cannot read autoupdate target version", "error", err)
 		}
+		// agentVersion doesn't have the leading "v" which is expected here.
+		automaticUpgradesTargetVersion = fmt.Sprintf("v%s", agentVersion)
 	}
 
 	webCfg := webclient.WebConfig{

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1848,9 +1848,10 @@ func (h *Handler) getWebConfig(w http.ResponseWriter, r *http.Request, p httprou
 		agentVersion, err := h.autoUpdateAgentVersion(r.Context(), group, updaterUUID)
 		if err != nil {
 			h.logger.ErrorContext(r.Context(), "Cannot read autoupdate target version", "error", err)
+		} else {
+			// agentVersion doesn't have the leading "v" which is expected here.
+			automaticUpgradesTargetVersion = fmt.Sprintf("v%s", agentVersion)
 		}
-		// agentVersion doesn't have the leading "v" which is expected here.
-		automaticUpgradesTargetVersion = fmt.Sprintf("v%s", agentVersion)
 	}
 
 	webCfg := webclient.WebConfig{

--- a/lib/web/autoupdate_common.go
+++ b/lib/web/autoupdate_common.go
@@ -20,6 +20,7 @@ package web
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/gravitational/trace"
@@ -49,6 +50,22 @@ func (h *Handler) autoUpdateAgentVersion(ctx context.Context, group, updaterUUID
 	}
 
 	return getVersionFromRollout(rollout, group, updaterUUID)
+}
+
+// handlerVersionGetter is a dummy struct implementing version.Getter by wrapping Handler.autoUpdateAgentVersion.
+type handlerVersionGetter struct {
+	*Handler
+}
+
+// GetVersion implements version.Getter.
+func (h *handlerVersionGetter) GetVersion(ctx context.Context) (string, error) {
+	const group, updaterUUID = "", ""
+	agentVersion, err := h.autoUpdateAgentVersion(ctx, group, updaterUUID)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	// We add the leading v required by the version.Getter interface.
+	return fmt.Sprintf("v%s", agentVersion), nil
 }
 
 // autoUpdateAgentShouldUpdate returns if the agent should update now to based on its group

--- a/lib/web/autoupdate_rfd109.go
+++ b/lib/web/autoupdate_rfd109.go
@@ -35,7 +35,7 @@ import (
 
 const defaultChannelTimeout = 5 * time.Second
 
-// automaticUpgrades implements a version server in the Teleport Proxy following the RFD 109 spec.
+// automaticUpgrades109 implements a version server in the Teleport Proxy following the RFD 109 spec.
 // It is configured through the Teleport Proxy configuration and tells agent updaters
 // which version they should install.
 func (h *Handler) automaticUpgrades109(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -159,9 +159,14 @@ func (h *Handler) awsOIDCDeployService(w http.ResponseWriter, r *http.Request, p
 	teleportVersionTag := teleport.Version
 	if automaticUpgrades(h.GetClusterFeatures()) {
 		const group, updaterUUID = "", ""
-		teleportVersionTag, err = h.autoUpdateAgentVersion(r.Context(), group, updaterUUID)
+		autoUpdateVersion, err := h.autoUpdateAgentVersion(r.Context(), group, updaterUUID)
 		if err != nil {
-			h.logger.ErrorContext(r.Context(), "Cannot read autoupdate target version", "error", err)
+			h.logger.ErrorContext(r.Context(),
+				"Cannot read autoupdate target version, falling back to our own version",
+				"error", err,
+				"version", teleport.Version)
+		} else {
+			teleportVersionTag = autoUpdateVersion
 		}
 	}
 

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -161,7 +161,7 @@ func (h *Handler) awsOIDCDeployService(w http.ResponseWriter, r *http.Request, p
 		const group, updaterUUID = "", ""
 		autoUpdateVersion, err := h.autoUpdateAgentVersion(r.Context(), group, updaterUUID)
 		if err != nil {
-			h.logger.ErrorContext(r.Context(),
+			h.logger.WarnContext(r.Context(),
 				"Cannot read autoupdate target version, falling back to our own version",
 				"error", err,
 				"version", teleport.Version)

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -215,10 +215,16 @@ func (h *Handler) awsOIDCDeployDatabaseServices(w http.ResponseWriter, r *http.R
 	teleportVersionTag := teleport.Version
 	if automaticUpgrades(h.GetClusterFeatures()) {
 		const group, updaterUUID = "", ""
-		teleportVersionTag, err = h.autoUpdateAgentVersion(r.Context(), group, updaterUUID)
+		autoUpdateVersion, err := h.autoUpdateAgentVersion(r.Context(), group, updaterUUID)
 		if err != nil {
-			h.logger.ErrorContext(r.Context(), "Cannot read autoupdate target version", "error", err)
+			h.logger.WarnContext(r.Context(),
+				"Cannot read autoupdate target version, falling back to self version.",
+				"error", err,
+				"version", teleport.Version)
+		} else {
+			teleportVersionTag = autoUpdateVersion
 		}
+
 	}
 
 	iamTokenName := deployserviceconfig.DefaultTeleportIAMTokenName

--- a/lib/web/join_tokens.go
+++ b/lib/web/join_tokens.go
@@ -39,6 +39,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 	"k8s.io/apimachinery/pkg/util/validation"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
@@ -378,7 +379,9 @@ func (h *Handler) createTokenForDiscoveryHandle(w http.ResponseWriter, r *http.R
 
 // getAutoUpgrades checks if automaticUpgrades are enabled and returns the
 // version that should be used according to auto upgrades default channel.
-func (h *Handler) getAutoUpgrades(ctx context.Context) (bool, string, error) {
+// If something bad happens, the error is logged and the function falls back to
+// the process Teleport version.
+func (h *Handler) getAutoUpgrades(ctx context.Context) (bool, string) {
 	var autoUpgradesVersion string
 	var err error
 	autoUpgrades := automaticUpgrades(h.GetClusterFeatures())
@@ -386,23 +389,19 @@ func (h *Handler) getAutoUpgrades(ctx context.Context) (bool, string, error) {
 		const group, updaterUUID = "", ""
 		autoUpgradesVersion, err = h.autoUpdateAgentVersion(ctx, group, updaterUUID)
 		if err != nil {
-			h.logger.InfoContext(ctx, "Failed to get auto upgrades version", "error", err)
-			return false, "", trace.Wrap(err)
+			h.logger.WarnContext(ctx, "Failed to get auto upgrades version, falling back to self version.", "error", err)
+			return autoUpgrades, teleport.Version
 		}
 		autoUpgradesVersion = fmt.Sprintf("v%s", autoUpgradesVersion)
 	}
-	return autoUpgrades, autoUpgradesVersion, nil
+	return autoUpgrades, autoUpgradesVersion
 
 }
 
 func (h *Handler) getNodeJoinScriptHandle(w http.ResponseWriter, r *http.Request, params httprouter.Params) (interface{}, error) {
 	httplib.SetScriptHeaders(w.Header())
 
-	autoUpgrades, autoUpgradesVersion, err := h.getAutoUpgrades(r.Context())
-	if err != nil {
-		w.Write(scripts.ErrorBashScript)
-		return nil, nil
-	}
+	autoUpgrades, autoUpgradesVersion := h.getAutoUpgrades(r.Context())
 
 	settings := scriptSettings{
 		token:                    params.ByName("token"),
@@ -452,11 +451,7 @@ func (h *Handler) getAppJoinScriptHandle(w http.ResponseWriter, r *http.Request,
 		return nil, nil
 	}
 
-	autoUpgrades, autoUpgradesVersion, err := h.getAutoUpgrades(r.Context())
-	if err != nil {
-		w.Write(scripts.ErrorBashScript)
-		return nil, nil
-	}
+	autoUpgrades, autoUpgradesVersion := h.getAutoUpgrades(r.Context())
 
 	settings := scriptSettings{
 		token:                    params.ByName("token"),
@@ -486,11 +481,7 @@ func (h *Handler) getAppJoinScriptHandle(w http.ResponseWriter, r *http.Request,
 func (h *Handler) getDatabaseJoinScriptHandle(w http.ResponseWriter, r *http.Request, params httprouter.Params) (interface{}, error) {
 	httplib.SetScriptHeaders(w.Header())
 
-	autoUpgrades, autoUpgradesVersion, err := h.getAutoUpgrades(r.Context())
-	if err != nil {
-		w.Write(scripts.ErrorBashScript)
-		return nil, nil
-	}
+	autoUpgrades, autoUpgradesVersion := h.getAutoUpgrades(r.Context())
 
 	settings := scriptSettings{
 		token:                    params.ByName("token"),
@@ -520,11 +511,7 @@ func (h *Handler) getDiscoveryJoinScriptHandle(w http.ResponseWriter, r *http.Re
 	queryValues := r.URL.Query()
 	const discoveryGroupQueryParam = "discoveryGroup"
 
-	autoUpgrades, autoUpgradesVersion, err := h.getAutoUpgrades(r.Context())
-	if err != nil {
-		w.Write(scripts.ErrorBashScript)
-		return nil, nil
-	}
+	autoUpgrades, autoUpgradesVersion := h.getAutoUpgrades(r.Context())
 
 	discoveryGroup, err := url.QueryUnescape(queryValues.Get(discoveryGroupQueryParam))
 	if err != nil {

--- a/lib/web/join_tokens.go
+++ b/lib/web/join_tokens.go
@@ -383,11 +383,13 @@ func (h *Handler) getAutoUpgrades(ctx context.Context) (bool, string, error) {
 	var err error
 	autoUpgrades := automaticUpgrades(h.GetClusterFeatures())
 	if autoUpgrades {
-		autoUpgradesVersion, err = h.cfg.AutomaticUpgradesChannels.DefaultVersion(ctx)
+		const group, updaterUUID = "", ""
+		autoUpgradesVersion, err = h.autoUpdateAgentVersion(ctx, group, updaterUUID)
 		if err != nil {
 			h.logger.InfoContext(ctx, "Failed to get auto upgrades version", "error", err)
 			return false, "", trace.Wrap(err)
 		}
+		autoUpgradesVersion = fmt.Sprintf("v%s", autoUpgradesVersion)
 	}
 	return autoUpgrades, autoUpgradesVersion, nil
 


### PR DESCRIPTION
This PR replaces every direct usage of the proxy's autoupdate channels from RFD 109 by `agentAutoUpdateVersion()` which will look at the RFD-184 autoupdate_agent_rollout resource first, then fallback to RFD-109 proxy channels.

Fixes an issue found during the autoupdate test plan: discovery service and discover UI don't use the version from `autoupdate_agent_rollout`, this causes version inconsistencies.

There are two gotchas in the PR:
- `version.Getter.GetVersion()` returned versions with the leading "v" while`agentAutoUpdateVersion()` doesn't have the leading v.
- The discovery service might not be running in the Teleport proxy nor have access to autoupdate resources. In this case, we build a version client (the same way we do for the kube-agent-updater) and hit the proxy. When building the version client I uncovered an existing bug where the discovery service cannot get the version if there is no proxy in the cluster. I caught the case, added a warning and fellback to the current Teleport version.

Changelog: Scripts installing nodes no longer fail if they cannot discover the autoupdate version, they send a warning and use the version from their own Teleport binary.

Part of: [RFD-184](https://github.com/gravitational/teleport/pull/47126)
Goal (internal): https://github.com/gravitational/cloud/issues/10289