### PR TITLE
Add required field indicators to labels

### DIFF
--- a/web/packages/design/src/LabelInput/LabelInput.story.tsx
+++ b/web/packages/design/src/LabelInput/LabelInput.story.tsx
@@ -17,7 +17,7 @@
  */
 
 import InputComp from './../Input';
-import { LabelInput } from './LabelInput';
+import { LabelContent, LabelInput } from './LabelInput';
 
 export default {
   title: 'Design/LabelInput',
@@ -31,5 +31,11 @@ export const Inputs = () => (
       With Error
     </LabelInput>
     <InputComp hasError={true} />
+    <LabelInput mt={4}>
+      <LabelContent required tooltipContent="Some tooltip content">
+        Label with a required mark and a tooltip
+      </LabelContent>
+    </LabelInput>
+    <InputComp />
   </>
 );

--- a/web/packages/design/src/LabelInput/LabelInput.tsx
+++ b/web/packages/design/src/LabelInput/LabelInput.tsx
@@ -16,9 +16,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { PropsWithChildren, ReactNode } from 'react';
 import styled from 'styled-components';
 
+import Flex from 'design/Flex';
 import { space, SpaceProps } from 'design/system';
+import Text from 'design/Text';
+import { IconTooltip } from 'design/Tooltip';
 
 interface LabelInputProps extends SpaceProps {
   hasError?: boolean;
@@ -34,4 +38,43 @@ export const LabelInput = styled.label<LabelInputProps>`
   margin-bottom: ${props => props.theme.space[1]}px;
   ${props => props.theme.typography.body3}
   ${space}
+`;
+
+/**
+ * Renders the label body, optionally decorated with an asterisk that marks it
+ * as a label for a required field, as well as an optional info icon with
+ * tooltip. Can be used inside {@link LabelInput} or a different label-like
+ * element, such as `<legend>`.
+ */
+export function LabelContent({
+  required,
+  tooltipContent,
+  tooltipSticky,
+  children,
+  ...otherProps
+}: PropsWithChildren<
+  SpaceProps & {
+    /** Adds a red asterisk after the field name. */
+    required?: boolean;
+    tooltipContent?: ReactNode;
+    tooltipSticky?: boolean;
+  }
+>) {
+  return (
+    <Flex flexDirection="row" gap={2} alignItems="center" {...otherProps}>
+      <Text typography="body3">
+        {children}
+        {required && (
+          <RequiredIndicator aria-label="(required)"> *</RequiredIndicator>
+        )}
+      </Text>
+      {tooltipContent && (
+        <IconTooltip sticky={tooltipSticky}>{tooltipContent}</IconTooltip>
+      )}
+    </Flex>
+  );
+}
+
+const RequiredIndicator = styled.span`
+  color: ${props => props.theme.colors.interactive.solid.danger.default};
 `;

--- a/web/packages/design/src/Tooltip/HoverTooltip.tsx
+++ b/web/packages/design/src/Tooltip/HoverTooltip.tsx
@@ -19,10 +19,11 @@
 import React, { PropsWithChildren, useState } from 'react';
 import styled, { useTheme } from 'styled-components';
 
-import { Flex, Popover, Text } from 'design';
-import { Origin } from 'design/Popover';
+import Flex from 'design/Flex';
+import Popover, { Origin } from 'design/Popover';
 import { Position } from 'design/Popover/Popover';
 import { FlexBasisProps, JustifyContentProps } from 'design/system';
+import Text from 'design/Text';
 
 import { anchorOriginForPosition, transformOriginForPosition } from './shared';
 

--- a/web/packages/design/src/Tooltip/IconTooltip.tsx
+++ b/web/packages/design/src/Tooltip/IconTooltip.tsx
@@ -19,9 +19,10 @@
 import React, { PropsWithChildren, useState } from 'react';
 import styled, { useTheme } from 'styled-components';
 
-import { Popover, Text } from 'design';
 import * as Icons from 'design/Icon';
+import Popover from 'design/Popover';
 import { Position } from 'design/Popover/Popover';
+import Text from 'design/Text';
 
 import { anchorOriginForPosition, transformOriginForPosition } from './shared';
 

--- a/web/packages/shared/components/FieldInput/FieldInput.story.tsx
+++ b/web/packages/shared/components/FieldInput/FieldInput.story.tsx
@@ -69,6 +69,7 @@ export const Fields = () => (
         <FieldInput
           label="Required"
           rule={requiredField('So required. Much mandatory.')}
+          required
           onChange={() => {}}
           value=""
         />

--- a/web/packages/shared/components/FieldInput/FieldInput.tsx
+++ b/web/packages/shared/components/FieldInput/FieldInput.tsx
@@ -27,7 +27,7 @@ import { Box, Input, LabelInput, Text } from 'design';
 import { BoxProps } from 'design/Box';
 import { IconProps } from 'design/Icon/Icon';
 import { InputMode, InputSize, InputType } from 'design/Input';
-import { IconTooltip } from 'design/Tooltip';
+import { LabelContent } from 'design/LabelInput/LabelInput';
 import { useRule } from 'shared/components/Validation';
 
 const FieldInput = forwardRef<HTMLInputElement, FieldInputProps>(
@@ -104,26 +104,14 @@ const FieldInput = forwardRef<HTMLInputElement, FieldInputProps>(
       <Box mb="3" {...styles}>
         {label ? (
           <LabelInput mb={0}>
-            <Box mb={1}>
-              {toolTipContent ? (
-                <>
-                  <span
-                    css={{
-                      marginRight: '4px',
-                      verticalAlign: 'middle',
-                    }}
-                  >
-                    {label}
-                  </span>
-                  <IconTooltip
-                    sticky={tooltipSticky}
-                    children={toolTipContent}
-                  />
-                </>
-              ) : (
-                <>{label}</>
-              )}
-            </Box>
+            <LabelContent
+              required={required}
+              tooltipContent={toolTipContent}
+              tooltipSticky={tooltipSticky}
+              mb={1}
+            >
+              {label}
+            </LabelContent>
             {$inputElement}
           </LabelInput>
         ) : (
@@ -248,9 +236,14 @@ export type FieldInputProps = BoxProps & {
   toolTipContent?: React.ReactNode;
   tooltipSticky?: boolean;
   disabled?: boolean;
-  // markAsError is a flag to highlight an
-  // input box as error color before validator
-  // runs (which marks it as error)
+  /**
+   * Highlights the input box with error color before validator runs (which
+   * marks it as error)
+   */
   markAsError?: boolean;
+  /**
+   * Adds a `required` attribute to the underlying input and adds a required
+   * field indicator to the label.
+   */
   required?: boolean;
 };

--- a/web/packages/shared/components/FieldMultiInput/FieldMultiInput.story.tsx
+++ b/web/packages/shared/components/FieldMultiInput/FieldMultiInput.story.tsx
@@ -41,6 +41,9 @@ export function Story() {
               value={items}
               onChange={setItems}
               rule={arrayOf(requiredField('required'))}
+              required
+              tooltipContent="I'm a sticky tooltip."
+              tooltipSticky
             />
             <Button mt={3} onClick={() => validator.validate()}>
               Validate

--- a/web/packages/shared/components/FieldMultiInput/FieldMultiInput.tsx
+++ b/web/packages/shared/components/FieldMultiInput/FieldMultiInput.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useRef } from 'react';
+import { ReactNode, useRef } from 'react';
 import styled, { useTheme } from 'styled-components';
 
 import Box from 'design/Box';
@@ -24,6 +24,7 @@ import { ButtonSecondary } from 'design/Button';
 import ButtonIcon from 'design/ButtonIcon';
 import Flex from 'design/Flex';
 import * as Icon from 'design/Icon';
+import { LabelContent } from 'design/LabelInput/LabelInput';
 import { useRule } from 'shared/components/Validation';
 import {
   precomputed,
@@ -48,6 +49,10 @@ export type FieldMultiInputProps = {
   label?: string;
   value: string[];
   disabled?: boolean;
+  /** Adds a required field indicator to the label. */
+  required?: boolean;
+  tooltipContent?: ReactNode;
+  tooltipSticky?: boolean;
   onChange?(val: string[]): void;
   rule?: Rule<string[], StringListValidationResult>;
 };
@@ -64,6 +69,9 @@ export function FieldMultiInput({
   label,
   value,
   disabled,
+  required,
+  tooltipContent,
+  tooltipSticky,
   onChange,
   rule = defaultRule,
 }: FieldMultiInputProps) {
@@ -103,7 +111,17 @@ export function FieldMultiInput({
   return (
     <Box>
       <Fieldset>
-        {label && <Legend>{label}</Legend>}
+        {label && (
+          <Legend>
+            <LabelContent
+              required={required}
+              tooltipContent={tooltipContent}
+              tooltipSticky={tooltipSticky}
+            >
+              {label}
+            </LabelContent>
+          </Legend>
+        )}
         {value.map((val, i) => (
           // Note on keys: using index as a key is an anti-pattern in general,
           // but here, we can safely assume that even though the list is

--- a/web/packages/shared/components/FieldSelect/FieldSelect.story.tsx
+++ b/web/packages/shared/components/FieldSelect/FieldSelect.story.tsx
@@ -23,6 +23,7 @@ import { Option } from 'shared/components/Select';
 import Validation from 'shared/components/Validation';
 import { wait } from 'shared/utils/wait';
 
+import { requiredField } from '../Validation/rules';
 import { FieldSelect, FieldSelectAsync } from './FieldSelect';
 import {
   FieldSelectCreatable,
@@ -80,6 +81,16 @@ export function Default() {
               options={OPTIONS}
               value={selectedOptions}
               onChange={setSelectedOptions}
+            />
+            <FieldSelect
+              label="FieldSelect, multi-select, required, with tooltip"
+              isMulti
+              options={OPTIONS}
+              value={selectedOptions}
+              onChange={setSelectedOptions}
+              rule={requiredField('Field is required')}
+              required
+              toolTipContent="I'm a tooltip."
             />
             <FieldSelectAsync
               label="FieldSelectAsync with search"

--- a/web/packages/shared/components/FieldSelect/shared.tsx
+++ b/web/packages/shared/components/FieldSelect/shared.tsx
@@ -20,9 +20,8 @@ import React, { useId } from 'react';
 import { GroupBase, OnChangeValue, OptionsOrGroups } from 'react-select';
 
 import Box, { BoxProps } from 'design/Box';
-import Flex from 'design/Flex';
-import LabelInput from 'design/LabelInput';
-import { IconTooltip } from 'design/Tooltip';
+import { LabelInput } from 'design/LabelInput';
+import { LabelContent } from 'design/LabelInput/LabelInput';
 
 import { HelperTextLine } from '../FieldInput/FieldInput';
 import {
@@ -42,6 +41,8 @@ export const LabelTip = ({ text }) => (
 type FieldSelectWrapperPropsBase<Opt, IsMulti extends boolean> = {
   label?: string;
   toolTipContent?: React.ReactNode;
+  tooltipSticky?: boolean;
+  required?: boolean;
   helperText?: React.ReactNode;
   value?: OnChangeValue<Opt, IsMulti>;
   rule?: (options: OnChangeValue<Opt, IsMulti>) => () => unknown;
@@ -68,6 +69,8 @@ type FieldSelectWrapperProps<
 export const FieldSelectWrapper = <Opt, IsMulti extends boolean>({
   label,
   toolTipContent,
+  tooltipSticky,
+  required,
   helperText,
   value,
   rule,
@@ -90,14 +93,13 @@ export const FieldSelectWrapper = <Opt, IsMulti extends boolean>({
     <Box mb="3" {...styles}>
       {label && (
         <LabelInput htmlFor={id}>
-          {toolTipContent ? (
-            <Flex gap={1} alignItems="center">
-              {label}
-              <IconTooltip children={toolTipContent} />
-            </Flex>
-          ) : (
-            label
-          )}
+          <LabelContent
+            required={required}
+            tooltipContent={toolTipContent}
+            tooltipSticky={tooltipSticky}
+          >
+            {label}
+          </LabelContent>
         </LabelInput>
       )}
       {React.cloneElement(children, {
@@ -142,6 +144,12 @@ export type FieldProps<Opt, IsMulti extends boolean> = BoxProps & {
   autoFocus?: boolean;
   label?: string;
   toolTipContent?: React.ReactNode;
+  tooltipSticky?: boolean;
+  /**
+   * Adds a `required` attribute to the underlying select and adds a required
+   * field indicator to the label.
+   */
+  required?: boolean;
   helperText?: React.ReactNode;
   rule?: (options: OnChangeValue<Opt, IsMulti>) => () => unknown;
   markAsError?: boolean;
@@ -203,6 +211,7 @@ export function splitSelectProps<
     openMenuOnClick,
     options,
     placeholder,
+    required,
     rule,
     stylesConfig,
     toolTipContent,
@@ -212,6 +221,11 @@ export function splitSelectProps<
   return {
     // hasError and inputId are deliberately excluded from the base, since they
     // are set by the wrapper component.
+    // `required` is special, because it appears in both places. It's handled
+    // by the wrapper, which uses it to display the read-only decoration;
+    // however, as it can mislead others who would think it's also forwarded to
+    // the underlying `ReactSelect` component, we also forward it there for
+    // consistency with that component's API.
     base: {
       'aria-label': ariaLabel,
       autoFocus,
@@ -240,6 +254,7 @@ export function splitSelectProps<
       options,
       openMenuOnClick,
       placeholder,
+      required,
       stylesConfig,
       value,
     },
@@ -248,6 +263,7 @@ export function splitSelectProps<
       inputId,
       label,
       markAsError,
+      required,
       rule,
       toolTipContent,
       value,
@@ -288,6 +304,7 @@ type KeysRemovedFromOthers =
   | 'openMenuOnClick'
   | 'options'
   | 'placeholder'
+  | 'required'
   | 'rule'
   | 'stylesConfig'
   | 'toolTipContent'

--- a/web/packages/shared/components/FieldTextArea/FieldTextArea.story.tsx
+++ b/web/packages/shared/components/FieldTextArea/FieldTextArea.story.tsx
@@ -45,6 +45,7 @@ export const Fields = () => (
           placeholder="placeholder"
           value={''}
           rule={requiredField('So required. Much mandatory.')}
+          required
         />
         <FieldTextArea
           label="Label with tooltip"
@@ -52,12 +53,12 @@ export const Fields = () => (
           onChange={() => {}}
           placeholder="placeholder"
           value={''}
-          toolTipContent={<Text>Hello world</Text>}
+          tooltipContent={<Text>Hello world</Text>}
         />
         <FieldTextArea
           label="Label with helper text and tooltip"
           helperText="Helper text"
-          toolTipContent={<Text>Hello world</Text>}
+          tooltipContent={<Text>Hello world</Text>}
           name="optional name"
           onChange={() => {}}
           placeholder="placeholder"
@@ -66,6 +67,7 @@ export const Fields = () => (
         <FieldTextArea placeholder="without label" onChange={() => {}} />
         <FieldTextArea
           label="Required"
+          required
           rule={requiredField('So required. Much mandatory.')}
           onChange={() => {}}
           value=""

--- a/web/packages/shared/components/FieldTextArea/FieldTextArea.tsx
+++ b/web/packages/shared/components/FieldTextArea/FieldTextArea.tsx
@@ -24,8 +24,8 @@ import React, {
 
 import { Box, LabelInput, TextArea } from 'design';
 import { BoxProps } from 'design/Box';
+import { LabelContent } from 'design/LabelInput/LabelInput';
 import { TextAreaSize } from 'design/TextArea';
-import { IconTooltip } from 'design/Tooltip';
 import { useRule } from 'shared/components/Validation';
 
 import { HelperTextLine } from '../FieldInput/FieldInput';
@@ -49,14 +49,21 @@ export type FieldTextAreaProps = BoxProps & {
   onBlur?: React.FocusEventHandler<HTMLInputElement>;
   readonly?: boolean;
   defaultValue?: string;
-  toolTipContent?: React.ReactNode;
+  tooltipContent?: React.ReactNode;
+  tooltipSticky?: boolean;
   disabled?: boolean;
-  // markAsError is a flag to highlight an
-  // input box as error color before validator
-  // runs (which marks it as error)
+  /**
+   * Highlights the text area with error color before validator runs (which
+   * marks it as error)
+   */
   markAsError?: boolean;
   textAreaCss?: string;
   resizable?: boolean;
+  /**
+   * Adds a `required` attribute to the underlying text area and adds a
+   * required field indicator to the label.
+   */
+  required?: boolean;
 };
 
 export const FieldTextArea = forwardRef<
@@ -83,11 +90,13 @@ export const FieldTextArea = forwardRef<
       autoComplete = 'off',
       spellCheck,
       readonly = false,
-      toolTipContent = null,
+      tooltipContent = null,
+      tooltipSticky = false,
       disabled = false,
       markAsError = false,
       resizable = true,
       textAreaCss,
+      required,
       ...styles
     },
     ref
@@ -127,23 +136,14 @@ export const FieldTextArea = forwardRef<
       <Box mb="3" {...styles}>
         {label ? (
           <LabelInput mb={0}>
-            <Box mb={1}>
-              {toolTipContent ? (
-                <>
-                  <span
-                    css={{
-                      marginRight: '4px',
-                      verticalAlign: 'middle',
-                    }}
-                  >
-                    {label}
-                  </span>
-                  <IconTooltip children={toolTipContent} />
-                </>
-              ) : (
-                <>{label}</>
-              )}
-            </Box>
+            <LabelContent
+              required={required}
+              tooltipContent={tooltipContent}
+              tooltipSticky={tooltipSticky}
+              mb={1}
+            >
+              {label}
+            </LabelContent>
             {$textAreaElement}
           </LabelInput>
         ) : (

--- a/web/packages/teleport/src/Bots/Add/GitHubActions/ConfigureBot.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActions/ConfigureBot.tsx
@@ -146,7 +146,7 @@ export function ConfigureBot({ nextStep, prevStep }: FlowStepProps) {
                 }
                 disableBtns={isLoading}
                 inputWidth={350}
-                areLabelsRequired={true}
+                required={true}
                 labelKey={{
                   fieldName: 'Label for Resources the User Can Access',
                   placeholder: 'label key',

--- a/web/packages/teleport/src/components/LabelsInput/LabelsInput.story.tsx
+++ b/web/packages/teleport/src/components/LabelsInput/LabelsInput.story.tsx
@@ -102,9 +102,10 @@ export const AtLeastOneRequired = () => {
   return (
     <Validation>
       <LabelsInput
+        legend="Labels"
         labels={labels}
         setLabels={setLables}
-        areLabelsRequired={true}
+        required={true}
       />
     </Validation>
   );

--- a/web/packages/teleport/src/components/LabelsInput/LabelsInput.test.tsx
+++ b/web/packages/teleport/src/components/LabelsInput/LabelsInput.test.tsx
@@ -29,12 +29,15 @@ import {
   Disabled,
 } from './LabelsInput.story';
 
+/** Marks asterisks in the required column headings. */
+const requiredMarkRegexp = /\*/;
+
 test('defaults, with empty labels', async () => {
   render(<Default />);
 
   expect(screen.queryByText(/key/i)).not.toBeInTheDocument();
   expect(screen.queryByText(/value/i)).not.toBeInTheDocument();
-  expect(screen.queryByText(/required field/i)).not.toBeInTheDocument();
+  expect(screen.queryByText(requiredMarkRegexp)).not.toBeInTheDocument();
   expect(screen.queryByPlaceholderText('label key')).not.toBeInTheDocument();
   expect(screen.queryByPlaceholderText('label value')).not.toBeInTheDocument();
 
@@ -42,7 +45,7 @@ test('defaults, with empty labels', async () => {
 
   expect(screen.getByText(/key/i)).toBeInTheDocument();
   expect(screen.getByText(/value/i)).toBeInTheDocument();
-  expect(screen.getAllByText(/required field/i)).toHaveLength(2);
+  expect(screen.getAllByText(requiredMarkRegexp)).toHaveLength(2);
   expect(screen.getByPlaceholderText('label key')).toBeInTheDocument();
   expect(screen.getByPlaceholderText('label value')).toBeInTheDocument();
   expect(screen.getByTitle(/remove label/i)).toBeInTheDocument();
@@ -61,7 +64,7 @@ test('with custom texts', async () => {
 
   expect(screen.getByText(/custom key name/i)).toBeInTheDocument();
   expect(screen.getByText(/custom value/i)).toBeInTheDocument();
-  expect(screen.getAllByText(/required field/i)).toHaveLength(2);
+  expect(screen.getAllByText(requiredMarkRegexp)).toHaveLength(2);
   expect(
     screen.getByPlaceholderText('custom key placeholder')
   ).toBeInTheDocument();

--- a/web/packages/teleport/src/components/LabelsInput/LabelsInput.tsx
+++ b/web/packages/teleport/src/components/LabelsInput/LabelsInput.tsx
@@ -18,10 +18,10 @@
 
 import styled from 'styled-components';
 
-import { Box, ButtonIcon, ButtonSecondary, Flex, Text } from 'design';
+import { Box, ButtonIcon, ButtonSecondary, Flex } from 'design';
 import * as Icons from 'design/Icon';
 import { inputGeometry } from 'design/Input/Input';
-import { IconTooltip } from 'design/Tooltip';
+import { LabelContent } from 'design/LabelInput/LabelInput';
 import FieldInput from 'shared/components/FieldInput';
 import {
   useRule,
@@ -66,11 +66,12 @@ export type LabelsRule = Rule<Label[], LabelListValidationResult>;
 export function LabelsInput({
   legend,
   tooltipContent,
+  tooltipSticky,
   labels = [],
   setLabels,
   disableBtns = false,
   autoFocus = false,
-  areLabelsRequired = false,
+  required = false,
   adjective = 'Label',
   labelKey = { fieldName: 'Key', placeholder: 'label key' },
   labelVal = { fieldName: 'Value', placeholder: 'label value' },
@@ -79,6 +80,7 @@ export function LabelsInput({
 }: {
   legend?: string;
   tooltipContent?: string;
+  tooltipSticky?: boolean;
   labels: Label[];
   setLabels(l: Label[]): void;
   disableBtns?: boolean;
@@ -90,7 +92,7 @@ export function LabelsInput({
   /**
    * Makes it so at least one label is required
    */
-  areLabelsRequired?: boolean;
+  required?: boolean;
   /**
    * A rule for validating the list of labels as a whole. Note that contrary to
    * other input fields, the labels input will default to validating every
@@ -106,7 +108,7 @@ export function LabelsInput({
   }
 
   function removeLabel(index: number) {
-    if (areLabelsRequired && labels.length === 1) {
+    if (required && labels.length === 1) {
       // Since at least one label is required
       // instead of removing the last row, clear
       // the input and turn on error.
@@ -149,31 +151,21 @@ export function LabelsInput({
     <Fieldset>
       {legend && (
         <Legend>
-          {tooltipContent ? (
-            <>
-              <span
-                css={{
-                  marginRight: '4px',
-                  verticalAlign: 'middle',
-                }}
-              >
-                {legend}
-              </span>
-              <IconTooltip children={tooltipContent} />
-            </>
-          ) : (
-            legend
-          )}
+          <LabelContent
+            required={required}
+            tooltipContent={tooltipContent}
+            tooltipSticky={tooltipSticky}
+          >
+            {legend}
+          </LabelContent>
         </Legend>
       )}
       {labels.length > 0 && (
         <Flex mt={legend ? 1 : 0} mb={1}>
           <Box width={width} mr="3">
-            <Text typography="body3">
-              {labelKey.fieldName} (required field)
-            </Text>
+            <LabelContent required>{labelKey.fieldName}</LabelContent>
           </Box>
-          <Text typography="body3">{labelVal.fieldName} (required field)</Text>
+          <LabelContent required>{labelVal.fieldName}</LabelContent>
         </Flex>
       )}
       <Box>

--- a/web/packages/teleterm/src/ui/DocumentGatewayApp/AppGateway.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGatewayApp/AppGateway.tsx
@@ -34,11 +34,13 @@ import {
   disappear,
   Flex,
   H1,
+  LabelInput,
   Link,
   rotate360,
   Text,
 } from 'design';
 import { Check, Spinner } from 'design/Icon';
+import { LabelContent } from 'design/LabelInput/LabelInput';
 import { Gateway } from 'gen-proto-ts/teleport/lib/teleterm/v1/gateway_pb';
 import { LoginItem, MenuLogin } from 'shared/components/MenuLogin';
 import { TextSelectCopy } from 'shared/components/TextSelectCopy';
@@ -186,31 +188,30 @@ export function AppGateway(props: {
 
         <Flex as="form" gap={2}>
           <Validation>
-            <PortFieldInput
-              label={
-                <LabelWithAttemptStatus
-                  text="Local Port"
-                  attempt={changeLocalPortAttempt}
-                />
-              }
-              defaultValue={gateway.localPort}
-              onChange={handleLocalPortChange}
-              mb={0}
-            />
-            {isMultiPort && (
+            <LabelWithAttemptStatus
+              text="Local Port"
+              attempt={changeLocalPortAttempt}
+            >
               <PortFieldInput
-                label={
-                  <LabelWithAttemptStatus
-                    text="Target Port"
-                    attempt={changeTargetPortAttempt}
-                  />
-                }
-                required
-                defaultValue={gateway.targetSubresourceName}
-                onChange={handleTargetPortChange}
+                defaultValue={gateway.localPort}
+                onChange={handleLocalPortChange}
                 mb={0}
-                ref={targetPortRef}
               />
+            </LabelWithAttemptStatus>
+            {isMultiPort && (
+              <LabelWithAttemptStatus
+                text="Target Port"
+                attempt={changeTargetPortAttempt}
+                required
+              >
+                <PortFieldInput
+                  required
+                  defaultValue={gateway.targetSubresourceName}
+                  onChange={handleTargetPortChange}
+                  mb={0}
+                  ref={targetPortRef}
+                />
+              </LabelWithAttemptStatus>
             )}
           </Validation>
         </Flex>
@@ -256,35 +257,49 @@ export function AppGateway(props: {
   );
 }
 
-const LabelWithAttemptStatus = (props: {
-  text: string;
-  attempt: Attempt<unknown>;
-}) => (
-  <Flex
-    alignItems="center"
-    justifyContent="space-between"
+const LabelWithAttemptStatus = (
+  props: PropsWithChildren<{
+    text: string;
+    attempt: Attempt<unknown>;
+    required?: boolean;
+  }>
+) => (
+  <LabelInput
+    mb={0}
     css={`
-      position: relative;
+      width: fit-content;
     `}
   >
-    {props.text}
-    {props.attempt.status === 'processing' && (
-      <AnimatedSpinner color="interactive.tonal.neutral.2" size="small" />
-    )}
-    {props.attempt.status === 'success' && (
-      // CSS animations are repeated whenever the parent goes from `display: none` to something
-      // else. As a result, we need to unmount the animated check so that the animation is not
-      // repeated when the user switches to this tab.
-      // https://www.w3.org/TR/css-animations-1/#example-4e34d7ba
-      <UnmountAfter timeoutMs={disappearanceDelayMs + disappearanceDurationMs}>
-        <DisappearingCheck
-          color="success.main"
-          size="small"
-          title={`${props.text} successfully updated`}
-        />
-      </UnmountAfter>
-    )}
-  </Flex>
+    <Flex
+      alignItems="center"
+      justifyContent="space-between"
+      mb={1}
+      css={`
+        position: relative;
+      `}
+    >
+      <LabelContent required={props.required}>{props.text}</LabelContent>
+      {props.attempt.status === 'processing' && (
+        <AnimatedSpinner color="interactive.tonal.neutral.2" size="small" />
+      )}
+      {props.attempt.status === 'success' && (
+        // CSS animations are repeated whenever the parent goes from `display: none` to something
+        // else. As a result, we need to unmount the animated check so that the animation is not
+        // repeated when the user switches to this tab.
+        // https://www.w3.org/TR/css-animations-1/#example-4e34d7ba
+        <UnmountAfter
+          timeoutMs={disappearanceDelayMs + disappearanceDurationMs}
+        >
+          <DisappearingCheck
+            color="success.main"
+            size="small"
+            title={`${props.text} successfully updated`}
+          />
+        </UnmountAfter>
+      )}
+    </Flex>
+    {props.children}
+  </LabelInput>
 );
 
 /**

--- a/web/packages/teleterm/src/ui/DocumentGatewayApp/DocumentGatewayApp.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGatewayApp/DocumentGatewayApp.test.tsx
@@ -153,13 +153,13 @@ describe('reconnecting when the gateway fails to be created', () => {
       await screen.findByText('Could not establish the connection')
     ).toBeInTheDocument();
 
-    const targetPortInput = screen.getByLabelText('Target Port');
+    const targetPortInput = screen.getByLabelText('Target Port *');
     await user.clear(targetPortInput);
     await user.type(targetPortInput, '4242');
     await user.click(screen.getByText('Reconnect'));
 
     expect(await screen.findByText('Close Connection')).toBeInTheDocument();
-    expect(screen.getByLabelText('Target Port')).toHaveValue(4242);
+    expect(screen.getByLabelText('Target Port *')).toHaveValue(4242);
 
     expect(appContext.tshd.createGateway).toHaveBeenLastCalledWith(
       expect.objectContaining({

--- a/web/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.test.tsx
+++ b/web/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.test.tsx
@@ -70,7 +70,7 @@ test('updating target port creates new connection', async () => {
   expect(conn1337.title).toEqual(`${app.name}:1337`);
 
   // Update target port.
-  let targetPortInput = screen.getByLabelText('Target Port');
+  let targetPortInput = screen.getByLabelText('Target Port *');
   await user.clear(targetPortInput);
   await user.type(targetPortInput, '4242');
   // We have to lose focus of that field, otherwise React is going to warn about updates not wrapped
@@ -154,7 +154,7 @@ test('updating target port to match connection params of gateway created by othe
   expect(ctx.connectionTracker.findConnection(conn1337Id).connected).toBe(true);
 
   // Update target port from 1337 to 4242.
-  let targetPortInput = screen.getByLabelText('Target Port');
+  let targetPortInput = screen.getByLabelText('Target Port *');
   await user.clear(targetPortInput);
   await user.type(targetPortInput, '4242');
   await user.tab();


### PR DESCRIPTION
This PR unifies the way we display labels across different types of input fields and adds consistent support for required field markers and info tooltips. Actually reusing these in places where fields are created manually, circumventing the built-in input fields, is not in the scope.

![Screenshot 2025-02-20 at 10 53 16](https://github.com/user-attachments/assets/8408b912-8717-4787-bb8c-786120e70221)
![Screenshot 2025-02-20 at 10 53 39](https://github.com/user-attachments/assets/76189de2-ae9b-41f1-bc56-4351c49e0f79)
![Screenshot 2025-02-20 at 10 53 48](https://github.com/user-attachments/assets/2c98f066-e2f2-4e23-b5ee-a064e636c916)
![Screenshot 2025-02-20 at 11 12 59](https://github.com/user-attachments/assets/59bed10f-5ccc-4b7a-a662-4795dee48c6b)

Tested:
- in Storybook
- in the role editor (with a follow-up PR that applies these to selected fields)
- app connection UI in teleterm

Contributes to https://github.com/gravitational/teleport/issues/52036
Followed up by https://github.com/gravitational/teleport/pull/52345