### PR TITLE
Fix RPM linking logic

### DIFF
--- a/examples/systemd/before-remove
+++ b/examples/systemd/before-remove
@@ -4,5 +4,9 @@
 
 set -eu
 
-echo "Removing symlinks from Teleport system paths..."
-/opt/teleport/system/bin/teleport-update unlink-package || true
+if [ $# -ge 1 ] && [ "$1" = "1" ]; then
+  echo "Skipping symlink removal as this is a package upgrade."
+else
+  echo "Removing symlinks from Teleport system paths..."
+  /opt/teleport/system/bin/teleport-update unlink-package || true
+fi


### PR DESCRIPTION
This PR fixes two RPM issues sharing the same root cause that went undetected until 17.3.0 release.

### Issue 1: `link-package` fails

`link-package` is supposed to run after we successfully installed teleport, to create symlinks to the teleport system install.

RPM hooks are different than other packages and --after-install runs before the previous package removal. This means the old teleport binary has not been removed yet when we invoke `teleport-updater link-package` and causes an error.
We cannot just overwrite the binaries because the old package removal will happen an tear down our symlinks.

Docs about RPM scriptlets ordering: https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#ordering

### Issue 2: `unlink-package` invoked on update

The uninstallation scriptlet is invoked after each package upgrade, which unlinks Teleport binaries from the system.

This can be detected by looking at the arguments passed by RPM to the scriptlet: https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_syntax

### Workaround

Both issues can be worked around by uninstalling and reinstalling the teleport package.
Because the 17.3.0 package potentially left teleport in a state without binaries after a failed update, we pulled 17.3.0 and are releasing 17.3.1.

Changelog: Fixes two issues in the 17.3.0 RPM causing package upgrades to fail and leading to teleport binaries not being symlinked in /usr/local/bin.
Changelog: On RPM-based distros, 17.3.0 can lead to a failed installation without a working Teleport service. The 17.3.0 RPM was pulled from our CDN. 17.3.1 should be used instead. If you updated to 17.3.0, you should update to 17.3.1.