### PR TITLE
[v16] Ignore SIGQUIT in networking subprocesses

### DIFF
--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -696,6 +696,12 @@ func handleRemotePortForward(ctx context.Context, addr string, file *os.File) er
 // runForward reads in the command to run from the parent process (over a
 // pipe) then port forwards.
 func runForward(handler forwardHandler) (errw io.Writer, code int, err error) {
+	// SIGQUIT is used by teleport to initiate graceful shutdown, waiting for
+	// existing exec sessions to close before ending the process. For this to
+	// work when closing the entire teleport process group, exec sessions must
+	// ignore SIGQUIT signals.
+	signal.Ignore(syscall.SIGQUIT)
+
 	// errorWriter is used to return any error message back to the client.
 	// Use stderr so that it's not forwarded to the remote client.
 	errorWriter := os.Stderr


### PR DESCRIPTION
This is morally a backport of #47515 to branch/v16, applying to the `teleport forwardv2` subcommand rather than the newer (v17+) `teleport networking`. 

Changelog: Fix graceful closing of networking subprocesses when the Teleport parent process is gracefully closed (SIGQUIT)