### PR TITLE
github: Remove codingllama from CODEOWNERS and dependabot config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Merge rules are governed by logic in the Workflow Bot. Protect the
 # .github/workflows directory (and the merge logic) using CODEOWNERS.
-/.github/workflows/ @klizhentas @russjones @r0mant @zmb3 @fheinecke @camscale @tcsc @rosstimothy @codingllama
+/.github/workflows/ @klizhentas @russjones @r0mant @zmb3 @fheinecke @camscale @tcsc @rosstimothy
 /build.assets/tooling/cmd/difftest/ @klizhentas @russjones @r0mant @zmb3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,6 @@ updates:
           - "minor"
           - "patch"
     reviewers:
-      - codingllama
       - rosstimothy
       - zmb3
       - hugoshaka
@@ -50,7 +49,6 @@ updates:
           - "minor"
           - "patch"
     reviewers:
-      - codingllama
       - rosstimothy
       - zmb3
       - hugoshaka
@@ -75,7 +73,6 @@ updates:
           - "minor"
           - "patch"
     reviewers:
-      - codingllama
       - rosstimothy
       - tcsc
       - zmb3
@@ -97,7 +94,6 @@ updates:
           - "minor"
           - "patch"
     reviewers:
-      - codingllama
       - rosstimothy
       - zmb3
     labels:
@@ -121,7 +117,6 @@ updates:
           - "minor"
           - "patch"
     reviewers:
-      - codingllama
       - fheinecke
       - rosstimothy
       - zmb3
@@ -148,7 +143,6 @@ updates:
           - "minor"
           - "patch"
     reviewers:
-      - codingllama
       - rosstimothy
       - hugoshaka
       - tigrato
@@ -171,7 +165,6 @@ updates:
           - "minor"
           - "patch"
     reviewers:
-      - codingllama
       - rosstimothy
       - hugoshaka
       - tigrato
@@ -195,7 +188,6 @@ updates:
           - "minor"
           - "patch"
     reviewers:
-      - codingllama
       - rosstimothy
       - zmb3
     labels:
@@ -216,7 +208,6 @@ updates:
           - "minor"
           - "patch"
     reviewers:
-      - codingllama
       - rosstimothy
       - zmb3
     labels:


### PR DESCRIPTION
Alan Parra (@codingllama) left the company on March 14th 2025.
