### PR TITLE
Add a tab-by-tab mode for creating new roles

### DIFF
--- a/web/packages/design/src/SlideTabs/SlideTabs.story.tsx
+++ b/web/packages/design/src/SlideTabs/SlideTabs.story.tsx
@@ -208,13 +208,29 @@ export const StatusIcons = () => {
   );
 };
 
-export const DisabledTab = () => {
+export const Disabled = () => {
   return (
     <SlideTabs
       tabs={threeSimpleTabs}
       onChange={() => null}
       activeIndex={1}
       disabled={true}
+    />
+  );
+};
+
+export const DisabledTab = () => {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const tabs = [
+    { key: 'aws', title: 'aws' },
+    { key: 'automatically', title: 'automatically', disabled: true },
+    { key: 'manually', title: 'manually' },
+  ];
+  return (
+    <SlideTabs
+      tabs={tabs}
+      activeIndex={activeIndex}
+      onChange={setActiveIndex}
     />
   );
 };

--- a/web/packages/design/src/SlideTabs/SlideTabs.tsx
+++ b/web/packages/design/src/SlideTabs/SlideTabs.tsx
@@ -85,13 +85,15 @@ export function SlideTabs({
               position: tooltipPosition,
             } = {},
             status: { kind: statusKind, ariaLabel: statusAriaLabel } = {},
+            disabled: tabDisabled = false,
           } = toFullTabSpec(tabSpec, tabIndex);
+          const resolvedDisabled = disabled || tabDisabled;
           const statusIconColorActive = hideStatusIconOnActiveTab
             ? 'transparent'
             : theme.colors.text.primaryInverse;
 
           let onClick = undefined;
-          if (!disabled && !isProcessing) {
+          if (!resolvedDisabled && !isProcessing) {
             onClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
               e.preventDefault();
               onChange(tabIndex);
@@ -111,9 +113,9 @@ export function SlideTabs({
                 selected={selected}
                 className={selected ? 'selected' : undefined}
                 aria-controls={controls}
-                tabIndex={!disabled && selected ? 0 : -1}
+                tabIndex={!resolvedDisabled && selected ? 0 : -1}
                 processing={isProcessing}
-                disabled={disabled}
+                disabled={resolvedDisabled}
                 aria-selected={selected}
                 size={size}
                 aria-label={ariaLabel}
@@ -236,6 +238,7 @@ type FullTabSpec = TabContentSpec & {
     kind: StatusKind;
     ariaLabel?: string;
   };
+  disabled?: boolean;
 };
 
 /**

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
@@ -16,14 +16,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { within } from '@testing-library/react';
+import { fireEvent, within } from '@testing-library/react';
 import { UserEvent } from '@testing-library/user-event';
 
 import { render, screen, userEvent } from 'design/utils/testing';
 
 import cfg from 'teleport/config';
 import { createTeleportContext } from 'teleport/mocks/contexts';
-import { Role } from 'teleport/services/resources';
+import { Role, RoleWithYaml } from 'teleport/services/resources';
 import { storageService } from 'teleport/services/storageService';
 import { CaptureEvent, userEventService } from 'teleport/services/userEvent';
 import { yamlService } from 'teleport/services/yaml';
@@ -35,7 +35,7 @@ import TeleportContextProvider from 'teleport/TeleportContextProvider';
 
 import { RoleEditor, RoleEditorProps } from './RoleEditor';
 import * as StandardEditorModule from './StandardEditor/StandardEditor';
-import { defaultRoleVersion } from './StandardEditor/standardmodel';
+import { defaultRoleVersion, newRole } from './StandardEditor/standardmodel';
 import * as StandardModelModule from './StandardEditor/standardmodel';
 import { defaultOptions, withDefaults } from './StandardEditor/withDefaults';
 
@@ -89,6 +89,9 @@ test('rendering and switching tabs for new role', async () => {
   ).not.toBeInTheDocument();
   expect(screen.getByLabelText('Role Name *')).toHaveValue('new_role_name');
   expect(screen.getByLabelText('Description')).toHaveValue('');
+  await forwardToTab('Resources');
+  await forwardToTab('Access Rules');
+  await forwardToTab('Options');
   expect(screen.getByRole('button', { name: 'Create Role' })).toBeEnabled();
 
   await user.click(getYamlEditorTab());
@@ -113,6 +116,9 @@ test('rendering and switching tabs for new role', async () => {
   expect(
     screen.queryByRole('button', { name: /Reset to Standard Settings/i })
   ).not.toBeInTheDocument();
+  await forwardToTab('Resources');
+  await forwardToTab('Access Rules');
+  await forwardToTab('Options');
   expect(screen.getByRole('button', { name: 'Create Role' })).toBeEnabled();
 });
 
@@ -126,12 +132,7 @@ test('rendering and switching tabs for a non-standard role', async () => {
       deny: { node_labels: { foo: ['bar'] } },
     },
   });
-  const originalYaml = toFauxYaml(originalRole);
-  render(
-    <TestRoleEditor
-      originalRole={{ object: originalRole, yaml: originalYaml }}
-    />
-  );
+  render(<TestRoleEditor originalRole={newRoleWithYaml(originalRole)} />);
   expect(getYamlEditorTab()).toHaveAttribute('aria-selected', 'true');
   expect(fromFauxYaml(await getTextEditorContents())).toEqual(originalRole);
   expect(screen.getByRole('button', { name: 'Save Changes' })).toBeDisabled();
@@ -191,11 +192,7 @@ test('switching tabs ignores standard model validation for a non-standard role',
     spec: {},
     unsupportedField: true, // This will cause disabling the standard editor.
   } as any as Role);
-  render(
-    <TestRoleEditor
-      originalRole={{ object: originalRole, yaml: toFauxYaml(originalRole) }}
-    />
-  );
+  render(<TestRoleEditor originalRole={newRoleWithYaml(originalRole)} />);
   expect(getYamlEditorTab()).toHaveAttribute('aria-selected', 'true');
   await user.click(getStandardEditorTab());
   expect(screen.getByText(/This role is too complex/)).toBeVisible();
@@ -227,16 +224,6 @@ test('no double conversions when clicking already active tabs', async () => {
 });
 
 describe('closing the editor', () => {
-  function originalRole() {
-    const object = withDefaults({
-      kind: 'role',
-      metadata: {
-        name: 'new_role_name',
-      },
-    });
-    return { object, yaml: toFauxYaml(object) };
-  }
-
   function setup(props: Partial<RoleEditorProps> = {}) {
     const onCancel = jest.fn();
     render(<TestRoleEditor onCancel={onCancel} {...props} />);
@@ -288,24 +275,39 @@ describe('closing the editor', () => {
   });
 
   test('standard editor, unmodified existing resource', async () => {
-    const onCancel = setup({ originalRole: originalRole() });
+    const onCancel = setup({ originalRole: newRoleWithYaml(newRole()) });
     await closeImmediately(onCancel);
   });
 
   test('standard editor, modified existing resource', async () => {
-    const onCancel = setup({ originalRole: originalRole() });
+    const onCancel = setup({ originalRole: newRoleWithYaml(newRole()) });
     await user.type(screen.getByLabelText('Description'), 'foo');
     await closeWithConfirmation(onCancel);
   });
 
   test('YAML editor, unmodified existing resource', async () => {
-    const onCancel = setup({ originalRole: originalRole() });
+    const originalRole = newRoleWithYaml(newRole());
+    const onCancel = setup({ originalRole: newRoleWithYaml(newRole()) });
     await user.click(getYamlEditorTab());
+
+    // Quirk ahead: `toFauxYaml` uses JSON.stringify(), which is
+    // indeterministic with regards to the key order. We work around this
+    // problem by manually verifying that the JSON values are equivalent (i.e.
+    // their deserializations are deeply equal) and simply stuffing the
+    // original back into the text editor, in case if the order of keys is
+    // different.
+    const editor = await findTextEditor();
+    expect(JSON.parse(editor.textContent)).toEqual(
+      JSON.parse(originalRole.yaml)
+    );
+    fireEvent.change(await findTextEditor(), {
+      target: { value: originalRole.yaml },
+    });
     await closeImmediately(onCancel);
   });
 
   test('YAML editor, modified existing resource', async () => {
-    const onCancel = setup({ originalRole: originalRole() });
+    const onCancel = setup({ originalRole: newRoleWithYaml(newRole()) });
     await user.click(getYamlEditorTab());
     await user.type(await findTextEditor(), '{{"foo":"bar"}');
     await closeWithConfirmation(onCancel);
@@ -315,7 +317,6 @@ describe('closing the editor', () => {
 test('saving a new role', async () => {
   const onSave = jest.fn();
   render(<TestRoleEditor onSave={onSave} />);
-  expect(screen.getByRole('button', { name: 'Create Role' })).toBeEnabled();
 
   await user.clear(screen.getByLabelText('Role Name *'));
   await user.type(screen.getByLabelText('Role Name *'), 'great-old-one');
@@ -324,6 +325,9 @@ test('saving a new role', async () => {
     screen.getByLabelText('Description'),
     'That is not dead which can eternal lie.'
   );
+  await forwardToTab('Resources');
+  await forwardToTab('Access Rules');
+  await forwardToTab('Options');
   await user.click(screen.getByRole('button', { name: 'Create Role' }));
 
   expect(onSave).toHaveBeenCalledWith({
@@ -350,7 +354,6 @@ describe('saving a new role after editing as YAML', () => {
   test('with Policy disabled', async () => {
     const onSave = jest.fn();
     render(<TestRoleEditor onSave={onSave} />);
-    expect(screen.getByRole('button', { name: 'Create Role' })).toBeEnabled();
 
     await user.click(getYamlEditorTab());
     await user.clear(await findTextEditor());
@@ -374,7 +377,6 @@ describe('saving a new role after editing as YAML', () => {
     const onRoleUpdate = jest.fn();
     const onSave = jest.fn();
     render(<TestRoleEditor onRoleUpdate={onRoleUpdate} onSave={onSave} />);
-    expect(screen.getByRole('button', { name: 'Create Role' })).toBeEnabled();
 
     await user.click(getYamlEditorTab());
     await user.clear(await findTextEditor());
@@ -404,6 +406,9 @@ describe('saving a new role after editing as YAML', () => {
 test('error while saving', async () => {
   const onSave = jest.fn().mockRejectedValue(new Error('oh noes'));
   render(<TestRoleEditor onSave={onSave} />);
+  await forwardToTab('Resources');
+  await forwardToTab('Access Rules');
+  await forwardToTab('Options');
   await user.click(screen.getByRole('button', { name: 'Create Role' }));
   expect(screen.getByText('oh noes')).toBeVisible();
 });
@@ -536,6 +541,11 @@ const TestRoleEditor = (props: RoleEditorProps) => {
   );
 };
 
+const newRoleWithYaml = (role: Role): RoleWithYaml => ({
+  object: role,
+  yaml: toFauxYaml(role),
+});
+
 const getStandardEditorTab = () =>
   screen.getByRole('tab', { name: 'Switch to standard editor' });
 
@@ -552,3 +562,11 @@ const findTextEditor = async () =>
  * contents, this is unreliable. We really have to use Ace editor API to do it.
  */
 const getTextEditorContents = async () => (await findTextEditor()).textContent;
+
+async function forwardToTab(name: string) {
+  await user.click(screen.getByRole('button', { name: `Next: ${name}` }));
+  expect(screen.getByRole('tab', { name })).toHaveAttribute(
+    'aria-selected',
+    'true'
+  );
+}

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.tsx
@@ -268,7 +268,6 @@ export const RoleEditor = ({
                   <StandardEditor
                     originalRole={originalRole}
                     onSave={object => handleSave({ object })}
-                    onCancel={confirmExit}
                     standardEditorModel={standardModel}
                     isProcessing={isProcessing}
                     dispatch={dispatch}
@@ -283,7 +282,6 @@ export const RoleEditor = ({
                   onChange={setYamlModel}
                   onSave={async yaml => void (await handleSave({ yaml }))}
                   isProcessing={isProcessing}
-                  onCancel={confirmExit}
                   originalRole={originalRole}
                   onPreview={roleTesterEnabled ? handleYamlPreview : undefined}
                 />

--- a/web/packages/teleport/src/Roles/RoleEditor/Shared.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/Shared.tsx
@@ -16,31 +16,32 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useTheme } from 'styled-components';
+import styled from 'styled-components';
 
-import { Box, ButtonPrimary, ButtonSecondary, Flex } from 'design';
+import { Box, ButtonPrimary, Flex } from 'design';
 import { HoverTooltip } from 'design/Tooltip';
 
 import useTeleport from 'teleport/useTeleport';
 
-export const EditorSaveCancelButton = ({
-  onSave,
-  onPreview,
-  onCancel,
-  saveDisabled,
-  previewDisabled = true,
+export const ActionButtonsContainer = styled(Flex).attrs({
+  gap: 2,
+  p: 3,
+  borderTop: 1,
+})`
+  border-color: ${props => props.theme.colors.interactive.tonal.neutral[0]};
+`;
+
+export const SaveButton = ({
   isEditing,
+  disabled,
+  onClick,
 }: {
-  onSave?(): void;
-  onPreview?(): void;
-  onCancel?(): void;
-  saveDisabled: boolean;
-  previewDisabled?: boolean;
-  isEditing?: boolean;
+  isEditing: boolean;
+  disabled: boolean;
+  onClick(): void;
 }) => {
   const ctx = useTeleport();
   const roleAccess = ctx.storeUser.getRoleAccess();
-  const theme = useTheme();
 
   let hoverTooltipContent = '';
   if (isEditing && !roleAccess.edit) {
@@ -49,15 +50,15 @@ export const EditorSaveCancelButton = ({
     hoverTooltipContent = 'You do not have access to create roles';
   }
 
-  const saveButton = (
+  return (
     <Box width="50%">
       <HoverTooltip tipContent={hoverTooltipContent}>
         <ButtonPrimary
           width="100%"
           size="large"
-          onClick={onSave}
+          onClick={onClick}
           disabled={
-            saveDisabled ||
+            disabled ||
             (isEditing && !roleAccess.edit) ||
             (!isEditing && !roleAccess.create)
           }
@@ -67,30 +68,19 @@ export const EditorSaveCancelButton = ({
       </HoverTooltip>
     </Box>
   );
-  const cancelButton = (
-    <ButtonSecondary width="50%" onClick={onCancel}>
-      Cancel
-    </ButtonSecondary>
-  );
-
-  const previewButton = (
-    <ButtonPrimary width="50%" onClick={onPreview} disabled={previewDisabled}>
-      Preview
-    </ButtonPrimary>
-  );
-
-  return (
-    <Flex
-      gap={2}
-      p={3}
-      borderTop={1}
-      borderColor={theme.colors.interactive.tonal.neutral[0]}
-    >
-      {saveButton}
-      {onPreview ? previewButton : cancelButton}
-    </Flex>
-  );
 };
+
+export const PreviewButton = ({
+  disabled,
+  onClick,
+}: {
+  disabled: boolean;
+  onClick(): void;
+}) => (
+  <ButtonPrimary size="large" width="50%" disabled={disabled} onClick={onClick}>
+    Preview
+  </ButtonPrimary>
+);
 
 export const unableToUpdatePreviewMessage =
   'Unable to update the role preview. You can still try and save the role anyway.';

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.test.tsx
@@ -17,26 +17,28 @@
  */
 
 import { within } from '@testing-library/react';
+import { UserEvent } from '@testing-library/user-event';
+import { produce } from 'immer';
 import selectEvent from 'react-select-event';
 
 import { render, screen, userEvent } from 'design/utils/testing';
 import Validation from 'shared/components/Validation';
 
 import { createTeleportContext } from 'teleport/mocks/contexts';
-import { Role } from 'teleport/services/resources';
+import { Role, RoleWithYaml } from 'teleport/services/resources';
 import TeleportContextProvider from 'teleport/TeleportContextProvider';
 
 import { StandardEditor, StandardEditorProps } from './StandardEditor';
+import { newRole } from './standardmodel';
 import { useStandardModel } from './useStandardModel';
 
 const TestStandardEditor = (props: Partial<StandardEditorProps>) => {
   const ctx = createTeleportContext();
-  const [model, dispatch] = useStandardModel();
+  const [model, dispatch] = useStandardModel(props.originalRole?.object);
   return (
     <TeleportContextProvider ctx={ctx}>
       <Validation>
         <StandardEditor
-          originalRole={null}
           standardEditorModel={model}
           isProcessing={false}
           dispatch={dispatch}
@@ -47,11 +49,16 @@ const TestStandardEditor = (props: Partial<StandardEditorProps>) => {
   );
 };
 
+let user: UserEvent;
+
+beforeEach(() => {
+  user = userEvent.setup();
+});
+
 test('adding and removing sections', async () => {
-  const user = userEvent.setup();
-  render(<TestStandardEditor />);
+  render(<TestStandardEditor originalRole={newRoleWithYaml(newRole())} />);
   expect(getAllSectionNames()).toEqual(['Role Metadata']);
-  await user.click(screen.getByRole('tab', { name: 'Resources' }));
+  await user.click(getTabByName('Resources'));
   expect(getAllSectionNames()).toEqual([]);
 
   await user.click(
@@ -99,59 +106,75 @@ test('adding and removing sections', async () => {
 });
 
 test('collapsed sections still apply validation', async () => {
-  const user = userEvent.setup();
   const onSave = jest.fn();
-  render(<TestStandardEditor onSave={onSave} />);
+  render(
+    <TestStandardEditor
+      originalRole={newRoleWithYaml(newRole())}
+      onSave={onSave}
+    />
+  );
   // Intentionally cause a validation error.
   await user.clear(screen.getByLabelText('Role Name *'));
   // Collapse the section.
   await user.click(screen.getByRole('heading', { name: 'Role Metadata' }));
-  await user.click(screen.getByRole('button', { name: 'Create Role' }));
+  await user.click(screen.getByRole('button', { name: 'Save Changes' }));
   expect(onSave).not.toHaveBeenCalled();
 
   // Expand the section, make it valid.
   await user.click(screen.getByRole('heading', { name: 'Role Metadata' }));
   await user.type(screen.getByLabelText('Role Name *'), 'foo');
-  await user.click(screen.getByRole('button', { name: 'Create Role' }));
+  await user.click(screen.getByRole('button', { name: 'Save Changes' }));
   expect(onSave).toHaveBeenCalled();
 });
 
 test('invisible tabs still apply validation', async () => {
-  const user = userEvent.setup();
   const onSave = jest.fn();
-  render(<TestStandardEditor onSave={onSave} />);
+  render(
+    <TestStandardEditor
+      originalRole={newRoleWithYaml(newRole())}
+      onSave={onSave}
+    />
+  );
   // Intentionally cause a validation error.
   await user.clear(screen.getByLabelText('Role Name *'));
   // Switch to a different tab.
-  await user.click(screen.getByRole('tab', { name: 'Resources' }));
-  await user.click(screen.getByRole('button', { name: 'Create Role' }));
+  await user.click(getTabByName('Resources'));
+  await user.click(screen.getByRole('button', { name: 'Save Changes' }));
   expect(onSave).not.toHaveBeenCalled();
 
   // Switch back, make it valid.
-  await user.click(screen.getByRole('tab', { name: 'Invalid data Overview' }));
+  await user.click(getTabByName('Invalid data Overview'));
   await user.type(screen.getByLabelText('Role Name *'), 'foo');
-  await user.click(screen.getByRole('button', { name: 'Create Role' }));
+  await user.click(screen.getByRole('button', { name: 'Save Changes' }));
   expect(onSave).toHaveBeenCalled();
 });
 
 test('edits metadata', async () => {
-  const user = userEvent.setup();
   let role: Role | undefined;
   const onSave = (r: Role) => (role = r);
-  render(<TestStandardEditor onSave={onSave} />);
+  render(
+    <TestStandardEditor
+      originalRole={newRoleWithYaml(newRole())}
+      onSave={onSave}
+    />
+  );
   await user.type(screen.getByLabelText('Description'), 'foo');
   await selectEvent.select(screen.getByLabelText('Version'), 'v6');
-  await user.click(screen.getByRole('button', { name: 'Create Role' }));
+  await user.click(screen.getByRole('button', { name: 'Save Changes' }));
   expect(role.metadata.description).toBe('foo');
   expect(role.version).toBe('v6');
 });
 
 test('edits resource access', async () => {
-  const user = userEvent.setup();
   let role: Role | undefined;
   const onSave = (r: Role) => (role = r);
-  render(<TestStandardEditor onSave={onSave} />);
-  await user.click(screen.getByRole('tab', { name: 'Resources' }));
+  render(
+    <TestStandardEditor
+      originalRole={newRoleWithYaml(newRole())}
+      onSave={onSave}
+    />
+  );
+  await user.click(getTabByName('Resources'));
   await user.click(
     screen.getByRole('button', { name: 'Add New Resource Access' })
   );
@@ -159,16 +182,20 @@ test('edits resource access', async () => {
   await selectEvent.create(screen.getByLabelText('Logins'), 'ec2-user', {
     createOptionText: 'Login: ec2-user',
   });
-  await user.click(screen.getByRole('button', { name: 'Create Role' }));
+  await user.click(screen.getByRole('button', { name: 'Save Changes' }));
   expect(role.spec.allow.logins).toEqual(['{{internal.logins}}', 'ec2-user']);
 });
 
 test('triggers v6 validation for Kubernetes resources', async () => {
-  const user = userEvent.setup();
   const onSave = jest.fn();
-  render(<TestStandardEditor onSave={onSave} />);
+  render(
+    <TestStandardEditor
+      originalRole={newRoleWithYaml(newRole())}
+      onSave={onSave}
+    />
+  );
   await selectEvent.select(screen.getByLabelText('Version'), 'v6');
-  await user.click(screen.getByRole('tab', { name: 'Resources' }));
+  await user.click(getTabByName('Resources'));
   await user.click(
     screen.getByRole('button', { name: 'Add New Resource Access' })
   );
@@ -183,7 +210,7 @@ test('triggers v6 validation for Kubernetes resources', async () => {
     screen.getByRole('button', { name: 'Add Another Resource' })
   );
   await selectEvent.select(screen.getAllByLabelText('Kind')[1], 'Pod');
-  await user.click(screen.getByRole('button', { name: 'Create Role' }));
+  await user.click(screen.getByRole('button', { name: 'Save Changes' }));
 
   // Validation should have failed on a Job resource and role v6.
   expect(
@@ -192,10 +219,85 @@ test('triggers v6 validation for Kubernetes resources', async () => {
   expect(onSave).not.toHaveBeenCalled();
 
   // Back to v7, try again
-  await user.click(screen.getByRole('tab', { name: 'Overview' }));
+  await user.click(getTabByName('Overview'));
   await selectEvent.select(screen.getByLabelText('Version'), 'v7');
-  await user.click(screen.getByRole('button', { name: 'Create Role' }));
+  await user.click(screen.getByRole('button', { name: 'Save Changes' }));
   expect(onSave).toHaveBeenCalled();
+});
+
+test('creating a new role', async () => {
+  async function forwardToTab(name: string) {
+    expect(
+      screen.queryByRole('button', { name: 'Create Role' })
+    ).not.toBeInTheDocument();
+    const tab = getTabByName(name);
+    expect(tab).toBeDisabled();
+    await user.click(screen.getByRole('button', { name: `Next: ${name}` }));
+    expect(tab).toHaveAttribute('aria-selected', 'true');
+  }
+
+  const onSave = jest.fn();
+  render(<TestStandardEditor onSave={onSave} />);
+  await user.type(screen.getByLabelText('Description'), 'foo');
+  await forwardToTab('Resources');
+  await forwardToTab('Access Rules');
+  await forwardToTab('Options');
+  expect(onSave).not.toHaveBeenCalled();
+
+  // By now, all the tabs should be enabled.
+  expect(getTabByName('Overview')).toBeEnabled();
+  expect(getTabByName('Resources')).toBeEnabled();
+  expect(getTabByName('Access Rules')).toBeEnabled();
+  expect(getTabByName('Options')).toBeEnabled();
+
+  // Allow free navigation.
+  await user.click(getTabByName('Resources'));
+  expect(getTabByName('Resources')).toHaveAttribute('aria-selected', 'true');
+  await user.click(getTabByName('Options'));
+  expect(getTabByName('Options')).toHaveAttribute('aria-selected', 'true');
+
+  await user.click(screen.getByRole('button', { name: 'Create Role' }));
+  expect(onSave).toHaveBeenCalledWith(
+    produce(newRole(), r => {
+      r.metadata.description = 'foo';
+    })
+  );
+});
+
+test('tab-level validation when creating a new role', async () => {
+  render(<TestStandardEditor />);
+  // Break the validation and attempt switching tabs.
+  await user.clear(screen.getByLabelText('Role Name *'));
+  await user.click(screen.getByRole('button', { name: 'Next: Resources' }));
+  expect(getTabByName('Resources')).toHaveAttribute('aria-selected', 'false');
+  // Fix the field value and retry.
+  expect(screen.getByLabelText('Role Name *')).toHaveAccessibleDescription(
+    'Role name is required'
+  );
+  await user.type(screen.getByLabelText('Role Name *'), 'some-role');
+  await user.click(screen.getByRole('button', { name: 'Next: Resources' }));
+  expect(getTabByName('Resources')).toHaveAttribute('aria-selected', 'true');
+
+  // Break the validation and attempt switching tabs.
+  await user.click(
+    screen.getByRole('button', { name: 'Add New Resource Access' })
+  );
+  await user.click(screen.getByRole('menuitem', { name: 'Servers' }));
+  await user.click(screen.getByRole('button', { name: 'Add a Label' }));
+  // The form should not be validating until we try to switch to the next tab.
+  expect(screen.getByPlaceholderText('label key')).toHaveAccessibleDescription(
+    ''
+  );
+  await user.click(screen.getByRole('button', { name: 'Next: Access Rules' }));
+  expect(getTabByName('Access Rules')).toHaveAttribute(
+    'aria-selected',
+    'false'
+  );
+  // Fix the field value and retry.
+  await user.type(screen.getByPlaceholderText('label key'), 'foo');
+  await user.type(screen.getByPlaceholderText('label value'), 'bar');
+  await user.click(screen.getByRole('button', { name: 'Next: Access Rules' }));
+  expect(getTabByName('Access Rules')).toHaveAttribute('aria-selected', 'true');
 });
 
 const getAllMenuItemNames = () =>
@@ -204,7 +306,14 @@ const getAllMenuItemNames = () =>
 const getAllSectionNames = () =>
   screen.queryAllByRole('heading', { level: 3 }).map(m => m.textContent);
 
+const getTabByName = (name: string) => screen.getByRole('tab', { name });
+
 const getSectionByName = (name: string) =>
   // There's no better way to do it, unfortunately.
   // eslint-disable-next-line testing-library/no-node-access
   screen.getByRole('heading', { level: 3, name }).closest('details');
+
+const newRoleWithYaml = (role: Role): RoleWithYaml => ({
+  object: role,
+  yaml: '{}', // Irrelevant in the standard editor context.
+});

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.tsx
@@ -16,16 +16,18 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { produce } from 'immer';
 import { useCallback, useId, useState } from 'react';
 import styled from 'styled-components';
 
-import { Box, Flex } from 'design';
+import { Box, ButtonPrimary, ButtonSecondary, Flex } from 'design';
 import { SlideTabs } from 'design/SlideTabs';
+import { TabSpec } from 'design/SlideTabs/SlideTabs';
 import { useValidation } from 'shared/components/Validation';
 
 import { Role, RoleWithYaml } from 'teleport/services/resources';
 
-import { EditorSaveCancelButton } from '../Shared';
+import { ActionButtonsContainer, SaveButton } from '../Shared';
 import { AccessRules } from './AccessRules';
 import { MetadataSection } from './MetadataSection';
 import { Options } from './Options';
@@ -39,11 +41,10 @@ import {
 import { StandardModelDispatcher } from './useStandardModel';
 
 export type StandardEditorProps = {
-  originalRole: RoleWithYaml;
+  originalRole?: RoleWithYaml;
   standardEditorModel: StandardEditorModel;
   isProcessing?: boolean;
   onSave?(r: Role): void;
-  onCancel?(): void;
   dispatch: StandardModelDispatcher;
 };
 
@@ -56,7 +57,6 @@ export const StandardEditor = ({
   standardEditorModel,
   isProcessing,
   onSave,
-  onCancel,
   dispatch,
 }: StandardEditorProps) => {
   const isEditing = !!originalRole;
@@ -70,11 +70,10 @@ export const StandardEditor = ({
   }
 
   const [currentTab, setCurrentTab] = useState(StandardEditorTab.Overview);
+  const [disabledTabs, setDisabledTabs] = useState(
+    isEditing ? [false, false, false, false] : [false, true, true, true]
+  );
   const idPrefix = useId();
-  const overviewTabId = `${idPrefix}-overview`;
-  const resourcesTabId = `${idPrefix}-resources`;
-  const accessRulesTabId = `${idPrefix}-access-rules`;
-  const optionsTabId = `${idPrefix}-options`;
 
   const validator = useValidation();
 
@@ -95,6 +94,44 @@ export const StandardEditor = ({
     [dispatch]
   );
 
+  const validateAndGoToNextTab = useCallback(() => {
+    const nextTabIndex = currentTab + 1;
+    const valid = validator.validate();
+    if (!valid) {
+      return;
+    }
+    validator.reset();
+    setCurrentTab(nextTabIndex);
+    setDisabledTabs(prevEnabledTabs =>
+      produce(prevEnabledTabs, et => {
+        et[nextTabIndex] = false;
+      })
+    );
+  }, [currentTab, setCurrentTab, setDisabledTabs, validator]);
+
+  const goToPreviousTab = useCallback(
+    () => setCurrentTab(currentTab - 1),
+    [setCurrentTab, currentTab]
+  );
+
+  const tabTitles = ['Overview', 'Resources', 'Access Rules', 'Options'];
+  const tabElementIDs = [
+    `${idPrefix}-overview`,
+    `${idPrefix}-resources`,
+    `${idPrefix}-access-rules`,
+    `${idPrefix}-options`,
+  ];
+
+  function tabSpec(tab: StandardEditorTab, error: boolean): TabSpec {
+    return {
+      key: tab,
+      title: tabTitles[tab],
+      disabled: disabledTabs[tab],
+      controls: tabElementIDs[tab],
+      status: error ? validationErrorTabStatus : undefined,
+    };
+  }
+
   return (
     <>
       {roleModel.conversionErrors.length > 0 && (
@@ -114,40 +151,21 @@ export const StandardEditor = ({
             appearance="round"
             hideStatusIconOnActiveTab
             tabs={[
-              {
-                key: StandardEditorTab.Overview,
-                title: 'Overview',
-                controls: overviewTabId,
-                status:
-                  validator.state.validating && !validationResult.metadata.valid
-                    ? validationErrorTabStatus
-                    : undefined,
-              },
-              {
-                key: StandardEditorTab.Resources,
-                title: 'Resources',
-                controls: resourcesTabId,
-                status:
-                  validator.state.validating &&
+              tabSpec(
+                StandardEditorTab.Overview,
+                validator.state.validating && !validationResult.metadata.valid
+              ),
+              tabSpec(
+                StandardEditorTab.Resources,
+                validator.state.validating &&
                   validationResult.resources.some(s => !s.valid)
-                    ? validationErrorTabStatus
-                    : undefined,
-              },
-              {
-                key: StandardEditorTab.AccessRules,
-                title: 'Access Rules',
-                controls: accessRulesTabId,
-                status:
-                  validator.state.validating &&
+              ),
+              tabSpec(
+                StandardEditorTab.AccessRules,
+                validator.state.validating &&
                   validationResult.rules.some(s => !s.valid)
-                    ? validationErrorTabStatus
-                    : undefined,
-              },
-              {
-                key: StandardEditorTab.Options,
-                title: 'Options',
-                controls: optionsTabId,
-              },
+              ),
+              tabSpec(StandardEditorTab.Options, false),
             ]}
             activeIndex={currentTab}
             onChange={setCurrentTab}
@@ -163,7 +181,7 @@ export const StandardEditor = ({
           `}
         >
           <Box
-            id={overviewTabId}
+            id={tabElementIDs[StandardEditorTab.Overview]}
             style={{
               display: currentTab === StandardEditorTab.Overview ? '' : 'none',
             }}
@@ -178,7 +196,7 @@ export const StandardEditor = ({
             />
           </Box>
           <Box
-            id={resourcesTabId}
+            id={tabElementIDs[StandardEditorTab.Resources]}
             style={{
               display: currentTab === StandardEditorTab.Resources ? '' : 'none',
             }}
@@ -191,7 +209,7 @@ export const StandardEditor = ({
             />
           </Box>
           <Box
-            id={accessRulesTabId}
+            id={tabElementIDs[StandardEditorTab.AccessRules]}
             style={{
               display:
                 currentTab === StandardEditorTab.AccessRules ? '' : 'none',
@@ -205,7 +223,7 @@ export const StandardEditor = ({
             />
           </Box>
           <Box
-            id={optionsTabId}
+            id={tabElementIDs[StandardEditorTab.Options]}
             style={{
               display: currentTab === StandardEditorTab.Options ? '' : 'none',
             }}
@@ -218,16 +236,37 @@ export const StandardEditor = ({
           </Box>
         </Flex>
       </EditorWrapper>
-      <EditorSaveCancelButton
-        onSave={() => handleSave()}
-        onCancel={onCancel}
-        saveDisabled={
-          isProcessing ||
-          standardEditorModel.roleModel.requiresReset ||
-          !standardEditorModel.isDirty
-        }
-        isEditing={isEditing}
-      />
+      <ActionButtonsContainer>
+        {isEditing || currentTab === StandardEditorTab.Options ? (
+          <SaveButton
+            onClick={() => handleSave()}
+            disabled={
+              isProcessing ||
+              standardEditorModel.roleModel.requiresReset ||
+              !standardEditorModel.isDirty
+            }
+            isEditing={isEditing}
+          />
+        ) : (
+          <ButtonPrimary
+            size="large"
+            width="50%"
+            onClick={validateAndGoToNextTab}
+          >
+            Next: {tabTitles[currentTab + 1]}
+          </ButtonPrimary>
+        )}
+        {!isEditing && (
+          <ButtonSecondary
+            size="large"
+            width="50%"
+            disabled={currentTab === StandardEditorTab.Overview}
+            onClick={goToPreviousTab}
+          >
+            Back
+          </ButtonSecondary>
+        )}
+      </ActionButtonsContainer>
     </>
   );
 };

--- a/web/packages/teleport/src/Roles/RoleEditor/YamlEditor.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/YamlEditor.tsx
@@ -23,7 +23,7 @@ import TextEditor from 'shared/components/TextEditor';
 
 import { RoleWithYaml } from 'teleport/services/resources';
 
-import { EditorSaveCancelButton } from './Shared';
+import { ActionButtonsContainer, PreviewButton, SaveButton } from './Shared';
 import { YamlEditorModel } from './yamlmodel';
 
 type YamlEditorProps = {
@@ -33,7 +33,6 @@ type YamlEditorProps = {
   onChange?(y: YamlEditorModel): void;
   onSave?(content: string): void;
   onPreview?(): void;
-  onCancel?(): void;
 };
 
 export const YamlEditor = ({
@@ -43,7 +42,6 @@ export const YamlEditor = ({
   onChange,
   onSave,
   onPreview,
-  onCancel,
 }: YamlEditorProps) => {
   const isEditing = !!originalRole;
   const [wasPreviewed, setHasPreviewed] = useState(!onPreview);
@@ -76,16 +74,19 @@ export const YamlEditor = ({
           onChange={handleSetYaml}
         />
       </Flex>
-      <EditorSaveCancelButton
-        onSave={handleSave}
-        onPreview={onPreview ? handlePreview : undefined}
-        onCancel={onCancel}
-        saveDisabled={isProcessing || !yamlEditorModel.isDirty || !wasPreviewed}
-        previewDisabled={
-          isProcessing || wasPreviewed || !yamlEditorModel.isDirty
-        }
-        isEditing={isEditing}
-      />
+      <ActionButtonsContainer>
+        <SaveButton
+          isEditing={isEditing}
+          disabled={isProcessing || !yamlEditorModel.isDirty || !wasPreviewed}
+          onClick={handleSave}
+        />
+        {onPreview && (
+          <PreviewButton
+            disabled={isProcessing || wasPreviewed || !yamlEditorModel.isDirty}
+            onClick={handlePreview}
+          />
+        )}
+      </ActionButtonsContainer>
     </Flex>
   );
 };


### PR DESCRIPTION
According to the UI designs, the user needs to be walked through every tab specifically when creating a new role (as opposed to modifying an existing one). In this mode, validation is triggered every time the user wants to progress to the next tab. Tab switching is allowed for tabs that have already been visited.

Figma: https://www.figma.com/design/v6GunK50D2VC7w7I2FBDNf/Access-(Management)?node-id=6262-85865&m=dev
Demo: https://goteleport.zoom.us/clips/share/FzZL7MpLSRGB6ZfMrkMTAg

Deviations from the design: didn't implement tooltips on clicking a disabled tab after validation errors (no time, I need to move on).

Followed up by https://github.com/gravitational/teleport/pull/52577
Contributes to https://github.com/gravitational/teleport/issues/52036