### PR TITLE
SPIFFE X.509 issuer override: issuance

### DIFF
--- a/api/gen/proto/go/teleport/workloadidentity/v1/issuance_service.pb.go
+++ b/api/gen/proto/go/teleport/workloadidentity/v1/issuance_service.pb.go
@@ -41,9 +41,13 @@ const (
 type X509SVIDParams struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The PKIX, ASN.1 DER public key to encode into the X509 SVID.
-	PublicKey     []byte `protobuf:"bytes,1,opt,name=public_key,json=publicKey,proto3" json:"public_key,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	PublicKey []byte `protobuf:"bytes,1,opt,name=public_key,json=publicKey,proto3" json:"public_key,omitempty"`
+	// Whether or not the issuance should use a configured X509 issuer override,
+	// if any. When set, the returned credentials might include a certificate
+	// chain that will be required to use the returned certificate correctly.
+	UseIssuerOverrides bool `protobuf:"varint,2,opt,name=use_issuer_overrides,json=useIssuerOverrides,proto3" json:"use_issuer_overrides,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *X509SVIDParams) Reset() {
@@ -81,6 +85,13 @@ func (x *X509SVIDParams) GetPublicKey() []byte {
 		return x.PublicKey
 	}
 	return nil
+}
+
+func (x *X509SVIDParams) GetUseIssuerOverrides() bool {
+	if x != nil {
+		return x.UseIssuerOverrides
+	}
+	return false
 }
 
 // The parameters for issuing a JWT SVID.
@@ -136,7 +147,11 @@ type X509SVIDCredential struct {
 	// ASN.1 DER encoded X.509 certificate. No PEM.
 	Cert []byte `protobuf:"bytes,1,opt,name=cert,proto3" json:"cert,omitempty"`
 	// The serial number of the X509 SVID.
-	SerialNumber  string `protobuf:"bytes,2,opt,name=serial_number,json=serialNumber,proto3" json:"serial_number,omitempty"`
+	SerialNumber string `protobuf:"bytes,2,opt,name=serial_number,json=serialNumber,proto3" json:"serial_number,omitempty"`
+	// The certificate chain for the issued X509 SVID (in order from end entity
+	// certificate to root certificate, excluding both ends). ASN.1 DER encoded
+	// X.509 certificate. No PEM. Can be empty.
+	Chain         [][]byte `protobuf:"bytes,3,rep,name=chain,proto3" json:"chain,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -183,6 +198,13 @@ func (x *X509SVIDCredential) GetSerialNumber() string {
 		return x.SerialNumber
 	}
 	return ""
+}
+
+func (x *X509SVIDCredential) GetChain() [][]byte {
+	if x != nil {
+		return x.Chain
+	}
+	return nil
 }
 
 // The issued JWT SVID credential and any JWT SVID specific metadata.
@@ -768,15 +790,17 @@ var File_teleport_workloadidentity_v1_issuance_service_proto protoreflect.FileDe
 
 const file_teleport_workloadidentity_v1_issuance_service_proto_rawDesc = "" +
 	"\n" +
-	"3teleport/workloadidentity/v1/issuance_service.proto\x12\x1cteleport.workloadidentity.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a(teleport/workloadidentity/v1/attrs.proto\"/\n" +
+	"3teleport/workloadidentity/v1/issuance_service.proto\x12\x1cteleport.workloadidentity.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a(teleport/workloadidentity/v1/attrs.proto\"a\n" +
 	"\x0eX509SVIDParams\x12\x1d\n" +
 	"\n" +
-	"public_key\x18\x01 \x01(\fR\tpublicKey\"-\n" +
+	"public_key\x18\x01 \x01(\fR\tpublicKey\x120\n" +
+	"\x14use_issuer_overrides\x18\x02 \x01(\bR\x12useIssuerOverrides\"-\n" +
 	"\rJWTSVIDParams\x12\x1c\n" +
-	"\taudiences\x18\x01 \x03(\tR\taudiences\"M\n" +
+	"\taudiences\x18\x01 \x03(\tR\taudiences\"c\n" +
 	"\x12X509SVIDCredential\x12\x12\n" +
 	"\x04cert\x18\x01 \x01(\fR\x04cert\x12#\n" +
-	"\rserial_number\x18\x02 \x01(\tR\fserialNumber\"7\n" +
+	"\rserial_number\x18\x02 \x01(\tR\fserialNumber\x12\x14\n" +
+	"\x05chain\x18\x03 \x03(\fR\x05chain\"7\n" +
 	"\x11JWTSVIDCredential\x12\x10\n" +
 	"\x03jwt\x18\x01 \x01(\tR\x03jwt\x12\x10\n" +
 	"\x03jti\x18\x02 \x01(\tR\x03jti\"\xc6\x03\n" +

--- a/api/gen/proto/go/teleport/workloadidentity/v1/x509_overrides.pb.go
+++ b/api/gen/proto/go/teleport/workloadidentity/v1/x509_overrides.pb.go
@@ -120,7 +120,11 @@ func (x *X509IssuerOverride) GetSpec() *X509IssuerOverrideSpec {
 
 // The spec for X509IssuerOverride.
 type X509IssuerOverrideSpec struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// A list of issuer overrides. The public key of each issuer must be unique
+	// across all overrides' issuers, and should match one of the keys in the
+	// cluster's SPIFFE certificate authority.
+	Overrides     []*X509IssuerOverrideSpec_Override `protobuf:"bytes,1,rep,name=overrides,proto3" json:"overrides,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -155,6 +159,71 @@ func (*X509IssuerOverrideSpec) Descriptor() ([]byte, []int) {
 	return file_teleport_workloadidentity_v1_x509_overrides_proto_rawDescGZIP(), []int{1}
 }
 
+func (x *X509IssuerOverrideSpec) GetOverrides() []*X509IssuerOverrideSpec_Override {
+	if x != nil {
+		return x.Overrides
+	}
+	return nil
+}
+
+// The override for a single issuer (i.e. a single X.509 certificate in a
+// SPIFFE cert_authority).
+type X509IssuerOverrideSpec_Override struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// ASN.1 DER certificate, not included by default in the chain.
+	Issuer []byte `protobuf:"bytes,1,opt,name=issuer,proto3" json:"issuer,omitempty"`
+	// ASN.1 DER certificate ordered from leaf to root as it should be presented
+	// by a client or server in a TLS connection. Must not include self-signed
+	// roots of trust.
+	Chain         [][]byte `protobuf:"bytes,2,rep,name=chain,proto3" json:"chain,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *X509IssuerOverrideSpec_Override) Reset() {
+	*x = X509IssuerOverrideSpec_Override{}
+	mi := &file_teleport_workloadidentity_v1_x509_overrides_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *X509IssuerOverrideSpec_Override) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*X509IssuerOverrideSpec_Override) ProtoMessage() {}
+
+func (x *X509IssuerOverrideSpec_Override) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_workloadidentity_v1_x509_overrides_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use X509IssuerOverrideSpec_Override.ProtoReflect.Descriptor instead.
+func (*X509IssuerOverrideSpec_Override) Descriptor() ([]byte, []int) {
+	return file_teleport_workloadidentity_v1_x509_overrides_proto_rawDescGZIP(), []int{1, 0}
+}
+
+func (x *X509IssuerOverrideSpec_Override) GetIssuer() []byte {
+	if x != nil {
+		return x.Issuer
+	}
+	return nil
+}
+
+func (x *X509IssuerOverrideSpec_Override) GetChain() [][]byte {
+	if x != nil {
+		return x.Chain
+	}
+	return nil
+}
+
 var File_teleport_workloadidentity_v1_x509_overrides_proto protoreflect.FileDescriptor
 
 const file_teleport_workloadidentity_v1_x509_overrides_proto_rawDesc = "" +
@@ -165,8 +234,12 @@ const file_teleport_workloadidentity_v1_x509_overrides_proto_rawDesc = "" +
 	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12H\n" +
-	"\x04spec\x18\x05 \x01(\v24.teleport.workloadidentity.v1.X509IssuerOverrideSpecR\x04spec\"\x18\n" +
-	"\x16X509IssuerOverrideSpecBdZbgithub.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1;workloadidentityv1b\x06proto3"
+	"\x04spec\x18\x05 \x01(\v24.teleport.workloadidentity.v1.X509IssuerOverrideSpecR\x04spec\"\xaf\x01\n" +
+	"\x16X509IssuerOverrideSpec\x12[\n" +
+	"\toverrides\x18\x01 \x03(\v2=.teleport.workloadidentity.v1.X509IssuerOverrideSpec.OverrideR\toverrides\x1a8\n" +
+	"\bOverride\x12\x16\n" +
+	"\x06issuer\x18\x01 \x01(\fR\x06issuer\x12\x14\n" +
+	"\x05chain\x18\x02 \x03(\fR\x05chainBdZbgithub.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1;workloadidentityv1b\x06proto3"
 
 var (
 	file_teleport_workloadidentity_v1_x509_overrides_proto_rawDescOnce sync.Once
@@ -180,20 +253,22 @@ func file_teleport_workloadidentity_v1_x509_overrides_proto_rawDescGZIP() []byte
 	return file_teleport_workloadidentity_v1_x509_overrides_proto_rawDescData
 }
 
-var file_teleport_workloadidentity_v1_x509_overrides_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_teleport_workloadidentity_v1_x509_overrides_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
 var file_teleport_workloadidentity_v1_x509_overrides_proto_goTypes = []any{
-	(*X509IssuerOverride)(nil),     // 0: teleport.workloadidentity.v1.X509IssuerOverride
-	(*X509IssuerOverrideSpec)(nil), // 1: teleport.workloadidentity.v1.X509IssuerOverrideSpec
-	(*v1.Metadata)(nil),            // 2: teleport.header.v1.Metadata
+	(*X509IssuerOverride)(nil),              // 0: teleport.workloadidentity.v1.X509IssuerOverride
+	(*X509IssuerOverrideSpec)(nil),          // 1: teleport.workloadidentity.v1.X509IssuerOverrideSpec
+	(*X509IssuerOverrideSpec_Override)(nil), // 2: teleport.workloadidentity.v1.X509IssuerOverrideSpec.Override
+	(*v1.Metadata)(nil),                     // 3: teleport.header.v1.Metadata
 }
 var file_teleport_workloadidentity_v1_x509_overrides_proto_depIdxs = []int32{
-	2, // 0: teleport.workloadidentity.v1.X509IssuerOverride.metadata:type_name -> teleport.header.v1.Metadata
+	3, // 0: teleport.workloadidentity.v1.X509IssuerOverride.metadata:type_name -> teleport.header.v1.Metadata
 	1, // 1: teleport.workloadidentity.v1.X509IssuerOverride.spec:type_name -> teleport.workloadidentity.v1.X509IssuerOverrideSpec
-	2, // [2:2] is the sub-list for method output_type
-	2, // [2:2] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	2, // 2: teleport.workloadidentity.v1.X509IssuerOverrideSpec.overrides:type_name -> teleport.workloadidentity.v1.X509IssuerOverrideSpec.Override
+	3, // [3:3] is the sub-list for method output_type
+	3, // [3:3] is the sub-list for method input_type
+	3, // [3:3] is the sub-list for extension type_name
+	3, // [3:3] is the sub-list for extension extendee
+	0, // [0:3] is the sub-list for field type_name
 }
 
 func init() { file_teleport_workloadidentity_v1_x509_overrides_proto_init() }
@@ -207,7 +282,7 @@ func file_teleport_workloadidentity_v1_x509_overrides_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_workloadidentity_v1_x509_overrides_proto_rawDesc), len(file_teleport_workloadidentity_v1_x509_overrides_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   2,
+			NumMessages:   3,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/workloadidentity/v1/issuance_service.proto
+++ b/api/proto/teleport/workloadidentity/v1/issuance_service.proto
@@ -38,6 +38,11 @@ service WorkloadIdentityIssuanceService {
 message X509SVIDParams {
   // The PKIX, ASN.1 DER public key to encode into the X509 SVID.
   bytes public_key = 1;
+
+  // Whether or not the issuance should use a configured X509 issuer override,
+  // if any. When set, the returned credentials might include a certificate
+  // chain that will be required to use the returned certificate correctly.
+  bool use_issuer_overrides = 2;
 }
 
 // The parameters for issuing a JWT SVID.
@@ -53,6 +58,10 @@ message X509SVIDCredential {
   bytes cert = 1;
   // The serial number of the X509 SVID.
   string serial_number = 2;
+  // The certificate chain for the issued X509 SVID (in order from end entity
+  // certificate to root certificate, excluding both ends). ASN.1 DER encoded
+  // X.509 certificate. No PEM. Can be empty.
+  repeated bytes chain = 3;
 }
 
 // The issued JWT SVID credential and any JWT SVID specific metadata.

--- a/api/proto/teleport/workloadidentity/v1/x509_overrides.proto
+++ b/api/proto/teleport/workloadidentity/v1/x509_overrides.proto
@@ -36,4 +36,20 @@ message X509IssuerOverride {
 }
 
 // The spec for X509IssuerOverride.
-message X509IssuerOverrideSpec {}
+message X509IssuerOverrideSpec {
+  // The override for a single issuer (i.e. a single X.509 certificate in a
+  // SPIFFE cert_authority).
+  message Override {
+    // ASN.1 DER certificate, not included by default in the chain.
+    bytes issuer = 1;
+    // ASN.1 DER certificate ordered from leaf to root as it should be presented
+    // by a client or server in a TLS connection. Must not include self-signed
+    // roots of trust.
+    repeated bytes chain = 2;
+  }
+
+  // A list of issuer overrides. The public key of each issuer must be unique
+  // across all overrides' issuers, and should match one of the keys in the
+  // cluster's SPIFFE certificate authority.
+  repeated Override overrides = 1;
+}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -7836,10 +7836,18 @@ func (a *Server) GetNodeStream(ctx context.Context, namespace string) stream.Str
 	})
 }
 
+// SetWorkloadIdentityX509CAOverrideGetter sets the underlying
+// [services.WorkloadIdentityX509CAOverrideGetter] used by the auth server for
+// the implementation of [Server.GetWorkloadIdentityX509CAOverride] (provided by
+// enterprise code). Not safe for concurrent access, so it should only be called
+// during setup.
 func (a *Server) SetWorkloadIdentityX509CAOverrideGetter(getter services.WorkloadIdentityX509CAOverrideGetter) {
 	a.workloadIdentityX509CAOverrideGetter = getter
 }
 
+// GetWorkloadIdentityX509CAOverride implements
+// [services.WorkloadIdentityX509CAOverrideGetter] by optionally delegating to
+// an underlying implementation (provided by enterprise code).
 func (a *Server) GetWorkloadIdentityX509CAOverride(ctx context.Context, name string, ca *tlsca.CertAuthority) (*tlsca.CertAuthority, [][]byte, error) {
 	getter := a.workloadIdentityX509CAOverrideGetter
 	if getter == nil {

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -5304,12 +5304,13 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		return nil, trace.Wrap(err, "getting cluster name")
 	}
 	workloadIdentityIssuanceService, err := workloadidentityv1.NewIssuanceService(&workloadidentityv1.IssuanceServiceConfig{
-		Authorizer:  cfg.Authorizer,
-		Cache:       cfg.AuthServer.Cache,
-		Emitter:     cfg.Emitter,
-		Clock:       cfg.AuthServer.GetClock(),
-		KeyStore:    cfg.AuthServer.keyStore,
-		ClusterName: clusterName.GetClusterName(),
+		Authorizer:     cfg.Authorizer,
+		Cache:          cfg.AuthServer.Cache,
+		Emitter:        cfg.Emitter,
+		Clock:          cfg.AuthServer.GetClock(),
+		KeyStore:       cfg.AuthServer.keyStore,
+		OverrideGetter: cfg.AuthServer,
+		ClusterName:    clusterName.GetClusterName(),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "creating workload identity issuance service")

--- a/lib/services/workload_identity_x509_overrides.go
+++ b/lib/services/workload_identity_x509_overrides.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
+	"github.com/gravitational/teleport/lib/tlsca"
 )
 
 type WorkloadIdentityX509Overrides interface {
@@ -45,4 +46,18 @@ type WorkloadIdentityX509Overrides interface {
 	// DeleteX509IssuerOverride deletes an existing override by name. If no
 	// override with such a name exists, a [*trace.NotFoundError] is returned.
 	DeleteX509IssuerOverride(ctx context.Context, name string) error
+}
+
+type WorkloadIdentityX509CAOverrideGetter interface {
+	// GetWorkloadIdentityX509CAOverride will return an alternate
+	// [tlsca.CertAuthority] to use for issuing workload identity X.509
+	// credentials, as well as any necessary certificates for the chain up to
+	// the actual root of trust. The name of the override can be blank, in which
+	// case the "default" override will be used if it exists, or the CA will be
+	// returned as is (with no chain). The "none" override is a special case,
+	// signifying that no override should be used. Any other name (including
+	// "default") will require an override with that name to be in storage, or
+	// an error will be returned. An error will likewise be returned if the
+	// override does not specify an issuer to replace the one in the CA.
+	GetWorkloadIdentityX509CAOverride(ctx context.Context, name string, ca *tlsca.CertAuthority) (*tlsca.CertAuthority, [][]byte, error)
 }

--- a/lib/tbot/service_workload_identity_api.go
+++ b/lib/tbot/service_workload_identity_api.go
@@ -17,6 +17,7 @@
 package tbot
 
 import (
+	"bytes"
 	"cmp"
 	"context"
 	"crypto/x509"
@@ -458,12 +459,17 @@ func (s *WorkloadIdentityAPIService) fetchX509SVIDs(
 	// format.
 	svids := make([]*workloadpb.X509SVID, len(creds))
 	for i, cred := range creds {
+		var svid bytes.Buffer
+		svid.Write(cred.GetX509Svid().GetCert())
+		for _, c := range cred.GetX509Svid().Chain {
+			svid.Write(c)
+		}
 		svids[i] = &workloadpb.X509SVID{
 			// Required. The SPIFFE ID of the SVID in this entry
 			SpiffeId: cred.SpiffeId,
 			// Required. ASN.1 DER encoded certificate chain. MAY include
 			// intermediates, the leaf certificate (or SVID itself) MUST come first.
-			X509Svid: cred.GetX509Svid().GetCert(),
+			X509Svid: svid.Bytes(),
 			// Required. ASN.1 DER encoded PKCS#8 private key. MUST be unencrypted.
 			X509SvidKey: pkcs8PrivateKey,
 			// Required. ASN.1 DER encoded X.509 bundle for the trust domain.

--- a/lib/tbot/service_workload_identity_api_test.go
+++ b/lib/tbot/service_workload_identity_api_test.go
@@ -51,6 +51,7 @@ func TestBotWorkloadIdentityAPI(t *testing.T) {
 	log := utils.NewSlogLoggerForTests()
 
 	process := testenv.MakeTestServer(t, defaultTestServerOpts(t, log))
+	setWorkloadIdentityX509CAOverride(ctx, t, process)
 	rootClient := testenv.MakeDefaultAuthClient(t, process)
 
 	role, err := types.NewRole("issue-foo", types.RoleSpecV6{
@@ -145,6 +146,8 @@ func TestBotWorkloadIdentityAPI(t *testing.T) {
 
 	expectedSPIFFEID := fmt.Sprintf("spiffe://root/valid/api/%d", os.Getpid())
 	require.Equal(t, expectedSPIFFEID, svid.ID.String())
+	// the override includes a chain with a single certificate
+	require.Len(t, svid.Certificates, 2)
 	require.Equal(t, expectedSPIFFEID, svid.Certificates[0].URIs[0].String())
 	_, _, err = x509svid.Verify(svid.Certificates, source)
 	require.NoError(t, err)

--- a/lib/tbot/service_workload_identity_x509.go
+++ b/lib/tbot/service_workload_identity_x509.go
@@ -17,6 +17,7 @@
 package tbot
 
 import (
+	"bytes"
 	"cmp"
 	"context"
 	"crypto"
@@ -293,11 +294,18 @@ func (s *WorkloadIdentityX509Service) render(
 		return trace.Wrap(err, "writing svid key")
 	}
 
-	certPEM := pem.EncodeToMemory(&pem.Block{
+	var certPEM bytes.Buffer
+	pem.Encode(&certPEM, &pem.Block{
 		Type:  pemCertificate,
 		Bytes: x509Cred.GetX509Svid().GetCert(),
 	})
-	if err := s.cfg.Destination.Write(ctx, config.SVIDPEMPath, certPEM); err != nil {
+	for _, c := range x509Cred.GetX509Svid().GetChain() {
+		pem.Encode(&certPEM, &pem.Block{
+			Type:  pemCertificate,
+			Bytes: c,
+		})
+	}
+	if err := s.cfg.Destination.Write(ctx, config.SVIDPEMPath, certPEM.Bytes()); err != nil {
 		return trace.Wrap(err, "writing svid certificate")
 	}
 

--- a/lib/tbot/workloadidentity/issue.go
+++ b/lib/tbot/workloadidentity/issue.go
@@ -74,7 +74,8 @@ type authClient interface {
 }
 
 // IssueX509WorkloadIdentity uses a given client and selector to issue a single
-// or multiple X509-SVID workload identity credentials.
+// or multiple X509-SVID workload identity credentials. The returned credentials
+// may have a certificate chain that should be consumed and used appropriately.
 func IssueX509WorkloadIdentity(
 	ctx context.Context,
 	log *slog.Logger,
@@ -113,7 +114,8 @@ func IssueX509WorkloadIdentity(
 				Name: workloadIdentity.Name,
 				Credential: &workloadidentityv1pb.IssueWorkloadIdentityRequest_X509SvidParams{
 					X509SvidParams: &workloadidentityv1pb.X509SVIDParams{
-						PublicKey: pubBytes,
+						PublicKey:          pubBytes,
+						UseIssuerOverrides: true,
 					},
 				},
 				RequestedTtl:  durationpb.New(ttl),
@@ -141,7 +143,8 @@ func IssueX509WorkloadIdentity(
 				LabelSelectors: labelSelectors,
 				Credential: &workloadidentityv1pb.IssueWorkloadIdentitiesRequest_X509SvidParams{
 					X509SvidParams: &workloadidentityv1pb.X509SVIDParams{
-						PublicKey: pubBytes,
+						PublicKey:          pubBytes,
+						UseIssuerOverrides: true,
 					},
 				},
 				RequestedTtl:  durationpb.New(ttl),

--- a/tool/tsh/common/workload_identity.go
+++ b/tool/tsh/common/workload_identity.go
@@ -177,12 +177,20 @@ func (c *issueX509Command) run(cf *CLIConf) error {
 
 		// Write SVID
 		svidPath := filepath.Join(c.outputDirectory, svidPEMPath)
+		var svidPEM bytes.Buffer
+		pem.Encode(&svidPEM, &pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: x509Credential.GetX509Svid().GetCert(),
+		})
+		for _, c := range x509Credential.GetX509Svid().GetChain() {
+			pem.Encode(&svidPEM, &pem.Block{
+				Type:  "CERTIFICATE",
+				Bytes: c,
+			})
+		}
 		err = os.WriteFile(
 			svidPath,
-			pem.EncodeToMemory(&pem.Block{
-				Type:  "CERTIFICATE",
-				Bytes: x509Credential.GetX509Svid().GetCert(),
-			}),
+			svidPEM.Bytes(),
 			teleport.FileMaskOwnerOnly,
 		)
 		if err != nil {


### PR DESCRIPTION
PR 2 in the series, after #53088
Paired with gravitational/teleport.e#6193
Part of the implementation of [RFD 0194](https://github.com/gravitational/teleport/pull/52195)