### PR TITLE
Add SFTP session details for agentless sessions

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -6279,7 +6279,7 @@ func testDataTransfer(t *testing.T, suite *integrationTestSuite) {
 	require.Len(t, output, MB)
 
 	// Make sure the session.data event was emitted to the audit log.
-	eventFields, err := findEventInLog(main, events.SessionDataEvent)
+	eventFields, err := findEventInLog(main, events.SessionDataEvent, time.Time{})
 	require.NoError(t, err)
 
 	// Make sure the audit event shows that 1 MB was written to the output.
@@ -6758,7 +6758,7 @@ func testBPFSessionDifferentiation(t *testing.T, suite *integrationTestSuite) {
 	for i := 0; i < 10; i++ {
 		sessionIDs := map[string]bool{}
 
-		eventFields, err := eventsInLog(main.Config.DataDir+"/log/events.log", events.SessionCommandEvent)
+		eventFields, err := eventsInLog(main.Config.DataDir+"/log/events.log", time.Time{})
 		if err != nil {
 			time.Sleep(1 * time.Second)
 			continue
@@ -7011,7 +7011,7 @@ func testSessionStartContainsAccessRequest(t *testing.T, suite *integrationTestS
 	require.NoError(t, err)
 
 	// Get session start event
-	sessionStart, err := findEventInLog(main, events.SessionStartEvent)
+	sessionStart, err := findEventInLog(main, events.SessionStartEvent, time.Time{})
 	require.NoError(t, err)
 	require.Equal(t, events.SessionStartCode, sessionStart.GetCode())
 	require.True(t, sessionStart.HasField(accessRequestsKey))
@@ -7043,9 +7043,9 @@ func WaitForResource(t *testing.T, watcher types.Watcher, kind, name string) {
 }
 
 // findEventInLog polls the event log looking for an event of a particular type.
-func findEventInLog(t *helpers.TeleInstance, eventName string) (events.EventFields, error) {
+func findEventInLog(t *helpers.TeleInstance, eventName string, after time.Time) (events.EventFields, error) {
 	for i := 0; i < 10; i++ {
-		eventFields, err := eventsInLog(t.Config.DataDir+"/log/events.log", eventName)
+		eventFields, err := eventsInLog(t.Config.DataDir+"/log/events.log", after)
 		if err != nil {
 			time.Sleep(1 * time.Second)
 			continue
@@ -7077,7 +7077,7 @@ func findCommandEventInLog(t *helpers.TeleInstance, eventName string, programNam
 
 func findMatchingEventInLog(t *helpers.TeleInstance, eventName string, match func(events.EventFields) bool) (events.EventFields, error) {
 	for i := 0; i < 10; i++ {
-		eventFields, err := eventsInLog(t.Config.DataDir+"/log/events.log", eventName)
+		eventFields, err := eventsInLog(t.Config.DataDir+"/log/events.log", time.Time{})
 		if err != nil {
 			time.Sleep(1 * time.Second)
 			continue
@@ -7095,7 +7095,7 @@ func findMatchingEventInLog(t *helpers.TeleInstance, eventName string, match fun
 }
 
 // eventsInLog returns all events in a log file.
-func eventsInLog(path string, eventName string) ([]events.EventFields, error) {
+func eventsInLog(path string, after time.Time) ([]events.EventFields, error) {
 	var ret []events.EventFields
 
 	file, err := os.Open(path)
@@ -7111,7 +7111,9 @@ func eventsInLog(path string, eventName string) ([]events.EventFields, error) {
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		ret = append(ret, fields)
+		if fields.GetTimestamp().After(after) {
+			ret = append(ret, fields)
+		}
 	}
 
 	if len(ret) == 0 {
@@ -8120,6 +8122,9 @@ func testSFTP(t *testing.T, suite *integrationTestSuite) {
 	err := teleport.WaitForNodeCount(context.Background(), helpers.Site, 1)
 	require.NoError(t, err)
 
+	agentlessHost := "agentless-node"
+	agentlessNode := testenv.CreateAgentlessNode(t, teleport.Process.GetAuthServer(), helpers.Site, agentlessHost)
+
 	teleportClient, err := teleport.NewClient(helpers.ClientConfig{
 		Login:   suite.Me.Username,
 		Cluster: helpers.Site,
@@ -8127,168 +8132,239 @@ func testSFTP(t *testing.T, suite *integrationTestSuite) {
 	})
 	require.NoError(t, err)
 
-	// Create SFTP session.
-	ctx := context.Background()
-	clusterClient, err := teleportClient.ConnectToCluster(ctx)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = clusterClient.Close()
-	})
-
-	nodeClient, err := teleportClient.ConnectToNode(
-		ctx,
-		clusterClient,
-		client.NodeDetails{
-			Addr:    teleport.Config.SSH.Addr.Addr,
-			Cluster: helpers.Site,
+	tests := []struct {
+		name     string
+		nodeAddr string
+	}{
+		{
+			name:     "regular",
+			nodeAddr: teleport.Config.SSH.Addr.Addr,
 		},
-		suite.Me.Username,
-	)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, nodeClient.Close())
-	})
+		{
+			name:     "agentless",
+			nodeAddr: agentlessNode.Spec.Addr,
+		},
+	}
 
-	sftpClient, err := sftp.NewClient(nodeClient.Client.Client)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, sftpClient.Close())
-	})
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create SFTP session.
+			ctx := t.Context()
+			clusterClient, err := teleportClient.ConnectToCluster(ctx)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_ = clusterClient.Close()
+			})
 
-	// Create file that will be uploaded and downloaded.
-	tempDir := t.TempDir()
-	testFilePath := filepath.Join(tempDir, "testfile")
-	testFile, err := os.Create(testFilePath)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, testFile.Close())
-	})
+			nodeClient, err := teleportClient.ConnectToNode(
+				ctx,
+				clusterClient,
+				client.NodeDetails{
+					Addr:    tc.nodeAddr,
+					Cluster: helpers.Site,
+				},
+				suite.Me.Username,
+			)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				// Ignore io.EOF.
+				_ = nodeClient.Close()
+			})
 
-	contents := []byte("This is test data.")
-	_, err = testFile.Write(contents)
-	require.NoError(t, err)
-	require.NoError(t, testFile.Sync())
-	_, err = testFile.Seek(0, io.SeekStart)
-	require.NoError(t, err)
+			sftpClient, err := sftp.NewClient(nodeClient.Client.Client)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				// Ignore io.EOF.
+				_ = sftpClient.Close()
+			})
 
-	// Test stat'ing a file.
-	t.Run("stat", func(t *testing.T) {
-		fi, err := sftpClient.Stat(testFilePath)
-		require.NoError(t, err)
-		require.NotNil(t, fi)
-	})
+			// Create file that will be uploaded and downloaded.
+			tempDir := t.TempDir()
+			testFilePath := filepath.Join(tempDir, "testfile")
+			testFile, err := os.Create(testFilePath)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				require.NoError(t, testFile.Close())
+			})
 
-	// Test downloading a file.
-	t.Run("download", func(t *testing.T) {
-		testFileDownload := testFilePath + "-download"
-		downloadFile, err := os.Create(testFileDownload)
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			require.NoError(t, downloadFile.Close())
+			contents := []byte("This is test data.")
+			_, err = testFile.Write(contents)
+			require.NoError(t, err)
+			require.NoError(t, testFile.Sync())
+			_, err = testFile.Seek(0, io.SeekStart)
+			require.NoError(t, err)
+
+			// Test stat'ing a file.
+			t.Run("stat", func(t *testing.T) {
+				fi, err := sftpClient.Stat(testFilePath)
+				require.NoError(t, err)
+				require.NotNil(t, fi)
+			})
+
+			// Test downloading a file.
+			t.Run("download", func(t *testing.T) {
+				start := time.Now()
+				testFileDownload := testFilePath + "-download"
+				downloadFile, err := os.Create(testFileDownload)
+				require.NoError(t, err)
+				t.Cleanup(func() {
+					require.NoError(t, downloadFile.Close())
+				})
+
+				remoteDownloadFile, err := sftpClient.Open(testFilePath)
+				require.NoError(t, err)
+				t.Cleanup(func() {
+					require.NoError(t, remoteDownloadFile.Close())
+				})
+
+				_, err = io.Copy(downloadFile, remoteDownloadFile)
+				require.NoError(t, err)
+
+				_, err = downloadFile.Seek(0, io.SeekStart)
+				require.NoError(t, err)
+				data, err := io.ReadAll(downloadFile)
+				require.NoError(t, err)
+				require.Equal(t, contents, data)
+
+				// Ensure SFTP audit events are present.
+				sftpEvent, err := findEventInLog(teleport, events.SFTPEvent, start)
+				if assert.NoError(t, err) {
+					assert.Equal(t, events.SFTPOpenCode, sftpEvent.GetCode())
+					assert.Equal(t, testFilePath, sftpEvent.GetString(events.SFTPPath))
+				}
+			})
+
+			// Test uploading a file.
+			t.Run("upload", func(t *testing.T) {
+				start := time.Now()
+				testFileUpload := testFilePath + "-upload"
+				remoteUploadFile, err := sftpClient.Create(testFileUpload)
+				require.NoError(t, err)
+				t.Cleanup(func() {
+					require.NoError(t, remoteUploadFile.Close())
+				})
+
+				_, err = io.Copy(remoteUploadFile, testFile)
+				require.NoError(t, err)
+
+				_, err = remoteUploadFile.Seek(0, io.SeekStart)
+				require.NoError(t, err)
+				data, err := io.ReadAll(remoteUploadFile)
+				require.NoError(t, err)
+				require.Equal(t, contents, data)
+
+				// Ensure SFTP audit events are present.
+				sftpEvent, err := findEventInLog(teleport, events.SFTPEvent, start)
+				if assert.NoError(t, err) {
+					assert.Equal(t, events.SFTPOpenCode, sftpEvent.GetCode())
+					assert.Equal(t, testFileUpload, sftpEvent.GetString(events.SFTPPath))
+				}
+			})
+
+			// Test changing file permissions.
+			t.Run("chmod", func(t *testing.T) {
+				start := time.Now()
+				err := sftpClient.Chmod(testFilePath, 0o777)
+				require.NoError(t, err)
+
+				fi, err := os.Stat(testFilePath)
+				require.NoError(t, err)
+				require.Equal(t, fs.FileMode(0o777), fi.Mode().Perm())
+
+				// Ensure SFTP audit events are present.
+				sftpEvent, err := findEventInLog(teleport, events.SFTPEvent, start)
+				if assert.NoError(t, err) {
+					assert.Equal(t, events.SFTPSetstatCode, sftpEvent.GetCode())
+					assert.Equal(t, testFilePath, sftpEvent.GetString(events.SFTPPath))
+				}
+			})
+
+			// Test operations on a directory.
+			t.Run("mkdir", func(t *testing.T) {
+				start := time.Now()
+				dirPath := filepath.Join(tempDir, "dir")
+				require.NoError(t, sftpClient.Mkdir(dirPath))
+
+				err := sftpClient.Chmod(dirPath, 0o777)
+				require.NoError(t, err)
+
+				fi, err := os.Stat(dirPath)
+				require.NoError(t, err)
+				require.Equal(t, fs.FileMode(0o777), fi.Mode().Perm())
+
+				f, err := sftpClient.Create(filepath.Join(dirPath, "file"))
+				require.NoError(t, err)
+				require.NoError(t, f.Close())
+
+				fileInfos, err := sftpClient.ReadDir(dirPath)
+				require.NoError(t, err)
+				require.Len(t, fileInfos, 1)
+				require.Equal(t, "file", fileInfos[0].Name())
+
+				// Ensure SFTP audit events are present.
+				sftpEvent, err := findEventInLog(teleport, events.SFTPEvent, start)
+				if assert.NoError(t, err) {
+					assert.Equal(t, events.SFTPMkdirCode, sftpEvent.GetCode())
+					assert.Equal(t, dirPath, sftpEvent.GetString(events.SFTPPath))
+				}
+			})
+
+			// Test renaming a file.
+			t.Run("rename", func(t *testing.T) {
+				path := filepath.Join(tempDir, "to-be-renamed")
+				f, err := sftpClient.Create(path)
+				require.NoError(t, err)
+				require.NoError(t, f.Close())
+
+				newPath := path + "-done"
+				start := time.Now()
+				err = sftpClient.Rename(path, newPath)
+				require.NoError(t, err)
+
+				_, err = sftpClient.Stat(path)
+				require.ErrorIs(t, err, os.ErrNotExist)
+				_, err = sftpClient.Stat(newPath)
+				require.NoError(t, err)
+
+				// Ensure SFTP audit events are present.
+				sftpEvent, err := findEventInLog(teleport, events.SFTPEvent, start)
+				if assert.NoError(t, err) {
+					assert.Equal(t, events.SFTPRenameCode, sftpEvent.GetCode())
+					assert.Equal(t, path, sftpEvent.GetString(events.SFTPPath))
+					assert.Equal(t, newPath, sftpEvent.GetString("target_path"))
+				}
+			})
+
+			// Test removing a file.
+			t.Run("remove", func(t *testing.T) {
+				path := filepath.Join(tempDir, "to-be-removed")
+				f, err := sftpClient.Create(path)
+				require.NoError(t, err)
+				require.NoError(t, f.Close())
+
+				start := time.Now()
+				err = sftpClient.Remove(path)
+				require.NoError(t, err)
+
+				_, err = sftpClient.Stat(path)
+				require.ErrorIs(t, err, os.ErrNotExist)
+
+				// Ensure SFTP audit events are present.
+				sftpEvent, err := findEventInLog(teleport, events.SFTPEvent, start)
+				if assert.NoError(t, err) {
+					assert.Equal(t, events.SFTPRemoveCode, sftpEvent.GetCode())
+					assert.Equal(t, path, sftpEvent.GetString(events.SFTPPath))
+				}
+			})
+
+			// Check for summary audit event.
+			start := time.Now()
+			require.NoError(t, sftpClient.Close())
+			require.NoError(t, nodeClient.Close())
+			_, err = findEventInLog(teleport, events.SFTPSummaryEvent, start)
+			require.NoError(t, err)
 		})
-
-		remoteDownloadFile, err := sftpClient.Open(testFilePath)
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			require.NoError(t, remoteDownloadFile.Close())
-		})
-
-		_, err = io.Copy(downloadFile, remoteDownloadFile)
-		require.NoError(t, err)
-
-		_, err = downloadFile.Seek(0, io.SeekStart)
-		require.NoError(t, err)
-		data, err := io.ReadAll(downloadFile)
-		require.NoError(t, err)
-		require.Equal(t, contents, data)
-	})
-
-	// Test uploading a file.
-	t.Run("upload", func(t *testing.T) {
-		testFileUpload := testFilePath + "-upload"
-		remoteUploadFile, err := sftpClient.Create(testFileUpload)
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			require.NoError(t, remoteUploadFile.Close())
-		})
-
-		_, err = io.Copy(remoteUploadFile, testFile)
-		require.NoError(t, err)
-
-		_, err = remoteUploadFile.Seek(0, io.SeekStart)
-		require.NoError(t, err)
-		data, err := io.ReadAll(remoteUploadFile)
-		require.NoError(t, err)
-		require.Equal(t, contents, data)
-	})
-
-	// Test changing file permissions.
-	t.Run("chmod", func(t *testing.T) {
-		err := sftpClient.Chmod(testFilePath, 0o777)
-		require.NoError(t, err)
-
-		fi, err := os.Stat(testFilePath)
-		require.NoError(t, err)
-		require.Equal(t, fs.FileMode(0o777), fi.Mode().Perm())
-	})
-
-	// Test operations on a directory.
-	t.Run("mkdir", func(t *testing.T) {
-		dirPath := filepath.Join(tempDir, "dir")
-		require.NoError(t, sftpClient.Mkdir(dirPath))
-
-		err := sftpClient.Chmod(dirPath, 0o777)
-		require.NoError(t, err)
-
-		fi, err := os.Stat(dirPath)
-		require.NoError(t, err)
-		require.Equal(t, fs.FileMode(0o777), fi.Mode().Perm())
-
-		f, err := sftpClient.Create(filepath.Join(dirPath, "file"))
-		require.NoError(t, err)
-		require.NoError(t, f.Close())
-
-		fileInfos, err := sftpClient.ReadDir(dirPath)
-		require.NoError(t, err)
-		require.Len(t, fileInfos, 1)
-		require.Equal(t, "file", fileInfos[0].Name())
-	})
-
-	// Test renaming a file.
-	t.Run("rename", func(t *testing.T) {
-		path := filepath.Join(tempDir, "to-be-renamed")
-		f, err := sftpClient.Create(path)
-		require.NoError(t, err)
-		require.NoError(t, f.Close())
-
-		newPath := path + "-done"
-		err = sftpClient.Rename(path, newPath)
-		require.NoError(t, err)
-
-		_, err = sftpClient.Stat(path)
-		require.ErrorIs(t, err, os.ErrNotExist)
-		_, err = sftpClient.Stat(newPath)
-		require.NoError(t, err)
-	})
-
-	// Test removing a file.
-	t.Run("remove", func(t *testing.T) {
-		path := filepath.Join(tempDir, "to-be-removed")
-		f, err := sftpClient.Create(path)
-		require.NoError(t, err)
-		require.NoError(t, f.Close())
-
-		err = sftpClient.Remove(path)
-		require.NoError(t, err)
-
-		_, err = sftpClient.Stat(path)
-		require.ErrorIs(t, err, os.ErrNotExist)
-	})
-
-	// Ensure SFTP audit events are present.
-	sftpEvent, err := findEventInLog(teleport, events.SFTPEvent)
-	require.NoError(t, err)
-	require.Equal(t, testFilePath, sftpEvent.GetString(events.SFTPPath))
+	}
 }
 
 func testAgentlessConnection(t *testing.T, suite *integrationTestSuite) {

--- a/lib/srv/forward/sftp.go
+++ b/lib/srv/forward/sftp.go
@@ -1,0 +1,237 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package forward
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/pkg/sftp"
+
+	"github.com/gravitational/teleport"
+	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/srv"
+	sftputils "github.com/gravitational/teleport/lib/sshutils/sftp"
+)
+
+// SFTPProxy proxies an SFTP session and emits audit events for the handled
+// commands.
+type SFTPProxy struct {
+	srv      *sftp.RequestServer
+	handlers *proxyHandlers
+}
+
+// NewSFTPProxy creates a new SFTPProxy to serve the given channel.
+func NewSFTPProxy(
+	scx *srv.ServerContext,
+	channel io.ReadWriteCloser,
+	logger *slog.Logger,
+) (*SFTPProxy, error) {
+	if scx == nil {
+		return nil, trace.BadParameter("missing parameter scx")
+	}
+	if channel == nil {
+		return nil, trace.BadParameter("missing parameter channel")
+	}
+	if logger == nil {
+		logger = slog.With(teleport.ComponentKey, "SFTP")
+	}
+
+	client, err := sftp.NewClient(scx.RemoteClient.Client)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	remoteFS := sftputils.NewRemoteFilesystem(client)
+	wd, err := remoteFS.Getwd()
+	if err != nil {
+		logger.WarnContext(scx.CancelContext(), `Unable to get working directory, defaulting to "/"`)
+	}
+	h := &proxyHandlers{
+		scx:      scx,
+		remoteFS: remoteFS,
+		logger:   logger,
+	}
+	handlers := sftp.Handlers{
+		FileGet:  h,
+		FilePut:  h,
+		FileCmd:  h,
+		FileList: h,
+	}
+	srv := sftp.NewRequestServer(channel, handlers, sftp.WithStartDirectory(wd))
+	return &SFTPProxy{srv: srv, handlers: h}, nil
+}
+
+// Serve serves SFTP requests. It returns after either [*SFTPProxy.Close] is
+// called or the underlying connection is closed.
+func (p *SFTPProxy) Serve() error {
+	// Run server to completion.
+	serveErr := p.srv.Serve()
+	// After the server has finished, send a summary event.
+	scx := p.handlers.scx
+	summaryEvent := &apievents.SFTPSummary{
+		Metadata: apievents.Metadata{
+			Type: events.SFTPSummaryEvent,
+			Code: events.SFTPSummaryCode,
+			Time: time.Now(),
+		},
+		ServerMetadata:  scx.GetServer().TargetMetadata(),
+		SessionMetadata: scx.GetSessionMetadata(),
+		UserMetadata:    scx.Identity.GetUserMetadata(),
+		ConnectionMetadata: apievents.ConnectionMetadata{
+			RemoteAddr: scx.ServerConn.RemoteAddr().String(),
+			LocalAddr:  scx.ServerConn.LocalAddr().String(),
+		},
+	}
+
+	for _, f := range p.handlers.files {
+		summaryEvent.FileTransferStats = append(summaryEvent.FileTransferStats, &apievents.FileTransferStat{
+			Path:         f.Name(),
+			BytesRead:    f.BytesRead(),
+			BytesWritten: f.BytesWritten(),
+		})
+	}
+	if err := scx.GetServer().EmitAuditEvent(scx.CancelContext(), summaryEvent); err != nil {
+		p.handlers.logger.WarnContext(scx.CancelContext(), "Failed to emit SFTP summary event", "error", err)
+	}
+
+	return trace.Wrap(serveErr)
+}
+
+// Close closes the SFTP proxy.
+func (p *SFTPProxy) Close() error {
+	return trace.Wrap(p.srv.Close())
+}
+
+type proxyHandlers struct {
+	scx      *srv.ServerContext
+	remoteFS sftputils.FileSystem
+	logger   *slog.Logger
+
+	fileMtx sync.Mutex
+	files   []*sftputils.TrackedFile
+}
+
+// Fileread handles Open requests for reading files.
+func (h *proxyHandlers) Fileread(req *sftp.Request) (_ io.ReaderAt, err error) {
+	defer h.sendSFTPEvent(req, err)
+	if req.Filepath == "" {
+		return nil, os.ErrInvalid
+	}
+	if !req.Pflags().Read {
+		return nil, os.ErrInvalid
+	}
+	f, err := h.remoteFS.Open(req.Filepath)
+	if err != nil {
+		return nil, err
+	}
+	return h.trackFile(f), nil
+}
+
+// Filewrite handles Open requests for writing files.
+func (h *proxyHandlers) Filewrite(req *sftp.Request) (_ io.WriterAt, err error) {
+	defer h.sendSFTPEvent(req, err)
+	if req.Filepath == "" {
+		return nil, os.ErrInvalid
+	}
+	if !req.Pflags().Write {
+		return nil, os.ErrInvalid
+	}
+	f, err := h.remoteFS.Create(req.Filepath, 0)
+	if err != nil {
+		return nil, err
+	}
+	return h.trackFile(f), nil
+}
+
+// OpenFile handles Open requests for both reading and writing. Required to
+// satisfy [sftp.OpenFileWriter].
+func (h *proxyHandlers) OpenFile(req *sftp.Request) (_ sftp.WriterAtReaderAt, retErr error) {
+	defer h.sendSFTPEvent(req, retErr)
+
+	if req.Filepath == "" {
+		return nil, os.ErrInvalid
+	}
+
+	f, err := h.remoteFS.OpenFile(req.Filepath, sftputils.ParseFlags(req))
+	if err != nil {
+		return nil, err
+	}
+	return h.trackFile(f), nil
+}
+
+func (h *proxyHandlers) trackFile(f sftputils.File) sftp.WriterAtReaderAt {
+	trackFile := &sftputils.TrackedFile{File: f}
+	h.fileMtx.Lock()
+	defer h.fileMtx.Unlock()
+	h.files = append(h.files, trackFile)
+	return trackFile
+}
+
+// Filecmd handles file commands.
+func (h *proxyHandlers) Filecmd(req *sftp.Request) (err error) {
+	defer func() {
+		if !errors.Is(err, sftp.ErrSSHFxOpUnsupported) {
+			h.sendSFTPEvent(req, err)
+		}
+	}()
+	return sftputils.HandleFilecmd(req, h.remoteFS)
+}
+
+// Filelist handles listing info about files.
+func (h *proxyHandlers) Filelist(req *sftp.Request) (_ sftp.ListerAt, err error) {
+	defer func() {
+		if req.Method == sftputils.MethodList {
+			h.sendSFTPEvent(req, err)
+		}
+	}()
+	lister, err := sftputils.HandleFilelist(req, h.remoteFS)
+	if err != nil {
+		return nil, err
+	}
+	return lister, nil
+}
+
+func (h *proxyHandlers) sendSFTPEvent(req *sftp.Request, reqErr error) {
+	wd, err := h.remoteFS.Getwd()
+	if err != nil {
+		h.logger.WarnContext(req.Context(), "Unable to get working directory", "error", err)
+		// Emit event without working directory.
+	}
+	event, err := sftputils.ParseSFTPEvent(req, wd, reqErr)
+	if err != nil {
+		h.logger.WarnContext(req.Context(), "Unknown SFTP request", "request", req.Method)
+		return
+	} else if reqErr != nil {
+		h.logger.DebugContext(req.Context(), "failed handling SFTP request", "request", req.Method, "error", reqErr)
+	}
+	event.ServerMetadata = h.scx.GetServer().TargetMetadata()
+	event.SessionMetadata = h.scx.GetSessionMetadata()
+	event.UserMetadata = h.scx.Identity.GetUserMetadata()
+	event.ConnectionMetadata = apievents.ConnectionMetadata{
+		RemoteAddr: h.scx.ServerConn.RemoteAddr().String(),
+		LocalAddr:  h.scx.ServerConn.LocalAddr().String(),
+	}
+	if err := h.scx.GetServer().EmitAuditEvent(req.Context(), event); err != nil {
+		h.logger.WarnContext(req.Context(), "Failed to emit SFTP event", "error", err)
+	}
+}

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -1477,7 +1477,7 @@ func (s *Server) handleSubsystem(ctx context.Context, ch ssh.Channel, req *ssh.R
 	}
 
 	// if SFTP was requested, check that
-	if subsystem.subsystemName == teleport.SFTPSubsystem {
+	if subsystem.Name() == teleport.SFTPSubsystem {
 		err := serverContext.CheckSFTPAllowed(s.sessionRegistry)
 		if err != nil {
 			s.EmitAuditEvent(context.WithoutCancel(ctx), &apievents.SFTP{
@@ -1498,7 +1498,7 @@ func (s *Server) handleSubsystem(ctx context.Context, ch ssh.Channel, req *ssh.R
 	err = subsystem.Start(ctx, ch)
 	if err != nil {
 		serverContext.SendSubsystemResult(ctx, srv.SubsystemResult{
-			Name: subsystem.subsystemName,
+			Name: subsystem.Name(),
 			Err:  trace.Wrap(err),
 		})
 		return trace.Wrap(err)
@@ -1508,7 +1508,7 @@ func (s *Server) handleSubsystem(ctx context.Context, ch ssh.Channel, req *ssh.R
 	go func() {
 		err := subsystem.Wait()
 		serverContext.SendSubsystemResult(ctx, srv.SubsystemResult{
-			Name: subsystem.subsystemName,
+			Name: subsystem.Name(),
 			Err:  trace.Wrap(err),
 		})
 	}()
@@ -1595,7 +1595,7 @@ func (s *Server) stderrWrite(ctx context.Context, ch ssh.Channel, message string
 	}
 }
 
-func parseSubsystemRequest(req *ssh.Request, ctx *srv.ServerContext) (*remoteSubsystem, error) {
+func parseSubsystemRequest(req *ssh.Request, ctx *srv.ServerContext) (RemoteSubsystem, error) {
 	var r sshutils.SubsystemReq
 	err := ssh.Unmarshal(req.Payload, &r)
 	if err != nil {

--- a/lib/srv/forward/subsystem.go
+++ b/lib/srv/forward/subsystem.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"time"
 
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
@@ -32,6 +33,16 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/srv"
 )
+
+// RemoteSubsystem is a handle for a remote subsystem.
+type RemoteSubsystem interface {
+	// Name is the name of the subsystem.
+	Name() string
+	// Start starts the subsystem on the given channel.
+	Start(ctx context.Context, channel ssh.Channel) error
+	// Wait waits for the subsystem to finish.
+	Wait() error
+}
 
 // remoteSubsystem is a subsystem that executes on a remote node.
 type remoteSubsystem struct {
@@ -45,8 +56,8 @@ type remoteSubsystem struct {
 }
 
 // parseRemoteSubsystem returns *remoteSubsystem which can be used to run a subsystem on a remote node.
-func parseRemoteSubsystem(ctx context.Context, subsystemName string, serverContext *srv.ServerContext) *remoteSubsystem {
-	return &remoteSubsystem{
+func parseRemoteSubsystem(ctx context.Context, subsystemName string, serverContext *srv.ServerContext) RemoteSubsystem {
+	r := &remoteSubsystem{
 		logger: slog.With(
 			teleport.ComponentKey, teleport.ComponentRemoteSubsystem,
 			"name", subsystemName,
@@ -54,8 +65,20 @@ func parseRemoteSubsystem(ctx context.Context, subsystemName string, serverConte
 		serverContext: serverContext,
 		subsystemName: subsystemName,
 		ctx:           ctx,
-		errorCh:       make(chan error, 3),
 	}
+	if subsystemName == teleport.SFTPSubsystem {
+		r.errorCh = make(chan error, 1) // one error for the sftp proxy as a whole
+		return &remoteSFTPSubsystem{
+			subsystem: r,
+		}
+	}
+	r.errorCh = make(chan error, 3) // one error each for stdin, stdout, and stderr
+	return r
+}
+
+// Name returns the name of the subsystem.
+func (r *remoteSubsystem) Name() string {
+	return r.subsystemName
 }
 
 // Start will begin execution of the remote subsystem on the passed in channel.
@@ -112,7 +135,7 @@ func (r *remoteSubsystem) Start(ctx context.Context, channel ssh.Channel) error 
 func (r *remoteSubsystem) Wait() error {
 	var lastErr error
 
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		select {
 		case err := <-r.errorCh:
 			if err != nil && !errors.Is(err, io.EOF) {
@@ -154,4 +177,67 @@ func (r *remoteSubsystem) emitAuditEvent(ctx context.Context, err error) {
 	if err := r.serverContext.GetServer().EmitAuditEvent(ctx, subsystemEvent); err != nil {
 		r.logger.WarnContext(ctx, "Failed to emit subsystem audit event", "error", err)
 	}
+}
+
+type remoteSFTPSubsystem struct {
+	subsystem *remoteSubsystem
+	proxy     *SFTPProxy
+}
+
+// Name returns the name of the subsystem.
+func (r *remoteSFTPSubsystem) Name() string {
+	return r.subsystem.Name()
+}
+
+// Start will begin execution of the remote SFTP subsystem on the passed in channel.
+func (r *remoteSFTPSubsystem) Start(ctx context.Context, channel ssh.Channel) error {
+	proxy, err := NewSFTPProxy(r.subsystem.serverContext, channel, r.subsystem.logger)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	r.proxy = proxy
+
+	go func() {
+		defer r.subsystem.serverContext.RemoteSession.Close()
+		errCh := make(chan error)
+		go func() {
+			errCh <- proxy.Serve()
+			close(errCh)
+		}()
+
+		var err error
+		select {
+		case err = <-errCh: // Serve finished on its own, error is ready.
+		case <-ctx.Done(): // Stop Serve and wait for error.
+			proxy.Close()
+			select {
+			case err = <-errCh:
+			case <-time.After(5 * time.Second):
+				err = trace.Errorf("SFTP server timed out while closing")
+			}
+		}
+		r.subsystem.errorCh <- err
+	}()
+
+	return nil
+}
+
+// Wait waits until the remote SFTP subsystem has finished execution.
+func (r *remoteSFTPSubsystem) Wait() error {
+	var err error
+	select {
+	case err = <-r.subsystem.errorCh:
+		if errors.Is(err, io.EOF) {
+			err = nil
+		}
+		if err != nil {
+			r.subsystem.logger.WarnContext(r.subsystem.ctx, "Connection problem", "error", err)
+		}
+	case <-r.subsystem.ctx.Done():
+		err = trace.ConnectionProblem(nil, "context is closing")
+	}
+
+	// emit an event to the audit log with the result of execution
+	r.subsystem.emitAuditEvent(r.subsystem.ctx, err)
+	return trace.Wrap(err)
 }

--- a/lib/sshutils/sftp/remote.go
+++ b/lib/sshutils/sftp/remote.go
@@ -19,68 +19,38 @@
 package sftp
 
 import (
-	"context"
-	"io"
-	"io/fs"
 	"os"
 	portablepath "path"
-	"time"
 
-	"github.com/gravitational/trace"
 	"github.com/pkg/sftp"
 )
 
-// remoteFS provides API for accessing the files on
+// RemoteFS provides API for accessing the files on
 // the local file system
-type remoteFS struct {
-	c *sftp.Client
+type RemoteFS struct {
+	*sftp.Client
 }
 
-func (r *remoteFS) Type() string {
+// NewRemoteFilesystem creates a new FileSystem over SFTP.
+func NewRemoteFilesystem(c *sftp.Client) *RemoteFS {
+	return &RemoteFS{Client: c}
+}
+
+func (r *RemoteFS) Type() string {
 	return "remote"
 }
 
-func (r *remoteFS) Glob(ctx context.Context, pattern string) ([]string, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	matches, err := r.c.Glob(pattern)
+func (r *RemoteFS) ReadDir(path string) ([]os.FileInfo, error) {
+	fileInfos, err := r.Client.ReadDir(path)
 	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return matches, nil
-}
-
-func (r *remoteFS) Stat(ctx context.Context, path string) (os.FileInfo, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	fi, err := r.c.Stat(path)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return fi, nil
-}
-
-func (r *remoteFS) ReadDir(ctx context.Context, path string) ([]os.FileInfo, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	fileInfos, err := r.c.ReadDir(path)
-	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, err
 	}
 	for i := range fileInfos {
 		// if the file is a symlink, return the info of the linked file
 		if fileInfos[i].Mode().Type()&os.ModeSymlink != 0 {
-			fileInfos[i], err = r.c.Stat(portablepath.Join(path, fileInfos[i].Name()))
+			fileInfos[i], err = r.Stat(portablepath.Join(path, fileInfos[i].Name()))
 			if err != nil {
-				return nil, trace.Wrap(err)
+				return nil, err
 			}
 		}
 	}
@@ -88,57 +58,22 @@ func (r *remoteFS) ReadDir(ctx context.Context, path string) ([]os.FileInfo, err
 	return fileInfos, nil
 }
 
-func (r *remoteFS) Open(ctx context.Context, path string) (fs.File, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	f, err := r.c.Open(path)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return f, nil
+func (r *RemoteFS) Open(path string) (File, error) {
+	return r.OpenFile(path, os.O_RDONLY)
 }
 
-func (r *remoteFS) Create(ctx context.Context, path string, _ int64) (io.WriteCloser, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	f, err := r.c.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return f, nil
+func (r *RemoteFS) Create(path string, _ int64) (File, error) {
+	return r.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC)
 }
 
-func (r *remoteFS) Mkdir(ctx context.Context, path string) error {
-	if err := ctx.Err(); err != nil {
-		return trace.Wrap(err)
-	}
-
-	err := r.c.MkdirAll(path)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	return nil
+func (r *RemoteFS) OpenFile(path string, flags int) (File, error) {
+	return r.Client.OpenFile(path, flags)
 }
 
-func (r *remoteFS) Chmod(ctx context.Context, path string, mode os.FileMode) error {
-	if err := ctx.Err(); err != nil {
-		return trace.Wrap(err)
-	}
-
-	return trace.Wrap(r.c.Chmod(path, mode))
+func (r *RemoteFS) Mkdir(path string) error {
+	return r.Client.MkdirAll(path)
 }
 
-func (r *remoteFS) Chtimes(ctx context.Context, path string, atime, mtime time.Time) error {
-	if err := ctx.Err(); err != nil {
-		return trace.Wrap(err)
-	}
-
-	return trace.Wrap(r.c.Chtimes(path, atime, mtime))
+func (r *RemoteFS) Readlink(name string) (string, error) {
+	return r.Client.ReadLink(name)
 }

--- a/lib/sshutils/sftp/sftp.go
+++ b/lib/sshutils/sftp/sftp.go
@@ -45,6 +45,38 @@ import (
 	"github.com/gravitational/teleport/lib/sshutils/scp"
 )
 
+// SFTP request methods.
+const (
+	// MethodGet opens a file for reading.
+	MethodGet = "Get"
+	// MethodPut opens a file for writing.
+	MethodPut = "Put"
+	// MethodOpen opens a file.
+	MethodOpen = "Open"
+	// MethodSetStat sets a file's stats.
+	MethodSetStat = "Setstat"
+	// MethodRename renames a file.
+	MethodRename = "Rename"
+	// MethodRmdir removes a directory.
+	MethodRmdir = "Rmdir"
+	// MethodMkdir creates a directory.
+	MethodMkdir = "Mkdir"
+	// MethodLink creates a hard link.
+	MethodLink = "Link"
+	// MethodSymlink creates a symbolic link.
+	MethodSymlink = "Symlink"
+	// MethodRemove deletes a file.
+	MethodRemove = "Remove"
+	// MethodList lists directory entries.
+	MethodList = "List"
+	// MethodStat gets a directory entry's stat info.
+	MethodStat = "Stat"
+	// MethodLstat gets a directory entry's stat info, without following symbolic links.
+	MethodLstat = "Lstat"
+	// MethodReadlink gets the target of a symbolic link.
+	MethodReadlink = "Readlink"
+)
+
 // Options control aspects of a file transfer
 type Options struct {
 	// Recursive indicates recursive file transfer
@@ -73,26 +105,61 @@ type Config struct {
 	Log *slog.Logger
 }
 
-// FileSystem describes file operations to be done either locally or over SFTP
+// File is the file interface required for [FileSystem].
+type File interface {
+	sftp.WriterAtReaderAt
+	io.ReadWriteCloser
+	// Name returns the name of the file.
+	Name() string
+	// Stat returns the files stat info.
+	Stat() (fs.FileInfo, error)
+}
+
+// FileSystem describes file operations to be done either locally or over SFTP.
+//
+// Note: errors returned by a FileSystem should not be `trace.Wrap()`ed so the
+// sftp package can parse os errors.
 type FileSystem interface {
-	// Type returns whether the filesystem is "local" or "remote"
+	// Type returns whether the filesystem is "local" or "remote".
 	Type() string
-	// Glob returns matching files of a glob pattern
-	Glob(ctx context.Context, pattern string) ([]string, error)
-	// Stat returns info about a file
-	Stat(ctx context.Context, path string) (os.FileInfo, error)
-	// ReadDir returns information about files contained within a directory
-	ReadDir(ctx context.Context, path string) ([]os.FileInfo, error)
-	// Open opens a file
-	Open(ctx context.Context, path string) (fs.File, error)
-	// Create creates a new file
-	Create(ctx context.Context, path string, size int64) (io.WriteCloser, error)
-	// Mkdir creates a directory
-	Mkdir(ctx context.Context, path string) error
-	// Chmod sets file permissions
-	Chmod(ctx context.Context, path string, mode os.FileMode) error
-	// Chtimes sets file access and modification time
-	Chtimes(ctx context.Context, path string, atime, mtime time.Time) error
+	// Glob returns matching files of a glob pattern.
+	Glob(pattern string) ([]string, error)
+	// Stat returns info about a file.
+	Stat(path string) (os.FileInfo, error)
+	// ReadDir returns information about files contained within a directory.
+	ReadDir(path string) ([]os.FileInfo, error)
+	// Open opens a file for reading.
+	Open(path string) (File, error)
+	// Create creates a new file for writing.
+	Create(path string, size int64) (File, error)
+	// Mkdir creates a directory.
+	Mkdir(path string) error
+	// Chmod sets file permissions.
+	Chmod(path string, mode os.FileMode) error
+	// Chtimes sets file access and modification time.
+	Chtimes(path string, atime, mtime time.Time) error
+	// OpenFile opens a file with the given flags.
+	OpenFile(path string, flags int) (File, error)
+	// Rename renames a file.
+	Rename(oldpath, newpath string) error
+	// Lstat returns info about a file or symlink.
+	Lstat(name string) (os.FileInfo, error)
+	// RemoveAll recursively removes a file or directory.
+	RemoveAll(path string) error
+	// Link creates a new link.
+	Link(oldname, newname string) error
+	// Symlink creates a new symlink.
+	Symlink(oldname, newname string) error
+	// Remove removes a file or (empty) directory.
+	Remove(name string) error
+	// Chown changes a file's owner and/or group.
+	Chown(name string, uid, gid int) error
+	// Truncate truncates a file's contents.
+	Truncate(name string, size int64) error
+	// Readlink gets the destination for a symlink.
+	Readlink(name string) (string, error)
+	// Getwd gets the current working directory.
+	Getwd() (string, error)
 }
 
 // CreateUploadConfig returns a Config ready to upload files over SFTP.
@@ -110,7 +177,7 @@ func CreateUploadConfig(src []string, dst string, opts Options) (*Config, error)
 		srcPaths: src,
 		dstPath:  dst,
 		srcFS:    &localFS{},
-		dstFS:    &remoteFS{},
+		dstFS:    &RemoteFS{},
 		opts:     opts,
 	}
 	c.setDefaults()
@@ -130,7 +197,7 @@ func CreateDownloadConfig(src, dst string, opts Options) (*Config, error) {
 	c := &Config{
 		srcPaths: []string{src},
 		dstPath:  dst,
-		srcFS:    &remoteFS{},
+		srcFS:    &RemoteFS{},
 		dstFS:    &localFS{},
 		opts:     opts,
 	}
@@ -177,7 +244,7 @@ func CreateHTTPUploadConfig(req HTTPTransferRequest) (*Config, error) {
 			fileName: req.Src,
 			fileSize: fileSize,
 		},
-		dstFS: &remoteFS{},
+		dstFS: &RemoteFS{},
 	}
 	c.setDefaults()
 
@@ -197,7 +264,7 @@ func CreateHTTPDownloadConfig(req HTTPTransferRequest) (*Config, error) {
 	c := &Config{
 		srcPaths: []string{req.Src},
 		dstPath:  req.Dst,
-		srcFS:    &remoteFS{},
+		srcFS:    &RemoteFS{},
 		dstFS: &httpFS{
 			writer:   req.HTTPResponse,
 			fileName: req.Dst,
@@ -290,7 +357,7 @@ func (c *Config) TransferFiles(ctx context.Context, sshClient *ssh.Client) error
 		return trace.Wrap(err)
 	}
 
-	if err := c.initFS(sshClient, sftpClient); err != nil {
+	if err := c.initFS(sftpClient); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -304,16 +371,16 @@ func (c *Config) TransferFiles(ctx context.Context, sshClient *ssh.Client) error
 }
 
 // initFS ensures the source and destination filesystems are ready to transfer
-func (c *Config) initFS(sshClient *ssh.Client, client *sftp.Client) error {
+func (c *Config) initFS(client *sftp.Client) error {
 	var haveRemoteFS bool
-	srcFS, srcOK := c.srcFS.(*remoteFS)
+	srcFS, srcOK := c.srcFS.(*RemoteFS)
 	if srcOK {
-		srcFS.c = client
+		srcFS.Client = client
 		haveRemoteFS = true
 	}
-	dstFS, dstOK := c.dstFS.(*remoteFS)
+	dstFS, dstOK := c.dstFS.(*RemoteFS)
 	if dstOK {
-		dstFS.c = client
+		dstFS.Client = client
 		haveRemoteFS = true
 	}
 	// this will only happen in tests
@@ -408,7 +475,7 @@ func (c *Config) transfer(ctx context.Context) error {
 		// specified a file path containing glob pattern characters but
 		// means the literal path without globbing, in which case we'll
 		// use the raw source path as the sole match below.
-		matches, err := c.srcFS.Glob(ctx, srcPath)
+		matches, err := c.srcFS.Glob(srcPath)
 		if err != nil {
 			return trace.Wrap(err, "error matching glob pattern %q", srcPath)
 		}
@@ -424,7 +491,7 @@ func (c *Config) transfer(ctx context.Context) error {
 		matchedPaths = append(matchedPaths, matches...)
 
 		for _, match := range matches {
-			fi, err := c.srcFS.Stat(ctx, match)
+			fi, err := c.srcFS.Stat(match)
 			if err != nil {
 				return trace.Wrap(err, "could not access %s path %q", c.srcFS.Type(), match)
 			}
@@ -440,7 +507,7 @@ func (c *Config) transfer(ctx context.Context) error {
 	// validate destination path and create it if necessary
 	var dstIsDir bool
 	c.dstPath = path.Clean(c.dstPath)
-	dstInfo, err := c.dstFS.Stat(ctx, c.dstPath)
+	dstInfo, err := c.dstFS.Stat(c.dstPath)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			return trace.NotFound("error accessing %s path %q: %v", c.dstFS.Type(), c.dstPath, err)
@@ -448,10 +515,10 @@ func (c *Config) transfer(ctx context.Context) error {
 		// if there are multiple source paths and the destination path
 		// doesn't exist, create it as a directory
 		if len(matchedPaths) > 1 {
-			if err := c.dstFS.Mkdir(ctx, c.dstPath); err != nil {
+			if err := c.dstFS.Mkdir(c.dstPath); err != nil {
 				return trace.Errorf("error creating %s directory %q: %w", c.dstFS.Type(), c.dstPath, err)
 			}
-			if err := c.dstFS.Chmod(ctx, c.dstPath, defaults.DirectoryPermissions); err != nil {
+			if err := c.dstFS.Chmod(c.dstPath, defaults.DirectoryPermissions); err != nil {
 				return trace.Errorf("error setting permissions of %s directory %q: %w", c.dstFS.Type(), c.dstPath, err)
 			}
 			dstIsDir = true
@@ -498,15 +565,15 @@ func (c *Config) transfer(ctx context.Context) error {
 func (c *Config) transferDir(ctx context.Context, dstPath, srcPath string, srcFileInfo os.FileInfo) error {
 	c.Log.DebugContext(ctx, "transferring contents of directory", "source_fs", c.srcFS.Type(), "source_path", srcPath, "dest_fs", c.dstFS.Type(), "dest_path", dstPath)
 
-	err := c.dstFS.Mkdir(ctx, dstPath)
+	err := c.dstFS.Mkdir(dstPath)
 	if err != nil && !errors.Is(err, os.ErrExist) {
 		return trace.Errorf("error creating %s directory %q: %w", c.dstFS.Type(), dstPath, err)
 	}
-	if err := c.dstFS.Chmod(ctx, dstPath, srcFileInfo.Mode()); err != nil {
+	if err := c.dstFS.Chmod(dstPath, srcFileInfo.Mode()); err != nil {
 		return trace.Errorf("error setting permissions of %s directory %q: %w", c.dstFS.Type(), dstPath, err)
 	}
 
-	infos, err := c.srcFS.ReadDir(ctx, srcPath)
+	infos, err := c.srcFS.ReadDir(srcPath)
 	if err != nil {
 		return trace.Errorf("error reading %s directory %q: %w", c.srcFS.Type(), srcPath, err)
 	}
@@ -529,7 +596,7 @@ func (c *Config) transferDir(ctx context.Context, dstPath, srcPath string, srcFi
 	// set modification and access times last so creating sub dirs/files
 	// doesn't update the times
 	if c.opts.PreserveAttrs {
-		err := c.dstFS.Chtimes(ctx, dstPath, getAtime(srcFileInfo), srcFileInfo.ModTime())
+		err := c.dstFS.Chtimes(dstPath, getAtime(srcFileInfo), srcFileInfo.ModTime())
 		if err != nil {
 			return trace.Errorf("error changing times of %s directory %q: %w", c.dstFS.Type(), dstPath, err)
 		}
@@ -542,19 +609,19 @@ func (c *Config) transferDir(ctx context.Context, dstPath, srcPath string, srcFi
 func (c *Config) transferFile(ctx context.Context, dstPath, srcPath string, srcFileInfo os.FileInfo) error {
 	c.Log.DebugContext(ctx, "transferring file", "source_fs", c.srcFS.Type(), "source_file", srcPath, "dest_fs", c.dstFS.Type(), "dest_file", dstPath)
 
-	srcFile, err := c.srcFS.Open(ctx, srcPath)
+	srcFile, err := c.srcFS.Open(srcPath)
 	if err != nil {
 		return trace.Errorf("error opening %s file %q: %w", c.srcFS.Type(), srcPath, err)
 	}
 	defer srcFile.Close()
 
-	dstFile, err := c.dstFS.Create(ctx, dstPath, srcFileInfo.Size())
+	dstFile, err := c.dstFS.Create(dstPath, srcFileInfo.Size())
 	if err != nil {
 		return trace.Errorf("error creating %s file %q: %w", c.dstFS.Type(), dstPath, err)
 	}
 	defer dstFile.Close()
 
-	if err := c.dstFS.Chmod(ctx, dstPath, srcFileInfo.Mode()); err != nil {
+	if err := c.dstFS.Chmod(dstPath, srcFileInfo.Mode()); err != nil {
 		return trace.Errorf("error setting permissions of %s file %q: %w", c.dstFS.Type(), dstPath, err)
 	}
 
@@ -590,7 +657,7 @@ func (c *Config) transferFile(ctx context.Context, dstPath, srcPath string, srcF
 	}
 
 	if c.opts.PreserveAttrs {
-		err := c.dstFS.Chtimes(ctx, dstPath, getAtime(srcFileInfo), srcFileInfo.ModTime())
+		err := c.dstFS.Chtimes(dstPath, getAtime(srcFileInfo), srcFileInfo.ModTime())
 		if err != nil {
 			return trace.Errorf("error changing times of %s file %q: %w", c.dstFS.Type(), dstPath, err)
 		}
@@ -696,4 +763,162 @@ type NonRecursiveDirectoryTransferError struct {
 
 func (n *NonRecursiveDirectoryTransferError) Error() string {
 	return fmt.Sprintf("%q is a directory, but the recursive option was not passed", n.Path)
+}
+
+func setstat(req *sftp.Request, fs FileSystem) error {
+	attrFlags := req.AttrFlags()
+	attrs := req.Attributes()
+
+	if attrFlags.Acmodtime {
+		atime := time.Unix(int64(attrs.Atime), 0)
+		mtime := time.Unix(int64(attrs.Mtime), 0)
+
+		err := fs.Chtimes(req.Filepath, atime, mtime)
+		if err != nil {
+			return err
+		}
+	}
+	if attrFlags.Permissions {
+		err := fs.Chmod(req.Filepath, attrs.FileMode())
+		if err != nil {
+			return err
+		}
+	}
+	if attrFlags.UidGid {
+		err := fs.Chown(req.Filepath, int(attrs.UID), int(attrs.GID))
+		if err != nil {
+			return err
+		}
+	}
+	if attrFlags.Size {
+		err := fs.Truncate(req.Filepath, int64(attrs.Size))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// HandleFilecmd handles file command requests. If filesys is nil, the local
+// filesystem will be used.
+func HandleFilecmd(req *sftp.Request, filesys FileSystem) error {
+	if filesys == nil {
+		filesys = localFS{}
+	}
+	switch req.Method {
+	case MethodSetStat:
+		return setstat(req, filesys)
+	case MethodRename:
+		if req.Target == "" {
+			return os.ErrInvalid
+		}
+		return filesys.Rename(req.Filepath, req.Target)
+	case MethodRmdir:
+		fi, err := filesys.Lstat(req.Filepath)
+		if err != nil {
+			return err
+		}
+		if !fi.IsDir() {
+			return fmt.Errorf("%q is not a directory", req.Filepath)
+		}
+		return filesys.RemoveAll(req.Filepath)
+	case MethodMkdir:
+		return filesys.Mkdir(req.Filepath)
+	case MethodLink:
+		if req.Target == "" {
+			return os.ErrInvalid
+		}
+		return filesys.Link(req.Target, req.Filepath)
+	case MethodSymlink:
+		if req.Target == "" {
+			return os.ErrInvalid
+		}
+		return filesys.Symlink(req.Target, req.Filepath)
+	case MethodRemove:
+		fi, err := filesys.Lstat(req.Filepath)
+		if err != nil {
+			return err
+		}
+		if fi.IsDir() {
+			return fmt.Errorf("%q is a directory", req.Filepath)
+		}
+		return filesys.Remove(req.Filepath)
+	default:
+		return sftp.ErrSSHFxOpUnsupported
+	}
+}
+
+// listerAt satisfies [sftp.listerAt].
+type listerAt []fs.FileInfo
+
+func (l listerAt) ListAt(ls []fs.FileInfo, offset int64) (int, error) {
+	if offset >= int64(len(l)) {
+		return 0, io.EOF
+	}
+	n := copy(ls, l[offset:])
+	if n < len(ls) {
+		return n, io.EOF
+	}
+
+	return n, nil
+}
+
+// fileName satisfies [fs.FileInfo] but only knows a file's name. This
+// is necessary when handling 'readlink' requests in sftpHandler.FileList,
+// as only the file's name is known after a readlink call.
+type fileName string
+
+func (f fileName) Name() string {
+	return string(f)
+}
+
+func (f fileName) Size() int64 {
+	return 0
+}
+
+func (f fileName) Mode() fs.FileMode {
+	return 0
+}
+
+func (f fileName) ModTime() time.Time {
+	return time.Time{}
+}
+
+func (f fileName) IsDir() bool {
+	return false
+}
+
+func (f fileName) Sys() any {
+	return nil
+}
+
+// HandleFilelist handles file list requests. If filesys is nil, the local
+// filesystem will be used.
+func HandleFilelist(req *sftp.Request, filesys FileSystem) (sftp.ListerAt, error) {
+	if filesys == nil {
+		filesys = localFS{}
+	}
+	switch req.Method {
+	case MethodList:
+		entries, err := filesys.ReadDir(req.Filepath)
+		if err != nil {
+			return nil, err
+		}
+		return listerAt(entries), nil
+	case MethodStat:
+		fi, err := filesys.Stat(req.Filepath)
+		if err != nil {
+			return nil, err
+		}
+		return listerAt{fi}, nil
+	case MethodReadlink:
+		dst, err := filesys.Readlink(req.Filepath)
+		if err != nil {
+			return nil, err
+		}
+		return listerAt{fileName(dst)}, nil
+	default:
+		return nil, sftp.ErrSSHFxOpUnsupported
+	}
 }

--- a/lib/sshutils/sftp/sftp_test.go
+++ b/lib/sshutils/sftp/sftp_test.go
@@ -24,7 +24,9 @@ import (
 	cryptorand "crypto/rand"
 	"fmt"
 	"io"
+	"io/fs"
 	mathrand "math/rand/v2"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -32,10 +34,15 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
+	"github.com/pkg/sftp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -358,7 +365,7 @@ func TestUpload(t *testing.T) {
 			require.NoError(t, err)
 			// use all local filesystems to avoid SSH overhead
 			cfg.dstFS = &localFS{}
-			err = cfg.initFS(nil, nil)
+			err = cfg.initFS(nil)
 			require.NoError(t, err)
 
 			ctx := context.Background()
@@ -536,7 +543,7 @@ func TestDownload(t *testing.T) {
 			require.NoError(t, err)
 			// use all local filesystems to avoid SSH overhead
 			cfg.srcFS = &localFS{}
-			err = cfg.initFS(nil, nil)
+			err = cfg.initFS(nil)
 			require.NoError(t, err)
 
 			ctx := context.Background()
@@ -616,7 +623,7 @@ func TestCopyingSymlinkedFile(t *testing.T) {
 	require.NoError(t, err)
 	// use all local filesystems to avoid SSH overhead
 	cfg.srcFS = &localFS{}
-	err = cfg.initFS(nil, nil)
+	err = cfg.initFS(nil)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -813,5 +820,325 @@ func compareFileInfos(t *testing.T, preserveAttrs bool, dstInfo, srcInfo os.File
 		require.True(t, dstInfo.ModTime().Equal(srcInfo.ModTime()), "%q and %q mod times not equal", dst, src)
 		// don't check access times, locally they line up but they are
 		// often different when run in CI
+	}
+}
+
+type mockCmdHandlers struct {
+	sftp.Handlers
+}
+
+func (m mockCmdHandlers) Filecmd(req *sftp.Request) error {
+	return trace.Wrap(HandleFilecmd(req, localFS{}))
+}
+
+func TestHandleFilecmd(t *testing.T) {
+	t.Parallel()
+	// We're using a full client/server instead of just calling HandleFilecmd so
+	// the sftp package can handle marshaling attributes.
+	clientConn, serverConn := net.Pipe()
+	srv := sftp.NewRequestServer(serverConn, sftp.Handlers{
+		FileGet:  sftp.InMemHandler().FileGet,
+		FilePut:  sftp.InMemHandler().FilePut,
+		FileCmd:  mockCmdHandlers{},
+		FileList: sftp.InMemHandler().FileList,
+	})
+
+	t.Cleanup(func() { require.NoError(t, srv.Close()) })
+	go srv.Serve()
+
+	clt, err := sftp.NewClientPipe(clientConn, clientConn)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, clt.Close()) })
+
+	t.Run("chtimes", func(t *testing.T) {
+		root := t.TempDir()
+		file := filepath.Join(root, "test.txt")
+		require.NoError(t, os.WriteFile(file, []byte("test"), 0o644))
+		originalInfo, err := os.Stat(file)
+		require.NoError(t, err)
+		setTime := originalInfo.ModTime().Add(time.Hour).Round(time.Second)
+
+		assert.NoError(t, clt.Chtimes(file, setTime, setTime))
+		updatedInfo, err := os.Stat(file)
+		if assert.NoError(t, err) {
+			assert.Equal(t, setTime, updatedInfo.ModTime())
+		}
+	})
+
+	t.Run("chmod", func(t *testing.T) {
+		root := t.TempDir()
+		file := filepath.Join(root, "test.txt")
+		require.NoError(t, os.WriteFile(file, []byte("test"), 0o644))
+
+		assert.NoError(t, clt.Chmod(file, 0o666))
+		fi, err := os.Stat(file)
+		if assert.NoError(t, err) {
+			assert.Equal(t, fs.FileMode(0o666), fi.Mode().Perm())
+		}
+	})
+
+	t.Run("truncate", func(t *testing.T) {
+		root := t.TempDir()
+		file := filepath.Join(root, "test.txt")
+		require.NoError(t, os.WriteFile(file, []byte(strings.Repeat("a", 100)), 0o644))
+
+		assert.NoError(t, clt.Truncate(file, 50))
+		data, err := os.ReadFile(file)
+		if assert.NoError(t, err) {
+			assert.Len(t, data, 50)
+		}
+	})
+
+	t.Run("rename", func(t *testing.T) {
+		root := t.TempDir()
+		initialFile := filepath.Join(root, "foo.txt")
+		finalFile := filepath.Join(root, "bar.txt")
+		require.NoError(t, os.WriteFile(initialFile, []byte("test"), 0o644))
+
+		assert.NoError(t, clt.Rename(initialFile, finalFile))
+		assert.NoFileExists(t, initialFile)
+		assert.FileExists(t, finalFile)
+	})
+
+	t.Run("rename missing target", func(t *testing.T) {
+		root := t.TempDir()
+		initialFile := filepath.Join(root, "foo.txt")
+		finalFile := filepath.Join(root, "bar.txt")
+		assert.Error(t, clt.Rename(initialFile, finalFile))
+		assert.NoFileExists(t, finalFile)
+	})
+
+	t.Run("rmdir", func(t *testing.T) {
+		root := t.TempDir()
+		dir := filepath.Join(root, "foo")
+		innerFile := filepath.Join(dir, "test.txt")
+		require.NoError(t, os.Mkdir(dir, defaults.DirectoryPermissions))
+		require.NoError(t, os.WriteFile(innerFile, []byte("test"), 0o644))
+
+		assert.NoError(t, clt.RemoveDirectory(dir))
+		assert.NoDirExists(t, dir)
+	})
+
+	t.Run("rmdir not found", func(t *testing.T) {
+		root := t.TempDir()
+		dir := filepath.Join(root, "foo")
+		assert.Error(t, clt.RemoveDirectory(dir))
+	})
+
+	t.Run("rmdir not a dir", func(t *testing.T) {
+		root := t.TempDir()
+		file := filepath.Join(root, "test.txt")
+		require.NoError(t, os.WriteFile(file, []byte("test"), 0o644))
+
+		assert.Error(t, clt.RemoveDirectory(file))
+		assert.FileExists(t, file)
+	})
+
+	t.Run("mkdir", func(t *testing.T) {
+		root := t.TempDir()
+		outer := filepath.Join(root, "a")
+		inner := filepath.Join(outer, "b/c")
+		require.NoError(t, os.Mkdir(outer, defaults.DirectoryPermissions))
+
+		assert.NoError(t, clt.Mkdir(inner))
+		assert.DirExists(t, inner)
+	})
+
+	t.Run("link", func(t *testing.T) {
+		root := t.TempDir()
+		file := filepath.Join(root, "foo.txt")
+		target := filepath.Join(root, "bar.txt")
+		require.NoError(t, os.WriteFile(file, []byte("test"), 0o644))
+
+		assert.NoError(t, clt.Link(target, file))
+		fi, err := os.Lstat(target)
+		if assert.NoError(t, err) {
+			assert.Zero(t, fi.Mode()&os.ModeSymlink)
+		}
+	})
+
+	t.Run("link missing target", func(t *testing.T) {
+		root := t.TempDir()
+		file := filepath.Join(root, "foo.txt")
+		target := filepath.Join(root, "bar.txt")
+
+		assert.Error(t, clt.Link(target, file))
+		assert.NoFileExists(t, target)
+	})
+
+	t.Run("link unset target", func(t *testing.T) {
+		root := t.TempDir()
+		file := filepath.Join(root, "foo.txt")
+		require.NoError(t, os.WriteFile(file, []byte("test"), 0o644))
+		assert.Error(t, clt.Link(file, ""))
+	})
+
+	t.Run("symlink", func(t *testing.T) {
+		root := t.TempDir()
+		file := filepath.Join(root, "foo.txt")
+		target := filepath.Join(root, "bar.txt")
+		require.NoError(t, os.WriteFile(file, []byte("test"), 0o644))
+
+		assert.NoError(t, clt.Symlink(target, file))
+		fi, err := os.Lstat(target)
+		assert.NoError(t, err)
+		assert.NotZero(t, fi.Mode()&os.ModeSymlink)
+	})
+
+	t.Run("symlink unset target", func(t *testing.T) {
+		root := t.TempDir()
+		file := filepath.Join(root, "foo.txt")
+		require.NoError(t, os.WriteFile(file, []byte("test"), 0o644))
+		assert.Error(t, clt.Symlink(file, ""))
+	})
+
+	t.Run("remove", func(t *testing.T) {
+		root := t.TempDir()
+		file := filepath.Join(root, "test.txt")
+		require.NoError(t, os.WriteFile(file, []byte("test"), 0o644))
+
+		assert.NoError(t, clt.Remove(file))
+		assert.NoFileExists(t, file)
+	})
+
+	t.Run("remove not found", func(t *testing.T) {
+		root := t.TempDir()
+		file := filepath.Join(root, "test.txt")
+
+		assert.Error(t, clt.Remove(file))
+	})
+
+	t.Run("remove directory", func(t *testing.T) {
+		root := t.TempDir()
+		dir := filepath.Join(root, "dir")
+		require.NoError(t, os.Mkdir(dir, defaults.DirectoryPermissions))
+
+		assert.NoError(t, clt.Remove(dir))
+		assert.NoDirExists(t, dir)
+	})
+
+	t.Run("unsupported operation", func(t *testing.T) {
+		root := t.TempDir()
+		file := filepath.Join(root, "test.txt")
+		require.NoError(t, os.WriteFile(file, []byte("foo"), 0o644))
+		req := sftp.NewRequest(MethodStat, file)
+		assert.Error(t, HandleFilecmd(req, localFS{}))
+	})
+}
+
+type fileInfo struct {
+	name string
+	mode fs.FileMode
+	size int64
+}
+
+func (fi fileInfo) Name() string {
+	return fi.name
+}
+
+func (fi fileInfo) Size() int64 {
+	return fi.size
+}
+
+func (fi fileInfo) Mode() fs.FileMode {
+	return fi.mode
+}
+
+func (fi fileInfo) ModTime() time.Time {
+	return time.Time{}
+}
+
+func (fi fileInfo) IsDir() bool {
+	return false
+}
+
+func (fi fileInfo) Sys() any {
+	return nil
+}
+
+func TestHandleFilelist(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	statMap := make(map[string]fs.FileInfo, 10)
+	for i := range 5 {
+		fileName := fmt.Sprintf("file-%d", i)
+		file := filepath.Join(root, fileName)
+		require.NoError(t, os.WriteFile(file, []byte("test"), 0o644))
+		statMap[fileName] = fileInfo{
+			name: fileName,
+			mode: 0o644,
+			size: 4,
+		}
+		symlinkName := fmt.Sprintf("file-%d", i+5)
+		symlink := filepath.Join(root, symlinkName)
+		require.NoError(t, os.Symlink(file, symlink))
+		statMap[symlinkName] = fileInfo{
+			name: symlinkName,
+			mode: 0o644,
+			size: 4,
+		}
+	}
+
+	tests := []struct {
+		name           string
+		req            *sftp.Request
+		assert         assert.ErrorAssertionFunc
+		expectedOutput map[string]fs.FileInfo
+	}{
+		{
+			name:           "list",
+			req:            sftp.NewRequest(MethodList, root),
+			assert:         assert.NoError,
+			expectedOutput: statMap,
+		},
+		{
+			name:   "stat",
+			req:    sftp.NewRequest(MethodStat, root+"/file-0"),
+			assert: assert.NoError,
+			expectedOutput: map[string]fs.FileInfo{
+				"file-0": fileInfo{
+					name: "file-0",
+					mode: 0o644,
+					size: 4,
+				},
+			},
+		},
+		{
+			name:   "readlink",
+			req:    sftp.NewRequest(MethodReadlink, root+"/file-5"),
+			assert: assert.NoError,
+			expectedOutput: map[string]fs.FileInfo{
+				root + "/file-0": fileName(root + "/file-0"),
+			},
+		},
+		{
+			name:   "unsupported operation",
+			req:    sftp.NewRequest(MethodRemove, root),
+			assert: assert.Error,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lister, err := HandleFilelist(tc.req, localFS{})
+			tc.assert(t, err)
+			if tc.expectedOutput == nil {
+				assert.Nil(t, lister)
+				return
+			}
+			assert.NotNil(t, lister)
+
+			list := make([]fs.FileInfo, len(tc.expectedOutput))
+			n, err := lister.ListAt(list, 0)
+			assert.NoError(t, err)
+			assert.Equal(t, len(tc.expectedOutput), n)
+			for _, fi := range list {
+				entry, ok := tc.expectedOutput[fi.Name()]
+				if assert.True(t, ok, "unexpected file %q", fi.Name()) {
+					assert.Equal(t, entry.Name(), fi.Name())
+					assert.Equal(t, entry.Size(), fi.Size(), fi.Name())
+					assert.Equal(t, entry.Mode(), fi.Mode(), fi.Name())
+				}
+			}
+		})
 	}
 }

--- a/lib/sshutils/sftp/utils.go
+++ b/lib/sshutils/sftp/utils.go
@@ -24,28 +24,24 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"sync/atomic"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/pkg/sftp"
+
+	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/events"
 )
 
-// fileWrapper provides minimal required file interface for SFTP package
-// including WriteTo() method required for concurrent data transfer.
+// fileWrapper is a wrapper for *os.File that implements the WriteTo() method
+// required for concurrent data transfer.
 type fileWrapper struct {
-	file *os.File
-}
-
-func (wt *fileWrapper) Read(p []byte) (n int, err error) {
-	return wt.file.Read(p)
-}
-
-func (wt *fileWrapper) Close() error {
-	return wt.file.Close()
+	*os.File
 }
 
 func (wt *fileWrapper) WriteTo(w io.Writer) (n int64, err error) {
-	return io.Copy(w, wt.file)
-}
-
-func (wt *fileWrapper) Stat() (os.FileInfo, error) {
-	return wt.file.Stat()
+	return io.Copy(w, wt.File)
 }
 
 // fileStreamReader is a thin wrapper around fs.File with additional streams.
@@ -94,4 +90,185 @@ func (c *cancelWriter) Write(b []byte) (int, error) {
 		return 0, err
 	}
 	return c.stream.Write(b)
+}
+
+// TrackedFile is a [File] that counts the bytes read from/written to it.
+type TrackedFile struct {
+	File
+	// BytesRead is the number of bytes read.
+	bytesRead atomic.Uint64
+	// BytesWritten is the number of bytes written.
+	bytesWritten atomic.Uint64
+}
+
+func (t *TrackedFile) ReadAt(b []byte, off int64) (int, error) {
+	n, err := t.File.ReadAt(b, off)
+	t.bytesRead.Add(uint64(n))
+	return n, err
+}
+
+func (t *TrackedFile) WriteAt(b []byte, off int64) (int, error) {
+	n, err := t.File.WriteAt(b, off)
+	t.bytesWritten.Add(uint64(n))
+	return n, err
+}
+
+func (t *TrackedFile) BytesRead() uint64 {
+	return t.bytesRead.Load()
+}
+
+func (t *TrackedFile) BytesWritten() uint64 {
+	return t.bytesWritten.Load()
+}
+
+// ParseFlags parses Open flags from an SFTP request to an int as used by
+// [os.OpenFile].
+func ParseFlags(req *sftp.Request) int {
+	pflags := req.Pflags()
+	var flags int
+	if pflags.Read && pflags.Write {
+		flags = os.O_RDWR
+	} else if pflags.Read {
+		flags = os.O_RDONLY
+	} else if pflags.Write {
+		flags = os.O_WRONLY
+	}
+
+	if pflags.Append {
+		flags |= os.O_APPEND
+	}
+	if pflags.Creat {
+		flags |= os.O_CREATE
+	}
+	if pflags.Excl {
+		flags |= os.O_EXCL
+	}
+	if pflags.Trunc {
+		flags |= os.O_TRUNC
+	}
+
+	return flags
+}
+
+// ParseSFTPEvent parses an SFTP request and associated error into an SFTP
+// audit event.
+func ParseSFTPEvent(req *sftp.Request, workingDirectory string, reqErr error) (*apievents.SFTP, error) {
+	event := &apievents.SFTP{
+		Metadata: apievents.Metadata{
+			Type: events.SFTPEvent,
+			Time: time.Now(),
+		},
+	}
+
+	switch req.Method {
+	case MethodOpen, MethodGet, MethodPut:
+		if reqErr == nil {
+			event.Code = events.SFTPOpenCode
+		} else {
+			event.Code = events.SFTPOpenFailureCode
+		}
+		event.Action = apievents.SFTPAction_OPEN
+	case MethodSetStat:
+		if reqErr == nil {
+			event.Code = events.SFTPSetstatCode
+		} else {
+			event.Code = events.SFTPSetstatFailureCode
+		}
+		event.Action = apievents.SFTPAction_SETSTAT
+	case MethodList:
+		if reqErr == nil {
+			event.Code = events.SFTPReaddirCode
+		} else {
+			event.Code = events.SFTPReaddirFailureCode
+		}
+		event.Action = apievents.SFTPAction_READDIR
+	case MethodRemove:
+		if reqErr == nil {
+			event.Code = events.SFTPRemoveCode
+		} else {
+			event.Code = events.SFTPRemoveFailureCode
+		}
+		event.Action = apievents.SFTPAction_REMOVE
+	case MethodMkdir:
+		if reqErr == nil {
+			event.Code = events.SFTPMkdirCode
+		} else {
+			event.Code = events.SFTPMkdirFailureCode
+		}
+		event.Action = apievents.SFTPAction_MKDIR
+	case MethodRmdir:
+		if reqErr == nil {
+			event.Code = events.SFTPRmdirCode
+		} else {
+			event.Code = events.SFTPRmdirFailureCode
+		}
+		event.Action = apievents.SFTPAction_RMDIR
+	case MethodRename:
+		if reqErr == nil {
+			event.Code = events.SFTPRenameCode
+		} else {
+			event.Code = events.SFTPRenameFailureCode
+		}
+		event.Action = apievents.SFTPAction_RENAME
+	case MethodSymlink:
+		if reqErr == nil {
+			event.Code = events.SFTPSymlinkCode
+		} else {
+			event.Code = events.SFTPSymlinkFailureCode
+		}
+		event.Action = apievents.SFTPAction_SYMLINK
+	case MethodLink:
+		if reqErr == nil {
+			event.Code = events.SFTPLinkCode
+		} else {
+			event.Code = events.SFTPLinkFailureCode
+		}
+		event.Action = apievents.SFTPAction_LINK
+	default:
+		return nil, trace.BadParameter("unknown SFTP request %q", req.Method)
+	}
+
+	event.Path = req.Filepath
+	event.TargetPath = req.Target
+	event.Flags = req.Flags
+	event.WorkingDirectory = workingDirectory
+	if req.Method == MethodSetStat {
+		attrFlags := req.AttrFlags()
+		attrs := req.Attributes()
+		event.Attributes = new(apievents.SFTPAttributes)
+
+		if attrFlags.Acmodtime {
+			atime := time.Unix(int64(attrs.Atime), 0)
+			mtime := time.Unix(int64(attrs.Mtime), 0)
+			event.Attributes.AccessTime = &atime
+			event.Attributes.ModificationTime = &mtime
+		}
+		if attrFlags.Permissions {
+			perms := uint32(attrs.FileMode().Perm())
+			event.Attributes.Permissions = &perms
+		}
+		if attrFlags.Size {
+			event.Attributes.FileSize = &attrs.Size
+		}
+		if attrFlags.UidGid {
+			event.Attributes.UID = &attrs.UID
+			event.Attributes.GID = &attrs.GID
+		}
+	}
+	if reqErr != nil {
+		// If possible, strip the filename from the error message. The
+		// path will be included in audit events already, no need to
+		// make the error message longer than it needs to be.
+		var pathErr *fs.PathError
+		var linkErr *os.LinkError
+		if errors.As(reqErr, &pathErr) {
+			event.Error = pathErr.Err.Error()
+		} else if errors.As(reqErr, &linkErr) {
+			event.Error = linkErr.Err.Error()
+		} else {
+			event.Error = reqErr.Error()
+		}
+	}
+
+	return event, nil
 }

--- a/tool/teleport/common/sftp.go
+++ b/tool/teleport/common/sftp.go
@@ -26,14 +26,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"log/slog"
 	"os"
 	"os/user"
 	"path"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/gogo/protobuf/jsonpb"
@@ -46,23 +44,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/srv"
-)
-
-const (
-	methodGet      = "Get"
-	methodPut      = "Put"
-	methodOpen     = "Open"
-	methodSetStat  = "Setstat"
-	methodRename   = "Rename"
-	methodRmdir    = "Rmdir"
-	methodMkdir    = "Mkdir"
-	methodLink     = "Link"
-	methodSymlink  = "Symlink"
-	methodRemove   = "Remove"
-	methodList     = "List"
-	methodStat     = "Stat"
-	methodLstat    = "Lstat"
-	methodReadlink = "Readlink"
+	sftputils "github.com/gravitational/teleport/lib/sshutils/sftp"
 )
 
 type compositeCh struct {
@@ -94,31 +76,9 @@ type sftpHandler struct {
 
 	// mtx protects files
 	mtx   sync.Mutex
-	files []*trackedFile
+	files []*sftputils.TrackedFile
 
 	events chan<- apievents.AuditEvent
-}
-
-type trackedFile struct {
-	file         *os.File
-	bytesRead    atomic.Uint64
-	bytesWritten atomic.Uint64
-}
-
-func (t *trackedFile) ReadAt(b []byte, off int64) (int, error) {
-	n, err := t.file.ReadAt(b, off)
-	t.bytesRead.Add(uint64(n))
-	return n, err
-}
-
-func (t *trackedFile) WriteAt(b []byte, off int64) (int, error) {
-	n, err := t.file.WriteAt(b, off)
-	t.bytesWritten.Add(uint64(n))
-	return n, err
-}
-
-func (t *trackedFile) Close() error {
-	return t.file.Close()
 }
 
 func newSFTPHandler(logger *slog.Logger, req *srv.FileTransferRequest, events chan<- apievents.AuditEvent) (*sftpHandler, error) {
@@ -156,14 +116,14 @@ func (s *sftpHandler) ensureReqIsAllowed(req *sftp.Request) error {
 	}
 
 	switch req.Method {
-	case methodLstat, methodStat:
+	case sftputils.MethodLstat, sftputils.MethodStat:
 		// these methods are allowed
-	case methodGet:
+	case sftputils.MethodGet:
 		// only allow reads for downloads
 		if s.allowed.write {
 			return newDisallowedErr(req)
 		}
-	case methodPut, methodSetStat:
+	case sftputils.MethodPut, sftputils.MethodSetStat:
 		// only allow writes and chmods for uploads
 		if !s.allowed.write {
 			return newDisallowedErr(req)
@@ -175,8 +135,8 @@ func (s *sftpHandler) ensureReqIsAllowed(req *sftp.Request) error {
 	return nil
 }
 
-// OpenFile handles 'open' requests when opening a file for reading
-// and writing is desired.
+// OpenFile handles Open requests for both reading and writing. Required to
+// satisfy [sftp.OpenFileWriter].
 func (s *sftpHandler) OpenFile(req *sftp.Request) (_ sftp.WriterAtReaderAt, retErr error) {
 	defer s.sendSFTPEvent(req, retErr)
 
@@ -222,34 +182,11 @@ func (s *sftpHandler) openFile(req *sftp.Request) (sftp.WriterAtReaderAt, error)
 		return nil, err
 	}
 
-	var flags int
-	pflags := req.Pflags()
-	if pflags.Append {
-		flags |= os.O_APPEND
-	}
-	if pflags.Creat {
-		flags |= os.O_CREATE
-	}
-	if pflags.Excl {
-		flags |= os.O_EXCL
-	}
-	if pflags.Trunc {
-		flags |= os.O_TRUNC
-	}
-
-	if pflags.Read && pflags.Write {
-		flags |= os.O_RDWR
-	} else if pflags.Read {
-		flags |= os.O_RDONLY
-	} else if pflags.Write {
-		flags |= os.O_WRONLY
-	}
-
-	f, err := os.OpenFile(req.Filepath, flags, defaults.FilePermissions)
+	f, err := os.OpenFile(req.Filepath, sftputils.ParseFlags(req), defaults.FilePermissions)
 	if err != nil {
 		return nil, err
 	}
-	trackFile := &trackedFile{file: f}
+	trackFile := &sftputils.TrackedFile{File: f}
 	s.mtx.Lock()
 	s.files = append(s.files, trackFile)
 	s.mtx.Unlock()
@@ -273,132 +210,13 @@ func (s *sftpHandler) Filecmd(req *sftp.Request) (retErr error) {
 		return err
 	}
 
-	switch req.Method {
-	case methodSetStat:
-		return s.setstat(req)
-	case methodRename:
-		if req.Target == "" {
-			return os.ErrInvalid
-		}
-		return os.Rename(req.Filepath, req.Target)
-	case methodRmdir:
-		fi, err := os.Lstat(req.Filepath)
-		if err != nil {
-			return err
-		}
-		if !fi.IsDir() {
-			return fmt.Errorf("%q is not a directory", req.Filepath)
-		}
-		return os.RemoveAll(req.Filepath)
-	case methodMkdir:
-		return os.MkdirAll(req.Filepath, defaults.DirectoryPermissions)
-	case methodLink:
-		if req.Target == "" {
-			return os.ErrInvalid
-		}
-		return os.Link(req.Target, req.Filepath)
-	case methodSymlink:
-		if req.Target == "" {
-			return os.ErrInvalid
-		}
-		return os.Symlink(req.Target, req.Filepath)
-	case methodRemove:
-		fi, err := os.Lstat(req.Filepath)
-		if err != nil {
-			return err
-		}
-		if fi.IsDir() {
-			return fmt.Errorf("%q is a directory", req.Filepath)
-		}
-		return os.Remove(req.Filepath)
-	default:
-		return sftp.ErrSSHFxOpUnsupported
-	}
-}
-
-func (s *sftpHandler) setstat(req *sftp.Request) error {
-	attrFlags := req.AttrFlags()
-	attrs := req.Attributes()
-
-	if attrFlags.Acmodtime {
-		atime := time.Unix(int64(attrs.Atime), 0)
-		mtime := time.Unix(int64(attrs.Mtime), 0)
-
-		err := os.Chtimes(req.Filepath, atime, mtime)
-		if err != nil {
-			return err
-		}
-	}
-	if attrFlags.Permissions {
-		err := os.Chmod(req.Filepath, attrs.FileMode())
-		if err != nil {
-			return err
-		}
-	}
-	if attrFlags.UidGid {
-		err := os.Chown(req.Filepath, int(attrs.UID), int(attrs.GID))
-		if err != nil {
-			return err
-		}
-	}
-	if attrFlags.Size {
-		err := os.Truncate(req.Filepath, int64(attrs.Size))
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// listerAt satisfies [sftp.ListerAt].
-type listerAt []fs.FileInfo
-
-func (l listerAt) ListAt(ls []fs.FileInfo, offset int64) (int, error) {
-	if offset >= int64(len(l)) {
-		return 0, io.EOF
-	}
-	n := copy(ls, l[offset:])
-	if n < len(ls) {
-		return n, io.EOF
-	}
-
-	return n, nil
-}
-
-// fileName satisfies [fs.FileInfo] but only knows a file's name. This
-// is necessary when handling 'readlink' requests in sftpHandler.FileList,
-// as only the file's name is known after a readlink call.
-type fileName string
-
-func (f fileName) Name() string {
-	return string(f)
-}
-
-func (f fileName) Size() int64 {
-	return 0
-}
-
-func (f fileName) Mode() fs.FileMode {
-	return 0
-}
-
-func (f fileName) ModTime() time.Time {
-	return time.Time{}
-}
-
-func (f fileName) IsDir() bool {
-	return false
-}
-
-func (f fileName) Sys() any {
-	return nil
+	return sftputils.HandleFilecmd(req, nil /* local filesystem */)
 }
 
 // Filelist handles 'readdir', 'stat' and 'readlink' requests.
 func (s *sftpHandler) Filelist(req *sftp.Request) (_ sftp.ListerAt, retErr error) {
 	defer func() {
-		if req.Method == methodList {
+		if req.Method == sftputils.MethodList {
 			s.sendSFTPEvent(req, retErr)
 		}
 	}()
@@ -410,181 +228,22 @@ func (s *sftpHandler) Filelist(req *sftp.Request) (_ sftp.ListerAt, retErr error
 		return nil, err
 	}
 
-	switch req.Method {
-	case methodList:
-		entries, err := os.ReadDir(req.Filepath)
-		if err != nil {
-			return nil, err
-		}
-		infos := make([]fs.FileInfo, len(entries))
-		for i, entry := range entries {
-			info, err := entry.Info()
-			if err != nil {
-				return nil, err
-			}
-			infos[i] = info
-		}
-		return listerAt(infos), nil
-	case methodStat:
-		fi, err := os.Stat(req.Filepath)
-		if err != nil {
-			return nil, err
-		}
-		return listerAt{fi}, nil
-	case methodReadlink:
-		dst, err := os.Readlink(req.Filepath)
-		if err != nil {
-			return nil, err
-		}
-		return listerAt{fileName(dst)}, nil
-	default:
-		return nil, sftp.ErrSSHFxOpUnsupported
-	}
-}
-
-// Lstat handles 'lstat' requests.
-func (s *sftpHandler) Lstat(req *sftp.Request) (sftp.ListerAt, error) {
-	if req.Filepath == "" {
-		return nil, os.ErrInvalid
-	}
-	if err := s.ensureReqIsAllowed(req); err != nil {
-		return nil, err
-	}
-
-	fi, err := os.Lstat(req.Filepath)
-	if err != nil {
-		return nil, err
-	}
-
-	return listerAt{fi}, nil
+	return sftputils.HandleFilelist(req, nil /* local filesystem */)
 }
 
 func (s *sftpHandler) sendSFTPEvent(req *sftp.Request, reqErr error) {
-	ctx := context.TODO()
-	event := &apievents.SFTP{
-		Metadata: apievents.Metadata{
-			Type: events.SFTPEvent,
-			Time: time.Now(),
-		},
-	}
-
-	switch req.Method {
-	case methodOpen, methodGet, methodPut:
-		if reqErr == nil {
-			event.Code = events.SFTPOpenCode
-		} else {
-			event.Code = events.SFTPOpenFailureCode
-		}
-		event.Action = apievents.SFTPAction_OPEN
-	case methodSetStat:
-		if reqErr == nil {
-			event.Code = events.SFTPSetstatCode
-		} else {
-			event.Code = events.SFTPSetstatFailureCode
-		}
-		event.Action = apievents.SFTPAction_SETSTAT
-	case methodList:
-		if reqErr == nil {
-			event.Code = events.SFTPReaddirCode
-		} else {
-			event.Code = events.SFTPReaddirFailureCode
-		}
-		event.Action = apievents.SFTPAction_READDIR
-	case methodRemove:
-		if reqErr == nil {
-			event.Code = events.SFTPRemoveCode
-		} else {
-			event.Code = events.SFTPRemoveFailureCode
-		}
-		event.Action = apievents.SFTPAction_REMOVE
-	case methodMkdir:
-		if reqErr == nil {
-			event.Code = events.SFTPMkdirCode
-		} else {
-			event.Code = events.SFTPMkdirFailureCode
-		}
-		event.Action = apievents.SFTPAction_MKDIR
-	case methodRmdir:
-		if reqErr == nil {
-			event.Code = events.SFTPRmdirCode
-		} else {
-			event.Code = events.SFTPRmdirFailureCode
-		}
-		event.Action = apievents.SFTPAction_RMDIR
-	case methodRename:
-		if reqErr == nil {
-			event.Code = events.SFTPRenameCode
-		} else {
-			event.Code = events.SFTPRenameFailureCode
-		}
-		event.Action = apievents.SFTPAction_RENAME
-	case methodSymlink:
-		if reqErr == nil {
-			event.Code = events.SFTPSymlinkCode
-		} else {
-			event.Code = events.SFTPSymlinkFailureCode
-		}
-		event.Action = apievents.SFTPAction_SYMLINK
-	case methodLink:
-		if reqErr == nil {
-			event.Code = events.SFTPLinkCode
-		} else {
-			event.Code = events.SFTPLinkFailureCode
-		}
-		event.Action = apievents.SFTPAction_LINK
-	default:
-		s.logger.WarnContext(ctx, "Unknown SFTP request", "request", req.Method)
-		return
-	}
-
 	wd, err := os.Getwd()
 	if err != nil {
-		s.logger.WarnContext(ctx, "Failed to get working dir", "error", err)
+		s.logger.WarnContext(req.Context(), "Failed to get working dir", "error", err)
+		// Emit event without working directory.
 	}
-
-	event.WorkingDirectory = wd
-	event.Path = req.Filepath
-	event.TargetPath = req.Target
-	event.Flags = req.Flags
-	if req.Method == methodSetStat {
-		attrFlags := req.AttrFlags()
-		attrs := req.Attributes()
-		event.Attributes = new(apievents.SFTPAttributes)
-
-		if attrFlags.Acmodtime {
-			atime := time.Unix(int64(attrs.Atime), 0)
-			mtime := time.Unix(int64(attrs.Mtime), 0)
-			event.Attributes.AccessTime = &atime
-			event.Attributes.ModificationTime = &mtime
-		}
-		if attrFlags.Permissions {
-			perms := uint32(attrs.FileMode().Perm())
-			event.Attributes.Permissions = &perms
-		}
-		if attrFlags.Size {
-			event.Attributes.FileSize = &attrs.Size
-		}
-		if attrFlags.UidGid {
-			event.Attributes.UID = &attrs.UID
-			event.Attributes.GID = &attrs.GID
-		}
+	event, err := sftputils.ParseSFTPEvent(req, wd, reqErr)
+	if err != nil {
+		s.logger.WarnContext(req.Context(), "Unknown SFTP request", "request", req.Method)
+		return
+	} else if reqErr != nil {
+		s.logger.DebugContext(req.Context(), "failed handling SFTP request", "request", req.Method, "error", reqErr)
 	}
-	if reqErr != nil {
-		s.logger.DebugContext(ctx, "failed handling SFTP request", "request", req.Method, "error", reqErr)
-		// If possible, strip the filename from the error message. The
-		// path will be included in audit events already, no need to
-		// make the error message longer than it needs to be.
-		var pathErr *fs.PathError
-		var linkErr *os.LinkError
-		if errors.As(reqErr, &pathErr) {
-			event.Error = pathErr.Err.Error()
-		} else if errors.As(reqErr, &linkErr) {
-			event.Error = linkErr.Err.Error()
-		} else {
-			event.Error = reqErr.Error()
-		}
-	}
-
 	s.events <- event
 }
 
@@ -704,9 +363,9 @@ func onSFTP() error {
 	// take care of that for us
 	for _, f := range h.files {
 		summaryEvent.FileTransferStats = append(summaryEvent.FileTransferStats, &apievents.FileTransferStat{
-			Path:         f.file.Name(),
-			BytesRead:    f.bytesRead.Load(),
-			BytesWritten: f.bytesWritten.Load(),
+			Path:         f.Name(),
+			BytesRead:    f.BytesRead(),
+			BytesWritten: f.BytesWritten(),
 		})
 	}
 	sftpEvents <- summaryEvent


### PR DESCRIPTION
This change updates SFTP to emit `sftp` and `sftp_summary` events for sessions on agentless nodes, the same as we do for regular nodes (previously, only a `subsystem` event was emitted at the start of the session).

Resolves #51841.

Changelog: Added detailed audit events for SFTP sessions on agentless nodes