### PR TITLE
[v16] Add correct principal for agentless nodes on leaf clusters

### DIFF
--- a/lib/proxy/router.go
+++ b/lib/proxy/router.go
@@ -234,7 +234,11 @@ func (r *Router) DialHost(ctx context.Context, clientSrcAddr, clientDstAddr net.
 	}
 	span.AddEvent("retrieved target server")
 
-	principals := []string{host}
+	principals := []string{
+		host,
+		// Add in principal for when nodes are on leaf clusters.
+		host + "." + clusterName,
+	}
 
 	var (
 		isAgentlessNode bool
@@ -296,7 +300,7 @@ func (r *Router) DialHost(ctx context.Context, clientSrcAddr, clientDstAddr net.
 		IsAgentlessNode:       isAgentlessNode,
 		AgentlessSigner:       sshSigner,
 		Address:               host,
-		Principals:            principals,
+		Principals:            apiutils.Deduplicate(principals),
 		ServerID:              serverID,
 		ProxyIDs:              proxyIDs,
 		ConnType:              types.NodeTunnel,

--- a/lib/proxy/router_test.go
+++ b/lib/proxy/router_test.go
@@ -748,6 +748,8 @@ func TestRouter_DialHost(t *testing.T) {
 				require.NotNil(t, params.GetUserAgent)
 				require.Nil(t, params.AgentlessSigner)
 				require.NotNil(t, conn)
+				require.Contains(t, params.Principals, "host")
+				require.Contains(t, params.Principals, "host.test")
 			},
 		},
 		{
@@ -767,6 +769,8 @@ func TestRouter_DialHost(t *testing.T) {
 				require.NotNil(t, params.AgentlessSigner)
 				require.True(t, params.IsAgentlessNode)
 				require.NotNil(t, conn)
+				require.Contains(t, params.Principals, "host")
+				require.Contains(t, params.Principals, "host.test")
 			},
 		},
 		{


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/52803 to branch/v16

Part of https://github.com/gravitational/teleport/issues/42252

Adds the correct principle to allow $ ssh -p ${PORT?} -F ssh_config_teleport "${USER?}@${NODE?}.${CLUSTER?}" when connecting to agent-less nodes on a leaf cluster.