### PR TITLE
Fix Windows permission error with self remove

### DIFF
--- a/integration/autoupdate/tools/main_test.go
+++ b/integration/autoupdate/tools/main_test.go
@@ -61,6 +61,7 @@ var (
 
 func TestMain(m *testing.M) {
 	modules.SetInsecureTestMode(true)
+	modules.SetModules(&modules.TestModules{TestBuildType: modules.BuildCommunity})
 	ctx := context.Background()
 	tmp, err := os.MkdirTemp(os.TempDir(), testBinaryName)
 	if err != nil {

--- a/integration/autoupdate/tools/updater/modules.go
+++ b/integration/autoupdate/tools/updater/modules.go
@@ -65,14 +65,14 @@ func (p *TestModules) BuildType() string {
 	return "CLI"
 }
 
-// IsEnterpriseBuild returns false for [TestModules].
+// IsEnterpriseBuild returns true if `UPDATER_TEST_BUILD` env is set `ent` for [TestModules].
 func (p *TestModules) IsEnterpriseBuild() bool {
 	return os.Getenv(TestBuild) == modules.BuildEnterprise
 }
 
-// IsOSSBuild returns false for [TestModules].
+// IsOSSBuild returns true if `UPDATER_TEST_BUILD` env is set `oss` for [TestModules].
 func (p *TestModules) IsOSSBuild() bool {
-	return true
+	return os.Getenv(TestBuild) == modules.BuildOSS
 }
 
 // LicenseExpiry returns the expiry date of the enterprise license, if applicable.

--- a/integration/autoupdate/tools/updater/modules.go
+++ b/integration/autoupdate/tools/updater/modules.go
@@ -72,7 +72,7 @@ func (p *TestModules) IsEnterpriseBuild() bool {
 
 // IsOSSBuild returns false for [TestModules].
 func (p *TestModules) IsOSSBuild() bool {
-	return os.Getenv(TestBuild) == modules.BuildOSS
+	return true
 }
 
 // LicenseExpiry returns the expiry date of the enterprise license, if applicable.

--- a/integration/autoupdate/tools/updater_tsh_test.go
+++ b/integration/autoupdate/tools/updater_tsh_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 /*
  * Teleport
  * Copyright (C) 2024  Gravitational, Inc.

--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -433,7 +433,7 @@ func CopyFile(src, dest string, perm os.FileMode) (err error) {
 		return trace.ConvertSystemError(err)
 	}
 	defer func() {
-		err = trace.Wrap(destFile.Close())
+		err = trace.NewAggregate(err, trace.Wrap(destFile.Close()))
 	}()
 	_, err = destFile.ReadFrom(srcFile)
 	if err != nil {

--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -422,15 +422,19 @@ func RecursiveChown(dir string, uid, gid int) error {
 	return nil
 }
 
-func CopyFile(src, dest string, perm os.FileMode) error {
+func CopyFile(src, dest string, perm os.FileMode) (err error) {
 	srcFile, err := os.Open(src)
 	if err != nil {
 		return trace.ConvertSystemError(err)
 	}
+	defer srcFile.Close()
 	destFile, err := os.OpenFile(dest, os.O_RDWR|os.O_CREATE|os.O_TRUNC, perm)
 	if err != nil {
 		return trace.ConvertSystemError(err)
 	}
+	defer func() {
+		err = trace.Wrap(destFile.Close())
+	}()
 	_, err = destFile.ReadFrom(srcFile)
 	if err != nil {
 		return trace.ConvertSystemError(err)

--- a/lib/utils/packaging/unarchive.go
+++ b/lib/utils/packaging/unarchive.go
@@ -129,9 +129,10 @@ func replaceZip(toolsDir string, archivePath string, extractDir string, execName
 				return trace.Wrap(err)
 			}
 			appPath := filepath.Join(toolsDir, baseName)
-			// For the Windows build we have to copy binary to be able
-			// to do this without administrative access as it required
-			// for symlinks.
+			// For the Windows build, we need to copy the binary to perform updates without requiring
+			// administrative access, which would otherwise be needed for creating symlinks.
+			// Since symlinks are not used on the Windows platform, there's no need to remove appPath
+			// before copying the new binary — it will simply be replaced.
 			if err := utils.CopyFile(dest, appPath, 0o755); err != nil {
 				return trace.Wrap(err)
 			}

--- a/lib/utils/packaging/unarchive.go
+++ b/lib/utils/packaging/unarchive.go
@@ -129,9 +129,6 @@ func replaceZip(toolsDir string, archivePath string, extractDir string, execName
 				return trace.Wrap(err)
 			}
 			appPath := filepath.Join(toolsDir, baseName)
-			if err := os.Remove(appPath); err != nil && !os.IsNotExist(err) {
-				return trace.Wrap(err)
-			}
 			// For the Windows build we have to copy binary to be able
 			// to do this without administrative access as it required
 			// for symlinks.


### PR DESCRIPTION
After regression testing for v14 and additional cases recognized in issue with `aliases`, identified another issue related specifically for windows platform and double re-execution after update.

https://github.com/gravitational/teleport/blob/e3ff2c04be205f0749707fe8059c181df9c4a80c/lib/utils/packaging/unarchive.go#L132-L134

Windows prevents the self-removal of an executed binary but allows it to be replaced, making this additional removal unnecessary, otherwise we get the access denied error.

https://github.com/gravitational/teleport/blob/e3ff2c04be205f0749707fe8059c181df9c4a80c/lib/utils/fs.go#L425-L439

The helper function does not close file descriptors, which blocks execution on Windows. In integration tests, we launch the update from the test function body and then attempt to execute it by `exec.CommandContext` which leads to the error with execution.

```
The process cannot access the file because it is being used by another process.
```

Related: https://github.com/gravitational/cloud/issues/11856