### PR TITLE
make session ID env vars agree

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -2246,17 +2246,14 @@ func testEnvironmentVariables(t *testing.T, suite *integrationTestSuite) {
 	})
 	require.NoError(t, err)
 
-	tc.SessionID = uuid.NewString()
-
-	// The SessionID and Web address should be set in the session env vars.
-	cmd := []string{"printenv", sshutils.SessionEnvVar, ";", "printenv", teleport.SSHSessionWebProxyAddr}
+	// The Web address should be set in the session env vars.
+	cmd := []string{"printenv", teleport.SSHSessionWebProxyAddr}
 	out := &bytes.Buffer{}
 	tc.Stdout = out
 	tc.Stdin = nil
 	err = tc.SSH(ctx, cmd)
 	require.NoError(t, err)
 	output := out.String()
-	require.Contains(t, output, tc.SessionID)
 	require.Contains(t, output, tc.WebProxyAddr)
 
 	term := NewTerminal(250)
@@ -2265,7 +2262,6 @@ func testEnvironmentVariables(t *testing.T, suite *integrationTestSuite) {
 	err = tc.SSH(ctx, nil)
 	require.NoError(t, err)
 	output = term.AllOutput()
-	require.Contains(t, output, tc.SessionID)
 	require.Contains(t, output, tc.WebProxyAddr)
 }
 

--- a/lib/client/client_test.go
+++ b/lib/client/client_test.go
@@ -28,7 +28,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -70,9 +69,8 @@ func TestNewSession(t *testing.T) {
 	ses, err = newSession(ctx, nc, nil, env, nil, nil, nil, true)
 	require.NoError(t, err)
 	require.NotNil(t, ses)
-	require.Empty(t, cmp.Diff(ses.env, env))
-	// the session ID must be taken from tne environ map, if passed:
-	require.Equal(t, "session-id", string(ses.id))
+	// the session ID must be unset from tne environ map, if we are not joining a session:
+	require.Empty(t, ses.id)
 }
 
 // TestProxyConnection verifies that client or server-side disconnect

--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -150,20 +150,9 @@ func newSession(ctx context.Context,
 			}
 
 		}
-		// new session!
-	} else {
-		// TODO(capnspacehook): DELETE IN 17.0.0
-		// clients shouldn't set TELEPORT_SESSION when they aren't joining
-		// a session, and won't need to once all supported Proxy/Node
-		// versions set the session ID for new sessions
-		sid, ok := ns.env[sshutils.SessionEnvVar]
-		if !ok {
-			sid = string(session.NewID())
-		}
-		ns.id = session.ID(sid)
-	}
 
-	ns.env[sshutils.SessionEnvVar] = string(ns.id)
+		ns.env[sshutils.SessionEnvVar] = string(ns.id)
+	}
 
 	// Close the Terminal when finished.
 	ns.closeWait.Add(1)

--- a/lib/srv/exec_linux_test.go
+++ b/lib/srv/exec_linux_test.go
@@ -84,6 +84,7 @@ func TestOSCommandPrep(t *testing.T) {
 		"TERM=xterm",
 		fmt.Sprintf("SSH_TTY=%v", scx.session.term.TTYName()),
 		"SSH_SESSION_ID=xxx",
+		"TELEPORT_SESSION=xxx",
 		"SSH_TELEPORT_HOST_UUID=testID",
 		"SSH_TELEPORT_CLUSTER_NAME=localhost",
 		"SSH_TELEPORT_USER=teleportUser",

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -120,7 +120,7 @@ func TestEmitExecAuditEvent(t *testing.T) {
 		require.Equal(t, "abc", execEvent.ForwardedBy)
 		require.Equal(t, expectedHostname, execEvent.ServerHostname)
 		require.Equal(t, "testNamespace", execEvent.ServerNamespace)
-		require.Equal(t, "xxx", execEvent.SessionID)
+		require.NotEqual(t, "xxx", execEvent.SessionID)
 		require.Equal(t, "10.0.0.5:4817", execEvent.RemoteAddr)
 		require.Equal(t, "127.0.0.1:3022", execEvent.LocalAddr)
 		require.NotEmpty(t, events.EventID)

--- a/lib/srv/mock.go
+++ b/lib/srv/mock.go
@@ -45,7 +45,6 @@ import (
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
-	rsession "github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
@@ -79,7 +78,6 @@ func newTestServerContext(t *testing.T, srv Server, sessionJoiningRoleSet servic
 		IsTestStub:             true,
 		ClusterName:            clusterName,
 		srv:                    srv,
-		sessionID:              rsession.NewID(),
 		Identity: IdentityContext{
 			UnmappedIdentity: ident,
 			Login:            usr.Username,

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -3917,7 +3917,6 @@ func (h *Handler) generateSession(ctx context.Context, req *TerminalRequest, clu
 		ServerHostname: host,
 		ServerHostPort: port,
 		Moderated:      accessEvaluator.IsModerated(),
-		ID:             session.NewID(),
 		Created:        time.Now().UTC(),
 		LastActive:     time.Now().UTC(),
 		Namespace:      apidefaults.Namespace,


### PR DESCRIPTION
`ServerContexts` now get their session ID from the parent `ConnectionContext`, making all child SSH sessions stemming from the same SSH connection use the same session ID internally.

Closes #51151.

changelog: fix TELEPORT_SESSION and SSH_SESSION_ID environmental variables not matching in an SSH session