### PR TITLE
Shamefully restore the exclude for grpc/stats/opentelemetry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -592,3 +592,9 @@ replace (
 	github.com/redis/go-redis/v9 => github.com/gravitational/redis/v9 v9.6.1-teleport.1
 	github.com/vulcand/predicate => github.com/gravitational/predicate v1.3.2
 )
+
+// this package was included in google.golang.org/grpc but because it's still
+// referenced by some dependencies we should exclude it here to avoid problems
+// when evaluating versions; "go get -u ./..." succeeding is a good sign that
+// the problem has been resolved
+exclude google.golang.org/grpc/stats/opentelemetry v0.0.0-20241028142157-ada6787961b3


### PR DESCRIPTION
In #52923 we removed the `exclude` directive for the `google.golang.org/grpc/stats/opentelemetry` package because it appeared to not be causing problems, but things that end up trying to figure out upgrade paths (such as `go get -u ./...`) will still error out. This PR restores the `exclude`.