### PR TITLE
[v17] Fixes panic on group database errors during host user reconciliation

### DIFF
--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -675,6 +675,7 @@ func (u *HostUserManagement) getHostUser(username string) (*HostUser, error) {
 		group, err := u.backend.LookupGroupByID(gid)
 		if err != nil {
 			groupErrs = append(groupErrs, err)
+			continue
 		}
 
 		groups[group.Name] = struct{}{}


### PR DESCRIPTION
Backport #53031 to branch/v17

changelog: Fixed an issue causing the teleport process to crash on group database errors when host user creation was enabled
