### PR TITLE
[v17] Fix 45 Vale warnings

### DIFF
--- a/docs/pages/admin-guides/access-controls/access-requests/resource-requests.mdx
+++ b/docs/pages/admin-guides/access-controls/access-requests/resource-requests.mdx
@@ -544,7 +544,7 @@ spec:
 ### Request access to Kubernetes resources
 
 Teleport users can request access to a Kubernetes resources by running the following
-command:
+command, where <Var name="resource-id" /> is the ID of the resource:
 
 ```code
 $ tsh request create <Var name="resource-id" />
@@ -626,8 +626,10 @@ spec:
 
 #### Search for Kubernetes resources
 
-If a user has no access to a Kubernetes cluster, they can search the list of resources
-in the cluster by running the following command:
+If a user has no access to a Kubernetes cluster, they can search the list of
+resources in the cluster by running the following command, replacing 
+<Var name="kube-cluster" /> with the name of the Kubernetes cluster and 
+<Var name="namespace" /> with the name of a Kubernetes namespace:
 
 ```code
 $ tsh request search --kind=<kind> --kube-cluster=<Var name="kube-cluster" /> \

--- a/docs/pages/admin-guides/access-controls/device-trust/device-management.mdx
+++ b/docs/pages/admin-guides/access-controls/device-trust/device-management.mdx
@@ -67,9 +67,10 @@ $ tsh device asset-tag
 </Details>
 
 
-Replace <Var name="(=devicetrust.asset_tag=)" description="The serial number to
-be registered"/> with the serial number of the device you wish to enroll and run
-the `tctl devices add` command:
+Replace 
+<Var name="(=devicetrust.asset_tag=)" description="The serial number to be registered"/> 
+with the serial number of the device you wish to enroll and
+<Var name="macos" /> with your operating system. Run the `tctl devices add` command:
 
 ```code
 $ tctl devices add --os='<Var name="macos"/>' --asset-tag='<Var name="(=devicetrust.asset_tag=)"/>'

--- a/docs/pages/admin-guides/access-controls/device-trust/jamf-integration.mdx
+++ b/docs/pages/admin-guides/access-controls/device-trust/jamf-integration.mdx
@@ -44,12 +44,17 @@ specific for Teleport.
 
 Make sure that your Jamf role has the "Read Computers" privilege.
 
-You can test your client credentials using the following Jamf query:
+You can test your client credentials using the following Jamf query, replacing
+<Var name="(=jamf.api_endpoint=)" description="Jamf API URL" /> with your Jamf
+API endpoint, <Var name="(=jamf.client_id=)" description="Jamf API client ID" />
+with your client ID, and 
+<Var name="(=jamf.client_secret=)" description="Jamf API client secret" /> with
+your client secret:
 
 ```code
-$ URL='<Var name="(=jamf.api_endpoint=)" description="Jamf API URL"/>'
-$ CLIENT_ID='<Var name="(=jamf.client_id=)" description="Jamf API client ID" />'
-$ CLIENT_SECRET='<Var name="(=jamf.client_secret=)" description="Jamf API client secret" />'
+$ URL='<Var name="(=jamf.api_endpoint=)" />'
+$ CLIENT_ID='<Var name="(=jamf.client_id=)" />'
+$ CLIENT_SECRET='<Var name="(=jamf.client_secret=)" />'
 
 ## Acquire access token from Jamf.
 $ TOKEN_RESP="$(curl -X POST "$URL/api/oauth/token" \

--- a/docs/pages/admin-guides/access-controls/guides/webauthn.mdx
+++ b/docs/pages/admin-guides/access-controls/guides/webauthn.mdx
@@ -289,9 +289,11 @@ $ tsh device asset-tag
 </Tabs>
 </Details>
 
-Replace <Var name="(=devicetrust.asset_tag=)" description="The serial number to
-be registered"/> with the serial number of the device you wish to enroll and run
-the `tctl devices add` command:
+Replace 
+<Var name="(=devicetrust.asset_tag=)" description="The serial number to be registered"/> 
+with the serial number of the device you wish to enroll, and
+<Var name="macos" /> with your operating system. Run the
+`tctl devices add` command:
 
 ```code
 $ tctl devices add --os='<Var name="macos"/>' --asset-tag='<Var name="(=devicetrust.asset_tag=)"/>'

--- a/docs/pages/admin-guides/access-controls/login-rules/guide.mdx
+++ b/docs/pages/admin-guides/access-controls/login-rules/guide.mdx
@@ -161,9 +161,10 @@ The [`tctl sso test`](../../../reference/cli/tctl.mdx) command can be used to
 debug SSO logins and see exactly which traits are being sent by your SSO
 provider and how they are being mapped by your Login Rules.
 
-`tctl sso test` expects a connector spec.
-Run the following command to debug with a connector currently installed in your
-cluster.
+`tctl sso test` expects a connector spec.  Run the following command to debug
+with a connector currently installed in your cluster, replacing 
+<Var name="SSO connector name"/> with the name of the SSO connector you registered with
+Teleport: 
 
 ```code
 $ tctl get connector/<Var name="SSO connector name"/> --with-secrets | tctl sso test

--- a/docs/pages/admin-guides/access-controls/sso/azuread.mdx
+++ b/docs/pages/admin-guides/access-controls/sso/azuread.mdx
@@ -66,10 +66,11 @@ Before you get started, you’ll need:
 
    ![Edit Basic SAML Configuration](../../../../img/azuread/azuread-6-editbasicsaml.png)
 
-1. Enter the URL for your Teleport Proxy Service host in the **Entity ID** and **Reply URL**  fields:
+1. Enter the URL for your Teleport Proxy Service host in the **Entity ID** and
+   **Reply URL**  fields, for example:
 
    ```code
-   https://<Var name="mytenant.teleport.sh:443" />/v1/webapi/saml/acs/ad
+   https://mytenant.teleport.sh:443/v1/webapi/saml/acs/ad
    ```
 
    ![Put in Entity ID and Reply URL](../../../../img/azuread/azuread-7-entityandreplyurl.png)

--- a/docs/pages/admin-guides/access-controls/sso/github-sso.mdx
+++ b/docs/pages/admin-guides/access-controls/sso/github-sso.mdx
@@ -198,8 +198,10 @@ spec.
 
 <Details title="Self-hosting GitHub Enterprise?" scope={["enterprise", "cloud"]} opened>
 
-For self-hosted GitHub Enterprise servers, you can specify the server
-instance endpoints with the `--endpoint-url`, `--api-endpoint-url` parameters:
+For self-hosted GitHub Enterprise servers, you can specify the server instance
+endpoints with the `--endpoint-url`, `--api-endpoint-url` parameters, replacing
+<Var name="github-enterprise-server-address"/> with your endpoint URL and 
+<Var name="api-github-enterprise-server-address"/> with your API endpoint URL:
 
 ```code
 $ tctl sso configure github \

--- a/docs/pages/admin-guides/access-controls/sso/oidc.mdx
+++ b/docs/pages/admin-guides/access-controls/sso/oidc.mdx
@@ -40,7 +40,7 @@ Save the relevant information from your identity provider. To make following
 this guide easier, you can add the Client ID here and it will be included in the
 example commands below:
 
-Client ID: <Var name="<CLIENT-ID>" description="The Client ID for your Teleport
+Client ID: <Var name="CLIENT-ID" description="The Client ID for your Teleport
 application, provided by your IdP"/>
 
 ## OIDC Redirect URL
@@ -49,10 +49,11 @@ OIDC relies on HTTP redirects to return control back to Teleport after
 authentication is complete. The redirect URL must be selected by a Teleport
 administrator in advance.
 
-The redirect URL for OIDC authentication in Teleport is <nobr><Var
-name="mytenant.teleport.sh" description="Your Teleport Cloud tenant or Proxy
-Service address"/>`/v1/webapi/oidc/callback`</nobr>. Replace `mytenant.teleport.sh`
-with your Teleport Cloud tenant or Proxy Service address.
+The redirect URL for OIDC authentication in Teleport is <nobr>
+<Var name="mytenant.teleport.sh" description="Your Teleport Cloud tenant or Proxy
+Service address"/>`/v1/webapi/oidc/callback`</nobr>. 
+Replace <Var name="mytenant.teleport.sh" /> with your Teleport Cloud tenant or
+Proxy Service address.
 
 ## OIDC connector configuration
 
@@ -69,7 +70,7 @@ connector resource file in YAML format named `oidc-connector.yaml`:
 ```code
 $ tctl sso configure oidc --name <CONNECTOR-NAME> \
   --issuer-url <PATH-TO-PROVIDER> \
-  --id <CLIENT-ID> \
+  --id <Var name="CLIENT-ID" /> \
   --secret $(cat client-secret.txt) \
   --claims-to-roles <CLAIM-KEY>,<CLAIM-VALUE>,access \
   --claims-to-roles <CLAIM-KEY>,<CLAIM-VALUE>,editor > oidc-connector.yaml

--- a/docs/pages/admin-guides/access-controls/sso/okta.mdx
+++ b/docs/pages/admin-guides/access-controls/sso/okta.mdx
@@ -173,7 +173,7 @@ flags for this command:
 
 ```code
 $ tctl sso configure saml --preset=okta \
---entity-descriptor <Var name="https://example.okta.com/app/000000/sso/saml/metadata"/> \
+--entity-descriptor "https://example.okta.com/app/000000/sso/saml/metadata" \
 --attributes-to-roles=groups,okta-admin,editor \
 --attributes-to-roles=groups,okta-dev,dev > okta-connector.yaml
 ```

--- a/docs/pages/admin-guides/access-controls/sso/sso.mdx
+++ b/docs/pages/admin-guides/access-controls/sso/sso.mdx
@@ -265,7 +265,7 @@ Create the resource:
 
   ```code
   # Log in to your cluster with tsh so you can run tctl commands.
-  $ tsh login --proxy=<Var name="mytenant.teleport.sh" /> --user=myuser
+  $ tsh login --proxy=example.teleport.sh --user=myuser
   $ tctl create -f cap.yaml
   ```
 

--- a/docs/pages/admin-guides/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform.mdx
@@ -855,7 +855,7 @@ You can also generate an SSH Service join token using `tctl tokens add --type=no
 
 The easiest way to quickly join nodes to your cluster is to use the "Enroll New Resource" wizard in the Teleport web UI.
 
-To manually join Teleport agents to your cluster, you will need [a join token](../../../enroll-resources/agents/join-services-to-your-cluster/join-token.mdx).
+To manually join Teleport Agents to your cluster, you will need [a join token](../../../enroll-resources/agents/join-services-to-your-cluster/join-token.mdx).
 
 You should join your agents using the public facing Proxy Service address - `teleport.example.com:443` for our
 example.

--- a/docs/pages/admin-guides/deploy-a-cluster/deployments/aws-starter-cluster-terraform.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/deployments/aws-starter-cluster-terraform.mdx
@@ -157,7 +157,7 @@ These are regions that support [DynamoDB encryption at rest](https://docs.aws.am
 ### cluster_name
 
 ```code
-$ export TF_VAR_cluster_name="<Var name="teleport-example" />"
+$ export TF_VAR_cluster_name="teleport-example"
 ```
 
 This is the internal Teleport cluster name to use. This should be unique, and not contain spaces, dots (.) or other

--- a/docs/pages/admin-guides/deploy-a-cluster/deployments/gcp.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/deployments/gcp.mdx
@@ -332,7 +332,7 @@ Save the following configuration file as `/etc/teleport.yaml` on the Node:
 version: v3
 teleport:
   auth_token: (= presets.tokens.second =)
-  # Teleport agents can be joined to the cluster via the Proxy Service's
+  # Teleport Agents can be joined to the cluster via the Proxy Service's
   # public address. This will establish a reverse tunnel between the Proxy
   # Service and the agent that is used for all traffic.
   proxy_server: teleport.example.com:443

--- a/docs/pages/admin-guides/deploy-a-cluster/linux-demo.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/linux-demo.mdx
@@ -211,5 +211,5 @@ databases, Kubernetes clusters, cloud provider APIs, and Windows desktops.
 
 Step 4 showed you how to install agents manually, and you can also launch agents
 and enroll resources with them using infrastructure-as-code tools. For example,
-you can use Terraform to declare a pool of Teleport agents and configure them to
+you can use Terraform to declare a pool of Teleport Agents and configure them to
 proxy your infrastructure. Read [Protect Infrastructure with Teleport](../../enroll-resources/agents/introduction.mdx) to get started.

--- a/docs/pages/admin-guides/deploy-a-cluster/multi-region-blueprint.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/multi-region-blueprint.mdx
@@ -53,7 +53,7 @@ To run a multi-region Teleport deployment, you must have:
   This means you have **cross-region Pod/Instance connectivity**. This is typically
   achieved with VPC peering and/or service mesh.
 - A **multi-region object storage** for session recordings.
-- **GeoDNS** to route users and Teleport agents to the closest Teleport cluster.
+- **GeoDNS** to route users and Teleport Agents to the closest Teleport cluster.
 - A **multi-region CockroachDB cluster**. You can use the CockroachDB core
   for testing purposes, but only CockroachDB Enterprise is recommended for production
   because of [its multi-region features](https://www.cockroachlabs.com/docs/stable/enterprise-licensing).

--- a/docs/pages/admin-guides/management/guides/awsoidc-integration.mdx
+++ b/docs/pages/admin-guides/management/guides/awsoidc-integration.mdx
@@ -5,7 +5,7 @@ description: How to connect your AWS account with Teleport and provide access to
 
 This guide explains how to set up the Teleport AWS OIDC integration.
 
-With the AWS OIDC integration you will no longer need to deploy Teleport agents in AWS manually for most use cases.
+With the AWS OIDC integration you will no longer need to deploy Teleport Agents in AWS manually for most use cases.
 The following features use an AWS OIDC integration to interact with AWS:
 - [External Audit Storage](../external-audit-storage.mdx)
 - [RDS Enrollment](./awsoidc-integration-rds.mdx)

--- a/docs/pages/admin-guides/management/guides/gcp-tags.mdx
+++ b/docs/pages/admin-guides/management/guides/gcp-tags.mdx
@@ -1,7 +1,7 @@
 ---
 title: GCP Tags and Labels as Teleport Agent Labels
-description: How to set up Teleport agent labels based on GCP tags and labels
-h1: Sync GCP Tags/Labels and Teleport agent labels
+description: How to set up Teleport Agent labels based on GCP tags and labels
+h1: Sync GCP Tags/Labels and Teleport Agent labels
 ---
 
 When running on an Google Compute Engine instance, Teleport will automatically detect and import GCP

--- a/docs/pages/admin-guides/management/security/restrict-privileges.mdx
+++ b/docs/pages/admin-guides/management/security/restrict-privileges.mdx
@@ -34,7 +34,7 @@ To prevent changes to labels from granting elevated privileges, you should:
 
 You should be highly selective in allowing any user to have root privileges or access to other 
 accounts with administrative privileges. 
-Privileged users could manipulate Teleport agents in ways that affect your authorization controls.
+Privileged users could manipulate Teleport Agents in ways that affect your authorization controls.
 For example, a privileged user with access to the Teleport configuration file might modify settings 
 to bypass role-based access controls. Similarly, a user with elevated access to the Teleport Auth Service, 
 Teleport Proxy Service, or Teleport Agent services might replace the Teleport executable to infiltrate or 

--- a/docs/pages/admin-guides/migrate-plans.mdx
+++ b/docs/pages/admin-guides/migrate-plans.mdx
@@ -185,11 +185,11 @@ and configure a new Auth Connector in the new Teleport Enterprise tenant.
 
 ## Step 3/4. Migrate Teleport services and plugins
 
-To migrate services such as Teleport agents, Machine ID Bots, and plugins, start
+To migrate services such as Teleport Agents, Machine ID Bots, and plugins, start
 by cataloging the various services you're managing with Teleport. The following
 resources should be considered for migration:
 
- - Teleport agents 
+ - Teleport Agents 
  - Machine ID Bots
  - Access Request plugins
  - The Teleport Event Handler
@@ -202,9 +202,9 @@ business requirements. If running Teleport at scale, you'll generally want to
 use a configuration management tool to automate and streamline the process of
 carrying out the actions involved in migrating agent configurations. 
 
-### Migrate Teleport agents
+### Migrate Teleport Agents
 
-To migrate Teleport agents:
+To migrate Teleport Agents:
 
 1. For each Agent and Machine ID Bot, obtain a valid join token. We recommend
    using a [delegated join

--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -246,7 +246,7 @@ couple of clicks.
 It is the easiest way to add a computer to the cluster, whether you're exploring the capabilities of
 Teleport or want your computer to be available in a Teleport-powered home lab.
 
-Connect My Computer sets up a Teleport agent managed completely by Teleport Connect, without having
+Connect My Computer sets up a Teleport Agent managed completely by Teleport Connect, without having
 to use the terminal to get the job done and without the need for tools like `systemctl` to control
 the lifecycle of the agent.
 
@@ -284,7 +284,7 @@ We recommend using Connect My Computer only in scenarios where no other user cou
 access to the node, such as when exploring a Teleport cluster as its only user or in a home lab.
 </Admonition>
 
-Next, the setup downloads a Teleport agent for your platform and runs `teleport node configure`
+Next, the setup downloads a Teleport Agent for your platform and runs `teleport node configure`
 pointed at the current cluster. Once that is done, Connect My Computer starts the agent and waits
 for it to show up in the cluster as an SSH node.
 

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
@@ -464,14 +464,14 @@ Application Service:
 
 1. (!docs/pages/includes/kubernetes-access/helm/helm-repo-add.mdx!)
 
-1. Install the Helm chart for Teleport agent services, `teleport-kube-agent`:
+1. Install the Helm chart for Teleport Agent services, `teleport-kube-agent`:
 
    ```code
    $ helm -n teleport-agent install teleport-kube-agent teleport/teleport-kube-agent \
      --values values.yaml --create-namespace
    ```
 
-1. Make sure that the Teleport agent pod is running. You should see one
+1. Make sure that the Teleport Agent pod is running. You should see one
    `teleport-kube-agent` pod with a single ready container:
 
    ```code
@@ -807,7 +807,7 @@ for all of the variables and functions you can use in the `aws_role_arns` field.
 
 ### Register the AWS application dynamically
 
-You can deploy a pool of Teleport agents to run the Teleport Application
+You can deploy a pool of Teleport Agents to run the Teleport Application
 Service, then enroll an AWS application in your Teleport cluster as a dynamic
 resource. Read more about [dynamically registering
 applications](../guides/dynamic-registration.mdx).

--- a/docs/pages/enroll-resources/application-access/cloud-apis/azure-aks-workload-id.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/azure-aks-workload-id.mdx
@@ -194,13 +194,13 @@ extraLabels:
 EOF
 ```
 
-Install the Helm chart for Teleport agent services, `teleport-kube-agent`:
+Install the Helm chart for Teleport Agent services, `teleport-kube-agent`:
 ```code
 $ helm -n <Var name="teleport-ns" /> install teleport-azure-access-agent \
   teleport/teleport-kube-agent --values azure_access_agent.values.yaml
 ```
 
-Make sure that the Teleport agent pod is running. You should see one
+Make sure that the Teleport Agent pod is running. You should see one
 `teleport-azure-access-agent` pod with a single ready container:
 
 ```code

--- a/docs/pages/enroll-resources/application-access/introduction.mdx
+++ b/docs/pages/enroll-resources/application-access/introduction.mdx
@@ -21,9 +21,9 @@ If you are running applications on Kubernetes, you can [enroll them in your
 Teleport cluster automatically](../auto-discovery/kubernetes-applications/kubernetes-applications.mdx).
 
 Teleport protects applications through the Teleport Application Service, which
-is a Teleport agent service. For more information on agent services, read
+is a Teleport Agent service. For more information on agent services, read
 [Teleport Agent Architecture](../../reference/architecture/agents.mdx). You can also learn
-how to deploy a [pool of Teleport agents](../agents/introduction.mdx) to run
+how to deploy a [pool of Teleport Agents](../agents/introduction.mdx) to run
 multiple agent services.
 
 ## Getting started

--- a/docs/pages/enroll-resources/auto-discovery/auto-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/auto-discovery.mdx
@@ -10,7 +10,7 @@ these resources with no further configuration. This lets you decouple the need
 to protect your infrastructure resources from the work of deploying and managing
 them.
 
-The Discovery Service runs on [Teleport agents](../agents/introduction.mdx). It
+The Discovery Service runs on [Teleport Agents](../agents/introduction.mdx). It
 periodically queries cloud provider APIs to list resources in your
 infrastructure. It then reconciles these resources with Teleport resources
 registered on the Auth Service backend.

--- a/docs/pages/enroll-resources/database-access/database-access.mdx
+++ b/docs/pages/enroll-resources/database-access/database-access.mdx
@@ -15,9 +15,9 @@ Some of the things you can do with database access:
 - Capture database activity in the Teleport audit log.
 
 Teleport protects databases through the Teleport Database Service, which is a
-Teleport agent service. For more information on agent services, read [Teleport
+Teleport Agent service. For more information on agent services, read [Teleport
 Agent Architecture](../../reference/architecture/agents.mdx). You can also learn how to
-deploy a [pool of Teleport agents](../agents/introduction.mdx) to run multiple
+deploy a [pool of Teleport Agents](../agents/introduction.mdx) to run multiple
 agent services.
 
 ![Teleport Database Access Diagram](../../../img/database-access/architecture.svg)

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds.mdx
@@ -238,14 +238,14 @@ $ TELEPORT_VERSION="$(curl https://<Var name="example.teleport.sh:443" />/v1/web
 ```
 
 
-Install the Helm chart for Teleport agent services, `teleport-kube-agent`:
+Install the Helm chart for Teleport Agent services, `teleport-kube-agent`:
 
 ```code
 $ helm -n teleport-agent install teleport-kube-agent teleport/teleport-kube-agent \
   --values values.yaml --create-namespace --version $TELEPORT_VERSION
 ```
 
-Make sure that the Teleport agent pod is running. You should see one
+Make sure that the Teleport Agent pod is running. You should see one
 `teleport-kube-agent` pod with a single ready container:
 
 ```code

--- a/docs/pages/enroll-resources/database-access/enroll-managed-databases/oracle-exadata.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-managed-databases/oracle-exadata.mdx
@@ -271,7 +271,7 @@ Install the chart:
      -f values.yaml
    ```
 
-Make sure that the Teleport agent pod is running. You should see one
+Make sure that the Teleport Agent pod is running. You should see one
 `teleport-kube-agent` pod with a single ready container:
 
    ```code

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/clickhouse-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/clickhouse-self-hosted.mdx
@@ -174,7 +174,7 @@ Kubernetes Clusters.
 {/* Inlining docs/pages/includes/database-access/self-hosted-db-helm-install.mdx
 so we can use the Var component for the protocol*/}
 
-Install a Teleport agent into your Kubernetes Cluster with the Teleport Database
+Install a Teleport Agent into your Kubernetes Cluster with the Teleport Database
 Service configuration. 
 
 Create a file called `values.yaml` with the following content. Update <Var
@@ -243,7 +243,7 @@ $ helm install teleport-kube-agent teleport/teleport-kube-agent \
   -f values.yaml
 ```
 
-Make sure that the Teleport agent pod is running. You should see one
+Make sure that the Teleport Agent pod is running. You should see one
 `teleport-kube-agent` pod with a single ready container:
 
 ```code

--- a/docs/pages/enroll-resources/database-access/guides/ha.mdx
+++ b/docs/pages/enroll-resources/database-access/guides/ha.mdx
@@ -135,4 +135,4 @@ you're using to connect.
 
 - Get started by [connecting](guides.mdx) your database.
 - Review the [architecture](../../../reference/architecture/agents.mdx) of the Teleport Database
-  Service and other services that run on Teleport agents.
+  Service and other services that run on Teleport Agents.

--- a/docs/pages/enroll-resources/desktop-access/active-directory.mdx
+++ b/docs/pages/enroll-resources/desktop-access/active-directory.mdx
@@ -35,7 +35,7 @@ To complete the steps in this guide, verify your environment meets the following
   edition you use.
 
 - A Linux server to run the Teleport Windows Desktop Service.
-  You can use an existing server that runs the Teleport agent for other resources.
+  You can use an existing server that runs the Teleport Agent for other resources.
 
 - An Active Directory domain that is configured for LDAPS. Because Teleport requires an
   encrypted LDAP connection, you should verify that your domain uses Active Directory
@@ -777,7 +777,7 @@ To change the default domain policy:
 
 Each `windows_desktop_service` is designed to support connecting to hosts in a
 single Active Directory domain. If you have multiple independent domains, you
-can deploy multiple Teleport agents to service them.
+can deploy multiple Teleport Agents to service them.
 
 If you have multiple domains with a trust relationship between them, you can
 configure Teleport to perform PKI operations against one domain, while generating

--- a/docs/pages/enroll-resources/kubernetes-access/introduction.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/introduction.mdx
@@ -27,9 +27,9 @@ with your Teleport automatically. Read more about [Teleport
 auto-discovery](../auto-discovery/kubernetes/kubernetes.mdx).
 
 Teleport protects Kubernetes clusters through the Teleport Kubernetes Service,
-which is a Teleport agent service. For more information on agent services, read
+which is a Teleport Agent service. For more information on agent services, read
 [Teleport Agent Architecture](../../reference/architecture/agents.mdx). You can also learn
-how to deploy a [pool of Teleport agents](../agents/introduction.mdx) to run
+how to deploy a [pool of Teleport Agents](../agents/introduction.mdx) to run
 multiple agent services.
 
 ## Get started

--- a/docs/pages/enroll-resources/kubernetes-access/register-clusters/iam-joining.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/register-clusters/iam-joining.mdx
@@ -261,7 +261,7 @@ $ helm install teleport-agent teleport/teleport-kube-agent \
   --version (=teleport.version=)
 ```
 
-Make sure that the Teleport agent pod is running. You should see one Teleport
+Make sure that the Teleport Agent pod is running. You should see one Teleport
 agent pod pod with a single ready container:
 
 ```code

--- a/docs/pages/enroll-resources/kubernetes-access/troubleshooting.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/troubleshooting.mdx
@@ -186,7 +186,7 @@ $ helm install teleport-agent teleport/teleport-kube-agent \
   --version (=teleport.version=)
 ```
 
-Make sure that the Teleport agent pod is running. You should see one Teleport
+Make sure that the Teleport Agent pod is running. You should see one Teleport
 agent pod pod with a single ready container:
 
 ```code

--- a/docs/pages/enroll-resources/server-access/guides/vscode.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/vscode.mdx
@@ -13,7 +13,7 @@ This guide explains how to use Teleport and Visual Studio Code's remote SSH exte
 - OpenSSH client.
 - Visual Studio Code with the [Remote - SSH extension](https://code.visualstudio.com/docs/remote/ssh#_system-requirements)
   for the Remote - SSH extension.
-- One or more Teleport agents running the Teleport SSH Service. If you have not yet
+- One or more Teleport Agents running the Teleport SSH Service. If you have not yet
   done this, read the
   [Server Access Getting Started Guide](../getting-started.mdx) to learn how.
 

--- a/docs/pages/enroll-resources/server-access/introduction.mdx
+++ b/docs/pages/enroll-resources/server-access/introduction.mdx
@@ -20,7 +20,7 @@ Teleport server access is designed for the following kinds of scenarios:
 Teleport protects servers through the Teleport SSH Service, which is a Teleport
 agent service. For more information on agent services, read [Teleport Agent
 Architecture](../../reference/architecture/agents.mdx). You can also learn how to deploy a
-[pool of Teleport agents](../agents/introduction.mdx) to run multiple agent
+[pool of Teleport Agents](../agents/introduction.mdx) to run multiple agent
 services.
 
 ## Getting started

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -63,7 +63,7 @@ archives containing Teleport binaries. All installations include `teleport`,
 
 If you are starting out with Teleport, we recommend beginning with a [Teleport
 Cloud](https://goteleport.com/signup/) account. From there, the only Teleport
-components you need to deploy yourself are Teleport agents. You can deploy
+components you need to deploy yourself are Teleport Agents. You can deploy
 agents by:
 - Following the instructions in the Teleport Web UI at `/web/discover`, where
   you can select a resource to enroll in your Teleport cluster and retrieve an
@@ -71,7 +71,7 @@ agents by:
 - Using the example Terraform module for deploying agents in [Deploy Agents with
   Terraform](admin-guides/infrastructure-as-code/terraform-starter/enroll-resources.mdx).
 - Running the [one-line installation script](#one-line-installation-script) on
-  each Linux server where you want to install a Teleport agent.
+  each Linux server where you want to install a Teleport Agent.
 
 If you are running a self-hosted Teleport Enterprise cluster, read our guidance
 in [Deploying a High-Availability Teleport

--- a/docs/pages/ips.mdx
+++ b/docs/pages/ips.mdx
@@ -46,7 +46,7 @@ When this list is modified, we will provide at least two weeks notice by:
 If you are Teleport Enterprise customer and plan to employ this allowlist, please let us know by opening a support ticket.
 </Notice>
 
-Additionally, to receive Teleport agent updates, nodes must be able to reach the following domains via HTTPS during the update.
+Additionally, to receive Teleport Agent updates, nodes must be able to reach the following domains via HTTPS during the update.
 
 ```
 apt.releases.teleport.dev

--- a/docs/pages/reference/architecture/agent-update-management.mdx
+++ b/docs/pages/reference/architecture/agent-update-management.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agent Update Management 
-description: This chapter explains how Teleport agent automatic update is working.
+description: This chapter explains how Teleport Agent automatic update is working.
 ---
 
 While many Teleport resources [support agentless

--- a/docs/pages/reference/architecture/agents.mdx
+++ b/docs/pages/reference/architecture/agents.mdx
@@ -4,11 +4,11 @@ description: Describes the architecture that enables Teleport to securely proxy 
 tocDepth: 3
 ---
 
-**Teleport agents** route traffic to and from resources in your infrastructure.
+**Teleport Agents** route traffic to and from resources in your infrastructure.
 This guide describes the architecture that enables Teleport to securely manage
 traffic through this pathway.
 
-Teleport agents are running instances of the `teleport` binary, and can run on
+Teleport Agents are running instances of the `teleport` binary, and can run on
 any Linux platform (e.g., bare-metal, a Linux VM, a Docker container, or a pod
 in a Kubernetes cluster). It is up to Teleport administrators to deploy and
 manage agents, including on managed Teleport Enterprise accounts. 
@@ -40,7 +40,7 @@ listed above can then proxy resources enrolled by the Discovery Service.
 
 ## Components
 
-![Components of a Teleport agent deployment](../../../img/architecture/agent-architecture.png)
+![Components of a Teleport Agent deployment](../../../img/architecture/agent-architecture.png)
 
 A Teleport cluster where an administrator has enrolled resources involves the
 following components:
@@ -53,11 +53,11 @@ following components:
 - **[Teleport Auth Service](../architecture/authentication.mdx):** Serves as the
   cluster's certificate authority, handles user authentication/authorization and
   issues short-lived client certificates.
-- **Teleport agents:** Agents perform authentication against infrastructure
+- **Teleport Agents:** Agents perform authentication against infrastructure
   resources, route user traffic to those resources, and perform protocol
   parsing.
 - **Teleport client tools (`tsh`, Teleport Connect, and the Teleport Web UI):**
-  Connect to resources in your infrastructure through Teleport agents and the
+  Connect to resources in your infrastructure through Teleport Agents and the
   Teleport Proxy Service.
 - **Local proxies:** In some cases, `tsh` spins up local proxy servers that
   authenticate to Teleport and forward traffic from client tools (e.g., database
@@ -65,7 +65,7 @@ following components:
 - **Infrastructure resources:** Teleport can protect access to self-hosted
   infrastructure as well as infrastructure managed by a cloud provider.
 
-## Teleport agents to the Teleport Auth Service
+## Teleport Agents to the Teleport Auth Service
 
 The Teleport Auth Service runs a certificate authority that issues a host
 certificate to an agent when it joins the cluster for the first time. Read [Join
@@ -98,7 +98,7 @@ The Auth Service also generates a short-lived X.509 certificate signed by the
 cluster's host CA, with the client's identity and routing information for an
 infrastructure resource encoded in it.
 
-## Teleport agents to the Teleport Proxy Service
+## Teleport Agents to the Teleport Proxy Service
 
 In most cases, when an agent joins a Teleport cluster, it establishes an SSH
 reverse tunnel to the Proxy Service. As such, users do not need to have direct
@@ -118,7 +118,7 @@ agent.
 
 <Details title="Connecting to agents without reverse tunnels">
 
-It is possible to join Teleport agents to a cluster [through the Teleport Auth
+It is possible to join Teleport Agents to a cluster [through the Teleport Auth
 Service](../../enroll-resources/agents/join-services-to-your-cluster/join-token.mdx).
 Once an agent joins a cluster through the Teleport Auth Service, the Teleport
 Proxy Service dials the agent directly, without creating a reverse tunnel. This
@@ -144,7 +144,7 @@ self-hosted Teleport deployment.
 
 ## Agents to infrastructure resources
 
-Teleport agents route user traffic to and from resources in your infrastructure.
+Teleport Agents route user traffic to and from resources in your infrastructure.
 Agents authenticate with infrastructure resources using a technique available to
 the target resource, often using a form of public key cryptography. A
 non-exhaustive list of examples is below:
@@ -230,7 +230,7 @@ resources through agents:
 
 After retrieving [client credentials](#credentials-for-teleport-clients), these
 tools are authenticated to the Teleport Proxy Service and can send traffic
-through it to Teleport agents. The protocol that a client uses depends on the
+through it to Teleport Agents. The protocol that a client uses depends on the
 upstream resource. See [TLS Routing](./tls-routing.mdx) for how client tools
 perform protocol negotiation with the Teleport Proxy Service.
 
@@ -264,7 +264,7 @@ starts a local proxy before using a database client to send traffic to it.
 
 ## Submitting audit events
 
-Teleport agents connect to the Teleport Auth Service through the Teleport Proxy
+Teleport Agents connect to the Teleport Auth Service through the Teleport Proxy
 Service and submit audit events at various moments within the life cycle of a
 user session, including when the user signs in, connects to a resource,
 interacts with a resource, and signs out. Agents interpret the wire protocol

--- a/docs/pages/reference/architecture/proxy-peering.mdx
+++ b/docs/pages/reference/architecture/proxy-peering.mdx
@@ -3,7 +3,7 @@ title: Proxy Peering
 description: How Teleport implements more efficient networking with Proxy Peering.
 ---
 
-Proxy Peering enables Teleport agents to be reachable without connecting to
+Proxy Peering enables Teleport Agents to be reachable without connecting to
 every Teleport Proxy Service. This allows Teleport Proxy instances to scale
 horizontally without increasing the number of connections created by agents.
 
@@ -12,7 +12,7 @@ horizontally without increasing the number of connections created by agents.
   Kubernetes, Database, Application, or Desktop Services.
 </Admonition>
 
-By default, Teleport agents need to create a reverse tunnel to every Teleport Proxy
+By default, Teleport Agents need to create a reverse tunnel to every Teleport Proxy
 to ensure a client is able to reach every agent. With Proxy Peering this is no
 longer a requirement. When Proxy Peering is enabled agents will automatically
 change their behavior to connect to the configured number of Teleport Proxy

--- a/docs/pages/reference/cloud-faq.mdx
+++ b/docs/pages/reference/cloud-faq.mdx
@@ -197,7 +197,7 @@ Teleport Cloud version server for automatic agent updates. With automatic agent
 updates, agents periodically check the version server for new releases and
 update the software when new versions are found.
 
-If you enroll in automatic agent updates, Teleport agents are automatically
+If you enroll in automatic agent updates, Teleport Agents are automatically
 updated after your Teleport cluster is updated during your scheduled maintenance
 period. For more information, read the [Automatic Agent
 Updates](../upgrading/automatic-agent-updates.mdx) guide.

--- a/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
@@ -3,7 +3,7 @@ title: teleport-kube-agent Chart Reference
 description: Values that can be set using the teleport-kube-agent Helm chart
 ---
 
-The `teleport-kube-agent` Helm chart is used to configure a Teleport agent that
+The `teleport-kube-agent` Helm chart is used to configure a Teleport Agent that
 runs in a remote Kubernetes cluster to provide access to resources in your
 infrastructure.
 

--- a/docs/pages/reference/networking.mdx
+++ b/docs/pages/reference/networking.mdx
@@ -227,7 +227,7 @@ Read more in our [TLS Routing](architecture/tls-routing.mdx) guide.
 
 ### Agent ports
 
-Teleport agents dial the Teleport Proxy Service to establish a reverse tunnel.
+Teleport Agents dial the Teleport Proxy Service to establish a reverse tunnel.
 Client traffic flows via the Proxy Service to the agent, and the agent forwards
 traffic to resources in your infrastructure.
 

--- a/docs/pages/upgrading/automatic-agent-updates.mdx
+++ b/docs/pages/upgrading/automatic-agent-updates.mdx
@@ -18,17 +18,17 @@ Teleport supports automatic agent updates for systemd-based Linux distributions
 using `apt`, `yum`, and `zypper` package managers, as well as Kubernetes
 clusters. 
 
-This guide explains how to enable automatic updates for Teleport agents on
+This guide explains how to enable automatic updates for Teleport Agents on
 Teleport Enterprise clusters, including both self-hosted and cloud-hosted
 clusters.
 
 ## How it works
 
 When automatic updates are enabled, a Teleport updater is installed alongside
-each Teleport agent. The updater communicates with the Teleport Proxy Service to
+each Teleport Agent. The updater communicates with the Teleport Proxy Service to
 determine when an update is available. When an update is available, the updater
-will update the Teleport agent during the next maintenance window. However, if a
-critical update is available, the Teleport agent will be updated outside the
+will update the Teleport Agent during the next maintenance window. However, if a
+critical update is available, the Teleport Agent will be updated outside the
 regular maintenance window.
 
 ## Prerequisites
@@ -38,7 +38,7 @@ regular maintenance window.
   Reference](upgrading-reference.mdx) to read about manual updates.
 - Familiarity with the [Upgrading Compatibility Overview](./overview.mdx) guide,
   which describes the sequence in which to upgrade components in your cluster.
-- Teleport agents that are not yet enrolled in automatic updates.
+- Teleport Agents that are not yet enrolled in automatic updates.
 - (!docs/pages/includes/tctl-tsh-prerequisite.mdx!)
 - (!docs/pages/includes/tctl.mdx!)
 
@@ -324,10 +324,10 @@ This section assumes that the name of your `teleport-kube-agent` release is
 
 ## Troubleshooting
 
-Teleport agents are not updated immediately when a new version of Teleport is
+Teleport Agents are not updated immediately when a new version of Teleport is
 released, and agent updates can lag behind the cluster by a few days.
 
-If the Teleport agent has not been automatically updating for several weeks, you
+If the Teleport Agent has not been automatically updating for several weeks, you
 can consult the updater logs to help troubleshoot the problem:
 
 ```code

--- a/docs/pages/upgrading/overview.mdx
+++ b/docs/pages/upgrading/overview.mdx
@@ -46,7 +46,7 @@ Teleport cluster:
    Service. Proxy Service instances are stateless and can be upgraded in any
    sequence or at the same time.
 
-1. Upgrade your Teleport agents to the same version number as the Auth Service.
+1. Upgrade your Teleport Agents to the same version number as the Auth Service.
    You can upgrade resource agents in any sequence or at the same time.
    
    If you are upgrading more then one version number, repeat these steps until

--- a/docs/pages/upgrading/upgrading-reference.mdx
+++ b/docs/pages/upgrading/upgrading-reference.mdx
@@ -31,13 +31,13 @@ server, the updater is an executable script called `teleport-upgrade`.
 ### `teleport-upgrade` commands
 
 The `teleport-upgrade` tool provides some basic commands to verify and perform an
-update of the Teleport agent.
+update of the Teleport Agent.
 
 ```code
 $ teleport-upgrade help
 USAGE: /usr/sbin/teleport-upgrade <command>
 
-Tool for automatic upgrades of Teleport agents.
+Tool for automatic upgrades of Teleport Agents.
 
 Commands:
   run           check for and potentially apply a teleport upgrade.
@@ -253,11 +253,11 @@ spec
 
 This section shows you how to upgrade Teleport manually. You can perform manual
 upgrades on Teleport Auth Service and Proxy Service instances running in
-self-hosted clusters, as well as all Teleport agents.
+self-hosted clusters, as well as all Teleport Agents.
 
-### Teleport agents
+### Teleport Agents
 
-1. Identify the latest compatible Teleport agent version by querying the
+1. Identify the latest compatible Teleport Agent version by querying the
    `webapi` endpoint of the Teleport Proxy Service, replacing 
    <Var name="teleport.example.com:443" /> with the host and port of your
    Teleport account or Teleport Proxy Service:
@@ -389,7 +389,7 @@ your `teleport-cluster` release is called `teleport-cluster`.
 1. Once you have completed this guide and upgraded the cluster, you can
    configure your cluster for high availability again.
 
-### Teleport agents running on Kubernetes
+### Teleport Agents running on Kubernetes
 
 The instructions in this section assume that you have configured the
 `teleport-kube-agent` Helm chart with a values file called `values.yaml`, and

--- a/docs/pages/upgrading/upgrading.mdx
+++ b/docs/pages/upgrading/upgrading.mdx
@@ -11,7 +11,7 @@ understand how to upgrade components in your Teleport cluster while ensuring
 compatibility between all components.
 
 If you have a Teleport Enterprise (Cloud) account, you **must** [set up automatic
-Teleport agent updates](automatic-agent-updates.mdx) to ensure that
+Teleport Agent updates](automatic-agent-updates.mdx) to ensure that
 the version of Teleport running on agents is always compatible with that of the
 Teleport cluster. You can also set up automatic agent upgrades in a self-hosted
 Enterprise cluster.


### PR DESCRIPTION
Backports #52483

- Fix Var components that only have a single instance on a page
- Replace "Teleport agent" with "Teleport Agent"