### PR TITLE
Correcting git user setup for post-release automation bot

### DIFF
--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -91,8 +91,8 @@ jobs:
           REVIEWER: ${{ github.event.release.author.login }}
         run: |
           BRANCH_NAME="release-auto-branch-$(date +%s)"
-          git config --global user.email "noreply@github.com"
-          git config --global user.name "GitHub"
+          git config --global user.email "128860004+teleport-post-release-automation[bot]@users.noreply.github.com"
+          git config --global user.name "teleport-post-release-automation[bot]"
 
           # get Go version from go.mod (preferring the toolchain directive if it's present)
           GO_VERSION=$(go mod edit -json | jq -r 'if has("Toolchain") then .Toolchain | sub("go"; "") else .Go end')

--- a/.github/workflows/update-ami-ids.yaml
+++ b/.github/workflows/update-ami-ids.yaml
@@ -53,7 +53,7 @@ jobs:
           VERSION: ${{ inputs.version }}
           PR_REVIEWER: ${{ github.event.release.author.login }}
         run: |
-          git config --global user.email "noreply@github.com"
-          git config --global user.name "GitHub"
+          git config --global user.email "128860004+teleport-post-release-automation[bot]@users.noreply.github.com"
+          git config --global user.name "teleport-post-release-automation[bot]"
           make -C assets/aws create-update-pr "TELEPORT_VERSION=${VERSION}" "AMI_PR_REVIEWER=${PR_REVIEWER}"
           echo "AMI PR: $(gh pr view --json url --jq .url)" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Previously, when setting up the Git user configuration in post release automation, we used configuration that matched the `webflow` user for GitHub. This was causing a problem with the CLA check since it isn't an allowed user.

GitHub uses the following format to tie commits to a bot's identity.
* `user.name`: <bot-username>[bot]
* `user.email`: <bot-id>+<bot-username>[bot]@users.noreply.github.com

With these set correctly, the commits generated by the post-release workflows should by tied to the bot's identity.