### PR TITLE
Update tar install to include enterprise suffix

### DIFF
--- a/lib/web/scripts/install/install.sh
+++ b/lib/web/scripts/install/install.sh
@@ -226,7 +226,7 @@ install_via_curl() {
   cd -
 
   $SUDO tar -xzf "${TEMP_DIR}/${TELEPORT_FILENAME}" -C "$TEMP_DIR"
-  $SUDO "$TEMP_DIR/teleport/install"
+  $SUDO "$TEMP_DIR/teleport${TELEPORT_SUFFIX}/install"
   set +x
 }
 


### PR DESCRIPTION
The enterprise or cloud version tar download and install script execution will fail since it does not run the install the in the `teleport-ent` dir. The script assumed it was always `teleport` dir.  This updates to include the suffix which is the same as the package installers do.


Example of current error:

```bash
curl https://cdn.teleport.dev/install-v17.3.4.sh | bash -s 17.3.4 enterprise
```

```bash
Downloading https://cdn.teleport.dev/teleport-ent-v17.3.4-linux-arm64-bin.tar.gz.sha256
+ curl -fL -o /tmp/teleport-Hvik4DQPP4/teleport-ent-v17.3.4-linux-arm64-bin.tar.gz.sha256 https://cdn.teleport.dev/teleport-ent-v17.3.4-linux-arm64-bin.tar.gz.sha256
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   110  100   110    0     0    322      0 --:--:-- --:--:-- --:--:--   323
+ set +x
+ cd /tmp/teleport-Hvik4DQPP4
+ sha256sum -c /tmp/teleport-Hvik4DQPP4/teleport-ent-v17.3.4-linux-arm64-bin.tar.gz.sha256
teleport-ent-v17.3.4-linux-arm64-bin.tar.gz: OK
+ cd -
/
+ tar -xzf /tmp/teleport-Hvik4DQPP4/teleport-ent-v17.3.4-linux-arm64-bin.tar.gz -C /tmp/teleport-Hvik4DQPP4
+ /tmp/teleport-Hvik4DQPP4/teleport/install
main: line 229: /tmp/teleport-Hvik4DQPP4/teleport/install: No such file or directory
[root@19beaa662990 /]# cd /tmp/teleport-Hvik4DQPP4/
```