### PR TITLE
Web: replace side docs with sliding side panel

### DIFF
--- a/web/packages/teleport/src/AuthConnectors/AuthConnectorEditor/AuthConnectorEditorContent.tsx
+++ b/web/packages/teleport/src/AuthConnectors/AuthConnectorEditor/AuthConnectorEditorContent.tsx
@@ -18,22 +18,20 @@
 
 import { Link as RouterLink } from 'react-router-dom';
 
-import { Link } from 'design';
 import { Alert } from 'design/Alert';
 import Box from 'design/Box';
 import { ButtonPrimary, ButtonSecondary } from 'design/Button';
 import Flex from 'design/Flex';
 import { ArrowBack } from 'design/Icon';
 import { Indicator } from 'design/Indicator';
-import { H1, H3 } from 'design/Text';
-import { P } from 'design/Text/Text';
+import { H1 } from 'design/Text';
 import TextEditor from 'shared/components/TextEditor';
 import { Attempt } from 'shared/hooks/useAsync';
 
-import { DesktopDescription } from 'teleport/AuthConnectors/styles/AuthConnectors.styles';
 import { FeatureBox, FeatureHeaderTitle } from 'teleport/components/Layout';
+import { InfoGuideWrapper } from 'teleport/components/SlidingSidePanel/InfoGuideSidePanel';
 
-import { description } from '../AuthConnectors';
+import { InfoGuide } from '../AuthConnectors';
 
 /**
  * AuthConnectorEditorContent is a the content of an Auth Connector editor page.
@@ -53,17 +51,20 @@ export function AuthConnectorEditorContent({
   return (
     <FeatureBox>
       <FeatureHeaderTitle py={3} mb={2}>
-        <Flex alignItems="center">
-          <ArrowBack
-            as={RouterLink}
-            mr={2}
-            size="large"
-            color="text.main"
-            to={backButtonRoute}
-          />
-          <Box mr={4}>
-            <H1>{title}</H1>
-          </Box>
+        <Flex alignItems="center" justifyContent="space-between">
+          <Flex alignItems="center">
+            <ArrowBack
+              as={RouterLink}
+              mr={2}
+              size="large"
+              color="text.main"
+              to={backButtonRoute}
+            />
+            <Box mr={4}>
+              <H1>{title}</H1>
+            </Box>
+          </Flex>
+          <InfoGuideWrapper guide={<InfoGuide isGitHub={isGithub} />} />
         </Flex>
       </FeatureHeaderTitle>
       {fetchAttempt.status === 'error' && (
@@ -107,35 +108,6 @@ export function AuthConnectorEditorContent({
               </ButtonSecondary>
             </Box>
           </Flex>
-          <DesktopDescription>
-            <H3 mb={3}>Auth Connectors</H3>
-            <P mb={3}>{description}</P>
-            {isGithub ? (
-              <P mb={2}>
-                Please
-                <Link
-                  color="text.main"
-                  href="https://goteleport.com/docs/admin-guides/access-controls/sso/github-sso/"
-                  target="_blank"
-                >
-                  view our documentation
-                </Link>{' '}
-                on how to configure a GitHub connector.
-              </P>
-            ) : (
-              <P>
-                Please{' '}
-                <Link
-                  color="text.main"
-                  href="https://goteleport.com/docs/admin-guides/access-controls/sso/"
-                  target="_blank"
-                >
-                  view our documentation
-                </Link>{' '}
-                for samples of each connector.
-              </P>
-            )}
-          </DesktopDescription>
         </Flex>
       )}
     </FeatureBox>

--- a/web/packages/teleport/src/AuthConnectors/AuthConnectors.tsx
+++ b/web/packages/teleport/src/AuthConnectors/AuthConnectors.tsx
@@ -19,18 +19,21 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useHistory } from 'react-router';
 
-import { Alert, Box, Flex, H3, Indicator, Link } from 'design';
-import { H2, P } from 'design/Text/Text';
+import { Alert, Box, Flex, Indicator } from 'design';
+import { H2 } from 'design/Text/Text';
 import { useAsync } from 'shared/hooks/useAsync';
 
 import {
-  DesktopDescription,
-  MobileDescription,
   ResponsiveAddButton,
   ResponsiveFeatureHeader,
 } from 'teleport/AuthConnectors/styles/AuthConnectors.styles';
 import { FeatureBox, FeatureHeaderTitle } from 'teleport/components/Layout';
 import { Route, Switch } from 'teleport/components/Router';
+import {
+  InfoParagraph,
+  InfoTitle,
+  ReferenceLinks,
+} from 'teleport/components/SlidingSidePanel/InfoGuideSidePanel';
 import useResources from 'teleport/components/useResources';
 import cfg from 'teleport/config';
 import { DefaultAuthConnector, Resource } from 'teleport/services/resources';
@@ -141,7 +144,6 @@ export function AuthConnectors() {
     <FeatureBox>
       <ResponsiveFeatureHeader>
         <FeatureHeaderTitle>Auth Connectors</FeatureHeaderTitle>
-        <MobileDescription>{description}</MobileDescription>
         <ResponsiveAddButton
           fill="border"
           onClick={() =>
@@ -188,22 +190,6 @@ export function AuthConnectors() {
             </Box>
             <CtaConnectors />
           </Flex>
-          <DesktopDescription>
-            <H3 mb={3}>Auth Connectors</H3>
-            <P mb={3}>{description}</P>
-            <P mb={2}>
-              Please{' '}
-              <Link
-                color="text.main"
-                // This URL is the OSS documentation for auth connectors
-                href="https://goteleport.com/docs/admin-guides/access-controls/sso/github-sso/"
-                target="_blank"
-              >
-                view our documentation
-              </Link>{' '}
-              on how to configure a GitHub connector.
-            </P>
-          </DesktopDescription>
         </Flex>
       )}
       {resources.status === 'removing' && (
@@ -219,3 +205,27 @@ export function AuthConnectors() {
     </FeatureBox>
   );
 }
+
+export const InfoGuide = ({ isGitHub = false }) => (
+  <Box>
+    <InfoTitle>Auth Connectors</InfoTitle>
+    <InfoParagraph>
+      Auth connectors allow Teleport to authenticate users via an external
+      identity source such as Okta, Microsoft Entra ID, GitHub, etc. This
+      authentication method is commonly known as single sign-on (SSO).
+    </InfoParagraph>
+    <ReferenceLinks
+      links={[
+        isGitHub
+          ? {
+              title: 'Configure GitHub connector',
+              href: 'https://goteleport.com/docs/admin-guides/access-controls/sso/github-sso/',
+            }
+          : {
+              title: 'Samples of different connectors',
+              href: 'https://goteleport.com/docs/admin-guides/access-controls/sso/',
+            },
+      ]}
+    />
+  </Box>
+);

--- a/web/packages/teleport/src/AuthConnectors/AuthConnectors.tsx
+++ b/web/packages/teleport/src/AuthConnectors/AuthConnectors.tsx
@@ -30,8 +30,8 @@ import {
 import { FeatureBox, FeatureHeaderTitle } from 'teleport/components/Layout';
 import { Route, Switch } from 'teleport/components/Router';
 import {
+  InfoGuideWrapper,
   InfoParagraph,
-  InfoTitle,
   ReferenceLinks,
 } from 'teleport/components/SlidingSidePanel/InfoGuideSidePanel';
 import useResources from 'teleport/components/useResources';
@@ -144,14 +144,16 @@ export function AuthConnectors() {
     <FeatureBox>
       <ResponsiveFeatureHeader>
         <FeatureHeaderTitle>Auth Connectors</FeatureHeaderTitle>
-        <ResponsiveAddButton
-          fill="border"
-          onClick={() =>
-            history.push(cfg.getCreateAuthConnectorRoute('github'))
-          }
-        >
-          New GitHub Connector
-        </ResponsiveAddButton>
+        <InfoGuideWrapper guide={<InfoGuide isGitHub={true} />}>
+          <ResponsiveAddButton
+            fill="border"
+            onClick={() =>
+              history.push(cfg.getCreateAuthConnectorRoute('github'))
+            }
+          >
+            New GitHub Connector
+          </ResponsiveAddButton>
+        </InfoGuideWrapper>
       </ResponsiveFeatureHeader>
       {fetchAttempt.status === 'error' && (
         <Alert children={fetchAttempt.statusText} />
@@ -208,7 +210,6 @@ export function AuthConnectors() {
 
 export const InfoGuide = ({ isGitHub = false }) => (
   <Box>
-    <InfoTitle>Auth Connectors</InfoTitle>
     <InfoParagraph>
       Auth connectors allow Teleport to authenticate users via an external
       identity source such as Okta, Microsoft Entra ID, GitHub, etc. This

--- a/web/packages/teleport/src/Bots/Add/AddBotsPicker.tsx
+++ b/web/packages/teleport/src/Bots/Add/AddBotsPicker.tsx
@@ -24,6 +24,7 @@ import { Server } from 'design/Icon';
 import { P } from 'design/Text/Text';
 
 import { FeatureHeader, FeatureHeaderTitle } from 'teleport/components/Layout';
+import { InfoGuideWrapper } from 'teleport/components/SlidingSidePanel/InfoGuideSidePanel';
 import { ToolTipNoPermBadge } from 'teleport/components/ToolTipNoPermBadge';
 import cfg from 'teleport/config';
 import { IntegrationTile } from 'teleport/Integrations';
@@ -34,6 +35,7 @@ import {
 } from 'teleport/services/userEvent';
 import useTeleport from 'teleport/useTeleport';
 
+import { InfoGuide } from '../InfoGuide';
 import { BotFlowType } from '../types';
 
 type BotIntegration = {
@@ -135,8 +137,9 @@ export function AddBotsPicker() {
   const ctx = useTeleport();
   return (
     <>
-      <FeatureHeader>
+      <FeatureHeader justifyContent="space-between">
         <FeatureHeaderTitle>Select Bot Type</FeatureHeaderTitle>
+        <InfoGuideWrapper guide={<InfoGuide />} />
       </FeatureHeader>
 
       <P mb="5">

--- a/web/packages/teleport/src/Bots/InfoGuide.tsx
+++ b/web/packages/teleport/src/Bots/InfoGuide.tsx
@@ -22,7 +22,6 @@ import { Mark } from 'design/Mark';
 import {
   InfoExternalTextLink,
   InfoParagraph,
-  InfoTitle,
   ReferenceLinks,
 } from 'teleport/components/SlidingSidePanel/InfoGuideSidePanel';
 
@@ -31,7 +30,7 @@ const InfoGuideReferenceLinks = {
     title: 'What are Bots',
     href: 'https://goteleport.com/docs/enroll-resources/machine-id/introduction/#bots',
   },
-  TBots: {
+  TBot: {
     title: 'What is tbot',
     href: 'https://goteleport.com/docs/reference/architecture/machine-id-architecture/#tbot',
   },
@@ -43,7 +42,6 @@ const InfoGuideReferenceLinks = {
 
 export const InfoGuide = () => (
   <Box>
-    <InfoTitle>Bots</InfoTitle>
     <InfoParagraph>
       <InfoExternalTextLink
         target="_blank"
@@ -67,12 +65,12 @@ export const InfoGuide = () => (
       Bots use the{' '}
       <InfoExternalTextLink
         target="_blank"
-        href={InfoGuideReferenceLinks.TBots.href}
+        href={InfoGuideReferenceLinks.TBot.href}
       >
         tbot
       </InfoExternalTextLink>{' '}
       binary rather than the <Mark>teleport</Mark> binary used for other agents.{' '}
-      <Mark>tbot</Mark> outputs identify files such as certificates and
+      <Mark>tbot</Mark> outputs identity files such as certificates and
       Kubernetes configuration files for processes to use for authentication.
     </InfoParagraph>
     <ReferenceLinks links={Object.values(InfoGuideReferenceLinks)} />

--- a/web/packages/teleport/src/Bots/InfoGuide.tsx
+++ b/web/packages/teleport/src/Bots/InfoGuide.tsx
@@ -1,0 +1,80 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Box from 'design/Box';
+import { Mark } from 'design/Mark';
+
+import {
+  InfoExternalTextLink,
+  InfoParagraph,
+  InfoTitle,
+  ReferenceLinks,
+} from 'teleport/components/SlidingSidePanel/InfoGuideSidePanel';
+
+const InfoGuideReferenceLinks = {
+  Bots: {
+    title: 'What are Bots',
+    href: 'https://goteleport.com/docs/enroll-resources/machine-id/introduction/#bots',
+  },
+  TBots: {
+    title: 'What is tbot',
+    href: 'https://goteleport.com/docs/reference/architecture/machine-id-architecture/#tbot',
+  },
+  AccessResources: {
+    title: 'Access your Infrastructure with Machine ID',
+    href: 'https://goteleport.com/docs/enroll-resources/machine-id/access-guides/',
+  },
+};
+
+export const InfoGuide = () => (
+  <Box>
+    <InfoTitle>Bots</InfoTitle>
+    <InfoParagraph>
+      <InfoExternalTextLink
+        target="_blank"
+        href={InfoGuideReferenceLinks.Bots.href}
+      >
+        Bots
+      </InfoExternalTextLink>{' '}
+      are identities a machine can use to authenticate to the Teleport cluster.
+      This allows processes like automated tests,
+      Infrastructure-as-Code/provisioning tools like Terraform or Ansible and
+      scripts to{' '}
+      <InfoExternalTextLink
+        target="_blank"
+        href={InfoGuideReferenceLinks.AccessResources.href}
+      >
+        access resources
+      </InfoExternalTextLink>{' '}
+      protected by the Teleport proxy.
+    </InfoParagraph>
+    <InfoParagraph>
+      Bots use the{' '}
+      <InfoExternalTextLink
+        target="_blank"
+        href={InfoGuideReferenceLinks.TBots.href}
+      >
+        tbot
+      </InfoExternalTextLink>{' '}
+      binary rather than the <Mark>teleport</Mark> binary used for other agents.{' '}
+      <Mark>tbot</Mark> outputs identify files such as certificates and
+      Kubernetes configuration files for processes to use for authentication.
+    </InfoParagraph>
+    <ReferenceLinks links={Object.values(InfoGuideReferenceLinks)} />
+  </Box>
+);

--- a/web/packages/teleport/src/Bots/List/Bots.test.tsx
+++ b/web/packages/teleport/src/Bots/List/Bots.test.tsx
@@ -22,6 +22,7 @@ import { render, screen, userEvent, waitFor } from 'design/utils/testing';
 
 import { botsApiResponseFixture } from 'teleport/Bots/fixtures';
 import { ContextProvider } from 'teleport/index';
+import { InfoGuidePanelProvider } from 'teleport/Main/InfoGuideContext';
 import {
   allAccessAcl,
   createTeleportContext,
@@ -38,7 +39,9 @@ function renderWithContext(element, ctx?: TeleportContext) {
   }
   return render(
     <MemoryRouter>
-      <ContextProvider ctx={ctx}>{element}</ContextProvider>
+      <InfoGuidePanelProvider>
+        <ContextProvider ctx={ctx}>{element}</ContextProvider>
+      </InfoGuidePanelProvider>
     </MemoryRouter>
   );
 }

--- a/web/packages/teleport/src/Bots/List/Bots.tsx
+++ b/web/packages/teleport/src/Bots/List/Bots.tsx
@@ -29,6 +29,7 @@ import {
   FeatureHeader,
   FeatureHeaderTitle,
 } from 'teleport/components/Layout';
+import { InfoGuideWrapper } from 'teleport/components/SlidingSidePanel/InfoGuideSidePanel';
 import cfg from 'teleport/config';
 import {
   deleteBot,
@@ -39,6 +40,7 @@ import {
 import { FlatBot } from 'teleport/services/bot/types';
 import useTeleport from 'teleport/useTeleport';
 
+import { InfoGuide } from '../InfoGuide';
 import { EmptyState } from './EmptyState/EmptyState';
 
 export function Bots() {
@@ -143,30 +145,32 @@ export function Bots() {
       <FeatureHeader>
         <FeatureHeaderTitle>Bots</FeatureHeaderTitle>
         <Box ml="auto">
-          <HoverTooltip
-            tipContent={
-              hasAddBotPermissions
-                ? ''
-                : `Insufficient permissions. Reach out to your Teleport administrator
+          <InfoGuideWrapper guide={<InfoGuide />}>
+            <HoverTooltip
+              tipContent={
+                hasAddBotPermissions
+                  ? ''
+                  : `Insufficient permissions. Reach out to your Teleport administrator
     to request bot creation permissions.`
-            }
-          >
-            <Button
-              intent="primary"
-              fill={
-                fetchAttempt.status === 'success' && bots.length === 0
-                  ? 'filled'
-                  : 'border'
               }
-              ml="auto"
-              width="240px"
-              as={Link}
-              to={cfg.getBotsNewRoute()}
-              disabled={!hasAddBotPermissions}
             >
-              Enroll New Bot
-            </Button>
-          </HoverTooltip>
+              <Button
+                intent="primary"
+                fill={
+                  fetchAttempt.status === 'success' && bots.length === 0
+                    ? 'filled'
+                    : 'border'
+                }
+                ml="auto"
+                width="240px"
+                as={Link}
+                to={cfg.getBotsNewRoute()}
+                disabled={!hasAddBotPermissions}
+              >
+                Enroll New Bot
+              </Button>
+            </HoverTooltip>
+          </InfoGuideWrapper>
         </Box>
       </FeatureHeader>
       {fetchAttempt.status == 'failed' && (

--- a/web/packages/teleport/src/JoinTokens/JoinTokens.test.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokens.test.tsx
@@ -21,6 +21,7 @@ import selectEvent from 'react-select-event';
 import { act, fireEvent, render, screen, tick } from 'design/utils/testing';
 
 import { ContextProvider } from 'teleport';
+import { InfoGuidePanelProvider } from 'teleport/Main/InfoGuideContext';
 import { createTeleportContext } from 'teleport/mocks/contexts';
 import makeJoinToken from 'teleport/services/joinToken/makeJoinToken';
 
@@ -153,9 +154,11 @@ const Component = () => {
   );
 
   return (
-    <ContextProvider ctx={ctx}>
-      <JoinTokens />
-    </ContextProvider>
+    <InfoGuidePanelProvider>
+      <ContextProvider ctx={ctx}>
+        <JoinTokens />
+      </ContextProvider>
+    </InfoGuidePanelProvider>
   );
 };
 

--- a/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
@@ -58,7 +58,6 @@ import {
   InfoExternalTextLink,
   InfoGuideWrapper,
   InfoParagraph,
-  InfoTitle,
   ReferenceLinks,
 } from 'teleport/components/SlidingSidePanel/InfoGuideSidePanel';
 import useResources from 'teleport/components/useResources';
@@ -149,7 +148,7 @@ export const JoinTokens = () => {
       >
         <FeatureHeaderTitle>Join Tokens</FeatureHeaderTitle>
         {!creatingToken && !editingToken && (
-          <Flex alignItems="center" gap={2}>
+          <InfoGuideWrapper guide={<InfoGuide />}>
             <Button
               intent="primary"
               fill="border"
@@ -159,8 +158,7 @@ export const JoinTokens = () => {
             >
               Create New Token
             </Button>
-            <InfoGuideWrapper guide={<InfoGuide />} />
-          </Flex>
+          </InfoGuideWrapper>
         )}
       </FeatureHeader>
       <Flex>
@@ -488,7 +486,6 @@ const InfoGuideReferenceLinks = {
 
 const InfoGuide = () => (
   <Box>
-    <InfoTitle>Join Tokens</InfoTitle>
     <InfoParagraph>
       <InfoExternalTextLink href={InfoGuideReferenceLinks.JoinTokens.href}>
         Join Tokens

--- a/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
@@ -30,6 +30,7 @@ import {
   Indicator,
   Label,
   Link,
+  Mark,
   MenuItem,
   Text,
 } from 'design';
@@ -53,6 +54,13 @@ import {
   FeatureHeaderTitle,
 } from 'teleport/components/Layout';
 import ResourceEditor from 'teleport/components/ResourceEditor';
+import {
+  InfoExternalTextLink,
+  InfoGuideWrapper,
+  InfoParagraph,
+  InfoTitle,
+  ReferenceLinks,
+} from 'teleport/components/SlidingSidePanel/InfoGuideSidePanel';
 import useResources from 'teleport/components/useResources';
 import { JoinToken } from 'teleport/services/joinToken';
 import { KindJoinToken, Resource } from 'teleport/services/resources';
@@ -137,18 +145,22 @@ export const JoinTokens = () => {
           border-bottom: none;
         `}
         alignItems="center"
+        justifyContent="space-between"
       >
         <FeatureHeaderTitle>Join Tokens</FeatureHeaderTitle>
         {!creatingToken && !editingToken && (
-          <Button
-            intent="primary"
-            fill="border"
-            ml="auto"
-            width="240px"
-            onClick={() => setCreatingToken(true)}
-          >
-            Create New Token
-          </Button>
+          <Flex alignItems="center" gap={2}>
+            <Button
+              intent="primary"
+              fill="border"
+              ml="auto"
+              width="240px"
+              onClick={() => setCreatingToken(true)}
+            >
+              Create New Token
+            </Button>
+            <InfoGuideWrapper guide={<InfoGuide />} />
+          </Flex>
         )}
       </FeatureHeader>
       <Flex>
@@ -458,3 +470,58 @@ function Directions() {
     </>
   );
 }
+
+const InfoGuideReferenceLinks = {
+  JoinTokens: {
+    title: 'Join Tokens',
+    href: 'https://goteleport.com/docs/reference/join-methods/',
+  },
+  DelegatedJoinMethods: {
+    title: 'Delegated Join Methods',
+    href: 'https://goteleport.com/docs/reference/join-methods/#delegated-join-methods',
+  },
+  SecretBasedJoinMethods: {
+    title: 'Secret-based Join Methods',
+    href: 'https://goteleport.com/docs/reference/join-methods/#secret-based-join-methods',
+  },
+};
+
+const InfoGuide = () => (
+  <Box>
+    <InfoTitle>Join Tokens</InfoTitle>
+    <InfoParagraph>
+      <InfoExternalTextLink href={InfoGuideReferenceLinks.JoinTokens.href}>
+        Join Tokens
+      </InfoExternalTextLink>{' '}
+      are how a Teleport agent authenticates itself to the Teleport cluster.
+    </InfoParagraph>
+    <InfoParagraph>
+      There are Join Tokens for most types of infrastructure you can connect to
+      Teleport that establish an identity for that infrastructure using
+      metadata, such as AWS role, GitHub organization or TPM hash. These are
+      called{' '}
+      <InfoExternalTextLink
+        href={InfoGuideReferenceLinks.DelegatedJoinMethods.href}
+      >
+        delegated join methods
+      </InfoExternalTextLink>
+      . We recommend you use these methods whenever possible. When they are not
+      available, there are{' '}
+      <InfoExternalTextLink
+        href={InfoGuideReferenceLinks.SecretBasedJoinMethods.href}
+      >
+        secret-based join methods
+      </InfoExternalTextLink>{' '}
+      to fall back on.
+    </InfoParagraph>
+    <InfoParagraph>
+      Agents’ permission to provide different connection services are limited by
+      the system role of their join token. For example, if you want to provide
+      access to a HTTP application running on a server, but also want to provide
+      SSH access to that server, the join token it uses must have both the{' '}
+      <Mark>node</Mark>
+      and <Mark>app</Mark> permissions.
+    </InfoParagraph>
+    <ReferenceLinks links={Object.values(InfoGuideReferenceLinks)} />
+  </Box>
+);

--- a/web/packages/teleport/src/Main/Main.test.tsx
+++ b/web/packages/teleport/src/Main/Main.test.tsx
@@ -115,7 +115,7 @@ test('toggle rendering of info guide panel', async () => {
   fireEvent.click(screen.getByTestId('info-guide-btn-open'));
   expect(screen.getByText(/i am the guide/i)).toBeInTheDocument();
 
-  // test closing of panel
+  // test closing of panel by clicking on explicit close button
   fireEvent.click(screen.getByTestId('info-guide-btn-close'));
   expect(screen.queryByText(/i am the guide/i)).not.toBeInTheDocument();
 });

--- a/web/packages/teleport/src/Roles/Roles.test.tsx
+++ b/web/packages/teleport/src/Roles/Roles.test.tsx
@@ -21,6 +21,7 @@ import { MemoryRouter } from 'react-router';
 import { fireEvent, render, screen, waitFor } from 'design/utils/testing';
 
 import { ContextProvider } from 'teleport';
+import { InfoGuidePanelProvider } from 'teleport/Main/InfoGuideContext';
 import { createTeleportContext } from 'teleport/mocks/contexts';
 import { yamlService } from 'teleport/services/yaml';
 
@@ -66,9 +67,11 @@ describe('Roles list', () => {
     const ctx = createTeleportContext();
     render(
       <MemoryRouter>
-        <ContextProvider ctx={ctx}>
-          <Roles {...defaultState} />
-        </ContextProvider>
+        <InfoGuidePanelProvider>
+          <ContextProvider ctx={ctx}>
+            <Roles {...defaultState} />
+          </ContextProvider>
+        </InfoGuidePanelProvider>
       </MemoryRouter>
     );
 
@@ -89,9 +92,11 @@ describe('Roles list', () => {
 
     render(
       <MemoryRouter>
-        <ContextProvider ctx={ctx}>
-          <Roles {...testState} />
-        </ContextProvider>
+        <InfoGuidePanelProvider>
+          <ContextProvider ctx={ctx}>
+            <Roles {...testState} />
+          </ContextProvider>
+        </InfoGuidePanelProvider>
       </MemoryRouter>
     );
 
@@ -105,9 +110,11 @@ describe('Roles list', () => {
 
     render(
       <MemoryRouter>
-        <ContextProvider ctx={ctx}>
-          <Roles {...defaultState} />
-        </ContextProvider>
+        <InfoGuidePanelProvider>
+          <ContextProvider ctx={ctx}>
+            <Roles {...defaultState} />
+          </ContextProvider>
+        </InfoGuidePanelProvider>
       </MemoryRouter>
     );
 
@@ -134,9 +141,11 @@ describe('Roles list', () => {
 
     render(
       <MemoryRouter>
-        <ContextProvider ctx={ctx}>
-          <Roles {...testState} />
-        </ContextProvider>
+        <InfoGuidePanelProvider>
+          <ContextProvider ctx={ctx}>
+            <Roles {...testState} />
+          </ContextProvider>
+        </InfoGuidePanelProvider>
       </MemoryRouter>
     );
 
@@ -169,9 +178,11 @@ describe('Roles list', () => {
 
     render(
       <MemoryRouter>
-        <ContextProvider ctx={ctx}>
-          <Roles {...testState} />
-        </ContextProvider>
+        <InfoGuidePanelProvider>
+          <ContextProvider ctx={ctx}>
+            <Roles {...testState} />
+          </ContextProvider>
+        </InfoGuidePanelProvider>
       </MemoryRouter>
     );
 
@@ -204,9 +215,11 @@ describe('Roles list', () => {
 
     render(
       <MemoryRouter>
-        <ContextProvider ctx={ctx}>
-          <Roles {...testState} />
-        </ContextProvider>
+        <InfoGuidePanelProvider>
+          <ContextProvider ctx={ctx}>
+            <Roles {...testState} />
+          </ContextProvider>
+        </InfoGuidePanelProvider>
       </MemoryRouter>
     );
 
@@ -233,9 +246,11 @@ describe('Roles list', () => {
 
     render(
       <MemoryRouter>
-        <ContextProvider ctx={ctx}>
-          <Roles {...testState} />
-        </ContextProvider>
+        <InfoGuidePanelProvider>
+          <ContextProvider ctx={ctx}>
+            <Roles {...testState} />
+          </ContextProvider>
+        </InfoGuidePanelProvider>
       </MemoryRouter>
     );
 
@@ -280,21 +295,23 @@ test('renders the role diff component', async () => {
 
   render(
     <MemoryRouter>
-      <ContextProvider ctx={ctx}>
-        <Roles
-          {...defaultState()}
-          roleDiffProps={{
-            roleDiffElement,
-            updateRoleDiff: () => null,
-            roleDiffAttempt: {
-              status: 'error',
-              statusText: 'there is an error here',
-              data: null,
-              error: null,
-            },
-          }}
-        />
-      </ContextProvider>
+      <InfoGuidePanelProvider>
+        <ContextProvider ctx={ctx}>
+          <Roles
+            {...defaultState()}
+            roleDiffProps={{
+              roleDiffElement,
+              updateRoleDiff: () => null,
+              roleDiffAttempt: {
+                status: 'error',
+                statusText: 'there is an error here',
+                data: null,
+                error: null,
+              },
+            }}
+          />
+        </ContextProvider>
+      </InfoGuidePanelProvider>
     </MemoryRouter>
   );
   await openEditor();

--- a/web/packages/teleport/src/Roles/Roles.tsx
+++ b/web/packages/teleport/src/Roles/Roles.tsx
@@ -40,7 +40,6 @@ import {
   InfoExternalTextLink,
   InfoGuideWrapper,
   InfoParagraph,
-  InfoTitle,
   ReferenceLinks,
 } from 'teleport/components/SlidingSidePanel/InfoGuideSidePanel';
 import useResources from 'teleport/components/useResources';
@@ -327,7 +326,6 @@ const InfoGuideReferenceLinks = {
 function InfoGuide() {
   return (
     <Box>
-      <InfoTitle>Role-based access control</InfoTitle>
       <InfoParagraph>
         Teleport Role-based access control (RBAC) provides fine-grained control
         over who can access resources and in which contexts. A Teleport role can

--- a/web/packages/teleport/src/Roles/Roles.tsx
+++ b/web/packages/teleport/src/Roles/Roles.tsx
@@ -19,8 +19,7 @@
 import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
-import { Alert, Box, Button, Flex, H3, Link } from 'design';
-import { P } from 'design/Text/Text';
+import { Alert, Box, Button, Flex, Link } from 'design';
 import { HoverTooltip } from 'design/Tooltip';
 import { MissingPermissionsTooltip } from 'shared/components/MissingPermissionsTooltip';
 import {
@@ -37,6 +36,13 @@ import {
   FeatureHeaderTitle,
 } from 'teleport/components/Layout';
 import ResourceEditor from 'teleport/components/ResourceEditor';
+import {
+  InfoExternalTextLink,
+  InfoGuideWrapper,
+  InfoParagraph,
+  InfoTitle,
+  ReferenceLinks,
+} from 'teleport/components/SlidingSidePanel/InfoGuideSidePanel';
 import useResources from 'teleport/components/useResources';
 import { Role, RoleResource, RoleWithYaml } from 'teleport/services/resources';
 import { storageService } from 'teleport/services/storageService';
@@ -189,41 +195,43 @@ export function Roles(props: State & RolesProps) {
     <FeatureBox>
       <FeatureHeader alignItems="center" justifyContent="space-between">
         <FeatureHeaderTitle>Roles</FeatureHeaderTitle>
-        <HoverTooltip
-          position="bottom"
-          tipContent={
-            !canCreate ? (
-              <MissingPermissionsTooltip
-                missingPermissions={['roles.create']}
-              />
-            ) : (
-              ''
-            )
-          }
-        >
-          <Button
-            data-testid="create_new_role_button"
-            intent="primary"
-            fill={
-              serverSidePagination.attempt.status === 'success' &&
-              serverSidePagination.fetchedData.agents.length === 0
-                ? 'filled'
-                : 'border'
+        <InfoGuideWrapper guide={<InfoGuide />}>
+          <HoverTooltip
+            position="bottom"
+            tipContent={
+              !canCreate ? (
+                <MissingPermissionsTooltip
+                  missingPermissions={['roles.create']}
+                />
+              ) : (
+                ''
+              )
             }
-            ml="auto"
-            width="240px"
-            disabled={!canCreate}
-            onClick={handleCreate}
           >
-            Create New Role
-          </Button>
-        </HoverTooltip>
+            <Button
+              data-testid="create_new_role_button"
+              intent="primary"
+              fill={
+                serverSidePagination.attempt.status === 'success' &&
+                serverSidePagination.fetchedData.agents.length === 0
+                  ? 'filled'
+                  : 'border'
+              }
+              ml="auto"
+              width="240px"
+              disabled={!canCreate}
+              onClick={handleCreate}
+            >
+              Create New Role
+            </Button>
+          </HoverTooltip>
+        </InfoGuideWrapper>
       </FeatureHeader>
       {serverSidePagination.attempt.status === 'failed' && (
         <Alert children={serverSidePagination.attempt.statusText} />
       )}
       <Flex flex="1">
-        <Box flex="1" mr="6" mb="4">
+        <Box flex="1" mb="4">
           <RoleList
             serversidePagination={serverSidePagination}
             onSearchChange={setSearch}
@@ -249,31 +257,6 @@ export function Roles(props: State & RolesProps) {
             roleDiffProps={props.roleDiffProps}
           />
         )}
-        <Box
-          ml="auto"
-          width="240px"
-          color="text.main"
-          style={{ flexShrink: 0 }}
-        >
-          <H3 mb={3}>Role-based access control</H3>
-          <P mb={3}>
-            Teleport Role-based access control (RBAC) provides fine-grained
-            control over who can access resources and in which contexts. A
-            Teleport role can be assigned automatically based on user identity
-            when used with single sign-on (SSO).
-          </P>
-          <P>
-            Learn more in{' '}
-            <Link
-              color="text.main"
-              target="_blank"
-              href="https://goteleport.com/docs/admin-guides/access-controls/guides/role-templates/"
-            >
-              the cluster management (RBAC)
-            </Link>{' '}
-            section of online documentation.
-          </P>
-        </Box>
       </Flex>
 
       {/* Old editor. */}
@@ -327,6 +310,44 @@ function Directions() {
       </Link>
       . YAML is sensitive to white space, so please be careful.
     </>
+  );
+}
+
+const InfoGuideReferenceLinks = {
+  PresetRoles: {
+    title: 'Teleport Preset Roles',
+    href: 'https://goteleport.com/docs/reference/access-controls/roles/#preset-roles',
+  },
+  RoleTemplates: {
+    title: 'Teleport Role Templates',
+    href: 'https://goteleport.com/docs/admin-guides/access-controls/guides/role-templates/',
+  },
+};
+
+function InfoGuide() {
+  return (
+    <Box>
+      <InfoTitle>Role-based access control</InfoTitle>
+      <InfoParagraph>
+        Teleport Role-based access control (RBAC) provides fine-grained control
+        over who can access resources and in which contexts. A Teleport role can
+        be assigned automatically based on user identity when used with single
+        sign-on (SSO).
+      </InfoParagraph>
+      <InfoParagraph>
+        New clusters have several{' '}
+        <InfoExternalTextLink href={InfoGuideReferenceLinks.PresetRoles.href}>
+          preset roles
+        </InfoExternalTextLink>
+        . These are convenient for getting started but are very permissive, and
+        we recommend you follow our{' '}
+        <InfoExternalTextLink href={InfoGuideReferenceLinks.RoleTemplates.href}>
+          best practices guide
+        </InfoExternalTextLink>{' '}
+        to create your own.
+      </InfoParagraph>
+      <ReferenceLinks links={Object.values(InfoGuideReferenceLinks)} />
+    </Box>
   );
 }
 

--- a/web/packages/teleport/src/Users/Users.test.tsx
+++ b/web/packages/teleport/src/Users/Users.test.tsx
@@ -21,6 +21,7 @@ import { MemoryRouter } from 'react-router';
 import { fireEvent, render, screen, userEvent } from 'design/utils/testing';
 
 import { ContextProvider } from 'teleport';
+import { InfoGuidePanelProvider } from 'teleport/Main/InfoGuideContext';
 import { createTeleportContext } from 'teleport/mocks/contexts';
 import { Access } from 'teleport/services/user';
 
@@ -75,9 +76,11 @@ describe('invite collaborators integration', () => {
   test('displays the Create New User button when not configured', async () => {
     render(
       <MemoryRouter>
-        <ContextProvider ctx={ctx}>
-          <Users {...props} />
-        </ContextProvider>
+        <InfoGuidePanelProvider>
+          <ContextProvider ctx={ctx}>
+            <Users {...props} />
+          </ContextProvider>
+        </InfoGuidePanelProvider>
       </MemoryRouter>
     );
 
@@ -97,9 +100,11 @@ describe('invite collaborators integration', () => {
 
     render(
       <MemoryRouter>
-        <ContextProvider ctx={ctx}>
-          <Users {...props} />
-        </ContextProvider>
+        <InfoGuidePanelProvider>
+          <ContextProvider ctx={ctx}>
+            <Users {...props} />
+          </ContextProvider>
+        </InfoGuidePanelProvider>
       </MemoryRouter>
     );
 
@@ -155,9 +160,11 @@ test('Users not equal to MAU Notice', async () => {
 
   render(
     <MemoryRouter>
-      <ContextProvider ctx={ctx}>
-        <Users {...props} />
-      </ContextProvider>
+      <InfoGuidePanelProvider>
+        <ContextProvider ctx={ctx}>
+          <Users {...props} />
+        </ContextProvider>
+      </InfoGuidePanelProvider>
     </MemoryRouter>
   );
 
@@ -210,9 +217,11 @@ describe('email password reset integration', () => {
   test('displays the traditional reset UI when not configured', async () => {
     render(
       <MemoryRouter>
-        <ContextProvider ctx={ctx}>
-          <Users {...props} />
-        </ContextProvider>
+        <InfoGuidePanelProvider>
+          <ContextProvider ctx={ctx}>
+            <Users {...props} />
+          </ContextProvider>
+        </InfoGuidePanelProvider>
       </MemoryRouter>
     );
 
@@ -230,9 +239,11 @@ describe('email password reset integration', () => {
 
     render(
       <MemoryRouter>
-        <ContextProvider ctx={ctx}>
-          <Users {...props} />
-        </ContextProvider>
+        <InfoGuidePanelProvider>
+          <ContextProvider ctx={ctx}>
+            <Users {...props} />
+          </ContextProvider>
+        </InfoGuidePanelProvider>
       </MemoryRouter>
     );
 
@@ -301,9 +312,11 @@ describe('permission handling', () => {
     };
     render(
       <MemoryRouter>
-        <ContextProvider ctx={ctx}>
-          <Users {...testProps} />
-        </ContextProvider>
+        <InfoGuidePanelProvider>
+          <ContextProvider ctx={ctx}>
+            <Users {...testProps} />
+          </ContextProvider>
+        </InfoGuidePanelProvider>
       </MemoryRouter>
     );
 
@@ -320,9 +333,11 @@ describe('permission handling', () => {
     };
     render(
       <MemoryRouter>
-        <ContextProvider ctx={ctx}>
-          <Users {...testProps} />
-        </ContextProvider>
+        <InfoGuidePanelProvider>
+          <ContextProvider ctx={ctx}>
+            <Users {...testProps} />
+          </ContextProvider>
+        </InfoGuidePanelProvider>
       </MemoryRouter>
     );
 
@@ -348,9 +363,11 @@ describe('permission handling', () => {
     };
     render(
       <MemoryRouter>
-        <ContextProvider ctx={ctx}>
-          <Users {...testProps} />
-        </ContextProvider>
+        <InfoGuidePanelProvider>
+          <ContextProvider ctx={ctx}>
+            <Users {...testProps} />
+          </ContextProvider>
+        </InfoGuidePanelProvider>
       </MemoryRouter>
     );
 
@@ -383,9 +400,11 @@ describe('permission handling', () => {
     };
     render(
       <MemoryRouter>
-        <ContextProvider ctx={ctx}>
-          <Users {...testProps} />
-        </ContextProvider>
+        <InfoGuidePanelProvider>
+          <ContextProvider ctx={ctx}>
+            <Users {...testProps} />
+          </ContextProvider>
+        </InfoGuidePanelProvider>
       </MemoryRouter>
     );
 

--- a/web/packages/teleport/src/Users/Users.tsx
+++ b/web/packages/teleport/src/Users/Users.tsx
@@ -17,8 +17,17 @@
  */
 
 import React from 'react';
+import { Link as InternalLink } from 'react-router-dom';
 
-import { Alert, Box, Button, Flex, Indicator, Link, Text } from 'design';
+import {
+  Alert,
+  Box,
+  Button,
+  Link as ExternalLink,
+  Flex,
+  Indicator,
+  Text,
+} from 'design';
 import { HoverTooltip } from 'design/Tooltip';
 
 import {
@@ -26,6 +35,15 @@ import {
   FeatureHeader,
   FeatureHeaderTitle,
 } from 'teleport/components/Layout';
+import {
+  InfoExternalTextLink,
+  InfoGuideWrapper,
+  InfoParagraph,
+  InfoTitle,
+  InfoUl,
+  ReferenceLinks,
+} from 'teleport/components/SlidingSidePanel/InfoGuideSidePanel';
+import cfg from 'teleport/config';
 
 import UserAddEdit from './UserAddEdit';
 import UserDelete from './UserDelete';
@@ -82,7 +100,7 @@ export function Users(props: State) {
       <FeatureHeader justifyContent="space-between">
         <FeatureHeaderTitle>Users</FeatureHeaderTitle>
         {attempt.isSuccess && (
-          <>
+          <Flex gap={2}>
             {!InviteCollaborators && (
               <HoverTooltip
                 position="bottom"
@@ -141,7 +159,8 @@ export function Users(props: State) {
                 Enroll Users
               </Button>
             )}
-          </>
+            <InfoGuideWrapper guide={<InfoGuide />} />
+          </Flex>
         )}
       </FeatureHeader>
       {attempt.isProcessing && (
@@ -166,20 +185,20 @@ export function Users(props: State) {
           Sign-On (SSO) providers such as Okta may only appear here temporarily
           and disappear once their sessions expire. For more information, read
           our documentation on{' '}
-          <Link
+          <ExternalLink
             target="_blank"
             href="https://goteleport.com/docs/usage-billing/#monthly-active-users"
             className="external-link"
           >
             MAU
-          </Link>{' '}
+          </ExternalLink>{' '}
           and{' '}
-          <Link
+          <ExternalLink
             href="https://goteleport.com/docs/reference/user-types/"
             className="external-link"
           >
             User Types
-          </Link>
+          </ExternalLink>
           .
         </Alert>
       )}
@@ -232,3 +251,39 @@ export function Users(props: State) {
     </FeatureBox>
   );
 }
+
+const InfoGuideReferenceLinks = {
+  Users: {
+    title: 'Teleport Users',
+    href: 'https://goteleport.com/docs/core-concepts/#teleport-users',
+  },
+};
+
+const InfoGuide = () => (
+  <Box>
+    <InfoTitle>Users</InfoTitle>
+    <InfoParagraph>
+      Teleport allows for two kinds of{' '}
+      <InfoExternalTextLink href={InfoGuideReferenceLinks.Users}>
+        users
+      </InfoExternalTextLink>
+      :
+      <InfoUl>
+        <li>
+          <b>Local</b> users are created and managed in Teleport and stored in
+          the Auth Service backend.
+        </li>
+        <li>
+          <b>Single Sign-On (SSO)</b> users are stored on the backend of your
+          SSO solution, e.g., Okta or GitHub. SSO can be set up with an{' '}
+          <InternalLink to={cfg.routes.sso}>Auth Connector</InternalLink>.
+        </li>
+      </InfoUl>
+    </InfoParagraph>
+    <InfoParagraph>
+      To take any action in Teleport, users must have at least one{' '}
+      <InternalLink to={cfg.routes.roles}>Role</InternalLink> assigned.
+    </InfoParagraph>
+    <ReferenceLinks links={Object.values(InfoGuideReferenceLinks)} />
+  </Box>
+);

--- a/web/packages/teleport/src/Users/Users.tsx
+++ b/web/packages/teleport/src/Users/Users.tsx
@@ -39,7 +39,6 @@ import {
   InfoExternalTextLink,
   InfoGuideWrapper,
   InfoParagraph,
-  InfoTitle,
   InfoUl,
   ReferenceLinks,
 } from 'teleport/components/SlidingSidePanel/InfoGuideSidePanel';
@@ -261,10 +260,9 @@ const InfoGuideReferenceLinks = {
 
 const InfoGuide = () => (
   <Box>
-    <InfoTitle>Users</InfoTitle>
     <InfoParagraph>
       Teleport allows for two kinds of{' '}
-      <InfoExternalTextLink href={InfoGuideReferenceLinks.Users}>
+      <InfoExternalTextLink href={InfoGuideReferenceLinks.Users.href}>
         users
       </InfoExternalTextLink>
       :


### PR DESCRIPTION
This PR just replaces visible side blocks that had docs, with a sliding side panel that is hidden by default. Users will have to click on the `info icon` to slide open the info panel

screenshots:

<details>
<summary>auth connector editor:</summary>
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/dd725fe1-7177-46fb-832f-80cb6b64aad8" />
</details>

<details>
<summary>auth connector:</summary>
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/f8e6abbf-24d4-480f-9e3a-82ce50d92b86" />
</details>

<details>
<summary>add bots</summary>
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/61bc3ea8-8d8a-4eb6-8fe3-bed12fc81074" />
</details>

<details>
<summary>bots list</summary>
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/cc5fdd9d-a6ed-4d04-a0be-245bdd302320" />
</details>

<details>
<summary>join tokens</summary>
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/2123ae19-7458-4830-9406-8a3aa58672cc" />
</details>

<details>
<summary>roles</summary>
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/2d9f05c6-8bad-4097-bf7e-663af87cf2e0" />
</details>

<details>
<summary>users</summary>
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/00fa2383-d09b-4473-a9f4-ad09da495526" />
</details>



