### PR TITLE
Add access requests context

### DIFF
--- a/web/packages/shared/components/AccessRequests/Shared/Shared.tsx
+++ b/web/packages/shared/components/AccessRequests/Shared/Shared.tsx
@@ -16,12 +16,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useState } from 'react';
+import { ComponentType, useState } from 'react';
 
 import { Box, ButtonIcon, ButtonPrimary, Menu, Text } from 'design';
 import { displayDateWithPrefixedTime } from 'design/datetime';
 import { Info } from 'design/Icon';
+import * as Icon from 'design/Icon';
+import { IconProps } from 'design/Icon/Icon';
 import { HoverTooltip } from 'design/Tooltip';
+import { RequestableResourceKind } from 'shared/components/AccessRequests/NewRequest';
+import { formattedName } from 'shared/components/AccessRequests/ReviewRequests';
 import { AccessRequest } from 'shared/services/accessRequests';
 
 export function PromotedMessage({
@@ -137,3 +141,51 @@ export const BlockedByStartTimeButton = ({
     </HoverTooltip>
   );
 };
+
+/** Returns a list of requested roles or resources. */
+export function getResourcesOrRolesFromRequest(
+  request: Pick<AccessRequest, 'resources' | 'roles'>
+): { Icon: ComponentType<IconProps>; name: string; title: string }[] {
+  return request.resources.length
+    ? request.resources.map(c => {
+        const name = formattedName(c);
+        return {
+          Icon: getIcon(c.id.kind),
+          name,
+          title: `${c.id.kind}: ${name}`,
+        };
+      })
+    : request.roles.map(c => ({
+        Icon: getIcon('role'),
+        name: c,
+        title: `role: ${c}`,
+      }));
+}
+
+function getIcon(item: RequestableResourceKind): ComponentType<IconProps> {
+  switch (item) {
+    case 'app':
+    case 'saml_idp_service_provider':
+    case 'aws_ic_account_assignment':
+      return Icon.Application;
+    case 'node':
+      return Icon.Server;
+    case 'db':
+      return Icon.Database;
+    case 'kube_cluster':
+    case 'namespace':
+      return Icon.Kubernetes;
+    case 'role':
+      return Icon.ClipboardUser;
+    case 'user_group':
+      return Icon.Server;
+    case 'git_server':
+      return Icon.GitHub;
+    case 'windows_desktop':
+      return Icon.Desktop;
+    case 'resource': // This probably never shows in the UI.
+      return Icon.Server;
+    default:
+      item satisfies never;
+  }
+}

--- a/web/packages/shared/hooks/useAsync.ts
+++ b/web/packages/shared/hooks/useAsync.ts
@@ -255,22 +255,25 @@ export function makeErrorAttemptWithStatusText<T>(
 }
 
 /**
- * mapAttempt maps attempt data but only if the attempt is successful.
+ * mapAttempt maps attempt data if the attempt is successful or in progress and contains data.
  */
 export function mapAttempt<A, B>(
   attempt: Attempt<A>,
   mapFunction: (attemptData: A) => B
 ): Attempt<B> {
-  if (attempt.status !== 'success') {
+  if (
+    attempt.status === 'success' ||
+    (attempt.status === 'processing' && attempt.data)
+  ) {
     return {
       ...attempt,
-      data: null,
+      data: mapFunction(attempt.data),
     };
   }
 
   return {
     ...attempt,
-    data: mapFunction(attempt.data),
+    data: null,
   };
 }
 

--- a/web/packages/teleterm/src/ui/AccessRequests/AccessRequestsContext.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequests/AccessRequestsContext.tsx
@@ -40,7 +40,6 @@ export interface AccessRequestsContext {
   fetchRequests(): Promise<[AccessRequest[], Error]>;
   /** Maps access request ID to the corresponding request object. */
   assumed: Map<string, AssumedRequest>;
-  rootClusterUri: RootClusterUri;
 }
 
 const AccessRequestsContext = createContext<AccessRequestsContext>(null);
@@ -84,7 +83,6 @@ export const AccessRequestsContextProvider: FC<
         fetchRequestsAttempt,
         fetchRequests,
         assumed,
-        rootClusterUri,
       }}
     >
       {children}

--- a/web/packages/teleterm/src/ui/AccessRequests/AccessRequestsContext.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequests/AccessRequestsContext.tsx
@@ -34,7 +34,9 @@ import { RootClusterUri } from 'teleterm/ui/uri';
 import { retryWithRelogin } from 'teleterm/ui/utils';
 
 export interface AccessRequestsContext {
-  /** Determines whether the user can use the Access Requests UI. */
+  /** Determines whether the user can use the Access Requests UI.
+   * True when the cluster enables it.
+   */
   canUse: boolean;
   fetchRequestsAttempt: Attempt<AccessRequest[]>;
   fetchRequests(): Promise<[AccessRequest[], Error]>;

--- a/web/packages/teleterm/src/ui/AccessRequests/AccessRequestsContext.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequests/AccessRequestsContext.tsx
@@ -1,0 +1,105 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  createContext,
+  FC,
+  PropsWithChildren,
+  useCallback,
+  useContext,
+} from 'react';
+
+import { AccessRequest } from 'gen-proto-ts/teleport/lib/teleterm/v1/access_request_pb';
+import { Attempt, useAsync } from 'shared/hooks/useAsync';
+
+import { AssumedRequest } from 'teleterm/services/tshd/types';
+import { useAppContext } from 'teleterm/ui/appContextProvider';
+import { useStoreSelector } from 'teleterm/ui/hooks/useStoreSelector';
+import { RootClusterUri } from 'teleterm/ui/uri';
+import { retryWithRelogin } from 'teleterm/ui/utils';
+
+export interface AccessRequestsContext {
+  /** Determines whether the user can use the Access Requests UI. */
+  canUse: boolean;
+  fetchRequestsAttempt: Attempt<AccessRequest[]>;
+  fetchRequests(): Promise<[AccessRequest[], Error]>;
+  assumed: Record<string, AssumedRequest>;
+  rootClusterUri: RootClusterUri;
+}
+
+const AccessRequestsContext = createContext<AccessRequestsContext>(null);
+
+export const AccessRequestsContextProvider: FC<
+  PropsWithChildren<{
+    rootClusterUri: RootClusterUri;
+  }>
+> = ({ rootClusterUri, children }) => {
+  const appContext = useAppContext();
+  const { tshd, clustersService } = appContext;
+  const rootCluster = useStoreSelector(
+    'clustersService',
+    useCallback(state => state.clusters.get(rootClusterUri), [rootClusterUri])
+  );
+  const assumed = clustersService.getAssumedRequests(rootClusterUri);
+
+  const canUse = !!(
+    rootCluster?.features?.advancedAccessWorkflows ||
+    Object.keys(assumed).length
+  );
+
+  const [fetchRequestsAttempt, fetchRequests] = useAsync(
+    useCallback(
+      () =>
+        retryWithRelogin(appContext, rootClusterUri, async () => {
+          const {
+            response: { requests },
+          } = await tshd.getAccessRequests({
+            clusterUri: rootClusterUri,
+          });
+          return requests;
+        }),
+      [tshd, rootClusterUri]
+    )
+  );
+
+  return (
+    <AccessRequestsContext.Provider
+      value={{
+        canUse,
+        fetchRequestsAttempt,
+        fetchRequests,
+        assumed,
+        rootClusterUri,
+      }}
+    >
+      {children}
+    </AccessRequestsContext.Provider>
+  );
+};
+
+export const useAccessRequestsContext = () => {
+  const context = useContext(AccessRequestsContext);
+
+  if (!context) {
+    throw new Error(
+      'useAccessRequestsContext must be used within a AccessRequestsContext'
+    );
+  }
+
+  return context;
+};

--- a/web/packages/teleterm/src/ui/AccessRequests/index.ts
+++ b/web/packages/teleterm/src/ui/AccessRequests/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export * from './AccessRequestsContext';

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/DocumentAccessRequests.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/DocumentAccessRequests.story.tsx
@@ -21,6 +21,7 @@ import { ShowResources } from 'gen-proto-ts/teleport/lib/teleterm/v1/cluster_pb'
 
 import { MockedUnaryCall } from 'teleterm/services/tshd/cloneableClient';
 import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
+import { AccessRequestsContextProvider } from 'teleterm/ui/AccessRequests';
 import AppContextProvider from 'teleterm/ui/appContextProvider';
 import { DocumentAccessRequests } from 'teleterm/ui/DocumentAccessRequests/DocumentAccessRequests';
 import { ResourcesContextProvider } from 'teleterm/ui/DocumentCluster/resourcesContext';
@@ -93,9 +94,11 @@ export function Browsing() {
   return (
     <AppContextProvider value={appContext}>
       <MockWorkspaceContextProvider>
-        <ResourcesContextProvider>
-          <DocumentAccessRequests doc={doc} visible={true} />
-        </ResourcesContextProvider>
+        <AccessRequestsContextProvider rootClusterUri={rootCluster.uri}>
+          <ResourcesContextProvider>
+            <DocumentAccessRequests doc={doc} visible={true} />
+          </ResourcesContextProvider>
+        </AccessRequestsContextProvider>
       </MockWorkspaceContextProvider>
     </AppContextProvider>
   );
@@ -110,9 +113,11 @@ export function BrowsingError() {
   return (
     <AppContextProvider value={appContext}>
       <MockWorkspaceContextProvider>
-        <ResourcesContextProvider>
-          <DocumentAccessRequests doc={doc} visible={true} />
-        </ResourcesContextProvider>
+        <AccessRequestsContextProvider rootClusterUri={rootCluster.uri}>
+          <ResourcesContextProvider>
+            <DocumentAccessRequests doc={doc} visible={true} />
+          </ResourcesContextProvider>
+        </AccessRequestsContextProvider>
       </MockWorkspaceContextProvider>
     </AppContextProvider>
   );
@@ -141,9 +146,11 @@ export function CreatingWhenUnifiedResourcesShowOnlyAccessibleResources() {
   return (
     <AppContextProvider value={appContext}>
       <MockWorkspaceContextProvider>
-        <ResourcesContextProvider>
-          <DocumentAccessRequests doc={docCreating} visible={true} />
-        </ResourcesContextProvider>
+        <AccessRequestsContextProvider rootClusterUri={rootCluster.uri}>
+          <ResourcesContextProvider>
+            <DocumentAccessRequests doc={docCreating} visible={true} />
+          </ResourcesContextProvider>
+        </AccessRequestsContextProvider>
       </MockWorkspaceContextProvider>
     </AppContextProvider>
   );
@@ -172,9 +179,11 @@ export function CreatingWhenUnifiedResourcesShowRequestableAndAccessibleResource
   return (
     <AppContextProvider value={appContext}>
       <MockWorkspaceContextProvider>
-        <ResourcesContextProvider>
-          <DocumentAccessRequests doc={docCreating} visible={true} />
-        </ResourcesContextProvider>
+        <AccessRequestsContextProvider rootClusterUri={rootCluster.uri}>
+          <ResourcesContextProvider>
+            <DocumentAccessRequests doc={docCreating} visible={true} />
+          </ResourcesContextProvider>
+        </AccessRequestsContextProvider>
       </MockWorkspaceContextProvider>
     </AppContextProvider>
   );

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/DocumentAccessRequests.tsx
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/DocumentAccessRequests.tsx
@@ -45,7 +45,6 @@ export function DocumentAccessRequests(props: DocumentProps) {
 }
 
 export function DocumentAccessRequestsViews({
-  accessRequests,
   attempt,
   doc,
   assumeRole,
@@ -73,7 +72,6 @@ export function DocumentAccessRequestsViews({
     <RequestList
       assumeRole={accessRequest => assumeRole(accessRequest.id)}
       attempt={attempt}
-      requests={accessRequests}
       getFlags={getFlags}
       getRequests={getRequests}
       viewRequest={(id: string) => onViewRequest(id)}

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/RequestList/RequestList.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/RequestList/RequestList.test.tsx
@@ -21,6 +21,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { fireEvent, render, screen } from 'design/utils/testing';
 import { requestRoleApproved } from 'shared/components/AccessRequests/fixtures';
 import { RequestFlags } from 'shared/components/AccessRequests/ReviewRequests';
+import { makeSuccessAttempt } from 'shared/hooks/useAsync';
 import { AccessRequest } from 'shared/services/accessRequests';
 
 import { RequestList } from './RequestList';
@@ -32,14 +33,13 @@ test('disabled assume button with assume start date', async () => {
   render(
     <MemoryRouter>
       <RequestList
-        attempt={{ status: 'success' }}
+        attempt={makeSuccessAttempt([request])}
         assumeRole={() => null}
         assumeRoleAttempt={{ status: '', data: null, statusText: '' }}
         getRequests={() => null}
         viewRequest={() => null}
         assumeAccessList={() => null}
         getFlags={() => flags}
-        requests={[request]}
       />
     </MemoryRouter>
   );
@@ -61,14 +61,13 @@ test('enabled assume button with assume start date', () => {
   render(
     <MemoryRouter>
       <RequestList
-        attempt={{ status: 'success' }}
+        attempt={makeSuccessAttempt([request])}
         assumeRole={() => null}
         assumeRoleAttempt={{ status: '', data: null, statusText: '' }}
         getRequests={() => null}
         viewRequest={() => null}
         assumeAccessList={() => null}
         getFlags={() => flags}
-        requests={[request]}
       />
     </MemoryRouter>
   );
@@ -81,16 +80,15 @@ test('enabled assume button with no assume start date', () => {
   render(
     <MemoryRouter>
       <RequestList
-        attempt={{ status: 'success' }}
+        attempt={makeSuccessAttempt([
+          { ...request, assumeStartTime: null, assumeStartTimeDuration: '' },
+        ])}
         assumeRole={() => null}
         assumeRoleAttempt={{ status: '', data: null, statusText: '' }}
         getRequests={() => null}
         viewRequest={() => null}
         assumeAccessList={() => null}
         getFlags={() => flags}
-        requests={[
-          { ...request, assumeStartTime: null, assumeStartTimeDuration: '' },
-        ]}
       />
     </MemoryRouter>
   );

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/RequestList/RequestList.tsx
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/RequestList/RequestList.tsx
@@ -20,6 +20,7 @@ import styled from 'styled-components';
 
 import { Alert, Box, ButtonBorder, ButtonPrimary, Flex, Label } from 'design';
 import Table, { Cell } from 'design/DataTable';
+import { displayDateTime } from 'design/datetime';
 import { requestMatcher } from 'shared/components/AccessRequests/NewRequest/matcher';
 import {
   formattedName,
@@ -110,7 +111,9 @@ export function RequestList({
             key: 'created',
             headerText: 'Created',
             isSortable: true,
-            render: ({ createdDuration }) => <Cell>{createdDuration}</Cell>,
+            render: ({ createdDuration, created }) => (
+              <Cell title={displayDateTime(created)}>{createdDuration}</Cell>
+            ),
           },
           {
             key: 'assumeStartTime',
@@ -124,8 +127,10 @@ export function RequestList({
             key: 'expires',
             headerText: 'Expires',
             isSortable: true,
-            render: ({ requestTTLDuration }) => (
-              <Cell>{requestTTLDuration}</Cell>
+            render: ({ requestTTLDuration, requestTTL }) => (
+              <Cell title={displayDateTime(requestTTL)}>
+                {requestTTLDuration}
+              </Cell>
             ),
           },
           {
@@ -236,7 +241,6 @@ const RequestedCell = ({
     </Cell>
   );
 };
-
 const Layout = styled(Box)`
   flex-direction: column;
   display: flex;

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/RequestList/RequestList.tsx
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/RequestList/RequestList.tsx
@@ -23,7 +23,6 @@ import Table, { Cell } from 'design/DataTable';
 import { displayDateTime } from 'design/datetime';
 import { requestMatcher } from 'shared/components/AccessRequests/NewRequest/matcher';
 import {
-  formattedName,
   renderIdCell,
   renderStatusCell,
   renderUserCell,
@@ -32,6 +31,7 @@ import {
 import {
   BlockedByStartTimeButton,
   ButtonPromotedInfo,
+  getResourcesOrRolesFromRequest,
 } from 'shared/components/AccessRequests/Shared/Shared';
 import { Attempt } from 'shared/hooks/useAsync';
 import { AccessRequest, canAssumeNow } from 'shared/services/accessRequests';
@@ -99,9 +99,7 @@ export function RequestList({
           {
             key: 'roles',
             headerText: 'Requested',
-            render: ({ resources, roles, id }) => (
-              <RequestedCell resources={resources} roles={roles} id={id} />
-            ),
+            render: request => <RequestedCell request={request} />,
           },
           {
             key: 'resources',
@@ -209,38 +207,38 @@ const renderActionCell = (
   );
 };
 
-const RequestedCell = ({
-  roles,
-  resources,
-  id,
-}: Pick<AccessRequest, 'roles' | 'resources' | 'id'>) => {
-  if (resources?.length > 0) {
-    return (
-      <Cell key={id}>
-        {resources.map((resource, index) => (
-          <Label
-            mb="0"
-            mr="1"
-            key={`${resource.id.kind}${formattedName(resource)}${index}`}
-            kind="secondary"
-          >
-            {resource.id.kind}: {formattedName(resource)}
-          </Label>
-        ))}
-      </Cell>
-    );
-  }
+const RequestedCell = ({ request }: { request: AccessRequest }) => (
+  <Cell
+    css={`
+      display: flex;
+      flex-wrap: wrap;
+      gap: ${props => props.theme.space[1]}px;
+    `}
+  >
+    {getResourcesOrRolesFromRequest(request).map((r, index) => (
+      <Label
+        kind="secondary"
+        key={`${r.title}${index}`}
+        title={r.title}
+        m={0}
+        css={`
+          display: flex;
+          gap: ${props => props.theme.space[1]}px;
+        `}
+      >
+        <r.Icon size="small" />
+        <span
+          css={`
+            white-space: nowrap;
+          `}
+        >
+          {r.name}
+        </span>
+      </Label>
+    ))}
+  </Cell>
+);
 
-  return (
-    <Cell>
-      {roles.sort().map(role => (
-        <Label mb="0" mr="1" key={role} kind="secondary">
-          role: {role}
-        </Label>
-      ))}
-    </Cell>
-  );
-};
 const Layout = styled(Box)`
   flex-direction: column;
   display: flex;

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/RequestList/RequestList.tsx
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/RequestList/RequestList.tsx
@@ -32,23 +32,29 @@ import {
   BlockedByStartTimeButton,
   ButtonPromotedInfo,
 } from 'shared/components/AccessRequests/Shared/Shared';
-import { Attempt as AsyncAttempt } from 'shared/hooks/useAsync';
-import { Attempt } from 'shared/hooks/useAttemptNext';
+import { Attempt } from 'shared/hooks/useAsync';
 import { AccessRequest, canAssumeNow } from 'shared/services/accessRequests';
 
 export function RequestList({
   attempt,
-  requests,
   getFlags,
   viewRequest,
   assumeRoleAttempt,
   assumeRole,
   getRequests,
   assumeAccessList,
-}: Props) {
+}: {
+  attempt: Attempt<AccessRequest[]>;
+  getFlags(accessRequest: AccessRequest): RequestFlags;
+  assumeRole(request: AccessRequest): void;
+  assumeRoleAttempt: Attempt<void>;
+  getRequests(): void;
+  viewRequest(requestId: string): void;
+  assumeAccessList(): void;
+}) {
   return (
     <Layout mx="auto" px={5} pt={3} height="100%">
-      {attempt.status === 'failed' && (
+      {attempt.status === 'error' && (
         <Alert kind="danger" details={attempt.statusText}>
           Could not fetch access requests
         </Alert>
@@ -69,7 +75,7 @@ export function RequestList({
         </ButtonPrimary>
       </Flex>
       <Table
-        data={requests}
+        data={attempt.data || []}
         columns={[
           {
             key: 'id',
@@ -149,7 +155,7 @@ const renderActionCell = (
   request: AccessRequest,
   flags: RequestFlags,
   assumeRole: (request: AccessRequest) => void,
-  assumeRoleAttempt: AsyncAttempt<void>,
+  assumeRoleAttempt: Attempt<void>,
   viewRequest: (id: string) => void,
   assumeAccessList: () => void
 ) => {
@@ -242,14 +248,3 @@ const Layout = styled(Box)`
     padding-bottom: 24px;
   }
 `;
-
-type Props = {
-  attempt: Attempt;
-  requests: AccessRequest[];
-  getFlags: (accessRequest: AccessRequest) => RequestFlags;
-  assumeRole: (request: AccessRequest) => void;
-  assumeRoleAttempt: AsyncAttempt<void>;
-  getRequests: () => void;
-  viewRequest: (requestId: string) => void;
-  assumeAccessList: () => void;
-};

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/RequestList/RequestList.tsx
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/RequestList/RequestList.tsx
@@ -208,34 +208,30 @@ const renderActionCell = (
 };
 
 const RequestedCell = ({ request }: { request: AccessRequest }) => (
-  <Cell
-    css={`
-      display: flex;
-      flex-wrap: wrap;
-      gap: ${props => props.theme.space[1]}px;
-    `}
-  >
-    {getResourcesOrRolesFromRequest(request).map((r, index) => (
-      <Label
-        kind="secondary"
-        key={`${r.title}${index}`}
-        title={r.title}
-        m={0}
-        css={`
-          display: flex;
-          gap: ${props => props.theme.space[1]}px;
-        `}
-      >
-        <r.Icon size="small" />
-        <span
+  <Cell>
+    <Flex gap={1} flexWrap="wrap">
+      {getResourcesOrRolesFromRequest(request).map((r, index) => (
+        <Label
+          kind="secondary"
+          key={`${r.title}${index}`}
+          title={r.title}
+          m={0}
           css={`
-            white-space: nowrap;
+            display: flex;
+            gap: ${props => props.theme.space[1]}px;
           `}
         >
-          {r.name}
-        </span>
-      </Label>
-    ))}
+          <r.Icon size="small" />
+          <span
+            css={`
+              white-space: nowrap;
+            `}
+          >
+            {r.name}
+          </span>
+        </Label>
+      ))}
+    </Flex>
   </Cell>
 );
 

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/useAccessRequests.tsx
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/useAccessRequests.tsx
@@ -46,19 +46,22 @@ export default function useAccessRequests(doc: types.DocumentAccessRequests) {
   const loggedInUser = useWorkspaceLoggedInUser();
 
   function goBack() {
-    documentsService.update(doc.uri, {
-      title: `Access Requests`,
+    const updatedDoc = documentsService.createAccessRequestDocument({
+      clusterUri: rootClusterUri,
       state: 'browsing',
-      requestId: '',
     });
+    updatedDoc.uri = doc.uri;
+    documentsService.update(doc.uri, updatedDoc);
   }
 
   function onViewRequest(requestId: string) {
-    documentsService.update(doc.uri, {
-      title: `Request: ${requestId}`,
+    const updatedDoc = documentsService.createAccessRequestDocument({
+      clusterUri: rootClusterUri,
       state: 'reviewing',
       requestId,
     });
+    updatedDoc.uri = doc.uri;
+    documentsService.update(doc.uri, updatedDoc);
   }
 
   useEffect(() => {

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/useAccessRequests.tsx
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/useAccessRequests.tsx
@@ -16,35 +16,34 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
 import { Timestamp } from 'gen-proto-ts/google/protobuf/timestamp_pb';
 import { AccessRequest as TshdAccessRequest } from 'gen-proto-ts/teleport/lib/teleterm/v1/access_request_pb';
 import { LoggedInUser } from 'gen-proto-ts/teleport/lib/teleterm/v1/cluster_pb';
 import { RequestFlags } from 'shared/components/AccessRequests/ReviewRequests';
-import useAttempt from 'shared/hooks/useAttemptNext';
+import { mapAttempt } from 'shared/hooks/useAsync';
 import {
   AccessRequest,
   makeAccessRequest,
 } from 'shared/services/accessRequests';
 
 import { AssumedRequest } from 'teleterm/services/tshd/types';
+import { useAccessRequestsContext } from 'teleterm/ui/AccessRequests/AccessRequestsContext';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { useWorkspaceContext } from 'teleterm/ui/Documents';
 import { useWorkspaceLoggedInUser } from 'teleterm/ui/hooks/useLoggedInUser';
 import * as types from 'teleterm/ui/services/workspacesService';
-import { retryWithRelogin } from 'teleterm/ui/utils';
 
 export default function useAccessRequests(doc: types.DocumentAccessRequests) {
   const ctx = useAppContext();
   ctx.clustersService.useState();
 
   const { rootClusterUri, documentsService } = useWorkspaceContext();
+  const { fetchRequestsAttempt, fetchRequests } = useAccessRequestsContext();
 
   const assumed = ctx.clustersService.getAssumedRequests(rootClusterUri);
   const loggedInUser = useWorkspaceLoggedInUser();
-  const [accessRequests, setAccessRequests] = useState<AccessRequest[]>();
-  const { attempt, setAttempt } = useAttempt('');
 
   function goBack() {
     documentsService.update(doc.uri, {
@@ -62,51 +61,21 @@ export default function useAccessRequests(doc: types.DocumentAccessRequests) {
     });
   }
 
-  const getRequests = async () => {
-    try {
-      const response = await retryWithRelogin(ctx, rootClusterUri, async () => {
-        const { response } = await ctx.tshd.getAccessRequests({
-          clusterUri: rootClusterUri,
-        });
-        return response.requests;
-      });
-      setAttempt({ status: 'success' });
-      // Transform tshd access request to the webui access request and add flags.
-      const requests = response.map(r => makeUiAccessRequest(r));
-      setAccessRequests(requests);
-    } catch (err) {
-      setAttempt({
-        status: 'failed',
-        statusText: err.message,
-      });
-    }
-  };
-
   useEffect(() => {
     // Only fetch when visiting RequestList.
     if (doc.state === 'browsing') {
-      getRequests();
+      void fetchRequests();
     }
   }, [doc.state]);
 
-  useEffect(() => {
-    // if assumed object changes, we update which roles have been assumed in the table
-    // this is mostly for using "Switchback" since that state is held outside this component
-    setAccessRequests(prevState =>
-      prevState?.map(r => ({
-        ...r,
-        isAssumed: assumed[r.id],
-      }))
-    );
-  }, [assumed]);
-
   return {
     ctx,
-    attempt,
-    accessRequests,
+    attempt: mapAttempt(fetchRequestsAttempt, requests =>
+      requests.map(makeUiAccessRequest)
+    ),
     onViewRequest,
     doc,
-    getRequests,
+    getRequests: fetchRequests,
     getFlags: (accessRequest: AccessRequest) =>
       makeFlags(accessRequest, assumed, loggedInUser),
     goBack,

--- a/web/packages/teleterm/src/ui/Documents/DocumentsRenderer.tsx
+++ b/web/packages/teleterm/src/ui/Documents/DocumentsRenderer.tsx
@@ -16,12 +16,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useMemo } from 'react';
+import { MutableRefObject, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import styled from 'styled-components';
 
 import { Text } from 'design';
 
+import { AccessRequestsContextProvider } from 'teleterm/ui/AccessRequests';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import {
   ConnectMyComputerContextProvider,
@@ -48,7 +49,8 @@ import { KeyboardShortcutsPanel } from './KeyboardShortcutsPanel';
 import { WorkspaceContextProvider } from './workspaceContext';
 
 export function DocumentsRenderer(props: {
-  topBarContainerRef: React.MutableRefObject<HTMLDivElement>;
+  topBarConnectMyComputerRef: MutableRefObject<HTMLDivElement>;
+  topBarAccessRequestRef: MutableRefObject<HTMLDivElement>;
 }) {
   const { workspacesService } = useAppContext();
 
@@ -96,12 +98,18 @@ export function DocumentsRenderer(props: {
                   <KeyboardShortcutsPanel />
                 )}
                 {workspace.rootClusterUri ===
-                  workspacesService.getRootClusterUri() &&
-                  props.topBarContainerRef.current &&
-                  createPortal(
-                    <ConnectMyComputerNavigationMenu />,
-                    props.topBarContainerRef.current
-                  )}
+                  workspacesService.getRootClusterUri() && (
+                  <>
+                    {props.topBarConnectMyComputerRef.current &&
+                      createPortal(
+                        <ConnectMyComputerNavigationMenu />,
+                        props.topBarConnectMyComputerRef.current
+                      )}
+                    {props.topBarAccessRequestRef.current &&
+                      //TODO(gzdunek): inject access requests menu.
+                      createPortal(null, props.topBarAccessRequestRef.current)}
+                  </>
+                )}
               </AccessRequestsContextProvider>
             </ConnectMyComputerContextProvider>
           </WorkspaceContextProvider>

--- a/web/packages/teleterm/src/ui/Documents/DocumentsRenderer.tsx
+++ b/web/packages/teleterm/src/ui/Documents/DocumentsRenderer.tsx
@@ -87,18 +87,22 @@ export function DocumentsRenderer(props: {
             <ConnectMyComputerContextProvider
               rootClusterUri={workspace.rootClusterUri}
             >
-              {workspace.documentsService.getDocuments().length ? (
-                renderDocuments(workspace.documentsService)
-              ) : (
-                <KeyboardShortcutsPanel />
-              )}
-              {workspace.rootClusterUri ===
-                workspacesService.getRootClusterUri() &&
-                props.topBarContainerRef.current &&
-                createPortal(
-                  <ConnectMyComputerNavigationMenu />,
-                  props.topBarContainerRef.current
+              <AccessRequestsContextProvider
+                rootClusterUri={workspace.rootClusterUri}
+              >
+                {workspace.documentsService.getDocuments().length ? (
+                  renderDocuments(workspace.documentsService)
+                ) : (
+                  <KeyboardShortcutsPanel />
                 )}
+                {workspace.rootClusterUri ===
+                  workspacesService.getRootClusterUri() &&
+                  props.topBarContainerRef.current &&
+                  createPortal(
+                    <ConnectMyComputerNavigationMenu />,
+                    props.topBarContainerRef.current
+                  )}
+              </AccessRequestsContextProvider>
             </ConnectMyComputerContextProvider>
           </WorkspaceContextProvider>
         </DocumentsContainer>

--- a/web/packages/teleterm/src/ui/LayoutManager.tsx
+++ b/web/packages/teleterm/src/ui/LayoutManager.tsx
@@ -27,11 +27,15 @@ import { TabHostContainer } from 'teleterm/ui/TabHost';
 import { TopBar } from 'teleterm/ui/TopBar';
 
 export function LayoutManager() {
-  const topBarContainerRef = useRef<HTMLDivElement>();
+  const topBarConnectMyComputerRef = useRef<HTMLDivElement>();
+  const topBarAccessRequestRef = useRef<HTMLDivElement>();
 
   return (
     <Flex flex="1" flexDirection="column" minHeight={0}>
-      <TopBar topBarContainerRef={topBarContainerRef} />
+      <TopBar
+        connectMyComputerRef={topBarConnectMyComputerRef}
+        accessRequestRef={topBarAccessRequestRef}
+      />
       <Flex
         flex="1"
         minHeight={0}
@@ -39,7 +43,10 @@ export function LayoutManager() {
           position: relative;
         `}
       >
-        <TabHostContainer topBarContainerRef={topBarContainerRef} />
+        <TabHostContainer
+          topBarConnectMyComputerRef={topBarConnectMyComputerRef}
+          topBarAccessRequestRef={topBarAccessRequestRef}
+        />
         <NotificationsHost />
       </Flex>
       <AccessRequestCheckout />

--- a/web/packages/teleterm/src/ui/TabHost/TabHost.story.tsx
+++ b/web/packages/teleterm/src/ui/TabHost/TabHost.story.tsx
@@ -66,7 +66,10 @@ export function Story() {
   return (
     <MockAppContextProvider appContext={ctx}>
       <ResourcesContextProvider>
-        <TabHostContainer topBarContainerRef={createRef()} />
+        <TabHostContainer
+          topBarConnectMyComputerRef={createRef()}
+          topBarAccessRequestRef={createRef()}
+        />
       </ResourcesContextProvider>
     </MockAppContextProvider>
   );

--- a/web/packages/teleterm/src/ui/TabHost/TabHost.test.tsx
+++ b/web/packages/teleterm/src/ui/TabHost/TabHost.test.tsx
@@ -70,7 +70,11 @@ async function getTestSetup({ documents }: { documents: Document[] }) {
   render(
     <MockAppContextProvider appContext={appContext}>
       <ResourcesContextProvider>
-        <TabHost ctx={appContext} topBarContainerRef={createRef()} />
+        <TabHost
+          ctx={appContext}
+          topBarConnectMyComputerRef={createRef()}
+          topBarAccessRequestRef={createRef()}
+        />
       </ResourcesContextProvider>
     </MockAppContextProvider>
   );

--- a/web/packages/teleterm/src/ui/TabHost/TabHost.tsx
+++ b/web/packages/teleterm/src/ui/TabHost/TabHost.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback } from 'react';
+import { MutableRefObject, useCallback } from 'react';
 import styled from 'styled-components';
 
 import { Flex } from 'design';
@@ -37,7 +37,8 @@ import { useNewTabOpener } from './useNewTabOpener';
 import { useTabShortcuts } from './useTabShortcuts';
 
 export function TabHostContainer(props: {
-  topBarContainerRef: React.MutableRefObject<HTMLDivElement>;
+  topBarConnectMyComputerRef: MutableRefObject<HTMLDivElement>;
+  topBarAccessRequestRef: MutableRefObject<HTMLDivElement>;
 }) {
   const ctx = useAppContext();
   const isRootClusterSelected = useStoreSelector(
@@ -46,17 +47,25 @@ export function TabHostContainer(props: {
   );
 
   if (isRootClusterSelected) {
-    return <TabHost ctx={ctx} topBarContainerRef={props.topBarContainerRef} />;
+    return (
+      <TabHost
+        ctx={ctx}
+        topBarConnectMyComputerRef={props.topBarConnectMyComputerRef}
+        topBarAccessRequestRef={props.topBarAccessRequestRef}
+      />
+    );
   }
   return <ClusterConnectPanel />;
 }
 
 export function TabHost({
   ctx,
-  topBarContainerRef,
+  topBarConnectMyComputerRef,
+  topBarAccessRequestRef,
 }: {
   ctx: IAppContext;
-  topBarContainerRef: React.MutableRefObject<HTMLDivElement>;
+  topBarConnectMyComputerRef: MutableRefObject<HTMLDivElement>;
+  topBarAccessRequestRef: MutableRefObject<HTMLDivElement>;
 }) {
   useWorkspaceServiceState();
   const documentsService =
@@ -134,7 +143,10 @@ export function TabHost({
           closeTabTooltip={getLabelWithAccelerator('Close', 'closeTab')}
         />
       </Flex>
-      <DocumentsRenderer topBarContainerRef={topBarContainerRef} />
+      <DocumentsRenderer
+        topBarConnectMyComputerRef={topBarConnectMyComputerRef}
+        topBarAccessRequestRef={topBarAccessRequestRef}
+      />
     </StyledTabHost>
   );
 }

--- a/web/packages/teleterm/src/ui/TopBar/AdditionalActions.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/AdditionalActions.tsx
@@ -109,7 +109,6 @@ function useMenuItems(): MenuItem[] {
         const doc = documentsService.createAccessRequestDocument({
           clusterUri: activeRootCluster.uri,
           state: 'creating',
-          title: 'New Role Request',
         });
         documentsService.add(doc);
         documentsService.open(doc.uri);

--- a/web/packages/teleterm/src/ui/TopBar/TopBar.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/TopBar.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import { MutableRefObject } from 'react';
 import styled from 'styled-components';
 
 import { Flex } from 'design';
@@ -28,19 +28,26 @@ import { Connections } from './Connections';
 import { Identity } from './Identity';
 
 export function TopBar(props: {
-  topBarContainerRef: React.MutableRefObject<HTMLDivElement>;
+  connectMyComputerRef: MutableRefObject<HTMLDivElement>;
+  accessRequestRef: MutableRefObject<HTMLDivElement>;
 }) {
   return (
     <Grid>
       <JustifyLeft>
         <Connections />
-        <div ref={props.topBarContainerRef} />
+        <div ref={props.connectMyComputerRef} />
       </JustifyLeft>
       <CentralContainer>
         <Clusters />
         <SearchBar />
       </CentralContainer>
       <JustifyRight>
+        <div
+          css={`
+            height: 100%;
+          `}
+          ref={props.accessRequestRef}
+        />
         <AdditionalActions />
         <Identity />
       </JustifyRight>
@@ -67,7 +74,7 @@ const CentralContainer = styled(Flex).attrs({ gap: 3 })`
 
 const JustifyLeft = styled(Flex).attrs({ gap: 3 })`
   align-items: center;
-  min-width: 80px; // reserves space for CMC icon to prevent layout shifting
+  min-width: 80px; // reserves space for Connect My Computer icon to prevent layout shifting
   height: 100%;
 `;
 

--- a/web/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.test.tsx
+++ b/web/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.test.tsx
@@ -242,11 +242,16 @@ function setupTests(): {
     .spyOn(ctx.tshd, 'getApp')
     .mockResolvedValue(new MockedUnaryCall({ app }));
 
-  const ref = createRef<HTMLDivElement>();
+  const topBarConnectMyComputerRef = createRef<HTMLDivElement>();
+  const topBarAccessRequestRef = createRef<HTMLDivElement>();
   const Component = () => (
     <MockAppContextProvider appContext={ctx}>
       <ResourcesContextProvider>
-        <TabHost ctx={ctx} topBarContainerRef={ref} />
+        <TabHost
+          ctx={ctx}
+          topBarConnectMyComputerRef={topBarConnectMyComputerRef}
+          topBarAccessRequestRef={topBarAccessRequestRef}
+        />
       </ResourcesContextProvider>
     </MockAppContextProvider>
   );

--- a/web/packages/teleterm/src/ui/services/immutableStore/immutableStore.test.ts
+++ b/web/packages/teleterm/src/ui/services/immutableStore/immutableStore.test.ts
@@ -85,15 +85,37 @@ describe('subscribeWithSelector', () => {
     expect(barUpdatedCallback).toHaveBeenCalledTimes(1);
     expect(quuxUpdatedCallback).not.toHaveBeenCalled();
   });
+
+  it('calls the callbacks if a deeper part of the state gets updated', () => {
+    const store = new TestStore();
+
+    const bazUpdatedCallback = jest.fn();
+    store.subscribeWithSelector(state => state.baz, bazUpdatedCallback);
+
+    store.setState(draft => {
+      // Update baz.items while the selector is set to just baz.
+      draft.baz.items.set('lorem', 'ipsum');
+    });
+
+    expect(bazUpdatedCallback).toHaveBeenCalledTimes(1);
+  });
 });
 
 class TestStore extends ImmutableStore<{
   foo: Map<string, string>;
   bar: Map<string, string>;
   quux: Map<string, string>;
+  baz: {
+    items: Map<string, string>;
+  };
 }> {
   constructor() {
     super();
-    this.setState(() => ({ foo: new Map(), bar: new Map(), quux: new Map() }));
+    this.setState(() => ({
+      foo: new Map(),
+      bar: new Map(),
+      quux: new Map(),
+      baz: { items: new Map() },
+    }));
   }
 }

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
@@ -75,11 +75,23 @@ export class DocumentsService {
     opts: CreateAccessRequestDocumentOpts
   ): DocumentAccessRequests {
     const uri = routing.getDocUri({ docId: unique() });
+    let title: string;
+    switch (opts.state) {
+      case 'creating':
+        title = 'New Role Request';
+        break;
+      case 'reviewing':
+        title = `Access Request: ${opts.requestId.slice(-5)}`;
+        break;
+      case 'browsing':
+      default:
+        title = 'Access Requests';
+    }
     return {
       uri,
       clusterUri: opts.clusterUri,
       requestId: opts.requestId,
-      title: opts.title || 'Access Requests',
+      title,
       kind: 'doc.access_requests',
       state: opts.state,
     };

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
@@ -342,7 +342,6 @@ export type CreateTshKubeDocumentOptions = {
 export type CreateAccessRequestDocumentOpts = {
   clusterUri: uri.ClusterUri;
   state: AccessRequestDocumentState;
-  title?: string;
   requestId?: string;
 };
 


### PR DESCRIPTION
Contributes to https://github.com/gravitational/teleport/issues/46223

This is the first of two PRs that will add an access requests selector (the UI will be added in the next PR):
<img width="638" alt="image" src="https://github.com/user-attachments/assets/ae785905-6d40-4095-9bc5-ca3a85dcea27" />


To display access requests that the user can assume in the top bar menu, we need a way to store them. I’ve decided to use a React context to manage these requests. This context will also be used in access request documents. 
I believe this has one main advantage over keeping the data in a component: we have a single source of truth for the entire workspace. If the user refreshes the list in the access requests document, the changes will be reflected in the menu (and vice-versa). This prevents inconsistencies where a request would appear in one view but not the other.

When adding this context, I took an inspiration from Connect My Computer: since the top bar lives above the workspace context in DOM, I will inject the access requests menu from the workspace, similarly to Connect My Computer icon. 

-------------

The new `AccessRequestsContext` only manages fetching requests - it doesn’t handle assuming or dropping them. Initially, I included those actions as well, but I later realized that might not be ideal.

For example, if a user tries to assume a request and it fails due to a network issue, should that error persist when reopening the menu or viewing access request documents? I think this could be confusing, so I kept these attempts local.

--------

I also included some smaller improvements, such as displaying exact dates on hover, centralizing the creation of access request document titles.