### PR TITLE
[v15] Use `pg_temp` to store PostgreSQL auto provisioning procedures

### DIFF
--- a/lib/srv/db/postgres/sql/activate-user.sql
+++ b/lib/srv/db/postgres/sql/activate-user.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE PROCEDURE teleport_activate_user(username varchar, roles varchar[])
+CREATE OR REPLACE PROCEDURE pg_temp.teleport_activate_user(username varchar, roles varchar[])
 LANGUAGE plpgsql
 AS $$
 DECLARE
@@ -22,7 +22,7 @@ BEGIN
         -- Otherwise reactivate the user, but first strip if of all roles to
         -- account for scenarios with left-over roles if database agent crashed
         -- and failed to cleanup upon session termination.
-        CALL teleport_deactivate_user(username);
+        CALL pg_temp.teleport_deactivate_user(username);
         EXECUTE FORMAT('ALTER USER %I WITH LOGIN', username);
     ELSE
         EXECUTE FORMAT('CREATE USER %I IN ROLE "teleport-auto-user"', username);

--- a/lib/srv/db/postgres/sql/deactivate-user.sql
+++ b/lib/srv/db/postgres/sql/deactivate-user.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE PROCEDURE teleport_deactivate_user(username varchar)
+CREATE OR REPLACE PROCEDURE pg_temp.teleport_deactivate_user(username varchar)
 LANGUAGE plpgsql
 AS $$
 DECLARE

--- a/lib/srv/db/postgres/sql/delete-user.sql
+++ b/lib/srv/db/postgres/sql/delete-user.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE PROCEDURE teleport_delete_user(username varchar, inout state varchar default 'TP003')
+CREATE OR REPLACE PROCEDURE pg_temp.teleport_delete_user(username varchar, inout state varchar default 'TP003')
 LANGUAGE plpgsql
 AS $$
 DECLARE
@@ -15,7 +15,7 @@ BEGIN
                 state := 'TP004';
                 -- Drop user/role will fail if user has dependent objects.
                 -- In this scenario, fallback into disabling the user.
-                CALL teleport_deactivate_user(username);
+                CALL pg_temp.teleport_deactivate_user(username);
         END;
     END IF;
 END;$$;

--- a/lib/srv/db/postgres/test.go
+++ b/lib/srv/db/postgres/test.go
@@ -24,6 +24,7 @@ import (
 	"crypto/rand"
 	"crypto/tls"
 	"fmt"
+	"log/slog"
 	"net"
 	"regexp"
 	"strconv"
@@ -36,7 +37,6 @@ import (
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgproto3/v2"
 	"github.com/jackc/pgtype"
-	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -77,13 +77,13 @@ type TestServer struct {
 	listener  net.Listener
 	port      string
 	tlsConfig *tls.Config
-	log       logrus.FieldLogger
+	log       *slog.Logger
 	// queryCount keeps track of the number of queries the server has received.
 	queryCount uint32
 	// parametersCh receives startup message connection parameters.
 	parametersCh chan map[string]string
 	// storedProcedures are the stored procedures created on the server.
-	storedProcedures map[string]string
+	storedProcedures map[string]*storedProcedure
 	// userEventsCh receives user activate/deactivate events.
 	userEventsCh chan UserEvent
 	// userPermissionEventsCh receives user permission change events.
@@ -133,6 +133,12 @@ type UserPermissionEvent struct {
 	Permissions Permissions
 }
 
+// storedProcedure represents a stored procedure.
+type storedProcedure struct {
+	query     string
+	argsCount int
+}
+
 // NewTestServer returns a new instance of a test Postgres server.
 func NewTestServer(config common.TestServerConfig) (svr *TestServer, err error) {
 	err = config.CheckAndSetDefaults()
@@ -160,13 +166,13 @@ func NewTestServer(config common.TestServerConfig) (svr *TestServer, err error) 
 		listener:  config.Listener,
 		port:      port,
 		tlsConfig: tlsConfig,
-		log: logrus.WithFields(logrus.Fields{
-			teleport.ComponentKey: defaults.ProtocolPostgres,
-			"name":                config.Name,
-		}),
+		log: slog.Default().With(
+			teleport.ComponentKey, defaults.ProtocolPostgres,
+			"name", config.Name,
+		),
 		parametersCh:           make(chan map[string]string, 100),
 		pids:                   make(map[uint32]*pidHandle),
-		storedProcedures:       make(map[string]string),
+		storedProcedures:       make(map[string]*storedProcedure),
 		userEventsCh:           make(chan UserEvent, 100),
 		userPermissionEventsCh: make(chan UserPermissionEvent, 100),
 		allowedUsers:           &allowedUsers,
@@ -176,25 +182,24 @@ func NewTestServer(config common.TestServerConfig) (svr *TestServer, err error) 
 
 // Serve starts serving client connections.
 func (s *TestServer) Serve() error {
-	s.log.Debugf("Starting test Postgres server on %v.", s.listener.Addr())
-	defer s.log.Debug("Test Postgres server stopped.")
+	s.log.DebugContext(context.Background(), "Starting test Postgres server.", "address", s.listener.Addr())
+	defer s.log.DebugContext(context.Background(), "Test Postgres server stopped.")
 	for {
 		conn, err := s.listener.Accept()
 		if err != nil {
 			if utils.IsOKNetworkError(err) {
 				return nil
 			}
-			s.log.WithError(err).Error("Failed to accept connection.")
+			s.log.ErrorContext(context.Background(), "Failed to accept connection.", "error", err)
 			continue
 		}
-		s.log.Debug("Accepted connection.")
+		s.log.DebugContext(context.Background(), "Accepted connection.")
 		go func() {
-			defer s.log.Debug("Connection done.")
+			defer s.log.DebugContext(context.Background(), "Connection done.")
 			defer conn.Close()
 			err = s.handleConnection(conn)
 			if err != nil {
-				s.log.Errorf("Failed to handle connection: %v.",
-					trace.DebugReport(err))
+				s.log.ErrorContext(context.Background(), "Failed to handle connection.", "debug_report", trace.DebugReport(err))
 			}
 		}()
 	}
@@ -210,7 +215,7 @@ func (s *TestServer) handleConnection(conn net.Conn) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	s.log.Debugf("Received %#v.", startupMessage)
+	s.log.DebugContext(context.Background(), "Received.", "message", fmt.Sprintf("%#v", startupMessage))
 	switch msg := startupMessage.(type) {
 	case *pgproto3.StartupMessage:
 		return s.handleStartup(client, msg)
@@ -232,7 +237,7 @@ func (s *TestServer) startTLS(conn net.Conn) (*pgproto3.Backend, error) {
 	if _, ok := startupMessage.(*pgproto3.SSLRequest); !ok {
 		return nil, trace.BadParameter("expected *pgproto3.SSLRequest, got: %#v", startupMessage)
 	}
-	s.log.Debugf("Received %#v.", startupMessage)
+	s.log.DebugContext(context.Background(), "Received.", "message", fmt.Sprintf("%#v", startupMessage))
 	// Reply with 'S' to indicate TLS support.
 	if _, err := conn.Write([]byte("S")); err != nil {
 		return nil, trace.Wrap(err)
@@ -293,45 +298,57 @@ func (s *TestServer) handleStartup(client *pgproto3.Backend, startupMessage *pgp
 		switch msg := message.(type) {
 		case *pgproto3.Query:
 			if err := s.handleQuery(client, msg.String, pid); err != nil {
-				s.log.WithError(err).Error("Failed to handle query.")
+				s.log.ErrorContext(context.Background(), "Failed to handle query.", "error", err)
 			}
 		// Following messages are for handling Postgres extended query
 		// protocol flow used by prepared statements.
 		case *pgproto3.Parse:
+			schema, procName, argsCount, ok := processProcedureCall(msg.Query)
+			if ok {
+				if !s.hasProcedure(pid, schema, procName, argsCount) {
+					return trace.BadParameter("procedure %q on schema %q wasn't created before the call for PID %d", procName, schema, pid)
+				}
+
+				switch procName {
+				case activateProcName:
+					if err := s.handleActivateUser(client); err != nil {
+						s.log.ErrorContext(context.Background(), "Failed to handle user activation.", "error", err)
+					}
+				case deleteProcName:
+					if err := s.handleDeactivateUser(client, true); err != nil {
+						s.log.ErrorContext(context.Background(), "Failed to handle user deletion.", "error", err)
+					}
+				case deactivateProcName:
+					if err := s.handleDeactivateUser(client, false); err != nil {
+						s.log.ErrorContext(context.Background(), "Failed to handle user deactivation.", "error", err)
+					}
+				case updatePermissionsProcName:
+					if err := s.handleUpdatePermissions(client); err != nil {
+						s.log.ErrorContext(context.Background(), "Failed to handle user permissions update.", "error", err)
+					}
+				}
+
+				continue
+			}
+
 			switch msg.Query {
-			case activateQuery:
-				if err := s.handleActivateUser(client); err != nil {
-					s.log.WithError(err).Error("Failed to handle user activation.")
-				}
-			case deleteQuery:
-				if err := s.handleDeactivateUser(client, true); err != nil {
-					s.log.WithError(err).Error("Failed to handle user deletion.")
-				}
-			case deactivateQuery:
-				if err := s.handleDeactivateUser(client, false); err != nil {
-					s.log.WithError(err).Error("Failed to handle user deactivation.")
-				}
-			case updatePermissionsQuery:
-				if err := s.handleUpdatePermissions(client); err != nil {
-					s.log.WithError(err).Error("Failed to handle user permissions update.")
-				}
 			case schemaInfoQuery:
 				if err := s.handleSchemaInfo(client); err != nil {
-					s.log.WithError(err).Error("Failed to handle schema info query.")
+					s.log.ErrorContext(context.Background(), "Failed to handle schema info query.", "error", err)
 				}
 			default:
-				s.log.Warnf("Ignoring PARSE message for query %q", msg.Query)
+				s.log.WarnContext(context.Background(), "Ignoring PARSE message", "query", msg.Query)
 			}
 		case *pgproto3.Bind:
 		case *pgproto3.Describe:
 		case *pgproto3.Sync:
 			if err := s.handleSync(client); err != nil {
-				s.log.WithError(err).Error("Failed to handle sync.")
+				s.log.ErrorContext(context.Background(), "Failed to handle sync.", "error", err)
 			}
 		case *pgproto3.Execute:
 			// Execute executes prepared statement.
 			if err := s.handleQuery(client, "", pid); err != nil {
-				s.log.WithError(err).Error("Failed to handle query.")
+				s.log.ErrorContext(context.Background(), "Failed to handle query.", "error", err)
 			}
 		case *pgproto3.Terminate:
 			return nil
@@ -378,7 +395,7 @@ func (s *TestServer) handleQuery(client *pgproto3.Backend, query string, pid uin
 		return trace.Wrap(s.fakeLongRunningQuery(client, pid))
 	}
 	if strings.Contains(strings.ToUpper(query), "CREATE OR REPLACE PROCEDURE") {
-		if err := s.handleCreateStoredProcedure(query); err != nil {
+		if err := s.handleCreateStoredProcedure(query, pid); err != nil {
 			return trace.Wrap(err)
 		}
 	}
@@ -393,7 +410,7 @@ func (s *TestServer) handleQuery(client *pgproto3.Backend, query string, pid uin
 		&pgproto3.ReadyForQuery{},
 	}
 	for _, message := range messages {
-		s.log.Debugf("Sending %#v.", message)
+		s.log.DebugContext(context.Background(), "Sending.", "message", fmt.Sprintf("%#v", message))
 		err := client.Send(message)
 		if err != nil {
 			return trace.Wrap(err)
@@ -402,23 +419,63 @@ func (s *TestServer) handleQuery(client *pgproto3.Backend, query string, pid uin
 	return nil
 }
 
-func (s *TestServer) handleCreateStoredProcedure(query string) error {
+func (s *TestServer) handleCreateStoredProcedure(query string, pid uint32) error {
 	match := storedProcedureRe.FindStringSubmatch(query)
-	if len(match) != 2 {
+	if match == nil {
 		return trace.BadParameter("failed to extract stored procedure name from query")
 	}
 
-	if _, ok := ephemeralProcs[match[1]]; !ok {
-		if _, ok := procs[match[1]]; !ok {
-			return trace.BadParameter("test server doesn't support stored procedure %q", match[1])
+	if _, ok := procs[match[storedProcedureRe.SubexpIndex("ProcName")]]; !ok {
+		return trace.BadParameter("test server doesn't support stored procedure %q", match[1])
+	}
+
+	procName := storedProcedureName(pid, match[storedProcedureRe.SubexpIndex("Schema")], match[storedProcedureRe.SubexpIndex("ProcName")])
+	var argsCount int
+	args := strings.Split(match[storedProcedureRe.SubexpIndex("Args")], ",")
+	for _, arg := range args {
+		// Skip arguments that have a default value.
+		if !strings.Contains(strings.ToLower(arg), "default") {
+			argsCount++
 		}
 	}
 
-	s.log.Debugf("Created stored procedure %q.", match[1])
+	s.log.DebugContext(context.Background(), "Created stored procedure.", "procedure", procName)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.storedProcedures[match[1]] = query
+	s.storedProcedures[procName] = &storedProcedure{query: query, argsCount: argsCount}
 	return nil
+}
+
+func (s *TestServer) hasProcedure(pid uint32, schema, procName string, argsCount int) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	storedProcedure, ok := s.storedProcedures[storedProcedureName(pid, schema, procName)]
+	if !ok {
+		s.log.ErrorContext(context.Background(), "Procedure not found", "procedure", procName, "schema", schema)
+		return false
+	}
+
+	if argsCount != storedProcedure.argsCount {
+		s.log.ErrorContext(context.Background(), "Wrong number of arguments for procedure call", "procedure", procName, "expected_args", storedProcedure.argsCount, "args_provided", argsCount)
+		return false
+	}
+
+	return true
+}
+
+func storedProcedureName(pid uint32, schema, procName string) string {
+	var name string
+	switch strings.ToLower(schema) {
+	case "pg_temp":
+		name = fmt.Sprintf("%d.%s", pid, procName)
+	case "":
+		name = procName
+	default:
+		name = fmt.Sprintf("%s.%s", schema, procName)
+	}
+
+	return strings.ToLower(name)
 }
 
 // multiMessage wraps *pgproto3.DataRow and implements pgproto3.BackendMessage by writing multiple copies of this message in Encode.
@@ -495,7 +552,7 @@ func (s *TestServer) handleBenchmarkQuery(query string, client *pgproto3.Backend
 		return trace.Wrap(err)
 	}
 
-	s.log.Debugf("Responding to query %q, will send %v messages, total length %v", query, repeats, len(mm.payload))
+	s.log.DebugContext(context.Background(), "Responding to query", "query", query, "repeat", repeats, "length", len(mm.payload))
 
 	// preamble
 	err = client.Send(&pgproto3.RowDescription{Fields: []pgproto3.FieldDescription{{Name: []byte("dummy")}}})
@@ -520,7 +577,7 @@ func (s *TestServer) handleBenchmarkQuery(query string, client *pgproto3.Backend
 		return trace.Wrap(err)
 	}
 
-	s.log.Debugf("Finished handling query %q", query)
+	s.log.DebugContext(context.Background(), "Finished handling query", "query", query)
 
 	return nil
 }
@@ -585,7 +642,7 @@ func (s *TestServer) handleActivateUser(client *pgproto3.Backend) error {
 		return trace.Wrap(err)
 	}
 	// Mark the user as active.
-	s.log.Debugf("Activated user %q with roles %v.", name, roles)
+	s.log.DebugContext(context.Background(), "Activated user.", "user", name, "roles", roles)
 	s.userEventsCh <- UserEvent{Name: name, Roles: roles, Active: true}
 	s.allowedUsers.Store(name, struct{}{})
 	return nil
@@ -658,7 +715,7 @@ func (s *TestServer) handleDeactivateUser(client *pgproto3.Backend, sendDeleteRe
 		return trace.Wrap(err)
 	}
 	// Mark the user as active.
-	s.log.Debugf("Deactivated user %q.", name)
+	s.log.DebugContext(context.Background(), "Deactivated user.", "user", name)
 	s.userEventsCh <- UserEvent{Name: name, Active: false}
 	s.allowedUsers.Delete(name)
 	return nil
@@ -724,7 +781,7 @@ func (s *TestServer) handleUpdatePermissions(client *pgproto3.Backend) error {
 		return trace.Wrap(err)
 	}
 	// Mark the user as active.
-	s.log.Debugf("Updated permissions for user %q with permissions %#v.", name, perms)
+	s.log.DebugContext(context.Background(), "Updated permissions for user.", "user", name, "permissions", fmt.Sprintf("%#v", perms))
 	s.userPermissionEventsCh <- UserPermissionEvent{Name: name, Permissions: perms}
 	return nil
 }
@@ -856,7 +913,7 @@ func (s *TestServer) receiveFrontendMessage(client *pgproto3.Backend) (pgproto3.
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	s.log.Debugf("Received %#v.", message)
+	s.log.DebugContext(context.Background(), "Received.", "message", fmt.Sprintf("%#v", message))
 	return message, nil
 }
 
@@ -902,7 +959,7 @@ func getJSONB[T any](formatCode int16, src []byte) (T, error) {
 
 func (s *TestServer) sendMessages(client *pgproto3.Backend, messages ...pgproto3.BackendMessage) error {
 	for _, message := range messages {
-		s.log.Debugf("Sending %#v.", message)
+		s.log.DebugContext(context.Background(), "Sending.", "message", fmt.Sprintf("%#v", message))
 		err := client.Send(message)
 		if err != nil {
 			return trace.Wrap(err)
@@ -926,7 +983,7 @@ func (s *TestServer) fakeLongRunningQuery(client *pgproto3.Backend, pid uint32) 
 		&pgproto3.ReadyForQuery{},
 	}
 	for _, message := range messages {
-		s.log.Debugf("Sending %#v.", message)
+		s.log.DebugContext(context.Background(), "Sending.", "message", fmt.Sprintf("%#v", message))
 		err := client.Send(message)
 		if err != nil {
 			return trace.Wrap(err)
@@ -937,7 +994,7 @@ func (s *TestServer) fakeLongRunningQuery(client *pgproto3.Backend, pid uint32) 
 
 func (s *TestServer) handleSync(client *pgproto3.Backend) error {
 	message := &pgproto3.ReadyForQuery{}
-	s.log.Debugf("Sending %#v.", message)
+	s.log.DebugContext(context.Background(), "Sending.", "message", fmt.Sprintf("%#v", message))
 	err := client.Send(message)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1048,7 +1105,36 @@ const userParameterName = "user"
 
 // storedProcedureRe is the regex for capturing stored procedure name from its
 // creation query.
-var storedProcedureRe = regexp.MustCompile(`(?i)create or replace procedure (.+)\(`)
+var storedProcedureRe = regexp.MustCompile(`(?i)create or replace procedure (?:(?P<Schema>\w+)\.)?(?P<ProcName>.+)\((?P<Args>.+)?\)`)
 
 // selectBenchmarkRe is the regex for capturing the parameters from the select query used for read benchmark.
 var selectBenchmarkRe = regexp.MustCompile(`SELECT \* FROM bench\_(\d+) LIMIT (\d+)`)
+
+// callProcedureRe is the regex for caputuring the schema name, and procedure
+// name from the procedure call query.
+// Examples:
+// - call pg_temp.hello($1)
+// - call pg_temp.hello1()
+// - call pg_temp.hello2($1, $2, $3)
+// - call hello3($1::jsonb)
+var callProcedureRe = regexp.MustCompile(`(?i)^call (?:(?P<Schema>\w+)\.)?(?P<ProcName>\w+)\((?P<Args>.+)?\)`)
+
+// processProcedureCall parses a query and returns the information about the
+// the procedure call.
+// Examples:
+// - create or replace procedure teleport_procedure(username varchar, inout state varchar default 'TP003')
+// - create or replace procedure pg_temp.teleport_procedure(username varchar, inout state varchar default 'TP003')
+// - create or replace procedure pg_temp.teleport_procedure()
+// - create or replace procedure pg_temp.teleport_procedure(permissions_ JSONB)
+func processProcedureCall(query string) (schema string, procName string, argsCount int, ok bool) {
+	procMatches := callProcedureRe.FindStringSubmatch(query)
+	if procMatches == nil {
+		return
+	}
+
+	ok = true
+	schema = procMatches[callProcedureRe.SubexpIndex("Schema")]
+	procName = procMatches[callProcedureRe.SubexpIndex("ProcName")]
+	argsCount = len(strings.Split(procMatches[callProcedureRe.SubexpIndex("Args")], ","))
+	return
+}

--- a/lib/srv/db/postgres/users.go
+++ b/lib/srv/db/postgres/users.go
@@ -77,9 +77,13 @@ func (e *Engine) ActivateUser(ctx context.Context, sessionCtx *common.Session) e
 	// bookkeeping group or stored procedures get deleted or changed offband.
 	logger := e.Log.WithField("user", sessionCtx.DatabaseUser)
 	err = withRetry(ctx, logger, func() error {
-		return trace.Wrap(e.initAutoUsers(ctx, sessionCtx, conn))
+		return trace.Wrap(e.updateAutoUsersRole(ctx, conn, sessionCtx.Database.GetAdminUser().Name))
 	})
 	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := e.createProcedures(ctx, sessionCtx, conn, []string{activateProcName, deactivateProcName}); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -90,8 +94,7 @@ func (e *Engine) ActivateUser(ctx context.Context, sessionCtx *common.Session) e
 
 	logger.WithField("roles", roles).Info("Activating PostgreSQL user")
 	err = withRetry(ctx, logger, func() error {
-		_, err = conn.Exec(ctx, activateQuery, sessionCtx.DatabaseUser, roles)
-		return trace.Wrap(err)
+		return trace.Wrap(e.callProcedure(ctx, sessionCtx, conn, activateProcName, sessionCtx.DatabaseUser, roles))
 	})
 	if err != nil {
 		logger.WithError(err).Debug("Call teleport_activate_user failed.")
@@ -100,13 +103,6 @@ func (e *Engine) ActivateUser(ctx context.Context, sessionCtx *common.Session) e
 		return trace.Wrap(errOut)
 	}
 	e.Audit.OnDatabaseUserCreate(ctx, sessionCtx, nil)
-
-	if err != nil {
-		if strings.Contains(err.Error(), "already exists") {
-			return trace.AlreadyExists("user %q already exists in this PostgreSQL database and is not managed by Teleport", sessionCtx.DatabaseUser)
-		}
-		return trace.Wrap(err)
-	}
 
 	err = e.applyPermissions(ctx, sessionCtx)
 	if err != nil {
@@ -241,22 +237,11 @@ func (e *Engine) applyPermissions(ctx context.Context, sessionCtx *common.Sessio
 		return trace.Wrap(err)
 	}
 
-	// teleport_remove_permissions and teleport_update_permissions are created in pg_temp table of the session database.
-	// teleport_remove_permissions gets called by teleport_update_permissions as needed.
-	_, err = conn.Exec(ctx, removePermissionsProc)
-	if err != nil {
-		e.Log.WithError(err).Errorf("Creating temporary stored procedure %q failed.", removePermissionsProcName)
+	if err := e.createProcedures(ctx, sessionCtx, conn, []string{removePermissionsProcName, updatePermissionsProcName}); err != nil {
 		return trace.Wrap(err)
 	}
 
-	_, err = conn.Exec(ctx, updatePermissionsProc)
-	if err != nil {
-		e.Log.WithError(err).Errorf("Creating temporary stored procedure %q failed.", updatePermissionsProcName)
-		return trace.Wrap(err)
-	}
-
-	_, err = conn.Exec(ctx, updatePermissionsQuery, sessionCtx.DatabaseUser, perms)
-	if err != nil {
+	if err := e.callProcedure(ctx, sessionCtx, conn, updatePermissionsProcName, sessionCtx.DatabaseUser, perms); err != nil {
 		var pgErr *pq.Error
 		if errors.As(err, &pgErr) {
 			if pgErr.Code == common.SQLStatePermissionsChanged {
@@ -271,12 +256,13 @@ func (e *Engine) applyPermissions(ctx context.Context, sessionCtx *common.Sessio
 }
 
 func (e *Engine) removePermissions(ctx context.Context, sessionCtx *common.Session) error {
+	logger := e.Log.WithField("user", sessionCtx.DatabaseUser)
 	if !e.granularPermissionsEnabled(sessionCtx) {
-		e.Log.WithField("user", sessionCtx.DatabaseUser).Info("Granular database permissions not enabled, skipping removal step.")
+		logger.Info("Granular database permissions not enabled, skipping removal step.")
 		return nil
 	}
 
-	e.Log.WithField("user", sessionCtx.DatabaseUser).Info("Removing permissions from PostgreSQL user")
+	logger.Info("Removing permissions from PostgreSQL user")
 	conn, err := e.connectAsAdmin(ctx, sessionCtx, false)
 	if err != nil {
 		return trace.Wrap(err)
@@ -284,15 +270,12 @@ func (e *Engine) removePermissions(ctx context.Context, sessionCtx *common.Sessi
 	defer conn.Close(ctx)
 
 	// teleport_remove_permissions is created in pg_temp table of the session database.
-	_, err = conn.Exec(ctx, removePermissionsProc)
-	if err != nil {
-		e.Log.WithError(err).Errorf("Creating temporary stored procedure %q failed.", removePermissionsProcName)
+	if err := e.createProcedures(ctx, sessionCtx, conn, []string{removePermissionsProcName}); err != nil {
 		return trace.Wrap(err)
 	}
 
-	_, err = conn.Exec(ctx, removePermissionsQuery, sessionCtx.DatabaseUser)
-	if err != nil {
-		e.Log.WithError(err).WithField("user", sessionCtx.DatabaseUser).Error("Removing permissions from user failed.")
+	if err := e.callProcedure(ctx, sessionCtx, conn, removePermissionsProcName, sessionCtx.DatabaseUser); err != nil {
+		logger.WithError(err).Error("Removing permissions from user failed.")
 		return trace.Wrap(err)
 	}
 	return nil
@@ -313,11 +296,14 @@ func (e *Engine) DeactivateUser(ctx context.Context, sessionCtx *common.Session)
 	}
 	defer conn.Close(ctx)
 
+	if err := e.createProcedures(ctx, sessionCtx, conn, []string{deactivateProcName}); err != nil {
+		return trace.Wrap(err)
+	}
+
 	logger := e.Log.WithField("user", sessionCtx.DatabaseUser)
 	logger.Info("Deactivating PostgreSQL user.")
 	err = withRetry(ctx, logger, func() error {
-		_, err = conn.Exec(ctx, deactivateQuery, sessionCtx.DatabaseUser)
-		return trace.Wrap(err)
+		return trace.Wrap(e.callProcedure(ctx, sessionCtx, conn, deactivateProcName, sessionCtx.DatabaseUser))
 	})
 	if err != nil {
 		e.Audit.OnDatabaseUserDeactivate(ctx, sessionCtx, false, err)
@@ -343,6 +329,10 @@ func (e *Engine) DeleteUser(ctx context.Context, sessionCtx *common.Session) err
 	}
 	defer conn.Close(ctx)
 
+	if err := e.createProcedures(ctx, sessionCtx, conn, []string{deleteProcName, deactivateProcName}); err != nil {
+		return trace.Wrap(err)
+	}
+
 	logger := e.Log.WithField("user", sessionCtx.DatabaseUser)
 	logger.Info("Deleting PostgreSQL user.")
 
@@ -352,6 +342,10 @@ func (e *Engine) DeleteUser(ctx context.Context, sessionCtx *common.Session) err
 		case sessionCtx.Database.IsRedshift():
 			return trace.Wrap(e.deleteUserRedshift(ctx, sessionCtx, conn, &state))
 		default:
+			deleteQuery, err := buildCallQuery(sessionCtx, deleteProcName)
+			if err != nil {
+				return trace.Wrap(err)
+			}
 			return trace.Wrap(conn.QueryRow(ctx, deleteQuery, sessionCtx.DatabaseUser).Scan(&state))
 		}
 	})
@@ -381,7 +375,7 @@ func (e *Engine) DeleteUser(ctx context.Context, sessionCtx *common.Session) err
 // into the returned error instead of doing this on state returned (like regular
 // PostgreSQL).
 func (e *Engine) deleteUserRedshift(ctx context.Context, sessionCtx *common.Session, conn *pgx.Conn, state *string) error {
-	_, err := conn.Exec(ctx, deleteQuery, sessionCtx.DatabaseUser)
+	err := e.callProcedure(ctx, sessionCtx, conn, deleteProcName, sessionCtx.DatabaseUser)
 	if err == nil {
 		*state = common.SQLStateUserDropped
 		return nil
@@ -398,10 +392,9 @@ func (e *Engine) deleteUserRedshift(ctx context.Context, sessionCtx *common.Sess
 	return trace.Wrap(err)
 }
 
-// initAutoUsers installs procedures for activating and deactivating users and
-// creates the bookkeeping role for auto-provisioned users.
-func (e *Engine) initAutoUsers(ctx context.Context, sessionCtx *common.Session, conn *pgx.Conn) error {
-	// Create a role/group which all auto-created users will be a part of.
+// updateAutoUsersRole ensures the bookkeeping role for auto-provisioned users
+// is present.
+func (e *Engine) updateAutoUsersRole(ctx context.Context, conn *pgx.Conn, adminUser string) error {
 	_, err := conn.Exec(ctx, fmt.Sprintf("create role %q", teleportAutoUserRole))
 	if err != nil {
 		if !strings.Contains(err.Error(), "already exists") {
@@ -430,7 +423,6 @@ func (e *Engine) initAutoUsers(ctx context.Context, sessionCtx *common.Session, 
 	// support WITH INHERIT FALSE or WITH SET FALSE syntax, so we only specify
 	// WITH ADMIN OPTION.
 	// See: https://www.postgresql.org/docs/16/release-16.html
-	adminUser := sessionCtx.Database.GetAdminUser().Name
 	stmt := fmt.Sprintf("grant %q to %q WITH ADMIN OPTION", teleportAutoUserRole, adminUser)
 	_, err = conn.Exec(ctx, stmt)
 	if err != nil {
@@ -442,14 +434,6 @@ func (e *Engine) initAutoUsers(ctx context.Context, sessionCtx *common.Session, 
 		}
 	}
 
-	// Install stored procedures for creating and disabling database users.
-	for name, sql := range pickProcedures(sessionCtx) {
-		_, err := conn.Exec(ctx, sql)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		e.Log.Debugf("Installed PostgreSQL stored procedure %q.", name)
-	}
 	return nil
 }
 
@@ -466,6 +450,72 @@ func (e *Engine) pgxConnect(ctx context.Context, sessionCtx *common.Session) (*p
 	}
 	pgxConf.Config = *config
 	return pgx.ConnectConfig(ctx, pgxConf)
+}
+
+// callProcedure calls the procedure with the provided arguments.
+func (e *Engine) callProcedure(ctx context.Context, sessionCtx *common.Session, conn *pgx.Conn, procName string, args ...any) error {
+	query, err := buildCallQuery(sessionCtx, procName)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	_, err = conn.Exec(ctx, query, args...)
+	return trace.Wrap(err)
+}
+
+// createProcedures executes the create procedures for the provided list of
+// procedures.
+func (e *Engine) createProcedures(ctx context.Context, sessionCtx *common.Session, conn *pgx.Conn, procNames []string) error {
+	selectedProcs := pickProcedures(sessionCtx)
+
+	for _, procName := range procNames {
+		proc, ok := selectedProcs[procName]
+		if !ok {
+			return trace.NotImplemented("procedure %q is not available for %s databases", procName, sessionCtx.Database.GetType())
+		}
+
+		logger := e.Log.WithField("procedure", procName)
+
+		if _, err := conn.Exec(ctx, proc); err != nil {
+			logger.Error("Failed to install procedure.")
+			return trace.Wrap(err)
+		}
+
+		logger.Debug("Installed procedure.")
+	}
+
+	return nil
+}
+
+// buildCallQuery builds the call query based on the procedure name and session.
+func buildCallQuery(sessionCtx *common.Session, procName string) (string, error) {
+	if _, ok := pickProcedures(sessionCtx)[procName]; !ok {
+		return "", trace.NotImplemented("procedure %q is not available for %s databases", procName, sessionCtx.Database.GetType())
+	}
+
+	var schema string
+	switch {
+	case sessionCtx.Database.IsRedshift():
+		// TODO(gabrielcorado): support customizing the schema the procedures
+		// will be stored on RedShift. For now, let the database decide where
+		// to store them.
+		schema = ""
+	default:
+		// Always use `pg_temp` if the database type supports it. This reduces
+		// the number of permissions required by the admin user.
+		schema = "pg_temp"
+	}
+
+	procCall, ok := procsCall[procName]
+	if !ok {
+		return "", trace.BadParameter("procedure %q doesn't have a call statement", procName)
+	}
+
+	if schema != "" {
+		return fmt.Sprintf("call %s.%s", schema, procCall), nil
+	}
+
+	return "call " + procCall, nil
 }
 
 func prepareRoles(sessionCtx *common.Session) (any, error) {
@@ -518,10 +568,10 @@ const (
 	deleteProcName = "teleport_delete_user"
 	// updatePermissionsProcName is the name of the stored procedure Teleport will use
 	// to automatically update database permissions.
-	updatePermissionsProcName = "pg_temp.teleport_update_permissions"
+	updatePermissionsProcName = "teleport_update_permissions"
 	// removePermissionsProcName is the name of the stored procedure Teleport will use
 	// to automatically remove all database permissions.
-	removePermissionsProcName = "pg_temp.teleport_remove_permissions"
+	removePermissionsProcName = "teleport_remove_permissions"
 	// teleportAutoUserRole is the name of a PostgreSQL role that all Teleport
 	// managed users will be a part of.
 	teleportAutoUserRole = "teleport-auto-user"
@@ -530,18 +580,21 @@ const (
 var (
 	//go:embed sql/activate-user.sql
 	activateProc string
-	// activateQuery is the query for calling user activation procedure.
-	activateQuery = fmt.Sprintf(`call %v($1, $2)`, activateProcName)
+	// activateProcCall contains the procedure name and arguments used to call
+	// the activate user procedure.
+	activateProcCall = fmt.Sprintf(`%v($1, $2)`, activateProcName)
 
 	//go:embed sql/deactivate-user.sql
 	deactivateProc string
-	// deactivateQuery is the query for calling user deactivation procedure.
-	deactivateQuery = fmt.Sprintf(`call %v($1)`, deactivateProcName)
+	// deactivateProcCall contains the procedure name and arguments used to call
+	// the deactivate user procedure.
+	deactivateProcCall = fmt.Sprintf(`%v($1)`, deactivateProcName)
 
 	//go:embed sql/delete-user.sql
 	deleteProc string
-	// deleteQuery is the query for calling user deletion procedure.
-	deleteQuery = fmt.Sprintf(`call %v($1)`, deleteProcName)
+	// deleteProcCall contains the procedure name and arguments used to call
+	// the delete user procedure.
+	deleteProcCall = fmt.Sprintf(`%v($1)`, deleteProcName)
 
 	//go:embed sql/redshift-activate-user.sql
 	redshiftActivateProc string
@@ -552,20 +605,22 @@ var (
 
 	//go:embed sql/update-permissions.sql
 	updatePermissionsProc string
-	// updatePermissionsQuery is the query for calling update permissions procedure.
-	// the procedure is created on demand in the pg_temp table in the session database.
-	updatePermissionsQuery = fmt.Sprintf(`call %v($1, $2::jsonb)`, updatePermissionsProcName)
+	// updatePermissionsProcCall contains the procedure name and arguments used
+	// to call the update permissions procedure.
+	updatePermissionsProcCall = fmt.Sprintf(`%v($1, $2::jsonb)`, updatePermissionsProcName)
 
 	//go:embed sql/remove-permissions.sql
 	removePermissionsProc string
-	// removePermissionsQuery is the query for calling update permissions procedure.
-	// the procedure is created on demand in the pg_temp table in the session database.
-	removePermissionsQuery = fmt.Sprintf(`call %v($1)`, removePermissionsProcName)
+	// removePermissionsProcCall contains the procedure name and arguments used
+	// to call the remove permissions procedure.
+	removePermissionsProcCall = fmt.Sprintf(`%v($1)`, removePermissionsProcName)
 
 	procs = map[string]string{
-		activateProcName:   activateProc,
-		deactivateProcName: deactivateProc,
-		deleteProcName:     deleteProc,
+		activateProcName:          activateProc,
+		deactivateProcName:        deactivateProc,
+		deleteProcName:            deleteProc,
+		updatePermissionsProcName: updatePermissionsProc,
+		removePermissionsProcName: removePermissionsProc,
 	}
 
 	redshiftProcs = map[string]string{
@@ -574,9 +629,13 @@ var (
 		deleteProcName:     redshiftDeleteProc,
 	}
 
-	ephemeralProcs = map[string]string{
-		updatePermissionsProcName: updatePermissionsProc,
-		removePermissionsProcName: removePermissionsProc,
+	// procsCall maps procedures names to their call statements.
+	procsCall = map[string]string{
+		activateProcName:          activateProcCall,
+		deactivateProcName:        deactivateProcCall,
+		deleteProcName:            deleteProcCall,
+		updatePermissionsProcName: updatePermissionsProcCall,
+		removePermissionsProcName: removePermissionsProcCall,
 	}
 )
 


### PR DESCRIPTION
Backports #44255 to branch/v15.

This is to make e2e test backports easier, as the postgres tests now rely on temp tables to test with multiple db admins (each must own the teleport procedures we install).

changelog: Moved PostgreSQL auto provisioning users procedures to pg_temp schema.