### PR TITLE
access_monitoring_rule: Support user.traits condition variable

### DIFF
--- a/integrations/access/accessmonitoring/access_monitoring_rules.go
+++ b/integrations/access/accessmonitoring/access_monitoring_rules.go
@@ -149,15 +149,7 @@ func (amrh *RuleHandler) RecipientsFromAccessMonitoringRules(ctx context.Context
 	recipientSet := common.NewRecipientSet()
 
 	for _, rule := range amrh.getAccessMonitoringRules() {
-		match, err := EvaluateCondition(rule.Spec.Condition, AccessRequestExpressionEnv{
-			Roles:              req.GetRoles(),
-			SuggestedReviewers: req.GetSuggestedReviewers(),
-			Annotations:        req.GetSystemAnnotations(),
-			User:               req.GetUser(),
-			RequestReason:      req.GetRequestReason(),
-			CreationTime:       req.GetCreationTime(),
-			Expiry:             req.Expiry(),
-		})
+		match, err := EvaluateCondition(rule.Spec.Condition, getAccessRequestExpressionEnv(req))
 		if err != nil {
 			log.WarnContext(ctx, "Failed to parse access monitoring notification rule",
 				"error", err,
@@ -184,15 +176,7 @@ func (amrh *RuleHandler) RawRecipientsFromAccessMonitoringRules(ctx context.Cont
 	log := logger.Get(ctx)
 	recipientSet := stringset.New()
 	for _, rule := range amrh.getAccessMonitoringRules() {
-		match, err := EvaluateCondition(rule.Spec.Condition, AccessRequestExpressionEnv{
-			Roles:              req.GetRoles(),
-			SuggestedReviewers: req.GetSuggestedReviewers(),
-			Annotations:        req.GetSystemAnnotations(),
-			User:               req.GetUser(),
-			RequestReason:      req.GetRequestReason(),
-			CreationTime:       req.GetCreationTime(),
-			Expiry:             req.Expiry(),
-		})
+		match, err := EvaluateCondition(rule.Spec.Condition, getAccessRequestExpressionEnv(req))
 		if err != nil {
 			log.WarnContext(ctx, "Failed to parse access monitoring notification rule",
 				"error", err,
@@ -247,4 +231,17 @@ func (amrh *RuleHandler) ruleApplies(amr *accessmonitoringrulesv1.AccessMonitori
 	return slices.ContainsFunc(amr.Spec.Subjects, func(subject string) bool {
 		return subject == types.KindAccessRequest
 	})
+}
+
+// getAccessRequestExpressionEnv returns the expression env of the access request.
+func getAccessRequestExpressionEnv(req types.AccessRequest) AccessRequestExpressionEnv {
+	return AccessRequestExpressionEnv{
+		Roles:              req.GetRoles(),
+		SuggestedReviewers: req.GetSuggestedReviewers(),
+		Annotations:        req.GetSystemAnnotations(),
+		User:               req.GetUser(),
+		RequestReason:      req.GetRequestReason(),
+		CreationTime:       req.GetCreationTime(),
+		Expiry:             req.Expiry(),
+	}
 }

--- a/integrations/access/accessmonitoring/access_monitoring_rules.go
+++ b/integrations/access/accessmonitoring/access_monitoring_rules.go
@@ -149,7 +149,15 @@ func (amrh *RuleHandler) RecipientsFromAccessMonitoringRules(ctx context.Context
 	recipientSet := common.NewRecipientSet()
 
 	for _, rule := range amrh.getAccessMonitoringRules() {
-		match, err := MatchAccessRequest(rule.Spec.Condition, req)
+		match, err := EvaluateCondition(rule.Spec.Condition, AccessRequestExpressionEnv{
+			Roles:              req.GetRoles(),
+			SuggestedReviewers: req.GetSuggestedReviewers(),
+			Annotations:        req.GetSystemAnnotations(),
+			User:               req.GetUser(),
+			RequestReason:      req.GetRequestReason(),
+			CreationTime:       req.GetCreationTime(),
+			Expiry:             req.Expiry(),
+		})
 		if err != nil {
 			log.WarnContext(ctx, "Failed to parse access monitoring notification rule",
 				"error", err,
@@ -176,7 +184,15 @@ func (amrh *RuleHandler) RawRecipientsFromAccessMonitoringRules(ctx context.Cont
 	log := logger.Get(ctx)
 	recipientSet := stringset.New()
 	for _, rule := range amrh.getAccessMonitoringRules() {
-		match, err := MatchAccessRequest(rule.Spec.Condition, req)
+		match, err := EvaluateCondition(rule.Spec.Condition, AccessRequestExpressionEnv{
+			Roles:              req.GetRoles(),
+			SuggestedReviewers: req.GetSuggestedReviewers(),
+			Annotations:        req.GetSystemAnnotations(),
+			User:               req.GetUser(),
+			RequestReason:      req.GetRequestReason(),
+			CreationTime:       req.GetCreationTime(),
+			Expiry:             req.Expiry(),
+		})
 		if err != nil {
 			log.WarnContext(ctx, "Failed to parse access monitoring notification rule",
 				"error", err,

--- a/integrations/access/accessmonitoring/request_mapping.go
+++ b/integrations/access/accessmonitoring/request_mapping.go
@@ -21,14 +21,13 @@ import (
 
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/expression"
 	"github.com/gravitational/teleport/lib/utils/typical"
 )
 
-// accessRequestExpressionEnv holds user details that can be mapped in an
+// AccessRequestExpressionEnv holds user details that can be mapped in an
 // access request condition assertion.
-type accessRequestExpressionEnv struct {
+type AccessRequestExpressionEnv struct {
 	Roles              []string
 	SuggestedReviewers []string
 	Annotations        map[string][]string
@@ -36,9 +35,13 @@ type accessRequestExpressionEnv struct {
 	RequestReason      string
 	CreationTime       time.Time
 	Expiry             time.Time
+
+	// UserTraits includes arbitrary user traits dynamically provided by the
+	// access monitoring rule handler.
+	UserTraits map[string][]string
 }
 
-type accessRequestExpression typical.Expression[accessRequestExpressionEnv, any]
+type accessRequestExpression typical.Expression[AccessRequestExpressionEnv, any]
 
 func parseAccessRequestExpression(expr string) (accessRequestExpression, error) {
 	parser, err := newRequestConditionParser()
@@ -51,63 +54,59 @@ func parseAccessRequestExpression(expr string) (accessRequestExpression, error) 
 	}
 	return parsedExpr, nil
 }
-
-func newRequestConditionParser() (*typical.Parser[accessRequestExpressionEnv, any], error) {
+func newRequestConditionParser() (*typical.Parser[AccessRequestExpressionEnv, any], error) {
 	typicalEnvVar := map[string]typical.Variable{
 		"true":  true,
 		"false": false,
-		"access_request.spec.roles": typical.DynamicVariable[accessRequestExpressionEnv](func(env accessRequestExpressionEnv) (expression.Set, error) {
+		"access_request.spec.roles": typical.DynamicVariable(func(env AccessRequestExpressionEnv) (expression.Set, error) {
 			return expression.NewSet(env.Roles...), nil
 		}),
-		"access_request.spec.suggested_reviewers": typical.DynamicVariable[accessRequestExpressionEnv](func(env accessRequestExpressionEnv) (expression.Set, error) {
+		"access_request.spec.suggested_reviewers": typical.DynamicVariable(func(env AccessRequestExpressionEnv) (expression.Set, error) {
 			return expression.NewSet(env.SuggestedReviewers...), nil
 		}),
-		"access_request.spec.system_annotations": typical.DynamicMap[accessRequestExpressionEnv, expression.Set](func(env accessRequestExpressionEnv) (expression.Dict, error) {
+		"access_request.spec.system_annotations": typical.DynamicMap(func(env AccessRequestExpressionEnv) (expression.Dict, error) {
 			return expression.DictFromStringSliceMap(env.Annotations), nil
 		}),
-		"access_request.spec.user": typical.DynamicVariable[accessRequestExpressionEnv](func(env accessRequestExpressionEnv) (string, error) {
+		"access_request.spec.user": typical.DynamicVariable(func(env AccessRequestExpressionEnv) (string, error) {
 			return env.User, nil
 		}),
-		"access_request.spec.request_reason": typical.DynamicVariable[accessRequestExpressionEnv](func(env accessRequestExpressionEnv) (string, error) {
+		"access_request.spec.request_reason": typical.DynamicVariable(func(env AccessRequestExpressionEnv) (string, error) {
 			return env.RequestReason, nil
 		}),
-		"access_request.spec.creation_time": typical.DynamicVariable[accessRequestExpressionEnv](func(env accessRequestExpressionEnv) (time.Time, error) {
+		"access_request.spec.creation_time": typical.DynamicVariable(func(env AccessRequestExpressionEnv) (time.Time, error) {
 			return env.CreationTime, nil
 		}),
-		"access_request.spec.expiry": typical.DynamicVariable[accessRequestExpressionEnv](func(env accessRequestExpressionEnv) (time.Time, error) {
+		"access_request.spec.expiry": typical.DynamicVariable(func(env AccessRequestExpressionEnv) (time.Time, error) {
 			return env.Expiry, nil
 		}),
+
+		"user.traits": typical.DynamicMap(func(env AccessRequestExpressionEnv) (expression.Dict, error) {
+			return expression.DictFromStringSliceMap(env.UserTraits), nil
+		}),
 	}
-	defParserSpec := expression.DefaultParserSpec[accessRequestExpressionEnv]()
+	defParserSpec := expression.DefaultParserSpec[AccessRequestExpressionEnv]()
 	defParserSpec.Variables = typicalEnvVar
 
-	requestConditionParser, err := typical.NewParser[accessRequestExpressionEnv, any](defParserSpec)
+	requestConditionParser, err := typical.NewParser[AccessRequestExpressionEnv, any](defParserSpec)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return requestConditionParser, nil
 }
 
-func MatchAccessRequest(expr string, req types.AccessRequest) (bool, error) {
+// EvaluateCondition evaluates the condition expression given the provided environment.
+// A true value indicates that the AMR is a match for the given access request
+// environment. Returns false, if evaluated to a non-boolean value.
+func EvaluateCondition(expr string, env AccessRequestExpressionEnv) (bool, error) {
 	parsedExpr, err := parseAccessRequestExpression(expr)
 	if err != nil {
 		return false, trace.Wrap(err)
 	}
 
-	match, err := parsedExpr.Evaluate(accessRequestExpressionEnv{
-		Roles:              req.GetRoles(),
-		SuggestedReviewers: req.GetSuggestedReviewers(),
-		Annotations:        req.GetSystemAnnotations(),
-		User:               req.GetUser(),
-		RequestReason:      req.GetRequestReason(),
-		CreationTime:       req.GetCreationTime(),
-		Expiry:             req.Expiry(),
-	})
+	match, err := parsedExpr.Evaluate(env)
 	if err != nil {
 		return false, trace.Wrap(err, "evaluating access monitoring rule condition expression %q", expr)
 	}
-	if matched, ok := match.(bool); ok && matched {
-		return true, nil
-	}
-	return false, nil
+	matched, ok := match.(bool)
+	return ok && matched, nil
 }

--- a/integrations/access/accessmonitoring/request_mapping_test.go
+++ b/integrations/access/accessmonitoring/request_mapping_test.go
@@ -1,0 +1,93 @@
+/*
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package accessmonitoring
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvaluateCondition(t *testing.T) {
+	tests := []struct {
+		description string
+		condition   string
+		env         AccessRequestExpressionEnv
+		match       bool
+	}{
+		{
+			description: "does not match user 'level' trait",
+			condition:   `contains_any(user.traits["level"], set("L1"))`,
+			env: AccessRequestExpressionEnv{
+				UserTraits: map[string][]string{
+					"level": {"L2"},
+				},
+			},
+			match: false,
+		},
+		{
+			description: "matches one of user 'level' trait",
+			condition:   `contains_any(user.traits["level"], set("L1", "L2"))`,
+			env: AccessRequestExpressionEnv{
+				UserTraits: map[string][]string{
+					"level": {"L1"},
+				},
+			},
+			match: true,
+		},
+		{
+			description: "matches all user traits",
+			condition: `
+				contains_any(user.traits["level"], set("L1", "L2")) &&
+				contains_any(user.traits["team"], set("Cloud")) &&
+				contains_any(user.traits["location"], set("Seattle"))`,
+			env: AccessRequestExpressionEnv{
+				UserTraits: map[string][]string{
+					"level":    {"L1"},
+					"team":     {"Cloud"},
+					"location": {"Seattle"},
+				},
+			},
+			match: true,
+		},
+		{
+			description: "matches some user traits",
+			condition: `
+				contains_any(user.traits["level"], set("L1", "L2")) &&
+				contains_any(user.traits["team"], set("Cloud")) &&
+				contains_any(user.traits["location"], set("Seattle"))`,
+			env: AccessRequestExpressionEnv{
+				UserTraits: map[string][]string{
+					"level":    {"L1"},
+					"team":     {"Tools"},
+					"location": {"Seattle"},
+				},
+			},
+			match: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			match, err := EvaluateCondition(test.condition, test.env)
+			require.NoError(t, err)
+			require.Equal(t, test.match, match)
+		})
+	}
+}


### PR DESCRIPTION
Supports https://github.com/gravitational/teleport/issues/51682
This extends the `access_monitoring_rule` condition to support the `user.traits` variable. This will allow users to configure automatic approvals based on the requesting user's traits. 

```yaml
# This example AMR would allow users with traits "level"="L1" and "team"="Cloud" and
# "location"="Seattle" to be pre-approved for the "cloud-dev" role.
kind: access_monitoring_rule
version: v1
metadata:
  name: example
spec:
  subjects:
    - access_request
  states:
    - approved
  condition: >
    access_request.spec.roles == set("cloud-dev") &&
    contains_any(user.traits["level"], set("L1")) &&
    contains_any(user.traits["team"], set("Cloud")) &&
    contains_any(user.traits["location"], set("Seattle"))
  automatic_approval:
    name: teleport
```

The `user.traits` variable will be assigned in a future PR by the new internal automatic approval service.