### PR TITLE
[teleport-update] Add local updater metadata

### DIFF
--- a/api/client/webclient/webclient.go
+++ b/api/client/webclient/webclient.go
@@ -55,12 +55,12 @@ const (
 	// before others.
 	AgentUpdateGroupParameter = "group"
 
-	// AgentUpdateHostParameter is the parameter used to specify the updater
-	// host during a Ping() or Find() query.
+	// AgentUpdateIDParameter is the parameter used to specify the updater
+	// ID during a Ping() or Find() query.
 	// The proxy server will modulate the auto_update part of the PingResponse
-	// based on the specified host ID. e.g. canary hosts might need to update
+	// based on the specified update ID. e.g. canary hosts might need to update
 	// before others.
-	AgentUpdateHostParameter = "host"
+	AgentUpdateIDParameter = "update_id"
 )
 
 // Config specifies information when building requests with the
@@ -87,9 +87,9 @@ type Config struct {
 	// UpdateGroup is used to vary the webapi response based on the
 	// client's Managed Update group.
 	UpdateGroup string
-	// UpdateHost is used to vary the webapi response based on the
-	// client's Managed Update Host ID.
-	UpdateHost string
+	// UpdateID is used to vary the webapi response based on the
+	// client's Managed Update ID.
+	UpdateID string
 }
 
 // CheckAndSetDefaults checks and sets defaults
@@ -204,8 +204,8 @@ func findWithClient(cfg *Config, clt *http.Client) (*PingResponse, error) {
 	if cfg.UpdateGroup != "" {
 		query[AgentUpdateGroupParameter] = []string{cfg.UpdateGroup}
 	}
-	if cfg.UpdateHost != "" {
-		query[AgentUpdateHostParameter] = []string{cfg.UpdateHost}
+	if cfg.UpdateID != "" {
+		query[AgentUpdateIDParameter] = []string{cfg.UpdateID}
 	}
 	endpoint.RawQuery = query.Encode()
 
@@ -256,8 +256,8 @@ func pingWithClient(cfg *Config, clt *http.Client) (*PingResponse, error) {
 	if cfg.UpdateGroup != "" {
 		query[AgentUpdateGroupParameter] = []string{cfg.UpdateGroup}
 	}
-	if cfg.UpdateHost != "" {
-		query[AgentUpdateHostParameter] = []string{cfg.UpdateHost}
+	if cfg.UpdateID != "" {
+		query[AgentUpdateIDParameter] = []string{cfg.UpdateID}
 	}
 	endpoint.RawQuery = query.Encode()
 	if cfg.ConnectorName != "" {

--- a/api/client/webclient/webclient.go
+++ b/api/client/webclient/webclient.go
@@ -54,6 +54,13 @@ const (
 	// based on the specified group. e.g. some groups might need to update
 	// before others.
 	AgentUpdateGroupParameter = "group"
+
+	// AgentUpdateHostParameter is the parameter used to specify the updater
+	// host during a Ping() or Find() query.
+	// The proxy server will modulate the auto_update part of the PingResponse
+	// based on the specified host ID. e.g. canary hosts might need to update
+	// before others.
+	AgentUpdateHostParameter = "host"
 )
 
 // Config specifies information when building requests with the
@@ -78,8 +85,11 @@ type Config struct {
 	// TraceProvider is used to retrieve a Tracer for creating spans
 	TraceProvider oteltrace.TracerProvider
 	// UpdateGroup is used to vary the webapi response based on the
-	// client's auto-update group.
+	// client's Managed Update group.
 	UpdateGroup string
+	// UpdateHost is used to vary the webapi response based on the
+	// client's Managed Update Host ID.
+	UpdateHost string
 }
 
 // CheckAndSetDefaults checks and sets defaults
@@ -190,11 +200,14 @@ func findWithClient(cfg *Config, clt *http.Client) (*PingResponse, error) {
 		Host:   cfg.ProxyAddr,
 		Path:   "/webapi/find",
 	}
+	query := url.Values{}
 	if cfg.UpdateGroup != "" {
-		endpoint.RawQuery = url.Values{
-			AgentUpdateGroupParameter: []string{cfg.UpdateGroup},
-		}.Encode()
+		query[AgentUpdateGroupParameter] = []string{cfg.UpdateGroup}
 	}
+	if cfg.UpdateHost != "" {
+		query[AgentUpdateHostParameter] = []string{cfg.UpdateHost}
+	}
+	endpoint.RawQuery = query.Encode()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
 	if err != nil {
@@ -239,11 +252,14 @@ func pingWithClient(cfg *Config, clt *http.Client) (*PingResponse, error) {
 		Host:   cfg.ProxyAddr,
 		Path:   "/webapi/ping",
 	}
+	query := url.Values{}
 	if cfg.UpdateGroup != "" {
-		endpoint.RawQuery = url.Values{
-			AgentUpdateGroupParameter: []string{cfg.UpdateGroup},
-		}.Encode()
+		query[AgentUpdateGroupParameter] = []string{cfg.UpdateGroup}
 	}
+	if cfg.UpdateHost != "" {
+		query[AgentUpdateHostParameter] = []string{cfg.UpdateHost}
+	}
+	endpoint.RawQuery = query.Encode()
 	if cfg.ConnectorName != "" {
 		endpoint = endpoint.JoinPath(cfg.ConnectorName)
 	}

--- a/lib/autoupdate/agent/config.go
+++ b/lib/autoupdate/agent/config.go
@@ -248,7 +248,6 @@ func validateConfigSpec(spec *UpdateSpec, override OverrideConfig) error {
 // Status of the agent auto-updates system.
 type Status struct {
 	UpdateSpec   `yaml:",inline"`
-	ID           string `yaml:"id,omitempty"`
 	UpdateStatus `yaml:",inline"`
 	FindResp     `yaml:",inline"`
 }
@@ -263,4 +262,6 @@ type FindResp struct {
 	Jitter time.Duration `yaml:"jitter"`
 	// AGPL installations cannot use the official CDN.
 	AGPL bool `yaml:"agpl,omitempty"`
+	// ID provided to the updater.
+	ID string `yaml:"id,omitempty"`
 }

--- a/lib/autoupdate/agent/config.go
+++ b/lib/autoupdate/agent/config.go
@@ -75,6 +75,8 @@ type UpdateSpec struct {
 type UpdateStatus struct {
 	// IDFile is the path to a temporary file containing the updater ID.
 	IDFile string `yaml:"id_file,omitempty"`
+	// LastUpdate status, if attempted
+	LastUpdate *LastUpdate `yaml:"last_update,omitempty"`
 	// Active is the currently active revision of Teleport.
 	Active Revision `yaml:"active"`
 	// Backup is the last working revision of Teleport.
@@ -83,8 +85,6 @@ type UpdateStatus struct {
 	// Skipped revisions are not applied because they
 	// are known to crash.
 	Skip *Revision `yaml:"skip,omitempty"`
-	// LastUpdate status, if attempted
-	LastUpdate *LastUpdate `yaml:"last_update,omitempty"`
 }
 
 // LastUpdate describes the last attempted updated.

--- a/lib/autoupdate/agent/config.go
+++ b/lib/autoupdate/agent/config.go
@@ -73,6 +73,8 @@ type UpdateSpec struct {
 
 // UpdateStatus describes the status field in update.yaml.
 type UpdateStatus struct {
+	// IDFile is the path to a temporary file containing the updater ID.
+	IDFile string `yaml:"id_file,omitempty"`
 	// Active is the currently active revision of Teleport.
 	Active Revision `yaml:"active"`
 	// Backup is the last working revision of Teleport.
@@ -81,6 +83,18 @@ type UpdateStatus struct {
 	// Skipped revisions are not applied because they
 	// are known to crash.
 	Skip *Revision `yaml:"skip,omitempty"`
+	// LastUpdate status, if attempted
+	LastUpdate *LastUpdate `yaml:"last_update,omitempty"`
+}
+
+// LastUpdate describes the last attempted updated.
+type LastUpdate struct {
+	// Success or failure of the attempted update
+	Success bool `yaml:"success"`
+	// Time the update occurred
+	Time time.Time `yaml:"time"`
+	// Target revision for the update
+	Target Revision `yaml:"target"`
 }
 
 // Revision is a version and edition of Teleport.
@@ -234,6 +248,7 @@ func validateConfigSpec(spec *UpdateSpec, override OverrideConfig) error {
 // Status of the agent auto-updates system.
 type Status struct {
 	UpdateSpec   `yaml:",inline"`
+	ID           string `yaml:"id,omitempty"`
 	UpdateStatus `yaml:",inline"`
 	FindResp     `yaml:",inline"`
 }

--- a/lib/autoupdate/agent/setup_test.go
+++ b/lib/autoupdate/agent/setup_test.go
@@ -134,7 +134,9 @@ func TestNewNamespace(t *testing.T) {
 			}
 			require.NoError(t, err)
 			ns.log = nil
-			ns.updaterIDFile = strings.Replace(ns.updaterIDFile, os.TempDir(), "/TMP/", 1)
+			ns.updaterIDFile = strings.Replace(ns.updaterIDFile,
+				strings.TrimSuffix(os.TempDir(), "/"), "/TMP", 1,
+			)
 			require.Equal(t, p.ns, ns)
 		})
 	}

--- a/lib/autoupdate/agent/setup_test.go
+++ b/lib/autoupdate/agent/setup_test.go
@@ -24,6 +24,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -50,6 +51,7 @@ func TestNewNamespace(t *testing.T) {
 				serviceFile:         "/lib/systemd/system/teleport.service",
 				configFile:          "/etc/teleport.yaml",
 				pidFile:             "/run/teleport.pid",
+				updaterIDFile:       "/TMP/teleport-update.id",
 				updaterServiceFile:  "/etc/systemd/system/teleport-update.service",
 				updaterTimerFile:    "/etc/systemd/system/teleport-update.timer",
 				dropInFile:          "/etc/systemd/system/teleport.service.d/teleport-update.conf",
@@ -66,6 +68,7 @@ func TestNewNamespace(t *testing.T) {
 				serviceFile:         "/lib/systemd/system/teleport.service",
 				configFile:          "/etc/teleport.yaml",
 				pidFile:             "/run/teleport.pid",
+				updaterIDFile:       "/TMP/teleport-update.id",
 				updaterServiceFile:  "/etc/systemd/system/teleport-update.service",
 				updaterTimerFile:    "/etc/systemd/system/teleport-update.timer",
 				dropInFile:          "/etc/systemd/system/teleport.service.d/teleport-update.conf",
@@ -83,6 +86,7 @@ func TestNewNamespace(t *testing.T) {
 				serviceFile:         "/etc/systemd/system/teleport_test.service",
 				configFile:          "/etc/teleport_test.yaml",
 				pidFile:             "/run/teleport_test.pid",
+				updaterIDFile:       "/TMP/teleport-update_test.id",
 				updaterServiceFile:  "/etc/systemd/system/teleport-update_test.service",
 				updaterTimerFile:    "/etc/systemd/system/teleport-update_test.timer",
 				dropInFile:          "/etc/systemd/system/teleport_test.service.d/teleport-update_test.conf",
@@ -101,6 +105,7 @@ func TestNewNamespace(t *testing.T) {
 				configFile:          "/etc/teleport_test.yaml",
 				pidFile:             "/run/teleport_test.pid",
 				serviceFile:         "/etc/systemd/system/teleport_test.service",
+				updaterIDFile:       "/TMP/teleport-update_test.id",
 				updaterServiceFile:  "/etc/systemd/system/teleport-update_test.service",
 				updaterTimerFile:    "/etc/systemd/system/teleport-update_test.timer",
 				dropInFile:          "/etc/systemd/system/teleport_test.service.d/teleport-update_test.conf",
@@ -129,6 +134,7 @@ func TestNewNamespace(t *testing.T) {
 			}
 			require.NoError(t, err)
 			ns.log = nil
+			ns.updaterIDFile = strings.Replace(ns.updaterIDFile, os.TempDir(), "/TMP/", 1)
 			require.Equal(t, p.ns, ns)
 		})
 	}
@@ -332,6 +338,58 @@ func TestNamespace_overrideFromConfig(t *testing.T) {
 			ns.configFile = ""
 			ns.log = nil
 			require.Equal(t, &tt.want, ns)
+		})
+	}
+}
+
+func TestNamespace_EnsureID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		exists bool
+		fails  bool
+	}{
+		{
+			name: "does not exist",
+		},
+		{
+			name:   "exists",
+			exists: true,
+		},
+		{
+			name:  "fails",
+			fails: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ns := &Namespace{
+				log:           slog.Default(),
+				updaterIDFile: filepath.Join(t.TempDir(), "id"),
+			}
+			if tt.exists {
+				err := os.WriteFile(ns.updaterIDFile, []byte("test"), os.ModePerm)
+				require.NoError(t, err)
+			}
+			if tt.fails {
+				ns.updaterIDFile = ""
+			}
+			p, err := ns.EnsureID()
+			require.Equal(t, ns.updaterIDFile, p)
+			if tt.fails {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			b, err := os.ReadFile(ns.updaterIDFile)
+			require.NoError(t, err)
+
+			if tt.exists {
+				require.Equal(t, "test", string(b))
+			} else {
+				require.Len(t, b, 36)
+			}
 		})
 	}
 }

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/FIPS_and_Enterprise_flags.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/FIPS_and_Enterprise_flags.golden
@@ -6,6 +6,7 @@ spec:
     enabled: false
     pinned: false
 status:
+    id_file: updater-id-file
     active:
         version: 16.3.0
         flags: [Enterprise, FIPS]

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/backup_version_kept_for_validation.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/backup_version_kept_for_validation.golden
@@ -6,6 +6,7 @@ spec:
     enabled: false
     pinned: false
 status:
+    id_file: updater-id-file
     active:
         version: 16.3.0
     backup:

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/backup_version_removed_on_install.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/backup_version_removed_on_install.golden
@@ -6,6 +6,7 @@ spec:
     enabled: false
     pinned: false
 status:
+    id_file: updater-id-file
     active:
         version: 16.3.0
     backup:

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/config_does_not_exist.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/config_does_not_exist.golden
@@ -6,5 +6,6 @@ spec:
     enabled: false
     pinned: false
 status:
+    id_file: updater-id-file
     active:
         version: 16.3.0

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/config_from_file.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/config_from_file.golden
@@ -8,6 +8,7 @@ spec:
     enabled: true
     pinned: false
 status:
+    id_file: updater-id-file
     active:
         version: 16.3.0
     backup:

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/config_from_user.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/config_from_user.golden
@@ -8,6 +8,7 @@ spec:
     enabled: true
     pinned: false
 status:
+    id_file: updater-id-file
     active:
         version: new-version
     backup:

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/defaults.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/defaults.golden
@@ -6,6 +6,7 @@ spec:
     enabled: false
     pinned: false
 status:
+    id_file: updater-id-file
     active:
         version: 16.3.0
     backup:

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/no_need_to_reload.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/no_need_to_reload.golden
@@ -6,5 +6,6 @@ spec:
     enabled: false
     pinned: false
 status:
+    id_file: updater-id-file
     active:
         version: 16.3.0

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/not_started_or_enabled.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/not_started_or_enabled.golden
@@ -6,5 +6,6 @@ spec:
     enabled: false
     pinned: false
 status:
+    id_file: updater-id-file
     active:
         version: 16.3.0

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/override_skip.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/override_skip.golden
@@ -6,6 +6,7 @@ spec:
     enabled: false
     pinned: false
 status:
+    id_file: updater-id-file
     active:
         version: 16.3.0
     backup:

--- a/lib/autoupdate/agent/testdata/TestUpdater_Install/version_already_installed.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Install/version_already_installed.golden
@@ -6,5 +6,6 @@ spec:
     enabled: false
     pinned: false
 status:
+    id_file: updater-id-file
     active:
         version: 16.3.0

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/FIPS_and_Enterprise_flags.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/FIPS_and_Enterprise_flags.golden
@@ -8,15 +8,15 @@ spec:
     pinned: false
 status:
     id_file: updater-id-file
-    active:
-        version: 16.3.0
-        flags: [Enterprise, FIPS]
-    backup:
-        version: old-version
-        flags: [Enterprise, FIPS]
     last_update:
         success: true
         time: 2025-01-01T00:00:00Z
         target:
             version: 16.3.0
             flags: [Enterprise, FIPS]
+    active:
+        version: 16.3.0
+        flags: [Enterprise, FIPS]
+    backup:
+        version: old-version
+        flags: [Enterprise, FIPS]

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/FIPS_and_Enterprise_flags.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/FIPS_and_Enterprise_flags.golden
@@ -7,9 +7,16 @@ spec:
     enabled: true
     pinned: false
 status:
+    id_file: updater-id-file
     active:
         version: 16.3.0
         flags: [Enterprise, FIPS]
     backup:
         version: old-version
         flags: [Enterprise, FIPS]
+    last_update:
+        success: true
+        time: 2025-01-01T00:00:00Z
+        target:
+            version: 16.3.0
+            flags: [Enterprise, FIPS]

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/agpl_requires_base_URL.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/agpl_requires_base_URL.golden
@@ -7,12 +7,12 @@ spec:
     pinned: false
 status:
     id_file: updater-id-file
-    active:
-        version: old-version
-    backup:
-        version: backup-version
     last_update:
         success: false
         time: 2025-01-01T00:00:00Z
         target:
             version: 16.3.0
+    active:
+        version: old-version
+    backup:
+        version: backup-version

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/agpl_requires_base_URL.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/agpl_requires_base_URL.golden
@@ -6,7 +6,13 @@ spec:
     enabled: true
     pinned: false
 status:
+    id_file: updater-id-file
     active:
         version: old-version
     backup:
         version: backup-version
+    last_update:
+        success: false
+        time: 2025-01-01T00:00:00Z
+        target:
+            version: 16.3.0

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/backup_version_is_linked.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/backup_version_is_linked.golden
@@ -8,12 +8,12 @@ spec:
     pinned: false
 status:
     id_file: updater-id-file
-    active:
-        version: 16.3.0
-    backup:
-        version: old-version
     last_update:
         success: true
         time: 2025-01-01T00:00:00Z
         target:
             version: 16.3.0
+    active:
+        version: 16.3.0
+    backup:
+        version: old-version

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/backup_version_is_linked.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/backup_version_is_linked.golden
@@ -7,7 +7,13 @@ spec:
     enabled: true
     pinned: false
 status:
+    id_file: updater-id-file
     active:
         version: 16.3.0
     backup:
         version: old-version
+    last_update:
+        success: true
+        time: 2025-01-01T00:00:00Z
+        target:
+            version: 16.3.0

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/backup_version_removed_on_install.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/backup_version_removed_on_install.golden
@@ -8,12 +8,12 @@ spec:
     pinned: false
 status:
     id_file: updater-id-file
-    active:
-        version: 16.3.0
-    backup:
-        version: old-version
     last_update:
         success: true
         time: 2025-01-01T00:00:00Z
         target:
             version: 16.3.0
+    active:
+        version: 16.3.0
+    backup:
+        version: old-version

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/backup_version_removed_on_install.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/backup_version_removed_on_install.golden
@@ -7,7 +7,13 @@ spec:
     enabled: true
     pinned: false
 status:
+    id_file: updater-id-file
     active:
         version: 16.3.0
     backup:
         version: old-version
+    last_update:
+        success: true
+        time: 2025-01-01T00:00:00Z
+        target:
+            version: 16.3.0

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/install_error.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/install_error.golden
@@ -6,5 +6,11 @@ spec:
     enabled: true
     pinned: false
 status:
+    id_file: updater-id-file
     active:
         version: ""
+    last_update:
+        success: false
+        time: 2025-01-01T00:00:00Z
+        target:
+            version: 16.3.0

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/install_error.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/install_error.golden
@@ -7,10 +7,10 @@ spec:
     pinned: false
 status:
     id_file: updater-id-file
-    active:
-        version: ""
     last_update:
         success: false
         time: 2025-01-01T00:00:00Z
         target:
             version: 16.3.0
+    active:
+        version: ""

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/setup_fails.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/setup_fails.golden
@@ -8,14 +8,14 @@ spec:
     pinned: false
 status:
     id_file: updater-id-file
+    last_update:
+        success: false
+        time: 2025-01-01T00:00:00Z
+        target:
+            version: 16.3.0
     active:
         version: old-version
     backup:
         version: backup-version
     skip:
         version: 16.3.0
-    last_update:
-        success: false
-        time: 2025-01-01T00:00:00Z
-        target:
-            version: 16.3.0

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/setup_fails.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/setup_fails.golden
@@ -7,9 +7,15 @@ spec:
     enabled: true
     pinned: false
 status:
+    id_file: updater-id-file
     active:
         version: old-version
     backup:
         version: backup-version
     skip:
         version: 16.3.0
+    last_update:
+        success: false
+        time: 2025-01-01T00:00:00Z
+        target:
+            version: 16.3.0

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_enabled_during_window.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_enabled_during_window.golden
@@ -9,12 +9,12 @@ spec:
     pinned: false
 status:
     id_file: updater-id-file
-    active:
-        version: 16.3.0
-    backup:
-        version: old-version
     last_update:
         success: true
         time: 2025-01-01T00:00:00Z
         target:
             version: 16.3.0
+    active:
+        version: 16.3.0
+    backup:
+        version: old-version

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_enabled_during_window.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_enabled_during_window.golden
@@ -8,7 +8,13 @@ spec:
     enabled: true
     pinned: false
 status:
+    id_file: updater-id-file
     active:
         version: 16.3.0
     backup:
         version: old-version
+    last_update:
+        success: true
+        time: 2025-01-01T00:00:00Z
+        target:
+            version: 16.3.0

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_enabled_now,_not_started_or_enabled.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_enabled_now,_not_started_or_enabled.golden
@@ -9,12 +9,12 @@ spec:
     pinned: false
 status:
     id_file: updater-id-file
-    active:
-        version: 16.3.0
-    backup:
-        version: old-version
     last_update:
         success: true
         time: 2025-01-01T00:00:00Z
         target:
             version: 16.3.0
+    active:
+        version: 16.3.0
+    backup:
+        version: old-version

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_enabled_now,_not_started_or_enabled.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_enabled_now,_not_started_or_enabled.golden
@@ -8,7 +8,13 @@ spec:
     enabled: true
     pinned: false
 status:
+    id_file: updater-id-file
     active:
         version: 16.3.0
     backup:
         version: old-version
+    last_update:
+        success: true
+        time: 2025-01-01T00:00:00Z
+        target:
+            version: 16.3.0

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_enabled_now.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_enabled_now.golden
@@ -9,12 +9,12 @@ spec:
     pinned: false
 status:
     id_file: updater-id-file
-    active:
-        version: 16.3.0
-    backup:
-        version: old-version
     last_update:
         success: true
         time: 2025-01-01T00:00:00Z
         target:
             version: 16.3.0
+    active:
+        version: 16.3.0
+    backup:
+        version: old-version

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_enabled_now.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/updates_enabled_now.golden
@@ -8,7 +8,13 @@ spec:
     enabled: true
     pinned: false
 status:
+    id_file: updater-id-file
     active:
         version: 16.3.0
     backup:
         version: old-version
+    last_update:
+        success: true
+        time: 2025-01-01T00:00:00Z
+        target:
+            version: 16.3.0

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/version_detects_as_linked.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/version_detects_as_linked.golden
@@ -8,12 +8,12 @@ spec:
     pinned: false
 status:
     id_file: updater-id-file
-    active:
-        version: 16.3.0
-    backup:
-        version: old-version
     last_update:
         success: true
         time: 2025-01-01T00:00:00Z
         target:
             version: 16.3.0
+    active:
+        version: 16.3.0
+    backup:
+        version: old-version

--- a/lib/autoupdate/agent/testdata/TestUpdater_Update/version_detects_as_linked.golden
+++ b/lib/autoupdate/agent/testdata/TestUpdater_Update/version_detects_as_linked.golden
@@ -7,7 +7,13 @@ spec:
     enabled: true
     pinned: false
 status:
+    id_file: updater-id-file
     active:
         version: 16.3.0
     backup:
         version: old-version
+    last_update:
+        success: true
+        time: 2025-01-01T00:00:00Z
+        target:
+            version: 16.3.0

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -601,7 +601,7 @@ func (u *Updater) Status(ctx context.Context) (Status, error) {
 		return out, trace.Wrap(err)
 	}
 	if cfg.Spec.Proxy == "" {
-		return out, ErrNotInstalled
+		return out, trace.Wrap(ErrNotInstalled)
 	}
 	out.UpdateSpec = cfg.Spec
 	out.UpdateStatus = cfg.Status

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -606,7 +606,7 @@ func (u *Updater) Status(ctx context.Context) (Status, error) {
 	out.UpdateSpec = cfg.Spec
 	out.UpdateStatus = cfg.Status
 	idBytes, err := os.ReadFile(out.IDFile)
-	if err != nil {
+	if err == nil {
 		out.ID = string(bytes.TrimSpace(idBytes))
 	}
 	out.IDFile = ""

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -230,7 +230,6 @@ type Updater struct {
 	TeardownNamespace func(ctx context.Context) error
 	// LogConfigWarnings logs warnings related to the configuration Namespace.
 	LogConfigWarnings func(ctx context.Context, pathDir string)
-
 	// EnsureUpdaterID generates and/or retrieves an ID for the updater, ensuring it is persisted.
 	// This ID is read by the Teleport agent and used to schedule progressive updates.
 	EnsureUpdaterID func() (string, error)

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -800,7 +800,7 @@ func (u *Updater) find(ctx context.Context, cfg *UpdateConfig) (FindResp, error)
 		Insecure:    u.InsecureSkipVerify,
 		Timeout:     30 * time.Second,
 		UpdateGroup: cfg.Spec.Group,
-		UpdateHost:  id,
+		UpdateID:    id,
 		Pool:        u.Pool,
 	})
 	if err != nil {

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -19,6 +19,7 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -69,6 +70,10 @@ const (
 	activeKey = "active_version"
 	backupKey = "backup_version"
 	errorKey  = "error"
+)
+
+var (
+	initTime = time.Now()
 )
 
 // SetRequiredUmask sets the umask to match the systemd umask that the teleport-update service will execute with.
@@ -169,6 +174,7 @@ func NewLocalUpdater(cfg LocalUpdaterConfig, ns *Namespace) (*Updater, error) {
 		SetupNamespace:    ns.Setup,
 		TeardownNamespace: ns.Teardown,
 		LogConfigWarnings: ns.LogWarnings,
+		EnsureUpdaterID:   ns.EnsureID,
 	}, nil
 }
 
@@ -224,6 +230,10 @@ type Updater struct {
 	TeardownNamespace func(ctx context.Context) error
 	// LogConfigWarnings logs warnings related to the configuration Namespace.
 	LogConfigWarnings func(ctx context.Context, pathDir string)
+
+	// EnsureUpdaterID generates and/or retrieves an ID for the updater, ensuring it is persisted.
+	// This ID is read by the Teleport agent and used to schedule progressive updates.
+	EnsureUpdaterID func() (string, error)
 }
 
 // Installer provides an API for installing Teleport agents.
@@ -353,6 +363,11 @@ func (u *Updater) Install(ctx context.Context, override OverrideConfig) error {
 	if err := validateConfigSpec(&cfg.Spec, override); err != nil {
 		return trace.Wrap(err)
 	}
+	// Always ensure the ID file is created, even if we do not write the path to disk on this run.
+	cfg.Status.IDFile, err = u.EnsureUpdaterID()
+	if err != nil {
+		u.Log.ErrorContext(ctx, "Failed to write updater ID file. Update tracking is degraded.", "id_file", cfg.Status.IDFile, errorKey, err)
+	}
 
 	if cfg.Spec.Proxy == "" {
 		cfg.Spec.Proxy = u.DefaultProxyAddr
@@ -412,7 +427,8 @@ func (u *Updater) Install(ctx context.Context, override OverrideConfig) error {
 	}
 	u.Log.InfoContext(ctx, "Configuration updated.")
 	u.LogConfigWarnings(ctx, cfg.Spec.Path)
-	return trace.Wrap(u.notices(ctx))
+	u.notices(ctx)
+	return nil
 }
 
 // sameProxies returns true if both proxies addresses are the same.
@@ -590,6 +606,11 @@ func (u *Updater) Status(ctx context.Context) (Status, error) {
 	}
 	out.UpdateSpec = cfg.Spec
 	out.UpdateStatus = cfg.Status
+	idBytes, err := os.ReadFile(out.IDFile)
+	if err != nil {
+		out.ID = string(bytes.TrimSpace(idBytes))
+	}
+	out.IDFile = ""
 
 	// Lookup target version from the proxy.
 	resp, err := u.find(ctx, cfg)
@@ -649,6 +670,11 @@ func (u *Updater) Update(ctx context.Context, now bool) error {
 	}
 	if err := validateConfigSpec(&cfg.Spec, OverrideConfig{}); err != nil {
 		return trace.Wrap(err)
+	}
+	// Always ensure the ID file is created, even if we do not write the path to disk on this run.
+	cfg.Status.IDFile, err = u.EnsureUpdaterID()
+	if err != nil {
+		u.Log.ErrorContext(ctx, "Failed to write updater ID file. Update tracking is degraded.", "id_file", cfg.Status.IDFile, errorKey, err)
 	}
 
 	active := cfg.Status.Active
@@ -727,8 +753,14 @@ func (u *Updater) Update(ctx context.Context, now bool) error {
 			return trace.Wrap(ctx.Err())
 		}
 	}
-
+	cfg.Status.LastUpdate = &LastUpdate{
+		Time:   initTime,
+		Target: target,
+	}
 	updateErr := u.update(ctx, cfg, target, false, resp.AGPL)
+	if updateErr == nil {
+		cfg.Status.LastUpdate.Success = true
+	}
 	writeErr := writeConfig(u.UpdateConfigFile, cfg)
 	if writeErr != nil {
 		writeErr = trace.Wrap(writeErr, "failed to write %s", updateConfigName)
@@ -737,7 +769,7 @@ func (u *Updater) Update(ctx context.Context, now bool) error {
 	}
 	// Show notices last
 	if updateErr == nil && now {
-		updateErr = u.notices(ctx)
+		u.notices(ctx)
 	}
 	return trace.NewAggregate(updateErr, writeErr)
 }
@@ -905,10 +937,10 @@ func (u *Updater) update(ctx context.Context, cfg *UpdateConfig, target Revision
 	if r := deref(cfg.Status.Backup); r.Version != "" {
 		u.Log.InfoContext(ctx, "Backup version set.", backupKey, r)
 	}
-
-	return trace.Wrap(u.cleanup(ctx, cfg, []Revision{
+	u.cleanup(ctx, cfg, []Revision{
 		target, active, backup,
-	}))
+	})
+	return nil
 }
 
 // Setup writes updater configuration and verifies the Teleport installation.
@@ -957,23 +989,25 @@ func (u *Updater) Setup(ctx context.Context, path string, restart bool) error {
 }
 
 // notices displays final notices after install or update.
-func (u *Updater) notices(ctx context.Context) error {
+func (u *Updater) notices(ctx context.Context) {
 	enabled, err := u.Process.IsEnabled(ctx)
 	if errors.Is(err, ErrNotSupported) {
 		u.Log.WarnContext(ctx, "Teleport is installed, but systemd is not present to start it.")
 		u.Log.WarnContext(ctx, "After configuring teleport.yaml, your system must also be configured to start Teleport.")
-		return nil
+		return
 	}
 	if errors.Is(err, ErrNotAvailable) {
 		u.Log.WarnContext(ctx, "Remember to use systemctl to enable and start Teleport.")
-		return nil
+		return
 	}
 	if err != nil {
-		return trace.Wrap(err, "failed to query Teleport systemd enabled status")
+		u.Log.ErrorContext(ctx, "Failed to determine if Teleport is enabled.", errorKey, err)
+		return
 	}
 	active, err := u.Process.IsActive(ctx)
 	if err != nil {
-		return trace.Wrap(err, "failed to query Teleport systemd active status")
+		u.Log.ErrorContext(ctx, "Failed to determine if Teleport is active.", errorKey, err)
+		return
 	}
 	if !enabled && active {
 		u.Log.WarnContext(ctx, "Teleport is installed and started, but not configured to start on boot.")
@@ -990,19 +1024,17 @@ func (u *Updater) notices(ctx context.Context) error {
 		u.Log.WarnContext(ctx, "After configuring teleport.yaml, you must enable and start.",
 			"command", "systemctl enable --now "+u.TeleportServiceName)
 	}
-
-	return nil
 }
 
 // cleanup orphan installations
-func (u *Updater) cleanup(ctx context.Context, cfg *UpdateConfig, keep []Revision) error {
+func (u *Updater) cleanup(ctx context.Context, cfg *UpdateConfig, keep []Revision) {
 	revs, err := u.Installer.List(ctx)
 	if err != nil {
 		u.Log.ErrorContext(ctx, "Failed to read installed versions.", errorKey, err)
-		return nil
+		return
 	}
 	if len(revs) < 3 {
-		return nil
+		return
 	}
 	u.Log.WarnContext(ctx, "More than two versions of Teleport are installed. Removing unused versions.", "count", len(revs))
 	for _, v := range revs {
@@ -1020,7 +1052,6 @@ func (u *Updater) cleanup(ctx context.Context, cfg *UpdateConfig, keep []Revisio
 		}
 		u.Log.WarnContext(ctx, "Deleted unused version of Teleport.", "version", v)
 	}
-	return nil
 }
 
 // LinkPackage creates links from the system (package) installation of Teleport, if they are needed.

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -73,7 +73,7 @@ const (
 )
 
 var (
-	initTime = time.Now()
+	initTime = time.Now().UTC()
 )
 
 // SetRequiredUmask sets the umask to match the systemd umask that the teleport-update service will execute with.
@@ -753,7 +753,7 @@ func (u *Updater) Update(ctx context.Context, now bool) error {
 		}
 	}
 	cfg.Status.LastUpdate = &LastUpdate{
-		Time:   initTime,
+		Time:   initTime.Truncate(time.Millisecond),
 		Target: target,
 	}
 	updateErr := u.update(ctx, cfg, target, false, resp.AGPL)

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"io/fs"
 	"log/slog"
+	"math/rand/v2"
 	"net/http"
 	"os"
 	"os/exec"
@@ -756,9 +757,9 @@ func (u *Updater) Update(ctx context.Context, now bool) error {
 	default:
 		u.Log.InfoContext(ctx, "Update available. Initiating update.", targetKey, target, activeKey, active)
 	}
-	if !now {
+	if !now && resp.Jitter > 0 {
 		select {
-		case <-time.After(resp.Jitter):
+		case <-time.After(time.Duration(rand.Int64N(int64(resp.Jitter)))):
 		case <-ctx.Done():
 			return trace.Wrap(ctx.Err())
 		}

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -176,7 +176,7 @@ func NewLocalUpdater(cfg LocalUpdaterConfig, ns *Namespace) (*Updater, error) {
 		SetupNamespace:    ns.Setup,
 		TeardownNamespace: ns.Teardown,
 		LogConfigWarnings: ns.LogWarnings,
-		EnsureUpdaterID:   ns.EnsureID,
+		EnsureUpdateID:    ns.EnsureID,
 	}, nil
 }
 
@@ -232,9 +232,9 @@ type Updater struct {
 	TeardownNamespace func(ctx context.Context) error
 	// LogConfigWarnings logs warnings related to the configuration Namespace.
 	LogConfigWarnings func(ctx context.Context, pathDir string)
-	// EnsureUpdaterID generates and/or retrieves an ID for the updater, ensuring it is persisted.
+	// EnsureUpdateID generates and/or retrieves an ID for the updater, ensuring it is persisted.
 	// This ID is read by the Teleport agent and used to schedule progressive updates.
-	EnsureUpdaterID func() (string, error)
+	EnsureUpdateID func() (string, error)
 }
 
 // Installer provides an API for installing Teleport agents.
@@ -365,7 +365,7 @@ func (u *Updater) Install(ctx context.Context, override OverrideConfig) error {
 		return trace.Wrap(err)
 	}
 	// Always ensure the ID file is created, even if we do not write the path to disk on this run.
-	cfg.Status.IDFile, err = u.EnsureUpdaterID()
+	cfg.Status.IDFile, err = u.EnsureUpdateID()
 	if err != nil {
 		u.Log.ErrorContext(ctx, "Failed to write updater ID file. Update tracking is degraded.", "id_file", cfg.Status.IDFile, errorKey, err)
 	}
@@ -683,7 +683,7 @@ func (u *Updater) Update(ctx context.Context, now bool) error {
 		return trace.Wrap(err)
 	}
 	// Always ensure the ID file is created, even if we do not write the path to disk on this run.
-	cfg.Status.IDFile, err = u.EnsureUpdaterID()
+	cfg.Status.IDFile, err = u.EnsureUpdateID()
 	if err != nil {
 		u.Log.ErrorContext(ctx, "Failed to write updater ID file. Update tracking is degraded.", "id_file", cfg.Status.IDFile, errorKey, err)
 	}

--- a/lib/autoupdate/agent/updater_test.go
+++ b/lib/autoupdate/agent/updater_test.go
@@ -836,7 +836,7 @@ func TestUpdater_Update(t *testing.T) {
 				revertSetupCalls++
 				return nil
 			}
-			updater.EnsureUpdaterID = func() (string, error) {
+			updater.EnsureUpdateID = func() (string, error) {
 				return "updater-id-file", nil
 			}
 
@@ -1778,7 +1778,7 @@ func TestUpdater_Install(t *testing.T) {
 				revertSetupCalls++
 				return nil
 			}
-			updater.EnsureUpdaterID = func() (string, error) {
+			updater.EnsureUpdateID = func() (string, error) {
 				return "updater-id-file", nil
 			}
 

--- a/lib/autoupdate/agent/updater_test.go
+++ b/lib/autoupdate/agent/updater_test.go
@@ -33,6 +33,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -42,6 +43,11 @@ import (
 	"github.com/gravitational/teleport/lib/autoupdate"
 	"github.com/gravitational/teleport/lib/utils/testutils/golden"
 )
+
+func TestMain(m *testing.M) {
+	initTime = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	os.Exit(m.Run())
+}
 
 func TestWarnUmask(t *testing.T) {
 	t.Parallel()
@@ -829,6 +835,9 @@ func TestUpdater_Update(t *testing.T) {
 			updater.SetupNamespace = func(_ context.Context, path string) error {
 				revertSetupCalls++
 				return nil
+			}
+			updater.EnsureUpdaterID = func() (string, error) {
+				return "updater-id-file", nil
 			}
 
 			ctx := context.Background()
@@ -1768,6 +1777,9 @@ func TestUpdater_Install(t *testing.T) {
 			updater.SetupNamespace = func(_ context.Context, path string) error {
 				revertSetupCalls++
 				return nil
+			}
+			updater.EnsureUpdaterID = func() (string, error) {
+				return "updater-id-file", nil
 			}
 
 			ctx := context.Background()

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -218,12 +218,16 @@ func Run(args []string) int {
 		err = cmdUnlinkPackage(ctx, &ccfg)
 	case setupCmd.FullCommand():
 		err = cmdSetup(ctx, &ccfg)
-	case statusCmd.FullCommand():
-		err = cmdStatus(ctx, &ccfg)
 	case uninstallCmd.FullCommand():
 		err = cmdUninstall(ctx, &ccfg)
 	case versionCmd.FullCommand():
 		modules.GetModules().PrintVersion()
+	case statusCmd.FullCommand():
+		err = cmdStatus(ctx, &ccfg)
+		if errors.Is(err, autoupdate.ErrNotInstalled) {
+			plog.ErrorContext(ctx, "Teleport is not installed by teleport-update with this suffix.")
+			return 1
+		}
 	default:
 		// This should only happen when there's a missing switch case above.
 		err = trace.Errorf("command %s not configured", command)
@@ -465,10 +469,6 @@ func cmdStatus(ctx context.Context, ccfg *cliConfig) error {
 		return trace.Wrap(err, "failed to initialize updater")
 	}
 	status, err := updater.Status(ctx)
-	if errors.Is(err, autoupdate.ErrNotInstalled) {
-		plog.InfoContext(ctx, "Teleport is not installed by teleport-update with this suffix.")
-		return nil
-	}
 	if err != nil {
 		return trace.Wrap(err, "failed to get status")
 	}

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -465,12 +465,12 @@ func cmdStatus(ctx context.Context, ccfg *cliConfig) error {
 		return trace.Wrap(err, "failed to initialize updater")
 	}
 	status, err := updater.Status(ctx)
-	if err != nil {
-		return trace.Wrap(err, "failed to get status")
-	}
 	if errors.Is(err, autoupdate.ErrNotInstalled) {
 		plog.InfoContext(ctx, "Teleport is not installed by teleport-update with this suffix.")
 		return nil
+	}
+	if err != nil {
+		return trace.Wrap(err, "failed to get status")
 	}
 	enc := yaml.NewEncoder(os.Stdout)
 	return trace.Wrap(enc.Encode(status))


### PR DESCRIPTION
This PR adds logic to teleport-update to write additional metadata to update.yaml. This metadata may be retrieved by a Teleport agent and sent to Teleport auth for tracking Managed Updates progress.

Metadata includes:
- Last update time, target version, and success/fail
- A host ID in /tmp that is not persisted across reboots (to avoid collisions when created in VM images)

The host ID is sent via /find requests, but not currently parsed by the proxy.

Metadata is visible to users via `teleport-update status`:

```shell
proxy: example.com:443
path: /usr/local/bin
enabled: true
pinned: false
last_update:
    success: true
    time: 2025-03-31T20:00:39.036Z
    target:
        version: 17.3.4
        flags: [Enterprise]
active:
    version: 17.3.4
    flags: [Enterprise]
backup:
    version: 17.3.3
    flags: [Enterprise]
target:
    version: 17.3.4
    flags: [Enterprise]
in_window: true
jitter: 1m0s
id: d700bec4-f685-4b44-8e59-da851e598e6d
```


This PR also improves output of the `teleport-update status` command when no installation is present.

---

changelog: teleport-update: Add last_update metadata and update tracking UUID

---

The `teleport-update` binary is used to enable, disable, and trigger automatic Teleport agent updates. The new Managed Updates system manages a local installation of the cluster-specified version of Teleport stored in `/opt/teleport`.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/11856