### PR TITLE
[v17] Include AD/non-AD status in certificate (#44549)

### DIFF
--- a/lib/auth/windows/windows.go
+++ b/lib/auth/windows/windows.go
@@ -107,6 +107,13 @@ func getCertRequest(req *GenerateCredentialsRequest) (*certRequest, error) {
 		csr.ExtraExtensions = append(csr.ExtraExtensions, createUser)
 	}
 
+	if req.AD {
+		csr.ExtraExtensions = append(csr.ExtraExtensions, pkix.Extension{
+			Id:    tlsca.ADStatusOID,
+			Value: []byte("AD"),
+		})
+	}
+
 	if req.ActiveDirectorySID != "" {
 		adUserMapping, err := asn1.Marshal(SubjectAltName[adSid]{
 			otherName[adSid]{
@@ -194,6 +201,9 @@ type GenerateCredentialsRequest struct {
 	// CRL Distribution Point (CDP). CDPs are required in user certificates
 	// for RDP, but they can be omitted for certs that are used for LDAP binds.
 	OmitCDP bool
+
+	// AD is true if we're connecting to a domain-joined desktop.
+	AD bool
 }
 
 // GenerateWindowsDesktopCredentials generates a private key / certificate pair for the given

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -1312,6 +1312,7 @@ func (s *WindowsService) generateUserCert(ctx context.Context, username string, 
 	return s.generateCredentials(ctx, generateCredentialsRequest{
 		username:           username,
 		domain:             desktop.GetDomain(),
+		ad:                 !desktop.NonAD(),
 		ttl:                ttl,
 		activeDirectorySID: activeDirectorySID,
 		createUser:         createUsers,
@@ -1325,6 +1326,8 @@ type generateCredentialsRequest struct {
 	username string
 	// domain is the Windows domain
 	domain string
+	// ad is true if we're connecting to a domain-joined desktop
+	ad bool
 	// ttl for the certificate
 	ttl time.Duration
 	// activeDirectorySID is the SID of the Windows user
@@ -1356,6 +1359,7 @@ func (s *WindowsService) generateCredentials(ctx context.Context, request genera
 		CAType:             types.UserCA,
 		Username:           request.username,
 		Domain:             request.domain,
+		AD:                 request.ad,
 		TTL:                request.ttl,
 		ClusterName:        s.clusterName,
 		ActiveDirectorySID: request.activeDirectorySID,

--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -568,6 +568,9 @@ var (
 	// JoinAttributesASN1ExtensionOID is an extension that encodes the
 	// attributes that resulted from the Bot/Agent join process.
 	JoinAttributesASN1ExtensionOID = asn1.ObjectIdentifier{1, 3, 9999, 2, 21}
+
+	// ADStatusOID is an extension OID used to indicate that we're connecting to AD-joined desktop.
+	ADStatusOID = asn1.ObjectIdentifier{1, 3, 9999, 2, 22}
 )
 
 // Device Trust OIDs.


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/44549 to branch/v17

changelog: Allow AD and non-AD logins to single Windows desktop