### PR TITLE
Machine ID: Document `kubernetes/v2` service

### DIFF
--- a/docs/pages/enroll-resources/machine-id/faq.mdx
+++ b/docs/pages/enroll-resources/machine-id/faq.mdx
@@ -105,6 +105,6 @@ Note that both `tbot` and the Teleport Proxy need to be running v17.2.7 to take
 advantage of this functionality.
 
 Refer to the
-[CLI reference](../../reference/cli/tbot#tbot-start-kubernetesv2) and
+[CLI reference](../../reference/cli/tbot.mdx#tbot-start-kubernetesv2) and
 [config reference](../../reference/machine-id/configuration.mdx#kubernetesv2)
 for more information.

--- a/docs/pages/enroll-resources/machine-id/faq.mdx
+++ b/docs/pages/enroll-resources/machine-id/faq.mdx
@@ -93,3 +93,15 @@ If your use case absolutely requires long-lived certificates,
 [`tctl auth sign`](../../reference/cli/tctl.mdx#tctl-auth-sign) can
 alternatively be used, however this loses the security benefits of Machine ID's
 short-lived renewable certificates.
+
+## Can Machine ID be used to connect to multiple Kubernetes clusters?
+
+This is possible in Teleport v17.2.7 or higher, using the new `kubernetes/v2`
+output type in `tbot`. This service can expose many clusters at once via
+contexts in the generated `kubeconfig.yaml`, and if label selectors are used,
+will dynamically add contexts as clusters are added and removed in Teleport.
+
+Refer to the
+[CLI reference](../../reference/cli/tbot#tbot-start-kubernetesv2) and
+[config reference](../../reference/machine-id/configuration.mdx#kubernetesv2)
+for more information.

--- a/docs/pages/enroll-resources/machine-id/faq.mdx
+++ b/docs/pages/enroll-resources/machine-id/faq.mdx
@@ -101,6 +101,9 @@ output type in `tbot`. This service can expose many clusters at once via
 contexts in the generated `kubeconfig.yaml`, and if label selectors are used,
 will dynamically add contexts as clusters are added and removed in Teleport.
 
+Note that both `tbot` and the Teleport Proxy need to be running v17.2.7 to take
+advantage of this functionality.
+
 Refer to the
 [CLI reference](../../reference/cli/tbot#tbot-start-kubernetesv2) and
 [config reference](../../reference/machine-id/configuration.mdx#kubernetesv2)

--- a/docs/pages/reference/cli/tbot.mdx
+++ b/docs/pages/reference/cli/tbot.mdx
@@ -427,6 +427,54 @@ command supports these additional flags:
 | `--reader-group`       | An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux. |
 | `--kubernetes-cluster` | The name of the Kubernetes cluster in Teleport for which to fetch credentials |
 
+## tbot start kubernetes/v2
+
+Starts the Machine ID client `tbot` with a Kubernetes V2 output, fetching and
+writing Kubernetes credentials to a `kubeconfig.yaml` at a regular interval to
+the output specified with `--destination`.
+
+Unlike the `kubernetes` output, `kubernetes/v2` allows fetching many Kubernetes
+clusters at once, as multiple contexts within the generated `kubeconfig.yaml`.
+If label selectors are used and clusters are added or removed, the list of
+clusters will be updated on the bot's next renewal. At least one selector -
+either name or label - is required.
+
+Note that as with human users using `tsh kube ls`, only clusters the bot user
+has permission to access will be matched. Additionally, note that label
+selectors do not currently support wildcards.
+
+### Flags
+
+In addition to the [common `tbot start` flags](#common-start-flags), this
+command supports these additional flags:
+
+| Flag                    | Description |
+|-------------------------|-------------|
+| `--destination`         | A destination URI, such as file:///foo/bar. See [Destination URIs](#destination-uris) for more info. Required. |
+| `--reader-user`         | An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux. |
+| `--reader-group`        | An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux. |
+| `--name-selector`       | Selects a Kubernetes cluster by exact name match. Repeatable. |
+| `--label-selector`      | Selects many Kubernetes clusters by label match, e.g. `env=dev,role=ci`. Repeatable. |
+| `--disable-exec-plugin` | If set, disables the exec plugin. Allows credentials to be used without the `tbot` binary. |
+
+### Examples
+
+First, run `tbot` to generate credentials:
+
+```code
+$ tbot start kubernetes/v2 --proxy-server=example.teleport.sh:443 --destination=./example --label-selector env=dev --name-selector example --oneshot
+```
+
+This will fetch credentials for all clusters with the label `env: dev`, plus the
+cluster named `example`. You can then access the clusters using `kubectl`:
+
+```code
+$ kubectl --kubeconfig ./example/kubeconfig.yaml --context example.teleport.sh-example get pods
+```
+
+You can inspect the generated `kubeconfig.yaml` to see which clusters were
+matched by the label selector.
+
 ## tbot start application
 
 Starts the Machine ID client `tbot` with an application output, fetching and

--- a/docs/pages/reference/cli/tbot.mdx
+++ b/docs/pages/reference/cli/tbot.mdx
@@ -450,7 +450,7 @@ command supports these additional flags:
 
 | Flag                    | Description |
 |-------------------------|-------------|
-| `--destination`         | A destination URI, such as file:///foo/bar. See [Destination URIs](#destination-uris) for more info. Required. |
+| `--destination`         | A destination URI, such as `file:///foo/bar`. See [Destination URIs](#destination-uris) for more info. Required. |
 | `--reader-user`         | An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux. |
 | `--reader-group`        | An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux. |
 | `--name-selector`       | Selects a Kubernetes cluster by exact name match. Repeatable. |

--- a/docs/pages/reference/machine-id/configuration.mdx
+++ b/docs/pages/reference/machine-id/configuration.mdx
@@ -294,6 +294,58 @@ kubernetes_cluster: my-cluster
 (!docs/pages/includes/machine-id/common-output-config.yaml!)
 ```
 
+### `kubernetes/v2`
+
+The `kubernetes/v2` output type can be used to access many Kubernetes clusters
+as individual contexts within the same `kubeconfig.yaml`.
+
+```yaml
+type: kubernetes/v2
+
+# selectors include one or more matching Kubernetes clusters. Each match will be
+# included in the resulting `kubeconfig.yaml`, assuming the bot has permission
+# to access the cluster.
+selectors:
+  # name includes an exact match by name. Note that wildcards are not currently
+  # supported. Multiple name selectors can be specified if desired.
+  - name: foo
+  # labels include all clusters matching all of these labels. Multiple label
+  # selectors can be provided if needed.
+  - labels:
+      env: dev
+
+# The following configuration fields are available across most output types.
+# Note that `roles` are not supported for this output type.
+
+destination:
+  type: directory
+  path: /opt/machine-id
+
+# credential_ttl and renewal_interval override the credential TTL and renewal
+# interval for this specific output, so that you can make its certificates valid
+# for shorter than `tbot`'s internal certificates.
+#
+# This is particularly useful when using `tbot` in one-shot as part of a cron job
+# where you need `tbot`'s internal certificate to live long enough to be renewed
+# on the next invocation, but don't want long-lived workload certificates on-disk.
+credential_ttl: 30m
+renewal_interval: 15m
+```
+
+Each Kubernetes cluster matching a selector will result in a new context in the
+generated `kubeconfig.yaml`. This can be consumed like so:
+
+```code
+$ kubectl --kubeconfig /opt/machine-id/kubeconfig.yaml --context=example.teleport.sh-foo get pods
+```
+
+The context name is `[Teleport cluster name]-[Kubernetes cluster name]`, so the
+command above runs `kubectl get pods` on the `foo` cluster.
+
+If clusters are added or removed over time, the `kubeconfig.yaml` will be
+updated at the bot's normal renewal interval. You can trigger an early renewal
+by restarting `tbot`, or signaling it with `pkill -usr1 tbot`.
+
 ### `ssh_host`
 
 The `ssh_host` output is used to generate the artifacts required to configure


### PR DESCRIPTION
This adds initial documentation for the new `kubernetes/v2` service.

This only includes reference documentation for now, since this service was added partway through v17; the existing Kubernetes guide will be updated in a separate PR for v18 and won't be backported to v17.

Updates #52412