### PR TITLE
Introduce TanStack query

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@nivo/bar": "^0.88.0",
     "@protobuf-ts/runtime": "^2.9.6",
     "@protobuf-ts/runtime-rpc": "^2.9.6",
+    "@tanstack/react-query": "^5.69.0",
     "@uiw/codemirror-themes": "^4.23.10",
     "@uiw/react-codemirror": "^4.23.10",
     "d3-scale": "^4.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@protobuf-ts/runtime-rpc':
         specifier: ^2.9.6
         version: 2.9.6
+      '@tanstack/react-query':
+        specifier: ^5.69.0
+        version: 5.69.0(react@18.3.1)
       '@uiw/codemirror-themes':
         specifier: ^4.23.10
         version: 4.23.10(@codemirror/language@6.11.0)(@codemirror/state@6.5.2)(@codemirror/view@6.36.5)
@@ -2624,6 +2627,14 @@ packages:
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
+
+  '@tanstack/query-core@5.69.0':
+    resolution: {integrity: sha512-Kn410jq6vs1P8Nm+ZsRj9H+U3C0kjuEkYLxbiCyn3MDEiYor1j2DGVULqAz62SLZtUZ/e9Xt6xMXiJ3NJ65WyQ==}
+
+  '@tanstack/react-query@5.69.0':
+    resolution: {integrity: sha512-Ift3IUNQqTcaFa1AiIQ7WCb/PPy8aexZdq9pZWLXhfLcLxH0+PZqJ2xFImxCpdDZrFRZhLJrh76geevS5xjRhA==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@testing-library/dom@10.1.0':
     resolution: {integrity: sha512-wdsYKy5zupPyLCW2Je5DLHSxSfbIp6h80WoHOQc+RPtmPGA52O9x5MJEkv92Sjonpq+poOAtUKhh1kBGAXBrNA==}
@@ -9759,6 +9770,13 @@ snapshots:
   '@szmarczak/http-timer@4.0.6':
     dependencies:
       defer-to-connect: 2.0.1
+
+  '@tanstack/query-core@5.69.0': {}
+
+  '@tanstack/react-query@5.69.0(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-core': 5.69.0
+      react: 18.3.1
 
   '@testing-library/dom@10.1.0':
     dependencies:

--- a/web/.storybook/preview.tsx
+++ b/web/.storybook/preview.tsx
@@ -17,6 +17,7 @@
  */
 
 import { Preview } from '@storybook/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { http, HttpResponse } from 'msw';
 import { initialize, mswLoader } from 'msw-storybook-addon';
 import { ComponentType, PropsWithChildren } from 'react';
@@ -123,6 +124,15 @@ function UserDecorator(props: PropsWithChildren<UserDecoratorProps>) {
   return props.children;
 }
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: false,
+    },
+  },
+});
+
 const preview: Preview = {
   args: {
     userContext: false,
@@ -140,11 +150,13 @@ const preview: Preview = {
   loaders: [mswLoader],
   decorators: [
     (Story, meta) => (
-      <UserDecorator userContext={meta.args.userContext}>
-        <ThemeDecorator theme={meta.globals.theme} title={meta.title}>
-          <Story />
-        </ThemeDecorator>
-      </UserDecorator>
+      <QueryClientProvider client={queryClient}>
+        <UserDecorator userContext={meta.args.userContext}>
+          <ThemeDecorator theme={meta.globals.theme} title={meta.title}>
+            <Story />
+          </ThemeDecorator>
+        </UserDecorator>
+      </QueryClientProvider>
     ),
   ],
   globalTypes: {

--- a/web/packages/design/src/utils/testing.tsx
+++ b/web/packages/design/src/utils/testing.tsx
@@ -36,11 +36,23 @@ import { ConfiguredThemeProvider } from 'design/ThemeProvider';
 import '@testing-library/jest-dom';
 import 'jest-styled-components';
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+export const testQueryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
+
 function Providers({ children }: { children: ReactNode }) {
   return (
-    <ConfiguredThemeProvider theme={darkTheme}>
-      {children}
-    </ConfiguredThemeProvider>
+    <QueryClientProvider client={testQueryClient}>
+      <ConfiguredThemeProvider theme={darkTheme}>
+        {children}
+      </ConfiguredThemeProvider>
+    </QueryClientProvider>
   );
 }
 

--- a/web/packages/teleport/src/Teleport.tsx
+++ b/web/packages/teleport/src/Teleport.tsx
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { History } from 'history';
 import React, { Suspense, useEffect } from 'react';
 
@@ -44,6 +45,15 @@ import { SingleLogoutFailed } from './SingleLogoutFailed';
 import TeleportContext from './teleportContext';
 import TeleportContextProvider from './TeleportContextProvider';
 import { Welcome } from './Welcome';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: false,
+    },
+  },
+});
 
 const Teleport: React.FC<Props> = props => {
   const { ctx, history } = props;
@@ -76,32 +86,34 @@ const Teleport: React.FC<Props> = props => {
 
   return (
     <CatchError>
-      <ThemeProvider>
-        <LayoutContextProvider>
-          <Router history={history}>
-            <Suspense fallback={null}>
-              <Switch>
-                {createPublicRoutes()}
-                <Route path={cfg.routes.root}>
-                  <Authenticated>
-                    <UserContextProvider>
-                      <TeleportContextProvider ctx={ctx}>
-                        <Switch>
-                          <Route
-                            path={cfg.routes.appLauncher}
-                            component={AppLauncher}
-                          />
-                          <Route>{createPrivateRoutes()}</Route>
-                        </Switch>
-                      </TeleportContextProvider>
-                    </UserContextProvider>
-                  </Authenticated>
-                </Route>
-              </Switch>
-            </Suspense>
-          </Router>
-        </LayoutContextProvider>
-      </ThemeProvider>
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider>
+          <LayoutContextProvider>
+            <Router history={history}>
+              <Suspense fallback={null}>
+                <Switch>
+                  {createPublicRoutes()}
+                  <Route path={cfg.routes.root}>
+                    <Authenticated>
+                      <UserContextProvider>
+                        <TeleportContextProvider ctx={ctx}>
+                          <Switch>
+                            <Route
+                              path={cfg.routes.appLauncher}
+                              component={AppLauncher}
+                            />
+                            <Route>{createPrivateRoutes()}</Route>
+                          </Switch>
+                        </TeleportContextProvider>
+                      </UserContextProvider>
+                    </Authenticated>
+                  </Route>
+                </Switch>
+              </Suspense>
+            </Router>
+          </LayoutContextProvider>
+        </ThemeProvider>
+      </QueryClientProvider>
     </CatchError>
   );
 };

--- a/web/packages/teleport/src/services/queryHelpers.ts
+++ b/web/packages/teleport/src/services/queryHelpers.ts
@@ -1,0 +1,138 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as reactQuery from '@tanstack/react-query';
+import {
+  type DataTag,
+  type DefaultError,
+  type UseMutationOptions,
+  type UseMutationResult,
+  type UseQueryOptions,
+  type UseQueryResult,
+} from '@tanstack/react-query';
+
+export type MutationHook<
+  TVariables = void,
+  TData = unknown,
+  TError = DefaultError,
+> = (
+  options?: Omit<UseMutationOptions<TData, TError, TVariables>, 'mutationFn'>
+) => UseMutationResult<TData, TError, TVariables>;
+
+export function wrapMutation<
+  TVariables = void,
+  TData = unknown,
+  TError = DefaultError,
+>(
+  mutationFn: (variables: TVariables) => Promise<TData>
+): MutationHook<TVariables, TData, TError> {
+  return function wrappedMutation(
+    options?: Omit<UseMutationOptions<TData, TError, TVariables>, 'mutationFn'>
+  ) {
+    return reactQuery.useMutation<TData, TError, TVariables>({
+      mutationFn,
+      ...options,
+    });
+  };
+}
+
+export type QueryHook<
+  TData = unknown,
+  TVariables = void,
+  TError = DefaultError,
+> = (
+  variables?: TVariables,
+  options?: Omit<UseQueryOptions<TData, TError>, 'queryKey' | 'queryFn'>
+) => UseQueryResult<TData, TError>;
+
+export interface WrappedQuery<
+  TData = unknown,
+  TVariables = void,
+  TError = DefaultError,
+> {
+  createQueryKey: (variables?: TVariables) => string[];
+  queryKey: DataTag<string[], TData, TError>;
+  useQuery: QueryHook<TData, TVariables, TError>;
+}
+
+type SignalOnlyQueryFn<TData> = (signal: AbortSignal) => Promise<TData>;
+type VariablesQueryFn<TData, TVariables> = (
+  variables: TVariables,
+  signal: AbortSignal
+) => Promise<TData>;
+
+type QueryFn<TData, TVariables> = TVariables extends void
+  ? SignalOnlyQueryFn<TData>
+  : VariablesQueryFn<TData, TVariables>;
+
+export function wrapQuery<
+  TData = unknown,
+  TVariables = void,
+  TError = DefaultError,
+>(
+  queryKey: string[],
+  queryFn: QueryFn<TData, TVariables>
+): WrappedQuery<TData, TVariables, TError> {
+  return {
+    queryKey: queryKey as DataTag<string[], TData, TError>,
+    createQueryKey(variables?: TVariables) {
+      const key = [...queryKey];
+
+      if (variables) {
+        key.push(JSON.stringify(variables));
+      }
+
+      return key;
+    },
+    useQuery: function wrappedQuery(
+      variables?: TVariables,
+      options?: Omit<UseQueryOptions<TData, TError>, 'queryKey' | 'queryFn'>
+    ) {
+      const key = [...queryKey];
+
+      if (variables) {
+        key.push(JSON.stringify(variables));
+      }
+
+      return reactQuery.useQuery({
+        queryKey: key,
+        queryFn: ({ signal }) => callQueryFn(queryFn, variables, signal),
+        ...options,
+      });
+    },
+  };
+}
+
+function isSignalOnlyQueryFn<TData = unknown, TVariables = void>(
+  queryFn: QueryFn<TData, unknown>,
+  variables: TVariables
+): queryFn is SignalOnlyQueryFn<TData> {
+  return typeof variables === 'undefined';
+}
+
+function callQueryFn<TData = unknown, TVariables = void>(
+  queryFn: QueryFn<TData, TVariables>,
+  variables: TVariables,
+  signal: AbortSignal
+) {
+  if (isSignalOnlyQueryFn(queryFn, variables)) {
+    return queryFn(signal);
+  }
+
+  return queryFn(variables, signal);
+}

--- a/web/packages/teleport/src/services/queryHelpers.ts
+++ b/web/packages/teleport/src/services/queryHelpers.ts
@@ -65,7 +65,7 @@ export interface WrappedQuery<
   TVariables = void,
   TError = DefaultError,
 > {
-  createQueryKey: (variables?: TVariables) => string[];
+  createQueryKey: (variables?: TVariables) => DataTag<string[], TData, TError>;
   queryKey: DataTag<string[], TData, TError>;
   useQuery: QueryHook<TData, TVariables, TError>;
 }
@@ -97,7 +97,7 @@ export function wrapQuery<
         key.push(JSON.stringify(variables));
       }
 
-      return key;
+      return key as DataTag<string[], TData, TError>;
     },
     useQuery: function wrappedQuery(
       variables?: TVariables,


### PR DESCRIPTION
This introduces TanStack query now that RFD 197 has been approved, as well as some helper functions so we can wrap existing service methods and get a hook out of them.