### PR TITLE
[v15] Bump electron from 33.2.1 to 34.1.1

### DIFF
--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -45,7 +45,7 @@
     "@types/node-forge": "^1.0.4",
     "@types/tar-fs": "^2.0.1",
     "@types/whatwg-url": "^11.0.1",
-    "electron": "33.2.1",
+    "electron": "34.1.1",
     "electron-vite": "^2.0.0",
     "google-protobuf": "^3.21.2",
     "immer": "^10.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7507,10 +7507,10 @@ electron-vite@^2.0.0:
     magic-string "^0.30.5"
     picocolors "^1.0.0"
 
-electron@33.2.1:
-  version "33.2.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-33.2.1.tgz#d0d7bba7a7abf4f14881d0a6e03c498b301a2d5f"
-  integrity sha512-SG/nmSsK9Qg1p6wAW+ZfqU+AV8cmXMTIklUL18NnOKfZLlum4ZsDoVdmmmlL39ZmeCaq27dr7CgslRPahfoVJg==
+electron@34.1.1:
+  version "34.1.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-34.1.1.tgz#1fc766e406401834fedb9747c4ca58671d9a1e46"
+  integrity sha512-1aDYk9Gsv1/fFeClMrxWGoVMl7uCUgl1pe26BiTnLXmAoqEXCa3f3sCKFWV+cuDzUjQGAZcpkWhGYTgWUSQrLA==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^20.9.0"


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/51906 to branch/v15