### PR TITLE
Web: Create a info guide right side panel component

### DIFF
--- a/web/packages/teleport/src/Clusters/ManageCluster/ManageCluster.story.tsx
+++ b/web/packages/teleport/src/Clusters/ManageCluster/ManageCluster.story.tsx
@@ -20,6 +20,7 @@ import { MemoryRouter } from 'react-router';
 
 import { Route } from 'teleport/components/Router';
 import { ContextProvider } from 'teleport/index';
+import { InfoGuidePanelProvider } from 'teleport/Main/InfoGuideContext';
 import { ContentMinWidth } from 'teleport/Main/Main';
 import { createTeleportContext } from 'teleport/mocks/contexts';
 
@@ -37,11 +38,13 @@ function render(fetchClusterDetails: (clusterId: string) => Promise<any>) {
   return (
     <MemoryRouter initialEntries={['/clusters/test-cluster']}>
       <Route path="/clusters/:clusterId">
-        <ContentMinWidth>
-          <ContextProvider ctx={ctx}>
-            <ManageCluster />
-          </ContextProvider>
-        </ContentMinWidth>
+        <InfoGuidePanelProvider>
+          <ContentMinWidth>
+            <ContextProvider ctx={ctx}>
+              <ManageCluster />
+            </ContextProvider>
+          </ContentMinWidth>
+        </InfoGuidePanelProvider>
       </Route>
     </MemoryRouter>
   );

--- a/web/packages/teleport/src/Clusters/ManageCluster/ManageCluster.test.tsx
+++ b/web/packages/teleport/src/Clusters/ManageCluster/ManageCluster.test.tsx
@@ -24,6 +24,7 @@ import { render, screen, waitFor } from 'design/utils/testing';
 
 import cfg from 'teleport/config';
 import { ContextProvider } from 'teleport/index';
+import { InfoGuidePanelProvider } from 'teleport/Main/InfoGuideContext';
 import { ContentMinWidth } from 'teleport/Main/Main';
 import { createTeleportContext } from 'teleport/mocks/contexts';
 
@@ -34,9 +35,11 @@ function renderElement(element, ctx) {
   return render(
     <MemoryRouter initialEntries={[`/clusters/cluster-id`]}>
       <Route path="/clusters/:clusterId">
-        <ContentMinWidth>
-          <ContextProvider ctx={ctx}>{element}</ContextProvider>
-        </ContentMinWidth>
+        <InfoGuidePanelProvider>
+          <ContentMinWidth>
+            <ContextProvider ctx={ctx}>{element}</ContextProvider>
+          </ContentMinWidth>
+        </InfoGuidePanelProvider>
       </Route>
     </MemoryRouter>
   );

--- a/web/packages/teleport/src/Main/InfoGuideContext.tsx
+++ b/web/packages/teleport/src/Main/InfoGuideContext.tsx
@@ -1,0 +1,76 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  createContext,
+  PropsWithChildren,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+
+type InfoGuidePanelContextState = {
+  setInfoGuideElement: (element: JSX.Element | null) => void;
+  infoGuideElement: JSX.Element | null;
+};
+
+const InfoGuidePanelContext = createContext<InfoGuidePanelContextState>(null);
+
+export const InfoGuidePanelProvider: React.FC<PropsWithChildren> = ({
+  children,
+}) => {
+  const [infoGuideElement, setInfoGuideElement] = useState<JSX.Element | null>(
+    null
+  );
+
+  return (
+    <InfoGuidePanelContext.Provider
+      value={{ infoGuideElement, setInfoGuideElement }}
+    >
+      {children}
+    </InfoGuidePanelContext.Provider>
+  );
+};
+
+/**
+ * hook that allows you to set the info guide element that
+ * will render in the InfoGuideSidePanel component.
+ *
+ * To close the InfoGuideSidePanel component, set infoGuideElement
+ * state back to null.
+ */
+export const useInfoGuide = () => {
+  const context = useContext(InfoGuidePanelContext);
+
+  if (!context) {
+    throw new Error('useInfoGuide must be used within a InfoGuidePanelContext');
+  }
+
+  const { infoGuideElement, setInfoGuideElement } = context;
+
+  useEffect(() => {
+    return () => {
+      setInfoGuideElement(null);
+    };
+  }, []);
+
+  return {
+    setInfoGuideElement,
+    infoGuideElement,
+  };
+};

--- a/web/packages/teleport/src/Main/Main.test.tsx
+++ b/web/packages/teleport/src/Main/Main.test.tsx
@@ -18,21 +18,26 @@
 
 import { MemoryRouter } from 'react-router';
 
-import { render, screen } from 'design/utils/testing';
+import { ListThin } from 'design/Icon';
+import { fireEvent, render, screen } from 'design/utils/testing';
 
 import { Context, ContextProvider } from 'teleport';
 import { apps } from 'teleport/Apps/fixtures';
 import { events } from 'teleport/Audit/fixtures';
 import { clusters } from 'teleport/Clusters/fixtures';
+import { InfoGuideWrapper } from 'teleport/components/SlidingSidePanel/InfoGuideSidePanel/InfoGuideSidePanel';
 import { databases } from 'teleport/Databases/fixtures';
 import { desktops } from 'teleport/Desktops/fixtures';
 import { getOSSFeatures } from 'teleport/features';
 import { kubes } from 'teleport/Kubes/fixtures';
 import { userContext } from 'teleport/Main/fixtures';
 import { LayoutContextProvider } from 'teleport/Main/LayoutContext';
+import { createTeleportContext } from 'teleport/mocks/contexts';
+import { NavigationCategory } from 'teleport/Navigation';
 import { nodes } from 'teleport/Nodes/fixtures';
 import { sessions } from 'teleport/Sessions/fixtures';
 import TeleportContext from 'teleport/teleportContext';
+import { TeleportFeature } from 'teleport/types';
 import { makeTestUserContext } from 'teleport/User/testHelpers/makeTestUserContext';
 import { mockUserContextProviderWith } from 'teleport/User/testHelpers/mockUserContextWith';
 
@@ -78,6 +83,43 @@ test('renders', () => {
   expect(screen.getByTestId('teleport-logo')).toBeInTheDocument();
 });
 
+test('toggle rendering of info guide panel', async () => {
+  mockUserContextProviderWith(makeTestUserContext());
+  const ctx = createTeleportContext();
+
+  const props: MainProps = {
+    features: [...getOSSFeatures(), new FeatureTestInfoGuide()],
+  };
+
+  render(
+    <MemoryRouter>
+      <ContextProvider ctx={ctx}>
+        <LayoutContextProvider>
+          <Main {...props} />
+        </LayoutContextProvider>
+      </ContextProvider>
+    </MemoryRouter>
+  );
+
+  expect(screen.getByTestId('teleport-logo')).toBeInTheDocument();
+
+  expect(screen.queryByText(/i am the guide/i)).not.toBeInTheDocument();
+  expect(screen.queryByText(/info guide title/i)).not.toBeInTheDocument();
+
+  // render the component that has the guide info button
+  fireEvent.click(screen.queryAllByText('Zero Trust Access')[0]);
+  fireEvent.click(screen.getByText(/test info guide/i));
+  expect(screen.getByText(/info guide title/i)).toBeInTheDocument();
+
+  // test opening of panel
+  fireEvent.click(screen.getByTestId('info-guide-btn-open'));
+  expect(screen.getByText(/i am the guide/i)).toBeInTheDocument();
+
+  // test closing of panel
+  fireEvent.click(screen.getByTestId('info-guide-btn-close'));
+  expect(screen.queryByText(/i am the guide/i)).not.toBeInTheDocument();
+});
+
 test('displays invite collaborators feedback if present', () => {
   mockUserContextProviderWith(makeTestUserContext());
   const ctx = setupContext();
@@ -121,3 +163,36 @@ test('renders without invite collaborators feedback enabled', () => {
 
   expect(screen.getByTestId('teleport-logo')).toBeInTheDocument();
 });
+
+const TestInfoGuide = () => {
+  return (
+    <div>
+      <InfoGuideWrapper guide={<div>I am the guide</div>}>
+        Info Guide Title
+      </InfoGuideWrapper>
+    </div>
+  );
+};
+
+class FeatureTestInfoGuide implements TeleportFeature {
+  category = NavigationCategory.Audit;
+
+  route = {
+    title: 'Test Info Guide',
+    path: '/web/testinfoguide',
+    component: TestInfoGuide,
+  };
+
+  navigationItem = {
+    title: 'Test Info Guide' as any,
+    icon: ListThin,
+    getLink() {
+      return '/web/testinfoguide';
+    },
+    searchableTags: ['test info guide'],
+  };
+
+  hasAccess() {
+    return true;
+  }
+}

--- a/web/packages/teleport/src/Main/Main.tsx
+++ b/web/packages/teleport/src/Main/Main.tsx
@@ -38,6 +38,8 @@ import type { BannerType } from 'teleport/components/BannerList/BannerList';
 import { useAlerts } from 'teleport/components/BannerList/useAlerts';
 import { CatchError } from 'teleport/components/CatchError';
 import { Redirect, Route, Switch } from 'teleport/components/Router';
+import { InfoGuideSidePanel } from 'teleport/components/SlidingSidePanel';
+import { infoGuidePanelWidth } from 'teleport/components/SlidingSidePanel/InfoGuideSidePanel/InfoGuideSidePanel';
 import cfg from 'teleport/config';
 import { FeaturesContextProvider, useFeatures } from 'teleport/FeaturesContext';
 import { Navigation } from 'teleport/Navigation';
@@ -52,6 +54,7 @@ import type { LockedFeatures, TeleportFeature } from 'teleport/types';
 import { useUser } from 'teleport/User/UserContext';
 import useTeleport from 'teleport/useTeleport';
 
+import { InfoGuidePanelProvider, useInfoGuide } from './InfoGuideContext';
 import { MainContainer } from './MainContainer';
 import { OnboardDiscover } from './OnboardDiscover';
 
@@ -189,19 +192,21 @@ export function Main(props: MainProps) {
       <Wrapper>
         <MainContainer>
           <Navigation />
-          <ContentWrapper>
-            <ContentMinWidth>
-              <BannerList
-                banners={banners}
-                customBanners={props.customBanners}
-                billingBanners={featureFlags.billing && props.billingBanners}
-                onBannerDismiss={dismissAlert}
-              />
-              <Suspense fallback={null}>
-                <FeatureRoutes lockedFeatures={ctx.lockedFeatures} />
-              </Suspense>
-            </ContentMinWidth>
-          </ContentWrapper>
+          <InfoGuidePanelProvider>
+            <ContentWrapper>
+              <ContentMinWidth>
+                <BannerList
+                  banners={banners}
+                  customBanners={props.customBanners}
+                  billingBanners={featureFlags.billing && props.billingBanners}
+                  onBannerDismiss={dismissAlert}
+                />
+                <Suspense fallback={null}>
+                  <FeatureRoutes lockedFeatures={ctx.lockedFeatures} />
+                </Suspense>
+              </ContentMinWidth>
+            </ContentWrapper>
+          </InfoGuidePanelProvider>
         </MainContainer>
       </Wrapper>
       {displayOnboardDiscover && (
@@ -302,6 +307,8 @@ export const useNoMinWidth = () => {
 
 export const ContentMinWidth = ({ children }: { children: ReactNode }) => {
   const [enforceMinWidth, setEnforceMinWidth] = useState(true);
+  const { infoGuideElement } = useInfoGuide();
+  const infoGuideSidePanelOpened = infoGuideElement != null;
 
   return (
     <ContentMinWidthContext.Provider value={{ setEnforceMinWidth }}>
@@ -312,10 +319,18 @@ export const ContentMinWidth = ({ children }: { children: ReactNode }) => {
           flex: 1;
           ${enforceMinWidth ? 'min-width: 1000px;' : ''}
           min-height: 0;
+          margin-right: ${infoGuideSidePanelOpened
+            ? infoGuidePanelWidth
+            : '0'}px;
+          transition: ${infoGuideSidePanelOpened
+            ? 'margin 150ms'
+            : 'margin 300ms'};
+          overflow-y: auto;
         `}
       >
         {children}
       </div>
+      <InfoGuideSidePanel />
     </ContentMinWidthContext.Provider>
   );
 };

--- a/web/packages/teleport/src/Navigation/Section.tsx
+++ b/web/packages/teleport/src/Navigation/Section.tsx
@@ -25,6 +25,7 @@ import { ArrowLineLeft, ArrowSquareIn } from 'design/Icon';
 import { Theme } from 'design/theme';
 import { HoverTooltip, IconTooltip } from 'design/Tooltip';
 
+import { SlidingSidePanel } from 'teleport/components/SlidingSidePanel';
 import cfg from 'teleport/config';
 
 import { CategoryIcon } from './CategoryIcon';
@@ -177,38 +178,30 @@ export function StandaloneSection({
 }
 
 export const rightPanelWidth = 274;
-
-export const RightPanel = styled(Box).attrs({ px: '5px' })<{
-  isVisible: boolean;
-  skipAnimation: boolean;
-}>`
-  position: fixed;
-  left: var(--sidenav-width);
-  height: 100%;
-  scrollbar-color: ${p => p.theme.colors.spotBackground[2]} transparent;
-  width: ${rightPanelWidth}px;
-  background: ${p => p.theme.colors.levels.surface};
-  z-index: ${zIndexMap.sideNavExpandedPanel};
-  border-right: 1px solid ${p => p.theme.colors.spotBackground[1]};
-
-  ${props =>
-    props.isVisible
-      ? `
-      ${props.skipAnimation ? '' : 'transition: transform .15s ease-out;'}
-      transform: translateX(0);
-      `
-      : `
-      ${props.skipAnimation ? '' : 'transition: transform .15s ease-in;'}
-      transform: translateX(-100%);
-      `}
-
-  top: ${p => p.theme.topBarHeight[0]}px;
-  padding-bottom: ${p => p.theme.topBarHeight[0] + p.theme.space[2]}px;
-  @media screen and (min-width: ${p => p.theme.breakpoints.small}px) {
-    top: ${p => p.theme.topBarHeight[1]}px;
-    padding-bottom: ${p => p.theme.topBarHeight[1] + p.theme.space[2]}px;
-  }
-`;
+export const RightPanel: React.FC<
+  PropsWithChildren<{
+    isVisible: boolean;
+    skipAnimation: boolean;
+    id: string;
+    onFocus(): void;
+  }>
+> = ({ isVisible, skipAnimation, id, onFocus, children }) => {
+  return (
+    <SlidingSidePanel
+      px="5px"
+      isVisible={isVisible}
+      skipAnimation={skipAnimation}
+      id={id}
+      onFocus={onFocus}
+      panelWidth={rightPanelWidth}
+      zIndex={zIndexMap.sideNavExpandedPanel}
+      slideFrom="left"
+      panelOffset="var(--sidenav-width)"
+    >
+      {children}
+    </SlidingSidePanel>
+  );
+};
 
 export function RightPanelHeader({
   title,

--- a/web/packages/teleport/src/Support/Support.story.tsx
+++ b/web/packages/teleport/src/Support/Support.story.tsx
@@ -19,6 +19,7 @@
 import { MemoryRouter } from 'react-router';
 
 import { ContextProvider } from 'teleport';
+import { InfoGuidePanelProvider } from 'teleport/Main/InfoGuideContext';
 import { ContentMinWidth } from 'teleport/Main/Main';
 import { createTeleportContext } from 'teleport/mocks/contexts';
 
@@ -30,9 +31,11 @@ export default {
 
 const Provider = ({ children }) => (
   <ContextProvider ctx={ctx}>
-    <ContentMinWidth>
-      <MemoryRouter>{children}</MemoryRouter>
-    </ContentMinWidth>
+    <InfoGuidePanelProvider>
+      <ContentMinWidth>
+        <MemoryRouter>{children}</MemoryRouter>
+      </ContentMinWidth>
+    </InfoGuidePanelProvider>
   </ContextProvider>
 );
 

--- a/web/packages/teleport/src/components/SlidingSidePanel/InfoGuideSidePanel/InfoGuideSidePanel.story.tsx
+++ b/web/packages/teleport/src/components/SlidingSidePanel/InfoGuideSidePanel/InfoGuideSidePanel.story.tsx
@@ -1,6 +1,6 @@
 /**
  * Teleport
- * Copyright (C) 2024 Gravitational, Inc.
+ * Copyright (C) 2025  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,10 +16,29 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export const zIndexMap = {
-  topBar: 19,
-  sideNavButtons: 18,
-  sideNavContainer: 17,
-  sideNavExpandedPanel: 16,
-  infoGuideSidePanel: 15,
+import { Box } from 'design';
+
+import { DevInfo, LongContent, TopBar } from '../storyHelpers';
+import {
+  InfoGuideSidePanel as Component,
+  InfoGuideWrapper,
+} from './InfoGuideSidePanel';
+
+export default {
+  title: 'Teleport/SlidingSidePanel',
+};
+
+export const InfoGuideSidePanel = () => {
+  return (
+    <TopBar>
+      {/* this Box wrapper is just for demo purposes */}
+      <Box mt={10} ml={3}>
+        <DevInfo />
+        <InfoGuideWrapper guide={<LongContent />}>
+          Click on the info icon
+        </InfoGuideWrapper>
+      </Box>
+      <Component />
+    </TopBar>
+  );
 };

--- a/web/packages/teleport/src/components/SlidingSidePanel/InfoGuideSidePanel/InfoGuideSidePanel.tsx
+++ b/web/packages/teleport/src/components/SlidingSidePanel/InfoGuideSidePanel/InfoGuideSidePanel.tsx
@@ -1,0 +1,158 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React, { PropsWithChildren } from 'react';
+import styled from 'styled-components';
+
+import { Box, Button, ButtonIcon, Flex, H3, Link, Text } from 'design';
+import { Cross, Info } from 'design/Icon';
+import { P } from 'design/Text/Text';
+
+import { useInfoGuide } from 'teleport/Main/InfoGuideContext';
+import { zIndexMap } from 'teleport/Navigation/zIndexMap';
+
+import { SlidingSidePanel } from '..';
+
+export const infoGuidePanelWidth = 300;
+
+/**
+ * An info panel that always slides from the right and supports closing
+ * from inside of panel (by clicking on x button from the sticky header).
+ */
+export const InfoGuideSidePanel = () => {
+  const { infoGuideElement, setInfoGuideElement } = useInfoGuide();
+  const infoGuideSidePanelOpened = infoGuideElement != null;
+
+  return (
+    <SlidingSidePanel
+      isVisible={infoGuideSidePanelOpened}
+      skipAnimation={false}
+      panelWidth={infoGuidePanelWidth}
+      zIndex={zIndexMap.infoGuideSidePanel}
+      slideFrom="right"
+    >
+      <Box css={{ height: '100%', overflow: 'auto' }}>
+        <InfoGuideHeader onClose={() => setInfoGuideElement(null)} />
+        <Box px={3} pb={3}>
+          {infoGuideElement}
+        </Box>
+      </Box>
+    </SlidingSidePanel>
+  );
+};
+
+const InfoGuideHeader = ({ onClose }: { onClose(): void }) => (
+  <Flex
+    gap={2}
+    alignItems="center"
+    justifyContent="space-between"
+    px={3}
+    py={2}
+    css={`
+      position: sticky;
+      top: 0;
+      background: ${p => p.theme.colors.levels.surface};
+      border-bottom: 1px solid ${p => p.theme.colors.spotBackground[1]};
+    `}
+  >
+    <Text bold>Page Info</Text>
+    <ButtonIcon onClick={onClose} data-testid="info-guide-btn-close">
+      <Cross size="small" />
+    </ButtonIcon>
+  </Flex>
+);
+
+const FilledButtonIcon = styled(Button)`
+  width: 32px;
+  height: 32px;
+  padding: 0;
+`;
+
+/**
+ * Renders a clickable info icon next to the children.
+ */
+export const InfoGuideWrapper: React.FC<
+  PropsWithChildren<{
+    guide: JSX.Element;
+    spaceBetween?: boolean;
+  }>
+> = ({ guide, children, spaceBetween = false }) => {
+  const { setInfoGuideElement } = useInfoGuide();
+
+  return (
+    <Flex
+      alignItems="center"
+      gap={2}
+      justifyContent={spaceBetween ? 'space-between' : undefined}
+    >
+      {children}
+      <FilledButtonIcon
+        intent="neutral"
+        onClick={() => setInfoGuideElement(guide)}
+        data-testid="info-guide-btn-open"
+      >
+        <Info size="small" />
+      </FilledButtonIcon>
+    </Flex>
+  );
+};
+
+export const InfoTitle = styled(H3)`
+  margin-bottom: ${p => p.theme.space[2]}px;
+  margin-top: ${p => p.theme.space[3]}px;
+`;
+
+export const InfoParagraph = styled(P)`
+  margin-top: ${p => p.theme.space[3]}px;
+`;
+
+/**
+ * Links used within a paragraph. The color of link is same as main texts
+ * so it doesn't take so much focus away from the paragraph.
+ */
+export const InfoExternalTextLink = styled(Link).attrs({ target: '_blank' })<{
+  href: string;
+}>`
+  color: ${({ theme }) => theme.colors.text.main};
+`;
+
+export const InfoUl = styled.ul`
+  margin: 0;
+  padding-left: ${p => p.theme.space[4]}px;
+`;
+
+const InfoLinkLi = styled.li`
+  color: ${({ theme }) => theme.colors.interactive.solid.accent.default};
+`;
+
+export type ReferenceLink = { title: string; href: string };
+
+export const ReferenceLinks = ({ links }: { links: ReferenceLink[] }) => (
+  <>
+    <InfoTitle>Reference Links</InfoTitle>
+    <InfoUl>
+      {links.map(link => (
+        <InfoLinkLi key={link.href}>
+          <Link target="_blank" href={link.href}>
+            {link.title}
+          </Link>
+        </InfoLinkLi>
+      ))}
+    </InfoUl>
+  </>
+);

--- a/web/packages/teleport/src/components/SlidingSidePanel/InfoGuideSidePanel/index.ts
+++ b/web/packages/teleport/src/components/SlidingSidePanel/InfoGuideSidePanel/index.ts
@@ -1,6 +1,6 @@
 /**
  * Teleport
- * Copyright (C) 2024 Gravitational, Inc.
+ * Copyright (C) 2025 Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,10 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export const zIndexMap = {
-  topBar: 19,
-  sideNavButtons: 18,
-  sideNavContainer: 17,
-  sideNavExpandedPanel: 16,
-  infoGuideSidePanel: 15,
-};
+export * from './InfoGuideSidePanel';

--- a/web/packages/teleport/src/components/SlidingSidePanel/SlidingSidePanel.story.tsx
+++ b/web/packages/teleport/src/components/SlidingSidePanel/SlidingSidePanel.story.tsx
@@ -1,0 +1,87 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Meta } from '@storybook/react';
+import { useState } from 'react';
+
+import { Box, ButtonPrimary } from 'design';
+import { Info } from 'design/Alert';
+
+import { SlidingSidePanel } from './SlidingSidePanel';
+import { LongContent, TopBar } from './storyHelpers';
+
+type StoryProps = {
+  slideFrom: 'left' | 'right';
+  panelOffset: string;
+  skipAnimation: boolean;
+  panelWidth: number;
+};
+
+const meta: Meta<StoryProps> = {
+  title: 'Teleport/SlidingSidePanel',
+  component: Controls,
+  argTypes: {
+    slideFrom: {
+      control: { type: 'select' },
+      options: ['left', 'right'],
+    },
+    panelOffset: {
+      control: { type: 'text' },
+    },
+    skipAnimation: {
+      control: { type: 'boolean' },
+    },
+    panelWidth: {
+      control: { type: 'number' },
+    },
+  },
+  // default
+  args: {
+    slideFrom: 'right',
+    panelOffset: '0',
+    skipAnimation: false,
+    panelWidth: 300,
+  },
+};
+export default meta;
+
+export function Controls(props: StoryProps) {
+  const [show, setShow] = useState(false);
+
+  return (
+    <TopBar>
+      {/* this Box wrapper is just for demo purposes */}
+      <Box mt={10} textAlign="center">
+        <Info>The top bar nav is only rendered for demo purposes</Info>
+        <ButtonPrimary onClick={() => setShow(!show)}>Toggle Me</ButtonPrimary>
+      </Box>
+      <SlidingSidePanel
+        isVisible={show}
+        skipAnimation={props.skipAnimation}
+        panelWidth={props.panelWidth}
+        zIndex={1000}
+        slideFrom={props.slideFrom}
+        panelOffset={props.panelOffset}
+      >
+        <Box css={{ height: '100%', overflow: 'auto' }}>
+          <LongContent withPadding />
+        </Box>
+      </SlidingSidePanel>
+    </TopBar>
+  );
+}

--- a/web/packages/teleport/src/components/SlidingSidePanel/SlidingSidePanel.tsx
+++ b/web/packages/teleport/src/components/SlidingSidePanel/SlidingSidePanel.tsx
@@ -1,0 +1,85 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import styled from 'styled-components';
+
+import { Box } from 'design';
+
+type Base = {
+  isVisible: boolean;
+  skipAnimation: boolean;
+  panelWidth: number;
+  zIndex: number;
+  /**
+   * panelOffset is how much space to offset the panel
+   * from left or right position.
+   *
+   * the value is a number postfixed by `px` eg: "50px" or
+   * css variable eg: var(--some-var-name)
+   */
+  panelOffset?: string;
+};
+
+type RightPanel = Base & {
+  slideFrom: 'right';
+};
+
+type LeftPanel = Base & {
+  slideFrom: 'left';
+};
+
+type Props = RightPanel | LeftPanel;
+
+/**
+ * Panel that slides from right or left underneath the web UI's
+ * top bar navigation.
+ */
+export const SlidingSidePanel = styled(Box)<Props>`
+  position: fixed;
+  height: 100%;
+  scrollbar-color: ${p => p.theme.colors.spotBackground[2]} transparent;
+  width: ${p => p.panelWidth}px;
+  background: ${p => p.theme.colors.levels.surface};
+  z-index: ${p => p.zIndex};
+
+  ${props =>
+    props.slideFrom === 'left'
+      ? `left: ${props.panelOffset || 0};
+       border-right: 1px solid ${props.theme.colors.spotBackground[1]};`
+      : `right: ${props.panelOffset || 0};
+       border-left: 1px solid ${props.theme.colors.spotBackground[1]};`}
+
+  ${props =>
+    props.isVisible
+      ? `
+      ${props.skipAnimation ? '' : 'transition: transform .15s ease-out;'}
+      transform: translateX(0);
+      `
+      : `
+      ${props.skipAnimation ? '' : 'transition: transform .15s ease-in;'}
+      transform: translateX(${props.slideFrom === 'left' ? '-100%' : '100%'});
+      `}
+
+
+  top: ${p => p.theme.topBarHeight[0]}px;
+  padding-bottom: ${p => p.theme.topBarHeight[0] + p.theme.space[2]}px;
+  @media screen and (min-width: ${p => p.theme.breakpoints.small}px) {
+    top: ${p => p.theme.topBarHeight[1]}px;
+    padding-bottom: ${p => p.theme.topBarHeight[1] + p.theme.space[2]}px;
+  }
+`;

--- a/web/packages/teleport/src/components/SlidingSidePanel/index.ts
+++ b/web/packages/teleport/src/components/SlidingSidePanel/index.ts
@@ -1,6 +1,6 @@
 /**
  * Teleport
- * Copyright (C) 2024 Gravitational, Inc.
+ * Copyright (C) 2025  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,10 +16,5 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export const zIndexMap = {
-  topBar: 19,
-  sideNavButtons: 18,
-  sideNavContainer: 17,
-  sideNavExpandedPanel: 16,
-  infoGuideSidePanel: 15,
-};
+export { SlidingSidePanel } from './SlidingSidePanel';
+export { InfoGuideSidePanel } from './InfoGuideSidePanel';

--- a/web/packages/teleport/src/components/SlidingSidePanel/storyHelpers.tsx
+++ b/web/packages/teleport/src/components/SlidingSidePanel/storyHelpers.tsx
@@ -1,0 +1,128 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { PropsWithChildren } from 'react';
+import { MemoryRouter } from 'react-router';
+
+import { Box } from 'design';
+import { Info } from 'design/Alert';
+
+import { getOSSFeatures } from 'teleport/features';
+import { FeaturesContextProvider } from 'teleport/FeaturesContext';
+import { ContextProvider } from 'teleport/index';
+import { InfoGuidePanelProvider } from 'teleport/Main/InfoGuideContext';
+import { LayoutContextProvider } from 'teleport/Main/LayoutContext';
+import { createTeleportContext } from 'teleport/mocks/contexts';
+import { makeDefaultUserPreferences } from 'teleport/services/userPreferences/userPreferences';
+import { TopBar as Component } from 'teleport/TopBar';
+import { UserContext } from 'teleport/User/UserContext';
+
+import { InfoParagraph, InfoTitle, ReferenceLinks } from './InfoGuideSidePanel';
+
+export const TopBar: React.FC<PropsWithChildren> = ({ children }) => {
+  const ctx = createTeleportContext();
+  const updatePreferences = () => Promise.resolve();
+  const getClusterPinnedResources = () => Promise.resolve([]);
+  const updateClusterPinnedResources = () => Promise.resolve();
+  const updateDiscoverResourcePreferences = () => Promise.resolve();
+  const preferences = makeDefaultUserPreferences();
+
+  return (
+    <MemoryRouter>
+      <UserContext.Provider
+        value={{
+          preferences,
+          updatePreferences,
+          getClusterPinnedResources,
+          updateClusterPinnedResources,
+          updateDiscoverResourcePreferences,
+        }}
+      >
+        <InfoGuidePanelProvider>
+          <ContextProvider ctx={ctx}>
+            <FeaturesContextProvider value={getOSSFeatures()}>
+              <LayoutContextProvider>
+                <Box
+                  css={`
+                    position: absolute;
+                    top: 0;
+                    right: 0;
+                    left: 0;
+                  `}
+                >
+                  <Component />
+                  {children}
+                </Box>
+              </LayoutContextProvider>
+            </FeaturesContextProvider>
+          </ContextProvider>
+        </InfoGuidePanelProvider>
+      </UserContext.Provider>
+    </MemoryRouter>
+  );
+};
+
+export const LongContent = ({ withPadding = false }) => (
+  <Box px={withPadding ? 3 : 0}>
+    <InfoTitle>Each title is wrapped with InfoTitle component</InfoTitle>
+    <InfoParagraph>
+      Each paragraphs are wrapped with InfoParagraph component.
+    </InfoParagraph>
+    <InfoTitle>InfoTitle Two</InfoTitle>
+    <InfoParagraph>
+      2 Lorem ipsum dolor sit, amet consectetur adipisicing elit. Commodi
+      corrupti voluptates aliquam eligendi placeat harum rerum ipsam. Corrupti
+      architecto laudantium, libero perspiciatis officia doloremque est aliquam,
+      eius qui tenetur.
+    </InfoParagraph>
+    <InfoTitle>InfoTitle Three</InfoTitle>
+    <InfoParagraph>
+      3 Lorem ipsum dolor sit, amet consectetur adipisicing elit. Commodi
+      corrupti voluptates aliquam eligendi placeat harum rerum ipsam. Corrupti
+      architecto laudantium, libero perspiciatis officia doloremque est aliquam,
+      eius qui tenetur.
+    </InfoParagraph>
+    <InfoTitle>InfoTitle Four</InfoTitle>
+    <InfoParagraph>
+      4 Lorem ipsum dolor sit, amet consectetur adipisicing elit. Commodi
+      corrupti voluptates aliquam eligendi placeat harum rerum ipsam. Corrupti
+      architecto laudantium, libero perspiciatis officia doloremque est aliquam,
+      eius qui tenetur.
+    </InfoParagraph>
+    <InfoTitle>InfoTitle Five</InfoTitle>
+    <InfoParagraph>
+      5 Lorem ipsum dolor sit, amet consectetur adipisicing elit. Commodi
+      corrupti voluptates aliquam eligendi placeat harum rerum ipsam. Corrupti
+      architecto laudantium, libero perspiciatis officia doloremque est aliquam,
+      eius qui tenetur.
+    </InfoParagraph>
+    <ReferenceLinks
+      links={[
+        { title: 'Some Link 1', href: 'link1' },
+        { title: 'Some Link 2', href: 'link2' },
+        { title: 'Some Link 3', href: 'link3' },
+        { title: 'Some Link 4', href: 'link4' },
+        { title: 'Some Link 5', href: 'link5' },
+      ]}
+    />
+  </Box>
+);
+
+export const DevInfo = () => (
+  <Info>The top bar nav is only rendered for demo purposes</Info>
+);


### PR DESCRIPTION
Re-uses the same styling used to render the side nav's expandable nav panel to create an info guide panel. It isn't currently being used yet since the content for guides are still WIP.

[figma](https://www.figma.com/design/v6GunK50D2VC7w7I2FBDNf/Access-(Management)?node-id=8127-9237&t=m2FVGXz8fzJTOiLG-0)


demo of how it can be used:

https://github.com/user-attachments/assets/3dc5399c-f9c0-48d3-9b2c-74b1b121a6ca




