### PR TITLE
Remove VNet diag feature flag, enable diag on macOS

### DIFF
--- a/web/packages/teleterm/src/services/config/appConfigSchema.ts
+++ b/web/packages/teleterm/src/services/config/appConfigSchema.ts
@@ -206,7 +206,6 @@ export const createAppConfigSchema = (settings: RuntimeSettings) => {
           "'no' never attempts to add them, 'yes' always attempts to add them, " +
           "'only' always attempts to add the keys to the agent but it does not save them on disk."
       ),
-    'unstable.vnetDiag': z.boolean().default(false),
   });
 };
 

--- a/web/packages/teleterm/src/ui/TopBar/Connections/Connections.story.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/Connections.story.tsx
@@ -127,7 +127,6 @@ export function VnetWarning() {
   const appContext = new MockAppContext();
   prepareAppContext(appContext);
 
-  appContext.configService.set('unstable.vnetDiag', true);
   appContext.statePersistenceService.putState({
     ...appContext.statePersistenceService.getState(),
     vnet: { autoStart: true },

--- a/web/packages/teleterm/src/ui/Vnet/VnetConnectionItem.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetConnectionItem.tsx
@@ -21,7 +21,6 @@ import React, { forwardRef, useEffect, useMemo, useRef } from 'react';
 import { ButtonIcon, Flex, rotate360, Text } from 'design';
 import * as icons from 'design/Icon';
 
-import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { useKeyboardArrowsNavigation } from 'teleterm/ui/components/KeyboardArrowsNavigation';
 import { ListItem } from 'teleterm/ui/components/ListItem';
 import {
@@ -93,8 +92,6 @@ const VnetConnectionItemBase = forwardRef<
       }
   )
 >((props, ref) => {
-  const { configService } = useAppContext();
-  const isVnetDiagEnabled = configService.get('unstable.vnetDiag').value;
   const {
     status,
     start,
@@ -104,6 +101,7 @@ const VnetConnectionItemBase = forwardRef<
     diagnosticsAttempt,
     getDisabledDiagnosticsReason,
     showDiagWarningIndicator,
+    isDiagSupported,
   } = useVnetContext();
   const isProcessing =
     startAttempt.status === 'processing' || stopAttempt.status === 'processing';
@@ -212,7 +210,7 @@ const VnetConnectionItemBase = forwardRef<
                 <icons.Question size={18} />
               </ButtonIcon>
 
-              {isVnetDiagEnabled && (
+              {isDiagSupported && (
                 <ButtonIcon
                   title={disabledDiagnosticsReason || 'Run diagnostics'}
                   disabled={!!disabledDiagnosticsReason}

--- a/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.story.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.story.tsx
@@ -108,7 +108,9 @@ const meta: Meta<StoryProps> = {
 export default meta;
 
 export function VnetSliderStep(props: StoryProps) {
-  const appContext = new MockAppContext();
+  const appContext = new MockAppContext({
+    platform: props.vnetDiag ? 'darwin' : 'win32',
+  });
 
   if (props.isWorkspacePresent) {
     appContext.addRootCluster(makeRootCluster());
@@ -122,10 +124,6 @@ export function VnetSliderStep(props: StoryProps) {
     appContext.workspacesService.setState(draft => {
       draft.isInitialized = true;
     });
-  }
-
-  if (props.vnetDiag) {
-    appContext.configService.set('unstable.vnetDiag', true);
   }
 
   const pendingPromise = usePromiseRejectedOnUnmount();

--- a/web/packages/teleterm/src/ui/Vnet/vnetContext.test.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/vnetContext.test.tsx
@@ -425,7 +425,6 @@ describe('diag notification', () => {
       ...appContext.statePersistenceService.getState(),
       vnet: { autoStart: true },
     });
-    appContext.configService.set('unstable.vnetDiag', true);
 
     jest.spyOn(appContext.notificationsService, 'notifyWarning');
 


### PR DESCRIPTION
This PR removes the feature flag behind VNet diagnostics and replaces it with a check for `isDiagSupported` returned from VNet context. Diagnostics are not supported on Windows as of yet, as the route conflict check is platform specific. In the near future, we plan to add another check that's going to be platform-agnostic and that's when we'll enable diagnostics on Windows.

changelog: Added warnings to VNet on macOS about other software that might conflict with VNet, based on inspecting network routes on the system