### PR TITLE
[teleport-update] Revert log level change

### DIFF
--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -375,7 +375,7 @@ func (s SystemdService) Enable(ctx context.Context, now bool) error {
 	if now {
 		args = append(args, "--now")
 	}
-	code := s.systemctl(ctx, slog.LevelError, args...)
+	code := s.systemctl(ctx, slog.LevelInfo, args...)
 	if code != 0 {
 		return trace.Errorf("unable to enable systemd service")
 	}
@@ -392,7 +392,7 @@ func (s SystemdService) Disable(ctx context.Context, now bool) error {
 	if now {
 		args = append(args, "--now")
 	}
-	code := s.systemctl(ctx, slog.LevelError, args...)
+	code := s.systemctl(ctx, slog.LevelInfo, args...)
 	if code != 0 {
 		return trace.Errorf("unable to disable systemd service")
 	}


### PR DESCRIPTION
This PR reverts a log level change mistakenly included in https://github.com/gravitational/teleport/pull/52152.

When systemd services are enabled or disabled, systemctl should not output the created/removed symlink to stderr (in red).

---

The `teleport-update` binary will be used to enable, disable, and trigger automatic Teleport agent updates. The new auto-updates system manages a local installation of the cluster-specified version of Teleport stored in `/opt/teleport`.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/11856