### PR TITLE
Decouple LDAP from cert generation

### DIFF
--- a/lib/auth/windows/certificate_authority.go
+++ b/lib/auth/windows/certificate_authority.go
@@ -42,11 +42,12 @@ type CertificateStoreClient struct {
 type CertificateStoreConfig struct {
 	// AccessPoint is the Auth API client (with caching).
 	AccessPoint authclient.WindowsDesktopAccessPoint
-	// LDAPConfig is the ldap configuration
-	LDAPConfig
+	// Domain is the Active Directory domain where Teleport publishes its
+	// Certificate Revocation List (CRL).
+	Domain string
 	// Log is the logging sink for the service
 	Logger *slog.Logger
-	// ClusterName is the name of this cluster
+	// ClusterName is the name of this Teleport cluster
 	ClusterName string
 	// LC is the LDAPClient
 	LC *LDAPClient
@@ -90,8 +91,8 @@ func (c *CertificateStoreClient) updateCRL(ctx context.Context, crlDER []byte, c
 	// Teleport cluster name. So, for instance, CRL for cluster "prod" and User
 	// CA will be placed at:
 	// ... > CDP > Teleport > prod
-	containerDN := crlContainerDN(c.cfg.LDAPConfig, caType)
-	crlDN := crlDN(c.cfg.ClusterName, c.cfg.LDAPConfig, caType)
+	containerDN := crlContainerDN(c.cfg.Domain, caType)
+	crlDN := crlDN(c.cfg.ClusterName, c.cfg.Domain, caType)
 
 	// Create the parent container.
 	if err := c.cfg.LC.CreateContainer(containerDN); err != nil {

--- a/lib/auth/windows/ldap.go
+++ b/lib/auth/windows/ldap.go
@@ -65,10 +65,10 @@ func (cfg LDAPConfig) Check() error {
 	return nil
 }
 
-// DomainDN returns the distinguished name for the domain
-func (cfg LDAPConfig) DomainDN() string {
+// DomainDN returns the distinguished name for the domain.
+func DomainDN(domain string) string {
 	var sb strings.Builder
-	parts := strings.Split(cfg.Domain, ".")
+	parts := strings.Split(domain, ".")
 	for _, p := range parts {
 		if sb.Len() > 0 {
 			sb.WriteString(",")
@@ -301,12 +301,12 @@ func CombineLDAPFilters(filters []string) string {
 	return "(&" + strings.Join(filters, "") + ")"
 }
 
-func crlContainerDN(config LDAPConfig, caType types.CertAuthType) string {
-	return fmt.Sprintf("CN=%s,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,%s", crlKeyName(caType), config.DomainDN())
+func crlContainerDN(domain string, caType types.CertAuthType) string {
+	return fmt.Sprintf("CN=%s,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,%s", crlKeyName(caType), DomainDN(domain))
 }
 
-func crlDN(clusterName string, config LDAPConfig, caType types.CertAuthType) string {
-	return "CN=" + clusterName + "," + crlContainerDN(config, caType)
+func crlDN(clusterName string, activeDirectoryDomain string, caType types.CertAuthType) string {
+	return "CN=" + clusterName + "," + crlContainerDN(activeDirectoryDomain, caType)
 }
 
 // crlKeyName returns the appropriate LDAP key given the CA type.

--- a/lib/auth/windows/windows.go
+++ b/lib/auth/windows/windows.go
@@ -19,6 +19,7 @@
 package windows
 
 import (
+	"cmp"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
@@ -148,7 +149,7 @@ func getCertRequest(req *GenerateCredentialsRequest) (*certRequest, error) {
 		// CRLs in it. Each service can also handle RDP connections for a different
 		// domain, with the assumption that some other windows_desktop_service
 		// published a CRL there.
-		crlDN := crlDN(req.ClusterName, req.LDAPConfig, req.CAType)
+		crlDN := crlDN(req.ClusterName, cmp.Or(req.PKIDomain, req.Domain), req.CAType)
 
 		// TODO(zmb3) consider making Teleport itself the CDP (via HTTP) instead of LDAP
 		cr.crlEndpoint = fmt.Sprintf("ldap:///%s?certificateRevocationList?base?objectClass=cRLDistributionPoint", crlDN)
@@ -174,8 +175,11 @@ type AuthInterface interface {
 type GenerateCredentialsRequest struct {
 	// Username is the Windows username
 	Username string
-	// Domain is the Windows domain
+	// Domain is the Active Directory domain of the user.
 	Domain string
+	// PKIDomain is the Active Directory domain where CRLs are published.
+	// (Optional, defaults to the same domain as the user.)
+	PKIDomain string
 	// TTL is the ttl for the certificate
 	TTL time.Duration
 	// ClusterName is the local cluster name
@@ -184,8 +188,6 @@ type GenerateCredentialsRequest struct {
 	// specified by Username. If specified (!= ""), it is
 	// encoded in the certificate per https://go.microsoft.com/fwlink/?linkid=2189925.
 	ActiveDirectorySID string
-	// LDAPConfig is the ldap config
-	LDAPConfig LDAPConfig
 	// AuthClient is the windows AuthInterface
 	AuthClient AuthInterface
 	// CAType is the certificate authority type used to generate the certificate.

--- a/lib/auth/windows/windows_test.go
+++ b/lib/auth/windows/windows_test.go
@@ -68,9 +68,6 @@ func TestGenerateCredentials(t *testing.T) {
 		require.NoError(t, client.Close())
 	})
 
-	ldapConfig := LDAPConfig{
-		Domain: domain,
-	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -96,7 +93,6 @@ func TestGenerateCredentials(t *testing.T) {
 				TTL:                CertTTL,
 				ClusterName:        clusterName,
 				ActiveDirectorySID: test.activeDirectorySID,
-				LDAPConfig:         ldapConfig,
 				AuthClient:         client,
 			})
 			require.NoError(t, err)
@@ -179,10 +175,7 @@ func TestCRLDN(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			cfg := LDAPConfig{
-				Domain: "test.goteleport.com",
-			}
-			require.Equal(t, test.crlDN, crlDN(test.clusterName, cfg, test.caType))
+			require.Equal(t, test.crlDN, crlDN(test.clusterName, "test.goteleport.com", test.caType))
 		})
 	}
 }

--- a/lib/srv/db/common/kerberos/kinit/kinit.go
+++ b/lib/srv/db/common/kerberos/kinit/kinit.go
@@ -218,15 +218,7 @@ func (d *DBCertGetter) GetCertificateBytes(ctx context.Context) (*WindowsCAAndKe
 		Domain:      d.RealmName,
 		TTL:         certTTL,
 		ClusterName: clusterName.GetClusterName(),
-		LDAPConfig: windows.LDAPConfig{
-			Addr:               d.KDCHostName,
-			Domain:             d.RealmName,
-			Username:           d.UserName,
-			InsecureSkipVerify: false,
-			ServerName:         d.AdminServerName,
-			CA:                 d.LDAPCA,
-		},
-		AuthClient: d.Auth,
+		AuthClient:  d.Auth,
 	})
 
 	if err != nil {

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -231,7 +231,7 @@ type HeartbeatConfig struct {
 func (cfg *WindowsServiceConfig) checkAndSetDiscoveryDefaults() error {
 	switch {
 	case cfg.DiscoveryBaseDN == types.Wildcard:
-		cfg.DiscoveryBaseDN = cfg.DomainDN()
+		cfg.DiscoveryBaseDN = windows.DomainDN(cfg.Domain)
 	case len(cfg.DiscoveryBaseDN) > 0:
 		if _, err := ldap.ParseDN(cfg.DiscoveryBaseDN); err != nil {
 			return trace.BadParameter("WindowsServiceConfig contains an invalid base_dn: %v", err)
@@ -373,21 +373,15 @@ func NewWindowsService(cfg WindowsServiceConfig) (*WindowsService, error) {
 		enableNLA: os.Getenv("TELEPORT_ENABLE_RDP_NLA") == "yes",
 	}
 
-	caLDAPConfig := s.cfg.LDAPConfig
-	if s.cfg.PKIDomain != "" {
-		caLDAPConfig.Domain = s.cfg.PKIDomain
-	}
-	s.cfg.Logger.InfoContext(ctx, "PKI domain configured", "domain", caLDAPConfig.Domain)
-
 	s.ca = windows.NewCertificateStoreClient(windows.CertificateStoreConfig{
 		AccessPoint: s.cfg.AccessPoint,
-		LDAPConfig:  caLDAPConfig,
+		Domain:      cmp.Or(s.cfg.PKIDomain, s.cfg.Domain),
 		Logger:      slog.Default(),
 		ClusterName: s.clusterName,
 		LC:          s.lc,
 	})
 
-	if caLDAPConfig.Addr != "" {
+	if s.cfg.LDAPConfig.Addr != "" {
 		s.ldapConfigured = true
 		// initialize LDAP - if this fails it will automatically schedule a retry.
 		// we don't want to return an error in this case, because failure to start
@@ -465,7 +459,7 @@ func (s *WindowsService) startLDAPConnectionCheck(ctx context.Context) {
 
 				// If we have initialized the LDAP client, then try to use it to make sure we're still connected
 				// by attempting to read CAs in the NTAuth store (we know we have permissions to do so).
-				ntAuthDN := "CN=NTAuthCertificates,CN=Public Key Services,CN=Services,CN=Configuration," + s.cfg.LDAPConfig.DomainDN()
+				ntAuthDN := "CN=NTAuthCertificates,CN=Public Key Services,CN=Services,CN=Configuration," + windows.DomainDN(s.cfg.LDAPConfig.Domain)
 				_, err := s.lc.Read(ntAuthDN, "certificationAuthority", []string{"cACertificate"})
 				if trace.IsConnectionProblem(err) {
 					s.cfg.Logger.DebugContext(ctx, "detected broken LDAP connection, will reconnect")
@@ -1285,14 +1279,15 @@ func (s *WindowsService) generateUserCert(ctx context.Context, username string, 
 			fmt.Sprintf("(%s=%s)", windows.AttrSAMAccountName, username),
 		})
 		s.cfg.Logger.DebugContext(ctx, "querying LDAP for objectSid of Windows user", "username", username, "filter", filter)
+		domainDN := windows.DomainDN(s.cfg.LDAPConfig.Domain)
 
-		entries, err := s.lc.ReadWithFilter(s.cfg.LDAPConfig.DomainDN(), filter, []string{windows.AttrObjectSid})
+		entries, err := s.lc.ReadWithFilter(domainDN, filter, []string{windows.AttrObjectSid})
 		// if LDAP-based desktop discovery is not enabled, there may not be enough
 		// traffic to keep the connection open. Attempt to open a new LDAP connection
 		// in this case.
 		if trace.IsConnectionProblem(err) {
 			s.initializeLDAP() // ignore error, this is a best effort attempt
-			entries, err = s.lc.ReadWithFilter(s.cfg.LDAPConfig.DomainDN(), filter, []string{windows.AttrObjectSid})
+			entries, err = s.lc.ReadWithFilter(domainDN, filter, []string{windows.AttrObjectSid})
 		}
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
@@ -1346,23 +1341,15 @@ type generateCredentialsRequest struct {
 // Directory. See:
 // https://docs.microsoft.com/en-us/windows/security/identity-protection/smart-cards/smart-card-certificate-requirements-and-enumeration
 func (s *WindowsService) generateCredentials(ctx context.Context, request generateCredentialsRequest) (certDER, keyDER []byte, err error) {
-	// If PKI domain has been overridden, make sure we pass that through
-	// to the cert request, otherwise the CRL in the cert we issue will
-	// point at the wrong domain.
-	lc := s.cfg.LDAPConfig
-	if s.cfg.PKIDomain != "" {
-		lc.Domain = s.cfg.PKIDomain
-	}
-
 	return windows.GenerateWindowsDesktopCredentials(ctx, &windows.GenerateCredentialsRequest{
 		CAType:             types.UserCA,
 		Username:           request.username,
 		Domain:             request.domain,
+		PKIDomain:          s.cfg.PKIDomain,
 		AD:                 request.ad,
 		TTL:                request.ttl,
 		ClusterName:        s.clusterName,
 		ActiveDirectorySID: request.activeDirectorySID,
-		LDAPConfig:         lc,
 		AuthClient:         s.cfg.AuthClient,
 		CreateUser:         request.createUser,
 		Groups:             request.groups,

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -404,19 +404,14 @@ func (a *AuthCommand) generateWindowsCert(ctx context.Context, clusterAPI certif
 		return trace.Wrap(err)
 	}
 
-	domain := a.windowsDomain
-	if a.windowsPKIDomain != "" {
-		domain = a.windowsPKIDomain
-	}
-
 	certDER, _, err := windows.GenerateWindowsDesktopCredentials(ctx, &windows.GenerateCredentialsRequest{
 		CAType:             types.UserCA,
 		Username:           a.windowsUser,
 		Domain:             a.windowsDomain,
+		PKIDomain:          a.windowsPKIDomain,
 		ActiveDirectorySID: a.windowsSID,
 		TTL:                a.genTTL,
 		ClusterName:        cn.GetClusterName(),
-		LDAPConfig:         windows.LDAPConfig{Domain: domain},
 		OmitCDP:            a.omitCDP,
 		AuthClient:         clusterAPI,
 	})


### PR DESCRIPTION
No functional changes, just a better abstraction. LDAP can be used to fetch metadata that is included in certificate requests, but LDAP is not required in order to issue certificates.

Better isolating LDAP to only the places where it is necessary is going to enable some new features that we plan to look at soon.