### PR TITLE
Reject "Bot" role in auth server static token config

### DIFF
--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -992,6 +992,9 @@ func (t StaticToken) Parse() ([]types.ProvisionTokenV1, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	if roles.Include(types.RoleBot) {
+		return nil, trace.BadParameter("role %q is not allowed in static token configuration", types.RoleBot)
+	}
 
 	tokenPart, err := utils.TryReadValueAsFile(parts[1])
 	if err != nil {

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -574,26 +574,50 @@ func TestAuthenticationConfig_Parse_StaticToken(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		desc  string
-		token string
+		desc      string
+		input     string
+		wantRoles []types.SystemRole
+		wantToken string
+		wantError string
 	}{
-		{desc: "file path on windows", token: `C:\path\to\some\file`},
-		{desc: "literal string", token: "some-literal-token"},
+		{
+			desc:      "file path on windows",
+			input:     `Auth,Node,Proxy:C:\path\to\some\file`,
+			wantToken: `C:\path\to\some\file`,
+			wantRoles: []types.SystemRole{
+				types.RoleAuth, types.RoleNode, types.RoleProxy,
+			},
+		},
+		{
+			desc:      "literal string",
+			input:     "Auth,Node,Proxy:some-literal-token",
+			wantToken: "some-literal-token",
+			wantRoles: []types.SystemRole{
+				types.RoleAuth, types.RoleNode, types.RoleProxy,
+			},
+		},
+		{
+			desc:      "reject bot role",
+			input:     "Bot:some-literal-token",
+			wantError: "role \"Bot\" is not allowed in static token configuration",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			staticToken := StaticToken("Auth,Node,Proxy:" + tt.token)
+			staticToken := StaticToken(tt.input)
 			provisionTokens, err := staticToken.Parse()
+			if tt.wantError != "" {
+				require.ErrorContains(t, err, tt.wantError)
+				return
+			}
 			require.NoError(t, err)
 
 			require.Len(t, provisionTokens, 1)
 			provisionToken := provisionTokens[0]
 
 			want := types.ProvisionTokenV1{
-				Roles: []types.SystemRole{
-					types.RoleAuth, types.RoleNode, types.RoleProxy,
-				},
-				Token:   tt.token,
+				Roles:   tt.wantRoles,
+				Token:   tt.wantToken,
 				Expires: provisionToken.Expires,
 			}
 			require.Equal(t, want, provisionToken)


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/45208

Rejects configuration of a "Bot" role static token in the auth server file config - this never actually worked but could produce confusing errors rather than a clear one. Since this is technically a breaking change, we'll have to leave this for v18.

Backport to v18 will switch the error for a logged warning.

changelog: Breaking - Teleport will now reject the configuration of a Bot role static token within the Auth Service file configuration (e.g. within `auth_service.tokens`)