### PR TITLE
[v15] chore: Bump golangci-lint to v1.64.2

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -4,7 +4,7 @@
 
 # Sync with devbox.json.
 GOLANG_VERSION ?= go1.22.12
-GOLANGCI_LINT_VERSION ?= v1.63.4
+GOLANGCI_LINT_VERSION ?= v1.64.2
 
 NODE_VERSION ?= 20.18.0
 


### PR DESCRIPTION
Backport #52061 to branch/v15.