### PR TITLE
docs: include Oracle RDS in AWS Database enrollment page

### DIFF
--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/enroll-aws-databases.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/enroll-aws-databases.mdx
@@ -22,6 +22,7 @@ with Teleport:
 - [Amazon ElastiCache and MemoryDB for Redis](redis-aws.mdx)
 - [Amazon Keyspaces (Apache Cassandra)](aws-cassandra-keyspaces.mdx)
 - [Amazon OpenSearch](aws-opensearch.mdx)
+- [Amazon RDS Oracle](rds-oracle.mdx)
 - [Amazon RDS Proxy MySQL](rds-proxy-mysql.mdx)
 - [Amazon RDS Proxy for Microsoft SQL Server](rds-proxy-sqlserver.mdx)
 - [Amazon RDS Proxy for PostgreSQL](rds-proxy-postgres.mdx)


### PR DESCRIPTION
Include Oracle RDS in the intro page list.