### PR TITLE
Add RoleEditorVisualizer to Role Editor

### DIFF
--- a/web/packages/teleport/src/Roles/PolicyPlaceholder.tsx
+++ b/web/packages/teleport/src/Roles/PolicyPlaceholder.tsx
@@ -18,8 +18,8 @@
 
 import { useTheme } from 'styled-components';
 
-import { Box, Flex } from 'design';
-import { ButtonSecondary } from 'design/Button';
+import { Alert, Box, Flex } from 'design';
+import { ButtonPrimary, ButtonSecondary } from 'design/Button';
 import { FeatureName } from 'design/constants';
 import { ChevronLeft, ChevronRight } from 'design/Icon';
 import Image from 'design/Image';
@@ -32,6 +32,7 @@ import cfg from 'teleport/config';
 
 import accessGraphPromoDark from './access-graph-promo-dark.png';
 import accessGraphPromoLight from './access-graph-promo-light.png';
+import { RoleDiffProps, RoleDiffState } from './Roles';
 
 const promoImageWidth = 782;
 const promoImages: Record<Theme['type'], string> = {
@@ -46,12 +47,23 @@ const promoFlows = {
 
 export function PolicyPlaceholder({
   currentFlow,
+  enableDemoMode,
+  roleDiffProps,
 }: {
   currentFlow: 'creating' | 'updating';
+  enableDemoMode?: () => void;
+  roleDiffProps?: RoleDiffProps;
 }) {
   const theme = useTheme();
+  const loading =
+    roleDiffProps?.roleDiffState === RoleDiffState.LoadingSettings ||
+    roleDiffProps?.roleDiffState === RoleDiffState.WaitingForSync;
+
   return (
     <Box maxWidth={promoImageWidth + 2 * 2} minWidth={300}>
+      {roleDiffProps?.roleDiffErrorMessage && (
+        <Alert>{roleDiffProps.roleDiffErrorMessage}</Alert>
+      )}
       <H1 mb={2}>{FeatureName.IdentitySecurity} saves you from mistakes.</H1>
       <Flex mb={4} gap={6} flexWrap="wrap" justifyContent="space-between">
         <Box flex="1" minWidth="30ch">
@@ -62,21 +74,35 @@ export function PolicyPlaceholder({
           </P>
         </Box>
         <Flex flex="0 0 auto" alignItems="start">
-          {!cfg.isPolicyEnabled && (
-            <>
-              <ButtonLockedFeature noIcon py={0} width={undefined}>
-                Contact Sales
-              </ButtonLockedFeature>
-              <ButtonSecondary
-                as="a"
-                href="https://goteleport.com/platform/policy/"
-                target="_blank"
-                ml={2}
+          {!cfg.isPolicyEnabled &&
+            cfg.isCloud &&
+            enableDemoMode && ( // cloud can enable a demo mode so show that button
+              <ButtonPrimary
+                onClick={enableDemoMode}
+                py="12px"
+                width="100%"
+                disabled={loading}
+                style={{ textTransform: 'none' }}
               >
-                Learn More
-              </ButtonSecondary>
-            </>
-          )}
+                {loading ? 'Creating graph…' : 'Preview Identity Security'}
+              </ButtonPrimary>
+            )}
+          {!cfg.isPolicyEnabled &&
+            !cfg.isCloud && ( // non-cloud must contact sales
+              <>
+                <ButtonLockedFeature noIcon py={0} width={undefined}>
+                  Contact Sales
+                </ButtonLockedFeature>
+                <ButtonSecondary
+                  as="a"
+                  href="https://goteleport.com/platform/policy/"
+                  target="_blank"
+                  ml={2}
+                >
+                  Learn More
+                </ButtonSecondary>
+              </>
+            )}
         </Flex>
       </Flex>
       <Flex

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditorAdapter.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditorAdapter.tsx
@@ -30,9 +30,9 @@ import { Role, RoleWithYaml } from 'teleport/services/resources';
 import { yamlService } from 'teleport/services/yaml';
 import { YamlSupportedResourceKind } from 'teleport/services/yaml/types';
 
-import { PolicyPlaceholder } from '../PolicyPlaceholder';
 import { RolesProps } from '../Roles';
 import { RoleEditor } from './RoleEditor';
+import { RoleEditorVisualizer } from './RoleEditorVisualizer';
 
 /**
  * This component is responsible for converting from the `Resource`
@@ -112,17 +112,10 @@ export function RoleEditorAdapter({
           />
         )}
       </Flex>
-      {roleDiffProps ? (
-        <Flex flex="1">{roleDiffProps.roleDiffElement}</Flex>
-      ) : (
-        <Flex flex="1" alignItems="center" justifyContent="center" m={3}>
-          <PolicyPlaceholder
-            currentFlow={
-              resources.status === 'creating' ? 'creating' : 'updating'
-            }
-          />
-        </Flex>
-      )}
+      <RoleEditorVisualizer
+        roleDiffProps={roleDiffProps}
+        currentFlow={resources.status === 'creating' ? 'creating' : 'updating'}
+      />
     </Flex>
   );
 }

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditorVisualizer.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditorVisualizer.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { fireEvent, render, screen } from 'design/utils/testing';
+
+import cfg from 'teleport/config';
+import { createTeleportContext } from 'teleport/mocks/contexts';
+import TeleportContextProvider from 'teleport/TeleportContextProvider';
+
+import { RoleDiffProps, RoleDiffState } from '../Roles';
+import { RoleEditorVisualizer } from './RoleEditorVisualizer';
+
+const defaultIsPolicyEnabled = cfg.isPolicyEnabled;
+const defaultIsCloud = cfg.isCloud;
+afterEach(() => {
+  cfg.isPolicyEnabled = defaultIsPolicyEnabled;
+  cfg.isCloud = defaultIsCloud;
+});
+
+const roleDiffElement = <div>i am rendered</div>;
+test('no roleDiffProps shows policyPlaceHolder', async () => {
+  render(getComponent(makeRoleDiffProps()));
+  expect(
+    screen.getByText('Teleport Identity Security saves you from mistakes.')
+  ).toBeInTheDocument();
+});
+
+test('POLICY_ENABLED displays roll diff visualizer', async () => {
+  render(
+    getComponent(
+      makeRoleDiffProps({ roleDiffState: RoleDiffState.PolicyEnabled })
+    )
+  );
+  expect(screen.getByText('i am rendered')).toBeInTheDocument();
+});
+
+test('Preview Identity Security button does not show for non-cloud', async () => {
+  cfg.isCloud = false;
+  render(
+    getComponent(
+      makeRoleDiffProps({
+        roleDiffState: RoleDiffState.Disabled,
+      })
+    )
+  );
+  expect(
+    screen.queryByText('Preview Identity Security')
+  ).not.toBeInTheDocument();
+});
+
+test('Preview Identity Security button displays for cloud users', async () => {
+  cfg.isCloud = true;
+  render(
+    getComponent(
+      makeRoleDiffProps({
+        roleDiffState: RoleDiffState.Disabled,
+      })
+    )
+  );
+  expect(screen.getByText('Preview Identity Security')).toBeInTheDocument();
+});
+
+test('DEMO_READY displays roll diff visualizer with demo banner', async () => {
+  render(
+    getComponent(makeRoleDiffProps({ roleDiffState: RoleDiffState.DemoReady }))
+  );
+  expect(screen.getByTestId('demo-banner')).toBeInTheDocument();
+  expect(screen.getByText('Contact Sales')).toBeInTheDocument();
+  expect(screen.getByText('Learn More')).toBeInTheDocument();
+});
+
+test('demo banner is dismissed and shows again on rerender', async () => {
+  const { rerender } = render(
+    getComponent(makeRoleDiffProps({ roleDiffState: RoleDiffState.DemoReady }))
+  );
+  expect(screen.getByTestId('demo-banner')).toBeInTheDocument();
+  fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+  expect(screen.queryByText('demo-banner')).not.toBeInTheDocument();
+  rerender(
+    getComponent(makeRoleDiffProps({ roleDiffState: RoleDiffState.DemoReady }))
+  );
+  expect(screen.getByTestId('demo-banner')).toBeInTheDocument();
+});
+
+test('ERROR displays policy placeholder with error', async () => {
+  const errorMessage = 'i am an error';
+  render(
+    getComponent(
+      makeRoleDiffProps({
+        roleDiffState: RoleDiffState.Error,
+        roleDiffErrorMessage: errorMessage,
+      })
+    )
+  );
+  expect(screen.getByText(errorMessage)).toBeInTheDocument();
+});
+
+test('LOADING_SETTINGS displays policy placeholder with a preview button in a loading state', async () => {
+  cfg.isCloud = true;
+  render(
+    getComponent(
+      makeRoleDiffProps({ roleDiffState: RoleDiffState.LoadingSettings })
+    )
+  );
+  expect(screen.getByText('Creating graph…')).toBeInTheDocument();
+});
+
+test('WAITING_FOR_SYNC displays policy placeholder with a preview button in a loading state', async () => {
+  cfg.isCloud = true;
+  render(
+    getComponent(
+      makeRoleDiffProps({ roleDiffState: RoleDiffState.WaitingForSync })
+    )
+  );
+  expect(screen.getByText('Creating graph…')).toBeInTheDocument();
+});
+
+function makeRoleDiffProps(props?: Partial<RoleDiffProps>) {
+  return {
+    roleDiffElement,
+    updateRoleDiff: () => null,
+    enableDemoMode: () => null,
+    ...props,
+  };
+}
+
+function getComponent(props: RoleDiffProps) {
+  const ctx = createTeleportContext();
+  return (
+    <TeleportContextProvider ctx={ctx}>
+      <RoleEditorVisualizer currentFlow="creating" roleDiffProps={props} />
+    </TeleportContextProvider>
+  );
+}

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditorVisualizer.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditorVisualizer.tsx
@@ -1,0 +1,104 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// RoleEditorVisualizer is the component that will be shown
+// next to the role editor adapter. This can either be the
+
+import { useState } from 'react';
+
+import { Alert } from 'design/Alert';
+import Box from 'design/Box';
+import Flex from 'design/Flex';
+import { ShieldCheck } from 'design/Icon';
+
+import { getSalesURL } from 'teleport/services/sales';
+import useTeleport from 'teleport/useTeleport';
+
+import { PolicyPlaceholder } from '../PolicyPlaceholder';
+import { RoleDiffProps, RoleDiffState } from '../Roles';
+
+// role diff visualizer, or the upsell
+export function RoleEditorVisualizer({
+  roleDiffProps,
+  currentFlow,
+}: {
+  roleDiffProps?: RoleDiffProps;
+  currentFlow: 'creating' | 'updating';
+}) {
+  const ctx = useTeleport();
+  const version = ctx.storeUser.state.cluster.authVersion;
+  // the demo banner should show every time they load the role editor
+  const [demoDismissed, setDemoDismissed] = useState(false);
+  if (
+    roleDiffProps &&
+    (roleDiffProps.roleDiffState === RoleDiffState.DemoReady ||
+      roleDiffProps.roleDiffState === RoleDiffState.PolicyEnabled)
+  ) {
+    return (
+      <Flex
+        flex="1"
+        flexDirection="column"
+        css={`
+          position: relative;
+        `}
+      >
+        <Box
+          data-testid="demo-banner"
+          css={`
+            position: absolute;
+            width: 100%;
+            z-index: 1000;
+            padding: 20px;
+          `}
+        >
+          {!demoDismissed &&
+            roleDiffProps.roleDiffState === RoleDiffState.DemoReady && (
+              <Alert
+                kind="neutral"
+                details="Secure identities and access policies across all of your infrastructure. Eliminate shadow access and blind spots."
+                icon={ShieldCheck}
+                primaryAction={{
+                  content: 'Contact Sales',
+                  href: getSalesURL(version, false),
+                }}
+                secondaryAction={{
+                  content: 'Learn More',
+                  href: 'https://goteleport.com/platform/policy/',
+                }}
+                dismissible
+                onDismiss={() => setDemoDismissed(true)}
+              >
+                Teleport Identity Security
+              </Alert>
+            )}
+        </Box>
+        {roleDiffProps.roleDiffElement}
+      </Flex>
+    );
+  }
+
+  return (
+    <Flex flex="1" alignItems="center" justifyContent="center" m={3}>
+      <PolicyPlaceholder
+        roleDiffProps={roleDiffProps}
+        enableDemoMode={roleDiffProps?.enableDemoMode}
+        currentFlow={currentFlow}
+      />
+    </Flex>
+  );
+}

--- a/web/packages/teleport/src/Roles/Roles.test.tsx
+++ b/web/packages/teleport/src/Roles/Roles.test.tsx
@@ -26,7 +26,7 @@ import { createTeleportContext } from 'teleport/mocks/contexts';
 import { yamlService } from 'teleport/services/yaml';
 
 import { withDefaults } from './RoleEditor/StandardEditor/withDefaults';
-import { Roles } from './Roles';
+import { RoleDiffState, Roles } from './Roles';
 import { State } from './useRoles';
 
 describe('Roles list', () => {
@@ -291,6 +291,7 @@ test('renders the role diff component', async () => {
   jest.spyOn(yamlService, 'parse').mockImplementation(async () => {
     return withDefaults({});
   });
+
   const roleDiffElement = <div>i am rendered</div>;
 
   render(
@@ -301,6 +302,7 @@ test('renders the role diff component', async () => {
             {...defaultState()}
             roleDiffProps={{
               roleDiffElement,
+              roleDiffState: RoleDiffState.PolicyEnabled,
               updateRoleDiff: () => null,
               roleDiffAttempt: {
                 status: 'error',

--- a/web/packages/teleport/src/Roles/Roles.tsx
+++ b/web/packages/teleport/src/Roles/Roles.tsx
@@ -54,8 +54,17 @@ import { RoleList } from './RoleList';
 import templates from './templates';
 import { State, useRoles } from './useRoles';
 
+export enum RoleDiffState {
+  Disabled,
+  Error,
+  PolicyEnabled,
+  LoadingSettings,
+  WaitingForSync,
+  DemoReady,
+}
+
 /** Optional set of props to render the role diff visualizer. */
-type RoleDiffProps = {
+export type RoleDiffProps = {
   roleDiffElement: React.ReactNode;
   updateRoleDiff: (role: Role) => void;
 
@@ -71,6 +80,9 @@ type RoleDiffProps = {
   // updated.
   roleDiffAttempt?: Attempt<unknown>;
   clearRoleDiffAttempt?: () => void;
+  enableDemoMode?: () => void;
+  roleDiffState?: RoleDiffState;
+  roleDiffErrorMessage?: string;
 };
 
 export type RolesProps = {


### PR DESCRIPTION
This component is used to contain and display the state of the role diff visualizer to include demo mode. Its either a policy placehodler (with the preview button), in a state of creating the graph (when enabling demo mode), or the role diff visualizer (with optional demo mode banner).

the hook (in the `e` part of this PR) is kinda complex but rather than throwing around 4 different `attempts`, i decided to amalgamate all of them into a `RoleDiffState` enum. because really, it can only be in one state at once determined by the combinatorics of the attempts.

requires https://github.com/gravitational/teleport/pull/53371 and https://github.com/gravitational/teleport.e/pull/6231