### PR TITLE
Clean up LDAP packages

### DIFF
--- a/lib/auth/windows/ldap.go
+++ b/lib/auth/windows/ldap.go
@@ -79,61 +79,20 @@ func DomainDN(domain string) string {
 	return sb.String()
 }
 
-// See: https://docs.microsoft.com/en-US/windows/security/identity-protection/access-control/security-identifiers
 const (
-	// WritableDomainControllerGroupID is the windows security identifier for dcs with write permissions
-	WritableDomainControllerGroupID = "516"
-	// ReadOnlyDomainControllerGroupID is the windows security identifier for read only dcs
-	ReadOnlyDomainControllerGroupID = "521"
-)
-
-const (
-	// ClassComputer is the object class for computers in Active Directory
-	ClassComputer = "computer"
-	// ClassContainer is the object class for containers in Active Directory
-	ClassContainer = "container"
-	// ClassGMSA is the object class for group managed service accounts in Active Directory.
-	ClassGMSA = "msDS-GroupManagedServiceAccount"
-
-	// AccountTypeUser is the SAM account type for user accounts.
-	// See https://learn.microsoft.com/en-us/windows/win32/adschema/a-samaccounttype
-	// (SAM_USER_OBJECT)
-	AccountTypeUser = "805306368"
-
-	// AttrName is the name of an LDAP object
-	AttrName = "name"
-	// AttrSAMAccountName is the SAM Account name of an LDAP object
-	AttrSAMAccountName = "sAMAccountName"
-	// AttrSAMAccountType is the SAM Account type for an LDAP object
-	AttrSAMAccountType = "sAMAccountType"
-	// AttrCommonName is the common name of an LDAP object, or "CN"
-	AttrCommonName = "cn"
-	// AttrDistinguishedName is the distinguished name of an LDAP object, or "DN"
-	AttrDistinguishedName = "distinguishedName"
-	// AttrDNSHostName is the DNS Host name of an LDAP object
-	AttrDNSHostName = "dNSHostName" // unusual capitalization is correct
-	// AttrObjectGUID is the globally unique identifier for an LDAP object
-	AttrObjectGUID = "objectGUID"
-	// AttrOS is the operating system of a computer object
-	AttrOS = "operatingSystem"
-	// AttrOSVersion is the operating system version of a computer object
-	AttrOSVersion = "operatingSystemVersion"
-	// AttrPrimaryGroupID is the primary group id of an LDAP object
-	AttrPrimaryGroupID = "primaryGroupID"
 	// AttrObjectSid is the Security Identifier of an LDAP object
 	AttrObjectSid = "objectSid"
-	// AttrObjectCategory is the object category of an LDAP object
-	AttrObjectCategory = "objectCategory"
 	// AttrObjectClass is the object class of an LDAP object
 	AttrObjectClass = "objectClass"
 )
+
+// classContainer is the object class for containers in Active Directory
+const classContainer = "container"
 
 // searchPageSize is desired page size for LDAP search. In Active Directory the default search size limit is 1000 entries,
 // so in most cases the 1000 search page size will result in the optimal amount of requests made to
 // LDAP server.
 const searchPageSize = 1000
-
-// Note: if you want to browse LDAP on the Windows machine, run ADSIEdit.msc.
 
 // LDAPClient is a windows LDAP client.
 //
@@ -264,7 +223,7 @@ func (c *LDAPClient) Create(dn string, class string, attrs map[string][]string) 
 // CreateContainer creates an LDAP container entry if
 // it doesn't already exist.
 func (c *LDAPClient) CreateContainer(dn string) error {
-	err := c.Create(dn, ClassContainer, nil)
+	err := c.Create(dn, classContainer, nil)
 	// Ignore the error if container already exists.
 	if trace.IsAlreadyExists(err) {
 		return nil

--- a/lib/auth/windows/windows_test.go
+++ b/lib/auth/windows/windows_test.go
@@ -90,7 +90,7 @@ func TestGenerateCredentials(t *testing.T) {
 			certb, keyb, err := GenerateWindowsDesktopCredentials(ctx, &GenerateCredentialsRequest{
 				Username:           user,
 				Domain:             domain,
-				TTL:                CertTTL,
+				TTL:                5 * time.Minute,
 				ClusterName:        clusterName,
 				ActiveDirectorySID: test.activeDirectorySID,
 				AuthClient:         client,

--- a/lib/srv/desktop/discovery_test.go
+++ b/lib/srv/desktop/discovery_test.go
@@ -35,7 +35,6 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
-	"github.com/gravitational/teleport/lib/auth/windows"
 	"github.com/gravitational/teleport/lib/services"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
@@ -80,14 +79,14 @@ func TestDiscoveryLDAPFilter(t *testing.T) {
 func TestAppliesLDAPLabels(t *testing.T) {
 	l := make(map[string]string)
 	entry := ldap.NewEntry("CN=test,DC=example,DC=com", map[string][]string{
-		windows.AttrDNSHostName:       {"foo.example.com"},
-		windows.AttrName:              {"foo"},
-		windows.AttrOS:                {"Windows Server"},
-		windows.AttrOSVersion:         {"6.1"},
-		windows.AttrDistinguishedName: {"CN=foo,OU=IT,DC=goteleport,DC=com"},
-		windows.AttrCommonName:        {"foo"},
-		"bar":                         {"baz"},
-		"quux":                        {""},
+		attrDNSHostName:       {"foo.example.com"},
+		attrName:              {"foo"},
+		attrOS:                {"Windows Server"},
+		attrOSVersion:         {"6.1"},
+		attrDistinguishedName: {"CN=foo,OU=IT,DC=goteleport,DC=com"},
+		attrCommonName:        {"foo"},
+		"bar":                 {"baz"},
+		"quux":                {""},
 	})
 
 	s := &WindowsService{
@@ -122,21 +121,21 @@ func TestLabelsDomainControllers(t *testing.T) {
 		{
 			desc: "DC",
 			entry: ldap.NewEntry("CN=test,DC=example,DC=com", map[string][]string{
-				windows.AttrPrimaryGroupID: {windows.WritableDomainControllerGroupID},
+				attrPrimaryGroupID: {writableDomainControllerGroupID},
 			}),
 			assert: require.True,
 		},
 		{
 			desc: "RODC",
 			entry: ldap.NewEntry("CN=test,DC=example,DC=com", map[string][]string{
-				windows.AttrPrimaryGroupID: {windows.ReadOnlyDomainControllerGroupID},
+				attrPrimaryGroupID: {readOnlyDomainControllerGroupID},
 			}),
 			assert: require.True,
 		},
 		{
 			desc: "computer",
 			entry: ldap.NewEntry("CN=test,DC=example,DC=com", map[string][]string{
-				windows.AttrPrimaryGroupID: {"515"},
+				attrPrimaryGroupID: {"515"},
 			}),
 			assert: require.False,
 		},

--- a/lib/srv/desktop/windows_server_test.go
+++ b/lib/srv/desktop/windows_server_test.go
@@ -177,7 +177,7 @@ func TestGenerateCredentials(t *testing.T) {
 		certb, keyb, err := w.generateCredentials(ctx, generateCredentialsRequest{
 			username:           user,
 			domain:             domain,
-			ttl:                windows.CertTTL,
+			ttl:                windowsUserCertTTL,
 			activeDirectorySID: test.activeDirectorySID,
 		})
 		require.NoError(t, err)


### PR DESCRIPTION
When we originally broke some of the desktop access code out into a shared windows package to help with MS SQL access we pulled too much code. This commit just moves code that is only needed in one package to the package where it is used, and un-exports it.

No functional changes.