### PR TITLE
[v16] Remove string style

### DIFF
--- a/docs/pages/admin-guides/deploy-a-cluster/access-graph/self-hosted-helm.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/access-graph/self-hosted-helm.mdx
@@ -33,7 +33,7 @@ to Teleport Enterprise customers.
 - A TLS certificate for the Access Graph service
   - The TLS certificate must be issued for "server authentication" key usage,
     and must contain an X.509 v3 `subjectAltName` extension with the Kubernetes service name for Access Graph
-    (<span style="white-space: nowrap;">`teleport-access-graph.teleport-access-graph.svc.cluster.local`</span> by default).
+    (`teleport-access-graph.teleport-access-graph.svc.cluster.local` by default).
 
 
 ## Step 1/4. Add the Teleport Helm chart repository


### PR DESCRIPTION
See gravitational/docs-website#97

The docs engine removes these using a custom plugin during builds. Remove string styles in the docs content so we can remove the plugin.