### PR TITLE
docs: Include reference to macOS/Linux hosts for Terraform Provider prereqs

### DIFF
--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/ci-or-cloud.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/ci-or-cloud.mdx
@@ -48,7 +48,7 @@ GitLab CI, ...)
 ## Prerequisites
 
 You need either:
-- A GCP or AWS VM with terraform installed
+- A GCP or AWS Linux/MacOS VM with terraform installed
 - A git repo able to run GitHub Actions, GitLab CI or CircleCI jobs
 
 You also need:

--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/ci-or-cloud.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/ci-or-cloud.mdx
@@ -48,7 +48,7 @@ GitLab CI, ...)
 ## Prerequisites
 
 You need either:
-- A GCP or AWS Linux/MacOS VM with terraform installed
+- A GCP or AWS Linux/MacOS VM with Terraform installed
 - A git repo able to run GitHub Actions, GitLab CI or CircleCI jobs
 
 You also need:

--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/ci-or-cloud.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/ci-or-cloud.mdx
@@ -48,7 +48,7 @@ GitLab CI, ...)
 ## Prerequisites
 
 You need either:
-- A GCP or AWS Linux/MacOS VM with Terraform installed
+- A GCP or AWS Linux/macOS VM with Terraform installed
 - A git repo able to run GitHub Actions, GitLab CI or CircleCI jobs
 
 You also need:

--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/dedicated-server.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/dedicated-server.mdx
@@ -33,9 +33,9 @@ Terraform provider. The daemon stores its identity on the disk and refresh the t
 
 - (!docs/pages/includes/tctl.mdx!)
 
-- A Linux host that you wish to run the Teleport Terraform provider onto.
+- A Linux or macOS host that you wish to run the Teleport Terraform provider onto.
 
-- A Linux user on that host that you wish Terraform and `tbot` to run as.
+- A user on that host that you wish Terraform and `tbot` to run as.
 
 ## Step 1/4. Install `tbot` on your server
 

--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/dedicated-server.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/dedicated-server.mdx
@@ -33,7 +33,7 @@ Terraform provider. The daemon stores its identity on the disk and refresh the t
 
 - (!docs/pages/includes/tctl.mdx!)
 
-- A Linux or macOS host that you wish to run the Teleport Terraform provider onto.
+- A Linux or macOS host that you wish to run the Teleport Terraform provider on.
 
 - A user on that host that you wish Terraform and `tbot` to run as.
 

--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/local.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/local.mdx
@@ -21,9 +21,12 @@ connect to Teleport as the temporary bot.
 ## Prerequisites
 
 - A running Teleport Cluster whose version is higher than 16.2
+
 - Local tsh/tctl clients with versions higher than 16.2
+
 - Being locally logged in Teleport on a macOS or Linux computer with a role that allows creating Bot and Token resources.
   You can use the default `editor` role for this.
+
 - [Terraform >= (=terraform.version=)+](https://learn.hashicorp.com/tutorials/terraform/install-cli)
 
   ```code

--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/local.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/local.mdx
@@ -22,8 +22,14 @@ connect to Teleport as the temporary bot.
 
 - A running Teleport Cluster whose version is higher than 16.2
 - Local tsh/tctl clients with versions higher than 16.2
-- Being locally logged in Teleport with a role that allows creating Bot and Token resources.
+- Being locally logged in Teleport on a macOS or Linux computer with a role that allows creating Bot and Token resources.
   You can use the default `editor` role for this.
+- [Terraform >= (=terraform.version=)+](https://learn.hashicorp.com/tutorials/terraform/install-cli)
+
+  ```code
+  $ terraform version
+  # Terraform v(=terraform.version=)
+  ```
 
 To check that you can connect to your Teleport cluster, sign in with `tsh login`, then
 verify that you can run `tctl` commands using your current credentials.

--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/long-lived-credentials.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/long-lived-credentials.mdx
@@ -38,6 +38,7 @@ which is an additional security layer that protects Teleport in case of Identity
   $ terraform version
   # Terraform v(=terraform.version=)
   ```
+
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/3. Create Teleport credentials for Terraform

--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/long-lived-credentials.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/long-lived-credentials.mdx
@@ -30,13 +30,14 @@ which is an additional security layer that protects Teleport in case of Identity
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
+- A macOS or Linux host for the Terraform command executions.
+
 - [Terraform >= (=terraform.version=)+](https://learn.hashicorp.com/tutorials/terraform/install-cli)
 
   ```code
   $ terraform version
   # Terraform v(=terraform.version=)
   ```
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/3. Create Teleport credentials for Terraform

--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/long-lived-credentials.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/long-lived-credentials.mdx
@@ -30,7 +30,7 @@ which is an additional security layer that protects Teleport in case of Identity
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-- A macOS or Linux host for the Terraform command executions.
+- A Linux or macOS host for the Terraform command executions.
 
 - [Terraform >= (=terraform.version=)+](https://learn.hashicorp.com/tutorials/terraform/install-cli)
 


### PR DESCRIPTION
Provides prereqs that the Teleport Terraform provider can run on Linux and macOS. Windows support could be assumed but is not currently available. 