### PR TITLE
[v16] Clean up LDAP packages

### DIFF
--- a/lib/auth/windows/ldap.go
+++ b/lib/auth/windows/ldap.go
@@ -79,61 +79,20 @@ func DomainDN(domain string) string {
 	return sb.String()
 }
 
-// See: https://docs.microsoft.com/en-US/windows/security/identity-protection/access-control/security-identifiers
 const (
-	// WritableDomainControllerGroupID is the windows security identifier for dcs with write permissions
-	WritableDomainControllerGroupID = "516"
-	// ReadOnlyDomainControllerGroupID is the windows security identifier for read only dcs
-	ReadOnlyDomainControllerGroupID = "521"
-)
-
-const (
-	// ClassComputer is the object class for computers in Active Directory
-	ClassComputer = "computer"
-	// ClassContainer is the object class for containers in Active Directory
-	ClassContainer = "container"
-	// ClassGMSA is the object class for group managed service accounts in Active Directory.
-	ClassGMSA = "msDS-GroupManagedServiceAccount"
-
-	// AccountTypeUser is the SAM account type for user accounts.
-	// See https://learn.microsoft.com/en-us/windows/win32/adschema/a-samaccounttype
-	// (SAM_USER_OBJECT)
-	AccountTypeUser = "805306368"
-
-	// AttrName is the name of an LDAP object
-	AttrName = "name"
-	// AttrSAMAccountName is the SAM Account name of an LDAP object
-	AttrSAMAccountName = "sAMAccountName"
-	// AttrSAMAccountType is the SAM Account type for an LDAP object
-	AttrSAMAccountType = "sAMAccountType"
-	// AttrCommonName is the common name of an LDAP object, or "CN"
-	AttrCommonName = "cn"
-	// AttrDistinguishedName is the distinguished name of an LDAP object, or "DN"
-	AttrDistinguishedName = "distinguishedName"
-	// AttrDNSHostName is the DNS Host name of an LDAP object
-	AttrDNSHostName = "dNSHostName" // unusual capitalization is correct
-	// AttrObjectGUID is the globally unique identifier for an LDAP object
-	AttrObjectGUID = "objectGUID"
-	// AttrOS is the operating system of a computer object
-	AttrOS = "operatingSystem"
-	// AttrOSVersion is the operating system version of a computer object
-	AttrOSVersion = "operatingSystemVersion"
-	// AttrPrimaryGroupID is the primary group id of an LDAP object
-	AttrPrimaryGroupID = "primaryGroupID"
 	// AttrObjectSid is the Security Identifier of an LDAP object
 	AttrObjectSid = "objectSid"
-	// AttrObjectCategory is the object category of an LDAP object
-	AttrObjectCategory = "objectCategory"
 	// AttrObjectClass is the object class of an LDAP object
 	AttrObjectClass = "objectClass"
 )
+
+// classContainer is the object class for containers in Active Directory
+const classContainer = "container"
 
 // searchPageSize is desired page size for LDAP search. In Active Directory the default search size limit is 1000 entries,
 // so in most cases the 1000 search page size will result in the optimal amount of requests made to
 // LDAP server.
 const searchPageSize = 1000
-
-// Note: if you want to browse LDAP on the Windows machine, run ADSIEdit.msc.
 
 // LDAPClient is a windows LDAP client.
 //
@@ -264,7 +223,7 @@ func (c *LDAPClient) Create(dn string, class string, attrs map[string][]string) 
 // CreateContainer creates an LDAP container entry if
 // it doesn't already exist.
 func (c *LDAPClient) CreateContainer(dn string) error {
-	err := c.Create(dn, ClassContainer, nil)
+	err := c.Create(dn, classContainer, nil)
 	// Ignore the error if container already exists.
 	if trace.IsAlreadyExists(err) {
 		return nil

--- a/lib/auth/windows/windows.go
+++ b/lib/auth/windows/windows.go
@@ -39,14 +39,6 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
-const (
-	// CertTTL is the TTL for Teleport-issued Windows Certificates.
-	// Certificates are requested on each connection attempt, so the TTL is
-	// deliberately set to a small value to give enough time to establish a
-	// single desktop session.
-	CertTTL = 5 * time.Minute
-)
-
 type certRequest struct {
 	csrPEM      []byte
 	crlEndpoint string
@@ -353,29 +345,30 @@ func SubjectAltNameExtension(user, domain string) (pkix.Extension, error) {
 }
 
 // Types for ASN.1 SAN serialization.
+type (
+	// SubjectAltName is a struct that can be marshaled as ASN.1
+	// into the SAN field in an x.509 certificate.
+	//
+	// See RFC 3280: https://www.ietf.org/rfc/rfc3280.txt
+	//
+	// T is the ASN.1 encodeable struct corresponding to an otherName
+	// item of the GeneralNames sequence.
+	SubjectAltName[T any] struct {
+		OtherName otherName[T] `asn1:"tag:0"`
+	}
 
-// SubjectAltName is a struct that can be marshaled as ASN.1
-// into the SAN field in an x.509 certificate.
-//
-// See RFC 3280: https://www.ietf.org/rfc/rfc3280.txt
-//
-// T is the ASN.1 encodeable struct corresponding to an otherName
-// item of the GeneralNames sequence.
-type SubjectAltName[T any] struct {
-	OtherName otherName[T] `asn1:"tag:0"`
-}
+	otherName[T any] struct {
+		OID   asn1.ObjectIdentifier
+		Value T `asn1:"tag:0"`
+	}
 
-type otherName[T any] struct {
-	OID   asn1.ObjectIdentifier
-	Value T `asn1:"tag:0"`
-}
+	upn struct {
+		Value string `asn1:"utf8"`
+	}
 
-type upn struct {
-	Value string `asn1:"utf8"`
-}
-
-type adSid struct {
-	// Value is the bytes representation of the user's SID string,
-	// e.g. []byte("S-1-5-21-1329593140-2634913955-1900852804-500")
-	Value []byte // Gets encoded as an asn1 octet string
-}
+	adSid struct {
+		// Value is the bytes representation of the user's SID string,
+		// e.g. []byte("S-1-5-21-1329593140-2634913955-1900852804-500")
+		Value []byte // Gets encoded as an asn1 octet string
+	}
+)

--- a/lib/auth/windows/windows_test.go
+++ b/lib/auth/windows/windows_test.go
@@ -90,7 +90,7 @@ func TestGenerateCredentials(t *testing.T) {
 			certb, keyb, err := GenerateWindowsDesktopCredentials(ctx, &GenerateCredentialsRequest{
 				Username:           user,
 				Domain:             domain,
-				TTL:                CertTTL,
+				TTL:                5 * time.Minute,
 				ClusterName:        clusterName,
 				ActiveDirectorySID: test.activeDirectorySID,
 				AuthClient:         client,

--- a/lib/srv/desktop/discovery.go
+++ b/lib/srv/desktop/discovery.go
@@ -40,6 +40,59 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
+const (
+	// attrName is the name of an LDAP object.
+	attrName = "name"
+
+	// attrCommonName is the common name of an LDAP object, or "CN".
+	attrCommonName = "cn"
+
+	// attrObjectGUID is the globally unique identifier for an LDAP object.
+	attrObjectGUID = "objectGUID"
+
+	// attrDistinguishedName is the distinguished name of an LDAP object, or "DN".
+	attrDistinguishedName = "distinguishedName"
+
+	// attrPrimaryGroupID is the primary group ID of an LDAP object.
+	attrPrimaryGroupID = "primaryGroupID"
+
+	// attrOS is the operating system of a computer object
+	attrOS = "operatingSystem"
+
+	// attrOSVersion is the operating system version of a computer object.
+	attrOSVersion = "operatingSystemVersion"
+
+	// attrDNSHostName is the DNS Host name of an LDAP object.
+	attrDNSHostName = "dNSHostName" // unusual capitalization is correct
+
+	// attrSAMAccountName is the SAM Account name of an LDAP object.
+	attrSAMAccountName = "sAMAccountName"
+
+	// attrSAMAccountType is the SAM Account type for an LDAP object.
+	attrSAMAccountType = "sAMAccountType"
+)
+
+const (
+	// AccountTypeUser is the SAM account type for user accounts.
+	// See https://learn.microsoft.com/en-us/windows/win32/adschema/a-samaccounttype
+	// (SAM_USER_OBJECT)
+	AccountTypeUser = "805306368"
+
+	// ClassComputer is the object class for computers in Active Directory.
+	ClassComputer = "computer"
+
+	// ClassGMSA is the object class for group managed service accounts in Active Directory.
+	ClassGMSA = "msDS-GroupManagedServiceAccount"
+)
+
+// See: https://docs.microsoft.com/en-US/windows/security/identity-protection/access-control/security-identifiers
+const (
+	// writableDomainControllerGroupID is the windows security identifier for dcs with write permissions
+	writableDomainControllerGroupID = "516"
+	// readOnlyDomainControllerGroupID is the windows security identifier for read only dcs
+	readOnlyDomainControllerGroupID = "521"
+)
+
 // startDesktopDiscovery starts fetching desktops from LDAP, periodically
 // registering and unregistering them as necessary.
 func (s *WindowsService) startDesktopDiscovery() error {
@@ -88,8 +141,8 @@ func (s *WindowsService) startDesktopDiscovery() error {
 
 func (s *WindowsService) ldapSearchFilter() string {
 	var filters []string
-	filters = append(filters, fmt.Sprintf("(%s=%s)", windows.AttrObjectClass, windows.ClassComputer))
-	filters = append(filters, fmt.Sprintf("(!(%s=%s))", windows.AttrObjectClass, windows.ClassGMSA))
+	filters = append(filters, fmt.Sprintf("(%s=%s)", windows.AttrObjectClass, ClassComputer))
+	filters = append(filters, fmt.Sprintf("(!(%s=%s))", windows.AttrObjectClass, ClassGMSA))
 	filters = append(filters, s.cfg.DiscoveryLDAPFilters...)
 
 	return windows.CombineLDAPFilters(filters)
@@ -111,7 +164,7 @@ func (s *WindowsService) getDesktopsFromLDAP() map[string]types.WindowsDesktop {
 	s.cfg.Logger.DebugContext(context.Background(), "searching for desktops", "filter", filter)
 
 	var attrs []string
-	attrs = append(attrs, ComputerAttributes...)
+	attrs = append(attrs, computerAttributes...)
 	attrs = append(attrs, s.cfg.DiscoveryLDAPAttributeLabels...)
 
 	entries, err := s.lc.ReadWithFilter(s.cfg.DiscoveryBaseDN, filter, attrs)
@@ -163,22 +216,22 @@ func (s *WindowsService) deleteDesktop(ctx context.Context, d types.WindowsDeskt
 func (s *WindowsService) applyLabelsFromLDAP(entry *ldap.Entry, labels map[string]string) {
 	// apply common LDAP labels by default
 	labels[types.OriginLabel] = types.OriginDynamic
-	labels[types.DiscoveryLabelWindowsDNSHostName] = entry.GetAttributeValue(windows.AttrDNSHostName)
-	labels[types.DiscoveryLabelWindowsComputerName] = entry.GetAttributeValue(windows.AttrName)
-	labels[types.DiscoveryLabelWindowsOS] = entry.GetAttributeValue(windows.AttrOS)
-	labels[types.DiscoveryLabelWindowsOSVersion] = entry.GetAttributeValue(windows.AttrOSVersion)
+	labels[types.DiscoveryLabelWindowsDNSHostName] = entry.GetAttributeValue(attrDNSHostName)
+	labels[types.DiscoveryLabelWindowsComputerName] = entry.GetAttributeValue(attrName)
+	labels[types.DiscoveryLabelWindowsOS] = entry.GetAttributeValue(attrOS)
+	labels[types.DiscoveryLabelWindowsOSVersion] = entry.GetAttributeValue(attrOSVersion)
 
 	// attempt to compute the desktop's OU from its DN
-	dn := entry.GetAttributeValue(windows.AttrDistinguishedName)
-	cn := entry.GetAttributeValue(windows.AttrCommonName)
+	dn := entry.GetAttributeValue(attrDistinguishedName)
+	cn := entry.GetAttributeValue(attrCommonName)
 	if len(dn) > 0 && len(cn) > 0 {
 		ou := strings.TrimPrefix(dn, "CN="+cn+",")
 		labels[types.DiscoveryLabelWindowsOU] = ou
 	}
 
 	// label domain controllers
-	switch entry.GetAttributeValue(windows.AttrPrimaryGroupID) {
-	case windows.WritableDomainControllerGroupID, windows.ReadOnlyDomainControllerGroupID:
+	switch entry.GetAttributeValue(attrPrimaryGroupID) {
+	case writableDomainControllerGroupID, readOnlyDomainControllerGroupID:
 		labels[types.DiscoveryLabelWindowsIsDomainController] = "true"
 	}
 
@@ -258,7 +311,7 @@ func (s *WindowsService) ldapEntryToWindowsDesktop(
 	entry *ldap.Entry,
 	getHostLabels func(string) map[string]string,
 ) (types.WindowsDesktop, error) {
-	hostname := entry.GetAttributeValue(windows.AttrDNSHostName)
+	hostname := entry.GetAttributeValue(attrDNSHostName)
 	if hostname == "" {
 		attrs := make([]string, len(entry.Attributes))
 		for _, a := range entry.Attributes {
@@ -292,7 +345,7 @@ func (s *WindowsService) ldapEntryToWindowsDesktop(
 
 	// append portion of the object GUID to ensure that desktops from
 	// different domains that happen to have the same hostname don't conflict
-	if guid := entry.GetRawAttributeValue(windows.AttrObjectGUID); len(guid) >= 4 {
+	if guid := entry.GetRawAttributeValue(attrObjectGUID); len(guid) >= 4 {
 		name += "-" + hex.EncodeToString(guid[:4])
 	}
 

--- a/lib/srv/desktop/discovery_test.go
+++ b/lib/srv/desktop/discovery_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth/windows"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
@@ -77,14 +76,14 @@ func TestDiscoveryLDAPFilter(t *testing.T) {
 func TestAppliesLDAPLabels(t *testing.T) {
 	l := make(map[string]string)
 	entry := ldap.NewEntry("CN=test,DC=example,DC=com", map[string][]string{
-		windows.AttrDNSHostName:       {"foo.example.com"},
-		windows.AttrName:              {"foo"},
-		windows.AttrOS:                {"Windows Server"},
-		windows.AttrOSVersion:         {"6.1"},
-		windows.AttrDistinguishedName: {"CN=foo,OU=IT,DC=goteleport,DC=com"},
-		windows.AttrCommonName:        {"foo"},
-		"bar":                         {"baz"},
-		"quux":                        {""},
+		attrDNSHostName:       {"foo.example.com"},
+		attrName:              {"foo"},
+		attrOS:                {"Windows Server"},
+		attrOSVersion:         {"6.1"},
+		attrDistinguishedName: {"CN=foo,OU=IT,DC=goteleport,DC=com"},
+		attrCommonName:        {"foo"},
+		"bar":                 {"baz"},
+		"quux":                {""},
 	})
 
 	s := &WindowsService{
@@ -119,21 +118,21 @@ func TestLabelsDomainControllers(t *testing.T) {
 		{
 			desc: "DC",
 			entry: ldap.NewEntry("CN=test,DC=example,DC=com", map[string][]string{
-				windows.AttrPrimaryGroupID: {windows.WritableDomainControllerGroupID},
+				attrPrimaryGroupID: {writableDomainControllerGroupID},
 			}),
 			assert: require.True,
 		},
 		{
 			desc: "RODC",
 			entry: ldap.NewEntry("CN=test,DC=example,DC=com", map[string][]string{
-				windows.AttrPrimaryGroupID: {windows.ReadOnlyDomainControllerGroupID},
+				attrPrimaryGroupID: {readOnlyDomainControllerGroupID},
 			}),
 			assert: require.True,
 		},
 		{
 			desc: "computer",
 			entry: ldap.NewEntry("CN=test,DC=example,DC=com", map[string][]string{
-				windows.AttrPrimaryGroupID: {"515"},
+				attrPrimaryGroupID: {"515"},
 			}),
 			assert: require.False,
 		},

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -83,6 +83,12 @@ const (
 	// a restrictive service account.
 	windowsDesktopServiceCertTTL = 8 * time.Hour
 
+	// windowsUserCertTTL is the TTL for certificates issued to users connecting
+	// to Windows hosts. These certicates are generated on-demand for each session,
+	// so the TTL is deliberately set to a small value to give enough time to establish
+	// a single session.
+	windowsUserCertTTL = 5 * time.Minute
+
 	// windowsDesktopServiceCertRetryInterval indicates how often to retry
 	// issuing an LDAP certificate if the operation fails.
 	windowsDesktopServiceCertRetryInterval = 10 * time.Minute
@@ -93,18 +99,18 @@ const (
 	ldapTimeoutRetryInterval = 10 * time.Second
 )
 
-// ComputerAttributes are the attributes we fetch when discovering
+// computerAttributes are the attributes we fetch when discovering
 // Windows hosts via LDAP
 // see: https://docs.microsoft.com/en-us/windows/win32/adschema/c-computer#windows-server-2012-attributes
-var ComputerAttributes = []string{
-	windows.AttrName,
-	windows.AttrCommonName,
-	windows.AttrDistinguishedName,
-	windows.AttrDNSHostName,
-	windows.AttrObjectGUID,
-	windows.AttrOS,
-	windows.AttrOSVersion,
-	windows.AttrPrimaryGroupID,
+var computerAttributes = []string{
+	attrName,
+	attrCommonName,
+	attrDistinguishedName,
+	attrDNSHostName,
+	attrObjectGUID,
+	attrOS,
+	attrOSVersion,
+	attrPrimaryGroupID,
 }
 
 // WindowsService implements the RDP-based Windows desktop access service.
@@ -952,7 +958,7 @@ func (s *WindowsService) connectRDP(ctx context.Context, log *slog.Logger, tdpCo
 		GenerateUserCert: func(ctx context.Context, username string, ttl time.Duration) (certDER, keyDER []byte, err error) {
 			return s.generateUserCert(ctx, username, ttl, desktop, createUsers, groups)
 		},
-		CertTTL:               windows.CertTTL,
+		CertTTL:               windowsUserCertTTL,
 		Addr:                  addr.String(),
 		ComputerName:          computerName,
 		KDCAddr:               kdcAddr,
@@ -1269,8 +1275,8 @@ func (s *WindowsService) generateUserCert(ctx context.Context, username string, 
 	if !desktop.NonAD() {
 		// Find the user's SID
 		filter := windows.CombineLDAPFilters([]string{
-			fmt.Sprintf("(%s=%s)", windows.AttrSAMAccountType, windows.AccountTypeUser),
-			fmt.Sprintf("(%s=%s)", windows.AttrSAMAccountName, username),
+			fmt.Sprintf("(%s=%s)", attrSAMAccountType, AccountTypeUser),
+			fmt.Sprintf("(%s=%s)", attrSAMAccountName, username),
 		})
 		s.cfg.Logger.DebugContext(ctx, "querying LDAP for objectSid of Windows user", "username", username, "filter", filter)
 		domainDN := windows.DomainDN(s.cfg.LDAPConfig.Domain)

--- a/lib/srv/desktop/windows_server_test.go
+++ b/lib/srv/desktop/windows_server_test.go
@@ -177,7 +177,7 @@ func TestGenerateCredentials(t *testing.T) {
 		certb, keyb, err := w.generateCredentials(ctx, generateCredentialsRequest{
 			username:           user,
 			domain:             domain,
-			ttl:                windows.CertTTL,
+			ttl:                windowsUserCertTTL,
 			activeDirectorySID: test.activeDirectorySID,
 		})
 		require.NoError(t, err)


### PR DESCRIPTION
When we originally broke some of the desktop access code out into a shared windows package to help with MS SQL access we pulled too much code. This commit just moves code that is only needed in one package to the package where it is used, and un-exports it.

No functional changes.

Backports #53497 