### PR TITLE
User task updates

### DIFF
--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.test.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.test.tsx
@@ -57,6 +57,7 @@ test('renders header and stats cards', () => {
             resourcesEnrollmentSuccess: 9,
             discoverLastSync: new Date().getTime(),
             ecsDatabaseServiceCount: 0, // irrelevant
+            unresolvedUserTasks: 0,
           },
           awsrds: {
             rulesCount: 14,
@@ -65,6 +66,7 @@ test('renders header and stats cards', () => {
             resourcesEnrollmentSuccess: 0,
             discoverLastSync: addHours(new Date().getTime(), -4).getTime(),
             ecsDatabaseServiceCount: 8, // relevant
+            unresolvedUserTasks: 0,
           },
           awseks: {
             rulesCount: 33,
@@ -73,6 +75,7 @@ test('renders header and stats cards', () => {
             resourcesEnrollmentSuccess: 3,
             discoverLastSync: addHours(new Date().getTime(), -48).getTime(),
             ecsDatabaseServiceCount: 0, // irrelevant
+            unresolvedUserTasks: 0,
           },
         }),
       }}
@@ -151,6 +154,7 @@ test('renders enroll cards', () => {
     resourcesEnrollmentSuccess: 0,
     discoverLastSync: new Date().getTime(),
     ecsDatabaseServiceCount: 0,
+    unresolvedUserTasks: 0,
   };
 
   render(

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Details.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Details.tsx
@@ -52,7 +52,21 @@ export function Details() {
   }
 
   const { data: integration } = integrationAttempt;
-  const { unresolvedUserTasks } = statsAttempt.data;
+  const { awsec2, awsrds, awseks, unresolvedUserTasks } = statsAttempt.data;
+
+  let pendingTasks = unresolvedUserTasks;
+  switch (resourceKind) {
+    case AwsResource.rds:
+      pendingTasks = awsrds.unresolvedUserTasks;
+      break;
+    case AwsResource.ec2:
+      pendingTasks = awsec2.unresolvedUserTasks;
+      break;
+    case AwsResource.eks:
+      pendingTasks = awseks.unresolvedUserTasks;
+      break;
+  }
+
   return (
     <>
       {integration && (
@@ -65,7 +79,8 @@ export function Details() {
               <AwsOidcTitle integration={integration} resource={resourceKind} />
               <TaskAlert
                 name={integration.name}
-                pendingTasksCount={unresolvedUserTasks}
+                pendingTasksCount={pendingTasks}
+                taskType={resourceKind}
               />
             </>
           )}

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Task.test.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Task.test.tsx
@@ -34,6 +34,7 @@ test('renders ec2 impacts', async () => {
     integration: '',
     lastStateChange: '2025-02-11T20:32:19.482607921Z',
     issueType: 'ec2-ssm-invocation-failure',
+    title: 'ec2 ssm invocation failure',
     description:
       'Teleport failed to access the SSM Agent to auto enroll the instance.\nSome instances failed to communicate with the AWS Systems Manager service to execute the install script.\n\nUsually this happens when:\n\n**Missing policies**\n\nThe IAM Role used by the integration might be missing some required permissions.\nEnsure the following actions are allowed in the IAM Role used by the integration:\n- `ec2:DescribeInstances`\n- `ssm:DescribeInstanceInformation`\n- `ssm:GetCommandInvocation`\n- `ssm:ListCommandInvocations`\n- `ssm:SendCommand`\n\n**SSM Document is invalid**\n\nTeleport uses an SSM Document to run an installation script.\nIf the document is changed or removed, it might no longer work.',
     discoverEks: undefined,
@@ -94,6 +95,7 @@ test('renders eks impacts', async () => {
     integration: 'integration-001',
     lastStateChange: '2025-02-11T20:32:19.482607921Z',
     issueType: 'eks-failure',
+    title: 'eks failure',
     description:
       'Only EKS Clusters whose status is active can be automatically enrolled into teleport.\n',
     discoverEc2: undefined,
@@ -145,6 +147,7 @@ test('renders rds impacts', async () => {
     integration: 'integration-001',
     lastStateChange: '2025-02-11T20:32:19.482607921Z',
     issueType: 'rds-failure',
+    title: 'rds failure',
     description:
       'The Teleport Database Service uses [IAM authentication](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html) to communicate with RDS.\n',
     discoverEks: undefined,

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Task.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Task.tsx
@@ -127,7 +127,7 @@ export function Task({
   return (
     <SidePanel
       onClose={() => close(false)}
-      header={<H2>{taskAttempt.data.issueType}</H2>}
+      header={<H2>{taskAttempt.data.title}</H2>}
       footer={
         <ButtonBorder
           intent="success"

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/TaskAlert.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/TaskAlert.tsx
@@ -21,16 +21,19 @@ import { Alert } from 'design';
 import { ArrowForward, BellRinging } from 'design/Icon';
 
 import cfg from 'teleport/config';
+import { AwsResource } from 'teleport/Integrations/status/AwsOidc/StatCard';
 import { IntegrationKind } from 'teleport/services/integrations';
 
 export function TaskAlert({
   name,
   pendingTasksCount,
   kind = IntegrationKind.AwsOidc,
+  taskType,
 }: {
   name: string;
   pendingTasksCount: number;
   kind?: IntegrationKind;
+  taskType?: AwsResource;
 }) {
   const history = useHistory();
   if (pendingTasksCount == 0) {
@@ -52,7 +55,8 @@ export function TaskAlert({
         onClick: () => history.push(cfg.getIntegrationTasksRoute(kind, name)),
       }}
     >
-      {pendingTasksCount} Pending Tasks
+      {pendingTasksCount} Pending {taskType && `${taskType.toUpperCase()} `}
+      Tasks
     </Alert>
   );
 }

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.story.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.story.tsx
@@ -134,6 +134,7 @@ const ec2Detail = {
   integration: integrationName,
   lastStateChange: '2025-02-11T20:32:19.482607921Z',
   issueType: 'ec2-ssm-invocation-failure',
+  title: 'EC2 failure',
   description:
     'Teleport failed to access the SSM Agent to auto enroll the instance.\nSome instances failed to communicate with the AWS Systems Manager service to execute the install script.\n\nUsually this happens when:\n\n**Missing policies**\n\nThe IAM Role used by the integration might be missing some required permissions.\nEnsure the following actions are allowed in the IAM Role used by the integration:\n- `ec2:DescribeInstances`\n- `ssm:DescribeInstanceInformation`\n- `ssm:GetCommandInvocation`\n- `ssm:ListCommandInvocations`\n- `ssm:SendCommand`\n\n**SSM Document is invalid**\n\nTeleport uses an SSM Document to run an installation script.\nIf the document is changed or removed, it might no longer work.',
   discoverEc2: {
@@ -157,6 +158,7 @@ const rdsDetail = {
   integration: integrationName,
   lastStateChange: '2025-02-11T20:32:19.482607921Z',
   issueType: 'rds-failure',
+  title: 'RDS Failure',
   description:
     'The Teleport Database Service uses [IAM authentication](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html) to communicate with RDS.\n',
   discoverRds: {
@@ -178,6 +180,7 @@ const eksDetail = {
   integration: integrationName,
   lastStateChange: '2025-02-11T20:32:19.482607921Z',
   issueType: 'eks-failure',
+  title: 'EKS failure',
   description:
     'Only EKS Clusters whose status is active can be automatically enrolled into teleport.\n',
   discoverEks: {

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.test.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.test.tsx
@@ -47,6 +47,7 @@ test('deep links an open task', async () => {
           integration: integrationName,
           lastStateChange: '2025-02-11T20:32:19.482607921Z',
           issueType: 'rds-failure',
+          title: 'RDS Failure',
         },
       ],
       nextKey: 'next',
@@ -70,7 +71,7 @@ test('deep links an open task', async () => {
   );
 
   await screen.findAllByText('Pending Tasks');
-  await userEvent.click(screen.getByText('rds-failure'));
+  await userEvent.click(screen.getByText('RDS Failure'));
 
   await waitFor(() =>
     expect(history.replace).toHaveBeenCalledWith(

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.tsx
@@ -156,7 +156,7 @@ export function Tasks() {
                 ),
               },
               {
-                key: 'issueType',
+                key: 'title',
                 headerText: 'Issue Details',
               },
               {

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/testHelpers/makeAwsOidcStatusContextState.ts
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/testHelpers/makeAwsOidcStatusContextState.ts
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { addHours } from 'date-fns';
-
 import { makeSuccessAttempt } from 'shared/hooks/useAsync';
 
 import { AwsOidcStatusContextState } from 'teleport/Integrations/status/AwsOidc/useAwsOidcStatus';
@@ -60,15 +58,13 @@ function makeResourceTypeSummary(
 ): ResourceTypeSummary {
   return Object.assign(
     {
-      rulesCount: Math.floor(Math.random() * 100),
-      resourcesFound: Math.floor(Math.random() * 100),
-      resourcesEnrollmentFailed: Math.floor(Math.random() * 100),
-      resourcesEnrollmentSuccess: Math.floor(Math.random() * 100),
-      discoverLastSync: addHours(
-        new Date().getTime(),
-        -Math.floor(Math.random() * 100)
-      ),
-      ecsDatabaseServiceCount: Math.floor(Math.random() * 100),
+      rulesCount: 11,
+      resourcesFound: 11,
+      resourcesEnrollmentFailed: 11,
+      resourcesEnrollmentSuccess: 11,
+      discoverLastSync: new Date().getTime(),
+      ecsDatabaseServiceCount: 11,
+      unresolvedUserTasks: 11,
     },
     overrides
   );

--- a/web/packages/teleport/src/services/integrations/integrations.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.ts
@@ -539,6 +539,7 @@ export const integrationService = {
           taskType: resp.taskType,
           state: resp.state,
           issueType: resp.issueType,
+          title: resp.title,
           integration: resp.integration,
           lastStateChange: resp.lastStateChange,
         };

--- a/web/packages/teleport/src/services/integrations/integrations.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.ts
@@ -505,6 +505,7 @@ export const integrationService = {
         integration: resp.integration,
         lastStateChange: resp.lastStateChange,
         description: resp.description,
+        title: resp.title,
         discoverEc2: {
           instances: resp.discoverEc2?.instances,
           accountId: resp.discoverEc2?.accountId,

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -426,8 +426,6 @@ export type UserTask = {
 
 // UserTaskDetail contains all the details for a User Task.
 export type UserTaskDetail = UserTask & {
-  // title is the issue title.
-  title: string;
   // description is a markdown document that explains the issue and how to fix it.
   description: string;
   // discoverEc2 contains the task details for the DiscoverEc2 tasks.
@@ -574,6 +572,8 @@ export type ResourceTypeSummary = {
   resourcesEnrollmentSuccess: number;
   // discoverLastSync contains the time when this integration tried to auto-enroll resources.
   discoverLastSync: number;
+  // unresolvedUserTasks contains the count of unresolved user tasks related to this integration and resource type.
+  unresolvedUserTasks: number;
   // ecsDatabaseServiceCount is the total number of DatabaseServices that were deployed into Amazon ECS.
   // Only applicable for AWS RDS resource summary.
   ecsDatabaseServiceCount: number;

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -416,6 +416,8 @@ export type UserTask = {
   state: string;
   // issueType identifies this task's issue type.
   issueType: string;
+  // title is the issue title.
+  title: string;
   // integration is the Integration Name this User Task refers to.
   integration: string;
   // lastStateChange indicates when the current's user task state was last changed.
@@ -424,6 +426,8 @@ export type UserTask = {
 
 // UserTaskDetail contains all the details for a User Task.
 export type UserTaskDetail = UserTask & {
+  // title is the issue title.
+  title: string;
   // description is a markdown document that explains the issue and how to fix it.
   description: string;
   // discoverEc2 contains the task details for the DiscoverEc2 tasks.


### PR DESCRIPTION
* Use the new `title` field instead of issue details in task table and task sidebar (https://github.com/gravitational/teleport/pull/52550)
* Continue to display the total count of tasks on the dashboard page, but use the new per-resource count to only show relevant tasks on resource pages (https://github.com/gravitational/teleport/pull/52692, https://github.com/gravitational/teleport/pull/52435)

<img width="1284" alt="Screenshot 2025-03-07 at 10 42 12 AM" src="https://github.com/user-attachments/assets/0a3b60d9-1e33-4b55-bea4-b0b8b0d66d76" />

all tasks
<img width="1284" alt="Screenshot 2025-03-07 at 10 41 46 AM" src="https://github.com/user-attachments/assets/7d2055b8-fc79-4976-96fc-e653c14c52db" />

relevant tasks
<img width="1270" alt="Screenshot 2025-03-07 at 10 41 52 AM" src="https://github.com/user-attachments/assets/d63517c7-d183-4089-93da-3c76cf7dbd26" />

No relevant tasks
<img width="1281" alt="Screenshot 2025-03-07 at 10 42 00 AM" src="https://github.com/user-attachments/assets/cc336277-3975-46c2-8f75-b8194f0af237" />


Supports https://github.com/gravitational/teleport/issues/52895