### PR TITLE
Machine ID: Update Kubernetes access guide for kubernetes/v2

### DIFF
--- a/docs/pages/enroll-resources/machine-id/access-guides/kubernetes.mdx
+++ b/docs/pages/enroll-resources/machine-id/access-guides/kubernetes.mdx
@@ -114,18 +114,13 @@ $ tctl bots update example --add-roles example-role
 ## Step 2/3. Configure a Kubernetes `tbot` output
 
 Now, `tbot` needs to be configured with an output to produce the Kubernetes
-credentials and client configuration file. This is done using the `kubernetes`
-output type.
+credentials and client configuration file. This is done using the
+`kubernetes/v2` output type.
 
-The Kubernetes cluster you want the credentials to have access to must
-be specified using the `kubernetes_cluster` field. In this example,
-`example-k8s-cluster` will be used.
-
-The output must be configured with a destination and the name of the
-Kubernetes cluster that should be encoded in the credentials produced by `tbot`.
-At this time, each output can only contain credentials for a single Kubernetes
-cluster. If your bot needs to connect to multiple Kubernetes clusters,
-create an output for each cluster.
+The Kubernetes clusters you wish to make available must be specified using
+entries in the `selectors` list. In this example, `example-k8s-cluster` will be
+selected using a name selector, and all clusters with the label
+`environment=dev` will be selected as well.
 
 Outputs must also be configured with a destination. In this example, the
 `directory` type will be used. This will write artifacts to a specified
@@ -133,14 +128,22 @@ directory on disk. Ensure that this directory can be written to by the Linux
 user that `tbot` runs as, and that it can be read by the Linux user that will
 be accessing the Kubernetes cluster.
 
-Modify your `tbot` configuration to add a `kubernetes` output:
+Modify your `tbot` configuration to add a `kubernetes/v2` output:
 
 ```yaml
 outputs:
-  - type: kubernetes
-    # Specify the name of the Kubernetes cluster you wish the credentials to
-    # grant access to.
-    kubernetes_cluster: example-k8s-cluster
+  - type: kubernetes/v2
+    selectors:
+      # Specify the name of the Kubernetes cluster you wish the credentials to
+      # grant access to. Note that wildcards are not supported.
+      - name: example-k8s-cluster
+
+      # Specify a label selector to dynamically select many clusters at once.
+      # All labels in a selector must match for a cluster to be selected, and
+      # multiple separate selectors can be specified if desired. Note that
+      # wildcards are not supported.
+      - labels:
+          environment: dev
     destination:
       type: directory
           # For this guide, /opt/machine-id is used as the destination directory.
@@ -150,7 +153,7 @@ outputs:
 ```
 
 Ensure you replace `example-k8s-cluster` with the name of the Kubernetes cluster
-as registered in Teleport and adjust `/opt/machine-id` if you wish
+as registered in Teleport and adjust `/opt/machine-id` if you wish.
 
 If operating `tbot` as a background service, restart it. If running `tbot` in
 one-shot mode, it must be executed before you attempt to use the credentials.
@@ -171,6 +174,25 @@ $ kubectl --kubeconfig /opt/machine-id/kubeconfig.yaml get pods -A
 $ export KUBECONFIG=/opt/machine-id/kubeconfig.yaml
 $ kubectl get pods -A
 ```
+
+If you selected multiple clusters, they will be exposed as separate contexts
+within the generated `kubeconfig.yaml`, and will be named following the format
+`$teleportClusterName-$kubeClusterName`. To target a specific cluster, use the
+`--context` flag:
+
+```code
+$ kubectl --kubeconfig /opt/machine-id/kubeconfig.yaml --context=example.teleport.sh-my-kube-cluster get pods -A
+```
+
+Note that the first selected cluster in `tbot.yaml` will be used as the default
+context. If using label selectors, the default context may vary over time if
+clusters are added or removed in Teleport.
+
+If new matching clusters are added or removed in Teleport, `kubeconfig.yaml`
+will be regenerated to reflect the change on the bot's next certificate renewal.
+If needed, the `tbot` process can be restarted or signaled (`pkill -USR1 tbot`)
+to trigger an immediate reload. Note that modifications to `kubeconfig.yaml`,
+such as changes to the `current-context` field, will be overwritten.
 
 Whilst this guide has demonstrated `kubeconfig.yaml` being used with `kubectl`,
 this format is compatible with most Kubernetes tools including:

--- a/docs/pages/enroll-resources/machine-id/faq.mdx
+++ b/docs/pages/enroll-resources/machine-id/faq.mdx
@@ -105,6 +105,6 @@ Note that both `tbot` and the Teleport Proxy need to be running v17.2.7 to take
 advantage of this functionality.
 
 Refer to the
-[CLI reference](../../reference/cli/tbot#tbot-start-kubernetesv2) and
+[CLI reference](../../reference/cli/tbot.mdx#tbot-start-kubernetesv2) and
 [config reference](../../reference/machine-id/configuration.mdx#kubernetesv2)
 for more information.

--- a/docs/pages/enroll-resources/machine-id/faq.mdx
+++ b/docs/pages/enroll-resources/machine-id/faq.mdx
@@ -93,3 +93,15 @@ If your use case absolutely requires long-lived certificates,
 [`tctl auth sign`](../../reference/cli/tctl.mdx#tctl-auth-sign) can
 alternatively be used, however this loses the security benefits of Machine ID's
 short-lived renewable certificates.
+
+## Can Machine ID be used to connect to multiple Kubernetes clusters?
+
+This is possible in Teleport v17.2.7 or higher, using the new `kubernetes/v2`
+output type in `tbot`. This service can expose many clusters at once via
+contexts in the generated `kubeconfig.yaml`, and if label selectors are used,
+will dynamically add contexts as clusters are added and removed in Teleport.
+
+Refer to the
+[CLI reference](../../reference/cli/tbot#tbot-start-kubernetesv2) and
+[config reference](../../reference/machine-id/configuration.mdx#kubernetesv2)
+for more information.

--- a/docs/pages/enroll-resources/machine-id/faq.mdx
+++ b/docs/pages/enroll-resources/machine-id/faq.mdx
@@ -101,6 +101,9 @@ output type in `tbot`. This service can expose many clusters at once via
 contexts in the generated `kubeconfig.yaml`, and if label selectors are used,
 will dynamically add contexts as clusters are added and removed in Teleport.
 
+Note that both `tbot` and the Teleport Proxy need to be running v17.2.7 to take
+advantage of this functionality.
+
 Refer to the
 [CLI reference](../../reference/cli/tbot#tbot-start-kubernetesv2) and
 [config reference](../../reference/machine-id/configuration.mdx#kubernetesv2)

--- a/docs/pages/reference/cli/tbot.mdx
+++ b/docs/pages/reference/cli/tbot.mdx
@@ -427,6 +427,54 @@ command supports these additional flags:
 | `--reader-group`       | An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux. |
 | `--kubernetes-cluster` | The name of the Kubernetes cluster in Teleport for which to fetch credentials |
 
+## tbot start kubernetes/v2
+
+Starts the Machine ID client `tbot` with a Kubernetes V2 output, fetching and
+writing Kubernetes credentials to a `kubeconfig.yaml` at a regular interval to
+the output specified with `--destination`.
+
+Unlike the `kubernetes` output, `kubernetes/v2` allows fetching many Kubernetes
+clusters at once, as multiple contexts within the generated `kubeconfig.yaml`.
+If label selectors are used and clusters are added or removed, the list of
+clusters will be updated on the bot's next renewal. At least one selector -
+either name or label - is required.
+
+Note that as with human users using `tsh kube ls`, only clusters the bot user
+has permission to access will be matched. Additionally, note that label
+selectors do not currently support wildcards.
+
+### Flags
+
+In addition to the [common `tbot start` flags](#common-start-flags), this
+command supports these additional flags:
+
+| Flag                    | Description |
+|-------------------------|-------------|
+| `--destination`         | A destination URI, such as file:///foo/bar. See [Destination URIs](#destination-uris) for more info. Required. |
+| `--reader-user`         | An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux. |
+| `--reader-group`        | An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux. |
+| `--name-selector`       | Selects a Kubernetes cluster by exact name match. Repeatable. |
+| `--label-selector`      | Selects many Kubernetes clusters by label match, e.g. `env=dev,role=ci`. Repeatable. |
+| `--disable-exec-plugin` | If set, disables the exec plugin. Allows credentials to be used without the `tbot` binary. |
+
+### Examples
+
+First, run `tbot` to generate credentials:
+
+```code
+$ tbot start kubernetes/v2 --proxy-server=example.teleport.sh:443 --destination=./example --label-selector env=dev --name-selector example --oneshot
+```
+
+This will fetch credentials for all clusters with the label `env: dev`, plus the
+cluster named `example`. You can then access the clusters using `kubectl`:
+
+```code
+$ kubectl --kubeconfig ./example/kubeconfig.yaml --context example.teleport.sh-example get pods
+```
+
+You can inspect the generated `kubeconfig.yaml` to see which clusters were
+matched by the label selector.
+
 ## tbot start application
 
 Starts the Machine ID client `tbot` with an application output, fetching and

--- a/docs/pages/reference/cli/tbot.mdx
+++ b/docs/pages/reference/cli/tbot.mdx
@@ -450,7 +450,7 @@ command supports these additional flags:
 
 | Flag                    | Description |
 |-------------------------|-------------|
-| `--destination`         | A destination URI, such as file:///foo/bar. See [Destination URIs](#destination-uris) for more info. Required. |
+| `--destination`         | A destination URI, such as `file:///foo/bar`. See [Destination URIs](#destination-uris) for more info. Required. |
 | `--reader-user`         | An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux. |
 | `--reader-group`        | An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux. |
 | `--name-selector`       | Selects a Kubernetes cluster by exact name match. Repeatable. |

--- a/docs/pages/reference/machine-id/configuration.mdx
+++ b/docs/pages/reference/machine-id/configuration.mdx
@@ -294,6 +294,58 @@ kubernetes_cluster: my-cluster
 (!docs/pages/includes/machine-id/common-output-config.yaml!)
 ```
 
+### `kubernetes/v2`
+
+The `kubernetes/v2` output type can be used to access many Kubernetes clusters
+as individual contexts within the same `kubeconfig.yaml`.
+
+```yaml
+type: kubernetes/v2
+
+# selectors include one or more matching Kubernetes clusters. Each match will be
+# included in the resulting `kubeconfig.yaml`, assuming the bot has permission
+# to access the cluster.
+selectors:
+  # name includes an exact match by name. Note that wildcards are not currently
+  # supported. Multiple name selectors can be specified if desired.
+  - name: foo
+  # labels include all clusters matching all of these labels. Multiple label
+  # selectors can be provided if needed.
+  - labels:
+      env: dev
+
+# The following configuration fields are available across most output types.
+# Note that `roles` are not supported for this output type.
+
+destination:
+  type: directory
+  path: /opt/machine-id
+
+# credential_ttl and renewal_interval override the credential TTL and renewal
+# interval for this specific output, so that you can make its certificates valid
+# for shorter than `tbot`'s internal certificates.
+#
+# This is particularly useful when using `tbot` in one-shot as part of a cron job
+# where you need `tbot`'s internal certificate to live long enough to be renewed
+# on the next invocation, but don't want long-lived workload certificates on-disk.
+credential_ttl: 30m
+renewal_interval: 15m
+```
+
+Each Kubernetes cluster matching a selector will result in a new context in the
+generated `kubeconfig.yaml`. This can be consumed like so:
+
+```code
+$ kubectl --kubeconfig /opt/machine-id/kubeconfig.yaml --context=example.teleport.sh-foo get pods
+```
+
+The context name is `[Teleport cluster name]-[Kubernetes cluster name]`, so the
+command above runs `kubectl get pods` on the `foo` cluster.
+
+If clusters are added or removed over time, the `kubeconfig.yaml` will be
+updated at the bot's normal renewal interval. You can trigger an early renewal
+by restarting `tbot`, or signaling it with `pkill -usr1 tbot`.
+
 ### `ssh_host`
 
 The `ssh_host` output is used to generate the artifacts required to configure


### PR DESCRIPTION
This updates the Kubernetes access guide to use the new `kubernetes/v2` service which allows access to multiple clusters from one output.

As support for this came out partway through v17 (v17.2.7), this guide update should not be backported to v17.

Fixes #52412