### PR TITLE
[v17][vnet] install wintun.dll and VNet service with Connect on Windows

### DIFF
--- a/build.assets/windows/build.ps1
+++ b/build.assets/windows/build.ps1
@@ -165,6 +165,33 @@ function Enable-Node {
     }
 }
 
+function Install-Wintun {
+    <#
+    .SYNOPSIS
+        Downloads wintun.dll into the supplied dir
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string] $InstallDir
+    )
+    begin {
+        Write-Host "::group::Installing wintun.dll to $InstallDir..."
+        New-Item -Path "$InstallDir" -ItemType Directory -Force | Out-Null
+        $WintunZipfile = "$InstallDir/wintun.zip"
+        Invoke-WebRequest -Uri https://www.wintun.net/builds/wintun-0.14.1.zip -OutFile $WintunZipfile
+        $ExpectedHash = "07C256185D6EE3652E09FA55C0B673E2624B565E02C4B9091C79CA7D2F24EF51"
+        $ZipFileHash = Get-FileHash -Path $WintunZipFile -Algorithm SHA256
+        if ($ZipFileHash.Hash -ne $ExpectedHash) {
+            Write-Host "checksum: $ZipFileHash"
+            throw "Checksum verification for wintun.zip failed! Expected $ExpectedHash but got $($ZipFileHash.Hash)"
+        }
+        Expand-Archive -Force -Path $WintunZipfile -DestinationPath $InstallDir
+        Move-Item -Force -Path "$InstallDir/wintun/bin/amd64/wintun.dll" -Destination "$InstallDir/wintun.dll"
+        Write-Host "::endgroup::"
+    }
+}
+
 function Get-Relcli {
     <#
     .SYNOPSIS
@@ -440,6 +467,8 @@ function Build-Connect {
 
     $CommandDuration = Measure-Block {
         Write-Host "::group::Building Teleport Connect..."
+        Install-Wintun -InstallDir "$TeleportSourceDirectory\wintun"
+        $env:CONNECT_WINTUN_DLL_PATH = "$TeleportSourceDirectory\wintun\wintun.dll"
         $env:CONNECT_TSH_BIN_PATH = "$SignedTshBinaryPath"
         pnpm install --frozen-lockfile
         pnpm build-term

--- a/web/packages/teleterm/README.md
+++ b/web/packages/teleterm/README.md
@@ -135,6 +135,14 @@ When running `pnpm package-term`, you need to provide these environment variable
 
 The details behind those vars are described below.
 
+### Windows
+
+Packaging Connect on Windows requires wintun.dll, which VNet uses to create a
+virtual network interface.
+A zip file containing the DLL can be downloaded from https://www.wintun.net/builds/wintun-0.14.1.zip
+Extract the zip file and then pass the path to wintun.dll to `pnpm package-term`
+with the `CONNECT_WINTUN_DLL_PATH` environment variable.
+
 #### tsh.app
 
 Unlike other platforms, macOS needs the whole tsh.app to be bundled with Connect, not just the tsh

--- a/web/packages/teleterm/build_resources/installer.nsh
+++ b/web/packages/teleterm/build_resources/installer.nsh
@@ -13,6 +13,15 @@
     # Make EnVar define user env vars instead of system env vars.
     EnVar::SetHKCU
     EnVar::AddValue "Path" $INSTDIR\resources\bin
+
+    nsExec::ExecToStack '"$INSTDIR\resources\bin\tsh.exe" vnet-install-service'
+    Pop $0 # ExitCode
+    Pop $1 # Output
+    ${If} $0 != 0
+        MessageBox MB_ICONSTOP \
+            "tsh.exe vnet-install-service failed with exit code $0. Output: $1"
+        Quit
+    ${Endif}
 !macroend
 
 !macro customUnInstall
@@ -21,4 +30,12 @@
     # Fortunately, electron-builder puts the uninstaller directly into the actual installation dir.
     # https://nsis.sourceforge.io/Docs/Chapter4.html#varother
     EnVar::DeleteValue "Path" $INSTDIR\resources\bin
+
+    nsExec::ExecToStack 'sc delete TeleportVNet'
+    Pop $0 # ExitCode
+    Pop $1 # Output
+    ${If} $0 != 0
+        MessageBox MB_ICONSTOP \
+            "sc delete TeleportVNet failed with exit code $0. Output: $1"
+    ${Endif}
 !macroend


### PR DESCRIPTION
Backport #52366 to branch/v17

This was already merged to v17 but reverted because it should wait for 17.3. This PR should be held until we are ready to release v17.3.0.

Changelog: Connect is now installed per-machine instead of per-user on Windows