### PR TITLE
[v17] Avoid Postgres Web Access to dial proxy public address

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -288,7 +288,11 @@ type Config struct {
 	PublicProxyAddr string
 
 	// ALPNHandler is the ALPN connection handler for handling upgraded ALPN
-	// connection through a HTTP upgrade call.
+	// connection through an HTTP upgrade call.
+	//
+	// It’s also used in scenarios where the Proxy needs to dial to itself (e.g.
+	// database access via ws), but the handler can directly forward the traffic
+	// to the ALPN router without initiating a new connection.
 	ALPNHandler ConnectionHandler
 
 	// TraceClient is used to forward spans to the upstream collector for the UI

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -214,6 +214,8 @@ type webSuiteConfig struct {
 
 	// databaseREPLGetter allows setting custom database REPLs.
 	databaseREPLGetter dbrepl.REPLRegistry
+
+	alpnHandler ConnectionHandler
 }
 
 func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
@@ -525,6 +527,7 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 		},
 		IntegrationAppHandler: &mockIntegrationAppHandler{},
 		DatabaseREPLRegistry:  cfg.databaseREPLGetter,
+		ALPNHandler:           cfg.alpnHandler,
 	}
 
 	if handlerConfig.HealthCheckAppServer == nil {

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -215,7 +215,11 @@ type webSuiteConfig struct {
 	// databaseREPLGetter allows setting custom database REPLs.
 	databaseREPLGetter dbrepl.REPLRegistry
 
+	// alpnHandler allows setting custom alpnHandler.
 	alpnHandler ConnectionHandler
+
+	// trustXForwardedFor enables NewXForwardedForMiddleware.
+	trustXForwardedFor bool
 }
 
 func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
@@ -537,7 +541,12 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 	handler, err := NewHandler(handlerConfig, SetSessionStreamPollPeriod(200*time.Millisecond), SetClock(s.clock))
 	require.NoError(t, err)
 
-	s.webServer = httptest.NewUnstartedServer(handler)
+	var httpTestHandler http.Handler = handler
+	if cfg.trustXForwardedFor {
+		httpTestHandler = NewXForwardedForMiddleware(httpTestHandler)
+	}
+
+	s.webServer = httptest.NewUnstartedServer(httpTestHandler)
 	s.webHandler = handler
 	s.webServer.StartTLS()
 	err = s.proxy.Start()

--- a/lib/web/databases.go
+++ b/lib/web/databases.go
@@ -609,8 +609,7 @@ func (s *databaseInteractiveSession) Run() error {
 	// handler.
 	go func() {
 		alpnConnWithAddr := utils.NewConnWithAddr(s.alpnConn, s.ws.LocalAddr(), s.ws.RemoteAddr())
-		err := s.alpnHandler(s.ctx, alpnConnWithAddr)
-		if !utils.IsOKNetworkError(err) {
+		if err := s.alpnHandler(s.ctx, alpnConnWithAddr); !utils.IsOKNetworkError(err) {
 			s.log.ErrorContext(s.ctx, "ALPN handler for database interactive session failed", "error", err)
 		}
 	}()

--- a/lib/web/databases.go
+++ b/lib/web/databases.go
@@ -485,6 +485,9 @@ func (h *Handler) dbConnect(
 		proxyAddr:         h.PublicProxyAddr(),
 		proxyHostCA:       proxyHostCA,
 	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	defer sess.Close()
 
 	// Don't close the terminal stream on session error, as it would also

--- a/lib/web/databases.go
+++ b/lib/web/databases.go
@@ -626,10 +626,6 @@ func newDatabaseInteractiveSession(ctx context.Context, cfg databaseInteractiveS
 }
 
 func (s *databaseInteractiveSession) Run() error {
-	if s.alpnHandler == nil {
-		return trace.BadParameter("missing ALPN handler for database interactive sessions")
-	}
-
 	replConn, err := s.makeReplConn()
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/web/databases.go
+++ b/lib/web/databases.go
@@ -455,7 +455,7 @@ func (h *Handler) dbConnect(
 	}
 
 	// Get host CA for this Proxy.
-	clusterName, err := h.GetAccessPoint().GetClusterName(ctx)
+	clusterName, err := h.GetAccessPoint().GetClusterName()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/databases.go
+++ b/lib/web/databases.go
@@ -455,7 +455,7 @@ func (h *Handler) dbConnect(
 	}
 
 	// Get host CA for this Proxy.
-	clusterName, err := h.GetAccessPoint().GetClusterName()
+	clusterName, err := h.GetAccessPoint().GetClusterName(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/databases_test.go
+++ b/lib/web/databases_test.go
@@ -23,6 +23,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -562,6 +563,15 @@ func TestConnectDatabaseInteractiveSession(t *testing.T) {
 					return repl, nil
 				},
 			},
+		},
+		alpnHandler: func(ctx context.Context, conn net.Conn) error {
+			// mock repl will not send any actual data. just verify the incoming
+			// connection is TLS.
+			_, ok := conn.(utils.TLSConn)
+			if !ok {
+				return trace.BadParameter("expected TLSConn, got %T", conn)
+			}
+			return nil
 		},
 	})
 	s.webHandler.handler.cfg.PublicProxyAddr = s.webHandler.handler.cfg.ProxyWebAddr.String()

--- a/lib/web/databases_test.go
+++ b/lib/web/databases_test.go
@@ -567,8 +567,7 @@ func TestConnectDatabaseInteractiveSession(t *testing.T) {
 		alpnHandler: func(ctx context.Context, conn net.Conn) error {
 			// mock repl will not send any actual data. just verify the incoming
 			// connection is TLS.
-			_, ok := conn.(utils.TLSConn)
-			if !ok {
+			if _, ok := conn.(utils.TLSConn); !ok {
 				return trace.BadParameter("expected TLSConn, got %T", conn)
 			}
 			return nil


### PR DESCRIPTION
Backport #52724 to branch/v17

changelog: fix an issue PostgreSQL via WebUI fails when IP pinning is enabled. PostgreSQL via WebUI no longer requires Proxy to dial its own public address.
