### PR TITLE
chore: Bump Go toolchain to 1.24.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -403,6 +403,6 @@ linters-settings:
         msg: 'Use stsutils.NewV1'
 
 run:
-  go: '1.23'
+  go: '1.24'
   build-tags: []
   timeout: 15m

--- a/build.assets/Dockerfile-grpcbox
+++ b/build.assets/Dockerfile-grpcbox
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/golang:1.23
+FROM docker.io/golang:1.24
 
 # Image layers go from less likely to most likely to change.
 RUN apt-get update && \

--- a/build.assets/tooling/go.mod
+++ b/build.assets/tooling/go.mod
@@ -2,6 +2,8 @@ module github.com/gravitational/teleport/build.assets/tooling
 
 go 1.23.6
 
+toolchain go1.24.0
+
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/alecthomas/kingpin/v2 v2.4.0 // replaced

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -3,7 +3,7 @@
 # Keep versions in sync with devbox.json, when applicable.
 
 # Sync with devbox.json.
-GOLANG_VERSION ?= go1.23.6
+GOLANG_VERSION ?= go1.24.0
 GOLANGCI_LINT_VERSION ?= v1.64.2
 
 # NOTE: Remember to update engines.node in package.json to match the major version.

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/gravitational/teleport
 
 go 1.23.6
 
+toolchain go1.24.0
+
 require (
 	cloud.google.com/go/cloudsqlconn v1.14.2
 	cloud.google.com/go/compute v1.32.0

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -2,6 +2,8 @@ module github.com/gravitational/teleport/integrations/event-handler
 
 go 1.23.6
 
+toolchain go1.24.0
+
 require (
 	github.com/alecthomas/kong v1.7.0
 	github.com/google/uuid v1.6.0

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -2,6 +2,8 @@ module github.com/gravitational/teleport/integrations/terraform
 
 go 1.23.6
 
+toolchain go1.24.0
+
 // Doc generation tooling
 require github.com/hashicorp/terraform-plugin-docs v0.0.0 // replaced
 


### PR DESCRIPTION
Update the Go toolchain to run using the latest major.

* https://go.dev/doc/go1.24

Changelog: Updated Go to 1.24.0