### PR TITLE
Require that FnCache keys are comparable

### DIFF
--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -1026,8 +1026,6 @@ type leaseKey struct {
 	bucket time.Time
 }
 
-var _ map[leaseKey]struct{} // compile-time hashability check
-
 func (b *EtcdBackend) setupLease(ctx context.Context, item backend.Item, lease *backend.Lease, opts *[]clientv3.OpOption) error {
 	// in order to reduce excess redundant lease generation, we bucket expiry times
 	// to the nearest multiple of 10s and then grant one lease per bucket. Too many
@@ -1067,8 +1065,6 @@ func (b *EtcdBackend) ttl(expires time.Time) time.Duration {
 type ttlKey struct {
 	leaseID int64
 }
-
-var _ map[ttlKey]struct{} // compile-time hashability check
 
 func (b *EtcdBackend) fromEvent(ctx context.Context, e clientv3.Event) (*backend.Event, error) {
 	event := &backend.Event{

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -1797,8 +1797,6 @@ type getCertAuthorityCacheKey struct {
 	id types.CertAuthID
 }
 
-var _ map[getCertAuthorityCacheKey]struct{} // compile-time hashability check
-
 // GetCertAuthority returns certificate authority by given id. Parameter loadSigningKeys
 // controls if signing keys are loaded
 func (c *Cache) GetCertAuthority(ctx context.Context, id types.CertAuthID, loadSigningKeys bool) (types.CertAuthority, error) {
@@ -1838,8 +1836,6 @@ func (c *Cache) GetCertAuthority(ctx context.Context, id types.CertAuthID, loadS
 type getCertAuthoritiesCacheKey struct {
 	caType types.CertAuthType
 }
-
-var _ map[getCertAuthoritiesCacheKey]struct{} // compile-time hashability check
 
 // GetCertAuthorities returns a list of authorities of a given type
 // loadSigningKeys controls whether signing keys should be loaded or not
@@ -1923,8 +1919,6 @@ type clusterConfigCacheKey struct {
 	kind string
 }
 
-var _ map[clusterConfigCacheKey]struct{} // compile-time hashability check
-
 // GetClusterAuditConfig gets ClusterAuditConfig from the backend.
 func (c *Cache) GetClusterAuditConfig(ctx context.Context) (types.ClusterAuditConfig, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/GetClusterAuditConfig")
@@ -1997,8 +1991,6 @@ func (c *Cache) GetClusterName(ctx context.Context) (types.ClusterName, error) {
 type autoUpdateCacheKey struct {
 	kind string
 }
-
-var _ map[autoUpdateCacheKey]struct{} // compile-time hashability check
 
 // GetAutoUpdateConfig gets the AutoUpdateConfig from the backend.
 func (c *Cache) GetAutoUpdateConfig(ctx context.Context) (*autoupdate.AutoUpdateConfig, error) {
@@ -2179,8 +2171,6 @@ type getNodesCacheKey struct {
 	namespace string
 }
 
-var _ map[getNodesCacheKey]struct{} // compile-time hashability check
-
 // GetNodes is a part of auth.Cache implementation
 func (c *Cache) GetNodes(ctx context.Context, namespace string) ([]types.Server, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/GetNodes")
@@ -2249,8 +2239,6 @@ func (c *Cache) GetProxies() ([]types.Server, error) {
 type remoteClustersCacheKey struct {
 	name string
 }
-
-var _ map[remoteClustersCacheKey]struct{} // compile-time hashability check
 
 // GetRemoteClusters returns a list of remote clusters
 func (c *Cache) GetRemoteClusters(ctx context.Context) ([]types.RemoteCluster, error) {

--- a/lib/cloud/azure/client_map.go
+++ b/lib/cloud/azure/client_map.go
@@ -79,7 +79,7 @@ func NewClientMap[ClientType any](
 // Get returns an Azure client by subscription. A new client is created if the
 // subscription is not found in the map.
 func (m *ClientMap[ClientType]) Get(subscription string, getCredentials func() (azcore.TokenCredential, error)) (ClientType, error) {
-	client, err := utils.FnCacheGet[ClientType](context.Background(), m.clients, subscription, func(ctx context.Context) (client ClientType, err error) {
+	client, err := utils.FnCacheGet(context.Background(), m.clients, subscription, func(ctx context.Context) (client ClientType, err error) {
 		cred, err := getCredentials()
 		if err != nil {
 			return client, trace.Wrap(err)

--- a/lib/utils/fncache.go
+++ b/lib/utils/fncache.go
@@ -230,13 +230,13 @@ func (c *FnCache) removeExpiredLocked(now time.Time) {
 // block until the first call updates the entry. Note that the supplied context can cancel the call to Get, but will
 // not cancel loading. The supplied loadfn should not be canceled just because the specific request happens to have
 // been canceled.
-func FnCacheGet[T any](ctx context.Context, cache *FnCache, key any, loadfn func(ctx context.Context) (T, error)) (T, error) {
+func FnCacheGet[K comparable, T any](ctx context.Context, cache *FnCache, key K, loadfn func(ctx context.Context) (T, error)) (T, error) {
 	return FnCacheGetWithTTL(ctx, cache, key, cache.cfg.TTL, loadfn)
 }
 
 // FnCacheGetWithTTL is identical to FnCacheGet except that it allows individual keys to specify
 // a TTL that is used instead of the configured TTL for the FnCache.
-func FnCacheGetWithTTL[T any](ctx context.Context, cache *FnCache, key any, ttl time.Duration, loadfn func(ctx context.Context) (T, error)) (T, error) {
+func FnCacheGetWithTTL[K comparable, T any](ctx context.Context, cache *FnCache, key K, ttl time.Duration, loadfn func(ctx context.Context) (T, error)) (T, error) {
 	t, err := cache.get(ctx, key, ttl, func(ctx context.Context) (any, error) {
 		return loadfn(ctx)
 	})

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1629,7 +1629,7 @@ func (h *Handler) find(w http.ResponseWriter, r *http.Request, p httprouter.Para
 	}
 
 	// cache the generic answer to avoid doing work for each request
-	resp, err := utils.FnCacheGet[*webclient.PingResponse](r.Context(), h.findEndpointCache, cacheKey, func(ctx context.Context) (*webclient.PingResponse, error) {
+	resp, err := utils.FnCacheGet(r.Context(), h.findEndpointCache, cacheKey, func(ctx context.Context) (*webclient.PingResponse, error) {
 		proxyConfig, err := h.cfg.ProxySettings.GetProxySettings(ctx)
 		if err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/web/autoupdate_common.go
+++ b/lib/web/autoupdate_common.go
@@ -207,7 +207,7 @@ func getVersionFromChannel(ctx context.Context, channels automaticupgrades.Chann
 func (h *Handler) getTriggerFromWindowThenChannel(ctx context.Context, groupName string) (bool, error) {
 	// Caching the CMC for 10 seconds because this resource is cached neither by the auth nor the proxy.
 	// And this function can be accessed via unauthenticated endpoints.
-	cmc, err := utils.FnCacheGet[types.ClusterMaintenanceConfig](ctx, h.clusterMaintenanceConfigCache, "cmc", func(ctx context.Context) (types.ClusterMaintenanceConfig, error) {
+	cmc, err := utils.FnCacheGet(ctx, h.clusterMaintenanceConfigCache, "cmc", func(ctx context.Context) (types.ClusterMaintenanceConfig, error) {
 		return h.cfg.ProxyClient.GetClusterMaintenanceConfig(ctx)
 	})
 


### PR DESCRIPTION
Adds an additional type constraint go FnCacheGet and FnCacheGetWithTTL to enforce that all keys are comparable. This should allow the removal of various compile time hashability checks that are in place for existing keys of custom types.