### PR TITLE
[v16] [17.4.1] bump cloud docs

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -17,7 +17,7 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "17.2.7",
+      "version": "17.3.3",
       "major_version": "17",
       "sla": {
         "monthly_percentage": "99.9%",

--- a/docs/config.json
+++ b/docs/config.json
@@ -17,7 +17,7 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "17.2.3",
+      "version": "17.2.7",
       "major_version": "17",
       "sla": {
         "monthly_percentage": "99.9%",

--- a/docs/config.json
+++ b/docs/config.json
@@ -17,7 +17,7 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "17.3.3",
+      "version": "17.4.1",
       "major_version": "17",
       "sla": {
         "monthly_percentage": "99.9%",


### PR DESCRIPTION
v16 branch missed couple of cloud version upgrades due to failing cherry-picks. This manually cherry-picks following:
- https://github.com/gravitational/teleport/pull/52507
- https://github.com/gravitational/teleport/pull/53022
- https://github.com/gravitational/teleport/pull/53686