### PR TITLE
[v17] helm: add topology spread constraints

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -1687,6 +1687,42 @@ Kubernetes affinity to set for pod assignments.
             - teleport
   ```
 
+## `disableTopologySpreadConstraints`
+
+| Type      | Default value | Required? |
+|-----------|---------------|-----------|
+| `boolean` | `false`       | No        |
+
+Turns off the topology spread constraints.
+The feature is automatically turned off on Kubernetes versions below 1.18.
+
+## `topologySpreadConstraints`
+
+| Type   | Default value   | Required? |
+|--------|-----------------|-----------|
+| `list` | see description | No        |
+
+Configures custom [Pod topology spread constraints
+](https://kubernetes.io/fr/docs/concepts/workloads/pods/pod-topology-spread-constraints/)
+
+When unset, the chart defaults to a soft topology spread constraint
+that tries to spread pods across hosts and zones.
+
+Default value:
+```
+topologySpreadConstraints
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels: # dynamically computed
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels: # dynamically computed
+```
+
 ## `annotations`
 ### `annotations.config`
 

--- a/examples/chart/teleport-cluster/templates/auth/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/deployment.yaml
@@ -1,6 +1,7 @@
 {{- $auth := mustMergeOverwrite (mustDeepCopy .Values) .Values.auth -}}
 {{- $replicated := gt (int $auth.highAvailability.replicaCount) 1 -}}
 {{- $projectedServiceAccountToken := semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version }}
+{{- $topologySpreadConstraints := and (semverCompare ">=1.18.0-0" .Capabilities.KubeVersion.Version) (not $auth.disableTopologySpreadConstraints) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -55,6 +56,23 @@ spec:
     spec:
 {{- if $auth.nodeSelector }}
       nodeSelector: {{- toYaml $auth.nodeSelector | nindent 8 }}
+{{- end }}
+{{- if $topologySpreadConstraints }}
+  {{- if $auth.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- toYaml $auth.topologySpreadConstraints | nindent 8 }}
+  {{- else }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: {{- include "teleport-cluster.auth.selectorLabels" . | nindent 14 }}
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: {{- include "teleport-cluster.auth.selectorLabels" . | nindent 14 }}
+  {{- end }}
 {{- end }}
       affinity:
 {{- if $auth.affinity }}

--- a/examples/chart/teleport-cluster/templates/proxy/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/deployment.yaml
@@ -1,6 +1,7 @@
 {{- $proxy := mustMergeOverwrite (mustDeepCopy .Values) .Values.proxy -}}
 {{- $replicable := or $proxy.highAvailability.certManager.enabled $proxy.tls.existingSecretName $proxy.ingress.enabled -}}
 {{- $projectedServiceAccountToken := semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version }}
+{{- $topologySpreadConstraints := and (semverCompare ">=1.18.0-0" .Capabilities.KubeVersion.Version) (not $proxy.disableTopologySpreadConstraints) }}
 # Deployment is {{ if not $replicable }}not {{end}}replicable
 {{- if and $proxy.highAvailability.certManager.enabled $proxy.tls.existingSecretName }}
 {{- fail "Cannot set both highAvailability.certManager.enabled and tls.existingSecretName, choose one or the other" }}
@@ -61,6 +62,23 @@ spec:
     spec:
 {{- if $proxy.nodeSelector }}
       nodeSelector: {{- toYaml $proxy.nodeSelector | nindent 8 }}
+{{- end }}
+{{- if $topologySpreadConstraints }}
+  {{- if $proxy.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- toYaml $proxy.topologySpreadConstraints | nindent 8 }}
+  {{- else }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: {{- include "teleport-cluster.proxy.selectorLabels" . | nindent 14 }}
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: {{- include "teleport-cluster.proxy.selectorLabels" . | nindent 14 }}
+  {{- end }}
 {{- end }}
       affinity:
 {{- if $proxy.affinity }}

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
@@ -57,6 +57,23 @@
         readOnly: true
     serviceAccountName: RELEASE-NAME
     terminationGracePeriodSeconds: 60
+    topologySpreadConstraints:
+    - labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: auth
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: teleport-cluster
+      maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+    - labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: auth
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: teleport-cluster
+      maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
     volumes:
     - name: auth-serviceaccount-token
       projected:
@@ -194,6 +211,23 @@ should set nodeSelector when set in values:
       role: bastion
     serviceAccountName: RELEASE-NAME
     terminationGracePeriodSeconds: 60
+    topologySpreadConstraints:
+    - labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: auth
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: teleport-cluster
+      maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+    - labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: auth
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: teleport-cluster
+      maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
     volumes:
     - name: auth-serviceaccount-token
       projected:
@@ -296,6 +330,23 @@ should set resources when set in values:
         readOnly: true
     serviceAccountName: RELEASE-NAME
     terminationGracePeriodSeconds: 60
+    topologySpreadConstraints:
+    - labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: auth
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: teleport-cluster
+      maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+    - labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: auth
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: teleport-cluster
+      maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
     volumes:
     - name: auth-serviceaccount-token
       projected:
@@ -383,6 +434,23 @@ should set securityContext when set in values:
         readOnly: true
     serviceAccountName: RELEASE-NAME
     terminationGracePeriodSeconds: 60
+    topologySpreadConstraints:
+    - labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: auth
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: teleport-cluster
+      maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+    - labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: auth
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: teleport-cluster
+      maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
     volumes:
     - name: auth-serviceaccount-token
       projected:
@@ -473,6 +541,23 @@ should use OSS image and not mount license when enterprise is not set in values:
         readOnly: true
     serviceAccountName: RELEASE-NAME
     terminationGracePeriodSeconds: 60
+    topologySpreadConstraints:
+    - labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: auth
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: teleport-cluster
+      maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+    - labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: auth
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: teleport-cluster
+      maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
     volumes:
     - name: auth-serviceaccount-token
       projected:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
@@ -110,6 +110,23 @@ sets clusterDomain on Deployment Pods:
             name: wait-auth-update
           serviceAccountName: RELEASE-NAME-proxy
           terminationGracePeriodSeconds: 60
+          topologySpreadConstraints:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: proxy
+                app.kubernetes.io/instance: RELEASE-NAME
+                app.kubernetes.io/name: teleport-cluster
+            maxSkew: 1
+            topologyKey: kubernetes.io/hostname
+            whenUnsatisfiable: ScheduleAnyway
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: proxy
+                app.kubernetes.io/instance: RELEASE-NAME
+                app.kubernetes.io/name: teleport-cluster
+            maxSkew: 1
+            topologyKey: topology.kubernetes.io/zone
+            whenUnsatisfiable: ScheduleAnyway
           volumes:
           - name: proxy-serviceaccount-token
             projected:
@@ -271,6 +288,23 @@ should set nodeSelector when set in values:
       role: bastion
     serviceAccountName: RELEASE-NAME-proxy
     terminationGracePeriodSeconds: 60
+    topologySpreadConstraints:
+    - labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: proxy
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: teleport-cluster
+      maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+    - labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: proxy
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: teleport-cluster
+      maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
     volumes:
     - name: proxy-serviceaccount-token
       projected:
@@ -395,6 +429,23 @@ should set resources for wait-auth-update initContainer when set in values:
           memory: 256Mi
     serviceAccountName: RELEASE-NAME-proxy
     terminationGracePeriodSeconds: 60
+    topologySpreadConstraints:
+    - labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: proxy
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: teleport-cluster
+      maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+    - labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: proxy
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: teleport-cluster
+      maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
     volumes:
     - name: proxy-serviceaccount-token
       projected:
@@ -504,6 +555,23 @@ should set resources when set in values:
           memory: 256Mi
     serviceAccountName: RELEASE-NAME-proxy
     terminationGracePeriodSeconds: 60
+    topologySpreadConstraints:
+    - labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: proxy
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: teleport-cluster
+      maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+    - labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: proxy
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: teleport-cluster
+      maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
     volumes:
     - name: proxy-serviceaccount-token
       projected:
@@ -613,6 +681,23 @@ should set securityContext for initContainers when set in values:
         runAsUser: 99
     serviceAccountName: RELEASE-NAME-proxy
     terminationGracePeriodSeconds: 60
+    topologySpreadConstraints:
+    - labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: proxy
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: teleport-cluster
+      maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+    - labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: proxy
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: teleport-cluster
+      maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
     volumes:
     - name: proxy-serviceaccount-token
       projected:
@@ -722,6 +807,23 @@ should set securityContext when set in values:
         runAsUser: 99
     serviceAccountName: RELEASE-NAME-proxy
     terminationGracePeriodSeconds: 60
+    topologySpreadConstraints:
+    - labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: proxy
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: teleport-cluster
+      maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+    - labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: proxy
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: teleport-cluster
+      maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
     volumes:
     - name: proxy-serviceaccount-token
       projected:

--- a/examples/chart/teleport-cluster/tests/auth_deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_deployment_test.yaml
@@ -950,3 +950,74 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
           value: 13
+
+  - it: sets topology spread constraints by default
+    template: auth/deployment.yaml
+    set:
+      clusterName: helm-lint
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints
+          value:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: ScheduleAnyway
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: auth
+                  app.kubernetes.io/instance: RELEASE-NAME
+                  app.kubernetes.io/name: teleport-cluster
+            - maxSkew: 1
+              topologyKey: topology.kubernetes.io/zone
+              whenUnsatisfiable: ScheduleAnyway
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: auth
+                  app.kubernetes.io/instance: RELEASE-NAME
+                  app.kubernetes.io/name: teleport-cluster
+
+  - it: removes topology spread constraints when disabled
+    template: auth/deployment.yaml
+    set:
+      clusterName: helm-lint
+      disableTopologySpreadConstraints: true
+    asserts:
+      - isEmpty:
+          path: spec.template.spec.topologySpreadConstraints
+
+  - it: removes topology spread constraints when running on antique kubernetes
+    template: auth/deployment.yaml
+    set:
+      clusterName: helm-lint
+    capabilities:
+      majorVersion: 1
+      minorVersion: 17
+    asserts:
+      - isEmpty:
+          path: spec.template.spec.topologySpreadConstraints
+
+  - it: uses custom topology spread constraints when set
+    template: auth/deployment.yaml
+    set:
+      clusterName: helm-lint
+      topologySpreadConstraints:
+        - maxSkew: 2
+          topologyKey: foobar
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: baz
+    # helm unit-test has a bug where capabilities are not reset between tests, we must set back to 1.18 after the 1.17 test.
+    capabilities:
+      majorVersion: 1
+      minorVersion: 18
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints
+          value:
+            - maxSkew: 2
+              topologyKey: foobar
+              whenUnsatisfiable: ScheduleAnyway
+              labelSelector:
+                matchLabels:
+                  app: baz

--- a/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
@@ -1069,3 +1069,74 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
           value: 13
+
+  - it: sets topology spread constraints by default
+    template: proxy/deployment.yaml
+    set:
+      clusterName: helm-lint
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints
+          value:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: ScheduleAnyway
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: proxy
+                  app.kubernetes.io/instance: RELEASE-NAME
+                  app.kubernetes.io/name: teleport-cluster
+            - maxSkew: 1
+              topologyKey: topology.kubernetes.io/zone
+              whenUnsatisfiable: ScheduleAnyway
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: proxy
+                  app.kubernetes.io/instance: RELEASE-NAME
+                  app.kubernetes.io/name: teleport-cluster
+
+  - it: removes topology spread constraints when disabled
+    template: proxy/deployment.yaml
+    set:
+      clusterName: helm-lint
+      disableTopologySpreadConstraints: true
+    asserts:
+      - isEmpty:
+          path: spec.template.spec.topologySpreadConstraints
+
+  - it: removes topology spread constraints when running on antique kubernetes
+    template: proxy/deployment.yaml
+    set:
+      clusterName: helm-lint
+    capabilities:
+      majorVersion: 1
+      minorVersion: 17
+    asserts:
+      - isEmpty:
+          path: spec.template.spec.topologySpreadConstraints
+
+  - it: uses custom topology spread constraints when set
+    template: proxy/deployment.yaml
+    set:
+      clusterName: helm-lint
+      topologySpreadConstraints:
+        - maxSkew: 2
+          topologyKey: foobar
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: baz
+    # helm unit-test has a bug where capabilities are not reset between tests, we must set back to 1.18 after the 1.17 test.
+    capabilities:
+      majorVersion: 1
+      minorVersion: 18
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints
+          value:
+            - maxSkew: 2
+              topologyKey: foobar
+              whenUnsatisfiable: ScheduleAnyway
+              labelSelector:
+                matchLabels:
+                  app: baz

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -604,6 +604,30 @@ log:
 # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
 nodeSelector: {}
 
+# Turns off the topology spread constraints.
+# The feature is automatically turned off on Kubernetes versions below 1.18.
+disableTopologySpreadConstraints: false
+
+# Pod topology spread constraints:
+# https://kubernetes.io/fr/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+# When unset, the chart defaults to a soft topology spread constraint
+# that tries to spread pods across hosts and zones.
+#
+# ```
+# topologySpreadConstraints
+#   - maxSkew: 1
+#     topologyKey: kubernetes.io/hostname
+#     whenUnsatisfiable: ScheduleAnyway
+#     labelSelector:
+#       matchLabels: # dynamically computed
+#   - maxSkew: 1
+#     topologyKey: topology.kubernetes.io/zone
+#     whenUnsatisfiable: ScheduleAnyway
+#     labelSelector:
+#       matchLabels: # dynamically computed
+# ```
+topologySpreadConstraints: []
+
 # Affinity for pod assignment
 # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 # NOTE: If affinity is set here, highAvailability.requireAntiAffinity cannot also be used - you can only set one or the other.


### PR DESCRIPTION
Backport #53276 to branch/v17

changelog: Add support for topologySpreadConstraints to the `teleport-cluster` Helm chart.
changelog: The `teleport-cluster` Helm chart now tries to spread pods across hosts and zones.
