### PR TITLE
[v17] Create v2 web api endpoint for deleting integration with cleanup

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1017,7 +1017,9 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.GET("/webapi/sites/:site/integrations/:name/stats", h.WithClusterAuth(h.integrationStats))
 	h.GET("/webapi/sites/:site/integrations/:name/discoveryrules", h.WithClusterAuth(h.integrationDiscoveryRules))
 	h.GET("/webapi/sites/:site/integrations/:name/ca", h.WithClusterAuth(h.integrationsExportCA))
+	// TODO(kimlisa): DELETE IN 19.0 - Replaced by /v2 equivalent endpoint
 	h.DELETE("/webapi/sites/:site/integrations/:name_or_subkind", h.WithClusterAuth(h.integrationsDelete))
+	h.DELETE("/v2/webapi/sites/:site/integrations/:name_or_subkind", h.WithClusterAuth(h.integrationsDelete))
 
 	// GET the Microsoft Teams plugin app.zip file.
 	h.GET("/webapi/sites/:site/plugins/:plugin/files/msteams_app.zip", h.WithClusterAuth(h.integrationsMsTeamsAppZipGet))

--- a/lib/web/git_servers.go
+++ b/lib/web/git_servers.go
@@ -93,5 +93,9 @@ func (h *Handler) gitServerDelete(_ http.ResponseWriter, r *http.Request, p http
 		return nil, trace.Wrap(err)
 	}
 
-	return OK(), clt.GitServerClient().DeleteGitServer(r.Context(), name)
+	if err := clt.GitServerClient().DeleteGitServer(r.Context(), name); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return OK(), nil
 }

--- a/web/packages/teleport/src/Integrations/Operations/IntegrationOperations.tsx
+++ b/web/packages/teleport/src/Integrations/Operations/IntegrationOperations.tsx
@@ -25,12 +25,16 @@ import {
   OperationType,
 } from './useIntegrationOperation';
 
+export type DeleteRequestOptions = {
+  deleteAssociatedResources?: boolean;
+};
+
 export type Props<UpdateRequest> = {
   operation: OperationType;
   integration: Integration;
   close(): void;
   edit(req: UpdateRequest): Promise<void>;
-  remove(): Promise<void>;
+  remove(opt?: DeleteRequestOptions): Promise<void>;
 };
 
 export function IntegrationOperations({

--- a/web/packages/teleport/src/Integrations/Operations/useIntegrationOperation.ts
+++ b/web/packages/teleport/src/Integrations/Operations/useIntegrationOperation.ts
@@ -26,6 +26,8 @@ import {
 } from 'teleport/services/integrations';
 import useStickyClusterId from 'teleport/useStickyClusterId';
 
+import { DeleteRequestOptions } from './IntegrationOperations';
+
 export function useIntegrationOperation() {
   const { clusterId } = useStickyClusterId();
 
@@ -37,8 +39,12 @@ export function useIntegrationOperation() {
     setOperation({ type: 'none' });
   }
 
-  function remove() {
-    return integrationService.deleteIntegration(operation.item.name);
+  function remove(opt: DeleteRequestOptions = {}) {
+    return integrationService.deleteIntegration({
+      name: operation.item.name,
+      clusterId,
+      deleteAssociatedResources: opt.deleteAssociatedResources,
+    });
   }
 
   async function edit(req: EditableIntegrationFields) {

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -33,6 +33,7 @@ import { TaskState } from 'teleport/Integrations/status/AwsOidc/Tasks/constants'
 import type { SortType } from 'teleport/services/agents';
 import {
   AwsOidcPolicyPreset,
+  IntegrationDeleteRequest,
   IntegrationKind,
   PluginKind,
   Regions,
@@ -361,7 +362,13 @@ const cfg = {
       export: '/v1/webapi/sites/:clusterId/integrations/:name/ca',
     },
 
+    // TODO(kimlisa): move integrationsPath into integration: {...}
     integrationsPath: '/v1/webapi/sites/:clusterId/integrations/:name?',
+    integration: {
+      deleteV2:
+        '/v2/webapi/sites/:clusterId/integrations/:name?associatedresources=:associatedresources',
+    },
+
     integrationStatsPath:
       '/v1/webapi/sites/:clusterId/integrations/:name/stats',
     integrationRulesPath:
@@ -1102,6 +1109,20 @@ const cfg = {
       clusterId,
       name: integrationName,
     });
+  },
+
+  getDeleteIntegrationUrlV2(req: IntegrationDeleteRequest) {
+    // Not using generatePath here because it doesn't work
+    // when a dynamic path and a query param is next to each other.
+    // eg: some/path/:name?queryParmKey=queryParamValue it will
+    // remove the required ? in the path.
+    return cfg.api.integration.deleteV2
+      .replace(':clusterId', req.clusterId)
+      .replace(':name', req.name)
+      .replace(
+        ':associatedresources',
+        req.deleteAssociatedResources ? 'true' : 'false'
+      );
   },
 
   getIntegrationStatsUrl(name: string) {

--- a/web/packages/teleport/src/services/integrations/integrations.test.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.test.ts
@@ -115,7 +115,7 @@ test('fetch integration list: fetchIntegrations()', async () => {
         kind: 'github',
         name: 'github-my-org',
         resourceType: 'integration',
-        details: 'GitHub Organization "my-org"',
+        details: 'GitHub repository access for organization "my-org"',
         spec: { organization: 'my-org' },
         statusCode: IntegrationStatusCode.Running,
       },

--- a/web/packages/teleport/src/services/integrations/integrations.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.ts
@@ -25,7 +25,10 @@ import { App } from '../apps';
 import makeApp from '../apps/makeApps';
 import auth, { MfaChallengeScope } from '../auth/auth';
 import makeNode from '../nodes/makeNode';
-import { withUnsupportedLabelFeatureErrorConversion } from '../version/unsupported';
+import {
+  withGenericUnsupportedError,
+  withUnsupportedLabelFeatureErrorConversion,
+} from '../version/unsupported';
 import {
   AwsDatabaseVpcsResponse,
   AwsOidcDeployDatabaseServicesRequest,
@@ -46,6 +49,7 @@ import {
   Integration,
   IntegrationCreateRequest,
   IntegrationCreateResult,
+  IntegrationDeleteRequest,
   IntegrationDiscoveryRules,
   IntegrationKind,
   IntegrationListResponse,
@@ -135,8 +139,10 @@ export const integrationService = {
       .then(makeIntegration);
   },
 
-  deleteIntegration(name: string): Promise<void> {
-    return api.delete(cfg.getIntegrationsUrl(name));
+  deleteIntegration(req: IntegrationDeleteRequest): Promise<void> {
+    return api
+      .delete(cfg.getDeleteIntegrationUrlV2(req))
+      .catch(err => withGenericUnsupportedError(err, 'v17.3.0'));
   },
 
   fetchThumbprint(): Promise<string> {
@@ -644,7 +650,7 @@ function makeIntegration(json: any): Integration {
     return {
       ...commonFields,
       resourceType: 'integration',
-      details: `GitHub Organization "${github.organization}"`,
+      details: `GitHub repository access for organization "${github.organization}"`,
       spec: {
         organization: github.organization,
       },

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -1030,3 +1030,15 @@ export type ExportedIntegrationCaResponse = {
   tls: TlsKey[];
   jwt: JwtKey[];
 };
+
+export type IntegrationDeleteRequest = {
+  name: string;
+  clusterId: string;
+  /**
+   * If true, will delete any associated resources
+   * tied to the integration.
+   *
+   * Not all integration kinds supports resource cleanup.
+   */
+  deleteAssociatedResources?: boolean;
+};

--- a/web/packages/teleport/src/services/version/unsupported.test.ts
+++ b/web/packages/teleport/src/services/version/unsupported.test.ts
@@ -20,8 +20,13 @@ import { renderHook } from '@testing-library/react';
 
 import { app } from 'teleport/Discover/AwsMangementConsole/fixtures';
 
+import { ApiError } from '../api/parseError';
 import { integrationService } from '../integrations';
-import { ProxyRequiresUpgrade, useV1Fallback } from './unsupported';
+import {
+  ProxyRequiresUpgrade,
+  useV1Fallback,
+  withGenericUnsupportedError,
+} from './unsupported';
 
 afterEach(() => {
   jest.resetAllMocks();
@@ -76,4 +81,50 @@ test('with upgrade proxy error, without labels, runs fallback', async () => {
 
   expect(resp).toEqual(app);
   expect(integrationService.createAwsAppAccess).toHaveBeenCalledTimes(1);
+});
+
+describe('withGenericUnsupportedError', () => {
+  test('path not found error with proxy version throws custom error', async () => {
+    const pathNotFoundError = new ApiError({
+      message: '',
+      response: { status: 404 } as Response,
+      proxyVersion: {
+        major: 1,
+        minor: 2,
+        patch: 3,
+        preRelease: 'dev',
+        string: 'v1.2.3-dev',
+      },
+    });
+
+    expect(() =>
+      withGenericUnsupportedError(pathNotFoundError, 'v2.0.0')
+    ).toThrow('Your proxy (v1.2.3-dev) may be behind');
+
+    expect(() =>
+      withGenericUnsupportedError(pathNotFoundError, 'v2.0.0')
+    ).toThrow('minimum required version (v2.0.0)');
+  });
+
+  test('legach path not found error throws custom error', async () => {
+    const legacyPathNotFoundError = new ApiError({
+      message: `404 - https://llama`,
+      response: { status: 404, url: 'https://llama' } as Response,
+    });
+
+    expect(() =>
+      withGenericUnsupportedError(legacyPathNotFoundError, 'v2.0.0')
+    ).toThrow('Your proxy may be behind');
+  });
+
+  test('non path related 404 error rethrows same error', async () => {
+    const resourceNotFoundError = new ApiError({
+      message: `same error`,
+      response: { status: 404 } as Response,
+    });
+
+    expect(() =>
+      withGenericUnsupportedError(resourceNotFoundError, 'v2.0.0')
+    ).toThrow('same error');
+  });
 });

--- a/web/packages/teleport/src/services/version/unsupported.ts
+++ b/web/packages/teleport/src/services/version/unsupported.ts
@@ -30,6 +30,44 @@ import { JoinToken, JoinTokenRequest } from '../joinToken';
 
 export const ProxyRequiresUpgrade = 'Ensure all proxies are upgraded';
 
+/**
+ * Throws a custom error that are a result of `path not found` as a generic
+ * error message about this request not being supported and suggests
+ * to user to upgrade all proxies to the specified version.
+ *
+ * Else, rethrows the same error.
+ *
+ * @param supportedVersion the minimum version required for this
+ * request to succeed eg: v17.3.0
+ */
+export function withGenericUnsupportedError(
+  err: unknown,
+  supportedVersion: string
+) {
+  if (err instanceof ApiError && err.response.status === 404) {
+    if (err.proxyVersion) {
+      throw new Error(
+        'We could not complete your request. ' +
+          `Your proxy (${err.proxyVersion.string}) may be behind the ` +
+          `minimum required version (${supportedVersion}) to support ` +
+          `this request. ${ProxyRequiresUpgrade} and try again.`
+      );
+    }
+    // DELETE IN 19.0
+    // pre v17 this is the legacy error message crafted as a result
+    // of no path found.
+    if (err.message == `${err.response.status} - ${err.response.url}`) {
+      throw new Error(
+        'We could not complete your request. ' +
+          'Your proxy may be behind the minimum required version ' +
+          `(${supportedVersion}) to support this request. ` +
+          `${ProxyRequiresUpgrade} and try again.`
+      );
+    }
+  }
+  throw err;
+}
+
 export function withUnsupportedLabelFeatureErrorConversion(
   err: unknown
 ): never {


### PR DESCRIPTION
backport https://github.com/gravitational/teleport/pull/52286 to branch/v17

manual because of simple import conflict