### PR TITLE
docs: Add Rocky Linux 8+ as supported on the installation page

### DIFF
--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -34,7 +34,7 @@ running Teleport on UNIX variants other than Linux \[1].
 
 | Operating System | `teleport` Daemon | `tctl` Admin Tool | `tsh` and Teleport Connect User Clients [2] | Web UI (via the browser) | `tbot` Daemon |
 | - | - | - | - | - | - |
-| Linux v2.6.23+ (RHEL/CentOS 7+, Amazon Linux 2+, Amazon Linux 2023+, Ubuntu 16.04+, Debian 9+, SLES 12 SP 5+, and SLES 15 SP 5+) \[3] | yes | yes | yes | yes | yes |
+| Linux v2.6.23+ (RHEL/CentOS 7+, Rocky Linux 8+, Amazon Linux 2+, Amazon Linux 2023+, Ubuntu 16.04+, Debian 9+, SLES 12 SP 5+, and SLES 15 SP 5+) \[3] | yes | yes | yes | yes | yes |
 | macOS 11+  (Big Sur)| yes | yes | yes | yes | yes |
 | Windows 10+ (rev. 1607) \[4] | no | yes | yes | yes | no |
 
@@ -230,6 +230,7 @@ repositories.
    | CentOS       | >= 7                 | `centos`                        |
    | Debian       | >= 9                 | `debian`                        |
    | RHEL         | >= 7                 | `rhel`                          |
+   | Rocky Linux  | >= 8                 | `rocky`                         |
    | SLES         | >= 12 SP5, >= 15 SP5 | `sles`                          |
    | Ubuntu       | >= 16.04             | `ubuntu`                        |
 
@@ -242,6 +243,7 @@ repositories.
    |--------------|--------------------------|
    | Amazon Linux | 2 (post 11/2021), 2023   |
    | CentOS/RHEL  | 9+                       |
+   | Rocky Linux  | 8+                       |
    | Debian       | 11, or 10 with backports |
    | Ubuntu       | 20.042+                  |
 


### PR DESCRIPTION
We have aliased `rocky` to `rhel` in our repo creation scripts: https://github.com/gravitational/teleport/blob/0a6f286cd2ea3226122b16282062b059827d06a5/lib/utils/packagemanager/yum.go#L38

We also support `rocky` explicitly in our `node-join.sh` script: https://github.com/gravitational/teleport/blob/0a6f286cd2ea3226122b16282062b059827d06a5/lib/web/scripts/node-join/install.sh#L983-L986

As indicated in the above comment, Rocky is bug-for-bug compatible with RHEL/Centos so I think it's safe to say Teleport supports it.