### PR TITLE
[web] Add FloatingUI, use for HoverTooltip and Navigation Sections

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@codemirror/autocomplete": "^6.18.6",
     "@codemirror/lang-sql": "^6.8.0",
     "@codemirror/view": "^6.36.4",
+    "@floating-ui/react": "^0.27.5",
     "@grpc/grpc-js": "1.12.6",
     "@lezer/highlight": "^1.2.1",
     "@nivo/bar": "^0.88.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@codemirror/view':
         specifier: ^6.36.4
         version: 6.36.4
+      '@floating-ui/react':
+        specifier: ^0.27.5
+        version: 0.27.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@grpc/grpc-js':
         specifier: 1.12.6
         version: 1.12.6
@@ -1723,6 +1726,18 @@ packages:
 
   '@floating-ui/dom@1.6.13':
     resolution: {integrity: sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==}
+
+  '@floating-ui/react-dom@2.1.2':
+    resolution: {integrity: sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/react@0.27.5':
+    resolution: {integrity: sha512-BX3jKxo39Ba05pflcQmqPPwc0qdNsdNi/eweAFtoIdrJWNen2sVEWMEac3i6jU55Qfx+lOcdMNKYn2CtWmlnOQ==}
+    peerDependencies:
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
 
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
@@ -6514,6 +6529,9 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
+  tabbable@6.2.0:
+    resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
+
   tar-fs@3.0.8:
     resolution: {integrity: sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==}
 
@@ -8537,6 +8555,20 @@ snapshots:
     dependencies:
       '@floating-ui/core': 1.6.9
       '@floating-ui/utils': 0.2.9
+
+  '@floating-ui/react-dom@2.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/dom': 1.6.13
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@floating-ui/react@0.27.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/utils': 0.2.9
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tabbable: 6.2.0
 
   '@floating-ui/utils@0.2.9': {}
 
@@ -14580,6 +14612,8 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   symbol-tree@3.2.4: {}
+
+  tabbable@6.2.0: {}
 
   tar-fs@3.0.8:
     dependencies:

--- a/web/packages/design/src/SlideTabs/SlideTabs.tsx
+++ b/web/packages/design/src/SlideTabs/SlideTabs.tsx
@@ -104,7 +104,7 @@ export function SlideTabs({
             <HoverTooltip
               key={key}
               tipContent={tooltipContent}
-              position={tooltipPosition}
+              placement={tooltipPosition}
             >
               <TabButton
                 ref={selected ? activeTab : undefined}

--- a/web/packages/design/src/Tooltip/HoverTooltip.tsx
+++ b/web/packages/design/src/Tooltip/HoverTooltip.tsx
@@ -37,24 +37,40 @@ import React, { PropsWithChildren, useRef, useState } from 'react';
 import styled, { useTheme } from 'styled-components';
 
 import Flex from 'design/Flex';
-import { FlexBasisProps, JustifyContentProps } from 'design/system';
 import Text from 'design/Text';
 
 type HoverTooltipProps = {
-  tipContent?: React.ReactNode;
-  showOnlyOnOverflow?: boolean;
-  className?: string;
   /**
-   * Specifies the position of tooltip relative to content. Used if neither
-   * anchor nor transform origins are specified.
+   * String or ReactNode to display in tooltip.
+   */
+  tipContent?: React.ReactNode;
+  /**
+   * Only show tooltip if trigger content is overflowing its container.
+   */
+  showOnlyOnOverflow?: boolean;
+  /**
+   * Specifies the position of tooltip relative to trigger content.
    */
   placement?: Placement;
-  justifyContentProps?: JustifyContentProps;
-  flexBasisProps?: FlexBasisProps;
-  // Optional additional props for FloatingUI
+  /**
+   * @deprecated – Prefer specifying `placement` instead.
+   */
+  position?: Placement;
+  /**
+   * Offset the tooltip relative to trigger content. Defaults to `8`.
+   */
   offset?: number;
+  /**
+   * Delay opening and/or closing of the tooltip.
+   */
   delay?: number | { open: number; close: number };
+  /**
+   * Don't flip the tooltip's placement when tooltip runs out of the viewport.
+   */
   disableFlip?: boolean;
+  /**
+   * Don't transition the tooltip in/out on mount/unmount.
+   */
   disableTransitions?: boolean;
 };
 
@@ -62,10 +78,8 @@ export const HoverTooltip = ({
   tipContent,
   children,
   showOnlyOnOverflow = false,
-  className,
   placement = 'top',
-  justifyContentProps = {},
-  flexBasisProps = {},
+  position,
   offset: offsetDistance = 8,
   delay = 0,
   disableFlip = false,
@@ -75,6 +89,10 @@ export const HoverTooltip = ({
   const [open, setOpen] = useState(false);
   const arrowRef = useRef(null);
   const contentRef = useRef<HTMLElement | null>(null);
+
+  if (position) {
+    placement = position;
+  }
 
   const { x, y, strategy, refs, context } = useFloating({
     placement,
@@ -144,17 +162,14 @@ export const HoverTooltip = ({
   return (
     <Flex
       ref={refs.setReference}
-      className={className}
       {...getReferenceProps({
         onMouseEnter: handleMouseEnter,
         onMouseLeave: () => setOpen(false),
       })}
-      {...justifyContentProps}
-      {...flexBasisProps}
     >
       {children}
-      <FloatingPortal>
-        {isMounted && (
+      {isMounted && (
+        <FloatingPortal>
           <StyledTooltip
             ref={refs.setFloating}
             style={{
@@ -171,14 +186,17 @@ export const HoverTooltip = ({
             <FloatingArrow
               ref={arrowRef}
               context={context}
-              style={{ fill: theme.colors.tooltip.background }}
+              style={{
+                fill: theme.colors.tooltip.background,
+                backdropFilter: 'blur(2px)',
+              }}
             />
             <StyledContent px={3} py={2}>
               {tipContent}
             </StyledContent>
           </StyledTooltip>
-        )}
-      </FloatingPortal>
+        </FloatingPortal>
+      )}
     </Flex>
   );
 };

--- a/web/packages/design/src/Tooltip/HoverTooltip.tsx
+++ b/web/packages/design/src/Tooltip/HoverTooltip.tsx
@@ -40,11 +40,6 @@ import Flex from 'design/Flex';
 import { FlexBasisProps, JustifyContentProps } from 'design/system';
 import Text from 'design/Text';
 
-type Origin = {
-  vertical: 'top' | 'center' | 'bottom';
-  horizontal: 'left' | 'center' | 'right';
-};
-
 type HoverTooltipProps = {
   tipContent?: React.ReactNode;
   showOnlyOnOverflow?: boolean;
@@ -54,18 +49,6 @@ type HoverTooltipProps = {
    * anchor nor transform origins are specified.
    */
   placement?: Placement;
-  /**
-   * @deprecated - Prefer specifying `placement`
-   */
-  position?: Placement;
-  /**
-   * @deprecated - Prefer specifying `placement`
-   */
-  anchorOrigin?: Origin;
-  /**
-   * @deprecated - Prefer specifying `placement`
-   */
-  transformOrigin?: Origin;
   justifyContentProps?: JustifyContentProps;
   flexBasisProps?: FlexBasisProps;
   // Optional additional props for FloatingUI
@@ -75,78 +58,12 @@ type HoverTooltipProps = {
   disableTransitions?: boolean;
 };
 
-// For backwards compatibility w/ existing usage, convert origin types to FloatingUI Placement
-// TODO(kiosion): Remove usages of Origin props / remove this util
-const originToPlacement = (
-  anchorOrigin?: Origin,
-  transformOrigin?: Origin
-): Placement => {
-  const primaryMap: Record<string, string> = {
-    bottom: 'top',
-    top: 'bottom',
-    right: 'left',
-    left: 'right',
-  };
-
-  let primary: string,
-    alignment: string | null = null;
-
-  if (transformOrigin && transformOrigin.vertical !== 'center') {
-    primary = primaryMap[transformOrigin.vertical];
-  } else if (transformOrigin && transformOrigin.horizontal !== 'center') {
-    primary = primaryMap[transformOrigin.horizontal];
-  } else {
-    primary = 'top';
-  }
-
-  if (primary === 'top' || primary === 'bottom') {
-    if (
-      transformOrigin &&
-      transformOrigin.horizontal === 'left' &&
-      anchorOrigin &&
-      anchorOrigin.horizontal !== 'left'
-    ) {
-      alignment = 'start';
-    } else if (
-      transformOrigin &&
-      transformOrigin.horizontal === 'right' &&
-      anchorOrigin &&
-      anchorOrigin.horizontal !== 'right'
-    ) {
-      alignment = 'end';
-    }
-  } else {
-    if (
-      transformOrigin &&
-      transformOrigin.vertical === 'top' &&
-      anchorOrigin &&
-      anchorOrigin.vertical !== 'top'
-    ) {
-      alignment = 'start';
-    } else if (
-      transformOrigin &&
-      transformOrigin.vertical === 'bottom' &&
-      anchorOrigin &&
-      anchorOrigin.vertical !== 'bottom'
-    ) {
-      alignment = 'end';
-    }
-  }
-
-  return alignment
-    ? (`${primary}-${alignment}` as Placement)
-    : (primary as Placement);
-};
-
 export const HoverTooltip = ({
   tipContent,
   children,
   showOnlyOnOverflow = false,
   className,
   placement = 'top',
-  position,
-  anchorOrigin,
-  transformOrigin,
   justifyContentProps = {},
   flexBasisProps = {},
   offset: offsetDistance = 8,
@@ -158,13 +75,6 @@ export const HoverTooltip = ({
   const [open, setOpen] = useState(false);
   const arrowRef = useRef(null);
   const contentRef = useRef<HTMLElement | null>(null);
-
-  // Determine position based on either anchorOrigin/transformOrigin if present
-  if (anchorOrigin || transformOrigin) {
-    placement = originToPlacement(anchorOrigin, transformOrigin);
-  } else if (position) {
-    placement = position;
-  }
 
   const { x, y, strategy, refs, context } = useFloating({
     placement,

--- a/web/packages/design/src/Tooltip/IconTooltip.story.tsx
+++ b/web/packages/design/src/Tooltip/IconTooltip.story.tsx
@@ -143,7 +143,7 @@ export const WithKindError = () => (
 export const HoverToolTip = () => (
   <Flex alignItems="baseline" gap={2}>
     <span>Hover the</span>
-    <HoverTooltip position="bottom" tipContent="some popover content">
+    <HoverTooltip placement="bottom" tipContent="some popover content">
       <ButtonPrimary>button</ButtonPrimary>
     </HoverTooltip>
   </Flex>

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
@@ -287,7 +287,7 @@ export function RequestCheckout<T extends PendingListItem>({
           {hasUnsupporteKubeResourceKinds && (
             <Alert kind="danger">
               <HoverTooltip
-                position="left"
+                placement="left"
                 tipContent={
                   fetchResourceRequestRolesAttempt.statusText.length > 248
                     ? fetchResourceRequestRolesAttempt.statusText

--- a/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.tsx
+++ b/web/packages/shared/components/AccessRequests/ReviewRequests/RequestView/RequestView.tsx
@@ -142,8 +142,7 @@ export function RequestView({
         <Box mt={4}>
           <HoverTooltip
             tipContent={getAssumeStartTimeTooltipText(request.assumeStartTime)}
-            anchorOrigin={{ vertical: 'top', horizontal: 'left' }}
-            transformOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+            placement="top-start"
           >
             <ButtonPrimary disabled={true}>Assume Roles</ButtonPrimary>
           </HoverTooltip>

--- a/web/packages/shared/components/AccessRequests/Shared/Shared.tsx
+++ b/web/packages/shared/components/AccessRequests/Shared/Shared.tsx
@@ -132,8 +132,7 @@ export const BlockedByStartTimeButton = ({
   return (
     <HoverTooltip
       tipContent={getAssumeStartTimeTooltipText(assumeStartTime)}
-      anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
-      transformOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      placement="top-end"
     >
       <ButtonPrimary disabled={true} size="small">
         Assume Roles

--- a/web/packages/shared/components/FileTransfer/FileTransferActionBar.tsx
+++ b/web/packages/shared/components/FileTransfer/FileTransferActionBar.tsx
@@ -39,7 +39,7 @@ export function FileTransferActionBar({
   return (
     <Flex flex="none" alignItems="center" height="24px">
       <HoverTooltip
-        position="bottom"
+        placement="bottom"
         tipContent={
           !hasAccess ? (
             <Text>

--- a/web/packages/teleport/src/DesktopSession/TopBar.tsx
+++ b/web/packages/teleport/src/DesktopSession/TopBar.tsx
@@ -66,11 +66,11 @@ export default function TopBar(props: Props) {
               canShareDirectory,
               isSharingDirectory
             )}
-            position="bottom"
+            placement="bottom"
           >
             <FolderShared style={primaryOnTrue(isSharingDirectory)} pr={3} />
           </HoverTooltip>
-          <HoverTooltip tipContent={clipboardSharingMessage} position="bottom">
+          <HoverTooltip tipContent={clipboardSharingMessage} placement="bottom">
             <Clipboard style={primaryOnTrue(isSharingClipboard)} pr={3} />
           </HoverTooltip>
           <AlertDropdown alerts={alerts} onRemoveAlert={onRemoveAlert} />

--- a/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/SelectSecurityGroups.tsx
+++ b/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/SelectSecurityGroups.tsx
@@ -179,7 +179,7 @@ export const SelectSecurityGroups = ({
           <Flex alignItems="center" gap={3} mt={2}>
             <HoverTooltip
               tipContent="Refreshing security groups will reset selections"
-              anchorOrigin={{ vertical: 'top', horizontal: 'left' }}
+              placement="top-start"
             >
               <ButtonSecondary
                 onClick={() => fetchSecurityGroups({ refresh: true })}

--- a/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/SelectSubnetIds.tsx
+++ b/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/SelectSubnetIds.tsx
@@ -164,7 +164,7 @@ export function SelectSubnetIds({
           <Flex alignItems="center" gap={3} mt={2}>
             <HoverTooltip
               tipContent="Refreshing subnets will reset selections"
-              anchorOrigin={{ vertical: 'top', horizontal: 'left' }}
+              placement="top-start"
             >
               <ButtonSecondary
                 onClick={() => fetchSubnets({ refresh: true })}

--- a/web/packages/teleport/src/Integrations/IntegrationsAddButton.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationsAddButton.tsx
@@ -36,7 +36,7 @@ export function IntegrationsAddButton({
 
   return (
     <HoverTooltip
-      position="bottom"
+      placement="bottom"
       tipContent={
         canCreateIntegrations ? null : (
           <MissingPermissionsTooltip

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcHeader.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcHeader.tsx
@@ -53,7 +53,7 @@ export function AwsOidcHeader({
       my={2}
       data-testid="aws-oidc-header"
     >
-      <HoverTooltip position="bottom" tipContent="Back to Integrations">
+      <HoverTooltip placement="bottom" tipContent="Back to Integrations">
         <ButtonText
           size="small"
           as={InternalLink}

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcTitle.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcTitle.tsx
@@ -40,7 +40,7 @@ export function AwsOidcTitle({
 
   return (
     <Flex alignItems="center" data-testid="aws-oidc-title">
-      <HoverTooltip position="bottom" tipContent={content.helper}>
+      <HoverTooltip placement="bottom" tipContent={content.helper}>
         <ButtonIcon as={InternalLink} to={content.to} aria-label="back">
           <ArrowLeft size="medium" />
         </ButtonIcon>

--- a/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
@@ -435,7 +435,7 @@ const ActionCell = ({
     return (
       <Cell align="right">
         <HoverTooltip
-          justifyContentProps={{ justifyContent: 'end' }}
+          placement="top-end"
           tipContent="You cannot configure or delete static tokens via the web UI. Static tokens should be removed from your Teleport configuration file."
         >
           <MenuButton buttonProps={{ disabled: true, ...buttonProps }} />

--- a/web/packages/teleport/src/Navigation/Navigation.tsx
+++ b/web/packages/teleport/src/Navigation/Navigation.tsx
@@ -16,6 +16,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {
+  useFloating,
+  useFocus,
+  useHover,
+  useInteractions,
+} from '@floating-ui/react';
 import type * as history from 'history';
 import React, {
   ReactNode,
@@ -273,6 +279,38 @@ function useDebounceClose<T>(
 
   return debouncedValue;
 }
+
+// TODO(kiosion): Once nav is reworked to use a single RightPanel,
+// can utilize `safePolygon` w/ `requireIntent` for `handleClose` here instead of `restMs`,
+// for less jank-y selection of nav items.
+/**
+ * useFloatingUiWithRestMs creates a new floating-ui ctx for toggling right nav panel on focus/hover,
+ * with restMs set to avoid sporadic selections while moving cursor to right panel
+ */
+export const useFloatingUiWithRestMs = ({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (newOpen: boolean) => void;
+}) => {
+  const { context, refs } = useFloating({
+    open,
+    onOpenChange,
+  });
+  const { getReferenceProps, getFloatingProps } = useInteractions([
+    useHover(context, {
+      restMs: 25,
+    }),
+    useFocus(context),
+  ]);
+
+  return {
+    refs,
+    getReferenceProps,
+    getFloatingProps,
+  };
+};
 
 export function Navigation() {
   const features = useFeatures();

--- a/web/packages/teleport/src/Navigation/ResourcesSection.tsx
+++ b/web/packages/teleport/src/Navigation/ResourcesSection.tsx
@@ -32,7 +32,11 @@ import { useUser } from 'teleport/User/UserContext';
 import useStickyClusterId from 'teleport/useStickyClusterId';
 
 import { CustomNavigationSubcategory, NavigationCategory } from './categories';
-import { NavigationSection, NavigationSubsection } from './Navigation';
+import {
+  NavigationSection,
+  NavigationSubsection,
+  useFloatingUiWithRestMs,
+} from './Navigation';
 import {
   CustomChildrenSection,
   RightPanel,
@@ -294,20 +298,30 @@ export function ResourcesSection({
 
   const currentViewRoute = currentView?.route;
 
+  const { refs, getReferenceProps, getFloatingProps } = useFloatingUiWithRestMs(
+    {
+      open: isExpanded,
+      onOpenChange: open => open && handleSetExpandedSection(section),
+    }
+  );
+
   return (
     <CustomChildrenSection
+      ref={refs.setReference}
       key="resources"
       section={section}
       $active={currentView?.route === baseRoute}
-      onExpandSection={() => handleSetExpandedSection(section)}
       aria-controls={`panel-${expandedSection?.category}`}
       isExpanded={isExpanded}
+      {...getReferenceProps()}
     >
       <RightPanel
+        ref={refs.setFloating}
         isVisible={isExpanded}
         skipAnimation={!!previousExpandedSection}
         id={`panel-resources`}
         onFocus={() => handleSetExpandedSection(section)}
+        {...getFloatingProps()}
       >
         <Box
           css={`

--- a/web/packages/teleport/src/Navigation/Search.tsx
+++ b/web/packages/teleport/src/Navigation/Search.tsx
@@ -26,7 +26,11 @@ import { color, height, space } from 'design/system';
 import { storageService } from 'teleport/services/storageService';
 
 import { CustomNavigationCategory } from './categories';
-import { NavigationSection, NavigationSubsection } from './Navigation';
+import {
+  NavigationSection,
+  NavigationSubsection,
+  useFloatingUiWithRestMs,
+} from './Navigation';
 import { RecentHistory, RecentHistoryItem } from './RecentHistory';
 import {
   CustomChildrenSection,
@@ -61,20 +65,31 @@ export function SearchSection({
 
   const isExpanded =
     expandedSection?.category === CustomNavigationCategory.Search;
+
+  const { refs, getReferenceProps, getFloatingProps } = useFloatingUiWithRestMs(
+    {
+      open: isExpanded,
+      onOpenChange: open => open && handleSetExpandedSection(section),
+    }
+  );
+
   return (
     <CustomChildrenSection
+      ref={refs.setReference}
       key="search"
       section={section}
       $active={false}
-      onExpandSection={() => handleSetExpandedSection(section)}
       aria-controls={`panel-${expandedSection?.category}`}
       isExpanded={isExpanded}
+      {...getReferenceProps()}
     >
       <RightPanel
+        ref={refs.setFloating}
         isVisible={isExpanded}
         skipAnimation={!!previousExpandedSection}
         id={`panel-${section.category}`}
         onFocus={() => handleSetExpandedSection(section)}
+        {...getFloatingProps()}
       >
         <Box
           css={`

--- a/web/packages/teleport/src/Notifications/Notifications.tsx
+++ b/web/packages/teleport/src/Notifications/Notifications.tsx
@@ -153,8 +153,7 @@ export function Notifications({ iconSize = 24 }: { iconSize?: number }) {
       className={IGNORE_CLICK_CLASSNAME}
     >
       <HoverTooltip
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-        transformOrigin={{ vertical: 'top', horizontal: 'center' }}
+        placement="bottom"
         tipContent="Notifications"
         css={`
           height: 100%;

--- a/web/packages/teleport/src/Roles/Roles.tsx
+++ b/web/packages/teleport/src/Roles/Roles.tsx
@@ -196,7 +196,7 @@ export function Roles(props: State & RolesProps) {
         <FeatureHeaderTitle>Roles</FeatureHeaderTitle>
         <InfoGuideWrapper guide={<InfoGuide />}>
           <HoverTooltip
-            position="bottom"
+            placement="bottom"
             tipContent={
               !canCreate ? (
                 <MissingPermissionsTooltip

--- a/web/packages/teleport/src/TopBar/TopBar.tsx
+++ b/web/packages/teleport/src/TopBar/TopBar.tsx
@@ -93,8 +93,7 @@ const TeleportLogo = ({ CustomLogo }: TopBarProps) => {
 
   return (
     <HoverTooltip
-      anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-      transformOrigin={{ vertical: 'top', horizontal: 'center' }}
+      placement="bottom"
       tipContent="Teleport Resources Home"
       css={`
         height: 100%;

--- a/web/packages/teleport/src/Users/Users.tsx
+++ b/web/packages/teleport/src/Users/Users.tsx
@@ -102,7 +102,7 @@ export function Users(props: State) {
           <Flex gap={2}>
             {!InviteCollaborators && (
               <HoverTooltip
-                position="bottom"
+                placement="bottom"
                 tipContent={
                   !isMissingPermissions ? (
                     ''


### PR DESCRIPTION
### Background
Add [FloatingUI](https://floating-ui.com/) and two initial usages: 
- In HoverTooltip instead of Popover, for more accurate positioning + support for subtle mount/unmount transition
- In Navigation Sections with `restMs` set to 25ms, to allow passing over other Section buttons while moving cursor towards the Right Panel, without sporadically selecting them


### Before / after
<img alt="floating-ui-before" src="https://github.com/user-attachments/assets/e773958d-13c2-4130-bef8-c4afbfc72006" width="50%" /><img alt="floating-ui-after" src="https://github.com/user-attachments/assets/cb0c396e-c5ed-4861-9613-b4d63493f1b7" width="50%" />
