### PR TITLE
[v17] Fix link in the Upcoming Releases page

### DIFF
--- a/docs/pages/upcoming-releases.mdx
+++ b/docs/pages/upcoming-releases.mdx
@@ -32,8 +32,10 @@ TCP applications protected by Teleport as if they were on the same network.
 
 #### Improved GitHub Proxy enrollment flow
 
+{/* lint ignore absolute-docs-links */}
 Teleport web UI will provide wizard-like guided enrollment flow for the new
-[GitHub Proxy](admin-guides/management/guides/github-integration.mdx)
+[GitHub
+Proxy](https://goteleport.com/docs/admin-guides/management/guides/github-integration)
 integration.
 
 #### AWS Identity Center integration improvements


### PR DESCRIPTION
Since we copy this page to non-default docs versions when building the docs site, if a link target that exists on the default docs version does not exist on a non-default version, the build will break. This change uses an absolute docs link to avoid breaking the build.