### PR TITLE
docs: update proxy recording mode tctl instrs

### DIFF
--- a/docs/pages/enroll-resources/server-access/guides/recording-proxy-mode.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/recording-proxy-mode.mdx
@@ -100,7 +100,7 @@ Now, `sshd` will trust users who present a Teleport-issued certificate.
 The next step is to configure host authentication.
 
 The recommended solution is to ask Teleport to issue valid host certificates for
-all OpenSSH nodes. To generate a host certificate, run this on your Teleport Auth Server:
+all OpenSSH nodes. To generate a host certificate, run this command:
 
 ```code
 # Creating host certs, with an array of every host to be accessed.
@@ -108,7 +108,7 @@ all OpenSSH nodes. To generate a host certificate, run this on your Teleport Aut
 # qualified.
 # Management of the host certificates can become complex. This is another
 # reason we recommend using Teleport SSH on nodes.
-$ sudo tctl auth sign \
+$ tctl auth sign \
       --host=api.example.com,ssh.example.com,64.225.88.175,64.225.88.178 \
       --format=openssh \
       --out=api.example.com


### PR DESCRIPTION
The pre-reqs have the user logged in remotely with access to `tctl`. To generate the certs the user does not need to directly issue from the auth server.