### PR TITLE
fix: use Go 1.18+ build tag syntax

### DIFF
--- a/integration/hostuser_test.go
+++ b/integration/hostuser_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
  * Teleport

--- a/lib/auth/storage/storage_unix.go
+++ b/lib/auth/storage/storage_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
  * Teleport

--- a/lib/auth/storage/storage_windows.go
+++ b/lib/auth/storage/storage_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
  * Teleport

--- a/lib/auth/touchid/api_darwin.go
+++ b/lib/auth/touchid/api_darwin.go
@@ -1,5 +1,4 @@
 //go:build touchid
-// +build touchid
 
 /*
  * Teleport

--- a/lib/auth/touchid/api_other.go
+++ b/lib/auth/touchid/api_other.go
@@ -1,5 +1,4 @@
 //go:build !touchid
-// +build !touchid
 
 /*
  * Teleport

--- a/lib/auth/webauthncli/export_fido2_test.go
+++ b/lib/auth/webauthncli/export_fido2_test.go
@@ -1,5 +1,4 @@
 //go:build libfido2
-// +build libfido2
 
 /*
  * Teleport

--- a/lib/auth/webauthncli/fido2.go
+++ b/lib/auth/webauthncli/fido2.go
@@ -1,5 +1,4 @@
 //go:build libfido2
-// +build libfido2
 
 /*
  * Teleport

--- a/lib/auth/webauthncli/fido2_other.go
+++ b/lib/auth/webauthncli/fido2_other.go
@@ -1,5 +1,4 @@
 //go:build !libfido2
-// +build !libfido2
 
 /*
  * Teleport

--- a/lib/auth/webauthncli/fido2_test.go
+++ b/lib/auth/webauthncli/fido2_test.go
@@ -1,5 +1,4 @@
 //go:build libfido2
-// +build libfido2
 
 /*
  * Teleport

--- a/lib/auth/webauthnwin/webauthn_other.go
+++ b/lib/auth/webauthnwin/webauthn_other.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
  * Teleport

--- a/lib/bpf/bpf.go
+++ b/lib/bpf/bpf.go
@@ -1,5 +1,4 @@
 //go:build bpf && !386
-// +build bpf,!386
 
 /*
  * Teleport

--- a/lib/bpf/bpf_nop.go
+++ b/lib/bpf/bpf_nop.go
@@ -1,5 +1,4 @@
 //go:build !bpf || 386
-// +build !bpf 386
 
 /*
  * Teleport

--- a/lib/bpf/bpf_test.go
+++ b/lib/bpf/bpf_test.go
@@ -1,5 +1,4 @@
 //go:build bpf && !386
-// +build bpf,!386
 
 /*
  * Teleport

--- a/lib/bpf/command.go
+++ b/lib/bpf/command.go
@@ -1,5 +1,4 @@
 //go:build bpf && !386
-// +build bpf,!386
 
 /*
  * Teleport

--- a/lib/bpf/common_linux.go
+++ b/lib/bpf/common_linux.go
@@ -1,5 +1,4 @@
 //go:build bpf && !386
-// +build bpf,!386
 
 /*
  * Teleport

--- a/lib/bpf/disk.go
+++ b/lib/bpf/disk.go
@@ -1,5 +1,4 @@
 //go:build bpf && !386
-// +build bpf,!386
 
 /*
  * Teleport

--- a/lib/bpf/helper.go
+++ b/lib/bpf/helper.go
@@ -1,5 +1,4 @@
 //go:build bpf && !386
-// +build bpf,!386
 
 /*
  * Teleport

--- a/lib/bpf/network.go
+++ b/lib/bpf/network.go
@@ -1,5 +1,4 @@
 //go:build bpf && !386
-// +build bpf,!386
 
 /*
  * Teleport

--- a/lib/client/terminal/terminal_unix.go
+++ b/lib/client/terminal/terminal_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
  * Teleport

--- a/lib/client/tncon/tncon.go
+++ b/lib/client/tncon/tncon.go
@@ -1,5 +1,4 @@
 //go:build windows && cgo
-// +build windows,cgo
 
 /*
  * Teleport

--- a/lib/events/filesessions/fileasync_chaos_test.go
+++ b/lib/events/filesessions/fileasync_chaos_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 /*
  * Teleport

--- a/lib/events/s3sessions/s3handler_test.go
+++ b/lib/events/s3sessions/s3handler_test.go
@@ -1,5 +1,4 @@
 //go:build dynamodb
-// +build dynamodb
 
 /*
  * Teleport

--- a/lib/inventory/metadata/metadata_darwin.go
+++ b/lib/inventory/metadata/metadata_darwin.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 /*
  * Teleport

--- a/lib/inventory/metadata/metadata_darwin_test.go
+++ b/lib/inventory/metadata/metadata_darwin_test.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 /*
  * Teleport

--- a/lib/inventory/metadata/metadata_linux.go
+++ b/lib/inventory/metadata/metadata_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
  * Teleport

--- a/lib/inventory/metadata/metadata_linux_test.go
+++ b/lib/inventory/metadata/metadata_linux_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
  * Teleport

--- a/lib/inventory/metadata/metadata_other.go
+++ b/lib/inventory/metadata/metadata_other.go
@@ -1,5 +1,4 @@
 //go:build !darwin && !linux
-// +build !darwin,!linux
 
 /*
  * Teleport

--- a/lib/pam/pam.go
+++ b/lib/pam/pam.go
@@ -1,5 +1,4 @@
 //go:build pam && cgo
-// +build pam,cgo
 
 /*
  * Teleport

--- a/lib/pam/pam_nop.go
+++ b/lib/pam/pam_nop.go
@@ -1,5 +1,4 @@
 //go:build !pam && cgo
-// +build !pam,cgo
 
 /*
  * Teleport

--- a/lib/shell/shell_unix.go
+++ b/lib/shell/shell_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
  * Teleport

--- a/lib/shell/shell_windows.go
+++ b/lib/shell/shell_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
  * Teleport

--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -1,5 +1,4 @@
 //go:build desktop_access_rdp
-// +build desktop_access_rdp
 
 /*
  * Teleport

--- a/lib/srv/desktop/rdp/rdpclient/client_nop.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_nop.go
@@ -1,5 +1,4 @@
 //go:build !desktop_access_rdp
-// +build !desktop_access_rdp
 
 /*
  * Teleport

--- a/lib/srv/exec_linux_test.go
+++ b/lib/srv/exec_linux_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
  * Teleport

--- a/lib/srv/reexec_linux.go
+++ b/lib/srv/reexec_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
  * Teleport

--- a/lib/srv/reexec_other.go
+++ b/lib/srv/reexec_other.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 /*
  * Teleport

--- a/lib/srv/regular/sshserver_unix_test.go
+++ b/lib/srv/regular/sshserver_unix_test.go
@@ -1,5 +1,4 @@
 //go:build unix
-// +build unix
 
 /*
  * Teleport

--- a/lib/srv/uacc/uacc_stub.go
+++ b/lib/srv/uacc/uacc_stub.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 /*
  * Teleport

--- a/lib/srv/usermgmt_other.go
+++ b/lib/srv/usermgmt_other.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 /*
  * Teleport

--- a/lib/tbot/botfs/fs_linux.go
+++ b/lib/tbot/botfs/fs_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
  * Teleport

--- a/lib/tbot/botfs/fs_linux_test.go
+++ b/lib/tbot/botfs/fs_linux_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
  * Teleport

--- a/lib/tbot/botfs/fs_unix.go
+++ b/lib/tbot/botfs/fs_unix.go
@@ -1,5 +1,4 @@
 //go:build unix && !linux
-// +build unix,!linux
 
 /*
  * Teleport

--- a/lib/tbot/botfs/fs_windows.go
+++ b/lib/tbot/botfs/fs_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
  * Teleport

--- a/lib/teleterm/vnet/service_daemon_darwin.go
+++ b/lib/teleterm/vnet/service_daemon_darwin.go
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 //go:build vnetdaemon
-// +build vnetdaemon
 
 package vnet
 

--- a/lib/utils/agentconn/agent_unix.go
+++ b/lib/utils/agentconn/agent_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
  * Teleport

--- a/lib/utils/agentconn/agent_windows.go
+++ b/lib/utils/agentconn/agent_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
  * Teleport

--- a/lib/utils/disk.go
+++ b/lib/utils/disk.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
  * Teleport

--- a/lib/utils/disk_windows.go
+++ b/lib/utils/disk_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
  * Teleport

--- a/lib/utils/fs_unix.go
+++ b/lib/utils/fs_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
  * Teleport

--- a/lib/utils/fs_unix_test.go
+++ b/lib/utils/fs_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
  * Teleport

--- a/lib/utils/fs_windows.go
+++ b/lib/utils/fs_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package utils
 

--- a/lib/utils/log/syslog.go
+++ b/lib/utils/log/syslog.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
  * Teleport

--- a/lib/vnet/client_application_service_other.go
+++ b/lib/vnet/client_application_service_other.go
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 //go:build !windows
-// +build !windows
 
 package vnet
 

--- a/lib/vnet/daemon/client_darwin.go
+++ b/lib/vnet/daemon/client_darwin.go
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 //go:build vnetdaemon
-// +build vnetdaemon
 
 package daemon
 

--- a/lib/vnet/daemon/common_darwin.go
+++ b/lib/vnet/daemon/common_darwin.go
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 //go:build vnetdaemon
-// +build vnetdaemon
 
 package daemon
 

--- a/lib/vnet/daemon/service_darwin.go
+++ b/lib/vnet/daemon/service_darwin.go
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 //go:build vnetdaemon
-// +build vnetdaemon
 
 package daemon
 

--- a/lib/vnet/diag/routeconflict_darwin_test.go
+++ b/lib/vnet/diag/routeconflict_darwin_test.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 // Teleport
 // Copyright (C) 2025 Gravitational, Inc.

--- a/lib/vnet/diag/routeconflict_other.go
+++ b/lib/vnet/diag/routeconflict_other.go
@@ -1,5 +1,4 @@
 //go:build !darwin
-// +build !darwin
 
 // Teleport
 // Copyright (C) 2025 Gravitational, Inc.

--- a/lib/vnet/dns/osnameservers_darwin_test.go
+++ b/lib/vnet/dns/osnameservers_darwin_test.go
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 //go:build darwin
-// +build darwin
 
 package dns
 

--- a/lib/vnet/dns/osnameservers_other.go
+++ b/lib/vnet/dns/osnameservers_other.go
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 //go:build !darwin && !windows
-// +build !darwin,!windows
 
 package dns
 

--- a/lib/vnet/escalate_daemon_darwin.go
+++ b/lib/vnet/escalate_daemon_darwin.go
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 //go:build vnetdaemon
-// +build vnetdaemon
 
 package vnet
 

--- a/lib/vnet/escalate_nodaemon_darwin.go
+++ b/lib/vnet/escalate_nodaemon_darwin.go
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 //go:build !vnetdaemon
-// +build !vnetdaemon
 
 package vnet
 

--- a/lib/vnet/socket_darwin.go
+++ b/lib/vnet/socket_darwin.go
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 //go:build darwin
-// +build darwin
 
 package vnet
 

--- a/lib/vnet/unsupported_os.go
+++ b/lib/vnet/unsupported_os.go
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 //go:build !darwin && !windows
-// +build !darwin,!windows
 
 package vnet
 

--- a/tool/tsh/common/daemonstop_unix.go
+++ b/tool/tsh/common/daemonstop_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
  * Teleport

--- a/tool/tsh/common/daemonstop_windows.go
+++ b/tool/tsh/common/daemonstop_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
  * Teleport

--- a/tool/tsh/common/kube_proxy_darwin.go
+++ b/tool/tsh/common/kube_proxy_darwin.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 /*
  * Teleport

--- a/tool/tsh/common/kube_proxy_linux.go
+++ b/tool/tsh/common/kube_proxy_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
  * Teleport

--- a/tool/tsh/common/kube_proxy_other.go
+++ b/tool/tsh/common/kube_proxy_other.go
@@ -1,5 +1,4 @@
 //go:build !darwin && !linux
-// +build !darwin,!linux
 
 /*
  * Teleport

--- a/tool/tsh/common/vnet_daemon_darwin.go
+++ b/tool/tsh/common/vnet_daemon_darwin.go
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 //go:build vnetdaemon
-// +build vnetdaemon
 
 package common
 

--- a/tool/tsh/common/vnet_nodaemon.go
+++ b/tool/tsh/common/vnet_nodaemon.go
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 //go:build !vnetdaemon || !darwin
-// +build !vnetdaemon !darwin
 
 package common
 

--- a/tool/tsh/common/vnet_other.go
+++ b/tool/tsh/common/vnet_other.go
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 //go:build !darwin && !windows
-// +build !darwin,!windows
 
 package common
 


### PR DESCRIPTION
All of our supported release branches are well past Go 1.18, so we don't need to support the old build tag syntax.

Changes made by running `go fix ./...`.