### PR TITLE
[v17] Bump electron from 33.2.1 to 34.1.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -470,8 +470,8 @@ importers:
         specifier: ^5.5.0
         version: 5.5.0
       electron:
-        specifier: 33.2.1
-        version: 33.2.1
+        specifier: 34.1.1
+        version: 34.1.1
       electron-builder:
         specifier: ^25.1.8
         version: 25.1.8(electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8))
@@ -3857,8 +3857,8 @@ packages:
       '@swc/core':
         optional: true
 
-  electron@33.2.1:
-    resolution: {integrity: sha512-SG/nmSsK9Qg1p6wAW+ZfqU+AV8cmXMTIklUL18NnOKfZLlum4ZsDoVdmmmlL39ZmeCaq27dr7CgslRPahfoVJg==}
+  electron@34.1.1:
+    resolution: {integrity: sha512-1aDYk9Gsv1/fFeClMrxWGoVMl7uCUgl1pe26BiTnLXmAoqEXCa3f3sCKFWV+cuDzUjQGAZcpkWhGYTgWUSQrLA==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
@@ -11118,7 +11118,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@33.2.1:
+  electron@34.1.1:
     dependencies:
       '@electron/get': 2.0.2
       '@types/node': 20.16.10

--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -45,7 +45,7 @@
     "@types/whatwg-url": "^11.0.5",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
-    "electron": "33.2.1",
+    "electron": "34.1.1",
     "electron-builder": "^25.1.8",
     "electron-vite": "^2.3.0",
     "events": "3.3.0",


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/51906 to branch/v17