### PR TITLE
aws oidc ux updates

### DIFF
--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.test.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.test.tsx
@@ -188,18 +188,12 @@ test('renders enroll cards', () => {
   );
 
   expect(
-    within(screen.getByTestId('ec2-enroll')).getByRole('link', {
-      name: 'Enroll EC2',
-    })
+    within(screen.getByTestId('ec2-enroll')).getByText('Enroll EC2')
   ).toBeInTheDocument();
   expect(
-    within(screen.getByTestId('rds-enroll')).getByRole('link', {
-      name: 'Enroll RDS',
-    })
+    within(screen.getByTestId('rds-enroll')).getByText('Enroll RDS')
   ).toBeInTheDocument();
   expect(
-    within(screen.getByTestId('eks-enroll')).getByRole('link', {
-      name: 'Enroll EKS',
-    })
+    within(screen.getByTestId('eks-enroll')).getByText('Enroll EKS')
   ).toBeInTheDocument();
 });

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Box, Flex, H2, Indicator } from 'design';
+import { Box, Flex, Indicator } from 'design';
 import { Danger } from 'design/Alert';
 
 import { FeatureBox } from 'teleport/components/Layout';
@@ -70,23 +70,24 @@ export function AwsOidcDashboard() {
             />
           </>
         )}
-
-        <H2 my={3}>Auto-Enrollment</H2>
         <Flex gap={3}>
           <StatCard
             name={integration.name}
+            item="instances"
             resource={AwsResource.ec2}
             summary={awsec2}
           />
           <StatCard
             name={integration.name}
-            resource={AwsResource.eks}
-            summary={awseks}
+            item="databases"
+            resource={AwsResource.rds}
+            summary={awsrds}
           />
           <StatCard
             name={integration.name}
-            resource={AwsResource.rds}
-            summary={awsrds}
+            item="clusters"
+            resource={AwsResource.eks}
+            summary={awseks}
           />
         </Flex>
       </FeatureBox>

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcTitle.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcTitle.tsx
@@ -17,8 +17,9 @@
  */
 import { useHistory } from 'react-router';
 import { Link as InternalLink } from 'react-router-dom';
+import { useTheme } from 'styled-components';
 
-import { ButtonIcon, Flex, Label, MenuItem, Text } from 'design';
+import { ButtonIcon, Flex, Label, Link, MenuItem, Text } from 'design';
 import * as Icons from 'design/Icon';
 import { ArrowLeft } from 'design/Icon';
 import { HoverTooltip } from 'design/Tooltip';
@@ -43,6 +44,7 @@ export function AwsOidcTitle({
   resource?: AwsResource;
   tasks?: boolean;
 }) {
+  const theme = useTheme();
   const history = useHistory();
   const integrationOps = useIntegrationOperation();
   const { status, labelKind } = getStatusAndLabel(integration);
@@ -67,15 +69,32 @@ export function AwsOidcTitle({
             <ArrowLeft size="medium" />
           </ButtonIcon>
         </HoverTooltip>
-        <Text bold fontSize={6} mx={2}>
-          {content.content}
-        </Text>
+        <Flex flexDirection="column" mx={2}>
+          <Text bold fontSize={6}>
+            {content.content}
+          </Text>
+          <Flex gap={1}>
+            Role ARN:{' '}
+            <Link
+              target="_blank"
+              href={`https://console.aws.amazon.com/iamv2/home#/roles/details/${integration.name}`}
+            >
+              <Text
+                style={{
+                  fontFamily: theme.fonts.mono,
+                }}
+              >
+                {integration.spec?.roleArn}
+              </Text>
+            </Link>
+          </Flex>
+        </Flex>
         <Label kind={labelKind} aria-label="status" px={3}>
           {status}
         </Label>
       </Flex>
       {!resource && !tasks && (
-        <MenuButton icon={<Icons.Cog />}>
+        <MenuButton icon={<Icons.Cog size="small" />}>
           <MenuItem onClick={() => integrationOps.onEdit(integration)}>
             Edit...
           </MenuItem>

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Agents.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Agents.tsx
@@ -18,12 +18,14 @@
 
 import { useEffect } from 'react';
 import { useParams } from 'react-router';
+import { Link as InternalLink } from 'react-router-dom';
 
-import { Box, Indicator } from 'design';
+import { Box, ButtonPrimary, Indicator } from 'design';
 import { Danger } from 'design/Alert';
 import Table, { LabelCell } from 'design/DataTable';
 import { useAsync } from 'shared/hooks/useAsync';
 
+import cfg from 'teleport/config';
 import { AwsResource } from 'teleport/Integrations/status/AwsOidc/StatCard';
 import {
   AWSOIDCDeployedDatabaseService,
@@ -76,7 +78,19 @@ export function Agents() {
             ),
           },
         ]}
-        emptyText={`No ${resourceKind.toUpperCase()} agents`}
+        emptyText={`No ${resourceKind.toUpperCase()} Agents Found`}
+        emptyButton={
+          <ButtonPrimary
+            as={InternalLink}
+            to={{
+              pathname: cfg.routes.discover,
+              state: { searchKeywords: resourceKind },
+            }}
+          >
+            Add Enrollment Rule
+          </ButtonPrimary>
+        }
+        emptyHint="Set up Teleport Discovery service to monitor the dynamic [db] resources registered by the discovery services"
       />
     </>
   );

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Rules.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Rules.tsx
@@ -18,10 +18,13 @@
 
 import { useEffect } from 'react';
 import { useParams } from 'react-router';
+import { Link as InternalLink } from 'react-router-dom';
 
+import { ButtonPrimary } from 'design';
 import Table, { LabelCell } from 'design/DataTable';
 
 import { useServerSidePagination } from 'teleport/components/hooks';
+import cfg from 'teleport/config';
 import { AwsResource } from 'teleport/Integrations/status/AwsOidc/StatCard';
 import {
   IntegrationDiscoveryRule,
@@ -68,7 +71,22 @@ export function Rules() {
           ),
         },
       ]}
-      emptyText={`No ${resourceKind.toUpperCase()} rules`}
+      emptyText={`No ${resourceKind.toUpperCase()} Rules Found`}
+      emptyHint={
+        resourceKind === AwsResource.rds &&
+        'Discover AWS-hosted databases automatically and register them with your Teleport cluster'
+      }
+      emptyButton={
+        <ButtonPrimary
+          as={InternalLink}
+          to={{
+            pathname: cfg.routes.discover,
+            state: { searchKeywords: resourceKind },
+          }}
+        >
+          Add Enrollment Rule
+        </ButtonPrimary>
+      }
       pagination={{ pageSize: serverSidePagination.pageSize }}
       fetching={{
         fetchStatus: serverSidePagination.fetchStatus,

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/EnrollCard.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/EnrollCard.tsx
@@ -15,33 +15,45 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 import { Link as InternalLink } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { ButtonSecondary, Card, Flex, H2, ResourceIcon } from 'design';
+import { Box, Card, Flex, H2, H3, P2, ResourceIcon } from 'design';
+import * as Icons from 'design/Icon';
 
 import cfg from 'teleport/config';
 import { AwsResource } from 'teleport/Integrations/status/AwsOidc/StatCard';
 
-export function EnrollCard({ resource }: { resource: AwsResource }) {
+export function EnrollCard({
+  resource,
+  item,
+}: {
+  resource: AwsResource;
+  item: string;
+}) {
   return (
-    <Enroll data-testid={`${resource}-enroll`}>
-      <Flex flexDirection="column" gap={4}>
-        <Flex alignItems="center">
-          <ResourceIcon name={resource} mr={2} width="32px" height="32px" />
-          <H2>{resource.toUpperCase()}</H2>
+    <Enroll
+      data-testid={`${resource}-enroll`}
+      as={InternalLink}
+      to={{
+        pathname: cfg.routes.discover,
+        state: { searchKeywords: resource },
+      }}
+    >
+      <Flex flexDirection="column" justifyContent="space-between" height="100%">
+        <Box>
+          <Flex alignItems="center">
+            <ResourceIcon name={resource} mr={2} width="32px" height="32px" />
+            <H2>{resource.toUpperCase()}</H2>
+          </Flex>
+          <P2 mb={2}>
+            Discover and enroll {resource.toUpperCase()} {item}
+          </P2>
+        </Box>
+        <Flex alignItems="center" gap={2}>
+          <H3>Enroll {resource.toUpperCase()}</H3>
+          <Icons.ArrowForward />
         </Flex>
-        <ButtonSecondary
-          width="136px"
-          as={InternalLink}
-          to={{
-            pathname: cfg.routes.discover,
-            state: { searchKeywords: resource },
-          }}
-        >
-          Enroll {resource.toUpperCase()}
-        </ButtonSecondary>
       </Flex>
     </Enroll>
   );
@@ -53,6 +65,9 @@ const Enroll = styled(Card)`
   padding: ${props => props.theme.space[3]}px;
   border-radius: ${props => props.theme.radii[2]}px;
   border: ${props => `1px solid ${props.theme.colors.levels.surface}`};
+  cursor: pointer;
+  text-decoration: none;
+  color: ${props => props.theme.colors.text.main};
 
   &:hover {
     background-color: ${props => props.theme.colors.levels.elevated};

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/StatCard.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/StatCard.tsx
@@ -20,7 +20,7 @@ import { formatDistanceStrict } from 'date-fns';
 import { Link as InternalLink } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { Card, Flex, H2, Text } from 'design';
+import { Card, Flex, H2, P2, Text } from 'design';
 import * as Icons from 'design/Icon';
 import { ResourceIcon } from 'design/ResourceIcon';
 
@@ -37,20 +37,23 @@ export enum AwsResource {
   rds = 'rds',
 }
 
+type Item = 'clusters' | 'databases' | 'instances';
+
 type StatCardProps = {
   name: string;
+  item: Item;
   resource: AwsResource;
   summary?: ResourceTypeSummary;
 };
 
-export function StatCard({ name, resource, summary }: StatCardProps) {
+export function StatCard({ name, item, resource, summary }: StatCardProps) {
   const updated = summary?.discoverLastSync
     ? new Date(summary?.discoverLastSync)
     : undefined;
   const term = getResourceTerm(resource);
 
   if (!summary || !foundResource(summary)) {
-    return <EnrollCard resource={resource} />;
+    return <EnrollCard resource={resource} item={item} />;
   }
 
   return (
@@ -69,10 +72,14 @@ export function StatCard({ name, resource, summary }: StatCardProps) {
         minHeight="220px"
       >
         <Flex flexDirection="column" gap={2}>
-          <Flex alignItems="center" mb={2}>
+          <Flex alignItems="center">
             <ResourceIcon name={resource} mr={2} width="32px" height="32px" />
             <H2>{resource.toUpperCase()}</H2>
           </Flex>
+          <P2 mb={2}>
+            Auto enrolled {resource.toUpperCase()} {item} matching configured
+            labels
+          </P2>
           <Flex justifyContent="space-between" data-testid="rules">
             <Text>Enrollment Rules </Text>
             <Text>{summary?.rulesCount || 0}</Text>

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Task.test.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Task.test.tsx
@@ -41,27 +41,27 @@ test('renders ec2 impacts', async () => {
     discoverRds: undefined,
     discoverEc2: {
       region: 'us-east-2',
-      accountId: undefined,
-      ssmDocument: undefined,
-      installerScript: undefined,
+      account_id: undefined,
+      ssm_document: undefined,
+      installer_script: undefined,
       instances: {
         'i-016e32a5882f5ee81': {
           instance_id: 'i-016e32a5882f5ee81',
           resourceUrl: '',
           name: undefined,
-          invocationUrl: undefined,
-          discoveryConfig: undefined,
-          discoveryGroup: undefined,
-          syncTime: undefined,
+          invocation_url: 'some-run-url',
+          discovery_config: undefined,
+          discovery_group: undefined,
+          sync_time: undefined,
         },
         'i-065818031835365cc': {
           instance_id: 'i-065818031835365cc',
           resourceUrl: '',
           name: 'aws-test',
-          invocationUrl: undefined,
-          discoveryConfig: undefined,
-          discoveryGroup: undefined,
-          syncTime: undefined,
+          invocation_url: undefined,
+          discovery_config: undefined,
+          discovery_group: undefined,
+          sync_time: undefined,
         },
       },
     },
@@ -76,12 +76,11 @@ test('renders ec2 impacts', async () => {
   await screen.findByText('Details');
 
   expect(getTableCellContents()).toEqual({
-    header: ['Instance ID', 'Instance Name'],
-    rows: [
-      ['i-016e32a5882f5ee81', ''],
-      ['i-065818031835365cc', 'aws-test'],
-    ],
+    header: ['Instances', 'Invocation Link'],
+    rows: [['i-016e32a5882f5ee81', ''], ['i-065818031835365ccaws-test']],
   });
+
+  expect(screen.getByRole('link')).toHaveAttribute('href', 'some-run-url');
 
   jest.resetAllMocks();
 });
@@ -101,23 +100,23 @@ test('renders eks impacts', async () => {
     discoverEc2: undefined,
     discoverRds: undefined,
     discoverEks: {
-      accountId: undefined,
+      account_id: undefined,
       region: undefined,
-      appAutoDiscover: false,
+      app_auto_discover: false,
       clusters: {
         'i-016e32a5882f5ee81': {
           name: 'i-016e32a5882f5ee81',
           resourceUrl: '',
-          discoveryConfig: undefined,
-          discoveryGroup: undefined,
-          syncTime: undefined,
+          discovery_config: undefined,
+          discovery_group: undefined,
+          sync_time: undefined,
         },
         'i-065818031835365cc': {
           name: 'i-065818031835365cc',
           resourceUrl: '',
-          discoveryConfig: undefined,
-          discoveryGroup: undefined,
-          syncTime: undefined,
+          discovery_config: undefined,
+          discovery_group: undefined,
+          sync_time: undefined,
         },
       },
     },
@@ -153,26 +152,26 @@ test('renders rds impacts', async () => {
     discoverEks: undefined,
     discoverEc2: undefined,
     discoverRds: {
-      accountId: undefined,
+      account_id: undefined,
       region: undefined,
       databases: {
         'i-016e32a5882f5ee81': {
           name: 'i-016e32a5882f5ee81',
           resourceUrl: '',
-          isCluster: undefined,
+          is_cluster: undefined,
           engine: undefined,
-          discoveryConfig: undefined,
-          discoveryGroup: undefined,
-          syncTime: undefined,
+          discovery_config: undefined,
+          discovery_group: undefined,
+          sync_time: undefined,
         },
         'i-065818031835365cc': {
           name: 'i-065818031835365cc',
           resourceUrl: '',
-          isCluster: undefined,
+          is_cluster: undefined,
           engine: undefined,
-          discoveryConfig: undefined,
-          discoveryGroup: undefined,
-          syncTime: undefined,
+          discovery_config: undefined,
+          discovery_group: undefined,
+          sync_time: undefined,
         },
       },
     },

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Task.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Task.tsx
@@ -18,13 +18,21 @@
 
 import { PropsWithChildren, useEffect } from 'react';
 import ReactMarkdown from 'react-markdown';
-import { useTheme } from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 
-import { Alert, ButtonBorder, Link as ExternalLink, Flex, H2 } from 'design';
+import {
+  Alert,
+  Button,
+  ButtonBorder,
+  Link as ExternalLink,
+  Flex,
+  H2,
+} from 'design';
 import { Danger } from 'design/Alert';
 import Table, { Cell } from 'design/DataTable';
 import { TableColumn } from 'design/DataTable/types';
-import { H3, P2, Subtitle2 } from 'design/Text';
+import * as Icons from 'design/Icon';
+import { H3, P2, P3, Subtitle2 } from 'design/Text';
 import { Attempt, useAsync } from 'shared/hooks/useAsync';
 import useAttempt from 'shared/hooks/useAttemptNext';
 import { getErrMessage } from 'shared/utils/errorType';
@@ -191,6 +199,7 @@ type TableInstance = {
   instanceId?: string;
   name: string;
   resourceUrl?: string;
+  invocationUrl?: string;
 };
 
 function makeImpactsTable(instances: ImpactedInstances): {
@@ -204,28 +213,43 @@ function makeImpactsTable(instances: ImpactedInstances): {
         columns: [
           {
             key: 'instanceId',
-            headerText: 'Instance ID',
+            headerText: 'Instances',
             render: item => {
-              return item.resourceUrl ? (
+              return (
                 <Cell>
-                  <ExternalLink href={item.resourceUrl} target="_blank">
-                    {item.instanceId}
-                  </ExternalLink>
+                  <Flex flexDirection="column">
+                    <P3>{item.instanceId}</P3>
+                    <P3 color="text.slightlyMuted" m={0}>
+                      {item.name}
+                    </P3>
+                  </Flex>
                 </Cell>
-              ) : (
-                <Cell>{item.instanceId}</Cell>
               );
             },
           },
           {
-            key: 'name',
-            headerText: 'Instance Name',
+            altKey: 'link',
+            headerText: 'Invocation Link',
+            render: item => {
+              return (
+                item.invocationUrl && (
+                  <Cell align="center">
+                    <ExternalLink href={item.invocationUrl} target="_blank">
+                      <LinkIcon intent="neutral">
+                        <Icons.Link size="small" />
+                      </LinkIcon>
+                    </ExternalLink>
+                  </Cell>
+                )
+              );
+            },
           },
         ],
         data: Object.keys(impacts).map(i => ({
           instanceId: impacts[i].instance_id,
           name: impacts[i].name,
           resourceUrl: impacts[i].resourceUrl,
+          invocationUrl: impacts[i].invocation_url,
         })),
       };
     case AwsResource.eks:
@@ -321,3 +345,9 @@ const Attribute = ({
     </P2>
   </Flex>
 );
+
+const LinkIcon = styled(Button)`
+  width: 32px;
+  height: 32px;
+  padding: 0;
+`;

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/TaskAlert.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/TaskAlert.tsx
@@ -55,8 +55,8 @@ export function TaskAlert({
         onClick: () => history.push(cfg.getIntegrationTasksRoute(kind, name)),
       }}
     >
-      {pendingTasksCount} Pending {taskType && `${taskType.toUpperCase()} `}
-      Tasks
+      {pendingTasksCount} pending tasks
+      {taskType && ` are affecting ${taskType.toUpperCase()} rule`}
     </Alert>
   );
 }

--- a/web/packages/teleport/src/services/integrations/integrations.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.ts
@@ -508,20 +508,20 @@ export const integrationService = {
         title: resp.title,
         discoverEc2: {
           instances: resp.discoverEc2?.instances,
-          accountId: resp.discoverEc2?.accountId,
+          account_id: resp.discoverEc2?.account_id,
           region: resp.discoverEc2?.region,
-          ssmDocument: resp.discoverEc2?.ssmDocument,
-          installerScript: resp.discoverEc2?.installerScript,
+          ssm_document: resp.discoverEc2?.ssm_document,
+          installer_script: resp.discoverEc2?.installer_script,
         },
         discoverEks: {
           clusters: resp.discoverEks?.instances,
-          accountId: resp.discoverEks?.accountId,
+          account_id: resp.discoverEks?.account_id,
           region: resp.discoverEks?.region,
-          appAutoDiscover: resp.discoverEks?.appAutoDiscover,
+          app_auto_discover: resp.discoverEks?.app_auto_discover,
         },
         discoverRds: {
           databases: resp.discoverRds?.instances,
-          accountId: resp.discoverRds?.accountId,
+          account_id: resp.discoverRds?.account_id,
           region: resp.discoverRds?.region,
         },
       };

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -441,15 +441,15 @@ export type DiscoverEc2 = {
   // instances maps an instance id to the result of enrolling that instance into teleport.
   instances: Record<string, DiscoverEc2Instance>;
   // accountID is the AWS Account ID for the instances.
-  accountId: string;
+  account_id: string;
   // region is the AWS Region where Teleport failed to enroll EC2 instances.
   region: string;
   // ssmDocument is the Amazon Systems Manager SSM Document name that was used to install teleport on the instance.
   // In Amazon console, the document is at:
   // https://REGION.console.aws.amazon.com/systems-manager/documents/SSM_DOCUMENT/description
-  ssmDocument: string;
+  ssm_document: string;
   // installerScript is the Teleport installer script that was used to install teleport on the instance.
-  installerScript: string;
+  installer_script: string;
 };
 
 // DiscoverEc2Instance contains the result of enrolling an AWS EC2 Instance.
@@ -461,13 +461,13 @@ export type DiscoverEc2Instance = {
   name: string;
   // invocationUrl is the url that points to the invocation.
   // Empty if there was an error before installing the
-  invocationUrl: string;
+  invocation_url: string;
   // discoveryConfig is the discovery config name that originated this instance enrollment.
-  discoveryConfig: string;
+  discovery_config: string;
   // discoveryGroup is the DiscoveryGroup name that originated this task.
-  discoveryGroup: string;
+  discovery_group: string;
   // syncTime is the timestamp when the error was produced.
-  syncTime: number;
+  sync_time: number;
   // resourceUrl is the Amazon Web Console URL to access this EC2 Instance.
   // Always present.
   // Format: https://console.aws.amazon.com/ec2/home?region=<region>#InstanceDetails:instanceId=<instance-id>
@@ -479,11 +479,11 @@ export type DiscoverEks = {
   // clusters maps a cluster name to the result of enrolling that cluster into teleport.
   clusters: Record<string, DiscoverEksCluster>;
   // accountId is the AWS Account ID for the cluster.
-  accountId: string;
+  account_id: string;
   // region is the AWS Region where Teleport failed to enroll EKS Clusters.
   region: string;
   // appAutoDiscover indicates whether the Kubernetes agent should auto enroll HTTP services as Teleport Apps.
-  appAutoDiscover: boolean;
+  app_auto_discover: boolean;
 };
 
 // DiscoverEksCluster contains the result of enrolling an AWS EKS Cluster.
@@ -491,11 +491,11 @@ export type DiscoverEksCluster = {
   // name is the cluster Name.
   name: string;
   // discoveryConfig is the discovery config name that originated this cluster enrollment.
-  discoveryConfig: string;
+  discovery_config: string;
   // discoveryGroup is the DiscoveryGroup name that originated this task.
-  discoveryGroup: string;
+  discovery_group: string;
   // syncTime is the timestamp when the error was produced.
-  syncTime: number;
+  sync_time: number;
   // resourceURL is the Amazon Web Console URL to access this EKS Cluster.
   // Always present.
   // Format: https://console.aws.amazon.com/eks/home?region=<region>#/clusters/<cluster-name>
@@ -509,7 +509,7 @@ export type DiscoverRds = {
   // For other RDS databases, this is the DBInstanceIdentifier.
   databases: Record<string, DiscoverRdsDatabase>;
   // accountId is the AWS Account ID for the database.
-  accountId: string;
+  account_id: string;
   // region is the AWS Region where Teleport failed to enroll RDS databases.
   region: string;
 };
@@ -521,16 +521,16 @@ export type DiscoverRdsDatabase = {
   // For other RDS databases, this is the DBInstanceIdentifier.
   name: string;
   // isCluster indicates whether this database is a cluster or a single instance.
-  isCluster: boolean;
+  is_cluster: boolean;
   // engine indicates the engine name for this RDS.
   // Eg, aurora-postgresql, postgresql
   engine: string;
   // discoveryConfig is the discovery config name that originated this database enrollment.
-  discoveryConfig: string;
+  discovery_config: string;
   // discoveryGroup is the DiscoveryGroup name that originated this task.
-  discoveryGroup: string;
+  discovery_group: string;
   // syncTime is the timestamp when the error was produced.
-  syncTime: number;
+  sync_time: number;
   // resourceURL is the Amazon Web Console URL to access this RDS Database.
   // Always present.
   // Format for instances: https://console.aws.amazon.com/rds/home?region=<region>#database:id=<name>;is-cluster=false


### PR DESCRIPTION
* Updates static text on cards (enrolled & empty state)
* Show role ARN on dash, is clickable 
* Update alert text
* Add context and action to empty state tables
* Replace resource URL with invocation URL and updated styles in ec2 user task table
* Updated type files to reflect the API, will chat with creator separately about case consistency

Supports https://github.com/gravitational/teleport/issues/52895