### PR TITLE
[v15] Escape labels on Node Join scripts

### DIFF
--- a/lib/web/join_tokens.go
+++ b/lib/web/join_tokens.go
@@ -441,6 +441,10 @@ func getJoinScript(ctx context.Context, settings scriptSettings, m nodeAPIGetter
 
 	labelsList := []string{}
 	for labelKey, labelValues := range token.GetSuggestedLabels() {
+		labelKey = shsprintf.EscapeDefaultContext(labelKey)
+		for i := range labelValues {
+			labelValues[i] = shsprintf.EscapeDefaultContext(labelValues[i])
+		}
 		labels := strings.Join(labelValues, " ")
 		labelsList = append(labelsList, fmt.Sprintf("%s=%s", labelKey, labels))
 	}
@@ -498,7 +502,7 @@ func getJoinScript(ctx context.Context, settings scriptSettings, m nodeAPIGetter
 	// This section relies on Go's default zero values to make sure that the settings
 	// are correct when not installing an app.
 	err = scripts.InstallNodeBashScript.Execute(&buf, map[string]interface{}{
-		"token":    settings.token,
+		"token":    shsprintf.EscapeDefaultContext(settings.token),
 		"hostname": hostname,
 		"port":     portStr,
 		// The install.sh script has some manually generated configs and some

--- a/lib/web/join_tokens_test.go
+++ b/lib/web/join_tokens_test.go
@@ -350,6 +350,7 @@ func toHex(s string) string { return hex.EncodeToString([]byte(s)) }
 
 func TestGetNodeJoinScript(t *testing.T) {
 	validToken := "f18da1c9f6630a51e8daf121e7451daa"
+	validTokenWithLabelsWithSpecialChars := "f18da1c9f6630a51e8daf121e7451dbb"
 	validIAMToken := "valid-iam-token"
 	internalResourceID := "967d38ff-7a61-4f42-bd2d-c61965b44db0"
 
@@ -365,19 +366,25 @@ func TestGetNodeJoinScript(t *testing.T) {
 			return &proto.GetClusterCACertResponse{TLSCA: fakeBytes}, nil
 		},
 		mockGetToken: func(_ context.Context, token string) (types.ProvisionToken, error) {
-			if token == validToken || token == validIAMToken {
-				return &types.ProvisionTokenV2{
-					Metadata: types.Metadata{
-						Name: token,
+			baseToken := &types.ProvisionTokenV2{
+				Metadata: types.Metadata{
+					Name: token,
+				},
+				Spec: types.ProvisionTokenSpecV2{
+					SuggestedLabels: types.Labels{
+						types.InternalResourceIDLabel: utils.Strings{internalResourceID},
 					},
-					Spec: types.ProvisionTokenSpecV2{
-						SuggestedLabels: types.Labels{
-							types.InternalResourceIDLabel: utils.Strings{internalResourceID},
-						},
-					},
-				}, nil
+				},
 			}
-			return nil, trace.NotFound("token does not exist")
+			switch token {
+			case validToken, validIAMToken:
+			case validTokenWithLabelsWithSpecialChars:
+				baseToken.Spec.SuggestedLabels["env"] = []string{"bad label value | ; & $ > < ' !"}
+				baseToken.Spec.SuggestedLabels["bad label key | ; & $ > < ' !"] = []string{"env"}
+			default:
+				return nil, trace.NotFound("token does not exist")
+			}
+			return baseToken, nil
 		},
 	}
 
@@ -385,7 +392,7 @@ func TestGetNodeJoinScript(t *testing.T) {
 		desc            string
 		settings        scriptSettings
 		errAssert       require.ErrorAssertionFunc
-		extraAssertions func(script string)
+		extraAssertions func(t *testing.T, script string)
 	}{
 		{
 			desc:      "zero value",
@@ -406,7 +413,7 @@ func TestGetNodeJoinScript(t *testing.T) {
 			desc:      "valid",
 			settings:  scriptSettings{token: validToken},
 			errAssert: require.NoError,
-			extraAssertions: func(script string) {
+			extraAssertions: func(t *testing.T, script string) {
 				require.Contains(t, script, validToken)
 				require.Contains(t, script, "test-host")
 				require.Contains(t, script, "12345678")
@@ -429,7 +436,7 @@ func TestGetNodeJoinScript(t *testing.T) {
 				joinMethod: string(types.JoinMethodIAM),
 			},
 			errAssert: require.NoError,
-			extraAssertions: func(script string) {
+			extraAssertions: func(t *testing.T, script string) {
 				require.Contains(t, script, "JOIN_METHOD='iam'")
 			},
 		},
@@ -437,9 +444,18 @@ func TestGetNodeJoinScript(t *testing.T) {
 			desc:      "internal resourceid label",
 			settings:  scriptSettings{token: validToken},
 			errAssert: require.NoError,
-			extraAssertions: func(script string) {
+			extraAssertions: func(t *testing.T, script string) {
 				require.Contains(t, script, "--labels ")
 				require.Contains(t, script, fmt.Sprintf("%s=%s", types.InternalResourceIDLabel, internalResourceID))
+			},
+		},
+		{
+			desc:      "attempt to shell injection using suggested labels",
+			settings:  scriptSettings{token: validTokenWithLabelsWithSpecialChars},
+			errAssert: require.NoError,
+			extraAssertions: func(t *testing.T, script string) {
+				require.Contains(t, script, `bad\ label\ key\ \|\ \;\ \&\ \$\ \>\ \<\ \'\ \!=env`)
+				require.Contains(t, script, `env=bad\ label\ value\ \|\ \;\ \&\ \$\ \>\ \<\ \'\ \!`)
 			},
 		},
 	} {
@@ -451,7 +467,7 @@ func TestGetNodeJoinScript(t *testing.T) {
 			}
 
 			if test.extraAssertions != nil {
-				test.extraAssertions(script)
+				test.extraAssertions(t, script)
 			}
 		})
 	}
@@ -646,6 +662,8 @@ func TestGetAppJoinScript(t *testing.T) {
 func TestGetDatabaseJoinScript(t *testing.T) {
 	validToken := "f18da1c9f6630a51e8daf121e7451daa"
 	emptySuggestedAgentMatcherLabelsToken := "f18da1c9f6630a51e8daf121e7451000"
+	wildcardLabelMatcherToken := "f18da1c9f6630a51e8daf121e7451001"
+	tokenWithSpecialChars := "f18da1c9f6630a51e8daf121e7451002"
 	internalResourceID := "967d38ff-7a61-4f42-bd2d-c61965b44db0"
 
 	m := &mockedNodeAPIGetter{
@@ -682,6 +700,22 @@ func TestGetDatabaseJoinScript(t *testing.T) {
 				provisionToken.Spec.SuggestedAgentMatcherLabels = types.Labels{}
 				return provisionToken, nil
 			}
+			if token == wildcardLabelMatcherToken {
+				provisionToken.Spec.SuggestedAgentMatcherLabels = types.Labels{"*": []string{"*"}}
+				return provisionToken, nil
+			}
+			if token == tokenWithSpecialChars {
+				provisionToken.Spec.SuggestedAgentMatcherLabels = types.Labels{
+					"*":                             utils.Strings{"*"},
+					"spa ces":                       utils.Strings{"spa ces"},
+					"EOF":                           utils.Strings{"test heredoc"},
+					`"EOF"`:                         utils.Strings{"test quoted heredoc"},
+					"#'; <>\\#":                     utils.Strings{"try to escape yaml"},
+					"&<>'\"$A,./;'BCD ${ABCD}":      utils.Strings{"key with special characters"},
+					"value with special characters": utils.Strings{"&<>'\"$A,./;'BCD ${ABCD}", "#&<>'\"$A,./;'BCD ${ABCD}"},
+				}
+				return provisionToken, nil
+			}
 			return nil, trace.NotFound("token does not exist")
 		},
 	}
@@ -690,7 +724,7 @@ func TestGetDatabaseJoinScript(t *testing.T) {
 		desc            string
 		settings        scriptSettings
 		errAssert       require.ErrorAssertionFunc
-		extraAssertions func(script string)
+		extraAssertions func(t *testing.T, script string)
 	}{
 		{
 			desc: "two installation methods",
@@ -708,16 +742,13 @@ func TestGetDatabaseJoinScript(t *testing.T) {
 				token:               validToken,
 			},
 			errAssert: require.NoError,
-			extraAssertions: func(script string) {
+			extraAssertions: func(t *testing.T, script string) {
 				require.Contains(t, script, validToken)
 				require.Contains(t, script, "test-host")
 				require.Contains(t, script, "sha256:")
 				require.Contains(t, script, "--labels ")
 				require.Contains(t, script, fmt.Sprintf("%s=%s", types.InternalResourceIDLabel, internalResourceID))
 				require.Contains(t, script, `
-db_service:
-  enabled: "yes"
-  resources:
     - labels:
         env: prod
         os:
@@ -728,22 +759,65 @@ db_service:
 			},
 		},
 		{
+			desc: "discover flow with wildcard label matcher",
+			settings: scriptSettings{
+				databaseInstallMode: true,
+				token:               wildcardLabelMatcherToken,
+			},
+			errAssert: require.NoError,
+			extraAssertions: func(t *testing.T, script string) {
+				require.Contains(t, script, wildcardLabelMatcherToken)
+				require.Contains(t, script, "test-host")
+				require.Contains(t, script, "sha256:")
+				require.Contains(t, script, "--labels ")
+				require.Contains(t, script, fmt.Sprintf("%s=%s", types.InternalResourceIDLabel, internalResourceID))
+				require.Contains(t, script, `
+    - labels:
+        '*': '*'
+`)
+			},
+		},
+		{
+			desc: "discover flow with shell injection attempt in resource matcher labels",
+			settings: scriptSettings{
+				databaseInstallMode: true,
+				token:               tokenWithSpecialChars,
+			},
+			errAssert: require.NoError,
+			extraAssertions: func(t *testing.T, script string) {
+				require.Contains(t, script, tokenWithSpecialChars)
+				require.Contains(t, script, "test-host")
+				require.Contains(t, script, "sha256:")
+				require.Contains(t, script, "--labels ")
+				require.Contains(t, script, fmt.Sprintf("%s=%s", types.InternalResourceIDLabel, internalResourceID))
+				require.Contains(t, script, `
+    - labels:
+        '"EOF"': test quoted heredoc
+        '#''; <>\#': try to escape yaml
+        '&<>''"$A,./;''BCD ${ABCD}': key with special characters
+        '*': '*'
+        EOF: test heredoc
+        spa ces: spa ces
+        value with special characters:
+          - '&<>''"$A,./;''BCD ${ABCD}'
+          - '#&<>''"$A,./;''BCD ${ABCD}'
+`)
+			},
+		},
+		{
 			desc: "empty suggestedAgentMatcherLabels",
 			settings: scriptSettings{
 				databaseInstallMode: true,
 				token:               emptySuggestedAgentMatcherLabelsToken,
 			},
 			errAssert: require.NoError,
-			extraAssertions: func(script string) {
+			extraAssertions: func(t *testing.T, script string) {
 				require.Contains(t, script, emptySuggestedAgentMatcherLabelsToken)
 				require.Contains(t, script, "test-host")
 				require.Contains(t, script, "sha256:")
 				require.Contains(t, script, "--labels ")
 				require.Contains(t, script, fmt.Sprintf("%s=%s", types.InternalResourceIDLabel, internalResourceID))
 				require.Contains(t, script, `
-db_service:
-  enabled: "yes"
-  resources:
     - labels:
         {}
 `)
@@ -758,7 +832,7 @@ db_service:
 			}
 
 			if test.extraAssertions != nil {
-				test.extraAssertions(script)
+				test.extraAssertions(t, script)
 			}
 		})
 	}

--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -47,7 +47,7 @@ JOIN_METHOD_FLAG=""
 [ -n "$JOIN_METHOD" ] && JOIN_METHOD_FLAG="--join-method ${JOIN_METHOD}"
 
 # inject labels into the configuration
-LABELS='{{.labels}}'
+LABELS="{{.labels}}"
 LABELS_FLAG=()
 [ -n "$LABELS" ] && LABELS_FLAG=(--labels "${LABELS}")
 
@@ -494,6 +494,10 @@ proxy_service:
 db_service:
   enabled: "yes"
   resources:
+EOF
+
+    # Quoting the EOF heredoc indicates to shell to treat this as a literal string and does not try to interpolate or execute anything.
+    cat << "EOF" >> ${TELEPORT_CONFIG_PATH}
     - labels:{{range $index, $line := .db_service_resource_labels}}
         {{$line -}}
 {{end}}


### PR DESCRIPTION
Backport #52350 to v15

changelog: Escape user provided labels when creating the shell script that enrolls servers, applications and databases into Teleport.