### PR TITLE
Add DemoMode and Status to AccessGraphSettings

### DIFF
--- a/api/gen/proto/go/teleport/clusterconfig/v1/access_graph_settings.pb.go
+++ b/api/gen/proto/go/teleport/clusterconfig/v1/access_graph_settings.pb.go
@@ -36,6 +36,59 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// AccessGraphDemoMode is used to determine if some features should be available for use in a demo capacity
+type AccessGraphDemoMode int32
+
+const (
+	// ACCESS_GRAPH_DEMO_MODE_UNSPECIFIED is an unknown demo mode configuration.
+	AccessGraphDemoMode_ACCESS_GRAPH_DEMO_MODE_UNSPECIFIED AccessGraphDemoMode = 0
+	// ACCESS_GRAPH_DEMO_MODE_DISABLED is a disabled demo mode configuration.
+	AccessGraphDemoMode_ACCESS_GRAPH_DEMO_MODE_DISABLED AccessGraphDemoMode = 1
+	// ACCESS_GRAPH_DEMO_MODE_ENABLED is an enabled demo mode configuration.
+	AccessGraphDemoMode_ACCESS_GRAPH_DEMO_MODE_ENABLED AccessGraphDemoMode = 2
+)
+
+// Enum value maps for AccessGraphDemoMode.
+var (
+	AccessGraphDemoMode_name = map[int32]string{
+		0: "ACCESS_GRAPH_DEMO_MODE_UNSPECIFIED",
+		1: "ACCESS_GRAPH_DEMO_MODE_DISABLED",
+		2: "ACCESS_GRAPH_DEMO_MODE_ENABLED",
+	}
+	AccessGraphDemoMode_value = map[string]int32{
+		"ACCESS_GRAPH_DEMO_MODE_UNSPECIFIED": 0,
+		"ACCESS_GRAPH_DEMO_MODE_DISABLED":    1,
+		"ACCESS_GRAPH_DEMO_MODE_ENABLED":     2,
+	}
+)
+
+func (x AccessGraphDemoMode) Enum() *AccessGraphDemoMode {
+	p := new(AccessGraphDemoMode)
+	*p = x
+	return p
+}
+
+func (x AccessGraphDemoMode) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (AccessGraphDemoMode) Descriptor() protoreflect.EnumDescriptor {
+	return file_teleport_clusterconfig_v1_access_graph_settings_proto_enumTypes[0].Descriptor()
+}
+
+func (AccessGraphDemoMode) Type() protoreflect.EnumType {
+	return &file_teleport_clusterconfig_v1_access_graph_settings_proto_enumTypes[0]
+}
+
+func (x AccessGraphDemoMode) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use AccessGraphDemoMode.Descriptor instead.
+func (AccessGraphDemoMode) EnumDescriptor() ([]byte, []int) {
+	return file_teleport_clusterconfig_v1_access_graph_settings_proto_rawDescGZIP(), []int{0}
+}
+
 // AccessGraphSecretsScanConfig is used to configure the parameters for the secrets scanning functionality.
 type AccessGraphSecretsScanConfig int32
 
@@ -73,11 +126,11 @@ func (x AccessGraphSecretsScanConfig) String() string {
 }
 
 func (AccessGraphSecretsScanConfig) Descriptor() protoreflect.EnumDescriptor {
-	return file_teleport_clusterconfig_v1_access_graph_settings_proto_enumTypes[0].Descriptor()
+	return file_teleport_clusterconfig_v1_access_graph_settings_proto_enumTypes[1].Descriptor()
 }
 
 func (AccessGraphSecretsScanConfig) Type() protoreflect.EnumType {
-	return &file_teleport_clusterconfig_v1_access_graph_settings_proto_enumTypes[0]
+	return &file_teleport_clusterconfig_v1_access_graph_settings_proto_enumTypes[1]
 }
 
 func (x AccessGraphSecretsScanConfig) Number() protoreflect.EnumNumber {
@@ -86,7 +139,7 @@ func (x AccessGraphSecretsScanConfig) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use AccessGraphSecretsScanConfig.Descriptor instead.
 func (AccessGraphSecretsScanConfig) EnumDescriptor() ([]byte, []int) {
-	return file_teleport_clusterconfig_v1_access_graph_settings_proto_rawDescGZIP(), []int{0}
+	return file_teleport_clusterconfig_v1_access_graph_settings_proto_rawDescGZIP(), []int{1}
 }
 
 // AccessGraphSettings holds dynamic configuration settings for the Access Graph service.
@@ -101,7 +154,9 @@ type AccessGraphSettings struct {
 	// metadata is the metadata of the resource.
 	Metadata *v1.Metadata `protobuf:"bytes,4,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	// spec is the spec of the resource.
-	Spec          *AccessGraphSettingsSpec `protobuf:"bytes,5,opt,name=spec,proto3" json:"spec,omitempty"`
+	Spec *AccessGraphSettingsSpec `protobuf:"bytes,5,opt,name=spec,proto3" json:"spec,omitempty"`
+	// status is the status of the configured access graph service
+	Status        *AccessGraphSettingsStatus `protobuf:"bytes,6,opt,name=status,proto3" json:"status,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -171,18 +226,73 @@ func (x *AccessGraphSettings) GetSpec() *AccessGraphSettingsSpec {
 	return nil
 }
 
+func (x *AccessGraphSettings) GetStatus() *AccessGraphSettingsStatus {
+	if x != nil {
+		return x.Status
+	}
+	return nil
+}
+
+// AccessGraphSettingsStatus is the status of the configured access graph service
+type AccessGraphSettingsStatus struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// initial_sync_complete indicates if the access graph service has sent resources to access graph at least once.
+	InitialSyncComplete bool `protobuf:"varint,1,opt,name=initial_sync_complete,json=initialSyncComplete,proto3" json:"initial_sync_complete,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
+}
+
+func (x *AccessGraphSettingsStatus) Reset() {
+	*x = AccessGraphSettingsStatus{}
+	mi := &file_teleport_clusterconfig_v1_access_graph_settings_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AccessGraphSettingsStatus) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AccessGraphSettingsStatus) ProtoMessage() {}
+
+func (x *AccessGraphSettingsStatus) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_clusterconfig_v1_access_graph_settings_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AccessGraphSettingsStatus.ProtoReflect.Descriptor instead.
+func (*AccessGraphSettingsStatus) Descriptor() ([]byte, []int) {
+	return file_teleport_clusterconfig_v1_access_graph_settings_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *AccessGraphSettingsStatus) GetInitialSyncComplete() bool {
+	if x != nil {
+		return x.InitialSyncComplete
+	}
+	return false
+}
+
 // AccessGraphSettingsSpec is the spec for the Access Graph service configuration settings.
 type AccessGraphSettingsSpec struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// secrets_scan_config is used to configure the parameters for the secrets scanning functionality.
 	SecretsScanConfig AccessGraphSecretsScanConfig `protobuf:"varint,1,opt,name=secrets_scan_config,json=secretsScanConfig,proto3,enum=teleport.clusterconfig.v1.AccessGraphSecretsScanConfig" json:"secrets_scan_config,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// demo_mode is used to determine if some features should be available for use in a demo capacity
+	DemoMode      AccessGraphDemoMode `protobuf:"varint,2,opt,name=demo_mode,json=demoMode,proto3,enum=teleport.clusterconfig.v1.AccessGraphDemoMode" json:"demo_mode,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *AccessGraphSettingsSpec) Reset() {
 	*x = AccessGraphSettingsSpec{}
-	mi := &file_teleport_clusterconfig_v1_access_graph_settings_proto_msgTypes[1]
+	mi := &file_teleport_clusterconfig_v1_access_graph_settings_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -194,7 +304,7 @@ func (x *AccessGraphSettingsSpec) String() string {
 func (*AccessGraphSettingsSpec) ProtoMessage() {}
 
 func (x *AccessGraphSettingsSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_clusterconfig_v1_access_graph_settings_proto_msgTypes[1]
+	mi := &file_teleport_clusterconfig_v1_access_graph_settings_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -207,7 +317,7 @@ func (x *AccessGraphSettingsSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccessGraphSettingsSpec.ProtoReflect.Descriptor instead.
 func (*AccessGraphSettingsSpec) Descriptor() ([]byte, []int) {
-	return file_teleport_clusterconfig_v1_access_graph_settings_proto_rawDescGZIP(), []int{1}
+	return file_teleport_clusterconfig_v1_access_graph_settings_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *AccessGraphSettingsSpec) GetSecretsScanConfig() AccessGraphSecretsScanConfig {
@@ -217,19 +327,34 @@ func (x *AccessGraphSettingsSpec) GetSecretsScanConfig() AccessGraphSecretsScanC
 	return AccessGraphSecretsScanConfig_ACCESS_GRAPH_SECRETS_SCAN_CONFIG_UNSPECIFIED
 }
 
+func (x *AccessGraphSettingsSpec) GetDemoMode() AccessGraphDemoMode {
+	if x != nil {
+		return x.DemoMode
+	}
+	return AccessGraphDemoMode_ACCESS_GRAPH_DEMO_MODE_UNSPECIFIED
+}
+
 var File_teleport_clusterconfig_v1_access_graph_settings_proto protoreflect.FileDescriptor
 
 const file_teleport_clusterconfig_v1_access_graph_settings_proto_rawDesc = "" +
 	"\n" +
-	"5teleport/clusterconfig/v1/access_graph_settings.proto\x12\x19teleport.clusterconfig.v1\x1a!teleport/header/v1/metadata.proto\"\xe0\x01\n" +
+	"5teleport/clusterconfig/v1/access_graph_settings.proto\x12\x19teleport.clusterconfig.v1\x1a!teleport/header/v1/metadata.proto\"\xae\x02\n" +
 	"\x13AccessGraphSettings\x12\x12\n" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x19\n" +
 	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12F\n" +
-	"\x04spec\x18\x05 \x01(\v22.teleport.clusterconfig.v1.AccessGraphSettingsSpecR\x04spec\"\x82\x01\n" +
+	"\x04spec\x18\x05 \x01(\v22.teleport.clusterconfig.v1.AccessGraphSettingsSpecR\x04spec\x12L\n" +
+	"\x06status\x18\x06 \x01(\v24.teleport.clusterconfig.v1.AccessGraphSettingsStatusR\x06status\"O\n" +
+	"\x19AccessGraphSettingsStatus\x122\n" +
+	"\x15initial_sync_complete\x18\x01 \x01(\bR\x13initialSyncComplete\"\xcf\x01\n" +
 	"\x17AccessGraphSettingsSpec\x12g\n" +
-	"\x13secrets_scan_config\x18\x01 \x01(\x0e27.teleport.clusterconfig.v1.AccessGraphSecretsScanConfigR\x11secretsScanConfig*\xad\x01\n" +
+	"\x13secrets_scan_config\x18\x01 \x01(\x0e27.teleport.clusterconfig.v1.AccessGraphSecretsScanConfigR\x11secretsScanConfig\x12K\n" +
+	"\tdemo_mode\x18\x02 \x01(\x0e2..teleport.clusterconfig.v1.AccessGraphDemoModeR\bdemoMode*\x86\x01\n" +
+	"\x13AccessGraphDemoMode\x12&\n" +
+	"\"ACCESS_GRAPH_DEMO_MODE_UNSPECIFIED\x10\x00\x12#\n" +
+	"\x1fACCESS_GRAPH_DEMO_MODE_DISABLED\x10\x01\x12\"\n" +
+	"\x1eACCESS_GRAPH_DEMO_MODE_ENABLED\x10\x02*\xad\x01\n" +
 	"\x1cAccessGraphSecretsScanConfig\x120\n" +
 	",ACCESS_GRAPH_SECRETS_SCAN_CONFIG_UNSPECIFIED\x10\x00\x12-\n" +
 	")ACCESS_GRAPH_SECRETS_SCAN_CONFIG_DISABLED\x10\x01\x12,\n" +
@@ -247,23 +372,27 @@ func file_teleport_clusterconfig_v1_access_graph_settings_proto_rawDescGZIP() []
 	return file_teleport_clusterconfig_v1_access_graph_settings_proto_rawDescData
 }
 
-var file_teleport_clusterconfig_v1_access_graph_settings_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_teleport_clusterconfig_v1_access_graph_settings_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_teleport_clusterconfig_v1_access_graph_settings_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_teleport_clusterconfig_v1_access_graph_settings_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
 var file_teleport_clusterconfig_v1_access_graph_settings_proto_goTypes = []any{
-	(AccessGraphSecretsScanConfig)(0), // 0: teleport.clusterconfig.v1.AccessGraphSecretsScanConfig
-	(*AccessGraphSettings)(nil),       // 1: teleport.clusterconfig.v1.AccessGraphSettings
-	(*AccessGraphSettingsSpec)(nil),   // 2: teleport.clusterconfig.v1.AccessGraphSettingsSpec
-	(*v1.Metadata)(nil),               // 3: teleport.header.v1.Metadata
+	(AccessGraphDemoMode)(0),          // 0: teleport.clusterconfig.v1.AccessGraphDemoMode
+	(AccessGraphSecretsScanConfig)(0), // 1: teleport.clusterconfig.v1.AccessGraphSecretsScanConfig
+	(*AccessGraphSettings)(nil),       // 2: teleport.clusterconfig.v1.AccessGraphSettings
+	(*AccessGraphSettingsStatus)(nil), // 3: teleport.clusterconfig.v1.AccessGraphSettingsStatus
+	(*AccessGraphSettingsSpec)(nil),   // 4: teleport.clusterconfig.v1.AccessGraphSettingsSpec
+	(*v1.Metadata)(nil),               // 5: teleport.header.v1.Metadata
 }
 var file_teleport_clusterconfig_v1_access_graph_settings_proto_depIdxs = []int32{
-	3, // 0: teleport.clusterconfig.v1.AccessGraphSettings.metadata:type_name -> teleport.header.v1.Metadata
-	2, // 1: teleport.clusterconfig.v1.AccessGraphSettings.spec:type_name -> teleport.clusterconfig.v1.AccessGraphSettingsSpec
-	0, // 2: teleport.clusterconfig.v1.AccessGraphSettingsSpec.secrets_scan_config:type_name -> teleport.clusterconfig.v1.AccessGraphSecretsScanConfig
-	3, // [3:3] is the sub-list for method output_type
-	3, // [3:3] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	5, // 0: teleport.clusterconfig.v1.AccessGraphSettings.metadata:type_name -> teleport.header.v1.Metadata
+	4, // 1: teleport.clusterconfig.v1.AccessGraphSettings.spec:type_name -> teleport.clusterconfig.v1.AccessGraphSettingsSpec
+	3, // 2: teleport.clusterconfig.v1.AccessGraphSettings.status:type_name -> teleport.clusterconfig.v1.AccessGraphSettingsStatus
+	1, // 3: teleport.clusterconfig.v1.AccessGraphSettingsSpec.secrets_scan_config:type_name -> teleport.clusterconfig.v1.AccessGraphSecretsScanConfig
+	0, // 4: teleport.clusterconfig.v1.AccessGraphSettingsSpec.demo_mode:type_name -> teleport.clusterconfig.v1.AccessGraphDemoMode
+	5, // [5:5] is the sub-list for method output_type
+	5, // [5:5] is the sub-list for method input_type
+	5, // [5:5] is the sub-list for extension type_name
+	5, // [5:5] is the sub-list for extension extendee
+	0, // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_teleport_clusterconfig_v1_access_graph_settings_proto_init() }
@@ -276,8 +405,8 @@ func file_teleport_clusterconfig_v1_access_graph_settings_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_clusterconfig_v1_access_graph_settings_proto_rawDesc), len(file_teleport_clusterconfig_v1_access_graph_settings_proto_rawDesc)),
-			NumEnums:      1,
-			NumMessages:   2,
+			NumEnums:      2,
+			NumMessages:   3,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/clusterconfig/v1/access_graph_settings.proto
+++ b/api/proto/teleport/clusterconfig/v1/access_graph_settings.proto
@@ -32,12 +32,32 @@ message AccessGraphSettings {
   teleport.header.v1.Metadata metadata = 4;
   // spec is the spec of the resource.
   AccessGraphSettingsSpec spec = 5;
+  // status is the status of the configured access graph service
+  AccessGraphSettingsStatus status = 6;
+}
+
+// AccessGraphSettingsStatus is the status of the configured access graph service
+message AccessGraphSettingsStatus {
+  // initial_sync_complete indicates if the access graph service has sent resources to access graph at least once.
+  bool initial_sync_complete = 1;
 }
 
 // AccessGraphSettingsSpec is the spec for the Access Graph service configuration settings.
 message AccessGraphSettingsSpec {
   // secrets_scan_config is used to configure the parameters for the secrets scanning functionality.
   AccessGraphSecretsScanConfig secrets_scan_config = 1;
+  // demo_mode is used to determine if some features should be available for use in a demo capacity
+  AccessGraphDemoMode demo_mode = 2;
+}
+
+// AccessGraphDemoMode is used to determine if some features should be available for use in a demo capacity
+enum AccessGraphDemoMode {
+  // ACCESS_GRAPH_DEMO_MODE_UNSPECIFIED is an unknown demo mode configuration.
+  ACCESS_GRAPH_DEMO_MODE_UNSPECIFIED = 0;
+  // ACCESS_GRAPH_DEMO_MODE_DISABLED is a disabled demo mode configuration.
+  ACCESS_GRAPH_DEMO_MODE_DISABLED = 1;
+  // ACCESS_GRAPH_DEMO_MODE_ENABLED is an enabled demo mode configuration.
+  ACCESS_GRAPH_DEMO_MODE_ENABLED = 2;
 }
 
 // AccessGraphSecretsScanConfig is used to configure the parameters for the secrets scanning functionality.

--- a/api/types/clusterconfig/access_graph_settings.go
+++ b/api/types/clusterconfig/access_graph_settings.go
@@ -33,13 +33,15 @@ func NewAccessGraphSettings(spec *clusterconfigpb.AccessGraphSettingsSpec) (*clu
 			Name: types.MetaNameAccessGraphSettings,
 		},
 		Spec: spec,
+		Status: &clusterconfigpb.AccessGraphSettingsStatus{
+			InitialSyncComplete: false,
+		},
 	}
 	if err := ValidateAccessGraphSettings(settings); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	return settings, nil
-
 }
 
 // ValidateAccessGraphSettings checks that required parameters are set

--- a/api/types/clusterconfig/access_graph_settings_test.go
+++ b/api/types/clusterconfig/access_graph_settings_test.go
@@ -52,6 +52,9 @@ func TestNewAccessGraphSettings(t *testing.T) {
 				Spec: &clusterconfigpb.AccessGraphSettingsSpec{
 					SecretsScanConfig: clusterconfigpb.AccessGraphSecretsScanConfig_ACCESS_GRAPH_SECRETS_SCAN_CONFIG_DISABLED,
 				},
+				Status: &clusterconfigpb.AccessGraphSettingsStatus{
+					InitialSyncComplete: false,
+				},
 			},
 		},
 		{
@@ -70,6 +73,9 @@ func TestNewAccessGraphSettings(t *testing.T) {
 				},
 				Spec: &clusterconfigpb.AccessGraphSettingsSpec{
 					SecretsScanConfig: clusterconfigpb.AccessGraphSecretsScanConfig_ACCESS_GRAPH_SECRETS_SCAN_CONFIG_ENABLED,
+				},
+				Status: &clusterconfigpb.AccessGraphSettingsStatus{
+					InitialSyncComplete: false,
 				},
 			},
 		},


### PR DESCRIPTION
This adds two new fields, the `DemoMode` to `AccessGraphSettingsSpec` and then an `AccessGraphSettingsStatus` message to the `status` field of `AccessGraphSettings`. 

Originally, I wanted to make a new resource to track the `AccessGraphState`. However, creating a new resource in the backend for a feature/field that no human should/would interact with (the `initial_sync_complete` state) is recommended to be added in [a status field](https://github.com/gravitational/teleport/blob/master/rfd/0153-resource-guidelines.md#defining-a-resource) in the resource instead of the spec (or its own spec)

> When Teleport automatically modifies the spec during runtime it causes drift between what is in the Teleport backend and the state stored by external IaC tools. If a resource has properties that are required to be modified dynamically by Teleport, a separate status field should be added to the resource to contain them. These fields will be ignored by IaC tools during their reconciliation

Teleport would be automatically updating the status of the `initial_sync_complete` field, therefore it should not exist in a spec, but instead in a `status` field for the responsible resource (in this case, `AccessGraphSettings`). 

This will be consumed by the access graph service with a PR to `e`