### PR TITLE
Force focus Connect window after enabling VNet daemon

### DIFF
--- a/build.assets/macos/tshdev/.gitignore
+++ b/build.assets/macos/tshdev/.gitignore
@@ -1,0 +1,3 @@
+# Artifacts generated when building and signing tsh.app.
+tsh.app/Contents/MacOS/tsh
+tsh.app/Contents/_CodeSignature/CodeResources

--- a/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
@@ -109,7 +109,7 @@ export class MockMainProcessClient implements MainProcessClient {
     return Promise.resolve(undefined);
   }
 
-  forceFocusWindow() {}
+  async forceFocusWindow() {}
 
   async symlinkTshMacOs() {
     return true;

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -379,9 +379,23 @@ export default class MainProcess {
       }
     );
 
-    ipcMain.handle('main-process-force-focus-window', () => {
-      this.windowsManager.forceFocusWindow();
-    });
+    ipcMain.handle(
+      MainProcessIpc.ForceFocusWindow,
+      async (
+        _,
+        args?: Parameters<MainProcessClient['forceFocusWindow']>[0]
+      ) => {
+        if (args?.wait && args.signal?.aborted) {
+          return;
+        }
+
+        this.windowsManager.forceFocusWindow();
+
+        if (args?.wait) {
+          await this.windowsManager.waitForWindowFocus(args.signal);
+        }
+      }
+    );
 
     // Used in the `tsh install` command on macOS to make the bundled tsh available in PATH.
     // Returns true if tsh got successfully installed, false if the user closed the osascript

--- a/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
@@ -113,8 +113,8 @@ export default function createMainProcessClient(): MainProcessClient {
     removeKubeConfig(options) {
       return ipcRenderer.invoke('main-process-remove-kube-config', options);
     },
-    forceFocusWindow() {
-      return ipcRenderer.invoke('main-process-force-focus-window');
+    forceFocusWindow(args) {
+      return ipcRenderer.invoke(MainProcessIpc.ForceFocusWindow, args);
     },
     symlinkTshMacOs() {
       return ipcRenderer.invoke('main-process-symlink-tsh-macos');

--- a/web/packages/teleterm/src/mainProcess/types.ts
+++ b/web/packages/teleterm/src/mainProcess/types.ts
@@ -142,7 +142,18 @@ export type MainProcessClient = {
     relativePath: string;
     isDirectory?: boolean;
   }): Promise<void>;
-  forceFocusWindow(): void;
+  /**
+   * Tells the OS to focus the window. If wait is true, polls periodically for window status and
+   * resolves when it's focused or after a short timeout.
+   *
+   * Most of the time wait shouldn't be used, it's there for use cases where it's important for the
+   * app to be focused (e.g., the business logic needs to use the clipboard API). Even in that case,
+   * the logic must handle a scenario where focus wasn't received as focus cannot be guaranteed.
+   * Any app can steal focus at any time.
+   */
+  forceFocusWindow(
+    args?: { wait?: false } | { wait: true; signal?: AbortSignal }
+  ): Promise<void>;
   /**
    * The promise returns true if tsh got successfully symlinked, false if the user closed the
    * osascript prompt. The promise gets rejected if osascript encountered an error.
@@ -298,6 +309,7 @@ export enum MainProcessIpc {
   DownloadConnectMyComputerAgent = 'main-process-connect-my-computer-download-agent',
   VerifyConnectMyComputerAgent = 'main-process-connect-my-computer-verify-agent',
   SaveTextToFile = 'main-process-save-text-to-file',
+  ForceFocusWindow = 'main-process-force-focus-window',
 }
 
 export enum WindowsManagerIpc {

--- a/web/packages/teleterm/src/mainProcess/windowsManager.test.ts
+++ b/web/packages/teleterm/src/mainProcess/windowsManager.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { BrowserWindow } from 'electron';
+
+import { createMockFileStorage } from 'teleterm/services/fileStorage/fixtures/mocks';
+
+import { makeRuntimeSettings } from './fixtures/mocks';
+import { WindowsManager } from './windowsManager';
+
+jest.mock('electron', () => ({
+  Menu: {
+    buildFromTemplate: jest.fn(),
+  },
+  ipcMain: {
+    once: jest.fn(),
+  },
+}));
+
+describe('waitForWindowFocus', () => {
+  it('waits for the window to receive focus', async () => {
+    const { windowsManager } = makeWindowsManager();
+
+    const promise = windowsManager.waitForWindowFocus();
+
+    windowsManager.focusWindow();
+
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it('returns early if signal is aborted', async () => {
+    const { windowsManager, mockWindow } = makeWindowsManager();
+
+    const abortController = new AbortController();
+    abortController.abort();
+
+    await expect(
+      windowsManager.waitForWindowFocus(abortController.signal)
+    ).resolves.toBeUndefined();
+
+    expect(mockWindow.isFocused).not.toHaveBeenCalled();
+  });
+
+  it('resolves after a timeout', async () => {
+    const { windowsManager } = makeWindowsManager();
+
+    // The premise behind this test is that we never trigger window focus and expect the method to
+    // automatically time out. If it doesn't do that, then the test itself will fail due to a timeout.
+    await expect(
+      windowsManager.waitForWindowFocus(undefined, 25)
+    ).resolves.toBeUndefined();
+  });
+});
+
+const makeWindowsManager = () => {
+  const windowsManager = new WindowsManager(
+    createMockFileStorage(),
+    makeRuntimeSettings()
+  );
+
+  let isFocused = false;
+
+  const mockWindow = {
+    focus: jest.fn().mockImplementation(() => {
+      isFocused = true;
+    }),
+    isFocused: jest.fn().mockImplementation(() => isFocused),
+    isMinimized: jest.fn().mockReturnValue(false),
+  } as Partial<BrowserWindow>;
+
+  windowsManager['window'] = mockWindow as BrowserWindow;
+
+  return { windowsManager, mockWindow };
+};

--- a/web/packages/teleterm/src/mainProcess/windowsManager.ts
+++ b/web/packages/teleterm/src/mainProcess/windowsManager.ts
@@ -283,11 +283,6 @@ export class WindowsManager {
     }
 
     return new Promise(resolve => {
-      if (signal?.aborted) {
-        resolve();
-        return;
-      }
-
       const interval = setInterval(() => {
         if (this.window.isFocused()) {
           resolve();

--- a/web/packages/teleterm/src/mainProcess/windowsManager.ts
+++ b/web/packages/teleterm/src/mainProcess/windowsManager.ts
@@ -272,6 +272,43 @@ export class WindowsManager {
     app.focus({ steal: true });
   }
 
+  /**
+   * Returns a promise that resolves after window is focused or after a timeout, or after the
+   * passed signal is aborted. There's no guarantee that the window receives focus, hence the
+   * built-in timeout.
+   */
+  waitForWindowFocus(signal?: AbortSignal, timeoutMs?: number): Promise<void> {
+    if (signal?.aborted) {
+      return Promise.resolve();
+    }
+
+    return new Promise(resolve => {
+      if (signal?.aborted) {
+        resolve();
+        return;
+      }
+
+      const interval = setInterval(() => {
+        if (this.window.isFocused()) {
+          resolve();
+          clearInterval(interval);
+          clearTimeout(timeout);
+        }
+      }, 16);
+
+      const timeout = setTimeout(() => {
+        resolve();
+        clearInterval(interval);
+      }, timeoutMs);
+
+      signal?.addEventListener('abort', () => {
+        resolve();
+        clearInterval(interval);
+        clearTimeout(timeout);
+      });
+    });
+  }
+
   getWindow() {
     return this.window;
   }

--- a/web/packages/teleterm/src/mainProcess/windowsManager.ts
+++ b/web/packages/teleterm/src/mainProcess/windowsManager.ts
@@ -277,7 +277,7 @@ export class WindowsManager {
    * passed signal is aborted. There's no guarantee that the window receives focus, hence the
    * built-in timeout.
    */
-  waitForWindowFocus(signal?: AbortSignal, timeoutMs?: number): Promise<void> {
+  waitForWindowFocus(signal?: AbortSignal, timeoutMs = 400): Promise<void> {
     if (signal?.aborted) {
       return Promise.resolve();
     }

--- a/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.tsx
@@ -125,6 +125,7 @@ export function ConnectAppActionButton(props: { app: App }): React.JSX.Element {
     void launchVnet({
       addrToCopy: appToAddrToCopy(props.app, targetPort),
       resourceUri: props.app.uri,
+      isMultiPort: !!props.app.tcpPorts.length,
     });
   }
 

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetInfo.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetInfo.tsx
@@ -57,6 +57,7 @@ export function DocumentVnetInfo(props: {
   const startVnet = async () => {
     await launchVnetWithoutFirstTimeCheck({
       addrToCopy: doc.app?.targetAddress,
+      isMultiPort: doc.app?.isMultiPort,
     });
     // Remove targetAddress so that subsequent launches of VNet from this specific doc won't copy
     // the stale app address to the clipboard.

--- a/web/packages/teleterm/src/ui/Vnet/DocumentVnetInfo.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/DocumentVnetInfo.tsx
@@ -55,10 +55,12 @@ export function DocumentVnetInfo(props: {
   const proxyHostname = routing.parseClusterName(rootClusterUri);
 
   const startVnet = async () => {
-    await launchVnetWithoutFirstTimeCheck(doc.targetAddress);
+    await launchVnetWithoutFirstTimeCheck({
+      addrToCopy: doc.app?.targetAddress,
+    });
     // Remove targetAddress so that subsequent launches of VNet from this specific doc won't copy
     // the stale app address to the clipboard.
-    documentsService.update(doc.uri, { targetAddress: undefined });
+    documentsService.update(doc.uri, { app: undefined });
   };
 
   return (

--- a/web/packages/teleterm/src/ui/Vnet/integration.test.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/integration.test.tsx
@@ -124,7 +124,13 @@ test.each(tests)(
     ).toBeInTheDocument();
 
     // Verify that a notification is shown and that the address is in the clipboard.
-    expect(await screen.findByText(/copied to clipboard/)).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        app.tcpPorts.length
+          ? /copied to clipboard/
+          : /\(copied to clipboard\) and any port/
+      )
+    ).toBeInTheDocument();
     await user.click(screen.getByTitle('Close Notification'));
     expect(await window.navigator.clipboard.readText()).toEqual(
       expectedPublicAddr
@@ -205,7 +211,13 @@ test.each(tests)(
     expect(
       await screen.findByText(/Proxying TCP connections/)
     ).toBeInTheDocument();
-    expect(await screen.findByText(/copied to clipboard/)).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        app.tcpPorts.length
+          ? /copied to clipboard/
+          : /\(copied to clipboard\) and any port/
+      )
+    ).toBeInTheDocument();
     expect(await window.navigator.clipboard.readText()).toEqual(
       expectedPublicAddr
     );

--- a/web/packages/teleterm/src/ui/Vnet/useVnetAppLauncher.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/useVnetAppLauncher.tsx
@@ -100,7 +100,7 @@ export const useVnetAppLauncher = (): {
       );
       // Update targetAddress so that clicking "Start VNet" from the info doc is going to copy that
       // address to clipboard.
-      docsService.update(docUri, { targetAddress: addrToCopy });
+      docsService.update(docUri, { app: { targetAddress: addrToCopy } });
     },
     [workspacesService]
   );

--- a/web/packages/teleterm/src/ui/Vnet/useVnetAppLauncher.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/useVnetAppLauncher.tsx
@@ -24,14 +24,24 @@ import { ResourceUri, routing } from 'teleterm/ui/uri';
 
 import { useVnetContext } from './vnetContext';
 
-export type VnetAppLauncher = (args: {
+export type VnetAppLauncher = (args: VnetAppLauncherArgs) => Promise<void>;
+
+// NOTE: Almost every field added to VnetAppLauncherArgs will need to be added to DocumentVnetInfo.
+//
+// This is because during the first launch of VNet through useVnetAppLauncher, the act of launching
+// VNet is split into two parts. When a user clicks the "Connect" button next to a TCP app or opens
+// one from the search bar, a DocumentVnetInfo is opened first. Then the user can start VNet from
+// there, which should carry out the launch of that particular app. Hence the need to copy some
+// arguments from the app to the doc.
+type VnetAppLauncherArgs = {
   addrToCopy: string | undefined;
   /**
    * resourceUri lets the VNet launcher establish which workspace to open the info doc in if
    * there's a need to do it.
    */
   resourceUri: ResourceUri;
-}) => Promise<void>;
+  isMultiPort: boolean;
+};
 
 export const useVnetAppLauncher = (): {
   /**
@@ -49,7 +59,7 @@ export const useVnetAppLauncher = (): {
    * address of the app to the clipboard.
    */
   launchVnetWithoutFirstTimeCheck: (
-    addrToCopy: string | undefined
+    args: Pick<VnetAppLauncherArgs, 'addrToCopy' | 'isMultiPort'>
   ) => Promise<void>;
 } => {
   const { notificationsService, workspacesService } = useAppContext();
@@ -72,13 +82,7 @@ export const useVnetAppLauncher = (): {
   }, [status.value, startAttempt.status, open, start]);
 
   const openInfoDoc = useCallback(
-    async ({
-      addrToCopy,
-      resourceUri,
-    }: {
-      addrToCopy: string | undefined;
-      resourceUri: ResourceUri;
-    }) => {
+    async ({ addrToCopy, resourceUri, isMultiPort }: VnetAppLauncherArgs) => {
       const rootClusterUri = routing.ensureRootClusterUri(resourceUri);
       // Since VNet app launcher might be called from the search bar, we have to account for the
       // user being in a different workspace than the selected app.
@@ -100,13 +104,18 @@ export const useVnetAppLauncher = (): {
       );
       // Update targetAddress so that clicking "Start VNet" from the info doc is going to copy that
       // address to clipboard.
-      docsService.update(docUri, { app: { targetAddress: addrToCopy } });
+      docsService.update(docUri, {
+        app: { targetAddress: addrToCopy, isMultiPort },
+      });
     },
     [workspacesService]
   );
 
   const launchVnetAndCopyAddr = useCallback(
-    async (addrToCopy: string | undefined) => {
+    async ({
+      addrToCopy,
+      isMultiPort,
+    }: Pick<VnetAppLauncherArgs, 'addrToCopy' | 'isMultiPort'>) => {
       if (!(await launchVnet())) {
         return;
       }
@@ -115,11 +124,15 @@ export const useVnetAppLauncher = (): {
         return;
       }
 
-      const ok = copyAddrToClipboard(addrToCopy);
+      const copiedToClipboard = copyAddrToClipboard(addrToCopy);
       notificationsService.notifyInfo(
-        ok
-          ? `Connect via VNet by using ${addrToCopy} (copied to clipboard).`
-          : `Connect via VNet by using ${addrToCopy}.`
+        [
+          `Connect via VNet by using ${addrToCopy}`,
+          copiedToClipboard && '(copied to clipboard)',
+          !isMultiPort && 'and any port',
+        ]
+          .filter(Boolean)
+          .join(' ') + '.'
       );
     },
     [launchVnet, notificationsService]
@@ -133,7 +146,7 @@ export const useVnetAppLauncher = (): {
           return;
         }
 
-        await launchVnetAndCopyAddr(args.addrToCopy);
+        await launchVnetAndCopyAddr(args);
       },
       launchVnetWithoutFirstTimeCheck: launchVnetAndCopyAddr,
     }),

--- a/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
@@ -169,7 +169,7 @@ export const VnetContextProvider: FC<
         // started VNet through the "Connect" button next to a TCP app, it means that once we return
         // from this function, Connect is going to attempt to copy the address of the app to the
         // clipboard. This won't work unless Connect has focus, hence forcing focus here.
-        mainProcessClient.forceFocusWindow();
+        await mainProcessClient.forceFocusWindow({ wait: true });
       }
 
       setStatus({ value: 'running' });

--- a/web/packages/teleterm/src/ui/services/headlessAuthn/headlessAuthnService.ts
+++ b/web/packages/teleterm/src/ui/services/headlessAuthn/headlessAuthnService.ts
@@ -31,7 +31,7 @@ export class HeadlessAuthenticationService {
     private configService: ConfigService
   ) {}
 
-  sendPendingHeadlessAuthentication(
+  async sendPendingHeadlessAuthentication(
     request: SendPendingHeadlessAuthenticationRequest,
     onRequestCancelled: (callback: () => void) => void
   ): Promise<void> {
@@ -40,7 +40,7 @@ export class HeadlessAuthenticationService {
     // If the user wants to skip the confirmation step, then don't force the window.
     // Instead, they can just tap their blinking yubikey with the window in the background.
     if (!skipConfirm) {
-      this.mainProcessClient.forceFocusWindow();
+      await this.mainProcessClient.forceFocusWindow();
     }
 
     return new Promise(resolve => {

--- a/web/packages/teleterm/src/ui/services/relogin/reloginService.ts
+++ b/web/packages/teleterm/src/ui/services/relogin/reloginService.ts
@@ -35,11 +35,11 @@ export class ReloginService {
     private clustersService: ClustersService
   ) {}
 
-  relogin(
+  async relogin(
     request: ReloginRequest,
     onRequestCancelled: (callback: () => void) => void
   ): Promise<void> {
-    this.mainProcessClient.forceFocusWindow();
+    await this.mainProcessClient.forceFocusWindow();
     const reason = this.getReason(request);
 
     return new Promise((resolve, reject) => {

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToApp.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToApp.ts
@@ -111,6 +111,7 @@ export async function connectToApp(
     await launchVnet({
       addrToCopy: appToAddrToCopy(target),
       resourceUri: target.uri,
+      isMultiPort: !!target.tcpPorts.length,
     });
     return;
   }

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
@@ -274,6 +274,7 @@ export class DocumentsService {
     rootClusterUri: RootClusterUri;
     app?: {
       targetAddress: string;
+      isMultiPort: boolean;
     };
   }): DocumentVnetInfo {
     const uri = routing.getDocUri({ docId: unique() });

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
@@ -272,7 +272,9 @@ export class DocumentsService {
 
   createVnetInfoDocument(opts: {
     rootClusterUri: RootClusterUri;
-    targetAddress?: string;
+    app?: {
+      targetAddress: string;
+    };
   }): DocumentVnetInfo {
     const uri = routing.getDocUri({ docId: unique() });
 
@@ -281,7 +283,7 @@ export class DocumentsService {
       kind: 'doc.vnet_info',
       title: 'VNet',
       rootClusterUri: opts.rootClusterUri,
-      targetAddress: opts.targetAddress,
+      app: opts.app,
     };
   }
 

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/testHelpers.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/testHelpers.ts
@@ -219,7 +219,7 @@ export function makeDocumentVnetInfo(
     uri: '/docs/vnet-info',
     title: 'VNet',
     rootClusterUri,
-    targetAddress: undefined,
+    app: undefined,
     ...props,
   };
 }

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
@@ -269,19 +269,27 @@ export interface DocumentVnetInfo extends DocumentBase {
   // the document fields, hence why rootClusterUri is defined here.
   rootClusterUri: uri.RootClusterUri;
   /**
-   * The address that's going to be copied to the clipboard after user starts VNet for the first
-   * time through this document.
+   * Details of the app if the doc was opened by selecting a specific TCP app.
    *
-   * This is to facilitate a scenario where a first time user clicks "Connect" next to a TCP app,
-   * which opens this doc. Once the user clicks "Start VNet" in the doc, Connect should continue the
-   * regular flow of connecting to a TCP app through VNet, which means it should copy the address of
-   * the app to the clipboard, hence this field.
+   * This field is needed to facilitate a scenario where a first-time user clicks "Connect" next to
+   * a TCP app, which opens this doc. Once the user clicks "Start VNet" in the doc, Connect should
+   * continue the regular flow of connecting to a TCP app through VNet, which means it should copy
+   * the address of the app to the clipboard, hence this field.
    *
-   * targetAddress is removed when restoring persisted state. Let's say the user opens the doc
-   * through the "Connect" button of a specific app. If they close the app and then reopen the docs,
-   * we don't want the "Start VNet" button to copy the address of the app from the prev session.
+   * app is removed when restoring persisted state. Let's say the user opens the doc through the
+   * "Connect" button of a specific app. If they close the app and then reopen the docs, we don't
+   * want the "Start VNet" button to copy the address of the app from the prev session.
    */
-  targetAddress: string | undefined;
+  app:
+    | {
+        /**
+         * The address that's going to be copied to the clipboard after user starts VNet for the
+         * first time through this document.
+         *
+         */
+        targetAddress: string | undefined;
+      }
+    | undefined;
 }
 
 /**

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
@@ -288,6 +288,7 @@ export interface DocumentVnetInfo extends DocumentBase {
          *
          */
         targetAddress: string | undefined;
+        isMultiPort: boolean;
       }
     | undefined;
 }

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
@@ -594,7 +594,7 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
         if (d.kind === 'doc.vnet_info') {
           const documentVnetInfo: DocumentVnetInfo = {
             ...d,
-            targetAddress: undefined,
+            app: undefined,
           };
           return documentVnetInfo;
         }

--- a/web/packages/teleterm/src/ui/tshdEvents.ts
+++ b/web/packages/teleterm/src/ui/tshdEvents.ts
@@ -110,7 +110,7 @@ export function createTshdEventsContextBridgeService(
     },
 
     promptHardwareKeyPIN: async ({ request, onRequestCancelled }) => {
-      ctx.mainProcessClient.forceFocusWindow();
+      await ctx.mainProcessClient.forceFocusWindow();
       const { pin, hasCanceledModal } = await new Promise<{
         pin: string;
         hasCanceledModal: boolean;
@@ -142,7 +142,7 @@ export function createTshdEventsContextBridgeService(
     },
 
     promptHardwareKeyTouch: async ({ request, onRequestCancelled }) => {
-      ctx.mainProcessClient.forceFocusWindow();
+      await ctx.mainProcessClient.forceFocusWindow();
       const { hasCanceledModal } = await new Promise<{
         hasCanceledModal: boolean;
       }>(resolve => {


### PR DESCRIPTION
Closes #53290.

After starting VNet through the "Connect" button next to a TCP app, Connect copies the public address of the app to the clipboard. However, this didn't work on the first launch on macOS, as the user has to enable the background item first. Doing so results in VNet losing focus and when the window isn't focused, the clipboard API doesn't work.

At first I tried just calling `forceFocusWindow` on the main process client after enabling the VNet background item. This didn't quite work, as [`app.focus()`](https://www.electronjs.org/docs/latest/api/app#appfocusoptions) ultimately doesn't wait for the focus to be received, it just asks the OS to focus the window and then returns. To work around this, I added polling for window focus status with a 400ms timeout (in case something else steals focus or the user focuses away).

I also updated the notification message for single-port apps so that the user knows that they can connect to the app using any port.


https://github.com/user-attachments/assets/eb88fe86-37f8-4ee0-94ea-620257be2dfa