### PR TITLE
Add `rowGap` and `columnGap` to `Flex`

### DIFF
--- a/web/packages/design/src/Flex/Flex.tsx
+++ b/web/packages/design/src/Flex/Flex.tsx
@@ -21,6 +21,8 @@ import styled from 'styled-components';
 import {
   alignItems,
   AlignItemsProps,
+  columnGap,
+  ColumnGapProps,
   flexBasis,
   FlexBasisProps,
   flexDirection,
@@ -31,6 +33,8 @@ import {
   GapProps,
   justifyContent,
   JustifyContentProps,
+  rowGap,
+  RowGapProps,
 } from 'design/system';
 
 import Box, { BoxProps } from '../Box';
@@ -42,6 +46,8 @@ export interface FlexProps
     FlexWrapProps,
     FlexDirectionProps,
     FlexBasisProps,
+    RowGapProps,
+    ColumnGapProps,
     GapProps {
   /**
    * Uses inline-flex instead of just flex as the display property.
@@ -58,6 +64,8 @@ const Flex = styled(Box)<FlexProps>`
   ${flexWrap}
   ${flexBasis}
   ${flexDirection}
+  ${rowGap};
+  ${columnGap};
   ${gap};
 
   ${props =>

--- a/web/packages/design/src/system/index.ts
+++ b/web/packages/design/src/system/index.ts
@@ -89,6 +89,26 @@ export interface GapProps<TLength = TLengthStyledSystem> {
   gap?: ResponsiveValue<Property.Gap<TLength>>;
 }
 
+const rowGap = style({
+  prop: 'rowGap',
+  cssProperty: 'row-gap',
+  key: 'space',
+});
+
+export interface RowGapProps<TLength = TLengthStyledSystem> {
+  rowGap?: ResponsiveValue<Property.RowGap<TLength>>;
+}
+
+const columnGap = style({
+  prop: 'columnGap',
+  cssProperty: 'column-gap',
+  key: 'space',
+});
+
+export interface ColumnGapProps<TLength = TLengthStyledSystem> {
+  columnGap?: ResponsiveValue<Property.ColumnGap<TLength>>;
+}
+
 export {
   alignItems,
   type AlignItemsProps,
@@ -117,6 +137,8 @@ export {
   fontWeight,
   type FontWeightProps,
   gap,
+  rowGap,
+  columnGap,
   height,
   type HeightProps,
   justifyContent,

--- a/web/packages/design/src/theme/themes/sharedStyles.ts
+++ b/web/packages/design/src/theme/themes/sharedStyles.ts
@@ -46,6 +46,11 @@ export const sharedStyles: SharedStyles = {
     large: 1280,
   },
   topBarHeight: [44, 56, 72],
+  /**
+   *
+   * idx:    0  1  2   3   4   5   6   7   8   9  10  11
+   * space: [0, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80]
+   */
   space: [0, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80],
   borders: [
     0,

--- a/web/packages/design/src/theme/themes/types.ts
+++ b/web/packages/design/src/theme/themes/types.ts
@@ -320,6 +320,11 @@ export type SharedStyles = {
     large: number;
   };
   topBarHeight: number[];
+  /**
+   *
+   * idx:    0  1  2   3   4   5   6   7   8   9  10  11
+   * space: [0, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80]
+   */
   space: number[];
   borders: (string | number)[];
   typography: typeof typography;


### PR DESCRIPTION
This PR adds `column-gap` and `row-gap` to `<Flex>`. They're both like `gap` but only in one direction. They're useful in situations where a certain element has to wrap on the next line on specific breakpoints, but the gap is supposed to be different depending on whether the element is in the same row or not, e.g.:

```tsx
<Flex columnGap={7} rowGap={4} flexWrap={{ _: 'wrap', medium: 'nowrap' }} >
  <Foo />
  <Bar/>
<Flex>
```

`column-gap` has been well-supported since 2015, `row-gap` since 2017. 

* https://caniuse.com/mdn-css_properties_column-gap
* https://caniuse.com/mdn-css_properties_row-gap