### PR TITLE
Remove deprecated HTTP RegisterUsingToken Auth RPC

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -145,10 +145,6 @@ func NewAPIServer(config *APIConfig) (http.Handler, error) {
 	// trusted clusters
 	srv.POST("/:version/trustedclusters/validate", srv.WithAuth(srv.validateTrustedCluster))
 
-	// Tokens
-	// TODO(strideynet): REMOVE IN 18.0.0 - this method is now gRPC
-	srv.POST("/:version/tokens/register", srv.WithAuth(srv.registerUsingToken))
-
 	// these endpoints are still in use by v17 agents since they cache
 	// KindNamespace
 	//
@@ -494,20 +490,6 @@ func rawMessage(data []byte, err error) (interface{}, error) {
 	}
 	m := json.RawMessage(data)
 	return &m, nil
-}
-
-// TODO(strideynet): REMOVE IN v18.0.0
-func (s *APIServer) registerUsingToken(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, _ httprouter.Params, version string) (interface{}, error) {
-	var req types.RegisterUsingTokenRequest
-	if err := httplib.ReadJSON(r, &req); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	certs, err := auth.RegisterUsingToken(r.Context(), &req)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return certs, nil
 }
 
 // validateGithubAuthCallbackReq is a request to validate Github OAuth2 callback

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -19,7 +19,6 @@
 package auth
 
 import (
-	"cmp"
 	"context"
 	"fmt"
 	"net/url"
@@ -578,53 +577,6 @@ func (a *ServerWithRoles) GetClusterCACert(
 ) (*proto.GetClusterCACertResponse, error) {
 	// Allow all roles to get the CA certs.
 	return a.authServer.GetClusterCACert(ctx)
-}
-
-// Deprecated: This method only exists to service the RegisterUsingToken HTTP
-// RPC, which has been replaced by an RPC on the JoinServiceServer.
-// JoinServiceServer directly invokes auth.Server and performs its own checks
-// on metadata.
-// TODO(strideynet): DELETE IN V18.0.0
-func (a *ServerWithRoles) RegisterUsingToken(ctx context.Context, req *types.RegisterUsingTokenRequest) (*proto.Certs, error) {
-	isProxy := a.hasBuiltinRole(types.RoleProxy)
-
-	// We do not trust remote addr in the request unless it's coming from the Proxy.
-	if !isProxy || req.RemoteAddr == "" {
-		if err := setRemoteAddrFromContext(ctx, req); err != nil {
-			return nil, trace.Wrap(err)
-		}
-	}
-
-	// Similarly, do not trust bot instance IDs or generation values in the
-	// request unless from a component with the proxy role (e.g. the join
-	// service). They will be derived from the client certificate otherwise.
-	if !isProxy {
-		if req.BotInstanceID != "" {
-			a.authServer.logger.WarnContext(ctx, "Untrusted client attempted to provide a bot instance ID, this will be ignored",
-				"bot_instance_id", req.BotInstanceID,
-			)
-
-			req.BotInstanceID = ""
-		}
-
-		if req.BotGeneration > 0 {
-			a.authServer.logger.WarnContext(ctx, "Untrusted client attempted to provide a bot generation, this will be ignored",
-				"bot_generation", req.BotGeneration,
-			)
-
-			req.BotGeneration = 0
-		}
-	}
-
-	// If the identity has a BotInstanceID or BotGeneration included, copy it
-	// onto the request - but only if one wasn't already passed along via the
-	// proxy.
-	ident := a.context.Identity.GetIdentity()
-	req.BotInstanceID = cmp.Or(req.BotInstanceID, ident.BotInstanceID)
-	req.BotGeneration = cmp.Or(req.BotGeneration, int32(ident.Generation))
-
-	// tokens have authz mechanism  on their own, no need to check
-	return a.authServer.RegisterUsingToken(ctx, req)
 }
 
 // GenerateHostCerts generates new host certificates (signed

--- a/lib/auth/authclient/httpfallback.go
+++ b/lib/auth/authclient/httpfallback.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/services"
 )
@@ -126,42 +125,4 @@ func (c *Client) deleteReverseTunnelLegacy(ctx context.Context, domainName strin
 	}
 	_, err := c.Delete(ctx, c.Endpoint("reversetunnels", domainName))
 	return trace.Wrap(err)
-}
-
-// RegisterUsingToken calls the auth service API to register a new node using a
-// registration token which was previously issued via CreateToken/UpsertToken.
-func (c *Client) RegisterUsingToken(
-	ctx context.Context, req *types.RegisterUsingTokenRequest,
-) (*proto.Certs, error) {
-	if err := req.CheckAndSetDefaults(); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	certs, err := c.APIClient.RegisterUsingToken(ctx, req)
-	if err == nil {
-		return certs, nil
-	}
-	if !trace.IsNotImplemented(err) {
-		return nil, trace.Wrap(err)
-	}
-
-	return c.registerUsingTokenLegacy(ctx, req)
-}
-
-func (c *HTTPClient) registerUsingTokenLegacy(
-	ctx context.Context, req *types.RegisterUsingTokenRequest,
-) (*proto.Certs, error) {
-	if err := req.CheckAndSetDefaults(); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	out, err := c.PostJSON(ctx, c.Endpoint("tokens", "register"), req)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	var certs proto.Certs
-	if err := json.Unmarshal(out.Bytes(), &certs); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return &certs, nil
 }

--- a/lib/auth/join.go
+++ b/lib/auth/join.go
@@ -25,13 +25,11 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
-	"net"
 	"slices"
 	"strings"
 
 	"github.com/gravitational/trace"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -42,7 +40,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1"
-	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 )
@@ -107,22 +104,6 @@ func (a *Server) checkTokenJoinRequestCommon(ctx context.Context, req *types.Reg
 	}
 
 	return provisionToken, nil
-}
-
-func setRemoteAddrFromContext(ctx context.Context, req *types.RegisterUsingTokenRequest) error {
-	var addr string
-	if clientIP, err := authz.ClientSrcAddrFromContext(ctx); err == nil {
-		addr = clientIP.String()
-	} else if p, ok := peer.FromContext(ctx); ok {
-		addr = p.Addr.String()
-	}
-	ip, _, err := net.SplitHostPort(addr)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	req.RemoteAddr = ip
-
-	return nil
 }
 
 // handleJoinFailure logs and audits the failure of a join. It is intentionally


### PR DESCRIPTION
Follows on from https://github.com/gravitational/teleport/pull/47853

Part of https://github.com/gravitational/teleport/issues/6394

Removes the HTTP RegisterUsingToken HTTP RPC from the Auth apiserver, which transitioned to a gRPC endpoint in v17.