### PR TITLE
[v17] lib/auth/windows: shrink CRL interface

### DIFF
--- a/lib/auth/windows/certificate_authority.go
+++ b/lib/auth/windows/certificate_authority.go
@@ -25,7 +25,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth/authclient"
 )
 
 // NewCertificateStoreClient returns a new structure for modifying windows certificates in a Windows CA.
@@ -38,16 +37,24 @@ type CertificateStoreClient struct {
 	cfg CertificateStoreConfig
 }
 
+// CRLGenerator generates CRLs, which are required for certificate-based authentication on Windows.
+// Teleport has its own locking concept that is used for revocation, so the CRLS generated here
+// are always empty and exist only to satisfy the Windows requirements for CRL checking.
+type CRLGenerator interface {
+	// GenerateCertAuthorityCRL returns an empty CRL for a CA.
+	GenerateCertAuthorityCRL(ctx context.Context, caType types.CertAuthType) ([]byte, error)
+}
+
 // CertificateStoreConfig is a config structure for a Windows Certificate Authority
 type CertificateStoreConfig struct {
 	// AccessPoint is the Auth API client (with caching).
-	AccessPoint authclient.WindowsDesktopAccessPoint
+	AccessPoint CRLGenerator
 	// Domain is the Active Directory domain where Teleport publishes its
 	// Certificate Revocation List (CRL).
 	Domain string
 	// Log is the logging sink for the service
 	Log logrus.FieldLogger
-	// ClusterName is the name of this cluster
+	// ClusterName is the name of this Teleport cluster
 	ClusterName string
 	// LC is the LDAPClient
 	LC *LDAPClient

--- a/lib/auth/windows/windows.go
+++ b/lib/auth/windows/windows.go
@@ -273,8 +273,8 @@ func generateDatabaseCredentials(ctx context.Context, req *GenerateCredentialsRe
 	return certDER, keyDER, genResp.CACerts, nil
 }
 
-// CertKeyPEM returns certificate and private key bytes encoded in PEM format for use with `kinit`
-func CertKeyPEM(ctx context.Context, req *GenerateCredentialsRequest) (certPEM, keyPEM []byte, caCerts [][]byte, err error) {
+// DatabaseCredentials returns certificate and private key bytes encoded in PEM format for use with `kinit`.
+func DatabaseCredentials(ctx context.Context, req *GenerateCredentialsRequest) (certPEM, keyPEM []byte, caCerts [][]byte, err error) {
 	certDER, keyDER, caCerts, err := generateDatabaseCredentials(ctx, req)
 	if err != nil {
 		return nil, nil, nil, trace.Wrap(err)

--- a/lib/srv/db/common/kerberos/kinit/kinit.go
+++ b/lib/srv/db/common/kerberos/kinit/kinit.go
@@ -212,7 +212,7 @@ func (d *DBCertGetter) GetCertificateBytes(ctx context.Context) (*WindowsCAAndKe
 		return nil, trace.Wrap(err)
 	}
 
-	certPEM, keyPEM, caCerts, err := windows.CertKeyPEM(ctx, &windows.GenerateCredentialsRequest{
+	certPEM, keyPEM, caCerts, err := windows.DatabaseCredentials(ctx, &windows.GenerateCredentialsRequest{
 		CAType:      types.DatabaseClientCA,
 		Username:    d.UserName,
 		Domain:      d.RealmName,


### PR DESCRIPTION
We only call a single method but were requiring an interface with over a dozen methods.

Backports #53540 