### PR TITLE
Clarify the wording in role editor

### DIFF
--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/AdminRules.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/AdminRules.test.tsx
@@ -55,7 +55,7 @@ describe('AdminRules', () => {
   test('editing', async () => {
     const { user, modelRef } = setup();
     await user.click(screen.getByRole('button', { name: 'Add New' }));
-    await selectEvent.select(screen.getByLabelText('Resources *'), [
+    await selectEvent.select(screen.getByLabelText('Teleport Resources *'), [
       'db',
       'node',
     ]);

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/AdminRules.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/AdminRules.tsx
@@ -108,7 +108,7 @@ const AdminRule = memo(function AdminRule({
         <ResourceKindSelect
           components={{ MultiValue: ResourceKindMultiValue }}
           isMulti
-          label="Resources"
+          label="Teleport Resources"
           required
           isDisabled={isProcessing}
           options={resourceKindOptions}

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.test.tsx
@@ -152,7 +152,9 @@ describe('KubernetesAccessSection', () => {
       createOptionText: 'User: mary',
     });
 
-    await user.click(screen.getByRole('button', { name: 'Add a Resource' }));
+    await user.click(
+      screen.getByRole('button', { name: 'Add a Kubernetes Resource' })
+    );
     expect(
       reactSelectValueContainer(screen.getByLabelText('Kind'))
     ).toHaveTextContent('Any kind');
@@ -201,16 +203,18 @@ describe('KubernetesAccessSection', () => {
   test('adding and removing resources', async () => {
     const { user, onChange } = setup();
 
-    await user.click(screen.getByRole('button', { name: 'Add a Resource' }));
+    await user.click(
+      screen.getByRole('button', { name: 'Add a Kubernetes Resource' })
+    );
     await user.clear(screen.getByLabelText('Name *'));
     await user.type(screen.getByLabelText('Name *'), 'res1');
     await user.click(
-      screen.getByRole('button', { name: 'Add Another Resource' })
+      screen.getByRole('button', { name: 'Add Another Kubernetes Resource' })
     );
     await user.clear(screen.getAllByLabelText('Name *')[1]);
     await user.type(screen.getAllByLabelText('Name *')[1], 'res2');
     await user.click(
-      screen.getByRole('button', { name: 'Add Another Resource' })
+      screen.getByRole('button', { name: 'Add Another Kubernetes Resource' })
     );
     await user.clear(screen.getAllByLabelText('Name *')[2]);
     await user.type(screen.getAllByLabelText('Name *')[2], 'res3');
@@ -225,7 +229,7 @@ describe('KubernetesAccessSection', () => {
     );
 
     await user.click(
-      screen.getAllByRole('button', { name: 'Remove resource' })[1]
+      screen.getAllByRole('button', { name: 'Remove Kubernetes resource' })[1]
     );
     expect(onChange).toHaveBeenLastCalledWith(
       expect.objectContaining({
@@ -236,7 +240,7 @@ describe('KubernetesAccessSection', () => {
       })
     );
     await user.click(
-      screen.getAllByRole('button', { name: 'Remove resource' })[0]
+      screen.getAllByRole('button', { name: 'Remove Kubernetes resource' })[0]
     );
     expect(onChange).toHaveBeenLastCalledWith(
       expect.objectContaining({
@@ -244,7 +248,7 @@ describe('KubernetesAccessSection', () => {
       })
     );
     await user.click(
-      screen.getAllByRole('button', { name: 'Remove resource' })[0]
+      screen.getAllByRole('button', { name: 'Remove Kubernetes resource' })[0]
     );
     expect(onChange).toHaveBeenLastCalledWith(
       expect.objectContaining({ resources: [] })
@@ -254,7 +258,9 @@ describe('KubernetesAccessSection', () => {
   test('validation', async () => {
     const { user, validator } = setup(RoleVersion.V6);
     await user.click(screen.getByRole('button', { name: 'Add a Label' }));
-    await user.click(screen.getByRole('button', { name: 'Add a Resource' }));
+    await user.click(
+      screen.getByRole('button', { name: 'Add a Kubernetes Resource' })
+    );
     await selectEvent.select(screen.getByLabelText('Kind'), 'Service');
     await user.clear(screen.getByLabelText('Name *'));
     await user.clear(screen.getByLabelText('Namespace *'));

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.tsx
@@ -122,7 +122,7 @@ export const ResourcesTab = memo(function ResourcesTab({
           buttonText={
             <>
               <Plus size="small" mr={2} />
-              Add Resource Access
+              Add Teleport Resource Access
             </>
           }
           buttonProps={{
@@ -354,8 +354,8 @@ export function KubernetesAccessSection({
           >
             <Add disabled={isProcessing} size="small" />
             {value.resources.length > 0
-              ? 'Add Another Resource'
-              : 'Add a Resource'}
+              ? 'Add Another Kubernetes Resource'
+              : 'Add a Kubernetes Resource'}
           </ButtonSecondary>
         </Box>
       </Flex>
@@ -387,10 +387,10 @@ function KubernetesResourceView({
     >
       <Flex>
         <Box flex="1">
-          <H4 mb={3}>Resource</H4>
+          <H4 mb={3}>Kubernetes Resource</H4>
         </Box>
         <ButtonIcon
-          aria-label="Remove resource"
+          aria-label="Remove Kubernetes resource"
           disabled={isProcessing}
           onClick={onRemove}
         >

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.test.tsx
@@ -61,7 +61,9 @@ test('adding and removing sections', async () => {
   await user.click(getTabByName('Resources'));
   expect(getAllSectionNames()).toEqual([]);
 
-  await user.click(screen.getByRole('button', { name: 'Add Resource Access' }));
+  await user.click(
+    screen.getByRole('button', { name: 'Add Teleport Resource Access' })
+  );
   expect(getAllMenuItemNames()).toEqual([
     'Kubernetes',
     'Servers',
@@ -74,7 +76,9 @@ test('adding and removing sections', async () => {
   await user.click(screen.getByRole('menuitem', { name: 'Servers' }));
   expect(getAllSectionNames()).toEqual(['Servers']);
 
-  await user.click(screen.getByRole('button', { name: 'Add Resource Access' }));
+  await user.click(
+    screen.getByRole('button', { name: 'Add Teleport Resource Access' })
+  );
   expect(getAllMenuItemNames()).toEqual([
     'Kubernetes',
     'Applications',
@@ -209,7 +213,9 @@ test('edits resource access', async () => {
     />
   );
   await user.click(getTabByName('Resources'));
-  await user.click(screen.getByRole('button', { name: 'Add Resource Access' }));
+  await user.click(
+    screen.getByRole('button', { name: 'Add Teleport Resource Access' })
+  );
   await user.click(screen.getByRole('menuitem', { name: 'Servers' }));
   await selectEvent.create(screen.getByLabelText('Logins'), 'ec2-user', {
     createOptionText: 'Login: ec2-user',
@@ -228,16 +234,20 @@ test('triggers v6 validation for Kubernetes resources', async () => {
   );
   await selectEvent.select(screen.getByLabelText('Version'), 'v6');
   await user.click(getTabByName('Resources'));
-  await user.click(screen.getByRole('button', { name: 'Add Resource Access' }));
+  await user.click(
+    screen.getByRole('button', { name: 'Add Teleport Resource Access' })
+  );
   await user.click(screen.getByRole('menuitem', { name: 'Kubernetes' }));
-  await user.click(screen.getByRole('button', { name: 'Add a Resource' }));
+  await user.click(
+    screen.getByRole('button', { name: 'Add a Kubernetes Resource' })
+  );
   await selectEvent.select(screen.getByLabelText('Kind'), 'Job');
 
   // Adding a second resource to make sure that we don't run into attempting to
   // modify an immer-frozen object. This might happen if the reducer tried to
   // modify resources that were already there.
   await user.click(
-    screen.getByRole('button', { name: 'Add Another Resource' })
+    screen.getByRole('button', { name: 'Add Another Kubernetes Resource' })
   );
   await selectEvent.select(screen.getAllByLabelText('Kind')[1], 'Pod');
   await user.click(screen.getByRole('button', { name: 'Save Changes' }));
@@ -309,7 +319,9 @@ test('tab-level validation when creating a new role', async () => {
   expect(getTabByName('Resources')).toHaveAttribute('aria-selected', 'true');
 
   // Break the validation and attempt switching tabs.
-  await user.click(screen.getByRole('button', { name: 'Add Resource Access' }));
+  await user.click(
+    screen.getByRole('button', { name: 'Add Teleport Resource Access' })
+  );
   await user.click(screen.getByRole('menuitem', { name: 'Servers' }));
   await user.click(screen.getByRole('button', { name: 'Add a Label' }));
   // The form should not be validating until we try to switch to the next tab.

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.test.tsx
@@ -164,7 +164,9 @@ test('hidden validation errors should not propagate to tab headings', async () =
 
   // Switch to the Resources tab. Add a new section and make it invalid.
   await user.click(getTabByName('Resources'));
-  await user.click(screen.getByRole('button', { name: 'Add Resource Access' }));
+  await user.click(
+    screen.getByRole('button', { name: 'Add Teleport Resource Access' })
+  );
   await user.click(screen.getByRole('menuitem', { name: 'Servers' }));
   await user.click(screen.getByRole('button', { name: 'Add a Label' }));
 


### PR DESCRIPTION
Use "Teleport resources" and "Kubernetes resources" instead of "resources" to make them unambiguous.

<img width="527" alt="Screenshot 2025-03-20 at 22 30 14" src="https://github.com/user-attachments/assets/5e40ce75-a14a-4a67-847f-78b5a59d2e3c" />

<img width="540" alt="Screenshot 2025-03-20 at 22 30 26" src="https://github.com/user-attachments/assets/21f686e1-ac29-4a28-861d-2f69e06b444c" />

Contributes to https://github.com/gravitational/teleport/issues/52220
Requires https://github.com/gravitational/teleport/pull/53177