### PR TITLE
[v15] Add support for JSON format to '/webapi/auth/export' endpoint

### DIFF
--- a/lib/client/ca_export.go
+++ b/lib/client/ca_export.go
@@ -57,7 +57,7 @@ type ExportedAuthority struct {
 	// Data is the output of the exported authority.
 	// May be an SSH authorized key, an SSH known hosts entry, a DER or a PEM,
 	// depending on the type of the exported authority.
-	Data []byte
+	Data []byte `json:"data"`
 }
 
 // ExportAllAuthorities exports public keys of all authorities of a particular


### PR DESCRIPTION
Backport #50193 to branch/v15

changelog: Added JSON response support to the `/webapi/auth/export` public certificate API endpoint.
