### PR TITLE
Fix web terminal ssh session creation race

### DIFF
--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -2047,7 +2047,7 @@ func TestTerminal(t *testing.T) {
 			})
 
 			require.NoError(t, err)
-			t.Cleanup(func() { require.True(t, utils.IsOKNetworkError(term.Close())) })
+			t.Cleanup(func() { require.NoError(t, term.Close()) })
 
 			// Send a command and validate the output
 			validateTerminal(t, term)

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -534,7 +534,12 @@ func (t *TerminalHandler) makeClient(ctx context.Context, stream *terminal.Strea
 	// used to update all other parties window size to that of the web client and
 	// to allow future window changes.
 	tc.OnShellCreated = func(s *tracessh.Session, c *tracessh.Client, _ io.ReadWriteCloser) (bool, error) {
-		t.stream.SessionCreated(s)
+		if err := t.stream.SessionCreated(s); err != nil {
+			t.logger.DebugContext(ctx, "terminating established ssh connection to host",
+				"error", err,
+			)
+			return false, trace.Wrap(s.Close())
+		}
 
 		// The web session was closed by the client while the ssh connection was being established.
 		// Attempt to close the SSH session instead of proceeding with the window change request.

--- a/lib/web/terminal/terminal.go
+++ b/lib/web/terminal/terminal.go
@@ -602,6 +602,9 @@ func (t *Stream) SessionCreated(s *tracessh.Session) error {
 func (t *Stream) Close() error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	if t.closed {
+		return nil
+	}
 	t.closed = true
 	if t.sshSession != nil {
 		return trace.NewAggregate(t.sshSession.Close(), t.WSStream.Close())


### PR DESCRIPTION
This fixes a data race I observed in an unrelated v16 backport test run: https://github.com/gravitational/teleport/actions/runs/13466661993/job/37634639889?pr=52403

```
==================
WARNING: DATA RACE
Read at 0x00c0209469f8 by goroutine 37792:
  github.com/gravitational/teleport/lib/web/terminal.(*Stream).Close()
      /__w/teleport/teleport/lib/web/terminal/terminal.go:595 +0xa4
  github.com/gravitational/teleport/lib/web.(*TerminalHandler).Close.func1()
      /__w/teleport/teleport/lib/web/terminal.go:423 +0x95
  sync.(*Once).doSlow()
      /opt/go/src/sync/once.go:76 +0xe1
  sync.(*Once).Do()
      /opt/go/src/sync/once.go:67 +0x44
  github.com/gravitational/teleport/lib/web.(*TerminalHandler).Close()
      /__w/teleport/teleport/lib/web/terminal.go:418 +0xe5
  github.com/gravitational/teleport/lib/web.(*TerminalHandler).handler.func2()
      /__w/teleport/teleport/lib/web/terminal.go:465 +0x195
  github.com/gorilla/websocket.(*Conn).advanceFrame()
      /go/pkg/mod/github.com/gorilla/websocket@v1.5.1/conn.go:991 +0x167d
  github.com/gorilla/websocket.(*Conn).NextReader()
      /go/pkg/mod/github.com/gorilla/websocket@v1.5.1/conn.go:1034 +0x290
  github.com/gorilla/websocket.(*Conn).ReadMessage()
      /go/pkg/mod/github.com/gorilla/websocket@v1.5.1/conn.go:1120 +0x2e
  github.com/gravitational/teleport/lib/web/terminal.(*WSStream).processMessages()
      /__w/teleport/teleport/lib/web/terminal/terminal.go:146 +0x1c7
  github.com/gravitational/teleport/lib/web/terminal.NewWStream.gowrap1()
      /__w/teleport/teleport/lib/web/terminal/terminal.go:447 +0x4f

Previous write at 0x00c0209469f8 by goroutine 37109:
  github.com/gravitational/teleport/lib/web/terminal.(*Stream).SessionCreated()
      /__w/teleport/teleport/lib/web/terminal/terminal.go:590 +0xe8
  github.com/gravitational/teleport/lib/web.(*TerminalHandler).makeClient.func1()
      /__w/teleport/teleport/lib/web/terminal.go:531 +0x5b
  github.com/gravitational/teleport/lib/client.(*NodeClient).RunInteractiveShell.(*NodeSession).runShell.func2()
      /__w/teleport/teleport/lib/client/session.go:539 +0x212
  github.com/gravitational/teleport/lib/client.(*NodeSession).interactiveSession()
      /__w/teleport/teleport/lib/client/session.go:318 +0x3cf
  github.com/gravitational/teleport/lib/client.(*NodeSession).runShell()
      /__w/teleport/teleport/lib/client/session.go:522 +0xde4
  github.com/gravitational/teleport/lib/client.(*NodeClient).RunInteractiveShell()
      /__w/teleport/teleport/lib/client/client.go:403 +0xc53
  github.com/gravitational/teleport/lib/web.(*TerminalHandler).streamTerminal()
      /__w/teleport/teleport/lib/web/terminal.go:867 +0x1009
  github.com/gravitational/teleport/lib/web.(*TerminalHandler).handler()
      /__w/teleport/teleport/lib/web/terminal.go:478 +0xd8d
  github.com/gravitational/teleport/lib/web.(*TerminalHandler).ServeHTTP()
      /__w/teleport/teleport/lib/web/terminal.go:358 +0x524
  github.com/gravitational/teleport/lib/httplib.MakeTracingHandler.func1()
      /__w/teleport/teleport/lib/httplib/httplib.go:104 +0x281
  net/http.HandlerFunc.ServeHTTP()
      /opt/go/src/net/http/server.go:2220 +0x47
  go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.(*middleware).serveHTTP()
      /go/pkg/mod/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.51.0/handler.go:212 +0x18bb
  go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.NewMiddleware.func1.1()
      /go/pkg/mod/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.51.0/handler.go:73 +0x67
  net/http.HandlerFunc.ServeHTTP()
      /opt/go/src/net/http/server.go:2220 +0x47
  github.com/gravitational/teleport/lib/web.(*Handler).siteNodeConnect()
      /__w/teleport/teleport/lib/web/apiserver.go:3636 +0x1b12
  github.com/gravitational/teleport/lib/web.(*Handler).siteNodeConnect-fm()
      <autogenerated>:1 +0xe9
  github.com/gravitational/teleport/lib/web.(*Handler).bindDefaultEndpoints.(*Handler).WithClusterAuthWebSocket.func31()
      /__w/teleport/teleport/lib/web/apiserver.go:4499 +0x235
  github.com/gravitational/teleport/lib/web.(*Handler).bindDefaultEndpoints.(*Handler).WithClusterAuthWebSocket.MakeHandler.MakeHandlerWithErrorWriter.func206()
      /__w/teleport/teleport/lib/httplib/httplib.go:127 +0xa5
  github.com/julienschmidt/httprouter.(*Router).ServeHTTP()
      /go/pkg/mod/github.com/gravitational/httprouter@v1.3.1-0.20220408074523-c876c5e705a5/router.go:399 +0xfcb
  github.com/gravitational/teleport/lib/web.(*Handler).ServeHTTP()
      <autogenerated>:1 +0x53
  github.com/gravitational/teleport/lib/web.NewHandler.func1.StripPrefix.1()
      /opt/go/src/net/http/server.go:2282 +0x471
  net/http.HandlerFunc.ServeHTTP()
      /opt/go/src/net/http/server.go:2220 +0x47
  github.com/gravitational/teleport/lib/web.NewHandler.func1()
      /__w/teleport/teleport/lib/web/apiserver.go:629 +0x1fc
  net/http.HandlerFunc.ServeHTTP()
      /opt/go/src/net/http/server.go:2220 +0x47
  github.com/julienschmidt/httprouter.(*Router).ServeHTTP()
      /go/pkg/mod/github.com/gravitational/httprouter@v1.3.1-0.20220408074523-c876c5e705a5/router.go:460 +0xda1
  github.com/gravitational/teleport/lib/web.(*APIHandler).ServeHTTP()
      /__w/teleport/teleport/lib/web/apiserver.go:454 +0xae9
  net/http.serverHandler.ServeHTTP()
      /opt/go/src/net/http/server.go:3210 +0x2a1
  net/http.(*conn).serve()
      /opt/go/src/net/http/server.go:2092 +0x12a4
  net/http.(*Server).Serve.gowrap3()
      /opt/go/src/net/http/server.go:3360 +0x4f
```
