### PR TITLE
Proof of concept for access requests in tbot

### DIFF
--- a/lib/tbot/config/service_identity.go
+++ b/lib/tbot/config/service_identity.go
@@ -68,6 +68,12 @@ var (
 	_ Initable      = &IdentityOutput{}
 )
 
+type AccessRequest struct {
+	Roles []string `yaml:"roles"`
+	Reviewers []string
+	Reason string
+}
+
 // IdentityOutput produces credentials which can be used with `tsh`, `tctl`,
 // `openssh` and most SSH compatible tooling. It can also be used with the
 // Teleport API and things which use the API client (e.g the terraform provider)
@@ -101,6 +107,10 @@ type IdentityOutput struct {
 	//
 	// Defaults to false.
 	AllowReissue bool `yaml:"allow_reissue,omitempty"`
+
+	// AccessRequest alternatively uses just-in-time access requests to fetch
+	// alternative credentials for this output. Mutually exclusive with Roles.
+	AccessRequest *AccessRequest `yaml:"access_request,omitempty"`
 }
 
 func (o *IdentityOutput) Init(ctx context.Context) error {


### PR DESCRIPTION
This allows tbot to use access requests instead of role requests on the identity output. If an access request is present in the output configuration, it will create a request and wait on it before issuing certificates, similar to tsh, and tbot's standard role requests will be disabled.

This currently requires manual tweaking of the bot role to add `allow.request` entries, and only really makes sense with `--oneshot`.

---

## Example

Note, this only works with the `identity` output type right now.

First, edit the bot role to add `spec.allow.request.roles`, e.g. with `tctl edit role/bot-foo`:
```yaml
kind: role
metadata:
  description: Automatically generated role for bot foo
  labels:
    teleport.internal/bot: foo
  name: bot-foo
spec:
  allow:
    impersonate:
      roles:
      - access
    request:
      roles:
      - access
    rules:
    - resources:
      - cert_authority
      verbs:
      - readnosecrets
```

(things may break with a nonempty list in `allow.impersonate.roles`, so a dummy role can be used for now)

Then, create a tbot.yaml like this:
```yaml
# tbot config file generated by `configure` command
version: v2
onboarding:
  token: foo
  join_method: token
storage:
  type: directory
  path: ./tbot-data
  symlinks: try-secure
  acls: "off"
services:
  - type: identity
    destination:
      type: directory
      path: ./tbot-user
      symlinks: try-secure
      acls: "off"
    access_request:
      roles: [access]
      reason: testing
    ssh_config: "on"
debug: false
proxy_server: example.teleport.sh:443
certificate_ttl: 1h0m0s
renewal_interval: 20m0s
oneshot: true
fips: false
```

Run tbot with `tbot start -c tbot.yaml` and it'll log its access request ID and wait. Approve the access request and it should write certs to the configured directory and exit (due to `oneshot: true`, or `--oneshot` if set).

An incomplete list of things we might want to make this a real feature:
- Explicit support for generating `allow.request` entries with the bot resource/bot service
- CLI support so tbot.yaml isn't needed
- Some nicer method to apply this to all output types since I clumsily hacked it into just the identity output. We could probably bake it into `generateIdentity()`.
- Probably need to evaluate UX and reliability in more depth; I just tossed in a function that will wait indefinitely for approval which is definitely not production ready.