### PR TITLE
Make node install scripts install Teleport via teleport-update

### DIFF
--- a/lib/web/scripts.go
+++ b/lib/web/scripts.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
@@ -33,6 +34,8 @@ import (
 	"github.com/gravitational/teleport/lib/utils/teleportassets"
 	"github.com/gravitational/teleport/lib/web/scripts"
 )
+
+const insecureParamName = "insecure"
 
 // installScriptHandle handles calls for "/scripts/install.sh" and responds with a bash script installing Teleport
 // by downloading and running `teleport-update`. This installation script does not start the agent, join it,
@@ -49,6 +52,15 @@ func (h *Handler) installScriptHandle(w http.ResponseWriter, r *http.Request, pa
 	opts, err := h.installScriptOptions(r.Context())
 	if err != nil {
 		return nil, trace.Wrap(err, "Failed to build install script options")
+	}
+
+	insecure := r.URL.Query().Get(insecureParamName)
+	if insecure != "" {
+		v, err := strconv.ParseBool(insecure)
+		if err != nil {
+			return nil, trace.BadParameter("failed to parse insecure flag %q: %v", insecure, err)
+		}
+		opts.Insecure = v
 	}
 
 	script, err := scripts.GetInstallScript(r.Context(), opts)

--- a/lib/web/scripts.go
+++ b/lib/web/scripts.go
@@ -54,8 +54,7 @@ func (h *Handler) installScriptHandle(w http.ResponseWriter, r *http.Request, pa
 		return nil, trace.Wrap(err, "Failed to build install script options")
 	}
 
-	insecure := r.URL.Query().Get(insecureParamName)
-	if insecure != "" {
+	if insecure := r.URL.Query().Get(insecureParamName); insecure != "" {
 		v, err := strconv.ParseBool(insecure)
 		if err != nil {
 			return nil, trace.BadParameter("failed to parse insecure flag %q: %v", insecure, err)

--- a/lib/web/scripts/install.go
+++ b/lib/web/scripts/install.go
@@ -138,7 +138,7 @@ func (o *InstallScriptOptions) oneOffParams() (params oneoff.OneOffScriptParams)
 	successMessage := "Teleport successfully installed."
 	if o.Insecure {
 		args = append(args, "--insecure")
-		successMessage += " --insecure was used during installation, automatic updates will not work unless the Proxy Service exposes a trusted certificate."
+		successMessage += " --insecure was used during installation, automatic updates will not work unless the Proxy Service presents a certificate trusted by the system."
 	}
 
 	return oneoff.OneOffScriptParams{

--- a/lib/web/scripts/install_node.go
+++ b/lib/web/scripts/install_node.go
@@ -92,21 +92,15 @@ func GetNodeInstallScript(ctx context.Context, opts InstallNodeScriptOptions) (s
 
 	// By default, it will use `stable/v<majorVersion>`, eg stable/v12
 	repoChannel := ""
-	installPackageUpdater := false
 
 	switch opts.InstallOptions.AutoupdateStyle {
-	case NoAutoupdate:
+	case NoAutoupdate, UpdaterBinaryAutoupdate:
 	case PackageManagerAutoupdate:
 		// Note: This is a cloud-specific repo. We could use the new stable/rolling
 		// repo in non-cloud case, but the script has never support enabling autoupdates
 		// in a non-cloud cluster.
 		// We will prefer using the new updater binary for autoupdates in self-hosted setups.
 		repoChannel = automaticupgrades.DefaultCloudChannelName
-		installPackageUpdater = true
-	case UpdaterBinaryAutoupdate:
-		// TODO(hugoShaka): add new autoupdate binary support in the node-install script
-		// by using oneoff in another PR
-		return "", trace.NotImplemented("This path is not implemented yet.")
 	default:
 		return "", trace.BadParameter("unsupported autoupdate style: %v", opts.InstallOptions.AutoupdateStyle)
 	}
@@ -173,7 +167,7 @@ func GetNodeInstallScript(ctx context.Context, opts InstallNodeScriptOptions) (s
 		"caPins":                  strings.Join(opts.CAPins, ","),
 		"packageName":             opts.InstallOptions.TeleportFlavor,
 		"repoChannel":             repoChannel,
-		"installUpdater":          strconv.FormatBool(installPackageUpdater),
+		"installUpdater":          opts.InstallOptions.AutoupdateStyle.String(),
 		"version":                 shsprintf.EscapeDefaultContext(opts.InstallOptions.TeleportVersion),
 		"appInstallMode":          strconv.FormatBool(opts.AppServiceEnabled),
 		"appServerResourceLabels": appServerResourceLabels,

--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -22,6 +22,13 @@ TELEPORT_BINARY_LIST_darwin="teleport" # only install server binaries for macOS
 TELEPORT_CONFIG_PATH="/etc/teleport.yaml"
 TELEPORT_DATA_DIR="/var/lib/teleport"
 TELEPORT_DOCS_URL="https://goteleport.com/docs/"
+# TELEPORT_FORMAT contains the Teleport installation formats.
+# The value is dynamically computed unless OVERRIDE_FORMAT it set.
+# Possible values are:
+# - "deb"
+# - "rpm"
+# - "tarball"
+# - "updater"
 TELEPORT_FORMAT=""
 
 # initialise variables (because set -u disallows unbound variables)
@@ -39,6 +46,9 @@ INTERACTIVE=false
 # optionally be replaced by the server before the script is served up
 TELEPORT_VERSION='{{.version}}'
 TELEPORT_PACKAGE_NAME='{{.packageName}}'
+# UPDATER_STYLE holds the Teleport updater style.
+# Supported values are "none", "" (same as "none"), "package", and "binary".
+UPDATER_STYLE='{{.installUpdater}}'
 REPO_CHANNEL='{{.repoChannel}}'
 TARGET_HOSTNAME='{{.hostname}}'
 TARGET_PORT='{{.port}}'
@@ -681,23 +691,30 @@ fi
 
 # use OSTYPE variable to figure out host type/arch
 if [[ "${OSTYPE}" == "linux"* ]]; then
-    # linux host, now detect arch
-    TELEPORT_BINARY_TYPE="linux"
-    ARCH=$(uname -m)
-    log "Detected host: ${OSTYPE}, using Teleport binary type ${TELEPORT_BINARY_TYPE}"
-    if [[ ${ARCH} == "armv7l" ]]; then
-        TELEPORT_ARCH="arm"
-    elif [[ ${ARCH} == "aarch64" ]]; then
-        TELEPORT_ARCH="arm64"
-    elif [[ ${ARCH} == "x86_64" ]]; then
-        TELEPORT_ARCH="amd64"
-    elif [[ ${ARCH} == "i686" ]]; then
-        TELEPORT_ARCH="386"
+
+    if [[ "$UPDATER_STYLE" == "binary" ]]; then
+      # if we are using the new updater, we can bypass this detection dance
+      # and always use the updater.
+      TELEPORT_FORMAT="updater"
     else
-        log_important "Error: cannot detect architecture from uname -m: ${ARCH}"
-        exit 1
+        # linux host, now detect arch
+        TELEPORT_BINARY_TYPE="linux"
+        ARCH=$(uname -m)
+        log "Detected host: ${OSTYPE}, using Teleport binary type ${TELEPORT_BINARY_TYPE}"
+        if [[ ${ARCH} == "armv7l" ]]; then
+            TELEPORT_ARCH="arm"
+        elif [[ ${ARCH} == "aarch64" ]]; then
+            TELEPORT_ARCH="arm64"
+        elif [[ ${ARCH} == "x86_64" ]]; then
+            TELEPORT_ARCH="amd64"
+        elif [[ ${ARCH} == "i686" ]]; then
+            TELEPORT_ARCH="386"
+        else
+            log_important "Error: cannot detect architecture from uname -m: ${ARCH}"
+            exit 1
+        fi
+        log "Detected arch: ${ARCH}, using Teleport arch ${TELEPORT_ARCH}"
     fi
-    log "Detected arch: ${ARCH}, using Teleport arch ${TELEPORT_ARCH}"
     # if the download format is already set, we have no need to detect distro
     if [[ ${TELEPORT_FORMAT} == "" ]]; then
         # detect distro
@@ -987,6 +1004,21 @@ install_from_repo() {
     fi
 }
 
+install_from_updater() {
+    SCRIPT_URL="https://$TARGET_HOSTNAME:$TARGET_PORT/scripts/install.sh"
+    CURL_COMMAND="curl -fsl"
+    if [[ ${DISABLE_TLS_VERIFICATION} == "true" ]]; then
+        CURL_COMMAND+=" -k"
+        SCRIPT_URL+="?insecure=true"
+    fi
+
+    log "Requesting the install script: $SCRIPT_URL"
+    $CURL_COMMAND "$SCRIPT_URL" -o "$TEMP_DIR/install.sh" || (log "Failed to retrieve the install script." && exit 1)
+
+    log "Executing the install script"
+    bash "$TEMP_DIR/install.sh"
+}
+
 # package_list returns the list of packages to install.
 # The list of packages can be fed into yum or apt because they already have the expected format when pinning versions.
 package_list() {
@@ -1007,7 +1039,7 @@ package_list() {
     # (warning): This expression is constant. Did you forget the $ on a variable?
     # Disabling the warning above because expression is templated.
     # shellcheck disable=SC2050
-    if is_using_systemd && [[ "{{.installUpdater}}" == "true" ]]; then
+    if is_using_systemd && [[ "$UPDATER_STYLE" == "package" ]]; then
         # Teleport Updater requires systemd.
         PACKAGE_LIST+=" ${TELEPORT_UPDATER_PIN_VERSION}"
     fi
@@ -1037,7 +1069,10 @@ is_repo_available() {
     return 1
 }
 
-if is_repo_available; then
+if [[ "$TELEPORT_FORMAT" == "updater" ]]; then
+    log "Installing from updater binary."
+    install_from_updater
+elif is_repo_available; then
     log "Installing repo for distro $ID."
     install_from_repo
 else

--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -1006,7 +1006,7 @@ install_from_repo() {
 
 install_from_updater() {
     SCRIPT_URL="https://$TARGET_HOSTNAME:$TARGET_PORT/scripts/install.sh"
-    CURL_COMMAND="curl -fsl"
+    CURL_COMMAND="curl -fsS"
     if [[ ${DISABLE_TLS_VERIFICATION} == "true" ]]; then
         CURL_COMMAND+=" -k"
         SCRIPT_URL+="?insecure=true"
@@ -1015,8 +1015,13 @@ install_from_updater() {
     log "Requesting the install script: $SCRIPT_URL"
     $CURL_COMMAND "$SCRIPT_URL" -o "$TEMP_DIR/install.sh" || (log "Failed to retrieve the install script." && exit 1)
 
+    chmod +x "$TEMP_DIR/install.sh"
+
     log "Executing the install script"
-    bash "$TEMP_DIR/install.sh"
+    # We execute the install script because it might be a bash or sh script depending on the install script served.
+    # This might cause issues if tmp is mounted with noexec, but the oneoff.sh script will also download and exec
+    # binaries from tmp
+    "$TEMP_DIR/install.sh"
 }
 
 # package_list returns the list of packages to install.


### PR DESCRIPTION
## Context

This PR is the third of a series to:
- have Teleport Discover scripts install with `teleport-update`
- consolidate installation scripts to reduce the amount of bash scripts we use
- add stronger and saner interface to generate install scripts

We don't want to have every install script use teleport-update as of today, we want to be able to have a controlled rollout. The proxy will lookup at the autoupdate configuration and see if the cluster is enrolled into new autoupdates before using teleport-update.

 Previous PRs:
- https://github.com/gravitational/teleport/pull/52155
- https://github.com/gravitational/teleport/pull/52196

## About this PR

This PR adds a new installation method in the node-install script: the updater.
If an autoupdate_agent_rollout resource exists, the cluster will set the updater style to "binary". The install script will then contact back the Teleport proxy to retrieve and run the install script.

Theoretically, the /scripts/install.sh script can also handle package and tarball installs. However its logic is not 100% equivalent with the node-install script so I did not factor the two scripts into a single one. We might want to do this cleanup in the future, but this should likely happen in a major version as there's no way to make sure two bash scripts of 700+ locs have the same behaviour.