### PR TITLE
S3: add a configurable option to ignore some uploads

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -394,6 +394,10 @@ const (
 	// S3UseVirtualStyleAddressing is an optional switch to use use a virtual-hosted–style URI.
 	S3UseVirtualStyleAddressing = "use_s3_virtual_style_addressing"
 
+	// S3CompleteInitiators is an optional allow list which configures the upload completer
+	// to only complete uploads from the specified set of initiators.
+	S3CompleteInitiators = "complete_initiators"
+
 	// SchemeFile configures local disk-based file storage for audit events
 	SchemeFile = "file"
 

--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -655,6 +655,12 @@ Service reads these parameters to configure its interactions with S3:
   bucket. Only applies when a custom endpoint is set. Defaults to false when unset. If used
   without a custom endpoint set, this option has no effect.
 
+- `complete_initiators` - When specified, Teleport will only complete uploads
+initiated by the specified set of initiators. This is helpful in scenarios where
+software other than Teleport is initiating multipart uploads in the recordings
+bucket. This should be set to the display name of the initiator(s) you want to
+ignore.
+
 ### S3 IAM policy
 
 (!docs/pages/includes/s3-iam-policy.mdx!)
@@ -1468,7 +1474,7 @@ teleport:
 </Admonition>
 
 Teleport can use [CockroachDB](https://www.cockroachlabs.com/) as a storage backend
-to achieve high availability and survive regional failures. You must take steps to 
+to achieve high availability and survive regional failures. You must take steps to
 protect access to CockroachDB in this configuration because that is where Teleport
 secrets like keys and user records will be stored.
 

--- a/lib/events/s3sessions/s3handler.go
+++ b/lib/events/s3sessions/s3handler.go
@@ -107,6 +107,11 @@ type Config struct {
 	// with 3rd party S3-compatible services out of the box.
 	// See https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html for more details.
 	UseVirtualStyleAddressing bool
+
+	// CompleteInitiators configures the S3 uploader to only complete
+	// uplpoads initiated by the specified set of initiators. If unspecified,
+	// the upload completer will attempt to complete all uploads in the bucket.
+	CompleteInitiators []string
 }
 
 // SetFromURL sets values on the Config from the supplied URI
@@ -167,6 +172,8 @@ func (s *Config) SetFromURL(in *url.URL, inRegion string) error {
 		// Default to false for backwards compatibility
 		s.UseVirtualStyleAddressing = false
 	}
+
+	s.CompleteInitiators = in.Query()[teleport.S3CompleteInitiators]
 
 	s.Region = region
 	s.Bucket = in.Host

--- a/lib/events/s3sessions/s3handler_config_test.go
+++ b/lib/events/s3sessions/s3handler_config_test.go
@@ -136,6 +136,16 @@ func TestConfig_SetFromURL(t *testing.T) {
 				require.True(t, config.UseVirtualStyleAddressing)
 			},
 		},
+		{
+			name: "complete initiators",
+			url:  "s3://path/bucket/audit?complete_initiators=dev-usw2-role/tenant-foo&complete_initiators=dev-usw2-role/tenant-bar",
+			cfgAssertion: func(t *testing.T, config Config) {
+				require.ElementsMatch(t, config.CompleteInitiators, []string{
+					"dev-usw2-role/tenant-foo",
+					"dev-usw2-role/tenant-bar",
+				})
+			},
+		},
 	}
 
 	for _, tt := range cases {


### PR DESCRIPTION
Teleport's uploader was written under the assumption that Teleport is the only thing generating uploads in the configured bucket. If this is no longer true, Teleport will attempt to complete uploads that it didn't start, potentially truncating the upload prematurely.

This hasn't been a problem to date, but new efforts to enable replication across regional buckets are one use case where our previous assumptions break.

This change allows us to specify an initiator to ignore, ensuring that Teleport won't stomp on or attempt to process the initiator's uploads in any way.