### PR TITLE
Update backends to support range iteration

### DIFF
--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -248,6 +248,19 @@ type Event struct {
 	Item Item
 }
 
+// IterationOrder dictates the order in which iteration should
+// return items.
+type IterationOrder int
+
+const (
+	// IterateAscend indicates to [backend.Iterate] that items should be
+	// returned in ascending lexicographical order of the queried key range.
+	IterateAscend IterationOrder = iota
+	// IterateAscend indicates to [backend.Iterate] that items should be
+	// returned in descending lexicographical order of the queried key range.
+	IterateDescend
+)
+
 // Item is a key value item
 type Item struct {
 	// Key is a key of the key value item


### PR DESCRIPTION
Introduces a new `Iterate(ctx context.Context, startKey, endKey backend.Key, limit int, order backend.IterationOrder) (iter.Seq2[backend.Item, error], error)` method to all concrete backend implementations. The core logic for this function was moved from GetRange, and GetRange now defers to calling Iterate and collecting a slice of items. This method will be included in the backend.Backend interface once the crdb implementation lands in teleport.e.

The motivation for this change is to attempt to reduce the complexity of pagination for consumers of GetRange. While `backend.IterateRange` and `backend.StreamRange` do already exists to serve the same purpose, they too have suffered from pagination bugs in the past. Additionally, this aims to unify iteration to using the new `iter` package instead of the various homegrown iteration functions and stream implementations.


There is also one distinct difference to the iteration api: it allows retrieving the items within the specified range in ascending or descending key order. While there may not be many use cases for this today, exposing this in the api from it's inception was easier than adding functional options, or IterateAscending/IterateDescending later.

The first commit introduces iteration constants and adds an iteration test to the backend test suite. All subsequent commits are atomic changes to each backend to add iteration support. The two most substantial changes introduced here are in the dynamodb and firestore backends. The dynamodb range retrieval was simplified to use the built in paginator provided by the sdk. The firestore backend iterator is more complicated than the rest because it needs to merge snapshots from three distinct document iterators due to the various key types that may exist, though this should be able to be removed in v19 with the background key migration.


CRDB iteration support: https://github.com/gravitational/teleport.e/pull/6024