### PR TITLE
[v17] Edit the Vale config

### DIFF
--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -4,5 +4,6 @@ MinAlertLevel = suggestion
 [formats]
 mdx = md
 
-[*.md]
+[*.mdx]
 BasedOnStyles = messaging,examples,3rd-party-products,structure
+CommentDelimiters = "{/*,*/}"


### PR DESCRIPTION
Backports #51937

1. Since version 3.9.4, Vale checks format-specific configurations against the extensions of target files before applying style rules. In previous versions, Vale would also check extensions that were mapped to these extensions in the configuration. Edit the `*.md` section to `*.mdx` so the Vale linter checks the pages in our docs source.

2. Add a `CommentDelimiters` config, allowing pages to ignore Vale rules by specifying them in MDX comments. See: https://vale.sh/docs/keys/commentdelimiters