### PR TITLE
 [v16] Use structured error responses from servicenow and opsgenie (#52434)

### DIFF
--- a/integrations/access/common/response.go
+++ b/integrations/access/common/response.go
@@ -1,0 +1,56 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"net/http"
+
+	"github.com/go-resty/resty/v2"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integrations/lib/logger"
+)
+
+// ErrWrapperFunc are functions used to wrap http errors by plugin clients that return structured error responses.
+type ErrWrapperFunc func(statusCode int, body []byte) error
+
+// OnAfterResponse is a generic resty ResponseMiddleware that wraps errors and updates the status sink for plugins.
+func OnAfterResponse(pluginName string, errWrapper ErrWrapperFunc, sink StatusSink) resty.ResponseMiddleware {
+	return func(_ *resty.Client, resp *resty.Response) error {
+		if sink != nil {
+			var code types.PluginStatusCode
+			switch {
+			case resp.StatusCode() == http.StatusUnauthorized:
+				code = types.PluginStatusCode_UNAUTHORIZED
+			case resp.StatusCode() >= 200 && resp.StatusCode() < 400:
+				code = types.PluginStatusCode_RUNNING
+			default:
+				code = types.PluginStatusCode_OTHER_ERROR
+			}
+			if err := sink.Emit(resp.Request.Context(), &types.PluginStatusV1{Code: code}); err != nil {
+				logger.Get(resp.Request.Context()).WithError(err).
+					WithField("code", resp.StatusCode()).Errorf("Error while emitting servicenow plugin status: %v", err)
+			}
+		}
+		if resp.IsError() {
+			return errWrapper(resp.StatusCode(), resp.Body())
+		}
+		return nil
+	}
+}

--- a/integrations/access/opsgenie/types.go
+++ b/integrations/access/opsgenie/types.go
@@ -102,3 +102,8 @@ type GetAlertRequestResult struct {
 		AlertID string `json:"alertId"`
 	} `json:"data"`
 }
+
+// errorResult represents the error response returned from Opsgenie.
+type errorResult struct {
+	Message string `json:"message"`
+}

--- a/integrations/access/servicenow/client.go
+++ b/integrations/access/servicenow/client.go
@@ -20,6 +20,7 @@ package servicenow
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -33,7 +34,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integrations/access/common"
 	"github.com/gravitational/teleport/integrations/lib"
-	"github.com/gravitational/teleport/integrations/lib/logger"
 )
 
 const (
@@ -95,7 +95,7 @@ type ClientConfig struct {
 	StatusSink common.StatusSink
 }
 
-// NewClient creates a new Servicenow client for managing incidents.
+// NewClient creates a new ServiceNow client for managing incidents.
 func NewClient(conf ClientConfig) (*Client, error) {
 	if err := conf.checkAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
@@ -129,6 +129,7 @@ func NewClient(conf ClientConfig) (*Client, error) {
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBasicAuth(conf.Username, conf.APIToken)
+	client.OnAfterResponse(common.OnAfterResponse(types.PluginTypeServiceNow, errWrapper, conf.StatusSink))
 	return &Client{
 		client:       client,
 		ClientConfig: conf,
@@ -142,14 +143,20 @@ func (conf ClientConfig) checkAndSetDefaults() error {
 	return nil
 }
 
-func errWrapper(statusCode int, body string) error {
+func errWrapper(statusCode int, body []byte) error {
+	defaultMessage := string(body)
+	errResponse := errorResult{}
+	if err := json.Unmarshal(body, &errResponse); err == nil {
+		defaultMessage = errResponse.Error.Message
+	}
+
 	switch statusCode {
 	case http.StatusForbidden:
-		return trace.AccessDenied("servicenow API access denied: status code %v: %q", statusCode, body)
+		return trace.AccessDenied("servicenow API access denied: status code %v: %q", statusCode, defaultMessage)
 	case http.StatusRequestTimeout:
-		return trace.ConnectionProblem(nil, "request to servicenow API failed: status code %v: %q", statusCode, body)
+		return trace.ConnectionProblem(nil, "request to servicenow API failed: status code %v: %q", statusCode, defaultMessage)
 	}
-	return trace.Errorf("request to servicenow API failed: status code %d: %q", statusCode, body)
+	return trace.Errorf("request to servicenow API failed: status code %d: %q", statusCode, defaultMessage)
 }
 
 // CreateIncident creates an servicenow incident.
@@ -180,9 +187,6 @@ func (snc *Client) CreateIncident(ctx context.Context, reqID string, reqData Req
 		return Incident{}, trace.Wrap(err)
 	}
 	defer resp.RawResponse.Body.Close()
-	if resp.IsError() {
-		return Incident{}, errWrapper(resp.StatusCode(), string(resp.Body()))
-	}
 
 	return Incident{IncidentID: result.Result.IncidentID}, nil
 }
@@ -205,9 +209,6 @@ func (snc *Client) PostReviewNote(ctx context.Context, incidentID string, review
 		return trace.Wrap(err)
 	}
 	defer resp.RawResponse.Body.Close()
-	if resp.IsError() {
-		return errWrapper(resp.StatusCode(), string(resp.Body()))
-	}
 	return nil
 }
 
@@ -231,9 +232,6 @@ func (snc *Client) ResolveIncident(ctx context.Context, incidentID string, resol
 		return trace.Wrap(err)
 	}
 	defer resp.RawResponse.Body.Close()
-	if resp.IsError() {
-		return errWrapper(resp.StatusCode(), string(resp.Body()))
-	}
 	return nil
 }
 
@@ -253,9 +251,6 @@ func (snc *Client) GetOnCall(ctx context.Context, rotaID string) ([]string, erro
 		return nil, trace.Wrap(err)
 	}
 	defer resp.RawResponse.Body.Close()
-	if resp.IsError() {
-		return nil, errWrapper(resp.StatusCode(), string(resp.Body()))
-	}
 	if len(result.Result) == 0 {
 		return nil, trace.NotFound("no user found for given rota: %q", rotaID)
 	}
@@ -282,26 +277,6 @@ func (snc *Client) CheckHealth(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 	defer resp.RawResponse.Body.Close()
-
-	if snc.StatusSink != nil {
-		var code types.PluginStatusCode
-		switch {
-		case resp.StatusCode() == http.StatusUnauthorized:
-			code = types.PluginStatusCode_UNAUTHORIZED
-		case resp.StatusCode() >= 200 && resp.StatusCode() < 400:
-			code = types.PluginStatusCode_RUNNING
-		default:
-			code = types.PluginStatusCode_OTHER_ERROR
-		}
-		if err := snc.StatusSink.Emit(ctx, &types.PluginStatusV1{Code: code}); err != nil {
-			log := logger.Get(resp.Request.Context())
-			log.WithError(err).WithField("code", resp.StatusCode()).Errorf("Error while emitting servicenow plugin status: %v", err)
-		}
-	}
-
-	if resp.IsError() {
-		return errWrapper(resp.StatusCode(), string(resp.Body()))
-	}
 	return nil
 }
 
@@ -320,9 +295,6 @@ func (snc *Client) GetUserName(ctx context.Context, userID string) (string, erro
 		return "", trace.Wrap(err)
 	}
 	defer resp.RawResponse.Body.Close()
-	if resp.IsError() {
-		return "", errWrapper(resp.StatusCode(), string(resp.Body()))
-	}
 	if result.Result.UserName == "" {
 		return "", trace.NotFound("no username found for given id: %v", userID)
 	}

--- a/integrations/access/servicenow/types.go
+++ b/integrations/access/servicenow/types.go
@@ -96,6 +96,7 @@ type RequestData struct {
 	SuggestedReviewers []string
 }
 
+// OnCallResult represents the response returned from a whoisoncall request to ServiceNow.
 type OnCallResult struct {
 	Result []struct {
 		// UserID is the ID of the on-call user.
@@ -103,6 +104,7 @@ type OnCallResult struct {
 	} `json:"result"`
 }
 
+// UserResult represents the response returned when retieving a user from ServiceNow.
 type UserResult struct {
 	Result struct {
 		// UserName is the username in servicenow of the requested user.
@@ -111,6 +113,7 @@ type UserResult struct {
 	} `json:"result"`
 }
 
+// IncidentResult represents the response returned when retieving an incident from ServiceNow.
 type IncidentResult struct {
 	Result struct {
 		// IncidentID is the sys_id of the incident
@@ -128,4 +131,11 @@ type IncidentResult struct {
 		// WorkNotes contains comments on the progress of the incident.
 		WorkNotes string `json:"work_notes,omitempty"`
 	} `json:"result"`
+}
+
+// errorResult represents the error response returned from ServiceNow.
+type errorResult struct {
+	Error struct {
+		Message string `json:"message"`
+	} `json:"error"`
 }


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport/issues/33754

Cleans up errors returned by opsgenie and servicenow when possible, and properly update status sink after each response.