### PR TITLE
Add `fullWidth` prop to `Stack` and `Flex`

### DIFF
--- a/web/packages/design/src/Flex/Flex.tsx
+++ b/web/packages/design/src/Flex/Flex.tsx
@@ -47,6 +47,8 @@ export interface FlexProps
    * Uses inline-flex instead of just flex as the display property.
    */
   inline?: boolean;
+  /** Makes the element and its immediate children have 100% width. */
+  fullWidth?: boolean;
 }
 
 const Flex = styled(Box)<FlexProps>`
@@ -57,6 +59,15 @@ const Flex = styled(Box)<FlexProps>`
   ${flexBasis}
   ${flexDirection}
   ${gap};
+
+  ${props =>
+    props.fullWidth &&
+    `
+    width: 100%;
+    & > * {
+      width: 100%;
+    }
+  `}
 `;
 
 Flex.displayName = 'Flex';
@@ -90,9 +101,9 @@ export default Flex;
 export const Stack = styled(Flex).attrs({
   flexDirection: 'column',
 })`
-  // Prevents children from shrinking, within a stack we pretty much never want that to happen.
-  // Individual children can override this.
   & > * {
+    // Prevents children from shrinking, within a stack we pretty much never want that to happen.
+    // Individual children can override this.
     flex-shrink: 0;
   }
 `;

--- a/web/packages/design/src/Flex/Stack.story.tsx
+++ b/web/packages/design/src/Flex/Stack.story.tsx
@@ -16,34 +16,61 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { Meta } from '@storybook/react';
 import styled from 'styled-components';
 
 import Box from 'design/Box';
 import { ButtonPrimary } from 'design/Button';
-import { P } from 'design/Text/Text';
+import { P, P2 } from 'design/Text/Text';
 
 import { Stack } from './Flex';
 
-export default {
-  title: 'Design/Flex/Stack',
+type StoryProps = {
+  fullWidth: boolean;
 };
 
-export const Basic = () => (
-  <Stack gap={6}>
+const meta: Meta<StoryProps> = {
+  title: 'Design/Flex/Stack',
+  args: {
+    fullWidth: false,
+  },
+};
+export default meta;
+
+export const Basic = ({ fullWidth }: StoryProps) => (
+  <Stack gap={6} fullWidth={fullWidth}>
     <Square bg="pink" />
 
-    <Stack gap={3}>
+    <Stack gap={3} fullWidth={fullWidth}>
       {/* If no gap prop is given, a default gap of 1 is used. */}
       <Stack>
         <Square bg="green" />
         <ButtonPrimary>Foo</ButtonPrimary>
       </Stack>
-      <Stack>
-        <Square bg="green" />
+      <Stack fullWidth={fullWidth}>
+        <Square bg="green">
+          {fullWidth && (
+            <Para>
+              Only the middle one among these three sibling Stacks is given{' '}
+              <code>fullWidth</code>. This demonstrates that{' '}
+              <code>fullWidth</code> can be used for specific child Stacks
+              within multiple levels of nested Stacks.
+            </Para>
+          )}
+        </Square>
         <ButtonPrimary>Bar</ButtonPrimary>
       </Stack>
-      <Stack>
-        <Square bg="green" />
+      <Stack width="100%">
+        <Square bg="green" width="100%">
+          {fullWidth && (
+            <Para>
+              With <code>fullWidth</code>, all immediate children of a Stack
+              have the width set to 100%. If only specific children are supposed
+              to have 100% width, the width can be set manually, like in this
+              last stack. Notice how the button doesn't span full width.
+            </Para>
+          )}
+        </Square>
         <ButtonPrimary>Baz</ButtonPrimary>
       </Stack>
     </Stack>
@@ -52,8 +79,8 @@ export const Basic = () => (
   </Stack>
 );
 
-export const MarginAuto = () => (
-  <Stack gap={6} height="90vh">
+export const MarginAuto = ({ fullWidth }: StoryProps) => (
+  <Stack gap={6} height="90vh" fullWidth={fullWidth}>
     <P>
       <code>margin-top: auto</code> can be used to automatically align elements
       after a certain child to the end of the stack.
@@ -66,5 +93,9 @@ export const MarginAuto = () => (
   </Stack>
 );
 
-const Square = styled(Box).attrs({ width: '150px', height: '150px' })``;
+const Square = styled(Box)``;
+Square.defaultProps = { width: '150px', height: '150px', p: 2 };
 const SmallSquare = styled(Box).attrs({ width: '50px', height: '50px' })``;
+const Para = styled(P2)`
+  max-width: 60ch;
+`;

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetDiagReport.tsx
@@ -134,7 +134,7 @@ export function DocumentVnetDiagReport(props: {
       <Stack
         gap={4}
         maxWidth="680px"
-        width="100%"
+        fullWidth
         mx="auto"
         mt={4}
         p={5}
@@ -144,13 +144,8 @@ export function DocumentVnetDiagReport(props: {
         // content was displayed in the Stack.
         alignSelf="flex-start"
       >
-        <Stack gap={2} width="100%" alignItems="stretch">
-          <Flex
-            flexWrap="wrap"
-            width="100%"
-            gap={2}
-            justifyContent="space-between"
-          >
+        <Stack gap={2} fullWidth alignItems="stretch">
+          <Flex flexWrap="wrap" gap={2} justifyContent="space-between">
             <H1>VNet Diagnostic Report</H1>
 
             <Flex gap={2}>
@@ -248,7 +243,7 @@ const CheckAttempt = ({
   const displayDetails = reportOneofDisplayDetails[reportOneof];
 
   return (
-    <Stack gap={2} width="100%">
+    <Stack gap={2} fullWidth>
       {!displayDetails ? (
         <Alert kind="danger">
           Cannot display the result from an unsupported check {reportOneof}
@@ -395,5 +390,5 @@ const Success = styled(SuccessIcon).attrs({
 `;
 
 const Alert = (props: Pick<AlertProps, 'children' | 'details' | 'kind'>) => (
-  <DesignAlert m={0} width="100%" {...props} />
+  <DesignAlert m={0} {...props} />
 );


### PR DESCRIPTION
Sometimes when using multiple levels of nesting of `Stack` and `Flex`, you have to set `width="100%"` on the parent and then its child and then its child to propagate the full width all the way down. To make it a little bit easier, I decided to add `fullWidth` prop. Initially I added it only on `Stack`, but then I realized that it might be useful on `Flex` as well. I updated `DocumentVnetDiagReport` and the story for `Stack` to demonstrate its usefulness.

I have another PR in the works where I had multiple `TextSelectCopy` elements in a Stack. Without this prop, I'd have to pass `width="100%"` to multiple Stack elements and each `TextSelectCopy`. With this change, it gets a little bit easier.

I verified that this doesn't break anything by opening these two stories and comparing how they look on master vs on this branch. It's mostly the Alerts that would not span the full width if `fullWidth` or `width="100%"` was not used.

* https://localhost:9002/?path=/story/teleterm-vnet-documentvnetdiagreport--document-vnet-diag-report
* https://localhost:9002/?path=/story/teleterm-vnet-documentvnetdiagreport--document-vnet-diag-report&args=networkStackAttempt:error;routeConflictAttempt:error;routeConflictCommandAttempt:error;displayUnsupportedCheckAttempt:!true