### PR TITLE
`tbot` env variable configurations

### DIFF
--- a/build.assets/charts/Dockerfile-tbot-distroless
+++ b/build.assets/charts/Dockerfile-tbot-distroless
@@ -19,3 +19,4 @@ RUN --mount=type=bind,target=/ctx dpkg-deb -R /ctx/$TELEPORT_DEB_FILE_NAME /opt/
 FROM $BASE_IMAGE
 COPY --from=teleport /opt/staging/opt/teleport/system/bin/tbot /usr/local/bin/tbot
 ENTRYPOINT ["/usr/local/bin/tbot"]
+CMD ["start"]

--- a/build.assets/charts/Dockerfile-tbot-distroless-fips
+++ b/build.assets/charts/Dockerfile-tbot-distroless-fips
@@ -19,3 +19,4 @@ RUN --mount=type=bind,target=/ctx dpkg-deb -R /ctx/$TELEPORT_DEB_FILE_NAME /opt/
 FROM $BASE_IMAGE
 COPY --from=teleport /opt/staging/opt/teleport/system/bin/tbot /usr/local/bin/tbot
 ENTRYPOINT ["/usr/local/bin/tbot", "--fips"]
+CMD ["start"]

--- a/docs/pages/reference/cli/tbot.mdx
+++ b/docs/pages/reference/cli/tbot.mdx
@@ -297,22 +297,23 @@ another dedicated mode instead.
 
 ### Flags
 
-| Flag                 | Description                                                                                    |
-|----------------------|------------------------------------------------------------------------------------------------|
-| `-d/--debug`         | Enable verbose logging to stderr.                                                              |
-| `-c/--config`        | Path to a Machine ID configuration file.                                                       |
-| `--[no-]fips`        | Whether to run tbot in FIPS compliance mode. This requires the FIPS `tbot` binary. |
-| `-a/--auth-server`   | Address of the Teleport Auth Service. Prefer using --proxy-server where possible                |
-| `--proxy-server`     | Address of the Teleport Proxy Server.                                                          |
-| `--token`            | A bot join token, if attempting to onboard a new bot; used on first connect. Can also be an absolute path to a file containing the token. |
-| `--ca-pin`           | CA pin to validate the Teleport Auth Service; used on first connect.                            |
+| Flag                 | Description                                                                                                                                                                     |
+|----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `-d/--debug`         | Enable verbose logging to stderr. Can also be configured using the `TBOT_DEBUG` environment variable.                                                                           |
+| `-c/--config`        | Path to a tbot configuration file. Mutually exclusive with `--config-string`. Can also be configured with the `TBOT_CONFIG_PATH` environment variable.                          |
+| `--config-string`    | Allows the tbot configuration to be provided as a base 64 string directly via this flag or the `TBOT_CONFIG` environment variable. Mutually exclusive with `--config`           |
+| `--[no-]fips`        | Whether to run tbot in FIPS compliance mode. This requires the FIPS `tbot` binary.                                                                                              |
+| `-a/--auth-server`   | Address of the Teleport Auth Service. Prefer using --proxy-server where possible                                                                                                |
+| `--proxy-server`     | Address of the Teleport Proxy Server.                                                                                                                                           |
+| `--token`            | A bot join token, if attempting to onboard a new bot; used on first connect. Can also be an absolute path to a file containing the token.                                       |
+| `--ca-pin`           | CA pin to validate the Teleport Auth Service; used on first connect.                                                                                                            |
 | `--data-dir`         | Directory to store internal bot data. In production environments access to this directory should be limited only to an isolated linux user as an owner with `0600` permissions. |
-| `--destination-dir`  | Directory to write short-lived machine certificates.                                           |
-| `--certificate-ttl`  | TTL of short-lived machine certificates.                                                       |
-| `--renewal-interval` | Interval at which short-lived certificates are renewed; must be less than the certificate TTL. |
-| `--join-method`      | Method to use to join the cluster. Can be `token`, `azure`, `circleci`, `gcp`, `github`, `gitlab` or `iam`. |
-| `--oneshot`          | If set, quit after the first renewal.                                                          |
-| `--log-format`       | Controls the format of output logs. Can be `json` or `text`. Defaults to `text`.               |
+| `--destination-dir`  | Directory to write short-lived machine certificates.                                                                                                                            |
+| `--certificate-ttl`  | TTL of short-lived machine certificates.                                                                                                                                        |
+| `--renewal-interval` | Interval at which short-lived certificates are renewed; must be less than the certificate TTL.                                                                                  |
+| `--join-method`      | Method to use to join the cluster. Can be `token`, `azure`, `circleci`, `gcp`, `github`, `gitlab` or `iam`.                                                                     |
+| `--oneshot`          | If set, quit after the first renewal.                                                                                                                                           |
+| `--log-format`       | Controls the format of output logs. Can be `json` or `text`. Defaults to `text`.                                                                                                |
 
 ### Examples
 <Tabs>

--- a/lib/tbot/cli/globals.go
+++ b/lib/tbot/cli/globals.go
@@ -42,6 +42,9 @@ type GlobalArgs struct {
 	// ConfigPath is a path to a YAML configuration file to load, if any.
 	ConfigPath string
 
+	// ConfigString is a base64 encoded string of a YAML configuration file to load, if any.
+	ConfigString string
+
 	// Debug enables debug-level logging, when set
 	Debug bool
 
@@ -67,8 +70,9 @@ type GlobalArgs struct {
 func NewGlobalArgs(app *kingpin.Application) *GlobalArgs {
 	g := &GlobalArgs{}
 
-	app.Flag("debug", "Verbose logging to stdout.").Short('d').BoolVar(&g.Debug)
-	app.Flag("config", "Path to a configuration file.").Short('c').StringVar(&g.ConfigPath)
+	app.Flag("debug", "Verbose logging to stdout.").Short('d').Envar(TBotDebugEnvVar).BoolVar(&g.Debug)
+	app.Flag("config", "Path to a configuration file.").Short('c').Envar(TBotConfigPathEnvVar).StringVar(&g.ConfigPath)
+	app.Flag("config-string", "Base64 encoded configuration string.").Hidden().Envar(TBotConfigEnvVar).StringVar(&g.ConfigString)
 	app.Flag("fips", "Runs tbot in FIPS compliance mode. This requires the FIPS binary is in use.").BoolVar(&g.FIPS)
 	app.Flag("trace", "Capture and export distributed traces.").Hidden().BoolVar(&g.Trace)
 	app.Flag("trace-exporter", "An OTLP exporter URL to send spans to.").Hidden().StringVar(&g.TraceExporter)

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -19,7 +19,9 @@
 package config
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -590,6 +592,16 @@ func ReadConfigFromFile(filePath string, manualMigration bool) (*BotConfig, erro
 
 	defer f.Close()
 	return ReadConfig(f, manualMigration)
+}
+
+// ReadConfigFromBase64String reads and parses a YAML config from a base64 encoded string.
+func ReadConfigFromBase64String(b64Str string, manualMigration bool) (*BotConfig, error) {
+	data, err := base64.StdEncoding.DecodeString(b64Str)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to decode base64 encoded config")
+	}
+	r := bytes.NewReader(data)
+	return ReadConfig(r, manualMigration)
 }
 
 type Version string

--- a/lib/tbot/config/config_test.go
+++ b/lib/tbot/config/config_test.go
@@ -517,3 +517,57 @@ func TestCredentialLifetimeValidate(t *testing.T) {
 		})
 	}
 }
+
+// TestBotConfig_Base64 ensures that config can be read from bas64 encoded YAML
+func TestBotConfig_Base64(t *testing.T) {
+	tests := []struct {
+		name         string
+		configBase64 string
+		expected     BotConfig
+	}{
+		{
+			name:         "minimal config, proxy server",
+			configBase64: "dmVyc2lvbjogdjIKcHJveHlfc2VydmVyOiAiZXhhbXBsZS50ZWxlcG9ydC5zaDo0NDMiCm9uYm9hcmRpbmc6CiAgdG9rZW46ICJteS10b2tlbiIKICBqb2luX21ldGhvZDogInRva2VuIgpzZXJ2aWNlczoKLSB0eXBlOiBhcHBsaWNhdGlvbi10dW5uZWwKICBhcHBfbmFtZTogdGVzdGFwcAogIGxpc3RlbjogdGNwOi8vMTI3LjAuMC4xOjgwODA=",
+			expected: BotConfig{
+				Version:     V2,
+				ProxyServer: "example.teleport.sh:443",
+				Onboarding: OnboardingConfig{
+					JoinMethod: "token",
+					TokenValue: "my-token",
+				},
+				Services: []ServiceConfig{
+					&ApplicationTunnelService{
+						Listen:  "tcp://127.0.0.1:8080",
+						AppName: "testapp",
+					},
+				},
+			},
+		},
+		{
+			name:         "minimal config, auth server",
+			configBase64: "dmVyc2lvbjogdjIKYXV0aF9zZXJ2ZXI6ICJleGFtcGxlLnRlbGVwb3J0LnNoOjQ0MyIKb25ib2FyZGluZzoKICB0b2tlbjogIm15LXRva2VuIgogIGpvaW5fbWV0aG9kOiAidG9rZW4iCnNlcnZpY2VzOgotIHR5cGU6IGFwcGxpY2F0aW9uLXR1bm5lbAogIGFwcF9uYW1lOiB0ZXN0YXBwCiAgbGlzdGVuOiB0Y3A6Ly8xMjcuMC4wLjE6ODA4MA==",
+			expected: BotConfig{
+				Version:    V2,
+				AuthServer: "example.teleport.sh:443",
+				Onboarding: OnboardingConfig{
+					JoinMethod: "token",
+					TokenValue: "my-token",
+				},
+				Services: []ServiceConfig{
+					&ApplicationTunnelService{
+						Listen:  "tcp://127.0.0.1:8080",
+						AppName: "testapp",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := ReadConfigFromBase64String(tt.configBase64, false)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, *cfg)
+		})
+	}
+}


### PR DESCRIPTION
### Summary

Add following env variable configurations for the `tbot` cli:
- `TBOT_DEBUG` - enable debug mode
- `TBOT_CONFIG_PATH` - provide location to the tbot config via env variable
- `TBOT_CONFIG` - (hidden) provide base64 encoded tbot config, similarly like teleport does
    - https://github.com/gravitational/teleport/blob/39a5fa300acab58ca019cbe147a770e1b437740f/tool/teleport/common/teleport.go#L153-L155
- Add `start` as default `CMD` in `tbot-distroless` image

As result tbot tunnels can be created by running like:
```sh
docker run -it --rm -e TBOT_CONFIG=<base64 encoded> public.ecr.aws/gravitational/teleport-distroless:17
```

### Context

This will allow us to use `tbot-distroless` docker image as  [Bitbucket Pipeline Service Container](https://support.atlassian.com/bitbucket-cloud/docs/databases-and-service-containers/)/[Gitlab Services](https://docs.gitlab.com/ci/services/) to start local tunnels as background process and use it in CI/CD steps.

- https://github.com/gravitational/teleport/issues/52231

---

changelog: Allow to provide `tbot` configurations via environment variables. Update `tbot-distroless` image to run `start` command by default.

