### PR TITLE
Clear role diff attempt on role editor close

### DIFF
--- a/web/packages/teleport/src/Roles/Roles.tsx
+++ b/web/packages/teleport/src/Roles/Roles.tsx
@@ -65,6 +65,7 @@ type RoleDiffProps = {
   // TODO(bl-nero): Make this property required once the Enterprise code is
   // updated.
   roleDiffAttempt?: Attempt<unknown>;
+  clearRoleDiffAttempt?: () => void;
 };
 
 export type RolesProps = {
@@ -239,7 +240,10 @@ export function Roles(props: State & RolesProps) {
             open={
               resources.status === 'creating' || resources.status === 'editing'
             }
-            onClose={resources.disregard}
+            onClose={() => {
+              resources.disregard();
+              props.roleDiffProps?.clearRoleDiffAttempt();
+            }}
             resources={resources}
             onSave={handleSave}
             roleDiffProps={props.roleDiffProps}


### PR DESCRIPTION
This fixes an issue where someone could see stale data when attempting to create a new role after editing a previous one