### PR TITLE
Change Notices to Admonitions

### DIFF
--- a/docs/pages/reference/resources.mdx
+++ b/docs/pages/reference/resources.mdx
@@ -214,12 +214,12 @@ spec:
 
 Global configuration options for the agents enrolled into automatic updates (v1).
 
-<Notice type="warning">
+<Admonition type="warning">
 `cluster_maintenance_config` configures Managed Updates v1,
 which are currently supported but will be superseded by Managed Updates v2.
 The `autoupdate_config` and `autoupdate_version` resources further down
 configure Managed Updates v2.
-</Notice>
+</Admonition>
 
 (!docs/pages/includes/cluster-maintenance-config-spec.mdx!)
 
@@ -340,13 +340,13 @@ Find out more on the
 
 Configuration options for Teleport Agent and client tools Managed Updates (v2).
 
-<Notice type="warning">
+<Admonition type="warning">
 The `autoupdate_config` and `autoupdate_version` resources configure Managed
 Updates v2 and Managed Updates v1.
 
 `cluster_maintenance_config` above configures only Managed Updates v1
 which are currently supported but will be deprecated in a future version.
-</Notice>
+</Admonition>
 
 ```yaml
 kind: autoupdate_config
@@ -419,13 +419,13 @@ See [Teleport Client Tool Managed Updates](../upgrading/client-tools-autoupdate.
 
 Allows cluster administrators to manage versions used for agent and client tools Managed Updates.
 
-<Notice type="warning">
+<Admonition type="warning">
 The `autoupdate_config` and `autoupdate_version` resources configure Managed
 Updates v2 and Managed Updates v1.
 
 `cluster_maintenance_config` above configures only Managed Updates v1
 which are currently supported but will be deprecated in a future version.
-</Notice>
+</Admonition>
 
 This resource is not editable for cloud-managed Teleport Enterprise to ensure that all of
 your clients receive security patches and remain compatible with your cluster.

--- a/docs/pages/upgrading/agent-managed-updates-v1.mdx
+++ b/docs/pages/upgrading/agent-managed-updates-v1.mdx
@@ -3,11 +3,11 @@ title: Managed Updates for Teleport Agents (v1)
 description: Describes how to set up Managed Updates for Teleport Agents (v1)
 ---
 
-<Notice type="warning">
+<Admonition type="warning">
 This document describes Managed Updates for Agents (v1), which is
 currently supported but will be deprecated after [Managed Updates for
 Agents (v2)](./agent-managed-updates.mdx) is generally available.
-</Notice>
+</Admonition>
 
 Managed Updates v1 uses a script called `teleport-upgrade` that is provided by
 the `teleport-ent-updater` package and configured by the `cluster_maintenance_config`

--- a/docs/pages/upgrading/agent-managed-updates.mdx
+++ b/docs/pages/upgrading/agent-managed-updates.mdx
@@ -3,12 +3,12 @@ title: Managed Updates (v2) for Teleport Agents
 description: Describes how to set up Managed Updates (v2) for Teleport Agents
 ---
 
-<Notice type="warning">
+<Admonition type="warning">
 This document describes Managed Updates for Agents (v2), which is currently in beta.
 
 For Managed Updates v1 instructions, see
 [Managed Updates for Agents (v1)](./agent-managed-updates-v1.mdx).
-</Notice>
+</Admonition>
 
 In Managed Updates v2, a binary called `teleport-update` is distributed in
 all Teleport packages, alongside the `teleport` binary. Admins configure updates
@@ -83,10 +83,10 @@ a Teleport Agent by running the following command on every server:
 $ sudo teleport-update enable
 ```
 
-<Notice type="note">
+<Admonition type="note">
 If this command is not available, update the `teleport` package
 to the latest version that is supported by your cluster.
-</Notice>
+</Admonition>
 
 The `teleport-update enable` command will disable (but not remove)
 the v1 updater if present. No other action is necessary.
@@ -201,12 +201,12 @@ update until the staging group has updated. The `wait_hours` field sets a minimu
 duration between groups, ensuring that `production` happens the day after `staging`,
 and not one hour after.
 
-<Notice type="warning">
+<Admonition type="warning">
 While failed installations will revert automatically on the client-side,
 server-side healthchecks are still in development. To prevent the `production`
 group above from updating after `staging` has failed, you must manually suspend
 the schedule by setting the `spec.agents.mode` to `suspended`.
-</Notice>
+</Admonition>
 
 You may wish to schedule groups of agents to update without any dependence between
 them. For example, groups may represent geographic areas and not environments.

--- a/docs/pages/upgrading/upgrading-reference.mdx
+++ b/docs/pages/upgrading/upgrading-reference.mdx
@@ -4,11 +4,11 @@ description: Provides detailed information on upgrading Teleport in various situ
 tocDepth: 3
 ---
 
-<Notice type="warning">
+<Admonition type="warning">
 This document describes the Managed Updates v1 Teleport Agent updater, which is
 currently supported but will be deprecated after the [Managed update v2 updater
 ](./agent-managed-updates.mdx) is generally available.
-</Notice>
+</Admonition>
 
 This guide explains how to upgrade components of a Teleport cluster in
 non-standard situations. 


### PR DESCRIPTION
We are deprecating the Notice component since it is not supported natively in Docusaurus and the Docusaurus-native Admonition component serves the same purpose.