### PR TITLE
docs: Fix broken link to predicate language in proxy templating docs

### DIFF
--- a/docs/pages/connect-your-client/tsh.mdx
+++ b/docs/pages/connect-your-client/tsh.mdx
@@ -1078,7 +1078,7 @@ proxy_templates:
 In the configuration above, `query` accepts an predicate expression.  This has
 priority over search but will be ignored if a host is provided.  See the
 [predicate language
-documentation](../reference/predicate-language.mdx#resource-filtering for
+documentation](../reference/predicate-language.mdx#resource-filtering) for
 predicate expression examples.
 
 `tsh -J {{proxy}} ssh` and `tsh -J {{proxy}} proxy ssh` will attempt to match the


### PR DESCRIPTION
A missing closing bracket caused this link not to render correctly.