### PR TITLE
Return db permission provisioning errors

### DIFF
--- a/lib/srv/db/postgres/users.go
+++ b/lib/srv/db/postgres/users.go
@@ -266,6 +266,7 @@ func (e *Engine) applyPermissions(ctx context.Context, sessionCtx *common.Sessio
 				"error", err,
 			)
 		}
+		return trace.Wrap(err)
 	}
 	return nil
 }
@@ -301,6 +302,7 @@ func (e *Engine) removePermissions(ctx context.Context, sessionCtx *common.Sessi
 		logger.ErrorContext(ctx, "Removing permissions from user failed",
 			"error", err,
 		)
+		return trace.Wrap(err)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR returns errors from db permission provisioning.
I removed these returns by mistake in https://github.com/gravitational/teleport/pull/51945