### PR TITLE
[v16] Import the Mattermost bot logo as a module

### DIFF
--- a/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
+++ b/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
@@ -3,7 +3,9 @@ title: Run the Mattermost Access Request plugin
 description: How to set up Teleport's Mattermost plugin for privilege elevation approvals.
 ---
 
-This guide explains how to integrate Teleport access requests with Mattermost, an open 
+import BotLogo from "/static/avatar_logo.png";
+
+This guide explains how to integrate Teleport Access Requests with Mattermost, an open 
 source messaging platform. The Teleport Mattermost plugin notifies individuals of
 access requests. Users can then approve and deny access requests by following the
 message link, making it easier to implement security best practices without
@@ -101,8 +103,9 @@ Set the "Username", "Display Name", and "Description" fields according to how
 you would like the Mattermost plugin bot to appear in your workspace. Set "Role"
 to "Member".
 
-You can <a href="../../../../img/enterprise/plugins/teleport_bot@2x.png"
-download>download</a> our avatar to set as your Bot Icon.
+{/* lint ignore absolute-docs-links */}
+You can <a href={BotLogo} download>download</a> our avatar to set as your Bot
+Icon.
 
 Set "post:all" to "Enabled".
 


### PR DESCRIPTION
Backports #51193

Closes #50827
Closes #50826

This allows us to create a download link using the `a` tag.

Depends on gravitational/docs-website#114