### PR TITLE
chore: Bump Buf to v1.50.1

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -21,7 +21,7 @@ LIBPCSCLITE_VERSION ?= 1.9.9-teleport
 DEVTOOLSET ?= devtoolset-12
 
 # Protogen related versions.
-BUF_VERSION ?= v1.48.0
+BUF_VERSION ?= v1.50.1
 # Keep in sync with api/proto/buf.yaml (and buf.lock).
 GOGO_PROTO_TAG ?= v1.3.2
 NODE_GRPC_TOOLS_VERSION ?= 1.12.4


### PR DESCRIPTION
Update to the latest release.

* https://github.com/bufbuild/buf/blob/main/CHANGELOG.md#v1501---2025-03-10