### PR TITLE
[v15] Update references to renamed features

### DIFF
--- a/lib/srv/discovery/access_graph.go
+++ b/lib/srv/discovery/access_graph.go
@@ -425,7 +425,7 @@ func (s *Server) initAccessGraphWatchers(ctx context.Context, cfg *Config) error
 				}
 				// reset the currentTAGResources to force a full sync
 				if err := s.initializeAndWatchAccessGraph(ctx, reloadCh); errors.Is(err, errTAGFeatureNotEnabled) {
-					s.Log.WarnContext(ctx, "Access Graph specified in config, but the license does not include Teleport Policy. Access graph sync will not be enabled.")
+					s.Log.WarnContext(ctx, "Access Graph specified in config, but the license does not include Teleport Identity Security. Access graph sync will not be enabled.")
 					break
 				} else if err != nil {
 					s.Log.WarnContext(ctx, "Error initializing and watching access graph", "error", err)

--- a/web/packages/design/src/constants.ts
+++ b/web/packages/design/src/constants.ts
@@ -1,0 +1,25 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** User-visible feature names */
+export enum FeatureName {
+  /** Teleport Identity Security (formerly Teleport Policy) */
+  IdentitySecurity = 'Teleport Identity Security',
+  /** Teleport Identity Governance (formerly Teleport Identity) */
+  IdentityGovernance = 'Teleport Identity Governance',
+}

--- a/web/packages/teleport/src/components/ToolTipNoPermBadge/ToolTipNoPermBadge.tsx
+++ b/web/packages/teleport/src/components/ToolTipNoPermBadge/ToolTipNoPermBadge.tsx
@@ -19,6 +19,8 @@
 import React, { PropsWithChildren } from 'react';
 import { useTheme } from 'styled-components';
 
+import { FeatureName } from 'design/constants';
+
 import { ToolTipBadge } from 'teleport/components/ToolTipBadge';
 
 type Props = {
@@ -50,5 +52,5 @@ export const ToolTipNoPermBadge: React.FC<PropsWithChildren<Props>> = ({
 export enum BadgeTitle {
   LackingPermissions = 'Lacking Permissions',
   LackingEnterpriseLicense = 'Enterprise Only',
-  LackingIgs = 'Teleport Identity Only',
+  LackingIgs = `${FeatureName.IdentityGovernance} Only`,
 }


### PR DESCRIPTION
Backport #53144 to branch/v15

Manual resolution:
- `access_graph_azure.go`: file not present in v15
- `PolicyPlaceholder.tsx`: file not present in v15