### PR TITLE
[v17] tctl: fix create cmd when input starts with an empty doc

### DIFF
--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"reflect"
 	"slices"
 	"sort"
 	"strings"
@@ -370,6 +371,14 @@ func (rc *ResourceCommand) Create(ctx context.Context, client *authclient.Client
 			}
 			return trace.Wrap(err)
 		}
+
+		// An empty document at the beginning of the input will unmarshal without error.
+		// Keep reading - there may be a valid document later on.
+		// https://github.com/gravitational/teleport/issues/4703
+		if reflect.ValueOf(raw).IsZero() {
+			continue
+		}
+
 		count++
 
 		// locate the creator function for a given resource kind:

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -1392,6 +1392,10 @@ func TestCreateResources(t *testing.T) {
 			create: testCreateUser,
 		},
 		{
+			kind:   "empty-doc",
+			create: testCreateWithEmptyDocument,
+		},
+		{
 			kind:   types.KindDatabaseObjectImportRule,
 			create: testCreateDatabaseObjectImportRule,
 		},
@@ -1646,6 +1650,22 @@ spec:
 	require.True(t, trace.IsAlreadyExists(err))
 
 	_, err = runResourceCommand(t, clt, []string{"create", "-f", serverInfoYAMLPath})
+	require.NoError(t, err)
+}
+
+func testCreateWithEmptyDocument(t *testing.T, clt *authclient.Client) {
+	const userYAML = `
+---
+kind: user
+version: v2
+metadata:
+  name: llama2
+spec:
+  roles: ["access"]
+`
+	userYAMLPath := filepath.Join(t.TempDir(), "user.yaml")
+	require.NoError(t, os.WriteFile(userYAMLPath, []byte(userYAML), 0644))
+	_, err := runResourceCommand(t, clt, []string{"create", userYAMLPath})
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
Backport #51989 to branch/v17