### PR TITLE
Stop PowerShell build scripts on non-zero exit codes

### DIFF
--- a/web/packages/teleterm/electron-builder-config.js
+++ b/web/packages/teleterm/electron-builder-config.js
@@ -170,6 +170,7 @@ module.exports = {
           '-c',
           "$ProgressPreference = 'SilentlyContinue'; " +
             "$ErrorActionPreference = 'Stop'; " +
+            '$PSNativeCommandUseErrorActionPreference = $true; ' +
             '. ../../../build.assets/windows/build.ps1; ' +
             `Invoke-SignBinary -UnsignedBinaryPath "${customSign.path}"`,
         ],


### PR DESCRIPTION
Closes #52055.
teleport.e counterpart: https://github.com/gravitational/teleport.e/pull/6225

Our build scripts already set [`$ErrorActionPreference`](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables?view=powershell-7.5#erroractionpreference), but that controls the behavior only for errors returned from cmdlets. To make PowerShell scripts exit on error for native commands (such as `pnpm install`), we need to set [`$PSNativeCommandUseErrorActionPreference`](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables?view=powershell-7.5#psnativecommanduseerroractionpreference) to `$true`.

* [An example of a failed build](https://github.com/gravitational/teleport.e/actions/runs/14038137914/job/39301253722#step:7:568) where a non-zero exit code from `pnpm install` fails the build.
* [An example of a successful build](https://github.com/gravitational/teleport.e/actions/runs/14038524250/job/39302572262) that has `$PSNativeCommandUseErrorActionPreference` set to `$true` but no commands fail.

I guess the only contraindication to using this option is if we had code that explicitly inspects the exit code of a native command, similar to how it's shown in [the docs for `$PSNativeCommandUseErrorActionPreference`](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables?view=powershell-7.5#psnativecommanduseerroractionpreference). However, we only have [a single place which uses `$LASTEXITCODE`](https://github.com/gravitational/teleport.e/blob/da0efb10bd8555bc03aec7dafee72fc0bfd19e0f/.github/workflows/build-windows.yaml#L138-L143) and it does not inspect the code.