### PR TITLE
[web] Fix unexpected scrollbars in Firefox/Safari

### DIFF
--- a/web/packages/shared/components/TextSelectCopy/TextSelectCopyMulti.tsx
+++ b/web/packages/shared/components/TextSelectCopy/TextSelectCopyMulti.tsx
@@ -51,25 +51,18 @@ export function TextSelectCopyMulti({
     selectElementContent(targetEl as HTMLElement);
   }
 
-  const isFirefox = window.navigator?.userAgent
-    ?.toLowerCase()
-    .includes('firefox');
-
   return (
     <Box
       bg="bgTerminal"
       pl={3}
       pt={2}
+      pb={3}
       pr={saveContent.save ? 10 : 6}
-      // pr={2}
       borderRadius={2}
       minHeight="50px"
-      // Firefox does not add space for visible scrollbars
-      // like it does for chrome and safari.
-      pb={isFirefox ? 3 : 0}
       css={{
         position: 'relative',
-        overflow: 'scroll',
+        overflow: 'auto',
       }}
       maxHeight={maxHeight}
     >
@@ -174,7 +167,7 @@ const Lines = styled(Box)`
   word-break: break-all;
   font-size: 12px;
   font-family: ${({ theme }) => theme.fonts.mono};
-  overflow: scroll;
+  overflow: auto;
   line-height: 20px;
   color: ${props => props.theme.colors.light};
 `;


### PR DESCRIPTION
Use `auto` overflow instead of explicit `scroll` to fix unexpected scrollbars in Firefox/Safari in TextSelectCopyMulti component.

Before (Firefox, Safari/Chrome):
![Screenshot 2025-02-07 at 19 08 22](https://github.com/user-attachments/assets/6ab5c3c1-0af1-4a75-a451-f74dfc65a972)
![Screenshot 2025-02-07 at 19 08 28](https://github.com/user-attachments/assets/32070334-6ddc-4145-8a7d-2a6410edafeb)

After:
![Screenshot 2025-02-07 at 19 08 42](https://github.com/user-attachments/assets/dfe0d7d6-dd30-444e-a195-00747e9c41b0)
