### PR TITLE
Support adding introduction text into Terraform reference pages

### DIFF
--- a/docs/pages/reference/terraform-provider/resources/access_list.mdx
+++ b/docs/pages/reference/terraform-provider/resources/access_list.mdx
@@ -7,6 +7,9 @@ description: This page describes the supported values of the teleport_access_lis
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_access_list resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -205,4 +208,3 @@ Optional:
 
 - `key` (String) key is the name of the trait.
 - `values` (List of String) values is the list of trait values.
-

--- a/docs/pages/reference/terraform-provider/resources/access_monitoring_rule.mdx
+++ b/docs/pages/reference/terraform-provider/resources/access_monitoring_rule.mdx
@@ -7,6 +7,9 @@ description: This page describes the supported values of the teleport_access_mon
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_access_monitoring_rule resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -84,4 +87,3 @@ Optional:
 - `description` (String) description is object description.
 - `expires` (String) expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) labels is a set of labels.
-

--- a/docs/pages/reference/terraform-provider/resources/app.mdx
+++ b/docs/pages/reference/terraform-provider/resources/app.mdx
@@ -7,6 +7,9 @@ description: This page describes the supported values of the teleport_app resour
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_app resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -143,4 +146,3 @@ Optional:
 
 - `end_port` (Number) EndPort describes the end of the range, inclusive. If set, it must be between 2 and 65535 and be greater than Port when describing a port range. When omitted or set to zero, it signifies that the port range defines a single port.
 - `port` (Number) Port describes the start of the range. It must be between 1 and 65535.
-

--- a/docs/pages/reference/terraform-provider/resources/auth_preference.mdx
+++ b/docs/pages/reference/terraform-provider/resources/auth_preference.mdx
@@ -7,6 +7,9 @@ description: This page describes the supported values of the teleport_auth_prefe
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_auth_preference resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -149,4 +152,3 @@ Optional:
 - `description` (String) Description is object description
 - `expires` (String) Expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) Labels is a set of labels
-

--- a/docs/pages/reference/terraform-provider/resources/autoupdate_config.mdx
+++ b/docs/pages/reference/terraform-provider/resources/autoupdate_config.mdx
@@ -7,6 +7,9 @@ description: This page describes the supported values of the teleport_autoupdate
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_autoupdate_config resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -109,4 +112,3 @@ Optional:
 - `expires` (String) expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) labels is a set of labels.
 - `name` (String) name is an object name.
-

--- a/docs/pages/reference/terraform-provider/resources/autoupdate_version.mdx
+++ b/docs/pages/reference/terraform-provider/resources/autoupdate_version.mdx
@@ -7,6 +7,9 @@ description: This page describes the supported values of the teleport_autoupdate
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_autoupdate_version resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -74,4 +77,3 @@ Optional:
 - `expires` (String) expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) labels is a set of labels.
 - `name` (String) name is an object name.
-

--- a/docs/pages/reference/terraform-provider/resources/bot.mdx
+++ b/docs/pages/reference/terraform-provider/resources/bot.mdx
@@ -7,6 +7,9 @@ description: This page describes the supported values of the teleport_bot resour
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_bot resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -66,4 +69,3 @@ resource "teleport_bot" "example" {
 
 - `role_name` (String) The name of the generated bot role
 - `user_name` (String) The name of the generated bot user
-

--- a/docs/pages/reference/terraform-provider/resources/cluster_maintenance_config.mdx
+++ b/docs/pages/reference/terraform-provider/resources/cluster_maintenance_config.mdx
@@ -7,6 +7,9 @@ description: This page describes the supported values of the teleport_cluster_ma
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_cluster_maintenance_config resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -64,4 +67,3 @@ Optional:
 
 - `utc_start_hour` (Number) UTCStartHour is the start hour of the maintenance window in UTC.
 - `weekdays` (List of String) Weekdays is an optional list of weekdays. If not specified, an agent upgrade window occurs every day.
-

--- a/docs/pages/reference/terraform-provider/resources/cluster_networking_config.mdx
+++ b/docs/pages/reference/terraform-provider/resources/cluster_networking_config.mdx
@@ -7,6 +7,9 @@ description: This page describes the supported values of the teleport_cluster_ne
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_cluster_networking_config resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -86,4 +89,3 @@ Optional:
 Optional:
 
 - `agent_connection_count` (Number)
-

--- a/docs/pages/reference/terraform-provider/resources/database.mdx
+++ b/docs/pages/reference/terraform-provider/resources/database.mdx
@@ -8,7 +8,8 @@ description: This page describes the supported values of the teleport_database r
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
 This page describes the supported values of the teleport_database resource of the Teleport Terraform provider.
-
+Follow [the database dynamic registration guide](../../../enroll-resources/database-access/guides/dynamic-registration.mdx)
+to complete deploying a database_service and access the database resource
 
 
 

--- a/docs/pages/reference/terraform-provider/resources/database.mdx
+++ b/docs/pages/reference/terraform-provider/resources/database.mdx
@@ -7,6 +7,9 @@ description: This page describes the supported values of the teleport_database r
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_database resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -266,4 +269,3 @@ Optional:
 - `mode` (Number) Mode is a TLS connection mode. 0 is "verify-full"; 1 is "verify-ca", 2 is "insecure".
 - `server_name` (String) ServerName allows to provide custom hostname. This value will override the servername/hostname on a certificate during validation.
 - `trust_system_cert_pool` (Boolean) TrustSystemCertPool allows Teleport to trust certificate authorities available on the host system. If not set (by default), Teleport only trusts self-signed databases with TLS certificates signed by Teleport's Database Server CA or the ca_cert specified in this TLS setting. For cloud-hosted databases, Teleport downloads the corresponding required CAs for validation.
-

--- a/docs/pages/reference/terraform-provider/resources/dynamic_windows_desktop.mdx
+++ b/docs/pages/reference/terraform-provider/resources/dynamic_windows_desktop.mdx
@@ -7,6 +7,9 @@ description: This page describes the supported values of the teleport_dynamic_wi
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_dynamic_windows_desktop resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -79,4 +82,3 @@ Optional:
 - `description` (String) Description is object description
 - `expires` (String) Expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) Labels is a set of labels
-

--- a/docs/pages/reference/terraform-provider/resources/github_connector.mdx
+++ b/docs/pages/reference/terraform-provider/resources/github_connector.mdx
@@ -7,6 +7,9 @@ description: This page describes the supported values of the teleport_github_con
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_github_connector resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -113,4 +116,3 @@ Optional:
 - `description` (String) Description is object description
 - `expires` (String) Expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) Labels is a set of labels
-

--- a/docs/pages/reference/terraform-provider/resources/installer.mdx
+++ b/docs/pages/reference/terraform-provider/resources/installer.mdx
@@ -7,6 +7,9 @@ description: This page describes the supported values of the teleport_installer 
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_installer resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -116,4 +119,3 @@ Optional:
 - `description` (String) Description is object description
 - `expires` (String) Expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) Labels is a set of labels
-

--- a/docs/pages/reference/terraform-provider/resources/login_rule.mdx
+++ b/docs/pages/reference/terraform-provider/resources/login_rule.mdx
@@ -7,6 +7,9 @@ description: This page describes the supported values of the teleport_login_rule
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_login_rule resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -72,4 +75,3 @@ Optional:
 Optional:
 
 - `values` (List of String)
-

--- a/docs/pages/reference/terraform-provider/resources/oidc_connector.mdx
+++ b/docs/pages/reference/terraform-provider/resources/oidc_connector.mdx
@@ -7,6 +7,9 @@ description: This page describes the supported values of the teleport_oidc_conne
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_oidc_connector resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -118,4 +121,3 @@ Optional:
 - `description` (String) Description is object description
 - `expires` (String) Expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) Labels is a set of labels
-

--- a/docs/pages/reference/terraform-provider/resources/okta_import_rule.mdx
+++ b/docs/pages/reference/terraform-provider/resources/okta_import_rule.mdx
@@ -7,6 +7,9 @@ description: This page describes the supported values of the teleport_okta_impor
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_okta_import_rule resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -122,4 +125,3 @@ Optional:
 - `description` (String) Description is object description
 - `expires` (String) Expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) Labels is a set of labels
-

--- a/docs/pages/reference/terraform-provider/resources/provision_token.mdx
+++ b/docs/pages/reference/terraform-provider/resources/provision_token.mdx
@@ -7,6 +7,9 @@ description: This page describes the supported values of the teleport_provision_
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_provision_token resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -320,4 +323,3 @@ Optional:
 - `expires` (String) Expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) Labels is a set of labels
 - `name` (String, Sensitive) Name is an object name
-

--- a/docs/pages/reference/terraform-provider/resources/role.mdx
+++ b/docs/pages/reference/terraform-provider/resources/role.mdx
@@ -7,6 +7,9 @@ description: This page describes the supported values of the teleport_role resou
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_role resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -591,4 +594,3 @@ Optional:
 Optional:
 
 - `enabled` (Boolean)
-

--- a/docs/pages/reference/terraform-provider/resources/saml_connector.mdx
+++ b/docs/pages/reference/terraform-provider/resources/saml_connector.mdx
@@ -7,6 +7,9 @@ description: This page describes the supported values of the teleport_saml_conne
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_saml_connector resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -154,4 +157,3 @@ Optional:
 - `description` (String) Description is object description
 - `expires` (String) Expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) Labels is a set of labels
-

--- a/docs/pages/reference/terraform-provider/resources/server.mdx
+++ b/docs/pages/reference/terraform-provider/resources/server.mdx
@@ -7,6 +7,9 @@ description: This page describes the supported values of the teleport_server res
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_server resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -142,4 +145,3 @@ Optional:
 - `standby` (String) Standby specifies time to switch to the "Standby" phase.
 - `update_clients` (String) UpdateClients specifies time to switch to the "Update clients" phase
 - `update_servers` (String) UpdateServers specifies time to switch to the "Update servers" phase.
-

--- a/docs/pages/reference/terraform-provider/resources/session_recording_config.mdx
+++ b/docs/pages/reference/terraform-provider/resources/session_recording_config.mdx
@@ -7,6 +7,9 @@ description: This page describes the supported values of the teleport_session_re
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_session_recording_config resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -58,4 +61,3 @@ Optional:
 
 - `mode` (String) Mode controls where (or if) the session is recorded.
 - `proxy_checks_host_keys` (Boolean) ProxyChecksHostKeys is used to control if the proxy will check host keys when in recording mode.
-

--- a/docs/pages/reference/terraform-provider/resources/static_host_user.mdx
+++ b/docs/pages/reference/terraform-provider/resources/static_host_user.mdx
@@ -7,6 +7,9 @@ description: This page describes the supported values of the teleport_static_hos
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_static_host_user resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -89,4 +92,3 @@ Required:
 
 - `name` (String) The name of the label.
 - `values` (List of String) The values associated with the label.
-

--- a/docs/pages/reference/terraform-provider/resources/trusted_cluster.mdx
+++ b/docs/pages/reference/terraform-provider/resources/trusted_cluster.mdx
@@ -7,6 +7,9 @@ description: This page describes the supported values of the teleport_trusted_cl
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_trusted_cluster resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -79,4 +82,3 @@ Optional:
 - `description` (String) Description is object description
 - `expires` (String) Expires is a global expiry time header can be set on any resource in the system.
 - `labels` (Map of String) Labels is a set of labels
-

--- a/docs/pages/reference/terraform-provider/resources/trusted_device.mdx
+++ b/docs/pages/reference/terraform-provider/resources/trusted_device.mdx
@@ -7,6 +7,9 @@ description: This page describes the supported values of the teleport_trusted_de
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_trusted_device resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -61,4 +64,3 @@ Optional:
 
 - `name` (String)
 - `origin` (String)
-

--- a/docs/pages/reference/terraform-provider/resources/user.mdx
+++ b/docs/pages/reference/terraform-provider/resources/user.mdx
@@ -7,6 +7,9 @@ description: This page describes the supported values of the teleport_user resou
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_user resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -133,4 +136,3 @@ Optional:
 
 - `mfa_weakest_device` (Number) mfa_weakest_device reflects what the system knows about the user's weakest MFA device. Note that this is a "best effort" property, in that it can be UNSPECIFIED.
 - `password_state` (Number) password_state reflects what the system knows about the user's password. Note that this is a "best effort" property, in that it can be UNSPECIFIED for users who were created before this property was introduced and didn't perform any password-related activity since then. See RFD 0159 for details. Do NOT use this value for authentication purposes!
-

--- a/docs/pages/reference/terraform-provider/resources/workload_identity.mdx
+++ b/docs/pages/reference/terraform-provider/resources/workload_identity.mdx
@@ -7,6 +7,9 @@ description: This page describes the supported values of the teleport_workload_i
 {/*Auto-generated file. Do not edit.*/}
 {/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}
 
+This page describes the supported values of the teleport_workload_identity resource of the Teleport Terraform provider.
+
+
 
 
 ## Example Usage
@@ -141,4 +144,3 @@ Optional:
 - `common_name` (String) Common Name (CN) - 2.5.4.3 If empty, the RDN will be omitted from the DN.
 - `organization` (String) Organization (O) - 2.5.4.10 If empty, the RDN will be omitted from the DN.
 - `organizational_unit` (String) Organizational Unit (OU) - 2.5.4.11 If empty, the RDN will be omitted from the DN.
-

--- a/integrations/terraform/examples/resources/teleport_database/introduction.md
+++ b/integrations/terraform/examples/resources/teleport_database/introduction.md
@@ -1,0 +1,2 @@
+Follow [the database dynamic registration guide](../../../enroll-resources/database-access/guides/dynamic-registration.mdx)
+to complete deploying a database_service and access the database resource

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -428,4 +428,4 @@ replace (
 // (using our fork of github.com/hashicorp/terraform-plugin-docs)
 tool github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
 
-replace github.com/hashicorp/terraform-plugin-docs => github.com/gravitational/terraform-plugin-docs v0.19.5-0.20240627183239-7e7e22a2c1f6
+replace github.com/hashicorp/terraform-plugin-docs => github.com/gravitational/terraform-plugin-docs v0.19.5-0.20250326215846-2e10ca5fcbdf

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -714,8 +714,8 @@ github.com/gravitational/roundtrip v1.0.2 h1:eOCY0NEKKaB0ksJmvhO6lPMFz1pIIef+vyP
 github.com/gravitational/roundtrip v1.0.2/go.mod h1:fuI1booM2hLRA/B/m5MRAPOU6mBZNYcNycono2UuTw0=
 github.com/gravitational/saml v0.4.15-teleport.2 h1:ruNtaIkDrCJ5eS+OBcKeER+P5ldDDys7SeCoyFJAX1o=
 github.com/gravitational/saml v0.4.15-teleport.2/go.mod h1:wGckhUH/I+hcDR2uo9WC4GyL+o4rid5JUe1Ze/joarI=
-github.com/gravitational/terraform-plugin-docs v0.19.5-0.20240627183239-7e7e22a2c1f6 h1:roGf4UO3jjf/vv2fc+ChlWFPISFMkRXFwBUKEtjH3uY=
-github.com/gravitational/terraform-plugin-docs v0.19.5-0.20240627183239-7e7e22a2c1f6/go.mod h1:8eiBaRanEugPy3lh7UZ5NW6yaISaXXS4R56pi1D962k=
+github.com/gravitational/terraform-plugin-docs v0.19.5-0.20250326215846-2e10ca5fcbdf h1:bAsFak60gi442t2x3GuDp5Fww47zUs460NFIPiQJjzg=
+github.com/gravitational/terraform-plugin-docs v0.19.5-0.20250326215846-2e10ca5fcbdf/go.mod h1:8eiBaRanEugPy3lh7UZ5NW6yaISaXXS4R56pi1D962k=
 github.com/gravitational/trace v1.5.0 h1:JbeL2HDGyzgy7G72Z2hP2gExEyA6Y2p7fCiSjyZwCJw=
 github.com/gravitational/trace v1.5.0/go.mod h1:dxezSkKm880IIDx+czWG8fq+pLnXjETBewMgN3jOBlg=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJrOjhax5N+uePQ0Fh1Z7PheYoUI/0nzkPA=

--- a/integrations/terraform/templates/resources.md.tmpl
+++ b/integrations/terraform/templates/resources.md.tmpl
@@ -7,6 +7,9 @@ description: This page describes the supported values of the {{.Name}} resource 
 {{ "{/*Auto-generated file. Do not edit.*/}" }}
 {{ "{/*To regenerate, navigate to integrations/terraform and run `make docs`.*/}" }}
 
+This page describes the supported values of the {{.Name}} resource of the Teleport Terraform provider.
+{{ includefileifexists (printf "./examples/resources/%s/introduction.md" .Name)}}
+
 {{ .Description | trimspace }}
 
 {{ if .HasExample -}}
@@ -24,4 +27,3 @@ Import is supported using the following syntax:
 
 {{codefile "shell" .ImportFile }}
 {{- end }}
-


### PR DESCRIPTION
This PR adds an optional `introduction.md` file inclusion in the Terraform resource reference generator.
This allows us to add a bit of context before the resource schema, and link to the relevant documentation guides.

Requires https://github.com/gravitational/terraform-plugin-docs/pull/4