### PR TITLE
Support wrapping in StepSlider

### DIFF
--- a/web/packages/design/src/StepSlider/StepSlider.story.tsx
+++ b/web/packages/design/src/StepSlider/StepSlider.story.tsx
@@ -30,6 +30,8 @@ export default {
 const singleFlow = { default: [Body1, Body2] };
 export const SingleFlowInPlaceSlider = (props: {
   defaultStepIndex?: number;
+  wrapping?: boolean;
+  tDuration?: number;
 }) => {
   return (
     <Card my="5" mx="auto" width={464}>
@@ -41,6 +43,8 @@ export const SingleFlowInPlaceSlider = (props: {
         currFlow={'default'}
         testProp="I'm that test prop"
         defaultStepIndex={props.defaultStepIndex}
+        wrapping={props.wrapping}
+        tDuration={props.tDuration}
       />
     </Card>
   );
@@ -48,6 +52,10 @@ export const SingleFlowInPlaceSlider = (props: {
 
 export const SingleFlowWithDefaultStepIndex = () => {
   return <SingleFlowInPlaceSlider defaultStepIndex={1} />;
+};
+
+export const SingleFlowWithWrapping = () => {
+  return <SingleFlowInPlaceSlider wrapping />;
 };
 
 type MultiFlow = 'primary' | 'secondary';
@@ -58,7 +66,10 @@ const multiflows = {
   primary: [MainStep1, MainStep2, FinalStep],
   secondary: [OtherStep1, FinalStep],
 };
-export const MultiFlowWheelSlider = (props: { defaultStepIndex?: number }) => {
+export const MultiFlowWheelSlider = (props: {
+  defaultStepIndex?: number;
+  tDuration?: number;
+}) => {
   const [flow, setFlow] = useState<MultiFlow>('primary');
   const [newFlow, setNewFlow] = useState<NewFlow<MultiFlow>>();
 
@@ -78,6 +89,7 @@ export const MultiFlowWheelSlider = (props: { defaultStepIndex?: number }) => {
       newFlow={newFlow}
       changeFlow={onNewFlow}
       defaultStepIndex={props.defaultStepIndex}
+      tDuration={props.tDuration}
     />
   );
 };

--- a/web/packages/design/src/StepSlider/StepSlider.story.tsx
+++ b/web/packages/design/src/StepSlider/StepSlider.story.tsx
@@ -27,7 +27,7 @@ export default {
   title: 'Design/StepSlider',
 };
 
-const singleFlow = { default: [Body1, Body2] };
+const singleFlow = { default: [Body1, Body2, Body3] };
 export const SingleFlowInPlaceSlider = (props: {
   defaultStepIndex?: number;
   wrapping?: boolean;
@@ -318,19 +318,63 @@ function Body2({
         size="large"
         onClick={e => {
           e.preventDefault();
-          onPrev();
+          onNext();
         }}
       >
-        Back2
+        Next2
       </ButtonPrimary>
       <Box mt={5}>
         <ButtonLink
           onClick={e => {
             e.preventDefault();
-            onNext();
+            onPrev();
           }}
         >
-          Next2
+          Back2
+        </ButtonLink>
+      </Box>
+    </Box>
+  );
+}
+
+function Body3({
+  prev: onPrev,
+  next: onNext,
+  refCallback,
+  testProp,
+}: StepComponentProps & { testProp: string }) {
+  return (
+    <Box p={6} ref={refCallback} data-testid="single-body3">
+      <H2 mb={3}>Step 3</H2>
+      <Text mb={3}>
+        Aenean et fringilla orci. Suspendisse ipsum arcu, molestie in quam eu,
+        euismod euismod nibh. Cras scelerisque vulputate mattis. Mauris eget
+        elit imperdiet diam volutpat egestas id non odio. Morbi sit amet
+        malesuada justo.
+      </Text>
+      <Text mb={3}>
+        Proin ipsum orci, imperdiet ac iaculis eget, mattis eu dolor. Maecenas
+        porta porta dolor ac vestibulum.
+      </Text>
+      <Text mb={6}>{testProp}</Text>
+      <ButtonPrimary
+        width="100%"
+        size="large"
+        onClick={e => {
+          e.preventDefault();
+          onNext();
+        }}
+      >
+        Next3
+      </ButtonPrimary>
+      <Box mt={5}>
+        <ButtonLink
+          onClick={e => {
+            e.preventDefault();
+            onPrev();
+          }}
+        >
+          Back3
         </ButtonLink>
       </Box>
     </Box>

--- a/web/packages/design/src/StepSlider/StepSlider.test.tsx
+++ b/web/packages/design/src/StepSlider/StepSlider.test.tsx
@@ -66,13 +66,13 @@ test('single flow with wrapping', async () => {
 
   // Test going backwards on step 1
   fireEvent.click(screen.getByText(/back1/i));
-  expect(screen.getByText('Step 2')).toBeVisible();
+  expect(screen.getByText('Step 3')).toBeVisible();
   await waitForElementToBeRemoved(() => screen.queryByText('Step 1'));
 
-  // Test going forwards on step 2
-  fireEvent.click(screen.getByText(/next2/i));
+  // Test going forwards on step 3
+  fireEvent.click(screen.getByText(/next3/i));
   expect(screen.getByText('Step 1')).toBeVisible();
-  await waitForElementToBeRemoved(() => screen.queryByText('Step 2'));
+  await waitForElementToBeRemoved(() => screen.queryByText('Step 3'));
 
   // Test the "normal" flow: forwards on step 1...
   fireEvent.click(screen.getByText(/next1/i));

--- a/web/packages/design/src/StepSlider/StepSlider.test.tsx
+++ b/web/packages/design/src/StepSlider/StepSlider.test.tsx
@@ -16,15 +16,21 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { fireEvent, render, screen } from 'design/utils/testing';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from 'design/utils/testing';
 
 import {
   MultiFlowWheelSlider,
   SingleFlowInPlaceSlider,
 } from './StepSlider.story';
 
-test('single flow', () => {
-  render(<SingleFlowInPlaceSlider />);
+test('single flow', async () => {
+  // Use custom animation duration to make tests faster.
+  render(<SingleFlowInPlaceSlider tDuration={0} />);
 
   // Test initial render.
   expect(screen.getByText('Step 1')).toBeVisible();
@@ -33,23 +39,55 @@ test('single flow', () => {
   // Should do nothing as expected.
   fireEvent.click(screen.getByText(/back1/i));
   expect(screen.getByText('Step 1')).toBeVisible();
+  // The above is not enough; make sure we didn't start transitioning.
+  expect(screen.queryByText('Step 2')).not.toBeInTheDocument();
 
   // Test next.
   fireEvent.click(screen.getByText(/next1/i));
   expect(screen.getByText('Step 2')).toBeVisible();
+  await waitForElementToBeRemoved(() => screen.queryByText('Step 1'));
 
   // Test going next when at the end of array.
   // Should do nothing.
   fireEvent.click(screen.getByText(/next2/i));
   expect(screen.getByText('Step 2')).toBeVisible();
+  // The above is not enough; make sure we didn't start transitioning.
+  expect(screen.queryByText('Step 1')).not.toBeInTheDocument();
 
   // Test going back.
   fireEvent.click(screen.getByText(/back2/i));
   expect(screen.getByText('Step 1')).toBeVisible();
 });
 
-test('switching between multi flow', () => {
-  render(<MultiFlowWheelSlider />);
+test('single flow with wrapping', async () => {
+  // Use custom animation duration to make tests faster.
+  render(<SingleFlowInPlaceSlider wrapping tDuration={0} />);
+  expect(screen.getByText('Step 1')).toBeVisible();
+
+  // Test going backwards on step 1
+  fireEvent.click(screen.getByText(/back1/i));
+  expect(screen.getByText('Step 2')).toBeVisible();
+  await waitForElementToBeRemoved(() => screen.queryByText('Step 1'));
+
+  // Test going forwards on step 2
+  fireEvent.click(screen.getByText(/next2/i));
+  expect(screen.getByText('Step 1')).toBeVisible();
+  await waitForElementToBeRemoved(() => screen.queryByText('Step 2'));
+
+  // Test the "normal" flow: forwards on step 1...
+  fireEvent.click(screen.getByText(/next1/i));
+  expect(screen.getByText('Step 2')).toBeVisible();
+  await waitForElementToBeRemoved(() => screen.queryByText('Step 1'));
+
+  // ...and backwards on step 2.
+  fireEvent.click(screen.getByText(/back2/i));
+  expect(screen.getByText('Step 1')).toBeVisible();
+  await waitForElementToBeRemoved(() => screen.queryByText('Step 2'));
+});
+
+test('switching between multi flow', async () => {
+  // Use custom animation duration to make tests faster.
+  render(<MultiFlowWheelSlider tDuration={0} />);
 
   // Test initial primary flow.
   expect(screen.getByTestId('multi-primary1')).toBeVisible();
@@ -57,19 +95,21 @@ test('switching between multi flow', () => {
   // Test switching to secondary flow.
   fireEvent.click(screen.getByText(/secondary flow/i));
   expect(screen.getByTestId('multi-secondary1')).toBeVisible();
+  await waitForElementToBeRemoved(() => screen.queryByTestId('multi-primary1'));
 
   // Test switching back to primary flow.
   fireEvent.click(screen.getByText(/primary flow/i));
   expect(screen.getByTestId('multi-primary1')).toBeVisible();
 });
 
-test('setting default step index', () => {
-  render(<SingleFlowInPlaceSlider defaultStepIndex={1} />);
+test('setting default step index', async () => {
+  render(<SingleFlowInPlaceSlider defaultStepIndex={1} tDuration={0} />);
 
   expect(screen.getByText('Step 2')).toBeVisible();
 
   fireEvent.click(screen.getByText(/back2/i));
   expect(screen.getByText('Step 1')).toBeVisible();
+  await waitForElementToBeRemoved(() => screen.queryByText('Step 2'));
 
   fireEvent.click(screen.getByText(/next1/i));
   expect(screen.getByText('Step 2')).toBeVisible();

--- a/web/packages/design/src/StepSlider/StepSlider.tsx
+++ b/web/packages/design/src/StepSlider/StepSlider.tsx
@@ -60,6 +60,7 @@ export function StepSlider<Flows>(props: Props<Flows>) {
     newFlow,
     defaultStepIndex = 0,
     tDuration = 500,
+    wrapping = false,
     // extraProps are the props required by our step components defined in our flows.
     ...extraProps
   } = props;
@@ -164,7 +165,12 @@ export function StepSlider<Flows>(props: Props<Flows>) {
         key={step}
         refCallback={refCallbackFn}
         next={() => {
-          preMountState.current.step = step + 1;
+          const flow = preMountState.current.flow ?? currFlow;
+          if (wrapping && step === flows[flow].length - 1) {
+            preMountState.current.step = 0;
+          } else {
+            preMountState.current.step = step + 1;
+          }
           setPreMount(true);
           startTransitionInDirection('next');
           if (rootRef.current) {
@@ -172,7 +178,12 @@ export function StepSlider<Flows>(props: Props<Flows>) {
           }
         }}
         prev={() => {
-          preMountState.current.step = step - 1;
+          if (wrapping && step === 0) {
+            const flow = preMountState.current.flow ?? currFlow;
+            preMountState.current.step = flows[flow].length - 1;
+          } else {
+            preMountState.current.step = step - 1;
+          }
           setPreMount(true);
           startTransitionInDirection('prev');
           if (rootRef.current) {
@@ -404,6 +415,11 @@ type Props<Flows> =
          * switching flows – this will result in the current step index being reset to 0.
          */
         defaultStepIndex?: number;
+        /**
+         * If set to `true`, allows going forwards the last slide to the first
+         * one and backwards from the first one to the last one.
+         */
+        wrapping?: boolean;
       } & ExtraProps // Extra props that are passed to each step component. Each step of each flow needs to accept the same set of extra props.
     : any;
 


### PR DESCRIPTION
This is required by the upcoming change to the Teleport Identity Security promo in the role editor.

![step-slider-wrapping](https://github.com/user-attachments/assets/54d7d4f0-35c6-48b2-92dc-ef8e4a397a1d)

Tested:
- on Storybook
- with existing (non-wrapping) instances on the login and account settings pages
- with the upcoming role editor change

Followed up by https://github.com/gravitational/teleport/pull/52744
Contributes to https://github.com/gravitational/teleport/issues/52036