### PR TITLE
Promote Items to backend.Backend interface

### DIFF
--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -68,6 +68,10 @@ type Backend interface {
 	// Get returns a single item or not found error
 	Get(ctx context.Context, key Key) (*Item, error)
 
+	// Items produces an iterator of backend items in the range, and order
+	// described in the provided [ItemsParams].
+	Items(ctx context.Context, params ItemsParams) iter.Seq2[Item, error]
+
 	// GetRange returns the items between the start and end keys, including both
 	// (if present).
 	GetRange(ctx context.Context, startKey, endKey Key, limit int) (*GetResult, error)
@@ -129,17 +133,6 @@ type ItemsParams struct {
 	Descending bool
 	// Limit is an optional maximum number of items to retrieve during iteration.
 	Limit int
-}
-
-// BackendWithItems is a temporary interface that will be added to [backend.Backend]
-// once all concrete backend implementations satisfy the new interface.
-// TODO(tross): REMEMBER TO DELETE THIS
-type BackendWithItems interface {
-	Backend
-
-	// Items produces an iterator of backend items in the range, and order
-	// described in the provided [ItemsParams].
-	Items(ctx context.Context, params ItemsParams) iter.Seq2[Item, error]
 }
 
 // New initializes a new [Backend] implementation based on the service config.

--- a/lib/backend/sanitize.go
+++ b/lib/backend/sanitize.go
@@ -20,6 +20,7 @@ package backend
 
 import (
 	"context"
+	"iter"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -96,6 +97,10 @@ func NewSanitizer(backend Backend) *Sanitizer {
 // GetRange returns query range
 func (s *Sanitizer) GetRange(ctx context.Context, startKey, endKey Key, limit int) (*GetResult, error) {
 	return s.backend.GetRange(ctx, startKey, endKey, limit)
+}
+
+func (s *Sanitizer) Items(ctx context.Context, params ItemsParams) iter.Seq2[Item, error] {
+	return s.backend.Items(ctx, params)
 }
 
 // Create creates item if it does not exist

--- a/lib/backend/sanitize_test.go
+++ b/lib/backend/sanitize_test.go
@@ -20,6 +20,7 @@ package backend
 
 import (
 	"context"
+	"iter"
 	"testing"
 	"time"
 
@@ -185,6 +186,12 @@ func (n *nopBackend) GetRange(_ context.Context, startKey, endKey Key, limit int
 	return &GetResult{Items: []Item{
 		{Key: NewKey("foo"), Value: []byte("bar")},
 	}}, nil
+}
+
+func (n *nopBackend) Items(context.Context, ItemsParams) iter.Seq2[Item, error] {
+	return func(yield func(Item, error) bool) {
+		yield(Item{Key: NewKey("foo"), Value: []byte("bar")}, nil)
+	}
 }
 
 func (n *nopBackend) Create(_ context.Context, _ Item) (*Lease, error) {

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -368,11 +368,6 @@ func testItems(t *testing.T, newBackend Constructor) {
 	require.NoError(t, err)
 	defer func() { require.NoError(t, uut.Close()) }()
 
-	it, ok := uut.(backend.BackendWithItems)
-	if !ok {
-		t.Skip("Backend does not support iteration")
-	}
-
 	ctx := context.Background()
 	prefix := MakePrefix()
 
@@ -442,7 +437,7 @@ func testItems(t *testing.T, newBackend Constructor) {
 		for _, test := range cases {
 			t.Run(test.name, func(t *testing.T) {
 				i := 0
-				for item, err := range it.Items(ctx, backend.ItemsParams{StartKey: test.startKey, EndKey: test.endKey}) {
+				for item, err := range uut.Items(ctx, backend.ItemsParams{StartKey: test.startKey, EndKey: test.endKey}) {
 					require.NoError(t, err)
 
 					if len(test.expected) == 0 {
@@ -516,7 +511,7 @@ func testItems(t *testing.T, newBackend Constructor) {
 		for _, test := range cases {
 			t.Run(test.name, func(t *testing.T) {
 				i := 0
-				for item, err := range it.Items(ctx, backend.ItemsParams{StartKey: test.startKey, EndKey: test.endKey, Descending: true}) {
+				for item, err := range uut.Items(ctx, backend.ItemsParams{StartKey: test.startKey, EndKey: test.endKey, Descending: true}) {
 					require.NoError(t, err)
 
 					if len(test.expected) == 0 {
@@ -557,7 +552,7 @@ func testItems(t *testing.T, newBackend Constructor) {
 
 		t.Run("ascending", func(t *testing.T) {
 			i := 0
-			for item := range it.Items(ctx, backend.ItemsParams{StartKey: prefix("page"), EndKey: backend.RangeEnd(prefix("page"))}) {
+			for item := range uut.Items(ctx, backend.ItemsParams{StartKey: prefix("page"), EndKey: backend.RangeEnd(prefix("page"))}) {
 				require.Equal(t, expected[i], string(item.Value))
 				i++
 			}
@@ -566,7 +561,7 @@ func testItems(t *testing.T, newBackend Constructor) {
 
 		t.Run("descending", func(t *testing.T) {
 			i := count - 1
-			for item := range it.Items(ctx, backend.ItemsParams{StartKey: prefix("page"), EndKey: backend.RangeEnd(prefix("page")), Descending: true}) {
+			for item := range uut.Items(ctx, backend.ItemsParams{StartKey: prefix("page"), EndKey: backend.RangeEnd(prefix("page")), Descending: true}) {
 				assert.Equal(t, expected[i], string(item.Value))
 				i--
 			}

--- a/lib/backend/wrap.go
+++ b/lib/backend/wrap.go
@@ -20,6 +20,7 @@ package backend
 
 import (
 	"context"
+	"iter"
 	"sync"
 	"time"
 
@@ -71,6 +72,10 @@ func (s *Wrapper) GetRange(ctx context.Context, startKey, endKey Key, limit int)
 		return nil, trace.Wrap(err)
 	}
 	return s.backend.GetRange(ctx, startKey, endKey, limit)
+}
+
+func (s *Wrapper) Items(ctx context.Context, params ItemsParams) iter.Seq2[Item, error] {
+	return s.backend.Items(ctx, params)
 }
 
 // Create creates item if it does not exist


### PR DESCRIPTION
Now that all backends implement backend.BackendWithItems the temporary interface is removed and the Items method is included in backend.Backend. All wrapper implementations, and backend mocks were updated accordingly.

The backend reporter used to tally prometheus metrics was updated with new metrics to track streaming requests since reusing the batch read requests wouldn't make sense for iteration. This means that once upstream consumers of the backend start switching from GetRange to Items the batch read metrics will not be the complete source of truth. The streaming metrics also lack some of the same observability since chunk sizes and latency of reads cannot be known at the reporter level. The only way to provide the same batch metrics that we have today would require each backend implementation to be responsible for updating the metrics when performing their internal reads to supply the Items iterator.