### PR TITLE
Add resizing wrapper around unified resources

### DIFF
--- a/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
@@ -17,8 +17,9 @@
  */
 
 import { useCallback, useMemo, useState } from 'react';
+import styled from 'styled-components';
 
-import { Flex } from 'design';
+import { Box, Flex } from 'design';
 import { Danger } from 'design/Alert';
 import { DefaultTab } from 'gen-proto-ts/teleport/userpreferences/v1/unified_resource_preferences_pb';
 import { ClusterDropdown } from 'shared/components/ClusterDropdown/ClusterDropdown';
@@ -60,16 +61,23 @@ export function UnifiedResources() {
 
   return (
     <FeatureBox px={4}>
-      <SamlAppActionProvider>
-        <ClusterResources
-          key={clusterId} // when the current cluster changes, remount the component
-          clusterId={clusterId}
-          isLeafCluster={isLeafCluster}
-        />
-      </SamlAppActionProvider>
+      <ResizingResourceWrapper>
+        <SamlAppActionProvider>
+          <ClusterResources
+            key={clusterId} // when the current cluster changes, remount the component
+            clusterId={clusterId}
+            isLeafCluster={isLeafCluster}
+          />
+        </SamlAppActionProvider>
+      </ResizingResourceWrapper>
     </FeatureBox>
   );
 }
+
+const ResizingResourceWrapper = styled(Box)`
+  width: 100%;
+  padding-right: ${props => props.theme.space[3]}px;
+`;
 
 const getAvailableKindsWithAccess = (flags: FeatureFlags): FilterKind[] => {
   return [


### PR DESCRIPTION
This extra padding was missing in the OSS version of unified resources wrapper (this wrapper exists in `e`) so the oss unified had a weird horizontal scrollbar. I originally thought you just add some `overflow-x: hidden` instead of adding random padding but, i believe they achieve the same effect (and this keeps it consistent with `e`)

before: 
![Screenshot 2025-03-05 at 11 25 20 AM](https://github.com/user-attachments/assets/547b253d-a49b-4f8d-98ed-080e26bf7385)


after:
![Screenshot 2025-03-05 at 11 25 30 AM](https://github.com/user-attachments/assets/5941288d-ab1b-4e7f-97e8-86cceb7a4324)
