### PR TITLE
[v16] docs: include self-hosted and cloud download reference

### DIFF
--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -456,6 +456,13 @@ For Teleport Community Edition, check the
 [Downloads](https://goteleport.com/download/) page for the most up-to-date
 information.
 
+
+On cloud-hosted Teleport Enterprise you can visit a download page in the Web UI. Select the user name
+in the upper right and select Downloads from the menu.
+
+Customers who self-host Teleport Enterprise can access Enterprise downloads and their license
+file from their [dedicated account dashboard](./admin-guides/deploy-a-cluster/license.mdx).
+
 ## Docker
 
 ### Images


### PR DESCRIPTION
backport #50025 to branch/v16