### PR TITLE
[v17] Add tctl plugins install awsic

### DIFF
--- a/tool/tctl/common/plugin/awsic.go
+++ b/tool/tctl/common/plugin/awsic.go
@@ -1,0 +1,255 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"slices"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+
+	pluginspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/plugins/v1"
+	"github.com/gravitational/teleport/api/types"
+	apicommon "github.com/gravitational/teleport/api/types/common"
+	icfilters "github.com/gravitational/teleport/lib/aws/identitycenter/filters"
+	"github.com/gravitational/teleport/lib/client"
+	awsutils "github.com/gravitational/teleport/lib/utils/aws"
+	icutils "github.com/gravitational/teleport/lib/utils/aws/identitycenterutils"
+)
+
+type awsICArgs struct {
+	cmd                  *kingpin.CmdClause
+	defaultOwners        []string
+	scimToken            string
+	scimURL              *url.URL
+	forceSCIMURL         bool
+	region               string
+	arn                  string
+	useSystemCredentials bool
+	userOrigins          []string
+	userLabels           []string
+	groupNameFilters     []string
+	accountNameFilters   []string
+	accountIDFilters     []string
+}
+
+func (a *awsICArgs) validate(ctx context.Context, log *slog.Logger) error {
+	if !awsutils.IsKnownRegion(a.region) {
+		return trace.BadParameter("unknown AWS region: %s", a.region)
+	}
+
+	if a.scimToken == "" {
+		return trace.BadParameter("SCIM token must not be empty")
+	}
+
+	if !a.useSystemCredentials {
+		return trace.BadParameter("only AWS Local system credentials are supported")
+	}
+
+	if err := a.validateSCIMBaseURL(ctx, log); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+func (a *awsICArgs) validateSCIMBaseURL(ctx context.Context, log *slog.Logger) error {
+	validatedBaseUrl, err := icutils.EnsureSCIMEndpointURL(a.scimURL)
+	if err == nil {
+		a.scimURL = validatedBaseUrl
+		return nil
+
+	}
+
+	if a.forceSCIMURL {
+		log.WarnContext(ctx, "Using supplied SCIM base URL even though it is not a valid AWS IC SCIM base URL.")
+		return nil
+	}
+
+	return trace.Wrap(err)
+}
+
+func (a *awsICArgs) parseGroupFilters() (icfilters.Filters, error) {
+	var filters []*types.AWSICResourceFilter
+	for _, n := range a.groupNameFilters {
+		filters = append(filters, &types.AWSICResourceFilter{
+			Include: &types.AWSICResourceFilter_NameRegex{NameRegex: n},
+		})
+	}
+	return icfilters.New(filters)
+}
+
+func (a *awsICArgs) parseAccountFilters() (icfilters.Filters, error) {
+	var filters []*types.AWSICResourceFilter
+	for _, n := range a.accountNameFilters {
+		filters = append(filters, &types.AWSICResourceFilter{
+			Include: &types.AWSICResourceFilter_NameRegex{NameRegex: n},
+		})
+	}
+
+	for _, id := range a.accountIDFilters {
+		filters = append(filters, &types.AWSICResourceFilter{
+			Include: &types.AWSICResourceFilter_Id{Id: id},
+		})
+	}
+
+	return icfilters.New(filters)
+}
+
+func (a *awsICArgs) parseUserFilters() ([]*types.AWSICUserSyncFilter, error) {
+	var result []*types.AWSICUserSyncFilter
+
+	if len(a.userOrigins) > 0 {
+		result = make([]*types.AWSICUserSyncFilter, 0, len(a.userOrigins))
+		for _, origin := range a.userOrigins {
+			result = append(result, &types.AWSICUserSyncFilter{
+				Labels: map[string]string{types.OriginLabel: origin},
+			})
+		}
+	}
+
+	if len(a.userLabels) > 0 {
+		result = slices.Grow(result, len(a.userLabels))
+		for _, labelSpec := range a.userLabels {
+			labels, err := client.ParseLabelSpec(labelSpec)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			result = append(result, &types.AWSICUserSyncFilter{Labels: labels})
+		}
+	}
+
+	return result, nil
+}
+
+func (p *PluginsCommand) initInstallAWSIC(parent *kingpin.CmdClause) {
+	p.install.awsIC.cmd = parent.Command("awsic", "Install an AWS IAM Identity Center integration.")
+	cmd := p.install.awsIC.cmd
+	cmd.Flag("access-list-default-owner", "Teleport user to set as default owner for the imported access lists. Multiple flags allowed.").
+		Required().
+		StringsVar(&p.install.awsIC.defaultOwners)
+	cmd.Flag("scim-url", "AWS Identity Center SCIM provisioning endpoint").
+		Required().
+		URLVar(&p.install.awsIC.scimURL)
+	cmd.Flag("force-scim-url", "Use the provided SCIM provisioning endpoint even if it fails scim endpoint validation").
+		Default("false").
+		BoolVar(&p.install.awsIC.forceSCIMURL)
+	cmd.Flag("scim-token", "AWS Identify Center SCIM provisioning token.").
+		Required().
+		StringVar(&p.install.awsIC.scimToken)
+	cmd.Flag("instance-region", "AWS Identity Center instance region").
+		Required().
+		StringVar(&p.install.awsIC.region)
+	cmd.Flag("instance-arn", "AWS Identity center instance ARN").
+		Required().
+		StringVar(&p.install.awsIC.arn)
+	cmd.Flag("use-system-credentials", "Uses system credentials instead of OIDC.").
+		Default("true").
+		BoolVar(&p.install.awsIC.useSystemCredentials)
+
+	cmd.Flag("user-origin", fmt.Sprintf(`Shorthand for "--user-label %s=ORIGIN"`, types.OriginLabel)).
+		PlaceHolder("ORIGIN").
+		EnumsVar(&p.install.awsIC.userOrigins, types.OriginValues...)
+	cmd.Flag("user-label", "Add user label filter, in the form of a comma-separated list of \"name=value\" pairs. If no label filters are supplied, all Teleport users will be provisioned to Identity Center").
+		PlaceHolder("LABELSPEC").
+		StringsVar(&p.install.awsIC.userLabels)
+
+	cmd.Flag("group-name", "Add AWS group to group import list by name. Can be a glob, or enclosed in ^$ to specify a regular expression. If no filters are supplied then all AWS groups will be imported.").
+		StringsVar(&p.install.awsIC.groupNameFilters)
+	cmd.Flag("account-name", "Add AWS Account to account import list by name. Can be a glob, or enclosed in ^$ to specify a regular expression. All AWS accounts will be imported if no items are added to account import list.").
+		StringsVar(&p.install.awsIC.accountNameFilters)
+	cmd.Flag("account-id", "Add AWS Account to account import list by ID. All AWS accounts will be imported if no items are added to account import list.").
+		StringsVar(&p.install.awsIC.accountIDFilters)
+}
+
+// InstallAWSIC installs AWS Identity Center plugin.
+func (p *PluginsCommand) InstallAWSIC(ctx context.Context, args installPluginArgs) error {
+	awsICArgs := p.install.awsIC
+	if err := awsICArgs.validate(ctx, p.config.Logger); err != nil {
+		return trace.Wrap(err)
+	}
+
+	userFilters, err := awsICArgs.parseUserFilters()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	groupFilters, err := awsICArgs.parseGroupFilters()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	accountFilters, err := awsICArgs.parseAccountFilters()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	req := &pluginspb.CreatePluginRequest{
+		Plugin: &types.PluginV1{
+			Metadata: types.Metadata{
+				Name: apicommon.OriginAWSIdentityCenter,
+				Labels: map[string]string{
+					"teleport.dev/hosted-plugin": "true",
+				},
+			},
+			Spec: types.PluginSpecV1{
+				Settings: &types.PluginSpecV1_AwsIc{
+					AwsIc: &types.PluginAWSICSettings{
+						IntegrationName: apicommon.OriginAWSIdentityCenter,
+						Region:          awsICArgs.region,
+						Arn:             awsICArgs.arn,
+						ProvisioningSpec: &types.AWSICProvisioningSpec{
+							BaseUrl: awsICArgs.scimURL.String(),
+						},
+						AccessListDefaultOwners: awsICArgs.defaultOwners,
+						CredentialsSource:       types.AWSICCredentialsSource_AWSIC_CREDENTIALS_SOURCE_SYSTEM,
+						UserSyncFilters:         userFilters,
+						GroupSyncFilters:        groupFilters,
+						AwsAccountsFilters:      accountFilters,
+					},
+				},
+			},
+		},
+		StaticCredentials: &types.PluginStaticCredentialsV1{
+			ResourceHeader: types.ResourceHeader{
+				Metadata: types.Metadata{
+					Labels: map[string]string{
+						"aws-ic/scim-api-endpoint": awsICArgs.scimURL.String(),
+					},
+					Name: types.PluginTypeAWSIdentityCenter,
+				},
+			},
+			Spec: &types.PluginStaticCredentialsSpecV1{
+				Credentials: &types.PluginStaticCredentialsSpecV1_APIToken{
+					APIToken: awsICArgs.scimToken,
+				},
+			},
+		},
+	}
+
+	_, err = args.plugins.CreatePlugin(ctx, req)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Println("Successfully created AWS Identity Center plugin.")
+
+	return nil
+}

--- a/tool/tctl/common/plugin/awsic_test.go
+++ b/tool/tctl/common/plugin/awsic_test.go
@@ -1,0 +1,271 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package plugin
+
+import (
+	"context"
+	"log/slog"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+func TestAWSICUserFilters(t *testing.T) {
+	testCases := []struct {
+		name            string
+		labelValues     []string
+		originValues    []string
+		expectedError   require.ErrorAssertionFunc
+		expectedFilters []*types.AWSICUserSyncFilter
+	}{
+		{
+			name:          "empty",
+			expectedError: require.NoError,
+		},
+		{
+			name:          "single",
+			labelValues:   []string{"a=alpha,b=bravo,c=charlie"},
+			expectedError: require.NoError,
+			expectedFilters: []*types.AWSICUserSyncFilter{
+				{Labels: map[string]string{"a": "alpha", "b": "bravo", "c": "charlie"}},
+			},
+		},
+		{
+			name: "multiple label filters",
+			labelValues: []string{
+				"a=alpha,b=bravo,c=charlie",
+				"a=aardvark,b=a buzzing thing,c=big blue wobbly thing",
+			},
+			expectedError: require.NoError,
+			expectedFilters: []*types.AWSICUserSyncFilter{
+				{Labels: map[string]string{"a": "alpha", "b": "bravo", "c": "charlie"}},
+				{Labels: map[string]string{"a": "aardvark", "b": "a buzzing thing", "c": "big blue wobbly thing"}},
+			},
+		},
+		{
+			name:          "origin only",
+			originValues:  []string{types.OriginOkta, types.OriginEntraID},
+			expectedError: require.NoError,
+			expectedFilters: []*types.AWSICUserSyncFilter{
+				{Labels: map[string]string{types.OriginLabel: types.OriginEntraID}},
+				{Labels: map[string]string{types.OriginLabel: types.OriginOkta}},
+			},
+		},
+		{
+			name: "complex",
+			labelValues: []string{
+				"a=alpha,b=bravo,c=charlie",
+				"a=aardvark,b=a buzzing thing,c=big blue wobbly thing",
+			},
+			originValues:  []string{types.OriginOkta, types.OriginEntraID},
+			expectedError: require.NoError,
+			expectedFilters: []*types.AWSICUserSyncFilter{
+				{Labels: map[string]string{"a": "alpha", "b": "bravo", "c": "charlie"}},
+				{Labels: map[string]string{"a": "aardvark", "b": "a buzzing thing", "c": "big blue wobbly thing"}},
+				{Labels: map[string]string{types.OriginLabel: types.OriginEntraID}},
+				{Labels: map[string]string{types.OriginLabel: types.OriginOkta}},
+			},
+		},
+		{
+			name:          "malformed label spec is an error",
+			labelValues:   []string{"a=alpha,potato,c=charlie"},
+			expectedError: require.Error,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			cliArgs := awsICArgs{
+				userLabels:  test.labelValues,
+				userOrigins: test.originValues,
+			}
+
+			actualFilters, err := cliArgs.parseUserFilters()
+			test.expectedError(t, err)
+			require.ElementsMatch(t, test.expectedFilters, actualFilters)
+		})
+	}
+}
+
+func TestAWSICGroupFilters(t *testing.T) {
+	testCases := []struct {
+		name            string
+		nameValues      []string
+		expectedError   require.ErrorAssertionFunc
+		expectedFilters []*types.AWSICResourceFilter
+	}{
+		{
+			name:          "empty",
+			expectedError: require.NoError,
+		},
+		{
+			name:          "multiple",
+			nameValues:    []string{"alpha", "bravo", "charlie"},
+			expectedError: require.NoError,
+			expectedFilters: []*types.AWSICResourceFilter{
+				{Include: &types.AWSICResourceFilter_NameRegex{NameRegex: "alpha"}},
+				{Include: &types.AWSICResourceFilter_NameRegex{NameRegex: "bravo"}},
+				{Include: &types.AWSICResourceFilter_NameRegex{NameRegex: "charlie"}},
+			},
+		},
+		{
+			name:          "malformed regex is an error",
+			nameValues:    []string{"alpha", "^[)$", "charlie"},
+			expectedError: require.Error,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			cliArgs := awsICArgs{
+				groupNameFilters: test.nameValues,
+			}
+
+			actualFilters, err := cliArgs.parseGroupFilters()
+			test.expectedError(t, err)
+			require.ElementsMatch(t, test.expectedFilters, actualFilters)
+		})
+	}
+}
+
+func TestAWSICAccountFilters(t *testing.T) {
+	testCases := []struct {
+		name            string
+		nameValues      []string
+		idValues        []string
+		expectedError   require.ErrorAssertionFunc
+		expectedFilters []*types.AWSICResourceFilter
+	}{
+		{
+			name:          "empty",
+			expectedError: require.NoError,
+		},
+		{
+			name:          "names only",
+			nameValues:    []string{"alpha", "bravo", "charlie"},
+			expectedError: require.NoError,
+			expectedFilters: []*types.AWSICResourceFilter{
+				{Include: &types.AWSICResourceFilter_NameRegex{NameRegex: "alpha"}},
+				{Include: &types.AWSICResourceFilter_NameRegex{NameRegex: "bravo"}},
+				{Include: &types.AWSICResourceFilter_NameRegex{NameRegex: "charlie"}},
+			},
+		},
+		{
+			name:          "ids only",
+			idValues:      []string{"0123456789", "9876543210"},
+			expectedError: require.NoError,
+			expectedFilters: []*types.AWSICResourceFilter{
+				{Include: &types.AWSICResourceFilter_Id{Id: "0123456789"}},
+				{Include: &types.AWSICResourceFilter_Id{Id: "9876543210"}},
+			},
+		},
+		{
+			name:          "complex",
+			nameValues:    []string{"alpha", "bravo", "charlie"},
+			idValues:      []string{"0123456789", "9876543210"},
+			expectedError: require.NoError,
+			expectedFilters: []*types.AWSICResourceFilter{
+				{Include: &types.AWSICResourceFilter_NameRegex{NameRegex: "alpha"}},
+				{Include: &types.AWSICResourceFilter_NameRegex{NameRegex: "bravo"}},
+				{Include: &types.AWSICResourceFilter_NameRegex{NameRegex: "charlie"}},
+				{Include: &types.AWSICResourceFilter_Id{Id: "0123456789"}},
+				{Include: &types.AWSICResourceFilter_Id{Id: "9876543210"}},
+			},
+		},
+		{
+			name:          "malformed regex is an error",
+			nameValues:    []string{"alpha", "^[)$", "charlie"},
+			expectedError: require.Error,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			cliArgs := awsICArgs{
+				accountNameFilters: test.nameValues,
+				accountIDFilters:   test.idValues,
+			}
+
+			actualFilters, err := cliArgs.parseAccountFilters()
+			test.expectedError(t, err)
+			require.ElementsMatch(t, test.expectedFilters, actualFilters)
+		})
+	}
+}
+
+func TestSCIMBaseURLValidation(t *testing.T) {
+	ctx := context.Background()
+
+	requireURL := func(expectedURL string) require.ValueAssertionFunc {
+		return func(subtestT require.TestingT, value any, _ ...any) {
+			actualURL, ok := value.(*url.URL)
+			require.True(subtestT, ok, "Expected value to be an *URL, got %T instead", value)
+			require.Equal(subtestT, expectedURL, actualURL.String())
+		}
+	}
+
+	testCases := []struct {
+		name        string
+		suppliedURL string
+		forceURL    bool
+		expectError require.ErrorAssertionFunc
+		expectValue require.ValueAssertionFunc
+	}{
+		{
+			name:        "valid url",
+			suppliedURL: "https://scim.us-east-1.amazonaws.com/f3v9c6bc2ca-b104-4571-b669-f2eba522efe8/scim/v2",
+			expectError: require.NoError,
+			expectValue: requireURL("https://scim.us-east-1.amazonaws.com/f3v9c6bc2ca-b104-4571-b669-f2eba522efe8/scim/v2"),
+		},
+		{
+			name:        "fragments are stripped",
+			suppliedURL: "https://scim.us-east-1.amazonaws.com/f3v9c6bc2ca-b104-4571-b669-f2eba522efe8/scim/v2#spurious-fragment",
+			expectError: require.NoError,
+			expectValue: requireURL("https://scim.us-east-1.amazonaws.com/f3v9c6bc2ca-b104-4571-b669-f2eba522efe8/scim/v2"),
+		},
+		{
+			name:        "invalid AWS SCIM Base URLs are an error",
+			suppliedURL: "https://scim.example.com/v2",
+			expectError: require.Error,
+		},
+		{
+			name:        "invalid AWS SCIM Base URL can be forced",
+			suppliedURL: "https://scim.example.com/v2",
+			forceURL:    true,
+			expectValue: requireURL("https://scim.example.com/v2"),
+			expectError: require.NoError,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			cliArgs := awsICArgs{
+				scimURL:      mustParseURL(test.suppliedURL),
+				forceSCIMURL: test.forceURL,
+			}
+
+			err := cliArgs.validateSCIMBaseURL(ctx, slog.Default().With("test", t.Name()))
+			test.expectError(t, err)
+			if test.expectValue != nil {
+				test.expectValue(t, cliArgs.scimURL)
+			}
+		})
+	}
+}

--- a/tool/tctl/common/plugin/plugins_command.go
+++ b/tool/tctl/common/plugin/plugins_command.go
@@ -57,6 +57,7 @@ type pluginInstallArgs struct {
 	scim    scimArgs
 	entraID entraArgs
 	netIQ   netIQArgs
+	awsIC   awsICArgs
 }
 
 type scimArgs struct {
@@ -104,6 +105,7 @@ func (p *PluginsCommand) initInstall(parent *kingpin.CmdClause, config *servicec
 	p.initInstallSCIM(p.install.cmd)
 	p.initInstallEntra(p.install.cmd)
 	p.initInstallNetIQ(p.install.cmd)
+	p.initInstallAWSIC(p.install.cmd)
 }
 
 func (p *PluginsCommand) initInstallSCIM(parent *kingpin.CmdClause) {
@@ -330,6 +332,8 @@ func (p *PluginsCommand) TryRun(ctx context.Context, cmd string, clientFunc comm
 		commandFunc = p.InstallEntra
 	case p.install.netIQ.cmd.FullCommand():
 		commandFunc = p.InstallNetIQ
+	case p.install.awsIC.cmd.FullCommand():
+		commandFunc = p.InstallAWSIC
 	case p.delete.cmd.FullCommand():
 		commandFunc = p.Delete
 	default:


### PR DESCRIPTION
Backports #51239

Adds a command-line installation tool for the AWS Identity Center integration.

Changelog: Added `tctl` installer for Identity Center integration