### PR TITLE
Make sure (*Struct).Fields map is not nil before assigment

### DIFF
--- a/api/types/events/events.go
+++ b/api/types/events/events.go
@@ -192,6 +192,11 @@ func (m *Struct) trimToMaxSize(maxSize int) *Struct {
 		if v != nil {
 			if strVal := v.GetStringValue(); strVal != "" {
 				trimmedVal := trimStr(strVal, maxSize)
+
+				if out.Fields == nil {
+					out.Fields = make(map[string]*types.Value)
+				}
+
 				out.Fields[trimmedKey] = &types.Value{
 					Kind: &types.Value_StringValue{
 						StringValue: trimmedVal,

--- a/api/types/events/struct_test.go
+++ b/api/types/events/struct_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2025 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gogo/protobuf/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStructTrimToMaxSize(t *testing.T) {
+	testCases := []struct {
+		name    string
+		maxSize int
+		in      *Struct
+		want    *Struct
+	}{
+		{
+			name:    "Field key exceeds max limit size",
+			maxSize: 10,
+			in: &Struct{
+				Struct: types.Struct{
+					Fields: map[string]*types.Value{
+						strings.Repeat("A", 100): {
+							Kind: &types.Value_StringValue{
+								StringValue: "A",
+							},
+						},
+					},
+				},
+			},
+			want: &Struct{
+				Struct: types.Struct{
+					Fields: map[string]*types.Value{
+						strings.Repeat("A", 8): {
+							Kind: &types.Value_StringValue{
+								StringValue: "A",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.in.trimToMaxSize(tc.maxSize)
+			require.True(t, reflect.DeepEqual(got, tc.want))
+		})
+	}
+}


### PR DESCRIPTION
During the following operation:

```
				out.Fields[trimmedKey] = &types.Value{
					Kind: &types.Value_StringValue{
						StringValue: trimmedVal,
					},
				}
```

fields map is not initialized and panics, i.e:

```
panic: assignment to entry in nil map

goroutine 2747 [running]:
github.com/gravitational/teleport/api/types/events.(*Struct).trimToMaxSize(0xc00370f5c0, 0x2dc4)
    github.com/gravitational/teleport/api@v0.0.0/types/events/events.go:195 +0x5d0
github.com/gravitational/teleport/api/types/events.(*AppSessionDynamoDBRequest).TrimToMaxSize(0xc002b3c848, 0x10000)
    github.com/gravitational/teleport/api@v0.0.0/types/events/events.go:811 +0x4ee
github.com/gravitational/teleport/lib/events.(*ProtoStream).RecordEvent(0xc00307bd40, {0x55740285e470, 0xc0032bfc70}, {0x55740275f7c0?, 0xc003908970?})
    github.com/gravitational/teleport/lib/events/stream.go:395 +0x9e
github.com/gravitational/teleport/lib/events.(*SessionWriter).processEvents(0xc00307be60)
    github.com/gravitational/teleport/lib/events/session_writer.go:435 +0x336
github.com/gravitational/teleport/lib/events.NewSessionWriter.func1()
    github.com/gravitational/teleport/lib/events/session_writer.go:61 +0x1c
created by github.com/gravitational/teleport/lib/events.NewSessionWriter in goroutine 2744
    github.com/gravitational/teleport/lib/events/session_writer.go:60 +0x33b
```

This occurs for example in DynamoDB queries.

I added very simple test case that covers `trimToMaxSize` for given type.

changelog: fix panic when trimming audit log entries