### PR TITLE
Minor improvements to the role editor

### DIFF
--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/AdminRules.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/AdminRules.tsx
@@ -57,6 +57,8 @@ export const AdminRules = memo(function AdminRules({
   }
   return (
     <Flex flexDirection="column" gap={3}>
+      Rules that give this role administrative rights to Teleport resources
+      through client apps and APIs
       {value.map((rule, i) => (
         <AdminRule
           key={rule.id}
@@ -90,8 +92,7 @@ const AdminRule = memo(function AdminRule({
   }
   return (
     <SectionBox
-      title="Admin Rule"
-      tooltip="A rule that gives users access to certain kinds of resources"
+      titleSegments={getTitleSegments(value.resources)}
       removable
       isProcessing={isProcessing}
       validation={validation}
@@ -145,6 +146,20 @@ const AdminRule = memo(function AdminRule({
     </SectionBox>
   );
 });
+
+function getTitleSegments(resources: readonly ResourceKindOption[]): string[] {
+  switch (resources.length) {
+    case 0:
+      return ['Admin Rule'];
+    case 1:
+      return ['Admin Rule', resources[0].label];
+    default:
+      return [
+        'Admin Rule',
+        `${resources[0].label} + ${resources.length - 1} more`,
+      ];
+  }
+}
 
 const ResourceKindSelect = styled(
   FieldSelectCreatable<ResourceKindOption, true>

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/AdminRules.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/AdminRules.tsx
@@ -32,7 +32,11 @@ import {
 } from 'shared/components/FieldSelect';
 import { precomputed } from 'shared/components/Validation/rules';
 
-import { SectionBox, SectionPropsWithDispatch } from './sections';
+import {
+  SectionBox,
+  SectionPadding,
+  SectionPropsWithDispatch,
+} from './sections';
 import {
   ResourceKindOption,
   resourceKindOptions,
@@ -57,8 +61,9 @@ export const AdminRules = memo(function AdminRules({
   }
   return (
     <Flex flexDirection="column" gap={3}>
-      Rules that give this role administrative rights to Teleport resources
-      through client apps and APIs
+      <SectionPadding>
+        Rules that give this role administrative rights to Teleport resources
+      </SectionPadding>
       {value.map((rule, i) => (
         <AdminRule
           key={rule.id}

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/MetadataSection.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/MetadataSection.tsx
@@ -17,6 +17,7 @@
  */
 
 import Box from 'design/Box';
+import Flex from 'design/Flex';
 import Text from 'design/Text';
 import FieldInput from 'shared/components/FieldInput';
 import { FieldSelect } from 'shared/components/FieldSelect';
@@ -34,49 +35,51 @@ export const MetadataSection = ({
   validation,
   onChange,
 }: SectionProps<MetadataModel, MetadataValidationResult>) => (
-  <SectionBox
-    title="Role Metadata"
-    tooltip="Basic information about the role resource"
-    isProcessing={isProcessing}
-    validation={validation}
-  >
-    <FieldInput
-      label="Role Name"
-      required
-      placeholder="Enter Role Name"
-      value={value.name}
-      disabled={isProcessing}
-      rule={precomputed(validation.fields.name)}
-      onChange={e => onChange({ ...value, name: e.target.value })}
-    />
-    <FieldInput
-      label="Description"
-      placeholder="Enter Role Description"
-      value={value.description || ''}
-      disabled={isProcessing}
-      onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-        onChange({ ...value, description: e.target.value })
-      }
-    />
-    <Box mb={3}>
-      <Text typography="body3" mb={1}>
-        Labels
-      </Text>
-      <LabelsInput
-        disableBtns={isProcessing}
-        labels={value.labels}
-        setLabels={labels => onChange({ ...value, labels })}
-        rule={precomputed(validation.fields.labels)}
+  <Flex flexDirection="column" gap={3}>
+    Basic information about this role
+    <SectionBox
+      titleSegments={['Role Information']}
+      isProcessing={isProcessing}
+      validation={validation}
+    >
+      <FieldInput
+        label="Role Name"
+        required
+        placeholder="Enter Role Name"
+        value={value.name}
+        disabled={isProcessing}
+        rule={precomputed(validation.fields.name)}
+        onChange={e => onChange({ ...value, name: e.target.value })}
       />
-    </Box>
-    <FieldSelect
-      label="Version"
-      isDisabled={isProcessing}
-      options={roleVersionOptions}
-      value={value.version}
-      onChange={version => onChange({ ...value, version })}
-      mb={0}
-      menuPosition="fixed"
-    />
-  </SectionBox>
+      <FieldInput
+        label="Description"
+        placeholder="Enter Role Description"
+        value={value.description || ''}
+        disabled={isProcessing}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+          onChange({ ...value, description: e.target.value })
+        }
+      />
+      <Box mb={3}>
+        <Text typography="body3" mb={1}>
+          Labels
+        </Text>
+        <LabelsInput
+          disableBtns={isProcessing}
+          labels={value.labels}
+          setLabels={labels => onChange({ ...value, labels })}
+          rule={precomputed(validation.fields.labels)}
+        />
+      </Box>
+      <FieldSelect
+        label="Version"
+        isDisabled={isProcessing}
+        options={roleVersionOptions}
+        value={value.version}
+        onChange={version => onChange({ ...value, version })}
+        mb={0}
+        menuPosition="fixed"
+      />
+    </SectionBox>
+  </Flex>
 );

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/MetadataSection.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/MetadataSection.tsx
@@ -25,7 +25,7 @@ import { precomputed } from 'shared/components/Validation/rules';
 
 import { LabelsInput } from 'teleport/components/LabelsInput';
 
-import { SectionBox, SectionProps } from './sections';
+import { SectionBox, SectionPadding, SectionProps } from './sections';
 import { MetadataModel, roleVersionOptions } from './standardmodel';
 import { MetadataValidationResult } from './validation';
 
@@ -36,7 +36,7 @@ export const MetadataSection = ({
   onChange,
 }: SectionProps<MetadataModel, MetadataValidationResult>) => (
   <Flex flexDirection="column" gap={3}>
-    Basic information about this role
+    <SectionPadding>Basic information about this role</SectionPadding>
     <SectionBox
       titleSegments={['Role Information']}
       isProcessing={isProcessing}

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Options.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Options.tsx
@@ -21,6 +21,7 @@ import { components, OptionProps } from 'react-select';
 import styled, { useTheme } from 'styled-components';
 
 import Box from 'design/Box';
+import Flex from 'design/Flex';
 import Input from 'design/Input';
 import LabelInput from 'design/LabelInput';
 import { RadioGroup } from 'design/RadioGroup';
@@ -59,156 +60,163 @@ export const Options = memo(function Options({
   const sshPortForwardingModeId = `${id}-ssh-port-forwarding-mode`;
 
   return (
-    <OptionsGridContainer
-      border={1}
-      borderColor={theme.colors.interactive.tonal.neutral[0]}
-      borderRadius={3}
-      p={3}
-    >
-      <OptionsHeader>Global Settings</OptionsHeader>
+    <Flex flexDirection="column" gap={3}>
+      Additional advanced settings
+      <OptionsGridContainer
+        border={1}
+        borderColor={theme.colors.interactive.tonal.neutral[0]}
+        borderRadius={3}
+        p={3}
+      >
+        <OptionsHeader>Global Settings</OptionsHeader>
 
-      <OptionLabel htmlFor={maxSessionTTLId}>Max Session TTL</OptionLabel>
-      <Input
-        id={maxSessionTTLId}
-        value={value.maxSessionTTL}
-        disabled={isProcessing}
-        onChange={e => onChange({ ...value, maxSessionTTL: e.target.value })}
-      />
+        <OptionLabel htmlFor={maxSessionTTLId}>Max Session TTL</OptionLabel>
+        <Input
+          id={maxSessionTTLId}
+          value={value.maxSessionTTL}
+          disabled={isProcessing}
+          onChange={e => onChange({ ...value, maxSessionTTL: e.target.value })}
+        />
 
-      <OptionLabel htmlFor={clientIdleTimeoutId}>
-        Client Idle Timeout
-      </OptionLabel>
-      <Input
-        id={clientIdleTimeoutId}
-        value={value.clientIdleTimeout}
-        disabled={isProcessing}
-        onChange={e =>
-          onChange({ ...value, clientIdleTimeout: e.target.value })
-        }
-      />
+        <OptionLabel htmlFor={clientIdleTimeoutId}>
+          Client Idle Timeout
+        </OptionLabel>
+        <Input
+          id={clientIdleTimeoutId}
+          value={value.clientIdleTimeout}
+          disabled={isProcessing}
+          onChange={e =>
+            onChange({ ...value, clientIdleTimeout: e.target.value })
+          }
+        />
 
-      <Box>Disconnect When Certificate Expires</Box>
-      <BoolRadioGroup
-        name="disconnect-expired-cert"
-        value={value.disconnectExpiredCert}
-        onChange={d => onChange({ ...value, disconnectExpiredCert: d })}
-      />
+        <Box>Disconnect When Certificate Expires</Box>
+        <BoolRadioGroup
+          name="disconnect-expired-cert"
+          value={value.disconnectExpiredCert}
+          onChange={d => onChange({ ...value, disconnectExpiredCert: d })}
+        />
 
-      <OptionLabel htmlFor={requireMFATypeId}>Require Session MFA</OptionLabel>
-      <Select
-        inputId={requireMFATypeId}
-        isDisabled={isProcessing}
-        options={requireMFATypeOptions}
-        value={value.requireMFAType}
-        onChange={t => onChange?.({ ...value, requireMFAType: t })}
-      />
+        <OptionLabel htmlFor={requireMFATypeId}>
+          Require Session MFA
+        </OptionLabel>
+        <Select
+          inputId={requireMFATypeId}
+          isDisabled={isProcessing}
+          options={requireMFATypeOptions}
+          value={value.requireMFAType}
+          onChange={t => onChange?.({ ...value, requireMFAType: t })}
+        />
 
-      <OptionLabel htmlFor={defaultSessionRecordingModeId}>
-        Default Session Recording Mode
-      </OptionLabel>
-      <Select
-        inputId={defaultSessionRecordingModeId}
-        isDisabled={isProcessing}
-        options={sessionRecordingModeOptions}
-        value={value.defaultSessionRecordingMode}
-        onChange={m => onChange?.({ ...value, defaultSessionRecordingMode: m })}
-      />
+        <OptionLabel htmlFor={defaultSessionRecordingModeId}>
+          Default Session Recording Mode
+        </OptionLabel>
+        <Select
+          inputId={defaultSessionRecordingModeId}
+          isDisabled={isProcessing}
+          options={sessionRecordingModeOptions}
+          value={value.defaultSessionRecordingMode}
+          onChange={m =>
+            onChange?.({ ...value, defaultSessionRecordingMode: m })
+          }
+        />
 
-      <OptionsHeader separator>SSH</OptionsHeader>
+        <OptionsHeader separator>SSH</OptionsHeader>
 
-      <OptionLabel htmlFor={createHostUserModeId}>
-        Create Host User Mode
-      </OptionLabel>
-      <Select
-        inputId={createHostUserModeId}
-        isDisabled={isProcessing}
-        options={createHostUserModeOptions}
-        value={value.createHostUserMode}
-        onChange={m => onChange?.({ ...value, createHostUserMode: m })}
-      />
+        <OptionLabel htmlFor={createHostUserModeId}>
+          Create Host User Mode
+        </OptionLabel>
+        <Select
+          inputId={createHostUserModeId}
+          isDisabled={isProcessing}
+          options={createHostUserModeOptions}
+          value={value.createHostUserMode}
+          onChange={m => onChange?.({ ...value, createHostUserMode: m })}
+        />
 
-      <Box>Agent Forwarding</Box>
-      <BoolRadioGroup
-        name="forward-agent"
-        value={value.forwardAgent}
-        onChange={f => onChange({ ...value, forwardAgent: f })}
-      />
+        <Box>Agent Forwarding</Box>
+        <BoolRadioGroup
+          name="forward-agent"
+          value={value.forwardAgent}
+          onChange={f => onChange({ ...value, forwardAgent: f })}
+        />
 
-      <OptionLabel htmlFor={sshSessionRecordingModeId}>
-        Session Recording Mode
-      </OptionLabel>
-      <Select
-        inputId={sshSessionRecordingModeId}
-        isDisabled={isProcessing}
-        options={sessionRecordingModeOptions}
-        value={value.sshSessionRecordingMode}
-        onChange={m => onChange?.({ ...value, sshSessionRecordingMode: m })}
-      />
+        <OptionLabel htmlFor={sshSessionRecordingModeId}>
+          Session Recording Mode
+        </OptionLabel>
+        <Select
+          inputId={sshSessionRecordingModeId}
+          isDisabled={isProcessing}
+          options={sessionRecordingModeOptions}
+          value={value.sshSessionRecordingMode}
+          onChange={m => onChange?.({ ...value, sshSessionRecordingMode: m })}
+        />
 
-      <OptionLabel htmlFor={sshPortForwardingModeId}>
-        Port Forwarding Mode
-      </OptionLabel>
-      <Select
-        components={sshPortForwardingModeComponents}
-        inputId={sshPortForwardingModeId}
-        isDisabled={isProcessing}
-        options={sshPortForwardingModeOptions}
-        value={value.sshPortForwardingMode}
-        onChange={m => onChange?.({ ...value, sshPortForwardingMode: m })}
-      />
+        <OptionLabel htmlFor={sshPortForwardingModeId}>
+          Port Forwarding Mode
+        </OptionLabel>
+        <Select
+          components={sshPortForwardingModeComponents}
+          inputId={sshPortForwardingModeId}
+          isDisabled={isProcessing}
+          options={sshPortForwardingModeOptions}
+          value={value.sshPortForwardingMode}
+          onChange={m => onChange?.({ ...value, sshPortForwardingMode: m })}
+        />
 
-      <OptionsHeader separator>Database</OptionsHeader>
+        <OptionsHeader separator>Database</OptionsHeader>
 
-      <Box>Create Database User</Box>
-      <BoolRadioGroup
-        name="create-db-user"
-        value={value.createDBUser}
-        onChange={c => onChange({ ...value, createDBUser: c })}
-      />
+        <Box>Create Database User</Box>
+        <BoolRadioGroup
+          name="create-db-user"
+          value={value.createDBUser}
+          onChange={c => onChange({ ...value, createDBUser: c })}
+        />
 
-      {/* TODO(bl-nero): a bug in YAML unmarshalling backend breaks the
+        {/* TODO(bl-nero): a bug in YAML unmarshalling backend breaks the
           createDBUserMode field. Fix it and add the field here. */}
-      <OptionLabel htmlFor={createDBUserModeId}>
-        Create Database User Mode
-      </OptionLabel>
-      <Select
-        inputId={createDBUserModeId}
-        isDisabled={isProcessing}
-        options={createDBUserModeOptions}
-        value={value.createDBUserMode}
-        onChange={m => onChange?.({ ...value, createDBUserMode: m })}
-      />
+        <OptionLabel htmlFor={createDBUserModeId}>
+          Create Database User Mode
+        </OptionLabel>
+        <Select
+          inputId={createDBUserModeId}
+          isDisabled={isProcessing}
+          options={createDBUserModeOptions}
+          value={value.createDBUserMode}
+          onChange={m => onChange?.({ ...value, createDBUserMode: m })}
+        />
 
-      <OptionsHeader separator>Desktop</OptionsHeader>
+        <OptionsHeader separator>Desktop</OptionsHeader>
 
-      <Box>Create Desktop User</Box>
-      <BoolRadioGroup
-        name="create-desktop-user"
-        value={value.createDesktopUser}
-        onChange={c => onChange({ ...value, createDesktopUser: c })}
-      />
+        <Box>Create Desktop User</Box>
+        <BoolRadioGroup
+          name="create-desktop-user"
+          value={value.createDesktopUser}
+          onChange={c => onChange({ ...value, createDesktopUser: c })}
+        />
 
-      <Box>Allow Clipboard Sharing</Box>
-      <BoolRadioGroup
-        name="desktop-clipboard"
-        value={value.desktopClipboard}
-        onChange={c => onChange({ ...value, desktopClipboard: c })}
-      />
+        <Box>Allow Clipboard Sharing</Box>
+        <BoolRadioGroup
+          name="desktop-clipboard"
+          value={value.desktopClipboard}
+          onChange={c => onChange({ ...value, desktopClipboard: c })}
+        />
 
-      <Box>Allow Directory Sharing</Box>
-      <BoolRadioGroup
-        name="desktop-directory-sharing"
-        value={value.desktopDirectorySharing}
-        onChange={s => onChange({ ...value, desktopDirectorySharing: s })}
-      />
+        <Box>Allow Directory Sharing</Box>
+        <BoolRadioGroup
+          name="desktop-directory-sharing"
+          value={value.desktopDirectorySharing}
+          onChange={s => onChange({ ...value, desktopDirectorySharing: s })}
+        />
 
-      <Box>Record Desktop Sessions</Box>
-      <BoolRadioGroup
-        name="record-desktop-sessions"
-        value={value.recordDesktopSessions}
-        onChange={r => onChange({ ...value, recordDesktopSessions: r })}
-      />
-    </OptionsGridContainer>
+        <Box>Record Desktop Sessions</Box>
+        <BoolRadioGroup
+          name="record-desktop-sessions"
+          value={value.recordDesktopSessions}
+          onChange={r => onChange({ ...value, recordDesktopSessions: r })}
+        />
+      </OptionsGridContainer>
+    </Flex>
   );
 });
 

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Options.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Options.tsx
@@ -28,7 +28,7 @@ import { RadioGroup } from 'design/RadioGroup';
 import Text, { H4 } from 'design/Text';
 import Select from 'shared/components/Select';
 
-import { SectionProps } from './sections';
+import { SectionPadding, SectionProps } from './sections';
 import {
   createDBUserModeOptions,
   createHostUserModeOptions,
@@ -61,7 +61,7 @@ export const Options = memo(function Options({
 
   return (
     <Flex flexDirection="column" gap={3}>
-      Additional advanced settings
+      <SectionPadding>Additional advanced settings</SectionPadding>
       <OptionsGridContainer
         border={1}
         borderColor={theme.colors.interactive.tonal.neutral[0]}

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.tsx
@@ -86,7 +86,8 @@ export const ResourcesTab = memo(function ResourcesTab({
     dispatch({ type: 'add-resource-access', payload: { kind } });
 
   return (
-    <Flex flexDirection="column" gap={3} my={2}>
+    <Flex flexDirection="column" gap={3}>
+      Rules that allow connecting to resources controlled by Teleport
       {value.map((res, i) => {
         return (
           <ResourceAccessSection
@@ -113,7 +114,7 @@ export const ResourcesTab = memo(function ResourcesTab({
           buttonText={
             <>
               <Plus size="small" mr={2} />
-              Add New Resource Access
+              Add Resource Access
             </>
           }
           buttonProps={{
@@ -151,38 +152,31 @@ export const resourceAccessSections: Record<
   ResourceAccessKind,
   {
     title: string;
-    tooltip: string;
     component: React.ComponentType<SectionProps<unknown, unknown>>;
   }
 > = {
   kube_cluster: {
     title: 'Kubernetes',
-    tooltip: 'Configures access to Kubernetes clusters',
     component: KubernetesAccessSection,
   },
   node: {
     title: 'Servers',
-    tooltip: 'Configures access to SSH servers',
     component: ServerAccessSection,
   },
   app: {
     title: 'Applications',
-    tooltip: 'Configures access to applications',
     component: AppAccessSection,
   },
   db: {
     title: 'Databases',
-    tooltip: 'Configures access to databases',
     component: DatabaseAccessSection,
   },
   windows_desktop: {
     title: 'Windows Desktops',
-    tooltip: 'Configures access to Windows desktops',
     component: WindowsDesktopAccessSection,
   },
   git_server: {
     title: 'GitHub Organizations',
-    tooltip: 'Configures access to GitHub organizations and their repositories',
     component: GitHubOrganizationAccessSection,
   },
 };
@@ -200,11 +194,7 @@ export const ResourceAccessSection = memo(function ResourceAccessSectionRaw<
   validation,
   dispatch,
 }: SectionPropsWithDispatch<T, V>) {
-  const {
-    component: Body,
-    title,
-    tooltip,
-  } = resourceAccessSections[value.kind];
+  const { component: Body, title } = resourceAccessSections[value.kind];
 
   function handleChange(val: T) {
     dispatch({ type: 'set-resource-access', payload: val });
@@ -216,10 +206,9 @@ export const ResourceAccessSection = memo(function ResourceAccessSectionRaw<
 
   return (
     <SectionBox
-      title={title}
+      titleSegments={[title]}
       removable
       onRemove={handleRemove}
-      tooltip={tooltip}
       isProcessing={isProcessing}
       validation={validation}
     >

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.tsx
@@ -37,7 +37,12 @@ import { precomputed } from 'shared/components/Validation/rules';
 
 import { LabelsInput } from 'teleport/components/LabelsInput';
 
-import { SectionBox, SectionProps, SectionPropsWithDispatch } from './sections';
+import {
+  SectionBox,
+  SectionPadding,
+  SectionProps,
+  SectionPropsWithDispatch,
+} from './sections';
 import {
   AppAccess,
   DatabaseAccess,
@@ -87,7 +92,9 @@ export const ResourcesTab = memo(function ResourcesTab({
 
   return (
     <Flex flexDirection="column" gap={3}>
-      Rules that allow connecting to resources controlled by Teleport
+      <SectionPadding>
+        Rules that allow connecting to resources controlled by Teleport
+      </SectionPadding>
       {value.map((res, i) => {
         return (
           <ResourceAccessSection

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.test.tsx
@@ -57,13 +57,11 @@ beforeEach(() => {
 
 test('adding and removing sections', async () => {
   render(<TestStandardEditor originalRole={newRoleWithYaml(newRole())} />);
-  expect(getAllSectionNames()).toEqual(['Role Metadata']);
+  expect(getAllSectionNames()).toEqual(['Role Information']);
   await user.click(getTabByName('Resources'));
   expect(getAllSectionNames()).toEqual([]);
 
-  await user.click(
-    screen.getByRole('button', { name: 'Add New Resource Access' })
-  );
+  await user.click(screen.getByRole('button', { name: 'Add Resource Access' }));
   expect(getAllMenuItemNames()).toEqual([
     'Kubernetes',
     'Servers',
@@ -76,9 +74,7 @@ test('adding and removing sections', async () => {
   await user.click(screen.getByRole('menuitem', { name: 'Servers' }));
   expect(getAllSectionNames()).toEqual(['Servers']);
 
-  await user.click(
-    screen.getByRole('button', { name: 'Add New Resource Access' })
-  );
+  await user.click(screen.getByRole('button', { name: 'Add Resource Access' }));
   expect(getAllMenuItemNames()).toEqual([
     'Kubernetes',
     'Applications',
@@ -116,12 +112,12 @@ test('collapsed sections still apply validation', async () => {
   // Intentionally cause a validation error.
   await user.clear(screen.getByLabelText('Role Name *'));
   // Collapse the section.
-  await user.click(screen.getByRole('heading', { name: 'Role Metadata' }));
+  await user.click(screen.getByRole('heading', { name: 'Role Information' }));
   await user.click(screen.getByRole('button', { name: 'Save Changes' }));
   expect(onSave).not.toHaveBeenCalled();
 
   // Expand the section, make it valid.
-  await user.click(screen.getByRole('heading', { name: 'Role Metadata' }));
+  await user.click(screen.getByRole('heading', { name: 'Role Information' }));
   await user.type(screen.getByLabelText('Role Name *'), 'foo');
   await user.click(screen.getByRole('button', { name: 'Save Changes' }));
   expect(onSave).toHaveBeenCalled();
@@ -175,9 +171,7 @@ test('edits resource access', async () => {
     />
   );
   await user.click(getTabByName('Resources'));
-  await user.click(
-    screen.getByRole('button', { name: 'Add New Resource Access' })
-  );
+  await user.click(screen.getByRole('button', { name: 'Add Resource Access' }));
   await user.click(screen.getByRole('menuitem', { name: 'Servers' }));
   await selectEvent.create(screen.getByLabelText('Logins'), 'ec2-user', {
     createOptionText: 'Login: ec2-user',
@@ -196,9 +190,7 @@ test('triggers v6 validation for Kubernetes resources', async () => {
   );
   await selectEvent.select(screen.getByLabelText('Version'), 'v6');
   await user.click(getTabByName('Resources'));
-  await user.click(
-    screen.getByRole('button', { name: 'Add New Resource Access' })
-  );
+  await user.click(screen.getByRole('button', { name: 'Add Resource Access' }));
   await user.click(screen.getByRole('menuitem', { name: 'Kubernetes' }));
   await user.click(screen.getByRole('button', { name: 'Add a Resource' }));
   await selectEvent.select(screen.getByLabelText('Kind'), 'Job');
@@ -279,9 +271,7 @@ test('tab-level validation when creating a new role', async () => {
   expect(getTabByName('Resources')).toHaveAttribute('aria-selected', 'true');
 
   // Break the validation and attempt switching tabs.
-  await user.click(
-    screen.getByRole('button', { name: 'Add New Resource Access' })
-  );
+  await user.click(screen.getByRole('button', { name: 'Add Resource Access' }));
   await user.click(screen.getByRole('menuitem', { name: 'Servers' }));
   await user.click(screen.getByRole('button', { name: 'Add a Label' }));
   // The form should not be validating until we try to switch to the next tab.
@@ -301,7 +291,7 @@ const getAllMenuItemNames = () =>
   screen.queryAllByRole('menuitem').map(m => m.textContent);
 
 const getAllSectionNames = () =>
-  screen.queryAllByRole('heading', { level: 3 }).map(m => m.textContent);
+  screen.queryAllByRole('heading', { level: 3 }).map(m => m.textContent.trim());
 
 const getTabByName = (name: string) => screen.getByRole('tab', { name });
 

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/sections.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/sections.tsx
@@ -16,10 +16,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Fragment, useEffect, useRef, useState } from 'react';
+import {
+  Fragment,
+  PropsWithChildren,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import styled, { useTheme } from 'styled-components';
 
-import Box from 'design/Box';
+import Box, { BoxProps } from 'design/Box';
 import ButtonIcon from 'design/ButtonIcon';
 import Flex from 'design/Flex';
 import { Check, ChevronDown, Trash, WarningCircle } from 'design/Icon';
@@ -66,6 +72,10 @@ enum ExpansionState {
    */
   Collapsing,
 }
+
+const sectionBoxBorderWidth = 1;
+
+const sectionBoxPadding = 3;
 
 /**
  * A wrapper for editor section. Its responsibility is rendering a header,
@@ -144,7 +154,7 @@ export const SectionBox = ({
     <Box
       as="details"
       open={expansionState !== ExpansionState.Collapsed}
-      border={1}
+      border={sectionBoxBorderWidth}
       borderColor={
         validator.state.validating && !validation.valid
           ? theme.colors.interactive.solid.danger.default
@@ -249,7 +259,7 @@ export const SectionBox = ({
       >
         {/* This element is measured, so its size must reflect the size of
             children. */}
-        <Box px={3} pb={3} ref={contentRef}>
+        <Box px={sectionBoxPadding} pb={sectionBoxPadding} ref={contentRef}>
           {children}
         </Box>
       </ContentExpander>
@@ -277,3 +287,17 @@ const ContentExpander = styled(Box)`
 const InlineH3 = styled(H3)`
   display: inline;
 `;
+
+/**
+ * A utility container that applies a horizontal padding that is consistent
+ * with the offset of the section content.
+ */
+export const SectionPadding = (props: PropsWithChildren<BoxProps>) => (
+  <Box
+    px={sectionBoxPadding}
+    borderLeft={sectionBoxBorderWidth}
+    borderRight={sectionBoxBorderWidth}
+    borderColor="transparent"
+    {...props}
+  />
+);


### PR DESCRIPTION
- Drop "New" from "Add New Resource Access"
- Add resource kind names to the collapsed admin rule section title
- Rename “Role Metadata” to “Role Information” and remove tooltip
- Add a description for each tab

![Screenshot 2025-03-24 at 12 42 19](https://github.com/user-attachments/assets/5c86faa8-75dc-4f3a-b8cc-4bf8d1e3183b)
![Screenshot 2025-03-24 at 12 42 54](https://github.com/user-attachments/assets/1c12d319-961f-438a-b340-b3530a751bf6)
![Screenshot 2025-03-24 at 12 44 10](https://github.com/user-attachments/assets/15ac540c-77b0-4abc-b6ad-8cbbbd47ef27)
![Screenshot 2025-03-24 at 12 44 35](https://github.com/user-attachments/assets/3eb7c0f2-523d-4fed-b4c5-b223226bea4d)


Contributes to https://github.com/gravitational/teleport/issues/52036
Contributes to https://github.com/gravitational/teleport/issues/52220