### PR TITLE
docs: update Teleport port to 443 in db examples

### DIFF
--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/postgres-redshift.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/postgres-redshift.mdx
@@ -55,7 +55,7 @@ Assign `CLUSTER_URI` to the domain name and port of the cluster:
 $ sudo teleport db configure create \
    -o file \
    --name="redshift-postgres" \
-   --proxy=teleport.example.com:3080 \
+   --proxy=teleport.example.com:443 \
    --protocol=postgres \
    --token=/tmp/token \
    --uri=${CLUSTER_URI?}

--- a/docs/pages/enroll-resources/database-access/enroll-azure-databases/azure-redis.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-azure-databases/azure-redis.mdx
@@ -64,7 +64,7 @@ $ sudo teleport db configure create \
 ```code
 $ sudo teleport db configure create \
   -o file \
-  --proxy=teleport.example.com:3080 \
+  --proxy=teleport.example.com:443 \
   --token=/tmp/token \
   --azure-redis-discovery=eastus
 ```

--- a/docs/pages/reference/agent-services/database-access-reference/cli.mdx
+++ b/docs/pages/reference/agent-services/database-access-reference/cli.mdx
@@ -27,7 +27,7 @@ Starts Teleport Database Service.
 ```code
 $ teleport db start \
     --token=/path/to/token \
-    --auth-server=proxy.example.com:3080 \
+    --auth-server=proxy.example.com:443 \
     --name=example \
     --protocol=postgres \
     --uri=postgres.example.com:5432
@@ -80,7 +80,7 @@ Creates a sample Database Service configuration.
 $ teleport db configure create --rds-discovery=us-west-1 --rds-discovery=us-west-2
 $ teleport db configure create \
   --token=/tmp/token \
-  --proxy=proxy.example.com:3080 \
+  --proxy=proxy.example.com:443 \
   --name=example \
   --protocol=postgres \
   --uri=postgres://postgres.example.com:5432 \


### PR DESCRIPTION
Updates ports to `443` from 3080 to keep consistent with other examples.