### PR TITLE
tctl: fix create cmd when input starts with an empty doc

### DIFF
--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -26,6 +26,7 @@ import (
 	"log/slog"
 	"math"
 	"os"
+	"reflect"
 	"slices"
 	"sort"
 	"strings"
@@ -403,6 +404,14 @@ func (rc *ResourceCommand) Create(ctx context.Context, client *authclient.Client
 			}
 			return trace.Wrap(err)
 		}
+
+		// An empty document at the beginning of the input will unmarshal without error.
+		// Keep reading - there may be a valid document later on.
+		// https://github.com/gravitational/teleport/issues/4703
+		if reflect.ValueOf(raw).IsZero() {
+			continue
+		}
+
 		count++
 
 		// locate the creator function for a given resource kind:

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -1408,6 +1408,10 @@ func TestCreateResources(t *testing.T) {
 			},
 		},
 		{
+			kind:   "empty-doc",
+			create: testCreateWithEmptyDocument,
+		},
+		{
 			kind:   types.KindDatabaseObjectImportRule,
 			create: testCreateDatabaseObjectImportRule,
 		},
@@ -1672,6 +1676,22 @@ spec:
 	require.True(t, trace.IsAlreadyExists(err))
 
 	_, err = runResourceCommand(t, clt, []string{"create", "-f", serverInfoYAMLPath})
+	require.NoError(t, err)
+}
+
+func testCreateWithEmptyDocument(t *testing.T, clt *authclient.Client) {
+	const userYAML = `
+---
+kind: user
+version: v2
+metadata:
+  name: llama2
+spec:
+  roles: ["access"]
+`
+	userYAMLPath := filepath.Join(t.TempDir(), "user.yaml")
+	require.NoError(t, os.WriteFile(userYAMLPath, []byte(userYAML), 0644))
+	_, err := runResourceCommand(t, clt, []string{"create", userYAMLPath})
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
Closes #4703