### PR TITLE
[v15] `tbot` Helm Chart: Add ability to configure securityContext (#51817)

### DIFF
--- a/docs/pages/includes/helm-reference/zz_generated.tbot.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.tbot.mdx
@@ -433,3 +433,15 @@ extraEnv:
   - name: HTTPS_PROXY
     value: "http://username:password@my.proxy.host:3128"
 ```
+
+## `securityContext`
+
+| Type | Default |
+|------|---------|
+| `object` | `null` |
+
+`securityContext` sets the container security context for any pods created by the chart.
+See [the Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
+for more details.
+
+By default, this is unset.

--- a/examples/chart/tbot/.lint/full.yaml
+++ b/examples/chart/tbot/.lint/full.yaml
@@ -98,3 +98,14 @@ extraArgs:
 extraEnv:
   - name: "TEST_ENV"
     value: "test-value"
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 9807
+  seccompProfile:
+    type: RuntimeDefault

--- a/examples/chart/tbot/templates/deployment.yaml
+++ b/examples/chart/tbot/templates/deployment.yaml
@@ -102,6 +102,9 @@ spec:
         {{- if .Values.resources }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
         {{- end }}
+        {{- if .Values.securityContext }}
+          securityContext: {{- toYaml .Values.securityContext | nindent 12 }}
+        {{- end }}
           ports:
             - containerPort: 3001
               name: diagnostics

--- a/examples/chart/tbot/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/tbot/tests/__snapshot__/deployment_test.yaml.snap
@@ -98,6 +98,16 @@ should match the snapshot (full):
               requests:
                 cpu: 250m
                 memory: 64Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              runAsUser: 9807
+              seccompProfile:
+                type: RuntimeDefault
             volumeMounts:
             - mountPath: /config
               name: config

--- a/examples/chart/tbot/values.yaml
+++ b/examples/chart/tbot/values.yaml
@@ -227,3 +227,10 @@ extraArgs: []
 #     value: "http://username:password@my.proxy.host:3128"
 # ```
 extraEnv: []
+
+# securityContext(object) -- sets the container security context for any pods created by the chart.
+# See [the Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
+# for more details.
+#
+# By default, this is unset.
+securityContext: null


### PR DESCRIPTION
Backports #51817

changelog: Added securityContext value to the tbot Helm chart.