### PR TITLE
User task design updates

### DIFF
--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.tsx
@@ -60,7 +60,7 @@ export function AwsOidcDashboard() {
   return (
     <>
       <AwsOidcHeader integration={integration} />
-      <FeatureBox css={{ maxWidth: '1400px', paddingTop: '16px', gap: '16px' }}>
+      <FeatureBox maxWidth={1440} margin="auto" gap={3} paddingLeft={5}>
         {integration && (
           <>
             <AwsOidcTitle integration={integration} />

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcTitle.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcTitle.tsx
@@ -48,7 +48,7 @@ export function AwsOidcTitle({
       <Text bold fontSize={6} mx={2}>
         {content.content}
       </Text>
-      <Label kind={labelKind} aria-label="status" px={3} ml={3}>
+      <Label kind={labelKind} aria-label="status" px={3}>
         {status}
       </Label>
     </Flex>

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Details.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Details.tsx
@@ -42,7 +42,7 @@ export function Details() {
       {integration && (
         <AwsOidcHeader integration={integration} resource={resourceKind} />
       )}
-      <FeatureBox css={{ maxWidth: '1400px', paddingTop: '16px', gap: '16px' }}>
+      <FeatureBox maxWidth={1440} margin="auto" gap={3} paddingLeft={5}>
         <>
           {integration && (
             <>

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/EnrollCard.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/EnrollCard.tsx
@@ -19,22 +19,21 @@
 import { Link as InternalLink } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { ButtonBorder, Card, Flex, H2, ResourceIcon } from 'design';
+import { ButtonSecondary, Card, Flex, H2, ResourceIcon } from 'design';
 
 import cfg from 'teleport/config';
 import { AwsResource } from 'teleport/Integrations/status/AwsOidc/StatCard';
 
 export function EnrollCard({ resource }: { resource: AwsResource }) {
-  // todo (michellescripts) update enroll design once ready
   return (
     <Enroll data-testid={`${resource}-enroll`}>
       <Flex flexDirection="column" gap={4}>
-        <Flex alignItems="center" mb={2}>
+        <Flex alignItems="center">
           <ResourceIcon name={resource} mr={2} width="32px" height="32px" />
           <H2>{resource.toUpperCase()}</H2>
         </Flex>
-        <ButtonBorder
-          size="large"
+        <ButtonSecondary
+          width="136px"
           as={InternalLink}
           to={{
             pathname: cfg.routes.discover,
@@ -42,7 +41,7 @@ export function EnrollCard({ resource }: { resource: AwsResource }) {
           }}
         >
           Enroll {resource.toUpperCase()}
-        </ButtonBorder>
+        </ButtonSecondary>
       </Flex>
     </Enroll>
   );
@@ -51,7 +50,7 @@ export function EnrollCard({ resource }: { resource: AwsResource }) {
 const Enroll = styled(Card)`
   width: 33%;
   background-color: ${props => props.theme.colors.levels.surface};
-  padding: 12px;
+  padding: ${props => props.theme.space[3]}px;
   border-radius: ${props => props.theme.radii[2]}px;
   border: ${props => `1px solid ${props.theme.colors.levels.surface}`};
 

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/StatCard.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/StatCard.tsx
@@ -141,7 +141,7 @@ function foundResource(resource: ResourceTypeSummary): boolean {
 export const SelectCard = styled(Card)`
   width: 33%;
   background-color: ${props => props.theme.colors.levels.surface};
-  padding: 12px;
+  padding: ${props => props.theme.space[3]}px;
   border-radius: ${props => props.theme.radii[2]}px;
   border: ${props => `1px solid ${props.theme.colors.levels.surface}`};
   cursor: pointer;

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/SidePanel.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/SidePanel.tsx
@@ -42,13 +42,14 @@ export const SidePanel = ({
         borderBottom={1}
         borderColor="levels.surface"
         py={1}
+        px={4}
       >
         {header}
         <ButtonIcon onClick={onClose} disabled={disabled}>
           <Cross size="medium" />
         </ButtonIcon>
       </Flex>
-      <ScrollContent>{children}</ScrollContent>
+      <ScrollContent px={4}>{children}</ScrollContent>
     </Flex>
   );
 };

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/SidePanel.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/SidePanel.tsx
@@ -15,49 +15,57 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-import React, { PropsWithChildren } from 'react';
+import { PropsWithChildren, ReactNode } from 'react';
 import styled from 'styled-components';
 
-import { Box, ButtonIcon, Flex } from 'design';
+import { ButtonIcon, Flex } from 'design';
 import { Cross } from 'design/Icon';
 
 export const SidePanel = ({
   onClose,
   header,
+  footer,
   disabled = false,
   children,
 }: PropsWithChildren & {
   onClose: () => void;
-  header?: React.ReactNode;
+  header?: ReactNode;
+  footer?: ReactNode;
   disabled?: boolean;
 }) => {
   return (
-    <Flex width="500px" flexDirection="column">
-      <Flex
-        alignItems="center"
-        mb={3}
-        justifyContent="space-between"
-        maxWidth="500px"
-        borderBottom={1}
-        borderColor="levels.surface"
-        py={1}
-        px={4}
-      >
+    <Container
+      width="500px"
+      flexDirection="column"
+      borderLeft={1}
+      borderColor="levels.surface"
+    >
+      <Flex alignItems="center" justifyContent="space-between" my={3} px={4}>
         {header}
         <ButtonIcon onClick={onClose} disabled={disabled}>
           <Cross size="medium" />
         </ButtonIcon>
       </Flex>
-      <ScrollContent px={4}>{children}</ScrollContent>
-    </Flex>
+      <Flex
+        flexDirection="column"
+        px={4}
+        style={{
+          flex: 1,
+          overflow: 'auto',
+          height: '100%',
+        }}
+      >
+        {children}
+      </Flex>
+      <Flex borderTop={1} borderColor="levels.surface" py={3} px={4}>
+        {footer}
+      </Flex>
+    </Container>
   );
 };
 
-const ScrollContent = styled(Box)`
-  max-height: calc(
-    100vh - ${props => props.theme.space[9]}px -
-      ${props => props.theme.topBarHeight[1]}px
-  );
-  overflow: auto;
+const Container = styled(Flex)`
+  flex-direction: column;
+
+  height: calc(100vh - ${props => props.theme.topBarHeight[1]}px);
 `;

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Task.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Task.tsx
@@ -71,7 +71,6 @@ export function Task({
     return null;
   }
 
-  // todo (michellescripts) implement either success view or confirmation based on design sync
   function resolve() {
     setAttempt({ status: 'processing' });
     integrationService
@@ -92,7 +91,8 @@ export function Task({
   return (
     <SidePanel
       onClose={() => close(false)}
-      header={
+      header={<H2>{taskAttempt.data.issueType}</H2>}
+      footer={
         <ButtonBorder
           intent="success"
           onClick={resolve}
@@ -103,7 +103,6 @@ export function Task({
       }
       disabled={attempt.status === 'processing'}
     >
-      <H2 mb={2}>{taskAttempt.data.issueType}</H2>
       {attempt.status === 'failed' && (
         <Alert kind="danger" details={attempt.statusText}>
           Unable to resolve task

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/TaskAlert.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/TaskAlert.tsx
@@ -60,6 +60,7 @@ export function TaskAlert({
     <Alert
       kind="warning"
       icon={BellRinging}
+      mb={0}
       primaryAction={{
         content: (
           <>

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.test.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { createMemoryHistory } from 'history';
+import { Router } from 'react-router';
+
+import { render, screen, userEvent, waitFor } from 'design/utils/testing';
+
+import { ContextProvider } from 'teleport';
+import { Route } from 'teleport/components/Router';
+import cfg from 'teleport/config';
+import { Tasks } from 'teleport/Integrations/status/AwsOidc/Tasks/Tasks';
+import { makeAwsOidcStatusContextState } from 'teleport/Integrations/status/AwsOidc/testHelpers/makeAwsOidcStatusContextState';
+import { awsOidcStatusContext } from 'teleport/Integrations/status/AwsOidc/useAwsOidcStatus';
+import {
+  IntegrationKind,
+  integrationService,
+} from 'teleport/services/integrations';
+import TeleportContext from 'teleport/teleportContext';
+
+const integrationName = 'integration-test';
+
+test('deep links an open task', async () => {
+  const ctx = new TeleportContext();
+  jest
+    .spyOn(integrationService, 'fetchIntegrationUserTasksList')
+    .mockResolvedValue({
+      items: [
+        {
+          name: 'df4d8288-7106-5a50-bb50-4b5858e48ad5',
+          taskType: 'discover-rds',
+          state: 'OPEN',
+          integration: integrationName,
+          lastStateChange: '2025-02-11T20:32:19.482607921Z',
+          issueType: 'rds-failure',
+        },
+      ],
+      nextKey: 'next',
+    });
+
+  const history = createMemoryHistory({
+    initialEntries: [
+      cfg.getIntegrationTasksRoute(IntegrationKind.AwsOidc, integrationName),
+    ],
+  });
+  history.replace = jest.fn();
+
+  render(
+    <Router history={history}>
+      <ContextProvider ctx={ctx}>
+        <awsOidcStatusContext.Provider value={makeAwsOidcStatusContextState()}>
+          <Route path={cfg.routes.integrationTasks} render={() => <Tasks />} />
+        </awsOidcStatusContext.Provider>
+      </ContextProvider>
+    </Router>
+  );
+
+  await screen.findAllByText('Pending Tasks');
+  await userEvent.click(screen.getByText('rds-failure'));
+
+  await waitFor(() =>
+    expect(history.replace).toHaveBeenCalledWith(
+      '/web/integrations/status/aws-oidc/integration-test/tasks?task=df4d8288-7106-5a50-bb50-4b5858e48ad5'
+    )
+  );
+});

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.tsx
@@ -92,9 +92,7 @@ export function Tasks() {
         {integration && (
           <AwsOidcHeader integration={integration} tasks={true} />
         )}
-        <FeatureBox
-          css={{ maxWidth: '1400px', paddingTop: '16px', gap: '30px' }}
-        >
+        <FeatureBox maxWidth={1440} margin="auto" gap={3} paddingLeft={5}>
           {integration && (
             <AwsOidcTitle integration={integration} tasks={true} />
           )}

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.tsx
@@ -73,10 +73,9 @@ export function Tasks() {
 
   function close(resolved: boolean) {
     if (resolved) {
-      serverSidePagination.modifyFetchedData(p => ({
-        ...p,
-        agents: p.agents.filter(t => t.name !== showTask.name),
-      }));
+      // If there are multiple pages, we would rather refresh the table with X results rather than
+      // use modifyFetchedData to remove the item.
+      serverSidePagination.fetch();
     }
     setShowTask(undefined);
   }

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.tsx
@@ -40,7 +40,7 @@ export function Tasks() {
 
   const { integrationAttempt } = useAwsOidcStatus();
   const { data: integration } = integrationAttempt;
-  const [selectedTask, setSelectedTask] = useState<string>(undefined);
+  const [selectedTask, setSelectedTask] = useState<string>('');
 
   const serverSidePagination = useServerSidePagination<UserTask>({
     pageSize: 20,
@@ -66,11 +66,11 @@ export function Tasks() {
       taskName &&
       taskName !== '' &&
       serverSidePagination.fetchedData.agents &&
-      selectedTask === undefined
+      selectedTask === ''
     ) {
       setSelectedTask(taskName);
     } else {
-      setSelectedTask(undefined);
+      setSelectedTask('');
     }
   }, [taskName, serverSidePagination?.fetchedData]);
 
@@ -100,11 +100,12 @@ export function Tasks() {
   }
 
   function openTask(task: UserTask) {
-    if (selectedTask == undefined) {
-      const urlParams = new URLSearchParams();
-      urlParams.append('task', task.name);
-      history.replace(`${history.location.pathname}?${urlParams.toString()}`);
+    if (selectedTask != '') {
+      return;
     }
+    const urlParams = new URLSearchParams();
+    urlParams.append('task', task.name);
+    history.replace(`${history.location.pathname}?${urlParams.toString()}`);
   }
 
   return (
@@ -126,12 +127,12 @@ export function Tasks() {
             data={serverSidePagination.fetchedData?.agents || []}
             row={{
               onClick: row => {
-                if (selectedTask === undefined) {
+                if (selectedTask === '') {
                   openTask(row);
                 }
               },
               getStyle: () => {
-                if (selectedTask === undefined) {
+                if (selectedTask === '') {
                   return { cursor: 'pointer' };
                 }
               },
@@ -162,7 +163,7 @@ export function Tasks() {
                   <Cell>
                     <ButtonBorder
                       onClick={() => openTask(item)}
-                      disabled={selectedTask != undefined}
+                      disabled={selectedTask != ''}
                       size="small"
                     >
                       View


### PR DESCRIPTION
Updated based on design requests:
- Padding on "feature box" decreased from 40 to 32
- Padding on side panel increased from 0 to 24
- Update task table to _not_ remove resolved items from the table but to instead re-fetch data
- Deep link an open task (note, the task will open even if the user is not on the page the task belongs in, table pagination is not deep linked)
