### PR TITLE
Remove outdated instruction in tfdocs

### DIFF
--- a/integrations/terraform/DOCS.md
+++ b/integrations/terraform/DOCS.md
@@ -25,8 +25,6 @@ To re-render the reference, run `make docs`.
 
 When adding a new resource, the file is automatically generated and included in the indices by `make docs`.
 
-The only thing you must do is add an entry in `docs/config.json`.
-
 #### Extending a resource reference
 
 By default, every resource is documented with [the default template](./templates/resources.md.tmpl).


### PR DESCRIPTION
Documentation engine doesn't require adding individual pages to config.json anymore.