### PR TITLE
Fix login/logout for a specific user+proxy.

### DIFF
--- a/api/utils/keys/piv/yubikey.go
+++ b/api/utils/keys/piv/yubikey.go
@@ -77,9 +77,9 @@ func FindYubiKey(serialNumber uint32) (*YubiKey, error) {
 
 	if len(yubiKeyCards) == 0 {
 		if serialNumber != 0 {
-			return nil, trace.ConnectionProblem(nil, "no YubiKey device connected with serial number %d", serialNumber)
+			return nil, trace.NotFound("no YubiKey device connected with serial number %d", serialNumber)
 		}
-		return nil, trace.ConnectionProblem(nil, "no YubiKey device connected")
+		return nil, trace.NotFound("no YubiKey device connected")
 	}
 
 	for _, card := range yubiKeyCards {
@@ -93,7 +93,7 @@ func FindYubiKey(serialNumber uint32) (*YubiKey, error) {
 		}
 	}
 
-	return nil, trace.ConnectionProblem(nil, "no YubiKey device connected with serial number %d", serialNumber)
+	return nil, trace.NotFound("no YubiKey device connected with serial number %d", serialNumber)
 }
 
 // pivCardTypeYubiKey is the PIV card type assigned to yubiKeys.

--- a/lib/client/client_store.go
+++ b/lib/client/client_store.go
@@ -316,6 +316,10 @@ func (s *Store) FullProfileStatus() (*ProfileStatus, []*ProfileStatus, error) {
 		profiles = append(profiles, status)
 	}
 
+	if currentProfile == nil && len(profiles) == 0 {
+		return nil, nil, trace.NotFound("no active profiles")
+	}
+
 	return currentProfile, profiles, nil
 }
 

--- a/lib/client/client_store.go
+++ b/lib/client/client_store.go
@@ -23,8 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net/url"
-	"time"
 
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
@@ -267,27 +265,6 @@ func (s *Store) ReadProfileStatus(profileName string) (*ProfileStatus, error) {
 	}
 	keyRing, err := s.GetKeyRing(idx, WithAllCerts...)
 	if err != nil {
-		if trace.IsNotFound(err) || trace.IsConnectionProblem(err) {
-			// If we can't find a keyRing to match the profile, or can't connect to
-			// the keyRing (hardware key), return a partial status. This is used for
-			// some superficial functions `tsh logout` and `tsh status`.
-			return &ProfileStatus{
-				Name: profileName,
-				Dir:  profile.Dir,
-				ProxyURL: url.URL{
-					Scheme: "https",
-					Host:   profile.WebProxyAddr,
-				},
-				Username:    profile.Username,
-				Cluster:     profile.SiteName,
-				KubeEnabled: profile.KubeProxyAddr != "",
-				// Set ValidUntil to now and GetKeyRingError to show that the keys are not available.
-				ValidUntil:              time.Now(),
-				GetKeyRingError:         err,
-				SAMLSingleLogoutEnabled: profile.SAMLSingleLogoutEnabled,
-				SSOHost:                 profile.SSOHost,
-			}, nil
-		}
 		return nil, trace.Wrap(err)
 	}
 
@@ -312,13 +289,8 @@ func (s *Store) ReadProfileStatus(profileName string) (*ProfileStatus, error) {
 // FullProfileStatus returns the name of the current profile with a
 // a list of all profile statuses.
 func (s *Store) FullProfileStatus() (*ProfileStatus, []*ProfileStatus, error) {
-	currentProfileName, err := s.CurrentProfile()
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-
-	currentProfile, err := s.ReadProfileStatus(currentProfileName)
-	if err != nil {
+	currentProfile, err := s.currentProfileStatus()
+	if err != nil && !trace.IsNotFound(err) {
 		return nil, nil, trace.Wrap(err)
 	}
 
@@ -329,7 +301,7 @@ func (s *Store) FullProfileStatus() (*ProfileStatus, []*ProfileStatus, error) {
 
 	var profiles []*ProfileStatus
 	for _, profileName := range profileNames {
-		if profileName == currentProfileName {
+		if currentProfile != nil && profileName == currentProfile.Name {
 			// already loaded this one
 			continue
 		}
@@ -345,6 +317,15 @@ func (s *Store) FullProfileStatus() (*ProfileStatus, []*ProfileStatus, error) {
 	}
 
 	return currentProfile, profiles, nil
+}
+
+func (s *Store) currentProfileStatus() (*ProfileStatus, error) {
+	currentProfileName, err := s.CurrentProfile()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return s.ReadProfileStatus(currentProfileName)
 }
 
 // LoadKeysToKubeFromStore loads the keys for a given teleport cluster and kube cluster from the store.

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -5496,7 +5496,7 @@ func onStatus(cf *CLIConf) error {
 	}
 
 	if profile == nil {
-		return trace.NotFound("Not logged in.")
+		return trace.NotFound("No active profile.")
 	}
 
 	duration := time.Until(profile.ValidUntil)


### PR DESCRIPTION
Changelog: Improve UX for `tsh` when managing multiple login profiles.

Changes:
- Restore old behavior that allows you to `tsh login --proxy=... --user=...` to switch between active profiles (proxies)
  - Note that switching between users on a given proxy is not working properly. We'd likely need to introduce separate profile files for every logged in user, or otherwise gather missing profile info when switching users.
- Fix `tsh status` output after using `tsh logout --proxy=... --user=...` to log out of a specific profile.

```
$ tsh status
> Profile URL:        https://root.example.com:3080
  Logged in as:       dev
  Cluster:            root.example.com
  Roles:              dev
  Logins:             bjoerger, root, pam, dev, ubuntu
  Kubernetes:         enabled
  Kubernetes users:   USER
  Kubernetes groups:  viewers
  Valid until:        2025-03-28 00:16:35 -0700 PDT [valid for 8h0m0s]
  Extensions:         login-ip, permit-X11-forwarding, permit-agent-forwarding, permit-port-forwarding, permit-pty, private-key-policy

  Profile URL:        https://leaf.example.com:5080
  Logged in as:       dev
  Cluster:            leaf.example.com
  Roles:              dev
  Logins:             bjoerger, root, pam, dev, ubuntu
  Kubernetes:         enabled
  Kubernetes users:   USER
  Kubernetes groups:  viewers
  Valid until:        2025-03-27 23:37:49 -0700 PDT [valid for 7h21m0s]
  Extensions:         login-ip, permit-X11-forwarding, permit-agent-forwarding, permit-port-forwarding, permit-pty, private-key-policy

$ tsh login --proxy=leaf.example.com:5080 --user=dev
> Profile URL:        https://leaf.example.com:5080
  Logged in as:       dev
  Cluster:            leaf.example.com
  Roles:              dev
  Logins:             bjoerger, root, pam, dev, ubuntu
  Kubernetes:         enabled
  Kubernetes users:   USER
  Kubernetes groups:  viewers
  Valid until:        2025-03-27 23:37:49 -0700 PDT [valid for 7h21m0s]
  Extensions:         login-ip, permit-X11-forwarding, permit-agent-forwarding, permit-port-forwarding, permit-pty, private-key-policy

  Profile URL:        https://root.example.com:3080
  Logged in as:       dev
  Cluster:            root.example.com
  Roles:              dev
  Logins:             bjoerger, root, pam, dev, ubuntu
  Kubernetes:         enabled
  Kubernetes users:   USER
  Kubernetes groups:  viewers
  Valid until:        2025-03-28 00:16:35 -0700 PDT [valid for 7h59m0s]
  Extensions:         login-ip, permit-X11-forwarding, permit-agent-forwarding, permit-port-forwarding, permit-pty, private-key-policy

$ tsh logout --proxy=leaf.example.com:5080 --user=dev
Logged out dev from leaf.example.com.

$ tsh status
  Profile URL:        https://root.example.com:3080
  Logged in as:       dev
  Cluster:            root.example.com
  Roles:              dev
  Logins:             bjoerger, root, pam, dev, ubuntu
  Kubernetes:         enabled
  Kubernetes users:   USER
  Kubernetes groups:  viewers
  Valid until:        2025-03-28 00:16:35 -0700 PDT [valid for 7h59m0s]
  Extensions:         login-ip, permit-X11-forwarding, permit-agent-forwarding, permit-port-forwarding, permit-pty, private-key-policy

ERROR: No active profile.
```

Fixes https://github.com/gravitational/teleport/issues/26860

Related https://github.com/gravitational/teleport/issues/50721

TODO:
- Fix https://github.com/gravitational/teleport/issues/50721
- Fix switching between users and/or clusters for the same proxy
- Manual testing