### PR TITLE
Fix wrong list indentation on ca-rotation page

### DIFF
--- a/docs/pages/admin-guides/management/operations/ca-rotation.mdx
+++ b/docs/pages/admin-guides/management/operations/ca-rotation.mdx
@@ -33,7 +33,7 @@ following order:
    signed by the new certificate authority, but still accept certificates issued
    by the original certificate authority. This only applies to the Teleport
    [`host` CA](#host).
-   1. `standby`: No rotation in progress. All operations have completed.
+1. `standby`: No rotation in progress. All operations have completed.
 
 Before the final `standby` phase, you can also put the rotation in the
 `rollback` phase, aborting the rotation and returning to the original


### PR DESCRIPTION
Indentation of last list item is wrong, see [here](https://goteleport.com/docs/admin-guides/management/operations/ca-rotation/#:~:text=standby%3A%20No%20rotation%20in%20progress.%20All%20operations%20have%20completed.).