### PR TITLE
Fix CGO-less TBot Build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -397,7 +397,8 @@ $(BUILDDIR)/tsh:
 
 .PHONY: $(BUILDDIR)/tbot
 # tbot is CGO-less by default except on Windows because lib/client/terminal/ wants CGO on this OS
-$(BUILDDIR)/tbot: TBOT_CGO_FLAGS ?= $(if $(filter windows,$(OS)),$(CGOFLAG))
+# We force cgo to be disabled, else the compiler might decide to enable it.
+$(BUILDDIR)/tbot: TBOT_CGO_FLAGS ?= $(if $(filter windows,$(OS)),$(CGOFLAG),CGO_ENABLED=0)
 # Build mode pie requires CGO
 $(BUILDDIR)/tbot: BUILDFLAGS_TBOT += $(if $(TBOT_CGO_FLAGS), -buildmode=pie)
 $(BUILDDIR)/tbot:

--- a/Makefile
+++ b/Makefile
@@ -400,7 +400,7 @@ $(BUILDDIR)/tsh:
 # We force cgo to be disabled, else the compiler might decide to enable it.
 $(BUILDDIR)/tbot: TBOT_CGO_FLAGS ?= $(if $(filter windows,$(OS)),$(CGOFLAG),CGO_ENABLED=0)
 # Build mode pie requires CGO
-$(BUILDDIR)/tbot: BUILDFLAGS_TBOT += $(if $(TBOT_CGO_FLAGS), -buildmode=pie)
+$(BUILDDIR)/tbot: BUILDFLAGS_TBOT += $(if $(findstring CGO_ENABLED=1,$(TBOT_CGO_FLAGS)), -buildmode=pie)
 $(BUILDDIR)/tbot:
 	GOOS=$(OS) GOARCH=$(ARCH) $(TBOT_CGO_FLAGS) go build -tags "$(FIPS_TAG) $(KUSTOMIZE_NO_DYNAMIC_PLUGIN)" -o $(BUILDDIR)/tbot $(BUILDFLAGS_TBOT) $(TOOLS_LDFLAGS) ./tool/tbot
 

--- a/integrations/teleport-spacelift-runner/Makefile
+++ b/integrations/teleport-spacelift-runner/Makefile
@@ -14,7 +14,7 @@ include ../../build.assets/images.mk
 .PHONY: docker-build
 docker-build:
 	docker buildx build --platform="$(OS)/$(ARCH)" \
-		--build-arg BUILDBOX=$(BUILDBOX_CENTOS7) \
+		--build-arg BUILDBOX=$(BUILDBOX_CENTOS7_NOARCH) \
 		--build-arg BASE_IMAGE=$(BASE_IMAGE) \
 		--load \
 		-f ./Dockerfile \


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/52101

Regression was introduced by https://github.com/gravitational/teleport/pull/43877 - which switched from explicitly setting CGO_ENABLED=0, to leaving it unset. The Go compiler then used its discretion to decide to perform a CGO build, which, has caused issues for the Spacelift image which is based on Alpine and has no glibc.

changelog: Fixed `cannot execute: required file not found` error with the `teleport-spacelift-runner` image