### PR TITLE
[buddy] fix superfluous response call for WS request

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -4500,7 +4500,10 @@ var authnWsUpgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
 	CheckOrigin:     func(r *http.Request) bool { return true },
-	Error:           func(w http.ResponseWriter, r *http.Request, status int, reason error) {},
+	// We’re disabling the error handler here since error handling is managed within the handler itself. 
+	// Allowing the WS error handler to operate would result in it writing to the response writer, 
+	// which conflicts with our custom error handler and leads to unintended errors.
+	Error:           func(http.ResponseWriter, *http.Request, int, error) {},
 }
 
 // WithClusterAuthWebSocket wraps a ClusterWebsocketHandler to ensure that a request is authenticated

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -4500,10 +4500,10 @@ var authnWsUpgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
 	CheckOrigin:     func(r *http.Request) bool { return true },
-	// We’re disabling the error handler here since error handling is managed within the handler itself. 
-	// Allowing the WS error handler to operate would result in it writing to the response writer, 
+	// We’re disabling the error handler here since error handling is managed within the handler itself.
+	// Allowing the WS error handler to operate would result in it writing to the response writer,
 	// which conflicts with our custom error handler and leads to unintended errors.
-	Error:           func(http.ResponseWriter, *http.Request, int, error) {},
+	Error: func(http.ResponseWriter, *http.Request, int, error) {},
 }
 
 // WithClusterAuthWebSocket wraps a ClusterWebsocketHandler to ensure that a request is authenticated

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -4500,6 +4500,7 @@ var authnWsUpgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
 	CheckOrigin:     func(r *http.Request) bool { return true },
+	Error:           func(w http.ResponseWriter, r *http.Request, status int, reason error) {},
 }
 
 // WithClusterAuthWebSocket wraps a ClusterWebsocketHandler to ensure that a request is authenticated


### PR DESCRIPTION
Buddy for #51493

---

## what happened

we experienced some issues with WebSockets:
* logs were saying
```
http: superfluous response.WriteHeader call from [go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/internal/request.(*RespWriterWrapper](http://go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/internal/request.(*RespWriterWrapper)).writeHeader (resp_writer_wrapper.go:80)
```
* browser was getting `400 Bad Request` without any error text in body

## Investigation

we traced the error and found where status 400 can be returned during `/webapi/sites/:site/connect/ws` call:
https://github.com/gorilla/websocket/blob/v1.5.3/server.go#L125

it turned out we had a wrong configured proxy before teleport
so teleport was receiving WS connect requests without WS headers

so the first `response.WriteHeader` call happens here:
https://github.com/gorilla/websocket/blob/v1.5.3/server.go#L77
if `authnWsUpgrader.Error` is empty `http.Error` will be used with just a status text (`400 Bad Request`)
and the original error (missing WS headers) is lost

## fix

the easiest fix is set `Error` function as empty function to prevent unplanned `http.Error` call
even the lib itself doing this https://github.com/gorilla/websocket/blob/v1.5.3/server.go#L299
