### PR TITLE
Update pnpm to 10.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
       "web/.storybook/public"
     ]
   },
-  "packageManager": "pnpm@10.6.5+sha512.cdf928fca20832cd59ec53826492b7dc25dc524d4370b6b4adbf65803d32efaa6c1c88147c0ae4e8d579a6c9eec715757b50d4fa35eea179d868eada4ed043af",
+  "packageManager": "pnpm@10.7.0+sha512.6b865ad4b62a1d9842b61d674a393903b871d9244954f652b8842c2b553c72176b278f64c463e52d40fff8aba385c235c8c9ecf5cc7de4fd78b8bb6d49633ab6",
   "engines": {
     "node": "^20"
   }


### PR DESCRIPTION
https://github.com/pnpm/pnpm/releases/tag/v10.7.0

Dependabot is going to send dep updates soon, so let's update pnpm as well, now that we're on v10 and the upgrade is less of a pain.

The workaround with node-gyp from #53330 cannot be removed yet as the underlying bug in node-gyp is yet to be fixed (https://github.com/nodejs/node-gyp/issues/3126). I'm [running a tag build](https://github.com/gravitational/teleport.e/actions/runs/14191789057) just to be safe.