### PR TITLE
Applying include file to the crown jewels page

### DIFF
--- a/docs/pages/admin-guides/teleport-policy/crown-jewels.mdx
+++ b/docs/pages/admin-guides/teleport-policy/crown-jewels.mdx
@@ -27,9 +27,7 @@ log in via Teleport Auth Connectors.
 Check [Access Graph page](teleport-policy.mdx) for details on
 how to set up Access Graph.
 
-Access Graph is a feature of the [Teleport Policy](https://goteleport.com/platform/policy/) product available to Teleport Enterprise edition customers.
-
-To verify the availability of the Access Graph, ensure that the Policy icon is present in the navigation sidebar.
+(!docs/pages/includes/policy/access-graph.mdx!)
 
 ## Required RBAC permissions
 


### PR DESCRIPTION
Noticed that the include file wasn't used on this particular page while back-porting the Azure integration docs to v17 https://github.com/gravitational/teleport/pull/51894. Applying this change to the latest docs as well.