### PR TITLE
Update ListResources to use ListUnifiedResources instead

### DIFF
--- a/lib/services/unified_resource.go
+++ b/lib/services/unified_resource.go
@@ -193,12 +193,11 @@ func (c *UnifiedResourceCache) deleteLocked(res types.Resource) error {
 
 func (c *UnifiedResourceCache) getSortTree(sortField string) (*btree.BTreeG[*item], error) {
 	switch sortField {
-	case sortByName:
+	// if no sort field is present, default to name sortTree
+	case sortByName, "":
 		return c.nameTree, nil
 	case sortByKind:
 		return c.typeTree, nil
-	case "":
-		return nil, trace.BadParameter("sort field is required")
 	default:
 		return nil, trace.NotImplemented("sorting by %v is not supported in unified resources", sortField)
 	}


### PR DESCRIPTION
This is the start of migrating `ListResources` to defer to the Unified Resource Cache instead

a couple issues so far.
- ListResources response expects `ResourceWithLabel` but ListUnifiedResources returns `PaginatedResource`. this can probably just be manipulated around

ListResources returns a "total count" that we dont return anymore in ListUnifiedResourcesResponse but this should be ok because we dont use that field anymore

I only hacked together the Node type but received a successful test in TestGetAndList_Node 