### PR TITLE
access_monitoring_rule: Support `plugin.spec.name` condition variable

### DIFF
--- a/docs/pages/admin-guides/access-controls/access-request-plugins/notification-routing-rules.mdx
+++ b/docs/pages/admin-guides/access-controls/access-request-plugins/notification-routing-rules.mdx
@@ -77,8 +77,11 @@ metadata:
   name: your-plugin-name
 spec:
   subjects: ['access_request']
-  condition: 'access_request.spec.roles.contains("your_role_name")'
+  condition: >
+    plugin.spec.name == "slack" &&
+    access_request.spec.roles.contains("your_role_name")
   notification:
+    # Deprecated: Use condition: 'plugin.spec.name == "slack"' instead.
     name: 'slack'
     recipients: ['your_slack_channel']
 ```
@@ -100,6 +103,7 @@ Fields of the Access Request that are currently supported are
 | access_request.spec.request_reason | The request reason. |
 | access_request.spec.creation_time | The creation time of the request. |
 | access_request.spec.expiry | The expiry time of the request. |
+| plugin.spec.name | The name of the plugin that this AMR applies to. |
 
 Predicate expressions used in the condition of Access Monitoring Rules must evaluate to
 either true or false.

--- a/integrations/access/accessmonitoring/request_mapping.go
+++ b/integrations/access/accessmonitoring/request_mapping.go
@@ -21,14 +21,13 @@ import (
 
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/expression"
 	"github.com/gravitational/teleport/lib/utils/typical"
 )
 
-// accessRequestExpressionEnv holds user details that can be mapped in an
+// AccessRequestExpressionEnv holds user details that can be mapped in an
 // access request condition assertion.
-type accessRequestExpressionEnv struct {
+type AccessRequestExpressionEnv struct {
 	Roles              []string
 	SuggestedReviewers []string
 	Annotations        map[string][]string
@@ -46,7 +45,7 @@ type PluginExpressionEnv struct {
 	Name string
 }
 
-type accessRequestExpression typical.Expression[accessRequestExpressionEnv, any]
+type accessRequestExpression typical.Expression[AccessRequestExpressionEnv, any]
 
 func parseAccessRequestExpression(expr string) (accessRequestExpression, error) {
 	parser, err := newRequestConditionParser()
@@ -60,68 +59,58 @@ func parseAccessRequestExpression(expr string) (accessRequestExpression, error) 
 	return parsedExpr, nil
 }
 
-func newRequestConditionParser() (*typical.Parser[accessRequestExpressionEnv, any], error) {
+func newRequestConditionParser() (*typical.Parser[AccessRequestExpressionEnv, any], error) {
 	typicalEnvVar := map[string]typical.Variable{
 		"true":  true,
 		"false": false,
-		"access_request.spec.roles": typical.DynamicVariable[accessRequestExpressionEnv](func(env accessRequestExpressionEnv) (expression.Set, error) {
+		"access_request.spec.roles": typical.DynamicVariable(func(env AccessRequestExpressionEnv) (expression.Set, error) {
 			return expression.NewSet(env.Roles...), nil
 		}),
-		"access_request.spec.suggested_reviewers": typical.DynamicVariable[accessRequestExpressionEnv](func(env accessRequestExpressionEnv) (expression.Set, error) {
+		"access_request.spec.suggested_reviewers": typical.DynamicVariable(func(env AccessRequestExpressionEnv) (expression.Set, error) {
 			return expression.NewSet(env.SuggestedReviewers...), nil
 		}),
-		"access_request.spec.system_annotations": typical.DynamicMap[accessRequestExpressionEnv, expression.Set](func(env accessRequestExpressionEnv) (expression.Dict, error) {
+		"access_request.spec.system_annotations": typical.DynamicMap(func(env AccessRequestExpressionEnv) (expression.Dict, error) {
 			return expression.DictFromStringSliceMap(env.Annotations), nil
 		}),
-		"access_request.spec.user": typical.DynamicVariable[accessRequestExpressionEnv](func(env accessRequestExpressionEnv) (string, error) {
+		"access_request.spec.user": typical.DynamicVariable(func(env AccessRequestExpressionEnv) (string, error) {
 			return env.User, nil
 		}),
-		"access_request.spec.request_reason": typical.DynamicVariable[accessRequestExpressionEnv](func(env accessRequestExpressionEnv) (string, error) {
+		"access_request.spec.request_reason": typical.DynamicVariable(func(env AccessRequestExpressionEnv) (string, error) {
 			return env.RequestReason, nil
 		}),
-		"access_request.spec.creation_time": typical.DynamicVariable[accessRequestExpressionEnv](func(env accessRequestExpressionEnv) (time.Time, error) {
+		"access_request.spec.creation_time": typical.DynamicVariable(func(env AccessRequestExpressionEnv) (time.Time, error) {
 			return env.CreationTime, nil
 		}),
-		"access_request.spec.expiry": typical.DynamicVariable[accessRequestExpressionEnv](func(env accessRequestExpressionEnv) (time.Time, error) {
+		"access_request.spec.expiry": typical.DynamicVariable(func(env AccessRequestExpressionEnv) (time.Time, error) {
 			return env.Expiry, nil
 		}),
 
 		// Plugin provided condition variables.
-		"plugin.spec.name": typical.DynamicVariable(func(env accessRequestExpressionEnv) (string, error) {
+		"plugin.spec.name": typical.DynamicVariable(func(env AccessRequestExpressionEnv) (string, error) {
 			return env.Plugin.Name, nil
 		}),
 	}
-	defParserSpec := expression.DefaultParserSpec[accessRequestExpressionEnv]()
+	defParserSpec := expression.DefaultParserSpec[AccessRequestExpressionEnv]()
 	defParserSpec.Variables = typicalEnvVar
 
-	requestConditionParser, err := typical.NewParser[accessRequestExpressionEnv, any](defParserSpec)
+	requestConditionParser, err := typical.NewParser[AccessRequestExpressionEnv, any](defParserSpec)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return requestConditionParser, nil
 }
 
-func MatchAccessRequest(expr string, req types.AccessRequest, pluginEnv PluginExpressionEnv) (bool, error) {
-	parsedExpr, err := parseAccessRequestExpression(expr)
+// IsConditionMatched returns the evaluated condition expression value.
+// A true value indicates that the condition is a match for the access request env.
+func IsConditionMatched(condition string, env AccessRequestExpressionEnv) (bool, error) {
+	parsedExpr, err := parseAccessRequestExpression(condition)
 	if err != nil {
 		return false, trace.Wrap(err)
 	}
-
-	match, err := parsedExpr.Evaluate(accessRequestExpressionEnv{
-		Roles:              req.GetRoles(),
-		SuggestedReviewers: req.GetSuggestedReviewers(),
-		Annotations:        req.GetSystemAnnotations(),
-		User:               req.GetUser(),
-		RequestReason:      req.GetRequestReason(),
-		CreationTime:       req.GetCreationTime(),
-		Expiry:             req.Expiry(),
-		Plugin:             pluginEnv,
-	})
+	match, err := parsedExpr.Evaluate(env)
 	if err != nil {
-		return false, trace.Wrap(err, "evaluating access monitoring rule condition expression %q", expr)
+		return false, trace.Wrap(err, "evaluating access monitoring rule condition expression %q", condition)
 	}
-	if matched, ok := match.(bool); ok && matched {
-		return true, nil
-	}
-	return false, nil
+	matched, ok := match.(bool)
+	return ok && matched, nil
 }

--- a/integrations/access/accessmonitoring/request_mapping_test.go
+++ b/integrations/access/accessmonitoring/request_mapping_test.go
@@ -1,0 +1,63 @@
+/*
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package accessmonitoring
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatchAccessRequest(t *testing.T) {
+	tests := []struct {
+		description string
+		condition   string
+		env         AccessRequestExpressionEnv
+		match       bool
+	}{
+		{
+			description: "match plugin name",
+			condition:   `plugin.spec.name == "teleport-plugin"`,
+			env: AccessRequestExpressionEnv{
+				Plugin: PluginExpressionEnv{
+					Name: "teleport-plugin",
+				},
+			},
+			match: true,
+		},
+		{
+			description: "mismatch plugin name",
+			condition:   `plugin.spec.name == "teleport-plugin"`,
+			env: AccessRequestExpressionEnv{
+				Plugin: PluginExpressionEnv{
+					Name: "teleport-plugin-mismatch",
+				},
+			},
+			match: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			match, err := IsConditionMatched(test.condition, test.env)
+			require.NoError(t, err)
+			require.Equal(t, test.match, match)
+		})
+	}
+}

--- a/integrations/access/accessmonitoring/request_mapping_test.go
+++ b/integrations/access/accessmonitoring/request_mapping_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMatchAccessRequest(t *testing.T) {
+func TestIsConditionMatched(t *testing.T) {
 	tests := []struct {
 		description string
 		condition   string

--- a/lib/services/access_monitoring_rules.go
+++ b/lib/services/access_monitoring_rules.go
@@ -20,7 +20,6 @@ package services
 
 import (
 	"context"
-	"slices"
 
 	"github.com/gravitational/trace"
 
@@ -85,15 +84,18 @@ func ValidateAccessMonitoringRule(accessMonitoringRule *accessmonitoringrulesv1.
 		return trace.BadParameter("accessMonitoringRule condition is missing")
 	}
 
-	if accessMonitoringRule.Spec.Notification != nil && accessMonitoringRule.Spec.Notification.Name == "" {
-		return trace.BadParameter("accessMonitoringRule notification plugin name is missing")
-	}
-	if hasAccessRequestAsSubject := slices.ContainsFunc(accessMonitoringRule.Spec.Subjects, func(subject string) bool {
-		return subject == types.KindAccessRequest
-	}); hasAccessRequestAsSubject && accessMonitoringRule.Spec.Notification == nil {
-		return trace.BadParameter("accessMonitoringRule notification configuration must be set if subjects contain %q",
-			types.KindAccessRequest)
-	}
+	// The notification name is deprecated and no longer required.
+	// if accessMonitoringRule.Spec.Notification != nil && accessMonitoringRule.Spec.Notification.Name == "" {
+	// 	return trace.BadParameter("accessMonitoringRule notification plugin name is missing")
+	// }
+
+	// Notification can be omitted if only the auto approval rules are required.
+	// if hasAccessRequestAsSubject := slices.ContainsFunc(accessMonitoringRule.Spec.Subjects, func(subject string) bool {
+	// 	return subject == types.KindAccessRequest
+	// }); hasAccessRequestAsSubject && accessMonitoringRule.Spec.Notification == nil {
+	// 	return trace.BadParameter("accessMonitoringRule notification configuration must be set if subjects contain %q",
+	// 		types.KindAccessRequest)
+	// }
 
 	return nil
 }

--- a/lib/services/access_monitoring_rules.go
+++ b/lib/services/access_monitoring_rules.go
@@ -84,19 +84,6 @@ func ValidateAccessMonitoringRule(accessMonitoringRule *accessmonitoringrulesv1.
 		return trace.BadParameter("accessMonitoringRule condition is missing")
 	}
 
-	// The notification name is deprecated and no longer required.
-	// if accessMonitoringRule.Spec.Notification != nil && accessMonitoringRule.Spec.Notification.Name == "" {
-	// 	return trace.BadParameter("accessMonitoringRule notification plugin name is missing")
-	// }
-
-	// Notification can be omitted if only the auto approval rules are required.
-	// if hasAccessRequestAsSubject := slices.ContainsFunc(accessMonitoringRule.Spec.Subjects, func(subject string) bool {
-	// 	return subject == types.KindAccessRequest
-	// }); hasAccessRequestAsSubject && accessMonitoringRule.Spec.Notification == nil {
-	// 	return trace.BadParameter("accessMonitoringRule notification configuration must be set if subjects contain %q",
-	// 		types.KindAccessRequest)
-	// }
-
 	return nil
 }
 


### PR DESCRIPTION
Supports https://github.com/gravitational/teleport/issues/51682

This PR adds supports for using `plugin.spec.name` variable within the condition expression.

The `plugin.spec.name` will replace the `spec.notification.name`. This is more of a UX change. We can deprecate the `spec.notification.name` but continue to support it. With built-in/native auto approvals, we'd like to support auto approvals without notifications. It would be a bit confusing to continue using `spec.notification.name` in this scenario.

```yaml
# Example AMR
kind: access_monitoring_rule
version: v1
metadata:
  name: teleport-pre-approved-roles
spec:
  condition: >
    plugin.spec.name == "teleport-slack" &&
    contains_any(access_request.spec.roles, set("prod"))
  subjects:
    - access_request
  notification:
    # Deprecated: Use 'plugin.spec.name == "teleport-native"' condition instead
    # name: teleport-slack
    recipients: ["access-requests"] 
```

There is one notable change in behavior with these changes. The AMR can now be configured to match all available plugins, because the `spec.notification.name` can be empty. If this is an undesirable change, we can add an extra validation step to ensure that a `plugin.spec.name` variable is used within the condition expression.

Changelog: Support `plugin.spec.name` AMR condition variable.