### PR TITLE
docs: update self-hosted config for db

### DIFF
--- a/docs/pages/includes/database-access/self-hosted-config-start.mdx
+++ b/docs/pages/includes/database-access/self-hosted-config-start.mdx
@@ -17,7 +17,7 @@ Service:
 $ sudo teleport db configure create \
    -o file \
    --token=/tmp/token \
-   --proxy=<Var name="example.teleport.sh" /> \
+   --proxy=<Var name="example.teleport.sh" />:443 \
    --name={{ dbName }} \
    --protocol={{ dbProtocol }} \
    --uri={{ databaseAddress }} \
@@ -37,7 +37,7 @@ To configure the Teleport Database Service to trust a custom CA:
    $ sudo teleport db configure create \
       -o file \
       --token=/tmp/token \
-      --proxy=<Var name="example.teleport.sh:443" /> \
+      --proxy=<Var name="example.teleport.sh" />:443 \
       --name={{ dbName }} \
       --protocol={{ dbProtocol }} \
       --uri={{ databaseAddress }} \
@@ -53,7 +53,7 @@ without exporting the CA:
 $ sudo teleport db configure create \
    -o file \
    --token=/tmp/token \
-   --proxy=<Var name="example.teleport.sh:443" /> \
+   --proxy=<Var name="example.teleport.sh" />:443 \
    --name={{ dbName }} \
    --protocol={{ dbProtocol }} \
    --uri={{ databaseAddress }} \


### PR DESCRIPTION
The configure example lacked a port specification (`:443`) which will cause an issue if not specified.  Also the variable was not consistently applied.