### PR TITLE
Remove two-dimensional and dropdown-only docs Tabs

### DIFF
--- a/docs/pages/enroll-resources/application-access/cloud-apis/google-cloud.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/google-cloud.mdx
@@ -305,8 +305,13 @@ claims.
 
 </Admonition>
 
-<Tabs dropdownCaption="Approach">
-<TabItem options="Dynamic Identities" label="Local Users">
+### Dynamic identities
+
+If you are using dynamic identities, the approach you choose depends on whether
+you use local or SSO Teleport users:
+
+<Tabs>
+<TabItem label="Local Users">
 
 Create a file called `google-cloud-cli-access.yaml` with the following content:
 
@@ -351,7 +356,7 @@ $ tctl create -f google-cloud-cli-access.yaml
 (!docs/pages/includes/create-role-using-web.mdx!)
 
 </TabItem>
-<TabItem options="Dynamic Identities" label="SAML/OIDC Connectors">
+<TabItem label="SAML/OIDC Connectors">
 
 In your identity provider, define a custom SAML attribute or OIDC claim called
 `gcp_service_accounts`. Each user's `gcp_service_accounts` attribute or claim
@@ -398,7 +403,11 @@ $ tctl create -f google-cloud-cli-access
 (!docs/pages/includes/create-role-using-web.mdx!)
 
 </TabItem>
-<TabItem options="Static Identities" label="All Authentication Methods">
+</Tabs>
+
+### Static identities
+
+If you are using static identities, complete the following instructions.
 
 Define a role with access to specific Google Cloud service accounts, which means
 that Teleport users who assume this role can use those (and only those)
@@ -430,9 +439,6 @@ Create the role:
 ```code
 $ tctl create -f google-cloud-cli-access.yaml
 ```
-
-</TabItem>
-</Tabs>
 
 <Details title="Denying access to Google Cloud service accounts">
 

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/google-cloud.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/google-cloud.mdx
@@ -494,22 +494,20 @@ command, depending on:
 - Whether you are running the Discovery and Kubernetes Service on Google Cloud
   or another platform
 
-<Tabs dropdownCaption="How your host is running:"
-dropdownSelected="Google Cloud">
-<TabItem options="Google Cloud" label="Package Manager ">
+<Tabs>
+<TabItem label="Google Cloud">
 
-On the host where you will run the Teleport Kubernetes Service and Discovery
-Service, start the Teleport service:
+If you installed Teleport with a package manager, on the host where you will run
+the Teleport Kubernetes Service and Discovery Service, start the Teleport
+service:
 
 ```code
 $ sudo systemctl start teleport
 ```
-</TabItem>
-<TabItem options="Google Cloud" label="TAR Archive ">
 
-On the host where you will run the Teleport Kubernetes Service and Discovery
-Service, create a systemd service configuration for Teleport, enable the
-Teleport service, and start Teleport:
+If you installed Teleport with a TAR archive, the host where you will run the
+Teleport Kubernetes Service and Discovery Service, create a systemd service
+configuration for Teleport, enable the Teleport service, and start Teleport:
 
 ```code
 $ sudo teleport install systemd -o /etc/systemd/system/teleport.service
@@ -517,57 +515,55 @@ $ sudo systemctl enable teleport
 $ sudo systemctl start teleport
 ```
 </TabItem>
-<TabItem options="Other Platform" label="Package Manager">
+<TabItem label="Other platform">
 
-When you installed Teleport via package manager, the installation process
-created a configuration for the init system `systemd` to run Teleport as a
-daemon.
-
-This service reads environment variables from a file at the path
+If you installed Teleport via package manager, the installation process created
+a configuration for the init system `systemd` to run Teleport as a daemon. This
+service reads environment variables from a file at the path
 `/etc/default/teleport`. Teleport's built-in Google Cloud client reads the
 credentials file at the location given by the `GOOGLE_APPLICATION_CREDENTIALS`
-variable.
+variable. In this case:
 
-Ensure that `/etc/default/teleport` has the following content:
+1. Ensure that `/etc/default/teleport` has the following content:
 
-```
-GOOGLE_APPLICATION_CREDENTIALS="/var/lib/teleport/google-cloud-credentials.json"
-```
+   ```
+   GOOGLE_APPLICATION_CREDENTIALS="/var/lib/teleport/google-cloud-credentials.json"
+   ```
 
-Start the Teleport service:
+1. Start the Teleport service:
 
-```code
-$ sudo systemctl enable teleport
-$ sudo systemctl start teleport
-```
-</TabItem>
-<TabItem options="Other Platform" label="TAR Archive">
+   ```code
+   $ sudo systemctl enable teleport
+   $ sudo systemctl start teleport
+   ```
 
-On the host where you are running the Teleport Discovery Service and Kubernetes
-Service, create a systemd configuration that you can use to run Teleport in the
-background:
+If you installed Teleport using a TAR archive:
 
-```code
-$ sudo teleport install systemd -o /etc/systemd/system/teleport.service
-$ sudo systemctl enable teleport
-```
+1. On the host where you are running the Teleport Discovery Service and
+   Kubernetes Service, create a systemd configuration that you can use to run
+   Teleport in the background:
 
-This service reads environment variables from a file at the path
-`/etc/default/teleport`. Teleport's built-in Google Cloud client reads the
-credentials file at the location given by the `GOOGLE_APPLICATION_CREDENTIALS`
-variable.
+   ```code
+   $ sudo teleport install systemd -o /etc/systemd/system/teleport.service
+   $ sudo systemctl enable teleport
+   ```
 
-Ensure that `/etc/default/teleport` has the following content:
+   This service reads environment variables from a file at the path
+   `/etc/default/teleport`. Teleport's built-in Google Cloud client reads the
+   credentials file at the location given by the
+   `GOOGLE_APPLICATION_CREDENTIALS` variable.
 
-```
-GOOGLE_APPLICATION_CREDENTIALS="/var/lib/teleport/google-cloud-credentials.json"
-```
+1. Ensure that `/etc/default/teleport` has the following content:
 
-Start the Discovery Service and Kubernetes Service:
+   ```
+   GOOGLE_APPLICATION_CREDENTIALS="/var/lib/teleport/google-cloud-credentials.json"
+   ```
 
-```code
-$ sudo systemctl start teleport
-```
+1. Start the Discovery Service and Kubernetes Service:
+
+   ```code
+   $ sudo systemctl start teleport
+   ```
 
 </TabItem>
 </Tabs>

--- a/docs/pages/includes/application-access/azure-teleport-role.mdx
+++ b/docs/pages/includes/application-access/azure-teleport-role.mdx
@@ -20,8 +20,13 @@ as OAuth-based GitHub applications do not support custom claims.
 
 </Admonition>
 
-<Tabs dropdownCaption="Approach">
-<TabItem options="Dynamic Identities" label="Local Users">
+### Dynamic identities
+
+If you are using the dynamic approach, the approach you choose depends on
+whether your Teleport user is a local user or an SSO user:
+
+<Tabs>
+<TabItem label="Local Users">
 
 Create a file called `azure-cli-access.yaml` with the following content:
 
@@ -71,7 +76,7 @@ $ tctl create -f azure-cli-access.yaml
 (!docs/pages/includes/create-role-using-web.mdx!)
 
 </TabItem>
-<TabItem options="Dynamic Identities" label="SAML/OIDC Connectors">
+<TabItem label="SAML/OIDC Connectors">
 
 In your identity provider, define a custom SAML attribute or OIDC claim called
 `azure_identities`. Each user's `azure_identities` attribute or claim must be a
@@ -110,11 +115,13 @@ $ tctl create -f azure-cli-access.yaml
 (!docs/pages/includes/create-role-using-web.mdx!)
 
 </TabItem>
-<TabItem options="Static Identities" label="All Authentication Methods">
+</Tabs>
 
-Define a role with access to specific Azure identities, which means that
-Teleport users who assume this role can use those (and only those) identities to
-execute commands via an Azure CLI.
+### Static identities
+
+If you are using static identities, define a role with access to specific Azure
+identities, which means that Teleport users who assume this role can use those
+(and only those) identities to execute commands via an Azure CLI.
 
 Create a file called `azure-cli-access.yaml` with the following content:
 
@@ -145,9 +152,6 @@ $ tctl create -f azure-cli-access.yaml
 ```
 
 (!docs/pages/includes/create-role-using-web.mdx!)
-
-</TabItem>
-</Tabs>
 
 <Details title="Denying access to Azure identities">
 

--- a/docs/pages/includes/database-access/aws-db-iam-policy-picker.mdx
+++ b/docs/pages/includes/database-access/aws-db-iam-policy-picker.mdx
@@ -1,6 +1,6 @@
 {/* this comment is here to make the includes below render */}
 
-<Tabs dropdownView dropdownCaption="Database Type">
+<Tabs>
 <TabItem label="DocumentDB">
 
 (!docs/pages/includes/database-access/reference/aws-iam/documentdb/access-policy.mdx dbUserRole="DatabaseUserRole" !)

--- a/docs/pages/includes/discovery/aws-db-discovery-config-picker.mdx
+++ b/docs/pages/includes/discovery/aws-db-discovery-config-picker.mdx
@@ -1,6 +1,6 @@
 {/* this comment is here to make the includes below render */}
 
-<Tabs dropdownView dropdownCaption="Database Type">
+<Tabs>
 <TabItem label="DocumentDB">
 
 (!docs/pages/includes/discovery/aws-db-discovery-config.mdx matcherType="docdb" !)

--- a/docs/pages/includes/discovery/aws-db-iam-policy-picker.mdx
+++ b/docs/pages/includes/discovery/aws-db-iam-policy-picker.mdx
@@ -1,6 +1,6 @@
 {/* this comment is here to make the includes below render */}
 
-<Tabs dropdownView dropdownCaption="Database Type">
+<Tabs>
 <TabItem label="DocumentDB">
 
 (!docs/pages/includes/discovery/reference/aws-iam/documentdb.mdx!)

--- a/docs/pages/includes/install-linux-enterprise.mdx
+++ b/docs/pages/includes/install-linux-enterprise.mdx
@@ -1,19 +1,36 @@
-Use the appropriate commands for your environment to install your package:
+Install Teleport on your Linux server:
 
-<Tabs dropdownView dropdownCaption="Teleport Edition">
-  <TabItem label="Enterprise" scope="enterprise">
-  (!docs/pages/includes/install-linux-ent-self-hosted.mdx!)
-  </TabItem>
-  <TabItem label="Enterprise Cloud" scope="cloud">
-  (!docs/pages/includes/cloud/install-linux-cloud.mdx!)
-  <Details title="Is my Teleport instance compatible with Teleport Enterprise Cloud?">
+1. Assign <Var name="edition" /> to one of the following, depending on your
+   Teleport edition:
 
-  Before installing a `teleport` binary with a version besides v(=cloud.major_version=),
-  read our compatibility rules to ensure that the binary is compatible with
-  Teleport Enterprise Cloud.
+   | Edition                           | Value        |
+   |-----------------------------------|--------------|
+   | Teleport Enterprise Cloud         | `cloud`      |
+   | Teleport Enterprise (Self-Hosted) | `enterprise` |
 
-  (!docs/pages/includes/compatibility.mdx!)
+1. Get the version of Teleport to install. If you have automatic agent updates
+   enabled in your cluster, query the latest Teleport version that is compatible
+   with the updater:
 
-  </Details>
-  </TabItem>
-</Tabs>
+   ```code
+   $ TELEPORT_DOMAIN=<Var name="example.teleport.com" />
+   $ TELEPORT_VERSION="$(curl https://$TELEPORT_DOMAIN/v1/webapi/automaticupgrades/channel/default/version | sed 's/v//')"
+   ```
+   
+   Otherwise, get the version of your Teleport cluster:
+   
+   ```code 
+   $ TELEPORT_DOMAIN=<Var name="example.teleport.com" />
+   $ TELEPORT_VERSION="$(curl https://$TELEPORT_DOMAIN/v1/webapi/ping | jq -r '.server_version')"
+   ```
+
+1. Install Teleport on your Linux server:
+
+   ```code
+   $ curl (=teleport.teleport_install_script_url=) | bash -s ${TELEPORT_VERSION} <Var name="edition" />
+   ```
+
+   The installation script detects the package manager on your Linux server and
+   uses it to install Teleport binaries. To customize your installation, learn
+   about the Teleport package repositories in the [installation
+   guide](../installation.mdx#linux).


### PR DESCRIPTION
Closes gravitational/docs-website#70

`Tabs` components that use a dropdown menu do not render on the Docusaurus site. Since there are not many of these in the docs content, it makes sense to change them to standard `Tabs` components instead of porting the legacy `Tabs` behavior to the new Docusaurus site.

- Change long picker partials to use a standard `Tabs` component instead of a dropdown menu. While this is not ideal, it standardizes the `Tabs` component in the docs to only use attributes that the docs engine can process. All `TabItems` render as expected.
- Remove an unused partial that uses two-dimensional `Tabs` (`docs/pages/includes/install-linux-self-hosted.mdx`).
- In some guides, collapse two-dimensional `Tabs` components to only require one dimension.
- In `install-linux-enterprise.mdx`, use the one-line installation script to simplify the instructions and avoid using `Tabs` entirely.