### PR TITLE
Add iteration support to etcd

### DIFF
--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"iter"
 	"sort"
 	"time"
 
@@ -111,6 +112,34 @@ type Backend interface {
 	// CloseWatchers closes all the watchers
 	// without closing the backend
 	CloseWatchers()
+}
+
+// IterateParams are parameters that are provided to
+// [BackendWithItems.Items] to alter the iteration behavior.
+type IterateParams struct {
+	// StartKey is the minimum key in the range yielded by the iteration. This key
+	// will be included in the results if it exists.
+	StartKey Key
+	// EndKey is the maximum key in the range yielded by the iteration. This key
+	// will be included in the results if it exists.
+	EndKey Key
+	// Descending makes the iteration yield items from the biggest to the smallest
+	// key (i.e. from EndKey to StartKey). If unset, the iteration will proceed in the
+	// usual ascending order (i.e. from StartKey to EndKey).
+	Descending bool
+	// Limit is an optional maximum number of items to retrieve during iteration.
+	Limit int
+}
+
+// BackendWithItems is a temporary interface that will be added to [backend.Backend]
+// once all concrete backend implementations satisfy the new interface.
+// TODO(tross): REMEMBER TO DELETE THIS
+type BackendWithItems interface {
+	Backend
+
+	// Items produces an iterator of backend items in the range, and order
+	// described in the provided [IterateParams].
+	Items(ctx context.Context, params IterateParams) iter.Seq2[Item, error]
 }
 
 // New initializes a new [Backend] implementation based on the service config.

--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -25,9 +25,9 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"errors"
+	"iter"
 	"log/slog"
 	"os"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -649,6 +649,84 @@ func (b *EtcdBackend) NewWatcher(ctx context.Context, watch backend.Watch) (back
 	return b.buf.NewWatcher(ctx, watch)
 }
 
+func (b *EtcdBackend) Items(ctx context.Context, params backend.IterateParams) iter.Seq2[backend.Item, error] {
+	if params.StartKey.IsZero() {
+		err := trace.BadParameter("missing parameter startKey")
+		return func(yield func(backend.Item, error) bool) { yield(backend.Item{}, err) }
+	}
+	if params.EndKey.IsZero() {
+		err := trace.BadParameter("missing parameter endKey")
+		return func(yield func(backend.Item, error) bool) { yield(backend.Item{}, err) }
+	}
+
+	sort := clientv3.SortAscend
+	if params.Descending {
+		sort = clientv3.SortDescend
+	}
+
+	const defaultPageSize = 1000
+	return func(yield func(backend.Item, error) bool) {
+		inclusiveStartKey := b.prependPrefix(params.StartKey)
+		// etcd's range query includes the start point and excludes the end point,
+		// but Backend.GetRange is supposed to be inclusive at both ends, so we
+		// query until the very next key in lexicographic order (i.e., the same key
+		// followed by a 0 byte)
+		endKey := b.prependPrefix(params.EndKey) + "\x00"
+		count := 0
+
+		pageSize := defaultPageSize
+		for {
+			if params.Limit > backend.NoLimit {
+				pageSize = min(params.Limit-count, defaultPageSize)
+			}
+
+			start := b.clock.Now()
+			re, err := b.clients.Next().Get(ctx, inclusiveStartKey,
+				clientv3.WithRange(endKey),
+				clientv3.WithSort(clientv3.SortByKey, sort),
+				clientv3.WithLimit(int64(pageSize)),
+			)
+			batchReadLatencies.Observe(time.Since(start).Seconds())
+			batchReadRequests.Inc()
+			if err := convertErr(err); err != nil {
+				yield(backend.Item{}, trace.Wrap(err))
+				return
+			}
+
+			if len(re.Kvs) == 0 {
+				return
+			}
+
+			for _, kv := range re.Kvs {
+				value, err := unmarshal(kv.Value)
+				if err != nil {
+					yield(backend.Item{}, trace.Wrap(err))
+					return
+				}
+
+				if !yield(backend.Item{
+					Key:      b.trimPrefix(kv.Key),
+					Value:    value,
+					Revision: toBackendRevision(kv.ModRevision),
+				}, nil) {
+					return
+				}
+
+				count++
+				if params.Limit != backend.NoLimit && count >= params.Limit {
+					return
+				}
+			}
+
+			if params.Descending {
+				endKey = string(re.Kvs[len(re.Kvs)-1].Key)
+			} else {
+				inclusiveStartKey = string(re.Kvs[len(re.Kvs)-1].Key) + "\x00"
+			}
+		}
+	}
+}
+
 // GetRange returns query range
 func (b *EtcdBackend) GetRange(ctx context.Context, startKey, endKey backend.Key, limit int) (*backend.GetResult, error) {
 	if startKey.IsZero() {
@@ -657,35 +735,18 @@ func (b *EtcdBackend) GetRange(ctx context.Context, startKey, endKey backend.Key
 	if endKey.IsZero() {
 		return nil, trace.BadParameter("missing parameter endKey")
 	}
-	// etcd's range query includes the start point and excludes the end point,
-	// but Backend.GetRange is supposed to be inclusive at both ends, so we
-	// query until the very next key in lexicographic order (i.e., the same key
-	// followed by a 0 byte)
-	opts := []clientv3.OpOption{clientv3.WithRange(b.prependPrefix(endKey) + "\x00")}
-	if limit > 0 {
-		opts = append(opts, clientv3.WithLimit(int64(limit)))
-	}
-	start := b.clock.Now()
-	re, err := b.clients.Next().Get(ctx, b.prependPrefix(startKey), opts...)
-	batchReadLatencies.Observe(time.Since(start).Seconds())
-	batchReadRequests.Inc()
-	if err := convertErr(err); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	items := make([]backend.Item, 0, len(re.Kvs))
-	for _, kv := range re.Kvs {
-		value, err := unmarshal(kv.Value)
+
+	var result backend.GetResult
+	for item, err := range b.Items(ctx, backend.IterateParams{StartKey: startKey, EndKey: endKey, Limit: limit}) {
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		items = append(items, backend.Item{
-			Key:      b.trimPrefix(kv.Key),
-			Value:    value,
-			Revision: toBackendRevision(kv.ModRevision),
-		})
+		result.Items = append(result.Items, item)
+		if limit != backend.NoLimit && len(result.Items) > limit {
+			return nil, trace.BadParameter("item iterator produced more items than requested (this is a bug). limit=%d, recevied=%d", limit, len(result.Items))
+		}
 	}
-	sort.Sort(backend.Items(items))
-	return &backend.GetResult{Items: items}, nil
+	return &result, nil
 }
 
 func toBackendRevision(rev int64) string {

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -36,6 +37,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
@@ -140,6 +142,10 @@ func RunBackendComplianceSuite(t *testing.T, newBackend Constructor) {
 
 	t.Run("QueryRange", func(t *testing.T) {
 		testQueryRange(t, newBackend)
+	})
+
+	t.Run("Items", func(t *testing.T) {
+		testItems(t, newBackend)
 	})
 
 	t.Run("DeleteRange", func(t *testing.T) {
@@ -355,6 +361,218 @@ func testQueryRange(t *testing.T, newBackend Constructor) {
 	result, err = uut.GetRange(ctx, backend.RangeEnd(prefix("prefix", "c", "c2")), backend.RangeEnd(prefix("prefix")), 2)
 	require.NoError(t, err)
 	require.Empty(t, result.Items)
+}
+
+func testItems(t *testing.T, newBackend Constructor) {
+	uut, _, err := newBackend()
+	require.NoError(t, err)
+	defer func() { require.NoError(t, uut.Close()) }()
+
+	it, ok := uut.(backend.BackendWithItems)
+	if !ok {
+		t.Skip("Backend does not support iteration")
+	}
+
+	ctx := context.Background()
+	prefix := MakePrefix()
+
+	outOfScope := backend.Item{Key: prefix("a"), Value: []byte("should not show up")}
+	a := backend.Item{Key: prefix("prefix", "a"), Value: []byte("val a")}
+	b := backend.Item{Key: prefix("prefix", "b"), Value: []byte("val b")}
+	c1 := backend.Item{Key: prefix("prefix", "c", "c1"), Value: []byte("val c1")}
+	c2 := backend.Item{Key: prefix("prefix", "c", "c2"), Value: []byte("val c2")}
+
+	// create items and set the revisions received from the lease
+	for _, item := range []*backend.Item{&outOfScope, &a, &b, &c1, &c2} {
+		lease, err := uut.Create(ctx, *item)
+		require.NoError(t, err, "Failed creating value: %q => %q", item.Key, item.Value)
+		item.Revision = lease.Revision
+	}
+
+	t.Run("ascending order", func(t *testing.T) {
+		cases := []struct {
+			name             string
+			startKey, endKey backend.Key
+			limit            int
+			expected         []backend.Item
+		}{
+			{
+				name:     "prefix range fetch",
+				startKey: prefix("prefix"),
+				endKey:   backend.RangeEnd(prefix("prefix")),
+				limit:    backend.NoLimit,
+				expected: []backend.Item{a, b, c1, c2},
+			},
+			{
+				name:     "sub prefix range fetch",
+				startKey: prefix("prefix", "c"),
+				endKey:   backend.RangeEnd(prefix("prefix", "c")),
+				limit:    backend.NoLimit,
+				expected: []backend.Item{c1, c2},
+			},
+			{
+				name:     "range match",
+				startKey: prefix("prefix", "c", "c1"),
+				endKey:   backend.RangeEnd(prefix("prefix", "c", "cz")),
+				limit:    backend.NoLimit,
+				expected: []backend.Item{c1, c2},
+			},
+			{
+				name:     "pagination",
+				startKey: prefix("prefix"),
+				endKey:   backend.RangeEnd(prefix("prefix")),
+				limit:    2,
+				expected: []backend.Item{a, b},
+			},
+			{
+				name:     "fetch next two items",
+				startKey: backend.RangeEnd(prefix("prefix", "b")),
+				endKey:   backend.RangeEnd(prefix("prefix")),
+				limit:    2,
+				expected: []backend.Item{c1, c2},
+			},
+			{
+				name:     "next fetch is empty",
+				startKey: backend.RangeEnd(prefix("prefix", "c", "c2")),
+				endKey:   backend.RangeEnd(prefix("prefix")),
+				limit:    2,
+			},
+		}
+
+		for _, test := range cases {
+			t.Run(test.name, func(t *testing.T) {
+				i := 0
+				for item, err := range it.Items(ctx, backend.IterateParams{StartKey: test.startKey, EndKey: test.endKey}) {
+					require.NoError(t, err)
+
+					if len(test.expected) == 0 {
+						t.Fatal("iterator produced an item when none are expected")
+					}
+					expected := test.expected[i]
+
+					assert.Equal(t, expected.Key, item.Key)
+					assert.Equal(t, expected.Value, item.Value)
+					assert.Equal(t, expected.Revision, item.Revision)
+					i++
+
+					if i == test.limit {
+						break
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("descending order", func(t *testing.T) {
+		cases := []struct {
+			name             string
+			startKey, endKey backend.Key
+			limit            int
+			expected         []backend.Item
+		}{
+			{
+				name:     "prefix range fetch",
+				startKey: prefix("prefix"),
+				endKey:   backend.RangeEnd(prefix("prefix")),
+				limit:    backend.NoLimit,
+				expected: []backend.Item{c2, c1, b, a},
+			},
+			{
+				name:     "sub prefix range fetch",
+				startKey: prefix("prefix", "c"),
+				endKey:   backend.RangeEnd(prefix("prefix", "c")),
+				limit:    backend.NoLimit,
+				expected: []backend.Item{c2, c1},
+			},
+			{
+				name:     "range match",
+				startKey: prefix("prefix", "c", "c1"),
+				endKey:   backend.RangeEnd(prefix("prefix", "c", "cz")),
+				limit:    backend.NoLimit,
+				expected: []backend.Item{c2, c1},
+			},
+			{
+				name:     "pagination",
+				startKey: prefix("prefix"),
+				endKey:   backend.RangeEnd(prefix("prefix")),
+				limit:    2,
+				expected: []backend.Item{c2, c1},
+			},
+			{
+				name:     "fetch next two items",
+				startKey: backend.RangeEnd(prefix("prefix", "b")),
+				endKey:   backend.RangeEnd(prefix("prefix")),
+				limit:    2,
+				expected: []backend.Item{c2, c1},
+			},
+			{
+				name:     "next fetch is empty",
+				startKey: backend.RangeEnd(prefix("prefix", "c", "c2")),
+				endKey:   backend.RangeEnd(prefix("prefix")),
+				limit:    2,
+			},
+		}
+
+		for _, test := range cases {
+			t.Run(test.name, func(t *testing.T) {
+				i := 0
+				for item, err := range it.Items(ctx, backend.IterateParams{StartKey: test.startKey, EndKey: test.endKey, Descending: true}) {
+					require.NoError(t, err)
+
+					if len(test.expected) == 0 {
+						t.Fatal("iterator produced an item when none are expected")
+					}
+
+					if i >= len(test.expected) {
+						t.Fatal("iterator produced more items than expected")
+					}
+
+					expected := test.expected[i]
+
+					assert.Equal(t, expected.Key, item.Key)
+					assert.Equal(t, expected.Value, item.Value)
+					assert.Equal(t, expected.Revision, item.Revision)
+					i++
+					if i == test.limit {
+						break
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("pagination", func(t *testing.T) {
+		const count = 1501
+		expected := make([]string, 0, count)
+
+		for i := range count {
+			value := strconv.Itoa(i)
+			expected = append(expected, value)
+			item := backend.Item{Key: prefix("page", strconv.Itoa(i)), Value: []byte(value)}
+			_, err := uut.Create(ctx, item)
+			require.NoError(t, err, "Failed creating value: %q => %q", item.Key, item.Value)
+		}
+
+		slices.Sort(expected)
+
+		t.Run("ascending", func(t *testing.T) {
+			i := 0
+			for item := range it.Items(ctx, backend.IterateParams{StartKey: prefix("page"), EndKey: backend.RangeEnd(prefix("page"))}) {
+				require.Equal(t, expected[i], string(item.Value))
+				i++
+			}
+			require.Equal(t, count, i)
+		})
+
+		t.Run("descending", func(t *testing.T) {
+			i := count - 1
+			for item := range it.Items(ctx, backend.IterateParams{StartKey: prefix("page"), EndKey: backend.RangeEnd(prefix("page")), Descending: true}) {
+				assert.Equal(t, expected[i], string(item.Value))
+				i--
+			}
+			require.Equal(t, -1, i)
+		})
+	})
 }
 
 // testDeleteRange tests delete items by range


### PR DESCRIPTION
Introduces a new `Items(context.Context, backend.IterateParams) iter.Seq2[backend.Item, error]` to the etcd backend. The core logic for this function was moved from GetRange, and GetRange now defers to calling Iterate and collecting a slice of items.

The motivation for this change is to attempt to reduce the complexity of pagination for consumers of GetRange. While `backend.IterateRange` and `backend.StreamRange` do already exists to serve the same purpose, they too have suffered from pagination bugs in the past. Additionally, this aims to unify iteration to using the iter package instead of the various homegrown iteration mechanisms that exist throughout the code base.

There is also one distinct difference to the iteration api: it allows retrieving items within the specified range in ascending or descending key order. While there may not be many use cases for this today, exposing this in the api from it's inception is easier than adding functional options, or IterateAscending/IterateDescending later.