### PR TITLE
[v17] docs: remove tsh pkg download for cloud install

### DIFF
--- a/docs/pages/includes/cloud/install-macos.mdx
+++ b/docs/pages/includes/cloud/install-macos.mdx
@@ -3,7 +3,6 @@
   | Link                                                                                                      | Binaries                                   |
   |-----------------------------------------------------------------------------------------------------------|--------------------------------------------|
   | [`teleport-ent-(=cloud.version=).pkg`](https://cdn.teleport.dev/teleport-ent-(=cloud.version=).pkg) | `teleport`<br/>`tctl`<br/>`tsh`<br/>`tbot`<br/>`fdpass-teleport` |
-  | [`tsh-(=cloud.version=).pkg`](https://cdn.teleport.dev/tsh-(=cloud.version=).pkg)                   | `tsh`                                      |
 
   You can also fetch an installer from the command line:
 


### PR DESCRIPTION
Backport #52223 to branch/v17