### PR TITLE
[v15] feat: Allow non-FIPS endpoints on FIPS binaries

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,17 @@ issues:
     - linters: [testifylint]
       text: "suite-thelper: suite helper method must start with"
       path: 'integrations/.+'
+      # lib/utils/aws/ subpackages are allowed to use AWS SDK constructors.
+    - path: lib/utils/aws/stsutils/sts.go
+      linters: [forbidigo]
+      text: 'sts.NewFromConfig'
+    - path: lib/utils/aws/stsutils/sts_v1.go
+      linters: [forbidigo]
+      text: 'sts.New'
+    # TODO(codingllama): Remove once e/ is updated.
+    - path: e/lib/cloud/aws/aws.go
+      linters: [forbidigo]
+      text: 'sts.NewFromConfig'
   exclude-use-default: true
   max-same-issues: 0
   max-issues-per-linter: 0
@@ -34,6 +45,7 @@ linters:
   enable:
     - bodyclose
     - depguard
+    - forbidigo
     - gci
     - goimports
     - gosimple
@@ -146,6 +158,12 @@ linters-settings:
       - len
       - suite-extra-assert-call
       - suite-thelper
+  forbidigo:
+    forbid:
+      - p: '^sts\.NewFromConfig$'
+        msg: 'Use stsutils.NewFromConfig'
+      - p: '^sts\.New$'
+        msg: 'Use stsutils.NewV1'
 
 run:
   go: '1.22'

--- a/api/utils/keys/yubikey.go
+++ b/api/utils/keys/yubikey.go
@@ -1061,4 +1061,3 @@ func SelfSignedMetadataCertificate(subject pkix.Name) (*x509.Certificate, error)
 	}
 	return cert, nil
 }
-

--- a/integration/ec2_test.go
+++ b/integration/ec2_test.go
@@ -52,6 +52,7 @@ import (
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/aws/stsutils"
 )
 
 func newSilentLogger() utils.Logger {
@@ -145,7 +146,7 @@ func getCallerIdentity(t *testing.T) *sts.GetCallerIdentityOutput {
 		SharedConfigState: session.SharedConfigEnable,
 	})
 	require.NoError(t, err)
-	stsService := sts.New(sess)
+	stsService := stsutils.NewV1(sess)
 	output, err := stsService.GetCallerIdentity(nil /*input*/)
 	require.NoError(t, err)
 	return output

--- a/lib/auth/join_ec2.go
+++ b/lib/auth/join_ec2.go
@@ -33,7 +33,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/digitorus/pkcs7"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -41,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/aws/stsutils"
 )
 
 type ec2Client interface {
@@ -96,7 +96,7 @@ func checkInstanceRunning(ctx context.Context, instanceID, region, IAMRole strin
 
 	// assume the configured IAM role if necessary
 	if IAMRole != "" {
-		stsClient := sts.NewFromConfig(awsClientConfig)
+		stsClient := stsutils.NewFromConfig(awsClientConfig)
 		creds := stscreds.NewAssumeRoleProvider(stsClient, IAMRole)
 		awsClientConfig.Credentials = aws.NewCredentialsCache(creds)
 	}

--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -46,8 +46,8 @@ import (
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/defaults"
-	"github.com/gravitational/teleport/lib/modules"
 	dynamometrics "github.com/gravitational/teleport/lib/observability/metrics/dynamo"
+	"github.com/gravitational/teleport/lib/utils/aws/dynamodbutils"
 )
 
 func init() {
@@ -247,7 +247,7 @@ func New(ctx context.Context, params backend.Params) (*Backend, error) {
 
 	// determine if the FIPS endpoints should be used
 	useFIPSEndpoint := endpoints.FIPSEndpointStateUnset
-	if modules.GetModules().IsBoringBinary() {
+	if dynamodbutils.IsFIPSEnabled() {
 		useFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
 	}
 

--- a/lib/cloud/clients.go
+++ b/lib/cloud/clients.go
@@ -64,7 +64,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/aws/aws-sdk-go/service/ssm/ssmiface"
-	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
@@ -82,6 +81,7 @@ import (
 	gcpimds "github.com/gravitational/teleport/lib/cloud/imds/gcp"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/aws/stsutils"
 )
 
 // Clients provides interface for obtaining cloud provider clients.
@@ -593,7 +593,7 @@ func (c *cloudClients) GetAWSSTSClient(ctx context.Context, region string, opts 
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return sts.New(session), nil
+	return stsutils.NewV1(session), nil
 }
 
 // GetAWSEC2Client returns AWS EC2 client for the specified region.
@@ -843,7 +843,7 @@ func (c *cloudClients) getAWSSessionForRole(ctx context.Context, region string, 
 		externalID:  options.assumeRoleExternalID,
 	}
 	return utils.FnCacheGet(ctx, c.awsSessionsCache, cacheKey, func(ctx context.Context) (*awssession.Session, error) {
-		stsClient := sts.New(options.baseSession)
+		stsClient := stsutils.NewV1(options.baseSession)
 		return newSessionWithRole(ctx, stsClient, region, options.assumeRoleARN, options.assumeRoleExternalID)
 	})
 }

--- a/lib/configurators/aws/aws.go
+++ b/lib/configurators/aws/aws.go
@@ -36,7 +36,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/aws/aws-sdk-go/service/ssm/ssmiface"
-	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 	"github.com/gravitational/trace"
 
@@ -52,6 +51,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv/db/secrets"
 	"github.com/gravitational/teleport/lib/utils"
 	awsutils "github.com/gravitational/teleport/lib/utils/aws"
+	"github.com/gravitational/teleport/lib/utils/aws/stsutils"
 )
 
 const (
@@ -339,7 +339,7 @@ func (c *ConfiguratorConfig) CheckAndSetDefaults() error {
 		}
 
 		if c.AWSSTSClient == nil {
-			c.AWSSTSClient = sts.New(c.AWSSession)
+			c.AWSSTSClient = stsutils.NewV1(c.AWSSession)
 		}
 		if c.AWSIAMClient == nil {
 			c.AWSIAMClient = iam.New(c.AWSSession)

--- a/lib/integrations/awsoidc/clients.go
+++ b/lib/integrations/awsoidc/clients.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/trace"
 
 	awsutils "github.com/gravitational/teleport/api/utils/aws"
+	"github.com/gravitational/teleport/lib/utils/aws/stsutils"
 )
 
 // AWSClientRequest contains the required fields to set up an AWS service client.
@@ -92,7 +93,7 @@ func newAWSConfig(ctx context.Context, req *AWSClientRequest) (*aws.Config, erro
 	}
 
 	cfg.Credentials = stscreds.NewWebIdentityRoleProvider(
-		sts.NewFromConfig(cfg),
+		stsutils.NewFromConfig(cfg),
 		req.RoleARN,
 		IdentityToken(req.Token),
 	)
@@ -136,7 +137,7 @@ func newSTSClient(ctx context.Context, req *AWSClientRequest) (*sts.Client, erro
 		return nil, trace.Wrap(err)
 	}
 
-	return sts.NewFromConfig(*cfg), nil
+	return stsutils.NewFromConfig(*cfg), nil
 }
 
 // newEC2Client creates an [ec2.Client] using the provided Token, RoleARN and Region.

--- a/lib/integrations/awsoidc/clientsv1.go
+++ b/lib/integrations/awsoidc/clientsv1.go
@@ -26,12 +26,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
 	utilsaws "github.com/gravitational/teleport/api/utils/aws"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/utils/aws/stsutils"
 )
 
 // FetchToken returns the token.
@@ -92,7 +92,7 @@ func NewSessionV1(ctx context.Context, client IntegrationTokenGenerator, region 
 		return []byte(token), trace.Wrap(err)
 	}
 
-	stsSTS := sts.New(sess)
+	stsSTS := stsutils.NewV1(sess)
 	roleProvider := stscreds.NewWebIdentityRoleProviderWithOptions(
 		stsSTS,
 		awsOIDCIntegration.RoleARN,

--- a/lib/integrations/awsoidc/deployservice_iam_config.go
+++ b/lib/integrations/awsoidc/deployservice_iam_config.go
@@ -32,6 +32,7 @@ import (
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
 	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
 	awslibutils "github.com/gravitational/teleport/lib/utils/aws"
+	"github.com/gravitational/teleport/lib/utils/aws/stsutils"
 )
 
 var taskRoleDescription = "Used by Teleport Database Service deployed in Amazon ECS."
@@ -142,7 +143,7 @@ func NewDeployServiceIAMConfigureClient(ctx context.Context, region string) (Dep
 
 	return &defaultDeployServiceIAMConfigureClient{
 		Client:    iam.NewFromConfig(cfg),
-		stsClient: sts.NewFromConfig(cfg),
+		stsClient: stsutils.NewFromConfig(cfg),
 	}, nil
 }
 

--- a/lib/integrations/awsoidc/idp_iam_config.go
+++ b/lib/integrations/awsoidc/idp_iam_config.go
@@ -34,6 +34,7 @@ import (
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/integrations/awsoidc/tags"
+	"github.com/gravitational/teleport/lib/utils/aws/stsutils"
 )
 
 const (
@@ -161,7 +162,7 @@ func NewIdPIAMConfigureClient(ctx context.Context) (IdPIAMConfigureClient, error
 		httpClient: httpClient,
 		awsConfig:  cfg,
 		Client:     iam.NewFromConfig(cfg),
-		stsClient:  sts.NewFromConfig(cfg),
+		stsClient:  stsutils.NewFromConfig(cfg),
 	}, nil
 }
 

--- a/lib/integrations/externalauditstorage/configurator.go
+++ b/lib/integrations/externalauditstorage/configurator.go
@@ -27,7 +27,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
-	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -38,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/api/types/externalauditstorage"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils/aws/stsutils"
 )
 
 const (
@@ -111,7 +111,7 @@ func (o *Options) setDefaults(ctx context.Context, region string) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		o.stsClient = sts.NewFromConfig(cfg)
+		o.stsClient = stsutils.NewFromConfig(cfg)
 	}
 	return nil
 }

--- a/lib/modules/test.go
+++ b/lib/modules/test.go
@@ -41,6 +41,8 @@ type TestModules struct {
 	TestBuildType string
 	// TestFeatures is returned from the Features function.
 	TestFeatures Features
+	// FIPS allows tests to toggle fips behavior.
+	FIPS bool
 
 	defaultModules
 
@@ -80,7 +82,7 @@ func (m *TestModules) PrintVersion() {
 
 // IsBoringBinary checks if the binary was compiled with BoringCrypto.
 func (m *TestModules) IsBoringBinary() bool {
-	return m.defaultModules.IsBoringBinary()
+	return m.FIPS
 }
 
 // Features returns supported features.

--- a/lib/srv/app/aws/handler_test.go
+++ b/lib/srv/app/aws/handler_test.go
@@ -55,6 +55,7 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	awsutils "github.com/gravitational/teleport/lib/utils/aws"
+	"github.com/gravitational/teleport/lib/utils/aws/stsutils"
 )
 
 type makeRequest func(url string, provider client.ConfigProvider, awsHost string) error
@@ -138,13 +139,14 @@ func lambdaRequestWithPayload(url string, provider client.ConfigProvider, payloa
 
 func assumeRoleRequest(requestDuration time.Duration) makeRequest {
 	return func(url string, provider client.ConfigProvider, _ string) error {
-		stsClient := sts.New(provider, &aws.Config{
+		stsClient := stsutils.NewV1(provider, &aws.Config{
 			Endpoint:   &url,
 			MaxRetries: aws.Int(0),
 			HTTPClient: &http.Client{
 				Timeout: 5 * time.Second,
 			},
 		})
+
 		_, err := stsClient.AssumeRole(&sts.AssumeRoleInput{
 			DurationSeconds: aws.Int64(int64(requestDuration.Seconds())),
 			RoleSessionName: aws.String("test-session"),

--- a/lib/utils/aws/dynamodbutils/dynamo.go
+++ b/lib/utils/aws/dynamodbutils/dynamo.go
@@ -1,0 +1,30 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package dynamodbutils
+
+import (
+	"github.com/gravitational/teleport/lib/modules"
+	awsutils "github.com/gravitational/teleport/lib/utils/aws"
+)
+
+// IsFIPSEnabled returns true if FIPS should be enabled for DynamoDB.
+// FIPS is enabled is the binary is boring ([modules.Modules.IsBoringBinary])
+// and if FIPS is not disabled by the environment
+// ([awsutils.IsFIPSDisabledByEnv]).
+func IsFIPSEnabled() bool {
+	return !awsutils.IsFIPSDisabledByEnv() && modules.GetModules().IsBoringBinary()
+}

--- a/lib/utils/aws/dynamodbutils/dynamo_test.go
+++ b/lib/utils/aws/dynamodbutils/dynamo_test.go
@@ -1,0 +1,65 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package dynamodbutils_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/utils/aws/dynamodbutils"
+)
+
+func TestIsFIPSEnabled(t *testing.T) {
+	// Don't t.Parallel(), uses t.Setenv and modules.SetTestModules.
+
+	tests := []struct {
+		name        string
+		fips        bool
+		envVarValue string
+		want        bool
+	}{
+		{
+			name: "non-FIPS binary",
+			want: false,
+		},
+		{
+			name: "FIPS binary",
+			fips: true,
+			want: true,
+		},
+		{
+			name:        "FIPS binary with skip",
+			fips:        true,
+			envVarValue: "yes",
+			want:        false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("TELEPORT_UNSTABLE_DISABLE_AWS_FIPS", test.envVarValue)
+
+			modules.SetTestModules(t, &modules.TestModules{
+				FIPS: test.fips,
+			})
+
+			got := dynamodbutils.IsFIPSEnabled()
+			assert.Equal(t, test.want, got, "IsFIPSEnabled mismatch")
+		})
+	}
+}

--- a/lib/utils/aws/fips_disabled.go
+++ b/lib/utils/aws/fips_disabled.go
@@ -1,0 +1,42 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package aws
+
+import (
+	"os"
+	"strconv"
+)
+
+// IsFIPSDisabledByEnv returns true if the TELEPORT_UNSTABLE_DISABLE_AWS_FIPS
+// environment variable is set.
+//
+// Either "yes" or a "truthy" value (as defined by [strconv.ParseBool]) are
+// considered true.
+//
+// Prefer using specific functions, such as those in the
+// lib/utils/aws/stsutils or lib/utils/aws/dynamodbutils packages.
+func IsFIPSDisabledByEnv() bool {
+	const envVar = "TELEPORT_UNSTABLE_DISABLE_AWS_FIPS"
+
+	// Disable FIPS endpoint?
+	if val := os.Getenv(envVar); val != "" {
+		b, _ := strconv.ParseBool(val)
+		return b || val == "yes"
+	}
+
+	return false
+}

--- a/lib/utils/aws/stsutils/sts.go
+++ b/lib/utils/aws/stsutils/sts.go
@@ -1,0 +1,38 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package stsutils
+
+import (
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+
+	awsutils "github.com/gravitational/teleport/lib/utils/aws"
+)
+
+// NewFromConfig wraps [sts.NewFromConfig] and applies FIPS settings
+// according to environment variables.
+//
+// See [awsutils.IsFIPSDisabledByEnv].
+func NewFromConfig(cfg aws.Config, optFns ...func(*sts.Options)) *sts.Client {
+	if awsutils.IsFIPSDisabledByEnv() {
+		// append so it overrides any preceding settings.
+		optFns = append(optFns, func(opts *sts.Options) {
+			opts.EndpointOptions.UseFIPSEndpoint = aws.FIPSEndpointStateDisabled
+		})
+	}
+	return sts.NewFromConfig(cfg, optFns...)
+}

--- a/lib/utils/aws/stsutils/sts_test.go
+++ b/lib/utils/aws/stsutils/sts_test.go
@@ -1,0 +1,79 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package stsutils_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/utils/aws/stsutils"
+)
+
+func TestNewFromConfig(t *testing.T) {
+	// Don't t.Parallel(), uses t.Setenv().
+
+	cfg := aws.Config{}
+	opts := func(opts *sts.Options) {
+		opts.EndpointOptions.UseFIPSEndpoint = aws.FIPSEndpointStateEnabled
+	}
+
+	tests := []struct {
+		name        string
+		envVarValue string // value for the _DISABLE_STS_FIPS environment variable
+		want        aws.FIPSEndpointState
+	}{
+		{
+			name: "env not set",
+			want: aws.FIPSEndpointStateEnabled,
+		},
+		{
+			name:        "invalid does not change FIPS",
+			envVarValue: "llama",
+			want:        aws.FIPSEndpointStateEnabled,
+		},
+		{
+			name:        "false does not change FIPS",
+			envVarValue: "0",
+			want:        aws.FIPSEndpointStateEnabled,
+		},
+		{
+			name:        `"yes" disables FIPS`,
+			envVarValue: "yes",
+			want:        aws.FIPSEndpointStateDisabled,
+		},
+		{
+			name:        "1 disables FIPS",
+			envVarValue: "1",
+			want:        aws.FIPSEndpointStateDisabled,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("TELEPORT_UNSTABLE_DISABLE_AWS_FIPS", test.envVarValue)
+
+			stsClient := stsutils.NewFromConfig(cfg, opts)
+			require.NotNil(t, stsClient, "*sts.Client")
+
+			got := stsClient.Options().EndpointOptions.UseFIPSEndpoint
+			assert.Equal(t, test.want, got, "opts.EndpointOptions.UseFIPSEndpoint mismatch")
+		})
+	}
+}

--- a/lib/utils/aws/stsutils/sts_v1.go
+++ b/lib/utils/aws/stsutils/sts_v1.go
@@ -1,0 +1,37 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package stsutils
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/service/sts"
+
+	awsutils "github.com/gravitational/teleport/lib/utils/aws"
+)
+
+// NewV1 wraps [sts.New] and applies FIPS settings according to environment
+// variables.
+//
+// See [awsutils.IsFIPSDisabledByEnv].
+func NewV1(p client.ConfigProvider, cfgs ...*aws.Config) *sts.STS {
+	if awsutils.IsFIPSDisabledByEnv() {
+		// append so it overrides any preceding settings.
+		cfgs = append(cfgs, aws.NewConfig().WithUseFIPSEndpoint(false))
+	}
+	return sts.New(p, cfgs...)
+}

--- a/lib/utils/aws/stsutils/sts_v1_test.go
+++ b/lib/utils/aws/stsutils/sts_v1_test.go
@@ -1,0 +1,91 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package stsutils_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/utils/aws/stsutils"
+)
+
+func TestNewV1(t *testing.T) {
+	// Don't t.Parallel(), uses t.Setenv().
+
+	configProvider := &mockConfigProvider{
+		Config: client.Config{
+			Config: aws.NewConfig().WithUseFIPSEndpoint(true),
+		},
+	}
+
+	tests := []struct {
+		name        string
+		envVarValue string // value for the _DISABLE_STS_FIPS environment variable
+		want        endpoints.FIPSEndpointState
+	}{
+		{
+			name: "env not set",
+			want: endpoints.FIPSEndpointStateEnabled,
+		},
+		{
+			name:        "invalid does not change FIPS",
+			envVarValue: "llama",
+			want:        endpoints.FIPSEndpointStateEnabled,
+		},
+		{
+			name:        "false does not change FIPS",
+			envVarValue: "0",
+			want:        endpoints.FIPSEndpointStateEnabled,
+		},
+		{
+			name:        `"yes" disables FIPS`,
+			envVarValue: "yes",
+			want:        endpoints.FIPSEndpointStateDisabled,
+		},
+		{
+			name:        "1 disables FIPS",
+			envVarValue: "1",
+			want:        endpoints.FIPSEndpointStateDisabled,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("TELEPORT_UNSTABLE_DISABLE_AWS_FIPS", test.envVarValue)
+
+			stsClient := stsutils.NewV1(configProvider)
+			require.NotNil(t, stsClient, "*sts.Client")
+
+			got := stsClient.Config.UseFIPSEndpoint
+			assert.Equal(t, test.want, got, "opts.EndpointOptions.UseFIPSEndpoint mismatch")
+		})
+	}
+}
+
+type mockConfigProvider struct {
+	Config client.Config
+}
+
+func (m *mockConfigProvider) ClientConfig(_ string, cfgs ...*aws.Config) client.Config {
+	cc := m.Config
+	cc.Config = cc.Config.Copy(cfgs...)
+	return cc
+}

--- a/tool/teleport/common/integration_configure.go
+++ b/tool/teleport/common/integration_configure.go
@@ -28,7 +28,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/glue"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/gravitational/trace"
 
 	ecatypes "github.com/gravitational/teleport/api/types/externalauditstorage"
@@ -41,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/lib/integrations/samlidp"
 	"github.com/gravitational/teleport/lib/integrations/samlidp/samlidpconfig"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/aws/stsutils"
 )
 
 func onIntegrationConfDeployService(ctx context.Context, params config.IntegrationConfDeployServiceIAM) error {
@@ -202,7 +202,7 @@ func onIntegrationConfExternalAuditCmd(ctx context.Context, params easconfig.Ext
 
 	clt := &awsoidc.DefaultConfigureExternalAuditStorageClient{
 		Iam: iam.NewFromConfig(cfg),
-		Sts: sts.NewFromConfig(cfg),
+		Sts: stsutils.NewFromConfig(cfg),
 	}
 	return trace.Wrap(awsoidc.ConfigureExternalAuditStorage(ctx, clt, params))
 }


### PR DESCRIPTION
Allow FIPS binaries to use non-FIPS AWS endpoints of STS and DynamoDB. Useful for running in AWS regions that lack some of the FIPS services, but mostly ill-advised - talk to your FIPS auditors first.

The "escape hatch" is the TELEPORT_UNSTABLE_DISABLE_AWS_FIPS environment variable. Set it to yes|true|1 to enable it: `TELEPORT_UNSTABLE_DISABLE_AWS_FIPS=yes`.

This is not a backport and should be fully-reviewed, as it was tested as a v15 patch for a particular version. Additionally, v15 heavily uses the AWSv1 SDK, whereas master is mostly on AWSv2. It'll be "forward-ported" to master and other active releases.

Changelog: Added an escape hatch to allow non-FIPS AWS endpoints on FIPS binaries (TELEPORT_UNSTABLE_DISABLE_AWS_FIPS=yes).