### PR TITLE
Add tctl support for health check config resources

### DIFF
--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -279,6 +279,8 @@ func ParseShortcut(in string) (string, error) {
 		return types.KindWorkloadIdentityX509Revocation, nil
 	case types.KindWorkloadIdentityX509IssuerOverride, types.KindWorkloadIdentityX509IssuerOverride + "s":
 		return types.KindWorkloadIdentityX509IssuerOverride, nil
+	case types.KindHealthCheckConfig, types.KindHealthCheckConfig + "s", "hcc":
+		return types.KindHealthCheckConfig, nil
 	}
 	return "", trace.BadParameter("unsupported resource: %q - resources should be expressed as 'type/name', for example 'connector/github'", in)
 }

--- a/tool/common/common.go
+++ b/tool/common/common.go
@@ -187,6 +187,17 @@ func FormatLabels(labels map[string]string, verbose bool) string {
 	return strings.Join(append(result, namespaced...), ",")
 }
 
+// FormatMultiValueLabels formats labels that have multiple values as a map
+// where each key has only one formatted value, then that map is formatted with
+// FormatLabels as above.
+func FormatMultiValueLabels(labels map[string][]string, verbose bool) string {
+	ll := make(map[string]string, len(labels))
+	for key, values := range labels {
+		ll[key] = fmt.Sprintf("%v", values)
+	}
+	return FormatLabels(ll, verbose)
+}
+
 // FormatResourceName returns the resource's name or its name as originally
 // discovered in the cloud by the Teleport Discovery Service.
 // In verbose mode, it always returns the resource name.
@@ -201,4 +212,14 @@ func FormatResourceName(r types.ResourceWithLabels, verbose bool) string {
 		}
 	}
 	return r.GetName()
+}
+
+// FormatDefault formats a zero value with its default, or if the value is not
+// zero it just returns the value.
+func FormatDefault[T comparable](val, defaultVal T) string {
+	var zero T
+	if val == zero {
+		return fmt.Sprintf("%v (default)", defaultVal)
+	}
+	return fmt.Sprintf("%v", val)
 }

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -31,12 +31,14 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/api/defaults"
 	accessmonitoringrulesv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessmonitoringrules/v1"
 	autoupdatev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	crownjewelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/crownjewel/v1"
 	dbobjectv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobject/v1"
 	dbobjectimportrulev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobjectimportrule/v1"
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
+	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
 	loginrulepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
@@ -2048,6 +2050,47 @@ func (c *accessMonitoringRuleCollection) writeText(w io.Writer, verbose bool) er
 	}
 	headers := []string{"Name", "Labels"}
 	t := asciitable.MakeTable(headers, rows...)
+
+	// stable sort by name.
+	t.SortRowsBy([]int{0}, true)
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
+}
+
+type healthCheckConfigCollection struct {
+	items []*healthcheckconfigv1.HealthCheckConfig
+}
+
+func (c *healthCheckConfigCollection) resources() []types.Resource {
+	out := make([]types.Resource, 0, len(c.items))
+	for _, item := range c.items {
+		out = append(out, types.ProtoResource153ToLegacy(item))
+	}
+	return out
+}
+
+func (c *healthCheckConfigCollection) writeText(w io.Writer, verbose bool) error {
+	headers := []string{"Name", "Interval", "Timeout", "Healthy Threshold", "Unhealthy Threshold", "DB Labels", "DB Expression"}
+	var rows [][]string
+	for _, item := range c.items {
+		meta := item.GetMetadata()
+		spec := item.GetSpec()
+		rows = append(rows, []string{
+			meta.GetName(),
+			common.FormatDefault(spec.GetInterval().AsDuration(), defaults.HealthCheckInterval),
+			common.FormatDefault(spec.GetTimeout().AsDuration(), defaults.HealthCheckTimeout),
+			common.FormatDefault(spec.GetHealthyThreshold(), defaults.HealthCheckHealthyThreshold),
+			common.FormatDefault(spec.GetUnhealthyThreshold(), defaults.HealthCheckUnhealthyThreshold),
+			common.FormatMultiValueLabels(label.ToMap(spec.GetMatch().GetDbLabels()), verbose),
+			spec.GetMatch().GetDbLabelsExpression(),
+		})
+	}
+	var t asciitable.Table
+	if verbose {
+		t = asciitable.MakeTable(headers, rows...)
+	} else {
+		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "DB Labels")
+	}
 
 	// stable sort by name.
 	t.SortRowsBy([]int{0}, true)

--- a/tool/tctl/common/edit_command_test.go
+++ b/tool/tctl/common/edit_command_test.go
@@ -95,6 +95,10 @@ func TestEditResources(t *testing.T) {
 			kind: types.KindDynamicWindowsDesktop,
 			edit: testEditDynamicWindowsDesktop,
 		},
+		{
+			kind: types.KindHealthCheckConfig,
+			edit: testEditHealthCheckConfig,
+		},
 	}
 
 	for _, test := range tests {

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -50,6 +50,7 @@ import (
 	dbobjectimportrulev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobjectimportrule/v1"
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
 	loginrulepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	pluginsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/plugins/v1"
@@ -185,6 +186,7 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Globa
 		types.KindGitServer:                          rc.createGitServer,
 		types.KindAutoUpdateAgentRollout:             rc.createAutoUpdateAgentRollout,
 		types.KindWorkloadIdentityX509IssuerOverride: rc.createWorkloadIdentityX509IssuerOverride,
+		types.KindHealthCheckConfig:                  rc.createHealthCheckConfig,
 	}
 	rc.UpdateHandlers = map[ResourceKind]ResourceCreateHandler{
 		types.KindUser:                               rc.updateUser,
@@ -208,6 +210,7 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Globa
 		types.KindGitServer:                          rc.updateGitServer,
 		types.KindAutoUpdateAgentRollout:             rc.updateAutoUpdateAgentRollout,
 		types.KindWorkloadIdentityX509IssuerOverride: rc.updateWorkloadIdentityX509IssuerOverride,
+		types.KindHealthCheckConfig:                  rc.updateHealthCheckConfig,
 	}
 	rc.config = config
 
@@ -2178,6 +2181,8 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 			return trace.Wrap(err)
 		}
 		fmt.Printf("AutoUpdateAgentRollout has been deleted\n")
+	case types.KindHealthCheckConfig:
+		return trace.Wrap(rc.deleteHealthCheckConfig(ctx, client))
 	default:
 		return trace.BadParameter("deleting resources of type %q is not supported", rc.ref.Kind)
 	}
@@ -3535,6 +3540,32 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			}
 		}
 		return collection, nil
+	case types.KindHealthCheckConfig:
+		if rc.ref.Name != "" {
+			cfg, err := client.GetHealthCheckConfig(ctx, rc.ref.Name)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			return &healthCheckConfigCollection{
+				items: []*healthcheckconfigv1.HealthCheckConfig{cfg},
+			}, nil
+		}
+		var items []*healthcheckconfigv1.HealthCheckConfig
+		var token string
+		for {
+			page, nextToken, err := client.ListHealthCheckConfigs(ctx, 0, token)
+			token = nextToken
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			items = append(items, page...)
+			if token == "" {
+				break
+			}
+		}
+		return &healthCheckConfigCollection{
+			items: items,
+		}, nil
 	}
 	return nil, trace.BadParameter("getting %q is not supported", rc.ref.String())
 }

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -1462,6 +1462,10 @@ func TestCreateResources(t *testing.T) {
 			kind:   types.KindDynamicWindowsDesktop,
 			create: testCreateDynamicWindowsDesktop,
 		},
+		{
+			kind:   types.KindHealthCheckConfig,
+			create: testCreateHealthCheckConfig,
+		},
 	}
 
 	for _, test := range tests {

--- a/tool/tctl/common/resource_health_check_config.go
+++ b/tool/tctl/common/resource_health_check_config.go
@@ -1,0 +1,65 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+func (rc *ResourceCommand) createHealthCheckConfig(ctx context.Context, clt *authclient.Client, raw services.UnknownResource) error {
+	in, err := services.UnmarshalHealthCheckConfig(raw.Raw, services.DisallowUnknown())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	createFn := clt.CreateHealthCheckConfig
+	if rc.IsForced() {
+		createFn = clt.UpsertHealthCheckConfig
+	}
+	if _, err := createFn(ctx, in); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("health_check_config %q has been created\n", in.GetMetadata().GetName())
+	return nil
+}
+
+func (rc *ResourceCommand) updateHealthCheckConfig(ctx context.Context, clt *authclient.Client, raw services.UnknownResource) error {
+	in, err := services.UnmarshalHealthCheckConfig(raw.Raw, services.DisallowUnknown())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if _, err := clt.UpdateHealthCheckConfig(ctx, in); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("health_check_config %q has been updated\n", in.GetMetadata().GetName())
+	return nil
+}
+
+func (rc *ResourceCommand) deleteHealthCheckConfig(ctx context.Context, clt *authclient.Client) error {
+	if err := clt.DeleteHealthCheckConfig(ctx, rc.ref.Name); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("health_check_config %q has been deleted\n", rc.ref.Name)
+	return nil
+}

--- a/tool/tctl/common/resource_health_check_config_test.go
+++ b/tool/tctl/common/resource_health_check_config_test.go
@@ -1,0 +1,145 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/healthcheckconfig"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+func testCreateHealthCheckConfig(t *testing.T, clt *authclient.Client) {
+	const resourceYAML = `kind: health_check_config
+version: v1
+metadata:
+  name: testcfg
+spec:
+  match:
+    db_labels:
+    - name: '*'
+      values:
+      - '*'
+    db_labels_expression: labels.env != "prod"
+  interval: 60s
+  timeout: 5s
+  healthy_threshold: 2
+  unhealthy_threshold: 1
+`
+	cfgRef := func(name string) string {
+		return fmt.Sprintf("%v/%v", types.KindHealthCheckConfig, name)
+	}
+	// Get a specific non-existent resource
+	_, err := runResourceCommand(t, clt, []string{"get", cfgRef("testcfg"), "--format=json"})
+	require.ErrorContains(t, err, "doesn't exist")
+
+	// Create the resource.
+	resourceYAMLPath := filepath.Join(t.TempDir(), "resource.yaml")
+	require.NoError(t, os.WriteFile(resourceYAMLPath, []byte(resourceYAML), 0644))
+	_, err = runResourceCommand(t, clt, []string{"create", resourceYAMLPath})
+	require.NoError(t, err)
+
+	// Get the resource
+	buf, err := runResourceCommand(t, clt, []string{"get", cfgRef("testcfg"), "--format=json"})
+	require.NoError(t, err)
+
+	rawResources := mustDecodeJSON[[]services.UnknownResource](t, buf)
+	require.Len(t, rawResources, 1)
+	resource, err := services.UnmarshalHealthCheckConfig(rawResources[0].Raw, services.DisallowUnknown())
+	require.NoError(t, err)
+
+	expectedJSON := mustTranscodeYAMLToJSON(t, bytes.NewReader([]byte(resourceYAML)))
+	expected, err := services.UnmarshalHealthCheckConfig(expectedJSON, services.DisallowUnknown())
+	require.NoError(t, err)
+
+	require.Empty(t, cmp.Diff(
+		expected,
+		resource,
+		protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
+		protocmp.Transform(),
+	))
+
+	// Explicitly change the revision and try creating the resource with and
+	// without the force flag.
+	expected.GetMetadata().Revision = uuid.NewString()
+	blob, err := services.MarshalHealthCheckConfig(expected, services.PreserveRevision())
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(resourceYAMLPath, blob, 0644))
+
+	_, err = runResourceCommand(t, clt, []string{"create", resourceYAMLPath})
+	require.Error(t, err)
+	require.IsType(t, trace.AlreadyExists(""), err)
+
+	_, err = runResourceCommand(t, clt, []string{"create", "-f", resourceYAMLPath})
+	require.NoError(t, err)
+}
+
+func testEditHealthCheckConfig(t *testing.T, clt *authclient.Client) {
+	ctx := context.Background()
+
+	// create expected health check config
+	expected, err := healthcheckconfig.NewHealthCheckConfig("test",
+		&healthcheckconfigv1.HealthCheckConfigSpec{
+			Match: &healthcheckconfigv1.Matcher{
+				DbLabelsExpression: "labels.env == `dev`",
+			},
+		},
+	)
+	require.NoError(t, err)
+	created, err := clt.CreateHealthCheckConfig(ctx, expected)
+	require.NoError(t, err)
+
+	editor := func(name string) error {
+		f, err := os.Create(name)
+		if err != nil {
+			return trace.Wrap(err, "opening file to edit")
+		}
+		expected.GetMetadata().Revision = created.GetMetadata().GetRevision()
+		collection := &healthCheckConfigCollection{
+			items: []*healthcheckconfigv1.HealthCheckConfig{expected},
+		}
+		return trace.NewAggregate(writeYAML(collection, f), f.Close())
+	}
+
+	// Edit the AutoUpdateConfig resource.
+	_, err = runEditCommand(t, clt, []string{"edit", "health_check_config/test"}, withEditor(editor))
+	require.NoError(t, err)
+
+	got, err := clt.GetHealthCheckConfig(ctx, "test")
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(expected, got,
+		protocmp.Transform(),
+		protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
+	))
+}


### PR DESCRIPTION
This PR is stacked on top of another PR and will switch to master automatically when it merges:
- #53555

Related issue:
- #20544

Example:

```
$ tctl get health_check_config
kind: health_check_config
metadata:
  description: Enables all health checks by default
  labels:
    teleport.internal/resource-type: preset
  name: default
  namespace: default
  revision: 8bc931b4-a2bc-4dfd-ab2a-4a650f80bbb3
spec:
  match:
    db_labels:
    - name: '*'
      values:
      - '*'
version: v1

$ tctl get health_check_config --format text
Name    Interval      Timeout      Healthy Threshold Unhealthy Threshold DB Labels DB Expression 
------- ------------- ------------ ----------------- ------------------- --------- ------------- 
default 30s (default) 5s (default) 2 (default)       1 (default)         *=[*]                   

$ tctl edit health_check_config/default
health_check_config "default" has been updated

$ tctl get health_check_config
kind: health_check_config
metadata:
  description: Enables all health checks by default
  labels:
    teleport.internal/resource-type: preset
  name: default
  namespace: default
  revision: ed1c4f00-26c1-4551-a6e8-9eb062938558
spec:
  healthy_threshold: 1
  match:
    db_labels:
    - name: '*'
      values:
      - '*'
version: v1

$ tctl get health_check_config --format text
Name    Interval      Timeout      Healthy Threshold Unhealthy Threshold DB Labels DB Expression 
------- ------------- ------------ ----------------- ------------------- --------- ------------- 
default 30s (default) 5s (default) 1                 1 (default)         *=[*]                   

```