### PR TITLE
Restrict agent updates on Cloud to Mon-Thu

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1367,6 +1367,7 @@ func (a *Server) syncUpgradeWindowStartHour(ctx context.Context) error {
 	agentWindow, _ := cmc.GetAgentUpgradeWindow()
 
 	agentWindow.UTCStartHour = uint32(startHour)
+	agentWindow.Weekdays = []string{"Mon", "Tue", "Wed", "Thu"}
 
 	cmc.SetAgentUpgradeWindow(agentWindow)
 

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -1856,6 +1856,7 @@ func TestSyncUpgradeWindowStartHour(t *testing.T) {
 	require.True(t, ok)
 
 	require.Equal(t, uint32(0), agentWindow.UTCStartHour)
+	require.Equal(t, []string{"Mon", "Tue", "Wed", "Thu"}, agentWindow.Weekdays)
 
 	// change the served hour
 	mu.Lock()


### PR DESCRIPTION
This PR restricts the days when agents are automatically updated for Cloud Tenants to Monday-Thursday. Currently, agent updates may happen on any day, and the days are not configurable.

For Managed Updates v2, users are only be able to select Monday-Thursday on Cloud without the UnlimitedManagedUpdates entitlement. For consistency, we are going to enforce Monday-Thursday for both v1 and v2 APIs. Currently, is possible for Managed Updates v2 to bypass this restriction by not creating `autoupdate_config`, which will use the all-days setting in CMC (the v1 default).

Cloud users will only be able to configure the days by creating `autoupdate_config` while they have the UnlimitedManagedUpdates entitlement.

---

changelog: Restrict agent update days to Mon-Thu on Cloud

---

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/11856