### PR TITLE
Move version support table to Upcoming Releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/test-plan-docs.md
+++ b/.github/ISSUE_TEMPLATE/test-plan-docs.md
@@ -70,9 +70,6 @@ version of Teleport.
   $ git checkout origin/branch/v<release_version> -- CHANGELOG.md
   ```
 
-- [ ] Update the supported versions table in the FAQ
-  (https://goteleport.com/docs/faq/#supported-versions).
-
 - [ ] Verify the accuracy of critical docs pages. Follow the docs guides below
   and verify their accuracy while using the newly released major version of
   Teleport.

--- a/docs/pages/connect-your-client/includes/connect-my-computer-prerequisites.mdx
+++ b/docs/pages/connect-your-client/includes/connect-my-computer-prerequisites.mdx
@@ -1,6 +1,6 @@
 - A macOS or Linux device.
 - Teleport Connect v14.1+, on the same major version or one version behind the Teleport Proxy
-  Service version. See [version compatibility](../../faq.mdx#version-compatibility).
+  Service version. See [version compatibility](../../upcoming-releases.mdx#teleport).
 - A local Teleport user: you must authenticate using credentials or passwordless login, and not with
   SSO.
 - Permissions to create join tokens (verb `create` for [the `token` resource](../../reference/access-controls/roles.mdx)).

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -96,24 +96,8 @@ time you run `tsh`.
 
 ## Which version of Teleport is supported?
 
-Teleport releases a new major version approximately every 4 months, and provides
-security-critical support for the current and two previous major versions. With
-our typical release cadence, we usually support each major version for 12
-months.
-
-### Supported versions
-
-Here are the major versions of Teleport and their support windows:
-
-| Release | Release Date      | EOL           | Minimum `tsh` version |
-|---------|-------------------|---------------|-----------------------|
-| v17.0   | November 16, 2024 | November 2025 | v16.0.0               |
-| v16.0   | June 14, 2024     | June 2025     | v15.0.0               |
-| v15.0   | January 29, 2024  | January 2025  | v14.0.0               |
-
-### Version compatibility
-
-(!docs/pages/includes/compatibility.mdx!)
+See [Upcoming Releases](upcoming-releases.mdx) for the versions of Teleport that
+we support and how long we plan to continue supporting them.
 
 ## Does the Web UI support copy and paste?
 


### PR DESCRIPTION
Ports #53003 to `master`

This change helps guarantee that we'll update the version support table at the same time as the upcoming release table to keep our support windows up to date. Since we otherwise do not update the two tables at the same time, the supported version table has become out of date.

This change also updates support windows based on the plan to release v18 in May, 2025, with the assumption that we release a major version every 4 months.

This change also moves the compatibility description from FAQ to Upcoming Releases so we keep this info in one place, and links to Upcoming Releases from the relevant section of the FAQ.

Since the docs engine automatically copies the Upcoming Releases page from the default version to all four versions of the docs, this change does not edit the Upcoming Releases page for this version.

This change removes an item from the docs test plan re: editing the supported versions table, since we'll be doing this continuously rather than when we release a new major version.