### PR TITLE
[v17] Fix standard role editor crash on empty GitHub organizations list

### DIFF
--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.ts
@@ -894,7 +894,7 @@ function kubernetesResourceToModel(
  * this function is protected anyway from attempting to interpret such an
  * extended object, and it would return non-empty `conversionErrors` anyway.
  */
-function gitHubOrganizationsToModel(
+export function gitHubOrganizationsToModel(
   gitHubPermissions: GitHubPermission[],
   pathPrefix: string
 ): {
@@ -906,7 +906,9 @@ function gitHubOrganizationsToModel(
   const conversionErrors: ConversionError[] = [];
   permissions.forEach((permission, i) => {
     const { orgs, ...unsupported } = permission;
-    model.push(...stringsToOptions(orgs));
+    if (orgs) {
+      model.push(...stringsToOptions(orgs));
+    }
     conversionErrors.push(
       ...unsupportedFieldErrorsFromObject(`${pathPrefix}[${i}]`, unsupported)
     );
@@ -1273,9 +1275,10 @@ export function roleEditorModelToRole(roleModel: RoleEditorModel): Role {
         break;
 
       case 'git_server':
-        role.spec.allow.github_permissions = [
-          { orgs: optionsToStrings(res.organizations) },
-        ];
+        const orgs = optionsToStrings(res.organizations);
+        if (orgs.length > 0) {
+          role.spec.allow.github_permissions = [{ orgs }];
+        }
         break;
 
       default:


### PR DESCRIPTION
Backport #52005 to branch/v17

No manual resolution needed; I don't understand why the automatic action had problems with backporting it.

Tested manually by adding GH access, saving, removing names from the organization list, and loading the role again into the editor.