### PR TITLE
Remove Figure tags

### DIFF
--- a/docs/pages/admin-guides/access-controls/guides/headless.mdx
+++ b/docs/pages/admin-guides/access-controls/guides/headless.mdx
@@ -173,15 +173,11 @@ Teleport Connect can also be used to approve Headless WebAuthn logins.  Teleport
 Connect will automatically detect the Headless WebAuthn login attempt and allow
 you to approve or cancel the request.
 
-<Figure width="700">
 ![Headless Confirmation](../../../../img/headless/confirmation.png)
-</Figure>
 
 You will be prompted to tap your MFA key to complete the approval process.
 
-<Figure width="700">
 ![Headless WebAuthn Approval](../../../../img/headless/approval.png)
-</Figure>
 
 ## Troubleshooting
 

--- a/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/digitalocean.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/digitalocean.mdx
@@ -21,15 +21,13 @@ cluster to Teleport.
 ## Step 1/4. Create a DigitalOcean Kubernetes cluster
 
 Create a new [DigitalOcean Kubernetes Cluster](https://cloud.digitalocean.com/kubernetes/clusters/)
-<Figure align="left" bordered caption="Create DigitalOcean Kubernetes cluster">
-  ![Create DigitalOcean Kubernetes cluster](../../../../img/helm/digitalocean/create-k8s.png)
-</Figure>
+
+![Create DigitalOcean Kubernetes cluster](../../../../img/helm/digitalocean/create-k8s.png)
 
 <br />
 While the Kubernetes cluster is being provisioned, follow the "Getting Started" guide as shown below:
-<Figure align="left" bordered caption="Set up DigitalOcean Kubernetes client">
-  ![Set up DigitalOcean Kubernetes client](../../../../img/helm/digitalocean/setup-k8s.png)
-</Figure>
+
+![Set up DigitalOcean Kubernetes client](../../../../img/helm/digitalocean/setup-k8s.png)
 
 ## Step 2/4. Install Teleport
 
@@ -116,9 +114,8 @@ teleport-cluster-auth   ClusterIP      10.245.164.28   <none>            3025/TC
 ```
 
 Once you get the value for the external IP (it may take a few minutes for this field to be populated), update your DNS record such that the clusterName's A record points to this IP address. For example `192.168.200.200` is the external IP in the above case.
-<Figure align="left" bordered caption="Configure DNS">
-  ![Configure DNS](../../../../img/helm/digitalocean/fqdn.png)
-</Figure>
+
+![Configure DNS](../../../../img/helm/digitalocean/fqdn.png)
 
 ## Step 3/4. Create and set up Teleport user
 Now we create a Teleport user by executing the `tctl` command with `kubectl`.
@@ -148,9 +145,8 @@ NOTE: Make sure tele.example.com:443 points at a Teleport proxy which users can 
 </Tabs>
 
 Copy the link shown after executing the above command and open the link in a web browser to complete the user registration process (the link is `https://tele.example.com:443/web/invite/<invite-token>` in the above case).
-<Figure align="left" bordered caption="Set up user">
-  ![Set up user](../../../../img/helm/digitalocean/setup-user.png)
-</Figure>
+
+![Set up user](../../../../img/helm/digitalocean/setup-user.png)
 
 After you complete the registration process by setting up a password and enrolling in multi-factor authentication, you will be logged in to Teleport Web UI. 
 
@@ -179,14 +175,12 @@ $ kubectl --namespace=teleport-cluster exec -i deployment/teleport-cluster-auth 
 
 Now we will assign Teleport user **tadmin** with this role. The example below shows a process using Teleport Web UI:
 First, lets select user edit menu:
-<Figure align="left" bordered caption="Edit user">
-  ![Edit user](../../../../img/helm/digitalocean/edit-user.png)
-</Figure>
+
+![Edit user](../../../../img/helm/digitalocean/edit-user.png)
 
 Second, update the **tadmin** user role to assign the **member** role:
-<Figure align="left" bordered caption="Update role">
-  ![Update role](../../../../img/helm/digitalocean/update-role.png)
-</Figure>
+
+![Update role](../../../../img/helm/digitalocean/update-role.png)
 
 We've updated the user **tadmin** to have the **member** role, which is allowed to access a Kubernetes cluster with privilege `system:master`.
 
@@ -263,9 +257,8 @@ teleport-cluster-6cc679b6f6-7xr5h   1/1     Running   0          14h
 Voila! User **tadmin** was able to list the pods in their DigitalOcean Kubernetes cluster.
 
 Teleport keeps an audit log of access to a Kubernetes cluster. In the screenshot below, the Teleport audit log shows that the user **tadmin** has logged into the cluster.
-<Figure align="left" bordered caption="View audit log">
-  ![View audit log](../../../../img/helm/digitalocean/view-activity.png)
-</Figure>
+
+![View audit log](../../../../img/helm/digitalocean/view-activity.png)
 
 ## Next steps
 

--- a/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/gcp.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/gcp.mdx
@@ -39,39 +39,27 @@ Go to the "Roles" section of Google Cloud IAM & Admin.
 
 1. Click the "Create Role" button at the top.
 
-<Figure align="left" bordered caption="Roles section">
-  ![Roles section](../../../../img/helm/gcp/1-roles@1.5x.png)
-</Figure>
+   ![Roles section](../../../../img/helm/gcp/1-roles@1.5x.png)
 
 2. Fill in the details of a "Storage Bucket Creator" role (we suggest using the name `storage-bucket-creator-role`)
 
-<Figure align="left" bordered caption="Create role">
-  ![Create role](../../../../img/helm/gcp/2-createrole@1.5x.png)
-</Figure>
+   ![Create role](../../../../img/helm/gcp/2-createrole@1.5x.png)
 
 3. Click the "Add Permissions" button.
 
-<Figure align="left" bordered caption="Storage bucket creator role">
-  ![Storage bucket creator role](../../../../img/helm/gcp/3-addpermissions@1.5x.png)
-</Figure>
+   ![Storage bucket creator role](../../../../img/helm/gcp/3-addpermissions@1.5x.png)
 
 4. Use the "Filter" box to enter `storage.buckets.create` and select it in the list.
 
-<Figure align="left" bordered caption="Filter the list">
-  ![Filter the list](../../../../img/helm/gcp/4-storagebucketscreate@1.5x.png)
-</Figure>
+   ![Filter the list](../../../../img/helm/gcp/4-storagebucketscreate@1.5x.png)
 
 5. Check the `storage.buckets.create` permission in the list and click the "Add" button to add it to the role.
 
-<Figure align="left" bordered caption="Select storage.buckets.create">
-  ![Select storage.buckets.create](../../../../img/helm/gcp/5-select@1.5x.png)
-</Figure>
+   ![Select storage.buckets.create](../../../../img/helm/gcp/5-select@1.5x.png)
 
 6. Once all these settings are entered successfully, click the "Create" button.
 
-<Figure align="left" bordered caption="Create role">
-  ![Create role](../../../../img/helm/gcp/6-createrole@1.5x.png)
-</Figure>
+   ![Create role](../../../../img/helm/gcp/6-createrole@1.5x.png)
 
 ### Create an IAM role granting Cloud DNS permissions
 
@@ -79,41 +67,34 @@ Go to the "Roles" section of Google Cloud IAM & Admin.
 
 1. Click the "Create Role" button at the top.
 
-<Figure align="left" bordered caption="Roles section">
-  ![Roles section](../../../../img/helm/gcp/1-roles@1.5x.png)
-</Figure>
+   ![Roles section](../../../../img/helm/gcp/1-roles@1.5x.png)
 
 2. Fill in the details of a "DNS Updater" role (we suggest using the name `dns-updater-role`)
 
-<Figure align="left" bordered caption="Create role">
-  ![Create role](../../../../img/helm/gcp/13-dns-createrole@1.5x.png)
-</Figure>
+   ![Create role](../../../../img/helm/gcp/13-dns-createrole@1.5x.png)
 
 3. Click the "Add Permissions" button.
 
-<Figure align="left" bordered caption="DNS updater role">
-  ![DNS updater role](../../../../img/helm/gcp/3-addpermissions@1.5x.png)
-</Figure>
+   ![DNS updater role](../../../../img/helm/gcp/3-addpermissions@1.5x.png)
 
-4. Use the "Filter" box to find each of the following permissions in the list and add it.
-You can type things like `dns.resourceRecordSets.*` to quickly filter the list.
+4. Use the "Filter" box to find each of the following permissions in the list
+   and add it.  You can type things like `dns.resourceRecordSets.*` to quickly
+   filter the list.
 
-```console
-dns.resourceRecordSets.create
-dns.resourceRecordSets.delete
-dns.resourceRecordSets.list
-dns.resourceRecordSets.update
-dns.changes.create
-dns.changes.get
-dns.changes.list
-dns.managedZones.list
-```
+   ```console
+   dns.resourceRecordSets.create
+   dns.resourceRecordSets.delete
+   dns.resourceRecordSets.list
+   dns.resourceRecordSets.update
+   dns.changes.create
+   dns.changes.get
+   dns.changes.list
+   dns.managedZones.list
+   ```
 
 5. Once all these settings are entered successfully, click the "Create" button.
 
-<Figure align="left" bordered caption="Add DNS permissions">
-  ![Add DNS permissions](../../../../img/helm/gcp/14-dns-permissions-create@1.5x.png)
-</Figure>
+   ![Add DNS permissions](../../../../img/helm/gcp/14-dns-permissions-create@1.5x.png)
 
 ### Create a service account for the Teleport Helm chart
 
@@ -127,15 +108,11 @@ Go to the "Service Accounts" section of Google Cloud IAM & Admin.
 
 1. Click the "Create Service Account" button at the top.
 
-<Figure align="left" bordered caption="Create service account">
-  ![Create service account](../../../../img/helm/gcp/7-serviceaccounts@1.5x.png)
-</Figure>
+   ![Create service account](../../../../img/helm/gcp/7-serviceaccounts@1.5x.png)
 
 2. Enter details for the service account (we recommend using the name `teleport-helm`) and click the "Create" button.
 
-<Figure align="left" bordered caption="Enter service account details">
-  ![Enter service account details](../../../../img/helm/gcp/8-createserviceaccount@1.5x.png)
-</Figure>
+   ![Enter service account details](../../../../img/helm/gcp/8-createserviceaccount@1.5x.png)
 
 3. In the "Grant this service account access to project" section, add these four roles:
 
@@ -146,9 +123,7 @@ Go to the "Service Accounts" section of Google Cloud IAM & Admin.
 | Cloud Datastore Owner | Grants permissions to create Cloud Datastore collections |
 | Storage Object Admin | Allows read/write/delete of Google Cloud storage objects |
 
-<Figure align="left" bordered caption="Add roles">
-  ![Add roles](../../../../img/helm/gcp/9-addroles@1.5x.png)
-</Figure>
+![Add roles](../../../../img/helm/gcp/9-addroles@1.5x.png)
 
 4. Click the "continue" button to save these settings, then click the "create" button to create the service account.
 
@@ -158,22 +133,16 @@ Go back to the "Service Accounts" view in Google Cloud IAM & Admin.
 
 1. Click on the `teleport-helm` service account that you just created.
 
-<Figure align="left" bordered caption="Click on the service account">
-  ![Click on the service account](../../../../img/helm/gcp/10-serviceaccountdetails@1.5x.png)
-</Figure>
+   ![Click on the service account](../../../../img/helm/gcp/10-serviceaccountdetails@1.5x.png)
 
 2. Click the "Keys" tab at the top and click "Add Key". Choose "JSON" and click "Create".
 
-<Figure align="left" bordered caption="Create JSON key">
-  ![Create JSON key](../../../../img/helm/gcp/11-createkey.png)
-</Figure>
+   ![Create JSON key](../../../../img/helm/gcp/11-createkey.png)
 
 3. The JSON private key will be downloaded to your computer. Take note of the filename (`bens-demos-24150b1a0a7f.json` in this example)
    as you will need it shortly.
 
-<Figure align="left" bordered caption="Private key saved">
-  ![Private key saved](../../../../img/helm/gcp/12-privatekey@1.5x.png)
-</Figure>
+   ![Private key saved](../../../../img/helm/gcp/12-privatekey@1.5x.png)
 
 #### Create the Kubernetes secret containing the JSON private key for the service account
 

--- a/docs/pages/admin-guides/deploy-a-cluster/linux-demo.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/linux-demo.mdx
@@ -15,10 +15,8 @@ You can also get started right away with a production-ready Teleport cluster by
 signing up for a [free trial of Teleport Enterprise
 Cloud](https://goteleport.com/signup/).
 
-<Figure width="700">
 ![Architecture of the setup you will complete in this
 guide](../../../img/linux-server-diagram.png)
-</Figure>
 
 We will run the following Teleport services:
 

--- a/docs/pages/admin-guides/management/export-audit-events/fluentd.mdx
+++ b/docs/pages/admin-guides/management/export-audit-events/fluentd.mdx
@@ -14,9 +14,7 @@ This guide also serves as an explanation for the Teleport Event Handler plugin,
 using Fluentd as the target service. We'll create a local Docker container as a
 destination for the Event Handler:
 
-<Figure width="600">
 ![The Teleport Fluentd plugin](../../../../img/enterprise/plugins/fluentd-diagram.png)
-</Figure>
 
 You can follow the instructions below for a local proof-of-concept demo, or use any
 of the additional installation instructions to configure the Teleport Event Handler

--- a/docs/pages/admin-guides/management/guides/ec2-tags.mdx
+++ b/docs/pages/admin-guides/management/guides/ec2-tags.mdx
@@ -50,22 +50,17 @@ To launch a new instance with instance metadata tags enabled:
 1. Ensure that `Metadata accessible` is not disabled.
 1. Enable `Allow tags in metadata`.
 
-<Figure align="left" bordered caption="Advanced Options">
   ![Advanced Options](../../../../img/aws/launch-instance-advanced-options.png)
-</Figure>
 
 To modify an existing instance to enable instance metadata tags:
 
 1. From the instance summary, go to `Actions > Instance Settings > Allow tags in instance metadata`.
+
+  ![Instance Settings](../../../../img/aws/instance-settings.png)
+
 1. Enable `Allow`.
 
-<Figure align="left" bordered caption="Instance Settings">
-  ![Instance Settings](../../../../img/aws/instance-settings.png)
-</Figure>
-
-<Figure align="left" bordered caption="Allow Tags">
   ![Allow Tags](../../../../img/aws/allow-tags.png)
-</Figure>
 
 ### AWS CLI
 

--- a/docs/pages/admin-guides/teleport-policy/integrations/entra-id.mdx
+++ b/docs/pages/admin-guides/teleport-policy/integrations/entra-id.mdx
@@ -110,24 +110,18 @@ navigate to the "Access Management" tab, and choose "Enroll New Integration", th
 
 In the onboarding wizard, choose a Teleport user that will be assigned as the default owner of Access Lists that are created for your Entra groups, and click "Next".
 
-<Figure width="600">
 ![First step of the Entra ID integration onboarding](../../../../img/access-graph/entra-id/integration-wizard-step-1.png)
-</Figure>
 
 ### Grant permissions in Azure and finish onboarding
 
 The wizard will now provide you with a script that will set up the necessary permissions in Azure.
 
-<Figure width="600">
 ![Second step of the Entra ID integration onboarding](../../../../img/access-graph/entra-id/integration-wizard-step-2.png)
-</Figure>
 
 Open Azure Cloud Shell by navigating to <a href="https://shell.azure.com">shell.azure.com</a>,
 or by clicking the Cloud Shell icon in the Azure Portal.
 
-<Figure width="600">
 ![Location of the Cloud Shell button in the Azure Portal](../../../../img/access-graph/entra-id/azure-cloud-shell-button.png)
-</Figure>
 
 Make sure to use the Bash version of Cloud Shell.
 Once a Cloud Shell instance opens, paste the generated command.
@@ -141,9 +135,7 @@ it prints out the data required to finish the integration onboarding.
 
 Back in the Teleport Web UI, fill out the required data and click "Finish".
 
-<Figure width="600">
 ![Second step of the Entra ID integration onboarding with required fields filled in](../../../../img/access-graph/entra-id/integration-wizard-step-2-filled.png)
-</Figure>
 
 </TabItem>
 

--- a/docs/pages/admin-guides/teleport-policy/policy-connections.mdx
+++ b/docs/pages/admin-guides/teleport-policy/policy-connections.mdx
@@ -83,9 +83,7 @@ When you inspect a particular user's access, the Teleport Access Graph will auto
 
 To see more details about a specific database object, simply select it.
 
-<Figure width="400">
 ![Details of an individual database object](../../../img/access-graph/dac/db-object-details.png)
-</Figure>
 
 In the graph, database objects are connected by multiple edges:
 

--- a/docs/pages/connect-your-client/gui-clients.mdx
+++ b/docs/pages/connect-your-client/gui-clients.mdx
@@ -578,9 +578,7 @@ Test and create the connection.
 
 The new connection should appear on the list.
 
-<Figure width="400">
 ![SQL Developer (VS Code) Connected (basic)](../../img/database-access/guides/oracle/sql-developer-vscode-connected-basic@2x.png)
-</Figure>
 
 </TabItem>
 
@@ -607,9 +605,7 @@ Test and create the connection.
 
 The new connection should appear on the list.
 
-<Figure width="400">
 ![SQL Developer (VS Code) Connected (JDBC)](../../img/database-access/guides/oracle/sql-developer-vscode-connected-jdbc@2x.png)
-</Figure>
 
 
 </TabItem>

--- a/docs/pages/connect-your-client/putty-winscp.mdx
+++ b/docs/pages/connect-your-client/putty-winscp.mdx
@@ -131,15 +131,11 @@ If you don't provide a login to this command, your local Windows username is use
 
 1. Start PuTTY to see the saved sessions available for your cluster.
 
-<Figure width="452" height="437" caption="Main PuTTY window">
 ![Main PuTTY window](../../img/connect-your-client/putty-window.png)
-</Figure>
 
 2. Double-click a session to connect to the host through Teleport.
 
-<Figure width="661" height="418" caption="PuTTY console">
 ![PuTTY console](../../img/connect-your-client/putty-console.png)
-</Figure>
 
 After you connect to the host, Teleport generates an audit log entry for the session's start,
 and appears in the list of "Active Sessions" within Teleport.
@@ -192,24 +188,18 @@ transfer files to and from it.
 If you don't see the Site Manager "Login" dialog appear with a list of sessions to connect to when WinSCP starts,
 click the **Tabs** menu, choose **Sites**, then **Site Manager...** to show it.
 
-<Figure width="626" height="422" caption="WinSCP Site Manager window">
 ![WinSCP Site Manager window](../../img/connect-your-client/winscp-1.png)
-</Figure>
 
 2. Click the **Tools** button at the bottom left, and choose **Import Sites**.
 
-<Figure width="226" height="237" caption="Click 'Tools', then choose 'Import Sites...'">
 ![Click 'Tools', then choose 'Import Sites...'](../../img/connect-your-client/winscp-2.png)
-</Figure>
 
 3. Check the box next to any saved PuTTY sessions that you wish to import into WinSCP for use, then click the "OK" button.
 
 If you don't see sessions matching the hosts that you want to connect to, close this box and run `tsh puttyconfig <user>@<host>`
 from a terminal [as described above](#summary) to add the sessions, then repeat this step.
 
-<Figure width="374" height="301" caption="Choose PuTTY sessions to import and click OK">
 ![Choose PuTTY sessions to import and click OK](../../img/connect-your-client/winscp-3.png)
-</Figure>
 
 4. To tell WinSCP it should trust and load saved Host CAs from PuTTY, click **Tools** again at the bottom left,
 then choose **Preferences...**
@@ -218,23 +208,17 @@ then choose **Preferences...**
   You can skip steps 4 and 5 if you've completed the process as this user on this PC before.
 </Admonition>
 
-<Figure width="226" height="245" caption="Click 'Tools', then choose 'Preferences...'">
 ![Click 'Tools', then choose 'Preferences...'](../../img/connect-your-client/winscp-4.png)
-</Figure>
 
 5. Click the **Security** section at the left, then check the **Load authorities from PuTTY** checkbox under
 the *Trusted host certification authorities* section and click **OK** to exit.
 
-<Figure width="545" height="495" caption="Click 'Security', Check 'Load authorities from PuTTY' then click OK">
 ![Click 'Security', Check 'Load authorities from PuTTY' then click OK](../../img/connect-your-client/winscp-5.png)
-</Figure>
 
 6. Choose the host to connect to from the list at the left-hand side and click **Login**. You can also start the session
 by double clicking on its name if you like.
 
-<Figure width="625" height="422" caption="Choose the host from the list and click Login">
 ![Choose the host from the list and click Login](../../img/connect-your-client/winscp-6.png)
-</Figure>
 
 Uploading or downloading files using WinSCP through Teleport will generate audit events.
 

--- a/docs/pages/enroll-resources/auto-discovery/servers/azure-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/azure-discovery.mdx
@@ -182,15 +182,11 @@ you want to further limit the `assignableScopes`, you can use a resource group
 Now go to the [Subscriptions](https://portal.azure.com/#view/Microsoft_Azure_Billing/SubscriptionsBlade) page and select a subscription.
 
 Click on *Access control (IAM)* in the subscription and select *Add > Add custom role*:
-<Figure align="left">
 ![IAM custom role](../../../../img/azure/add-custom-role@2x.png)
-</Figure>
 
 In the custom role creation page, click the *JSON* tab and click *Edit*, then paste the JSON example
 and replace the subscription in `assignableScopes` with your own subscription id:
-<Figure align="left">
 ![Create JSON role](../../../../img/server-access/guides/azure/vm-create-role-from-json@2x.png)
-</Figure>
 
 ### Create a role assignment for the Teleport Discovery Service principal
 

--- a/docs/pages/enroll-resources/database-access/enroll-azure-databases/azure-postgres-mysql.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-azure-databases/azure-postgres-mysql.mdx
@@ -94,15 +94,11 @@ more information.
 Go to the [Subscriptions](https://portal.azure.com/#view/Microsoft_Azure_Billing/SubscriptionsBlade) page and select a subscription.
 
 Click on *Access control (IAM)* in the subscription and select *Add > Add custom role*:
-<Figure align="left">
 ![IAM custom role](../../../../img/azure/add-custom-role@2x.png)
-</Figure>
 
 In the custom role creation page, click the *JSON* tab and click *Edit*, then paste the JSON example
 and replace the subscription in "assignableScopes" with your own subscription id:
-<Figure align="left">
 ![Create JSON role](../../../../img/database-access/guides/azure/create-role-from-json@2x.png)
-</Figure>
 
 ### Create a role assignment for the Teleport Database Service principal
 

--- a/docs/pages/enroll-resources/database-access/enroll-azure-databases/azure-redis.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-azure-databases/azure-redis.mdx
@@ -139,15 +139,11 @@ you want to further limit the `assignableScopes`, you can use a resource group
 Now go to the [Subscriptions](https://portal.azure.com/#view/Microsoft_Azure_Billing/SubscriptionsBlade) page and select a subscription.
 
 Click on *Access control (IAM)* in the subscription and select *Add > Add custom role*:
-<Figure align="left">
 ![IAM custom role](../../../../img/azure/add-custom-role@2x.png)
-</Figure>
 
 In the custom role creation page, click the *JSON* tab and click *Edit*, then paste the JSON example
 and replace the subscription in `assignableScopes` with your own subscription id:
-<Figure align="left">
 ![Create JSON role](../../../../img/database-access/guides/azure/redis-create-role-from-json.png)
-</Figure>
 
 ### Create a role assignment for the Teleport Database Service principal
 

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/sql-server-ad-pkinit.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/sql-server-ad-pkinit.mdx
@@ -119,9 +119,7 @@ You will need to repeat these steps if you rotate Teleport's database certificat
 
 1. Click through the wizard, selecting your CA file (`db-ca.cer`).
 
-<Figure align="left" bordered caption="Import Teleport CA">
   ![Import Teleport CA](../../../../img/desktop-access/ca.png)
-</Figure>
 
 ### Enable smart card service
 
@@ -136,9 +134,7 @@ Teleport performs certificate-based authentication by emulating a smart card.
 1. Double click on `Smart Card`, select `Define this policy setting` and switch
    to `Automatic` then click `OK`.
 
-<Figure align="left" bordered caption="Enable the Smart Card service">
   ![Enable Smartcard](../../../../img/desktop-access/smartcard.png)
-</Figure>
 
 <Admonition type="note" title="gpupdate.exe">
   You will be modifying GPOs, and sometimes GPO modifications can take some time

--- a/docs/pages/enroll-resources/desktop-access/active-directory.mdx
+++ b/docs/pages/enroll-resources/desktop-access/active-directory.mdx
@@ -205,9 +205,7 @@ logins.
 
 1. Verify the **Teleport Service Account** is selected, then click **OK** in all the dialogs.
 
-   <Figure align="left" bordered caption="Deny Interactive Login">
    ![Deny interactive login](../../../img/desktop-access/deny-interactive-login.png)
-   </Figure>
 
 1. Repeat these steps for **Deny log on through Remote Desktop Services**.
 
@@ -273,9 +271,7 @@ To configure the group policy object:
    should apply this GPO to the automatically-created OU with the NetBIOS domain name
    containing `Computers` and `Users` nested one level inside the domain root.
 
-   <Figure align="left" bordered caption="AWS Managed AD OU Location">
    ![AWS Managed AD OU Location](../../../img/desktop-access/aws-managed-ad.png)
-   </Figure>
 
 1. Open **Group Policy Management** and expand Forest, Domains, your domain, and
    Group Policy Objects to locate the GPO you just created.
@@ -289,9 +285,7 @@ To configure the group policy object:
 
 1. Use the wizard to select and import the Teleport certificate.
 
-   <Figure align="left" bordered caption="Import Teleport CA">
    ![Import Teleport CA](../../../img/desktop-access/ca.png)
-   </Figure>
 
    If you are using HSM-backed keys, you should repeat this step for each CA certificate.
 
@@ -367,9 +361,7 @@ To add smart card authentication to your group policy object:
 
 1. Select **Automatic**, then click **OK**.
 
-   <Figure align="left" bordered caption="Enable the Smart Card Service">
    ![Enable Smartcard](../../../img/desktop-access/smartcard.png)
-   </Figure>
 
 1. To ensure your GPO update takes effect immediately on this host,
    open PowerShell and run the following command (optional):
@@ -401,9 +393,7 @@ Next you need to configure policies that allow remote connections to domain comp
    [NLA](#network-level-authentication-nla) section.
    </Admonition>
 
-   <Figure align="left" bordered caption="Disable Require user authentication...">
    ![Disable Require](../../../img/desktop-access/disable.png)
-   </Figure>
 
 1. Right-click **Always prompt for password upon connection**, select **Edit**,
    select **Disabled**, then click **OK**.
@@ -423,9 +413,7 @@ Next you need to configure policies that allow remote connections to domain comp
    - Select **User Mode (TCP-in)**, then click **Next**.
    - Select **Allow the connection**, then click **Finish**.
 
-   <Figure align="left" bordered caption="Open the Firewall">
    ![Open the Firewall](../../../img/desktop-access/firewall.png)
-   </Figure>
 
 1. To ensure your GPO update takes effect immediately on this host,
    open PowerShell and run the following command (optional):
@@ -447,23 +435,17 @@ the performance of remote desktop connections.
 
 1. Right-click **Configure RemoteFX**, select **Edit**, select **Enabled**, then click **OK**.
 
-   <Figure align="left" bordered caption="Enable RemoteFX (Step 1)">
    ![Enable RemoteFX](../../../img/desktop-access/enable-remotefx-step-1.png)
-   </Figure>
 
 1. Now left-click **Remote Session Environment**
    (**`Computer Configuration > Policies > Administrative Templates > Windows Components > Remote Desktop Services > Remote Desktop Session Host > Remote Session Environment`** in the left pane)
    and from the items in the right pane, right-click **Enable RemoteFX encoding for RemoteFX clients designed for Windows Server 2008 R2 SP1**, select **Edit**, select **Enabled**, then click **OK**.
 
-   <Figure align="left" bordered caption="Enable RemoteFX (Step 2)">
    ![Enable RemoteFX](../../../img/desktop-access/enable-remotefx-step-2.png)
-   </Figure>
 
 1. Again left-click **Remote Session Environment** in the left pane, and from the items in the right pane, right-click **Limit maximum color depth**, select **Edit**, select **Enabled**, then click **OK**.
 
-   <Figure align="left" bordered caption="Enable RemoteFX (Step 3)">
    ![Enable RemoteFX](../../../img/desktop-access/enable-remotefx-step-3.png)
-   </Figure>
 
 1. Open PowerShell and run the following command to update your Teleport
    group policy object:
@@ -543,9 +525,7 @@ To update the Teleport group policy object to use the new certificate template:
 1. Right-click **Server authentication certificate template**, select **Edit**, select
    **Enabled**, then set the Certificate Template Name to **RemoteDesktopAccess**.
 
-   <Figure align="left" bordered caption="RDP Certificate Template">
    ![RDP Certificate Template](../../../img/desktop-access/rdp-certificate-template.png)
-   </Figure>
 
 1. Expand Computer Configuration, Policies, and Windows Settings to select
    **Public Key Policies**.

--- a/docs/pages/enroll-resources/machine-id/access-guides/databases.mdx
+++ b/docs/pages/enroll-resources/machine-id/access-guides/databases.mdx
@@ -9,9 +9,7 @@ can be used to grant machines secure, short-lived access to these databases.
 In this guide, you will configure `tbot` to produce credentials that can be
 used to access a database configured in Teleport.
 
-<Figure align="left" bordered caption="Accessing Teleport-protected databases with Machine ID">
 ![Accessing Teleport-protected databases with Machine ID](../../../../img/machine-id/machine-id-database-access.svg)
-</Figure>
 
 ## Prerequisites
 

--- a/docs/pages/enroll-resources/machine-id/deployment/jenkins.mdx
+++ b/docs/pages/enroll-resources/machine-id/deployment/jenkins.mdx
@@ -52,9 +52,7 @@ scope for server access, reduce the blast radius if one pipeline is
 compromised, and allow you to remotely audit and lock pipelines if you detect
 malicious behavior.
 
-<Figure align="left" bordered caption="Jenkins Deployments">
   ![Jenkins Deployments](../../../../img/machine-id/jenkins.png)
-</Figure>
 
 ## Step 1/2 Configure and start Machine ID
 

--- a/docs/pages/enroll-resources/server-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/server-access/getting-started.mdx
@@ -26,13 +26,7 @@ per the instructions in this guide. Do not run the SSH Service as a Kubernetes
 pod, as there is no guarantee that the SSH Service pod is running on a server
 that a user intends to access.
 
-<Figure
-  align="center"
-  bordered
-  caption="Teleport Bastion"
->
   ![Teleport Bastion](../../../img/server-access/getting-started-diagram.png)
-</Figure>
 
 ## Prerequisites
 
@@ -145,13 +139,7 @@ Principle of Least Privilege.
 You should now be able to view your server in the Teleport Web UI after
 logging in as `myuser`:
 
-   <Figure
-     align="center"
-     bordered
-     caption="Both servers in the Web UI"
-   >
-     ![Both servers in the Web UI](../../../img/server-access/teleport_ui.png)
-   </Figure>
+![Both servers in the Web UI](../../../img/server-access/teleport_ui.png)
 
 ## Step 3/4. SSH into the server
 

--- a/docs/pages/enroll-resources/server-access/guides/recording-proxy-mode.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/recording-proxy-mode.mdx
@@ -7,13 +7,7 @@ Teleport Recording Proxy Mode was added to allow Teleport users
 to enable session recording for servers running `sshd`, which is helpful
 when gradually transitioning large server fleets to Teleport.
 
-<Figure
-  align="center"
-  bordered
-  caption="Teleport OpenSSH Recording Proxy"
->
-  ![Teleport OpenSSH Recording Proxy](../../../../img/server-access/openssh-proxy.png)
-</Figure>
+![Teleport OpenSSH Recording Proxy](../../../../img/server-access/openssh-proxy.png)
 
 <Admonition type="warning">
 

--- a/docs/pages/enroll-resources/server-access/guides/ssh-pam.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/ssh-pam.mdx
@@ -170,13 +170,7 @@ $ cat /etc/motd
 # WARNING: All activity on this node is being recorded by Teleport
 ```
 
-<Figure
-  align="center"
-  bordered
-  caption="Teleport SSH with updated MOTD"
->
-  ![Teleport SSH with updated MOTD](../../../../img/motd/teleport-with-updated-MOTD.png)
-</Figure>
+![Teleport SSH with updated MOTD](../../../../img/motd/teleport-with-updated-MOTD.png)
 
 ## Create local Unix users on login
 

--- a/docs/pages/enroll-resources/server-access/guides/vscode.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/vscode.mdx
@@ -91,17 +91,13 @@ When you see this error, re-run `tsh login` to refresh your local certificate.
 Install the [Remote - SSH extension][remote-ssh] in your local VS Code instance.
 A new "Window Indicator" (icon with two arrows) should appear in the bottom left of your VS Code window.
 
-<Figure align="left" bordered caption="Window Indicator">
 ![Window Indicator in bottom left corner of VS Code](../../../../img/vscode/window-indicator.png)
-</Figure>
 
 Prior to connecting with a host, set the `Remote.SSH: Use Local Server` setting
 to false in the extension setting. You can search for
 `@ext:ms-vscode-remote.remote-ssh ` to find the plugin-specific settings.
 
-<Figure align="left" bordered caption="VSCode Setting">
 ![Remote SSH Extension VS Code Settings](../../../../img/vscode/settings.png)
-</Figure>
 
 To connect, click on the icon with two arrows and select "Connect to Host...".
 Select "+ Add New SSH Host..."
@@ -112,9 +108,7 @@ For each host you wish to remotely develop on, add an entry like the following:
 alice@node000.foo.example.com
 ```
 
-<Figure align="left" bordered caption="Adding new Node">
 ![Input box to add new Node](../../../../img/vscode/add-host.png)
-</Figure>
 
 When prompted to choose which SSH Configuration file to update select the one we generated during Step 1.
 
@@ -126,24 +120,18 @@ Start a Remote Development session by either:
 
 1. Clicking "Connect" on the notification that opens after adding a new host.
 
-<Figure align="left" bordered caption="Host added notification">
 ![Notification of "Host added" that has connect button](../../../../img/vscode/host-added-notification.png)
-</Figure>
 
 2. Clicking on the Window Indicator again and selecting "Connect to Host".
 You should see the host you just added and any others in your Configuration file in the drop down.
 
-<Figure align="left" bordered caption="Connect to a Node">
 ![Connecting to a Teleport host in VS Code](../../../../img/vscode/select-host-to-connect.png)
-</Figure>
 
 On first connect, you'll be prompted to configure the remote OS. Select the
 proper platform and VS Code will install its server-side component. When it
 completes, you should be left with a working editor:
 
-<Figure align="left" bordered caption="Connected VS Code">
 ![VS Code connected to a Teleport Node](../../../../img/vscode/connected-editor.png)
-</Figure>
 
 The Window Indicator in the bottom left highlights the currently connected remote host.
 

--- a/docs/pages/includes/database-access/attach-iam-policies.mdx
+++ b/docs/pages/includes/database-access/attach-iam-policies.mdx
@@ -6,6 +6,4 @@ in the AWS Management Console, attach the created policy in the "Permissions
 policies" section, and set the created boundary policy in the "Permissions
 boundary" section.
 
-<Figure>
 ![IAM user](../../../img/database-access/iam@2x.png)
-</Figure>

--- a/docs/pages/includes/database-access/azure-assign-service-principal.mdx
+++ b/docs/pages/includes/database-access/azure-assign-service-principal.mdx
@@ -5,9 +5,7 @@ Navigate to the resource scope where you want to make the role assignment. Click
 select *Add > Add role assignment*. Choose the custom role you created as the role and the Teleport
 service principal as a member.
 
-<Figure align="left">
 ![Assign role](../../../img/database-access/guides/azure/create-role-assignment@2x.png)
-</Figure>
 
 <Admonition type="note" title="Azure Role Assignments">
 The role assignment should be at a high enough scope to allow the Teleport Database Service to discover

--- a/docs/pages/includes/server-access/azure-assign-service-principal.mdx
+++ b/docs/pages/includes/server-access/azure-assign-service-principal.mdx
@@ -5,9 +5,7 @@ Navigate to the resource scope where you want to make the role assignment. Click
 select *Add > Add role assignment*. Choose the custom role you created as the role and the Teleport
 service principal as a member.
 
-<Figure align="left">
 ![Assign role](../../../img/server-access/guides/azure/create-role-assignment@2x.png)
-</Figure>
 
 <Admonition type="note" title="Azure Role Assignments">
 The role assignment should be at a high enough scope to allow the Teleport Discovery Service to discover

--- a/docs/pages/reference/architecture/authentication.mdx
+++ b/docs/pages/reference/architecture/authentication.mdx
@@ -48,14 +48,7 @@ without invalidating the certificates, so any system can validate the certificat
 X.509 certificates are the same certificates you use when accessing websites with a browser. They bind
 identity to the public key with a certificate authority's signature.
 
-<Figure
-  align="center"
-  caption="Example of x.509 short-lived certs"
->
-
 ![x.509 certs](../../../img/architecture/x509-cert@2x.svg)
-
-</Figure>
 
 Teleport uses x.509 certificates for Kubernetes clusters, databases, web
 services and its own internal components, such as the Proxy Service and Auth
@@ -66,14 +59,7 @@ Service, to establish mutually authenticated TLS connections (mTLS).
 OpenSSH certificates are similar to X.509 (web) certificates and also bind identity of the user or a server
 to the public key with a certificate authority's signature.
 
-<Figure
-  align="center"
-  caption="Example of SSH short-lived certs"
->
-
 ![SSH certs](../../../img/architecture/ssh-cert@2x.svg)
-
-</Figure>
 
 OpenSSH certificate contain metadata used to authenticate users and hosts:
 
@@ -88,14 +74,7 @@ Expiry is a feature of certificates that makes time work in favor of security.
 SSH and X.509 certificates include an optional expiry date that is verified by
 servers in addition to a signature.
 
-<Figure
-  align="center"
-  caption="Example of SSH short-lived certs"
->
-
 ![Short lived certs](../../../img/architecture/ssh-cert-short-lived@1.5x.svg)
-
-</Figure>
 
 In the diagram above, Alice gets a short lived SSH certificate, but the same rules apply to
 X.509 certificates issued by Teleport and used for Kubernetes, Databases, Web Apps and Desktops.
@@ -115,14 +94,7 @@ To issue a certificate to a user, Teleport opens login screen, issues a cert and
 
 We recommend using SSO with GitHub, Okta or any other identity provider and get a cert.
 
-<Figure
-  align="center"
-  bordered="true"
-  caption="SSO exchange with short-lived certs"
-  >
-  
 ![SSO exchange for short-lived certs](../../../img/architecture/idp-sso-traits@1.5x.svg)
-</Figure>
 
 ### Short-lived Certs for Services
 
@@ -130,14 +102,7 @@ Deployment automation services, such as Jenkins, can use Teleport's Machine ID
 service to receive and renew certificates. Teleport Machine ID's bot runs alongside
 services and rotates SSH and X.509 certificates.
 
-<Figure
-  align="center"
-  bordered="true"
-  caption="Machine-ID certs"
-  >
-  
 ![Certificates for services](../../../img/architecture/certs-machine-id@1.8x.svg)
-</Figure>
 
 ### Internal certificates
 

--- a/docs/pages/reference/architecture/authorization.mdx
+++ b/docs/pages/reference/architecture/authorization.mdx
@@ -68,14 +68,7 @@ Non-interactive users have to use Teleport's machine ID product to receive and r
 Teleport Machine ID's bot runs alongside services and rotates SSH and X.509 certificates on behalf
 of non-interactive users:
 
-<Figure
-  align="center"
-  bordered="true"
-  caption="Machine-ID certs"
-  >
-
 ![Certificates for services](../../../img/architecture/certs-machine-id@1.8x.svg)
-</Figure>
 
 #### External non-interactive users
 

--- a/docs/pages/reference/architecture/tls-routing.mdx
+++ b/docs/pages/reference/architecture/tls-routing.mdx
@@ -55,9 +55,7 @@ these clients can connect to it.
 
 ### Diagram
 
-<Figure align="left" bordered caption="TLS routing">
-  ![TLS routing](../../../img/architecture/tls-routing.png)
-</Figure>
+![TLS routing](../../../img/architecture/tls-routing.png)
 
 Let's take a look at how each protocol Teleport supports implements TLS routing.
 


### PR DESCRIPTION
See gravitational/docs-website#95

The docs engine currently unwraps them, meaning that they are no-op components. Remove these so we can delete the Figure-unwrapping code.