### PR TITLE
[v16] Fix docs prose linting error for deleted files

### DIFF
--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -14,6 +14,8 @@ jobs:
     outputs:
       changed: ${{ steps.changes.outputs.changed }}
       changed_files: ${{ steps.changes.outputs.changed_files }}
+      new_docs_content: ${{ steps.changes.outputs.new_docs_content }}
+      new_docs_content_files: ${{ steps.changes.outputs.new_docs_content_files }}
     steps:
       - name: Checkout
         if: ${{ github.event_name == 'merge_group' }}
@@ -30,6 +32,8 @@ jobs:
               - 'CHANGELOG.md'
               - 'docs/**'
               - 'examples/**'
+            new_docs_content:
+              - added|modified: 'docs/pages/**/*.mdx'
 
   doc-tests:
     name: Lint (Docs)
@@ -156,7 +160,7 @@ jobs:
     name: Lint docs prose style
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ !startsWith(github.head_ref, 'dependabot/') && needs.changes.outputs.changed == 'true' && github.event_name == 'pull_request' }}
+    if: ${{ !startsWith(github.head_ref, 'dependabot/') && needs.changes.outputs.new_docs_content == 'true' && github.event_name == 'pull_request' }}
     permissions:
       pull-requests: read
     steps:
@@ -172,7 +176,7 @@ jobs:
           # Take the comma-separated list of files returned by the "Check for
           # relevant changes" job.
           separator: ","
-          files: ${{ needs.changes.outputs.changed_files }}
+          files: ${{ needs.changes.outputs.new_docs_content_files }}
           # Restrict the linter to lines modified/added by a PR, not entire
           # changed files.
           filter_mode: added


### PR DESCRIPTION
Backports #52819

The docs prose linter currently fails when a pull request deletes a file. This is because the `vale` CLI exits with a nonzero code when it receives a nonexistent path. This change adds a filter to the `dorny/paths-filter` job in addition to the `changed` filter that only matches added or changed files. It passes this list of files to the prose linter instead of the list of all changes files.