### PR TITLE
Fix minor details syntax issue

### DIFF
--- a/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
@@ -50,7 +50,7 @@ cluster to Teleport.
   ```
 
   <details>
-  <summary>Launching a fresh EKS cluster with eksctl?" open="false</summary>
+  <summary>Launching a fresh EKS cluster with eksctl?</summary>
 
   If you are using `eksctl` to launch a fresh Amazon Elastic Kubernetes Service
   cluster in order to follow this guide, the following example configuration


### PR DESCRIPTION
When converting one `Details` component into semantic HTML tags, `Details` attributes were left by mistake a `summary` tag. This change fixes the issue.