### PR TITLE
Fix TestAutoUsersPostgres flakiness

### DIFF
--- a/lib/srv/db/objects/importer.go
+++ b/lib/srv/db/objects/importer.go
@@ -77,7 +77,11 @@ func newSingleDatabaseImporter(cfg Config, database types.Database, fetcher Obje
 }
 
 func (i *singleDatabaseImporter) start(ctx context.Context) {
-	i.cfg.Log.DebugContext(ctx, "Starting database importer.")
+	i.cfg.Log.DebugContext(ctx, "Starting database importer",
+		"scan_interval", i.cfg.ScanInterval.String(),
+		"object_ttl", i.cfg.ObjectTTL.String(),
+		"refresh_threshold", i.cfg.RefreshThreshold.String(),
+	)
 	ticker := interval.New(interval.Config{
 		Jitter:        retryutils.SeventhJitter,
 		Duration:      i.cfg.ScanInterval * 7 / 6,

--- a/lib/srv/db/objects/objects.go
+++ b/lib/srv/db/objects/objects.go
@@ -99,7 +99,11 @@ func (c *Config) loadEnvVarOverrides(ctx context.Context) {
 	}
 
 	if needInfo {
-		c.Log.InfoContext(ctx, "Applied env var overrides.", "scan_interval", c.ScanInterval, "object_ttl", c.ObjectTTL, "refresh_threshold", c.RefreshThreshold)
+		c.Log.InfoContext(ctx, "Applied env var overrides",
+			"scan_interval", c.ScanInterval.String(),
+			"object_ttl", c.ObjectTTL.String(),
+			"refresh_threshold", c.RefreshThreshold.String(),
+		)
 	}
 }
 


### PR DESCRIPTION
* Disable the object importer during test to avoid unexpected database connections in the middle of the test.

Fixes https://github.com/gravitational/teleport/issues/51355

The issue is that the object importer can connect to the db to scan for objects at a random time during the auto-user test for Postgres.
If that happens, then the test can fail since it expects a specific order of connections to the database with specific startup parameters.

This fixes the test by disabling the object importer.