### PR TITLE
[web] Fix CollapsibleInfoSection animation with `defaultOpen`

### DIFF
--- a/web/packages/design/src/CollapsibleInfoSection/CollapsibleInfoSection.tsx
+++ b/web/packages/design/src/CollapsibleInfoSection/CollapsibleInfoSection.tsx
@@ -60,11 +60,14 @@ export const CollapsibleInfoSection = ({
 }: PropsWithChildren<CollapsibleInfoSectionProps>) => {
   const contentId = useId();
   const [isOpen, setIsOpen] = useState(defaultOpen);
-  const [contentHeight, setContentHeight] = useState(0);
+  const [contentHeight, setContentHeight] = useState<number>();
   const [shouldRenderContent, setShouldRenderContent] = useState(defaultOpen);
   const contentRef = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
+    if (!defaultOpen && contentHeight === undefined) {
+      setContentHeight(0);
+    }
     if (!contentRef.current || !shouldRenderContent) {
       return;
     }
@@ -77,6 +80,7 @@ export const CollapsibleInfoSection = ({
     });
     ro.observe(contentRef.current);
     return () => ro.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [contentRef, shouldRenderContent]);
 
   return (
@@ -92,8 +96,14 @@ export const CollapsibleInfoSection = ({
         aria-expanded={isOpen}
         aria-controls={contentId}
       >
-        {isOpen ? <Minus size="small" /> : <Plus size="small" />}
-        <Text>{isOpen ? closeLabel : openLabel}</Text>
+        {isOpen ? (
+          <Minus size="small" style={{ transition: 'color 200ms ease' }} />
+        ) : (
+          <Plus size="small" style={{ transition: 'color 200ms ease' }} />
+        )}
+        <Text style={{ transition: 'color 200ms ease' }}>
+          {isOpen ? closeLabel : openLabel}
+        </Text>
       </ToggleButton>
       <ContentWrapper
         id={contentId}
@@ -146,9 +156,14 @@ const Bar = styled.div`
   background: ${({ theme }) => theme.colors.interactive.tonal.neutral[0]};
 `;
 
-const ContentWrapper = styled.div<{ $isOpen: boolean; $contentHeight: number }>`
+const ContentWrapper = styled.div<{
+  $isOpen: boolean;
+  $contentHeight?: number;
+}>`
   overflow: hidden;
-  height: ${props => (props.$isOpen ? `${props.$contentHeight}px` : '0')};
+  ${props =>
+    typeof props.$contentHeight === 'number' &&
+    `height: ${props.$isOpen ? `${props.$contentHeight}px` : '0'};`};
   will-change: height;
   transition: height 200ms ease;
   transform-origin: top;


### PR DESCRIPTION
Small fix for CollapsibleInfoSection: Make `contentHeight` optional and only apply `height` CSS after measurement of content height, preventing unwanted animation artifacts on initial mount when `defaultOpen` is true.