### PR TITLE
Add ValidationSuspender component

### DIFF
--- a/web/packages/shared/components/FieldInput/FieldInput.tsx
+++ b/web/packages/shared/components/FieldInput/FieldInput.tsx
@@ -30,6 +30,8 @@ import { InputMode, InputSize, InputType } from 'design/Input';
 import { LabelContent } from 'design/LabelInput/LabelInput';
 import { useRule } from 'shared/components/Validation';
 
+import { Rule } from '../Validation/rules';
+
 const FieldInput = forwardRef<HTMLInputElement, FieldInputProps>(
   (
     {
@@ -223,7 +225,7 @@ export type FieldInputProps = BoxProps & {
   type?: InputType;
   inputMode?: InputMode;
   spellCheck?: boolean;
-  rule?: (options: unknown) => () => unknown;
+  rule?: Rule;
   onChange?: React.ChangeEventHandler<HTMLInputElement>;
   onKeyPress?: React.KeyboardEventHandler<HTMLInputElement>;
   onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>;

--- a/web/packages/shared/components/FieldSelect/FieldSelectCreatable.tsx
+++ b/web/packages/shared/components/FieldSelect/FieldSelectCreatable.tsx
@@ -29,6 +29,7 @@ import {
   CreatableProps as SelectCreatableProps,
 } from '../Select';
 import { SelectCreatableAsync } from '../Select/Select';
+import { Rule } from '../Validation/rules';
 import {
   FieldProps,
   FieldSelectWrapper,
@@ -127,7 +128,7 @@ type CreatableProps<
     autoFocus?: boolean;
     label?: string;
     toolTipContent?: React.ReactNode;
-    rule?: (options: OnChangeValue<Opt, IsMulti>) => () => unknown;
+    rule?: Rule<OnChangeValue<Opt, IsMulti>>;
     markAsError?: boolean;
     ariaLabel?: string;
   };

--- a/web/packages/shared/components/FieldSelect/shared.tsx
+++ b/web/packages/shared/components/FieldSelect/shared.tsx
@@ -29,6 +29,7 @@ import {
   Props as SelectProps,
 } from '../Select';
 import { useRule } from '../Validation';
+import { Rule } from '../Validation/rules';
 
 export const defaultRule = () => () => ({ valid: true });
 
@@ -45,7 +46,7 @@ type FieldSelectWrapperPropsBase<Opt, IsMulti extends boolean> = {
   required?: boolean;
   helperText?: React.ReactNode;
   value?: OnChangeValue<Opt, IsMulti>;
-  rule?: (options: OnChangeValue<Opt, IsMulti>) => () => unknown;
+  rule?: Rule<OnChangeValue<Opt, IsMulti>>;
   inputId?: string;
   markAsError?: boolean;
 };
@@ -151,7 +152,7 @@ export type FieldProps<Opt, IsMulti extends boolean> = BoxProps & {
    */
   required?: boolean;
   helperText?: React.ReactNode;
-  rule?: (options: OnChangeValue<Opt, IsMulti>) => () => unknown;
+  rule?: Rule<OnChangeValue<Opt, IsMulti>>;
   markAsError?: boolean;
   ariaLabel?: string;
 };

--- a/web/packages/shared/components/FieldTextArea/FieldTextArea.tsx
+++ b/web/packages/shared/components/FieldTextArea/FieldTextArea.tsx
@@ -29,6 +29,7 @@ import { TextAreaSize } from 'design/TextArea';
 import { useRule } from 'shared/components/Validation';
 
 import { HelperTextLine } from '../FieldInput/FieldInput';
+import { Rule } from '../Validation/rules';
 
 export type FieldTextAreaProps = BoxProps & {
   id?: string;
@@ -41,7 +42,7 @@ export type FieldTextAreaProps = BoxProps & {
   autoFocus?: boolean;
   autoComplete?: HTMLInputAutoCompleteAttribute;
   spellCheck?: boolean;
-  rule?: (options: unknown) => () => unknown;
+  rule?: Rule;
   onChange?: React.ChangeEventHandler<HTMLInputElement>;
   onKeyPress?: React.KeyboardEventHandler<HTMLInputElement>;
   onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>;

--- a/web/packages/shared/components/Validation/Validation.tsx
+++ b/web/packages/shared/components/Validation/Validation.tsx
@@ -180,3 +180,25 @@ export function useValidation(): Validator {
   }
   return useStore(validator);
 }
+
+/** Conditionally suspends showing validation errors for all the children. */
+export function ValidationSuspender({
+  suspend,
+  children,
+}: React.PropsWithChildren<{ suspend?: boolean }>) {
+  // The trick is to substitute the current validator with a phony one. While
+  // we could render the children as wrapped or not wrapped, depending on the
+  // `suspend` flag value, we would end up remounting the children when the
+  // flag changes. As this would obliterate their state, we thus wrap it with a
+  // context provider that toggles between the actual and phony validator.
+  const currentValidator = useValidation();
+  const [phonyValidator] = React.useState(() => new Validator());
+  useStore(phonyValidator);
+  return (
+    <ValidationContext.Provider
+      value={suspend ? phonyValidator : currentValidator}
+    >
+      {children}
+    </ValidationContext.Provider>
+  );
+}

--- a/web/packages/shared/components/Validation/rules.ts
+++ b/web/packages/shared/components/Validation/rules.ts
@@ -262,7 +262,7 @@ const requiredPort: Rule = port => () => {
  * @returns a rule function that ANDs all input rules
  */
 const requiredAll =
-  <T>(...rules: Rule<T | string | string[], ValidationResult>[]): Rule<T> =>
+  <T>(...rules: Rule<T, ValidationResult>[]): Rule<T> =>
   (value: T) =>
   () => {
     let messages = [];

--- a/web/packages/shared/components/Validation/useRule.ts
+++ b/web/packages/shared/components/Validation/useRule.ts
@@ -18,21 +18,14 @@
 
 import { useEffect, useState } from 'react';
 
-import Logger from '../../libs/logger';
+import { ValidationResult } from './rules';
 import { useValidation } from './Validation';
-
-const logger = Logger.create('validation');
 
 /**
  * useRule subscribes to validation requests upon which executes validate() callback
  */
-export default function useRule(cb) {
-  if (typeof cb !== 'function') {
-    logger.warn(`useRule(fn), fn() must be a function`);
-    return;
-  }
-
-  const [, rerender] = useState();
+export default function useRule(cb: () => ValidationResult): ValidationResult {
+  const [, rerender] = useState({});
   const validator = useValidation();
 
   // register to validation context to be called on cb()
@@ -54,7 +47,7 @@ export default function useRule(cb) {
     }
 
     return cleanup;
-  }, [cb]);
+  }, [cb, validator]);
 
   // if validation has been requested, cb right away.
   if (validator.state.validating) {


### PR DESCRIPTION
This component makes it possible to conditionally hide validation errors in a subset of form fields. It is required by an upcoming PR to the role editor that satisfies the UX requirement of not showing validation errors on newly added sections until the next explicit validation is requested.

Also: add type information to useRule.

Contributes to https://github.com/gravitational/teleport/issues/52036
Followed up by https://github.com/gravitational/teleport/pull/53224