### PR TITLE
[buddy] helm: add support for secondFactors

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -330,6 +330,37 @@ For example, if users are accessing the cluster with the domain
 Changing the RP ID will invalidate all already registered webauthn second factors.
 </Admonition>
 
+### `authentication.secondFactors`
+
+| Type     | Default value | Required? | `teleport.yaml` equivalent                  |
+|----------|---------------|-----------|---------------------------------------------|
+| `array`  | `[]`          | No        | `auth_service.authentication.second_factors` |
+
+`authentication.secondFactors` configures multi-factor authentication types. Possible values supported by this chart
+are `otp`, `sso`, and `webauthn`.
+
+`authentication.secondFactors` takes precedence over any value that is set in `authentication.secondFactor`.
+If `webauthn` is passed, the `authentication.webauthn` section can also be used.
+The configured `rp_id` defaults to `clusterName`.
+
+<Admonition type="warning">
+If you set `publicAddr` for users to access the cluster under a domain different
+to [`clusterName`](#clusterName), you must manually set the webauthn [Relying
+Party Identifier (RP
+ID)](https://www.w3.org/TR/webauthn-2/#relying-party-identifier). If you don't,
+RP ID will default to `clusterName` and users will fail to register second
+factors.
+
+You can do this by setting the value
+`auth.teleportConfig.auth_service.authentication.webauthn.rp_id`.
+
+RP ID must be both a valid domain, and part of the full domain users are connecting to.
+For example, if users are accessing the cluster with the domain
+"teleport.example.com", RP ID can be "teleport.example.com" or "example.com".
+
+Changing the RP ID will invalidate all already registered webauthn second factors.
+</Admonition>
+
 ### `authentication.webauthn`
 
 See [Harden your Cluster Against IdP Compromises](../../admin-guides/access-controls/guides/webauthn.mdx) for more details.

--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -302,12 +302,16 @@ Defaults to Teleport's binary default when empty: `best_effort`.
 
 ### `authentication.secondFactor`
 
+<Admonition type="warning">
+Deprecated, you should use [`authentication.secondFactors`](#authenticationsecondfactors) instead.
+</Admonition>
+
 | Type     | Default value | Required? | `teleport.yaml` equivalent                  |
 |----------|---------------|-----------|---------------------------------------------|
-| `string` | `otp`         | Yes       | `auth_service.authentication.second_factor` |
+| `string` | none          | Yes       | `auth_service.authentication.second_factor` |
 
-`authentication.secondFactor` configures multi-factor authentication for local users. Possible values supported by this chart
-are `on`, `otp`, and `webauthn`.
+`authentication.secondFactor` configures multi-factor authentication for local users.
+Possible values supported by this chart are `on`, `otp`, and `webauthn`.
 
 When set to `on` or `webauthn`, the `authenticationSecondFactor.webauthn` section can also be used.
 The configured `rp_id` defaults to `clusterName`.
@@ -332,12 +336,12 @@ Changing the RP ID will invalidate all already registered webauthn second factor
 
 ### `authentication.secondFactors`
 
-| Type     | Default value | Required? | `teleport.yaml` equivalent                  |
-|----------|---------------|-----------|---------------------------------------------|
-| `array`  | `[]`          | No        | `auth_service.authentication.second_factors` |
+| Type    | Default value         | Required? | `teleport.yaml` equivalent                   |
+|---------|-----------------------|-----------|----------------------------------------------|
+| `array` | `["otp", "webauthn"]` | No        | `auth_service.authentication.second_factors` |
 
-`authentication.secondFactors` configures multi-factor authentication types. Possible values supported by this chart
-are `otp`, `sso`, and `webauthn`.
+`authentication.secondFactors` configures multi-factor authentication types.
+Supported item values are `otp`, `sso`, and `webauthn`.
 
 `authentication.secondFactors` takes precedence over any value that is set in `authentication.secondFactor`.
 If `webauthn` is passed, the `authentication.webauthn` section can also be used.

--- a/examples/chart/CONTRIBUTING.md
+++ b/examples/chart/CONTRIBUTING.md
@@ -34,7 +34,7 @@ case. A good tip is to use your newly added linter file to set values appropriat
 3) Add any new values at the correct location in the `values.schema.json` file for the appropriate chart. This
 will ensure that Helm is able to validate values at install-time and can prevent users from making easy mistakes.
 
-4) Document any new values or changes to existing behaviour in the [chart reference](../../docs/pages/kubernetes-access/helm/reference).
+4) Document any new values or changes to existing behaviour in the [chart reference](../../docs/pages/reference/helm-reference).
 
 5) Run `make lint-helm test-helm` from the root of the repo before raising your PR.
 You will need `yamllint`, `helm` and [helm-unittest](https://github.com/quintush/helm-unittest) installed locally.

--- a/examples/chart/teleport-cluster/.lint/auth-secondfactors-sso.yaml
+++ b/examples/chart/teleport-cluster/.lint/auth-secondfactors-sso.yaml
@@ -1,0 +1,4 @@
+clusterName: helm-lint
+authentication:
+  secondFactors:
+    - sso

--- a/examples/chart/teleport-cluster/.lint/auth-secondfactors-webauthn.yaml
+++ b/examples/chart/teleport-cluster/.lint/auth-secondfactors-webauthn.yaml
@@ -1,0 +1,10 @@
+clusterName: helm-lint
+authentication:
+  secondFactors:
+    - sso
+    - webauthn
+  webauthn:
+    attestationAllowedCas:
+      - "/etc/ssl/certs/ca-certificates.crt"
+    attestationDeniedCas:
+      - "/etc/ssl/certs/ca-certificates.crt"

--- a/examples/chart/teleport-cluster/templates/auth/_config.common.tpl
+++ b/examples/chart/teleport-cluster/templates/auth/_config.common.tpl
@@ -36,19 +36,22 @@ auth_service:
 {{- if $authentication.lockingMode }}
     locking_mode: "{{ $authentication.lockingMode }}"
 {{- end }}
-{{- if $authentication.secondFactor }}
-    second_factor: "{{ $authentication.secondFactor }}"
-  {{- if not (or (eq $authentication.secondFactor "off") (eq $authentication.secondFactor "otp")) }}
+{{- if and (not (eq $authentication.secondFactor "off")) $authentication.secondFactors }}
+  {{- $secondFactors := (concat $authentication.secondFactors (without (list $authentication.secondFactor) "on" "optional")) -}}
+  {{- if $secondFactors }}
+    second_factors: {{- toYaml $secondFactors | nindent 6 }}
+  {{- end }}
+  {{- if has "webauthn" $secondFactors }}
     webauthn:
       rp_id: {{ required "clusterName is required in chart values" .Values.clusterName }}
-    {{- if $authentication.webauthn }}
-      {{- if $authentication.webauthn.attestationAllowedCas }}
+      {{- if $authentication.webauthn }}
+        {{- if $authentication.webauthn.attestationAllowedCas }}
       attestation_allowed_cas: {{- toYaml $authentication.webauthn.attestationAllowedCas | nindent 12 }}
-      {{- end }}
-      {{- if $authentication.webauthn.attestationDeniedCas }}
+        {{- end }}
+        {{- if $authentication.webauthn.attestationDeniedCas }}
       attestation_denied_cas: {{- toYaml $authentication.webauthn.attestationDeniedCas | nindent 12 }}
+        {{- end }}
       {{- end }}
-    {{- end }}
   {{- end }}
 {{- end }}
 {{- if .Values.sessionRecording }}

--- a/examples/chart/teleport-cluster/templates/auth/_config.common.tpl
+++ b/examples/chart/teleport-cluster/templates/auth/_config.common.tpl
@@ -37,14 +37,18 @@ auth_service:
     locking_mode: "{{ $authentication.lockingMode }}"
 {{- end }}
 {{- $hasWebauthnMFA := false }}
-{{- if $authentication.secondFactors }}
-    second_factors: {{- toYaml $authentication.secondFactors | nindent 6 }}
-    {{- if has "webauthn" $authentication.secondFactors }}
+{{/* secondFactor takes precedence for backward compatibility, but new chart releases
+should have second_factor unset and privilege second_factors instead.
+Sadly, it is not possible to do a conversion between second_factor and second_factors
+because of the "off" value. */}}
+{{- if $authentication.secondFactor }}
+    second_factor: {{ $authentication.secondFactor | squote }}
+    {{- if has $authentication.secondFactor (list "webauthn" "on" "optional") }}
       {{- $hasWebauthnMFA = true }}
     {{- end }}
 {{- else }}
-    second_factor: {{ $authentication.secondFactor | squote }}
-    {{- if has $authentication.secondFactor (list "webauthn" "on" "optional") }}
+    second_factors: {{- toYaml $authentication.secondFactors | nindent 6 }}
+    {{- if has "webauthn" $authentication.secondFactors }}
       {{- $hasWebauthnMFA = true }}
     {{- end }}
 {{- end }}

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
@@ -377,6 +377,81 @@ matches snapshot for auth-passwordless.yaml:
           output: stderr
           severity: INFO
       version: v3
+matches snapshot for auth-secondfactors-sso.yaml:
+  1: |
+    |-
+      auth_service:
+        authentication:
+          local_auth: true
+          second_factors:
+          - sso
+          type: local
+        cluster_name: helm-lint
+        enabled: true
+        proxy_listener_mode: separate
+      kubernetes_service:
+        enabled: true
+        kube_cluster_name: helm-lint
+        listen_addr: 0.0.0.0:3026
+        public_addr: RELEASE-NAME-auth.NAMESPACE.svc.cluster.local:3026
+      proxy_service:
+        enabled: false
+      ssh_service:
+        enabled: false
+      teleport:
+        auth_server: 127.0.0.1:3025
+        log:
+          format:
+            extra_fields:
+            - timestamp
+            - level
+            - component
+            - caller
+            output: text
+          output: stderr
+          severity: INFO
+      version: v3
+matches snapshot for auth-secondfactors-webauthn.yaml:
+  1: |
+    |-
+      auth_service:
+        authentication:
+          local_auth: true
+          second_factors:
+          - sso
+          - webauthn
+          type: local
+          webauthn:
+            attestation_allowed_cas:
+            - /etc/ssl/certs/ca-certificates.crt
+            attestation_denied_cas:
+            - /etc/ssl/certs/ca-certificates.crt
+            rp_id: helm-lint
+        cluster_name: helm-lint
+        enabled: true
+        proxy_listener_mode: separate
+      kubernetes_service:
+        enabled: true
+        kube_cluster_name: helm-lint
+        listen_addr: 0.0.0.0:3026
+        public_addr: RELEASE-NAME-auth.NAMESPACE.svc.cluster.local:3026
+      proxy_service:
+        enabled: false
+      ssh_service:
+        enabled: false
+      teleport:
+        auth_server: 127.0.0.1:3025
+        log:
+          format:
+            extra_fields:
+            - timestamp
+            - level
+            - component
+            - caller
+            output: text
+          output: stderr
+          severity: INFO
+      version: v3
 matches snapshot for auth-type-legacy.yaml:
   1: |
     |-

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
@@ -24,7 +24,9 @@ configures access monitoring when its values are set:
           workgroup: example_access_monitoring_workgroup
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: test-aws-cluster
@@ -101,7 +103,9 @@ keeps the session_recording type even when it's "off":
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: helm-lint
@@ -137,7 +141,9 @@ matches snapshot for acme-off.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: test-cluster-name
@@ -172,7 +178,9 @@ matches snapshot for acme-on.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: test-acme-cluster
@@ -207,7 +215,9 @@ matches snapshot for acme-uri-staging.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: test-acme-cluster
@@ -243,7 +253,9 @@ matches snapshot for auth-connector-name.yaml:
         authentication:
           connector_name: okta
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: helm-lint
@@ -312,7 +324,9 @@ matches snapshot for auth-locking-mode.yaml:
         authentication:
           local_auth: true
           locking_mode: strict
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: helm-lint
@@ -458,7 +472,9 @@ matches snapshot for auth-type-legacy.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: github
           webauthn:
             rp_id: helm-lint
@@ -493,7 +509,9 @@ matches snapshot for auth-type.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: github
           webauthn:
             rp_id: helm-lint
@@ -606,7 +624,9 @@ matches snapshot for aws-dynamodb-autoscaling.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: test-aws-cluster
@@ -657,7 +677,9 @@ matches snapshot for aws-ha-acme.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: test-aws-cluster
@@ -703,7 +725,9 @@ matches snapshot for aws-ha-antiaffinity.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: test-aws-cluster
@@ -749,7 +773,9 @@ matches snapshot for aws-ha-log.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: test-aws-cluster
@@ -796,7 +822,9 @@ matches snapshot for aws-ha.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: test-aws-cluster
@@ -842,7 +870,9 @@ matches snapshot for aws.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: test-aws-cluster
@@ -888,7 +918,9 @@ matches snapshot for azure.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: test-azure-cluster
@@ -931,7 +963,9 @@ matches snapshot for azure.yaml without pool_max_conn:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: test-azure-cluster
@@ -974,7 +1008,9 @@ matches snapshot for existing-tls-secret-with-ca.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: test-cluster-name
@@ -1009,7 +1045,9 @@ matches snapshot for existing-tls-secret.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: test-cluster-name
@@ -1044,7 +1082,9 @@ matches snapshot for gcp-ha-acme.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: test-gcp-cluster
@@ -1089,7 +1129,9 @@ matches snapshot for gcp-ha-antiaffinity.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: test-gcp-cluster
@@ -1134,7 +1176,9 @@ matches snapshot for gcp-ha-log.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: test-gcp-cluster
@@ -1180,7 +1224,9 @@ matches snapshot for gcp.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: test-gcp-cluster
@@ -1225,7 +1271,9 @@ matches snapshot for initcontainers.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: helm-lint
@@ -1260,7 +1308,9 @@ matches snapshot for kube-cluster-name.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: test-aws-cluster
@@ -1295,7 +1345,9 @@ matches snapshot for log-basic.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: test-log-cluster
@@ -1330,7 +1382,9 @@ matches snapshot for log-extra.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: test-log-cluster
@@ -1365,7 +1419,9 @@ matches snapshot for log-legacy.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: test-log-cluster
@@ -1400,7 +1456,9 @@ matches snapshot for priority-class-name.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: helm-lint
@@ -1435,7 +1493,9 @@ matches snapshot for proxy-listener-mode-multiplex.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: test-proxy-listener-mode
@@ -1470,7 +1530,9 @@ matches snapshot for proxy-listener-mode-separate.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: test-proxy-listener-mode
@@ -1505,7 +1567,9 @@ matches snapshot for public-addresses.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: helm-lint
@@ -1540,7 +1604,9 @@ matches snapshot for separate-mongo-listener.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: helm-lint
@@ -1575,7 +1641,9 @@ matches snapshot for separate-postgres-listener.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: helm-lint
@@ -1610,7 +1678,9 @@ matches snapshot for service.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: helm-lint
@@ -1645,7 +1715,9 @@ matches snapshot for session-recording.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: helm-lint
@@ -1681,7 +1753,9 @@ matches snapshot for standalone-customsize.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: test-standalone-cluster
@@ -1718,7 +1792,9 @@ matches snapshot for standalone-existingpvc.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: test-standalone-cluster
@@ -1755,7 +1831,9 @@ matches snapshot for tolerations.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: test-aws-cluster
@@ -1799,7 +1877,9 @@ matches snapshot for version-override.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: test-cluster-name
@@ -1837,10 +1917,45 @@ matches snapshot for volumes.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: helm-lint
+        cluster_name: helm-lint
+        enabled: true
+        proxy_listener_mode: separate
+      kubernetes_service:
+        enabled: true
+        kube_cluster_name: helm-lint
+        listen_addr: 0.0.0.0:3026
+        public_addr: RELEASE-NAME-auth.NAMESPACE.svc.cluster.local:3026
+      proxy_service:
+        enabled: false
+      ssh_service:
+        enabled: false
+      teleport:
+        auth_server: 127.0.0.1:3025
+        log:
+          format:
+            extra_fields:
+            - timestamp
+            - level
+            - component
+            - caller
+            output: text
+          output: stderr
+          severity: INFO
+      version: v3
+matches snapshot when both secondFactor and secondFactors are set.:
+  1: |
+    |-
+      auth_service:
+        authentication:
+          local_auth: true
+          second_factor: "off"
+          type: local
         cluster_name: helm-lint
         enabled: true
         proxy_listener_mode: separate
@@ -1887,7 +2002,9 @@ sets clusterDomain on Configmap:
         auth_service:
           authentication:
             local_auth: true
-            second_factor: "on"
+            second_factors:
+            - otp
+            - webauthn
             type: local
             webauthn:
               rp_id: teleport.example.com
@@ -1934,7 +2051,9 @@ uses athena as primary backend when configured:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: teleport.example.com
@@ -1979,7 +2098,9 @@ uses athena, dynamo, and stdout when everything is on:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: teleport.example.com
@@ -2025,7 +2146,9 @@ uses dynamo as primary backend when configured:
       auth_service:
         authentication:
           local_auth: true
-          second_factor: "on"
+          second_factors:
+          - otp
+          - webauthn
           type: local
           webauthn:
             rp_id: teleport.example.com

--- a/examples/chart/teleport-cluster/tests/auth_config_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_config_test.yaml
@@ -698,3 +698,25 @@ tests:
       - matchRegex:
           path: data.teleport\.yaml
           pattern: 'svc.test.com:3026'
+
+  - it: matches snapshot for auth-secondfactors-webauthn.yaml
+    values:
+      - ../.lint/auth-secondfactors-webauthn.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data.teleport\.yaml
+
+  - it: matches snapshot for auth-secondfactors-sso.yaml
+    values:
+      - ../.lint/auth-secondfactors-sso.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data.teleport\.yaml

--- a/examples/chart/teleport-cluster/tests/auth_config_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_config_test.yaml
@@ -720,3 +720,17 @@ tests:
           of: ConfigMap
       - matchSnapshot:
           path: data.teleport\.yaml
+
+  - it: matches snapshot when both secondFactor and secondFactors are set.
+    set:
+      clusterName: helm-lint
+      authentication:
+        secondFactor: "off"
+        secondFactors: ["otp", "webauthn"]
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data.teleport\.yaml

--- a/examples/chart/teleport-cluster/values.schema.json
+++ b/examples/chart/teleport-cluster/values.schema.json
@@ -126,6 +126,19 @@
                     ],
                     "default": "otp"
                 },
+                "secondFactors": {
+                    "$id": "#/properties/authentication/properties/secondFactors",
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "otp",
+                            "sso",
+                            "webauthn"
+                        ]
+                    },
+                    "default": []
+                },
                 "webauthn": {
                     "$id": "#/properties/authentication/properties/webauthn",
                     "type": "object",

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -150,6 +150,27 @@ authentication:
   #   Changing the RP ID will invalidate all already registered webauthn second factors.
   secondFactor: "on"
 
+  # Second factor requirements for users of the Teleport cluster.
+  # Controls the `auth_config.authentication.second_factors` field in `teleport.yaml`.
+  # Possible values are 'otp', 'sso' and 'webauthn'.
+  #
+  # WARNING:
+  #   If you set `publicAddr` for users to access the cluster under a domain different
+  #   to clusterName you must manually set the webauthn Relying
+  #   Party Identifier (RP ID) - https://www.w3.org/TR/webauthn-2/#relying-party-identifier
+  #   If you don't, RP ID will default to `clusterName` and users will fail
+  #   to register second factors.
+  #
+  #   You can do this by setting the value
+  #   `auth.teleportConfig.auth_service.authentication.webauthn.rp_id`.
+  #
+  #   RP ID must be both a valid domain, and part of the full domain users are connecting to.
+  #   For example, if users are accessing the cluster with the domain
+  #   "teleport.example.com", RP ID can be "teleport.example.com" or "example.com".
+  #
+  #   Changing the RP ID will invalidate all already registered webauthn second factors.
+  secondFactors: []
+
   # (Optional) When using webauthn this allows to restrict which vendor and key models can be used.
   # webauthn:
   #   attestationAllowedCas:

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -129,9 +129,11 @@ authentication:
   # See https://goteleport.com/docs/access-controls/guides/locking/#next-steps-locking-modes.
   lockingMode: ""
 
-  # Second factor requirements for users of the Teleport cluster.
+  # DEPRECATED: Second factor requirements for users of the Teleport cluster.
   # Controls the `auth_config.authentication.second_factor` field in `teleport.yaml`.
   # Possible values are 'off', 'on', 'otp', 'optional' and 'webauthn'.
+  # This field is kept for backward compatibility purposes, you should use
+  # `secondFactors` instead.
   #
   # WARNING:
   #   If you set `publicAddr` for users to access the cluster under a domain different
@@ -148,11 +150,12 @@ authentication:
   #   "teleport.example.com", RP ID can be "teleport.example.com" or "example.com".
   #
   #   Changing the RP ID will invalidate all already registered webauthn second factors.
-  secondFactor: "on"
+  # secondFactor: ""
 
   # Second factor requirements for users of the Teleport cluster.
   # Controls the `auth_config.authentication.second_factors` field in `teleport.yaml`.
-  # Possible values are 'otp', 'sso' and 'webauthn'.
+  # This is a list whose possible item values are item values are 'otp', 'sso' and 'webauthn'.
+  # This should be preferred over `secondFactor`.
   #
   # WARNING:
   #   If you set `publicAddr` for users to access the cluster under a domain different
@@ -169,7 +172,7 @@ authentication:
   #   "teleport.example.com", RP ID can be "teleport.example.com" or "example.com".
   #
   #   Changing the RP ID will invalidate all already registered webauthn second factors.
-  secondFactors: []
+  secondFactors: ["otp", "webauthn"]
 
   # (Optional) When using webauthn this allows to restrict which vendor and key models can be used.
   # webauthn:


### PR DESCRIPTION
Buddy PR for https://github.com/gravitational/teleport/pull/52712

This PR allows users to configure `second_factors` (different from `second_factor`). Sadly `second_factor` cannot always be translated to `second_factors`, so we have to keep both 🫠 .

The chart now uses `secondFactors` by default. I deprecated `secondFactor` and might remove references to the value in the future. If `secondFactor` is set, it still takes precedence over `secondFactors` to ensure backward compatibility.

Changelog: Helm chart now supports specifying a second factor list, this simplifies setting up SSO MFA with the `teleport-cluster` chart.

