### PR TITLE
User task design updates

### DIFF
--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcTitle.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcTitle.tsx
@@ -48,7 +48,7 @@ export function AwsOidcTitle({
       <Text bold fontSize={6} mx={2}>
         {content.content}
       </Text>
-      <Label kind={labelKind} aria-label="status" px={3} ml={3}>
+      <Label kind={labelKind} aria-label="status" px={3}>
         {status}
       </Label>
     </Flex>

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/EnrollCard.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/EnrollCard.tsx
@@ -19,22 +19,21 @@
 import { Link as InternalLink } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { ButtonBorder, Card, Flex, H2, ResourceIcon } from 'design';
+import { ButtonSecondary, Card, Flex, H2, ResourceIcon } from 'design';
 
 import cfg from 'teleport/config';
 import { AwsResource } from 'teleport/Integrations/status/AwsOidc/StatCard';
 
 export function EnrollCard({ resource }: { resource: AwsResource }) {
-  // todo (michellescripts) update enroll design once ready
   return (
     <Enroll data-testid={`${resource}-enroll`}>
       <Flex flexDirection="column" gap={4}>
-        <Flex alignItems="center" mb={2}>
+        <Flex alignItems="center">
           <ResourceIcon name={resource} mr={2} width="32px" height="32px" />
           <H2>{resource.toUpperCase()}</H2>
         </Flex>
-        <ButtonBorder
-          size="large"
+        <ButtonSecondary
+          width="136px"
           as={InternalLink}
           to={{
             pathname: cfg.routes.discover,
@@ -42,7 +41,7 @@ export function EnrollCard({ resource }: { resource: AwsResource }) {
           }}
         >
           Enroll {resource.toUpperCase()}
-        </ButtonBorder>
+        </ButtonSecondary>
       </Flex>
     </Enroll>
   );
@@ -51,7 +50,7 @@ export function EnrollCard({ resource }: { resource: AwsResource }) {
 const Enroll = styled(Card)`
   width: 33%;
   background-color: ${props => props.theme.colors.levels.surface};
-  padding: 12px;
+  padding: ${props => props.theme.space[3]}px;
   border-radius: ${props => props.theme.radii[2]}px;
   border: ${props => `1px solid ${props.theme.colors.levels.surface}`};
 

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/StatCard.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/StatCard.tsx
@@ -141,7 +141,7 @@ function foundResource(resource: ResourceTypeSummary): boolean {
 export const SelectCard = styled(Card)`
   width: 33%;
   background-color: ${props => props.theme.colors.levels.surface};
-  padding: 12px;
+  padding: ${props => props.theme.space[3]}px;
   border-radius: ${props => props.theme.radii[2]}px;
   border: ${props => `1px solid ${props.theme.colors.levels.surface}`};
   cursor: pointer;

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/SidePanel.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/SidePanel.tsx
@@ -40,13 +40,7 @@ export const SidePanel = ({
       borderLeft={1}
       borderColor="levels.surface"
     >
-      <Flex
-        alignItems="center"
-        justifyContent="space-between"
-        mt={3}
-        mb={3}
-        px={4}
-      >
+      <Flex alignItems="center" justifyContent="space-between" my={3} px={4}>
         {header}
         <ButtonIcon onClick={onClose} disabled={disabled}>
           <Cross size="medium" />

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/SidePanel.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/SidePanel.tsx
@@ -65,7 +65,6 @@ export const SidePanel = ({
 };
 
 const Container = styled(Flex)`
-  display: flex;
   flex-direction: column;
 
   height: calc(100vh - ${props => props.theme.topBarHeight[1]}px);

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/SidePanel.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/SidePanel.tsx
@@ -15,33 +15,36 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-import React, { PropsWithChildren } from 'react';
+import { PropsWithChildren, ReactNode } from 'react';
 import styled from 'styled-components';
 
-import { Box, ButtonIcon, Flex } from 'design';
+import { ButtonIcon, Flex } from 'design';
 import { Cross } from 'design/Icon';
 
 export const SidePanel = ({
   onClose,
   header,
+  footer,
   disabled = false,
   children,
 }: PropsWithChildren & {
   onClose: () => void;
-  header?: React.ReactNode;
+  header?: ReactNode;
+  footer?: ReactNode;
   disabled?: boolean;
 }) => {
   return (
-    <Flex width="500px" flexDirection="column">
+    <Container
+      width="500px"
+      flexDirection="column"
+      borderLeft={1}
+      borderColor="levels.surface"
+    >
       <Flex
         alignItems="center"
-        mb={3}
         justifyContent="space-between"
-        maxWidth="500px"
-        borderBottom={1}
-        borderColor="levels.surface"
-        py={1}
+        mt={3}
+        mb={3}
         px={4}
       >
         {header}
@@ -49,15 +52,27 @@ export const SidePanel = ({
           <Cross size="medium" />
         </ButtonIcon>
       </Flex>
-      <ScrollContent px={4}>{children}</ScrollContent>
-    </Flex>
+      <Flex
+        flexDirection="column"
+        px={4}
+        style={{
+          flex: 1,
+          overflow: 'auto',
+          height: '100%',
+        }}
+      >
+        {children}
+      </Flex>
+      <Flex borderTop={1} borderColor="levels.surface" py={3} px={4}>
+        {footer}
+      </Flex>
+    </Container>
   );
 };
 
-const ScrollContent = styled(Box)`
-  max-height: calc(
-    100vh - ${props => props.theme.space[9]}px -
-      ${props => props.theme.topBarHeight[1]}px
-  );
-  overflow: auto;
+const Container = styled(Flex)`
+  display: flex;
+  flex-direction: column;
+
+  height: calc(100vh - ${props => props.theme.topBarHeight[1]}px);
 `;

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Task.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Task.tsx
@@ -71,7 +71,6 @@ export function Task({
     return null;
   }
 
-  // todo (michellescripts) implement either success view or confirmation based on design sync
   function resolve() {
     setAttempt({ status: 'processing' });
     integrationService
@@ -92,7 +91,8 @@ export function Task({
   return (
     <SidePanel
       onClose={() => close(false)}
-      header={
+      header={<H2>{taskAttempt.data.issueType}</H2>}
+      footer={
         <ButtonBorder
           intent="success"
           onClick={resolve}
@@ -103,7 +103,6 @@ export function Task({
       }
       disabled={attempt.status === 'processing'}
     >
-      <H2 mb={2}>{taskAttempt.data.issueType}</H2>
       {attempt.status === 'failed' && (
         <Alert kind="danger" details={attempt.statusText}>
           Unable to resolve task

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/TaskAlert.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/TaskAlert.tsx
@@ -60,6 +60,7 @@ export function TaskAlert({
     <Alert
       kind="warning"
       icon={BellRinging}
+      mb={0}
       primaryAction={{
         content: (
           <>

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.tsx
@@ -18,7 +18,7 @@
 
 import { useEffect, useState } from 'react';
 import { useHistory } from 'react-router';
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 
 import { ButtonBorder, Flex, Indicator } from 'design';
 import { Danger } from 'design/Alert';
@@ -36,6 +36,7 @@ import { useAwsOidcStatus } from 'teleport/Integrations/status/AwsOidc/useAwsOid
 import { integrationService, UserTask } from 'teleport/services/integrations';
 
 export function Tasks() {
+  const theme = useTheme();
   const history = useHistory();
   const searchParams = new URLSearchParams(history.location.search);
   const taskName = searchParams.get('task');
@@ -143,9 +144,14 @@ export function Tasks() {
                   openTask(row);
                 }
               },
-              getStyle: () => {
+              getStyle: (row: UserTask) => {
                 if (selectedTask === '') {
                   return { cursor: 'pointer' };
+                }
+                if (row.name === selectedTask) {
+                  return {
+                    backgroundColor: theme.colors.interactive.tonal.primary[0],
+                  };
                 }
               },
             }}

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.tsx
@@ -185,7 +185,10 @@ export function Tasks() {
               },
             ]}
             emptyText={`No pending tasks`}
-            pagination={{ pageSize: serverSidePagination.pageSize }}
+            pagination={{
+              pageSize: serverSidePagination.pageSize,
+              pagerPosition: 'both',
+            }}
             fetching={{
               fetchStatus: serverSidePagination.fetchStatus,
               onFetchNext: serverSidePagination.fetchNext,

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.tsx
@@ -18,10 +18,12 @@
 
 import { useEffect, useState } from 'react';
 import { useHistory } from 'react-router';
+import styled from 'styled-components';
 
 import { ButtonBorder, Flex, Indicator } from 'design';
 import { Danger } from 'design/Alert';
 import Table, { Cell } from 'design/DataTable';
+import { Notification, NotificationItem } from 'shared/components/Notification';
 
 import { useServerSidePagination } from 'teleport/components/hooks';
 import { FeatureBox } from 'teleport/components/Layout';
@@ -37,6 +39,7 @@ export function Tasks() {
   const history = useHistory();
   const searchParams = new URLSearchParams(history.location.search);
   const taskName = searchParams.get('task');
+  const [notification, setNotification] = useState<NotificationItem>();
 
   const { integrationAttempt } = useAwsOidcStatus();
   const { data: integration } = integrationAttempt;
@@ -95,6 +98,15 @@ export function Tasks() {
       // If there are multiple pages, we would rather refresh the table with X results rather than
       // use modifyFetchedData to remove the item.
       serverSidePagination.fetch();
+
+      setNotification({
+        content: {
+          description:
+            'The task has been marked as resolved; it will reappear in the table if the issue persists in the next sync.',
+        },
+        severity: 'success',
+        id: taskName,
+      });
     }
     history.replace(history.location.pathname);
   }
@@ -180,9 +192,25 @@ export function Tasks() {
               onFetchPrev: serverSidePagination.fetchPrev,
             }}
           />
+          {notification && (
+            <NotificationContainer>
+              <Notification
+                key={notification.id}
+                item={notification}
+                onRemove={() => setNotification(undefined)}
+                minWidth="432px"
+              />
+            </NotificationContainer>
+          )}
         </FeatureBox>
       </Flex>
       {selectedTask && <Task name={selectedTask} close={closeTask} />}
     </Flex>
   );
 }
+
+const NotificationContainer = styled.div`
+  position: absolute;
+  top: ${props => props.theme.space[10]}px;
+  right: ${props => props.theme.space[5]}px;
+`;

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.tsx
@@ -103,7 +103,7 @@ export function Tasks() {
       setNotification({
         content: {
           description:
-            'The task has been marked as resolved; it will reappear in the table if the issue persists in the next sync.',
+            'The task has been marked as resolved; it will reappear in the table if the issue persists after the next sync.',
         },
         severity: 'success',
         id: taskName,


### PR DESCRIPTION
Updated based on design requests:

- Side Panel: button moves to sticky footer, title goes to header, center content scrolls
- Success notification: Auto dismiss notification displays in top right on resolve
- Add pager to top & bottom of tasks table
- Open task is highlighted in table
- Bottom margin removed from alert banner
- Enroll card: Secondary button instead of boarder, set width

https://www.figma.com/design/v6GunK50D2VC7w7I2FBDNf/Access-(Management)?node-id=4143-2783&m=dev&focus-id=8345-25666

<details>
  <summary>after screen shots</summary>
<img width="1723" alt="Screenshot 2025-02-19 at 2 06 41 PM" src="https://github.com/user-attachments/assets/5b3db824-cda7-40c1-8655-54d329cb4a90" />
<img width="1717" alt="Screenshot 2025-02-19 at 2 07 34 PM" src="https://github.com/user-attachments/assets/59f73b43-3c2a-4b67-88d2-f6752bab58cb" />


<img width="409" alt="Screenshot 2025-02-19 at 2 00 51 PM" src="https://github.com/user-attachments/assets/00a58c02-fc45-4844-a701-a0550deacfa1" />
</details>
