### PR TITLE
Add rollout mutation functions

### DIFF
--- a/lib/autoupdate/rollout/transitions.go
+++ b/lib/autoupdate/rollout/transitions.go
@@ -1,0 +1,238 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package rollout
+
+import (
+	"time"
+
+	"github.com/gravitational/trace"
+
+	autoupdatev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
+	"github.com/gravitational/teleport/api/types/autoupdate"
+)
+
+const (
+	updateReasonManualTrigger  = "manual_trigger"
+	updateReasonForcedDone     = "manual_forced_done"
+	updateReasonManualRollback = "manual_rollback"
+)
+
+// TriggerGroups mutates a rollout to trigger updates for the given groups.
+// The function does not apply the rollout back, it is the caller's responsibility
+// to commit it in the backend.
+// The function takes a desired State parameter to leave room for future canary
+// state support as specified in RFD 184.
+func TriggerGroups(rollout *autoupdatev1pb.AutoUpdateAgentRollout, groupNames []string, desiredState autoupdatev1pb.AutoUpdateAgentGroupState, now time.Time) error {
+	// Validation part, we look for everything not in order or unsupported.
+	if rollout == nil {
+		return trace.BadParameter("rollout cannot be nil")
+	}
+
+	if err := checkSchedule(rollout); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := strategySupportsManualTransition(rollout); err != nil {
+		return trace.Wrap(err)
+	}
+
+	switch desiredState {
+	case autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_UNSPECIFIED:
+		// When unspecified, we default to active
+		desiredState = autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE
+	case autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE:
+	default:
+		return trace.BadParameter("unsupported desired state: %s, supported states are 'unspecified' and 'active'", desiredState)
+	}
+
+	groups := rollout.GetStatus().GetGroups()
+	if len(groups) == 0 {
+		return trace.BadParameter("rollout has no groups")
+	}
+
+	// Part where we do the real work, doing a state transition for every requested group.
+	for _, groupName := range groupNames {
+		group, err := getGroup(groups, groupName)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		// We check if the group state transition is legal.
+		switch group.GetState() {
+		case autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_UNSPECIFIED,
+			autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_UNSTARTED,
+			autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ROLLEDBACK:
+		case autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE:
+			return trace.AlreadyExists("group %q is already active", groupName)
+		case autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_DONE:
+			return trace.AlreadyExists("group %q is already done", groupName)
+		default:
+			return trace.BadParameter("group %q in unexpected state %s", groupName, group.GetState())
+		}
+
+		setGroupState(group, desiredState, updateReasonManualTrigger, now)
+	}
+
+	return nil
+}
+
+// ForceGroupsDone mutates a rollout to forcefully transition groups to the done state.
+// The function does not apply the rollout back, it is the caller's responsibility
+// to commit it in the backend.
+func ForceGroupsDone(rollout *autoupdatev1pb.AutoUpdateAgentRollout, groupNames []string, now time.Time) error {
+	// Validation part, we look for everything not in order or unsupported.
+	if rollout == nil {
+		return trace.BadParameter("rollout cannot be nil")
+	}
+
+	if err := checkSchedule(rollout); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := strategySupportsManualTransition(rollout); err != nil {
+		return trace.Wrap(err)
+	}
+
+	groups := rollout.GetStatus().GetGroups()
+	if len(groups) == 0 {
+		return trace.BadParameter("rollout has no groups")
+	}
+
+	// Part where we do the real work, doing a state transition for every requested group.
+	for _, groupName := range groupNames {
+		group, err := getGroup(groups, groupName)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		// We check if the group state transition is legal.
+		switch group.GetState() {
+		case autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_UNSPECIFIED,
+			autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_UNSTARTED,
+			autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ROLLEDBACK,
+			autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE:
+		case autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_DONE:
+			return trace.AlreadyExists("group %q is already done", groupName)
+		default:
+			return trace.BadParameter("group %q in unexpected state %s", groupName, group.GetState())
+		}
+
+		setGroupState(group, autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_DONE, updateReasonForcedDone, now)
+	}
+
+	return nil
+}
+
+// RollbackStartedGroups mutates a rollout to rollback every group that started updating.
+// The function does not apply the rollout back, it is the caller's responsibility
+// to commit it in the backend.
+func RollbackStartedGroups(rollout *autoupdatev1pb.AutoUpdateAgentRollout, now time.Time) error {
+	groups := rollout.GetStatus().GetGroups()
+	startedGroups := make([]string, 0, len(groups))
+
+	for _, group := range groups {
+		switch group.GetState() {
+		case autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE,
+			autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_DONE:
+			startedGroups = append(startedGroups, group.GetName())
+		}
+	}
+
+	if len(startedGroups) == 0 {
+		return trace.NotFound("no already started group found")
+	}
+
+	return RollbackGroups(rollout, startedGroups, now)
+}
+
+// RollbackGroups mutates a rollout to rollback groups (to the rolledback state).
+// The function does not apply the rollout back, it is the caller's responsibility
+// to commit it in the backend.
+func RollbackGroups(rollout *autoupdatev1pb.AutoUpdateAgentRollout, groupNames []string, now time.Time) error {
+	// Validation part, we look for everything not in order or unsupported.
+	if rollout == nil {
+		return trace.BadParameter("rollout cannot be nil")
+	}
+
+	if err := checkSchedule(rollout); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := strategySupportsManualTransition(rollout); err != nil {
+		return trace.Wrap(err)
+	}
+
+	groups := rollout.GetStatus().GetGroups()
+	if len(groups) == 0 {
+		return trace.BadParameter("rollout has no groups")
+	}
+
+	// Part where we do the real work, doing a state transition for every requested group.
+	for _, groupName := range groupNames {
+		group, err := getGroup(groups, groupName)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		if group.GetState() == autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ROLLEDBACK {
+			return trace.AlreadyExists("group %q is already in a rolled-back state", groupName)
+		}
+
+		setGroupState(group, autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ROLLEDBACK, updateReasonManualRollback, now)
+	}
+
+	return nil
+}
+
+// getGroup returns the group of a given name in a rollout.
+func getGroup(groups []*autoupdatev1pb.AutoUpdateAgentRolloutStatusGroup, groupName string) (*autoupdatev1pb.AutoUpdateAgentRolloutStatusGroup, error) {
+	if groupName == "" {
+		return nil, trace.BadParameter("group name cannot be empty")
+	}
+	for _, group := range groups {
+		if group.GetName() == groupName {
+			return group, nil
+		}
+	}
+	return nil, trace.NotFound("group %q not found", groupName)
+}
+
+// checkSchedule fails early if this is an immediate rollout or some unknown schedule.
+func checkSchedule(rollout *autoupdatev1pb.AutoUpdateAgentRollout) error {
+	switch rollout.GetSpec().GetSchedule() {
+	case autoupdate.AgentsScheduleImmediate:
+		return trace.BadParameter("rollout schedule is immediate, it has no groups and cannot be triggered")
+	case autoupdate.AgentsScheduleRegular:
+		return nil
+	default:
+		return trace.BadParameter("unknown rollout schedule: %v", rollout.GetSpec().GetSchedule())
+	}
+}
+
+// strategySupportsManualTransition checks if the current rollout strategy can be manually transitioned.
+// We don't currently support manual transitions in time-based rollouts.
+// We might do so in the future by introducing a new manual active state.
+func strategySupportsManualTransition(rollout *autoupdatev1pb.AutoUpdateAgentRollout) error {
+	switch rollout.GetSpec().GetStrategy() {
+	case autoupdate.AgentsStrategyHaltOnError:
+		return nil
+	default:
+		return trace.NotImplemented("manual group state transition is not supported for rollout strategy %q", rollout.GetSpec().GetStrategy())
+	}
+}

--- a/lib/autoupdate/rollout/transitions_test.go
+++ b/lib/autoupdate/rollout/transitions_test.go
@@ -1,0 +1,589 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package rollout
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	autoupdatev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
+	"github.com/gravitational/teleport/api/types/autoupdate"
+)
+
+func TestTriggerGroups(t *testing.T) {
+	now := time.Now()
+	nowPb := timestamppb.New(now)
+	spec := &autoupdatev1pb.AutoUpdateAgentRolloutSpec{
+		StartVersion:   "1.2.3",
+		TargetVersion:  "1.2.4",
+		Schedule:       autoupdate.AgentsScheduleRegular,
+		AutoupdateMode: autoupdate.AgentsUpdateModeEnabled,
+		Strategy:       autoupdate.AgentsStrategyHaltOnError,
+	}
+	status := &autoupdatev1pb.AutoUpdateAgentRolloutStatus{
+		Groups: []*autoupdatev1pb.AutoUpdateAgentRolloutStatusGroup{
+			{
+				Name:  "blue",
+				State: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ROLLEDBACK,
+			},
+			{
+				Name:  "dev",
+				State: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_DONE,
+			},
+			{
+				Name:  "stage",
+				State: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE,
+			},
+			{
+				Name:  "prod",
+				State: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_UNSTARTED,
+			},
+			{
+				Name:  "backup",
+				State: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_UNSPECIFIED,
+			},
+		},
+	}
+
+	tests := []struct {
+		name           string
+		rollout        *autoupdatev1pb.AutoUpdateAgentRollout
+		groupNames     []string
+		desiredState   autoupdatev1pb.AutoUpdateAgentGroupState
+		expectedStatus *autoupdatev1pb.AutoUpdateAgentRolloutStatus
+		expectErr      require.ErrorAssertionFunc
+	}{
+		{
+			name: "valid transition",
+			rollout: &autoupdatev1pb.AutoUpdateAgentRollout{
+				Spec:   spec,
+				Status: status,
+			},
+			groupNames:   []string{"blue", "prod", "backup"},
+			desiredState: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE,
+			expectErr:    require.NoError,
+			expectedStatus: &autoupdatev1pb.AutoUpdateAgentRolloutStatus{
+				Groups: []*autoupdatev1pb.AutoUpdateAgentRolloutStatusGroup{
+					{
+						Name:             "blue",
+						State:            autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE,
+						StartTime:        nowPb,
+						LastUpdateTime:   nowPb,
+						LastUpdateReason: updateReasonManualTrigger,
+					},
+					{
+						Name:  "dev",
+						State: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_DONE,
+					},
+					{
+						Name:  "stage",
+						State: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE,
+					},
+					{
+						Name:             "prod",
+						State:            autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE,
+						StartTime:        nowPb,
+						LastUpdateTime:   nowPb,
+						LastUpdateReason: updateReasonManualTrigger,
+					},
+					{
+						Name:             "backup",
+						State:            autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE,
+						StartTime:        nowPb,
+						LastUpdateTime:   nowPb,
+						LastUpdateReason: updateReasonManualTrigger,
+					},
+				},
+			},
+		},
+		{
+			name: "no groups in rollout",
+			rollout: &autoupdatev1pb.AutoUpdateAgentRollout{
+				Spec:   spec,
+				Status: &autoupdatev1pb.AutoUpdateAgentRolloutStatus{},
+			},
+			groupNames:   []string{"prod", "backup"},
+			desiredState: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE,
+			expectErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "rollout has no groups")
+			},
+		},
+		{
+			name: "unsupported desired state",
+			rollout: &autoupdatev1pb.AutoUpdateAgentRollout{
+				Spec:   spec,
+				Status: status,
+			},
+			groupNames:   []string{"prod", "backup"},
+			desiredState: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ROLLEDBACK,
+			expectErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "unsupported desired state")
+			},
+		},
+		{
+			name: "unsupported strategy",
+			rollout: &autoupdatev1pb.AutoUpdateAgentRollout{
+				Spec: &autoupdatev1pb.AutoUpdateAgentRolloutSpec{
+					StartVersion:   "1.2.3",
+					TargetVersion:  "1.2.4",
+					Schedule:       autoupdate.AgentsScheduleRegular,
+					AutoupdateMode: autoupdate.AgentsUpdateModeEnabled,
+					Strategy:       autoupdate.AgentsStrategyTimeBased,
+				},
+				Status: status,
+			},
+			groupNames:   []string{"prod", "backup"},
+			desiredState: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE,
+			expectErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "not supported for rollout strategy")
+			},
+		},
+		{
+			name: "unsupported schedule",
+			rollout: &autoupdatev1pb.AutoUpdateAgentRollout{
+				Spec: &autoupdatev1pb.AutoUpdateAgentRolloutSpec{
+					StartVersion:   "1.2.3",
+					TargetVersion:  "1.2.4",
+					Schedule:       autoupdate.AgentsScheduleImmediate,
+					AutoupdateMode: autoupdate.AgentsUpdateModeEnabled,
+				},
+				Status: nil,
+			},
+			groupNames:   []string{"prod", "backup"},
+			desiredState: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE,
+			expectErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "rollout schedule is immediate")
+			},
+		},
+		{
+			name: "group already active",
+			rollout: &autoupdatev1pb.AutoUpdateAgentRollout{
+				Spec:   spec,
+				Status: status,
+			},
+			groupNames:   []string{"stage"},
+			desiredState: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE,
+			expectErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "is already active")
+			},
+		},
+		{
+			name: "group already done",
+			rollout: &autoupdatev1pb.AutoUpdateAgentRollout{
+				Spec:   spec,
+				Status: status,
+			},
+			groupNames:   []string{"dev"},
+			desiredState: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE,
+			expectErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "is already done")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := TriggerGroups(tt.rollout, tt.groupNames, tt.desiredState, now)
+			tt.expectErr(t, err)
+
+			if err == nil {
+				require.Empty(t, cmp.Diff(tt.expectedStatus, tt.rollout.GetStatus(), protocmp.Transform()))
+			}
+		})
+	}
+}
+
+func TestForceGroupsDone(t *testing.T) {
+	now := time.Now()
+	nowPb := timestamppb.New(now)
+	spec := &autoupdatev1pb.AutoUpdateAgentRolloutSpec{
+		StartVersion:   "1.2.3",
+		TargetVersion:  "1.2.4",
+		Schedule:       autoupdate.AgentsScheduleRegular,
+		AutoupdateMode: autoupdate.AgentsUpdateModeEnabled,
+		Strategy:       autoupdate.AgentsStrategyHaltOnError,
+	}
+	status := &autoupdatev1pb.AutoUpdateAgentRolloutStatus{
+		Groups: []*autoupdatev1pb.AutoUpdateAgentRolloutStatusGroup{
+			{
+				Name:  "blue",
+				State: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ROLLEDBACK,
+			},
+			{
+				Name:  "dev",
+				State: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_DONE,
+			},
+			{
+				Name:  "stage",
+				State: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE,
+			},
+			{
+				Name:  "prod",
+				State: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_UNSTARTED,
+			},
+			{
+				Name:  "backup",
+				State: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_UNSPECIFIED,
+			},
+		},
+	}
+
+	tests := []struct {
+		name           string
+		rollout        *autoupdatev1pb.AutoUpdateAgentRollout
+		groupNames     []string
+		expectedStatus *autoupdatev1pb.AutoUpdateAgentRolloutStatus
+		expectErr      require.ErrorAssertionFunc
+	}{
+		{
+			name: "valid transition",
+			rollout: &autoupdatev1pb.AutoUpdateAgentRollout{
+				Spec:   spec,
+				Status: status,
+			},
+			groupNames: []string{"blue", "stage", "prod", "backup"},
+			expectErr:  require.NoError,
+			expectedStatus: &autoupdatev1pb.AutoUpdateAgentRolloutStatus{
+				Groups: []*autoupdatev1pb.AutoUpdateAgentRolloutStatusGroup{
+					{
+						Name:             "blue",
+						State:            autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_DONE,
+						LastUpdateTime:   nowPb,
+						LastUpdateReason: updateReasonForcedDone,
+					},
+					{
+						Name:  "dev",
+						State: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_DONE,
+					},
+					{
+						Name:             "stage",
+						State:            autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_DONE,
+						LastUpdateTime:   nowPb,
+						LastUpdateReason: updateReasonForcedDone,
+					},
+					{
+						Name:             "prod",
+						State:            autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_DONE,
+						LastUpdateTime:   nowPb,
+						LastUpdateReason: updateReasonForcedDone,
+					},
+					{
+						Name:             "backup",
+						State:            autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_DONE,
+						LastUpdateTime:   nowPb,
+						LastUpdateReason: updateReasonForcedDone,
+					},
+				},
+			},
+		},
+		{
+			name: "no groups in rollout",
+			rollout: &autoupdatev1pb.AutoUpdateAgentRollout{
+				Spec:   spec,
+				Status: &autoupdatev1pb.AutoUpdateAgentRolloutStatus{},
+			},
+			groupNames: []string{"prod", "backup"},
+			expectErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "rollout has no groups")
+			},
+		},
+		{
+			name: "unsupported strategy",
+			rollout: &autoupdatev1pb.AutoUpdateAgentRollout{
+				Spec: &autoupdatev1pb.AutoUpdateAgentRolloutSpec{
+					StartVersion:   "1.2.3",
+					TargetVersion:  "1.2.4",
+					Schedule:       autoupdate.AgentsScheduleRegular,
+					AutoupdateMode: autoupdate.AgentsUpdateModeEnabled,
+					Strategy:       autoupdate.AgentsStrategyTimeBased,
+				},
+				Status: status,
+			},
+			groupNames: []string{"prod", "backup"},
+			expectErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "not supported for rollout strategy")
+			},
+		},
+		{
+			name: "unsupported schedule",
+			rollout: &autoupdatev1pb.AutoUpdateAgentRollout{
+				Spec: &autoupdatev1pb.AutoUpdateAgentRolloutSpec{
+					StartVersion:   "1.2.3",
+					TargetVersion:  "1.2.4",
+					Schedule:       autoupdate.AgentsScheduleImmediate,
+					AutoupdateMode: autoupdate.AgentsUpdateModeEnabled,
+				},
+				Status: nil,
+			},
+			groupNames: []string{"prod", "backup"},
+			expectErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "rollout schedule is immediate")
+			},
+		},
+		{
+			name: "group already done",
+			rollout: &autoupdatev1pb.AutoUpdateAgentRollout{
+				Spec:   spec,
+				Status: status,
+			},
+			groupNames: []string{"dev"},
+			expectErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "is already done")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ForceGroupsDone(tt.rollout, tt.groupNames, now)
+			tt.expectErr(t, err)
+
+			if err == nil {
+				require.Empty(t, cmp.Diff(tt.expectedStatus, tt.rollout.GetStatus(), protocmp.Transform()))
+			}
+		})
+	}
+}
+
+func TestRollbackGroups(t *testing.T) {
+	now := time.Now()
+	nowPb := timestamppb.New(now)
+	spec := &autoupdatev1pb.AutoUpdateAgentRolloutSpec{
+		StartVersion:   "1.2.3",
+		TargetVersion:  "1.2.4",
+		Schedule:       autoupdate.AgentsScheduleRegular,
+		AutoupdateMode: autoupdate.AgentsUpdateModeEnabled,
+		Strategy:       autoupdate.AgentsStrategyHaltOnError,
+	}
+	status := &autoupdatev1pb.AutoUpdateAgentRolloutStatus{
+		Groups: []*autoupdatev1pb.AutoUpdateAgentRolloutStatusGroup{
+			{
+				Name:  "blue",
+				State: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ROLLEDBACK,
+			},
+			{
+				Name:  "dev",
+				State: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_DONE,
+			},
+			{
+				Name:  "stage",
+				State: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE,
+			},
+			{
+				Name:  "prod",
+				State: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_UNSTARTED,
+			},
+			{
+				Name:  "backup",
+				State: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_UNSPECIFIED,
+			},
+		},
+	}
+
+	tests := []struct {
+		name           string
+		rollout        *autoupdatev1pb.AutoUpdateAgentRollout
+		groupNames     []string
+		expectedStatus *autoupdatev1pb.AutoUpdateAgentRolloutStatus
+		expectErr      require.ErrorAssertionFunc
+	}{
+		{
+			name: "valid transition",
+			rollout: &autoupdatev1pb.AutoUpdateAgentRollout{
+				Spec:   spec,
+				Status: status,
+			},
+			groupNames: []string{"dev", "stage", "prod", "backup"},
+			expectErr:  require.NoError,
+			expectedStatus: &autoupdatev1pb.AutoUpdateAgentRolloutStatus{
+				Groups: []*autoupdatev1pb.AutoUpdateAgentRolloutStatusGroup{
+					{
+						Name:  "blue",
+						State: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ROLLEDBACK,
+					},
+					{
+						Name:             "dev",
+						State:            autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ROLLEDBACK,
+						LastUpdateTime:   nowPb,
+						LastUpdateReason: updateReasonManualRollback,
+					},
+					{
+						Name:             "stage",
+						State:            autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ROLLEDBACK,
+						LastUpdateTime:   nowPb,
+						LastUpdateReason: updateReasonManualRollback,
+					},
+					{
+						Name:             "prod",
+						State:            autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ROLLEDBACK,
+						LastUpdateTime:   nowPb,
+						LastUpdateReason: updateReasonManualRollback,
+					},
+					{
+						Name:             "backup",
+						State:            autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ROLLEDBACK,
+						LastUpdateTime:   nowPb,
+						LastUpdateReason: updateReasonManualRollback,
+					},
+				},
+			},
+		},
+		{
+			name: "no groups in rollout",
+			rollout: &autoupdatev1pb.AutoUpdateAgentRollout{
+				Spec:   spec,
+				Status: &autoupdatev1pb.AutoUpdateAgentRolloutStatus{},
+			},
+			groupNames: []string{"prod", "backup"},
+			expectErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "rollout has no groups")
+			},
+		},
+		{
+			name: "unsupported strategy",
+			rollout: &autoupdatev1pb.AutoUpdateAgentRollout{
+				Spec: &autoupdatev1pb.AutoUpdateAgentRolloutSpec{
+					StartVersion:   "1.2.3",
+					TargetVersion:  "1.2.4",
+					Schedule:       autoupdate.AgentsScheduleRegular,
+					AutoupdateMode: autoupdate.AgentsUpdateModeEnabled,
+					Strategy:       autoupdate.AgentsStrategyTimeBased,
+				},
+				Status: status,
+			},
+			groupNames: []string{"prod", "backup"},
+			expectErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "not supported for rollout strategy")
+			},
+		},
+		{
+			name: "unsupported schedule",
+			rollout: &autoupdatev1pb.AutoUpdateAgentRollout{
+				Spec: &autoupdatev1pb.AutoUpdateAgentRolloutSpec{
+					StartVersion:   "1.2.3",
+					TargetVersion:  "1.2.4",
+					Schedule:       autoupdate.AgentsScheduleImmediate,
+					AutoupdateMode: autoupdate.AgentsUpdateModeEnabled,
+				},
+				Status: nil,
+			},
+			groupNames: []string{"prod", "backup"},
+			expectErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "rollout schedule is immediate")
+			},
+		},
+		{
+			name: "group already rolledback",
+			rollout: &autoupdatev1pb.AutoUpdateAgentRollout{
+				Spec:   spec,
+				Status: status,
+			},
+			groupNames: []string{"blue"},
+			expectErr: func(t require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(t, err, "is already in a rolled-back state")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := RollbackGroups(tt.rollout, tt.groupNames, now)
+			tt.expectErr(t, err)
+
+			if err == nil {
+				require.Empty(t, cmp.Diff(tt.expectedStatus, tt.rollout.GetStatus(), protocmp.Transform()))
+			}
+		})
+	}
+}
+
+func TestRollbackStartedGroups(t *testing.T) {
+	now := time.Now()
+	nowPb := timestamppb.New(now)
+
+	rollout := &autoupdatev1pb.AutoUpdateAgentRollout{
+		Spec: &autoupdatev1pb.AutoUpdateAgentRolloutSpec{
+			StartVersion:   "1.2.3",
+			TargetVersion:  "1.2.4",
+			Schedule:       autoupdate.AgentsScheduleRegular,
+			AutoupdateMode: autoupdate.AgentsUpdateModeEnabled,
+			Strategy:       autoupdate.AgentsStrategyHaltOnError,
+		},
+		Status: &autoupdatev1pb.AutoUpdateAgentRolloutStatus{
+			Groups: []*autoupdatev1pb.AutoUpdateAgentRolloutStatusGroup{
+				{
+					Name:  "blue",
+					State: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ROLLEDBACK,
+				},
+				{
+					Name:  "dev",
+					State: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_DONE,
+				},
+				{
+					Name:  "stage",
+					State: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ACTIVE,
+				},
+				{
+					Name:  "prod",
+					State: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_UNSTARTED,
+				},
+				{
+					Name:  "backup",
+					State: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_UNSPECIFIED,
+				},
+			},
+		},
+	}
+
+	expectedGroups := []*autoupdatev1pb.AutoUpdateAgentRolloutStatusGroup{
+		{
+			// Already rolledback group is not changed.
+			Name:  "blue",
+			State: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ROLLEDBACK,
+		},
+		{
+			// Active and done groups are rolledback.
+			Name:             "dev",
+			State:            autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ROLLEDBACK,
+			LastUpdateTime:   nowPb,
+			LastUpdateReason: updateReasonManualRollback,
+		},
+		{
+			Name:             "stage",
+			State:            autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_ROLLEDBACK,
+			LastUpdateTime:   nowPb,
+			LastUpdateReason: updateReasonManualRollback,
+		},
+		{
+			// Unstarted and unknown groups are not changed.
+			Name:  "prod",
+			State: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_UNSTARTED,
+		},
+		{
+			Name:  "backup",
+			State: autoupdatev1pb.AutoUpdateAgentGroupState_AUTO_UPDATE_AGENT_GROUP_STATE_UNSPECIFIED,
+		},
+	}
+
+	require.NoError(t, RollbackStartedGroups(rollout, now))
+	require.Empty(t, cmp.Diff(expectedGroups, rollout.GetStatus().GetGroups(), protocmp.Transform()))
+
+}


### PR DESCRIPTION
PR 1/4 adding manual rollout control as specified [in RFD 184](https://github.com/gravitational/teleport/blob/master/rfd/0184-agent-auto-updates.md).

This PR adds the functions mutating the rollout. Those functions will be invoked by the autoupdate service in a followup PR.