### PR TITLE
Add empty title to VNet toggle button in VNet panel

### DIFF
--- a/web/packages/teleterm/src/ui/Vnet/VnetConnectionItem.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetConnectionItem.tsx
@@ -246,6 +246,7 @@ const VnetConnectionItemBase = forwardRef<
                 size="small"
                 intent="neutral"
                 fill="minimal"
+                title=""
                 onClick={e => {
                   e.stopPropagation();
                 }}
@@ -289,6 +290,7 @@ const VnetConnectionItemBase = forwardRef<
                 key={toggleVnetButtonKey}
                 size="small"
                 width={toggleVnetButtonWidth}
+                title=""
                 onClick={e => {
                   e.stopPropagation();
                   stop();
@@ -316,6 +318,7 @@ const VnetConnectionItemBase = forwardRef<
                 key={toggleVnetButtonKey}
                 size="small"
                 width={toggleVnetButtonWidth}
+                title=""
                 onClick={e => {
                   e.stopPropagation();
                   start();


### PR DESCRIPTION
A small fix for [the new version of the VNet button introduced in #53226](https://github.com/gravitational/teleport/pull/53226#discussion_r2013809382). Because the button didn't have any title while being a child of an element with a title, it'd "inherit" the title from its parent. By setting the title to an empty string, the title is no longer inherited.

Before and after:

https://github.com/user-attachments/assets/0339e8ff-cbba-4bc1-8024-a97e22ada71e

