### PR TITLE
[Web] Hide "create your first bot" button if you don't have permissions.

### DIFF
--- a/web/packages/teleport/src/Bots/List/EmptyState/EmptyState.tsx
+++ b/web/packages/teleport/src/Bots/List/EmptyState/EmptyState.tsx
@@ -34,6 +34,7 @@ import {
 
 import { DisplayTile } from 'teleport/Bots/Add/AddBotsPicker';
 import cfg from 'teleport/config';
+import useTeleport from 'teleport/useTeleport';
 
 import argoCD from './argocd.png';
 import controlWorkflowsLightImage from './control-workflows-light.svg';
@@ -46,6 +47,10 @@ const maxWidth = '1204px';
 export function EmptyState() {
   const [currIndex, setCurrIndex] = useState(0);
   const [intervalId, setIntervalId] = useState<any>();
+
+  const ctx = useTeleport();
+  const flags = ctx.getFeatureFlags();
+  const hasAddBotPermissions = flags.addBots;
 
   function handleOnClick(clickedIndex: number) {
     clearInterval(intervalId);
@@ -106,16 +111,18 @@ export function EmptyState() {
         </Box>
       </FeatureContainer>
       {/* setting a max width here to keep it "in the center" with the content above instead of with the screen */}
-      <Box width="100%" maxWidth={maxWidth} textAlign="center" mt={6}>
-        <ButtonPrimary
-          width="280px"
-          as={Link}
-          to={cfg.getBotsNewRoute()}
-          size="large"
-        >
-          Create Your First Bot
-        </ButtonPrimary>
-      </Box>
+      {hasAddBotPermissions && (
+        <Box width="100%" maxWidth={maxWidth} textAlign="center" mt={6}>
+          <ButtonPrimary
+            width="280px"
+            as={Link}
+            to={cfg.getBotsNewRoute()}
+            size="large"
+          >
+            Create Your First Bot
+          </ButtonPrimary>
+        </Box>
+      )}
     </Box>
   );
 }


### PR DESCRIPTION
## Purpose

Hides the "create your first bot" button on the empty state page for bots if you don't have permission to create a bot. Previously this would lead to a 404.