### PR TITLE
Improve perf on label key validation

### DIFF
--- a/api/types/common/common.go
+++ b/api/types/common/common.go
@@ -16,9 +16,11 @@ limitations under the License.
 
 package common
 
-// IsValidLabelKey checks if the supplied string matches the
-// label key regexp.
+// IsValidLabelKey checks if the supplied string is a valid label key.
 func IsValidLabelKey(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
 	for _, b := range []byte(s) {
 		if !isValidLabelKeyByte(b) {
 			return false

--- a/api/types/common/common.go
+++ b/api/types/common/common.go
@@ -16,22 +16,43 @@ limitations under the License.
 
 package common
 
-import "regexp"
+// IsValidLabelKey checks if the supplied string matches the
+// label key regexp.
+func IsValidLabelKey(s string) bool {
+	for _, b := range []byte(s) {
+		if !isValidLabelKeyByte(b) {
+			return false
+		}
+	}
+	return true
+}
 
-// LabelPattern is a regexp that describes a valid label key. In this case,
-// valid label keys can consist of alphanumeric characters, forward slashes,
+// isValidLabelKeyByte checks if the byte is a valid character for a label key.
+// Valid label keys can consist of alphanumeric characters, forward slashes,
 // periods, underscores, colons, stars, and dashes. Some valid label examples:
 //
 // label
 // teleport.dev/fine-grained-access
 // teleport.dev/managed:internal_access
 // all-objects*
-const LabelPattern = `^[a-zA-Z/.0-9_:*-]+$`
+func isValidLabelKeyByte(b byte) bool {
+	switch b {
+	case
+		// Digits
+		'0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
 
-var validLabelKey = regexp.MustCompile(LabelPattern)
+		// Lowercase letters
+		'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+		'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
 
-// IsValidLabelKey checks if the supplied string matches the
-// label key regexp.
-func IsValidLabelKey(s string) bool {
-	return validLabelKey.MatchString(s)
+		// Uppercase letters
+		'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+		'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+
+		// Allowed symbols
+		'/', '.', '_', ':', '*', '-':
+		return true
+	default:
+		return false
+	}
 }

--- a/api/types/common/common_test.go
+++ b/api/types/common/common_test.go
@@ -63,3 +63,19 @@ func TestIsValidLabelKey(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkIsValidLabelKey(b *testing.B) {
+	var labelsForBenchmark = []string{
+		"labelLABEL1234",
+		"label-LABEL12__34",
+		"label.:-LABEL12__34",
+		"label/.:-LABEL12__34*",
+		"label^/.:-LABEL12__34*",
+	}
+
+	for b.Loop() {
+		for _, s := range labelsForBenchmark {
+			IsValidLabelKey(s)
+		}
+	}
+}

--- a/api/types/common/common_test.go
+++ b/api/types/common/common_test.go
@@ -73,7 +73,7 @@ func BenchmarkIsValidLabelKey(b *testing.B) {
 		"label^/.:-LABEL12__34*",
 	}
 
-	for b.Loop() {
+	for i := 0; i < b.N; i++ {
 		for _, s := range labelsForBenchmark {
 			IsValidLabelKey(s)
 		}

--- a/api/types/common/common_test.go
+++ b/api/types/common/common_test.go
@@ -65,7 +65,7 @@ func TestIsValidLabelKey(t *testing.T) {
 }
 
 func BenchmarkIsValidLabelKey(b *testing.B) {
-	var labelsForBenchmark = []string{
+	labelsForBenchmark := []string{
 		"labelLABEL1234",
 		"label-LABEL12__34",
 		"label.:-LABEL12__34",

--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -534,8 +534,7 @@ func MatchKinds(resource ResourceWithLabels, kinds []string) bool {
 	}
 }
 
-// IsValidLabelKey checks if the supplied string matches the
-// label key regexp.
+// IsValidLabelKey checks if the supplied string is a valid label key.
 func IsValidLabelKey(s string) bool {
 	return common.IsValidLabelKey(s)
 }


### PR DESCRIPTION
```
> go test -benchmem '-run=^$' -bench '^BenchmarkIsValidLabelKey' github.com/gravitational/teleport/api/types/common
goos: darwin
goarch: arm64
pkg: github.com/gravitational/teleport/api/types/common
cpu: Apple M3 Pro
BenchmarkIsValidLabelKeyNew-12          16505014                72.53 ns/op            0 B/op          0 allocs/op
BenchmarkIsValidLabelKeyOld-12           1333614               898.9 ns/op             0 B/op          0 allocs/op
PASS
ok      github.com/gravitational/teleport/api/types/common      2.639s
```