### PR TITLE
Release 17.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,58 @@
 # Changelog
 
+## 17.2.7 (02/13/25)
+
+### Security Fixes
+
+* Fixed security issue with arbitrary file reads on SSH nodes. [#52136](https://github.com/gravitational/teleport/pull/52136)
+* Verify that cluster name of TLS peer certs matches the cluster name of the CA that issued it to prevent Auth bypasses. [#52130](https://github.com/gravitational/teleport/pull/52130)
+* Reject authentication attempts from remote identities in the git forwarder. [#52126](https://github.com/gravitational/teleport/pull/52126)
+
+### Other fixes and improvements
+* Added an escape hatch to allow non-FIPS AWS endpoints on FIPS binaries (`TELEPORT_UNSTABLE_DISABLE_AWS_FIPS=yes`). [#52069](https://github.com/gravitational/teleport/pull/52069)
+* Fixed Postgres database access control privileges auto-provisioning to grant USAGE on schemas as needed for table privileges and fixed an issue that prevented user privileges from being revoked at the end of their session in some cases. [#52047](https://github.com/gravitational/teleport/pull/52047)
+* Updated OpenSSL to 3.0.16. [#52037](https://github.com/gravitational/teleport/pull/52037)
+* Added ability to disable path-style S3 access for third-party endpoints. [#52009](https://github.com/gravitational/teleport/pull/52009)
+* Fixed displaying Access List form when request reason is required. [#51998](https://github.com/gravitational/teleport/pull/51998)
+* Fixed a bug in the WebUI where file transfers would always prompt for MFA, even when not required. [#51962](https://github.com/gravitational/teleport/pull/51962)
+* Reduced CPU consumption required to map roles between clusters and perform trait to role resolution. [#51935](https://github.com/gravitational/teleport/pull/51935)
+* Client tools managed updates require a base URL for the open-source build type. [#51931](https://github.com/gravitational/teleport/pull/51931)
+* Fixed an issue leaf AWS console app shows "not found" error when root cluster has an app of the same name. [#51928](https://github.com/gravitational/teleport/pull/51928)
+* Added `securityContext` value to the `tbot` Helm chart. [#51907](https://github.com/gravitational/teleport/pull/51907)
+* Fixed an issue where required apps wouldn't be authenticated when launching an application from outside the Teleport Web UI. [#51873](https://github.com/gravitational/teleport/pull/51873)
+* Prevent Teleport proxy failing to initialize when listener address's host component is empty. [#51864](https://github.com/gravitational/teleport/pull/51864)
+* Fixed connecting to Apps in a leaf cluster when Per-session MFA is enabled. [#51853](https://github.com/gravitational/teleport/pull/51853)
+* Updated Go to 1.23.6. [#51835](https://github.com/gravitational/teleport/pull/51835)
+* Fixed bug where role `max_duration` is not respected unless request `max_duration` is set. [#51821](https://github.com/gravitational/teleport/pull/51821)
+* Improved `instance.join` event error messaging. [#51779](https://github.com/gravitational/teleport/pull/51779)
+* Teleport agents always create the `debug.sock` UNIX socket. The configuration field `debug_service.enabled` now controls if the debug and metrics endpoints are available via the UNIX socket. [#51771](https://github.com/gravitational/teleport/pull/51771)
+* Backport new Azure integration functionality to v17, which allows the Discovery Service to fetch Azure resources and send them to the Access Graph. [#51725](https://github.com/gravitational/teleport/pull/51725)
+* Added support for caching Microsoft Remote Desktop Services licenses. [#51684](https://github.com/gravitational/teleport/pull/51684)
+* Added Audit Log statistics to `tctl top`. [#51655](https://github.com/gravitational/teleport/pull/51655)
+* Redesigned the profile switcher in Teleport Connect for a more intuitive experience. Clusters now have distinct colors for easier identification, and readability is improved by preventing truncation of long user and cluster names. [#51654](https://github.com/gravitational/teleport/pull/51654)
+* Fixed a regression that caused the Kubernetes Service to reuse expired tokens when accessing EKS, GKE and AKS clusters using dynamic credentials. [#51652](https://github.com/gravitational/teleport/pull/51652)
+* Fixes issue where the Postgres backend would drop App Access events. [#51643](https://github.com/gravitational/teleport/pull/51643)
+* Fixed a rare crash that can happen with malformed SAML connector. [#51634](https://github.com/gravitational/teleport/pull/51634)
+* Fixed occasional Web UI session renewal issues (reverts "Avoid tight renewals for sessions with short TTL"). [#51601](https://github.com/gravitational/teleport/pull/51601)
+* Introduced `tsh workload-identity issue-x509` as the replacement to `tsh svid issue` and which is compatible with the new WorkloadIdentity resource. [#51597](https://github.com/gravitational/teleport/pull/51597)
+* Machine ID's new kubernetes/v2 service supports access to multiple Kubernetes clusters by name or label without needing to issue new identities. [#51535](https://github.com/gravitational/teleport/pull/51535)
+* Quoted the `KUBECONFIG` environment variable output by the `tsh proxy kube` command. [#51523](https://github.com/gravitational/teleport/pull/51523)
+* Fixed a bug where performing an admin action in the WebUI would hang indefinitely instead of getting an actionable error if the user has no MFA devices registered. [#51513](https://github.com/gravitational/teleport/pull/51513)
+* Added support for continuous profile collection with Pyroscope. [#51477](https://github.com/gravitational/teleport/pull/51477)
+* Added support for customizing the base URL for downloading Teleport packages used in client tools managed updates. [#51476](https://github.com/gravitational/teleport/pull/51476)
+* Improved handling of client session termination during Kubernetes Exec sessions. The disconnection reason is now accurately returned for cases such as certificate expiration, forced lock activation, or idle timeout. [#51454](https://github.com/gravitational/teleport/pull/51454)
+* Fixed an issue that prevented IPs provided in the `X-Forwarded-For` header from being honored in some scenarios when `TrustXForwardedFor` is enabled. [#51416](https://github.com/gravitational/teleport/pull/51416)
+* Added support for multiple active CAs in the `/auth/export` endpoint. [#51415](https://github.com/gravitational/teleport/pull/51415)
+* Fixed integrations status page in WebUI. [#51404](https://github.com/gravitational/teleport/pull/51404)
+* Fixed a bug in GKE auto-discovery where the process failed to discover any clusters if the identity lacked permissions for one or more detected GCP project IDs. [#51399](https://github.com/gravitational/teleport/pull/51399)
+* Introduced the new `workload_identity` resource for configuring Teleport Workload Identity. [#51288](https://github.com/gravitational/teleport/pull/51288)
+
+Enterprise:
+* Fixed a regression in the Web UI that prevented Access List members to view the Access List's they are member of.
+* Fixed an issue with recreating Teleport resources for Okta applications with multiple embed links.
+* Fixed an issue in the Identity Center principal assignment service that incorrectly reported a successful permission assignment delete request as a failed one.
+* Fixed an issue in the Identity Center group import service which incorrectly handled import error event.
+
 ## 17.2.1 (01/22/2025)
 
 ### Security Fixes

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 #   Stable releases:   "1.0.0"
 #   Pre-releases:      "1.0.0-alpha.1", "1.0.0-beta.2", "1.0.0-rc.3"
 #   Master/dev branch: "1.0.0-dev"
-VERSION=17.2.1
+VERSION=17.2.7
 
 DOCKER_IMAGE ?= teleport
 

--- a/api/version.go
+++ b/api/version.go
@@ -3,6 +3,6 @@ package api
 
 import "github.com/coreos/go-semver/semver"
 
-const Version = "17.2.1"
+const Version = "17.2.7"
 
 var SemVersion = semver.New(Version)

--- a/build.assets/macos/tsh/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tsh/tsh.app/Contents/Info.plist
@@ -19,13 +19,13 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>17.2.1</string>
+		<string>17.2.7</string>
 		<key>CFBundleSupportedPlatforms</key>
 		<array>
 			<string>MacOSX</string>
 		</array>
 		<key>CFBundleVersion</key>
-		<string>17.2.1</string>
+		<string>17.2.7</string>
 		<key>DTCompiler</key>
 		<string>com.apple.compilers.llvm.clang.1_0</string>
 		<key>DTPlatformBuild</key>

--- a/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
@@ -17,13 +17,13 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>17.2.1</string>
+		<string>17.2.7</string>
 		<key>CFBundleSupportedPlatforms</key>
 		<array>
 			<string>MacOSX</string>
 		</array>
 		<key>CFBundleVersion</key>
-		<string>17.2.1</string>
+		<string>17.2.7</string>
 		<key>DTCompiler</key>
 		<string>com.apple.compilers.llvm.clang.1_0</string>
 		<key>DTPlatformBuild</key>

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -180,6 +180,7 @@
     "Pbbd",
     "Pluggable",
     "Println",
+    "Pyroscope",
     "Quickstart",
     "Quicktime's",
     "REDISCLI",

--- a/examples/chart/access/datadog/Chart.yaml
+++ b/examples/chart/access/datadog/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.2.1"
+.version: &version "17.2.7"
 
 apiVersion: v2
 name: teleport-plugin-datadog

--- a/examples/chart/access/datadog/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/datadog/tests/__snapshot__/configmap_test.yaml.snap
@@ -26,6 +26,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-datadog
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-plugin-datadog-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-plugin-datadog-17.2.7
       name: RELEASE-NAME-teleport-plugin-datadog

--- a/examples/chart/access/datadog/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/datadog/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-datadog
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-plugin-datadog-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-plugin-datadog-17.2.7
       name: RELEASE-NAME-teleport-plugin-datadog
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-datadog
-            app.kubernetes.io/version: 17.2.1
-            helm.sh/chart: teleport-plugin-datadog-17.2.1
+            app.kubernetes.io/version: 17.2.7
+            helm.sh/chart: teleport-plugin-datadog-17.2.7
         spec:
           containers:
           - command:

--- a/examples/chart/access/discord/Chart.yaml
+++ b/examples/chart/access/discord/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.2.1"
+.version: &version "17.2.7"
 
 apiVersion: v2
 name: teleport-plugin-discord

--- a/examples/chart/access/discord/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/discord/tests/__snapshot__/configmap_test.yaml.snap
@@ -24,6 +24,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-discord
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-plugin-discord-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-plugin-discord-17.2.7
       name: RELEASE-NAME-teleport-plugin-discord

--- a/examples/chart/access/discord/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/discord/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-discord
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-plugin-discord-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-plugin-discord-17.2.7
       name: RELEASE-NAME-teleport-plugin-discord
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-discord
-            app.kubernetes.io/version: 17.2.1
-            helm.sh/chart: teleport-plugin-discord-17.2.1
+            app.kubernetes.io/version: 17.2.7
+            helm.sh/chart: teleport-plugin-discord-17.2.7
         spec:
           containers:
           - command:

--- a/examples/chart/access/email/Chart.yaml
+++ b/examples/chart/access/email/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.2.1"
+.version: &version "17.2.7"
 
 apiVersion: v2
 name: teleport-plugin-email

--- a/examples/chart/access/email/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/email/tests/__snapshot__/configmap_test.yaml.snap
@@ -26,8 +26,8 @@ should match the snapshot (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-plugin-email-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-plugin-email-17.2.7
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on):
   1: |
@@ -59,8 +59,8 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-plugin-email-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-plugin-email-17.2.7
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, no starttls):
   1: |
@@ -92,8 +92,8 @@ should match the snapshot (smtp on, no starttls):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-plugin-email-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-plugin-email-17.2.7
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, password file):
   1: |
@@ -125,8 +125,8 @@ should match the snapshot (smtp on, password file):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-plugin-email-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-plugin-email-17.2.7
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, roleToRecipients set):
   1: |
@@ -161,8 +161,8 @@ should match the snapshot (smtp on, roleToRecipients set):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-plugin-email-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-plugin-email-17.2.7
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, starttls disabled):
   1: |
@@ -194,6 +194,6 @@ should match the snapshot (smtp on, starttls disabled):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-plugin-email-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-plugin-email-17.2.7
       name: RELEASE-NAME-teleport-plugin-email

--- a/examples/chart/access/email/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/email/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should be possible to override volume name (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-plugin-email-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-plugin-email-17.2.7
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should be possible to override volume name (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 17.2.1
-            helm.sh/chart: teleport-plugin-email-17.2.1
+            app.kubernetes.io/version: 17.2.7
+            helm.sh/chart: teleport-plugin-email-17.2.7
         spec:
           containers:
           - command:
@@ -34,7 +34,7 @@ should be possible to override volume name (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:17.2.1
+            image: public.ecr.aws/gravitational/teleport-plugin-email:17.2.7
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -75,8 +75,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-plugin-email-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-plugin-email-17.2.7
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -90,8 +90,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 17.2.1
-            helm.sh/chart: teleport-plugin-email-17.2.1
+            app.kubernetes.io/version: 17.2.7
+            helm.sh/chart: teleport-plugin-email-17.2.7
         spec:
           containers:
           - command:
@@ -136,8 +136,8 @@ should match the snapshot (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-plugin-email-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-plugin-email-17.2.7
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -151,8 +151,8 @@ should match the snapshot (mailgun on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 17.2.1
-            helm.sh/chart: teleport-plugin-email-17.2.1
+            app.kubernetes.io/version: 17.2.7
+            helm.sh/chart: teleport-plugin-email-17.2.7
         spec:
           containers:
           - command:
@@ -163,7 +163,7 @@ should match the snapshot (mailgun on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:17.2.1
+            image: public.ecr.aws/gravitational/teleport-plugin-email:17.2.7
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -204,8 +204,8 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-plugin-email-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-plugin-email-17.2.7
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -219,8 +219,8 @@ should match the snapshot (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 17.2.1
-            helm.sh/chart: teleport-plugin-email-17.2.1
+            app.kubernetes.io/version: 17.2.7
+            helm.sh/chart: teleport-plugin-email-17.2.7
         spec:
           containers:
           - command:
@@ -231,7 +231,7 @@ should match the snapshot (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:17.2.1
+            image: public.ecr.aws/gravitational/teleport-plugin-email:17.2.7
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -272,8 +272,8 @@ should mount external secret (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-plugin-email-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-plugin-email-17.2.7
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -287,8 +287,8 @@ should mount external secret (mailgun on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 17.2.1
-            helm.sh/chart: teleport-plugin-email-17.2.1
+            app.kubernetes.io/version: 17.2.7
+            helm.sh/chart: teleport-plugin-email-17.2.7
         spec:
           containers:
           - command:
@@ -299,7 +299,7 @@ should mount external secret (mailgun on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:17.2.1
+            image: public.ecr.aws/gravitational/teleport-plugin-email:17.2.7
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -340,8 +340,8 @@ should mount external secret (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-plugin-email-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-plugin-email-17.2.7
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -355,8 +355,8 @@ should mount external secret (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 17.2.1
-            helm.sh/chart: teleport-plugin-email-17.2.1
+            app.kubernetes.io/version: 17.2.7
+            helm.sh/chart: teleport-plugin-email-17.2.7
         spec:
           containers:
           - command:
@@ -367,7 +367,7 @@ should mount external secret (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:17.2.1
+            image: public.ecr.aws/gravitational/teleport-plugin-email:17.2.7
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:

--- a/examples/chart/access/jira/Chart.yaml
+++ b/examples/chart/access/jira/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.2.1"
+.version: &version "17.2.7"
 
 apiVersion: v2
 name: teleport-plugin-jira

--- a/examples/chart/access/jira/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/jira/tests/__snapshot__/configmap_test.yaml.snap
@@ -32,6 +32,6 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-jira
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-plugin-jira-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-plugin-jira-17.2.7
       name: RELEASE-NAME-teleport-plugin-jira

--- a/examples/chart/access/jira/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/jira/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-jira
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-plugin-jira-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-plugin-jira-17.2.7
       name: RELEASE-NAME-teleport-plugin-jira
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-jira
-            app.kubernetes.io/version: 17.2.1
-            helm.sh/chart: teleport-plugin-jira-17.2.1
+            app.kubernetes.io/version: 17.2.7
+            helm.sh/chart: teleport-plugin-jira-17.2.7
         spec:
           containers:
           - command:

--- a/examples/chart/access/mattermost/Chart.yaml
+++ b/examples/chart/access/mattermost/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.2.1"
+.version: &version "17.2.7"
 
 apiVersion: v2
 name: teleport-plugin-mattermost

--- a/examples/chart/access/mattermost/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/mattermost/tests/__snapshot__/configmap_test.yaml.snap
@@ -22,6 +22,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-plugin-mattermost-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-plugin-mattermost-17.2.7
       name: RELEASE-NAME-teleport-plugin-mattermost

--- a/examples/chart/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-plugin-mattermost-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-plugin-mattermost-17.2.7
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 17.2.1
-            helm.sh/chart: teleport-plugin-mattermost-17.2.1
+            app.kubernetes.io/version: 17.2.7
+            helm.sh/chart: teleport-plugin-mattermost-17.2.7
         spec:
           containers:
           - command:
@@ -75,8 +75,8 @@ should mount external secret:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-plugin-mattermost-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-plugin-mattermost-17.2.7
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -90,8 +90,8 @@ should mount external secret:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 17.2.1
-            helm.sh/chart: teleport-plugin-mattermost-17.2.1
+            app.kubernetes.io/version: 17.2.7
+            helm.sh/chart: teleport-plugin-mattermost-17.2.7
         spec:
           containers:
           - command:
@@ -102,7 +102,7 @@ should mount external secret:
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:17.2.1
+            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:17.2.7
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
             ports:
@@ -143,8 +143,8 @@ should override volume name:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-plugin-mattermost-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-plugin-mattermost-17.2.7
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -158,8 +158,8 @@ should override volume name:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 17.2.1
-            helm.sh/chart: teleport-plugin-mattermost-17.2.1
+            app.kubernetes.io/version: 17.2.7
+            helm.sh/chart: teleport-plugin-mattermost-17.2.7
         spec:
           containers:
           - command:
@@ -170,7 +170,7 @@ should override volume name:
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:17.2.1
+            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:17.2.7
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
             ports:

--- a/examples/chart/access/msteams/Chart.yaml
+++ b/examples/chart/access/msteams/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.2.1"
+.version: &version "17.2.7"
 
 apiVersion: v2
 name: teleport-plugin-msteams

--- a/examples/chart/access/msteams/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/msteams/tests/__snapshot__/configmap_test.yaml.snap
@@ -29,6 +29,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-msteams
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-plugin-msteams-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-plugin-msteams-17.2.7
       name: RELEASE-NAME-teleport-plugin-msteams

--- a/examples/chart/access/msteams/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/msteams/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-msteams
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-plugin-msteams-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-plugin-msteams-17.2.7
       name: RELEASE-NAME-teleport-plugin-msteams
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-msteams
-            app.kubernetes.io/version: 17.2.1
-            helm.sh/chart: teleport-plugin-msteams-17.2.1
+            app.kubernetes.io/version: 17.2.7
+            helm.sh/chart: teleport-plugin-msteams-17.2.7
         spec:
           containers:
           - command:

--- a/examples/chart/access/pagerduty/Chart.yaml
+++ b/examples/chart/access/pagerduty/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.2.1"
+.version: &version "17.2.7"
 
 apiVersion: v2
 name: teleport-plugin-pagerduty

--- a/examples/chart/access/pagerduty/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/pagerduty/tests/__snapshot__/configmap_test.yaml.snap
@@ -21,6 +21,6 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-pagerduty
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-plugin-pagerduty-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-plugin-pagerduty-17.2.7
       name: RELEASE-NAME-teleport-plugin-pagerduty

--- a/examples/chart/access/pagerduty/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/pagerduty/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-pagerduty
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-plugin-pagerduty-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-plugin-pagerduty-17.2.7
       name: RELEASE-NAME-teleport-plugin-pagerduty
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-pagerduty
-            app.kubernetes.io/version: 17.2.1
-            helm.sh/chart: teleport-plugin-pagerduty-17.2.1
+            app.kubernetes.io/version: 17.2.7
+            helm.sh/chart: teleport-plugin-pagerduty-17.2.7
         spec:
           containers:
           - command:

--- a/examples/chart/access/slack/Chart.yaml
+++ b/examples/chart/access/slack/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.2.1"
+.version: &version "17.2.7"
 
 apiVersion: v2
 name: teleport-plugin-slack

--- a/examples/chart/access/slack/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/slack/tests/__snapshot__/configmap_test.yaml.snap
@@ -24,6 +24,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-slack
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-plugin-slack-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-plugin-slack-17.2.7
       name: RELEASE-NAME-teleport-plugin-slack

--- a/examples/chart/access/slack/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/slack/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-slack
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-plugin-slack-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-plugin-slack-17.2.7
       name: RELEASE-NAME-teleport-plugin-slack
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-slack
-            app.kubernetes.io/version: 17.2.1
-            helm.sh/chart: teleport-plugin-slack-17.2.1
+            app.kubernetes.io/version: 17.2.7
+            helm.sh/chart: teleport-plugin-slack-17.2.7
         spec:
           containers:
           - command:

--- a/examples/chart/event-handler/Chart.yaml
+++ b/examples/chart/event-handler/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.2.1"
+.version: &version "17.2.7"
 
 apiVersion: v2
 name: teleport-plugin-event-handler

--- a/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
@@ -26,6 +26,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-plugin-event-handler-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-plugin-event-handler-17.2.7
       name: RELEASE-NAME-teleport-plugin-event-handler

--- a/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-plugin-event-handler-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-plugin-event-handler-17.2.7
       name: RELEASE-NAME-teleport-plugin-event-handler
     spec:
       replicas: 1
@@ -82,7 +82,7 @@ should mount tls.existingCASecretName and set environment when set in values:
         value: "true"
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-plugin-event-handler:17.2.1
+      image: public.ecr.aws/gravitational/teleport-plugin-event-handler:17.2.7
       imagePullPolicy: IfNotPresent
       name: teleport-plugin-event-handler
       ports:

--- a/examples/chart/tbot/Chart.yaml
+++ b/examples/chart/tbot/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.2.1"
+.version: &version "17.2.7"
 
 name: tbot
 apiVersion: v2

--- a/examples/chart/tbot/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/tbot/tests/__snapshot__/deployment_test.yaml.snap
@@ -29,7 +29,7 @@ should match the snapshot (full):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: tbot
-            helm.sh/chart: tbot-17.2.1
+            helm.sh/chart: tbot-17.2.7
             test-key: test-label-pod
         spec:
           affinity:
@@ -68,7 +68,7 @@ should match the snapshot (full):
               value: "1"
             - name: TEST_ENV
               value: test-value
-            image: public.ecr.aws/gravitational/tbot-distroless:17.2.1
+            image: public.ecr.aws/gravitational/tbot-distroless:17.2.7
             imagePullPolicy: Always
             livenessProbe:
               failureThreshold: 6
@@ -164,7 +164,7 @@ should match the snapshot (simple):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: tbot
-            helm.sh/chart: tbot-17.2.1
+            helm.sh/chart: tbot-17.2.7
         spec:
           containers:
           - args:
@@ -186,7 +186,7 @@ should match the snapshot (simple):
                   fieldPath: spec.nodeName
             - name: KUBERNETES_TOKEN_PATH
               value: /var/run/secrets/tokens/join-sa-token
-            image: public.ecr.aws/gravitational/tbot-distroless:17.2.1
+            image: public.ecr.aws/gravitational/tbot-distroless:17.2.7
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6

--- a/examples/chart/teleport-cluster/Chart.yaml
+++ b/examples/chart/teleport-cluster/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.2.1"
+.version: &version "17.2.7"
 
 name: teleport-cluster
 apiVersion: v2

--- a/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.2.1"
+.version: &version "17.2.7"
 
 name: teleport-operator
 apiVersion: v2

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_clusterrole_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_clusterrole_test.yaml.snap
@@ -8,8 +8,8 @@ adds operator permissions to ClusterRole:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-cluster-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-cluster-17.2.7
         teleport.dev/majorVersion: "17"
       name: RELEASE-NAME
     rules:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
@@ -1848,8 +1848,8 @@ sets clusterDomain on Configmap:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-cluster-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-cluster-17.2.7
         teleport.dev/majorVersion: "17"
       name: RELEASE-NAME-auth
       namespace: NAMESPACE

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
@@ -8,7 +8,7 @@
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -141,7 +141,7 @@ should set nodeSelector when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -238,7 +238,7 @@ should set resources when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -324,7 +324,7 @@ should set securityContext when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_config_test.yaml.snap
@@ -567,8 +567,8 @@ sets clusterDomain on Configmap:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-cluster-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-cluster-17.2.7
         teleport.dev/majorVersion: "17"
       name: RELEASE-NAME-proxy
       namespace: NAMESPACE

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
@@ -11,8 +11,8 @@ sets clusterDomain on Deployment Pods:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 17.2.1
-        helm.sh/chart: teleport-cluster-17.2.1
+        app.kubernetes.io/version: 17.2.7
+        helm.sh/chart: teleport-cluster-17.2.7
         teleport.dev/majorVersion: "17"
       name: RELEASE-NAME-proxy
       namespace: NAMESPACE
@@ -26,7 +26,7 @@ sets clusterDomain on Deployment Pods:
       template:
         metadata:
           annotations:
-            checksum/config: d650477161286c155fb8415249401cfbe8e074fa26e6a15bf1f8346ad3762108
+            checksum/config: 788cc751f0c48b48415714a674bdb771ba9a079091aa0bbe737447df2f94ec58
             kubernetes.io/pod: test-annotation
             kubernetes.io/pod-different: 4
           labels:
@@ -34,8 +34,8 @@ sets clusterDomain on Deployment Pods:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-cluster
-            app.kubernetes.io/version: 17.2.1
-            helm.sh/chart: teleport-cluster-17.2.1
+            app.kubernetes.io/version: 17.2.7
+            helm.sh/chart: teleport-cluster-17.2.7
             teleport.dev/majorVersion: "17"
         spec:
           affinity:
@@ -44,7 +44,7 @@ sets clusterDomain on Deployment Pods:
           containers:
           - args:
             - --diag-addr=0.0.0.0:3000
-            image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+            image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
             imagePullPolicy: IfNotPresent
             lifecycle:
               preStop:
@@ -105,7 +105,7 @@ sets clusterDomain on Deployment Pods:
             - wait
             - no-resolve
             - RELEASE-NAME-auth-v16.NAMESPACE.svc.test.com
-            image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+            image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
             name: wait-auth-update
           serviceAccountName: RELEASE-NAME-proxy
           terminationGracePeriodSeconds: 60
@@ -137,7 +137,7 @@ should provision initContainer correctly when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v16.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       name: wait-auth-update
       resources:
         limits:
@@ -201,7 +201,7 @@ should set nodeSelector when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -262,7 +262,7 @@ should set nodeSelector when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v16.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       name: wait-auth-update
     nodeSelector:
       environment: security
@@ -313,7 +313,7 @@ should set resources for wait-auth-update initContainer when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -381,7 +381,7 @@ should set resources for wait-auth-update initContainer when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v16.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       name: wait-auth-update
       resources:
         limits:
@@ -421,7 +421,7 @@ should set resources when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -489,7 +489,7 @@ should set resources when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v16.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       name: wait-auth-update
       resources:
         limits:
@@ -529,7 +529,7 @@ should set securityContext for initContainers when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -597,7 +597,7 @@ should set securityContext for initContainers when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v16.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       name: wait-auth-update
       securityContext:
         allowPrivilegeEscalation: false
@@ -637,7 +637,7 @@ should set securityContext when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -705,7 +705,7 @@ should set securityContext when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v16.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       name: wait-auth-update
       securityContext:
         allowPrivilegeEscalation: false

--- a/examples/chart/teleport-kube-agent/Chart.yaml
+++ b/examples/chart/teleport-kube-agent/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.2.1"
+.version: &version "17.2.7"
 
 name: teleport-kube-agent
 apiVersion: v2

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
@@ -32,7 +32,7 @@ sets Deployment annotations when specified if action is Upgrade:
               value: "true"
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+            image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -109,7 +109,7 @@ sets Deployment labels when specified if action is Upgrade:
             value: "true"
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-          image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+          image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -173,7 +173,7 @@ sets Pod annotations when specified if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -237,7 +237,7 @@ sets Pod labels when specified if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -322,7 +322,7 @@ should add emptyDir for data when existingDataVolume is not set if action is Upg
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -387,7 +387,7 @@ should add insecureSkipProxyTLSVerify to args when set in values if action is Up
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -451,7 +451,7 @@ should correctly configure existingDataVolume when set if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -513,7 +513,7 @@ should expose diag port if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -589,7 +589,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -665,7 +665,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -729,7 +729,7 @@ should have one replica when replicaCount is not set if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -793,7 +793,7 @@ should mount extraVolumes and extraVolumeMounts if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -862,7 +862,7 @@ should mount jamfCredentialsSecret if it already exists and when role is jamf an
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -932,7 +932,7 @@ should mount jamfCredentialsSecret.name when role is jamf and action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1004,7 +1004,7 @@ should mount tls.existingCASecretName and set environment when set in values if 
         value: cluster.local
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1078,7 +1078,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: http://username:password@my.proxy.host:3128
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1148,7 +1148,7 @@ should provision initContainer correctly when set in values if action is Upgrade
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1270,7 +1270,7 @@ should set affinity when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1334,7 +1334,7 @@ should set default serviceAccountName when not set in values if action is Upgrad
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1411,7 +1411,7 @@ should set environment when extraEnv set in values if action is Upgrade:
         value: cluster.local
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1539,7 +1539,7 @@ should set imagePullPolicy when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -1603,7 +1603,7 @@ should set nodeSelector if set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1669,7 +1669,7 @@ should set not set priorityClassName when not set in values if action is Upgrade
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1745,7 +1745,7 @@ should set preferred affinity when more than one replica is used if action is Up
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1809,7 +1809,7 @@ should set priorityClassName when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1874,7 +1874,7 @@ should set probeTimeoutSeconds when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1948,7 +1948,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set if
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2012,7 +2012,7 @@ should set resources when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2083,7 +2083,7 @@ should set serviceAccountName when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2147,7 +2147,7 @@ should set tolerations when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
@@ -25,7 +25,7 @@ should create ServiceAccount for post-delete hook by default:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -108,7 +108,7 @@ should not create ServiceAccount for post-delete hook if serviceAccount.create i
                   fieldPath: metadata.namespace
             - name: RELEASE_NAME
               value: RELEASE-NAME
-            image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+            image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
             imagePullPolicy: IfNotPresent
             name: post-delete-job
             securityContext:
@@ -138,7 +138,7 @@ should not create ServiceAccount, Role or RoleBinding for post-delete hook if se
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -168,7 +168,7 @@ should set nodeSelector in post-delete hook:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -200,7 +200,7 @@ should set resources in the Job's pod spec if resources is set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       resources:

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
@@ -18,7 +18,7 @@ sets Pod annotations when specified:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -91,7 +91,7 @@ sets Pod labels when specified:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -188,7 +188,7 @@ sets StatefulSet labels when specified:
               value: RELEASE-NAME
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+            image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -293,7 +293,7 @@ should add insecureSkipProxyTLSVerify to args when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -366,7 +366,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and action
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -459,7 +459,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and is Fre
               value: RELEASE-NAME
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+            image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -542,7 +542,7 @@ should add volumeMount for data volume when using StatefulSet:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -615,7 +615,7 @@ should expose diag port:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -688,7 +688,7 @@ should generate Statefulset when storage is disabled and mode is a Upgrade:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -775,7 +775,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -860,7 +860,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -933,7 +933,7 @@ should have one replica when replicaCount is not set:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1006,7 +1006,7 @@ should install Statefulset when storage is disabled and mode is a Fresh Install:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1081,7 +1081,7 @@ should mount extraVolumes and extraVolumeMounts:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1159,7 +1159,7 @@ should mount jamfCredentialsSecret if it already exists and when role is jamf:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1240,7 +1240,7 @@ should mount jamfCredentialsSecret.name when role is jamf:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1323,7 +1323,7 @@ should mount tls.existingCASecretName and set environment when set in values:
         value: cluster.local
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1408,7 +1408,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: /etc/teleport-tls-ca/ca.pem
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1489,7 +1489,7 @@ should not add emptyDir for data when using StatefulSet:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1562,7 +1562,7 @@ should provision initContainer correctly when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1693,7 +1693,7 @@ should set affinity when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1766,7 +1766,7 @@ should set default serviceAccountName when not set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1852,7 +1852,7 @@ should set environment when extraEnv set in values:
         value: cluster.local
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1998,7 +1998,7 @@ should set imagePullPolicy when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -2071,7 +2071,7 @@ should set nodeSelector if set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2158,7 +2158,7 @@ should set preferred affinity when more than one replica is used:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2231,7 +2231,7 @@ should set probeTimeoutSeconds when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2314,7 +2314,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2387,7 +2387,7 @@ should set resources when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2467,7 +2467,7 @@ should set serviceAccountName when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2540,7 +2540,7 @@ should set storage.requests when set in values and action is an Upgrade:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2613,7 +2613,7 @@ should set storage.storageClassName when set in values and action is an Upgrade:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2686,7 +2686,7 @@ should set tolerations when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.2.1
+      image: public.ecr.aws/gravitational/teleport-distroless:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
@@ -27,7 +27,7 @@ sets the affinity:
       - --base-image=public.ecr.aws/gravitational/teleport-distroless
       - --version-server=https://my-custom-version-server/v1
       - --version-channel=custom/preview
-      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:17.2.1
+      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -73,7 +73,7 @@ sets the tolerations:
       - --base-image=public.ecr.aws/gravitational/teleport-distroless
       - --version-server=https://my-custom-version-server/v1
       - --version-channel=custom/preview
-      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:17.2.1
+      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:17.2.7
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6


### PR DESCRIPTION
## 17.2.7 (02/13/25)

### Security Fixes

* Fixed security issue with arbitrary file reads on SSH nodes. [#52136](https://github.com/gravitational/teleport/pull/52136)
* Verify that cluster name of TLS peer certs matches the cluster name of the CA that issued it to prevent Auth bypasses. [#52130](https://github.com/gravitational/teleport/pull/52130)
* Reject authentication attempts from remote identities in the git forwarder. [#52126](https://github.com/gravitational/teleport/pull/52126)

### Other fixes and improvements
* Added an escape hatch to allow non-FIPS AWS endpoints on FIPS binaries (`TELEPORT_UNSTABLE_DISABLE_AWS_FIPS=yes`). [#52069](https://github.com/gravitational/teleport/pull/52069)
* Fixed Postgres database access control privileges auto-provisioning to grant USAGE on schemas as needed for table privileges and fixed an issue that prevented user privileges from being revoked at the end of their session in some cases. [#52047](https://github.com/gravitational/teleport/pull/52047)
* Updated OpenSSL to 3.0.16. [#52037](https://github.com/gravitational/teleport/pull/52037)
* Added ability to disable path-style S3 access for third-party endpoints. [#52009](https://github.com/gravitational/teleport/pull/52009)
* Fixed displaying Access List form when request reason is required. [#51998](https://github.com/gravitational/teleport/pull/51998)
* Fixed a bug in the WebUI where file transfers would always prompt for MFA, even when not required. [#51962](https://github.com/gravitational/teleport/pull/51962)
* Reduced CPU consumption required to map roles between clusters and perform trait to role resolution. [#51935](https://github.com/gravitational/teleport/pull/51935)
* Client tools managed updates require a base URL for the open-source build type. [#51931](https://github.com/gravitational/teleport/pull/51931)
* Fixed an issue leaf AWS console app shows "not found" error when root cluster has an app of the same name. [#51928](https://github.com/gravitational/teleport/pull/51928)
* Added `securityContext` value to the `tbot` Helm chart. [#51907](https://github.com/gravitational/teleport/pull/51907)
* Fixed an issue where required apps wouldn't be authenticated when launching an application from outside the Teleport Web UI. [#51873](https://github.com/gravitational/teleport/pull/51873)
* Prevent Teleport proxy failing to initialize when listener address's host component is empty. [#51864](https://github.com/gravitational/teleport/pull/51864)
* Fixed connecting to Apps in a leaf cluster when Per-session MFA is enabled. [#51853](https://github.com/gravitational/teleport/pull/51853)
* Updated Go to 1.23.6. [#51835](https://github.com/gravitational/teleport/pull/51835)
* Fixed bug where role `max_duration` is not respected unless request `max_duration` is set. [#51821](https://github.com/gravitational/teleport/pull/51821)
* Improved `instance.join` event error messaging. [#51779](https://github.com/gravitational/teleport/pull/51779)
* Teleport agents always create the `debug.sock` UNIX socket. The configuration field `debug_service.enabled` now controls if the debug and metrics endpoints are available via the UNIX socket. [#51771](https://github.com/gravitational/teleport/pull/51771)
* Backport new Azure integration functionality to v17, which allows the Discovery Service to fetch Azure resources and send them to the Access Graph. [#51725](https://github.com/gravitational/teleport/pull/51725)
* Added support for caching Microsoft Remote Desktop Services licenses. [#51684](https://github.com/gravitational/teleport/pull/51684)
* Added Audit Log statistics to `tctl top`. [#51655](https://github.com/gravitational/teleport/pull/51655)
* Redesigned the profile switcher in Teleport Connect for a more intuitive experience. Clusters now have distinct colors for easier identification, and readability is improved by preventing truncation of long user and cluster names. [#51654](https://github.com/gravitational/teleport/pull/51654)
* Fixed a regression that caused the Kubernetes Service to reuse expired tokens when accessing EKS, GKE and AKS clusters using dynamic credentials. [#51652](https://github.com/gravitational/teleport/pull/51652)
* Fixes issue where the Postgres backend would drop App Access events. [#51643](https://github.com/gravitational/teleport/pull/51643)
* Fixed a rare crash that can happen with malformed SAML connector. [#51634](https://github.com/gravitational/teleport/pull/51634)
* Fixed occasional Web UI session renewal issues (reverts "Avoid tight renewals for sessions with short TTL"). [#51601](https://github.com/gravitational/teleport/pull/51601)
* Introduced `tsh workload-identity issue-x509` as the replacement to `tsh svid issue` and which is compatible with the new WorkloadIdentity resource. [#51597](https://github.com/gravitational/teleport/pull/51597)
* Machine ID's new kubernetes/v2 service supports access to multiple Kubernetes clusters by name or label without needing to issue new identities. [#51535](https://github.com/gravitational/teleport/pull/51535)
* Quoted the `KUBECONFIG` environment variable output by the `tsh proxy kube` command. [#51523](https://github.com/gravitational/teleport/pull/51523)
* Fixed a bug where performing an admin action in the WebUI would hang indefinitely instead of getting an actionable error if the user has no MFA devices registered. [#51513](https://github.com/gravitational/teleport/pull/51513)
* Added support for continuous profile collection with Pyroscope. [#51477](https://github.com/gravitational/teleport/pull/51477)
* Added support for customizing the base URL for downloading Teleport packages used in client tools managed updates. [#51476](https://github.com/gravitational/teleport/pull/51476)
* Improved handling of client session termination during Kubernetes Exec sessions. The disconnection reason is now accurately returned for cases such as certificate expiration, forced lock activation, or idle timeout. [#51454](https://github.com/gravitational/teleport/pull/51454)
* Fixed an issue that prevented IPs provided in the `X-Forwarded-For` header from being honored in some scenarios when `TrustXForwardedFor` is enabled. [#51416](https://github.com/gravitational/teleport/pull/51416)
* Added support for multiple active CAs in the `/auth/export` endpoint. [#51415](https://github.com/gravitational/teleport/pull/51415)
* Fixed integrations status page in WebUI. [#51404](https://github.com/gravitational/teleport/pull/51404)
* Fixed a bug in GKE auto-discovery where the process failed to discover any clusters if the identity lacked permissions for one or more detected GCP project IDs. [#51399](https://github.com/gravitational/teleport/pull/51399)
* Introduced the new `workload_identity` resource for configuring Teleport Workload Identity. [#51288](https://github.com/gravitational/teleport/pull/51288)

Enterprise:
* Fixed a regression in the Web UI that prevented Access List members to view the Access List's they are member of.
* Fixed an issue with recreating Teleport resources for Okta applications with multiple embed links.
* Fixed an issue in the Identity Center principal assignment service that incorrectly reported a successful permission assignment delete request as a failed one.
* Fixed an issue in the Identity Center group import service which incorrectly handled import error event.
* Added a preview of changes to access to resources in the role editor. This feature requires Teleport Identity Security.

