### PR TITLE
lib/auth/windows: shrink CRL interface

### DIFF
--- a/lib/auth/windows/windows.go
+++ b/lib/auth/windows/windows.go
@@ -264,8 +264,8 @@ func generateDatabaseCredentials(ctx context.Context, req *GenerateCredentialsRe
 	return certDER, keyDER, genResp.CACerts, nil
 }
 
-// CertKeyPEM returns certificate and private key bytes encoded in PEM format for use with `kinit`
-func CertKeyPEM(ctx context.Context, req *GenerateCredentialsRequest) (certPEM, keyPEM []byte, caCerts [][]byte, err error) {
+// DatabaseCredentials returns certificate and private key bytes encoded in PEM format for use with `kinit`.
+func DatabaseCredentials(ctx context.Context, req *GenerateCredentialsRequest) (certPEM, keyPEM []byte, caCerts [][]byte, err error) {
 	certDER, keyDER, caCerts, err := generateDatabaseCredentials(ctx, req)
 	if err != nil {
 		return nil, nil, nil, trace.Wrap(err)

--- a/lib/srv/db/common/kerberos/kinit/kinit.go
+++ b/lib/srv/db/common/kerberos/kinit/kinit.go
@@ -212,7 +212,7 @@ func (d *DBCertGetter) GetCertificateBytes(ctx context.Context) (*WindowsCAAndKe
 		return nil, trace.Wrap(err)
 	}
 
-	certPEM, keyPEM, caCerts, err := windows.CertKeyPEM(ctx, &windows.GenerateCredentialsRequest{
+	certPEM, keyPEM, caCerts, err := windows.DatabaseCredentials(ctx, &windows.GenerateCredentialsRequest{
 		CAType:      types.DatabaseClientCA,
 		Username:    d.UserName,
 		Domain:      d.RealmName,


### PR DESCRIPTION
We only call a single method but were requiring an interface with over a dozen methods.