### PR TITLE
[branch/v16] Backport Update CI runner lable to 'macos-13-xlarge'

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -19,7 +19,7 @@ jobs:
   build:
     name: Build on Mac OS
     if: ${{ !startsWith(github.head_ref, 'dependabot/') }}
-    runs-on: macos-13-xl-arm64
+    runs-on: macos-13-xlarge
 
     permissions:
       contents: read


### PR DESCRIPTION
Signed-off-by: Fred Heinecke <fred.heinecke@goteleport.com>
