### PR TITLE
feat: Hardware Key Agent - Propagate contextual key info from key store to hardware key prompts

### DIFF
--- a/api/utils/keys/hardwarekey/cliprompt.go
+++ b/api/utils/keys/hardwarekey/cliprompt.go
@@ -58,7 +58,7 @@ func NewCLIPrompt(w io.Writer, r prompt.StdinReader) *cliPrompt {
 
 // AskPIN prompts the user for a PIN. If the requirement is [PINOptional],
 // the prompt will offer the default PIN as a default value.
-func (c *cliPrompt) AskPIN(ctx context.Context, requirement PINPromptRequirement) (string, error) {
+func (c *cliPrompt) AskPIN(ctx context.Context, requirement PINPromptRequirement, _ ContextualKeyInfo) (string, error) {
 	message := "Enter your YubiKey PIV PIN"
 	if requirement == PINOptional {
 		message = "Enter your YubiKey PIV PIN [blank to use default PIN]"
@@ -68,7 +68,7 @@ func (c *cliPrompt) AskPIN(ctx context.Context, requirement PINPromptRequirement
 }
 
 // Touch prompts the user to touch the hardware key.
-func (c *cliPrompt) Touch(_ context.Context) error {
+func (c *cliPrompt) Touch(_ context.Context, _ ContextualKeyInfo) error {
 	_, err := fmt.Fprintln(c.writer, "Tap your YubiKey")
 	return trace.Wrap(err)
 }
@@ -77,7 +77,7 @@ func (c *cliPrompt) Touch(_ context.Context) error {
 // If the provided PUK is the default value, it will ask for a new PUK as well.
 // If an invalid PIN or PUK is provided, the user will be re-prompted until a
 // valid value is provided.
-func (c *cliPrompt) ChangePIN(ctx context.Context) (*PINAndPUK, error) {
+func (c *cliPrompt) ChangePIN(ctx context.Context, _ ContextualKeyInfo) (*PINAndPUK, error) {
 	var pinAndPUK = &PINAndPUK{}
 	for {
 		fmt.Fprintf(c.writer, "Please set a new 6-8 character PIN.\n")
@@ -155,7 +155,7 @@ func (c *cliPrompt) ChangePIN(ctx context.Context) (*PINAndPUK, error) {
 }
 
 // ConfirmSlotOverwrite asks the user if the slot's private key and certificate can be overridden.
-func (c *cliPrompt) ConfirmSlotOverwrite(ctx context.Context, message string) (bool, error) {
+func (c *cliPrompt) ConfirmSlotOverwrite(ctx context.Context, message string, _ ContextualKeyInfo) (bool, error) {
 	confirmation, err := prompt.Confirmation(ctx, c.writer, c.reader, message)
 	return confirmation, trace.Wrap(err)
 }

--- a/api/utils/keys/hardwarekey/cliprompt_test.go
+++ b/api/utils/keys/hardwarekey/cliprompt_test.go
@@ -153,7 +153,7 @@ func TestChangePIN(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 			defer cancel()
 
-			PINAndPUK, err := prompt.ChangePIN(ctx)
+			PINAndPUK, err := prompt.ChangePIN(ctx, hardwarekey.ContextualKeyInfo{})
 			require.ErrorIs(t, err, tc.expectError)
 			require.Equal(t, tc.expectPINAndPUK, PINAndPUK)
 		})

--- a/api/utils/keys/hardwarekey/hardwarekey.go
+++ b/api/utils/keys/hardwarekey/hardwarekey.go
@@ -33,7 +33,7 @@ type Service interface {
 	NewPrivateKey(ctx context.Context, config PrivateKeyConfig) (*Signer, error)
 	// Sign performs a cryptographic signature using the specified hardware
 	// private key and provided signature parameters.
-	Sign(ctx context.Context, ref *PrivateKeyRef, rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error)
+	Sign(ctx context.Context, ref *PrivateKeyRef, keyInfo ContextualKeyInfo, rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error)
 	// TODO(Joerger): DELETE IN v19.0.0
 	// GetFullKeyRef gets the full [PrivateKeyRef] for an existing hardware private
 	// key in the given slot of the hardware key with the given serial number.
@@ -44,13 +44,16 @@ type Service interface {
 type Signer struct {
 	service Service
 	Ref     *PrivateKeyRef
+	keyInfo ContextualKeyInfo
 }
 
 // NewSigner returns a [Signer] for the given service and ref.
-func NewSigner(s Service, ref *PrivateKeyRef) *Signer {
+// keyInfo is an optional argument to supply additional contextual info.
+func NewSigner(s Service, ref *PrivateKeyRef, keyInfo ContextualKeyInfo) *Signer {
 	return &Signer{
 		service: s,
 		Ref:     ref,
+		keyInfo: keyInfo,
 	}
 }
 
@@ -61,7 +64,7 @@ func (h *Signer) Public() crypto.PublicKey {
 
 // Sign implements [crypto.Signer].
 func (h *Signer) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
-	return h.service.Sign(context.TODO(), h.Ref, rand, digest, opts)
+	return h.service.Sign(context.TODO(), h.Ref, h.keyInfo, rand, digest, opts)
 }
 
 // GetAttestation returns the hardware private key attestation details.
@@ -88,7 +91,7 @@ func (h *Signer) WarmupHardwareKey(ctx context.Context) error {
 	// We don't actually need to hash the digest, just make it match the hash size.
 	digest := make([]byte, hash.Size())
 
-	_, err := h.service.Sign(ctx, h.Ref, rand.Reader, digest, hash)
+	_, err := h.service.Sign(ctx, h.Ref, h.keyInfo, rand.Reader, digest, hash)
 	return trace.Wrap(err, "failed to perform warmup signature with hardware private key")
 }
 
@@ -98,13 +101,13 @@ func EncodeSigner(p *Signer) ([]byte, error) {
 }
 
 // DecodeSigner decodes an encoded hardware key signer for the given service.
-func DecodeSigner(encodedKey []byte, s Service) (*Signer, error) {
+func DecodeSigner(encodedKey []byte, s Service, keyInfo ContextualKeyInfo) (*Signer, error) {
 	ref, err := decodeKeyRef(encodedKey, s)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return NewSigner(s, ref), nil
+	return NewSigner(s, ref, keyInfo), nil
 }
 
 // PrivateKeyRef references a specific hardware private key.
@@ -230,4 +233,18 @@ type PrivateKeyConfig struct {
 	//   - touch & pin   -> 9d
 	//   - touch & !pin  -> 9e
 	CustomSlot PIVSlotKeyString
+	// ContextualKeyInfo contains additional info to associate with the key.
+	ContextualKeyInfo ContextualKeyInfo
+}
+
+// ContextualKeyInfo contains contextual information associated with a hardware [PrivateKey].
+// TODO(Joerger): This is not hardware key specific, so it may be better placed in a more general package
+// if it is used more broadly, though moving this to the keys package would cause an import cycle.
+type ContextualKeyInfo struct {
+	// ProxyHost is the root proxy hostname that the key is associated with.
+	ProxyHost string
+	// Username is a Teleport username that the key is associated with.
+	Username string
+	// ClusterName is a Teleport cluster name that the key is associated with.
+	ClusterName string
 }

--- a/api/utils/keys/hardwarekey/hardwarekey_test.go
+++ b/api/utils/keys/hardwarekey/hardwarekey_test.go
@@ -42,16 +42,23 @@ func TestPrivateKey_EncodeDecode(t *testing.T) {
 
 	ctx := context.Background()
 	s := hardwarekey.NewMockHardwareKeyService(nil /*prompt*/)
+
+	contextualKeyInfo := hardwarekey.ContextualKeyInfo{
+		ProxyHost:   "billy.io",
+		Username:    "Billy@billy.io",
+		ClusterName: "billy.io",
+	}
+
 	hwSigner, err := s.NewPrivateKey(ctx, hardwarekey.PrivateKeyConfig{
-		Policy: hardwarekey.PromptPolicyNone,
+		Policy:            hardwarekey.PromptPolicyNone,
+		ContextualKeyInfo: contextualKeyInfo,
 	})
 	require.NoError(t, err)
 
-	priv := hardwarekey.NewSigner(s, hwSigner.Ref)
-	encoded, err := hardwarekey.EncodeSigner(priv)
+	encoded, err := hardwarekey.EncodeSigner(hwSigner)
 	require.NoError(t, err)
 
-	decodedSigner, err := hardwarekey.DecodeSigner(encoded, s)
+	decodedSigner, err := hardwarekey.DecodeSigner(encoded, s, contextualKeyInfo)
 	require.NoError(t, err)
 	require.Equal(t, hwSigner, decodedSigner)
 }
@@ -74,7 +81,7 @@ func TestPrivateKey_DecodePartialKeyRef(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	decodedSigner, err := hardwarekey.DecodeSigner(partialKeyRefJSON, s)
+	decodedSigner, err := hardwarekey.DecodeSigner(partialKeyRefJSON, s, hardwarekey.ContextualKeyInfo{})
 	require.NoError(t, err)
 	require.Equal(t, hwSigner, decodedSigner)
 }

--- a/api/utils/keys/hardwarekey/prompt.go
+++ b/api/utils/keys/hardwarekey/prompt.go
@@ -43,17 +43,17 @@ type PromptPolicy struct {
 type Prompt interface {
 	// AskPIN prompts the user for a PIN.
 	// The requirement tells if the PIN is required or optional.
-	AskPIN(ctx context.Context, requirement PINPromptRequirement) (string, error)
+	AskPIN(ctx context.Context, requirement PINPromptRequirement, keyInfo ContextualKeyInfo) (string, error)
 	// Touch prompts the user to touch the hardware key.
-	Touch(ctx context.Context) error
+	Touch(ctx context.Context, keyInfo ContextualKeyInfo) error
 	// ChangePIN asks for a new PIN.
 	// If the PUK has a default value, it should ask for the new value for it.
 	// It is up to the implementer how the validation is handled.
 	// For example, CLI prompt can ask for a valid PIN/PUK in a loop, a GUI
 	// prompt can use the frontend validation.
-	ChangePIN(ctx context.Context) (*PINAndPUK, error)
+	ChangePIN(ctx context.Context, keyInfo ContextualKeyInfo) (*PINAndPUK, error)
 	// ConfirmSlotOverwrite asks the user if the slot's private key and certificate can be overridden.
-	ConfirmSlotOverwrite(ctx context.Context, message string) (bool, error)
+	ConfirmSlotOverwrite(ctx context.Context, message string, keyInfo ContextualKeyInfo) (bool, error)
 }
 
 // PINPromptRequirement specifies whether a PIN is required.

--- a/api/utils/keys/piv/service_unavailable.go
+++ b/api/utils/keys/piv/service_unavailable.go
@@ -41,7 +41,7 @@ func (s *unavailableYubiKeyPIVService) NewPrivateKey(_ context.Context, _ hardwa
 
 // Sign performs a cryptographic signature using the specified hardware
 // private key and provided signature parameters.
-func (s *unavailableYubiKeyPIVService) Sign(_ context.Context, _ *hardwarekey.PrivateKeyRef, _ io.Reader, _ []byte, _ crypto.SignerOpts) ([]byte, error) {
+func (s *unavailableYubiKeyPIVService) Sign(_ context.Context, _ *hardwarekey.PrivateKeyRef, _ hardwarekey.ContextualKeyInfo, _ io.Reader, _ []byte, _ crypto.SignerOpts) ([]byte, error) {
 	return nil, trace.Wrap(errPIVUnavailable)
 }
 

--- a/api/utils/keys/privatekey.go
+++ b/api/utils/keys/privatekey.go
@@ -253,6 +253,8 @@ func LoadPrivateKey(keyFile string) (*PrivateKey, error) {
 type ParsePrivateKeyOptions struct {
 	// HardwareKeyService is the hardware key service to use with parsed hardware private keys.
 	HardwareKeyService hardwarekey.Service
+	// ContextualKeyInfo is contextual information associated with the key.
+	ContextualKeyInfo hardwarekey.ContextualKeyInfo
 }
 
 // ParsePrivateKeyOpt applies configuration options.
@@ -262,6 +264,13 @@ type ParsePrivateKeyOpt func(o *ParsePrivateKeyOptions)
 func WithHardwareKeyService(hwKeyService hardwarekey.Service) ParsePrivateKeyOpt {
 	return func(o *ParsePrivateKeyOptions) {
 		o.HardwareKeyService = hwKeyService
+	}
+}
+
+// WithContextualKeyInfo adds contextual key info to the parsed private key.
+func WithContextualKeyInfo(info hardwarekey.ContextualKeyInfo) ParsePrivateKeyOpt {
+	return func(o *ParsePrivateKeyOptions) {
+		o.ContextualKeyInfo = info
 	}
 }
 
@@ -296,7 +305,7 @@ func ParsePrivateKey(keyPEM []byte, opts ...ParsePrivateKeyOpt) (*PrivateKey, er
 			hwks = piv.NewYubiKeyService(nil /*prompt*/)
 		}
 
-		hwSigner, err := hardwarekey.DecodeSigner(block.Bytes, hwks)
+		hwSigner, err := hardwarekey.DecodeSigner(block.Bytes, hwks, appliedOpts.ContextualKeyInfo)
 		if err != nil {
 			return nil, trace.Wrap(err, "failed to parse hardware key signer")
 		}

--- a/integration/proxy/teleterm_test.go
+++ b/integration/proxy/teleterm_test.go
@@ -248,7 +248,7 @@ func testGatewayCertRenewal(ctx context.Context, t *testing.T, params gatewayCer
 		// db cert has expired.
 		Clock:         fakeClock,
 		WebauthnLogin: webauthnLogin,
-		HardwareKeyPromptConstructor: func(rootClusterURI uri.ResourceURI) hardwarekey.Prompt {
+		HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
 			return nil
 		},
 	})
@@ -882,7 +882,7 @@ func testTeletermAppGatewayTargetPortValidation(t *testing.T, pack *appaccess.Pa
 		storage, err := clusters.NewStorage(clusters.Config{
 			Dir:                tc.KeysDir,
 			InsecureSkipVerify: tc.InsecureSkipVerify,
-			HardwareKeyPromptConstructor: func(rootClusterURI uri.ResourceURI) hardwarekey.Prompt {
+			HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
 				return nil
 			},
 		})

--- a/integration/proxy/teleterm_test.go
+++ b/integration/proxy/teleterm_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/utils/keys/hardwarekey"
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
 	"github.com/gravitational/teleport/integration/appaccess"
 	dbhelpers "github.com/gravitational/teleport/integration/db"
@@ -248,9 +247,6 @@ func testGatewayCertRenewal(ctx context.Context, t *testing.T, params gatewayCer
 		// db cert has expired.
 		Clock:         fakeClock,
 		WebauthnLogin: webauthnLogin,
-		HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
-			return nil
-		},
 	})
 	require.NoError(t, err)
 
@@ -882,9 +878,6 @@ func testTeletermAppGatewayTargetPortValidation(t *testing.T, pack *appaccess.Pa
 		storage, err := clusters.NewStorage(clusters.Config{
 			Dir:                tc.KeysDir,
 			InsecureSkipVerify: tc.InsecureSkipVerify,
-			HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
-				return nil
-			},
 		})
 		require.NoError(t, err)
 		daemonService, err := daemon.New(daemon.Config{

--- a/integration/teleterm_test.go
+++ b/integration/teleterm_test.go
@@ -258,7 +258,7 @@ func testAddingRootCluster(t *testing.T, pack *dbhelpers.DatabasePack, creds *he
 	storage, err := clusters.NewStorage(clusters.Config{
 		Dir:                t.TempDir(),
 		InsecureSkipVerify: true,
-		HardwareKeyPromptConstructor: func(rootClusterURI uri.ResourceURI) hardwarekey.Prompt {
+		HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
 			return nil
 		},
 	})
@@ -293,7 +293,7 @@ func testListRootClustersReturnsLoggedInUser(t *testing.T, pack *dbhelpers.Datab
 	storage, err := clusters.NewStorage(clusters.Config{
 		Dir:                tc.KeysDir,
 		InsecureSkipVerify: tc.InsecureSkipVerify,
-		HardwareKeyPromptConstructor: func(rootClusterURI uri.ResourceURI) hardwarekey.Prompt {
+		HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
 			return nil
 		},
 	})
@@ -378,7 +378,7 @@ func testGetClusterReturnsPropertiesFromAuthServer(t *testing.T, pack *dbhelpers
 	storage, err := clusters.NewStorage(clusters.Config{
 		Dir:                tc.KeysDir,
 		InsecureSkipVerify: tc.InsecureSkipVerify,
-		HardwareKeyPromptConstructor: func(rootClusterURI uri.ResourceURI) hardwarekey.Prompt {
+		HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
 			return nil
 		},
 	})
@@ -433,7 +433,7 @@ func testHeadlessWatcher(t *testing.T, pack *dbhelpers.DatabasePack, creds *help
 	storage, err := clusters.NewStorage(clusters.Config{
 		Dir:                tc.KeysDir,
 		InsecureSkipVerify: tc.InsecureSkipVerify,
-		HardwareKeyPromptConstructor: func(rootClusterURI uri.ResourceURI) hardwarekey.Prompt {
+		HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
 			return nil
 		},
 	})
@@ -504,7 +504,7 @@ func testClientCache(t *testing.T, pack *dbhelpers.DatabasePack, creds *helpers.
 		Dir:                tc.KeysDir,
 		Clock:              storageFakeClock,
 		InsecureSkipVerify: tc.InsecureSkipVerify,
-		HardwareKeyPromptConstructor: func(rootClusterURI uri.ResourceURI) hardwarekey.Prompt {
+		HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
 			return nil
 		},
 	})
@@ -766,7 +766,7 @@ func testCreateConnectMyComputerRole(t *testing.T, pack *dbhelpers.DatabasePack)
 			storage, err := clusters.NewStorage(clusters.Config{
 				Dir:                t.TempDir(),
 				InsecureSkipVerify: true,
-				HardwareKeyPromptConstructor: func(rootClusterURI uri.ResourceURI) hardwarekey.Prompt {
+				HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
 					return nil
 				},
 			})
@@ -885,7 +885,7 @@ func testCreateConnectMyComputerToken(t *testing.T, pack *dbhelpers.DatabasePack
 		InsecureSkipVerify: tc.InsecureSkipVerify,
 		Clock:              fakeClock,
 		WebauthnLogin:      webauthnLogin,
-		HardwareKeyPromptConstructor: func(rootClusterURI uri.ResourceURI) hardwarekey.Prompt {
+		HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
 			return nil
 		},
 	})
@@ -948,7 +948,7 @@ func testWaitForConnectMyComputerNodeJoin(t *testing.T, pack *dbhelpers.Database
 	storage, err := clusters.NewStorage(clusters.Config{
 		Dir:                tc.KeysDir,
 		InsecureSkipVerify: tc.InsecureSkipVerify,
-		HardwareKeyPromptConstructor: func(rootClusterURI uri.ResourceURI) hardwarekey.Prompt {
+		HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
 			return nil
 		},
 	})
@@ -1035,7 +1035,7 @@ func testDeleteConnectMyComputerNode(t *testing.T, pack *dbhelpers.DatabasePack)
 	storage, err := clusters.NewStorage(clusters.Config{
 		Dir:                tc.KeysDir,
 		InsecureSkipVerify: tc.InsecureSkipVerify,
-		HardwareKeyPromptConstructor: func(rootClusterURI uri.ResourceURI) hardwarekey.Prompt {
+		HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
 			return nil
 		},
 	})
@@ -1265,7 +1265,7 @@ func testListDatabaseUsers(t *testing.T, pack *dbhelpers.DatabasePack) {
 			storage, err := clusters.NewStorage(clusters.Config{
 				Dir:                tc.KeysDir,
 				InsecureSkipVerify: tc.InsecureSkipVerify,
-				HardwareKeyPromptConstructor: func(rootClusterURI uri.ResourceURI) hardwarekey.Prompt {
+				HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
 					return nil
 				},
 			})

--- a/integration/teleterm_test.go
+++ b/integration/teleterm_test.go
@@ -43,7 +43,6 @@ import (
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils"
-	"github.com/gravitational/teleport/api/utils/keys/hardwarekey"
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
 	dbhelpers "github.com/gravitational/teleport/integration/db"
 	"github.com/gravitational/teleport/integration/helpers"
@@ -258,9 +257,6 @@ func testAddingRootCluster(t *testing.T, pack *dbhelpers.DatabasePack, creds *he
 	storage, err := clusters.NewStorage(clusters.Config{
 		Dir:                t.TempDir(),
 		InsecureSkipVerify: true,
-		HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
-			return nil
-		},
 	})
 	require.NoError(t, err)
 
@@ -293,9 +289,6 @@ func testListRootClustersReturnsLoggedInUser(t *testing.T, pack *dbhelpers.Datab
 	storage, err := clusters.NewStorage(clusters.Config{
 		Dir:                tc.KeysDir,
 		InsecureSkipVerify: tc.InsecureSkipVerify,
-		HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
-			return nil
-		},
 	})
 	require.NoError(t, err)
 
@@ -378,9 +371,6 @@ func testGetClusterReturnsPropertiesFromAuthServer(t *testing.T, pack *dbhelpers
 	storage, err := clusters.NewStorage(clusters.Config{
 		Dir:                tc.KeysDir,
 		InsecureSkipVerify: tc.InsecureSkipVerify,
-		HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
-			return nil
-		},
 	})
 	require.NoError(t, err)
 
@@ -433,9 +423,6 @@ func testHeadlessWatcher(t *testing.T, pack *dbhelpers.DatabasePack, creds *help
 	storage, err := clusters.NewStorage(clusters.Config{
 		Dir:                tc.KeysDir,
 		InsecureSkipVerify: tc.InsecureSkipVerify,
-		HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
-			return nil
-		},
 	})
 	require.NoError(t, err)
 
@@ -504,9 +491,6 @@ func testClientCache(t *testing.T, pack *dbhelpers.DatabasePack, creds *helpers.
 		Dir:                tc.KeysDir,
 		Clock:              storageFakeClock,
 		InsecureSkipVerify: tc.InsecureSkipVerify,
-		HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
-			return nil
-		},
 	})
 	require.NoError(t, err)
 
@@ -766,9 +750,6 @@ func testCreateConnectMyComputerRole(t *testing.T, pack *dbhelpers.DatabasePack)
 			storage, err := clusters.NewStorage(clusters.Config{
 				Dir:                t.TempDir(),
 				InsecureSkipVerify: true,
-				HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
-					return nil
-				},
 			})
 			require.NoError(t, err)
 
@@ -885,9 +866,6 @@ func testCreateConnectMyComputerToken(t *testing.T, pack *dbhelpers.DatabasePack
 		InsecureSkipVerify: tc.InsecureSkipVerify,
 		Clock:              fakeClock,
 		WebauthnLogin:      webauthnLogin,
-		HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
-			return nil
-		},
 	})
 	require.NoError(t, err)
 
@@ -948,9 +926,6 @@ func testWaitForConnectMyComputerNodeJoin(t *testing.T, pack *dbhelpers.Database
 	storage, err := clusters.NewStorage(clusters.Config{
 		Dir:                tc.KeysDir,
 		InsecureSkipVerify: tc.InsecureSkipVerify,
-		HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
-			return nil
-		},
 	})
 	require.NoError(t, err)
 
@@ -1035,9 +1010,6 @@ func testDeleteConnectMyComputerNode(t *testing.T, pack *dbhelpers.DatabasePack)
 	storage, err := clusters.NewStorage(clusters.Config{
 		Dir:                tc.KeysDir,
 		InsecureSkipVerify: tc.InsecureSkipVerify,
-		HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
-			return nil
-		},
 	})
 	require.NoError(t, err)
 
@@ -1265,9 +1237,6 @@ func testListDatabaseUsers(t *testing.T, pack *dbhelpers.DatabasePack) {
 			storage, err := clusters.NewStorage(clusters.Config{
 				Dir:                tc.KeysDir,
 				InsecureSkipVerify: tc.InsecureSkipVerify,
-				HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
-					return nil
-				},
 			})
 			require.NoError(t, err)
 

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -4007,6 +4007,11 @@ func (tc *TeleportClient) GetNewLoginKeyRing(ctx context.Context) (keyRing *KeyR
 		priv, err := tc.ClientStore.NewHardwarePrivateKey(ctx, hardwarekey.PrivateKeyConfig{
 			Policy:     tc.PrivateKeyPolicy.GetPromptPolicy(),
 			CustomSlot: tc.PIVSlot,
+			ContextualKeyInfo: hardwarekey.ContextualKeyInfo{
+				ProxyHost:   tc.WebProxyHost(),
+				Username:    tc.Username,
+				ClusterName: tc.SiteName,
+			},
 		})
 		if err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/api/utils/keys/hardwarekey"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/cryptosuites"
@@ -88,6 +89,14 @@ func (idx KeyRingIndex) LogValue() slog.Value {
 		slog.String("cluster", idx.ClusterName),
 		slog.String("username", idx.Username),
 	)
+}
+
+func (idx KeyRingIndex) contextualKeyInfo() hardwarekey.ContextualKeyInfo {
+	return hardwarekey.ContextualKeyInfo{
+		ProxyHost:   idx.ProxyHost,
+		Username:    idx.Username,
+		ClusterName: idx.ClusterName,
+	}
 }
 
 // TLSCredential holds a signed TLS certificate and matching private key.

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -540,7 +540,7 @@ func (fs *FSKeyStore) GetKeyRing(idx KeyRingIndex, hwks hardwarekey.Service, opt
 		return nil, trace.Wrap(err, "no session keys for %+v", idx)
 	}
 
-	tlsCred, err := readTLSCredential(fs.userTLSKeyPath(idx), fs.tlsCertPath(idx), keys.WithHardwareKeyService(hwks))
+	tlsCred, err := readTLSCredential(fs.userTLSKeyPath(idx), fs.tlsCertPath(idx), keys.WithHardwareKeyService(hwks), keys.WithContextualKeyInfo(idx.contextualKeyInfo()))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			if _, statErr := os.Stat(fs.tlsCertPathLegacy(idx)); statErr == nil {
@@ -551,7 +551,7 @@ func (fs *FSKeyStore) GetKeyRing(idx KeyRingIndex, hwks hardwarekey.Service, opt
 		return nil, trace.Wrap(err)
 	}
 
-	sshPriv, err := keys.LoadKeyPair(fs.userSSHKeyPath(idx), fs.publicKeyPath(idx), keys.WithHardwareKeyService(hwks))
+	sshPriv, err := keys.LoadKeyPair(fs.userSSHKeyPath(idx), fs.publicKeyPath(idx), keys.WithHardwareKeyService(hwks), keys.WithContextualKeyInfo(idx.contextualKeyInfo()))
 	if err != nil {
 		return nil, trace.ConvertSystemError(err)
 	}
@@ -574,7 +574,7 @@ func (fs *FSKeyStore) GetKeyRing(idx KeyRingIndex, hwks hardwarekey.Service, opt
 }
 
 func (fs *FSKeyStore) updateKeyRingWithCerts(o CertOption, hwks hardwarekey.Service, keyRing *KeyRing) error {
-	return o.updateKeyRing(fs.KeyDir, keyRing.KeyRingIndex, keyRing, keys.WithHardwareKeyService(hwks))
+	return o.updateKeyRing(fs.KeyDir, keyRing.KeyRingIndex, keyRing, keys.WithHardwareKeyService(hwks), keys.WithContextualKeyInfo(keyRing.contextualKeyInfo()))
 }
 
 // GetSSHCertificates gets all certificates signed for the given user and proxy.

--- a/lib/teleterm/clusters/config.go
+++ b/lib/teleterm/clusters/config.go
@@ -46,17 +46,13 @@ type Config struct {
 	AddKeysToAgent string
 	// CustomHardwareKeyPrompt is a custom hardware key prompt to use when asking
 	// for a hardware key PIN, touch, etc.
-	HardwareKeyPromptConstructor func() hardwarekey.Prompt
+	CustomHardwareKeyPrompt hardwarekey.Prompt
 }
 
 // CheckAndSetDefaults checks the configuration for its validity and sets default values if needed
 func (c *Config) CheckAndSetDefaults() error {
 	if c.Dir == "" {
 		return trace.BadParameter("missing working directory")
-	}
-
-	if c.HardwareKeyPromptConstructor == nil {
-		return trace.BadParameter("missing hardware key prompt constructor")
 	}
 
 	if c.Clock == nil {

--- a/lib/teleterm/clusters/config.go
+++ b/lib/teleterm/clusters/config.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/utils/keys/hardwarekey"
 	"github.com/gravitational/teleport/lib/client"
-	"github.com/gravitational/teleport/lib/teleterm/api/uri"
 )
 
 // Config is the cluster service config
@@ -47,7 +46,7 @@ type Config struct {
 	AddKeysToAgent string
 	// CustomHardwareKeyPrompt is a custom hardware key prompt to use when asking
 	// for a hardware key PIN, touch, etc.
-	HardwareKeyPromptConstructor func(rootClusterURI uri.ResourceURI) hardwarekey.Prompt
+	HardwareKeyPromptConstructor func() hardwarekey.Prompt
 }
 
 // CheckAndSetDefaults checks the configuration for its validity and sets default values if needed

--- a/lib/teleterm/clusters/storage.go
+++ b/lib/teleterm/clusters/storage.go
@@ -286,11 +286,7 @@ func (s *Storage) makeDefaultClientConfig(rootClusterURI uri.ResourceURI) *clien
 	cfg.InsecureSkipVerify = s.InsecureSkipVerify
 	cfg.AddKeysToAgent = s.AddKeysToAgent
 	cfg.WebauthnLogin = s.WebauthnLogin
-	// TODO(Joerger): Remove the rootClusterURI dependency from the teleterm prompt so that
-	// the storage service can share a single hardware key service+prompt. This allows the
-	// process to properly share PIV connections, prevents duplicate prompts, and enables
-	// PIN caching across clusters (if both clusters allow PIN caching).
-	cfg.CustomHardwareKeyPrompt = s.HardwareKeyPromptConstructor(rootClusterURI)
+	cfg.CustomHardwareKeyPrompt = s.HardwareKeyPromptConstructor()
 	cfg.DTAuthnRunCeremony = dtauthn.NewCeremony().Run
 	cfg.DTAutoEnroll = dtenroll.AutoEnroll
 	return cfg

--- a/lib/teleterm/clusters/storage.go
+++ b/lib/teleterm/clusters/storage.go
@@ -286,7 +286,7 @@ func (s *Storage) makeDefaultClientConfig(rootClusterURI uri.ResourceURI) *clien
 	cfg.InsecureSkipVerify = s.InsecureSkipVerify
 	cfg.AddKeysToAgent = s.AddKeysToAgent
 	cfg.WebauthnLogin = s.WebauthnLogin
-	cfg.CustomHardwareKeyPrompt = s.HardwareKeyPromptConstructor()
+	cfg.CustomHardwareKeyPrompt = s.CustomHardwareKeyPrompt
 	cfg.DTAuthnRunCeremony = dtauthn.NewCeremony().Run
 	cfg.DTAutoEnroll = dtenroll.AutoEnroll
 	return cfg

--- a/lib/teleterm/daemon/daemon_test.go
+++ b/lib/teleterm/daemon/daemon_test.go
@@ -348,7 +348,7 @@ func TestUpdateTshdEventsServerAddress(t *testing.T) {
 	storage, err := clusters.NewStorage(clusters.Config{
 		Dir:                homeDir,
 		InsecureSkipVerify: true,
-		HardwareKeyPromptConstructor: func(rootClusterURI uri.ResourceURI) hardwarekey.Prompt {
+		HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
 			return nil
 		},
 	})
@@ -385,7 +385,7 @@ func TestUpdateTshdEventsServerAddress_CredsErr(t *testing.T) {
 	storage, err := clusters.NewStorage(clusters.Config{
 		Dir:                homeDir,
 		InsecureSkipVerify: true,
-		HardwareKeyPromptConstructor: func(rootClusterURI uri.ResourceURI) hardwarekey.Prompt {
+		HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
 			return nil
 		},
 	})
@@ -489,7 +489,7 @@ func TestRetryWithRelogin(t *testing.T) {
 			storage, err := clusters.NewStorage(clusters.Config{
 				Dir:                t.TempDir(),
 				InsecureSkipVerify: true,
-				HardwareKeyPromptConstructor: func(rootClusterURI uri.ResourceURI) hardwarekey.Prompt {
+				HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
 					return nil
 				},
 			})
@@ -545,7 +545,7 @@ func TestConcurrentHeadlessAuthPrompts(t *testing.T) {
 	storage, err := clusters.NewStorage(clusters.Config{
 		Dir:                t.TempDir(),
 		InsecureSkipVerify: true,
-		HardwareKeyPromptConstructor: func(rootClusterURI uri.ResourceURI) hardwarekey.Prompt {
+		HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
 			return nil
 		},
 	})

--- a/lib/teleterm/daemon/daemon_test.go
+++ b/lib/teleterm/daemon/daemon_test.go
@@ -40,7 +40,6 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/utils/keys/hardwarekey"
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/client/clientcache"
@@ -348,9 +347,6 @@ func TestUpdateTshdEventsServerAddress(t *testing.T) {
 	storage, err := clusters.NewStorage(clusters.Config{
 		Dir:                homeDir,
 		InsecureSkipVerify: true,
-		HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
-			return nil
-		},
 	})
 	require.NoError(t, err)
 
@@ -385,9 +381,6 @@ func TestUpdateTshdEventsServerAddress_CredsErr(t *testing.T) {
 	storage, err := clusters.NewStorage(clusters.Config{
 		Dir:                homeDir,
 		InsecureSkipVerify: true,
-		HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
-			return nil
-		},
 	})
 	require.NoError(t, err)
 
@@ -489,9 +482,6 @@ func TestRetryWithRelogin(t *testing.T) {
 			storage, err := clusters.NewStorage(clusters.Config{
 				Dir:                t.TempDir(),
 				InsecureSkipVerify: true,
-				HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
-					return nil
-				},
 			})
 			require.NoError(t, err)
 
@@ -545,9 +535,6 @@ func TestConcurrentHeadlessAuthPrompts(t *testing.T) {
 	storage, err := clusters.NewStorage(clusters.Config{
 		Dir:                t.TempDir(),
 		InsecureSkipVerify: true,
-		HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
-			return nil
-		},
 	})
 	require.NoError(t, err)
 

--- a/lib/teleterm/teleterm.go
+++ b/lib/teleterm/teleterm.go
@@ -33,7 +33,6 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/gravitational/teleport/api/utils/keys/hardwarekey"
-	"github.com/gravitational/teleport/lib/teleterm/api/uri"
 	"github.com/gravitational/teleport/lib/teleterm/apiserver"
 	"github.com/gravitational/teleport/lib/teleterm/clusteridcache"
 	"github.com/gravitational/teleport/lib/teleterm/clusters"
@@ -42,7 +41,8 @@ import (
 
 // Serve starts daemon service
 func Serve(ctx context.Context, cfg Config) error {
-	var hardwareKeyPromptConstructor func(clusterURI uri.ResourceURI) hardwarekey.Prompt
+	var hardwareKeyPromptConstructor func() hardwarekey.Prompt
+
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
@@ -59,8 +59,8 @@ func Serve(ctx context.Context, cfg Config) error {
 		Clock:              clock,
 		InsecureSkipVerify: cfg.InsecureSkipVerify,
 		AddKeysToAgent:     cfg.AddKeysToAgent,
-		HardwareKeyPromptConstructor: func(rootClusterURI uri.ResourceURI) hardwarekey.Prompt {
-			return hardwareKeyPromptConstructor(rootClusterURI)
+		HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
+			return hardwareKeyPromptConstructor()
 		},
 	})
 	if err != nil {
@@ -83,7 +83,8 @@ func Serve(ctx context.Context, cfg Config) error {
 
 	// TODO(gzdunek): Move tshdEventsClient out of daemonService so that we can
 	// construct the prompt before creating Storage.
-	hardwareKeyPromptConstructor = daemonService.NewHardwareKeyPromptConstructor
+	hardwareKeyPromptConstructor = daemonService.NewHardwareKeyPrompt
+
 	apiServer, err := apiserver.New(apiserver.Config{
 		HostAddr:           cfg.Addr,
 		InsecureSkipVerify: cfg.InsecureSkipVerify,

--- a/lib/teleterm/teleterm.go
+++ b/lib/teleterm/teleterm.go
@@ -32,7 +32,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	"github.com/gravitational/teleport/api/utils/keys/hardwarekey"
 	"github.com/gravitational/teleport/lib/teleterm/apiserver"
 	"github.com/gravitational/teleport/lib/teleterm/clusteridcache"
 	"github.com/gravitational/teleport/lib/teleterm/clusters"
@@ -41,8 +40,6 @@ import (
 
 // Serve starts daemon service
 func Serve(ctx context.Context, cfg Config) error {
-	var hardwareKeyPromptConstructor func() hardwarekey.Prompt
-
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
@@ -59,9 +56,6 @@ func Serve(ctx context.Context, cfg Config) error {
 		Clock:              clock,
 		InsecureSkipVerify: cfg.InsecureSkipVerify,
 		AddKeysToAgent:     cfg.AddKeysToAgent,
-		HardwareKeyPromptConstructor: func() hardwarekey.Prompt {
-			return hardwareKeyPromptConstructor()
-		},
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -83,7 +77,7 @@ func Serve(ctx context.Context, cfg Config) error {
 
 	// TODO(gzdunek): Move tshdEventsClient out of daemonService so that we can
 	// construct the prompt before creating Storage.
-	hardwareKeyPromptConstructor = daemonService.NewHardwareKeyPrompt
+	storage.CustomHardwareKeyPrompt = daemonService.NewHardwareKeyPrompt()
 
 	apiServer, err := apiserver.New(apiserver.Config{
 		HostAddr:           cfg.Addr,


### PR DESCRIPTION
Part of [RFD 199](https://github.com/gravitational/teleport/pull/52495)

Add `ContextualKeyInfo` from the client store in order to reliably provide contextual key info (e.g. proxy, username, cluster) to hardware key prompts.

This also removes the `rootClusterURI` dependency from `tshd`'s hardware key prompt so that a single hardware key service can be shared by a cross-cluster `tshd` instance, which will be necessary for hardware key PIN caching.

Depends on https://github.com/gravitational/teleport/pull/53563