### PR TITLE
Auth: Rework resourceAccess to unifiedResourceLister

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -47,6 +47,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/wrappers"
+	"github.com/gravitational/teleport/api/utils"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/entitlements"
@@ -1177,25 +1178,28 @@ func (a *ServerWithRoles) GetNode(ctx context.Context, namespace, name string) (
 	return node, nil
 }
 
-// resourceAccess is used for different rbac results when filtering items
-type resourceAccess struct {
+// unifiedResourceLister is used to check if an unified resource should be listed. It also
+// memorizes all the resources which are requestable-only in the requestableMap.
+type unifiedResourceLister struct {
 	// accessChecker is used to check a user's access to resources. This can
 	// be extended to include SearchAsRoles
-	accessChecker resourceAccessChecker
-	// baseAuthChecker is set when a user's auth context is extended during a
-	// searchAsRoles request
-	baseAuthChecker resourceAccessChecker
-	// kindAccessMap is used to check errors for list/read verbs per kind
-	kindAccessMap map[string]error
+	accessChecker *resourceChecker
+	// requestableAccessChecker is optional. If set it will be considered a fallback checker if
+	// accessChecker denies access. If a resource is allowed by the requestableAccessChecker,
+	// the resource's name will be added to the requestableMap.
+	requestableAccessChecker *resourceChecker
+	// kindAccessErrMap is used to check errors for list/read verbs per kind.
+	kindAccessErrMap map[string]error
+
 	// requestableMap is used to track if a resource matches a filter but is only
-	// available after an access request. This map is of Resource.GetName()
+	// available after an access request. This map is of Resource.GetName().
 	requestableMap map[string]struct{}
 }
 
-func (c *resourceAccess) checkAccess(resource types.ResourceWithLabels, filter services.MatchResourceFilter) (bool, error) {
+func (c *unifiedResourceLister) canList(resource types.ResourceWithLabels, filter services.MatchResourceFilter) (bool, error) {
 	resourceKind := resource.GetKind()
 
-	if canAccessErr := c.kindAccessMap[resourceKind]; canAccessErr != nil {
+	if canAccessErr := c.kindAccessErrMap[resourceKind]; canAccessErr != nil {
 		// skip access denied error. It is expected that resources won't be available
 		// to some users and we want to keep iterating until we've reached the request limit
 		// of resources they have access to
@@ -1220,50 +1224,50 @@ func (c *resourceAccess) checkAccess(resource types.ResourceWithLabels, filter s
 		return false, nil
 	}
 
-	// check access normally if base checker doesn't exist
-	if c.baseAuthChecker == nil {
-		if err := c.accessChecker.CanAccess(resource); err != nil {
-			if trace.IsAccessDenied(err) {
-				return false, nil
-			}
-			return false, trace.Wrap(err)
-		}
+	// If the resource is accessible with the primary access checker, allow listing.
+	if err := c.accessChecker.CanAccess(resource); err == nil {
 		return true, nil
+	} else if !trace.IsAccessDenied(err) {
+		return false, trace.Wrap(err)
 	}
 
-	// baseAuthChecker exists if the current auth context has been extended for a includeRequestable request.
-	// if true, we should check with the base auth checker first and if that returns false, check the extended context
-	// so we know if a resource is being matched because they have access to it currently, or only to be added
-	// to an access request
-	if err := c.baseAuthChecker.CanAccess(resource); err != nil {
-		if !trace.IsAccessDenied(err) {
-			return false, trace.Wrap(err)
-		}
+	// If there isn't a requestable access checker and the resource wasn't allowed by the
+	// primary checker, don't list it.
+	if c.requestableAccessChecker == nil {
+		return false, nil
+	}
 
-		// user does not have access with their base context
-		// check if they would have access with the extended context
-		if err := c.accessChecker.CanAccess(resource); err != nil {
-			if trace.IsAccessDenied(err) {
-				return false, nil
-			}
-			return false, trace.Wrap(err)
-		}
+	// If the resource is requestable, allow listing it as requestable (put it in the the
+	// requestableMap).
+	if err := c.requestableAccessChecker.CanAccess(resource); err == nil {
 		c.requestableMap[resource.GetName()] = struct{}{}
+		return true, nil
+	} else if !trace.IsAccessDenied(err) {
+		return false, trace.Wrap(err)
 	}
 
-	return true, nil
+	return false, nil
 }
 
-type actionChecker func(namespace, resourceKind string, verbs ...string) error
+func (l *unifiedResourceLister) getAllowedLogins(resource services.AccessCheckable) ([]string, error) {
+	if l.requestableAccessChecker != nil {
+		logins, err := l.requestableAccessChecker.GetAllowedLoginsForResource(resource)
+		return logins, trace.Wrap(err)
+	} else {
+		logins, err := l.accessChecker.GetAllowedLoginsForResource(resource)
+		return logins, trace.Wrap(err)
+	}
+}
 
-func (a *ServerWithRoles) selectActionChecker(resourceKind string) actionChecker {
+func (a *ServerWithRoles) checkAction(namespace, resourceKind string, verbs ...string) error {
 	switch resourceKind {
 	case types.KindIdentityCenterAccount, types.KindIdentityCenterAccountAssignment:
 		// Identity Center resources can be specified multiple ways in a Role
 		// Condition statement, so we need a special checker to handle it.
-		return a.identityCenterAction
+		return trace.Wrap(a.identityCenterAction(namespace, resourceKind, verbs...))
+	default:
+		return trace.Wrap(a.actionNamespace(namespace, resourceKind, verbs...))
 	}
-	return a.actionNamespace
 }
 
 var (
@@ -1281,6 +1285,24 @@ var (
 
 	defaultUnifiedResourceKinds = slices.Collect(maps.Keys(supportedUnifiedResourceKinds))
 )
+
+func (a *ServerWithRoles) checkKindAccess(kind string) error {
+	if _, ok := supportedUnifiedResourceKinds[kind]; !ok {
+		return trace.BadParameter("unsupported kind %q requested", kind)
+	}
+	switch kind {
+	case types.KindNode:
+		// We are checking list only for Nodes to keep backwards compatibility.
+		// The read verb got added to GetNodes initially in:
+		//   https://github.com/gravitational/teleport/pull/1209
+		// but got removed shortly afterwards in:
+		//   https://github.com/gravitational/teleport/pull/1224
+		return trace.Wrap(a.checkAction(apidefaults.Namespace, kind, types.VerbList))
+	default:
+		return trace.Wrap(a.checkAction(apidefaults.Namespace, kind, types.VerbList, types.VerbRead))
+	}
+
+}
 
 // ListUnifiedResources returns a paginated list of unified resources filtered by user access.
 func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.ListUnifiedResourcesRequest) (*proto.ListUnifiedResourcesResponse, error) {
@@ -1301,58 +1323,42 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 	// Validate the requested kinds and precheck that the user has read/list
 	// permissions for all requested resources before doing any listing of
 	// resources to conserve resources.
-	requested := req.Kinds
+	requested := utils.Deduplicate(req.Kinds)
 	if len(req.Kinds) == 0 {
 		requested = defaultUnifiedResourceKinds
 	}
 
-	resourceAccess := &resourceAccess{
-		// Populate kindAccessMap with any access errors the user has for each possible
-		// resource kind. This allows the access check to occur a single time per resource
-		// kind instead of once per matching resource.
-		kindAccessMap: make(map[string]error, len(requested)),
-		// requestableMap is populated with resources that are being returned but can only
-		// be accessed to the user via an access request
-		requestableMap: make(map[string]struct{}),
-	}
-
+	kindAccessErrMap := make(map[string]error)
 	for _, kind := range requested {
-		if _, ok := supportedUnifiedResourceKinds[kind]; !ok {
-			return nil, trace.BadParameter("Unsupported kind %q requested", kind)
+		if err := a.checkKindAccess(kind); err != nil {
+			kindAccessErrMap[kind] = trace.Wrap(err)
 		}
-
-		actionVerbs := []string{types.VerbList, types.VerbRead}
-		if kind == types.KindNode {
-			// We are checking list only for Nodes to keep backwards compatibility.
-			// The read verb got added to GetNodes initially in:
-			//   https://github.com/gravitational/teleport/pull/1209
-			// but got removed shortly afterwards in:
-			//   https://github.com/gravitational/teleport/pull/1224
-			actionVerbs = []string{types.VerbList}
-		}
-
-		checkAction := a.selectActionChecker(kind)
-		resourceAccess.kindAccessMap[kind] = checkAction(apidefaults.Namespace, kind, actionVerbs...)
 	}
 
 	// Before doing any listing, verify that the user is allowed to list
 	// at least one of the requested kinds. If no access is permitted, then
 	// return an access denied error.
-	var rbacErrors int
-	for _, kind := range requested {
-		if err, ok := resourceAccess.kindAccessMap[kind]; ok && err != nil {
-			rbacErrors++
-		}
+	if len(kindAccessErrMap) == len(requested) {
+		return nil, trace.AccessDenied("User does not have access to any of the requested kinds: %v", requested)
 	}
 
-	if rbacErrors == len(requested) {
-		return nil, trace.AccessDenied("User does not have access to any of the requested kinds: %v", requested)
+	var err error
+
+	resourceLister := &unifiedResourceLister{
+		kindAccessErrMap: kindAccessErrMap,
+
+		requestableMap: make(map[string]struct{}),
+	}
+
+	resourceLister.accessChecker, err = newResourceAccessChecker(a.context, types.KindUnifiedResource)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	// Apply any requested additional search_as_roles and/or preview_as_roles
 	// for the duration of the search.
 	if req.UseSearchAsRoles || req.UsePreviewAsRoles || req.IncludeRequestable {
-		extendedContext, err := a.authContextForSearch(ctx, &proto.ListResourcesRequest{
+		extendedAuthCtx, err := a.authContextForSearch(ctx, &proto.ListResourcesRequest{
 			UseSearchAsRoles:    req.UseSearchAsRoles || req.IncludeRequestable,
 			UsePreviewAsRoles:   req.UsePreviewAsRoles,
 			ResourceType:        types.KindUnifiedResource,
@@ -1364,29 +1370,18 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		baseContext := a.context
-		// If IncludeRequestable is true, we will create a baseChecker to
-		// use during RBAC to determine if a resource would be available only after extending
-		if req.IncludeRequestable {
-			baseChecker, err := a.newResourceAccessChecker(types.KindUnifiedResource)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			resourceAccess.baseAuthChecker = baseChecker
+
+		requestableAccessChecker, err := newResourceAccessChecker(*extendedAuthCtx, types.KindUnifiedResource)
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
 
-		a.context = *extendedContext
-		defer func() {
-			a.context = baseContext
-		}()
+		if req.IncludeRequestable {
+			resourceLister.requestableAccessChecker = requestableAccessChecker
+		} else {
+			resourceLister.accessChecker = requestableAccessChecker
+		}
 	}
-
-	checker, err := a.newResourceAccessChecker(types.KindUnifiedResource)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	resourceAccess.accessChecker = checker
 
 	var (
 		unifiedResources types.ResourcesWithLabels
@@ -1401,7 +1396,7 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 			return &proto.ListUnifiedResourcesResponse{}, nil
 		}
 		unifiedResources, err = a.authServer.UnifiedResourceCache.GetUnifiedResourcesByIDs(ctx, prefs.ClusterPreferences.PinnedResources.GetResourceIds(), func(resource types.ResourceWithLabels) (bool, error) {
-			match, err := resourceAccess.checkAccess(resource, filter)
+			match, err := resourceLister.canList(resource, filter)
 			return match, trace.Wrap(err)
 		})
 		if err != nil {
@@ -1416,7 +1411,7 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 		}
 	} else {
 		unifiedResources, nextKey, err = a.authServer.UnifiedResourceCache.IterateUnifiedResources(ctx, func(resource types.ResourceWithLabels) (bool, error) {
-			match, err := resourceAccess.checkAccess(resource, filter)
+			match, err := resourceLister.canList(resource, filter)
 			return match, trace.Wrap(err)
 		}, req)
 		if err != nil {
@@ -1424,7 +1419,7 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 		}
 	}
 
-	paginatedResources, err := services.MakePaginatedResources(ctx, types.KindUnifiedResource, unifiedResources, resourceAccess.requestableMap)
+	paginatedResources, err := services.MakePaginatedResources(ctx, types.KindUnifiedResource, unifiedResources, resourceLister.requestableMap)
 	if err != nil {
 		return nil, trace.Wrap(err, "making paginated unified resources")
 	}
@@ -1432,7 +1427,7 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 	if req.IncludeLogins {
 		for _, r := range paginatedResources {
 			if n := r.GetNode(); n != nil {
-				logins, err := checker.GetAllowedLoginsForResource(n)
+				logins, err := resourceLister.getAllowedLogins(n)
 				if err != nil {
 					a.authServer.logger.WarnContext(ctx, "Unable to determine logins for node",
 						"error", err,
@@ -1442,7 +1437,7 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 				}
 				r.Logins = logins
 			} else if d := r.GetWindowsDesktop(); d != nil {
-				logins, err := checker.GetAllowedLoginsForResource(d)
+				logins, err := resourceLister.getAllowedLogins(d)
 				if err != nil {
 					a.authServer.logger.WarnContext(ctx, "Unable to determine logins for desktop",
 						"error", err,
@@ -1457,7 +1452,7 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 				// view of the account we check access for each Permission Set, filter out those that have
 				// no access and treat the whole app as requiring an access request if _any_ of the contained
 				// permission sets require one.
-				if err := a.filterICPermissionSets(r, d.GetApp(), resourceAccess); err != nil {
+				if err := a.filterICPermissionSets(r, d.GetApp(), resourceLister); err != nil {
 					a.authServer.logger.WarnContext(ctx, "Unable to filter",
 						"error", err,
 						"resource", d.GetApp().GetName(),
@@ -1465,7 +1460,7 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 					continue
 				}
 
-				logins, err := checker.GetAllowedLoginsForResource(d.GetApp())
+				logins, err := resourceLister.getAllowedLogins(d.GetApp())
 				if err != nil {
 					a.authServer.logger.WarnContext(ctx, "Unable to determine logins for app",
 						"error", err,
@@ -1484,7 +1479,7 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 	}, nil
 }
 
-func (a *ServerWithRoles) filterICPermissionSets(r *proto.PaginatedResource, app types.Application, checker *resourceAccess) error {
+func (a *ServerWithRoles) filterICPermissionSets(r *proto.PaginatedResource, app types.Application, checker *unifiedResourceLister) error {
 	appV3, ok := app.(*types.AppV3)
 	if !ok {
 		return trace.BadParameter("resource must be an app")
@@ -1514,7 +1509,7 @@ func (a *ServerWithRoles) filterICPermissionSets(r *proto.PaginatedResource, app
 		assignment.Metadata.Name = ps.AssignmentID
 		permissionSetQuery.Arn = ps.ARN
 
-		hasAccess, err := checker.checkAccess(checkable, services.MatchResourceFilter{
+		hasAccess, err := checker.canList(checkable, services.MatchResourceFilter{
 			ResourceKind: types.KindIdentityCenterAccountAssignment,
 		})
 		if err != nil {
@@ -1837,8 +1832,7 @@ func (a *ServerWithRoles) ListResources(ctx context.Context, req proto.ListResou
 		return nil, trace.NotImplemented("resource type %s does not support pagination", req.ResourceType)
 	}
 
-	checkAction := a.selectActionChecker(req.ResourceType)
-	if err := checkAction(req.Namespace, req.ResourceType, actionVerbs...); err != nil {
+	if err := a.checkAction(req.Namespace, req.ResourceType, actionVerbs...); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -1868,7 +1862,7 @@ func (a *ServerWithRoles) ListResources(ctx context.Context, req proto.ListResou
 	// the next key.
 	req.Limit++
 
-	resourceChecker, err := a.newResourceAccessChecker(req.ResourceType)
+	resourceChecker, err := newResourceAccessChecker(a.context, req.ResourceType)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1923,14 +1917,8 @@ func (a *ServerWithRoles) ListResources(ctx context.Context, req proto.ListResou
 	return &resp, nil
 }
 
-// resourceAccessChecker allows access to be checked differently per resource type.
-type resourceAccessChecker interface {
-	CanAccess(resource types.Resource) error
-	GetAllowedLoginsForResource(resource services.AccessCheckable) ([]string, error)
-}
-
-// resourceChecker is a pass through checker that utilizes the provided
-// services.AccessChecker to check access
+// resourceChecker is a pass through checker that utilizes the provided [services.AccessChecker] to
+// check access to an untyped resource.
 type resourceChecker struct {
 	services.AccessChecker
 }
@@ -1983,8 +1971,8 @@ func (r resourceChecker) CanAccess(resource types.Resource) error {
 	return trace.BadParameter("could not check access to resource type %T", resource)
 }
 
-// newResourceAccessChecker creates a resourceAccessChecker for the provided resource type
-func (a *ServerWithRoles) newResourceAccessChecker(resource string) (resourceAccessChecker, error) {
+// newResourceAccessChecker creates a resourceChecker for the provided resource type
+func newResourceAccessChecker(authCtx authz.Context, resource string) (*resourceChecker, error) {
 	switch resource {
 	case types.KindAppServer,
 		types.KindDatabaseServer,
@@ -1998,7 +1986,7 @@ func (a *ServerWithRoles) newResourceAccessChecker(resource string) (resourceAcc
 		types.KindSAMLIdPServiceProvider,
 		types.KindIdentityCenterAccount,
 		types.KindIdentityCenterAccountAssignment:
-		return &resourceChecker{AccessChecker: a.context.Checker}, nil
+		return &resourceChecker{AccessChecker: authCtx.Checker}, nil
 	default:
 		return nil, trace.BadParameter("could not check access to resource type %s", resource)
 	}
@@ -2168,7 +2156,7 @@ func (a *ServerWithRoles) listResourcesWithSort(ctx context.Context, req proto.L
 				return r, nil
 			}
 
-			resourceChecker, err := a.newResourceAccessChecker(req.ResourceType)
+			resourceChecker, err := newResourceAccessChecker(a.context, req.ResourceType)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}


### PR DESCRIPTION
There are no semantic changes whatsoever.

While I was working on support Okta read-only in Access Requests I needed to understand the way we handle unified resources listing. While figuring this out I refactored the code so it is now easier to comprehend to me. Hopefully it's also easier to comprehend to others.

This is a part of my branch with changes for Okta read-only support in Access Requests.