### PR TITLE
[v16] Optimize desktop backend reads

### DIFF
--- a/lib/services/local/desktops.go
+++ b/lib/services/local/desktops.go
@@ -38,8 +38,64 @@ func NewWindowsDesktopService(backend backend.Backend) *WindowsDesktopService {
 	return &WindowsDesktopService{Backend: backend}
 }
 
-// GetWindowsDesktops returns all Windows desktops matching filter.
+func (s *WindowsDesktopService) getWindowsDesktop(ctx context.Context, name, hostID string) (types.WindowsDesktop, error) {
+	key := backend.NewKey(windowsDesktopsPrefix, hostID, name)
+	item, err := s.Get(ctx, key)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	desktop, err := s.itemToWindowsDesktop(item)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return desktop, nil
+}
+
+func (*WindowsDesktopService) itemToWindowsDesktop(item *backend.Item) (types.WindowsDesktop, error) {
+	desktop, err := services.UnmarshalWindowsDesktop(
+		item.Value,
+		services.WithExpires(item.Expires),
+		services.WithRevision(item.Revision),
+	)
+	return desktop, trace.Wrap(err)
+}
+
+func (s *WindowsDesktopService) getWindowsDesktopsForHostID(ctx context.Context, hostID string) ([]types.WindowsDesktop, error) {
+	startKey := backend.ExactKey(windowsDesktopsPrefix, hostID)
+	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var desktops []types.WindowsDesktop
+	for _, item := range result.Items {
+		desktop, err := s.itemToWindowsDesktop(&item)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		desktops = append(desktops, desktop)
+	}
+
+	return desktops, nil
+}
+
+// GetWindowsDesktops returns all Windows desktops matching the specified filter.
+// Most callers should prefer ListWindowsDesktops instead, as it supports pagination.
 func (s *WindowsDesktopService) GetWindowsDesktops(ctx context.Context, filter types.WindowsDesktopFilter) ([]types.WindowsDesktop, error) {
+	// TODO(zmb3,espadolini): implement this via ListWindowsDesktops
+
+	// do a point-read instead of a range-read if a filter is provided
+	if filter.HostID != "" && filter.Name != "" {
+		desktop, err := s.getWindowsDesktop(ctx, filter.Name, filter.HostID)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return []types.WindowsDesktop{desktop}, nil
+	}
+	if filter.HostID != "" {
+		return s.getWindowsDesktopsForHostID(ctx, filter.HostID)
+	}
+
 	startKey := backend.ExactKey(windowsDesktopsPrefix)
 	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
@@ -48,8 +104,7 @@ func (s *WindowsDesktopService) GetWindowsDesktops(ctx context.Context, filter t
 
 	var desktops []types.WindowsDesktop
 	for _, item := range result.Items {
-		desktop, err := services.UnmarshalWindowsDesktop(item.Value,
-			services.WithExpires(item.Expires), services.WithRevision(item.Revision))
+		desktop, err := s.itemToWindowsDesktop(&item)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -57,10 +112,6 @@ func (s *WindowsDesktopService) GetWindowsDesktops(ctx context.Context, filter t
 			continue
 		}
 		desktops = append(desktops, desktop)
-	}
-	// If both HostID and Name are set in the filter only one desktop should be expected
-	if filter.HostID != "" && filter.Name != "" && len(desktops) == 0 {
-		return nil, trace.NotFound("windows desktop \"%s/%s\" doesn't exist", filter.HostID, filter.Name)
 	}
 
 	return desktops, nil
@@ -176,20 +227,37 @@ func (s *WindowsDesktopService) ListWindowsDesktops(ctx context.Context, req typ
 		return nil, trace.BadParameter("nonpositive parameter limit")
 	}
 
-	rangeStart := backend.NewKey(windowsDesktopsPrefix, req.StartKey)
-	rangeEnd := backend.RangeEnd(backend.ExactKey(windowsDesktopsPrefix))
 	filter := services.MatchResourceFilter{
 		ResourceKind:   types.KindWindowsDesktop,
 		Labels:         req.Labels,
 		SearchKeywords: req.SearchKeywords,
 	}
-
 	if req.PredicateExpression != "" {
 		expression, err := services.NewResourceExpression(req.PredicateExpression)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		filter.PredicateExpression = expression
+	}
+
+	var rangeStart, rangeEnd backend.Key
+	switch {
+	case req.Name != "" && req.HostID != "":
+		rangeStart = backend.NewKey(windowsDesktopsPrefix, req.HostID, req.Name)
+		rangeEnd = rangeStart
+	case req.HostID != "":
+		rangeStart = backend.ExactKey(windowsDesktopsPrefix, req.HostID)
+		rangeEnd = backend.RangeEnd(rangeStart)
+	default:
+		rangeStart = backend.ExactKey(windowsDesktopsPrefix)
+		rangeEnd = backend.RangeEnd(rangeStart)
+	}
+
+	if req.StartKey != "" {
+		k := backend.NewKey(windowsDesktopsPrefix, req.StartKey)
+		if k.Compare(rangeStart) > 0 {
+			rangeStart = k
+		}
 	}
 
 	// Get most limit+1 results to determine if there will be a next key.
@@ -201,8 +269,7 @@ func (s *WindowsDesktopService) ListWindowsDesktops(ctx context.Context, req typ
 				break
 			}
 
-			desktop, err := services.UnmarshalWindowsDesktop(item.Value,
-				services.WithExpires(item.Expires), services.WithRevision(item.Revision))
+			desktop, err := s.itemToWindowsDesktop(&item)
 			if err != nil {
 				return false, trace.Wrap(err)
 			}
@@ -222,11 +289,6 @@ func (s *WindowsDesktopService) ListWindowsDesktops(ctx context.Context, req typ
 		return len(desktops) == maxLimit, nil
 	}); err != nil {
 		return nil, trace.Wrap(err)
-	}
-
-	// If both HostID and Name are set in the filter only one desktop should be expected
-	if req.HostID != "" && req.Name != "" && len(desktops) == 0 {
-		return nil, trace.NotFound("windows desktop \"%s/%s\" doesn't exist", req.HostID, req.Name)
 	}
 
 	var nextKey string
@@ -273,8 +335,11 @@ func (s *WindowsDesktopService) ListWindowsDesktopServices(ctx context.Context, 
 				break
 			}
 
-			desktop, err := services.UnmarshalWindowsDesktopService(item.Value,
-				services.WithExpires(item.Expires), services.WithRevision(item.Revision))
+			desktop, err := services.UnmarshalWindowsDesktopService(
+				item.Value,
+				services.WithExpires(item.Expires),
+				services.WithRevision(item.Revision),
+			)
 			if err != nil {
 				return false, trace.Wrap(err)
 			}

--- a/lib/services/local/desktops_test.go
+++ b/lib/services/local/desktops_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
@@ -31,6 +32,57 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
 )
+
+func TestGetWindowsDesktops(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	bk, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service := NewWindowsDesktopService(bk)
+
+	d1, err := types.NewWindowsDesktopV3("apple", nil, types.WindowsDesktopSpecV3{Addr: "_", HostID: "test-host-id-1"})
+	require.NoError(t, err)
+	require.NoError(t, service.CreateWindowsDesktop(ctx, d1))
+
+	d2, err := types.NewWindowsDesktopV3("apple", nil, types.WindowsDesktopSpecV3{Addr: "_", HostID: "test-host-id-2"})
+	require.NoError(t, err)
+	require.NoError(t, service.CreateWindowsDesktop(ctx, d2))
+
+	d3, err := types.NewWindowsDesktopV3("carrot", nil, types.WindowsDesktopSpecV3{Addr: "_", HostID: "test-host-id-2"})
+	require.NoError(t, err)
+	require.NoError(t, service.CreateWindowsDesktop(ctx, d3))
+
+	// search by name and host ID
+	result, err := service.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{Name: "apple", HostID: "test-host-id-2"})
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	require.Equal(t, d1.GetName(), result[0].GetName())
+
+	// search by host ID
+	result, err = service.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{HostID: "test-host-id-2"})
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+	require.Equal(t, d2.GetName(), result[0].GetName())
+	require.Equal(t, d3.GetName(), result[1].GetName())
+
+	// no filter
+	result, err = service.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
+	require.NoError(t, err)
+	require.Len(t, result, 3)
+
+	// non-matching filter
+	result, err = service.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{Name: "foo", HostID: "bar"})
+	require.Error(t, err)
+	require.True(t, trace.IsNotFound(err))
+	require.Empty(t, result)
+}
 
 func TestListWindowsDesktops(t *testing.T) {
 	t.Parallel()
@@ -58,11 +110,11 @@ func TestListWindowsDesktops(t *testing.T) {
 
 	// With label.
 	testLabel := map[string]string{"env": "test"}
-	d1, err := types.NewWindowsDesktopV3("apple", testLabel, types.WindowsDesktopSpecV3{Addr: "_"})
+	d1, err := types.NewWindowsDesktopV3("apple", testLabel, types.WindowsDesktopSpecV3{Addr: "_", HostID: "hostA"})
 	require.NoError(t, err)
 	require.NoError(t, service.CreateWindowsDesktop(ctx, d1))
 
-	d2, err := types.NewWindowsDesktopV3("banana", testLabel, types.WindowsDesktopSpecV3{Addr: "_"})
+	d2, err := types.NewWindowsDesktopV3("banana", testLabel, types.WindowsDesktopSpecV3{Addr: "_", HostID: "hostA"})
 	require.NoError(t, err)
 	require.NoError(t, service.CreateWindowsDesktop(ctx, d2))
 
@@ -70,6 +122,18 @@ func TestListWindowsDesktops(t *testing.T) {
 	d3, err := types.NewWindowsDesktopV3("carrot", nil, types.WindowsDesktopSpecV3{Addr: "_", HostID: "test-host-id"})
 	require.NoError(t, err)
 	require.NoError(t, service.CreateWindowsDesktop(ctx, d3))
+
+	// Test fetch by host ID
+	out, err = service.ListWindowsDesktops(ctx, types.ListWindowsDesktopsRequest{
+		Limit: 10,
+		WindowsDesktopFilter: types.WindowsDesktopFilter{
+			HostID: "test-host-id",
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, out.Desktops, 1)
+	require.Equal(t, "carrot", out.Desktops[0].GetName())
+	require.Equal(t, "test-host-id", out.Desktops[0].GetHostID())
 
 	// Test fetch all.
 	out, err = service.ListWindowsDesktops(ctx, types.ListWindowsDesktopsRequest{
@@ -111,6 +175,30 @@ func TestListWindowsDesktops(t *testing.T) {
 	require.Len(t, resp.Desktops, 1)
 	require.Equal(t, out.Desktops[2], resp.Desktops[0])
 	require.Empty(t, resp.NextKey)
+
+	// Test paginating while filtering by Host ID
+
+	resp, err = service.ListWindowsDesktops(ctx, types.ListWindowsDesktopsRequest{
+		Limit: 1,
+		WindowsDesktopFilter: types.WindowsDesktopFilter{
+			HostID: "hostA",
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Desktops, 1)
+	require.Equal(t, "apple", resp.Desktops[0].GetName())
+
+	resp, err = service.ListWindowsDesktops(ctx, types.ListWindowsDesktopsRequest{
+		Limit:    1,
+		StartKey: resp.NextKey,
+		WindowsDesktopFilter: types.WindowsDesktopFilter{
+			HostID: "hostA",
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Desktops, 1)
+	require.Equal(t, "banana", resp.Desktops[0].GetName())
+	require.Empty(t, resp.NextKey)
 }
 
 func TestListWindowsDesktops_Filters(t *testing.T) {
@@ -147,7 +235,8 @@ func TestListWindowsDesktops_Filters(t *testing.T) {
 	tests := []struct {
 		name    string
 		filter  types.ListWindowsDesktopsRequest
-		wantErr bool
+		assert  require.ErrorAssertionFunc
+		wantLen int
 	}{
 		{
 			name: "NOK non-matching host id and name",
@@ -158,12 +247,14 @@ func TestListWindowsDesktops_Filters(t *testing.T) {
 					Name:   "no-match",
 				},
 			},
-			wantErr: true,
+			assert:  require.NoError,
+			wantLen: 0,
 		},
 		{
 			name:    "NOK invalid limit",
 			filter:  types.ListWindowsDesktopsRequest{},
-			wantErr: true,
+			assert:  require.Error,
+			wantLen: 0,
 		},
 		{
 			name: "matching host id",
@@ -171,6 +262,18 @@ func TestListWindowsDesktops_Filters(t *testing.T) {
 				Limit:                5,
 				WindowsDesktopFilter: types.WindowsDesktopFilter{HostID: "test-host-id"},
 			},
+			assert:  require.NoError,
+			wantLen: 2,
+		},
+		{
+			name: "matching host id, mismatching labels",
+			filter: types.ListWindowsDesktopsRequest{
+				Limit:                5,
+				Labels:               map[string]string{"doesnot": "exist"},
+				WindowsDesktopFilter: types.WindowsDesktopFilter{HostID: "test-host-id"},
+			},
+			assert:  require.NoError,
+			wantLen: 0,
 		},
 		{
 			name: "matching name",
@@ -178,6 +281,8 @@ func TestListWindowsDesktops_Filters(t *testing.T) {
 				Limit:                5,
 				WindowsDesktopFilter: types.WindowsDesktopFilter{Name: "banana"},
 			},
+			assert:  require.NoError,
+			wantLen: 2,
 		},
 		{
 			name: "with search",
@@ -185,6 +290,8 @@ func TestListWindowsDesktops_Filters(t *testing.T) {
 				Limit:          5,
 				SearchKeywords: []string{"env", "test"},
 			},
+			assert:  require.NoError,
+			wantLen: 2,
 		},
 		{
 			name: "with labels",
@@ -192,6 +299,8 @@ func TestListWindowsDesktops_Filters(t *testing.T) {
 				Limit:  5,
 				Labels: testLabel,
 			},
+			assert:  require.NoError,
+			wantLen: 2,
 		},
 		{
 			name: "with predicate",
@@ -199,6 +308,8 @@ func TestListWindowsDesktops_Filters(t *testing.T) {
 				Limit:               5,
 				PredicateExpression: `labels.env == "test"`,
 			},
+			assert:  require.NoError,
+			wantLen: 2,
 		},
 	}
 
@@ -207,12 +318,10 @@ func TestListWindowsDesktops_Filters(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			resp, err := service.ListWindowsDesktops(ctx, tc.filter)
+			tc.assert(t, err)
 
-			if tc.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				require.Len(t, resp.Desktops, 2)
+			if resp != nil {
+				require.Len(t, resp.Desktops, tc.wantLen)
 			}
 		})
 	}


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/52070

Changelog: Reduce backend load in clusters with large numbers of Windows desktops.