### PR TITLE
fix: fix flaky TestCreateSignedSTSIdentityRequest

### DIFF
--- a/lib/auth/join/iam/iam_test.go
+++ b/lib/auth/join/iam/iam_test.go
@@ -38,6 +38,10 @@ func TestCreateSignedSTSIdentityRequest(t *testing.T) {
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "FAKE_KEY")
 	t.Setenv("AWS_SESSION_TOKEN", "FAKE_SESSION_TOKEN")
 
+	// If the user has an AWS config file that sets a region, it conflicts with
+	// the test cases. Disable loading a config file by setting a nonexistent path.
+	t.Setenv("AWS_CONFIG_FILE", "fake-file-this-must-not-exist")
+
 	const challenge = "asdf12345"
 
 	for desc, tc := range map[string]struct {


### PR DESCRIPTION
This commit prevents the test from loading an AWS config file that may set a region that conflicts with the test cases.

Fixes #53263