### PR TITLE
Add backend WorkloadIdentityX509Revocations service

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -607,6 +607,10 @@ const (
 	// KindWorkloadIdentity is the WorkloadIdentity resource.
 	KindWorkloadIdentity = "workload_identity"
 
+	// KindWorkloadIdentityX509Revocation is the WorkloadIdentityX509Revocation
+	// resource.
+	KindWorkloadIdentityX509Revocation = "workload_identity_x509_revocation"
+
 	// KindGitServer represents a Git server that can proxy git commands.
 	KindGitServer = "git_server"
 	// SubKindGitHub specifies the GitHub subkind of a Git server.

--- a/api/types/events/events.go
+++ b/api/types/events/events.go
@@ -2431,6 +2431,48 @@ func (m *WorkloadIdentityDelete) TrimToMaxSize(_ int) AuditEvent {
 	return m
 }
 
+func (m *WorkloadIdentityX509RevocationCreate) TrimToMaxSize(maxSize int) AuditEvent {
+	size := m.Size()
+	if size <= maxSize {
+		return m
+	}
+
+	out := utils.CloneProtoMsg(m)
+	out.Reason = ""
+
+	maxSize = adjustedMaxSize(out, maxSize)
+
+	customFieldsCount := nonEmptyStrs(m.Reason)
+	maxFieldsSize := maxSizePerField(maxSize, customFieldsCount)
+
+	out.Reason = trimStr(m.Reason, maxFieldsSize)
+
+	return m
+}
+
+func (m *WorkloadIdentityX509RevocationUpdate) TrimToMaxSize(maxSize int) AuditEvent {
+	size := m.Size()
+	if size <= maxSize {
+		return m
+	}
+
+	out := utils.CloneProtoMsg(m)
+	out.Reason = ""
+
+	maxSize = adjustedMaxSize(out, maxSize)
+
+	customFieldsCount := nonEmptyStrs(m.Reason)
+	maxFieldsSize := maxSizePerField(maxSize, customFieldsCount)
+
+	out.Reason = trimStr(m.Reason, maxFieldsSize)
+
+	return m
+}
+
+func (m *WorkloadIdentityX509RevocationDelete) TrimToMaxSize(_ int) AuditEvent {
+	return m
+}
+
 func (m *GitCommand) TrimToMaxSize(_ int) AuditEvent {
 	return m
 }

--- a/api/types/events/oneof.go
+++ b/api/types/events/oneof.go
@@ -827,6 +827,18 @@ func ToOneOf(in AuditEvent) (*OneOf, error) {
 		out.Event = &OneOf_StableUNIXUserCreate{
 			StableUNIXUserCreate: e,
 		}
+	case *WorkloadIdentityX509RevocationCreate:
+		out.Event = &OneOf_WorkloadIdentityX509RevocationCreate{
+			WorkloadIdentityX509RevocationCreate: e,
+		}
+	case *WorkloadIdentityX509RevocationDelete:
+		out.Event = &OneOf_WorkloadIdentityX509RevocationDelete{
+			WorkloadIdentityX509RevocationDelete: e,
+		}
+	case *WorkloadIdentityX509RevocationUpdate:
+		out.Event = &OneOf_WorkloadIdentityX509RevocationUpdate{
+			WorkloadIdentityX509RevocationUpdate: e,
+		}
 	default:
 		slog.ErrorContext(context.Background(), "Attempted to convert dynamic event of unknown type into protobuf event.", "event_type", in.GetType())
 		unknown := &Unknown{}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -405,6 +405,12 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 		}
 		cfg.WorkloadIdentity = workloadIdentity
 	}
+	if cfg.WorkloadIdentityX509Revocations == nil {
+		cfg.WorkloadIdentityX509Revocations, err = local.NewWorkloadIdentityX509RevocationService(cfg.Backend)
+		if err != nil {
+			return nil, trace.Wrap(err, "creating WorkloadIdentityX509Revocation service")
+		}
+	}
 	if cfg.StableUNIXUsers == nil {
 		cfg.StableUNIXUsers = &local.StableUNIXUsersService{
 			Backend: cfg.Backend,
@@ -464,53 +470,54 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 
 	closeCtx, cancelFunc := context.WithCancel(context.TODO())
 	services := &Services{
-		TrustInternal:                cfg.Trust,
-		PresenceInternal:             cfg.Presence,
-		Provisioner:                  cfg.Provisioner,
-		Identity:                     cfg.Identity,
-		Access:                       cfg.Access,
-		DynamicAccessExt:             cfg.DynamicAccessExt,
-		ClusterConfigurationInternal: cfg.ClusterConfiguration,
-		AutoUpdateService:            cfg.AutoUpdateService,
-		Restrictions:                 cfg.Restrictions,
-		Apps:                         cfg.Apps,
-		Kubernetes:                   cfg.Kubernetes,
-		Databases:                    cfg.Databases,
-		DatabaseServices:             cfg.DatabaseServices,
-		AuditLogSessionStreamer:      cfg.AuditLog,
-		Events:                       cfg.Events,
-		WindowsDesktops:              cfg.WindowsDesktops,
-		DynamicWindowsDesktops:       cfg.DynamicWindowsDesktops,
-		SAMLIdPServiceProviders:      cfg.SAMLIdPServiceProviders,
-		UserGroups:                   cfg.UserGroups,
-		SessionTrackerService:        cfg.SessionTrackerService,
-		ConnectionsDiagnostic:        cfg.ConnectionsDiagnostic,
-		Integrations:                 cfg.Integrations,
-		UserTasks:                    cfg.UserTasks,
-		DiscoveryConfigs:             cfg.DiscoveryConfigs,
-		Okta:                         cfg.Okta,
-		AccessLists:                  cfg.AccessLists,
-		DatabaseObjectImportRules:    cfg.DatabaseObjectImportRules,
-		DatabaseObjects:              cfg.DatabaseObjects,
-		SecReports:                   cfg.SecReports,
-		UserLoginStates:              cfg.UserLoginState,
-		StatusInternal:               cfg.Status,
-		UsageReporter:                cfg.UsageReporter,
-		UserPreferences:              cfg.UserPreferences,
-		PluginData:                   cfg.PluginData,
-		KubeWaitingContainer:         cfg.KubeWaitingContainers,
-		Notifications:                cfg.Notifications,
-		AccessMonitoringRules:        cfg.AccessMonitoringRules,
-		CrownJewels:                  cfg.CrownJewels,
-		BotInstance:                  cfg.BotInstance,
-		SPIFFEFederations:            cfg.SPIFFEFederations,
-		StaticHostUser:               cfg.StaticHostUsers,
-		ProvisioningStates:           cfg.ProvisioningStates,
-		IdentityCenter:               cfg.IdentityCenter,
-		PluginStaticCredentials:      cfg.PluginStaticCredentials,
-		GitServers:                   cfg.GitServers,
-		WorkloadIdentities:           cfg.WorkloadIdentity,
-		StableUNIXUsersInternal:      cfg.StableUNIXUsers,
+		TrustInternal:                   cfg.Trust,
+		PresenceInternal:                cfg.Presence,
+		Provisioner:                     cfg.Provisioner,
+		Identity:                        cfg.Identity,
+		Access:                          cfg.Access,
+		DynamicAccessExt:                cfg.DynamicAccessExt,
+		ClusterConfigurationInternal:    cfg.ClusterConfiguration,
+		AutoUpdateService:               cfg.AutoUpdateService,
+		Restrictions:                    cfg.Restrictions,
+		Apps:                            cfg.Apps,
+		Kubernetes:                      cfg.Kubernetes,
+		Databases:                       cfg.Databases,
+		DatabaseServices:                cfg.DatabaseServices,
+		AuditLogSessionStreamer:         cfg.AuditLog,
+		Events:                          cfg.Events,
+		WindowsDesktops:                 cfg.WindowsDesktops,
+		DynamicWindowsDesktops:          cfg.DynamicWindowsDesktops,
+		SAMLIdPServiceProviders:         cfg.SAMLIdPServiceProviders,
+		UserGroups:                      cfg.UserGroups,
+		SessionTrackerService:           cfg.SessionTrackerService,
+		ConnectionsDiagnostic:           cfg.ConnectionsDiagnostic,
+		Integrations:                    cfg.Integrations,
+		UserTasks:                       cfg.UserTasks,
+		DiscoveryConfigs:                cfg.DiscoveryConfigs,
+		Okta:                            cfg.Okta,
+		AccessLists:                     cfg.AccessLists,
+		DatabaseObjectImportRules:       cfg.DatabaseObjectImportRules,
+		DatabaseObjects:                 cfg.DatabaseObjects,
+		SecReports:                      cfg.SecReports,
+		UserLoginStates:                 cfg.UserLoginState,
+		StatusInternal:                  cfg.Status,
+		UsageReporter:                   cfg.UsageReporter,
+		UserPreferences:                 cfg.UserPreferences,
+		PluginData:                      cfg.PluginData,
+		KubeWaitingContainer:            cfg.KubeWaitingContainers,
+		Notifications:                   cfg.Notifications,
+		AccessMonitoringRules:           cfg.AccessMonitoringRules,
+		CrownJewels:                     cfg.CrownJewels,
+		BotInstance:                     cfg.BotInstance,
+		SPIFFEFederations:               cfg.SPIFFEFederations,
+		StaticHostUser:                  cfg.StaticHostUsers,
+		ProvisioningStates:              cfg.ProvisioningStates,
+		IdentityCenter:                  cfg.IdentityCenter,
+		PluginStaticCredentials:         cfg.PluginStaticCredentials,
+		GitServers:                      cfg.GitServers,
+		WorkloadIdentities:              cfg.WorkloadIdentity,
+		StableUNIXUsersInternal:         cfg.StableUNIXUsers,
+		WorkloadIdentityX509Revocations: cfg.WorkloadIdentityX509Revocations,
 	}
 
 	as := Server{
@@ -733,6 +740,7 @@ type Services struct {
 	services.GitServers
 	services.WorkloadIdentities
 	services.StableUNIXUsersInternal
+	services.WorkloadIdentityX509Revocations
 }
 
 // GetWebSession returns existing web session described by req.

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -322,6 +322,10 @@ type InitConfig struct {
 	// WorkloadIdentity resources.
 	WorkloadIdentity services.WorkloadIdentities
 
+	// WorkloadIdentityX509Revocations is the service for storing and retrieving
+	// WorkloadIdentityX509Revocations.
+	WorkloadIdentityX509Revocations services.WorkloadIdentityX509Revocations
+
 	// StaticHostUsers is a service that manages host users that should be
 	// created on SSH nodes.
 	StaticHostUsers services.StaticHostUser

--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -859,6 +859,16 @@ const (
 	// WorkloadIdentityDeleteEvent is emitted when a WorkloadIdentity resource is deleted.
 	WorkloadIdentityDeleteEvent = "workload_identity.delete"
 
+	// WorkloadIdentityX509RevocationCreateEvent is emitted when a
+	// WorkloadIdentityX509Revocation resource is created.
+	WorkloadIdentityX509RevocationCreateEvent = "workload_identity_x509_revocation.create"
+	// WorkloadIdentityX509RevocationUpdateEvent is emitted when a
+	// WorkloadIdentityX509Revocation resource is updated.
+	WorkloadIdentityX509RevocationUpdateEvent = "workload_identity_x509_revocation.update"
+	// WorkloadIdentityX509RevocationDeleteEvent is emitted when a
+	// WorkloadIdentityX509Revocation resource is deleted.
+	WorkloadIdentityX509RevocationDeleteEvent = "workload_identity_x509_revocation.delete"
+
 	// GitCommandEvent is emitted when a Git command is executed.
 	GitCommandEvent = "git.command"
 

--- a/lib/events/codes.go
+++ b/lib/events/codes.go
@@ -687,6 +687,15 @@ const (
 	WorkloadIdentityUpdateCode = "WID002I"
 	// WorkloadIdentityDeleteCode is the workload identity delete event code.
 	WorkloadIdentityDeleteCode = "WID003I"
+	// WorkloadIdentityX509RevocationCreateCode is the
+	// WorkloadIdentityX509Revocation create event code.
+	WorkloadIdentityX509RevocationCreateCode = "WID004I"
+	// WorkloadIdentityX509RevocationUpdateCode is the
+	// WorkloadIdentityX509Revocation update event code.
+	WorkloadIdentityX509RevocationUpdateCode = "WID005I"
+	// WorkloadIdentityX509RevocationDeleteCode is the
+	// WorkloadIdentityX509Revocation delete event code.
+	WorkloadIdentityX509RevocationDeleteCode = "WID006I"
 
 	// GitCommandCode is the git command event code
 	GitCommandCode = "TGIT001I"

--- a/lib/events/dynamic.go
+++ b/lib/events/dynamic.go
@@ -487,6 +487,13 @@ func FromEventFields(fields EventFields) (events.AuditEvent, error) {
 	case WorkloadIdentityDeleteEvent:
 		e = &events.WorkloadIdentityDelete{}
 
+	case WorkloadIdentityX509RevocationCreateEvent:
+		e = &events.WorkloadIdentityX509RevocationCreate{}
+	case WorkloadIdentityX509RevocationUpdateEvent:
+		e = &events.WorkloadIdentityX509RevocationUpdate{}
+	case WorkloadIdentityX509RevocationDeleteEvent:
+		e = &events.WorkloadIdentityX509RevocationDelete{}
+
 	case StableUNIXUserCreateEvent:
 		e = &events.StableUNIXUserCreate{}
 

--- a/lib/events/events_test.go
+++ b/lib/events/events_test.go
@@ -250,6 +250,9 @@ var eventsMap = map[string]apievents.AuditEvent{
 	WorkloadIdentityDeleteEvent:                 &apievents.WorkloadIdentityDelete{},
 	AccessRequestExpireEvent:                    &apievents.AccessRequestExpire{},
 	StableUNIXUserCreateEvent:                   &apievents.StableUNIXUserCreate{},
+	WorkloadIdentityX509RevocationCreateEvent:   &apievents.WorkloadIdentityX509RevocationCreate{},
+	WorkloadIdentityX509RevocationDeleteEvent:   &apievents.WorkloadIdentityX509RevocationDelete{},
+	WorkloadIdentityX509RevocationUpdateEvent:   &apievents.WorkloadIdentityX509RevocationUpdate{},
 }
 
 // TestJSON tests JSON marshal events

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -3143,126 +3143,6 @@ func (p *accessGraphSettingsParser) parse(event backend.Event) (types.Resource, 
 	}
 }
 
-func newSPIFFEFederationParser() *spiffeFederationParser {
-	return &spiffeFederationParser{
-		baseParser: newBaseParser(backend.NewKey(spiffeFederationPrefix)),
-	}
-}
-
-type spiffeFederationParser struct {
-	baseParser
-}
-
-func (p *spiffeFederationParser) parse(event backend.Event) (types.Resource, error) {
-	switch event.Type {
-	case types.OpDelete:
-		name := event.Item.Key.TrimPrefix(backend.NewKey(spiffeFederationPrefix)).String()
-		if name == "" {
-			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
-		}
-
-		return &types.ResourceHeader{
-			Kind:    types.KindSPIFFEFederation,
-			Version: types.V1,
-			Metadata: types.Metadata{
-				Name:      strings.TrimPrefix(name, backend.SeparatorString),
-				Namespace: apidefaults.Namespace,
-			},
-		}, nil
-	case types.OpPut:
-		federation, err := services.UnmarshalSPIFFEFederation(
-			event.Item.Value,
-			services.WithExpires(event.Item.Expires),
-			services.WithRevision(event.Item.Revision))
-		if err != nil {
-			return nil, trace.Wrap(err, "unmarshalling resource from event")
-		}
-		return types.Resource153ToLegacy(federation), nil
-	default:
-		return nil, trace.BadParameter("event %v is not supported", event.Type)
-	}
-}
-
-func newWorkloadIdentityParser() *workloadIdentityParser {
-	return &workloadIdentityParser{
-		baseParser: newBaseParser(backend.NewKey(workloadIdentityPrefix)),
-	}
-}
-
-type workloadIdentityParser struct {
-	baseParser
-}
-
-func (p *workloadIdentityParser) parse(event backend.Event) (types.Resource, error) {
-	switch event.Type {
-	case types.OpDelete:
-		name := event.Item.Key.TrimPrefix(backend.NewKey(workloadIdentityPrefix)).String()
-		if name == "" {
-			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
-		}
-
-		return &types.ResourceHeader{
-			Kind:    types.KindWorkloadIdentity,
-			Version: types.V1,
-			Metadata: types.Metadata{
-				Name:      strings.TrimPrefix(name, backend.SeparatorString),
-				Namespace: apidefaults.Namespace,
-			},
-		}, nil
-	case types.OpPut:
-		resource, err := services.UnmarshalWorkloadIdentity(
-			event.Item.Value,
-			services.WithExpires(event.Item.Expires),
-			services.WithRevision(event.Item.Revision))
-		if err != nil {
-			return nil, trace.Wrap(err, "unmarshalling resource from event")
-		}
-		return types.Resource153ToLegacy(resource), nil
-	default:
-		return nil, trace.BadParameter("event %v is not supported", event.Type)
-	}
-}
-
-func newWorkloadIdentityX509RevocationParser() *workloadIdentityX509RevocationParser {
-	return &workloadIdentityX509RevocationParser{
-		baseParser: newBaseParser(backend.NewKey(workloadIdentityX509RevocationPrefix)),
-	}
-}
-
-type workloadIdentityX509RevocationParser struct {
-	baseParser
-}
-
-func (p *workloadIdentityX509RevocationParser) parse(event backend.Event) (types.Resource, error) {
-	switch event.Type {
-	case types.OpDelete:
-		name := event.Item.Key.TrimPrefix(backend.NewKey(workloadIdentityX509RevocationPrefix)).String()
-		if name == "" {
-			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
-		}
-
-		return &types.ResourceHeader{
-			Kind:    types.KindWorkloadIdentityX509Revocation,
-			Version: types.V1,
-			Metadata: types.Metadata{
-				Name:      strings.TrimPrefix(name, backend.SeparatorString),
-				Namespace: apidefaults.Namespace,
-			},
-		}, nil
-	case types.OpPut:
-		resource, err := services.UnmarshalWorkloadIdentityX509Revocation(
-			event.Item.Value,
-			services.WithExpires(event.Item.Expires),
-			services.WithRevision(event.Item.Revision))
-		if err != nil {
-			return nil, trace.Wrap(err, "unmarshalling resource from event")
-		}
-		return types.Resource153ToLegacy(resource), nil
-	default:
-		return nil, trace.BadParameter("event %v is not supported", event.Type)
-	}
-}
-
 func newProvisioningStateParser() *provisioningStateParser {
 	return &provisioningStateParser{
 		baseParser: newBaseParser(backend.NewKey(provisioningStatePrefix)),
@@ -3314,3 +3194,7 @@ func (p *provisioningStateParser) parse(event backend.Event) (types.Resource, er
 		return nil, trace.BadParameter("event %v is not supported", event.Type)
 	}
 }
+
+// Thinking of adding a new parser? To avoid this file growing unreasonably
+// large, instead add the parser into the resource specific file, e.g, for the
+// workloadIdentityParser, use the existing `workload_identity.go`.

--- a/lib/services/local/spiffe_federations.go
+++ b/lib/services/local/spiffe_federations.go
@@ -18,9 +18,11 @@ package local
 
 import (
 	"context"
+	"strings"
 
 	"github.com/gravitational/trace"
 
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
@@ -112,4 +114,44 @@ func (b *SPIFFEFederationService) UpdateSPIFFEFederation(
 ) (*machineidv1.SPIFFEFederation, error) {
 	updated, err := b.service.ConditionalUpdateResource(ctx, federation)
 	return updated, trace.Wrap(err)
+}
+
+func newSPIFFEFederationParser() *spiffeFederationParser {
+	return &spiffeFederationParser{
+		baseParser: newBaseParser(backend.NewKey(spiffeFederationPrefix)),
+	}
+}
+
+type spiffeFederationParser struct {
+	baseParser
+}
+
+func (p *spiffeFederationParser) parse(event backend.Event) (types.Resource, error) {
+	switch event.Type {
+	case types.OpDelete:
+		name := event.Item.Key.TrimPrefix(backend.NewKey(spiffeFederationPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindSPIFFEFederation,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
+	case types.OpPut:
+		federation, err := services.UnmarshalSPIFFEFederation(
+			event.Item.Value,
+			services.WithExpires(event.Item.Expires),
+			services.WithRevision(event.Item.Revision))
+		if err != nil {
+			return nil, trace.Wrap(err, "unmarshalling resource from event")
+		}
+		return types.Resource153ToLegacy(federation), nil
+	default:
+		return nil, trace.BadParameter("event %v is not supported", event.Type)
+	}
 }

--- a/lib/services/local/workload_identity.go
+++ b/lib/services/local/workload_identity.go
@@ -18,9 +18,11 @@ package local
 
 import (
 	"context"
+	"strings"
 
 	"github.com/gravitational/trace"
 
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
@@ -115,4 +117,44 @@ func (b *WorkloadIdentityService) UpdateWorkloadIdentity(
 ) (*workloadidentityv1pb.WorkloadIdentity, error) {
 	updated, err := b.service.ConditionalUpdateResource(ctx, resource)
 	return updated, trace.Wrap(err)
+}
+
+func newWorkloadIdentityParser() *workloadIdentityParser {
+	return &workloadIdentityParser{
+		baseParser: newBaseParser(backend.NewKey(workloadIdentityPrefix)),
+	}
+}
+
+type workloadIdentityParser struct {
+	baseParser
+}
+
+func (p *workloadIdentityParser) parse(event backend.Event) (types.Resource, error) {
+	switch event.Type {
+	case types.OpDelete:
+		name := event.Item.Key.TrimPrefix(backend.NewKey(workloadIdentityPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindWorkloadIdentity,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
+	case types.OpPut:
+		resource, err := services.UnmarshalWorkloadIdentity(
+			event.Item.Value,
+			services.WithExpires(event.Item.Expires),
+			services.WithRevision(event.Item.Revision))
+		if err != nil {
+			return nil, trace.Wrap(err, "unmarshalling resource from event")
+		}
+		return types.Resource153ToLegacy(resource), nil
+	default:
+		return nil, trace.BadParameter("event %v is not supported", event.Type)
+	}
 }

--- a/lib/services/local/workload_identity_x509_revocation.go
+++ b/lib/services/local/workload_identity_x509_revocation.go
@@ -1,0 +1,126 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package local
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local/generic"
+)
+
+const (
+	workloadIdentityX509RevocationPrefix = "workload_identity_x509_revocation"
+)
+
+// WorkloadIdentityX509RevocationService exposes backend functionality for
+// storing WorkloadIdentityX509Revocation resources
+type WorkloadIdentityX509RevocationService struct {
+	service *generic.ServiceWrapper[*workloadidentityv1pb.WorkloadIdentityX509Revocation]
+}
+
+// NewWorkloadIdentityX509RevocationService creates a new
+// WorkloadIdentityX509RevocationService
+func NewWorkloadIdentityX509RevocationService(
+	b backend.Backend,
+) (*WorkloadIdentityX509RevocationService, error) {
+	service, err := generic.NewServiceWrapper(
+		generic.ServiceWrapperConfig[*workloadidentityv1pb.WorkloadIdentityX509Revocation]{
+			Backend:       b,
+			ResourceKind:  types.KindWorkloadIdentityX509Revocation,
+			BackendPrefix: backend.NewKey(workloadIdentityX509RevocationPrefix),
+			MarshalFunc:   services.MarshalWorkloadIdentityX509Revocation,
+			UnmarshalFunc: services.UnmarshalWorkloadIdentityX509Revocation,
+			ValidateFunc:  services.ValidateWorkloadIdentityX509Revocation,
+		})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &WorkloadIdentityX509RevocationService{
+		service: service,
+	}, nil
+}
+
+// CreateWorkloadIdentityX509Revocation inserts a new
+// WorkloadIdentityX509Revocation into the backend.
+func (b *WorkloadIdentityX509RevocationService) CreateWorkloadIdentityX509Revocation(
+	ctx context.Context, resource *workloadidentityv1pb.WorkloadIdentityX509Revocation,
+) (*workloadidentityv1pb.WorkloadIdentityX509Revocation, error) {
+	created, err := b.service.CreateResource(ctx, resource)
+	return created, trace.Wrap(err)
+}
+
+// GetWorkloadIdentityX509Revocation retrieves a specific
+// WorkloadIdentityX509Revocation given a name
+func (b *WorkloadIdentityX509RevocationService) GetWorkloadIdentityX509Revocation(
+	ctx context.Context, name string,
+) (*workloadidentityv1pb.WorkloadIdentityX509Revocation, error) {
+	resource, err := b.service.GetResource(ctx, name)
+	return resource, trace.Wrap(err)
+}
+
+// ListWorkloadIdentityX509Revocations lists all WorkloadIdentityX509Revocation
+// using a given page size and last key.
+func (b *WorkloadIdentityX509RevocationService) ListWorkloadIdentityX509Revocations(
+	ctx context.Context, pageSize int, currentToken string,
+) ([]*workloadidentityv1pb.WorkloadIdentityX509Revocation, string, error) {
+	r, nextToken, err := b.service.ListResources(ctx, pageSize, currentToken)
+	return r, nextToken, trace.Wrap(err)
+}
+
+// DeleteWorkloadIdentityX509Revocation deletes a specific
+// WorkloadIdentityX509Revocation.
+func (b *WorkloadIdentityX509RevocationService) DeleteWorkloadIdentityX509Revocation(
+	ctx context.Context, name string,
+) error {
+	return trace.Wrap(b.service.DeleteResource(ctx, name))
+}
+
+// DeleteAllWorkloadIdentityX509Revocations deletes all
+// WorkloadIdentityX509Revocation resources, this is typically only meant to be
+// used by the cache.
+func (b *WorkloadIdentityX509RevocationService) DeleteAllWorkloadIdentityX509Revocations(
+	ctx context.Context,
+) error {
+	return trace.Wrap(b.service.DeleteAllResources(ctx))
+}
+
+// UpsertWorkloadIdentityX509Revocation upserts a WorkloadIdentityX509Revocation.
+// Prefer using CreateWorkloadIdentity. This is only designed for usage by the
+// cache.
+func (b *WorkloadIdentityX509RevocationService) UpsertWorkloadIdentityX509Revocation(
+	ctx context.Context, resource *workloadidentityv1pb.WorkloadIdentityX509Revocation,
+) (*workloadidentityv1pb.WorkloadIdentityX509Revocation, error) {
+	upserted, err := b.service.UpsertResource(ctx, resource)
+	return upserted, trace.Wrap(err)
+}
+
+// UpdateWorkloadIdentityX509Revocation updates a specific
+// WorkloadIdentityX509Revocation. The resource must already exist, and,
+// conditional update semantics are used - e.g the submitted resource must have
+// a revision matching the revision of the resource in the backend.
+func (b *WorkloadIdentityX509RevocationService) UpdateWorkloadIdentityX509Revocation(
+	ctx context.Context, resource *workloadidentityv1pb.WorkloadIdentityX509Revocation,
+) (*workloadidentityv1pb.WorkloadIdentityX509Revocation, error) {
+	updated, err := b.service.ConditionalUpdateResource(ctx, resource)
+	return updated, trace.Wrap(err)
+}

--- a/lib/services/local/workload_identity_x509_revocation.go
+++ b/lib/services/local/workload_identity_x509_revocation.go
@@ -18,9 +18,11 @@ package local
 
 import (
 	"context"
+	"strings"
 
 	"github.com/gravitational/trace"
 
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
@@ -123,4 +125,44 @@ func (b *WorkloadIdentityX509RevocationService) UpdateWorkloadIdentityX509Revoca
 ) (*workloadidentityv1pb.WorkloadIdentityX509Revocation, error) {
 	updated, err := b.service.ConditionalUpdateResource(ctx, resource)
 	return updated, trace.Wrap(err)
+}
+
+func newWorkloadIdentityX509RevocationParser() *workloadIdentityX509RevocationParser {
+	return &workloadIdentityX509RevocationParser{
+		baseParser: newBaseParser(backend.NewKey(workloadIdentityX509RevocationPrefix)),
+	}
+}
+
+type workloadIdentityX509RevocationParser struct {
+	baseParser
+}
+
+func (p *workloadIdentityX509RevocationParser) parse(event backend.Event) (types.Resource, error) {
+	switch event.Type {
+	case types.OpDelete:
+		name := event.Item.Key.TrimPrefix(backend.NewKey(workloadIdentityX509RevocationPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+		}
+
+		return &types.ResourceHeader{
+			Kind:    types.KindWorkloadIdentityX509Revocation,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name:      strings.TrimPrefix(name, backend.SeparatorString),
+				Namespace: apidefaults.Namespace,
+			},
+		}, nil
+	case types.OpPut:
+		resource, err := services.UnmarshalWorkloadIdentityX509Revocation(
+			event.Item.Value,
+			services.WithExpires(event.Item.Expires),
+			services.WithRevision(event.Item.Revision))
+		if err != nil {
+			return nil, trace.Wrap(err, "unmarshalling resource from event")
+		}
+		return types.Resource153ToLegacy(resource), nil
+	default:
+		return nil, trace.BadParameter("event %v is not supported", event.Type)
+	}
 }

--- a/lib/services/local/workload_identity_x509_revocation_test.go
+++ b/lib/services/local/workload_identity_x509_revocation_test.go
@@ -157,7 +157,7 @@ func TestWorkloadIdentityX509RevocationService_List(t *testing.T) {
 	for i := 0; i < 49; i++ {
 		created, err := service.CreateWorkloadIdentityX509Revocation(
 			ctx,
-			newValidWorkloadIdentityX509Revocation(clock, fmt.Sprintf("%d%d", i)),
+			newValidWorkloadIdentityX509Revocation(clock, fmt.Sprintf("%d%d", i, i)),
 		)
 		require.NoError(t, err)
 		createdObjects = append(createdObjects, created)

--- a/lib/services/local/workload_identity_x509_revocation_test.go
+++ b/lib/services/local/workload_identity_x509_revocation_test.go
@@ -157,7 +157,7 @@ func TestWorkloadIdentityX509RevocationService_List(t *testing.T) {
 	for i := 0; i < 49; i++ {
 		created, err := service.CreateWorkloadIdentityX509Revocation(
 			ctx,
-			newValidWorkloadIdentityX509Revocation(clock, fmt.Sprintf("%d", i)),
+			newValidWorkloadIdentityX509Revocation(clock, fmt.Sprintf("%d%d", i)),
 		)
 		require.NoError(t, err)
 		createdObjects = append(createdObjects, created)

--- a/lib/services/local/workload_identity_x509_revocation_test.go
+++ b/lib/services/local/workload_identity_x509_revocation_test.go
@@ -1,0 +1,361 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package local
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/backend/memory"
+)
+
+func setupWorkloadIdentityX509RevocationServiceTest(
+	t *testing.T,
+) (context.Context, clockwork.Clock, *WorkloadIdentityX509RevocationService) {
+	t.Parallel()
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+	service, err := NewWorkloadIdentityX509RevocationService(backend.NewSanitizer(mem))
+	require.NoError(t, err)
+	return ctx, clock, service
+}
+
+func newValidWorkloadIdentityX509Revocation(clock clockwork.Clock, name string) *workloadidentityv1pb.WorkloadIdentityX509Revocation {
+	return &workloadidentityv1pb.WorkloadIdentityX509Revocation{
+		Kind:    types.KindWorkloadIdentityX509Revocation,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name:    name,
+			Expires: timestamppb.New(clock.Now().Add(time.Hour)),
+		},
+		Spec: &workloadidentityv1pb.WorkloadIdentityX509RevocationSpec{
+			Reason:    "compromised",
+			RevokedAt: timestamppb.New(clock.Now()),
+		},
+	}
+}
+
+func TestWorkloadIdentityX509RevocationService_Create(t *testing.T) {
+	ctx, clock, service := setupWorkloadIdentityX509RevocationServiceTest(t)
+
+	t.Run("ok", func(t *testing.T) {
+		want := newValidWorkloadIdentityX509Revocation(clock, "aabbcc")
+		got, err := service.CreateWorkloadIdentityX509Revocation(
+			ctx,
+			// Clone to avoid Marshaling modifying want
+			proto.Clone(want).(*workloadidentityv1pb.WorkloadIdentityX509Revocation),
+		)
+		require.NoError(t, err)
+		require.NotEmpty(t, got.Metadata.Revision)
+		require.Empty(t, cmp.Diff(
+			want,
+			got,
+			protocmp.Transform(),
+			protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
+		))
+	})
+	t.Run("validation occurs", func(t *testing.T) {
+		out, err := service.CreateWorkloadIdentityX509Revocation(
+			ctx, newValidWorkloadIdentityX509Revocation(clock, ""),
+		)
+		require.ErrorContains(t, err, "metadata.name: is required")
+		require.Nil(t, out)
+	})
+	t.Run("no upsert", func(t *testing.T) {
+		res := newValidWorkloadIdentityX509Revocation(clock, "ccddee")
+		_, err := service.CreateWorkloadIdentityX509Revocation(
+			ctx,
+			// Clone to avoid Marshaling modifying want
+			proto.Clone(res).(*workloadidentityv1pb.WorkloadIdentityX509Revocation),
+		)
+		require.NoError(t, err)
+		_, err = service.CreateWorkloadIdentityX509Revocation(
+			ctx,
+			// Clone to avoid Marshaling modifying want
+			proto.Clone(res).(*workloadidentityv1pb.WorkloadIdentityX509Revocation),
+		)
+		require.Error(t, err)
+		require.True(t, trace.IsAlreadyExists(err))
+	})
+}
+
+func TestWorkloadIdentityX509RevocationService_Upsert(t *testing.T) {
+	ctx, clock, service := setupWorkloadIdentityX509RevocationServiceTest(t)
+
+	t.Run("ok", func(t *testing.T) {
+		want := newValidWorkloadIdentityX509Revocation(clock, "aa")
+		got, err := service.UpsertWorkloadIdentityX509Revocation(
+			ctx,
+			// Clone to avoid Marshaling modifying want
+			proto.Clone(want).(*workloadidentityv1pb.WorkloadIdentityX509Revocation),
+		)
+		require.NoError(t, err)
+		require.NotEmpty(t, got.Metadata.Revision)
+		require.Empty(t, cmp.Diff(
+			want,
+			got,
+			protocmp.Transform(),
+			protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
+		))
+
+		// Ensure we can upsert over an existing resource
+		_, err = service.UpsertWorkloadIdentityX509Revocation(
+			ctx,
+			// Clone to avoid Marshaling modifying want
+			proto.Clone(want).(*workloadidentityv1pb.WorkloadIdentityX509Revocation),
+		)
+		require.NoError(t, err)
+	})
+	t.Run("validation occurs", func(t *testing.T) {
+		out, err := service.UpdateWorkloadIdentityX509Revocation(
+			ctx, newValidWorkloadIdentityX509Revocation(clock, ""),
+		)
+		require.ErrorContains(t, err, "metadata.name: is required")
+		require.Nil(t, out)
+	})
+}
+
+func TestWorkloadIdentityX509RevocationService_List(t *testing.T) {
+	ctx, clock, service := setupWorkloadIdentityX509RevocationServiceTest(t)
+	// Create entities to list
+	createdObjects := []*workloadidentityv1pb.WorkloadIdentityX509Revocation{}
+	// Create 49 entities to test an incomplete page at the end.
+	for i := 0; i < 49; i++ {
+		created, err := service.CreateWorkloadIdentityX509Revocation(
+			ctx,
+			newValidWorkloadIdentityX509Revocation(clock, fmt.Sprintf("%d", i)),
+		)
+		require.NoError(t, err)
+		createdObjects = append(createdObjects, created)
+	}
+	t.Run("default page size", func(t *testing.T) {
+		page, nextToken, err := service.ListWorkloadIdentityX509Revocations(ctx, 0, "")
+		require.NoError(t, err)
+		require.Len(t, page, 49)
+		require.Empty(t, nextToken)
+
+		// Expect that we get all the things we have created
+		for _, created := range createdObjects {
+			slices.ContainsFunc(page, func(resource *workloadidentityv1pb.WorkloadIdentityX509Revocation) bool {
+				return proto.Equal(created, resource)
+			})
+		}
+	})
+	t.Run("pagination", func(t *testing.T) {
+		fetched := []*workloadidentityv1pb.WorkloadIdentityX509Revocation{}
+		token := ""
+		iterations := 0
+		for {
+			iterations++
+			page, nextToken, err := service.ListWorkloadIdentityX509Revocations(ctx, 10, token)
+			require.NoError(t, err)
+			fetched = append(fetched, page...)
+			if nextToken == "" {
+				break
+			}
+			token = nextToken
+		}
+		require.Equal(t, 5, iterations)
+
+		require.Len(t, fetched, 49)
+		// Expect that we get all the things we have created
+		for _, created := range createdObjects {
+			slices.ContainsFunc(fetched, func(resource *workloadidentityv1pb.WorkloadIdentityX509Revocation) bool {
+				return proto.Equal(created, resource)
+			})
+		}
+	})
+}
+
+func TestWorkloadIdentityX509RevocationService_Get(t *testing.T) {
+	ctx, clock, service := setupWorkloadIdentityX509RevocationServiceTest(t)
+
+	t.Run("ok", func(t *testing.T) {
+		want := newValidWorkloadIdentityX509Revocation(clock, "aa")
+		_, err := service.CreateWorkloadIdentityX509Revocation(
+			ctx,
+			// Clone to avoid Marshaling modifying want
+			proto.Clone(want).(*workloadidentityv1pb.WorkloadIdentityX509Revocation),
+		)
+		require.NoError(t, err)
+		got, err := service.GetWorkloadIdentityX509Revocation(ctx, "aa")
+		require.NoError(t, err)
+		require.NotEmpty(t, got.Metadata.Revision)
+		require.Empty(t, cmp.Diff(
+			want,
+			got,
+			protocmp.Transform(),
+			protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
+		))
+	})
+	t.Run("not found", func(t *testing.T) {
+		_, err := service.GetWorkloadIdentityX509Revocation(ctx, "ff")
+		require.Error(t, err)
+		require.True(t, trace.IsNotFound(err))
+	})
+}
+
+func TestWorkloadIdentityX509RevocationService_Delete(t *testing.T) {
+	ctx, clock, service := setupWorkloadIdentityX509RevocationServiceTest(t)
+
+	t.Run("ok", func(t *testing.T) {
+		_, err := service.CreateWorkloadIdentityX509Revocation(
+			ctx,
+			newValidWorkloadIdentityX509Revocation(clock, "aa"),
+		)
+		require.NoError(t, err)
+
+		_, err = service.GetWorkloadIdentityX509Revocation(ctx, "aa")
+		require.NoError(t, err)
+
+		err = service.DeleteWorkloadIdentityX509Revocation(ctx, "aa")
+		require.NoError(t, err)
+
+		_, err = service.GetWorkloadIdentityX509Revocation(ctx, "aa")
+		require.Error(t, err)
+		require.True(t, trace.IsNotFound(err))
+	})
+	t.Run("not found", func(t *testing.T) {
+		err := service.DeleteWorkloadIdentityX509Revocation(ctx, "bb")
+		require.Error(t, err)
+		require.True(t, trace.IsNotFound(err))
+	})
+}
+
+func TestWorkloadIdentityX509RevocationService_DeleteAll(t *testing.T) {
+	ctx, clock, service := setupWorkloadIdentityX509RevocationServiceTest(t)
+	_, err := service.CreateWorkloadIdentityX509Revocation(
+		ctx,
+		newValidWorkloadIdentityX509Revocation(clock, "1"),
+	)
+	require.NoError(t, err)
+	_, err = service.CreateWorkloadIdentityX509Revocation(
+		ctx,
+		newValidWorkloadIdentityX509Revocation(clock, "2"),
+	)
+	require.NoError(t, err)
+
+	page, _, err := service.ListWorkloadIdentityX509Revocations(ctx, 0, "")
+	require.NoError(t, err)
+	require.Len(t, page, 2)
+
+	err = service.DeleteAllWorkloadIdentityX509Revocations(ctx)
+	require.NoError(t, err)
+
+	page, _, err = service.ListWorkloadIdentityX509Revocations(ctx, 0, "")
+	require.NoError(t, err)
+	require.Empty(t, page)
+}
+
+func TestWorkloadIdentityX509RevocationService_Update(t *testing.T) {
+	ctx, clock, service := setupWorkloadIdentityX509RevocationServiceTest(t)
+
+	t.Run("ok", func(t *testing.T) {
+		// Create first to support updating
+		toCreate := newValidWorkloadIdentityX509Revocation(clock, "aa")
+		got, err := service.CreateWorkloadIdentityX509Revocation(
+			ctx,
+			// Clone to avoid Marshaling modifying want
+			proto.Clone(toCreate).(*workloadidentityv1pb.WorkloadIdentityX509Revocation),
+		)
+		require.NoError(t, err)
+		require.NotEmpty(t, got.Metadata.Revision)
+		got.Spec.Reason = "changed"
+		got2, err := service.UpdateWorkloadIdentityX509Revocation(
+			ctx,
+			// Clone to avoid Marshaling modifying want
+			proto.Clone(got).(*workloadidentityv1pb.WorkloadIdentityX509Revocation),
+		)
+		require.NoError(t, err)
+		require.NotEmpty(t, got2.Metadata.Revision)
+		require.Empty(t, cmp.Diff(
+			got,
+			got2,
+			protocmp.Transform(),
+			protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
+		))
+	})
+	t.Run("validation occurs", func(t *testing.T) {
+		// Create first to support updating
+		toCreate := newValidWorkloadIdentityX509Revocation(clock, "bb")
+		got, err := service.CreateWorkloadIdentityX509Revocation(
+			ctx,
+			// Clone to avoid Marshaling modifying want
+			proto.Clone(toCreate).(*workloadidentityv1pb.WorkloadIdentityX509Revocation),
+		)
+		require.NoError(t, err)
+		require.NotEmpty(t, got.Metadata.Revision)
+		got.Spec.Reason = ""
+		got2, err := service.UpdateWorkloadIdentityX509Revocation(
+			ctx,
+			// Clone to avoid Marshaling modifying want
+			proto.Clone(got).(*workloadidentityv1pb.WorkloadIdentityX509Revocation),
+		)
+		require.ErrorContains(t, err, "spec.reason: is required")
+		require.Nil(t, got2)
+	})
+	t.Run("cond update blocks", func(t *testing.T) {
+		toCreate := newValidWorkloadIdentityX509Revocation(clock, "cc")
+		got, err := service.CreateWorkloadIdentityX509Revocation(
+			ctx,
+			// Clone to avoid Marshaling modifying want
+			proto.Clone(toCreate).(*workloadidentityv1pb.WorkloadIdentityX509Revocation),
+		)
+		require.NoError(t, err)
+		// We'll now update it twice, but on the second update, we will use the
+		// revision from the creation not the second update.
+		_, err = service.UpdateWorkloadIdentityX509Revocation(
+			ctx,
+			proto.Clone(got).(*workloadidentityv1pb.WorkloadIdentityX509Revocation),
+		)
+		require.NoError(t, err)
+		_, err = service.UpdateWorkloadIdentityX509Revocation(
+			ctx,
+			proto.Clone(got).(*workloadidentityv1pb.WorkloadIdentityX509Revocation),
+		)
+		require.ErrorIs(t, err, backend.ErrIncorrectRevision)
+	})
+	t.Run("no upsert", func(t *testing.T) {
+		toUpdate := newValidWorkloadIdentityX509Revocation(clock, "dd")
+		_, err := service.UpdateWorkloadIdentityX509Revocation(
+			ctx,
+			// Clone to avoid Marshaling modifying want
+			proto.Clone(toUpdate).(*workloadidentityv1pb.WorkloadIdentityX509Revocation),
+		)
+		require.Error(t, err)
+	})
+}

--- a/lib/services/local/workload_identity_x509_revocation_test.go
+++ b/lib/services/local/workload_identity_x509_revocation_test.go
@@ -260,12 +260,12 @@ func TestWorkloadIdentityX509RevocationService_DeleteAll(t *testing.T) {
 	ctx, clock, service := setupWorkloadIdentityX509RevocationServiceTest(t)
 	_, err := service.CreateWorkloadIdentityX509Revocation(
 		ctx,
-		newValidWorkloadIdentityX509Revocation(clock, "1"),
+		newValidWorkloadIdentityX509Revocation(clock, "11"),
 	)
 	require.NoError(t, err)
 	_, err = service.CreateWorkloadIdentityX509Revocation(
 		ctx,
-		newValidWorkloadIdentityX509Revocation(clock, "2"),
+		newValidWorkloadIdentityX509Revocation(clock, "21"),
 	)
 	require.NoError(t, err)
 

--- a/lib/services/workload_identity_x509_revocation.go
+++ b/lib/services/workload_identity_x509_revocation.go
@@ -32,31 +32,35 @@ import (
 // implemented by a client to allow remote and local consumers to access the
 // resource in a similar way.
 type WorkloadIdentityX509Revocations interface {
-	// GetWorkloadIdentity gets a SPIFFE Federation by name.
+	// GetWorkloadIdentityX509Revocation gets a WorkloadIdentityX509Revocation
+	// by name.
 	GetWorkloadIdentityX509Revocation(
 		ctx context.Context, name string,
 	) (*workloadidentityv1pb.WorkloadIdentityX509Revocation, error)
-	// ListWorkloadIdentities lists all WorkloadIdentities using Google style
-	// pagination.
+	// ListWorkloadIdentityX509Revocations lists all
+	// WorkloadIdentityX509Revocation using Google style pagination.
 	ListWorkloadIdentityX509Revocations(
 		ctx context.Context, pageSize int, lastToken string,
 	) ([]*workloadidentityv1pb.WorkloadIdentityX509Revocation, string, error)
-	// CreateWorkloadIdentity creates a new WorkloadIdentity.
+	// CreateWorkloadIdentityX509Revocation creates a new
+	// WorkloadIdentityX509Revocation.
 	CreateWorkloadIdentityX509Revocation(
 		ctx context.Context,
 		workloadIdentityX509Revocation *workloadidentityv1pb.WorkloadIdentityX509Revocation,
 	) (*workloadidentityv1pb.WorkloadIdentityX509Revocation, error)
-	// DeleteWorkloadIdentity deletes a SPIFFE Federation by name.
+	// DeleteWorkloadIdentityX509Revocation deletes a
+	// WorkloadIdentityX509Revocation by name.
 	DeleteWorkloadIdentityX509Revocation(ctx context.Context, name string) error
-	// UpdateWorkloadIdentity updates a specific WorkloadIdentity. The resource must
-	// already exist, and, condition update semantics are used - e.g the submitted
-	// resource must have a revision matching the revision of the resource in the
-	// backend.
+	// UpdateWorkloadIdentityX509Revocation updates a specific
+	// WorkloadIdentityX509Revocation. The resource must already exist, and,
+	// conditional update semantics are used - e.g the submitted resource must
+	// have a revision matching the revision of the resource in the backend.
 	UpdateWorkloadIdentityX509Revocation(
 		ctx context.Context,
 		workloadIdentityX509Revocation *workloadidentityv1pb.WorkloadIdentityX509Revocation,
 	) (*workloadidentityv1pb.WorkloadIdentityX509Revocation, error)
-	// UpsertWorkloadIdentity creates or updates a WorkloadIdentity.
+	// UpsertWorkloadIdentityX509Revocation creates or updates a
+	// WorkloadIdentityX509Revocation.
 	UpsertWorkloadIdentityX509Revocation(
 		ctx context.Context,
 		workloadIdentityX509Revocation *workloadidentityv1pb.WorkloadIdentityX509Revocation,

--- a/lib/services/workload_identity_x509_revocation.go
+++ b/lib/services/workload_identity_x509_revocation.go
@@ -18,8 +18,7 @@ package services
 
 import (
 	"context"
-	"math/big"
-	"strings"
+	"regexp"
 
 	"github.com/gravitational/trace"
 
@@ -83,6 +82,8 @@ func UnmarshalWorkloadIdentityX509Revocation(
 	return UnmarshalProtoResource[*workloadidentityv1pb.WorkloadIdentityX509Revocation](data, opts...)
 }
 
+var validSerialRe = regexp.MustCompile("^(?:[0-9a-f]{2})+$")
+
 // ValidateWorkloadIdentityX509Revocation validates the
 // WorkloadIdentityX509Revocation object.
 // It returns a nil if the object is valid, otherwise an error.
@@ -120,13 +121,8 @@ func ValidateWorkloadIdentityX509Revocation(s *workloadidentityv1pb.WorkloadIden
 	// X509 cert. Whilst typically presented using a colon separated hex string,
 	// here we will remove the colons. We will also ensure it is encoded in
 	// lowercase, to ensure consistency.
-	serial := big.Int{}
-	_, ok := serial.SetString(s.Metadata.Name, 16)
-	if !ok {
-		return trace.BadParameter("metadata.name: must be a hex encoded integer without colons")
-	}
-	if s.Metadata.Name != strings.ToLower(s.Metadata.Name) {
-		return trace.BadParameter("metadata.name: must be a lower-case encoded hex string")
+	if !validSerialRe.MatchString(s.Metadata.Name) {
+		return trace.BadParameter("metadata.name: must be a lower-case hex encoded integer without colons")
 	}
 
 	return nil

--- a/lib/services/workload_identity_x509_revocation.go
+++ b/lib/services/workload_identity_x509_revocation.go
@@ -1,0 +1,129 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package services
+
+import (
+	"context"
+	"math/big"
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
+	"github.com/gravitational/teleport/api/types"
+)
+
+// WorkloadIdentityX509Revocations is an interface over the
+// WorkloadIdentityX509Revocations service. This  interface may also be
+// implemented by a client to allow remote and local consumers to access the
+// resource in a similar way.
+type WorkloadIdentityX509Revocations interface {
+	// GetWorkloadIdentity gets a SPIFFE Federation by name.
+	GetWorkloadIdentityX509Revocation(
+		ctx context.Context, name string,
+	) (*workloadidentityv1pb.WorkloadIdentityX509Revocation, error)
+	// ListWorkloadIdentities lists all WorkloadIdentities using Google style
+	// pagination.
+	ListWorkloadIdentityX509Revocations(
+		ctx context.Context, pageSize int, lastToken string,
+	) ([]*workloadidentityv1pb.WorkloadIdentityX509Revocation, string, error)
+	// CreateWorkloadIdentity creates a new WorkloadIdentity.
+	CreateWorkloadIdentityX509Revocation(
+		ctx context.Context,
+		workloadIdentityX509Revocation *workloadidentityv1pb.WorkloadIdentityX509Revocation,
+	) (*workloadidentityv1pb.WorkloadIdentityX509Revocation, error)
+	// DeleteWorkloadIdentity deletes a SPIFFE Federation by name.
+	DeleteWorkloadIdentityX509Revocation(ctx context.Context, name string) error
+	// UpdateWorkloadIdentity updates a specific WorkloadIdentity. The resource must
+	// already exist, and, condition update semantics are used - e.g the submitted
+	// resource must have a revision matching the revision of the resource in the
+	// backend.
+	UpdateWorkloadIdentityX509Revocation(
+		ctx context.Context,
+		workloadIdentityX509Revocation *workloadidentityv1pb.WorkloadIdentityX509Revocation,
+	) (*workloadidentityv1pb.WorkloadIdentityX509Revocation, error)
+	// UpsertWorkloadIdentity creates or updates a WorkloadIdentity.
+	UpsertWorkloadIdentityX509Revocation(
+		ctx context.Context,
+		workloadIdentityX509Revocation *workloadidentityv1pb.WorkloadIdentityX509Revocation,
+	) (*workloadidentityv1pb.WorkloadIdentityX509Revocation, error)
+}
+
+// MarshalWorkloadIdentityX509Revocation marshals the
+// WorkloadIdentityX509Revocation object into a JSON byte array.
+func MarshalWorkloadIdentityX509Revocation(
+	object *workloadidentityv1pb.WorkloadIdentityX509Revocation, opts ...MarshalOption,
+) ([]byte, error) {
+	return MarshalProtoResource(object, opts...)
+}
+
+// UnmarshalWorkloadIdentityX509Revocation unmarshals the
+// WorkloadIdentityX509Revocation object from a JSON byte array.
+func UnmarshalWorkloadIdentityX509Revocation(
+	data []byte, opts ...MarshalOption,
+) (*workloadidentityv1pb.WorkloadIdentityX509Revocation, error) {
+	return UnmarshalProtoResource[*workloadidentityv1pb.WorkloadIdentityX509Revocation](data, opts...)
+}
+
+// ValidateWorkloadIdentityX509Revocation validates the
+// WorkloadIdentityX509Revocation object.
+// It returns a nil if the object is valid, otherwise an error.
+func ValidateWorkloadIdentityX509Revocation(s *workloadidentityv1pb.WorkloadIdentityX509Revocation) error {
+	switch {
+	case s == nil:
+		return trace.BadParameter("object cannot be nil")
+	case s.Version != types.V1:
+		return trace.BadParameter("version: only %q is supported", types.V1)
+	case s.Kind != types.KindWorkloadIdentityX509Revocation:
+		return trace.BadParameter("kind: must be %q", types.KindWorkloadIdentityX509Revocation)
+	case s.Metadata == nil:
+		return trace.BadParameter("metadata: is required")
+	case s.Metadata.Name == "":
+		return trace.BadParameter("metadata.name: is required")
+	case s.Metadata.Expires == nil:
+		return trace.BadParameter("metadata.expires: is required")
+	case s.Metadata.Expires.IsValid() == false:
+		return trace.BadParameter("metadata.expires: must be valid")
+	case s.Metadata.Expires.AsTime().IsZero():
+		return trace.BadParameter("metadata.expires: must be non-zero")
+	case s.Spec == nil:
+		return trace.BadParameter("spec: is required")
+	case s.Spec.Reason == "":
+		return trace.BadParameter("spec.reason: is required")
+	case s.Spec.RevokedAt == nil:
+		return trace.BadParameter("spec.revoked_at: is required")
+	case s.Spec.RevokedAt.IsValid() == false:
+		return trace.BadParameter("spec.revoked_at: must be valid")
+	case s.Spec.RevokedAt.AsTime().IsZero():
+		return trace.BadParameter("spec.revoked_at: must be non-zero")
+	}
+
+	// Name must be a integer encoded as hex - this is the serial number of the
+	// X509 cert. Whilst typically presented using a colon separated hex string,
+	// here we will remove the colons. We will also ensure it is encoded in
+	// lowercase, to ensure consistency.
+	serial := big.Int{}
+	_, ok := serial.SetString(s.Metadata.Name, 16)
+	if !ok {
+		return trace.BadParameter("metadata.name: must be a hex encoded integer without colons")
+	}
+	if s.Metadata.Name != strings.ToLower(s.Metadata.Name) {
+		return trace.BadParameter("metadata.name: must be a lower-case encoded hex string")
+	}
+
+	return nil
+}

--- a/lib/services/workload_identity_x509_revocation_test.go
+++ b/lib/services/workload_identity_x509_revocation_test.go
@@ -1,0 +1,177 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package services
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
+	"github.com/gravitational/teleport/api/types"
+)
+
+func TestValidateWorkloadIdentityX509Revocation(t *testing.T) {
+	t.Parallel()
+
+	var errContains = func(contains string) require.ErrorAssertionFunc {
+		return func(t require.TestingT, err error, msgAndArgs ...interface{}) {
+			require.ErrorContains(t, err, contains, msgAndArgs...)
+		}
+	}
+
+	testCases := []struct {
+		name       string
+		in         *workloadidentityv1pb.WorkloadIdentityX509Revocation
+		requireErr require.ErrorAssertionFunc
+	}{
+		{
+			name: "success - full",
+			in: &workloadidentityv1pb.WorkloadIdentityX509Revocation{
+				Kind:    types.KindWorkloadIdentityX509Revocation,
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name:    "aabbccddeeff",
+					Expires: timestamppb.New(time.Now().Add(time.Hour)),
+				},
+				Spec: &workloadidentityv1pb.WorkloadIdentityX509RevocationSpec{
+					Reason:    "compromised",
+					RevokedAt: timestamppb.Now(),
+				},
+			},
+			requireErr: require.NoError,
+		},
+		{
+			name: "missing name",
+			in: &workloadidentityv1pb.WorkloadIdentityX509Revocation{
+				Kind:    types.KindWorkloadIdentityX509Revocation,
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Expires: timestamppb.New(time.Now().Add(time.Hour)),
+				},
+				Spec: &workloadidentityv1pb.WorkloadIdentityX509RevocationSpec{
+					Reason:    "compromised",
+					RevokedAt: timestamppb.Now(),
+				},
+			},
+			requireErr: errContains("metadata.name: is required"),
+		},
+		{
+			name: "missing reason",
+			in: &workloadidentityv1pb.WorkloadIdentityX509Revocation{
+				Kind:    types.KindWorkloadIdentityX509Revocation,
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name:    "aabbccddeeff",
+					Expires: timestamppb.New(time.Now().Add(time.Hour)),
+				},
+				Spec: &workloadidentityv1pb.WorkloadIdentityX509RevocationSpec{
+					RevokedAt: timestamppb.Now(),
+				},
+			},
+			requireErr: errContains("spec.reason: is required"),
+		},
+		{
+			name: "invalid name: colons",
+			in: &workloadidentityv1pb.WorkloadIdentityX509Revocation{
+				Kind:    types.KindWorkloadIdentityX509Revocation,
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name:    "aa:bb:cc:dd:ee:ff",
+					Expires: timestamppb.New(time.Now().Add(time.Hour)),
+				},
+				Spec: &workloadidentityv1pb.WorkloadIdentityX509RevocationSpec{
+					Reason:    "compromised",
+					RevokedAt: timestamppb.Now(),
+				},
+			},
+			requireErr: errContains("metadata.name: must be a hex encoded integer without colons"),
+		},
+		{
+			name: "invalid name: not lowercase",
+			in: &workloadidentityv1pb.WorkloadIdentityX509Revocation{
+				Kind:    types.KindWorkloadIdentityX509Revocation,
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name:    "AAbbCCddEE",
+					Expires: timestamppb.New(time.Now().Add(time.Hour)),
+				},
+				Spec: &workloadidentityv1pb.WorkloadIdentityX509RevocationSpec{
+					Reason:    "compromised",
+					RevokedAt: timestamppb.Now(),
+				},
+			},
+			requireErr: errContains("metadata.name: must be a lower-case encoded hex string"),
+		},
+		{
+			name: "invalid name: not base 16",
+			in: &workloadidentityv1pb.WorkloadIdentityX509Revocation{
+				Kind:    types.KindWorkloadIdentityX509Revocation,
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name:    "aabbxx",
+					Expires: timestamppb.New(time.Now().Add(time.Hour)),
+				},
+				Spec: &workloadidentityv1pb.WorkloadIdentityX509RevocationSpec{
+					Reason:    "compromised",
+					RevokedAt: timestamppb.Now(),
+				},
+			},
+			requireErr: errContains("metadata.name: must be a hex encoded integer without colons"),
+		},
+		{
+			name: "missing expiry",
+			in: &workloadidentityv1pb.WorkloadIdentityX509Revocation{
+				Kind:    types.KindWorkloadIdentityX509Revocation,
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "aabbccddeeff",
+				},
+				Spec: &workloadidentityv1pb.WorkloadIdentityX509RevocationSpec{
+					Reason:    "compromised",
+					RevokedAt: timestamppb.Now(),
+				},
+			},
+			requireErr: errContains("metadata.expires: is required"),
+		},
+		{
+			name: "missing revoked at",
+			in: &workloadidentityv1pb.WorkloadIdentityX509Revocation{
+				Kind:    types.KindWorkloadIdentityX509Revocation,
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name:    "aabbccddeeff",
+					Expires: timestamppb.New(time.Now().Add(time.Hour)),
+				},
+				Spec: &workloadidentityv1pb.WorkloadIdentityX509RevocationSpec{
+					Reason: "compromised",
+				},
+			},
+			requireErr: errContains("spec.revoked_at: is required"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateWorkloadIdentityX509Revocation(tc.in)
+			tc.requireErr(t, err)
+		})
+	}
+}

--- a/lib/services/workload_identity_x509_revocation_test.go
+++ b/lib/services/workload_identity_x509_revocation_test.go
@@ -104,7 +104,7 @@ func TestValidateWorkloadIdentityX509Revocation(t *testing.T) {
 					RevokedAt: timestamppb.Now(),
 				},
 			},
-			requireErr: errContains("metadata.name: must be a hex encoded integer without colons"),
+			requireErr: errContains("metadata.name: must be a lower-case hex encoded integer without colons"),
 		},
 		{
 			name: "invalid name: not lowercase",
@@ -120,7 +120,7 @@ func TestValidateWorkloadIdentityX509Revocation(t *testing.T) {
 					RevokedAt: timestamppb.Now(),
 				},
 			},
-			requireErr: errContains("metadata.name: must be a lower-case encoded hex string"),
+			requireErr: errContains("metadata.name: must be a lower-case hex encoded integer without colons"),
 		},
 		{
 			name: "invalid name: not base 16",
@@ -136,7 +136,7 @@ func TestValidateWorkloadIdentityX509Revocation(t *testing.T) {
 					RevokedAt: timestamppb.Now(),
 				},
 			},
-			requireErr: errContains("metadata.name: must be a hex encoded integer without colons"),
+			requireErr: errContains("metadata.name: must be a lower-case hex encoded integer without colons"),
 		},
 		{
 			name: "missing expiry",


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport/issues/51504

Depends on https://github.com/gravitational/teleport/pull/51996

Adds backend service implementation for WorkloadIdentityX509Revocation service & tests, as well as support for the events and audit events. Will follow up with GRPC service implementation.