### PR TITLE
lib/utils/typical: support `==` and `!=` operators for integers

### DIFF
--- a/lib/services/label_expressions_test.go
+++ b/lib/services/label_expressions_test.go
@@ -58,8 +58,7 @@ func TestLabelExpressions(t *testing.T) {
 			desc: "wrong type",
 			expr: `user.spec.traits["allow-env"] == "staging"`,
 			expectParseError: []string{
-				"parsing lhs of (==) operator",
-				"expected type string, got expression returning type ([]string)",
+				"operator (==) not supported for type: []string",
 			},
 		},
 		{

--- a/lib/utils/typical/parser.go
+++ b/lib/utils/typical/parser.go
@@ -916,9 +916,30 @@ func or[TEnv any]() func(lhs, rhs any) (Expression[TEnv, bool], error) {
 }
 
 func eq[TEnv any]() func(lhs, rhs any) (Expression[TEnv, bool], error) {
-	return booleanOperator[TEnv, string]{
+	return func(lhs any, rhs any) (Expression[TEnv, bool], error) {
+		// If the LHS operand type isn't known at compile time (e.g. an `ifelse`
+		// function call) try the RHS instead.
+		operand := lhs
+		if _, isAny := operand.(Expression[TEnv, any]); isAny {
+			operand = rhs
+		}
+		switch operand.(type) {
+		case string, Expression[TEnv, string]:
+			return eqExpression[TEnv, string](lhs, rhs)
+		case int, Expression[TEnv, int]:
+			return eqExpression[TEnv, int](lhs, rhs)
+		case Expression[TEnv, any]:
+			return nil, trace.Errorf("operator (==) can only be used when at least one operand type is known at compile-time")
+		default:
+			return nil, trace.Errorf("operator (==) not supported for type: %s", typeName(operand))
+		}
+	}
+}
+
+func eqExpression[TEnv any, TResult comparable](lhs any, rhs any) (Expression[TEnv, bool], error) {
+	return booleanOperator[TEnv, TResult]{
 		name: "==",
-		f: func(env TEnv, lhsExpr, rhsExpr Expression[TEnv, string]) (bool, error) {
+		f: func(env TEnv, lhsExpr, rhsExpr Expression[TEnv, TResult]) (bool, error) {
 			lhs, err := lhsExpr.Evaluate(env)
 			if err != nil {
 				return false, trace.Wrap(err, "evaluating lhs of (==) operator")
@@ -929,13 +950,34 @@ func eq[TEnv any]() func(lhs, rhs any) (Expression[TEnv, bool], error) {
 			}
 			return lhs == rhs, nil
 		},
-	}.buildExpression
+	}.buildExpression(lhs, rhs)
 }
 
 func neq[TEnv any]() func(lhs, rhs any) (Expression[TEnv, bool], error) {
-	return booleanOperator[TEnv, string]{
+	return func(lhs any, rhs any) (Expression[TEnv, bool], error) {
+		// If the LHS operand type isn't known at compile time (e.g. an `ifelse`
+		// function call) try the RHS instead.
+		operand := lhs
+		if _, isAny := operand.(Expression[TEnv, any]); isAny {
+			operand = rhs
+		}
+		switch operand.(type) {
+		case string, Expression[TEnv, string]:
+			return neqExpression[TEnv, string](lhs, rhs)
+		case int, Expression[TEnv, int]:
+			return neqExpression[TEnv, int](lhs, rhs)
+		case Expression[TEnv, any]:
+			return nil, trace.Errorf("operator (!=) can only be used when at least one operand type is known at compile-time")
+		default:
+			return nil, trace.Errorf("operator (!=) not supported for type: %s", typeName(operand))
+		}
+	}
+}
+
+func neqExpression[TEnv any, TResult comparable](lhs any, rhs any) (Expression[TEnv, bool], error) {
+	return booleanOperator[TEnv, TResult]{
 		name: "!=",
-		f: func(env TEnv, lhsExpr, rhsExpr Expression[TEnv, string]) (bool, error) {
+		f: func(env TEnv, lhsExpr, rhsExpr Expression[TEnv, TResult]) (bool, error) {
 			lhs, err := lhsExpr.Evaluate(env)
 			if err != nil {
 				return false, trace.Wrap(err, "evaluating lhs of (!=) operator")
@@ -946,7 +988,7 @@ func neq[TEnv any]() func(lhs, rhs any) (Expression[TEnv, bool], error) {
 			}
 			return lhs != rhs, nil
 		},
-	}.buildExpression
+	}.buildExpression(lhs, rhs)
 }
 
 type notExpr[TEnv any] struct {
@@ -1112,4 +1154,13 @@ func unexpectedTypeError[TExpected any](v any) error {
 	}
 	resultType := evaluateMethod.Type.Out(0)
 	return trace.BadParameter(prefix+"got expression returning type (%s)", resultType)
+}
+
+func typeName(v any) string {
+	evaluateMethod, ok := reflect.TypeOf(v).MethodByName("Evaluate")
+	if !ok {
+		// This isn't an expr
+		return fmt.Sprintf("%T", v)
+	}
+	return evaluateMethod.Type.Out(0).String()
 }

--- a/lib/utils/typical/parser.go
+++ b/lib/utils/typical/parser.go
@@ -917,7 +917,7 @@ func or[TEnv any]() func(lhs, rhs any) (Expression[TEnv, bool], error) {
 
 func eq[TEnv any]() func(lhs, rhs any) (Expression[TEnv, bool], error) {
 	return func(lhs any, rhs any) (Expression[TEnv, bool], error) {
-		// If the LHS operand type isn't known at compile time (e.g. an `ifelse`
+		// If the LHS operand type isn't known at parse time (e.g. an `ifelse`
 		// function call) try the RHS instead.
 		operand := lhs
 		if _, isAny := operand.(Expression[TEnv, any]); isAny {
@@ -929,7 +929,7 @@ func eq[TEnv any]() func(lhs, rhs any) (Expression[TEnv, bool], error) {
 		case int, Expression[TEnv, int]:
 			return eqExpression[TEnv, int](lhs, rhs)
 		case Expression[TEnv, any]:
-			return nil, trace.Errorf("operator (==) can only be used when at least one operand type is known at compile-time")
+			return nil, trace.Errorf("operator (==) can only be used when at least one operand type is known at parse time")
 		default:
 			return nil, trace.Errorf("operator (==) not supported for type: %s", typeName(operand))
 		}
@@ -955,7 +955,7 @@ func eqExpression[TEnv any, TResult comparable](lhs any, rhs any) (Expression[TE
 
 func neq[TEnv any]() func(lhs, rhs any) (Expression[TEnv, bool], error) {
 	return func(lhs any, rhs any) (Expression[TEnv, bool], error) {
-		// If the LHS operand type isn't known at compile time (e.g. an `ifelse`
+		// If the LHS operand type isn't known at parse time (e.g. an `ifelse`
 		// function call) try the RHS instead.
 		operand := lhs
 		if _, isAny := operand.(Expression[TEnv, any]); isAny {
@@ -967,7 +967,7 @@ func neq[TEnv any]() func(lhs, rhs any) (Expression[TEnv, bool], error) {
 		case int, Expression[TEnv, int]:
 			return neqExpression[TEnv, int](lhs, rhs)
 		case Expression[TEnv, any]:
-			return nil, trace.Errorf("operator (!=) can only be used when at least one operand type is known at compile-time")
+			return nil, trace.Errorf("operator (!=) can only be used when at least one operand type is known at parse time")
 		default:
 			return nil, trace.Errorf("operator (!=) not supported for type: %s", typeName(operand))
 		}

--- a/lib/utils/typical/parser.go
+++ b/lib/utils/typical/parser.go
@@ -936,10 +936,10 @@ func eq[TEnv any]() func(lhs, rhs any) (Expression[TEnv, bool], error) {
 	}
 }
 
-func eqExpression[TEnv any, TResult comparable](lhs any, rhs any) (Expression[TEnv, bool], error) {
-	return booleanOperator[TEnv, TResult]{
+func eqExpression[TEnv any, TArgs comparable](lhs any, rhs any) (Expression[TEnv, bool], error) {
+	return booleanOperator[TEnv, TArgs]{
 		name: "==",
-		f: func(env TEnv, lhsExpr, rhsExpr Expression[TEnv, TResult]) (bool, error) {
+		f: func(env TEnv, lhsExpr, rhsExpr Expression[TEnv, TArgs]) (bool, error) {
 			lhs, err := lhsExpr.Evaluate(env)
 			if err != nil {
 				return false, trace.Wrap(err, "evaluating lhs of (==) operator")
@@ -974,10 +974,10 @@ func neq[TEnv any]() func(lhs, rhs any) (Expression[TEnv, bool], error) {
 	}
 }
 
-func neqExpression[TEnv any, TResult comparable](lhs any, rhs any) (Expression[TEnv, bool], error) {
-	return booleanOperator[TEnv, TResult]{
+func neqExpression[TEnv any, TArgs comparable](lhs any, rhs any) (Expression[TEnv, bool], error) {
+	return booleanOperator[TEnv, TArgs]{
 		name: "!=",
-		f: func(env TEnv, lhsExpr, rhsExpr Expression[TEnv, TResult]) (bool, error) {
+		f: func(env TEnv, lhsExpr, rhsExpr Expression[TEnv, TArgs]) (bool, error) {
 			lhs, err := lhsExpr.Evaluate(env)
 			if err != nil {
 				return false, trace.Wrap(err, "evaluating lhs of (!=) operator")

--- a/lib/utils/typical/parser_test.go
+++ b/lib/utils/typical/parser_test.go
@@ -398,6 +398,74 @@ func TestParser(t *testing.T) {
 				"haha",
 			},
 		},
+		{
+			desc:        "integer equality (true)",
+			expr:        `1 == 1`,
+			expectMatch: true,
+		},
+		{
+			desc:        "integer equality (false)",
+			expr:        `1 == 2`,
+			expectMatch: false,
+		},
+		{
+			desc:        "equality lhs dynamic",
+			expr:        `ifelse(1 == 1, 1, "one") == 1`,
+			expectMatch: true,
+		},
+		{
+			desc:        "equality rhs dynamic",
+			expr:        `1 == ifelse(1 == 1, 1, "one")`,
+			expectMatch: true,
+		},
+		{
+			desc: "equality both operands dynamic",
+			expr: `ifelse(1 == 1, 1, "one") == ifelse(1 == 1, 1, "one")`,
+			expectParseError: []string{
+				"operator (==) can only be used when at least one operand type is known at compile-time",
+			},
+		},
+		{
+			desc: "equality unsupported operand type",
+			expr: `traits == traits`,
+			expectParseError: []string{
+				"operator (==) not supported for type: map[string][]string",
+			},
+		},
+		{
+			desc:        "integer inequality (true)",
+			expr:        `1 != 2`,
+			expectMatch: true,
+		},
+		{
+			desc:        "integer inequality (false)",
+			expr:        `1 != 1`,
+			expectMatch: false,
+		},
+		{
+			desc:        "inequality lhs dynamic",
+			expr:        `ifelse(1 == 1, 1, "one") != 2`,
+			expectMatch: true,
+		},
+		{
+			desc:        "inequality rhs dynamic",
+			expr:        `2 != ifelse(1 == 1, 1, "one")`,
+			expectMatch: true,
+		},
+		{
+			desc: "iequality both operands dynamic",
+			expr: `ifelse(1 == 1, 1, "one") != ifelse(1 == 1, 1, "one")`,
+			expectParseError: []string{
+				"operator (!=) can only be used when at least one operand type is known at compile-time",
+			},
+		},
+		{
+			desc: "inequality unsupported operand type",
+			expr: `traits != traits`,
+			expectParseError: []string{
+				"operator (!=) not supported for type: map[string][]string",
+			},
+		},
 	} {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {

--- a/lib/utils/typical/parser_test.go
+++ b/lib/utils/typical/parser_test.go
@@ -422,7 +422,7 @@ func TestParser(t *testing.T) {
 			desc: "equality both operands dynamic",
 			expr: `ifelse(1 == 1, 1, "one") == ifelse(1 == 1, 1, "one")`,
 			expectParseError: []string{
-				"operator (==) can only be used when at least one operand type is known at compile-time",
+				"operator (==) can only be used when at least one operand type is known at parse time",
 			},
 		},
 		{
@@ -456,7 +456,7 @@ func TestParser(t *testing.T) {
 			desc: "iequality both operands dynamic",
 			expr: `ifelse(1 == 1, 1, "one") != ifelse(1 == 1, 1, "one")`,
 			expectParseError: []string{
-				"operator (!=) can only be used when at least one operand type is known at compile-time",
+				"operator (!=) can only be used when at least one operand type is known at parse time",
 			},
 		},
 		{


### PR DESCRIPTION
In #52460, we're adopting the Teleport predicate language for Workload Identity rules. We currently allow you to match on the equality/inequality of the attested process' PID, GID, and UID, but this wasn't supported in the predicate language.

We now check the operand types at compile-time and choose the correct `booleanOperator`. If both operands are dynamically typed (e.g. `ifelse` expressions) we do not allow you to use the `==` or `!=` operators.

changelog: You can now use `==` and `!=` operators with integer operands in Teleport predicate language