### PR TITLE
Use ExactKey for WorkloadIdentityParser to avoid parsing WorkloadIdentityX509Revocations

### DIFF
--- a/lib/services/local/workload_identity.go
+++ b/lib/services/local/workload_identity.go
@@ -121,7 +121,7 @@ func (b *WorkloadIdentityService) UpdateWorkloadIdentity(
 
 func newWorkloadIdentityParser() *workloadIdentityParser {
 	return &workloadIdentityParser{
-		baseParser: newBaseParser(backend.NewKey(workloadIdentityPrefix)),
+		baseParser: newBaseParser(backend.ExactKey(workloadIdentityPrefix)),
 	}
 }
 

--- a/lib/services/local/workload_identity_test.go
+++ b/lib/services/local/workload_identity_test.go
@@ -355,6 +355,7 @@ func TestWorkloadIdentityService_UpdateWorkloadIdentity(t *testing.T) {
 }
 
 func TestWorkloadIdentityParser(t *testing.T) {
+	t.Parallel()
 	parser := newWorkloadIdentityParser()
 	t.Run("delete", func(t *testing.T) {
 		event := backend.Event{


### PR DESCRIPTION
Currently, the WorkloadIdentityParser is invoked when an event for the WorkloadIdentityX509Revocation is emitted. This results in a confusing error:

```json
{"level":"error","process":"leaf","replica":0,"message":"2025-02-20T11:41:36.139Z WARN [EVENTS]    failed parsing event error:["}
{"level":"error","process":"leaf","replica":0,"message":"ERROR REPORT:"}
{"level":"error","process":"leaf","replica":0,"message":"Original Error: *errors.prefixError proto: (line 1:139): unknown field &#34;reason&#34;"}
{"level":"error","process":"leaf","replica":0,"message":"Stack Trace:"}
{"level":"error","process":"leaf","replica":0,"message":"\tgithub.com/gravitational/teleport/lib/services/resource.go:908 github.com/gravitational/teleport/lib/services.UnmarshalProtoResource[...]"}
{"level":"error","process":"leaf","replica":0,"message":"\tgithub.com/gravitational/teleport/lib/services/workload_identity.go:74 github.com/gravitational/teleport/lib/services.UnmarshalWorkloadIdentity"}
{"level":"error","process":"leaf","replica":0,"message":"\tgithub.com/gravitational/teleport/lib/services/local/workload_identity.go:149 github.com/gravitational/teleport/lib/services/local.(*workloadIdentityParser).parse"}
{"level":"error","process":"leaf","replica":0,"message":"\tgithub.com/gravitational/teleport/lib/services/local/events.go:327 github.com/gravitational/teleport/lib/services/local.(*watcher).parseEvent"}
{"level":"error","process":"leaf","replica":0,"message":"\tgithub.com/gravitational/teleport/lib/services/local/events.go:348 github.com/gravitational/teleport/lib/services/local.(*watcher).forwardEvents"}
{"level":"error","process":"leaf","replica":0,"message":"\truntime/asm_arm64.s:1223 runtime.goexit"}
{"level":"error","process":"leaf","replica":0,"message":"User Message: unmarshalling resource from event"}
{"level":"error","process":"leaf","replica":0,"message":"\tproto: (line 1:139): unknown field &#34;reason&#34;] local/events.go:355"}
```