### PR TITLE
Remove Scheduled Upgrades moving notice

### DIFF
--- a/web/packages/teleport/src/Support/Support.tsx
+++ b/web/packages/teleport/src/Support/Support.tsx
@@ -96,27 +96,6 @@ export const Support = ({
           {isEnterprise && !cfg.isCloud && licenseExpiryDateText && (
             <DataItem title="License Expiry" data={licenseExpiryDateText} />
           )}
-          {isCloud && (
-            <Flex mt="5">
-              <Icons.Info mr="2" />
-              <Text>
-                Looking for{' '}
-                <Text
-                  fontWeight={'bold'}
-                  css={`
-                    display: inline;
-                  `}
-                >
-                  Scheduled Upgrades?
-                </Text>{' '}
-                It is now in{' '}
-                <Link to={cfg.getManageClusterRoute(clusterId)}>
-                  Cluster Management
-                </Link>{' '}
-                page.
-              </Text>
-            </Flex>
-          )}
         </StyledRow>
       </StyledMultiRowBox>
       <MobileSeparator />


### PR DESCRIPTION
Revert https://github.com/gravitational/teleport/pull/49404

The scheduled upgrades page is going to be added back to the Help & Support page where this exists.

more info https://github.com/gravitational/teleport.e/pull/6062