### PR TITLE
Adjust copy in VNet panel to better fit new panel width

### DIFF
--- a/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.tsx
@@ -104,8 +104,8 @@ export const VnetSliderStep = (props: StepComponentProps) => {
           ) : (
             <Flex flexDirection="column" gap={1}>
               <Text>
-                VNet enables any program to connect to TCP applications
-                protected by Teleport.
+                VNet enables any program to connect to TCP apps protected by
+                Teleport.
               </Text>
               <Text>
                 Start VNet and connect to any TCP app over its public address –


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="586" alt="before" src="https://github.com/user-attachments/assets/6462f38b-cc1d-4c63-8984-fc99e1d72e1c" /> | <img width="586" alt="after" src="https://github.com/user-attachments/assets/bd225f0f-e771-4470-8f62-5fbac121ebef" /> |

The panel width was adjusted in #52213 to account for the new diagnostic alert.

Before this change, "applications" would be shifted to the next line, creating a lot of empty space, so I shortened it to "apps".