### PR TITLE
Web: Add filters and pinning support for Enroll Resources page

### DIFF
--- a/web/packages/design/src/DataTable/InputSearch/InputSearch.tsx
+++ b/web/packages/design/src/DataTable/InputSearch/InputSearch.tsx
@@ -35,6 +35,8 @@ export default function InputSearch({
   setSearchValue,
   children,
   bigInputSize = false,
+  autoFocus = false,
+  placeholder = 'Search...',
 }: Props) {
   function submitSearch(e: FormEvent<HTMLFormElement>) {
     e.preventDefault(); // prevent form default
@@ -50,10 +52,11 @@ export default function InputSearch({
       <Form onSubmit={submitSearch}>
         <StyledInput
           bigInputSize={bigInputSize}
-          placeholder="Search..."
+          placeholder={placeholder}
           px={3}
           defaultValue={searchValue}
           name={searchInputName}
+          autoFocus={autoFocus}
         />
         <ChildWrapperBackground>
           <ChildWrapper>{children}</ChildWrapper>
@@ -68,6 +71,8 @@ type Props = {
   setSearchValue: (searchValue: string) => void;
   children?: JSX.Element;
   bigInputSize?: boolean;
+  autoFocus?: boolean;
+  placeholder?: string;
 };
 
 const ChildWrapper = styled.div`

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -473,7 +473,7 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
             bg="levels.sunken"
             details={updatePinnedResourcesAttempt.statusText}
           >
-            Could not update pinned resources:
+            Could not update pinned resources
           </Danger>
         )}
         {unifiedResourcePreferencesAttempt?.status === 'error' && (

--- a/web/packages/shared/components/UnifiedResources/shared/PinButton.tsx
+++ b/web/packages/shared/components/UnifiedResources/shared/PinButton.tsx
@@ -23,7 +23,6 @@ import { PushPin, PushPinFilled } from 'design/Icon';
 import { HoverTooltip } from 'design/Tooltip';
 
 import { PinningSupport } from '../types';
-import { PINNING_NOT_SUPPORTED_MESSAGE } from '../UnifiedResources';
 
 // TODO(kimlisa): move this out of the UnifiedResources directory,
 // since it is also used outside of UnifiedResources
@@ -31,24 +30,18 @@ import { PINNING_NOT_SUPPORTED_MESSAGE } from '../UnifiedResources';
 export function PinButton({
   pinned,
   pinningSupport,
-  notSupportedTipContent,
   hovered,
   setPinned,
   className,
 }: {
   pinned: boolean;
   pinningSupport: PinningSupport;
-  notSupportedTipContent?: string;
   hovered: boolean;
   setPinned: () => void;
   className?: string;
 }) {
   const copyAnchorEl = useRef(null);
-  const tipContent = getTipContent(
-    pinningSupport,
-    pinned,
-    notSupportedTipContent
-  );
+  const tipContent = getTipContent(pinningSupport, pinned);
 
   const shouldShowButton =
     pinningSupport !== PinningSupport.Hidden && (pinned || hovered);
@@ -69,9 +62,9 @@ export function PinButton({
       setRef={copyAnchorEl}
       size={0}
       onClick={e => {
-        // This ButtonIcon can be used within another
-        // button (stops propagating click action to the outer button) or
-        // within an anchor element (prevents browser default to go the link).
+        // This ButtonIcon can be used within another element that also has a
+        // onClick handler (stops propagating click event) or within an
+        // anchor element (prevents browser default to go the link).
         e.stopPropagation();
         e.preventDefault();
         setPinned();
@@ -96,12 +89,11 @@ export function PinButton({
 
 function getTipContent(
   pinningSupport: PinningSupport,
-  pinned: boolean,
-  notSupportedTipContent?: string
+  pinned: boolean
 ): string {
   switch (pinningSupport) {
     case PinningSupport.NotSupported:
-      return notSupportedTipContent || PINNING_NOT_SUPPORTED_MESSAGE;
+      return 'To enable pinning support, upgrade to 17.3 or newer.';
     case PinningSupport.Supported:
       return pinned ? 'Unpin' : 'Pin';
     default:

--- a/web/packages/shared/components/UnifiedResources/shared/PinButton.tsx
+++ b/web/packages/shared/components/UnifiedResources/shared/PinButton.tsx
@@ -25,21 +25,30 @@ import { HoverTooltip } from 'design/Tooltip';
 import { PinningSupport } from '../types';
 import { PINNING_NOT_SUPPORTED_MESSAGE } from '../UnifiedResources';
 
+// TODO(kimlisa): move this out of the UnifiedResources directory,
+// since it is also used outside of UnifiedResources
+// (eg: Discover/SelectResource.tsx)
 export function PinButton({
   pinned,
   pinningSupport,
+  notSupportedTipContent,
   hovered,
   setPinned,
   className,
 }: {
   pinned: boolean;
   pinningSupport: PinningSupport;
+  notSupportedTipContent?: string;
   hovered: boolean;
   setPinned: () => void;
   className?: string;
 }) {
   const copyAnchorEl = useRef(null);
-  const tipContent = getTipContent(pinningSupport, pinned);
+  const tipContent = getTipContent(
+    pinningSupport,
+    pinned,
+    notSupportedTipContent
+  );
 
   const shouldShowButton =
     pinningSupport !== PinningSupport.Hidden && (pinned || hovered);
@@ -55,10 +64,18 @@ export function PinButton({
 
   return (
     <ButtonIcon
+      data-testid="pin-button"
       disabled={shouldDisableButton}
       setRef={copyAnchorEl}
       size={0}
-      onClick={setPinned}
+      onClick={e => {
+        // This ButtonIcon can be used within another
+        // button (stops propagating click action to the outer button) or
+        // within an anchor element (prevents browser default to go the link).
+        e.stopPropagation();
+        e.preventDefault();
+        setPinned();
+      }}
       className={className}
       css={`
         visibility: ${shouldShowButton ? 'visible' : 'hidden'};
@@ -79,11 +96,12 @@ export function PinButton({
 
 function getTipContent(
   pinningSupport: PinningSupport,
-  pinned: boolean
+  pinned: boolean,
+  notSupportedTipContent?: string
 ): string {
   switch (pinningSupport) {
     case PinningSupport.NotSupported:
-      return PINNING_NOT_SUPPORTED_MESSAGE;
+      return notSupportedTipContent || PINNING_NOT_SUPPORTED_MESSAGE;
     case PinningSupport.Supported:
       return pinned ? 'Unpin' : 'Pin';
     default:

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.story.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.story.tsx
@@ -144,6 +144,7 @@ const Provider = ({ children }) => {
   const updatePreferences = () => Promise.resolve();
   const getClusterPinnedResources = () => Promise.resolve([]);
   const updateClusterPinnedResources = () => Promise.resolve();
+  const updateDiscoverResourcePreferences = () => Promise.resolve();
 
   return (
     <MemoryRouter>
@@ -153,6 +154,7 @@ const Provider = ({ children }) => {
           updatePreferences,
           getClusterPinnedResources,
           updateClusterPinnedResources,
+          updateDiscoverResourcePreferences,
         }}
       >
         <ContextProvider ctx={ctx}>{children}</ContextProvider>

--- a/web/packages/teleport/src/Discover/Discover.test.tsx
+++ b/web/packages/teleport/src/Discover/Discover.test.tsx
@@ -42,6 +42,7 @@ import { makeTestUserContext } from 'teleport/User/testHelpers/makeTestUserConte
 import { mockUserContextProviderWith } from 'teleport/User/testHelpers/mockUserContextWith';
 
 import { ResourceKind } from './Shared';
+import { getGuideTileId } from './testUtils';
 import { DiscoverUpdateProps, useDiscover } from './useDiscover';
 
 beforeEach(() => {
@@ -88,18 +89,24 @@ test('displays all resources by default', () => {
 
   expect(
     screen
-      .getAllByTestId(ResourceKind.Server)
-      .concat(screen.getAllByTestId(ResourceKind.ConnectMyComputer))
+      .getAllByTestId(getGuideTileId({ kind: ResourceKind.Server }))
+      .concat(
+        screen.getAllByTestId(
+          getGuideTileId({ kind: ResourceKind.ConnectMyComputer })
+        )
+      )
   ).toHaveLength(SERVERS.length);
-  expect(screen.getAllByTestId(ResourceKind.Database)).toHaveLength(
+  expect(
+    screen.getAllByTestId(getGuideTileId({ kind: ResourceKind.Database }))
+  ).toHaveLength(
     DATABASES.length + DATABASES_UNGUIDED.length + DATABASES_UNGUIDED_DOC.length
   );
-  expect(screen.getAllByTestId(ResourceKind.Application)).toHaveLength(
-    APPLICATIONS.length
-  );
-  expect(screen.getAllByTestId(ResourceKind.Kubernetes)).toHaveLength(
-    KUBERNETES.length
-  );
+  expect(
+    screen.getAllByTestId(getGuideTileId({ kind: ResourceKind.Application }))
+  ).toHaveLength(APPLICATIONS.length);
+  expect(
+    screen.getAllByTestId(getGuideTileId({ kind: ResourceKind.Kubernetes }))
+  ).toHaveLength(KUBERNETES.length);
 });
 
 test('location state applies filter/search', () => {
@@ -109,11 +116,17 @@ test('location state applies filter/search', () => {
   });
 
   expect(
-    screen.queryByTestId(ResourceKind.Application)
+    screen.queryByTestId(getGuideTileId({ kind: ResourceKind.Application }))
   ).not.toBeInTheDocument();
-  expect(screen.queryByTestId(ResourceKind.Server)).not.toBeInTheDocument();
-  expect(screen.queryByTestId(ResourceKind.Database)).not.toBeInTheDocument();
-  expect(screen.queryByTestId(ResourceKind.Kubernetes)).not.toBeInTheDocument();
+  expect(
+    screen.queryByTestId(getGuideTileId({ kind: ResourceKind.Server }))
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByTestId(getGuideTileId({ kind: ResourceKind.Database }))
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByTestId(getGuideTileId({ kind: ResourceKind.Kubernetes }))
+  ).not.toBeInTheDocument();
 });
 
 describe('location state', () => {
@@ -122,79 +135,109 @@ describe('location state', () => {
 
     expect(
       screen
-        .getAllByTestId(ResourceKind.Server)
-        .concat(screen.getAllByTestId(ResourceKind.ConnectMyComputer))
+        .getAllByTestId(getGuideTileId({ kind: ResourceKind.Server }))
+        .concat(
+          screen.getAllByTestId(
+            getGuideTileId({ kind: ResourceKind.ConnectMyComputer })
+          )
+        )
     ).toHaveLength(SERVERS.length);
 
     // we assert three databases for servers because the naming convention includes "server"
-    expect(screen.queryAllByTestId(ResourceKind.Database)).toHaveLength(4);
-
-    expect(screen.queryByTestId(ResourceKind.Desktop)).not.toBeInTheDocument();
     expect(
-      screen.queryByTestId(ResourceKind.Application)
+      screen.queryAllByTestId(getGuideTileId({ kind: ResourceKind.Database }))
+    ).toHaveLength(4);
+
+    expect(
+      screen.queryByTestId(getGuideTileId({ kind: ResourceKind.Desktop }))
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByTestId(ResourceKind.Kubernetes)
+      screen.queryByTestId(getGuideTileId({ kind: ResourceKind.Application }))
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(getGuideTileId({ kind: ResourceKind.Kubernetes }))
     ).not.toBeInTheDocument();
   });
 
   test('displays desktops when the location state is desktop', () => {
     create({ initialEntry: 'desktop' });
 
-    expect(screen.queryByTestId(ResourceKind.Server)).not.toBeInTheDocument();
-    expect(screen.queryByTestId(ResourceKind.Database)).not.toBeInTheDocument();
     expect(
-      screen.queryByTestId(ResourceKind.Application)
+      screen.queryByTestId(getGuideTileId({ kind: ResourceKind.Server }))
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByTestId(ResourceKind.Kubernetes)
+      screen.queryByTestId(getGuideTileId({ kind: ResourceKind.Database }))
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(getGuideTileId({ kind: ResourceKind.Application }))
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(getGuideTileId({ kind: ResourceKind.Kubernetes }))
     ).not.toBeInTheDocument();
   });
 
   test('displays apps when the location state is application', () => {
     create({ initialEntry: 'application' });
 
-    expect(screen.getAllByTestId(ResourceKind.Application)).toHaveLength(
-      APPLICATIONS.length
-    );
-
-    expect(screen.queryByTestId(ResourceKind.Server)).not.toBeInTheDocument();
-    expect(screen.queryByTestId(ResourceKind.Desktop)).not.toBeInTheDocument();
-    expect(screen.queryByTestId(ResourceKind.Database)).not.toBeInTheDocument();
     expect(
-      screen.queryByTestId(ResourceKind.Kubernetes)
+      screen.getAllByTestId(getGuideTileId({ kind: ResourceKind.Application }))
+    ).toHaveLength(APPLICATIONS.length);
+
+    expect(
+      screen.queryByTestId(getGuideTileId({ kind: ResourceKind.Server }))
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(getGuideTileId({ kind: ResourceKind.Desktop }))
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(getGuideTileId({ kind: ResourceKind.Database }))
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(getGuideTileId({ kind: ResourceKind.Kubernetes }))
     ).not.toBeInTheDocument();
   });
 
   test('displays databases when the location state is database', () => {
     create({ initialEntry: 'database' });
 
-    expect(screen.getAllByTestId(ResourceKind.Database)).toHaveLength(
+    expect(
+      screen.getAllByTestId(getGuideTileId({ kind: ResourceKind.Database }))
+    ).toHaveLength(
       DATABASES.length +
         DATABASES_UNGUIDED.length +
         DATABASES_UNGUIDED_DOC.length
     );
 
-    expect(screen.queryByTestId(ResourceKind.Server)).not.toBeInTheDocument();
-    expect(screen.queryByTestId(ResourceKind.Desktop)).not.toBeInTheDocument();
     expect(
-      screen.queryByTestId(ResourceKind.Application)
+      screen.queryByTestId(getGuideTileId({ kind: ResourceKind.Server }))
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByTestId(ResourceKind.Kubernetes)
+      screen.queryByTestId(getGuideTileId({ kind: ResourceKind.Desktop }))
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(getGuideTileId({ kind: ResourceKind.Application }))
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(getGuideTileId({ kind: ResourceKind.Kubernetes }))
     ).not.toBeInTheDocument();
   });
 
   test('displays kube resources when the location state is kubernetes', () => {
     create({ initialEntry: 'kubernetes' });
 
-    expect(screen.getAllByTestId(ResourceKind.Kubernetes)).toHaveLength(
-      KUBERNETES.length
-    );
+    expect(
+      screen.getAllByTestId(getGuideTileId({ kind: ResourceKind.Kubernetes }))
+    ).toHaveLength(KUBERNETES.length);
 
-    expect(screen.queryByTestId(ResourceKind.Server)).not.toBeInTheDocument();
-    expect(screen.queryByTestId(ResourceKind.Desktop)).not.toBeInTheDocument();
-    expect(screen.queryByTestId(ResourceKind.Database)).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(getGuideTileId({ kind: ResourceKind.Server }))
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(getGuideTileId({ kind: ResourceKind.Desktop }))
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(getGuideTileId({ kind: ResourceKind.Database }))
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByTestId(ResourceKind.Application)
     ).not.toBeInTheDocument();

--- a/web/packages/teleport/src/Discover/SelectResource/SelectResource.story.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/SelectResource.story.tsx
@@ -96,6 +96,7 @@ const Provider = ({
   const updatePreferences = () => Promise.resolve();
   const getClusterPinnedResources = () => Promise.resolve([]);
   const updateClusterPinnedResources = () => Promise.resolve();
+  const updateDiscoverResourcePreferences = () => Promise.resolve();
   const preferences: UserPreferences = makeDefaultUserPreferences();
   preferences.onboard.preferredResources = resources;
 
@@ -109,6 +110,7 @@ const Provider = ({
           updatePreferences,
           getClusterPinnedResources,
           updateClusterPinnedResources,
+          updateDiscoverResourcePreferences,
         }}
       >
         <ContextProvider ctx={ctx}>{children}</ContextProvider>

--- a/web/packages/teleport/src/Discover/SelectResource/SelectResource.test.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/SelectResource.test.tsx
@@ -16,10 +16,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 
 import { Platform, UserAgent } from 'design/platform';
-import { render, screen, waitFor } from 'design/utils/testing';
+import { render, screen, userEvent, waitFor } from 'design/utils/testing';
 import {
   OnboardUserPreferences,
   Resource,
@@ -32,37 +33,41 @@ import {
   noAccess,
 } from 'teleport/mocks/contexts';
 import { OnboardDiscover } from 'teleport/services/user';
+import * as service from 'teleport/services/userPreferences/userPreferences';
 import { makeDefaultUserPreferences } from 'teleport/services/userPreferences/userPreferences';
 import * as userUserContext from 'teleport/User/UserContext';
+import { UserContextProvider } from 'teleport/User/UserContext';
 
 import { ResourceKind } from '../Shared';
 import { resourceKindToPreferredResource } from '../Shared/ResourceKind';
+import { getGuideTileId } from '../testUtils';
 import { SelectResourceSpec } from './resources';
 import { SelectResource } from './SelectResource';
+import {
+  a_DatabaseAws,
+  c_ApplicationGcp,
+  d_Saml,
+  e_KubernetesSelfHosted_unguided,
+  f_Server,
+  g_Application,
+  h_Server,
+  i_Desktop,
+  j_Kubernetes,
+  k_Database,
+  kindBasedList,
+  l_DesktopAzure,
+  l_Saml,
+  makeResourceSpec,
+  NoAccessList,
+} from './testUtils';
 import { filterBySupportedPlatformsAndAuthTypes } from './utils/filters';
+import { defaultPins } from './utils/pins';
 import { sortResourcesByPreferences } from './utils/sort';
 
 const setUp = () => {
   jest
     .spyOn(window.navigator, 'userAgent', 'get')
     .mockReturnValue(UserAgent.macOS);
-};
-
-const makeResourceSpec = (
-  overrides: Partial<SelectResourceSpec> = {}
-): SelectResourceSpec => {
-  return Object.assign(
-    {
-      id: '',
-      name: '',
-      kind: ResourceKind.Application,
-      icon: '',
-      event: null,
-      keywords: [],
-      hasAccess: true,
-    },
-    overrides
-  );
 };
 
 /**
@@ -83,6 +88,10 @@ const onboardDiscoverNoResources: OnboardDiscover = {
   notified: true,
   hasVisited: false,
 };
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+});
 
 test('sortResourcesByPreferences without preferred resources, sorts resources alphabetically with guided resources first', () => {
   setUp();
@@ -117,121 +126,6 @@ test('sortResourcesByPreferences without preferred resources, sorts resources al
   ]);
 });
 
-const t_Application_NoAccess = makeResourceSpec({
-  name: 'tango',
-  kind: ResourceKind.Application,
-  hasAccess: false,
-});
-const u_Database_NoAccess = makeResourceSpec({
-  name: 'uniform',
-  kind: ResourceKind.Database,
-  hasAccess: false,
-});
-const v_Desktop_NoAccess = makeResourceSpec({
-  name: 'victor',
-  kind: ResourceKind.Desktop,
-  hasAccess: false,
-});
-const w_Kubernetes_NoAccess = makeResourceSpec({
-  name: 'whiskey',
-  kind: ResourceKind.Kubernetes,
-  hasAccess: false,
-});
-const x_Server_NoAccess = makeResourceSpec({
-  name: 'xray',
-  kind: ResourceKind.Server,
-  hasAccess: false,
-});
-const y_Saml_NoAccess = makeResourceSpec({
-  name: 'yankee',
-  kind: ResourceKind.SamlApplication,
-  hasAccess: false,
-});
-const z_Discovery_NoAccess = makeResourceSpec({
-  name: 'zulu',
-  kind: ResourceKind.Discovery,
-  hasAccess: false,
-});
-
-const NoAccessList: SelectResourceSpec[] = [
-  t_Application_NoAccess,
-  u_Database_NoAccess,
-  v_Desktop_NoAccess,
-  w_Kubernetes_NoAccess,
-  x_Server_NoAccess,
-  y_Saml_NoAccess,
-  z_Discovery_NoAccess,
-];
-
-const c_Application = makeResourceSpec({
-  name: 'charlie',
-  kind: ResourceKind.Application,
-});
-const a_Database = makeResourceSpec({
-  name: 'alpha',
-  kind: ResourceKind.Database,
-});
-const l_Desktop = makeResourceSpec({
-  name: 'linux',
-  kind: ResourceKind.Desktop,
-});
-const e_Kubernetes_unguided = makeResourceSpec({
-  name: 'echo',
-  kind: ResourceKind.Kubernetes,
-  unguidedLink: 'test.com',
-});
-const f_Server = makeResourceSpec({
-  name: 'foxtrot',
-  kind: ResourceKind.Server,
-});
-const d_Saml = makeResourceSpec({
-  name: 'delta',
-  kind: ResourceKind.SamlApplication,
-});
-const g_Application = makeResourceSpec({
-  name: 'golf',
-  kind: ResourceKind.Application,
-});
-const k_Database = makeResourceSpec({
-  name: 'kilo',
-  kind: ResourceKind.Database,
-});
-const i_Desktop = makeResourceSpec({
-  name: 'india',
-  kind: ResourceKind.Desktop,
-});
-const j_Kubernetes = makeResourceSpec({
-  name: 'juliette',
-  kind: ResourceKind.Kubernetes,
-});
-const h_Server = makeResourceSpec({ name: 'hotel', kind: ResourceKind.Server });
-const l_Saml = makeResourceSpec({
-  name: 'lima',
-  kind: ResourceKind.SamlApplication,
-});
-
-const kindBasedList: SelectResourceSpec[] = [
-  c_Application,
-  a_Database,
-  t_Application_NoAccess,
-  l_Desktop,
-  e_Kubernetes_unguided,
-  u_Database_NoAccess,
-  f_Server,
-  w_Kubernetes_NoAccess,
-  d_Saml,
-  v_Desktop_NoAccess,
-  g_Application,
-  x_Server_NoAccess,
-  k_Database,
-  i_Desktop,
-  z_Discovery_NoAccess,
-  j_Kubernetes,
-  h_Server,
-  y_Saml_NoAccess,
-  l_Saml,
-];
-
 describe('preferred resources', () => {
   beforeEach(() => {
     setUp();
@@ -250,16 +144,16 @@ describe('preferred resources', () => {
         f_Server,
         h_Server,
         // alpha; guided before unguided
-        a_Database,
-        c_Application,
+        a_DatabaseAws,
+        c_ApplicationGcp,
         d_Saml,
         g_Application,
         i_Desktop,
         j_Kubernetes,
         k_Database,
         l_Saml,
-        l_Desktop,
-        e_Kubernetes_unguided,
+        l_DesktopAzure,
+        e_KubernetesSelfHosted_unguided,
         // no access is last
         ...NoAccessList,
       ],
@@ -269,10 +163,10 @@ describe('preferred resources', () => {
       preferred: [Resource.DATABASES],
       expected: [
         // preferred first
-        a_Database,
+        a_DatabaseAws,
         k_Database,
         // alpha; guided before unguided
-        c_Application,
+        c_ApplicationGcp,
         d_Saml,
         f_Server,
         g_Application,
@@ -280,8 +174,8 @@ describe('preferred resources', () => {
         i_Desktop,
         j_Kubernetes,
         l_Saml,
-        l_Desktop,
-        e_Kubernetes_unguided,
+        l_DesktopAzure,
+        e_KubernetesSelfHosted_unguided,
         // no access is last
         ...NoAccessList,
       ],
@@ -292,10 +186,10 @@ describe('preferred resources', () => {
       expected: [
         // preferred first
         i_Desktop,
-        l_Desktop,
+        l_DesktopAzure,
         // alpha; guided before unguided
-        a_Database,
-        c_Application,
+        a_DatabaseAws,
+        c_ApplicationGcp,
         d_Saml,
         f_Server,
         g_Application,
@@ -303,7 +197,7 @@ describe('preferred resources', () => {
         j_Kubernetes,
         k_Database,
         l_Saml,
-        e_Kubernetes_unguided,
+        e_KubernetesSelfHosted_unguided,
         // no access is last
         ...NoAccessList,
       ],
@@ -313,10 +207,10 @@ describe('preferred resources', () => {
       preferred: [Resource.WEB_APPLICATIONS],
       expected: [
         // preferred first
-        c_Application,
+        c_ApplicationGcp,
         g_Application,
         // alpha; guided before unguided
-        a_Database,
+        a_DatabaseAws,
         d_Saml,
         f_Server,
         h_Server,
@@ -324,8 +218,8 @@ describe('preferred resources', () => {
         j_Kubernetes,
         k_Database,
         l_Saml,
-        l_Desktop,
-        e_Kubernetes_unguided,
+        l_DesktopAzure,
+        e_KubernetesSelfHosted_unguided,
         // no access is last
         ...NoAccessList,
       ],
@@ -336,10 +230,10 @@ describe('preferred resources', () => {
       expected: [
         // preferred first; guided before unguided
         j_Kubernetes,
-        e_Kubernetes_unguided,
+        e_KubernetesSelfHosted_unguided,
         // alpha
-        a_Database,
-        c_Application,
+        a_DatabaseAws,
+        c_ApplicationGcp,
         d_Saml,
         f_Server,
         g_Application,
@@ -347,7 +241,7 @@ describe('preferred resources', () => {
         i_Desktop,
         k_Database,
         l_Saml,
-        l_Desktop,
+        l_DesktopAzure,
         // no access is last
         ...NoAccessList,
       ],
@@ -391,10 +285,10 @@ describe('marketing params', () => {
       expected: [
         // marketing params first; no preferred priority, guided before unguided
         j_Kubernetes,
-        e_Kubernetes_unguided,
+        e_KubernetesSelfHosted_unguided,
         // alpha
-        a_Database,
-        c_Application,
+        a_DatabaseAws,
+        c_ApplicationGcp,
         d_Saml,
         f_Server,
         g_Application,
@@ -402,7 +296,7 @@ describe('marketing params', () => {
         i_Desktop,
         k_Database,
         l_Saml,
-        l_Desktop,
+        l_DesktopAzure,
         // no access is last
         ...NoAccessList,
       ],
@@ -423,16 +317,16 @@ describe('marketing params', () => {
         f_Server,
         h_Server,
         // alpha; guided before unguided
-        a_Database,
-        c_Application,
+        a_DatabaseAws,
+        c_ApplicationGcp,
         d_Saml,
         g_Application,
         i_Desktop,
         j_Kubernetes,
         k_Database,
         l_Saml,
-        l_Desktop,
-        e_Kubernetes_unguided,
+        l_DesktopAzure,
+        e_KubernetesSelfHosted_unguided,
         // no access is last
         ...NoAccessList,
       ],
@@ -450,10 +344,10 @@ describe('marketing params', () => {
       },
       expected: [
         // preferred first
-        a_Database,
+        a_DatabaseAws,
         k_Database,
         // alpha; guided before unguided
-        c_Application,
+        c_ApplicationGcp,
         d_Saml,
         f_Server,
         g_Application,
@@ -461,8 +355,8 @@ describe('marketing params', () => {
         i_Desktop,
         j_Kubernetes,
         l_Saml,
-        l_Desktop,
-        e_Kubernetes_unguided,
+        l_DesktopAzure,
+        e_KubernetesSelfHosted_unguided,
         // no access is last
         ...NoAccessList,
       ],
@@ -481,10 +375,10 @@ describe('marketing params', () => {
       expected: [
         // preferred first
         i_Desktop,
-        l_Desktop,
+        l_DesktopAzure,
         // alpha; guided before unguided
-        a_Database,
-        c_Application,
+        a_DatabaseAws,
+        c_ApplicationGcp,
         d_Saml,
         f_Server,
         g_Application,
@@ -492,7 +386,7 @@ describe('marketing params', () => {
         j_Kubernetes,
         k_Database,
         l_Saml,
-        e_Kubernetes_unguided,
+        e_KubernetesSelfHosted_unguided,
         // no access is last
         ...NoAccessList,
       ],
@@ -510,10 +404,10 @@ describe('marketing params', () => {
       },
       expected: [
         // preferred first
-        c_Application,
+        c_ApplicationGcp,
         g_Application,
         // alpha; guided before unguided
-        a_Database,
+        a_DatabaseAws,
         d_Saml,
         f_Server,
         h_Server,
@@ -521,8 +415,8 @@ describe('marketing params', () => {
         j_Kubernetes,
         k_Database,
         l_Saml,
-        l_Desktop,
-        e_Kubernetes_unguided,
+        l_DesktopAzure,
+        e_KubernetesSelfHosted_unguided,
         // no access is last
         ...NoAccessList,
       ],
@@ -541,10 +435,10 @@ describe('marketing params', () => {
       expected: [
         // preferred first; guided before unguided
         j_Kubernetes,
-        e_Kubernetes_unguided,
+        e_KubernetesSelfHosted_unguided,
         // alpha
-        a_Database,
-        c_Application,
+        a_DatabaseAws,
+        c_ApplicationGcp,
         d_Saml,
         f_Server,
         g_Application,
@@ -552,7 +446,7 @@ describe('marketing params', () => {
         i_Desktop,
         k_Database,
         l_Saml,
-        l_Desktop,
+        l_DesktopAzure,
         // no access is last
         ...NoAccessList,
       ],
@@ -1151,6 +1045,52 @@ test('displays an info banner if lacking "all" permissions to add resources', as
   });
 });
 
+test('add and remove pin, and rendering of default pins', async () => {
+  jest
+    .spyOn(window.navigator, 'userAgent', 'get')
+    .mockReturnValue(UserAgent.macOS);
+
+  const prefs = makeDefaultUserPreferences();
+  jest.spyOn(service, 'getUserPreferences').mockResolvedValue(prefs);
+  jest.spyOn(service, 'updateUserPreferences').mockResolvedValue(prefs);
+
+  render(
+    <MemoryRouter>
+      <ContextProvider ctx={createTeleportContext()}>
+        <UserContextProvider>
+          <SelectResource onSelect={() => {}} />
+        </UserContextProvider>
+      </ContextProvider>
+    </MemoryRouter>
+  );
+
+  await screen.findAllByTestId(/large-tile-/);
+
+  // Default pins on initial render with no preferences set.
+  let pinnedGuides = screen.queryAllByTestId(/large-tile-/);
+  expect(pinnedGuides).toHaveLength(defaultPins.length);
+
+  // Add pin.
+  let snowflakeGuide = screen.getByTestId(
+    getGuideTileId({ kind: ResourceKind.Database, title: 'snowflake' })
+  );
+  await userEvent.click(within(snowflakeGuide).getByTestId(/pin-button/i));
+  pinnedGuides = screen.queryAllByTestId(/large-tile-/);
+  expect(pinnedGuides).toHaveLength(defaultPins.length + 1);
+
+  // Remove pin.
+  snowflakeGuide = screen.getByTestId(
+    getGuideTileId({
+      kind: ResourceKind.Database,
+      title: 'snowflake',
+      size: 'large',
+    })
+  );
+  await userEvent.click(within(snowflakeGuide).getByTestId(/pin-button/i));
+  pinnedGuides = screen.queryAllByTestId(/large-tile-/);
+  expect(pinnedGuides).toHaveLength(defaultPins.length);
+});
+
 test('does not display erorr banner if user has "some" permissions to add', async () => {
   jest.spyOn(userUserContext, 'useUser').mockReturnValue({
     preferences: makeDefaultUserPreferences(),
@@ -1175,7 +1115,7 @@ test('does not display erorr banner if user has "some" permissions to add', asyn
   ).not.toBeInTheDocument();
 });
 
-describe('filterResources', () => {
+describe('filterBySupportedPlatformsAndAuthTypes', () => {
   it('filters out resources based on supportedPlatforms', () => {
     const winAndLinux = makeResourceSpec({
       name: 'Filtered out with many supported platforms',

--- a/web/packages/teleport/src/Discover/SelectResource/SelectResource.test.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/SelectResource.test.tsx
@@ -1025,6 +1025,7 @@ test('displays an info banner if lacking "all" permissions to add resources', as
     updatePreferences: () => null,
     updateClusterPinnedResources: () => null,
     getClusterPinnedResources: () => null,
+    updateDiscoverResourcePreferences: () => null,
   });
 
   const ctx = createTeleportContext();
@@ -1097,6 +1098,7 @@ test('does not display erorr banner if user has "some" permissions to add', asyn
     updatePreferences: () => null,
     updateClusterPinnedResources: () => null,
     getClusterPinnedResources: () => null,
+    updateDiscoverResourcePreferences: () => null,
   });
 
   const ctx = createTeleportContext();

--- a/web/packages/teleport/src/Discover/SelectResource/icons.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/icons.tsx
@@ -20,8 +20,11 @@ import { ResourceIcon, ResourceIconName } from 'design/ResourceIcon';
 
 interface DiscoverIconProps {
   name: ResourceIconName;
+  size?: 'large' | 'small';
 }
 
-export const DiscoverIcon = ({ name }: DiscoverIconProps) => (
-  <ResourceIcon name={name} width="23.9px" height="24px" />
-);
+export const DiscoverIcon = ({ name, size = 'small' }: DiscoverIconProps) => {
+  const width = size === 'small' ? '23.9px' : '72';
+  const height = size === 'small' ? '24px' : '72';
+  return <ResourceIcon name={name} width={width} height={height} />;
+};

--- a/web/packages/teleport/src/Discover/SelectResource/resources/databases.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/resources/databases.tsx
@@ -22,19 +22,16 @@ import { DbProtocol } from 'shared/services/databases';
 import { DiscoverEventResource } from 'teleport/services/userEvent';
 import { DiscoverGuideId } from 'teleport/services/userPreferences/discoverPreference';
 
+import { SelectResourceSpec } from '.';
 import { ResourceKind } from '../../Shared/ResourceKind';
 import { DatabaseEngine, DatabaseLocation } from '../types';
-import { SelectResourceSpec } from './resources';
-
-const baseDatabaseKeywords = ['db', 'database', 'databases'];
-const awsKeywords = [...baseDatabaseKeywords, 'aws', 'amazon web services'];
-const gcpKeywords = [...baseDatabaseKeywords, 'gcp', 'google cloud platform'];
-const selfhostedKeywords = [
-  ...baseDatabaseKeywords,
-  'self hosted',
-  'self-hosted',
-];
-const azureKeywords = [...baseDatabaseKeywords, 'microsoft azure'];
+import {
+  awsDatabaseKeywords,
+  azureKeywords,
+  baseDatabaseKeywords,
+  gcpKeywords,
+  selfHostedDatabaseKeywords,
+} from './keywords';
 
 // DATABASES_UNGUIDED_DOC are documentations that is not specific
 // to one type of database.
@@ -43,7 +40,7 @@ export const DATABASES_UNGUIDED_DOC: SelectResourceSpec[] = [
     id: DiscoverGuideId.DatabaseAwsRdsProxyPostgres,
     dbMeta: { location: DatabaseLocation.Aws, engine: DatabaseEngine.Doc },
     name: 'RDS Proxy PostgreSQL',
-    keywords: [...awsKeywords, 'rds', 'proxy', 'postgresql'],
+    keywords: [...awsDatabaseKeywords, 'rds', 'proxy', 'postgresql'],
     kind: ResourceKind.Database,
     icon: 'aws',
     unguidedLink:
@@ -55,7 +52,13 @@ export const DATABASES_UNGUIDED_DOC: SelectResourceSpec[] = [
     id: DiscoverGuideId.DatabaseAwsRdsProxySqlServer,
     dbMeta: { location: DatabaseLocation.Aws, engine: DatabaseEngine.Doc },
     name: 'RDS Proxy SQL Server',
-    keywords: [...awsKeywords, 'rds', 'proxy', 'sql server', 'sqlserver'],
+    keywords: [
+      ...awsDatabaseKeywords,
+      'rds',
+      'proxy',
+      'sql server',
+      'sqlserver',
+    ],
     kind: ResourceKind.Database,
     icon: 'aws',
     unguidedLink:
@@ -67,7 +70,7 @@ export const DATABASES_UNGUIDED_DOC: SelectResourceSpec[] = [
     id: DiscoverGuideId.DatabaseAwsRdsProxyMariaMySql,
     dbMeta: { location: DatabaseLocation.Aws, engine: DatabaseEngine.Doc },
     name: 'RDS Proxy MariaDB/MySQL',
-    keywords: [...awsKeywords, 'rds', 'proxy', 'mariadb', 'mysql'],
+    keywords: [...awsDatabaseKeywords, 'rds', 'proxy', 'mariadb', 'mysql'],
     kind: ResourceKind.Database,
     icon: 'aws',
     unguidedLink:
@@ -104,7 +107,7 @@ export const DATABASES_UNGUIDED: SelectResourceSpec[] = [
     id: DiscoverGuideId.DatabaseAwsDynamoDb,
     dbMeta: { location: DatabaseLocation.Aws, engine: DatabaseEngine.DynamoDb },
     name: 'DynamoDB',
-    keywords: [...awsKeywords, 'dynamodb'],
+    keywords: [...awsDatabaseKeywords, 'dynamodb'],
     kind: ResourceKind.Database,
     icon: 'dynamo',
     unguidedLink:
@@ -115,7 +118,7 @@ export const DATABASES_UNGUIDED: SelectResourceSpec[] = [
     id: DiscoverGuideId.DatabaseAwsElastiCacheMemoryDb,
     dbMeta: { location: DatabaseLocation.Aws, engine: DatabaseEngine.Redis },
     name: 'ElastiCache & MemoryDB',
-    keywords: [...awsKeywords, 'elasticache', 'memorydb', 'redis'],
+    keywords: [...awsDatabaseKeywords, 'elasticache', 'memorydb', 'redis'],
     kind: ResourceKind.Database,
     icon: 'aws',
     unguidedLink:
@@ -129,7 +132,7 @@ export const DATABASES_UNGUIDED: SelectResourceSpec[] = [
       engine: DatabaseEngine.Cassandra,
     },
     name: 'Keyspaces (Apache Cassandra)',
-    keywords: [...awsKeywords, 'keyspaces', 'apache', 'cassandra'],
+    keywords: [...awsDatabaseKeywords, 'keyspaces', 'apache', 'cassandra'],
     kind: ResourceKind.Database,
     icon: 'aws',
     unguidedLink:
@@ -140,7 +143,7 @@ export const DATABASES_UNGUIDED: SelectResourceSpec[] = [
     id: DiscoverGuideId.DatabaseAwsPostgresRedshift,
     dbMeta: { location: DatabaseLocation.Aws, engine: DatabaseEngine.Redshift },
     name: 'Redshift PostgreSQL',
-    keywords: [...awsKeywords, 'redshift', 'postgresql'],
+    keywords: [...awsDatabaseKeywords, 'redshift', 'postgresql'],
     kind: ResourceKind.Database,
     icon: 'redshift',
     unguidedLink:
@@ -151,7 +154,7 @@ export const DATABASES_UNGUIDED: SelectResourceSpec[] = [
     id: DiscoverGuideId.DatabaseAwsRedshiftServerless,
     dbMeta: { location: DatabaseLocation.Aws, engine: DatabaseEngine.Redshift },
     name: 'Redshift Serverless',
-    keywords: [...awsKeywords, 'redshift', 'serverless', 'postgresql'],
+    keywords: [...awsDatabaseKeywords, 'redshift', 'serverless', 'postgresql'],
     kind: ResourceKind.Database,
     icon: 'redshift',
     unguidedLink:
@@ -224,7 +227,7 @@ export const DATABASES_UNGUIDED: SelectResourceSpec[] = [
     },
     name: 'RDS SQL Server',
     keywords: [
-      ...awsKeywords,
+      ...awsDatabaseKeywords,
       'rds',
       'microsoft',
       'active directory',
@@ -283,7 +286,7 @@ export const DATABASES_UNGUIDED: SelectResourceSpec[] = [
       engine: DatabaseEngine.Cassandra,
     },
     name: 'Cassandra & ScyllaDB',
-    keywords: [...selfhostedKeywords, 'cassandra scylladb'],
+    keywords: [...selfHostedDatabaseKeywords, 'cassandra scylladb'],
     kind: ResourceKind.Database,
     icon: 'selfhosted',
     unguidedLink:
@@ -297,7 +300,7 @@ export const DATABASES_UNGUIDED: SelectResourceSpec[] = [
       engine: DatabaseEngine.CockroachDb,
     },
     name: 'CockroachDB',
-    keywords: [...selfhostedKeywords, 'cockroachdb'],
+    keywords: [...selfHostedDatabaseKeywords, 'cockroachdb'],
     kind: ResourceKind.Database,
     icon: 'cockroach',
     unguidedLink:
@@ -311,7 +314,7 @@ export const DATABASES_UNGUIDED: SelectResourceSpec[] = [
       engine: DatabaseEngine.ElasticSearch,
     },
     name: 'Elasticsearch',
-    keywords: [...selfhostedKeywords, 'elasticsearch', 'es'],
+    keywords: [...selfHostedDatabaseKeywords, 'elasticsearch', 'es'],
     kind: ResourceKind.Database,
     icon: 'selfhosted',
     unguidedLink:
@@ -325,7 +328,7 @@ export const DATABASES_UNGUIDED: SelectResourceSpec[] = [
       engine: DatabaseEngine.MongoDb,
     },
     name: 'MongoDB',
-    keywords: [...selfhostedKeywords, 'mongodb'],
+    keywords: [...selfHostedDatabaseKeywords, 'mongodb'],
     kind: ResourceKind.Database,
     icon: 'mongo',
     unguidedLink:
@@ -339,7 +342,7 @@ export const DATABASES_UNGUIDED: SelectResourceSpec[] = [
       engine: DatabaseEngine.Redis,
     },
     name: 'Redis',
-    keywords: [...selfhostedKeywords, 'redis'],
+    keywords: [...selfHostedDatabaseKeywords, 'redis'],
     kind: ResourceKind.Database,
     icon: 'selfhosted',
     unguidedLink:
@@ -353,7 +356,7 @@ export const DATABASES_UNGUIDED: SelectResourceSpec[] = [
       engine: DatabaseEngine.Redis,
     },
     name: 'Redis Cluster',
-    keywords: [...selfhostedKeywords, 'redis cluster'],
+    keywords: [...selfHostedDatabaseKeywords, 'redis cluster'],
     kind: ResourceKind.Database,
     icon: 'selfhosted',
     unguidedLink:
@@ -384,7 +387,7 @@ export const DATABASES: SelectResourceSpec[] = [
       engine: DatabaseEngine.Postgres,
     },
     name: 'RDS PostgreSQL',
-    keywords: [...awsKeywords, 'rds postgresql'],
+    keywords: [...awsDatabaseKeywords, 'rds postgresql'],
     kind: ResourceKind.Database,
     icon: 'aws',
     event: DiscoverEventResource.DatabasePostgresRds,
@@ -396,7 +399,7 @@ export const DATABASES: SelectResourceSpec[] = [
       engine: DatabaseEngine.AuroraPostgres,
     },
     name: 'RDS Aurora PostgreSQL',
-    keywords: [...awsKeywords, 'rds aurora postgresql'],
+    keywords: [...awsDatabaseKeywords, 'rds aurora postgresql'],
     kind: ResourceKind.Database,
     icon: 'aws',
     event: DiscoverEventResource.DatabasePostgresRds,
@@ -405,7 +408,7 @@ export const DATABASES: SelectResourceSpec[] = [
     id: DiscoverGuideId.DatabaseAwsRdsMysqlMariaDb,
     dbMeta: { location: DatabaseLocation.Aws, engine: DatabaseEngine.MySql },
     name: 'RDS MySQL/MariaDB',
-    keywords: [...awsKeywords, 'rds mysql mariadb'],
+    keywords: [...awsDatabaseKeywords, 'rds mysql mariadb'],
     kind: ResourceKind.Database,
     icon: 'aws',
     event: DiscoverEventResource.DatabaseMysqlRds,
@@ -417,7 +420,7 @@ export const DATABASES: SelectResourceSpec[] = [
       engine: DatabaseEngine.AuroraMysql,
     },
     name: 'RDS Aurora MySQL',
-    keywords: [...awsKeywords, 'rds aurora mysql'],
+    keywords: [...awsDatabaseKeywords, 'rds aurora mysql'],
     kind: ResourceKind.Database,
     icon: 'aws',
     event: DiscoverEventResource.DatabaseMysqlRds,
@@ -429,7 +432,7 @@ export const DATABASES: SelectResourceSpec[] = [
       engine: DatabaseEngine.Postgres,
     },
     name: 'PostgreSQL',
-    keywords: [...selfhostedKeywords, 'postgresql'],
+    keywords: [...selfHostedDatabaseKeywords, 'postgresql'],
     kind: ResourceKind.Database,
     icon: 'postgres',
     event: DiscoverEventResource.DatabasePostgresSelfHosted,
@@ -441,7 +444,7 @@ export const DATABASES: SelectResourceSpec[] = [
       engine: DatabaseEngine.MySql,
     },
     name: 'MySQL/MariaDB',
-    keywords: [...selfhostedKeywords, 'mysql mariadb'],
+    keywords: [...selfHostedDatabaseKeywords, 'mysql mariadb'],
     kind: ResourceKind.Database,
     icon: 'selfhosted',
     event: DiscoverEventResource.DatabaseMysqlSelfHosted,

--- a/web/packages/teleport/src/Discover/SelectResource/resources/keywords.ts
+++ b/web/packages/teleport/src/Discover/SelectResource/resources/keywords.ts
@@ -16,15 +16,20 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ResourceIcon, ResourceIconName } from 'design/ResourceIcon';
+export const baseServerKeywords = ['server', 'node', 'ssh'];
+export const awsKeywords = ['aws', 'amazon', 'amazon web services'];
+export const kubeKeywords = ['kubernetes', 'k8s', 'kubes', 'cluster'];
+export const selfHostedKeywords = ['self hosted', 'self-hosted'];
 
-interface DiscoverIconProps {
-  name: ResourceIconName;
-  size?: 'large' | 'small';
-}
-
-export const DiscoverIcon = ({ name, size = 'small' }: DiscoverIconProps) => {
-  const width = size === 'small' ? '24px' : '72';
-  const height = size === 'small' ? '24px' : '72';
-  return <ResourceIcon name={name} width={width} height={height} />;
-};
+export const baseDatabaseKeywords = ['db', 'database', 'databases'];
+export const awsDatabaseKeywords = [...baseDatabaseKeywords, ...awsKeywords];
+export const gcpKeywords = [
+  ...baseDatabaseKeywords,
+  'gcp',
+  'google cloud platform',
+];
+export const selfHostedDatabaseKeywords = [
+  ...baseDatabaseKeywords,
+  ...selfHostedKeywords,
+];
+export const azureKeywords = [...baseDatabaseKeywords, 'microsoft azure'];

--- a/web/packages/teleport/src/Discover/SelectResource/resources/resources.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/resources/resources.tsx
@@ -38,18 +38,12 @@ import {
   DATABASES_UNGUIDED,
   DATABASES_UNGUIDED_DOC,
 } from './databases';
-
-export type SelectResourceSpec = ResourceSpec & {
-  id: DiscoverGuideId;
-  /**
-   * true if user pinned this guide
-   */
-  pinned?: boolean;
-};
-
-const baseServerKeywords = ['server', 'node', 'ssh'];
-const awsKeywords = ['aws', 'amazon', 'amazon web services'];
-const kubeKeywords = ['kubernetes', 'k8s', 'kubes', 'cluster'];
+import {
+  awsKeywords,
+  baseServerKeywords,
+  kubeKeywords,
+  selfHostedKeywords,
+} from './keywords';
 
 export const SERVERS: SelectResourceSpec[] = [
   {
@@ -192,7 +186,7 @@ export const KUBERNETES: SelectResourceSpec[] = [
     id: DiscoverGuideId.Kubernetes,
     name: 'Kubernetes',
     kind: ResourceKind.Kubernetes,
-    keywords: [...kubeKeywords],
+    keywords: [...kubeKeywords, ...selfHostedKeywords],
     icon: 'kube',
     event: DiscoverEventResource.Kubernetes,
     kubeMeta: { location: KubeLocation.SelfHosted },
@@ -293,3 +287,7 @@ export function getResourcePretitle(r: SelectResourceSpec) {
 
   return '';
 }
+
+export type SelectResourceSpec = ResourceSpec & {
+  id: DiscoverGuideId;
+};

--- a/web/packages/teleport/src/Discover/SelectResource/resources/resourcesE.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/resources/resourcesE.tsx
@@ -20,8 +20,8 @@ import { SamlServiceProviderPreset } from 'teleport/services/samlidp/types';
 import { DiscoverEventResource } from 'teleport/services/userEvent';
 import { DiscoverGuideId } from 'teleport/services/userPreferences/discoverPreference';
 
+import { SelectResourceSpec } from '.';
 import { ResourceKind } from '../../Shared';
-import { SelectResourceSpec } from './resources';
 
 export const SAML_APPLICATIONS: SelectResourceSpec[] = [
   {

--- a/web/packages/teleport/src/Discover/SelectResource/testUtils.ts
+++ b/web/packages/teleport/src/Discover/SelectResource/testUtils.ts
@@ -1,0 +1,159 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ResourceKind } from '../Shared';
+import { SelectResourceSpec } from './resources';
+
+export const makeResourceSpec = (
+  overrides: Partial<SelectResourceSpec> = {}
+): SelectResourceSpec => {
+  return Object.assign(
+    {
+      id: '',
+      name: '',
+      kind: ResourceKind.Application,
+      icon: '',
+      event: null,
+      keywords: [],
+      hasAccess: true,
+    },
+    overrides
+  );
+};
+
+export const t_Application_NoAccess = makeResourceSpec({
+  name: 'tango',
+  kind: ResourceKind.Application,
+  hasAccess: false,
+});
+export const u_Database_NoAccess = makeResourceSpec({
+  name: 'uniform',
+  kind: ResourceKind.Database,
+  hasAccess: false,
+});
+export const v_Desktop_NoAccess = makeResourceSpec({
+  name: 'victor',
+  kind: ResourceKind.Desktop,
+  hasAccess: false,
+});
+export const w_Kubernetes_NoAccess = makeResourceSpec({
+  name: 'whiskey',
+  kind: ResourceKind.Kubernetes,
+  hasAccess: false,
+});
+export const x_Server_NoAccess = makeResourceSpec({
+  name: 'xray',
+  kind: ResourceKind.Server,
+  hasAccess: false,
+});
+export const y_Saml_NoAccess = makeResourceSpec({
+  name: 'yankee',
+  kind: ResourceKind.SamlApplication,
+  hasAccess: false,
+});
+export const z_Discovery_NoAccess = makeResourceSpec({
+  name: 'zulu',
+  kind: ResourceKind.Discovery,
+  hasAccess: false,
+});
+
+export const NoAccessList: SelectResourceSpec[] = [
+  t_Application_NoAccess,
+  u_Database_NoAccess,
+  v_Desktop_NoAccess,
+  w_Kubernetes_NoAccess,
+  x_Server_NoAccess,
+  y_Saml_NoAccess,
+  z_Discovery_NoAccess,
+];
+
+export const c_ApplicationGcp = makeResourceSpec({
+  name: 'charlie',
+  kind: ResourceKind.Application,
+  keywords: ['gcp'],
+});
+export const a_DatabaseAws = makeResourceSpec({
+  name: 'alpha',
+  kind: ResourceKind.Database,
+  keywords: ['aws'],
+});
+export const l_DesktopAzure = makeResourceSpec({
+  name: 'linux',
+  kind: ResourceKind.Desktop,
+  keywords: ['azure'],
+});
+export const e_KubernetesSelfHosted_unguided = makeResourceSpec({
+  name: 'echo',
+  kind: ResourceKind.Kubernetes,
+  unguidedLink: 'test.com',
+  keywords: ['self-hosted'],
+});
+export const f_Server = makeResourceSpec({
+  name: 'foxtrot',
+  kind: ResourceKind.Server,
+});
+export const d_Saml = makeResourceSpec({
+  name: 'delta',
+  kind: ResourceKind.SamlApplication,
+});
+export const g_Application = makeResourceSpec({
+  name: 'golf',
+  kind: ResourceKind.Application,
+});
+export const k_Database = makeResourceSpec({
+  name: 'kilo',
+  kind: ResourceKind.Database,
+});
+export const i_Desktop = makeResourceSpec({
+  name: 'india',
+  kind: ResourceKind.Desktop,
+});
+export const j_Kubernetes = makeResourceSpec({
+  name: 'juliette',
+  kind: ResourceKind.Kubernetes,
+});
+export const h_Server = makeResourceSpec({
+  name: 'hotel',
+  kind: ResourceKind.Server,
+});
+export const l_Saml = makeResourceSpec({
+  name: 'lima',
+  kind: ResourceKind.SamlApplication,
+});
+
+export const kindBasedList: SelectResourceSpec[] = [
+  c_ApplicationGcp,
+  a_DatabaseAws,
+  t_Application_NoAccess,
+  l_DesktopAzure,
+  e_KubernetesSelfHosted_unguided,
+  u_Database_NoAccess,
+  f_Server,
+  w_Kubernetes_NoAccess,
+  d_Saml,
+  v_Desktop_NoAccess,
+  g_Application,
+  x_Server_NoAccess,
+  k_Database,
+  i_Desktop,
+  z_Discovery_NoAccess,
+  j_Kubernetes,
+  h_Server,
+  y_Saml_NoAccess,
+  l_Saml,
+];

--- a/web/packages/teleport/src/Discover/SelectResource/utils/filters.test.ts
+++ b/web/packages/teleport/src/Discover/SelectResource/utils/filters.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { SelectResourceSpec } from '../resources';
+import {
+  a_DatabaseAws,
+  c_ApplicationGcp,
+  e_KubernetesSelfHosted_unguided,
+  f_Server,
+  l_DesktopAzure,
+  t_Application_NoAccess,
+} from '../testUtils';
+import { filterResources, Filters } from './filters';
+
+const resources: SelectResourceSpec[] = [
+  c_ApplicationGcp,
+  t_Application_NoAccess,
+  a_DatabaseAws,
+  l_DesktopAzure,
+  e_KubernetesSelfHosted_unguided,
+  f_Server,
+];
+
+describe('filters by resource types', () => {
+  const testCases: {
+    name: string;
+    filter: Filters;
+    expected: SelectResourceSpec[];
+  }[] = [
+    {
+      name: 'no filter',
+      filter: { resourceTypes: [], hostingPlatforms: [] },
+      expected: resources,
+    },
+    {
+      name: 'filter by application',
+      filter: { resourceTypes: ['app'], hostingPlatforms: [] },
+      expected: [c_ApplicationGcp, t_Application_NoAccess],
+    },
+    {
+      name: 'filter by database',
+      filter: { resourceTypes: ['db'], hostingPlatforms: [] },
+      expected: [a_DatabaseAws],
+    },
+    {
+      name: 'filter by desktop',
+      filter: { resourceTypes: ['desktops'], hostingPlatforms: [] },
+      expected: [l_DesktopAzure],
+    },
+    {
+      name: 'filter by kuberenetes',
+      filter: { resourceTypes: ['kube'], hostingPlatforms: [] },
+      expected: [e_KubernetesSelfHosted_unguided],
+    },
+    {
+      name: 'filter by server',
+      filter: { resourceTypes: ['server'], hostingPlatforms: [] },
+      expected: [f_Server],
+    },
+    {
+      name: 'filter by server and app',
+      filter: { resourceTypes: ['app', 'server'], hostingPlatforms: [] },
+      expected: [c_ApplicationGcp, t_Application_NoAccess, f_Server],
+    },
+  ];
+  test.each(testCases)('$name', tc => {
+    expect(filterResources(resources, tc.filter)).toEqual(tc.expected);
+  });
+});
+
+describe('filters by hosting platform', () => {
+  const testCases: {
+    name: string;
+    filter: Filters;
+    expected: SelectResourceSpec[];
+  }[] = [
+    {
+      name: 'no filter',
+      filter: { resourceTypes: [], hostingPlatforms: [] },
+      expected: resources,
+    },
+    {
+      name: 'filter by aws',
+      filter: { resourceTypes: [], hostingPlatforms: ['aws'] },
+      expected: [a_DatabaseAws],
+    },
+    {
+      name: 'filter by azure',
+      filter: { resourceTypes: [], hostingPlatforms: ['azure'] },
+      expected: [l_DesktopAzure],
+    },
+    {
+      name: 'filter by gcp',
+      filter: { resourceTypes: [], hostingPlatforms: ['gcp'] },
+      expected: [c_ApplicationGcp],
+    },
+    {
+      name: 'filter by self-hosted',
+      filter: { resourceTypes: [], hostingPlatforms: ['self-hosted'] },
+      expected: [e_KubernetesSelfHosted_unguided],
+    },
+    {
+      name: 'filter by aws and azure',
+      filter: { resourceTypes: [], hostingPlatforms: ['aws', 'azure'] },
+      expected: [a_DatabaseAws, l_DesktopAzure],
+    },
+  ];
+  test.each(testCases)('$name', tc => {
+    expect(filterResources(resources, tc.filter)).toEqual(tc.expected);
+  });
+});
+
+describe('filters by resource types and hosting platform', () => {
+  const testCases: {
+    name: string;
+    filter: Filters;
+    expected: SelectResourceSpec[];
+  }[] = [
+    {
+      name: 'no results found',
+      filter: { resourceTypes: ['app'], hostingPlatforms: ['aws'] },
+      expected: [],
+    },
+    {
+      name: 'filter by app and gcp',
+      filter: { resourceTypes: ['app'], hostingPlatforms: ['gcp'] },
+      expected: [c_ApplicationGcp],
+    },
+    {
+      name: 'filter by app, kube and self-hosted',
+      filter: {
+        resourceTypes: ['app', 'kube'],
+        hostingPlatforms: ['self-hosted'],
+      },
+      expected: [e_KubernetesSelfHosted_unguided],
+    },
+  ];
+  test.each(testCases)('$name', tc => {
+    expect(filterResources(resources, tc.filter)).toEqual(tc.expected);
+  });
+});

--- a/web/packages/teleport/src/Discover/SelectResource/utils/pins.ts
+++ b/web/packages/teleport/src/Discover/SelectResource/utils/pins.ts
@@ -1,0 +1,57 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { UserPreferences } from 'gen-proto-ts/teleport/userpreferences/v1/userpreferences_pb';
+
+import { DiscoverGuideId } from 'teleport/services/userPreferences/discoverPreference';
+
+import { SelectResourceSpec } from '../resources';
+
+export const defaultPins = [
+  DiscoverGuideId.ConnectMyComputer,
+  DiscoverGuideId.Kubernetes,
+  DiscoverGuideId.ApplicationWebHttpProxy,
+  // TODO(kimlisa): add linux server, once they are all consolidated into one
+];
+
+/**
+ * Only returns the defaults of resources that is available to the user.
+ */
+export function getDefaultPins(availableResources: SelectResourceSpec[]) {
+  return availableResources
+    .filter(r => defaultPins.includes(r.id))
+    .map(r => r.id);
+}
+
+/**
+ * Returns pins from preference if any or default pins.
+ */
+export function getPins(preferences: DiscoverResourcePreference) {
+  if (!preferences.discoverResourcePreferences) {
+    return [];
+  }
+
+  if (!preferences.discoverResourcePreferences.discoverGuide) {
+    return defaultPins;
+  }
+
+  return preferences.discoverResourcePreferences.discoverGuide.pinned || [];
+}
+
+export type DiscoverResourcePreference = Partial<
+  Pick<UserPreferences, 'discoverResourcePreferences'>
+>;

--- a/web/packages/teleport/src/Discover/testUtils.ts
+++ b/web/packages/teleport/src/Discover/testUtils.ts
@@ -1,6 +1,6 @@
 /**
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2025  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,15 +16,19 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ResourceIcon, ResourceIconName } from 'design/ResourceIcon';
+import { Size } from './SelectResource/Tile';
+import { ResourceKind } from './Shared';
 
-interface DiscoverIconProps {
-  name: ResourceIconName;
-  size?: 'large' | 'small';
+export function getGuideTileId({
+  kind,
+  title,
+  size = 'regular',
+}: {
+  kind: ResourceKind;
+  title?: string;
+  size?: Size;
+}) {
+  const base = `${size}-tile-${kind}`;
+
+  return new RegExp(title ? `${base}-${title}` : base, 'i');
 }
-
-export const DiscoverIcon = ({ name, size = 'small' }: DiscoverIconProps) => {
-  const width = size === 'small' ? '24px' : '72';
-  const height = size === 'small' ? '24px' : '72';
-  return <ResourceIcon name={name} width={width} height={height} />;
-};

--- a/web/packages/teleport/src/User/UserContext.tsx
+++ b/web/packages/teleport/src/User/UserContext.tsx
@@ -32,6 +32,7 @@ import { UserPreferences } from 'gen-proto-ts/teleport/userpreferences/v1/userpr
 import useAttempt from 'shared/hooks/useAttemptNext';
 
 import cfg from 'teleport/config';
+import { DiscoverResourcePreference } from 'teleport/Discover/SelectResource/utils/pins';
 import { StyledIndicator } from 'teleport/Main';
 import { KeysEnum, storageService } from 'teleport/services/storageService';
 import * as service from 'teleport/services/userPreferences';
@@ -39,6 +40,9 @@ import { makeDefaultUserPreferences } from 'teleport/services/userPreferences/us
 
 export interface UserContextValue {
   preferences: UserPreferences;
+  updateDiscoverResourcePreferences: (
+    preferences: Partial<DiscoverResourcePreference>
+  ) => Promise<void>;
   updatePreferences: (preferences: Partial<UserPreferences>) => Promise<void>;
   updateClusterPinnedResources: (
     clusterId: string,
@@ -93,6 +97,20 @@ export function UserContextProvider(props: PropsWithChildren<unknown>) {
     });
   };
 
+  const updateDiscoverResourcePreferences = async (
+    discoverResourcePreferences: Partial<DiscoverResourcePreference>
+  ) => {
+    const nextPreferences: UserPreferences = {
+      ...preferences,
+      ...discoverResourcePreferences,
+    };
+
+    return service.updateUserPreferences(nextPreferences).then(() => {
+      setPreferences(nextPreferences);
+      storageService.setUserPreferences(nextPreferences);
+    });
+  };
+
   async function loadUserPreferences() {
     const storedPreferences = storageService.getUserPreferences();
 
@@ -132,6 +150,7 @@ export function UserContextProvider(props: PropsWithChildren<unknown>) {
         ...newPreferences.accessGraph,
       },
     } as UserPreferences;
+
     setPreferences(nextPreferences);
     storageService.setUserPreferences(nextPreferences);
 
@@ -171,6 +190,7 @@ export function UserContextProvider(props: PropsWithChildren<unknown>) {
         updatePreferences,
         getClusterPinnedResources,
         updateClusterPinnedResources,
+        updateDiscoverResourcePreferences,
       }}
     >
       {props.children}

--- a/web/packages/teleport/src/User/testHelpers/makeTestUserContext.ts
+++ b/web/packages/teleport/src/User/testHelpers/makeTestUserContext.ts
@@ -38,6 +38,7 @@ export const makeTestUserContext = (
       updatePreferences: () => Promise.resolve(),
       updateClusterPinnedResources: () => Promise.resolve(),
       getClusterPinnedResources: () => Promise.resolve(),
+      updateDiscoverResourcePreferences: () => Promise.resolve(),
     },
     overrides
   );

--- a/web/packages/teleport/src/services/userPreferences/userPreferences.ts
+++ b/web/packages/teleport/src/services/userPreferences/userPreferences.ts
@@ -101,6 +101,7 @@ export function makeDefaultUserPreferences(): UserPreferences {
     },
     clusterPreferences: makeDefaultUserClusterPreferences(),
     sideNavDrawerMode: SideNavDrawerMode.COLLAPSED,
+    discoverResourcePreferences: {},
   };
 }
 


### PR DESCRIPTION
[RFD](https://github.com/gravitational/teleport/blob/b8ace0885f859248e0004ab84eb499a62dbcbd4f/rfd/0187-redesign-enroll-new-resource-page.md) that also links to figma

- [ ] requires https://github.com/gravitational/teleport/pull/52017

- converted search bar to be `type and enter` like it is everywhere else
- added filter dropdowns to filter by `resource kind` and `hosting platform`
- added pinning support where users can pin any guides and it will be saved in user preference
  - if user initially had no pin preferences, it'll render `default pins`

play with filter in story: https://localhost:9002/?path=/story/teleport-discover-selectresource--all-access

demo:

~~double checking if that's the intended behavior (where it resets to default if you remove all pins)~~

https://github.com/user-attachments/assets/8ad78430-c0bc-4ed7-9758-02ed92c5861e

changelog: Add filter drop-downs and pinning support for the "Enroll a New Resource" page in the web UI

TODO in another PR:
- consolidate linux tiles into one, and add them as part of default pins
- add URL query param support and remove the use of `url loc state`
- add responsiveness (remove the 1000 min width requirement)