### PR TITLE
Do not delete integration CAs on auth init

### DIFF
--- a/api/utils/clientutils/resources.go
+++ b/api/utils/clientutils/resources.go
@@ -1,0 +1,47 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package clientutils
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/defaults"
+)
+
+// ListAllResources is a helper that fetches all resources by iterating all
+// pages.
+func ListAllResources[T any](
+	ctx context.Context,
+	listPageFunc func(context.Context, int, string) ([]T, string, error),
+) (all []T, err error) {
+	var page []T
+	var nextToken string
+	for {
+		page, nextToken, err = listPageFunc(ctx, defaults.DefaultChunkSize, nextToken)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		all = append(all, page...)
+		if nextToken == "" {
+			return all, nil
+		}
+	}
+}

--- a/api/utils/clientutils/resources_test.go
+++ b/api/utils/clientutils/resources_test.go
@@ -1,0 +1,63 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package clientutils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/defaults"
+)
+
+type mockPaginator struct {
+	accessDenied bool
+}
+
+func (m *mockPaginator) List(_ context.Context, pageSize int, token string) ([]bool, string, error) {
+	if m.accessDenied {
+		return nil, "", trace.AccessDenied("access denied")
+	}
+	switch token {
+	case "":
+		return make([]bool, pageSize), "page1", nil
+	case "page1":
+		return make([]bool, pageSize), "page2", nil
+	case "page2":
+		return make([]bool, 5), "", nil
+	default:
+		return nil, "", trace.BadParameter("invalid token")
+	}
+}
+
+func TestListAllResources(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		paginator := mockPaginator{}
+		items, err := ListAllResources(context.Background(), paginator.List)
+		require.NoError(t, err)
+		require.Equal(t, defaults.DefaultChunkSize*2+5, len(items))
+	})
+	t.Run("error", func(t *testing.T) {
+		paginator := mockPaginator{accessDenied: true}
+		_, err := ListAllResources(context.Background(), paginator.List)
+		require.Error(t, err)
+	})
+}

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -640,19 +640,21 @@ func initializeAuthorities(ctx context.Context, asrv *Server, cfg *InitConfig) e
 	}
 
 	// Collect CAs from integrations to avoid deleting them.
-	igs, err := clientutils.ListAllResources(ctx, asrv.Services.ListIntegrations)
+	err := clientutils.IterateResources(ctx, asrv.Services.ListIntegrations, func(ig types.Integration) error {
+		caKeySet, err := igcredentials.GetIntegrationCertAuthorities(ctx, ig, asrv.Services)
+		switch {
+		case trace.IsNotImplemented(err):
+		case err != nil:
+			// This should not happen by design. In case integration is in a
+			// bad state, log a warning instead of failing this initialization.
+			asrv.logger.WarnContext(ctx, "Failed to fetch integration CAs", "ig", ig.GetName(), "error", err)
+		default:
+			allKeysInUse = append(allKeysInUse, collectKeysInUse(*caKeySet)...)
+		}
+		return nil
+	})
 	if err != nil {
 		return trace.Wrap(err)
-	}
-	for _, ig := range igs {
-		caKeySet, err := igcredentials.GetIntegrationCertAuthorities(ctx, ig, asrv.Services)
-		if err != nil {
-			if !trace.IsNotImplemented(err) {
-				asrv.logger.WarnContext(ctx, "Failed to fetch integration CAs", "ig", ig.GetName(), "error", err)
-			}
-			continue
-		}
-		allKeysInUse = append(allKeysInUse, collectKeysInUse(*caKeySet)...)
 	}
 
 	// Delete any unused keys from the keyStore. This is to avoid exhausting
@@ -666,7 +668,7 @@ func initializeAuthorities(ctx context.Context, asrv *Server, cfg *InitConfig) e
 	return nil
 }
 
-func initializeAuthority(ctx context.Context, asrv *Server, caID types.CertAuthID) (usableKeysResult *keystore.UsableKeysResult, keysInUse [][]byte, err error) {
+func initializeAuthority(ctx context.Context, asrv *Server, caID types.CertAuthID) (*keystore.UsableKeysResult, [][]byte, error) {
 	ca, err := asrv.Services.GetCertAuthority(ctx, caID, true)
 	if err != nil {
 		if !trace.IsNotFound(err) {
@@ -686,7 +688,7 @@ func initializeAuthority(ctx context.Context, asrv *Server, caID types.CertAuthI
 	// Make sure the keystore has usable keys. This is a bit redundant if the CA
 	// was just generated above, but cheap relative to generating the CA, and
 	// it's nice to get the usableKeysResult.
-	usableKeysResult, err = asrv.keyStore.HasUsableActiveKeys(ctx, ca)
+	usableKeysResult, err := asrv.keyStore.HasUsableActiveKeys(ctx, ca)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
@@ -746,7 +748,7 @@ func initializeAuthority(ctx context.Context, asrv *Server, caID types.CertAuthI
 		)
 	}
 
-	keysInUse = collectKeysInUse(ca.GetActiveKeys(), ca.GetAdditionalTrustedKeys())
+	keysInUse := collectKeysInUse(ca.GetActiveKeys(), ca.GetAdditionalTrustedKeys())
 	return usableKeysResult, keysInUse, nil
 }
 

--- a/lib/auth/integration/credentials/credentials_test.go
+++ b/lib/auth/integration/credentials/credentials_test.go
@@ -192,6 +192,7 @@ func TestGetIntegrationCertAuthorities(t *testing.T) {
 		metadataWithName("github-success"),
 		githubSpec,
 	)
+	require.NoError(t, err)
 	githubIntegration.SetCredentials(&types.PluginCredentialsV1{
 		Credentials: &types.PluginCredentialsV1_StaticCredentialsRef{
 			StaticCredentialsRef: NewRef(),

--- a/lib/auth/integration/integrationv1/credentials_test.go
+++ b/lib/auth/integration/integrationv1/credentials_test.go
@@ -110,7 +110,7 @@ func TestExportIntegrationCertAuthorities(t *testing.T) {
 				t.Helper()
 				require.Nil(t, resp)
 				require.Error(t, err)
-				require.True(t, trace.IsBadParameter(err))
+				require.True(t, trace.IsNotImplemented(err))
 			},
 		},
 	}

--- a/lib/auth/integration/integrationv1/github.go
+++ b/lib/auth/integration/integrationv1/github.go
@@ -28,6 +28,7 @@ import (
 
 	integrationpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/integration/credentials"
 	"github.com/gravitational/teleport/lib/authz"
 )
 
@@ -91,7 +92,7 @@ func (s *Service) getGitHubSigner(ctx context.Context, integration string) (ssh.
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	caKeySet, err := s.getGitHubCertAuthorities(ctx, ig)
+	caKeySet, err := credentials.GetGitHubCertAuthorities(ctx, ig, s.cache)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
Fixes #51920 

changelog: Fix an issue that GitHub integration CA gets deleted during Auth restart for non-software key stores like KMS. For broken GitHub integrations, the `integration` resource must be deleted and recreated.