### PR TITLE
Fix issue applying the --listen-ip flag

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2784,14 +2784,15 @@ func isCmdLabelSpec(spec string) (types.CommandLabel, error) {
 func applyListenIP(ip net.IP, cfg *servicecfg.Config) {
 	listeningAddresses := []*utils.NetAddr{
 		&cfg.Auth.ListenAddr,
-		&cfg.Auth.ListenAddr,
 		&cfg.Proxy.SSHAddr,
 		&cfg.Proxy.WebAddr,
 		&cfg.SSH.Addr,
 		&cfg.Proxy.ReverseTunnelListenAddr,
 	}
 	for _, addr := range listeningAddresses {
-		replaceHost(addr, ip.String())
+		if !addr.IsEmpty() {
+			replaceHost(addr, ip.String())
+		}
 	}
 }
 


### PR DESCRIPTION
When you use the --listen-ip flag, some very old Teleport code attempts to replace the IP (but not the port) of a bunch of internal listening addresses.

Some of these addresses used to be required in older versions of Teleport, but are typically left empty in modern Teleport now that we have things like multiplexing and TLS routing.

The code that applies the listen IP was not written to be able to handle empty addresses, so it would log errors on startup.

Fix this by only updating addresses that are non-empty.

Note: there may well be more issues with the --listen-ip flag, as it is not frequently used and was written many years ago.

Closes #51064