### PR TITLE
Web: Fixes handling native fetch response that can result in unexpected errors

### DIFF
--- a/lib/web/git_servers.go
+++ b/lib/web/git_servers.go
@@ -93,5 +93,5 @@ func (h *Handler) gitServerDelete(_ http.ResponseWriter, r *http.Request, p http
 		return nil, trace.Wrap(err)
 	}
 
-	return nil, clt.GitServerClient().DeleteGitServer(r.Context(), name)
+	return OK(), clt.GitServerClient().DeleteGitServer(r.Context(), name)
 }

--- a/lib/web/userevent.go
+++ b/lib/web/userevent.go
@@ -57,7 +57,7 @@ func (h *Handler) createPreUserEventHandle(w http.ResponseWriter, r *http.Reques
 		return nil, trace.Wrap(err)
 	}
 
-	return nil, nil
+	return OK(), nil
 }
 
 // createUserEventHandle sends a user event to the UserEvent service
@@ -91,5 +91,5 @@ func (h *Handler) createUserEventHandle(w http.ResponseWriter, r *http.Request, 
 		return nil, trace.Wrap(err)
 	}
 
-	return nil, nil
+	return OK(), nil
 }

--- a/web/packages/teleport/src/services/api/api.test.ts
+++ b/web/packages/teleport/src/services/api/api.test.ts
@@ -78,6 +78,14 @@ describe('api.fetch', () => {
     });
   });
 
+  test('no json in response', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
+    const resp = await api.fetch('/something');
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+
+    expect(resp).toStrictEqual({ ok: true });
+  });
+
   test('with customOptions', async () => {
     await api.fetch('/something', customOpts);
     expect(mockedFetch).toHaveBeenCalledTimes(1);

--- a/web/packages/teleport/src/services/api/api.ts
+++ b/web/packages/teleport/src/services/api/api.ts
@@ -247,6 +247,13 @@ const api = {
     // native call
     const response = await fetch(url, options);
 
+    // Some api response does not return a body, so there is no JSON
+    // to read.
+    const contentType = response.headers?.get('content-type');
+    if (!contentType || !contentType.includes('application/json')) {
+      return response;
+    }
+
     let json;
     try {
       json = await response.json();

--- a/web/packages/teleport/src/services/api/api.ts
+++ b/web/packages/teleport/src/services/api/api.ts
@@ -151,16 +151,54 @@ const api = {
     mfaResponse?: MfaChallengeResponse
   ): Promise<any> {
     try {
-      return await api.fetch(url, customOptions, mfaResponse);
+      const response = await api.fetch(url, customOptions, mfaResponse);
+      return await api.getJsonFromFetchResponse(response);
     } catch (err) {
       // Retry with MFA if we get an admin action MFA error.
       if (!mfaResponse && isAdminActionRequiresMfaError(err)) {
         mfaResponse = await api.getAdminActionMfaResponse();
-        return api.fetch(url, customOptions, mfaResponse);
+        const response = await api.fetch(url, customOptions, mfaResponse);
+        return await api.getJsonFromFetchResponse(response);
       } else {
         throw err;
       }
     }
+  },
+
+  async getJsonFromFetchResponse(response: Response) {
+    let json;
+    try {
+      json = await response.json();
+    } catch (err) {
+      // error reading JSON
+      const message = response.ok
+        ? err.message
+        : `${response.status} - ${response.url}`;
+      throw new ApiError({ message, response, opts: { cause: err } });
+    }
+
+    if (response.ok) {
+      return json;
+    }
+
+    /** This error can occur in the edge case where a role in the user's certificate was deleted during their session. */
+    const isRoleNotFoundErr = isRoleNotFoundError(parseError(json));
+    if (isRoleNotFoundErr) {
+      websession.logoutWithoutSlo({
+        /* Don't remember location after login, since they may no longer have access to the page they were on. */
+        rememberLocation: false,
+        /* Show "access changed" notice on login page. */
+        withAccessChangedMessage: true,
+      });
+      return;
+    }
+
+    throw new ApiError({
+      message: parseError(json),
+      response,
+      proxyVersion: parseProxyVersion(json),
+      messages: json.messages,
+    });
   },
 
   async getAdminActionMfaResponse() {
@@ -218,12 +256,14 @@ const api = {
    *
    * @param mfaResponse if defined (eg: `fetchJsonWithMfaAuthnRetry`)
    * will add a custom MFA header field that will hold the mfaResponse.
+   *
+   * @returns the native fetch's response object.
    */
   async fetch(
     url: string,
     customOptions: RequestInit = {},
     mfaResponse?: MfaChallengeResponse
-  ) {
+  ): Promise<Response> {
     url = window.location.origin + url;
     const options = {
       ...defaultRequestOptions,
@@ -245,48 +285,7 @@ const api = {
     }
 
     // native call
-    const response = await fetch(url, options);
-
-    // Some api response does not return a body, so there is no JSON
-    // to read.
-    const contentType = response.headers?.get('content-type');
-    if (!contentType || !contentType.includes('application/json')) {
-      return response;
-    }
-
-    let json;
-    try {
-      json = await response.json();
-    } catch (err) {
-      // error reading JSON
-      const message = response.ok
-        ? err.message
-        : `${response.status} - ${response.url}`;
-      throw new ApiError({ message, response, opts: { cause: err } });
-    }
-
-    if (response.ok) {
-      return json;
-    }
-
-    /** This error can occur in the edge case where a role in the user's certificate was deleted during their session. */
-    const isRoleNotFoundErr = isRoleNotFoundError(parseError(json));
-    if (isRoleNotFoundErr) {
-      websession.logoutWithoutSlo({
-        /* Don't remember location after login, since they may no longer have access to the page they were on. */
-        rememberLocation: false,
-        /* Show "access changed" notice on login page. */
-        withAccessChangedMessage: true,
-      });
-      return;
-    }
-
-    throw new ApiError({
-      message: parseError(json),
-      response,
-      proxyVersion: parseProxyVersion(json),
-      messages: json.messages,
-    });
+    return await fetch(url, options);
   },
 };
 


### PR DESCRIPTION
fixes regression introduced by https://github.com/gravitational/teleport/pull/51134

some of the callsite to `api.fetch` expects and handles native fetch response, explained more [here](https://github.com/gravitational/teleport/pull/52154#discussion_r1960439830)

also some of our api responses does not return a body like [here](https://github.com/gravitational/teleport/blob/master/lib/web/userevent.go), and if we try to `response.json()` it throws an error, even though the request itself was successful

previously, the `api.fetch` definition was just returning native fetch call but ^ PR changed it to also read JSON 

we should ideally be returning [OK json response](https://github.com/gravitational/teleport/blob/master/lib/web/apiserver.go#L5068), but some of it has slipped and i don't think there is too many

example of error on a success fetch:
<img width="729" alt="image" src="https://github.com/user-attachments/assets/f6aab888-2c32-43c9-92b8-b1333175708f" />

changelog: Fixed broken `Download Metadata File` button from the SAML enrolling resource flow in the web UI.
changelog: Fixed broken `Refresh` button in the Access Monitoring reports page in the web UI.
changelog: Fixed broken `Download app.zip` menu item in the Integrations list dropdown menu for Microsoft Teams in the web UI.
changelog: Fixed `Unexpected end of JSON input` error in an otherwise successful web API call.
