### PR TITLE
Fix breakpoints

### DIFF
--- a/web/packages/design/src/Flex/Flex.story.jsx
+++ b/web/packages/design/src/Flex/Flex.story.jsx
@@ -27,7 +27,7 @@ export default {
 
 const BoxWithBreakpoints = styled(Box)`
   width: 100%;
-  @media screen and (min-width: ${p => p.theme.breakpoints.small}px) {
+  @media screen and (min-width: ${p => p.theme.breakpoints.small}) {
     width: 50%;
   }
 `;

--- a/web/packages/design/src/index.ts
+++ b/web/packages/design/src/index.ts
@@ -112,3 +112,4 @@ export {
 export type { TextAreaProps } from './TextArea';
 export * from './keyframes';
 export { Stack } from './Flex';
+export { breakpointsPx } from './theme';

--- a/web/packages/design/src/theme/index.ts
+++ b/web/packages/design/src/theme/index.ts
@@ -23,3 +23,4 @@ import lightTheme from './themes/lightTheme';
 export * from './themes/types';
 
 export { darkTheme, lightTheme, bblpTheme };
+export { breakpointsPx } from './themes/sharedStyles';

--- a/web/packages/design/src/theme/themes/sharedStyles.ts
+++ b/web/packages/design/src/theme/themes/sharedStyles.ts
@@ -37,13 +37,16 @@ export const sharedStyles: SharedStyles = {
   ],
   breakpoints: {
     // TODO (avatus): remove mobile/tablet/desktop breakpoints in favor of screensize descriptions
-    mobile: 400 + sidebarWidth,
-    tablet: 800 + sidebarWidth,
-    desktop: 1200 + sidebarWidth,
+    /** @deprecated Use the "small" breakpoint instead. */
+    mobile: `${400 + sidebarWidth}px`,
+    /** @deprecated Use the "medium" breakpoint instead. */
+    tablet: `${800 + sidebarWidth}px`,
+    /** @deprecated Use the "large" breakpoint instead. */
+    desktop: `${1200 + sidebarWidth}px`,
     // use these from now on
-    small: 600,
-    medium: 1024,
-    large: 1280,
+    small: '600px',
+    medium: '1024px',
+    large: '1280px',
   },
   topBarHeight: [44, 56, 72],
   space: [0, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80],

--- a/web/packages/design/src/theme/themes/sharedStyles.ts
+++ b/web/packages/design/src/theme/themes/sharedStyles.ts
@@ -26,6 +26,12 @@ import { SharedColors, SharedStyles } from './types';
 // by changing the minimum width on a per-view basis (Main.tsx).
 const sidebarWidth = 256;
 
+export const breakpointsPx = {
+  small: 600,
+  medium: 1024,
+  large: 1280,
+} as const;
+
 // Styles that are shared by all themes.
 export const sharedStyles: SharedStyles = {
   sidebarWidth,
@@ -44,9 +50,9 @@ export const sharedStyles: SharedStyles = {
     /** @deprecated Use the "large" breakpoint instead. */
     desktop: `${1200 + sidebarWidth}px`,
     // use these from now on
-    small: '600px',
-    medium: '1024px',
-    large: '1280px',
+    small: `${breakpointsPx.small}px`,
+    medium: `${breakpointsPx.medium}px`,
+    large: `${breakpointsPx.large}px`,
   },
   topBarHeight: [44, 56, 72],
   space: [0, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80],

--- a/web/packages/design/src/theme/themes/types.ts
+++ b/web/packages/design/src/theme/themes/types.ts
@@ -312,12 +312,15 @@ export type SharedStyles = {
   sidebarWidth: number;
   boxShadow: string[];
   breakpoints: {
-    mobile: number;
-    tablet: number;
-    desktop: number;
-    small: number;
-    medium: number;
-    large: number;
+    /** @deprecated Use the "small" breakpoint instead. */
+    mobile: string;
+    /** @deprecated Use the "medium" breakpoint instead. */
+    tablet: string;
+    /** @deprecated Use the "large" breakpoint instead. */
+    desktop: string;
+    small: string;
+    medium: string;
+    large: string;
   };
   topBarHeight: number[];
   space: number[];

--- a/web/packages/teleport/src/AuthConnectors/styles/AuthConnectors.styles.ts
+++ b/web/packages/teleport/src/AuthConnectors/styles/AuthConnectors.styles.ts
@@ -25,7 +25,7 @@ import { FeatureHeader } from 'teleport/components/Layout';
 export const ResponsiveFeatureHeader = styled(FeatureHeader)`
   justify-content: space-between;
 
-  @media screen and (max-width: ${p => p.theme.breakpoints.tablet}px) {
+  @media screen and (max-width: ${p => p.theme.breakpoints.tablet}) {
     flex-direction: column;
     height: auto;
     gap: 10px;
@@ -37,7 +37,7 @@ export const ResponsiveFeatureHeader = styled(FeatureHeader)`
 
 export const MobileDescription = styled(Subtitle1)`
   margin-bottom: ${p => p.theme.space[3]}px;
-  @media screen and (min-width: ${p => p.theme.breakpoints.tablet}px) {
+  @media screen and (min-width: ${p => p.theme.breakpoints.tablet}) {
     display: none;
   }
 `;
@@ -47,14 +47,14 @@ export const DesktopDescription = styled(Box)`
   width: 240px;
   color: ${p => p.theme.colors.text.main};
   flex-shrink: 0;
-  @media screen and (max-width: ${p => p.theme.breakpoints.tablet}px) {
+  @media screen and (max-width: ${p => p.theme.breakpoints.tablet}) {
     display: none;
   }
 `;
 
 export const ResponsiveAddButton = styled(Button)`
   width: 240px;
-  @media screen and (max-width: ${p => p.theme.breakpoints.tablet}px) {
+  @media screen and (max-width: ${p => p.theme.breakpoints.tablet}) {
     width: 100%;
   }
 `;

--- a/web/packages/teleport/src/AuthConnectors/styles/LockedFeatureContainer.styles.ts
+++ b/web/packages/teleport/src/AuthConnectors/styles/LockedFeatureContainer.styles.ts
@@ -35,7 +35,7 @@ export const LockedFeatureButton = styled(ButtonLockedFeature)`
   right: 10%;
   bottom: -10px;
 
-  @media screen and (max-width: ${props => props.theme.breakpoints.tablet}px) {
+  @media screen and (max-width: ${props => props.theme.breakpoints.tablet}) {
     width: 100%;
     right: 1px;
   }

--- a/web/packages/teleport/src/Clusters/ManageCluster/ManageCluster.tsx
+++ b/web/packages/teleport/src/Clusters/ManageCluster/ManageCluster.tsx
@@ -202,7 +202,7 @@ export const DataItem = ({ title = '', data = null, isLoading = false }) => (
 const DataItemFlex = styled(Flex)`
   margin-bottom: ${props => props.theme.space[3]}px;
   align-items: center;
-  @media screen and (max-width: ${props => props.theme.breakpoints.mobile}px) {
+  @media screen and (max-width: ${props => props.theme.breakpoints.mobile}) {
     flex-direction: column;
     padding-left: ${props => props.theme.space[2]}px;
     align-items: start;

--- a/web/packages/teleport/src/Main/MainContainer.tsx
+++ b/web/packages/teleport/src/Main/MainContainer.tsx
@@ -30,7 +30,7 @@ export const MainContainer = styled.div`
   --sidenav-panel-width: 264px;
   overflow: hidden;
   margin-top: ${p => p.theme.topBarHeight[0]}px;
-  @media screen and (min-width: ${p => p.theme.breakpoints.small}px) {
+  @media screen and (min-width: ${p => p.theme.breakpoints.small}) {
     margin-top: ${p => p.theme.topBarHeight[1]}px;
   }
 `;

--- a/web/packages/teleport/src/Notifications/Notifications.tsx
+++ b/web/packages/teleport/src/Notifications/Notifications.tsx
@@ -310,10 +310,10 @@ const NotificationsDropdown = styled(Dropdown)`
   height: 80vh;
 
   right: -40px;
-  @media screen and (min-width: ${p => p.theme.breakpoints.small}px) {
+  @media screen and (min-width: ${p => p.theme.breakpoints.small}) {
     right: -52px;
   }
-  @media screen and (min-width: ${p => p.theme.breakpoints.large}px) {
+  @media screen and (min-width: ${p => p.theme.breakpoints.large}) {
     right: -140px;
   }
 `;

--- a/web/packages/teleport/src/Support/Support.tsx
+++ b/web/packages/teleport/src/Support/Support.tsx
@@ -188,13 +188,13 @@ export const Support = ({
 };
 
 export const StyledMultiRowBox = styled(MultiRowBox)`
-  @media screen and (max-width: ${props => props.theme.breakpoints.mobile}px) {
+  @media screen and (max-width: ${props => props.theme.breakpoints.mobile}) {
     border: none;
   }
 `;
 
 export const StyledRow = styled(Row)`
-  @media screen and (max-width: ${props => props.theme.breakpoints.mobile}px) {
+  @media screen and (max-width: ${props => props.theme.breakpoints.mobile}) {
     border: none !important;
     padding-left: 0;
     padding-bottom: 0;
@@ -204,7 +204,7 @@ export const StyledRow = styled(Row)`
 export const MobileSeparator = styled.div`
   width: 100vw;
   margin-left: -${props => props.theme.space[6]}px;
-  @media screen and (max-width: ${props => props.theme.breakpoints.mobile}px) {
+  @media screen and (max-width: ${props => props.theme.breakpoints.mobile}) {
     border-bottom: ${props =>
       `${props.theme.borders[1]} ${props.theme.colors.interactive.tonal.neutral[2]}`};
   }
@@ -217,14 +217,14 @@ export const IconBox = styled(Box)`
   margin-right: ${props => props.theme.space[3]}px;
   background: ${props => props.theme.colors.interactive.tonal.neutral[0]};
 
-  @media screen and (max-width: ${props => props.theme.breakpoints.mobile}px) {
+  @media screen and (max-width: ${props => props.theme.breakpoints.mobile}) {
     background: transparent;
     margin-right: ${props => props.theme.space[1]}px;
   }
 `;
 
 const SupportContentFlex = styled(Flex)`
-  @media screen and (max-width: ${props => props.theme.breakpoints.mobile}px) {
+  @media screen and (max-width: ${props => props.theme.breakpoints.mobile}) {
     flex-direction: column;
     align-items: flex-start;
   }
@@ -232,7 +232,7 @@ const SupportContentFlex = styled(Flex)`
 
 const SupportButtonBox = styled(Box)`
   width: 320px;
-  @media screen and (max-width: ${props => props.theme.breakpoints.mobile}px) {
+  @media screen and (max-width: ${props => props.theme.breakpoints.mobile}) {
     margin-left: ${props => props.theme.space[6]}px;
     margin-top: ${props => props.theme.space[2]}px;
   }
@@ -242,10 +242,10 @@ const SupportLinksFlex = styled(Flex)`
   justify-content: space-between;
   flex-wrap: wrap;
   max-width: 70%;
-  @media screen and (max-width: ${props => props.theme.breakpoints.tablet}px) {
+  @media screen and (max-width: ${props => props.theme.breakpoints.tablet}) {
     max-width: 100%;
   }
-  @media screen and (max-width: ${props => props.theme.breakpoints.mobile}px) {
+  @media screen and (max-width: ${props => props.theme.breakpoints.mobile}) {
     flex-direction: column;
     gap: ${props => props.theme.space[3]}px;
     margin-bottom: ${props => props.theme.space[3]}px;
@@ -254,7 +254,7 @@ const SupportLinksFlex = styled(Flex)`
 
 const DataItemFlex = styled(Flex)`
   margin-bottom: ${props => props.theme.space[3]}px;
-  @media screen and (max-width: ${props => props.theme.breakpoints.mobile}px) {
+  @media screen and (max-width: ${props => props.theme.breakpoints.mobile}) {
     flex-direction: column;
     padding-left: ${props => props.theme.space[2]}px;
   }

--- a/web/packages/teleport/src/TopBar/Shared.tsx
+++ b/web/packages/teleport/src/TopBar/Shared.tsx
@@ -26,7 +26,7 @@ export const ButtonIconContainer = styled.div<{ open?: boolean }>`
   justify-content: center;
   padding-left: 12px;
   padding-right: 12px;
-  @media screen and (min-width: ${p => p.theme.breakpoints.large}px) {
+  @media screen and (min-width: ${p => p.theme.breakpoints.large}) {
     padding-left: 24px;
     padding-right: 24px;
   }

--- a/web/packages/teleport/src/TopBar/TopBar.tsx
+++ b/web/packages/teleport/src/TopBar/TopBar.tsx
@@ -82,7 +82,7 @@ export const TopBarContainer = styled(TopNav)`
   border-bottom: 1px solid ${({ theme }) => theme.colors.spotBackground[1]};
 
   height: ${p => p.theme.topBarHeight[0]}px;
-  @media screen and (min-width: ${p => p.theme.breakpoints.small}px) {
+  @media screen and (min-width: ${p => p.theme.breakpoints.small}) {
     height: ${p => p.theme.topBarHeight[1]}px;
   }
 `;
@@ -98,10 +98,10 @@ const TeleportLogo = ({ CustomLogo }: TopBarProps) => {
       css={`
         height: 100%;
         margin-right: 0px;
-        @media screen and (min-width: ${p => p.theme.breakpoints.medium}px) {
+        @media screen and (min-width: ${p => p.theme.breakpoints.medium}) {
           margin-right: 76px;
         }
-        @media screen and (min-width: ${p => p.theme.breakpoints.large}px) {
+        @media screen and (min-width: ${p => p.theme.breakpoints.large}) {
           margin-right: 67px;
         }
       `}
@@ -130,14 +130,12 @@ const TeleportLogo = ({ CustomLogo }: TopBarProps) => {
               padding-left: ${props => props.theme.space[3]}px;
               padding-right: ${props => props.theme.space[3]}px;
               height: 18px;
-              @media screen and (min-width: ${p =>
-                  p.theme.breakpoints.small}px) {
+              @media screen and (min-width: ${p => p.theme.breakpoints.small}) {
                 height: 28px;
                 padding-left: ${props => props.theme.space[4]}px;
                 padding-right: ${props => props.theme.space[4]}px;
               }
-              @media screen and (min-width: ${p =>
-                  p.theme.breakpoints.large}px) {
+              @media screen and (min-width: ${p => p.theme.breakpoints.large}) {
                 height: 30px;
               }
             `}

--- a/web/packages/teleport/src/TopBar/TopBar.tsx
+++ b/web/packages/teleport/src/TopBar/TopBar.tsx
@@ -21,8 +21,7 @@ import { matchPath, useHistory } from 'react-router';
 import { Link } from 'react-router-dom';
 import styled, { useTheme } from 'styled-components';
 
-import { Flex, Image, TopNav } from 'design';
-import { Theme } from 'design/theme/themes/types';
+import { breakpointsPx, Flex, Image, TopNav } from 'design';
 import { HoverTooltip } from 'design/Tooltip';
 
 import { logos } from 'teleport/components/LogoHero/LogoHero';
@@ -39,7 +38,6 @@ export function TopBar({ CustomLogo }: TopBarProps) {
   const history = useHistory();
   const features = useFeatures();
   const { currentWidth } = useLayout();
-  const theme: Theme = useTheme();
 
   // find active feature
   const feature = features.find(
@@ -52,7 +50,7 @@ export function TopBar({ CustomLogo }: TopBarProps) {
   );
 
   const iconSize =
-    currentWidth >= theme.breakpoints.medium
+    currentWidth >= breakpointsPx.medium
       ? navigationIconSizeMedium
       : navigationIconSizeSmall;
 

--- a/web/packages/teleport/src/components/Dropdown/Dropdown.tsx
+++ b/web/packages/teleport/src/components/Dropdown/Dropdown.tsx
@@ -47,7 +47,7 @@ export const Dropdown = styled.div<OpenProps>`
   transform: ${p => (p.open ? 'scale(1)' : 'scale(.8)')};
 
   top: ${p => p.theme.topBarHeight[0]}px;
-  @media screen and (min-width: ${p => p.theme.breakpoints.small}px) {
+  @media screen and (min-width: ${p => p.theme.breakpoints.small}) {
     top: ${p => p.theme.topBarHeight[1]}px;
   }
 `;

--- a/web/packages/teleport/src/components/ExternalAuditStorageCta/ExternalAuditStorageCta.tsx
+++ b/web/packages/teleport/src/components/ExternalAuditStorageCta/ExternalAuditStorageCta.tsx
@@ -64,7 +64,7 @@ export const ExternalAuditStorageCta = () => {
         justifyContent="space-between"
         css={`
           @media screen and (max-width: ${props =>
-              props.theme.breakpoints.mobile}px) {
+              props.theme.breakpoints.mobile}) {
             flex-direction: column;
             gap: ${props => props.theme.space[3]}px;
           }

--- a/web/packages/teleport/src/components/SlidingSidePanel/SlidingSidePanel.tsx
+++ b/web/packages/teleport/src/components/SlidingSidePanel/SlidingSidePanel.tsx
@@ -78,7 +78,7 @@ export const SlidingSidePanel = styled(Box)<Props>`
 
   top: ${p => p.theme.topBarHeight[0]}px;
   padding-bottom: ${p => p.theme.topBarHeight[0] + p.theme.space[2]}px;
-  @media screen and (min-width: ${p => p.theme.breakpoints.small}px) {
+  @media screen and (min-width: ${p => p.theme.breakpoints.small}) {
     top: ${p => p.theme.topBarHeight[1]}px;
     padding-bottom: ${p => p.theme.topBarHeight[1] + p.theme.space[2]}px;
   }

--- a/web/packages/teleport/src/components/UserMenuNav/UserMenuNav.tsx
+++ b/web/packages/teleport/src/components/UserMenuNav/UserMenuNav.tsx
@@ -76,7 +76,7 @@ const Username = styled(Text)`
   font-size: 14px;
   font-weight: 400;
   display: none;
-  @media screen and (min-width: ${p => p.theme.breakpoints.large}px) {
+  @media screen and (min-width: ${p => p.theme.breakpoints.large}) {
     display: inline-flex;
   }
 `;
@@ -86,7 +86,7 @@ const StyledAvatar = styled.div`
   background: ${props => props.theme.colors.brand};
   color: ${props => props.theme.colors.text.primaryInverse};
   border-radius: 50%;
-  @media screen and (min-width: ${p => p.theme.breakpoints.medium}px) {
+  @media screen and (min-width: ${p => p.theme.breakpoints.medium}) {
     margin-right: 16px;
     height: 32px;
     max-width: 32px;
@@ -112,7 +112,7 @@ const Arrow = styled.div<{ open?: boolean }>`
   }
 
   display: none;
-  @media screen and (min-width: ${p => p.theme.breakpoints.medium}px) {
+  @media screen and (min-width: ${p => p.theme.breakpoints.medium}) {
     display: inline-flex;
   }
 `;


### PR DESCRIPTION
teleport.e counterpart: https://github.com/gravitational/teleport.e/pull/6240

Breakpoints in styled-system v5 are supposed to be defined as numbers with units, not just numbers, see [the docs](https://github.com/styled-system/styled-system/blob/v5.1.5/docs/responsive-styles.md#using-objects).

With the previous approach, if you have a code like this: `<Flex flexWrap={{ _: 'wrap', medium: 'nowrap' }}>`, it'll generate CSS that looks like this:

```css
.xUaJS{display:flex;flex-wrap:wrap;}
@media screen and (min-width: 1024){.xUaJS{flex-wrap:nowrap;}}
```

This won't work: it's supposed to be `min-width: 1024px`.

The fix is to define breakpoints with the units included. This meant that I had to update a lot of places in the code that take breakpoint values directly from the theme and then manually append "px". I did this by doing search-and-replace. When backporting, I'm going to grep the project for `breakpoints.*px` to see if I didn't miss anything.

I tested this by inspecting if these two stories still work:

* https://localhost:9002/?path=/story/teleport-support--support-oss
* https://localhost:9002/?path=/story/teleport-usermenunav--loaded