### PR TITLE
Log in warn level when updating DiscoveryConfigStatus fails

### DIFF
--- a/lib/srv/discovery/status.go
+++ b/lib/srv/discovery/status.go
@@ -88,7 +88,7 @@ func (s *Server) updateDiscoveryConfigStatus(discoveryConfigNames ...string) {
 		case trace.IsNotImplemented(err):
 			s.Log.WarnContext(ctx, "UpdateDiscoveryConfigStatus method is not implemented in Auth Server. Please upgrade it to a recent version.")
 		case err != nil:
-			s.Log.InfoContext(ctx, "Error updating discovery config status", "discovery_config_name", discoveryConfigName, "error", err)
+			s.Log.WarnContext(ctx, "Error updating discovery config status", "discovery_config_name", discoveryConfigName, "error", err)
 		}
 	}
 }


### PR DESCRIPTION
Info level is not suited for this kind of failures.