### PR TITLE
Add benchmark tests to capture init cost

### DIFF
--- a/tool/tbot/main_test.go
+++ b/tool/tbot/main_test.go
@@ -21,13 +21,37 @@ package main
 import (
 	"bytes"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"slices"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/lib/utils/testutils/golden"
 )
+
+const initTestSentinel = "init_test"
+
+func TestMain(m *testing.M) {
+	if slices.Contains(os.Args, initTestSentinel) {
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
+}
+
+func BenchmarkInit(b *testing.B) {
+	executable, err := os.Executable()
+	require.NoError(b, err)
+
+	for b.Loop() {
+		cmd := exec.Command(executable, initTestSentinel)
+		err := cmd.Run()
+		assert.NoError(b, err)
+	}
+}
 
 func TestRun_Configure(t *testing.T) {
 	t.Parallel()

--- a/tool/tctl/common/tctl_test.go
+++ b/tool/tctl/common/tctl_test.go
@@ -22,8 +22,11 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
+	"slices"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/breaker"
@@ -37,9 +40,26 @@ import (
 	"github.com/gravitational/teleport/tool/teleport/testenv"
 )
 
+const initTestSentinel = "init_test"
+
 func TestMain(m *testing.M) {
+	if slices.Contains(os.Args, initTestSentinel) {
+		os.Exit(0)
+	}
+
 	modules.SetInsecureTestMode(true)
 	os.Exit(m.Run())
+}
+
+func BenchmarkInit(b *testing.B) {
+	executable, err := os.Executable()
+	require.NoError(b, err)
+
+	for b.Loop() {
+		cmd := exec.Command(executable, initTestSentinel)
+		err := cmd.Run()
+		assert.NoError(b, err)
+	}
 }
 
 // TestCommandMatchBeforeAuthConnect verifies all defined `tctl` commands `TryRun`

--- a/tool/teleport-update/main_test.go
+++ b/tool/teleport-update/main_test.go
@@ -1,0 +1,48 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const initTestSentinel = "init_test"
+
+func TestMain(m *testing.M) {
+	if slices.Contains(os.Args, initTestSentinel) {
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
+}
+
+func BenchmarkInit(b *testing.B) {
+	executable, err := os.Executable()
+	require.NoError(b, err)
+
+	for b.Loop() {
+		cmd := exec.Command(executable, initTestSentinel)
+		err := cmd.Run()
+		assert.NoError(b, err)
+	}
+}

--- a/tool/teleport/common/teleport_test.go
+++ b/tool/teleport/common/teleport_test.go
@@ -24,10 +24,13 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
@@ -37,9 +40,26 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
+const initTestSentinel = "init_test"
+
 func TestMain(m *testing.M) {
+	if slices.Contains(os.Args, initTestSentinel) {
+		os.Exit(0)
+	}
+
 	utils.InitLoggerForTests()
 	os.Exit(m.Run())
+}
+
+func BenchmarkInit(b *testing.B) {
+	executable, err := os.Executable()
+	require.NoError(b, err)
+
+	for b.Loop() {
+		cmd := exec.Command(executable, initTestSentinel)
+		err := cmd.Run()
+		assert.NoError(b, err)
+	}
 }
 
 // bootstrap check

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -113,6 +113,8 @@ const (
 
 var ports utils.PortList
 
+const initTestSentinel = "init_test"
+
 func TestMain(m *testing.M) {
 	handleReexec()
 
@@ -130,7 +132,22 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+func BenchmarkInit(b *testing.B) {
+	executable, err := os.Executable()
+	require.NoError(b, err)
+
+	for b.Loop() {
+		cmd := exec.Command(executable, initTestSentinel)
+		err := cmd.Run()
+		assert.NoError(b, err)
+	}
+}
+
 func handleReexec() {
+	if slices.Contains(os.Args, initTestSentinel) {
+		os.Exit(0)
+	}
+
 	var runOpts []CliOption
 
 	// Allows mock headless auth to be implemented when the test binary


### PR DESCRIPTION
https://github.com/gravitational/teleport/issues/53050 was a result of some expensive initialization that ended up impacting end users. Existing benchmark tests did not cover this because they do not actually launch the entire teleport binary.

The cost can be observed via `inittrace`, though it is documented that the output is not stable and may be changed at any time.

```bash
GODEBUG='inittrace=1' ./releases/17.4.1/teleport version 2>&1 | rg '^init' | awk '{print $5 " ms " $2}' | sort -n -r | head -10
170 ms github.com/go-mysql-org/go-mysql/server
2.6 ms github.com/microsoft/go-mssqldb/internal/cp
2.6 ms github.com/goccy/go-json/internal/decoder
2.2 ms cloud.google.com/go/compute/apiv1/computepb
2.0 ms github.com/aws/aws-sdk-go/aws/endpoints
1.8 ms k8s.io/client-go/kubernetes/scheme
1.2 ms github.com/gravitational/teleport/lib/kube/proxy
1.2 ms github.com/gogo/protobuf/types
0.78 ms k8s.io/kubectl/pkg/scheme
0.73 ms github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server
```

In order to cover in a stable way, new tests were added to the tool package of each binary. The tests does one basic thing, re-execute the test binary and exits. The re-execution is required to account for any initialization costs that would otherwise be missed since they happen prior to TestMain being called.