### PR TITLE
Enable 128-bit SIMD operations for WASM build

### DIFF
--- a/web/packages/shared/package.json
+++ b/web/packages/shared/package.json
@@ -10,7 +10,7 @@
     "directory": "packages/shared"
   },
   "scripts": {
-    "build-wasm": "node ../../scripts/clean-up-ironrdp-artifacts.mjs && RUST_MIN_STACK=16777216 wasm-pack build ./libs/ironrdp --target web"
+    "build-wasm": "node ../../scripts/clean-up-ironrdp-artifacts.mjs && RUST_MIN_STACK=16777216 RUSTFLAGS=-Ctarget-feature=+simd128 wasm-pack build ./libs/ironrdp --target web"
   },
   "dependencies": {
     "@gravitational/design": "workspace:*",


### PR DESCRIPTION
Supported in Chrome as of v91 in May 2021.

Verified the presence of SIMD instructions with:

```
$ wasm-tools print ./webassets/teleport/app/ironrdp_bg.wasm | grep v128
```