### PR TITLE
[teleport-update] Adjust non-critical SELinux contexts

### DIFF
--- a/lib/autoupdate/agent/config.go
+++ b/lib/autoupdate/agent/config.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -184,6 +185,7 @@ func writeConfig(filename string, cfg *UpdateConfig) error {
 	opts := []renameio.Option{
 		renameio.WithPermissions(configFileMode),
 		renameio.WithExistingPermissions(),
+		renameio.WithTempDir(filepath.Dir(filename)),
 	}
 	t, err := renameio.NewPendingFile(filename, opts...)
 	if err != nil {

--- a/lib/autoupdate/agent/installer.go
+++ b/lib/autoupdate/agent/installer.go
@@ -224,7 +224,6 @@ func (li *LocalInstaller) Install(ctx context.Context, rev Revision, baseURL str
 	}
 	// Write the checksum last. This marks the version directory as valid.
 	if err := os.WriteFile(sumPath, []byte(hex.EncodeToString(newSum)), configFileMode); err != nil {
-	if err != nil {
 		return trace.Wrap(err, "failed to write checksum")
 	}
 	return nil

--- a/lib/autoupdate/agent/installer.go
+++ b/lib/autoupdate/agent/installer.go
@@ -223,7 +223,7 @@ func (li *LocalInstaller) Install(ctx context.Context, rev Revision, baseURL str
 		return trace.Wrap(err, "failed to extract teleport")
 	}
 	// Write the checksum last. This marks the version directory as valid.
-	err = renameio.WriteFile(sumPath, []byte(hex.EncodeToString(newSum)), configFileMode)
+	err = os.WriteFile(sumPath, []byte(hex.EncodeToString(newSum)), configFileMode)
 	if err != nil {
 		return trace.Wrap(err, "failed to write checksum")
 	}

--- a/lib/autoupdate/agent/installer.go
+++ b/lib/autoupdate/agent/installer.go
@@ -223,7 +223,7 @@ func (li *LocalInstaller) Install(ctx context.Context, rev Revision, baseURL str
 		return trace.Wrap(err, "failed to extract teleport")
 	}
 	// Write the checksum last. This marks the version directory as valid.
-	err = os.WriteFile(sumPath, []byte(hex.EncodeToString(newSum)), configFileMode)
+	if err := os.WriteFile(sumPath, []byte(hex.EncodeToString(newSum)), configFileMode); err != nil {
 	if err != nil {
 		return trace.Wrap(err, "failed to write checksum")
 	}


### PR DESCRIPTION
This PR is similar to https://github.com/gravitational/teleport/pull/51474, in that it ensures that files written by `teleport-update` have correct SELinux contexts. Files can receive incorrect SELinux contexts when they are created in /tmp and copied to their destination.

Unlike https://github.com/gravitational/teleport/pull/51474, the incorrect contexts fixed in this PR do not appear to break anything when SELinux is configured without custom rules. This PR just cleans up the remaining contexts that are incorrect in case custom rules exist that might break the updater.

---

The `teleport-update` binary will be used to enable, disable, and trigger automatic Teleport agent updates. The new auto-updates system manages a local installation of the cluster-specified version of Teleport stored in `/opt/teleport`.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/10289
