### PR TITLE
[docs] add yaml syntax highlight for `login_rule` sepc

### DIFF
--- a/docs/pages/admin-guides/access-controls/login-rules/guide.mdx
+++ b/docs/pages/admin-guides/access-controls/login-rules/guide.mdx
@@ -56,7 +56,7 @@ of their current `username` trait converted to lowercase.
 Copy this example rule to a file called `my_rule.yaml` to continue with the
 guide.
 
-```
+```yaml
 # my_rule.yaml
 kind: login_rule
 version: v1

--- a/docs/pages/admin-guides/access-controls/login-rules/guide.mdx
+++ b/docs/pages/admin-guides/access-controls/login-rules/guide.mdx
@@ -136,8 +136,8 @@ You can check the traits and roles with the following command:
 $ tctl get --format json users/<Var name="username"/> | jq '{traits: first.spec.traits, roles: first.spec.roles}'
 {
   "traits": {
-	"access": [
-	  "staging"
+    "access": [
+      "staging"
     ],
     "groups": [
       "dbs",

--- a/docs/pages/includes/login-rule-spec.mdx
+++ b/docs/pages/includes/login-rule-spec.mdx
@@ -1,4 +1,4 @@
-```
+```yaml
 kind: login_rule
 version: v1
 metadata:


### PR DESCRIPTION
YAML syntax highlight isn't available for:
- https://goteleport.com/docs/reference/access-controls/login-rules/
- https://goteleport.com/docs/admin-guides/access-controls/login-rules/guide/#step-25-draft-your-login-rule-resource

This PR adds `yaml` annotation to markdown code snippets.