### PR TITLE
Always use the same address format in session trackers

### DIFF
--- a/lib/proxy/router_test.go
+++ b/lib/proxy/router_test.go
@@ -385,7 +385,7 @@ func TestGetServers(t *testing.T) {
 			name:         "no matches for hostname",
 			site:         testSite{cfg: &unambiguousCfg},
 			host:         "test",
-			errAssertion: require.NoError,
+			errAssertion: require.Error,
 			serverAssertion: func(t *testing.T, srv types.Server) {
 				require.Empty(t, srv)
 			},
@@ -799,7 +799,6 @@ func TestRouter_DialHost(t *testing.T) {
 				require.Equal(t, agentlessSrv, params.TargetServer)
 				require.Nil(t, params.GetUserAgent)
 				require.NotNil(t, params.AgentlessSigner)
-				require.True(t, params.IsAgentlessNode)
 				require.NotNil(t, conn)
 				require.Contains(t, params.Principals, "host")
 				require.Contains(t, params.Principals, "host.test")
@@ -819,7 +818,6 @@ func TestRouter_DialHost(t *testing.T) {
 				require.Equal(t, agentlessEC2ICESrv, params.TargetServer)
 				require.Nil(t, params.GetUserAgent)
 				require.Nil(t, params.AgentlessSigner)
-				require.True(t, params.IsAgentlessNode)
 				require.NotNil(t, conn)
 			},
 		},

--- a/lib/reversetunnelclient/api.go
+++ b/lib/reversetunnelclient/api.go
@@ -47,10 +47,6 @@ type DialParams struct {
 	// forwarding proxy.
 	GetUserAgent teleagent.Getter
 
-	// IsAgentlessNode indicates whether the Node is an OpenSSH Node.
-	// This includes Nodes whose sub kind is OpenSSH and OpenSSHEICE.
-	IsAgentlessNode bool
-
 	// AgentlessSigner is used for authenticating to the remote host when it is an
 	// agentless node.
 	AgentlessSigner ssh.Signer

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -120,11 +120,14 @@ type Server interface {
 	// event streams for recording sessions
 	events.StreamEmitter
 
-	// ID is the unique ID of the server.
+	// ID is the unique ID of the server. For the forwarding server
+	// this is the UUID of the forwarding proxy, NOT the UUID of
+	// the target host.
 	ID() string
 
 	// HostUUID is the UUID of the underlying host. For the forwarding
-	// server this is the proxy the forwarding server is running in.
+	// server this is the UUID of the target host, NOT the UUID of
+	// the forwarding proxy.
 	HostUUID() string
 
 	// GetNamespace returns the namespace the server was created in.

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -30,7 +30,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
@@ -82,8 +81,6 @@ import (
 //	}
 type Server struct {
 	logger *slog.Logger
-
-	id string
 
 	// targetConn is the TCP connection to the remote host.
 	targetConn net.Conn
@@ -174,11 +171,9 @@ type Server struct {
 	// of starting spans.
 	tracerProvider oteltrace.TracerProvider
 
-	targetID, targetAddr, targetHostname string
+	targetAddr string
 
 	// targetServer is the host that the connection is being established for.
-	// It **MUST** only be populated when the target is a teleport ssh server
-	// or an agentless server.
 	targetServer types.Server
 }
 
@@ -248,16 +243,10 @@ type ServerConfig struct {
 	// of starting spans.
 	TracerProvider oteltrace.TracerProvider
 
-	TargetID, TargetAddr, TargetHostname string
+	TargetAddr string
 
 	// TargetServer is the host that the connection is being established for.
-	// It **MUST** only be populated when the target is a teleport ssh server
-	// or an agentless server.
 	TargetServer types.Server
-
-	// IsAgentlessNode indicates whether the targetServer is a Node with an OpenSSH server (no teleport agent).
-	// This includes Nodes whose sub kind is OpenSSH and OpenSSHEphemeralKey.
-	IsAgentlessNode bool
 }
 
 // CheckDefaults makes sure all required parameters are passed in.
@@ -271,19 +260,20 @@ func (s *ServerConfig) CheckDefaults() error {
 	if s.DataDir == "" {
 		return trace.BadParameter("missing parameter DataDir")
 	}
-	if s.IsAgentlessNode {
-		if s.TargetServer == nil {
-			return trace.BadParameter("target server is required for agentless nodes")
-		}
+	if s.TargetServer == nil {
+		return trace.BadParameter("target server is required")
+	}
 
-		if s.TargetServer.GetSubKind() == types.SubKindOpenSSHNode && s.AgentlessSigner == nil {
+	if s.TargetServer.IsOpenSSHNode() {
+		if s.AgentlessSigner == nil {
 			return trace.BadParameter("agentless signer is required for OpenSSH Nodes")
 		}
+	} else {
+		if s.UserAgent == nil {
+			return trace.BadParameter("user agent required for teleport nodes")
+		}
 	}
 
-	if s.UserAgent == nil && !s.IsAgentlessNode {
-		return trace.BadParameter("user agent required for teleport nodes (agentless)")
-	}
 	if s.TargetConn == nil {
 		return trace.BadParameter("connection to target connection required")
 	}
@@ -335,7 +325,6 @@ func New(c ServerConfig) (*Server, error) {
 			"src_addr", c.SrcAddr.String(),
 			"dst_addr", c.DstAddr.String(),
 		),
-		id:              uuid.New().String(),
 		targetConn:      c.TargetConn,
 		serverConn:      utils.NewTrackingConn(serverConn),
 		clientConn:      clientConn,
@@ -353,9 +342,7 @@ func New(c ServerConfig) (*Server, error) {
 		parentContext:   c.ParentContext,
 		lockWatcher:     c.LockWatcher,
 		tracerProvider:  c.TracerProvider,
-		targetID:        c.TargetID,
 		targetAddr:      c.TargetAddr,
-		targetHostname:  c.TargetHostname,
 		targetServer:    c.TargetServer,
 	}
 
@@ -403,19 +390,14 @@ func New(c ServerConfig) (*Server, error) {
 
 // TargetMetadata returns metadata about the forwarding target.
 func (s *Server) TargetMetadata() apievents.ServerMetadata {
-	var subKind string
-	if s.targetServer != nil {
-		subKind = s.targetServer.GetSubKind()
-	}
-
 	return apievents.ServerMetadata{
 		ServerVersion:   teleport.Version,
 		ServerNamespace: s.GetNamespace(),
-		ServerID:        s.targetID,
-		ServerAddr:      s.targetAddr,
-		ServerHostname:  s.targetHostname,
+		ServerID:        s.targetServer.GetName(),
+		ServerAddr:      s.targetServer.GetName(),
+		ServerHostname:  s.targetServer.GetHostname(),
 		ForwardedBy:     s.hostUUID,
-		ServerSubKind:   subKind,
+		ServerSubKind:   s.targetServer.GetSubKind(),
 	}
 }
 
@@ -432,13 +414,13 @@ func (s *Server) GetDataDir() string {
 
 // ID returns the ID of the proxy that creates the in-memory forwarding server.
 func (s *Server) ID() string {
-	return s.id
+	return s.hostUUID
 }
 
 // HostUUID is the UUID of the underlying proxy that the forwarding server
 // is running in.
 func (s *Server) HostUUID() string {
-	return s.hostUUID
+	return s.targetServer.GetName()
 }
 
 // GetNamespace returns the namespace the forwarding server resides in.
@@ -603,7 +585,7 @@ func (s *Server) Serve() {
 		return
 	}
 
-	if s.targetServer != nil && s.targetServer.IsOpenSSHNode() {
+	if s.targetServer.IsOpenSSHNode() {
 		// OpenSSH nodes don't support moderated sessions, send an error to
 		// the user and gracefully fail if the user is attempting to create one.
 		policySets := s.identityContext.AccessChecker.SessionPolicySets()
@@ -1019,7 +1001,7 @@ func (s *Server) checkTCPIPForwardRequest(ctx context.Context, r *ssh.Request) e
 	}
 
 	// RBAC checks are only necessary when connecting to an agentless node
-	if s.targetServer != nil && s.targetServer.IsOpenSSHNode() {
+	if s.targetServer.IsOpenSSHNode() {
 		scx, err := srv.NewServerContext(s.Context(), s.connectionContext, s, s.identityContext)
 		if err != nil {
 			return err
@@ -1102,7 +1084,7 @@ func (s *Server) handleDirectTCPIPRequest(ctx context.Context, ch ssh.Channel, r
 	ch = scx.TrackActivity(ch)
 
 	// RBAC checks are only necessary when connecting to an agentless node
-	if s.targetServer != nil && s.targetServer.IsOpenSSHNode() {
+	if s.targetServer.IsOpenSSHNode() {
 		err = s.authHandlers.CheckPortForward(scx.DstAddr, scx, decisionpb.SSHPortForwardMode_SSH_PORT_FORWARD_MODE_LOCAL)
 		if err != nil {
 			s.stderrWrite(ctx, ch, err.Error())

--- a/lib/srv/forward/sshserver_test.go
+++ b/lib/srv/forward/sshserver_test.go
@@ -31,6 +31,7 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/fixtures"
@@ -259,6 +260,7 @@ func TestCheckTCPIPForward(t *testing.T) {
 			s := Server{
 				logger:          utils.NewSlogLoggerForTests(),
 				identityContext: srv.IdentityContext{Login: tt.login},
+				targetServer:    &types.ServerV2{},
 			}
 			err := s.checkTCPIPForwardRequest(context.Background(),
 				&ssh.Request{

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -2297,7 +2297,7 @@ func (s *session) trackSession(ctx context.Context, teleportUser string, policyS
 		Kind:         string(types.SSHSessionKind),
 		State:        types.SessionState_SessionStatePending,
 		Hostname:     s.serverMeta.ServerHostname,
-		Address:      s.serverMeta.ServerID,
+		Address:      s.scx.srv.HostUUID(),
 		ClusterName:  s.scx.ClusterName,
 		Login:        s.login,
 		HostUser:     teleportUser,


### PR DESCRIPTION
It is assumed that the `target_address` of a SessionTracker is the host UUID for SSH sessions. However, this was only the case when in node recording mode. The value is derived from the `ServerID` in the return value from `lib/srv.Server.TargetMetadata`. In node recording mode the value is populated from the host uuid of the process running the SSH service. In proxy recording mode, the value is populated from the server id in the dial request. The discrepancy arises from the fact that the router was altering the server id to include the cluster name suffix to populate the prinicpals appropriately.

To remedy this some slight tweaks were made to the semantics of the `srv.Server.HostUUID` and the `reversetunnelclient.DialParams`. All dial requests for SSH targets now provide the resolved types.Server. This server is used as the source of truth for the hostname and host uuid of the target by the forward server. `(forward.Server) ID()` now returns the proxy host uuid instead of a uuid generated when creating the server. `(forward.Server) HostUUID()` now returns the host uuid of the target server.

Fixes #42346.