### PR TITLE
[v15] chore: Bump Go to 1.23.6

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -166,6 +166,6 @@ linters-settings:
         msg: 'Use stsutils.NewV1'
 
 run:
-  go: '1.22'
+  go: '1.23'
   build-tags: []
   timeout: 15m

--- a/build.assets/Dockerfile-grpcbox
+++ b/build.assets/Dockerfile-grpcbox
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/golang:1.23
+FROM docker.io/golang:1.23.6
 
 # Image layers go from less likely to most likely to change.
 RUN apt-get update && \

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -3,7 +3,7 @@
 # Keep versions in sync with devbox.json, when applicable.
 
 # Sync with devbox.json.
-GOLANG_VERSION ?= go1.22.12
+GOLANG_VERSION ?= go1.23.6
 GOLANGCI_LINT_VERSION ?= v1.64.2
 
 NODE_VERSION ?= 20.18.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport
 
-go 1.22.12
+go 1.23.6
 
 require (
 	cloud.google.com/go/cloudsqlconn v1.9.0

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/event-handler
 
-go 1.22.12
+go 1.23.6
 
 require (
 	github.com/alecthomas/kong v0.9.0

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/terraform
 
-go 1.22.12
+go 1.23.6
 
 require (
 	github.com/gogo/protobuf v1.3.2


### PR DESCRIPTION
Go 1.22 has now reached end-of-life, so we are updating to 1.23 (which is already battle-tested by v17).

This is not technically a backport, although it's somewhat close in spirit to #46299.

Changelog: Updated Go to 1.23.6