### PR TITLE
[v15] Remove Icon tags

### DIFF
--- a/docs/pages/connect-your-client/introduction.mdx
+++ b/docs/pages/connect-your-client/introduction.mdx
@@ -174,9 +174,9 @@ terminal environment.
 </TabItem>
 <TabItem label="Web UI">
 
-From the <Icon name="server" size="sm" inline/> **Servers** menu, the Teleport
-Web UI will list all servers your user has permission to access. The **CONNECT**
-button will open a new tab with a terminal emulator to provide access to that server.
+From the **Servers** menu, the Teleport Web UI will list all servers your user
+has permission to access. The **CONNECT** button will open a new tab with a
+terminal emulator to provide access to that server.
 
 </TabItem>
 </Tabs>
@@ -234,9 +234,8 @@ open a terminal in a new tab and authenticate to the cluster. You can then run
 </TabItem>
 <TabItem label="Web UI">
 
-In the Teleport Web UI, click the <Icon name="kubernetes" size="sm" inline/>
-**Kubernetes** tab. You will see a list of Kubernetes clusters your Teleport
-user is authorized to connect to.
+In the Teleport Web UI, click the **Kubernetes** tab. You will see a list of
+Kubernetes clusters your Teleport user is authorized to connect to.
 
 ![Available Kubernetes clusters](../../img/use-teleport/kubernetes-clusters.png)
 
@@ -324,8 +323,8 @@ initiate a CLI connection inside Teleport Connect:
 <TabItem label="Web UI">
 
 The Teleport Web UI cannot provide direct connections to databases, but it will
-list those that are accessible to your user under <Icon name="database" size="sm" inline/>
-**Databases** and provide `tsh` commands to connect from your local terminal environment.
+list those that are accessible to your user under **Databases** and provide
+`tsh` commands to connect from your local terminal environment.
 
 </TabItem>
 </Tabs>
@@ -336,7 +335,7 @@ Desktop access is available through the Teleport Web UI.
 
 1. In your browser, navigate to your Teleport cluster (for example, 
 `https://example.teleport.sh`).
-1. From the menu on the right, select <Icon name="desktop" inline size="sm"/> **Desktops**.
+1. From the menu on the right, select **Desktops**.
 1. Next to the desktop you want to access, click **CONNECT**. Select
 or type in a username available to your Teleport user.
 1. Teleport will open a new browser tab or window and begin the RDP session.


### PR DESCRIPTION
Backports #52932

The docs engine strips these, so they are no op. Remove them so we can remove the docs engine code that strip them. As part of this, remove the `icons-table.mdx` partial, which no pages include.