### PR TITLE
Improve readability of Managed Updates docs intro

### DIFF
--- a/docs/pages/upgrading/agent-managed-updates-v1.mdx
+++ b/docs/pages/upgrading/agent-managed-updates-v1.mdx
@@ -4,27 +4,27 @@ description: Describes how to set up Teleport Managed Agent Updates v1.
 ---
 
 <Notice type="warning">
-This document describes the Managed Updates v1 Teleport Agent updater, which is
-currently supported but will be deprecated after the [Managed update v2 updater
+This document describes the Managed Updates v1 for Teleport Agents, which is
+currently supported but will be deprecated after [Managed Updates v2
 ](./agent-managed-updates.mdx) is generally available.
 </Notice>
 
-The Managed Updates v1 updater uses a script called `teleport-upgrade` that is provided by
+Managed Updates v1 uses a script called `teleport-upgrade` that is provided by
 the `teleport-ent-updater` package and configured by the `cluster_maintenance_config`
-Teleport resource. The new updater uses a binary called `teleport-update` that is
+Teleport resource. Managed Updates v2 uses a binary called `teleport-update` that is
 provided by the `teleport` package and configured by the `autoupdate_version` and
 `autoupdate_config`. The original updater and resource are described in this document.
 
 Only Enterprise versions of Teleport can use Managed Updates v1.
 
 Please consider using [Managed Updates for Agents (v2)](./agent-managed-updates.mdx),
-as its updater provides a safer, simpler, more flexible, compatible, and reliable
-update experience compared to Managed Updates v1.
+as it provides a safer, simpler, more flexible, compatible, and reliable update experience
+compared to Managed Updates v1.
 
 <Admonition type="note" title="Compatibility between Managed Updates v1 and v2">
-Managed Updates v2 are backwards compatible with the
+Managed Updates v2 is backwards compatible with the
 `cluster_maintenance_config` resource. The Managed Updates v1 `teleport-upgrade` script
-is forwards compatible with the `autoupdate_config` and `autoupdate_version` resources.
+is forwards-compatible with the `autoupdate_config` and `autoupdate_version` resources.
 Agents connected to the same cluster may use either resource.
 
 If the `autoupdate_*` resources are configured, they take precedence over
@@ -35,8 +35,8 @@ Users of cloud-hosted Teleport Enterprise will be migrated to Managed Updates v2
 in the first half of 2025 and should plan to migrate their agents to `teleport-update`.
 </Admonition>
 
-On cloud-hosted Teleport Enterprise accounts, users must set up managed agent
-updates to ensure that the version of Teleport running on agents remains
+On cloud-hosted Teleport Enterprise accounts, users must set up Managed Updates for
+Teleport Agents to ensure that the version of Teleport running on agents remains
 compatible with the version running on the Auth Service and Proxy Service. If an
 agent does not maintain [version compatibility](./overview.mdx) with your
 Teleport cluster, connections to those agents will become degraded or lost.
@@ -50,7 +50,7 @@ Teleport supports managed agent updates for SystemD-based Linux distributions
 using `apt`, `yum`, and `zypper` package managers, as well as Kubernetes
 clusters. 
 
-This guide explains how to enable Managed Updates for Teleport Agents on
+This guide explains how to enable Managed Updates v1 for Teleport Agents on
 Teleport Enterprise clusters, including both self-hosted and cloud-hosted
 clusters.
 

--- a/docs/pages/upgrading/agent-managed-updates-v1.mdx
+++ b/docs/pages/upgrading/agent-managed-updates-v1.mdx
@@ -22,9 +22,9 @@ as it provides a safer, simpler, more flexible, compatible, and reliable update 
 compared to Managed Updates v1.
 
 <Admonition type="note" title="Compatibility between Managed Updates v1 and v2">
-Managed Updates v2 is backwards-compatible with the
+Managed Updates v2 is backwards compatible with the
 `cluster_maintenance_config` resource. The Managed Updates v1 `teleport-upgrade` script
-is forwards-compatible with the `autoupdate_config` and `autoupdate_version` resources.
+is forwards compatible with the `autoupdate_config` and `autoupdate_version` resources.
 Teleport Agents connected to the same cluster may use either resource.
 
 If the `autoupdate_*` resources are configured, they take precedence over

--- a/docs/pages/upgrading/agent-managed-updates-v1.mdx
+++ b/docs/pages/upgrading/agent-managed-updates-v1.mdx
@@ -1,12 +1,12 @@
 ---
-title: Teleport Managed Agent Updates (v1)
-description: Describes how to set up Teleport Managed Agent Updates v1.
+title: Managed Updates for Teleport Agents (v1)
+description: Describes how to set up Managed Updates for Teleport Agents (v1)
 ---
 
 <Notice type="warning">
-This document describes the Managed Updates v1 for Teleport Agents, which is
-currently supported but will be deprecated after [Managed Updates v2
-](./agent-managed-updates.mdx) is generally available.
+This document describes Managed Updates for Agents (v1), which is
+currently supported but will be deprecated after [Managed Updates for
+Agents (v2)](./agent-managed-updates.mdx) is generally available.
 </Notice>
 
 Managed Updates v1 uses a script called `teleport-upgrade` that is provided by
@@ -22,10 +22,10 @@ as it provides a safer, simpler, more flexible, compatible, and reliable update 
 compared to Managed Updates v1.
 
 <Admonition type="note" title="Compatibility between Managed Updates v1 and v2">
-Managed Updates v2 is backwards compatible with the
+Managed Updates v2 is backwards-compatible with the
 `cluster_maintenance_config` resource. The Managed Updates v1 `teleport-upgrade` script
 is forwards-compatible with the `autoupdate_config` and `autoupdate_version` resources.
-Agents connected to the same cluster may use either resource.
+Teleport Agents connected to the same cluster may use either resource.
 
 If the `autoupdate_*` resources are configured, they take precedence over
 `cluster_maintenance_config`. This allows for a safe, non-breaking, incremental

--- a/docs/pages/upgrading/agent-managed-updates.mdx
+++ b/docs/pages/upgrading/agent-managed-updates.mdx
@@ -1,10 +1,10 @@
 ---
-title: Teleport Managed Agent Updates (v2)
-description: Describes how to set up Teleport Managed Agent Updates v2.
+title: Managed Updates (v2) for Teleport Agents
+description: Describes how to set up Managed Updates (v2) for Teleport Agents
 ---
 
 <Notice type="warning">
-This document describes the Managed Updates v2 updater, which is currently in beta.
+This document describes Managed Updates for Agents (v2), which is currently in beta.
 
 For Managed Updates v1 instructions, see
 [Managed Updates for Agents (v1)](./agent-managed-updates-v1.mdx).
@@ -32,9 +32,9 @@ resources to manage your agent updates from Teleport. It describes:
 - systemd-based operating systems, regardless of the package manager used
 
 <Admonition type="note" title="Compatibility between Managed Updates v1 and v2">
-Managed updates v2 are backwards compatible with the
+Managed Updates v2 is backwards-compatible with the
 `cluster_maintenance_config` resource. The Managed Updates v1 `teleport-upgrade` script
-is forwards compatible with the `autoupdate_config` and `autoupdate_version` resources.
+is forwards-compatible with the `autoupdate_config` and `autoupdate_version` resources.
 Agents connected to the same cluster should all update to the same version.
 
 If the `autoupdate_version` resource is configured, it takes precedence over


### PR DESCRIPTION
This PR simplifies the wording in the Managed Updates docs, fixing consistency issues and removing confusing phrases like "Managed Updates v1 updater"

--

The `teleport-update` binary will be used to enable, disable, and trigger automatic Teleport agent updates. The new auto-updates system manages a local installation of the cluster-specified version of Teleport stored in `/opt/teleport`.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/11856