### PR TITLE
[v17] Fix RPM linking logic

### DIFF
--- a/examples/systemd/before-remove
+++ b/examples/systemd/before-remove
@@ -4,5 +4,9 @@
 
 set -eu
 
-echo "Removing symlinks from Teleport system paths..."
-/opt/teleport/system/bin/teleport-update unlink-package || true
+if [ $# -ge 1 ] && [ "$1" = "1" ]; then
+  echo "Skipping symlink removal as this is a package upgrade."
+else
+  echo "Removing symlinks from Teleport system paths..."
+  /opt/teleport/system/bin/teleport-update unlink-package || true
+fi


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/52703 to branch/v17`

Changelog: Fixes two issues in the 17.3.0 RPM causing package upgrades to fail and leading to teleport binaries not being symlinked in /usr/local/bin.
Changelog: On RPM-based distros, 17.3.0 can lead to a failed installation without a working Teleport service. The 17.3.0 RPM was pulled from our CDN. 17.3.1 should be used instead. If you updated to 17.3.0, you should update to 17.3.1.