### PR TITLE
docs: fix typo in config example

### DIFF
--- a/docs/pages/includes/config-reference/auth-service.yaml
+++ b/docs/pages/includes/config-reference/auth-service.yaml
@@ -57,7 +57,7 @@ teleport:
     # consume the retention period via a query parameter in the audit_events_uri. See the examples below
     # for how to configure the retention period for other backends.
     # Firestore: firestore://events_table_name?eventRetentionPeriod=10d
-    # Postgres: postgresql://user_name@database-address/teleport_audit?sslmode=verfify-full#retention_period=240h
+    # Postgres: postgresql://user_name@database-address/teleport_audit?sslmode=verify-full#retention_period=240h
     retention_period: 365d
 
     # minimum/maximum read capacity in units


### PR DESCRIPTION
No backports needed - I caught the mistake before merging backports for the PR where it was introduced.