### PR TITLE
Update billing metrics doc with MWI information

### DIFF
--- a/docs/pages/usage-billing.mdx
+++ b/docs/pages/usage-billing.mdx
@@ -137,22 +137,23 @@ The Machine and Workload Identity (MWI) metric is an aggregate of
 * [Bot Instances](reference/architecture/machine-id-architecture.mdx#joining-and-authentication)
 * [SPIFFE IDs](enroll-resources/workload-identity/spiffe.mdx#spiffe-ids-and-trust-domains)
 
-We aggregate Bots and Bot Instances during each day on an hourly basis, and take an hourly average
-to compute a daily Bot and Bot Instance count. Then we average the daily Bot and Bot Instance count
-over a monthly period, which starts on the subscription start date and ends on each monthly anniversary
-thereafter.
+We aggregate Bots, Bot Instances and unique SPIFFE IDs during each day on an hourly basis, and take
+an hourly average to compute a daily Bot, Bot Instance and SPIFFE ID count. Then we average the daily
+counts over a monthly period, which starts on the subscription start date and ends on each monthly
+anniversary thereafter.
 
-If you recreate a single Bot more than once an hour, this will affect the
+If you recreate a single Bot or Bot Instance more than once an hour, this will affect the
 hourly average. For example, if you were to create then delete 10 Bots three
 times in one hour, Teleport would display 10 Bots at any given time. However,
 for the entire hour, Teleport would report 30 Bots.
 
-For SPIFFE IDs, we count the number of unique, active SPIFFE IDs used in the billing period.
-Unique means that we only count a SPIFFE ID once, even if it is used multiple times, and 
-active means it was issued to and used by a workload or user in the billing period.
+For SPIFFE IDs, unique means that we only count a SPIFFE ID once during the calculation period,
+even if it is used for multiple services. For example, if ten services running 24 hours per day
+share the ID `spiffe://mydomain.cloud.gravitational.io/web-service`, Teleport would report that 
+as one SPIFFE ID for billing.
 
-The sum of your calculated Bots and Bot Instances, and unique, active SPIFFE IDs is your
-total MWI for the billing period.
+The sum of your calculated Bots, Bot Instances, and unique SPIFFE IDs is your
+total MWI for the billng period.
 
 ## Usage measurement for billing
 

--- a/docs/pages/usage-billing.mdx
+++ b/docs/pages/usage-billing.mdx
@@ -153,7 +153,7 @@ share the ID `spiffe://mydomain.cloud.gravitational.io/web-service`, Teleport wo
 as one SPIFFE ID for billing.
 
 The sum of your calculated Bots, Bot Instances, and unique SPIFFE IDs is your
-total MWI for the billng period.
+total MWI for the billing period.
 
 ## Usage measurement for billing
 

--- a/docs/pages/usage-billing.mdx
+++ b/docs/pages/usage-billing.mdx
@@ -133,8 +133,8 @@ for the entire hour, Teleport would report 30 protected servers.
 ### Machine and Workload Identities
 
 The Machine and Workload Identity (MWI) metric is an aggregate of
-* [Bots](reference/architecture/machine-id-architecture.mdx#joining-and-authentication)
-* [Bot Instances](reference/architecture/machine-id-architecture.mdx#joining-and-authentication)
+* [Bots](reference/architecture/machine-id-architecture.mdx#what-is-a-bot)
+* [Bot Instances](reference/architecture/machine-id-architecture.mdx#what-is-a-bot)
 * [SPIFFE IDs](enroll-resources/workload-identity/spiffe.mdx#spiffe-ids-and-trust-domains)
 
 We aggregate Bots, Bot Instances and unique SPIFFE IDs during each day on an hourly basis, and take

--- a/docs/pages/usage-billing.mdx
+++ b/docs/pages/usage-billing.mdx
@@ -130,6 +130,30 @@ hourly average. For example, if you were to create then delete 10 servers three
 times in one hour, Teleport would display 10 servers at any given time. However,
 for the entire hour, Teleport would report 30 protected servers.
 
+### Machine and Workload Identities
+
+The Machine and Workload Identity (MWI) metric is an aggregate of
+* [Bots](reference/architecture/machine-id-architecture.mdx#joining-and-authentication)
+* [Bot Instances](reference/architecture/machine-id-architecture.mdx#joining-and-authentication)
+* [SPIFFE IDs](enroll-resources/workload-identity/spiffe.mdx#spiffe-ids-and-trust-domains)
+
+We aggregate Bots and Bot Instances during each day on an hourly basis, and take an hourly average
+to compute a daily Bot and Bot Instance count. Then we average the daily Bot and Bot Instance count
+over a monthly period, which starts on the subscription start date and ends on each monthly anniversary
+thereafter.
+
+If you recreate a single Bot more than once an hour, this will affect the
+hourly average. For example, if you were to create then delete 10 Bots three
+times in one hour, Teleport would display 10 Bots at any given time. However,
+for the entire hour, Teleport would report 30 Bots.
+
+For SPIFFE IDs, we count the number of unique, active SPIFFE IDs used in the billing period.
+Unique means that we only count a SPIFFE ID once, even if it is used multiple times, and 
+active means it was issued to and used by a workload or user in the billing period.
+
+The sum of your calculated Bots and Bot Instances, and unique, active SPIFFE IDs is your
+total MWI for the bililng period.
+
 ## Usage measurement for billing
 
 We aggregate all counts of the billing metrics on a monthly basis starting on

--- a/docs/pages/usage-billing.mdx
+++ b/docs/pages/usage-billing.mdx
@@ -152,7 +152,7 @@ Unique means that we only count a SPIFFE ID once, even if it is used multiple ti
 active means it was issued to and used by a workload or user in the billing period.
 
 The sum of your calculated Bots and Bot Instances, and unique, active SPIFFE IDs is your
-total MWI for the bililng period.
+total MWI for the billing period.
 
 ## Usage measurement for billing
 


### PR DESCRIPTION
For Revenue to begin creating orders for MWI that can be fulfilled after the new billing metrics are shipped, we must have the MWI information in the billing docs. This needs to be live by end of day on Friday, 2/28/25.

We will need to backport this to v17 and v16 docs.

The calculation here is relatively complex. I've taken a first go at it, but welcome suggestions and revisions.