### PR TITLE
[teleport-update] Improve clarity of error logs and address UX edge cases

### DIFF
--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -86,11 +86,6 @@ func warnUmask(ctx context.Context, log *slog.Logger, old int) {
 	}
 }
 
-var (
-	// ErrNotInstalled is returned when Teleport is not installed.
-	ErrNotInstalled = trace.Errorf("not installed")
-)
-
 // NewLocalUpdater returns a new Updater that auto-updates local
 // installations of the Teleport agent.
 // The AutoUpdater uses an HTTP client with sane defaults for downloads, and
@@ -283,6 +278,8 @@ var (
 	ErrNoBinaries = errors.New("no binaries available to link")
 	// ErrFilePresent is returned when a file is present.
 	ErrFilePresent = errors.New("file present")
+	// ErrNotInstalled is returned when Teleport is not installed.
+	ErrNotInstalled = trace.Errorf("not installed")
 )
 
 // Process provides an API for interacting with a running Teleport process.

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -697,7 +697,11 @@ func (u *Updater) Update(ctx context.Context, now bool) error {
 		u.Log.InfoContext(ctx, "Update available. Initiating update.", targetKey, target, activeKey, active)
 	}
 	if !now {
-		time.Sleep(resp.Jitter)
+		select {
+		case <-time.After(resp.Jitter):
+		case <-ctx.Done():
+			return trace.Wrap(ctx.Err())
+		}
 	}
 
 	updateErr := u.update(ctx, cfg, target, false, resp.AGPL)

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -278,7 +278,7 @@ var (
 	// ErrFilePresent is returned when a file is present.
 	ErrFilePresent = errors.New("file present")
 	// ErrNotInstalled is returned when Teleport is not installed.
-	ErrNotInstalled = trace.Errorf("not installed")
+	ErrNotInstalled = errors.New("not installed")
 )
 
 // Process provides an API for interacting with a running Teleport process.

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -459,6 +459,8 @@ func (u *Updater) Remove(ctx context.Context, force bool) error {
 		if u.TeleportServiceName == serviceName && !force {
 			u.Log.ErrorContext(ctx, "Default Teleport systemd service would be removed, and --force was not passed. Refusing to remove Teleport from this system.")
 			return trace.Errorf("unable to remove Teleport completely without --force")
+		} else {
+			u.Log.WarnContext(ctx, "Default Teleport systemd service would be removed since --force was passed. Teleport will be removed from this system.")
 		}
 		return u.removeWithoutSystem(ctx, cfg)
 	}

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -457,10 +457,12 @@ func (u *Updater) Remove(ctx context.Context, force bool) error {
 	if filepath.Clean(cfg.Spec.Path) != filepath.Clean(defaultPathDir) {
 		if u.TeleportServiceName == serviceName {
 			if !force {
-				u.Log.ErrorContext(ctx, "Default Teleport systemd service would be removed, and --force was not passed. Refusing to remove Teleport from this system.")
+				u.Log.ErrorContext(ctx, "Default Teleport systemd service would be removed, and --force was not passed.")
+				u.Log.ErrorContext(ctx, "Refusing to remove Teleport from this system.")
 				return trace.Errorf("unable to remove Teleport completely without --force")
 			} else {
-				u.Log.WarnContext(ctx, "Default Teleport systemd service will be removed since --force was passed. Teleport will be removed from this system.")
+				u.Log.WarnContext(ctx, "Default Teleport systemd service will be removed since --force was passed.")
+				u.Log.WarnContext(ctx, "Teleport will be removed from this system.")
 			}
 		}
 		return u.removeWithoutSystem(ctx, cfg)
@@ -468,10 +470,12 @@ func (u *Updater) Remove(ctx context.Context, force bool) error {
 	revert, err := u.Installer.LinkSystem(ctx)
 	if errors.Is(err, ErrNoBinaries) {
 		if !force {
-			u.Log.ErrorContext(ctx, "No packaged installation of Teleport was found, and --force was not passed. Refusing to remove Teleport from this system.")
+			u.Log.ErrorContext(ctx, "No packaged installation of Teleport was found, and --force was not passed.")
+			u.Log.ErrorContext(ctx, "Refusing to remove Teleport from this system.")
 			return trace.Errorf("unable to remove Teleport completely without --force")
 		} else {
-			u.Log.WarnContext(ctx, "No packaged installation of Teleport was found, and --force was passed. Teleport will be removed from this system.")
+			u.Log.WarnContext(ctx, "No packaged installation of Teleport was found, and --force was passed.")
+			u.Log.WarnContext(ctx, "Teleport will be removed from this system.")
 		}
 		return u.removeWithoutSystem(ctx, cfg)
 	}
@@ -479,7 +483,8 @@ func (u *Updater) Remove(ctx context.Context, force bool) error {
 		return trace.Wrap(err, "failed to link")
 	}
 
-	u.Log.InfoContext(ctx, "Updater-managed installation of Teleport detected. Restoring packaged version of Teleport before removing.")
+	u.Log.InfoContext(ctx, "Updater-managed installation of Teleport detected.")
+	u.Log.InfoContext(ctx, "Restoring packaged version of Teleport before removing.")
 
 	revertConfig := func(ctx context.Context) bool {
 		if ok := revert(ctx); !ok {
@@ -525,7 +530,8 @@ func (u *Updater) Remove(ctx context.Context, force bool) error {
 		u.Log.ErrorContext(ctx, "Reverting symlinks due to failed restart.")
 		if ok := revertConfig(ctx); ok {
 			if err := u.Process.Reload(ctx); err != nil && !errors.Is(err, ErrNotNeeded) {
-				u.Log.ErrorContext(ctx, "Failed to reload Teleport after reverting. Installation likely broken.", errorKey, err)
+				u.Log.ErrorContext(ctx, "Failed to reload Teleport after reverting.", errorKey, err)
+				u.Log.ErrorContext(ctx, "Installation likely broken.")
 			} else {
 				u.Log.WarnContext(ctx, "Teleport updater detected an error with the new installation and successfully reverted it.")
 			}
@@ -541,7 +547,8 @@ func (u *Updater) Remove(ctx context.Context, force bool) error {
 }
 
 func (u *Updater) removeWithoutSystem(ctx context.Context, cfg *UpdateConfig) error {
-	u.Log.InfoContext(ctx, "Updater-managed installation of Teleport detected. Attempting to unlink and remove.")
+	u.Log.InfoContext(ctx, "Updater-managed installation of Teleport detected.")
+	u.Log.InfoContext(ctx, "Attempting to unlink and remove.")
 	ok, err := u.Process.IsActive(ctx)
 	if err != nil && !errors.Is(err, ErrNotSupported) {
 		return trace.Wrap(err)

--- a/lib/autoupdate/agent/updater_test.go
+++ b/lib/autoupdate/agent/updater_test.go
@@ -1058,6 +1058,7 @@ func TestUpdater_Remove(t *testing.T) {
 		reloadErr     error
 		processActive bool
 		force         bool
+		serviceName   string
 
 		unlinkedVersion string
 		teardownCalls   int
@@ -1159,6 +1160,53 @@ func TestUpdater_Remove(t *testing.T) {
 			linkSystemErr:   ErrNoBinaries,
 			linkSystemCalls: 1,
 			isActiveErr:     ErrNotSupported,
+			unlinkedVersion: version,
+			teardownCalls:   1,
+			force:           true,
+		},
+		{
+			name: "no system links, process disabled, custom path, force",
+			cfg: &UpdateConfig{
+				Version: updateConfigVersion,
+				Kind:    updateConfigKind,
+				Spec: UpdateSpec{
+					Path: "custom",
+				},
+				Status: UpdateStatus{
+					Active: NewRevision(version, 0),
+				},
+			},
+			unlinkedVersion: version,
+			teardownCalls:   1,
+			force:           true,
+		},
+		{
+			name: "no system links, process disabled, custom path, no force",
+			cfg: &UpdateConfig{
+				Version: updateConfigVersion,
+				Kind:    updateConfigKind,
+				Spec: UpdateSpec{
+					Path: "custom",
+				},
+				Status: UpdateStatus{
+					Active: NewRevision(version, 0),
+				},
+			},
+			errMatch: "unable to remove",
+		},
+		{
+			name: "no system links, process disabled, custom path, no force, custom service",
+			cfg: &UpdateConfig{
+				Version: updateConfigVersion,
+				Kind:    updateConfigKind,
+				Spec: UpdateSpec{
+					Path: "custom",
+				},
+				Status: UpdateStatus{
+					Active: NewRevision(version, 0),
+				},
+			},
+			serviceName:     "custom",
 			unlinkedVersion: version,
 			teardownCalls:   1,
 			force:           true,
@@ -1268,6 +1316,10 @@ func TestUpdater_Remove(t *testing.T) {
 				InsecureSkipVerify: true,
 			}, ns)
 			require.NoError(t, err)
+			updater.TeleportServiceName = serviceName
+			if tt.serviceName != "" {
+				updater.TeleportServiceName = tt.serviceName
+			}
 
 			// Create config file only if provided in test case
 			if tt.cfg != nil {

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -460,6 +460,10 @@ func cmdStatus(ctx context.Context, ccfg *cliConfig) error {
 	if err != nil {
 		return trace.Wrap(err, "failed to get status")
 	}
+	if errors.Is(err, autoupdate.ErrNotInstalled) {
+		plog.InfoContext(ctx, "Teleport is not installed.")
+		return nil
+	}
 	enc := yaml.NewEncoder(os.Stdout)
 	return trace.Wrap(enc.Encode(status))
 }

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -465,7 +465,7 @@ func cmdStatus(ctx context.Context, ccfg *cliConfig) error {
 		return trace.Wrap(err, "failed to get status")
 	}
 	if errors.Is(err, autoupdate.ErrNotInstalled) {
-		plog.InfoContext(ctx, "Teleport is not installed.")
+		plog.InfoContext(ctx, "Teleport is not installed by teleport-update with this suffix.")
 		return nil
 	}
 	enc := yaml.NewEncoder(os.Stdout)

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -184,10 +184,14 @@ func Run(args []string) int {
 		return 1
 	}
 
-	// Set required umask for commands that write files to system directories as root, and warn loudly if it changes.
 	switch command {
 	case statusCmd.FullCommand(), versionCmd.FullCommand():
 	default:
+		if os.Geteuid() != 0 {
+			plog.ErrorContext(ctx, "This command must be run as root. Try running with sudo.")
+			return 1
+		}
+		// Set required umask for commands that write files to system directories as root, and warn loudly if it changes.
 		autoupdate.SetRequiredUmask(ctx, plog)
 	}
 


### PR DESCRIPTION
This PR makes adds a few minor usability tweaks to teleport-update:
- `teleport-update status` has more clear output when Teleport is not installed
- `teleport-update uninstall` no longer requires the --force flag when run with a non-conflicting suffix
- Running commands as a non-root effective user fails with a clear error
- Logs after prefixed installations complete suggest commands that use the correct service name
- Jitter can be terminated with SIGINT / SIGTERM

---

changelog: Improve clarity of error logs and address UX edge cases in teleport-update

---

The `teleport-update` binary will be used to enable, disable, and trigger automatic Teleport agent updates. The new auto-updates system manages a local installation of the cluster-specified version of Teleport stored in `/opt/teleport`.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/11856