### PR TITLE
Fix test flakes related to Kubernetes user cert generation

### DIFF
--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -735,6 +735,16 @@ func TestAuthenticateSSHUser(t *testing.T) {
 	_, err = s.a.UpsertKubernetesServer(ctx, kubeServer)
 	require.NoError(t, err)
 
+	// Wait for cache propagation of the kubernetes resources before proceeding with the tests.
+	require.Eventually(t, func() bool {
+		for ks := range s.a.UnifiedResourceCache.KubernetesServers(ctx, services.UnifiedResourcesIterateParams{}) {
+			if ks.GetCluster().GetName() == kubeCluster.GetName() {
+				return true
+			}
+		}
+		return false
+	}, 10*time.Second, 100*time.Millisecond)
+
 	// Login specifying a valid kube cluster. It should appear in the TLS cert.
 	resp, err = s.a.AuthenticateSSHUser(ctx, authclient.AuthenticateSSHRequest{
 		AuthenticateUserRequest: authclient.AuthenticateUserRequest{

--- a/tool/tsh/common/tsh_helper_test.go
+++ b/tool/tsh/common/tsh_helper_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/gravitational/teleport/lib/config"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -482,10 +483,8 @@ func mustRegisterKubeClusters(t *testing.T, ctx context.Context, authSrv *auth.S
 	require.NoError(t, wg.Wait())
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		servers, err := authSrv.GetKubernetesServers(ctx)
-		assert.NoError(c, err)
 		gotNames := map[string]struct{}{}
-		for _, ks := range servers {
+		for ks := range authSrv.UnifiedResourceCache.KubernetesServers(ctx, services.UnifiedResourcesIterateParams{}) {
 			gotNames[ks.GetName()] = struct{}{}
 		}
 		for _, name := range wantNames {


### PR DESCRIPTION
#52109 added a dependency on the unified resource cache to user cert generation to reduce resource consumption. A number of tests that exercise generating Kubernetes user certs were either not waiting for the Kubernetes resources to exist prior to authentication and getting lucky, or checking that the resources were in the auth cache, but not the unified resource cache.

This attempts to cover any tests which generate Kubernetes user certificates to verify that the unified resource cache contains the expected cluster before proceeding.

Fixes #52157.
Fixes #52441.