### PR TITLE
Show notification and warning indicators for periodic VNet diag checks

### DIFF
--- a/web/packages/shared/hooks/index.ts
+++ b/web/packages/shared/hooks/index.ts
@@ -29,3 +29,5 @@ export {
   useInterval,
   useInfiniteScroll,
 };
+
+export { useStateRef } from './useStateRef';

--- a/web/packages/shared/hooks/useStateRef.test.ts
+++ b/web/packages/shared/hooks/useStateRef.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+
+import { useStateRef } from './useStateRef';
+
+it('updates both state and ref at the same time when passing a regular value', () => {
+  const { result } = renderHook(props => useStateRef(props.initialState), {
+    initialProps: { initialState: false },
+  });
+  let [state, ref, setState] = result.current;
+  expect(state).toBe(false);
+  expect(ref.current).toBe(false);
+
+  act(() => {
+    setState(true);
+  });
+
+  [state, ref] = result.current;
+  expect(state).toBe(true);
+  expect(ref.current).toBe(true);
+
+  // @ts-expect-error ref.current should be readonly.
+  ref.current = false;
+});
+
+it('updates both state and ref at the same time when passing an updater function', () => {
+  const { result } = renderHook(props => useStateRef(props.initialState), {
+    initialProps: { initialState: false },
+  });
+  let [state, ref, setState] = result.current;
+  expect(state).toBe(false);
+  expect(ref.current).toBe(false);
+
+  act(() => {
+    setState(currentValue => !currentValue);
+  });
+
+  [state, ref] = result.current;
+  expect(state).toBe(true);
+  expect(ref.current).toBe(true);
+});

--- a/web/packages/shared/hooks/useStateRef.ts
+++ b/web/packages/shared/hooks/useStateRef.ts
@@ -66,5 +66,5 @@ export function useStateRef<T>(
     }
   }, []);
 
-  return [state, stateRef, setStateAndRef] as const;
+  return [state, stateRef, setStateAndRef];
 }

--- a/web/packages/shared/hooks/useStateRef.ts
+++ b/web/packages/shared/hooks/useStateRef.ts
@@ -1,0 +1,70 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  Dispatch,
+  RefObject,
+  SetStateAction,
+  useCallback,
+  useRef,
+  useState,
+} from 'react';
+
+/**
+ * useStateRef creates a piece of state and a ref reflecting a value of the state and a setter that
+ * updates both the state and the ref. Useful is situations where an event handler needs to read the
+ * value of the state without making its identity dependent on the value of the state.
+ *
+ * @example
+ *
+ * const [isOpen, isOpenRef, setIsOpen] = useStateRef(false)
+ *
+ * const sendNotification = useCallback(() => {
+ *   if (isOpenRef.current) {
+ *     return;
+ *   }
+ *
+ *   client.sendNotification(foo);
+ * }, [client, foo]);
+ *
+ * useEffect(() => {
+ *   setInterval(sendNotification, 5000);
+ *
+ *   return () => {
+ *     // cleanup
+ *   }
+ * }, [sendNotification])
+ */
+export function useStateRef<T>(
+  initialState: T
+): [T, RefObject<T>, Dispatch<SetStateAction<T>>] {
+  const stateRef = useRef(initialState);
+  const [state, setState] = useState(initialState);
+
+  const setStateAndRef = useCallback((newState: SetStateAction<T>) => {
+    setState(newState);
+
+    if (typeof newState === 'function') {
+      stateRef.current = (newState as (prevState: T) => T)(stateRef.current);
+    } else {
+      stateRef.current = newState;
+    }
+  }, []);
+
+  return [state, stateRef, setStateAndRef] as const;
+}

--- a/web/packages/teleterm/src/services/vnet/diag.ts
+++ b/web/packages/teleterm/src/services/vnet/diag.ts
@@ -22,6 +22,13 @@ import * as diag from 'gen-proto-ts/teleport/lib/vnet/diag/v1/diag_pb';
 
 import { reportOneOfIsRouteConflictReport } from 'teleterm/helpers';
 
+export const hasReportFoundIssues = (report: diag.Report): boolean =>
+  report.checks.some(
+    checkAttempt =>
+      checkAttempt.status === diag.CheckAttemptStatus.OK &&
+      checkAttempt.checkReport.status === diag.CheckReportStatus.ISSUES_FOUND
+  );
+
 export const getReportFilename = (report: diag.Report) => {
   const createdAt = displayDateTime(Timestamp.toDate(report.createdAt));
   // Colons are best avoided on macOS and forbidden on Windows.

--- a/web/packages/teleterm/src/services/vnet/testHelpers.ts
+++ b/web/packages/teleterm/src/services/vnet/testHelpers.ts
@@ -44,6 +44,20 @@ export const makeReport = (props: Partial<Report> = {}): Report => ({
   ...props,
 });
 
+export const makeReportWithIssuesFound = (
+  props: Partial<Report> = {}
+): Report =>
+  makeReport({
+    checks: [
+      makeCheckAttempt({
+        checkReport: makeCheckReport({
+          status: CheckReportStatus.ISSUES_FOUND,
+        }),
+      }),
+    ],
+    ...props,
+  });
+
 export const makeCheckAttempt = (
   props: Partial<CheckAttempt> = {}
 ): CheckAttempt => ({

--- a/web/packages/teleterm/src/ui/TopBar/Connections/Connections.story.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/Connections.story.tsx
@@ -16,12 +16,19 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { Meta } from '@storybook/react';
 import { useLayoutEffect } from 'react';
 
 import { Flex, Text } from 'design';
+import { CheckReportStatus } from 'gen-proto-ts/teleport/lib/vnet/diag/v1/diag_pb';
 
 import { MockedUnaryCall } from 'teleterm/services/tshd/cloneableClient';
 import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
+import {
+  makeCheckAttempt,
+  makeCheckReport,
+  makeReport,
+} from 'teleterm/services/vnet/testHelpers';
 import AppContextProvider from 'teleterm/ui/appContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import { VnetContextProvider } from 'teleterm/ui/Vnet';
@@ -29,7 +36,7 @@ import { VnetContextProvider } from 'teleterm/ui/Vnet';
 import { Connections } from './Connections';
 import { ConnectionsContextProvider } from './connectionsContext';
 
-export default {
+const meta: Meta = {
   title: 'Teleterm/TopBar/Connections',
   decorators: [
     Story => {
@@ -39,6 +46,7 @@ export default {
     },
   ],
 };
+export default meta;
 
 const rootClusterUri = '/clusters/foo';
 
@@ -108,6 +116,42 @@ export function JustVnetWithNoClusters() {
   const appContext = new MockAppContext();
   prepareAppContext(appContext);
   appContext.connectionTracker.getConnections = () => [];
+
+  return (
+    <AppContextProvider value={appContext}>
+      <ConnectionsContextProvider>
+        <VnetContextProvider>
+          <Connections />
+        </VnetContextProvider>
+      </ConnectionsContextProvider>
+    </AppContextProvider>
+  );
+}
+
+export function VnetWarning() {
+  const appContext = new MockAppContext();
+  prepareAppContext(appContext);
+
+  appContext.configService.set('unstable.vnetDiag', true);
+  appContext.statePersistenceService.putState({
+    ...appContext.statePersistenceService.getState(),
+    vnet: { autoStart: true },
+  });
+  appContext.workspacesService.setState(draft => {
+    draft.isInitialized = true;
+  });
+  appContext.vnet.runDiagnostics = () =>
+    new MockedUnaryCall({
+      report: makeReport({
+        checks: [
+          makeCheckAttempt({
+            checkReport: makeCheckReport({
+              status: CheckReportStatus.ISSUES_FOUND,
+            }),
+          }),
+        ],
+      }),
+    });
 
   return (
     <AppContextProvider value={appContext}>

--- a/web/packages/teleterm/src/ui/TopBar/Connections/Connections.story.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/Connections.story.tsx
@@ -20,15 +20,10 @@ import { Meta } from '@storybook/react';
 import { useLayoutEffect } from 'react';
 
 import { Flex, Text } from 'design';
-import { CheckReportStatus } from 'gen-proto-ts/teleport/lib/vnet/diag/v1/diag_pb';
 
 import { MockedUnaryCall } from 'teleterm/services/tshd/cloneableClient';
 import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
-import {
-  makeCheckAttempt,
-  makeCheckReport,
-  makeReport,
-} from 'teleterm/services/vnet/testHelpers';
+import { makeReportWithIssuesFound } from 'teleterm/services/vnet/testHelpers';
 import AppContextProvider from 'teleterm/ui/appContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import { VnetContextProvider } from 'teleterm/ui/Vnet';
@@ -142,15 +137,7 @@ export function VnetWarning() {
   });
   appContext.vnet.runDiagnostics = () =>
     new MockedUnaryCall({
-      report: makeReport({
-        checks: [
-          makeCheckAttempt({
-            checkReport: makeCheckReport({
-              status: CheckReportStatus.ISSUES_FOUND,
-            }),
-          }),
-        ],
-      }),
+      report: makeReportWithIssuesFound(),
     });
 
   return (

--- a/web/packages/teleterm/src/ui/TopBar/Connections/Connections.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/Connections.tsx
@@ -34,10 +34,17 @@ export function Connections() {
   connectionTracker.useState();
   const iconRef = useRef();
   const { isOpen, toggle, close, stepToOpen } = useConnectionsContext();
-  const { status: vnetStatus } = useVnetContext();
+  const { status: vnetStatus, showDiagWarningIndicator } = useVnetContext();
   const isAnyConnectionActive =
     connectionTracker.getConnections().some(c => c.connected) ||
     vnetStatus.value === 'running';
+  const status = useMemo(() => {
+    if (showDiagWarningIndicator) {
+      return 'warning';
+    }
+
+    return isAnyConnectionActive ? 'on' : 'off';
+  }, [showDiagWarningIndicator, isAnyConnectionActive]);
 
   useKeyboardShortcuts(
     useMemo(
@@ -59,11 +66,7 @@ export function Connections() {
 
   return (
     <>
-      <ConnectionsIcon
-        isAnyConnectionActive={isAnyConnectionActive}
-        onClick={toggle}
-        ref={iconRef}
-      />
+      <ConnectionsIcon status={status} onClick={toggle} ref={iconRef} />
       <Popover
         open={isOpen}
         anchorEl={iconRef.current}

--- a/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionStatusIndicator.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionStatusIndicator.tsx
@@ -113,7 +113,8 @@ const StyledStatus = styled(Box)<{
             `
             position: absolute;
             top: -1px;
-            left: -2px;
+            // Visually, -1px seems to be better aligned than -2px.
+            left: -1px;
             line-height: 8px;
             `}
           }

--- a/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionStatusIndicator.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionStatusIndicator.tsx
@@ -89,22 +89,23 @@ const StyledStatus = styled(Box)<{
         // To verify that the position of the cross is correct, move the &:after pseudoselector
         // outside of this switch to StyledStatus.
         return css`
-          color: ${theme.colors.error.main};
+          color: ${theme.colors.interactive.solid.danger.default};
           &:after {
-            content: '𐄂';
-            font-size: 19px;
+            // This is "multiplication X" (U+2715) as "aegan check mark" (U+10102) doesn't work on
+            // Windows.
+            content: '✕';
+            font-size: 12px;
 
             ${!props.$inline &&
             `position: absolute;
-            top: -3px;
-            left: -1px;
-            line-height: 8px;`}
+            top: -8px;
+            `}
           }
         `;
       }
       case 'warning': {
         return css`
-          color: ${theme.colors.warning.main};
+          color: ${theme.colors.interactive.solid.alert.default};
           &:after {
             content: '⚠';
             font-size: 12px;
@@ -113,7 +114,8 @@ const StyledStatus = styled(Box)<{
             `
             position: absolute;
             top: -1px;
-            // Visually, -1px seems to be better aligned than -2px.
+            // Visually, -1px seems to be better aligned than -2px, especially when looking at
+            // VnetWarning story.
             left: -1px;
             line-height: 8px;
             `}

--- a/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsIcon/ConnectionsIcon.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsIcon/ConnectionsIcon.tsx
@@ -24,34 +24,33 @@ import { Cluster } from 'design/Icon';
 
 import { useKeyboardShortcutFormatters } from 'teleterm/ui/services/keyboardShortcuts';
 
-import { ConnectionsIconStatusIndicator } from './ConnectionsIconStatusIndicator';
+import {
+  ConnectionsIconStatusIndicator,
+  Status,
+} from './ConnectionsIconStatusIndicator';
 
-interface ConnectionsIconProps {
-  isAnyConnectionActive: boolean;
-
-  onClick(): void;
-}
-
-export const ConnectionsIcon = forwardRef<HTMLDivElement, ConnectionsIconProps>(
-  (props, ref) => {
-    const { getLabelWithAccelerator } = useKeyboardShortcutFormatters();
-    return (
-      <Container ref={ref}>
-        <ConnectionsIconStatusIndicator
-          connected={props.isAnyConnectionActive}
-        />
-        <StyledButton
-          onClick={props.onClick}
-          size="small"
-          m="auto"
-          title={getLabelWithAccelerator('Open Connections', 'openConnections')}
-        >
-          <Cluster size="medium" />
-        </StyledButton>
-      </Container>
-    );
+export const ConnectionsIcon = forwardRef<
+  HTMLDivElement,
+  {
+    status: Status;
+    onClick(): void;
   }
-);
+>((props, ref) => {
+  const { getLabelWithAccelerator } = useKeyboardShortcutFormatters();
+  return (
+    <Container ref={ref}>
+      <ConnectionsIconStatusIndicator status={props.status} />
+      <StyledButton
+        onClick={props.onClick}
+        size="small"
+        m="auto"
+        title={getLabelWithAccelerator('Open Connections', 'openConnections')}
+      >
+        <Cluster size="medium" />
+      </StyledButton>
+    </Container>
+  );
+});
 
 const Container = styled.div`
   position: relative;

--- a/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsIcon/ConnectionsIconStatusIndicator.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsIcon/ConnectionsIconStatusIndicator.tsx
@@ -16,17 +16,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { Box } from 'design';
 
-export const ConnectionsIconStatusIndicator: React.FC<Props> = props => {
-  const { connected, ...styles } = props;
-  return <StyledStatus $connected={connected} {...styles} />;
-};
+export type Status = 'on' | 'off' | 'warning';
 
-const StyledStatus = styled(Box)<InternalProps>`
+export const ConnectionsIconStatusIndicator = styled(Box)<{
+  status: Status;
+}>`
   position: absolute;
   top: -4px;
   right: -4px;
@@ -36,9 +34,28 @@ const StyledStatus = styled(Box)<InternalProps>`
   border-radius: 50%;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   ${props => {
-    const { $connected, theme } = props;
-    const backgroundColor = $connected ? theme.colors.success.main : null;
-    const border = $connected
+    const { status, theme } = props;
+
+    if (status === 'warning') {
+      return css`
+        color: ${theme.colors.interactive.solid.alert.default};
+        &:after {
+          content: '⚠';
+          font-size: 12px;
+
+          position: absolute;
+          top: -8px;
+          left: -2px;
+        }
+      `;
+    }
+
+    const connected = status === 'on';
+
+    const backgroundColor = connected
+      ? theme.colors.interactive.solid.success.default
+      : null;
+    const border = connected
       ? null
       : `1px solid ${theme.colors.text.slightlyMuted}`;
     return {
@@ -47,11 +64,3 @@ const StyledStatus = styled(Box)<InternalProps>`
     };
   }}
 `;
-
-type Props = {
-  connected: boolean;
-};
-
-type InternalProps = {
-  $connected?: boolean;
-};

--- a/web/packages/teleterm/src/ui/TopBar/Connections/connectionsContext.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/connectionsContext.tsx
@@ -20,16 +20,24 @@ import {
   createContext,
   FC,
   PropsWithChildren,
+  RefObject,
   useCallback,
   useContext,
   useState,
 } from 'react';
+
+import { useStateRef } from 'shared/hooks';
 
 /**
  * ConnectionsContext allows other parts of the app to control the connection list.
  */
 export type ConnectionsContext = {
   isOpen: boolean;
+  /**
+   * isOpenRef is useful for reading isOpen from within event handlers whose identity shouldn't be
+   * based on isOpen.
+   */
+  isOpenRef: RefObject<boolean>;
   open: (step?: Step) => void;
   close: () => void;
   toggle: () => void;
@@ -47,7 +55,7 @@ const defaultStep: Step = 'connections';
 export const ConnectionsContext = createContext<ConnectionsContext>(null);
 
 export const ConnectionsContextProvider: FC<PropsWithChildren> = props => {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, isOpenRef, setIsOpen] = useStateRef(false);
   const [stepToOpen, setStepToOpen] = useState<Step>('connections');
 
   const toggle = useCallback(() => {
@@ -56,21 +64,24 @@ export const ConnectionsContextProvider: FC<PropsWithChildren> = props => {
     if (isOpen) {
       setStepToOpen(defaultStep);
     }
-  }, [isOpen]);
+  }, [isOpen, setIsOpen]);
 
   const close = useCallback(() => {
     setIsOpen(false);
     setStepToOpen(defaultStep);
-  }, []);
+  }, [setIsOpen]);
 
-  const open = useCallback((step: Step = defaultStep) => {
-    setIsOpen(true);
-    setStepToOpen(step);
-  }, []);
+  const open = useCallback(
+    (step: Step = defaultStep) => {
+      setIsOpen(true);
+      setStepToOpen(step);
+    },
+    [setIsOpen]
+  );
 
   return (
     <ConnectionsContext.Provider
-      value={{ isOpen, toggle, close, open, stepToOpen }}
+      value={{ isOpen, isOpenRef, toggle, close, open, stepToOpen }}
     >
       {props.children}
     </ConnectionsContext.Provider>

--- a/web/packages/teleterm/src/ui/Vnet/DiagnosticsAlert.test.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DiagnosticsAlert.test.tsx
@@ -31,6 +31,7 @@ import {
   makeCheckAttempt,
   makeCheckReport,
   makeReport,
+  makeReportWithIssuesFound,
 } from 'teleterm/services/vnet/testHelpers';
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
@@ -234,15 +235,7 @@ describe('DiagnosticsAlert', () => {
     const appContext = new MockAppContext();
     const otherDoc = makeDocumentConnectMyComputer();
     appContext.addRootClusterWithDoc(makeRootCluster(), otherDoc);
-    const report = makeReport({
-      checks: [
-        makeCheckAttempt({
-          checkReport: makeCheckReport({
-            status: CheckReportStatus.ISSUES_FOUND,
-          }),
-        }),
-      ],
-    });
+    const report = makeReportWithIssuesFound();
 
     appContext.vnet.runDiagnostics = () => new MockedUnaryCall({ report });
 

--- a/web/packages/teleterm/src/ui/Vnet/DiagnosticsAlert.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DiagnosticsAlert.tsx
@@ -34,6 +34,17 @@ import { useConnectionsContext } from 'teleterm/ui/TopBar/Connections/connection
 import { textSpacing } from './sliderStep';
 import { useVnetContext } from './vnetContext';
 
+/**
+ * DiagnosticsAlert informs the user about the results of running VNet diagnostics.
+ * If there are no issues found, it shows a subtle text with a button to open the report.
+ * If the diag run found some issues, it shows a prominent alert which should also be reflected in
+ * other elements in the UI, like the warning indicators and a warning notification.
+ *
+ * Since we're worried about false positives, the user is able to dismiss the diagnostics alert. In
+ * that case, the alert disappears together with the warning indicators and the notification.
+ * Further periodic diagnostic runs will not cause those elements to show up again, until the user
+ * manually runs diagnostics from the VNet panel.
+ */
 export const DiagnosticsAlert = (props: {
   runDiagnosticsFromVnetPanel: () => Promise<unknown>;
 }) => {

--- a/web/packages/teleterm/src/ui/Vnet/DiagnosticsAlert.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DiagnosticsAlert.tsx
@@ -28,6 +28,7 @@ import {
   CheckReportStatus,
 } from 'gen-proto-ts/teleport/lib/vnet/diag/v1/diag_pb';
 
+import { hasReportFoundIssues } from 'teleterm/services/vnet/diag';
 import { useConnectionsContext } from 'teleterm/ui/TopBar/Connections/connectionsContext';
 
 import { textSpacing } from './sliderStep';
@@ -113,13 +114,7 @@ export const DiagnosticsAlert = (props: {
   // If this default warningText is shown the user, it means we failed to account for a specific
   // state.
   let warningText = 'Unknown report status';
-  if (
-    report.checks.some(
-      checkAttempt =>
-        checkAttempt.status === CheckAttemptStatus.OK &&
-        checkAttempt.checkReport.status === CheckReportStatus.ISSUES_FOUND
-    )
-  ) {
+  if (hasReportFoundIssues(report)) {
     warningText = 'Other software on your device might interfere with VNet.';
   } else if (
     report.checks.some(

--- a/web/packages/teleterm/src/ui/Vnet/DiagnosticsAlert.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DiagnosticsAlert.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { PropsWithChildren, ReactNode, useCallback } from 'react';
+import { PropsWithChildren, ReactNode } from 'react';
 
 import { Alert, Flex, P2 } from 'design';
 import { ActionButton } from 'design/Alert';
@@ -28,8 +28,6 @@ import {
   CheckReportStatus,
 } from 'gen-proto-ts/teleport/lib/vnet/diag/v1/diag_pb';
 
-import { useAppContext } from 'teleterm/ui/appContextProvider';
-import { useStoreSelector } from 'teleterm/ui/hooks/useStoreSelector';
 import { useConnectionsContext } from 'teleterm/ui/TopBar/Connections/connectionsContext';
 
 import { textSpacing } from './sliderStep';
@@ -42,13 +40,9 @@ export const DiagnosticsAlert = (props: {
     diagnosticsAttempt,
     dismissDiagnosticsAlert,
     hasDismissedDiagnosticsAlert,
+    openReport,
   } = useVnetContext();
-  const { workspacesService } = useAppContext();
   const { close: closeConnectionsPanel } = useConnectionsContext();
-  const rootClusterUri = useStoreSelector(
-    'workspacesService',
-    useCallback(state => state.rootClusterUri, [])
-  );
 
   if (
     diagnosticsAttempt.status === '' ||
@@ -72,39 +66,18 @@ export const DiagnosticsAlert = (props: {
   }
 
   const report = diagnosticsAttempt.data;
-  const disabledOpenReportButtonProps = !rootClusterUri
+  const disabledOpenReportButtonProps = !openReport
     ? {
         disabled: true,
         title: 'Log in to a cluster to see the full report',
       }
     : {};
-  const openReport = () => {
-    if (!rootClusterUri) {
+  const openReportAndClosePanel = () => {
+    if (!openReport) {
       return;
     }
 
-    const docsService =
-      workspacesService.getWorkspaceDocumentService(rootClusterUri);
-
-    // Check for an existing doc first. It may be present if someone re-runs diagnostics from within
-    // a doc, then opens the VNet panel and clicks "Open Diag Report". The report in the panel and
-    // the report in the doc are equal in that case, as they both come from diagnosticsAttempt.data.
-    const existingDoc = docsService.getDocuments().find(
-      d =>
-        d.kind === 'doc.vnet_diag_report' &&
-        // Reports don't have IDs, so createdAt is used as a good-enough approximation of an ID.
-        d.report?.createdAt === report.createdAt
-    );
-    if (existingDoc) {
-      docsService.open(existingDoc.uri);
-    } else {
-      const doc = docsService.createVnetDiagReportDocument({
-        rootClusterUri,
-        report,
-      });
-      docsService.add(doc);
-      docsService.open(doc.uri);
-    }
+    openReport(report);
     closeConnectionsPanel();
   };
 
@@ -127,7 +100,10 @@ export const DiagnosticsAlert = (props: {
           fill="minimal"
           intent="neutral"
           inputAlignment
-          action={{ content: 'Open Diag Report', onClick: openReport }}
+          action={{
+            content: 'Open Diag Report',
+            onClick: openReportAndClosePanel,
+          }}
           {...disabledOpenReportButtonProps}
         />
       </Flex>
@@ -163,7 +139,10 @@ export const DiagnosticsAlert = (props: {
             fill="border"
             intent="neutral"
             inputAlignment
-            action={{ content: 'Open Diag Report', onClick: openReport }}
+            action={{
+              content: 'Open Diag Report',
+              onClick: openReportAndClosePanel,
+            }}
             {...disabledOpenReportButtonProps}
           />
           <ActionButton

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.story.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.story.tsx
@@ -43,6 +43,7 @@ import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvi
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
 import { MockWorkspaceContextProvider } from 'teleterm/ui/fixtures/MockWorkspaceContextProvider';
 import { makeDocumentVnetDiagReport } from 'teleterm/ui/services/workspacesService/documentsService/testHelpers';
+import { ConnectionsContextProvider } from 'teleterm/ui/TopBar/Connections/connectionsContext';
 
 import { DocumentVnetDiagReport as Component } from './DocumentVnetDiagReport';
 import { useVnetContext, VnetContextProvider } from './vnetContext';
@@ -147,9 +148,11 @@ const Decorator = (props: PropsWithChildren<StoryProps>) => {
 
   return (
     <MockAppContextProvider appContext={appContext}>
-      <MockWorkspaceContextProvider>
-        <VnetContextProvider>{props.children}</VnetContextProvider>
-      </MockWorkspaceContextProvider>
+      <ConnectionsContextProvider>
+        <MockWorkspaceContextProvider>
+          <VnetContextProvider>{props.children}</VnetContextProvider>
+        </MockWorkspaceContextProvider>
+      </ConnectionsContextProvider>
     </MockAppContextProvider>
   );
 };

--- a/web/packages/teleterm/src/ui/Vnet/VnetConnectionItem.test.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetConnectionItem.test.tsx
@@ -21,6 +21,7 @@ import { wait } from 'shared/utils/wait';
 import { MockedUnaryCall } from 'teleterm/services/tshd/cloneableClient';
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
+import { ConnectionsContextProvider } from 'teleterm/ui/TopBar/Connections/connectionsContext';
 
 import { VnetSliderStepHeader } from './VnetConnectionItem';
 import { VnetContextProvider } from './vnetContext';
@@ -30,12 +31,14 @@ describe('VnetSliderStepHeader', () => {
     const user = userEvent.setup();
     render(
       <MockAppContextProvider>
-        <VnetContextProvider>
-          <VnetSliderStepHeader
-            goBack={() => {}}
-            runDiagnosticsFromVnetPanel={() => Promise.resolve()}
-          />
-        </VnetContextProvider>
+        <ConnectionsContextProvider>
+          <VnetContextProvider>
+            <VnetSliderStepHeader
+              goBack={() => {}}
+              runDiagnosticsFromVnetPanel={() => Promise.resolve()}
+            />
+          </VnetContextProvider>
+        </ConnectionsContextProvider>
       </MockAppContextProvider>
     );
 
@@ -70,12 +73,14 @@ describe('VnetSliderStepHeader', () => {
     const user = userEvent.setup();
     render(
       <MockAppContextProvider appContext={appContext}>
-        <VnetContextProvider>
-          <VnetSliderStepHeader
-            goBack={() => {}}
-            runDiagnosticsFromVnetPanel={() => Promise.resolve()}
-          />
-        </VnetContextProvider>
+        <ConnectionsContextProvider>
+          <VnetContextProvider>
+            <VnetSliderStepHeader
+              goBack={() => {}}
+              runDiagnosticsFromVnetPanel={() => Promise.resolve()}
+            />
+          </VnetContextProvider>
+        </ConnectionsContextProvider>
       </MockAppContextProvider>
     );
 

--- a/web/packages/teleterm/src/ui/Vnet/VnetConnectionItem.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetConnectionItem.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { forwardRef, useEffect, useRef } from 'react';
+import React, { forwardRef, useEffect, useMemo, useRef } from 'react';
 
 import { ButtonIcon, Flex, rotate360, Text } from 'design';
 import * as icons from 'design/Icon';
@@ -24,7 +24,10 @@ import * as icons from 'design/Icon';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { useKeyboardArrowsNavigation } from 'teleterm/ui/components/KeyboardArrowsNavigation';
 import { ListItem } from 'teleterm/ui/components/ListItem';
-import { ConnectionStatusIndicator } from 'teleterm/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionStatusIndicator';
+import {
+  Status as ConnectionStatus,
+  ConnectionStatusIndicator,
+} from 'teleterm/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionStatusIndicator';
 
 import { useVnetContext } from './vnetContext';
 
@@ -100,20 +103,33 @@ const VnetConnectionItemBase = forwardRef<
     stopAttempt,
     diagnosticsAttempt,
     getDisabledDiagnosticsReason,
+    showDiagWarningIndicator,
   } = useVnetContext();
   const isProcessing =
     startAttempt.status === 'processing' || stopAttempt.status === 'processing';
   const disabledDiagnosticsReason =
     getDisabledDiagnosticsReason(diagnosticsAttempt);
-  const indicatorStatus =
-    startAttempt.status === 'error' ||
-    stopAttempt.status === 'error' ||
-    (status.value === 'stopped' &&
-      status.reason.value === 'unexpected-shutdown')
-      ? 'error'
-      : status.value === 'running'
-        ? 'on'
-        : 'off';
+  const indicatorStatus: ConnectionStatus = useMemo(() => {
+    // Consider an error state first. If there was an error, status.value is not 'running'.
+    if (
+      startAttempt.status === 'error' ||
+      stopAttempt.status === 'error' ||
+      (status.value === 'stopped' &&
+        status.reason.value === 'unexpected-shutdown')
+    ) {
+      return 'error';
+    }
+
+    if (status.value === 'stopped') {
+      return 'off';
+    }
+
+    if (showDiagWarningIndicator) {
+      return 'warning';
+    }
+
+    return 'on';
+  }, [startAttempt, stopAttempt, status, showDiagWarningIndicator]);
 
   const onEnterPress = (event: React.KeyboardEvent) => {
     if (

--- a/web/packages/teleterm/src/ui/Vnet/vnetContext.test.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/vnetContext.test.tsx
@@ -17,15 +17,36 @@
  */
 
 import { act, renderHook, waitFor } from '@testing-library/react';
-import { PropsWithChildren } from 'react';
+import {
+  ComponentType,
+  createRef,
+  MutableRefObject,
+  PropsWithChildren,
+  useEffect,
+  useImperativeHandle,
+} from 'react';
+
+import { CheckReportStatus } from 'gen-proto-ts/teleport/lib/vnet/diag/v1/diag_pb';
 
 import { MockedUnaryCall } from 'teleterm/services/tshd/cloneableClient';
+import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
+import {
+  makeCheckAttempt,
+  makeCheckReport,
+  makeReport,
+} from 'teleterm/services/vnet/testHelpers';
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
+import { makeDocumentConnectMyComputer } from 'teleterm/ui/services/workspacesService/documentsService/testHelpers';
+import {
+  ConnectionsContextProvider,
+  useConnectionsContext,
+} from 'teleterm/ui/TopBar/Connections/connectionsContext';
 import { IAppContext } from 'teleterm/ui/types';
 
 import {
   useVnetContext,
+  VnetContext,
   VnetContextProvider,
   VnetStatus,
   VnetStoppedReason,
@@ -193,15 +214,297 @@ it('registers a callback for unexpected shutdown', async () => {
   expect(reason.errorMessage).toEqual('lorem ipsum dolor sit amet');
 });
 
-const Wrapper = (props: PropsWithChildren<{ appContext: IAppContext }>) => (
-  <MockAppContextProvider appContext={props.appContext}>
-    <VnetContextProvider>{props.children}</VnetContextProvider>
-  </MockAppContextProvider>
-);
+/* eslint-disable jest/no-standalone-expect */
+describe('diag notification', () => {
+  const noIssuesFoundReport = makeReport();
+  const issuesFoundReport = makeReport({
+    checks: [
+      makeCheckAttempt({
+        checkReport: makeCheckReport({
+          status: CheckReportStatus.ISSUES_FOUND,
+        }),
+      }),
+    ],
+  });
+  const tests: Array<{
+    it: string;
+    /** Ref for opening/closing the connections panel. If provided, the panel will be open by default. */
+    controlConnectionsRef?: MutableRefObject<ControlConnections>;
+    mockAppContext: (appContext: MockAppContext) => void;
+    verify: (
+      appContext: MockAppContext,
+      result: { current: VnetContext },
+      controlConnectionsRef?: MutableRefObject<ControlConnections>
+    ) => Promise<void>;
+  }> = [
+    {
+      it: 'is shown when the report cycles from issues found to no issues and back to issues found',
+      mockAppContext: appContext => {
+        jest
+          .spyOn(appContext.vnet, 'runDiagnostics')
+          .mockResolvedValueOnce(
+            new MockedUnaryCall({ report: issuesFoundReport })
+          )
+          .mockResolvedValueOnce(
+            new MockedUnaryCall({ report: noIssuesFoundReport })
+          )
+          .mockResolvedValueOnce(
+            new MockedUnaryCall({ report: issuesFoundReport })
+          )
+          .mockResolvedValue(
+            new MockedUnaryCall({}, new Error('something went wrong'))
+          );
+      },
+      verify: async ({ notificationsService, vnet }) => {
+        // Verify that after the diagnostics are run three times, only two notifications have been
+        // created.
+        await waitFor(
+          () => expect(vnet.runDiagnostics).toHaveBeenCalledTimes(3),
+          { interval }
+        );
 
-//testing-library.com/docs/react-testing-library/api/#renderhook-options-initialprops
-const createWrapper = (Wrapper, props) => {
+        expect(notificationsService.notifyWarning).toHaveBeenCalledTimes(2);
+        expect(notificationsService.getNotifications()).toHaveLength(1);
+      },
+    },
+    {
+      it: 'is not shown after opening a report, receiving another report with no issues and then issues reoccuring',
+      mockAppContext: appContext => {
+        jest
+          .spyOn(appContext.vnet, 'runDiagnostics')
+          .mockResolvedValueOnce(
+            new MockedUnaryCall({ report: issuesFoundReport })
+          )
+          .mockResolvedValueOnce(
+            new MockedUnaryCall({ report: noIssuesFoundReport })
+          )
+          .mockResolvedValueOnce(
+            new MockedUnaryCall({ report: issuesFoundReport })
+          )
+          .mockResolvedValue(
+            new MockedUnaryCall({}, new Error('something went wrong'))
+          );
+      },
+      verify: async ({ notificationsService, vnet }, result) => {
+        // Open the diag report and verify that it removes the notification.
+        await waitFor(
+          () =>
+            expect(result.current.diagnosticsAttempt.status).toEqual('success'),
+          { interval }
+        );
+        await act(async () => {
+          result.current.openReport(result.current.diagnosticsAttempt.data);
+        });
+        expect(notificationsService.notifyWarning).toHaveBeenCalledTimes(1);
+        expect(notificationsService.getNotifications()).toHaveLength(0);
+
+        jest.clearAllMocks();
+
+        // Wait for the third report to be processed and verify that it does not result in another
+        // notification being created.
+        await waitFor(
+          () => expect(vnet.runDiagnostics).toHaveBeenCalledTimes(3),
+          { interval }
+        );
+        expect(notificationsService.notifyWarning).toHaveBeenCalledTimes(0);
+        expect(notificationsService.getNotifications()).toHaveLength(0);
+      },
+    },
+    {
+      it: "is not shown when the VNet panel is opened and doesn't appear after the panel is closed",
+      controlConnectionsRef: createRef(),
+      mockAppContext: appContext => {
+        jest
+          .spyOn(appContext.vnet, 'runDiagnostics')
+          .mockResolvedValue(
+            new MockedUnaryCall({ report: issuesFoundReport })
+          );
+      },
+      verify: async (
+        { vnet, notificationsService },
+        result,
+        controlConnectionsRef
+      ) => {
+        await waitFor(
+          () =>
+            expect(result.current.diagnosticsAttempt.status).toEqual('success'),
+          { interval }
+        );
+        expect(notificationsService.notifyWarning).not.toHaveBeenCalled();
+
+        // Close the panel and wait for the next run, verify that the notification wasn't sent.
+        await act(async () => controlConnectionsRef.current.close());
+        await waitFor(
+          () => expect(vnet.runDiagnostics).toHaveBeenCalledTimes(2),
+          { interval }
+        );
+        expect(notificationsService.notifyWarning).not.toHaveBeenCalled();
+      },
+    },
+    {
+      it: 'is not shown when the VNet panel is opened and no issues are found, but appears after the panel is closed and issues are found',
+      controlConnectionsRef: createRef(),
+      mockAppContext: appContext => {
+        jest
+          .spyOn(appContext.vnet, 'runDiagnostics')
+          .mockResolvedValueOnce(
+            new MockedUnaryCall({ report: noIssuesFoundReport })
+          )
+          .mockReturnValue(new MockedUnaryCall({ report: issuesFoundReport }));
+      },
+      verify: async (
+        { vnet, notificationsService },
+        result,
+        controlConnectionsRef
+      ) => {
+        await waitFor(
+          () =>
+            expect(result.current.diagnosticsAttempt.status).toEqual('success'),
+          { interval }
+        );
+        expect(notificationsService.notifyWarning).not.toHaveBeenCalled();
+
+        // Close the panel and wait for the next run, verify that the notification was sent.
+        await act(async () => controlConnectionsRef.current.close());
+        await waitFor(
+          () => expect(vnet.runDiagnostics).toHaveBeenCalledTimes(2),
+          { interval }
+        );
+        expect(notificationsService.getNotifications().length).toEqual(1);
+      },
+    },
+    {
+      it: 'is not shown after dismissing a dialog and reappears after manually running diagnostics',
+      mockAppContext: appContext => {
+        jest
+          .spyOn(appContext.vnet, 'runDiagnostics')
+          .mockResolvedValue(
+            new MockedUnaryCall({ report: issuesFoundReport })
+          );
+      },
+      verify: async ({ notificationsService, vnet }, result) => {
+        // Verify that the first run creates a notification.
+        await waitFor(
+          () =>
+            expect(result.current.diagnosticsAttempt.status).toEqual('success'),
+          { interval }
+        );
+        expect(notificationsService.getNotifications()).toHaveLength(1);
+
+        // Verify that dismissing the alert removes the notification.
+        await act(async () => result.current.dismissDiagnosticsAlert());
+        expect(notificationsService.getNotifications()).toHaveLength(0);
+
+        // Verify that the next auto diagnostics run does not create a notification.
+        jest.clearAllMocks();
+        await waitFor(
+          () => expect(vnet.runDiagnostics).toHaveBeenCalledTimes(1),
+          { interval }
+        );
+        expect(notificationsService.getNotifications()).toHaveLength(0);
+
+        // Manually run diagnostics, wait for another auto call and confirm that it creates a
+        // notification.
+        await act(() =>
+          result.current
+            .runDiagnostics()
+            .finally(() => result.current.reinstateDiagnosticsAlert())
+        );
+        jest.clearAllMocks();
+        await waitFor(
+          () => expect(vnet.runDiagnostics).toHaveBeenCalledTimes(1),
+          { interval }
+        );
+        expect(notificationsService.getNotifications()).toHaveLength(1);
+      },
+    },
+  ];
+
+  // eslint-disable-next-line jest/expect-expect
+  test.each(tests)('$it', async test => {
+    const appContext = new MockAppContext();
+    // Set up a proper workspace so that the diag report can be opened.
+    appContext.workspacesService.setState(draft => {
+      draft.isInitialized = true;
+    });
+    appContext.addRootClusterWithDoc(
+      makeRootCluster(),
+      makeDocumentConnectMyComputer()
+    );
+    // Automatically start VNet.
+    appContext.statePersistenceService.putState({
+      ...appContext.statePersistenceService.getState(),
+      vnet: { autoStart: true },
+    });
+    appContext.configService.set('unstable.vnetDiag', true);
+
+    jest.spyOn(appContext.notificationsService, 'notifyWarning');
+
+    test.mockAppContext(appContext);
+
+    const { result } = renderHook(() => useVnetContext(), {
+      wrapper: createWrapper(Wrapper, {
+        appContext,
+        controlConnectionsRef: test.controlConnectionsRef,
+      }),
+    });
+
+    await test.verify(appContext, result, test.controlConnectionsRef);
+  });
+});
+/* eslint-enable jest/no-standalone-expect */
+
+const Wrapper = (
+  props: PropsWithChildren<{
+    appContext: IAppContext;
+    controlConnectionsRef?: MutableRefObject<ControlConnections>;
+  }>
+) => {
+  return (
+    <MockAppContextProvider appContext={props.appContext}>
+      <ConnectionsContextProvider>
+        <VnetContextProvider diagnosticsIntervalMs={diagnosticsIntervalMs}>
+          {props.controlConnectionsRef && (
+            <OpenConnections
+              controlConnectionsRef={props.controlConnectionsRef}
+            />
+          )}
+          {props.children}
+        </VnetContextProvider>
+      </ConnectionsContextProvider>
+    </MockAppContextProvider>
+  );
+};
+
+const diagnosticsIntervalMs = 50;
+/** Interval for waitFor. Needs to be lower than diagnosticsIntervalMs. */
+const interval = 10;
+
+// Make Wrapper receive initialProps.
+// https://testing-library.com/docs/react-testing-library/api/#renderhook-options-initialprops
+function createWrapper<Props>(
+  Wrapper: ComponentType<PropsWithChildren<Props>>,
+  props: PropsWithChildren<Props>
+) {
   return function CreatedWrapper({ children }) {
     return <Wrapper {...props}>{children}</Wrapper>;
   };
+}
+
+const OpenConnections = (props: {
+  controlConnectionsRef: MutableRefObject<ControlConnections>;
+}) => {
+  const { open, close } = useConnectionsContext();
+  useImperativeHandle(props.controlConnectionsRef, () => ({ open, close }));
+
+  useEffect(() => {
+    open();
+  }, [open]);
+
+  return null;
+};
+
+type ControlConnections = {
+  open: () => void;
+  close: () => void;
 };

--- a/web/packages/teleterm/src/ui/Vnet/vnetContext.test.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/vnetContext.test.tsx
@@ -26,14 +26,11 @@ import {
   useImperativeHandle,
 } from 'react';
 
-import { CheckReportStatus } from 'gen-proto-ts/teleport/lib/vnet/diag/v1/diag_pb';
-
 import { MockedUnaryCall } from 'teleterm/services/tshd/cloneableClient';
 import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
 import {
-  makeCheckAttempt,
-  makeCheckReport,
   makeReport,
+  makeReportWithIssuesFound,
 } from 'teleterm/services/vnet/testHelpers';
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
@@ -217,15 +214,7 @@ it('registers a callback for unexpected shutdown', async () => {
 /* eslint-disable jest/no-standalone-expect */
 describe('diag notification', () => {
   const noIssuesFoundReport = makeReport();
-  const issuesFoundReport = makeReport({
-    checks: [
-      makeCheckAttempt({
-        checkReport: makeCheckReport({
-          status: CheckReportStatus.ISSUES_FOUND,
-        }),
-      }),
-    ],
-  });
+  const issuesFoundReport = makeReportWithIssuesFound();
   const tests: Array<{
     it: string;
     /** Ref for opening/closing the connections panel. If provided, the panel will be open by default. */

--- a/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
@@ -93,6 +93,11 @@ export type VnetContext = {
    * openReport is undefined if the user is not within any workspace.
    */
   openReport: ((report: Report) => void) | undefined;
+  /**
+   * Whether the connections icon in the top left and the icon for the VNet connection item should
+   * show a warning state.
+   */
+  showDiagWarningIndicator: boolean;
 };
 
 export type VnetStatus =
@@ -272,6 +277,16 @@ export const VnetContextProvider: FC<
     [rootClusterUri, workspacesService, notificationsService]
   );
 
+  const showDiagWarningIndicator: boolean = useMemo(
+    () =>
+      !hasDismissedDiagnosticsAlert &&
+      // Look at data, not status === 'running', otherwise this would briefly swap to false
+      // whenever a diagnostic run would be in progress.
+      diagnosticsAttempt.data &&
+      hasReportFoundIssues(diagnosticsAttempt.data),
+    [hasDismissedDiagnosticsAlert, diagnosticsAttempt]
+  );
+
   useEffect(() => {
     const handleAutoStart = async () => {
       if (
@@ -440,6 +455,7 @@ export const VnetContextProvider: FC<
         hasDismissedDiagnosticsAlert,
         reinstateDiagnosticsAlert,
         openReport: rootClusterUri ? openReport : undefined,
+        showDiagWarningIndicator,
       }}
     >
       {children}

--- a/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
@@ -24,17 +24,21 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 
 import { BackgroundItemStatus } from 'gen-proto-ts/teleport/lib/teleterm/vnet/v1/vnet_service_pb';
 import { Report } from 'gen-proto-ts/teleport/lib/vnet/diag/v1/diag_pb';
+import { useStateRef } from 'shared/hooks';
 import { Attempt, makeEmptyAttempt, useAsync } from 'shared/hooks/useAsync';
 
 import { cloneAbortSignal, isTshdRpcError } from 'teleterm/services/tshd';
+import { hasReportFoundIssues } from 'teleterm/services/vnet/diag';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { usePersistedState } from 'teleterm/ui/hooks/usePersistedState';
 import { useStoreSelector } from 'teleterm/ui/hooks/useStoreSelector';
+import { useConnectionsContext } from 'teleterm/ui/TopBar/Connections/connectionsContext';
 import { IAppContext } from 'teleterm/ui/types';
 
 /**
@@ -101,7 +105,9 @@ export type VnetStoppedReason =
 
 export const VnetContext = createContext<VnetContext>(null);
 
-export const VnetContextProvider: FC<PropsWithChildren> = props => {
+export const VnetContextProvider: FC<
+  PropsWithChildren<{ diagnosticsIntervalMs?: number }>
+> = ({ diagnosticsIntervalMs = defaultDiagnosticsIntervalMs, children }) => {
   const [status, setStatus] = useState<VnetStatus>({
     value: 'stopped',
     reason: { value: 'regular-shutdown-or-not-started' },
@@ -121,6 +127,7 @@ export const VnetContextProvider: FC<PropsWithChildren> = props => {
   const [{ autoStart }, setAppState] = usePersistedState('vnet', {
     autoStart: false,
   });
+  const { isOpenRef: isConnectionsPanelOpenRef } = useConnectionsContext();
 
   const isSupported = useMemo(() => {
     const { platform } = mainProcessClient.getRuntimeSettings();
@@ -153,6 +160,35 @@ export const VnetContextProvider: FC<PropsWithChildren> = props => {
     )
   );
 
+  /** Holds the ID of the currently displayed warning notification about diagnostics. */
+  const diagNotificationIdRef = useRef('');
+  /**
+   * Removes any currently shown diag notification _and_ makes it so that the next periodic call to
+   * runDiagnosticsAndShowNotification is not going to skip the notification due to the user
+   * interacting with the notification.
+   */
+  const resetHasActedOnPreviousNotification = useCallback(() => {
+    if (!diagNotificationIdRef.current) {
+      return;
+    }
+    notificationsService.removeNotification(diagNotificationIdRef.current);
+    diagNotificationIdRef.current = '';
+  }, [notificationsService]);
+
+  const [
+    /** Whether user has dismissed the diagnostic alert shown in the VNet panel. */
+    hasDismissedDiagnosticsAlert,
+    hasDismissedDiagnosticsAlertRef,
+    setHasDismissedDiagnosticsAlert,
+  ] = useStateRef(false);
+  const reinstateDiagnosticsAlert = useCallback(() => {
+    setHasDismissedDiagnosticsAlert(false);
+  }, [setHasDismissedDiagnosticsAlert]);
+  const dismissDiagnosticsAlert = useCallback(() => {
+    setHasDismissedDiagnosticsAlert(true);
+    resetHasActedOnPreviousNotification();
+  }, [setHasDismissedDiagnosticsAlert, resetHasActedOnPreviousNotification]);
+
   const [stopAttempt, stop] = useAsync(
     useCallback(async () => {
       await vnet.stop({});
@@ -163,7 +199,12 @@ export const VnetContextProvider: FC<PropsWithChildren> = props => {
       setAppState({ autoStart: false });
       setDiagnosticsAttempt(makeEmptyAttempt());
       setHasDismissedDiagnosticsAlert(false);
-    }, [vnet, setAppState, setDiagnosticsAttempt])
+    }, [
+      vnet,
+      setAppState,
+      setDiagnosticsAttempt,
+      setHasDismissedDiagnosticsAlert,
+    ])
   );
 
   const [listDNSZonesAttempt, listDNSZones] = useAsync(
@@ -223,8 +264,12 @@ export const VnetContextProvider: FC<PropsWithChildren> = props => {
         docsService.add(doc);
         docsService.open(doc.uri);
       }
+
+      // NOTE: Do not reset diagNotificationIdRef here for the notification to be considered acted
+      // upon on the next run of runDiagnosticsAndShowNotification.
+      notificationsService.removeNotification(diagNotificationIdRef.current);
     },
-    [rootClusterUri, workspacesService]
+    [rootClusterUri, workspacesService, notificationsService]
   );
 
   useEffect(() => {
@@ -273,6 +318,75 @@ export const VnetContextProvider: FC<PropsWithChildren> = props => {
     [appCtx, notificationsService]
   );
 
+  const runDiagnosticsAndShowNotification = useCallback(
+    async (signal: AbortSignal) => {
+      const [report, error] = await runDiagnostics(signal);
+      if (error) {
+        return;
+      }
+
+      const previousNotificationId = diagNotificationIdRef.current;
+      /**
+       * Whether the user dismissed the previous notification or opened the report from the previous
+       * notification.
+       */
+      const hasActedOnPreviousNotification =
+        previousNotificationId &&
+        !notificationsService.hasNotification(previousNotificationId);
+      notificationsService.removeNotification(previousNotificationId);
+
+      if (
+        hasActedOnPreviousNotification ||
+        hasDismissedDiagnosticsAlertRef.current
+      ) {
+        return;
+      }
+
+      if (!hasReportFoundIssues(report)) {
+        // Resetting here handles a situation where issues are found, then a second run finds no
+        // issues and then another run finds issues again. Without resetting after the second run,
+        // that last run would not send a notification
+        resetHasActedOnPreviousNotification();
+        return;
+      }
+
+      if (isConnectionsPanelOpenRef.current) {
+        // If the connection panel is open and the report has found some issues, the user should be
+        // able to see the warning in the panel. If they're on the VNet panel, we don't want to show
+        // the notification _and_ the alert in the panel.
+        //
+        // diagNotificationIdRef needs to be made dirty so that on the next run the notification is
+        // considered to be acted upon.
+        diagNotificationIdRef.current = 'bogus-id';
+        return;
+      }
+
+      diagNotificationIdRef.current = notificationsService.notifyWarning({
+        isAutoRemovable: false,
+        title: 'Other software on your device might interfere with VNet.',
+        action: {
+          content: 'Open Diag Report',
+          onClick: () => {
+            openReport(report);
+            // NOTE: Do not reset diagNotificationIdRef here. Opening a notification must result in
+            // hasActedOnPreviousNotification to be equal to true on the next interval run.
+            notificationsService.removeNotification(
+              diagNotificationIdRef.current
+            );
+          },
+        },
+      });
+    },
+    [
+      runDiagnostics,
+      notificationsService,
+      openReport,
+      hasDismissedDiagnosticsAlertRef,
+      resetHasActedOnPreviousNotification,
+      isConnectionsPanelOpenRef,
+    ]
+  );
+
   useEffect(
     function periodicallyRunDiagnostics() {
       if (!configService.get('unstable.vnetDiag').value) {
@@ -285,31 +399,27 @@ export const VnetContextProvider: FC<PropsWithChildren> = props => {
 
       let abortController = new AbortController();
 
-      runDiagnostics(abortController.signal);
+      runDiagnosticsAndShowNotification(abortController.signal);
       const intervalId = setInterval(() => {
         abortController.abort();
         abortController = new AbortController();
 
-        runDiagnostics(abortController.signal);
+        runDiagnosticsAndShowNotification(abortController.signal);
       }, diagnosticsIntervalMs);
 
       return () => {
         abortController.abort();
         clearInterval(intervalId);
+        resetHasActedOnPreviousNotification();
       };
     },
-    [configService, runDiagnostics, status.value]
-  );
-
-  const [hasDismissedDiagnosticsAlert, setHasDismissedDiagnosticsAlert] =
-    useState(false);
-  const reinstateDiagnosticsAlert = useCallback(
-    () => setHasDismissedDiagnosticsAlert(false),
-    []
-  );
-  const dismissDiagnosticsAlert = useCallback(
-    () => setHasDismissedDiagnosticsAlert(true),
-    []
+    [
+      configService,
+      diagnosticsIntervalMs,
+      runDiagnosticsAndShowNotification,
+      status.value,
+      resetHasActedOnPreviousNotification,
+    ]
   );
 
   return (
@@ -332,12 +442,12 @@ export const VnetContextProvider: FC<PropsWithChildren> = props => {
         openReport: rootClusterUri ? openReport : undefined,
       }}
     >
-      {props.children}
+      {children}
     </VnetContext.Provider>
   );
 };
 
-const diagnosticsIntervalMs = 30 * 1000; // 30s
+const defaultDiagnosticsIntervalMs = 30 * 1000; // 30s
 
 export const useVnetContext = () => {
   const context = useContext(VnetContext);

--- a/web/packages/teleterm/src/ui/services/notifications/notificationsService.ts
+++ b/web/packages/teleterm/src/ui/services/notifications/notificationsService.ts
@@ -41,6 +41,14 @@ export class NotificationsService extends ImmutableStore<NotificationItem[]> {
   }
 
   removeNotification(id: string): void {
+    if (!id) {
+      return;
+    }
+
+    if (!this.state.length) {
+      return;
+    }
+
     this.setState(draftState =>
       draftState.filter(stateItem => stateItem.id !== id)
     );
@@ -48,6 +56,10 @@ export class NotificationsService extends ImmutableStore<NotificationItem[]> {
 
   getNotifications(): NotificationItem[] {
     return this.state;
+  }
+
+  hasNotification(id: string): boolean {
+    return !!this.state.find(n => n.id === id);
   }
 
   useState(): NotificationItem[] {


### PR DESCRIPTION
Building on #52461 which runs the checks periodically, this PR makes it so that Connect shows a notification if issues are found. This is the last big PR related to diag checks.

The core of this is in `runDiagnosticsAndShowNotification` in `web/packages/teleterm/src/ui/Vnet/vnetContext.tsx` and it turned out to be way more complex than I thought. There are so many things to account for when considering the notification, the diagnostic alert in the VNet panel and the user opening the diag report either from the VNet panel or the notification. I think I managed to strip as much complexity from this as I could, but I do realize that it might still be pretty dense. If you see something and think to yourself that you have no idea what it's for, it's best if we leave a comment about it. But you can also try to comment out that line of code and see which test of vnetContext.ts fails.

Demo, which is a bit outdated as some copy got changed, but the behavior is the same. In the demo, the checks run ever 5s and not 30s like in the actual app.

https://github.com/user-attachments/assets/afb53fef-aefa-4988-8484-d03cb4c32411

