### PR TITLE
Fix createAppSession call from web

### DIFF
--- a/web/packages/teleport/src/AppLauncher/AppLauncher.test.tsx
+++ b/web/packages/teleport/src/AppLauncher/AppLauncher.test.tsx
@@ -295,8 +295,8 @@ describe('fqdn is matched', () => {
       await waitFor(() => {
         expect(service.createAppSession).toHaveBeenCalledWith({
           fqdn: expectedFqdn,
-          clusterId: 'test.teleport',
-          publicAddr: expectedPublicAddr,
+          cluster_name: 'test.teleport',
+          public_addr: expectedPublicAddr,
           arn: expectedArn,
         });
       });

--- a/web/packages/teleport/src/AppLauncher/AppLauncher.tsx
+++ b/web/packages/teleport/src/AppLauncher/AppLauncher.tsx
@@ -115,8 +115,13 @@ export function AppLauncher() {
         params.arn = decodeURIComponent(params.arn);
       }
 
-      const createAppSessionParams = params as CreateAppSessionParams;
-      createAppSessionParams.mfaResponse = await mfa.getChallengeResponse();
+      const createAppSessionParams: CreateAppSessionParams = {
+        fqdn: params.fqdn,
+        cluster_name: params.clusterId,
+        public_addr: params.publicAddr,
+        arn: params.arn,
+        mfaResponse: await mfa.getChallengeResponse(),
+      };
       const session = await service.createAppSession(createAppSessionParams);
 
       // Set all the fields expected by server to validate request.

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -1270,8 +1270,9 @@ export interface UrlAppParams {
 
 export interface CreateAppSessionParams {
   fqdn: string;
-  clusterId?: string;
-  publicAddr?: string;
+  // This API requires cluster_name and public_addr with underscores.
+  cluster_name?: string;
+  public_addr?: string;
   arn?: string;
   mfaResponse?: MfaChallengeResponse;
 }

--- a/web/packages/teleport/src/services/apps/apps.test.ts
+++ b/web/packages/teleport/src/services/apps/apps.test.ts
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import cfg from 'teleport/config';
 import api from 'teleport/services/api';
 import apps from 'teleport/services/apps';
 
@@ -144,6 +145,31 @@ test('null labels field in apps fetch response', async () => {
   });
 
   expect(response.agents[0].labels).toEqual([]);
+});
+
+test('createAppSession', async () => {
+  const backend = jest.spyOn(api, 'post').mockResolvedValue({
+    fqdn: 'app-name.example.com',
+    cookieValue: 'cookie-value',
+    subjectCookieValue: 'subject-cookie-value',
+  });
+
+  const response = await apps.createAppSession({
+    fqdn: 'app-name.example.com',
+    clusterId: 'example.com',
+    publicAddr: 'app-name.example.com',
+  });
+
+  expect(response.fqdn).toEqual('app-name.example.com');
+
+  expect(backend).toHaveBeenCalledWith(
+    cfg.api.appSession,
+    expect.objectContaining({
+      fqdn: 'app-name.example.com',
+      cluster_name: 'example.com',
+      public_addr: 'app-name.example.com',
+    })
+  );
 });
 
 const mockResponse = {

--- a/web/packages/teleport/src/services/apps/apps.test.ts
+++ b/web/packages/teleport/src/services/apps/apps.test.ts
@@ -156,8 +156,8 @@ test('createAppSession', async () => {
 
   const response = await apps.createAppSession({
     fqdn: 'app-name.example.com',
-    clusterId: 'example.com',
-    publicAddr: 'app-name.example.com',
+    cluster_name: 'example.com',
+    public_addr: 'app-name.example.com',
   });
 
   expect(response.fqdn).toEqual('app-name.example.com');

--- a/web/packages/teleport/src/services/apps/apps.ts
+++ b/web/packages/teleport/src/services/apps/apps.ts
@@ -46,6 +46,8 @@ const service = {
   async createAppSession(params: CreateAppSessionParams) {
     const createAppSession = {
       ...params,
+      cluster_name: params.clusterId,
+      public_addr: params.publicAddr,
       // TODO(Joerger): DELETE IN v19.0.0.
       // We include a string version of the MFA response for backwards compatibility.
       mfa_response: params.mfaResponse

--- a/web/packages/teleport/src/services/apps/apps.ts
+++ b/web/packages/teleport/src/services/apps/apps.ts
@@ -46,8 +46,6 @@ const service = {
   async createAppSession(params: CreateAppSessionParams) {
     const createAppSession = {
       ...params,
-      cluster_name: params.clusterId,
-      public_addr: params.publicAddr,
       // TODO(Joerger): DELETE IN v19.0.0.
       // We include a string version of the MFA response for backwards compatibility.
       mfa_response: params.mfaResponse


### PR DESCRIPTION
related:
- https://github.com/gravitational/customer-sensitive-requests/issues/395
- https://github.com/gravitational/teleport/pull/50529

changelog: Fix an issue leaf AWS console app shows "not found" error when root cluster has an app of the same name