### PR TITLE
Update grpc/stats/opentelemetry exclude

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -591,7 +591,4 @@ replace (
 // least, one of the grpc-go versions above we need to exclude
 // stats/opentelemetry in order to avoid "ambiguous import" errors on build.
 // TODO(codingllama): Remove once no dependencies import stats/opentelemetry.
-exclude (
-	google.golang.org/grpc/stats/opentelemetry v0.0.0-20240907200651-3ffb98b2c93a
-	google.golang.org/grpc/stats/opentelemetry v0.0.0-20241028142157-ada6787961b3
-)
+exclude google.golang.org/grpc/stats/opentelemetry v0.0.0-20241028142157-ada6787961b3

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -352,7 +352,4 @@ replace (
 )
 
 // TODO(codingllama): Remove once no dependencies import stats/opentelemetry.
-exclude (
-	google.golang.org/grpc/stats/opentelemetry v0.0.0-20240907200651-3ffb98b2c93a
-	google.golang.org/grpc/stats/opentelemetry v0.0.0-20241028142157-ada6787961b3
-)
+exclude google.golang.org/grpc/stats/opentelemetry v0.0.0-20241028142157-ada6787961b3

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -418,7 +418,4 @@ replace (
 )
 
 // TODO(codingllama): Remove once no dependencies import stats/opentelemetry.
-exclude (
-	google.golang.org/grpc/stats/opentelemetry v0.0.0-20240907200651-3ffb98b2c93a
-	google.golang.org/grpc/stats/opentelemetry v0.0.0-20241028142157-ada6787961b3
-)
+exclude google.golang.org/grpc/stats/opentelemetry v0.0.0-20241028142157-ada6787961b3


### PR DESCRIPTION
One one excluded version left: https://github.com/fsouza/fake-gcs-server/blob/7ab6342379e25a82c2466c277a20478e9164bb60/go.mod#L54.