### PR TITLE
docs: add jwt options to application-acces full spec

### DIFF
--- a/docs/pages/reference/agent-services/application-access.mdx
+++ b/docs/pages/reference/agent-services/application-access.mdx
@@ -46,7 +46,7 @@ app_service:
       # - traits: include only traits
       # - none: exclude both roles and traits from the JWT token
       # Default: roles-and-traits
-    jwt_claims: roles-and-traits
+      jwt_claims: roles-and-traits
     redirect:
       # Rewrite the "Location" header on redirect responses replacing the
       # host with the public address of this application.

--- a/docs/pages/reference/agent-services/application-access.mdx
+++ b/docs/pages/reference/agent-services/application-access.mdx
@@ -39,9 +39,17 @@ app_service:
     public_addr: "grafana.teleport.example.com"
     # Rewrites section.
     rewrite:
+      # Specify whether to include roles or traits in the JWT.
+      # Options:
+      # - roles-and-traits: include both roles and traits
+      # - roles: include only roles
+      # - traits: include only traits
+      # - none: exclude both roles and traits from the JWT token
+      # Default: roles-and-traits
+    jwt_claims: roles-and-traits
+    redirect:
       # Rewrite the "Location" header on redirect responses replacing the
       # host with the public address of this application.
-      redirect:
       - "grafana.internal.dev"
       # Headers passthrough configuration.
       headers:

--- a/docs/pages/reference/agent-services/application-access.mdx
+++ b/docs/pages/reference/agent-services/application-access.mdx
@@ -47,9 +47,9 @@ app_service:
       # - none: exclude both roles and traits from the JWT token
       # Default: roles-and-traits
       jwt_claims: roles-and-traits
-    redirect:
       # Rewrite the "Location" header on redirect responses replacing the
       # host with the public address of this application.
+      redirect:
       - "grafana.internal.dev"
       # Headers passthrough configuration.
       headers:


### PR DESCRIPTION

Per Solutions Engineering: 

On [dynamic-registration](https://goteleport.com/docs/enroll-resources/application-access/guides/dynamic-registration/#creating-an-app-resource) for create an app resource, we point to the [full app spec](https://goteleport.com/docs/reference/agent-services/application-access/) reference which is missing the jwt section: 

```
    # Specify whether to include roles or traits in the JWT.
    # Options:
    # - roles-and-traits: include both roles and traits
    # - roles: include only roles
    # - traits: include only traits
    # - none: exclude both roles and traits from the JWT token
    # Default: roles-and-traits
    jwt_claims: roles-and-traits
```