### PR TITLE
[v17] Fix MFA always required for file transfers

### DIFF
--- a/web/packages/teleport/src/Console/DocumentSsh/DocumentSsh.tsx
+++ b/web/packages/teleport/src/Console/DocumentSsh/DocumentSsh.tsx
@@ -55,6 +55,9 @@ function DocumentSsh({ doc, visible }: PropTypes) {
   const [showSearch, setShowSearch] = useState(false);
 
   const mfa = useMfaEmitter(tty, {
+    // The MFA requirement will be determined by whether we do/don't get
+    // an mfa challenge over the event emitter at session start.
+    isMfaRequired: false,
     req: {
       scope: MfaChallengeScope.USER_SESSION,
     },

--- a/web/packages/teleport/src/Console/DocumentSsh/DocumentSsh.tsx
+++ b/web/packages/teleport/src/Console/DocumentSsh/DocumentSsh.tsx
@@ -25,6 +25,7 @@ import {
   FileTransferActionBar,
   FileTransferContextProvider,
   FileTransferRequests,
+  useFileTransferContext,
 } from 'shared/components/FileTransfer';
 import { TerminalSearch } from 'shared/components/TerminalSearch';
 
@@ -63,6 +64,8 @@ function DocumentSsh({ doc, visible }: PropTypes) {
     },
   });
   const ft = useFileTransfer(tty, session, doc, mfa);
+  const { openedDialog: ftOpenedDialog } = useFileTransferContext();
+
   const theme = useTheme();
 
   function handleCloseFileTransfer() {
@@ -74,11 +77,12 @@ function DocumentSsh({ doc, visible }: PropTypes) {
   }
 
   useEffect(() => {
-    // when switching tabs or closing tabs, focus on visible terminal
-    if (mfa.attempt.status === 'processing') {
+    // If an MFA attempt starts while switching tabs or closing tabs,
+    // automatically focus on visible terminal.
+    if (mfa.challenge) {
       terminalRef.current?.focus();
     }
-  }, [visible, mfa.attempt.status]);
+  }, [visible, mfa.challenge]);
 
   const onSearchClose = useCallback(() => {
     setShowSearch(false);
@@ -143,7 +147,7 @@ function DocumentSsh({ doc, visible }: PropTypes) {
         mfaState={mfa}
         onClose={() => {
           // Don't close the ssh doc if this is just a file transfer request.
-          if (!ft.openedDialog) {
+          if (!ftOpenedDialog) {
             closeDocument();
           }
         }}

--- a/web/packages/teleport/src/Console/DocumentSsh/useFileTransfer.ts
+++ b/web/packages/teleport/src/Console/DocumentSsh/useFileTransfer.ts
@@ -54,7 +54,7 @@ export const useFileTransfer = (
   currentDoc: DocumentSsh,
   mfa: MfaState
 ) => {
-  const { filesStore } = useFileTransferContext();
+  const { filesStore, openedDialog } = useFileTransferContext();
   const startTransfer = filesStore.start;
   const ctx = useConsoleContext();
   const currentUser = ctx.getStoreUser();
@@ -261,6 +261,7 @@ export const useFileTransfer = (
 
   return {
     fileTransferRequests,
+    openedDialog,
     getUploader,
     getDownloader,
   };

--- a/web/packages/teleport/src/Console/DocumentSsh/useFileTransfer.ts
+++ b/web/packages/teleport/src/Console/DocumentSsh/useFileTransfer.ts
@@ -54,7 +54,7 @@ export const useFileTransfer = (
   currentDoc: DocumentSsh,
   mfa: MfaState
 ) => {
-  const { filesStore, openedDialog } = useFileTransferContext();
+  const { filesStore } = useFileTransferContext();
   const startTransfer = filesStore.start;
   const ctx = useConsoleContext();
   const currentUser = ctx.getStoreUser();
@@ -261,7 +261,6 @@ export const useFileTransfer = (
 
   return {
     fileTransferRequests,
-    openedDialog,
     getUploader,
     getDownloader,
   };

--- a/web/packages/teleport/src/lib/useMfa.test.tsx
+++ b/web/packages/teleport/src/lib/useMfa.test.tsx
@@ -235,14 +235,21 @@ describe('useMfa', () => {
       })
     );
 
-    let resp;
+    let resp: Promise<MfaChallengeResponse>;
     await act(async () => {
       resp = mfa.current.getChallengeResponse();
     });
 
+    // Before calling mfa.current.cancelAttempt(), we need to write code that handles rejection of
+    // resp. Otherwise the test is going to fail because of unhandled promise rejection.
+    // eslint-disable-next-line jest/valid-expect
+    const expectedRespRejection = expect(resp).rejects.toEqual(
+      new MfaCanceledError()
+    );
+
     await act(async () => mfa.current.cancelAttempt());
 
-    await expect(resp).rejects.toThrow(new MfaCanceledError());
+    await expectedRespRejection;
     expect(mfa.current.attempt.status).toEqual('error');
     expect(
       mfa.current.attempt.status === 'error' && mfa.current.attempt.error

--- a/web/packages/teleport/src/lib/useMfa.ts
+++ b/web/packages/teleport/src/lib/useMfa.ts
@@ -54,8 +54,8 @@ type mfaResponsePromiseWithResolvers = {
  * be used to display options to the user and prompt for them to complete
  * the MFA check.
  */
-export function useMfa({ req, isMfaRequired }: MfaProps): MfaState {
-  const [mfaRequired, setMfaRequired] = useState<boolean>(isMfaRequired);
+export function useMfa(props: MfaProps): MfaState {
+  const [mfaRequired, setMfaRequired] = useState<boolean>(props.isMfaRequired);
   const [options, setMfaOptions] = useState<MfaOption[]>();
   const [challenge, setMfaChallenge] = useState<MfaAuthenticateChallenge>();
 
@@ -75,7 +75,9 @@ export function useMfa({ req, isMfaRequired }: MfaProps): MfaState {
         // required, this is a noop.
         if (mfaRequired === false && !challenge) return;
 
-        challenge = challenge ? challenge : await auth.getMfaChallenge(req);
+        challenge = challenge
+          ? challenge
+          : await auth.getMfaChallenge(props.req);
         if (!challenge) {
           setMfaRequired(false);
           return;
@@ -107,7 +109,7 @@ export function useMfa({ req, isMfaRequired }: MfaProps): MfaState {
           setMfaChallenge(null);
         }
       },
-      [req, mfaRequired]
+      [props, mfaRequired]
     )
   );
 

--- a/web/packages/teleport/src/lib/useMfa.ts
+++ b/web/packages/teleport/src/lib/useMfa.ts
@@ -54,8 +54,8 @@ type mfaResponsePromiseWithResolvers = {
  * be used to display options to the user and prompt for them to complete
  * the MFA check.
  */
-export function useMfa(props: MfaProps): MfaState {
-  const [mfaRequired, setMfaRequired] = useState<boolean>(props.isMfaRequired);
+export function useMfa(props?: MfaProps): MfaState {
+  const [mfaRequired, setMfaRequired] = useState<boolean>(props?.isMfaRequired);
   const [options, setMfaOptions] = useState<MfaOption[]>();
   const [challenge, setMfaChallenge] = useState<MfaAuthenticateChallenge>();
 


### PR DESCRIPTION
Backport #51740 to branch/v17

changelog: Fixed a bug in the WebUI where file transfers would always prompt for MFA, even when not required.
