### PR TITLE
[v17] Respect role max duration when request does not set it

### DIFF
--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -1421,8 +1421,7 @@ func (m *RequestValidator) calculateMaxAccessDuration(req types.AccessRequest, s
 			}
 		}
 
-		if !roleDurationSet || maxDurationForRole < minAdjDuration {
-			roleDurationSet = true
+		if minAdjDuration == 0 || maxDurationForRole < minAdjDuration {
 			minAdjDuration = maxDurationForRole
 		}
 	}

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -1398,7 +1398,7 @@ func (m *RequestValidator) calculateMaxAccessDuration(req types.AccessRequest, s
 	// This prevents the time drift that can occur as the value is set on the client side.
 	if req.GetDryRun() {
 		maxDuration = MaxAccessDuration
-		// maxDuration may end upo < 0 even if maxDurationTime is set
+		// maxDuration may end up < 0 even if maxDurationTime is set
 	} else if !maxDurationTime.IsZero() && maxDuration < 0 {
 		return 0, trace.BadParameter("invalid maxDuration: must be greater than creation time")
 	}
@@ -1430,11 +1430,11 @@ func (m *RequestValidator) calculateMaxAccessDuration(req types.AccessRequest, s
 	return minAdjDuration, nil
 }
 
-func (m *RequestValidator) maxDurationForRole(role string) time.Duration {
+func (m *RequestValidator) maxDurationForRole(roleName string) time.Duration {
 	var maxDurationForRole time.Duration
 	for _, tms := range m.MaxDurationMatchers {
 		for _, matcher := range tms.Matchers {
-			if matcher.Match(role) {
+			if matcher.Match(roleName) {
 				if tms.MaxDuration > maxDurationForRole {
 					maxDurationForRole = tms.MaxDuration
 				}

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -1407,7 +1407,6 @@ func (m *RequestValidator) calculateMaxAccessDuration(req types.AccessRequest, s
 	}
 
 	var minAdjDuration time.Duration
-	roleDurationSet := false
 	// Adjust the expiration time if the max_duration value is set on the request role.
 	for _, roleName := range req.GetRoles() {
 		var maxDurationForRole time.Duration

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -1398,6 +1398,7 @@ func (m *RequestValidator) calculateMaxAccessDuration(req types.AccessRequest, s
 	// This prevents the time drift that can occur as the value is set on the client side.
 	if req.GetDryRun() {
 		maxDuration = MaxAccessDuration
+		// maxDuration may end upo < 0 even if maxDurationTime is set
 	} else if !maxDurationTime.IsZero() && maxDuration < 0 {
 		return 0, trace.BadParameter("invalid maxDuration: must be greater than creation time")
 	}
@@ -1409,17 +1410,7 @@ func (m *RequestValidator) calculateMaxAccessDuration(req types.AccessRequest, s
 	var minAdjDuration time.Duration
 	// Adjust the expiration time if the max_duration value is set on the request role.
 	for _, roleName := range req.GetRoles() {
-		var maxDurationForRole time.Duration
-		for _, tms := range m.MaxDurationMatchers {
-			for _, matcher := range tms.Matchers {
-				if matcher.Match(roleName) {
-					if tms.MaxDuration > maxDurationForRole {
-						maxDurationForRole = tms.MaxDuration
-					}
-				}
-			}
-		}
-
+		maxDurationForRole := m.maxDurationForRole(roleName)
 		if minAdjDuration == 0 || maxDurationForRole < minAdjDuration {
 			minAdjDuration = maxDurationForRole
 		}
@@ -1437,6 +1428,20 @@ func (m *RequestValidator) calculateMaxAccessDuration(req types.AccessRequest, s
 	}
 
 	return minAdjDuration, nil
+}
+
+func (m *RequestValidator) maxDurationForRole(role string) time.Duration {
+	var maxDurationForRole time.Duration
+	for _, tms := range m.MaxDurationMatchers {
+		for _, matcher := range tms.Matchers {
+			if matcher.Match(role) {
+				if tms.MaxDuration > maxDurationForRole {
+					maxDurationForRole = tms.MaxDuration
+				}
+			}
+		}
+	}
+	return maxDurationForRole
 }
 
 // calculatePendingRequestTTL calculates the TTL of the Access Request (how long it will await

--- a/lib/services/access_request_test.go
+++ b/lib/services/access_request_test.go
@@ -2806,8 +2806,8 @@ func TestValidate_RequestedMaxDuration(t *testing.T) {
 		},
 		{
 			desc:                   "role max_duration is respected when requestedMaxDuration is not set",
-			requestor:              "alice",
-			roles:                  []string{"requestedRole"}, // role max_duration capped to 1 day
+			requestor:              "alice",                   // has shortMaxDurationReqRole role assigned
+			roles:                  []string{"requestedRole"}, // caps max_duration to 3 days
 			expectedAccessDuration: 3 * day,
 			expectedPendingTTL:     3 * day,
 			expectedSessionTTL:     8 * time.Hour,

--- a/lib/services/access_request_test.go
+++ b/lib/services/access_request_test.go
@@ -2673,6 +2673,14 @@ func TestValidate_RequestedMaxDuration(t *testing.T) {
 				},
 			},
 		},
+		"shortMaxDurationReqRole3": {
+			condition: types.RoleConditions{
+				Request: &types.AccessRequestConditions{
+					Roles:       []string{"requestedRole"},
+					MaxDuration: types.Duration(day),
+				},
+			},
+		},
 	}
 
 	// describes a collection of users with various roles
@@ -2681,6 +2689,7 @@ func TestValidate_RequestedMaxDuration(t *testing.T) {
 		"bob":   {"defaultRole"},
 		"carol": {"shortMaxDurationReqRole", "shortMaxDurationReqRole2"},
 		"david": {"maxDurationReqRole"},
+		"erin":  {"shortMaxDurationReqRole", "shortMaxDurationReqRole3", "maxDurationReqRole"},
 	}
 
 	defaultSessionTTL := 8 * time.Hour
@@ -2810,6 +2819,17 @@ func TestValidate_RequestedMaxDuration(t *testing.T) {
 			roles:                  []string{"requestedRole"}, // caps max_duration to 3 days
 			expectedAccessDuration: 3 * day,
 			expectedPendingTTL:     3 * day,
+			expectedSessionTTL:     8 * time.Hour,
+		},
+		{
+			desc: "multiple roles with different max durations assigned",
+			// erin has the maxDurationReqRole (7 days) role assigned
+			// along with 2 other roles with shorter durations
+			// shortMaxDurationReqRole (3 days) and shortMaxDurationReqRole3 (1 day)
+			requestor:              "erin",
+			roles:                  []string{"requestedRole"}, // caps max_duration to 7 days
+			expectedAccessDuration: 7 * day,
+			expectedPendingTTL:     7 * day,
 			expectedSessionTTL:     8 * time.Hour,
 		},
 	}


### PR DESCRIPTION
Backport #51467 to branch/v17

changelog: Fix bug where role max_duration is not respected unless request max_duration is set
