### PR TITLE
[teleport-update] Warn instead of erroring when disabling the deprecated updater

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1289,7 +1289,8 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 				return nil, trace.Wrap(err)
 			}
 			if err := driver.ForceNop(process.ExitContext()); err != nil {
-				return nil, trace.Wrap(err)
+				process.logger.WarnContext(process.ExitContext(), "Unable to disable the deprecated updater.", "error", err)
+				process.logger.WarnContext(process.ExitContext(), "If the deprecated updater is installed, please ensure /etc/teleport-upgrade.d/schedule contains 'nop'.")
 			}
 		case types.UpgraderKindSystemdUnit:
 			process.RegisterFunc("autoupdates.endpoint.export", func() error {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1289,7 +1289,7 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 				return nil, trace.Wrap(err)
 			}
 			if err := driver.ForceNop(process.ExitContext()); err != nil {
-				process.logger.WarnContext(process.ExitContext(), "Unable to disable the deprecated updater.", "error", err)
+				process.logger.WarnContext(process.ExitContext(), "Unable to disable the teleport-upgrade command provided by the deprecated teleport-ent-updater package.", "error", err)
 				process.logger.WarnContext(process.ExitContext(), "If the deprecated updater is installed, please ensure /etc/teleport-upgrade.d/schedule contains 'nop'.")
 			}
 		case types.UpgraderKindSystemdUnit:

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1290,7 +1290,7 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 			}
 			if err := driver.ForceNop(process.ExitContext()); err != nil {
 				process.logger.WarnContext(process.ExitContext(), "Unable to disable the teleport-upgrade command provided by the deprecated teleport-ent-updater package.", "error", err)
-				process.logger.WarnContext(process.ExitContext(), "If the deprecated updater is installed, please ensure /etc/teleport-upgrade.d/schedule contains 'nop'.")
+				process.logger.WarnContext(process.ExitContext(), "If the deprecated teleport-ent-updater package is installed, please ensure /etc/teleport-upgrade.d/schedule contains 'nop'.")
 			}
 		case types.UpgraderKindSystemdUnit:
 			process.RegisterFunc("autoupdates.endpoint.export", func() error {


### PR DESCRIPTION
The new `teleport-update` auto-updater writes `/etc/teleport-upgrade.d/schedule` as `nop` to prevent the old script-based updater from running and attempting to update the `teleport` package. If Teleport is running as a regular user, this write will fail.

Users should not have to manually create `/etc/teleport-upgrade.d/schedule` with the correct permissions to use the new auto-updater, given that `/etc/teleport-upgrade.d/schedule` is no longer used. This PR makes the agent warn instead of erroring when `/etc/teleport-upgrade.d/schedule` cannot be written and the new updater is active.