### PR TITLE
iterator-based stream package

### DIFF
--- a/lib/itertools/stream/legacy.go
+++ b/lib/itertools/stream/legacy.go
@@ -1,0 +1,73 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package stream
+
+import (
+	"iter"
+
+	legacy "github.com/gravitational/teleport/api/internalutils/stream"
+)
+
+type legacyAdapter[T any] struct {
+	next func() (T, error, bool)
+	stop func()
+	item T
+	err  error
+}
+
+func (stream *legacyAdapter[T]) Next() bool {
+	var ok bool
+	stream.item, stream.err, ok = stream.next()
+	return ok && stream.err == nil
+}
+
+func (stream *legacyAdapter[T]) Item() T {
+	return stream.item
+}
+
+func (stream *legacyAdapter[T]) Done() error {
+	stream.stop()
+	return stream.err
+}
+
+// IntoLegacy converts a standard stream into a legacy pull-based stream.
+func IntoLegacy[T any](stream Stream[T]) legacy.Stream[T] {
+	next, stop := iter.Pull2(stream)
+	return &legacyAdapter[T]{
+		next: next,
+		stop: stop,
+	}
+}
+
+// FromLegacy converts a legacy pull-based stream into a standard stream.
+func FromLegacy[T any](stream legacy.Stream[T]) Stream[T] {
+	return func(yield func(T, error) bool) {
+		for stream.Next() {
+			if !yield(stream.Item(), nil) {
+				stream.Done()
+				return
+			}
+		}
+
+		if err := stream.Done(); err != nil {
+			var zero T
+			yield(zero, err)
+		}
+	}
+}

--- a/lib/itertools/stream/legacy_test.go
+++ b/lib/itertools/stream/legacy_test.go
@@ -1,0 +1,103 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package stream
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	legacy "github.com/gravitational/teleport/api/internalutils/stream"
+)
+
+func TestLegacyCompat(t *testing.T) {
+	t.Parallel()
+
+	var s []int
+	var err error
+
+	// basic from legacy compat & use as a standard stream
+	for n, err := range FromLegacy(legacy.Slice([]int{1, 2, 3, 4})) {
+		require.NoError(t, err)
+		s = append(s, n)
+	}
+	require.Equal(t, []int{1, 2, 3, 4}, s)
+
+	// basic into legacy compat
+	s, err = legacy.Collect(IntoLegacy(func(yield func(int, error) bool) {
+		for i := 0; i < 4; i++ {
+			if !yield(i, nil) {
+				return
+			}
+		}
+	}))
+	require.NoError(t, err)
+	require.Equal(t, []int{0, 1, 2, 3}, s)
+
+	// nested compat
+	s, err = legacy.Collect(IntoLegacy(FromLegacy(legacy.Slice([]int{7, 8, 9}))))
+	require.NoError(t, err)
+	require.Equal(t, []int{7, 8, 9}, s)
+
+	// single-element from legacy compat
+	s = nil
+	for n, err := range FromLegacy(legacy.Slice([]int{11})) {
+		require.NoError(t, err)
+		s = append(s, n)
+	}
+	require.Equal(t, []int{11}, s)
+
+	// single-element into legacy compat
+	s, err = legacy.Collect(IntoLegacy(func(yield func(int, error) bool) {
+		if !yield(111, nil) {
+			return
+		}
+	}))
+	require.NoError(t, err)
+	require.Equal(t, []int{111}, s)
+
+	// empty from legacy compat
+	s = nil
+	for n, err := range FromLegacy(legacy.Empty[int]()) {
+		require.NoError(t, err)
+		s = append(s, n)
+	}
+
+	// empty into legacy compat
+	s, err = legacy.Collect(IntoLegacy(func(yield func(int, error) bool) {}))
+	require.NoError(t, err)
+	require.Empty(t, s)
+
+	// error from legacy compat
+	err = nil
+	for _, ierr := range FromLegacy(legacy.Fail[int](fmt.Errorf("unexpected error"))) {
+		err = ierr
+		break
+	}
+	require.Error(t, err)
+
+	// error into legacy compat
+	s, err = legacy.Collect(IntoLegacy(func(yield func(int, error) bool) {
+		yield(0, fmt.Errorf("unexpected error"))
+	}))
+	require.Error(t, err)
+	require.Empty(t, s)
+
+}

--- a/lib/itertools/stream/stream.go
+++ b/lib/itertools/stream/stream.go
@@ -1,0 +1,406 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package stream
+
+import (
+	"errors"
+	"io"
+	"iter"
+
+	"github.com/gravitational/trace"
+)
+
+// Stream is an alias for a fallible iterator. The Stream type alias and related
+// utilities follow a specific model that may not be appropriate for all types
+// that match the underlying signature. In particular, streams are modeled as the iterator
+// equivalent of a function of the form `func() ([]T, error)`. This means that streams
+// are expected to yield at most one error, and to not yield any additional values after
+// an error has been produced. The combinators in this package short-circuit on the
+// first error encountered, including those that handle multiple substreams.
+type Stream[T any] = iter.Seq2[T, error]
+
+// Func builds a stream from a closure. The supplied closure *must*
+// return io.EOF if no more items are available. Failure to return io.EOF
+// (or some other error) may cause infinite loops. If wrapping a
+// paginated API, consider using PageFunc instead.
+func Func[T any](fn func() (T, error)) Stream[T] {
+	return func(yield func(T, error) bool) {
+		for {
+			item, err := fn()
+			if err != nil {
+				if !errors.Is(err, io.EOF) {
+					yield(*new(T), trace.Wrap(err))
+				}
+				return
+			}
+
+			if !yield(item, nil) {
+				return
+			}
+		}
+	}
+}
+
+// Collect aggregates a stream into a slice. If an error is hit, the
+// items observed thus far are still returned, but they may not represent
+// the complete set.
+func Collect[T any](stream Stream[T]) ([]T, error) {
+	var c []T
+	for item, err := range stream {
+		if err != nil {
+			return c, trace.Wrap(err)
+		}
+		c = append(c, item)
+	}
+	return c, nil
+}
+
+// CollectPages aggregates a paginated stream into a slice. If an error
+// is hit, the pages observed thus far are still returned, but they may not
+// represent the complete set.
+func CollectPages[T any, S ~[]T](stream Stream[S]) ([]T, error) {
+	var c []T
+	for page, err := range stream {
+		if err != nil {
+			return c, trace.Wrap(err)
+		}
+		c = append(c, page...)
+	}
+	return c, nil
+}
+
+// FilterMap maps a stream of type A into a stream of type B, filtering out
+// items when fn returns false.
+func FilterMap[A, B any](stream Stream[A], fn func(A) (B, bool)) Stream[B] {
+	return func(yield func(B, error) bool) {
+		for item, err := range stream {
+			if err != nil {
+				yield(*new(B), trace.Wrap(err))
+				return
+			}
+
+			mapped, ok := fn(item)
+			if !ok {
+				continue
+			}
+
+			if !yield(mapped, nil) {
+				return
+			}
+		}
+	}
+}
+
+// Chain joins multiple streams in order, fully consuming one before moving to the next.
+func Chain[T any](streams ...Stream[T]) Stream[T] {
+	return func(yield func(T, error) bool) {
+		for _, stream := range streams {
+			for item, err := range stream {
+				if err != nil {
+					yield(*new(T), trace.Wrap(err))
+					return
+				}
+
+				if !yield(item, nil) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// Chunks breaks a stream into chunks of a fixed size. The last chunk may be smaller
+// than the specified size. Zero/negative values of size result in an empty stream.
+func Chunks[T any](stream Stream[T], size int) Stream[[]T] {
+	if size < 1 {
+		return Empty[[]T]()
+	}
+	return func(yield func([]T, error) bool) {
+		var chunk []T
+		for item, err := range stream {
+			if err != nil {
+				yield(nil, trace.Wrap(err))
+				return
+			}
+
+			if chunk == nil {
+				chunk = make([]T, 0, size)
+			}
+
+			chunk = append(chunk, item)
+			if len(chunk) == size {
+				if !yield(chunk, nil) {
+					return
+				}
+				chunk = nil
+			}
+		}
+
+		if len(chunk) > 0 {
+			if !yield(chunk, nil) {
+				return
+			}
+		}
+	}
+}
+
+// Fail creates an empty stream that fails immediately with the supplied error.
+func Fail[T any](err error) Stream[T] {
+	if err != nil {
+		return func(yield func(T, error) bool) {
+			yield(*new(T), trace.Wrap(err))
+		}
+	}
+
+	return Empty[T]()
+}
+
+// Empty creates an empty stream.
+func Empty[T any]() Stream[T] {
+	return func(yield func(T, error) bool) {}
+}
+
+// Once creates a stream that yields a single item.
+func Once[T any](item T) Stream[T] {
+	return func(yield func(T, error) bool) {
+		yield(item, nil)
+	}
+}
+
+// OnceFunc builds a stream from a closure that will yield exactly zero or one items. This stream
+// is the lazy equivalent of the Once/Fail/Empty combinators. A nil error value results
+// in a single-element stream. An error value of io.EOF results in an empty stream. All other error
+// values result in a failing stream.
+func OnceFunc[T any](fn func() (T, error)) Stream[T] {
+	return func(yield func(T, error) bool) {
+		item, err := fn()
+		if errors.Is(err, io.EOF) {
+			return
+		}
+		yield(item, err)
+	}
+}
+
+// Drain consumes a stream to completion, reporting its error if any.
+func Drain[T any](stream Stream[T]) error {
+	for _, err := range stream {
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Slice constructs a stream from a slice.
+func Slice[T any, S ~[]T](items S) Stream[T] {
+	return func(yield func(T, error) bool) {
+		for _, item := range items {
+			if !yield(item, nil) {
+				return
+			}
+		}
+	}
+}
+
+// PageFunc is equivalent to Func except that it performs internal depagination. As with
+// Func, the supplied closure *must* return io.EOF if no more items are available. Failure
+// to return io.EOF (or some other error) may result in infinite loops.
+func PageFunc[T any](fn func() ([]T, error)) Stream[T] {
+	return func(yield func(T, error) bool) {
+		for {
+			items, err := fn()
+			if err != nil {
+				if !errors.Is(err, io.EOF) {
+					yield(*new(T), trace.Wrap(err))
+				}
+				return
+			}
+
+			for _, item := range items {
+				if !yield(item, nil) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// Skip skips the first n items from a stream. Zero/negative values of n
+// have no effect.
+func Skip[T any](stream Stream[T], n int) Stream[T] {
+	return func(yield func(T, error) bool) {
+		n := n // copy
+		for item, err := range stream {
+			if err != nil {
+				yield(*new(T), trace.Wrap(err))
+				return
+			}
+
+			if n > 0 {
+				n--
+				continue
+			}
+
+			if !yield(item, nil) {
+				return
+			}
+		}
+	}
+}
+
+// Flatten flattens a stream of streams into a single stream of items.
+func Flatten[T any](stream Stream[Stream[T]]) Stream[T] {
+	return func(yield func(T, error) bool) {
+		for inner, err := range stream {
+			if err != nil {
+				yield(*new(T), trace.Wrap(err))
+				return
+			}
+
+			for item, err := range inner {
+				if err != nil {
+					yield(*new(T), trace.Wrap(err))
+					return
+				}
+
+				if !yield(item, nil) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// MapErr maps over the "terminating" error value of a stream. This is a distinctly different
+// concept than mapping over the second value of an iter.Seq2. The mapping function is called with
+// a nil value when the stream terminates successfully, and nil values returned by the function are
+// not yielded. The effect of this behavior is that MapErr can be used to suppress, inject, *or* modify
+// the terminating error of a stream.
+func MapErr[T any](stream Stream[T], fn func(error) error) Stream[T] {
+	return func(yield func(T, error) bool) {
+		for item, err := range stream {
+			if err != nil {
+				mappedErr := fn(err)
+				if mappedErr == nil {
+					// terminating error was suppressed
+					return
+				}
+				yield(*new(T), mappedErr)
+				return
+			}
+
+			if !yield(item, nil) {
+				return
+			}
+		}
+
+		if err := fn(nil); err != nil {
+			yield(*new(T), trace.Wrap(err))
+		}
+	}
+}
+
+// RateLimit applies a rate-limiting function to a stream before each attempt to get the
+// next item. If the wait function returns a non-nil error, the stream is halted. The wait
+// function may return io.EOF to indicate a graceful/expected halting condition.
+func RateLimit[T any](stream Stream[T], wait func() error) Stream[T] {
+	return func(yield func(T, error) bool) {
+		for item, err := range stream {
+			if err != nil {
+				yield(*new(T), trace.Wrap(err))
+				return
+			}
+
+			if !yield(item, nil) {
+				return
+			}
+
+			if err := wait(); err != nil {
+				if !errors.Is(err, io.EOF) {
+					yield(*new(T), trace.Wrap(err))
+				}
+				return
+			}
+		}
+	}
+}
+
+// MergeStreams merges two sorted streams and returns a single stream which uses the provided less function to determine which item to yield first in order to preserve the sort order.
+func MergeStreams[T any](
+	streamA Stream[T],
+	streamB Stream[T],
+	less func(a, b T) bool,
+) Stream[T] {
+	return func(yield func(T, error) bool) {
+		var itemA, itemB T
+		var okA, okB bool
+		var err error
+
+		nextA, stopA := iter.Pull2(streamA)
+		nextB, stopB := iter.Pull2(streamB)
+		defer stopA()
+		defer stopB()
+
+		itemA, err, okA = nextA()
+		if err != nil {
+			yield(*new(T), trace.Wrap(err))
+			return
+		}
+
+		itemB, err, okB = nextB()
+
+		for {
+			if err != nil {
+				yield(*new(T), trace.Wrap(err))
+				return
+			}
+			switch {
+			case !okA && !okB:
+				return
+			case !okA:
+				if !yield(itemB, nil) {
+					return
+				}
+
+				itemB, err, okB = nextB()
+			case !okB:
+				if !yield(itemA, nil) {
+					return
+				}
+
+				itemA, err, okA = nextA()
+			default:
+				if less(itemA, itemB) {
+					if !yield(itemA, nil) {
+						return
+					}
+
+					itemA, err, okA = nextA()
+				} else {
+					if !yield(itemB, nil) {
+						return
+					}
+
+					itemB, err, okB = nextB()
+				}
+			}
+		}
+	}
+}

--- a/lib/itertools/stream/stream_test.go
+++ b/lib/itertools/stream/stream_test.go
@@ -1,0 +1,886 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package stream
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSlice tests the slice stream.
+func TestSlice(t *testing.T) {
+	t.Parallel()
+
+	// normal usage
+	s, err := Collect(Slice([]int{1, 2, 3}))
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3}, s)
+
+	// single-element slice
+	s, err = Collect(Slice([]int{100}))
+	require.NoError(t, err)
+	require.Equal(t, []int{100}, s)
+
+	// nil slice
+	s, err = Collect(Slice([]int(nil)))
+	require.NoError(t, err)
+	require.Empty(t, s)
+}
+
+// TestFilterMap tests the FilterMap combinator.
+func TestFilterMap(t *testing.T) {
+	t.Parallel()
+
+	// normal usage
+	s, err := Collect(FilterMap(Slice([]int{1, 2, 3, 4}), func(i int) (string, bool) {
+		if i%2 == 0 {
+			return fmt.Sprintf("%d", i*10), true
+		}
+		return "", false
+	}))
+	require.NoError(t, err)
+	require.Equal(t, []string{"20", "40"}, s)
+
+	// single-match
+	s, err = Collect(FilterMap(Slice([]int{1, 2, 3, 4}), func(i int) (string, bool) {
+		if i == 3 {
+			return "three", true
+		}
+		return "", false
+	}))
+	require.NoError(t, err)
+	require.Equal(t, []string{"three"}, s)
+
+	// no matches
+	s, err = Collect(FilterMap(Slice([]int{1, 2, 3, 4}), func(i int) (string, bool) {
+		return "", false
+	}))
+	require.NoError(t, err)
+	require.Empty(t, s)
+
+	// empty stream
+	s, err = Collect(FilterMap(Empty[int](), func(_ int) (string, bool) { panic("unreachable") }))
+	require.NoError(t, err)
+	require.Empty(t, s)
+
+	// failure
+	err = Drain(FilterMap(Fail[int](fmt.Errorf("unexpected error")), func(_ int) (string, bool) { panic("unreachable") }))
+	require.Error(t, err)
+}
+
+// TestChain tests the Chain combinator.
+func TestChain(t *testing.T) {
+	t.Parallel()
+
+	// normal usage
+	s, err := Collect(Chain(
+		Slice([]int{1, 2, 3}),
+		Slice([]int{4}),
+		Slice([]int{5, 6}),
+	))
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3, 4, 5, 6}, s)
+
+	// single substream
+	s, err = Collect(Chain(Slice([]int{1, 2, 3})))
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3}, s)
+
+	// no substreams
+	s, err = Collect(Chain[int]())
+	require.NoError(t, err)
+	require.Empty(t, s)
+
+	// some empty substreams
+	s, err = Collect(Chain(
+		Empty[int](),
+		Slice([]int{4, 5, 6}),
+		Empty[int](),
+	))
+	require.NoError(t, err)
+	require.Equal(t, []int{4, 5, 6}, s)
+
+	// all empty substreams
+	s, err = Collect(Chain(
+		Empty[int](),
+		Empty[int](),
+	))
+	require.NoError(t, err)
+	require.Empty(t, s)
+
+	// late failure
+	s, err = Collect(Chain(
+		Slice([]int{7, 7, 7}),
+		Fail[int](fmt.Errorf("some error")),
+	))
+	require.Error(t, err)
+	require.Equal(t, []int{7, 7, 7}, s)
+
+	// early failure
+	s, err = Collect(Chain(
+		Fail[int](fmt.Errorf("some other error")),
+		Func(func() (int, error) { panic("unreachable") }),
+	))
+	require.Error(t, err)
+	require.Empty(t, s)
+}
+
+// TestChunks tests the Chunks combinator.
+func TestChunks(t *testing.T) {
+	t.Parallel()
+
+	// normal usage
+	s, err := Collect(Chunks(Slice([]int{1, 2, 3, 4, 5, 6}), 2))
+	require.NoError(t, err)
+	require.Equal(t, [][]int{{1, 2}, {3, 4}, {5, 6}}, s)
+
+	// single-element chunks
+	s, err = Collect(Chunks(Slice([]int{1, 2, 3, 4, 5, 6}), 1))
+	require.NoError(t, err)
+	require.Equal(t, [][]int{{1}, {2}, {3}, {4}, {5}, {6}}, s)
+
+	// empty stream
+	s, err = Collect(Chunks(Empty[int](), 2))
+	require.NoError(t, err)
+	require.Empty(t, s)
+
+	// zero chunk size
+	s, err = Collect(Chunks(Slice([]int{1, 2, 3, 4, 5, 6}), 0))
+	require.NoError(t, err)
+	require.Equal(t, ([][]int)(nil), s)
+
+	// negative chunk size
+	s, err = Collect(Chunks(Slice([]int{1, 2, 3, 4, 5, 6}), -1))
+	require.NoError(t, err)
+	require.Equal(t, ([][]int)(nil), s)
+
+	// chunk size larger than stream
+	s, err = Collect(Chunks(Slice([]int{1, 2, 3, 4, 5, 6}), 10))
+	require.NoError(t, err)
+	require.Equal(t, [][]int{{1, 2, 3, 4, 5, 6}}, s)
+
+	// chunk size equal to stream size
+	s, err = Collect(Chunks(Slice([]int{1, 2, 3, 4, 5, 6}), 6))
+	require.NoError(t, err)
+	require.Equal(t, [][]int{{1, 2, 3, 4, 5, 6}}, s)
+
+	// chunk size with remainder
+	s, err = Collect(Chunks(Slice([]int{1, 2, 3, 4, 5, 6}), 4))
+	require.NoError(t, err)
+	require.Equal(t, [][]int{{1, 2, 3, 4}, {5, 6}}, s)
+
+	// chunk with immediate failure
+	err = Drain(Chunks(Fail[int](fmt.Errorf("unexpected error")), 2))
+	require.Error(t, err)
+
+	// chunk with failure after a few iterations
+	err = Drain(Chunks(Chain(
+		Slice([]int{1, 2, 3}),
+		Fail[int](fmt.Errorf("unexpected error")),
+		Slice([]int{4, 5, 6}),
+	), 2))
+	require.Error(t, err)
+}
+
+// TestFunc tests the Func stream.
+func TestFunc(t *testing.T) {
+	t.Parallel()
+
+	// normal usage
+	var n int
+	s, err := Collect(Func(func() (int, error) {
+		n++
+		if n > 3 {
+			return 0, io.EOF
+		}
+		return n, nil
+	}))
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3}, s)
+
+	// single-element
+	var once bool
+	s, err = Collect(Func(func() (int, error) {
+		if once {
+			return 0, io.EOF
+		}
+		once = true
+		return 100, nil
+	}))
+	require.NoError(t, err)
+	require.Equal(t, []int{100}, s)
+
+	// no element
+	s, err = Collect(Func(func() (int, error) {
+		return 0, io.EOF
+	}))
+	require.NoError(t, err)
+	require.Empty(t, s)
+
+	// immediate error
+	err = Drain(Func(func() (int, error) {
+		return 0, fmt.Errorf("unexpected error")
+	}))
+	require.Error(t, err)
+
+	// error after a few streamations
+	n = 0
+	err = Drain(Func(func() (int, error) {
+		n++
+		if n > 10 {
+			return 0, fmt.Errorf("unexpected error")
+		}
+		return n, nil
+	}))
+	require.Error(t, err)
+}
+
+func TestPageFunc(t *testing.T) {
+	t.Parallel()
+
+	// basic pages
+	var n int
+	s, err := Collect(PageFunc(func() ([]int, error) {
+		n++
+		if n > 3 {
+			return nil, io.EOF
+		}
+		return []int{
+			n,
+			n * 10,
+			n * 100,
+		}, nil
+	}))
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 10, 100, 2, 20, 200, 3, 30, 300}, s)
+
+	// single page
+	var once bool
+	s, err = Collect(PageFunc(func() ([]int, error) {
+		if once {
+			return nil, io.EOF
+		}
+		once = true
+		return []int{1, 2, 3}, nil
+	}))
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3}, s)
+
+	// single element
+	once = false
+	s, err = Collect(PageFunc(func() ([]int, error) {
+		if once {
+			return nil, io.EOF
+		}
+		once = true
+		return []int{100}, nil
+	}))
+	require.NoError(t, err)
+	require.Equal(t, []int{100}, s)
+
+	// no pages
+	s, err = Collect(PageFunc(func() ([]int, error) {
+		return nil, io.EOF
+	}))
+	require.NoError(t, err)
+	require.Empty(t, s)
+
+	// lots of empty pages
+	n = 0
+	s, err = Collect(PageFunc(func() ([]int, error) {
+		n++
+		switch n {
+		case 5:
+			return []int{1, 2, 3}, nil
+		case 10:
+			return []int{4, 5, 6}, nil
+		case 15:
+			return nil, io.EOF
+		default:
+			return nil, nil
+		}
+	}))
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3, 4, 5, 6}, s)
+
+	// only empty and/or nil pages
+	n = 0
+	s, err = Collect(PageFunc(func() ([]int, error) {
+		n++
+		if n > 20 {
+			return nil, io.EOF
+		}
+		if n%2 == 0 {
+			return []int{}, nil
+		}
+		return nil, nil
+	}))
+	require.NoError(t, err)
+	require.Empty(t, s)
+
+	// eventual failure
+	n = 0
+	s, err = Collect(PageFunc(func() ([]int, error) {
+		n++
+		if n > 3 {
+			return nil, fmt.Errorf("bad things")
+		}
+		return []int{1, 2, 3}, nil
+	}))
+	require.Error(t, err)
+	require.Equal(t, []int{1, 2, 3, 1, 2, 3, 1, 2, 3}, s)
+
+	// immediate failure
+	err = Drain(PageFunc(func() ([]int, error) {
+		return nil, fmt.Errorf("very bad things")
+	}))
+	require.Error(t, err)
+}
+
+// TestEmpty tests the Empty/Fail stream.
+func TestEmpty(t *testing.T) {
+	t.Parallel()
+
+	// empty case
+	s, err := Collect(Empty[int]())
+	require.NoError(t, err)
+	require.Empty(t, s)
+
+	// normal error case
+	s, err = Collect(Fail[int](fmt.Errorf("unexpected error")))
+	require.Error(t, err)
+	require.Empty(t, s)
+
+	// nil error case
+	s, err = Collect(Fail[int](nil))
+	require.NoError(t, err)
+	require.Empty(t, s)
+}
+
+// TestOnceFunc tests the OnceFunc stream combinator.
+func TestOnceFunc(t *testing.T) {
+	t.Parallel()
+
+	// single-element variant
+	s, err := Collect(OnceFunc(func() (int, error) {
+		return 1, nil
+	}))
+	require.NoError(t, err)
+	require.Equal(t, []int{1}, s)
+
+	// empty stream case
+	s, err = Collect(OnceFunc(func() (int, error) {
+		return 1, io.EOF
+	}))
+	require.NoError(t, err)
+	require.Empty(t, s)
+
+	// error case
+	s, err = Collect(OnceFunc(func() (int, error) {
+		return 1, fmt.Errorf("unexpected error")
+	}))
+	require.Error(t, err)
+	require.Empty(t, s)
+}
+
+func TestCollectPages(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		pages  [][]string
+		expect []string
+		err    error
+		desc   string
+	}{
+		{
+			pages: [][]string{
+				{"foo", "bar"},
+				{},
+				{"bin", "baz"},
+			},
+			expect: []string{
+				"foo",
+				"bar",
+				"bin",
+				"baz",
+			},
+			desc: "basic-depagination",
+		},
+		{
+			pages: [][]string{
+				{"one"},
+			},
+			expect: []string{"one"},
+			desc:   "single-element-case",
+		},
+		{
+			desc: "empty-case",
+		},
+		{
+			err:  fmt.Errorf("failure"),
+			desc: "error-case",
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.desc, func(t *testing.T) {
+			var stream Stream[[]string]
+			if tt.err == nil {
+				stream = Slice(tt.pages)
+			} else {
+				stream = Fail[[]string](tt.err)
+			}
+			collected, err := CollectPages(stream)
+			if tt.err == nil {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+			if len(tt.expect) == 0 {
+				require.Empty(t, collected)
+			} else {
+				require.Equal(t, tt.expect, collected)
+			}
+		})
+	}
+}
+
+// TestSkip tests the Skip combinator.
+func TestSkip(t *testing.T) {
+	t.Parallel()
+
+	// normal usage
+	s, err := Collect(Skip(Slice([]int{1, 2, 3, 4}), 2))
+	require.NoError(t, err)
+	require.Equal(t, []int{3, 4}, s)
+
+	// skip all
+	s, err = Collect(Skip(Slice([]int{1, 2, 3, 4}), 4))
+	require.NoError(t, err)
+	require.Empty(t, s)
+
+	// skip none
+	s, err = Collect(Skip(Slice([]int{1, 2, 3, 4}), 0))
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3, 4}, s)
+
+	// negative skip
+	s, err = Collect(Skip(Slice([]int{1, 2, 3, 4}), -1))
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3, 4}, s)
+
+	// skip more than available
+	s, err = Collect(Skip(Slice([]int{1, 2, 3, 4}), 5))
+	require.NoError(t, err)
+	require.Empty(t, s)
+
+	// positive skip on empty stream
+	s, err = Collect(Skip(Empty[int](), 2))
+	require.NoError(t, err)
+	require.Empty(t, s)
+
+	// zero skip on empty stream
+	s, err = Collect(Skip(Empty[int](), 0))
+	require.NoError(t, err)
+	require.Empty(t, s)
+
+	// negative skip on empty stream
+	s, err = Collect(Skip(Empty[int](), -1))
+	require.NoError(t, err)
+	require.Empty(t, s)
+
+	// immediate failure
+	err = Drain(Skip(Fail[int](fmt.Errorf("unexpected error")), 1))
+	require.Error(t, err)
+
+	// failure during skip
+	err = Drain(Skip(Chain(
+		Slice([]int{1, 2}),
+		Fail[int](fmt.Errorf("unexpected error")),
+		Slice([]int{3, 4}),
+	), 3))
+	require.Error(t, err)
+}
+
+// TestFlatten tests the Flatten combinator.
+func TestFlatten(t *testing.T) {
+	t.Parallel()
+
+	// normal usage
+	s, err := Collect(Flatten(Slice([]Stream[int]{
+		Slice([]int{1, 2}),
+		Slice([]int{3, 4}),
+		Slice([]int{5, 6}),
+	})))
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3, 4, 5, 6}, s)
+
+	// empty stream
+	s, err = Collect(Flatten(Empty[Stream[int]]()))
+	require.NoError(t, err)
+	require.Empty(t, s)
+
+	// empty substreams
+	s, err = Collect(Flatten(Slice([]Stream[int]{
+		Empty[int](),
+		Slice([]int{1, 2, 3}),
+		Empty[int](),
+		Slice([]int{4, 5, 6}),
+		Empty[int](),
+	})))
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3, 4, 5, 6}, s)
+
+	// immediate failure
+	err = Drain(Flatten(Fail[Stream[int]](fmt.Errorf("unexpected error"))))
+	require.Error(t, err)
+
+	// failure during streaming
+	s, err = Collect(Flatten(Slice([]Stream[int]{
+		Slice([]int{1, 2}),
+		Fail[int](fmt.Errorf("unexpected error")),
+		Slice([]int{3, 4}),
+	})))
+	require.Error(t, err)
+	require.Equal(t, []int{1, 2}, s)
+}
+
+// TestMapErr tests the MapErr combinator.
+func TestMapErr(t *testing.T) {
+	t.Parallel()
+
+	// normal inject error
+	err := Drain(MapErr(Slice([]int{1, 2, 3}), func(err error) error {
+		require.NoError(t, err)
+		return fmt.Errorf("unexpected error")
+	}))
+	require.Error(t, err)
+
+	// empty inject error
+	err = Drain(MapErr(Empty[int](), func(err error) error {
+		require.NoError(t, err)
+		return fmt.Errorf("unexpected error")
+	}))
+	require.Error(t, err)
+
+	// normal suppress error
+	s, err := Collect(MapErr(Chain(Slice([]int{1, 2, 3}), Fail[int](fmt.Errorf("unexpected error"))), func(err error) error {
+		require.Error(t, err)
+		return nil
+	}))
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3}, s)
+
+	// empty suppress error
+	s, err = Collect(MapErr(Fail[int](fmt.Errorf("unexpected error")), func(err error) error {
+		require.Error(t, err)
+		return nil
+	}))
+	require.NoError(t, err)
+	require.Empty(t, s)
+}
+
+// TestRateLimitFailure verifies the expected failure conditions of the RateLimit helper.
+func TestRateLimitFailure(t *testing.T) {
+	t.Parallel()
+
+	var limiterError = errors.New("limiter-error")
+	var streamError = errors.New("stream-error")
+
+	tts := []struct {
+		desc    string
+		items   int
+		stream  error
+		limiter error
+		expect  error
+	}{
+		{
+			desc:    "simultaneous",
+			stream:  streamError,
+			limiter: limiterError,
+			expect:  streamError,
+		},
+		{
+			desc:   "stream-only",
+			stream: streamError,
+			expect: streamError,
+		},
+		{
+			desc:    "limiter-only",
+			limiter: limiterError,
+			expect:  limiterError,
+		},
+		{
+			desc:    "limiter-graceful",
+			limiter: io.EOF,
+			expect:  nil,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.desc, func(t *testing.T) {
+			// stream must be non-empty for limiter to be triggered
+			stream := Once(1)
+			if tt.stream != nil {
+				stream = Fail[int](tt.stream)
+			}
+			err := Drain(RateLimit(stream, func() error { return tt.limiter }))
+			if tt.expect == nil {
+				require.NoError(t, err)
+				return
+			}
+
+			require.ErrorIs(t, err, tt.expect)
+		})
+	}
+}
+
+// TestRateLimit sets up a concurrent channel-based limiter and verifies its effect on a pool of workers consuming
+// items from streams.
+func TestRateLimit(t *testing.T) {
+	t.Parallel()
+
+	const workers = 16
+	const maxItemsPerWorker = 16
+	const tokens = 100
+	const burst = 10
+
+	lim := make(chan struct{}, burst)
+	done := make(chan struct{})
+
+	results := make(chan error, workers)
+
+	items := make(chan struct{}, tokens+1)
+
+	for i := 0; i < workers; i++ {
+		go func() {
+			stream := RateLimit(repeat("some-item", maxItemsPerWorker), func() error {
+				select {
+				case <-lim:
+					return nil
+				case <-done:
+					// make sure we still consume remaining tokens even if 'done' is closed (simplifies
+					// test logic by letting us close 'done' immediately after sending last token without
+					// worrying about racing).
+					select {
+					case <-lim:
+						return nil
+					default:
+						return io.EOF
+					}
+				}
+			})
+
+			for _, err := range stream {
+				if err != nil {
+					results <- err
+					return
+				}
+				items <- struct{}{}
+			}
+
+			results <- nil
+		}()
+	}
+
+	// limiter isn't applied until after the first item is yielded, so pop the first item
+	// from each worker immediately to simplify test logic.
+	for i := 0; i < workers; i++ {
+		select {
+		case <-items:
+		case <-time.After(time.Second * 10):
+			require.FailNow(t, "timeout waiting for first item")
+		}
+	}
+
+	// yielded tracks total number of tokens yielded on limiter channel
+	var yielded int
+
+	// do an initial fill of limiter channel
+	for i := 0; i < burst; i++ {
+		select {
+		case lim <- struct{}{}:
+			yielded++
+		default:
+			require.FailNow(t, "initial burst should never block")
+		}
+	}
+
+	var consumed int
+
+	// consume item receipt events
+	timeoutC := time.After(time.Second * 30)
+	for i := 0; i < burst; i++ {
+		select {
+		case <-items:
+			consumed++
+		case <-timeoutC:
+			require.FailNow(t, "timeout waiting for item")
+		}
+	}
+
+	// ensure no more items available
+	select {
+	case <-items:
+		require.FailNow(t, "received item without corresponding token yield")
+	default:
+	}
+
+	// yield the rest of the tokens
+	for yielded < tokens {
+		select {
+		case lim <- struct{}{}:
+			yielded++
+		case <-timeoutC:
+			require.FailNow(t, "timeout waiting to yield token")
+		}
+	}
+
+	// signal workers that they should exit once remaining tokens
+	// are consumed.
+	close(done)
+
+	// wait for all workers to finish
+	for i := 0; i < workers; i++ {
+		select {
+		case err := <-results:
+			require.NoError(t, err)
+		case <-timeoutC:
+			require.FailNow(t, "timeout waiting for worker to exit")
+		}
+	}
+
+	// consume the rest of the item events
+ConsumeItems:
+	for {
+		select {
+		case <-items:
+			consumed++
+		default:
+			break ConsumeItems
+		}
+	}
+
+	// note that total number of processed items may actually vary since we are rate-limiting
+	// how frequently a stream is *polled*, not how frequently it yields an item. A stream being
+	// polled may result in us discovering that it is empty, in which case a limiter token is still
+	// consumed, but no item is yielded.
+	require.LessOrEqual(t, consumed, tokens)
+	require.GreaterOrEqual(t, consumed, tokens-workers)
+}
+
+// repeat repeats the same item N times
+func repeat[T any](item T, count int) Stream[T] {
+	var n int
+	return Func(func() (T, error) {
+		n++
+		if n > count {
+			var zero T
+			return zero, io.EOF
+		}
+		return item, nil
+	})
+}
+
+// TestMergeStreams tests the MergeStreams adapter.
+func TestMergeStreams(t *testing.T) {
+	t.Parallel()
+
+	// Mock compare function that favors the lower value.
+	compareFunc := func(a, b int) bool {
+		return a <= b
+	}
+
+	// Test the case where the streams should have interlaced values.
+	t.Run("interlaced streams", func(t *testing.T) {
+		streamA := Slice([]int{1, 3, 5})
+		streamB := Slice([]int{2, 4, 6})
+
+		resultStream := MergeStreams(streamA, streamB, compareFunc)
+		out, err := Collect(resultStream)
+
+		require.NoError(t, err)
+		require.Equal(t, []int{1, 2, 3, 4, 5, 6}, out)
+	})
+
+	// Test the case where streamA is empty.
+	t.Run("stream A empty", func(t *testing.T) {
+		streamA := Empty[int]()
+		streamB := Slice([]int{1, 2, 3})
+
+		resultStream := MergeStreams(streamA, streamB, compareFunc)
+		out, err := Collect(resultStream)
+
+		require.NoError(t, err)
+		require.Equal(t, []int{1, 2, 3}, out)
+	})
+
+	// Test the case where streamB is empty.
+	t.Run("stream B empty", func(t *testing.T) {
+		streamA := Slice([]int{1, 2, 3})
+		streamB := Empty[int]()
+
+		resultStream := MergeStreams(streamA, streamB, compareFunc)
+		out, err := Collect(resultStream)
+
+		require.NoError(t, err)
+		require.Equal(t, []int{1, 2, 3}, out)
+	})
+
+	// Test the case where both streams are empty.
+	t.Run("both streams empty", func(t *testing.T) {
+		streamA := Empty[int]()
+		streamB := Empty[int]()
+
+		resultStream := MergeStreams(streamA, streamB, compareFunc)
+		out, err := Collect(resultStream)
+
+		require.NoError(t, err)
+		require.Empty(t, out)
+	})
+
+	// Test the case where every value in streamA is lower than every value in streamB.
+	t.Run("compare always favors A", func(t *testing.T) {
+		streamA := Slice([]int{1, 2, 3})
+		streamB := Slice([]int{4, 5, 6})
+
+		resultStream := MergeStreams(streamA, streamB, compareFunc)
+		out, err := Collect(resultStream)
+
+		require.NoError(t, err)
+		require.Equal(t, []int{1, 2, 3, 4, 5, 6}, out)
+	})
+
+	// Test the case where every value in streamB is lower than every value in streamA.
+	t.Run("compare always favors B", func(t *testing.T) {
+		streamA := Slice([]int{4, 5, 6})
+		streamB := Slice([]int{1, 2, 3})
+
+		resultStream := MergeStreams(streamA, streamB, compareFunc)
+		out, err := Collect(resultStream)
+
+		require.NoError(t, err)
+		require.Equal(t, []int{1, 2, 3, 4, 5, 6}, out)
+	})
+}


### PR DESCRIPTION
This PR provides a potential replacement for `internalutils/stream` now that go supports iterators.  Our API package is still on a version of go too early for iterators, so we're still limited on where we can use them, but adoption has started with work like the new `Backend.Items` API.

This PR attempts to be a drop-in replacement for most (but not all) of the functionality of `internalutils/stream`.  From testing, a bit over half of our stream logic can be swapped over just by changing the import to point to this new package (though in many cases doing so right now breaks `api/` because of the aforementioned versioning issue).

Test coverage in this package is copied almost verbatim from `internalutils/stream`, with most tests entirely unchanged.

New `FromLegacy` and `ToLegacy` adapters have been added for convenient interop with `internalutils/stream`.

The key differences between this package and `internalutils/stream` are:

- The process of manually consuming a stream differs (range based instead of a scanner-style flow), meaning all consuming logic that doesn't use a helper like `Collect` will need to change.
- The `Take` helper has been omitted since iterator based streams are push based by default and don't map well to a combinator like `Take` without adding a lot of additional complexity to the API.  Existing usages of `Take` will likely need to be evaluated on a case-by-case basis to determine what the best alternative flow is.
- The `Func` and `PageFunc` combinators had their ability to register closers removed. Iterator-based streams use a different cleanup pattern that requires that associated setup does not happen until the iterator is used.  Most existing usages of the `Func` family of combinators should be switched over to manually implemented iterators.
- The `MergeStreams` combinator was simplified to no longer support remapping of types (old behavior is achievable by pre-processing the streams first with `FilterMap`).
- The `Chunks` combinator was added because Edoardo likes his iterators chunky.
