### PR TITLE
[v16] Support context path for Kubernetes app discovery

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -796,6 +796,8 @@ const (
 	DiscoveryAppRewriteLabel = TeleportNamespace + "/app-rewrite"
 	// DiscoveryAppNameLabel specifies explicitly name of an app created from Kubernetes service.
 	DiscoveryAppNameLabel = TeleportNamespace + "/name"
+	// DiscoveryPathLabel optionally specifies a context path for apps created from Kubernetes services.
+	DiscoveryPathLabel = TeleportNamespace + "/path"
 	// DiscoveryAppInsecureSkipVerify specifies the TLS verification enforcement for a discovered app created from Kubernetes service.
 	DiscoveryAppInsecureSkipVerify = TeleportNamespace + "/insecure-skip-verify"
 	// DiscoveryAppIgnore specifies if a Kubernetes service should be ignored by discovery service.

--- a/docs/pages/reference/agent-services/kubernetes-application-discovery.mdx
+++ b/docs/pages/reference/agent-services/kubernetes-application-discovery.mdx
@@ -150,3 +150,13 @@ Controls the public address for the Teleport app we create if needed.
 annotations:
   teleport.dev/public-addr: "custom.teleport.dev"
 ```
+
+### `teleport.dev/path`
+
+The path is appended to the URI generated for the Teleport app for cases where
+an application is served on a sub-path of an HTTP service.
+
+```yaml
+annotations:
+  teleport.dev/path: "foo/bar"
+```

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -164,7 +164,7 @@ func UnmarshalAppServer(data []byte, opts ...MarshalOption) (types.AppServer, er
 // It transforms service fields and annotations into appropriate Teleport app fields.
 // Service labels are copied to app labels.
 func NewApplicationFromKubeService(service corev1.Service, clusterName, protocol string, port corev1.ServicePort) (types.Application, error) {
-	appURI := buildAppURI(protocol, GetServiceFQDN(service), port.Port)
+	appURI := buildAppURI(protocol, GetServiceFQDN(service), service.GetAnnotations()[types.DiscoveryPathLabel], port.Port)
 
 	rewriteConfig, err := getAppRewriteConfig(service.GetAnnotations())
 	if err != nil {
@@ -210,10 +210,11 @@ func GetServiceFQDN(service corev1.Service) string {
 	return fmt.Sprintf("%s.%s.svc.%s", service.GetName(), service.GetNamespace(), clusterDomainResolver())
 }
 
-func buildAppURI(protocol, serviceFQDN string, port int32) string {
+func buildAppURI(protocol, serviceFQDN, path string, port int32) string {
 	return (&url.URL{
 		Scheme: protocol,
 		Host:   fmt.Sprintf("%s:%d", serviceFQDN, port),
+		Path:   path,
 	}).String()
 }
 

--- a/lib/services/app_test.go
+++ b/lib/services/app_test.go
@@ -211,6 +211,7 @@ func TestBuildAppURI(t *testing.T) {
 	tests := []struct {
 		serviceFQDN string
 		port        int32
+		path        string
 		protocol    string
 		expected    string
 	}{
@@ -219,6 +220,34 @@ func TestBuildAppURI(t *testing.T) {
 			port:        8080,
 			protocol:    "http",
 			expected:    "http://service.example:8080",
+		},
+		{
+			serviceFQDN: "service.example",
+			port:        8080,
+			protocol:    "http",
+			path:        "foo",
+			expected:    "http://service.example:8080/foo",
+		},
+		{
+			serviceFQDN: "service.example",
+			port:        8080,
+			protocol:    "http",
+			path:        "/foo",
+			expected:    "http://service.example:8080/foo",
+		},
+		{
+			serviceFQDN: "service.example",
+			port:        8080,
+			protocol:    "http",
+			path:        "foo/bar",
+			expected:    "http://service.example:8080/foo/bar",
+		},
+		{
+			serviceFQDN: "service.example",
+			port:        8080,
+			protocol:    "http",
+			path:        "foo bar",
+			expected:    "http://service.example:8080/foo%20bar",
 		},
 		{
 			serviceFQDN: "service.example",
@@ -235,7 +264,7 @@ func TestBuildAppURI(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		require.Equal(t, tt.expected, buildAppURI(tt.protocol, tt.serviceFQDN, tt.port))
+		require.Equal(t, tt.expected, buildAppURI(tt.protocol, tt.serviceFQDN, tt.path, tt.port))
 	}
 }
 


### PR DESCRIPTION
Backports #52897

changelog: Kubernetes app discovery now supports an additional annotation for apps that are served on a sub-path of an HTTP service.