### PR TITLE
[teleport-update] Add missing names to autoupdate resources in docs

### DIFF
--- a/docs/pages/upgrading/agent-managed-updates.mdx
+++ b/docs/pages/upgrading/agent-managed-updates.mdx
@@ -159,6 +159,8 @@ like this:
 
 ```yaml
 kind: autoupdate_config
+metadata:
+  name: autoupdate-config
 spec:
   agents:
     mode: enabled
@@ -176,6 +178,8 @@ environments might create a custom schedule that looks like this:
 
 ```yaml
 kind: autoupdate_config
+metadata:
+  name: autoupdate-config
 spec:
   agents:
     mode: enabled
@@ -211,6 +215,8 @@ To accomplish this, you can change the default `halt-on-error` strategy to the
 
 ```yaml
 kind: autoupdate_config
+metadata:
+  name: autoupdate-config
 spec:
   agents:
     strategy: time-based
@@ -260,6 +266,8 @@ Create a file called `autoupdate_version.yaml` containing:
 
 ```yaml
 kind: autoupdate_version
+metadata:
+  name: autoupdate-version
 spec:
   agents:
     start_version: 17.2.0


### PR DESCRIPTION
Fixes:
```
$ sudo tctl create autoupdate_version.yaml
ERROR: Metadata is nil
```

See: https://github.com/gravitational/teleport/issues/49525

--

The `teleport-update` binary will be used to enable, disable, and trigger automatic Teleport agent updates. The new auto-updates system manages a local installation of the cluster-specified version of Teleport stored in `/opt/teleport`.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/11856