### PR TITLE
[v17] Prevent loading default config in tctl on Windows

### DIFF
--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -25,11 +25,13 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/breaker"
+	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/autoupdate/tools"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -111,7 +113,9 @@ func TryRun(commands []CLICommand, args []string) error {
 	if configFileEnv, ok := os.LookupEnv(defaults.ConfigFileEnvar); ok {
 		ccf.ConfigFile = configFileEnv
 	} else {
-		if utils.FileExists(defaults.ConfigFilePath) {
+		// Skip the default config path on windows since the C:\etc\ directory
+		// does not exist by default and low-privileged users can create the folder.
+		if runtime.GOOS != constants.WindowsOS && utils.FileExists(defaults.ConfigFilePath) {
 			ccf.ConfigFile = defaults.ConfigFilePath
 		}
 	}


### PR DESCRIPTION
Backport #52184 to branch/v17

changelog: Remove the ability of tctl to load the default configuration file on Windows.
