### PR TITLE
[v16] Remove legacy `TabsItem` usage

### DIFF
--- a/docs/pages/includes/database-access/iam_role_trust_relationship.mdx
+++ b/docs/pages/includes/database-access/iam_role_trust_relationship.mdx
@@ -8,7 +8,7 @@ generally required:
 `{{role1}}` or its AWS account should be set as `Principal` in `{{role2}}`'s trust
 policy.
 <Tabs>
-<TabsItem label="Role as principal">
+<TabItem label="Role as principal">
 ```json
 {
   "Version": "2012-10-17",
@@ -23,8 +23,8 @@ policy.
   ]
 }
 ```
-</TabsItem>
-<TabsItem label="Account as principal">
+</TabItem>
+<TabItem label="Account as principal">
 ```json
 {
   "Version": "2012-10-17",
@@ -39,8 +39,8 @@ policy.
   ]
 }
 ```
-</TabsItem>
-<TabsItem label="Cross-account with external-id">
+</TabItem>
+<TabItem label="Cross-account with external-id">
 ```json
 {
   "Version": "2012-10-17",
@@ -60,7 +60,7 @@ policy.
   ]
 }
 ```
-</TabsItem>
+</TabItem>
 
 </Tabs>
 


### PR DESCRIPTION
Deprecating this tag in favor of the Docusaurus-native TabItem.