### PR TITLE
kube-agent-updater pre-release builds trust the staging repo + insecure validator private repo fix

### DIFF
--- a/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/constants.go
+++ b/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/constants.go
@@ -36,3 +36,21 @@ EuIXJJox2oAL7NzdSi9VIUYnEnx+2EtkU/spAFRR6i1BnT6aoIy3521B76wnmRr9
 atCSKjt6MdRxgj4htCjBWWJAGM9Z/avF4CYFmK7qiVxgpdrSM8Esbt2Ta+Lu3QMJ
 T8LjqFu3u3dxVOo9RuLk+BkCAwEAAQ==
 -----END PUBLIC KEY-----`)
+
+// teleportStageOCIPubKey is the key used to sign Teleport distroless images dev builds.
+// The key lives in the Teleport staging AWS KMS.
+// This key is only trusted on dev builds/pre-release versions of the kube updater.
+var teleportStageOCIPubKey = []byte(`-----BEGIN PUBLIC KEY-----
+MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA8MPaUO4fcN3gS1psn3U7
+Pm/iM7jLQVg5MgcG9jbAkFsVOvmk3eq7cv0r94voz63IXhs4wKLK/e2QMljW1kz1
+AX7NvdXecCxwcyntgYnDXtxYBhcPGSM6cVnWlZ3pLNb8uVK7oxm0HjGUblcLreaI
+aoLGmpyK+eCCLJso0Y7Yw0qRTJHg+2JQenbWps23AO96a6nqab2Ix7zEa3HyNZLa
+P6rYV9q6vqZ3MBsDz5Lrc76JYSliqGVMVONhdXcqS2PYNti4Wm8o2CTJ0gRf2zYx
+z2how6+rWM8HVoRYqG8JvCDvY6SGr5AbqIz/UCGm7XDH1S7M7C4FZ3MNTazoHY7h
+VGAYLNPOtnQeZTtJDyRPH7csq+2tyvDPin3ymgRvvBrMrpBSmnnr67TxSIAv4xgu
+B2hAgTL501B+s2m06bBcbKc03JsxgJBu4sBxKqIh1yeF8AW861bh90oZGI8/d9xM
+fyI0BiELvY08HioQaAoC2VJx44I+KVDA1SLnMEx9n44eZ5Bk8G6PiZe5bikVDizF
+RBVos6fjDapmGqVGoj+eotrI755FTKA3egB8DYw/H5yD1CO0QBBWXDhqM0ruTt4i
+LzfxsdKEiXFMFZmXYzqwut9RXguGa/7LYPT7ijtW57z/wLytIjyYRkZH1P0dffFs
+tiben+kjeNwFJ7Kg/WIDjjUCAwEAAQ==
+-----END PUBLIC KEY-----`)

--- a/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
+++ b/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
@@ -254,7 +254,7 @@ func main() {
 		imageValidators = append(imageValidators, img.NewInsecureValidator("insecure always verified", kc))
 	case semver.Prerelease("v"+kubeversionupdater.Version) != "":
 		ctrl.Log.Info("This is a pre-release updater version, the key usied to sign dev and pre-release builds of Teleport will be trusted.")
-		validator, err := img.NewCosignSingleKeyValidator(teleportStageOCIPubKey, "cosign signature validator", kc)
+		validator, err := img.NewCosignSingleKeyValidator(teleportStageOCIPubKey, "staging cosign signature validator", kc)
 		if err != nil {
 			ctrl.Log.Error(err, "failed to build pre-release image validator, exiting")
 			os.Exit(1)

--- a/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
+++ b/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/distribution/reference"
 	"github.com/go-logr/logr"
 	"github.com/gravitational/trace"
+	"golang.org/x/mod/semver"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -238,6 +239,11 @@ func main() {
 		maintenance.FailoverTrigger(plannedMaintenanceTriggers),
 	}
 
+	kc, err := img.GetKeychain(credSource)
+	if err != nil {
+		ctrl.Log.Error(err, "failed to get keychain for registry auth")
+	}
+
 	var imageValidators img.Validators
 	switch {
 	case insecureNoResolve:
@@ -245,12 +251,17 @@ func main() {
 		imageValidators = append(imageValidators, img.NewNopValidator("insecure no resolution"))
 	case insecureNoVerify:
 		ctrl.Log.Info("INSECURE: Image validation disabled")
-		imageValidators = append(imageValidators, img.NewInsecureValidator("insecure always verified"))
-	default:
-		kc, err := img.GetKeychain(credSource)
+		imageValidators = append(imageValidators, img.NewInsecureValidator("insecure always verified", kc))
+	case semver.Prerelease("v"+kubeversionupdater.Version) != "":
+		ctrl.Log.Info("This is a pre-release updater version, the key usied to sign dev and pre-release builds of Teleport will be trusted.")
+		validator, err := img.NewCosignSingleKeyValidator(teleportStageOCIPubKey, "cosign signature validator", kc)
 		if err != nil {
-			ctrl.Log.Error(err, "failed to get keychain for registry auth")
+			ctrl.Log.Error(err, "failed to build pre-release image validator, exiting")
+			os.Exit(1)
 		}
+		imageValidators = append(imageValidators, validator)
+		fallthrough
+	default:
 		validator, err := img.NewCosignSingleKeyValidator(teleportProdOCIPubKey, "cosign signature validator", kc)
 		if err != nil {
 			ctrl.Log.Error(err, "failed to build image validator, exiting")


### PR DESCRIPTION
Second version of the PR based on @marcoandredinis  and @tigrato 's feedback:
- Updater prerelease builds will trust both the prod and staging signing keys.
- Non-prerelease builds still only trust the Teleport prod signing key.

While writing this I found a bug in the insecure image validator: it was not using the keychain to resolve images in private repos: I changed the function signature to pass the same registry options as we do for regular image validation.

Changelog: Pre-releases version of the `teleport-kube-agent-updater` now trust Teleport's staging repository.
Changeog: Fix a bug in `teleport-kube-agent-updater` causing the image validator to not resolve images when both `--pull-credentials` and `--insecure-no-verify-image` were set.