### PR TITLE
[teleport-update] Additional log message and UX cleanup

### DIFF
--- a/lib/autoupdate/agent/setup.go
+++ b/lib/autoupdate/agent/setup.go
@@ -245,9 +245,12 @@ func (ns *Namespace) Setup(ctx context.Context, path string) error {
 		}
 		if present {
 			if err := oldTimer.Disable(ctx, true); err != nil {
-				ns.log.ErrorContext(ctx, "The deprecated teleport-ent-updater package is installed on this server, and it cannot be disabled due to an error. You must remove the teleport-ent-updater package after verifying that teleport-update is working.", errorKey, err)
+				ns.log.ErrorContext(ctx, "The deprecated teleport-ent-updater package is installed on this server, and it cannot be disabled due to an error.", errorKey, err)
+				ns.log.ErrorContext(ctx, "You must remove the teleport-ent-updater package after verifying that teleport-update is working.", errorKey, err)
 			} else {
-				ns.log.WarnContext(ctx, "The deprecated teleport-ent-updater package is installed on this server. This package has been disabled to prevent conflicts. Please remove the teleport-ent-updater package after verifying that teleport-update is working.")
+				ns.log.WarnContext(ctx, "The deprecated teleport-ent-updater package is installed on this server.")
+				ns.log.WarnContext(ctx, "The systemd timer included in this package has been disabled to prevent conflicts.", "timer", deprecatedTimerName)
+				ns.log.WarnContext(ctx, "Please remove the teleport-ent-updater package after verifying that teleport-update is working.")
 			}
 		}
 	}
@@ -269,7 +272,8 @@ func (ns *Namespace) Teardown(ctx context.Context) error {
 		Log:         ns.log,
 	}
 	if err := svc.Disable(ctx, true); err != nil {
-		ns.log.WarnContext(ctx, "Unable to disable teleport-update systemd timer before removing.", errorKey, err)
+		ns.log.WarnContext(ctx, "Unable to disable teleport-update systemd timer before removing.")
+		ns.log.DebugContext(ctx, "Error disabling teleport-update systemd timer.", errorKey, err)
 	}
 	for _, p := range []string{
 		ns.updaterServiceFile,
@@ -305,9 +309,12 @@ func (ns *Namespace) Teardown(ctx context.Context) error {
 		}
 		if present {
 			if err := oldTimer.Enable(ctx, true); err != nil {
-				ns.log.ErrorContext(ctx, "The deprecated teleport-ent-updater package is installed on this server, and it cannot be re-enabled due to an error. Please fix the teleport-ent-updater package if you intend to use the deprecated updater.", errorKey, err)
+				ns.log.ErrorContext(ctx, "The deprecated teleport-ent-updater package is installed on this server, and it cannot be re-enabled due to an error.", errorKey, err)
+				ns.log.ErrorContext(ctx, "Please fix the systemd timer included in the teleport-ent-updater package if you intend to use the deprecated updater.")
 			} else {
-				ns.log.WarnContext(ctx, "The deprecated teleport-ent-updater package is installed on this server. This package has been re-enabled to ensure continued updates. To disable automatic updates entirely, please remove the teleport-ent-updater package.")
+				ns.log.WarnContext(ctx, "The deprecated teleport-ent-updater package is installed on this server.")
+				ns.log.WarnContext(ctx, "The systemd timer included in this package has been re-enabled to ensure continued updates.", "timer", deprecatedTimerName)
+				ns.log.WarnContext(ctx, "To disable updates entirely, please remove the teleport-ent-updater package.")
 			}
 		}
 	}

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -394,8 +394,9 @@ func (u *Updater) Install(ctx context.Context, override OverrideConfig) error {
 
 	if err := u.update(ctx, cfg, target, override.AllowOverwrite, resp.AGPL); err != nil {
 		if errors.Is(err, ErrFilePresent) && !override.AllowOverwrite {
-			u.Log.WarnContext(ctx, "Use --overwrite to force removal of existing binaries installed via script.")
-			u.Log.WarnContext(ctx, "If a teleport rpm or deb package is installed, upgrade it to the latest version and retry. DO NOT USE --overwrite.")
+			u.Log.ErrorContext(ctx, "Manual installation of Teleport was detected. Manual installations cannot be reverted in case of failure.")
+			u.Log.ErrorContext(ctx, "Use --overwrite to force immediate removal of existing binaries installed via script.")
+			u.Log.ErrorContext(ctx, "If a Teleport rpm or deb package is installed, upgrade it to the latest version and retry without --overwrite.")
 		}
 		return trace.Wrap(err)
 	}

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -394,9 +394,9 @@ func (u *Updater) Install(ctx context.Context, override OverrideConfig) error {
 
 	if err := u.update(ctx, cfg, target, override.AllowOverwrite, resp.AGPL); err != nil {
 		if errors.Is(err, ErrFilePresent) && !override.AllowOverwrite {
-			u.Log.ErrorContext(ctx, "An non-packaged installation of Teleport was detected. These installations cannot be reverted in case of failure.")
-			u.Log.ErrorContext(ctx, "Use --overwrite to force immediate removal of existing binaries installed manually or via script.")
-			u.Log.ErrorContext(ctx, "If a Teleport rpm or deb package is installed, upgrade it to the latest version and retry without --overwrite.")
+			u.Log.ErrorContext(ctx, "A non-packaged or outdated installation of Teleport was detected on this system.")
+			u.Log.ErrorContext(ctx, "Use --overwrite to force immediate removal of any existing binaries installed manually or via script.")
+			u.Log.ErrorContext(ctx, "Alternatively, if a Teleport RPM or DEB package is installed, upgrade it to the latest version and retry without --overwrite.")
 		}
 		return trace.Wrap(err)
 	}

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -394,8 +394,8 @@ func (u *Updater) Install(ctx context.Context, override OverrideConfig) error {
 
 	if err := u.update(ctx, cfg, target, override.AllowOverwrite, resp.AGPL); err != nil {
 		if errors.Is(err, ErrFilePresent) && !override.AllowOverwrite {
-			u.Log.ErrorContext(ctx, "Manual installation of Teleport was detected. Manual installations cannot be reverted in case of failure.")
-			u.Log.ErrorContext(ctx, "Use --overwrite to force immediate removal of existing binaries installed via script.")
+			u.Log.ErrorContext(ctx, "An non-packaged installation of Teleport was detected. These installations cannot be reverted in case of failure.")
+			u.Log.ErrorContext(ctx, "Use --overwrite to force immediate removal of existing binaries installed manually or via script.")
 			u.Log.ErrorContext(ctx, "If a Teleport rpm or deb package is installed, upgrade it to the latest version and retry without --overwrite.")
 		}
 		return trace.Wrap(err)

--- a/lib/autoupdate/agent/updater_test.go
+++ b/lib/autoupdate/agent/updater_test.go
@@ -1708,6 +1708,7 @@ func TestUpdater_Install(t *testing.T) {
 			if tt.userCfg.Proxy == "" {
 				tt.userCfg.Proxy = strings.TrimPrefix(server.URL, "https://")
 			}
+			updater.DefaultProxyAddr = tt.userCfg.Proxy
 
 			var (
 				installedRevision Revision

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -120,6 +120,8 @@ func Run(args []string) int {
 		Short('b').Envar(common.BaseURLEnvVar).StringVar(&ccfg.BaseURL)
 	enableCmd.Flag("overwrite", "Allow existing installed Teleport binaries to be overwritten.").
 		Short('o').BoolVar(&ccfg.AllowOverwrite)
+	enableCmd.Flag("allow-proxy-conflict", "Allow proxy addresses in teleport.yaml and update.yaml to conflict.").
+		BoolVar(&ccfg.AllowProxyConflict)
 	enableCmd.Flag("force-version", "Force the provided version instead of using the version provided by the Teleport cluster.").
 		Hidden().Short('f').Envar(updateVersionEnvVar).StringVar(&ccfg.ForceVersion)
 	enableCmd.Flag("self-setup", "Use the current teleport-update binary to create systemd service config for managed updates.").
@@ -139,6 +141,8 @@ func Run(args []string) int {
 		Short('b').Envar(common.BaseURLEnvVar).StringVar(&ccfg.BaseURL)
 	pinCmd.Flag("overwrite", "Allow existing installed Teleport binaries to be overwritten.").
 		Short('o').BoolVar(&ccfg.AllowOverwrite)
+	pinCmd.Flag("allow-proxy-conflict", "Allow proxy addresses in teleport.yaml and update.yaml to conflict.").
+		BoolVar(&ccfg.AllowProxyConflict)
 	pinCmd.Flag("force-version", "Force the provided version instead of using the version provided by the Teleport cluster.").
 		Short('f').Envar(updateVersionEnvVar).StringVar(&ccfg.ForceVersion)
 	pinCmd.Flag("self-setup", "Use the current teleport-update binary to create systemd service config for managed updates.").


### PR DESCRIPTION
This PR makes adds a few more minor usability tweaks to teleport-update:
- Further clarify log messages, and add newlines where appropriate for readability
- Ensure proxy address conflict warning does not appear when Managed Updates are disabled
- Fail when proxy address conflict exists on initial installation unless `--allow-proxy-conflict` is passed

(Part 1: https://github.com/gravitational/teleport/pull/52777)

---

changelog: Improve clarity of error logs and address UX edge cases in teleport-update, part 2

---

The `teleport-update` binary will be used to enable, disable, and trigger automatic Teleport agent updates. The new auto-updates system manages a local installation of the cluster-specified version of Teleport stored in `/opt/teleport`.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/11856