### PR TITLE
Improve perf on backend key validation

### DIFF
--- a/lib/backend/sanitize.go
+++ b/lib/backend/sanitize.go
@@ -20,8 +20,6 @@ package backend
 
 import (
 	"context"
-	"regexp"
-	"strings"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -31,9 +29,28 @@ import (
 // errorMessage is the error message to return when invalid input is provided by the caller.
 const errorMessage = "special characters are not allowed in resource names, please use name composed only from characters, hyphens, dots, and plus signs: %q"
 
-// allowPattern is the pattern of allowed characters for each key within
-// the path.
-var allowPattern = regexp.MustCompile(`^[0-9A-Za-z@_:.\-/+]*$`)
+// isValidByte checks if the byte is a valid character for a key.
+func isValidByte(b byte) bool {
+	switch b {
+	case
+		// Digits
+		'0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+
+		// Lowercase letters
+		'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+		'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+
+		// Uppercase letters
+		'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+		'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+
+		// Allowed symbols
+		'@', '_', ':', '.', '-', '+':
+		return true
+	default:
+		return false
+	}
+}
 
 // IsKeySafe checks if the passed in key conforms to whitelist
 func IsKeySafe(key Key) bool {
@@ -48,12 +65,10 @@ func IsKeySafe(key Key) bool {
 			return key.exactKey && i == len(components)-1
 		}
 
-		if strings.Contains(k, string(Separator)) {
-			return false
-		}
-
-		if !allowPattern.MatchString(k) {
-			return false
+		for _, b := range []byte(k) {
+			if !isValidByte(b) {
+				return false
+			}
 		}
 	}
 	return true

--- a/lib/backend/sanitize.go
+++ b/lib/backend/sanitize.go
@@ -29,8 +29,8 @@ import (
 // errorMessage is the error message to return when invalid input is provided by the caller.
 const errorMessage = "special characters are not allowed in resource names, please use name composed only from characters, hyphens, dots, and plus signs: %q"
 
-// isValidByte checks if the byte is a valid character for a key.
-func isValidByte(b byte) bool {
+// isValidKeyByte checks if the byte is a valid character for a key.
+func isValidKeyByte(b byte) bool {
 	switch b {
 	case
 		// Digits
@@ -66,7 +66,7 @@ func IsKeySafe(key Key) bool {
 		}
 
 		for _, b := range []byte(k) {
-			if !isValidByte(b) {
+			if !isValidKeyByte(b) {
 				return false
 			}
 		}

--- a/lib/backend/sanitize_test.go
+++ b/lib/backend/sanitize_test.go
@@ -139,6 +139,38 @@ func TestSanitize(t *testing.T) {
 	}
 }
 
+func BenchmarkIsKeySafe(b *testing.B) {
+	keys := []Key{
+		NewKey("a-b", "c:d", ".e_f", "01"),
+		NewKey("namespaces", "", "params"),
+		NewKey("namespaces", ".."),
+		NewKey("namespaces", "..", "params"),
+		NewKey("namespaces", "..params"),
+		NewKey("namespaces", "."),
+		NewKey("namespaces", ".", "params"),
+		NewKey("namespaces", ".params"),
+		NewKey(".."),
+		NewKey("..params"),
+		NewKey("..", "params"),
+		NewKey("."),
+		NewKey(".params"),
+		NewKey(".", "params"),
+		RangeEnd(NewKey("a-b", "c:d", ".e_f", "01")),
+		RangeEnd(NewKey("")),
+		RangeEnd(NewKey("Malformed \xf0\x90\x28\xbc UTF8")),
+		NewKey("test+subaddr@example.com"),
+		NewKey("xyz"),
+		NewKey("@@"),
+		NewKey("@_:.-+"),
+	}
+
+	for b.Loop() {
+		for _, key := range keys {
+			IsKeySafe(key)
+		}
+	}
+}
+
 type nopBackend struct{}
 
 func (n *nopBackend) GetName() string {


### PR DESCRIPTION
Replacing the regexp with a comparison gets us much faster validations:

```
> go test -benchmem '-run=^$' -bench '^BenchmarkIsKeySafe' github.com/gravitational/teleport/lib/backend
goos: darwin
goarch: arm64
pkg: github.com/gravitational/teleport/lib/backend
cpu: Apple M3 Pro
BenchmarkIsKeySafeOld-12          376246              3150 ns/op             608 B/op         20 allocs/op
BenchmarkIsKeySafeNew-12         1872952               637.6 ns/op           608 B/op         20 allocs/op
PASS
ok      github.com/gravitational/teleport/lib/backend   2.966s
```

Co-authored-by: Edoardo Spadolini <edoardo.spadolini@goteleport.com>