### PR TITLE
Add document with VNet diag report

### DIFF
--- a/web/packages/teleterm/src/helpers.ts
+++ b/web/packages/teleterm/src/helpers.ts
@@ -22,6 +22,10 @@ import { Kube } from 'gen-proto-ts/teleport/lib/teleterm/v1/kube_pb';
 import { Server } from 'gen-proto-ts/teleport/lib/teleterm/v1/server_pb';
 import { PaginatedResource } from 'gen-proto-ts/teleport/lib/teleterm/v1/service_pb';
 import * as api from 'gen-proto-ts/teleport/lib/teleterm/v1/tshd_events_service_pb';
+import {
+  CheckReport,
+  RouteConflictReport,
+} from 'gen-proto-ts/teleport/lib/vnet/diag/v1/diag_pb';
 
 import {
   ReloginRequest,
@@ -170,4 +174,13 @@ export function reloginReasonOneOfIsVnetCertExpired(
   vnetCertExpired: api.VnetCertExpired;
 } {
   return reason.oneofKind === 'vnetCertExpired';
+}
+
+export function reportOneOfIsRouteConflictReport(
+  report: CheckReport['report']
+): report is {
+  oneofKind: 'routeConflictReport';
+  routeConflictReport: RouteConflictReport;
+} {
+  return report.oneofKind === 'routeConflictReport';
 }

--- a/web/packages/teleterm/src/services/vnet/testHelpers.ts
+++ b/web/packages/teleterm/src/services/vnet/testHelpers.ts
@@ -23,10 +23,11 @@ import {
   CheckReport,
   CheckReportStatus,
   Report,
+  RouteConflict,
 } from 'gen-proto-ts/teleport/lib/vnet/diag/v1/diag_pb';
 
 export const makeReport = (props: Partial<Report> = {}): Report => ({
-  createdAt: Timestamp.fromDate(new Date(2025, 0, 1, 12, 0)),
+  createdAt: Timestamp.fromDate(new Date(2024, 10, 23, 13, 27, 48)),
   checks: [makeCheckAttempt()],
   networkStackAttempt: {
     status: CheckAttemptStatus.OK,
@@ -61,5 +62,15 @@ export const makeCheckReport = (
       routeConflicts: [],
     },
   },
+  ...props,
+});
+
+export const makeRouteConflict = (
+  props: Partial<RouteConflict> = {}
+): RouteConflict => ({
+  dest: '100.64.0.0/10',
+  vnetDest: '100.64.0.1',
+  interfaceName: 'utun5',
+  interfaceApp: '',
   ...props,
 });

--- a/web/packages/teleterm/src/services/vnet/testHelpers.ts
+++ b/web/packages/teleterm/src/services/vnet/testHelpers.ts
@@ -56,7 +56,10 @@ export const makeCheckReport = (
 ): CheckReport => ({
   status: CheckReportStatus.OK,
   report: {
-    oneofKind: undefined,
+    oneofKind: 'routeConflictReport',
+    routeConflictReport: {
+      routeConflicts: [],
+    },
   },
   ...props,
 });

--- a/web/packages/teleterm/src/ui/Documents/DocumentsRenderer.tsx
+++ b/web/packages/teleterm/src/ui/Documents/DocumentsRenderer.tsx
@@ -47,6 +47,7 @@ import {
   Workspace,
 } from 'teleterm/ui/services/workspacesService';
 import { isAppUri, isDatabaseUri, RootClusterUri } from 'teleterm/ui/uri';
+import { DocumentVnetDiagReport } from 'teleterm/ui/Vnet/DocumentVnetDiagReport';
 
 import { KeyboardShortcutsPanel } from './KeyboardShortcutsPanel';
 import { WorkspaceContextProvider } from './workspaceContext';
@@ -171,6 +172,8 @@ function MemoizedDocument(props: { doc: types.Document; visible: boolean }) {
         return <DocumentConnectMyComputer doc={doc} visible={visible} />;
       case 'doc.authorize_web_session':
         return <DocumentAuthorizeWebSession doc={doc} visible={visible} />;
+      case 'doc.vnet_diag_report':
+        return <DocumentVnetDiagReport doc={doc} visible={visible} />;
       default:
         return (
           <Document visible={visible}>

--- a/web/packages/teleterm/src/ui/TabHost/TabHost.story.tsx
+++ b/web/packages/teleterm/src/ui/TabHost/TabHost.story.tsx
@@ -45,7 +45,7 @@ const meta: Meta = {
 
 export default meta;
 
-const allDocuments: Document[] = [
+const allDocuments = [
   makeDocumentCluster(),
   makeDocumentTshNode(),
   makeDocumentConnectMyComputer(),
@@ -74,3 +74,21 @@ export function Story() {
     </MockAppContextProvider>
   );
 }
+
+// https://stackoverflow.com/questions/53807517/how-to-test-if-two-types-are-exactly-the-same/73461648#73461648
+function assert<T extends never>() {} // eslint-disable-line @typescript-eslint/no-unused-vars
+type TypeEqualityGuard<A, B> = Exclude<A, B> | Exclude<B, A>;
+type ArrayElement<T> = T extends (infer U)[] ? U : never;
+
+type AllExpectedDocs = Exclude<
+  Document,
+  // DocumentBlank isn't rendered with other documents in the real app.
+  | { kind: 'doc.blank' }
+  // Deprecated DocumentTshNodeWithLoginHost.
+  | { kind: 'doc.terminal_tsh_node'; loginHost: string }
+  // Deprecated DocumentTshKube.
+  | { kind: 'doc.terminal_tsh_kube' }
+>;
+// This is going to raise a type error if allDocuments does not include all expected documents
+// defined in Document.
+assert<TypeEqualityGuard<ArrayElement<typeof allDocuments>, AllExpectedDocs>>();

--- a/web/packages/teleterm/src/ui/TabHost/TabHost.story.tsx
+++ b/web/packages/teleterm/src/ui/TabHost/TabHost.story.tsx
@@ -35,6 +35,7 @@ import {
   makeDocumentGatewayKube,
   makeDocumentPtySession,
   makeDocumentTshNode,
+  makeDocumentVnetDiagReport,
 } from 'teleterm/ui/services/workspacesService/documentsService/testHelpers';
 
 import { TabHostContainer } from './TabHost';
@@ -56,6 +57,7 @@ const allDocuments = [
   makeDocumentAccessRequests(),
   makeDocumentPtySession(),
   makeDocumentAuthorizeWebSession(),
+  makeDocumentVnetDiagReport(),
 ];
 
 const cluster = makeRootCluster();

--- a/web/packages/teleterm/src/ui/Vnet/DiagnosticsAlert.test.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DiagnosticsAlert.test.tsx
@@ -33,6 +33,7 @@ import {
 } from 'teleterm/services/vnet/testHelpers';
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
+import { ConnectionsContextProvider } from 'teleterm/ui/TopBar/Connections/connectionsContext';
 
 import { DiagnosticsAlert } from './DiagnosticsAlert';
 import { useVnetContext, VnetContextProvider } from './vnetContext';
@@ -168,10 +169,12 @@ describe('DiagnosticsAlert', () => {
 
       render(
         <MockAppContextProvider appContext={appContext}>
-          <VnetContextProvider>
-            <RunDiagnostics />
-            <DiagnosticsAlert />
-          </VnetContextProvider>
+          <ConnectionsContextProvider>
+            <VnetContextProvider>
+              <RunDiagnostics />
+              <DiagnosticsAlert />
+            </VnetContextProvider>
+          </ConnectionsContextProvider>
         </MockAppContextProvider>
       );
 

--- a/web/packages/teleterm/src/ui/Vnet/DiagnosticsAlert.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DiagnosticsAlert.tsx
@@ -73,34 +73,36 @@ export const DiagnosticsAlert = () => {
         title: 'Log in to a cluster to see the full report',
       }
     : {};
-  const openReport = !rootClusterUri
-    ? () => {}
-    : () => {
-        const docsService =
-          workspacesService.getWorkspaceDocumentService(rootClusterUri);
+  const openReport = () => {
+    if (!rootClusterUri) {
+      return;
+    }
 
-        // Check for an existing doc first. It may be present if someone re-runs diagnostics from
-        // within a doc, then opens the VNet panel and clicks "Open Report". The report in the panel
-        // and the report in the doc are equal in that case, as they both come from
-        // diagnosticsAttempt.data.
-        const existingDoc = docsService.getDocuments().find(
-          d =>
-            d.kind === 'doc.vnet_diag_report' &&
-            // Reports don't have IDs, so createdAt is used as a good-enough approximation of an ID.
-            d.report?.createdAt === report.createdAt
-        );
-        if (existingDoc) {
-          docsService.open(existingDoc.uri);
-        } else {
-          const doc = docsService.createVnetDiagReportDocument({
-            rootClusterUri,
-            report,
-          });
-          docsService.add(doc);
-          docsService.open(doc.uri);
-        }
-        closeConnectionsPanel();
-      };
+    const docsService =
+      workspacesService.getWorkspaceDocumentService(rootClusterUri);
+
+    // Check for an existing doc first. It may be present if someone re-runs diagnostics from
+    // within a doc, then opens the VNet panel and clicks "Open Report". The report in the panel
+    // and the report in the doc are equal in that case, as they both come from
+    // diagnosticsAttempt.data.
+    const existingDoc = docsService.getDocuments().find(
+      d =>
+        d.kind === 'doc.vnet_diag_report' &&
+        // Reports don't have IDs, so createdAt is used as a good-enough approximation of an ID.
+        d.report?.createdAt === report.createdAt
+    );
+    if (existingDoc) {
+      docsService.open(existingDoc.uri);
+    } else {
+      const doc = docsService.createVnetDiagReportDocument({
+        rootClusterUri,
+        report,
+      });
+      docsService.add(doc);
+      docsService.open(doc.uri);
+    }
+    closeConnectionsPanel();
+  };
 
   if (
     report.checks.length &&

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.story.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.story.tsx
@@ -1,0 +1,209 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Meta } from '@storybook/react';
+
+import {
+  CheckAttemptStatus,
+  CheckReportStatus,
+  CommandAttemptStatus,
+  RouteConflict,
+  RouteConflictReport,
+} from 'gen-proto-ts/teleport/lib/vnet/diag/v1/diag_pb';
+
+import {
+  makeCheckAttempt,
+  makeCheckReport,
+  makeReport,
+  makeRouteConflict,
+} from 'teleterm/services/vnet/testHelpers';
+import { makeDocumentVnetDiagReport } from 'teleterm/ui/services/workspacesService/documentsService/testHelpers';
+
+import { DocumentVnetDiagReport as Component } from './DocumentVnetDiagReport';
+
+type StoryProps = {
+  networkStackAttempt: 'ok' | 'error';
+  ipv4CidrRanges: string[];
+  dnsZones: string[];
+  routeConflictAttempt: 'ok' | 'issues-found' | 'error';
+  routeConflicts: RouteConflict[];
+  routeConflictCommandAttempt: 'ok' | 'error';
+  displayUnsupportedCheckAttempt: boolean;
+};
+
+const meta: Meta<StoryProps> = {
+  title: 'Teleterm/Vnet/DocumentVnetDiagReport',
+  component: DocumentVnetDiagReport,
+  argTypes: {
+    networkStackAttempt: {
+      control: { type: 'inline-radio' },
+      options: ['ok', 'error'],
+    },
+    ipv4CidrRanges: { control: { type: 'object' } },
+    dnsZones: { control: { type: 'object' } },
+    routeConflictAttempt: {
+      control: { type: 'inline-radio' },
+      options: ['ok', 'issues-found', 'error'],
+    },
+    routeConflicts: { control: { type: 'object' } },
+    routeConflictCommandAttempt: {
+      control: { type: 'inline-radio' },
+      options: ['ok', 'error'],
+    },
+    displayUnsupportedCheckAttempt: {
+      description:
+        "Simulates the component receiving a report with a check attempt that's not supported in the current version",
+    },
+  },
+  args: {
+    networkStackAttempt: 'ok',
+    ipv4CidrRanges: ['100.64.0.0/10'],
+    dnsZones: ['teleport.example.com', 'company.test'],
+    routeConflictAttempt: 'issues-found',
+    routeConflicts: [
+      makeRouteConflict({
+        dest: '100.64.0.0/10',
+        vnetDest: '100.64.0.1',
+        interfaceName: 'utun5',
+        interfaceApp: 'VPN: Foobar',
+      }),
+      makeRouteConflict({
+        dest: '0.0.0.0/1',
+        vnetDest: '100.64.0.0/10',
+        interfaceName: 'utun6',
+        interfaceApp: '',
+      }),
+    ],
+    routeConflictCommandAttempt: 'ok',
+    displayUnsupportedCheckAttempt: false,
+  },
+};
+export default meta;
+
+export function DocumentVnetDiagReport(props: StoryProps) {
+  const report = makeReport({ checks: [] });
+  if (props.networkStackAttempt === 'error') {
+    report.networkStackAttempt.status = CheckAttemptStatus.ERROR;
+    report.networkStackAttempt.error = 'something went wrong';
+    report.networkStackAttempt.networkStack = undefined;
+  }
+  if (props.networkStackAttempt === 'ok') {
+    report.networkStackAttempt.networkStack.ipv4CidrRanges =
+      props.ipv4CidrRanges;
+    report.networkStackAttempt.networkStack.dnsZones = props.dnsZones;
+  }
+
+  const routeConflictReport: RouteConflictReport = { routeConflicts: [] };
+  const routeConflictCheckAttempt = makeCheckAttempt({
+    checkReport: makeCheckReport({
+      report: {
+        oneofKind: 'routeConflictReport',
+        routeConflictReport,
+      },
+    }),
+  });
+  if (props.routeConflictAttempt === 'error') {
+    routeConflictCheckAttempt.status = CheckAttemptStatus.ERROR;
+    routeConflictCheckAttempt.error = 'something went wrong';
+  } else {
+    routeConflictCheckAttempt.status = CheckAttemptStatus.OK;
+    routeConflictCheckAttempt.checkReport.status = CheckReportStatus.OK;
+    if (props.routeConflictAttempt === 'issues-found') {
+      routeConflictCheckAttempt.checkReport.status =
+        CheckReportStatus.ISSUES_FOUND;
+      routeConflictReport.routeConflicts = props.routeConflicts;
+    }
+  }
+  if (props.routeConflictCommandAttempt === 'error') {
+    routeConflictCheckAttempt.commands.push({
+      status: CommandAttemptStatus.ERROR,
+      error: 'something went wrong',
+      command: 'netstat -rn -f inet',
+      output: '',
+    });
+  } else {
+    routeConflictCheckAttempt.commands.push({
+      status: CommandAttemptStatus.OK,
+      error: '',
+      command: 'netstat -rn -f inet',
+      output: netstatOutput,
+    });
+  }
+  report.checks.push(routeConflictCheckAttempt);
+
+  if (props.displayUnsupportedCheckAttempt) {
+    report.checks.push({
+      status: CheckAttemptStatus.OK,
+      checkReport: {
+        report: { oneofKind: 'bazBarFooReport' as any },
+        status: CheckReportStatus.ISSUES_FOUND,
+      },
+      error: '',
+      commands: [],
+    });
+  }
+
+  const doc = makeDocumentVnetDiagReport({
+    report,
+  });
+
+  return <Component visible doc={doc} />;
+}
+
+const netstatOutput = `Routing tables
+
+Internet:
+Destination        Gateway            Flags               Netif Expire
+default            192.168.1.1        UGdScg                en0       
+default            link#23            UCSIg           bridge100      !
+default            link#25            UCSIg               utun4       
+100.64/10          link#25            UCS                 utun4       
+100.64.0.1         100.64.0.1         UH                  utun5       
+100.87.112.117     100.87.112.117     UH                  utun4       
+100.100.100.100/32 link#25            UCS                 utun4       
+100.100.100.100    link#25            UHWIi               utun4       
+127                127.0.0.1          UCS                   lo0       
+127.0.0.1          127.0.0.1          UH                    lo0       
+169.254            link#14            UCS                   en0      !
+169.254.11.121     50:ec:50:ed:89:cd  UHLSW                 en0      !
+169.254.169.254    link#14            UHRLSW                en0      !
+172.20.10.2        link#23            UHRLWIg         bridge100     16
+172.20.10.2        link#25            UHW3Ig              utun4      6
+192.168.1          link#14            UCS                   en0      !
+192.168.1.1/32     link#14            UCS                   en0      !
+192.168.1.1        7c:10:c9:b5:da:f8  UHLWIir               en0   1188
+192.168.1.29       link#14            UHLWI                 en0      !
+192.168.1.37       0:5:cd:b0:91:ce    UHLWI                 en0   1181
+192.168.1.54       0:11:32:64:d7:d3   UHLWIi                en0   1185
+192.168.1.121      2a:d0:62:b8:f6:e2  UHLWI                 en0   1027
+192.168.1.183/32   link#14            UCS                   en0      !
+192.168.1.183      8e:62:82:7f:23:cb  UHLWI                 lo0       
+192.168.1.247      6a:8:72:ed:38:34   UHLWI                 en0   1072
+192.168.1.255      ff:ff:ff:ff:ff:ff  UHLWbI                en0      !
+192.168.64         link#23            UC              bridge100      !
+192.168.64.1       fa.4d.89.68.e8.64  UHLWI                 lo0       
+192.168.64.10      12.15.6e.c9.b5.8f  UHLWI           bridge100      !
+192.168.64.255     ff.ff.ff.ff.ff.ff  UHLWbI          bridge100      !
+224.0.0/4          link#14            UmCS                  en0      !
+224.0.0/4          link#25            UmCSI               utun4       
+224.0.0.251        1:0:5e:0:0:fb      UHmLWI                en0       
+224.0.0.251        1:0:5e:0:0:fb      UHmLWIg         bridge100       
+239.255.255.250    1:0:5e:7f:ff:fa    UHmLWI                en0       
+255.255.255.255/32 link#14            UCS                   en0      !
+255.255.255.255/32 link#25            UCSI                utun4       
+`;

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
@@ -73,7 +73,7 @@ export function DocumentVnetDiagReport(props: {
             <H1>VNet Diagnostic Report</H1>
 
             <Flex gap={2}>
-              {/* TODO: Implement buttons. */}
+              {/* TODO(ravicious): Implement buttons. */}
               <HoverTooltip tipContent="Run Diagnostics Again">
                 <Button intent="neutral" p={1}>
                   <Refresh size="medium" />

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
@@ -101,7 +101,7 @@ export function DocumentVnetDiagReport(props: {
                 kind="danger"
                 details={<P2>{networkStackAttempt.error}</P2>}
               >
-                Network details could not be determined.
+                Network details could not be determined
               </Alert>
             </>
           )}
@@ -153,13 +153,13 @@ const CheckAttempt = ({
     <Stack gap={2} width="100%">
       {!displayDetails ? (
         <Alert kind="danger">
-          Cannot display the result from an unsupported check {reportOneof}.
+          Cannot display the result from an unsupported check {reportOneof}
         </Alert>
       ) : (
         <>
           {checkAttempt.status === diag.CheckAttemptStatus.ERROR && (
             <Alert kind="danger" details={<P2>{checkAttempt.error}</P2>}>
-              Failed to {displayDetails.errorTitle}.
+              Failed to {displayDetails.errorTitle}
             </Alert>
           )}
 

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
@@ -1,0 +1,301 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import styled from 'styled-components';
+
+import { Button, Alert as DesignAlert, Flex, H1, Link, Stack } from 'design';
+import { AlertProps } from 'design/Alert/Alert';
+import Table, { TextCell } from 'design/DataTable';
+import { displayDateTime } from 'design/datetime';
+import {
+  Copy,
+  Download,
+  Refresh,
+  Check as SuccessIcon,
+  Warning as WarningIcon,
+} from 'design/Icon';
+import { P1, P2 } from 'design/Text/Text';
+import { HoverTooltip } from 'design/Tooltip';
+import { Timestamp } from 'gen-proto-ts/google/protobuf/timestamp_pb';
+import * as diag from 'gen-proto-ts/teleport/lib/vnet/diag/v1/diag_pb';
+import { pluralize } from 'shared/utils/text';
+
+import { reportOneOfIsRouteConflictReport } from 'teleterm/helpers';
+import Document from 'teleterm/ui/Document';
+import type * as docTypes from 'teleterm/ui/services/workspacesService';
+
+export function DocumentVnetDiagReport(props: {
+  visible: boolean;
+  doc: docTypes.DocumentVnetDiagReport;
+}) {
+  const { report } = props.doc;
+  const { networkStackAttempt } = report;
+  const { networkStack } = networkStackAttempt;
+  const createdAt = displayDateTime(Timestamp.toDate(report.createdAt));
+
+  return (
+    <Document visible={props.visible}>
+      <Stack
+        gap={4}
+        maxWidth="680px"
+        width="100%"
+        mx="auto"
+        mt={4}
+        p={5}
+        backgroundColor="levels.surface"
+        borderRadius={2}
+        // Without this, the Stack would span the whole height of the Document, no matter how much
+        // content was displayed in the Stack.
+        alignSelf="flex-start"
+      >
+        <Stack gap={2} width="100%" alignItems="stretch">
+          <Flex
+            flexWrap="wrap"
+            width="100%"
+            gap={2}
+            justifyContent="space-between"
+          >
+            <H1>VNet Diagnostic Report</H1>
+
+            <Flex gap={2}>
+              {/* TODO: Implement buttons. */}
+              <HoverTooltip tipContent="Run Diagnostics Again">
+                <Button intent="neutral" p={1}>
+                  <Refresh size="medium" />
+                </Button>
+              </HoverTooltip>
+
+              <HoverTooltip tipContent="Copy Report to Clipboard">
+                <Button intent="neutral" p={1}>
+                  <Copy size="medium" />
+                </Button>
+              </HoverTooltip>
+
+              <HoverTooltip tipContent="Save Report to File">
+                <Button intent="neutral" p={1}>
+                  <Download size="medium" />
+                </Button>
+              </HoverTooltip>
+            </Flex>
+          </Flex>
+
+          {networkStackAttempt.status === diag.CheckAttemptStatus.ERROR && (
+            <>
+              <P2>Created at: {createdAt}</P2>
+              <Alert
+                kind="danger"
+                details={<P2>{networkStackAttempt.error}</P2>}
+              >
+                Network details could not be determined.
+              </Alert>
+            </>
+          )}
+
+          {networkStackAttempt.status === diag.CheckAttemptStatus.OK && (
+            <P2>
+              Created at: {createdAt}
+              <br />
+              Network interface: <code>{networkStack.interfaceName}</code>
+              <br />
+              IPv4 CIDR {pluralize(networkStack.ipv4CidrRanges.length, 'range')}
+              : <code>{networkStack.ipv4CidrRanges.join(', ')}</code>
+              <br />
+              IPv6 prefix: <code>{networkStack.ipv6Prefix}</code>
+              <br />
+              DNS {pluralize(networkStack.dnsZones.length, 'zone')}:{' '}
+              <code>{networkStack.dnsZones.join(', ')}</code>
+            </P2>
+          )}
+        </Stack>
+
+        {report.checks.map(checkAttempt => (
+          <CheckAttempt
+            // tshd promises that checkAttempt.checkReport.report.oneofKind is
+            // 1) always present even if the check fails to complete
+            // 2) unique
+            key={checkAttempt.checkReport.report.oneofKind}
+            checkAttempt={checkAttempt}
+          />
+        ))}
+      </Stack>
+    </Document>
+  );
+}
+
+/**
+ * CheckAttempt displays the result of attempting to run an individual check along with the outputs
+ * of the accompanying commands. The commands are displayed even if the check itself failed to run.
+ */
+const CheckAttempt = ({
+  checkAttempt,
+}: {
+  checkAttempt: diag.CheckAttempt;
+}) => {
+  const reportOneof = checkAttempt.checkReport.report.oneofKind;
+  const displayDetails = reportOneofDisplayDetails[reportOneof];
+
+  return (
+    <Stack gap={2} width="100%">
+      {!displayDetails ? (
+        <Alert kind="danger">
+          Cannot display the result from an unsupported check {reportOneof}.
+        </Alert>
+      ) : (
+        <>
+          {checkAttempt.status === diag.CheckAttemptStatus.ERROR && (
+            <Alert kind="danger" details={<P2>{checkAttempt.error}</P2>}>
+              Failed to {displayDetails.errorTitle}.
+            </Alert>
+          )}
+
+          {checkAttempt.status === diag.CheckAttemptStatus.OK && (
+            <displayDetails.Component checkReport={checkAttempt.checkReport} />
+          )}
+        </>
+      )}
+
+      {checkAttempt.commands.map(commandAttempt =>
+        commandAttempt.status === diag.CommandAttemptStatus.ERROR ? (
+          <Alert
+            kind="danger"
+            key={commandAttempt.command}
+            details={<P2>{commandAttempt.error}</P2>}
+          >
+            Ran into an error when executing{' '}
+            <code>{commandAttempt.command}</code>
+          </Alert>
+        ) : (
+          <details key={commandAttempt.command}>
+            <Summary>
+              <code>{commandAttempt.command}</code>
+            </Summary>
+
+            <Pre>{commandAttempt.output}</Pre>
+          </details>
+        )
+      )}
+    </Stack>
+  );
+};
+
+const reportOneofDisplayDetails: Record<
+  diag.CheckReport['report']['oneofKind'],
+  {
+    Component: React.ComponentType<{ checkReport: diag.CheckReport }>;
+    errorTitle: string;
+  }
+> = {
+  routeConflictReport: {
+    errorTitle: 'inspect network routes',
+    Component: CheckReportRouteConflict,
+  },
+};
+
+/**
+ * CheckReportRouteConflict displays a table with network routes in the system that are in conflict
+ * with routes set up by VNet.
+ */
+function CheckReportRouteConflict({
+  checkReport: { report, status },
+}: {
+  checkReport: diag.CheckReport;
+}) {
+  if (!reportOneOfIsRouteConflictReport(report)) {
+    return null;
+  }
+
+  if (status === diag.CheckReportStatus.OK) {
+    return (
+      <P1>
+        <Success /> There are no network routes in conflict with VNet.
+      </P1>
+    );
+  }
+
+  const { routeConflicts } = report.routeConflictReport;
+
+  return (
+    <>
+      <Stack>
+        <P1>
+          <Warning /> There{' '}
+          {routeConflicts.length === 1
+            ? 'is a network route'
+            : 'are multiple network routes'}{' '}
+          in conflict with VNet.
+        </P1>
+
+        <P2 m={0}>
+          This might cause the traffic meant for VNet to be captured by another
+          interface. The cluster admin might be able to resolve this problem by{' '}
+          <Link
+            target="_blank"
+            href="https://goteleport.com/docs/enroll-resources/application-access/guides/vnet/#configuring-ipv4-cidr-range"
+          >
+            adjusting the IPv4 CIDR range used by VNet
+          </Link>
+          .
+        </P2>
+      </Stack>
+
+      <Table
+        emptyText=""
+        data={routeConflicts}
+        columns={[
+          { key: 'dest', headerText: 'Conflicting destination' },
+          { key: 'vnetDest', headerText: 'VNet destination' },
+          { key: 'interfaceName', headerText: 'Interface' },
+          {
+            key: 'interfaceApp',
+            headerText: 'Set up by',
+            render: routeConflict => (
+              <TextCell data={routeConflict.interfaceApp || 'unknown'} />
+            ),
+          },
+        ]}
+        row={{ getStyle: () => ({ fontFamily: 'monospace' }) }}
+      />
+    </>
+  );
+}
+
+const Summary = styled.summary`
+  cursor: pointer;
+`;
+
+const Pre = styled.pre`
+  white-space: pre-wrap;
+`;
+
+const Warning = styled(WarningIcon).attrs({
+  size: 'small',
+  color: 'interactive.solid.alert.default',
+})`
+  vertical-align: sub;
+`;
+
+const Success = styled(SuccessIcon).attrs({
+  size: 'small',
+  color: 'interactive.solid.success.default',
+})`
+  vertical-align: sub;
+`;
+
+const Alert = (props: Pick<AlertProps, 'children' | 'details' | 'kind'>) => (
+  <DesignAlert m={0} width="100%" {...props} />
+);

--- a/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.story.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.story.tsx
@@ -30,6 +30,7 @@ import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
 import { makeReport } from 'teleterm/services/vnet/testHelpers';
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
+import { ConnectionsContextProvider } from 'teleterm/ui/TopBar/Connections/connectionsContext';
 
 import { useVnetContext, VnetContextProvider } from './vnetContext';
 import { VnetSliderStep as Component } from './VnetSliderStep';
@@ -203,19 +204,21 @@ export function VnetSliderStep(props: StoryProps) {
       // data are fired again.
       key={JSON.stringify(props)}
     >
-      <VnetContextProvider>
-        {props.listDnsZones === 'processing-with-previous-results' && (
-          <RerequestDNSZones />
-        )}
-        <Component
-          refCallback={noop}
-          next={noop}
-          prev={noop}
-          hasTransitionEnded
-          stepIndex={1}
-          flowLength={2}
-        />
-      </VnetContextProvider>
+      <ConnectionsContextProvider>
+        <VnetContextProvider>
+          {props.listDnsZones === 'processing-with-previous-results' && (
+            <RerequestDNSZones />
+          )}
+          <Component
+            refCallback={noop}
+            next={noop}
+            prev={noop}
+            hasTransitionEnded
+            stepIndex={1}
+            flowLength={2}
+          />
+        </VnetContextProvider>
+      </ConnectionsContextProvider>
     </MockAppContextProvider>
   );
 }

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { Report } from 'gen-proto-ts/teleport/lib/vnet/diag/v1/diag_pb';
+
 import type { Shell } from 'teleterm/mainProcess/shell';
 import type { RuntimeSettings } from 'teleterm/mainProcess/types';
 import * as uri from 'teleterm/ui/uri';
@@ -48,6 +50,7 @@ import {
   DocumentTshKube,
   DocumentTshNode,
   DocumentTshNodeWithServerId,
+  DocumentVnetDiagReport,
   WebSessionRequest,
 } from './types';
 
@@ -248,6 +251,21 @@ export class DocumentsService {
       title: 'Authorize Web Session',
       rootClusterUri: params.rootClusterUri,
       webSessionRequest: params.webSessionRequest,
+    };
+  }
+
+  createVnetDiagReportDocument(opts: {
+    rootClusterUri: RootClusterUri;
+    report: Report;
+  }): DocumentVnetDiagReport {
+    const uri = routing.getDocUri({ docId: unique() });
+
+    return {
+      uri,
+      kind: 'doc.vnet_diag_report',
+      title: 'VNet Diagnostic Report',
+      rootClusterUri: opts.rootClusterUri,
+      report: opts.report,
     };
   }
 

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsUtils.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsUtils.ts
@@ -24,6 +24,7 @@ import {
   Kubernetes,
   Laptop,
   ListAddCheck,
+  ListMagnifyingGlass,
   Server,
   ShieldCheck,
   Table,
@@ -78,6 +79,8 @@ export function getResourceUri(
     case 'doc.connect_my_computer':
       return document.rootClusterUri;
     case 'doc.authorize_web_session':
+      return document.rootClusterUri;
+    case 'doc.vnet_diag_report':
       return document.rootClusterUri;
     case 'doc.blank':
       return undefined;
@@ -194,6 +197,11 @@ export function getStaticNameAndIcon(
       return {
         name: document.title,
         Icon: ShieldCheck,
+      };
+    case 'doc.vnet_diag_report':
+      return {
+        name: document.title,
+        Icon: ListMagnifyingGlass,
       };
     case 'doc.blank':
     case 'doc.terminal_tsh_kube':

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/testHelpers.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/testHelpers.ts
@@ -20,9 +20,10 @@ import {
   makeAppGateway,
   makeDatabaseGateway,
   makeKubeGateway,
-  makeRootCluster,
   makeServer,
+  rootClusterUri,
 } from 'teleterm/services/tshd/testHelpers';
+import { makeReport } from 'teleterm/services/vnet/testHelpers';
 
 import {
   DocumentAccessRequests,
@@ -34,6 +35,7 @@ import {
   DocumentGatewayKube,
   DocumentPtySession,
   DocumentTshNodeWithServerId,
+  DocumentVnetDiagReport,
 } from './types';
 
 export function makeDocumentCluster(
@@ -43,7 +45,7 @@ export function makeDocumentCluster(
     kind: 'doc.cluster',
     uri: '/docs/cluster',
     title: 'teleport-ent.asteroid.earth',
-    clusterUri: makeRootCluster().uri,
+    clusterUri: rootClusterUri,
     queryParams: {
       sort: {
         fieldName: 'name',
@@ -169,7 +171,7 @@ export function makeDocumentAccessRequests(
     kind: 'doc.access_requests',
     uri: '/docs/access_requests',
     title: 'Access Requests',
-    clusterUri: makeRootCluster().uri,
+    clusterUri: rootClusterUri,
     state: 'browsing',
     requestId: '1231',
     ...props,
@@ -182,7 +184,7 @@ export function makeDocumentConnectMyComputer(
   return {
     kind: 'doc.connect_my_computer',
     uri: '/docs/connect-my-computer',
-    rootClusterUri: makeRootCluster().uri,
+    rootClusterUri,
     status: '',
     title: 'Connect My Computer',
     ...props,
@@ -196,13 +198,26 @@ export function makeDocumentAuthorizeWebSession(
     kind: 'doc.authorize_web_session',
     uri: '/docs/authorize-web-session',
     title: 'Authorize Web Session',
-    rootClusterUri: makeRootCluster().uri,
+    rootClusterUri,
     webSessionRequest: {
       id: '123',
       username: 'alice',
       token: 'secret-token',
       redirectUri: '',
     },
+    ...props,
+  };
+}
+
+export function makeDocumentVnetDiagReport(
+  props?: Partial<DocumentVnetDiagReport>
+): DocumentVnetDiagReport {
+  return {
+    kind: 'doc.vnet_diag_report',
+    uri: '/docs/vnet-diag-report',
+    title: 'VNet Diagnostics Report',
+    rootClusterUri,
+    report: makeReport(),
     ...props,
   };
 }

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { Report } from 'gen-proto-ts/teleport/lib/vnet/diag/v1/diag_pb';
 import { SharedUnifiedResource } from 'shared/components/UnifiedResources';
 
 import type * as tsh from 'teleterm/services/tshd/types';
@@ -252,6 +253,15 @@ export interface DocumentConnectMyComputer extends DocumentBase {
   status: '' | 'connecting' | 'connected' | 'error';
 }
 
+export interface DocumentVnetDiagReport extends DocumentBase {
+  kind: 'doc.vnet_diag_report';
+  // VNet itself is not bound to any workspace, but a document must belong to a workspace. Also, it
+  // must be possible to determine the relation between a document and a cluster just by looking at
+  // the document fields, hence why rootClusterUri is defined here.
+  rootClusterUri: uri.RootClusterUri;
+  report: Report;
+}
+
 /**
  * Document to authorize a web session with device trust.
  * Unlike other documents, it is not persisted on disk.
@@ -286,6 +296,7 @@ export type Document =
   | DocumentCluster
   | DocumentTerminal
   | DocumentConnectMyComputer
+  | DocumentVnetDiagReport
   | DocumentAuthorizeWebSession;
 
 /**

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Immutable, produce } from 'immer';
+import { castDraft, Immutable, produce } from 'immer';
 import { z } from 'zod';
 
 import {
@@ -513,7 +513,9 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
   ): void {
     this.setState(draftState => {
       const workspace = draftState.workspaces[rootClusterUri];
-      workspace.documents = reopen.documents.map(d => {
+      // reopen.documents is immutable, but workspace.documents is a mutable draft, hence the cast.
+      // https://immerjs.github.io/immer/typescript/#cast-utilities
+      workspace.documents = castDraft(reopen.documents).map(d => {
         //TODO: create a function that will prepare a new document, it will be used in:
         // DocumentsService
         // TrackedConnectionOperationsFactory

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
@@ -492,7 +492,7 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
       const documents = workspace?.documents || [];
 
       for (const doc of documents) {
-        if (doc?.kind === 'doc.vnet_diag_report' && doc?.report?.createdAt) {
+        if (doc.kind === 'doc.vnet_diag_report' && doc.report?.createdAt) {
           // Timestamps use BigInt, which currently isn't serializable to JSON.
           // TODO(ravicious): Once we upgrade to Node.js >= 21, deal with serializing BigInt
           // in the function `stringify` of fileStorage, using a combination of these two approaches:


### PR DESCRIPTION
This PR adds a document that shows the VNet diag report generated by tshd. What's not included is the implementation behind individual buttons in the top right as well as running diagnostics periodically.

<img width="944" alt="vnet-diag-report" src="https://github.com/user-attachments/assets/77943631-9da5-481a-8a77-3b78906e57f2" />

Info for Grzegorz: [I changed a lot of nomenclature](https://github.com/gravitational/teleport/pull/52066#discussion_r1959523721) in report protos since you've reviewed #52213. However, the new names should make the protos easier to understand. If you're not Grzegorz and you haven't seen them before, they're all in [`diag.proto`](https://github.com/gravitational/teleport/blob/r7s/diag-doc/proto/teleport/lib/vnet/diag/v1/diag.proto) and a quick glance over them and the screenshot should make it easier to understand what's going on.

The whole feature is still behind a feature flag, you have to set `"unstable.vnetDiag": true` in [the app config](https://goteleport.com/docs/connect-your-client/teleport-connect/#configuration) to see the button for running diagnostics in the top left panel. You should be able to see the report even if no issues are found. The easiest way to trigger any issues is probably to install Tailscale (which requires creating a free account). Now that I think about it, starting VNet from the official build of Connect and then starting VNet from a dev build should make diagnostics discover some issues too. 😅 But I haven't tried this before.