### PR TITLE
Use b.Loop in benchmark tests

### DIFF
--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -2131,9 +2131,8 @@ func benchmarkListNodes(
 	require.NoError(b, err)
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		var resources []types.ResourceWithLabels
 		req := proto.ListResourcesRequest{
 			ResourceType: types.KindNode,
@@ -6479,9 +6478,8 @@ func benchmarkListUnifiedResources(
 	require.NoError(b, err)
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		var resources []*proto.PaginatedResource
 		req := &proto.ListUnifiedResourcesRequest{
 			SortBy: types.SortBy{IsDesc: false, Field: types.ResourceMetadataName},

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -1060,9 +1060,7 @@ func benchGetNodes(b *testing.B, nodeCount int) {
 		}
 	}
 
-	b.ResetTimer()
-
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		nodes, err := p.cache.GetNodes(ctx, apidefaults.Namespace)
 		require.NoError(b, err)
 		require.Len(b, nodes, nodeCount)
@@ -1108,7 +1106,7 @@ func BenchmarkListResourcesWithSort(b *testing.B) {
 	for _, limit := range []int32{100, 1_000, 10_000, 100_000} {
 		for _, totalCount := range []bool{true, false} {
 			b.Run(fmt.Sprintf("limit=%d,needTotal=%t", limit, totalCount), func(b *testing.B) {
-				for n := 0; n < b.N; n++ {
+				for b.Loop() {
 					resp, err := p.cache.ListResources(ctx, proto.ListResourcesRequest{
 						ResourceType: types.KindNode,
 						Namespace:    apidefaults.Namespace,

--- a/lib/client/client_store_test.go
+++ b/lib/client/client_store_test.go
@@ -436,7 +436,7 @@ func BenchmarkLoadKeysToKubeFromStore(b *testing.B) {
 	require.NoError(b, err)
 
 	b.Run("LoadKeysToKubeFromStore", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			var wg sync.WaitGroup
 			wg.Add(len(kubeClusterNames))
 			for _, kubeClusterName := range kubeClusterNames {
@@ -458,7 +458,7 @@ func BenchmarkLoadKeysToKubeFromStore(b *testing.B) {
 	// Compare against a naive GetKeyRing call which loads the key and cert for
 	// all active kube clusters, not just the one requested.
 	b.Run("GetKeyRing", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			var wg sync.WaitGroup
 			wg.Add(len(kubeClusterNames))
 			for _, kubeClusterName := range kubeClusterNames {

--- a/lib/client/tncon/buffer_test.go
+++ b/lib/client/tncon/buffer_test.go
@@ -153,7 +153,6 @@ func BenchmarkBufferedChannelPipe(b *testing.B) {
 	for _, s := range []int{1, 10, 100, 500, 1000} {
 		data := make([]byte, 1000)
 		b.Run(fmt.Sprintf("size=%d", s), func(b *testing.B) {
-			b.StopTimer() // stop timer during setup
 			buffer := newBufferedChannelPipe(s)
 			b.Cleanup(func() { require.NoError(b, buffer.Close()) })
 
@@ -165,8 +164,7 @@ func BenchmarkBufferedChannelPipe(b *testing.B) {
 			}()
 
 			// benchmark write+read
-			b.StartTimer()
-			for n := 0; n < b.N; n++ {
+			for b.Loop() {
 				written, err := buffer.Write(data)
 				require.NoError(b, err)
 				require.Len(b, data, written)

--- a/lib/inventory/store_test.go
+++ b/lib/inventory/store_test.go
@@ -46,7 +46,7 @@ func BenchmarkStore(b *testing.B) {
 	var failOnce sync.Once
 	var failErr error
 
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		store := NewStore()
 		var wg sync.WaitGroup
 

--- a/lib/multiplexer/multiplexer_test.go
+++ b/lib/multiplexer/multiplexer_test.go
@@ -1266,7 +1266,7 @@ func BenchmarkMux_ProxyV2Signature(b *testing.B) {
 	defer backend4.Close()
 
 	b.Run("simulation of signing and verifying PROXY header", func(b *testing.B) {
-		for n := 0; n < b.N; n++ {
+		for b.Loop() {
 			conn, err := net.Dial("tcp", listener4.Addr().String())
 			require.NoError(b, err)
 			defer conn.Close()

--- a/lib/services/authority_test.go
+++ b/lib/services/authority_test.go
@@ -397,13 +397,13 @@ func BenchmarkCertAuthoritiesEquivalent(b *testing.B) {
 	require.NoError(b, err)
 
 	b.Run("true", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			require.True(b, CertAuthoritiesEquivalent(ca1, ca2))
 		}
 	})
 
 	b.Run("false", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			require.False(b, CertAuthoritiesEquivalent(ca1, ca3))
 		}
 	})

--- a/lib/services/local/perf_test.go
+++ b/lib/services/local/perf_test.go
@@ -122,7 +122,7 @@ func insertNodes(ctx context.Context, b *testing.B, svc services.Presence, nodeC
 func benchmarkGetNodes(ctx context.Context, b *testing.B, svc services.Presence, nodeCount int) {
 	var nodes []types.Server
 	var err error
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		nodes, err = svc.GetNodes(ctx, apidefaults.Namespace)
 		require.NoError(b, err)
 	}

--- a/lib/services/parser_test.go
+++ b/lib/services/parser_test.go
@@ -403,9 +403,7 @@ func BenchmarkContains(b *testing.B) {
 	expression, err := NewResourceExpression(`contains(split(labels["ip"], "|"), "1.2.3.1")`)
 	require.NoError(b, err)
 
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		match, err := expression.Evaluate(server)
 		require.NoError(b, err)
 		require.True(b, match)

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -1184,8 +1184,7 @@ func BenchmarkValidateRole(b *testing.B) {
 	})
 	require.NoError(b, err)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		require.NoError(b, ValidateRole(role))
 	}
 }
@@ -7062,7 +7061,7 @@ func BenchmarkCheckAccessToServer(b *testing.B) {
 	}
 
 	// Check access to all 4,000 nodes.
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		for i := 0; i < 4000; i++ {
 			for login := range allowLogins {
 				// note: we don't check the error here because this benchmark

--- a/lib/services/user_test.go
+++ b/lib/services/user_test.go
@@ -303,7 +303,7 @@ func BenchmarkTraitToRoles(b *testing.B) {
 			traits := SAMLAssertionsToTraits(claimsToAttributes(input.claims))
 
 			b.Run(testCaseInputName, func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for b.Loop() {
 					TraitsToRoles(mappings, traits)
 				}
 			})

--- a/lib/srv/db/benchmark_test.go
+++ b/lib/srv/db/benchmark_test.go
@@ -72,7 +72,7 @@ func BenchmarkPostgresReadLargeTable(b *testing.B) {
 		require.NoError(b, err)
 
 		b.Run(fmt.Sprintf("size=%v", messageSize), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				// Execute a query, count results.
 				q := pgConn.Exec(ctx, fmt.Sprintf("SELECT * FROM bench_%v LIMIT %v", messageSize, rowCount))
 

--- a/lib/srv/regular/sshserver_unix_test.go
+++ b/lib/srv/regular/sshserver_unix_test.go
@@ -63,9 +63,8 @@ func BenchmarkRootExecCommand(b *testing.B) {
 			}
 
 			f := newFixtureWithoutDiskBasedLogging(b, opts...)
-			b.ResetTimer()
 
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				username := f.user
 				if test.createUser {
 					username = utils.GenerateLocalUsername(b)

--- a/lib/utils/concurrentqueue/queue_test.go
+++ b/lib/utils/concurrentqueue/queue_test.go
@@ -183,9 +183,7 @@ func BenchmarkQueue(b *testing.B) {
 	q := New(workfn, Workers(workers))
 	defer q.Close()
 
-	b.ResetTimer()
-
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		collected := make(chan struct{})
 		go func() {
 			for i := 0; i < iters; i++ {

--- a/lib/utils/fanoutbuffer/buffer_test.go
+++ b/lib/utils/fanoutbuffer/buffer_test.go
@@ -62,7 +62,7 @@ func BenchmarkBuffer(b *testing.B) {
 
 	for _, bb := range bbs {
 		b.Run(fmt.Sprintf("%d-events-%d-cursors", bb.events, bb.cursors), func(b *testing.B) {
-			for n := 0; n < b.N; n++ {
+			for b.Loop() {
 				ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 				concurrentFanout(ctx, b, bb.events, bb.cursors)
 				cancel()

--- a/lib/utils/log/formatter_test.go
+++ b/lib/utils/log/formatter_test.go
@@ -322,9 +322,8 @@ func BenchmarkFormatter(b *testing.B) {
 				AddSource: true,
 				Level:     slog.LevelDebug,
 			})).With(teleport.ComponentKey, "test")
-			b.ResetTimer()
 
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				l := logger.With("test", 123).With("animal", "llama\n").With("error", logErr)
 				l.With(teleport.ComponentFields, fields).InfoContext(ctx, message, "diag_addr", &addr)
 			}
@@ -332,9 +331,8 @@ func BenchmarkFormatter(b *testing.B) {
 
 		b.Run("text", func(b *testing.B) {
 			logger := slog.New(NewSlogTextHandler(io.Discard, SlogTextHandlerConfig{Level: slog.LevelDebug, EnableColors: true})).With(teleport.ComponentKey, "test")
-			b.ResetTimer()
 
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				l := logger.With("test", 123).With("animal", "llama\n").With("error", logErr)
 				l.With(teleport.ComponentFields, fields).InfoContext(ctx, message, "diag_addr", &addr)
 			}
@@ -345,9 +343,8 @@ func BenchmarkFormatter(b *testing.B) {
 				AddSource: true,
 				Level:     slog.LevelDebug,
 			})).With(teleport.ComponentKey, "test")
-			b.ResetTimer()
 
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				l := logger.With("test", 123).With("animal", "llama\n").With("error", logErr)
 				l.With(teleport.ComponentFields, fields).InfoContext(ctx, message, "diag_addr", &addr)
 			}
@@ -355,9 +352,8 @@ func BenchmarkFormatter(b *testing.B) {
 
 		b.Run("json", func(b *testing.B) {
 			logger := slog.New(NewSlogJSONHandler(io.Discard, SlogJSONHandlerConfig{Level: slog.LevelDebug})).With(teleport.ComponentKey, "test")
-			b.ResetTimer()
 
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				l := logger.With("test", 123).With("animal", "llama\n").With("error", logErr)
 				l.With(teleport.ComponentFields, fields).InfoContext(ctx, message, "diag_addr", &addr)
 			}

--- a/lib/utils/replace_test.go
+++ b/lib/utils/replace_test.go
@@ -1323,7 +1323,7 @@ func TestKubeResourceCouldMatchRules(t *testing.T) {
 
 func BenchmarkReplaceRegexp(b *testing.B) {
 	b.Run("same expression", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			replaced, err := ReplaceRegexp("*", "foo", "test")
 			require.NoError(b, err)
 			require.NotEmpty(b, replaced)
@@ -1331,20 +1331,24 @@ func BenchmarkReplaceRegexp(b *testing.B) {
 	})
 
 	b.Run("unique expressions", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		i := 0
+		for b.Loop() {
 			r := strconv.Itoa(i)
 			replaced, err := ReplaceRegexp(r, r, r)
 			require.NoError(b, err)
 			require.NotEmpty(b, replaced)
+			i++
 		}
 	})
 
 	b.Run("no matches", func(b *testing.B) {
 		expression := "$abc^"
-		for i := 0; i < b.N; i++ {
+		i := 0
+		for b.Loop() {
 			replaced, err := ReplaceRegexp(expression, strconv.Itoa(i), "test")
 			require.ErrorIs(b, err, ErrReplaceRegexNotFound)
 			require.Empty(b, replaced)
+			i++
 		}
 	})
 }

--- a/lib/utils/sortcache/sortcache_test.go
+++ b/lib/utils/sortcache/sortcache_test.go
@@ -375,11 +375,9 @@ func BenchmarkSortCache(b *testing.B) {
 	// actual benchmark gets performed against one singular read loop. the goal here being to
 	// figure out what a single reader would experience when trying to pull a large block of
 	// values from a SortCache that is under high concurrent load.
-	b.ResetTimer()
-
 	var n int
 	buf := make([]resource, 0, resourcesPerKind)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		buf = buf[:0]
 		n++
 		key := "node/"

--- a/lib/web/ui/perf_test.go
+++ b/lib/web/ui/perf_test.go
@@ -97,12 +97,7 @@ func BenchmarkGetClusterDetails(b *testing.B) {
 					presence: svc,
 				},
 			}
-
-			sb.StartTimer() // restart timer for benchmark operations
-
 			benchmarkGetClusterDetails(ctx, sb, site, tt.nodes)
-
-			sb.StopTimer() // stop timer to exclude deferred cleanup
 		})
 	}
 }
@@ -148,7 +143,7 @@ func insertServers(ctx context.Context, b *testing.B, svc services.Presence, kin
 func benchmarkGetClusterDetails(ctx context.Context, b *testing.B, site reversetunnelclient.RemoteSite, nodes int, opts ...services.MarshalOption) {
 	var cluster *Cluster
 	var err error
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		cluster, err = GetClusterDetails(ctx, site, opts...)
 		require.NoError(b, err)
 	}


### PR DESCRIPTION
Prefer using b.Loop instead of b.N style benchmarks now that we are using Go 1.24.

See https://pkg.go.dev/testing#B.Loop for more details.