### PR TITLE
Improve discovery service name conflict error log

### DIFF
--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -1959,6 +1959,17 @@ func (s *Server) resolveCreateErr(createErr error, discoveryOrigin string, gette
 
 	old, err := getter()
 	if err != nil {
+		if trace.IsNotFound(err) {
+			// if we get an AlreadyExists error while creating the resource and
+			// a NotFound error when retrieving it, then it's a resource that
+			// already exists and we are not allowed to read it, so we can't
+			// update it either. NotFound comes from the discovery service's
+			// cache which only contains resources that this process is allowed
+			// to access.
+			return trace.Wrap(createErr,
+				"not updating because the existing resource is not managed by auto-discovery",
+			)
+		}
 		return trace.NewAggregate(createErr, err)
 	}
 


### PR DESCRIPTION
Check for an edge case that lead to a confusing error log when the discovery service tries to create a resource that already exists and came from a different origin.

The discovery service only has permissions to read/write Teleport resources with the label teleport.dev/origin: "cloud".

Additionally, the discovery service tries to resolve an AlreadyExists error by checking that the existing resource has "cloud" origin and is in the same discovery_group as the discovery service.

However, it checks the existing resource by consulting its cache, which may not contain the existing resource if the discovery service is not allowed to read it.

The error log might say something like "failed to create X ... X doesn't exist", which was confusing.
This fixes that error log.