### PR TITLE
[v17] Exclude IronRDP artifacts from linting in both `teleport` and `shared` directories

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,6 +2,6 @@
 .eslintrc.js
 
 # Ignore WASM generated files:
-web/packages/teleport/src/ironrdp/pkg
+**/ironrdp/pkg/**
 
 web/packages/teleterm/build

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,6 +6,6 @@
 **/*_pb.*
 
 # Ignore WASM generated files:
-web/packages/teleport/src/ironrdp/pkg
+**/ironrdp/pkg/**
 # Ignore generated mockServiceWorker file
 web/.storybook/public/mockServiceWorker.js


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/53500 to branch/v17