### PR TITLE
[v16] chore: Bump golangci-lint to v1.64.5

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -4,7 +4,7 @@
 
 # Sync with devbox.json.
 GOLANG_VERSION ?= go1.23.6
-GOLANGCI_LINT_VERSION ?= v1.64.2
+GOLANGCI_LINT_VERSION ?= v1.64.5
 
 # TODO(ravicious): When updating Node.js, see if corepack distributed with the new Node.JS version
 # is >= 0.31.0. If so, remove manual calls to install corepack@0.31.0 from CI scripts and


### PR DESCRIPTION
Backport #52219 to branch/v16.