### PR TITLE
GitHub proxy: emit rbac failure event and add prometheus counters

### DIFF
--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -369,25 +369,8 @@ func (h *AuthHandlers) UserKeyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*s
 			h.log.WarnContext(ctx, "Failed to append Trace to ConnectionDiagnostic", "error", err)
 		}
 
-		if err := h.c.Emitter.EmitAuditEvent(h.c.Server.Context(), &apievents.AuthAttempt{
-			Metadata: apievents.Metadata{
-				Type: events.AuthAttemptEvent,
-				Code: events.AuthAttemptFailureCode,
-			},
-			UserMetadata: apievents.UserMetadata{
-				Login:         principal,
-				User:          ident.Username,
-				TrustedDevice: eventDeviceMetadataFromIdentity(ident),
-			},
-			ConnectionMetadata: apievents.ConnectionMetadata{
-				LocalAddr:  conn.LocalAddr().String(),
-				RemoteAddr: conn.RemoteAddr().String(),
-			},
-			Status: apievents.Status{
-				Success: false,
-				Error:   err.Error(),
-			},
-		}); err != nil {
+		failureEvent := MakeAuthAttemptFailureEvent(conn, ident, err)
+		if err := h.c.Emitter.EmitAuditEvent(h.c.Server.Context(), failureEvent); err != nil {
 			h.log.WarnContext(ctx, "Failed to emit failed login audit event", "error", err)
 		}
 
@@ -715,4 +698,28 @@ func (h *AuthHandlers) authorityForCert(caType types.CertAuthType, key ssh.Publi
 // isProxy returns true if it's a regular SSH proxy.
 func (h *AuthHandlers) isProxy() bool {
 	return h.c.Component == teleport.ComponentProxy
+}
+
+// MakeAuthAttemptFailureEvent creates an auth attempt failure event using
+// provided info.
+func MakeAuthAttemptFailureEvent(conn ssh.ConnMetadata, ident *sshca.Identity, err error) *apievents.AuthAttempt {
+	return &apievents.AuthAttempt{
+		Metadata: apievents.Metadata{
+			Type: events.AuthAttemptEvent,
+			Code: events.AuthAttemptFailureCode,
+		},
+		UserMetadata: apievents.UserMetadata{
+			Login:         conn.User(),
+			User:          ident.Username,
+			TrustedDevice: eventDeviceMetadataFromIdentity(ident),
+		},
+		ConnectionMetadata: apievents.ConnectionMetadata{
+			LocalAddr:  conn.LocalAddr().String(),
+			RemoteAddr: conn.RemoteAddr().String(),
+		},
+		Status: apievents.Status{
+			Success: false,
+			Error:   err.Error(),
+		},
+	}
 }

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -1066,22 +1066,6 @@ func (c *ServerContext) ExecCommand() (*ExecCommand, error) {
 	}, nil
 }
 
-func eventDeviceMetadataFromIdentity(ident *sshca.Identity) *apievents.DeviceMetadata {
-	if ident == nil {
-		return nil
-	}
-
-	if ident.DeviceID == "" && ident.DeviceAssetTag == "" && ident.DeviceCredentialID == "" {
-		return nil
-	}
-
-	return &apievents.DeviceMetadata{
-		DeviceId:     ident.DeviceID,
-		AssetTag:     ident.DeviceAssetTag,
-		CredentialId: ident.DeviceCredentialID,
-	}
-}
-
 func (id *IdentityContext) GetUserMetadata() apievents.UserMetadata {
 	userKind := apievents.UserKind_USER_KIND_HUMAN
 	if id.BotName != "" {
@@ -1093,7 +1077,7 @@ func (id *IdentityContext) GetUserMetadata() apievents.UserMetadata {
 		User:           id.TeleportUser,
 		Impersonator:   id.Impersonator,
 		AccessRequests: id.ActiveRequests,
-		TrustedDevice:  eventDeviceMetadataFromIdentity(id.UnmappedIdentity),
+		TrustedDevice:  id.UnmappedIdentity.GetDeviceMetadata(),
 		UserKind:       userKind,
 		BotName:        id.BotName,
 		BotInstanceID:  id.BotInstanceID,

--- a/lib/srv/git/forward_test.go
+++ b/lib/srv/git/forward_test.go
@@ -136,6 +136,14 @@ func TestForwardServer(t *testing.T) {
 			clientLogin:        "git",
 			verifyRemoteHost:   ssh.InsecureIgnoreHostKey(),
 			wantNewClientError: true,
+			verifyEvent: func(t *testing.T, event apievents.AuditEvent) {
+				authFailureEvent, ok := event.(*apievents.AuthAttempt)
+				require.True(t, ok)
+				assert.Equal(t, libevents.AuthAttemptEvent, authFailureEvent.Metadata.Type)
+				assert.Equal(t, libevents.AuthAttemptFailureCode, authFailureEvent.Metadata.Code)
+				assert.Equal(t, "alice", authFailureEvent.User)
+				assert.Contains(t, authFailureEvent.Error, "access denied")
+			},
 		},
 		{
 			name:               "failed client login check",

--- a/lib/sshca/identity.go
+++ b/lib/sshca/identity.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
+	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/utils"
@@ -304,6 +305,22 @@ func (i *Identity) Encode(certFormat string) (*ssh.Certificate, error) {
 	}
 
 	return cert, nil
+}
+
+// GetDeviceMetadata returns information about user's trusted device.
+func (i *Identity) GetDeviceMetadata() *apievents.DeviceMetadata {
+	if i == nil {
+		return nil
+	}
+	if i.DeviceID == "" && i.DeviceAssetTag == "" && i.DeviceCredentialID == "" {
+		return nil
+	}
+
+	return &apievents.DeviceMetadata{
+		DeviceId:     i.DeviceID,
+		AssetTag:     i.DeviceAssetTag,
+		CredentialId: i.DeviceCredentialID,
+	}
 }
 
 // DecodeIdentity decodes an ssh certificate into an identity.


### PR DESCRIPTION
fixes #51826 

changelog: Fixed missing audit event on GitHub proxy RBAC failure