### PR TITLE
[v15] Improve per-session MFA in a desktop session

### DIFF
--- a/lib/web/desktop.go
+++ b/lib/web/desktop.go
@@ -382,6 +382,9 @@ func (h *Handler) performMFACeremony(
 	promptMFA := mfa.PromptFunc(func(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
 		codec := tdpMFACodec{}
 
+		if chal.WebauthnChallenge == nil {
+			return nil, trace.AccessDenied("Desktop access requires WebAuthn MFA, please register a WebAuthn device to connect")
+		}
 		// Send the challenge over the socket.
 		msg, err := codec.Encode(
 			&client.MFAAuthenticateChallenge{


### PR DESCRIPTION
Backport #52790 to branch/v15

changelog: Web UI now correctly displays errors in desktop sessions when a required WebAuthn MFA device is missing