### PR TITLE
Don't rely on SKID and AKID for IsSelfSigned

### DIFF
--- a/lib/utils/certs.go
+++ b/lib/utils/certs.go
@@ -177,25 +177,15 @@ func VerifyCertificateChain(certificateChain []*x509.Certificate) error {
 	return nil
 }
 
-// IsSelfSigned checks if the certificate is a self-signed certificate. To
-// check if a certificate is self-signed, we make sure that only one
-// certificate is in the chain and that the SubjectKeyId and AuthorityKeyId
-// match.
-//
-// From RFC5280: https://tools.ietf.org/html/rfc5280#section-4.2.1.1
-//
-//	The signature on a self-signed certificate is generated with the private
-//	key associated with the certificate's subject public key. (This
-//	proves that the issuer possesses both the public and private keys.)
-//	In this case, the subject and authority key identifiers would be
-//	identical, but only the subject key identifier is needed for
-//	certification path building.
+// IsSelfSigned checks if the certificate is a self-signed certificate. To check
+// if a certificate is self-signed, we make sure that only one certificate is in
+// the chain and that its Subject and Issuer match.
 func IsSelfSigned(certificateChain []*x509.Certificate) bool {
 	if len(certificateChain) != 1 {
 		return false
 	}
 
-	return bytes.Equal(certificateChain[0].SubjectKeyId, certificateChain[0].AuthorityKeyId)
+	return bytes.Equal(certificateChain[0].RawSubject, certificateChain[0].RawIssuer)
 }
 
 // ReadCertificates parses PEM encoded bytes that can contain one or


### PR DESCRIPTION
The `authorityKeyIdentifier` extension is only listed as a MUST for non-self-signed X.509v3 certificates that are part of the "Internet X.509 Public Key Infrastructure" (as per [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280)); the only necessary and sufficient condition for an X.509 certificate to be self-signed is that the subject and issuer of the certificate are equal, and it's not necessary to check for keys or signatures or to consult extensions that are only there to help build certificate chains at verification time. Notably, self-signed certificates made by Go's `x509.CreateCertificate`, unless you go out of your way to explicitly include it, will omit the AKID extension.

[Citing Filippo Valsorda](https://github.com/golang/go/issues/62060#issuecomment-1681436651):
> If you make a certificate with Issuer equal to Subject but signed by a different public key, it's just a self-signed certificate with a broken signature, it doesn't stop being a self-signed certificate.