### PR TITLE
[vnet] add vnet-(un)install-service commands for Windows

### DIFF
--- a/lib/devicetrust/native/device_windows.go
+++ b/lib/devicetrust/native/device_windows.go
@@ -233,7 +233,7 @@ func collectDeviceData(_ CollectDataMode) (*devicepb.DeviceCollectedData, error)
 	return dcd, nil
 }
 
-// activateCredentialInElevated child uses `runas` to trigger a child process
+// activateCredentialInElevatedChild uses `runas` to trigger a child process
 // with elevated privileges. This is necessary because the process must have
 // elevated privileges in order to invoke the TPM 2.0 ActivateCredential
 // command.

--- a/lib/vnet/install_service_windows.go
+++ b/lib/vnet/install_service_windows.go
@@ -1,0 +1,181 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+// InstallService installs the VNet windows service.
+//
+// Windows services are installed by the service manager, which takes a path to
+// the service executable. So that regular users are not able to overwrite the
+// executable at that path, we use a path under %PROGRAMFILES%, which is not
+// writable by regular users by default.
+func InstallService(ctx context.Context) (err error) {
+	tshPath, err := os.Executable()
+	if err != nil {
+		return trace.Wrap(err, "getting current exe path")
+	}
+	if err := assertTshInProgramFiles(tshPath); err != nil {
+		return trace.Wrap(err, "checking if tsh.exe is installed under %%PROGRAMFILES%%")
+	}
+	if err := assertWintunInstalled(tshPath); err != nil {
+		return trace.Wrap(err, "checking if wintun.dll is installed next to %s", tshPath)
+	}
+
+	svcMgr, err := mgr.Connect()
+	if err != nil {
+		return trace.Wrap(err, "connecting to Windows service manager")
+	}
+	svc, err := svcMgr.OpenService(serviceName)
+	if err != nil {
+		if !errors.Is(err, windows.ERROR_SERVICE_DOES_NOT_EXIST) {
+			return trace.Wrap(err, "unexpected error checking if Windows service %s exists", serviceName)
+		}
+		// The service has not been created yet and must be installed.
+		svc, err = svcMgr.CreateService(
+			serviceName,
+			tshPath,
+			mgr.Config{
+				StartType: mgr.StartManual,
+			},
+			ServiceCommand,
+		)
+		if err != nil {
+			return trace.Wrap(err, "creating VNet Windows service")
+		}
+	}
+	if err := svc.Close(); err != nil {
+		return trace.Wrap(err, "closing VNet Windows service")
+	}
+	if err := grantServiceRights(); err != nil {
+		return trace.Wrap(err, "granting authenticated users permission to control the VNet Windows service")
+	}
+	return nil
+}
+
+// UninstallService uninstalls the VNet windows service.
+func UninstallService(ctx context.Context) (err error) {
+	svcMgr, err := mgr.Connect()
+	if err != nil {
+		return trace.Wrap(err, "connecting to Windows service manager")
+	}
+	svc, err := svcMgr.OpenService(serviceName)
+	if err != nil {
+		return trace.Wrap(err, "opening Windows service %s", serviceName)
+	}
+	if err := svc.Delete(); err != nil {
+		return trace.Wrap(err, "deleting Windows service %s", serviceName)
+	}
+	if err := svc.Close(); err != nil {
+		return trace.Wrap(err, "closing VNet Windows service")
+	}
+	return nil
+}
+
+func grantServiceRights() error {
+	// Get the current security info for the service, requesting only the DACL
+	// (discretionary access control list).
+	si, err := windows.GetNamedSecurityInfo(serviceName, windows.SE_SERVICE, windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		return trace.Wrap(err, "getting current service security information")
+	}
+	// Get the DACL from the security info.
+	dacl, _ /*defaulted*/, err := si.DACL()
+	if err != nil {
+		return trace.Wrap(err, "getting current service DACL")
+	}
+	// Build an explicit access entry allowing authenticated users to start,
+	// stop, and query the service.
+	ea := []windows.EXPLICIT_ACCESS{{
+		AccessPermissions: windows.SERVICE_QUERY_STATUS | windows.SERVICE_START | windows.SERVICE_STOP,
+		AccessMode:        windows.GRANT_ACCESS,
+		Trustee: windows.TRUSTEE{
+			TrusteeForm:  windows.TRUSTEE_IS_NAME,
+			TrusteeType:  windows.TRUSTEE_IS_WELL_KNOWN_GROUP,
+			TrusteeValue: windows.TrusteeValueFromString("Authenticated Users"),
+		},
+	}}
+	// Merge the new explicit access entry with the existing DACL.
+	dacl, err = windows.ACLFromEntries(ea, dacl)
+	if err != nil {
+		return trace.Wrap(err, "merging service DACL entries")
+	}
+	// Set the DACL on the service security info.
+	if err := windows.SetNamedSecurityInfo(
+		serviceName,
+		windows.SE_SERVICE,
+		windows.DACL_SECURITY_INFORMATION,
+		nil,  // owner
+		nil,  // group
+		dacl, // dacl
+		nil,  // sacl
+	); err != nil {
+		return trace.Wrap(err, "setting service DACL")
+	}
+	return nil
+}
+
+// assertTshInProgramFiles asserts that tsh is a regular file installed under
+// the program files directory (usually C:\Program Files\).
+func assertTshInProgramFiles(tshPath string) error {
+	if err := assertRegularFile(tshPath); err != nil {
+		return trace.Wrap(err)
+	}
+	programFiles := os.Getenv("PROGRAMFILES")
+	if programFiles == "" {
+		return trace.Errorf("PROGRAMFILES env var is not set")
+	}
+	// Windows file paths are case-insensitive.
+	cleanedProgramFiles := strings.ToLower(filepath.Clean(programFiles)) + string(filepath.Separator)
+	cleanedTshPath := strings.ToLower(filepath.Clean(tshPath))
+	if !strings.HasPrefix(cleanedTshPath, cleanedProgramFiles) {
+		return trace.BadParameter(
+			"tsh.exe is currently installed at %s, it must be installed under %s in order to install the VNet Windows service",
+			tshPath, programFiles)
+	}
+	return nil
+}
+
+// asertWintunInstalled returns an error if wintun.dll is not a regular file
+// installed in the same directory as tshPath.
+func assertWintunInstalled(tshPath string) error {
+	dir := filepath.Dir(tshPath)
+	wintunPath := filepath.Join(dir, "wintun.dll")
+	return trace.Wrap(assertRegularFile(wintunPath))
+}
+
+func assertRegularFile(path string) error {
+	switch info, err := os.Lstat(path); {
+	case os.IsNotExist(err):
+		return trace.Wrap(err, "%s not found", path)
+	case err != nil:
+		return trace.Wrap(err, "unexpected error checking %s", path)
+	case !info.Mode().IsRegular():
+		return trace.BadParameter("%s is not a regular file", path)
+	}
+	return nil
+}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1264,6 +1264,8 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	vnetAdminSetupCommand := newVnetAdminSetupCommand(app)
 	vnetDaemonCommand := newVnetDaemonCommand(app)
 	vnetServiceCommand := newVnetServiceCommand(app)
+	vnetInstallServiceCommand := newVnetInstallServiceCommand(app)
+	vnetUninstallServiceCommand := newVnetUninstallServiceCommand(app)
 
 	gitCmd := newGitCommands(app)
 
@@ -1651,6 +1653,10 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		err = vnetDaemonCommand.run(&cf)
 	case vnetServiceCommand.FullCommand():
 		err = vnetServiceCommand.run(&cf)
+	case vnetInstallServiceCommand.FullCommand():
+		err = vnetInstallServiceCommand.run(&cf)
+	case vnetUninstallServiceCommand.FullCommand():
+		err = vnetUninstallServiceCommand.run(&cf)
 	case gitCmd.list.FullCommand():
 		err = gitCmd.list.run(&cf)
 	case gitCmd.login.FullCommand():

--- a/tool/tsh/common/vnet.go
+++ b/tool/tsh/common/vnet.go
@@ -100,6 +100,14 @@ func newVnetServiceCommand(app *kingpin.Application) vnetCLICommand {
 	return newPlatformVnetServiceCommand(app)
 }
 
+func newVnetInstallServiceCommand(app *kingpin.Application) vnetCLICommand {
+	return newPlatformVnetInstallServiceCommand(app)
+}
+
+func newVnetUninstallServiceCommand(app *kingpin.Application) vnetCLICommand {
+	return newPlatformVnetUninstallServiceCommand(app)
+}
+
 // vnetCommandNotSupported implements vnetCLICommand, it is returned when a specific
 // command is not implemented for a certain platform or environment.
 type vnetCommandNotSupported struct{}

--- a/tool/tsh/common/vnet_darwin.go
+++ b/tool/tsh/common/vnet_darwin.go
@@ -85,8 +85,18 @@ func (c *vnetAdminSetupCommand) run(cf *CLIConf) error {
 	return trace.Wrap(vnet.RunDarwinAdminProcess(cf.Context, config))
 }
 
-// the vnet-service command is only supported on windows.
+// The vnet-service command is only supported on windows.
 func newPlatformVnetServiceCommand(app *kingpin.Application) vnetCommandNotSupported {
+	return vnetCommandNotSupported{}
+}
+
+// The vnet-install-service command is only supported on windows.
+func newPlatformVnetInstallServiceCommand(app *kingpin.Application) vnetCommandNotSupported {
+	return vnetCommandNotSupported{}
+}
+
+// The vnet-uninstall-service command is only supported on windows.
+func newPlatformVnetUninstallServiceCommand(app *kingpin.Application) vnetCommandNotSupported {
 	return vnetCommandNotSupported{}
 }
 

--- a/tool/tsh/common/vnet_other.go
+++ b/tool/tsh/common/vnet_other.go
@@ -39,6 +39,14 @@ func newPlatformVnetServiceCommand(app *kingpin.Application) vnetCLICommand {
 	return vnetCommandNotSupported{}
 }
 
+func newPlatformVnetInstallServiceCommand(app *kingpin.Application) vnetCommandNotSupported {
+	return vnetCommandNotSupported{}
+}
+
+func newPlatformVnetUninstallServiceCommand(app *kingpin.Application) vnetCommandNotSupported {
+	return vnetCommandNotSupported{}
+}
+
 //nolint:staticcheck // SA4023. runVnetDiagnostics on unsupported platforms always returns err.
 func runVnetDiagnostics(ctx context.Context, nsi vnet.NetworkStackInfo) error {
 	return trace.NotImplemented("diagnostics are not implemented yet on this platform")

--- a/tool/tsh/common/vnet_windows.go
+++ b/tool/tsh/common/vnet_windows.go
@@ -33,7 +33,7 @@ type vnetServiceCommand struct {
 
 func newPlatformVnetServiceCommand(app *kingpin.Application) *vnetServiceCommand {
 	cmd := &vnetServiceCommand{
-		CmdClause: app.Command(vnet.ServiceCommand, "Start the VNet service.").Hidden(),
+		CmdClause: app.Command(vnet.ServiceCommand, "Start the VNet Windows service.").Hidden(),
 	}
 	return cmd
 }
@@ -51,6 +51,36 @@ func (c *vnetServiceCommand) run(_ *CLIConf) error {
 func isWindowsService() bool {
 	isSvc, err := svc.IsWindowsService()
 	return err == nil && isSvc
+}
+
+type vnetInstallServiceCommand struct {
+	*kingpin.CmdClause
+}
+
+func newPlatformVnetInstallServiceCommand(app *kingpin.Application) *vnetInstallServiceCommand {
+	cmd := &vnetInstallServiceCommand{
+		CmdClause: app.Command("vnet-install-service", "Install the VNet Windows service.").Hidden(),
+	}
+	return cmd
+}
+
+func (c *vnetInstallServiceCommand) run(cf *CLIConf) error {
+	return trace.Wrap(vnet.InstallService(cf.Context), "installing Windows service")
+}
+
+type vnetUninstallServiceCommand struct {
+	*kingpin.CmdClause
+}
+
+func newPlatformVnetUninstallServiceCommand(app *kingpin.Application) *vnetUninstallServiceCommand {
+	cmd := &vnetUninstallServiceCommand{
+		CmdClause: app.Command("vnet-uninstall-service", "Uninstall the VNet Windows service.").Hidden(),
+	}
+	return cmd
+}
+
+func (c *vnetUninstallServiceCommand) run(cf *CLIConf) error {
+	return trace.Wrap(vnet.UninstallService(cf.Context), "uninstalling Windows service")
 }
 
 // the admin-setup command is only supported on darwin.


### PR DESCRIPTION
This PR adds the command `tsh vnet-install-service` to install the VNet Windows service. It does this by using the Windows Service Control Manager to configure a Windows service to start `tsh.exe` with the appropriate arguments.

`tsh.exe` should not be saved in a user-writable path or else the user could overwrite the exe and then start the service to get privilege escalation. To try to prevent misconfiguration, the installer asserts that `tsh.exe` must be installed under `Program Files`, usually `C:\Program Files\` but this can be controlled by the environment variable `PROGRAMFILES`. If `tsh.exe` is not found there, or wintun.dll is not installed next to `tsh.exe`, the command fails. This will require a per-machine install of Connect so that `tsh.exe` is properly installed under PROGRAMFILES and so that the installer runs with admin rights, which are necessary in order to install the service. The following PR https://github.com/gravitational/teleport/pull/52165 updates the Connect installer.

I'm also adding a `tsh vnet-uninstall-service` command which deletes the service configuration, although this will not be called by the Connect uninstaller which runs after `tsh.exe` has already been deleted. Fortunately all the uninstaller needs to do is delete the service configuration, which can be done in a single command. The `tsh vnet-uninstall-service` command may be useful if any users manually install the service for use with `tsh` instead of Connect.