### PR TITLE
[v15] build: Fix buildbox for fips builds of ironrdp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,12 +121,21 @@ ifeq ($(RDPCLIENT_SKIP_BUILD),0)
 ifneq ($(CHECK_RUST),)
 ifneq ($(CHECK_CARGO),)
 
-# Do not build RDP client on ARM or 386.
+is_fips_on_arm64 := no
+ifneq ("$(FIPS)","")
+ifeq ("$(ARCH)","arm64")
+is_fips_on_arm64 := yes
+endif
+endif
+
+# Do not build RDP client on 32-bit ARM or 386, or for FIPS builds on arm64.
 ifneq ("$(ARCH)","arm")
 ifneq ("$(ARCH)","386")
+ifneq ("$(is_fips_on_arm64)","yes")
 with_rdpclient := yes
 RDPCLIENT_MESSAGE := with-Windows-RDP-client
 RDPCLIENT_TAG := desktop_access_rdp
+endif
 endif
 endif
 

--- a/build.assets/Dockerfile-centos7-assets
+++ b/build.assets/Dockerfile-centos7-assets
@@ -87,14 +87,11 @@ RUN git clone --depth=1 https://github.com/ninja-build/ninja.git -b v1.11.1 && \
     cmake --build build-cmake --target  install"
 
 # Use just created devtool image with newer GCC and Cmake
-FROM --platform=$BUILDPLATFORM centos-devtoolset as clang14
+FROM --platform=$BUILDPLATFORM centos-devtoolset as clang12
 
 ARG DEVTOOLSET
 
-# Bring in our custom ninja build, needed for building clang.
-COPY --from=ninja-build /usr/local/bin/ninja /usr/local/bin/ninja
-
-# Compile Clang 14.0.6 from source. It is needed to create BoringSSL and BPF files.
+# Compile Clang 12.0.0 from source. It is needed to create BoringSSL and BPF files.
 # CentOS 7 doesn't provide it as a package unfortunately.
 # This version of Clang is explicitly required for FIPS compliance when building BoringSSL.
 # For more information please refer to the section 12. Guidance and Secure Operation of:
@@ -103,18 +100,17 @@ COPY --from=ninja-build /usr/local/bin/ninja /usr/local/bin/ninja
 # CLANG_BUILD_TOOLS must be on, it builds clang binary,
 # LLVM_BUILD_TOOLS must be on, it builds llvm-strip binary.
 # the rest is disabled to speedup the compilation.
-RUN git clone --branch llvmorg-14.0.6 --depth=1 https://github.com/llvm/llvm-project.git && \
+RUN git clone --branch llvmorg-12.0.0 --depth=1 https://github.com/llvm/llvm-project.git && \
     cd llvm-project/ && \
-    [ "$(git rev-parse HEAD)" = 'f28c006a5895fc0e329fe15fead81e37457cb1d1' ] && \
+    [ "$(git rev-parse HEAD)" = 'd28af7c654d8db0b68c175db5ce212d74fb5e9bc' ] && \
     mkdir build && cd build/ && \
     scl enable ${DEVTOOLSET} 'bash -c "cmake3 \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=/opt/llvm \
-    -DLLVM_ENABLE_PROJECTS=\"clang;libcxx;libcxxabi\" \
-    -DLLVM_ENABLE_LIBCXX=ON \
-    -G \"Ninja\" ../llvm && \
-    cmake3 --build . && \
-    cmake3 -DCMAKE_INSTALL_PREFIX=/opt/llvm -P cmake_install.cmake"' && \
+    -DLLVM_ENABLE_PROJECTS=clang \
+    -DLLVM_BUILD_TOOLS=ON \
+    -G \"Unix Makefiles\" ../llvm && \
+    make -j$(grep -c processor /proc/cpuinfo) install-llvm-strip install-clang-format install-clang install-clang-resource-headers install-libclang"' && \
     cd ../.. && \
     rm -rf llvm-project
 
@@ -147,7 +143,7 @@ RUN mkdir -p /opt/custom-packages && cd /opt && \
 FROM scratch AS buildbox-centos7-assets
 
 # Copy Clang into the final image.
-COPY --from=clang14 /opt/llvm /opt/llvm/
+COPY --from=clang12 /opt/llvm /opt/llvm/
 
 # Copy ninja into the final image.
 COPY --from=ninja-build /usr/local/bin/ninja /usr/local/bin/ninja

--- a/common.mk
+++ b/common.mk
@@ -23,8 +23,8 @@ ifneq ("$(wildcard /usr/libbpf-${LIBBPF_VER}/include/bpf/bpf.h)","")
 with_bpf := yes
 BPF_TAG := bpf
 BPF_MESSAGE := with-BPF-support
-CLANG ?= $(shell which clang || which clang-14)
-LLVM_STRIP ?= $(shell which llvm-strip || which llvm-strip-14)
+CLANG ?= $(shell which clang || which clang-12)
+LLVM_STRIP ?= $(shell which llvm-strip || which llvm-strip-12)
 KERNEL_ARCH := $(shell uname -m | sed 's/x86_64/x86/g; s/aarch64/arm64/g')
 INCLUDES :=
 ER_BPF_BUILDDIR := lib/bpf/bytecode

--- a/lib/srv/desktop/rdp/rdpclient/src/client.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/client.rs
@@ -72,7 +72,7 @@ use crate::rdpdr::scard::SCARD_DEVICE_ID;
 use crate::rdpdr::TeleportRdpdrBackend;
 use crate::ssl::TlsStream;
 #[cfg(feature = "fips")]
-use tokio_boring::{HandshakeError, SslStream};
+use tokio_boring::HandshakeError;
 
 const RDP_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 

--- a/lib/srv/desktop/rdp/rdpclient/src/ssl.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/ssl.rs
@@ -46,6 +46,7 @@ pub(crate) async fn upgrade(
         use tokio::io::AsyncWriteExt;
         let mut builder = SslConnector::builder(SslMethod::tls_client())?;
         builder.set_verify(SslVerifyMode::NONE);
+        builder.set_fips_compliance_policy()?;
         let configuration = builder.build().configure()?;
         let mut tls_stream =
             tokio_boring::connect(configuration, server_name, initial_stream).await?;


### PR DESCRIPTION
Apply some changes that have been made to the later branches to v15 to
try to get the FIPS release builds working. It seems to have broken with
an ironrdp update recently.

This rolls back clang in the buildbox from v14 to v12 as required by
FIPS compliance, and also disables rdpclient for arm64 FIPS builds
(although that is actually controlled by the e/Makefile, so this change
here is just to keep things in sync).

Backport: https://github.com/gravitational/teleport/pull/42277 (partial)
Companion: https://github.com/gravitational/teleport.e/pull/6065
Test-run: https://github.com/gravitational/teleport.e/actions/runs/13322984063
Test-run: https://github.com/gravitational/teleport.e/actions/runs/13322571444
Test-run: https://github.com/gravitational/teleport.e/actions/runs/13322865636

---

Note: Once the companion teleport.e PR has merged, I'll add a e ref update to
bring that change in here.
