### PR TITLE
Unhide commands pertaining to new workload identity config mechanism

### DIFF
--- a/lib/tbot/cli/start_workload_identity_api.go
+++ b/lib/tbot/cli/start_workload_identity_api.go
@@ -48,7 +48,6 @@ type WorkloadIdentityAPICommand struct {
 // `workload-identity-api` service and returns a struct that will contain the
 // parse result.
 func NewWorkloadIdentityAPICommand(parentCmd *kingpin.CmdClause, action MutatorAction, mode CommandMode) *WorkloadIdentityAPICommand {
-	// TODO(noah): Unhide this command when feature flag removed
 	cmd := parentCmd.Command(
 		"workload-identity-api",
 		fmt.Sprintf("%s tbot with a workload identity API listener. Compatible with the SPIFFE Workload API and Envoy SDS.", mode),

--- a/lib/tbot/cli/start_workload_identity_jwt.go
+++ b/lib/tbot/cli/start_workload_identity_jwt.go
@@ -49,7 +49,6 @@ type WorkloadIdentityJWTCommand struct {
 // `workload-identity-jwt` output and returns a struct that will contain the parse
 // result.
 func NewWorkloadIdentityJWTCommand(parentCmd *kingpin.CmdClause, action MutatorAction, mode CommandMode) *WorkloadIdentityJWTCommand {
-	// TODO(noah): Unhide this command when feature flag removed
 	cmd := parentCmd.Command("workload-identity-jwt", fmt.Sprintf("%s tbot with a SPIFFE-compatible JWT SVID output.", mode))
 
 	c := &WorkloadIdentityJWTCommand{}

--- a/lib/tbot/cli/start_workload_identity_x509.go
+++ b/lib/tbot/cli/start_workload_identity_x509.go
@@ -47,7 +47,6 @@ type WorkloadIdentityX509Command struct {
 // `workload-identity-x509` output and returns a struct that will contain the parse
 // result.
 func NewWorkloadIdentityX509Command(parentCmd *kingpin.CmdClause, action MutatorAction, mode CommandMode) *WorkloadIdentityX509Command {
-	// TODO(noah): Unhide this command when feature flag removed
 	cmd := parentCmd.Command("workload-identity-x509", fmt.Sprintf("%s tbot with a SPIFFE-compatible SVID output.", mode))
 
 	c := &WorkloadIdentityX509Command{}

--- a/tool/tctl/common/workload_identity_command.go
+++ b/tool/tctl/common/workload_identity_command.go
@@ -51,11 +51,10 @@ type WorkloadIdentityCommand struct {
 func (c *WorkloadIdentityCommand) Initialize(
 	app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags, _ *servicecfg.Config,
 ) {
-	// TODO(noah): Remove the hidden flag once base functionality is released.
 	cmd := app.Command(
 		"workload-identity",
 		"Manage Teleport Workload Identity.",
-	).Hidden()
+	)
 
 	c.listCmd = cmd.Command(
 		"ls",


### PR DESCRIPTION
These commands were intended to be hidden until we removed the feature flag, as that has been done, these commands can now be unhidden.