### PR TITLE
Add singular resource 153 default name support

### DIFF
--- a/integrations/terraform/gen/main.go
+++ b/integrations/terraform/gen/main.go
@@ -101,6 +101,8 @@ type payload struct {
 	ForceSetKind string
 	// GetCanReturnNil is used to check for nil returned value when doing a Get<Resource>.
 	GetCanReturnNil bool
+	// DefaultName is the default singleton resource name. This is currently only supported for 153 resources.
+	DefaultName string
 }
 
 func (p *payload) CheckAndSetDefaults() error {

--- a/integrations/terraform/gen/singular_resource.go.tpl
+++ b/integrations/terraform/gen/singular_resource.go.tpl
@@ -6,7 +6,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,12 +28,16 @@ import (
 {{- end }}
 
 	{{.ProtoPackage}} "{{.ProtoPackagePath}}"
+{{- if .DefaultName }}
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+{{- end}}
 	"github.com/gravitational/teleport/integrations/lib/backoff"
 	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/jonboulle/clockwork"
+
 
 	{{ schemaImport . }}
 )
@@ -97,6 +101,15 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 	}
 	{{- end}}
 
+	{{- if .DefaultName }}
+	if {{.VarName}}.GetMetadata() == nil {
+		{{.VarName}}.Metadata = &headerv1.Metadata{}
+	}
+	if {{ .VarName }}.GetMetadata().GetName() == "" {
+		{{ .VarName }}.Metadata.Name = {{ .DefaultName }}
+	}
+	{{- end}}
+
 	{{.VarName}}Before, err := r.p.Client.Get{{.Name}}(ctx)
 	if err != nil && !trace.IsNotFound(err) {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
@@ -137,7 +150,10 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Wrap(err), "{{.Kind}}"))
 			return
 		}
-		if {{.VarName}}Before.GetMetadata().Revision != {{.VarName}}I.GetMetadata().Revision || {{.HasStaticID}} {
+
+		previousMetadata := {{.VarName}}Before.GetMetadata()
+		currentMetadata := {{.VarName}}I.GetMetadata()
+		if previousMetadata.GetRevision() != currentMetadata.GetRevision() || {{.HasStaticID}} {
 			break
 		}
 		if bErr := backoff.Do(ctx); bErr != nil {

--- a/integrations/terraform/gen/singular_resource.go.tpl
+++ b/integrations/terraform/gen/singular_resource.go.tpl
@@ -6,7 +6,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -37,7 +37,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/jonboulle/clockwork"
-
 
 	{{ schemaImport . }}
 )

--- a/integrations/terraform/provider/resource_teleport_auth_preference.go
+++ b/integrations/terraform/provider/resource_teleport_auth_preference.go
@@ -103,7 +103,10 @@ func (r resourceTeleportAuthPreference) Create(ctx context.Context, req tfsdk.Cr
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading AuthPreference", trace.Wrap(err), "cluster_auth_preference"))
 			return
 		}
-		if authPreferenceBefore.GetMetadata().Revision != authPreferenceI.GetMetadata().Revision || false {
+
+		previousMetadata := authPreferenceBefore.GetMetadata()
+		currentMetadata := authPreferenceI.GetMetadata()
+		if previousMetadata.GetRevision() != currentMetadata.GetRevision() || false {
 			break
 		}
 		if bErr := backoff.Do(ctx); bErr != nil {

--- a/integrations/terraform/provider/resource_teleport_cluster_maintenance_config.go
+++ b/integrations/terraform/provider/resource_teleport_cluster_maintenance_config.go
@@ -109,7 +109,10 @@ func (r resourceTeleportClusterMaintenanceConfig) Create(ctx context.Context, re
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading ClusterMaintenanceConfig", trace.Wrap(err), "cluster_maintenance_config"))
 			return
 		}
-		if clusterMaintenanceConfigBefore.GetMetadata().Revision != clusterMaintenanceConfigI.GetMetadata().Revision || true {
+
+		previousMetadata := clusterMaintenanceConfigBefore.GetMetadata()
+		currentMetadata := clusterMaintenanceConfigI.GetMetadata()
+		if previousMetadata.GetRevision() != currentMetadata.GetRevision() || true {
 			break
 		}
 		if bErr := backoff.Do(ctx); bErr != nil {

--- a/integrations/terraform/provider/resource_teleport_cluster_networking_config.go
+++ b/integrations/terraform/provider/resource_teleport_cluster_networking_config.go
@@ -103,7 +103,10 @@ func (r resourceTeleportClusterNetworkingConfig) Create(ctx context.Context, req
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading ClusterNetworkingConfig", trace.Wrap(err), "cluster_networking_config"))
 			return
 		}
-		if clusterNetworkingConfigBefore.GetMetadata().Revision != clusterNetworkingConfigI.GetMetadata().Revision || false {
+
+		previousMetadata := clusterNetworkingConfigBefore.GetMetadata()
+		currentMetadata := clusterNetworkingConfigI.GetMetadata()
+		if previousMetadata.GetRevision() != currentMetadata.GetRevision() || false {
 			break
 		}
 		if bErr := backoff.Do(ctx); bErr != nil {

--- a/integrations/terraform/provider/resource_teleport_session_recording_config.go
+++ b/integrations/terraform/provider/resource_teleport_session_recording_config.go
@@ -103,7 +103,10 @@ func (r resourceTeleportSessionRecordingConfig) Create(ctx context.Context, req 
 			resp.Diagnostics.Append(diagFromWrappedErr("Error reading SessionRecordingConfig", trace.Wrap(err), "session_recording_config"))
 			return
 		}
-		if sessionRecordingConfigBefore.GetMetadata().Revision != sessionRecordingConfigI.GetMetadata().Revision || false {
+
+		previousMetadata := sessionRecordingConfigBefore.GetMetadata()
+		currentMetadata := sessionRecordingConfigI.GetMetadata()
+		if previousMetadata.GetRevision() != currentMetadata.GetRevision() || false {
 			break
 		}
 		if bErr := backoff.Do(ctx); bErr != nil {


### PR DESCRIPTION
This PR adds default name support for 153 singular resources + fixes a potential panic in case of nil Metadata.

Depends on https://github.com/gravitational/teleport/pull/52960.

This will be used for autoupdate_version and autoupdate_config support. Both resources must have default names set in their metadata (else they are rejected by the server) but it's a very bad experience to have users specify constants every time.

This PR allows us to set`DefaultName` in `gen/main.go`. Please note that it only supports 153 resources (not the interface-based resource implementation). I did not see the need to complexity the template to support those, I'll do it if we add a legacy singleton resource that requires a default name (very unlikely as every new resource is 153-style).