### PR TITLE
improve dynamoevents cursor logs

### DIFF
--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -838,21 +838,28 @@ func (l *Log) searchEventsRaw(ctx context.Context, fromUTC, toUTC time.Time, nam
 		return nil, "", trace.Wrap(err)
 	}
 
+	l.logger.DebugContext(ctx, "search events", "from", fromUTC, "to", toUTC, "filter", filter, "limit", limit, "start_key", startKey, "order", order, "checkpoint", checkpoint)
+
 	if startKey != "" {
-		if createdAt, err := GetCreatedAtFromStartKey(startKey); err == nil {
+		createdAt, err := GetCreatedAtFromStartKey(startKey)
+		if err == nil {
 			// we compare the cursor unix time to the from unix in order to drop the nanoseconds
 			// that are not present in the cursor.
 			if fromUTC.Unix() > createdAt.Unix() {
+				l.logger.WarnContext(ctx, "cursor is from before window start time, resetting cursor", "created_at", createdAt, "from", fromUTC)
 				// if fromUTC is after than the cursor, we changed the window and need to reset the cursor.
 				// This is a guard check when iterating over the events using sliding window
 				// and the previous cursor no longer fits the new window.
 				checkpoint = checkpointKey{}
 			}
 			if createdAt.After(toUTC) {
+				l.logger.DebugContext(ctx, "cursor is after the end of the window, skipping search", "created_at", createdAt, "to", toUTC)
 				// if the cursor is after the end of the window, we can return early since we
 				// won't find any events.
 				return nil, "", nil
 			}
+		} else {
+			l.logger.WarnContext(ctx, "failed to get creation time from start key", "start_key", startKey, "error", err)
 		}
 	}
 
@@ -1388,6 +1395,7 @@ func (l *eventsFetcher) processQueryOutput(output *dynamodb.QueryOutput, hasLeft
 		if err != nil {
 			return nil, false, err
 		}
+		l.log.DebugContext(context.Background(), "updating iterator for events fetcher", "iterator", string(iter))
 		l.checkpoint.Iterator = string(iter)
 	}
 
@@ -1419,6 +1427,7 @@ func (l *eventsFetcher) processQueryOutput(output *dynamodb.QueryOutput, hasLeft
 			if err != nil {
 				return nil, false, trace.Wrap(err)
 			}
+			l.log.DebugContext(context.Background(), "breaking up sub-page due to event size", "key", key)
 			l.checkpoint.EventKey = key
 
 			// We need to reset the iterator so we get the previous page again.
@@ -1441,6 +1450,7 @@ func (l *eventsFetcher) processQueryOutput(output *dynamodb.QueryOutput, hasLeft
 			}
 			l.hasLeft = hf || l.checkpoint.Iterator != ""
 			l.checkpoint.EventKey = ""
+			l.log.DebugContext(context.Background(), "resetting checkpoint event-key due to full page", "has_left", l.hasLeft, "checkpoint", l.checkpoint)
 			return out, true, nil
 		}
 	}
@@ -1497,6 +1507,7 @@ dateLoop:
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
+
 			l.log.DebugContext(ctx, "Query completed.",
 				"duration", time.Since(start),
 				"items", len(out.Items),

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"math/rand/v2"
 	"net/http"
 	"net/http/httptest"
@@ -126,7 +127,9 @@ func TestSearchSessionEvensBySessionID(t *testing.T) {
 // TestCheckpointOutsideOfWindow tests if [Log] doesn't panic
 // if checkpoint date is outside of the window [fromUTC,toUTC].
 func TestCheckpointOutsideOfWindow(t *testing.T) {
-	tt := &Log{}
+	tt := &Log{
+		logger: slog.With(teleport.ComponentKey, teleport.ComponentDynamoDB),
+	}
 
 	key := checkpointKey{
 		Date: "2022-10-02",


### PR DESCRIPTION
Increases the detail level of debug logs directly and indirectly related to the handling of dynamoevents cursors.  This PR was developed based on a recent experience attempting to debug an issue that manifested as incorrect dynamoevents cursor behavior.  There is enough branching/complexity around the handling of dynamoevents cursor state, that it can be confusing/tricky to nail down exactly where a problem is occurring.  This PR hopes to remedy that issue.