### PR TITLE
Update Forward SSH Server to handle terminal size requests

### DIFF
--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -986,7 +986,7 @@ func (s *Server) handleGlobalRequest(ctx context.Context, req *ssh.Request) {
 			s.logger.WarnContext(ctx, "Failed to reply to session ID query request", "error", err)
 		}
 		return
-	case teleport.KeepAliveReqType:
+	case teleport.KeepAliveReqType, teleport.TerminalSizeRequest:
 	default:
 		s.logger.DebugContext(ctx, "Rejecting unknown global request", "request_type", req.Type)
 		_ = req.Reply(false, nil)


### PR DESCRIPTION
Ensures that `x-teleport-terminal-size` requests are forwarded on to the target host instead of rejecting them.

Closes #52913.