### PR TITLE
Moving session recording file ops behind an interface

### DIFF
--- a/lib/events/filesessions/filesessionrecorder.go
+++ b/lib/events/filesessions/filesessionrecorder.go
@@ -1,0 +1,140 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package filesessions
+
+import (
+	"context"
+	"io"
+	"iter"
+	"log/slog"
+	"os"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+const (
+	reservationFilePerm = 0600
+	combinedFilePerm    = reservationFilePerm
+)
+
+// PlainFileRecorder interacts with the file system to write unencrypted recording parts to disk.
+type PlainFileRecorder struct {
+	log      *slog.Logger
+	openFile utils.OpenFileWithFlagsFunc
+}
+
+var _ sessionFileRecorder = (*PlainFileRecorder)(nil)
+
+// NewPlainFileRecorder returns a plaintext implementation of the SessionFileRecorder interface.
+func NewPlainFileRecorder(log *slog.Logger, openFile utils.OpenFileWithFlagsFunc) *PlainFileRecorder {
+	return &PlainFileRecorder{
+		log:      log,
+		openFile: openFile,
+	}
+}
+
+// ReservePart creates a new file for recording session data with a reserved file size.
+func (p *PlainFileRecorder) ReservePart(ctx context.Context, name string, size int64) (err error) {
+	log := p.log.With("file", name, "size", size)
+
+	f, err := p.openFile(name, os.O_WRONLY|os.O_CREATE, reservationFilePerm)
+	if err != nil {
+		return trace.ConvertSystemError(err)
+	}
+
+	defer func() {
+		closeErr := f.Close()
+		if closeErr != nil {
+			log.ErrorContext(ctx, "failed to close reservation file", "error", closeErr)
+		}
+
+		if err = trace.NewAggregate(err, closeErr); err != nil {
+			if rmErr := os.Remove(name); rmErr != nil {
+				log.WarnContext(ctx, "failed to remove part file", "file", name, "error", rmErr)
+			}
+		}
+	}()
+
+	if err := f.Truncate(size); err != nil {
+		return trace.ConvertSystemError(err)
+	}
+
+	return nil
+}
+
+// WritePart writes session data to an already Reserved file and truncates it to the new size.
+func (p *PlainFileRecorder) WritePart(ctx context.Context, name string, data io.Reader) (err error) {
+	log := p.log.With("file", name)
+
+	// O_CREATE kepr for backwards compatibility only
+	const flag = os.O_WRONLY | os.O_CREATE
+
+	f, err := p.openFile(name, flag, reservationFilePerm)
+	if err != nil {
+		return trace.ConvertSystemError(err)
+	}
+
+	defer func() {
+		closeErr := f.Close()
+		if closeErr != nil {
+			log.ErrorContext(ctx, "failed to close file part file after write", "error", closeErr)
+		}
+
+		if err = trace.NewAggregate(err, closeErr); err != nil {
+			if rmErr := os.Remove(name); rmErr != nil {
+				log.WarnContext(ctx, "failed to remove part file", "error", rmErr)
+			}
+		}
+	}()
+
+	n, err := io.Copy(f, data)
+	if err != nil {
+		return trace.ConvertSystemError(err)
+	}
+
+	if err := f.Truncate(n); err != nil {
+		return trace.ConvertSystemError(err)
+	}
+
+	return nil
+}
+
+// CombineParts collects part files of a single session recording and combines them into a single io.Writer.
+func (p *PlainFileRecorder) CombineParts(ctx context.Context, dst io.Writer, parts iter.Seq[string]) error {
+	for part := range parts {
+		partFile, err := p.openFile(part, os.O_RDONLY, 0)
+		if err != nil {
+			return trace.ConvertSystemError(err)
+		}
+
+		defer func() {
+			if err := partFile.Close(); err != nil {
+				p.log.ErrorContext(ctx, "failed to close part file during combine", "file", part, "error", err)
+			}
+		}()
+
+		if _, err = io.Copy(dst, partFile); err != nil {
+			return trace.ConvertSystemError(err)
+		}
+	}
+
+	return nil
+}

--- a/lib/events/filesessions/filesessionrecorder_test.go
+++ b/lib/events/filesessions/filesessionrecorder_test.go
@@ -1,0 +1,81 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package filesessions
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+func TestPlainFileOpsReservations(t *testing.T) {
+	ctx := context.Background()
+	rec := NewPlainFileRecorder(utils.NewSlogLoggerForTests(), os.OpenFile)
+	base := t.TempDir()
+	reservation := filepath.Join(base, "reservation")
+	var fileSize int64 = 512
+
+	err := rec.ReservePart(ctx, reservation, fileSize)
+	require.NoError(t, err)
+
+	info, err := os.Stat(reservation)
+	require.NoError(t, err)
+	require.Equal(t, fileSize, info.Size())
+
+	buf := bytes.NewBufferString("testing")
+	expectedLen := buf.Len()
+	err = rec.WritePart(ctx, reservation, buf)
+	require.NoError(t, err)
+
+	info, err = os.Stat(reservation)
+	require.NoError(t, err)
+	require.Equal(t, int64(expectedLen), info.Size())
+}
+
+func TestPlainFileOpsCombineParts(t *testing.T) {
+	ctx := context.Background()
+	rec := NewPlainFileRecorder(utils.NewSlogLoggerForTests(), os.OpenFile)
+	base := t.TempDir()
+	parts := []string{"part1", "part2", "part3"}
+	partPaths := make([]string, len(parts))
+	for idx, part := range parts {
+		partPaths[idx] = filepath.Join(base, part)
+		f, err := os.Create(partPaths[idx])
+		require.NoError(t, err)
+
+		_, err = f.WriteString(part)
+		require.NoError(t, err)
+	}
+
+	dst := bytes.NewBuffer(nil)
+	err := rec.CombineParts(ctx, dst, slices.Values(partPaths))
+	require.NoError(t, err)
+
+	output, _ := dst.ReadString(0)
+
+	require.Equal(t, strings.Join(parts, ""), output)
+}

--- a/lib/events/filesessions/filestream.go
+++ b/lib/events/filesessions/filestream.go
@@ -19,12 +19,14 @@
 package filesessions
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -68,12 +70,16 @@ func GetOpenFileFunc() utils.OpenFileWithFlagsFunc {
 	return openFileFunc
 }
 
-// minUploadBytes is the minimum part file size required to trigger its upload.
-const minUploadBytes = events.MaxProtoMessageSizeBytes * 2
+const (
+	// minUploadBytes is the minimum part file size required to trigger its upload.
+	minUploadBytes = events.MaxProtoMessageSizeBytes * 2
+	// reservationSize is the size new reservations will preallocate.
+	reservationSize = minUploadBytes + events.MaxProtoMessageSizeBytes
+)
 
 // NewStreamer creates a streamer sending uploads to disk
 func NewStreamer(dir string) (*events.ProtoStreamer, error) {
-	handler, err := NewHandler(Config{Directory: dir})
+	handler, err := NewHandler(Config{Directory: dir, OpenFile: GetOpenFileFunc()})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -110,23 +116,14 @@ func (h *Handler) UploadPart(ctx context.Context, upload events.StreamUpload, pa
 		return nil, trace.Wrap(err)
 	}
 
-	file, reservationPath, err := h.openReservationPart(upload, partNumber)
-	if err != nil {
-		return nil, trace.ConvertSystemError(err)
-	}
-
-	size, err := io.Copy(file, partBody)
-	if err = trace.NewAggregate(err, file.Truncate(size), file.Close()); err != nil {
-		if rmErr := os.Remove(reservationPath); rmErr != nil {
-			h.logger.WarnContext(ctx, "Failed to remove part file", "file", reservationPath, "error", rmErr)
-		}
+	reservationPath := h.reservationPath(upload, partNumber)
+	if err := h.fileRecorder.WritePart(ctx, reservationPath, partBody); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	// Rename reservation to part file.
 	partPath := h.partPath(upload, partNumber)
-	err = os.Rename(reservationPath, partPath)
-	if err != nil {
+	if err := os.Rename(reservationPath, partPath); err != nil {
 		return nil, trace.ConvertSystemError(err)
 	}
 
@@ -144,11 +141,6 @@ func (h *Handler) CompleteUpload(ctx context.Context, upload events.StreamUpload
 	if err := checkUpload(upload); err != nil {
 		return trace.Wrap(err)
 	}
-
-	// Parts must be sorted in PartNumber order.
-	sort.Slice(parts, func(i, j int) bool {
-		return parts[i].Number < parts[j].Number
-	})
 
 	uploadPath := h.path(upload.SessionID)
 
@@ -204,26 +196,19 @@ Loop:
 		}
 	}()
 
-	writePartToFile := func(path string) error {
-		file, err := os.Open(path)
-		if err != nil {
-			return err
-		}
-		defer func() {
-			if err := file.Close(); err != nil {
-				h.logger.ErrorContext(ctx, "failed to close file", "file", path, "error", err)
+	// Parts must be sorted in PartNumber order.
+	slices.SortFunc(parts, func(a, b events.StreamPart) int {
+		return cmp.Compare(a.Number, b.Number)
+	})
+
+	if err := h.fileRecorder.CombineParts(ctx, f, func(yield func(string) bool) {
+		for _, part := range parts {
+			if !yield(h.partPath(upload, part.Number)) {
+				break
 			}
-		}()
-
-		_, err = io.Copy(f, file)
-		return err
-	}
-
-	for _, part := range parts {
-		partPath := h.partPath(upload, part.Number)
-		if err := writePartToFile(partPath); err != nil {
-			return trace.Wrap(err)
 		}
+	}); err != nil {
+		return trace.Wrap(err)
 	}
 
 	err = h.Config.OnBeforeComplete(ctx, upload)
@@ -349,35 +334,12 @@ func (h *Handler) GetUploadMetadata(s session.ID) events.UploadMetadata {
 
 // ReserveUploadPart reserves an upload part.
 func (h *Handler) ReserveUploadPart(ctx context.Context, upload events.StreamUpload, partNumber int64) error {
-	file, partPath, err := h.openReservationPart(upload, partNumber)
-	if err != nil {
-		return trace.ConvertSystemError(err)
-	}
-
-	// Create a buffer with the max size that a part file can have.
-	buf := make([]byte, minUploadBytes+events.MaxProtoMessageSizeBytes)
-
-	_, err = file.Write(buf)
-	if err = trace.NewAggregate(err, file.Close()); err != nil {
-		if rmErr := os.Remove(partPath); rmErr != nil {
-			h.logger.WarnContext(ctx, "Failed to remove part file.", "file", partPath, "error", rmErr)
-		}
-
-		return trace.ConvertSystemError(err)
+	reservationPath := h.reservationPath(upload, partNumber)
+	if err := h.fileRecorder.ReservePart(ctx, reservationPath, reservationSize); err != nil {
+		return trace.Wrap(err)
 	}
 
 	return nil
-}
-
-// openReservationPart opens a reservation upload part file.
-func (h *Handler) openReservationPart(upload events.StreamUpload, partNumber int64) (*os.File, string, error) {
-	partPath := h.reservationPath(upload, partNumber)
-	file, err := GetOpenFileFunc()(partPath, os.O_RDWR|os.O_CREATE, 0o600)
-	if err != nil {
-		return nil, partPath, trace.ConvertSystemError(err)
-	}
-
-	return file, partPath, nil
 }
 
 func (h *Handler) uploadsPath() string {

--- a/lib/events/filesessions/filestream_test.go
+++ b/lib/events/filesessions/filestream_test.go
@@ -38,6 +38,7 @@ func TestReserveUploadPart(t *testing.T) {
 
 	handler, err := NewHandler(Config{
 		Directory: dir,
+		OpenFile:  os.OpenFile,
 	})
 	require.NoError(t, err)
 
@@ -60,6 +61,7 @@ func TestUploadPart(t *testing.T) {
 
 	handler, err := NewHandler(Config{
 		Directory: dir,
+		OpenFile:  os.OpenFile,
 	})
 	require.NoError(t, err)
 
@@ -138,6 +140,7 @@ func TestCompleteUpload(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			handler, err := NewHandler(Config{
 				Directory: t.TempDir(),
+				OpenFile:  os.OpenFile,
 			})
 			require.NoError(t, err)
 

--- a/lib/events/filesessions/fileuploader.go
+++ b/lib/events/filesessions/fileuploader.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"iter"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -41,6 +42,8 @@ type Config struct {
 	Directory string
 	// OnBeforeComplete can be used to inject failures during tests
 	OnBeforeComplete func(ctx context.Context, upload events.StreamUpload) error
+	// OpenFile is used by session recording to open OS files
+	OpenFile utils.OpenFileWithFlagsFunc
 }
 
 // nopBeforeComplete does nothing
@@ -59,7 +62,17 @@ func (s *Config) CheckAndSetDefaults() error {
 	if s.OnBeforeComplete == nil {
 		s.OnBeforeComplete = nopBeforeComplete
 	}
+	if s.OpenFile == nil {
+		s.OpenFile = os.OpenFile
+	}
 	return nil
+}
+
+// sessionFileRecorder captures file operations performed as part of saving session recordings as files.
+type sessionFileRecorder interface {
+	ReservePart(ctx context.Context, name string, size int64) error
+	WritePart(ctx context.Context, name string, data io.Reader) error
+	CombineParts(ctx context.Context, dst io.Writer, parts iter.Seq[string]) error
 }
 
 // NewHandler returns new file sessions handler
@@ -72,9 +85,11 @@ func NewHandler(cfg Config) (*Handler, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	logger := slog.With(teleport.ComponentKey, teleport.SchemeFile)
 	h := &Handler{
-		logger: slog.With(teleport.ComponentKey, teleport.SchemeFile),
-		Config: cfg,
+		logger:       logger,
+		Config:       cfg,
+		fileRecorder: NewPlainFileRecorder(logger, cfg.OpenFile),
 	}
 	return h, nil
 }
@@ -86,6 +101,8 @@ type Handler struct {
 	Config
 	// logger emits logs messages
 	logger *slog.Logger
+	// fileRecorder is the interface for "low-level" file operations
+	fileRecorder sessionFileRecorder
 }
 
 // Closer releases connection and resources associated with log if any

--- a/lib/events/filesessions/fileuploader_test.go
+++ b/lib/events/filesessions/fileuploader_test.go
@@ -43,6 +43,7 @@ func TestStreams(t *testing.T) {
 
 	handler, err := NewHandler(Config{
 		Directory: dir,
+		OpenFile:  os.OpenFile,
 	})
 	require.NoError(t, err)
 	defer handler.Close()
@@ -54,6 +55,7 @@ func TestStreams(t *testing.T) {
 		var completeCount atomic.Uint64
 		handler, err := NewHandler(Config{
 			Directory: dir,
+			OpenFile:  os.OpenFile,
 			OnBeforeComplete: func(ctx context.Context, upload events.StreamUpload) error {
 				if completeCount.Add(1) <= 1 {
 					return trace.ConnectionProblem(nil, "simulate failure %v", completeCount.Load())

--- a/lib/events/stream.go
+++ b/lib/events/stream.go
@@ -90,6 +90,8 @@ type ProtoStreamerConfig struct {
 	// sending on this channel just forces a single flush for whichever upload happens
 	// to receive the signal first, so this may not be suitable for concurrent tests.
 	ForceFlush chan struct{}
+	// RetryConfig defines how to retry on a failed upload
+	RetryConfig *retryutils.LinearConfig
 }
 
 // CheckAndSetDefaults checks and sets streamer defaults
@@ -139,6 +141,7 @@ func (s *ProtoStreamer) CreateAuditStreamForUpload(ctx context.Context, sid sess
 		MinUploadBytes:    s.cfg.MinUploadBytes,
 		ConcurrentUploads: s.cfg.ConcurrentUploads,
 		ForceFlush:        s.cfg.ForceFlush,
+		RetryConfig:       s.cfg.RetryConfig,
 	})
 }
 
@@ -167,6 +170,7 @@ func (s *ProtoStreamer) ResumeAuditStream(ctx context.Context, sid session.ID, u
 		Uploader:       s.cfg.Uploader,
 		MinUploadBytes: s.cfg.MinUploadBytes,
 		CompletedParts: parts,
+		RetryConfig:    s.cfg.RetryConfig,
 	})
 }
 
@@ -197,6 +201,8 @@ type ProtoStreamConfig struct {
 	Clock clockwork.Clock
 	// ConcurrentUploads sets concurrent uploads per stream
 	ConcurrentUploads int
+	// RetryConfig defines how to retry on a failed upload
+	RetryConfig *retryutils.LinearConfig
 }
 
 // CheckAndSetDefaults checks and sets default values
@@ -224,6 +230,12 @@ func (cfg *ProtoStreamConfig) CheckAndSetDefaults() error {
 	}
 	if cfg.Clock == nil {
 		cfg.Clock = clockwork.NewRealClock()
+	}
+	if cfg.RetryConfig == nil {
+		cfg.RetryConfig = &retryutils.LinearConfig{
+			Step: NetworkRetryDuration,
+			Max:  NetworkBackoffDuration,
+		}
 	}
 	return nil
 }
@@ -284,6 +296,7 @@ func NewProtoStream(cfg ProtoStreamConfig) (*ProtoStream, error) {
 		completedUploadsC: make(chan *activeUpload, cfg.ConcurrentUploads),
 		semUploads:        make(chan struct{}, cfg.ConcurrentUploads),
 		lastPartNumber:    0,
+		retryConfig:       *cfg.RetryConfig,
 	}
 	if len(cfg.CompletedParts) > 0 {
 		// skip 2 extra parts as a protection from accidental overwrites.
@@ -489,6 +502,8 @@ type sliceWriter struct {
 	// emptyHeader is used to write empty header
 	// to preserve some bytes
 	emptyHeader [ProtoStreamV1PartHeaderSize]byte
+	// retryConfig  defines how to retry on a failed upload
+	retryConfig retryutils.LinearConfig
 }
 
 func (w *sliceWriter) updateCompletedParts(part StreamPart, lastEventIndex int64) {
@@ -776,10 +791,7 @@ func (w *sliceWriter) startUpload(partNumber int64, slice *slice) (*activeUpload
 			// retry is created on the first upload error
 			if retry == nil {
 				var rerr error
-				retry, rerr = retryutils.NewLinear(retryutils.LinearConfig{
-					Step: NetworkRetryDuration,
-					Max:  NetworkBackoffDuration,
-				})
+				retry, rerr = retryutils.NewLinear(w.retryConfig)
 				if rerr != nil {
 					activeUpload.setError(rerr)
 					return

--- a/lib/events/test/streamsuite.go
+++ b/lib/events/test/streamsuite.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/fixtures"
@@ -205,6 +206,10 @@ func StreamWithParameters(t *testing.T, handler events.MultipartHandler, params 
 		MinUploadBytes:    params.MinUploadBytes,
 		ConcurrentUploads: params.ConcurrentUploads,
 		ForceFlush:        forceFlush,
+		RetryConfig: &retryutils.LinearConfig{
+			Step: time.Millisecond * 10,
+			Max:  time.Millisecond * 500,
+		},
 	})
 	require.NoError(t, err)
 
@@ -275,6 +280,10 @@ func StreamResumeWithParameters(t *testing.T, handler events.MultipartHandler, p
 		Uploader:          handler,
 		MinUploadBytes:    params.MinUploadBytes,
 		ConcurrentUploads: params.ConcurrentUploads,
+		RetryConfig: &retryutils.LinearConfig{
+			Step: time.Millisecond * 10,
+			Max:  time.Millisecond * 500,
+		},
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
This PR prepares session recording to use different file operations based on configuration (e.g. encrypted or not). There shouldn't be any functional changes to how recordings are saved included in this PR