### PR TITLE
Fix install script when using Managed Updates v2

### DIFF
--- a/lib/srv/server/installer/defaultinstallers.go
+++ b/lib/srv/server/installer/defaultinstallers.go
@@ -63,7 +63,7 @@ var (
 echo "Configuring the Teleport agent"
 
 set +x
-sudo teleport ` + strings.Join(argsList, " ")
+sudo teleport ` + strings.Join(argsList, " ") + " $@"
 
 	argsList = []string{
 		"install", "autodiscover-node",

--- a/lib/srv/server/installer/defaultinstallers_test.go
+++ b/lib/srv/server/installer/defaultinstallers_test.go
@@ -49,7 +49,7 @@ rm "$TEMP_INSTALLER_SCRIPT"
 echo "Configuring the Teleport agent"
 
 set +x
-sudo teleport install autodiscover-node --public-proxy-addr=teleport.example.com:443 --teleport-package=teleport-ent --repo-channel=stable/cloud --auto-upgrade=true --azure-client-id=`
+sudo teleport install autodiscover-node --public-proxy-addr=teleport.example.com:443 --teleport-package=teleport-ent --repo-channel=stable/cloud --auto-upgrade=true --azure-client-id= $@`
 
 // TestNewDefaultInstaller is a minimal
 func TestNewDefaultInstaller(t *testing.T) {


### PR DESCRIPTION
This PR fixes a bug causing the `teleport install autodiscover-node` command to fail when ran by the discovery ervice with the error: `required argument 'token' not provided`. This bug broke the discovery service in 17.3.0 and 16.5.0 with managed updates v2 enabled.

Explanation: the oneoff.sh script was ending with $@, which passed the token to the command. The new script did not.

Changelog: Fix a bug causing the discovery service to fail to configure teleport on discovered nodes when managed updates v2 are enabled.