### PR TITLE
[v15] Remove string style

### DIFF
--- a/docs/pages/admin-guides/deploy-a-cluster/access-graph/self-hosted-helm.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/access-graph/self-hosted-helm.mdx
@@ -35,7 +35,7 @@ to Teleport Enterprise customers.
 - A TLS certificate for the Access Graph service
   - The TLS certificate must be issued for "server authentication" key usage,
     and must contain an X.509 v3 `subjectAltName` extension with the Kubernetes service name for TAG
-    (<span style="white-space: nowrap;">`teleport-access-graph.teleport-access-graph.svc.cluster.local`</span> by default).
+    (`teleport-access-graph.teleport-access-graph.svc.cluster.local` by default).
 
 
 ## Step 1/4. Add the Teleport Helm chart repository

--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -67,7 +67,7 @@ which cluster the current tab is bound to, and the **Share Feedback** button in 
 ## Connecting to an SSH server
 
 1. Open a tab with cluster resources by clicking on the plus symbol at the right end of the tab bar.
-   You can also press <span style="white-space: nowrap;">`Ctrl/Cmd + T`</span> to achieve the same result.
+   You can also press `Ctrl/Cmd + T` to achieve the same result.
 1. Look for the SSH server you want to connect to and click the Connect button.
 1. Select or enter the SSH user you wish to log in as and press `Enter`.
 
@@ -78,7 +78,7 @@ Alternatively, you can look for the server in the search bar and press `Enter` t
 ## Opening a local terminal
 
 To open a terminal with a local shell session, either select "Open new terminal" from the additional
-actions menu or press <span style="white-space: nowrap;">`Ctrl/Cmd + Shift + T`</span>.
+actions menu or press `Ctrl/Cmd + Shift + T`.
 
 Any tsh command executed within the tab targets the current cluster. Teleport Connect accomplishes
 this by setting the environment variables `TELEPORT_PROXY` and `TELEPORT_CLUSTER` for the session.
@@ -92,7 +92,7 @@ reflected in both the tab title and the status bar.
 ## Connecting to a Kubernetes cluster
 
 1. Open a tab with cluster resources by clicking on the plus symbol at the right end of the tab bar.
-   You can also press <span style="white-space: nowrap;">`Ctrl/Cmd + T`</span> to achieve the same result.
+   You can also press `Ctrl/Cmd + T` to achieve the same result.
 1. Look for the cluster you wish to connect to and click the Connect button.
 
 Alternatively, you can look for the cluster in the search bar and press `Enter`
@@ -113,7 +113,7 @@ Teleport Connect is closed.
 ## Connecting to a database
 
 1. Open a tab with cluster resources by clicking on the plus symbol at the end of the tab bar. You
-  can also press <span style="white-space: nowrap;">`Ctrl/Cmd + T`</span> to achieve the same result.
+  can also press `Ctrl/Cmd + T` to achieve the same result.
 1. Look for the database server you wish to connect to and click the Connect button.
 1. Select or enter the database user you wish to use and press `Enter`.
 
@@ -148,7 +148,7 @@ be used only through tsh in [a local terminal tab](#opening-a-local-terminal).
 ### Launching an application in the browser
 
 1. Open a tab with cluster resources by clicking on the plus symbol at the end of the tab bar. You
-  can also press <span style="white-space: nowrap;">`Ctrl/Cmd + T`</span> to achieve the same result.
+  can also press `Ctrl/Cmd + T` to achieve the same result.
 1. Look for the application you wish to open and click the Launch button (web apps and AWS console)
    or the Login button (SAML apps).
 
@@ -158,7 +158,7 @@ the browser.
 ### Creating an authenticated tunnel
 
 1. Open a tab with cluster resources by clicking on the plus symbol at the end of the tab bar. You
-  can also press <span style="white-space: nowrap;">`Ctrl/Cmd + T`</span> to achieve the same result.
+  can also press `Ctrl/Cmd + T` to achieve the same result.
 1. Look for the application you wish to connect to.
   - For TCP applications, click the Connect button.
   - For web applications, click the three dots next to the Launch button and select Set up
@@ -184,7 +184,7 @@ your first cluster, open the profile selector at the top right and click the *+A
 button. You can switch between active profiles in multiple ways:
 
 1. Click at the profile selector button at the top right.
-1. Open the profile selector with a shortcut (<span style="white-space: nowrap;">`Ctrl/Cmd + I`</span>).
+1. Open the profile selector with a shortcut (`Ctrl/Cmd + I`).
 1. Select a connection from the connection list at the top to automatically switch to the right profile.
 
 At the moment Teleport Connect supports only one user per cluster. To log in as a different user,
@@ -450,7 +450,7 @@ Below is the list of the supported config properties.
 
 ### Configuring keyboard shortcuts
 
-A valid shortcut contains at least one modifier and a single key code, for example <span style="white-space: nowrap;">`Shift+Tab`</span>.
+A valid shortcut contains at least one modifier and a single key code, for example `Shift+Tab`.
 Function keys such as `F1` do not require a modifier.
 Modifiers and a key code must be combined by the `+` character.
 


### PR DESCRIPTION
See gravitational/docs-website#97

The docs engine removes these using a custom plugin during builds. Remove string styles in the docs content so we can remove the plugin.