### PR TITLE
Run diag checks periodically in Connect

### DIFF
--- a/tool/tsh/common/vnet.go
+++ b/tool/tsh/common/vnet.go
@@ -19,7 +19,6 @@ package common
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
@@ -66,15 +65,7 @@ func (c *vnetCommand) run(cf *CLIConf) error {
 
 	if c.runDiag {
 		go func() {
-			timeout := 2 * time.Second
-			fmt.Printf("Running diagnostics in %s.\n", timeout)
-			select {
-			case <-cf.Context.Done():
-				return
-			case <-time.After(timeout):
-			}
-			// Sleep is needed to give the admin process time to actually set up the routes.
-			// TODO(ravicious): Figure out how to guarantee that routes are set up without sleeping.
+			fmt.Println("Running diagnostics.")
 			//nolint:staticcheck // SA4023. runVnetDiagnostics on unsupported platforms always returns err.
 			if err := runVnetDiagnostics(cf.Context, nsi); err != nil {
 				logger.ErrorContext(cf.Context, "Ran into a problem while running diagnostics", "error", err)

--- a/tool/tsh/common/vnet_darwin.go
+++ b/tool/tsh/common/vnet_darwin.go
@@ -101,7 +101,6 @@ func newPlatformVnetUninstallServiceCommand(app *kingpin.Application) vnetComman
 }
 
 func runVnetDiagnostics(ctx context.Context, nsi vnet.NetworkStackInfo) error {
-	fmt.Println("Running diagnostics.")
 	routeConflictDiag, err := diag.NewRouteConflictDiag(&diag.RouteConflictConfig{
 		VnetIfaceName: nsi.IfaceName,
 		Routing:       &diag.DarwinRouting{},

--- a/web/packages/shared/hooks/useAsync.test.ts
+++ b/web/packages/shared/hooks/useAsync.test.ts
@@ -57,6 +57,11 @@ test('run resolves the promise to an error and does not update the state on unmo
   await expect(promise).resolves.toEqual([null, new CanceledError()]);
   const [attempt] = result.current;
   expect(attempt.status).toBe('processing');
+
+  const [, error] = await promise;
+  await expect(
+    error instanceof CanceledError && error.stalePromise
+  ).resolves.toEqual(expect.any(Symbol));
 });
 
 test('run resolves the promise to an error and does not update the state on unmount when the callback returns a rejected promise', async () => {
@@ -74,6 +79,11 @@ test('run resolves the promise to an error and does not update the state on unmo
   await expect(promise).resolves.toEqual([null, new CanceledError()]);
   const [attempt] = result.current;
   expect(attempt.status).toBe('processing');
+
+  const [, error] = await promise;
+  await expect(
+    error instanceof CanceledError && error.stalePromise
+  ).rejects.toThrow(expect.objectContaining({ message: 'oops' }));
 });
 
 test('run resolves the promise to an error after being re-run when the callback returns a resolved promise', async () => {
@@ -94,6 +104,11 @@ test('run resolves the promise to an error after being re-run when the callback 
   await waitFor(() =>
     expect(firstRunPromise).resolves.toEqual([null, new CanceledError()])
   );
+
+  const [, error] = await firstRunPromise;
+  await expect(
+    error instanceof CanceledError && error.stalePromise
+  ).resolves.toEqual(1);
 });
 
 test('run does not update state after being re-run when the callback returns a resolved promise', async () => {
@@ -155,6 +170,11 @@ test('run resolves the promise to an error after being re-run when the callback 
   await waitFor(() =>
     expect(firstRunPromise).resolves.toEqual([null, new CanceledError()])
   );
+
+  const [, error] = await firstRunPromise;
+  await expect(
+    error instanceof CanceledError && error.stalePromise
+  ).rejects.toThrow(expect.objectContaining({ message: 'oops 1' }));
 });
 
 test('run does not update state after being re-run when the callback returns a rejected promise', async () => {

--- a/web/packages/teleterm/src/services/tshd/interceptors.ts
+++ b/web/packages/teleterm/src/services/tshd/interceptors.ts
@@ -22,7 +22,18 @@ import { isObject } from 'shared/utils/highbar';
 
 import Logger from 'teleterm/logger';
 
-const SENSITIVE_PROPERTIES = ['password', 'authClusterId', 'pin', 'puk'];
+const SENSITIVE_PROPERTIES = [
+  'password',
+  'authClusterId',
+  'pin',
+  'puk',
+  // Filter out output of auxiliary commands run as a part of VNet diag report.
+  // Diagnostics are run periodically and the command outputs are typically dozens of lines long, so
+  // it'd be a waste of space to log them.
+  //
+  // TODO(ravicious): Do not filter out commands if RuntimeSettings.debug is true.
+  'commands',
+];
 
 export function loggingInterceptor(logger: Logger): RpcInterceptor {
   return {

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
@@ -35,7 +35,7 @@ import { HoverTooltip } from 'design/Tooltip';
 import { copyToClipboard } from 'design/utils/copyToClipboard';
 import { Timestamp } from 'gen-proto-ts/google/protobuf/timestamp_pb';
 import * as diag from 'gen-proto-ts/teleport/lib/vnet/diag/v1/diag_pb';
-import { useAsync } from 'shared/hooks/useAsync';
+import { CanceledError, useAsync } from 'shared/hooks/useAsync';
 import { pluralize } from 'shared/utils/text';
 
 import { reportOneOfIsRouteConflictReport } from 'teleterm/helpers';
@@ -68,6 +68,11 @@ export function DocumentVnetDiagReport(props: {
     useCallback(async () => {
       const [report, error] = await runDiagnostics();
       if (error) {
+        // If the manual run is made stale by VNet context executing a periodic run, use the result
+        // of the manual run anyway.
+        if (error instanceof CanceledError && error.stalePromise) {
+          return error.stalePromise as Promise<diag.Report>;
+        }
         throw error;
       }
       return report;

--- a/web/packages/teleterm/src/ui/Vnet/VnetConnectionItem.test.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetConnectionItem.test.tsx
@@ -31,7 +31,10 @@ describe('VnetSliderStepHeader', () => {
     render(
       <MockAppContextProvider>
         <VnetContextProvider>
-          <VnetSliderStepHeader goBack={() => {}} />
+          <VnetSliderStepHeader
+            goBack={() => {}}
+            runDiagnosticsFromVnetPanel={() => Promise.resolve()}
+          />
         </VnetContextProvider>
       </MockAppContextProvider>
     );
@@ -68,7 +71,10 @@ describe('VnetSliderStepHeader', () => {
     render(
       <MockAppContextProvider appContext={appContext}>
         <VnetContextProvider>
-          <VnetSliderStepHeader goBack={() => {}} />
+          <VnetSliderStepHeader
+            goBack={() => {}}
+            runDiagnosticsFromVnetPanel={() => Promise.resolve()}
+          />
         </VnetContextProvider>
       </MockAppContextProvider>
     );

--- a/web/packages/teleterm/src/ui/Vnet/VnetConnectionItem.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetConnectionItem.tsx
@@ -57,7 +57,10 @@ export const VnetConnectionItem = (props: {
   );
 };
 
-export const VnetSliderStepHeader = (props: { goBack: () => void }) => (
+export const VnetSliderStepHeader = (props: {
+  goBack: () => void;
+  runDiagnosticsFromVnetPanel: () => Promise<unknown>;
+}) => (
   <VnetConnectionItemBase
     title="Go back to Connections"
     onClick={props.goBack}
@@ -65,6 +68,7 @@ export const VnetSliderStepHeader = (props: { goBack: () => void }) => (
     showExtraRightButtons
     // Make the element focusable.
     tabIndex={0}
+    runDiagnosticsFromVnetPanel={props.runDiagnosticsFromVnetPanel}
   />
 );
 
@@ -78,7 +82,13 @@ const VnetConnectionItemBase = forwardRef<
     showExtraRightButtons?: boolean;
     isActive?: boolean;
     tabIndex?: number;
-  }
+  } & (
+    | { showExtraRightButtons?: false }
+    | {
+        showExtraRightButtons: true;
+        runDiagnosticsFromVnetPanel: () => Promise<unknown>;
+      }
+  )
 >((props, ref) => {
   const { configService } = useAppContext();
   const isVnetDiagEnabled = configService.get('unstable.vnetDiag').value;
@@ -88,7 +98,6 @@ const VnetConnectionItemBase = forwardRef<
     stop,
     startAttempt,
     stopAttempt,
-    runDiagnostics,
     diagnosticsAttempt,
     getDisabledDiagnosticsReason,
   } = useVnetContext();
@@ -193,7 +202,7 @@ const VnetConnectionItemBase = forwardRef<
                   disabled={!!disabledDiagnosticsReason}
                   onClick={e => {
                     e.stopPropagation();
-                    runDiagnostics();
+                    props.runDiagnosticsFromVnetPanel();
                   }}
                 >
                   <icons.ListMagnifyingGlass size={18} />


### PR DESCRIPTION
This PR makes it so that after starting VNet, Connect runs a diagnostic check immediately after and then every 30 seconds. Showing a notification and warning indicators will be implemented in another PR as it turned out to be surprisingly complex.

The previous implementation that had no periodic runs always showed an alert that can be dismissed. In order to simplify the implementation and the UX of the VNet panel, I changed things slightly. Now when everything's okay, we show just a subtle text that cannot be dismissed. If the user gets a report that found issues or there were checks that failed to complete, they can dismiss the alert. 

The general rationale for this approach goes like this: the diag check might find false positives. In that case, we want the user to be able to dismiss those results. If 30 seconds later Connect re-runs the diag check and finds the same results, we don't want to show them to the user. This is achieved by flipping a flag in the context (`hasDismissedDiagnosticsAlert`) when the user dismisses the alert and then flipping it back only when they manually request a diagnostic run through the VNet panel.

| No issues found | Issues found |
| --- | --- |
| <img width="413" alt="no-issues-found" src="https://github.com/user-attachments/assets/252b7845-86a1-4865-b984-227d2c3a3055" /> | <img width="413" alt="issues-found" src="https://github.com/user-attachments/assets/38be7553-5961-4deb-86e9-39f416bb57b7" /> |

---

In order to be able to run diagnostics immediately after starting VNet, I had to account for an edge case. When VNet starts, the admin VNet process takes just a little bit of time to set up network routes for VNet, it's a separate process after all. Those network routes are used for diagnostics and the diagnostics run from tshd. To account for the routes not being set up yet, I changed the diag check to re-fetch the routes up to two times if there are no VNet routes present. This way the RPC that runs diagnostics waits for the routes to be present.

If the routes are not present after three attempts, the diag check returns no issues. We cannot return an error at this point, as technically no VNet routes is a valid scenario in case where the user is not logged in to any cluster. We could return an error if there are no routes and the user is logged in to a cluster, but I didn't feel like making the check code more complex.

Besides, if we ever get around to introducing the second diag check that's going to check responses to DNS queries, it'll necessitate setting up a fake DNS zone (say `teleport-vnet.test`) which in turn will make VNet always set up network routes, even if the user is not logged in to any cluster.