### PR TITLE
Update self-hosted upgrade guide

### DIFF
--- a/docs/pages/includes/compatibility.mdx
+++ b/docs/pages/includes/compatibility.mdx
@@ -3,9 +3,6 @@ include a major version, minor version, and patch version, separated by dots.
 When running multiple `teleport` binaries within a cluster, the following rules
 apply:
 
-- **Patch and minor** versions are always compatible, for example, any 8.0.1
-  component will work with any 8.0.3 component and any 8.1.0 component will work
-  with any 8.3.0 component.
 - Servers support clients that are one major version behind, but do not support
   clients that are on a newer major version. For example, an 8.x.x Proxy Service
   instance is compatible with 7.x.x agents and 7.x.x `tsh`, but we don't
@@ -14,5 +11,5 @@ apply:
   You must upgrade to 7.x.x first.
 - Proxy Service instances and agents do not support Auth Service instances that
   are on an older major version, and will fail to connect to older Auth Service
-  instances by default. You can override version checks by passing
-  `--skip-version-check` when starting agents and Proxy Service instances.
+  instances by default. For example, an 8.x.x Proxy Service or agent is not
+  compatible with an 7.x.x Auth Service.

--- a/docs/pages/upgrading/overview.mdx
+++ b/docs/pages/upgrading/overview.mdx
@@ -27,36 +27,36 @@ $ curl -s https://mytenant.teleport.sh/webapi/ping | jq '.server_version'
 
 Because of the component compatibility guarantees we described in the previous
 section, you must adhere to the following sequence when upgrading a self-hosted
-Teleport cluster:
+Teleport cluster.
+
+<Admonition type="warning">
+  If you are upgrading more then one major version, you must repeat the
+  following steps for each major version until you reach your target version.
+  For example, if your cluster is on v10 and you wish to upgrade to v13, you
+  must first follow the sequence below for v11, then v12, before finally upgrading
+  to v13. You must not upgrade directly from v10 to v13.
+</Admonition>
 
 1. Back up your Teleport cluster state as a precaution against any unforeseen
    incidents while upgrading the Auth Service, which may perform data
    migrations on its backend. Follow the instructions in [Backup and
    Restore](../admin-guides/management/operations/backup-restore.mdx).
-
-1. If several Auth Service instances are running in a high availability
-   configuration (for example, in an AWS Auto Scaling group), you must shrink
-   the group to **just one Auth Service** before performing an upgrade.
-
-1. Upgrade the **Auth Service** to the next **major version first**. If there
-   are data format changes introduced in the new version, the Auth Service
-   performs the necessary migrations.  After the upgrade, start the Auth Service
-   and CONFIRM that it's in a healthy state before continuing.
-
-1. Upgrade Proxy Service instances to the same version number as the Auth
+1. Upgrade all **Auth Service** instances to the **target version first**.
+   Auth Service instances may be upgraded in any sequence or at the same time. After
+   the upgrade **confirm** that the cluster is in a healthy state before continuing.
+1. Upgrade Proxy Service instances to the same version as the Auth
    Service. Proxy Service instances are stateless and can be upgraded in any
-   sequence or at the same time.
-
-1. Upgrade your Teleport Agents to the same version number as the Auth Service.
-   You can upgrade resource agents in any sequence or at the same time.
-   
-   If you are upgrading more then one version number, repeat these steps until
-   you reach your target major version number.
+   sequence or at the same time. After the upgrade **confirm** that the cluster
+   is in a healthy state before continuing.
+1. Upgrade your Teleport Agents to the same version as the Auth Service.
+   You can upgrade resource agents in any sequence or at the same time. After the
+   upgrade **confirm** that the cluster is in a healthy state before continuing.
+1. Upgrade your Teleport clients and plugins (tctl, tsh, tbot, terraform-provider, event-handler, etc.).
 
 ## Upgrading multiple Teleport clusters
 
 When upgrading multiple Teleport clusters with a trust relationship, you must
-upgrade in the following sequence to avoid compatibility issues. 
+upgrade in the following sequence to avoid compatibility issues.
 
 You must upgrade all clusters one major version at a time. For example, if you
 would like to upgrade your clusters from v10 to v12, you must follow the


### PR DESCRIPTION
The guide now reflects that rolling Auth upgrades are allowable in certain scenarios. The guide also explicitly calls out when client tools should be upgraded.