### PR TITLE
Refresh the Backup and Restore guide

### DIFF
--- a/docs/pages/admin-guides/management/operations/backup-restore.mdx
+++ b/docs/pages/admin-guides/management/operations/backup-restore.mdx
@@ -38,95 +38,118 @@ backends depends on the solution you use for each backend. The following table
 includes instructions for backing up each backend solution. For backends not
 listed here, consult the documentation for your backend:
 
+### Cluster state backends
+
 | Backend | Recommended backup strategy |
 | - | - |
 | Local Filesystem | Back up the data directory (`/var/lib/teleport/` by default) |
-| DynamoDB | [Follow AWS's guidelines for backup and restore](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/BackupRestore.html) |
-| etcd | [Follow etcd's guidelines for disaster recovery](https://etcd.io/docs/v2/admin_guide) |
-| Firestore | [Follow GCP's guidelines for automated backups](https://firebase.google.com/docs/database/backups) |
-| Azure Database for PostgreSQL | [Follow Azure's guidelines for automated backups](https://learn.microsoft.com/en-us/azure/backup/backup-azure-database-postgresql) |
+| DynamoDB | [Amazon DynamoDB documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/BackupRestore.html) |
+| etcd | [etcd documentation](https://etcd.io/docs/v2.3/admin_guide/#disaster-recovery) |
+| Firestore | [Firestore documentation](https://firebase.google.com/docs/database/backups) |
+| Azure Database for PostgreSQL | [Azure Database for PostgreSQL documentation](https://learn.microsoft.com/en-us/azure/backup/backup-azure-database-postgresql) |
+| Cloud SQL for PostgreSQL | [Cloud SQL for PostgreSQL documentation](https://cloud.google.com/sql/docs/postgres/backup-recovery/backups) |
 
-## Dynamic resources
+### Session recording backends
+
+| Backend | Recommended backup strategy |
+| - | - |
+| Local Filesystem | Back up the data directory (`/var/lib/teleport/` by default) |
+| S3 | [Amazon S3 documentation](https://docs.aws.amazon.com/aws-backup/latest/devguide/s3-backups.html) |
+| GCS | GCS has [built-in
+redundancy](https://cloud.google.com/storage/docs/availability-durability), but you may also use [cross-bucket replication](https://cloud.google.com/storage/docs/using-cross-bucket-replication) |
+| Azure Blob Storage | [Azure Blob backup documentation](https://learn.microsoft.com/en-us/azure/backup/blob-backup-overview)|
+
+## Versioning dynamic resources with infrastructure as code
 
 Teleport uses [dynamic
 resources](../../infrastructure-as-code/infrastructure-as-code.mdx) for roles,
-local users, authentication connectors, and other configurations. We recommend
-that you back up your configuration resources because they are essential to the
-normal operation of your cluster.
+local users, authentication connectors, and other configurations, and stores
+dynamic resource data on the cluster state backend. Backing up the cluster
+state backend protects your cluster against the loss of dynamic resource data.
 
-### Using infrastructure as code (recommended)
+For more control over the version of a dynamic resource that you back up and
+restore, we recommend storing dynamic resource manifests in a code repository
+that uses a version control system. You can use a continuous deployment pipeline
+to apply configurations automatically, so your Teleport cluster always reflects
+the latest state of your dynamic resources. 
 
-We recommend managing dynamic resources as code using one of the following
-tools, along with a version control system and continuous deployment pipeline
-that applies your configurations automatically:
+If you need to revert to an earlier version of a resource (e.g., to correct a
+misconfiguration), you can restore the resource on your code repository without
+conducting a full restore of the cluster state backend.
 
-- [Teleport Terraform
+Teleport provides the following infrastructure as code tools for managing
+dynamic resources:
+
+- [Terraform
   provider](../../infrastructure-as-code/terraform-provider/terraform-provider.mdx)
-- [Teleport Kubernetes
+- [Kubernetes
   operator](../../infrastructure-as-code/teleport-operator/teleport-operator.mdx)
 
-This way, you can ensure that all Teleport configurations in your cluster are
-always up to date. Your source repository can act as a backup of your dynamic
-configurations, and restoring is only a matter of applying these configurations.
+## Cloning a backend
 
-### Using a state file
+You can clone a Teleport Auth Service backend by instructing Teleport to
+retrieve all dynamic resources from one backend and apply them against another
+backend. You can use this operation to, for example, migrate dynamic resources
+to a new backend or back up dynamic resources from one region to another. 
 
-You can run a command to retrieve all resource manifests and print them to a
-single file, the **state file**, then restart the Teleport Auth Service using
-the state file to bootstrap the cluster.
+This operation uses the `teleport backend clone` command with a configuration
+file that includes information about the source and destination backends. The
+`teleport` process running the clone must have access to credentials for both
+backends. If you complete the instructions below on a virtual machine or
+Kubernetes pod that usually runs the Teleport Auth Service, you can expect the
+`teleport` process to have the required permissions.
 
-#### Restarting the Auth Service with a state file
+1. Write a configuration file for the clone. Create a file called `clone.yaml`
+   that includes the following structure:
 
-1. Log in to your Auth Service machine and run the following command:
-
-   ```code
-   $ tctl get all --with-secrets > state.yaml
+   ```yaml
+     # src is the configuration for the backend where data is cloned from.
+     src: 
+       type: sqlite
+       path: /var/lib/teleport_data
+     # dst is the configuration for the backend where data is cloned to.
+     dst:
+       type: dynamodb
+       region: us-east-1
+       table: teleport_backend
+     # parallel is the amount of backend data cloned in parallel.
+     # If a clone operation is taking too long consider increasing this value.
+     parallel: 100
+     # force, if set to true, will continue cloning data to a destination
+     # regardless of whether data is already present. By default this is false
+     # to protect against overwriting the data of an existing Teleport cluster.
+     force: false
    ```
 
-1. Prepare a new uninitialized backend (make sure to port any non-default config
-   values from the old config file):
+1. Update the `src` and `dst` sections of the clone configuration file to
+   include information about the source and destination backends. Possible
+   values of `src` and `dst` are the same as the `teleport.storage` section in
+   the Teleport configuration file. See the [Storage
+   Backends](../../../reference/backends.mdx) reference for the configuration
+   fields to assign for each backend.
+
+1. Scale your Auth Service pool down to a single instance in order to avoid
+   inconsistent data.
+
+1. Stop the Teleport Auth Service. For example, on a Linux host running a
+   Teleport binary installed through a package manager, run the following
+   command:
 
    ```code
-   $ mkdir fresh && cat > fresh.yaml << EOF
-   teleport:
-     data_dir: fresh
-   EOF
+   $ sudo systemctl stop teleport
    ```
 
-1. Stop Teleport on each Auth Service instance.
-
-1. Restart Teleport on each Auth Service instance with the fresh backend and the
-   state file you created earlier:
-
+1. Run the following command on your Auth Service instance to execute the clone
+   operation. The value of the `-c` flag is the configuration file you created
+   earlier:
+   
    ```code
-   $ sudo teleport start --config fresh.yaml --bootstrap state.yaml
+   $ sudo teleport backend clone -c clone.yaml
    ```
 
-1. From another terminal, verify that the state transferred correctly:
+After the clone operation is complete, you can either:
 
-   ```code
-   $ tctl --config fresh.yaml get all
-   # <your state here>
-   ```
-
-#### Limitations
-
-The `--bootstrap` flag has no effect, except when the Auth Service initializes
-its backend on first startup, so it is safe for use in supervised/High
-Availability contexts.
-
-The `--bootstrap` flag doesn't re-trigger Trusted Cluster handshakes, so Trusted
-Cluster resources need to be recreated manually.
-
-All the same limitations around modifying the config file of an existing cluster
-also apply to a new cluster being bootstrapped from the state of an old cluster:
-
-  - Changing the cluster name will break your CAs. This will be caught and Teleport
-    will refuse to start.
-  - Some user authentication mechanisms (e.g. WebAuthn) require that the public
-    endpoint of the Web UI remains the same. This cannot be caught by Teleport,
-    so be careful!
-  - Any Teleport Agent whose invite token is defined in the Auth Service's
-    configuration file will be able to join automatically, but Agents that were
-    added dynamically will need to be re-invited.
-
+- Start the Teleport Auth Service again with the existing backend (e.g., if you
+  are using `teleport backend clone` to back up dynamic resources).
+- Update the Teleport Auth Service configuration file to point to the new
+  backend (the `teleport.storage` section) and start the Teleport Auth Service.

--- a/docs/pages/admin-guides/management/operations/backup-restore.mdx
+++ b/docs/pages/admin-guides/management/operations/backup-restore.mdx
@@ -15,20 +15,28 @@ performing backups.
 
 ## Data to back up
 
-You must back up the following Auth Service data. The cluster state backend is a
-key-value store for dynamic resources, audit events, and other state data. The
-session recording backend is an Amazon S3-compatible object store:
+You must back up data that the Auth Service manages across its three backends:
+
+- Cluster state backend
+- Audit event backend
+- Session recording backend
+
+See [Storage Backends](../../../reference/backends.mdx) for more information on
+Teleport backends.
+
+The following table summarizes the kinds of backend data the Auth Service
+maintains:
 
 | What | Where |
 | - | - |
 | Local Users (not SSO) | Cluster state backend |
 | Certificate Authorities | Cluster state backend |
-| Dynamic resources ([more information below](#dynamic-resources)) | Cluster state backend |
+| Dynamic resources ([more information below](#versioning-dynamic-resources-with-infrastructure-as-code)) | Cluster state backend |
 | teleport.yaml | File system |
 | teleport.service | File system |
 | license.pem | File system |
 | TLS key/certificate | File system or third-party service (e.g., AWS Certificate Manager)|
-| Audit log | Cluster state backend |
+| Audit log | Audit event backend |
 | Session recordings | Session recording backend |
 
 ## Backing up Teleport backends
@@ -38,7 +46,12 @@ backends depends on the solution you use for each backend. The following table
 includes instructions for backing up each backend solution. For backends not
 listed here, consult the documentation for your backend:
 
-### Cluster state backends
+### Cluster state and audit event backends
+
+For the most part, you can use the same solution for both cluster state and
+audit events, setting aside a separate table for each kind of backend. The
+exception is etcd, which can only function as a cluster state backend. (See a
+full explanation in [Storage Backends](../../../reference/backends.mdx#etcd).)
 
 | Backend | Recommended backup strategy |
 | - | - |
@@ -88,9 +101,9 @@ dynamic resources:
 ## Cloning a backend
 
 You can clone a Teleport Auth Service backend by instructing Teleport to
-retrieve all dynamic resources from one backend and apply them against another
-backend. You can use this operation to, for example, migrate dynamic resources
-to a new backend or back up dynamic resources from one region to another. 
+retrieve all items from one backend and store them in another backend. You can
+use this operation to, for example, migrate data to a new backend or back up
+data from one region to another. 
 
 This operation uses the `teleport backend clone` command with a configuration
 file that includes information about the source and destination backends. The
@@ -105,13 +118,13 @@ Kubernetes pod that usually runs the Teleport Auth Service, you can expect the
    ```yaml
      # src is the configuration for the backend where data is cloned from.
      src: 
-       type: sqlite
-       path: /var/lib/teleport_data
-     # dst is the configuration for the backend where data is cloned to.
-     dst:
        type: dynamodb
        region: us-east-1
        table: teleport_backend
+     # dst is the configuration for the backend where data is cloned to.
+     dst:
+       type: sqlite
+       path: /var/lib/teleport_data
      # parallel is the amount of backend data cloned in parallel.
      # If a clone operation is taking too long consider increasing this value.
      parallel: 100
@@ -121,6 +134,8 @@ Kubernetes pod that usually runs the Teleport Auth Service, you can expect the
      force: false
    ```
 
+   This example clones backend data in Amazon DynamoDB to a SQLite database.
+
 1. Update the `src` and `dst` sections of the clone configuration file to
    include information about the source and destination backends. Possible
    values of `src` and `dst` are the same as the `teleport.storage` section in
@@ -128,18 +143,7 @@ Kubernetes pod that usually runs the Teleport Auth Service, you can expect the
    Backends](../../../reference/backends.mdx) reference for the configuration
    fields to assign for each backend.
 
-1. Scale your Auth Service pool down to a single instance in order to avoid
-   inconsistent data.
-
-1. Stop the Teleport Auth Service. For example, on a Linux host running a
-   Teleport binary installed through a package manager, run the following
-   command:
-
-   ```code
-   $ sudo systemctl stop teleport
-   ```
-
-1. Run the following command on your Auth Service instance to execute the clone
+1. Run the following command on an Auth Service instance to execute the clone
    operation. The value of the `-c` flag is the configuration file you created
    earlier:
    
@@ -147,9 +151,7 @@ Kubernetes pod that usually runs the Teleport Auth Service, you can expect the
    $ sudo teleport backend clone -c clone.yaml
    ```
 
-After the clone operation is complete, you can either:
-
-- Start the Teleport Auth Service again with the existing backend (e.g., if you
-  are using `teleport backend clone` to back up dynamic resources).
-- Update the Teleport Auth Service configuration file to point to the new
-  backend (the `teleport.storage` section) and start the Teleport Auth Service.
+You can run the `teleport backend clone` command on an Auth Service instance
+without stopping your cluster. The command retrieves each item from the source
+backend and writes it to the destination backend. Any items created on the
+source backend after the initial retrieval will not be included in the clone.

--- a/docs/pages/admin-guides/management/operations/backup-restore.mdx
+++ b/docs/pages/admin-guides/management/operations/backup-restore.mdx
@@ -2,147 +2,118 @@
 title: Backup and Restore
 description: How to back up and restore your Teleport cluster state.
 ---
-This guide explains the components of your Teleport deployment that must be
-backed up and lays out our recommended approach for performing backups.
+
+Operators must have a plan in place to back up self-hosted Teleport clusters.
+While the Teleport Proxy Service and Teleport Agent services are stateless, you
+should ensure that you can restore their configuration files. The Teleport Auth
+Service manages state for the entire cluster, and it is critical that you can
+back up its data. This guide explains the components of a Teleport Auth Service
+deployment that must be backed up and lays out our recommended approach for
+performing backups. 
 
 (!docs/pages/includes/cloud/call-to-action.mdx!)
 
-## What you should back up
+## Data to back up
 
-### Teleport services
-<Tabs>
-<TabItem scope={["enterprise", "oss"]} label="Self-Hosted">
+You must back up the following Auth Service data. The cluster state backend is a
+key-value store for dynamic resources, audit events, and other state data. The
+session recording backend is an Amazon S3-compatible object store:
 
-Teleport's Proxy Service and Nodes are stateless. For these components, only
-the configuration file (`/etc/teleport.yaml` by default) should be backed up.
-
-The Auth Service is Teleport's brain, and depending on the backend should be
-backed up regularly.
-
-For example, a Teleport cluster running on AWS with DynamoDB must back up the
-following data:
-
-| What | Where ( Example AWS Customer ) |
+| What | Where |
 | - | - |
-| Local Users ( not SSO ) | DynamoDB |
-| Certificate Authorities | DynamoDB |
-| Trusted Clusters | DynamoDB |
-| Connectors: SSO | DynamoDB / File System |
-| RBAC | DynamoDB / File System |
-| teleport.yaml | File System |
-| teleport.service | File System |
-| license.pem | File System |
-| TLS key/certificate | File System / AWS Certificate Manager |
-| Audit log | DynamoDB |
-| Session recordings | S3 |
+| Local Users (not SSO) | Cluster state backend |
+| Certificate Authorities | Cluster state backend |
+| Dynamic resources ([more information below](#dynamic-resources)) | Cluster state backend |
+| teleport.yaml | File system |
+| teleport.service | File system |
+| license.pem | File system |
+| TLS key/certificate | File system or third-party service (e.g., AWS Certificate Manager)|
+| Audit log | Cluster state backend |
+| Session recordings | Session recording backend |
 
-For this customer, we would recommend using [AWS best practices](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/BackupRestore.html) for backing up DynamoDB. If DynamoDB is used for
-Teleport audit logs, logged events have a TTL of 1 year.
+## Backing up Teleport backends
+
+Your plan for backing up the Teleport cluster state and session recording
+backends depends on the solution you use for each backend. The following table
+includes instructions for backing up each backend solution. For backends not
+listed here, consult the documentation for your backend:
 
 | Backend | Recommended backup strategy |
 | - | - |
-| Local Filesystem | Back up the data directory (`/var/lib/teleport/` by default) and the output of `tctl get all --with-secrets`. |
+| Local Filesystem | Back up the data directory (`/var/lib/teleport/` by default) |
 | DynamoDB | [Follow AWS's guidelines for backup and restore](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/BackupRestore.html) |
 | etcd | [Follow etcd's guidelines for disaster recovery](https://etcd.io/docs/v2/admin_guide) |
 | Firestore | [Follow GCP's guidelines for automated backups](https://firebase.google.com/docs/database/backups) |
+| Azure Database for PostgreSQL | [Follow Azure's guidelines for automated backups](https://learn.microsoft.com/en-us/azure/backup/backup-azure-database-postgresql) |
 
-</TabItem>
-<TabItem label="Cloud-Hosted">
+## Dynamic resources
 
-Teleport Enterprise Cloud manages all Auth Service and Proxy Service backups.
+Teleport uses [dynamic
+resources](../../infrastructure-as-code/infrastructure-as-code.mdx) for roles,
+local users, authentication connectors, and other configurations. We recommend
+that you back up your configuration resources because they are essential to the
+normal operation of your cluster.
 
-While Teleport Nodes are stateless, you should ensure that you can restore their
-configuration files.
+### Using infrastructure as code (recommended)
 
-</TabItem>
-</Tabs>
+We recommend managing dynamic resources as code using one of the following
+tools, along with a version control system and continuous deployment pipeline
+that applies your configurations automatically:
 
-### Teleport resources
+- [Teleport Terraform
+  provider](../../infrastructure-as-code/terraform-provider/terraform-provider.mdx)
+- [Teleport Kubernetes
+  operator](../../infrastructure-as-code/teleport-operator/teleport-operator.mdx)
 
-Teleport uses YAML resources for roles, Trusted Clusters, local users, and authentication connectors.
-These could be created via `tctl` or the Web UI.
+This way, you can ensure that all Teleport configurations in your cluster are
+always up to date. Your source repository can act as a backup of your dynamic
+configurations, and restoring is only a matter of applying these configurations.
 
-You should back up your dynamic resource configurations to ensure that you can restore them in case of an outage.
+### Using a state file
 
-## Our recommended backup practice
+You can run a command to retrieve all resource manifests and print them to a
+single file, the **state file**, then restart the Teleport Auth Service using
+the state file to bootstrap the cluster.
 
-If you're running Teleport at scale, your teams need to have an automated way to restore Teleport. At a high level, this is our recommended approach:
+#### Restarting the Auth Service with a state file
 
-<Tabs>
-<TabItem scope={["enterprise", "oss"]} label="Self-Hosted">
+1. Log in to your Auth Service machine and run the following command:
 
-- Persist and back up your backend.
-- Share that backend among Auth Service instances.
-- Store your dynamic resource configurations as discrete files in a git
-  repository.
-- Have your continuous integration system run `tctl create -f *.yaml` from the
-  git repository. The `-f` flag instructs `tctl create` not to return an error
-  if a resource already exists, so this command can be run regularly.
+   ```code
+   $ tctl get all --with-secrets > state.yaml
+   ```
 
-</TabItem>
-<TabItem scope={["cloud","team"]} label="Cloud-Hosted">
+1. Prepare a new uninitialized backend (make sure to port any non-default config
+   values from the old config file):
 
-- Store your dynamic resource configurations as discrete files in a git
-  repository.
-- Have your continuous integration system run `tctl create -f *.yaml` from the
-  git repository. The `-f` flag instructs `tctl create` not to return an error
-  if a resource already exists, so this command can be run regularly.
+   ```code
+   $ mkdir fresh && cat > fresh.yaml << EOF
+   teleport:
+     data_dir: fresh
+   EOF
+   ```
 
-</TabItem>
-</Tabs>
+1. Stop Teleport on each Auth Service instance.
 
-## Migrating backends
-<Tabs>
-<TabItem scope={["enterprise"]} label="Teleport Enterprise">
+1. Restart Teleport on each Auth Service instance with the fresh backend and the
+   state file you created earlier:
 
-You can export a collection of resources from
-Teleport using the below command. This feature helps for migrating
-from one backend to another.
+   ```code
+   $ sudo teleport start --config fresh.yaml --bootstrap state.yaml
+   ```
 
-Using `tctl get all --with-secrets` will retrieve the below items:
+1. From another terminal, verify that the state transferred correctly:
 
-- Users
-- Certificate Authorities
-- Trusted Clusters
-- Connectors:
-  - GitHub
-  - SAML
-  - OIDC
-- Roles
+   ```code
+   $ tctl --config fresh.yaml get all
+   # <your state here>
+   ```
 
-When migrating backends, you should back up your Auth Service's
-`data_dir/storage` directly.
-
-### Example of backing up and restoring a cluster
-
-```code
-# Log in to your cluster with tsh so you can use tctl from your local machine.
-# You can also run tctl on your Auth Service host without running "tsh login"
-# first.
-$ tsh login --proxy=teleport.example.com --user=myuser
-# Export dynamic configuration state from old cluster
-$ tctl get all --with-secrets > state.yaml
-
-# Prepare a new uninitialized backend (make sure to port
-# any non-default config values from the old config file)
-$ mkdir fresh && cat > fresh.yaml << EOF
-teleport:
-  data_dir: fresh
-EOF
-
-# bootstrap fresh server (kill the old one first!)
-$ sudo teleport start --config fresh.yaml --bootstrap state.yaml
-
-# from another terminal, verify state transferred correctly
-$ tctl --config fresh.yaml get all
-# <your state here>
-```
+#### Limitations
 
 The `--bootstrap` flag has no effect, except when the Auth Service initializes
-its backend initialization on first startup, so it is safe for use in
-supervised/High Availability contexts.
-
-### Limitations
+its backend on first startup, so it is safe for use in supervised/High
+Availability contexts.
 
 The `--bootstrap` flag doesn't re-trigger Trusted Cluster handshakes, so Trusted
 Cluster resources need to be recreated manually.
@@ -155,87 +126,7 @@ also apply to a new cluster being bootstrapped from the state of an old cluster:
   - Some user authentication mechanisms (e.g. WebAuthn) require that the public
     endpoint of the Web UI remains the same. This cannot be caught by Teleport,
     so be careful!
-  - Any Node whose invite token is defined in the Auth Service's configuration
-    file will be able to join automatically, but Nodes that were added
-    dynamically will need to be re-invited.
-
-</TabItem>
-<TabItem scope={["oss"]} label="Open Source">
-
-You can export a collection of resources from
-Teleport using the below command. This feature helps for migrating
-from one backend to another.
-
-Using `tctl get all --with-secrets` will retrieve the below items:
-
-- Users
-- Certificate Authorities
-- Trusted Clusters
-- GitHub Connectors
-- Roles
-
-When migrating backends, you should back up your Auth Service's
-`data_dir/storage` directly.
-
-### Example of backing up and restoring a cluster
-
-```code
-# Log in to your cluster with tsh so you can use tctl from your local machine.
-# You can also run tctl on your Auth Service host without running "tsh login"
-# first.
-$ tsh login --user=myuser --proxy=teleport.example.com
-# Export dynamic configuration state from old cluster
-$ tctl get all --with-secrets > state.yaml
-
-# Prepare a new uninitialized backend (make sure to port
-# any non-default config values from the old config file)
-$ mkdir fresh && cat > fresh.yaml << EOF
-teleport:
-  data_dir: fresh
-EOF
-
-# bootstrap fresh server (kill the old one first!)
-$ sudo teleport start --config fresh.yaml --bootstrap state.yaml
-
-# from another terminal, verify state transferred correctly
-$ tctl --config fresh.yaml get all
-# <your state here>
-```
-
-The `--bootstrap` flag has no effect, except when the Auth Service initializes
-its backend initialization on first startup, so it is safe for use in
-supervised/High Availability contexts.
-
-### Limitations
-
-The `--bootstrap` flag doesn't re-trigger Trusted Cluster handshakes, so Trusted
-Cluster resources need to be recreated manually.
-
-All the same limitations around modifying the config file of an existing cluster
-also apply to a new cluster being bootstrapped from the state of an old cluster:
-
-  - Changing the cluster name will break your CAs. This will be caught and Teleport
-    will refuse to start.
-  - Some user authentication mechanisms (e.g. WebAuthn) require that the public
-    endpoint of the Web UI remains the same. This cannot be caught by Teleport,
-    so be careful!
-  - Any Node whose invite token is defined in the Auth Service's configuration
-    file will be able to join automatically, but Nodes that were added
-    dynamically will need to be re-invited.
-
-</TabItem>
-<TabItem label="Teleport Enterprise Cloud">
-
-In Teleport Enterprise Cloud, backend data is managed for you automatically. 
-
-If you would like to migrate configuration resources to a self-hosted Teleport
-cluster, follow our recommended backup practice of storing configuration
-resources in a git repository and running `tctl create -f` regularly for each
-resource. 
-
-This will enable you to keep your configuration resources up to date regardless
-of storage backend.
-
-</TabItem>
-</Tabs>
+  - Any Teleport Agent whose invite token is defined in the Auth Service's
+    configuration file will be able to join automatically, but Agents that were
+    added dynamically will need to be re-invited.
 


### PR DESCRIPTION
Closes #31866
Closes #14537
Closes #51782
Closes #30843 

- Recommend IaC for dynamic resources instead of using `tctl`.
- Add a separate section on using `tctl get all` on the Auth Service machine.
- Remove tabs in service state section to simplify the guide.
- Condense the state type table. Condense different rows re: dynamic resources into a single row to make the table shorter. Also make this a generic table, rather than an example table for DynamoDB and S3 users.
- Assume the guide is about the Auth Service. Adjust sections accordingly.
- Add an item to the backend table re: Azure Postgres.