### PR TITLE
Exclude IronRDP artifacts from linting in both `teleport` and `shared` directories

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,6 +6,6 @@
 **/*_pb.*
 
 # Ignore WASM generated files:
-web/packages/teleport/src/ironrdp/pkg
+**/ironrdp/pkg/**
 # Ignore generated mockServiceWorker file
 web/.storybook/public/mockServiceWorker.js

--- a/web/packages/build/eslint.config.mjs
+++ b/web/packages/build/eslint.config.mjs
@@ -34,7 +34,7 @@ export default tseslint.config(
       '.prettierrc.js',
       '**/tshd/**/*_pb.js',
       // WASM generated files
-      'web/packages/teleport/src/ironrdp/pkg',
+      '**/ironrdp/pkg/**',
       'web/packages/teleterm/build',
     ],
   },


### PR DESCRIPTION
In the next PR, I will be moving `ironrdp` from `teleport` to the `shared` package. Unfortunately, this won't automatically move the build artifacts from the old location to the new one, as those are gitignored. As a result, we will need to remove the previous artifacts on our own. I'll add a script to do this automatically in `build-wasm` package.json script.

Despite these efforts, there might still be issues for users switching branches during the period between merging the subsequent PR into master and backporting it. If artifacts are present locally in both locations, Prettier and ESLint will fail because artifacts under the `shared` path won’t be ignored. To prevent this issue, I will first merge this PR, backport it to all release branches, and then proceed with merging the subsequent PR.