### PR TITLE
[teleport-update] Support for CentOS 7

### DIFF
--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -372,6 +372,7 @@ func (s SystemdService) Enable(ctx context.Context, now bool) error {
 	if err := s.checkSystem(ctx); err != nil {
 		return trace.Wrap(err)
 	}
+	// The --now flag is not supported in systemd versions older than 219.
 	code := s.systemctl(ctx, slog.LevelInfo, "enable", s.ServiceName)
 	if code != 0 {
 		return trace.Errorf("unable to enable systemd service")
@@ -391,6 +392,7 @@ func (s SystemdService) Disable(ctx context.Context, now bool) error {
 	if err := s.checkSystem(ctx); err != nil {
 		return trace.Wrap(err)
 	}
+	// The --now flag is not supported in systemd versions older than 219.
 	code := s.systemctl(ctx, slog.LevelInfo, "disable", s.ServiceName)
 	if code != 0 {
 		return trace.Errorf("unable to disable systemd service")

--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -372,7 +372,7 @@ func (s SystemdService) Enable(ctx context.Context, now bool) error {
 	if err := s.checkSystem(ctx); err != nil {
 		return trace.Wrap(err)
 	}
-	// The --now flag is not supported in systemd versions older than 219,
+	// The --now flag is not supported in systemd versions older than 220,
 	// so perform enable + start commands instead.
 	code := s.systemctl(ctx, slog.LevelInfo, "enable", s.ServiceName)
 	if code != 0 {
@@ -393,7 +393,8 @@ func (s SystemdService) Disable(ctx context.Context, now bool) error {
 	if err := s.checkSystem(ctx); err != nil {
 		return trace.Wrap(err)
 	}
-	// The --now flag is not supported in systemd versions older than 219.
+	// The --now flag is not supported in systemd versions older than 220,
+	// so perform enable + start commands instead.
 	code := s.systemctl(ctx, slog.LevelInfo, "disable", s.ServiceName)
 	if code != 0 {
 		return trace.Errorf("unable to disable systemd service")
@@ -446,7 +447,7 @@ func (s SystemdService) IsPresent(ctx context.Context) (bool, error) {
 	if err := s.checkSystem(ctx); err != nil {
 		return false, trace.Wrap(err)
 	}
-	if hasSystemDBelow(ctx, 233) {
+	if hasSystemDBelow(ctx, 246) {
 		return false, trace.Wrap(ErrNotSupported)
 	}
 	code := s.systemctl(ctx, slog.LevelDebug, "list-unit-files", "--quiet", s.ServiceName)

--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -372,7 +372,8 @@ func (s SystemdService) Enable(ctx context.Context, now bool) error {
 	if err := s.checkSystem(ctx); err != nil {
 		return trace.Wrap(err)
 	}
-	// The --now flag is not supported in systemd versions older than 219.
+	// The --now flag is not supported in systemd versions older than 219,
+	// so perform enable + start commands instead.
 	code := s.systemctl(ctx, slog.LevelInfo, "enable", s.ServiceName)
 	if code != 0 {
 		return trace.Errorf("unable to enable systemd service")
@@ -487,10 +488,8 @@ func hasSystemDBelow(ctx context.Context, i int) bool {
 	if err != nil {
 		return false
 	}
-	if v, ok := parseSystemDVersion(out); ok && v < i {
-		return true
-	}
-	return false
+	v, ok := parseSystemDVersion(out)
+	return ok && v < i
 }
 
 // parseSystemDVersion parses the SystemD version from systemctl command output.

--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -415,7 +415,7 @@ func (s SystemdService) IsEnabled(ctx context.Context) (bool, error) {
 		return false, trace.Wrap(err)
 	}
 	if hasSystemDBelow(ctx, 238) {
-		return false, trace.Wrap(ErrNotSupported)
+		return false, trace.Wrap(ErrNotAvailable)
 	}
 	code := s.systemctl(ctx, slog.LevelDebug, "is-enabled", "--quiet", s.ServiceName)
 	switch {
@@ -448,7 +448,7 @@ func (s SystemdService) IsPresent(ctx context.Context) (bool, error) {
 		return false, trace.Wrap(err)
 	}
 	if hasSystemDBelow(ctx, 246) {
-		return false, trace.Wrap(ErrNotSupported)
+		return false, trace.Wrap(ErrNotAvailable)
 	}
 	code := s.systemctl(ctx, slog.LevelDebug, "list-unit-files", "--quiet", s.ServiceName)
 	if code < 0 {

--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -371,15 +372,17 @@ func (s SystemdService) Enable(ctx context.Context, now bool) error {
 	if err := s.checkSystem(ctx); err != nil {
 		return trace.Wrap(err)
 	}
-	args := []string{"enable", s.ServiceName}
-	if now {
-		args = append(args, "--now")
-	}
-	code := s.systemctl(ctx, slog.LevelInfo, args...)
+	code := s.systemctl(ctx, slog.LevelInfo, "enable", s.ServiceName)
 	if code != 0 {
 		return trace.Errorf("unable to enable systemd service")
 	}
-	s.Log.InfoContext(ctx, "Service enabled.", unitKey, s.ServiceName)
+	if now {
+		code := s.systemctl(ctx, slog.LevelInfo, "start", s.ServiceName)
+		if code != 0 {
+			return trace.Errorf("unable to start systemd service")
+		}
+	}
+	s.Log.InfoContext(ctx, "Systemd service enabled.", unitKey, s.ServiceName, "now", now)
 	return nil
 }
 
@@ -388,15 +391,17 @@ func (s SystemdService) Disable(ctx context.Context, now bool) error {
 	if err := s.checkSystem(ctx); err != nil {
 		return trace.Wrap(err)
 	}
-	args := []string{"disable", s.ServiceName}
-	if now {
-		args = append(args, "--now")
-	}
-	code := s.systemctl(ctx, slog.LevelInfo, args...)
+	code := s.systemctl(ctx, slog.LevelInfo, "disable", s.ServiceName)
 	if code != 0 {
 		return trace.Errorf("unable to disable systemd service")
 	}
-	s.Log.InfoContext(ctx, "Systemd service disabled.", unitKey, s.ServiceName)
+	if now {
+		code := s.systemctl(ctx, slog.LevelInfo, "stop", s.ServiceName)
+		if code != 0 {
+			return trace.Errorf("unable to stop systemd service")
+		}
+	}
+	s.Log.InfoContext(ctx, "Systemd service disabled.", unitKey, s.ServiceName, "now", now)
 	return nil
 }
 
@@ -404,6 +409,9 @@ func (s SystemdService) Disable(ctx context.Context, now bool) error {
 func (s SystemdService) IsEnabled(ctx context.Context) (bool, error) {
 	if err := s.checkSystem(ctx); err != nil {
 		return false, trace.Wrap(err)
+	}
+	if hasSystemDBelow(ctx, 238) {
+		return false, trace.Wrap(ErrNotSupported)
 	}
 	code := s.systemctl(ctx, slog.LevelDebug, "is-enabled", "--quiet", s.ServiceName)
 	switch {
@@ -435,6 +443,9 @@ func (s SystemdService) IsPresent(ctx context.Context) (bool, error) {
 	if err := s.checkSystem(ctx); err != nil {
 		return false, trace.Wrap(err)
 	}
+	if hasSystemDBelow(ctx, 233) {
+		return false, trace.Wrap(ErrNotSupported)
+	}
 	code := s.systemctl(ctx, slog.LevelDebug, "list-unit-files", "--quiet", s.ServiceName)
 	if code < 0 {
 		return false, trace.Errorf("unable to determine if systemd service %s is present", s.ServiceName)
@@ -464,6 +475,34 @@ func hasSystemD() (bool, error) {
 		return false, trace.Wrap(err)
 	}
 	return true, nil
+}
+
+// hasSystemDBelow returns true the version of systemd can be determined, and it
+// is below the provided version.
+func hasSystemDBelow(ctx context.Context, i int) bool {
+	cmd := exec.CommandContext(ctx, "systemctl", "--version")
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	if v, ok := parseSystemDVersion(out); ok && v < i {
+		return true
+	}
+	return false
+}
+
+// parseSystemDVersion parses the SystemD version from systemctl command output.
+func parseSystemDVersion(out []byte) (int, bool) {
+	first, _, _ := strings.Cut(string(out), "\n")
+	parts := strings.SplitN(first, " ", 3)
+	if len(parts) < 2 || parts[0] != "systemd" {
+		return 0, false
+	}
+	version, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, false
+	}
+	return version, true
 }
 
 // systemctl returns a systemctl subcommand, converting the output to logs.

--- a/lib/autoupdate/agent/process.go
+++ b/lib/autoupdate/agent/process.go
@@ -394,7 +394,7 @@ func (s SystemdService) Disable(ctx context.Context, now bool) error {
 		return trace.Wrap(err)
 	}
 	// The --now flag is not supported in systemd versions older than 220,
-	// so perform enable + start commands instead.
+	// so perform disable + stop commands instead.
 	code := s.systemctl(ctx, slog.LevelInfo, "disable", s.ServiceName)
 	if code != 0 {
 		return trace.Errorf("unable to disable systemd service")

--- a/lib/autoupdate/agent/process_test.go
+++ b/lib/autoupdate/agent/process_test.go
@@ -311,3 +311,47 @@ func TestTickFile(t *testing.T) {
 		})
 	}
 }
+
+func TestParseSystemdVersion(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name    string
+		output  string
+		version int
+	}{
+		{
+			name:    "valid",
+			output:  "systemd 249 (249.4-1ubuntu1.1)\n+PAM +AUDIT\n",
+			version: 249,
+		},
+		{
+			name:    "short",
+			output:  "systemd 249\n",
+			version: 249,
+		},
+		{
+			name:    "stripped",
+			output:  "systemd 249",
+			version: 249,
+		},
+		{
+			name:   "missing",
+			output: "systemd",
+		},
+		{
+			name:   "bad",
+			output: "not found",
+		},
+		{
+			name: "empty",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			v, ok := parseSystemDVersion([]byte(tt.output))
+			if tt.version == 0 {
+				require.False(t, ok)
+			}
+			require.Equal(t, tt.version, v)
+		})
+	}
+}

--- a/lib/autoupdate/agent/setup.go
+++ b/lib/autoupdate/agent/setup.go
@@ -234,7 +234,7 @@ func (ns *Namespace) Setup(ctx context.Context, path string) error {
 		// If the old teleport-upgrade script is detected, disable it to ensure they do not interfere.
 		// Note that the schedule is also set to nop by the Teleport agent -- this just prevents restarts.
 		present, err := oldTimer.IsPresent(ctx)
-		if errors.Is(err, ErrNotSupported) { // systemd too old
+		if errors.Is(err, ErrNotAvailable) { // systemd too old
 			if err := oldTimer.Disable(ctx, true); err != nil {
 				ns.log.DebugContext(ctx, "The deprecated teleport-ent-updater package is either missing, or could not be disabled.", errorKey, err)
 			}
@@ -294,7 +294,7 @@ func (ns *Namespace) Teardown(ctx context.Context) error {
 		}
 		// If the old upgrader exists, attempt to re-enable it automatically
 		present, err := oldTimer.IsPresent(ctx)
-		if errors.Is(err, ErrNotSupported) { // systemd too old
+		if errors.Is(err, ErrNotAvailable) { // systemd too old
 			if err := oldTimer.Enable(ctx, true); err != nil {
 				ns.log.DebugContext(ctx, "The deprecated teleport-ent-updater package is either missing, or could not be enabled.", errorKey, err)
 			}

--- a/lib/autoupdate/agent/setup.go
+++ b/lib/autoupdate/agent/setup.go
@@ -234,7 +234,7 @@ func (ns *Namespace) Setup(ctx context.Context, path string) error {
 		// If the old teleport-upgrade script is detected, disable it to ensure they do not interfere.
 		// Note that the schedule is also set to nop by the Teleport agent -- this just prevents restarts.
 		present, err := oldTimer.IsPresent(ctx)
-		if errors.Is(err, ErrNotSupported) {
+		if errors.Is(err, ErrNotSupported) { // systemd too old
 			if err := oldTimer.Disable(ctx, true); err != nil {
 				ns.log.DebugContext(ctx, "The deprecated teleport-ent-updater package is either missing, or could not be disabled.", errorKey, err)
 			}
@@ -294,7 +294,7 @@ func (ns *Namespace) Teardown(ctx context.Context) error {
 		}
 		// If the old upgrader exists, attempt to re-enable it automatically
 		present, err := oldTimer.IsPresent(ctx)
-		if errors.Is(err, ErrNotSupported) {
+		if errors.Is(err, ErrNotSupported) { // systemd too old
 			if err := oldTimer.Enable(ctx, true); err != nil {
 				ns.log.DebugContext(ctx, "The deprecated teleport-ent-updater package is either missing, or could not be enabled.", errorKey, err)
 			}

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -525,7 +525,7 @@ func (u *Updater) removeWithoutSystem(ctx context.Context, cfg *UpdateConfig, fo
 		u.Log.WarnContext(ctx, "No packaged installation of Teleport was found, and --force was passed. Teleport will be removed from this system.")
 	}
 	u.Log.InfoContext(ctx, "Updater-managed installation of Teleport detected. Attempting to unlink and remove.")
-	ok, err := isActiveOrEnabled(ctx, u.Process)
+	ok, err := u.Process.IsActive(ctx)
 	if err != nil && !errors.Is(err, ErrNotSupported) {
 		return trace.Wrap(err)
 	}
@@ -541,25 +541,6 @@ func (u *Updater) removeWithoutSystem(ctx context.Context, cfg *UpdateConfig, fo
 	}
 	u.Log.InfoContext(ctx, "Automatic update configuration for Teleport successfully uninstalled.")
 	return nil
-}
-
-// isActiveOrEnabled returns true if the service is active or enabled.
-func isActiveOrEnabled(ctx context.Context, s Process) (bool, error) {
-	enabled, err := s.IsEnabled(ctx)
-	if err != nil {
-		return false, trace.Wrap(err)
-	}
-	if enabled {
-		return true, nil
-	}
-	active, err := s.IsActive(ctx)
-	if err != nil {
-		return false, trace.Wrap(err)
-	}
-	if active {
-		return true, nil
-	}
-	return false, nil
 }
 
 // Status returns all available local and remote fields related to agent auto-updates.
@@ -938,10 +919,14 @@ func (u *Updater) Setup(ctx context.Context, path string, restart bool) error {
 
 // notices displays final notices after install or update.
 func (u *Updater) notices(ctx context.Context) error {
-	enabled, err := u.Process.IsEnabled(ctx)
-	if errors.Is(err, ErrNotSupported) {
+	if ok, err := hasSystemD(); err == nil && !ok {
 		u.Log.WarnContext(ctx, "Teleport is installed, but systemd is not present to start it.")
 		u.Log.WarnContext(ctx, "After configuring teleport.yaml, your system must also be configured to start Teleport.")
+		return nil
+	}
+	enabled, err := u.Process.IsEnabled(ctx)
+	if errors.Is(err, ErrNotSupported) {
+		u.Log.WarnContext(ctx, "Remember to use systemctl to enable and start Teleport.")
 		return nil
 	}
 	if err != nil {
@@ -1035,10 +1020,11 @@ func (u *Updater) LinkPackage(ctx context.Context) error {
 		return trace.Wrap(err, "failed to sync systemd configuration")
 	} else {
 		present, err := u.Process.IsPresent(ctx)
-		if err != nil {
+		if errors.Is(err, ErrNotSupported) {
+			u.Log.DebugContext(ctx, "Systemd version is outdated. Skipping SELinux verification.")
+		} else if err != nil {
 			return trace.Wrap(err, "failed to determine if Teleport has an installed systemd service")
-		}
-		if !present {
+		} else if !present {
 			return trace.Errorf("cannot find systemd service for Teleport, check SELinux settings")
 		}
 	}

--- a/lib/autoupdate/agent/updater_test.go
+++ b/lib/autoupdate/agent/updater_test.go
@@ -1050,14 +1050,14 @@ func TestUpdater_Remove(t *testing.T) {
 	const version = "active-version"
 
 	tests := []struct {
-		name           string
-		cfg            *UpdateConfig // nil -> file not present
-		linkSystemErr  error
-		isEnabledErr   error
-		syncErr        error
-		reloadErr      error
-		processEnabled bool
-		force          bool
+		name          string
+		cfg           *UpdateConfig // nil -> file not present
+		linkSystemErr error
+		isActiveErr   error
+		syncErr       error
+		reloadErr     error
+		processActive bool
+		force         bool
 
 		unlinkedVersion string
 		teardownCalls   int
@@ -1093,7 +1093,7 @@ func TestUpdater_Remove(t *testing.T) {
 			force:           true,
 		},
 		{
-			name: "no system links, process enabled, force",
+			name: "no system links, process active, force",
 			cfg: &UpdateConfig{
 				Version: updateConfigVersion,
 				Kind:    updateConfigKind,
@@ -1106,7 +1106,7 @@ func TestUpdater_Remove(t *testing.T) {
 			},
 			linkSystemErr:   ErrNoBinaries,
 			linkSystemCalls: 1,
-			processEnabled:  true,
+			processActive:   true,
 			force:           true,
 			errMatch:        "refusing to remove",
 		},
@@ -1158,7 +1158,7 @@ func TestUpdater_Remove(t *testing.T) {
 			},
 			linkSystemErr:   ErrNoBinaries,
 			linkSystemCalls: 1,
-			isEnabledErr:    ErrNotSupported,
+			isActiveErr:     ErrNotSupported,
 			unlinkedVersion: version,
 			teardownCalls:   1,
 			force:           true,
@@ -1307,11 +1307,8 @@ func TestUpdater_Remove(t *testing.T) {
 					reloadCalls++
 					return tt.reloadErr
 				},
-				FuncIsEnabled: func(_ context.Context) (bool, error) {
-					return tt.processEnabled, tt.isEnabledErr
-				},
 				FuncIsActive: func(_ context.Context) (bool, error) {
-					return false, nil
+					return tt.processActive, tt.isActiveErr
 				},
 			}
 			updater.TeardownNamespace = func(_ context.Context) error {

--- a/lib/autoupdate/agent/updater_test.go
+++ b/lib/autoupdate/agent/updater_test.go
@@ -1893,7 +1893,6 @@ func TestUpdater_Setup(t *testing.T) {
 			ns := &Namespace{}
 			updater, err := NewLocalUpdater(LocalUpdaterConfig{}, ns)
 			require.NoError(t, err)
-			updater.SystemDUnavailable = false
 
 			updater.Process = &testProcess{
 				FuncReload: func(_ context.Context) error {

--- a/lib/autoupdate/agent/updater_test.go
+++ b/lib/autoupdate/agent/updater_test.go
@@ -1893,6 +1893,7 @@ func TestUpdater_Setup(t *testing.T) {
 			ns := &Namespace{}
 			updater, err := NewLocalUpdater(LocalUpdaterConfig{}, ns)
 			require.NoError(t, err)
+			updater.SystemDUnavailable = false
 
 			updater.Process = &testProcess{
 				FuncReload: func(_ context.Context) error {


### PR DESCRIPTION
The `teleport-update` binary uses systemctl commands that are not supported on CentOS 7. Although CentOS 7 is EOL and no longer receiving security patches as of June 2024, Teleport v17 is currently documented to support it.

These commands include `list-unit-files`, `is-enabled`, and the `--now` flag.

This PR avoids executing those commands when systemd is too old to support them. **Edit: due to backports of the most of the functionality above, the last published version of CentOS 7 is fully-functional aside from a few missing warnings. I still plan to merge this PR to protect against unexpected behavior on Linux distros with older versions of systemd.**

Additionally, this PR simplifies the uninstallation workflow by allowing a stopped but enabled teleport systemd service to be removed. This behavior is more logical, and avoids `is-enabled`.

---

changelog: Improve support for teleport-update on CentOS 7 and distros with older SystemD versions.

---

The `teleport-update` binary will be used to enable, disable, and trigger automatic Teleport agent updates. The new auto-updates system manages a local installation of the cluster-specified version of Teleport stored in `/opt/teleport`.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/11856