### PR TITLE
tctl edit: refuse to operate on multiple resources at once

### DIFF
--- a/tool/tctl/common/edit_command.go
+++ b/tool/tctl/common/edit_command.go
@@ -128,6 +128,10 @@ func (e *EditCommand) editResource(ctx context.Context, client *authclient.Clien
 	}
 	rc.Initialize(e.app, nil, e.config)
 
+	if rc.refs.IsAll() || len(rc.refs) != 1 || rc.refs[0].Name == "" {
+		return trace.BadParameter("tctl can only edit a single resource at a time")
+	}
+
 	// Prompt for admin action MFA if required, before getting any
 	// resources with secrets and before the update/editor below.
 	if mfaResponse, err := mfa.PerformAdminActionMFACeremony(ctx, client.PerformMFACeremony, true /*allowReuse*/); err == nil {


### PR DESCRIPTION
For now, prevent trying to edit multiple resources (`tctl edit users` for example), because only the first will be applied.

Some day we may revisit this and allow edits of multiple resources, but for now we keep it simple by refusing the edit and not giving the impression that it is supposed to work.

Closes #38531