### PR TITLE
[v16] Read `~/.tsh/environment` as the target user

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -549,13 +549,16 @@ const (
 	// RemoteCommandFailure is returned when a command has failed to execute and
 	// we don't have another status code for it.
 	RemoteCommandFailure = 255
-	// HomeDirNotFound is returned when a the "teleport checkhomedir" command cannot
+	// HomeDirNotFound is returned when the "teleport checkhomedir" command cannot
 	// find the user's home directory.
 	HomeDirNotFound = 254
-	// HomeDirNotAccessible is returned when a the "teleport checkhomedir" command has
+	// HomeDirNotAccessible is returned when the "teleport checkhomedir" command has
 	// found the user's home directory, but the user does NOT have permissions to
 	// access it.
 	HomeDirNotAccessible = 253
+	// UnexpectedCredentials is returned when a command is no longer running with the expected
+	// credentials.
+	UnexpectedCredentials = 252
 )
 
 // MaxEnvironmentFileLines is the maximum number of lines in a environment file.

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -865,7 +865,7 @@ func RunAndExit(commandType string) {
 // IsReexec determines if the current process is a teleport reexec command.
 // Used by tests to reroute the execution to RunAndExit.
 func IsReexec() bool {
-	if len(os.Args) == 2 {
+	if len(os.Args) >= 2 {
 		switch os.Args[1] {
 		case teleport.ExecSubCommand, teleport.LocalForwardSubCommand, teleport.RemoteForwardSubCommand,
 			teleport.CheckHomeDirSubCommand, teleport.ParkSubCommand, teleport.SFTPSubCommand:
@@ -874,6 +874,59 @@ func IsReexec() bool {
 	}
 
 	return false
+}
+
+// openFileAsUser opens a file as the given user to ensure proper access checks. This is unsafe and should not be used outside of
+// bootstrapping reexec commands.
+func openFileAsUser(localUser *user.User, path string) (file *os.File, err error) {
+	if os.Args[1] != teleport.ExecSubCommand {
+		return nil, trace.Errorf("opening files as a user is only possible in a reexec context")
+	}
+
+	uid, err := strconv.Atoi(localUser.Uid)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	gid, err := strconv.Atoi(localUser.Gid)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	prevUID := os.Geteuid()
+	prevGID := os.Getegid()
+
+	defer func() {
+		gidErr := syscall.Setegid(prevGID)
+		uidErr := syscall.Seteuid(prevUID)
+		if uidErr != nil || gidErr != nil {
+			file.Close()
+			slog.ErrorContext(context.Background(), "cannot proceed with invalid effective credentials", "uid_err", uidErr, "gid_err", gidErr, "error", err)
+			os.Exit(teleport.UnexpectedCredentials)
+		}
+	}()
+
+	if err := syscall.Setegid(gid); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := syscall.Seteuid(uid); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	file, err = utils.OpenFileNoUnsafeLinks(path)
+	return file, trace.Wrap(err)
+}
+
+func readUserEnv(localUser *user.User, path string) ([]string, error) {
+	file, err := openFileAsUser(localUser, path)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer file.Close()
+
+	envs, err := envutils.ReadEnvironment(context.Background(), file)
+	return envs, trace.Wrap(err)
 }
 
 // buildCommand constructs a command that will execute the users shell. This
@@ -944,12 +997,13 @@ func buildCommand(c *ExecCommand, localUser *user.User, tty *os.File, pamEnviron
 	// and pass environment variables along to new session.
 	// User controlled values are added last to ensure administrator controlled sources take priority (duplicates ignored)
 	if c.PermitUserEnvironment {
-		filename := filepath.Join(localUser.HomeDir, ".tsh", "environment")
-		userEnvs, err := envutils.ReadEnvironmentFile(filename)
+		path := filepath.Join(localUser.HomeDir, ".tsh", "environment")
+		userEnvs, err := readUserEnv(localUser, path)
 		if err != nil {
-			return nil, trace.Wrap(err)
+			slog.WarnContext(context.Background(), "Could not read user environment", "error", err)
+		} else {
+			env.AddFullUnique(userEnvs...)
 		}
-		env.AddFullUnique(userEnvs...)
 	}
 
 	// after environment is fully built, set it to cmd

--- a/lib/utils/envutils/environment.go
+++ b/lib/utils/envutils/environment.go
@@ -20,12 +20,14 @@ package envutils
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/utils"
@@ -39,15 +41,15 @@ func ReadEnvironmentFile(filename string) ([]string, error) {
 	// having this file for the user is optional.
 	file, err := utils.OpenFileNoUnsafeLinks(filename)
 	if err != nil {
-		log.Warnf("Unable to open environment file %v: %v, skipping", filename, err)
+		slog.WarnContext(context.TODO(), "Unable to open environment file, skipping", "filename", filename, "error", err)
 		return []string{}, nil
 	}
 	defer file.Close()
 
-	return readEnvironment(file)
+	return ReadEnvironment(context.TODO(), file)
 }
 
-func readEnvironment(r io.Reader) ([]string, error) {
+func ReadEnvironment(ctx context.Context, r io.Reader) ([]string, error) {
 	var lineno int
 	env := &SafeEnv{}
 
@@ -59,7 +61,7 @@ func readEnvironment(r io.Reader) ([]string, error) {
 		// https://github.com/openssh/openssh-portable/blob/master/session.c#L873-L874
 		lineno = lineno + 1
 		if lineno > teleport.MaxEnvironmentFileLines {
-			log.Warnf("Too many lines in environment file, returning first %v lines", teleport.MaxEnvironmentFileLines)
+			slog.WarnContext(ctx, "Too many lines in environment file, returning truncated lines", "lines", teleport.MaxEnvironmentFileLines)
 			return *env, nil
 		}
 
@@ -71,7 +73,7 @@ func readEnvironment(r io.Reader) ([]string, error) {
 		// split on first =, if not found, log it and continue
 		idx := strings.Index(line, "=")
 		if idx == -1 {
-			log.Debugf("Bad line %v while reading environment file: no = separator found", lineno)
+			slog.DebugContext(ctx, "Bad line while reading environment file: no = separator found", "line_num", lineno)
 			continue
 		}
 
@@ -79,7 +81,7 @@ func readEnvironment(r io.Reader) ([]string, error) {
 		key := line[:idx]
 		value := line[idx+1:]
 		if strings.TrimSpace(key) == "" {
-			log.Debugf("Bad line %v while reading environment file: key without name", lineno)
+			slog.DebugContext(ctx, "Bad line while reading environment file: key without name", "line_num", lineno)
 			continue
 		}
 
@@ -88,8 +90,8 @@ func readEnvironment(r io.Reader) ([]string, error) {
 	}
 
 	if err := scanner.Err(); err != nil {
-		log.Warnf("Unable to read environment file: %v", err)
-		return []string{}, nil
+		slog.ErrorContext(ctx, "Unable to read environment file", "error", err)
+		return []string{}, trace.Wrap(err, "reading environment file")
 	}
 
 	return *env, nil

--- a/lib/utils/envutils/environment_test.go
+++ b/lib/utils/envutils/environment_test.go
@@ -20,6 +20,7 @@ package envutils
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -27,6 +28,7 @@ import (
 
 func TestReadEnvironment(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	// contents of environment file
 	rawenv := []byte(`
@@ -42,7 +44,7 @@ bar=foo
 LD_PRELOAD=attack
 `)
 
-	env, err := readEnvironment(bytes.NewReader(rawenv))
+	env, err := ReadEnvironment(ctx, bytes.NewReader(rawenv))
 	require.NoError(t, err)
 
 	// check we parsed it correctly


### PR DESCRIPTION
This PR adds a readfile sub-command that can be reexec'd in order to read a file as a target user. This is useful in cases where we need to do some processing on file contents as root, but we want to make sure the target user has access to the file at the time of reading it (e.g. to prevent arbitrary file reads as root on behalf of the user). It works by passing an os.Pipe to the subcommand in order to send the file contents back to the parent process. To support future use cases, ProcessFileAsUser is generic and accepts a process() callback responsible for reading file contents from an io.Reader and marshaling into some type T.

changelog: Fixed security issue with arbitrary file reads on SSH nodes.