### PR TITLE
[v15] Use DynamoDB Streams FIPS endpoints

### DIFF
--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -281,8 +281,8 @@ func New(ctx context.Context, params backend.Params) (*Backend, error) {
 
 	// Create DynamoDB service.
 	svc, err := dynamometrics.NewAPIMetrics(dynamometrics.Backend, dynamodb.New(b.session, &aws.Config{
-		// Setting this on the individual service instead of the session, as DynamoDB Streams
-		// and Application Auto Scaling do not yet have FIPS endpoints in non-GovCloud.
+		// Setting this on the individual service instead of the session, as Application Auto Scaling
+		// does not yet have FIPS endpoints in non-GovCloud.
 		// See also: https://aws.amazon.com/compliance/fips/#FIPS_Endpoints_by_Service
 		UseFIPSEndpoint: useFIPSEndpoint,
 	}))
@@ -290,7 +290,12 @@ func New(ctx context.Context, params backend.Params) (*Backend, error) {
 		return nil, trace.Wrap(err)
 	}
 	b.svc = svc
-	streams, err := dynamometrics.NewStreamsMetricsAPI(dynamometrics.Backend, dynamodbstreams.New(b.session))
+	streams, err := dynamometrics.NewStreamsMetricsAPI(dynamometrics.Backend, dynamodbstreams.New(b.session, &aws.Config{
+		// Setting this on the individual service instead of the session, as Application Auto Scaling
+		// does not yet have FIPS endpoints in non-GovCloud.
+		// See also: https://aws.amazon.com/compliance/fips/#FIPS_Endpoints_by_Service
+		UseFIPSEndpoint: useFIPSEndpoint,
+	}))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
This is not a direct backport of https://github.com/gravitational/teleport/pull/51896 since branch/v15 uses the legacy aws sdk, but it does enable the same functionality.

changelog: Add support for using DynamoDB Streams FIPS endpoints.