### PR TITLE
[v16] transition ssh enforcement to sshca.Identity

### DIFF
--- a/api/types/authority.go
+++ b/api/types/authority.go
@@ -545,14 +545,6 @@ func (s *RotationSchedule) CheckAndSetDefaults(now time.Time) error {
 	return nil
 }
 
-// CertRoles defines certificate roles
-type CertRoles struct {
-	// Version is current version of the roles
-	Version string `json:"version"`
-	// Roles is a list of roles
-	Roles []string `json:"roles"`
-}
-
 // Clone returns a deep copy of TLSKeyPair that can be mutated without
 // modifying the original.
 func (k *TLSKeyPair) Clone() *TLSKeyPair {

--- a/lib/auth/access_request_test.go
+++ b/lib/auth/access_request_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
+	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
@@ -1357,6 +1358,8 @@ func checkCerts(t *testing.T,
 	// Parse SSH cert.
 	sshCert, err := sshutils.ParseCertificate(certs.SSH)
 	require.NoError(t, err)
+	sshIdentity, err := sshca.DecodeIdentity(sshCert)
+	require.NoError(t, err)
 
 	// Parse TLS cert.
 	tlsCert, err := tlsca.ParseCertificatePEM(certs.TLS)
@@ -1365,14 +1368,11 @@ func checkCerts(t *testing.T,
 	require.NoError(t, err)
 
 	// Make sure both certs have the expected roles.
-	rawSSHCertRoles := sshCert.Permissions.Extensions[teleport.CertExtensionTeleportRoles]
-	sshCertRoles, err := services.UnmarshalCertRoles(rawSSHCertRoles)
-	require.NoError(t, err)
-	assert.ElementsMatch(t, roles, sshCertRoles)
+	assert.ElementsMatch(t, roles, sshIdentity.Roles)
 	assert.ElementsMatch(t, roles, tlsIdentity.Groups)
 
 	// Make sure both certs have the expected logins/principals.
-	for _, certLogins := range [][]string{sshCert.ValidPrincipals, tlsIdentity.Principals} {
+	for _, certLogins := range [][]string{sshIdentity.Principals, tlsIdentity.Principals} {
 		// filter out invalid logins placed in the cert
 		validCertLogins := []string{}
 		for _, certLogin := range certLogins {
@@ -1384,12 +1384,7 @@ func checkCerts(t *testing.T,
 	}
 
 	// Make sure both certs have the expected access requests, if any.
-	rawSSHCertAccessRequests := sshCert.Permissions.Extensions[teleport.CertExtensionTeleportActiveRequests]
-	sshCertAccessRequests := services.RequestIDs{}
-	if len(rawSSHCertAccessRequests) > 0 {
-		require.NoError(t, sshCertAccessRequests.Unmarshal([]byte(rawSSHCertAccessRequests)))
-	}
-	assert.ElementsMatch(t, accessRequests, sshCertAccessRequests.AccessRequests)
+	assert.ElementsMatch(t, accessRequests, sshIdentity.ActiveRequests)
 	assert.ElementsMatch(t, accessRequests, tlsIdentity.ActiveRequests)
 
 	// Make sure both certs have the expected allowed resources, if any.

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2614,7 +2614,7 @@ func (a *Server) AugmentWebSessionCertificates(ctx context.Context, opts *Augmen
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	accessInfo, err := services.AccessInfoFromLocalIdentity(*x509Identity, a)
+	accessInfo, err := services.AccessInfoFromLocalTLSIdentity(*x509Identity, a)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -4156,7 +4156,7 @@ func (a *Server) ExtendWebSession(ctx context.Context, req authclient.WebSession
 		return nil, trace.NotFound("web session has expired")
 	}
 
-	accessInfo, err := services.AccessInfoFromLocalIdentity(identity, a)
+	accessInfo, err := services.AccessInfoFromLocalTLSIdentity(identity, a)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -80,6 +80,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/services/suite"
+	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -2747,9 +2748,10 @@ func TestGenerateUserCertWithUserLoginState(t *testing.T) {
 	sshCert, err := sshutils.ParseCertificate(resp.SSH)
 	require.NoError(t, err)
 
-	roles, err := services.UnmarshalCertRoles(sshCert.Extensions[teleport.CertExtensionTeleportRoles])
+	sshIdent, err := sshca.DecodeIdentity(sshCert)
 	require.NoError(t, err)
-	require.Equal(t, []string{role.GetName()}, roles)
+
+	require.Equal(t, []string{role.GetName()}, sshIdent.Roles)
 
 	traits := wrappers.Traits{}
 	err = wrappers.UnmarshalTraits([]byte(sshCert.Extensions[teleport.CertExtensionTeleportTraits]), &traits)
@@ -2805,9 +2807,9 @@ func TestGenerateUserCertWithUserLoginState(t *testing.T) {
 	sshCert, err = sshutils.ParseCertificate(resp.SSH)
 	require.NoError(t, err)
 
-	roles, err = services.UnmarshalCertRoles(sshCert.Extensions[teleport.CertExtensionTeleportRoles])
+	sshIdent, err = sshca.DecodeIdentity(sshCert)
 	require.NoError(t, err)
-	require.Equal(t, []string{role.GetName(), "uls-role1", "uls-role2"}, roles)
+	require.Equal(t, []string{role.GetName(), "uls-role1", "uls-role2"}, sshIdent.Roles)
 
 	traits = wrappers.Traits{}
 	err = wrappers.UnmarshalTraits([]byte(sshCert.Extensions[teleport.CertExtensionTeleportTraits]), &traits)

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2970,7 +2970,7 @@ func (a *ServerWithRoles) desiredAccessInfoForUser(ctx context.Context, req *pro
 	// considering new or dropped access requests. This will include roles from
 	// currently assumed role access requests, and allowed resources from
 	// currently assumed resource access requests.
-	accessInfo, err := services.AccessInfoFromLocalIdentity(currentIdentity, a.authServer)
+	accessInfo, err := services.AccessInfoFromLocalTLSIdentity(currentIdentity, a.authServer)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -69,6 +69,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
+	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/tlsca"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
@@ -1151,33 +1152,28 @@ func TestGenerateUserCertsWithRoleRequest(t *testing.T) {
 			userCert, err := sshutils.ParseCertificate(certs.SSH)
 			require.NoError(t, err)
 
-			roles, ok := userCert.Extensions[teleport.CertExtensionTeleportRoles]
-			require.True(t, ok)
-
-			parsedRoles, err := services.UnmarshalCertRoles(roles)
+			userIdent, err := sshca.DecodeIdentity(userCert)
 			require.NoError(t, err)
 
 			if len(tt.expectPrincipals) > 0 {
 				expectPrincipals := append(tt.expectPrincipals, teleport.SSHSessionJoinPrincipal)
-				require.ElementsMatch(t, expectPrincipals, userCert.ValidPrincipals, "principals must match")
+				require.ElementsMatch(t, expectPrincipals, userIdent.Principals, "principals must match")
 			}
 
 			if tt.expectRoles != nil {
-				require.ElementsMatch(t, tt.expectRoles, parsedRoles, "granted roles must match expected values")
+				require.ElementsMatch(t, tt.expectRoles, userIdent.Roles, "granted roles must match expected values")
 			} else {
-				require.ElementsMatch(t, tt.roleRequests, parsedRoles, "granted roles must match requests")
+				require.ElementsMatch(t, tt.roleRequests, userIdent.Roles, "granted roles must match requests")
 			}
 
-			_, disallowReissue := userCert.Extensions[teleport.CertExtensionDisallowReissue]
 			if len(tt.roleRequests) > 0 {
-				impersonator, ok := userCert.Extensions[teleport.CertExtensionImpersonator]
-				require.True(t, ok, "impersonator must be set if any role requests exist")
-				require.Equal(t, tt.username, impersonator, "certificate must show self-impersonation")
+				require.NotEmpty(t, userIdent.Impersonator, "impersonator must be set if any role requests exist")
+				require.Equal(t, tt.username, userIdent.Impersonator, "certificate must show self-impersonation")
 
-				require.True(t, disallowReissue)
+				require.True(t, userIdent.DisallowReissue)
 				require.True(t, impersonatedIdent.DisallowReissue)
 			} else {
-				require.False(t, disallowReissue)
+				require.False(t, userIdent.DisallowReissue)
 				require.False(t, impersonatedIdent.DisallowReissue)
 			}
 		})

--- a/lib/auth/test/suite.go
+++ b/lib/auth/test/suite.go
@@ -35,7 +35,6 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/sshutils"
-	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/sshca"
 )
 
@@ -180,12 +179,12 @@ func (s *AuthSuite) GenerateUserCert(t *testing.T) {
 	require.NoError(t, err)
 	parsedCert, err := sshutils.ParseCertificate(cert)
 	require.NoError(t, err)
-	outRoles, err := services.UnmarshalCertRoles(parsedCert.Extensions[teleport.CertExtensionTeleportRoles])
-	require.NoError(t, err)
-	require.Empty(t, cmp.Diff(outRoles, inRoles))
 
-	outImpersonator := parsedCert.Extensions[teleport.CertExtensionImpersonator]
-	require.Empty(t, cmp.Diff(outImpersonator, impersonator))
+	parsedIdent, err := sshca.DecodeIdentity(parsedCert)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(parsedIdent.Roles, inRoles))
+
+	require.Empty(t, cmp.Diff(parsedIdent.Impersonator, impersonator))
 
 	// Check that MFAVerified and PreviousIdentityExpires are encoded into ssh cert
 	clock := clockwork.NewFakeClock()

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -70,6 +70,7 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/suite"
+	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -1823,14 +1824,12 @@ func TestWebSessionMultiAccessRequests(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, baseWebClient.Close()) })
 
 	expectRolesAndResources := func(t *testing.T, sess types.WebSession, expectRoles []string, expectResources []types.ResourceID) {
-		sshCert, err := sshutils.ParseCertificate(sess.GetPub())
+		sshcert, err := sshutils.ParseCertificate(sess.GetPub())
 		require.NoError(t, err)
-		gotRoles, err := services.ExtractRolesFromCert(sshCert)
+		ident, err := sshca.DecodeIdentity(sshcert)
 		require.NoError(t, err)
-		gotResources, err := services.ExtractAllowedResourcesFromCert(sshCert)
-		require.NoError(t, err)
-		assert.ElementsMatch(t, expectRoles, gotRoles)
-		assert.ElementsMatch(t, expectResources, gotResources)
+		assert.ElementsMatch(t, expectRoles, ident.Roles)
+		assert.ElementsMatch(t, expectResources, ident.AllowedResourceIDs)
 	}
 
 	type extendSessionFunc func(*testing.T, *authclient.Client, types.WebSession) (*authclient.Client, types.WebSession)
@@ -2015,13 +2014,13 @@ func TestWebSessionWithApprovedAccessRequestAndSwitchback(t *testing.T) {
 	require.NoError(t, err)
 
 	// Roles extracted from cert should contain the initial role and the role assigned with access request.
-	roles, err := services.ExtractRolesFromCert(sshcert)
+	ident, err := sshca.DecodeIdentity(sshcert)
 	require.NoError(t, err)
-	require.Len(t, roles, 2)
+	require.Len(t, ident.Roles, 2)
 
 	mappedRole := map[string]string{
-		roles[0]: "",
-		roles[1]: "",
+		ident.Roles[0]: "",
+		ident.Roles[1]: "",
 	}
 
 	_, hasRole := mappedRole[initialRole]
@@ -2056,9 +2055,9 @@ func TestWebSessionWithApprovedAccessRequestAndSwitchback(t *testing.T) {
 	sshcert, err = sshutils.ParseCertificate(sess2.GetPub())
 	require.NoError(t, err)
 
-	roles, err = services.ExtractRolesFromCert(sshcert)
+	ident, err = sshca.DecodeIdentity(sshcert)
 	require.NoError(t, err)
-	require.Empty(t, cmp.Diff(roles, []string{initialRole}))
+	require.Empty(t, cmp.Diff(ident.Roles, []string{initialRole}))
 
 	require.Empty(t, certRequests(sess2.GetTLSCert()))
 }
@@ -2121,13 +2120,12 @@ func TestExtendWebSessionWithReloadUser(t *testing.T) {
 	// Check traits has been updated to latest.
 	sshcert, err := sshutils.ParseCertificate(sess1.GetPub())
 	require.NoError(t, err)
-	traits, err := services.ExtractTraitsFromCert(sshcert)
+
+	ident, err := sshca.DecodeIdentity(sshcert)
 	require.NoError(t, err)
-	roles, err := services.ExtractRolesFromCert(sshcert)
-	require.NoError(t, err)
-	require.Equal(t, []string{"apple", "banana"}, traits[constants.TraitLogins])
-	require.Equal(t, []string{"llama", "alpaca"}, traits[constants.TraitDBUsers])
-	require.Contains(t, roles, newRoleName)
+	require.Equal(t, []string{"apple", "banana"}, ident.Traits[constants.TraitLogins])
+	require.Equal(t, []string{"llama", "alpaca"}, ident.Traits[constants.TraitDBUsers])
+	require.Contains(t, ident.Roles, newRoleName)
 }
 
 func TestExtendWebSessionWithMaxDuration(t *testing.T) {

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -694,7 +694,7 @@ func (a *authorizer) authorizeRemoteUser(ctx context.Context, u RemoteUser) (*Co
 		return nil, trace.Wrap(err)
 	}
 
-	accessInfo, err := services.AccessInfoFromRemoteIdentity(u.Identity, ca.CombinedMapping())
+	accessInfo, err := services.AccessInfoFromRemoteTLSIdentity(u.Identity, ca.CombinedMapping())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1331,7 +1331,7 @@ func ContextForLocalUser(ctx context.Context, u LocalUser, accessPoint Authorize
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	accessInfo, err := services.AccessInfoFromLocalIdentity(u.Identity, accessPoint)
+	accessInfo, err := services.AccessInfoFromLocalTLSIdentity(u.Identity, accessPoint)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/benchmark/db/db.go
+++ b/lib/benchmark/db/db.go
@@ -48,7 +48,7 @@ func retrieveDatabaseCertificates(ctx context.Context, tc *client.TeleportClient
 			Username:    dbUser,
 			Database:    dbName,
 		},
-		AccessRequests: profile.ActiveRequests.AccessRequests,
+		AccessRequests: profile.ActiveRequests,
 	})
 	if err != nil {
 		return tls.Certificate{}, trace.Wrap(err)

--- a/lib/client/cluster_client.go
+++ b/lib/client/cluster_client.go
@@ -340,7 +340,7 @@ func (c *ClusterClient) prepareUserCertsRequest(params ReissueParams, key *Key) 
 		if err != nil && !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)
 		}
-		params.AccessRequests = activeRequests.AccessRequests
+		params.AccessRequests = activeRequests
 	}
 
 	expires := tlsCert.NotAfter

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -34,14 +34,13 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/native"
-	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -321,17 +320,13 @@ func (k *Key) CertRoles() ([]string, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	// Extract roles from certificate. Note, if the certificate is in old format,
-	// this will be empty.
-	var roles []string
-	rawRoles, ok := cert.Extensions[teleport.CertExtensionTeleportRoles]
-	if ok {
-		roles, err = services.UnmarshalCertRoles(rawRoles)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
+
+	ident, err := sshca.DecodeIdentity(cert)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
-	return roles, nil
+
+	return ident.Roles, nil
 }
 
 const (
@@ -531,19 +526,18 @@ func (k *Key) SSHCert() (*ssh.Certificate, error) {
 }
 
 // ActiveRequests gets the active requests associated with this key.
-func (k *Key) ActiveRequests() (services.RequestIDs, error) {
-	var activeRequests services.RequestIDs
+func (k *Key) ActiveRequests() ([]string, error) {
 	sshCert, err := k.SSHCert()
 	if err != nil {
-		return activeRequests, trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-	rawRequests, ok := sshCert.Extensions[teleport.CertExtensionTeleportActiveRequests]
-	if ok {
-		if err := activeRequests.Unmarshal([]byte(rawRequests)); err != nil {
-			return activeRequests, trace.Wrap(err)
-		}
+
+	ident, err := sshca.DecodeIdentity(sshCert)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
-	return activeRequests, nil
+
+	return ident.ActiveRequests, nil
 }
 
 // CheckCert makes sure the key's SSH certificate is valid.

--- a/lib/client/local_proxy_middleware.go
+++ b/lib/client/local_proxy_middleware.go
@@ -214,7 +214,7 @@ func (c *DBCertIssuer) IssueCert(ctx context.Context) (tls.Certificate, error) {
 	if profile, err := c.Client.ProfileStatus(); err != nil {
 		log.WithError(err).Warn("unable to load profile, requesting database certs without access requests")
 	} else {
-		accessRequests = profile.ActiveRequests.AccessRequests
+		accessRequests = profile.ActiveRequests
 	}
 
 	var key *Key
@@ -286,7 +286,7 @@ func (c *AppCertIssuer) IssueCert(ctx context.Context) (tls.Certificate, error) 
 	if profile, err := c.Client.ProfileStatus(); err != nil {
 		log.WithError(err).Warn("unable to load profile, requesting app certs without access requests")
 	} else {
-		accessRequests = profile.ActiveRequests.AccessRequests
+		accessRequests = profile.ActiveRequests
 	}
 
 	var key *Key

--- a/lib/devicetrust/authz/authz.go
+++ b/lib/devicetrust/authz/authz.go
@@ -21,12 +21,12 @@ package authz
 import (
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	dtconfig "github.com/gravitational/teleport/lib/devicetrust/config"
+	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
@@ -51,12 +51,12 @@ func VerifyTLSUser(dt *types.DeviceTrust, identity tlsca.Identity) error {
 
 // IsSSHDeviceVerified returns true if cert contains all required device
 // extensions.
-func IsSSHDeviceVerified(cert *ssh.Certificate) bool {
+func IsSSHDeviceVerified(ident *sshca.Identity) bool {
 	// Expect all device extensions to be present.
-	return cert != nil &&
-		cert.Extensions[teleport.CertExtensionDeviceID] != "" &&
-		cert.Extensions[teleport.CertExtensionDeviceAssetTag] != "" &&
-		cert.Extensions[teleport.CertExtensionDeviceCredentialID] != ""
+	return ident != nil &&
+		ident.DeviceID != "" &&
+		ident.DeviceAssetTag != "" &&
+		ident.DeviceCredentialID != ""
 }
 
 // HasDeviceTrustExtensions returns true if the certificate's extension names
@@ -83,13 +83,12 @@ func HasDeviceTrustExtensions(extensions []string) bool {
 
 // VerifySSHUser verifies if the SSH certificate has the required extensions to
 // fulfill the device trust configuration.
-func VerifySSHUser(dt *types.DeviceTrust, cert *ssh.Certificate) error {
-	if cert == nil {
-		return trace.BadParameter("cert required")
+func VerifySSHUser(dt *types.DeviceTrust, ident *sshca.Identity) error {
+	if ident == nil {
+		return trace.BadParameter("ssh identity required")
 	}
 
-	username := cert.KeyId
-	return verifyDeviceExtensions(dt, username, IsSSHDeviceVerified(cert))
+	return verifyDeviceExtensions(dt, ident.Username, IsSSHDeviceVerified(ident))
 }
 
 func verifyDeviceExtensions(dt *types.DeviceTrust, username string, verified bool) error {

--- a/lib/devicetrust/authz/authz_test.go
+++ b/lib/devicetrust/authz/authz_test.go
@@ -23,13 +23,13 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/devicetrust/authz"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
@@ -39,19 +39,15 @@ func TestIsTLSDeviceVerified(t *testing.T) {
 
 func TestIsSSHDeviceVerified(t *testing.T) {
 	testIsDeviceVerified(t, "IsSSHDeviceVerified", func(ext *tlsca.DeviceExtensions) bool {
-		var cert *ssh.Certificate
+		var ident *sshca.Identity
 		if ext != nil {
-			cert = &ssh.Certificate{
-				Permissions: ssh.Permissions{
-					Extensions: map[string]string{
-						teleport.CertExtensionDeviceID:           ext.DeviceID,
-						teleport.CertExtensionDeviceAssetTag:     ext.AssetTag,
-						teleport.CertExtensionDeviceCredentialID: ext.CredentialID,
-					},
-				},
+			ident = &sshca.Identity{
+				DeviceID:           ext.DeviceID,
+				DeviceAssetTag:     ext.AssetTag,
+				DeviceCredentialID: ext.CredentialID,
 			}
 		}
-		return authz.IsSSHDeviceVerified(cert)
+		return authz.IsSSHDeviceVerified(ident)
 	})
 }
 
@@ -140,15 +136,10 @@ func TestVerifyTLSUser(t *testing.T) {
 
 func TestVerifySSHUser(t *testing.T) {
 	runVerifyUserTest(t, "VerifySSHUser", func(dt *types.DeviceTrust, ext *tlsca.DeviceExtensions) error {
-		return authz.VerifySSHUser(dt, &ssh.Certificate{
-			KeyId: "llama",
-			Permissions: ssh.Permissions{
-				Extensions: map[string]string{
-					teleport.CertExtensionDeviceID:           ext.DeviceID,
-					teleport.CertExtensionDeviceAssetTag:     ext.AssetTag,
-					teleport.CertExtensionDeviceCredentialID: ext.CredentialID,
-				},
-			},
+		return authz.VerifySSHUser(dt, &sshca.Identity{
+			DeviceID:           ext.DeviceID,
+			DeviceAssetTag:     ext.AssetTag,
+			DeviceCredentialID: ext.CredentialID,
 		})
 	})
 }

--- a/lib/reversetunnel/srv_test.go
+++ b/lib/reversetunnel/srv_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -43,16 +44,16 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-func TestServerKeyAuth(t *testing.T) {
+func newCAAndSigner(t *testing.T, caType types.CertAuthType, name string) (types.CertAuthority, ssh.Signer) {
 	ta := testauthority.New()
 	priv, pub, err := ta.GenerateKeyPair()
 	require.NoError(t, err)
-	caSigner, err := ssh.ParsePrivateKey(priv)
+	signer, err := ssh.ParsePrivateKey(priv)
 	require.NoError(t, err)
 
 	ca, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
-		Type:        types.HostCA,
-		ClusterName: "cluster-name",
+		Type:        caType,
+		ClusterName: name,
 		ActiveKeys: types.CAKeySet{
 			SSH: []*types.SSHKeyPair{{
 				PrivateKey:     priv,
@@ -63,13 +64,32 @@ func TestServerKeyAuth(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	return ca, signer
+}
+
+// newPubKey generates a new public key for testing.
+func newPubKey(t *testing.T) []byte {
+	_, pub, err := testauthority.New().GenerateKeyPair()
+	require.NoError(t, err)
+	return pub
+}
+
+func TestServerKeyAuth(t *testing.T) {
+	hostCA, hostCASigner := newCAAndSigner(t, types.HostCA, "root")
+	userCA, userCASigner := newCAAndSigner(t, types.UserCA, "root")
+	leafHostCA, leafHostCASigner := newCAAndSigner(t, types.HostCA, "leaf")
+	leafUserCA, leafUserCASigner := newCAAndSigner(t, types.UserCA, "leaf")
+
 	s := &server{
 		log:    utils.NewLoggerForTests(),
-		Config: Config{Clock: clockwork.NewRealClock()},
+		Config: Config{Clock: clockwork.NewRealClock(), ClusterName: "root"},
 		localAccessPoint: mockAccessPoint{
-			ca: ca,
+			cas: []types.CertAuthority{hostCA, userCA, leafHostCA, leafUserCA},
 		},
 	}
+
+	ta := testauthority.New()
+
 	con := mockSSHConnMetadata{}
 	tests := []struct {
 		desc           string
@@ -78,15 +98,15 @@ func TestServerKeyAuth(t *testing.T) {
 		wantErr        require.ErrorAssertionFunc
 	}{
 		{
-			desc: "host cert",
+			desc: "root host cert",
 			key: func() ssh.PublicKey {
 				rawCert, err := ta.GenerateHostCert(sshca.HostCertificateRequest{
-					CASigner:      caSigner,
-					PublicHostKey: pub,
-					HostID:        "host-id",
+					CASigner:      hostCASigner,
+					PublicHostKey: newPubKey(t),
+					HostID:        "root-host-id",
 					NodeName:      con.User(),
 					Identity: sshca.Identity{
-						ClusterName: "host-cluster-name",
+						ClusterName: "root",
 						SystemRole:  types.RoleNode,
 					},
 				})
@@ -99,23 +119,22 @@ func TestServerKeyAuth(t *testing.T) {
 				extHost:              con.User(),
 				utils.ExtIntCertType: utils.ExtIntCertTypeHost,
 				extCertRole:          string(types.RoleNode),
-				extAuthority:         "host-cluster-name",
+				extAuthority:         "root",
 			},
 			wantErr: require.NoError,
 		},
 		{
-			desc: "user cert",
+			desc: "root user cert",
 			key: func() ssh.PublicKey {
 				rawCert, err := ta.GenerateUserCert(sshca.UserCertificateRequest{
-					CASigner:          caSigner,
-					PublicUserKey:     pub,
+					CASigner:          userCASigner,
+					PublicUserKey:     newPubKey(t),
 					CertificateFormat: constants.CertificateFormatStandard,
 					TTL:               time.Minute,
 					Identity: sshca.Identity{
-						Username:       con.User(),
-						Principals:     []string{con.User()},
-						Roles:          []string{"dev", "admin"},
-						RouteToCluster: "user-cluster-name",
+						Username:   con.User(),
+						Principals: []string{con.User()},
+						Roles:      []string{"dev", "admin"},
 					},
 				})
 				require.NoError(t, err)
@@ -127,14 +146,129 @@ func TestServerKeyAuth(t *testing.T) {
 				extHost:              con.User(),
 				utils.ExtIntCertType: utils.ExtIntCertTypeUser,
 				extCertRole:          "dev",
-				extAuthority:         "user-cluster-name",
+				extAuthority:         "root",
 			},
 			wantErr: require.NoError,
 		},
 		{
+			desc: "leaf host cert",
+			key: func() ssh.PublicKey {
+				rawCert, err := ta.GenerateHostCert(sshca.HostCertificateRequest{
+					CASigner:      leafHostCASigner,
+					PublicHostKey: newPubKey(t),
+					HostID:        "leaf-host-id",
+					NodeName:      con.User(),
+					Identity: sshca.Identity{
+						ClusterName: "leaf",
+						SystemRole:  types.RoleNode,
+					},
+				})
+				require.NoError(t, err)
+				key, _, _, _, err := ssh.ParseAuthorizedKey(rawCert)
+				require.NoError(t, err)
+				return key
+			}(),
+			wantExtensions: map[string]string{
+				extHost:              con.User(),
+				utils.ExtIntCertType: utils.ExtIntCertTypeHost,
+				extCertRole:          string(types.RoleNode),
+				extAuthority:         "leaf",
+			},
+			wantErr: require.NoError,
+		},
+		{
+			desc: "leaf user cert",
+			key: func() ssh.PublicKey {
+				rawCert, err := ta.GenerateUserCert(sshca.UserCertificateRequest{
+					CASigner:          leafUserCASigner,
+					PublicUserKey:     newPubKey(t),
+					CertificateFormat: constants.CertificateFormatStandard,
+					TTL:               time.Minute,
+					Identity: sshca.Identity{
+						Username:   con.User(),
+						Principals: []string{con.User()},
+						Roles:      []string{"dev", "admin"},
+					},
+				})
+				require.NoError(t, err)
+				key, _, _, _, err := ssh.ParseAuthorizedKey(rawCert)
+				require.NoError(t, err)
+				return key
+			}(),
+			// leaf user certs are not supported by this endpoint
+			wantErr: require.Error,
+		},
+		{
+			desc: "root user cert with cluster routing directive",
+			key: func() ssh.PublicKey {
+				rawCert, err := ta.GenerateUserCert(sshca.UserCertificateRequest{
+					CASigner:          userCASigner,
+					PublicUserKey:     newPubKey(t),
+					CertificateFormat: constants.CertificateFormatStandard,
+					TTL:               time.Minute,
+					Identity: sshca.Identity{
+						Username:       con.User(),
+						Principals:     []string{con.User()},
+						Roles:          []string{"dev", "admin"},
+						RouteToCluster: "leaf",
+					},
+				})
+				require.NoError(t, err)
+				key, _, _, _, err := ssh.ParseAuthorizedKey(rawCert)
+				require.NoError(t, err)
+				return key
+			}(),
+			// this endpoint does not support cross-cluster routing
+			wantErr: require.Error,
+		},
+		{
+			desc: "host cert with incorrect cluster name",
+			key: func() ssh.PublicKey {
+				rawCert, err := ta.GenerateHostCert(sshca.HostCertificateRequest{
+					CASigner:      hostCASigner, // signer of root
+					PublicHostKey: newPubKey(t),
+					HostID:        "root-host-id",
+					NodeName:      con.User(),
+					Identity: sshca.Identity{
+						ClusterName: "leaf", // cluster name of leaf
+						SystemRole:  types.RoleNode,
+					},
+				})
+				require.NoError(t, err)
+				key, _, _, _, err := ssh.ParseAuthorizedKey(rawCert)
+				require.NoError(t, err)
+				return key
+			}(),
+			// cluster name mismatch should result in cert validation failure
+			wantErr: require.Error,
+		},
+		{
+
+			desc: "user cert with incorrect principals",
+			key: func() ssh.PublicKey {
+				rawCert, err := ta.GenerateUserCert(sshca.UserCertificateRequest{
+					CASigner:          userCASigner,
+					PublicUserKey:     newPubKey(t),
+					CertificateFormat: constants.CertificateFormatStandard,
+					TTL:               time.Minute,
+					Identity: sshca.Identity{
+						Username:   con.User(),
+						Principals: []string{"not-the-user"},
+						Roles:      []string{"dev", "admin"},
+					},
+				})
+				require.NoError(t, err)
+				key, _, _, _, err := ssh.ParseAuthorizedKey(rawCert)
+				require.NoError(t, err)
+				return key
+			}(),
+			// principal mismatch should result in cert validation failure
+			wantErr: require.Error,
+		},
+		{
 			desc: "not a cert",
 			key: func() ssh.PublicKey {
-				key, _, _, _, err := ssh.ParseAuthorizedKey(pub)
+				key, _, _, _, err := ssh.ParseAuthorizedKey(newPubKey(t))
 				require.NoError(t, err)
 				return key
 			}(),
@@ -162,11 +296,16 @@ func (mockSSHConnMetadata) RemoteAddr() net.Addr { return &net.TCPAddr{} }
 
 type mockAccessPoint struct {
 	authclient.ProxyAccessPoint
-	ca types.CertAuthority
+	cas []types.CertAuthority
 }
 
 func (ap mockAccessPoint) GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error) {
-	return ap.ca, nil
+	for _, ca := range ap.cas {
+		if id == ca.GetID() {
+			return ca, nil
+		}
+	}
+	return nil, trace.NotFound("no cert authority matching %+v", id)
 }
 
 func Test_ParseDialReq(t *testing.T) {

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
@@ -37,6 +36,7 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/services/readonly"
+	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -1175,87 +1175,59 @@ func (a *accessChecker) HostSudoers(s types.Server) ([]string, error) {
 	return sudoers, nil
 }
 
-// AccessInfoFromLocalCertificate returns a new AccessInfo populated from the
-// given ssh certificate. Should only be used for cluster local users as roles
+// AccessInfoFromLocalSSHIdentity returns a new AccessInfo populated from the
+// given sshca.Identity. Should only be used for cluster local users as roles
 // will not be mapped.
-func AccessInfoFromLocalCertificate(cert *ssh.Certificate) (*AccessInfo, error) {
-	traits, err := ExtractTraitsFromCert(cert)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	roles, err := ExtractRolesFromCert(cert)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	allowedResourceIDs, err := ExtractAllowedResourcesFromCert(cert)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
+func AccessInfoFromLocalSSHIdentity(ident *sshca.Identity) *AccessInfo {
 	return &AccessInfo{
-		Username:           cert.KeyId,
-		Roles:              roles,
-		Traits:             traits,
-		AllowedResourceIDs: allowedResourceIDs,
-	}, nil
+		Username:           ident.Username,
+		Roles:              ident.Roles,
+		Traits:             ident.Traits,
+		AllowedResourceIDs: ident.AllowedResourceIDs,
+	}
 }
 
-// AccessInfoFromRemoteCertificate returns a new AccessInfo populated from the
-// given remote cluster user's ssh certificate. Remote roles will be mapped to
+// AccessInfoFromRemoteSSHIdentity returns a new AccessInfo populated from the
+// given remote cluster user's ssh identity. Remote roles will be mapped to
 // local roles based on the given roleMap.
-func AccessInfoFromRemoteCertificate(cert *ssh.Certificate, roleMap types.RoleMap) (*AccessInfo, error) {
-	// Old-style SSH certificates don't have traits in metadata.
-	traits, err := ExtractTraitsFromCert(cert)
-	if err != nil && !trace.IsNotFound(err) {
-		return nil, trace.AccessDenied("failed to parse certificate traits: %v", err)
+func AccessInfoFromRemoteSSHIdentity(unmappedIdentity *sshca.Identity, roleMap types.RoleMap) (*AccessInfo, error) {
+	// make a shallow copy of traits to avoid modifying the original
+	traits := make(map[string][]string, len(unmappedIdentity.Traits)+1)
+	for k, v := range unmappedIdentity.Traits {
+		traits[k] = v
 	}
-	if traits == nil {
-		traits = make(map[string][]string)
-	}
+
 	// Prior to Teleport 6.2 the only trait passed to the remote cluster
 	// was the "logins" trait set to the SSH certificate principals.
 	//
 	// Keep backwards-compatible behavior and set it in addition to the
 	// traits extracted from the certificate.
-	traits[constants.TraitLogins] = cert.ValidPrincipals
+	traits[constants.TraitLogins] = unmappedIdentity.Principals
 
-	unmappedRoles, err := ExtractRolesFromCert(cert)
+	roles, err := MapRoles(roleMap, unmappedIdentity.Roles)
 	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	roles, err := MapRoles(roleMap, unmappedRoles)
-	if err != nil {
-		return nil, trace.AccessDenied("failed to map roles for user with remote roles %v: %v", unmappedRoles, err)
+		return nil, trace.AccessDenied("failed to map roles for user with remote roles %v: %v", unmappedIdentity.Roles, err)
 	}
 	if len(roles) == 0 {
-		return nil, trace.AccessDenied("no roles mapped for user with remote roles %v", unmappedRoles)
+		return nil, trace.AccessDenied("no roles mapped for user with remote roles %v", unmappedIdentity.Roles)
 	}
 	log.Debugf("Mapped remote roles %v to local roles %v and traits %v.",
-		unmappedRoles, roles, traits)
-
-	allowedResourceIDs, err := ExtractAllowedResourcesFromCert(cert)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+		unmappedIdentity.Roles, roles, traits)
 
 	return &AccessInfo{
-		Username:           cert.KeyId,
+		Username:           unmappedIdentity.Username,
 		Roles:              roles,
 		Traits:             traits,
-		AllowedResourceIDs: allowedResourceIDs,
+		AllowedResourceIDs: unmappedIdentity.AllowedResourceIDs,
 	}, nil
 }
 
-// AccessInfoFromLocalIdentity returns a new AccessInfo populated from the given
+// AccessInfoFromLocalTLSIdentity returns a new AccessInfo populated from the given
 // tlsca.Identity. Should only be used for cluster local users as roles will not
 // be mapped.
-func AccessInfoFromLocalIdentity(identity tlsca.Identity, access UserGetter) (*AccessInfo, error) {
+func AccessInfoFromLocalTLSIdentity(identity tlsca.Identity, access UserGetter) (*AccessInfo, error) {
 	roles := identity.Groups
 	traits := identity.Traits
-	allowedResourceIDs := identity.AllowedResourceIDs
 
 	// Legacy certs are not encoded with roles or traits,
 	// so we fallback to the traits and roles in the backend.
@@ -1279,14 +1251,14 @@ func AccessInfoFromLocalIdentity(identity tlsca.Identity, access UserGetter) (*A
 		Username:           identity.Username,
 		Roles:              roles,
 		Traits:             traits,
-		AllowedResourceIDs: allowedResourceIDs,
+		AllowedResourceIDs: identity.AllowedResourceIDs,
 	}, nil
 }
 
-// AccessInfoFromRemoteIdentity returns a new AccessInfo populated from the
+// AccessInfoFromRemoteTLSIdentity returns a new AccessInfo populated from the
 // given remote cluster user's tlsca.Identity. Remote roles will be mapped to
 // local roles based on the given roleMap.
-func AccessInfoFromRemoteIdentity(identity tlsca.Identity, roleMap types.RoleMap) (*AccessInfo, error) {
+func AccessInfoFromRemoteTLSIdentity(identity tlsca.Identity, roleMap types.RoleMap) (*AccessInfo, error) {
 	// Set internal traits for the remote user. This allows Teleport to work by
 	// passing exact logins, Kubernetes users/groups and database users/names
 	// to the remote cluster.
@@ -1323,13 +1295,11 @@ func AccessInfoFromRemoteIdentity(identity tlsca.Identity, roleMap types.RoleMap
 	log.Debugf("Mapped roles %v of remote user %q to local roles %v and traits %v.",
 		unmappedRoles, identity.Username, roles, traits)
 
-	allowedResourceIDs := identity.AllowedResourceIDs
-
 	return &AccessInfo{
 		Username:           identity.Username,
 		Roles:              roles,
 		Traits:             traits,
-		AllowedResourceIDs: allowedResourceIDs,
+		AllowedResourceIDs: identity.AllowedResourceIDs,
 	}, nil
 }
 

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -143,40 +143,6 @@ func NewAccessRequestWithResources(user string, roles []string, resourceIDs []ty
 	return req, nil
 }
 
-// RequestIDs is a collection of IDs for privilege escalation requests.
-type RequestIDs struct {
-	AccessRequests []string `json:"access_requests,omitempty"`
-}
-
-func (r *RequestIDs) Marshal() ([]byte, error) {
-	data, err := utils.FastMarshal(r)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return data, nil
-}
-
-func (r *RequestIDs) Unmarshal(data []byte) error {
-	if err := utils.FastUnmarshal(data, r); err != nil {
-		return trace.Wrap(err)
-	}
-	return trace.Wrap(r.Check())
-}
-
-func (r *RequestIDs) Check() error {
-	for _, id := range r.AccessRequests {
-		_, err := uuid.Parse(id)
-		if err != nil {
-			return trace.BadParameter("invalid request id %q", id)
-		}
-	}
-	return nil
-}
-
-func (r *RequestIDs) IsEmpty() bool {
-	return len(r.AccessRequests) < 1
-}
-
 // AccessRequestGetter defines the interface for fetching access request resources.
 type AccessRequestGetter interface {
 	// GetAccessRequests gets all currently active access requests.

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -22,7 +22,6 @@ import (
 	"crypto"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/json"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
@@ -319,24 +318,6 @@ func CertPool(ca types.CertAuthority) (*x509.CertPool, error) {
 		certPool.AddCert(cert)
 	}
 	return certPool, nil
-}
-
-// MarshalCertRoles marshal roles list to OpenSSH
-func MarshalCertRoles(roles []string) (string, error) {
-	out, err := json.Marshal(types.CertRoles{Version: types.V1, Roles: roles})
-	if err != nil {
-		return "", trace.Wrap(err)
-	}
-	return string(out), err
-}
-
-// UnmarshalCertRoles marshals roles list to OpenSSH format
-func UnmarshalCertRoles(data string) ([]string, error) {
-	var certRoles types.CertRoles
-	if err := utils.FastUnmarshal([]byte(data), &certRoles); err != nil {
-		return nil, trace.BadParameter(err.Error())
-	}
-	return certRoles.Roles, nil
 }
 
 // UnmarshalCertAuthority unmarshals the CertAuthority resource to JSON.

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -47,6 +47,7 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/fixtures"
+	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
@@ -3608,26 +3609,26 @@ func TestExtractFrom(t *testing.T) {
 
 	// At this point, services.User and the certificate/identity are still in
 	// sync. The roles and traits returned should be the same as the original.
-	roles, traits, err := ExtractFromCertificate(cert)
+	ident, err := sshca.DecodeIdentity(cert)
 	require.NoError(t, err)
-	require.Equal(t, roles, origRoles)
-	require.Equal(t, traits, origTraits)
+	require.Equal(t, origRoles, ident.Roles)
+	require.Equal(t, origTraits, ident.Traits)
 
-	roles, traits, err = ExtractFromIdentity(ctx, &userGetter{
+	roles, traits, err := ExtractFromIdentity(ctx, &userGetter{
 		roles:  origRoles,
 		traits: origTraits,
 	}, *identity)
 	require.NoError(t, err)
-	require.Equal(t, roles, origRoles)
-	require.Equal(t, traits, origTraits)
+	require.Equal(t, origRoles, roles)
+	require.Equal(t, origTraits, traits)
 
 	// The backend now returns new roles and traits, however because the roles
 	// and traits are extracted from the certificate/identity, the original
 	// roles and traits will be returned.
-	roles, traits, err = ExtractFromCertificate(cert)
+	ident, err = sshca.DecodeIdentity(cert)
 	require.NoError(t, err)
-	require.Equal(t, roles, origRoles)
-	require.Equal(t, traits, origTraits)
+	require.Equal(t, origRoles, ident.Roles)
+	require.Equal(t, origTraits, ident.Traits)
 
 	roles, traits, err = ExtractFromIdentity(ctx, &userGetter{
 		roles:  origRoles,

--- a/lib/srv/authhandlers_test.go
+++ b/lib/srv/authhandlers_test.go
@@ -62,7 +62,7 @@ type mockLoginChecker struct {
 	rbacChecked bool
 }
 
-func (m *mockLoginChecker) canLoginWithRBAC(_ *ssh.Certificate, _ types.CertAuthority, _ string, _ types.Server, _, _ string) error {
+func (m *mockLoginChecker) canLoginWithRBAC(_ *sshca.Identity, _ types.CertAuthority, _ string, _ types.Server, _ string) error {
 	m.rbacChecked = true
 	return nil
 }
@@ -407,7 +407,10 @@ func TestRBACJoinMFA(t *testing.T) {
 			cert, err := sshutils.ParseCertificate(c)
 			require.NoError(t, err)
 
-			err = ah.canLoginWithRBAC(cert, userCA, clusterName, node, username, teleport.SSHSessionJoinPrincipal)
+			ident, err := sshca.DecodeIdentity(cert)
+			require.NoError(t, err)
+
+			err = ah.canLoginWithRBAC(ident, userCA, clusterName, node, teleport.SSHSessionJoinPrincipal)
 			tt.testError(t, err)
 		})
 	}

--- a/lib/srv/ctx_test.go
+++ b/lib/srv/ctx_test.go
@@ -28,14 +28,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/crypto/ssh"
 	"google.golang.org/protobuf/testing/protocmp"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/services"
 	rsession "github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/sshutils"
 )
 
@@ -209,17 +208,14 @@ func TestIdentityContext_GetUserMetadata(t *testing.T) {
 		{
 			name: "device metadata",
 			idCtx: IdentityContext{
+				UnmappedIdentity: &sshca.Identity{
+					Username:           "alpaca",
+					DeviceID:           "deviceid1",
+					DeviceAssetTag:     "assettag1",
+					DeviceCredentialID: "credentialid1",
+				},
 				TeleportUser: "alpaca",
 				Login:        "alpaca1",
-				Certificate: &ssh.Certificate{
-					Permissions: ssh.Permissions{
-						Extensions: map[string]string{
-							teleport.CertExtensionDeviceID:           "deviceid1",
-							teleport.CertExtensionDeviceAssetTag:     "assettag1",
-							teleport.CertExtensionDeviceCredentialID: "credentialid1",
-						},
-					},
-				},
 			},
 			want: apievents.UserMetadata{
 				User:  "alpaca",
@@ -271,17 +267,14 @@ func TestComputeLockTargets(t *testing.T) {
 		accessRequests := []string{"access-request-1", "access-request-2"}
 
 		identityCtx := IdentityContext{
+			UnmappedIdentity: &sshca.Identity{
+				Username:    "llama",
+				MFAVerified: mfaDevice,
+				DeviceID:    trustedDevice,
+			},
 			TeleportUser: "llama",
 			Impersonator: "alpaca",
 			Login:        "camel",
-			Certificate: &ssh.Certificate{
-				Permissions: ssh.Permissions{
-					Extensions: map[string]string{
-						teleport.CertExtensionMFAVerified: mfaDevice,
-						teleport.CertExtensionDeviceID:    trustedDevice,
-					},
-				},
-			},
 			AccessChecker: &fixedRolesChecker{
 				roleNames: mappedRoles,
 			},

--- a/lib/srv/mock.go
+++ b/lib/srv/mock.go
@@ -46,6 +46,7 @@ import (
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	rsession "github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -55,6 +56,9 @@ func newTestServerContext(t *testing.T, srv Server, roleSet services.RoleSet) *S
 	require.NoError(t, err)
 
 	cert, err := apisshutils.ParseCertificate([]byte(fixtures.UserCertificateStandard))
+	require.NoError(t, err)
+
+	ident, err := sshca.DecodeIdentity(cert)
 	require.NoError(t, err)
 
 	sshConn := &mockSSHConn{}
@@ -76,9 +80,9 @@ func newTestServerContext(t *testing.T, srv Server, roleSet services.RoleSet) *S
 		srv:                    srv,
 		sessionID:              rsession.NewID(),
 		Identity: IdentityContext{
-			Login:        usr.Username,
-			TeleportUser: "teleportUser",
-			Certificate:  cert,
+			UnmappedIdentity: ident,
+			Login:            usr.Username,
+			TeleportUser:     "teleportUser",
 			// roles do not actually exist in mock backend, just need a non-nil
 			// access checker to avoid panic
 			AccessChecker: services.NewAccessCheckerWithRoleSet(

--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -254,7 +254,8 @@ func (t *proxySubsys) proxyToHost(ctx context.Context, ch ssh.Channel, clientSrc
 	}
 	identity := t.ctx.Identity
 
-	signer := agentless.SignerFromSSHCertificate(identity.Certificate, authClient, t.clusterName, identity.TeleportUser)
+	signer := agentless.SignerFromSSHIdentity(identity.UnmappedIdentity, authClient, t.clusterName, identity.TeleportUser)
+
 	aGetter := t.ctx.StartAgentChannel
 	conn, err := t.router.DialHost(ctx, clientSrcAddr, clientDstAddr, t.host, t.port, t.clusterName, t.ctx.Identity.AccessChecker, aGetter, signer)
 	if err != nil {

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -820,7 +820,7 @@ func newSession(ctx context.Context, id rsession.ID, r *SessionRegistry, scx *Se
 		serverCtx:                      scx.srv.Context(),
 		access:                         &access,
 		scx:                            scx,
-		presenceEnabled:                scx.Identity.Certificate.Extensions[teleport.CertExtensionMFAVerified] != "",
+		presenceEnabled:                scx.Identity.UnmappedIdentity.MFAVerified != "",
 		io:                             NewTermManager(),
 		doneCh:                         make(chan struct{}),
 		initiator:                      scx.Identity.TeleportUser,

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -53,49 +53,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-func TestParseAccessRequestIDs(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		input     string
-		comment   string
-		result    []string
-		assertErr require.ErrorAssertionFunc
-	}{
-		{
-			input:     `{"access_requests":["1a7483e0-575a-4bd1-9faa-022500a49325","30b344f5-d1ba-49fc-b2aa-b04234d0a4ec"]}`,
-			comment:   "complete valid input",
-			assertErr: require.NoError,
-			result:    []string{"1a7483e0-575a-4bd1-9faa-022500a49325", "30b344f5-d1ba-49fc-b2aa-b04234d0a4ec"},
-		},
-		{
-			input:     `{"access_requests":["1a7483e0-575a-4bd1-9faa-022500a49325","30b344f5-d1ba-49fc-b2aa"]}`,
-			comment:   "invalid uuid",
-			assertErr: require.Error,
-			result:    nil,
-		},
-		{
-			input:     `{"access_requests":[nil,"30b344f5-d1ba-49fc-b2aa-b04234d0a4ec"]}`,
-			comment:   "invalid value, value in slice is nil",
-			assertErr: require.Error,
-			result:    nil,
-		},
-		{
-			input:     `{"access_requests":nil}`,
-			comment:   "invalid value, whole value is nil",
-			assertErr: require.Error,
-			result:    nil,
-		},
-	}
-	for _, tt := range testCases {
-		t.Run(tt.comment, func(t *testing.T) {
-			out, err := ParseAccessRequestIDs(tt.input)
-			tt.assertErr(t, err)
-			require.Equal(t, out, tt.result)
-		})
-	}
-}
-
 func TestIsApprovedFileTransfer(t *testing.T) {
 	// set enterprise for tests
 	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})

--- a/lib/srv/session_control.go
+++ b/lib/srv/session_control.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/sshca"
 )
 
 var userSessionLimitHitCount = prometheus.NewCounter(
@@ -166,24 +167,19 @@ func WebSessionController(controller *SessionController) func(ctx context.Contex
 			return ctx, trace.Wrap(err)
 		}
 
-		unmappedRoles, err := services.ExtractRolesFromCert(sshCert)
-		if err != nil {
-			return ctx, trace.Wrap(err)
-		}
-
-		accessRequestIDs, err := ParseAccessRequestIDs(sshCert.Extensions[teleport.CertExtensionTeleportActiveRequests])
+		unmappedIdentity, err := sshca.DecodeIdentity(sshCert)
 		if err != nil {
 			return ctx, trace.Wrap(err)
 		}
 
 		identity := IdentityContext{
-			AccessChecker:  accessChecker,
-			TeleportUser:   sctx.GetUser(),
-			Login:          login,
-			Certificate:    sshCert,
-			UnmappedRoles:  unmappedRoles,
-			ActiveRequests: accessRequestIDs,
-			Impersonator:   sshCert.Extensions[teleport.CertExtensionImpersonator],
+			UnmappedIdentity: unmappedIdentity,
+			AccessChecker:    accessChecker,
+			TeleportUser:     sctx.GetUser(),
+			Login:            login,
+			UnmappedRoles:    unmappedIdentity.Roles,
+			ActiveRequests:   unmappedIdentity.ActiveRequests,
+			Impersonator:     unmappedIdentity.Impersonator,
 		}
 		ctx, err = controller.AcquireSessionContext(ctx, identity, localAddr, remoteAddr)
 		return ctx, trace.Wrap(err)
@@ -221,12 +217,11 @@ func (s *SessionController) AcquireSessionContext(ctx context.Context, identity 
 
 	// Check that the required private key policy, defined by roles and auth pref,
 	// is met by this Identity's ssh certificate.
-	identityPolicy := keys.PrivateKeyPolicy(identity.Certificate.Extensions[teleport.CertExtensionPrivateKeyPolicy])
 	requiredPolicy, err := identity.AccessChecker.PrivateKeyPolicy(authPref.GetPrivateKeyPolicy())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if !requiredPolicy.IsSatisfiedBy(identityPolicy) {
+	if !requiredPolicy.IsSatisfiedBy(identity.UnmappedIdentity.PrivateKeyPolicy) {
 		return ctx, keys.NewPrivateKeyPolicyError(requiredPolicy)
 	}
 
@@ -236,7 +231,7 @@ func (s *SessionController) AcquireSessionContext(ctx context.Context, identity 
 	}
 
 	// Device Trust: authorize device extensions.
-	if err := dtauthz.VerifySSHUser(authPref.GetDeviceTrust(), identity.Certificate); err != nil {
+	if err := dtauthz.VerifySSHUser(authPref.GetDeviceTrust(), identity.UnmappedIdentity); err != nil {
 		return ctx, trace.Wrap(err)
 	}
 

--- a/lib/srv/session_control_test.go
+++ b/lib/srv/session_control_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
@@ -38,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/sshca"
 )
 
 type mockLockEnforcer struct {
@@ -131,11 +131,11 @@ func TestSessionController_AcquireSessionContext(t *testing.T) {
 	}
 
 	minimalIdentity := IdentityContext{
+		UnmappedIdentity: &sshca.Identity{
+			Username: "alpaca",
+		},
 		TeleportUser: "alpaca",
 		Login:        "alpaca",
-		Certificate: &ssh.Certificate{
-			KeyId: "alpaca",
-		},
 		AccessChecker: &mockAccessChecker{
 			keyPolicy: keys.PrivateKeyPolicyNone,
 		},
@@ -150,17 +150,12 @@ func TestSessionController_AcquireSessionContext(t *testing.T) {
 		return cfg
 	}
 	identityWithDeviceExtensions := func() IdentityContext {
+		ident := *minimalIdentity.UnmappedIdentity
 		idCtx := minimalIdentity
-		idCtx.Certificate = &ssh.Certificate{
-			KeyId: "alpaca",
-			Permissions: ssh.Permissions{
-				Extensions: map[string]string{
-					teleport.CertExtensionDeviceID:           "deviceid1",
-					teleport.CertExtensionDeviceAssetTag:     "assettag1",
-					teleport.CertExtensionDeviceCredentialID: "credentialid1",
-				},
-			},
-		}
+		idCtx.UnmappedIdentity = &ident
+		idCtx.UnmappedIdentity.DeviceID = "deviceid1"
+		idCtx.UnmappedIdentity.DeviceAssetTag = "assettag1"
+		idCtx.UnmappedIdentity.DeviceCredentialID = "credentialid1"
 		return idCtx
 	}
 	assertTrustedDeviceRequired := func(t *testing.T, _ context.Context, err error, _ *eventstest.MockRecorderEmitter) {
@@ -194,15 +189,12 @@ func TestSessionController_AcquireSessionContext(t *testing.T) {
 				ServerID:     "1234",
 			},
 			identity: IdentityContext{
+				UnmappedIdentity: &sshca.Identity{
+					Username:         "alpaca",
+					PrivateKeyPolicy: keys.PrivateKeyPolicyNone,
+				},
 				TeleportUser: "alpaca",
 				Login:        "alpaca",
-				Certificate: &ssh.Certificate{
-					Permissions: ssh.Permissions{
-						Extensions: map[string]string{
-							teleport.CertExtensionPrivateKeyPolicy: string(keys.PrivateKeyPolicyNone),
-						},
-					},
-				},
 				AccessChecker: mockAccessChecker{
 					keyPolicy:      keys.PrivateKeyPolicyNone,
 					maxConnections: 1,
@@ -245,15 +237,12 @@ func TestSessionController_AcquireSessionContext(t *testing.T) {
 				ServerID:     "1234",
 			},
 			identity: IdentityContext{
+				UnmappedIdentity: &sshca.Identity{
+					Username:         "alpaca",
+					PrivateKeyPolicy: keys.PrivateKeyPolicyNone,
+				},
 				TeleportUser: "alpaca",
 				Login:        "alpaca",
-				Certificate: &ssh.Certificate{
-					Permissions: ssh.Permissions{
-						Extensions: map[string]string{
-							teleport.CertExtensionPrivateKeyPolicy: string(keys.PrivateKeyPolicyNone),
-						},
-					},
-				},
 				AccessChecker: mockAccessChecker{
 					keyPolicy:      keys.PrivateKeyPolicyNone,
 					maxConnections: 1,
@@ -286,15 +275,12 @@ func TestSessionController_AcquireSessionContext(t *testing.T) {
 				ServerID:  "1234",
 			},
 			identity: IdentityContext{
+				UnmappedIdentity: &sshca.Identity{
+					Username:         "alpaca",
+					PrivateKeyPolicy: keys.PrivateKeyPolicyNone,
+				},
 				TeleportUser: "alpaca",
 				Login:        "alpaca",
-				Certificate: &ssh.Certificate{
-					Permissions: ssh.Permissions{
-						Extensions: map[string]string{
-							teleport.CertExtensionPrivateKeyPolicy: string(keys.PrivateKeyPolicyNone),
-						},
-					},
-				},
 				AccessChecker: mockAccessChecker{
 					keyPolicy:      keys.PrivateKeyPolicyNone,
 					maxConnections: 1,
@@ -332,15 +318,12 @@ func TestSessionController_AcquireSessionContext(t *testing.T) {
 				ServerID:     "1234",
 			},
 			identity: IdentityContext{
+				UnmappedIdentity: &sshca.Identity{
+					Username:         "alpaca",
+					PrivateKeyPolicy: keys.PrivateKeyPolicyNone,
+				},
 				TeleportUser: "alpaca",
 				Login:        "alpaca",
-				Certificate: &ssh.Certificate{
-					Permissions: ssh.Permissions{
-						Extensions: map[string]string{
-							teleport.CertExtensionPrivateKeyPolicy: string(keys.PrivateKeyPolicyNone),
-						},
-					},
-				},
 				AccessChecker: mockAccessChecker{
 					keyPolicy:      keys.PrivateKeyPolicyHardwareKey,
 					maxConnections: 1,
@@ -379,15 +362,12 @@ func TestSessionController_AcquireSessionContext(t *testing.T) {
 				ServerID:     "1234",
 			},
 			identity: IdentityContext{
+				UnmappedIdentity: &sshca.Identity{
+					Username:         "alpaca",
+					PrivateKeyPolicy: keys.PrivateKeyPolicyNone,
+				},
 				TeleportUser: "alpaca",
 				Login:        "alpaca",
-				Certificate: &ssh.Certificate{
-					Permissions: ssh.Permissions{
-						Extensions: map[string]string{
-							teleport.CertExtensionPrivateKeyPolicy: string(keys.PrivateKeyPolicyNone),
-						},
-					},
-				},
 				AccessChecker: mockAccessChecker{
 					keyPolicy:      keys.PrivateKeyPolicyNone,
 					maxConnections: 1,
@@ -434,15 +414,12 @@ func TestSessionController_AcquireSessionContext(t *testing.T) {
 				ServerID:     "1234",
 			},
 			identity: IdentityContext{
+				UnmappedIdentity: &sshca.Identity{
+					Username:         "alpaca",
+					PrivateKeyPolicy: keys.PrivateKeyPolicyNone,
+				},
 				TeleportUser: "alpaca",
 				Login:        "alpaca",
-				Certificate: &ssh.Certificate{
-					Permissions: ssh.Permissions{
-						Extensions: map[string]string{
-							teleport.CertExtensionPrivateKeyPolicy: string(keys.PrivateKeyPolicyNone),
-						},
-					},
-				},
 				AccessChecker: mockAccessChecker{
 					keyPolicy:      keys.PrivateKeyPolicyNone,
 					maxConnections: 0,

--- a/lib/sshca/encoding_helpers.go
+++ b/lib/sshca/encoding_helpers.go
@@ -1,0 +1,65 @@
+/*
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package sshca
+
+import (
+	"encoding/json"
+
+	"github.com/gravitational/trace"
+)
+
+// requestIDs is a collection of IDs for privilege escalation requests. This type is used
+// for serialization/deserialization of request IDs for embedding in certificates. Most usecases
+// should prefer representing request IDs as a slice of strings.
+type requestIDs struct {
+	AccessRequests []string `json:"access_requests,omitempty"`
+}
+
+// Marshal encodes requestIDs into the canonical JSON format expected for teleport certificates.
+func (r *requestIDs) Marshal() ([]byte, error) {
+	data, err := json.Marshal(r)
+	return data, trace.Wrap(err)
+}
+
+// Unmarshal decodes requestIDs from the canonical JSON format expected for teleport certificates.
+func (r *requestIDs) Unmarshal(data []byte) error {
+	return trace.Wrap(json.Unmarshal(data, r))
+}
+
+// IsEmpty returns true if the requestIDs is empty.
+func (r *requestIDs) IsEmpty() bool {
+	return len(r.AccessRequests) < 1
+}
+
+// certRoles is a helper for marshaling and unmarshaling roles list to the format
+// used by the teleport ssh certificate role extension.
+type certRoles struct {
+	// Roles is a list of roles
+	Roles []string `json:"roles"`
+}
+
+// Marshal marshals roles to the format used by the teleport ssh certificate role extension.
+func (r *certRoles) Marshal() ([]byte, error) {
+	data, err := json.Marshal(r)
+	return data, trace.Wrap(err)
+}
+
+// Unmarshal unmarshals roles from the teleport ssh certificate role extension format.
+func (r *certRoles) Unmarshal(data []byte) error {
+	return trace.Wrap(json.Unmarshal(data, r))
+}

--- a/lib/sshca/identity.go
+++ b/lib/sshca/identity.go
@@ -34,7 +34,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/teleport/api/utils/keys"
-	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -268,24 +267,27 @@ func (i *Identity) Encode(certFormat string) (*ssh.Certificate, error) {
 			cert.Permissions.Extensions[teleport.CertExtensionTeleportTraits] = string(traits)
 		}
 		if len(i.Roles) != 0 {
-			roles, err := services.MarshalCertRoles(i.Roles)
+			roles := certRoles{
+				Roles: i.Roles,
+			}
+			rolesExt, err := roles.Marshal()
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
-			cert.Permissions.Extensions[teleport.CertExtensionTeleportRoles] = roles
+			cert.Permissions.Extensions[teleport.CertExtensionTeleportRoles] = string(rolesExt)
 		}
 		if i.RouteToCluster != "" {
 			cert.Permissions.Extensions[teleport.CertExtensionTeleportRouteToCluster] = i.RouteToCluster
 		}
 		if len(i.ActiveRequests) != 0 {
-			reqs := services.RequestIDs{
+			reqs := requestIDs{
 				AccessRequests: i.ActiveRequests,
 			}
-			requests, err := reqs.Marshal()
+			reqsExt, err := reqs.Marshal()
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
-			cert.Permissions.Extensions[teleport.CertExtensionTeleportActiveRequests] = string(requests)
+			cert.Permissions.Extensions[teleport.CertExtensionTeleportActiveRequests] = string(reqsExt)
 		}
 	}
 
@@ -398,17 +400,17 @@ func DecodeIdentity(cert *ssh.Certificate) (*Identity, error) {
 	}
 
 	if v, ok := takeExtension(teleport.CertExtensionTeleportRoles); ok {
-		roles, err := services.UnmarshalCertRoles(v)
-		if err != nil {
+		var roles certRoles
+		if err := roles.Unmarshal([]byte(v)); err != nil {
 			return nil, trace.BadParameter("failed to unmarshal value %q for extension %q as roles: %v", v, teleport.CertExtensionTeleportRoles, err)
 		}
-		ident.Roles = roles
+		ident.Roles = roles.Roles
 	}
 
 	ident.RouteToCluster = takeValue(teleport.CertExtensionTeleportRouteToCluster)
 
 	if v, ok := takeExtension(teleport.CertExtensionTeleportActiveRequests); ok {
-		var reqs services.RequestIDs
+		var reqs requestIDs
 		if err := reqs.Unmarshal([]byte(v)); err != nil {
 			return nil, trace.BadParameter("failed to unmarshal value %q for extension %q as active requests: %v", v, teleport.CertExtensionTeleportActiveRequests, err)
 		}

--- a/lib/sshca/identity_test.go
+++ b/lib/sshca/identity_test.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 
@@ -51,7 +50,7 @@ func TestIdentityConversion(t *testing.T) {
 		Roles:                   []string{"role1", "role2"},
 		RouteToCluster:          "cluster",
 		Traits:                  wrappers.Traits{"trait1": []string{"value1"}, "trait2": []string{"value2"}},
-		ActiveRequests:          []string{uuid.NewString()},
+		ActiveRequests:          []string{"some-request"},
 		MFAVerified:             "mfa",
 		PreviousIdentityExpires: time.Unix(12345, 0),
 		LoginIP:                 "127.0.0.1",

--- a/lib/teleterm/clusters/cluster.go
+++ b/lib/teleterm/clusters/cluster.go
@@ -309,7 +309,7 @@ func (c *Cluster) GetLoggedInUser() LoggedInUser {
 		Name:           c.status.Username,
 		SSHLogins:      c.status.Logins,
 		Roles:          c.status.Roles,
-		ActiveRequests: c.status.ActiveRequests.AccessRequests,
+		ActiveRequests: c.status.ActiveRequests,
 	}
 }
 

--- a/lib/teleterm/clusters/cluster_access_requests.go
+++ b/lib/teleterm/clusters/cluster_access_requests.go
@@ -221,7 +221,7 @@ func (c *Cluster) AssumeRole(ctx context.Context, rootClient *client.ClusterClie
 		}
 
 		// keep existing access requests that aren't included in the droprequests
-		for _, reqID := range c.status.ActiveRequests.AccessRequests {
+		for _, reqID := range c.status.ActiveRequests {
 			if !slices.Contains(req.DropRequestIds, reqID) {
 				params.AccessRequests = append(params.AccessRequests, reqID)
 			}

--- a/lib/teleterm/clusters/cluster_apps.go
+++ b/lib/teleterm/clusters/cluster_apps.go
@@ -155,7 +155,7 @@ func (c *Cluster) ReissueAppCert(ctx context.Context, clusterClient *client.Clus
 	// Refresh the certs to account for clusterClient.SiteName pointing at a leaf cluster.
 	err := clusterClient.ReissueUserCerts(ctx, client.CertCacheKeep, client.ReissueParams{
 		RouteToCluster: c.clusterClient.SiteName,
-		AccessRequests: c.status.ActiveRequests.AccessRequests,
+		AccessRequests: c.status.ActiveRequests,
 	})
 	if err != nil {
 		return tls.Certificate{}, trace.Wrap(err)
@@ -185,7 +185,7 @@ func (c *Cluster) ReissueAppCert(ctx context.Context, clusterClient *client.Clus
 	key, _, err := clusterClient.IssueUserCertsWithMFA(ctx, client.ReissueParams{
 		RouteToCluster: c.clusterClient.SiteName,
 		RouteToApp:     routeToApp,
-		AccessRequests: c.status.ActiveRequests.AccessRequests,
+		AccessRequests: c.status.ActiveRequests,
 		RequesterName:  proto.UserCertsRequest_TSH_APP_LOCAL_PROXY,
 		TTL:            c.clusterClient.KeyTTL,
 	})

--- a/lib/teleterm/clusters/cluster_databases.go
+++ b/lib/teleterm/clusters/cluster_databases.go
@@ -125,7 +125,7 @@ func (c *Cluster) reissueDBCerts(ctx context.Context, clusterClient *client.Clus
 	// Refresh the certs to account for clusterClient.SiteName pointing at a leaf cluster.
 	err := clusterClient.ReissueUserCerts(ctx, client.CertCacheKeep, client.ReissueParams{
 		RouteToCluster: c.clusterClient.SiteName,
-		AccessRequests: c.status.ActiveRequests.AccessRequests,
+		AccessRequests: c.status.ActiveRequests,
 	})
 	if err != nil {
 		return tls.Certificate{}, trace.Wrap(err)
@@ -138,7 +138,7 @@ func (c *Cluster) reissueDBCerts(ctx context.Context, clusterClient *client.Clus
 			Protocol:    routeToDatabase.Protocol,
 			Username:    routeToDatabase.Username,
 		},
-		AccessRequests: c.status.ActiveRequests.AccessRequests,
+		AccessRequests: c.status.ActiveRequests,
 		RequesterName:  proto.UserCertsRequest_TSH_DB_LOCAL_PROXY_TUNNEL,
 		TTL:            c.clusterClient.KeyTTL,
 	})

--- a/lib/teleterm/clusters/cluster_kubes.go
+++ b/lib/teleterm/clusters/cluster_kubes.go
@@ -104,7 +104,7 @@ func (c *Cluster) reissueKubeCert(ctx context.Context, clusterClient *client.Clu
 	// Refresh the certs to account for clusterClient.SiteName pointing at a leaf cluster.
 	err := clusterClient.ReissueUserCerts(ctx, client.CertCacheKeep, client.ReissueParams{
 		RouteToCluster: c.clusterClient.SiteName,
-		AccessRequests: c.status.ActiveRequests.AccessRequests,
+		AccessRequests: c.status.ActiveRequests,
 	})
 	if err != nil {
 		return tls.Certificate{}, trace.Wrap(err)

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -59,6 +59,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
 	alpncommon "github.com/gravitational/teleport/lib/srv/alpnproxy/common"
+	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -503,10 +504,12 @@ func (c *SessionContext) GetUserAccessChecker() (services.AccessChecker, error) 
 		return nil, trace.Wrap(err)
 	}
 
-	accessInfo, err := services.AccessInfoFromLocalCertificate(cert)
+	ident, err := sshca.DecodeIdentity(cert)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	accessInfo := services.AccessInfoFromLocalSSHIdentity(ident)
 
 	accessChecker, err := services.NewAccessChecker(accessInfo, c.cfg.RootClusterName, c.cfg.UnsafeCachedAuthClient)
 	return accessChecker, trace.Wrap(err)

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -59,6 +59,7 @@ import (
 	"github.com/gravitational/teleport/lib/proxy"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/teleagent"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/diagnostics/latency"
@@ -669,7 +670,13 @@ func (t *sshBaseHandler) connectToHost(ctx context.Context, ws terminal.WSConn, 
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	signer := agentless.SignerFromSSHCertificate(cert, t.localAccessPoint, tc.SiteName, tc.Username)
+
+	ident, err := sshca.DecodeIdentity(cert)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	signer := agentless.SignerFromSSHIdentity(ident, t.localAccessPoint, tc.SiteName, tc.Username)
 
 	type clientRes struct {
 		clt *client.NodeClient

--- a/tool/tsh/common/app.go
+++ b/tool/tsh/common/app.go
@@ -86,7 +86,7 @@ func onAppLogin(cf *CLIConf) error {
 	appCertParams := client.ReissueParams{
 		RouteToCluster: tc.SiteName,
 		RouteToApp:     appInfo.RouteToApp,
-		AccessRequests: appInfo.profile.ActiveRequests.AccessRequests,
+		AccessRequests: appInfo.profile.ActiveRequests,
 	}
 
 	key, err := appLogin(cf.Context, tc, clusterClient, rootClient, appCertParams)

--- a/tool/tsh/common/db.go
+++ b/tool/tsh/common/db.go
@@ -319,7 +319,7 @@ func databaseLogin(cf *CLIConf, tc *client.TeleportClient, dbInfo *databaseInfo)
 					Database:    dbInfo.Database,
 					Roles:       dbInfo.Roles,
 				},
-				AccessRequests: profile.ActiveRequests.AccessRequests,
+				AccessRequests: profile.ActiveRequests,
 			})
 			return trace.Wrap(err)
 		}); err != nil {

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1949,7 +1949,7 @@ func onLogin(cf *CLIConf, reExecArgs ...string) error {
 			}
 			// trigger reissue, preserving any active requests.
 			err = tc.ReissueUserCerts(cf.Context, client.CertCacheKeep, client.ReissueParams{
-				AccessRequests: profile.ActiveRequests.AccessRequests,
+				AccessRequests: profile.ActiveRequests,
 				RouteToCluster: cf.SiteName,
 			})
 			if err != nil {
@@ -5028,7 +5028,7 @@ func makeProfileInfo(p *client.ProfileStatus, env map[string]string, isActive bo
 	out := &profileInfo{
 		ProxyURL:           p.ProxyURL.String(),
 		Username:           p.Username,
-		ActiveRequests:     p.ActiveRequests.AccessRequests,
+		ActiveRequests:     p.ActiveRequests,
 		Cluster:            p.Cluster,
 		Roles:              p.Roles,
 		Traits:             p.Traits,
@@ -5234,7 +5234,7 @@ func reissueWithRequests(cf *CLIConf, tc *client.TeleportClient, newRequests []s
 		RouteToCluster:     cf.SiteName,
 	}
 	// If the certificate already had active requests, add them to our inputs parameters.
-	for _, reqID := range profile.ActiveRequests.AccessRequests {
+	for _, reqID := range profile.ActiveRequests {
 		if !slices.Contains(dropRequests, reqID) {
 			params.AccessRequests = append(params.AccessRequests, reqID)
 		}

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -4611,7 +4611,7 @@ func TestSerializeProfiles(t *testing.T) {
 	activeProfile := &client.ProfileStatus{
 		ProxyURL:       *p,
 		Username:       "test",
-		ActiveRequests: services.RequestIDs{AccessRequests: []string{"1", "2", "3"}},
+		ActiveRequests: []string{"1", "2", "3"},
 		Cluster:        "main",
 		Roles:          []string{"a", "b", "c"},
 		Traits:         wrappers.Traits{"a": []string{"1", "2", "3"}},

--- a/tool/tsh/common/vnet_common.go
+++ b/tool/tsh/common/vnet_common.go
@@ -188,7 +188,7 @@ func (p *vnetAppProvider) reissueAppCert(ctx context.Context, tc *client.Telepor
 	appCertParams := client.ReissueParams{
 		RouteToCluster: tc.SiteName,
 		RouteToApp:     routeToApp,
-		AccessRequests: profile.ActiveRequests.AccessRequests,
+		AccessRequests: profile.ActiveRequests,
 		RequesterName:  proto.UserCertsRequest_TSH_APP_LOCAL_PROXY,
 		TTL:            tc.KeyTTL,
 	}


### PR DESCRIPTION
Backport #51468 to branch/v16.