### PR TITLE
Remember current standard editor tab

### DIFF
--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
@@ -112,13 +112,10 @@ test('rendering and switching tabs for new role', async () => {
   expect(screen.getByRole('button', { name: 'Create Role' })).toBeEnabled();
 
   await user.click(getStandardEditorTab());
-  await screen.findByLabelText('Role Name *');
+  await screen.findByLabelText('Max Session TTL');
   expect(
     screen.queryByRole('button', { name: /Reset to Standard Settings/i })
   ).not.toBeInTheDocument();
-  await forwardToTab('Resources');
-  await forwardToTab('Admin Rules');
-  await forwardToTab('Options');
   expect(screen.getByRole('button', { name: 'Create Role' })).toBeEnabled();
 }, 10000);
 

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.tsx
@@ -16,8 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { produce } from 'immer';
-import { useCallback, useId, useState } from 'react';
+import { useCallback, useId } from 'react';
 import styled from 'styled-components';
 
 import { Box, ButtonPrimary, ButtonSecondary, Flex } from 'design';
@@ -37,6 +36,7 @@ import {
   OptionsModel,
   roleEditorModelToRole,
   StandardEditorModel,
+  StandardEditorTab,
 } from './standardmodel';
 import { ActionType, StandardModelDispatcher } from './useStandardModel';
 
@@ -60,20 +60,10 @@ export const StandardEditor = ({
   dispatch,
 }: StandardEditorProps) => {
   const isEditing = !!originalRole;
-  const { roleModel, validationResult } = standardEditorModel;
+  const { roleModel, validationResult, currentTab, disabledTabs } =
+    standardEditorModel;
   const modelValid = validationResult.isValid;
 
-  enum StandardEditorTab {
-    Overview,
-    Resources,
-    AdminRules,
-    Options,
-  }
-
-  const [currentTab, setCurrentTab] = useState(StandardEditorTab.Overview);
-  const [disabledTabs, setDisabledTabs] = useState(
-    isEditing ? [false, false, false, false] : [false, true, true, true]
-  );
   const idPrefix = useId();
 
   const validator = useValidation();
@@ -104,6 +94,10 @@ export const StandardEditor = ({
     [dispatch]
   );
 
+  const setCurrentTab = (newTab: StandardEditorTab) => {
+    dispatch({ type: ActionType.SetCurrentTab, payload: newTab });
+  };
+
   const validateAndGoToNextTab = useCallback(() => {
     const nextTabIndex = currentTab + 1;
     const valid = validate();
@@ -112,12 +106,7 @@ export const StandardEditor = ({
     }
     validator.reset();
     setCurrentTab(nextTabIndex);
-    setDisabledTabs(prevEnabledTabs =>
-      produce(prevEnabledTabs, et => {
-        et[nextTabIndex] = false;
-      })
-    );
-  }, [currentTab, validate, validator, setCurrentTab, setDisabledTabs]);
+  }, [currentTab, validate, validator, setCurrentTab]);
 
   const goToPreviousTab = useCallback(
     () => setCurrentTab(currentTab - 1),

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.tsx
@@ -94,9 +94,12 @@ export const StandardEditor = ({
     [dispatch]
   );
 
-  const setCurrentTab = (newTab: StandardEditorTab) => {
-    dispatch({ type: ActionType.SetCurrentTab, payload: newTab });
-  };
+  const setCurrentTab = useCallback(
+    (newTab: StandardEditorTab) => {
+      dispatch({ type: ActionType.SetCurrentTab, payload: newTab });
+    },
+    [dispatch]
+  );
 
   const validateAndGoToNextTab = useCallback(() => {
     const nextTabIndex = currentTab + 1;
@@ -125,7 +128,7 @@ export const StandardEditor = ({
     return {
       key: tab,
       title: tabTitles[tab],
-      disabled: disabledTabs[tab],
+      disabled: disabledTabs.has(tab),
       controls: tabElementIDs[tab],
       status: error ? validationErrorTabStatus : undefined,
     };

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.ts
@@ -78,7 +78,7 @@ export type StandardEditorModel = {
    */
   validationResult?: RoleEditorModelValidationResult;
   currentTab: StandardEditorTab;
-  disabledTabs: { [t in StandardEditorTab]: boolean };
+  disabledTabs: Set<StandardEditorTab>;
 };
 
 /**

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.ts
@@ -53,6 +53,13 @@ import {
 import { RoleEditorModelValidationResult } from './validation';
 import { defaultOptions } from './withDefaults';
 
+export enum StandardEditorTab {
+  Overview,
+  Resources,
+  AdminRules,
+  Options,
+}
+
 export type StandardEditorModel = {
   /**
    * The role model. Can be undefined if there was an unhandled error when
@@ -70,6 +77,8 @@ export type StandardEditorModel = {
    * role.
    */
   validationResult?: RoleEditorModelValidationResult;
+  currentTab: StandardEditorTab;
+  disabledTabs: { [t in StandardEditorTab]: boolean };
 };
 
 /**

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/useStandardModel.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/useStandardModel.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { current, original } from 'immer';
+import { current, enableMapSet, original } from 'immer';
 import { Dispatch } from 'react';
 import { useImmerReducer } from 'use-immer';
 
@@ -44,6 +44,9 @@ import { validateRoleEditorModel } from './validation';
 
 const logger = new Logger('useStandardModel');
 
+// Enable support for the Set type in Immer. We use it for `disabledTabs`.
+enableMapSet();
+
 /**
  * Creates a standard model state and returns an array composed of the state
  * and an action dispatcher that can be used to change it. Since the conversion
@@ -68,8 +71,12 @@ const initializeState = (originalRole?: Role): StandardEditorModel => {
       roleModel && validateRoleEditorModel(roleModel, undefined, undefined),
     currentTab: StandardEditorTab.Overview,
     disabledTabs: isEditing
-      ? [false, false, false, false]
-      : [false, true, true, true],
+      ? new Set()
+      : new Set([
+          StandardEditorTab.Resources,
+          StandardEditorTab.AdminRules,
+          StandardEditorTab.Options,
+        ]),
   };
 };
 
@@ -189,7 +196,7 @@ const reduce = (
   switch (type) {
     case ActionType.SetCurrentTab:
       state.currentTab = payload;
-      state.disabledTabs[payload] = false;
+      state.disabledTabs.delete(payload);
       break;
 
     case ActionType.SetModel:


### PR DESCRIPTION
This change moves the information about current and disabled editor tabs to the editor model so that it's persisted when the user switches back and forth between standard and YAML editors.

Requires https://github.com/gravitational/teleport/pull/53635
Contributes to https://github.com/gravitational/teleport/issues/52221