### PR TITLE
[v15] docs: clarify pgevents retention period

### DIFF
--- a/docs/pages/includes/config-reference/auth-service.yaml
+++ b/docs/pages/includes/config-reference/auth-service.yaml
@@ -1,444 +1,443 @@
 teleport:
+  # Configuration for the storage back-end used for the cluster state and the
+  # audit log. Several back-end types are supported.
+  # See the "Storage backends" (https://goteleport.com/docs/setup/reference/backends)
+  # section of the documentation to learn how to configure
+  # DynamoDB, S3, etcd, and other highly available back-ends.
+  storage:
+    # By default teleport uses a SQLite database in the `data_dir`
+    # directory on a local filesystem
+    type: sqlite
 
-    # Configuration for the storage back-end used for the cluster state and the
-    # audit log. Several back-end types are supported.
-    # See the "Storage backends" (https://goteleport.com/docs/setup/reference/backends)
-    # section of the documentation to learn how to configure
-    # DynamoDB, S3, etcd, and other highly available back-ends.
-    storage:
-        # By default teleport uses a SQLite database in the `data_dir`
-        # directory on a local filesystem
-        type: sqlite
+    # List of locations where the audit log events will be stored. By
+    # default, they are stored in `/var/lib/teleport/log`.
+    #
+    # When specifying multiple destinations like this, make sure that
+    # highly-available storage methods (like DynamoDB or Firestore) are
+    # specified first, as this is what the Teleport Web UI uses as its
+    # source of events to display.
+    audit_events_uri:
+      - "dynamodb://events_table_name"
+      - "firestore://events_table_name"
+      - "postgresql://user_name@database-address/events_table_name"
+      - "file:///var/lib/teleport/log"
+      - "stdout://"
 
-        # List of locations where the audit log events will be stored. By
-        # default, they are stored in `/var/lib/teleport/log`.
-        #
-        # When specifying multiple destinations like this, make sure that
-        # highly-available storage methods (like DynamoDB or Firestore) are
-        # specified first, as this is what the Teleport Web UI uses as its
-        # source of events to display.
-        audit_events_uri:
-          - 'dynamodb://events_table_name'
-          - 'firestore://events_table_name'
-          - 'postgresql://user_name@database-address/events_table_name'
-          - 'file:///var/lib/teleport/log'
-          - 'stdout://'
+    # Use this setting to configure teleport to store the recorded sessions
+    # in an AWS S3 bucket or use GCP Storage with 'gs://'.
+    # See the S3 section on "Storage backends" for more information
+    # (https://goteleport.com/docs/setup/reference/backends/#s3).
+    audit_sessions_uri: "s3://example.com/path/to/bucket?region=us-east-1"
 
-        # Use this setting to configure teleport to store the recorded sessions
-        # in an AWS S3 bucket or use GCP Storage with 'gs://'.
-        # See the S3 section on "Storage backends" for more information
-        # (https://goteleport.com/docs/setup/reference/backends/#s3).
-        audit_sessions_uri: 's3://example.com/path/to/bucket?region=us-east-1'
+    # SQLite-specific section:
 
-        # SQLite-specific section:
+    # The default path is the `backend` directory in the `data_dir`
+    path: /var/lib/teleport/backend/
+    # SQLite's `synchronous` pragma, can be set to `"OFF"` for improved
+    # write performance in exchange for reliability against system crashes
+    # (see https://www.sqlite.org/pragma.html#pragma_synchronous).
+    sync: FULL
+    # SQLite's `journal_mode` pragma, by default it doesn't change the mode from
+    # the SQLite default (DELETE unless the database file is using WAL mode).
+    # For improved performance without sacrificing reliability it's possible to
+    # set `journal` to `WAL` and `sync` to `NORMAL`, but only when using a filesystem
+    # that supports locks (see https://www.sqlite.org/pragma.html#pragma_journal_mode).
+    #journal: DELETE
 
-        # The default path is the `backend` directory in the `data_dir`
-        path: /var/lib/teleport/backend/
-        # SQLite's `synchronous` pragma, can be set to `"OFF"` for improved
-        # write performance in exchange for reliability against system crashes
-        # (see https://www.sqlite.org/pragma.html#pragma_synchronous).
-        sync: FULL
-        # SQLite's `journal_mode` pragma, by default it doesn't change the mode from
-        # the SQLite default (DELETE unless the database file is using WAL mode).
-        # For improved performance without sacrificing reliability it's possible to
-        # set `journal` to `WAL` and `sync` to `NORMAL`, but only when using a filesystem
-        # that supports locks (see https://www.sqlite.org/pragma.html#pragma_journal_mode).
-        #journal: DELETE
+    # DynamoDB-specific section:
 
-        # DynamoDB-specific section:
+    # continuous_backups is used to enable continuous backups.
+    # default: false
+    continuous_backups: true
 
-        # continuous_backups is used to enable continuous backups.
-        # default: false
-        continuous_backups: true
+    # auto_scaling is used to enable (and define settings for) auto
+    # scaling.
+    # default: false
+    auto_scaling: true
 
-        # auto_scaling is used to enable (and define settings for) auto
-        # scaling.
-        # default: false
-        auto_scaling: true
+    # By default, Teleport stores stores audit events with an AWS TTL of 1 year.
+    # This value can be configured as shown below. If set to 0 seconds, TTL is disabled.
+    #
+    # NOTE: Only the DynamoDB events backend respects the retention_period. All other event backends
+    # consume the retention period via a query parameter in the audit_events_uri. See the examples below
+    # for how to configure the retention period for other backends.
+    # Firestore: firestore://events_table_name?eventRetentionPeriod=10d
+    # Postgres: postgresql://user_name@database-address/teleport_audit?sslmode=verify-full#retention_period=240h
+    retention_period: 365d
 
-        # By default, Teleport stores stores audit events with an AWS TTL of 1 year.
-        # This value can be configured as shown below. If set to 0 seconds, TTL is disabled.
-        #
-        # NOTE: Only the DynamoDB events backend respects the retention_period. All other event backends
-        # consume the retention period via a query parameter in the audit_events_uri. See the examples below
-        # for how to configure the retention period for other backends.
-        # Firestore: firestore://events_table_name?eventRetentionPeriod=10d
-        # Postgres: postgresql://user_name@database-address/teleport_audit#retention_period=240h
-        retention_period: 365d
+    # minimum/maximum read capacity in units
+    read_min_capacity: int
+    read_max_capacity: int
+    read_target_value: float
+    # minimum/maximum write capacity in units
+    write_min_capacity: int
+    write_max_capacity: int
+    write_target_value: float
 
-        # minimum/maximum read capacity in units
-        read_min_capacity: int
-        read_max_capacity: int
-        read_target_value: float
-        # minimum/maximum write capacity in units
-        write_min_capacity: int
-        write_max_capacity: int
-        write_target_value: float
+  # Default cipher algorithms for SSH. This section only needs to be set if
+  # you want to override the defaults.
+  ciphers:
+    - aes128-ctr
+    - aes192-ctr
+    - aes256-ctr
+    - aes128-gcm@openssh.com
+    - aes256-gcm@openssh.com
+    - chacha20-poly1305@openssh.com
 
-    # Default cipher algorithms for SSH. This section only needs to be set if
-    # you want to override the defaults.
-    ciphers:
-      - aes128-ctr
-      - aes192-ctr
-      - aes256-ctr
-      - aes128-gcm@openssh.com
-      - aes256-gcm@openssh.com
-      - chacha20-poly1305@openssh.com
+  # Default key exchange algorithms (KEX) for SSH. This section only needs to
+  # be set if you want to override the defaults.
+  kex_algos:
+    - curve25519-sha256
+    - curve25519-sha256@libssh.org
+    - ecdh-sha2-nistp256
+    - ecdh-sha2-nistp384
+    - ecdh-sha2-nistp521
+    - diffie-hellman-group14-sha256
 
-    # Default key exchange algorithms (KEX) for SSH. This section only needs to
-    # be set if you want to override the defaults.
-    kex_algos:
-      - curve25519-sha256
-      - curve25519-sha256@libssh.org
-      - ecdh-sha2-nistp256
-      - ecdh-sha2-nistp384
-      - ecdh-sha2-nistp521
-      - diffie-hellman-group14-sha256
+  # Default message authentication code (MAC) algorithms for SSH.  This
+  # section only needs to be set if you want to override the defaults.
+  mac_algos:
+    - hmac-sha2-256-etm@openssh.com
+    - hmac-sha2-512-etm@openssh.com
+    - hmac-sha2-256
+    - hmac-sha2-512
 
-    # Default message authentication code (MAC) algorithms for SSH.  This
-    # section only needs to be set if you want to override the defaults.
-    mac_algos:
-      - hmac-sha2-256-etm@openssh.com
-      - hmac-sha2-512-etm@openssh.com
-      - hmac-sha2-256
-      - hmac-sha2-512
-
-    # Default ciphersuites for TLS. If this section is not specified, only the
-    # default ciphersuites are enabled.
-    ciphersuites:
-       - tls-ecdhe-rsa-with-aes-128-gcm-sha256
-       - tls-ecdhe-ecdsa-with-aes-128-gcm-sha256
-       - tls-ecdhe-rsa-with-aes-256-gcm-sha384
-       - tls-ecdhe-ecdsa-with-aes-256-gcm-sha384
-       - tls-ecdhe-rsa-with-chacha20-poly1305
-       - tls-ecdhe-ecdsa-with-chacha20-poly1305
+  # Default ciphersuites for TLS. If this section is not specified, only the
+  # default ciphersuites are enabled.
+  ciphersuites:
+    - tls-ecdhe-rsa-with-aes-128-gcm-sha256
+    - tls-ecdhe-ecdsa-with-aes-128-gcm-sha256
+    - tls-ecdhe-rsa-with-aes-256-gcm-sha384
+    - tls-ecdhe-ecdsa-with-aes-256-gcm-sha384
+    - tls-ecdhe-rsa-with-chacha20-poly1305
+    - tls-ecdhe-ecdsa-with-chacha20-poly1305
 
 # This section configures the 'auth service':
 auth_service:
-    # Turns 'auth' role on. Default is 'yes'
-    enabled: yes
+  # Turns 'auth' role on. Default is 'yes'
+  enabled: yes
 
-    # cluster_name is the name used to initiate a new cluster.
-    # A cluster name is used as part of a signature in certificates
-    # generated by this CA.
-    #
-    # We strongly recommend explicitly setting it to something meaningful as it
-    # becomes important when configuring trust between multiple clusters.
-    #
-    # By default an automatically generated name is used (not recommended)
-    #
-    # IMPORTANT: changes to this field won't have an effect on an already created cluster.
-    # To change the name of an existing cluster, you can use
-    # the 'POST /v2/configuration/name' endpoint, but it will invalidate all generated
-    # certificates and keys (may need to wipe out /var/lib/teleport directory)
-    cluster_name: "main"
+  # cluster_name is the name used to initiate a new cluster.
+  # A cluster name is used as part of a signature in certificates
+  # generated by this CA.
+  #
+  # We strongly recommend explicitly setting it to something meaningful as it
+  # becomes important when configuring trust between multiple clusters.
+  #
+  # By default an automatically generated name is used (not recommended)
+  #
+  # IMPORTANT: changes to this field won't have an effect on an already created cluster.
+  # To change the name of an existing cluster, you can use
+  # the 'POST /v2/configuration/name' endpoint, but it will invalidate all generated
+  # certificates and keys (may need to wipe out /var/lib/teleport directory)
+  cluster_name: "main"
 
-    # proxy_protocol controls support for HAProxy PROXY protocol.
-    # Unspecified by default, possible values:
-    # 'on' - PROXY protocol is enabled and required.
-    # 'off' - PROXY protocol is disabled and forbidden.
-    #
-    # If unspecified, PROXY protocol is allowed, but not required. This is
-    # suitable for test environments, but not recommended for production use.
-    # Teleport's IP pinning functionality will not work if this field is left
-    # unspecified and PROXY headers are received.
-    # Set to `on` if Auth service runs behind a L4 load balancer that sends PROXY
-    # headers, otherwise set to `off`.
-    proxy_protocol: on
+  # proxy_protocol controls support for HAProxy PROXY protocol.
+  # Unspecified by default, possible values:
+  # 'on' - PROXY protocol is enabled and required.
+  # 'off' - PROXY protocol is disabled and forbidden.
+  #
+  # If unspecified, PROXY protocol is allowed, but not required. This is
+  # suitable for test environments, but not recommended for production use.
+  # Teleport's IP pinning functionality will not work if this field is left
+  # unspecified and PROXY headers are received.
+  # Set to `on` if Auth service runs behind a L4 load balancer that sends PROXY
+  # headers, otherwise set to `off`.
+  proxy_protocol: on
 
-    authentication:
-        # default authentication type. possible values are 'local' and 'github'
-        # for Teleport Community Edition, plus 'oidc' and 'saml' for Enterprise.
-        # Only local authentication (Teleport's own user DB) & GitHub is
-        # supported in the open source version
-        type: local
+  authentication:
+    # default authentication type. possible values are 'local' and 'github'
+    # for Teleport Community Edition, plus 'oidc' and 'saml' for Enterprise.
+    # Only local authentication (Teleport's own user DB) & GitHub is
+    # supported in the open source version
+    type: local
 
-        # Sets whether local auth is enabled alongside any other authentication
-        # type. Default is true. local_auth must be 'false' for FedRAMP / FIPS.
-        # (https://goteleport.com/docs/enterprise/ssh-kubernetes-fedramp/)
-        #local_auth: true
+    # Sets whether local auth is enabled alongside any other authentication
+    # type. Default is true. local_auth must be 'false' for FedRAMP / FIPS.
+    # (https://goteleport.com/docs/enterprise/ssh-kubernetes-fedramp/)
+    #local_auth: true
 
-        # Enforce per-session MFA or PIV-hardware key restrictions on user login sessions.
-        # Possible values: true, false, "hardware_key", "hardware_key_touch".
-        # Defaults to false.
-        require_session_mfa: false
+    # Enforce per-session MFA or PIV-hardware key restrictions on user login sessions.
+    # Possible values: true, false, "hardware_key", "hardware_key_touch".
+    # Defaults to false.
+    require_session_mfa: false
 
-        # second_factor can be 'off', 'on', 'optional', 'otp' or 'webauthn'.
-        # - 'on' requires either otp or webauthn second factor.
-        # - 'optional' allows otp and webauthn second factor.
-        # - 'otp' and 'webauthn' require the corresponding second factor.
-        second_factor: otp
+    # second_factor can be 'off', 'on', 'optional', 'otp' or 'webauthn'.
+    # - 'on' requires either otp or webauthn second factor.
+    # - 'optional' allows otp and webauthn second factor.
+    # - 'otp' and 'webauthn' require the corresponding second factor.
+    second_factor: otp
 
-        # Sets whether passwordless authentication is allowed.
-        # Passwordless requires WebAuthn.
-        # Defaults to "true".
-        #passwordless: true
+    # Sets whether passwordless authentication is allowed.
+    # Passwordless requires WebAuthn.
+    # Defaults to "true".
+    #passwordless: true
 
-        # Sets whether headless authentication is allowed.
-        # Headless authentication requires WebAuthn.
-        # Defaults to "true".
-        #headless: true
+    # Sets whether headless authentication is allowed.
+    # Headless authentication requires WebAuthn.
+    # Defaults to "true".
+    #headless: true
 
-        # Sets the default authentication connector for the cluster:
-        # - 'local' for local authentication (password, WebAuthn, etc.)
-        # - 'passwordless' for passwordless authentication
-        #   (http://goteleport.com/docs/access-controls/guides/passwordless/#optional-enable-passwordless-by-default)
-        # - 'headless' for headless authentication
-        #   (http://goteleport.com/docs/access-controls/guides/headless-login/#optional-enable-passwordless-by-default)
-        # - A specific SSO connector name - see https://goteleport.com/docs/access-controls/sso/ for details.
-        # Defaults to "local".
-        #connector_name: local
+    # Sets the default authentication connector for the cluster:
+    # - 'local' for local authentication (password, WebAuthn, etc.)
+    # - 'passwordless' for passwordless authentication
+    #   (http://goteleport.com/docs/access-controls/guides/passwordless/#optional-enable-passwordless-by-default)
+    # - 'headless' for headless authentication
+    #   (http://goteleport.com/docs/access-controls/guides/headless-login/#optional-enable-passwordless-by-default)
+    # - A specific SSO connector name - see https://goteleport.com/docs/access-controls/sso/ for details.
+    # Defaults to "local".
+    #connector_name: local
 
-        # this section is used if second_factor is set to 'on', 'optional' or
-        # 'webauthn'.
-        webauthn:
-          # public domain of the Teleport proxy, *excluding* protocol
-          # (`https://`) and port number.
-          #
-          # IMPORTANT: rp_id must never change in the lifetime of the cluster,
-          # because it's recorded in the registration data on the second factor
-          # authenticator. If the rp_id changes, all existing authenticator
-          # registrations will become invalid and all users who use WebAuthn as
-          # the second factor will need to re-register.
-          rp_id: "localhost"
-
-          # optional allow list of certificate authorities (as local file paths
-          # or in-line PEM certificate string) for [device verification](
-          # https://developers.yubico.com/WebAuthn/WebAuthn_Developer_Guide/Attestation.html).
-          # This field allows you to restrict which device models and vendors
-          # you trust.
-          # Devices outside of the list will be rejected during registration.
-          # By default all devices are allowed.
-          # If you must use attestation, consider using
-          # `attestation_denied_cas` to forbid troublesome devices instead.
-          attestation_allowed_cas:
-          - /path/to/allowed_ca.pem
-          - |
-            -----BEGIN CERTIFICATE-----
-            ...
-            -----END CERTIFICATE-----
-
-          # optional deny list of certificate authorities (as local file paths
-          # or in-line PEM certificate string) for [device verification](
-          # https://developers.yubico.com/WebAuthn/WebAuthn_Developer_Guide/Attestation.html).
-          # This field allows you to forbid specific device models and vendors,
-          # while allowing all others (provided they clear
-          # `attestation_allowed_cas` as well).
-          # Devices within this list will be rejected during registration. By
-          # default no devices are forbidden.
-          attestation_denied_cas:
-          - /path/to/denied_ca.pem
-          - |
-            -----BEGIN CERTIFICATE-----
-            ...
-            -----END CERTIFICATE-----
-
-          # if set to true, disables WebAuthn. Allows a fallback to U2F for
-          # second factor modes 'on' and 'optional'.
-          disabled: false
-
-        # the U2F section is kept for legacy purposes and to support existing
-        # U2F registrations.
-        u2f:
-            # app ID used by U2F registrations.
-            # Keep it in your config to avoid having to re-register U2F devices.
-            app_id: https://localhost:3080
-
-        # Locking mode determines how to apply lock views locally available to
-        # a Teleport component; can be strict or best_effort.
-        # See the "Locking mode" section for more details
-        # (https://goteleport.com/docs/access-controls/guides/locking/#locking-mode).
-        locking_mode: best_effort
-
-        # Device Trust configures Teleport's behavior in regards to trusted
-        # devices.
-        # Device Trust is a Teleport Enterprise feature.
-        # (https://goteleport.com/docs/access-controls/guides/device-trust/)
-        device_trust:
-          # 'mode' is the cluster-wide device trust mode.
-          # The following values are supported:
-          # - 'off' - disables device trust. Device authentication is not
-          #   performed and device-aware audit logs are absent.
-          # - 'optional' - enables device authentication and device-aware audit,
-          #   but doesn't require a trusted device to access resources.
-          # - 'required' - enables device authentication and device-aware audit.
-          #   Additionally, it requires a trusted device for all SSH, Database
-          #   and Kubernetes connections.
-          mode: optional # always "off" for Teleport Community Edition
-
-        # Determines the default time to live for user certificates
-        # issued by this auth server, defaults to 12 hours.  Examples:
-        # "14h30m", "1h" etc.
-        default_session_ttl: 12h
-
-    # IP and the port to bind to. Other Teleport Nodes will be connecting to
-    # this port (AKA "Auth API" or "Cluster API") to validate client
-    # certificates
-    listen_addr: 0.0.0.0:3025
-
-    # The optional DNS name for the auth server if located behind a load
-    # balancer.
-    public_addr: auth.example.com:3025
-
-    # Pre-defined tokens for adding new nodes to a cluster. Each token specifies
-    # the role a new node will be allowed to assume. The more secure way to
-    # add nodes is to use `tctl nodes add --ttl` command to generate auto-expiring
-    # tokens.
-    #
-    # We recommend to use tools like `pwgen` to generate sufficiently random
-    # tokens of 32+ byte length.
-    tokens:
-        - "proxy,node:xxxxx"
-        - "auth:yyyy"
-
-    # Optional setting for configuring session recording. Possible values are:
-    #    "node"      : (default) sessions will be recorded on the node
-    #                  and periodically cleaned up after they are uploaded
-    #                  to the storage service.
-    #    "node-sync" : session recordings will be streamed from
-    #                  node -> auth -> storage service without being stored on
-    #                  disk at all.
-    #    "proxy"     : sessions will be recorded on the proxy and periodically
-    #                  cleaned up after they are uploaded to the storage service.
-    #    "proxy-sync : session recordings will be streamed from
-    #                  proxy -> auth -> storage service without being stored on
-    #                  disk at all.
-    #    "off"   : session recording is turned off
-    #
-    session_recording: "node"
-
-    # This setting determines if a Teleport proxy performs strict host key
-    # checks.
-    # Only applicable if session_recording=proxy, see "Recording Proxy Mode"
-    # for details
-    # (https://goteleport.com/docs/architecture/proxy/#recording-proxy-mode).
-    proxy_checks_host_keys: yes
-
-    # Determines if sessions to cluster resources are forcefully terminated after
-    # no activity from a client (idle client).
-    # Examples: "30m", "1h" or "1h30m"
-    client_idle_timeout: never
-
-    # Send a custom message to the client when they are disconnected due to
-    # inactivity. The empty string indicates that no message will be sent.
-    # (Currently only supported for Server Access connections)
-    client_idle_timeout_message: ""
-
-    # Sets an idle timeout for the Web UI. The default is 10m.
-    web_idle_timeout: 10m
-
-    # Determines if the clients will be forcefully disconnected when their
-    # certificates expire in the middle of an active session. (default is 'no')
-    disconnect_expired_cert: no
-
-    # keep_alive_interval determines the interval at which Teleport will
-    # send keep-alive messages for client and reverse tunnel connections.
-    # The default is set to 5 minutes (300 seconds) to stay lower than the
-    # common load balancer timeout of 350 seconds.
-    # keep_alive_count_max is the number of missed keep-alive messages before
-    # the Teleport cluster tears down the connection to the client or service.
-    keep_alive_interval: 5m
-    keep_alive_count_max: 3
-
-    # Specifies the cluster wide dial timeout used for establishing SSH connections
-    # via tsh ssh and the Web UI. The default value of 30 seconds should suffice for
-    # most use cases. However, if there are multiple network hops to reach the target
-    # host causing dial timeout failures, this value can be increased as needed.
-    ssh_dial_timeout: 30s
-
-    # Determines the internal session control timeout cluster-wide. This value
-    # will be used with enterprise max_connections and max_sessions. It's
-    # unlikely that you'll need to change this.
-    # session_control_timeout: 2m
-
-    # Determines the routing strategy used to connect to nodes. Can be
-    # 'unambiguous_match' (default), or 'most_recent'.
-    routing_strategy: unambiguous_match
-
-    # License file to start auth server with. Note that this setting is ignored
-    # in the Teleport Community Edition and is required only for Teleport Enterprise.
-    #
-    # The path can be either absolute or relative to the configured `data_dir`
-    # and should point to the license file obtained from Teleport Download
-    # Portal.
-    #
-    # If not set, by default Teleport will look for the `license.pem` file in
-    # the configured `data_dir` .
-    license_file: /var/lib/teleport/license.pem
-
-    # Configures a banner message to be displayed to a user logging into the
-    # cluster, which must be acknowledged before the user is allowed to log in.
-    # Note that will be shown *before* login, so should not contain any
-    # confidential information.
-    # Defaults to the empty string, implying no message or acknowledgment is
-    # required.
-    message_of_the_day: ""
-
-    # Indicates to the clients whether the cluster is running in TLS routing
-    # mode with all protocols multiplexed on the proxy's web_listen_addr.
-    #
-    # Possible values are:
-    #
-    # "multiplex": clients will be connecting to Teleport proxy's web listener
-    #              in TLS routing mode.
-    # "separate":  clients will be connecting to Teleport proxy's individual
-    #              listeners: tunnel_listen_addr, mysql_listen_addr, etc.
-    #
-    # See "TLS Routing" in Architecture section for additional information.
-    proxy_listener_mode: multiplex
-
-    # Determines the strategy that the cluster uses for connecting clients to
-    # agents through the Teleport Proxy Service.
-    tunnel_strategy:
-      # Possible tunnel strategy types are:
+    # this section is used if second_factor is set to 'on', 'optional' or
+    # 'webauthn'.
+    webauthn:
+      # public domain of the Teleport proxy, *excluding* protocol
+      # (`https://`) and port number.
       #
-      # "agent_mesh":    The default behavior, where agents will connect to every
-      #                  Teleport Proxy Service instance.
-      # "proxy_peering": Agents will connect to a subset of Proxy Service instances
-      #                  and clients will be routed between Proxy Service instances
-      #                  for end-to-end connectivity.
-      type: proxy_peering
+      # IMPORTANT: rp_id must never change in the lifetime of the cluster,
+      # because it's recorded in the registration data on the second factor
+      # authenticator. If the rp_id changes, all existing authenticator
+      # registrations will become invalid and all users who use WebAuthn as
+      # the second factor will need to re-register.
+      rp_id: "localhost"
 
-      # The number of reverse tunnel connections agents will attempt to create.
-      # This field is only available when using the "proxy_peering" tunnel
-      # strategy type. For high availability we recommend setting this value to
-      # 2 or more.
-      agent_connection_count: 1
+      # optional allow list of certificate authorities (as local file paths
+      # or in-line PEM certificate string) for [device verification](
+      # https://developers.yubico.com/WebAuthn/WebAuthn_Developer_Guide/Attestation.html).
+      # This field allows you to restrict which device models and vendors
+      # you trust.
+      # Devices outside of the list will be rejected during registration.
+      # By default all devices are allowed.
+      # If you must use attestation, consider using
+      # `attestation_denied_cas` to forbid troublesome devices instead.
+      attestation_allowed_cas:
+        - /path/to/allowed_ca.pem
+        - |
+          -----BEGIN CERTIFICATE-----
+          ...
+          -----END CERTIFICATE-----
 
-    # Tells tsh to load the CAs of all clusters when trying to ssh into a Teleport Node,
-    # instead of just the CA for the current cluster. This may be useful for
-    # users that want to log in to a root cluster and then "tsh ssh" into a node
-    # in a leaf cluster. Defaults to false.
-    load_all_cas: false
+      # optional deny list of certificate authorities (as local file paths
+      # or in-line PEM certificate string) for [device verification](
+      # https://developers.yubico.com/WebAuthn/WebAuthn_Developer_Guide/Attestation.html).
+      # This field allows you to forbid specific device models and vendors,
+      # while allowing all others (provided they clear
+      # `attestation_allowed_cas` as well).
+      # Devices within this list will be rejected during registration. By
+      # default no devices are forbidden.
+      attestation_denied_cas:
+        - /path/to/denied_ca.pem
+        - |
+          -----BEGIN CERTIFICATE-----
+          ...
+          -----END CERTIFICATE-----
 
-    # Enables case-insensitivity for ssh dial requests. Setting this to true will allow
-    # 'tsh ssh myserver' to route to host 'MyServer'. Dialing with an uppercase hostname
-    # will still require an exact match. Openssh always lowercases hostnames, so setting
-    # this to true is necessary if you want to use openssh to access nodes with uppercase
-    # characters in their hostnames.
-    case_insensitive_routing: false
+      # if set to true, disables WebAuthn. Allows a fallback to U2F for
+      # second factor modes 'on' and 'optional'.
+      disabled: false
 
-    # Configuration for the Teleport Assist functionality
-    assist:
-      openai:
-        # An absolute path to the file containing the API token for OpenAI.
-        # This is required for Assist functionality.
-        api_token_path: /etc/teleport/openai_key
+    # the U2F section is kept for legacy purposes and to support existing
+    # U2F registrations.
+    u2f:
+      # app ID used by U2F registrations.
+      # Keep it in your config to avoid having to re-register U2F devices.
+      app_id: https://localhost:3080
 
-      # When executing commands on servers through Teleport Assist,
-      # this is the maximum number of servers that Assist will connect to in parallel.
-      # This only applies in the context of a single command execution -
-      # if multiple users are using Assist concurrently, more connections may be made.
-      command_execution_workers: 30
+    # Locking mode determines how to apply lock views locally available to
+    # a Teleport component; can be strict or best_effort.
+    # See the "Locking mode" section for more details
+    # (https://goteleport.com/docs/access-controls/guides/locking/#locking-mode).
+    locking_mode: best_effort
 
-    # AccessMonitoring is a set of options related to the Access Monitoring feature.
-    access_monitoring:
-      # Turn on Access Monitoring. Default is 'no'.
-      enabled: yes
-      # AWS role ARN that Teleport will assume to execute Athena SQL queries.
-      # The Teleport role should be configured with a trust relationship and should be able to assume this role.
-      role_arn: arn:aws:iam::123456789012:role/AccessMonitoringRole
-      # S3 bucket where Access Monitoring reports will be stored.
-      report_results: s3://audit-long-term/report_results
-      # (Optional) Athena workgroup used by access monitoring queries (if not set, the default primary workgroup will be used).
-      workgroup: access_monitoring_workgroup
+    # Device Trust configures Teleport's behavior in regards to trusted
+    # devices.
+    # Device Trust is a Teleport Enterprise feature.
+    # (https://goteleport.com/docs/access-controls/guides/device-trust/)
+    device_trust:
+      # 'mode' is the cluster-wide device trust mode.
+      # The following values are supported:
+      # - 'off' - disables device trust. Device authentication is not
+      #   performed and device-aware audit logs are absent.
+      # - 'optional' - enables device authentication and device-aware audit,
+      #   but doesn't require a trusted device to access resources.
+      # - 'required' - enables device authentication and device-aware audit.
+      #   Additionally, it requires a trusted device for all SSH, Database
+      #   and Kubernetes connections.
+      mode: optional # always "off" for Teleport Community Edition
+
+    # Determines the default time to live for user certificates
+    # issued by this auth server, defaults to 12 hours.  Examples:
+    # "14h30m", "1h" etc.
+    default_session_ttl: 12h
+
+  # IP and the port to bind to. Other Teleport Nodes will be connecting to
+  # this port (AKA "Auth API" or "Cluster API") to validate client
+  # certificates
+  listen_addr: 0.0.0.0:3025
+
+  # The optional DNS name for the auth server if located behind a load
+  # balancer.
+  public_addr: auth.example.com:3025
+
+  # Pre-defined tokens for adding new nodes to a cluster. Each token specifies
+  # the role a new node will be allowed to assume. The more secure way to
+  # add nodes is to use `tctl nodes add --ttl` command to generate auto-expiring
+  # tokens.
+  #
+  # We recommend to use tools like `pwgen` to generate sufficiently random
+  # tokens of 32+ byte length.
+  tokens:
+    - "proxy,node:xxxxx"
+    - "auth:yyyy"
+
+  # Optional setting for configuring session recording. Possible values are:
+  #    "node"      : (default) sessions will be recorded on the node
+  #                  and periodically cleaned up after they are uploaded
+  #                  to the storage service.
+  #    "node-sync" : session recordings will be streamed from
+  #                  node -> auth -> storage service without being stored on
+  #                  disk at all.
+  #    "proxy"     : sessions will be recorded on the proxy and periodically
+  #                  cleaned up after they are uploaded to the storage service.
+  #    "proxy-sync : session recordings will be streamed from
+  #                  proxy -> auth -> storage service without being stored on
+  #                  disk at all.
+  #    "off"   : session recording is turned off
+  #
+  session_recording: "node"
+
+  # This setting determines if a Teleport proxy performs strict host key
+  # checks.
+  # Only applicable if session_recording=proxy, see "Recording Proxy Mode"
+  # for details
+  # (https://goteleport.com/docs/architecture/proxy/#recording-proxy-mode).
+  proxy_checks_host_keys: yes
+
+  # Determines if sessions to cluster resources are forcefully terminated after
+  # no activity from a client (idle client).
+  # Examples: "30m", "1h" or "1h30m"
+  client_idle_timeout: never
+
+  # Send a custom message to the client when they are disconnected due to
+  # inactivity. The empty string indicates that no message will be sent.
+  # (Currently only supported for Server Access connections)
+  client_idle_timeout_message: ""
+
+  # Sets an idle timeout for the Web UI. The default is 10m.
+  web_idle_timeout: 10m
+
+  # Determines if the clients will be forcefully disconnected when their
+  # certificates expire in the middle of an active session. (default is 'no')
+  disconnect_expired_cert: no
+
+  # keep_alive_interval determines the interval at which Teleport will
+  # send keep-alive messages for client and reverse tunnel connections.
+  # The default is set to 5 minutes (300 seconds) to stay lower than the
+  # common load balancer timeout of 350 seconds.
+  # keep_alive_count_max is the number of missed keep-alive messages before
+  # the Teleport cluster tears down the connection to the client or service.
+  keep_alive_interval: 5m
+  keep_alive_count_max: 3
+
+  # Specifies the cluster wide dial timeout used for establishing SSH connections
+  # via tsh ssh and the Web UI. The default value of 30 seconds should suffice for
+  # most use cases. However, if there are multiple network hops to reach the target
+  # host causing dial timeout failures, this value can be increased as needed.
+  ssh_dial_timeout: 30s
+
+  # Determines the internal session control timeout cluster-wide. This value
+  # will be used with enterprise max_connections and max_sessions. It's
+  # unlikely that you'll need to change this.
+  # session_control_timeout: 2m
+
+  # Determines the routing strategy used to connect to nodes. Can be
+  # 'unambiguous_match' (default), or 'most_recent'.
+  routing_strategy: unambiguous_match
+
+  # License file to start auth server with. Note that this setting is ignored
+  # in the Teleport Community Edition and is required only for Teleport Enterprise.
+  #
+  # The path can be either absolute or relative to the configured `data_dir`
+  # and should point to the license file obtained from Teleport Download
+  # Portal.
+  #
+  # If not set, by default Teleport will look for the `license.pem` file in
+  # the configured `data_dir` .
+  license_file: /var/lib/teleport/license.pem
+
+  # Configures a banner message to be displayed to a user logging into the
+  # cluster, which must be acknowledged before the user is allowed to log in.
+  # Note that will be shown *before* login, so should not contain any
+  # confidential information.
+  # Defaults to the empty string, implying no message or acknowledgment is
+  # required.
+  message_of_the_day: ""
+
+  # Indicates to the clients whether the cluster is running in TLS routing
+  # mode with all protocols multiplexed on the proxy's web_listen_addr.
+  #
+  # Possible values are:
+  #
+  # "multiplex": clients will be connecting to Teleport proxy's web listener
+  #              in TLS routing mode.
+  # "separate":  clients will be connecting to Teleport proxy's individual
+  #              listeners: tunnel_listen_addr, mysql_listen_addr, etc.
+  #
+  # See "TLS Routing" in Architecture section for additional information.
+  proxy_listener_mode: multiplex
+
+  # Determines the strategy that the cluster uses for connecting clients to
+  # agents through the Teleport Proxy Service.
+  tunnel_strategy:
+    # Possible tunnel strategy types are:
+    #
+    # "agent_mesh":    The default behavior, where agents will connect to every
+    #                  Teleport Proxy Service instance.
+    # "proxy_peering": Agents will connect to a subset of Proxy Service instances
+    #                  and clients will be routed between Proxy Service instances
+    #                  for end-to-end connectivity.
+    type: proxy_peering
+
+    # The number of reverse tunnel connections agents will attempt to create.
+    # This field is only available when using the "proxy_peering" tunnel
+    # strategy type. For high availability we recommend setting this value to
+    # 2 or more.
+    agent_connection_count: 1
+
+  # Tells tsh to load the CAs of all clusters when trying to ssh into a Teleport Node,
+  # instead of just the CA for the current cluster. This may be useful for
+  # users that want to log in to a root cluster and then "tsh ssh" into a node
+  # in a leaf cluster. Defaults to false.
+  load_all_cas: false
+
+  # Enables case-insensitivity for ssh dial requests. Setting this to true will allow
+  # 'tsh ssh myserver' to route to host 'MyServer'. Dialing with an uppercase hostname
+  # will still require an exact match. Openssh always lowercases hostnames, so setting
+  # this to true is necessary if you want to use openssh to access nodes with uppercase
+  # characters in their hostnames.
+  case_insensitive_routing: false
+
+  # Configuration for the Teleport Assist functionality
+  assist:
+    openai:
+      # An absolute path to the file containing the API token for OpenAI.
+      # This is required for Assist functionality.
+      api_token_path: /etc/teleport/openai_key
+
+    # When executing commands on servers through Teleport Assist,
+    # this is the maximum number of servers that Assist will connect to in parallel.
+    # This only applies in the context of a single command execution -
+    # if multiple users are using Assist concurrently, more connections may be made.
+    command_execution_workers: 30
+
+  # AccessMonitoring is a set of options related to the Access Monitoring feature.
+  access_monitoring:
+    # Turn on Access Monitoring. Default is 'no'.
+    enabled: yes
+    # AWS role ARN that Teleport will assume to execute Athena SQL queries.
+    # The Teleport role should be configured with a trust relationship and should be able to assume this role.
+    role_arn: arn:aws:iam::123456789012:role/AccessMonitoringRole
+    # S3 bucket where Access Monitoring reports will be stored.
+    report_results: s3://audit-long-term/report_results
+    # (Optional) Athena workgroup used by access monitoring queries (if not set, the default primary workgroup will be used).
+    workgroup: access_monitoring_workgroup


### PR DESCRIPTION
The retention period goes in the URL fragment, which comes after the rest of the query parameters.

Backports #53422