### PR TITLE
[web] Fall back to `any` for unspecified Plugin types

### DIFF
--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -237,7 +237,7 @@ export type PluginNameToSpec = {
   datadog: PluginDatadogSpec;
   email: PluginEmailSpec;
   msteams: PluginMsTeamsSpec;
-  [key: string]: unknown;
+  [key: string]: any;
 };
 
 /**
@@ -246,7 +246,7 @@ export type PluginNameToSpec = {
  */
 export type PluginNameToDetails = {
   okta: PluginStatusOkta;
-  [key: string]: unknown;
+  [key: string]: any;
 };
 
 // PluginKind represents the type of the plugin


### PR DESCRIPTION
Changed in #51731, but there are still some usages in E that we need to update, so for now, fall back to `any`, which was the previous handling.
