### PR TITLE
Fixes flaky `TestIntegrations/SessionRecordingModes`

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -946,6 +946,7 @@ func testSessionRecordingModes(t *testing.T, suite *integrationTestSuite) {
 		filesessions.SetOpenFileFunc(os.OpenFile)
 	}
 
+	teleport.WaitForNodeCount(ctx, helpers.Site, 1)
 	for name, test := range map[string]struct {
 		recordingMode        constants.SessionRecordingMode
 		expectSessionFailure bool


### PR DESCRIPTION
This PR adds a wait for the cluster to come fully online before attempting to create a session.