### PR TITLE
feat: Add an escape hatch for non-FIPS DynamoDB on FIPS binaries

### DIFF
--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -47,9 +47,9 @@ import (
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/defaults"
-	"github.com/gravitational/teleport/lib/modules"
 	awsmetrics "github.com/gravitational/teleport/lib/observability/metrics/aws"
 	dynamometrics "github.com/gravitational/teleport/lib/observability/metrics/dynamo"
+	awsutils "github.com/gravitational/teleport/lib/utils/aws"
 	"github.com/gravitational/teleport/lib/utils/aws/endpoint"
 )
 
@@ -293,7 +293,7 @@ func New(ctx context.Context, params backend.Params) (*Backend, error) {
 	// FIPS settings are applied on the individual service instead of the aws config,
 	// as DynamoDB Streams and Application Auto Scaling do not yet have FIPS endpoints in non-GovCloud.
 	// See also: https://aws.amazon.com/compliance/fips/#FIPS_Endpoints_by_Service
-	if modules.GetModules().IsBoringBinary() {
+	if awsutils.UseFIPSForDynamoDB() {
 		dynamoOpts = append(dynamoOpts, func(o *dynamodb.Options) {
 			o.EndpointOptions.UseFIPSEndpoint = aws.FIPSEndpointStateEnabled
 		})

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -59,10 +59,10 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
-	"github.com/gravitational/teleport/lib/modules"
 	awsmetrics "github.com/gravitational/teleport/lib/observability/metrics/aws"
 	dynamometrics "github.com/gravitational/teleport/lib/observability/metrics/dynamo"
 	"github.com/gravitational/teleport/lib/utils"
+	awsutils "github.com/gravitational/teleport/lib/utils/aws"
 	"github.com/gravitational/teleport/lib/utils/aws/endpoint"
 )
 
@@ -330,7 +330,7 @@ func New(ctx context.Context, cfg Config) (*Log, error) {
 	// FIPS settings are applied on the individual service instead of the aws config,
 	// as DynamoDB Streams and Application Auto Scaling do not yet have FIPS endpoints in non-GovCloud.
 	// See also: https://aws.amazon.com/compliance/fips/#FIPS_Endpoints_by_Service
-	if modules.GetModules().IsBoringBinary() && cfg.UseFIPSEndpoint == types.ClusterAuditConfigSpecV2_FIPS_ENABLED {
+	if awsutils.UseFIPSForDynamoDB() && cfg.UseFIPSEndpoint == types.ClusterAuditConfigSpecV2_FIPS_ENABLED {
 		dynamoOpts = append(dynamoOpts, func(o *dynamodb.Options) {
 			o.EndpointOptions.UseFIPSEndpoint = aws.FIPSEndpointStateEnabled
 		})

--- a/lib/utils/aws/dynamo_fips.go
+++ b/lib/utils/aws/dynamo_fips.go
@@ -1,0 +1,49 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package aws
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/gravitational/teleport/lib/modules"
+)
+
+// EnvVarDisableDynamoDBFIPS holds the name of the environment variable that
+// disables FIPS for DynamoDB access in builds where FIPS would otherwise be
+// required.
+const EnvVarDisableDynamoDBFIPS = "TELEPORT_UNSTABLE_DISABLE_DYNAMODB_FIPS"
+
+// UseFIPSForDynamoDB is a DynamoDB-specific check that builds on
+// [modules.Modules.IsBoringBinary].
+//
+// FIPS is enabled by default for boring/FIPS teleport binaries, unless the
+// TELEPORT_UNSTABLE_DISABLE_DYNAMODB_FIPS env variable is set to "yes" (or an
+// equivalent boolean).
+func UseFIPSForDynamoDB() bool {
+	// If the skip toggle is set we don't use FIPS DynamoDB.
+	if val := os.Getenv(EnvVarDisableDynamoDBFIPS); val != "" {
+		if val == "yes" {
+			return false
+		}
+		if b, _ := strconv.ParseBool(val); b {
+			return false
+		}
+	}
+
+	return modules.GetModules().IsBoringBinary()
+}

--- a/lib/utils/aws/dynamo_fips_test.go
+++ b/lib/utils/aws/dynamo_fips_test.go
@@ -1,0 +1,82 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package aws_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gravitational/teleport/lib/modules"
+	awsutils "github.com/gravitational/teleport/lib/utils/aws"
+)
+
+func TestUseFIPSForDynamoDB(t *testing.T) {
+	// Don't t.Parallel(), uses both modules.SetTestModules and t.Setenv.
+
+	tests := []struct {
+		name string
+		fips bool
+		env  map[string]string
+		want bool
+	}{
+		{
+			name: "non-FIPS binary",
+			want: false,
+		},
+		{
+			name: "non-FIPS binary with env skip",
+			env: map[string]string{
+				awsutils.EnvVarDisableDynamoDBFIPS: "yes",
+			},
+			want: false,
+		},
+		{
+			name: "FIPS binary",
+			fips: true,
+			want: true,
+		},
+		{
+			name: "FIPS binary with env skip",
+			fips: true,
+			env: map[string]string{
+				awsutils.EnvVarDisableDynamoDBFIPS: "yes",
+			},
+			want: false,
+		},
+		{
+			name: "FIPS binary with env skip (strconv.ParseBool)",
+			fips: true,
+			env: map[string]string{
+				awsutils.EnvVarDisableDynamoDBFIPS: "1",
+			},
+			want: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			modules.SetTestModules(t, &modules.TestModules{
+				FIPS: test.fips,
+			})
+			for k, v := range test.env {
+				t.Setenv(k, v)
+			}
+
+			assert.Equal(t, test.want, awsutils.UseFIPSForDynamoDB(), "UseFIPSForDynamoDB mismatch")
+		})
+	}
+}


### PR DESCRIPTION
Add the "TELEPORT_UNSTABLE_DISABLE_DYNAMODB_FIPS" environment variable as an escape hatch for FIPS binaries that want to use non-FIPS DynamoDB endpoints.

[FIPS DynamoDB is not available][1] in all AWS regions. Nevertheless, this may be acceptable for certain use-cases.

Without the env varible:

```shell
$ teleport start --fips
> 2025-02-05T13:55:48.665-03:00 INFO [DYNAMODB]  resolved endpoint for aws service service.id:DynamoDB service.api_version:2012-08-10 uri:https://dynamodb-fips.sa-east-1.amazonaws.com endpoint/resolver.go:71
>
> ERROR REPORT:
> User Message: initialization failed
> 	operation error DynamoDB: DescribeTable, https response error StatusCode: 0, RequestID: , request send failed, Post &#34;https://dynamodb-fips.sa-east-1.amazonaws.com/&#34;: dial tcp: lookup dynamodb-fips.sa-east-1.amazonaws.com on 127.0.0.53:53: no such host
```

Using the env variable:

```shell
$ TELEPORT_UNSTABLE_DISABLE_DYNAMODB_FIPS=yes teleport start --fips
# backend
> 2025-02-05T14:05:51.828-03:00 INFO [DYNAMODB]  resolved endpoint for aws service service.id:DynamoDB service.api_version:2012-08-10 uri:https://dynamodb.sa-east-1.amazonaws.com endpoint/resolver.go:71
> 2025-02-05T14:05:51.996-03:00 INFO [DYNAMODB]  resolved endpoint for aws service service.id:DynamoDB Streams service.api_version:2012-08-10 uri:https://streams.dynamodb.sa-east-1.amazonaws.com endpoint/resolver.go:71
# events
> 2025-02-05T14:05:52.238-03:00 INFO [DYNAMODB]  resolved endpoint for aws service service.id:DynamoDB service.api_version:2012-08-10 uri:https://dynamodb.sa-east-1.amazonaws.com endpoint/resolver.go:71
```

Partially retracts #34170 via the added env variable.

[1]: https://aws.amazon.com/compliance/fips/