### PR TITLE
Add iterators to unified resource cache

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1519,62 +1519,46 @@ func (a *Server) runPeriodicOperations() {
 				}()
 			case heartbeatCheckKey:
 				go func() {
-					req := &proto.ListUnifiedResourcesRequest{Kinds: []string{types.KindNode}, SortBy: types.SortBy{Field: types.ResourceKind}}
-
-					for {
-						_, next, err := a.UnifiedResourceCache.IterateUnifiedResources(a.closeCtx,
-							func(rwl types.ResourceWithLabels) (bool, error) {
-								srv, ok := rwl.(types.Server)
-								if !ok {
-									return false, nil
-								}
-								if services.NodeHasMissedKeepAlives(srv) {
-									heartbeatsMissedByAuth.Inc()
-								}
-
-								if srv.GetSubKind() != types.SubKindOpenSSHNode {
-									return false, nil
-								}
-								// TODO(tross) DELETE in v20.0.0 - all invalid hostnames should have been sanitized by then.
-								if !validServerHostname(srv.GetHostname()) {
-									logger := a.logger.With("server", srv.GetName(), "hostname", srv.GetHostname())
-
-									logger.DebugContext(a.closeCtx, "sanitizing invalid static SSH server hostname")
-									// Any existing static hosts will not have their
-									// hostname sanitized since they don't heartbeat.
-									if err := sanitizeHostname(srv); err != nil {
-										logger.WarnContext(a.closeCtx, "failed to sanitize static SSH server hostname", "error", err)
-										return false, nil
-									}
-
-									if _, err := a.Services.UpdateNode(a.closeCtx, srv); err != nil && !trace.IsCompareFailed(err) {
-										logger.WarnContext(a.closeCtx, "failed to update SSH server hostname", "error", err)
-									}
-								} else if oldHostname, ok := srv.GetLabel(replacedHostnameLabel); ok && validServerHostname(oldHostname) {
-									// If the hostname has been replaced by a sanitized version, revert it back to the original
-									// if the original is valid under the most recent rules.
-									logger := a.logger.With("server", srv.GetName(), "old_hostname", oldHostname, "sanitized_hostname", srv.GetHostname())
-									if err := restoreSanitizedHostname(srv); err != nil {
-										logger.WarnContext(a.closeCtx, "failed to restore sanitized static SSH server hostname", "error", err)
-										return false, nil
-									}
-									if _, err := a.Services.UpdateNode(a.closeCtx, srv); err != nil && !trace.IsCompareFailed(err) {
-										logger.WarnContext(a.closeCtx, "Failed to update node hostname", "error", err)
-									}
-								}
-
-								return false, nil
-							},
-							req,
-						)
+					for srv, err := range a.UnifiedResourceCache.Nodes(a.closeCtx, services.UnifiedResourcesIterateParams{}) {
 						if err != nil {
 							a.logger.ErrorContext(a.closeCtx, "Failed to load nodes for heartbeat metric calculation", "error", err)
 							return
 						}
 
-						req.StartKey = next
-						if req.StartKey == "" {
-							break
+						if services.NodeHasMissedKeepAlives(srv) {
+							heartbeatsMissedByAuth.Inc()
+						}
+
+						if srv.GetSubKind() != types.SubKindOpenSSHNode {
+							continue
+						}
+
+						// TODO(tross) DELETE in v20.0.0 - all invalid hostnames should have been sanitized by then.
+						if !validServerHostname(srv.GetHostname()) {
+							logger := a.logger.With("server", srv.GetName(), "hostname", srv.GetHostname())
+
+							logger.DebugContext(a.closeCtx, "sanitizing invalid static SSH server hostname")
+							// Any existing static hosts will not have their
+							// hostname sanitized since they don't heartbeat.
+							if err := sanitizeHostname(srv); err != nil {
+								logger.WarnContext(a.closeCtx, "failed to sanitize static SSH server hostname", "error", err)
+								continue
+							}
+
+							if _, err := a.Services.UpdateNode(a.closeCtx, srv); err != nil && !trace.IsCompareFailed(err) {
+								logger.WarnContext(a.closeCtx, "failed to update SSH server hostname", "error", err)
+							}
+						} else if oldHostname, ok := srv.GetLabel(replacedHostnameLabel); ok && validServerHostname(oldHostname) {
+							// If the hostname has been replaced by a sanitized version, revert it back to the original
+							// if the original is valid under the most recent rules.
+							logger := a.logger.With("server", srv.GetName(), "old_hostname", oldHostname, "sanitized_hostname", srv.GetHostname())
+							if err := restoreSanitizedHostname(srv); err != nil {
+								logger.WarnContext(a.closeCtx, "failed to restore sanitized static SSH server hostname", "error", err)
+								continue
+							}
+							if _, err := a.Services.UpdateNode(a.closeCtx, srv); err != nil && !trace.IsCompareFailed(err) {
+								logger.WarnContext(a.closeCtx, "Failed to update node hostname", "error", err)
+							}
 						}
 					}
 				}()
@@ -3316,27 +3300,18 @@ func generateCert(ctx context.Context, a *Server, req certRequest, caType types.
 	// If the certificate is targeting a trusted Teleport cluster, it is the
 	// responsibility of the cluster to ensure its existence.
 	if req.routeToCluster == clusterName && req.kubernetesCluster != "" {
-		found, _, err := a.UnifiedResourceCache.IterateUnifiedResources(a.closeCtx, func(rwl types.ResourceWithLabels) (bool, error) {
-			if rwl.GetKind() != types.KindKubeServer {
-				return false, nil
+		var found bool
+		for ks, err := range a.UnifiedResourceCache.KubernetesServers(a.closeCtx, services.UnifiedResourcesIterateParams{}) {
+			if err != nil {
+				return nil, trace.Wrap(err)
 			}
 
-			ks, ok := rwl.(types.KubeServer)
-			if !ok {
-				return false, nil
+			if ks.GetCluster().GetName() == req.kubernetesCluster {
+				found = true
+				break
 			}
-
-			return ks.GetCluster().GetName() == req.kubernetesCluster, nil
-		}, &proto.ListUnifiedResourcesRequest{
-			Kinds:  []string{types.KindKubeServer},
-			SortBy: types.SortBy{Field: services.SortByName},
-			Limit:  1,
-		})
-		if err != nil {
-			return nil, trace.Wrap(err)
 		}
-
-		if len(found) == 0 {
+		if !found {
 			return nil, trace.BadParameter("Kubernetes cluster %q is not registered in this Teleport cluster; you can list registered Kubernetes clusters using 'tsh kube ls'", req.kubernetesCluster)
 		}
 	}

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -5584,13 +5584,12 @@ func TestListUnifiedResources_KindsFilter(t *testing.T) {
 		require.Equal(t, types.KindDatabaseServer, r.GetKind())
 	}
 
-	// Check for invalid sort error message
+	// Check that sorting is not required
 	_, err = clt.ListUnifiedResources(ctx, &proto.ListUnifiedResourcesRequest{
-		Kinds:  []string{types.KindDatabase},
-		Limit:  5,
-		SortBy: types.SortBy{},
+		Kinds: []string{types.KindDatabase},
+		Limit: 5,
 	})
-	require.ErrorContains(t, err, "sort field is required")
+	require.NoError(t, err, "sort field is not required")
 }
 
 func TestListUnifiedResources_WithPinnedResources(t *testing.T) {

--- a/lib/services/unified_resource.go
+++ b/lib/services/unified_resource.go
@@ -20,6 +20,7 @@ package services
 
 import (
 	"context"
+	"iter"
 	"log/slog"
 	"strings"
 	"sync"
@@ -33,8 +34,10 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	identitycenterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/identitycenter/v1"
 	"github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/api/types"
+	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/utils"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
@@ -42,7 +45,7 @@ import (
 )
 
 // UnifiedResourceKinds is a list of all kinds that are stored in the unified resource cache.
-var UnifiedResourceKinds []string = []string{
+var UnifiedResourceKinds = []string{
 	types.KindNode,
 	types.KindKubeServer,
 	types.KindDatabaseServer,
@@ -193,127 +196,323 @@ func (c *UnifiedResourceCache) deleteLocked(res types.Resource) error {
 
 func (c *UnifiedResourceCache) getSortTree(sortField string) (*btree.BTreeG[*item], error) {
 	switch sortField {
-	case sortByName:
+	case "", sortByName:
 		return c.nameTree, nil
 	case sortByKind:
 		return c.typeTree, nil
-	case "":
-		return nil, trace.BadParameter("sort field is required")
 	default:
 		return nil, trace.NotImplemented("sorting by %v is not supported in unified resources", sortField)
 	}
 }
 
-func (c *UnifiedResourceCache) getRange(ctx context.Context, startKey backend.Key, matchFn func(types.ResourceWithLabels) (bool, error), req *proto.ListUnifiedResourcesRequest) ([]resource, string, error) {
-	if startKey.IsZero() {
-		return nil, "", trace.BadParameter("missing parameter startKey")
-	}
-	if req.Limit <= 0 {
-		req.Limit = backend.DefaultRangeLimit
+func getStartKey(startKey string, sortBy types.SortBy) backend.Key {
+	if startKey == prefix {
+		return backend.NewKey(prefix)
 	}
 
-	var res []resource
-	var nextKey string
-	err := c.read(ctx, func(cache *UnifiedResourceCache) error {
-		tree, err := cache.getSortTree(req.SortBy.Field)
-		if err != nil {
-			return trace.Wrap(err, "getting sort tree")
-		}
-		var iterateRange func(lessOrEqual, greaterThan *item, iterator btree.ItemIteratorG[*item])
-		var endKey backend.Key
-		if req.SortBy.IsDesc {
-			iterateRange = tree.DescendRange
-			endKey = backend.NewKey(prefix)
-		} else {
-			iterateRange = tree.AscendRange
-			endKey = backend.RangeEnd(backend.NewKey(prefix))
-		}
-		var iteratorErr error
-		iterateRange(&item{Key: startKey}, &item{Key: endKey}, func(item *item) bool {
-			// get resource from resource map
-			resourceFromMap, ok := cache.resources[item.Value]
-			if !ok {
-				// skip and continue
-				return true
-			}
-
-			// check if the resource matches our filter
-			match, err := matchFn(resourceFromMap)
-			if err != nil {
-				iteratorErr = err
-				// stop the iterator so we can return the error
-				return false
-			}
-
-			if !match {
-				return true
-			}
-
-			// do we have all we need? set nextKey and stop iterating
-			// we do this after the matchFn to make sure they have access to the "next" node
-			if req.Limit > 0 && len(res) >= int(req.Limit) {
-				nextKey = item.Key.String()
-				return false
-			}
-			res = append(res, resourceFromMap)
-			return true
-		})
-		return iteratorErr
-	})
-	if err != nil {
-		return nil, "", trace.Wrap(err)
+	// if startKey exists, return it
+	if startKey != "" {
+		return backend.KeyFromString(startKey)
 	}
-
-	if len(res) == backend.DefaultRangeLimit {
-		c.logger.WarnContext(ctx, "Range query hit backend limit. (this is a bug!)",
-			"start_key", startKey,
-			"range_limit", backend.DefaultRangeLimit,
-		)
-	}
-
-	return res, nextKey, nil
-}
-
-func getStartKey(req *proto.ListUnifiedResourcesRequest) backend.Key {
-	// if startkey exists, return it
-	if req.StartKey != "" {
-		return backend.KeyFromString(req.StartKey)
-	}
-	// if startkey doesnt exist, we check the sort direction.
-	// If sort is descending, startkey is end of the list
-	if req.SortBy.IsDesc {
+	// If startKey doesn't exist, we check the sort direction.
+	// If sort is descending, startKey is end of the list
+	if sortBy.IsDesc {
 		return backend.RangeEnd(backend.NewKey(prefix))
 	}
 	// return start of the list
 	return backend.NewKey(prefix)
 }
 
+type iteratedItem struct {
+	resource resource
+	key      backend.Key
+}
+
+// iterateItems is a helper for iterating the correct cache, in the correct order
+// for only the specified kinds. All external iteration APIs are built upon this
+// method.
+func (c *UnifiedResourceCache) iterateItems(ctx context.Context, start string, sortBy types.SortBy, kinds ...string) iter.Seq2[iteratedItem, error] {
+	return func(yield func(iteratedItem, error) bool) {
+		startKey := getStartKey(start, sortBy)
+
+		kindsMap := make(map[string]struct{})
+		for _, k := range kinds {
+			kindsMap[k] = struct{}{}
+		}
+
+		err := c.read(ctx, func(cache *UnifiedResourceCache) error {
+			tree, err := cache.getSortTree(sortBy.Field)
+			if err != nil {
+				return trace.Wrap(err, "getting sort tree")
+			}
+
+			iterateRange := tree.DescendRange
+			endKey := backend.NewKey(prefix)
+			if !sortBy.IsDesc {
+				iterateRange = tree.AscendRange
+				endKey = backend.RangeEnd(endKey)
+			}
+
+			iterateRange(&item{Key: startKey}, &item{Key: endKey}, func(item *item) bool {
+				r, ok := cache.resources[item.Value]
+				if !ok {
+					return true
+				}
+
+				if len(kinds) == 0 || c.itemKindMatches(r, kindsMap) {
+					return yield(iteratedItem{key: item.Key, resource: r}, nil)
+				}
+
+				return true
+			})
+
+			return nil
+		})
+		if err != nil {
+			yield(iteratedItem{}, err)
+		}
+	}
+}
+
+// Resources iterates over all resources from the start key that match
+// one of the provided kinds. If no kinds are provided, resources of all supported
+// kinds are returned.
+func (c *UnifiedResourceCache) Resources(ctx context.Context, start string, sortBy types.SortBy, kinds ...string) iter.Seq2[types.ResourceWithLabels, error] {
+	return func(yield func(types.ResourceWithLabels, error) bool) {
+		for item, err := range c.iterateItems(ctx, start, sortBy, kinds...) {
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+
+			if !yield(item.resource.CloneResource(), nil) {
+				return
+			}
+		}
+	}
+}
+
+// UnifiedResourcesIterateParams are parameters that are provided to
+// UnifiedResourceCache iterators to alter the iteration behavior.
+type UnifiedResourcesIterateParams struct {
+	Start      string
+	Descending bool
+}
+
+// Nodes iterates over all cached nodes starting from the provided key.
+func (c *UnifiedResourceCache) Nodes(ctx context.Context, params UnifiedResourcesIterateParams) iter.Seq2[types.Server, error] {
+	return iterateUnifiedResourceCache(ctx, c, params, types.KindNode, types.Server.DeepCopy)
+}
+
+// AppServers iterates over all cached app servers starting from the provided key.
+func (c *UnifiedResourceCache) AppServers(ctx context.Context, params UnifiedResourcesIterateParams) iter.Seq2[types.AppServer, error] {
+	return iterateUnifiedResourceCache(ctx, c, params, types.KindAppServer, types.AppServer.Copy)
+}
+
+// DatabaseServers iterates over all cached database servers starting from the provided key.
+func (c *UnifiedResourceCache) DatabaseServers(ctx context.Context, params UnifiedResourcesIterateParams) iter.Seq2[types.DatabaseServer, error] {
+	return iterateUnifiedResourceCache(ctx, c, params, types.KindDatabaseServer, types.DatabaseServer.Copy)
+}
+
+// KubernetesServers iterates over all cached Kubernetes servers starting from the provided key.
+func (c *UnifiedResourceCache) KubernetesServers(ctx context.Context, params UnifiedResourcesIterateParams) iter.Seq2[types.KubeServer, error] {
+	return iterateUnifiedResourceCache(ctx, c, params, types.KindKubeServer, types.KubeServer.Copy)
+}
+
+// WindowsDesktops iterates over all cached windows desktops starting from the provided key.
+func (c *UnifiedResourceCache) WindowsDesktops(ctx context.Context, params UnifiedResourcesIterateParams) iter.Seq2[types.WindowsDesktop, error] {
+	return iterateUnifiedResourceCache(ctx, c, params, types.KindWindowsDesktop, func(desktop types.WindowsDesktop) types.WindowsDesktop { return desktop.Copy() })
+}
+
+// GitServers iterates over all cached git servers starting from the provided key.
+func (c *UnifiedResourceCache) GitServers(ctx context.Context, params UnifiedResourcesIterateParams) iter.Seq2[types.Server, error] {
+	return iterateUnifiedResourceCache(ctx, c, params, types.KindGitServer, types.Server.DeepCopy)
+}
+
+// SAMLIdPServiceProviders iterates over all cached sAML IdP service providers starting from the provided key.
+func (c *UnifiedResourceCache) SAMLIdPServiceProviders(ctx context.Context, params UnifiedResourcesIterateParams) iter.Seq2[types.SAMLIdPServiceProvider, error] {
+	return iterateUnifiedResourceCache(ctx, c, params, types.KindSAMLIdPServiceProvider, types.SAMLIdPServiceProvider.Copy)
+}
+
+// IdentityCenterAccounts iterates over all cached identity center accounts starting from the provided key.
+func (c *UnifiedResourceCache) IdentityCenterAccounts(ctx context.Context, params UnifiedResourcesIterateParams) iter.Seq2[*identitycenterv1.Account, error] {
+	// cloning is performed on the concrete resource below instead of
+	// on the wrapper type.
+	cloneFn := func(account IdentityCenterAccount) IdentityCenterAccount {
+		return account
+	}
+	return func(yield func(*identitycenterv1.Account, error) bool) {
+		for account, err := range iterateUnifiedResourceCache(ctx, c, params, types.KindIdentityCenterAccount, cloneFn) {
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+
+			if !yield(apiutils.CloneProtoMsg(account.Account), nil) {
+				return
+			}
+		}
+	}
+}
+
+// IdentityCenterAccountAssignments iterates over all cached identity center account assignments starting from the provided key.
+func (c *UnifiedResourceCache) IdentityCenterAccountAssignments(ctx context.Context, params UnifiedResourcesIterateParams) iter.Seq2[*identitycenterv1.AccountAssignment, error] {
+	// cloning is performed on the concrete resource below instead of
+	// on the wrapper type.
+	cloneFn := func(account IdentityCenterAccountAssignment) IdentityCenterAccountAssignment {
+		return account
+	}
+	return func(yield func(*identitycenterv1.AccountAssignment, error) bool) {
+		for assignment, err := range iterateUnifiedResourceCache(ctx, c, params, types.KindIdentityCenterAccountAssignment, cloneFn) {
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+
+			if !yield(apiutils.CloneProtoMsg(assignment.AccountAssignment), nil) {
+				return
+			}
+		}
+	}
+}
+
+func iterateUnifiedResourceCache[T any](ctx context.Context, c *UnifiedResourceCache, params UnifiedResourcesIterateParams, kind string, cloneFn func(T) T) iter.Seq2[T, error] {
+	return func(yield func(T, error) bool) {
+		sortBy := types.SortBy{IsDesc: params.Descending, Field: SortByName}
+		for i, err := range c.iterateItems(ctx, params.Start, sortBy, kind) {
+			if err != nil {
+				var t T
+				yield(t, err)
+				return
+			}
+
+			switch r := i.resource.(type) {
+			case T:
+				if !yield(cloneFn(r), nil) {
+					return
+				}
+			case types.Resource153Unwrapper:
+				res, ok := r.Unwrap().(T)
+				if !ok {
+					continue
+				}
+
+				if !yield(cloneFn(res), nil) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// IterateUnifiedResources allows building a custom page of resources. All items within the
+// range and limit of the request are passed to the matchFn. Only those resource which
+// have a true value returned from the matchFn are included in the returned page.
 func (c *UnifiedResourceCache) IterateUnifiedResources(ctx context.Context, matchFn func(types.ResourceWithLabels) (bool, error), req *proto.ListUnifiedResourcesRequest) ([]types.ResourceWithLabels, string, error) {
-	startKey := getStartKey(req)
-	result, nextKey, err := c.getRange(ctx, startKey, matchFn, req)
-	if err != nil {
-		return nil, "", trace.Wrap(err)
+	var resources []types.ResourceWithLabels
+	for item, err := range c.iterateItems(ctx, req.StartKey, req.SortBy, req.Kinds...) {
+		if err != nil {
+			return nil, "", trace.Wrap(err)
+		}
+
+		match, err := matchFn(item.resource)
+		if err != nil {
+			return nil, "", trace.Wrap(err)
+		}
+
+		if match {
+			if req.Limit != backend.NoLimit && len(resources) == int(req.Limit) {
+				return resources, item.key.String(), nil
+			}
+
+			resources = append(resources, item.resource.CloneResource())
+		}
 	}
 
-	resources := make([]types.ResourceWithLabels, 0, len(result))
-	for _, item := range result {
-		resources = append(resources, item.CloneResource())
-	}
+	return resources, "", nil
+}
 
-	return resources, nextKey, nil
+func (c *UnifiedResourceCache) itemKindMatches(r resource, kinds map[string]struct{}) bool {
+	switch r.GetKind() {
+	case types.KindNode,
+		types.KindWindowsDesktop,
+		types.KindIdentityCenterAccountAssignment,
+		types.KindGitServer,
+		types.KindDatabase,
+		types.KindKubernetesCluster:
+		_, ok := kinds[r.GetKind()]
+		return ok
+	case types.KindIdentityCenterAccount:
+		if _, ok := kinds[types.KindApp]; ok {
+			return ok
+		}
+
+		_, ok := kinds[types.KindIdentityCenterAccount]
+		return ok
+	case types.KindApp:
+		if _, ok := kinds[types.KindApp]; ok {
+			return ok
+		}
+
+		if _, ok := kinds[types.KindAppServer]; ok {
+			return ok
+		}
+
+		_, ok := kinds[types.KindIdentityCenterAccount]
+		return ok
+	case types.KindKubeServer:
+		if _, ok := kinds[types.KindKubernetesCluster]; ok {
+			return ok
+		}
+
+		_, ok := kinds[types.KindKubeServer]
+		return ok
+	case types.KindDatabaseServer:
+		if _, ok := kinds[types.KindDatabase]; ok {
+			return ok
+		}
+
+		_, ok := kinds[types.KindDatabaseServer]
+		return ok
+	case types.KindSAMLIdPServiceProvider:
+		_, ok := kinds[types.KindSAMLIdPServiceProvider]
+		return ok
+	case types.KindAppOrSAMLIdPServiceProvider:
+		switch r.(type) {
+		case types.AppServer:
+			if _, ok := kinds[types.KindApp]; ok {
+				return ok
+			}
+
+			_, ok := kinds[types.KindAppServer]
+			return ok
+		case types.SAMLIdPServiceProvider:
+			_, ok := kinds[types.KindSAMLIdPServiceProvider]
+			return ok
+		default:
+			return false
+		}
+	case types.KindAppServer:
+		if _, ok := kinds[types.KindApp]; ok {
+			return ok
+		}
+
+		_, ok := kinds[types.KindAppServer]
+		return ok
+	default:
+		return false
+	}
 }
 
 // GetUnifiedResources returns a list of all resources stored in the current unifiedResourceCollector tree in ascending order
 func (c *UnifiedResourceCache) GetUnifiedResources(ctx context.Context) ([]types.ResourceWithLabels, error) {
-	req := &proto.ListUnifiedResourcesRequest{Limit: backend.NoLimit, SortBy: types.SortBy{IsDesc: false, Field: sortByName}}
-	result, _, err := c.getRange(ctx, backend.NewKey(prefix), func(rwl types.ResourceWithLabels) (bool, error) { return true, nil }, req)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+	var resources []types.ResourceWithLabels
+	for resource, err := range c.Resources(ctx, prefix, types.SortBy{IsDesc: false, Field: sortByName}) {
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 
-	resources := make([]types.ResourceWithLabels, 0, len(result))
-	for _, item := range result {
-		resources = append(resources, item.CloneResource())
+		resources = append(resources, resource)
 	}
 
 	return resources, nil

--- a/lib/services/unified_resource_test.go
+++ b/lib/services/unified_resource_test.go
@@ -21,7 +21,10 @@ package services_test
 import (
 	"context"
 	"fmt"
+	"iter"
+	"maps"
 	"slices"
+	"strconv"
 	"testing"
 	"time"
 
@@ -41,12 +44,14 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/common"
 	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 )
 
 type client struct {
+	bk backend.Backend
 	services.Presence
 	services.WindowsDesktops
 	services.SAMLIdPServiceProviders
@@ -72,6 +77,7 @@ func newClient(t *testing.T) *client {
 	require.NoError(t, err)
 
 	return &client{
+		bk:                               bk,
 		Presence:                         local.NewPresenceService(bk),
 		WindowsDesktops:                  local.NewWindowsDesktopService(bk),
 		SAMLIdPServiceProviders:          samlService,
@@ -111,7 +117,6 @@ func TestUnifiedResourceWatcher(t *testing.T) {
 	_, err = clt.UpsertDatabaseServer(ctx, dbServer)
 	require.NoError(t, err)
 	gitServer := newGitServer(t, "my-org")
-	require.NoError(t, err)
 	_, err = clt.CreateGitServer(ctx, gitServer)
 	require.NoError(t, err)
 
@@ -257,6 +262,567 @@ func TestUnifiedResourceWatcher(t *testing.T) {
 		// Ignore order.
 		cmpopts.SortSlices(func(a, b types.ResourceWithLabels) bool { return a.GetName() < b.GetName() }),
 	))
+}
+
+func TestUnifiedResourceCacheIterateResources(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	clt := newClient(t)
+
+	node := newNodeServer(t, "node1", "hostname1", "127.0.0.1:22", false /*tunnel*/)
+	_, err := clt.UpsertNode(ctx, node)
+	require.NoError(t, err)
+
+	db, err := types.NewDatabaseV3(types.Metadata{
+		Name: "db1",
+	}, types.DatabaseSpecV3{
+		Protocol: "test-protocol",
+		URI:      "test-uri",
+	})
+	require.NoError(t, err)
+	dbServer, err := types.NewDatabaseServerV3(types.Metadata{
+		Name: "db1-server",
+	}, types.DatabaseServerSpecV3{
+		Hostname: "db-hostname",
+		HostID:   uuid.NewString(),
+		Database: db,
+	})
+	require.NoError(t, err)
+	_, err = clt.UpsertDatabaseServer(ctx, dbServer)
+	require.NoError(t, err)
+	gitServer := newGitServer(t, "my-org")
+	_, err = clt.CreateGitServer(ctx, gitServer)
+	require.NoError(t, err)
+
+	// Add app to the backend.
+	app, err := types.NewAppServerV3(
+		types.Metadata{Name: "app1"},
+		types.AppServerSpecV3{
+			HostID: "app1-host-id",
+			App:    newApp(t, "app1"),
+		},
+	)
+	require.NoError(t, err)
+	_, err = clt.UpsertApplicationServer(ctx, app)
+	require.NoError(t, err)
+
+	// Add saml idp service provider to the backend.
+	samlapp, err := types.NewSAMLIdPServiceProvider(
+		types.Metadata{
+			Name: "sp1",
+		},
+		types.SAMLIdPServiceProviderSpecV1{
+			EntityDescriptor: newTestEntityDescriptor("sp1"),
+			EntityID:         "sp1",
+		},
+	)
+	require.NoError(t, err)
+	err = clt.CreateSAMLIdPServiceProvider(ctx, samlapp)
+	require.NoError(t, err)
+
+	win, err := types.NewWindowsDesktopV3(
+		"win1",
+		nil,
+		types.WindowsDesktopSpecV3{Addr: "localhost", HostID: "win1-host-id"},
+	)
+	require.NoError(t, err)
+	err = clt.UpsertWindowsDesktop(ctx, win)
+	require.NoError(t, err)
+
+	kubeCluster, err := types.NewKubernetesClusterV3(types.Metadata{Name: "kube-cluster"}, types.KubernetesClusterSpecV3{})
+	require.NoError(t, err)
+	kubeServer, err := types.NewKubernetesServerV3FromCluster(kubeCluster, "foo", "1")
+	require.NoError(t, err)
+	_, err = clt.UpsertKubernetesServer(ctx, kubeServer)
+	require.NoError(t, err)
+
+	icAcct := newICAccount(t, ctx, clt)
+	icAcctAssignment := newICAccountAssignment(t, ctx, clt)
+
+	w, err := services.NewUnifiedResourceCache(ctx, services.UnifiedResourceCacheConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Component: teleport.ComponentUnifiedResource,
+			Client:    clt,
+		},
+		ResourceGetter: clt,
+	})
+	require.NoError(t, err)
+
+	assert.Eventually(t, func() bool {
+		return w.IsInitialized()
+	}, 5*time.Second, 10*time.Millisecond, "unified resource watcher never initialized")
+
+	compareResourceOpts := []cmp.Option{cmpopts.EquateEmpty(),
+		cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+		cmpopts.IgnoreFields(header.Metadata{}, "Revision"),
+
+		// Allow comparison of the wrapped values inside a Resource153ToLegacyAdapter
+		cmp.Transformer("Unwrap",
+			func(t types.Resource153Unwrapper) types.Resource153 {
+				return t.Unwrap()
+			}),
+
+		// Ignore unexported values in RFD153-style resources
+		cmpopts.IgnoreUnexported(
+			headerv1.Metadata{},
+			identitycenterv1.Account{},
+			identitycenterv1.AccountSpec{},
+			identitycenterv1.PermissionSetInfo{},
+			identitycenterv1.AccountAssignment{},
+			identitycenterv1.AccountAssignmentSpec{}),
+
+		// Ignore order.
+		cmpopts.SortSlices(func(a, b types.ResourceWithLabels) bool { return a.GetName() < b.GetName() }),
+	}
+
+	expected := map[string]types.ResourceWithLabels{
+		types.KindApp:                             app,
+		types.KindDatabase:                        dbServer,
+		types.KindNode:                            node,
+		types.KindWindowsDesktop:                  win,
+		types.KindKubernetesCluster:               kubeServer,
+		types.KindSAMLIdPServiceProvider:          samlapp,
+		types.KindGitServer:                       gitServer,
+		types.KindIdentityCenterAccount:           types.Resource153ToUnifiedResource(icAcct),
+		types.KindIdentityCenterAccountAssignment: types.Resource153ToUnifiedResource(icAcctAssignment),
+	}
+
+	for r, err := range w.Resources(ctx, "", types.SortBy{Field: services.SortByKind}) {
+		require.NoError(t, err)
+
+		kind := r.GetKind()
+		switch kind {
+		case types.KindAppServer:
+			kind = types.KindApp
+		case types.KindDatabaseServer:
+			kind = types.KindDatabase
+		case types.KindKubeServer:
+			kind = types.KindKubernetesCluster
+		}
+
+		expectedResource, ok := expected[kind]
+		require.True(t, ok, "resource not expected %v", r)
+
+		assert.Empty(t, cmp.Diff(
+			expectedResource,
+			r,
+			compareResourceOpts...,
+		))
+	}
+
+	for len(expected) > 0 {
+		count := 0
+		kinds := slices.Collect(maps.Keys(expected))
+		for r, err := range w.Resources(ctx, "", types.SortBy{Field: services.SortByKind}, kinds...) {
+			require.NoError(t, err)
+
+			kind := r.GetKind()
+			switch kind {
+			case types.KindAppServer:
+				kind = types.KindApp
+			case types.KindDatabaseServer:
+				kind = types.KindDatabase
+			case types.KindKubeServer:
+				kind = types.KindKubernetesCluster
+			}
+
+			expectedResource, ok := expected[kind]
+			require.True(t, ok, "resource not expected %v", r)
+
+			if count == 0 {
+				delete(expected, kind)
+			}
+
+			assert.Empty(t, cmp.Diff(
+				expectedResource,
+				r,
+				compareResourceOpts...,
+			))
+			count++
+		}
+		assert.Equal(t, len(kinds), count)
+	}
+}
+
+func TestUnifiedResourceCacheIteration(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	const resourceCount = 1234
+	ids := make([]string, 0, resourceCount)
+	for i := 0; i < resourceCount; i++ {
+		ids = append(ids, "resource"+strconv.Itoa(i))
+	}
+
+	slices.Sort(ids)
+
+	type GetNamer interface {
+		GetName() string
+	}
+
+	tests := []struct {
+		name             string
+		createResource   func(name string, c *client) error
+		iterateResources func(urc *services.UnifiedResourceCache) iter.Seq2[GetNamer, error]
+	}{
+		{
+			name: "nodes",
+			createResource: func(name string, c *client) error {
+				node := newNodeServer(t, name, "hostname1", "127.0.0.1:22", false)
+				_, err := c.UpsertNode(ctx, node)
+				return err
+			},
+			iterateResources: func(urc *services.UnifiedResourceCache) iter.Seq2[GetNamer, error] {
+				return func(yield func(GetNamer, error) bool) {
+					for n, err := range urc.Nodes(ctx, services.UnifiedResourcesIterateParams{}) {
+						if err != nil {
+							yield(nil, err)
+							return
+						}
+
+						if !yield(n, nil) {
+							return
+						}
+					}
+				}
+			},
+		},
+		{
+			name: "databases",
+			createResource: func(name string, c *client) error {
+				db, err := types.NewDatabaseV3(types.Metadata{
+					Name: name,
+				}, types.DatabaseSpecV3{
+					Protocol: "test-protocol",
+					URI:      "test-uri",
+				})
+				if err != nil {
+					return err
+				}
+				dbServer, err := types.NewDatabaseServerV3(types.Metadata{
+					Name: name,
+				}, types.DatabaseServerSpecV3{
+					Hostname: "hostname:" + name,
+					HostID:   uuid.NewString(),
+					Database: db,
+				})
+				if err != nil {
+					return err
+				}
+				_, err = c.UpsertDatabaseServer(ctx, dbServer)
+				return err
+			},
+			iterateResources: func(urc *services.UnifiedResourceCache) iter.Seq2[GetNamer, error] {
+				return func(yield func(GetNamer, error) bool) {
+					for n, err := range urc.DatabaseServers(ctx, services.UnifiedResourcesIterateParams{}) {
+						if err != nil {
+							yield(nil, err)
+							return
+						}
+
+						if !yield(n, nil) {
+							return
+						}
+					}
+				}
+			},
+		},
+		{
+			name: "apps",
+			createResource: func(name string, c *client) error {
+				app, err := types.NewAppServerV3(
+					types.Metadata{Name: name},
+					types.AppServerSpecV3{
+						HostID: "app1-host-id",
+						App:    newApp(t, name),
+					},
+				)
+				if err != nil {
+					return err
+				}
+				_, err = c.UpsertApplicationServer(ctx, app)
+				return err
+			},
+			iterateResources: func(urc *services.UnifiedResourceCache) iter.Seq2[GetNamer, error] {
+				return func(yield func(GetNamer, error) bool) {
+					for n, err := range urc.AppServers(ctx, services.UnifiedResourcesIterateParams{}) {
+						if err != nil {
+							yield(nil, err)
+							return
+						}
+
+						if !yield(n, nil) {
+							return
+						}
+					}
+				}
+			},
+		},
+		{
+			name: "kubernetes",
+			createResource: func(name string, c *client) error {
+				kubeCluster, err := types.NewKubernetesClusterV3(types.Metadata{Name: name}, types.KubernetesClusterSpecV3{})
+				if err != nil {
+					return err
+				}
+				kubeServer, err := types.NewKubernetesServerV3FromCluster(kubeCluster, name, "1")
+				if err != nil {
+					return err
+				}
+				_, err = c.UpsertKubernetesServer(ctx, kubeServer)
+				return err
+			},
+			iterateResources: func(urc *services.UnifiedResourceCache) iter.Seq2[GetNamer, error] {
+				return func(yield func(GetNamer, error) bool) {
+					for n, err := range urc.KubernetesServers(ctx, services.UnifiedResourcesIterateParams{}) {
+						if err != nil {
+							yield(nil, err)
+							return
+						}
+
+						if !yield(n, nil) {
+							return
+						}
+					}
+				}
+			},
+		},
+		{
+			name: "git",
+			createResource: func(name string, c *client) error {
+				gitServer, err := types.NewGitHubServerWithName(name, types.GitHubServerMetadata{
+					Organization: name,
+					Integration:  name,
+				})
+				if err != nil {
+					return err
+				}
+
+				_, err = c.CreateGitServer(ctx, gitServer)
+				return err
+			},
+			iterateResources: func(urc *services.UnifiedResourceCache) iter.Seq2[GetNamer, error] {
+				return func(yield func(GetNamer, error) bool) {
+					for n, err := range urc.GitServers(ctx, services.UnifiedResourcesIterateParams{}) {
+						if err != nil {
+							yield(nil, err)
+							return
+						}
+
+						if !yield(n, nil) {
+							return
+						}
+					}
+				}
+			},
+		},
+		{
+			name: "desktops",
+			createResource: func(name string, c *client) error {
+				win, err := types.NewWindowsDesktopV3(
+					name,
+					nil,
+					types.WindowsDesktopSpecV3{Addr: "localhost", HostID: "win1-host-id"},
+				)
+				if err != nil {
+					return err
+				}
+				err = c.UpsertWindowsDesktop(ctx, win)
+				return err
+			},
+			iterateResources: func(urc *services.UnifiedResourceCache) iter.Seq2[GetNamer, error] {
+				return func(yield func(GetNamer, error) bool) {
+					for n, err := range urc.WindowsDesktops(ctx, services.UnifiedResourcesIterateParams{}) {
+						if err != nil {
+							yield(nil, err)
+							return
+						}
+
+						if !yield(n, nil) {
+							return
+						}
+					}
+				}
+			},
+		},
+		{
+			name: "saml",
+			createResource: func(name string, c *client) error {
+				sp, err := types.NewSAMLIdPServiceProvider(
+					types.Metadata{
+						Name: name,
+					},
+					types.SAMLIdPServiceProviderSpecV1{
+						EntityDescriptor: newTestEntityDescriptor(name),
+						EntityID:         name,
+					},
+				)
+				if err != nil {
+					return err
+				}
+
+				// Items are manually inserted into the backend to avoid
+				// the penalty associated ensuring entity ids are unique
+				// in CreateSAMLIdPServiceProvider.
+				raw, err := services.MarshalSAMLIdPServiceProvider(sp)
+				if err != nil {
+					return err
+				}
+
+				_, err = c.bk.Create(ctx, backend.Item{
+					Key:      backend.NewKey("saml_idp_service_provider", sp.GetName()),
+					Value:    raw,
+					Revision: sp.GetRevision(),
+				})
+				return err
+			},
+			iterateResources: func(urc *services.UnifiedResourceCache) iter.Seq2[GetNamer, error] {
+				return func(yield func(GetNamer, error) bool) {
+					for n, err := range urc.SAMLIdPServiceProviders(ctx, services.UnifiedResourcesIterateParams{}) {
+						if err != nil {
+							yield(nil, err)
+							return
+						}
+
+						if !yield(n, nil) {
+							return
+						}
+					}
+				}
+			},
+		},
+		{
+			name: "identity center account",
+			createResource: func(name string, c *client) error {
+				_, err := c.CreateIdentityCenterAccount(ctx, services.IdentityCenterAccount{
+					Account: &identitycenterv1.Account{
+						Kind:    types.KindIdentityCenterAccount,
+						Version: types.V1,
+						Metadata: &headerv1.Metadata{
+							Name: name,
+							Labels: map[string]string{
+								types.OriginLabel: common.OriginAWSIdentityCenter,
+							},
+						},
+						Spec: &identitycenterv1.AccountSpec{
+							Id:          name,
+							Arn:         "arn:aws:sso:::account/" + name,
+							Name:        "Test AWS Account",
+							Description: "Used for testing",
+							PermissionSetInfo: []*identitycenterv1.PermissionSetInfo{
+								{
+									Name: "Alpha",
+									Arn:  "arn:aws:sso:::permissionSet/ssoins-1234567890/ps-alpha",
+								},
+								{
+									Name: "Beta",
+									Arn:  "arn:aws:sso:::permissionSet/ssoins-1234567890/ps-beta",
+								},
+							},
+						},
+					}})
+				return err
+			},
+			iterateResources: func(urc *services.UnifiedResourceCache) iter.Seq2[GetNamer, error] {
+				return func(yield func(GetNamer, error) bool) {
+					for n, err := range urc.IdentityCenterAccounts(ctx, services.UnifiedResourcesIterateParams{}) {
+						if err != nil {
+							yield(nil, err)
+							return
+						}
+
+						if !yield(types.Resource153ToResourceWithLabels(n), nil) {
+							return
+						}
+					}
+				}
+			},
+		},
+		{
+			name: "identity center account assignment",
+			createResource: func(name string, c *client) error {
+				_, err := c.CreateAccountAssignment(ctx, services.IdentityCenterAccountAssignment{
+					AccountAssignment: &identitycenterv1.AccountAssignment{
+						Kind:    types.KindIdentityCenterAccountAssignment,
+						Version: types.V1,
+						Metadata: &headerv1.Metadata{
+							Name: name,
+							Labels: map[string]string{
+								types.OriginLabel: common.OriginAWSIdentityCenter,
+							},
+						},
+						Spec: &identitycenterv1.AccountAssignmentSpec{
+							Display: "Admin access on Production",
+							PermissionSet: &identitycenterv1.PermissionSetInfo{
+								Arn:          "arn:aws::::ps-Admin",
+								Name:         "Admin",
+								AssignmentId: "production--admin",
+							},
+							AccountName: "Production",
+							AccountId:   "99999999",
+						},
+					}})
+				return err
+			},
+			iterateResources: func(urc *services.UnifiedResourceCache) iter.Seq2[GetNamer, error] {
+				return func(yield func(GetNamer, error) bool) {
+					for n, err := range urc.IdentityCenterAccountAssignments(ctx, services.UnifiedResourcesIterateParams{}) {
+						if err != nil {
+							yield(nil, err)
+							return
+						}
+
+						if !yield(types.Resource153ToResourceWithLabels(n), nil) {
+							return
+						}
+					}
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			clt := newClient(t)
+
+			w, err := services.NewUnifiedResourceCache(ctx, services.UnifiedResourceCacheConfig{
+				ResourceWatcherConfig: services.ResourceWatcherConfig{
+					Component: teleport.ComponentUnifiedResource,
+					Client:    clt,
+				},
+				ResourceGetter: clt,
+			})
+			require.NoError(t, err)
+
+			for i := 0; i < resourceCount; i++ {
+				require.NoError(t, test.createResource(ids[i], clt), "creating resource %d", i)
+			}
+
+			require.EventuallyWithT(t, func(t *assert.CollectT) {
+				found, err := w.GetUnifiedResources(ctx)
+				assert.NoError(t, err)
+				assert.Len(t, found, resourceCount)
+			}, 10*time.Second, 100*time.Millisecond)
+
+			count := 0
+			for r, err := range test.iterateResources(w) {
+				require.NoError(t, err)
+
+				if r.GetName() != ids[count] {
+					t.Fatalf("expected resource named %s, got %s", ids[count], r.GetName())
+				}
+				count++
+			}
+
+			if count != resourceCount {
+				t.Fatalf("iteration completed early, expected %d apps, got %d", resourceCount, count)
+			}
+		})
+	}
 }
 
 func TestUnifiedResourceWatcher_PreventDuplicates(t *testing.T) {


### PR DESCRIPTION
This updates the UnifiedResourceCache with IterateResources as an alternative to IterateUnifiedResources. The new function returns an iterator instead of collecting and returning a page of results. While this API may not entirely replace the current one, it offers a better way for users that just want to iterate resources without collecting them. Additionally, a few helper methods were included for callers that might wish to only iterate one specific resource type. Internally the UnifiedResourceCache was refactored to use the same logic for all exposed iteration methods.