### PR TITLE
Abstract TDP transport layer

### DIFF
--- a/web/packages/shared/components/DesktopSession/DesktopSession.story.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSession.story.tsx
@@ -86,7 +86,7 @@ export const FetchError = () => (
 export const TdpError = () => {
   const client = fakeClient();
   client.connect = async () => {
-    client.emit(TdpClientEvent.TDP_ERROR, new Error('some tdp error'));
+    client.emit(TdpClientEvent.ERROR, new Error('some tdp error'));
   };
 
   return <DesktopSession {...props} client={client} />;

--- a/web/packages/shared/components/DesktopSession/DesktopSession.story.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSession.story.tsx
@@ -99,7 +99,7 @@ export const Connected = () => {
 export const Disconnected = () => {
   const client = fakeClient();
   client.connect = async () => {
-    client.emit(TdpClientEvent.WS_CLOSE, 'session disconnected');
+    client.emit(TdpClientEvent.TRANSPORT_CLOSE, 'session disconnected');
   };
 
   return <DesktopSession {...props} client={client} />;

--- a/web/packages/shared/components/DesktopSession/DesktopSession.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSession.tsx
@@ -137,7 +137,6 @@ export function DesktopSession({
     [setClipboardSharingState, setDirectorySharingState]
   );
   useListener(client.onError, handleFatalError);
-  useListener(client.onClientError, handleFatalError);
 
   const addWarning = useCallback(
     (warning: string) => {

--- a/web/packages/shared/components/DesktopSession/DesktopSession.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSession.tsx
@@ -164,7 +164,7 @@ export function DesktopSession({
   );
 
   useListener(
-    client.onWsClose,
+    client.onTransportClose,
     useCallback(
       statusText => {
         setTdpConnectionStatus({ status: 'disconnected', message: statusText });
@@ -174,7 +174,7 @@ export function DesktopSession({
     )
   );
   useListener(
-    client.onWsOpen,
+    client.onTransportOpen,
     useCallback(() => {
       setTdpConnectionStatus({ status: 'connected' });
     }, [setTdpConnectionStatus])

--- a/web/packages/shared/libs/tdp/client.ts
+++ b/web/packages/shared/libs/tdp/client.ts
@@ -68,8 +68,8 @@ export enum TdpClientEvent {
   CLIENT_WARNING = 'client warning',
   // TDP_INFO corresponds with the TDP info message
   TDP_INFO = 'tdp info',
-  WS_OPEN = 'ws open',
-  WS_CLOSE = 'ws close',
+  TRANSPORT_OPEN = 'transport open',
+  TRANSPORT_CLOSE = 'transport close',
   RESET = 'reset',
   POINTER = 'pointer',
 }
@@ -148,7 +148,7 @@ export class TdpClient extends EventEmitter {
       return;
     }
 
-    this.emit(TdpClientEvent.WS_OPEN);
+    this.emit(TdpClientEvent.TRANSPORT_OPEN);
     if (spec) {
       this.sendClientScreenSpec(spec);
     }
@@ -185,9 +185,9 @@ export class TdpClient extends EventEmitter {
     if (processingError) {
       this.emit(TdpClientEvent.ERROR, processingError.message);
     } else if (connectionError) {
-      this.emit(TdpClientEvent.WS_CLOSE, connectionError.message);
+      this.emit(TdpClientEvent.TRANSPORT_CLOSE, connectionError.message);
     } else {
-      this.emit(TdpClientEvent.WS_CLOSE, 'Session disconnected');
+      this.emit(TdpClientEvent.TRANSPORT_CLOSE, 'Session disconnected');
     }
 
     this.logger.info('Transport is closed');
@@ -235,14 +235,14 @@ export class TdpClient extends EventEmitter {
     return () => this.off(TdpClientEvent.TDP_WARNING, listener);
   };
 
-  onWsClose = (listener: (message: string) => void) => {
-    this.on(TdpClientEvent.WS_CLOSE, listener);
-    return () => this.off(TdpClientEvent.WS_CLOSE, listener);
+  onTransportClose = (listener: (message: string) => void) => {
+    this.on(TdpClientEvent.TRANSPORT_CLOSE, listener);
+    return () => this.off(TdpClientEvent.TRANSPORT_CLOSE, listener);
   };
 
-  onWsOpen = (listener: () => void) => {
-    this.on(TdpClientEvent.WS_OPEN, listener);
-    return () => this.off(TdpClientEvent.WS_OPEN, listener);
+  onTransportOpen = (listener: () => void) => {
+    this.on(TdpClientEvent.TRANSPORT_OPEN, listener);
+    return () => this.off(TdpClientEvent.TRANSPORT_OPEN, listener);
   };
 
   onClipboardData = (listener: (clipboardData: ClipboardData) => void) => {

--- a/web/packages/shared/libs/tdp/client.ts
+++ b/web/packages/shared/libs/tdp/client.ts
@@ -60,10 +60,8 @@ export enum TdpClientEvent {
   TDP_PNG_FRAME = 'tdp png frame',
   TDP_BMP_FRAME = 'tdp bmp frame',
   TDP_CLIPBOARD_DATA = 'tdp clipboard data',
-  // TDP_ERROR corresponds with the TDP error message
-  TDP_ERROR = 'tdp error',
-  // CLIENT_ERROR represents an error event in the client that isn't a TDP_ERROR
-  CLIENT_ERROR = 'client error',
+  // Represents either a remote TDP error or a client-side error.
+  ERROR = 'error',
   // TDP_WARNING corresponds the TDP warning message
   TDP_WARNING = 'tdp warning',
   // CLIENT_WARNING represents a warning event that isn't a TDP_WARNING
@@ -197,19 +195,14 @@ export class TdpClient extends EventEmitter {
     this.transport = undefined;
   }
 
-  onClientError = (listener: (error: Error) => void) => {
-    this.on(TdpClientEvent.CLIENT_ERROR, listener);
-    return () => this.off(TdpClientEvent.CLIENT_ERROR, listener);
-  };
-
   onClientWarning = (listener: (warningMessage: string) => void) => {
     this.on(TdpClientEvent.CLIENT_WARNING, listener);
     return () => this.off(TdpClientEvent.CLIENT_WARNING, listener);
   };
 
   onError = (listener: (error: Error) => void) => {
-    this.on(TdpClientEvent.TDP_ERROR, listener);
-    return () => this.off(TdpClientEvent.TDP_ERROR, listener);
+    this.on(TdpClientEvent.ERROR, listener);
+    return () => this.off(TdpClientEvent.ERROR, listener);
   };
 
   onInfo = (listener: (info: string) => void) => {
@@ -293,82 +286,74 @@ export class TdpClient extends EventEmitter {
   // processMessage should be await-ed when called,
   // so that its internal await-or-not logic is obeyed.
   async processMessage(buffer: ArrayBuffer): Promise<void> {
-    try {
-      const messageType = this.codec.decodeMessageType(buffer);
-      switch (messageType) {
-        case MessageType.PNG_FRAME:
-          this.handlePngFrame(buffer);
-          break;
-        case MessageType.PNG2_FRAME:
-          this.handlePng2Frame(buffer);
-          break;
-        case MessageType.RDP_CONNECTION_ACTIVATED:
-          this.handleRdpConnectionActivated(buffer);
-          break;
-        case MessageType.RDP_FASTPATH_PDU:
-          this.handleRdpFastPathPDU(buffer);
-          break;
-        case MessageType.CLIENT_SCREEN_SPEC:
-          this.handleClientScreenSpec(buffer);
-          break;
-        case MessageType.MOUSE_BUTTON:
-          this.handleMouseButton(buffer);
-          break;
-        case MessageType.MOUSE_MOVE:
-          this.handleMouseMove(buffer);
-          break;
-        case MessageType.CLIPBOARD_DATA:
-          this.handleClipboardData(buffer);
-          break;
-        case MessageType.ERROR:
-          this.handleError(
-            new Error(this.codec.decodeErrorMessage(buffer)),
-            TdpClientEvent.TDP_ERROR
-          );
-          break;
-        case MessageType.ALERT:
-          this.handleTdpAlert(buffer);
-          break;
-        case MessageType.MFA_JSON:
-          this.handleMfaChallenge(buffer);
-          break;
-        case MessageType.SHARED_DIRECTORY_ACKNOWLEDGE:
-          this.handleSharedDirectoryAcknowledge(buffer);
-          break;
-        case MessageType.SHARED_DIRECTORY_INFO_REQUEST:
-          this.handleSharedDirectoryInfoRequest(buffer);
-          break;
-        case MessageType.SHARED_DIRECTORY_CREATE_REQUEST:
-          // A typical sequence is that we receive a SharedDirectoryCreateRequest
-          // immediately followed by a SharedDirectoryWriteRequest. It's important
-          // that we await here so that this client doesn't field the SharedDirectoryWriteRequest
-          // until the create has successfully completed, or else we might get an error
-          // trying to write to a file that hasn't been created yet.
-          await this.handleSharedDirectoryCreateRequest(buffer);
-          break;
-        case MessageType.SHARED_DIRECTORY_DELETE_REQUEST:
-          this.handleSharedDirectoryDeleteRequest(buffer);
-          break;
-        case MessageType.SHARED_DIRECTORY_READ_REQUEST:
-          this.handleSharedDirectoryReadRequest(buffer);
-          break;
-        case MessageType.SHARED_DIRECTORY_WRITE_REQUEST:
-          this.handleSharedDirectoryWriteRequest(buffer);
-          break;
-        case MessageType.SHARED_DIRECTORY_MOVE_REQUEST:
-          this.handleSharedDirectoryMoveRequest(buffer);
-          break;
-        case MessageType.SHARED_DIRECTORY_LIST_REQUEST:
-          this.handleSharedDirectoryListRequest(buffer);
-          break;
-        case MessageType.SHARED_DIRECTORY_TRUNCATE_REQUEST:
-          this.handleSharedDirectoryTruncateRequest(buffer);
-          break;
-        default:
-          this.logger.warn(`received unsupported message type ${messageType}`);
-      }
-    } catch (err) {
-      this.handleError(err, TdpClientEvent.CLIENT_ERROR);
+    const messageType = this.codec.decodeMessageType(buffer);
+    switch (messageType) {
+      case MessageType.PNG_FRAME:
+        this.handlePngFrame(buffer);
+        break;
+      case MessageType.PNG2_FRAME:
+        this.handlePng2Frame(buffer);
+        break;
+      case MessageType.RDP_CONNECTION_ACTIVATED:
+        this.handleRdpConnectionActivated(buffer);
+        break;
+      case MessageType.RDP_FASTPATH_PDU:
+        this.handleRdpFastPathPDU(buffer);
+        break;
+      case MessageType.CLIENT_SCREEN_SPEC:
+        this.handleClientScreenSpec(buffer);
+        break;
+      case MessageType.MOUSE_BUTTON:
+        this.handleMouseButton(buffer);
+        break;
+      case MessageType.MOUSE_MOVE:
+        this.handleMouseMove(buffer);
+        break;
+      case MessageType.CLIPBOARD_DATA:
+        this.handleClipboardData(buffer);
+        break;
+      case MessageType.ERROR:
+        throw new Error(this.codec.decodeErrorMessage(buffer));
+      case MessageType.ALERT:
+        this.handleTdpAlert(buffer);
+        break;
+      case MessageType.MFA_JSON:
+        this.handleMfaChallenge(buffer);
+        break;
+      case MessageType.SHARED_DIRECTORY_ACKNOWLEDGE:
+        this.handleSharedDirectoryAcknowledge(buffer);
+        break;
+      case MessageType.SHARED_DIRECTORY_INFO_REQUEST:
+        await this.handleSharedDirectoryInfoRequest(buffer);
+        break;
+      case MessageType.SHARED_DIRECTORY_CREATE_REQUEST:
+        // A typical sequence is that we receive a SharedDirectoryCreateRequest
+        // immediately followed by a SharedDirectoryWriteRequest. It's important
+        // that we await here so that this client doesn't field the SharedDirectoryWriteRequest
+        // until the create has successfully completed, or else we might get an error
+        // trying to write to a file that hasn't been created yet.
+        await this.handleSharedDirectoryCreateRequest(buffer);
+        break;
+      case MessageType.SHARED_DIRECTORY_DELETE_REQUEST:
+        await this.handleSharedDirectoryDeleteRequest(buffer);
+        break;
+      case MessageType.SHARED_DIRECTORY_READ_REQUEST:
+        await this.handleSharedDirectoryReadRequest(buffer);
+        break;
+      case MessageType.SHARED_DIRECTORY_WRITE_REQUEST:
+        await this.handleSharedDirectoryWriteRequest(buffer);
+        break;
+      case MessageType.SHARED_DIRECTORY_MOVE_REQUEST:
+        this.handleSharedDirectoryMoveRequest(buffer);
+        break;
+      case MessageType.SHARED_DIRECTORY_LIST_REQUEST:
+        await this.handleSharedDirectoryListRequest(buffer);
+        break;
+      case MessageType.SHARED_DIRECTORY_TRUNCATE_REQUEST:
+        await this.handleSharedDirectoryTruncateRequest(buffer);
+        break;
+      default:
+        this.logger.warn(`received unsupported message type ${messageType}`);
     }
   }
 
@@ -407,7 +392,7 @@ export class TdpClient extends EventEmitter {
     const alert = this.codec.decodeAlert(buffer);
     // TODO(zmb3): info and warning should use the same handler
     if (alert.severity === Severity.Error) {
-      this.handleError(new Error(alert.message), TdpClientEvent.TDP_ERROR);
+      throw new Error(alert.message);
     } else if (alert.severity === Severity.Warning) {
       this.handleWarning(alert.message, TdpClientEvent.TDP_WARNING);
     } else {
@@ -451,51 +436,38 @@ export class TdpClient extends EventEmitter {
     let rdpFastPathPDU = this.codec.decodeRdpFastPathPDU(buffer);
 
     // This should never happen but let's catch it with an error in case it does.
-    if (!this.fastPathProcessor)
-      this.handleError(
-        new Error('FastPathProcessor not initialized'),
-        TdpClientEvent.CLIENT_ERROR
-      );
-
-    try {
-      this.fastPathProcessor.process(
-        rdpFastPathPDU,
-        this,
-        (bmpFrame: BitmapFrame) => {
-          this.emit(TdpClientEvent.TDP_BMP_FRAME, bmpFrame);
-        },
-        (responseFrame: ArrayBuffer) => {
-          this.sendRdpResponsePDU(responseFrame);
-        },
-        (data: ImageData | boolean, hotspot_x?: number, hotspot_y?: number) => {
-          this.emit(TdpClientEvent.POINTER, { data, hotspot_x, hotspot_y });
-        }
-      );
-    } catch (e) {
-      this.handleError(e, TdpClientEvent.CLIENT_ERROR);
+    if (!this.fastPathProcessor) {
+      throw new Error('FastPathProcessor not initialized');
     }
+
+    this.fastPathProcessor.process(
+      rdpFastPathPDU,
+      this,
+      (bmpFrame: BitmapFrame) => {
+        this.emit(TdpClientEvent.TDP_BMP_FRAME, bmpFrame);
+      },
+      (responseFrame: ArrayBuffer) => {
+        this.sendRdpResponsePDU(responseFrame);
+      },
+      (data: ImageData | boolean, hotspot_x?: number, hotspot_y?: number) => {
+        this.emit(TdpClientEvent.POINTER, { data, hotspot_x, hotspot_y });
+      }
+    );
   }
 
   handleMfaChallenge(buffer: ArrayBuffer) {
-    try {
-      const mfaJson = this.codec.decodeMfaJson(buffer);
-      if (mfaJson.mfaType == 'n') {
-        // TermEvent.MFA_CHALLENGE
-        this.emit('terminal.webauthn', mfaJson.jsonString);
-      } else {
-        // mfaJson.mfaType === 'u', or else decodeMfaJson would have thrown an error.
-        this.handleError(
-          new Error(
-            'Multifactor authentication is required for accessing this desktop, \
+    const mfaJson = this.codec.decodeMfaJson(buffer);
+    if (mfaJson.mfaType == 'n') {
+      // TermEvent.MFA_CHALLENGE
+      this.emit('terminal.webauthn', mfaJson.jsonString);
+    } else {
+      // mfaJson.mfaType === 'u', or else decodeMfaJson would have thrown an error.
+      throw new Error(
+        'Multifactor authentication is required for accessing this desktop, \
       however the U2F API for hardware keys is not supported for desktop sessions. \
       Please notify your system administrator to update cluster settings \
       to use WebAuthn as the second factor protocol.'
-          ),
-          TdpClientEvent.CLIENT_ERROR
-        );
-      }
-    } catch (err) {
-      this.handleError(err, TdpClientEvent.CLIENT_ERROR);
+      );
     }
   }
 
@@ -540,7 +512,7 @@ export class TdpClient extends EventEmitter {
           },
         });
       } else {
-        this.handleError(e, TdpClientEvent.CLIENT_ERROR);
+        throw e;
       }
     }
   }
@@ -592,40 +564,32 @@ export class TdpClient extends EventEmitter {
 
   async handleSharedDirectoryReadRequest(buffer: ArrayBuffer) {
     const req = this.codec.decodeSharedDirectoryReadRequest(buffer);
-    try {
-      const readData = await this.sdManager.readFile(
-        req.path,
-        req.offset,
-        req.length
-      );
-      this.sendSharedDirectoryReadResponse({
-        completionId: req.completionId,
-        errCode: SharedDirectoryErrCode.Nil,
-        readDataLength: readData.length,
-        readData,
-      });
-    } catch (e) {
-      this.handleError(e, TdpClientEvent.CLIENT_ERROR);
-    }
+    const readData = await this.sdManager.readFile(
+      req.path,
+      req.offset,
+      req.length
+    );
+    this.sendSharedDirectoryReadResponse({
+      completionId: req.completionId,
+      errCode: SharedDirectoryErrCode.Nil,
+      readDataLength: readData.length,
+      readData,
+    });
   }
 
   async handleSharedDirectoryWriteRequest(buffer: ArrayBuffer) {
     const req = this.codec.decodeSharedDirectoryWriteRequest(buffer);
-    try {
-      const bytesWritten = await this.sdManager.writeFile(
-        req.path,
-        req.offset,
-        req.writeData
-      );
+    const bytesWritten = await this.sdManager.writeFile(
+      req.path,
+      req.offset,
+      req.writeData
+    );
 
-      this.sendSharedDirectoryWriteResponse({
-        completionId: req.completionId,
-        errCode: SharedDirectoryErrCode.Nil,
-        bytesWritten,
-      });
-    } catch (e) {
-      this.handleError(e, TdpClientEvent.CLIENT_ERROR);
-    }
+    this.sendSharedDirectoryWriteResponse({
+      completionId: req.completionId,
+      errCode: SharedDirectoryErrCode.Nil,
+      bytesWritten,
+    });
   }
 
   handleSharedDirectoryMoveRequest(buffer: ArrayBuffer) {
@@ -643,36 +607,26 @@ export class TdpClient extends EventEmitter {
   }
 
   async handleSharedDirectoryListRequest(buffer: ArrayBuffer) {
-    try {
-      const req = this.codec.decodeSharedDirectoryListRequest(buffer);
-      const path = req.path;
+    const req = this.codec.decodeSharedDirectoryListRequest(buffer);
+    const path = req.path;
 
-      const infoList: FileOrDirInfo[] = await this.sdManager.listContents(path);
-      const fsoList: FileSystemObject[] = infoList.map(info =>
-        this.toFso(info)
-      );
+    const infoList: FileOrDirInfo[] = await this.sdManager.listContents(path);
+    const fsoList: FileSystemObject[] = infoList.map(info => this.toFso(info));
 
-      this.sendSharedDirectoryListResponse({
-        completionId: req.completionId,
-        errCode: SharedDirectoryErrCode.Nil,
-        fsoList,
-      });
-    } catch (e) {
-      this.handleError(e, TdpClientEvent.CLIENT_ERROR);
-    }
+    this.sendSharedDirectoryListResponse({
+      completionId: req.completionId,
+      errCode: SharedDirectoryErrCode.Nil,
+      fsoList,
+    });
   }
 
   async handleSharedDirectoryTruncateRequest(buffer: ArrayBuffer) {
     const req = this.codec.decodeSharedDirectoryTruncateRequest(buffer);
-    try {
-      await this.sdManager.truncateFile(req.path, req.endOfFile);
-      this.sendSharedDirectoryTruncateResponse({
-        completionId: req.completionId,
-        errCode: SharedDirectoryErrCode.Nil,
-      });
-    } catch (e) {
-      this.handleError(e, TdpClientEvent.CLIENT_ERROR);
-    }
+    await this.sdManager.truncateFile(req.path, req.endOfFile);
+    this.sendSharedDirectoryTruncateResponse({
+      completionId: req.completionId,
+      errCode: SharedDirectoryErrCode.Nil,
+    });
   }
 
   private toFso(info: FileOrDirInfo): FileSystemObject {
@@ -753,29 +707,20 @@ export class TdpClient extends EventEmitter {
   }
 
   addSharedDirectory(sharedDirectory: FileSystemDirectoryHandle) {
-    try {
-      this.sdManager.add(sharedDirectory);
-    } catch (err) {
-      this.handleError(err, TdpClientEvent.CLIENT_ERROR);
-    }
+    this.sdManager.add(sharedDirectory);
   }
 
   sendSharedDirectoryAnnounce() {
-    let name: string;
-    try {
-      name = this.sdManager.getName();
-      this.send(
-        this.codec.encodeSharedDirectoryAnnounce({
-          discard: 0, // This is always the first request.
-          // Hardcode directoryId for now since we only support sharing 1 directory.
-          // We're using 2 because the smartcard device is hardcoded to 1 in the backend.
-          directoryId: 2,
-          name,
-        })
-      );
-    } catch (e) {
-      this.handleError(e, TdpClientEvent.CLIENT_ERROR);
-    }
+    const name = this.sdManager.getName();
+    this.send(
+      this.codec.encodeSharedDirectoryAnnounce({
+        discard: 0, // This is always the first request.
+        // Hardcode directoryId for now since we only support sharing 1 directory.
+        // We're using 2 because the smartcard device is hardcoded to 1 in the backend.
+        directoryId: 2,
+        name,
+      })
+    );
   }
 
   sendSharedDirectoryInfoResponse(res: SharedDirectoryInfoResponse) {
@@ -818,23 +763,6 @@ export class TdpClient extends EventEmitter {
 
   sendRdpResponsePDU(responseFrame: ArrayBuffer) {
     this.send(this.codec.encodeRdpResponsePDU(responseFrame));
-  }
-
-  // Emits an errType event and closes the websocket connection.
-  // Should only be used for fatal errors.
-  private handleError(
-    err: Error,
-    errType: TdpClientEvent.TDP_ERROR | TdpClientEvent.CLIENT_ERROR
-  ) {
-    this.logger.error(err);
-    this.emit(errType, err);
-    // All errors are fatal, meaning that we are closing the connection after they happen.
-    // To prevent overwriting such error with our close handler, remove it before
-    // closing the connection.
-    if (this.socket) {
-      this.socket.onclose = null;
-      this.socket.close();
-    }
   }
 
   // Emits a warning event, but keeps the socket open.

--- a/web/packages/teleport/src/DesktopSession/DesktopSession.tsx
+++ b/web/packages/teleport/src/DesktopSession/DesktopSession.tsx
@@ -30,6 +30,7 @@ import { useTeleport } from 'teleport';
 import AuthnDialog from 'teleport/components/AuthnDialog';
 import cfg, { UrlDesktopParams } from 'teleport/config';
 import { AuthenticatedWebSocket } from 'teleport/lib/AuthenticatedWebSocket';
+import { adaptWebSocketToTdpTransport } from 'teleport/lib/tdp';
 import { shouldShowMfaPrompt, useMfaEmitter } from 'teleport/lib/useMfa';
 import { getHostName } from 'teleport/services/api';
 
@@ -43,15 +44,17 @@ export function DesktopSession() {
   const [client] = useState(
     () =>
       //TODO(gzdunek): It doesn't really matter here, but make TdpClient reactive to addr change.
-      new TdpClient(
-        () =>
+      new TdpClient(abortSignal =>
+        adaptWebSocketToTdpTransport(
           new AuthenticatedWebSocket(
             cfg.api.desktopWsAddr
               .replace(':fqdn', getHostName())
               .replace(':clusterId', clusterId)
               .replace(':desktopName', desktopName)
               .replace(':username', username)
-          )
+          ),
+          abortSignal
+        )
       )
   );
   const mfa = useMfaEmitter(client);

--- a/web/packages/teleport/src/Player/DesktopPlayer.tsx
+++ b/web/packages/teleport/src/Player/DesktopPlayer.tsx
@@ -61,7 +61,6 @@ export const DesktopPlayer = ({
 
   useListener(playerClient?.onError, clientOnTdpError);
   useListener(playerClient?.onClientError, clientOnTdpError);
-  useListener(playerClient?.onClientError, clientOnTdpError);
   useListener(playerClient?.onInfo, clientOnTdpInfo);
   useListener(playerClient?.onWsClose, clientOnWsClose);
   useListener(

--- a/web/packages/teleport/src/Player/DesktopPlayer.tsx
+++ b/web/packages/teleport/src/Player/DesktopPlayer.tsx
@@ -50,6 +50,7 @@ export const DesktopPlayer = ({
     statusText,
     time,
 
+    clientOnTransportOpen,
     clientOnWsClose,
     clientOnError,
     clientOnTdpInfo,
@@ -61,6 +62,7 @@ export const DesktopPlayer = ({
 
   useListener(playerClient?.onError, clientOnError);
   useListener(playerClient?.onInfo, clientOnTdpInfo);
+  useListener(playerClient?.onTransportOpen, clientOnTransportOpen);
   useListener(playerClient?.onTransportClose, clientOnWsClose);
   useListener(
     playerClient?.onPngFrame,
@@ -130,6 +132,10 @@ const useDesktopPlayer = ({ clusterId, sid }) => {
     return new PlayerClient({ url, setTime, setPlayerStatus, setStatusText });
   }, [clusterId, sid]);
 
+  const clientOnTransportOpen = useCallback(() => {
+    setPlayerStatus(StatusEnum.PLAYING);
+  }, []);
+
   const clientOnWsClose = useCallback(() => {
     if (playerClient) {
       playerClient.cancelTimeUpdate();
@@ -162,6 +168,7 @@ const useDesktopPlayer = ({ clusterId, sid }) => {
     playerStatus,
     statusText,
 
+    clientOnTransportOpen,
     clientOnWsClose,
     clientOnError,
     clientOnTdpInfo,

--- a/web/packages/teleport/src/Player/DesktopPlayer.tsx
+++ b/web/packages/teleport/src/Player/DesktopPlayer.tsx
@@ -51,7 +51,7 @@ export const DesktopPlayer = ({
     time,
 
     clientOnWsClose,
-    clientOnTdpError,
+    clientOnError,
     clientOnTdpInfo,
   } = useDesktopPlayer({
     sid,
@@ -59,8 +59,7 @@ export const DesktopPlayer = ({
   });
   const canvasRendererRef = useRef<CanvasRendererRef>(null);
 
-  useListener(playerClient?.onError, clientOnTdpError);
-  useListener(playerClient?.onClientError, clientOnTdpError);
+  useListener(playerClient?.onError, clientOnError);
   useListener(playerClient?.onInfo, clientOnTdpInfo);
   useListener(playerClient?.onWsClose, clientOnWsClose);
   useListener(
@@ -137,7 +136,7 @@ const useDesktopPlayer = ({ clusterId, sid }) => {
     }
   }, [playerClient]);
 
-  const clientOnTdpError = useCallback((error: Error) => {
+  const clientOnError = useCallback((error: Error) => {
     setPlayerStatus(StatusEnum.ERROR);
     setStatusText(error.message || error.toString());
   }, []);
@@ -164,7 +163,7 @@ const useDesktopPlayer = ({ clusterId, sid }) => {
     statusText,
 
     clientOnWsClose,
-    clientOnTdpError,
+    clientOnError,
     clientOnTdpInfo,
   };
 };

--- a/web/packages/teleport/src/Player/DesktopPlayer.tsx
+++ b/web/packages/teleport/src/Player/DesktopPlayer.tsx
@@ -51,7 +51,7 @@ export const DesktopPlayer = ({
     time,
 
     clientOnTransportOpen,
-    clientOnWsClose,
+    clientOnTransportClose,
     clientOnError,
     clientOnTdpInfo,
   } = useDesktopPlayer({
@@ -63,7 +63,7 @@ export const DesktopPlayer = ({
   useListener(playerClient?.onError, clientOnError);
   useListener(playerClient?.onInfo, clientOnTdpInfo);
   useListener(playerClient?.onTransportOpen, clientOnTransportOpen);
-  useListener(playerClient?.onTransportClose, clientOnWsClose);
+  useListener(playerClient?.onTransportClose, clientOnTransportClose);
   useListener(
     playerClient?.onPngFrame,
     canvasRendererRef.current?.renderPngFrame
@@ -88,7 +88,7 @@ export const DesktopPlayer = ({
 
   return (
     <StyledPlayer>
-      {isError && <DesktopPlayerAlert my={4} children={statusText} />}
+      {isError && <DesktopPlayerAlert my={4}>{statusText}</DesktopPlayerAlert>}
       {isLoading && (
         <Box textAlign="center" m={10}>
           <Indicator />
@@ -136,7 +136,7 @@ const useDesktopPlayer = ({ clusterId, sid }) => {
     setPlayerStatus(StatusEnum.PLAYING);
   }, []);
 
-  const clientOnWsClose = useCallback(() => {
+  const clientOnTransportClose = useCallback(() => {
     if (playerClient) {
       playerClient.cancelTimeUpdate();
     }
@@ -169,7 +169,7 @@ const useDesktopPlayer = ({ clusterId, sid }) => {
     statusText,
 
     clientOnTransportOpen,
-    clientOnWsClose,
+    clientOnTransportClose,
     clientOnError,
     clientOnTdpInfo,
   };

--- a/web/packages/teleport/src/Player/DesktopPlayer.tsx
+++ b/web/packages/teleport/src/Player/DesktopPlayer.tsx
@@ -61,7 +61,7 @@ export const DesktopPlayer = ({
 
   useListener(playerClient?.onError, clientOnError);
   useListener(playerClient?.onInfo, clientOnTdpInfo);
-  useListener(playerClient?.onWsClose, clientOnWsClose);
+  useListener(playerClient?.onTransportClose, clientOnWsClose);
   useListener(
     playerClient?.onPngFrame,
     canvasRendererRef.current?.renderPngFrame

--- a/web/packages/teleport/src/Player/Player.story.tsx
+++ b/web/packages/teleport/src/Player/Player.story.tsx
@@ -16,17 +16,30 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { Meta } from '@storybook/react';
 import { createMemoryHistory } from 'history';
 
 import { Flex } from 'design';
 
+import { ContextProvider } from 'teleport';
 import { Route, Router } from 'teleport/components/Router';
+import { createTeleportContext } from 'teleport/mocks/contexts';
 
 import { Player } from './Player';
 
-export default {
+const meta: Meta = {
   title: 'Teleport/Player',
+  decorators: Story => {
+    const ctx = createTeleportContext();
+
+    return (
+      <ContextProvider ctx={ctx}>
+        <Story />
+      </ContextProvider>
+    );
+  },
 };
+export default meta;
 
 export const SSH = () => {
   const history = createMemoryHistory({

--- a/web/packages/teleport/src/lib/tdp/index.ts
+++ b/web/packages/teleport/src/lib/tdp/index.ts
@@ -17,3 +17,4 @@
  */
 
 export { PlayerClient } from './playerClient';
+export { adaptWebSocketToTdpTransport } from './webSocketTransportAdapter';

--- a/web/packages/teleport/src/lib/tdp/playerClient.ts
+++ b/web/packages/teleport/src/lib/tdp/playerClient.ts
@@ -23,6 +23,8 @@ import { throttle } from 'shared/utils/highbar';
 import { AuthenticatedWebSocket } from 'teleport/lib/AuthenticatedWebSocket';
 import { StatusEnum } from 'teleport/lib/player';
 
+import { adaptWebSocketToTdpTransport } from './webSocketTransportAdapter';
+
 // we update the time every time we receive data, or
 // at this interval (which ensures that the progress
 // bar updates even when we aren't receiving data)
@@ -52,7 +54,9 @@ export class PlayerClient extends TdpClient {
   private timeout = null;
 
   constructor({ url, setTime, setPlayerStatus, setStatusText }) {
-    super(() => new AuthenticatedWebSocket(url));
+    super(signal =>
+      adaptWebSocketToTdpTransport(new AuthenticatedWebSocket(url), signal)
+    );
     this.setPlayerStatus = setPlayerStatus;
     this.setStatusText = setStatusText;
     this._setTime = setTime;

--- a/web/packages/teleport/src/lib/tdp/playerClient.ts
+++ b/web/packages/teleport/src/lib/tdp/playerClient.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ClientScreenSpec, TdpClient, TdpClientEvent } from 'shared/libs/tdp';
+import { TdpClient, TdpClientEvent } from 'shared/libs/tdp';
 import { base64ToArrayBuffer } from 'shared/utils/base64';
 import { throttle } from 'shared/utils/highbar';
 
@@ -71,12 +71,6 @@ export class PlayerClient extends TdpClient {
       this.lastTimestamp = t;
       this.lastUpdateTime = Date.now();
     }, PROGRESS_UPDATE_INTERVAL_MS);
-  }
-
-  // Override so we can set player status.
-  async connect(spec?: ClientScreenSpec) {
-    await super.connect(spec);
-    this.setPlayerStatus(StatusEnum.PLAYING);
   }
 
   scheduleNextUpdate(current: number) {

--- a/web/packages/teleport/src/lib/tdp/webSocketTransportAdapter.ts
+++ b/web/packages/teleport/src/lib/tdp/webSocketTransportAdapter.ts
@@ -1,0 +1,106 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Logger } from 'design/logger';
+import { TdpTransport } from 'shared/libs/tdp/client';
+
+const logger = new Logger('WebSocketTdpTransport');
+
+/**
+ * Adapts WebSocket to TDP transport.
+ * Returns a promise that fulfills with an object once the socket connection is successfully opened.
+ * The promise rejects if the WebSocket connection fails during the setup.
+ */
+export async function adaptWebSocketToTdpTransport(
+  socket: WebSocket,
+  signal: AbortSignal
+): Promise<TdpTransport> {
+  // WebsocketCloseCode.NORMAL
+  signal.addEventListener('abort', () => socket.close(1000));
+  socket.binaryType = 'arraybuffer';
+
+  try {
+    await waitToOpen(socket);
+  } catch (e) {
+    logger.error('Could not open WebSocket', e);
+    throw e;
+  }
+  logger.info('WebSocket is open');
+
+  return {
+    send: data => {
+      // WebSocket only throws when we try to send a message while it is non-OPEN state.
+      if (socket.readyState !== WebSocket.OPEN) {
+        logger.info('WebSocket is not open, cannot send message.');
+        return;
+      }
+      socket.send(data);
+    },
+    onMessage: callback => {
+      const handler = (e: MessageEvent) => {
+        callback(e.data);
+      };
+      socket.addEventListener('message', handler);
+      return () => socket.removeEventListener('message', handler);
+    },
+    onComplete: callback => {
+      const handler = (e: CloseEvent) => {
+        if (e.wasClean) {
+          callback();
+        }
+      };
+      socket.addEventListener('close', handler);
+      return () => socket.removeEventListener('close', handler);
+    },
+    onError: callback => {
+      const handler = (e: CloseEvent) => {
+        if (!e.wasClean) {
+          logger.error(`Websocket closed with error (${e.code})`);
+          callback(new Error(`Connection closed with websocket error`));
+        }
+      };
+      // The socket will only ever emit the socket 'error' event
+      // prior to a socket 'close' event (https://stackoverflow.com/a/40084550/6277051).
+      // Therefore, we can rely on 'close' events to account for any websocket errors.
+      socket.addEventListener('close', handler);
+      return () => socket.removeEventListener('close', handler);
+    },
+  };
+}
+
+async function waitToOpen(socket: WebSocket): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const handleOpen = () => {
+      cleanup();
+      resolve();
+    };
+
+    const handleError = (event: Event) => {
+      cleanup();
+      reject(event);
+    };
+
+    function cleanup() {
+      socket.removeEventListener('open', handleOpen);
+      socket.removeEventListener('error', handleError);
+    }
+
+    socket.addEventListener('open', handleOpen);
+    socket.addEventListener('error', handleError);
+  });
+}


### PR DESCRIPTION
Contributes to https://github.com/gravitational/teleport/issues/20802

The purpose of this PR is to make the transport layer more abstract, so that it can support both WebSocket and gRPC bidirectional stream.

While working on this, I realized that the way we handle errors (both the TDP and client ones) is quite hard to follow.

Currently, it works like this:
1. In `connect` method we set up websocket listeners.
2. In `processMessage`, both the entire method and the individual handlers for each message are wrapped in `try/catch` that call `handleError` when an error is thrown.
3. In `handleError` we emit the error, remove `onclose` handler (to avoid emitting `WS_CLOSE` event) and close the stream. The listeners in `connect` are not fired.
4. However, if the socket closes without an error, the handlers from connect are triggered as expected.

We can simplify this by throwing errors directly in the message handlers, allowing them to propagate to the `connect` method. This keeps the entire connection lifecycle in one place, making it easier to handle errors and events consistently.

I also merged `TdpClientEvent.TDP_ERROR` and `TdpClientEvent.CLIENT_ERROR` into a single `TdpClientEvent.ERROR`. I see the idea behind separate events, but in practice, they don't seem to give us any value. Since all errors are handled the same way in the UI, consolidating them simplifies the code without losing functionality.