### PR TITLE
Hardcode corepack integrity keys on Windows

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -8,7 +8,8 @@ GOLANGCI_LINT_VERSION ?= v1.63.4
 
 # NOTE: Remember to update engines.node in package.json to match the major version.
 # TODO(ravicious): When updating Node.js, see if corepack distributed with the new Node.JS version
-# is >= 0.31.0. If so, remove manual calls to install corepack@0.31.0 from CI scripts.
+# is >= 0.31.0. If so, remove manual calls to install corepack@0.31.0 from CI scripts and
+# COREPACK_INTEGRITY_KEYS env var from windows/build.ps1.
 NODE_VERSION ?= 20.18.0
 
 # Run lint-rust check locally before merging code after you bump this.

--- a/build.assets/windows/build.ps1
+++ b/build.assets/windows/build.ps1
@@ -144,7 +144,7 @@ function Install-Node {
         Expand-Archive -Path $NodeZipfile -DestinationPath $ToolchainDir
         Rename-Item -Path "$ToolchainDir/node-v$NodeVersion-win-x64" -NewName "$ToolchainDir/node"
         Enable-Node -ToolchainDir $ToolchainDir
-        npm install -g corepack@0.31.0
+        $Env:COREPACK_INTEGRITY_KEYS = '{"npm":[{"expires":"2025-01-29T00:00:00.000Z","keyid":"SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA","keytype":"ecdsa-sha2-nistp256","scheme":"ecdsa-sha2-nistp256","key":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1Olb3zMAFFxXKHiIkQO5cJ3Yhl5i6UPp+IhuteBJbuHcA5UogKo0EWtlWwW6KSaKoTNEYL7JlCQiVnkhBktUgg=="},{"expires":null,"keyid":"SHA256:DhQ8wR5APBvFHLF/+Tc+AYvPOdTpcIDqOhxsBHRwC7U","keytype":"ecdsa-sha2-nistp256","scheme":"ecdsa-sha2-nistp256","key":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEY6Ya7W++7aUPzvMTrezH6Ycx3c+HOKYCcNGybJZSCJq/fd7Qa8uuAKtdIkUQtQiEKERhAmE5lMMJhP8OkDOa2g=="}]}'
         corepack enable pnpm
         Write-Host "::endgroup::"
     }


### PR DESCRIPTION
This reverts the Windows part of #51819.

After #51819, Windows tag builds started silently failing because `npm install -g corepack@0.31.0` was trying to overwrite the existing `yarn` binary. After tinkering with Node.js setup on Windows a little bit (#52050), I couldn't get it to actually use the new corepack binary. As debugging this is hard without shelling into the actual Windows machine, we're reverting to the previous solution of hardcoding corepack integrity keys from #51761.

Successful Windows tag build to verify the fix: https://github.com/gravitational/teleport.e/actions/runs/13283873863/job/37088137811#step:6:365