### PR TITLE
Log obfuscated login error

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2875,6 +2875,8 @@ func (h *Handler) mfaLoginFinishSession(w http.ResponseWriter, r *http.Request, 
 
 	// Obscure all other errors.
 	case err != nil:
+		// log the actual error.
+		h.logger.WarnContext(r.Context(), "Login attempt denied for user", "user", req.User, "error", err)
 		return nil, trace.AccessDenied("invalid credentials")
 	}
 


### PR DESCRIPTION
Ben ran into an unexpected login error in this [slack thread](https://gravitational.slack.com/archives/C01TYKHFVTQ/p1739576905171499). There is no descriptive error returned or logged, so this PR adds a warning log for debugging the login error. This matches the [warning log](https://github.com/gravitational/teleport/blob/221c3168ccb64ca5c63fa75e95d830a3c0f410f7/lib/web/apiserver.go#L2469) for password login and session renewal.