### PR TITLE
[v17] Use ExactKey for WorkloadIdentityParser to avoid parsing WorkloadIdentityX509Revocations

### DIFF
--- a/lib/services/local/workload_identity.go
+++ b/lib/services/local/workload_identity.go
@@ -121,7 +121,7 @@ func (b *WorkloadIdentityService) UpdateWorkloadIdentity(
 
 func newWorkloadIdentityParser() *workloadIdentityParser {
 	return &workloadIdentityParser{
-		baseParser: newBaseParser(backend.NewKey(workloadIdentityPrefix)),
+		baseParser: newBaseParser(backend.ExactKey(workloadIdentityPrefix)),
 	}
 }
 

--- a/lib/services/local/workload_identity_test.go
+++ b/lib/services/local/workload_identity_test.go
@@ -355,6 +355,7 @@ func TestWorkloadIdentityService_UpdateWorkloadIdentity(t *testing.T) {
 }
 
 func TestWorkloadIdentityParser(t *testing.T) {
+	t.Parallel()
 	parser := newWorkloadIdentityParser()
 	t.Run("delete", func(t *testing.T) {
 		event := backend.Event{


### PR DESCRIPTION
Backport #52375 to branch/v17