### PR TITLE
[v14] Read `~/.tsh/environment` as the target user

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -523,13 +523,16 @@ const (
 	// RemoteCommandFailure is returned when a command has failed to execute and
 	// we don't have another status code for it.
 	RemoteCommandFailure = 255
-	// HomeDirNotFound is returned when a the "teleport checkhomedir" command cannot
+	// HomeDirNotFound is returned when the "teleport checkhomedir" command cannot
 	// find the user's home directory.
 	HomeDirNotFound = 254
-	// HomeDirNotAccessible is returned when a the "teleport checkhomedir" command has
+	// HomeDirNotAccessible is returned when the "teleport checkhomedir" command has
 	// found the user's home directory, but the user does NOT have permissions to
 	// access it.
 	HomeDirNotAccessible = 253
+	// UnexpectedCredentials is returned when a command is no longer running with the expected
+	// credentials.
+	UnexpectedCredentials = 252
 )
 
 // MaxEnvironmentFileLines is the maximum number of lines in a environment file.

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"os"
 	"os/exec"
@@ -771,7 +772,7 @@ func RunAndExit(commandType string) {
 // IsReexec determines if the current process is a teleport reexec command.
 // Used by tests to reroute the execution to RunAndExit.
 func IsReexec() bool {
-	if len(os.Args) == 2 {
+	if len(os.Args) >= 2 {
 		switch os.Args[1] {
 		case teleport.ExecSubCommand, teleport.ForwardSubCommand, teleport.CheckHomeDirSubCommand,
 			teleport.ParkSubCommand, teleport.SFTPSubCommand:
@@ -780,6 +781,59 @@ func IsReexec() bool {
 	}
 
 	return false
+}
+
+// openFileAsUser opens a file as the given user to ensure proper access checks. This is unsafe and should not be used outside of
+// bootstrapping reexec commands.
+func openFileAsUser(localUser *user.User, path string) (file *os.File, err error) {
+	if os.Args[1] != teleport.ExecSubCommand {
+		return nil, trace.Errorf("opening files as a user is only possible in a reexec context")
+	}
+
+	uid, err := strconv.Atoi(localUser.Uid)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	gid, err := strconv.Atoi(localUser.Gid)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	prevUID := os.Geteuid()
+	prevGID := os.Getegid()
+
+	defer func() {
+		gidErr := syscall.Setegid(prevGID)
+		uidErr := syscall.Seteuid(prevUID)
+		if uidErr != nil || gidErr != nil {
+			file.Close()
+			slog.ErrorContext(context.Background(), "cannot proceed with invalid effective credentials", "uid_err", uidErr, "gid_err", gidErr, "error", err)
+			os.Exit(teleport.UnexpectedCredentials)
+		}
+	}()
+
+	if err := syscall.Setegid(gid); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := syscall.Seteuid(uid); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	file, err = utils.OpenFileNoUnsafeLinks(path)
+	return file, trace.Wrap(err)
+}
+
+func readUserEnv(localUser *user.User, path string) ([]string, error) {
+	file, err := openFileAsUser(localUser, path)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer file.Close()
+
+	envs, err := envutils.ReadEnvironment(context.Background(), file)
+	return envs, trace.Wrap(err)
 }
 
 // buildCommand constructs a command that will execute the users shell. This
@@ -850,12 +904,13 @@ func buildCommand(c *ExecCommand, localUser *user.User, tty *os.File, pamEnviron
 	// and pass environment variables along to new session.
 	// User controlled values are added last to ensure administrator controlled sources take priority (duplicates ignored)
 	if c.PermitUserEnvironment {
-		filename := filepath.Join(localUser.HomeDir, ".tsh", "environment")
-		userEnvs, err := envutils.ReadEnvironmentFile(filename)
+		path := filepath.Join(localUser.HomeDir, ".tsh", "environment")
+		userEnvs, err := readUserEnv(localUser, path)
 		if err != nil {
-			return nil, trace.Wrap(err)
+			slog.WarnContext(context.Background(), "Could not read user environment", "error", err)
+		} else {
+			env.AddFullUnique(userEnvs...)
 		}
-		env.AddFullUnique(userEnvs...)
 	}
 
 	// after environment is fully built, set it to cmd

--- a/lib/utils/envutils/environment_test.go
+++ b/lib/utils/envutils/environment_test.go
@@ -17,6 +17,7 @@ package envutils
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -24,6 +25,7 @@ import (
 
 func TestReadEnvironment(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	// contents of environment file
 	rawenv := []byte(`
@@ -39,7 +41,7 @@ bar=foo
 LD_PRELOAD=attack
 `)
 
-	env, err := readEnvironment(bytes.NewReader(rawenv))
+	env, err := ReadEnvironment(ctx, bytes.NewReader(rawenv))
 	require.NoError(t, err)
 
 	// check we parsed it correctly


### PR DESCRIPTION
This PR adds a readfile sub-command that can be reexec'd in order to read a file as a target user. This is useful in cases where we need to do some processing on file contents as root, but we want to make sure the target user has access to the file at the time of reading it (e.g. to prevent arbitrary file reads as root on behalf of the user). It works by passing an os.Pipe to the subcommand in order to send the file contents back to the parent process. To support future use cases, ProcessFileAsUser is generic and accepts a process() callback responsible for reading file contents from an io.Reader and marshaling into some type T.

changelog: Fixed security issue with arbitrary file reads on SSH nodes.