### PR TITLE
[v17] Change GitHub SSHA CA sig algo for legacy to be compatible with KMS

### DIFF
--- a/lib/cryptosuites/suites.go
+++ b/lib/cryptosuites/suites.go
@@ -176,6 +176,7 @@ var (
 		SPIFFECATLS:             RSA2048,
 		SPIFFECAJWT:             RSA2048,
 		OktaCAJWT:               ECDSAP256,
+		GitHubProxyCASSH:        ECDSAP256,
 		UserSSH:                 RSA2048,
 		UserTLS:                 RSA2048,
 		DatabaseClient:          RSA2048,
@@ -191,14 +192,11 @@ var (
 		ProxyKubeClient:      RSA2048,
 		// EC2InstanceConnect has always used Ed25519 by default.
 		EC2InstanceConnect: Ed25519,
-		// Use ECDSAP256 for KMS compatibility while avoiding RSA2048.
-		GitHubProxyCASSH: ECDSAP256,
-		GitClient:        Ed25519,
+		GitClient:          Ed25519,
 	}
 
 	// balancedV1 strikes a balance between security, compatibility, and
-	// performance. It uses ECDSA256, Ed25591, and 2048-bit RSA. It is not
-	// completely implemented yet.
+	// performance. It uses ECDSA256, Ed25591, and 2048-bit RSA.
 	balancedV1 = suite{
 		UserCATLS:               ECDSAP256,
 		UserCASSH:               Ed25519,
@@ -213,6 +211,7 @@ var (
 		SPIFFECATLS:             ECDSAP256,
 		SPIFFECAJWT:             RSA2048,
 		OktaCAJWT:               ECDSAP256,
+		GitHubProxyCASSH:        Ed25519,
 		UserSSH:                 Ed25519,
 		UserTLS:                 ECDSAP256,
 		DatabaseClient:          RSA2048,
@@ -224,13 +223,12 @@ var (
 		ProxyToDatabaseAgent:    ECDSAP256,
 		ProxyKubeClient:         ECDSAP256,
 		EC2InstanceConnect:      Ed25519,
-		GitHubProxyCASSH:        ECDSAP256,
 		GitClient:               Ed25519,
 	}
 
 	// fipsv1 is an algorithm suite tailored for FIPS compliance. It is based on
 	// the balancedv1 suite but replaces all instances of Ed25519 with ECDSA on
-	// the NIST P256 curve. It is not completely implemented yet.
+	// the NIST P256 curve.
 	fipsv1 = suite{
 		UserCATLS:               ECDSAP256,
 		UserCASSH:               ECDSAP256,
@@ -245,6 +243,7 @@ var (
 		SPIFFECATLS:             ECDSAP256,
 		SPIFFECAJWT:             RSA2048,
 		OktaCAJWT:               ECDSAP256,
+		GitHubProxyCASSH:        ECDSAP256,
 		UserSSH:                 ECDSAP256,
 		UserTLS:                 ECDSAP256,
 		DatabaseClient:          RSA2048,
@@ -256,7 +255,6 @@ var (
 		ProxyToDatabaseAgent:    ECDSAP256,
 		ProxyKubeClient:         ECDSAP256,
 		EC2InstanceConnect:      ECDSAP256,
-		GitHubProxyCASSH:        ECDSAP256,
 		GitClient:               ECDSAP256,
 	}
 
@@ -264,7 +262,7 @@ var (
 	// service to back CA private material.  It is based on the balancedv1 suite
 	// but replaces Ed25519 with ECDSA on the NIST P256 curve *for CA keys
 	// only*. It is also valid to use the legacy or fipsv1 suites if your
-	// cluster uses an HSM or KMS. It is not completely implemented yet.
+	// cluster uses an HSM or KMS.
 	hsmv1 = suite{
 		UserCATLS:               ECDSAP256,
 		UserCASSH:               ECDSAP256,
@@ -279,6 +277,7 @@ var (
 		SPIFFECATLS:             ECDSAP256,
 		SPIFFECAJWT:             RSA2048,
 		OktaCAJWT:               ECDSAP256,
+		GitHubProxyCASSH:        ECDSAP256,
 		UserSSH:                 Ed25519,
 		UserTLS:                 ECDSAP256,
 		DatabaseClient:          RSA2048,
@@ -290,7 +289,6 @@ var (
 		ProxyToDatabaseAgent:    ECDSAP256,
 		ProxyKubeClient:         ECDSAP256,
 		EC2InstanceConnect:      Ed25519,
-		GitHubProxyCASSH:        ECDSAP256,
 		GitClient:               Ed25519,
 	}
 

--- a/lib/cryptosuites/suites.go
+++ b/lib/cryptosuites/suites.go
@@ -191,8 +191,9 @@ var (
 		ProxyKubeClient:      RSA2048,
 		// EC2InstanceConnect has always used Ed25519 by default.
 		EC2InstanceConnect: Ed25519,
-		GitHubProxyCASSH:   Ed25519,
-		GitClient:          Ed25519,
+		// Use ECDSAP256 for KMS compatibility while avoiding RSA2048.
+		GitHubProxyCASSH: ECDSAP256,
+		GitClient:        Ed25519,
 	}
 
 	// balancedV1 strikes a balance between security, compatibility, and
@@ -223,7 +224,7 @@ var (
 		ProxyToDatabaseAgent:    ECDSAP256,
 		ProxyKubeClient:         ECDSAP256,
 		EC2InstanceConnect:      Ed25519,
-		GitHubProxyCASSH:        Ed25519,
+		GitHubProxyCASSH:        ECDSAP256,
 		GitClient:               Ed25519,
 	}
 


### PR DESCRIPTION
Backport #53444 to branch/v17