### PR TITLE
docs: Remove references to `tsh aws proxy` `--endpoint-url` mode

### DIFF
--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
@@ -782,17 +782,17 @@ instance and attach an IAM role to it.
 
 ### Missing X-Forwarded-Host HTTP header
 
-You may enconter the error `proxied requests must include X-Forwarded-Host header`
-when making requests to your `tsh` local proxy. This is due to Telepor's
-expecting the HTTP requests to include the `X-Forwarded-Host` header, containing
+You may encounter the error `proxied requests must include X-Forwarded-Host header`
+when making requests to your `tsh` local proxy. This is because Teleport
+expects the HTTP requests to include the `X-Forwarded-Host` header, containing
 a valid AWS endpoint.
 
-Ensure the application using the Teleport's AWS local proxy supports HTTPS proxy
+Ensure the application using the Teleport AWS local proxy supports HTTPS proxy
 setting. Passing the local proxy address to applications as the AWS endpoint URL
 is no longer supported.
 
 If you were previously using the `--endpoint-url` flag on `tsh proxy aws`
-command, you must update your applications to use HTTP Proxy instead.
+command, you must update your applications to use the local HTTPS proxy instead.
 
 ## Next steps
 

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
@@ -780,6 +780,20 @@ instance and attach an IAM role to it.
 
 (!docs/pages/includes/aws-no-credential-provider.mdx service="Application"!)
 
+### Missing X-Forwarded-Host HTTP header
+
+You may enconter the error `proxied requests must include X-Forwarded-Host header`
+when making requests to your `tsh` local proxy. This is due to Telepor's
+expecting the HTTP requests to include the `X-Forwarded-Host` header, containing
+a valid AWS endpoint.
+
+Ensure the application using the Teleport's AWS local proxy supports HTTPS proxy
+setting. Passing the local proxy address to applications as the AWS endpoint URL
+is no longer supported.
+
+If you were previously using the `--endpoint-url` flag on `tsh proxy aws`
+command, you must update your applications to use HTTP Proxy instead.
+
 ## Next steps
 
 Now that you know how to set up Teleport to protect access to the AWS Management

--- a/docs/pages/enroll-resources/application-access/guides/dynamodb.mdx
+++ b/docs/pages/enroll-resources/application-access/guides/dynamodb.mdx
@@ -91,80 +91,42 @@ so:
 $ tsh apps login --aws-role ExampleTeleportDynamoDBRole aws
 ```
 
-To connect your DynamoDB application, you can start either a local HTTPS proxy
-or a local AWS Service Endpoint proxy.
+To connect your DynamoDB application, start a local HTTPS proxy that forwards
+AWS requests to the Teleport Proxy Service, enabling you to access AWS
+applications.
 
-<Tabs>
-  <TabItem label="HTTPS proxy">
-  By default, starting the AWS app proxy creates a local HTTPS proxy server
-  that forwards AWS requests to the Teleport Proxy Service, enabling you to
-  access AWS applications.
+Use the following command to start the proxy your applications will be
+connecting to:
 
-  Now, use the following command to start the proxy your applications will be
-  connecting to:
+```code
+$ tsh proxy aws -p 23456
+Started AWS proxy on http://127.0.0.1:23456.
 
-  ```code
-  $ tsh proxy aws -p 23456
-  Started AWS proxy on http://127.0.0.1:23456.
+Use the following credentials and HTTPS proxy setting to connect to the proxy:
+  AWS_ACCESS_KEY_ID=(=aws.aws_access_key=)
+  AWS_SECRET_ACCESS_KEY=(=aws.aws_secret_access_key=)
+  AWS_CA_BUNDLE=<local-ca-bundle-path>
+  HTTPS_PROXY=http://127.0.0.1:23456
+```
 
-  Use the following credentials and HTTPS proxy setting to connect to the proxy:
-    AWS_ACCESS_KEY_ID=(=aws.aws_access_key=)
-    AWS_SECRET_ACCESS_KEY=(=aws.aws_secret_access_key=)
-    AWS_CA_BUNDLE=<local-ca-bundle-path>
-    HTTPS_PROXY=http://127.0.0.1:23456
-  ```
+Use the displayed AWS credentials and HTTPS proxy settings when configuring
+your application.
 
-  Use the displayed AWS credentials and HTTPS proxy settings when configuring
-  your application.
+For example, you can assign the AWS credentials and the HTTPS proxy address
+to environment variables for Python AWS SDK:
 
-  For example, you can assign the AWS credentials and the HTTPS proxy address
-  to environment variables for Python AWS SDK:
+```code
+$ export AWS_ACCESS_KEY_ID=(=aws.aws_access_key=)
+$ export AWS_SECRET_ACCESS_KEY=(=aws.aws_secret_access_key=)
+$ export AWS_CA_BUNDLE=<local-ca-bundle-path>
+$ export HTTPS_PROXY=http://127.0.0.1:23456
+$ python3
+>>> import boto3
+>>> boto3.client('dynamodb').list_tables()
+{'TableNames': ['my-dynamodb-table'], 'ResponseMetadata': {...}}
 
-  ```code
-  $ export AWS_ACCESS_KEY_ID=(=aws.aws_access_key=)
-  $ export AWS_SECRET_ACCESS_KEY=(=aws.aws_secret_access_key=)
-  $ export AWS_CA_BUNDLE=<local-ca-bundle-path>
-  $ export HTTPS_PROXY=http://127.0.0.1:23456
-  $ python3
-  >>> import boto3
-  >>> boto3.client('dynamodb').list_tables()
-  {'TableNames': ['my-dynamodb-table'], 'ResponseMetadata': {...}}
+```
 
-  ```
-
-  </TabItem>
-  <TabItem label="AWS Service Endpoint proxy">
-  If your application cannot use a HTTPS proxy, start the AWS app proxy with
-  the `--endpoint-url` flag to create a local server that can be used as an
-  AWS Service Endpoint.
-
-  ```code
-  $ tsh proxy aws --endpoint-url -p 23457
-  Started AWS proxy which serves as an AWS endpoint URL at https://localhost:23457
-
-  In addition to the endpoint URL, use the following credentials to connect to the proxy:
-    AWS_ACCESS_KEY_ID=(=aws.aws_access_key=)
-    AWS_SECRET_ACCESS_KEY=(=aws.aws_secret_access_key=)
-    AWS_CA_BUNDLE=<local-ca-bundle-path>
-  ```
-
-  For example, to connect the GUI tool `dynamodb-admin` to the local AWS
-  Service Endpoint proxy:
-  ```code
-  $ export AWS_ACCESS_KEY_ID=(=aws.aws_access_key=)
-  $ export AWS_SECRET_ACCESS_KEY=(=aws.aws_secret_access_key=)
-  $ export NODE_EXTRA_CA_CERTS=<local-ca-bundle-path>
-  $ export DYNAMO_ENDPOINT=https://127.0.0.1:23457
-  $ dynamodb-admin
-  database endpoint:     https://127.0.0.1:23457
-  region:                ca-central-1
-  accessKey:             <access-key-id>
-
-  dynamodb-admin listening on http://localhost:8001 (alternatively http://0.0.0.0:8001)
-  ```
-
-  </TabItem>
-</Tabs>
 To log out of the `aws` application and remove credentials:
 
 ```code

--- a/docs/pages/reference/cli/tsh.mdx
+++ b/docs/pages/reference/cli/tsh.mdx
@@ -591,7 +591,6 @@ $ tsh proxy aws [<flags>]
 | - | - | - | - |
 | `--app` | Currently logged in AWS app | string | Optional name of the AWS application (as shown in `tsh apps ls`) to use if logged in to multiple |
 | `-p`, `--port` | none | port number | Specify the source port for the local proxy |
-| `-e`, `--endpoint-url` | HTTP Proxy | Endpoint URL | Run the local proxy to serve as an AWS endpoint URL. If not specified, the local proxy serves as an HTTPS proxy. |
 | `-f`, `--format` | unix | `text`, `unix`, `command-prompt`, or `powershell` | Optional format for printing environment variables for the AWS proxy |
 
 ### [Global Flags](#tsh-global-flags)


### PR DESCRIPTION
This PR removes references to it and adds a troubleshooting section mentioning the issue users might face when running in the default mode (HTTP Proxy). This is due to #52042 (which will only be available in the next major release) removing support for the `--endpoint-url` flag on the `tsh aws proxy` command. 

Note that the DynamoDB (app access) guide already mentions that users must configure their access through DB Access if they want to use a GUI. This is why I haven't added any reference to GUI on the page. Also, the [NoSQL Workbench guide](https://goteleport.com/docs/connect-your-client/gui-clients/#nosql-workbench) already uses DB access.