### PR TITLE
[v17] Add uri flag for s3 path style addressing configuration

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -388,6 +388,9 @@ const (
 	// SSEKMSKey is an optional switch to use an KMS CMK key for S3 SSE.
 	SSEKMSKey = "sse_kms_key"
 
+	// S3UseVirtualStyleAddressing is an optional switch to use use a virtual-hosted–style URI.
+	S3UseVirtualStyleAddressing = "use_s3_virtual_style_addressing"
+
 	// SchemeFile configures local disk-based file storage for audit events
 	SchemeFile = "file"
 

--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -651,6 +651,10 @@ Service reads these parameters to configure its interactions with S3:
 - `use_fips_endpoint=true` -  [Configure S3 FIPS
   endpoints](#configuring-aws-fips-endpoints)
 
+- `use_s3_virtual_style_addressing` - Whether to use virtual-host-style instead of path-style URLs for the
+  bucket. Only applies when a custom endpoint is set. Defaults to false when unset. If used
+  without a custom endpoint set, this option has no effect.
+
 ### S3 IAM policy
 
 (!docs/pages/includes/s3-iam-policy.mdx!)

--- a/lib/events/s3sessions/s3handler.go
+++ b/lib/events/s3sessions/s3handler.go
@@ -97,6 +97,14 @@ type Config struct {
 	Insecure bool
 	// DisableServerSideEncryption is an optional switch to opt out of SSE in case the provider does not support it
 	DisableServerSideEncryption bool
+
+	// UseVirtualStyleAddressing use a virtual-hosted–style URI.
+	// Path style e.g. https://s3.region-code.amazonaws.com/bucket-name/key-name
+	// Virtual hosted style e.g. https://bucket-name.s3.region-code.amazonaws.com/key-name
+	// Teleport defaults to path-style addressing for better interoperability
+	// with 3rd party S3-compatible services out of the box.
+	// See https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html for more details.
+	UseVirtualStyleAddressing bool
 }
 
 // SetFromURL sets values on the Config from the supplied URI
@@ -145,6 +153,17 @@ func (s *Config) SetFromURL(in *url.URL, inRegion string) error {
 		} else {
 			s.UseFIPSEndpoint = types.ClusterAuditConfigSpecV2_FIPS_DISABLED
 		}
+	}
+
+	if val := in.Query().Get(teleport.S3UseVirtualStyleAddressing); val != "" {
+		useVirtualStyleAddressing, err := strconv.ParseBool(val)
+		if err != nil {
+			return trace.BadParameter(boolErrorTemplate, in.String(), teleport.S3UseVirtualStyleAddressing, val)
+		}
+		s.UseVirtualStyleAddressing = useVirtualStyleAddressing
+	} else {
+		// Default to false for backwards compatibility
+		s.UseVirtualStyleAddressing = false
 	}
 
 	s.Region = region
@@ -219,7 +238,7 @@ func NewHandler(ctx context.Context, cfg Config) (*Handler, error) {
 		opts = append(opts, config.WithBaseEndpoint(cfg.Endpoint))
 
 		s3Opts = append(s3Opts, func(options *s3.Options) {
-			options.UsePathStyle = true
+			options.UsePathStyle = !cfg.UseVirtualStyleAddressing
 		})
 	}
 

--- a/lib/events/s3sessions/s3handler_config_test.go
+++ b/lib/events/s3sessions/s3handler_config_test.go
@@ -115,6 +115,27 @@ func TestConfig_SetFromURL(t *testing.T) {
 				require.Equal(t, types.ClusterAuditConfigSpecV2_FIPS_DISABLED, config.UseFIPSEndpoint)
 			},
 		},
+		{
+			name: "path style addressing enabled via url",
+			url:  "s3://path/bucket/adit?use_s3_virtual_style_addressing=false",
+			cfgAssertion: func(t *testing.T, config Config) {
+				require.False(t, config.UseVirtualStyleAddressing)
+			},
+		},
+		{
+			name: "path style addressing enabled by default",
+			url:  "s3://path/bucket/audit",
+			cfgAssertion: func(t *testing.T, config Config) {
+				require.False(t, config.UseVirtualStyleAddressing)
+			},
+		},
+		{
+			name: "path style addressing disabled via url",
+			url:  "s3://path/bucket/audit?use_s3_virtual_style_addressing=true",
+			cfgAssertion: func(t *testing.T, config Config) {
+				require.True(t, config.UseVirtualStyleAddressing)
+			},
+		},
 	}
 
 	for _, tt := range cases {


### PR DESCRIPTION
Backport #49835 to branch/v17

changelog: Add ability to disable  path-style S3 access for third-party endpoints.
