### PR TITLE
Paginate unified resource cache iteration

### DIFF
--- a/lib/services/unified_resource.go
+++ b/lib/services/unified_resource.go
@@ -205,24 +205,6 @@ func (c *UnifiedResourceCache) getSortTree(sortField string) (*btree.BTreeG[*ite
 	}
 }
 
-func getStartKey(startKey string, sortBy types.SortBy) backend.Key {
-	if startKey == prefix {
-		return backend.NewKey(prefix)
-	}
-
-	// if startKey exists, return it
-	if startKey != "" {
-		return backend.KeyFromString(startKey)
-	}
-	// If startKey doesn't exist, we check the sort direction.
-	// If sort is descending, startKey is end of the list
-	if sortBy.IsDesc {
-		return backend.RangeEnd(backend.NewKey(prefix))
-	}
-	// return start of the list
-	return backend.NewKey(prefix)
-}
-
 type iteratedItem struct {
 	resource resource
 	key      backend.Key
@@ -233,43 +215,85 @@ type iteratedItem struct {
 // method.
 func (c *UnifiedResourceCache) iterateItems(ctx context.Context, start string, sortBy types.SortBy, kinds ...string) iter.Seq2[iteratedItem, error] {
 	return func(yield func(iteratedItem, error) bool) {
-		startKey := getStartKey(start, sortBy)
-
 		kindsMap := make(map[string]struct{})
 		for _, k := range kinds {
 			kindsMap[k] = struct{}{}
 		}
 
-		err := c.read(ctx, func(cache *UnifiedResourceCache) error {
-			tree, err := cache.getSortTree(sortBy.Field)
-			if err != nil {
-				return trace.Wrap(err, "getting sort tree")
-			}
+		var startKey backend.Key
+		if start != "" {
+			startKey = backend.KeyFromString(start)
+		}
 
-			iterateRange := tree.DescendRange
-			endKey := backend.NewKey(prefix)
-			if !sortBy.IsDesc {
-				iterateRange = tree.AscendRange
-				endKey = backend.RangeEnd(endKey)
-			}
+		itemIter := (*btree.BTreeG[*item]).AscendGreaterOrEqual
+		if sortBy.IsDesc {
+			itemIter = (*btree.BTreeG[*item]).DescendLessOrEqual
+		}
 
-			iterateRange(&item{Key: startKey}, &item{Key: endKey}, func(item *item) bool {
-				r, ok := cache.resources[item.Value]
-				if !ok {
+		var excludedStart bool
+		const defaultPageSize = 100
+		items := make([]iteratedItem, 0, defaultPageSize)
+		for {
+			items = items[:0]
+
+			err := c.read(ctx, func(cache *UnifiedResourceCache) error {
+				tree, err := cache.getSortTree(sortBy.Field)
+				if err != nil {
+					return trace.Wrap(err, "getting sort tree")
+				}
+
+				if startKey.IsZero() {
+					max, ok := tree.Max()
+					if sortBy.IsDesc && ok {
+						startKey = max.Key
+					} else {
+						startKey = backend.NewKey("")
+					}
+				}
+
+				itemIter(tree, &item{Key: startKey}, func(item *item) bool {
+					if excludedStart {
+						excludedStart = false
+						if item.Key.Compare(startKey) <= 0 {
+							return true
+						}
+					}
+
+					r, ok := cache.resources[item.Value]
+					if !ok {
+						return true
+					}
+
+					if len(kinds) == 0 || c.itemKindMatches(r, kindsMap) {
+						items = append(items, iteratedItem{key: item.Key, resource: r})
+					}
+
+					if len(items) >= defaultPageSize {
+						startKey = item.Key
+						excludedStart = true
+						return false
+					}
+
 					return true
-				}
+				})
 
-				if len(kinds) == 0 || c.itemKindMatches(r, kindsMap) {
-					return yield(iteratedItem{key: item.Key, resource: r}, nil)
-				}
-
-				return true
+				return nil
 			})
+			if err != nil {
+				yield(iteratedItem{}, err)
+				return
+			}
 
-			return nil
-		})
-		if err != nil {
-			yield(iteratedItem{}, err)
+			for _, i := range items {
+				if !yield(i, nil) {
+					return
+				}
+
+			}
+
+			if len(items) < defaultPageSize {
+				return
+			}
 		}
 	}
 }
@@ -507,7 +531,7 @@ func (c *UnifiedResourceCache) itemKindMatches(r resource, kinds map[string]stru
 // GetUnifiedResources returns a list of all resources stored in the current unifiedResourceCollector tree in ascending order
 func (c *UnifiedResourceCache) GetUnifiedResources(ctx context.Context) ([]types.ResourceWithLabels, error) {
 	var resources []types.ResourceWithLabels
-	for resource, err := range c.Resources(ctx, prefix, types.SortBy{IsDesc: false, Field: sortByName}) {
+	for resource, err := range c.Resources(ctx, "", types.SortBy{IsDesc: false, Field: sortByName}) {
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/services/unified_resource_test.go
+++ b/lib/services/unified_resource_test.go
@@ -465,7 +465,7 @@ func TestUnifiedResourceCacheIteration(t *testing.T) {
 	tests := []struct {
 		name             string
 		createResource   func(name string, c *client) error
-		iterateResources func(urc *services.UnifiedResourceCache) iter.Seq2[GetNamer, error]
+		iterateResources func(urc *services.UnifiedResourceCache, descending bool) iter.Seq2[GetNamer, error]
 	}{
 		{
 			name: "nodes",
@@ -474,9 +474,9 @@ func TestUnifiedResourceCacheIteration(t *testing.T) {
 				_, err := c.UpsertNode(ctx, node)
 				return err
 			},
-			iterateResources: func(urc *services.UnifiedResourceCache) iter.Seq2[GetNamer, error] {
+			iterateResources: func(urc *services.UnifiedResourceCache, descending bool) iter.Seq2[GetNamer, error] {
 				return func(yield func(GetNamer, error) bool) {
-					for n, err := range urc.Nodes(ctx, services.UnifiedResourcesIterateParams{}) {
+					for n, err := range urc.Nodes(ctx, services.UnifiedResourcesIterateParams{Descending: descending}) {
 						if err != nil {
 							yield(nil, err)
 							return
@@ -514,9 +514,9 @@ func TestUnifiedResourceCacheIteration(t *testing.T) {
 				_, err = c.UpsertDatabaseServer(ctx, dbServer)
 				return err
 			},
-			iterateResources: func(urc *services.UnifiedResourceCache) iter.Seq2[GetNamer, error] {
+			iterateResources: func(urc *services.UnifiedResourceCache, descending bool) iter.Seq2[GetNamer, error] {
 				return func(yield func(GetNamer, error) bool) {
-					for n, err := range urc.DatabaseServers(ctx, services.UnifiedResourcesIterateParams{}) {
+					for n, err := range urc.DatabaseServers(ctx, services.UnifiedResourcesIterateParams{Descending: descending}) {
 						if err != nil {
 							yield(nil, err)
 							return
@@ -545,9 +545,9 @@ func TestUnifiedResourceCacheIteration(t *testing.T) {
 				_, err = c.UpsertApplicationServer(ctx, app)
 				return err
 			},
-			iterateResources: func(urc *services.UnifiedResourceCache) iter.Seq2[GetNamer, error] {
+			iterateResources: func(urc *services.UnifiedResourceCache, descending bool) iter.Seq2[GetNamer, error] {
 				return func(yield func(GetNamer, error) bool) {
-					for n, err := range urc.AppServers(ctx, services.UnifiedResourcesIterateParams{}) {
+					for n, err := range urc.AppServers(ctx, services.UnifiedResourcesIterateParams{Descending: descending}) {
 						if err != nil {
 							yield(nil, err)
 							return
@@ -574,9 +574,9 @@ func TestUnifiedResourceCacheIteration(t *testing.T) {
 				_, err = c.UpsertKubernetesServer(ctx, kubeServer)
 				return err
 			},
-			iterateResources: func(urc *services.UnifiedResourceCache) iter.Seq2[GetNamer, error] {
+			iterateResources: func(urc *services.UnifiedResourceCache, descending bool) iter.Seq2[GetNamer, error] {
 				return func(yield func(GetNamer, error) bool) {
-					for n, err := range urc.KubernetesServers(ctx, services.UnifiedResourcesIterateParams{}) {
+					for n, err := range urc.KubernetesServers(ctx, services.UnifiedResourcesIterateParams{Descending: descending}) {
 						if err != nil {
 							yield(nil, err)
 							return
@@ -603,9 +603,9 @@ func TestUnifiedResourceCacheIteration(t *testing.T) {
 				_, err = c.CreateGitServer(ctx, gitServer)
 				return err
 			},
-			iterateResources: func(urc *services.UnifiedResourceCache) iter.Seq2[GetNamer, error] {
+			iterateResources: func(urc *services.UnifiedResourceCache, descending bool) iter.Seq2[GetNamer, error] {
 				return func(yield func(GetNamer, error) bool) {
-					for n, err := range urc.GitServers(ctx, services.UnifiedResourcesIterateParams{}) {
+					for n, err := range urc.GitServers(ctx, services.UnifiedResourcesIterateParams{Descending: descending}) {
 						if err != nil {
 							yield(nil, err)
 							return
@@ -632,9 +632,9 @@ func TestUnifiedResourceCacheIteration(t *testing.T) {
 				err = c.UpsertWindowsDesktop(ctx, win)
 				return err
 			},
-			iterateResources: func(urc *services.UnifiedResourceCache) iter.Seq2[GetNamer, error] {
+			iterateResources: func(urc *services.UnifiedResourceCache, descending bool) iter.Seq2[GetNamer, error] {
 				return func(yield func(GetNamer, error) bool) {
-					for n, err := range urc.WindowsDesktops(ctx, services.UnifiedResourcesIterateParams{}) {
+					for n, err := range urc.WindowsDesktops(ctx, services.UnifiedResourcesIterateParams{Descending: descending}) {
 						if err != nil {
 							yield(nil, err)
 							return
@@ -678,9 +678,9 @@ func TestUnifiedResourceCacheIteration(t *testing.T) {
 				})
 				return err
 			},
-			iterateResources: func(urc *services.UnifiedResourceCache) iter.Seq2[GetNamer, error] {
+			iterateResources: func(urc *services.UnifiedResourceCache, descending bool) iter.Seq2[GetNamer, error] {
 				return func(yield func(GetNamer, error) bool) {
-					for n, err := range urc.SAMLIdPServiceProviders(ctx, services.UnifiedResourcesIterateParams{}) {
+					for n, err := range urc.SAMLIdPServiceProviders(ctx, services.UnifiedResourcesIterateParams{Descending: descending}) {
 						if err != nil {
 							yield(nil, err)
 							return
@@ -725,9 +725,9 @@ func TestUnifiedResourceCacheIteration(t *testing.T) {
 					}})
 				return err
 			},
-			iterateResources: func(urc *services.UnifiedResourceCache) iter.Seq2[GetNamer, error] {
+			iterateResources: func(urc *services.UnifiedResourceCache, descending bool) iter.Seq2[GetNamer, error] {
 				return func(yield func(GetNamer, error) bool) {
-					for n, err := range urc.IdentityCenterAccounts(ctx, services.UnifiedResourcesIterateParams{}) {
+					for n, err := range urc.IdentityCenterAccounts(ctx, services.UnifiedResourcesIterateParams{Descending: descending}) {
 						if err != nil {
 							yield(nil, err)
 							return
@@ -766,9 +766,9 @@ func TestUnifiedResourceCacheIteration(t *testing.T) {
 					}})
 				return err
 			},
-			iterateResources: func(urc *services.UnifiedResourceCache) iter.Seq2[GetNamer, error] {
+			iterateResources: func(urc *services.UnifiedResourceCache, descending bool) iter.Seq2[GetNamer, error] {
 				return func(yield func(GetNamer, error) bool) {
-					for n, err := range urc.IdentityCenterAccountAssignments(ctx, services.UnifiedResourcesIterateParams{}) {
+					for n, err := range urc.IdentityCenterAccountAssignments(ctx, services.UnifiedResourcesIterateParams{Descending: descending}) {
 						if err != nil {
 							yield(nil, err)
 							return
@@ -802,25 +802,100 @@ func TestUnifiedResourceCacheIteration(t *testing.T) {
 				require.NoError(t, test.createResource(ids[i], clt), "creating resource %d", i)
 			}
 
+			var expected []types.ResourceWithLabels
 			require.EventuallyWithT(t, func(t *assert.CollectT) {
-				found, err := w.GetUnifiedResources(ctx)
+				var err error
+				expected, err = w.GetUnifiedResources(ctx)
 				assert.NoError(t, err)
-				assert.Len(t, found, resourceCount)
+				assert.Len(t, expected, resourceCount)
 			}, 10*time.Second, 100*time.Millisecond)
 
-			count := 0
-			for r, err := range test.iterateResources(w) {
-				require.NoError(t, err)
+			t.Run("resource iterator", func(t *testing.T) {
+				t.Run("ascending", func(t *testing.T) {
+					count := 0
+					for r, err := range test.iterateResources(w, false) {
+						require.NoError(t, err)
 
-				if r.GetName() != ids[count] {
-					t.Fatalf("expected resource named %s, got %s", ids[count], r.GetName())
-				}
-				count++
-			}
+						if r.GetName() != ids[count] {
+							t.Fatalf("expected resource named %s, got %s", ids[count], r.GetName())
+						}
+						count++
+					}
 
-			if count != resourceCount {
-				t.Fatalf("iteration completed early, expected %d apps, got %d", resourceCount, count)
-			}
+					require.Equal(t, resourceCount, count)
+				})
+
+				t.Run("descending", func(t *testing.T) {
+					count := resourceCount - 1
+					for r, err := range test.iterateResources(w, true) {
+						require.NoError(t, err)
+
+						if r.GetName() != ids[count] {
+							t.Fatalf("expected resource named %s, got %s", ids[count], r.GetName())
+						}
+						count--
+					}
+
+					require.Equal(t, -1, count)
+				})
+			})
+
+			t.Run("IterateUnifiedResources", func(t *testing.T) {
+				t.Run("ascending", func(t *testing.T) {
+					count := 0
+					req := proto.ListUnifiedResourcesRequest{}
+					for {
+						resources, next, err := w.IterateUnifiedResources(ctx, func(labels types.ResourceWithLabels) (bool, error) {
+							return true, nil
+						}, &req)
+
+						require.NoError(t, err)
+
+						for _, r := range resources {
+							if r.GetName() != ids[count] {
+								t.Fatalf("expected resource named %s, got %s", ids[count], r.GetName())
+							}
+							count++
+						}
+
+						if next == "" {
+							break
+						}
+						req.StartKey = next
+					}
+
+					require.Equal(t, resourceCount, count)
+				})
+
+				t.Run("descending", func(t *testing.T) {
+					count := resourceCount - 1
+					req := proto.ListUnifiedResourcesRequest{
+						SortBy: types.SortBy{Field: types.ResourceKind, IsDesc: true},
+					}
+					for {
+						resources, next, err := w.IterateUnifiedResources(ctx, func(labels types.ResourceWithLabels) (bool, error) {
+							return true, nil
+						}, &req)
+
+						require.NoError(t, err)
+
+						for _, r := range resources {
+							if r.GetName() != ids[count] {
+								t.Fatalf("expected resource named %s, got %s", ids[count], r.GetName())
+							}
+							count--
+						}
+
+						if next == "" {
+							break
+						}
+						req.StartKey = next
+					}
+
+					require.Equal(t, -1, count)
+				})
+			})
+
 		})
 	}
 }


### PR DESCRIPTION
The internal pagination allows the read lock to be held for shorter intervals, and most crucially, cannot be held open while consuming the iterator. This eliminate issues that may arise by executing slow operations during iteration which may starve writes. 

The changes here were heavily influenced by and modeled after https://github.com/gravitational/teleport/pull/52575.