### PR TITLE
Remove legacy `TabsItem` usage

### DIFF
--- a/docs/pages/includes/database-access/iam_role_trust_relationship.mdx
+++ b/docs/pages/includes/database-access/iam_role_trust_relationship.mdx
@@ -8,7 +8,7 @@ generally required:
 `{{role1}}` or its AWS account should be set as `Principal` in `{{role2}}`'s trust
 policy.
 <Tabs>
-<TabsItem label="Role as principal">
+<TabItem label="Role as principal">
 
 Assign <Var name="aws-account-id"/> to your AWS account ID:
 ```json
@@ -25,8 +25,8 @@ Assign <Var name="aws-account-id"/> to your AWS account ID:
   ]
 }
 ```
-</TabsItem>
-<TabsItem label="Account as principal">
+</TabItem>
+<TabItem label="Account as principal">
 
 Assign <Var name="aws-account-id"/> to your AWS account ID:
 
@@ -44,8 +44,8 @@ Assign <Var name="aws-account-id"/> to your AWS account ID:
   ]
 }
 ```
-</TabsItem>
-<TabsItem label="Cross-account with external-id">
+</TabItem>
+<TabItem label="Cross-account with external-id">
 
 Assign <Var name="external-aws-account-id"/> to an external AWS account ID:
 
@@ -68,7 +68,7 @@ Assign <Var name="external-aws-account-id"/> to an external AWS account ID:
   ]
 }
 ```
-</TabsItem>
+</TabItem>
 
 </Tabs>
 


### PR DESCRIPTION
Deprecating this tag in favor of the Docusaurus-native TabItem.