### PR TITLE
[Web] Update `makeCluster` to handle an empty response

### DIFF
--- a/web/packages/teleport/src/services/clusters/makeCluster.ts
+++ b/web/packages/teleport/src/services/clusters/makeCluster.ts
@@ -23,6 +23,8 @@ import cfg from 'teleport/config';
 import { Cluster, ClusterInfo } from './types';
 
 export function makeCluster(json): Cluster {
+  json = json || {};
+
   const {
     name,
     lastConnected,
@@ -33,12 +35,21 @@ export function makeCluster(json): Cluster {
     licenseExpiry,
   } = json;
 
-  const lastConnectedDate = new Date(lastConnected);
-  const connectedText = displayDateTime(lastConnectedDate);
+  let lastConnectedDate: Date;
+  let connectedText;
+  if (lastConnected) {
+    lastConnectedDate = new Date(lastConnected);
+    connectedText = displayDateTime(lastConnectedDate);
+  }
 
   let licenseExpiryDateText;
   if (licenseExpiry) {
     licenseExpiryDateText = displayDate(new Date(licenseExpiry));
+  }
+
+  let url;
+  if (name) {
+    url = cfg.getClusterRoute(name);
   }
 
   return {
@@ -46,7 +57,7 @@ export function makeCluster(json): Cluster {
     lastConnected: lastConnectedDate,
     connectedText,
     status,
-    url: cfg.getClusterRoute(name),
+    url,
     authVersion,
     publicURL,
     proxyVersion,


### PR DESCRIPTION
## Purpose

This PR fixes a minor bug which would trigger a javascript error `Cannot destructure property 'name' of 'e' as it is undefined`. This occurs when the response from `context` doesn't have a `cluster` field (such as when it returns an error). 

We typically write all of our `makeXXXX` functions such that they're able to handle an undefined json, however this wasn't done for `makeCluster`, leading to errors whenever the json passed in was `undefined`.