### PR TITLE
[v17] GitHub proxy: git to prompt for password when tsh session expires

### DIFF
--- a/api/utils/prompt/stdin.go
+++ b/api/utils/prompt/stdin.go
@@ -89,21 +89,23 @@ func maybeUseStdinTerminalFallbackLocked(original *ContextReader) *ContextReader
 		return original
 	}
 
+	ctx := context.Background()
+
 	// File /dev/tty is the controlling tty of the current terminal. Not
 	// available on Windows.
 	// https://tldp.org/HOWTO/Text-Terminal-HOWTO-7.html
 	devTTY, err := os.Open("/dev/tty")
 	if err != nil {
-		slog.DebugContext(context.Background(), "Failed to open /dev/tty", "error", err)
+		slog.DebugContext(ctx, "Failed to open /dev/tty", "error", err)
 		return original
 	}
 
 	fallback := NewContextReader(devTTY)
 	if !fallback.IsTerminal() {
-		slog.DebugContext(context.Background(), "/dev/tty is not a terminal")
+		slog.DebugContext(ctx, "/dev/tty is not a terminal")
 		return original
 	}
 
-	slog.DebugContext(context.Background(), "Using /dev/tty for prompt")
+	slog.DebugContext(ctx, "Using /dev/tty for prompt")
 	return fallback
 }

--- a/api/utils/prompt/stdin.go
+++ b/api/utils/prompt/stdin.go
@@ -91,7 +91,7 @@ func maybeUseStdinTerminalFallbackLocked(original *ContextReader) *ContextReader
 
 	// File /dev/tty is the controlling tty of the current terminal. Not
 	// available on Windows.
-	// https://man7.org/linux/man-pages/man4/tty.4.html
+	// https://tldp.org/HOWTO/Text-Terminal-HOWTO-7.html
 	devTTY, err := os.Open("/dev/tty")
 	if err != nil {
 		slog.DebugContext(context.Background(), "Failed to open /dev/tty", "error", err)

--- a/tool/tsh/common/git_ssh.go
+++ b/tool/tsh/common/git_ssh.go
@@ -27,7 +27,9 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/prompt"
 	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 // gitSSHCommand implements `tsh git ssh`.
@@ -55,15 +57,24 @@ func newGitSSHCommand(parent *kingpin.CmdClause) *gitSSHCommand {
 	return cmd
 }
 
-func (c *gitSSHCommand) run(cf *CLIConf) error {
+func (c *gitSSHCommand) run(cf *CLIConf) (err error) {
 	_, host, ok := strings.Cut(c.userHost, "@")
 	if !ok || host != "github.com" {
 		return trace.BadParameter("user-host %q is not GitHub", c.userHost)
 	}
 
-	// TODO(greedy52) when git calls tsh, tsh cannot prompt for password (e.g.
-	// user session expired) using provided stdin pipe. `tc.Login` should try
-	// hijacking "/dev/tty" and replace `prompt.Stdin` temporarily.
+	// This command is invoked by "git" and it can be invoked when the user
+	// session is expired. Stdin piped by "git" is likely not the terminal so
+	// try some hacks to do the prompt. In cases the prompt is still not
+	// available (e.g. Windows, GUI tools, etc.), print a user-friendly message
+	// instead of "ssh: cert has expired".
+	prompt.EnableStdinTerminalFallback()
+	defer func() {
+		if utils.IsCertExpiredError(err) {
+			err = trace.AccessDenied("Your Teleport session has expired. Please login using 'tsh login'.")
+		}
+	}()
+
 	identity, err := getGitHubIdentity(cf, c.gitHubOrg)
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
Backport #51305 to branch/v17

changelog: Git proxy commands executed in terminals now support interactive login prompts when the `tsh` session expires
