### PR TITLE
Harden the role editor by falling back to YAML

### DIFF
--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
@@ -21,8 +21,10 @@ import { UserEvent } from '@testing-library/user-event';
 
 import { render, screen, userEvent } from 'design/utils/testing';
 
+import cfg from 'teleport/config';
 import { createTeleportContext } from 'teleport/mocks/contexts';
 import { Role } from 'teleport/services/resources';
+import { storageService } from 'teleport/services/storageService';
 import { CaptureEvent, userEventService } from 'teleport/services/userEvent';
 import { yamlService } from 'teleport/services/yaml';
 import {
@@ -32,8 +34,12 @@ import {
 import TeleportContextProvider from 'teleport/TeleportContextProvider';
 
 import { RoleEditor, RoleEditorProps } from './RoleEditor';
+import * as StandardEditorModule from './StandardEditor/StandardEditor';
 import { defaultRoleVersion } from './StandardEditor/standardmodel';
+import * as StandardModelModule from './StandardEditor/standardmodel';
 import { defaultOptions, withDefaults } from './StandardEditor/withDefaults';
+
+const defaultIsPolicyEnabled = cfg.isPolicyEnabled;
 
 // The Ace editor is very difficult to deal with in tests, especially that for
 // handling its state, we are using input event, which is asynchronous. Thus,
@@ -72,6 +78,7 @@ beforeEach(() => {
 
 afterEach(() => {
   jest.restoreAllMocks();
+  cfg.isPolicyEnabled = defaultIsPolicyEnabled;
 });
 
 test('rendering and switching tabs for new role', async () => {
@@ -138,6 +145,21 @@ test('rendering and switching tabs for a non-standard role', async () => {
   await user.click(getYamlEditorTab());
   expect(fromFauxYaml(await getTextEditorContents())).toEqual(originalRole);
   expect(screen.getByRole('button', { name: 'Save Changes' })).toBeDisabled();
+});
+
+it('calls onRoleUpdate on each modification in the standard editor', async () => {
+  cfg.isPolicyEnabled = true;
+  const onRoleUpdate = jest.fn();
+  render(<TestRoleEditor onRoleUpdate={onRoleUpdate} />);
+  expect(onRoleUpdate).toHaveBeenLastCalledWith(
+    withDefaults({ metadata: { name: 'new_role_name' } })
+  );
+  await user.type(screen.getByLabelText('Description'), 'some-description');
+  expect(onRoleUpdate).toHaveBeenLastCalledWith(
+    withDefaults({
+      metadata: { name: 'new_role_name', description: 'some-description' },
+    })
+  );
 });
 
 test('switching tabs triggers validation', async () => {
@@ -259,21 +281,58 @@ test('saving a new role', async () => {
   });
 });
 
-test('saving a new role after editing as YAML', async () => {
-  const onSave = jest.fn();
-  render(<TestRoleEditor onSave={onSave} />);
-  expect(screen.getByRole('button', { name: 'Create Role' })).toBeEnabled();
+describe('saving a new role after editing as YAML', () => {
+  test('with Policy disabled', async () => {
+    const onSave = jest.fn();
+    render(<TestRoleEditor onSave={onSave} />);
+    expect(screen.getByRole('button', { name: 'Create Role' })).toBeEnabled();
 
-  await user.click(getYamlEditorTab());
-  await user.clear(await findTextEditor());
-  await user.type(await findTextEditor(), '{{"foo":"bar"}');
-  await user.click(screen.getByRole('button', { name: 'Create Role' }));
+    await user.click(getYamlEditorTab());
+    await user.clear(await findTextEditor());
+    await user.type(await findTextEditor(), '{{"foo":"bar"}');
+    await user.click(screen.getByRole('button', { name: 'Create Role' }));
 
-  expect(onSave).toHaveBeenCalledWith({
-    yaml: '{"foo":"bar"}',
+    expect(onSave).toHaveBeenCalledWith({
+      yaml: '{"foo":"bar"}',
+    });
+    expect(userEventService.captureUserEvent).toHaveBeenCalledWith({
+      event: CaptureEvent.CreateNewRoleSaveClickEvent,
+    });
   });
-  expect(userEventService.captureUserEvent).toHaveBeenCalledWith({
-    event: CaptureEvent.CreateNewRoleSaveClickEvent,
+
+  test('with Policy enabled', async () => {
+    cfg.isPolicyEnabled = true;
+    jest
+      .spyOn(storageService, 'getAccessGraphRoleTesterEnabled')
+      .mockReturnValue(true);
+
+    const onRoleUpdate = jest.fn();
+    const onSave = jest.fn();
+    render(<TestRoleEditor onRoleUpdate={onRoleUpdate} onSave={onSave} />);
+    expect(screen.getByRole('button', { name: 'Create Role' })).toBeEnabled();
+
+    await user.click(getYamlEditorTab());
+    await user.clear(await findTextEditor());
+
+    onRoleUpdate.mockReset();
+    await user.type(
+      await findTextEditor(),
+      '{{"metadata":{{"description":"foo"}}'
+    );
+    expect(onRoleUpdate).not.toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: 'Preview' }));
+    expect(onRoleUpdate).toHaveBeenCalledTimes(1);
+    expect(onRoleUpdate).toHaveBeenCalledWith(
+      withDefaults({ metadata: { description: 'foo' } })
+    );
+    await user.click(screen.getByRole('button', { name: 'Create Role' }));
+
+    expect(onSave).toHaveBeenCalledWith({
+      yaml: '{"metadata":{"description":"foo"}}',
+    });
+    expect(userEventService.captureUserEvent).toHaveBeenCalledWith({
+      event: CaptureEvent.CreateNewRoleSaveClickEvent,
+    });
   });
 });
 
@@ -290,7 +349,7 @@ test('error while yamlifying', async () => {
     .mockRejectedValue(new Error('me no speak yaml'));
   render(<TestRoleEditor />);
   await user.click(getYamlEditorTab());
-  expect(screen.getByText('me no speak yaml')).toBeVisible();
+  expect(screen.getByText(/me no speak yaml/)).toBeVisible();
 });
 
 test('error while parsing', async () => {
@@ -300,7 +359,87 @@ test('error while parsing', async () => {
   render(<TestRoleEditor />);
   await user.click(getYamlEditorTab());
   await user.click(getStandardEditorTab());
-  expect(screen.getByText('me no speak yaml')).toBeVisible();
+  expect(
+    screen.getByText('Unable to load role into the standard editor')
+  ).toBeVisible();
+  expect(screen.getByText(/me no speak yaml/)).toBeVisible();
+});
+
+test('YAML editor usable even if the standard one throws', async () => {
+  // Mock the standard editor to force it to throw an error.
+  jest.spyOn(StandardEditorModule, 'StandardEditor').mockImplementation(() => {
+    throw new Error('oh noes, it crashed');
+  });
+  // Ignore the error being reported on the console.
+  jest.spyOn(console, 'error').mockImplementation();
+
+  const onSave = jest.fn();
+  render(<TestRoleEditor onSave={onSave} />);
+  expect(getStandardEditorTab()).toHaveAttribute('aria-selected', 'true');
+  expect(screen.getByText('oh noes, it crashed')).toBeVisible();
+
+  // Expect to still be able to use to the YAML editor.
+  await user.click(getYamlEditorTab());
+  expect(fromFauxYaml(await getTextEditorContents())).toEqual(
+    withDefaults({
+      kind: 'role',
+      metadata: {
+        name: 'new_role_name',
+      },
+      spec: {
+        allow: {},
+        deny: {},
+        options: {},
+      },
+      version: defaultRoleVersion,
+    })
+  );
+  await user.clear(await findTextEditor());
+  await user.type(await findTextEditor(), '{{"modified":1}');
+  await user.click(screen.getByRole('button', { name: 'Create Role' }));
+
+  expect(onSave).toHaveBeenCalledWith({
+    yaml: '{"modified":1}',
+  });
+});
+
+it('YAML editor usable even if the initial conversion throws', async () => {
+  // Mock the role converter to force it to throw an error.
+  jest
+    .spyOn(StandardModelModule, 'roleToRoleEditorModel')
+    .mockImplementation(() => {
+      throw new Error('oh noes, it crashed');
+    });
+  // Ignore the error being reported on the console.
+  jest.spyOn(console, 'error').mockImplementation();
+
+  const originalRole = withDefaults({
+    metadata: {
+      name: 'some-role',
+      revision: 'aa27b7e2-080f-4aba-9f93-c7d168505798',
+    },
+    spec: {
+      allow: { node_labels: { foo: ['bar'] } },
+    },
+  });
+  const originalYaml = toFauxYaml(originalRole);
+  const onSave = jest.fn();
+  render(
+    <TestRoleEditor
+      originalRole={{ object: originalRole, yaml: originalYaml }}
+      onSave={onSave}
+    />
+  );
+  expect(getYamlEditorTab()).toHaveAttribute('aria-selected', 'true');
+
+  expect(fromFauxYaml(await getTextEditorContents())).toEqual(originalRole);
+  await user.clear(await findTextEditor());
+  await user.type(await findTextEditor(), '{{"modified":1}');
+  await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+  expect(onSave).toHaveBeenCalledWith({
+    yaml: '{"modified":1}',
+  });
 });
 
 // Here's a trick: since we can't parse YAML back and forth, we use a

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
@@ -440,6 +440,16 @@ it('YAML editor usable even if the initial conversion throws', async () => {
   expect(onSave).toHaveBeenCalledWith({
     yaml: '{"modified":1}',
   });
+
+  expect(console.error).toHaveBeenCalledTimes(1);
+  expect(console.error).toHaveBeenCalledWith(
+    expect.any(String),
+    expect.any(String),
+    'Could not convert Role to a standard model',
+    expect.objectContaining({
+      message: expect.stringMatching('oh noes, it crashed'),
+    })
+  );
 });
 
 // Here's a trick: since we can't parse YAML back and forth, we use a

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
@@ -365,7 +365,7 @@ test('error while parsing', async () => {
   expect(screen.getByText(/me no speak yaml/)).toBeVisible();
 });
 
-test('YAML editor usable even if the standard one throws', async () => {
+test('YAML editor is usable even if the standard one throws', async () => {
   // Mock the standard editor to force it to throw an error.
   jest.spyOn(StandardEditorModule, 'StandardEditor').mockImplementation(() => {
     throw new Error('oh noes, it crashed');

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useEffect, useId, useState } from 'react';
+import { useCallback, useEffect, useId, useState } from 'react';
 
 import { Alert, Box, Flex } from 'design';
 import { Danger } from 'design/Alert';
@@ -114,17 +114,19 @@ export const RoleEditor = ({
 
   // The standard editor will automatically preview the changes based on state updates
   // but the yaml editor needs to be told when to update (the preview button)
-  const [yamlPreviewAttempt, handleYamlPreview] = useAsync(async () => {
-    if (!onRoleUpdate) {
-      return;
-    }
-    try {
-      const newRole = await yamlModelToRole(yamlModel);
-      onRoleUpdate(newRole);
-    } catch (err) {
-      throw new Error(unableToUpdatePreviewMessage, { cause: err });
-    }
-  });
+  const [yamlPreviewAttempt, handleYamlPreview] = useAsync(
+    useCallback(async () => {
+      if (!onRoleUpdate) {
+        return;
+      }
+      try {
+        const newRole = await yamlModelToRole(yamlModel);
+        onRoleUpdate(newRole);
+      } catch (err) {
+        throw new Error(unableToUpdatePreviewMessage, { cause: err });
+      }
+    }, [onRoleUpdate, yamlModel])
+  );
 
   // Converts standard editor model to a YAML representation.
   const [yamlifyAttempt, yamlifyRole] = useAsync(
@@ -159,7 +161,7 @@ export const RoleEditor = ({
     // attempt to submit the form.
     if (
       standardModel.roleModel !== undefined &&
-      !standardModel.roleModel.requiresReset &&
+      !standardModel.roleModel?.requiresReset &&
       !validator.validate()
     )
       return;

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditorAdapter.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditorAdapter.tsx
@@ -96,12 +96,16 @@ export function RoleEditorAdapter({
         {convertAttempt.status === 'error' && (
           <Danger>{convertAttempt.statusText}</Danger>
         )}
+
+        {/* TODO(bl-nero): Remove once RoleE doesn't set this attribute. */}
         {roleDiffProps?.errorMessage && (
           <Danger>{roleDiffProps.errorMessage}</Danger>
         )}
+
         {convertAttempt.status === 'success' && (
           <RoleEditor
             originalRole={convertAttempt.data}
+            roleDiffAttempt={roleDiffProps?.roleDiffAttempt}
             onCancel={onCancel}
             onSave={onSave}
             onRoleUpdate={onRoleUpdate}

--- a/web/packages/teleport/src/Roles/RoleEditor/Shared.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/Shared.tsx
@@ -91,3 +91,6 @@ export const EditorSaveCancelButton = ({
     </Flex>
   );
 };
+
+export const unableToUpdatePreviewMessage =
+  'Unable to update the role preview. You can still try and save the role anyway.';

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.ts
@@ -54,13 +54,22 @@ import { RoleEditorModelValidationResult } from './validation';
 import { defaultOptions } from './withDefaults';
 
 export type StandardEditorModel = {
-  roleModel: RoleEditorModel;
+  /**
+   * The role model. Can be undefined if there was an unhandled error when
+   * converting an existing role.
+   */
+  roleModel?: RoleEditorModel;
   originalRole: Role;
   /**
    * Will be true if fields have been modified from the original.
    */
   isDirty: boolean;
-  validationResult: RoleEditorModelValidationResult;
+  /**
+   * Result of validating {@link StandardEditorModel.roleModel}. Can be
+   * undefined if there was an unhandled error when converting an existing
+   * role.
+   */
+  validationResult?: RoleEditorModelValidationResult;
 };
 
 /**

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.ts
@@ -92,6 +92,10 @@ export type RoleEditorModel = {
   conversionErrors: ConversionErrorGroup[];
 };
 
+export function requiresReset(rm: RoleEditorModel | undefined): boolean {
+  if (rm === undefined) return false;
+}
+
 export type MetadataModel = {
   name: string;
   description?: string;

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/useStandardModel.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/useStandardModel.ts
@@ -20,6 +20,8 @@ import { current, original } from 'immer';
 import { Dispatch } from 'react';
 import { useImmerReducer } from 'use-immer';
 
+import { Logger } from 'design/logger';
+
 import { Role, RoleVersion } from 'teleport/services/resources';
 
 import {
@@ -38,9 +40,14 @@ import {
 } from './standardmodel';
 import { validateRoleEditorModel } from './validation';
 
+const logger = new Logger('useStandardModel');
+
 /**
  * Creates a standard model state and returns an array composed of the state
- * and an action dispatcher that can be used to change it.
+ * and an action dispatcher that can be used to change it. Since the conversion
+ * is a complex process, we put additional protection against unexpected errors
+ * here: if an error is thrown, the {@link StandardEditorModel.roleModel} and
+ * {@link StandardEditorModel.validationResult} will be set to `undefined`.
  */
 export const useStandardModel = (
   originalRole?: Role
@@ -49,13 +56,25 @@ export const useStandardModel = (
 
 const initializeState = (originalRole?: Role): StandardEditorModel => {
   const role = originalRole ?? newRole();
-  const roleModel = roleToRoleEditorModel(role, role);
+  const roleModel = safelyConvertRoleToEditorModel(role);
   return {
     roleModel,
     originalRole,
     isDirty: !originalRole, // New role is dirty by default.
-    validationResult: validateRoleEditorModel(roleModel, undefined, undefined),
+    validationResult:
+      roleModel && validateRoleEditorModel(roleModel, undefined, undefined),
   };
+};
+
+const safelyConvertRoleToEditorModel = (
+  role: Role
+): RoleEditorModel | undefined => {
+  try {
+    return roleToRoleEditorModel(role, role);
+  } catch (err) {
+    logger.error('Could not convert Role to a standard model', err);
+    return undefined;
+  }
 };
 
 /** A function for dispatching model-changing actions. */

--- a/web/packages/teleport/src/Roles/Roles.test.tsx
+++ b/web/packages/teleport/src/Roles/Roles.test.tsx
@@ -299,9 +299,7 @@ test('renders the role diff component', async () => {
   );
   await openEditor();
   expect(screen.getByText('i am rendered')).toBeInTheDocument();
-  await waitFor(() => {
-    expect(screen.getByText('there is an error here')).toBeInTheDocument();
-  });
+  expect(await screen.findByText('there is an error here')).toBeInTheDocument();
 });
 
 async function openEditor() {

--- a/web/packages/teleport/src/Roles/Roles.test.tsx
+++ b/web/packages/teleport/src/Roles/Roles.test.tsx
@@ -22,7 +22,9 @@ import { fireEvent, render, screen, waitFor } from 'design/utils/testing';
 
 import { ContextProvider } from 'teleport';
 import { createTeleportContext } from 'teleport/mocks/contexts';
+import { yamlService } from 'teleport/services/yaml';
 
+import { withDefaults } from './RoleEditor/StandardEditor/withDefaults';
 import { Roles } from './Roles';
 import { State } from './useRoles';
 
@@ -271,6 +273,9 @@ test('renders the role diff component', async () => {
       list: true,
     },
   });
+  jest.spyOn(yamlService, 'parse').mockImplementation(async () => {
+    return withDefaults({});
+  });
   const roleDiffElement = <div>i am rendered</div>;
 
   render(
@@ -281,7 +286,12 @@ test('renders the role diff component', async () => {
           roleDiffProps={{
             roleDiffElement,
             updateRoleDiff: () => null,
-            errorMessage: 'there is an error here',
+            roleDiffAttempt: {
+              status: 'error',
+              statusText: 'there is an error here',
+              data: null,
+              error: null,
+            },
           }}
         />
       </ContextProvider>
@@ -289,7 +299,9 @@ test('renders the role diff component', async () => {
   );
   await openEditor();
   expect(screen.getByText('i am rendered')).toBeInTheDocument();
-  expect(screen.getByText('there is an error here')).toBeInTheDocument();
+  await waitFor(() => {
+    expect(screen.getByText('there is an error here')).toBeInTheDocument();
+  });
 });
 
 async function openEditor() {

--- a/web/packages/teleport/src/Roles/Roles.tsx
+++ b/web/packages/teleport/src/Roles/Roles.tsx
@@ -28,6 +28,7 @@ import {
   NotificationItem,
   NotificationSeverity,
 } from 'shared/components/Notification';
+import { Attempt } from 'shared/hooks/useAsync';
 
 import { useServerSidePagination } from 'teleport/components/hooks';
 import {
@@ -48,11 +49,22 @@ import { RoleList } from './RoleList';
 import templates from './templates';
 import { State, useRoles } from './useRoles';
 
-// RoleDiffProps are an optional set of props to render the role diff visualizer.
+/** Optional set of props to render the role diff visualizer. */
 type RoleDiffProps = {
   roleDiffElement: React.ReactNode;
   updateRoleDiff: (role: Role) => void;
-  errorMessage: string;
+
+  /** @deprecated Use {@link RoleDiffProps.roleDiffAttempt} instead. */
+  // TODO(bl-nero): Remove this property once the Enterprise code is updated.
+  errorMessage?: string;
+
+  /**
+   * State of the attempt to fetch the information required by the role diff
+   * visualizer. Required to show an error message in the editor UI.
+   */
+  // TODO(bl-nero): Make this property required once the Enterprise code is
+  // updated.
+  roleDiffAttempt?: Attempt<unknown>;
 };
 
 export type RolesProps = {


### PR DESCRIPTION
Enables the user to recover by editing role using YAML in case if an unexpected error happens either in rendering or initial role conversion. Also reorganizes error handling to give users more meaningful messages.

![Screenshot 2025-02-13 at 15 14 22](https://github.com/user-attachments/assets/7b195c73-d07c-4ee5-959e-0907ba4979c3)
![Screenshot 2025-02-13 at 15 13 17](https://github.com/user-attachments/assets/4f8a61b2-1c91-4c2c-8d46-9fc0fd5ad953)
![Screenshot 2025-02-13 at 15 09 42](https://github.com/user-attachments/assets/82eaa0ac-477f-4f00-9f16-2f23bcd8da67)
![Screenshot 2025-02-13 at 15 06 09](https://github.com/user-attachments/assets/bdc2d647-482b-461a-8cdf-4dba9be7fe40)

Followed up by https://github.com/gravitational/teleport.e/pull/6076.

Tested along with https://github.com/gravitational/teleport.e/pull/6076 in the following scenarios:

- Error thrown by `roleToRoleEditorModel()`
- Error thrown while rendering the `StandardEditor` component
- Access graph server unavailable when opening the role editor or in the middle of editing session

In each case, the user can still edit and save the role.