### PR TITLE
[v17] docs: fix access list default owner flag name in identity center okta migration guide

### DIFF
--- a/docs/pages/admin-guides/management/guides/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport.mdx
+++ b/docs/pages/admin-guides/management/guides/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport.mdx
@@ -128,7 +128,7 @@ $ tctl plugins install awsic \
     --use-system-credentials \
     --scim-url ${IDENTITY_CENTER_SCIM_BASE_URL} \
     --scim-token ${IDENTITY_CENTER_SCIM_BEARER_TOKEN} \
-    --default-owner ${TELEPORT_ACCESS_LIST_DEFAULT_OWNER} \
+    --access-list-default-owner ${TELEPORT_ACCESS_LIST_DEFAULT_OWNER} \
     --user-origin okta \
     --account-name ${ACCOUNT_NAME_ALLOW_FILTER} \
     --group-name ${GROUP_NAME_ALLOW_FILTER}


### PR DESCRIPTION
Backport #53420 to branch/v17