### PR TITLE
tctl support for Workload Identity revocations

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -890,6 +890,12 @@ func (c *Client) WorkloadIdentityResourceServiceClient() workloadidentityv1pb.Wo
 	return workloadidentityv1pb.NewWorkloadIdentityResourceServiceClient(c.conn)
 }
 
+// WorkloadIdentityRevocationServiceClient returns an unadorned client for the
+// workload identity revocation service.
+func (c *Client) WorkloadIdentityRevocationServiceClient() workloadidentityv1pb.WorkloadIdentityRevocationServiceClient {
+	return workloadidentityv1pb.NewWorkloadIdentityRevocationServiceClient(c.conn)
+}
+
 // WorkloadIdentityIssuanceClient returns an unadorned client for the workload
 // identity service.
 func (c *Client) WorkloadIdentityIssuanceClient() workloadidentityv1pb.WorkloadIdentityIssuanceServiceClient {

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -260,6 +260,8 @@ func ParseShortcut(in string) (string, error) {
 		return types.KindAutoUpdateAgentRollout, nil
 	case types.KindGitServer, types.KindGitServer + "s":
 		return types.KindGitServer, nil
+	case types.KindWorkloadIdentityX509Revocation, types.KindWorkloadIdentityX509Revocation + "s":
+		return types.KindWorkloadIdentityX509Revocation, nil
 	}
 	return "", trace.BadParameter("unsupported resource: %q - resources should be expressed as 'type/name', for example 'connector/github'", in)
 }

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -2068,6 +2068,14 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 			return trace.Wrap(err)
 		}
 		fmt.Printf("Workload identity %q has been deleted\n", rc.ref.Name)
+	case types.KindWorkloadIdentityX509Revocation:
+		if _, err := client.WorkloadIdentityRevocationServiceClient().DeleteWorkloadIdentityX509Revocation(
+			ctx, &workloadidentityv1pb.DeleteWorkloadIdentityX509RevocationRequest{
+				Name: rc.ref.Name,
+			}); err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Printf("Workload identity X509 revocation %q has been deleted\n", rc.ref.Name)
 	case types.KindStaticHostUser:
 		if err := client.StaticHostUserClient().DeleteStaticHostUser(ctx, rc.ref.Name); err != nil {
 			return trace.Wrap(err)
@@ -3237,6 +3245,40 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		}
 
 		return &workloadIdentityCollection{items: resources}, nil
+	case types.KindWorkloadIdentityX509Revocation:
+		if rc.ref.Name != "" {
+			resource, err := client.
+				WorkloadIdentityRevocationServiceClient().
+				GetWorkloadIdentityX509Revocation(ctx, &workloadidentityv1pb.GetWorkloadIdentityX509RevocationRequest{
+					Name: rc.ref.Name,
+				})
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			return &workloadIdentityX509RevocationCollection{items: []*workloadidentityv1pb.WorkloadIdentityX509Revocation{resource}}, nil
+		}
+
+		var resources []*workloadidentityv1pb.WorkloadIdentityX509Revocation
+		pageToken := ""
+		for {
+			resp, err := client.
+				WorkloadIdentityRevocationServiceClient().
+				ListWorkloadIdentityX509Revocations(ctx, &workloadidentityv1pb.ListWorkloadIdentityX509RevocationsRequest{
+					PageToken: pageToken,
+				})
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			resources = append(resources, resp.WorkloadIdentityX509Revocations...)
+
+			if resp.NextPageToken == "" {
+				break
+			}
+			pageToken = resp.NextPageToken
+		}
+
+		return &workloadIdentityX509RevocationCollection{items: resources}, nil
 	case types.KindBotInstance:
 		if rc.ref.Name != "" && rc.ref.SubKind != "" {
 			// Gets a specific bot instance, e.g. bot_instance/<bot name>/<instance id>

--- a/tool/tctl/common/testdata/TestWorkloadIdentityRevocation/workload-identity_revocations_add.golden
+++ b/tool/tctl/common/testdata/TestWorkloadIdentityRevocation/workload-identity_revocations_add.golden
@@ -1,0 +1,1 @@
+Revocation for the X509 certificate with serial aabbccdd created

--- a/tool/tctl/common/testdata/TestWorkloadIdentityRevocation/workload-identity_revocations_ls_empty.golden
+++ b/tool/tctl/common/testdata/TestWorkloadIdentityRevocation/workload-identity_revocations_ls_empty.golden
@@ -1,0 +1,1 @@
+No revocations configured

--- a/tool/tctl/common/testdata/TestWorkloadIdentityRevocation/workload-identity_revocations_ls_with_value.golden
+++ b/tool/tctl/common/testdata/TestWorkloadIdentityRevocation/workload-identity_revocations_ls_with_value.golden
@@ -1,0 +1,4 @@
+Type Serial   Revoked At           Expires At                        Reason      
+---- -------- -------------------- --------------------------------- ----------- 
+x509 aabbccdd 2024-02-05T15:04:00Z 2030-02-24T15:04:00Z (53064h0m0s) compromised 
+

--- a/tool/tctl/common/testdata/TestWorkloadIdentityRevocation/workload-identity_revocations_rm.golden
+++ b/tool/tctl/common/testdata/TestWorkloadIdentityRevocation/workload-identity_revocations_rm.golden
@@ -1,0 +1,1 @@
+Revocation for the X509 certificate with serial aabbccdd deleted

--- a/tool/tctl/common/workload_identity_command.go
+++ b/tool/tctl/common/workload_identity_command.go
@@ -58,7 +58,6 @@ type WorkloadIdentityCommand struct {
 	revocationSerial string
 	revocationReason string
 	revocationExpiry string
-	revokedAt        string
 
 	now func() time.Time
 

--- a/tool/tctl/common/workload_identity_command.go
+++ b/tool/tctl/common/workload_identity_command.go
@@ -20,13 +20,19 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math/big"
 	"os"
+	"strings"
+	"time"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/gravitational/teleport"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
@@ -43,6 +49,15 @@ type WorkloadIdentityCommand struct {
 
 	listCmd *kingpin.CmdClause
 	rmCmd   *kingpin.CmdClause
+
+	revocationsAddCmd *kingpin.CmdClause
+	revocationsRmCmd  *kingpin.CmdClause
+	revocationsLsCmd  *kingpin.CmdClause
+
+	revocationType   string
+	revocationSerial string
+	revocationReason string
+	revocationExpiry string
 
 	stdout io.Writer
 }
@@ -79,6 +94,37 @@ func (c *WorkloadIdentityCommand) Initialize(
 		Required().
 		StringVar(&c.workloadIdentityName)
 
+	revocationsCmd := cmd.Command("revocations", "Manage workload identity revocations.")
+	c.revocationsAddCmd = revocationsCmd.Command("add", "Create a new revocation.")
+	c.revocationsAddCmd.Flag("serial", "Serial number of the certificate to revoke.").
+		Required().
+		StringVar(&c.revocationSerial)
+	c.revocationsAddCmd.Flag("type", "Type of credential to revoke (x509)").
+		Required().
+		EnumVar(&c.revocationType, "x509")
+	c.revocationsAddCmd.Flag("reason", "Reason for revocation.").
+		Required().
+		StringVar(&c.revocationReason)
+	c.revocationsAddCmd.
+		Flag(
+			"expiry",
+			"Time that the revocation should expire, usually this should match the expiry time of the credential. This should be specified using RFC3339 e.g 2024-02-05T15:04:00Z. If unspecified, the time 1 week from now is used.").
+		StringVar(&c.revocationExpiry)
+
+	c.revocationsRmCmd = revocationsCmd.Command("rm", "Delete a revocation.")
+	c.revocationsRmCmd.Flag("serial", "Serial number of the certificate to remove the revocation for.").Required().StringVar(&c.revocationSerial)
+	c.revocationsRmCmd.Flag("type", "Type of credential to remove the revocation for (x509).").Required().EnumVar(&c.revocationType, "x509")
+
+	c.revocationsLsCmd = revocationsCmd.Command("ls", "List revocations.")
+	c.revocationsLsCmd.
+		Flag(
+			"format",
+			"Output format, 'text' or 'json'",
+		).
+		Hidden().
+		Default(teleport.Text).
+		EnumVar(&c.format, teleport.Text, teleport.JSON)
+
 	if c.stdout == nil {
 		c.stdout = os.Stdout
 	}
@@ -94,6 +140,12 @@ func (c *WorkloadIdentityCommand) TryRun(
 		commandFunc = c.ListWorkloadIdentities
 	case c.rmCmd.FullCommand():
 		commandFunc = c.DeleteWorkloadIdentity
+	case c.revocationsAddCmd.FullCommand():
+		commandFunc = c.AddRevocation
+	case c.revocationsLsCmd.FullCommand():
+		commandFunc = c.ListRevocations
+	case c.revocationsRmCmd.FullCommand():
+		commandFunc = c.DeleteRevocation
 	default:
 		return false, nil
 	}
@@ -168,6 +220,150 @@ func (c *WorkloadIdentityCommand) ListWorkloadIdentities(
 		err := utils.WriteJSONArray(c.stdout, workloadIdentities)
 		if err != nil {
 			return trace.Wrap(err, "failed to marshal workload identities")
+		}
+	}
+	return nil
+}
+
+func normalizeCertificateSerial(str string) (string, error) {
+	stripped := strings.ReplaceAll(str, ":", "")
+	value := new(big.Int)
+	_, ok := value.SetString(stripped, 16)
+	if !ok {
+		return "", trace.BadParameter("invalid serial number")
+	}
+	return value.Text(16), nil
+}
+
+func (c *WorkloadIdentityCommand) AddRevocation(
+	ctx context.Context,
+	client *authclient.Client,
+) error {
+	if c.revocationType != "x509" {
+		return trace.BadParameter("only x509 revocations are supported")
+	}
+	normalizedSerial, err := normalizeCertificateSerial(c.revocationSerial)
+	if err != nil {
+		return trace.Wrap(err, "normalizing serial")
+	}
+
+	// Default to a weeks TTL as this aligns with the longest possible TTL of
+	// an issued credential.
+	expiry := time.Now().Add(time.Hour * 24 * 7)
+	if c.revocationExpiry != "" {
+		expiry, err = time.Parse(time.RFC3339, c.revocationExpiry)
+		if err != nil {
+			return trace.Wrap(err, "parsing expiry time")
+		}
+	}
+
+	revocationClient := client.WorkloadIdentityRevocationServiceClient()
+	_, err = revocationClient.CreateWorkloadIdentityX509Revocation(ctx, &workloadidentityv1pb.CreateWorkloadIdentityX509RevocationRequest{
+		WorkloadIdentityX509Revocation: &workloadidentityv1pb.WorkloadIdentityX509Revocation{
+			Kind:    types.KindWorkloadIdentityX509Revocation,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name:    normalizedSerial,
+				Expires: timestamppb.New(expiry),
+			},
+			Spec: &workloadidentityv1pb.WorkloadIdentityX509RevocationSpec{
+				Reason:    c.revocationReason,
+				RevokedAt: timestamppb.Now(),
+			},
+		},
+	})
+	if err != nil {
+		return trace.Wrap(err, "creating revocation")
+	}
+
+	fmt.Fprintf(
+		c.stdout,
+		"Revocation for the X509 certificate with serial %s created\n",
+		normalizedSerial,
+	)
+
+	return nil
+}
+
+func (c *WorkloadIdentityCommand) DeleteRevocation(
+	ctx context.Context,
+	client *authclient.Client,
+) error {
+	if c.revocationType != "x509" {
+		return trace.BadParameter("only x509 revocations are supported")
+	}
+	normalizedSerial, err := normalizeCertificateSerial(c.revocationSerial)
+	if err != nil {
+		return trace.Wrap(err, "normalizing serial")
+	}
+
+	revocationClient := client.WorkloadIdentityRevocationServiceClient()
+	_, err = revocationClient.DeleteWorkloadIdentityX509Revocation(ctx, &workloadidentityv1pb.DeleteWorkloadIdentityX509RevocationRequest{
+		Name: normalizedSerial,
+	})
+	if err != nil {
+		return trace.Wrap(err, "deleting revocation")
+	}
+
+	fmt.Fprintf(
+		c.stdout,
+		"Revocation for the X509 certificate with serial %s deleted\n",
+		normalizedSerial,
+	)
+
+	return nil
+}
+
+func (c *WorkloadIdentityCommand) ListRevocations(
+	ctx context.Context, client *authclient.Client,
+) error {
+	revocationsClient := client.WorkloadIdentityRevocationServiceClient()
+	var revocations []*workloadidentityv1pb.WorkloadIdentityX509Revocation
+	req := &workloadidentityv1pb.ListWorkloadIdentityX509RevocationsRequest{}
+	for {
+		resp, err := revocationsClient.ListWorkloadIdentityX509Revocations(ctx, req)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		revocations = append(
+			revocations, resp.WorkloadIdentityX509Revocations...,
+		)
+		if resp.NextPageToken == "" {
+			break
+		}
+		req.PageToken = resp.NextPageToken
+	}
+
+	if c.format == teleport.Text {
+		if len(revocations) == 0 {
+			fmt.Fprintln(c.stdout, "No revocations configured")
+			return nil
+		}
+		t := asciitable.MakeTable([]string{"Type", "Serial", "Revoked At", "Expires At", "Reason"})
+		for _, u := range revocations {
+			expiryTime := u.GetMetadata().GetExpires().AsTime()
+			t.AddRow([]string{
+				"x509",
+				u.GetMetadata().GetName(),
+				u.GetSpec().GetRevokedAt().AsTime().Format(time.RFC3339),
+				fmt.Sprintf(
+					"%s (%s)",
+					expiryTime.Format(time.RFC3339),
+					expiryTime.Sub(time.Now()).Truncate(time.Second).String(),
+				),
+				u.GetSpec().GetReason(),
+			})
+		}
+		fmt.Fprintln(c.stdout, t.AsBuffer().String())
+	} else {
+		converted := []types.Resource{}
+		for _, resource := range revocations {
+			converted = append(converted, types.ProtoResource153ToLegacy(resource))
+		}
+		err := utils.WriteJSONArray(c.stdout, converted)
+		if err != nil {
+			return trace.Wrap(err, "failed to marshal revocations")
 		}
 	}
 	return nil

--- a/tool/tctl/common/workload_identity_command.go
+++ b/tool/tctl/common/workload_identity_command.go
@@ -58,6 +58,9 @@ type WorkloadIdentityCommand struct {
 	revocationSerial string
 	revocationReason string
 	revocationExpiry string
+	revokedAt        string
+
+	now func() time.Time
 
 	stdout io.Writer
 }
@@ -107,8 +110,8 @@ func (c *WorkloadIdentityCommand) Initialize(
 		StringVar(&c.revocationReason)
 	c.revocationsAddCmd.
 		Flag(
-			"expiry",
-			"Time that the revocation should expire, usually this should match the expiry time of the credential. This should be specified using RFC3339 e.g 2024-02-05T15:04:00Z. If unspecified, the time 1 week from now is used.").
+			"expires-at",
+			"Time that the revocation should expire, usually this should match the expiry time of the credential. This should be specified using RFC3339 e.g '2024-02-05T15:04:00Z'. If unspecified, the time 1 week from now is used.").
 		StringVar(&c.revocationExpiry)
 
 	c.revocationsRmCmd = revocationsCmd.Command("rm", "Delete a revocation.")
@@ -127,6 +130,9 @@ func (c *WorkloadIdentityCommand) Initialize(
 
 	if c.stdout == nil {
 		c.stdout = os.Stdout
+	}
+	if c.now == nil {
+		c.now = time.Now
 	}
 }
 
@@ -235,6 +241,8 @@ func normalizeCertificateSerial(str string) (string, error) {
 	return value.Text(16), nil
 }
 
+// AddRevocation creates a new revocation. Currently, only the X509 type is
+// supported.
 func (c *WorkloadIdentityCommand) AddRevocation(
 	ctx context.Context,
 	client *authclient.Client,
@@ -249,11 +257,11 @@ func (c *WorkloadIdentityCommand) AddRevocation(
 
 	// Default to a weeks TTL as this aligns with the longest possible TTL of
 	// an issued credential.
-	expiry := time.Now().Add(time.Hour * 24 * 7)
+	expiry := c.now().Add(time.Hour * 24 * 7)
 	if c.revocationExpiry != "" {
 		expiry, err = time.Parse(time.RFC3339, c.revocationExpiry)
 		if err != nil {
-			return trace.Wrap(err, "parsing expiry time")
+			return trace.Wrap(err, "parsing expires-at time")
 		}
 	}
 
@@ -268,7 +276,7 @@ func (c *WorkloadIdentityCommand) AddRevocation(
 			},
 			Spec: &workloadidentityv1pb.WorkloadIdentityX509RevocationSpec{
 				Reason:    c.revocationReason,
-				RevokedAt: timestamppb.Now(),
+				RevokedAt: timestamppb.New(c.now()),
 			},
 		},
 	})
@@ -285,6 +293,8 @@ func (c *WorkloadIdentityCommand) AddRevocation(
 	return nil
 }
 
+// DeleteRevocation deletes a revocation. Currently, only the X509 type is
+// supported.
 func (c *WorkloadIdentityCommand) DeleteRevocation(
 	ctx context.Context,
 	client *authclient.Client,
@@ -314,6 +324,8 @@ func (c *WorkloadIdentityCommand) DeleteRevocation(
 	return nil
 }
 
+// ListRevocations lists the existing X509 revocations, and can display them as
+// a table or as YAML.
 func (c *WorkloadIdentityCommand) ListRevocations(
 	ctx context.Context, client *authclient.Client,
 ) error {
@@ -350,7 +362,7 @@ func (c *WorkloadIdentityCommand) ListRevocations(
 				fmt.Sprintf(
 					"%s (%s)",
 					expiryTime.Format(time.RFC3339),
-					expiryTime.Sub(time.Now()).Truncate(time.Second).String(),
+					expiryTime.Sub(c.now()).Truncate(time.Second).String(),
 				),
 				u.GetSpec().GetReason(),
 			})

--- a/tool/tctl/common/workload_identity_test.go
+++ b/tool/tctl/common/workload_identity_test.go
@@ -20,13 +20,17 @@ package common
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"gopkg.in/yaml.v3"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
@@ -44,6 +48,9 @@ func runWorkloadIdentityCommand(
 	var stdoutBuf bytes.Buffer
 	cmd := &WorkloadIdentityCommand{
 		stdout: &stdoutBuf,
+		now: func() time.Time {
+			return time.Date(2024, 2, 5, 15, 4, 0, 0, time.UTC)
+		},
 	}
 	return &stdoutBuf, runCommand(t, clt, cmd, args)
 }
@@ -159,5 +166,133 @@ spec:
 
 		resources := mustDecodeJSON[[]*workloadidentityv1pb.WorkloadIdentity](t, buf)
 		require.Empty(t, resources)
+	})
+}
+
+func TestWorkloadIdentityRevocation(t *testing.T) {
+	t.Parallel()
+
+	process := testenv.MakeTestServer(t, testenv.WithLogger(utils.NewSlogLoggerForTests()))
+	rootClient := testenv.MakeDefaultAuthClient(t, process)
+
+	t.Run("workload-identity revocations ls empty", func(t *testing.T) {
+		buf, err := runWorkloadIdentityCommand(
+			t, rootClient, []string{
+				"workload-identity", "revocations", "ls",
+			},
+		)
+		require.NoError(t, err)
+		if golden.ShouldSet() {
+			golden.Set(t, buf.Bytes())
+		}
+		require.Equal(t, string(golden.Get(t)), buf.String())
+	})
+
+	t.Run("get list empty", func(t *testing.T) {
+		buf, err := runResourceCommand(
+			t, rootClient, []string{
+				"get",
+				types.KindWorkloadIdentityX509Revocation,
+				"--format=json",
+			},
+		)
+		require.NoError(t, err)
+		require.Equal(t, "[]", buf.String())
+	})
+
+	t.Run("workload-identity revocations add", func(t *testing.T) {
+		buf, err := runWorkloadIdentityCommand(
+			t, rootClient, []string{
+				"workload-identity",
+				"revocations",
+				"add",
+				"--type=x509",
+				"--serial=aa:bb:cc:dd",
+				"--reason=compromised",
+				"--expires-at=2030-02-24T15:04:00Z",
+			},
+		)
+		require.NoError(t, err)
+		if golden.ShouldSet() {
+			golden.Set(t, buf.Bytes())
+		}
+		require.Equal(t, string(golden.Get(t)), buf.String())
+	})
+
+	t.Run("workload-identity revocations ls with value", func(t *testing.T) {
+		buf, err := runWorkloadIdentityCommand(
+			t, rootClient, []string{
+				"workload-identity", "revocations", "ls",
+			},
+		)
+		require.NoError(t, err)
+		if golden.ShouldSet() {
+			golden.Set(t, buf.Bytes())
+		}
+		require.Equal(t, string(golden.Get(t)), buf.String())
+	})
+
+	t.Run("get list with value", func(t *testing.T) {
+		buf, err := runResourceCommand(
+			t, rootClient, []string{
+				"get",
+				types.KindWorkloadIdentityX509Revocation,
+				"--format=json",
+			},
+		)
+		require.NoError(t, err)
+
+		resources := mustDecodeJSON[[]json.RawMessage](t, buf)
+		require.Len(t, resources, 1)
+		resource := &workloadidentityv1pb.WorkloadIdentityX509Revocation{}
+		err = protojson.Unmarshal(resources[0], resource)
+		require.NoError(t, err)
+
+		require.Empty(t, cmp.Diff(
+			&workloadidentityv1pb.WorkloadIdentityX509Revocation{
+				Kind:    types.KindWorkloadIdentityX509Revocation,
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name:    "aabbccdd",
+					Expires: timestamppb.New(time.Date(2030, 2, 24, 15, 4, 0, 0, time.UTC)),
+				},
+				Spec: &workloadidentityv1pb.WorkloadIdentityX509RevocationSpec{
+					Reason:    "compromised",
+					RevokedAt: timestamppb.New(time.Date(2024, 2, 5, 15, 4, 0, 0, time.UTC)),
+				},
+			},
+			resource,
+			protocmp.Transform(),
+			protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
+		))
+	})
+
+	t.Run("workload-identity revocations rm", func(t *testing.T) {
+		buf, err := runWorkloadIdentityCommand(
+			t, rootClient, []string{
+				"workload-identity",
+				"revocations",
+				"rm",
+				"--serial=aa:bb:cc:dd",
+				"--type=x509",
+			},
+		)
+		require.NoError(t, err)
+		if golden.ShouldSet() {
+			golden.Set(t, buf.Bytes())
+		}
+		require.Equal(t, string(golden.Get(t)), buf.String())
+	})
+
+	t.Run("get list empty after delete", func(t *testing.T) {
+		buf, err := runResourceCommand(
+			t, rootClient, []string{
+				"get",
+				types.KindWorkloadIdentityX509Revocation,
+				"--format=json",
+			},
+		)
+		require.NoError(t, err)
+		require.Equal(t, "[]", buf.String())
 	})
 }


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport/issues/51504

Adds the `tctl workload-identity revocations` family of commands for creating, deleting and listing revocations.