### PR TITLE
Force install corepack on Windows

### DIFF
--- a/build.assets/windows/build.ps1
+++ b/build.assets/windows/build.ps1
@@ -147,6 +147,8 @@ function Install-Node {
         # --force is needed because binaries distributed with Node.js and
         # binaries installed globally through npm are put in the same dir.
         # As such, corepack tries to add the yarn binary which already exists.
+        # TODO(ravicious): Remove usage of $NpmGlobalBin below when removing
+        # manual installation of corepack.
         npm install -g corepack@0.31.0 --force
         corepack enable pnpm
         Write-Host "::endgroup::"
@@ -164,7 +166,8 @@ function Enable-Node {
         [string] $ToolchainDir
     )
     begin {
-        $Env:Path = "$ToolchainDir/node;$Env:Path"
+        $NpmGlobalBin = npm -g bin
+        $Env:Path = "$NpmGlobalBin;$ToolchainDir/node;$Env:Path"
     }
 }
 

--- a/build.assets/windows/build.ps1
+++ b/build.assets/windows/build.ps1
@@ -144,7 +144,10 @@ function Install-Node {
         Expand-Archive -Path $NodeZipfile -DestinationPath $ToolchainDir
         Rename-Item -Path "$ToolchainDir/node-v$NodeVersion-win-x64" -NewName "$ToolchainDir/node"
         Enable-Node -ToolchainDir $ToolchainDir
-        npm install -g corepack@0.31.0
+        # --force is needed because binaries distributed with Node.js and
+        # binaries installed globally through npm are put in the same dir.
+        # As such, corepack tries to add the yarn binary which already exists.
+        npm install -g corepack@0.31.0 --force
         corepack enable pnpm
         Write-Host "::endgroup::"
     }


### PR DESCRIPTION
Because of how we set up Node.js on Windows, binaries distributed with Node.js (such as yarn) and binaries later installed through `npm install -g` seem to be put in the same folder.

corepack seems to add a shim for yarn during installation (https://github.com/nodejs/corepack/issues/6#issuecomment-701608777). Since the yarn binary already exists, `npm install -g corepack@0.31.0` fails.

Since manually installing corepack is a short-term fix, we can use `--force` to let `npm install -g corepack@0.31.0` override the existing yarn binary.

Build tag to test this:

* ~https://github.com/gravitational/teleport.e/actions/runs/13282751524/job/37084589914~
   * Failed, likely because `npm -g bin` is not in Path.
* https://github.com/gravitational/teleport.e/actions/runs/13283304693/job/37086300069
---

npm now outputs this when installing corepack on Windows:

>   npm warn using --force Recommended protections disabled.

I suspect the only "protections" it means are protections from overriding already existing binaries. [The docs](https://docs.npmjs.com/cli/v8/commands/npm-install) don't say much about `--force`:

> The -f or --force argument will force npm to fetch remote resources even if a local copy exists on disk.