### PR TITLE
aws oidc menu and edit updates

### DIFF
--- a/web/packages/shared/components/MenuAction/MenuActionButton.tsx
+++ b/web/packages/shared/components/MenuAction/MenuActionButton.tsx
@@ -17,8 +17,9 @@
  */
 
 import React, { PropsWithChildren } from 'react';
+import styled from 'styled-components';
 
-import { ButtonBorder } from 'design';
+import { Button, ButtonBorder } from 'design';
 import { ChevronDown } from 'design/Icon';
 import Menu from 'design/Menu';
 
@@ -29,6 +30,9 @@ type Props = MenuProps & {
   buttonProps?: AnchorProps;
   buttonText?: React.ReactNode;
   menuProps?: MenuProps;
+
+  // If present, button text is not used, and a square icon button is rendered instead of a border button
+  icon?: React.ReactNode;
 };
 
 export default class MenuActionIcon extends React.Component<
@@ -56,18 +60,29 @@ export default class MenuActionIcon extends React.Component<
 
   render() {
     const { open } = this.state;
-    const { children, menuProps, buttonProps } = this.props;
+    const { children, menuProps, buttonProps, icon } = this.props;
     return (
       <>
-        <ButtonBorder
-          size="small"
-          setRef={e => (this.anchorEl = e)}
-          onClick={this.onOpen}
-          {...buttonProps}
-        >
-          {this.props.buttonText || 'Options'}
-          <ChevronDown ml={2} size="small" color="text.slightlyMuted" />
-        </ButtonBorder>
+        {icon ? (
+          <FilledButtonIcon
+            intent="neutral"
+            setRef={e => (this.anchorEl = e)}
+            onClick={this.onOpen}
+            {...buttonProps}
+          >
+            {icon}
+          </FilledButtonIcon>
+        ) : (
+          <ButtonBorder
+            size="small"
+            setRef={e => (this.anchorEl = e)}
+            onClick={this.onOpen}
+            {...buttonProps}
+          >
+            {this.props.buttonText || 'Options'}
+            <ChevronDown ml={2} size="small" color="text.slightlyMuted" />
+          </ButtonBorder>
+        )}
         <Menu
           getContentAnchorEl={null}
           menuListCss={menuListCss}
@@ -112,4 +127,10 @@ export default class MenuActionIcon extends React.Component<
 
 const menuListCss = () => `
   min-width: 100px;
+`;
+
+const FilledButtonIcon = styled(Button)`
+  width: 32px;
+  height: 32px;
+  padding: 0;
 `;

--- a/web/packages/teleport/src/Integrations/EditAwsOidcIntegrationDialog.tsx
+++ b/web/packages/teleport/src/Integrations/EditAwsOidcIntegrationDialog.tsx
@@ -17,7 +17,6 @@
  */
 
 import { useState } from 'react';
-import styled from 'styled-components';
 
 import {
   Alert,
@@ -28,7 +27,7 @@ import {
   Link,
   Text,
 } from 'design';
-import { OutlineInfo, OutlineWarn } from 'design/Alert/Alert';
+import { Info, Warning } from 'design/Alert/Alert';
 import Dialog, {
   DialogContent,
   DialogFooter,
@@ -109,128 +108,141 @@ export function EditAwsOidcIntegrationDialog(props: Props) {
 
   const changeDetected = integration.spec.roleArn !== roleArn;
 
+  function actionButtons(validator: Validator) {
+    if (!scriptUrl) {
+      return (
+        <ButtonBorder
+          mr="3"
+          onClick={() =>
+            generateAwsOidcConfigIdpScript(
+              validator,
+              AwsOidcPolicyPreset.Unspecified
+            )
+          }
+          disabled={!roleArn || !showGenerateCommand}
+        >
+          Reconfigure
+        </ButtonBorder>
+      );
+    }
+
+    return (
+      <>
+        <ButtonPrimary
+          mr="3"
+          disabled={
+            isProcessing ||
+            (showGenerateCommand && !confirmed) ||
+            (!showReadonlyS3Fields && !changeDetected)
+          }
+          onClick={() => handleEdit(validator)}
+        >
+          Save
+        </ButtonPrimary>
+        <ButtonSecondary
+          mr="3"
+          onClick={() => setScriptUrl('')}
+          disabled={confirmed}
+        >
+          Edit
+        </ButtonSecondary>
+      </>
+    );
+  }
+
   return (
     <Validation>
       {({ validator }) => (
         <Dialog
-          disableEscapeKeyDown={false}
           onClose={close}
           open={true}
           dialogCss={() => ({
+            minHeight: '324px',
             maxWidth: '650px',
             width: '100%',
           })}
         >
           <DialogHeader>
-            <DialogTitle>Edit Integration</DialogTitle>
+            <DialogTitle>Edit Role ARN: {integration.name}</DialogTitle>
           </DialogHeader>
-          <DialogContent width="650px">
+          <DialogContent width="650px" m={0}>
             {updateAttempt.status === 'error' && (
               <Alert children={updateAttempt.statusText} />
             )}
             <FieldInput
-              label="Integration Name"
-              value={integration.name}
-              readonly={true}
+              autoFocus
+              label="Role ARN"
+              rule={requiredRoleArn}
+              value={roleArn}
+              onChange={e => setRoleArn(e.target.value)}
+              placeholder="arn:aws:iam::<ACCOUNT_ID>:role/<ROLE_NAME>"
+              helperText="Role ARN can be found in the format: arn:aws:iam::<ACCOUNT_ID>:role/<ROLE_NAME>"
+              disabled={!!scriptUrl}
             />
-            <EditableBox px={3} pt={2} mt={2}>
-              <FieldInput
-                autoFocus
-                label="Role ARN"
-                rule={requiredRoleArn}
-                value={roleArn}
-                onChange={e => setRoleArn(e.target.value)}
-                placeholder="arn:aws:iam::<ACCOUNT_ID>:role/<ROLE_NAME>"
-                toolTipContent={
-                  <Text>
-                    Role ARN can be found in the format: <br />
-                    {`arn:aws:iam::<ACCOUNT_ID>:role/<ROLE_NAME>`}
-                  </Text>
-                }
-                disabled={!!scriptUrl}
-              />
-              {showReadonlyS3Fields && !scriptUrl && (
-                <>
-                  <S3BucketConfiguration
-                    s3Bucket={s3Bucket}
-                    s3Prefix={s3Prefix}
+            {showReadonlyS3Fields && !scriptUrl && (
+              <>
+                <S3BucketConfiguration
+                  s3Bucket={s3Bucket}
+                  s3Prefix={s3Prefix}
+                />
+                <Warning>
+                  Using an S3 bucket to store the OpenID Configuration is not
+                  recommended. Reconfiguring this integration is suggested (this
+                  will not break existing features).
+                </Warning>
+              </>
+            )}
+            {scriptUrl && (
+              <Box mb={2} data-testid="scriptbox">
+                <Text mb={2}>
+                  Open{' '}
+                  <Link
+                    href="https://console.aws.amazon.com/cloudshell/home"
+                    target="_blank"
+                  >
+                    AWS CloudShell
+                  </Link>{' '}
+                  and copy and paste the command that configures the permissions
+                  for you:
+                </Text>
+                <Box>
+                  <TextSelectCopyMulti
+                    lines={[
+                      {
+                        text: `bash -c "$(curl '${scriptUrl}')"`,
+                      },
+                    ]}
                   />
-                  <OutlineWarn>
-                    Using an S3 bucket to store the OpenID Configuration is not
-                    recommended. Reconfiguring this integration is suggested
-                    (this will not break existing features).
-                  </OutlineWarn>
-                </>
-              )}
-              {scriptUrl && (
-                <Box mb={5} data-testid="scriptbox">
-                  <Text mb={2}>
-                    Open{' '}
-                    <Link
-                      href="https://console.aws.amazon.com/cloudshell/home"
-                      target="_blank"
-                    >
-                      AWS CloudShell
-                    </Link>{' '}
-                    and copy and paste the command that configures the
-                    permissions for you:
-                  </Text>
-                  <Box mb={2}>
-                    <TextSelectCopyMulti
-                      lines={[
-                        {
-                          text: `bash -c "$(curl '${scriptUrl}')"`,
-                        },
-                      ]}
-                    />
-                    {showReadonlyS3Fields && (
-                      <OutlineInfo mt={3} linkColor="buttons.link.default">
-                        <Box>
-                          After running the command, delete the previous{' '}
-                          <Link
-                            target="_blank"
-                            href={`https://console.aws.amazon.com/iam/home#/identity_providers/details/OPENID/${getIdpArn({ s3Bucket, s3Prefix, roleArn: integration.spec.roleArn })}`}
-                          >
-                            identity provider
-                          </Link>{' '}
-                          along with its{' '}
-                          <Link
-                            target="_blank"
-                            href={`https://console.aws.amazon.com/s3/buckets/${s3Bucket}`}
-                          >
-                            S3 bucket
-                          </Link>{' '}
-                          from your AWS console.
-                        </Box>
-                      </OutlineInfo>
-                    )}
-                  </Box>
+                  {showReadonlyS3Fields && (
+                    <Info mt={3} linkColor="buttons.link.default">
+                      <Box>
+                        After running the command, delete the previous{' '}
+                        <Link
+                          target="_blank"
+                          href={`https://console.aws.amazon.com/iam/home#/identity_providers/details/OPENID/${getIdpArn(
+                            {
+                              s3Bucket,
+                              s3Prefix,
+                              roleArn: integration.spec.roleArn,
+                            }
+                          )}`}
+                        >
+                          identity provider
+                        </Link>{' '}
+                        along with its{' '}
+                        <Link
+                          target="_blank"
+                          href={`https://console.aws.amazon.com/s3/buckets/${s3Bucket}`}
+                        >
+                          S3 bucket
+                        </Link>{' '}
+                        from your AWS console.
+                      </Box>
+                    </Info>
+                  )}
                 </Box>
-              )}
-              {scriptUrl && (
-                <ButtonSecondary
-                  mb={3}
-                  onClick={() => setScriptUrl('')}
-                  disabled={confirmed}
-                >
-                  Edit
-                </ButtonSecondary>
-              )}
-              {!scriptUrl && showGenerateCommand && (
-                <ButtonBorder
-                  mb={3}
-                  onClick={() =>
-                    generateAwsOidcConfigIdpScript(
-                      validator,
-                      AwsOidcPolicyPreset.Unspecified
-                    )
-                  }
-                  disabled={!roleArn}
-                >
-                  Reconfigure
-                </ButtonBorder>
-              )}
-            </EditableBox>
+              </Box>
+            )}
           </DialogContent>
           <DialogFooter>
             {showGenerateCommand && scriptUrl && (
@@ -244,17 +256,7 @@ export function EditAwsOidcIntegrationDialog(props: Props) {
                 disabled={isProcessing}
               />
             )}
-            <ButtonPrimary
-              mr="3"
-              disabled={
-                isProcessing ||
-                (showGenerateCommand && !confirmed) ||
-                (!showReadonlyS3Fields && !changeDetected)
-              }
-              onClick={() => handleEdit(validator)}
-            >
-              Save
-            </ButtonPrimary>
+            {actionButtons(validator)}
             <ButtonSecondary disabled={isProcessing} onClick={close}>
               Cancel
             </ButtonSecondary>
@@ -264,12 +266,6 @@ export function EditAwsOidcIntegrationDialog(props: Props) {
     </Validation>
   );
 }
-
-const EditableBox = styled(Box)`
-  border-radius: ${p => p.theme.space[1]}px;
-  border: 2px solid ${p => p.theme.colors.spotBackground[1]};
-  background-color: ${p => p.theme.colors.spotBackground[0]};
-`;
 
 function getIdpArn({
   s3Bucket,

--- a/web/packages/teleport/src/Integrations/Enroll/AwsOidc/S3BucketConfiguration.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsOidc/S3BucketConfiguration.tsx
@@ -43,14 +43,14 @@ export function S3BucketConfiguration({
           placeholder="bucket"
           label="Bucket Name"
           width="50%"
-          readonly={true}
+          disabled
         />
         <FieldInput
           value={s3Prefix}
           placeholder="prefix"
           label="Bucket's Prefix Name"
           width="50%"
-          readonly={true}
+          disabled
         />
       </Flex>
     </>

--- a/web/packages/teleport/src/Integrations/IntegrationList.test.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationList.test.tsx
@@ -19,7 +19,7 @@
 import { createMemoryHistory } from 'history';
 import { Router } from 'react-router';
 
-import { fireEvent, render, screen, userEvent } from 'design/utils/testing';
+import { render, screen, userEvent } from 'design/utils/testing';
 
 import { IntegrationList } from 'teleport/Integrations/IntegrationList';
 import {
@@ -27,7 +27,7 @@ import {
   IntegrationStatusCode,
 } from 'teleport/services/integrations';
 
-test('integration list shows edit and view action menu for aws-oidc, row click navigates', async () => {
+test('integration list does not display action menu for aws-oidc, row click navigates', async () => {
   const history = createMemoryHistory();
   history.push = jest.fn();
 
@@ -47,15 +47,9 @@ test('integration list shows edit and view action menu for aws-oidc, row click n
     </Router>
   );
 
-  fireEvent.click(screen.getByRole('button', { name: 'Options' }));
-  expect(screen.getByText('View Status')).toBeInTheDocument();
-  expect(screen.getByText('View Status')).toHaveAttribute(
-    'href',
-    '/web/integrations/status/aws-oidc/aws-integration'
-  );
-  expect(screen.getByText('Edit...')).toBeInTheDocument();
-  expect(screen.getByText('Delete...')).toBeInTheDocument();
-
+  expect(
+    screen.queryByRole('button', { name: 'Options' })
+  ).not.toBeInTheDocument();
   await userEvent.click(screen.getAllByRole('row')[1]);
   expect(history.push).toHaveBeenCalledWith(
     '/web/integrations/status/aws-oidc/aws-integration'

--- a/web/packages/teleport/src/Integrations/IntegrationList.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationList.tsx
@@ -118,6 +118,11 @@ export function IntegrationList(props: Props) {
         {
           altKey: 'options-btn',
           render: item => {
+            if (item.kind === IntegrationKind.AwsOidc) {
+              // do not show any action menu for aws oidc; settings are available on the dashboard
+              return;
+            }
+
             if (item.resourceType === 'plugin') {
               return (
                 <Cell align="right">
@@ -152,17 +157,7 @@ export function IntegrationList(props: Props) {
               return (
                 <Cell align="right">
                   <MenuButton>
-                    {/* Currently, only AWS OIDC supports editing & status dash */}
-                    {item.kind === IntegrationKind.AwsOidc && (
-                      <MenuItem
-                        as={InternalRouteLink}
-                        to={cfg.getIntegrationStatusRoute(item.kind, item.name)}
-                      >
-                        View Status
-                      </MenuItem>
-                    )}
-                    {(item.kind === IntegrationKind.GitHub ||
-                      item.kind === IntegrationKind.AwsOidc) && (
+                    {item.kind === IntegrationKind.GitHub && (
                       <MenuItem
                         onClick={() =>
                           props.integrationOps.onEditIntegration(item)

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcTitle.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcTitle.tsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { useHistory } from 'react-router';
 import { Link as InternalLink } from 'react-router-dom';
 
 import { ButtonIcon, Flex, Label, MenuItem, Text } from 'design';
@@ -23,11 +24,13 @@ import { ArrowLeft } from 'design/Icon';
 import { HoverTooltip } from 'design/Tooltip';
 import { MenuButton } from 'shared/components/MenuAction';
 
-import { IntegrationOperationsE } from 'e-teleport/Integrations/IntegrationOperationsE';
-import { useIntegrations } from 'e-teleport/Integrations/useIntegrations';
 import cfg from 'teleport/config';
 import { getStatusAndLabel } from 'teleport/Integrations/helpers';
-import { EditableIntegration } from 'teleport/Integrations/Operations/useIntegrationOperation';
+import {
+  IntegrationOperations,
+  useIntegrationOperation,
+} from 'teleport/Integrations/Operations';
+import type { EditableIntegrationFields } from 'teleport/Integrations/Operations/useIntegrationOperation';
 import { AwsResource } from 'teleport/Integrations/status/AwsOidc/StatCard';
 import { IntegrationAwsOidc } from 'teleport/services/integrations';
 
@@ -40,9 +43,21 @@ export function AwsOidcTitle({
   resource?: AwsResource;
   tasks?: boolean;
 }) {
-  const { integrationOps } = useIntegrations();
+  const history = useHistory();
+  const integrationOps = useIntegrationOperation();
   const { status, labelKind } = getStatusAndLabel(integration);
   const content = getContent(integration, resource, tasks);
+
+  async function removeIntegration() {
+    await integrationOps.remove();
+    integrationOps.clear();
+    history.push(cfg.routes.integrations);
+  }
+
+  async function editIntegration(req: EditableIntegrationFields) {
+    await integrationOps.edit(req);
+    integrationOps.clear();
+  }
 
   return (
     <Flex justifyContent="space-between">
@@ -69,12 +84,12 @@ export function AwsOidcTitle({
           </MenuItem>
         </MenuButton>
       )}
-      <IntegrationOperationsE
+      <IntegrationOperations
         operation={integrationOps.type}
-        integration={integrationOps.item as EditableIntegration}
+        integration={integrationOps.item}
         close={integrationOps.clear}
-        remove={integrationOps.removeIntegration}
-        edit={integrationOps.editIntegration}
+        edit={editIntegration}
+        remove={removeIntegration}
       />
     </Flex>
   );

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcTitle.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcTitle.tsx
@@ -17,12 +17,17 @@
  */
 import { Link as InternalLink } from 'react-router-dom';
 
-import { ButtonIcon, Flex, Label, Text } from 'design';
+import { ButtonIcon, Flex, Label, MenuItem, Text } from 'design';
+import * as Icons from 'design/Icon';
 import { ArrowLeft } from 'design/Icon';
 import { HoverTooltip } from 'design/Tooltip';
+import { MenuButton } from 'shared/components/MenuAction';
 
+import { IntegrationOperationsE } from 'e-teleport/Integrations/IntegrationOperationsE';
+import { useIntegrations } from 'e-teleport/Integrations/useIntegrations';
 import cfg from 'teleport/config';
 import { getStatusAndLabel } from 'teleport/Integrations/helpers';
+import { EditableIntegration } from 'teleport/Integrations/Operations/useIntegrationOperation';
 import { AwsResource } from 'teleport/Integrations/status/AwsOidc/StatCard';
 import { IntegrationAwsOidc } from 'teleport/services/integrations';
 
@@ -35,22 +40,42 @@ export function AwsOidcTitle({
   resource?: AwsResource;
   tasks?: boolean;
 }) {
+  const { integrationOps } = useIntegrations();
   const { status, labelKind } = getStatusAndLabel(integration);
   const content = getContent(integration, resource, tasks);
 
   return (
-    <Flex alignItems="center" data-testid="aws-oidc-title">
-      <HoverTooltip placement="bottom" tipContent={content.helper}>
-        <ButtonIcon as={InternalLink} to={content.to} aria-label="back">
-          <ArrowLeft size="medium" />
-        </ButtonIcon>
-      </HoverTooltip>
-      <Text bold fontSize={6} mx={2}>
-        {content.content}
-      </Text>
-      <Label kind={labelKind} aria-label="status" px={3}>
-        {status}
-      </Label>
+    <Flex justifyContent="space-between">
+      <Flex alignItems="center" data-testid="aws-oidc-title">
+        <HoverTooltip placement="bottom" tipContent={content.helper}>
+          <ButtonIcon as={InternalLink} to={content.to} aria-label="back">
+            <ArrowLeft size="medium" />
+          </ButtonIcon>
+        </HoverTooltip>
+        <Text bold fontSize={6} mx={2}>
+          {content.content}
+        </Text>
+        <Label kind={labelKind} aria-label="status" px={3}>
+          {status}
+        </Label>
+      </Flex>
+      {!resource && !tasks && (
+        <MenuButton icon={<Icons.Cog />}>
+          <MenuItem onClick={() => integrationOps.onEdit(integration)}>
+            Edit...
+          </MenuItem>
+          <MenuItem onClick={() => integrationOps.onRemove(integration)}>
+            Delete...
+          </MenuItem>
+        </MenuButton>
+      )}
+      <IntegrationOperationsE
+        operation={integrationOps.type}
+        integration={integrationOps.item as EditableIntegration}
+        close={integrationOps.clear}
+        remove={integrationOps.removeIntegration}
+        edit={integrationOps.editIntegration}
+      />
     </Flex>
   );
 }


### PR DESCRIPTION
* Remove actions menu from integrations list
* Add actions menu to dashboard page
  * Update action menu to accept optional icon
  * If icon is present, display menu as square icon button
* Edit updates:
  * Remove name input field
  * Put name in title
  * Remove custom edit styles
  * Set S3 ready only fields as disabled instead
  * Move reconfigure and edit buttons to footer
  * Move arn info tooltip to input helper text

<details>
  <summary>Before & After</summary>
  
table before

<img width="1432" alt="table before" src="https://github.com/user-attachments/assets/2182ae63-f6b7-4dda-b980-31eaf581dc1b" />


table after

<img width="1167" alt="table-after" src="https://github.com/user-attachments/assets/cbfb10fc-9e3b-44f9-816a-343539a78faf" />

new settings menu

<img width="1488" alt="new menu" src="https://github.com/user-attachments/assets/5fd3a321-6909-412d-90ec-aeee0de0e77b" />

edit before

https://github.com/user-attachments/assets/f3e10e6f-e41f-437e-9fbe-fafb362de88a

edit after

https://github.com/user-attachments/assets/2d2b4000-57b2-4808-a874-44bf2b045a5d

</details>

Supports https://github.com/gravitational/teleport/issues/52895