### PR TITLE
Fix setting modules build type for tsh and tctl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -357,6 +357,14 @@ all: version
 binaries:
 	$(MAKE) $(BINARIES)
 
+# Appending new conditional settings for community build type for tools.
+ifeq ("$(GITHUB_REPOSITORY_OWNER)","gravitational")
+# TELEPORT_LDFLAGS and TOOLS_LDFLAGS if appended will overwrite the previous LDFLAGS set in the BUILDFLAGS.
+# This is done here to prevent any changes to the (BUI)LDFLAGS passed to the other binaries
+TELEPORT_LDFLAGS ?= -ldflags '$(GO_LDFLAGS) -X github.com/gravitational/teleport/lib/modules.teleportBuildType=community'
+TOOLS_LDFLAGS ?= -ldflags '$(GO_LDFLAGS) -X github.com/gravitational/teleport/lib/modules.teleportBuildType=community'
+endif
+
 # By making these 3 targets below (tsh, tctl and teleport) PHONY we are solving
 # several problems:
 # * Build will rely on go build internal caching https://golang.org/doc/go1.10 at all times
@@ -370,15 +378,9 @@ $(BUILDDIR)/tctl:
 	@if [[ "$(OS)" != "windows" && -z "$(LIBFIDO2_BUILD_TAG)" ]]; then \
 		echo 'Warning: Building tctl without libfido2. Install libfido2 to have access to MFA.' >&2; \
 	fi
-	GOOS=$(OS) GOARCH=$(ARCH) $(CGOFLAG) go build -tags "$(PAM_TAG) $(FIPS_TAG) $(LIBFIDO2_BUILD_TAG) $(TOUCHID_TAG) $(PIV_BUILD_TAG) $(KUSTOMIZE_NO_DYNAMIC_PLUGIN)" -o $(BUILDDIR)/tctl $(BUILDFLAGS) ./tool/tctl
+	GOOS=$(OS) GOARCH=$(ARCH) $(CGOFLAG) go build -tags "$(PAM_TAG) $(FIPS_TAG) $(LIBFIDO2_BUILD_TAG) $(TOUCHID_TAG) $(PIV_BUILD_TAG) $(KUSTOMIZE_NO_DYNAMIC_PLUGIN)" -o $(BUILDDIR)/tctl $(BUILDFLAGS) $(TOOLS_LDFLAGS) ./tool/tctl
 
 .PHONY: $(BUILDDIR)/teleport
-# Appending new conditional settings for community build type
-ifeq ("$(GITHUB_REPOSITORY_OWNER)","gravitational")
-# TELEPORT_LDFLAGS if appended will overwrite the previous LDFLAGS set in the BUILDFLAGS.
-# This is done here to prevent any changes to the (BUI)LDFLAGS passed to the other binaries
-TELEPORT_LDFLAGS ?= -ldflags '$(GO_LDFLAGS) -X github.com/gravitational/teleport/lib/modules.teleportBuildType=community'
-endif
 $(BUILDDIR)/teleport: ensure-webassets bpf-bytecode rdpclient
 	GOOS=$(OS) GOARCH=$(ARCH) $(CGOFLAG) go build -tags "webassets_embed $(PAM_TAG) $(FIPS_TAG) $(BPF_TAG) $(WEBASSETS_TAG) $(RDPCLIENT_TAG) $(PIV_BUILD_TAG) $(KUSTOMIZE_NO_DYNAMIC_PLUGIN)" -o $(BUILDDIR)/teleport $(BUILDFLAGS) $(TELEPORT_LDFLAGS) ./tool/teleport
 
@@ -391,7 +393,7 @@ $(BUILDDIR)/tsh:
 	@if [[ "$(OS)" != "windows" && -z "$(LIBFIDO2_BUILD_TAG)" ]]; then \
 		echo 'Warning: Building tsh without libfido2. Install libfido2 to have access to MFA.' >&2; \
 	fi
-	GOOS=$(OS) GOARCH=$(ARCH) $(CGOFLAG_TSH) go build -tags "$(FIPS_TAG) $(LIBFIDO2_BUILD_TAG) $(TOUCHID_TAG) $(PIV_BUILD_TAG) $(VNETDAEMON_TAG) $(KUSTOMIZE_NO_DYNAMIC_PLUGIN)" -o $(BUILDDIR)/tsh $(BUILDFLAGS) ./tool/tsh
+	GOOS=$(OS) GOARCH=$(ARCH) $(CGOFLAG_TSH) go build -tags "$(FIPS_TAG) $(LIBFIDO2_BUILD_TAG) $(TOUCHID_TAG) $(PIV_BUILD_TAG) $(VNETDAEMON_TAG) $(KUSTOMIZE_NO_DYNAMIC_PLUGIN)" -o $(BUILDDIR)/tsh $(BUILDFLAGS) $(TOOLS_LDFLAGS) ./tool/tsh
 
 .PHONY: $(BUILDDIR)/tbot
 # tbot is CGO-less by default except on Windows because lib/client/terminal/ wants CGO on this OS
@@ -399,11 +401,11 @@ $(BUILDDIR)/tbot: TBOT_CGO_FLAGS ?= $(if $(filter windows,$(OS)),$(CGOFLAG))
 # Build mode pie requires CGO
 $(BUILDDIR)/tbot: BUILDFLAGS_TBOT += $(if $(TBOT_CGO_FLAGS), -buildmode=pie)
 $(BUILDDIR)/tbot:
-	GOOS=$(OS) GOARCH=$(ARCH) $(TBOT_CGO_FLAGS) go build -tags "$(FIPS_TAG) $(KUSTOMIZE_NO_DYNAMIC_PLUGIN)" -o $(BUILDDIR)/tbot $(BUILDFLAGS_TBOT) ./tool/tbot
+	GOOS=$(OS) GOARCH=$(ARCH) $(TBOT_CGO_FLAGS) go build -tags "$(FIPS_TAG) $(KUSTOMIZE_NO_DYNAMIC_PLUGIN)" -o $(BUILDDIR)/tbot $(BUILDFLAGS_TBOT) $(TOOLS_LDFLAGS) ./tool/tbot
 
 .PHONY: $(BUILDDIR)/teleport-update
 $(BUILDDIR)/teleport-update:
-	GOOS=$(OS) GOARCH=$(ARCH) CGO_ENABLED=0 go build -o $(BUILDDIR)/teleport-update $(BUILDFLAGS_TELEPORT_UPDATE) ./tool/teleport-update
+	GOOS=$(OS) GOARCH=$(ARCH) CGO_ENABLED=0 go build -o $(BUILDDIR)/teleport-update $(BUILDFLAGS_TELEPORT_UPDATE) $(TOOLS_LDFLAGS) ./tool/teleport-update
 
 TELEPORT_ARGS ?= start
 .PHONY: teleport-hot-reload

--- a/lib/autoupdate/tools/helper.go
+++ b/lib/autoupdate/tools/helper.go
@@ -31,11 +31,6 @@ import (
 	stacksignal "github.com/gravitational/teleport/lib/utils/signal"
 )
 
-// warnMessageOSSBuild is warning exposed to the user that build type without base url is disabled.
-const warnMessageOSSBuild = "Client tools updates are disabled because the server is licensed under AGPL " +
-	"but Teleport-distributed binaries are licensed under Community Edition. To use Community Edition " +
-	"builds or custom binaries, set the 'TELEPORT_CDN_BASE_URL' environment variable."
-
 // Variables might to be overridden during compilation time for integration tests.
 var (
 	// version is the current version of the Teleport.
@@ -116,10 +111,7 @@ func updateAndReExec(ctx context.Context, updater *Updater, toolsVersion string,
 	// is required if the user passed in the TELEPORT_TOOLS_VERSION
 	// explicitly.
 	err := updater.UpdateWithLock(ctxUpdate, toolsVersion)
-	if errors.Is(err, errNoBaseURL) {
-		// If base URL wasn't defined we have to cancel update and re-execution with warning.
-		slog.WarnContext(ctx, warnMessageOSSBuild)
-	} else if err != nil && !errors.Is(err, context.Canceled) {
+	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, errNoBaseURL) {
 		return trace.Wrap(err)
 	}
 

--- a/lib/autoupdate/tools/helper.go
+++ b/lib/autoupdate/tools/helper.go
@@ -116,12 +116,10 @@ func updateAndReExec(ctx context.Context, updater *Updater, toolsVersion string,
 	// is required if the user passed in the TELEPORT_TOOLS_VERSION
 	// explicitly.
 	err := updater.UpdateWithLock(ctxUpdate, toolsVersion)
-	if err != nil && errors.Is(err, errNoBaseURL) {
+	if errors.Is(err, errNoBaseURL) {
 		// If base URL wasn't defined we have to cancel update and re-execution with warning.
 		slog.WarnContext(ctx, warnMessageOSSBuild)
-		return nil
-	}
-	if err != nil && !errors.Is(err, context.Canceled) {
+	} else if err != nil && !errors.Is(err, context.Canceled) {
 		return trace.Wrap(err)
 	}
 

--- a/lib/autoupdate/tools/updater.go
+++ b/lib/autoupdate/tools/updater.go
@@ -43,7 +43,6 @@ import (
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/lib/autoupdate"
-	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/packaging"
 )
@@ -202,15 +201,6 @@ func (u *Updater) CheckRemote(ctx context.Context, proxyAddr string, insecure bo
 	})
 	if err != nil {
 		return "", false, trace.Wrap(err)
-	}
-
-	m := modules.GetModules()
-	envBaseURL := os.Getenv(autoupdate.BaseURLEnvVar)
-	if resp.Edition == modules.BuildOSS && m.BuildType() == modules.BuildCommunity && envBaseURL == "" {
-		slog.WarnContext(ctx, "Client tools updates are disabled because the server is licensed under AGPL "+
-			"but Teleport-distributed binaries are licensed under Community Edition. To use Community Edition "+
-			"builds or custom binaries, set the 'TELEPORT_CDN_BASE_URL' environment variable.")
-		return "", false, errNoBaseURL
 	}
 
 	// If a version of client tools has already been downloaded to

--- a/lib/autoupdate/tools/utils.go
+++ b/lib/autoupdate/tools/utils.go
@@ -134,8 +134,7 @@ func teleportPackageURLs(ctx context.Context, uriTmpl string, baseURL, version s
 	m := modules.GetModules()
 	envBaseURL := os.Getenv(autoupdate.BaseURLEnvVar)
 	if m.BuildType() == modules.BuildOSS && envBaseURL == "" {
-		slog.WarnContext(ctx, "Client tools updates are disabled as they are licensed under AGPL. "+
-			"To use Community Edition builds or custom binaries, set the 'TELEPORT_CDN_BASE_URL' environment variable.")
+		slog.WarnContext(ctx, "Client tools updates are disabled as they are licensed under AGPL. To use Community Edition builds or custom binaries, set the 'TELEPORT_CDN_BASE_URL' environment variable.")
 		return nil, errNoBaseURL
 	}
 

--- a/lib/autoupdate/tools/utils.go
+++ b/lib/autoupdate/tools/utils.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -128,15 +129,17 @@ type packageURL struct {
 	Optional bool
 }
 
-// teleportPackageURLs returns the URL for the Teleport archive to download.
-func teleportPackageURLs(uriTmpl string, baseURL, version string) ([]packageURL, error) {
+// teleportPackageURLs returns URLs for the Teleport archives to download.
+func teleportPackageURLs(ctx context.Context, uriTmpl string, baseURL, version string) ([]packageURL, error) {
+	m := modules.GetModules()
 	envBaseURL := os.Getenv(autoupdate.BaseURLEnvVar)
-	if modules.GetModules().BuildType() == modules.BuildOSS && envBaseURL == "" {
+	if m.BuildType() == modules.BuildOSS && envBaseURL == "" {
+		slog.WarnContext(ctx, "Client tools updates are disabled as they are licensed under AGPL. "+
+			"To use Community Edition builds or custom binaries, set the 'TELEPORT_CDN_BASE_URL' environment variable.")
 		return nil, errNoBaseURL
 	}
 
 	var flags autoupdate.InstallFlags
-	m := modules.GetModules()
 	if m.IsBoringBinary() {
 		flags |= autoupdate.FlagFIPS
 	}

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -383,7 +383,9 @@ func (p *defaultModules) IsEnterpriseBuild() bool {
 
 // IsOSSBuild returns true for [defaultModules].
 func (p *defaultModules) IsOSSBuild() bool {
-	return true
+	// teleportBuildType variable might be overridden during the build process,
+	// we have to always check the type.
+	return teleportBuildType == BuildOSS
 }
 
 // PrintVersion prints the Teleport version.

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -383,9 +383,7 @@ func (p *defaultModules) IsEnterpriseBuild() bool {
 
 // IsOSSBuild returns true for [defaultModules].
 func (p *defaultModules) IsOSSBuild() bool {
-	// teleportBuildType variable might be overridden during the build process,
-	// we have to always check the type.
-	return teleportBuildType == BuildOSS
+	return true
 }
 
 // PrintVersion prints the Teleport version.


### PR DESCRIPTION
I've postponed merging backports of https://github.com/gravitational/teleport/pull/51732 until verify `nightly` build since I didn't find `BuildType` modification in scripts for the client tools `tsh` and `tctl`. I've verified on the latest builds:
```
teleport-v18.0.0-dev-nightly20250207-1-f186fb4-darwin-arm64-bin.tar.gz
teleport-ent-v18.0.0-dev-nightly20250207-1-f186fb4-darwin-arm64-bin.tar.gz
```

For client tools, `modules.GetModules().BuildType()` always returns "oss", causing a warning to always be displayed for community and enterprise builds and disabling updates until the base URL environment variable is set.

Related:
 - https://github.com/gravitational/teleport/pull/51931
 - https://github.com/gravitational/teleport/pull/51933
 - https://github.com/gravitational/teleport/pull/51934

Tag build: https://github.com/gravitational/teleport.e/actions/runs/13212233201