### PR TITLE
docs: update build instructions for access request plugins

### DIFF
--- a/docs/pages/admin-guides/access-controls/guides/dual-authz.mdx
+++ b/docs/pages/admin-guides/access-controls/guides/dual-authz.mdx
@@ -74,6 +74,8 @@ We'll reference the exported file(s) later when configuring the plugin.
 
 ### Install the plugin
 
+(!docs/pages/includes/plugins/install-access-request.mdx name="mattermost"!)
+
 <Tabs>
 <TabItem label="Download">
   Access Request Plugins are available as `amd64` or `arm64` Linux binaries for downloading.
@@ -87,16 +89,16 @@ We'll reference the exported file(s) later when configuring the plugin.
   ```
 </TabItem>
 <TabItem label="From Source">
-  To install from source you need `git` and `go >= (=teleport.golang=)` installed.
+  To install from source you need `git` and `go` installed. If you do not have Go
+  installed, visit the Go [downloads page](https://go.dev/dl/).
 
   ```code
-  # Checkout the Teleport repo and go in the mattermost access plugin directory
-  $ git clone https://github.com/gravitational/teleport.git -b branch/v(=teleport.major_version=)
+  $ git clone https://github.com/gravitational/teleport -b branch/v(=teleport.major_version=)
   $ cd teleport/integrations/access/mattermost
-  $ git checkout (=teleport.plugin.version=)
-  $ make
+  $ git checkout v(=teleport.plugin.version=)
+  $ make build/teleport-mattermost
   ```
-</TabItem>
+  TabItem>
 </Tabs>
 
 ```code

--- a/docs/pages/admin-guides/access-controls/guides/dual-authz.mdx
+++ b/docs/pages/admin-guides/access-controls/guides/dual-authz.mdx
@@ -98,7 +98,7 @@ We'll reference the exported file(s) later when configuring the plugin.
   $ git checkout v(=teleport.plugin.version=)
   $ make build/teleport-mattermost
   ```
-  TabItem>
+<TabItem>
 </Tabs>
 
 ```code

--- a/docs/pages/admin-guides/access-controls/guides/dual-authz.mdx
+++ b/docs/pages/admin-guides/access-controls/guides/dual-authz.mdx
@@ -98,7 +98,7 @@ We'll reference the exported file(s) later when configuring the plugin.
   $ git checkout v(=teleport.plugin.version=)
   $ make build/teleport-mattermost
   ```
-<TabItem>
+</TabItem>
 </Tabs>
 
 ```code

--- a/docs/pages/includes/plugins/install-access-request.mdx
+++ b/docs/pages/includes/plugins/install-access-request.mdx
@@ -42,8 +42,8 @@ installed, visit the Go [downloads page](https://go.dev/dl/).
 ```code
 $ git clone https://github.com/gravitational/teleport -b branch/v(=teleport.major_version=)
 $ cd teleport/integrations/access/{{ name }}
-$ git checkout (=teleport.plugin.version=)
-$ make
+$ git checkout v(=teleport.plugin.version=)
+$ make build/teleport-{{ name }}
 ```
 
 Move the `teleport-{{ name }}` binary into your PATH.


### PR DESCRIPTION
Two updates:
- `git checkout` was referencing the incorrect tag without the prefix `v`
- `make` command doesn't have a default so needs to have `build/teleport-PLUGIN` such as `make build/teleport-slack`


Currently if you correct the tags but just run `make` you get this without it building.

```bash
$ make
ghcr.io/gravitational/teleport-buildbox:teleport18
```