### PR TITLE
GCP LB timeout recommendation

### DIFF
--- a/docs/pages/admin-guides/deploy-a-cluster/deployments/gcp.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/deployments/gcp.mdx
@@ -117,7 +117,7 @@ storage:
 Load Balancing is required for Proxy and SSH traffic. Use `TCP Load Balancing` as
 Teleport requires custom ports for SSH and Web Traffic.
 
-GCP sets a default Load Balancer timeout of 30 seconds. You should either increase this to be longer than the Teleport Auth service default keepalive interval of 300 seconds or decrease the Teleport ```keep_alive_interval``` to be lower than the GCP timeout value.
+GCP sets a default Load Balancer timeout of 30 seconds. You should either increase this to be longer than the Teleport Auth Service default keepalive interval of 300 seconds or decrease the Teleport `keep_alive_interval` to be lower than the GCP timeout value.
 
 Please reference the [Teleport Auth Service Configuration](https://goteleport.com/docs/reference/config/#auth-service) documentation for additional details.
 

--- a/docs/pages/admin-guides/deploy-a-cluster/deployments/gcp.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/deployments/gcp.mdx
@@ -114,10 +114,10 @@ storage:
 
 ### Network Services: Load Balancing
 
-Load Balancing is required for Proxy and SSH traffic. Use `TCP Load Balancing` as
-Teleport requires custom ports for SSH and Web Traffic.
 
-GCP sets a default Load Balancer timeout of 30 seconds. You should either increase this to be longer than the Teleport Auth Service default keepalive interval of 300 seconds or decrease the Teleport `keep_alive_interval` to be lower than the GCP timeout value.
+Load Balancing is required for Proxy and SSH traffic. It is recommended to use `TCP Load Balancing` to support custom ports for SSH and Web Traffic.
+
+If you must use an L7 Load Balancer solution, please reference the [TLS Routing for Layer 7 Load Balancers](https://goteleport.com/docs/reference/architecture/tls-routing/#working-with-layer-7-load-balancers-or-reverse-proxies) documentation.
 
 Please reference the [Teleport Auth Service Configuration](https://goteleport.com/docs/reference/config/#auth-service) documentation for additional details.
 

--- a/docs/pages/admin-guides/deploy-a-cluster/deployments/gcp.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/deployments/gcp.mdx
@@ -117,6 +117,10 @@ storage:
 Load Balancing is required for Proxy and SSH traffic. Use `TCP Load Balancing` as
 Teleport requires custom ports for SSH and Web Traffic.
 
+GCP sets a default Load Balancer timeout of 30 seconds. You should either increase this to be longer than the Teleport Auth service default keepalive interval of 300 seconds or decrease the Teleport ```keep_alive_interval``` to be lower than the GCP timeout value.
+
+Please reference the [Teleport Auth Configuration](https://goteleport.com/docs/reference/config/#auth-service) documentation for additional details.
+
 ### Network Services: Cloud DNS
 
 Cloud DNS is used to set up the public URL of the Teleport Proxy.

--- a/docs/pages/admin-guides/deploy-a-cluster/deployments/gcp.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/deployments/gcp.mdx
@@ -119,7 +119,7 @@ Teleport requires custom ports for SSH and Web Traffic.
 
 GCP sets a default Load Balancer timeout of 30 seconds. You should either increase this to be longer than the Teleport Auth service default keepalive interval of 300 seconds or decrease the Teleport ```keep_alive_interval``` to be lower than the GCP timeout value.
 
-Please reference the [Teleport Auth Configuration](https://goteleport.com/docs/reference/config/#auth-service) documentation for additional details.
+Please reference the [Teleport Auth Service Configuration](https://goteleport.com/docs/reference/config/#auth-service) documentation for additional details.
 
 ### Network Services: Cloud DNS
 


### PR DESCRIPTION
When customers use the default GCP LB timeout value of 30 seconds, agents disconnect due to the Teleport keepalive_interval being higher by default.