### PR TITLE
WebUI: Allow optional tooltip in traits editor

### DIFF
--- a/web/packages/shared/components/TraitsEditor/TraitsEditor.story.tsx
+++ b/web/packages/shared/components/TraitsEditor/TraitsEditor.story.tsx
@@ -17,25 +17,22 @@
  */
 
 import { useState } from 'react';
-import { TraitsEditor, TraitsOption } from './TraitsEditor';
+
 import Validation from 'shared/components/Validation';
+
+import { TraitsEditor, TraitsOption } from './TraitsEditor';
 
 export default {
   title: 'Shared/TraitsEditor',
 };
 
-
 export const TraitsEditorWithoutToolTip = () => {
-  const [traits, setTraits] = useState<TraitsOption[]>(
-    [
-      {
-        traitKey: { label: "logins", value: "logins" },
-        traitValues: [
-          { label: "root", value: "root" },
-        ]
-      }
-    ]
-  );
+  const [traits, setTraits] = useState<TraitsOption[]>([
+    {
+      traitKey: { label: 'logins', value: 'logins' },
+      traitValues: [{ label: 'root', value: 'root' }],
+    },
+  ]);
 
   return (
     <Validation>
@@ -45,34 +42,28 @@ export const TraitsEditorWithoutToolTip = () => {
         setConfiguredTraits={setTraits}
       />
     </Validation>
-  )
+  );
 };
 
 export const TraitsEditorWithToolTip = () => {
-  const [traits, setTraits] = useState<TraitsOption[]>(
-    [
-      {
-        traitKey: { label: "level", value: "level" },
-        traitValues: [
-          { label: "L1", value: "L1" },
-        ]
-      },
-      {
-        traitKey: { label: "team", value: "team" },
-        traitValues: [
-          { label: "Cloud", value: "Cloud" },
-        ]
-      }
-    ]
-  );
+  const [traits, setTraits] = useState<TraitsOption[]>([
+    {
+      traitKey: { label: 'level', value: 'level' },
+      traitValues: [{ label: 'L1', value: 'L1' }],
+    },
+    {
+      traitKey: { label: 'team', value: 'team' },
+      traitValues: [{ label: 'Cloud', value: 'Cloud' }],
+    },
+  ]);
 
   const tooltip = (
     <>
-      If a Teleport user with the following user traits creates an Access Request
-      that triggers this Access Monitoring Rule, the Access Request is automatically
-      approved.
+      If a Teleport user with the following user traits creates an Access
+      Request that triggers this Access Monitoring Rule, the Access Request is
+      automatically approved.
     </>
-  )
+  );
 
   return (
     <Validation>
@@ -83,5 +74,5 @@ export const TraitsEditorWithToolTip = () => {
         toolTipContent={tooltip}
       />
     </Validation>
-  )
+  );
 };

--- a/web/packages/shared/components/TraitsEditor/TraitsEditor.story.tsx
+++ b/web/packages/shared/components/TraitsEditor/TraitsEditor.story.tsx
@@ -1,0 +1,87 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useState } from 'react';
+import { TraitsEditor, TraitsOption } from './TraitsEditor';
+import Validation from 'shared/components/Validation';
+
+export default {
+  title: 'Shared/TraitsEditor',
+};
+
+
+export const TraitsEditorWithoutToolTip = () => {
+  const [traits, setTraits] = useState<TraitsOption[]>(
+    [
+      {
+        traitKey: { label: "logins", value: "logins" },
+        traitValues: [
+          { label: "root", value: "root" },
+        ]
+      }
+    ]
+  );
+
+  return (
+    <Validation>
+      <TraitsEditor
+        attempt={{ status: 'success' }}
+        configuredTraits={traits}
+        setConfiguredTraits={setTraits}
+      />
+    </Validation>
+  )
+};
+
+export const TraitsEditorWithToolTip = () => {
+  const [traits, setTraits] = useState<TraitsOption[]>(
+    [
+      {
+        traitKey: { label: "level", value: "level" },
+        traitValues: [
+          { label: "L1", value: "L1" },
+        ]
+      },
+      {
+        traitKey: { label: "team", value: "team" },
+        traitValues: [
+          { label: "Cloud", value: "Cloud" },
+        ]
+      }
+    ]
+  );
+
+  const tooltip = (
+    <>
+      If a Teleport user with the following user traits creates an Access Request
+      that triggers this Access Monitoring Rule, the Access Request is automatically
+      approved.
+    </>
+  )
+
+  return (
+    <Validation>
+      <TraitsEditor
+        attempt={{ status: 'success' }}
+        configuredTraits={traits}
+        setConfiguredTraits={setTraits}
+        toolTipContent={tooltip}
+      />
+    </Validation>
+  )
+};

--- a/web/packages/shared/components/TraitsEditor/TraitsEditor.story.tsx
+++ b/web/packages/shared/components/TraitsEditor/TraitsEditor.story.tsx
@@ -71,7 +71,7 @@ export const TraitsEditorWithToolTip = () => {
         attempt={{ status: 'success' }}
         configuredTraits={traits}
         setConfiguredTraits={setTraits}
-        toolTipContent={tooltip}
+        tooltipContent={tooltip}
       />
     </Validation>
   );

--- a/web/packages/shared/components/TraitsEditor/TraitsEditor.tsx
+++ b/web/packages/shared/components/TraitsEditor/TraitsEditor.tsx
@@ -58,7 +58,7 @@ export function TraitsEditor({
   attempt,
   configuredTraits,
   setConfiguredTraits,
-  toolTipContent,
+  tooltipContent,
 }: TraitEditorProps) {
   function handleInputChange(i: InputOption | InputOptionArray) {
     const newTraits = [...configuredTraits];
@@ -107,7 +107,7 @@ export function TraitsEditor({
     <Box>
       <Flex gap={2} alignItems="center">
         <Text typography="body3">User Traits</Text>
-        {toolTipContent && <IconTooltip>{toolTipContent}</IconTooltip>}
+        {tooltipContent && <IconTooltip>{tooltipContent}</IconTooltip>}
       </Flex>
       <Box>
         {configuredTraits.map(({ traitKey, traitValues }, index) => {
@@ -257,7 +257,7 @@ export type TraitEditorProps = {
   setConfiguredTraits: Dispatch<SetStateAction<TraitsOption[]>>;
   configuredTraits: TraitsOption[];
   attempt: Attempt;
-  toolTipContent?: React.ReactNode;
+  tooltipContent?: React.ReactNode;
 };
 
 export function traitsToTraitsOption(allTraits: AllUserTraits): TraitsOption[] {

--- a/web/packages/shared/components/TraitsEditor/TraitsEditor.tsx
+++ b/web/packages/shared/components/TraitsEditor/TraitsEditor.tsx
@@ -20,13 +20,13 @@ import { Dispatch, SetStateAction } from 'react';
 
 import { Box, ButtonBorder, ButtonIcon, Flex, Text } from 'design';
 import { Add, Trash } from 'design/Icon';
+import { IconTooltip } from 'design/Tooltip';
 import { FieldSelectCreatable } from 'shared/components/FieldSelect';
 import { Option } from 'shared/components/Select';
 import { requiredAll, requiredField } from 'shared/components/Validation/rules';
 import { Attempt } from 'shared/hooks/useAttemptNext';
 
 import { AllUserTraits } from 'teleport/services/user';
-import { IconTooltip } from 'design/Tooltip';
 
 /**
  * traitsPreset is a list of system defined traits in Teleport.

--- a/web/packages/shared/components/TraitsEditor/TraitsEditor.tsx
+++ b/web/packages/shared/components/TraitsEditor/TraitsEditor.tsx
@@ -26,6 +26,7 @@ import { requiredAll, requiredField } from 'shared/components/Validation/rules';
 import { Attempt } from 'shared/hooks/useAttemptNext';
 
 import { AllUserTraits } from 'teleport/services/user';
+import { IconTooltip } from 'design/Tooltip';
 
 /**
  * traitsPreset is a list of system defined traits in Teleport.
@@ -57,6 +58,7 @@ export function TraitsEditor({
   attempt,
   configuredTraits,
   setConfiguredTraits,
+  toolTipContent,
 }: TraitEditorProps) {
   function handleInputChange(i: InputOption | InputOptionArray) {
     const newTraits = [...configuredTraits];
@@ -103,7 +105,10 @@ export function TraitsEditor({
 
   return (
     <Box>
-      <Text typography="body3">User Traits</Text>
+      <Flex gap={2} alignItems="center">
+        <Text typography="body3">User Traits</Text>
+        {toolTipContent && <IconTooltip>{toolTipContent}</IconTooltip>}
+      </Flex>
       <Box>
         {configuredTraits.map(({ traitKey, traitValues }, index) => {
           return (
@@ -252,6 +257,7 @@ export type TraitEditorProps = {
   setConfiguredTraits: Dispatch<SetStateAction<TraitsOption[]>>;
   configuredTraits: TraitsOption[];
   attempt: Attempt;
+  toolTipContent?: React.ReactNode;
 };
 
 export function traitsToTraitsOption(allTraits: AllUserTraits): TraitsOption[] {


### PR DESCRIPTION
Supports: https://github.com/gravitational/teleport/issues/51682
This PR allows the `TraitsEditor` component to be configured with an optional tooltip.

<img width="791" alt="Screenshot 2025-03-19 at 1 36 36 PM" src="https://github.com/user-attachments/assets/98b4fffb-3daa-4a51-aa3e-49875d3a5da4" />
