### PR TITLE
Add ClusterMaintenanceConfig to web user ACL

### DIFF
--- a/lib/services/useracl.go
+++ b/lib/services/useracl.go
@@ -48,6 +48,8 @@ type UserACL struct {
 	Users ResourceAccess `json:"users"`
 	// TrustedClusters defines access to trusted clusters.
 	TrustedClusters ResourceAccess `json:"trustedClusters"`
+	// ClusterMaintenanceConfig defines access to update cluster maintenance config.
+	ClusterMaintenanceConfig ResourceAccess `json:"clusterMaintenanceConfig"`
 	// Events defines access to audit logs.
 	Events ResourceAccess `json:"events"`
 	// Tokens defines access to tokens.
@@ -153,6 +155,7 @@ func NewUserACL(user types.User, userRoles RoleSet, features proto.Features, des
 	roleAccess := newAccess(userRoles, ctx, types.KindRole)
 	authConnectors := newAccess(userRoles, ctx, types.KindAuthConnector)
 	trustedClusterAccess := newAccess(userRoles, ctx, types.KindTrustedCluster)
+	clusterMaintenanceConfig := newAccess(userRoles, ctx, types.KindClusterMaintenanceConfig)
 	eventAccess := newAccess(userRoles, ctx, types.KindEvent)
 	userAccess := newAccess(userRoles, ctx, types.KindUser)
 	tokenAccess := newAccess(userRoles, ctx, types.KindToken)
@@ -227,48 +230,49 @@ func NewUserACL(user types.User, userRoles RoleSet, features proto.Features, des
 	contact := newAccess(userRoles, ctx, types.KindContact)
 
 	return UserACL{
-		AccessRequests:          requestAccess,
-		AppServers:              appServerAccess,
-		DBServers:               dbServerAccess,
-		DB:                      dbAccess,
-		ReviewRequests:          reviewRequests,
-		KubeServers:             kubeServerAccess,
-		Desktops:                desktopAccess,
-		AuthConnectors:          authConnectors,
-		TrustedClusters:         trustedClusterAccess,
-		RecordedSessions:        recordedSessionAccess,
-		ActiveSessions:          activeSessionAccess,
-		Roles:                   roleAccess,
-		Events:                  eventAccess,
-		Users:                   userAccess,
-		Tokens:                  tokenAccess,
-		Nodes:                   nodeAccess,
-		Billing:                 billingAccess,
-		ConnectionDiagnostic:    cnDiagnosticAccess,
-		Clipboard:               clipboard,
-		DesktopSessionRecording: desktopSessionRecording,
-		DirectorySharing:        directorySharing,
-		Download:                download,
-		License:                 license,
-		Plugins:                 pluginsAccess,
-		Integrations:            integrationsAccess,
-		UserTasks:               userTasksAccess,
-		DiscoveryConfig:         discoveryConfigsAccess,
-		DeviceTrust:             deviceTrust,
-		Locks:                   lockAccess,
-		SAMLIdpServiceProvider:  samlIdpServiceProviderAccess,
-		AccessList:              accessListAccess,
-		AuditQuery:              auditQuery,
-		SecurityReport:          securityReports,
-		ExternalAuditStorage:    externalAuditStorage,
-		AccessGraph:             accessGraphAccess,
-		Bots:                    bots,
-		BotInstances:            botInstances,
-		AccessMonitoringRule:    accessMonitoringRules,
-		CrownJewel:              crownJewelAccess,
-		AccessGraphSettings:     accessGraphSettings,
-		Contact:                 contact,
-		FileTransferAccess:      fileTransferAccess,
-		GitServers:              gitServersAccess,
+		AccessRequests:           requestAccess,
+		AppServers:               appServerAccess,
+		DBServers:                dbServerAccess,
+		DB:                       dbAccess,
+		ReviewRequests:           reviewRequests,
+		KubeServers:              kubeServerAccess,
+		Desktops:                 desktopAccess,
+		AuthConnectors:           authConnectors,
+		TrustedClusters:          trustedClusterAccess,
+		ClusterMaintenanceConfig: clusterMaintenanceConfig,
+		RecordedSessions:         recordedSessionAccess,
+		ActiveSessions:           activeSessionAccess,
+		Roles:                    roleAccess,
+		Events:                   eventAccess,
+		Users:                    userAccess,
+		Tokens:                   tokenAccess,
+		Nodes:                    nodeAccess,
+		Billing:                  billingAccess,
+		ConnectionDiagnostic:     cnDiagnosticAccess,
+		Clipboard:                clipboard,
+		DesktopSessionRecording:  desktopSessionRecording,
+		DirectorySharing:         directorySharing,
+		Download:                 download,
+		License:                  license,
+		Plugins:                  pluginsAccess,
+		Integrations:             integrationsAccess,
+		UserTasks:                userTasksAccess,
+		DiscoveryConfig:          discoveryConfigsAccess,
+		DeviceTrust:              deviceTrust,
+		Locks:                    lockAccess,
+		SAMLIdpServiceProvider:   samlIdpServiceProviderAccess,
+		AccessList:               accessListAccess,
+		AuditQuery:               auditQuery,
+		SecurityReport:           securityReports,
+		ExternalAuditStorage:     externalAuditStorage,
+		AccessGraph:              accessGraphAccess,
+		Bots:                     bots,
+		BotInstances:             botInstances,
+		AccessMonitoringRule:     accessMonitoringRules,
+		CrownJewel:               crownJewelAccess,
+		AccessGraphSettings:      accessGraphSettings,
+		Contact:                  contact,
+		FileTransferAccess:       fileTransferAccess,
+		GitServers:               gitServersAccess,
 	}
 }

--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -556,15 +556,24 @@ export class FeatureClusters implements TeleportFeature {
     title: 'Clusters',
     path: cfg.routes.clusters,
     exact: false,
+    // TODO (avatus) if cloud/dashboard, make this go directly to the manage cluster page
+    // rather than the cluster "list", as this would always only have a single cluster
+    // for cloud users.
     component: Clusters,
   };
 
   hasAccess(flags: FeatureFlags) {
-    return cfg.isDashboard || flags.trustedClusters;
+    return (
+      cfg.isDashboard || flags.trustedClusters || flags.clusterMaintenanceConfig
+    );
   }
 
+  showInDashboard = true;
+
   navigationItem = {
-    title: NavTitle.ManageClusters,
+    title: cfg.isDashboard
+      ? NavTitle.ManageClustersShortened
+      : NavTitle.ManageClusters,
     icon: SlidersVertical,
     exact: false,
     getLink() {

--- a/web/packages/teleport/src/mocks/contexts.ts
+++ b/web/packages/teleport/src/mocks/contexts.ts
@@ -47,6 +47,7 @@ export const allAccessAcl: Acl = {
   roles: fullAccess,
   users: fullAccess,
   trustedClusters: fullAccess,
+  clusterMaintenanceConfig: fullAccess,
   events: fullAccess,
   accessRequests: fullAccess,
   billing: fullAccess,

--- a/web/packages/teleport/src/services/user/makeAcl.ts
+++ b/web/packages/teleport/src/services/user/makeAcl.ts
@@ -23,6 +23,8 @@ export function makeAcl(json): Acl {
   const accessList = json.accessList || defaultAccess;
   const authConnectors = json.authConnectors || defaultAccess;
   const trustedClusters = json.trustedClusters || defaultAccess;
+  const clusterMaintenanceConfig =
+    json.clusterMaintenanceConfig || defaultAccess;
   const roles = json.roles || defaultAccess;
   const recordedSessions = json.recordedSessions || defaultAccess;
   const activeSessions = json.activeSessions || defaultAccess;
@@ -87,6 +89,7 @@ export function makeAcl(json): Acl {
     accessList,
     authConnectors,
     trustedClusters,
+    clusterMaintenanceConfig,
     roles,
     recordedSessions,
     activeSessions,

--- a/web/packages/teleport/src/services/user/types.ts
+++ b/web/packages/teleport/src/services/user/types.ts
@@ -77,6 +77,7 @@ export interface Acl {
   clipboardSharingEnabled: boolean;
   authConnectors: Access;
   trustedClusters: Access;
+  clusterMaintenanceConfig: Access;
   roles: Access;
   recordedSessions: Access;
   activeSessions: Access;

--- a/web/packages/teleport/src/services/user/user.test.ts
+++ b/web/packages/teleport/src/services/user/user.test.ts
@@ -80,6 +80,13 @@ test('undefined values in context response gives proper default values', async (
       create: false,
       remove: false,
     },
+    clusterMaintenanceConfig: {
+      list: false,
+      read: false,
+      edit: false,
+      create: false,
+      remove: false,
+    },
     nodes: {
       create: false,
       edit: false,

--- a/web/packages/teleport/src/stores/storeUserContext.ts
+++ b/web/packages/teleport/src/stores/storeUserContext.ts
@@ -56,6 +56,10 @@ export default class StoreUserContext extends Store<UserContext> {
     return this.state.acl.trustedClusters;
   }
 
+  getClusterMaintenanceConfigAccess() {
+    return this.state.acl.clusterMaintenanceConfig;
+  }
+
   getUserAccess() {
     return this.state.acl.users;
   }

--- a/web/packages/teleport/src/teleportContext.tsx
+++ b/web/packages/teleport/src/teleportContext.tsx
@@ -172,6 +172,8 @@ class TeleportContext implements types.Context {
       authConnector: userContext.getConnectorAccess().list,
       roles: userContext.getRoleAccess().list,
       trustedClusters: userContext.getTrustedClusterAccess().list,
+      clusterMaintenanceConfig:
+        userContext.getClusterMaintenanceConfigAccess()?.list,
       users: userContext.getUserAccess().list,
       applications:
         userContext.getAppServerAccess().list &&
@@ -235,6 +237,7 @@ export const disabledFeatureFlags: types.FeatureFlags = {
   recordings: false,
   roles: false,
   trustedClusters: false,
+  clusterMaintenanceConfig: false,
   users: false,
   newAccessRequest: false,
   tokens: false,

--- a/web/packages/teleport/src/types.ts
+++ b/web/packages/teleport/src/types.ts
@@ -94,6 +94,7 @@ export enum NavTitle {
 
   // Clusters
   ManageClusters = 'Manage Clusters',
+  ManageClustersShortened = 'Clusters',
   TrustedClusters = 'Trusted Root Clusters',
 
   // Account
@@ -170,6 +171,7 @@ export interface FeatureFlags {
   authConnector: boolean;
   roles: boolean;
   trustedClusters: boolean;
+  clusterMaintenanceConfig: boolean;
   users: boolean;
   applications: boolean;
   kubernetes: boolean;


### PR DESCRIPTION
This adds the ClusterMaintenanceConfig to the web UI acl, which will allow us to use it as a flag when determining if we should show the Manage Clusters page or not.

This is an attempt to fix
https://github.com/gravitational/customer-sensitive-requests/issues/387

However, I don't have all the context around the cloud roles/workflows to enable this feature so I'm opening this in draft form to get some thoughts/ideas before commiting to a solution

(TODO, add tests once the solution is accepted)


NOTE:
I think this entire change can _maybe_ just be boiled down to `showInDashboard = true` because, dashboard tenants would again see the cluster maint window box (which anyone can edit) and ignore all the other code. I can break it into two PRs but, would like thoughts on the larger change either way