### PR TITLE
Bring back the ability to reset roles to standard model

### DIFF
--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/RequiresResetToStandard.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/RequiresResetToStandard.tsx
@@ -16,14 +16,151 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Text } from 'design';
-import { Info } from 'design/Alert/Alert';
+import { useState } from 'react';
 
-export const RequiresResetToStandard = () => (
-  <Info>
-    <Text>
-      This role is too complex to be edited in the standard editor. To continue
-      editing, go back to YAML editor.
-    </Text>
-  </Info>
-);
+import {
+  ButtonPrimary,
+  ButtonSecondary,
+  Flex,
+  H2,
+  Mark,
+  P2,
+  Text,
+} from 'design';
+import { Info } from 'design/Alert/Alert';
+import Dialog, { DialogContent, DialogHeader } from 'design/Dialog';
+
+import {
+  ConversionError,
+  ConversionErrorGroup,
+  ConversionErrorType,
+} from './errors';
+
+/**
+ * Informs the user that the role they're trying to edit is not supported by
+ * the standard editor. Provides a dialog that explains the details of what's
+ * not supported and lets the user commit the proposed changes.
+ */
+export const RequiresResetToStandard = ({
+  conversionErrors,
+  onReset,
+}: {
+  conversionErrors: ConversionErrorGroup[];
+  /**
+   * Called if the user decides to reset the role to be compatible with the
+   * standard model.
+   */
+  onReset(): void;
+}) => {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const handleReviewClick = () => {
+    setDialogOpen(true);
+  };
+  const handleCancelClick = () => {
+    setDialogOpen(false);
+  };
+  return (
+    <Info>
+      <Text>
+        This role is too complex to be edited in the standard editor. To
+        continue editing, go back to YAML editor or reset the affected fields to
+        standard settings.
+      </Text>
+      <ButtonSecondary size="large" my={2} onClick={handleReviewClick}>
+        Review and Reset to Standard Settings
+      </ButtonSecondary>
+      <Dialog open={dialogOpen}>
+        <DialogHeader mb={4}>
+          <H2>Review and Reset to Standard Settings</H2>
+        </DialogHeader>
+        <DialogContent mb={3}>
+          <P2>
+            To support editing this role in the standard editor, the following
+            fields will be altered. Please review the list carefully before
+            continuing.
+          </P2>
+
+          {conversionErrors.map(group => (
+            // group.type is unique per contract of
+            // `groupAndSortConversionErrors()`.
+            <ErrorGroupSection key={group.type} group={group} />
+          ))}
+        </DialogContent>
+        <Flex gap={3}>
+          <ButtonPrimary block size="large" onClick={onReset}>
+            Reset to Standard Settings
+          </ButtonPrimary>
+          <ButtonSecondary block size="large" onClick={handleCancelClick}>
+            Cancel
+          </ButtonSecondary>
+        </Flex>
+      </Dialog>
+    </Info>
+  );
+};
+
+const ErrorGroupSection = ({
+  group: { type, errors },
+}: {
+  group: ConversionErrorGroup;
+}) => {
+  return (
+    <>
+      <ErrorGroupSectionHeader type={type} />
+      <ul>
+        {errors.map((error, i) => (
+          <li key={`${i}:${error.path}`}>
+            <ErrorMessage error={error} />
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+};
+
+const ErrorGroupSectionHeader = ({ type }: { type: ConversionErrorType }) => {
+  switch (type) {
+    case ConversionErrorType.UnsupportedField:
+      return <P2>The following fields are unsupported and will be deleted:</P2>;
+    case ConversionErrorType.UnsupportedValue:
+      return (
+        <P2>
+          The following fields have unsupported values and will be deleted:
+        </P2>
+      );
+    case ConversionErrorType.UnsupportedValueWithReplacement:
+      return (
+        <P2>
+          The following fields have unsupported values and will be replaced:
+        </P2>
+      );
+    case ConversionErrorType.UnsupportedChange:
+      return (
+        <P2>
+          Modifying the following fields is not supported at all, and they will
+          be reset to their original value:
+        </P2>
+      );
+    default:
+      (type) satisfies never;
+  }
+};
+
+const ErrorMessage = ({ error }: { error: ConversionError }) => {
+  const { type, path } = error;
+  switch (type) {
+    case ConversionErrorType.UnsupportedField:
+    case ConversionErrorType.UnsupportedValue:
+    case ConversionErrorType.UnsupportedChange:
+      return <Mark>{path}</Mark>;
+    case ConversionErrorType.UnsupportedValueWithReplacement:
+      return (
+        <>
+          <Mark>{path}</Mark>: will be replaced with{' '}
+          <Mark>{error.replacement}</Mark>
+        </>
+      );
+    default:
+      (type) satisfies never;
+  }
+};

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.tsx
@@ -78,6 +78,10 @@ export const StandardEditor = ({
 
   const validator = useValidation();
 
+  function handleResetToStandard() {
+    dispatch({ type: 'reset-to-standard' });
+  }
+
   function handleSave() {
     if (!validator.validate()) {
       return;
@@ -93,9 +97,12 @@ export const StandardEditor = ({
 
   return (
     <>
-      {roleModel.requiresReset && (
+      {roleModel.conversionErrors.length > 0 && (
         <Box mx={3}>
-          <RequiresResetToStandard />
+          <RequiresResetToStandard
+            conversionErrors={roleModel.conversionErrors}
+            onReset={handleResetToStandard}
+          />
         </Box>
       )}
       <EditorWrapper

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/errors.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/errors.ts
@@ -1,0 +1,193 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Option } from 'shared/components/Select';
+
+/**
+ * Represents an error that occurred during converting a field of the role
+ * resource to its editor model. These errors are not fatal, and as such, are
+ * collected and returned along with the converted model.
+ */
+export type ConversionError =
+  | SimpleConversionError
+  | ConversionErrorWithReplacement;
+
+export enum ConversionErrorType {
+  /** Field has an unsupported value and will be removed. */
+  UnsupportedValue = 'value',
+  /** Field is unsupported and will be removed. */
+  UnsupportedField = 'field',
+  /** Field has an unsupported value and will be replaced. */
+  UnsupportedValueWithReplacement = 'value-with-replacement',
+  /** Changing this field is not supported. */
+  UnsupportedChange = 'change',
+}
+
+export type SimpleConversionErrorType =
+  | ConversionErrorType.UnsupportedValue
+  | ConversionErrorType.UnsupportedField
+  | ConversionErrorType.UnsupportedChange;
+
+type ConversionErrorBase<T extends ConversionErrorType> = {
+  type: T;
+  /**
+   * A full path of the field in the role resource that this error is about.
+   */
+  path: string;
+};
+
+/** An error that doesn't have any additional fields. */
+export type SimpleConversionError =
+  ConversionErrorBase<SimpleConversionErrorType>;
+
+/**
+ * An error that carries information about a replacement value for the field.
+ */
+export type ConversionErrorWithReplacement =
+  ConversionErrorBase<ConversionErrorType.UnsupportedValueWithReplacement> & {
+    /**
+     * A serialized representation of a value that this field will be replaced
+     * with.
+     */
+    replacement: string;
+  };
+
+/** A group of conversion errors of a given type. */
+export type ConversionErrorGroup = {
+  type: ConversionErrorType;
+  errors: ConversionError[];
+};
+
+/**
+ * A utility function that creates conversion errors for a group of unsupported
+ * fields.
+ * @param prefix Field path of the object that contained these unsupported
+ *   fields.
+ * @param obj An object that contains unsupported fields. Easy to obtain by
+ *   destructuring the known fields and collecting the rest.
+ */
+export function unsupportedFieldErrorsFromObject(
+  prefix: string,
+  obj: Record<string, any>
+): ConversionError[] {
+  const keys = Object.keys(obj);
+  return simpleConversionErrors(
+    ConversionErrorType.UnsupportedField,
+    prefix ? keys.map(key => `${prefix}.${key}`) : keys
+  );
+}
+
+/**
+ * A utility function that creates a list of conversion errors of a given type
+ * for a given list of paths.
+ */
+export function simpleConversionErrors<T extends SimpleConversionErrorType>(
+  type: T,
+  paths: string[]
+): SimpleConversionError[] {
+  return paths.map(path => ({ type, path }));
+}
+
+/**
+ * Creates a {@link ConversionErrorType.UnsupportedValueWithReplacement} error.
+ */
+export function unsupportedValueWithReplacement(
+  path: string,
+  replacement: any
+): ConversionErrorWithReplacement {
+  return {
+    type: ConversionErrorType.UnsupportedValueWithReplacement,
+    path,
+    replacement: JSON.stringify(replacement),
+  };
+}
+
+/**
+ * Retrieves an {@link Option} that corresponds to a given value. If the value
+ * is not allowed (i.e. it's not contained in the options map), pushes an error
+ * to the given errors list and returns a default option.
+ */
+export function getOptionOrPushError<V>(
+  value: V,
+  optionsMap: Map<V, Option<V>>,
+  defaultValue: V,
+  fieldPath: string,
+  errors: ConversionError[]
+) {
+  const opt = optionsMap.get(value);
+  if (opt !== undefined) {
+    return opt;
+  }
+  errors.push(unsupportedValueWithReplacement(fieldPath, defaultValue));
+  return optionsMap.get(defaultValue);
+}
+
+type GroupedErrors = Partial<Record<ConversionErrorType, ConversionError[]>>;
+
+function groupErrors(errors: ConversionError[]): GroupedErrors {
+  // We can't use Object.groupBy just yet because of Node.js version.
+  const grouped: GroupedErrors = {};
+  for (const e of errors) {
+    if (!(e.type in grouped)) {
+      grouped[e.type] = [];
+    }
+    grouped[e.type].push(e);
+  }
+  return grouped;
+}
+
+/**
+ * Returns conversion errors grouped by type and sorted by path within each
+ * group. The returned value is a list, not an object or map, to make sure that
+ * we have full control over the order, which will be reflected on the UI.
+ * However, it's guaranteed that each error type has no more than one group.
+ */
+export function groupAndSortConversionErrors(
+  errors: ConversionError[]
+): ConversionErrorGroup[] {
+  const grouped = groupErrors(errors);
+  const result: ConversionErrorGroup[] = [];
+
+  // Add groups for known conversion error types in desired order.
+  for (const type of [
+    ConversionErrorType.UnsupportedField,
+    ConversionErrorType.UnsupportedValue,
+    ConversionErrorType.UnsupportedValueWithReplacement,
+    ConversionErrorType.UnsupportedChange,
+  ]) {
+    const group = grouped[type];
+    if (group) {
+      result.push({ type, errors: group });
+      delete grouped[type];
+    }
+  }
+
+  // If someone adds an error type, but forgets to mention it above, we can
+  // still add it to the groups; the order may me not guaranteed and unstable,
+  // but it's better than not reporting it at all.
+  for (const t in grouped) {
+    result.push({ type: t as ConversionErrorType, errors: grouped[t] });
+  }
+
+  // Sort the groups by path.
+  for (const group of result) {
+    group.errors.sort((a, b) => a.path.localeCompare(b.path));
+  }
+
+  return result;
+}

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.test.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.test.ts
@@ -26,6 +26,7 @@ import {
   RequireMFAType,
   ResourceKind,
   Role,
+  RoleOptions,
   RoleVersion,
   Rule,
   SessionRecordingMode,
@@ -33,6 +34,11 @@ import {
 } from 'teleport/services/resources';
 
 import presetRoles from '../../../../../../../gen/preset-roles.json';
+import {
+  ConversionErrorType,
+  simpleConversionErrors,
+  unsupportedValueWithReplacement,
+} from './errors';
 import {
   createDBUserModeOptionsMap,
   createHostUserModeOptionsMap,
@@ -53,7 +59,7 @@ import {
   sshPortForwardingModeOptionsMap,
   verbOptionsMap,
 } from './standardmodel';
-import { optionsWithDefaults, withDefaults } from './withDefaults';
+import { withDefaults } from './withDefaults';
 
 const minimalRole = () =>
   withDefaults({ metadata: { name: 'foobar' }, version: defaultRoleVersion });
@@ -67,6 +73,7 @@ const minimalRoleModel = (): RoleEditorModel => ({
   resources: [],
   rules: [],
   requiresReset: false,
+  conversionErrors: [],
   options: {
     maxSessionTTL: '30h0m0s',
     clientIdleTimeout: '',
@@ -85,6 +92,36 @@ const minimalRoleModel = (): RoleEditorModel => ({
     forwardAgent: false,
     sshPortForwardingMode: sshPortForwardingModeOptionsMap.get(''),
   },
+});
+
+test('conversion error utilities', () => {
+  expect(
+    simpleConversionErrors(ConversionErrorType.UnsupportedField, ['foo', 'bar'])
+  ).toEqual([
+    {
+      type: ConversionErrorType.UnsupportedField,
+      path: 'foo',
+    },
+    {
+      type: ConversionErrorType.UnsupportedField,
+      path: 'bar',
+    },
+  ]);
+
+  expect(
+    simpleConversionErrors(ConversionErrorType.UnsupportedValue, ['foo'])
+  ).toEqual([
+    {
+      type: ConversionErrorType.UnsupportedValue,
+      path: 'foo',
+    },
+  ]);
+
+  expect(unsupportedValueWithReplacement('foo', { bar: 123 })).toEqual({
+    type: ConversionErrorType.UnsupportedValueWithReplacement,
+    path: 'foo',
+    replacement: '{"bar":123}',
+  });
 });
 
 // These tests make sure that role to model and model to role conversions are
@@ -370,95 +407,145 @@ describe.each<{ name: string; role: Role; model: RoleEditorModel }>([
   });
 });
 
-test.each<{
-  name: string;
-  portForwarding?: SSHPortForwarding;
-  legacyPortForwarding?: boolean;
-  expected: ReturnType<typeof portForwardingOptionsToModel>;
-}>([
-  { name: 'unspecified', expected: { model: '', requiresReset: false } },
+test.each<
+  {
+    name: string;
+    expected: ReturnType<typeof portForwardingOptionsToModel>;
+  } & Pick<RoleOptions, 'ssh_port_forwarding' | 'port_forwarding'>
+>([
+  {
+    name: 'unspecified',
+    expected: { model: '', conversionErrors: [] },
+  },
   {
     name: 'none',
-    portForwarding: { local: { enabled: false }, remote: { enabled: false } },
-    expected: { model: 'none', requiresReset: false },
+    ssh_port_forwarding: {
+      local: { enabled: false },
+      remote: { enabled: false },
+    },
+    expected: { model: 'none', conversionErrors: [] },
   },
   {
     name: 'local-only',
-    portForwarding: { local: { enabled: true }, remote: { enabled: false } },
-    expected: { model: 'local-only', requiresReset: false },
+    ssh_port_forwarding: {
+      local: { enabled: true },
+      remote: { enabled: false },
+    },
+    expected: {
+      model: 'local-only',
+      conversionErrors: [],
+    },
   },
   {
     name: 'remote-only',
-    portForwarding: { local: { enabled: false }, remote: { enabled: true } },
-    expected: { model: 'remote-only', requiresReset: false },
+    ssh_port_forwarding: {
+      local: { enabled: false },
+      remote: { enabled: true },
+    },
+    expected: {
+      model: 'remote-only',
+      conversionErrors: [],
+    },
   },
   {
     name: ' local-and-remote',
-    portForwarding: { local: { enabled: true }, remote: { enabled: true } },
-    expected: { model: 'local-and-remote', requiresReset: false },
+    ssh_port_forwarding: {
+      local: { enabled: true },
+      remote: { enabled: true },
+    },
+    expected: {
+      model: 'local-and-remote',
+      conversionErrors: [],
+    },
   },
   {
     name: 'deprecated-on',
-    legacyPortForwarding: true,
-    expected: { model: 'deprecated-on', requiresReset: false },
+    port_forwarding: true,
+    expected: {
+      model: 'deprecated-on',
+      conversionErrors: [],
+    },
   },
   {
     name: 'deprecated-off',
-    legacyPortForwarding: false,
-    expected: { model: 'deprecated-off', requiresReset: false },
+    port_forwarding: false,
+    expected: {
+      model: 'deprecated-off',
+      conversionErrors: [],
+    },
   },
   {
     name: 'local-and-remote (overriding deprecated even if specified)',
-    portForwarding: { local: { enabled: true }, remote: { enabled: true } },
-    legacyPortForwarding: false,
-    expected: { model: 'local-and-remote', requiresReset: false },
+    ssh_port_forwarding: {
+      local: { enabled: true },
+      remote: { enabled: true },
+    },
+    port_forwarding: false,
+    expected: {
+      model: 'local-and-remote',
+      conversionErrors: [],
+    },
   },
   {
     name: 'an empty port forwarding object',
-    portForwarding: {},
-    expected: { model: '', requiresReset: true },
+    ssh_port_forwarding: {},
+    expected: {
+      model: '',
+      conversionErrors: [
+        {
+          type: ConversionErrorType.UnsupportedValue,
+          path: 'spec.options.ssh_port_forwarding',
+        },
+      ],
+    },
   },
   {
     name: 'empty local and remote objects',
-    portForwarding: { local: {}, remote: {} },
-    expected: { model: '', requiresReset: true },
+    ssh_port_forwarding: { local: {}, remote: {} },
+    expected: {
+      model: '',
+      conversionErrors: [
+        {
+          type: ConversionErrorType.UnsupportedValue,
+          path: 'spec.options.ssh_port_forwarding',
+        },
+      ],
+    },
   },
   {
     name: 'unknown fields',
-    portForwarding: {
-      local: { enabled: true },
-      remote: { enabled: true },
+    ssh_port_forwarding: {
+      local: { enabled: true, localFoo: 'bar' },
+      remote: { enabled: true, remoteFoo: 'bar' },
       foo: 'bar',
     } as SSHPortForwarding,
-    expected: { model: 'local-and-remote', requiresReset: true },
-  },
-  {
-    name: 'unknown fields in local',
-    portForwarding: {
-      local: { enabled: true, foo: 'bar' },
-      remote: { enabled: false },
-    } as SSHPortForwarding,
-    expected: { model: 'local-only', requiresReset: true },
-  },
-  {
-    name: 'unknown fields in remote',
-    portForwarding: {
-      local: { enabled: false },
-      remote: { enabled: false, foo: 'bar' },
-    } as SSHPortForwarding,
-    expected: { model: 'none', requiresReset: true },
+    expected: {
+      model: 'local-and-remote',
+      conversionErrors: simpleConversionErrors(
+        ConversionErrorType.UnsupportedField,
+        [
+          'spec.options.ssh_port_forwarding.foo',
+          'spec.options.ssh_port_forwarding.local.localFoo',
+          'spec.options.ssh_port_forwarding.remote.remoteFoo',
+        ]
+      ),
+    },
   },
 ])(
   'portForwardingOptionsToModel(): $name',
-  ({ portForwarding, legacyPortForwarding, expected }) => {
+  ({ ssh_port_forwarding, port_forwarding, expected }) => {
     expect(
-      portForwardingOptionsToModel(portForwarding, legacyPortForwarding)
+      portForwardingOptionsToModel(
+        { ssh_port_forwarding, port_forwarding },
+        'spec.options'
+      )
     ).toEqual(expected);
   }
 );
 
 describe('roleToRoleEditorModel', () => {
   const minRole = minimalRole();
+  const minRoleModel = minimalRoleModel();
   const roleModelWithReset: RoleEditorModel = {
     ...minimalRoleModel(),
     requiresReset: true,
@@ -473,364 +560,158 @@ describe('roleToRoleEditorModel', () => {
     roleVersion: defaultRoleVersion,
   });
 
-  test.each<{ name: string; role: Role; model?: RoleEditorModel }>([
-    {
-      name: 'unknown fields in Role',
-      role: { ...minRole, unknownField: 123 } as Role,
-    },
-
-    {
-      name: 'unknown fields in metadata',
-      role: {
-        ...minRole,
-        metadata: { name: 'foobar', unknownField: 123 },
-      } as Role,
-    },
-
-    {
-      name: 'unknown fields in spec',
-      role: {
-        ...minRole,
-        spec: { ...minRole.spec, unknownField: 123 },
-      } as Role,
-    },
-
-    {
-      name: 'unknown fields in spec.allow',
-      role: {
-        ...minRole,
-        spec: {
-          ...minRole.spec,
-          allow: { ...minRole.spec.allow, unknownField: 123 },
+  test('unknown and invalid fields are reported as conversion errors', () => {
+    const role = {
+      ...minRole,
+      unknown1: 123,
+      unknown2: 234,
+      metadata: { name: 'foobar', metadataUnknown: 123 },
+      spec: {
+        ...minRole.spec,
+        specUnknown: 123,
+        allow: {
+          ...minRole.spec.allow,
+          allowUnknown: 123,
+          kubernetes_resources: [
+            { kind: 'job', resUnknown: 123 } as KubernetesResource,
+            { kind: 'illegal' } as unknown as KubernetesResource,
+            {
+              kind: '*',
+              verbs: ['illegal', 'get'],
+            } as unknown as KubernetesResource,
+          ],
+          github_permissions: [
+            { orgs: ['foo'], gitHubUnknown: 123 } as GitHubPermission,
+          ],
+          rules: [
+            { ruleUnknown: 123 } as Rule,
+            { verbs: ['create', 'illegal'] } as Rule,
+          ],
         },
-      } as Role,
-    },
-
-    {
-      name: 'unknown fields in KubernetesResource',
-      role: {
-        ...minRole,
-        spec: {
-          ...minRole.spec,
-          allow: {
-            ...minRole.spec.allow,
-            kubernetes_resources: [
-              { kind: 'job', unknownField: 123 } as KubernetesResource,
-            ],
-          },
-        },
-      } as Role,
-      model: {
-        ...roleModelWithReset,
-        resources: [
-          {
-            ...newKubeClusterResourceAccess(),
-            resources: [expect.any(Object)],
-          },
-        ],
-      },
-    },
-
-    {
-      name: 'unsupported resource kind in KubernetesResource',
-      role: {
-        ...minRole,
-        spec: {
-          ...minRole.spec,
-          allow: {
-            ...minRole.spec.allow,
-            kubernetes_resources: [
-              { kind: 'illegal' } as unknown as KubernetesResource,
-              { kind: 'job' },
-            ],
-          },
-        },
-      } as Role,
-      model: {
-        ...roleModelWithReset,
-        resources: [
-          {
-            ...newKubeClusterResourceAccess(),
-            resources: [
-              expect.objectContaining({ kind: { value: 'job', label: 'Job' } }),
-            ],
-          },
-        ],
-      },
-    },
-
-    {
-      name: 'unsupported verb in KubernetesResource',
-      role: {
-        ...minRole,
-        spec: {
-          ...minRole.spec,
-          allow: {
-            ...minRole.spec.allow,
-            kubernetes_resources: [
-              {
-                kind: '*',
-                verbs: ['illegal', 'get'],
-              } as unknown as KubernetesResource,
-            ],
-          },
-        },
-      } as Role,
-      model: {
-        ...roleModelWithReset,
-        resources: [
-          {
-            ...newKubeClusterResourceAccess(),
-            resources: [
-              expect.objectContaining({
-                verbs: [kubernetesVerbOptionsMap.get('get')],
-              }),
-            ],
-          },
-        ],
-      },
-    },
-
-    {
-      name: 'unknown field in github_permissions',
-      role: {
-        ...minRole,
-        spec: {
-          ...minRole.spec,
-          allow: {
-            ...minRole.spec.allow,
-            github_permissions: [
-              { orgs: ['foo'], unknownField: 123 } as GitHubPermission,
-            ],
-          },
-        },
-      },
-      model: {
-        ...roleModelWithReset,
-        resources: [
-          {
-            kind: 'git_server',
-            organizations: [{ label: 'foo', value: 'foo' }],
-          },
-        ],
-      },
-    },
-
-    {
-      name: 'unknown fields in Rule',
-      role: {
-        ...minRole,
-        spec: {
-          ...minRole.spec,
-          allow: {
-            ...minRole.spec.allow,
-            rules: [{ unknownField: 123 } as Rule],
-          },
-        },
-      } as Role,
-      model: {
-        ...roleModelWithReset,
-        rules: [expect.any(Object)],
-      },
-    },
-
-    {
-      name: 'unsupported verb in Rule',
-      role: {
-        ...minRole,
-        spec: {
-          ...minRole.spec,
-          allow: {
-            ...minRole.spec.allow,
-            rules: [{ verbs: ['illegal', 'create'] } as unknown as Rule],
-          },
-        },
-      } as Role,
-      model: {
-        ...roleModelWithReset,
-        rules: [
-          expect.objectContaining({
-            verbs: [{ value: 'create', label: 'create' }],
-          }),
-        ],
-      },
-    },
-
-    {
-      name: 'unknown fields in spec.deny',
-      role: {
-        ...minRole,
-        spec: {
-          ...minRole.spec,
-          deny: { ...minRole.spec.deny, unknownField: 123 },
-        },
-      } as Role,
-    },
-
-    {
-      name: 'unknown fields in spec.options',
-      role: {
-        ...minRole,
-        spec: {
-          ...minRole.spec,
-          options: { ...minRole.spec.options, unknownField: 123 },
-        },
-      } as Role,
-    },
-
-    {
-      name: 'unknown fields in spec.options.idp.saml',
-      role: {
-        ...minRole,
-        spec: {
-          ...minRole.spec,
-          options: {
-            ...minRole.spec.options,
-            idp: { saml: { enabled: true, unknownField: 123 } },
-          },
-        },
-      } as Role,
-    },
-
-    {
-      name: 'unknown fields in spec.options.record_session',
-      role: {
-        ...minRole,
-        spec: {
-          ...minRole.spec,
-          options: {
-            ...minRole.spec.options,
-            record_session: {
-              ...minRole.spec.options.record_session,
-              unknownField: 123,
-            },
-          },
-        },
-      } as Role,
-    },
-
-    {
-      name: 'unsupported value in spec.options.require_session_mfa',
-      role: {
-        ...minRole,
-        spec: {
-          ...minRole.spec,
-          options: {
-            ...minRole.spec.options,
-            require_session_mfa: 'bogus' as RequireMFAType,
-          },
-        },
-      },
-      model: {
-        ...roleModelWithReset,
+        deny: { ...minRole.spec.deny, denyUnknown: 123 },
         options: {
-          ...roleModelWithReset.options,
-          requireMFAType: requireMFATypeOptionsMap.get(false),
-        },
-      },
-    },
-
-    {
-      name: 'unsupported value in spec.options.create_host_user_mode',
-      role: {
-        ...minRole,
-        spec: {
-          ...minRole.spec,
-          options: {
-            ...minRole.spec.options,
-            create_host_user_mode: 'bogus' as CreateHostUserMode,
+          ...minRole.spec.options,
+          optionsUnknown: 123,
+          idp: { saml: { enabled: true, unknownField: 123 } },
+          record_session: {
+            ...minRole.spec.options.record_session,
+            recordSessionUnknown: 123,
+            default: 'bogus' as SessionRecordingMode,
+            ssh: 'bogus' as SessionRecordingMode,
           },
+          require_session_mfa: 'bogus' as RequireMFAType,
+          create_host_user_mode: 'bogus' as CreateHostUserMode,
+          create_db_user_mode: 'bogus' as CreateDBUserMode,
+          ssh_port_forwarding: {},
+          cert_format: 'unsupported-format',
+          enhanced_recording: [],
+          pin_source_ip: true,
+          ssh_file_copy: false,
         },
       },
-      model: {
-        ...roleModelWithReset,
-        options: {
-          ...roleModelWithReset.options,
-          createHostUserMode: createHostUserModeOptionsMap.get(''),
+    } as Role;
+    const model: RoleEditorModel = {
+      ...minRoleModel,
+      conversionErrors: [
+        {
+          type: ConversionErrorType.UnsupportedField,
+          errors: simpleConversionErrors(ConversionErrorType.UnsupportedField, [
+            'metadata.metadataUnknown',
+            'spec.allow.allowUnknown',
+            'spec.allow.github_permissions[0].gitHubUnknown',
+            'spec.allow.kubernetes_resources[0].resUnknown',
+            'spec.allow.rules[0].ruleUnknown',
+            'spec.deny.denyUnknown',
+            'spec.options.optionsUnknown',
+            'spec.options.record_session.recordSessionUnknown',
+            'spec.specUnknown',
+            'unknown1',
+            'unknown2',
+          ]),
         },
+        {
+          type: ConversionErrorType.UnsupportedValue,
+          errors: simpleConversionErrors(ConversionErrorType.UnsupportedValue, [
+            'spec.allow.kubernetes_resources[1]',
+            'spec.allow.kubernetes_resources[2].verbs[0]',
+            'spec.allow.rules[1].verbs[1]',
+            'spec.options.ssh_port_forwarding',
+          ]),
+        },
+        {
+          type: ConversionErrorType.UnsupportedValueWithReplacement,
+          errors: [
+            unsupportedValueWithReplacement(
+              'spec.options.cert_format',
+              'standard'
+            ),
+            unsupportedValueWithReplacement(
+              'spec.options.create_db_user_mode',
+              ''
+            ),
+            unsupportedValueWithReplacement(
+              'spec.options.create_host_user_mode',
+              ''
+            ),
+            unsupportedValueWithReplacement('spec.options.enhanced_recording', [
+              'command',
+              'network',
+            ]),
+            unsupportedValueWithReplacement('spec.options.idp', {
+              saml: { enabled: true },
+            }),
+            unsupportedValueWithReplacement(
+              'spec.options.pin_source_ip',
+              false
+            ),
+            unsupportedValueWithReplacement(
+              'spec.options.record_session.default',
+              ''
+            ),
+            unsupportedValueWithReplacement(
+              'spec.options.record_session.ssh',
+              ''
+            ),
+            unsupportedValueWithReplacement(
+              'spec.options.require_session_mfa',
+              false
+            ),
+            unsupportedValueWithReplacement('spec.options.ssh_file_copy', true),
+          ],
+        },
+      ],
+      requiresReset: true,
+      resources: [
+        {
+          ...newKubeClusterResourceAccess(),
+          resources: [
+            expect.objectContaining({
+              kind: kubernetesResourceKindOptionsMap.get('job'),
+            }),
+            expect.objectContaining({
+              verbs: [kubernetesVerbOptionsMap.get('get')],
+            }),
+          ],
+        },
+        {
+          kind: 'git_server',
+          organizations: [{ label: 'foo', value: 'foo' }],
+        },
+      ],
+      rules: [
+        expect.any(Object),
+        expect.objectContaining({
+          verbs: [{ value: 'create', label: 'create' }],
+        }),
+      ],
+      options: {
+        ...roleModelWithReset.options,
+        defaultSessionRecordingMode: sessionRecordingModeOptionsMap.get(''),
       },
-    },
+    };
 
-    {
-      name: 'unsupported value in spec.options.create_db_user_mode',
-      role: {
-        ...minRole,
-        spec: {
-          ...minRole.spec,
-          options: {
-            ...minRole.spec.options,
-            create_db_user_mode: 'bogus' as CreateDBUserMode,
-          },
-        },
-      },
-      model: {
-        ...roleModelWithReset,
-        options: {
-          ...roleModelWithReset.options,
-          createDBUserMode: createDBUserModeOptionsMap.get(''),
-        },
-      },
-    },
-
-    {
-      name: 'unsupported value in spec.options.record_session.default',
-      role: {
-        ...minRole,
-        spec: {
-          ...minRole.spec,
-          options: optionsWithDefaults({
-            record_session: { default: 'bogus' as SessionRecordingMode },
-          }),
-        },
-      },
-      model: {
-        ...roleModelWithReset,
-        options: {
-          ...roleModelWithReset.options,
-          defaultSessionRecordingMode: sessionRecordingModeOptionsMap.get(''),
-        },
-      },
-    },
-
-    {
-      name: 'unsupported value in spec.options.record_session.ssh',
-      role: {
-        ...minRole,
-        spec: {
-          ...minRole.spec,
-          options: optionsWithDefaults({
-            record_session: { ssh: 'bogus' as SessionRecordingMode },
-          }),
-        },
-      },
-      model: {
-        ...roleModelWithReset,
-        options: {
-          ...roleModelWithReset.options,
-          sshSessionRecordingMode: sessionRecordingModeOptionsMap.get(''),
-        },
-      },
-    },
-
-    {
-      name: 'unsupported value in spec.options.ssh_port_forwarding',
-      role: {
-        ...minRole,
-        spec: {
-          ...minRole.spec,
-          options: optionsWithDefaults({
-            ssh_port_forwarding: {},
-          }),
-        },
-      },
-      model: roleModelWithReset,
-    },
-  ])(
-    'requires reset because of $name',
-    ({ role, model = roleModelWithReset }) => {
-      expect(roleToRoleEditorModel(role)).toEqual(model);
-    }
-  );
+    expect(roleToRoleEditorModel(role)).toEqual(model);
+  });
 
   test('unsupported version requires reset', () => {
     expect(
@@ -838,10 +719,22 @@ describe('roleToRoleEditorModel', () => {
     ).toEqual({
       ...minimalRoleModel(),
       requiresReset: true,
+      conversionErrors: [
+        {
+          type: ConversionErrorType.UnsupportedValueWithReplacement,
+          errors: [
+            {
+              type: ConversionErrorType.UnsupportedValueWithReplacement,
+              path: 'version',
+              replacement: '"v7"',
+            },
+          ],
+        },
+      ],
     } as RoleEditorModel);
   });
 
-  it('preserves original revision', () => {
+  it('revision change requires reset', () => {
     const rev = '5d7e724b-a52c-4c12-9372-60a8d1af5d33';
     const originalRev = '9c2d5732-c514-46c3-b18d-2009b65af7b8';
     const exampleRole = (revision: string) => ({
@@ -860,41 +753,23 @@ describe('roleToRoleEditorModel', () => {
       ...minimalRoleModel(),
       metadata: {
         name: 'role-name',
+        // We need to preserve the original revision.
         revision: originalRev,
         labels: [],
         version: roleVersionOptionsMap.get(defaultRoleVersion),
       },
       requiresReset: true,
-    } as RoleEditorModel);
-  });
-
-  test('revision change requires reset', () => {
-    expect(
-      roleToRoleEditorModel(
+      conversionErrors: [
         {
-          ...minimalRole(),
-          metadata: {
-            name: 'role-name',
-            revision: '5d7e724b-a52c-4c12-9372-60a8d1af5d33',
-          },
+          type: ConversionErrorType.UnsupportedChange,
+          errors: [
+            {
+              type: ConversionErrorType.UnsupportedChange,
+              path: 'metadata.revision',
+            },
+          ],
         },
-        {
-          ...minimalRole(),
-          metadata: {
-            name: 'role-name',
-            revision: 'e39ea9f1-79b7-4d28-8f0c-af6848f9e655',
-          },
-        }
-      )
-    ).toEqual({
-      ...minimalRoleModel(),
-      metadata: {
-        name: 'role-name',
-        revision: 'e39ea9f1-79b7-4d28-8f0c-af6848f9e655',
-        labels: [],
-        version: roleVersionOptionsMap.get(defaultRoleVersion),
-      },
-      requiresReset: true,
+      ],
     } as RoleEditorModel);
   });
 

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.ts
@@ -38,10 +38,18 @@ import {
   RoleVersion,
   Rule,
   SessionRecordingMode,
-  SSHPortForwarding,
   Verb,
 } from 'teleport/services/resources/types';
 
+import {
+  ConversionError,
+  ConversionErrorGroup,
+  ConversionErrorType,
+  getOptionOrPushError,
+  groupAndSortConversionErrors,
+  unsupportedFieldErrorsFromObject,
+  unsupportedValueWithReplacement,
+} from './errors';
 import { RoleEditorModelValidationResult } from './validation';
 import { defaultOptions } from './withDefaults';
 
@@ -72,6 +80,7 @@ export type RoleEditorModel = {
    * structured editor.
    */
   requiresReset: boolean;
+  conversionErrors: ConversionErrorGroup[];
 };
 
 export type MetadataModel = {
@@ -535,22 +544,52 @@ export function roleToRoleEditorModel(
   role: Role,
   originalRole?: Role
 ): RoleEditorModel {
+  const conversionErrors: ConversionError[] = [];
+
   // We use destructuring to strip fields from objects and assert that nothing
   // has been left. Therefore, we don't want Lint to warn us that we didn't use
   // some of the fields.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { kind, metadata, spec, version, ...unsupported } = role;
+  conversionErrors.push(...unsupportedFieldErrorsFromObject('', unsupported));
+
   const { name, description, revision, labels, ...unsupportedMetadata } =
     metadata;
+  conversionErrors.push(
+    ...unsupportedFieldErrorsFromObject('metadata', unsupportedMetadata)
+  );
+
   const { allow, deny, options, ...unsupportedSpecs } = spec;
+  conversionErrors.push(
+    ...unsupportedFieldErrorsFromObject('spec', unsupportedSpecs)
+  );
+  conversionErrors.push(...unsupportedFieldErrorsFromObject('spec.deny', deny));
+
+  const versionOption = getOptionOrPushError(
+    version,
+    roleVersionOptionsMap,
+    RoleVersion.V7,
+    'version',
+    conversionErrors
+  );
+
+  if (revision !== originalRole?.metadata?.revision) {
+    conversionErrors.push({
+      type: ConversionErrorType.UnsupportedChange,
+      path: 'metadata.revision',
+    });
+  }
+
   const {
     resources,
     rules,
-    requiresReset: allowRequiresReset,
-  } = roleConditionsToModel(allow, version);
-  const { model: optionsModel, requiresReset: optionsRequireReset } =
-    optionsToModel(options);
-  const versionOption = roleVersionOptionsMap.get(version);
+    conversionErrors: allowConversionErrors,
+  } = roleConditionsToModel(allow, version, 'spec.allow');
+  conversionErrors.push(...allowConversionErrors);
+
+  const { model: optionsModel, conversionErrors: optionsConversionErrors } =
+    optionsToModel(options, 'spec.options');
+  conversionErrors.push(...optionsConversionErrors);
 
   return {
     metadata: {
@@ -558,22 +597,13 @@ export function roleToRoleEditorModel(
       description,
       revision: originalRole?.metadata?.revision,
       labels: labelsToModel(labels),
-      version: versionOption ?? roleVersionOptionsMap.get(RoleVersion.V7),
+      version: versionOption,
     },
     resources,
     rules,
     options: optionsModel,
-    requiresReset:
-      revision !== originalRole?.metadata?.revision ||
-      versionOption === undefined ||
-      !(
-        isEmpty(unsupported) &&
-        isEmpty(unsupportedMetadata) &&
-        isEmpty(unsupportedSpecs) &&
-        isEmpty(deny)
-      ) ||
-      allowRequiresReset ||
-      optionsRequireReset,
+    requiresReset: conversionErrors.length > 0,
+    conversionErrors: groupAndSortConversionErrors(conversionErrors),
   };
 }
 
@@ -583,8 +613,12 @@ export function roleToRoleEditorModel(
  */
 function roleConditionsToModel(
   conditions: RoleConditions,
-  roleVersion: RoleVersion
-): Pick<RoleEditorModel, 'resources' | 'rules' | 'requiresReset'> {
+  roleVersion: RoleVersion,
+  pathPrefix: string
+): Pick<RoleEditorModel, 'resources' | 'rules'> & {
+  conversionErrors: ConversionError[];
+} {
+  const conversionErrors: ConversionError[] = [];
   const {
     // Server access
     node_labels,
@@ -619,8 +653,11 @@ function roleConditionsToModel(
     // Access rules
     rules,
 
-    ...unsupportedConditions
+    ...unsupported
   } = conditions;
+  conversionErrors.push(
+    ...unsupportedFieldErrorsFromObject(pathPrefix, unsupported)
+  );
 
   const resources: ResourceAccess[] = [];
 
@@ -638,8 +675,14 @@ function roleConditionsToModel(
   const kubeLabelsModel = labelsToModel(kubernetes_labels);
   const {
     model: kubeResourcesModel,
-    requiresReset: kubernetesResourcesRequireReset,
-  } = kubernetesResourcesToModel(kubernetes_resources, roleVersion);
+    conversionErrors: kubernetesResourceConversionErrors,
+  } = kubernetesResourcesToModel(
+    kubernetes_resources,
+    roleVersion,
+    `${pathPrefix}.kubernetes_resources`
+  );
+  conversionErrors.push(...kubernetesResourceConversionErrors);
+
   const kubeUsersModel = stringsToOptions(kubernetes_users ?? []);
   if (
     someNonEmpty(
@@ -718,26 +761,27 @@ function roleConditionsToModel(
 
   const {
     model: gitHubOrganizationsModel,
-    requiresReset: gitHubOrgsRequireReset,
-  } = gitHubOrganizationsToModel(github_permissions);
+    conversionErrors: gitHubOrganizationConversionErrors,
+  } = gitHubOrganizationsToModel(
+    github_permissions,
+    `${pathPrefix}.github_permissions`
+  );
   if (someNonEmpty(gitHubOrganizationsModel)) {
     resources.push({
       kind: 'git_server',
       organizations: gitHubOrganizationsModel,
     });
   }
+  conversionErrors.push(...gitHubOrganizationConversionErrors);
 
-  const { model: rulesModel, requiresReset: rulesRequireReset } =
-    rulesToModel(rules);
+  const { model: rulesModel, conversionErrors: ruleConversionErrors } =
+    rulesToModel(rules, `${pathPrefix}.rules`);
+  conversionErrors.push(...ruleConversionErrors);
 
   return {
     resources: resources,
     rules: rulesModel,
-    requiresReset:
-      kubernetesResourcesRequireReset ||
-      gitHubOrgsRequireReset ||
-      rulesRequireReset ||
-      !isEmpty(unsupportedConditions),
+    conversionErrors,
   };
 }
 
@@ -773,28 +817,56 @@ function stringsToOptions<T extends string>(arr: T[]): Option<T>[] {
 
 function kubernetesResourcesToModel(
   resources: KubernetesResource[] | undefined,
-  roleVersion: RoleVersion
-): { model: KubernetesResourceModel[]; requiresReset: boolean } {
-  const result = (resources ?? []).map(res =>
-    kubernetesResourceToModel(res, roleVersion)
+  roleVersion: RoleVersion,
+  pathPrefix: string
+): {
+  model: KubernetesResourceModel[];
+  conversionErrors: ConversionError[];
+} {
+  const result = (resources ?? []).map((res, i) =>
+    kubernetesResourceToModel(res, roleVersion, `${pathPrefix}[${i}]`)
   );
   return {
     model: result.map(r => r.model).filter(m => m !== undefined),
-    requiresReset: result.some(r => r.requiresReset),
+    conversionErrors: result.flatMap(r => r.conversionErrors),
   };
 }
 
 function kubernetesResourceToModel(
   res: KubernetesResource,
-  roleVersion: RoleVersion
+  roleVersion: RoleVersion,
+  pathPrefix: string
 ): {
   model?: KubernetesResourceModel;
-  requiresReset: boolean;
+  conversionErrors: ConversionError[];
 } {
   const { kind, name, namespace = '', verbs = [], ...unsupported } = res;
+  const conversionErrors = unsupportedFieldErrorsFromObject(
+    pathPrefix,
+    unsupported
+  );
+
   const kindOption = kubernetesResourceKindOptionsMap.get(kind);
+  if (kindOption === undefined) {
+    conversionErrors.push({
+      type: ConversionErrorType.UnsupportedValue,
+      path: pathPrefix,
+    });
+  }
+
   const verbOptions = verbs.map(verb => kubernetesVerbOptionsMap.get(verb));
-  const knownVerbOptions = verbOptions.filter(v => v !== undefined);
+  const knownVerbOptions: KubernetesVerbOption[] = [];
+  for (let i = 0; i < verbOptions.length; i++) {
+    if (verbOptions[i] !== undefined) {
+      knownVerbOptions.push(verbOptions[i]);
+    } else {
+      conversionErrors.push({
+        type: ConversionErrorType.UnsupportedValue,
+        path: `${pathPrefix}.verbs[${i}]`,
+      });
+    }
+  }
+
   return {
     model:
       kindOption !== undefined
@@ -807,10 +879,7 @@ function kubernetesResourceToModel(
             roleVersion,
           }
         : undefined,
-    requiresReset:
-      kindOption === undefined ||
-      verbOptions.length !== knownVerbOptions.length ||
-      !isEmpty(unsupported),
+    conversionErrors,
   };
 }
 
@@ -823,45 +892,81 @@ function kubernetesResourceToModel(
  * organizations; however, since this would require adding additional fields to
  * the `GitHubPermission` object (otherwise, such change wouldn't make sense),
  * this function is protected anyway from attempting to interpret such an
- * extended object, and it would return `requiresReset: true` anyway.
+ * extended object, and it would return non-empty `conversionErrors` anyway.
  */
-function gitHubOrganizationsToModel(gitHubPermissions: GitHubPermission[]): {
+function gitHubOrganizationsToModel(
+  gitHubPermissions: GitHubPermission[],
+  pathPrefix: string
+): {
   model: Option[];
-  requiresReset: boolean;
+  conversionErrors: ConversionError[];
 } {
   const permissions = gitHubPermissions ?? [];
-  let requiresReset = false;
   const model: Option[] = [];
-  for (const { orgs, ...rest } of permissions) {
-    if (!isEmpty(rest)) {
-      requiresReset = true;
-    }
+  const conversionErrors: ConversionError[] = [];
+  for (let i = 0; i < permissions.length; i++) {
+    const { orgs, ...unsupported } = permissions[i];
     model.push(...stringsToOptions(orgs));
+    conversionErrors.push(
+      ...unsupportedFieldErrorsFromObject(`${pathPrefix}[${i}]`, unsupported)
+    );
   }
 
-  return { model, requiresReset };
-}
-
-function rulesToModel(rules: Rule[]): {
-  model: RuleModel[];
-  requiresReset: boolean;
-} {
-  const result = (rules ?? []).map(ruleToModel);
   return {
-    model: result.map(r => r.model),
-    requiresReset: result.some(r => r.requiresReset),
+    model,
+    conversionErrors,
   };
 }
 
-function ruleToModel(rule: Rule): { model: RuleModel; requiresReset: boolean } {
+function rulesToModel(
+  rules: Rule[] | undefined,
+  pathPrefix: string
+): {
+  model: RuleModel[];
+  conversionErrors: ConversionError[];
+} {
+  const model: RuleModel[] = [];
+  const conversionErrors: ConversionError[] = [];
+  for (let i = 0; i < (rules?.length ?? 0); i++) {
+    const m = ruleToModel(rules[i], `${pathPrefix}[${i}]`);
+    model.push(m.model);
+    conversionErrors.push(...m.conversionErrors);
+  }
+  return {
+    model,
+    conversionErrors,
+  };
+}
+
+function ruleToModel(
+  rule: Rule,
+  pathPrefix: string
+): {
+  model: RuleModel;
+  conversionErrors: ConversionError[];
+} {
   const { resources = [], verbs = [], where = '', ...unsupported } = rule;
+  const conversionErrors = unsupportedFieldErrorsFromObject(
+    pathPrefix,
+    unsupported
+  );
   const resourcesModel = resources.map(
+    // Resource kind can be unknown, so we just create a necessary option on
+    // the fly.
     k => resourceKindOptionsMap.get(k) ?? { label: k, value: k }
   );
   const verbsModel = verbs.map(v => verbOptionsMap.get(v));
-  const knownVerbsModel = verbsModel.filter(m => m !== undefined);
-  const requiresReset =
-    !isEmpty(unsupported) || knownVerbsModel.length !== verbs.length;
+  const knownVerbsModel: VerbOption[] = [];
+  for (let i = 0; i < verbsModel.length; i++) {
+    if (verbsModel[i] !== undefined) {
+      knownVerbsModel.push(verbsModel[i]);
+    } else {
+      conversionErrors.push({
+        type: ConversionErrorType.UnsupportedValue,
+        path: `${pathPrefix}.verbs[${i}]`,
+      });
+    }
+  }
   return {
     model: {
       id: crypto.randomUUID(),
@@ -869,14 +974,29 @@ function ruleToModel(rule: Rule): { model: RuleModel; requiresReset: boolean } {
       verbs: knownVerbsModel,
       where,
     },
-    requiresReset,
+    conversionErrors,
   };
 }
 
-function optionsToModel(options: RoleOptions): {
+// These options must keep their default values, as we don't support them in
+// the standard editor, but they are required fields of the RoleOptions type.
+const uneditableOptionKeys: (keyof RoleOptions)[] = [
+  'cert_format',
+  'enhanced_recording',
+  'idp',
+  'pin_source_ip',
+  'ssh_file_copy',
+];
+
+function optionsToModel(
+  options: RoleOptions,
+  pathPrefix: string
+): {
   model: OptionsModel;
-  requiresReset: boolean;
+  conversionErrors: ConversionError[];
 } {
+  const defaultOpts = defaultOptions();
+  const conversionErrors: ConversionError[] = [];
   const {
     // Customizable options.
     max_session_ttl,
@@ -894,16 +1014,27 @@ function optionsToModel(options: RoleOptions): {
     port_forwarding,
     ssh_port_forwarding,
 
-    // These options must keep their default values, as we don't support them
-    // in the standard editor.
-    cert_format,
-    enhanced_recording,
-    idp,
-    pin_source_ip,
-    ssh_file_copy,
-
     ...unsupported
   } = options;
+
+  for (const key of uneditableOptionKeys) {
+    // Report uneditable options as errors if they diverge from their defaults.
+    if (!equalsDeep(options[key], defaultOpts[key])) {
+      conversionErrors.push(
+        unsupportedValueWithReplacement(
+          `${pathPrefix}.${key}`,
+          defaultOpts[key]
+        )
+      );
+    }
+    // Instead of using destructuring to remove them from our sight, we
+    // explicitly delete these here to have these keys declared in a single
+    // place (the `uneditableOptionKeys` array) and prevent inconsistency.
+    delete unsupported[key];
+  }
+  conversionErrors.push(
+    ...unsupportedFieldErrorsFromObject('spec.options', unsupported)
+  );
 
   const {
     default: defaultRecordingMode = '',
@@ -911,45 +1042,76 @@ function optionsToModel(options: RoleOptions): {
     desktop: recordDesktopSessions = true,
     ...unsupportedRecordingOptions
   } = record_session || {};
-
-  const requireMFATypeOption =
-    requireMFATypeOptionsMap.get(require_session_mfa);
-  const createHostUserModeOption = createHostUserModeOptionsMap.get(
-    create_host_user_mode
+  conversionErrors.push(
+    ...unsupportedFieldErrorsFromObject(
+      `${pathPrefix}.record_session`,
+      unsupportedRecordingOptions
+    )
   );
-  const createDBUserModeOption =
-    createDBUserModeOptionsMap.get(create_db_user_mode);
-  const defaultSessionRecordingModeOption =
-    sessionRecordingModeOptionsMap.get(defaultRecordingMode);
-  const sshSessionRecordingModeOption =
-    sessionRecordingModeOptionsMap.get(sshRecordingMode);
+
+  const requireMFATypeOption = getOptionOrPushError(
+    require_session_mfa,
+    requireMFATypeOptionsMap,
+    false,
+    `${pathPrefix}.require_session_mfa`,
+    conversionErrors
+  );
+
+  const createHostUserModeOption = getOptionOrPushError(
+    create_host_user_mode,
+    createHostUserModeOptionsMap,
+    '',
+    `${pathPrefix}.create_host_user_mode`,
+    conversionErrors
+  );
+
+  const createDBUserModeOption = getOptionOrPushError(
+    create_db_user_mode,
+    createDBUserModeOptionsMap,
+    '',
+    `${pathPrefix}.create_db_user_mode`,
+    conversionErrors
+  );
+
+  const defaultSessionRecordingModeOption = getOptionOrPushError(
+    defaultRecordingMode,
+    sessionRecordingModeOptionsMap,
+    '',
+    `${pathPrefix}.record_session.default`,
+    conversionErrors
+  );
+
+  const sshSessionRecordingModeOption = getOptionOrPushError(
+    sshRecordingMode,
+    sessionRecordingModeOptionsMap,
+    '',
+    `${pathPrefix}.record_session.ssh`,
+    conversionErrors
+  );
+
   const {
     model: sshPortForwardingMode,
-    requiresReset: sshPortForwardingModeRequiresReset,
-  } = portForwardingOptionsToModel(ssh_port_forwarding, port_forwarding);
-
-  const defaultOpts = defaultOptions();
+    conversionErrors: sshPortForwardingConversionErrors,
+  } = portForwardingOptionsToModel(
+    { ssh_port_forwarding, port_forwarding },
+    `${pathPrefix}`
+  );
+  conversionErrors.push(...sshPortForwardingConversionErrors);
 
   return {
     model: {
       maxSessionTTL: max_session_ttl,
       clientIdleTimeout: client_idle_timeout,
       disconnectExpiredCert: disconnect_expired_cert,
-      requireMFAType:
-        requireMFATypeOption ?? requireMFATypeOptionsMap.get(false),
-      createHostUserMode:
-        createHostUserModeOption ?? createHostUserModeOptionsMap.get(''),
+      requireMFAType: requireMFATypeOption,
+      createHostUserMode: createHostUserModeOption,
       createDBUser: create_db_user,
-      createDBUserMode:
-        createDBUserModeOption ?? createDBUserModeOptionsMap.get(''),
+      createDBUserMode: createDBUserModeOption,
       desktopClipboard: desktop_clipboard,
       createDesktopUser: create_desktop_user,
       desktopDirectorySharing: desktop_directory_sharing,
-      defaultSessionRecordingMode:
-        defaultSessionRecordingModeOption ??
-        sessionRecordingModeOptionsMap.get(''),
-      sshSessionRecordingMode:
-        sshSessionRecordingModeOption ?? sessionRecordingModeOptionsMap.get(''),
+      defaultSessionRecordingMode: defaultSessionRecordingModeOption,
+      sshSessionRecordingMode: sshSessionRecordingModeOption,
       recordDesktopSessions,
       forwardAgent: forward_agent,
       sshPortForwardingMode: sshPortForwardingModeOptionsMap.get(
@@ -957,64 +1119,83 @@ function optionsToModel(options: RoleOptions): {
       ),
     },
 
-    requiresReset:
-      cert_format !== defaultOpts.cert_format ||
-      !equalsDeep(enhanced_recording, defaultOpts.enhanced_recording) ||
-      !equalsDeep(idp, defaultOpts.idp) ||
-      pin_source_ip !== defaultOpts.pin_source_ip ||
-      ssh_file_copy !== defaultOpts.ssh_file_copy ||
-      requireMFATypeOption === undefined ||
-      createHostUserModeOption === undefined ||
-      createDBUserModeOption === undefined ||
-      !isEmpty(unsupported) ||
-      !isEmpty(unsupportedRecordingOptions) ||
-      defaultSessionRecordingModeOption === undefined ||
-      sshSessionRecordingModeOption === undefined ||
-      sshPortForwardingModeRequiresReset,
+    conversionErrors,
   };
 }
 
 export function portForwardingOptionsToModel(
-  sshPortForwarding?: SSHPortForwarding,
-  legacyPortForwarding?: boolean
-): { model: SSHPortForwardingMode; requiresReset: boolean } {
-  if (sshPortForwarding) {
-    const { local, remote, ...rest } = sshPortForwarding;
+  {
+    ssh_port_forwarding,
+    port_forwarding,
+  }: Pick<RoleOptions, 'ssh_port_forwarding' | 'port_forwarding'>,
+  pathPrefix: string
+): {
+  model: SSHPortForwardingMode;
+  conversionErrors: ConversionError[];
+} {
+  if (ssh_port_forwarding) {
+    const { local, remote, ...unsupported } = ssh_port_forwarding;
     if (!local || !remote) {
-      return { model: '', requiresReset: true };
+      return {
+        model: '',
+        conversionErrors: [
+          {
+            type: ConversionErrorType.UnsupportedValue,
+            path: `${pathPrefix}.ssh_port_forwarding`,
+          },
+        ],
+      };
     }
 
-    const { enabled: localEnabled, ...localRest } = sshPortForwarding.local;
-    const { enabled: remoteEnabled, ...remoteRest } = sshPortForwarding.remote;
+    const { enabled: localEnabled, ...localUnsupported } =
+      ssh_port_forwarding.local;
+    const { enabled: remoteEnabled, ...remoteUnsupported } =
+      ssh_port_forwarding.remote;
     if (localEnabled === undefined || remoteEnabled === undefined) {
-      return { model: '', requiresReset: true };
+      return {
+        model: '',
+        conversionErrors: [
+          {
+            type: ConversionErrorType.UnsupportedValue,
+            path: `${pathPrefix}.ssh_port_forwarding`,
+          },
+        ],
+      };
     }
 
-    const requiresReset =
-      !isEmpty(rest) || !isEmpty(localRest) || !isEmpty(remoteRest);
+    const conversionErrors: ConversionError[] = [
+      ...unsupportedFieldErrorsFromObject(
+        `${pathPrefix}.ssh_port_forwarding`,
+        unsupported
+      ),
+      ...unsupportedFieldErrorsFromObject(
+        `${pathPrefix}.ssh_port_forwarding.local`,
+        localUnsupported
+      ),
+      ...unsupportedFieldErrorsFromObject(
+        `${pathPrefix}.ssh_port_forwarding.remote`,
+        remoteUnsupported
+      ),
+    ];
 
     if (!localEnabled && !remoteEnabled) {
-      return { model: 'none', requiresReset };
+      return { model: 'none', conversionErrors };
     }
     if (localEnabled && !remoteEnabled) {
-      return { model: 'local-only', requiresReset };
+      return { model: 'local-only', conversionErrors };
     }
     if (!localEnabled && remoteEnabled) {
-      return { model: 'remote-only', requiresReset };
+      return { model: 'remote-only', conversionErrors };
     }
-    return { model: 'local-and-remote', requiresReset };
+    return { model: 'local-and-remote', conversionErrors };
   }
-  if (legacyPortForwarding !== undefined) {
+  if (port_forwarding !== undefined) {
     return {
-      model: legacyPortForwarding ? 'deprecated-on' : 'deprecated-off',
-      requiresReset: false,
+      model: port_forwarding ? 'deprecated-on' : 'deprecated-off',
+      conversionErrors: [],
     };
   }
-  return { model: '', requiresReset: false };
-}
-
-function isEmpty(obj: object) {
-  return Object.keys(obj).length === 0;
+  return { model: '', conversionErrors: [] };
 }
 
 /**
@@ -1157,7 +1338,8 @@ function optionsModelToRoleOptions(model: OptionsModel): RoleOptions {
     forward_agent: model.forwardAgent,
   };
 
-  switch (model.sshPortForwardingMode.value) {
+  const mode = model.sshPortForwardingMode.value;
+  switch (mode) {
     case 'none':
       options.ssh_port_forwarding = {
         local: { enabled: false },
@@ -1193,6 +1375,9 @@ function optionsModelToRoleOptions(model: OptionsModel): RoleOptions {
     case 'deprecated-on':
       options.port_forwarding = true;
       break;
+
+    default:
+      mode satisfies '';
   }
 
   return options;

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.ts
@@ -856,16 +856,16 @@ function kubernetesResourceToModel(
 
   const verbOptions = verbs.map(verb => kubernetesVerbOptionsMap.get(verb));
   const knownVerbOptions: KubernetesVerbOption[] = [];
-  for (let i = 0; i < verbOptions.length; i++) {
-    if (verbOptions[i] !== undefined) {
-      knownVerbOptions.push(verbOptions[i]);
+  verbOptions.forEach((vo, i) => {
+    if (vo !== undefined) {
+      knownVerbOptions.push(vo);
     } else {
       conversionErrors.push({
         type: ConversionErrorType.UnsupportedValue,
         path: `${pathPrefix}.verbs[${i}]`,
       });
     }
-  }
+  });
 
   return {
     model:
@@ -904,13 +904,13 @@ function gitHubOrganizationsToModel(
   const permissions = gitHubPermissions ?? [];
   const model: Option[] = [];
   const conversionErrors: ConversionError[] = [];
-  for (let i = 0; i < permissions.length; i++) {
-    const { orgs, ...unsupported } = permissions[i];
+  permissions.forEach((permission, i) => {
+    const { orgs, ...unsupported } = permission;
     model.push(...stringsToOptions(orgs));
     conversionErrors.push(
       ...unsupportedFieldErrorsFromObject(`${pathPrefix}[${i}]`, unsupported)
     );
-  }
+  });
 
   return {
     model,
@@ -927,11 +927,11 @@ function rulesToModel(
 } {
   const model: RuleModel[] = [];
   const conversionErrors: ConversionError[] = [];
-  for (let i = 0; i < (rules?.length ?? 0); i++) {
-    const m = ruleToModel(rules[i], `${pathPrefix}[${i}]`);
+  rules?.forEach?.((rule, i) => {
+    const m = ruleToModel(rule, `${pathPrefix}[${i}]`);
     model.push(m.model);
     conversionErrors.push(...m.conversionErrors);
-  }
+  });
   return {
     model,
     conversionErrors,
@@ -957,16 +957,16 @@ function ruleToModel(
   );
   const verbsModel = verbs.map(v => verbOptionsMap.get(v));
   const knownVerbsModel: VerbOption[] = [];
-  for (let i = 0; i < verbsModel.length; i++) {
-    if (verbsModel[i] !== undefined) {
-      knownVerbsModel.push(verbsModel[i]);
+  verbsModel.forEach((verb, i) => {
+    if (verb !== undefined) {
+      knownVerbsModel.push(verb);
     } else {
       conversionErrors.push({
         type: ConversionErrorType.UnsupportedValue,
         path: `${pathPrefix}.verbs[${i}]`,
       });
     }
-  }
+  });
   return {
     model: {
       id: crypto.randomUUID(),

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/useStandardModel.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/useStandardModel.ts
@@ -63,6 +63,7 @@ export type StandardModelDispatcher = Dispatch<StandardModelAction>;
 
 type StandardModelAction =
   | SetModelAction
+  | ResetToStandardAction
   | SetMetadataAction
   | AddResourceAccessAction
   | SetResourceAccessAction
@@ -74,6 +75,7 @@ type StandardModelAction =
 
 /** Sets the entire model. */
 type SetModelAction = { type: 'set-role-model'; payload: RoleEditorModel };
+type ResetToStandardAction = { type: 'reset-to-standard'; payload?: never };
 type SetMetadataAction = { type: 'set-metadata'; payload: MetadataModel };
 type AddResourceAccessAction = {
   type: 'add-resource-access';
@@ -109,6 +111,11 @@ const reduce = (
   switch (type) {
     case 'set-role-model':
       state.roleModel = payload;
+      break;
+
+    case 'reset-to-standard':
+      state.roleModel.conversionErrors = [];
+      state.roleModel.requiresReset = false;
       break;
 
     case 'set-metadata':


### PR DESCRIPTION
Instead of collecting a single "requires reset" flag, we now collect every single conversion error when converting a role resource to the standard editor model.

![image](https://github.com/user-attachments/assets/6d461223-342a-4df4-829f-ad285e4e3223)