### PR TITLE
Deprecate old Workload Identity UX

### DIFF
--- a/lib/auth/machineid/machineidv1/workload_identity_service.go
+++ b/lib/auth/machineid/machineidv1/workload_identity_service.go
@@ -536,7 +536,7 @@ func (wis *WorkloadIdentityService) SignJWTSVIDs(
 
 	wis.logger.WarnContext(
 		ctx,
-		"The 'SignX509SVIDs' RPC has been invoked. This RPC is deprecated and will be removed in Teleport V19.0.0. See https://goteleport.com/docs/reference/workload-identity/configuration-resource-migration/ for further information.",
+		"The 'SignJWTSVIDs' RPC has been invoked. This RPC is deprecated and will be removed in Teleport V19.0.0. See https://goteleport.com/docs/reference/workload-identity/configuration-resource-migration/ for further information.",
 	)
 
 	return res, nil

--- a/lib/auth/machineid/machineidv1/workload_identity_service.go
+++ b/lib/auth/machineid/machineidv1/workload_identity_service.go
@@ -370,6 +370,11 @@ func (wis *WorkloadIdentityService) SignX509SVIDs(ctx context.Context, req *pb.S
 		res.Svids = append(res.Svids, svidRes)
 	}
 
+	wis.logger.WarnContext(
+		ctx,
+		"The 'SignX509SVIDs' RPC has been invoked. This RPC is deprecated and will be removed in Teleport V19.0.0. See https://goteleport.com/docs/reference/workload-identity/configuration-resource-migration/ for further information.",
+	)
+
 	return res, nil
 }
 
@@ -528,6 +533,11 @@ func (wis *WorkloadIdentityService) SignJWTSVIDs(
 		}
 		res.Svids = append(res.Svids, svidRes)
 	}
+
+	wis.logger.WarnContext(
+		ctx,
+		"The 'SignX509SVIDs' RPC has been invoked. This RPC is deprecated and will be removed in Teleport V19.0.0. See https://goteleport.com/docs/reference/workload-identity/configuration-resource-migration/ for further information.",
+	)
 
 	return res, nil
 }

--- a/lib/tbot/cli/start_spiffe_svid.go
+++ b/lib/tbot/cli/start_spiffe_svid.go
@@ -47,7 +47,7 @@ type SPIFFESVIDCommand struct {
 // `spiffe-svid` output and returns a struct that will contain the parse
 // result.
 func NewSPIFFESVIDCommand(parentCmd *kingpin.CmdClause, action MutatorAction, mode CommandMode) *SPIFFESVIDCommand {
-	cmd := parentCmd.Command("spiffe-svid", fmt.Sprintf("%s tbot with a SPIFFE-compatible SVID output.", mode))
+	cmd := parentCmd.Command("spiffe-svid", fmt.Sprintf("%s tbot with a SPIFFE-compatible SVID output.", mode)).Hidden()
 
 	c := &SPIFFESVIDCommand{}
 	c.sharedStartArgs = newSharedStartArgs(cmd)

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -309,6 +309,10 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 		// Convert the service config into the actual service type.
 		switch svcCfg := svcCfg.(type) {
 		case *config.SPIFFEWorkloadAPIService:
+			b.log.WarnContext(
+				ctx,
+				"The 'spiffe-workload-api' service is deprecated and will be removed in Teleport V19.0.0. See https://goteleport.com/docs/reference/workload-identity/configuration-resource-migration/ for further information.",
+			)
 			clientCredential := &config.UnstableClientCredentialOutput{}
 			svcIdentity := &ClientCredentialOutputService{
 				botAuthClient:     b.botIdentitySvc.GetClient(),
@@ -403,6 +407,10 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 			)
 			services = append(services, svc)
 		case *config.SPIFFESVIDOutput:
+			b.log.WarnContext(
+				ctx,
+				"The 'spiffe-svid' service is deprecated and will be removed in Teleport V19.0.0. See https://goteleport.com/docs/reference/workload-identity/configuration-resource-migration/ for further information.",
+			)
 			svc := &SPIFFESVIDOutputService{
 				botAuthClient:  b.botIdentitySvc.GetClient(),
 				botCfg:         b.cfg,

--- a/tool/tsh/common/workload_identity.go
+++ b/tool/tsh/common/workload_identity.go
@@ -286,6 +286,11 @@ func newSVIDIssueCommand(parent *kingpin.CmdClause) *svidIssueCommand {
 }
 
 func (c *svidIssueCommand) run(cf *CLIConf) error {
+	logger.WarnContext(
+		cf.Context,
+		"The 'tsh svid issue' command is deprecated and will be removed in Teleport V19.0.0. See https://goteleport.com/docs/reference/workload-identity/configuration-resource-migration/ for further information.",
+	)
+
 	ctx := cf.Context
 	// Validate flags
 	if c.svidType != svidTypeX509 {

--- a/tool/tsh/common/workload_identity.go
+++ b/tool/tsh/common/workload_identity.go
@@ -235,7 +235,7 @@ type svidCommands struct {
 }
 
 func newSVIDCommands(app *kingpin.Application) svidCommands {
-	cmd := app.Command("svid", "Manage Teleport Workload Identity SVIDs.")
+	cmd := app.Command("svid", "Manage Teleport Workload Identity SVIDs.").Hidden()
 	cmds := svidCommands{
 		issue: newSVIDIssueCommand(cmd),
 	}


### PR DESCRIPTION
Adds deprecation warnings in v18 to commands, configuration options and RPCs ahead of the removal of these in V19.