### PR TITLE
Add support for RDS-hosted Oracle and update related RDS handling

### DIFF
--- a/api/types/database.go
+++ b/api/types/database.go
@@ -566,6 +566,10 @@ func (d *DatabaseV3) getAWSType() (string, bool) {
 		return DatabaseTypeDynamoDB, true
 	case DatabaseTypeOpenSearch:
 		return DatabaseTypeOpenSearch, true
+	case DatabaseProtocolOracle:
+		if !aws.IsEmpty() {
+			return DatabaseTypeRDSOracle, true
+		}
 	}
 	if aws.Redshift.ClusterID != "" {
 		return DatabaseTypeRedshift, true
@@ -1139,6 +1143,8 @@ const (
 	DatabaseProtocolMongoDB = "mongodb"
 	// DatabaseProtocolCockroachDB is the CockroachDB database protocol.
 	DatabaseProtocolCockroachDB = "cockroachdb"
+	// DatabaseProtocolOracle is the Oracle database protocol.
+	DatabaseProtocolOracle = "oracle"
 
 	// DatabaseTypeSelfHosted is the self-hosted type of database.
 	DatabaseTypeSelfHosted = "self-hosted"
@@ -1172,6 +1178,8 @@ const (
 	DatabaseTypeMongoAtlas = "mongo-atlas"
 	// DatabaseTypeDocumentDB is the database type for AWS-hosted DocumentDB.
 	DatabaseTypeDocumentDB = "docdb"
+	// DatabaseTypeRDSOracle is AWS-hosted Oracle instance.
+	DatabaseTypeRDSOracle = "rds-oracle"
 )
 
 // GetServerName returns the GCP database project and instance as "<project-id>:<instance-id>".

--- a/api/types/database_test.go
+++ b/api/types/database_test.go
@@ -1174,3 +1174,18 @@ func TestGetAdminUser(t *testing.T) {
 		})
 	}
 }
+
+func TestDatabaseOracleRDS(t *testing.T) {
+	database, err := NewDatabaseV3(Metadata{
+		Name: "my-oracle",
+	}, DatabaseSpecV3{
+		Protocol: "oracle",
+		URI:      "my-oracle-db.abcdefghijklmnop.eu-central-1.rds.amazonaws.com:2484",
+	})
+	require.NoError(t, err)
+	require.Equal(t, AWS{
+		Region: "eu-central-1",
+		RDS:    RDS{InstanceID: "my-oracle-db"},
+	}, database.GetAWS())
+	require.Equal(t, DatabaseTypeRDSOracle, database.GetType())
+}

--- a/lib/srv/db/ca.go
+++ b/lib/srv/db/ca.go
@@ -101,6 +101,7 @@ func (s *Server) shouldInitCACertLocked(database types.Database) bool {
 	// Can only download it for cloud-hosted instances.
 	switch database.GetType() {
 	case types.DatabaseTypeRDS,
+		types.DatabaseTypeRDSOracle,
 		types.DatabaseTypeDocumentDB,
 		types.DatabaseTypeRedshift,
 		types.DatabaseTypeRedshiftServerless,
@@ -166,7 +167,7 @@ func (s *Server) getCACertPaths(database types.Database) ([]string, error) {
 	// All RDS instances share the same root CA (per AWS region) which can be
 	// downloaded from a well-known URL.
 	// DocumentDB uses same certs as RDS.
-	case types.DatabaseTypeRDS, types.DatabaseTypeDocumentDB:
+	case types.DatabaseTypeRDS, types.DatabaseTypeRDSOracle, types.DatabaseTypeDocumentDB:
 		return []string{filepath.Join(s.cfg.DataDir, filepath.Base(rdsCAURLForDatabase(database)))}, nil
 
 	// All Redshift instances share the same root CA which can be downloaded
@@ -309,7 +310,7 @@ func NewRealDownloader() CADownloader {
 // Download downloads CA certificate for the provided cloud database instance.
 func (d *realDownloader) Download(ctx context.Context, database types.Database, hint string) ([]byte, []byte, error) {
 	switch database.GetType() {
-	case types.DatabaseTypeRDS, types.DatabaseTypeDocumentDB:
+	case types.DatabaseTypeRDS, types.DatabaseTypeRDSOracle, types.DatabaseTypeDocumentDB:
 		return d.downloadFromURL(rdsCAURLForDatabase(database))
 	case types.DatabaseTypeRedshift,
 		types.DatabaseTypeRedshiftServerless:
@@ -338,7 +339,7 @@ func (d *realDownloader) Download(ctx context.Context, database types.Database, 
 // GetVersion returns the CA version for the provided database.
 func (d *realDownloader) GetVersion(ctx context.Context, database types.Database, hint string) ([]byte, error) {
 	switch database.GetType() {
-	case types.DatabaseTypeRDS, types.DatabaseTypeDocumentDB:
+	case types.DatabaseTypeRDS, types.DatabaseTypeRDSOracle, types.DatabaseTypeDocumentDB:
 		return d.getVersionFromURL(database, rdsCAURLForDatabase(database))
 	case types.DatabaseTypeRedshift,
 		types.DatabaseTypeRedshiftServerless:

--- a/lib/srv/db/cloud/meta.go
+++ b/lib/srv/db/cloud/meta.go
@@ -187,7 +187,7 @@ func NewMetadata(config MetadataConfig) (*Metadata, error) {
 // Update updates cloud metadata of the provided database.
 func (m *Metadata) Update(ctx context.Context, database types.Database) error {
 	switch database.GetType() {
-	case types.DatabaseTypeRDS:
+	case types.DatabaseTypeRDS, types.DatabaseTypeRDSOracle:
 		return m.updateAWS(ctx, database, m.fetchRDSMetadata)
 	case types.DatabaseTypeRDSProxy:
 		return m.updateAWS(ctx, database, m.fetchRDSProxyMetadata)

--- a/lib/srv/db/cloud/resource_checker_url.go
+++ b/lib/srv/db/cloud/resource_checker_url.go
@@ -99,6 +99,7 @@ func convIsEndpoint(isEndpoint isEndpointFunc) checkDatabaseFunc {
 func (c *urlChecker) Check(ctx context.Context, database types.Database) error {
 	checkersByDatabaseType := map[string]checkDatabaseFunc{
 		types.DatabaseTypeRDS:                c.checkAWS(c.checkRDS, convIsEndpoint(apiawsutils.IsRDSEndpoint)),
+		types.DatabaseTypeRDSOracle:          c.checkAWS(c.checkRDS, convIsEndpoint(apiawsutils.IsRDSEndpoint)),
 		types.DatabaseTypeRDSProxy:           c.checkAWS(c.checkRDSProxy, convIsEndpoint(apiawsutils.IsRDSEndpoint)),
 		types.DatabaseTypeRedshift:           c.checkAWS(c.checkRedshift, convIsEndpoint(apiawsutils.IsRedshiftEndpoint)),
 		types.DatabaseTypeRedshiftServerless: c.checkAWS(c.checkRedshiftServerless, convIsEndpoint(apiawsutils.IsRedshiftServerlessEndpoint)),


### PR DESCRIPTION
This change adds explicit support for Oracle RDS and introduces new db type `rds-oracle`. For this new type, Cloud CA downloads and metadata service are supported.

Updates https://github.com/gravitational/teleport/issues/43765.

changelog: Recognize Oracle RDS instances.