### PR TITLE
Add ManageClusters to dashboard navigation

### DIFF
--- a/web/packages/teleport/src/Navigation/Navigation.test.tsx
+++ b/web/packages/teleport/src/Navigation/Navigation.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { MemoryRouter } from 'react-router';
+
+import { render, screen } from 'design/utils/testing';
+
+import cfg from 'teleport/config';
+import { getOSSFeatures } from 'teleport/features';
+import { FeaturesContextProvider } from 'teleport/FeaturesContext';
+import { ContextProvider } from 'teleport/index';
+import { createTeleportContext } from 'teleport/mocks/contexts';
+import { makeDefaultUserPreferences } from 'teleport/services/userPreferences/userPreferences';
+import { NavTitle } from 'teleport/types';
+import { makeTestUserContext } from 'teleport/User/testHelpers/makeTestUserContext';
+import { mockUserContextProviderWith } from 'teleport/User/testHelpers/mockUserContextWith';
+
+import { Navigation } from '.';
+
+test('show all dashboard navigation items', async () => {
+  const expectedItems = [
+    NavTitle.Roles,
+    NavTitle.Users,
+    NavTitle.AuthConnectorsShortened,
+    NavTitle.ManageClustersShortened,
+    NavTitle.Downloads,
+  ];
+  cfg.isDashboard = true;
+  const defaultPref = makeDefaultUserPreferences();
+  mockUserContextProviderWith(
+    makeTestUserContext({ preferences: defaultPref })
+  );
+  const ctx = createTeleportContext();
+  const features = getOSSFeatures();
+  const dashboardItems = features.filter(feature =>
+    expectedItems.includes(feature.navigationItem?.title)
+  );
+  const nonDashboardItems = features.filter(
+    feature => !expectedItems.includes(feature.navigationItem?.title)
+  );
+
+  render(
+    <MemoryRouter>
+      <ContextProvider ctx={ctx}>
+        <FeaturesContextProvider value={features}>
+          <Navigation />
+        </FeaturesContextProvider>
+      </ContextProvider>
+    </MemoryRouter>
+  );
+
+  dashboardItems.forEach(item => {
+    expect(screen.getByText(item.navigationItem.title)).toBeInTheDocument();
+  });
+
+  nonDashboardItems.forEach(item => {
+    if (!item.navigationItem) {
+      return;
+    }
+    expect(
+      screen.queryByText(item.navigationItem.title)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/packages/teleport/src/Navigation/Section.tsx
+++ b/web/packages/teleport/src/Navigation/Section.tsx
@@ -163,12 +163,7 @@ export function StandaloneSection({
   $active: boolean;
 }) {
   return (
-    <CategoryButton
-      as={NavLink}
-      $active={$active}
-      isExpanded={false}
-      to={route}
-    >
+    <CategoryButton as={NavLink} $active={$active} to={route}>
       <Icon />
       {title}
     </CategoryButton>
@@ -269,7 +264,7 @@ const AnimatedArrow = styled(ArrowLineLeft)<{ $isSticky: boolean }>`
 
 export const CategoryButton = styled.button<{
   $active: boolean;
-  isExpanded: boolean;
+  isExpanded?: boolean;
 }>`
   min-height: 60px;
   min-width: 60px;

--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -563,8 +563,12 @@ export class FeatureClusters implements TeleportFeature {
     return cfg.isDashboard || flags.trustedClusters;
   }
 
+  showInDashboard = true;
+
   navigationItem = {
-    title: NavTitle.ManageClusters,
+    title: cfg.isDashboard
+      ? NavTitle.ManageClustersShortened
+      : NavTitle.ManageClusters,
     icon: SlidersVertical,
     exact: false,
     getLink() {

--- a/web/packages/teleport/src/types.ts
+++ b/web/packages/teleport/src/types.ts
@@ -94,6 +94,7 @@ export enum NavTitle {
 
   // Clusters
   ManageClusters = 'Manage Clusters',
+  ManageClustersShortened = 'Clusters',
   TrustedClusters = 'Trusted Root Clusters',
 
   // Account


### PR DESCRIPTION
This PR adds back the "Manage Clusters" button to dashboards clients.

Also, we seem to have a few issues in the past few months about missing items in dashboard clusters so I added a test with the expected (and not expected items).
