### PR TITLE
Update Platform name in cli  to Teleport Infrastructure Identity Platform

### DIFF
--- a/tool/tctl/common/usage.go
+++ b/tool/tctl/common/usage.go
@@ -19,7 +19,7 @@
 package common
 
 const (
-	GlobalHelpString = "Admin tool for the Teleport Access Platform"
+	GlobalHelpString = "Admin tool for the Teleport Infrastructure Identity Platform"
 
 	AddUserHelp = `Notes:
 

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -79,7 +79,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	// configure logger for a typical CLI scenario until configuration file is
 	// parsed
 	utils.InitLogger(utils.LoggingForDaemon, slog.LevelError)
-	app = utils.InitCLIParser("teleport", "Teleport Access Platform. Learn more at https://goteleport.com")
+	app = utils.InitCLIParser("teleport", "Teleport Infrastructure Identity Platform. Learn more at https://goteleport.com")
 
 	// define global flags:
 	var (


### PR DESCRIPTION
Update `teleport` and `tctl` description to match naming update in https://goteleport.com/blog/teleport-evolution-shift-in-infrastructure-security/