### PR TITLE
[v15] docs: update storage backends to include AWS S3 for audit events

### DIFF
--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -12,9 +12,9 @@ read/write ratio, mutability, etc.).
 
 | Data type | Description | Supported storage backends |
 | - | - | - |
-| core cluster state | Cluster configuration (e.g. users, roles, auth connectors) and identity (e.g. certificate authorities, registered nodes, trusted clusters). | Local directory (SQLite), etcd, PostgreSQL, AWS DynamoDB, GCP Firestore |
-| audit events | JSON-encoded events from the audit log (e.g. user logins, RBAC changes) | Local directory, PostgreSQL, AWS DynamoDB, GCP Firestore |
-| session recordings | Raw terminal recordings of interactive user sessions | Local directory, AWS S3 (and any S3-compatible product), GCP Cloud Storage, Azure Blob Storage |
+| core cluster state | Cluster configuration (e.g. users, roles, auth connectors) and identity (e.g. certificate authorities, registered nodes, trusted clusters). | Local directory (SQLite), etcd, PostgreSQL, Amazon DynamoDB, GCP Firestore |
+| audit events | Events from the audit log (e.g. user logins, RBAC changes) | Local directory, PostgreSQL, Amazon DynamoDB, Amazon S3, GCP Firestore |
+| session recordings | Raw terminal recordings of interactive user sessions | Local directory, Amazon S3 (and any S3-compatible product), GCP Cloud Storage, Azure Blob Storage |
 | teleport instance state | ID and credentials of a non-auth teleport instance (e.g. node, proxy) | Local directory |
 
 ## Cluster state


### PR DESCRIPTION
backport #53718 to branch/v15