### PR TITLE
[web] Add hooks for ResizeObserver / element size

### DIFF
--- a/web/packages/build/jest/jest-environment-patched-jsdom.js
+++ b/web/packages/build/jest/jest-environment-patched-jsdom.js
@@ -80,6 +80,17 @@ export default class PatchedJSDOMEnvironment extends JSDOMEnvironment {
         return result;
       };
     }
+
+    // If a test actually depends on a working ResizeObserver implementation, call
+    // mockResizeObserver provided by jsdom-testing-mocks.
+    if (!global.ResizeObserver) {
+      function NullResizeObserver() {
+        this.observe = () => {};
+        this.unobserve = () => {};
+        this.disconnect = () => {};
+      }
+      global.ResizeObserver = NullResizeObserver;
+    }
   }
 }
 export const TestEnvironment = PatchedJSDOMEnvironment;

--- a/web/packages/build/jest/setupTests.ts
+++ b/web/packages/build/jest/setupTests.ts
@@ -22,6 +22,10 @@ import crypto from 'node:crypto';
 import path from 'node:path';
 
 import failOnConsole from 'jest-fail-on-console';
+import { configMocks } from 'jsdom-testing-mocks';
+import { act } from 'react';
+
+configMocks({ act });
 
 let entFailOnConsoleIgnoreList = [];
 try {
@@ -41,12 +45,6 @@ Object.defineProperty(globalThis, 'crypto', {
     randomUUID: () => crypto.randomUUID(),
   },
 });
-
-global.ResizeObserver = jest.fn().mockImplementation(() => ({
-  observe: jest.fn(),
-  unobserve: jest.fn(),
-  disconnect: jest.fn(),
-}));
 
 const rootDir = path.join(__dirname, '..', '..', '..', '..');
 // Do not add new paths to this list, instead fix the underlying problem which causes console.error

--- a/web/packages/design/src/CollapsibleInfoSection/CollapsibleInfoSection.tsx
+++ b/web/packages/design/src/CollapsibleInfoSection/CollapsibleInfoSection.tsx
@@ -16,18 +16,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {
-  PropsWithChildren,
-  useId,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react';
+import { PropsWithChildren, useId, useState } from 'react';
 import styled from 'styled-components';
 
 import { Box, Button, Text } from 'design';
 import { BoxProps } from 'design/Box';
 import { Minus, Plus } from 'design/Icon';
+import { useElementSize } from 'design/utils/useElementSize';
 
 type CollapsibleInfoSectionProps = {
   /* defaultOpen is optional and determines whether the section is open or closed initially */
@@ -60,28 +55,9 @@ export const CollapsibleInfoSection = ({
 }: PropsWithChildren<CollapsibleInfoSectionProps>) => {
   const contentId = useId();
   const [isOpen, setIsOpen] = useState(defaultOpen);
-  const [contentHeight, setContentHeight] = useState<number>();
   const [shouldRenderContent, setShouldRenderContent] = useState(defaultOpen);
-  const contentRef = useRef<HTMLDivElement>(null);
-
-  useLayoutEffect(() => {
-    if (!defaultOpen && contentHeight === undefined) {
-      setContentHeight(0);
-    }
-    if (!contentRef.current || !shouldRenderContent) {
-      return;
-    }
-    const ro = new ResizeObserver(entries => {
-      for (const entry of entries) {
-        if (entry.target === contentRef.current) {
-          setContentHeight(entry.contentRect.height);
-        }
-      }
-    });
-    ro.observe(contentRef.current);
-    return () => ro.disconnect();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [contentRef, shouldRenderContent]);
+  const [contentRef, { height: contentHeight }] =
+    useElementSize<HTMLDivElement>({ height: defaultOpen ? undefined : 0 });
 
   return (
     <Box {...boxProps}>

--- a/web/packages/design/src/Popover/Transition.tsx
+++ b/web/packages/design/src/Popover/Transition.tsx
@@ -16,9 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { RefObject, useLayoutEffect } from 'react';
-
-import { useResizeObserver } from 'design/utils/useResizeObserver';
+import React, { RefObject, useCallback, useLayoutEffect } from 'react';
 
 /**
  * Transition is a helper for firing certain effects from Popover, as it's way easier to use them
@@ -40,9 +38,23 @@ export function Transition({
   // It's especially noticeable on Safari.
   useLayoutEffect(onEntering, []);
 
-  useResizeObserver(paperRef, onPaperResize, {
-    enabled: enablePaperResizeObserver,
-  });
+  const effect = useCallback(() => {
+    if (!paperRef.current || !enablePaperResizeObserver) return;
+
+    const observer = new ResizeObserver(entries => {
+      const entry = entries[0];
+      if (entry.contentRect.height === 0) return;
+      onPaperResize();
+    });
+
+    observer.observe(paperRef.current);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [onPaperResize, paperRef, enablePaperResizeObserver]);
+
+  useLayoutEffect(effect, [effect]);
 
   return children;
 }

--- a/web/packages/design/src/Popover/Transition.tsx
+++ b/web/packages/design/src/Popover/Transition.tsx
@@ -38,7 +38,7 @@ export function Transition({
   // It's especially noticeable on Safari.
   useLayoutEffect(onEntering, []);
 
-  const effect = useCallback(() => {
+  const resizeEffect = useCallback(() => {
     if (!paperRef.current || !enablePaperResizeObserver) return;
 
     const observer = new ResizeObserver(entries => {
@@ -54,7 +54,7 @@ export function Transition({
     };
   }, [onPaperResize, paperRef, enablePaperResizeObserver]);
 
-  useLayoutEffect(effect, [effect]);
+  useLayoutEffect(resizeEffect, [resizeEffect]);
 
   return children;
 }

--- a/web/packages/design/src/utils/useElementSize.test.tsx
+++ b/web/packages/design/src/utils/useElementSize.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import '@testing-library/jest-dom';
+
+import { render, screen } from '@testing-library/react';
+import { mockResizeObserver } from 'jsdom-testing-mocks';
+
+import { act } from 'design/utils/testing';
+
+import { useElementSize } from './useElementSize';
+
+const resizeObserver = mockResizeObserver();
+
+describe('useElementSize', () => {
+  it('tracks element size correctly with default initial values', () => {
+    render(<TestComponent />);
+
+    const resizableElement = screen.getByTestId('resizable');
+
+    expect(screen.getByTestId('width')).toHaveTextContent('0');
+    expect(screen.getByTestId('height')).toHaveTextContent('0');
+
+    resizeObserver.mockElementSize(resizableElement, {
+      contentBoxSize: { inlineSize: 300, blockSize: 200 },
+    });
+
+    act(() => {
+      resizeObserver.resize(resizableElement);
+    });
+
+    expect(screen.getByTestId('width')).toHaveTextContent('300');
+    expect(screen.getByTestId('height')).toHaveTextContent('200');
+
+    resizeObserver.mockElementSize(resizableElement, {
+      contentBoxSize: { inlineSize: 400, blockSize: 250 },
+    });
+
+    act(() => {
+      resizeObserver.resize(resizableElement);
+    });
+
+    expect(screen.getByTestId('width')).toHaveTextContent('400');
+    expect(screen.getByTestId('height')).toHaveTextContent('250');
+  });
+
+  it('allows undefined as initial dimension value', () => {
+    render(<TestComponentWithUndefinedHeight />);
+
+    expect(screen.getByTestId('width')).toHaveTextContent('0');
+    expect(screen.getByTestId('height')).toHaveTextContent('undefined');
+
+    const resizableElement = screen.getByTestId('resizable');
+
+    resizeObserver.mockElementSize(resizableElement, {
+      contentBoxSize: { inlineSize: 300, blockSize: 200 },
+    });
+
+    act(() => {
+      resizeObserver.resize(resizableElement);
+    });
+
+    expect(screen.getByTestId('width')).toHaveTextContent('300');
+    expect(screen.getByTestId('height')).toHaveTextContent('200');
+  });
+});
+
+const TestComponent = () => {
+  const [ref, { width, height }] = useElementSize<HTMLDivElement>();
+
+  return (
+    <div>
+      <div data-testid="resizable" ref={ref}>
+        This element&#39;s size is being observed
+      </div>
+      <p>
+        Width: <span data-testid="width">{width}</span>px, Height:{' '}
+        <span data-testid="height">{height}</span>px
+      </p>
+    </div>
+  );
+};
+
+const TestComponentWithUndefinedHeight = () => {
+  const [ref, { width, height }] = useElementSize<HTMLDivElement>({
+    height: undefined,
+  });
+
+  return (
+    <div>
+      <div data-testid="resizable" ref={ref}>
+        This element has an undefined initial height
+      </div>
+      <p>
+        Width: <span data-testid="width">{width}</span>px, Height:{' '}
+        <span data-testid="height">
+          {height === undefined ? 'undefined' : height}
+        </span>
+        px
+      </p>
+    </div>
+  );
+};

--- a/web/packages/design/src/utils/useElementSize.ts
+++ b/web/packages/design/src/utils/useElementSize.ts
@@ -1,0 +1,65 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useCallback, useState } from 'react';
+
+import { useResizeObserver } from './useResizeObserver';
+
+/**
+ * useElementSize returns a ref and the size of the element.
+ * The size is updated whenever the element is resized.
+ *
+ * @example
+ * // With default initial size (width = 0, height = 0)
+ * const Component = () => {
+ *   const [ref, { width, height }] = useElementSize<HTMLDivElement>();
+ *
+ *   return (
+ *     <>
+ *       <div ref={ref}>This element's size is being observed</div>
+ *       <p>Width: {width}px, Height: {height}px</p>
+ *     </>
+ *   );
+ * };
+ *
+ * @example
+ * // With custom initial size
+ * const Component = () => {
+ *   const [ref, { width, height }] = useElementSize<HTMLDivElement>({ height: undefined });
+ *
+ *   return <div ref={ref}>This element starts with an observed height of 'undefined'</div>;
+ * };
+ */
+export const useElementSize = <T extends HTMLElement = HTMLElement>(
+  initialSize: { width?: number; height?: number } = { width: 0, height: 0 },
+  opts: Parameters<typeof useResizeObserver>[1] = {}
+) => {
+  const [size, setSize] = useState({
+    width: 'width' in initialSize ? initialSize.width : 0,
+    height: 'height' in initialSize ? initialSize.height : 0,
+  });
+
+  const handleResize = useCallback((entry: ResizeObserverEntry) => {
+    const { width, height } = entry.contentRect;
+    setSize({ width, height });
+  }, []);
+
+  const ref = useResizeObserver<T>(handleResize, opts);
+
+  return [ref, size] as const;
+};

--- a/web/packages/design/src/utils/useResizeObserver.test.tsx
+++ b/web/packages/design/src/utils/useResizeObserver.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import '@testing-library/jest-dom';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { mockResizeObserver } from 'jsdom-testing-mocks';
+import { useState } from 'react';
+
+import { useResizeObserver } from './useResizeObserver';
+
+const resizeObserver = mockResizeObserver();
+
+describe('useResizeObserver', () => {
+  it('functions when observed element is conditionally rendered', async () => {
+    const user = userEvent.setup();
+    const onResize = jest.fn();
+
+    render(<ExampleComponent onResize={onResize} />);
+
+    let resizableElement = screen.getByTestId('resizable');
+
+    expect(resizableElement).toBeInTheDocument();
+    resizeObserver.mockElementSize(resizableElement, {
+      contentBoxSize: { inlineSize: 300, blockSize: 200 },
+    });
+    expect(onResize).not.toHaveBeenCalled();
+
+    // Verify that ResizeObserver is working as expected.
+    resizeObserver.resize(resizableElement);
+    expect(onResize).toHaveBeenCalledTimes(1);
+    resizeObserver.resize(resizableElement);
+    expect(onResize).toHaveBeenCalledTimes(2);
+
+    // Hide element and verify that resizing the old, now unmounted node does not trigger the callback.
+    await user.click(screen.getByText('Hide'));
+    expect(screen.queryByTestId('resizable')).not.toBeInTheDocument();
+
+    resizeObserver.resize(resizableElement);
+    expect(onResize).toHaveBeenCalledTimes(2);
+
+    // Show element again, resize the new node and verify that it triggers the callback.
+    await user.click(screen.getByText('Show'));
+    resizableElement = screen.getByTestId('resizable');
+
+    resizeObserver.mockElementSize(resizableElement, {
+      contentBoxSize: { inlineSize: 300, blockSize: 200 },
+    });
+
+    resizeObserver.resize(resizableElement);
+
+    expect(onResize).toHaveBeenCalledTimes(3);
+  });
+});
+
+const ExampleComponent = (props: { onResize: () => void }) => {
+  const [isShown, setIsShown] = useState(true);
+  const ref = useResizeObserver(props.onResize);
+
+  return (
+    <div>
+      <button type="button" onClick={() => setIsShown(!isShown)}>
+        {isShown ? 'Hide' : 'Show'}
+      </button>
+      {isShown && <div data-testid="resizable" ref={ref}></div>}
+    </div>
+  );
+};

--- a/web/packages/design/src/utils/useResizeObserver.ts
+++ b/web/packages/design/src/utils/useResizeObserver.ts
@@ -33,6 +33,10 @@ import {
  * Returns a ref callback to attach to the element to be observed – the element
  * must be a HTMLElement but may be conditionally null.
  *
+ * `fireOnZeroHeight` determines whether the callback should be fired when the
+ * element's height is 0. This defaults to false, to account for a special case in
+ * Connect where tabs are hidden using `display: none;`.
+ *
  * @example
  * // Basic usage
  * const Component = () => {
@@ -47,7 +51,7 @@ import {
  */
 export const useResizeObserver = <T extends HTMLElement = HTMLElement>(
   callback: (entry: ResizeObserverEntry) => void,
-  { fireOnZeroHeight = true } = {}
+  { fireOnZeroHeight = false } = {}
 ): RefCallback<T> => {
   const callbackRef = useRef(callback);
   const elementRef = useRef<T | null>(null);

--- a/web/packages/design/src/utils/useResizeObserver.ts
+++ b/web/packages/design/src/utils/useResizeObserver.ts
@@ -1,6 +1,6 @@
 /**
  * Teleport
- * Copyright (C) 2024 Gravitational, Inc.
+ * Copyright (C) 2025 Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,46 +16,70 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { RefObject, useCallback, useLayoutEffect } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  type RefCallback,
+} from 'react';
 
 /**
- * useResizeObserver sets up a ResizeObserver for ref and calls callback on each resize.
+ * useResizeObserver creates a ResizeObserver which fires a callback
+ * when the provided element is resized. The callback is called with the
+ * ResizeObserverEntry. The observer is disconnected when the element is
+ * unmounted.
  *
- * It does not fire if ref.current.contentRect.height is zero, to account for a special case in
- * Connect where tabs are hidden using `display: none;`.
+ * Returns a ref callback to attach to the element to be observed – the element
+ * must be a HTMLElement but may be conditionally null.
  *
- * Uses a layout effect underneath. If ref is conditionally rendered, set enabled to false when ref
- * is null.
+ * @example
+ * // Basic usage
+ * const Component = () => {
+ *   const handleResize = (entry: ResizeObserverEntry) => {
+ *     console.log({ entryContentRect: entry.contentRect });
+ *   };
+ *
+ *   const ref = useResizeObserver<HTMLDivElement>(handleResize);
+ *
+ *   return <div ref={ref}>This div is being observed</div>;
+ * };
  */
-export function useResizeObserver(
-  ref: RefObject<HTMLElement>,
+export const useResizeObserver = <T extends HTMLElement = HTMLElement>(
   callback: (entry: ResizeObserverEntry) => void,
-  { enabled = true }
-): void {
-  const effect = useCallback(() => {
-    if (!ref.current || !enabled) {
-      return;
-    }
+  { fireOnZeroHeight = true } = {}
+): RefCallback<T> => {
+  const callbackRef = useRef(callback);
+  const elementRef = useRef<T | null>(null);
 
-    const observer = new ResizeObserver(entries => {
-      const entry = entries[0];
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
 
-      // In Connect, when a tab becomes active, its outermost DOM element switches from `display:
-      // none` to `display: flex`. This callback is then fired with the height reported as zero.
-      // To avoid unnecessary calls to callback, return early here.
-      if (entry.contentRect.height === 0) {
-        return;
+  const observer = useMemo(
+    () =>
+      new ResizeObserver(([entry]) => {
+        if (!entry || (!fireOnZeroHeight && entry.contentRect.height === 0))
+          return;
+        callbackRef.current?.(entry);
+      }),
+    [fireOnZeroHeight]
+  );
+
+  useEffect(() => {
+    return () => observer.disconnect();
+  }, [observer]);
+
+  return useCallback(
+    (element: T | null) => {
+      if (element) {
+        observer.observe(element);
+        elementRef.current = element;
+      } else {
+        elementRef.current && observer.unobserve(elementRef.current);
+        elementRef.current = null;
       }
-
-      callback(entry);
-    });
-
-    observer.observe(ref.current);
-
-    return () => {
-      observer.disconnect();
-    };
-  }, [callback, ref, enabled]);
-
-  useLayoutEffect(effect, [effect]);
-}
+    },
+    [observer]
+  );
+};

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/sections.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/sections.tsx
@@ -16,13 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {
-  Fragment,
-  PropsWithChildren,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import { Fragment, PropsWithChildren, useEffect, useState } from 'react';
 import styled, { useTheme } from 'styled-components';
 
 import Box, { BoxProps } from 'design/Box';
@@ -102,18 +96,13 @@ export const SectionBox = ({
   const expandTooltip =
     expansionState === ExpansionState.Collapsed ? 'Collapse' : 'Expand';
   const validator = useValidation();
-  // Points to the content element whose height will be observed for setting
-  // target height of the expand animation.
-  const contentRef = useRef();
   const [contentHeight, setContentHeight] = useState(0);
 
-  useResizeObserver(
-    contentRef,
-    entry => {
-      setContentHeight(entry.borderBoxSize[0].blockSize);
-    },
-    { enabled: true }
-  );
+  // Points to the content element whose height will be observed for setting
+  // target height of the expand animation.
+  const contentRef = useResizeObserver(entry => {
+    setContentHeight(entry.borderBoxSize[0].blockSize);
+  });
 
   useEffect(() => {
     // After the content is rendered and measured, immediately transition to


### PR DESCRIPTION
Adds a hook for using a new ResizeObserver instance, and a hook for getting the width/height of an element.

Although there's already a ResizeObserver hook that lives under `design/utils`, it requires passing in a ref, which feels a bit less ergonomic - let me know thoughts on this.
