### PR TITLE
Update pnpm to v10

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,5 @@
 # The pnpm team releases new versions pretty often and we don't need to stay
 # at the freshest version at all times.
 update-notifier=false
+# ESLint binary must be accessible to editors to allow showing inline errors.
+public-hoist-pattern[]=eslint

--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,5 @@
 # The pnpm team releases new versions pretty often and we don't need to stay
 # at the freshest version at all times.
 update-notifier=false
-# ESLint binary must be accessible to editors to allow showing inline errors.
+# ESLint editor integrations expect ESLint's binary to be in the root node_modules.
 public-hoist-pattern[]=eslint

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@gravitational/build": "workspace:*",
+    "@ianvs/prettier-plugin-sort-imports": "^4.4.1",
     "@storybook/addon-actions": "^8.6.3",
     "@storybook/addon-controls": "^8.6.3",
     "@storybook/addon-toolbars": "^8.6.3",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
       "web/.storybook/public"
     ]
   },
-  "packageManager": "pnpm@9.9.0+sha512.60c18acd138bff695d339be6ad13f7e936eea6745660d4cc4a776d5247c540d0edee1a563695c183a66eb917ef88f2b4feb1fc25f32a7adcadc7aaf3438e99c1",
+  "packageManager": "pnpm@10.6.5+sha512.cdf928fca20832cd59ec53826492b7dc25dc524d4370b6b4adbf65803d32efaa6c1c88147c0ae4e8d579a6c9eec715757b50d4fa35eea179d868eada4ed043af",
   "engines": {
     "node": "^20"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   jsdom@^20.0.3>nwsapi@^2: 2.2.9
   electron-vite@^3.0.0>esbuild@0.24.2: ^0.25.0
 
-pnpmfileChecksum: w7xzadmfdycxsdgkkk3qgpkydu
+pnpmfileChecksum: sha256-UhbfH9wqbTOi0Lx+Gm0eQ8EkqLSQxYCWXAFDAbl28uo=
 
 importers:
 
@@ -487,7 +487,7 @@ importers:
         version: 34.3.0
       electron-builder:
         specifier: ^25.1.8
-        version: 25.1.8(electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8))
+        version: 25.1.8(electron-builder-squirrel-windows@25.1.8)
       electron-vite:
         specifier: ^3.0.0
         version: 3.0.0(@swc/core@1.11.5)(vite@6.2.0(@types/node@20.17.22)(terser@5.31.1)(yaml@2.7.0))
@@ -10071,7 +10071,7 @@ snapshots:
 
   app-builder-bin@5.0.0-alpha.10: {}
 
-  app-builder-lib@25.1.8(dmg-builder@25.1.8(electron-builder-squirrel-windows@25.1.8))(electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8)):
+  app-builder-lib@25.1.8(dmg-builder@25.1.8)(electron-builder-squirrel-windows@25.1.8):
     dependencies:
       '@develar/schema-utils': 2.6.5
       '@electron/notarize': 2.5.0
@@ -11085,7 +11085,7 @@ snapshots:
 
   dmg-builder@25.1.8(electron-builder-squirrel-windows@25.1.8):
     dependencies:
-      app-builder-lib: 25.1.8(dmg-builder@25.1.8(electron-builder-squirrel-windows@25.1.8))(electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8))
+      app-builder-lib: 25.1.8(dmg-builder@25.1.8)(electron-builder-squirrel-windows@25.1.8)
       builder-util: 25.1.7
       builder-util-runtime: 9.2.10
       fs-extra: 10.1.0
@@ -11175,7 +11175,7 @@ snapshots:
 
   electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8):
     dependencies:
-      app-builder-lib: 25.1.8(dmg-builder@25.1.8(electron-builder-squirrel-windows@25.1.8))(electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8))
+      app-builder-lib: 25.1.8(dmg-builder@25.1.8)(electron-builder-squirrel-windows@25.1.8)
       archiver: 5.3.2
       builder-util: 25.1.7
       fs-extra: 10.1.0
@@ -11184,9 +11184,9 @@ snapshots:
       - dmg-builder
       - supports-color
 
-  electron-builder@25.1.8(electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8)):
+  electron-builder@25.1.8(electron-builder-squirrel-windows@25.1.8):
     dependencies:
-      app-builder-lib: 25.1.8(dmg-builder@25.1.8(electron-builder-squirrel-windows@25.1.8))(electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8))
+      app-builder-lib: 25.1.8(dmg-builder@25.1.8)(electron-builder-squirrel-windows@25.1.8)
       builder-util: 25.1.7
       builder-util-runtime: 9.2.10
       chalk: 4.1.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       '@gravitational/build':
         specifier: workspace:*
         version: link:web/packages/build
+      '@ianvs/prettier-plugin-sort-imports':
+        specifier: ^4.4.1
+        version: 4.4.1(prettier@3.5.3)
       '@storybook/addon-actions':
         specifier: ^8.6.3
         version: 8.6.3(storybook@8.6.3(prettier@3.5.3))
@@ -221,9 +224,6 @@ importers:
       '@eslint/js':
         specifier: ^9.21.0
         version: 9.21.0
-      '@ianvs/prettier-plugin-sort-imports':
-        specifier: ^4.4.1
-        version: 4.4.1(prettier@3.5.3)
       '@swc/core':
         specifier: ^1.11.5
         version: 1.11.5
@@ -8575,10 +8575,10 @@ snapshots:
 
   '@ianvs/prettier-plugin-sort-imports@4.4.1(prettier@3.5.3)':
     dependencies:
-      '@babel/generator': 7.26.9
-      '@babel/parser': 7.26.9
-      '@babel/traverse': 7.26.9
-      '@babel/types': 7.26.9
+      '@babel/generator': 7.26.10
+      '@babel/parser': 7.26.10
+      '@babel/traverse': 7.26.10
+      '@babel/types': 7.26.10
       prettier: 3.5.3
       semver: 7.7.1
     transitivePeerDependencies:
@@ -10289,7 +10289,7 @@ snapshots:
   babel-plugin-jest-hoist@29.6.3:
     dependencies:
       '@babel/template': 7.26.9
-      '@babel/types': 7.26.9
+      '@babel/types': 7.26.10
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.6
 
@@ -12327,7 +12327,7 @@ snapshots:
   istanbul-lib-instrument@5.2.1:
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/parser': 7.26.9
+      '@babel/parser': 7.26.10
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -12337,7 +12337,7 @@ snapshots:
   istanbul-lib-instrument@6.0.3:
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/parser': 7.26.9
+      '@babel/parser': 7.26.10
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 7.7.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,10 @@
 packages:
-  - 'web/packages/*'
-  - 'e/web/*'
+  - web/packages/*
+  - e/web/*
+onlyBuiltDependencies:
+  - '@swc/core'
+  - electron
+  - esbuild
+  - msw
+  - node-pty
+  - protobufjs

--- a/web/packages/build/package.json
+++ b/web/packages/build/package.json
@@ -15,7 +15,6 @@
     "@babel/preset-react": "^7.26.3",
     "@babel/preset-typescript": "^7.26.0",
     "@eslint/js": "^9.21.0",
-    "@ianvs/prettier-plugin-sort-imports": "^4.4.1",
     "@swc/core": "^1.11.5",
     "@swc/plugin-styled-components": "^7.0.0",
     "@types/jsdom": "^21.1.7",


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/51153

Summary of changes:
* Added allowlist for `onlyBuiltDependencies`. The list was generated with `pnpm approve-builds`, I selected all packages that it proposed.
* pnpm no longer hoists `*prettier*` packages, so I moved `prettier-plugin-sort-imports` to the root `package.json` (to keep it available for Prettier).
* Restored ESLint hoisting to avoid disrupting editor integrations. Initially, I planned to keep it in the build package and call it from the root package.json script. However, this approach prevents ESLint errors from showing in editors, as ESLint plugins invoke the binary directly rather than using our `pnpm eslint` script. Without hoisting, the binary would be missing in the root `node_modules`, forcing users to manually configure their editors to point to `web/packages/build/node_modules/.bin/eslint`.

I went through the [chanelog](https://github.com/pnpm/pnpm/releases/tag/v10.0.0), and the other changes should not impact us.

A tag build to make sure everything works https://github.com/gravitational/teleport.e/actions/runs/13950257864.