### PR TITLE
[v17] chore: Bump Buf to v1.50.1

### DIFF
--- a/build.assets/Dockerfile-grpcbox
+++ b/build.assets/Dockerfile-grpcbox
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/golang:1.23.7
+FROM docker.io/golang:1.24.1
 
 # Image layers go from less likely to most likely to change.
 RUN apt-get update && \

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -20,7 +20,7 @@ LIBPCSCLITE_VERSION ?= 1.9.9-teleport
 DEVTOOLSET ?= devtoolset-12
 
 # Protogen related versions.
-BUF_VERSION ?= v1.48.0
+BUF_VERSION ?= v1.50.1
 # Keep in sync with api/proto/buf.yaml (and buf.lock).
 GOGO_PROTO_TAG ?= v1.3.2
 NODE_GRPC_TOOLS_VERSION ?= 1.12.4


### PR DESCRIPTION
Backport #52962 to branch/v17.