### PR TITLE
Add documentation for `workload-identity-aws-ra` tbot service

### DIFF
--- a/docs/pages/reference/cli/tbot.mdx
+++ b/docs/pages/reference/cli/tbot.mdx
@@ -581,7 +581,7 @@ command supports these additional flags:
 | `--name-selector`                        | Specifies a WorkloadIdentity resource by name to use when issuing the X509 for a workload. Mutually exclusive with `--label-selector`.                             |
 | `--label-selector`                       | Specifies a set of labels to use when selecting WorkloadIdentity resources to use when issuing the X509 for a workload. Mutually exclusive with `--name-selector`. |
 
-## tbot start workload-identity-aws-ra
+## tbot start workload-identity-aws-roles-anywhere
 
 Issues an X509 workload identity credential, exchanges this for short-lived AWS
 credentials using Roles Anywhere, and writes these to a configured destination.
@@ -597,7 +597,7 @@ command supports these additional flags:
 
 | Flag                         | Description                                                                                                                                                        |
 |------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `--destination`              | A destination URI, such as `file:///foo/bar`. See [Destination URIs](#destination-uris) for more info. Required.                                                     |
+| `--destination`              | A destination URI, such as `file:///foo/bar`. See [Destination URIs](#destination-uris) for more info. Required.                                                   |
 | `--reader-user`              | An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.                                 |
 | `--reader-group`             | An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.                                |
 | `--name-selector`            | Specifies a WorkloadIdentity resource by name to use when issuing the X509 for a workload. Mutually exclusive with `--label-selector`.                             |
@@ -605,7 +605,7 @@ command supports these additional flags:
 | `--role-arn`                 | The ARN of the AWS role to assume. Required.                                                                                                                       |
 | `--profile-arn`              | The ARN of the AWS profile to use for the Roles Anywhere exchange. Required.                                                                                       |
 | `--trust-anchor-arn`         | The ARN of the trust anchor to use for the Roles Anywhere exchange. Required.                                                                                      |
-| `--region`                   | The AWS region to use for the Roles Anywhere exchange. Falls back to value in `AWS_REGION` or the AWS configuration file if unspecified.                             |
+| `--region`                   | The AWS region to use for the Roles Anywhere exchange. Falls back to value in `AWS_REGION` or the AWS configuration file if unspecified.                           |
 | `--session-duration`         | The duration of the AWS session. Defaults to `6h`. This may be up to `12h`.                                                                                        |
 | `--session-renewal-interval` | The interval at which to renew the AWS session. Defaults to `1h`. This must be less than the session duration.                                                     |
 

--- a/docs/pages/reference/cli/tbot.mdx
+++ b/docs/pages/reference/cli/tbot.mdx
@@ -581,6 +581,34 @@ command supports these additional flags:
 | `--name-selector`                        | Specifies a WorkloadIdentity resource by name to use when issuing the X509 for a workload. Mutually exclusive with `--label-selector`.                             |
 | `--label-selector`                       | Specifies a set of labels to use when selecting WorkloadIdentity resources to use when issuing the X509 for a workload. Mutually exclusive with `--name-selector`. |
 
+## tbot start workload-identity-aws-ra
+
+Issues an X509 workload identity credential, exchange this for short-lived AWS
+credentials using Roles Anywhere and writes these to a configured destination.
+
+See the [configuration reference](../machine-id/configuration.mdx) for further
+information about the workload identity credential output and the YAML
+configuration file format.
+
+### Flags
+
+In addition to the [common `tbot start` flags](#common-start-flags), this
+command supports these additional flags:
+
+| Flag                         | Description                                                                                                                                                        |
+|------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--destination`              | A destination URI, such as file:///foo/bar. See [Destination URIs](#destination-uris) for more info. Required.                                                     |
+| `--reader-user`              | An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.                                 |
+| `--reader-group`             | An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.                                |
+| `--name-selector`            | Specifies a WorkloadIdentity resource by name to use when issuing the X509 for a workload. Mutually exclusive with `--label-selector`.                             |
+| `--label-selector`           | Specifies a set of labels to use when selecting WorkloadIdentity resources to use when issuing the X509 for a workload. Mutually exclusive with `--name-selector`. |
+| `--role-arn`                 | The ARN of the AWS role to assume. Required.                                                                                                                       |
+| `--profile-arn`              | The ARN of the AWS profile to use for the Roles Anywhere exchange. Required.                                                                                       |
+| `--trust-anchor-arn`         | The ARN of the trust anchor to use for the Roles Anywhere exchange. Required.                                                                                      |
+| `--region`                   | The AWS region to use for the Roles Anywhere exchange. Falls back to value in AWS_REGION or the AWS configuration file if unspecified.                             |
+| `--session-duration`         | The duration of the AWS session. Defaults to `6h`. This may be up to `12h`.                                                                                        |
+| `--session-renewal-interval` | The interval at which to renew the AWS session. Defaults to `1h`. This must be less than the session duration.                                                     |
+
 ## tbot start workload-identity-jwt
 
 Issues a JWT workload identity credential using Teleport Workload Identity and

--- a/docs/pages/reference/cli/tbot.mdx
+++ b/docs/pages/reference/cli/tbot.mdx
@@ -583,8 +583,8 @@ command supports these additional flags:
 
 ## tbot start workload-identity-aws-ra
 
-Issues an X509 workload identity credential, exchange this for short-lived AWS
-credentials using Roles Anywhere and writes these to a configured destination.
+Issues an X509 workload identity credential, exchanges this for short-lived AWS
+credentials using Roles Anywhere, and writes these to a configured destination.
 
 See the [configuration reference](../machine-id/configuration.mdx) for further
 information about the workload identity credential output and the YAML
@@ -597,7 +597,7 @@ command supports these additional flags:
 
 | Flag                         | Description                                                                                                                                                        |
 |------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `--destination`              | A destination URI, such as file:///foo/bar. See [Destination URIs](#destination-uris) for more info. Required.                                                     |
+| `--destination`              | A destination URI, such as `file:///foo/bar`. See [Destination URIs](#destination-uris) for more info. Required.                                                     |
 | `--reader-user`              | An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.                                 |
 | `--reader-group`             | An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.                                |
 | `--name-selector`            | Specifies a WorkloadIdentity resource by name to use when issuing the X509 for a workload. Mutually exclusive with `--label-selector`.                             |
@@ -605,7 +605,7 @@ command supports these additional flags:
 | `--role-arn`                 | The ARN of the AWS role to assume. Required.                                                                                                                       |
 | `--profile-arn`              | The ARN of the AWS profile to use for the Roles Anywhere exchange. Required.                                                                                       |
 | `--trust-anchor-arn`         | The ARN of the trust anchor to use for the Roles Anywhere exchange. Required.                                                                                      |
-| `--region`                   | The AWS region to use for the Roles Anywhere exchange. Falls back to value in AWS_REGION or the AWS configuration file if unspecified.                             |
+| `--region`                   | The AWS region to use for the Roles Anywhere exchange. Falls back to value in `AWS_REGION` or the AWS configuration file if unspecified.                             |
 | `--session-duration`         | The duration of the AWS session. Defaults to `6h`. This may be up to `12h`.                                                                                        |
 | `--session-renewal-interval` | The interval at which to renew the AWS session. Defaults to `1h`. This must be less than the session duration.                                                     |
 

--- a/docs/pages/reference/machine-id/configuration.mdx
+++ b/docs/pages/reference/machine-id/configuration.mdx
@@ -422,10 +422,11 @@ audiences:
 (!docs/pages/includes/machine-id/common-output-config.yaml!)
 ```
 
-### `workload-identity-aws-ra`
+### `workload-identity-aws-roles-anywhere`
 
-The `workload-identity-aws-ra` output is used to issue an X509 workload identity
-credential, exchange this for short-lived AWS credentials using Roles Anywhere, and write these to a configured destination.
+The `workload-identity-aws-roles-anywhere` output is used to issue an X509
+workload identity credential, exchange this for short-lived AWS credentials
+using Roles Anywhere, and write these to a configured destination.
 
 The credentials are written in the [AWS shared credentials file format](https://docs.aws.amazon.com/sdkref/latest/guide/file-format.html#file-format-creds),
 which is compatible with the AWS CLI and SDKs.
@@ -439,8 +440,8 @@ for more information on Workload Identity functionality.
 
 ```yaml
 # type specifies the type of the output. For the Workload Identity AWS Roles
-# Anywhere output, this will always be `workload-identity-aws-ra`.
-type: workload-identity-aws-ra
+# Anywhere output, this will always be `workload-identity-aws-roles-anywhere`.
+type: workload-identity-aws-roles-anywhere
 # The following configuration fields are available across most output types.
 
 # destination specifies where the output should write any generated artifacts

--- a/docs/pages/reference/machine-id/configuration.mdx
+++ b/docs/pages/reference/machine-id/configuration.mdx
@@ -422,6 +422,62 @@ audiences:
 (!docs/pages/includes/machine-id/common-output-config.yaml!)
 ```
 
+### `workload-identity-aws-ra`
+
+The `workload-identity-aws-ra` output is used to issue an X509 workload identity
+credential, exchange this for short-lived AWS credentials using Roles Anywhere
+and writes these to a configured destination.
+
+The credentials are written in the [AWS shared credentials file format](https://docs.aws.amazon.com/sdkref/latest/guide/file-format.html#file-format-creds)
+which is compatible with the AWS CLI and SDKs.
+
+The output generates the following artifacts:
+
+- `aws_credentials`: the CLI and SDK compatible AWS shared credentials file.
+
+See [Workload Identity introduction](../../enroll-resources/workload-identity/introduction.mdx)
+for more information on Workload Identity functionality.
+
+```yaml
+# type specifies the type of the output. For the Workload Identity AWS Roles
+# Anywhere output, this will always be `workload-identity-aws-ra`.
+type: workload-identity-aws-ra
+# The following configuration fields are available across most output types.
+
+# destination specifies where the output should write any generated artifacts
+# such as certificates and configuration files.
+#
+# See the full list of supported destinations and their configuration options
+# under the Destinations section of this reference page.
+destination:
+  type: directory
+  path: /opt/machine-id
+# role_arn is the ARN of the AWS role that the generated credentials should
+# assume.
+# Required.
+role_arn: arn:aws:iam::123456789012:role/example-role
+# profile_arn is the ARN of the AWS profile to be used during the Roles Anywhere
+# exchange.
+# Required.
+profile_arn: arn:aws:rolesanywhere:us-east-1:123456789012:profile/0000000-0000-0000-0000-00000000000
+# trust_anchor_arn is the ARN of the trust anchor that should be used during the
+# Roles Anywhere exchange.
+# Required.
+trust_anchor_arn: arn:aws:rolesanywhere:us-east-1:123456789012:trust-anchor/0000000-0000-0000-0000-000000000000
+# region is the AWS region to use for the Roles Anywhere exchange. If omitted,
+# this defaults to the region set by `AWS_REGION` environment variable or the
+# AWS configuration file.
+region: us-east-1
+# session_duration is the duration that the generated AWS credentials should be
+# valid for. This may be up to 12 hours. If omitted, this defaults to 6 hours.
+session_duration: 6h
+# session_renewal_interval is the interval at which the AWS credentials should
+# be renewed. This should be less than the session duration. If omitted, this
+# defaults to 1 hour.
+session_renewal_interval: 1h
+(!docs/pages/includes/machine-id/workload-identity-selector-config.yaml!)
+```
+
 ### `spiffe-svid`
 
 <Admonition type="warning" >

--- a/docs/pages/reference/machine-id/configuration.mdx
+++ b/docs/pages/reference/machine-id/configuration.mdx
@@ -425,10 +425,9 @@ audiences:
 ### `workload-identity-aws-ra`
 
 The `workload-identity-aws-ra` output is used to issue an X509 workload identity
-credential, exchange this for short-lived AWS credentials using Roles Anywhere
-and writes these to a configured destination.
+credential, exchange this for short-lived AWS credentials using Roles Anywhere, and write these to a configured destination.
 
-The credentials are written in the [AWS shared credentials file format](https://docs.aws.amazon.com/sdkref/latest/guide/file-format.html#file-format-creds)
+The credentials are written in the [AWS shared credentials file format](https://docs.aws.amazon.com/sdkref/latest/guide/file-format.html#file-format-creds),
 which is compatible with the AWS CLI and SDKs.
 
 The output generates the following artifacts:


### PR DESCRIPTION
Reference documentation for https://github.com/gravitational/teleport/pull/52426