### PR TITLE
[v15] Allow unused fields used in Debug

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs
@@ -167,6 +167,7 @@ impl TeleportRdpdrBackend {
 }
 
 /// A generic error type for the TeleportRdpdrBackend that can contain any arbitrary error message.
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct TeleportRdpdrBackendError(pub String);
 

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/path.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/path.rs
@@ -139,6 +139,7 @@ fn crop_first_n_letters(s: &mut String, n: usize) {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct PathError(pub String);
 

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/tdp.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/tdp.rs
@@ -700,6 +700,7 @@ pub(crate) fn to_windows_time(tdp_time_ms: u64) -> i64 {
 /// A generic error type that can contain any arbitrary error message.
 ///
 /// TODO: This is a temporary solution until we can figure out a better error handling system.
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct TdpHandlingError(pub String);
 


### PR DESCRIPTION
This fixes build in v15 broken in https://github.com/gravitational/teleport/pull/52010 - linter got more strict so we have to allow unused fields that are only used in derived `Debug`