### PR TITLE
Fix: Overlapping unified cache backend key for apps

### DIFF
--- a/lib/services/unified_resource.go
+++ b/lib/services/unified_resource.go
@@ -600,7 +600,11 @@ func makeResourceSortKey(resource types.Resource) resourceSortKey {
 		if app != nil {
 			friendlyName := types.FriendlyName(app)
 			if friendlyName != "" {
-				name = friendlyName
+				sanitizedFriendlyName := strings.ReplaceAll(types.FriendlyName(app), "/", "-")
+				// FriendlyName is not unique, and multiple apps may have the same friendly name.
+				// To prevent collisions in the resource cache, we append the app name to the
+				// friendly name, ensuring uniqueness.
+				name = sanitizedFriendlyName + "/" + app.GetName()
 			} else {
 				name = app.GetName()
 			}


### PR DESCRIPTION
### What

Changelog: Fix the issue with multiple Okta app links that is causing a high level of Okta API usage.
