### PR TITLE
Replace Notices with Docusaurus syntax

### DIFF
--- a/docs/pages/admin-guides/access-controls/access-monitoring.mdx
+++ b/docs/pages/admin-guides/access-controls/access-monitoring.mdx
@@ -15,7 +15,7 @@ or database sessions without MFA) and provides users with recommendations on sug
 
 Users are able to write their own custom access monitoring queries by querying the audit log.
 
-<Admonition type="notice">
+<Admonition type="note">
   Access Monitoring is not currently supported with External Audit Storage
   in Teleport Enterprise (Cloud). This functionality will be
   enabled in a future Teleport release.

--- a/docs/pages/admin-guides/access-controls/access-request-plugins/datadog-hosted.mdx
+++ b/docs/pages/admin-guides/access-controls/access-request-plugins/datadog-hosted.mdx
@@ -199,7 +199,7 @@ approve or deny the request:
 
 ![Review access request](../../../../img/enterprise/plugins/datadog/review-access-request.png)
 
-<Admonition title="Auditing Access Requests">
+<Admonition type="info" title="Auditing Access Requests">
 
 When the Datadog plugin sends a notification, anyone who receives the
 notification can follow the enclosed link to an Access Request URL. While users

--- a/docs/pages/admin-guides/access-controls/access-request-plugins/opsgenie.mdx
+++ b/docs/pages/admin-guides/access-controls/access-request-plugins/opsgenie.mdx
@@ -130,7 +130,7 @@ or in the schedules specified by `teleport.dev/notify-services` annotation in th
 
 (!docs/pages/includes/plugins/resolve-request.mdx!)
 
-<Admonition title="Auditing Access Requests">
+<Admonition type="info" title="Auditing Access Requests">
 
 When the Opsgenie plugin sends a notification, anyone who receives the
 notification can follow the enclosed link to an Access Request URL. While users

--- a/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-email.mdx
+++ b/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-email.mdx
@@ -181,13 +181,13 @@ the URL scheme and port. (If you're using a local SMTP server for testing, use
 If you are running the email plugin on a Linux host, fill in `username` and
 `password`.
 
-<Notice type="tip">
+<Admonition type="tip">
 
 You can also save your password to a separate file and assign `password_file` to
 the file's path. The plugin reads the file and uses the file's content as the
 password.
 
-</Notice>
+</Admonition>
 
 If you are deploying the email plugin on Kubernetes:
 

--- a/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-jira.mdx
+++ b/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-jira.mdx
@@ -127,13 +127,13 @@ following:
 
 ![Jira board setup](../../../../img/enterprise/plugins/jira/board-setup.png)
 
-<Notice type="warning">
+<Admonition type="warning">
 
 If your project board does not contain these (and only these) columns, each with
 a status of the same name, the Jira Access Request plugin will behave in
 unexpected ways. Remove all other columns and statuses.
 
-</Notice>
+</Admonition>
 
 Click **Back to board** to review your changes.
 
@@ -409,12 +409,12 @@ Request Reviewed` in the Teleport Web UI.
 
 ## Step 7/7. Set up systemd
 
-<Notice type="tip">
+<Admonition type="tip">
 
 This step is only applicable if you are running the Teleport Jira plugin on a
 Linux machine.
 
-</Notice>
+</Admonition>
 
 In production, we recommend starting the Teleport plugin daemon via an init
 system like systemd. Here's the recommended Teleport plugin service unit file

--- a/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
+++ b/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
@@ -320,7 +320,7 @@ the Teleport Web UI and either approve or deny the request.
 
 (!docs/pages/includes/plugins/resolve-request.mdx!)
 
-<Admonition title="Auditing Access Requests">
+<Admonition type="info" title="Auditing Access Requests">
 
 When the Mattermost plugin posts an Access Request notification to a channel,
 anyone with access to the channel can view the notification and follow the link.

--- a/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-slack.mdx
+++ b/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-slack.mdx
@@ -364,7 +364,7 @@ Once the request is resolved, the Slack bot will add an emoji reaction of ✅ or
 ❌ to the Slack message for the Access Request, depending on whether the request
 was approved or denied.
 
-<Admonition title="Auditing Access Requests">
+<Admonition type="info" title="Auditing Access Requests">
 
 When the Slack plugin posts an Access Request notification to a channel, anyone
 with access to the channel can view the notification and follow the link. While

--- a/docs/pages/admin-guides/access-controls/access-requests/resource-requests.mdx
+++ b/docs/pages/admin-guides/access-controls/access-requests/resource-requests.mdx
@@ -39,13 +39,13 @@ user named `bob`.
 
 1. Repeat these steps to assign the `reviewer` role to a user named `bob`.
 
-<Notice type="tip">
+<Admonition type="tip">
 
 Consider defining custom roles to limit the scope of a requester or reviewer's
 permissions. Read the [Access Request
 Configuration](./access-request-configuration.mdx) guide for available options.
 
-</Notice>
+</Admonition>
 
 ## Step 2/6. Search for resources
 
@@ -194,11 +194,11 @@ $ tsh request review --approve f406f5d8-3c2a-428f-8547-a1d091a4ddab
 Successfully submitted review.  Request state: APPROVED
 ```
 
-<Notice type="tip">
+<Admonition type="tip">
 Check out our
 [Access Request Integrations](#integrating-with-an-external-tool)
 to notify the right people about new Access Requests.
-</Notice>
+</Admonition>
 
 ## Step 5/6. Access the requested resource
 

--- a/docs/pages/admin-guides/access-controls/compliance-frameworks/soc2.mdx
+++ b/docs/pages/admin-guides/access-controls/compliance-frameworks/soc2.mdx
@@ -7,12 +7,12 @@ h1: SOC 2 Compliance for SSH, Kubernetes, Databases, Desktops, and Web Apps
 Teleport is designed to meet SOC 2 requirements for the purposes of accessing infrastructure, change management, and system operations. This document outlines a high
 level overview of how Teleport can be used to help your company to become SOC 2 compliant.
 
-<Notice type="warning">
+<Admonition type="warning">
 
   SOC 2 compliance features are only available for Teleport Enterprise and
   Teleport Enterprise Cloud.
 
-</Notice>
+</Admonition>
 
 ## Achieving SOC 2 Compliance with Teleport
 SOC 2 or Service Organization Controls were developed by the American Institute of CPAs (AICPA). They are based on five trust services criteria: security, availability, processing integrity, confidentiality, and privacy.

--- a/docs/pages/admin-guides/access-controls/device-trust/enforcing-device-trust.mdx
+++ b/docs/pages/admin-guides/access-controls/device-trust/enforcing-device-trust.mdx
@@ -4,7 +4,7 @@ description: Learn how to enforce trusted devices with Teleport
 videoBanner: gBQyj_X1LVw
 ---
 
-<Admonition type="notice" title="Supported Resources">
+<Admonition type="note" title="Supported Resources">
 Device Trust fully supports SSH, database and Kubernetes resources using
 cluster-wide or role-based enforcement.
 

--- a/docs/pages/admin-guides/access-controls/device-trust/jamf-integration.mdx
+++ b/docs/pages/admin-guides/access-controls/device-trust/jamf-integration.mdx
@@ -31,7 +31,7 @@ and behavior.
 
 ## Step 1/4. Create Jamf API credentials
 
-<Admonition type="notice" title="v16.0.0 or lower">
+<Admonition type="note" title="v16.0.0 or lower">
   Teleport versions v16.0.0 or lower don't support Jamf API credentials. Follow
   the instructions under [Using Jamf user and password authentication](
   #optional-using-jamf-user-and-password-authentication) instead.
@@ -335,7 +335,7 @@ ssh_service:
 
 ## Optional: Using Jamf user and password authentication
 
-<Admonition type="notice" title="v16.1.0+">
+<Admonition type="note" title="v16.1.0+">
   Teleport versions v16.1.0 and higher support [Jamf API credentials](
   #step-14-create-jamf-api-credentials). Prefer using API credentials instead
   of username and password authentication.

--- a/docs/pages/admin-guides/access-controls/guides/dual-authz.mdx
+++ b/docs/pages/admin-guides/access-controls/guides/dual-authz.mdx
@@ -16,11 +16,11 @@ the approval of two team members for a privileged role `elevated-access`.
 The steps below describe how to use Teleport with Mattermost. You can also
 [integrate with many other providers](../access-requests/access-requests.mdx).
 
-<Notice type="warning">
+<Admonition type="warning">
 
 Dual Authorization requires Teleport Enterprise.
 
-</Notice>
+</Admonition>
 
 ## Prerequisites
 

--- a/docs/pages/admin-guides/access-controls/guides/headless.mdx
+++ b/docs/pages/admin-guides/access-controls/guides/headless.mdx
@@ -155,7 +155,7 @@ $ tsh ssh --headless --proxy=proxy.example.com --user=alice alice@server01
 alice@server01 $
 ```
 
-<Notice type="note">
+<Admonition type="note">
   The Teleport user, `--user` parameter, is the Teleport user requesting Headless WebAuthn activity.
   If no `--user` parameter or environment variables set the OS user in the machine terminal is used.
 
@@ -165,7 +165,7 @@ alice@server01 $
   an access denied message. The user could receive an access denied message after being approved
   for their Headless WebAuthn activity since the same access rights are granted or denied as if running from
   your local terminal.
-</Notice>
+</Admonition>
 
 ## Optional: Teleport Connect
 

--- a/docs/pages/admin-guides/access-controls/guides/mfa-for-admin-actions.mdx
+++ b/docs/pages/admin-guides/access-controls/guides/mfa-for-admin-actions.mdx
@@ -21,7 +21,7 @@ Examples of administrative actions include, but are not limited to:
 This is an advanced security feature that protects users against compromises of
 their on-disk Teleport certificates.
 
-<Notice type="warning">
+<Admonition type="warning">
   When MFA for administrative actions is enabled, user certificates produced
   with `tctl auth sign` will no longer be suitable for automation due to the
   additional MFA checks.
@@ -33,7 +33,7 @@ their on-disk Teleport certificates.
   Certificates produced with `tctl auth sign` directly on an Auth Service
   instance using the super-admin role are not subject to MFA checks to support
   legacy self-hosted setups.
-</Notice>
+</Admonition>
 
 ## Prerequisites
 
@@ -51,10 +51,10 @@ their on-disk Teleport certificates.
 MFA for administrative actions is automatically enforced for clusters where
 WebAuthn is the only form of multi-factor authentication allowed.
 
-<Notice type="note">
+<Admonition type="note">
   In a future major version, Teleport may enforce MFA for administrative actions
   for a wider range of cluster configurations.
-</Notice>
+</Admonition>
 
 Edit the `cluster_auth_preference` resource:
 

--- a/docs/pages/admin-guides/access-controls/guides/per-session-mfa.mdx
+++ b/docs/pages/admin-guides/access-controls/guides/per-session-mfa.mdx
@@ -16,12 +16,12 @@ when starting new:
 This is an advanced security feature that protects users against compromises of
 their on-disk Teleport certificates.
 
-<Notice type="note">
+<Admonition type="note">
   In addition to per-session MFA, enable login MFA in your SSO provider and/or
   for all [local Teleport
   users](../../../reference/access-controls/authentication.mdx)
   to improve security.
-</Notice>
+</Admonition>
 
 ## Prerequisites
 

--- a/docs/pages/admin-guides/access-controls/guides/webauthn.mdx
+++ b/docs/pages/admin-guides/access-controls/guides/webauthn.mdx
@@ -172,12 +172,12 @@ when starting new:
 - Application sessions
 - Desktop sessions
 
-<Notice type="note">
+<Admonition type="note">
   In addition to per-session MFA, enable login MFA in your SSO provider and/or
   for all [local Teleport
   users](../../../reference/access-controls/authentication.mdx)
   to improve security.
-</Notice>
+</Admonition>
 
 To enforce MFA checks for all roles, edit your cluster authentication
 configuration:
@@ -413,7 +413,7 @@ layer by re-verifying user identity immediately before any admin action, mitigat
 By adopting these advanced security measures, you can create a robust defense against IdP compromises and significantly reduce your organization's attack surface.
 In the following sections, we'll dive deeper into each of these recommendations, providing step-by-step guidance on implementation and best practices.
 
-<Notice type="warning">
+<Admonition type="warning">
   When MFA for administrative actions is enabled, user certificates produced
   with `tctl auth sign` will no longer be suitable for automation due to the
   additional MFA checks.
@@ -423,7 +423,7 @@ In the following sections, we'll dive deeper into each of these recommendations,
 
   Certificates produced with `tctl auth sign` directly on an Auth Service instance using the super-admin
   role are not subject to MFA checks to support legacy self-hosted setups.
-</Notice>
+</Admonition>
 
 ### Prerequisites
 
@@ -435,10 +435,10 @@ In the following sections, we'll dive deeper into each of these recommendations,
 
 MFA for administrative actions is automatically enforced for clusters where WebAuthn is the only form of multi-factor allowed.
 
-<Notice type="note">
+<Admonition type="note">
   In a future major version, Teleport may enforce MFA for administrative actions
   for a wider range of cluster configurations.
-</Notice>
+</Admonition>
 
 Examples of administrative actions include, but are not limited to:
 

--- a/docs/pages/admin-guides/access-controls/sso/github-sso.mdx
+++ b/docs/pages/admin-guides/access-controls/sso/github-sso.mdx
@@ -26,7 +26,7 @@ reading data from the OAuth 2.0 access token. In particular, the Auth Service:
   permissions. 
 - Assigns the user's Teleport username to their GitHub username.
 
-<Notice type="warning">
+<Admonition type="warning">
 
 GitHub usernames are not formatted as email addresses. As a result, any Teleport
 plugin that expects to send email to a user based on their Teleport username
@@ -34,7 +34,7 @@ will not work as expected. For example, the [PagerDuty Access Request
 plugin](../access-request-plugins/ssh-approval-pagerduty.mdx) has this
 limitation.
 
-</Notice>
+</Admonition>
 
 ## Prerequisites
 

--- a/docs/pages/admin-guides/api/access-plugin.mdx
+++ b/docs/pages/admin-guides/api/access-plugin.mdx
@@ -20,12 +20,12 @@ spreadsheet, with links to allow or deny each request.
 
 ![The result of the plugin](../../../img/api/google-sheets.png)
 
-<Notice type="danger">
+<Admonition type="danger">
 
 The plugin we will build in this guide is intended as a learning tool. **Do not
 connect it to your production Teleport cluster.**  Use a demo cluster instead.
 
-</Notice>
+</Admonition>
 
 ## Prerequisites
 
@@ -428,14 +428,14 @@ In your spreadsheet, click "View Access Request" next to your new request. Sign
 into the Teleport Web UI as your original user. When you submit your review,
 e.g., deny the request, the new status will appear within the spreadsheet.
 
-<Notice type="danger">
+<Admonition type="danger">
 
 Access Request plugins must not enable reviewing Access Requests via the plugin,
 and must always refer a reviewer to the Teleport Web UI to complete the review.
 Otherwise, an unauthorized party could spoof traffic to the plugin and escalate
 privileges. 
 
-</Notice>
+</Admonition>
 
 ## Next steps
 

--- a/docs/pages/admin-guides/api/automatically-register-agents.mdx
+++ b/docs/pages/admin-guides/api/automatically-register-agents.mdx
@@ -29,12 +29,12 @@ Automatic registration consists of the following steps:
   infrastructure, use the Teleport API to deregister the resource and, if
   necessary, remove the Teleport service proxying the resource.
 
-<Notice type="danger">
+<Admonition type="danger">
 
 The program we build in this guide is intended as a learning tool. **Do not
 connect it to your production Teleport cluster.**  Use a demo cluster instead.
 
-</Notice>
+</Admonition>
 
 ## Prerequisites
 
@@ -706,13 +706,13 @@ To deregister the Application Service instance manually, we call the
 `pruneAppServiceInstance` function to get the namespace, host ID, and name of
 the Application Service instance to delete.
 
-<Notice type="tip">
+<Admonition type="tip">
 
 While Teleport namespaces are deprecated, they still appear occasionally in the
 Teleport API client library. The only namespace that Teleport supports is called
 `default`.
 
-</Notice>
+</Admonition>
 
 Next, this function stops and removes the Application Service container
 associated with the `types.AppServer` we want to prune. The hostname of an

--- a/docs/pages/admin-guides/api/rbac.mdx
+++ b/docs/pages/admin-guides/api/rbac.mdx
@@ -20,12 +20,12 @@ This is especially useful for:
 In this guide, we will build a small demo application to show you how to
 generate Teleport roles using Teleport's API client library.
 
-<Notice type="danger">
+<Admonition type="danger">
 
 The program we will build in this guide is intended as a learning tool. **Do not
 connect it to your production Teleport cluster.**  Use a demo cluster instead.
 
-</Notice>
+</Admonition>
 
 ## Prerequisites
 

--- a/docs/pages/admin-guides/deploy-a-cluster/access-graph/self-hosted.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/access-graph/self-hosted.mdx
@@ -29,11 +29,11 @@ This guide will help you set up the service and enable Access Graph in your Tele
     ```
 - The node running the Access Graph service must be reachable from Teleport Auth Service and Proxy Service.
 
-<Notice type="warning">
+<Admonition type="warning">
     The deployment with Docker is suitable for testing and development purposes. For production deployments,
     consider using the Access Graph Helm chart to deploy this service on Kubernetes.
     Refer to [Helm chart for Access Graph](self-hosted-helm.mdx) for instructions.
-</Notice>
+</Admonition>
 
 ## Step 1/3. Set up Access Graph
 

--- a/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
@@ -55,13 +55,13 @@ cluster to Teleport.
   cluster in order to follow this guide, the following example configuration
   sets up the EBS CSI driver add-on.
 
-  <Notice type="danger">
+  <Admonition type="danger">
 
   The example configuration below assumes that you are familiar with how `eksctl`
   works, are not using your EKS cluster in production, and understand that you
   are proceeding at your own risk.
 
-  </Notice>
+  </Admonition>
 
   Update the cluster name, version, node group size, and region as required:
 
@@ -96,7 +96,7 @@ cluster to Teleport.
 
 (!docs/pages/includes/kubernetes-access/helm-k8s.mdx!)
 
-<Notice type="warning">
+<Admonition type="warning">
 
 It is worth noting that this guide shows you how to set up Kubernetes access
 with the broadest set of permissions. This is suitable for a personal demo
@@ -104,7 +104,7 @@ cluster, but if you would like to set up Kubernetes RBAC for production usage,
 we recommend getting familiar with the [Teleport Kubernetes RBAC
 guide](../../../enroll-resources/kubernetes-access/controls.mdx) before you begin.
 
-</Notice>
+</Admonition>
 
 ## Step 1/2. Install Teleport
 

--- a/docs/pages/admin-guides/deploy-a-cluster/high-availability.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/high-availability.mdx
@@ -163,7 +163,7 @@ When you configure the Teleport Auth Service to access a table or collection,
 the Auth Service checks that the table or collection exists on startup. If it
 does not, the Auth Service attempts to create it.
 
-<Admonition title="Required permissions">
+<Admonition type="info" title="Required permissions">
 
 Make sure you configure your cloud provider's RBAC solution (e.g., AWS or Google
 Cloud IAM) so that your Auth Service instances have permissions to read from and
@@ -192,7 +192,7 @@ S3-compatible service to use for managing session recordings.
 The Auth Service will check that the bucket exists on startup. If it does not,
 the Auth Service attempts to create it.
 
-<Admonition title="Required permissions">
+<Admonition type="info" title="Required permissions">
 
 In your cloud provider's RBAC solution, your Auth Service instances need
 permissions to get buckets as well as to create, get, list, and update objects.
@@ -273,7 +273,7 @@ application with Teleport:
 |A|*.teleport.example.com|The IP address of your load balancer|
 |CNAME|*.teleport.example.com|The domain name of your load balancer|
 
-<Admonition title="Required permissions">
+<Admonition type="info" title="Required permissions">
 
 If you are using Let's Encrypt to provide TLS credentials to your Teleport
 instances, the TLS credential system we mentioned earlier needs permissions to
@@ -292,13 +292,13 @@ compute resources, for example, using Kubernetes Deployments or AWS Auto
 Scaling groups. This requires running the `teleport` binary on each Kubernetes
 pod or virtual machine in your group. 
 
-<Notice type="tip">
+<Admonition type="tip">
 
 If you plan to run Teleport on Kubernetes, the `teleport-cluster` Helm chart
 deploys the Auth Service and Proxy Service pools for you. To see how to use this
 Helm chart, read our [Helm Deployments](helm-deployments/helm-deployments.mdx) documentation.
 
-</Notice>
+</Admonition>
 
 You should deploy your Teleport instances across multiple zones (if using a
 cloud provider) or data centers (if using an on-premise solution) to ensure

--- a/docs/pages/admin-guides/infrastructure-as-code/infrastructure-as-code.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/infrastructure-as-code.mdx
@@ -243,13 +243,13 @@ If you remove a dynamic configuration resource, the Auth Service will restore
 its configuration fields to the default values and add the
 `teleport.dev/origin=defaults` label.
 
-<Notice type="tip">
+<Admonition type="tip">
 
 Cloud-hosted Teleport deployments use configuration files, but these are not
 available for operators to modify. Users of Teleport Enterprise Cloud may see
 configuration resources with the `teleport.dev/origin=config-file` label.
 
-</Notice>
+</Admonition>
 
 ## Further reading
 

--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-starter/enroll-resources.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-starter/enroll-resources.mdx
@@ -254,11 +254,11 @@ Edit the `agent_installation_dev` and `agent_installation_prod` blocks in
 1. Assign `proxy_service_address` to the host and HTTPS port of your Teleport
    Proxy Service, e.g., `mytenant.teleport.sh:443`.
 
-   <Notice type="tip">
+   <Admonition type="tip">
    
    Make sure to include the port.
    
-   </Notice>
+   </Admonition>
 
 1. Make sure `teleport_edition` matches your Teleport edition. Assign this to
    `oss`, `cloud`, or `enterprise`. The default is `oss`.

--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-starter/rbac.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-starter/rbac.mdx
@@ -438,14 +438,14 @@ configuration. The bot will exist for one hour and will be granted the default
    role in your authentication connector. Your user should have the `dev_access`
    role.
 
-   <Notice type="tip">
+   <Admonition type="tip">
 
    If you receive errors logging in using your authentication connector, log in
    as a local user with permissions to view the Teleport audit log. These is
    available in the preset `auditor` role. Check for error messages in events
    related with the "SSO Login" type.
 
-   </Notice>
+   </Admonition>
 
 1. Request access to the `prod_access` role through the Web UI. Visit the
    "Access Requests" tab and click "New Request".

--- a/docs/pages/admin-guides/management/admin/daemon.mdx
+++ b/docs/pages/admin-guides/management/admin/daemon.mdx
@@ -19,7 +19,7 @@ $ readlink /sbin/init
 /lib/systemd/systemd
 ```
 
-<Notice
+<Admonition
   type="danger"
   scope={["oss", "enterprise"]}
 >
@@ -27,7 +27,7 @@ $ readlink /sbin/init
   Teleport stores data in `/var/lib/teleport`. Make sure that regular/non-admin
   users do not have access to this folder on the Auth Service host.
 
-</Notice>
+</Admonition>
 
 ## Step 1/3. Install and configure Teleport
 

--- a/docs/pages/admin-guides/management/admin/self-signed-certs.mdx
+++ b/docs/pages/admin-guides/management/admin/self-signed-certs.mdx
@@ -17,7 +17,7 @@ you will likely see a page warning you that the website is not trusted.
 Additionally, self-signed certificates can prevent `teleport`, `tsh`, and `tctl` from connecting
 to the Proxy Service.
 
-<Notice type="warning" title="DO NOT USE THIS IN PRODUCTION">
+<Admonition type="warning" title="DO NOT USE THIS IN PRODUCTION">
   **DO NOT USE SELF-SIGNED CERTIFICATES IN PRODUCTION**
 
   Configuring your cluster to trust self-signed certificates
@@ -26,7 +26,7 @@ to the Proxy Service.
   way to verify the authenticity of the certificates.
   It is therefore important to properly configure certificates
   when using Teleport in a production environment.
-</Notice>
+</Admonition>
 
 ## Prerequisites
 

--- a/docs/pages/admin-guides/management/admin/troubleshooting.mdx
+++ b/docs/pages/admin-guides/management/admin/troubleshooting.mdx
@@ -82,13 +82,13 @@ DEBU [NODE:PROX] Pool is closing agent. leaseID:2 target:tele.example.com:11106 
 DEBU [NODE:PROX] Pool is closing agent. leaseID:3 target:tele.example.com:11106 reversetunnel/agentpool.go:238
 ```
 
-<Notice
+<Admonition
   type="warning"
 >
   It is not recommended to run Teleport in production with verbose logging as it
   generates a substantial amount of data.
 
-</Notice>
+</Admonition>
 
 ## Step 2/3. Generate a debug dump
 
@@ -127,11 +127,11 @@ runtime/pprof.writeGoroutineStacks(0x3c2ffc0, 0xc0001a8010, 0xc001011a38, 0x4bcf
 ...
 ```
 
-<Notice type="tip">
+<Admonition type="tip">
 
 You can print a goroutine dump without enabling verbose logging.
 
-</Notice>
+</Admonition>
 
 ## Step 3/3. Ask for help
 

--- a/docs/pages/admin-guides/management/admin/uninstall-teleport.mdx
+++ b/docs/pages/admin-guides/management/admin/uninstall-teleport.mdx
@@ -96,7 +96,7 @@ Follow the instructions for your Linux distribution:
   $ sudo rm -f /etc/apt/sources.list.d/teleport.list
   ```
 
-  <Admonition type="notice" title="Uninstall standalone DEB package">
+  <Admonition type="note" title="Uninstall standalone DEB package">
   If the commands above do not work, you may have installed Teleport using a standalone DEB package. Remove it with:
 
   ```code
@@ -123,7 +123,7 @@ Follow the instructions for your Linux distribution:
   $ sudo rm -f /etc/yum.repos.d/teleport.repo
   ```
 
-  <Admonition type="notice" title="Uninstall standalone RPM package">
+  <Admonition type="note" title="Uninstall standalone RPM package">
   If the commands above do not work, you may have installed Teleport using a standalone RPM package. Remove it with:
 
   ```code
@@ -151,7 +151,7 @@ Follow the instructions for your Linux distribution:
   </TabItem>
   <TabItem label="Linux Tarball">
 
-  <Admonition type="notice">
+  <Admonition type="note">
   These are the default paths to the Teleport binaries. If you have changed these from the defaults on your system, substitute those paths here.
   You can use `dirname $(which teleport)` to look this up automatically.
   </Admonition>
@@ -171,7 +171,7 @@ Follow the instructions for your Linux distribution:
 
 ### macOS
 
-  <Admonition type="notice">
+  <Admonition type="note">
   These are the default paths to the Teleport binaries. If you have changed these from the defaults on your system, substitute those paths here.
   You can use `dirname $(which teleport)` to look this up automatically.
   </Admonition>
@@ -186,7 +186,7 @@ Follow the instructions for your Linux distribution:
   $ sudo rm -f /usr/local/bin/fdpass-teleport
   ```
 
-  <Admonition type="notice" title="Uninstall macOS client tools">
+  <Admonition type="note" title="Uninstall macOS client tools">
 
   You may have Teleport software in the `/Applications` folder if you:
   - Installed from a macOS tarball for v17+ that includes `tsh.app` and `tctl.app`
@@ -218,7 +218,7 @@ Follow the instructions for your Linux distribution:
 
 <Tabs>
   <TabItem label="Linux">
-    <Admonition type="notice">
+    <Admonition type="note">
     These are the default paths to the Teleport config files and data directory.
     If you have changed these from the defaults on your system, substitute those paths here.
     </Admonition>
@@ -245,7 +245,7 @@ Follow the instructions for your Linux distribution:
     ```
   </TabItem>
   <TabItem label="MacOS">
-    <Admonition type="notice">
+    <Admonition type="note">
     These are the default paths to the Teleport config files and data directory.
     If you have changed these from the defaults on your system, substitute those paths here.
     </Admonition>

--- a/docs/pages/admin-guides/management/diagnostics/diagnostics.mdx
+++ b/docs/pages/admin-guides/management/diagnostics/diagnostics.mdx
@@ -76,11 +76,11 @@ metrics that Teleport tracks. It is compatible with [Prometheus](https://prometh
 
 The following metrics are available:
 
-<Notice scope={["cloud"]} type="tip">
+<Admonition scope={["cloud"]} type="tip">
 
     Teleport Cloud does not expose monitoring endpoints for the Auth Service and Proxy Service.
 
-</Notice>
+</Admonition>
 
 (!docs/pages/includes/metrics.mdx!)
 

--- a/docs/pages/admin-guides/management/external-audit-storage.mdx
+++ b/docs/pages/admin-guides/management/external-audit-storage.mdx
@@ -21,7 +21,7 @@ External Audit Storage is based on Teleport's
 available on Teleport Enterprise Cloud clusters running Teleport v14.2.1 or
 above.
 
-<Admonition type="notice">
+<Admonition type="note">
 On Teleport Enterprise (Cloud), External Audit
 Storage is not currently supported for users who have Access Monitoring enabled.
 This functionality will be enabled in a future Teleport release.  

--- a/docs/pages/admin-guides/management/guides/ec2-tags.mdx
+++ b/docs/pages/admin-guides/management/guides/ec2-tags.mdx
@@ -19,10 +19,10 @@ Node Name            Address        Labels
 fakehost.example.com 127.0.0.1:3022 env=example,hostname=ip-172-31-53-70,aws/Name=atburke-dev,aws/TagKey=TagValue,aws/TeleportHostname=fakehost.example.com
 ```
 
-<Notice type="note">
+<Admonition type="note">
   For services that manage multiple resources (such as the Database Service), each resource will receive the
   same labels from EC2.
-</Notice>
+</Admonition>
 
 ## Prerequisites
 

--- a/docs/pages/admin-guides/management/guides/gcp-tags.mdx
+++ b/docs/pages/admin-guides/management/guides/gcp-tags.mdx
@@ -27,10 +27,10 @@ Node Name            Address        Labels
 fakehost.example.com 127.0.0.1:3022 gcp/label/testing=yes,gcp/tag/environment=staging,gcp/TeleportHostname=fakehost.example.com
 ```
 
-<Notice type="note">
+<Admonition type="note">
   For services that manage multiple resources (such as the Database Service), each resource will receive the
   same tags and labels from GCP.
-</Notice>
+</Admonition>
 
 ## Prerequisites
 

--- a/docs/pages/admin-guides/management/guides/oracle-tags.mdx
+++ b/docs/pages/admin-guides/management/guides/oracle-tags.mdx
@@ -25,7 +25,7 @@ Node Name            Address        Labels
 fakehost.example.com 127.0.0.1:3022 oracle/testing=yes,oracle/definedTagNamespace/environment=staging,oracle/teleporthostname=fakehost.example.com
 ```
 
-<Notice type="note">
+<Admonition type="note">
   For services that manage multiple resources (such as the Database Service), each resource will receive the
   same tags from Oracle.
-</Notice>
+</Admonition>

--- a/docs/pages/admin-guides/management/security/proxy-protocol.mdx
+++ b/docs/pages/admin-guides/management/security/proxy-protocol.mdx
@@ -12,13 +12,13 @@ reliable client IP information is important from a security standpoint,
 because features like audit logging and IP pinning depend on it. If the PROXY
 protocol is not configured correctly, these features will be compromised.
 
-<Notice type="note">
+<Admonition type="note">
 
 Users of Teleport Enterprise (Cloud) do not need to manage PROXY protocol
 setting. Teleport-managed Auth Service and Proxy Service deployments run behind
 an L4 load balancer with the PROXY protocol configured. 
 
-</Notice>
+</Admonition>
 
 ## How it works
 
@@ -125,10 +125,10 @@ IP pinning will not work if `proxy_protocol` setting wasn't explicitly set in
 the config. Connections that are marked with `0` as the source port will be
 rejected during IP pinning checks.
 
-<Notice type="danger">
+<Admonition type="danger">
 
 The default unspecified value mode is not suitable for production. It is only
 suitable for test environments. 
 
-</Notice>
+</Admonition>
 

--- a/docs/pages/admin-guides/migrate-plans.mdx
+++ b/docs/pages/admin-guides/migrate-plans.mdx
@@ -115,7 +115,7 @@ Teleport clusters and execute `tctl` commands using your current credentials.
    website](https://status.teleport.sh/) to stay current on any issues impacting
    the performance of your new cluster.
 
-<Notice
+<Admonition
   type="danger"
 >
 
@@ -125,7 +125,7 @@ Teleport clusters and execute `tctl` commands using your current credentials.
   security, Teleport Support cannot assist with resetting passwords or
   recovering lost credentials.
 
-</Notice>
+</Admonition>
 
 ## Step 2/4. Migrate Teleport resources
 
@@ -170,13 +170,13 @@ To achieve this:
    $ tctl create -f user.yaml
    ```
 
-<Notice type="tip">
+<Admonition type="tip">
 
 We recommend managing dynamic resources with the Teleport Terraform provider or
 Kubernetes operator. In this case, you can configure these tools to manage
 dynamic resources on your new Teleport cluster.
 
-</Notice>
+</Admonition>
 
 For your SSO auth connector, most SSO integrations only work for a single
 configured endpoint. It is recommended to create a separate SSO connector in

--- a/docs/pages/admin-guides/teleport-policy/crown-jewels.mdx
+++ b/docs/pages/admin-guides/teleport-policy/crown-jewels.mdx
@@ -12,14 +12,14 @@ Crown Jewels, and how to see permission changes for these resources.
 
 ## Prerequisites
 
-<Notice type="tip">
+<Admonition type="tip">
 
 For an improved experience, we recommend using Crown Jewels in conjunction with Teleport local users or integrating with
 [Okta](../../enroll-resources/application-access/okta/okta.mdx) or [Microsoft Entra ID](./integrations/entra-id.mdx).
 This setup helps minimize the number of access path change entries generated when highly privileged ephemeral users
 log in via Teleport Auth Connectors.
 
-</Notice>
+</Admonition>
 
 - A running Teleport Enterprise cluster v16.2.0 or later.
 - For self-hosted clusters, an updated `license.pem` with Teleport Policy enabled.

--- a/docs/pages/admin-guides/teleport-policy/integrations/aws-sync.mdx
+++ b/docs/pages/admin-guides/teleport-policy/integrations/aws-sync.mdx
@@ -66,12 +66,12 @@ how to set up Access Graph.
 
 ## Step 1/2. Configure Discovery Service (Self-hosted only)
 
-<Notice type="warning">
+<Admonition type="warning">
 
 If you have a cloud-hosted Teleport Enterprise cluster, you can disregard
 this step, as cloud-hosted Teleport Enterprise already operates a properly configured
 Discovery Service within your cluster.
-</Notice>
+</Admonition>
 
 To activate the Teleport Discovery Service, add a top level discovery_service section to the teleport.yaml
 config used by the Auth Service. This service monitors dynamic `discovery_config` resources that are set up

--- a/docs/pages/admin-guides/teleport-policy/integrations/azure-sync.mdx
+++ b/docs/pages/admin-guides/teleport-policy/integrations/azure-sync.mdx
@@ -60,11 +60,11 @@ how to set up Access Graph.
 
 ## Step 1/2. Configure the Discovery Service (Self-hosted only)
 
-<Notice type="warning">
+<Admonition type="warning">
   If you have a cloud-hosted Teleport Enterprise cluster, you can disregard
   this step, as cloud-hosted Teleport Enterprise already operates a properly configured
   Discovery Service within your cluster.
-</Notice>
+</Admonition>
 
 To activate the Teleport Discovery Service, add a top level discovery_service section to the `teleport.yaml`
 config file used by the Auth Service. This service monitors dynamic `discovery_config` resources that are set up

--- a/docs/pages/admin-guides/teleport-policy/integrations/entra-id.mdx
+++ b/docs/pages/admin-guides/teleport-policy/integrations/entra-id.mdx
@@ -8,12 +8,12 @@ and offers insights into relationships in your Entra ID directory.
 Additionally, when Entra ID is used as an SSO identity provider, Teleport Policy visualizes
 SSO grants across your services.
 
-<Notice type="note">
+<Admonition type="note">
 SSO grant analysis is currently only supported in situations where Entra ID acts as the identity provider,
 and AWS accounts are set up as relying parties using AWS IAM role federation.
 
 Support for additional relying parties will be added in the future.
-</Notice>
+</Admonition>
 
 ## How it works
 
@@ -54,9 +54,9 @@ configuration and user requirements.
 
 ### Automatic setup with Teleport as an OIDC Provider for Entra ID
 
-<Notice type="tip">
+<Admonition type="tip">
 This method is recommended and is required if you are a Teleport Enterprise (Cloud) customer.
-</Notice>
+</Admonition>
 
 This method is suitable for Teleport clusters that are publicly accessible and lack Azure credentials on Auth
 Service nodes or pods.
@@ -251,10 +251,10 @@ Be sure to follow each step in the `tctl plugins install entraid` guide closely 
 
 This step configures the Azure Identity on your Auth Service machine with the required Entra ID permissions.
 
-<Notice type="warning">
+<Admonition type="warning">
 Follow this step only if you want to use system-available credentials to authenticate Teleport with Entra ID.
 If you intend to use Teleport as an OIDC provider for Entra ID, you can skip this step.
-</Notice>
+</Admonition>
 
 
 - `Application.Read.All`
@@ -512,9 +512,9 @@ For clusters running in multiplex mode, this address will be the same as your pr
 If you chose to use Teleport as the OIDC provider for Entra ID in the previous step, remove the `--use-system-credentials`
 flag from the command below.
 
-<Notice type="note">
+<Admonition type="note">
 Currently, when using manual mode, it is not possible to operate without the `--no-access-graph` flag.
-</Notice>
+</Admonition>
 
 ```code
 # enable Access Graph integration if your license supports Teleport Policy.

--- a/docs/pages/admin-guides/teleport-policy/integrations/gitlab.mdx
+++ b/docs/pages/admin-guides/teleport-policy/integrations/gitlab.mdx
@@ -62,7 +62,7 @@ Create a new token with the `read_api` scope and copy the generated token. For m
 
 The importer will use this token to fetch the necessary resources from your GitLab instance.
 
-<Notice type="warning">
+<Admonition type="warning">
 
     The GitLab importer will only fetch resources that the token has access to. Ensure that the user associated with
     the token has the necessary permissions to access/view the resources you want to import.
@@ -73,7 +73,7 @@ The importer will use this token to fetch the necessary resources from your GitL
     If you're using a self-hosted GitLab instance, the importer will fetch all resources that the token has access to,
     including all users who are part of the instance.
 
-</Notice>
+</Admonition>
 
 The token will be used in the next step to configure the GitLab Sync integration.
 

--- a/docs/pages/admin-guides/teleport-policy/integrations/ssh-keys-scan.mdx
+++ b/docs/pages/admin-guides/teleport-policy/integrations/ssh-keys-scan.mdx
@@ -58,10 +58,10 @@ Teleport cluster with metadata such as:
   public key is extracted from the private key, `public_key_file` if the private key is encrypted and the public key is
     available in a separate file, or `protected` if the public key fingerprint is not available.
 
-<Notice type="warning">
+<Admonition type="warning">
 `tsh` never sends the private key itself to the Teleport cluster, ensuring that the private key remains secure on the device.
 It also never sends the private key path or any other sensitive information.
-</Notice>
+</Admonition>
 
 ## Prerequisites
 
@@ -191,10 +191,10 @@ given that the command may consume system resources during the scan.
 
 ![Example of a recurring Jamf Pro](../../../../img/access-graph/jamf-pro.png)
 
-<Notice type="warning">
+<Admonition type="warning">
     `tsh` must be installed on the devices to run the scan. If the `tsh` binary is not installed, consider distributing it
     to the devices using the same policy or a separate policy.
-</Notice>
+</Admonition>
 
 Once the policy is created, the devices will start scanning for SSH private keys and sending the fingerprints to the Teleport
 Cluster. The keys will be imported and displayed in the Access Graph.

--- a/docs/pages/connect-your-client/gui-clients.mdx
+++ b/docs/pages/connect-your-client/gui-clients.mdx
@@ -511,9 +511,9 @@ The Oracle integration works only in the authenticated proxy mode. Start a local
 Started authenticated tunnel for the Oracle database "oracle" in cluster "teleport.example.com" on 127.0.0.1:11555.
 ```
 
-<Notice type="tip">
+<Admonition type="tip">
 The command above uses the local port 11555, but you can choose any available port. Leaving `--port` empty will cause `tsh` to pick a random one.
-</Notice>
+</Admonition>
 
 The local proxy supports TCP and TCPS modes. Different clients prefer different modes.
 
@@ -526,9 +526,9 @@ TCPS:
 - depends on automatically created wallet
 - uses JDBC URL for configuration
 
-<Notice type="warning">
+<Admonition type="warning">
 Teleport versions earlier than 17.2.0 support only a limited range of clients and only offer TCPS mode. `tsh` will automatically detect this situation and warn the user. We recommend updating to the latest version of Teleport to access full client support and additional connection options.
-</Notice>
+</Admonition>
 
 ### Oracle SQL Developer (standalone)
 
@@ -640,9 +640,9 @@ The newly added login should appear on the login list.
 
 ![Toad Login List](../../img/database-access/guides/oracle/toad-login-list@2x.png)
 
-<Notice type="tip">
+<Admonition type="tip">
 You can also configure Toad to use an external Oracle client. Both native and external clients are supported.
-</Notice>
+</Admonition>
 
 ### DBeaver
 

--- a/docs/pages/connect-your-client/tsh.mdx
+++ b/docs/pages/connect-your-client/tsh.mdx
@@ -686,9 +686,9 @@ $ tsh join <session_ID>
   Refer them to the [Moderated Sessions guide](../admin-guides/access-controls/guides/joining-sessions.mdx) for more information on configuring join permissions.
 </Admonition>
 
-<Notice type="note" scope={["oss", "enterprise"]}>
+<Admonition type="note" scope={["oss", "enterprise"]}>
   Joining sessions is not supported in recording proxy mode (where `session_recording` is set to `proxy`).
-</Notice>
+</Admonition>
 
 ## Connecting to SSH clusters behind firewalls
 
@@ -699,9 +699,9 @@ tunnels from behind-firewall environments into a Teleport Proxy Service you have
 To learn more about setting up a trust relationship between clusters behind firewalls, see
 [Configure Trusted Clusters](../admin-guides/management/admin/trustedclusters.mdx).
 
-<Notice type="note" >
+<Admonition type="note" >
   Trusted clusters are only available for self-hosted Teleport clusters.
-</Notice>
+</Admonition>
 
 Assuming the Teleport Proxy Server called `work` is configured with a few trusted
 clusters, you can use the `tsh clusters` command to see a list of all the trusted clusters on the server:
@@ -752,13 +752,13 @@ $ tsh ssh -X node01
 X11 forwarding provides the server with secure access to your local X Server
 so that it can communicate directly with your local display and I/O devices.
 
-<Notice type="note">
+<Admonition type="note">
   The `-Y` flag can be used to start Trusted X11 forwarding. This is needed
   in order to enable more "unsafe" features, such as running clipboard or
   screenshot utilities like `xclip`. However, it provides the server with
   unmitigated access to your local X Server and puts your local machine at
   risk of X11 attacks, so it should only be used with extreme caution.
-</Notice>
+</Admonition>
 
 In order to use X11 forwarding, you'll need to enable it on the Teleport Node.
 You'll also need to ensure that your user has the `permit_x11_forwarding` role option:

--- a/docs/pages/enroll-resources/agents/join-services-to-your-cluster/join-token.mdx
+++ b/docs/pages/enroll-resources/agents/join-services-to-your-cluster/join-token.mdx
@@ -38,12 +38,12 @@ relationship with the Teleport cluster.
 
   </Details>
 
-  <Notice type="tip" >
+  <Admonition type="tip" >
 
   If you are using a Docker container, note that this guide assumes that
   your Linux host has `curl` and `sudo` installed.
 
-  </Notice>
+  </Admonition>
 
 (!docs/pages/includes/tctl.mdx!)
 
@@ -127,10 +127,10 @@ Token                            Type Labels Expiry Time (UTC)
 
 <Details scope={["oss","enterprise"]} title="An insecure alternative: static tokens" scopeOnly={false} >
 
-<Notice type="Danger">
+<Admonition type="Danger">
 Use short-lived tokens instead of long-lived static tokens.
 Static tokens are easier to steal, guess, and leak.
-</Notice>
+</Admonition>
 
 Static tokens are defined ahead of time by an administrator and stored in the
 Auth Service's config file:
@@ -165,13 +165,13 @@ $ sudo teleport configure \
    -o file
 ```
 
-<Notice type="tip">
+<Admonition type="tip">
 
 For SSH Service instances, you can also run `teleport node configure` instead of
 `teleport configure`. This way, you can exclude the `--roles=node` flag from the
 command.
 
-</Notice>
+</Admonition>
 
 <Details title="Connecting directly to the Auth Service">
 
@@ -181,13 +181,13 @@ possibility in Teleport Enterprise Cloud.) Depending on the design of your
 infrastructure, you may need to connect your new Teleport process directly to
 the Auth Service.
 
-<Notice type="warning">
+<Admonition type="warning">
 
 Only connect Teleport processes directly to the Auth Service if no other join
 methods are suitable, as we recommend exposing the Auth Service to as few
 sources of ingress traffic as possible.
 
-</Notice>
+</Admonition>
 
 The Teleport process joining the cluster must also establish trust with the Auth
 Service in order to prevent an attacker from hijacking the address of your Auth
@@ -217,12 +217,12 @@ CA pin       (=presets.ca_pin=)
 
 Copy the CA pin and assign it to the value of <Var name="ca-pin" />.
 
-<Notice type="warning">
+<Admonition type="warning">
 
 The CA pin becomes invalid if a Teleport administrator performs the CA rotation
 by executing [`tctl auth rotate`](../../../reference/cli/tctl.mdx#tctl-auth-rotate).
 
-</Notice>
+</Admonition>
 
 ### Configure your Teleport process with the join token and CA pin
 

--- a/docs/pages/enroll-resources/agents/join-services-to-your-cluster/kubernetes.mdx
+++ b/docs/pages/enroll-resources/agents/join-services-to-your-cluster/kubernetes.mdx
@@ -13,12 +13,12 @@ Kubernetes issues signed proof to each pod describing which Kubernetes
 ServiceAccount they can assume. When using the Kubernetes join
 method, Teleport uses this Kubernetes proof to become part of the cluster.
 
-<Notice type="warning">
+<Admonition type="warning">
 
 The Kubernetes join method is not available in Teleport Enterprise Cloud as it requires the
 joining service to run in the same Kubernetes cluster as the Auth Service.
 
-</Notice>
+</Admonition>
 
 The Kubernetes join method is available in self-hosted versions of Teleport.
 It supports joining any Teleport service running in the same Kubernetes cluster

--- a/docs/pages/enroll-resources/agents/join-services-to-your-cluster/oracle.mdx
+++ b/docs/pages/enroll-resources/agents/join-services-to-your-cluster/oracle.mdx
@@ -56,12 +56,12 @@ Any {instance.compartment.id = '<Var name="compartment-id" />'}
 
 ![Create dynamic group](../../../../img/oracle/oracle-join-dynamic-group@2x.png)
 
-<Notice type="tip">
+<Admonition type="tip">
 
 To minimize unnecessary permissions, configure your matching rules to match
 the rules in the token created in step 1.
 
-</Notice>
+</Admonition>
 
 ### Add policy to group
 

--- a/docs/pages/enroll-resources/application-access/cloud-apis/google-cloud.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/google-cloud.mdx
@@ -32,13 +32,13 @@ prevent unauthorized access to your organization's Google Cloud service accounts
   page](https://cloud.google.com/sdk/docs/install-sdk) to install and
   authenticate to `gcloud`.
 
-  <Notice type="tip">
+  <Admonition type="tip">
 
   While this guide focuses on `gcloud`, once you set up Google Cloud API access
   with Teleport, you can also manage access to `gsutil` and other Google Cloud
   CLI tools using the Teleport Application Service.
 
-  </Notice>
+  </Admonition>
 
 - Either a Google Compute Engine VM where you will run the Teleport Application
   Service *or* permissions to create VMs in your Google Cloud project. If you
@@ -106,14 +106,14 @@ permissions to impersonate target service accounts.
 
 #### Create a service account and enable it to view resources
 
-<Notice type="tip">
+<Admonition type="tip">
 
 If you are enabling access to an existing service account, you can skip to the
 [next
 section](#enable-teleport-google-cloud-cli-to-impersonate-target-service-accounts
 ).
 
-</Notice>
+</Admonition>
 
 Create a target service account:
 
@@ -139,12 +139,12 @@ Enable the `teleport-google-cloud-cli` service account to impersonate
 `teleport-google-cloud-cli` account to the predefined "Service Account Token
 Creator Role" for the `teleport-vm-viewer` service account:
 
-<Notice type="tip">
+<Admonition type="tip">
 
 To enable Google Cloud CLI access for pre-existing service accounts, you must
 run this command for each service account.
 
-</Notice>
+</Admonition>
 
 ```code
 $ gcloud iam service-accounts add-iam-policy-binding \
@@ -209,13 +209,13 @@ $ gcloud compute instances set-service-account <Var name="vm-name" /> \
    --scopes=cloud-platform
 ```
 
-<Notice type="warning">
+<Admonition type="warning">
 
 You must use the `scopes` flag in the `gcloud compute instances
 set-service-account` command. Otherwise, your Google Cloud VM will fail to
 obtain the required authorization to access Google Cloud.
 
-</Notice>
+</Admonition>
 
 Once you have attached the service account, restart your VM:
 
@@ -295,7 +295,7 @@ service accounts:
 |**Dynamic**|A Teleport role includes a template variable that grants a user access to all Google Cloud service accounts assigned directly to them.|Local users, OIDC, SAML|
 |**Static**|A Teleport role explicitly specifies the Google Cloud service accounts a user is allowed to assume.|Local users, OIDC, SAML, GitHub|
 
-<Notice type="tip">
+<Admonition type="tip">
 
 We recommend using the dynamic approach, since it scales more easily as you add
 service accounts to your Google Cloud account. If you have configured an open
@@ -303,7 +303,7 @@ source Teleport cluster to authenticate users via GitHub SSO, you must use the
 static approach, as OAuth-based GitHub applications do not support custom
 claims.
 
-</Notice>
+</Admonition>
 
 <Tabs dropdownCaption="Approach">
 <TabItem options="Dynamic Identities" label="Local Users">
@@ -590,13 +590,13 @@ Use the following credentials and HTTPS proxy setting to connect to the proxy:
   export HTTPS_PROXY=http://127.0.0.1:50614
 ```
 
-<Notice type="warning">
+<Admonition type="warning">
 
 `tsh proxy gcloud` runs the local proxy in the foreground, so don't interrupt
 the process or exit the terminal where you ran the command until you're ready
 to close the local proxy.
 
-</Notice>
+</Admonition>
 
 Copy the `export` commands and paste them into a second terminal. In that
 terminal, you can now run your Google Cloud CLI application of choice. For
@@ -621,13 +621,13 @@ ERROR: (gcloud.iam.service-accounts.create) User [myuser] does not have permissi
   reason: IAM_PERMISSION_DENIED
 ```
 
-<Notice type="info">
+<Admonition type="info">
 
 When you run a `gcloud` or `gsutil` command via `tsh gcloud` or `tsh gsutil`,
 `tsh` starts the local proxy in the background and uses it to execute the
 command.
 
-</Notice>
+</Admonition>
 
 ## Next steps
 

--- a/docs/pages/enroll-resources/application-access/guides/tcp.mdx
+++ b/docs/pages/enroll-resources/application-access/guides/tcp.mdx
@@ -181,11 +181,11 @@ HTTP/1.1 200 OK
 $ psql postgres://postgres@tcp-app.teleport.example.com:5432/postgres
 ```
 
-<Notice type="warning">
+<Admonition type="warning">
 There is no RBAC for TCP ports – a user that has access to an application can connect to any port in
 the specification. We&nbsp;strongly recommend specifying only the necessary ports instead of defining a
 wide port range that happens to include ports that are meant to be available.
-</Notice>
+</Admonition>
 
 {/* TODO: DELETE IN 19.0.0. At this point all compatible servers and clients are going
 to support multiple ports. */}

--- a/docs/pages/enroll-resources/auto-discovery/databases/aws.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/databases/aws.mdx
@@ -112,7 +112,7 @@ discover AWS databases.
 Once it discovers databases, the Discovery Service will register them as `db`
 resources in your Teleport cluster.
 
-<Notice type="info">
+<Admonition type="info">
 A Teleport `db` resource represents the specification of a database that a
 Teleport Database Service can then use to provide access to the database.
 When a Database Service instance matches the `db` resource via label selectors, it will
@@ -120,7 +120,7 @@ begin to heartbeat the database by regularly creating short-lived `db_server`
 resources in your Teleport cluster.
 Tools like `tsh db ls` and `tctl db ls` will only display `db_server` resources,
 i.e. databases that a Database Service instance is providing access to.
-</Notice>
+</Admonition>
 
 ## Step 5/8. List registered databases
 
@@ -252,13 +252,13 @@ In this case, it will match auto-discovered AWS databases in the
 from any AWS account (`"*"` is a wildcard and it can be used as a label key and/or value).
 You can make it match more specific databases by adjusting the label selectors.
 
-<Notice type="tip">
+<Admonition type="tip">
 The AWS tags attached to AWS databases are imported as Teleport `db` labels
 in addition to some other identifying metadata.
 Refer to
 [Database Labels Reference](../../../reference/agent-services/database-access-reference/labels.mdx)
 for more information about available database labels.
-</Notice>
+</Admonition>
 
 ### Generate a join token
 
@@ -283,7 +283,7 @@ $ tctl db ls teleport.dev/origin=cloud,teleport.dev/cloud=AWS,region=<Var name="
 If you do not see the databases that you expected, then refer to
 [Database Service troubleshooting](#database-service-troubleshooting) below.
 
-<Notice type="note">
+<Admonition type="note">
 This guide shows you how to set-up AWS database auto-discovery with a Discovery
 Service and Database Service, but does not cover database user provisioning.
 
@@ -293,7 +293,7 @@ be required to connect to the discovered databases via Teleport.
 Refer to the appropriate guide in
 [Enroll AWS Databases](../../database-access/enroll-aws-databases/enroll-aws-databases.mdx)
 for information about database user provisioning and configuration.
-</Notice>
+</Admonition>
 
 ## Next
 - Learn about [Dynamic Registration](../../database-access/guides/dynamic-registration.mdx) by the

--- a/docs/pages/enroll-resources/auto-discovery/databases/databases.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/databases/databases.mdx
@@ -46,7 +46,7 @@ information such as:
     "rds", "redshift", etc.
 - *Endpoint Info*: Connection endpoint the database can be reached at
 
-<Notice type="tip">
+<Admonition type="tip">
 You can override a discovered database's name by using a special tag attached
 to the database in your cloud provider:
  - ***key***: `TeleportDatabaseName`
@@ -56,7 +56,7 @@ The Discovery Service will check if the database metadata includes the tag and
 use its value as the resource name in Teleport.
 The name override will be used verbatim, i.e. additional metadata will not be
 appended to it.
-</Notice>
+</Admonition>
 
 The Teleport Discovery Service only needs access to APIs that it can poll for
 databases - it does not need network connectivity or permissions to connect to

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/aws.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/aws.mdx
@@ -50,12 +50,12 @@ running the Teleport Discovery Service:
 
 ## Step 2/3. Configure EKS cluster authorization
 
-<Notice type="warning">
+<Admonition type="warning">
 If you are running Teleport Discovery v15.3.8 or later and the IAM role
 used by the Discovery Service has the necessary permissions to create and
 update Access Entries, you can skip this section. The service can self-bootstrap
 the required permissions automatically.
-</Notice>
+</Admonition>
 
 When the Kubernetes Service uses an IAM role that is different from the one that
 creates the clusters, you need to configure the mapping between the Teleport IAM
@@ -202,11 +202,11 @@ to forward requests to the cluster.
 
 <TabItem label="Use system:masters" >
 
-    <Notice type="warning">
+    <Admonition type="warning">
 Granting the `system:masters` group to the IAM role associated with the Teleport
 service means granting administrator-level permissions on the Kubernetes cluster.
 To follow least privilege principle we do not recommend using this method in production.
-  </Notice>
+  </Admonition>
 
 If your cluster contains an `aws-auth` config map, you can use this to associate
 the Teleport IAM role with the `system:masters` RBAC group. Edit the
@@ -261,11 +261,11 @@ to forward requests to the cluster.
   </TabItem>
 </Tabs>
 
-<Notice type="tip">
+<Admonition type="tip">
 If you provision your EKS clusters using tools such as `terraform`, `eksctl` or
 `Cloudformation`, you can use them to automatically configure the `aws-auth` `Configmap` or access entry
 and create the `ClusterRole` and `ClusterRoleBinding` resources during cluster provisioning.
-</Notice>
+</Admonition>
 
 ## Step 3/3. Configure Teleport to discover EKS clusters
 

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/google-cloud.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/google-cloud.mdx
@@ -207,13 +207,13 @@ $ gcloud compute instances set-service-account ${VM2_NAME?} \
 
 </Details>
 
-<Notice type="warning">
+<Admonition type="warning">
 
 You must use the `scopes` flag in the `gcloud compute instances
 set-service-account` command. Otherwise, your Google Cloud VM will fail to
 obtain the required authorization to access the GKE API.
 
-</Notice>
+</Admonition>
 
 Once you have attached the service account, restart your VM:
 

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/kubernetes.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/kubernetes.mdx
@@ -35,7 +35,7 @@ cloud provider such as:
   - Cluster location.
   - Identification of which cloud account the cluster belongs to — AWS Account ID / Azure Subscription ID.
 
-<Notice type="tip">
+<Admonition type="tip">
 You can import the cluster under a different name into Teleport's registry.
 To achieve this, you must attach the following tag to the resources — EKS, AKS, GKE — in your cloud provider:
  - ***key***: `TeleportKubernetesName`
@@ -47,7 +47,7 @@ as the resource name in Teleport.
 You should use this feature whenever there are clusters in different regions/cloud providers
 with the same name to prevent them from colliding in Teleport.
 
-</Notice>
+</Admonition>
 
 In addition to detecting new Kubernetes clusters, the Discovery Service also removes
 — from Teleport's registry — the Kubernetes clusters that have been deleted or whose tags

--- a/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/mysql-cloudsql.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/mysql-cloudsql.mdx
@@ -59,12 +59,12 @@ The pre-defined "Cloud SQL Viewer" role has this permission, but also has other
 permissions that are not needed. Define and bind a custom role to the service
 account to follow the  principal of least privilege.
 
-<Notice type="note">
+<Admonition type="note">
 Support for legacy one-time password authentication will be deprecated.
 If you are following this guide and have already set up Teleport prior to the
 introduction of support for IAM database user authentication, then you should
 configure your database users to use IAM auth as described in this guide.
-</Notice>
+</Admonition>
 
 ## Step 2/9. Create a service account for a database user
 
@@ -94,12 +94,12 @@ default 3306 as the default Cloud SQL MySQL listener does not trust generated
 ephemeral certificates. For this reason, you should make sure to allow port 
 3307 when using "require trusted client certificates".
 
-<Notice type="note">
+<Admonition type="note">
 The "require trusted client certificates" SSL mode only forces the client
 (Teleport) to provide a trusted client certificate. Teleport will always connect
 to the database over encrypted TLS regardless of the instance's SSL mode 
 setting.
-</Notice>
+</Admonition>
 
 ### Create a database user
 
@@ -175,12 +175,12 @@ $ tsh db ls
 
 </Tabs>
 
-<Notice
+<Admonition
   type="note"
 >
 You will only be able to see databases that your Teleport role has
 access to. See our [RBAC](../rbac.mdx) guide for more details.
-</Notice>
+</Admonition>
 
 When connecting to the database, use either the database user name or the
 service account's Email ID. Both the user name and the service account's Email

--- a/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/postgres-cloudsql.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/postgres-cloudsql.mdx
@@ -131,12 +131,12 @@ $ tsh db ls
 
 </Tabs>
 
-<Notice
+<Admonition
   type="note"
 >
 You will only be able to see databases that your Teleport role has
 access to. See our [RBAC](../rbac.mdx) guide for more details.
-</Notice>
+</Admonition>
 
 When connecting to the database, use the name of the database's service account
 that you added as an IAM database user

--- a/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/spanner.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/spanner.mdx
@@ -73,13 +73,13 @@ account as a principal and assign it the "Cloud Spanner Database User" role:
 
 Click "Save".
 
-<Notice type="note">
+<Admonition type="note">
 [Cloud Spanner Database User](https://cloud.google.com/spanner/docs/iam#spanner.databaseUser)
 is a pre-defined role.
 You can use a different pre-defined role or create and customize your own role
 permissions with
 [custom IAM roles](https://cloud.google.com/spanner/docs/iam#custom-roles).
-</Notice>
+</Admonition>
 
 ### Grant access to the service account
 
@@ -177,12 +177,12 @@ spanner-example GCP Cloud Spanner [*]           env=dev
 
 </Tabs>
 
-<Notice
+<Admonition
   type="note"
 >
 You will only be able to see databases that your Teleport role has
 access to. See our [RBAC](../rbac.mdx) guide for more details.
-</Notice>
+</Admonition>
 
 When connecting to the database, use the name of the service account
 that you created for a database user 

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/vitess.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/vitess.mdx
@@ -19,10 +19,10 @@ description: How to configure Teleport database access for Vitess (MySQL protoco
 
 </Tabs>
 
-<Notice type="note">
+<Admonition type="note">
   Accessing Vitess using the gRPC protocol is not currently supported by
   Teleport.
-</Notice>
+</Admonition>
 
 ## Prerequisites
 

--- a/docs/pages/enroll-resources/database-access/rbac.mdx
+++ b/docs/pages/enroll-resources/database-access/rbac.mdx
@@ -30,12 +30,12 @@ For a more general description of Teleport roles and examples see
 [RBAC](../../admin-guides/access-controls/access-controls.mdx), as this section focuses on
 configuring RBAC for database access.
 
-<Notice type="warning">
+<Admonition type="warning">
 
 Database Access Controls for database objects only supports PostgreSQL
 databases.
 
-</Notice>
+</Admonition>
 
 ## Role configuration
 

--- a/docs/pages/enroll-resources/desktop-access/directory-sharing.mdx
+++ b/docs/pages/enroll-resources/desktop-access/directory-sharing.mdx
@@ -105,12 +105,12 @@ the shared directory.
 You can also copy a file from one subdirectory within the shared directory and
 paste it into another—the local side will reflect the changes.
 
-<Notice type="warning">
+<Admonition type="warning">
 
 Directory Sharing does not support moving files between subdirectories within
 the shared directory on the remote side.
 
-</Notice>
+</Admonition>
 
 ### Editing on the local side
 

--- a/docs/pages/enroll-resources/kubernetes-access/controls.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/controls.mdx
@@ -335,14 +335,14 @@ Below is a Kubernetes `ClusterRole` that grants the minimum set of permissions
 to enable impersonation, and a `ClusterRoleBinding` that grants these
 permissions to a service account.
 
-<Notice type="tip">
+<Admonition type="tip">
 
 There is usually no need to define these resources manually. The [manual
 methods](register-clusters/register-clusters.mdx) and [automatic methods](../auto-discovery/kubernetes/kubernetes.mdx) for
 registering Kubernetes clusters with Teleport include steps for setting up the
 Kubernetes RBAC resources that Teleport needs to allow access to clusters.
 
-</Notice>
+</Admonition>
 
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -555,14 +555,14 @@ value begins with `^` and ends in `$`, the Kubernetes Service will treat it as a
 regular expression using Go's `re2` syntax (see the `re2`
 [README](https://github.com/google/re2/wiki/Syntax)).
 
-<Notice type="tip" >
+<Admonition type="tip" >
 For a user to access a pod named in a role's `kubernetes_resources` field, the user
 must be assigned a Teleport role that contains at least one value within
 `kubernetes_groups` or `kubernetes_users`. Teleport does not alter Kubernetes
 roles to allow or deny access. Read the next section for an explanation of how the
 Kubernetes Service evaluates Teleport roles in order to allow or deny access to
 pods in a cluster.
-</Notice>
+</Admonition>
 
 ## How the Kubernetes Service evaluates Teleport roles
 

--- a/docs/pages/enroll-resources/kubernetes-access/register-clusters/dynamic-registration.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/register-clusters/dynamic-registration.mdx
@@ -21,12 +21,12 @@ registration, then create, list, update, and delete Kubernetes clusters via
 
 - A Linux host where you will install the Teleport Kubernetes Service.
 
-  <Notice type="tip">
+  <Admonition type="tip">
 
   Our `teleport-kube-agent` Helm chart does not support dynamic Kubernetes
   cluster registration.
 
-  </Notice>
+  </Admonition>
 
 - A Kubernetes cluster to join to your Teleport cluster. You must have
   permissions to create namespaces, secrets, service accounts, cluster roles,
@@ -424,13 +424,13 @@ $ tsh kube ls
  mycluster         env=test teleport.dev/origin=dynamic *
 ```
 
-<Notice type="warning">
+<Admonition type="warning">
 
 If the updated `kube_cluster` resource's labels no longer match the ones a Teleport
 Kubernetes Service instance is configured to watch, the instance will unregister
 and stop proxying the Kubernetes cluster.  
 
-</Notice>
+</Admonition>
 
 ### Delete Kubernetes cluster resources
 

--- a/docs/pages/enroll-resources/kubernetes-access/troubleshooting.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/troubleshooting.mdx
@@ -93,10 +93,10 @@ Or the following:
 GKE Autopilot denies requests that impersonate "system:masters" group
 ```
 
-<Notice type="note">
+<Admonition type="note">
 This issue only affects GKE Autopilot clusters. If you're using a standard GKE
 cluster, this issue doesn't apply to you.
-</Notice>
+</Admonition>
 
 ### Explanation
 

--- a/docs/pages/enroll-resources/machine-id/access-guides/ssh.mdx
+++ b/docs/pages/enroll-resources/machine-id/access-guides/ssh.mdx
@@ -145,11 +145,11 @@ $ ssh -F /opt/machine-id/ssh_config root@my-host.example.teleport.sh hostname
 my-host
 ```
 
-<Notice type="warning">
+<Admonition type="warning">
   The `ssh_config` for OpenSSH requires that `tsh` is installed. This is
   necessary as `tsh` is used to make the OpenSSH client compatible with
   Teleport's port multiplexing.
-</Notice>
+</Admonition>
 
 ### Connecting using other tools
 

--- a/docs/pages/enroll-resources/machine-id/deployment/linux.mdx
+++ b/docs/pages/enroll-resources/machine-id/deployment/linux.mdx
@@ -73,12 +73,12 @@ Replace:
 - `(=presets.tokens.first=)` with the token that was returned by `tctl bots add`
   in the previous step.
 
-<Notice type="note">
+<Admonition type="note">
 The first time that `tbot` runs, this token will be exchanged for a certificate
 that the bot uses for authentication. At this point, the token is invalidated.
 This means you may remove the token from the configuration file after the first
 run has completed, but there is no tangible security benefit to doing so.
-</Notice>
+</Admonition>
 
 ### Prepare the storage directory
 

--- a/docs/pages/enroll-resources/machine-id/troubleshooting.mdx
+++ b/docs/pages/enroll-resources/machine-id/troubleshooting.mdx
@@ -34,12 +34,12 @@ some additional context:
 
 ### Explanation
 
-<Notice type="note">
+<Admonition type="note">
 This applies only to bots using the `token` join method, which makes use of
 one-time use shared secrets. Provider-specific join methods, such as GitHub,
 AWS IAM, etc will not be locked in this fashion unless another instance of the
 bot uses `token` joining.
-</Notice>
+</Admonition>
 
 Machine ID (with token-based joining) uses a certificate generation counter to
 detect potentially stolen renewable certificates. Each time a bot fetches a new
@@ -288,7 +288,7 @@ Edit the role, then save and close the file to apply your changes.
 
 (!docs/pages/includes/create-role-using-web.mdx!)
 
-<Notice type="note">
+<Admonition type="note">
 By default, outputs (like `/opt/machine-id`) are granted all roles provided
 to the bot via `tctl bots add --roles=...`, but it's possible to grant only a
 subset of these roles using the `roles: ...` parameter in `tbot.yaml`.
@@ -296,7 +296,7 @@ subset of these roles using the `roles: ...` parameter in `tbot.yaml`.
 If permissions are unexpectedly missing, ensure `tbot.yaml` requests your
 database role, either by relying on default behavior or adding the role to the
 `roles: ...` list.
-</Notice>
+</Admonition>
 
 Once fixed, restart or reload the `tbot` clients for the updated role to take
 effect.

--- a/docs/pages/enroll-resources/server-access/guides/bpf-session-recording.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/bpf-session-recording.mdx
@@ -71,12 +71,12 @@ library preloading, and environment variables may not be captured in session rec
   See below for more details on the required versions for your Linux kernel and
   distribution.
 
-<Notice type="tip">
+<Admonition type="tip">
 
   Our Standard Session Recording works with older Linux kernels. View [Teleport
   Session Recording](../../../reference/architecture/session-recording.mdx) for more details.
 
-</Notice>
+</Admonition>
 
 ### Linux distributions and supported kernels
 

--- a/docs/pages/enroll-resources/server-access/guides/recording-proxy-mode.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/recording-proxy-mode.mdx
@@ -15,14 +15,14 @@ when gradually transitioning large server fleets to Teleport.
   ![Teleport OpenSSH Recording Proxy](../../../../img/server-access/openssh-proxy.png)
 </Figure>
 
-<Notice type="warning">
+<Admonition type="warning">
 
 Teleport Cloud only supports session recording at the Node level. If you are
 interested in setting up session recording, read our
 [getting started guide](../getting-started.mdx) so you can start
 replacing your OpenSSH servers with Teleport Agents.
 
-</Notice>
+</Admonition>
 
 We consider Recording Proxy Mode to be less secure than recording at the Node
 level for two reasons:

--- a/docs/pages/enroll-resources/workload-identity/aws-oidc-federation.mdx
+++ b/docs/pages/enroll-resources/workload-identity/aws-oidc-federation.mdx
@@ -59,10 +59,10 @@ This guide covers configuring OIDC federation. For Roles Anywhere, see
   information, see the [deployment
   guides](../machine-id/deployment/deployment.mdx).
 
-<Notice type="warning">
+<Admonition type="warning">
 Issuing JWT SVIDs with Teleport Workload Identity requires at least Teleport
 version 16.4.3.
-</Notice>
+</Admonition>
 
 ### Deciding on a SPIFFE ID structure
 

--- a/docs/pages/enroll-resources/workload-identity/azure-federated-credentials.mdx
+++ b/docs/pages/enroll-resources/workload-identity/azure-federated-credentials.mdx
@@ -44,10 +44,10 @@ protect Azure APIs in a few ways:
 - An Azure resource group and subscription you wish to grant the workload access
   to.
 
-<Notice type="warning">
+<Admonition type="warning">
 Issuing JWT SVIDs with Teleport Workload Identity requires at least Teleport
 version 16.4.3.
-</Notice>
+</Admonition>
 
 ### Deciding on a SPIFFE ID structure
 

--- a/docs/pages/enroll-resources/workload-identity/gcp-workload-identity-federation-jwt.mdx
+++ b/docs/pages/enroll-resources/workload-identity/gcp-workload-identity-federation-jwt.mdx
@@ -40,10 +40,10 @@ GCP APIs in a few ways:
 workloads which need to access Teleport Workload Identity will run. For more
 information, see the [deployment guides](../machine-id/deployment/deployment.mdx).
 
-<Notice type="warning">
+<Admonition type="warning">
 Issuing JWT SVIDs with Teleport Workload Identity requires at minimum version
 16.4.3.
-</Notice>
+</Admonition>
 
 ### Deciding on a SPIFFE ID structure
 

--- a/docs/pages/includes/application-access/azure-teleport-role.mdx
+++ b/docs/pages/includes/application-access/azure-teleport-role.mdx
@@ -11,14 +11,14 @@ identities.
 |**Dynamic**|A Teleport role includes a template variable that grants a user access to all Azure identities assigned directly to them.|Local users, OIDC, SAML|
 |**Static**|A Teleport role explicitly specifies the Azure identities a user is allowed to assume.|Local users, OIDC, SAML, GitHub|
 
-<Notice type="tip">
+<Admonition type="tip">
 
 We recommend using the dynamic approach, since it scales well as you add
 Azure identities to your account. If you have configured a Teleport Community Edition
 cluster to authenticate users using GitHub SSO, you must use the static approach,
 as OAuth-based GitHub applications do not support custom claims.
 
-</Notice>
+</Admonition>
 
 <Tabs dropdownCaption="Approach">
 <TabItem options="Dynamic Identities" label="Local Users">

--- a/docs/pages/includes/application-access/azure-tsh.mdx
+++ b/docs/pages/includes/application-access/azure-tsh.mdx
@@ -69,13 +69,13 @@ for example, run the following command:
 $ tsh az vm list
 ```
 
-<Notice type="tip">
+<Admonition type="tip">
 
 If you're not seeing the expected VMs at this point, double-check that your
 Azure managed identity is assigned the "Reader" role at the scope of your
 resource group.
 
-</Notice>
+</Admonition>
 
 ### Use Azure CLI applications without `tsh`
 
@@ -93,11 +93,11 @@ To start the local proxy, run the following `tsh` command:
 $ tsh proxy azure 
 ```
 
-<Notice type="tip">
+<Admonition type="tip">
 
 The command `tsh proxy az` is an alias for `tsh proxy azure`.
 
-</Notice>
+</Admonition>
 
 The command will print the address of the local proxy server along with `export`
 commands for assigning environment variables. Azure CLI applications read these
@@ -105,13 +105,13 @@ variables in order to request an authentication token for Azure's APIs:
 
 (!docs/pages/includes/application-access/azure-tsh-proxy-azure-sample.mdx!)
 
-<Notice type="warning">
+<Admonition type="warning">
 
 `tsh proxy azure` runs the local proxy in the foreground, so don't interrupt
 the process or exit the terminal where you ran the command until you're ready
 to close the local proxy.
 
-</Notice>
+</Admonition>
 
 Copy the `export` commands and paste them into a second terminal. In that
 terminal, you can now run your Azure CLI application of choice. For example, you
@@ -126,9 +126,9 @@ identity you created earlier, and that identity is authorized to view resources
 in your resource group, the `az vm list` command will only list VMs in that
 resource group.
 
-<Notice type="info">
+<Admonition type="info">
 
 When you run an `az` command via `tsh az`, `tsh` starts the local proxy in the
 background and uses it to execute the command.
 
-</Notice>
+</Admonition>

--- a/docs/pages/includes/cloud/call-to-action.mdx
+++ b/docs/pages/includes/cloud/call-to-action.mdx
@@ -1,4 +1,4 @@
-<Notice 
+<Admonition 
 type="tip" 
 >
 
@@ -8,4 +8,4 @@ secure access to your infrastructure right away.
 Get started with a [free trial](https://goteleport.com/signup?t_source=docs) of
 Teleport Enterprise Cloud.
 
-</Notice>
+</Admonition>

--- a/docs/pages/includes/database-access/gui-clients/spanner-local-proxy.mdx
+++ b/docs/pages/includes/database-access/gui-clients/spanner-local-proxy.mdx
@@ -12,10 +12,10 @@ The name of the service account should be everything before the "@" of the
 service account email address, e.g. the name for
 `llama@example-project-123456.iam.gserviceaccount.com` is just "llama".
 
-<Notice type="tip">
+<Admonition type="tip">
 This command uses the local port 1443, but you can choose any port, or let
 `tsh` pick a local port at random if you omit the `--port` flag.
 You should specify a port to avoid the need to reconfigure your GUI client again
 later.
-</Notice>
+</Admonition>
 

--- a/docs/pages/includes/database-access/reference/aws-iam/redis/auto-password-access-policy.mdx
+++ b/docs/pages/includes/database-access/reference/aws-iam/redis/auto-password-access-policy.mdx
@@ -1,11 +1,11 @@
 {{ dbType="ElastiCache" permissionType="elasticache" updateUserPermission="ModifyUser" listTagsPermission="ListTagsForResource" }}
 
-<Notice type="note">
+<Admonition type="note">
 The recommended way to configure Teleport access to {{ dbType }} is to use IAM
 auth, which is supported for Redis engine version 7.0 and up.
 Using managed users with passwords stored in AWS Secrets Manager is a legacy
 method for configuring Teleport access to {{ dbType }}.
-</Notice>
+</Admonition>
 
 If any {{ dbType }} users are tagged to be managed by Teleport, below are the
 IAM permissions required for managing the {{ dbType }} users:

--- a/docs/pages/includes/device-trust/support-notice.mdx
+++ b/docs/pages/includes/device-trust/support-notice.mdx
@@ -1,4 +1,4 @@
-<Admonition type="notice">
+<Admonition type="note">
   Device Trust supports all platforms and clients, including `tsh`, Teleport
   Connect and the Web UI (requires Teleport Connect to be installed).
 

--- a/docs/pages/includes/discovery/database-service-troubleshooting.mdx
+++ b/docs/pages/includes/discovery/database-service-troubleshooting.mdx
@@ -37,11 +37,11 @@ spec:
 
 #### Errors when connecting to a database
 
-<Notice type="note">
+<Admonition type="note">
 This section assumes you have already provisioned a database user and configured
 Teleport RBAC for that database user by following a specific guide in 
 [Enroll AWS Databases](../../enroll-resources/database-access/enroll-aws-databases/enroll-aws-databases.mdx).
-</Notice>
+</Admonition>
 
 If there are connection errors when you try to connect to a database, then
 first check if there are multiple `db_server` heartbeat resources for the target

--- a/docs/pages/includes/discovery/discovery-group.mdx
+++ b/docs/pages/includes/discovery/discovery-group.mdx
@@ -1,4 +1,4 @@
-<Notice type="warning">
+<Admonition type="warning">
 Discovery Service exposes a configuration parameter - `discovery_service.discovery_group` -
 that allows you to group discovered resources into different sets. This parameter
 is used to prevent Discovery Agents watching different sets of cloud resources
@@ -18,4 +18,4 @@ the following configuration.
 from Production account.
 - 2 Discovery Services configured with `discovery_group: "staging"` polling data
 from Staging account.
-</Notice>
+</Admonition>

--- a/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
@@ -675,9 +675,9 @@ You must create a secret containing the CA certs in the same namespace as Telepo
 $ kubectl create secret generic my-root-ca --from-file=ca.pem=/path/to/root-ca.pem
 ```
 
-<Notice type="warning" title="Root CA filename">
+<Admonition type="warning" title="Root CA filename">
   The key containing the root CA in the secret must be `ca.pem`.
-</Notice>
+</Admonition>
 
 ## `updater`
 

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -871,13 +871,13 @@ You can download one of the following .pkg installers for macOS:
   # /usr/local/bin/teleport
   ```
 
-<Notice type="danger">
+<Admonition type="danger">
 
 We do not recommend using Homebrew to install Teleport.  The Teleport package in
 Homebrew is not maintained by Teleport and we can't guarantee its reliability or
 security.
 
-</Notice>
+</Admonition>
 
 </TabItem>
 </Tabs>

--- a/docs/pages/ips.mdx
+++ b/docs/pages/ips.mdx
@@ -32,9 +32,9 @@ This list may be used to allowlist outbound network connections from Teleport Ag
 Allowlisting these IPs is not a required or recommended configuration for Teleport Agents, but it may be useful in environments that require restrictions to outbound network connections.
 For example, this list may be used to configure firewalls that sit in front of Teleport Agents, when those firewalls block access to the public internet by default.
 
-<Notice type="warning">
+<Admonition type="warning">
 Note that IP addresses may be added or removed from the above list over time.
-</Notice>
+</Admonition>
 
 When this list is modified, we will provide at least two weeks notice by:
 1. Updating the Changelog below.
@@ -42,9 +42,9 @@ When this list is modified, we will provide at least two weeks notice by:
 1. Providing a [Status Page](https://status.teleport.sh/) update.
 1. Reaching out directly to Enterprise customers that have requested advanced notice.
 
-<Notice type="warning">
+<Admonition type="warning">
 If you are Teleport Enterprise customer and plan to employ this allowlist, please let us know by opening a support ticket.
-</Notice>
+</Admonition>
 
 Additionally, to receive Teleport Agent updates, nodes must be able to reach the following domains via HTTPS during the update.
 

--- a/docs/pages/reference/architecture/authentication.mdx
+++ b/docs/pages/reference/architecture/authentication.mdx
@@ -34,14 +34,14 @@ untrusted certificate authority.
 if the certificate has been signed with a valid certificate authority, and does not need to copy user
 credentials over to every service.
 
-<Notice type="tip">
+<Admonition type="tip">
 Teleport issues certificates that are good from a few hours to minutes before they auto-expire without any action.
 The shorter the duration for these certificates, the better.
 Ideally, certs should be issued only for the duration of a session.
 In practice, several hours or the duration of the workday are OK too.
 The expiry date in certificates can not be forged
 without invalidating the certificates, so any system can validate the certificate.
-</Notice>
+</Admonition>
 
 ### X.509 certificates
 
@@ -103,11 +103,11 @@ X.509 certificates issued by Teleport and used for Kubernetes, Databases, Web Ap
 Teleport issues certificates that are good from a few hours to minutes before they auto-expire without any action.
 Instead of distributing revocation lists, Teleport relies on time to do the job for us.
 
-<Notice type="tip">
+<Admonition type="tip">
 In some cases, certificate expiration is not fast enough, and all sessions have to be terminated immediately,
 for example during active security incident.
 For those cases, Teleport Proxy can terminate live connections using [session and identity locking](../../admin-guides/access-controls/guides/locking.mdx).
-</Notice>
+</Admonition>
 
 ### Short-lived Certs For Users
 
@@ -154,12 +154,12 @@ using a new certificate authority.
 Take a look at the [Certificate Rotation Guide](../../admin-guides/management/operations/ca-rotation.mdx) to
 learn how to do certificate rotation in practice.
 
-<Notice type="tip">
+<Admonition type="tip">
 To quickly lock out a potentially compromised Auth Service instance, Proxy
 Service instance, or Teleport Agent without rotating the entire cluster
 certificates, use [session and identity
 locking](../../admin-guides/access-controls/guides/locking.mdx).
-</Notice>
+</Admonition>
 
 ## More concepts
 

--- a/docs/pages/reference/architecture/authorization.mdx
+++ b/docs/pages/reference/architecture/authorization.mdx
@@ -33,12 +33,12 @@ with Teleport:
 
 ![Role mapping](../../../img/architecture/role-mapping@1.5x.svg)
 
-<Notice type="tip">
+<Admonition type="tip">
 Every time SSO user logs in, Teleport creates a temporary user account record
 that automatically expires with SSO session and logs audit log entries.
 
 Teleport creates this record to avoid name collisions with local users.
-</Notice>
+</Admonition>
 
 #### External users from other clusters
 
@@ -228,10 +228,10 @@ spec:
     kubernetes_groups: ['{{external.groups}}']
 ```
 
-<Notice type="tip">
+<Admonition type="tip">
 Any role that uses variable interpolation is treated as a role template.
 You can add interpolation to any role spec.
-</Notice>
+</Admonition>
 
 **Variable interpolation rules*
 
@@ -322,9 +322,9 @@ spec:
       where: contains(session.participants, user.metadata.name)
 ```
 
-<Notice type="tip">
+<Admonition type="tip">
 You can use `where` fields in all resource rules. Check out [the full role reference](../access-controls/roles.mdx) contains full role spec for details.
-</Notice>
+</Admonition>
 
 ### Role options
 
@@ -356,12 +356,12 @@ options, Teleport will choose `strict` option.
 
 ### Just in Time Access Requests
 
-<Notice type="tip">
+<Admonition type="tip">
 
   The full version of Just In Time Access Requests is available only in Teleport
   Enterprise (including Enterprise Cloud).
 
-</Notice>
+</Admonition>
 
 Roles allow requesting elevated privileges - other roles or individual resources.
 

--- a/docs/pages/reference/architecture/proxy.mdx
+++ b/docs/pages/reference/architecture/proxy.mdx
@@ -21,11 +21,11 @@ provides the following key features:
 
 ![Proxy service](../../../img/architecture/proxy.png)
 
-<Notice type="tip">
+<Admonition type="tip">
 To create a minimal Teleport cluster, you have run two services:
 Teleport Auth Service and Teleport Proxy Service. For your home lab,
 you can run both services as a one binary and process.
-</Notice>
+</Admonition>
 
 ## Web UI
 
@@ -65,10 +65,10 @@ In the example below, Alice connects to kubernetes cluster behind firewall via t
 
 ![Teleport Proxy Tunnel](../../../img/architecture/proxy-tunnel@1.2x.png)
 
-<Notice type="tip">
+<Admonition type="tip">
 All modes above are turned on by default in Proxies. No special configuration is necessary, unless you
 want to turn some of those modes off.
-</Notice>
+</Admonition>
 
 ## More concepts
 

--- a/docs/pages/reference/architecture/trustedclusters.mdx
+++ b/docs/pages/reference/architecture/trustedclusters.mdx
@@ -18,11 +18,11 @@ Uses for Trusted Clusters include:
 - Device manufacturers remotely maintaining computing appliances deployed on premises.
 - Large cloud software vendors managing multiple data centers.
 
-<Notice type="tip">
+<Admonition type="tip">
 Individual nodes and proxies can create reverse tunnels to proxy services without creating a new cluster.
 You don't need to set up a trusted cluster just to connect a couple of servers, Kubernetes clusters or
 databases behind a firewall.
-</Notice>
+</Admonition>
 
 ## Multi-Data-center Clusters
 

--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -856,7 +856,7 @@ To configure Teleport to use DynamoDB:
 - Make sure that all Teleport resource services have the `auth_servers` configuration setting
   populated with the addresses of your cluster's Auth Service instances.
 
-<Notice type="danger">
+<Admonition type="danger">
 
 AWS can throttle DynamoDB if more than two processes are reading from the same
 stream's shard simultaneously, so you must not deploy more than two Auth Service
@@ -864,7 +864,7 @@ instances that read from a DynamoDB backend. For details on DynamoDB Streams,
 read the [AWS
 documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.html).
 
-</Notice>
+</Admonition>
 
 ```yaml
 teleport:

--- a/docs/pages/reference/cli/teleport.mdx
+++ b/docs/pages/reference/cli/teleport.mdx
@@ -36,9 +36,9 @@ The primary commands for the `teleport` CLI are as follows:
 | `teleport debug get-log-level` | Fetches instance current log level. |
 | `teleport debug debug profile` | Export the application profiles (pprof format). |
 
-<Notice type="tip">
+<Admonition type="tip">
 For more information on subcommands when working with the `teleport` cli, use the `--help` option or `teleport <subcommand> --help`.
-</Notice>
+</Admonition>
 
 ## teleport start
 
@@ -86,13 +86,13 @@ The `--roles` flag when used with `teleport --start` instructs Teleport on which
 | [App](../../enroll-resources/application-access/introduction.mdx) | `app` | Provides access to applications. |
 | [Database](../agent-services/database-access-reference/database-access-reference.mdx) | `db` | Provides access to databases. |
 
-<Notice type="tip" scope={["cloud"]}>
+<Admonition type="tip" scope={["cloud"]}>
 
 Teleport Cloud manages Teleport instances with the `auth` and `proxy` roles. Use
 the remaining roles to manage access to specific resources and other Teleport
 clusters.
 
-</Notice>
+</Admonition>
 
 ### Examples
 

--- a/docs/pages/reference/cli/tsh.mdx
+++ b/docs/pages/reference/cli/tsh.mdx
@@ -631,13 +631,13 @@ commands for environment variables required to connect:
 
 (!docs/pages/includes/application-access/azure-tsh-proxy-azure-sample.mdx!)
 
-<Notice type="tip">
+<Admonition type="tip">
 
 `tsh proxy azure` runs the local proxy in the foreground, so don't interrupt
 the process or exit the terminal where you ran the command until you're ready
 to close the local proxy.
 
-</Notice>
+</Admonition>
 
 Copy the `export` commands and paste them into a second terminal.
 

--- a/docs/pages/reference/config.mdx
+++ b/docs/pages/reference/config.mdx
@@ -14,11 +14,11 @@ By default, Teleport reads its configuration from `/etc/teleport.yaml`.
 
 ## Before using this reference
 
-<Notice type="danger">
+<Admonition type="danger">
 
 Do not use this example configuration in production.
 
-</Notice>
+</Admonition>
 
 You must edit your configuration file to meet the needs of your environment.
 Using a copy of the reference configuration will have unintended effects. To
@@ -33,12 +33,12 @@ There are also `configure` commands available for the SSH Service and Database
 Service. See our documentation on `teleport node configure` and `teleport db
 configure` in the [Teleport CLI Reference](cli/teleport.mdx).
 
-<Notice type="warning">
+<Admonition type="warning">
 
 You should back up your configuration file before making changes. This will
 enable you to roll back to the previous configuration if you need to.
 
-</Notice>
+</Admonition>
 
 ## Enabling Teleport services
 
@@ -112,10 +112,10 @@ Further reading:
 
 These settings apply to the Teleport Proxy Service:
 
-<Notice type="tip">
+<Admonition type="tip">
 Teleport Enterprise Cloud manages the Proxy Service for you, so you do not need
 to specify these configuration settings.
-</Notice>
+</Admonition>
 
 ```yaml
 (!docs/pages/includes/config-reference/proxy-service.yaml!)
@@ -125,10 +125,10 @@ to specify these configuration settings.
 
 These settings apply to the Teleport Auth Service:
 
-<Notice type="tip">
+<Admonition type="tip">
 Teleport Enterprise Cloud manages the Auth Service for you, so you do not need
 to specify these configuration settings.
-</Notice>
+</Admonition>
 
 ```yaml
 (!docs/pages/includes/config-reference/auth-service.yaml!)

--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -1513,9 +1513,9 @@ You should create the secret in the same namespace as Teleport using a command l
 kubectl create secret generic my-root-ca --from-file=ca.pem=/path/to/root-ca.pem
 ```
 
-<Notice type="warning" title="Root CA filename">
+<Admonition type="warning" title="Root CA filename">
   The filename used for the root CA in the secret must be `ca.pem`.
-</Notice>
+</Admonition>
 
 `values.yaml` example:
 

--- a/docs/pages/reference/join-methods.mdx
+++ b/docs/pages/reference/join-methods.mdx
@@ -284,13 +284,13 @@ IAM credentials with `ec2:DescribeInstances` permissions are required on your
 Teleport Auth Service. No IAM credentials are required on the Teleport processes
 joining the cluster.
 
-<Notice type="warning">
+<Admonition type="warning">
 
 The EC2 join method is not available in Teleport Enterprise Cloud and Teleport
 Team. Teleport Enterprise Cloud and Team customers can use the [IAM join
 method](#aws-iam-role-iam) or [ephemeral secret tokens](#ephemeral-tokens).
 
-</Notice>
+</Admonition>
 
 (!docs/pages/includes/provision-token/ec2-spec.mdx!)
 

--- a/docs/pages/reference/monitoring/audit.mdx
+++ b/docs/pages/reference/monitoring/audit.mdx
@@ -27,13 +27,13 @@ There are two components of the audit log:
 </TabItem>
 </Tabs>
 
-<Notice type="tip">
+<Admonition type="tip">
 
 You can use
 [Enhanced Session Recording with BPF](../../enroll-resources/server-access/guides/bpf-session-recording.mdx)
 to get even more comprehensive audit logs with advanced security.
 
-</Notice>
+</Admonition>
 
 ## Events
 
@@ -124,14 +124,14 @@ format:
 
 Below are some possible types of audit events.
 
-<Notice type="tip">
+<Admonition type="tip">
 
 This list is not comprehensive. We recommend exporting audit events to a
 platform that automatically parses event payloads so you can group and filter
 them by their `event` key and discover trends. To set up audit event exporting,
 read [Exporting Teleport Audit Events](../../admin-guides/management/export-audit-events/export-audit-events.mdx).
 
-</Notice>
+</Admonition>
 
 | Event Type | Description |
 | - | - |
@@ -207,10 +207,10 @@ $ tsh play 4c146ec8-eab6-11e6-b1b3-40167e68e931 --format=json
 
 ### Modes
 
-<Notice type="note">
+<Admonition type="note">
 Available only for SSH sessions and when Teleport is configured with
 `auth_service.session_recording: node`.
-</Notice>
+</Admonition>
 
 Modes define how Teleport deals with recording failures, such as a full disk
 error. They are configured per-service at the role level, where the strictest

--- a/docs/pages/reference/monitoring/metrics.mdx
+++ b/docs/pages/reference/monitoring/metrics.mdx
@@ -3,11 +3,11 @@ title: Teleport Metrics
 description: Comprehensive list of all metrics exposed by Teleport.
 ---
 
-<Notice scope={["cloud"]} type="tip">
+<Admonition scope={["cloud"]} type="tip">
 
 Teleport Cloud does not expose monitoring endpoints for the Auth Service and Proxy Service.
 
-</Notice>
+</Admonition>
 
 Teleport metrics are intended for performance monitoring. If you'd like to
 monitor Teleport usage, consider utilizing our Event Handler plugin to push Audit Events into your

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -569,9 +569,9 @@ tls:
   # $ kubectl create secret generic my-root-ca --from-file=ca.pem=/path/to/root-ca.pem
   # ```
   #
-  # <Notice type="warning" title="Root CA filename">
+  # <Admonition type="warning" title="Root CA filename">
   #   The key containing the root CA in the secret must be `ca.pem`.
-  # </Notice>
+  # </Admonition>
   existingCASecretName: ""
 
 # updater -- controls whether the Kube Agent Updater should be deployed alongside


### PR DESCRIPTION
Use Docusaurus syntax for admonitions so the docs engine does not need to replace these. This is one step toward removing the `remark-update-tags` plugin. See: gravitational/docs-website#94

Relevant commands are included below to make reproducing this work easier.

1. Replace all `Notice` tags with `Admonition` tags.

2. Add `type="info"` if an Admonition is missing a type.

   To find instances:

   ``` find docs/pages -name "*.mdx" -exec awk ' BEGIN{a=0} a==0 && /<Admonition/{ a = 1 } a==1 && /type/{t = 1} a==1 && />/{ a = 0; if(t == 0) print FILENAME ":" FNR }' {} \; ```

3. Replace `type="notice"` with `type="note"`.

   To find instances:

   ``` find docs/pages -name "*.mdx" -exec awk ' BEGIN{a=0} a==0 && /<Admonition/{ a = 1 } a==1 && /type="notice"/{t = 1} a==1 && />/{ a = 0; if(t == 1) print FILENAME ":" FNR }' {} \; ```