### PR TITLE
Edit the Feature Matrix

### DIFF
--- a/docs/pages/feature-matrix.mdx
+++ b/docs/pages/feature-matrix.mdx
@@ -97,7 +97,3 @@ options:
   Proxy Service on the Teleport Cloud infrastructure.
 - **Self-Hosted:** Teleport users deploy the Teleport Auth Service and Teleport Proxy
   Service on their own infrastructure.
-
-Teleport Enterprise includes add-on products that provide a more complete
-infrastructure identity solution, which this guide explains in more detail
-below.


### PR DESCRIPTION
Remove a paragraph that only made sense when the edition description was organized before the rest of the content. This paragraph was left in the page by mistake during editing.