### PR TITLE
Fix total counter for system clock reconciliation

### DIFF
--- a/lib/auth/server_monitor.go
+++ b/lib/auth/server_monitor.go
@@ -78,11 +78,6 @@ func (a *Server) checkInventorySystemClocks(ctx context.Context) {
 	var counter int
 	var messages []string
 	a.inventory.Iter(func(handle inventory.UpstreamHandle) {
-		counter++
-		if counter >= systemClockMessagesLimit {
-			return
-		}
-
 		hello := handle.Hello()
 		handle.VisitInstanceState(func(ref inventory.InstanceStateRef) (update inventory.InstanceStateUpdate) {
 			if ref.LastHeartbeat != nil && ref.LastHeartbeat.GetLastMeasurement() != nil {
@@ -97,12 +92,15 @@ func (a *Server) checkInventorySystemClocks(ctx context.Context) {
 						"services", hello.GetServices(),
 						"difference", durationText(diff),
 					)
-					messages = append(messages, fmt.Sprintf(
-						"%s[%s] is %s",
-						hello.GetServerID(),
-						types.SystemRoles(hello.GetServices()).String(),
-						durationText(diff),
-					))
+					if counter < systemClockMessagesLimit {
+						messages = append(messages, fmt.Sprintf(
+							"%s[%s] is %s",
+							hello.GetServerID(),
+							types.SystemRoles(hello.GetServices()).String(),
+							durationText(diff),
+						))
+					}
+					counter++
 				}
 			}
 			return


### PR DESCRIPTION
In this PR add fix for the total counter in global notification of instances with system clock difference introduced in https://github.com/gravitational/teleport/pull/44489

Discovered notification in our test cluster:

<img width="829" alt="image" src="https://github.com/user-attachments/assets/d9cea4e6-e955-4135-8a4e-db72d5099fe3" />

We have to: log warning for the each node, increase counter only for the nodes with time difference