### PR TITLE
[v17] Add correct principal for agentless nodes on leaf clusters

### DIFF
--- a/lib/proxy/router.go
+++ b/lib/proxy/router.go
@@ -302,7 +302,7 @@ func (r *Router) DialHost(ctx context.Context, clientSrcAddr, clientDstAddr net.
 		IsAgentlessNode:       isAgentlessNode,
 		AgentlessSigner:       sshSigner,
 		Address:               host,
-		Principals:            principals,
+		Principals:            apiutils.Deduplicate(principals),
 		ServerID:              serverID,
 		ProxyIDs:              proxyIDs,
 		ConnType:              types.NodeTunnel,

--- a/lib/proxy/router.go
+++ b/lib/proxy/router.go
@@ -240,7 +240,7 @@ func (r *Router) DialHost(ctx context.Context, clientSrcAddr, clientDstAddr net.
 
 	principals := []string{
 		host,
-		fmt.Sprintf("%s.%s", host, clusterName),
+		host + "." + clusterName,
 	}
 
 	var (

--- a/lib/proxy/router.go
+++ b/lib/proxy/router.go
@@ -285,6 +285,7 @@ func (r *Router) DialHost(ctx context.Context, clientSrcAddr, clientDstAddr net.
 				if err != nil {
 					return nil, trace.Wrap(err)
 				}
+				principals = append(principals, fmt.Sprintf("%s.%s", host, clusterName))
 			}
 		}
 	} else {

--- a/lib/proxy/router.go
+++ b/lib/proxy/router.go
@@ -238,7 +238,10 @@ func (r *Router) DialHost(ctx context.Context, clientSrcAddr, clientDstAddr net.
 	}
 	span.AddEvent("retrieved target server")
 
-	principals := []string{host}
+	principals := []string{
+		host,
+		fmt.Sprintf("%s.%s", host, clusterName),
+	}
 
 	var (
 		isAgentlessNode bool
@@ -285,7 +288,6 @@ func (r *Router) DialHost(ctx context.Context, clientSrcAddr, clientDstAddr net.
 				if err != nil {
 					return nil, trace.Wrap(err)
 				}
-				principals = append(principals, fmt.Sprintf("%s.%s", host, clusterName))
 			}
 		}
 	} else {

--- a/lib/proxy/router.go
+++ b/lib/proxy/router.go
@@ -240,6 +240,7 @@ func (r *Router) DialHost(ctx context.Context, clientSrcAddr, clientDstAddr net.
 
 	principals := []string{
 		host,
+		// Add in principal for when nodes are on leaf clusters.
 		host + "." + clusterName,
 	}
 

--- a/lib/proxy/router_test.go
+++ b/lib/proxy/router_test.go
@@ -808,6 +808,7 @@ func TestRouter_DialHost(t *testing.T) {
 				require.NotNil(t, params.AgentlessSigner)
 				require.True(t, params.IsAgentlessNode)
 				require.NotNil(t, conn)
+				require.Contains(t, params.Principals, "host")
 				require.Contains(t, params.Principals, "host.test")
 			},
 		},

--- a/lib/proxy/router_test.go
+++ b/lib/proxy/router_test.go
@@ -787,6 +787,7 @@ func TestRouter_DialHost(t *testing.T) {
 				require.NotNil(t, params.GetUserAgent)
 				require.Nil(t, params.AgentlessSigner)
 				require.NotNil(t, conn)
+				require.Contains(t, params.Principals, "host")
 				require.Contains(t, params.Principals, "host.test")
 			},
 		},

--- a/lib/proxy/router_test.go
+++ b/lib/proxy/router_test.go
@@ -787,6 +787,7 @@ func TestRouter_DialHost(t *testing.T) {
 				require.NotNil(t, params.GetUserAgent)
 				require.Nil(t, params.AgentlessSigner)
 				require.NotNil(t, conn)
+				require.Contains(t, params.Principals, "host.test")
 			},
 		},
 		{
@@ -806,6 +807,7 @@ func TestRouter_DialHost(t *testing.T) {
 				require.NotNil(t, params.AgentlessSigner)
 				require.True(t, params.IsAgentlessNode)
 				require.NotNil(t, conn)
+				require.Contains(t, params.Principals, "host.test")
 			},
 		},
 		{


### PR DESCRIPTION
Backport #52803 to branch/v17

Part of https://github.com/gravitational/teleport/issues/42252

Adds the correct principle to allow $ ssh -p ${PORT?} -F ssh_config_teleport "${USER?}@${NODE?}.${CLUSTER?}" when connecting to agent-less nodes on a leaf cluster.