### PR TITLE
Edit DNS guidance for registered apps

### DIFF
--- a/docs/pages/enroll-resources/application-access/guides/connecting-apps.mdx
+++ b/docs/pages/enroll-resources/application-access/guides/connecting-apps.mdx
@@ -106,40 +106,7 @@ Application Service:
 
 ## Step 2/3. [Optional] Configure TLS and DNS for your web applications
 
-Once the Teleport Application Service is proxying traffic to your web
-application, the Teleport Proxy Service makes the application available at the
-following URL:
-
-```text
-https://<APPLICATION_NAME>.<TELEPORT_DOMAIN>
-```
-
-For example, if your Teleport domain name is `teleport.example.com`, the
-application named `my-app` would be available at
-`https://my-app.teleport.example.com`. The Proxy Service presents a TLS
-certificate for this domain name that browsers can verify against a certificate
-authority.
-
-If you are using Teleport Enterprise (Cloud), DNS records and TLS certificates
-for this domain name are provisioned automatically. If you are self-hosting
-Teleport, you must configure these yourself:
-
-1. Create either:
-   - A DNS A record that associates a wildcard subdomain of your Teleport Proxy
-     Service domain, e.g., `*.teleport.example.com`, with the IP address of the
-     Teleport Proxy Service.
-   - A DNS CNAME record that associates a wildcard subdomain of your Proxy
-     Service domain, e.g., `*.teleport.example.com`, with the domain name of the
-     Teleport Proxy Service.
-
-1. Ensure that your system provisions TLS certificates for Teleport-registered
-   applications. The method to use depends on how you originally set up TLS for
-   your self-hosted Teleport deployment, and is outside the scope of this guide. 
-
-   In general, the same system that provisions TLS certificates signed for the
-   web address of the Proxy Service (e.g., `teleport.example.com`) must also
-   provision certificates for the wildcard address used for applications (e.g.,
-   `*.teleport.example.com`).
+(!docs/pages/includes/dns-app-access.mdx!)
 
 ## Step 3/3. Configure RBAC and access the application
 

--- a/docs/pages/includes/dns-app-access.mdx
+++ b/docs/pages/includes/dns-app-access.mdx
@@ -1,20 +1,39 @@
-Teleport assigns a subdomain to each application you configure for Application
-Access. For example, if you enroll Grafana as a resource, Teleport assigns the resource
-to the `grafana.teleport.example.com` subdomain. 
+Once the Teleport Application Service is proxying traffic to your web
+application, the Teleport Proxy Service makes the application available at the
+following URL:
 
-If you host the Teleport cluster on your own network, you should update your DNS 
-configuration to account for application subdomains.
-You can update DNS in one of two ways: 
+```text
+https://<APPLICATION_NAME>.<TELEPORT_DOMAIN>
+```
 
-- Create a single DNS address (A) or canonical name (CNAME) record using wildcard substitution 
-for the subdomain name. For example, create a DNS record with the name `*.teleport.example.com`. 
-- Create a separate DNS address (A) or canonical name (CNAME) record for each application subdomain.
+For example, if your Teleport domain name is `teleport.example.com`, the
+application named `my-app` would be available at
+`https://my-app.teleport.example.com`. The Proxy Service presents a TLS
+certificate for this domain name that browsers can verify against a certificate
+authority.
 
-Modifying DNS ensures that the certificate authority—for example, Let's Encrypt—can issue a 
-certificate for each subdomain and that clients can verify Teleport hosts regardless of the
-application they are accessing.
+If you are using Teleport Enterprise (Cloud), DNS records and TLS certificates
+for this domain name are provisioned automatically. If you are self-hosting
+Teleport, you must configure these yourself:
 
-If you use the Teleport cloud platform, no DNS updates are needed because your Teleport 
-cluster automatically provides the subdomains and signed TLS certificates for your 
-applications under your tenant address.
+1. Create either:
+   - A DNS A record that associates a wildcard subdomain of your Teleport Proxy
+     Service domain, e.g., `*.teleport.example.com`, with the IP address of the
+     Teleport Proxy Service.
+   - A DNS CNAME record that associates a wildcard subdomain of your Proxy
+     Service domain, e.g., `*.teleport.example.com`, with the domain name of the
+     Teleport Proxy Service.
+
+1. Ensure that your system provisions TLS certificates for Teleport-registered
+   applications. The method to use depends on how you originally set up TLS for
+   your self-hosted Teleport deployment, and is outside the scope of this guide. 
+
+   In general, the same system that provisions TLS certificates signed for the
+   web address of the Proxy Service (e.g., `teleport.example.com`) must also
+   provision certificates for the wildcard address used for applications (e.g.,
+   `*.teleport.example.com`).
+
+Take care not to create DNS records that map the Teleport cluster subdomain of a
+registered application to the application's own host, as attempts to navigate to
+the application will fail.
 

--- a/docs/pages/includes/dns-app-access.mdx
+++ b/docs/pages/includes/dns-app-access.mdx
@@ -8,7 +8,7 @@ https://<APPLICATION_NAME>.<TELEPORT_DOMAIN>
 
 For example, if your Teleport domain name is `teleport.example.com`, the
 application named `my-app` would be available at
-`https://my-app.teleport.example.com`. The Proxy Service presents a TLS
+`https://my-app.teleport.example.com`. The Proxy Service must present a TLS
 certificate for this domain name that browsers can verify against a certificate
 authority.
 


### PR DESCRIPTION
Closes #30361

Add an explicit warning against creating DNS records that map application subdomains to the hosts of registered applications. Use the `dns-app-access` partial in `connecting-apps.mdx` to simplify reuse.