### PR TITLE
[v16] docs: update terraform example for local access

### DIFF
--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/local.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/local.mdx
@@ -96,7 +96,7 @@ You can run the Teleport Terraform provider from this shell.
    }
    
    provider "teleport" {
-     addr               = '<Var name="teleport.example.com:443" />'
+     addr               = "<Var name="teleport.example.com:443" />"
    }
    
    # We must create a test role, if we don't declare resources, Terraform won't try to


### PR DESCRIPTION
Applies fix for terraform file example in `local.mdx` from #50847. The trusted cluster part does not apply.