### PR TITLE
[web] Add CollapsibleInfoSection component

### DIFF
--- a/web/packages/design/src/CollapsibleInfoSection/CollapsibleInfoSection.story.tsx
+++ b/web/packages/design/src/CollapsibleInfoSection/CollapsibleInfoSection.story.tsx
@@ -1,0 +1,110 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { action } from '@storybook/addon-actions';
+import { Meta, StoryFn, type StoryObj } from '@storybook/react';
+import styled from 'styled-components';
+
+import { Flex, H2, Text } from 'design';
+
+import { CollapsibleInfoSection as CollapsibleInfoSectionComponent } from './';
+
+type Story = StoryObj<typeof CollapsibleInfoSectionComponent>;
+type StoryMeta = Meta<typeof CollapsibleInfoSectionComponent>;
+
+const defaultArgs = {
+  size: 'large',
+  defaultOpen: false,
+  openLabel: 'More info',
+  closeLabel: 'Less info',
+  onClick: action('onClick'),
+} satisfies StoryMeta['args'];
+
+export default {
+  title: 'Design/CollapsibleInfoSection',
+  component: CollapsibleInfoSectionComponent,
+  argTypes: {
+    size: {
+      control: { type: 'radio' },
+      options: ['small', 'large'],
+      description: 'Size of the toggle button',
+      table: { defaultValue: { summary: defaultArgs.size } },
+    },
+    defaultOpen: {
+      control: { type: 'boolean' },
+      description: 'Whether the section is open or closed initially',
+      table: {
+        defaultValue: { summary: defaultArgs.defaultOpen.toString() },
+      },
+    },
+    openLabel: {
+      control: { type: 'text' },
+      description: 'Label for the closed state',
+      table: { defaultValue: { summary: defaultArgs.openLabel } },
+    },
+    closeLabel: {
+      control: { type: 'text' },
+      description: 'Label for the opened state',
+      table: { defaultValue: { summary: defaultArgs.closeLabel } },
+    },
+    onClick: {
+      control: false,
+      description: 'Callback for when the toggle is clicked',
+      table: { type: { summary: '(isOpen: boolean) => void' } },
+    },
+  },
+  args: defaultArgs,
+  render: (args => (
+    <Container maxWidth="750px">
+      <H2 ml={1}>Collapsible Info Section</H2>
+      <Text ml={1} mb={1}>
+        This is an example of a collapsible section that shows more information
+        when expanded. It is useful for hiding less important – or more detailed
+        – information by default.
+      </Text>
+      <CollapsibleInfoSectionComponent {...args} maxWidth="500px">
+        <DummyContent />
+      </CollapsibleInfoSectionComponent>
+    </Container>
+  )) satisfies StoryFn<typeof CollapsibleInfoSectionComponent>,
+} satisfies StoryMeta;
+
+const Container = styled(Flex).attrs({
+  flexDirection: 'column',
+  gap: 2,
+})`
+  background-color: ${p => p.theme.colors.spotBackground[0]};
+  border-radius: ${p => `${p.theme.radii[3]}px`};
+  padding: ${p => p.theme.space[3]}px;
+`;
+
+const DummyContent = () => (
+  <Flex flexDirection="column" gap={2}>
+    <Text bold>What this does:</Text>
+    <Text>
+      This is a dummy section that shows some information when the section is
+      expanded. It can contain anything you want.
+    </Text>
+    <Text>
+      There is no limit to the amount of content you can put in here, but it is
+      recommended to keep it concise.
+    </Text>
+  </Flex>
+);
+
+export const CollapsibleInfoSection: Story = { args: defaultArgs };

--- a/web/packages/design/src/CollapsibleInfoSection/CollapsibleInfoSection.test.tsx
+++ b/web/packages/design/src/CollapsibleInfoSection/CollapsibleInfoSection.test.tsx
@@ -1,0 +1,103 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { fireEvent, render, screen, userEvent } from 'design/utils/testing';
+
+import { CollapsibleInfoSection } from './CollapsibleInfoSection';
+
+describe('CollapsibleInfoSection', () => {
+  test('renders with default props, closed by default', () => {
+    render(<CollapsibleInfoSection>Some content</CollapsibleInfoSection>);
+
+    expect(screen.getByText('More info')).toBeInTheDocument();
+    expect(screen.queryByText('Some content')).not.toBeInTheDocument();
+  });
+
+  test('opens when the toggle is clicked, and closes again when clicked again', async () => {
+    render(<CollapsibleInfoSection>Some content</CollapsibleInfoSection>);
+
+    await userEvent.click(screen.getByRole('button', { name: /More info/i }));
+    expect(screen.getByText('Less info')).toBeInTheDocument();
+    expect(screen.getByText('Some content')).toBeInTheDocument();
+
+    const button = screen.getByRole('button', { name: /Less info/i });
+    await userEvent.click(button);
+
+    // In a real browser, `onTransitionEnd` would eventually be fired, hiding the content.
+    // Since we're testing w/ JSDOM, let's simulate:
+    fireEvent.transitionEnd(button.nextElementSibling!);
+
+    expect(screen.getByText('More info')).toBeInTheDocument();
+    expect(screen.queryByText('Some content')).not.toBeInTheDocument();
+  });
+
+  test('can be open by default using defaultOpen prop', () => {
+    render(
+      <CollapsibleInfoSection defaultOpen>
+        This starts out visible
+      </CollapsibleInfoSection>
+    );
+
+    expect(screen.getByText('Less info')).toBeInTheDocument();
+    expect(screen.getByText('This starts out visible')).toBeInTheDocument();
+  });
+
+  test('allows custom open and close labels', async () => {
+    render(
+      <CollapsibleInfoSection
+        openLabel="Show details"
+        closeLabel="Hide details"
+      >
+        Custom labels
+      </CollapsibleInfoSection>
+    );
+
+    expect(screen.getByText('Show details')).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole('button', { name: /Show details/i })
+    );
+    expect(screen.getByText('Hide details')).toBeInTheDocument();
+    expect(screen.getByText('Custom labels')).toBeInTheDocument();
+  });
+
+  test('calls onClick callback with isOpen toggle state', async () => {
+    const handleClick = jest.fn();
+    render(
+      <CollapsibleInfoSection onClick={handleClick}>
+        Content
+      </CollapsibleInfoSection>
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /More info/i }));
+    expect(handleClick).toHaveBeenCalledWith(true);
+
+    await userEvent.click(screen.getByRole('button', { name: /Less info/i }));
+    expect(handleClick).toHaveBeenCalledWith(false);
+  });
+
+  test('does not toggle when disabled', async () => {
+    render(
+      <CollapsibleInfoSection disabled>Disabled content</CollapsibleInfoSection>
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /More info/i }));
+
+    expect(screen.getByText('More info')).toBeInTheDocument();
+    expect(screen.queryByText('Disabled content')).not.toBeInTheDocument();
+  });
+});

--- a/web/packages/design/src/CollapsibleInfoSection/CollapsibleInfoSection.tsx
+++ b/web/packages/design/src/CollapsibleInfoSection/CollapsibleInfoSection.tsx
@@ -1,0 +1,155 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  PropsWithChildren,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+import styled from 'styled-components';
+
+import { Box, Button, Text } from 'design';
+import { BoxProps } from 'design/Box';
+import { Minus, Plus } from 'design/Icon';
+
+type CollapsibleInfoSectionProps = {
+  /* defaultOpen is optional and determines whether the section is open or closed initially */
+  defaultOpen?: boolean;
+  /* size is an optional prop to set the size of the toggle button */
+  size?: 'small' | 'large';
+  /* onClick is an optional callback for when the toggle is clicked */
+  onClick?: (isOpen: boolean) => void;
+  /* openLabel is an optional label for the closed state */
+  openLabel?: string;
+  /* closeLabel is an optional label for the opened state */
+  closeLabel?: string;
+  /* disabled is an optional flag to disable the toggle */
+  disabled?: boolean;
+} & BoxProps;
+
+/**
+ * CollapsibleInfoSection is a collapsible section that shows more information when expanded.
+ * It is useful for hiding less important – or more detailed – information by default.
+ */
+export const CollapsibleInfoSection = ({
+  defaultOpen = false,
+  openLabel = 'More info',
+  closeLabel = 'Less info',
+  size = 'large',
+  onClick,
+  disabled = false,
+  children,
+  ...boxProps
+}: PropsWithChildren<CollapsibleInfoSectionProps>) => {
+  const contentId = useId();
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+  const [contentHeight, setContentHeight] = useState(0);
+  const [shouldRenderContent, setShouldRenderContent] = useState(defaultOpen);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    if (!contentRef.current || !shouldRenderContent) {
+      return;
+    }
+    const ro = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        if (entry.target === contentRef.current) {
+          setContentHeight(entry.contentRect.height);
+        }
+      }
+    });
+    ro.observe(contentRef.current);
+    return () => ro.disconnect();
+  }, [contentRef, shouldRenderContent]);
+
+  return (
+    <Box {...boxProps}>
+      <ToggleButton
+        size={size}
+        onClick={() => {
+          !isOpen && setShouldRenderContent(true);
+          setIsOpen(!isOpen);
+          onClick?.(!isOpen);
+        }}
+        disabled={disabled}
+        aria-expanded={isOpen}
+        aria-controls={contentId}
+      >
+        {isOpen ? <Minus size="small" /> : <Plus size="small" />}
+        <Text>{isOpen ? closeLabel : openLabel}</Text>
+      </ToggleButton>
+      <ContentWrapper
+        id={contentId}
+        role="region"
+        aria-hidden={!isOpen}
+        $isOpen={isOpen}
+        $contentHeight={contentHeight}
+        onTransitionEnd={() => !isOpen && setShouldRenderContent(false)}
+      >
+        {shouldRenderContent && (
+          <Box
+            ml={size === 'small' ? 3 : 4}
+            style={{ position: 'relative' }}
+            ref={contentRef}
+          >
+            <Bar />
+            <Box
+              ml={3}
+              pt={size === 'small' ? 2 : 3}
+              pb={size === 'small' ? 1 : 2}
+            >
+              {children}
+            </Box>
+          </Box>
+        )}
+      </ContentWrapper>
+    </Box>
+  );
+};
+
+const ToggleButton = styled(Button).attrs({ intent: 'neutral' })<{
+  size: 'small' | 'large';
+}>`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  ${({ size, theme }) =>
+    size === 'small'
+      ? `padding: ${theme.space[1]}px ${theme.space[2]}px;`
+      : `padding: ${theme.space[2]}px ${theme.space[3]}px;`}
+  gap: ${({ theme }) => theme.space[2]}px;
+`;
+
+const Bar = styled.div`
+  position: absolute;
+  top: ${({ theme }) => theme.space[1]}px;
+  bottom: 0;
+  left: 0;
+  width: 2px;
+  background: ${({ theme }) => theme.colors.interactive.tonal.neutral[0]};
+`;
+
+const ContentWrapper = styled.div<{ $isOpen: boolean; $contentHeight: number }>`
+  overflow: hidden;
+  height: ${props => (props.$isOpen ? `${props.$contentHeight}px` : '0')};
+  will-change: height;
+  transition: height 200ms ease;
+  transform-origin: top;
+`;

--- a/web/packages/design/src/CollapsibleInfoSection/index.ts
+++ b/web/packages/design/src/CollapsibleInfoSection/index.ts
@@ -1,0 +1,19 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export { CollapsibleInfoSection } from './CollapsibleInfoSection';


### PR DESCRIPTION
## Background
Add component for collapsible 'more/less info' sections, intended for use in guided flows where extended instructions may be desirable to initially hide.

## Screenshots
<img width="984" alt="Screenshot 2025-02-26 at 19 29 08" src="https://github.com/user-attachments/assets/f2652f64-f404-4656-b2dc-ea21dd18f950" />
<img width="983" alt="Screenshot 2025-02-26 at 19 29 01" src="https://github.com/user-attachments/assets/2008a4d8-8a02-4df6-8444-7b78473a1d61" />
