### PR TITLE
[v17] ci: Remove changelog check concurrency

### DIFF
--- a/.github/workflows/changelog-merge-queue.yaml
+++ b/.github/workflows/changelog-merge-queue.yaml
@@ -1,6 +1,6 @@
 # This check runs only on PRs that are in the merge queue.
 #
-# PRs in the merge queue have already been approved but the reviewers check
+# PRs in the merge queue have already passed changelog validation but the check
 # is still required so this workflow allows the required check to succeed,
 # otherwise PRs in the merge queue would be blocked indefinitely.
 #

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -1,6 +1,7 @@
-# This changelog ensures that PR bodies include a `changelog: <changelog entry>` section,
-# or a `no-changelog` label set. If they do not, then a comment will be added to the PR
-# asking the developer to add one of the two.
+# The changelog workflow checks that a PR message has a line of the form
+# `changelog: <text>` or a `no-changelog` label. If neither are present,
+# the workflow run will fail, and as this workflow job is a required check,
+# the PR cannot be merged.
 name: Validate changelog entry
 on:
   pull_request:
@@ -15,11 +16,6 @@ on:
 
 permissions:
   pull-requests: write
-
-concurrency: 
-  cancel-in-progress: true
-  # This value is arbitrary as long as it includes the pull request number
-  group: 'limit to running one instance at a time for the pull request ${{ github.event.pull_request.number }}'
 
 jobs:
   validate-changelog:


### PR DESCRIPTION
Remove the changelog.yaml workflow concurrency check that ensures only
one instance runs at a time, with later runs killing earlier ones. This
was previously used to ensure we did not put multiple messages on the
PR, but as we no longer write messages to the PR, we don't need this.

The concurrency constraint causes an occasional problem where due to
workflow scheduling irregularities an earlier workflow run starts after
a later one, killing it and leaving the PR without a required check
having run on the latest commit.

Backport: https://github.com/gravitational/teleport/pull/52939
