### PR TITLE
docs: update role v5 reference info

### DIFF
--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -87,7 +87,9 @@ There are currently five supported role versions: `v3`, `v4`, `v5`, `v6`, and `v
 
 `v4` and higher roles are completely backwards compatible with `v3`. The only difference
 lies in the default values which will be applied to the role if they are not explicitly set.
-Additionally, roles with version `v5` or higher are required to use [Moderated Sessions](../../admin-guides/access-controls/guides/joining-sessions.mdx).
+Additionally, roles with version `v5` or higher do not allow joining sessions by default. The
+[Joining Sessions](../../admin-guides/access-controls/guides/joining-sessions.mdx) configuration in roles 'v5` or higher
+must be set to allow for moderation, obsering or peering in sessions.
 
 Label              | `v3` Default   | `v4` and higher Default
 ------------------ | -------------- | ---------------

--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -89,7 +89,7 @@ There are currently five supported role versions: `v3`, `v4`, `v5`, `v6`, and `v
 lies in the default values which will be applied to the role if they are not explicitly set.
 Additionally, roles with version `v5` or higher do not allow joining sessions by default. The
 [Joining Sessions](../../admin-guides/access-controls/guides/joining-sessions.mdx) configuration in roles 'v5` or higher
-must be set to allow for moderation, obsering or peering in sessions.
+must be set to allow for moderation, observing or peering in sessions.
 
 Label              | `v3` Default   | `v4` and higher Default
 ------------------ | -------------- | ---------------

--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -89,7 +89,7 @@ There are currently five supported role versions: `v3`, `v4`, `v5`, `v6`, and `v
 lies in the default values which will be applied to the role if they are not explicitly set.
 Additionally, roles with version `v5` or higher do not allow joining sessions by default. The
 [Joining Sessions](../../admin-guides/access-controls/guides/joining-sessions.mdx) configuration in roles 'v5` or higher
-must be set to allow for moderation, observing or peering in sessions.
+must be set to allow for joining sessions.
 
 Label              | `v3` Default   | `v4` and higher Default
 ------------------ | -------------- | ---------------


### PR DESCRIPTION
The language explained role version 5 and higher as requiring session moderation. This is optional and requires the joining session configuration if needed.