### PR TITLE
Update Identity output docs to include `ssh_config` option

### DIFF
--- a/docs/pages/reference/machine-id/configuration.mdx
+++ b/docs/pages/reference/machine-id/configuration.mdx
@@ -206,7 +206,7 @@ output used in context.
 type: identity
 # ssh_config controls whether the identity output will attempt to generate an
 # OpenSSH configuration file. This requires that `tbot` can connect to the
-# Teleport Proxy. If unspecified, this defaults to 'on'.
+# Teleport Proxy Service. If unspecified, this defaults to 'on'.
 ssh_config: on
 
 (!docs/pages/includes/machine-id/common-output-config.yaml!)

--- a/docs/pages/reference/machine-id/configuration.mdx
+++ b/docs/pages/reference/machine-id/configuration.mdx
@@ -204,6 +204,10 @@ output used in context.
 # type specifies the type of the output. For the identity output, this will
 # always be `identity`.
 type: identity
+# ssh_config controls whether the identity output will attempt to generate an
+# OpenSSH configuration file. This requires that `tbot` can connect to the
+# Teleport Proxy. If unspecified, this defaults to 'on'.
+ssh_config: on
 
 (!docs/pages/includes/machine-id/common-output-config.yaml!)
 ```


### PR DESCRIPTION
This configuration option was missing. This PR adds it.

