### PR TITLE
[v16] Move version support table to Upcoming Releases

### DIFF
--- a/docs/pages/connect-your-client/includes/connect-my-computer-prerequisites.mdx
+++ b/docs/pages/connect-your-client/includes/connect-my-computer-prerequisites.mdx
@@ -1,6 +1,6 @@
 - A macOS or Linux device.
 - Teleport Connect v14.1+, on the same major version or one version behind the Teleport Proxy
-  Service version. See [version compatibility](../../faq.mdx#version-compatibility).
+  Service version. See [version compatibility](../../upcoming-releases.mdx#teleport).
 - A local Teleport user: you must authenticate using credentials or passwordless login, and not with
   SSO.
 - Permissions to create join tokens (verb `create` for [the `token` resource](../../reference/access-controls/roles.mdx)).

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -93,24 +93,8 @@ time you run `tsh`.
 
 ## Which version of Teleport is supported?
 
-Teleport releases a new major version approximately every 4 months, and provides
-security-critical support for the current and two previous major versions. With
-our typical release cadence, we usually support each major version for 12
-months.
-
-### Supported versions
-
-Here are the major versions of Teleport and their support windows:
-
-| Release | Release Date  | EOL           | Minimum `tsh` version |
-|---------|---------------|---------------|-----------------------|
-| v17.0   | November 2024 | November 2025 | v16.0.0               |
-| v16.0   | June 2024     | June 2025     | v15.0.0               |
-| v15.0   | January 2024  | January 2025  | v14.0.0               |
-
-### Version compatibility
-
-(!docs/pages/includes/compatibility.mdx!)
+See [Upcoming Releases](upcoming-releases.mdx) for the versions of Teleport that
+we support and how long we plan to continue supporting them.
 
 ## Does the Web UI support copy and paste?
 


### PR DESCRIPTION
Backports #53046

This change helps guarantee that we'll update the version support table at the same time as the upcoming release table to keep our support windows up to date. Since we otherwise do not update the two tables at the same time, the supported version table has become out of date.

This change also moves the compatibility description from FAQ to Upcoming Releases so we keep this info in one place, and links to Upcoming Releases from the relevant section of the FAQ.

Since the docs engine automatically copies the Upcoming Releases page from the default version to all four versions of the docs, this change does not edit the Upcoming Releases page for this version.