### PR TITLE
Escape labels on Node Join scripts

### DIFF
--- a/lib/web/scripts/install_node.go
+++ b/lib/web/scripts/install_node.go
@@ -114,6 +114,10 @@ func GetNodeInstallScript(ctx context.Context, opts InstallNodeScriptOptions) (s
 	// Computing service configuration-related values
 	labelsList := []string{}
 	for labelKey, labelValues := range opts.Labels {
+		labelKey = shsprintf.EscapeDefaultContext(labelKey)
+		for i := range labelValues {
+			labelValues[i] = shsprintf.EscapeDefaultContext(labelValues[i])
+		}
 		labels := strings.Join(labelValues, " ")
 		labelsList = append(labelsList, fmt.Sprintf("%s=%s", labelKey, labels))
 	}
@@ -155,7 +159,7 @@ func GetNodeInstallScript(ctx context.Context, opts InstallNodeScriptOptions) (s
 	// This section relies on Go's default zero values to make sure that the settings
 	// are correct when not installing an app.
 	err = installNodeBashScript.Execute(&buf, map[string]interface{}{
-		"token":    opts.Token,
+		"token":    shsprintf.EscapeDefaultContext(opts.Token),
 		"hostname": hostname,
 		"port":     portStr,
 		// The install.sh script has some manually generated configs and some

--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -58,7 +58,7 @@ JOIN_METHOD_FLAG=""
 [ -n "$JOIN_METHOD" ] && JOIN_METHOD_FLAG="--join-method ${JOIN_METHOD}"
 
 # inject labels into the configuration
-LABELS='{{.labels}}'
+LABELS="{{.labels}}"
 LABELS_FLAG=()
 [ -n "$LABELS" ] && LABELS_FLAG=(--labels "${LABELS}")
 
@@ -479,6 +479,10 @@ app_service:
   - name: "${APP_NAME}"
     uri: "${APP_URI}"
     public_addr: ${APP_PUBLIC_ADDR}
+EOF
+
+    # Quoting the EOF heredoc indicates to shell to treat this as a literal string and does not try to interpolate or execute anything.
+    cat << "EOF" >> ${TELEPORT_CONFIG_PATH}
     labels:{{range $index, $line := .appServerResourceLabels}}
       {{$line -}}
 {{end}}
@@ -513,6 +517,10 @@ proxy_service:
 db_service:
   enabled: "yes"
   resources:
+EOF
+
+    # Quoting the EOF heredoc indicates to shell to treat this as a literal string and does not try to interpolate or execute anything.
+    cat << "EOF" >> ${TELEPORT_CONFIG_PATH}
     - labels:{{range $index, $line := .db_service_resource_labels}}
         {{$line -}}
 {{end}}


### PR DESCRIPTION
Fixes: https://github.com/gravitational/teleport-private/issues/1883

changelog: Escape user provided labels when creating the shell script that enrolls servers, applications and databases into Teleport.

Enrolling new servers using the UI (`Enroll new resource` button), generates a script that installs teleport into the machine and enrolls it into teleport.
We now support adding labels to this script, so that when the teleport service presents itself to the cluster, it will advertise those labels.

However, those labels were added into the script without escaping their values.

This PR changes 3 places where user input data was being used:
- when installing the node, it runs `teleport node configure --labels <labels>`
- when installing as a Application Service, it would put the labels in the `teleport.yaml` file
- when installing as a Database Service, it would put the labels as resource label matchers in the `teleport.yaml` file

The source of the first two installation modes (node and app service), labels are sourced from `Token.Spec.SuggestedLabels`.
For the Database Service installation mode, labels are sourced from `Token.Spec.SuggestedAgentMatcherLabels`.

For the node, the labels are now escaped before being added into the `teleport node configure --labels` command.

For the Application and Database installation modes, we keep using the same method we were using but now prevent any escape from the expected flow by creating a new HEREDOC using a quoted starting identifier (`"EOF"`), which prevents any interpolation of the HEREDOC contents.

---

I think we should be more strict about the labels we accept in the first place, but I'll not add those checks here to keep the PR as specific as possible.

Example A
When the `teleport node configure --labels x=y` is called, teleport will validate the labels using [`client.ParseLabelSpec`](https://github.com/gravitational/teleport/blob/62c28bb69248acf945d3a3df1684ac9aab8ab4b8/lib/client/api.go#L4935) which might return invalid even tho the labels were set as SuggestedLabels.

Example B
Even if the `teleport.yaml` was generated using `teleport node configure --labels x=y` it might be the case that the label is invalid.
There's a validation using [`types.IsValidLabelKey`](https://github.com/gravitational/teleport/blob/62c28bb69248acf945d3a3df1684ac9aab8ab4b8/api/types/resource.go#L539), which is different from the above.