### PR TITLE
Add VNet diagnostics alert

### DIFF
--- a/lib/vnet/diag/diag.go
+++ b/lib/vnet/diag/diag.go
@@ -35,10 +35,6 @@ import (
 
 var log = logutils.NewPackageLogger(teleport.ComponentKey, teleport.Component("vnet", "diag"))
 
-// Diagnostician runs individual diag checks along with their accompanying commands and produces a
-// report.
-type Diagnostician struct{}
-
 // DiagCheck is an individual diag check run by [GenerateReport].
 type DiagCheck interface {
 	// Run performs the check.

--- a/web/packages/design/src/Alert/Alert.tsx
+++ b/web/packages/design/src/Alert/Alert.tsx
@@ -366,10 +366,16 @@ export const ActionButton = ({
   action: { href, content, onClick },
   fill,
   intent,
+  inputAlignment = false,
+  disabled = false,
+  title,
 }: {
   action: Action;
   fill?: ButtonFill;
   intent?: ButtonIntent;
+  inputAlignment?: boolean;
+  disabled?: boolean;
+  title?: string;
 }) =>
   href ? (
     <Button
@@ -379,11 +385,21 @@ export const ActionButton = ({
       fill={fill}
       intent={intent}
       onClick={onClick}
+      inputAlignment={inputAlignment}
+      disabled={disabled}
+      title={title}
     >
       {content}
     </Button>
   ) : (
-    <Button fill={fill} intent={intent} onClick={onClick}>
+    <Button
+      fill={fill}
+      intent={intent}
+      onClick={onClick}
+      inputAlignment={inputAlignment}
+      disabled={disabled}
+      title={title}
+    >
       {content}
     </Button>
   );

--- a/web/packages/teleterm/src/services/tshd/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/services/tshd/fixtures/mocks.ts
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { Timestamp } from 'gen-proto-ts/google/protobuf/timestamp_pb';
+
 import {
   makeApp,
   makeAppGateway,
@@ -118,5 +120,12 @@ export class MockVnetClient implements VnetClient {
   stop = () => new MockedUnaryCall({});
   listDNSZones = () => new MockedUnaryCall({ dnsZones: [] });
   getBackgroundItemStatus = () => new MockedUnaryCall({ status: 0 });
-  runDiagnostics = () => new MockedUnaryCall({});
+  runDiagnostics() {
+    return new MockedUnaryCall({
+      report: {
+        checks: [],
+        createdAt: Timestamp.fromDate(new Date(2025, 0, 1, 12, 0)),
+      },
+    });
+  }
 }

--- a/web/packages/teleterm/src/services/vnet/testHelpers.ts
+++ b/web/packages/teleterm/src/services/vnet/testHelpers.ts
@@ -1,0 +1,62 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Timestamp } from 'gen-proto-ts/google/protobuf/timestamp_pb';
+import {
+  CheckAttempt,
+  CheckAttemptStatus,
+  CheckReport,
+  CheckReportStatus,
+  Report,
+} from 'gen-proto-ts/teleport/lib/vnet/diag/v1/diag_pb';
+
+export const makeReport = (props: Partial<Report> = {}): Report => ({
+  createdAt: Timestamp.fromDate(new Date(2025, 0, 1, 12, 0)),
+  checks: [makeCheckAttempt()],
+  networkStackAttempt: {
+    status: CheckAttemptStatus.OK,
+    error: '',
+    networkStack: {
+      dnsZones: ['teleport.example.com', 'company.test'],
+      interfaceName: 'utun4',
+      ipv4CidrRanges: ['100.64.0.0/10'],
+      ipv6Prefix: 'fdff:fd74:46c0::',
+    },
+  },
+  ...props,
+});
+
+export const makeCheckAttempt = (
+  props: Partial<CheckAttempt> = {}
+): CheckAttempt => ({
+  status: CheckAttemptStatus.OK,
+  error: '',
+  commands: [],
+  checkReport: makeCheckReport(),
+  ...props,
+});
+
+export const makeCheckReport = (
+  props: Partial<CheckReport> = {}
+): CheckReport => ({
+  status: CheckReportStatus.OK,
+  report: {
+    oneofKind: undefined,
+  },
+  ...props,
+});

--- a/web/packages/teleterm/src/ui/TopBar/Connections/Connections.story.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/Connections.story.tsx
@@ -42,35 +42,6 @@ export default {
 
 const rootClusterUri = '/clusters/foo';
 
-export function Story() {
-  const appContext = new MockAppContext();
-  prepareAppContext(appContext);
-  appContext.clustersService.setState(draft => {
-    const rootCluster1 = makeRootCluster({
-      uri: rootClusterUri,
-      name: 'teleport.example.sh',
-      proxyHost: 'teleport.example.sh:443',
-    });
-    const rootCluster2 = makeRootCluster({
-      uri: '/clusters/bar',
-      name: 'bar.example.com',
-      proxyHost: 'bar.example.com:3080',
-    });
-    draft.clusters.set(rootCluster1.uri, rootCluster1);
-    draft.clusters.set(rootCluster2.uri, rootCluster2);
-  });
-
-  return (
-    <AppContextProvider value={appContext}>
-      <ConnectionsContextProvider>
-        <VnetContextProvider>
-          <Connections />
-        </VnetContextProvider>
-      </ConnectionsContextProvider>
-    </AppContextProvider>
-  );
-}
-
 export function MultipleClusters() {
   const appContext = new MockAppContext();
   prepareAppContext(appContext);
@@ -98,6 +69,29 @@ export function MultipleClusters() {
       clusterName: 'bar.example.com',
     },
   ];
+
+  return (
+    <AppContextProvider value={appContext}>
+      <ConnectionsContextProvider>
+        <VnetContextProvider>
+          <Connections />
+        </VnetContextProvider>
+      </ConnectionsContextProvider>
+    </AppContextProvider>
+  );
+}
+
+export function SingleCluster() {
+  const appContext = new MockAppContext();
+  prepareAppContext(appContext);
+  appContext.clustersService.setState(draft => {
+    const rootCluster1 = makeRootCluster({
+      uri: rootClusterUri,
+      name: 'teleport.example.sh',
+      proxyHost: 'teleport.example.sh:443',
+    });
+    draft.clusters.set(rootCluster1.uri, rootCluster1);
+  });
 
   return (
     <AppContextProvider value={appContext}>

--- a/web/packages/teleterm/src/ui/TopBar/Connections/Connections.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/Connections.tsx
@@ -71,10 +71,9 @@ export function Connections() {
         onClose={close}
       >
         {/*
-          324px matches the total width when the outer div inside Popover used to have 12px of
-          padding (so 24px on both sides) and ConnectionsFilterableList had 300px of width.
+          It needs to be wide enough for the diag warning in the VNet panel to not be squished too much.
         */}
-        <Box width="324px" bg="levels.elevated">
+        <Box width="396px" bg="levels.elevated">
           <StepSlider
             tDuration={250}
             currFlow="default"

--- a/web/packages/teleterm/src/ui/Vnet/DiagnosticsAlert.test.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DiagnosticsAlert.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useEffect } from 'react';
+
+import { render, screen } from 'design/utils/testing';
+import {
+  CheckAttemptStatus,
+  CheckReportStatus,
+  Report,
+} from 'gen-proto-ts/teleport/lib/vnet/diag/v1/diag_pb';
+
+import { MockedUnaryCall } from 'teleterm/services/tshd/cloneableClient';
+import {
+  makeCheckAttempt,
+  makeCheckReport,
+  makeReport,
+} from 'teleterm/services/vnet/testHelpers';
+import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
+import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
+
+import { DiagnosticsAlert } from './DiagnosticsAlert';
+import { useVnetContext, VnetContextProvider } from './vnetContext';
+
+const noIssuesFound = 'No issues found';
+const otherSoftwareMightInterfere =
+  'software on your device might interfere with VNet';
+const someChecksFailed = 'Some diagnostic checks failed';
+
+describe('DiagnosticsAlert', () => {
+  const tests: Array<{
+    when: string;
+    expectedMessage: string;
+    makeReport: () => Report;
+  }> = [
+    {
+      when: 'all checks succeeded and have found no issues',
+      expectedMessage: noIssuesFound,
+      makeReport,
+    },
+    {
+      when: 'all checks found issues',
+      expectedMessage: otherSoftwareMightInterfere,
+      makeReport: () =>
+        makeReport({
+          checks: [
+            makeCheckAttempt({
+              checkReport: makeCheckReport({
+                status: CheckReportStatus.ISSUES_FOUND,
+              }),
+            }),
+          ],
+        }),
+    },
+    {
+      when: 'all checks failed to complete',
+      expectedMessage: someChecksFailed,
+      makeReport: () =>
+        makeReport({
+          checks: [
+            makeCheckAttempt({
+              status: CheckAttemptStatus.ERROR,
+              error: 'something went wrong',
+              checkReport: undefined,
+            }),
+          ],
+        }),
+    },
+    {
+      when: 'some checks found no issues, some did',
+      expectedMessage: otherSoftwareMightInterfere,
+      makeReport: () =>
+        makeReport({
+          checks: [
+            makeCheckAttempt({
+              checkReport: makeCheckReport({
+                status: CheckReportStatus.OK,
+              }),
+            }),
+            makeCheckAttempt({
+              checkReport: makeCheckReport({
+                status: CheckReportStatus.ISSUES_FOUND,
+              }),
+            }),
+          ],
+        }),
+    },
+    {
+      when: 'some checks found no issues, some failed to complete',
+      expectedMessage: someChecksFailed,
+      makeReport: () =>
+        makeReport({
+          checks: [
+            makeCheckAttempt({
+              checkReport: makeCheckReport({
+                status: CheckReportStatus.OK,
+              }),
+            }),
+            makeCheckAttempt({
+              status: CheckAttemptStatus.ERROR,
+              error: 'something went wrong',
+              checkReport: undefined,
+            }),
+          ],
+        }),
+    },
+    {
+      when: 'some checks found issues, some failed to complete',
+      expectedMessage: otherSoftwareMightInterfere,
+      makeReport: () =>
+        makeReport({
+          checks: [
+            makeCheckAttempt({
+              checkReport: makeCheckReport({
+                status: CheckReportStatus.ISSUES_FOUND,
+              }),
+            }),
+            makeCheckAttempt({
+              status: CheckAttemptStatus.ERROR,
+              error: 'something went wrong',
+              checkReport: undefined,
+            }),
+          ],
+        }),
+    },
+    {
+      when: 'some checks found no issues, some failed to complete',
+      expectedMessage: someChecksFailed,
+      makeReport: () =>
+        makeReport({
+          checks: [
+            makeCheckAttempt({
+              checkReport: makeCheckReport({
+                status: CheckReportStatus.OK,
+              }),
+            }),
+            makeCheckAttempt({
+              status: CheckAttemptStatus.ERROR,
+              error: 'something went wrong',
+              checkReport: undefined,
+            }),
+          ],
+        }),
+    },
+  ];
+
+  test.each(tests)(
+    'when $when it says "$expectedMessage"',
+    async ({ makeReport, expectedMessage }) => {
+      const appContext = new MockAppContext();
+      const report = makeReport();
+      appContext.vnet.runDiagnostics = () => new MockedUnaryCall({ report });
+
+      render(
+        <MockAppContextProvider appContext={appContext}>
+          <VnetContextProvider>
+            <RunDiagnostics />
+            <DiagnosticsAlert />
+          </VnetContextProvider>
+        </MockAppContextProvider>
+      );
+
+      expect(
+        await screen.findByText(new RegExp(expectedMessage))
+      ).toBeInTheDocument();
+    }
+  );
+});
+
+const RunDiagnostics = () => {
+  const { runDiagnostics } = useVnetContext();
+  useEffect(() => {
+    void runDiagnostics();
+  }, [runDiagnostics]);
+
+  return null;
+};

--- a/web/packages/teleterm/src/ui/Vnet/DiagnosticsAlert.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DiagnosticsAlert.tsx
@@ -1,0 +1,181 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ReactNode, useCallback } from 'react';
+
+import { Alert, Flex, P2 } from 'design';
+import { ActionButton } from 'design/Alert';
+import { AlertProps } from 'design/Alert/Alert';
+import {
+  CheckAttemptStatus,
+  CheckReportStatus,
+} from 'gen-proto-ts/teleport/lib/vnet/diag/v1/diag_pb';
+
+import { useStoreSelector } from 'teleterm/ui/hooks/useStoreSelector';
+
+import { textSpacing } from './sliderStep';
+import { useVnetContext } from './vnetContext';
+
+export const DiagnosticsAlert = () => {
+  const { diagnosticsAttempt, runDiagnostics, resetDiagnosticsAttempt } =
+    useVnetContext();
+  const rootClusterUri = useStoreSelector(
+    'workspacesService',
+    useCallback(state => state.rootClusterUri, [])
+  );
+  const onDismiss = () => {
+    // Reset the attempt, otherwise re-opening the panel would show the warning again.
+    resetDiagnosticsAttempt();
+  };
+
+  if (
+    diagnosticsAttempt.status === '' ||
+    diagnosticsAttempt.status === 'processing'
+  ) {
+    return null;
+  }
+
+  if (diagnosticsAttempt.status === 'error') {
+    return (
+      <SliderStepAlert
+        kind="danger"
+        details={<P2>{diagnosticsAttempt.statusText}</P2>}
+        onDismiss={onDismiss}
+      >
+        Encountered an error while running diagnostics
+      </SliderStepAlert>
+    );
+  }
+
+  const report = diagnosticsAttempt.data;
+  const disabledOpenReportButtonProps = !rootClusterUri
+    ? {
+        disabled: true,
+        title: 'Log in to a cluster to see the full report',
+      }
+    : {};
+  const openReport = () => {
+    // TODO(ravicious): Open report doc.
+  };
+
+  if (
+    report.checks.length &&
+    report.checks.every(
+      checkAttempt =>
+        checkAttempt.status === CheckAttemptStatus.OK &&
+        checkAttempt.checkReport.status === CheckReportStatus.OK
+    )
+  ) {
+    // TODO(ravicious): Once we start automatically running checks, this alert needs to be shown
+    // only if the user manually requested diagnostics to be run. Alternatively, we can replace it
+    // with some kind of a smaller "Everything's okay" indicator, but the user needs to be able to
+    // open the report anyway.
+    return (
+      <SliderStepAlert
+        kind="success"
+        onDismiss={onDismiss}
+        buttons={
+          <ActionButton
+            fill="border"
+            intent="neutral"
+            inputAlignment
+            action={{ content: 'Open Report', onClick: openReport }}
+            {...disabledOpenReportButtonProps}
+          />
+        }
+      >
+        No issues found.
+      </SliderStepAlert>
+    );
+  }
+
+  // If this default warningText is shown the user, it means we failed to account for a specific
+  // state.
+  let warningText = 'Unknown report status';
+  if (
+    report.checks.some(
+      checkAttempt =>
+        checkAttempt.status === CheckAttemptStatus.OK &&
+        checkAttempt.checkReport.status === CheckReportStatus.ISSUES_FOUND
+    )
+  ) {
+    warningText = 'Other software on your device might interfere with VNet.';
+  } else if (
+    report.checks.some(
+      checkAttempt => checkAttempt.status === CheckAttemptStatus.ERROR
+    )
+  ) {
+    warningText = 'Some diagnostic checks failed to report results.';
+  }
+
+  return (
+    <SliderStepAlert
+      kind="warning"
+      onDismiss={onDismiss}
+      buttons={
+        <>
+          <ActionButton
+            fill="border"
+            intent="neutral"
+            inputAlignment
+            action={{ content: 'Open Report', onClick: openReport }}
+            {...disabledOpenReportButtonProps}
+          />
+          <ActionButton
+            fill="minimal"
+            intent="neutral"
+            inputAlignment
+            action={{ content: 'Retry', onClick: runDiagnostics }}
+          />
+        </>
+      }
+    >
+      {warningText}
+    </SliderStepAlert>
+  );
+};
+
+const SliderStepAlert = (
+  props: (
+    | { buttons?: ReactNode; details?: never }
+    | { details?: ReactNode; buttons?: never }
+  ) &
+    Required<Pick<AlertProps, 'kind' | 'onDismiss' | 'children'>>
+) => {
+  const { buttons, details, ...alertProps } = props;
+
+  return (
+    <Alert
+      mt={0}
+      mx={textSpacing}
+      mb={textSpacing}
+      dismissible
+      alignItems={buttons ? 'flex-start' : 'center'}
+      details={
+        buttons ? (
+          <Flex mt={2} gap={2}>
+            {buttons}
+          </Flex>
+        ) : (
+          details
+        )
+      }
+      {...alertProps}
+    />
+  );
+};

--- a/web/packages/teleterm/src/ui/Vnet/VnetConnectionItem.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetConnectionItem.tsx
@@ -84,8 +84,15 @@ const VnetConnectionItemBase = forwardRef<
 >((props, ref) => {
   const { configService } = useAppContext();
   const isVnetDiagEnabled = configService.get('unstable.vnetDiag').value;
-  const { status, start, stop, startAttempt, stopAttempt, runDiagnostics } =
-    useVnetContext();
+  const {
+    status,
+    start,
+    stop,
+    startAttempt,
+    stopAttempt,
+    runDiagnostics,
+    diagnosticsAttempt,
+  } = useVnetContext();
   const isProcessing =
     startAttempt.status === 'processing' || stopAttempt.status === 'processing';
   const indicatorStatus =
@@ -182,11 +189,16 @@ const VnetConnectionItemBase = forwardRef<
               {isVnetDiagEnabled && (
                 <ButtonIcon
                   title={
-                    status.value === 'running'
-                      ? 'Run diagnostics'
-                      : 'VNet must be running to run diagnostics'
+                    status.value !== 'running'
+                      ? 'VNet must be running to run diagnostics'
+                      : diagnosticsAttempt.status === 'processing'
+                        ? 'Generating diagnostic report…'
+                        : 'Run diagnostics'
                   }
-                  disabled={status.value !== 'running'}
+                  disabled={
+                    status.value !== 'running' ||
+                    diagnosticsAttempt.status === 'processing'
+                  }
                   onClick={e => {
                     e.stopPropagation();
                     runDiagnostics();

--- a/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
@@ -26,6 +26,8 @@ import { mergeRefs } from 'shared/libs/mergeRefs';
 
 import { ConnectionStatusIndicator } from 'teleterm/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionStatusIndicator';
 
+import { DiagnosticsAlert } from './DiagnosticsAlert';
+import { textSpacing } from './sliderStep';
 import { VnetSliderStepHeader } from './VnetConnectionItem';
 import { useVnetContext } from './vnetContext';
 
@@ -93,11 +95,11 @@ export const VnetSliderStep = (props: StepComponentProps) => {
       </Flex>
 
       {status.value === 'running' && <DnsZones />}
+
+      <DiagnosticsAlert />
     </Box>
   );
 };
-
-const textSpacing = 1;
 
 const ErrorText = (props: PropsWithChildren) => (
   <Text>
@@ -121,12 +123,15 @@ const DnsZones = () => {
   );
   const dnsZonesRefreshRequestedRef = useRef(false);
 
-  useEffect(function refreshListOnOpen() {
-    if (!dnsZonesRefreshRequestedRef.current) {
-      dnsZonesRefreshRequestedRef.current = true;
-      listDNSZones();
-    }
-  }, []);
+  useEffect(
+    function refreshListOnOpen() {
+      if (!dnsZonesRefreshRequestedRef.current) {
+        dnsZonesRefreshRequestedRef.current = true;
+        listDNSZones();
+      }
+    },
+    [listDNSZones]
+  );
 
   if (listDNSZonesAttempt.status === 'error') {
     return (

--- a/web/packages/teleterm/src/ui/Vnet/sliderStep.ts
+++ b/web/packages/teleterm/src/ui/Vnet/sliderStep.ts
@@ -1,0 +1,22 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * textSpacing is the spacing between the border of the slider step and text within VnetSliderStep.
+ */
+export const textSpacing = 2;


### PR DESCRIPTION
This PR adds an alert that's going to be shown in the VNet panel in the top left after running diagnostics. The PR does not include running the diagnostics periodically or showing the report in the UI, this will come in upcoming PRs.

<img width="416" alt="diag-alert" src="https://github.com/user-attachments/assets/0a3386ac-dd1b-4e45-8f51-9793915d8bab" />

For reference, this is how the report is going to look like:

<details>
<summary>VNet diag report</summary>

<img width="1031" alt="vnet-diag-report" src="https://github.com/user-attachments/assets/90dd9f6c-88f8-4d2c-9eff-11590f536014" />

</details>

---

We aim to have two diagnostic checks on macOS (though right now I might end up implementing just one due to time constraints). Each check can fail to complete. If it completes, it can either find no issues or some issues. [The protos describing the report](https://github.com/gravitational/teleport/blob/r7s/diag-tshd/proto/teleport/lib/vnet/diag/v1/diag.proto) are in #52066. I think a quick glance over them can help understand how this whole thing is going to work.

If some checks have failed to complete but some have found issues, I think it makes more sense to show a message about issues being found rather than about some checks having failed to complete.

I also had to make the whole popup menu wider. Otherwise there just wasn't enough space in the menu to show the alert.