### PR TITLE
Remove `/` from the regex that validates backend Keys

### DIFF
--- a/lib/backend/sanitize.go
+++ b/lib/backend/sanitize.go
@@ -33,7 +33,7 @@ const errorMessage = "special characters are not allowed in resource names, plea
 
 // allowPattern is the pattern of allowed characters for each key within
 // the path.
-var allowPattern = regexp.MustCompile(`^[0-9A-Za-z@_:.\-/+]*$`)
+var allowPattern = regexp.MustCompile(`^[0-9A-Za-z@_:.\-+]*$`)
 
 // IsKeySafe checks if the passed in key conforms to whitelist
 func IsKeySafe(key Key) bool {


### PR DESCRIPTION
`/` is used as a separator and cannot be used as part of the key component.
Removing it from the `allowPattern` regex makes things faster. (measured using my non-scientific set up)