### PR TITLE
chore: Bump OpenSSL to 3.0.16

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -46,9 +46,9 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.11.0 && \
 
 # Install openssl.
 # install_sw install only binaries, skips docs.
-RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.15 && \
+RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.16 && \
     cd openssl && \
-    [ "$(git rev-parse HEAD)" = 'c523121f902fde2929909dc7f76b13ceb4961efe' ] && \
+    [ "$(git rev-parse HEAD)" = 'fa1e5dfb142bb1c26c3c38a10aafa7a095df52e5' ] && \
     ./config --release -fPIC --libdir=/usr/local/lib && \
     make -j"$(nproc)" && \
     make install_sw

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -126,9 +126,9 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.11.0 && \
 # Specific install arguments used to skip docs.
 # Note that FIPS is enabled as part of this build, but it is unused without the
 # necessary configuration (which is included as part of the separate FIPS buildbox).
-RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.15 && \
+RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.16 && \
     cd openssl && \
-    [ "$(git rev-parse HEAD)" = 'c523121f902fde2929909dc7f76b13ceb4961efe' ] && \
+    [ "$(git rev-parse HEAD)" = 'fa1e5dfb142bb1c26c3c38a10aafa7a095df52e5' ] && \
     ./config enable-fips --release -fPIC --libdir=/usr/local/lib64 && \
     make -j"$(nproc)" && \
     make install_sw install_ssldirs install_fips

--- a/build.assets/build-fido2-macos.sh
+++ b/build.assets/build-fido2-macos.sh
@@ -23,8 +23,8 @@ fi
 # Note: versions are the same as the corresponding git tags for each repo.
 readonly CBOR_VERSION=v0.11.0
 readonly CBOR_COMMIT=170bee2b82cdb7b2ed25af301f62cb6efdd40ec1
-readonly CRYPTO_VERSION=openssl-3.0.15
-readonly CRYPTO_COMMIT=c523121f902fde2929909dc7f76b13ceb4961efe
+readonly CRYPTO_VERSION=openssl-3.0.16
+readonly CRYPTO_COMMIT=fa1e5dfb142bb1c26c3c38a10aafa7a095df52e5
 readonly FIDO2_VERSION=1.15.0
 readonly FIDO2_COMMIT=f87c19c9487c0131531314d9ccb475ea5325794e
 

--- a/build.assets/buildbox/pkgconfig/libcrypto-static.pc
+++ b/build.assets/buildbox/pkgconfig/libcrypto-static.pc
@@ -7,6 +7,6 @@ modulesdir=${libdir}/ossl-modules
 
 Name: OpenSSL-libcrypto
 Description: OpenSSL cryptography library
-Version: 3.0.13
+Version: 3.0.16
 Libs: ${libdir}/libcrypto.a -ldl -pthread
 Cflags: -I${includedir}

--- a/build.assets/buildbox/pkgconfig/libfido2-static.pc
+++ b/build.assets/buildbox/pkgconfig/libfido2-static.pc
@@ -6,7 +6,7 @@ includedir=${prefix}/include
 Name: libfido2
 Description: A FIDO2 library
 URL: https://github.com/yubico/libfido2
-Version: 1.14.0
+Version: 1.15.0
 Requires: libcrypto-static
 # libfido2, libcbor and libudev combined here for simplicity.
 Libs: ${libdir}/libfido2.a ${libdir}/libcbor.a ${libdir}/libudev.a -pthread

--- a/build.assets/buildbox/thirdparty-libs.mk
+++ b/build.assets/buildbox/thirdparty-libs.mk
@@ -160,9 +160,9 @@ tp-build-libcbor: fetch-git-libcbor
 # -----------------------------------------------------------------------------
 # openssl
 
-openssl_VERSION = 3.0.15
+openssl_VERSION = 3.0.16
 openssl_GIT_REF = openssl-$(openssl_VERSION)
-openssl_GIT_REF_HASH = c523121f902fde2929909dc7f76b13ceb4961efe
+openssl_GIT_REF_HASH = fa1e5dfb142bb1c26c3c38a10aafa7a095df52e5
 openssl_GIT_REPO = https://github.com/openssl/openssl
 openssl_SRCDIR = $(call tp-src-dir,openssl)
 

--- a/build.assets/pkgconfig/buildbox/usr/local/lib/pkgconfig/libcrypto-static.pc
+++ b/build.assets/pkgconfig/buildbox/usr/local/lib/pkgconfig/libcrypto-static.pc
@@ -7,6 +7,6 @@ modulesdir=${libdir}/ossl-modules
 
 Name: OpenSSL-libcrypto
 Description: OpenSSL cryptography library
-Version: 3.0.15
+Version: 3.0.16
 Libs: ${libdir}/libcrypto.a -ldl -pthread
 Cflags: -I${includedir}

--- a/build.assets/pkgconfig/centos7/usr/local/lib64/pkgconfig/libcrypto-static.pc
+++ b/build.assets/pkgconfig/centos7/usr/local/lib64/pkgconfig/libcrypto-static.pc
@@ -7,6 +7,6 @@ modulesdir=${libdir}/ossl-modules
 
 Name: OpenSSL-libcrypto
 Description: OpenSSL cryptography library
-Version: 3.0.15
+Version: 3.0.16
 Libs: ${libdir}/libcrypto.a -ldl -pthread
 Cflags: -I${includedir}


### PR DESCRIPTION
Update to the latest patch (security release),

* https://github.com/openssl/openssl/releases/tag/openssl-3.0.16

Changelog: Updated OpenSSL to 3.0.16