### PR TITLE
[v16] Escape labels on Node Join scripts

### DIFF
--- a/lib/web/join_tokens.go
+++ b/lib/web/join_tokens.go
@@ -603,6 +603,10 @@ func getJoinScript(ctx context.Context, settings scriptSettings, m nodeAPIGetter
 
 	labelsList := []string{}
 	for labelKey, labelValues := range token.GetSuggestedLabels() {
+		labelKey = shsprintf.EscapeDefaultContext(labelKey)
+		for i := range labelValues {
+			labelValues[i] = shsprintf.EscapeDefaultContext(labelValues[i])
+		}
 		labels := strings.Join(labelValues, " ")
 		labelsList = append(labelsList, fmt.Sprintf("%s=%s", labelKey, labels))
 	}
@@ -660,7 +664,7 @@ func getJoinScript(ctx context.Context, settings scriptSettings, m nodeAPIGetter
 	// This section relies on Go's default zero values to make sure that the settings
 	// are correct when not installing an app.
 	err = scripts.InstallNodeBashScript.Execute(&buf, map[string]interface{}{
-		"token":    settings.token,
+		"token":    shsprintf.EscapeDefaultContext(settings.token),
 		"hostname": hostname,
 		"port":     portStr,
 		// The install.sh script has some manually generated configs and some

--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -47,7 +47,7 @@ JOIN_METHOD_FLAG=""
 [ -n "$JOIN_METHOD" ] && JOIN_METHOD_FLAG="--join-method ${JOIN_METHOD}"
 
 # inject labels into the configuration
-LABELS='{{.labels}}'
+LABELS="{{.labels}}"
 LABELS_FLAG=()
 [ -n "$LABELS" ] && LABELS_FLAG=(--labels "${LABELS}")
 
@@ -494,6 +494,10 @@ proxy_service:
 db_service:
   enabled: "yes"
   resources:
+EOF
+
+    # Quoting the EOF heredoc indicates to shell to treat this as a literal string and does not try to interpolate or execute anything.
+    cat << "EOF" >> ${TELEPORT_CONFIG_PATH}
     - labels:{{range $index, $line := .db_service_resource_labels}}
         {{$line -}}
 {{end}}


### PR DESCRIPTION
Backport #52350 to v16

changelog: Escape user provided labels when creating the shell script that enrolls servers, applications and databases into Teleport.