### PR TITLE
Confirm regions filter is not empty

### DIFF
--- a/lib/web/integrations.go
+++ b/lib/web/integrations.go
@@ -426,6 +426,11 @@ func (h *Handler) integrationDiscoveryRules(w http.ResponseWriter, r *http.Reque
 	startKey := values.Get("startKey")
 	resourceType := values.Get("resourceType")
 	regionsFilter := values["regions"]
+	// the regions key is always sent as a query param but is not always populated (&regions=)
+	// this results in a slice containing a single empty string
+	if len(regionsFilter) == 1 && regionsFilter[0] == "" {
+		regionsFilter = nil
+	}
 
 	clt, err := sctx.GetUserClient(r.Context(), site)
 	if err != nil {


### PR DESCRIPTION
Subsequent use of regionsFilter was checking that the length is greater than 0, but the UI will always send an empty key if no region is selected (`&regions=`). This was resulting in a region filter of empty string. 

We talked about having the UI send all regions if none were selected, but its a bit of an anti-pattern and 
diverges from what we're doing with other endpoints

Supports https://github.com/gravitational/teleport/issues/49088