### PR TITLE
Remove unused SearchEvents and SearchSessionEvents HTTP RPCs

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -142,7 +142,6 @@ func NewAPIServer(config *APIConfig) (http.Handler, error) {
 	srv.DELETE("/:version/reversetunnels/:domain", srv.WithAuth(srv.deleteReverseTunnel))
 
 	// trusted clusters
-	// TODO(noah): REMOVE IN V19.0.0 - this method is now gRPC.
 	srv.POST("/:version/trustedclusters/validate", srv.WithAuth(srv.validateTrustedCluster))
 
 	// Tokens


### PR DESCRIPTION
It looks like these were formally replaced by work back in 2021 (https://github.com/gravitational/teleport/pull/5885/files) - I can't find any client calls to these endpoints in master or v17, so this should be safe to remove.

Part of https://github.com/gravitational/teleport/issues/6394