### PR TITLE
Update Application CORS policy documentation

### DIFF
--- a/docs/pages/enroll-resources/application-access/guides/connecting-apps.mdx
+++ b/docs/pages/enroll-resources/application-access/guides/connecting-apps.mdx
@@ -465,6 +465,14 @@ route.
     # Indicates how long (in seconds) the results of a preflight request can be cached.
     max_age: 3600
 ```
+<Admonition type="warning">
+
+Teleport requires that credentials are sent with every request to your applications. This is
+necessary so that Teleport can determine whether you have an authenticated session, allowing it to
+properly verify and route your requests. Please ensure that your client fetch requests include
+`credentials: include`, even if your backend application doesn't require credentials.
+
+</Admonition>
 
 ## View applications in Teleport
 


### PR DESCRIPTION
This adds a note that lets users know that credentials are required to be sent from their frontend apps to authenticate the request with teleport, regardless of the need in their backend apps

link https://avatus-update-docs.d3pp5qlev8mo18.amplifyapp.com/enroll-resources/application-access/guides/connecting-apps/#cors-support-for-preflight-requests

![Screenshot 2025-02-03 at 2 57 07 PM](https://github.com/user-attachments/assets/af0ac586-7dff-4ed3-be5e-318058be4368)
