### PR TITLE
[vnet] enable VNet in Connect on Windows

### DIFF
--- a/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
@@ -84,10 +84,10 @@ export const VnetContextProvider: FC<PropsWithChildren> = props => {
     autoStart: false,
   });
 
-  const isSupported = useMemo(
-    () => mainProcessClient.getRuntimeSettings().platform === 'darwin',
-    [mainProcessClient]
-  );
+  const isSupported = useMemo(() => {
+    const { platform } = mainProcessClient.getRuntimeSettings();
+    return platform === 'darwin' || platform === 'win32';
+  }, [mainProcessClient]);
 
   const [startAttempt, start] = useAsync(
     useCallback(async () => {


### PR DESCRIPTION
This PR enables VNet in the Connect UI on Windows. I will hold the backport until 17.3.

Changelog: Added support for VNet on Windows