### PR TITLE
Deflake TestDiscoveryServer when checking for created UserTasks

### DIFF
--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -1028,7 +1028,7 @@ func fetchAllUserTasks(t *testing.T, userTasksClt services.UserTasks, minUserTas
 		}
 
 		return gotResources >= minUserTaskResources
-	}, 5*time.Second, 1*time.Second)
+	}, 5*time.Second, 50*time.Millisecond)
 
 	return existingTasks
 }

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -1016,7 +1016,9 @@ func fetchAllUserTasks(t *testing.T, userTasksClt services.UserTasks, minUserTas
 		}
 		existingTasks = allTasks
 
-		assert.GreaterOrEqual(t, len(allTasks), minUserTasks)
+		if !assert.GreaterOrEqual(t, len(allTasks), minUserTasks) {
+			return
+		}
 
 		gotResources := 0
 		for _, task := range allTasks {


### PR DESCRIPTION
The DiscoveryService is highly async and failed clusters are reported in separate goroutines.
The test was only checking for a single UserTask, and then asserting on the reported items.

Now, it will wait until there's at least two reported items to ensure we waited for both enrollment routines to finish.