### PR TITLE
Align semver libs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -122,7 +122,9 @@ linters-settings:
           - pkg: golang.org/x/exp/slices
             desc: 'use "slices" instead'
           - pkg: github.com/hashicorp/go-version
-            desc: 'use "golang.org/x/mod/semver" or "coreos/go-semver/semver" instead'
+            desc: 'use "coreos/go-semver/semver" instead'
+          - pkg: golang.org/x/mod/semver
+            desc: 'use "coreos/go-semver/semver" instead'
           - pkg: github.com/microsoftgraph/msgraph-sdk-go
             desc: 'use "github.com/gravitational/teleport/lib/msgraph" instead'
           - pkg: github.com/cloudflare/cfssl

--- a/build.assets/tooling/cmd/check/main.go
+++ b/build.assets/tooling/cmd/check/main.go
@@ -30,7 +30,7 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
-	"golang.org/x/mod/semver" //nolint:depguard
+	"golang.org/x/mod/semver" //nolint:depguard // Usage precedes the x/mod/semver rule.
 
 	"github.com/gravitational/teleport/build.assets/tooling/lib/github"
 )

--- a/build.assets/tooling/cmd/check/main.go
+++ b/build.assets/tooling/cmd/check/main.go
@@ -30,7 +30,7 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
-	"golang.org/x/mod/semver"
+	"golang.org/x/mod/semver" //nolint:depguard
 
 	"github.com/gravitational/teleport/build.assets/tooling/lib/github"
 )

--- a/build.assets/tooling/cmd/query-latest/main.go
+++ b/build.assets/tooling/cmd/query-latest/main.go
@@ -37,7 +37,7 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
-	"golang.org/x/mod/semver" //nolint:depguard
+	"golang.org/x/mod/semver" //nolint:depguard // Usage precedes the x/mod/semver rule.
 
 	"github.com/gravitational/teleport/build.assets/tooling/lib/github"
 )

--- a/build.assets/tooling/cmd/query-latest/main.go
+++ b/build.assets/tooling/cmd/query-latest/main.go
@@ -37,7 +37,7 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
-	"golang.org/x/mod/semver"
+	"golang.org/x/mod/semver" //nolint:depguard
 
 	"github.com/gravitational/teleport/build.assets/tooling/lib/github"
 )

--- a/e_imports.go
+++ b/e_imports.go
@@ -119,7 +119,7 @@ import (
 	_ "golang.org/x/crypto/ssh"
 	_ "golang.org/x/crypto/ssh/agent"
 	_ "golang.org/x/exp/constraints"
-	_ "golang.org/x/mod/semver"
+	_ "golang.org/x/mod/semver" //nolint:depguard
 	_ "golang.org/x/net/html"
 	_ "golang.org/x/net/http/httpproxy"
 	_ "golang.org/x/net/http2"

--- a/e_imports.go
+++ b/e_imports.go
@@ -119,7 +119,7 @@ import (
 	_ "golang.org/x/crypto/ssh"
 	_ "golang.org/x/crypto/ssh/agent"
 	_ "golang.org/x/exp/constraints"
-	_ "golang.org/x/mod/semver" //nolint:depguard
+	_ "golang.org/x/mod/semver" //nolint:depguard // Usage precedes the x/mod/semver rule.
 	_ "golang.org/x/net/html"
 	_ "golang.org/x/net/http/httpproxy"
 	_ "golang.org/x/net/http2"

--- a/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
+++ b/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
@@ -30,7 +30,6 @@ import (
 	"github.com/distribution/reference"
 	"github.com/go-logr/logr"
 	"github.com/gravitational/trace"
-	"golang.org/x/mod/semver"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -252,7 +251,7 @@ func main() {
 	case insecureNoVerify:
 		ctrl.Log.Info("INSECURE: Image validation disabled")
 		imageValidators = append(imageValidators, img.NewInsecureValidator("insecure always verified", kc))
-	case semver.Prerelease("v"+kubeversionupdater.Version) != "":
+	case kubeversionupdater.SemVersion != nil && kubeversionupdater.SemVersion.PreRelease != "":
 		ctrl.Log.Info("This is a pre-release updater version, the key used to sign dev and pre-release builds of Teleport will be trusted.")
 		validator, err := img.NewCosignSingleKeyValidator(teleportStageOCIPubKey, "staging cosign signature validator", kc)
 		if err != nil {

--- a/integrations/kube-agent-updater/pkg/controller/updater.go
+++ b/integrations/kube-agent-updater/pkg/controller/updater.go
@@ -20,8 +20,8 @@ package controller
 
 import (
 	"context"
-	"strings"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/distribution/reference"
 	"github.com/gravitational/trace"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -44,7 +44,7 @@ type VersionUpdater struct {
 // validating the new image signature.
 // If all steps are successfully executed and there's a new version, it returns
 // a digested reference to the new image that should be deployed.
-func (r *VersionUpdater) GetVersion(ctx context.Context, obj client.Object, currentVersion string) (img.NamedTaggedDigested, error) {
+func (r *VersionUpdater) GetVersion(ctx context.Context, obj client.Object, currentVersion *semver.Version) (img.NamedTaggedDigested, error) {
 	// Those are debug logs only
 	log := ctrllog.FromContext(ctx).V(1)
 
@@ -68,7 +68,7 @@ func (r *VersionUpdater) GetVersion(ctx context.Context, obj client.Object, curr
 
 	log.Info("Version change is valid, building img candidate")
 	// We tag our img candidate with the version
-	image, err := reference.WithTag(r.baseImage, strings.TrimPrefix(nextVersion, "v"))
+	image, err := reference.WithTag(r.baseImage, nextVersion.String())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/integrations/kube-agent-updater/pkg/controller/updater_test.go
+++ b/integrations/kube-agent-updater/pkg/controller/updater_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/distribution/reference"
 	"github.com/gravitational/trace"
 	"github.com/opencontainers/go-digest"
@@ -63,6 +64,13 @@ func errorIsType(errType interface{}) require.ErrorAssertionFunc {
 	}
 }
 
+func mustNewStaticGetter(t *testing.T, versionMock string, errMock error) version.Getter {
+	t.Helper()
+	getter, err := version.NewStaticGetter(versionMock, errMock)
+	require.NoError(t, err)
+	return getter
+}
+
 func Test_VersionUpdater_GetVersion(t *testing.T) {
 	ctx := context.Background()
 
@@ -70,7 +78,7 @@ func Test_VersionUpdater_GetVersion(t *testing.T) {
 		name                string
 		releaseRegistry     string
 		releasePath         string
-		currentVersion      string
+		currentVersion      *semver.Version
 		versionGetter       version.Getter
 		maintenanceTriggers []maintenance.Trigger
 		imageCheckers       []img.Validator
@@ -81,8 +89,8 @@ func Test_VersionUpdater_GetVersion(t *testing.T) {
 			name:                "all good",
 			releaseRegistry:     defaultTestRegistry,
 			releasePath:         defaultTestPath,
-			currentVersion:      versionMid,
-			versionGetter:       version.NewStaticGetter(versionHigh, nil),
+			currentVersion:      semver.Must(version.EnsureSemver(versionMid)),
+			versionGetter:       mustNewStaticGetter(t, versionHigh, nil),
 			maintenanceTriggers: []maintenance.Trigger{alwaysTrigger},
 			imageCheckers:       []img.Validator{alwaysValid},
 			assertErr:           require.NoError,
@@ -92,8 +100,8 @@ func Test_VersionUpdater_GetVersion(t *testing.T) {
 			name:                "all good but no current version",
 			releaseRegistry:     defaultTestRegistry,
 			releasePath:         defaultTestPath,
-			currentVersion:      "",
-			versionGetter:       version.NewStaticGetter(versionHigh, nil),
+			currentVersion:      nil,
+			versionGetter:       mustNewStaticGetter(t, versionHigh, nil),
 			maintenanceTriggers: []maintenance.Trigger{alwaysTrigger},
 			imageCheckers:       []img.Validator{alwaysValid},
 			assertErr:           require.NoError,
@@ -103,8 +111,8 @@ func Test_VersionUpdater_GetVersion(t *testing.T) {
 			name:                "same version",
 			releaseRegistry:     defaultTestRegistry,
 			releasePath:         defaultTestPath,
-			currentVersion:      versionMid,
-			versionGetter:       version.NewStaticGetter(versionMid, nil),
+			currentVersion:      semver.Must(version.EnsureSemver(versionMid)),
+			versionGetter:       mustNewStaticGetter(t, versionMid, nil),
 			maintenanceTriggers: []maintenance.Trigger{alwaysTrigger},
 			imageCheckers:       []img.Validator{alwaysValid},
 			assertErr:           errorIsType(&version.NoNewVersionError{}),
@@ -114,8 +122,8 @@ func Test_VersionUpdater_GetVersion(t *testing.T) {
 			name:                "no version",
 			releaseRegistry:     defaultTestRegistry,
 			releasePath:         defaultTestPath,
-			currentVersion:      versionMid,
-			versionGetter:       version.NewStaticGetter("", &version.NoNewVersionError{Message: "version server did not advertise a version"}),
+			currentVersion:      semver.Must(version.EnsureSemver(versionMid)),
+			versionGetter:       mustNewStaticGetter(t, "", &version.NoNewVersionError{Message: "version server did not advertise a version"}),
 			maintenanceTriggers: []maintenance.Trigger{alwaysTrigger},
 			imageCheckers:       []img.Validator{alwaysValid},
 			assertErr:           errorIsType(&version.NoNewVersionError{}),
@@ -125,8 +133,8 @@ func Test_VersionUpdater_GetVersion(t *testing.T) {
 			name:                "no maintenance triggered",
 			releaseRegistry:     defaultTestRegistry,
 			releasePath:         defaultTestPath,
-			currentVersion:      versionMid,
-			versionGetter:       version.NewStaticGetter(versionHigh, nil),
+			currentVersion:      semver.Must(version.EnsureSemver(versionMid)),
+			versionGetter:       mustNewStaticGetter(t, versionHigh, nil),
 			maintenanceTriggers: []maintenance.Trigger{neverTrigger},
 			imageCheckers:       []img.Validator{alwaysValid},
 			assertErr:           errorIsType(&MaintenanceNotTriggeredError{}),
@@ -136,8 +144,8 @@ func Test_VersionUpdater_GetVersion(t *testing.T) {
 			name:                "invalid signature",
 			releaseRegistry:     defaultTestRegistry,
 			releasePath:         defaultTestPath,
-			currentVersion:      versionMid,
-			versionGetter:       version.NewStaticGetter(versionHigh, nil),
+			currentVersion:      semver.Must(version.EnsureSemver(versionMid)),
+			versionGetter:       mustNewStaticGetter(t, versionHigh, nil),
 			maintenanceTriggers: []maintenance.Trigger{alwaysTrigger},
 			imageCheckers:       []img.Validator{neverValid},
 			assertErr:           errorIsType(&trace.TrustError{}),
@@ -147,8 +155,8 @@ func Test_VersionUpdater_GetVersion(t *testing.T) {
 			name:                "error getting version",
 			releaseRegistry:     defaultTestRegistry,
 			releasePath:         defaultTestPath,
-			currentVersion:      versionMid,
-			versionGetter:       version.NewStaticGetter("", &trace.ConnectionProblemError{}),
+			currentVersion:      semver.Must(version.EnsureSemver(versionMid)),
+			versionGetter:       mustNewStaticGetter(t, "", &trace.ConnectionProblemError{}),
 			maintenanceTriggers: []maintenance.Trigger{alwaysTrigger},
 			imageCheckers:       []img.Validator{neverValid},
 			assertErr:           errorIsType(&trace.ConnectionProblemError{}),
@@ -176,7 +184,7 @@ func Test_VersionUpdater_GetVersion(t *testing.T) {
 			obj := &core.Pod{}
 
 			// Doing the test
-			image, err := updater.GetVersion(ctx, obj, "v"+tt.currentVersion)
+			image, err := updater.GetVersion(ctx, obj, tt.currentVersion)
 			tt.assertErr(t, err)
 			if tt.expectedImage == "" {
 				require.Nil(t, image)

--- a/integrations/kube-agent-updater/version.go
+++ b/integrations/kube-agent-updater/version.go
@@ -21,3 +21,5 @@ package kubeversionupdater
 import "github.com/gravitational/teleport/api"
 
 const Version = api.Version
+
+var SemVersion = api.SemVersion

--- a/lib/auth/periodic.go
+++ b/lib/auth/periodic.go
@@ -23,7 +23,7 @@ import (
 	"slices"
 	"strings"
 
-	"golang.org/x/mod/semver"
+	"golang.org/x/mod/semver" //nolint:depguard
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"

--- a/lib/auth/periodic.go
+++ b/lib/auth/periodic.go
@@ -23,7 +23,7 @@ import (
 	"slices"
 	"strings"
 
-	"golang.org/x/mod/semver" //nolint:depguard
+	"golang.org/x/mod/semver" //nolint:depguard // Usage precedes the x/mod/semver rule.
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"

--- a/lib/automaticupgrades/version/basichttp.go
+++ b/lib/automaticupgrades/version/basichttp.go
@@ -22,8 +22,8 @@ import (
 	"context"
 	"net/http"
 	"net/url"
-	"strings"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/lib/automaticupgrades/basichttp"
@@ -43,18 +43,17 @@ type basicHTTPVersionClient struct {
 // Get sends an HTTP GET request and returns the version prefixed by "v".
 // It expects the endpoint to be unauthenticated, return 200 and the response
 // body to contain a valid semver tag without the "v".
-func (b *basicHTTPVersionClient) Get(ctx context.Context) (string, error) {
+func (b *basicHTTPVersionClient) Get(ctx context.Context) (*semver.Version, error) {
 	versionURL := b.baseURL.JoinPath(constants.VersionPath)
 	body, err := b.client.GetContent(ctx, *versionURL)
 	if err != nil {
-		return "", trace.Wrap(err, "failed to get version from %s", versionURL)
+		return nil, trace.Wrap(err, "failed to get version from %s", versionURL)
 	}
 	response := string(body)
 	if response == constants.NoVersion {
-		return "", &NoNewVersionError{Message: "version server did not advertise a version"}
+		return nil, &NoNewVersionError{Message: "version server did not advertise a version"}
 	}
-	// We trim spaces because the value might end with one or many newlines
-	version, err := EnsureSemver(strings.TrimSpace(response))
+	version, err := EnsureSemver(response)
 	return version, trace.Wrap(err)
 }
 
@@ -65,10 +64,10 @@ func (b *basicHTTPVersionClient) Get(ctx context.Context) (string, error) {
 // in order to mitigate the impact of too frequent reconciliations.
 // The structure implements the version.Getter interface.
 type BasicHTTPVersionGetter struct {
-	versionGetter func(context.Context) (string, error)
+	versionGetter func(context.Context) (*semver.Version, error)
 }
 
-func (g BasicHTTPVersionGetter) GetVersion(ctx context.Context) (string, error) {
+func (g BasicHTTPVersionGetter) GetVersion(ctx context.Context) (*semver.Version, error) {
 	return g.versionGetter(ctx)
 }
 
@@ -81,5 +80,5 @@ func NewBasicHTTPVersionGetter(baseURL *url.URL) Getter {
 		client:  &basichttp.Client{Client: client},
 	}
 
-	return BasicHTTPVersionGetter{cache.NewTimedMemoize[string](httpVersionClient.Get, constants.CacheDuration).Get}
+	return BasicHTTPVersionGetter{cache.NewTimedMemoize[*semver.Version](httpVersionClient.Get, constants.CacheDuration).Get}
 }

--- a/lib/automaticupgrades/version/errors.go
+++ b/lib/automaticupgrades/version/errors.go
@@ -18,13 +18,17 @@
 
 package version
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/coreos/go-semver/semver"
+)
 
 // NoNewVersionError indicates that no new version was found and the controller did not reconcile.
 type NoNewVersionError struct {
-	Message        string `json:"message"`
-	CurrentVersion string `json:"currentVersion"`
-	NextVersion    string `json:"nextVersion"`
+	Message        string          `json:"message"`
+	CurrentVersion *semver.Version `json:"currentVersion"`
+	NextVersion    *semver.Version `json:"nextVersion"`
 }
 
 // Error returns log friendly description of an error

--- a/lib/automaticupgrades/version/proxy.go
+++ b/lib/automaticupgrades/version/proxy.go
@@ -21,6 +21,7 @@ package version
 import (
 	"context"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/client/webclient"
@@ -36,14 +37,14 @@ type proxyVersionClient struct {
 	client Finder
 }
 
-func (b *proxyVersionClient) Get(_ context.Context) (string, error) {
+func (b *proxyVersionClient) Get(_ context.Context) (*semver.Version, error) {
 	resp, err := b.client.Find()
 	if err != nil {
-		return "", trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	// We check if a version is advertised to know if the proxy implements RFD-184 or not.
 	if resp.AutoUpdate.AgentVersion == "" {
-		return "", trace.NotImplemented("proxy does not seem to implement RFD-184")
+		return nil, trace.NotImplemented("proxy does not seem to implement RFD-184")
 	}
 	return EnsureSemver(resp.AutoUpdate.AgentVersion)
 }
@@ -53,11 +54,11 @@ func (b *proxyVersionClient) Get(_ context.Context) (string, error) {
 // The Getter returns trace.NotImplementedErr when running against a proxy that does not seem to
 // expose automatic update instructions over the /find endpoint (proxy too old).
 type ProxyVersionGetter struct {
-	cachedGetter func(context.Context) (string, error)
+	cachedGetter func(context.Context) (*semver.Version, error)
 }
 
 // GetVersion implements Getter
-func (g ProxyVersionGetter) GetVersion(ctx context.Context) (string, error) {
+func (g ProxyVersionGetter) GetVersion(ctx context.Context) (*semver.Version, error) {
 	return g.cachedGetter(ctx)
 }
 
@@ -68,5 +69,5 @@ func NewProxyVersionGetter(clt *webclient.ReusableClient) Getter {
 		client: clt,
 	}
 
-	return ProxyVersionGetter{cache.NewTimedMemoize[string](versionClient.Get, constants.CacheDuration).Get}
+	return ProxyVersionGetter{cache.NewTimedMemoize[*semver.Version](versionClient.Get, constants.CacheDuration).Get}
 }

--- a/lib/automaticupgrades/version/proxy_test.go
+++ b/lib/automaticupgrades/version/proxy_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -44,7 +45,7 @@ func TestProxyVersionClient(t *testing.T) {
 		name            string
 		pong            *webclient.PingResponse
 		pongErr         error
-		expectedVersion string
+		expectedVersion *semver.Version
 		expectErr       require.ErrorAssertionFunc
 	}{
 		{
@@ -54,7 +55,7 @@ func TestProxyVersionClient(t *testing.T) {
 					AgentVersion: "1.2.3",
 				},
 			},
-			expectedVersion: "v1.2.3",
+			expectedVersion: semver.Must(EnsureSemver("1.2.3")),
 			expectErr:       require.NoError,
 		},
 		{
@@ -64,7 +65,7 @@ func TestProxyVersionClient(t *testing.T) {
 					AgentVersion: "v1.2.3",
 				},
 			},
-			expectedVersion: "v1.2.3",
+			expectedVersion: semver.Must(EnsureSemver("1.2.3")),
 			expectErr:       require.NoError,
 		},
 		{
@@ -74,7 +75,7 @@ func TestProxyVersionClient(t *testing.T) {
 					AgentVersion: "1.2.3-dev.bartmoss.1",
 				},
 			},
-			expectedVersion: "v1.2.3-dev.bartmoss.1",
+			expectedVersion: semver.Must(EnsureSemver("v1.2.3-dev.bartmoss.1")),
 			expectErr:       require.NoError,
 		},
 		{
@@ -84,13 +85,13 @@ func TestProxyVersionClient(t *testing.T) {
 					AgentVersion: "v",
 				},
 			},
-			expectedVersion: "",
+			expectedVersion: nil,
 			expectErr:       require.Error,
 		},
 		{
 			name:            "empty response",
 			pong:            &webclient.PingResponse{},
-			expectedVersion: "",
+			expectedVersion: nil,
 			expectErr: func(t require.TestingT, err error, i ...interface{}) {
 				require.ErrorIs(t, err, trace.NotImplemented("proxy does not seem to implement RFD-184"))
 			},

--- a/lib/kube/utils/utils.go
+++ b/lib/kube/utils/utils.go
@@ -22,8 +22,8 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
-	"strings"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/trace"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -183,21 +183,32 @@ type Pinger interface {
 
 // GetKubeAgentVersion returns a version of the Kube agent appropriate for this Teleport cluster. Used for example when deciding version
 // for enrolling EKS clusters.
-func GetKubeAgentVersion(ctx context.Context, pinger Pinger, clusterFeatures proto.Features, versionGetter version.Getter) (string, error) {
+func GetKubeAgentVersion(ctx context.Context, pinger Pinger, clusterFeatures proto.Features, versionGetter version.Getter) (*semver.Version, error) {
 	pingResponse, err := pinger.Ping(ctx)
 	if err != nil {
-		return "", trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-	agentVersion := pingResponse.ServerVersion
 
+	var agentVersion *semver.Version
+
+	// TODO(hugoShaka) remove the conditional check, we always use the cluster version
 	if clusterFeatures.GetAutomaticUpgrades() && clusterFeatures.GetCloud() {
 		defaultVersion, err := versionGetter.GetVersion(ctx)
 		if err == nil {
 			agentVersion = defaultVersion
 		} else if !errors.Is(err, &version.NoNewVersionError{}) {
-			return "", trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 	}
 
-	return strings.TrimPrefix(agentVersion, "v"), nil
+	if agentVersion == nil {
+		clusterVersion, err := version.EnsureSemver(pingResponse.ServerVersion)
+		if err != nil {
+			return nil, trace.Wrap(err, "failed to parse cluster version")
+		} else {
+			agentVersion = clusterVersion
+		}
+	}
+
+	return agentVersion, nil
 }

--- a/lib/service/awsoidc.go
+++ b/lib/service/awsoidc.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"golang.org/x/sync/semaphore"
@@ -197,12 +198,9 @@ func (updater *AWSOIDCDeployServiceUpdater) updateAWSOIDCDeployServices(ctx cont
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	// stableVersion has vX.Y.Z format, however the container image tag does not include the `v`.
-	stableVersion = strings.TrimPrefix(stableVersion, "v")
-
 	// minServerVersion specifies the minimum version of the cluster required for
 	// updated AWS OIDC deploy service to remain compatible with the cluster.
-	minServerVersion, err := utils.MajorSemver(stableVersion)
+	minServerVersion, err := utils.MajorSemver(stableVersion.String())
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -253,10 +251,13 @@ func (updater *AWSOIDCDeployServiceUpdater) updateAWSOIDCDeployServices(ctx cont
 	return trace.Wrap(sem.Acquire(ctx, maxConcurrentUpdates))
 }
 
-func (updater *AWSOIDCDeployServiceUpdater) updateAWSOIDCDeployService(ctx context.Context, integration types.Integration, awsRegion, teleportVersion string) error {
+func (updater *AWSOIDCDeployServiceUpdater) updateAWSOIDCDeployService(ctx context.Context, integration types.Integration, awsRegion string, teleportVersion *semver.Version) error {
 	// Do not attempt update if integration is not an AWS OIDC integration.
 	if integration.GetAWSOIDCIntegrationSpec() == nil {
 		return nil
+	}
+	if teleportVersion == nil {
+		return trace.BadParameter("teleport version is required")
 	}
 
 	token, err := updater.AuthClient.GenerateAWSOIDCToken(ctx, integration.GetName())
@@ -313,7 +314,7 @@ func (updater *AWSOIDCDeployServiceUpdater) updateAWSOIDCDeployService(ctx conte
 	)
 	if err := awsoidc.UpdateDeployService(ctx, awsOIDCDeployServiceClient, updater.Log, awsoidc.UpdateServiceRequest{
 		TeleportClusterName: updater.TeleportClusterName,
-		TeleportVersionTag:  teleportVersion,
+		TeleportVersionTag:  teleportVersion.String(),
 		OwnershipTags:       ownershipTags,
 	}); err != nil {
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -47,6 +47,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/google/renameio/v2"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
@@ -167,7 +168,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils/cert"
 	"github.com/gravitational/teleport/lib/utils/hostid"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
-	vc "github.com/gravitational/teleport/lib/versioncontrol"
 	"github.com/gravitational/teleport/lib/versioncontrol/endpoint"
 	uw "github.com/gravitational/teleport/lib/versioncontrol/upgradewindow"
 	"github.com/gravitational/teleport/lib/web"
@@ -1240,18 +1240,27 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	hello := proto.UpstreamInventoryHello{
+		ServerID: cfg.HostUUID,
+		Version:  teleport.Version,
+		Services: process.getInstanceRoles(),
+		Hostname: cfg.Hostname,
+	}
+
 	upgraderKind, externalUpgrader, upgraderVersion := process.detectUpgrader()
+	hello.ExternalUpgrader = externalUpgrader
+	if upgraderVersion != nil {
+		// The UpstreamInventoryHello message wants versions with the leading "v".
+		hello.ExternalUpgraderVersion = "v" + upgraderVersion.String()
+	}
 
 	// note: we must create the inventory handle *after* registerExpectedServices because that function determines
 	// the list of services (instance roles) to be included in the heartbeat.
-	process.inventoryHandle = inventory.NewDownstreamHandle(process.makeInventoryControlStreamWhenReady, proto.UpstreamInventoryHello{
-		ServerID:                cfg.HostUUID,
-		Version:                 teleport.Version,
-		Services:                process.getInstanceRoles(),
-		Hostname:                cfg.Hostname,
-		ExternalUpgrader:        externalUpgrader,
-		ExternalUpgraderVersion: vc.Normalize(upgraderVersion),
-	}, inventory.WithDownstreamClock(process.Clock))
+	process.inventoryHandle = inventory.NewDownstreamHandle(
+		process.makeInventoryControlStreamWhenReady,
+		hello,
+		inventory.WithDownstreamClock(process.Clock),
+	)
 
 	process.inventoryHandle.RegisterPingHandler(func(sender inventory.DownstreamSender, ping proto.DownstreamInventoryPing) {
 		systemClock := process.Clock.Now().UTC()
@@ -1545,11 +1554,11 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 // Note that kind and externalName are usually the same.
 // However, some unregistered upgraders like the AWS ODIC upgrader are not valid kinds.
 // For these upgraders, kind is empty and externalName is set to a non-kind value.
-func (process *TeleportProcess) detectUpgrader() (kind, externalName, version string) {
+func (process *TeleportProcess) detectUpgrader() (kind, externalName string, version *semver.Version) {
 	// Check if the deprecated teleport-upgrader script is being used.
 	kind = os.Getenv(automaticupgrades.EnvUpgrader)
 	version = automaticupgrades.GetUpgraderVersion(process.GracefulExitContext())
-	if version == "" {
+	if version == nil {
 		kind = ""
 	}
 
@@ -1561,7 +1570,7 @@ func (process *TeleportProcess) detectUpgrader() (kind, externalName, version st
 		// If this is a teleport-update managed installation, the version
 		// managed by the timer will always match the installed version of teleport.
 		kind = types.UpgraderKindTeleportUpdate
-		version = "v" + teleport.Version
+		version = teleport.SemVersion
 	}
 
 	// Instances deployed using the AWS OIDC integration are automatically updated

--- a/lib/srv/server/installer/autodiscover.go
+++ b/lib/srv/server/installer/autodiscover.go
@@ -462,6 +462,7 @@ func (ani *AutoDiscoverNodeInstaller) fetchTargetVersion(ctx context.Context) st
 		return api.Version
 	}
 
+	// TODO(hugoShaka): convert this to a proxy version getter
 	targetVersion, err := version.NewBasicHTTPVersionGetter(upgradeURL).GetVersion(ctx)
 	if err != nil {
 		ani.Logger.WarnContext(ctx, "Failed to query target version, using api version",
@@ -473,7 +474,7 @@ func (ani *AutoDiscoverNodeInstaller) fetchTargetVersion(ctx context.Context) st
 		"channel_url", ani.autoUpgradesChannelURL,
 		"version", targetVersion)
 
-	return strings.TrimSpace(strings.TrimPrefix(targetVersion, "v"))
+	return strings.TrimSpace(strings.TrimPrefix(targetVersion.String(), "v"))
 }
 
 func fetchNodeAutoDiscoverLabels(ctx context.Context, imdsClient imds.Client) (map[string]string, error) {

--- a/lib/utils/teleportassets/teleportassets.go
+++ b/lib/utils/teleportassets/teleportassets.go
@@ -60,6 +60,11 @@ func CDNBaseURLForVersion(artifactVersion *semver.Version) string {
 }
 
 func cdnBaseURLForVersion(artifactVersion, teleportVersion *semver.Version) string {
+	// Something is not right a version is nil, we default to the standard CDN.
+	if artifactVersion == nil || teleportVersion == nil {
+		return TeleportReleaseCDN
+	}
+
 	if teleportVersion.PreRelease != "" && artifactVersion.PreRelease != "" {
 		return teleportPreReleaseCDN
 	}

--- a/lib/versioncontrol/github/github.go
+++ b/lib/versioncontrol/github/github.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 
 	"github.com/gravitational/trace"
-	"golang.org/x/mod/semver" //nolint:depguard
+	"golang.org/x/mod/semver" //nolint:depguard // Usage precedes the x/mod/semver rule.
 
 	"github.com/gravitational/teleport"
 	logutils "github.com/gravitational/teleport/lib/utils/log"

--- a/lib/versioncontrol/github/github.go
+++ b/lib/versioncontrol/github/github.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 
 	"github.com/gravitational/trace"
-	"golang.org/x/mod/semver"
+	"golang.org/x/mod/semver" //nolint:depguard
 
 	"github.com/gravitational/teleport"
 	logutils "github.com/gravitational/teleport/lib/utils/log"

--- a/lib/versioncontrol/target.go
+++ b/lib/versioncontrol/target.go
@@ -24,7 +24,7 @@ import (
 	"strconv"
 	"strings"
 
-	"golang.org/x/mod/semver"
+	"golang.org/x/mod/semver" //nolint:depguard
 )
 
 // NOTE: the contents of this file might be moving to the 'api' package in the future.

--- a/lib/versioncontrol/target.go
+++ b/lib/versioncontrol/target.go
@@ -24,7 +24,7 @@ import (
 	"strconv"
 	"strings"
 
-	"golang.org/x/mod/semver" //nolint:depguard
+	"golang.org/x/mod/semver" //nolint:depguard // Usage precedes the x/mod/semver rule.
 )
 
 // NOTE: the contents of this file might be moving to the 'api' package in the future.

--- a/lib/versioncontrol/versioncontrol.go
+++ b/lib/versioncontrol/versioncontrol.go
@@ -21,7 +21,7 @@ package versioncontrol
 import (
 	"fmt"
 
-	"golang.org/x/mod/semver"
+	"golang.org/x/mod/semver" //nolint:depguard
 )
 
 // Normalize attaches the expected `v` prefix to a version string if the supplied

--- a/lib/versioncontrol/versioncontrol.go
+++ b/lib/versioncontrol/versioncontrol.go
@@ -21,7 +21,7 @@ package versioncontrol
 import (
 	"fmt"
 
-	"golang.org/x/mod/semver" //nolint:depguard
+	"golang.org/x/mod/semver" //nolint:depguard // Usage precedes the x/mod/semver rule.
 )
 
 // Normalize attaches the expected `v` prefix to a version string if the supplied

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -54,7 +54,6 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/mod/semver"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -2228,8 +2227,14 @@ func (h *Handler) installer(w http.ResponseWriter, r *http.Request, p httprouter
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	// semver parsing requires a 'v' at the beginning of the version string.
-	version := semver.Major("v" + ping.ServerVersion)
+
+	const group, agentUUD = "", ""
+	targetVersion, err := h.autoUpdateAgentVersion(r.Context(), group, agentUUD)
+	if err != nil {
+		h.logger.WarnContext(r.Context(), "Error retrieving the target version", "error", err)
+		targetVersion = teleport.SemVersion
+	}
+
 	instTmpl, err := template.New("").Parse(installer.GetScript())
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -2245,7 +2250,7 @@ func (h *Handler) installer(w http.ResponseWriter, r *http.Request, p httprouter
 	}
 
 	// By default, it uses the stable/v<majorVersion> channel.
-	repoChannel := fmt.Sprintf("stable/%s", version)
+	repoChannel := fmt.Sprintf("stable/v%d", targetVersion.Major)
 
 	// If the updater must be installed, then change the repo to stable/cloud
 	// It must also install the version specified in
@@ -2258,7 +2263,7 @@ func (h *Handler) installer(w http.ResponseWriter, r *http.Request, p httprouter
 
 	tmpl := installers.Template{
 		PublicProxyAddr:   h.PublicProxyAddr(),
-		MajorVersion:      shsprintf.EscapeDefaultContext(version),
+		MajorVersion:      shsprintf.EscapeDefaultContext(fmt.Sprintf("v%d", targetVersion.Major)),
 		TeleportPackage:   teleportPackage,
 		RepoChannel:       shsprintf.EscapeDefaultContext(repoChannel),
 		AutomaticUpgrades: strconv.FormatBool(installUpdater),

--- a/lib/web/autoupdate_common.go
+++ b/lib/web/autoupdate_common.go
@@ -20,15 +20,15 @@ package web
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/trace"
 
 	autoupdatepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/autoupdate"
 	"github.com/gravitational/teleport/lib/automaticupgrades"
+	"github.com/gravitational/teleport/lib/automaticupgrades/version"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -37,8 +37,7 @@ import (
 // If the cluster contains an autoupdate_agent_rollout resource from RFD184 it should take precedence.
 // If the resource is not there, we fall back to RFD109-style updates with channels
 // and maintenance window derived from the cluster_maintenance_config resource.
-// Version returned follows semver without the leading "v".
-func (h *Handler) autoUpdateAgentVersion(ctx context.Context, group, updaterUUID string) (string, error) {
+func (h *Handler) autoUpdateAgentVersion(ctx context.Context, group, updaterUUID string) (*semver.Version, error) {
 	rollout, err := h.cfg.AccessPoint.GetAutoUpdateAgentRollout(ctx)
 	if err != nil {
 		// Fallback to channels if there is no autoupdate_agent_rollout.
@@ -46,7 +45,7 @@ func (h *Handler) autoUpdateAgentVersion(ctx context.Context, group, updaterUUID
 			return getVersionFromChannel(ctx, h.cfg.AutomaticUpgradesChannels, group)
 		}
 		// Something is broken, we don't want to fallback to channels, this would be harmful.
-		return "", trace.Wrap(err, "getting autoupdate_agent_rollout")
+		return nil, trace.Wrap(err, "getting autoupdate_agent_rollout")
 	}
 
 	return getVersionFromRollout(rollout, group, updaterUUID)
@@ -58,14 +57,10 @@ type handlerVersionGetter struct {
 }
 
 // GetVersion implements version.Getter.
-func (h *handlerVersionGetter) GetVersion(ctx context.Context) (string, error) {
+func (h *handlerVersionGetter) GetVersion(ctx context.Context) (*semver.Version, error) {
 	const group, updaterUUID = "", ""
 	agentVersion, err := h.autoUpdateAgentVersion(ctx, group, updaterUUID)
-	if err != nil {
-		return "", trace.Wrap(err)
-	}
-	// We add the leading v required by the version.Getter interface.
-	return fmt.Sprintf("v%s", agentVersion), nil
+	return agentVersion, trace.Wrap(err)
 }
 
 // autoUpdateAgentShouldUpdate returns if the agent should update now to based on its group
@@ -98,41 +93,40 @@ func (h *Handler) autoUpdateAgentShouldUpdate(ctx context.Context, group, update
 // This logic is pretty complex and described in RFD 184.
 // The spec is summed up in the following table:
 // https://github.com/gravitational/teleport/blob/master/rfd/0184-agent-auto-updates.md#rollout-status-disabled
-// Version returned follows semver without the leading "v".
 func getVersionFromRollout(
 	rollout *autoupdatepb.AutoUpdateAgentRollout,
 	groupName, updaterUUID string,
-) (string, error) {
+) (*semver.Version, error) {
 	switch rollout.GetSpec().GetAutoupdateMode() {
 	case autoupdate.AgentsUpdateModeDisabled:
 		// If AUs are disabled, we always answer the target version
-		return rollout.GetSpec().GetTargetVersion(), nil
+		return version.EnsureSemver(rollout.GetSpec().GetTargetVersion())
 	case autoupdate.AgentsUpdateModeSuspended, autoupdate.AgentsUpdateModeEnabled:
 		// If AUs are enabled or suspended, we modulate the response based on the schedule and agent group state
 	default:
-		return "", trace.BadParameter("unsupported agent update mode %q", rollout.GetSpec().GetAutoupdateMode())
+		return nil, trace.BadParameter("unsupported agent update mode %q", rollout.GetSpec().GetAutoupdateMode())
 	}
 
 	// If the schedule is immediate, agents always update to the latest version
 	if rollout.GetSpec().GetSchedule() == autoupdate.AgentsScheduleImmediate {
-		return rollout.GetSpec().GetTargetVersion(), nil
+		return version.EnsureSemver(rollout.GetSpec().GetTargetVersion())
 	}
 
 	// Else we follow the regular schedule and answer based on the agent group state
 	group, err := getGroup(rollout, groupName)
 	if err != nil {
-		return "", trace.Wrap(err, "getting group %q", groupName)
+		return nil, trace.Wrap(err, "getting group %q", groupName)
 	}
 
 	switch group.GetState() {
 	case autoupdatepb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_UNSTARTED,
 		autoupdatepb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ROLLEDBACK:
-		return rollout.GetSpec().GetStartVersion(), nil
+		return version.EnsureSemver(rollout.GetSpec().GetStartVersion())
 	case autoupdatepb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE,
 		autoupdatepb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_DONE:
-		return rollout.GetSpec().GetTargetVersion(), nil
+		return version.EnsureSemver(rollout.GetSpec().GetTargetVersion())
 	default:
-		return "", trace.NotImplemented("unsupported group state %q", group.GetState())
+		return nil, trace.NotImplemented("unsupported group state %q", group.GetState())
 	}
 }
 
@@ -202,14 +196,7 @@ func getGroup(
 }
 
 // getVersionFromChannel gets the target version from the RFD109 channels.
-// Version returned follows semver without the leading "v".
-func getVersionFromChannel(ctx context.Context, channels automaticupgrades.Channels, groupName string) (version string, err error) {
-	// RFD109 channels return the version with the 'v' prefix.
-	// We can't change the internals for backward compatibility, so we must trim the prefix if it's here.
-	defer func() {
-		version = strings.TrimPrefix(version, "v")
-	}()
-
+func getVersionFromChannel(ctx context.Context, channels automaticupgrades.Channels, groupName string) (version *semver.Version, err error) {
 	if channel, ok := channels[groupName]; ok {
 		return channel.GetVersion(ctx)
 	}

--- a/lib/web/autoupdate_rfd109.go
+++ b/lib/web/autoupdate_rfd109.go
@@ -92,7 +92,7 @@ func (h *Handler) automaticUpgradesVersion109(w http.ResponseWriter, r *http.Req
 
 	// RFD 109 specifies that version from channels must have the leading "v".
 	// As h.autoUpdateAgentVersion doesn't, we must add it.
-	_, err = fmt.Fprintf(w, "v%s", targetVersion)
+	_, err = fmt.Fprintf(w, "v%s", targetVersion.String())
 	return nil, trace.Wrap(err)
 }
 

--- a/lib/web/autoupdate_rfd184.go
+++ b/lib/web/autoupdate_rfd184.go
@@ -21,13 +21,14 @@ package web
 import (
 	"context"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/api"
 	"github.com/gravitational/teleport/api/client/webclient"
 	autoupdatepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	"github.com/gravitational/teleport/api/types/autoupdate"
+	"github.com/gravitational/teleport/lib/automaticupgrades/version"
 )
 
 // automaticUpdateSettings184 crafts the automatic updates part of the ping/find response
@@ -51,7 +52,7 @@ func (h *Handler) automaticUpdateSettings184(ctx context.Context, group, updater
 	if err != nil {
 		h.logger.ErrorContext(ctx, "failed to resolve AgentVersion", "error", err)
 		// Defaulting to current version
-		agentVersion = teleport.Version
+		agentVersion = teleport.SemVersion
 	}
 	// If the source of truth is RFD 109 configuration (channels + CMC) we must emulate the
 	// RFD109 agent maintenance window behavior by looking up the CMC and checking if
@@ -63,11 +64,17 @@ func (h *Handler) automaticUpdateSettings184(ctx context.Context, group, updater
 		shouldUpdate = false
 	}
 
+	toolsVersion, err := getToolsVersion(autoUpdateVersion)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "failed to get rools version", "error", err)
+		toolsVersion = teleport.SemVersion
+	}
+
 	return webclient.AutoUpdateSettings{
 		ToolsAutoUpdate:          getToolsAutoUpdate(autoUpdateConfig),
-		ToolsVersion:             getToolsVersion(autoUpdateVersion),
+		ToolsVersion:             toolsVersion.String(),
 		AgentUpdateJitterSeconds: DefaultAgentUpdateJitterSeconds,
-		AgentVersion:             agentVersion,
+		AgentVersion:             agentVersion.String(),
 		AgentAutoUpdate:          shouldUpdate,
 	}
 }
@@ -83,11 +90,11 @@ func getToolsAutoUpdate(config *autoupdatepb.AutoUpdateConfig) bool {
 	return false
 }
 
-func getToolsVersion(version *autoupdatepb.AutoUpdateVersion) string {
+func getToolsVersion(v *autoupdatepb.AutoUpdateVersion) (*semver.Version, error) {
 	// If we can't get the AU version or tools AU version is not specified, we default to the current proxy version.
 	// This ensures we always advertise a version compatible with the cluster.
-	if version.GetSpec().GetTools() == nil {
-		return api.Version
+	if v.GetSpec().GetTools() == nil {
+		return teleport.SemVersion, nil
 	}
-	return version.GetSpec().GetTools().GetTargetVersion()
+	return version.EnsureSemver(v.GetSpec().GetTools().GetTargetVersion())
 }

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -166,7 +166,7 @@ func (h *Handler) awsOIDCDeployService(w http.ResponseWriter, r *http.Request, p
 				"error", err,
 				"version", teleport.Version)
 		} else {
-			teleportVersionTag = autoUpdateVersion
+			teleportVersionTag = autoUpdateVersion.String()
 		}
 	}
 
@@ -222,7 +222,7 @@ func (h *Handler) awsOIDCDeployDatabaseServices(w http.ResponseWriter, r *http.R
 				"error", err,
 				"version", teleport.Version)
 		} else {
-			teleportVersionTag = autoUpdateVersion
+			teleportVersionTag = autoUpdateVersion.String()
 		}
 
 	}
@@ -794,7 +794,7 @@ func (h *Handler) awsOIDCEnrollEKSClusters(w http.ResponseWriter, r *http.Reques
 		Region:             req.Region,
 		EksClusterNames:    req.ClusterNames,
 		EnableAppDiscovery: req.EnableAppDiscovery,
-		AgentVersion:       agentVersion,
+		AgentVersion:       agentVersion.String(),
 		ExtraLabels:        extraLabels,
 	})
 	if err != nil {

--- a/lib/web/scripts.go
+++ b/lib/web/scripts.go
@@ -89,7 +89,7 @@ func (h *Handler) installScriptOptions(ctx context.Context) (scripts.InstallScri
 	version, err := h.autoUpdateAgentVersion(ctx, defaultGroup, defaultUpdater)
 	if err != nil {
 		h.logger.WarnContext(ctx, "Failed to get intended agent version", "error", err)
-		version = teleport.Version
+		version = teleport.SemVersion
 	}
 
 	// if there's a rollout, we do new autoupdates
@@ -145,15 +145,10 @@ func (h *Handler) installScriptOptions(ctx context.Context) (scripts.InstallScri
 // - "https://cdn.cloud.gravitational.io" (dev builds/staging)
 const EnvVarCDNBaseURL = "TELEPORT_CDN_BASE_URL"
 
-func getCDNBaseURL(version string) (string, error) {
+func getCDNBaseURL(version *semver.Version) (string, error) {
 	// If the user explicitly overrides the CDN base URL, we use it.
 	if override := os.Getenv(EnvVarCDNBaseURL); override != "" {
 		return override, nil
-	}
-
-	v, err := semver.NewVersion(version)
-	if err != nil {
-		return "", trace.Wrap(err)
 	}
 
 	// If this is an AGPL build, we don't want to automatically install binaries distributed under a more restrictive
@@ -167,5 +162,5 @@ func getCDNBaseURL(version string) (string, error) {
 			teleportassets.CDNBaseURL())
 	}
 
-	return teleportassets.CDNBaseURLForVersion(v), nil
+	return teleportassets.CDNBaseURLForVersion(version), nil
 }

--- a/lib/web/scripts/install_node.go
+++ b/lib/web/scripts/install_node.go
@@ -172,7 +172,7 @@ func GetNodeInstallScript(ctx context.Context, opts InstallNodeScriptOptions) (s
 		"packageName":             opts.InstallOptions.TeleportFlavor,
 		"repoChannel":             repoChannel,
 		"installUpdater":          opts.InstallOptions.AutoupdateStyle.String(),
-		"version":                 shsprintf.EscapeDefaultContext(opts.InstallOptions.TeleportVersion),
+		"version":                 shsprintf.EscapeDefaultContext(opts.InstallOptions.TeleportVersion.String()),
 		"appInstallMode":          strconv.FormatBool(opts.AppServiceEnabled),
 		"appServerResourceLabels": appServerResourceLabels,
 		"appName":                 shsprintf.EscapeDefaultContext(opts.AppName),

--- a/lib/web/scripts/install_test.go
+++ b/lib/web/scripts/install_test.go
@@ -26,12 +26,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/automaticupgrades/version"
 	"github.com/gravitational/teleport/lib/utils/teleportassets"
 )
 
 func TestGetInstallScript(t *testing.T) {
 	ctx := context.Background()
-	testVersion := "1.2.3"
+	testVersion, err := version.EnsureSemver("1.2.3")
+	require.NoError(t, err)
 	testProxyAddr := "proxy.example.com:443"
 
 	tests := []struct {


### PR DESCRIPTION
This PR aligns semantic version handling in automatic updates to coreos/go-semver.

This started from a comment from @espadolini during a review, I postponed the refactoring until the MVP got out. This PR now addresses the tech debt I left.

## Why not x/mod/semver?

x/mod/semver uses strings to carry versions. We have to always check that the version is normalized. This ended up in some functions taking versions with the leading "v" and some not. This causes significant cognitive overload each time we deal with version and increases the risk of using the wrong one. In autoupdate we were sometimes removing and adding back the leading "v" 4 times.

Teleport uses a mix of coreos/go-semver and x/mod/semver. I did not change the other semver usages but thing we should use coreos/go-semver more as it offer stronger typing and a more developer-friendly API.