### PR TITLE
[v17] Move version support table to Upcoming Releases

### DIFF
--- a/docs/pages/connect-your-client/includes/connect-my-computer-prerequisites.mdx
+++ b/docs/pages/connect-your-client/includes/connect-my-computer-prerequisites.mdx
@@ -1,6 +1,6 @@
 - A macOS or Linux device.
 - Teleport Connect v14.1+, on the same major version or one version behind the Teleport Proxy
-  Service version. See [version compatibility](../../faq.mdx#version-compatibility).
+  Service version. See [version compatibility](../../upcoming-releases.mdx#teleport).
 - A local Teleport user: you must authenticate using credentials or passwordless login, and not with
   SSO.
 - Permissions to create join tokens (verb `create` for [the `token` resource](../../reference/access-controls/roles.mdx)).

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -93,24 +93,8 @@ time you run `tsh`.
 
 ## Which version of Teleport is supported?
 
-Teleport releases a new major version approximately every 4 months, and provides
-security-critical support for the current and two previous major versions. With
-our typical release cadence, we usually support each major version for 12
-months.
-
-### Supported versions
-
-Here are the major versions of Teleport and their support windows:
-
-| Release | Release Date      | EOL           | Minimum `tsh` version |
-|---------|-------------------|---------------|-----------------------|
-| v17.0   | November 16, 2024 | November 2025 | v16.0.0               |
-| v16.0   | June 14, 2024     | June 2025     | v15.0.0               |
-| v15.0   | January 29, 2024  | January 2025  | v14.0.0               |
-
-### Version compatibility
-
-(!docs/pages/includes/compatibility.mdx!)
+See [Upcoming Releases](upcoming-releases.mdx) for the versions of Teleport that
+we support and how long we plan to continue supporting them.
 
 ## Does the Web UI support copy and paste?
 

--- a/docs/pages/upcoming-releases.mdx
+++ b/docs/pages/upcoming-releases.mdx
@@ -3,15 +3,28 @@ title: Teleport Upcoming Releases
 description: A timeline of upcoming Teleport releases.
 ---
 
-The Teleport team delivers a new major release roughly every 4 months.
+Teleport releases a new major version approximately every 4 months, and provides
+security-critical support for the current and two previous major versions. With
+our typical release cadence, we usually support each major version for 12
+months.
 
 ## Teleport
+
+We plan to release the following versions in the coming months:
 
 | Version | Date                        |
 |---------|-----------------------------|
 | 17.4.0  | Week of March 24th, 2025    |
 | 17.5.0  | Week of May 19th, 2025      |
 | 18.0.0  | Week of May 26th, 2025      |
+
+We continue to support the following major versions of Teleport:
+
+| Release | Release Date      | EOL            | Minimum `tsh` version |
+|---------|-------------------|----------------|-----------------------|
+| v17.x   | November 16, 2024 | January 2026   | v16.0.0               |
+| v16.x   | June 14, 2024     | September 2025 | v15.0.0               |
+| v15.x   | January 29, 2024  | May 2025       | v14.0.0               |
 
 ### 17.4.0
 
@@ -117,3 +130,8 @@ minor release, such as (=teleport.major_version=).1.0.
 
 Patch releases contain small bug fixes and can typically be deployed directly
 to production.
+
+## Version compatibility
+
+(!docs/pages/includes/compatibility.mdx!)
+


### PR DESCRIPTION
This change helps guarantee that we'll update the version support table at the same time as the upcoming release table to keep our support windows up to date. Since we otherwise do not update the two tables at the same time, the supported version table has become out of date.

This change also updates support windows based on the plan to release v18 in May, 2025, with the assumption that we release a major version every 4 months.

This change also moves the compatibility description from FAQ to Upcoming Releases so we keep this info in one place, and links to Upcoming Releases from the relevant section of the FAQ.