### PR TITLE
Support SSO MFA for headless

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -7589,10 +7589,11 @@ func (a *ServerWithRoles) UpdateHeadlessAuthenticationState(ctx context.Context,
 		}
 
 		// Only WebAuthn is supported in headless login flow for superior phishing prevention.
-		if _, ok := mfaResp.Response.(*proto.MFAAuthenticateResponse_Webauthn); !ok {
-			err = trace.BadParameter("expected WebAuthn challenge response, but got %T", mfaResp.Response)
+		switch mfaResp.Response.(type) {
+		case *proto.MFAAuthenticateResponse_Webauthn, *proto.MFAAuthenticateResponse_SSO:
+		default:
+			err = trace.BadParameter("MFA response of type %T is not supported for headless authentication", mfaResp.Response)
 			emitHeadlessLoginEvent(ctx, events.UserHeadlessLoginApprovedFailureCode, a.authServer.emitter, headlessAuthn, err)
-			return err
 		}
 
 		requiredExt := &mfav1.ChallengeExtensions{Scope: mfav1.ChallengeScope_CHALLENGE_SCOPE_HEADLESS_LOGIN}

--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -388,7 +388,10 @@ type AuthenticateWebUserRequest struct {
 type HeadlessRequest struct {
 	// Actions can be either accept or deny.
 	Action string `json:"action"`
+	// MFAResponse is an MFA response used to authenticate the headless request.
+	MFAResponse *MFAChallengeResponse `json:"mfaResponse"`
 	// WebauthnAssertionResponse is a signed WebAuthn credential assertion.
+	// TODO(Joerger): DELETE IN v19.0.0, new clients send mfaResponse
 	WebauthnAssertionResponse *wantypes.CredentialAssertionResponse `json:"webauthnAssertionResponse,omitempty"`
 }
 

--- a/rfd/0180-sso-mfa.md
+++ b/rfd/0180-sso-mfa.md
@@ -850,3 +850,15 @@ From what I can tell from the [documentation](https://docs.github.com/en/apps/oa
 you can only do the basic github 2fa login flow. There is no support for MFA
 acr values like okta, or customized web flows with MFA like Auth0. Therefore
 Github connectors will be left out of the initial implementation.
+
+#### Headless
+
+Originally, Webauthn was the only supported MFA type for Headless, as legacy
+OTP is especially at risk to phishing attacks. However, a securely configured
+SSO MFA connector with Webauthn enforced by the provider is also sufficiently
+phishing proof. Therefore, SSO MFA will be supported as an MFA method for
+headless approvals.
+
+Note: as stated elsewhere in this RFD, it is the onus the administrator to
+head warnings in the documentation and ensure the secure setup of SSO MFA.
+Admins should not enable headless authentication with insecure SSO MFA setups.

--- a/web/packages/teleport/src/services/auth/auth.ts
+++ b/web/packages/teleport/src/services/auth/auth.ts
@@ -219,9 +219,7 @@ const auth = {
   },
 
   headlessSSOGet(transactionId: string) {
-    return auth
-      .checkWebauthnSupport()
-      .then(() => api.get(cfg.getHeadlessSsoPath(transactionId)))
+    return api.get(cfg.getHeadlessSsoPath(transactionId))
       .then((json: any) => {
         json = json || {};
 
@@ -234,10 +232,12 @@ const auth = {
   headlessSSOAccept(transactionId: string) {
     return auth
       .getMfaChallenge({ scope: MfaChallengeScope.HEADLESS_LOGIN })
-      .then(challenge => auth.getMfaChallengeResponse(challenge, 'webauthn'))
+      .then(challenge => auth.getMfaChallengeResponse(challenge))
       .then(res => {
         const request = {
           action: 'accept',
+          mfaResponse: res,
+          // TODO(Joerger): DELETE IN v19.0.0, new clients send mfaResponse.
           webauthnAssertionResponse: res.webauthn_response,
         };
 


### PR DESCRIPTION
Changelog: Support SSO MFA as an MFA method for headless.