### PR TITLE
Add autoupdate events to web UI

### DIFF
--- a/web/packages/teleport/src/Audit/EventList/EventTypeCell.tsx
+++ b/web/packages/teleport/src/Audit/EventList/EventTypeCell.tsx
@@ -296,6 +296,12 @@ const EventIconMap: Record<EventCode, any> = {
   [eventCodes.STABLE_UNIX_USER_CREATE]: Icons.Info,
   [eventCodes.AWS_IC_RESOURCE_SYNC_SUCCESS]: Icons.AmazonAws,
   [eventCodes.AWS_IC_RESOURCE_SYNC_FAILURE]: Icons.Warning,
+  [eventCodes.AUTOUPDATE_CONFIG_CREATE]: Icons.Info,
+  [eventCodes.AUTOUPDATE_CONFIG_UPDATE]: Icons.Info,
+  [eventCodes.AUTOUPDATE_CONFIG_DELETE]: Icons.Info,
+  [eventCodes.AUTOUPDATE_VERSION_CREATE]: Icons.Info,
+  [eventCodes.AUTOUPDATE_VERSION_UPDATE]: Icons.Info,
+  [eventCodes.AUTOUPDATE_VERSION_DELETE]: Icons.Info,
 };
 
 export default function renderTypeCell(event: Event) {

--- a/web/packages/teleport/src/Audit/fixtures/index.ts
+++ b/web/packages/teleport/src/Audit/fixtures/index.ts
@@ -3788,6 +3788,96 @@ export const events = [
     total_permission_sets: 3,
     total_user_groups: 5,
   },
+  {
+    'addr.remote': '127.0.0.1:41608',
+    cluster_name: 'autest.cloud.gravitational.io',
+    code: 'AUV001I',
+    ei: 0,
+    event: 'auto_update_version.create',
+    expires: '0001-01-01T00:00:00Z',
+    name: 'autoupdate-version',
+    success: true,
+    time: '2025-03-04T15:41:24.433Z',
+    uid: '3d677d2f-91d0-4b5a-966d-183a59cec888',
+    updated_by: 'b6eae9ed-bfde-40ba-a880-948a2c598b2b.autest.cloud.gravitational.io',
+    user: 'b6eae9ed-bfde-40ba-a880-948a2c598b2b.autest.cloud.gravitational.io',
+    user_kind: 1
+  },
+  {
+    'addr.remote': '127.0.0.1:42540',
+    cluster_name: 'autest.cloud.gravitational.io',
+    code: 'AUV002I',
+    ei: 0,
+    event: 'auto_update_version.update',
+    expires: '0001-01-01T00:00:00Z',
+    name: 'autoupdate-version',
+    success: true,
+    time: '2025-03-04T15:27:36.039Z',
+    uid: 'b7f9dde2-2899-46f1-bd4e-699d7b630e33',
+    updated_by: 'b6eae9ed-bfde-40ba-a880-948a2c598b2b.autest.cloud.gravitational.io',
+    user: 'b6eae9ed-bfde-40ba-a880-948a2c598b2b.autest.cloud.gravitational.io',
+    user_kind: 1
+  },
+  {
+    'addr.remote': "127.0.0.1:50316",
+    cluster_name: 'autest.cloud.gravitational.io',
+    code: 'AUV003I',
+    ei: 0,
+    event: 'auto_update_version.delete',
+    expires: '0001-01-01T00:00:00Z',
+    name: 'autoupdate-version',
+    success: true,
+    time: '2025-03-04T15:25:44.805Z',
+    uid: 'c4d0d165-3a17-46ac-baa7-c7f521629997',
+    updated_by: 'b6eae9ed-bfde-40ba-a880-948a2c598b2b.autest.cloud.gravitational.io',
+    user: 'b6eae9ed-bfde-40ba-a880-948a2c598b2b.autest.cloud.gravitational.io',
+    user_kind: 1
+  },
+  {
+    'addr.remote': '127.0.0.1:46790',
+    cluster_name: 'autest.cloud.gravitational.io',
+    code: 'AUC001I',
+    ei: 0,
+    event: 'auto_update_config.create',
+    expires: '0001-01-01T00:00:00Z',
+    name: 'autoupdate-config',
+    success: true,
+    time: '2025-03-04T15:49:31.946Z',
+    uid: '6fcbf7ed-b44c-4b83-bb70-02a574564e0b',
+    updated_by: 'b6eae9ed-bfde-40ba-a880-948a2c598b2b.autest.cloud.gravitational.io',
+    user: 'b6eae9ed-bfde-40ba-a880-948a2c598b2b.autest.cloud.gravitational.io',
+    user_kind: 1
+  },
+  {
+    'addr.remote': '127.0.0.1:46798',
+    cluster_name: 'autest.cloud.gravitational.io',
+    code: 'AUC002I',
+    ei: 0,
+    event: 'auto_update_config.update',
+    expires: '0001-01-01T00:00:00Z',
+    name: 'autoupdate-config',
+    success: true,
+    time: '2025-03-04T15:49:37.633Z',
+    uid: '94c580a9-6f87-4a23-9fe5-f93de4390cff',
+    updated_by: 'b6eae9ed-bfde-40ba-a880-948a2c598b2b.autest.cloud.gravitational.io',
+    user: 'b6eae9ed-bfde-40ba-a880-948a2c598b2b.autest.cloud.gravitational.io',
+    user_kind: 1
+  },
+  {
+    'addr.remote': '127.0.0.1:39518',
+    cluster_name: 'autest.cloud.gravitational.io',
+    code: 'AUC003I',
+    ei: 0,
+    event: 'auto_update_config.delete',
+    expires: '0001-01-01T00:00:00Z',
+    name: 'autoupdate-config',
+    success: true,
+    time: '2025-03-04T15:49:21.869Z',
+    uid: 'af17ab4a-d5a2-44a3-93ce-89390b50d52f',
+    updated_by: 'b6eae9ed-bfde-40ba-a880-948a2c598b2b.autest.cloud.gravitational.io',
+    user: 'b6eae9ed-bfde-40ba-a880-948a2c598b2b.autest.cloud.gravitational.io',
+    user_kind: 1
+  }
 ].map(makeEvent);
 
 // Do not add new events to this array, add it to `events` list.
@@ -3884,6 +3974,5 @@ export const eventsSample = [
     uid: '0cb8a020-46ee-4938-833a-69bc03a7a831',
     user: 'moe',
   },
-
   // Do not add new events to this array, add it to `events` list.
 ].map(makeEvent);

--- a/web/packages/teleport/src/Audit/fixtures/index.ts
+++ b/web/packages/teleport/src/Audit/fixtures/index.ts
@@ -3799,9 +3799,10 @@ export const events = [
     success: true,
     time: '2025-03-04T15:41:24.433Z',
     uid: '3d677d2f-91d0-4b5a-966d-183a59cec888',
-    updated_by: 'b6eae9ed-bfde-40ba-a880-948a2c598b2b.autest.cloud.gravitational.io',
+    updated_by:
+      'b6eae9ed-bfde-40ba-a880-948a2c598b2b.autest.cloud.gravitational.io',
     user: 'b6eae9ed-bfde-40ba-a880-948a2c598b2b.autest.cloud.gravitational.io',
-    user_kind: 1
+    user_kind: 1,
   },
   {
     'addr.remote': '127.0.0.1:42540',
@@ -3814,12 +3815,13 @@ export const events = [
     success: true,
     time: '2025-03-04T15:27:36.039Z',
     uid: 'b7f9dde2-2899-46f1-bd4e-699d7b630e33',
-    updated_by: 'b6eae9ed-bfde-40ba-a880-948a2c598b2b.autest.cloud.gravitational.io',
+    updated_by:
+      'b6eae9ed-bfde-40ba-a880-948a2c598b2b.autest.cloud.gravitational.io',
     user: 'b6eae9ed-bfde-40ba-a880-948a2c598b2b.autest.cloud.gravitational.io',
-    user_kind: 1
+    user_kind: 1,
   },
   {
-    'addr.remote': "127.0.0.1:50316",
+    'addr.remote': '127.0.0.1:50316',
     cluster_name: 'autest.cloud.gravitational.io',
     code: 'AUV003I',
     ei: 0,
@@ -3829,9 +3831,10 @@ export const events = [
     success: true,
     time: '2025-03-04T15:25:44.805Z',
     uid: 'c4d0d165-3a17-46ac-baa7-c7f521629997',
-    updated_by: 'b6eae9ed-bfde-40ba-a880-948a2c598b2b.autest.cloud.gravitational.io',
+    updated_by:
+      'b6eae9ed-bfde-40ba-a880-948a2c598b2b.autest.cloud.gravitational.io',
     user: 'b6eae9ed-bfde-40ba-a880-948a2c598b2b.autest.cloud.gravitational.io',
-    user_kind: 1
+    user_kind: 1,
   },
   {
     'addr.remote': '127.0.0.1:46790',
@@ -3844,9 +3847,10 @@ export const events = [
     success: true,
     time: '2025-03-04T15:49:31.946Z',
     uid: '6fcbf7ed-b44c-4b83-bb70-02a574564e0b',
-    updated_by: 'b6eae9ed-bfde-40ba-a880-948a2c598b2b.autest.cloud.gravitational.io',
+    updated_by:
+      'b6eae9ed-bfde-40ba-a880-948a2c598b2b.autest.cloud.gravitational.io',
     user: 'b6eae9ed-bfde-40ba-a880-948a2c598b2b.autest.cloud.gravitational.io',
-    user_kind: 1
+    user_kind: 1,
   },
   {
     'addr.remote': '127.0.0.1:46798',
@@ -3859,9 +3863,10 @@ export const events = [
     success: true,
     time: '2025-03-04T15:49:37.633Z',
     uid: '94c580a9-6f87-4a23-9fe5-f93de4390cff',
-    updated_by: 'b6eae9ed-bfde-40ba-a880-948a2c598b2b.autest.cloud.gravitational.io',
+    updated_by:
+      'b6eae9ed-bfde-40ba-a880-948a2c598b2b.autest.cloud.gravitational.io',
     user: 'b6eae9ed-bfde-40ba-a880-948a2c598b2b.autest.cloud.gravitational.io',
-    user_kind: 1
+    user_kind: 1,
   },
   {
     'addr.remote': '127.0.0.1:39518',
@@ -3874,10 +3879,11 @@ export const events = [
     success: true,
     time: '2025-03-04T15:49:21.869Z',
     uid: 'af17ab4a-d5a2-44a3-93ce-89390b50d52f',
-    updated_by: 'b6eae9ed-bfde-40ba-a880-948a2c598b2b.autest.cloud.gravitational.io',
+    updated_by:
+      'b6eae9ed-bfde-40ba-a880-948a2c598b2b.autest.cloud.gravitational.io',
     user: 'b6eae9ed-bfde-40ba-a880-948a2c598b2b.autest.cloud.gravitational.io',
-    user_kind: 1
-  }
+    user_kind: 1,
+  },
 ].map(makeEvent);
 
 // Do not add new events to this array, add it to `events` list.

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -2052,6 +2052,48 @@ export const formatters: Formatters = {
       return message;
     },
   },
+  [eventCodes.AUTOUPDATE_CONFIG_CREATE]: {
+    type: 'auto_update_config.create',
+    desc: 'Automatic Update Config Created',
+    format: ({user}) => {
+      return `User ${user} created the Automatic Update Config`;
+    },
+  },
+  [eventCodes.AUTOUPDATE_CONFIG_UPDATE]: {
+    type: 'auto_update_config.update',
+    desc: 'Automatic Update Config Updated',
+    format: ({user}) => {
+      return `User ${user} updated the Automatic Update Config`;
+    },
+  },
+  [eventCodes.AUTOUPDATE_CONFIG_DELETE]: {
+    type: 'auto_update_config.delete',
+    desc: 'Automatic Update Config Deleted',
+    format: ({user}) => {
+      return `User ${user} deleted the Automatic Update Config`;
+    },
+  },
+  [eventCodes.AUTOUPDATE_VERSION_CREATE]: {
+    type: 'auto_update_version.create',
+    desc: 'Automatic Update Version Created',
+    format: ({user}) => {
+      return `User ${user} created the Automatic Update Version`;
+    },
+  },
+  [eventCodes.AUTOUPDATE_VERSION_UPDATE]: {
+    type: 'auto_update_version.update',
+    desc: 'Automatic Update Version Updated',
+    format: ({user}) => {
+      return `User ${user} updated the Automatic Update Version`;
+    },
+  },
+  [eventCodes.AUTOUPDATE_VERSION_DELETE]: {
+    type: 'auto_update_version.delete',
+    desc: 'Automatic Update Version Deleted',
+    format: ({user}) => {
+      return `User ${user} deleted the Automatic Update Version`;
+    },
+  },
 };
 
 const unknownFormatter = {

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -2055,42 +2055,42 @@ export const formatters: Formatters = {
   [eventCodes.AUTOUPDATE_CONFIG_CREATE]: {
     type: 'auto_update_config.create',
     desc: 'Automatic Update Config Created',
-    format: ({user}) => {
+    format: ({ user }) => {
       return `User ${user} created the Automatic Update Config`;
     },
   },
   [eventCodes.AUTOUPDATE_CONFIG_UPDATE]: {
     type: 'auto_update_config.update',
     desc: 'Automatic Update Config Updated',
-    format: ({user}) => {
+    format: ({ user }) => {
       return `User ${user} updated the Automatic Update Config`;
     },
   },
   [eventCodes.AUTOUPDATE_CONFIG_DELETE]: {
     type: 'auto_update_config.delete',
     desc: 'Automatic Update Config Deleted',
-    format: ({user}) => {
+    format: ({ user }) => {
       return `User ${user} deleted the Automatic Update Config`;
     },
   },
   [eventCodes.AUTOUPDATE_VERSION_CREATE]: {
     type: 'auto_update_version.create',
     desc: 'Automatic Update Version Created',
-    format: ({user}) => {
+    format: ({ user }) => {
       return `User ${user} created the Automatic Update Version`;
     },
   },
   [eventCodes.AUTOUPDATE_VERSION_UPDATE]: {
     type: 'auto_update_version.update',
     desc: 'Automatic Update Version Updated',
-    format: ({user}) => {
+    format: ({ user }) => {
       return `User ${user} updated the Automatic Update Version`;
     },
   },
   [eventCodes.AUTOUPDATE_VERSION_DELETE]: {
     type: 'auto_update_version.delete',
     desc: 'Automatic Update Version Deleted',
-    format: ({user}) => {
+    format: ({ user }) => {
       return `User ${user} deleted the Automatic Update Version`;
     },
   },

--- a/web/packages/teleport/src/services/audit/types.ts
+++ b/web/packages/teleport/src/services/audit/types.ts
@@ -315,6 +315,12 @@ export const eventCodes = {
   STABLE_UNIX_USER_CREATE: 'TSUU001I',
   AWS_IC_RESOURCE_SYNC_SUCCESS: 'TAIC001I',
   AWS_IC_RESOURCE_SYNC_FAILURE: 'TAIC001E',
+  AUTOUPDATE_CONFIG_CREATE: 'AUC001I',
+  AUTOUPDATE_CONFIG_UPDATE: 'AUC002I',
+  AUTOUPDATE_CONFIG_DELETE: 'AUC003I',
+  AUTOUPDATE_VERSION_CREATE: 'AUV001I',
+  AUTOUPDATE_VERSION_UPDATE: 'AUV002I',
+  AUTOUPDATE_VERSION_DELETE: 'AUV003I',
 } as const;
 
 /**
@@ -1802,6 +1808,42 @@ export type RawEvents = {
   >;
   [eventCodes.AWS_IC_RESOURCE_SYNC_FAILURE]: RawEventAwsIcResourceSync<
     typeof eventCodes.AWS_IC_RESOURCE_SYNC_FAILURE
+  >;
+  [eventCodes.AUTOUPDATE_CONFIG_CREATE]: RawEvent<
+      typeof eventCodes.AUTOUPDATE_CONFIG_CREATE,
+      {
+        user: string;
+      }
+  >;
+  [eventCodes.AUTOUPDATE_CONFIG_UPDATE]: RawEvent<
+      typeof eventCodes.AUTOUPDATE_CONFIG_UPDATE,
+      {
+        user: string;
+      }
+  >;
+  [eventCodes.AUTOUPDATE_CONFIG_DELETE]: RawEvent<
+      typeof eventCodes.AUTOUPDATE_CONFIG_DELETE,
+      {
+        user: string;
+      }
+  >;
+  [eventCodes.AUTOUPDATE_VERSION_CREATE]: RawEvent<
+      typeof eventCodes.AUTOUPDATE_VERSION_CREATE,
+      {
+        user: string;
+      }
+  >;
+  [eventCodes.AUTOUPDATE_VERSION_UPDATE]: RawEvent<
+      typeof eventCodes.AUTOUPDATE_VERSION_UPDATE,
+      {
+        user: string;
+      }
+  >;
+  [eventCodes.AUTOUPDATE_VERSION_DELETE]: RawEvent<
+      typeof eventCodes.AUTOUPDATE_VERSION_DELETE,
+      {
+        user: string;
+      }
   >;
 };
 

--- a/web/packages/teleport/src/services/audit/types.ts
+++ b/web/packages/teleport/src/services/audit/types.ts
@@ -1810,40 +1810,40 @@ export type RawEvents = {
     typeof eventCodes.AWS_IC_RESOURCE_SYNC_FAILURE
   >;
   [eventCodes.AUTOUPDATE_CONFIG_CREATE]: RawEvent<
-      typeof eventCodes.AUTOUPDATE_CONFIG_CREATE,
-      {
-        user: string;
-      }
+    typeof eventCodes.AUTOUPDATE_CONFIG_CREATE,
+    {
+      user: string;
+    }
   >;
   [eventCodes.AUTOUPDATE_CONFIG_UPDATE]: RawEvent<
-      typeof eventCodes.AUTOUPDATE_CONFIG_UPDATE,
-      {
-        user: string;
-      }
+    typeof eventCodes.AUTOUPDATE_CONFIG_UPDATE,
+    {
+      user: string;
+    }
   >;
   [eventCodes.AUTOUPDATE_CONFIG_DELETE]: RawEvent<
-      typeof eventCodes.AUTOUPDATE_CONFIG_DELETE,
-      {
-        user: string;
-      }
+    typeof eventCodes.AUTOUPDATE_CONFIG_DELETE,
+    {
+      user: string;
+    }
   >;
   [eventCodes.AUTOUPDATE_VERSION_CREATE]: RawEvent<
-      typeof eventCodes.AUTOUPDATE_VERSION_CREATE,
-      {
-        user: string;
-      }
+    typeof eventCodes.AUTOUPDATE_VERSION_CREATE,
+    {
+      user: string;
+    }
   >;
   [eventCodes.AUTOUPDATE_VERSION_UPDATE]: RawEvent<
-      typeof eventCodes.AUTOUPDATE_VERSION_UPDATE,
-      {
-        user: string;
-      }
+    typeof eventCodes.AUTOUPDATE_VERSION_UPDATE,
+    {
+      user: string;
+    }
   >;
   [eventCodes.AUTOUPDATE_VERSION_DELETE]: RawEvent<
-      typeof eventCodes.AUTOUPDATE_VERSION_DELETE,
-      {
-        user: string;
-      }
+    typeof eventCodes.AUTOUPDATE_VERSION_DELETE,
+    {
+      user: string;
+    }
   >;
 };
 


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/52727 by adding autoudpate events to the audit web UI.

Changelog: The audit log web UI now renders Teleport Autoupdate Config and Version events properly.