### PR TITLE
Remove Workload ID design partner CTA

### DIFF
--- a/docs/pages/enroll-resources/workload-identity/aws-oidc-federation.mdx
+++ b/docs/pages/enroll-resources/workload-identity/aws-oidc-federation.mdx
@@ -3,8 +3,6 @@ title: Configuring Workload Identity and AWS OIDC Federation
 description: Configuring AWS to accept Workload Identity JWTs as authentication using OIDC Federation
 ---
 
-(!/docs/pages/includes/workload-id-preview.mdx!)
-
 Teleport Workload Identity issues flexible short-lived identities in JWT format.
 AWS OIDC Federation allows you to use these JWTs to authenticate to AWS
 services.

--- a/docs/pages/enroll-resources/workload-identity/aws-roles-anywhere.mdx
+++ b/docs/pages/enroll-resources/workload-identity/aws-roles-anywhere.mdx
@@ -3,8 +3,6 @@ title: Configuring Workload Identity and AWS Roles Anywhere
 description: Configuring AWS to accept Workload Identity certificates as authentication using AWS Roles Anywhere
 ---
 
-(!/docs/pages/includes/workload-id-preview.mdx!)
-
 Teleport Workload Identity issues flexible short-lived identities in X.509
 certificates. AWS Roles Anywhere allows you to use these certificates to
 authenticate to AWS services.

--- a/docs/pages/enroll-resources/workload-identity/azure-federated-credentials.mdx
+++ b/docs/pages/enroll-resources/workload-identity/azure-federated-credentials.mdx
@@ -3,8 +3,6 @@ title: Configuring Workload Identity and Azure Federated Credentials
 description: Configuring Azure to accept Workload Identity JWTs as authentication using Azure Federated Credentials
 ---
 
-(!/docs/pages/includes/workload-id-preview.mdx!)
-
 Teleport Workload Identity issues flexible short-lived identities in JWT format.
 Azure Federated Credentials allows you to use these JWTs to authenticate to
 Azure services.

--- a/docs/pages/enroll-resources/workload-identity/best-practices.mdx
+++ b/docs/pages/enroll-resources/workload-identity/best-practices.mdx
@@ -3,8 +3,6 @@ title: Best Practices for Teleport Workload Identity
 description: Answers common questions and describes best practices for using Teleport Workload Identity in production.
 ---
 
-(!/docs/pages/includes/workload-id-preview.mdx!)
-
 This page covers common questions and best practices for using Teleport's
 Workload Identity feature in production.
 

--- a/docs/pages/enroll-resources/workload-identity/federation.mdx
+++ b/docs/pages/enroll-resources/workload-identity/federation.mdx
@@ -3,8 +3,6 @@ title: SPIFFE Federation
 description: An overview of the Teleport Workload Identity SPIFFE Federation feature.
 ---
 
-(!/docs/pages/includes/workload-id-preview.mdx!)
-
 Federation allows a relationship to be established between your Teleport
 Workload Identity trust domain and another trust domain, enabling workloads
 within the two trust domains to validate each other's identities. This can be

--- a/docs/pages/enroll-resources/workload-identity/gcp-workload-identity-federation-jwt.mdx
+++ b/docs/pages/enroll-resources/workload-identity/gcp-workload-identity-federation-jwt.mdx
@@ -3,8 +3,6 @@ title: Configuring Workload Identity and GCP Workload Identity Federation with J
 description: Configuring GCP to accept Workload Identity JWTs as authentication using Workload Identity Federation
 ---
 
-(!/docs/pages/includes/workload-id-preview.mdx!)
-
 Teleport Workload Identity issues flexible short-lived identities in JWT format.
 GCP Workload Identity Federation allows you to use these JWTs to authenticate to
 GCP services.

--- a/docs/pages/enroll-resources/workload-identity/getting-started.mdx
+++ b/docs/pages/enroll-resources/workload-identity/getting-started.mdx
@@ -3,8 +3,6 @@ title: Getting Started with Workload Identity
 description: Getting started with Teleport Workload Identity for SPIFFE and Machine ID
 ---
 
-(!/docs/pages/includes/workload-id-preview.mdx!)
-
 Teleport's Workload Identity issues flexible short-lived identities intended
 for workloads. It is compatible with the industry-standard SPIFFE specification
 meaning that it can be used in place of other SPIFFE compatible identity

--- a/docs/pages/enroll-resources/workload-identity/introduction.mdx
+++ b/docs/pages/enroll-resources/workload-identity/introduction.mdx
@@ -3,8 +3,6 @@ title: Introduction to Workload Identity
 description: Describes Teleport Workload Identity, which securely issues flexible, short-lived cryptographic identities to workloads and non-human identities.
 ---
 
-(!/docs/pages/includes/workload-id-preview.mdx!)
-
 Teleport Workload Identity securely issues short-lived cryptographic identities
 to workloads. It is a flexible foundation for workload identity across your 
 infrastructure, creating a uniform way for your workloads to authenticate 

--- a/docs/pages/enroll-resources/workload-identity/jwt-svids.mdx
+++ b/docs/pages/enroll-resources/workload-identity/jwt-svids.mdx
@@ -3,8 +3,6 @@ title: JWT SVIDs
 description: An overview of the JWT SVIDs issued by Teleport Workload Identity
 ---
 
-(!/docs/pages/includes/workload-id-preview.mdx!)
-
 One type of credential that can be issued by Teleport Workload Identity is a
 JWT SVID. This is a short-lived JSON Web Token (JWT) that contains the identity
 of the workload and is signed by the Teleport Workload Identity CA.

--- a/docs/pages/enroll-resources/workload-identity/tsh.mdx
+++ b/docs/pages/enroll-resources/workload-identity/tsh.mdx
@@ -3,8 +3,6 @@ title: Workload Identity and tsh
 description: Issuing SPIFFE SVIDs using Workload Identity and tsh
 ---
 
-(!/docs/pages/includes/workload-id-preview.mdx!)
-
 In some scenarios, you may wish to issue a SPIFFE SVID manually, without using
 Machine ID. This can be useful in scenarios where you need to impersonate a
 service for the purposes of debugging or could provide a mechanism for providing

--- a/docs/pages/enroll-resources/workload-identity/workload-attestation.mdx
+++ b/docs/pages/enroll-resources/workload-identity/workload-attestation.mdx
@@ -3,8 +3,6 @@ title: Workload Attestation
 description: An overview of the Teleport Workload Identity Workload Attestation feature.
 ---
 
-(!/docs/pages/includes/workload-id-preview.mdx!)
-
 Workload Attestation is the process completed by `tbot` to assert the identity
 of a workload that has connected to the Workload API and requested certificates.
 The information gathered during attestation is used to decide which, if any,

--- a/docs/pages/includes/workload-id-preview.mdx
+++ b/docs/pages/includes/workload-id-preview.mdx
@@ -1,5 +1,0 @@
-<Admonition type="tip" title="Design Partnership">
-We're actively looking for design partners to help us shape the future of
-Teleport Workload Identity and would love to
-<a href="mailto:product@goteleport.com">hear your feedback</a>.
-</Admonition>


### PR DESCRIPTION
We're no longer looking for design partners for this product now that we have officially launched it. Removing this CTA to keep messaging clearer when we send resources to people. @strideynet and I had discussed this as a thing to get to soon, but I've now gotten some internal requests to remove it as soon as we can.