### PR TITLE
Handle Access Requests in Okta read-only mode

### DIFF
--- a/api/types/okta.go
+++ b/api/types/okta.go
@@ -508,6 +508,34 @@ func (o *PluginOktaSettings) GetSyncSettings() *PluginOktaSyncSettings {
 	return o.SyncSettings
 }
 
+func (o *PluginOktaSyncSettings) GetUserSyncEnabled() bool {
+	if o == nil {
+		return false
+	}
+	return o.SyncUsers
+}
+
+func (o *PluginOktaSyncSettings) GetAppGroupSyncEnabled() bool {
+	if !o.GetUserSyncEnabled() {
+		return false
+	}
+	return !o.DisableSyncAppGroups
+}
+
+func (o *PluginOktaSyncSettings) GetAccessListSyncEnabled() bool {
+	if o == nil {
+		return false
+	}
+	return o.SyncAccessLists
+}
+
+func (o *PluginOktaSyncSettings) GetBidirectionalSyncEnabled() bool {
+	if !o.GetAccessListSyncEnabled() {
+		return false
+	}
+	return !o.DisableBidirectionalSync
+}
+
 type OktaUserSyncSource string
 
 // IsUnknown returns true if user sync source is empty or explicitly set to "unknown".

--- a/api/types/okta_test.go
+++ b/api/types/okta_test.go
@@ -304,3 +304,69 @@ func Test_PluginOktaSyncSettings_SetUserSyncSource(t *testing.T) {
 		require.Equal(t, OktaUserSyncSourceSamlApp, syncSettings.GetUserSyncSource())
 	})
 }
+
+func Test_PluginOktaSyncSettings_SyncEnabledGetters(t *testing.T) {
+	t.Run("on nil settings", func(t *testing.T) {
+		syncSettings := (*PluginOktaSyncSettings)(nil)
+
+		require.False(t, syncSettings.GetUserSyncEnabled())
+		require.False(t, syncSettings.GetAppGroupSyncEnabled())
+		require.False(t, syncSettings.GetAccessListSyncEnabled())
+		require.False(t, syncSettings.GetBidirectionalSyncEnabled())
+	})
+
+	t.Run("on empty settings", func(t *testing.T) {
+		syncSettings := &PluginOktaSyncSettings{}
+
+		require.False(t, syncSettings.GetUserSyncEnabled())
+		require.False(t, syncSettings.GetAppGroupSyncEnabled())
+		require.False(t, syncSettings.GetAccessListSyncEnabled())
+		require.False(t, syncSettings.GetBidirectionalSyncEnabled())
+	})
+
+	t.Run("on user sync enabled", func(t *testing.T) {
+		syncSettings := &PluginOktaSyncSettings{
+			SyncUsers: true,
+		}
+
+		require.True(t, syncSettings.GetUserSyncEnabled())
+		require.True(t, syncSettings.GetAppGroupSyncEnabled()) // true by default
+		require.False(t, syncSettings.GetAccessListSyncEnabled())
+		require.False(t, syncSettings.GetBidirectionalSyncEnabled())
+	})
+
+	t.Run("on user sync enabled with disabled app and group sync", func(t *testing.T) {
+		syncSettings := &PluginOktaSyncSettings{
+			SyncUsers:            true,
+			DisableSyncAppGroups: true,
+		}
+
+		require.True(t, syncSettings.GetUserSyncEnabled())
+		require.False(t, syncSettings.GetAppGroupSyncEnabled())
+		require.False(t, syncSettings.GetAccessListSyncEnabled())
+		require.False(t, syncSettings.GetBidirectionalSyncEnabled())
+	})
+
+	t.Run("on access list sync enabled", func(t *testing.T) {
+		syncSettings := &PluginOktaSyncSettings{
+			SyncAccessLists: true,
+		}
+
+		require.False(t, syncSettings.GetUserSyncEnabled())
+		require.False(t, syncSettings.GetAppGroupSyncEnabled())
+		require.True(t, syncSettings.GetAccessListSyncEnabled())
+		require.True(t, syncSettings.GetBidirectionalSyncEnabled()) // true by default
+	})
+
+	t.Run("on access list sync enabled with bidirectional sync disabled", func(t *testing.T) {
+		syncSettings := &PluginOktaSyncSettings{
+			SyncAccessLists:          true,
+			DisableBidirectionalSync: true,
+		}
+
+		require.False(t, syncSettings.GetUserSyncEnabled())
+		require.False(t, syncSettings.GetAppGroupSyncEnabled())
+		require.True(t, syncSettings.GetAccessListSyncEnabled())
+		require.False(t, syncSettings.GetBidirectionalSyncEnabled())
+	})
+}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1183,16 +1183,16 @@ func (a *ServerWithRoles) GetNode(ctx context.Context, namespace, name string) (
 type unifiedResourceLister struct {
 	// accessChecker is used to check a user's access to resources. This can
 	// be extended to include SearchAsRoles
-	accessChecker *resourceChecker
+	accessChecker resourceCheckerI
 	// requestableAccessChecker is optional. If set it will be considered a fallback checker if
 	// accessChecker denies access. If a resource is allowed by the requestableAccessChecker,
 	// the resource's name will be added to the requestableMap.
-	requestableAccessChecker *resourceChecker
+	requestableAccessChecker resourceCheckerI
 	// kindAccessErrMap is used to check errors for list/read verbs per kind.
 	kindAccessErrMap map[string]error
-
 	// requestableMap is used to track if a resource matches a filter but is only
 	// available after an access request. This map is of Resource.GetName().
+	// If the requestableMap is nil then no requestable resources will be traced.
 	requestableMap map[string]struct{}
 }
 
@@ -1237,10 +1237,12 @@ func (c *unifiedResourceLister) canList(resource types.ResourceWithLabels, filte
 		return false, nil
 	}
 
-	// If the resource is requestable, allow listing it as requestable (put it in the the
-	// requestableMap).
+	// If the resource is requestable, allow listing it as requestable (and put it in the the
+	// requestableMap if not nil).
 	if err := c.requestableAccessChecker.CanAccess(resource); err == nil {
-		c.requestableMap[resource.GetName()] = struct{}{}
+		if c.requestableMap != nil {
+			c.requestableMap[resource.GetName()] = struct{}{}
+		}
 		return true, nil
 	} else if !trace.IsAccessDenied(err) {
 		return false, trace.Wrap(err)
@@ -1306,7 +1308,7 @@ func (a *ServerWithRoles) checkKindAccess(kind string) error {
 
 // ListUnifiedResources returns a paginated list of unified resources filtered by user access.
 func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.ListUnifiedResourcesRequest) (*proto.ListUnifiedResourcesResponse, error) {
-	filter := services.MatchResourceFilter{
+	userFilter := services.MatchResourceFilter{
 		Labels:         req.Labels,
 		SearchKeywords: req.SearchKeywords,
 		Kinds:          req.Kinds,
@@ -1317,7 +1319,7 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		filter.PredicateExpression = expression
+		userFilter.PredicateExpression = expression
 	}
 
 	// Validate the requested kinds and precheck that the user has read/list
@@ -1346,8 +1348,6 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 
 	resourceLister := &unifiedResourceLister{
 		kindAccessErrMap: kindAccessErrMap,
-
-		requestableMap: make(map[string]struct{}),
 	}
 
 	resourceLister.accessChecker, err = newResourceAccessChecker(a.context, types.KindUnifiedResource)
@@ -1371,15 +1371,22 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 			return nil, trace.Wrap(err)
 		}
 
-		requestableAccessChecker, err := newResourceAccessChecker(*extendedAuthCtx, types.KindUnifiedResource)
+		var requestableAccessChecker resourceCheckerI
+		requestableAccessChecker, err = newResourceAccessChecker(*extendedAuthCtx, types.KindUnifiedResource)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		requestableAccessChecker, err = createOktaRequestableResourceChecker(ctx, a.authServer.Plugins, requestableAccessChecker)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
+		resourceLister.requestableAccessChecker = requestableAccessChecker
+
 		if req.IncludeRequestable {
-			resourceLister.requestableAccessChecker = requestableAccessChecker
-		} else {
-			resourceLister.accessChecker = requestableAccessChecker
+			// if IncludeRequestable is set, then we want to know which of the listed
+			// resources are requestable in the listing.
+			resourceLister.requestableMap = make(map[string]struct{})
 		}
 	}
 
@@ -1396,7 +1403,7 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 			return &proto.ListUnifiedResourcesResponse{}, nil
 		}
 		unifiedResources, err = a.authServer.UnifiedResourceCache.GetUnifiedResourcesByIDs(ctx, prefs.ClusterPreferences.PinnedResources.GetResourceIds(), func(resource types.ResourceWithLabels) (bool, error) {
-			match, err := resourceLister.canList(resource, filter)
+			match, err := resourceLister.canList(resource, userFilter)
 			return match, trace.Wrap(err)
 		})
 		if err != nil {
@@ -1411,7 +1418,7 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 		}
 	} else {
 		unifiedResources, nextKey, err = a.authServer.UnifiedResourceCache.IterateUnifiedResources(ctx, func(resource types.ResourceWithLabels) (bool, error) {
-			match, err := resourceLister.canList(resource, filter)
+			match, err := resourceLister.canList(resource, userFilter)
 			return match, trace.Wrap(err)
 		}, req)
 		if err != nil {
@@ -1917,6 +1924,12 @@ func (a *ServerWithRoles) ListResources(ctx context.Context, req proto.ListResou
 	return &resp, nil
 }
 
+// resourceCheckerI is an interface for [resourceChecker] allowing extending the resourceChecker.
+type resourceCheckerI interface {
+	CanAccess(resource types.ResourceWithLabels) error
+	GetAllowedLoginsForResource(resource services.AccessCheckable) ([]string, error)
+}
+
 // resourceChecker is a pass through checker that utilizes the provided [services.AccessChecker] to
 // check access to an untyped resource.
 type resourceChecker struct {
@@ -1925,7 +1938,7 @@ type resourceChecker struct {
 
 // CanAccess handles providing the proper services.AccessCheckable resource
 // to the services.AccessChecker
-func (r resourceChecker) CanAccess(resource types.Resource) error {
+func (r *resourceChecker) CanAccess(resource types.ResourceWithLabels) error {
 	// MFA is not required for operations on app resources but
 	// will be enforced at the connection time.
 	state := services.AccessState{MFAVerified: true}
@@ -1990,6 +2003,39 @@ func newResourceAccessChecker(authCtx authz.Context, resource string) (*resource
 	default:
 		return nil, trace.BadParameter("could not check access to resource type %s", resource)
 	}
+}
+
+// createOktaRequestableResourceChecker creates [oktaRequestableResoruceChecker].
+func createOktaRequestableResourceChecker(ctx context.Context, plugins services.Plugins, underlying resourceCheckerI) (*oktaRequestableResoruceChecker, error) {
+	bidirectionalSync, err := okta.BidirectionalSyncEnabled(ctx, plugins)
+	if err != nil {
+		return nil, trace.Wrap(err, "checking if Okta bidirectional sync is enabled")
+	}
+	return &oktaRequestableResoruceChecker{
+		underlying: underlying,
+		readOnly:   !bidirectionalSync,
+	}, nil
+}
+
+// oktaRequestableResoruceChecker is a wrapper for [resourceCheckerI] checking if Okta-originated
+// resource should not be allowed due to bidirectional sync being disabled.  It exists to support
+// the Okta Access Request flow, where creating an Access Request can trigger changes in the
+// upstream Okta provider. In read-only mode, we want to prevent such changes.
+type oktaRequestableResoruceChecker struct {
+	underlying resourceCheckerI
+	readOnly   bool
+}
+
+func (c *oktaRequestableResoruceChecker) CanAccess(resource types.ResourceWithLabels) error {
+	if c.readOnly && resource.Origin() == types.OriginOkta {
+		return trace.AccessDenied("resource not requestable due to disabled Okta bidirectional sync")
+	}
+	return trace.Wrap(c.underlying.CanAccess(resource))
+}
+
+func (c *oktaRequestableResoruceChecker) GetAllowedLoginsForResource(resource services.AccessCheckable) ([]string, error) {
+	logins, err := c.underlying.GetAllowedLoginsForResource(resource)
+	return logins, trace.Wrap(err)
 }
 
 // listResourcesWithSort retrieves all resources of a certain resource type with rbac applied

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -64,6 +64,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/auth/okta"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/cryptosuites"
@@ -71,6 +72,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/okta/oktatest"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
@@ -5516,6 +5518,270 @@ func TestListUnifiedResources_IncludeRequestable(t *testing.T) {
 	}
 }
 
+func TestCreateAccessRequestV2_oktaReadOnly(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	srv := newTestTLSServer(t)
+
+	// 1. Create Okta-originated app server in the backend.
+
+	searchableOktaApp := newTestAppServerV3(t, srv.Auth(), "serachable-okta-app", map[string]string{
+		"name":            "serachable-okta-app",
+		types.OriginLabel: types.OriginOkta,
+	})
+
+	// 2. Create a role allowing the Okta app (used for search_as_roles)
+
+	searchRole, err := CreateRole(ctx, srv.Auth(), "serach_role", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			AppLabels: types.Labels{
+				"name": {searchableOktaApp.GetName()},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// 3. Create the user role allowing to search Okta app
+
+	aliceRole, err := CreateRole(ctx, srv.Auth(), "alice_role", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Request: &types.AccessRequestConditions{
+				SearchAsRoles: []string{
+					searchRole.GetName(),
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// 4. Create the user
+
+	alice, err := CreateUser(ctx, srv.Auth(), "alice", aliceRole)
+	require.NoError(t, err)
+
+	// 5. Create a client for the user
+
+	aliceClt, err := srv.NewClient(TestUser(alice.GetName()))
+	require.NoError(t, err)
+
+	// 6. Prepare access requests
+
+	testAccessRequests := []types.AccessRequest{
+		// requesting app
+		mustAccessRequest(t, alice.GetName(), types.RequestState_PENDING, srv.Clock().Now(), srv.Clock().Now().Add(time.Hour),
+			[]string{}, // roles
+			[]types.ResourceID{
+				mustResourceID(srv.ClusterName(), types.KindApp, searchableOktaApp.GetName()),
+			},
+		),
+		// requesting app_server
+		mustAccessRequest(t, alice.GetName(), types.RequestState_PENDING, srv.Clock().Now(), srv.Clock().Now().Add(time.Hour),
+			[]string{}, // roles
+			[]types.ResourceID{
+				mustResourceID(srv.ClusterName(), types.KindAppServer, searchableOktaApp.GetName()),
+			},
+		),
+	}
+
+	// 7. Run tests
+
+	t.Run("requesting okta resources but no okta plugin", func(t *testing.T) {
+		// Note: Okta-originated resources present in the cluster and no Okta plugin
+		// configured is the situation where the plugin was freshly deleted and the
+		// heartbeats for the Okta apps haven't expired yet. This is an edge-case so the
+		// error is a bit confusing.
+		for _, accessRequest := range testAccessRequests {
+			_, err := aliceClt.CreateAccessRequestV2(ctx, accessRequest)
+			require.Error(t, err)
+			require.True(t, trace.IsBadParameter(err))
+			require.ErrorContains(t, err, okta.OktaResourceNotRequestableError.Error())
+		}
+	})
+
+	t.Run("requesting okta resources and okta bidirectional sync enabled", func(t *testing.T) {
+		oktatest.UpsertPlugin(t, srv.Auth().Plugins,
+			oktatest.NewPlugin(t,
+				oktatest.WithSyncSettings(&types.PluginOktaSyncSettings{
+					SyncAccessLists:          true,
+					DefaultOwners:            []string{"the-owner"},
+					DisableBidirectionalSync: false,
+				}),
+			),
+		)
+
+		for _, accessRequest := range testAccessRequests {
+			_, err := aliceClt.CreateAccessRequestV2(ctx, accessRequest)
+			require.NoError(t, err)
+		}
+	})
+
+	t.Run("requesting okta resources and okta bidirectional sync disabled", func(t *testing.T) {
+		oktatest.UpsertPlugin(t, srv.Auth().Plugins,
+			oktatest.NewPlugin(t,
+				oktatest.WithSyncSettings(&types.PluginOktaSyncSettings{
+					SyncAccessLists:          true,
+					DefaultOwners:            []string{"the-owner"},
+					DisableBidirectionalSync: true,
+				}),
+			),
+		)
+
+		for _, accessRequest := range testAccessRequests {
+			_, err := aliceClt.CreateAccessRequestV2(ctx, accessRequest)
+			require.Error(t, err)
+			require.True(t, trace.IsBadParameter(err))
+			require.ErrorContains(t, err, okta.OktaResourceNotRequestableError.Error())
+		}
+	})
+}
+
+func TestListUnifiedResources_search_as_roles_oktaReadOnly(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	srv := newTestTLSServer(t)
+
+	// 1. Create app resources
+
+	searchableGenericApp := newTestAppServerV3(t, srv.Auth(),
+		"test_generic_app",
+		map[string]string{
+			"find_me": "please",
+		},
+	)
+
+	searchableOktaApp := newTestAppServerV3(t, srv.Auth(),
+		"test_searchable_okta_app",
+		map[string]string{
+			"find_me":         "please",
+			types.OriginLabel: types.OriginOkta,
+		},
+	)
+
+	assignedOktaApp := newTestAppServerV3(t, srv.Auth(),
+		"test_assigned_okta_app",
+		map[string]string{
+			"owner":           "alice",
+			types.OriginLabel: types.OriginOkta,
+		},
+	)
+
+	// 2. Create a role allowing the Okta app (used for search_as_roles)
+
+	searchRole, err := CreateRole(ctx, srv.Auth(), "serach_role", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			AppLabels: types.Labels{
+				"find_me": {"please"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// 3. Create the user role allowing access to one Okta app and allowing to search the other Okta app
+
+	aliceRole, err := CreateRole(ctx, srv.Auth(), "alice_role", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			AppLabels: types.Labels{
+				"owner": []string{"alice"},
+			},
+			Request: &types.AccessRequestConditions{
+				SearchAsRoles: []string{
+					searchRole.GetName(),
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// 4. Create the user
+
+	alice, err := CreateUser(ctx, srv.Auth(), "alice", aliceRole)
+	require.NoError(t, err)
+
+	// 5. Run tests
+
+	type expected struct {
+		name        string
+		requestable bool
+	}
+
+	for _, tc := range []struct {
+		name                  string
+		useSearchAsRoles      bool
+		includeRequestable    bool
+		oktaBidirectionalSync bool
+		expectedResources     []expected
+	}{
+		{
+			name:                  "useSearchAsRoles and Okta bidirectional sync enabled",
+			useSearchAsRoles:      true,
+			oktaBidirectionalSync: true,
+			expectedResources: []expected{
+				{name: assignedOktaApp.GetName(), requestable: false},
+				{name: searchableOktaApp.GetName(), requestable: false}, // includes Okta searchable app
+				{name: searchableGenericApp.GetName(), requestable: false},
+			},
+		},
+		{
+			name:                  "useSearchAsRoles and Okta bidirectional sync disabled",
+			useSearchAsRoles:      true,
+			oktaBidirectionalSync: false,
+			expectedResources: []expected{
+				{name: assignedOktaApp.GetName(), requestable: false},
+				{name: searchableGenericApp.GetName(), requestable: false},
+			},
+		},
+		{
+			name:                  "includeRequestable and Okta bidirectional sync enabled",
+			includeRequestable:    true,
+			oktaBidirectionalSync: true,
+			expectedResources: []expected{
+				{name: assignedOktaApp.GetName(), requestable: false},
+				{name: searchableOktaApp.GetName(), requestable: true}, // includes Okta searchable app
+				{name: searchableGenericApp.GetName(), requestable: true},
+			},
+		},
+		{
+			name:                  "includeRequestable and Okta bidirectional sync disabled",
+			includeRequestable:    true,
+			oktaBidirectionalSync: false,
+			expectedResources: []expected{
+				{name: assignedOktaApp.GetName(), requestable: false},
+				{name: searchableGenericApp.GetName(), requestable: true},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := proto.ListUnifiedResourcesRequest{
+				SortBy:             types.SortBy{Field: "name", IsDesc: false},
+				Limit:              int32(1000),
+				IncludeRequestable: tc.includeRequestable,
+				UseSearchAsRoles:   tc.useSearchAsRoles,
+			}
+
+			oktatest.UpsertPlugin(t, srv.Auth().Plugins,
+				oktatest.NewPlugin(t, oktatest.WithSyncSettings(&types.PluginOktaSyncSettings{
+					SyncAccessLists:          true,
+					DefaultOwners:            []string{"alice"},
+					DisableBidirectionalSync: !tc.oktaBidirectionalSync,
+				})),
+			)
+
+			aliceClt, err := srv.NewClient(TestUser(alice.GetName()))
+			require.NoError(t, err)
+
+			resp, err := aliceClt.ListUnifiedResources(ctx, &req)
+			require.NoError(t, err)
+
+			var resources []expected
+			for _, resource := range resp.Resources {
+				resources = append(resources, expected{name: resource.GetAppServer().GetName(), requestable: resource.RequiresRequest})
+			}
+			require.Len(t, resources, len(tc.expectedResources))
+			require.ElementsMatch(t, tc.expectedResources, resources)
+		})
+	}
+}
+
 // TestListUnifiedResources_KindsFilter will generate multiple resources
 // and filter for only one kind.
 func TestListUnifiedResources_KindsFilter(t *testing.T) {
@@ -9326,10 +9592,9 @@ func TestAccessRequestNonGreedyAnnotations(t *testing.T) {
 func mustAccessRequest(t *testing.T, user string, state types.RequestState, created, expires time.Time, roles []string, resourceIDs []types.ResourceID) types.AccessRequest {
 	t.Helper()
 
-	accessRequest, err := types.NewAccessRequest(uuid.NewString(), user, roles...)
+	accessRequest, err := types.NewAccessRequestWithResources(uuid.NewString(), user, roles, resourceIDs)
 	require.NoError(t, err)
 
-	accessRequest.SetRequestedResourceIDs(resourceIDs)
 	accessRequest.SetState(state)
 	accessRequest.SetCreationTime(created)
 	accessRequest.SetExpiry(expires)
@@ -10250,4 +10515,36 @@ func TestValidateOracleJoinToken(t *testing.T) {
 			})
 		}
 	})
+}
+
+func newTestAppServerV3(t *testing.T, auth *Server, name string, labels map[string]string) *types.AppServerV3 {
+	t.Helper()
+	ctx := context.Background()
+
+	app, err := types.NewAppV3(
+		types.Metadata{
+			Name:   name,
+			Labels: labels,
+		},
+		types.AppSpecV3{
+			URI: "https://" + name + ".example.com",
+		},
+	)
+	require.NoError(t, err)
+	appServer, err := types.NewAppServerV3(
+		types.Metadata{
+			Name:   name,
+			Labels: labels,
+		},
+		types.AppServerSpecV3{
+			HostID: "test-host-id",
+			App:    app,
+		},
+	)
+	require.NoError(t, err)
+
+	_, err = auth.UpsertApplicationServer(ctx, appServer)
+	require.NoError(t, err, "upserting test Application Server")
+
+	return appServer
 }

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -347,6 +347,9 @@ type InitConfig struct {
 	// this node.
 	IdentityCenter services.IdentityCenter
 
+	// Plugins is a service that manages plugin resources for integrations.
+	Plugins *local.PluginsService
+
 	// PluginStaticCredentials handles credentials for integrations and plugins.
 	PluginStaticCredentials services.PluginStaticCredentials
 

--- a/lib/auth/okta/auth.go
+++ b/lib/auth/okta/auth.go
@@ -19,10 +19,14 @@
 package okta
 
 import (
+	"context"
+
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
+	oktaplugin "github.com/gravitational/teleport/lib/okta/plugin"
+	"github.com/gravitational/teleport/lib/services"
 )
 
 // Okta-origin resources have some special access rules that are implemented in
@@ -91,4 +95,76 @@ func CheckAccess(authzCtx *authz.Context, existingResource types.ResourceWithLab
 	// may be allowed to modify a resource, so they get AccessDenied by
 	// default.
 	return trace.AccessDenied("Okta service may only %s Okta resources", verb)
+}
+
+// BidirectionalSyncEnabled checks if the bidirectional sync is enabled on the Okta plugin.  If the
+// Okta plugin does not exist the result is false.
+func BidirectionalSyncEnabled(ctx context.Context, plugins services.Plugins) (bool, error) {
+	plugin, err := oktaplugin.Get(ctx, plugins, false /* withSecrets */)
+	if trace.IsNotFound(err) {
+		return false, nil
+	} else if err != nil {
+		return false, trace.Wrap(err, "getting Okta plugin")
+	}
+	return plugin.Spec.GetOkta().GetSyncSettings().GetBidirectionalSyncEnabled(), nil
+}
+
+// AccessPoint provides services required by [CheckResourcesRequestable].
+type AccessPoint struct {
+	Plugins              services.Plugins
+	UnifiedResourceCache *services.UnifiedResourceCache
+}
+
+var (
+	// OktaResourceNotRequestableError means resources cannot be requested because Okta
+	// bidirectional sync is disabled.
+	OktaResourceNotRequestableError = trace.BadParameter("Okta resources not requestable due to disabled bidirectional sync")
+)
+
+// CheckResourcesRequestable checks if the provided resources are requestable from the Okta integration point of view.
+//
+// Resources are considered not requestable and AccessDenied error is returned when:
+//
+//   - bidirectional sync is disabled in the Okta plugin
+//   - any of the resources is an Okta-originated app_server
+//
+// If any resource is not requestable, [OktaResourceNotRequestableError] will be returned. Any
+// other error can be returned.
+func CheckResourcesRequestable(ctx context.Context, ids []types.ResourceID, ap AccessPoint) error {
+	bidirectionalSyncEnabled, err := BidirectionalSyncEnabled(ctx, ap.Plugins)
+	if err != nil {
+		return trace.Wrap(err, "getting bidirectional sync")
+	}
+	if bidirectionalSyncEnabled {
+		return nil
+	}
+
+	var denied []types.ResourceID
+	for app, err := range ap.UnifiedResourceCache.AppServers(ctx, services.UnifiedResourcesIterateParams{}) {
+		if err != nil {
+			return trace.Wrap(err, "iterating cached AppServers")
+		}
+		for _, id := range ids {
+			switch id.Kind {
+			case types.KindApp, types.KindAppServer:
+				// ok
+			default:
+				continue
+			}
+			if app.GetName() == id.Name && app.Origin() == types.OriginOkta {
+				denied = append(denied, id)
+			}
+		}
+	}
+
+	if len(denied) == 0 {
+		return nil
+	}
+
+	resourcesStr, err := types.ResourceIDsToString(denied)
+	if err != nil {
+		return trace.Wrap(err, "converting resource IDs to string")
+	}
+
+	return trace.Wrap(OktaResourceNotRequestableError, "requested Okta resources: %s", resourcesStr)
 }

--- a/lib/okta/oktatest/helpers.go
+++ b/lib/okta/oktatest/helpers.go
@@ -1,0 +1,98 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package oktatest
+
+import (
+	"context"
+	"testing" //nolint:depguard // this a shared test package
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require" //nolint:depguard // this a shared test package
+
+	"github.com/gravitational/teleport/api/types"
+	oktaplugin "github.com/gravitational/teleport/lib/okta/plugin"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+type pluginOption func(*pluginOptions)
+
+type pluginOptions struct {
+	syncSettings *types.PluginOktaSyncSettings
+}
+
+func WithSyncSettings(syncSettings *types.PluginOktaSyncSettings) pluginOption {
+	return func(pluginOpts *pluginOptions) {
+		pluginOpts.syncSettings = syncSettings
+	}
+}
+
+// CreatePlugin creates a Okta plugin for test.
+func NewPlugin(t *testing.T, opts ...pluginOption) *types.PluginV1 {
+	t.Helper()
+
+	pluginOpts := &pluginOptions{}
+	for _, opt := range opts {
+		opt(pluginOpts)
+	}
+
+	plugin := types.NewPluginV1(
+		types.Metadata{
+			Name: types.PluginTypeOkta,
+		},
+		types.PluginSpecV1{
+			Settings: &types.PluginSpecV1_Okta{
+				Okta: &types.PluginOktaSettings{
+					OrgUrl:       "https://okta.example.com",
+					SyncSettings: pluginOpts.syncSettings,
+				},
+			},
+		},
+		&types.PluginCredentialsV1{
+			Credentials: &types.PluginCredentialsV1_StaticCredentialsRef{
+				StaticCredentialsRef: &types.PluginStaticCredentialsRef{
+					Labels: map[string]string{"test-cred-key": "test-cred-value"},
+				},
+			},
+		},
+	)
+
+	require.NoError(t, plugin.CheckAndSetDefaults(), "validating test Okta plugin")
+	return plugin
+}
+
+// UpsertPlugin upserts Okta plugin ignoring the revision.
+func UpsertPlugin(t *testing.T, plugins services.Plugins, plugin *types.PluginV1) {
+	t.Helper()
+	ctx := context.Background()
+
+	require.Equal(t, types.PluginTypeOkta, plugin.GetName())
+
+	old, err := oktaplugin.Get(ctx, plugins, true /* withSecrets */)
+	if trace.IsNotFound(err) {
+		err := plugins.CreatePlugin(ctx, plugin)
+		require.NoError(t, err, "creating test Okta plugin")
+		return
+	} else {
+		require.NoError(t, err, "getting test Okta plugin")
+	}
+
+	plugin.SetRevision(old.GetRevision())
+	_, err = plugins.UpdatePlugin(ctx, plugin)
+	require.NoError(t, err, "updating test Okta plugin")
+}

--- a/lib/okta/plugin/okta_plugin.go
+++ b/lib/okta/plugin/okta_plugin.go
@@ -1,0 +1,50 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package oktaplugin
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+// Get fetches the Okta plugin if it exists and does proper type assertions.
+func Get(ctx context.Context, plugins services.Plugins, withSecrets bool) (*types.PluginV1, error) {
+	plugin, err := plugins.GetPlugin(ctx, types.PluginTypeOkta, withSecrets)
+	if err != nil {
+		return nil, trace.Wrap(err, "getting Okta plugin")
+	}
+	pluginV1, ok := plugin.(*types.PluginV1)
+	if !ok {
+		return nil, trace.BadParameter("plugin.(%T) is not of type PluginV1", plugin)
+	}
+
+	oktaSettings := pluginV1.Spec.GetOkta()
+	if oktaSettings == nil {
+		return nil, trace.BadParameter("plugin %q does not have Okta settings", plugin.GetName())
+	}
+	if oktaSettings.SyncSettings == nil {
+		oktaSettings.SyncSettings = &types.PluginOktaSyncSettings{}
+	}
+
+	return pluginV1, nil
+}


### PR DESCRIPTION
Requires https://github.com/gravitational/teleport/pull/53590

Changes:

When Okta read-only is enabled (bidirectional sync is disabled):

- don't display Okta-originated resources in "All Resources" view
- don't display Okta-originated resources in "New Request" view
- error if Okta-originated resource access is requested

Note: this is still possible to request a role which allow access to an Okta-originated resource, but the team made a decision to allow this case.