### PR TITLE
Pyroscope flush on shutdown

### DIFF
--- a/lib/service/pyroscope.go
+++ b/lib/service/pyroscope.go
@@ -132,7 +132,8 @@ func (process *TeleportProcess) initPyroscope(address string) {
 		logger.ErrorContext(process.ExitContext(), "error starting pyroscope profiler", "address", address, "error", err)
 	} else {
 		process.OnExit("pyroscope.profiler", func(payload any) {
-			profiler.Flush(payload == nil)
+			// Observed rare and inconsistent panics, short term solution is to not wait for flush
+			profiler.Flush(false)
 			_ = profiler.Stop()
 		})
 	}


### PR DESCRIPTION
Observed an inconsistent and rare panic during shutdown.  This may lead to dropped profiles but is generally more safe.

```
panic: sync: WaitGroup is reused before previous Wait has returned
```