### PR TITLE
chore: Bump golangci-lint to v1.64.2

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -4,7 +4,7 @@
 
 # Sync with devbox.json.
 GOLANG_VERSION ?= go1.23.6
-GOLANGCI_LINT_VERSION ?= v1.63.4
+GOLANGCI_LINT_VERSION ?= v1.64.2
 
 # NOTE: Remember to update engines.node in package.json to match the major version.
 # TODO(ravicious): When updating Node.js, see if corepack distributed with the new Node.JS version


### PR DESCRIPTION
Update to the latest release. (Yes, it did jump straight from v1.63.4 to v1.64.2.)

* https://github.com/golangci/golangci-lint/releases/tag/v1.64.2