### PR TITLE
Modulate install script when managed updates v2 are off

### DIFF
--- a/lib/web/scripts/install.go
+++ b/lib/web/scripts/install.go
@@ -22,13 +22,13 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"github.com/gravitational/teleport/api/types"
 	"net/url"
 	"strings"
 
 	"github.com/google/safetext/shsprintf"
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/utils/teleportassets"
 	"github.com/gravitational/teleport/lib/web/scripts/oneoff"
 )

--- a/lib/web/scripts/install/install.sh
+++ b/lib/web/scripts/install/install.sh
@@ -402,11 +402,13 @@ TELEPORT_EDITION=""
 if [ $# -ge 1 ] && [ -n "$1" ]; then
   TELEPORT_VERSION=$1
 else
-  echo "ERROR: Please provide the version you want to install (e.g., 10.1.9)."
-  exit 1
+  if [ -z "$TELEPORT_VERSION" ]; then
+    echo "ERROR: Please provide the version you want to install (e.g., 10.1.9)."
+    exit 1
+  fi
 fi
 
-if ! echo "$1" |  grep -qE "[0-9]+\.[0-9]+\.[0-9]+"; then
+if ! echo "$TELEPORT_VERSION" |  grep -qE "[0-9]+\.[0-9]+\.[0-9]+"; then
   echo "ERROR: The first parameter must be a version number, e.g., 10.1.9."
   exit 1
 fi

--- a/lib/web/scripts/install_test.go
+++ b/lib/web/scripts/install_test.go
@@ -40,17 +40,42 @@ func TestGetInstallScript(t *testing.T) {
 		assertFn func(t *testing.T, script string)
 	}{
 		{
-			name: "Legacy install, no autoupdate",
-			opts: InstallScriptOptions{AutoupdateStyle: NoAutoupdate},
+			name: "Legacy install, oss",
+			opts: InstallScriptOptions{
+				AutoupdateStyle: NoAutoupdate,
+				TeleportVersion: testVersion,
+				TeleportFlavor:  types.PackageNameOSS,
+			},
 			assertFn: func(t *testing.T, script string) {
-				require.Equal(t, legacyInstallScript, script)
+				require.Contains(t, script, fmt.Sprintf(`TELEPORT_VERSION="%s"`, testVersion))
+				require.Contains(t, script, `TELEPORT_SUFFIX=""`)
+				require.Contains(t, script, `TELEPORT_EDITION="oss"`)
 			},
 		},
 		{
-			name: "Legacy install, package manager autoupdate",
-			opts: InstallScriptOptions{AutoupdateStyle: NoAutoupdate},
+			name: "Legacy install, enterprise",
+			opts: InstallScriptOptions{
+				AutoupdateStyle: NoAutoupdate,
+				TeleportVersion: testVersion,
+				TeleportFlavor:  types.PackageNameEnt,
+			},
 			assertFn: func(t *testing.T, script string) {
-				require.Equal(t, legacyInstallScript, script)
+				require.Contains(t, script, fmt.Sprintf(`TELEPORT_VERSION="%s"`, testVersion))
+				require.Contains(t, script, `TELEPORT_SUFFIX="-ent"`)
+				require.Contains(t, script, `TELEPORT_EDITION="enterprise"`)
+			},
+		},
+		{
+			name: "Legacy install, cloud",
+			opts: InstallScriptOptions{
+				AutoupdateStyle: PackageManagerAutoupdate,
+				TeleportVersion: testVersion,
+				TeleportFlavor:  types.PackageNameEnt,
+			},
+			assertFn: func(t *testing.T, script string) {
+				require.Contains(t, script, fmt.Sprintf(`TELEPORT_VERSION="%s"`, testVersion))
+				require.Contains(t, script, `TELEPORT_SUFFIX="-ent"`)
+				require.Contains(t, script, `TELEPORT_EDITION="cloud"`)
 			},
 		},
 		{


### PR DESCRIPTION
This is a fix for the /scripts/install.sh for a bug I found when testing the Au docs.

If you use the install script but autoupdates are off, we were returning the install script but not setting the desired version and edition.

I used a strings.Replace instead of a go template because the script is also served as-in by our CDN.

