### PR TITLE
docs: include note on label expr support

### DIFF
--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -212,6 +212,12 @@ spec:
       contains(user.spec.traits["teams"], labels["team"])
 ```
 
+<Admonition type="note">
+Usage of label expressions must be the only label logic in roles
+assigned to an identity. For example you cannot have `node_labels`
+and `node_labels_expressions` in the same role or from separate roles.
+</Admonition>
+
 The `<kind>_labels_expression` fields have the same purpose of the
 matching `<kind>_labels` fields, but support predicate expressions instead
 of label matchers.


### PR DESCRIPTION
Include note that label expressions should not be intermixed with other label matching.  The label expressions are not evaluated then.