### PR TITLE
[v17] Build & release tbot.exe on Windows

### DIFF
--- a/build.assets/windows/build.ps1
+++ b/build.assets/windows/build.ps1
@@ -422,6 +422,39 @@ function Build-Tctl {
     return "$SignedBinaryPath"  # This is needed for bundling the zip archive
 }
 
+function Build-Tbot {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string] $TeleportSourceDirectory,
+        [Parameter(Mandatory)]
+        [string] $ArtifactDirectory,
+        [Parameter(Mandatory)]
+        [string] $TeleportVersion
+    )
+
+    $BinaryName = "tbot.exe"
+    $BuildDirectory = "$TeleportSourceDirectory\build"
+    $SignedBinaryPath = "$BuildDirectory\$BinaryName"
+
+    $CommandDuration = Measure-Block {
+        Write-Host "::group::Building tbot..."
+        $UnsignedBinaryPath = "$BuildDirectory\unsigned-$BinaryName"
+        go build -trimpath -ldflags "-s -w" -o "$UnsignedBinaryPath" "$TeleportSourceDirectory\tool\tbot"
+        if ($LastExitCode -ne 0) {
+            exit $LastExitCode
+        }
+        Write-Host "::endgroup::"
+
+        Write-Host "::group::Signing tbot..."
+        Invoke-SignBinary -UnsignedBinaryPath "$UnsignedBinaryPath" -SignedBinaryPath "$SignedBinaryPath"
+        Write-Host "::endgroup::"
+    }
+    Write-Host $("Built tbot in {0:g}" -f $CommandDuration)
+
+    return "$SignedBinaryPath"  # This is needed for bundling the zip archive
+}
+
 function Package-Artifacts {
     [CmdletBinding()]
     param(
@@ -435,6 +468,8 @@ function Package-Artifacts {
         [string] $SignedTctlBinaryPath,
         [Parameter(Mandatory)]
         [string] $SignedTshBinaryPath
+        [Parameter(Mandatory)]
+        [string] $SignedTBotBinaryPath
     )
 
     $CommandDuration = Measure-Block {
@@ -442,6 +477,7 @@ function Package-Artifacts {
         Write-Host "Packaging zip archive $PackageDirectory..."
         Copy-Item -Path "$SignedTctlBinaryPath" -Destination "$PackageDirectory"
         Copy-Item -Path "$SignedTshBinaryPath" -Destination "$PackageDirectory"
+        Copy-Item -Path "$SignedTbotBinaryPath" -Destination "$PackageDirectory"
         Copy-Item -Path "$TeleportSourceDirectory\CHANGELOG.md" -Destination "$PackageDirectory"
         Copy-Item -Path "$TeleportSourceDirectory\README.md" -Destination "$PackageDirectory"
         Out-File -FilePath "$PackageDirectory\VERSION" -InputObject "v$TeleportVersion"
@@ -526,6 +562,17 @@ function Write-Version-Objects {
         --file-version $TeleportVersion `
         --out "$TeleportSourceDirectory\tool\tctl\resource.syso"
 
+    # generate tbot version info
+    & $GoWinres simply --no-suffix --arch amd64 `
+        --file-description "Teleport Machine and Workload Identity agent" `
+        --original-filename tbot.exe `
+        --copyright "Copyright (C) $Year Gravitational Inc." `
+        --icon "$TeleportSourceDirectory\e\windowsauth\installer\teleport.ico" `
+        --product-name Teleport `
+        --product-version $TeleportVersion `
+        --file-version $TeleportVersion `
+        --out "$TeleportSourceDirectory\tool\tbot\resource.syso"
+
     # generate windowsauth version info (note the --admin flag, as the installer must run as admin)
     & $GoWinres simply --no-suffix --arch amd64 --admin `
         --file-description "Teleport Authentication Package" `
@@ -565,6 +612,12 @@ function Build-Artifacts {
         -ArtifactDirectory "$ArtifactDirectory" `
         -TeleportVersion "$TeleportVersion"
 
+    # Build TBot
+    $SignedTbotBinaryPath = Build-Tbot `
+        -TeleportSourceDirectory "$TeleportSourceDirectory" `
+        -ArtifactDirectory "$ArtifactDirectory" `
+        -TeleportVersion "$TeleportVersion"
+
     # Create archive
     Package-Artifacts `
         -TeleportSourceDirectory "$TeleportSourceDirectory" `
@@ -572,6 +625,7 @@ function Build-Artifacts {
         -TeleportVersion "$TeleportVersion" `
         -SignedTshBinaryPath "$SignedTshBinaryPath" `
         -SignedTctlBinaryPath "$SignedTctlBinaryPath"
+        -SignedTBotBinaryPath "$SignedTBotBinaryPath"
 
     # Build Teleport Connect
     Build-Connect `

--- a/build.assets/windows/build.ps1
+++ b/build.assets/windows/build.ps1
@@ -467,7 +467,7 @@ function Package-Artifacts {
         [Parameter(Mandatory)]
         [string] $SignedTctlBinaryPath,
         [Parameter(Mandatory)]
-        [string] $SignedTshBinaryPath
+        [string] $SignedTshBinaryPath,
         [Parameter(Mandatory)]
         [string] $SignedTBotBinaryPath
     )

--- a/build.assets/windows/build.ps1
+++ b/build.assets/windows/build.ps1
@@ -624,7 +624,7 @@ function Build-Artifacts {
         -ArtifactDirectory "$ArtifactDirectory" `
         -TeleportVersion "$TeleportVersion" `
         -SignedTshBinaryPath "$SignedTshBinaryPath" `
-        -SignedTctlBinaryPath "$SignedTctlBinaryPath"
+        -SignedTctlBinaryPath "$SignedTctlBinaryPath" `
         -SignedTBotBinaryPath "$SignedTBotBinaryPath"
 
     # Build Teleport Connect


### PR DESCRIPTION
Backport #53523 to branch/v17

changelog: Tbot is now built and released for Windows and can be found in the Windows client tools zip.
