### PR TITLE
[teleport-update] skip updater setup when systemd is missing

### DIFF
--- a/lib/autoupdate/agent/installer.go
+++ b/lib/autoupdate/agent/installer.go
@@ -370,6 +370,7 @@ func tgzExtractPaths(ent bool) []utils.ExtractPath {
 		{Src: path.Join(prefix, "README.md"), Dst: "share/README.md", DirMode: systemDirMode},
 		{Src: path.Join(prefix, "CHANGELOG.md"), Dst: "share/CHANGELOG.md", DirMode: systemDirMode},
 		{Src: path.Join(prefix, "VERSION"), Dst: "share/VERSION", DirMode: systemDirMode},
+		{Src: path.Join(prefix, "LICENSE-community"), Dst: "share/LICENSE-community", DirMode: systemDirMode},
 		{Src: prefix, Dst: "bin", DirMode: systemDirMode},
 	}
 }

--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -449,11 +449,9 @@ func (s SystemdService) checkSystem(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 	if !present {
-		s.Log.ErrorContext(ctx, "This system does not support systemd, which is required by the updater.")
 		return trace.Wrap(ErrNotSupported)
 	}
 	return nil
-
 }
 
 // hasSystemD returns true if the system uses the SystemD process manager.

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -897,10 +897,6 @@ func (u *Updater) Setup(ctx context.Context, restart bool) error {
 	if errors.Is(err, context.Canceled) {
 		return trace.Errorf("sync canceled")
 	}
-	if errors.Is(err, ErrNotSupported) {
-		u.Log.WarnContext(ctx, "Skipping all systemd setup because systemd is not running.")
-		return nil
-	}
 	if err != nil {
 		return trace.Wrap(err, "failed to setup updater")
 	}
@@ -908,6 +904,10 @@ func (u *Updater) Setup(ctx context.Context, restart bool) error {
 	present, err := u.Process.IsPresent(ctx)
 	if errors.Is(err, context.Canceled) {
 		return trace.Errorf("config check canceled")
+	}
+	if errors.Is(err, ErrNotSupported) {
+		u.Log.WarnContext(ctx, "Skipping all systemd setup because systemd is not running.")
+		return nil
 	}
 	if err != nil {
 		return trace.Wrap(err, "failed to determine if new version of Teleport has an installed systemd service")

--- a/lib/autoupdate/agent/updater_test.go
+++ b/lib/autoupdate/agent/updater_test.go
@@ -1759,11 +1759,6 @@ func TestUpdater_Setup(t *testing.T) {
 			errMatch: "some error",
 		},
 		{
-			name:     "setup error not supported",
-			restart:  false,
-			setupErr: ErrNotSupported,
-		},
-		{
 			name:     "setup error canceled",
 			restart:  false,
 			setupErr: context.Canceled,
@@ -1780,6 +1775,11 @@ func TestUpdater_Setup(t *testing.T) {
 			restart:    false,
 			presentErr: context.Canceled,
 			errMatch:   "canceled",
+		},
+		{
+			name:       "preset error not supported",
+			restart:    false,
+			presentErr: ErrNotSupported,
 		},
 		{
 			name:      "reload error canceled",

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -41,11 +41,11 @@ import (
 
 const appHelp = `Teleport Updater
 
-The Teleport Updater automatically updates a Teleport agent.
+The Teleport Updater applies Managed Updates to a Teleport agent installation.
 
-The Teleport Updater supports upgrade schedules and automated rollbacks. 
+The Teleport Updater supports update scheduling and automated rollbacks.
 
-Find out more at https://goteleport.com/docs/updater`
+Find out more at https://goteleport.com/docs/upgrading/agent-managed-updates`
 
 const (
 	// proxyServerEnvVar allows the proxy server address to be specified via env var.
@@ -112,7 +112,7 @@ func Run(args []string) int {
 
 	versionCmd := app.Command("version", fmt.Sprintf("Print the version of your %s binary.", autoupdate.BinaryName))
 
-	enableCmd := app.Command("enable", "Enable agent auto-updates and perform initial installation or update. This creates a systemd timer that periodically runs the update subcommand.")
+	enableCmd := app.Command("enable", "Enable agent managed updates and perform initial installation or update. This creates a systemd timer that periodically runs the update subcommand.")
 	enableCmd.Flag("proxy", "Address of the Teleport Proxy.").
 		Short('p').Envar(proxyServerEnvVar).StringVar(&ccfg.Proxy)
 	enableCmd.Flag("group", "Update group for this agent installation.").
@@ -123,9 +123,11 @@ func Run(args []string) int {
 		Short('o').BoolVar(&ccfg.AllowOverwrite)
 	enableCmd.Flag("force-version", "Force the provided version instead of using the version provided by the Teleport cluster.").
 		Short('f').Envar(updateVersionEnvVar).Hidden().StringVar(&ccfg.ForceVersion)
-	enableCmd.Flag("self-setup", "Use the current teleport-update binary to create systemd service config for auto-updates.").
+	enableCmd.Flag("self-setup", "Use the current teleport-update binary to create systemd service config for managed updates.").
 		Short('s').Hidden().BoolVar(&ccfg.SelfSetup)
 	// TODO(sclevine): add force-fips and force-enterprise as hidden flags
+
+	disableCmd := app.Command("disable", "Disable agent managed updates. Does not affect the active installation of Teleport.")
 
 	pinCmd := app.Command("pin", "Install Teleport and lock the updater to the installed version.")
 	pinCmd.Flag("proxy", "Address of the Teleport Proxy.").
@@ -136,19 +138,18 @@ func Run(args []string) int {
 		Short('b').Envar(common.BaseURLEnvVar).StringVar(&ccfg.BaseURL)
 	pinCmd.Flag("force-version", "Force the provided version instead of using the version provided by the Teleport cluster.").
 		Short('f').Envar(updateVersionEnvVar).StringVar(&ccfg.ForceVersion)
-	pinCmd.Flag("self-setup", "Use the current teleport-update binary to create systemd service config for auto-updates.").
+	pinCmd.Flag("self-setup", "Use the current teleport-update binary to create systemd service config for managed updates.").
 		Short('s').Hidden().BoolVar(&ccfg.SelfSetup)
 
-	disableCmd := app.Command("disable", "Disable agent auto-updates. Does not affect the active installation of Teleport.")
 	unpinCmd := app.Command("unpin", "Unpin the current version, allowing it to be updated.")
 
 	updateCmd := app.Command("update", "Update the agent to the latest version, if a new version is available.")
 	updateCmd.Flag("now", "Force immediate update even if update window is not active.").
 		Short('n').BoolVar(&ccfg.UpdateNow)
-	updateCmd.Flag("self-setup", "Use the current teleport-update binary to create systemd service config for auto-updates and verify the Teleport installation.").
+	updateCmd.Flag("self-setup", "Use the current teleport-update binary to create systemd service config for managed updates and verify the Teleport installation.").
 		Short('s').Hidden().BoolVar(&ccfg.SelfSetup)
 
-	linkCmd := app.Command("link-package", "Link the system installation of Teleport from the Teleport package, if auto-updates is disabled.")
+	linkCmd := app.Command("link-package", "Link the system installation of Teleport from the Teleport package, if managed updates is disabled.")
 	unlinkCmd := app.Command("unlink-package", "Unlink the system installation of Teleport from the Teleport package.")
 
 	setupCmd := app.Command("setup", "Write configuration files that run the update subcommand on a timer and verify the Teleport installation.").
@@ -365,7 +366,7 @@ func cmdUpdate(ctx context.Context, ccfg *cliConfig) error {
 	return nil
 }
 
-// cmdLinkPackage creates system package links if no version is linked and auto-updates is disabled.
+// cmdLinkPackage creates system package links if no version is linked and managed updates is disabled.
 func cmdLinkPackage(ctx context.Context, ccfg *cliConfig) error {
 	updater, lockFile, err := initConfig(ccfg)
 	if err != nil {


### PR DESCRIPTION
This PR makes `teleport-update` skip installing systemd timers that configure the updater when systemd is missing.

This makes it easier to test `teleport-update` in a docker container, or alternatively, use `teleport-update` to install Teleport on non-systemd systems.

This PR also includes help text updates to better match the upcoming docs PR.

---

The `teleport-update` binary will be used to enable, disable, and trigger automatic Teleport agent updates. The new auto-updates system manages a local installation of the cluster-specified version of Teleport stored in `/opt/teleport`.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/10289