### PR TITLE
[v15] Replace `(!toc!)` syntax with DocCardList

### DIFF
--- a/docs/pages/admin-guides/admin-guides.mdx
+++ b/docs/pages/admin-guides/admin-guides.mdx
@@ -3,4 +3,4 @@ title: Teleport Admin Guides
 description: Provides step-by-step instructions for completing administrative tasks in Teleport.
 ---
 
-(!toc!)
+<DocCardList />

--- a/docs/pages/admin-guides/deploy-a-cluster/access-graph/access-graph.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/access-graph/access-graph.mdx
@@ -8,4 +8,4 @@ Teleport Policy) requires running the Access Graph Service on your own
 infrastructure. The following guides show you how to deploy the Access Graph
 Service.
 
-(!toc!)
+<DocCardList />

--- a/docs/pages/admin-guides/deploy-a-cluster/deploy-a-cluster.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/deploy-a-cluster.mdx
@@ -6,4 +6,4 @@ description: "Guides to running a self-hosted Teleport cluster in production."
 These guides show you how to run a self-hosted Teleport Enterprise cluster in
 production.
 
-(!toc!)
+<DocCardList />

--- a/docs/pages/admin-guides/infrastructure-as-code/managing-resources/managing-resources.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/managing-resources/managing-resources.mdx
@@ -7,4 +7,4 @@ layout: tocless-doc
 Read the guides in this section for instructions on managing specific dynamic
 resources with tctl and the Teleport Terraform provider and Kubernetes operator.
 
-(!toc!)
+<DocCardList />

--- a/docs/pages/admin-guides/management/management.mdx
+++ b/docs/pages/admin-guides/management/management.mdx
@@ -7,4 +7,4 @@ layout: tocless-doc
 In this section, you can find guides on managing a Teleport cluster after
 deploying it, i.e., day-two operations.
 
-(!toc!)
+<DocCardList />

--- a/docs/pages/admin-guides/teleport-policy/integrations/integrations.mdx
+++ b/docs/pages/admin-guides/teleport-policy/integrations/integrations.mdx
@@ -11,7 +11,7 @@ enabling administrators to better understand and control access policies.
 Read the following guides for information on using Teleport Access Graph to
 visualize role-based access controls from third-party services:
 
-(!toc!)
+<DocCardList />
 
 ## Viewing available integrations
 

--- a/docs/pages/admin-guides/teleport-policy/teleport-policy.mdx
+++ b/docs/pages/admin-guides/teleport-policy/teleport-policy.mdx
@@ -27,4 +27,4 @@ If you are a self-hosted Teleport customer, you will need to [deploy the Access 
 
 ## Teleport Policy guides
 
-(!toc!)
+<DocCardList />

--- a/docs/pages/connect-your-client/connect-your-client.mdx
+++ b/docs/pages/connect-your-client/connect-your-client.mdx
@@ -3,4 +3,4 @@ title: Teleport User Guides
 description: Provides instructions to help users connect to infrastructure resources with Teleport.
 ---
 
-(!toc!)
+<DocCardList />

--- a/docs/pages/enroll-resources/agents/agents.mdx
+++ b/docs/pages/enroll-resources/agents/agents.mdx
@@ -3,4 +3,4 @@ title: Using Teleport Agents
 description: How to use Teleport Agents, which allow you to enroll infrastructure resources with Teleport
 ---
 
-(!toc!)
+<DocCardList />

--- a/docs/pages/enroll-resources/application-access/application-access.mdx
+++ b/docs/pages/enroll-resources/application-access/application-access.mdx
@@ -3,4 +3,4 @@ title: Applications
 description: Guides to using Teleport to protect web applications, cloud provider APIs, and more.
 ---
 
-(!toc!)
+<DocCardList />

--- a/docs/pages/enroll-resources/auto-discovery/auto-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/auto-discovery.mdx
@@ -17,4 +17,4 @@ registered on the Auth Service backend.
 
 Set up Teleport auto-discovery for resources in your infrastructure:
 
-(!toc!)
+<DocCardList />

--- a/docs/pages/enroll-resources/auto-discovery/reference/reference.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/reference/reference.mdx
@@ -3,4 +3,4 @@ title: Discovery Service Reference
 description: Configuration reference for the Teleport Discovery Service.
 ---
 
-(!toc!)
+<DocCardList />

--- a/docs/pages/enroll-resources/database-access/database-access.mdx
+++ b/docs/pages/enroll-resources/database-access/database-access.mdx
@@ -22,4 +22,4 @@ agent services.
 
 ![Teleport Database Access Diagram](../../../img/database-access/architecture.svg)
 
-(!toc!)
+<DocCardList />

--- a/docs/pages/enroll-resources/desktop-access/desktop-access.mdx
+++ b/docs/pages/enroll-resources/desktop-access/desktop-access.mdx
@@ -3,4 +3,4 @@ title: Windows Desktops
 description: Guides to protecting Windows desktops with Teleport
 ---
 
-(!toc!)
+<DocCardList />

--- a/docs/pages/enroll-resources/enroll-resources.mdx
+++ b/docs/pages/enroll-resources/enroll-resources.mdx
@@ -26,4 +26,4 @@ accounts to access Teleport-protected resources.
 Read the following documentation for more information on enrolling
 infrastructure resources with Teleport:
 
-(!toc!)
+<DocCardList />

--- a/docs/pages/enroll-resources/kubernetes-access/kubernetes-access.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/kubernetes-access.mdx
@@ -3,4 +3,4 @@ title: Kubernetes Clusters
 description: Guides to protecting Kubernetes clusters with Teleport
 ---
 
-(!toc!)
+<DocCardList />

--- a/docs/pages/enroll-resources/machine-id/machine-id.mdx
+++ b/docs/pages/enroll-resources/machine-id/machine-id.mdx
@@ -3,4 +3,4 @@ title: Machine ID
 description: Guides to using Machine ID, which allows you to provide secure access to your infrastructure from automated services.
 ---
 
-(!toc!)
+<DocCardList />

--- a/docs/pages/enroll-resources/server-access/server-access.mdx
+++ b/docs/pages/enroll-resources/server-access/server-access.mdx
@@ -3,4 +3,4 @@ title: Linux Servers
 description: Guides to protecting Linux servers with Teleport, including OpenSSH servers.
 ---
 
-(!toc!)
+<DocCardList />

--- a/docs/pages/enroll-resources/workload-identity/workload-identity.mdx
+++ b/docs/pages/enroll-resources/workload-identity/workload-identity.mdx
@@ -3,4 +3,4 @@ title: Workload Identity
 description: Securely issue flexible short-lived identities to your workloads
 ---
 
-(!toc!)
+<DocCardList />

--- a/docs/pages/reference/access-controls/access-controls.mdx
+++ b/docs/pages/reference/access-controls/access-controls.mdx
@@ -4,4 +4,4 @@ h1: Access Controls References
 description: Contains guides to configuring authentication and authorization in Teleport.
 ---
 
-(!toc!)
+<DocCardList />

--- a/docs/pages/reference/agent-services/agent-services.mdx
+++ b/docs/pages/reference/agent-services/agent-services.mdx
@@ -9,4 +9,4 @@ comprehensive list of options you can configure when running the `teleport`
 binary, including all options for Agent services, consult the [Teleport
 Configuration Reference](../config.mdx).
 
-(!toc!)
+<DocCardList />

--- a/docs/pages/reference/monitoring/monitoring.mdx
+++ b/docs/pages/reference/monitoring/monitoring.mdx
@@ -4,4 +4,4 @@ h1: Teleport Monitoring References
 description: Provides comprehensive guides to monitoring data available from Teleport.
 ---
 
-(!toc!)
+<DocCardList />

--- a/docs/pages/reference/reference.mdx
+++ b/docs/pages/reference/reference.mdx
@@ -3,4 +3,4 @@ title: Teleport Reference Guides
 description: Provides comprehensive information on configuration fields, Teleport commands, and other ways of interacting with Teleport.
 ---
 
-(!toc!)
+<DocCardList />


### PR DESCRIPTION
DocCardList is a Docusaurus-native component that achieves the same goal as our custom `remark-toc` plugin, but with Docusaurus APIs instead of file system lookups. Replace `(!toc!)` mentions so we can remove `remark-toc`.