### PR TITLE
helm: Add fullnameOverride to teleport-kube-agent

### DIFF
--- a/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
@@ -1824,3 +1824,11 @@ for more details.
 
 `probeTimeoutSeconds` sets the timeout for the readiness and liveness probes
 https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+
+## `fullnameOverride`
+
+| Type | Default |
+|------|---------|
+| `string` | `""` |
+
+`fullnameOverride` override the chart's name

--- a/examples/chart/teleport-kube-agent/.lint/fullname-override.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/fullname-override.yaml
@@ -1,0 +1,4 @@
+authToken: auth-token
+proxyAddr: proxy.example.com:3080
+kubeClusterName: test-kube-cluster
+fullnameOverride: teleport

--- a/examples/chart/teleport-kube-agent/templates/_helpers.tpl
+++ b/examples/chart/teleport-kube-agent/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{- define "teleport.kube.agent.isUpgrade" -}}
 {{- /* Checks if action is an upgrade from an old release that didn't support Secret storage */}}
 {{- if .Release.IsUpgrade }}
-  {{- $deployment := (lookup "apps/v1" "Deployment"  .Release.Namespace .Release.Name ) -}}
+  {{- $deployment := (lookup "apps/v1" "Deployment"  .Release.Namespace (include "teleport-kube-agent.fullname" .) ) -}}
   {{- if ($deployment) }}
 true
   {{- else if .Values.unitTestUpgrade }}
@@ -11,15 +11,15 @@ true
 {{- end -}}
 {{/*
 Create the name of the service account to use
-if serviceAccount is not defined or serviceAccount.name is empty, use .Release.Name
+if serviceAccount is not defined or serviceAccount.name is empty, use teleport-kube-agent.fullname
 */}}
 {{- define "teleport-kube-agent.serviceAccountName" -}}
-{{- coalesce .Values.serviceAccount.name .Values.serviceAccountName .Release.Name -}}
+{{- coalesce .Values.serviceAccount.name .Values.serviceAccountName (include "teleport-kube-agent.fullname" .) -}}
 {{- end -}}
 
 {{/*
 Create the name of the service account to use for the post-delete hook
-if serviceAccount is not defined or serviceAccount.name is empty, use .Release.Name-delete-hook
+if serviceAccount is not defined or serviceAccount.name is empty, use "teleport-kube-agent.fullname"-delete-hook
 */}}
 {{- define "teleport-kube-agent.deleteHookServiceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
@@ -48,3 +48,16 @@ if serviceAccount is not defined or serviceAccount.name is empty, use .Release.N
 {{- define "teleport-kube-agent.image" -}}
 {{ include "teleport-kube-agent.baseImage" . }}:{{ include "teleport-kube-agent.version" . }}
 {{- end -}}
+
+{{/*
+This is a modified version of the default fully qualified app name helper.
+We diverge by defaulting to .Release.Name to be backwards compatible with older versions of this chart.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "teleport-kube-agent.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}

--- a/examples/chart/teleport-kube-agent/templates/clusterrole.yaml
+++ b/examples/chart/teleport-kube-agent/templates/clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.clusterRoleName | default .Release.Name }}
+  name: {{ .Values.clusterRoleName | default (include "teleport-kube-agent.fullname" .) }}
 {{- if .Values.extraLabels.clusterRole }}
   labels:
   {{- toYaml .Values.extraLabels.clusterRole | nindent 4 }}

--- a/examples/chart/teleport-kube-agent/templates/clusterrolebinding.yaml
+++ b/examples/chart/teleport-kube-agent/templates/clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.clusterRoleBindingName | default .Release.Name }}
+  name: {{ .Values.clusterRoleBindingName | default (include "teleport-kube-agent.fullname" .) }}
 {{- if .Values.extraLabels.clusterRoleBinding }}
   labels:
   {{- toYaml .Values.extraLabels.clusterRoleBinding | nindent 4 }}
@@ -10,7 +10,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Values.clusterRoleName | default .Release.Name }}
+  name: {{ .Values.clusterRoleName | default (include "teleport-kube-agent.fullname" .) }}
 subjects:
 - kind: ServiceAccount
   name: {{ template "teleport-kube-agent.serviceAccountName" . }}

--- a/examples/chart/teleport-kube-agent/templates/config.yaml
+++ b/examples/chart/teleport-kube-agent/templates/config.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ include "teleport-kube-agent.fullname" . }}
   namespace: {{ .Release.Namespace }}
 {{- if .Values.extraLabels.config }}
   labels:

--- a/examples/chart/teleport-kube-agent/templates/delete_hook.yaml
+++ b/examples/chart/teleport-kube-agent/templates/delete_hook.yaml
@@ -18,7 +18,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Release.Name }}-delete-hook
+  name: {{ include "teleport-kube-agent.fullname" . }}-delete-hook
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-delete
@@ -36,7 +36,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Release.Name }}-delete-hook
+  name: {{ include "teleport-kube-agent.fullname" . }}-delete-hook
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-delete
@@ -49,7 +49,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .Release.Name }}-delete-hook
+  name: {{ include "teleport-kube-agent.fullname" . }}-delete-hook
 subjects:
 - kind: ServiceAccount
   name: {{ template "teleport-kube-agent.deleteHookServiceAccountName" . }}
@@ -59,7 +59,7 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-delete-hook
+  name: {{ include "teleport-kube-agent.fullname" . }}-delete-hook
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-delete
@@ -72,13 +72,13 @@ metadata:
 spec:
   template:
     metadata:
-      name: {{ .Release.Name }}-delete-hook
+      name: {{ include "teleport-kube-agent.fullname" . }}-delete-hook
 {{- if .Values.annotations.pod }}
       annotations:
   {{- toYaml .Values.annotations.pod | nindent 8 }}
 {{- end }}
       labels:
-        app: {{ .Release.Name }}
+        app: {{ include "teleport-kube-agent.fullname" . }}
 {{- if .Values.extraLabels.pod }}
   {{- toYaml .Values.extraLabels.pod | nindent 8 }}
 {{- end }}
@@ -108,7 +108,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: RELEASE_NAME
-            value: {{ .Release.Name }}
+            value: {{ include "teleport-kube-agent.fullname" . }}
         image: {{ include "teleport-kube-agent.image" . | quote }}
         {{- if .Values.imagePullPolicy }}
         imagePullPolicy: {{ toYaml .Values.imagePullPolicy }}

--- a/examples/chart/teleport-kube-agent/templates/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/deployment.yaml
@@ -7,10 +7,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ include "teleport-kube-agent.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name }}
+    app: {{ include "teleport-kube-agent.fullname" . }}
   {{- if .Values.extraLabels.deployment }}
     {{- toYaml .Values.extraLabels.deployment | nindent 4 }}
   {{- end }}
@@ -22,7 +22,7 @@ spec:
   replicas: {{ $replicaCount }}
   selector:
     matchLabels:
-      app: {{ .Release.Name }}
+      app: {{ include "teleport-kube-agent.fullname" . }}
   template:
     metadata:
       annotations:
@@ -32,7 +32,7 @@ spec:
   {{- toYaml .Values.annotations.pod | nindent 8 }}
 {{- end }}
       labels:
-        app: {{ .Release.Name }}
+        app: {{ include "teleport-kube-agent.fullname" . }}
 {{- if .Values.extraLabels.pod }}
   {{- toYaml .Values.extraLabels.pod | nindent 8 }}
 {{- end }}
@@ -65,7 +65,7 @@ spec:
               - key: app
                 operator: In
                 values:
-                - {{ .Release.Name }}
+                - {{ include "teleport-kube-agent.fullname" . }}
             topologyKey: "kubernetes.io/hostname"
         {{- else if gt (int $replicaCount) 1 }}
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -76,7 +76,7 @@ spec:
                 - key: app
                   operator: In
                   values:
-                  - {{ .Release.Name }}
+                  - {{ include "teleport-kube-agent.fullname" . }}
               topologyKey: "kubernetes.io/hostname"
         {{- end }}
         {{- end }}
@@ -215,7 +215,7 @@ spec:
       volumes:
       - name: "config"
         configMap:
-          name: {{ .Release.Name }}
+          name: {{ include "teleport-kube-agent.fullname" . }}
       - name: "auth-token"
         secret:
           secretName: {{ coalesce .Values.secretName .Values.joinTokenSecret.name }}

--- a/examples/chart/teleport-kube-agent/templates/hook.yaml
+++ b/examples/chart/teleport-kube-agent/templates/hook.yaml
@@ -1,9 +1,9 @@
-{{- $deployment := (lookup "apps/v1" "Deployment"  .Release.Namespace .Release.Name ) -}}
+{{- $deployment := (lookup "apps/v1" "Deployment"  .Release.Namespace (include "teleport-kube-agent.fullname" .) ) -}}
 {{- if $deployment }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}-hook
+  name: {{ include "teleport-kube-agent.fullname" . }}-hook
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-upgrade
@@ -13,7 +13,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Release.Name }}-hook
+  name: {{ include "teleport-kube-agent.fullname" . }}-hook
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-upgrade
@@ -22,20 +22,20 @@ metadata:
 rules:
   - apiGroups: ["apps"]
     resources: ["statefulsets"]
-    resourceNames: ["{{ .Release.Name }}"]
+    resourceNames: [{{ include "teleport-kube-agent.fullname" . | quote }}]
     verbs: ["get", "watch", "list"]
   - apiGroups: [""]
     resources: ["pods",]
     verbs: ["get", "watch"]
   - apiGroups: ["apps"]
     resources: ["deployments",]
-    resourceNames: ["{{ .Release.Name }}"]
+    resourceNames: [{{ include "teleport-kube-agent.fullname" . | quote }}]
     verbs: ["get", "delete", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Release.Name }}-hook
+  name: {{ include "teleport-kube-agent.fullname" . }}-hook
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-upgrade
@@ -44,16 +44,16 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .Release.Name }}-hook
+  name: {{ include "teleport-kube-agent.fullname" . }}-hook
 subjects:
 - kind: ServiceAccount
-  name: {{ .Release.Name }}-hook
+  name: {{ include "teleport-kube-agent.fullname" . }}-hook
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-hook
+  name: {{ include "teleport-kube-agent.fullname" . }}-hook
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-upgrade
@@ -62,13 +62,13 @@ metadata:
 spec:
   template:
     metadata:
-      name: {{ .Release.Name }}-hook
+      name: {{ include "teleport-kube-agent.fullname" . }}-hook
 {{- if .Values.annotations.pod }}
       annotations:
   {{- toYaml .Values.annotations.pod | nindent 8 }}
 {{- end }}
       labels:
-        app: {{ .Release.Name }}
+        app: {{ include "teleport-kube-agent.fullname" . }}
 {{- if .Values.extraLabels.pod }}
   {{- toYaml .Values.extraLabels.pod | nindent 8 }}
 {{- end }}
@@ -80,7 +80,7 @@ spec:
       tolerations:
         {{- toYaml .Values.tolerations | nindent 6 }}
 {{- end }}
-      serviceAccountName: {{ .Release.Name }}-hook
+      serviceAccountName: {{ include "teleport-kube-agent.fullname" . }}-hook
       restartPolicy: OnFailure
 {{- if .Values.nodeSelector }}
       nodeSelector:
@@ -96,9 +96,9 @@ spec:
             /bin/sh <<'EOF'
               set -eu -o pipefail
               # wait until statefulset is ready
-              kubectl rollout status --watch --timeout=600s statefulset/{{ .Release.Name }}
+              kubectl rollout status --watch --timeout=600s statefulset/{{ include "teleport-kube-agent.fullname" . }}
               # delete deployment
-              kubectl delete deployment/{{ .Release.Name }}
+              kubectl delete deployment/{{ include "teleport-kube-agent.fullname" . }}
             EOF
         {{- if .Values.securityContext }}
         securityContext: {{- toYaml .Values.securityContext | nindent 10 }}

--- a/examples/chart/teleport-kube-agent/templates/pdb.yaml
+++ b/examples/chart/teleport-kube-agent/templates/pdb.yaml
@@ -6,10 +6,10 @@ apiVersion: policy/v1beta1
 {{- end }}
 kind: PodDisruptionBudget
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ include "teleport-kube-agent.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name }}
+    app: {{ include "teleport-kube-agent.fullname" . }}
 {{- if .Values.extraLabels.podDisruptionBudget }}
   {{- toYaml .Values.extraLabels.podDisruptionBudget | nindent 4 }}
 {{- end }}
@@ -17,5 +17,5 @@ spec:
   minAvailable: {{ .Values.highAvailability.podDisruptionBudget.minAvailable }}
   selector:
     matchLabels:
-      app: {{ .Release.Name }}
+      app: {{ include "teleport-kube-agent.fullname" . }}
 {{- end }}

--- a/examples/chart/teleport-kube-agent/templates/podmonitor.yaml
+++ b/examples/chart/teleport-kube-agent/templates/podmonitor.yaml
@@ -2,20 +2,20 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ include "teleport-kube-agent.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
   {{- with .Values.podMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  jobLabel: {{ .Release.Name }}
+  jobLabel: {{ include "teleport-kube-agent.fullname" . }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      app: {{ .Release.Name }}
+      app: {{ include "teleport-kube-agent.fullname" . }}
   podMetricsEndpoints:
     - port: diag
       path: /metrics

--- a/examples/chart/teleport-kube-agent/templates/psp.yaml
+++ b/examples/chart/teleport-kube-agent/templates/psp.yaml
@@ -6,7 +6,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ include "teleport-kube-agent.fullname" . }}
 {{- if .Values.extraLabels.podSecurityPolicy }}
   labels:
   {{- toYaml .Values.extraLabels.podSecurityPolicy | nindent 4 }}
@@ -45,7 +45,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Release.Name }}-psp
+  name: {{ include "teleport-kube-agent.fullname" . }}-psp
 rules:
 - apiGroups:
   - policy
@@ -54,16 +54,16 @@ rules:
   verbs:
   - use
   resourceNames:
-  - {{ .Release.Name }}
+  - {{ include "teleport-kube-agent.fullname" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Release.Name }}-psp
+  name: {{ include "teleport-kube-agent.fullname" . }}-psp
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .Release.Name }}-psp
+  name: {{ include "teleport-kube-agent.fullname" . }}-psp
 subjects:
 - kind: ServiceAccount
   name: {{ template "teleport-kube-agent.serviceAccountName" . }}

--- a/examples/chart/teleport-kube-agent/templates/role.yaml
+++ b/examples/chart/teleport-kube-agent/templates/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Values.roleName | default .Release.Name }}
+  name: {{ .Values.roleName | default (include "teleport-kube-agent.fullname" .) }}
   namespace: {{ .Release.Namespace }}
 {{- if .Values.extraLabels.role }}
   labels:

--- a/examples/chart/teleport-kube-agent/templates/rolebinding.yaml
+++ b/examples/chart/teleport-kube-agent/templates/rolebinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Values.roleBindingName | default .Release.Name }}
+  name: {{ .Values.roleBindingName | default (include "teleport-kube-agent.fullname" .) }}
   namespace: {{ .Release.Namespace }}
 {{- if .Values.extraLabels.roleBinding }}
   labels:
@@ -10,7 +10,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .Values.roleName | default .Release.Name }}
+  name: {{ .Values.roleName | default (include "teleport-kube-agent.fullname" .) }}
 subjects:
 - kind: ServiceAccount
   name: {{ template "teleport-kube-agent.serviceAccountName" . }}

--- a/examples/chart/teleport-kube-agent/templates/statefulset.yaml
+++ b/examples/chart/teleport-kube-agent/templates/statefulset.yaml
@@ -6,10 +6,10 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ include "teleport-kube-agent.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name }}
+    app: {{ include "teleport-kube-agent.fullname" . }}
   {{- if .Values.extraLabels.deployment }}
     {{- toYaml .Values.extraLabels.deployment | nindent 4 }}
   {{- end }}
@@ -18,11 +18,11 @@ metadata:
     {{- toYaml .Values.annotations.deployment | nindent 4 }}
   {{- end }}
 spec:
-  serviceName: {{ .Release.Name }}
+  serviceName: {{ include "teleport-kube-agent.fullname" . }}
   replicas: {{ $replicaCount }}
   selector:
     matchLabels:
-      app: {{ .Release.Name }}
+      app: {{ include "teleport-kube-agent.fullname" . }}
   template:
     metadata:
       annotations:
@@ -32,7 +32,7 @@ spec:
   {{- toYaml .Values.annotations.pod | nindent 8 }}
 {{- end }}
       labels:
-        app: {{ .Release.Name }}
+        app: {{ include "teleport-kube-agent.fullname" . }}
 {{- if .Values.extraLabels.pod }}
   {{- toYaml .Values.extraLabels.pod | nindent 8 }}
 {{- end }}
@@ -68,7 +68,7 @@ spec:
               - key: app
                 operator: In
                 values:
-                - {{ .Release.Name }}
+                - {{ include "teleport-kube-agent.fullname" . }}
             topologyKey: "kubernetes.io/hostname"
         {{- else if gt (int $replicaCount) 1 }}
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -79,7 +79,7 @@ spec:
                 - key: app
                   operator: In
                   values:
-                  - {{ .Release.Name }}
+                  - {{ include "teleport-kube-agent.fullname" . }}
               topologyKey: "kubernetes.io/hostname"
         {{- end }}
         {{- end }}
@@ -108,7 +108,7 @@ spec:
           name: "auth-token"
           readOnly: true
         - mountPath: /var/lib/teleport
-          name: "{{ .Release.Name }}-teleport-data"
+          name: "{{ include "teleport-kube-agent.fullname" . }}-teleport-data"
           {{- if .Values.tls.existingCASecretName }}
         - mountPath: /etc/teleport-tls-ca
           name: "teleport-tls-ca"
@@ -151,7 +151,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: RELEASE_NAME
-            value: {{ .Release.Name }}
+            value: {{ include "teleport-kube-agent.fullname" . }}
           {{- if .Values.updater.enabled }}
           - name: TELEPORT_EXT_UPGRADER
             value: kube
@@ -213,7 +213,7 @@ spec:
           readOnly: true
 {{- if .Values.storage.enabled }}
         - mountPath: /var/lib/teleport
-          name: "{{ .Release.Name }}-teleport-data"
+          name: "{{ include "teleport-kube-agent.fullname" . }}-teleport-data"
 {{- else }}
         - mountPath: /var/lib/teleport
           name: "data"
@@ -237,7 +237,7 @@ spec:
       volumes:
       - name: "config"
         configMap:
-          name: {{ .Release.Name }}
+          name: {{ include "teleport-kube-agent.fullname" . }}
       - name: "auth-token"
         secret:
           secretName: {{ coalesce .Values.secretName .Values.joinTokenSecret.name }}
@@ -261,7 +261,7 @@ spec:
 {{- if and .Values.storage.enabled }}
   volumeClaimTemplates:
   - metadata:
-      name: "{{ .Release.Name }}-teleport-data"
+      name: "{{ include "teleport-kube-agent.fullname" . }}-teleport-data"
     spec:
       accessModes: [ "ReadWriteOnce" ]
       storageClassName: {{ .Values.storage.storageClassName }}

--- a/examples/chart/teleport-kube-agent/templates/updater/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/updater/deployment.yaml
@@ -4,10 +4,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-updater
+  name: {{ include "teleport-kube-agent.fullname" . }}-updater
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name }}-updater
+    app: {{ include "teleport-kube-agent.fullname" . }}-updater
 {{- if $updater.extraLabels.deployment }}
     {{- toYaml $updater.extraLabels.deployment | nindent 4 }}
 {{- end }}
@@ -18,7 +18,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-updater
+      app: {{ include "teleport-kube-agent.fullname" . }}-updater
   template:
     metadata:
       annotations:
@@ -26,7 +26,7 @@ spec:
   {{- toYaml $updater.annotations.pod | nindent 8 }}
 {{- end }}
       labels:
-        app: {{ .Release.Name }}-updater
+        app: {{ include "teleport-kube-agent.fullname" . }}-updater
 {{- if $updater.extraLabels.pod }}
   {{- toYaml $updater.extraLabels.pod | nindent 8 }}
 {{- end }}
@@ -60,7 +60,7 @@ spec:
   {{- end }}
 {{- end }}
         args:
-          - "--agent-name={{ .Release.Name }}"
+          - "--agent-name={{ include "teleport-kube-agent.fullname" . }}"
           - "--agent-namespace={{ .Release.Namespace }}"
           - "--base-image={{ include "teleport-kube-agent.baseImage" . }}"
   {{- if $updater.versionServer}}

--- a/examples/chart/teleport-kube-agent/templates/updater/role.yaml
+++ b/examples/chart/teleport-kube-agent/templates/updater/role.yaml
@@ -4,7 +4,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Release.Name }}-updater
+  name: {{ include "teleport-kube-agent.fullname" . }}-updater
   namespace: {{ .Release.Namespace }}
 {{- if $updater.extraLabels.role }}
   labels: {{- toYaml $updater.extraLabels.role | nindent 4 }}
@@ -45,7 +45,7 @@ rules:
   verbs:
     - get
   resourceNames:
-    - {{ .Release.Name }}-shared-state
+    - {{ include "teleport-kube-agent.fullname" . }}-shared-state
 - apiGroups:
     - ""
   resources:
@@ -75,7 +75,7 @@ rules:
   verbs:
     - update
   resourceNames:
-    - {{ .Release.Name }}
+    - {{ include "teleport-kube-agent.fullname" . }}
 - apiGroups:
     - coordination.k8s.io
   resources:
@@ -85,7 +85,7 @@ rules:
 - apiGroups:
     - coordination.k8s.io
   resourceNames:
-    - {{ .Release.Name }}
+    - {{ include "teleport-kube-agent.fullname" . }}
   resources:
     - leases
   verbs:

--- a/examples/chart/teleport-kube-agent/templates/updater/rolebinding.yaml
+++ b/examples/chart/teleport-kube-agent/templates/updater/rolebinding.yaml
@@ -4,7 +4,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Release.Name }}-updater
+  name: {{ include "teleport-kube-agent.fullname" . }}-updater
   namespace: {{ .Release.Namespace }}
 {{- if $updater.extraLabels.roleBinding }}
   labels:
@@ -13,7 +13,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .Release.Name }}-updater
+  name: {{ include "teleport-kube-agent.fullname" . }}-updater
 subjects:
 - kind: ServiceAccount
   name: {{ template "teleport-kube-agent-updater.serviceAccountName" . }}

--- a/examples/chart/teleport-kube-agent/tests/deployment_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/deployment_test.yaml
@@ -781,3 +781,16 @@ tests:
           content:
             name: TELEPORT_EXT_UPGRADER_VERSION
             value: 13.4.5
+
+  - it: should set name to fullnameOverride when set in values if action is Upgrade
+    template: deployment.yaml
+    set:
+      # unit test does not support lookup functions, so to test the behavior we use this undoc value
+      # https://github.com/helm/helm/issues/8137
+      unitTestUpgrade: true
+    values:
+      - ../.lint/fullname-override.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: teleport

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -466,6 +466,11 @@
             "type": "string",
             "default": ""
         },
+        "fullnameOverride": {
+            "$id": "#/properties/fullnameOverride",
+            "type": "string",
+            "default": ""
+        },
         "serviceAccountName": {
             "$id": "#/properties/serviceAccountName",
             "type": "string",

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -1329,3 +1329,6 @@ tolerations: []
 # probeTimeoutSeconds(int) -- sets the timeout for the readiness and liveness probes
 # https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 probeTimeoutSeconds: 1
+
+# fullnameOverride(string) -- override the chart's name
+fullnameOverride: ""


### PR DESCRIPTION
It would be useful to be able to override the teleport-kube-agent chart's name.

I modeled these changes off of the `templates/_helpers.tpl` file that `helm create` generates by default.

I didn't include a `nameOverride` value and I excluded the logic checking for the chart's name in `.Release.Name` so anyone upgrading wouldn't run into their resources getting renamed.