### PR TITLE
[v16] Machine ID: fix example GHA workflow in web UI flow

### DIFF
--- a/web/packages/teleport/src/Bots/Add/GitHubActions/AddBotToWorkflow.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActions/AddBotToWorkflow.tsx
@@ -100,7 +100,7 @@ jobs:
       # able to authenticate with the cluster.
       id-token: write
       contents: read
-    ${includeNameComment && '# if you added a workflow name in the previous step, make sure you use the same value here'}
+    ${includeNameComment ? '# if you added a workflow name in the previous step, make sure you use the same value here' : ''}
     name: ${botName}-example
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
We need to emit an empty string when the expression evaluates to false, otherwise we end up with invalid YAML.

Backports #52240