### PR TITLE
Move IsFIPSDisabledByEnv to lib/utils/aws/awsfips

### DIFF
--- a/lib/utils/aws/awsfips/fips_disabled.go
+++ b/lib/utils/aws/awsfips/fips_disabled.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package aws
+package awsfips
 
 import (
 	"os"

--- a/lib/utils/aws/dynamodbutils/dynamo.go
+++ b/lib/utils/aws/dynamodbutils/dynamo.go
@@ -18,13 +18,13 @@ package dynamodbutils
 
 import (
 	"github.com/gravitational/teleport/lib/modules"
-	awsutils "github.com/gravitational/teleport/lib/utils/aws"
+	"github.com/gravitational/teleport/lib/utils/aws/awsfips"
 )
 
 // IsFIPSEnabled returns true if FIPS should be enabled for DynamoDB.
 // FIPS is enabled is the binary is boring ([modules.Modules.IsBoringBinary])
 // and if FIPS is not disabled by the environment
-// ([awsutils.IsFIPSDisabledByEnv]).
+// ([awsfips.IsFIPSDisabledByEnv]).
 func IsFIPSEnabled() bool {
-	return !awsutils.IsFIPSDisabledByEnv() && modules.GetModules().IsBoringBinary()
+	return !awsfips.IsFIPSDisabledByEnv() && modules.GetModules().IsBoringBinary()
 }

--- a/lib/utils/aws/iamutils/iam.go
+++ b/lib/utils/aws/iamutils/iam.go
@@ -20,15 +20,15 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 
-	awsutils "github.com/gravitational/teleport/lib/utils/aws"
+	"github.com/gravitational/teleport/lib/utils/aws/awsfips"
 )
 
 // NewFromConfig wraps [iam.NewFromConfig] and applies FIPS settings
 // according to environment variables.
 //
-// See [awsutils.IsFIPSDisabledByEnv].
+// See [awsfips.IsFIPSDisabledByEnv].
 func NewFromConfig(cfg aws.Config, optFns ...func(*iam.Options)) *iam.Client {
-	if awsutils.IsFIPSDisabledByEnv() {
+	if awsfips.IsFIPSDisabledByEnv() {
 		// append so it overrides any preceding settings.
 		optFns = append(optFns, func(opts *iam.Options) {
 			opts.EndpointOptions.UseFIPSEndpoint = aws.FIPSEndpointStateDisabled

--- a/lib/utils/aws/stsutils/sts.go
+++ b/lib/utils/aws/stsutils/sts.go
@@ -20,15 +20,15 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 
-	awsutils "github.com/gravitational/teleport/lib/utils/aws"
+	"github.com/gravitational/teleport/lib/utils/aws/awsfips"
 )
 
 // NewFromConfig wraps [sts.NewFromConfig] and applies FIPS settings
 // according to environment variables.
 //
-// See [awsutils.IsFIPSDisabledByEnv].
+// See [awsfips.IsFIPSDisabledByEnv].
 func NewFromConfig(cfg aws.Config, optFns ...func(*sts.Options)) *sts.Client {
-	if awsutils.IsFIPSDisabledByEnv() {
+	if awsfips.IsFIPSDisabledByEnv() {
 		// append so it overrides any preceding settings.
 		optFns = append(optFns, func(opts *sts.Options) {
 			opts.EndpointOptions.UseFIPSEndpoint = aws.FIPSEndpointStateDisabled

--- a/lib/utils/aws/stsutils/sts_v1.go
+++ b/lib/utils/aws/stsutils/sts_v1.go
@@ -21,15 +21,15 @@ import (
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/service/sts"
 
-	awsutils "github.com/gravitational/teleport/lib/utils/aws"
+	"github.com/gravitational/teleport/lib/utils/aws/awsfips"
 )
 
 // NewV1 wraps [sts.New] and applies FIPS settings according to environment
 // variables.
 //
-// See [awsutils.IsFIPSDisabledByEnv].
+// See [awsfips.IsFIPSDisabledByEnv].
 func NewV1(p client.ConfigProvider, cfgs ...*aws.Config) *sts.STS {
-	if awsutils.IsFIPSDisabledByEnv() {
+	if awsfips.IsFIPSDisabledByEnv() {
 		// append so it overrides any preceding settings.
 		cfgs = append(cfgs, aws.NewConfig().WithUseFIPSEndpoint(false))
 	}

--- a/lib/utils/aws/stsutils/stscreds_v1.go
+++ b/lib/utils/aws/stsutils/stscreds_v1.go
@@ -22,19 +22,19 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 
-	awsutils "github.com/gravitational/teleport/lib/utils/aws"
+	"github.com/gravitational/teleport/lib/utils/aws/awsfips"
 )
 
 // NewCredentialsV1 wraps [stscreds.NewCredentials] and applies FIPS settings
 // according to environment variables.
 //
-// See [awsutils.IsFIPSDisabledByEnv].
+// See [awsfips.IsFIPSDisabledByEnv].
 func NewCredentialsV1(
 	c client.ConfigProvider,
 	roleARN string,
 	options ...func(*stscreds.AssumeRoleProvider),
 ) *credentials.Credentials {
-	if awsutils.IsFIPSDisabledByEnv() {
+	if awsfips.IsFIPSDisabledByEnv() {
 		c = fipsDisabledProvider{provider: c}
 	}
 	return stscreds.NewCredentials(c, roleARN, options...)


### PR DESCRIPTION
Avoid an import cycle between lib/utils/aws/stsutils (and any other utils package) and lib/utils/aws.

The cycle doesn't happen in master, but it will happen in release branches. This PR helps to keep the code in sync.