### PR TITLE
Workload Identity Revocations Signing

### DIFF
--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -5295,7 +5295,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		Emitter:             cfg.Emitter,
 		Clock:               cfg.AuthServer.GetClock(),
 		Store:               cfg.AuthServer.Services.WorkloadIdentityX509Revocations,
-		KeyStorer:           cfg.AuthServer.keyStore,
+		KeyStore:            cfg.AuthServer.keyStore,
 		CertAuthorityGetter: cfg.AuthServer.Cache,
 		EventsWatcher:       cfg.AuthServer.Services,
 		ClusterName:         clusterName.GetClusterName(),

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -5304,6 +5304,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		return nil, trace.Wrap(err, "creating workload identity revocation service")
 	}
 	workloadidentityv1pb.RegisterWorkloadIdentityRevocationServiceServer(server, workloadIdentityRevocationService)
+	go workloadIdentityRevocationService.RunCRLSigner(cfg.AuthServer.CloseContext())
 
 	dbObjectImportRuleService, err := dbobjectimportrulev1.NewDatabaseObjectImportRuleService(dbobjectimportrulev1.DatabaseObjectImportRuleServiceConfig{
 		Authorizer: cfg.Authorizer,

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -5291,10 +5291,13 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	workloadidentityv1pb.RegisterWorkloadIdentityIssuanceServiceServer(server, workloadIdentityIssuanceService)
 
 	workloadIdentityRevocationService, err := workloadidentityv1.NewRevocationService(&workloadidentityv1.RevocationServiceConfig{
-		Authorizer: cfg.Authorizer,
-		Emitter:    cfg.Emitter,
-		Clock:      cfg.AuthServer.GetClock(),
-		Store:      cfg.AuthServer.Services.WorkloadIdentityX509Revocations,
+		Authorizer:          cfg.Authorizer,
+		Emitter:             cfg.Emitter,
+		Clock:               cfg.AuthServer.GetClock(),
+		Store:               cfg.AuthServer.Services.WorkloadIdentityX509Revocations,
+		KeyStorer:           cfg.AuthServer.keyStore,
+		CertAuthorityGetter: cfg.AuthServer.Cache,
+		EventsWatcher:       cfg.AuthServer.Services,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "creating workload identity issuance service")

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -5298,9 +5298,10 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		KeyStorer:           cfg.AuthServer.keyStore,
 		CertAuthorityGetter: cfg.AuthServer.Cache,
 		EventsWatcher:       cfg.AuthServer.Services,
+		ClusterName:         clusterName.GetClusterName(),
 	})
 	if err != nil {
-		return nil, trace.Wrap(err, "creating workload identity issuance service")
+		return nil, trace.Wrap(err, "creating workload identity revocation service")
 	}
 	workloadidentityv1pb.RegisterWorkloadIdentityRevocationServiceServer(server, workloadIdentityRevocationService)
 

--- a/lib/auth/machineid/workloadidentityv1/revocation_service.go
+++ b/lib/auth/machineid/workloadidentityv1/revocation_service.go
@@ -132,6 +132,8 @@ func NewRevocationService(cfg *RevocationServiceConfig) (*RevocationService, err
 		certAuthorityGetter: cfg.CertAuthorityGetter,
 		keyStorer:           cfg.KeyStorer,
 		eventsWatcher:       cfg.EventsWatcher,
+
+		notifyNewSignedCRL: make(chan struct{}),
 	}, nil
 }
 

--- a/lib/auth/machineid/workloadidentityv1/revocation_service.go
+++ b/lib/auth/machineid/workloadidentityv1/revocation_service.go
@@ -71,9 +71,9 @@ type RevocationServiceConfig struct {
 	// ClusterName is the name of the cluster that the service is running in,
 	// used to fetch the correct CA for signing the CRL.
 	ClusterName string
-	// KeyStorer is the key storer used to store and retrieve keys for the
+	// KeyStore is the key storer used to store and retrieve keys for the
 	// signing of the CRL.
-	KeyStorer KeyStorer
+	KeyStore KeyStorer
 }
 
 // RevocationService is the gRPC service for managing workload identity
@@ -88,7 +88,7 @@ type RevocationService struct {
 	emitter             apievents.Emitter
 	logger              *slog.Logger
 	certAuthorityGetter certAuthorityGetter
-	keyStorer           KeyStorer
+	keyStore            KeyStorer
 	clusterName         string
 	eventsWatcher       eventsWatcher
 
@@ -114,7 +114,7 @@ func NewRevocationService(cfg *RevocationServiceConfig) (*RevocationService, err
 		return nil, trace.BadParameter("emitter is required")
 	case cfg.ClusterName == "":
 		return nil, trace.BadParameter("cluster name is required")
-	case cfg.KeyStorer == nil:
+	case cfg.KeyStore == nil:
 		return nil, trace.BadParameter("key storer is required")
 	case cfg.EventsWatcher == nil:
 		return nil, trace.BadParameter("events watcher is required")
@@ -134,7 +134,7 @@ func NewRevocationService(cfg *RevocationServiceConfig) (*RevocationService, err
 		logger:              cfg.Logger,
 		clusterName:         cfg.ClusterName,
 		certAuthorityGetter: cfg.CertAuthorityGetter,
-		keyStorer:           cfg.KeyStorer,
+		keyStore:            cfg.KeyStore,
 		eventsWatcher:       cfg.EventsWatcher,
 		crlSigningDebounce:  5 * time.Second,
 		crlFailureBackoff:   30 * time.Second,
@@ -594,7 +594,7 @@ func (s *RevocationService) signCRL(
 	if err != nil {
 		return nil, trace.Wrap(err, "getting CA")
 	}
-	tlsCert, tlsSigner, err := s.keyStorer.GetTLSCertAndSigner(ctx, ca)
+	tlsCert, tlsSigner, err := s.keyStore.GetTLSCertAndSigner(ctx, ca)
 	if err != nil {
 		return nil, trace.Wrap(err, "getting CA cert and key")
 	}

--- a/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
+++ b/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
@@ -3099,7 +3099,7 @@ func TestRevocationService_CRL(t *testing.T) {
 	// Create new revocations
 	createRevocation(t, "ff")
 	createRevocation(t, "aa")
-	require.NoError(t, fakeClock.BlockUntilContext(ctx, 1))
+	require.NoError(t, fakeClock.BlockUntilContext(ctx, 2))
 	t.Log("Advancing fake clock to pass debounce period")
 	fakeClock.Advance(6 * time.Second)
 	// The client should now receive a new CRL
@@ -3119,7 +3119,7 @@ func TestRevocationService_CRL(t *testing.T) {
 	// Add another revocation, delete one revocation
 	createRevocation(t, "bb")
 	deleteRevocation(t, "aa")
-	require.NoError(t, fakeClock.BlockUntilContext(ctx, 1))
+	require.NoError(t, fakeClock.BlockUntilContext(ctx, 2))
 	t.Log("Advancing fake clock to pass debounce period")
 	fakeClock.Advance(6 * time.Second)
 	// The client should now receive a new CRL
@@ -3139,10 +3139,17 @@ func TestRevocationService_CRL(t *testing.T) {
 	// Delete all remaining CRL
 	deleteRevocation(t, "bb")
 	deleteRevocation(t, "ff")
-	require.NoError(t, fakeClock.BlockUntilContext(ctx, 1))
+	require.NoError(t, fakeClock.BlockUntilContext(ctx, 2))
 	t.Log("Advancing fake clock to pass debounce period")
 	fakeClock.Advance(6 * time.Second)
 	// The client should now receive a new CRL
+	res, err = stream.Recv()
+	require.NoError(t, err)
+	checkCRL(t, res.Crl, nil)
+
+	// Wait ten minutes to see if the periodic CRL is sent.
+	t.Log("Advancing fake clock to pass the periodic timer")
+	fakeClock.Advance(11 * time.Minute)
 	res, err = stream.Recv()
 	require.NoError(t, err)
 	checkCRL(t, res.Crl, nil)

--- a/lib/tbot/config/service_spiffe_svid.go
+++ b/lib/tbot/config/service_spiffe_svid.go
@@ -38,6 +38,7 @@ const (
 	SVIDPEMPath            = "svid.pem"
 	SVIDKeyPEMPath         = "svid_key.pem"
 	SVIDTrustBundlePEMPath = "svid_bundle.pem"
+	SVIDCRLPemPath         = "svid_crl.pem"
 )
 
 // SVIDRequestSANs is the configuration for the SANs of a single SVID request.

--- a/lib/tbot/config/service_workload_identity_x509.go
+++ b/lib/tbot/config/service_workload_identity_x509.go
@@ -110,6 +110,9 @@ func (o *WorkloadIdentityX509Service) Describe() []FileDescription {
 		{
 			Name: SVIDTrustBundlePEMPath,
 		},
+		{
+			Name: SVIDCRLPemPath,
+		},
 	}
 	return fds
 }

--- a/lib/tbot/service_workload_identity_api.go
+++ b/lib/tbot/service_workload_identity_api.go
@@ -334,7 +334,6 @@ func (s *WorkloadIdentityAPIService) FetchX509SVID(
 			FederatedBundles: bundleSet.EncodedX509Bundles(false),
 		}
 		if len(crlSet.LocalCRL) > 0 {
-			// TODO: Copy?
 			resp.Crl = [][]byte{crlSet.LocalCRL}
 		}
 
@@ -406,7 +405,6 @@ func (s *WorkloadIdentityAPIService) FetchX509Bundles(
 			Bundles: bundleSet.EncodedX509Bundles(true),
 		}
 		if len(crlSet.LocalCRL) > 0 {
-			// TODO: Copy?
 			resp.Crl = [][]byte{crlSet.LocalCRL}
 		}
 		err = srv.Send(resp)

--- a/lib/tbot/service_workload_identity_api.go
+++ b/lib/tbot/service_workload_identity_api.go
@@ -418,7 +418,9 @@ func (s *WorkloadIdentityAPIService) FetchX509Bundles(
 		case <-ctx.Done():
 			return nil
 		case <-bundleSet.Stale():
+			s.log.DebugContext(ctx, "Trust bundle set has been updated, distributing to client")
 		case <-crlSet.Stale():
+			s.log.DebugContext(ctx, "CRL set has been updated, distributing to client")
 		}
 	}
 }

--- a/lib/tbot/service_workload_identity_api_test.go
+++ b/lib/tbot/service_workload_identity_api_test.go
@@ -171,7 +171,7 @@ func TestBotWorkloadIdentityAPI(t *testing.T) {
 	_, err = jwtsvid.ParseAndValidate(jwtSVID.Marshal(), jwtBundles, []string{"example.com"})
 	require.NoError(t, err)
 
-	// Check CSR is delivered - we have to manually craft the client for this
+	// Check CRL is delivered - we have to manually craft the client for this
 	// since the current go-spiffe SDK doesn't support this.
 	// TODO(noah): I'll raise some changes upstream to add CSR field support to
 	// the go-spiffe SDK, and then we can remove this code.

--- a/lib/tbot/service_workload_identity_api_test.go
+++ b/lib/tbot/service_workload_identity_api_test.go
@@ -189,7 +189,7 @@ func TestBotWorkloadIdentityAPI(t *testing.T) {
 	require.Len(t, resp.Crl, 1)
 	crl, err := x509.ParseRevocationList(resp.Crl[0])
 	require.NoError(t, err)
-	require.Len(t, crl.RevokedCertificateEntries, 0)
+	require.Empty(t, crl.RevokedCertificateEntries)
 	tb, ok := set.Get(svid.ID.TrustDomain())
 	require.True(t, ok)
 	require.NoError(t, crl.CheckSignatureFrom(tb.X509Authorities()[0]))

--- a/lib/tbot/service_workload_identity_api_test.go
+++ b/lib/tbot/service_workload_identity_api_test.go
@@ -18,6 +18,7 @@ package tbot
 
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
 	"net/url"
 	"os"
@@ -25,11 +26,14 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/spiffe/go-spiffe/v2/proto/spiffe/workload"
 	"github.com/spiffe/go-spiffe/v2/svid/jwtsvid"
 	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
 	"github.com/spiffe/go-spiffe/v2/workloadapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
@@ -166,4 +170,27 @@ func TestBotWorkloadIdentityAPI(t *testing.T) {
 	require.NoError(t, err)
 	_, err = jwtsvid.ParseAndValidate(jwtSVID.Marshal(), jwtBundles, []string{"example.com"})
 	require.NoError(t, err)
+
+	// Check CSR is delivered - we have to manually craft the client for this
+	// since the current go-spiffe SDK doesn't support this.
+	// TODO(noah): I'll raise some changes upstream to add CSR field support to
+	// the go-spiffe SDK, and then we can remove this code.
+	conn, err := grpc.NewClient(
+		listenAddr.String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	spiffeWorkloadAPI := workload.NewSpiffeWorkloadAPIClient(conn)
+	stream, err := spiffeWorkloadAPI.FetchX509SVID(ctx, &workload.X509SVIDRequest{})
+	require.NoError(t, err)
+
+	resp, err := stream.Recv()
+	require.NoError(t, err)
+	require.Len(t, resp.Crl, 1)
+	crl, err := x509.ParseRevocationList(resp.Crl[0])
+	require.NoError(t, err)
+	require.Len(t, crl.RevokedCertificateEntries, 0)
+	tb, ok := set.Get(svid.ID.TrustDomain())
+	require.True(t, ok)
+	require.NoError(t, crl.CheckSignatureFrom(tb.X509Authorities()[0]))
 }

--- a/lib/tbot/service_workload_identity_api_test.go
+++ b/lib/tbot/service_workload_identity_api_test.go
@@ -173,7 +173,7 @@ func TestBotWorkloadIdentityAPI(t *testing.T) {
 
 	// Check CRL is delivered - we have to manually craft the client for this
 	// since the current go-spiffe SDK doesn't support this.
-	// TODO(noah): I'll raise some changes upstream to add CSR field support to
+	// TODO(noah): I'll raise some changes upstream to add CRL field support to
 	// the go-spiffe SDK, and then we can remove this code.
 	conn, err := grpc.NewClient(
 		listenAddr.String(),

--- a/lib/tbot/service_workload_identity_x509.go
+++ b/lib/tbot/service_workload_identity_x509.go
@@ -131,7 +131,7 @@ func (s *WorkloadIdentityX509Service) Run(ctx context.Context) error {
 			if err != nil {
 				return trace.Wrap(err, "getting trust bundle set")
 			}
-			s.log.InfoContext(ctx, "Trust bundle set has been updated")
+			s.log.InfoContext(ctx, "Trust bundle set has been updated, will regenerate output")
 			if !newBundleSet.Local.Equal(bundleSet.Local) {
 				// If the local trust domain CA has changed, we need to reissue
 				// the SVID.
@@ -145,7 +145,7 @@ func (s *WorkloadIdentityX509Service) Run(ctx context.Context) error {
 				return trace.Wrap(err, "getting CRL set from cache")
 			}
 			crlSet = newCRLSet
-			s.log.DebugContext(ctx, "CRL set has been updated")
+			s.log.DebugContext(ctx, "CRL set has been updated, will regenerate output")
 		case <-time.After(cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime).RenewalInterval):
 			s.log.InfoContext(ctx, "Renewal interval reached, renewing SVIDs")
 			x509Cred = nil

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -304,6 +304,25 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 		services = append(services, trustBundleCache)
 		return trustBundleCache, nil
 	}
+	var crlCache *workloadidentity.CRLCache
+	setupCRLCache := func() (*workloadidentity.CRLCache, error) {
+		if crlCache != nil {
+			return crlCache, nil
+		}
+
+		var err error
+		crlCache, err = workloadidentity.NewCRLCache(workloadidentity.CRLCacheConfig{
+			RevocationsClient: b.botIdentitySvc.GetClient().WorkloadIdentityRevocationServiceClient(),
+			Logger: b.log.With(
+				teleport.ComponentKey, teleport.Component(componentTBot, "crl-cache"),
+			),
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		services = append(services, crlCache)
+		return crlCache, nil
+	}
 
 	// Append any services configured by the user
 	for _, svcCfg := range b.cfg.Services {
@@ -527,6 +546,11 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 					return trace.Wrap(err)
 				}
 				svc.trustBundleCache = tbCache
+				crlCache, err := setupCRLCache()
+				if err != nil {
+					return trace.Wrap(err)
+				}
+				svc.crlCache = crlCache
 			}
 			services = append(services, svc)
 		case *config.WorkloadIdentityJWTService:
@@ -568,6 +592,10 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 			if err != nil {
 				return trace.Wrap(err)
 			}
+			crlCache, err := setupCRLCache()
+			if err != nil {
+				return trace.Wrap(err)
+			}
 
 			svc := &WorkloadIdentityAPIService{
 				svcIdentity:      clientCredential,
@@ -575,6 +603,7 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 				cfg:              svcCfg,
 				resolver:         resolver,
 				trustBundleCache: tbCache,
+				crlCache:         crlCache,
 			}
 			svc.log = b.log.With(
 				teleport.ComponentKey, teleport.Component(componentTBot, "svc", svc.String()),

--- a/lib/tbot/workloadidentity/crl_cache.go
+++ b/lib/tbot/workloadidentity/crl_cache.go
@@ -1,0 +1,173 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package workloadidentity
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
+)
+
+type CRLSet struct {
+	LocalCRL []byte
+	stale    chan struct{}
+}
+
+// Clone returns a deep copy of the CRLSet.
+func (b *CRLSet) Clone() *CRLSet {
+	clone := &CRLSet{}
+	if b.LocalCRL != nil {
+		clone.LocalCRL = make([]byte, len(b.LocalCRL))
+		copy(clone.LocalCRL, b.LocalCRL)
+	}
+	return clone
+}
+
+// Stale returns a channel that will be closed when the CRLSet is stale
+// and a new CRLSet is available.
+func (b *CRLSet) Stale() <-chan struct{} {
+	return b.stale
+}
+
+type CRLCache struct {
+	revocationsClient workloadidentityv1pb.WorkloadIdentityRevocationServiceClient
+	logger            *slog.Logger
+
+	mu     sync.Mutex
+	crlSet *CRLSet
+	// initialized will close when the cache is fully initialized.
+	initialized chan struct{}
+}
+
+// String returns a string representation of the CRLCache. Implements the
+// tbot Service interface and fmt.Stringer interface.
+func (m *CRLCache) String() string {
+	return "crl-cache"
+}
+
+func (m *CRLCache) Run(ctx context.Context) error {
+	for {
+		m.logger.InfoContext(
+			ctx,
+			"Initializing cache",
+		)
+		if err := m.watch(ctx); err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			// TODO(noah): DELETE IN V19 once CRL streaming functionality is
+			// available on all supported versions.
+			if trace.IsNotImplemented(err) {
+				m.logger.WarnContext(
+					ctx, "Server does not support X509 CRL functionality",
+				)
+				// Set empty CRL set so consumers are unblocked.
+				m.setCRLSet(ctx, &CRLSet{})
+				return nil
+			}
+			m.logger.ErrorContext(
+				ctx,
+				"Cache failed, will attempt to re-initialize after back off",
+				"error", err,
+				"backoff", trustBundleInitFailureBackoff,
+			)
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(trustBundleInitFailureBackoff):
+			continue
+		}
+	}
+}
+
+func (m *CRLCache) watch(ctx context.Context) error {
+	stream, err := m.revocationsClient.StreamSignedCRL(
+		ctx, &workloadidentityv1pb.StreamSignedCRLRequest{},
+	)
+	if err != nil {
+		return trace.Wrap(err, "streaming CRL")
+	}
+
+	for {
+		res, err := stream.Recv()
+		if err != nil {
+			return trace.Wrap(err, "receiving CRL")
+		}
+		m.setCRLSet(ctx, &CRLSet{
+			LocalCRL: res.Crl,
+		})
+	}
+}
+
+func (m *CRLCache) setCRLSet(ctx context.Context, crlSet *CRLSet) {
+	m.mu.Lock()
+	old := m.crlSet
+
+	// Exit early if the CRL set is the same as the current one.
+	if old != nil {
+		if bytes.Equal(old.LocalCRL, crlSet.LocalCRL) {
+			m.logger.DebugContext(ctx, "Ignoring unchanged CRL set")
+		}
+	}
+
+	// Clone the CRL set to avoid the caller mutating the state after it has
+	// been set.
+	m.crlSet = crlSet.Clone()
+	m.crlSet.stale = make(chan struct{})
+
+	if old == nil {
+		// Indicate that the first CRL set is now available.
+		close(m.initialized)
+	} else {
+		// Indicate that a new CRL set is available.
+		close(old.stale)
+	}
+	m.mu.Unlock()
+}
+
+func (m *CRLCache) getCRLSet() *CRLSet {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.crlSet == nil {
+		return nil
+	}
+	// Clone so a receiver cannot mutate the current state without calling
+	// setCRLSet.
+	return m.crlSet.Clone()
+}
+
+// GetCRLSet returns the current CRLSet. If the cache is not yet
+// initialized, it will block until it is.
+func (m *CRLCache) GetCRLSet(
+	ctx context.Context,
+) (*CRLSet, error) {
+	select {
+	case <-m.initialized:
+		return m.getCRLSet(), nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}

--- a/lib/tbot/workloadidentity/crl_cache.go
+++ b/lib/tbot/workloadidentity/crl_cache.go
@@ -41,7 +41,9 @@ type CRLSet struct {
 
 // Clone returns a deep copy of the CRLSet.
 func (b *CRLSet) Clone() *CRLSet {
-	clone := &CRLSet{}
+	clone := &CRLSet{
+		stale: b.stale,
+	}
 	if b.LocalCRL != nil {
 		clone.LocalCRL = make([]byte, len(b.LocalCRL))
 		copy(clone.LocalCRL, b.LocalCRL)

--- a/tool/tctl/common/workload_identity_command.go
+++ b/tool/tctl/common/workload_identity_command.go
@@ -399,7 +399,8 @@ func (c *WorkloadIdentityCommand) ListRevocations(
 func (c *WorkloadIdentityCommand) StreamCRL(
 	ctx context.Context, client *authclient.Client,
 ) error {
-
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	revocationsClient := client.WorkloadIdentityRevocationServiceClient()
 
 	req := &workloadidentityv1pb.StreamSignedCRLRequest{}

--- a/tool/tctl/common/workload_identity_command.go
+++ b/tool/tctl/common/workload_identity_command.go
@@ -18,6 +18,7 @@ package common
 
 import (
 	"context"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"math/big"
@@ -50,9 +51,12 @@ type WorkloadIdentityCommand struct {
 	listCmd *kingpin.CmdClause
 	rmCmd   *kingpin.CmdClause
 
-	revocationsAddCmd *kingpin.CmdClause
-	revocationsRmCmd  *kingpin.CmdClause
-	revocationsLsCmd  *kingpin.CmdClause
+	revocationsAddCmd    *kingpin.CmdClause
+	revocationsRmCmd     *kingpin.CmdClause
+	revocationsLsCmd     *kingpin.CmdClause
+	revocationsCrlCmd    *kingpin.CmdClause
+	revocationsCRLFollow bool
+	revocationsCRLOut    string
 
 	revocationType   string
 	revocationSerial string
@@ -126,6 +130,16 @@ func (c *WorkloadIdentityCommand) Initialize(
 		Default(teleport.Text).
 		EnumVar(&c.format, teleport.Text, teleport.JSON)
 
+	c.revocationsCrlCmd = revocationsCmd.Command(
+		"crl", "Fetch the signed CRL for existing revocations.",
+	)
+	c.revocationsCrlCmd.Flag(
+		"follow", "Follow the stream of CRL updates.",
+	).BoolVar(&c.revocationsCRLFollow)
+	c.revocationsCrlCmd.Flag(
+		"out", "Path to write the CRL as a file to. If unspecified, STDOUT will be used.",
+	).StringVar(&c.revocationsCRLOut)
+
 	if c.stdout == nil {
 		c.stdout = os.Stdout
 	}
@@ -150,6 +164,8 @@ func (c *WorkloadIdentityCommand) TryRun(
 		commandFunc = c.ListRevocations
 	case c.revocationsRmCmd.FullCommand():
 		commandFunc = c.DeleteRevocation
+	case c.revocationsCrlCmd.FullCommand():
+		commandFunc = c.StreamCRL
 	default:
 		return false, nil
 	}
@@ -377,4 +393,48 @@ func (c *WorkloadIdentityCommand) ListRevocations(
 		}
 	}
 	return nil
+}
+
+func (c *WorkloadIdentityCommand) StreamCRL(
+	ctx context.Context, client *authclient.Client,
+) error {
+
+	revocationsClient := client.WorkloadIdentityRevocationServiceClient()
+
+	req := &workloadidentityv1pb.StreamSignedCRLRequest{}
+	stream, err := revocationsClient.StreamSignedCRL(ctx, req)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	write := func(data []byte) error {
+		_, err := c.stdout.Write(data)
+		return trace.Wrap(err)
+	}
+	if c.revocationsCRLOut != "" {
+		write = func(data []byte) error {
+			return trace.Wrap(
+				os.WriteFile(c.revocationsCRLOut, data, 0644),
+			)
+		}
+	}
+
+	for {
+		res, err := stream.Recv()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		pemData := pem.EncodeToMemory(&pem.Block{
+			Type:  "X509 CRL",
+			Bytes: res.Crl,
+		})
+		if err := write(pemData); err != nil {
+			return trace.Wrap(err, "writing CRL pem")
+		}
+
+		// If --follow has not been specified, exit.
+		if !c.revocationsCRLFollow {
+			return nil
+		}
+	}
 }

--- a/tool/tctl/common/workload_identity_command.go
+++ b/tool/tctl/common/workload_identity_command.go
@@ -427,6 +427,9 @@ func (c *WorkloadIdentityCommand) StreamCRL(
 	for {
 		res, err := stream.Recv()
 		if err != nil {
+			if trace.IsNotImplemented(err) {
+				slog.ErrorContext(ctx, "Server does not support X509 CRL functionality")
+			}
 			return trace.Wrap(err)
 		}
 		slog.InfoContext(ctx, "Received CRL from server")


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/51504

Extends the Revocation service to offer a stream of signed CRLs, implements support in `tctl` and `tbot` for exposing those CRLs.

changelog: Added support for X509 revocations to Workload Identity.