### PR TITLE
[v15] Check redirects introduced by docs changes

### DIFF
--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -41,7 +41,7 @@ jobs:
       contents: read
 
     steps:
-      - name: Checkout
+      - name: Check out teleport
         uses: actions/checkout@v4
         with:
           repository: 'gravitational/teleport'
@@ -53,6 +53,29 @@ jobs:
           repository: 'gravitational/docs-website'
           path: 'docs'
 
+      - name: Generate GitHub Token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.REVIEWERS_APP_ID }}
+          private-key: ${{ secrets.REVIEWERS_PRIVATE_KEY }}
+
+      - name: Check out shared-workflows
+        uses: actions/checkout@v4
+        with:
+          repository: gravitational/shared-workflows
+          path: shared-workflows
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+
+      - name: Ensure docs changes include redirects
+        env:
+          TOKEN: ${{ steps.generate_token.outputs.token }}
+          REVIEWERS: ${{ secrets.reviewers }}
+        run: cd shared-workflows/bot && go run main.go -workflow=docpaths -token="${TOKEN}" -teleport-path="${GITHUB_WORKSPACE}/teleport" -reviewers="${REVIEWERS}"
       # Cache node_modules. Unlike the example in the actions/cache repo, this
       # caches the node_modules directory instead of the yarn cache. This is
       # because yarn needs to build fresh packages even when it copies files


### PR DESCRIPTION
Backports #48546

* Check redirects introduced by docs changes

Configure the `Lint (Docs)` workflow to ensure that docs changes that delete or rename a docs page also introduce a redirect.

* Respond to fheinecke feedback

- Edit the checkout path for shared-workflows
- Use environment variables instead of interpolation with GHA contexts