### PR TITLE
[v16] [buddy] Make sure (*Struct).Fields map is not nil before assignment

### DIFF
--- a/api/types/events/events.go
+++ b/api/types/events/events.go
@@ -184,9 +184,16 @@ func (m *Struct) nonEmptyStrs() int {
 }
 
 func (m *Struct) trimToMaxSize(maxSize int) *Struct {
-	var out Struct
+	if len(m.Fields) == 0 {
+		return m
+	}
+
+	out := Struct{
+		Struct: types.Struct{
+			Fields: make(map[string]*types.Value),
+		},
+	}
 	for k, v := range m.Fields {
-		delete(out.Fields, k)
 		trimmedKey := trimStr(k, maxSize)
 
 		if v != nil {

--- a/api/types/events/events_test.go
+++ b/api/types/events/events_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gogo/protobuf/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
@@ -154,5 +155,48 @@ func TestTrimStr(t *testing.T) {
 	const maxLen = 20
 	for _, test := range tests {
 		require.Equal(t, test.want, trimStr(test.have, maxLen))
+	}
+}
+
+func TestStructTrimToMaxSize(t *testing.T) {
+	testCases := []struct {
+		name    string
+		maxSize int
+		in      *Struct
+		want    *Struct
+	}{
+		{
+			name:    "Field key exceeds max limit size",
+			maxSize: 10,
+			in: &Struct{
+				Struct: types.Struct{
+					Fields: map[string]*types.Value{
+						strings.Repeat("A", 100): {
+							Kind: &types.Value_StringValue{
+								StringValue: "A",
+							},
+						},
+					},
+				},
+			},
+			want: &Struct{
+				Struct: types.Struct{
+					Fields: map[string]*types.Value{
+						strings.Repeat("A", 8): {
+							Kind: &types.Value_StringValue{
+								StringValue: "A",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.in.trimToMaxSize(tc.maxSize)
+			require.Equal(t, tc.want, got)
+		})
 	}
 }


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/53035.

changelog: fix panic when trimming audit log entries