### PR TITLE
Rename `NewSoftwarePrivateKey` to `NewPrivateKey`

### DIFF
--- a/api/testhelpers/mtls/mtls.go
+++ b/api/testhelpers/mtls/mtls.go
@@ -56,7 +56,7 @@ func generateCA(t *testing.T) (*keys.PrivateKey, *x509.Certificate) {
 
 	caPub, caPriv, err := ed25519.GenerateKey(rand.Reader)
 	require.NoError(t, err)
-	caKey, err := keys.NewPrivateKey(caPriv, nil)
+	caKey, err := keys.NewPrivateKey(caPriv)
 	require.NoError(t, err)
 
 	// Create a self signed certificate.
@@ -97,7 +97,7 @@ func generateChildTLSConfigFromCA(t *testing.T, caKey *keys.PrivateKey, caCert *
 	pub, priv, err := ed25519.GenerateKey(rand.Reader)
 	require.NoError(t, err)
 
-	key, err := keys.NewPrivateKey(priv, nil)
+	key, err := keys.NewPrivateKey(priv)
 	require.NoError(t, err)
 
 	// Create a certificate signed by the CA.

--- a/api/utils/keys/privatekey.go
+++ b/api/utils/keys/privatekey.go
@@ -60,29 +60,21 @@ type PrivateKey struct {
 	keyPEM []byte
 }
 
-// NewPrivateKey returns a new PrivateKey for the given crypto.Signer with a
-// pre-marshaled private key PEM, which may be a special PIV key PEM.
-func NewPrivateKey(signer crypto.Signer, keyPEM []byte) (*PrivateKey, error) {
-	sshPub, err := ssh.NewPublicKey(signer.Public())
+// NewPrivateKey returns a new PrivateKey for a crypto.Signer.
+// [signer] must be an *rsa.PrivateKey, *ecdsa.PrivateKey, ed25519.PrivateKey, or *hardwarekey.PrivateKey.
+// TODO(Joerger): Remove the variadic argument once /e is updated to not provide it.
+func NewPrivateKey(signer crypto.Signer, _ ...[]byte) (*PrivateKey, error) {
+	keyPEM, err := MarshalPrivateKey(signer)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	return &PrivateKey{
-		Signer: signer,
-		sshPub: sshPub,
-		keyPEM: keyPEM,
-	}, nil
+	return newPrivateKeyWithKeyPEM(signer, keyPEM)
 }
 
-// NewSoftwarePrivateKey returns a new PrivateKey for a crypto.Signer.
-// [signer] must be an *rsa.PrivateKey, *ecdsa.PrivateKey, ed25519.PrivateKey, or *hardwarekey.PrivateKey
-func NewSoftwarePrivateKey(signer crypto.Signer) (*PrivateKey, error) {
+// newPrivateKeyWithKeyPEM returns a new PrivateKey for the given crypto.Signer with a
+// pre-marshaled private key PEM, which may be a special PIV key PEM.
+func newPrivateKeyWithKeyPEM(signer crypto.Signer, keyPEM []byte) (*PrivateKey, error) {
 	sshPub, err := ssh.NewPublicKey(signer.Public())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	keyPEM, err := MarshalPrivateKey(signer)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -106,12 +98,7 @@ func NewHardwarePrivateKey(ctx context.Context, s hardwarekey.Service, keyConfig
 		return nil, trace.Wrap(err)
 	}
 
-	keyPEM, err := MarshalPrivateKey(hwSigner)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return NewPrivateKey(hwSigner, keyPEM)
+	return NewPrivateKey(hwSigner)
 }
 
 // GetAttestationStatement returns this key's AttestationStatement. If the key is
@@ -303,7 +290,7 @@ func ParsePrivateKey(keyPEM []byte, opts ...ParsePrivateKeyOpt) (*PrivateKey, er
 			return nil, trace.Wrap(err, "failed to parse hardware key signer")
 		}
 
-		return NewPrivateKey(hwPrivateKey, keyPEM)
+		return newPrivateKeyWithKeyPEM(hwPrivateKey, keyPEM)
 	case OpenSSHPrivateKeyType:
 		priv, err := ssh.ParseRawPrivateKey(keyPEM)
 		if err != nil {
@@ -319,7 +306,7 @@ func ParsePrivateKey(keyPEM []byte, opts ...ParsePrivateKeyOpt) (*PrivateKey, er
 		if pEdwards, ok := cryptoSigner.(*ed25519.PrivateKey); ok {
 			cryptoSigner = *pEdwards
 		}
-		return NewPrivateKey(cryptoSigner, keyPEM)
+		return newPrivateKeyWithKeyPEM(cryptoSigner, keyPEM)
 	case PKCS1PrivateKeyType, PKCS8PrivateKeyType, ECPrivateKeyType:
 		// The DER format doesn't always exactly match the PEM header, various
 		// versions of Teleport and OpenSSL have been guilty of writing PKCS#8
@@ -331,17 +318,17 @@ func ParsePrivateKey(keyPEM []byte, opts ...ParsePrivateKeyOpt) (*PrivateKey, er
 			if !ok {
 				return nil, trace.BadParameter("x509.ParsePKCS8PrivateKey returned an invalid private key of type %T", priv)
 			}
-			return NewPrivateKey(signer, keyPEM)
+			return newPrivateKeyWithKeyPEM(signer, keyPEM)
 		} else if block.Type == PKCS8PrivateKeyType {
 			preferredErr = err
 		}
 		if signer, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
-			return NewPrivateKey(signer, keyPEM)
+			return newPrivateKeyWithKeyPEM(signer, keyPEM)
 		} else if block.Type == PKCS1PrivateKeyType {
 			preferredErr = err
 		}
 		if signer, err := x509.ParseECPrivateKey(block.Bytes); err == nil {
-			return NewPrivateKey(signer, keyPEM)
+			return newPrivateKeyWithKeyPEM(signer, keyPEM)
 		} else if block.Type == ECPrivateKeyType {
 			preferredErr = err
 		}

--- a/api/utils/keys/privatekey_test.go
+++ b/api/utils/keys/privatekey_test.go
@@ -301,7 +301,7 @@ func TestHardwareKeyMethods(t *testing.T) {
 	// Test hardware key methods with a software key.
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
-	key, err := keys.NewSoftwarePrivateKey(priv)
+	key, err := keys.NewPrivateKey(priv)
 	require.NoError(t, err)
 
 	require.Nil(t, key.GetAttestationStatement())

--- a/integration/helpers/helpers.go
+++ b/integration/helpers/helpers.go
@@ -197,9 +197,9 @@ func MustCreateUserKeyRing(t *testing.T, tc *TeleInstance, username string, ttl 
 }
 
 func mustCreateUserKeyRingWithKeys(t *testing.T, tc *TeleInstance, username string, ttl time.Duration, sshKey, tlsKey crypto.Signer) *client.KeyRing {
-	sshPriv, err := keys.NewSoftwarePrivateKey(sshKey)
+	sshPriv, err := keys.NewPrivateKey(sshKey)
 	require.NoError(t, err)
-	tlsPriv, err := keys.NewSoftwarePrivateKey(tlsKey)
+	tlsPriv, err := keys.NewPrivateKey(tlsKey)
 	require.NoError(t, err)
 	keyRing := client.NewKeyRing(sshPriv, tlsPriv)
 	keyRing.ClusterName = tc.Secrets.SiteName

--- a/integration/helpers/usercreds.go
+++ b/integration/helpers/usercreds.go
@@ -120,11 +120,11 @@ func GenerateUserCreds(req UserCredsRequest) (*UserCreds, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	sshPriv, err := keys.NewSoftwarePrivateKey(sshKey)
+	sshPriv, err := keys.NewPrivateKey(sshKey)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	tlsPriv, err := keys.NewSoftwarePrivateKey(tlsKey)
+	tlsPriv, err := keys.NewPrivateKey(tlsKey)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/agentless/agentless.go
+++ b/lib/agentless/agentless.go
@@ -177,7 +177,7 @@ func createAuthSigner(ctx context.Context, params certParams, localAccessPoint L
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	priv, err := keys.NewSoftwarePrivateKey(key)
+	priv, err := keys.NewPrivateKey(key)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/keygen/keygen_test.go
+++ b/lib/auth/keygen/keygen_test.go
@@ -106,7 +106,7 @@ func TestBuildPrincipals(t *testing.T) {
 
 	hostKey, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.Ed25519)
 	require.NoError(t, err)
-	hostPrivateKey, err := keys.NewSoftwarePrivateKey(hostKey)
+	hostPrivateKey, err := keys.NewPrivateKey(hostKey)
 	require.NoError(t, err)
 	hostPublicKey := hostPrivateKey.MarshalSSHPublicKey()
 

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -4038,11 +4038,11 @@ func (tc *TeleportClient) GetNewLoginKeyRing(ctx context.Context) (keyRing *KeyR
 		}
 	}
 
-	sshPriv, err := keys.NewSoftwarePrivateKey(sshKey)
+	sshPriv, err := keys.NewPrivateKey(sshKey)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	tlsPriv, err := keys.NewSoftwarePrivateKey(tlsKey)
+	tlsPriv, err := keys.NewPrivateKey(tlsKey)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/client/client_store_test.go
+++ b/lib/client/client_store_test.go
@@ -76,9 +76,9 @@ func (s *testAuthority) makeSignedKeyRing(t *testing.T, idx KeyRingIndex, makeEx
 		return types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_BALANCED_V1, nil
 	})
 	require.NoError(t, err)
-	sshPriv, err := keys.NewSoftwarePrivateKey(sshKey)
+	sshPriv, err := keys.NewPrivateKey(sshKey)
 	require.NoError(t, err)
-	tlsPriv, err := keys.NewSoftwarePrivateKey(tlsKey)
+	tlsPriv, err := keys.NewPrivateKey(tlsKey)
 	require.NoError(t, err)
 
 	allowedLogins := []string{idx.Username, "root"}
@@ -400,9 +400,7 @@ func BenchmarkLoadKeysToKubeFromStore(b *testing.B) {
 	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
 	require.NotEmpty(b, certPEM)
 
-	keyPEM, err := keys.MarshalPrivateKey(key)
-	require.NoError(b, err)
-	privateKey, err := keys.NewPrivateKey(key, keyPEM)
+	privateKey, err := keys.NewPrivateKey(key)
 	require.NoError(b, err)
 
 	kubeCred := TLSCredential{

--- a/lib/client/conntest/ssh.go
+++ b/lib/client/conntest/ssh.go
@@ -114,7 +114,7 @@ func (s *SSHConnectionTester) TestConnection(ctx context.Context, req TestConnec
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	privateKey, err := keys.NewSoftwarePrivateKey(key)
+	privateKey, err := keys.NewPrivateKey(key)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/client/db/database_certificates.go
+++ b/lib/client/db/database_certificates.go
@@ -102,7 +102,7 @@ func GenerateDatabaseServerCertificates(ctx context.Context, req GenerateDatabas
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		privateKey, err := keys.NewSoftwarePrivateKey(key)
+		privateKey, err := keys.NewPrivateKey(key)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/client/db/oracle/oracle_test.go
+++ b/lib/client/db/oracle/oracle_test.go
@@ -40,7 +40,7 @@ func TestCreateJksWallet(t *testing.T) {
 			publicPEM, err := keys.MarshalPublicKey(signer.Public())
 			require.NoError(t, err)
 
-			wrapped, err := keys.NewSoftwarePrivateKey(signer)
+			wrapped, err := keys.NewPrivateKey(signer)
 			require.NoError(t, err)
 
 			_, err = createJKSWallet(signer, publicPEM, publicPEM, "dummy")

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -162,7 +162,7 @@ func (k *KeyRing) generateSubjectTLSKey(ctx context.Context, tc *TeleportClient,
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	priv, err := keys.NewSoftwarePrivateKey(key)
+	priv, err := keys.NewPrivateKey(key)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/client/keyagent_test.go
+++ b/lib/client/keyagent_test.go
@@ -772,9 +772,9 @@ func (s *KeyAgentTestSuite) makeKeyRing(t *testing.T, username, proxyHost string
 	})
 	require.NoError(t, err)
 
-	sshPriv, err := keys.NewSoftwarePrivateKey(sshKey)
+	sshPriv, err := keys.NewPrivateKey(sshKey)
 	require.NoError(t, err)
-	tlsPriv, err := keys.NewSoftwarePrivateKey(tlsKey)
+	tlsPriv, err := keys.NewPrivateKey(tlsKey)
 	require.NoError(t, err)
 
 	return &KeyRing{

--- a/lib/cryptosuites/suites.go
+++ b/lib/cryptosuites/suites.go
@@ -446,7 +446,7 @@ func GeneratePrivateKeyWithAlgorithm(alg Algorithm) (*keys.PrivateKey, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	privateKey, err := keys.NewSoftwarePrivateKey(key)
+	privateKey, err := keys.NewPrivateKey(key)
 	return privateKey, trace.Wrap(err)
 }
 

--- a/lib/kube/kubeconfig/kubeconfig_test.go
+++ b/lib/kube/kubeconfig/kubeconfig_test.go
@@ -569,7 +569,7 @@ func genUserKeyRing(hostname string) (*client.KeyRing, []byte, error) {
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
-	priv, err := keys.NewSoftwarePrivateKey(key)
+	priv, err := keys.NewPrivateKey(key)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -122,14 +122,11 @@ func NewTestCAWithConfig(config TestCAConfig) *types.CertAuthorityV2 {
 		if err != nil {
 			panic(err)
 		}
-		keyPEM, err = keys.MarshalPrivateKey(signer)
+		key, err = keys.NewPrivateKey(signer)
 		if err != nil {
 			panic(err)
 		}
-		key, err = keys.NewPrivateKey(signer, keyPEM)
-		if err != nil {
-			panic(err)
-		}
+		keyPEM = key.PrivateKeyPEM()
 	}
 
 	ca := &types.CertAuthorityV2{

--- a/lib/srv/db/common/auth.go
+++ b/lib/srv/db/common/auth.go
@@ -1069,7 +1069,7 @@ func (a *dbAuth) GenerateDatabaseClientKey(ctx context.Context) (*keys.PrivateKe
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	privateKey, err := keys.NewSoftwarePrivateKey(signer)
+	privateKey, err := keys.NewPrivateKey(signer)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/tbot/service_ssh_host_output.go
+++ b/lib/tbot/service_ssh_host_output.go
@@ -136,7 +136,7 @@ func (s *SSHHostOutputService) generate(ctx context.Context) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	privKey, err := keys.NewSoftwarePrivateKey(key)
+	privKey, err := keys.NewPrivateKey(key)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/teleterm/gateway/kube.go
+++ b/lib/teleterm/gateway/kube.go
@@ -120,7 +120,7 @@ func newKubeCAKey(kubeCert tls.Certificate) (*keys.PrivateKey, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	privateKey, err := keys.NewSoftwarePrivateKey(signer)
+	privateKey, err := keys.NewPrivateKey(signer)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -301,7 +301,7 @@ func (a *AuthCommand) GenerateKeys(ctx context.Context, clusterAPI authCommandCl
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	key, err := keys.NewSoftwarePrivateKey(signer)
+	key, err := keys.NewPrivateKey(signer)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -530,7 +530,7 @@ func (a *AuthCommand) generateHostKeys(ctx context.Context, clusterAPI certifica
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	key, err := keys.NewSoftwarePrivateKey(signer)
+	key, err := keys.NewPrivateKey(signer)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -890,7 +890,7 @@ func generateKeyRing(ctx context.Context, clusterAPI certificateSigner, purpose 
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	key, err := keys.NewSoftwarePrivateKey(signer)
+	key, err := keys.NewPrivateKey(signer)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/tsh/common/kube_proxy.go
+++ b/tool/tsh/common/kube_proxy.go
@@ -325,7 +325,7 @@ func makeKubeLocalProxy(cf *CLIConf, tc *client.TeleportClient, clusters kubecon
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	localClientKey, err := keys.NewSoftwarePrivateKey(key)
+	localClientKey, err := keys.NewPrivateKey(key)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/tsh/common/kubectl_test.go
+++ b/tool/tsh/common/kubectl_test.go
@@ -269,7 +269,7 @@ func mustSetupKubeconfig(t *testing.T, tshHome, kubeCluster string) string {
 	kubeconfigLocation := filepath.Join(tshHome, "kubeconfig")
 	key, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
 	require.NoError(t, err)
-	priv, err := keys.NewSoftwarePrivateKey(key)
+	priv, err := keys.NewPrivateKey(key)
 	require.NoError(t, err)
 	err = kubeconfig.Update(kubeconfigLocation, kubeconfig.Values{
 		TeleportClusterName: "localhost",

--- a/tool/tsh/common/proxy_test.go
+++ b/tool/tsh/common/proxy_test.go
@@ -1505,7 +1505,7 @@ func TestProxyAppWithIdentity(t *testing.T) {
 
 	key, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
 	require.NoError(t, err)
-	privateKey, err := keys.NewSoftwarePrivateKey(key)
+	privateKey, err := keys.NewPrivateKey(key)
 	require.NoError(t, err)
 	// Identity files only support a single key for SSH/TLS
 	keyRing := client.NewKeyRing(privateKey, privateKey)

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -5831,9 +5831,9 @@ func TestLogout(t *testing.T) {
 		return types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_BALANCED_V1, nil
 	})
 	require.NoError(t, err)
-	sshPriv, err := keys.NewSoftwarePrivateKey(sshKey)
+	sshPriv, err := keys.NewPrivateKey(sshKey)
 	require.NoError(t, err)
-	tlsPriv, err := keys.NewSoftwarePrivateKey(tlsKey)
+	tlsPriv, err := keys.NewPrivateKey(tlsKey)
 	require.NoError(t, err)
 	clientKeyRing := &client.KeyRing{
 		KeyRingIndex: client.KeyRingIndex{


### PR DESCRIPTION
Previously `NewSoftwarePrivateKey` was added because `YubiKeyPrivateKey` was not uniform across build tags and was difficult to work with in marshal/parsing logic. With #53435, we added a more generic `HardwarePrivateKey` which can be marshaled and parsed as if they are software private keys.

Depends on https://github.com/gravitational/teleport/pull/53674