### PR TITLE
[vnet] process authentication on Windows

### DIFF
--- a/lib/vnet/admin_process_windows.go
+++ b/lib/vnet/admin_process_windows.go
@@ -17,13 +17,22 @@
 package vnet
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"errors"
+	"fmt"
+	"io"
+	"os"
+	"syscall"
 	"time"
+	"unsafe"
 
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sys/windows"
 	"golang.zx2c4.com/wireguard/tun"
 )
 
@@ -38,6 +47,8 @@ type windowsAdminProcessConfig struct {
 	// serviceCredentialPath is the path where credentials for IPC with the
 	// client application are found.
 	serviceCredentialPath string
+	// userSID is the SID of the user running the client application.
+	userSID string
 }
 
 func (c *windowsAdminProcessConfig) check() error {
@@ -46,6 +57,9 @@ func (c *windowsAdminProcessConfig) check() error {
 	}
 	if c.serviceCredentialPath == "" {
 		return trace.BadParameter("serviceCredentialPath is required")
+	}
+	if c.userSID == "" {
+		return trace.BadParameter("userSID is required")
 	}
 	return nil
 }
@@ -70,7 +84,7 @@ func runWindowsAdminProcess(ctx context.Context, cfg *windowsAdminProcessConfig)
 	}
 	defer clt.close()
 
-	if err := authenticateUserProcess(ctx, clt); err != nil {
+	if err := authenticateUserProcess(ctx, clt, cfg.userSID); err != nil {
 		return trace.Wrap(err, "authenticating user process")
 	}
 
@@ -150,7 +164,189 @@ func newWindowsNetworkStackConfig(tun tunDevice, clt *clientApplicationServiceCl
 	}, nil
 }
 
-func authenticateUserProcess(ctx context.Context, clt *clientApplicationServiceClient) error {
-	// TODO(nklaassen): implement process authentication.
+func authenticateUserProcess(ctx context.Context, clt *clientApplicationServiceClient, userSID string) error {
+	pipe, err := createNamedPipe(ctx, userSID)
+	if err != nil {
+		return trace.Wrap(err, "creating named pipe")
+	}
+	defer pipe.Close()
+	g, ctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		if err := clt.AuthenticateProcess(ctx, pipe.name); err != nil {
+			return trace.Wrap(err, "authenticating user process")
+		}
+		return nil
+	})
+	g.Go(func() error {
+		if err := validateClientExe(ctx, pipe); err != nil {
+			return trace.Wrap(err, "validating user process exe")
+		}
+		return nil
+	})
+	if err := g.Wait(); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+func validateClientExe(ctx context.Context, p *winpipe) error {
+	thisExePath, err := os.Executable()
+	if err != nil {
+		return trace.Wrap(err, "getting executable path for this service")
+	}
+	clientExePath, err := p.waitForClient(ctx)
+	if err != nil {
+		return trace.Wrap(err, "waiting for client to connect to named pipe")
+	}
+	log.DebugContext(ctx, "Got pipe connection from client", "exe", clientExePath)
+	if err := compareFiles(thisExePath, clientExePath); err != nil {
+		return trace.AccessDenied(
+			"remote process is not running the same executable as this service, remote process exe: %s, this process exe: %s",
+			clientExePath, thisExePath)
+	}
+	return nil
+}
+
+func compareFiles(p1, p2 string) error {
+	h1, err := hashFile(p1)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	h2, err := hashFile(p2)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if !bytes.Equal(h1, h2) {
+		return trace.CompareFailed("files %s and %s are not equal", p1, p2)
+	}
+	return nil
+}
+
+func hashFile(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, trace.Wrap(err, "opening %s", path)
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return nil, trace.Wrap(err, "hashing %s", path)
+	}
+	return h.Sum(nil), nil
+}
+
+type winpipe struct {
+	pipeHandle  windows.Handle
+	eventHandle windows.Handle
+	name        string
+}
+
+// createNamedPipe creates a new Windows named pipe, connects to it as a server
+// and sets up the pipe to receive client connections.
+func createNamedPipe(ctx context.Context, userSID string) (*winpipe, error) {
+	pipeName := `\\.\pipe\` + uuid.NewString()
+	pipePath, err := syscall.UTF16PtrFromString(pipeName)
+	if err != nil {
+		return nil, trace.Wrap(err, "converting string to UTF16")
+	}
+	// Allow GA (Generic All) pipe access to the user.
+	sdString := fmt.Sprintf("D:P(A;;GA;;;%s)", userSID)
+	sd, err := windows.SecurityDescriptorFromString(sdString)
+	if err != nil {
+		return nil, trace.Wrap(err, "creating security descriptor from string")
+	}
+	sa := windows.SecurityAttributes{
+		Length:             uint32(unsafe.Sizeof(windows.SecurityAttributes{})),
+		SecurityDescriptor: sd,
+		InheritHandle:      0,
+	}
+	pipeHandle, err := windows.CreateNamedPipe(
+		pipePath,
+		windows.PIPE_ACCESS_DUPLEX|windows.FILE_FLAG_OVERLAPPED,
+		windows.PIPE_TYPE_BYTE|windows.PIPE_WAIT,
+		1,    // maxInstances
+		1024, // outSize
+		1024, // inSize
+		0,    // defaultTimeOut
+		&sa,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err, "creating named pipe")
+	}
+	log.DebugContext(ctx, "Created named pipe", "name", pipeName)
+	eventHandle, err := windows.CreateEvent(nil, 1, 0, nil)
+	if err != nil {
+		return nil, trace.Wrap(err, "creating Windows event handle")
+	}
+	overlapped := &windows.Overlapped{HEvent: eventHandle}
+	if err := windows.ConnectNamedPipe(pipeHandle, overlapped); err != nil && !errors.Is(err, windows.ERROR_IO_PENDING) {
+		return nil, trace.Wrap(err, "connecting to named pipe")
+	}
+	return &winpipe{
+		pipeHandle:  pipeHandle,
+		eventHandle: overlapped.HEvent,
+		name:        pipeName,
+	}, nil
+}
+
+// waitForClient waits for a client to connect to the pipe, and returns the exe
+// path of the client process.
+func (p *winpipe) waitForClient(ctx context.Context) (string, error) {
+	evt, err := windows.WaitForSingleObject(p.eventHandle, 500 /*milliseconds*/)
+	if err != nil {
+		return "", trace.Wrap(err, "waiting for connection on named pipe")
+	}
+	if evt != windows.WAIT_OBJECT_0 {
+		return "", trace.Errorf("failed to wait for connection on named pipe, error code: %d", evt)
+	}
+	var pid uint32
+	if err := windows.GetNamedPipeClientProcessId(p.pipeHandle, &pid); err != nil {
+		return "", trace.Wrap(err, "getting named pipe client process ID")
+	}
+	processHandle, err := windows.OpenProcess(
+		windows.PROCESS_QUERY_LIMITED_INFORMATION,
+		false, // inheritHandle
+		pid,
+	)
+	if err != nil {
+		return "", trace.Wrap(err, "opening client process")
+	}
+	buf := make([]uint16, windows.MAX_PATH)
+	size := uint32(len(buf))
+	if err := windows.QueryFullProcessImageName(processHandle, 0, &buf[0], &size); err != nil {
+		return "", trace.Wrap(err, "querying pipe client process image name")
+	}
+	return windows.UTF16PtrToString(&buf[0]), nil
+}
+
+func (p *winpipe) Close() error {
+	return trace.NewAggregate(
+		trace.Wrap(windows.CloseHandle(p.pipeHandle), "closing pipe handle"),
+		trace.Wrap(windows.CloseHandle(p.eventHandle), "closing pipe event handle"),
+	)
+}
+
+// connectToPipe connects to a Windows named pipe, then immediately closes the
+// connection. This is used for process authentication.
+func connectToPipe(pipePath string) error {
+	pipePathPtr, err := syscall.UTF16PtrFromString(pipePath)
+	if err != nil {
+		return trace.Wrap(err, "converting string to UTF16")
+	}
+	handle, err := windows.CreateFile(
+		pipePathPtr,
+		windows.GENERIC_READ|windows.GENERIC_WRITE,
+		0,   // ShareMode
+		nil, // SecurityAttributes
+		windows.OPEN_EXISTING,
+		0, // FlagsAndAttributes
+		0, // TemplateFile
+	)
+	if err != nil {
+		return trace.Wrap(err, "opening named pipe")
+	}
+	if err := windows.CloseHandle(handle); err != nil {
+		return trace.Wrap(err, "closing named pipe")
+	}
 	return nil
 }

--- a/lib/vnet/admin_process_windows.go
+++ b/lib/vnet/admin_process_windows.go
@@ -249,8 +249,9 @@ func createNamedPipe(ctx context.Context, userSID string) (*winpipe, error) {
 	if err != nil {
 		return nil, trace.Wrap(err, "converting string to UTF16")
 	}
-	// Allow GA (Generic All) pipe access to the user.
-	sdString := fmt.Sprintf("D:P(A;;GA;;;%s)", userSID)
+	// https://learn.microsoft.com/en-us/windows/win32/secauthz/security-descriptor-definition-language
+	// This discretionary ACL grants GA (Generic All) pipe access to the user.
+	sdString := fmt.Sprintf("D:(A;;GA;;;%s)", userSID)
 	sd, err := windows.SecurityDescriptorFromString(sdString)
 	if err != nil {
 		return nil, trace.Wrap(err, "creating security descriptor from string")

--- a/lib/vnet/client_application_service.go
+++ b/lib/vnet/client_application_service.go
@@ -69,7 +69,10 @@ func (s *clientApplicationService) AuthenticateProcess(ctx context.Context, req 
 		return nil, trace.BadParameter("version mismatch, user process version is %s, admin process version is %s",
 			api.Version, req.Version)
 	}
-	// TODO(nklaassen): implement process authentication.
+	if err := platformAuthenticateProcess(ctx, req); err != nil {
+		log.ErrorContext(ctx, "Failed to authenticate process", "error", err)
+		return nil, trace.Wrap(err, "authenticating process")
+	}
 	return &vnetv1.AuthenticateProcessResponse{
 		Version: api.Version,
 	}, nil

--- a/lib/vnet/client_application_service_other.go
+++ b/lib/vnet/client_application_service_other.go
@@ -1,0 +1,31 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build !windows
+// +build !windows
+
+package vnet
+
+import (
+	"context"
+
+	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
+)
+
+func platformAuthenticateProcess(ctx context.Context, req *vnetv1.AuthenticateProcessRequest) error {
+	// This is only called in tests, the real method is only used on Windows.
+	return nil
+}

--- a/lib/vnet/client_application_service_windows.go
+++ b/lib/vnet/client_application_service_windows.go
@@ -1,0 +1,37 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
+)
+
+func platformAuthenticateProcess(ctx context.Context, req *vnetv1.AuthenticateProcessRequest) error {
+	// The Windows service is authenticating this process, all this process has
+	// to do is connect to the named pipe. The Windows service is already
+	// authenticated to this process via mTLS credentials written to a
+	// privileged directory.
+	if err := connectToPipe(req.GetPipePath()); err != nil {
+		return trace.Wrap(err, "connecting to named pipe")
+	}
+	log.DebugContext(ctx, "Connected to named pipe for process authentication")
+	return nil
+}

--- a/lib/vnet/user_process_windows_test.go
+++ b/lib/vnet/user_process_windows_test.go
@@ -18,6 +18,7 @@ package vnet
 
 import (
 	"os"
+	"os/user"
 	"path/filepath"
 	"syscall"
 	"testing"
@@ -32,8 +33,13 @@ func TestSecureCredDir(t *testing.T) {
 	creds, err := newIPCCredentials()
 	require.NoError(t, err)
 
+	u, err := user.Current()
+	require.NoError(t, err)
+	// Uid is documented to be the user's SID on Windows.
+	userSID := u.Uid
+
 	credPath := t.TempDir()
-	require.NoError(t, secureCredDir(credPath))
+	require.NoError(t, secureCredDir(credPath, userSID))
 	require.NoError(t, creds.client.write(credPath))
 	defer func() {
 		err := creds.client.remove(credPath)


### PR DESCRIPTION
Part of [RFD 195](https://github.com/gravitational/teleport/pull/50850).

In the [parent PR](https://github.com/gravitational/teleport/pull/51856), the VNet client application writes mTLS credentials to a privileged directory that the VNet Windows services then uses to connect to the gRPC service provided to the client application. This authenticates the Windows service to the client application.

In this PR, the Windows service authenticates the client application by:
- creating a Windows named pipe that only the user running the client application can connect to
- sends the name of the pipe to the client application over gRPC
- waits for the client application to connect to the pipe and uses Windows APIs to get the path to the client's exe
- verifies that the client application exe is identical to the running Windows service exe

The RFD mentions verifying that the client application is running a signed binary. By instead making sure that the client application is running the same exe as the service, signed builds make sure that the client is also signed, and unsigned builds allow an unsigned client as long as they are identical.