### PR TITLE
Bump github.com/gravitational/go-mysql to v1.9.1-teleport.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -590,7 +590,7 @@ replace (
 	github.com/coreos/go-oidc => github.com/gravitational/go-oidc v0.1.1
 	github.com/crewjam/saml => github.com/gravitational/saml v0.4.15-teleport.2
 	github.com/datastax/go-cassandra-native-protocol => github.com/gravitational/go-cassandra-native-protocol v0.0.0-teleport.1
-	github.com/go-mysql-org/go-mysql => github.com/gravitational/go-mysql v1.9.1-teleport.3
+	github.com/go-mysql-org/go-mysql => github.com/gravitational/go-mysql v1.9.1-teleport.4
 	github.com/gogo/protobuf => github.com/gravitational/protobuf v1.3.2-teleport.2
 	github.com/gravitational/teleport/api => ./api
 	github.com/julienschmidt/httprouter => github.com/gravitational/httprouter v1.3.1-0.20220408074523-c876c5e705a5

--- a/go.sum
+++ b/go.sum
@@ -1570,8 +1570,8 @@ github.com/gravitational/go-libfido2 v1.5.3-teleport.1 h1:nPfxiTH2Sr3J6zan280fbH
 github.com/gravitational/go-libfido2 v1.5.3-teleport.1/go.mod h1:92J9LtSBl0UyUWljElJpTbMMNhC6VeY8dshsu40qjjo=
 github.com/gravitational/go-mssqldb v0.11.1-0.20230331180905-0f76f1751cd3 h1:3JGTacvAeV5tIC4/9XsdLC2K5K7FWaXxIwpW4t+dGH0=
 github.com/gravitational/go-mssqldb v0.11.1-0.20230331180905-0f76f1751cd3/go.mod h1:LbRWqr72fXehxAGLXO8nDNQAi4gthRz4j7f8L2LS0XM=
-github.com/gravitational/go-mysql v1.9.1-teleport.3 h1:mGX/4bvWpqqpLKdNP0jG/gfWnDrbiXvJGaMgS+bF9bo=
-github.com/gravitational/go-mysql v1.9.1-teleport.3/go.mod h1:pkllauQtJgHr2mTonYYysOznctozxiWgwpKAez0s+2U=
+github.com/gravitational/go-mysql v1.9.1-teleport.4 h1:2Lt2fcEMrco6apu8jme0mj6OS2pXa/9+Tjl+5MpyVKY=
+github.com/gravitational/go-mysql v1.9.1-teleport.4/go.mod h1:pkllauQtJgHr2mTonYYysOznctozxiWgwpKAez0s+2U=
 github.com/gravitational/go-oidc v0.1.1 h1:T5nZxwkrfqfDMW4VPomCiG50Ae5ToaL9NFxEJHKURXc=
 github.com/gravitational/go-oidc v0.1.1/go.mod h1:A/IrBuKme/aPiJ9RIctJnSfPKUAzSQ4zaacIXDCQGx4=
 github.com/gravitational/httprouter v1.3.1-0.20220408074523-c876c5e705a5 h1:qg8FcGwRACSHortU1UxCSo9nF0t34rPWjk9Nef3j2Ic=


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/53050.


```bash

GODEBUG='inittrace=1' ./build/teleport version 2>&1 | rg '^init' | awk '{print $5 " ms " $2}' | sort -n -r | head -10
1.2 ms github.com/aws/aws-sdk-go/aws/endpoints
1.1 ms cloud.google.com/go/compute/apiv1/computepb
1.0 ms k8s.io/client-go/kubernetes/scheme
1.0 ms github.com/microsoft/go-mssqldb/internal/cp
0.97 ms github.com/gravitational/teleport/lib/kube/proxy
0.83 ms github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server
0.74 ms sigs.k8s.io/controller-runtime/pkg/client/apiutil
0.66 ms k8s.io/kubectl/pkg/scheme
0.66 ms github.com/asaskevich/govalidator
0.63 ms go.etcd.io/etcd/api/v3/etcdserverpb

```


Changelog: Reduce resource consumption and improve latency of tsh ssh.