### PR TITLE
Fix flaky test in Revocations service.

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/auth/machineid/workloadidentityv1"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/httplib"
@@ -60,6 +61,9 @@ type APIConfig struct {
 	MetadataGetter events.UploadMetadataGetter
 	// AccessGraph contains the configuration about the access graph service
 	AccessGraph AccessGraphConfig
+	// MutateRevocationsServiceConfig is a function that allows to mutate
+	// the revocation service configuration for testing.
+	MutateRevocationsServiceConfig func(config *workloadidentityv1.RevocationServiceConfig)
 }
 
 // CheckAndSetDefaults checks and sets default values

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -5314,7 +5314,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	}
 	workloadidentityv1pb.RegisterWorkloadIdentityIssuanceServiceServer(server, workloadIdentityIssuanceService)
 
-	workloadIdentityRevocationService, err := workloadidentityv1.NewRevocationService(&workloadidentityv1.RevocationServiceConfig{
+	revSvcConfig := &workloadidentityv1.RevocationServiceConfig{
 		Authorizer:          cfg.Authorizer,
 		Emitter:             cfg.Emitter,
 		Clock:               cfg.AuthServer.GetClock(),
@@ -5323,7 +5323,11 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		CertAuthorityGetter: cfg.AuthServer.Cache,
 		EventsWatcher:       cfg.AuthServer.Services,
 		ClusterName:         clusterName.GetClusterName(),
-	})
+	}
+	if cfg.MutateRevocationsServiceConfig != nil {
+		cfg.MutateRevocationsServiceConfig(revSvcConfig)
+	}
+	workloadIdentityRevocationService, err := workloadidentityv1.NewRevocationService(revSvcConfig)
 	if err != nil {
 		return nil, trace.Wrap(err, "creating workload identity revocation service")
 	}

--- a/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
+++ b/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
@@ -3025,6 +3025,8 @@ func TestRevocationService_CRL(t *testing.T) {
 	require.NoError(t, err)
 	revocationsClient := authorizedClient.WorkloadIdentityRevocationServiceClient()
 
+	// Touch this test to trigger it.
+
 	// Fetch the SPIFFE CA so we can validate CRL signature.
 	ca, err := srv.Auth().GetCertAuthority(ctx, types.CertAuthID{
 		Type:       types.SPIFFECA,

--- a/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
+++ b/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
@@ -55,6 +55,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/join"
+	"github.com/gravitational/teleport/lib/auth/machineid/workloadidentityv1"
 	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	libevents "github.com/gravitational/teleport/lib/events"
@@ -71,7 +72,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func newTestTLSServer(t testing.TB) (*auth.TestTLSServer, *eventstest.MockRecorderEmitter) {
+func newTestTLSServer(t testing.TB, opts ...auth.TestTLSServerOption) (*auth.TestTLSServer, *eventstest.MockRecorderEmitter) {
 	as, err := auth.NewTestAuthServer(auth.TestAuthServerConfig{
 		Dir:   t.TempDir(),
 		Clock: clockwork.NewFakeClockAt(time.Now().Round(time.Second).UTC()),
@@ -79,9 +80,10 @@ func newTestTLSServer(t testing.TB) (*auth.TestTLSServer, *eventstest.MockRecord
 	require.NoError(t, err)
 
 	emitter := &eventstest.MockRecorderEmitter{}
-	srv, err := as.NewTestTLSServer(func(config *auth.TestTLSServerConfig) {
+	opts = append(opts, func(config *auth.TestTLSServerConfig) {
 		config.APIConfig.Emitter = emitter
 	})
+	srv, err := as.NewTestTLSServer(opts...)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -3000,9 +3002,15 @@ func TestRevocationService_UpsertWorkloadIdentityX509Revocation(t *testing.T) {
 
 func TestRevocationService_CRL(t *testing.T) {
 	t.Parallel()
-	srv, _ := newTestTLSServer(t)
+	revocationsEventCh := make(chan struct{})
+	fakeClock := clockwork.NewFakeClock()
+	srv, _ := newTestTLSServer(t, func(config *auth.TestTLSServerConfig) {
+		config.APIConfig.MutateRevocationsServiceConfig = func(config *workloadidentityv1.RevocationServiceConfig) {
+			config.RevocationsEventProcessedCh = revocationsEventCh
+			config.Clock = fakeClock
+		}
+	})
 	ctx := context.Background()
-	fakeClock := srv.Clock().(*clockwork.FakeClock)
 
 	authorizedUser, _, err := auth.CreateUserAndRole(
 		srv.Auth(),
@@ -3024,8 +3032,6 @@ func TestRevocationService_CRL(t *testing.T) {
 	authorizedClient, err := srv.NewClient(auth.TestUser(authorizedUser.GetName()))
 	require.NoError(t, err)
 	revocationsClient := authorizedClient.WorkloadIdentityRevocationServiceClient()
-
-	// Touch this test to trigger it.
 
 	// Fetch the SPIFFE CA so we can validate CRL signature.
 	ca, err := srv.Auth().GetCertAuthority(ctx, types.CertAuthID{
@@ -3084,6 +3090,12 @@ func TestRevocationService_CRL(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
+		// Wait for the revocation event to be processed.
+		select {
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for revocation event to be processed")
+		case <-revocationsEventCh:
+		}
 	}
 	deleteRevocation := func(t *testing.T, name string) {
 		_, err = revocationsClient.DeleteWorkloadIdentityX509Revocation(
@@ -3093,6 +3105,12 @@ func TestRevocationService_CRL(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
+		// Wait for the revocation event to be processed.
+		select {
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for revocation event to be processed")
+		case <-revocationsEventCh:
+		}
 	}
 
 	// Fetch the initial, empty, CRL


### PR DESCRIPTION
There was a race here when the system was under load ( as in our main test suite ). Whilst I'm not too keen on the solution I've gone with here, since it involves the test hooking into the subject code, it does ensure that the test waits for the event to be processed before moving forward.

Closes https://github.com/gravitational/teleport/issues/52756