### PR TITLE
Fetch relevant regions for agents endpoint

### DIFF
--- a/lib/utils/set.go
+++ b/lib/utils/set.go
@@ -84,6 +84,15 @@ func (s Set[T]) Subtract(other Set[T]) Set[T] {
 	return s
 }
 
+// Intersection updates the set to contain the similarity between the set and `other`
+func (s Set[T]) Intersection(other Set[T]) {
+	for b := range s {
+		if !other.Contains(b) {
+			s.Remove(b)
+		}
+	}
+}
+
 // Elements returns the elements in the set. Order of the elements is undefined.
 //
 // NOTE: Due to the underlying map type, a set can be naturally ranged over like

--- a/lib/utils/set_test.go
+++ b/lib/utils/set_test.go
@@ -279,6 +279,54 @@ func TestSet(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("intersection", func(t *testing.T) {
+		testCases := []struct {
+			name     string
+			a        []string
+			b        []string
+			expected []string
+		}{
+			{
+				name:     "empty intersection empty",
+				expected: []string{},
+			},
+			{
+				name:     "empty intersection populated",
+				b:        []string{"alpha", "beta"},
+				expected: []string{},
+			},
+			{
+				name:     "populated intersection empty",
+				a:        []string{"alpha", "beta"},
+				expected: []string{},
+			},
+			{
+				name:     "populated intersection populated",
+				a:        []string{"alpha", "beta", "gamma", "delta", "epsilon"},
+				b:        []string{"beta", "eta", "zeta", "epsilon"},
+				expected: []string{"beta", "epsilon"},
+			},
+		}
+
+		for _, test := range testCases {
+			t.Run(test.name, func(t *testing.T) {
+				// GIVEN a pair of sets
+				a := NewSet(test.a...)
+				b := NewSet(test.b...)
+				bItems := b.Elements()
+
+				// WHEN I take the intersection of both sets
+				a.Intersection(b)
+
+				// EXPECT that the target set is updated with the intersection of both sets.
+				require.ElementsMatch(t, a.Elements(), test.expected)
+
+				// EXPECT also that the second set is unchanged
+				require.ElementsMatch(t, b.Elements(), bItems)
+			})
+		}
+	})
 }
 
 func TestSetTransform(t *testing.T) {

--- a/lib/web/integrations_awsoidc_test.go
+++ b/lib/web/integrations_awsoidc_test.go
@@ -1361,10 +1361,16 @@ func dummyDeployedDatabaseServices(count int, command []string) []*integrationv1
 func TestRegionsForListingDeployedDatabaseService(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("regions query param is used instead of parsing internal resources", func(t *testing.T) {
+	t.Run("regions query param, returns nil if no internal resources match", func(t *testing.T) {
 		clt := &mockRelevantAWSRegionsClient{
 			databaseServices: &proto.ListResourcesResponse{
-				Resources: []*proto.PaginatedResource{},
+				Resources: []*proto.PaginatedResource{{Resource: &proto.PaginatedResource_DatabaseService{
+					DatabaseService: &types.DatabaseServiceV1{Spec: types.DatabaseServiceSpecV1{
+						ResourceMatchers: []*types.DatabaseResourceMatcher{
+							{Labels: &types.Labels{"region": []string{"af-south-1"}}},
+						},
+					}},
+				}}},
 			},
 			databases:        make([]types.Database, 0),
 			discoveryConfigs: make([]*discoveryconfig.DiscoveryConfig, 0),
@@ -1374,7 +1380,28 @@ func TestRegionsForListingDeployedDatabaseService(t *testing.T) {
 		}
 		gotRegions, err := regionsForListingDeployedDatabaseService(ctx, &r, clt, clt)
 		require.NoError(t, err)
-		require.ElementsMatch(t, []string{"us-east-1", "us-east-2"}, gotRegions)
+		require.ElementsMatch(t, nil, gotRegions)
+	})
+
+	t.Run("regions query param, returns matches in internal resources", func(t *testing.T) {
+		clt := &mockRelevantAWSRegionsClient{
+			databaseServices: &proto.ListResourcesResponse{
+				Resources: []*proto.PaginatedResource{{Resource: &proto.PaginatedResource_DatabaseService{
+					DatabaseService: &types.DatabaseServiceV1{Spec: types.DatabaseServiceSpecV1{
+						ResourceMatchers: []*types.DatabaseResourceMatcher{
+							{Labels: &types.Labels{"region": []string{"af-south-1"}}}},
+					}},
+				}}},
+			},
+			databases:        make([]types.Database, 0),
+			discoveryConfigs: make([]*discoveryconfig.DiscoveryConfig, 0),
+		}
+		r := http.Request{
+			URL: &url.URL{RawQuery: "regions=af-south-1&regions=us-east-2"},
+		}
+		gotRegions, err := regionsForListingDeployedDatabaseService(ctx, &r, clt, clt)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []string{"af-south-1"}, gotRegions)
 	})
 
 	t.Run("fallbacks to internal resources when query param is not present", func(t *testing.T) {
@@ -1393,13 +1420,14 @@ func TestRegionsForListingDeployedDatabaseService(t *testing.T) {
 			discoveryConfigs: make([]*discoveryconfig.DiscoveryConfig, 0),
 		}
 		r := http.Request{
-			URL: &url.URL{},
+			URL: &url.URL{RawQuery: "regions="},
 		}
 		gotRegions, err := regionsForListingDeployedDatabaseService(ctx, &r, clt, clt)
 		require.NoError(t, err)
 		require.ElementsMatch(t, []string{"us-east-1", "us-east-2"}, gotRegions)
 	})
 }
+
 func TestFetchRelevantAWSRegions(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
This PR updates the region logic for the aws oidc database services; it checks for relevant regions, and then applies a filter to that subset if applicable. This prevents us from trying to get services from regions that are not yet set up. 

Supports https://github.com/gravitational/teleport/pull/49855

Before:
![Screenshot 2025-02-03 at 11 56 27 AM](https://github.com/user-attachments/assets/f63ce8f3-a7d1-4d61-b376-8f8e882fa639)
