### PR TITLE
Fix SemaphoreLock context.Context implementation

### DIFF
--- a/lib/services/semaphore.go
+++ b/lib/services/semaphore.go
@@ -100,11 +100,11 @@ func (l *SemaphoreLockConfig) CheckAndSetDefaults() error {
 //	 defer cancel()
 //	 ... do work with newCtx ...
 type SemaphoreLock struct {
-	// ctx is the parent context for the lease keepalive operation.
+	// Context is the parent context for the lease keepalive operation.
 	// it's used to propagate deadline cancellations from the parent
 	// context and to carry values for the context interface.
-	ctx       context.Context
-	cancelCtx context.CancelFunc
+	context.Context
+	cancelCtx context.CancelCauseFunc
 	cfg       SemaphoreLockConfig
 	lease0    types.SemaphoreLease
 	retry     retryutils.Retry
@@ -128,31 +128,6 @@ func (l *SemaphoreLock) finish(err error) {
 	l.cond.Broadcast()
 }
 
-// Done signals that lease keepalive operations
-// have stopped.
-// If the parent context is canceled, the lease
-// will be released and done will be closed.
-func (l *SemaphoreLock) Done() <-chan struct{} {
-	return l.ctx.Done()
-}
-
-// Deadline returns the deadline of the parent context if it exists.
-func (l *SemaphoreLock) Deadline() (time.Time, bool) {
-	return l.ctx.Deadline()
-}
-
-// Value returns the value associated with the key in the parent context.
-func (l *SemaphoreLock) Value(key interface{}) interface{} {
-	return l.ctx.Value(key)
-}
-
-// Error returns the final error value.
-func (l *SemaphoreLock) Err() error {
-	l.cond.L.Lock()
-	defer l.cond.L.Unlock()
-	return l.err
-}
-
 // Wait blocks until the final result is available.  Note that
 // this method may block longer than desired since cancellation of
 // the parent context triggers the *start* of the release operation.
@@ -169,7 +144,7 @@ func (l *SemaphoreLock) Wait() error {
 func (l *SemaphoreLock) Stop() {
 	l.closeOnce.Do(func() {
 		l.ticker.Stop()
-		l.cancelCtx()
+		l.cancelCtx(nil)
 	})
 }
 
@@ -179,12 +154,12 @@ func (l *SemaphoreLock) Renewed() <-chan struct{} {
 	return l.renewalC
 }
 
-func (l *SemaphoreLock) keepAlive(ctx context.Context) {
+func (l *SemaphoreLock) keepAlive() {
 	var nodrop bool
 	var err error
 	lease := l.lease0
 	defer func() {
-		l.cancelCtx()
+		l.cancelCtx(err)
 		l.Stop()
 		defer l.finish(err)
 		if nodrop {
@@ -217,7 +192,7 @@ Outer:
 	for {
 		select {
 		case tick := <-l.ticker.Chan():
-			leaseContext, leaseCancel := context.WithDeadline(ctx, lease.Expires)
+			leaseContext, leaseCancel := context.WithDeadline(l.Context, lease.Expires)
 			nextLease := lease
 			nextLease.Expires = tick.Add(l.cfg.Expiry)
 			for {
@@ -268,8 +243,6 @@ Outer:
 					return
 				}
 			}
-		case <-ctx.Done():
-			return
 		case <-l.Done():
 			return
 		}
@@ -323,9 +296,9 @@ func AcquireSemaphoreLock(ctx context.Context, cfg SemaphoreLockConfig) (*Semaph
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancelCause(ctx)
 	lock := &SemaphoreLock{
-		ctx:       ctx,
+		Context:   ctx,
 		cancelCtx: cancel,
 		cfg:       cfg,
 		lease0:    *lease,
@@ -334,7 +307,7 @@ func AcquireSemaphoreLock(ctx context.Context, cfg SemaphoreLockConfig) (*Semaph
 		renewalC:  make(chan struct{}),
 		cond:      sync.NewCond(&sync.Mutex{}),
 	}
-	go lock.keepAlive(ctx)
+	go lock.keepAlive()
 	return lock, nil
 }
 


### PR DESCRIPTION
This updates `SempahoreLock` to embed its context.Context and use WithCancelCause for its cancellation func, so that it properly implements the context.Context interface.
Specifically, the Err() method of a context.Context must not return a nil error if its Done channel has closed.

Fixes a panic that occurs if `context.WithCancel(lease)` is called after the lease context is done.
See: https://github.com/gravitational/teleport/actions/runs/13255328689/job/37001102495?pr=52023
```
{"timestamp":"2025-02-11T03:41:14Z","level":"debug","caller":"retryutils/retry.go:193","message":"Waiting to retry operation again","wait":826308778,"error":"cannot acquire semaphore user_task/deb47f2c-cfef-5b4d-bd50-15ed83d48e2d (err-max-leases)"}
{"timestamp":"2025-02-11T03:41:14Z","level":"warning","caller":"discovery/status.go:729","message":"Failed to create discover eks user task","component":"discovery:service","integration":"my-integration","issue_type":"eks-cluster-unreachable","aws_account_id":"123456789012","aws_region":"us-west-2","error":"context canceled"}
panic: context: internal error: missing cancel error

goroutine 6143 [running]:
context.(*cancelCtx).cancel(0xc002523b80, 0x0, {0x0, 0x0}, {0x1213ba00, 0x17048650})
	/opt/go/src/context/context.go:538 +0x346
context.(*cancelCtx).propagateCancel(0xc002523b80, {0x122031b8, 0xc007504d80}, {0x12174528, 0xc002523b80})
	/opt/go/src/context/context.go:473 +0x2c5
context.withCancel(...)
	/opt/go/src/context/context.go:273
context.WithCancel({0x122031b8, 0xc007504d80})
	/opt/go/src/context/context.go:236 +0xb1
github.com/gravitational/teleport/lib/srv/discovery.(*Server).acquireSemaphoreForUserTask(0xc008072708, {0xc008697a70, 0x24})
	/__w/teleport/teleport/lib/srv/discovery/status.go:609 +0x44c
github.com/gravitational/teleport/lib/srv/discovery.(*Server).mergeUpsertDiscoverEKSTask(0xc008072708, {{0xc00780cee2, 0xe}, {0x11226b9b, 0x17}, {0x113092c9, 0xc}, {0x113092bf, 0x9}, 0x0}, ...)
	/__w/teleport/teleport/lib/srv/discovery/status.go:760 +0x285
github.com/gravitational/teleport/lib/srv/discovery.(*Server).upsertTasksForAWSEKSFailedEnrollments(0xc008072708)
	/__w/teleport/teleport/lib/srv/discovery/status.go:728 +0x2bd
github.com/gravitational/teleport/lib/srv/discovery.(*Server).enrollEKSClusters(0xc008072708, {0x113092bf, 0x9}, {0xc00780cee2, 0xe}, {0xc004e12d80, 0x24}, {0xc000c98240, 0x2, 0x2}, ...)
	/__w/teleport/teleport/lib/srv/discovery/kube_integration_watcher.go:318 +0x1ae6
created by github.com/gravitational/teleport/lib/srv/discovery.(*Server).startKubeIntegrationWatchers.func2 in goroutine 5320
	/__w/teleport/teleport/lib/srv/discovery/kube_integration_watcher.go:185 +0x154e
```