### PR TITLE
fix: tsh await request resolution expired

### DIFF
--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -5281,7 +5281,9 @@ func awaitRequestResolution(ctx context.Context, clt authclient.ClientI, req typ
 					return nil, trace.BadParameter("unexpected resource type %T", event.Resource)
 				}
 			case types.OpDelete:
-				return nil, trace.Errorf("request %s has expired or been deleted...", event.Resource.GetName())
+				if reqState.GetName() == event.Resource.GetName() {
+					return nil, trace.Errorf("request %s has expired or been deleted...", event.Resource.GetName())
+				}
 			default:
 				logger.WarnContext(ctx, "Skipping unknown event type", "event_type", event.Type)
 			}


### PR DESCRIPTION
When creating and waiting for an access to be approved, if another access request is expired, it should not fail my await. 

Example:

![Screenshot 2025-02-17 at 18 00 44](https://github.com/user-attachments/assets/d041cd27-0ce3-4936-905e-61cbe621ad65)

You can see the access request ID that expired is not the ID of the access request Im waiting for approval. 