### PR TITLE
Remove unused SetClusterName HTTP RPC

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -158,7 +158,6 @@ func NewAPIServer(config *APIConfig) (http.Handler, error) {
 
 	// cluster configuration
 	srv.GET("/:version/configuration/name", srv.WithAuth(srv.getClusterName))
-	srv.POST("/:version/configuration/name", srv.WithAuth(srv.setClusterName))
 
 	// SSO validation handlers
 	srv.POST("/:version/github/requests/validate", srv.WithAuth(srv.validateGithubAuthCallback))
@@ -712,31 +711,6 @@ func (s *APIServer) getClusterName(auth *ServerWithRoles, w http.ResponseWriter,
 	}
 
 	return rawMessage(services.MarshalClusterName(cn, services.WithVersion(version), services.PreserveRevision()))
-}
-
-type setClusterNameReq struct {
-	ClusterName json.RawMessage `json:"cluster_name"`
-}
-
-func (s *APIServer) setClusterName(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
-	var req setClusterNameReq
-
-	err := httplib.ReadJSON(r, &req)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	cn, err := services.UnmarshalClusterName(req.ClusterName)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	err = auth.SetClusterName(cn)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return message(fmt.Sprintf("cluster name set: %+v", cn)), nil
 }
 
 type upsertTunnelConnectionRawReq struct {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -4678,36 +4678,12 @@ func (a *ServerWithRoles) DeleteRole(ctx context.Context, name string) error {
 	return a.authServer.DeleteRole(ctx, name)
 }
 
-// DeleteClusterName deletes cluster name
-func (a *ServerWithRoles) DeleteClusterName() error {
-	if err := a.action(types.KindClusterName, types.VerbDelete); err != nil {
-		return trace.Wrap(err)
-	}
-	return a.authServer.DeleteClusterName()
-}
-
 // GetClusterName gets the name of the cluster.
 func (a *ServerWithRoles) GetClusterName(opts ...services.MarshalOption) (types.ClusterName, error) {
 	if err := a.action(types.KindClusterName, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return a.authServer.GetClusterName()
-}
-
-// SetClusterName sets the name of the cluster. SetClusterName can only be called once.
-func (a *ServerWithRoles) SetClusterName(c types.ClusterName) error {
-	if err := a.action(types.KindClusterName, types.VerbCreate, types.VerbUpdate); err != nil {
-		return trace.Wrap(err)
-	}
-	return a.authServer.SetClusterName(c)
-}
-
-// UpsertClusterName sets the name of the cluster.
-func (a *ServerWithRoles) UpsertClusterName(c types.ClusterName) error {
-	if err := a.action(types.KindClusterName, types.VerbCreate, types.VerbUpdate); err != nil {
-		return trace.Wrap(err)
-	}
-	return a.authServer.UpsertClusterName(c)
 }
 
 // GetAuthPreference gets cluster auth preference.

--- a/lib/auth/authclient/http_client.go
+++ b/lib/auth/authclient/http_client.go
@@ -811,26 +811,6 @@ func (c *HTTPClient) GetClusterName(opts ...services.MarshalOption) (types.Clust
 	return cn, err
 }
 
-type setClusterNameReq struct {
-	ClusterName json.RawMessage `json:"cluster_name"`
-}
-
-// SetClusterName sets cluster name once, will
-// return Already Exists error if the name is already set
-func (c *HTTPClient) SetClusterName(cn types.ClusterName) error {
-	data, err := services.MarshalClusterName(cn)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	_, err = c.PostJSON(context.TODO(), c.Endpoint("configuration", "name"), &setClusterNameReq{ClusterName: data})
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	return nil
-}
-
 func (c *HTTPClient) ValidateTrustedCluster(ctx context.Context, validateRequest *ValidateTrustedClusterRequest) (*ValidateTrustedClusterResponse, error) {
 	validateRequestRaw, err := validateRequest.ToRaw()
 	if err != nil {

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -500,7 +500,7 @@ type Cache struct {
 	fnCache *utils.FnCache
 
 	trustCache                   services.Trust
-	clusterConfigCache           services.ClusterConfiguration
+	clusterConfigCache           services.ClusterConfigurationInternal
 	autoUpdateCache              *local.AutoUpdateService
 	provisionerCache             services.Provisioner
 	usersCache                   services.UsersService

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -104,7 +104,7 @@ type testPack struct {
 	eventsS        *proxyEvents
 	trustS         services.Trust
 	provisionerS   services.Provisioner
-	clusterConfigS services.ClusterConfiguration
+	clusterConfigS services.ClusterConfigurationInternal
 
 	usersS                  services.UsersService
 	accessS                 services.Access

--- a/lib/services/configuration.go
+++ b/lib/services/configuration.go
@@ -39,13 +39,6 @@ type ClusterNameGetter interface {
 // in the backend.
 type ClusterConfiguration interface {
 	ClusterNameGetter
-	// SetClusterName sets services.ClusterName on the backend.
-	SetClusterName(types.ClusterName) error
-	// UpsertClusterName upserts cluster name
-	UpsertClusterName(types.ClusterName) error
-
-	// DeleteClusterName deletes cluster name resource
-	DeleteClusterName() error
 
 	// GetStaticTokens gets services.StaticTokens from the backend.
 	GetStaticTokens() (types.StaticTokens, error)
@@ -142,6 +135,13 @@ type ClusterConfiguration interface {
 type ClusterConfigurationInternal interface {
 	ClusterConfiguration
 
+	// SetClusterName sets services.ClusterName on the backend.
+	SetClusterName(types.ClusterName) error
+	// UpsertClusterName upserts cluster name
+	UpsertClusterName(types.ClusterName) error
+	// DeleteClusterName deletes cluster name resource
+	DeleteClusterName() error
+	
 	// AppendCheckAuthPreferenceActions appends some atomic write actions to the
 	// given slice that will check that the currently stored cluster auth
 	// preference has the given revision when applied as part of a

--- a/lib/services/configuration.go
+++ b/lib/services/configuration.go
@@ -141,7 +141,7 @@ type ClusterConfigurationInternal interface {
 	UpsertClusterName(types.ClusterName) error
 	// DeleteClusterName deletes cluster name resource
 	DeleteClusterName() error
-	
+
 	// AppendCheckAuthPreferenceActions appends some atomic write actions to the
 	// given slice that will check that the currently stored cluster auth
 	// preference has the given revision when applied as part of a

--- a/lib/services/local/configuration_test.go
+++ b/lib/services/local/configuration_test.go
@@ -89,7 +89,8 @@ func TestClusterName(t *testing.T) {
 	require.NoError(t, err)
 
 	suite := &suite.ServicesTestSuite{
-		ConfigS: clusterConfig,
+		ConfigS:      clusterConfig,
+		LocalConfigS: clusterConfig,
 	}
 	suite.ClusterName(t)
 }

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -202,7 +202,7 @@ type ServicesTestSuite struct {
 	PresenceS      services.Presence
 	ProvisioningS  services.Provisioner
 	WebS           services.Identity
-	ConfigS        services.ClusterConfiguration
+	ConfigS        services.ClusterConfigurationInternal
 	// LocalConfigS is used for local config which can only be
 	// managed by the Auth service directly (static tokens).
 	// Used by some tests to differentiate between a server

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -202,12 +202,12 @@ type ServicesTestSuite struct {
 	PresenceS      services.Presence
 	ProvisioningS  services.Provisioner
 	WebS           services.Identity
-	ConfigS        services.ClusterConfigurationInternal
+	ConfigS        services.ClusterConfiguration
 	// LocalConfigS is used for local config which can only be
 	// managed by the Auth service directly (static tokens).
 	// Used by some tests to differentiate between a server
 	// and client interface.
-	LocalConfigS  services.ClusterConfiguration
+	LocalConfigS  services.ClusterConfigurationInternal
 	EventsS       types.Events
 	UsersS        services.UsersService
 	RestrictionsS services.Restrictions
@@ -1329,20 +1329,20 @@ func (s *ServicesTestSuite) ClusterName(t *testing.T, opts ...Option) {
 		ClusterName: "example.com",
 	})
 	require.NoError(t, err)
-	err = s.ConfigS.SetClusterName(clusterName)
+	err = s.LocalConfigS.SetClusterName(clusterName)
 	require.NoError(t, err)
 
 	gotName, err := s.ConfigS.GetClusterName()
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(clusterName, gotName, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
-	err = s.ConfigS.DeleteClusterName()
+	err = s.LocalConfigS.DeleteClusterName()
 	require.NoError(t, err)
 
 	_, err = s.ConfigS.GetClusterName()
 	require.True(t, trace.IsNotFound(err))
 
-	err = s.ConfigS.UpsertClusterName(clusterName)
+	err = s.LocalConfigS.UpsertClusterName(clusterName)
 	require.NoError(t, err)
 
 	gotName, err = s.ConfigS.GetClusterName()
@@ -1915,13 +1915,13 @@ func (s *ServicesTestSuite) EventsClusterConfig(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				err = s.ConfigS.UpsertClusterName(clusterName)
+				err = s.LocalConfigS.UpsertClusterName(clusterName)
 				require.NoError(t, err)
 
 				out, err := s.ConfigS.GetClusterName()
 				require.NoError(t, err)
 
-				err = s.ConfigS.DeleteClusterName()
+				err = s.LocalConfigS.DeleteClusterName()
 				require.NoError(t, err)
 				return out
 			},


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport/issues/6394

It looks like this endpoint hasn't been used in a long time, and, it seems like this would potentially break a lot of stuff if this was used on a running cluster anyway. All calls to SetClusterName occur locally during auth server init so there's no real reason for this to be exposed via the API, hence removing it rather than converting to gRPC.