### PR TITLE
[v17] [teleport-update] Set umask 0022 for teleport-update to avoid errors on enable

### DIFF
--- a/lib/autoupdate/agent/installer.go
+++ b/lib/autoupdate/agent/installer.go
@@ -64,6 +64,7 @@ const (
 
 // LocalInstaller manages the creation and removal of installations
 // of Teleport.
+// SetRequiredUmask must be called before any methods are executed.
 type LocalInstaller struct {
 	// InstallDir contains each installation, named by version.
 	InstallDir string

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -75,7 +75,10 @@ const (
 // This ensures consistent file permissions.
 // NOTE: This must be run in main.go before any goroutines that create files are started.
 func SetRequiredUmask(ctx context.Context, log *slog.Logger) {
-	old := syscall.Umask(requiredUmask)
+	warnUmask(ctx, log, syscall.Umask(requiredUmask))
+}
+
+func warnUmask(ctx context.Context, log *slog.Logger, old int) {
 	if old&^requiredUmask != 0 {
 		log.WarnContext(ctx, "Restrictive umask detected. Umask has been changed to 0022 for teleport-update and all child processes.")
 		log.WarnContext(ctx, "All files created by teleport-update will have permissions set according to this umask.")

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -77,7 +77,7 @@ const (
 // NOTE: This must be run in main.go before any goroutines that create files are started.
 func SetRequiredUmask(ctx context.Context, log *slog.Logger, fail bool) error {
 	old := syscall.Umask(requiredUmask)
-	if old&requiredUmask > 0 {
+	if old&^requiredUmask > 0 {
 		if fail {
 			return trace.Errorf("refusing to make umask less restrictive")
 		}

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -86,7 +86,6 @@ func SetRequiredUmask(ctx context.Context, log *slog.Logger) {
 // installations of the Teleport agent.
 // The AutoUpdater uses an HTTP client with sane defaults for downloads, and
 // will not fill disk to within 10 MB of available capacity.
-// SetRequiredUmask must be called before any methods are executed, except for Status.
 func NewLocalUpdater(cfg LocalUpdaterConfig, ns *Namespace) (*Updater, error) {
 	certPool, err := x509.SystemCertPool()
 	if err != nil {
@@ -190,6 +189,7 @@ type LocalUpdaterConfig struct {
 }
 
 // Updater implements the agent-local logic for Teleport agent auto-updates.
+// SetRequiredUmask must be called before any methods are executed, except for Status.
 type Updater struct {
 	// Log contains a logger.
 	Log *slog.Logger

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -47,9 +47,6 @@ import (
 const (
 	// BinaryName specifies the name of the updater binary.
 	BinaryName = "teleport-update"
-	// requiredUmask must be set before this package can be used.
-	// Use syscall.Umask to set when no other goroutines are running.
-	requiredUmask = 0o022
 )
 
 const (
@@ -61,6 +58,9 @@ const (
 	reservedFreeDisk = 10_000_000
 	// debugSocketFileName is the name of Teleport's debug socket in the data dir.
 	debugSocketFileName = "debug.sock" // 10 MB
+	// requiredUmask must be set before this package can be used.
+	// Use syscall.Umask to set when no other goroutines are running.
+	requiredUmask = 0o022
 )
 
 // Log keys

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -77,7 +77,7 @@ const (
 // NOTE: This must be run in main.go before any goroutines that create files are started.
 func SetRequiredUmask(ctx context.Context, log *slog.Logger, fail bool) error {
 	old := syscall.Umask(requiredUmask)
-	if old&^requiredUmask > 0 {
+	if old&^requiredUmask != 0 {
 		if fail {
 			return trace.Errorf("refusing to make umask less restrictive")
 		}

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -86,7 +86,7 @@ func SetRequiredUmask(ctx context.Context, log *slog.Logger) {
 // installations of the Teleport agent.
 // The AutoUpdater uses an HTTP client with sane defaults for downloads, and
 // will not fill disk to within 10 MB of available capacity.
-// SetRequiredUmask must be called before any methods are executed.
+// SetRequiredUmask must be called before any methods are executed, except for Status.
 func NewLocalUpdater(cfg LocalUpdaterConfig, ns *Namespace) (*Updater, error) {
 	certPool, err := x509.SystemCertPool()
 	if err != nil {
@@ -561,6 +561,7 @@ func isActiveOrEnabled(ctx context.Context, s Process) (bool, error) {
 
 // Status returns all available local and remote fields related to agent auto-updates.
 // Status is safe to run concurrently with other Updater commands.
+// Status does not write files, and therefore does not require SetRequiredUmask.
 func (u *Updater) Status(ctx context.Context) (Status, error) {
 	var out Status
 	// Read configuration from update.yaml.

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -73,18 +73,13 @@ const (
 
 // SetRequiredUmask sets the umask to match the systemd umask that the teleport-update service will execute with.
 // This ensures consistent file permissions.
-// If fail is true, SetRequiredUmask will fail if the overridden umask is more restrictive.
 // NOTE: This must be run in main.go before any goroutines that create files are started.
-func SetRequiredUmask(ctx context.Context, log *slog.Logger, fail bool) error {
+func SetRequiredUmask(ctx context.Context, log *slog.Logger) {
 	old := syscall.Umask(requiredUmask)
 	if old&^requiredUmask != 0 {
-		if fail {
-			return trace.Errorf("refusing to make umask less restrictive")
-		}
 		log.WarnContext(ctx, "Restrictive umask detected. Umask has been changed to 0022 for teleport-update and all child processes.")
 		log.WarnContext(ctx, "All files created by teleport-update will have permissions set according to this umask.")
 	}
-	return nil
 }
 
 // NewLocalUpdater returns a new Updater that auto-updates local

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -60,6 +60,13 @@ const (
 
 var plog = logutils.NewPackageLogger(teleport.ComponentKey, teleport.ComponentUpdater)
 
+func init() {
+	// Set the umask to match the systemd umask that the teleport-update service will execute with.
+	// This ensures consistent file permissions.
+	// NOTE: This must be run before any goroutines that create files are started.
+	syscall.Umask(0022)
+}
+
 func main() {
 	if code := Run(os.Args[1:]); code != 0 {
 		os.Exit(code)

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -61,10 +61,6 @@ const (
 var plog = logutils.NewPackageLogger(teleport.ComponentKey, teleport.ComponentUpdater)
 
 func main() {
-	// Set the umask to match the systemd umask that the teleport-update service will execute with.
-	// This ensures consistent file permissions.
-	// NOTE: This must be run before any goroutines that create files are started.
-	syscall.Umask(0o022)
 	if code := Run(os.Args[1:]); code != 0 {
 		os.Exit(code)
 	}
@@ -187,6 +183,9 @@ func Run(args []string) int {
 		plog.ErrorContext(ctx, "Failed to set up logger.", "error", err)
 		return 1
 	}
+
+	// Set required umask for all commands, and warn loudly if it changes.
+	autoupdate.SetRequiredUmask(ctx, plog)
 
 	switch command {
 	case enableCmd.FullCommand():

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -184,7 +184,7 @@ func Run(args []string) int {
 		return 1
 	}
 
-	// Set required umask for most commands, and warn loudly if it changes.
+	// Set required umask for commands that write files to system directories as root, and warn loudly if it changes.
 	switch command {
 	case statusCmd.FullCommand(), versionCmd.FullCommand():
 	default:

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -54,8 +54,6 @@ const (
 	updateGroupEnvVar = "TELEPORT_UPDATE_GROUP"
 	// updateVersionEnvVar forces the version to specified value.
 	updateVersionEnvVar = "TELEPORT_UPDATE_VERSION"
-	// ignoreUmaskEnvVar allows teleport-update to ignore a restrictive umask.
-	ignoreUmaskEnvVar = "TELEPORT_UPDATE_IGNORE_UMASK"
 	// updateLockTimeout is the duration commands will wait for update to complete before failing.
 	updateLockTimeout = 10 * time.Minute
 )

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -60,14 +60,11 @@ const (
 
 var plog = logutils.NewPackageLogger(teleport.ComponentKey, teleport.ComponentUpdater)
 
-func init() {
+func main() {
 	// Set the umask to match the systemd umask that the teleport-update service will execute with.
 	// This ensures consistent file permissions.
 	// NOTE: This must be run before any goroutines that create files are started.
-	syscall.Umask(0022)
-}
-
-func main() {
+	syscall.Umask(0o022)
 	if code := Run(os.Args[1:]); code != 0 {
 		os.Exit(code)
 	}


### PR DESCRIPTION
Backport #52725 to branch/v17

changelog: Allow `teleport-update` to be used in shells that set a restrictive umask
