### PR TITLE
Remove PAM user creation deprecation

### DIFF
--- a/docs/pages/enroll-resources/server-access/guides/ssh-pam.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/ssh-pam.mdx
@@ -180,19 +180,14 @@ $ cat /etc/motd
 
 ## Create local Unix users on login
 
-<Admonition type="warning">
-Using PAM to create local users on login is obsolete and will be removed in a future version. Refer to the
-[Host user creation](./host-user-creation.mdx) guide to learn how to configure
-Teleport to automatically create local Linux users without PAM.
-</Admonition>
-
 Teleport has the ability to create local Unix users on login. This is
 very helpful if you're a large organization and want to provision local users and home
 directories on the fly.
 
 Using `pam_exec.so` is the easiest way to use the PAM stack to create a user if
 the user does not already exist. `pam_exec.so` usually ships with the operating
-system.
+system. If you do not already use the PAM stack, you may alternatively use
+Teleport's built in support for [automatically provisioning users](./host-user-creation.mdx).
 
 You can either add `pam_exec.so` to the existing PAM stack for your application or
 write a new one for Teleport. In this example, we'll write a new one to simplify how
@@ -241,7 +236,7 @@ $ chmod +x /etc/pam-exec.d/teleport_acct
 
 This script will check if the login assigned to `TELEPORT_LOGIN` exists and, if
 it does not, it will create it. Any error from `useradd` will be written to
-`/tmp/pam.error`. 
+`/tmp/pam.error`.
 
 The environment variables `TELEPORT_USERNAME` and `TELEPORT_ROLES` can be used
 to write richer scripts that may change the system in other ways based on
@@ -252,7 +247,7 @@ identity information.
   The `useradd` command can have a different path than the example above
   depending on your Linux distribution. Adjust to your particular system as needed
   depending on the result of the following command:
-  
+
   ```code
   $ which useradd
   ```
@@ -301,4 +296,3 @@ ssh_service:
     # use the "auth" modules in the PAM config
     use_pam_auth: true
 ```
-


### PR DESCRIPTION
The deprecation often leads to confusion and support load as suggesting PAM as a solution to problems is met with questions about why a customer should use a solution that will be deprecated in the future.

While Teleport's built in host user provisioning may be the preferred approach to create local users on the fly, folks that already leverage the PAM stack may prefer PAM to provision users.