### PR TITLE
[v17] event-handler: allow DNS alternative names that don't resolve

### DIFF
--- a/docs/pages/includes/configure-event-handler.mdx
+++ b/docs/pages/includes/configure-event-handler.mdx
@@ -13,7 +13,7 @@ $ teleport-event-handler configure . mytenant.teleport.sh:443
 <TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 Run the `configure` command to generate a sample configuration. Replace
-`teleport.example.com:443` with the DNS name and HTTPS port of Teleport's Proxy
+`mytenant.teleport.sh:443` with the DNS name and HTTPS port of Teleport's Proxy
 Service:
 
 ```code
@@ -110,8 +110,5 @@ the value of `--cn`.
 
 The `--dns-names` flag accepts a comma-separated list of DNS names. It will
 append subject alternative names (SANs) to the server certificate (the one you
-will provide to your log forwarder) for each DNS name in the list. The Event
-Handler looks up each DNS name before appending it as an SAN and exits with an
-error if the lookup fails.
-
+will provide to your log forwarder) for each DNS name in the list.
 </Details>

--- a/integrations/event-handler/fake_fluentd_test.go
+++ b/integrations/event-handler/fake_fluentd_test.go
@@ -68,7 +68,7 @@ func NewFakeFluentd(t *testing.T) *FakeFluentd {
 
 // writeCerts generates and writes temporary mTLS keys
 func (f *FakeFluentd) writeCerts() error {
-	g, err := GenerateMTLSCerts([]string{"localhost"}, []string{}, time.Hour, 1024)
+	g, err := GenerateMTLSCerts([]string{"localhost"}, []string{"127.0.0.1"}, time.Hour, 1024)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/integrations/event-handler/mtls_certs_test.go
+++ b/integrations/event-handler/mtls_certs_test.go
@@ -20,6 +20,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"testing"
@@ -34,11 +35,11 @@ func TestGenerateClientCertFile(t *testing.T) {
 	kp := "client.key"
 
 	// Generate certs in memory
-	certs, err := GenerateMTLSCerts([]string{"localhost"}, nil, time.Second, 1024)
+	certs, err := GenerateMTLSCerts([]string{"localhost"}, []string{"127.0.0.1"}, time.Second, 1024)
 	require.NoError(t, err)
-	require.NotNil(t, certs.caCert.Issuer)
-	require.NotNil(t, certs.clientCert.Issuer)
-	require.NotNil(t, certs.serverCert.Issuer)
+	require.NotZero(t, certs.caCert.Issuer)
+	require.NotZero(t, certs.clientCert.Issuer)
+	require.NotZero(t, certs.serverCert.Issuer)
 	// don't be self-signed
 	require.NotEqual(t, certs.serverCert.Issuer, certs.serverCert.Subject)
 	require.NotEqual(t, certs.clientCert.Issuer, certs.clientCert.Subject)
@@ -58,6 +59,7 @@ func TestGenerateClientCertFile(t *testing.T) {
 	require.NotEmpty(t, certs.clientCert.DNSNames)
 	// server leaf cert should have SAN DNS:localhost
 	require.Equal(t, "localhost", certs.serverCert.DNSNames[0])
+	require.Equal(t, net.ParseIP("127.0.0.1"), certs.serverCert.IPAddresses[0])
 
 	// Write the cert to the tempdir
 	err = certs.ClientCert.WriteFile(filepath.Join(td, cp), filepath.Join(td, kp), ".")


### PR DESCRIPTION
Backport #53006 to branch/v17
Backport #53021 to branch/v17

changelog: The event handler can now generate certificates for DNS names that are not resolvable.
