### PR TITLE
[v17][vnet] docs updates

### DIFF
--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -33,14 +33,26 @@ $ tar -xf  teleport-connect-(=teleport.version=)-linux-*.tar.gz
 Download and run the installer `.exe` file. It will install and open Teleport Connect without
 further user input.
 
+The installer requires administrator privileges in order to set up a Windows
+service used by the [VNet](#connecting-to-tcp-apps-with-vnet) feature.
+If you run the installer as a regular user it will automatically create a UAC
+(User Account Control) prompt for the necessary permissions.
+
 Repeat the process with newer versions to upgrade.
 
-A silent installation can be performed by running the installer with the `/S` flag. This will hide
-the progress bar and skip the launch of the app after the installation is complete.
+A silent installation can be performed by running the installer as an
+administrator with the `/S` flag. This will hide the progress bar and skip the
+launch of the app after the installation is complete.
 
 ```code
 $ "Teleport Connect Setup-(=teleport.version=).exe" /S
 ```
+
+In version 17.3.0+ Connect is installed per-machine.
+In older versions Connect was installed only for the user running the installer.
+When upgrading to 17.3.0+ from an older version, the installer will
+automatically handle the migration to a per-machine installation.
+
 </TabItem>
 </Tabs>
 
@@ -170,11 +182,13 @@ authentication data, you will have to log in to the Web UI before accessing an a
 Alternatively, you can look for the application in the search bar and press `Enter` to launch it in
 the browser.
 
-### Connecting to TCP apps with VNet on macOS
+### Connecting to TCP apps with VNet
 
-VNet is a virtual network emulation tool available in Teleport Connect. It enables any program on
-your computer to connect to TCP applications protected by Teleport, with no extra changes required
-to the program itself. It removes the need to manually create tunnels for TCP applications.
+VNet is a virtual network emulation tool available in Teleport Connect on macOS
+and Windows. It enables any program on your computer to connect to TCP
+applications protected by Teleport, with no extra changes required
+to the program itself. It removes the need to manually create tunnels for TCP
+applications.
 
 This is the recommended way of connecting to TCP apps.
 
@@ -199,12 +213,12 @@ is not yet available on your system.
   can also press `Ctrl+Shift+T/Cmd+T` to achieve the same result.
 1. Look for the application you wish to connect to.
   - For TCP applications, click the Connect button.
-    - On macOS, click the three dots instead and select "Connect to local port".
+    - On macOS and Windows, click the three dots instead and select "Connect to local port".
   - For web applications, click the three dots next to the Launch button and select "Set up
     connection".
 
-Alternatively, on Windows and Linux you can look for a TCP application in the search bar and press
-`Enter` to set up a connection to it.
+Alternatively, on Linux you can look for a TCP application in the search bar and
+press `Enter` to set up a connection to it.
 
 A new tab will open with a new connection established between your device and the application.
 
@@ -618,7 +632,7 @@ The app version can be found under Help -> About Teleport Connect.
 To get more detailed logs, open Teleport Connect from the Command Prompt with the `--connect-debug` flag:
 
 ```code
-$ "%LocalAppData%\Programs\teleport-connect\Teleport Connect.exe" --connect-debug
+$ "%PROGRAMFILES%\Teleport Connect\Teleport Connect.exe" --connect-debug
 ````
 </TabItem>
 </Tabs>
@@ -655,7 +669,7 @@ $ teleport-connect --insecure
 From the Command Prompt, open Teleport Connect with the `--insecure` flag:
 
 ```code
-$ "%LocalAppData%\Programs\teleport-connect\Teleport Connect.exe" --insecure
+$ "%PROGRAMFILES%\Teleport Connect\Teleport Connect.exe" --insecure
 ````
 </TabItem>
 </Tabs>

--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -631,9 +631,16 @@ The app version can be found under Help -> About Teleport Connect.
 
 To get more detailed logs, open Teleport Connect from the Command Prompt with the `--connect-debug` flag:
 
+In version 17.3.0+:
 ```code
 $ "%PROGRAMFILES%\Teleport Connect\Teleport Connect.exe" --connect-debug
 ````
+
+In older versions:
+```code
+$ "%LOCALAPPDATA%\Programs\teleport-connect\Teleport Connect.exe" --connect-debug
+````
+
 </TabItem>
 </Tabs>
 
@@ -668,9 +675,16 @@ $ teleport-connect --insecure
 <TabItem label="Windows">
 From the Command Prompt, open Teleport Connect with the `--insecure` flag:
 
+In version 17.3.0+:
 ```code
 $ "%PROGRAMFILES%\Teleport Connect\Teleport Connect.exe" --insecure
 ````
+
+In older versions:
+```code
+$ "%LOCALAPPDATA%\Programs\teleport-connect\Teleport Connect.exe" --insecure
+````
+
 </TabItem>
 </Tabs>
 

--- a/docs/pages/connect-your-client/vnet.mdx
+++ b/docs/pages/connect-your-client/vnet.mdx
@@ -13,13 +13,21 @@ Teleport. Underneath, VNet authenticates the connection with your credentials, u
 routing technology](../reference/architecture/tls-routing.mdx) as `tsh proxy app`. This is all done
 client-side – VNet sets up a local DNS name server and a virtual network device.
 
-VNet is available on macOS in Teleport Connect and tsh, with plans for future Windows and Linux
-versions.
+VNet is available on macOS and Windows in Teleport Connect and tsh, with plans
+for Linux support in a future version.
 
 ## Prerequisites
 
+<Tabs>
+<TabItem label="macOS">
 - A client machine running macOS Ventura (13.0) or higher.
 - [Teleport Connect](teleport-connect.mdx), version 16.0.0 or higher.
+</TabItem>
+<TabItem label="Windows">
+- A client machine running Windows 10 or higher.
+- [Teleport Connect](teleport-connect.mdx), version 17.3.0 or higher.
+</TabItem>
+</Tabs>
 
 ## Step 1/3. Start Teleport Connect
 
@@ -33,12 +41,14 @@ have `tcp://` as the protocol in their addresses.
 Click "Connect" next to the TCP app. This starts VNet if it's not already running. Alternatively,
 you can start VNet through the connection list in the top left.
 
+<Details title="First launch on macOS">
 During the first launch, macOS will prompt you to enable a background item for tsh.app. VNet needs
 this background item in order to configure DNS on your device. To enable the background item, either
 interact with the system notification or go to System Settings > General > Login Items and look for
 tsh.app under "Allow in the Background".
 
 ![VNet starting up](../../img/use-teleport/vnet-starting@2x.png)
+</Details>
 
 ## Step 3/3. Connect
 

--- a/docs/pages/includes/uninstall-teleport-connect-windows.mdx
+++ b/docs/pages/includes/uninstall-teleport-connect-windows.mdx
@@ -1,3 +1,3 @@
   You can uninstall Teleport Connect from the "Apps and Features" section of the Control Panel.
 
-  For reference, Teleport Connect binaries are installed to `%LOCALAPPDATA%\Programs\teleport-connect`.
+  For reference, Teleport Connect binaries are installed to `%PROGRAMFILES%\Teleport Connect`.

--- a/docs/pages/includes/uninstall-teleport-connect-windows.mdx
+++ b/docs/pages/includes/uninstall-teleport-connect-windows.mdx
@@ -1,3 +1,5 @@
   You can uninstall Teleport Connect from the "Apps and Features" section of the Control Panel.
 
-  For reference, Teleport Connect binaries are installed to `%PROGRAMFILES%\Teleport Connect`.
+  For reference, Teleport Connect binaries are installed to
+  `%PROGRAMFILES%\Teleport Connect` in version 17.3.0+ and
+  `%LOCALAPPDATA%\Programs\teleport-connect` in older versions.


### PR DESCRIPTION
Backport #52371 to branch/v17

The second commit adds mentions of the connect path used before we switch to a per-machine install in 17.3.0