### PR TITLE
[v17] Machine ID: Warn when returned cert TTL is less than expected

### DIFF
--- a/lib/tbot/output_utils.go
+++ b/lib/tbot/output_utils.go
@@ -401,7 +401,8 @@ func generateIdentity(
 // less than the renewal interval, or if the server returns certs valid for a
 // shorter-than-expected period of time.
 // This assumes the identity was just renewed, for the purposes of calculating
-// TTLs.
+// TTLs, and may log false positive warnings if the time delta is large; the
+// time calculations include a 1m buffer to mitigate this.
 func warnOnEarlyExpiration(
 	ctx context.Context,
 	log *slog.Logger,
@@ -421,6 +422,10 @@ func warnOnEarlyExpiration(
 			"expires", ident.TLSIdentity.Expires,
 			"roles", ident.TLSIdentity.Groups,
 		)
+
+		// TODO(timothyb89): we can technically fetch our individual roles
+		// without explicit permission, and could determine which role in
+		// particular limited the TTL.
 
 		if effectiveTTL < lifetime.RenewalInterval {
 			l.WarnContext(ctx, "The server returned an identity shorter than "+

--- a/lib/tbot/output_utils.go
+++ b/lib/tbot/output_utils.go
@@ -412,7 +412,7 @@ func warnOnEarlyExpiration(
 	// Calculate a rough TTL, assuming this was called shortly after the
 	// identity was returned. We'll add a minute buffer to compensate and avoid
 	// superfluous warning messages.
-	effectiveTTL := ident.TLSIdentity.Expires.Sub(time.Now()) + time.Minute
+	effectiveTTL := time.Until(ident.TLSIdentity.Expires) + time.Minute
 
 	if effectiveTTL < lifetime.TTL {
 		l := log.With(
@@ -428,12 +428,14 @@ func warnOnEarlyExpiration(
 		// particular limited the TTL.
 
 		if effectiveTTL < lifetime.RenewalInterval {
+			//nolint:sloglint // multiline string is actually constant
 			l.WarnContext(ctx, "The server returned an identity shorter than "+
 				"expected and below the configured renewal interval, probably "+
 				"due to a `max_session_ttl` configured on a server-side role. "+
 				"Unless corrected, the credentials will be invalid for some "+
 				"period until renewal.")
 		} else {
+			//nolint:sloglint // multiline string is actually constant
 			l.WarnContext(ctx, "The server returned an identity shorter than "+
 				"the requested TTL, probably due to a `max_session_ttl` "+
 				"configured on a server-side role. It may not remain valid as "+

--- a/lib/tbot/output_utils.go
+++ b/lib/tbot/output_utils.go
@@ -396,6 +396,47 @@ func generateIdentity(
 	return newIdentity, nil
 }
 
+// warnOnEarlyExpiration logs a warning if the given identity is likely to
+// expire problematically early. This can happen if either the configured TTL is
+// less than the renewal interval, or if the server returns certs valid for a
+// shorter-than-expected period of time.
+// This assumes the identity was just renewed, for the purposes of calculating
+// TTLs.
+func warnOnEarlyExpiration(
+	ctx context.Context,
+	log *slog.Logger,
+	ident *identity.Identity,
+	lifetime config.CredentialLifetime,
+) {
+	// Calculate a rough TTL, assuming this was called shortly after the
+	// identity was returned. We'll add a minute buffer to compensate and avoid
+	// superfluous warning messages.
+	effectiveTTL := ident.TLSIdentity.Expires.Sub(time.Now()) + time.Minute
+
+	if effectiveTTL < lifetime.TTL {
+		l := log.With(
+			"requested_ttl", lifetime.TTL,
+			"renewal_interval", lifetime.RenewalInterval,
+			"effective_ttl", effectiveTTL,
+			"expires", ident.TLSIdentity.Expires,
+			"roles", ident.TLSIdentity.Groups,
+		)
+
+		if effectiveTTL < lifetime.RenewalInterval {
+			l.WarnContext(ctx, "The server returned an identity shorter than "+
+				"expected and below the configured renewal interval, probably "+
+				"due to a `max_session_ttl` configured on a server-side role. "+
+				"Unless corrected, the credentials will be invalid for some "+
+				"period until renewal.")
+		} else {
+			l.WarnContext(ctx, "The server returned an identity shorter than "+
+				"the requested TTL, probably due to a `max_session_ttl` "+
+				"configured on a server-side role. It may not remain valid as "+
+				"long as expected.")
+		}
+	}
+}
+
 // fetchDefaultRoles requests the bot's own role from the auth server and
 // extracts its full list of allowed roles.
 func fetchDefaultRoles(ctx context.Context, roleGetter services.RoleGetter, identity *identity.Identity) ([]string, error) {

--- a/lib/tbot/service_application_output.go
+++ b/lib/tbot/service_application_output.go
@@ -131,12 +131,13 @@ func (s *ApplicationOutputService) generate(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 
+	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
 	routedIdentity, err := generateIdentity(
 		ctx,
 		s.botAuthClient,
 		id,
 		roles,
-		cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime).TTL,
+		effectiveLifetime.TTL,
 		func(req *proto.UserCertsRequest) {
 			req.RouteToApp = routeToApp
 		},
@@ -144,6 +145,8 @@ func (s *ApplicationOutputService) generate(ctx context.Context) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+
+	warnOnEarlyExpiration(ctx, s.log.With("output", s), id, effectiveLifetime)
 
 	s.log.InfoContext(
 		ctx,

--- a/lib/tbot/service_identity_output.go
+++ b/lib/tbot/service_identity_output.go
@@ -152,6 +152,8 @@ func (s *IdentityOutputService) generate(ctx context.Context) error {
 		}
 	}
 
+	warnOnEarlyExpiration(ctx, s.log.With("output", s), id, cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime))
+
 	hostCAs, err := s.botAuthClient.GetCertAuthorities(ctx, types.HostCA, false)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/tbot/service_identity_output.go
+++ b/lib/tbot/service_identity_output.go
@@ -113,12 +113,13 @@ func (s *IdentityOutputService) generate(ctx context.Context) error {
 		}
 	}
 
+	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
 	id, err := generateIdentity(
 		ctx,
 		s.botAuthClient,
 		s.getBotIdentity(),
 		roles,
-		cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime).TTL,
+		effectiveLifetime.TTL,
 		func(req *proto.UserCertsRequest) {
 			req.ReissuableRoleImpersonation = s.cfg.AllowReissue
 		},
@@ -152,7 +153,7 @@ func (s *IdentityOutputService) generate(ctx context.Context) error {
 		}
 	}
 
-	warnOnEarlyExpiration(ctx, s.log.With("output", s), id, cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime))
+	warnOnEarlyExpiration(ctx, s.log.With("output", s), id, effectiveLifetime)
 
 	hostCAs, err := s.botAuthClient.GetCertAuthorities(ctx, types.HostCA, false)
 	if err != nil {

--- a/lib/tbot/service_spiffe_svid_output.go
+++ b/lib/tbot/service_spiffe_svid_output.go
@@ -179,17 +179,21 @@ func (s *SPIFFESVIDOutputService) requestSVID(
 		return nil, nil, nil, trace.Wrap(err, "fetching roles")
 	}
 
+	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
 	id, err := generateIdentity(
 		ctx,
 		s.botAuthClient,
 		s.getBotIdentity(),
 		roles,
-		cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime).TTL,
+		effectiveLifetime.TTL,
 		nil,
 	)
 	if err != nil {
 		return nil, nil, nil, trace.Wrap(err, "generating identity")
 	}
+
+	warnOnEarlyExpiration(ctx, s.log.With("output", s), id, effectiveLifetime)
+
 	// create a client that uses the impersonated identity, so that when we
 	// fetch information, we can ensure access rights are enforced.
 	facade := identity.NewFacade(s.botCfg.FIPS, s.botCfg.Insecure, id)

--- a/lib/tbot/service_ssh_host_output.go
+++ b/lib/tbot/service_ssh_host_output.go
@@ -104,17 +104,21 @@ func (s *SSHHostOutputService) generate(ctx context.Context) error {
 		}
 	}
 
+	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
 	id, err := generateIdentity(
 		ctx,
 		s.botAuthClient,
 		s.getBotIdentity(),
 		roles,
-		cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime).TTL,
+		effectiveLifetime.TTL,
 		nil,
 	)
 	if err != nil {
 		return trace.Wrap(err, "generating identity")
 	}
+
+	warnOnEarlyExpiration(ctx, s.log.With("output", s), id, effectiveLifetime)
+
 	// create a client that uses the impersonated identity, so that when we
 	// fetch information, we can ensure access rights are enforced.
 	facade := identity.NewFacade(s.botCfg.FIPS, s.botCfg.Insecure, id)

--- a/lib/tbot/service_workload_identity_x509.go
+++ b/lib/tbot/service_workload_identity_x509.go
@@ -191,17 +191,21 @@ func (s *WorkloadIdentityX509Service) requestSVID(
 		return nil, nil, trace.Wrap(err, "fetching roles")
 	}
 
+	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime)
 	id, err := generateIdentity(
 		ctx,
 		s.botAuthClient,
 		s.getBotIdentity(),
 		roles,
-		cmp.Or(s.cfg.CredentialLifetime, s.botCfg.CredentialLifetime).TTL,
+		effectiveLifetime.TTL,
 		nil,
 	)
 	if err != nil {
 		return nil, nil, trace.Wrap(err, "generating identity")
 	}
+
+	warnOnEarlyExpiration(ctx, s.log.With("output", s), id, effectiveLifetime)
+
 	// create a client that uses the impersonated identity, so that when we
 	// fetch information, we can ensure access rights are enforced.
 	facade := identity.NewFacade(s.botCfg.FIPS, s.botCfg.Insecure, id)


### PR DESCRIPTION
Backport #52833 to branch/v17

changelog: Machine ID: Added warning when generated certificates will not last as long as expected
