### PR TITLE
[v17] docs: correct x86_64 ref

### DIFF
--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -369,7 +369,7 @@ script](#one-line-installation-script).
 
    The following architecture values are available:
 
-   - `amd64` (`x86_84` if downloading an RPM package)
+   - `amd64` (`x86_64` if downloading an RPM package)
    - `arm64`
    - `arm`
    - `386` (`i386` if downloading a DEB or RPM package)


### PR DESCRIPTION
backport #53183 to branch/v17