### PR TITLE
Adjust fonts and symbols on Windows

### DIFF
--- a/web/packages/teleterm/src/ui/StatusBar/StatusBar.tsx
+++ b/web/packages/teleterm/src/ui/StatusBar/StatusBar.tsx
@@ -19,6 +19,7 @@
 import { Fragment } from 'react';
 
 import { Flex, Text } from 'design';
+import { ChevronRight } from 'design/Icon';
 
 import { AccessRequestCheckoutButton } from './AccessRequestCheckoutButton';
 import { ShareFeedback } from './ShareFeedback';
@@ -69,7 +70,8 @@ export function StatusBar() {
                 )}
                 <Text>{breadcrumb.name}</Text>
                 {index !== breadcrumbs.length - 1 && (
-                  <Text color="text.disabled">→</Text>
+                  // Size 'small' is too large here.
+                  <ChevronRight size={13} color="text.muted" />
                 )}
               </Fragment>
             ))}

--- a/web/packages/teleterm/src/ui/TopBar/Identity/IdentityList/IdentityListItem.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Identity/IdentityList/IdentityListItem.tsx
@@ -146,7 +146,7 @@ export function TitleAndSubtitle(props: { title: string; subtitle?: string }) {
         typography="body2"
         fontWeight="400"
         css={`
-          line-height: 1.25;
+          line-height: 1.3;
         `}
       >
         {props.title}
@@ -156,7 +156,7 @@ export function TitleAndSubtitle(props: { title: string; subtitle?: string }) {
         <P3
           color="text.slightlyMuted"
           css={`
-            line-height: 1.25;
+            line-height: 1.3;
           `}
         >
           {props.subtitle}

--- a/web/packages/teleterm/src/ui/components/ProfileStatusError.tsx
+++ b/web/packages/teleterm/src/ui/components/ProfileStatusError.tsx
@@ -30,7 +30,7 @@ export function ProfileStatusError(props: {
         color="text.slightlyMuted"
         css={`
           text-wrap: auto;
-          line-height: 1.25;
+          line-height: 1.3;
         `}
       >
         {toWellFormattedConnectionError(props.error)}


### PR DESCRIPTION
While testing the app on Windows, I noticed that text in the profile switcher is slightly clipped, it's because too low `line-height`. I increased it a bit.

I also replaced the right arrow symbol with an icon, this makes it look the same on all OSes.
Before:
<img width="297" alt="image" src="https://github.com/user-attachments/assets/073a16e0-bf7f-47d5-890f-079f98aca3ae" />

Afer:
<img width="297" alt="image" src="https://github.com/user-attachments/assets/022db3cf-83ae-4624-84b0-221f91fd1e46" />

