### PR TITLE
Fix the css prop in HoverTooltip

### DIFF
--- a/web/packages/design/src/Tooltip/HoverTooltip.tsx
+++ b/web/packages/design/src/Tooltip/HoverTooltip.tsx
@@ -49,6 +49,11 @@ type HoverTooltipProps = {
    */
   showOnlyOnOverflow?: boolean;
   /**
+   * Element's class name. Might seem unimportant, but required for using the
+   * styled-components' `css` property.
+   */
+  className?: string;
+  /**
    * Specifies the position of tooltip relative to trigger content.
    */
   placement?: Placement;
@@ -78,6 +83,7 @@ export const HoverTooltip = ({
   tipContent,
   children,
   showOnlyOnOverflow = false,
+  className,
   placement = 'top',
   position,
   offset: offsetDistance = 8,
@@ -166,6 +172,7 @@ export const HoverTooltip = ({
         onMouseEnter: handleMouseEnter,
         onMouseLeave: () => setOpen(false),
       })}
+      className={className}
     >
       {children}
       {isMounted && (


### PR DESCRIPTION
[A PR that introduced FloatingUI](https://github.com/gravitational/teleport/pull/53044) introduced subtle breakages in a couple of places, but the most prominent one was the bell icon in the nav bar:

Before:
![Screenshot 2025-03-24 at 18 19 53](https://github.com/user-attachments/assets/ae2cc136-b278-438d-867e-eaf4af8356ee)

After:
![Screenshot 2025-03-24 at 19 11 15](https://github.com/user-attachments/assets/df9c02f1-9a6e-44ae-94b7-8ca1aaa0afd1)

Tested:
- navigation bar
- The `TeleportE/Clusters/Contacts/Loaded` story (tooltip on the disabled button)
- The unified resources list view (for example: the address cell layout no longer breaks when a server address overflows)