### PR TITLE
[v16] Fixes panic on group database errors during host user reconciliation

### DIFF
--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -674,6 +674,7 @@ func (u *HostUserManagement) getHostUser(username string) (*HostUser, error) {
 		group, err := u.backend.LookupGroupByID(gid)
 		if err != nil {
 			groupErrs = append(groupErrs, err)
+			continue
 		}
 
 		groups[group.Name] = struct{}{}


### PR DESCRIPTION
Backport #53031 for branch/v16

changelog: Fixed an issue causing the teleport process to crash on group database errors when host user creation was enabled