### PR TITLE
Add `<Stack>` (a variant of `<Flex>`)

### DIFF
--- a/web/packages/design/src/Flex/Flex.tsx
+++ b/web/packages/design/src/Flex/Flex.tsx
@@ -62,3 +62,45 @@ const Flex = styled(Box)<FlexProps>`
 Flex.displayName = 'Flex';
 
 export default Flex;
+
+/**
+ * Stack is a variant of Flex designed to distribute elements in a vertical space with consistent
+ * spacing using the gap property. If no gap is specified, it defaults to 1.
+ *
+ * It's possible to "split the stack" by setting `margin-top: auto;` on a specific child. That child
+ * and all children below it will be aligned to the bottom of the stack.
+ *
+ * Inspired by https://every-layout.dev/layouts/stack/. It follows the approach of styling the
+ * context, not the individual elements, to achieve desired spacing.
+ *
+ * @example
+ *
+ * <Stack gap={3}>
+ *   <Stack>
+ *     <Breadcrumbs />
+ *     <ComponentHeader/>
+ *   </Stack>
+ *
+ *   <Stack gap={2}>
+ *     <ComponentMainBody/>
+ *     <ComponentSidenote />
+ *   </Stack>
+ * </Stack>
+ */
+export const Stack = styled(Flex).attrs({
+  flexDirection: 'column',
+})`
+  // Prevents children from shrinking, within a stack we pretty much never want that to happen.
+  // Individual children can override this.
+  & > * {
+    flex-shrink: 0;
+  }
+`;
+Stack.defaultProps = {
+  gap: 1,
+  // align-items: flex-start lets children keep their original size. Otherwise elements like buttons
+  // would occupy all available horizontal space instead of the minimal amount of space they need.
+  //
+  // This is set as a default prop, as in some cases it might be necessary to override align-items.
+  alignItems: 'flex-start',
+};

--- a/web/packages/design/src/Flex/Stack.story.tsx
+++ b/web/packages/design/src/Flex/Stack.story.tsx
@@ -1,0 +1,70 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import styled from 'styled-components';
+
+import Box from 'design/Box';
+import { ButtonPrimary } from 'design/Button';
+import { P } from 'design/Text/Text';
+
+import { Stack } from './Flex';
+
+export default {
+  title: 'Design/Flex/Stack',
+};
+
+export const Basic = () => (
+  <Stack gap={6}>
+    <Square bg="pink" />
+
+    <Stack gap={3}>
+      {/* If no gap prop is given, a default gap of 1 is used. */}
+      <Stack>
+        <Square bg="green" />
+        <ButtonPrimary>Foo</ButtonPrimary>
+      </Stack>
+      <Stack>
+        <Square bg="green" />
+        <ButtonPrimary>Bar</ButtonPrimary>
+      </Stack>
+      <Stack>
+        <Square bg="green" />
+        <ButtonPrimary>Baz</ButtonPrimary>
+      </Stack>
+    </Stack>
+
+    <Square bg="yellow" />
+  </Stack>
+);
+
+export const MarginAuto = () => (
+  <Stack gap={6} height="90vh">
+    <P>
+      <code>margin-top: auto</code> can be used to automatically align elements
+      after a certain child to the end of the stack.
+    </P>
+    <SmallSquare bg="pink" />
+    <SmallSquare bg="green" />
+    <SmallSquare bg="brown" />
+    <SmallSquare bg="yellow" marginTop="auto" />
+    <SmallSquare bg="orange" />
+  </Stack>
+);
+
+const Square = styled(Box).attrs({ width: '150px', height: '150px' })``;
+const SmallSquare = styled(Box).attrs({ width: '50px', height: '50px' })``;

--- a/web/packages/design/src/Flex/index.ts
+++ b/web/packages/design/src/Flex/index.ts
@@ -18,6 +18,6 @@
 
 import Flex from './Flex';
 
-export { type FlexProps } from './Flex';
+export { type FlexProps, Stack } from './Flex';
 
 export default Flex;

--- a/web/packages/design/src/index.ts
+++ b/web/packages/design/src/index.ts
@@ -111,3 +111,4 @@ export {
 };
 export type { TextAreaProps } from './TextArea';
 export * from './keyframes';
+export { Stack } from './Flex';


### PR DESCRIPTION
This PR adds a `Flex` variant called `Stack`. It's basically just `<Flex flexDirection="column" alignItems="flex-start">`. Over time, I found myself reaching for it pretty often, especially in the new VNet diagnostic report that I'm working on. It gets pretty annoying to define it by hand whenever you want to use it, hence this PR.

It's based on [The Stack from Every Layout](https://every-layout.dev/layouts/stack/):

> Flow elements require space (sometimes referred to as white space) to physically and conceptually separate them from the elements that come before and after them. This is the purpose of the margin property.
>
> However, design systems conceive elements and components in isolation. At the time of conception, it is not settled whether there will be surrounding content or what the nature of that content will be. One element or component is likely to appear in different contexts, and the requirement for spacing will differ.
>
> We are in the habit of styling elements, or classes of elements, directly: we make style declarations belong to elements. Typically, this does not produce any issues, but margin is really a property of the relationship between two proximate elements. (…)
>
> The trick is to style the context, not the individual element(s). The Stack layout primitive injects margin between elements via their common parent.

I've used `gap` instead of `margin-block` like Every Layout does because 1) it's what we already use 2) it has wider browser support.

| Basic example | Example with `margin-top: auto` |
| --- | --- |
| <img width="1135" alt="stack-basic" src="https://github.com/user-attachments/assets/5ba8b4ed-4019-43a1-8148-4725560d8864" /> | <img width="1135" alt="stack-margin-auto" src="https://github.com/user-attachments/assets/13531193-7419-4f56-a676-4a7b939dfce0" /> |

