### PR TITLE
[v17] Docs: fix typo in url for openid configuration

### DIFF
--- a/docs/pages/admin-guides/management/operations/ca-rotation.mdx
+++ b/docs/pages/admin-guides/management/operations/ca-rotation.mdx
@@ -268,7 +268,7 @@ the `/.well-known/openid-configuration` path of the Web UI and reading the
 `jwks_uri` field:
 
 ```code
-$ curl https://example.teleport.sh/.well-known/open-id-configuration | jq '.jwks_uri'
+$ curl https://example.teleport.sh/.well-known/openid-configuration | jq '.jwks_uri'
 "https://example.teleport.sh/.well-known-jwks-oidc"
 ```
 


### PR DESCRIPTION
Backport #53664 to branch/v17