### PR TITLE
Docs: Move creating Okta SAML app to include

### DIFF
--- a/docs/pages/admin-guides/access-controls/sso/okta.mdx
+++ b/docs/pages/admin-guides/access-controls/sso/okta.mdx
@@ -81,67 +81,7 @@ In this section we will create an application in the Okta dashboard to allow our
 Teleport cluster to access Okta as an IdP provider. We'll also locate the
 address that Okta uses to provides their IdP metadata to Teleport.
 
-First, create a SAML 2.0 Web App in Okta:
-
-From the main navigation menu, select **Applications** -> **Applications**, and click
-**Create App Integration**. Select SAML 2.0, then click **Next**.
-
-![Create APP](../../../../img/sso/okta/okta-saml-1.png)
-
-On the next screen (**General Settings**), provide a name and optional logo for
-your new app, then click **Next**. This will bring you to the **Configure SAML** section.
-
-### Configure the App
-
-Provide the following values to their respective fields:
-
-#### General
-
-- Single sign on URL: `https://<cluster-url>:<port>/v1/webapi/saml/acs/okta`
-- Audience URI (SP Entity ID): <nobr>`https://<cluster-url>:<port>/v1/webapi/saml/acs/okta`</nobr>
-- Name ID format `EmailAddress`
-- Application username `Okta username`
-
-Replace `<cluster-url>` with your Teleport Proxy Service address or Enterprise
-Cloud tenant (e.g. `mytenant.teleport.sh`). Replace `<port>` with your Proxy
-Service listening port (`443` by default).
-
-#### Attribute Statements
-
-- Name: `username`  | Name format: `Unspecified` | Value: `user.login`
-
-#### Group Attribute Statements
-
-We will map our Okta groups to SAML attribute statements (special signed metadata
-exposed via a SAML XML response), so that Teleport can discover a user's group
-membership and assign matching roles.
-
-- Name: `groups` | Name format: `Unspecified`
-- Filter: `Matches regex` |  `.*`
-
-The configuration page should now look like this:
-
-![Configure APP](../../../../img/sso/okta/setup-redirection.png)
-
-<Admonition type="warning" >
-The "Matches regex" filter requires the literal string `.*` in order to match all
-content from the group attribute statement.
-</Admonition>
-
-<Admonition type="tip">
-Notice that we have set "NameID" to the email format and mapped the groups with
-a wildcard regex in the Group Attribute statements. We have also set the "Audience"
-and SSO URLs to the same value. This is so Teleport can read and use Okta users'
-email addresses to create their usernames in Teleport, instead of relying on additional
-name fields.
-</Admonition>
-
-Once you've filled the required fields, click **Next**, then finish the app creation wizard.
-
-From the **Assignments** tab of the new application page, click **Assign**.
-Assign the newly created groups access to the app.
-
-![Configure APP](../../../../img/sso/okta/okta-saml-3.1.png)
+(!docs/pages/includes/okta-create-saml-connector.mdx hosted="true"!)
 
 ### Save IdP metadata path
 

--- a/docs/pages/includes/okta-create-saml-connector.mdx
+++ b/docs/pages/includes/okta-create-saml-connector.mdx
@@ -1,0 +1,61 @@
+### Create Okta SAML 2.0 App
+
+From the main navigation menu, select **Applications** -> **Applications**, and click
+**Create App Integration**. Select SAML 2.0, then click **Next**.
+
+![Create APP](../../img/sso/okta/okta-saml-1.png)
+
+On the next screen (**General Settings**), provide a name and optional logo for
+your new app, then click **Next**. This will bring you to the **Configure SAML** section.
+
+### Configure the App
+
+Provide the following values to their respective fields:
+
+#### General
+
+- Single sign on URL: `https://<cluster-url>:<port>/v1/webapi/saml/acs/okta`
+- Audience URI (SP Entity ID): <nobr>`https://<cluster-url>:<port>/v1/webapi/saml/acs/okta`</nobr>
+- Name ID format `EmailAddress`
+- Application username `Okta username`
+
+Replace `<cluster-url>` with your Teleport Proxy Service address or Enterprise
+Cloud tenant (e.g. `mytenant.teleport.sh`). Replace `<port>` with your Proxy
+Service listening port (`443` by default).
+
+#### Attribute Statements
+
+- Name: `username`  | Name format: `Unspecified` | Value: `user.login`
+
+#### Group Attribute Statements
+
+We will map our Okta groups to SAML attribute statements (special signed metadata
+exposed via a SAML XML response), so that Teleport can discover a user's group
+membership and assign matching roles.
+
+- Name: `groups` | Name format: `Unspecified`
+- Filter: `Matches regex` |  `.*`
+
+The configuration page should now look like this:
+
+![Configure APP](../../img/sso/okta/setup-redirection.png)
+
+<Admonition type="warning" >
+The "Matches regex" filter requires the literal string `.*` in order to match all
+content from the group attribute statement.
+</Admonition>
+
+<Admonition type="tip">
+Notice that we have set "NameID" to the email format and mapped the groups with
+a wildcard regex in the Group Attribute statements. We have also set the "Audience"
+and SSO URLs to the same value. This is so Teleport can read and use Okta users'
+email addresses to create their usernames in Teleport, instead of relying on additional
+name fields.
+</Admonition>
+
+Once you've filled the required fields, click **Next**, then finish the app creation wizard.
+
+From the **Assignments** tab of the new application page, click **Assign**.
+Assign the newly created groups access to the app.
+
+![Configure APP](../../img/sso/okta/okta-saml-3.1.png)


### PR DESCRIPTION
So it can be (re)used in the new Okta enrolment flow page.

**Note to reviewers:** this is almost 1:1 copy. Only the first line changed to `### Create Okta SAML 2.0 App` and image links were adapted to the new path.