### PR TITLE
[v17] Support setting app public-addr within Kubernetes app discovery

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -851,6 +851,8 @@ const (
 	DiscoveryAppInsecureSkipVerify = TeleportNamespace + "/insecure-skip-verify"
 	// DiscoveryAppIgnore specifies if a Kubernetes service should be ignored by discovery service.
 	DiscoveryAppIgnore = TeleportNamespace + "/ignore"
+	// DiscoveryPublicAddr specifies the public address for a discovered app created from a Kubernetes service.
+	DiscoveryPublicAddr = TeleportNamespace + "/public-addr"
 
 	// ReqAnnotationApproveSchedulesLabel is the request annotation key at which schedules are stored for access plugins.
 	ReqAnnotationApproveSchedulesLabel = "/schedules"

--- a/docs/pages/reference/agent-services/kubernetes-application-discovery.mdx
+++ b/docs/pages/reference/agent-services/kubernetes-application-discovery.mdx
@@ -142,3 +142,11 @@ annotations:
       value: "Bearer {{internal.jwt}}"
 ```
 
+### `teleport.dev/public-addr`
+
+Controls the public address for the Teleport app we create if needed.
+
+```yaml
+annotations:
+  teleport.dev/public-addr: "custom.teleport.dev"
+```

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -190,6 +190,7 @@ func NewApplicationFromKubeService(service corev1.Service, clusterName, protocol
 		URI:                appURI,
 		Rewrite:            rewriteConfig,
 		InsecureSkipVerify: getTLSInsecureSkipVerify(service.GetAnnotations()),
+		PublicAddr:         getPublicAddr(service.GetAnnotations()),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "could not create an app from Kubernetes service")
@@ -231,6 +232,10 @@ func getAppRewriteConfig(annotations map[string]string) (*types.Rewrite, error) 
 	}
 
 	return &rw, nil
+}
+
+func getPublicAddr(annotations map[string]string) string {
+	return annotations[types.DiscoveryPublicAddr]
 }
 
 func getTLSInsecureSkipVerify(annotations map[string]string) bool {

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -1158,7 +1158,7 @@ func TestDiscoveryKubeServices(t *testing.T) {
 
 	appProtocolHTTP := "http"
 	mockKubeServices := []*corev1.Service{
-		newMockKubeService("service1", "ns1", "", map[string]string{"test-label": "testval"}, nil,
+		newMockKubeService("service1", "ns1", "", map[string]string{"test-label": "testval"}, map[string]string{types.DiscoveryPublicAddr: "custom.example.com"},
 			[]corev1.ServicePort{{Port: 42, Name: "http", Protocol: corev1.ProtocolTCP}}),
 		newMockKubeService("service2", "ns2", "", map[string]string{
 			"test-label":  "testval",
@@ -1980,6 +1980,8 @@ func mustConvertKubeServiceToApp(t *testing.T, discoveryGroup, protocol string, 
 	port.Name = ""
 	app, err := services.NewApplicationFromKubeService(*kubeService, discoveryGroup, protocol, port)
 	require.NoError(t, err)
+	require.Equal(t, kubeService.Annotations[types.DiscoveryPublicAddr], app.GetPublicAddr())
+
 	app.GetStaticLabels()[types.TeleportInternalDiscoveryGroupName] = discoveryGroup
 	app.GetStaticLabels()[types.OriginLabel] = types.OriginDiscoveryKubernetes
 	app.GetStaticLabels()[types.DiscoveryTypeLabel] = types.KubernetesMatchersApp


### PR DESCRIPTION
Backport #52642 to branch/v17

changelog: Support setting the public address for discovered apps based on Kubernetes annotations.
