### PR TITLE
Create v2 web api endpoint for deleting integration with cleanup

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1013,7 +1013,9 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.GET("/webapi/sites/:site/integrations/:name/stats", h.WithClusterAuth(h.integrationStats))
 	h.GET("/webapi/sites/:site/integrations/:name/discoveryrules", h.WithClusterAuth(h.integrationDiscoveryRules))
 	h.GET("/webapi/sites/:site/integrations/:name/ca", h.WithClusterAuth(h.integrationsExportCA))
+	// TODO(kimlisa): DELETE IN 19.0 - Replaced by /v2 equivalent endpoint
 	h.DELETE("/webapi/sites/:site/integrations/:name_or_subkind", h.WithClusterAuth(h.integrationsDelete))
+	h.DELETE("/v2/webapi/sites/:site/integrations/:name_or_subkind", h.WithClusterAuth(h.integrationsDelete))
 
 	// GET the Microsoft Teams plugin app.zip file.
 	h.GET("/webapi/sites/:site/plugins/:plugin/files/msteams_app.zip", h.WithClusterAuth(h.integrationsMsTeamsAppZipGet))

--- a/lib/web/git_servers.go
+++ b/lib/web/git_servers.go
@@ -93,5 +93,9 @@ func (h *Handler) gitServerDelete(_ http.ResponseWriter, r *http.Request, p http
 		return nil, trace.Wrap(err)
 	}
 
-	return OK(), clt.GitServerClient().DeleteGitServer(r.Context(), name)
+	if err := clt.GitServerClient().DeleteGitServer(r.Context(), name); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return OK(), nil
 }

--- a/web/packages/teleport/src/Integrations/Operations/IntegrationOperations.tsx
+++ b/web/packages/teleport/src/Integrations/Operations/IntegrationOperations.tsx
@@ -25,12 +25,16 @@ import {
   OperationType,
 } from './useIntegrationOperation';
 
+export type DeleteRequestOptions = {
+  deleteAssociatedResources?: boolean;
+};
+
 export type Props<UpdateRequest> = {
   operation: OperationType;
   integration: Integration;
   close(): void;
   edit(req: UpdateRequest): Promise<void>;
-  remove(): Promise<void>;
+  remove(opt?: DeleteRequestOptions): Promise<void>;
 };
 
 export function IntegrationOperations({

--- a/web/packages/teleport/src/Integrations/Operations/useIntegrationOperation.ts
+++ b/web/packages/teleport/src/Integrations/Operations/useIntegrationOperation.ts
@@ -26,6 +26,8 @@ import {
 } from 'teleport/services/integrations';
 import useStickyClusterId from 'teleport/useStickyClusterId';
 
+import { DeleteRequestOptions } from './IntegrationOperations';
+
 export function useIntegrationOperation() {
   const { clusterId } = useStickyClusterId();
 
@@ -37,8 +39,12 @@ export function useIntegrationOperation() {
     setOperation({ type: 'none' });
   }
 
-  function remove() {
-    return integrationService.deleteIntegration(operation.item.name);
+  function remove(opt: DeleteRequestOptions = {}) {
+    return integrationService.deleteIntegration({
+      name: operation.item.name,
+      clusterId,
+      associatedResources: opt.deleteAssociatedResources,
+    });
   }
 
   async function edit(req: EditableIntegrationFields) {

--- a/web/packages/teleport/src/Integrations/Operations/useIntegrationOperation.ts
+++ b/web/packages/teleport/src/Integrations/Operations/useIntegrationOperation.ts
@@ -43,7 +43,7 @@ export function useIntegrationOperation() {
     return integrationService.deleteIntegration({
       name: operation.item.name,
       clusterId,
-      associatedResources: opt.deleteAssociatedResources,
+      deleteAssociatedResources: opt.deleteAssociatedResources,
     });
   }
 

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -1113,14 +1113,17 @@ const cfg = {
   },
 
   getDeleteIntegrationUrlV2(req: IntegrationDeleteRequest) {
-    const path = cfg.api.integration.deleteV2
+    // Not using generatePath here because it doesn't work
+    // when a dynamic path and a query param is next to each other.
+    // eg: some/path/:name?queryParmKey=queryParamValue it will
+    // remove the required ? in the path.
+    return cfg.api.integration.deleteV2
       .replace(':clusterId', req.clusterId)
       .replace(':name', req.name)
       .replace(
         ':associatedresources',
-        req.associatedResources ? 'true' : 'false'
+        req.deleteAssociatedResources ? 'true' : 'false'
       );
-    return generatePath(path, req);
   },
 
   getIntegrationStatsUrl(name: string) {

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -33,6 +33,7 @@ import { TaskState } from 'teleport/Integrations/status/AwsOidc/Tasks/constants'
 import type { SortType } from 'teleport/services/agents';
 import {
   AwsOidcPolicyPreset,
+  IntegrationDeleteRequest,
   IntegrationKind,
   PluginKind,
   Regions,
@@ -360,7 +361,13 @@ const cfg = {
       export: '/v1/webapi/sites/:clusterId/integrations/:name/ca',
     },
 
+    // TODO(kimlisa): move integrationsPath into integration: {...}
     integrationsPath: '/v1/webapi/sites/:clusterId/integrations/:name?',
+    integration: {
+      deleteV2:
+        '/v2/webapi/sites/:clusterId/integrations/:name?associatedresources=:associatedresources',
+    },
+
     integrationStatsPath:
       '/v1/webapi/sites/:clusterId/integrations/:name/stats',
     integrationRulesPath:
@@ -1103,6 +1110,17 @@ const cfg = {
       clusterId,
       name: integrationName,
     });
+  },
+
+  getDeleteIntegrationUrlV2(req: IntegrationDeleteRequest) {
+    const path = cfg.api.integration.deleteV2
+      .replace(':clusterId', req.clusterId)
+      .replace(':name', req.name)
+      .replace(
+        ':associatedresources',
+        req.associatedResources ? 'true' : 'false'
+      );
+    return generatePath(path, req);
   },
 
   getIntegrationStatsUrl(name: string) {

--- a/web/packages/teleport/src/services/integrations/integrations.test.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.test.ts
@@ -115,7 +115,7 @@ test('fetch integration list: fetchIntegrations()', async () => {
         kind: 'github',
         name: 'github-my-org',
         resourceType: 'integration',
-        details: 'GitHub Organization "my-org"',
+        details: 'GitHub repository access for organization "my-org"',
         spec: { organization: 'my-org' },
         statusCode: IntegrationStatusCode.Running,
       },

--- a/web/packages/teleport/src/services/integrations/integrations.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.ts
@@ -24,7 +24,10 @@ import api from 'teleport/services/api';
 import { App } from '../apps';
 import makeApp from '../apps/makeApps';
 import auth, { MfaChallengeScope } from '../auth/auth';
-import { withUnsupportedLabelFeatureErrorConversion } from '../version/unsupported';
+import {
+  withGenericUnsupportedError,
+  withUnsupportedLabelFeatureErrorConversion,
+} from '../version/unsupported';
 import {
   AwsDatabaseVpcsResponse,
   AwsOidcDeployDatabaseServicesRequest,
@@ -42,6 +45,7 @@ import {
   Integration,
   IntegrationCreateRequest,
   IntegrationCreateResult,
+  IntegrationDeleteRequest,
   IntegrationDiscoveryRules,
   IntegrationKind,
   IntegrationListResponse,
@@ -127,8 +131,10 @@ export const integrationService = {
       .then(makeIntegration);
   },
 
-  deleteIntegration(name: string): Promise<void> {
-    return api.delete(cfg.getIntegrationsUrl(name));
+  deleteIntegration(req: IntegrationDeleteRequest): Promise<void> {
+    return api
+      .delete(cfg.getDeleteIntegrationUrlV2(req))
+      .catch(err => withGenericUnsupportedError(err, 'v17.3.0'));
   },
 
   fetchThumbprint(): Promise<string> {
@@ -590,7 +596,7 @@ function makeIntegration(json: any): Integration {
     return {
       ...commonFields,
       resourceType: 'integration',
-      details: `GitHub Organization "${github.organization}"`,
+      details: `GitHub repository access for organization "${github.organization}"`,
       spec: {
         organization: github.organization,
       },

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -985,3 +985,15 @@ export type ExportedIntegrationCaResponse = {
   tls: TlsKey[];
   jwt: JwtKey[];
 };
+
+export type IntegrationDeleteRequest = {
+  name: string;
+  clusterId: string;
+  /**
+   * If true, will delete any associated resources
+   * tied to the integration.
+   *
+   * Not all integration kinds supports resource cleanup.
+   */
+  associatedResources?: boolean;
+};

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -995,5 +995,5 @@ export type IntegrationDeleteRequest = {
    *
    * Not all integration kinds supports resource cleanup.
    */
-  associatedResources?: boolean;
+  deleteAssociatedResources?: boolean;
 };

--- a/web/packages/teleport/src/services/version/unsupported.test.ts
+++ b/web/packages/teleport/src/services/version/unsupported.test.ts
@@ -99,11 +99,11 @@ describe('withGenericUnsupportedError', () => {
 
     expect(() =>
       withGenericUnsupportedError(pathNotFoundError, 'v2.0.0')
-    ).toThrow(/could not complete your request/i);
+    ).toThrow('Your proxy (v1.2.3-dev) may be behind');
 
     expect(() =>
       withGenericUnsupportedError(pathNotFoundError, 'v2.0.0')
-    ).toThrow(/v2.0.0/i);
+    ).toThrow('minimum required version (v2.0.0)');
   });
 
   test('legach path not found error throws custom error', async () => {
@@ -114,7 +114,7 @@ describe('withGenericUnsupportedError', () => {
 
     expect(() =>
       withGenericUnsupportedError(legacyPathNotFoundError, 'v2.0.0')
-    ).toThrow(/could not complete your request/i);
+    ).toThrow('Your proxy may be behind');
   });
 
   test('non path related 404 error rethrows same error', async () => {


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/51410

- [ ] requires https://github.com/gravitational/teleport/pull/52333

creates a v2 endpoint for deleting integration with cleanup, required so that this request can fail in older proxies, otherwise it'll look like it succeeded (query params added to ^ pr will get ignored) but no resources will have been deleted