### PR TITLE
[v17] docs: include self-hosted and cloud download reference

### DIFF
--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -472,10 +472,10 @@ For Teleport Community Edition, check the
 [Downloads](https://goteleport.com/download/) page for the most up-to-date
 information.
 
-Teleport Enterprise (Managed) provides a Enterprise download page in the Web UI. Select the user name
+On cloud-hosted Teleport Enterprise you can visit a download page in the Web UI. Select the user name
 in the upper right and select Downloads from the menu.
 
-Teleport Enterprise (Self-Hosted) customers can access Enterprise downloads and their license
+Teleport Enterprise self-hosted customers can access Enterprise downloads and their license
 file from their [dedicated account dashboard](./admin-guides/deploy-a-cluster/license.mdx).
 
 ## Docker

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -472,6 +472,12 @@ For Teleport Community Edition, check the
 [Downloads](https://goteleport.com/download/) page for the most up-to-date
 information.
 
+Teleport Enterprise (Managed) provides a Enterprise download page in the Web UI. Select the user name
+in the upper right and select Downloads from the menu.
+
+Teleport Enterprise (Self-Hosted) customers can access Enterprise downloads and their license
+file from their [dedicated account dashboard](./admin-guides/deploy-a-cluster/license.mdx).
+
 ## Docker
 
 ### Images

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -475,7 +475,7 @@ information.
 On cloud-hosted Teleport Enterprise you can visit a download page in the Web UI. Select the user name
 in the upper right and select Downloads from the menu.
 
-Teleport Enterprise self-hosted customers can access Enterprise downloads and their license
+Customers who self-host Teleport Enterprise can access Enterprise downloads and their license
 file from their [dedicated account dashboard](./admin-guides/deploy-a-cluster/license.mdx).
 
 ## Docker


### PR DESCRIPTION
Backport #50025 to branch/v17