### PR TITLE
Fix 18 Vale warnings related to Var components

### DIFF
--- a/docs/pages/get-started.mdx
+++ b/docs/pages/get-started.mdx
@@ -185,8 +185,10 @@ To access the server using commands in a terminal:
 
 1. Open a new terminal window.
 
-1. Sign in to your Teleport cluster by running the `tsh login` command  with the URL 
-of your cluster and the name of your Teleport user:
+1. Sign in to your Teleport cluster by running the `tsh login` command  with the
+   URL of your cluster and the name of your Teleport user, assigning 
+   <Var name="example" /> to your account subdomain and <Var name="username" /> to
+   your Teleport username:
    
    ```code
    $ tsh login --proxy=<Var name="example" />.teleport.sh --user=<Var name="username" />
@@ -220,7 +222,8 @@ of your cluster and the name of your Teleport user:
    b6c1072b5af5 ⟵ Tunnel  
    ```
 
-1. Access your server as the `root` user:
+1. Access your server as the `root` user, assigning <Var name="node-name" /> to
+   the name of the server as displayed by `tsh ls`:
 
    ```code
    $ tsh ssh root@<Var name="node-name" />

--- a/docs/pages/includes/database-access/reference/aws-iam/redshift-serverless/role-as-user-policy.mdx
+++ b/docs/pages/includes/database-access/reference/aws-iam/redshift-serverless/role-as-user-policy.mdx
@@ -1,5 +1,7 @@
 The following permissions policy should be attached to an IAM role that Teleport
-users can specify as a database user.
+users can specify as a database user. Assign <Var name="us-east-2"/> to an AWS
+region, <Var name="aws-account-id"/> to your AWS account ID, and 
+<Var name="workgroup-id"/> to a workgroup ID:
 
 ```json
 {

--- a/docs/pages/includes/discovery/aws-db-discovery-config.mdx
+++ b/docs/pages/includes/discovery/aws-db-discovery-config.mdx
@@ -1,5 +1,8 @@
 {{ roleARN="arn:aws:iam::123456789012:role/example-role" }}
 
+Assign <Var name="aws-example"/> to the name of your discovery group and 
+<Var name="us-east-1"/> to the name of an AWS region:
+
 ```yaml
 version: v1
 kind: "discovery_config"

--- a/docs/pages/includes/install-linux-ent-self-hosted.mdx
+++ b/docs/pages/includes/install-linux-ent-self-hosted.mdx
@@ -9,7 +9,7 @@ mode for your cluster.
 1. Run your cluster's install script:
 
    ```code
-   $ curl "https://<Var name="example.teleport.sh:443"/>/scripts/install.sh" | sudo bash
+   $ curl "https://<Var name="teleport.example.com:443"/>/scripts/install.sh" | sudo bash
    ```
 
 The other installation methods are:

--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -4,13 +4,13 @@ The easiest installation method, for *Teleport versions 17.3 and above*, is the
 cluster install script. It will use the best version, edition, and installation
 mode for your cluster.
 
-1. Assign <Var name="teleport.example.com:443"/> to your Teleport cluster hostname.
-   This should contain you cluster hostname and port, but not the scheme (https://).
+1. Assign <Var name="teleport.example.com:443"/> to your Teleport cluster
+   hostname and port, but not the scheme (https://).
 
 1. Run your cluster's install script:
 
    ```code
-   $ curl "https://<Var name="example.teleport.sh:443"/>/scripts/install.sh" | sudo bash
+   $ curl "https://<Var name="teleport.example.com:443"/>/scripts/install.sh" | sudo bash
    ```
 
 On *older Teleport versions*:
@@ -29,14 +29,14 @@ On *older Teleport versions*:
    with the updater:
 
    ```code
-   $ TELEPORT_DOMAIN=<Var name="example.teleport.com" />
+   $ TELEPORT_DOMAIN=<Var name="example.teleport.com:443" />
    $ TELEPORT_VERSION="$(curl https://$TELEPORT_DOMAIN/v1/webapi/automaticupgrades/channel/default/version | sed 's/v//')"
    ```
 
    Otherwise, get the version of your Teleport cluster:
 
    ```code
-   $ TELEPORT_DOMAIN=<Var name="example.teleport.com" />
+   $ TELEPORT_DOMAIN=<Var name="example.teleport.com:443" />
    $ TELEPORT_VERSION="$(curl https://$TELEPORT_DOMAIN/v1/webapi/ping | jq -r '.server_version')"
    ```
 

--- a/docs/pages/includes/tctl.mdx
+++ b/docs/pages/includes/tctl.mdx
@@ -1,7 +1,9 @@
 To check that you can connect to your Teleport cluster, sign in with `tsh login`, then 
 verify that you can run `tctl` commands using your current credentials. 
 
-For example:
+For example, run the following command, assigning 
+<Var name="teleport.example.com" /> to the domain name of the Teleport Proxy Service
+in your cluster and <Var name="email@example.com" /> to your Teleport username:
 
 ```code
 $ tsh login --proxy=<Var name="teleport.example.com" /> --user=<Var name="email@example.com" />

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -94,7 +94,7 @@ The easiest installation method, for Teleport versions 17.3 and above, is the
 cluster install script. It will use the best version, edition, and installation
 mode for your cluster.
 
-1. Assign <Var name="teleport.example.com:443"/> to your Teleport cluster hostname.
+1. Assign <Var name="example.teleport.sh:443"/> to your Teleport cluster hostname and Web UI port.
    This should contain you cluster hostname and port, but not the scheme (https://).
 1. Run your cluster's install script:
    ```code

--- a/docs/pages/reference/access-controls/authentication.mdx
+++ b/docs/pages/reference/access-controls/authentication.mdx
@@ -125,7 +125,8 @@ Overriding a block is available to users with rights to maintain `user` resource
 available in the built-in `editor` role. To turn off a block, update the user entry,
 following these steps.
 
-Open the user resource in your editor:
+Open the user resource in your editor, assigning <Var name="username" /> to the
+name of your Teleport user:
 
 ```code
 $ tctl edit users/<Var name="username" />

--- a/docs/pages/reference/architecture/tls-routing.mdx
+++ b/docs/pages/reference/architecture/tls-routing.mdx
@@ -243,8 +243,10 @@ For Teleport version before 15.1, the reverse proxy must support custom
 upgrades](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Upgrade)
 and long-lived connections.
 
-You can set up a Teleport Proxy Service behind the reverse proxy and run the
-following command to test the connection:
+You can set up the Teleport Proxy Service behind the reverse proxy and run the
+following command to test the connection, assigning 
+<Var name="teleport.example.com" /> to the domain name of the Proxy Service:
+
 ```code
 $ curl -v https://<Var name="teleport.example.com" />/webapi/connectionupgrade -H "Connection: Upgrade" -H "Upgrade: alpn-ping" --no-alpn
 ```


### PR DESCRIPTION
`Var` components with a particular `name` should have multiple instances in a given page.