### PR TITLE
Add Oracle join tokens to web UI

### DIFF
--- a/lib/web/join_tokens.go
+++ b/lib/web/join_tokens.go
@@ -202,11 +202,14 @@ func (h *Handler) upsertTokenHandle(w http.ResponseWriter, r *http.Request, para
 		return nil, trace.BadParameter("renaming tokens is not supported")
 	}
 
-	// set expires time to default node join token TTL
-	expires := time.Now().UTC().Add(defaults.NodeJoinTokenTTL)
-	// IAM and GCP tokens should never expire
-	if req.JoinMethod == types.JoinMethodGCP || req.JoinMethod == types.JoinMethodIAM {
+	var expires time.Time
+	switch req.JoinMethod {
+	case types.JoinMethodGCP, types.JoinMethodIAM, types.JoinMethodOracle:
+		// IAM, GCP, and Oracle tokens should never expire.
 		expires = time.Now().UTC().AddDate(1000, 0, 0)
+	default:
+		// Set expires time to default node join token TTL.
+		expires = time.Now().UTC().Add(defaults.NodeJoinTokenTTL)
 	}
 
 	name := req.Name

--- a/web/packages/teleport/src/JoinTokens/JoinTokenForms.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokenForms.tsx
@@ -22,7 +22,11 @@ import FieldInput from 'shared/components/FieldInput';
 import { FieldSelectCreatable } from 'shared/components/FieldSelect';
 import { requiredField } from 'shared/components/Validation/rules';
 
-import { NewJoinTokenState, OptionGCP, RuleBox } from './UpsertJoinTokenDialog';
+import {
+  AllowOption,
+  NewJoinTokenState,
+  RuleBox,
+} from './UpsertJoinTokenDialog';
 
 export const JoinTokenIAMForm = ({
   tokenState,
@@ -149,7 +153,7 @@ export const JoinTokenGCPForm = ({
   function updateRuleField(
     index: number,
     fieldName: string,
-    opts: OptionGCP[]
+    opts: AllowOption[]
   ) {
     const newState = {
       ...tokenState,
@@ -189,7 +193,7 @@ export const JoinTokenGCPForm = ({
             isClearable
             isSearchable
             onChange={opts =>
-              updateRuleField(index, 'project_ids', opts as OptionGCP[])
+              updateRuleField(index, 'project_ids', opts as AllowOption[])
             }
             value={rule.project_ids}
             label="Add Project ID(s)"
@@ -201,7 +205,7 @@ export const JoinTokenGCPForm = ({
             isClearable
             isSearchable
             onChange={opts =>
-              updateRuleField(index, 'locations', opts as OptionGCP[])
+              updateRuleField(index, 'locations', opts as AllowOption[])
             }
             value={rule.locations}
             label="Add Locations"
@@ -213,7 +217,7 @@ export const JoinTokenGCPForm = ({
             isClearable
             isSearchable
             onChange={opts =>
-              updateRuleField(index, 'service_accounts', opts as OptionGCP[])
+              updateRuleField(index, 'service_accounts', opts as AllowOption[])
             }
             value={rule.service_accounts}
             label="Add Service Account Emails"
@@ -223,6 +227,113 @@ export const JoinTokenGCPForm = ({
       <ButtonText onClick={addNewRule} compact>
         <Plus size={16} mr={2} />
         Add another GCP Rule
+      </ButtonText>
+    </>
+  );
+};
+
+export const JoinTokenOracleForm = ({
+  tokenState,
+  onUpdateState,
+}: {
+  tokenState: NewJoinTokenState;
+  onUpdateState: (newToken: NewJoinTokenState) => void;
+}) => {
+  const rules = tokenState.oracle;
+  function removeRule(index: number) {
+    const newRules = rules.filter((_, i) => index !== i);
+    const newState = {
+      ...tokenState,
+      oracle: newRules,
+    };
+    onUpdateState(newState);
+  }
+
+  function addNewRule() {
+    const newState = {
+      ...tokenState,
+      oracle: [
+        ...tokenState.oracle,
+        { tenancy: '', parent_compartments: [], regions: [] },
+      ],
+    };
+    onUpdateState(newState);
+  }
+
+  function updateRuleField(
+    index: number,
+    fieldName: string,
+    opts: AllowOption[] | string
+  ) {
+    const newState = {
+      ...tokenState,
+      oracle: tokenState.oracle.map((rule, i) => {
+        if (i === index) {
+          return { ...rule, [fieldName]: opts };
+        }
+        return rule;
+      }),
+    };
+    onUpdateState(newState);
+  }
+
+  return (
+    <>
+      {rules.map((rule, index) => (
+        <RuleBox key={index}>
+          <Flex alignItems="center" justifyContent="space-between">
+            <Text fontWeight={700} mb={2}>
+              Oracle Rule
+            </Text>
+
+            {rules.length > 1 && ( // at least one rule is required, so lets not allow the user to remove it
+              <ButtonIcon
+                data-testid="delete_rule"
+                onClick={() => removeRule(index)}
+              >
+                <Trash size={16} color="text.muted" />
+              </ButtonIcon>
+            )}
+          </Flex>
+          <FieldInput
+            label="Tenancy"
+            rule={requiredField('tenancy OCID is required')}
+            placeholder="ocid1.tenancy.oc1..<unique ID>"
+            value={rule.tenancy}
+            onChange={e => updateRuleField(index, 'tenancy', e.target.value)}
+          />
+          <FieldSelectCreatable
+            placeholder="ocid1.compartment.oc1..<unique ID>"
+            isMulti
+            isClearable
+            isSearchable
+            onChange={opts =>
+              updateRuleField(
+                index,
+                'parent_compartments',
+                opts as AllowOption[]
+              )
+            }
+            value={rule.parent_compartments}
+            label="Add Compartments"
+            helperText="Direct parent compartments only, no nested compartments."
+          />
+          <FieldSelectCreatable
+            placeholder="us-ashburn-1, phx"
+            isMulti
+            isClearable
+            isSearchable
+            onChange={opts =>
+              updateRuleField(index, 'regions', opts as AllowOption[])
+            }
+            value={rule.regions}
+            label="Add Regions"
+          />
+        </RuleBox>
+      ))}
+      <ButtonText onClick={addNewRule} compact>
+        <Plus size={16} mr={2} />
+        Add another Oracle Rule
       </ButtonText>
     </>
   );

--- a/web/packages/teleport/src/JoinTokens/UpsertJoinTokenDialog.tsx
+++ b/web/packages/teleport/src/JoinTokens/UpsertJoinTokenDialog.tsx
@@ -47,7 +47,11 @@ import {
   JoinToken,
 } from 'teleport/services/joinToken';
 
-import { JoinTokenGCPForm, JoinTokenIAMForm } from './JoinTokenForms';
+import {
+  JoinTokenGCPForm,
+  JoinTokenIAMForm,
+  JoinTokenOracleForm,
+} from './JoinTokenForms';
 
 const maxWidth = '550px';
 
@@ -61,18 +65,25 @@ const joinRoleOptions: OptionJoinRole[] = [
   'Discovery',
 ].map(role => ({ value: role as JoinRole, label: role as JoinRole }));
 
-const availableJoinMethods: OptionJoinMethod[] = ['iam', 'gcp'].map(method => ({
-  value: method as JoinMethod,
-  label: method as JoinMethod,
-}));
+const availableJoinMethods: OptionJoinMethod[] = ['iam', 'gcp', 'oracle'].map(
+  method => ({
+    value: method as JoinMethod,
+    label: method as JoinMethod,
+  })
+);
 
-export type OptionGCP = Option<string, string>;
+export type AllowOption = Option<string, string>;
 type OptionJoinMethod = Option<JoinMethod, JoinMethod>;
 type OptionJoinRole = Option<JoinRole, JoinRole>;
 type NewJoinTokenGCPState = {
-  project_ids: OptionGCP[];
-  service_accounts: OptionGCP[];
-  locations: OptionGCP[];
+  project_ids: AllowOption[];
+  service_accounts: AllowOption[];
+  locations: AllowOption[];
+};
+type NewJoinTokenOracleState = {
+  tenancy: string;
+  parent_compartments: AllowOption[];
+  regions: AllowOption[];
 };
 
 export type NewJoinTokenState = {
@@ -83,6 +94,7 @@ export type NewJoinTokenState = {
   roles: OptionJoinRole[];
   iam: AWSRules[];
   gcp: NewJoinTokenGCPState[];
+  oracle: NewJoinTokenOracleState[];
 };
 
 export const defaultNewTokenState: NewJoinTokenState = {
@@ -92,6 +104,7 @@ export const defaultNewTokenState: NewJoinTokenState = {
   roles: [],
   iam: [{ aws_account: '', aws_arn: '' }],
   gcp: [{ project_ids: [], service_accounts: [], locations: [] }],
+  oracle: [{ tenancy: '', parent_compartments: [], regions: [] }],
 };
 
 function makeDefaultEditState(token: JoinToken): NewJoinTokenState {
@@ -108,6 +121,14 @@ function makeDefaultEditState(token: JoinToken): NewJoinTokenState {
       project_ids: r.project_ids?.map(i => ({ value: i, label: i })),
       service_accounts: r.service_accounts?.map(i => ({ value: i, label: i })),
       locations: r.locations?.map(i => ({ value: i, label: i })),
+    })),
+    oracle: token.oracle?.allow.map(r => ({
+      tenancy: r.tenancy,
+      parent_compartments: r.parent_compartments?.map(i => ({
+        value: i,
+        label: i,
+      })),
+      regions: r.regions?.map(i => ({ value: i, label: i })),
     })),
   };
 }
@@ -171,6 +192,19 @@ export const UpsertJoinTokenDialog = ({
         })),
       };
       request.gcp = gcp;
+    }
+
+    if (newTokenState.method.value === 'oracle') {
+      const oracle = {
+        allow: newTokenState.oracle.map(rule => ({
+          tenancy: rule.tenancy,
+          parent_compartments: rule.parent_compartments?.map(
+            compartment => compartment.value
+          ),
+          regions: rule.regions?.map(region => region.value),
+        })),
+      };
+      request.oracle = oracle;
     }
 
     runCreateTokenAttempt(request);
@@ -264,11 +298,7 @@ export const UpsertJoinTokenDialog = ({
                     editToken ? 'Editing token names is not supported.' : ''
                   }
                   rule={requiredField('Token name is required')}
-                  placeholder={
-                    newTokenState.method.value === 'iam'
-                      ? 'iam-token-name'
-                      : 'gcp-token-name'
-                  }
+                  placeholder={`${newTokenState.method.value}-token-name`}
                   autoFocus
                   value={newTokenState.name}
                   onChange={e => setTokenField('name', e.target.value)}
@@ -306,6 +336,12 @@ export const UpsertJoinTokenDialog = ({
               )}
               {newTokenState.method.value === 'gcp' && (
                 <JoinTokenGCPForm
+                  tokenState={newTokenState}
+                  onUpdateState={newState => setNewTokenState(newState)}
+                />
+              )}
+              {newTokenState.method.value === 'oracle' && (
+                <JoinTokenOracleForm
                   tokenState={newTokenState}
                   onUpdateState={newState => setNewTokenState(newState)}
                 />

--- a/web/packages/teleport/src/services/joinToken/types.ts
+++ b/web/packages/teleport/src/services/joinToken/types.ts
@@ -47,6 +47,9 @@ export type JoinToken = {
   gcp?: {
     allow: GCPRules[];
   };
+  oracle?: {
+    allow: OracleRules[];
+  };
 };
 
 // JoinRole defines built-in system roles and are roles associated with
@@ -82,7 +85,8 @@ export type JoinMethod =
   | 'circleci'
   | 'gitlab'
   | 'kubernetes'
-  | 'tpm';
+  | 'tpm'
+  | 'oracle';
 
 // JoinRule is a rule that a joining node must match in order to use the
 // associated token.
@@ -104,6 +108,12 @@ export type GCPRules = {
   service_accounts: string[];
 };
 
+export type OracleRules = {
+  tenancy: string;
+  parent_compartments: string[];
+  regions: string[];
+};
+
 export type JoinTokenRulesObject = AWSRules | GCPRules;
 
 export type CreateJoinTokenRequest = {
@@ -120,6 +130,9 @@ export type CreateJoinTokenRequest = {
   allow?: JoinTokenRulesObject[];
   gcp?: {
     allow: GCPRules[];
+  };
+  oracle?: {
+    allow: OracleRules[];
   };
 };
 


### PR DESCRIPTION
This change adds the Oracle join method (#41705) to the supported join methods for creating/editing in the web UI.

Resolves #51954.

Changelog: Added Oracle join method to web UI provision token editor