### PR TITLE
Migrate lib/player tests to testing/synctest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -915,7 +915,7 @@ test-go-prepare: ensure-webassets bpf-bytecode $(TEST_LOG_DIR) ensure-gotestsum 
 test-go-unit: FLAGS ?= -race -shuffle on
 test-go-unit: SUBJECT ?= $(shell go list ./... | grep -vE 'teleport/(e2e|integration|tool/tsh|integrations/operator|integrations/access|integrations/lib)')
 test-go-unit:
-	$(CGOFLAG) go test -cover -json -tags "$(PAM_TAG) $(FIPS_TAG) $(BPF_TAG) $(LIBFIDO2_TEST_TAG) $(TOUCHID_TAG) $(PIV_TEST_TAG) $(VNETDAEMON_TAG)" $(PACKAGES) $(SUBJECT) $(FLAGS) $(ADDFLAGS) \
+	$(CGOFLAG) GOEXPERIMENT=synctest go test -cover -json -tags "enablesynctest $(PAM_TAG) $(FIPS_TAG) $(BPF_TAG) $(LIBFIDO2_TEST_TAG) $(TOUCHID_TAG) $(PIV_TEST_TAG) $(VNETDAEMON_TAG)" $(PACKAGES) $(SUBJECT) $(FLAGS) $(ADDFLAGS) \
 		| tee $(TEST_LOG_DIR)/unit.json \
 		| gotestsum --raw-command -- cat
 

--- a/lib/player/player_experimental_test.go
+++ b/lib/player/player_experimental_test.go
@@ -1,0 +1,108 @@
+//go:build go1.24 && enablesynctest
+
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package player_test
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/gravitational/teleport/lib/player"
+	"github.com/stretchr/testify/require"
+)
+
+/*
+This file uses the experimental testing/synctest package introduced with Go 1.24:
+
+    https://go.dev/blog/synctest
+
+When editing this file, you should set GOEXPERIMENT=synctest for your editor/LSP
+to ensure that the language server doesn't fail to recognize the package.
+
+This file is also protected by a build tag to ensure that `go test` doesn't fail
+for users who haven't set the environment variable.
+*/
+
+// TestInterruptsDelay tests that the player responds to playback
+// controls even when it is waiting to emit an event.
+func TestInterruptsDelay(t *testing.T) {
+	synctest.Run(func() {
+		p, err := player.New(&player.Config{
+			SessionID: "test-session",
+			Streamer:  &simpleStreamer{count: 3, delay: 5000},
+		})
+		require.NoError(t, err)
+
+		synctest.Wait()
+
+		require.NoError(t, p.Play())
+		t.Cleanup(func() { p.Close() })
+
+		synctest.Wait() // player is now waiting to emit event 0
+
+		// emulate the user seeking forward while the player is waiting..
+		start := time.Now()
+		p.SetPos(10_001 * time.Millisecond)
+
+		// expect event 0 and event 1 to be emitted right away
+		evt0 := <-p.C()
+		evt1 := <-p.C()
+		require.Equal(t, int64(0), evt0.GetIndex())
+		require.Equal(t, int64(1), evt1.GetIndex())
+
+		// Time will advance automatically in the synctest bubble.
+		// This assertion checks that the player was unblocked by
+		// the SetPos call and not because enough time elapsed.
+		require.Zero(t, time.Since(start))
+
+		<-p.C()
+
+		// the user seeked to 10.001 seconds, it should take 4.999
+		// seconds to get the third event that arrives at second 15.
+		require.Equal(t, time.Since(start), 4999*time.Millisecond)
+	})
+}
+
+func TestSeekForward(t *testing.T) {
+	synctest.Run(func() {
+		p, err := player.New(&player.Config{
+			SessionID: "test-session",
+			Streamer:  &simpleStreamer{count: 1, delay: 6000},
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { p.Close() })
+		require.NoError(t, p.Play())
+
+		start := time.Now()
+
+		time.Sleep(100 * time.Millisecond)
+		p.SetPos(500 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
+		p.SetPos(5900 * time.Millisecond)
+
+		<-p.C()
+
+		// It should take 300ms for the event to be emitted.
+		// Two 100ms sleeps (200ms), then a seek to 5.900 seconds which
+		// requires another 100ms to wait for the event at 6s.
+		require.Equal(t, time.Since(start), 300*time.Millisecond)
+	})
+}

--- a/lib/player/player_test.go
+++ b/lib/player/player_test.go
@@ -173,57 +173,6 @@ func TestClose(t *testing.T) {
 	require.Equal(t, time.Second, p.LastPlayed())
 }
 
-func TestSeekForward(t *testing.T) {
-	clk := clockwork.NewRealClock()
-	p, err := player.New(&player.Config{
-		Clock:     clk,
-		SessionID: "test-session",
-		Streamer:  &simpleStreamer{count: 1, delay: 6000},
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() { p.Close() })
-	require.NoError(t, p.Play())
-
-	time.Sleep(100 * time.Millisecond)
-	p.SetPos(500 * time.Millisecond)
-	time.Sleep(100 * time.Millisecond)
-	p.SetPos(5900 * time.Millisecond)
-
-	select {
-	case <-p.C():
-	case <-time.After(5 * time.Second):
-		require.FailNow(t, "event not emitted on time")
-	}
-}
-
-// TestInterruptsDelay tests that the player responds to playback
-// controls even when it is waiting to emit an event.
-func TestInterruptsDelay(t *testing.T) {
-	clk := clockwork.NewFakeClock()
-	p, err := player.New(&player.Config{
-		Clock:     clk,
-		SessionID: "test-session",
-		Streamer:  &simpleStreamer{count: 3, delay: 5000},
-	})
-	require.NoError(t, err)
-	require.NoError(t, p.Play())
-
-	t.Cleanup(func() { p.Close() })
-
-	clk.BlockUntil(1) // player is now waiting to emit event 0
-
-	// emulate the user seeking forward while the player is waiting..
-	p.SetPos(10_001 * time.Millisecond)
-
-	// expect event 0 and event 1 to be emitted right away
-	// even without advancing the clock
-	evt0 := <-p.C()
-	evt1 := <-p.C()
-
-	require.Equal(t, int64(0), evt0.GetIndex())
-	require.Equal(t, int64(1), evt1.GetIndex())
-}
-
 func TestRewind(t *testing.T) {
 	clk := clockwork.NewFakeClock()
 	p, err := player.New(&player.Config{


### PR DESCRIPTION
These tests have been flaky because clockwork's BlockUntil functionality isn't capable of blocking until the code is waiting on a timer.

The synctest package introduced in Go 1.24 doesn't suffer from this limitation and allows us to reliably wait for the code to be blocked on the timer's channel.

This package is experimental only available to the compiler when the GOEXPERIMENT=synctest environment variable is set. For this reason, the tests are hidden behind a build flag to prevent `go test` invocations from failing for devs who haven't set the env var. The makefile does set the variable, so `make test-go` _will_ execute the test (both locally and in CI).

To test locally: `GOEXPERIMENT=synctest go test ./lib/player -tags=enablesynctest`

Closes #43559
Closes #40842