### PR TITLE
Helm chart support for sso mfa

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -327,6 +327,37 @@ For example, if users are accessing the cluster with the domain
 Changing the RP ID will invalidate all already registered webauthn second factors.
 </Admonition>
 
+### `authentication.secondFactors`
+
+| Type     | Default value | Required? | `teleport.yaml` equivalent                  |
+|----------|---------------|-----------|---------------------------------------------|
+| `array`  | `[]`          | No        | `auth_service.authentication.second_factors` |
+
+`authentication.secondFactors` configures multi-factor authentication types. Possible values supported by this chart
+are `otp`, `sso`, and `webauthn`.
+
+`authentication.secondFactors` takes precedence over any value that is set in `authentication.secondFactor`.
+If `webauthn` is passed, the `authentication.webauthn` section can also be used.
+The configured `rp_id` defaults to `clusterName`.
+
+<Admonition type="warning">
+If you set `publicAddr` for users to access the cluster under a domain different
+to [`clusterName`](#clusterName), you must manually set the webauthn [Relying
+Party Identifier (RP
+ID)](https://www.w3.org/TR/webauthn-2/#relying-party-identifier). If you don't,
+RP ID will default to `clusterName` and users will fail to register second
+factors.
+
+You can do this by setting the value
+`auth.teleportConfig.auth_service.authentication.webauthn.rp_id`.
+
+RP ID must be both a valid domain, and part of the full domain users are connecting to.
+For example, if users are accessing the cluster with the domain
+"teleport.example.com", RP ID can be "teleport.example.com" or "example.com".
+
+Changing the RP ID will invalidate all already registered webauthn second factors.
+</Admonition>
+
 ### `authentication.webauthn`
 
 See [Harden your Cluster Against IdP Compromises](../../admin-guides/access-controls/guides/webauthn.mdx) for more details.

--- a/examples/chart/CONTRIBUTING.md
+++ b/examples/chart/CONTRIBUTING.md
@@ -34,7 +34,7 @@ case. A good tip is to use your newly added linter file to set values appropriat
 3) Add any new values at the correct location in the `values.schema.json` file for the appropriate chart. This
 will ensure that Helm is able to validate values at install-time and can prevent users from making easy mistakes.
 
-4) Document any new values or changes to existing behaviour in the [chart reference](../../docs/pages/kubernetes-access/helm/reference).
+4) Document any new values or changes to existing behaviour in the [chart reference](../../docs/pages/reference/helm-reference).
 
 5) Run `make lint-helm test-helm` from the root of the repo before raising your PR.
 You will need `yamllint`, `helm` and [helm-unittest](https://github.com/quintush/helm-unittest) installed locally.

--- a/examples/chart/teleport-cluster/.lint/auth-secondfactors-sso.yaml
+++ b/examples/chart/teleport-cluster/.lint/auth-secondfactors-sso.yaml
@@ -1,0 +1,4 @@
+clusterName: helm-lint
+authentication:
+  secondFactors:
+    - sso

--- a/examples/chart/teleport-cluster/.lint/auth-secondfactors-webauthn.yaml
+++ b/examples/chart/teleport-cluster/.lint/auth-secondfactors-webauthn.yaml
@@ -1,0 +1,10 @@
+clusterName: helm-lint
+authentication:
+  secondFactors:
+    - sso
+    - webauthn
+  webauthn:
+    attestationAllowedCas:
+      - "/etc/ssl/certs/ca-certificates.crt"
+    attestationDeniedCas:
+      - "/etc/ssl/certs/ca-certificates.crt"

--- a/examples/chart/teleport-cluster/templates/auth/_config.common.tpl
+++ b/examples/chart/teleport-cluster/templates/auth/_config.common.tpl
@@ -36,19 +36,22 @@ auth_service:
 {{- if $authentication.lockingMode }}
     locking_mode: "{{ $authentication.lockingMode }}"
 {{- end }}
-{{- if $authentication.secondFactor }}
-    second_factor: "{{ $authentication.secondFactor }}"
-  {{- if not (or (eq $authentication.secondFactor "off") (eq $authentication.secondFactor "otp")) }}
+{{- if and (not (eq $authentication.secondFactor "off")) $authentication.secondFactors }}
+  {{- $secondFactors := (concat $authentication.secondFactors (without (list $authentication.secondFactor) "on" "optional")) -}}
+  {{- if $secondFactors }}
+    second_factors: {{- toYaml $secondFactors | nindent 6 }}
+  {{- end }}
+  {{- if has "webauthn" $secondFactors }}
     webauthn:
       rp_id: {{ required "clusterName is required in chart values" .Values.clusterName }}
-    {{- if $authentication.webauthn }}
-      {{- if $authentication.webauthn.attestationAllowedCas }}
+      {{- if $authentication.webauthn }}
+        {{- if $authentication.webauthn.attestationAllowedCas }}
       attestation_allowed_cas: {{- toYaml $authentication.webauthn.attestationAllowedCas | nindent 12 }}
-      {{- end }}
-      {{- if $authentication.webauthn.attestationDeniedCas }}
+        {{- end }}
+        {{- if $authentication.webauthn.attestationDeniedCas }}
       attestation_denied_cas: {{- toYaml $authentication.webauthn.attestationDeniedCas | nindent 12 }}
+        {{- end }}
       {{- end }}
-    {{- end }}
   {{- end }}
 {{- end }}
 {{- if .Values.sessionRecording }}

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
@@ -377,6 +377,81 @@ matches snapshot for auth-passwordless.yaml:
           output: stderr
           severity: INFO
       version: v3
+matches snapshot for auth-secondfactors-sso.yaml:
+  1: |
+    |-
+      auth_service:
+        authentication:
+          local_auth: true
+          second_factors:
+          - sso
+          type: local
+        cluster_name: helm-lint
+        enabled: true
+        proxy_listener_mode: separate
+      kubernetes_service:
+        enabled: true
+        kube_cluster_name: helm-lint
+        listen_addr: 0.0.0.0:3026
+        public_addr: RELEASE-NAME-auth.NAMESPACE.svc.cluster.local:3026
+      proxy_service:
+        enabled: false
+      ssh_service:
+        enabled: false
+      teleport:
+        auth_server: 127.0.0.1:3025
+        log:
+          format:
+            extra_fields:
+            - timestamp
+            - level
+            - component
+            - caller
+            output: text
+          output: stderr
+          severity: INFO
+      version: v3
+matches snapshot for auth-secondfactors-webauthn.yaml:
+  1: |
+    |-
+      auth_service:
+        authentication:
+          local_auth: true
+          second_factors:
+          - sso
+          - webauthn
+          type: local
+          webauthn:
+            attestation_allowed_cas:
+            - /etc/ssl/certs/ca-certificates.crt
+            attestation_denied_cas:
+            - /etc/ssl/certs/ca-certificates.crt
+            rp_id: helm-lint
+        cluster_name: helm-lint
+        enabled: true
+        proxy_listener_mode: separate
+      kubernetes_service:
+        enabled: true
+        kube_cluster_name: helm-lint
+        listen_addr: 0.0.0.0:3026
+        public_addr: RELEASE-NAME-auth.NAMESPACE.svc.cluster.local:3026
+      proxy_service:
+        enabled: false
+      ssh_service:
+        enabled: false
+      teleport:
+        auth_server: 127.0.0.1:3025
+        log:
+          format:
+            extra_fields:
+            - timestamp
+            - level
+            - component
+            - caller
+            output: text
+          output: stderr
+          severity: INFO
+      version: v3
 matches snapshot for auth-type-legacy.yaml:
   1: |
     |-

--- a/examples/chart/teleport-cluster/tests/auth_config_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_config_test.yaml
@@ -698,3 +698,25 @@ tests:
       - matchRegex:
           path: data.teleport\.yaml
           pattern: 'svc.test.com:3026'
+
+  - it: matches snapshot for auth-secondfactors-webauthn.yaml
+    values:
+      - ../.lint/auth-secondfactors-webauthn.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data.teleport\.yaml
+
+  - it: matches snapshot for auth-secondfactors-sso.yaml
+    values:
+      - ../.lint/auth-secondfactors-sso.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data.teleport\.yaml

--- a/examples/chart/teleport-cluster/values.schema.json
+++ b/examples/chart/teleport-cluster/values.schema.json
@@ -126,6 +126,19 @@
                     ],
                     "default": "otp"
                 },
+                "secondFactors": {
+                    "$id": "#/properties/authentication/properties/secondFactors",
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "otp",
+                            "sso",
+                            "webauthn"
+                        ]
+                    },
+                    "default": []
+                },
                 "webauthn": {
                     "$id": "#/properties/authentication/properties/webauthn",
                     "type": "object",

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -150,6 +150,27 @@ authentication:
   #   Changing the RP ID will invalidate all already registered webauthn second factors.
   secondFactor: "on"
 
+  # Second factor requirements for users of the Teleport cluster.
+  # Controls the `auth_config.authentication.second_factors` field in `teleport.yaml`.
+  # Possible values are 'otp', 'sso' and 'webauthn'.
+  #
+  # WARNING:
+  #   If you set `publicAddr` for users to access the cluster under a domain different
+  #   to clusterName you must manually set the webauthn Relying
+  #   Party Identifier (RP ID) - https://www.w3.org/TR/webauthn-2/#relying-party-identifier
+  #   If you don't, RP ID will default to `clusterName` and users will fail
+  #   to register second factors.
+  #
+  #   You can do this by setting the value
+  #   `auth.teleportConfig.auth_service.authentication.webauthn.rp_id`.
+  #
+  #   RP ID must be both a valid domain, and part of the full domain users are connecting to.
+  #   For example, if users are accessing the cluster with the domain
+  #   "teleport.example.com", RP ID can be "teleport.example.com" or "example.com".
+  #
+  #   Changing the RP ID will invalidate all already registered webauthn second factors.
+  secondFactors: []
+
   # (Optional) When using webauthn this allows to restrict which vendor and key models can be used.
   # webauthn:
   #   attestationAllowedCas:


### PR DESCRIPTION
Add Helm chart support for setting up SSO MFA. 
As such, this PR also adds support to the preferred `authentication.second_factors` configuration property (as per the [configuration reference](https://goteleport.com/docs/reference/config/) and [proto](https://github.com/gravitational/teleport/blob/468663ed916aafc9b5260245f57d1ed72c0342a0/api/proto/teleport/legacy/types/types.proto#L2160-L2161) mention).

Note: the template logic keeps backward compatibility - if `authentication.secondFactors` is left empty nothing changes, hence its default value of `[]` instead of `["otp"]`.

Closes https://github.com/gravitational/teleport/issues/52711

changelog: helm chart support for SSO MFA

