### PR TITLE
Remove some rdpclient dependencies and simplify some async code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2371,7 +2371,6 @@ dependencies = [
  "iso7816",
  "iso7816-tlv",
  "log",
- "parking_lot",
  "picky",
  "picky-asn1-der",
  "picky-asn1-x509",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2374,7 +2374,6 @@ dependencies = [
  "picky",
  "picky-asn1-der",
  "picky-asn1-x509",
- "picky-krb",
  "rand 0.9.0",
  "reqwest",
  "rsa",

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -29,7 +29,6 @@ ironrdp-tokio.workspace = true
 iso7816 = "0.1.4"
 iso7816-tlv = "0.4.4"
 log = "0.4.27"
-parking_lot = "0.12.3"
 rand = { version = "0.9.0", features = ["os_rng"] }
 rsa = "0.9.8"
 sspi = { version = "0.15.0", features = ["network_client"] }
@@ -43,7 +42,9 @@ picky-asn1-der = "0.5.2"
 picky-asn1-x509 = "0.14.3"
 picky-krb = "0.9.4"
 reqwest = { version = "0.12", default-features = false }
-rustls = { version = "0.23.25", default-features = false, features = ["aws-lc-rs"] }
+rustls = { version = "0.23.25", default-features = false, features = [
+    "aws-lc-rs",
+] }
 
 [build-dependencies]
 cbindgen = "0.28.0"

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -40,7 +40,6 @@ url = "2.5.4"
 picky = { version = "7.0.0-rc.11", default-features = false }
 picky-asn1-der = "0.5.2"
 picky-asn1-x509 = "0.14.3"
-picky-krb = "0.9.4"
 reqwest = { version = "0.12", default-features = false }
 rustls = { version = "0.23.25", default-features = false, features = [
     "aws-lc-rs",

--- a/lib/srv/desktop/rdp/rdpclient/src/client.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/client.rs
@@ -530,7 +530,7 @@ impl Client {
         user_channel_id: u16,
         desktop_size: DesktopSize,
     ) -> ClientResult<()> {
-        tokio::task::spawn_blocking(move || unsafe {
+        task::spawn_blocking(move || unsafe {
             ClientResult::from(cgo_handle_rdp_connection_activated(
                 cgo_handle,
                 io_channel_id,

--- a/lib/srv/desktop/rdp/rdpclient/src/client.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/client.rs
@@ -247,7 +247,8 @@ impl Client {
             connection_result.io_channel_id,
             connection_result.user_channel_id,
             connection_result.desktop_size,
-        )?;
+        )
+        .await?;
 
         // Take the stream back out of the framed object for splitting.
         let rdp_stream = rdp_stream.into_inner_no_leftover();
@@ -401,7 +402,8 @@ impl Client {
                                             io_channel_id,
                                             user_channel_id,
                                             desktop_size,
-                                        )?;
+                                        )
+                                        .await?;
                                         break;
                                     }
                                 }
@@ -522,13 +524,13 @@ impl Client {
         Ok(vec![])
     }
 
-    fn send_connection_activated(
+    async fn send_connection_activated(
         cgo_handle: CgoHandle,
         io_channel_id: u16,
         user_channel_id: u16,
         desktop_size: DesktopSize,
     ) -> ClientResult<()> {
-        unsafe {
+        tokio::task::spawn_blocking(move || unsafe {
             ClientResult::from(cgo_handle_rdp_connection_activated(
                 cgo_handle,
                 io_channel_id,
@@ -536,7 +538,8 @@ impl Client {
                 desktop_size.width,
                 desktop_size.height,
             ))
-        }
+        })
+        .await?
     }
 
     async fn update_clipboard(

--- a/lib/srv/desktop/rdp/rdpclient/src/client/global.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/client/global.rs
@@ -35,8 +35,10 @@
 
 use super::ClientHandle;
 use crate::CgoHandle;
-use parking_lot::RwLock;
-use std::{collections::HashMap, sync::LazyLock};
+use std::{
+    collections::HashMap,
+    sync::{LazyLock, Mutex},
+};
 
 /// Gets a [`ClientHandle`] from the global [`CLIENT_HANDLES`] map.
 pub fn get_client_handle(cgo_handle: CgoHandle) -> Option<ClientHandle> {
@@ -65,11 +67,11 @@ const _: () = {
 /// A map of [`ClientHandle`] indexed by [`CgoHandle`].
 ///
 /// A function can be dispatched to the [`Client`] corresponding to a
-/// given [`CgoHandle`] by retrieving it's corresponding [`ClientHandle`]
+/// given [`CgoHandle`] by retrieving its corresponding [`ClientHandle`]
 /// from this map and sending the desired [`ClientFunction`].
 #[derive(Default)]
 pub struct ClientHandles {
-    map: RwLock<HashMap<CgoHandle, ClientHandle>>,
+    map: Mutex<HashMap<CgoHandle, ClientHandle>>,
 }
 
 impl ClientHandles {
@@ -78,14 +80,14 @@ impl ClientHandles {
     }
 
     pub fn insert(&self, cgo_handle: CgoHandle, client_handle: ClientHandle) {
-        self.map.write().insert(cgo_handle, client_handle);
+        self.map.lock().unwrap().insert(cgo_handle, client_handle);
     }
 
     pub fn get(&self, cgo_handle: CgoHandle) -> Option<ClientHandle> {
-        self.map.read().get(&cgo_handle).map(|c| (*c).clone())
+        self.map.lock().unwrap().get(&cgo_handle).map(|c| c.clone())
     }
 
     pub fn remove(&self, cgo_handle: CgoHandle) {
-        self.map.write().remove(&cgo_handle);
+        self.map.lock().unwrap().remove(&cgo_handle);
     }
 }

--- a/lib/srv/desktop/rdp/rdpclient/src/client/global.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/client/global.rs
@@ -45,10 +45,6 @@ pub fn get_client_handle(cgo_handle: CgoHandle) -> Option<ClientHandle> {
     CLIENT_HANDLES.get(cgo_handle)
 }
 
-/// A global, static tokio runtime for use by all clients.
-pub static TOKIO_RT: LazyLock<tokio::runtime::Runtime> =
-    LazyLock::new(|| tokio::runtime::Runtime::new().unwrap());
-
 /// A global, static map of [`ClientHandle`] indexed by [`CgoHandle`].
 ///
 /// See [`ClientHandles`].

--- a/lib/srv/desktop/rdp/rdpclient/src/client/global.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/client/global.rs
@@ -80,7 +80,7 @@ impl ClientHandles {
     }
 
     pub fn get(&self, cgo_handle: CgoHandle) -> Option<ClientHandle> {
-        self.map.lock().unwrap().get(&cgo_handle).map(|c| c.clone())
+        self.map.lock().unwrap().get(&cgo_handle).cloned()
     }
 
     pub fn remove(&self, cgo_handle: CgoHandle) {

--- a/lib/srv/desktop/rdp/rdpclient/src/license.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/license.rs
@@ -20,7 +20,6 @@ use crate::{
 };
 use ironrdp_connector::{custom_err, general_err, ConnectorError, ConnectorResult, LicenseCache};
 use ironrdp_pdu::rdp::server_license::LicenseInformation;
-use picky_krb::negoex::NegoexDataType;
 use std::ffi::{CString, NulError};
 use std::{ptr, slice};
 
@@ -75,7 +74,7 @@ impl LicenseCache for GoLicenseCache {
                 self.cgo_handle,
                 &mut req,
                 license_info.license_info.as_mut_ptr(),
-                license_info.license_info.size(),
+                license_info.license_info.len(),
             ) {
                 CGOErrCode::ErrCodeSuccess => Ok(()),
                 _ => Err(general_err!("error storing license")),


### PR DESCRIPTION
This PR removes some unnecessary dependencies from rdpclient (`parking-lot` was only used for a single rwlock and we can change to mutex, there's no need for a direct dependency on `picky-krb`) and cleans up some async oddities (two interleaved spawned tasks were turned into futures, a blocking go client function needed `spawn_blocking`).