### PR TITLE
[v16] Machine ID: Warn when returned cert TTL is less than expected (#52833)

### DIFF
--- a/lib/tbot/output_utils.go
+++ b/lib/tbot/output_utils.go
@@ -390,6 +390,55 @@ func generateIdentity(
 	return newIdentity, nil
 }
 
+// warnOnEarlyExpiration logs a warning if the given identity is likely to
+// expire problematically early. This can happen if either the configured TTL is
+// less than the renewal interval, or if the server returns certs valid for a
+// shorter-than-expected period of time.
+// This assumes the identity was just renewed, for the purposes of calculating
+// TTLs, and may log false positive warnings if the time delta is large; the
+// time calculations include a 1m buffer to mitigate this.
+func warnOnEarlyExpiration(
+	ctx context.Context,
+	log *slog.Logger,
+	ident *identity.Identity,
+	ttl time.Duration,
+	renewalInterval time.Duration,
+) {
+	// Calculate a rough TTL, assuming this was called shortly after the
+	// identity was returned. We'll add a minute buffer to compensate and avoid
+	// superfluous warning messages.
+	effectiveTTL := time.Until(ident.TLSIdentity.Expires) + time.Minute
+
+	if effectiveTTL < ttl {
+		l := log.With(
+			"requested_ttl", ttl,
+			"renewal_interval", renewalInterval,
+			"effective_ttl", effectiveTTL,
+			"expires", ident.TLSIdentity.Expires,
+			"roles", ident.TLSIdentity.Groups,
+		)
+
+		// TODO(timothyb89): we can technically fetch our individual roles
+		// without explicit permission, and could determine which role in
+		// particular limited the TTL.
+
+		if effectiveTTL < renewalInterval {
+			//nolint:sloglint // multiline string is actually constant
+			l.WarnContext(ctx, "The server returned an identity shorter than "+
+				"expected and below the configured renewal interval, probably "+
+				"due to a `max_session_ttl` configured on a server-side role. "+
+				"Unless corrected, the credentials will be invalid for some "+
+				"period until renewal.")
+		} else {
+			//nolint:sloglint // multiline string is actually constant
+			l.WarnContext(ctx, "The server returned an identity shorter than "+
+				"the requested TTL, probably due to a `max_session_ttl` "+
+				"configured on a server-side role. It may not remain valid as "+
+				"long as expected.")
+		}
+	}
+}
+
 // fetchDefaultRoles requests the bot's own role from the auth server and
 // extracts its full list of allowed roles.
 func fetchDefaultRoles(ctx context.Context, roleGetter services.RoleGetter, identity *identity.Identity) ([]string, error) {

--- a/lib/tbot/service_application_output.go
+++ b/lib/tbot/service_application_output.go
@@ -144,6 +144,8 @@ func (s *ApplicationOutputService) generate(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 
+	warnOnEarlyExpiration(ctx, s.log.With("output", s), id, s.botCfg.CertificateTTL, s.botCfg.RenewalInterval)
+
 	s.log.InfoContext(
 		ctx,
 		"Generated identity for app",

--- a/lib/tbot/service_database_output.go
+++ b/lib/tbot/service_database_output.go
@@ -146,6 +146,8 @@ func (s *DatabaseOutputService) generate(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 
+	warnOnEarlyExpiration(ctx, s.log.With("output", s), id, s.botCfg.CertificateTTL, s.botCfg.RenewalInterval)
+
 	s.log.InfoContext(
 		ctx,
 		"Generated identity for database",

--- a/lib/tbot/service_identity_output.go
+++ b/lib/tbot/service_identity_output.go
@@ -161,6 +161,8 @@ func (s *IdentityOutputService) generate(ctx context.Context) error {
 		}
 	}
 
+	warnOnEarlyExpiration(ctx, s.log.With("output", s), id, s.botCfg.CertificateTTL, s.botCfg.RenewalInterval)
+
 	hostCAs, err := s.botAuthClient.GetCertAuthorities(ctx, types.HostCA, false)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/tbot/service_kubernetes_output.go
+++ b/lib/tbot/service_kubernetes_output.go
@@ -162,6 +162,8 @@ func (s *KubernetesOutputService) generate(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 
+	warnOnEarlyExpiration(ctx, s.log.With("output", s), id, s.botCfg.CertificateTTL, s.botCfg.RenewalInterval)
+
 	s.log.InfoContext(
 		ctx,
 		"Generated identity for Kubernetes cluster",

--- a/lib/tbot/service_spiffe_svid_output.go
+++ b/lib/tbot/service_spiffe_svid_output.go
@@ -189,6 +189,9 @@ func (s *SPIFFESVIDOutputService) requestSVID(
 	if err != nil {
 		return nil, nil, nil, trace.Wrap(err, "generating identity")
 	}
+
+	warnOnEarlyExpiration(ctx, s.log.With("output", s), id, s.botCfg.CertificateTTL, s.botCfg.RenewalInterval)
+
 	// create a client that uses the impersonated identity, so that when we
 	// fetch information, we can ensure access rights are enforced.
 	facade := identity.NewFacade(s.botCfg.FIPS, s.botCfg.Insecure, id)

--- a/lib/tbot/service_ssh_host_output.go
+++ b/lib/tbot/service_ssh_host_output.go
@@ -112,6 +112,9 @@ func (s *SSHHostOutputService) generate(ctx context.Context) error {
 	if err != nil {
 		return trace.Wrap(err, "generating identity")
 	}
+
+	warnOnEarlyExpiration(ctx, s.log.With("output", s), id, s.botCfg.CertificateTTL, s.botCfg.RenewalInterval)
+
 	// create a client that uses the impersonated identity, so that when we
 	// fetch information, we can ensure access rights are enforced.
 	facade := identity.NewFacade(s.botCfg.FIPS, s.botCfg.Insecure, id)

--- a/lib/tbot/service_workload_identity_jwt.go
+++ b/lib/tbot/service_workload_identity_jwt.go
@@ -184,6 +184,9 @@ func (s *WorkloadIdentityJWTService) requestJWTSVID(
 	if err != nil {
 		return nil, trace.Wrap(err, "generating JWT SVID")
 	}
+
+	warnOnEarlyExpiration(ctx, s.log.With("output", s), id, s.botCfg.CertificateTTL, s.botCfg.RenewalInterval)
+
 	var credential *workloadidentityv1pb.Credential
 	switch len(credentials) {
 	case 0:

--- a/lib/tbot/service_workload_identity_x509.go
+++ b/lib/tbot/service_workload_identity_x509.go
@@ -201,6 +201,9 @@ func (s *WorkloadIdentityX509Service) requestSVID(
 	if err != nil {
 		return nil, nil, trace.Wrap(err, "generating identity")
 	}
+
+	warnOnEarlyExpiration(ctx, s.log.With("output", s), id, s.botCfg.CertificateTTL, s.botCfg.RenewalInterval)
+
 	// create a client that uses the impersonated identity, so that when we
 	// fetch information, we can ensure access rights are enforced.
 	facade := identity.NewFacade(s.botCfg.FIPS, s.botCfg.Insecure, id)


### PR DESCRIPTION
Backport of #52833 for branch/v16

Contains some tweaks to account for some v17-only changes, namely introduction of the `CredentialLifetime` struct.

changelog: Machine ID: Added warning when generated certificates will not last as long as expected

---

* Machine ID: Warn when returned cert TTL is less than expected

This adds a warning when the returned certificate TTL is lower than requested, which can happen if `max_session_ttl` is set in a bot role.

Fixes #29579

* Add warning on most outputs; add TODO comment for future improvements

* Mute slonglint false positivess