### PR TITLE
Fixes panic on group database errors during host user reconciliation

### DIFF
--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -686,6 +686,7 @@ func (u *HostUserManagement) getHostUser(username string) (*HostUser, error) {
 		group, err := u.backend.LookupGroupByID(gid)
 		if err != nil {
 			groupErrs = append(groupErrs, err)
+			continue
 		}
 
 		groups[group.Name] = struct{}{}


### PR DESCRIPTION
Fixes #53020 

This fixes an issue where error returns from `user.LookupGroupByID` would cause host user reconciliation to panic and crash the teleport process. A missing `continue` meant that we would attempt to mark a group as found by accessing the `ID` field on a `nil` pointer.

changelog: Fixed an issue causing the teleport process to crash on group database errors when host user creation was enabled