### PR TITLE
Add engines.node to package.json

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -6,6 +6,7 @@
 GOLANG_VERSION ?= go1.23.5
 GOLANGCI_LINT_VERSION ?= v1.63.4
 
+# NOTE: Remember to update engines.node in package.json to match the major version.
 # TODO(ravicious): When attempting to update Node.js version, see if corepack distributed with this
 # version is > 0.31.0. If so, remove definitions of COREPACK_INTEGRITY_KEYS from CI.
 NODE_VERSION ?= 20.18.0

--- a/package.json
+++ b/package.json
@@ -104,5 +104,8 @@
       "web/.storybook/public"
     ]
   },
-  "packageManager": "pnpm@9.9.0+sha512.60c18acd138bff695d339be6ad13f7e936eea6745660d4cc4a776d5247c540d0edee1a563695c183a66eb917ef88f2b4feb1fc25f32a7adcadc7aaf3438e99c1"
+  "packageManager": "pnpm@9.9.0+sha512.60c18acd138bff695d339be6ad13f7e936eea6745660d4cc4a776d5247c540d0edee1a563695c183a66eb917ef88f2b4feb1fc25f32a7adcadc7aaf3438e99c1",
+  "engines": {
+    "node": "^20"
+  }
 }


### PR DESCRIPTION
https://docs.npmjs.com/cli/v11/configuring-npm/package-json#engines

This makes pnpm and other tools show a warning when an unsupported version is used. As we don't currently automatically manage the Node.js version that the project uses, I set the version requirement just to `^20`. I suspect most of the time we won't care if someone has 20.18.0 or 20.18.2, just that they have v20.

CI is already configured to use 20.18.0, so it shouldn't cause problems.

```
$ export PATH=/opt/homebrew/opt/node@22/bin:$PATH
$ which node
/opt/homebrew/opt/node@22/bin/node
$ node -v
v22.13.1
$ pnpm test
 WARN  Unsupported engine: wanted: {"node":"^20"} (current: {"node":"v22.13.1","pnpm":"9.9.0"})

> teleport-ui@1.0.0 test /Users/rav/src/teleport-jj
…
```