### PR TITLE
Update codeowners and dependabot reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Merge rules are governed by logic in the Workflow Bot. Protect the
 # .github/workflows directory (and the merge logic) using CODEOWNERS.
-/.github/workflows/ @klizhentas @russjones @r0mant @zmb3 @fheinecke @camscale @tcsc @rosstimothy @codingllama
+/.github/workflows/ @klizhentas @russjones @r0mant @zmb3 @fheinecke @camscale @tcsc @rosstimothy
 /build.assets/tooling/cmd/difftest/ @klizhentas @russjones @r0mant @zmb3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,10 +28,9 @@ updates:
           - "minor"
           - "patch"
     reviewers:
-      - codingllama
       - rosstimothy
       - zmb3
-      - hugoshaka
+      - hugoShaka
     labels:
       - "dependencies"
       - "go"
@@ -50,10 +49,9 @@ updates:
           - "minor"
           - "patch"
     reviewers:
-      - codingllama
       - rosstimothy
       - zmb3
-      - hugoshaka
+      - hugoShaka
     labels:
       - "dependencies"
       - "go"
@@ -75,7 +73,6 @@ updates:
           - "minor"
           - "patch"
     reviewers:
-      - codingllama
       - rosstimothy
       - tcsc
       - zmb3
@@ -97,7 +94,6 @@ updates:
           - "minor"
           - "patch"
     reviewers:
-      - codingllama
       - rosstimothy
       - zmb3
     labels:
@@ -121,7 +117,6 @@ updates:
           - "minor"
           - "patch"
     reviewers:
-      - codingllama
       - fheinecke
       - rosstimothy
       - zmb3
@@ -148,9 +143,8 @@ updates:
           - "minor"
           - "patch"
     reviewers:
-      - codingllama
       - rosstimothy
-      - hugoshaka
+      - hugoShaka
       - tigrato
       - marcoandredinis
     labels:
@@ -171,9 +165,8 @@ updates:
           - "minor"
           - "patch"
     reviewers:
-      - codingllama
       - rosstimothy
-      - hugoshaka
+      - hugoShaka
       - tigrato
       - marcoandredinis
     labels:
@@ -195,7 +188,6 @@ updates:
           - "minor"
           - "patch"
     reviewers:
-      - codingllama
       - rosstimothy
       - zmb3
     labels:
@@ -216,7 +208,6 @@ updates:
           - "minor"
           - "patch"
     reviewers:
-      - codingllama
       - rosstimothy
       - zmb3
     labels:


### PR DESCRIPTION
This PR removes `codingllama` and fixes a typo in Hugo's github user name.

See this comment for more information:
https://github.com/gravitational/teleport/pull/53102#issuecomment-2731252514