### PR TITLE
chore: Bump modules to Go 1.24.0

### DIFF
--- a/build.assets/tooling/go.mod
+++ b/build.assets/tooling/go.mod
@@ -1,8 +1,6 @@
 module github.com/gravitational/teleport/build.assets/tooling
 
-go 1.23.6
-
-toolchain go1.24.0
+go 1.24.0
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/gravitational/teleport
 
-go 1.23.6
-
-toolchain go1.24.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/cloudsqlconn v1.14.2

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -1,8 +1,6 @@
 module github.com/gravitational/teleport/integrations/event-handler
 
-go 1.23.6
-
-toolchain go1.24.0
+go 1.24.0
 
 require (
 	github.com/alecthomas/kong v1.7.0

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -1,8 +1,6 @@
 module github.com/gravitational/teleport/integrations/terraform
 
-go 1.23.6
-
-toolchain go1.24.0
+go 1.24.0
 
 // TF provider dependencies
 require (


### PR DESCRIPTION
Bump modules (and not only the toolchain) to Go 1.24.

It's been about a week since #52064 and it looks stable enough.