### PR TITLE
Add health check config service

### DIFF
--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -422,6 +422,26 @@ const (
 	MaxAssumeStartDuration = time.Hour * 24 * 7
 )
 
+const (
+	// MaxHealthCheckInterval is the minimum interval between resource health
+	// checks.
+	MinHealthCheckInterval = 30 * time.Second
+	// MaxHealthCheckInterval is the maximum interval between resource health
+	// checks. Since timeout must be less than interval, this is effectively the
+	// maximum health check timeout as well.
+	MaxHealthCheckInterval = 600 * time.Second
+	// MinHealthCheckTimeout is the minimum resource health check timeout.
+	// There is no corresponding MaxHealthCheckTimeout, because timeout is
+	// bounded to be no greater than the interval.
+	MinHealthCheckTimeout = time.Second
+	// MaxHealthCheckHealthyThreshold is the maximum health check healthy
+	// threshold.
+	MaxHealthCheckHealthyThreshold = 10
+	// MaxHealthCheckUnhealthyThreshold is the maximum health check unhealthy
+	// threshold.
+	MaxHealthCheckUnhealthyThreshold = MaxHealthCheckHealthyThreshold
+)
+
 // Constants for TLS routing connection upgrade. See RFD for more details:
 // https://github.com/gravitational/teleport/blob/master/rfd/0123-tls-routing-behind-layer7-lb.md
 const (

--- a/api/defaults/defaults.go
+++ b/api/defaults/defaults.go
@@ -196,3 +196,16 @@ const (
 	// TODO(greedy52) DELETE in 17.0
 	TLSRoutingConnUpgradeModeEnvVar = "TELEPORT_TLS_ROUTING_CONN_UPGRADE_MODE"
 )
+
+const (
+	// HealthCheckInterval is the default resource health check interval.
+	HealthCheckInterval time.Duration = 30 * time.Second
+	// HealthCheckTimeout is the default resource health check timeout.
+	HealthCheckTimeout time.Duration = 5 * time.Second
+	// HealthCheckHealthyThreshold is the default resource health check healthy
+	// threshold.
+	HealthCheckHealthyThreshold uint32 = 2
+	// HealthCheckUnhealthyThreshold is the default resource health check
+	// unhealthy threshold.
+	HealthCheckUnhealthyThreshold uint32 = 1
+)

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -498,6 +498,9 @@ const (
 	// KindHeadlessAuthentication is a headless authentication resource.
 	KindHeadlessAuthentication = "headless_authentication"
 
+	// KindHealthCheckConfig is the resource for health check configuration.
+	KindHealthCheckConfig = "health_check_config"
+
 	// KindAccessGraph is the RBAC kind for access graph.
 	KindAccessGraph = "access_graph"
 

--- a/api/types/healthcheckconfig/health_check_config.go
+++ b/api/types/healthcheckconfig/health_check_config.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2025 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthcheckconfig
+
+import (
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
+	"github.com/gravitational/teleport/api/types"
+)
+
+// NewHealthCheckConfig creates a new health check configuration resource.
+func NewHealthCheckConfig(name string, spec *healthcheckconfigv1.HealthCheckConfigSpec) (*healthcheckconfigv1.HealthCheckConfig, error) {
+	config := &healthcheckconfigv1.HealthCheckConfig{
+		Kind:    types.KindHealthCheckConfig,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: name,
+		},
+		Spec: spec,
+	}
+	return config, nil
+}

--- a/lib/services/health_check_config.go
+++ b/lib/services/health_check_config.go
@@ -1,0 +1,151 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package services
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/api/defaults"
+	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
+	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
+	"github.com/gravitational/teleport/api/types"
+)
+
+// HealthCheckConfigReader defines methods for reading health check config
+// resources.
+type HealthCheckConfigReader interface {
+	// GetHealthCheckConfig fetches a health check config by name.
+	GetHealthCheckConfig(ctx context.Context, name string) (*healthcheckconfigv1.HealthCheckConfig, error)
+	// ListHealthCheckConfigs lists health check configs with pagination.
+	ListHealthCheckConfigs(ctx context.Context, limit int, startKey string) ([]*healthcheckconfigv1.HealthCheckConfig, string, error)
+}
+
+// HealthCheckConfig is a service that manages
+// [healthcheckconfigv1.HealthCheckConfig] resources.
+type HealthCheckConfig interface {
+	HealthCheckConfigReader
+
+	// CreateHealthCheckConfig creates a new health check config.
+	CreateHealthCheckConfig(ctx context.Context, in *healthcheckconfigv1.HealthCheckConfig) (*healthcheckconfigv1.HealthCheckConfig, error)
+	// UpdateHealthCheckConfig updates an existing health check config.
+	UpdateHealthCheckConfig(ctx context.Context, in *healthcheckconfigv1.HealthCheckConfig) (*healthcheckconfigv1.HealthCheckConfig, error)
+	// UpsertHealthCheckConfig creates or updates a health check config.
+	UpsertHealthCheckConfig(ctx context.Context, in *healthcheckconfigv1.HealthCheckConfig) (*healthcheckconfigv1.HealthCheckConfig, error)
+	// DeleteHealthCheckConfig deletes a health check config.
+	DeleteHealthCheckConfig(ctx context.Context, name string) error
+}
+
+// ValidateHealthCheckConfig validates the given health check config.
+func ValidateHealthCheckConfig(s *healthcheckconfigv1.HealthCheckConfig) error {
+	switch {
+	case s == nil:
+		return trace.BadParameter("object must not be nil")
+	case s.Version != types.V1:
+		return trace.BadParameter("only version %q is supported, got %q", types.V1, s.Version)
+	case s.Kind != types.KindHealthCheckConfig:
+		return trace.BadParameter("kind must be %q, got %q", types.KindHealthCheckConfig, s.Kind)
+	case s.Metadata == nil:
+		return trace.BadParameter("metadata is missing")
+	case s.Metadata.Name == "":
+		return trace.BadParameter("metadata.name is missing")
+	case s.Spec == nil:
+		return trace.BadParameter("spec is missing")
+	case s.Spec.Match == nil:
+		return trace.BadParameter("spec.match is missing")
+	case len(s.Spec.Match.DbLabels) == 0 && len(s.Spec.Match.DbLabelsExpression) == 0:
+		return trace.BadParameter("at least one of spec.match.db_labels or spec.match.db_labels_expression must be set")
+	}
+
+	for _, label := range s.Spec.Match.DbLabels {
+		if err := validateLabel(label); err != nil {
+			return trace.BadParameter("invalid spec.db_labels: %v", err)
+		}
+	}
+	if expr := s.Spec.Match.DbLabelsExpression; len(expr) > 0 {
+		if _, err := parseLabelExpression(expr); err != nil {
+			return trace.BadParameter("invalid spec.db_labels_expression: %v", err)
+		}
+	}
+
+	timeout := s.Spec.Timeout.AsDuration()
+	switch {
+	case timeout == 0:
+		timeout = defaults.HealthCheckTimeout
+	case timeout < constants.MinHealthCheckTimeout:
+		return trace.BadParameter("spec.timeout must be at least %s", constants.MinHealthCheckTimeout)
+	}
+
+	interval := s.Spec.Interval.AsDuration()
+	switch {
+	case interval == 0:
+		interval = defaults.HealthCheckInterval
+	case interval < constants.MinHealthCheckInterval:
+		return trace.BadParameter("spec.interval must be at least %s", constants.MinHealthCheckInterval)
+	case interval > constants.MaxHealthCheckInterval:
+		return trace.BadParameter("spec.interval must not be greater than %s", constants.MaxHealthCheckInterval)
+	}
+
+	if timeout > interval {
+		if s.Spec.Timeout.AsDuration() == 0 {
+			return trace.BadParameter("spec.interval (%s) must not be less than the default timeout (%s)", interval, defaults.HealthCheckTimeout)
+		}
+		if s.Spec.Interval.AsDuration() == 0 {
+			return trace.BadParameter("spec.timeout (%s) must not be greater than the default interval (%s)", timeout, defaults.HealthCheckInterval)
+		}
+		return trace.BadParameter("spec.timeout (%s) must not be greater than spec.interval (%s)", timeout, interval)
+	}
+
+	if s.Spec.HealthyThreshold > constants.MaxHealthCheckHealthyThreshold {
+		return trace.BadParameter(
+			"spec.healthy_threshold (%v) must not be greater than %v",
+			s.Spec.HealthyThreshold,
+			constants.MaxHealthCheckHealthyThreshold,
+		)
+	}
+	if s.Spec.UnhealthyThreshold > constants.MaxHealthCheckUnhealthyThreshold {
+		return trace.BadParameter(
+			"spec.unhealthy_threshold (%v) must not be greater than %v",
+			s.Spec.UnhealthyThreshold,
+			constants.MaxHealthCheckUnhealthyThreshold,
+		)
+	}
+	return nil
+}
+
+func validateLabel(label *labelv1.Label) error {
+	if label.Name == types.Wildcard {
+		if len(label.Values) != 1 || label.Values[0] != types.Wildcard {
+			return trace.BadParameter("selector *:%s is not supported, a wildcard label key may only be used with a wildcard label value", label.Values[0])
+		}
+	}
+	return nil
+}
+
+// MarshalHealthCheckConfig marshals HealthCheckConfig resource to JSON.
+func MarshalHealthCheckConfig(cfg *healthcheckconfigv1.HealthCheckConfig, opts ...MarshalOption) ([]byte, error) {
+	return MarshalProtoResource(cfg, opts...)
+}
+
+// UnmarshalHealthCheckConfig unmarshals the HealthCheckConfig resource.
+func UnmarshalHealthCheckConfig(data []byte, opts ...MarshalOption) (*healthcheckconfigv1.HealthCheckConfig, error) {
+	return UnmarshalProtoResource[*healthcheckconfigv1.HealthCheckConfig](data, opts...)
+}

--- a/lib/services/health_check_config_test.go
+++ b/lib/services/health_check_config_test.go
@@ -1,0 +1,414 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package services
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
+	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
+	"github.com/gravitational/teleport/api/types"
+)
+
+func TestValidateHealthCheckConfig(t *testing.T) {
+	t.Parallel()
+
+	var errContains = func(substr string) require.ErrorAssertionFunc {
+		return func(t require.TestingT, err error, _ ...interface{}) {
+			t.(*testing.T).Helper()
+			require.ErrorContains(t, err, substr)
+		}
+	}
+
+	testCases := []struct {
+		name       string
+		in         *healthcheckconfigv1.HealthCheckConfig
+		requireErr require.ErrorAssertionFunc
+	}{
+		{
+			name: "default is valid",
+			in: &healthcheckconfigv1.HealthCheckConfig{
+				Version: types.V1,
+				Kind:    types.KindHealthCheckConfig,
+				Metadata: &headerv1.Metadata{
+					Name: "default",
+				},
+				Spec: &healthcheckconfigv1.HealthCheckConfigSpec{
+					Match: &healthcheckconfigv1.Matcher{
+						DbLabels: []*labelv1.Label{{
+							Name:   "*",
+							Values: []string{"*"},
+						}},
+					},
+				},
+			},
+			requireErr: require.NoError,
+		},
+		{
+			name: "valid custom",
+			in: &healthcheckconfigv1.HealthCheckConfig{
+				Version: types.V1,
+				Kind:    types.KindHealthCheckConfig,
+				Metadata: &headerv1.Metadata{
+					Name: "example",
+				},
+				Spec: &healthcheckconfigv1.HealthCheckConfigSpec{
+					Match: &healthcheckconfigv1.Matcher{
+						DbLabels: []*labelv1.Label{{
+							Name:   "env",
+							Values: []string{"prod"},
+						}},
+						DbLabelsExpression: "labels.env == `prod`",
+					},
+					Timeout:  durationpb.New(1 * time.Second),
+					Interval: durationpb.New(30 * time.Second),
+				},
+			},
+			requireErr: require.NoError,
+		},
+		{
+			name:       "nil object is invalid",
+			in:         nil,
+			requireErr: errContains("object must not be nil"),
+		},
+		{
+			name: "unknown version is invalid",
+			in: &healthcheckconfigv1.HealthCheckConfig{
+				Version: "v999",
+				Kind:    types.KindHealthCheckConfig,
+				Metadata: &headerv1.Metadata{
+					Name: "example",
+				},
+				Spec: &healthcheckconfigv1.HealthCheckConfigSpec{
+					Match: &healthcheckconfigv1.Matcher{
+						DbLabels: []*labelv1.Label{{
+							Name:   "env",
+							Values: []string{"prod"},
+						}},
+					},
+					Timeout:  durationpb.New(time.Second),
+					Interval: durationpb.New(2 * time.Second),
+				},
+			},
+			requireErr: errContains(`only version "v1" is supported`),
+		},
+		{
+			name: "mismatched kind is invalid",
+			in: &healthcheckconfigv1.HealthCheckConfig{
+				Version: types.V1,
+				Kind:    types.KindUser,
+				Metadata: &headerv1.Metadata{
+					Name: "example",
+				},
+				Spec: &healthcheckconfigv1.HealthCheckConfigSpec{
+					Match: &healthcheckconfigv1.Matcher{
+						DbLabels: []*labelv1.Label{{
+							Name:   "env",
+							Values: []string{"prod"},
+						}},
+					},
+					Timeout:  durationpb.New(time.Second),
+					Interval: durationpb.New(2 * time.Second),
+				},
+			},
+			requireErr: errContains(`kind must be "health_check_config"`),
+		},
+		{
+			name: "missing metadata is invalid",
+			in: &healthcheckconfigv1.HealthCheckConfig{
+				Version: types.V1,
+				Kind:    types.KindHealthCheckConfig,
+				Spec: &healthcheckconfigv1.HealthCheckConfigSpec{
+					Match: &healthcheckconfigv1.Matcher{
+						DbLabels: []*labelv1.Label{{
+							Name:   "env",
+							Values: []string{"prod"},
+						}},
+					},
+					Timeout:  durationpb.New(time.Second),
+					Interval: durationpb.New(2 * time.Second),
+				},
+			},
+			requireErr: errContains("metadata is missing"),
+		},
+		{
+			name: "missing name is invalid",
+			in: &healthcheckconfigv1.HealthCheckConfig{
+				Version: types.V1,
+				Kind:    types.KindHealthCheckConfig,
+				Metadata: &headerv1.Metadata{
+					Name: "",
+				},
+				Spec: &healthcheckconfigv1.HealthCheckConfigSpec{
+					Match: &healthcheckconfigv1.Matcher{
+						DbLabels: []*labelv1.Label{{
+							Name:   "env",
+							Values: []string{"prod"},
+						}},
+					},
+					Timeout:  durationpb.New(time.Second),
+					Interval: durationpb.New(2 * time.Second),
+				},
+			},
+			requireErr: errContains("metadata.name is missing"),
+		},
+		{
+			name: "missing spec is invalid",
+			in: &healthcheckconfigv1.HealthCheckConfig{
+				Version: types.V1,
+				Kind:    types.KindHealthCheckConfig,
+				Metadata: &headerv1.Metadata{
+					Name: "example",
+				},
+				Spec: nil,
+			},
+			requireErr: errContains("spec is missing"),
+		},
+		{
+			name: "missing match section is invalid",
+			in: &healthcheckconfigv1.HealthCheckConfig{
+				Version: types.V1,
+				Kind:    types.KindHealthCheckConfig,
+				Metadata: &headerv1.Metadata{
+					Name: "example",
+				},
+				Spec: &healthcheckconfigv1.HealthCheckConfigSpec{
+					Match:    nil,
+					Timeout:  durationpb.New(time.Second),
+					Interval: durationpb.New(2 * time.Second),
+				},
+			},
+			requireErr: errContains("spec.match is missing"),
+		},
+		{
+			name: "missing matcher is invalid",
+			in: &healthcheckconfigv1.HealthCheckConfig{
+				Version: types.V1,
+				Kind:    types.KindHealthCheckConfig,
+				Metadata: &headerv1.Metadata{
+					Name: "example",
+				},
+				Spec: &healthcheckconfigv1.HealthCheckConfigSpec{
+					Match:    &healthcheckconfigv1.Matcher{},
+					Timeout:  durationpb.New(time.Second),
+					Interval: durationpb.New(2 * time.Second),
+				},
+			},
+			requireErr: errContains("at least one of spec.match.db_labels or spec.match.db_labels_expression must be set"),
+		},
+		{
+			name: "invalid label matcher",
+			in: &healthcheckconfigv1.HealthCheckConfig{
+				Version: types.V1,
+				Kind:    types.KindHealthCheckConfig,
+				Metadata: &headerv1.Metadata{
+					Name: "example",
+				},
+				Spec: &healthcheckconfigv1.HealthCheckConfigSpec{
+					Match: &healthcheckconfigv1.Matcher{
+						DbLabels: []*labelv1.Label{{
+							Name:   types.Wildcard,
+							Values: []string{"asdf"},
+						}},
+					},
+					Timeout:  durationpb.New(time.Second),
+					Interval: durationpb.New(2 * time.Second),
+				},
+			},
+			requireErr: errContains("invalid spec.db_labels: selector *:asdf is not supported, a wildcard label key may only be used with a wildcard label value"),
+		},
+		{
+			name: "invalid label expression matcher",
+			in: &healthcheckconfigv1.HealthCheckConfig{
+				Version: types.V1,
+				Kind:    types.KindHealthCheckConfig,
+				Metadata: &headerv1.Metadata{
+					Name: "example",
+				},
+				Spec: &healthcheckconfigv1.HealthCheckConfigSpec{
+					Match: &healthcheckconfigv1.Matcher{
+						DbLabelsExpression: "abc",
+					},
+					Timeout:  durationpb.New(time.Second),
+					Interval: durationpb.New(2 * time.Second),
+				},
+			},
+			requireErr: errContains("invalid spec.db_labels_expression: parsing label expression"),
+		},
+		{
+			name: "timeout less than minimum is invalid",
+			in: &healthcheckconfigv1.HealthCheckConfig{
+				Version: types.V1,
+				Kind:    types.KindHealthCheckConfig,
+				Metadata: &headerv1.Metadata{
+					Name: "example",
+				},
+				Spec: &healthcheckconfigv1.HealthCheckConfigSpec{
+					Match: &healthcheckconfigv1.Matcher{
+						DbLabels: []*labelv1.Label{{
+							Name:   "env",
+							Values: []string{"prod"},
+						}},
+					},
+					Timeout:  durationpb.New(500 * time.Millisecond),
+					Interval: durationpb.New(5 * time.Second),
+				},
+			},
+			requireErr: errContains("spec.timeout must be at least"),
+		},
+		{
+			name: "interval less than minimum is invalid",
+			in: &healthcheckconfigv1.HealthCheckConfig{
+				Version: types.V1,
+				Kind:    types.KindHealthCheckConfig,
+				Metadata: &headerv1.Metadata{
+					Name: "example",
+				},
+				Spec: &healthcheckconfigv1.HealthCheckConfigSpec{
+					Match: &healthcheckconfigv1.Matcher{
+						DbLabels: []*labelv1.Label{{
+							Name:   "env",
+							Values: []string{"prod"},
+						}},
+					},
+					Timeout:  durationpb.New(time.Second),
+					Interval: durationpb.New(250 * time.Millisecond),
+				},
+			},
+			requireErr: errContains("spec.interval must be at least"),
+		},
+		{
+			name: "timeout greater than interval is invalid",
+			in: &healthcheckconfigv1.HealthCheckConfig{
+				Version: types.V1,
+				Kind:    types.KindHealthCheckConfig,
+				Metadata: &headerv1.Metadata{
+					Name: "example",
+				},
+				Spec: &healthcheckconfigv1.HealthCheckConfigSpec{
+					Match: &healthcheckconfigv1.Matcher{
+						DbLabels: []*labelv1.Label{{
+							Name:   "env",
+							Values: []string{"prod"},
+						}},
+					},
+					Timeout:  durationpb.New(31 * time.Second),
+					Interval: durationpb.New(30 * time.Second),
+				},
+			},
+			requireErr: errContains("spec.timeout (31s) must not be greater than spec.interval (30s)"),
+		},
+		{
+			name: "timeout greater than default interval is invalid",
+			in: &healthcheckconfigv1.HealthCheckConfig{
+				Version: types.V1,
+				Kind:    types.KindHealthCheckConfig,
+				Metadata: &headerv1.Metadata{
+					Name: "example",
+				},
+				Spec: &healthcheckconfigv1.HealthCheckConfigSpec{
+					Match: &healthcheckconfigv1.Matcher{
+						DbLabels: []*labelv1.Label{{
+							Name:   "env",
+							Values: []string{"prod"},
+						}},
+					},
+					Timeout:  durationpb.New(31 * time.Second),
+					Interval: nil,
+				},
+			},
+			requireErr: errContains("spec.timeout (31s) must not be greater than the default interval (30s)"),
+		},
+		{
+			name: "interval greater than maximum is invalid",
+			in: &healthcheckconfigv1.HealthCheckConfig{
+				Version: types.V1,
+				Kind:    types.KindHealthCheckConfig,
+				Metadata: &headerv1.Metadata{
+					Name: "example",
+				},
+				Spec: &healthcheckconfigv1.HealthCheckConfigSpec{
+					Match: &healthcheckconfigv1.Matcher{
+						DbLabels: []*labelv1.Label{{
+							Name:   "env",
+							Values: []string{"prod"},
+						}},
+					},
+					Timeout:  durationpb.New(time.Second),
+					Interval: durationpb.New(601 * time.Second),
+				},
+			},
+			requireErr: errContains("spec.interval must not be greater than 10m0s"),
+		},
+		{
+			name: "healthy threshold greater than maximum is invalid",
+			in: &healthcheckconfigv1.HealthCheckConfig{
+				Version: types.V1,
+				Kind:    types.KindHealthCheckConfig,
+				Metadata: &headerv1.Metadata{
+					Name: "example",
+				},
+				Spec: &healthcheckconfigv1.HealthCheckConfigSpec{
+					Match: &healthcheckconfigv1.Matcher{
+						DbLabels: []*labelv1.Label{{
+							Name:   "env",
+							Values: []string{"prod"},
+						}},
+					},
+					Timeout:          durationpb.New(time.Second),
+					Interval:         durationpb.New(30 * time.Second),
+					HealthyThreshold: 11,
+				},
+			},
+			requireErr: errContains("spec.healthy_threshold (11) must not be greater than 10"),
+		},
+		{
+			name: "unhealthy threshold greater than maximum is invalid",
+			in: &healthcheckconfigv1.HealthCheckConfig{
+				Version: types.V1,
+				Kind:    types.KindHealthCheckConfig,
+				Metadata: &headerv1.Metadata{
+					Name: "example",
+				},
+				Spec: &healthcheckconfigv1.HealthCheckConfigSpec{
+					Match: &healthcheckconfigv1.Matcher{
+						DbLabels: []*labelv1.Label{{
+							Name:   "env",
+							Values: []string{"prod"},
+						}},
+					},
+					Timeout:            durationpb.New(time.Second),
+					Interval:           durationpb.New(30 * time.Second),
+					UnhealthyThreshold: 11,
+				},
+			},
+			requireErr: errContains("spec.unhealthy_threshold (11) must not be greater than 10"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateHealthCheckConfig(tc.in)
+			tc.requireErr(t, err)
+		})
+	}
+}

--- a/lib/services/local/health_check_config.go
+++ b/lib/services/local/health_check_config.go
@@ -1,0 +1,105 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package local
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local/generic"
+)
+
+const healthCheckConfigPrefix = "health_check_config"
+
+// HealthCheckConfigService manages [healthcheckconfigv1.HealthCheckConfig] resources in
+// the backend.
+type HealthCheckConfigService struct {
+	svc *generic.ServiceWrapper[*healthcheckconfigv1.HealthCheckConfig]
+}
+
+// NewHealthCheckConfigService creates a new HealthCheckConfigService.
+func NewHealthCheckConfigService(b backend.Backend) (*HealthCheckConfigService, error) {
+	service, err := generic.NewServiceWrapper(
+		generic.ServiceConfig[*healthcheckconfigv1.HealthCheckConfig]{
+			Backend:       b,
+			ResourceKind:  types.KindHealthCheckConfig,
+			BackendPrefix: backend.NewKey(healthCheckConfigPrefix),
+			MarshalFunc:   services.MarshalHealthCheckConfig,
+			UnmarshalFunc: services.UnmarshalHealthCheckConfig,
+			ValidateFunc:  services.ValidateHealthCheckConfig,
+		})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &HealthCheckConfigService{
+		svc: service,
+	}, nil
+}
+
+// CreateHealthCheckConfig creates a new HealthCheckConfig resource.
+func (s *HealthCheckConfigService) CreateHealthCheckConfig(ctx context.Context, config *healthcheckconfigv1.HealthCheckConfig) (*healthcheckconfigv1.HealthCheckConfig, error) {
+	created, err := s.svc.CreateResource(ctx, config)
+	return created, trace.Wrap(err)
+}
+
+// GetHealthCheckConfig returns the specified HealthCheckConfig resource.
+func (s *HealthCheckConfigService) GetHealthCheckConfig(ctx context.Context, name string) (*healthcheckconfigv1.HealthCheckConfig, error) {
+	item, err := s.svc.GetResource(ctx, name)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return item, nil
+}
+
+// ListHealthCheckConfigs returns a paginated list of HealthCheckConfig resources.
+func (s *HealthCheckConfigService) ListHealthCheckConfigs(ctx context.Context, pageSize int, pageToken string) ([]*healthcheckconfigv1.HealthCheckConfig, string, error) {
+	items, nextKey, err := s.svc.ListResources(ctx, pageSize, pageToken)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+
+	return items, nextKey, nil
+}
+
+// UpdateHealthCheckConfig updates an existing HealthCheckConfig resource.
+func (s *HealthCheckConfigService) UpdateHealthCheckConfig(ctx context.Context, config *healthcheckconfigv1.HealthCheckConfig) (*healthcheckconfigv1.HealthCheckConfig, error) {
+	updated, err := s.svc.ConditionalUpdateResource(ctx, config)
+	return updated, trace.Wrap(err)
+}
+
+// UpsertHealthCheckConfig upserts an existing HealthCheckConfig resource.
+func (s *HealthCheckConfigService) UpsertHealthCheckConfig(ctx context.Context, config *healthcheckconfigv1.HealthCheckConfig) (*healthcheckconfigv1.HealthCheckConfig, error) {
+	upserted, err := s.svc.UpsertResource(ctx, config)
+	return upserted, trace.Wrap(err)
+}
+
+// DeleteHealthCheckConfig removes the specified HealthCheckConfig resource.
+func (s *HealthCheckConfigService) DeleteHealthCheckConfig(ctx context.Context, name string) error {
+	return trace.Wrap(s.svc.DeleteResource(ctx, name))
+}
+
+// DeleteAllHealthCheckConfigs removes all HealthCheckConfig resources.
+func (s *HealthCheckConfigService) DeleteAllHealthCheckConfigs(ctx context.Context) error {
+	return trace.Wrap(s.svc.DeleteAllResources(ctx))
+}

--- a/lib/services/local/health_check_config_test.go
+++ b/lib/services/local/health_check_config_test.go
@@ -1,0 +1,161 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package local
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
+	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/healthcheckconfig"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/backend/memory"
+)
+
+func TestHealthCheckConfigService(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clockwork.NewFakeClock(),
+	})
+	require.NoError(t, err)
+	service, err := NewHealthCheckConfigService(backend.NewSanitizer(mem))
+	require.NoError(t, err)
+
+	cfg1 := newHealthCheckConfig(t, "cfg1")
+	cfg2 := newHealthCheckConfig(t, "cfg2")
+
+	t.Run("empty", func(t *testing.T) {
+		out, _, err := service.ListHealthCheckConfigs(ctx, 10, "")
+		require.NoError(t, err)
+		require.Empty(t, out)
+	})
+
+	t.Run("invalid resource is rejected", func(t *testing.T) {
+		cfg := newHealthCheckConfig(t, "example")
+		cfg.Spec = nil
+		_, err := service.CreateHealthCheckConfig(ctx, cfg)
+		require.Error(t, err)
+	})
+
+	t.Run("create", func(t *testing.T) {
+		_, err := service.CreateHealthCheckConfig(ctx, cfg1)
+		require.NoError(t, err)
+		_, err = service.CreateHealthCheckConfig(ctx, cfg2)
+		require.NoError(t, err)
+	})
+
+	t.Run("list", func(t *testing.T) {
+		out, _, err := service.ListHealthCheckConfigs(ctx, 10, "")
+		require.NoError(t, err)
+		requireEqualHealthCheckConfigs(t, out, cfg1, cfg2)
+	})
+
+	t.Run("list with token", func(t *testing.T) {
+		out1, token, err := service.ListHealthCheckConfigs(ctx, 1, "")
+		require.NoError(t, err)
+		require.NotEmpty(t, token)
+		require.Len(t, out1, 1)
+		out2, token, err := service.ListHealthCheckConfigs(ctx, 1, token)
+		require.NoError(t, err)
+		require.Empty(t, token)
+		require.Len(t, out2, 1)
+
+		combined := append(out1, out2...)
+		require.Contains(t, combined, cfg1)
+		require.Contains(t, combined, cfg2)
+	})
+
+	t.Run("get and update", func(t *testing.T) {
+		out, err := service.GetHealthCheckConfig(ctx, cfg1.Metadata.Name)
+		require.NoError(t, err)
+		require.Equal(t, out, cfg1)
+
+		out.Spec.HealthyThreshold = 3
+		out, err = service.UpdateHealthCheckConfig(ctx, out)
+		require.NoError(t, err)
+		require.Equal(t, uint32(3), out.Spec.HealthyThreshold)
+	})
+
+	t.Run("delete not found", func(t *testing.T) {
+		err := service.DeleteHealthCheckConfig(ctx, "asdf")
+		require.IsType(t, trace.NotFound(""), err)
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		require.NoError(t, service.DeleteHealthCheckConfig(ctx, cfg1.Metadata.Name))
+	})
+
+	t.Run("upsert", func(t *testing.T) {
+		cfg3 := newHealthCheckConfig(t, "cfg3")
+		_, err := service.UpsertHealthCheckConfig(ctx, cfg3)
+		require.NoError(t, err)
+
+		out, _, err := service.ListHealthCheckConfigs(ctx, 10, "")
+		require.NoError(t, err)
+		requireEqualHealthCheckConfigs(t, out, cfg2, cfg3)
+	})
+
+	t.Run("delete all", func(t *testing.T) {
+		require.NoError(t, service.DeleteAllHealthCheckConfigs(ctx))
+		out, _, err := service.ListHealthCheckConfigs(ctx, 10, "")
+		require.NoError(t, err)
+		require.Empty(t, out)
+	})
+}
+
+func newHealthCheckConfig(t *testing.T, name string) *healthcheckconfigv1.HealthCheckConfig {
+	t.Helper()
+	cfg, err := healthcheckconfig.NewHealthCheckConfig(name,
+		&healthcheckconfigv1.HealthCheckConfigSpec{
+			Match: &healthcheckconfigv1.Matcher{
+				DbLabels: []*labelv1.Label{{
+					Name:   types.Wildcard,
+					Values: []string{types.Wildcard},
+				}},
+			},
+		},
+	)
+	require.NoError(t, err)
+	return cfg
+}
+
+func requireEqualHealthCheckConfigs(t *testing.T, got []*healthcheckconfigv1.HealthCheckConfig, want ...*healthcheckconfigv1.HealthCheckConfig) {
+	t.Helper()
+	cmpByName := func(a, b *healthcheckconfigv1.HealthCheckConfig) int {
+		return strings.Compare(a.Metadata.GetName(), b.Metadata.GetName())
+	}
+	require.Empty(t, cmp.Diff(
+		slices.SortedFunc(slices.Values(want), cmpByName),
+		slices.SortedFunc(slices.Values(got), cmpByName),
+		protocmp.Transform(),
+		protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
+	))
+}


### PR DESCRIPTION
Adds a backend storage service for health_check_config resources.

This PR is stacked on top of another PR and will switch to master automatically when it merges:
- #53437

Related issue:
- #20544