### PR TITLE
[docs] Fix role reference `request_access` docs

### DIFF
--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -3153,7 +3153,7 @@ message RoleOptions {
   // concurrent sessions per connection.
   int64 MaxSessions = 10 [(gogoproto.jsontag) = "max_sessions,omitempty"];
 
-  // RequestAccess defines the request strategy (optional|note|always)
+  // RequestAccess defines the request strategy (optional|reason|always)
   // where optional is the default.
   string RequestAccess = 11 [
     (gogoproto.jsontag) = "request_access,omitempty",

--- a/api/types/types.pb.go
+++ b/api/types/types.pb.go
@@ -8665,7 +8665,7 @@ type RoleOptions struct {
 	// MaxSessions defines the maximum number of
 	// concurrent sessions per connection.
 	MaxSessions int64 `protobuf:"varint,10,opt,name=MaxSessions,proto3" json:"max_sessions,omitempty"`
-	// RequestAccess defines the request strategy (optional|note|always)
+	// RequestAccess defines the request strategy (optional|reason|always)
 	// where optional is the default.
 	RequestAccess RequestStrategy `protobuf:"bytes,11,opt,name=RequestAccess,proto3,casttype=RequestStrategy" json:"request_access,omitempty"`
 	// RequestPrompt is an optional message which tells users what they aught to request.

--- a/docs/pages/reference/operator-resources/resources-teleport-dev-roles.mdx
+++ b/docs/pages/reference/operator-resources/resources-teleport-dev-roles.mdx
@@ -422,7 +422,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |pin_source_ip|boolean|PinSourceIP forces the same client IP for certificate generation and usage|
 |port_forwarding|boolean|Deprecated: Use SSHPortForwarding instead|
 |record_session|[object](#specoptionsrecord_session)|RecordDesktopSession indicates whether desktop access sessions should be recorded. It defaults to true unless explicitly set to false.|
-|request_access|string|RequestAccess defines the request strategy (optional|note|always) where optional is the default.|
+|request_access|string|RequestAccess defines the request strategy (optional|reason|always) where optional is the default.|
 |request_prompt|string|RequestPrompt is an optional message which tells users what they aught to request.|
 |require_session_mfa|string or integer|RequireMFAType is the type of MFA requirement enforced for this user. 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY", 3 is "HARDWARE_KEY_TOUCH", 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN". Can be either the string or the integer representation of each option.|
 |ssh_file_copy|boolean|SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed over an SSH session. It defaults to true unless explicitly set to false.|
@@ -887,7 +887,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |pin_source_ip|boolean|PinSourceIP forces the same client IP for certificate generation and usage|
 |port_forwarding|boolean|Deprecated: Use SSHPortForwarding instead|
 |record_session|[object](#specoptionsrecord_session)|RecordDesktopSession indicates whether desktop access sessions should be recorded. It defaults to true unless explicitly set to false.|
-|request_access|string|RequestAccess defines the request strategy (optional|note|always) where optional is the default.|
+|request_access|string|RequestAccess defines the request strategy (optional|reason|always) where optional is the default.|
 |request_prompt|string|RequestPrompt is an optional message which tells users what they aught to request.|
 |require_session_mfa|string or integer|RequireMFAType is the type of MFA requirement enforced for this user. 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY", 3 is "HARDWARE_KEY_TOUCH", 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN". Can be either the string or the integer representation of each option.|
 |ssh_file_copy|boolean|SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed over an SSH session. It defaults to true unless explicitly set to false.|

--- a/docs/pages/reference/operator-resources/resources-teleport-dev-rolesv6.mdx
+++ b/docs/pages/reference/operator-resources/resources-teleport-dev-rolesv6.mdx
@@ -422,7 +422,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |pin_source_ip|boolean|PinSourceIP forces the same client IP for certificate generation and usage|
 |port_forwarding|boolean|Deprecated: Use SSHPortForwarding instead|
 |record_session|[object](#specoptionsrecord_session)|RecordDesktopSession indicates whether desktop access sessions should be recorded. It defaults to true unless explicitly set to false.|
-|request_access|string|RequestAccess defines the request strategy (optional|note|always) where optional is the default.|
+|request_access|string|RequestAccess defines the request strategy (optional|reason|always) where optional is the default.|
 |request_prompt|string|RequestPrompt is an optional message which tells users what they aught to request.|
 |require_session_mfa|string or integer|RequireMFAType is the type of MFA requirement enforced for this user. 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY", 3 is "HARDWARE_KEY_TOUCH", 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN". Can be either the string or the integer representation of each option.|
 |ssh_file_copy|boolean|SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed over an SSH session. It defaults to true unless explicitly set to false.|

--- a/docs/pages/reference/operator-resources/resources-teleport-dev-rolesv7.mdx
+++ b/docs/pages/reference/operator-resources/resources-teleport-dev-rolesv7.mdx
@@ -422,7 +422,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |pin_source_ip|boolean|PinSourceIP forces the same client IP for certificate generation and usage|
 |port_forwarding|boolean|Deprecated: Use SSHPortForwarding instead|
 |record_session|[object](#specoptionsrecord_session)|RecordDesktopSession indicates whether desktop access sessions should be recorded. It defaults to true unless explicitly set to false.|
-|request_access|string|RequestAccess defines the request strategy (optional|note|always) where optional is the default.|
+|request_access|string|RequestAccess defines the request strategy (optional|reason|always) where optional is the default.|
 |request_prompt|string|RequestPrompt is an optional message which tells users what they aught to request.|
 |require_session_mfa|string or integer|RequireMFAType is the type of MFA requirement enforced for this user. 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY", 3 is "HARDWARE_KEY_TOUCH", 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN". Can be either the string or the integer representation of each option.|
 |ssh_file_copy|boolean|SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed over an SSH session. It defaults to true unless explicitly set to false.|

--- a/docs/pages/reference/terraform-provider/data-sources/role.mdx
+++ b/docs/pages/reference/terraform-provider/data-sources/role.mdx
@@ -471,7 +471,7 @@ Optional:
 - `pin_source_ip` (Boolean) PinSourceIP forces the same client IP for certificate generation and usage
 - `port_forwarding` (Boolean) Deprecated: Use SSHPortForwarding instead
 - `record_session` (Attributes) RecordDesktopSession indicates whether desktop access sessions should be recorded. It defaults to true unless explicitly set to false. (see [below for nested schema](#nested-schema-for-specoptionsrecord_session))
-- `request_access` (String) RequestAccess defines the request strategy (optional|note|always) where optional is the default.
+- `request_access` (String) RequestAccess defines the request strategy (optional|reason|always) where optional is the default.
 - `request_prompt` (String) RequestPrompt is an optional message which tells users what they aught to request.
 - `require_session_mfa` (Number) RequireMFAType is the type of MFA requirement enforced for this user. 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY", 3 is "HARDWARE_KEY_TOUCH", 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN".
 - `ssh_file_copy` (Boolean) SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed over an SSH session. It defaults to true unless explicitly set to false.

--- a/docs/pages/reference/terraform-provider/resources/role.mdx
+++ b/docs/pages/reference/terraform-provider/resources/role.mdx
@@ -41,7 +41,7 @@ resource "teleport_role" "example" {
       client_idle_timeout     = "1h"
       disconnect_expired_cert = true
       permit_x11_forwarding   = false
-      request_access          = "denied"
+      request_access          = "optional"
     }
 
     allow = {
@@ -533,7 +533,7 @@ Optional:
 - `pin_source_ip` (Boolean) PinSourceIP forces the same client IP for certificate generation and usage
 - `port_forwarding` (Boolean) Deprecated: Use SSHPortForwarding instead
 - `record_session` (Attributes) RecordDesktopSession indicates whether desktop access sessions should be recorded. It defaults to true unless explicitly set to false. (see [below for nested schema](#nested-schema-for-specoptionsrecord_session))
-- `request_access` (String) RequestAccess defines the request strategy (optional|note|always) where optional is the default.
+- `request_access` (String) RequestAccess defines the request strategy (optional|reason|always) where optional is the default.
 - `request_prompt` (String) RequestPrompt is an optional message which tells users what they aught to request.
 - `require_session_mfa` (Number) RequireMFAType is the type of MFA requirement enforced for this user. 0 is "OFF", 1 is "SESSION", 2 is "SESSION_AND_HARDWARE_KEY", 3 is "HARDWARE_KEY_TOUCH", 4 is "HARDWARE_KEY_PIN", 5 is "HARDWARE_KEY_TOUCH_AND_PIN".
 - `ssh_file_copy` (Boolean) SSHFileCopy indicates whether remote file operations via SCP or SFTP are allowed over an SSH session. It defaults to true unless explicitly set to false.

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_roles.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_roles.yaml
@@ -1376,7 +1376,7 @@ spec:
                         type: string
                     type: object
                   request_access:
-                    description: RequestAccess defines the request strategy (optional|note|always)
+                    description: RequestAccess defines the request strategy (optional|reason|always)
                       where optional is the default.
                     type: string
                   request_prompt:
@@ -2849,7 +2849,7 @@ spec:
                         type: string
                     type: object
                   request_access:
-                    description: RequestAccess defines the request strategy (optional|note|always)
+                    description: RequestAccess defines the request strategy (optional|reason|always)
                       where optional is the default.
                     type: string
                   request_prompt:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_rolesv6.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_rolesv6.yaml
@@ -1379,7 +1379,7 @@ spec:
                         type: string
                     type: object
                   request_access:
-                    description: RequestAccess defines the request strategy (optional|note|always)
+                    description: RequestAccess defines the request strategy (optional|reason|always)
                       where optional is the default.
                     type: string
                   request_prompt:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_rolesv7.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_rolesv7.yaml
@@ -1379,7 +1379,7 @@ spec:
                         type: string
                     type: object
                   request_access:
-                    description: RequestAccess defines the request strategy (optional|note|always)
+                    description: RequestAccess defines the request strategy (optional|reason|always)
                       where optional is the default.
                     type: string
                   request_prompt:

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_roles.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_roles.yaml
@@ -1376,7 +1376,7 @@ spec:
                         type: string
                     type: object
                   request_access:
-                    description: RequestAccess defines the request strategy (optional|note|always)
+                    description: RequestAccess defines the request strategy (optional|reason|always)
                       where optional is the default.
                     type: string
                   request_prompt:
@@ -2849,7 +2849,7 @@ spec:
                         type: string
                     type: object
                   request_access:
-                    description: RequestAccess defines the request strategy (optional|note|always)
+                    description: RequestAccess defines the request strategy (optional|reason|always)
                       where optional is the default.
                     type: string
                   request_prompt:

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_rolesv6.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_rolesv6.yaml
@@ -1379,7 +1379,7 @@ spec:
                         type: string
                     type: object
                   request_access:
-                    description: RequestAccess defines the request strategy (optional|note|always)
+                    description: RequestAccess defines the request strategy (optional|reason|always)
                       where optional is the default.
                     type: string
                   request_prompt:

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_rolesv7.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_rolesv7.yaml
@@ -1379,7 +1379,7 @@ spec:
                         type: string
                     type: object
                   request_access:
-                    description: RequestAccess defines the request strategy (optional|note|always)
+                    description: RequestAccess defines the request strategy (optional|reason|always)
                       where optional is the default.
                     type: string
                   request_prompt:

--- a/integrations/terraform/examples/resources/teleport_role/resource.tf
+++ b/integrations/terraform/examples/resources/teleport_role/resource.tf
@@ -27,7 +27,7 @@ resource "teleport_role" "example" {
       client_idle_timeout     = "1h"
       disconnect_expired_cert = true
       permit_x11_forwarding   = false
-      request_access          = "denied"
+      request_access          = "optional"
     }
 
     allow = {

--- a/integrations/terraform/reference.mdx
+++ b/integrations/terraform/reference.mdx
@@ -2054,7 +2054,7 @@ Options is for OpenSSH options like agent forwarding.
 | ssh_port_forwarding        | object           |          | SSHPortForwarding configures what types of SSH port forwarding are allowed by a role.                                                                                                                  |
 | port_forwarding            | bool             |          | Deprecated: Use SSHPortForwarding instead.                                                                                                                                                             |
 | record_session             | object           |          | RecordDesktopSession indicates whether desktop access sessions should be recorded. It defaults to true unless explicitly set to false.                                                                 |
-| request_access             | string           |          | RequestAccess defines the access request strategy (optional|note|always) where optional is the default.                                                                                                |
+| request_access             | string           |          | RequestAccess defines the access request strategy (optional|reason|always) where optional is the default.                                                                                                |
 | request_prompt             | string           |          | RequestPrompt is an optional message which tells users what they aught to request.                                                                                                                     |
 | require_session_mfa        | number           |          | RequireMFAType is the type of MFA requirement enforced for this role: 0:Off, 1:Session, 2:SessionAndHardwareKey, 3:HardwareKeyTouch                                                                    |
 | ssh_file_copy              | bool             |          |                                                                                                                                                                                                        |
@@ -2143,7 +2143,7 @@ resource "teleport_role" "example" {
       client_idle_timeout     = "1h"
       disconnect_expired_cert = true
       permit_x11_forwarding   = false
-      request_access          = "denied"
+      request_access          = "optional"
       ssh_port_forwarding     = {
         remote = {
           enabled = false

--- a/integrations/terraform/tfschema/types_terraform.go
+++ b/integrations/terraform/tfschema/types_terraform.go
@@ -2775,7 +2775,7 @@ func GenSchemaRoleV6(ctx context.Context) (github_com_hashicorp_terraform_plugin
 							Optional:    true,
 						},
 						"request_access": {
-							Description: "RequestAccess defines the request strategy (optional|note|always) where optional is the default.",
+							Description: "RequestAccess defines the request strategy (optional|reason|always) where optional is the default.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},


### PR DESCRIPTION
This PR fixes the godoc on RequestAccess and regenerates docs reference for the terraform and kube integrations.

The "note" and "denied" values are not supported `role.spec.options.request_access` values.