### PR TITLE
[web] Type changes for Bidirectional Sync for Okta Integration

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -6214,6 +6214,10 @@ func (a *Server) CreateAccessListReminderNotifications(ctx context.Context) {
 
 	now := a.clock.Now()
 
+	// TODO(kiosion): Check possible Okta plugin configuration – if Bidirectional Sync is explicitly disabled,
+	// we shouldn't create notifications for any Okta-synced Access Lists, as they are managed in Okta and
+	// their grants, owners/members, and ownership/membership requirements cannot be edited in Teleport.
+
 	// Fetch all access lists
 	var accessLists []*accesslist.AccessList
 	var accessListsPageKey string

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -291,6 +291,8 @@ export type PluginOktaSpec = {
   defaultOwners: string[];
   // The Okta organization's base URL
   orgUrl: string;
+  // Whether changes made in Teleport should be synced back to Okta.
+  enableBidirectionalSync?: boolean;
   // Whether User Sync is enabled
   enableUserSync?: boolean;
   // Whether Access List Sync is enabled. Should match App/Group sync.


### PR DESCRIPTION
Add `enableBidirectionalSync` field to Okta Integration spec type. Required for [#6155](https://github.com/gravitational/teleport.e/pull/6155). 