### PR TITLE
kube: prepare for k8s v1.32.0 deps

### DIFF
--- a/lib/kube/proxy/testing/kube_server/clusterrole.go
+++ b/lib/kube/proxy/testing/kube_server/clusterrole.go
@@ -76,7 +76,7 @@ func (s *KubeMockServer) getClusterRole(w http.ResponseWriter, req *http.Request
 
 func (s *KubeMockServer) deleteClusterRole(w http.ResponseWriter, req *http.Request, p httprouter.Params) (any, error) {
 	name := p.ByName("name")
-	deleteOpts, err := parseDeleteCollectionBody(req.Body)
+	deleteOpts, err := parseDeleteCollectionBody(req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/kube/proxy/testing/kube_server/crd.go
+++ b/lib/kube/proxy/testing/kube_server/crd.go
@@ -116,7 +116,7 @@ const (
 func (s *KubeMockServer) deleteTeleportRole(w http.ResponseWriter, req *http.Request, p httprouter.Params) (any, error) {
 	namespace := p.ByName("namespace")
 	name := p.ByName("name")
-	deleteOpts, err := parseDeleteCollectionBody(req.Body)
+	deleteOpts, err := parseDeleteCollectionBody(req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/kube/proxy/testing/kube_server/pods.go
+++ b/lib/kube/proxy/testing/kube_server/pods.go
@@ -19,8 +19,8 @@
 package kubeserver
 
 import (
-	"encoding/json"
 	"io"
+	"mime"
 	"net/http"
 	"path/filepath"
 	"sort"
@@ -29,8 +29,11 @@ import (
 	"github.com/julienschmidt/httprouter"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/kube/proxy/responsewriters"
 )
 
 var podList = corev1.PodList{
@@ -109,7 +112,7 @@ func (s *KubeMockServer) getPod(w http.ResponseWriter, req *http.Request, p http
 func (s *KubeMockServer) deletePod(w http.ResponseWriter, req *http.Request, p httprouter.Params) (any, error) {
 	namespace := p.ByName("namespace")
 	name := p.ByName("name")
-	deleteOpts, err := parseDeleteCollectionBody(req.Body)
+	deleteOpts, err := parseDeleteCollectionBody(req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -143,15 +146,60 @@ func (s *KubeMockServer) DeletedPods(reqID string) []string {
 
 // parseDeleteCollectionBody parses the request body targeted to pod collection
 // endpoints.
-func parseDeleteCollectionBody(r io.Reader) (metav1.DeleteOptions, error) {
+func parseDeleteCollectionBody(r *http.Request) (metav1.DeleteOptions, error) {
 	into := metav1.DeleteOptions{}
-	data, err := io.ReadAll(r)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		return into, trace.Wrap(err)
 	}
 	if len(data) == 0 {
 		return into, nil
 	}
-	err = json.Unmarshal(data, &into)
-	return into, trace.Wrap(err)
+	decoder, err := newDecoderForContentType(r.Header.Get(responsewriters.ContentTypeHeader))
+	if err != nil {
+		return into, trace.Wrap(err)
+	}
+	objI, _, err := decoder.Decode(data, nil, &into)
+	if err != nil {
+		return into, trace.Wrap(err)
+	}
+	obj, ok := objI.(*metav1.DeleteOptions)
+	if !ok {
+		return into, trace.BadParameter("expected DeleteOptions, got %T", objI)
+	}
+	return *obj, trace.Wrap(err)
+}
+
+func newDecoderForContentType(contentType string) (runtime.Decoder, error) {
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return nil, trace.Wrap(
+			err,
+			"unable to parse %q header %q",
+			responsewriters.ContentTypeHeader,
+			contentType,
+		)
+	}
+	negotiator := newClientNegotiator()
+	dec, err := negotiator.Decoder(mediaType, params)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return dec, nil
+}
+
+// newClientNegotiator creates a negotiator that based on `Content-Type` header
+// from the Kubernetes API response is able to create a different encoder/decoder.
+// Supported content types:
+// - "application/json"
+// - "application/yaml"
+// - "application/vnd.kubernetes.protobuf"
+func newClientNegotiator() runtime.ClientNegotiator {
+	return runtime.NewClientNegotiator(
+		kubeCodecs.WithoutConversion(),
+		schema.GroupVersion{
+			// create a serializer for Kube API v1
+			Version: "v1",
+		},
+	)
 }

--- a/lib/kube/proxy/testing/kube_server/secrets.go
+++ b/lib/kube/proxy/testing/kube_server/secrets.go
@@ -101,7 +101,7 @@ func (s *KubeMockServer) getSecret(w http.ResponseWriter, req *http.Request, p h
 func (s *KubeMockServer) deleteSecret(w http.ResponseWriter, req *http.Request, p httprouter.Params) (any, error) {
 	namespace := p.ByName("namespace")
 	name := p.ByName("name")
-	deleteOpts, err := parseDeleteCollectionBody(req.Body)
+	deleteOpts, err := parseDeleteCollectionBody(req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
This PR updates the Kubernetes proxy and server mock to align with the default content-type change introduced in version v1.32.0 of client-go.

In `k8s.io/client-go`, the client's default content type was changed from `application/json` to `application/vnd.kubernetes.protobuf`.

Kube mock was not equipped to decode protobuf messages, leading to multiple failures. Additionally, there was a typo where both request content-types were inconsistently mixed.