### PR TITLE
Use install.sh in discovery's default installer

### DIFF
--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -4516,18 +4516,15 @@ func (g *GRPCServer) DeleteUIConfig(ctx context.Context, _ *emptypb.Empty) (*emp
 }
 
 func (g *GRPCServer) defaultInstaller(ctx context.Context) (*types.InstallerV1, error) {
-	var defaultInstaller *types.InstallerV1
-
 	_, err := g.AuthServer.GetAutoUpdateAgentRollout(ctx)
 	switch {
 	case trace.IsNotFound(err):
-		defaultInstaller = installer.LegacyDefaultInstaller
+		return installer.LegacyDefaultInstaller, nil
 	case err != nil:
 		return nil, trace.Wrap(err, "failed to get query autoupdate state to build installer")
 	default:
-		defaultInstaller = installer.NewDefaultInstaller
+		return installer.NewDefaultInstaller, nil
 	}
-	return defaultInstaller, nil
 }
 
 // GetInstaller retrieves the installer script resource

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -47,12 +47,14 @@ import (
 	otlpresourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
 	otlptracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	autoupdatev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	"github.com/gravitational/teleport/api/internalutils/stream"
@@ -61,6 +63,7 @@ import (
 	"github.com/gravitational/teleport/api/observability/tracing"
 	"github.com/gravitational/teleport/api/trail"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/autoupdate"
 	"github.com/gravitational/teleport/api/types/installers"
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
@@ -4611,12 +4614,21 @@ func TestGRPCServer_GetInstallers(t *testing.T) {
 	tests := []struct {
 		name               string
 		inputInstallers    map[string]string
+		hasAgentRollout    bool
 		expectedInstallers map[string]string
 	}{
 		{
 			name: "default installers only",
 			expectedInstallers: map[string]string{
-				types.DefaultInstallerScriptName:        installer.DefaultInstaller.GetScript(),
+				types.DefaultInstallerScriptName:        installer.LegacyDefaultInstaller.GetScript(),
+				installers.InstallerScriptNameAgentless: installers.DefaultAgentlessInstaller.GetScript(),
+			},
+		},
+		{
+			name:            "new default installers",
+			hasAgentRollout: true,
+			expectedInstallers: map[string]string{
+				types.DefaultInstallerScriptName:        installer.NewDefaultInstaller.GetScript(),
 				installers.InstallerScriptNameAgentless: installers.DefaultAgentlessInstaller.GetScript(),
 			},
 		},
@@ -4627,7 +4639,7 @@ func TestGRPCServer_GetInstallers(t *testing.T) {
 			},
 			expectedInstallers: map[string]string{
 				"my-custom-installer":                   "echo test",
-				types.DefaultInstallerScriptName:        installer.DefaultInstaller.GetScript(),
+				types.DefaultInstallerScriptName:        installer.LegacyDefaultInstaller.GetScript(),
 				installers.InstallerScriptNameAgentless: installers.DefaultAgentlessInstaller.GetScript(),
 			},
 		},
@@ -4648,6 +4660,25 @@ func TestGRPCServer_GetInstallers(t *testing.T) {
 				_, err := grpc.DeleteAllInstallers(ctx, &emptypb.Empty{})
 				require.NoError(t, err)
 			})
+
+			if tc.hasAgentRollout {
+				rollout, err := autoupdate.NewAutoUpdateAgentRollout(
+					&autoupdatev1pb.AutoUpdateAgentRolloutSpec{
+						StartVersion:              "1.2.3",
+						TargetVersion:             "1.2.4",
+						Schedule:                  autoupdate.AgentsScheduleImmediate,
+						AutoupdateMode:            autoupdate.AgentsUpdateModeEnabled,
+						Strategy:                  autoupdate.AgentsStrategyTimeBased,
+						MaintenanceWindowDuration: durationpb.New(1 * time.Hour),
+					})
+				require.NoError(t, err)
+				_, err = grpc.AuthServer.CreateAutoUpdateAgentRollout(ctx, rollout)
+				require.NoError(t, err)
+
+				t.Cleanup(func() {
+					assert.NoError(t, grpc.AuthServer.DeleteAutoUpdateAgentRollout(ctx))
+				})
+			}
 
 			for name, script := range tc.inputInstallers {
 				installer, err := types.NewInstallerV1(name, script)

--- a/lib/srv/server/installer/autodiscover.go
+++ b/lib/srv/server/installer/autodiscover.go
@@ -226,6 +226,8 @@ func (ani *AutoDiscoverNodeInstaller) Install(ctx context.Context) error {
 	ani.Logger.InfoContext(ctx, "Detected cloud provider", "cloud", imdsClient.GetType())
 
 	// Check if teleport is already installed and install it, if it's absent.
+	// In the new autoupdate install flow, teleport-update should have already
+	// taken care of installing teleport.
 	if _, err := os.Stat(ani.binariesLocation.Teleport); err != nil {
 		ani.Logger.InfoContext(ctx, "Installing teleport")
 		if err := ani.installTeleportFromRepo(ctx); err != nil {

--- a/lib/srv/server/installer/defaultinstallers.go
+++ b/lib/srv/server/installer/defaultinstallers.go
@@ -50,7 +50,7 @@ INSTALL_SCRIPT_URL="https://{{.PublicProxyAddr}}/scripts/install.sh"
 
 echo "Offloading the installation part to the generic Teleport install script hosted at: $INSTALL_SCRIPT_URL"
 
-curl "$INSTALL_SCRIPT_URL" | sudo bash`
+curl -sSf "$INSTALL_SCRIPT_URL" | sudo bash || (echo "The install.sh script returned a non-zero exit code" && exit 1)`
 	configureTeleport = `
 echo "Configuring the Teleport agent"
 

--- a/lib/srv/server/installer/defaultinstallers.go
+++ b/lib/srv/server/installer/defaultinstallers.go
@@ -26,6 +26,20 @@ import (
 	"github.com/gravitational/teleport/lib/web/scripts/oneoff"
 )
 
+const (
+	scriptShebangAndSetOptions = `#!/bin/bash
+set -euo pipefail`
+	execGenericInstallScript = `
+INSTALL_SCRIPT_URL="https://{{.PublicProxyAddr}}/scripts/install.sh"
+
+echo "Offloading the installation part to the generic Teleport install script hosted at: $INSTALL_SCRIPT_URL"
+
+TEMP_INSTALLER_SCRIPT="$(mktemp)"
+curl -sSf "$INSTALL_SCRIPT_URL" -o "$TEMP_INSTALLER_SCRIPT"
+sudo bash "$TEMP_INSTALLER_SCRIPT" || (echo "The install script ($TEMP_INSTALLER_SCRIPT) returned a non-zero exit code" && exit 1)
+rm "$TEMP_INSTALLER_SCRIPT"`
+)
+
 // LegacyDefaultInstaller represents the default installer script provided by teleport.
 var (
 	// LegacyDefaultInstaller uses oneoff.sh to download the Teleport tarball and run `teleport install`.
@@ -42,15 +56,6 @@ var (
 			"\n\n",
 		),
 	)
-
-	scriptShebangAndSetOptions = `#!/bin/bash
-set -euo pipefail`
-	execGenericInstallScript = `
-INSTALL_SCRIPT_URL="https://{{.PublicProxyAddr}}/scripts/install.sh"
-
-echo "Offloading the installation part to the generic Teleport install script hosted at: $INSTALL_SCRIPT_URL"
-
-curl -sSf "$INSTALL_SCRIPT_URL" | sudo bash || (echo "The install.sh script returned a non-zero exit code" && exit 1)`
 	configureTeleport = `
 echo "Configuring the Teleport agent"
 

--- a/lib/srv/server/installer/defaultinstallers.go
+++ b/lib/srv/server/installer/defaultinstallers.go
@@ -26,11 +26,6 @@ import (
 	"github.com/gravitational/teleport/lib/web/scripts/oneoff"
 )
 
-// Depending on your cluster setup we have 2 installers:
-//   - LegacyDefaultInstaller which uses oneoff.sh to download teleport and run "teleport install".
-//     Teleport install does package-based installations.
-//   -
-
 // LegacyDefaultInstaller represents the default installer script provided by teleport.
 var (
 	// LegacyDefaultInstaller uses oneoff.sh to download the Teleport tarball and run `teleport install`.

--- a/lib/srv/server/installer/defaultinstallers.go
+++ b/lib/srv/server/installer/defaultinstallers.go
@@ -26,11 +26,40 @@ import (
 	"github.com/gravitational/teleport/lib/web/scripts/oneoff"
 )
 
-// DefaultInstaller represents the default installer script provided by teleport.
-var DefaultInstaller = oneoffScriptToDefaultInstaller()
+// Depending on your cluster setup we have 2 installers:
+//   - LegacyDefaultInstaller which uses oneoff.sh to download teleport and run "teleport install".
+//     Teleport install does package-based installations.
+//   -
 
-func oneoffScriptToDefaultInstaller() *types.InstallerV1 {
-	argsList := []string{
+// LegacyDefaultInstaller represents the default installer script provided by teleport.
+var (
+	// LegacyDefaultInstaller uses oneoff.sh to download the Teleport tarball and run `teleport install`.
+	// The Teleport install command handles both Teleport installation and agent configuration.
+	LegacyDefaultInstaller = oneoffScriptToDefaultInstaller()
+
+	// NewDefaultInstaller installs Teleport by calling the standard "/scripts/install.sh" route on the proxy.
+	// After successfully installing Teleport, it will invoke the same `teleport install`
+	// command as the LegacyDefaultInstaller which will only take care of configuring Teleport.
+	NewDefaultInstaller = types.MustNewInstallerV1(installers.InstallerScriptName, execGenericInstallScript+configureTeleport)
+
+	execGenericInstallScript = `#!/bin/bash
+set -euo pipefail
+
+INSTALL_SCRIPT_URL="https://{{.PublicProxyAddr}}/scripts/install.sh"
+
+echo "Offloading the installation part to the generic Teleport install script hosted at: $INSTALL_SCRIPT_URL"
+
+curl "$INSTALL_SCRIPT_URL" | sudo bash
+`
+	configureTeleport = `#!/bin/bash
+set -euo pipefail
+
+echo "Configuring the Teleport agent"
+
+set +x
+sudo teleport ` + strings.Join(argsList, " ")
+
+	argsList = []string{
 		"install", "autodiscover-node",
 		"--public-proxy-addr={{.PublicProxyAddr}}",
 		"--teleport-package={{.TeleportPackage}}",
@@ -38,7 +67,9 @@ func oneoffScriptToDefaultInstaller() *types.InstallerV1 {
 		"--auto-upgrade={{.AutomaticUpgrades}}",
 		"--azure-client-id={{.AzureClientID}}",
 	}
+)
 
+func oneoffScriptToDefaultInstaller() *types.InstallerV1 {
 	script, err := oneoff.BuildScript(oneoff.OneOffScriptParams{
 		EntrypointArgs:        strings.Join(argsList, " "),
 		SuccessMessage:        "Teleport is installed and running.",

--- a/lib/srv/server/installer/defaultinstallers.go
+++ b/lib/srv/server/installer/defaultinstallers.go
@@ -35,20 +35,23 @@ var (
 	// NewDefaultInstaller installs Teleport by calling the standard "/scripts/install.sh" route on the proxy.
 	// After successfully installing Teleport, it will invoke the same `teleport install`
 	// command as the LegacyDefaultInstaller which will only take care of configuring Teleport.
-	NewDefaultInstaller = types.MustNewInstallerV1(installers.InstallerScriptName, execGenericInstallScript+configureTeleport)
+	NewDefaultInstaller = types.MustNewInstallerV1(
+		installers.InstallerScriptName,
+		strings.Join(
+			[]string{scriptShebangAndSetOptions, execGenericInstallScript, configureTeleport},
+			"\n\n",
+		),
+	)
 
-	execGenericInstallScript = `#!/bin/bash
-set -euo pipefail
-
+	scriptShebangAndSetOptions = `#!/bin/bash
+set -euo pipefail`
+	execGenericInstallScript = `
 INSTALL_SCRIPT_URL="https://{{.PublicProxyAddr}}/scripts/install.sh"
 
 echo "Offloading the installation part to the generic Teleport install script hosted at: $INSTALL_SCRIPT_URL"
 
-curl "$INSTALL_SCRIPT_URL" | sudo bash
-`
-	configureTeleport = `#!/bin/bash
-set -euo pipefail
-
+curl "$INSTALL_SCRIPT_URL" | sudo bash`
+	configureTeleport = `
 echo "Configuring the Teleport agent"
 
 set +x

--- a/lib/srv/server/installer/defaultinstallers.go
+++ b/lib/srv/server/installer/defaultinstallers.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	scriptShebangAndSetOptions = `#!/bin/bash
+	scriptShebangAndSetOptions = `#!/usr/bin/env sh
 set -euo pipefail`
 	execGenericInstallScript = `
 INSTALL_SCRIPT_URL="https://{{.PublicProxyAddr}}/scripts/install.sh"
@@ -36,7 +36,10 @@ echo "Offloading the installation part to the generic Teleport install script ho
 
 TEMP_INSTALLER_SCRIPT="$(mktemp)"
 curl -sSf "$INSTALL_SCRIPT_URL" -o "$TEMP_INSTALLER_SCRIPT"
-sudo bash "$TEMP_INSTALLER_SCRIPT" || (echo "The install script ($TEMP_INSTALLER_SCRIPT) returned a non-zero exit code" && exit 1)
+
+chmod +x "$TEMP_INSTALLER_SCRIPT"
+
+sudo "$TEMP_INSTALLER_SCRIPT" || (echo "The install script ($TEMP_INSTALLER_SCRIPT) returned a non-zero exit code" && exit 1)
 rm "$TEMP_INSTALLER_SCRIPT"`
 )
 

--- a/lib/srv/server/installer/defaultinstallers_test.go
+++ b/lib/srv/server/installer/defaultinstallers_test.go
@@ -20,11 +20,13 @@ package installer_test
 
 import (
 	"bytes"
-	"github.com/gravitational/teleport/api/types/installers"
-	"github.com/gravitational/teleport/lib/srv/server/installer"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"text/template"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types/installers"
+	"github.com/gravitational/teleport/lib/srv/server/installer"
 )
 
 const defaultInstallerSnapshot = `#!/usr/bin/env sh

--- a/lib/srv/server/installer/defaultinstallers_test.go
+++ b/lib/srv/server/installer/defaultinstallers_test.go
@@ -1,0 +1,75 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package installer_test
+
+import (
+	"bytes"
+	"github.com/gravitational/teleport/api/types/installers"
+	"github.com/gravitational/teleport/lib/srv/server/installer"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"text/template"
+)
+
+const defaultInstallerSnapshot = `#!/usr/bin/env sh
+set -euo pipefail
+
+
+INSTALL_SCRIPT_URL="https://teleport.example.com:443/scripts/install.sh"
+
+echo "Offloading the installation part to the generic Teleport install script hosted at: $INSTALL_SCRIPT_URL"
+
+TEMP_INSTALLER_SCRIPT="$(mktemp)"
+curl -sSf "$INSTALL_SCRIPT_URL" -o "$TEMP_INSTALLER_SCRIPT"
+
+chmod +x "$TEMP_INSTALLER_SCRIPT"
+
+sudo "$TEMP_INSTALLER_SCRIPT" || (echo "The install script ($TEMP_INSTALLER_SCRIPT) returned a non-zero exit code" && exit 1)
+rm "$TEMP_INSTALLER_SCRIPT"
+
+
+echo "Configuring the Teleport agent"
+
+set +x
+sudo teleport install autodiscover-node --public-proxy-addr=teleport.example.com:443 --teleport-package=teleport-ent --repo-channel=stable/cloud --auto-upgrade=true --azure-client-id=`
+
+// TestNewDefaultInstaller is a minimal
+func TestNewDefaultInstaller(t *testing.T) {
+	// Test setup.
+	inputs := installers.Template{
+		PublicProxyAddr:   "teleport.example.com:443",
+		MajorVersion:      "v16",
+		TeleportPackage:   "teleport-ent",
+		RepoChannel:       "stable/cloud",
+		AutomaticUpgrades: "true",
+		AzureClientID:     "",
+	}
+
+	// Test execution: check that the template can be parsed.
+	script := installer.NewDefaultInstaller.GetScript()
+	installationTemplate, err := template.New("").Parse(script)
+	require.NoError(t, err)
+
+	// Test execution: render template.
+	buf := &bytes.Buffer{}
+	require.NoError(t, installationTemplate.Execute(buf, inputs))
+
+	// Test validation: rendered template must look like the snapshot.
+	require.Equal(t, defaultInstallerSnapshot, buf.String())
+}


### PR DESCRIPTION
## Context

This PR is the fourth of a series to:
- have Teleport Discover scripts install with `teleport-update`
- consolidate installation scripts to reduce the amount of bash scripts we use
- add stronger and saner interface to generate install scripts

Previous PRs:
- https://github.com/gravitational/teleport/pull/52155 (we depend on this one)
- https://github.com/gravitational/teleport/pull/52196
- https://github.com/gravitational/teleport/pull/52226

## About this PR

This PR introduce a new default installer that calls `https://proxy.example.com/scripts/install.sh` to install teleport. This new script is gated behind the autoupdate_agent_rollout presence.