### PR TITLE
docs: redirect for ui auth connectors page

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -370,6 +370,11 @@
       "permanent": true
     },
     {
+      "source": "/enterprise/sso/",
+      "destination": "/admin-guides/access-controls/sso/",
+      "permanent": true
+    },
+    {
       "source": "/access-controls/access-request-plugins/",
       "destination": "/admin-guides/access-controls/access-request-plugins/",
       "permanent": true


### PR DESCRIPTION
The current link on the Auth Connectors page is broken:

> Please [view our documentation](https://goteleport.com/docs/enterprise/sso/) for samples of each connector.

Created a redirect to https://goteleport.com/docs/admin-guides/access-controls/sso/

![broken-auth-connector-ui-link](https://github.com/user-attachments/assets/af84bb07-d04b-4c29-a062-e0b7fe40601a)
