### PR TITLE
Extend the generic storage service to support custom names for names

### DIFF
--- a/lib/services/local/access_graph.go
+++ b/lib/services/local/access_graph.go
@@ -48,7 +48,7 @@ type AccessGraphSecretsService struct {
 // SSH Keys. Future implementations might extend them.
 func NewAccessGraphSecretsService(b backend.Backend) (*AccessGraphSecretsService, error) {
 	authorizedKeysSvc, err := generic.NewServiceWrapper(
-		generic.ServiceWrapperConfig[*accessgraphsecretspb.AuthorizedKey]{
+		generic.ServiceConfig[*accessgraphsecretspb.AuthorizedKey]{
 			Backend:       b,
 			ResourceKind:  types.KindAccessGraphSecretAuthorizedKey,
 			BackendPrefix: backend.NewKey(authorizedKeysPrefix),
@@ -60,7 +60,7 @@ func NewAccessGraphSecretsService(b backend.Backend) (*AccessGraphSecretsService
 	}
 
 	privateKeysSvc, err := generic.NewServiceWrapper(
-		generic.ServiceWrapperConfig[*accessgraphsecretspb.PrivateKey]{
+		generic.ServiceConfig[*accessgraphsecretspb.PrivateKey]{
 			Backend:       b,
 			ResourceKind:  types.KindAccessGraphSecretPrivateKey,
 			BackendPrefix: backend.NewKey(privateKeysPrefix),

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -407,7 +407,7 @@ func TestAccessListDedupeOwnersBackwardsCompat(t *testing.T) {
 	accessListDuplicateOwners.Spec.Owners = append(accessListDuplicateOwners.Spec.Owners, accessListDuplicateOwners.Spec.Owners[0])
 	require.Len(t, accessListDuplicateOwners.Spec.Owners, 3)
 
-	item, err := service.service.MakeBackendItem(accessListDuplicateOwners, accessListDuplicateOwners.GetName())
+	item, err := service.service.MakeBackendItem(accessListDuplicateOwners)
 	require.NoError(t, err)
 	_, err = mem.Put(ctx, item)
 	require.NoError(t, err)
@@ -490,7 +490,6 @@ func TestAccessListUpsertWithMembers(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, members)
 	})
-
 }
 
 func TestAccessListMembersCRUD(t *testing.T) {

--- a/lib/services/local/access_monitoring_rules.go
+++ b/lib/services/local/access_monitoring_rules.go
@@ -41,7 +41,7 @@ type AccessMonitoringRulesService struct {
 // NewAccessMonitoringRulesService creates a new AccessMonitoringRulesService.
 func NewAccessMonitoringRulesService(b backend.Backend) (*AccessMonitoringRulesService, error) {
 	service, err := generic.NewServiceWrapper(
-		generic.ServiceWrapperConfig[*accessmonitoringrulesv1.AccessMonitoringRule]{
+		generic.ServiceConfig[*accessmonitoringrulesv1.AccessMonitoringRule]{
 			Backend:       b,
 			ResourceKind:  types.KindAccessMonitoringRule,
 			BackendPrefix: backend.NewKey(accessMonitoringRulesPrefix),

--- a/lib/services/local/autoupdate.go
+++ b/lib/services/local/autoupdate.go
@@ -47,14 +47,14 @@ type AutoUpdateService struct {
 // NewAutoUpdateService returns a new AutoUpdateService.
 func NewAutoUpdateService(b backend.Backend) (*AutoUpdateService, error) {
 	config, err := generic.NewServiceWrapper(
-		generic.ServiceWrapperConfig[*autoupdate.AutoUpdateConfig]{
+		generic.ServiceConfig[*autoupdate.AutoUpdateConfig]{
 			Backend:       b,
 			ResourceKind:  types.KindAutoUpdateConfig,
 			BackendPrefix: backend.NewKey(autoUpdateConfigPrefix),
 			MarshalFunc:   services.MarshalProtoResource[*autoupdate.AutoUpdateConfig],
 			UnmarshalFunc: services.UnmarshalProtoResource[*autoupdate.AutoUpdateConfig],
 			ValidateFunc:  update.ValidateAutoUpdateConfig,
-			KeyFunc: func(*autoupdate.AutoUpdateConfig) string {
+			ResourceKeyFunc: func(*autoupdate.AutoUpdateConfig) string {
 				return types.MetaNameAutoUpdateConfig
 			},
 		})
@@ -62,14 +62,14 @@ func NewAutoUpdateService(b backend.Backend) (*AutoUpdateService, error) {
 		return nil, trace.Wrap(err)
 	}
 	version, err := generic.NewServiceWrapper(
-		generic.ServiceWrapperConfig[*autoupdate.AutoUpdateVersion]{
+		generic.ServiceConfig[*autoupdate.AutoUpdateVersion]{
 			Backend:       b,
 			ResourceKind:  types.KindAutoUpdateVersion,
 			BackendPrefix: backend.NewKey(autoUpdateVersionPrefix),
 			MarshalFunc:   services.MarshalProtoResource[*autoupdate.AutoUpdateVersion],
 			UnmarshalFunc: services.UnmarshalProtoResource[*autoupdate.AutoUpdateVersion],
 			ValidateFunc:  update.ValidateAutoUpdateVersion,
-			KeyFunc: func(version *autoupdate.AutoUpdateVersion) string {
+			ResourceKeyFunc: func(*autoupdate.AutoUpdateVersion) string {
 				return types.MetaNameAutoUpdateVersion
 			},
 		})
@@ -77,14 +77,14 @@ func NewAutoUpdateService(b backend.Backend) (*AutoUpdateService, error) {
 		return nil, trace.Wrap(err)
 	}
 	rollout, err := generic.NewServiceWrapper(
-		generic.ServiceWrapperConfig[*autoupdate.AutoUpdateAgentRollout]{
+		generic.ServiceConfig[*autoupdate.AutoUpdateAgentRollout]{
 			Backend:       b,
 			ResourceKind:  types.KindAutoUpdateAgentRollout,
 			BackendPrefix: backend.NewKey(autoUpdateAgentRolloutPrefix),
 			MarshalFunc:   services.MarshalProtoResource[*autoupdate.AutoUpdateAgentRollout],
 			UnmarshalFunc: services.UnmarshalProtoResource[*autoupdate.AutoUpdateAgentRollout],
 			ValidateFunc:  update.ValidateAutoUpdateAgentRollout,
-			KeyFunc: func(_ *autoupdate.AutoUpdateAgentRollout) string {
+			ResourceKeyFunc: func(*autoupdate.AutoUpdateAgentRollout) string {
 				return types.MetaNameAutoUpdateAgentRollout
 			},
 		})
@@ -222,7 +222,7 @@ func itemFromAutoUpdateConfig(config *autoupdate.AutoUpdateConfig) (*backend.Ite
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	value, err := services.MarshalProtoResource[*autoupdate.AutoUpdateConfig](config)
+	value, err := services.MarshalProtoResource(config)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -248,7 +248,7 @@ func itemFromAutoUpdateVersion(version *autoupdate.AutoUpdateVersion) (*backend.
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	value, err := services.MarshalProtoResource[*autoupdate.AutoUpdateVersion](version)
+	value, err := services.MarshalProtoResource(version)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/local/autoupdate.go
+++ b/lib/services/local/autoupdate.go
@@ -54,7 +54,7 @@ func NewAutoUpdateService(b backend.Backend) (*AutoUpdateService, error) {
 			MarshalFunc:   services.MarshalProtoResource[*autoupdate.AutoUpdateConfig],
 			UnmarshalFunc: services.UnmarshalProtoResource[*autoupdate.AutoUpdateConfig],
 			ValidateFunc:  update.ValidateAutoUpdateConfig,
-			ResourceKeyFunc: func(*autoupdate.AutoUpdateConfig) string {
+			NameKeyFunc: func(string) string {
 				return types.MetaNameAutoUpdateConfig
 			},
 		})
@@ -69,7 +69,7 @@ func NewAutoUpdateService(b backend.Backend) (*AutoUpdateService, error) {
 			MarshalFunc:   services.MarshalProtoResource[*autoupdate.AutoUpdateVersion],
 			UnmarshalFunc: services.UnmarshalProtoResource[*autoupdate.AutoUpdateVersion],
 			ValidateFunc:  update.ValidateAutoUpdateVersion,
-			ResourceKeyFunc: func(*autoupdate.AutoUpdateVersion) string {
+			NameKeyFunc: func(string) string {
 				return types.MetaNameAutoUpdateVersion
 			},
 		})
@@ -84,7 +84,7 @@ func NewAutoUpdateService(b backend.Backend) (*AutoUpdateService, error) {
 			MarshalFunc:   services.MarshalProtoResource[*autoupdate.AutoUpdateAgentRollout],
 			UnmarshalFunc: services.UnmarshalProtoResource[*autoupdate.AutoUpdateAgentRollout],
 			ValidateFunc:  update.ValidateAutoUpdateAgentRollout,
-			ResourceKeyFunc: func(*autoupdate.AutoUpdateAgentRollout) string {
+			NameKeyFunc: func(string) string {
 				return types.MetaNameAutoUpdateAgentRollout
 			},
 		})

--- a/lib/services/local/bot_instance.go
+++ b/lib/services/local/bot_instance.go
@@ -45,7 +45,7 @@ type BotInstanceService struct {
 // NewBotInstanceService creates a new BotInstanceService with the given backend.
 func NewBotInstanceService(b backend.Backend, clock clockwork.Clock) (*BotInstanceService, error) {
 	service, err := generic.NewServiceWrapper(
-		generic.ServiceWrapperConfig[*machineidv1.BotInstance]{
+		generic.ServiceConfig[*machineidv1.BotInstance]{
 			Backend:       b,
 			ResourceKind:  types.KindBotInstance,
 			BackendPrefix: backend.NewKey(botInstancePrefix),

--- a/lib/services/local/crown_jewels.go
+++ b/lib/services/local/crown_jewels.go
@@ -39,7 +39,7 @@ const crownJewelsKey = "crown_jewels"
 // NewCrownJewelsService creates a new CrownJewelsService.
 func NewCrownJewelsService(b backend.Backend) (*CrownJewelsService, error) {
 	service, err := generic.NewServiceWrapper(
-		generic.ServiceWrapperConfig[*crownjewelv1.CrownJewel]{
+		generic.ServiceConfig[*crownjewelv1.CrownJewel]{
 			Backend:       b,
 			ResourceKind:  types.KindCrownJewel,
 			BackendPrefix: backend.NewKey(crownJewelsKey),

--- a/lib/services/local/databaseobject.go
+++ b/lib/services/local/databaseobject.go
@@ -74,7 +74,7 @@ const (
 
 func NewDatabaseObjectService(b backend.Backend) (*DatabaseObjectService, error) {
 	service, err := generic.NewServiceWrapper(
-		generic.ServiceWrapperConfig[*dbobjectv1.DatabaseObject]{
+		generic.ServiceConfig[*dbobjectv1.DatabaseObject]{
 			Backend:       b,
 			ResourceKind:  types.KindDatabaseObject,
 			BackendPrefix: backend.NewKey(databaseObjectPrefix),

--- a/lib/services/local/databaseobjectimportrule.go
+++ b/lib/services/local/databaseobjectimportrule.go
@@ -72,7 +72,7 @@ const (
 
 func NewDatabaseObjectImportRuleService(b backend.Backend) (services.DatabaseObjectImportRules, error) {
 	service, err := generic.NewServiceWrapper(
-		generic.ServiceWrapperConfig[*databaseobjectimportrulev1.DatabaseObjectImportRule]{
+		generic.ServiceConfig[*databaseobjectimportrulev1.DatabaseObjectImportRule]{
 			Backend:       b,
 			ResourceKind:  types.KindDatabaseObjectImportRule,
 			BackendPrefix: backend.NewKey(databaseObjectImportRulePrefix),

--- a/lib/services/local/generic/generic_test.go
+++ b/lib/services/local/generic/generic_test.go
@@ -540,7 +540,6 @@ func TestGenericListResourcesWithFilterForScale(t *testing.T) {
 }
 
 func TestGenericValidation(t *testing.T) {
-
 	ctx := context.Background()
 
 	memBackend, err := memory.New(memory.Config{
@@ -571,25 +570,27 @@ func TestGenericValidation(t *testing.T) {
 
 	_, err = service.UpsertResource(ctx, r1)
 	require.ErrorIs(t, err, validationErr)
-
 }
 
 func TestGenericKeyOverride(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	memBackend, err := memory.New(memory.Config{
 		Context: ctx,
 		Clock:   clockwork.NewFakeClock(),
 	})
 	require.NoError(t, err)
+	defer memBackend.Close()
 
 	service, err := NewService(&ServiceConfig[*testResource]{
-		Backend:       memBackend,
-		ResourceKind:  "generic resource",
-		PageLimit:     200,
-		BackendPrefix: backend.NewKey("generic_prefix"),
-		UnmarshalFunc: unmarshalResource,
-		MarshalFunc:   marshalResource,
-		KeyFunc:       func(tr *testResource) string { return "llama" },
+		Backend:         memBackend,
+		ResourceKind:    "generic resource",
+		PageLimit:       200,
+		BackendPrefix:   backend.NewKey("generic_prefix"),
+		UnmarshalFunc:   unmarshalResource,
+		MarshalFunc:     marshalResource,
+		ResourceKeyFunc: func(tr *testResource) string { return "llama" },
 	})
 	require.NoError(t, err)
 
@@ -654,4 +655,69 @@ func TestGenericKeyOverride(t *testing.T) {
 	item, err = memBackend.Get(ctx, backend.NewKey("generic_prefix", r1.GetName()))
 	require.Error(t, err)
 	require.Nil(t, item)
+
+	// Validate that getting the resource through the service requires the
+	// overridden name and not the resource name because we've configured
+	// ResourceKeyFunc and not NameKeyFunc
+	_, err = service.GetResource(ctx, r1.GetName())
+	require.ErrorAs(t, err, new(*trace.NotFoundError))
+	_, err = service.GetResource(ctx, "llama")
+	require.NoError(t, err)
+
+	service2, err := NewService(&ServiceConfig[*testResource]{
+		Backend:       memBackend,
+		ResourceKind:  "generic resource",
+		PageLimit:     200,
+		BackendPrefix: backend.NewKey("generic_prefix"),
+		UnmarshalFunc: unmarshalResource,
+		MarshalFunc:   marshalResource,
+		NameKeyFunc:   func(string) string { return "llama" },
+	})
+	require.NoError(t, err)
+
+	// Validate that when NameKeyFunc is set we can override the key for reads
+	// and deletes too
+	_, err = service2.GetResource(ctx, "llama")
+	require.NoError(t, err)
+	_, err = service2.GetResource(ctx, r1.GetName())
+	require.NoError(t, err)
+	_, err = service2.GetResource(ctx, "notllama")
+	require.NoError(t, err)
+
+	err = service2.DeleteResource(ctx, "notllama")
+	require.NoError(t, err)
+	_, err = memBackend.Get(ctx, backend.NewKey("generic_prefix", "llama"))
+	require.ErrorAs(t, err, new(*trace.NotFoundError))
+
+	// Validate that when NameKeyFunc is set and ResourceKeyFunc is unset we
+	// will use NameKeyFunc for writes
+	_, err = service2.CreateResource(ctx, r1)
+	require.NoError(t, err)
+	_, err = memBackend.Get(ctx, backend.NewKey("generic_prefix", "llama"))
+	require.NoError(t, err)
+
+	service3, err := NewService(&ServiceConfig[*testResource]{
+		Backend:         memBackend,
+		ResourceKind:    "generic resource",
+		PageLimit:       200,
+		BackendPrefix:   backend.NewKey("generic_prefix"),
+		UnmarshalFunc:   unmarshalResource,
+		MarshalFunc:     marshalResource,
+		NameKeyFunc:     func(string) string { return "llama" },
+		ResourceKeyFunc: func(*testResource) string { return "notllama" },
+	})
+	require.NoError(t, err)
+
+	// Validate that ResourceKeyFunc takes priority over NameKeyFunc (deletes
+	// and reads will use NameKeyFunc, writes will use ResourceKeyFunc)
+	err = service3.DeleteResource(ctx, "llamallama")
+	require.NoError(t, err)
+
+	_, err = service3.CreateResource(ctx, r1)
+	require.NoError(t, err)
+	_, err = memBackend.Get(ctx, backend.NewKey("generic_prefix", "notllama"))
+	require.NoError(t, err)
+
+	_, err = service3.GetResource(ctx, "notllama")
+	require.ErrorAs(t, err, new(*trace.NotFoundError))
 }

--- a/lib/services/local/generic/generic_wrapper.go
+++ b/lib/services/local/generic/generic_wrapper.go
@@ -18,7 +18,6 @@ package generic
 
 import (
 	"context"
-	"time"
 
 	"github.com/gravitational/trace"
 
@@ -27,34 +26,8 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 )
 
-// ServiceWrapperConfig is the configuration for the service wrapper.
-type ServiceWrapperConfig[T types.ResourceMetadata] struct {
-	// Backend used to persist the resource.
-	Backend backend.Backend
-	// ResourceKind is the friendly name of the resource.
-	ResourceKind string
-	// PageLimit
-	PageLimit uint
-	// BackendPrefix used when constructing the [backend.Item.Key].
-	BackendPrefix backend.Key
-	// MarshlFunc converts the resource to bytes for persistence.
-	MarshalFunc MarshalFunc[T]
-	// UnmarshalFunc converts the bytes read from the backend to the resource.
-	UnmarshalFunc UnmarshalFunc[T]
-	// ValidateFunc optionally validates the resource prior to persisting it. Any errors
-	// returned from the validation function will prevent writes to the backend.
-	ValidateFunc func(T) error
-	// RunWhileLockedRetryInterval is the interval to retry the RunWhileLocked function.
-	// If set to 0, the default interval of 250ms will be used.
-	// WARNING: If set to a negative value, the RunWhileLocked function will retry immediately.
-	RunWhileLockedRetryInterval time.Duration
-	// KeyFunc optionally allows resource to have a custom key. If not provided the
-	// name of the resource will be used.
-	KeyFunc func(T) string
-}
-
 // NewServiceWrapper will return a new generic service wrapper. It is compatible with resources aligned with RFD 153.
-func NewServiceWrapper[T types.ResourceMetadata](cfg ServiceWrapperConfig[T]) (*ServiceWrapper[T], error) {
+func NewServiceWrapper[T types.ResourceMetadata](cfg ServiceConfig[T]) (*ServiceWrapper[T], error) {
 	serviceConfig := &ServiceConfig[resourceMetadataAdapter[T]]{
 		Backend:       cfg.Backend,
 		ResourceKind:  cfg.ResourceKind,
@@ -68,6 +41,7 @@ func NewServiceWrapper[T types.ResourceMetadata](cfg ServiceWrapperConfig[T]) (*
 			return newResourceMetadataAdapter(r), trace.Wrap(err)
 		},
 		RunWhileLockedRetryInterval: cfg.RunWhileLockedRetryInterval,
+		NameKeyFunc:                 cfg.NameKeyFunc,
 	}
 
 	if cfg.ValidateFunc != nil {
@@ -76,13 +50,13 @@ func NewServiceWrapper[T types.ResourceMetadata](cfg ServiceWrapperConfig[T]) (*
 		}
 	}
 
-	if cfg.KeyFunc != nil {
-		serviceConfig.KeyFunc = func(rma resourceMetadataAdapter[T]) string {
-			return cfg.KeyFunc(rma.resource)
+	if cfg.ResourceKeyFunc != nil {
+		serviceConfig.ResourceKeyFunc = func(rma resourceMetadataAdapter[T]) string {
+			return cfg.ResourceKeyFunc(rma.resource)
 		}
 	}
 
-	service, err := NewService[resourceMetadataAdapter[T]](serviceConfig)
+	service, err := NewService(serviceConfig)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -99,24 +73,12 @@ type ServiceWrapper[T types.ResourceMetadata] struct {
 }
 
 // WithPrefix will return a service wrapper with the given parts appended to the backend prefix.
-func (s ServiceWrapper[T]) WithPrefix(parts ...string) *ServiceWrapper[T] {
+func (s *ServiceWrapper[T]) WithPrefix(parts ...string) *ServiceWrapper[T] {
 	if len(parts) == 0 {
-		return &s
+		return s
 	}
 
-	return &ServiceWrapper[T]{
-		service: &Service[resourceMetadataAdapter[T]]{
-			backend:                     s.service.backend,
-			resourceKind:                s.service.resourceKind,
-			pageLimit:                   s.service.pageLimit,
-			backendPrefix:               s.service.backendPrefix.AppendKey(backend.NewKey(parts...)),
-			marshalFunc:                 s.service.marshalFunc,
-			unmarshalFunc:               s.service.unmarshalFunc,
-			validateFunc:                s.service.validateFunc,
-			keyFunc:                     s.service.keyFunc,
-			runWhileLockedRetryInterval: s.service.runWhileLockedRetryInterval,
-		},
-	}
+	return &ServiceWrapper[T]{service: s.service.WithPrefix(parts...)}
 }
 
 // UpsertResource upserts a resource.

--- a/lib/services/local/generic/generic_wrapper.go
+++ b/lib/services/local/generic/generic_wrapper.go
@@ -50,12 +50,6 @@ func NewServiceWrapper[T types.ResourceMetadata](cfg ServiceConfig[T]) (*Service
 		}
 	}
 
-	if cfg.ResourceKeyFunc != nil {
-		serviceConfig.ResourceKeyFunc = func(rma resourceMetadataAdapter[T]) string {
-			return cfg.ResourceKeyFunc(rma.resource)
-		}
-	}
-
 	service, err := NewService(serviceConfig)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/local/generic/generic_wrapper_test.go
+++ b/lib/services/local/generic/generic_wrapper_test.go
@@ -105,8 +105,8 @@ func TestGenericWrapperCRUD(t *testing.T) {
 
 	const backendPrefix = "generic_prefix"
 
-	service, err := NewServiceWrapper[*testResource153](
-		ServiceWrapperConfig[*testResource153]{
+	service, err := NewServiceWrapper(
+		ServiceConfig[*testResource153]{
 			Backend:       memBackend,
 			ResourceKind:  "generic resource",
 			BackendPrefix: backend.NewKey(backendPrefix),
@@ -248,8 +248,8 @@ func TestGenericWrapperWithPrefix(t *testing.T) {
 	initialBackendPrefix := backend.NewKey("initial_prefix")
 	const additionalBackendPrefix = "additional_prefix"
 
-	service, err := NewServiceWrapper[*testResource153](
-		ServiceWrapperConfig[*testResource153]{
+	service, err := NewServiceWrapper(
+		ServiceConfig[*testResource153]{
 			Backend:       memBackend,
 			ResourceKind:  "generic resource",
 			BackendPrefix: initialBackendPrefix,

--- a/lib/services/local/identitycenter.go
+++ b/lib/services/local/identitycenter.go
@@ -90,7 +90,7 @@ func NewIdentityCenterService(cfg IdentityCenterServiceConfig) (*IdentityCenterS
 		return nil, trace.Wrap(err)
 	}
 
-	accountsSvc, err := generic.NewServiceWrapper(generic.ServiceWrapperConfig[*identitycenterv1.Account]{
+	accountsSvc, err := generic.NewServiceWrapper(generic.ServiceConfig[*identitycenterv1.Account]{
 		Backend:       cfg.Backend,
 		ResourceKind:  types.KindIdentityCenterAccount,
 		BackendPrefix: backend.NewKey(awsResourcePrefix, awsAccountPrefix),
@@ -101,7 +101,7 @@ func NewIdentityCenterService(cfg IdentityCenterServiceConfig) (*IdentityCenterS
 		return nil, trace.Wrap(err, "creating accounts service")
 	}
 
-	permissionSetSvc, err := generic.NewServiceWrapper(generic.ServiceWrapperConfig[*identitycenterv1.PermissionSet]{
+	permissionSetSvc, err := generic.NewServiceWrapper(generic.ServiceConfig[*identitycenterv1.PermissionSet]{
 		Backend:       cfg.Backend,
 		ResourceKind:  types.KindIdentityCenterPermissionSet,
 		BackendPrefix: backend.NewKey(awsResourcePrefix, awsPermissionSetPrefix),
@@ -112,7 +112,7 @@ func NewIdentityCenterService(cfg IdentityCenterServiceConfig) (*IdentityCenterS
 		return nil, trace.Wrap(err, "creating permission sets service")
 	}
 
-	principalsSvc, err := generic.NewServiceWrapper(generic.ServiceWrapperConfig[*identitycenterv1.PrincipalAssignment]{
+	principalsSvc, err := generic.NewServiceWrapper(generic.ServiceConfig[*identitycenterv1.PrincipalAssignment]{
 		Backend:       cfg.Backend,
 		ResourceKind:  types.KindIdentityCenterPrincipalAssignment,
 		BackendPrefix: backend.NewKey(awsResourcePrefix, awsPrincipalAssignmentPrefix),
@@ -123,7 +123,7 @@ func NewIdentityCenterService(cfg IdentityCenterServiceConfig) (*IdentityCenterS
 		return nil, trace.Wrap(err, "creating principal assignments service")
 	}
 
-	accountAssignmentsSvc, err := generic.NewServiceWrapper(generic.ServiceWrapperConfig[*identitycenterv1.AccountAssignment]{
+	accountAssignmentsSvc, err := generic.NewServiceWrapper(generic.ServiceConfig[*identitycenterv1.AccountAssignment]{
 		Backend:       cfg.Backend,
 		ResourceKind:  types.KindIdentityCenterAccountAssignment,
 		BackendPrefix: backend.NewKey(awsResourcePrefix, awsAccountAssignmentPrefix),

--- a/lib/services/local/kubewaitingcontainer.go
+++ b/lib/services/local/kubewaitingcontainer.go
@@ -44,7 +44,7 @@ type KubeWaitingContainerService struct {
 // container service.
 func NewKubeWaitingContainerService(b backend.Backend) (*KubeWaitingContainerService, error) {
 	svc, err := generic.NewServiceWrapper(
-		generic.ServiceWrapperConfig[*kubewaitingcontainerpb.KubernetesWaitingContainer]{
+		generic.ServiceConfig[*kubewaitingcontainerpb.KubernetesWaitingContainer]{
 			Backend:       b,
 			ResourceKind:  types.KindKubeWaitingContainer,
 			BackendPrefix: backend.NewKey(kubeWaitingContPrefix),

--- a/lib/services/local/notifications.go
+++ b/lib/services/local/notifications.go
@@ -48,8 +48,8 @@ type NotificationsService struct {
 
 // NewNotificationsService returns a new instance of the NotificationService.
 func NewNotificationsService(backend backend.Backend, clock clockwork.Clock) (*NotificationsService, error) {
-	userNotificationService, err := generic.NewServiceWrapper[*notificationsv1.Notification](
-		generic.ServiceWrapperConfig[*notificationsv1.Notification]{
+	userNotificationService, err := generic.NewServiceWrapper(
+		generic.ServiceConfig[*notificationsv1.Notification]{
 			Backend:       backend,
 			ResourceKind:  types.KindNotification,
 			BackendPrefix: notificationsUserSpecificPrefix,
@@ -60,8 +60,8 @@ func NewNotificationsService(backend backend.Backend, clock clockwork.Clock) (*N
 		return nil, trace.Wrap(err)
 	}
 
-	globalNotificationService, err := generic.NewServiceWrapper[*notificationsv1.GlobalNotification](
-		generic.ServiceWrapperConfig[*notificationsv1.GlobalNotification]{
+	globalNotificationService, err := generic.NewServiceWrapper(
+		generic.ServiceConfig[*notificationsv1.GlobalNotification]{
 			Backend:       backend,
 			ResourceKind:  types.KindGlobalNotification,
 			BackendPrefix: notificationsGlobalPrefix,
@@ -72,8 +72,8 @@ func NewNotificationsService(backend backend.Backend, clock clockwork.Clock) (*N
 		return nil, trace.Wrap(err)
 	}
 
-	userNotificationStateService, err := generic.NewServiceWrapper[*notificationsv1.UserNotificationState](
-		generic.ServiceWrapperConfig[*notificationsv1.UserNotificationState]{
+	userNotificationStateService, err := generic.NewServiceWrapper(
+		generic.ServiceConfig[*notificationsv1.UserNotificationState]{
 			Backend:       backend,
 			ResourceKind:  types.KindUserNotificationState,
 			BackendPrefix: notificationsStatePrefix,
@@ -84,8 +84,8 @@ func NewNotificationsService(backend backend.Backend, clock clockwork.Clock) (*N
 		return nil, trace.Wrap(err)
 	}
 
-	userLastSeenNotificationService, err := generic.NewServiceWrapper[*notificationsv1.UserLastSeenNotification](
-		generic.ServiceWrapperConfig[*notificationsv1.UserLastSeenNotification]{
+	userLastSeenNotificationService, err := generic.NewServiceWrapper(
+		generic.ServiceConfig[*notificationsv1.UserLastSeenNotification]{
 			Backend:       backend,
 			ResourceKind:  types.KindUserLastSeenNotification,
 			BackendPrefix: notificationsUserLastSeenPrefix,
@@ -97,8 +97,8 @@ func NewNotificationsService(backend backend.Backend, clock clockwork.Clock) (*N
 		return nil, trace.Wrap(err)
 	}
 
-	uniqueNotificationIdentifierService, err := generic.NewServiceWrapper[*notificationsv1.UniqueNotificationIdentifier](
-		generic.ServiceWrapperConfig[*notificationsv1.UniqueNotificationIdentifier]{
+	uniqueNotificationIdentifierService, err := generic.NewServiceWrapper(
+		generic.ServiceConfig[*notificationsv1.UniqueNotificationIdentifier]{
 			Backend:       backend,
 			ResourceKind:  types.KindUniqueNotificationIdentifier,
 			BackendPrefix: notificationUniqueIdentifierPrefix,
@@ -415,7 +415,6 @@ func (s *NotificationsService) UpsertUserLastSeenNotification(ctx context.Contex
 
 // GetUserLastSeenNotification returns a user's last seen notification item.
 func (s *NotificationsService) GetUserLastSeenNotification(ctx context.Context, username string) (*notificationsv1.UserLastSeenNotification, error) {
-
 	ulsn, err := s.userLastSeenNotificationService.GetResource(ctx, username)
 	return ulsn, trace.Wrap(err)
 }

--- a/lib/services/local/provisioningstates.go
+++ b/lib/services/local/provisioningstates.go
@@ -46,7 +46,7 @@ var _ services.ProvisioningStates = (*ProvisioningStateService)(nil)
 // NewProvisioningStateService creates a new ProvisioningStateService backed by
 // the supplied backend.
 func NewProvisioningStateService(backendInstance backend.Backend) (*ProvisioningStateService, error) {
-	userStatusSvc, err := generic.NewServiceWrapper(generic.ServiceWrapperConfig[*provisioningv1.PrincipalState]{
+	userStatusSvc, err := generic.NewServiceWrapper(generic.ServiceConfig[*provisioningv1.PrincipalState]{
 		Backend:       backendInstance,
 		ResourceKind:  types.KindProvisioningPrincipalState,
 		BackendPrefix: backend.NewKey(provisioningStatePrefix),

--- a/lib/services/local/saml_idp_service_provider.go
+++ b/lib/services/local/saml_idp_service_provider.go
@@ -146,7 +146,7 @@ func (s *SAMLIdPServiceProviderService) CreateSAMLIdPServiceProvider(ctx context
 		return trace.Wrap(err)
 	}
 
-	item, err := s.svc.MakeBackendItem(sp, sp.GetName())
+	item, err := s.svc.MakeBackendItem(sp)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -184,7 +184,7 @@ func (s *SAMLIdPServiceProviderService) UpdateSAMLIdPServiceProvider(ctx context
 		return trace.Wrap(err)
 	}
 
-	item, err := s.svc.MakeBackendItem(sp, sp.GetName())
+	item, err := s.svc.MakeBackendItem(sp)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -225,7 +225,6 @@ func (s *SAMLIdPServiceProviderService) ensureEntityIDIsUnique(ctx context.Conte
 		var listSps []types.SAMLIdPServiceProvider
 		var err error
 		listSps, nextToken, err = s.ListSAMLIdPServiceProviders(ctx, samlIDPServiceProviderMaxPageSize, nextToken)
-
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/services/local/spiffe_federations.go
+++ b/lib/services/local/spiffe_federations.go
@@ -43,7 +43,7 @@ type SPIFFEFederationService struct {
 // NewSPIFFEFederationService creates a new SPIFFEFederationService.
 func NewSPIFFEFederationService(b backend.Backend) (*SPIFFEFederationService, error) {
 	service, err := generic.NewServiceWrapper(
-		generic.ServiceWrapperConfig[*machineidv1.SPIFFEFederation]{
+		generic.ServiceConfig[*machineidv1.SPIFFEFederation]{
 			Backend:       b,
 			ResourceKind:  types.KindSPIFFEFederation,
 			BackendPrefix: backend.NewKey(spiffeFederationPrefix),

--- a/lib/services/local/statichostuser.go
+++ b/lib/services/local/statichostuser.go
@@ -42,7 +42,7 @@ type StaticHostUserService struct {
 // NewStaticHostUserService creates a new static host user service.
 func NewStaticHostUserService(bk backend.Backend) (*StaticHostUserService, error) {
 	svc, err := generic.NewServiceWrapper(
-		generic.ServiceWrapperConfig[*userprovisioningpb.StaticHostUser]{
+		generic.ServiceConfig[*userprovisioningpb.StaticHostUser]{
 			Backend:       bk,
 			ResourceKind:  types.KindStaticHostUser,
 			BackendPrefix: backend.NewKey(staticHostUserPrefix),

--- a/lib/services/local/user_task.go
+++ b/lib/services/local/user_task.go
@@ -40,7 +40,7 @@ const userTasksKey = "user_tasks"
 // NewUserTasksService creates a new UserTasksService.
 func NewUserTasksService(b backend.Backend) (*UserTasksService, error) {
 	service, err := generic.NewServiceWrapper(
-		generic.ServiceWrapperConfig[*usertasksv1.UserTask]{
+		generic.ServiceConfig[*usertasksv1.UserTask]{
 			Backend:       b,
 			ResourceKind:  types.KindUserTask,
 			BackendPrefix: backend.NewKey(userTasksKey),

--- a/lib/services/local/vnet_config.go
+++ b/lib/services/local/vnet_config.go
@@ -46,7 +46,7 @@ type VnetConfigService struct {
 // NewVnetConfigService returns a new VnetConfig storage service.
 func NewVnetConfigService(b backend.Backend) (*VnetConfigService, error) {
 	svc, err := generic.NewServiceWrapper(
-		generic.ServiceWrapperConfig[*vnet.VnetConfig]{
+		generic.ServiceConfig[*vnet.VnetConfig]{
 			Backend:       b,
 			ResourceKind:  types.KindVnetConfig,
 			BackendPrefix: backend.NewKey(vnetConfigPrefix),

--- a/lib/services/local/workload_identity.go
+++ b/lib/services/local/workload_identity.go
@@ -43,7 +43,7 @@ type WorkloadIdentityService struct {
 // NewWorkloadIdentityService creates a new WorkloadIdentityService
 func NewWorkloadIdentityService(b backend.Backend) (*WorkloadIdentityService, error) {
 	service, err := generic.NewServiceWrapper(
-		generic.ServiceWrapperConfig[*workloadidentityv1pb.WorkloadIdentity]{
+		generic.ServiceConfig[*workloadidentityv1pb.WorkloadIdentity]{
 			Backend:       b,
 			ResourceKind:  types.KindWorkloadIdentity,
 			BackendPrefix: backend.NewKey(workloadIdentityPrefix),

--- a/lib/services/local/workload_identity_x509_revocation.go
+++ b/lib/services/local/workload_identity_x509_revocation.go
@@ -46,7 +46,7 @@ func NewWorkloadIdentityX509RevocationService(
 	b backend.Backend,
 ) (*WorkloadIdentityX509RevocationService, error) {
 	service, err := generic.NewServiceWrapper(
-		generic.ServiceWrapperConfig[*workloadidentityv1pb.WorkloadIdentityX509Revocation]{
+		generic.ServiceConfig[*workloadidentityv1pb.WorkloadIdentityX509Revocation]{
 			Backend:       b,
 			ResourceKind:  types.KindWorkloadIdentityX509Revocation,
 			BackendPrefix: backend.NewKey(workloadIdentityX509RevocationPrefix),


### PR DESCRIPTION
The current implementation of the generic storage service supports a "`KeyFunc`" that lets us specify a backend key suffix for any given resource, but this is only really usable for singletons that just need a name override when writing, because operations such as Get or Delete only make use of a name rather than a full resource, and names for those operations are used as is. This PR adds two levels of key override, one to transform a name into a name, and one to transform a resource into a name, such that the latter will take priority over the former when applicable, and such that the latter will default to using the former on the resource name if unset.

In addition, this PR cleans up some boilerplate in the implementation of `generic.Service` and `generic.ServiceWrapper` by using the same configuration struct for both and delegating the `WithPrefix` method from the wrapper to the wrapped.