### PR TITLE
[v17] Adds edit support for IC plugin to `tctl edit`

### DIFF
--- a/api/types/plugin.go
+++ b/api/types/plugin.go
@@ -17,9 +17,11 @@ limitations under the License.
 package types
 
 import (
+	"bytes"
 	"net/url"
 	"time"
 
+	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/utils"
@@ -793,6 +795,28 @@ func (c *AWSICProvisioningSpec) CheckAndSetDefaults() error {
 	}
 
 	return nil
+}
+
+// UnmarshalJSON implements [json.Unmarshaler] for the AWSICResourceFilter, forcing
+// it to use the `jsonpb` unmarshaler, which understands how to unpack values
+// generated from a protobuf `oneof` directive.
+func (s *AWSICResourceFilter) UnmarshalJSON(b []byte) error {
+	if err := jsonpb.Unmarshal(bytes.NewReader(b), s); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// MarshalJSON implements [json.Marshaler] for the AWSICResourceFilter, forcing
+// it to use the `jsonpb` marshaler, which understands how to pack values
+// generated from a protobuf `oneof` directive.
+func (s AWSICResourceFilter) MarshalJSON() ([]byte, error) {
+	m := jsonpb.Marshaler{}
+	var buf bytes.Buffer
+	if err := m.Marshal(&buf, &s); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return buf.Bytes(), nil
 }
 
 func (c *PluginEmailSettings) CheckAndSetDefaults() error {

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -1717,18 +1717,6 @@ func (p *pluginResourceWrapper) UnmarshalJSON(data []byte) error {
 		case settingsEmailAccessPlugin:
 			p.PluginV1.Spec.Settings = &types.PluginSpecV1_Email{}
 		case settingsAWSIdentityCenter:
-			// // The AWS IC setting block contains polymorphic filter values, so
-			// // we have to do the whole structure-unpacking thing again for
-			// // those.
-			// settings := &types.PluginSpecV1_AwsIc{
-			// 	AwsIc: &types.PluginAWSICSettings{},
-			// }
-			// p.PluginV1.Spec.Settings = settings
-
-			// unmshallingWrapper := icSettingsWrapper{inner: settings.AwsIc}
-			// if err := json.Unmarshal(value, &unmshallingWrapper); err != nil {
-			// 	return trace.Wrap(err)
-			// }
 			p.PluginV1.Spec.Settings = &types.PluginSpecV1_AwsIc{}
 		default:
 			return trace.BadParameter("unsupported plugin type: %v", k)

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -1734,6 +1734,9 @@ func (p *pluginResourceWrapper) UnmarshalJSON(data []byte) error {
 		}
 	}
 
+	// Status blocks use the same sort of polymorphic values to hold status details for
+	// the various plugin types, so we need to do the same sort of structure unpacking
+	// again here. The actual values will be filled in by the final JSON unmarshalling.
 	if len(unknownPlugin.Status.Details) > 1 {
 		return trace.BadParameter("malformed status details")
 	}

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -1602,10 +1602,8 @@ type pluginResourceWrapper struct {
 }
 
 func (p *pluginResourceWrapper) UnmarshalJSON(data []byte) error {
-  // If your plugin contains a `oneof` message, implement custom UnmarshalJSON/MarshalJSON 
-  // using gogo/jsonpb for the type.
-jsonpb 
-
+	// If your plugin contains a `oneof` message, implement custom UnmarshalJSON/MarshalJSON
+	// using gogo/jsonpb for the type.
 	const (
 		credOauth2AccessToken             = "oauth2_access_token"
 		credBearerToken                   = "bearer_token"
@@ -1701,21 +1699,9 @@ jsonpb
 			p.PluginV1.Spec.Settings = &types.PluginSpecV1_Email{}
 		case settingsAWSIdentityCenter:
 			p.PluginV1.Spec.Settings = &types.PluginSpecV1_AwsIc{}
+			p.PluginV1.Status.Details = &types.PluginStatusV1_AwsIc{}
 		default:
 			return trace.BadParameter("unsupported plugin type: %v", k)
-		}
-	}
-
-	// Status blocks use the same sort of polymorphic values to hold status details for
-	// the various plugin types, so we need to do the same sort of structure unpacking
-	// again here. The actual values will be filled in by the final JSON unmarshalling.
-	if len(unknownPlugin.Status.Details) > 1 {
-		return trace.BadParameter("malformed status details")
-	}
-	for k := range unknownPlugin.Status.Details {
-		switch k {
-		case settingsAWSIdentityCenter:
-			p.PluginV1.Status.Details = &types.PluginStatusV1_AwsIc{}
 		}
 	}
 

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -1602,26 +1602,9 @@ type pluginResourceWrapper struct {
 }
 
 func (p *pluginResourceWrapper) UnmarshalJSON(data []byte) error {
-	// The individual plugin settings blocks included in the plugin spec are
-	// specified in the original protobuf message declaration as heterogeneous
-	// message types, tied together by a `oneof` directive.
-	//
-	// Unfortunately the stdlib JSON unmarshaler doesn't know how to select which
-	// Go type to unmarshal the corresponding JSON value onto, so we have to
-	// partially unpack the plugin structure and supply the appropriate Go types
-	// for each polymorphic value.
-	//
-	// Once the type structure is in place, the stdlib JSON unmarshaler can use
-	// that structure to decide how to unmarshal the JSON values.
-	//
-	// Unfortunately we can't just use either the `protojson` or `jsonpb`
-	// package to parse all of this for, because:
-	//  - PluginV1 type doesn't implement [proto.Message], required by `protojson`.
-	//    Using [protoadapt.MessageV2Of()] was only slightly less messy than this
-	//    approach, as it required re-wrapping nested messages at every level
-	//
-	//  - There is no way to tell [jsonpb] to use the JSON style snake-case
-	//    field names, rather than the protobuf-style camel-case names
+  // If your plugin contains a `oneof` message, implement custom UnmarshalJSON/MarshalJSON 
+  // using gogo/jsonpb for the type.
+jsonpb 
 
 	const (
 		credOauth2AccessToken             = "oauth2_access_token"

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -1618,11 +1618,15 @@ func (p *pluginResourceWrapper) UnmarshalJSON(data []byte) error {
 		settingsEntraID                   = "entra_id"
 		settingsDatadogIncidentManagement = "datadog_incident_management"
 		settingsEmailAccessPlugin         = "email_access_plugin"
+		settingsAWSIdentityCenter         = "aws_ic"
 	)
 	type unknownPluginType struct {
 		Spec struct {
 			Settings map[string]json.RawMessage `json:"Settings"`
 		} `json:"spec"`
+		Status struct {
+			Details map[string]json.RawMessage `json:"Details"`
+		} `json:"status"`
 		Credentials struct {
 			Credentials map[string]json.RawMessage `json:"Credentials"`
 		} `json:"credentials"`
@@ -1658,8 +1662,7 @@ func (p *pluginResourceWrapper) UnmarshalJSON(data []byte) error {
 		}
 	}
 
-	for k := range unknownPlugin.Spec.Settings {
-
+	for k, value := range unknownPlugin.Spec.Settings {
 		switch k {
 		case settingsSlackAccessPlugin:
 			p.PluginV1.Spec.Settings = &types.PluginSpecV1_SlackAccessPlugin{}
@@ -1689,14 +1692,96 @@ func (p *pluginResourceWrapper) UnmarshalJSON(data []byte) error {
 			p.PluginV1.Spec.Settings = &types.PluginSpecV1_Datadog{}
 		case settingsEmailAccessPlugin:
 			p.PluginV1.Spec.Settings = &types.PluginSpecV1_Email{}
+		case settingsAWSIdentityCenter:
+			settings := &types.PluginSpecV1_AwsIc{
+				AwsIc: &types.PluginAWSICSettings{},
+			}
+			p.PluginV1.Spec.Settings = settings
+
+			unmshallingWrapper := icSettingsWrapper{inner: settings.AwsIc}
+			if err := json.Unmarshal(value, &unmshallingWrapper); err != nil {
+				return trace.Wrap(err)
+			}
 		default:
 			return trace.BadParameter("unsupported plugin type: %v", k)
+		}
+	}
+
+	if len(unknownPlugin.Status.Details) > 1 {
+		return trace.BadParameter("malformed status details")
+	}
+	for k := range unknownPlugin.Status.Details {
+		switch k {
+		case settingsAWSIdentityCenter:
+			p.PluginV1.Status.Details = &types.PluginStatusV1_AwsIc{}
 		}
 	}
 
 	if err := json.Unmarshal(data, &p.PluginV1); err != nil {
 		return err
 	}
+	return nil
+}
+
+// icSettingsWrapper is a wrapper around the Identity Center plugin settings to
+// provide custom unmarshalling.
+type icSettingsWrapper struct {
+	inner *types.PluginAWSICSettings
+}
+
+// UnmarshalJSON implements custom JSON-unmarshaling for the Identity Center
+// plugin settings. This custom unmarshaler is required to unpack the structure
+// of the polymorphic filters in the plugin settings, which otherise cannot be
+// unpacked.
+func (s *icSettingsWrapper) UnmarshalJSON(data []byte) error {
+	type resourceFilter struct {
+		Include map[string]json.RawMessage `json:"Include"`
+	}
+
+	var settings struct {
+		AccountFilters []resourceFilter `json:"aws_accounts_filters"`
+		GroupFilters   []resourceFilter `json:"group_sync_filters"`
+	}
+
+	// unpackFilters only creates the structure of the filters so that the
+	// normal JSON unmarshaller knows how to fill in the actual values
+	unpackFilters := func(src []resourceFilter) ([]*types.AWSICResourceFilter, error) {
+		var dst []*types.AWSICResourceFilter
+		for _, f := range src {
+			if len(f.Include) != 1 {
+				return nil, trace.BadParameter("Malformed filter")
+			}
+			for k := range f.Include {
+				switch k {
+				case "id":
+					dst = append(dst, &types.AWSICResourceFilter{Include: &types.AWSICResourceFilter_Id{}})
+
+				case "name_regex":
+					dst = append(dst, &types.AWSICResourceFilter{Include: &types.AWSICResourceFilter_NameRegex{}})
+
+				default:
+					return nil, trace.BadParameter("Unexpected filter key: %s", k)
+				}
+			}
+		}
+		return dst, nil
+	}
+
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return trace.Wrap(err)
+	}
+
+	var err error
+	s.inner.AwsAccountsFilters, err = unpackFilters(settings.AccountFilters)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	s.inner.GroupSyncFilters, err = unpackFilters(settings.GroupFilters)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	return nil
 }
 

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -46,6 +46,7 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	"github.com/gravitational/teleport/api/types"
+	apicommon "github.com/gravitational/teleport/api/types/common"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/entitlements"
@@ -2572,6 +2573,53 @@ func TestPluginResourceWrapper(t *testing.T) {
 						Oauth2AccessToken: &types.PluginOAuth2AccessTokenCredentials{
 							AccessToken:  "token",
 							RefreshToken: "refresh_token",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "identity center",
+			plugin: types.PluginV1{
+				Metadata: types.Metadata{
+					Name: apicommon.OriginAWSIdentityCenter,
+					Labels: map[string]string{
+						"teleport.dev/hosted-plugin": "true",
+					},
+				},
+				Spec: types.PluginSpecV1{
+					Settings: &types.PluginSpecV1_AwsIc{
+						AwsIc: &types.PluginAWSICSettings{
+							IntegrationName: apicommon.OriginAWSIdentityCenter,
+							Region:          "ap-south-2",
+							Arn:             "some:arn",
+							ProvisioningSpec: &types.AWSICProvisioningSpec{
+								BaseUrl: "https://scim.example.com/v2",
+							},
+							AccessListDefaultOwners: []string{"root"},
+							CredentialsSource:       types.AWSICCredentialsSource_AWSIC_CREDENTIALS_SOURCE_SYSTEM,
+							UserSyncFilters: []*types.AWSICUserSyncFilter{
+								{Labels: map[string]string{types.OriginLabel: types.OriginOkta}},
+								{Labels: map[string]string{types.OriginLabel: types.OriginEntraID}},
+							},
+							GroupSyncFilters: []*types.AWSICResourceFilter{
+								{Include: &types.AWSICResourceFilter_NameRegex{NameRegex: `^Group #\\d+$`}},
+								{Include: &types.AWSICResourceFilter_Id{Id: "42"}},
+							},
+							AwsAccountsFilters: []*types.AWSICResourceFilter{
+								{Include: &types.AWSICResourceFilter_Id{Id: "314159"}},
+								{Include: &types.AWSICResourceFilter_NameRegex{NameRegex: `^Account #\\d+$`}},
+							},
+						},
+					},
+				},
+				Status: types.PluginStatusV1{
+					Code: types.PluginStatusCode_RUNNING,
+					Details: &types.PluginStatusV1_AwsIc{
+						AwsIc: &types.PluginAWSICStatusV1{
+							GroupImportStatus: &types.AWSICGroupImportStatus{
+								StatusCode: types.AWSICGroupImportStatusCode_DONE,
+							},
 						},
 					},
 				},

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -2533,6 +2533,8 @@ func TestPluginResourceWrapper(t *testing.T) {
 		{
 			name: "okta",
 			plugin: types.PluginV1{
+				Kind:    types.KindPlugin,
+				Version: types.V1,
 				Metadata: types.Metadata{
 					Name: "okta",
 				},
@@ -2558,6 +2560,8 @@ func TestPluginResourceWrapper(t *testing.T) {
 		{
 			name: "slack",
 			plugin: types.PluginV1{
+				Kind:    types.KindPlugin,
+				Version: types.V1,
 				Metadata: types.Metadata{
 					Name: "okta",
 				},
@@ -2581,6 +2585,8 @@ func TestPluginResourceWrapper(t *testing.T) {
 		{
 			name: "identity center",
 			plugin: types.PluginV1{
+				Kind:    types.KindPlugin,
+				Version: types.V1,
 				Metadata: types.Metadata{
 					Name: apicommon.OriginAWSIdentityCenter,
 					Labels: map[string]string{


### PR DESCRIPTION
Backport #52243 to branch/v17

changelog: Added `tctl edit` support for Identity Center plugin resources
