### PR TITLE
Add PlainStruct and HasCheckAndSetDefaults support to singular resource

### DIFF
--- a/integrations/terraform/gen/singular_data_source.go.tpl
+++ b/integrations/terraform/gen/singular_data_source.go.tpl
@@ -82,7 +82,12 @@ func (r dataSourceTeleport{{.Name}}) Read(ctx context.Context, req tfsdk.ReadDat
 	// https://developer.hashicorp.com/terraform/plugin/framework/acctests#no-id-found-in-attributes
 	v, ok := state.Attrs["id"]
 	if !ok || v.IsNull() {
-		state.Attrs["id"] = types.String{Value: {{.VarName}}.GetName()}
+{{- if .IsPlainStruct}}
+		id := {{.VarName}}.Metadata.Name
+{{- else }}
+		id := {{.VarName}}.GetName()
+{{- end}}
+		state.Attrs["id"] = types.String{Value: id}
 	}
 
 	diags = resp.State.Set(ctx, &state)

--- a/integrations/terraform/provider/data_source_teleport_auth_preference.go
+++ b/integrations/terraform/provider/data_source_teleport_auth_preference.go
@@ -76,7 +76,8 @@ func (r dataSourceTeleportAuthPreference) Read(ctx context.Context, req tfsdk.Re
 	// https://developer.hashicorp.com/terraform/plugin/framework/acctests#no-id-found-in-attributes
 	v, ok := state.Attrs["id"]
 	if !ok || v.IsNull() {
-		state.Attrs["id"] = types.String{Value: authPreference.GetName()}
+		id := authPreference.GetName()
+		state.Attrs["id"] = types.String{Value: id}
 	}
 
 	diags = resp.State.Set(ctx, &state)

--- a/integrations/terraform/provider/data_source_teleport_cluster_maintenance_config.go
+++ b/integrations/terraform/provider/data_source_teleport_cluster_maintenance_config.go
@@ -76,7 +76,8 @@ func (r dataSourceTeleportClusterMaintenanceConfig) Read(ctx context.Context, re
 	// https://developer.hashicorp.com/terraform/plugin/framework/acctests#no-id-found-in-attributes
 	v, ok := state.Attrs["id"]
 	if !ok || v.IsNull() {
-		state.Attrs["id"] = types.String{Value: clusterMaintenanceConfig.GetName()}
+		id := clusterMaintenanceConfig.GetName()
+		state.Attrs["id"] = types.String{Value: id}
 	}
 
 	diags = resp.State.Set(ctx, &state)

--- a/integrations/terraform/provider/data_source_teleport_cluster_networking_config.go
+++ b/integrations/terraform/provider/data_source_teleport_cluster_networking_config.go
@@ -76,7 +76,8 @@ func (r dataSourceTeleportClusterNetworkingConfig) Read(ctx context.Context, req
 	// https://developer.hashicorp.com/terraform/plugin/framework/acctests#no-id-found-in-attributes
 	v, ok := state.Attrs["id"]
 	if !ok || v.IsNull() {
-		state.Attrs["id"] = types.String{Value: clusterNetworkingConfig.GetName()}
+		id := clusterNetworkingConfig.GetName()
+		state.Attrs["id"] = types.String{Value: id}
 	}
 
 	diags = resp.State.Set(ctx, &state)

--- a/integrations/terraform/provider/data_source_teleport_session_recording_config.go
+++ b/integrations/terraform/provider/data_source_teleport_session_recording_config.go
@@ -76,7 +76,8 @@ func (r dataSourceTeleportSessionRecordingConfig) Read(ctx context.Context, req 
 	// https://developer.hashicorp.com/terraform/plugin/framework/acctests#no-id-found-in-attributes
 	v, ok := state.Attrs["id"]
 	if !ok || v.IsNull() {
-		state.Attrs["id"] = types.String{Value: sessionRecordingConfig.GetName()}
+		id := sessionRecordingConfig.GetName()
+		state.Attrs["id"] = types.String{Value: id}
 	}
 
 	diags = resp.State.Set(ctx, &state)

--- a/integrations/terraform/provider/resource_teleport_auth_preference.go
+++ b/integrations/terraform/provider/resource_teleport_auth_preference.go
@@ -159,6 +159,7 @@ func (r resourceTeleportAuthPreference) Read(ctx context.Context, req tfsdk.Read
 		return
 	}
 
+	
 	authPreference := authPreferenceI.(*apitypes.AuthPreferenceV2)
 	diags = tfschema.CopyAuthPreferenceV2ToTerraform(ctx, authPreference, &state)
 	resp.Diagnostics.Append(diags...)
@@ -211,7 +212,6 @@ func (r resourceTeleportAuthPreference) Update(ctx context.Context, req tfsdk.Up
 		resp.Diagnostics.Append(diagFromWrappedErr("Error updating AuthPreference", trace.Wrap(err), "cluster_auth_preference"))
 		return
 	}
-
 	var authPreferenceI apitypes.AuthPreference
 
 	tries := 0
@@ -241,6 +241,7 @@ func (r resourceTeleportAuthPreference) Update(ctx context.Context, req tfsdk.Up
 		return
 	}
 
+	
 	authPreference = authPreferenceI.(*apitypes.AuthPreferenceV2)
 	diags = tfschema.CopyAuthPreferenceV2ToTerraform(ctx, authPreference, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -273,7 +274,6 @@ func (r resourceTeleportAuthPreference) ImportState(ctx context.Context, req tfs
 		resp.Diagnostics.Append(diagFromWrappedErr("Error updating AuthPreference", trace.Wrap(err), "cluster_auth_preference"))
 		return
 	}
-
 	authPreference := authPreferenceI.(*apitypes.AuthPreferenceV2)
 
 	var state types.Object
@@ -289,8 +289,9 @@ func (r resourceTeleportAuthPreference) ImportState(ctx context.Context, req tfs
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	id := authPreference.GetName()
 
-	state.Attrs["id"] = types.String{Value: authPreference.Metadata.Name}
+	state.Attrs["id"] = types.String{Value: id}
 
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)

--- a/integrations/terraform/provider/resource_teleport_cluster_maintenance_config.go
+++ b/integrations/terraform/provider/resource_teleport_cluster_maintenance_config.go
@@ -165,6 +165,7 @@ func (r resourceTeleportClusterMaintenanceConfig) Read(ctx context.Context, req 
 		return
 	}
 
+	
 	clusterMaintenanceConfig := clusterMaintenanceConfigI.(*apitypes.ClusterMaintenanceConfigV1)
 	diags = tfschema.CopyClusterMaintenanceConfigV1ToTerraform(ctx, clusterMaintenanceConfig, &state)
 	resp.Diagnostics.Append(diags...)
@@ -218,7 +219,6 @@ func (r resourceTeleportClusterMaintenanceConfig) Update(ctx context.Context, re
 		resp.Diagnostics.Append(diagFromWrappedErr("Error updating ClusterMaintenanceConfig", trace.Wrap(err), "cluster_maintenance_config"))
 		return
 	}
-
 	var clusterMaintenanceConfigI apitypes.ClusterMaintenanceConfig
 
 	tries := 0
@@ -248,6 +248,7 @@ func (r resourceTeleportClusterMaintenanceConfig) Update(ctx context.Context, re
 		return
 	}
 
+	
 	clusterMaintenanceConfig = clusterMaintenanceConfigI.(*apitypes.ClusterMaintenanceConfigV1)
 	diags = tfschema.CopyClusterMaintenanceConfigV1ToTerraform(ctx, clusterMaintenanceConfig, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -280,7 +281,6 @@ func (r resourceTeleportClusterMaintenanceConfig) ImportState(ctx context.Contex
 		resp.Diagnostics.Append(diagFromWrappedErr("Error updating ClusterMaintenanceConfig", trace.Wrap(err), "cluster_maintenance_config"))
 		return
 	}
-
 	clusterMaintenanceConfig := clusterMaintenanceConfigI.(*apitypes.ClusterMaintenanceConfigV1)
 
 	var state types.Object
@@ -296,8 +296,9 @@ func (r resourceTeleportClusterMaintenanceConfig) ImportState(ctx context.Contex
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	id := clusterMaintenanceConfig.GetName()
 
-	state.Attrs["id"] = types.String{Value: clusterMaintenanceConfig.Metadata.Name}
+	state.Attrs["id"] = types.String{Value: id}
 
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)

--- a/integrations/terraform/provider/resource_teleport_cluster_networking_config.go
+++ b/integrations/terraform/provider/resource_teleport_cluster_networking_config.go
@@ -159,6 +159,7 @@ func (r resourceTeleportClusterNetworkingConfig) Read(ctx context.Context, req t
 		return
 	}
 
+	
 	clusterNetworkingConfig := clusterNetworkingConfigI.(*apitypes.ClusterNetworkingConfigV2)
 	diags = tfschema.CopyClusterNetworkingConfigV2ToTerraform(ctx, clusterNetworkingConfig, &state)
 	resp.Diagnostics.Append(diags...)
@@ -211,7 +212,6 @@ func (r resourceTeleportClusterNetworkingConfig) Update(ctx context.Context, req
 		resp.Diagnostics.Append(diagFromWrappedErr("Error updating ClusterNetworkingConfig", trace.Wrap(err), "cluster_networking_config"))
 		return
 	}
-
 	var clusterNetworkingConfigI apitypes.ClusterNetworkingConfig
 
 	tries := 0
@@ -241,6 +241,7 @@ func (r resourceTeleportClusterNetworkingConfig) Update(ctx context.Context, req
 		return
 	}
 
+	
 	clusterNetworkingConfig = clusterNetworkingConfigI.(*apitypes.ClusterNetworkingConfigV2)
 	diags = tfschema.CopyClusterNetworkingConfigV2ToTerraform(ctx, clusterNetworkingConfig, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -273,7 +274,6 @@ func (r resourceTeleportClusterNetworkingConfig) ImportState(ctx context.Context
 		resp.Diagnostics.Append(diagFromWrappedErr("Error updating ClusterNetworkingConfig", trace.Wrap(err), "cluster_networking_config"))
 		return
 	}
-
 	clusterNetworkingConfig := clusterNetworkingConfigI.(*apitypes.ClusterNetworkingConfigV2)
 
 	var state types.Object
@@ -289,8 +289,9 @@ func (r resourceTeleportClusterNetworkingConfig) ImportState(ctx context.Context
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	id := clusterNetworkingConfig.GetName()
 
-	state.Attrs["id"] = types.String{Value: clusterNetworkingConfig.Metadata.Name}
+	state.Attrs["id"] = types.String{Value: id}
 
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)

--- a/integrations/terraform/provider/resource_teleport_session_recording_config.go
+++ b/integrations/terraform/provider/resource_teleport_session_recording_config.go
@@ -159,6 +159,7 @@ func (r resourceTeleportSessionRecordingConfig) Read(ctx context.Context, req tf
 		return
 	}
 
+	
 	sessionRecordingConfig := sessionRecordingConfigI.(*apitypes.SessionRecordingConfigV2)
 	diags = tfschema.CopySessionRecordingConfigV2ToTerraform(ctx, sessionRecordingConfig, &state)
 	resp.Diagnostics.Append(diags...)
@@ -211,7 +212,6 @@ func (r resourceTeleportSessionRecordingConfig) Update(ctx context.Context, req 
 		resp.Diagnostics.Append(diagFromWrappedErr("Error updating SessionRecordingConfig", trace.Wrap(err), "session_recording_config"))
 		return
 	}
-
 	var sessionRecordingConfigI apitypes.SessionRecordingConfig
 
 	tries := 0
@@ -241,6 +241,7 @@ func (r resourceTeleportSessionRecordingConfig) Update(ctx context.Context, req 
 		return
 	}
 
+	
 	sessionRecordingConfig = sessionRecordingConfigI.(*apitypes.SessionRecordingConfigV2)
 	diags = tfschema.CopySessionRecordingConfigV2ToTerraform(ctx, sessionRecordingConfig, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -273,7 +274,6 @@ func (r resourceTeleportSessionRecordingConfig) ImportState(ctx context.Context,
 		resp.Diagnostics.Append(diagFromWrappedErr("Error updating SessionRecordingConfig", trace.Wrap(err), "session_recording_config"))
 		return
 	}
-
 	sessionRecordingConfig := sessionRecordingConfigI.(*apitypes.SessionRecordingConfigV2)
 
 	var state types.Object
@@ -289,8 +289,9 @@ func (r resourceTeleportSessionRecordingConfig) ImportState(ctx context.Context,
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	id := sessionRecordingConfig.GetName()
 
-	state.Attrs["id"] = types.String{Value: sessionRecordingConfig.Metadata.Name}
+	state.Attrs["id"] = types.String{Value: id}
 
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)


### PR DESCRIPTION
This PR adds [Resource 153](https://github.com/gravitational/teleport/blob/master/rfd/0153-resource-guidelines.md) support to the Terraform Provider singular resources.

I did it for plural resources last year, but I forgot to do the same on singular resource 🫠 .

With this PR, the singular resource/datasource templates honour the following parameters:
- `IsPlainStruct`
- `ForceSetKind`
- `ExtraImports`
- `UpsertMethodArity`
- `HasCheckAndSetDefaults`

This is used by autoupdate_version and autoupdate_config resources. They will come in a future PR, this template change has been extracted for reviewability purposes.