### PR TITLE
Add auditlog exports to TAG via grpc

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -2583,7 +2583,7 @@ func (c *Client) SearchEvents(ctx context.Context, fromUTC, toUTC time.Time, nam
 // SearchUnstructuredEvents allows searching for events with a full pagination support
 // and returns events in an unstructured format (json like).
 // This method is used by the Teleport event-handler plugin to receive events
-// from the auth server wihout having to support the Protobuf event schema.
+// from the auth server without having to support the Protobuf event schema.
 func (c *Client) SearchUnstructuredEvents(ctx context.Context, fromUTC, toUTC time.Time, namespace string, eventTypes []string, limit int, order types.EventOrder, startKey string) ([]*auditlogpb.EventUnstructured, string, error) {
 	request := &auditlogpb.GetUnstructuredEventsRequest{
 		Namespace:  namespace,

--- a/api/gen/proto/go/teleport/clusterconfig/v1/access_graph.pb.go
+++ b/api/gen/proto/go/teleport/clusterconfig/v1/access_graph.pb.go
@@ -50,8 +50,11 @@ type AccessGraphConfig struct {
 	Insecure bool `protobuf:"varint,4,opt,name=insecure,proto3" json:"insecure,omitempty"`
 	// secrets_scan_config is used to configure the parameters for the secrets scanning functionality.
 	SecretsScanConfig *AccessGraphSecretsScanConfiguration `protobuf:"bytes,5,opt,name=secrets_scan_config,json=secretsScanConfig,proto3" json:"secrets_scan_config,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// audit_logs_enabled is a flag that indicates whether the access graph
+	// service should process audit logs.
+	AuditLogsEnabled bool `protobuf:"varint,6,opt,name=audit_logs_enabled,json=auditLogsEnabled,proto3" json:"audit_logs_enabled,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *AccessGraphConfig) Reset() {
@@ -119,6 +122,13 @@ func (x *AccessGraphConfig) GetSecretsScanConfig() *AccessGraphSecretsScanConfig
 	return nil
 }
 
+func (x *AccessGraphConfig) GetAuditLogsEnabled() bool {
+	if x != nil {
+		return x.AuditLogsEnabled
+	}
+	return false
+}
+
 // AccessGraphSecretsScanConfiguration controls the secrets scanning service parameters.
 type AccessGraphSecretsScanConfiguration struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -169,13 +179,14 @@ var File_teleport_clusterconfig_v1_access_graph_proto protoreflect.FileDescripto
 
 const file_teleport_clusterconfig_v1_access_graph_proto_rawDesc = "" +
 	"\n" +
-	",teleport/clusterconfig/v1/access_graph.proto\x12\x19teleport.clusterconfig.v1\"\xe3\x01\n" +
+	",teleport/clusterconfig/v1/access_graph.proto\x12\x19teleport.clusterconfig.v1\"\x91\x02\n" +
 	"\x11AccessGraphConfig\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\x12\x18\n" +
 	"\aaddress\x18\x02 \x01(\tR\aaddress\x12\x0e\n" +
 	"\x02ca\x18\x03 \x01(\fR\x02ca\x12\x1a\n" +
 	"\binsecure\x18\x04 \x01(\bR\binsecure\x12n\n" +
-	"\x13secrets_scan_config\x18\x05 \x01(\v2>.teleport.clusterconfig.v1.AccessGraphSecretsScanConfigurationR\x11secretsScanConfig\"O\n" +
+	"\x13secrets_scan_config\x18\x05 \x01(\v2>.teleport.clusterconfig.v1.AccessGraphSecretsScanConfigurationR\x11secretsScanConfig\x12,\n" +
+	"\x12audit_logs_enabled\x18\x06 \x01(\bR\x10auditLogsEnabled\"O\n" +
 	"#AccessGraphSecretsScanConfiguration\x12(\n" +
 	"\x10ssh_scan_enabled\x18\x01 \x01(\bR\x0esshScanEnabledB^Z\\github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1;clusterconfigv1b\x06proto3"
 

--- a/api/gen/proto/go/teleport/clusterconfig/v1/access_graph.pb.go
+++ b/api/gen/proto/go/teleport/clusterconfig/v1/access_graph.pb.go
@@ -23,6 +23,7 @@ package clusterconfigv1
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -50,11 +51,10 @@ type AccessGraphConfig struct {
 	Insecure bool `protobuf:"varint,4,opt,name=insecure,proto3" json:"insecure,omitempty"`
 	// secrets_scan_config is used to configure the parameters for the secrets scanning functionality.
 	SecretsScanConfig *AccessGraphSecretsScanConfiguration `protobuf:"bytes,5,opt,name=secrets_scan_config,json=secretsScanConfig,proto3" json:"secrets_scan_config,omitempty"`
-	// audit_logs_enabled is a flag that indicates whether the access graph
-	// service should process audit logs.
-	AuditLogsEnabled bool `protobuf:"varint,6,opt,name=audit_logs_enabled,json=auditLogsEnabled,proto3" json:"audit_logs_enabled,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// audit_log_config sets up audit log event exporting.
+	AuditLogConfig *AuditLogConfig `protobuf:"bytes,6,opt,name=audit_log_config,json=auditLogConfig,proto3" json:"audit_log_config,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *AccessGraphConfig) Reset() {
@@ -122,11 +122,11 @@ func (x *AccessGraphConfig) GetSecretsScanConfig() *AccessGraphSecretsScanConfig
 	return nil
 }
 
-func (x *AccessGraphConfig) GetAuditLogsEnabled() bool {
+func (x *AccessGraphConfig) GetAuditLogConfig() *AuditLogConfig {
 	if x != nil {
-		return x.AuditLogsEnabled
+		return x.AuditLogConfig
 	}
-	return false
+	return nil
 }
 
 // AccessGraphSecretsScanConfiguration controls the secrets scanning service parameters.
@@ -175,20 +175,79 @@ func (x *AccessGraphSecretsScanConfiguration) GetSshScanEnabled() bool {
 	return false
 }
 
+// AuditLogConfig sepcifies the audit log event export setup.
+type AuditLogConfig struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// enbled indicates if Audit Log event exporting is enabled.
+	Enabled bool `protobuf:"varint,1,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	// start_date is the start date for exporting audit logs. It defaults to 90 days ago on the first export.
+	StartDate     *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=start_date,json=startDate,proto3" json:"start_date,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AuditLogConfig) Reset() {
+	*x = AuditLogConfig{}
+	mi := &file_teleport_clusterconfig_v1_access_graph_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AuditLogConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AuditLogConfig) ProtoMessage() {}
+
+func (x *AuditLogConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_clusterconfig_v1_access_graph_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AuditLogConfig.ProtoReflect.Descriptor instead.
+func (*AuditLogConfig) Descriptor() ([]byte, []int) {
+	return file_teleport_clusterconfig_v1_access_graph_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *AuditLogConfig) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
+}
+
+func (x *AuditLogConfig) GetStartDate() *timestamppb.Timestamp {
+	if x != nil {
+		return x.StartDate
+	}
+	return nil
+}
+
 var File_teleport_clusterconfig_v1_access_graph_proto protoreflect.FileDescriptor
 
 const file_teleport_clusterconfig_v1_access_graph_proto_rawDesc = "" +
 	"\n" +
-	",teleport/clusterconfig/v1/access_graph.proto\x12\x19teleport.clusterconfig.v1\"\x91\x02\n" +
+	",teleport/clusterconfig/v1/access_graph.proto\x12\x19teleport.clusterconfig.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xb8\x02\n" +
 	"\x11AccessGraphConfig\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\x12\x18\n" +
 	"\aaddress\x18\x02 \x01(\tR\aaddress\x12\x0e\n" +
 	"\x02ca\x18\x03 \x01(\fR\x02ca\x12\x1a\n" +
 	"\binsecure\x18\x04 \x01(\bR\binsecure\x12n\n" +
-	"\x13secrets_scan_config\x18\x05 \x01(\v2>.teleport.clusterconfig.v1.AccessGraphSecretsScanConfigurationR\x11secretsScanConfig\x12,\n" +
-	"\x12audit_logs_enabled\x18\x06 \x01(\bR\x10auditLogsEnabled\"O\n" +
+	"\x13secrets_scan_config\x18\x05 \x01(\v2>.teleport.clusterconfig.v1.AccessGraphSecretsScanConfigurationR\x11secretsScanConfig\x12S\n" +
+	"\x10audit_log_config\x18\x06 \x01(\v2).teleport.clusterconfig.v1.AuditLogConfigR\x0eauditLogConfig\"O\n" +
 	"#AccessGraphSecretsScanConfiguration\x12(\n" +
-	"\x10ssh_scan_enabled\x18\x01 \x01(\bR\x0esshScanEnabledB^Z\\github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1;clusterconfigv1b\x06proto3"
+	"\x10ssh_scan_enabled\x18\x01 \x01(\bR\x0esshScanEnabled\"e\n" +
+	"\x0eAuditLogConfig\x12\x18\n" +
+	"\aenabled\x18\x01 \x01(\bR\aenabled\x129\n" +
+	"\n" +
+	"start_date\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\tstartDateB^Z\\github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1;clusterconfigv1b\x06proto3"
 
 var (
 	file_teleport_clusterconfig_v1_access_graph_proto_rawDescOnce sync.Once
@@ -202,18 +261,22 @@ func file_teleport_clusterconfig_v1_access_graph_proto_rawDescGZIP() []byte {
 	return file_teleport_clusterconfig_v1_access_graph_proto_rawDescData
 }
 
-var file_teleport_clusterconfig_v1_access_graph_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_teleport_clusterconfig_v1_access_graph_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
 var file_teleport_clusterconfig_v1_access_graph_proto_goTypes = []any{
 	(*AccessGraphConfig)(nil),                   // 0: teleport.clusterconfig.v1.AccessGraphConfig
 	(*AccessGraphSecretsScanConfiguration)(nil), // 1: teleport.clusterconfig.v1.AccessGraphSecretsScanConfiguration
+	(*AuditLogConfig)(nil),                      // 2: teleport.clusterconfig.v1.AuditLogConfig
+	(*timestamppb.Timestamp)(nil),               // 3: google.protobuf.Timestamp
 }
 var file_teleport_clusterconfig_v1_access_graph_proto_depIdxs = []int32{
 	1, // 0: teleport.clusterconfig.v1.AccessGraphConfig.secrets_scan_config:type_name -> teleport.clusterconfig.v1.AccessGraphSecretsScanConfiguration
-	1, // [1:1] is the sub-list for method output_type
-	1, // [1:1] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	2, // 1: teleport.clusterconfig.v1.AccessGraphConfig.audit_log_config:type_name -> teleport.clusterconfig.v1.AuditLogConfig
+	3, // 2: teleport.clusterconfig.v1.AuditLogConfig.start_date:type_name -> google.protobuf.Timestamp
+	3, // [3:3] is the sub-list for method output_type
+	3, // [3:3] is the sub-list for method input_type
+	3, // [3:3] is the sub-list for extension type_name
+	3, // [3:3] is the sub-list for extension extendee
+	0, // [0:3] is the sub-list for field type_name
 }
 
 func init() { file_teleport_clusterconfig_v1_access_graph_proto_init() }
@@ -227,7 +290,7 @@ func file_teleport_clusterconfig_v1_access_graph_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_clusterconfig_v1_access_graph_proto_rawDesc), len(file_teleport_clusterconfig_v1_access_graph_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   2,
+			NumMessages:   3,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/clusterconfig/v1/access_graph.proto
+++ b/api/proto/teleport/clusterconfig/v1/access_graph.proto
@@ -16,6 +16,8 @@ syntax = "proto3";
 
 package teleport.clusterconfig.v1;
 
+import "google/protobuf/timestamp.proto";
+
 option go_package = "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1;clusterconfigv1";
 
 // AccessGraphConfig holds the information about the configured Access Graph service.
@@ -32,13 +34,20 @@ message AccessGraphConfig {
   bool insecure = 4;
   // secrets_scan_config is used to configure the parameters for the secrets scanning functionality.
   AccessGraphSecretsScanConfiguration secrets_scan_config = 5;
-  // audit_logs_enabled is a flag that indicates whether the access graph
-  // service should process audit logs.
-  AuditLogsState audit_logs = 6;
+  // audit_log_config sets up audit log event exporting.
+  AuditLogConfig audit_log_config = 6;
 }
 
 // AccessGraphSecretsScanConfiguration controls the secrets scanning service parameters.
 message AccessGraphSecretsScanConfiguration {
   // ssh_scan_enabled indicates if the SSH scan feature is enabled for the cluster.
   bool ssh_scan_enabled = 1;
+}
+
+// AuditLogConfig sepcifies the audit log event export setup.
+message AuditLogConfig {
+  // enbled indicates if Audit Log event exporting is enabled.
+  bool enabled = 1;
+  // start_date is the start date for exporting audit logs. It defaults to 90 days ago on the first export.
+  google.protobuf.Timestamp start_date = 2;
 }

--- a/api/proto/teleport/clusterconfig/v1/access_graph.proto
+++ b/api/proto/teleport/clusterconfig/v1/access_graph.proto
@@ -32,6 +32,9 @@ message AccessGraphConfig {
   bool insecure = 4;
   // secrets_scan_config is used to configure the parameters for the secrets scanning functionality.
   AccessGraphSecretsScanConfiguration secrets_scan_config = 5;
+  // audit_logs_enabled is a flag that indicates whether the access graph
+  // service should process audit logs.
+  bool audit_logs_enabled = 6;
 }
 
 // AccessGraphSecretsScanConfiguration controls the secrets scanning service parameters.

--- a/api/proto/teleport/clusterconfig/v1/access_graph.proto
+++ b/api/proto/teleport/clusterconfig/v1/access_graph.proto
@@ -34,7 +34,7 @@ message AccessGraphConfig {
   AccessGraphSecretsScanConfiguration secrets_scan_config = 5;
   // audit_logs_enabled is a flag that indicates whether the access graph
   // service should process audit logs.
-  bool audit_logs_enabled = 6;
+  AuditLogsState audit_logs = 6;
 }
 
 // AccessGraphSecretsScanConfiguration controls the secrets scanning service parameters.

--- a/gen/proto/go/accessgraph/v1alpha/access_graph_service.pb.go
+++ b/gen/proto/go/accessgraph/v1alpha/access_graph_service.pb.go
@@ -24,8 +24,10 @@
 package accessgraphv1alpha
 
 import (
+	v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/auditlog/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -738,6 +740,612 @@ type AuditEvent_AccessPathChanged struct {
 
 func (*AuditEvent_AccessPathChanged) isAuditEvent_Event() {}
 
+// AuditLogStreamRequest is sent from the client to the server over the
+// AuditLogStream. It contains different actions related to sending audit logs
+// in unstructured events and managing resume state.
+//
+// The message uses a `oneof` to distinguish between two primary client actions:
+//  1. Sending a batch of audit log events (`events`): This includes the actual
+//     log data (unstructured format) and the corresponding resume state
+//     information relevant to the event source ('search' or 'bulk').
+//  2. Synchronizing bulk export resume state (`bulk_sync`): This is a command
+//     sent separately from log events, instructing the server to clean up state
+//     related to older, completed bulk export dates.
+//
+// Behavior and Constraints
+//   - Direction: Client -> Server.
+//   - Stream Consistency: When sending the `events` payload, a single gRPC stream
+//     connection MUST consistently send *either only* 'search' type events
+//     *or only* 'bulk' type events. Mixing event types within the `events`
+//     payload on the same stream is not permitted.
+//   - State Management: Resume state sent with `events` allows the server to
+//     track the client's progress. The `bulk_sync` provides an explicit
+//     mechanism for purging old, completed dates of bulk exporting from the
+//     resume state.
+//   - Stream Evolution: While the overall system might support upgrading the
+//     event type processed from 'search' to 'bulk' handling across
+//     *different* connections or restarts, downgrading behavior is undefined.
+type AuditLogStreamRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Action:
+	//
+	//	*AuditLogStreamRequest_Events
+	//	*AuditLogStreamRequest_BulkSync
+	Action        isAuditLogStreamRequest_Action `protobuf_oneof:"action"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AuditLogStreamRequest) Reset() {
+	*x = AuditLogStreamRequest{}
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AuditLogStreamRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AuditLogStreamRequest) ProtoMessage() {}
+
+func (x *AuditLogStreamRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AuditLogStreamRequest.ProtoReflect.Descriptor instead.
+func (*AuditLogStreamRequest) Descriptor() ([]byte, []int) {
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *AuditLogStreamRequest) GetAction() isAuditLogStreamRequest_Action {
+	if x != nil {
+		return x.Action
+	}
+	return nil
+}
+
+func (x *AuditLogStreamRequest) GetEvents() *AuditLogEvents {
+	if x != nil {
+		if x, ok := x.Action.(*AuditLogStreamRequest_Events); ok {
+			return x.Events
+		}
+	}
+	return nil
+}
+
+func (x *AuditLogStreamRequest) GetBulkSync() *BulkResumeStateSync {
+	if x != nil {
+		if x, ok := x.Action.(*AuditLogStreamRequest_BulkSync); ok {
+			return x.BulkSync
+		}
+	}
+	return nil
+}
+
+type isAuditLogStreamRequest_Action interface {
+	isAuditLogStreamRequest_Action()
+}
+
+type AuditLogStreamRequest_Events struct {
+	Events *AuditLogEvents `protobuf:"bytes,1,opt,name=events,proto3,oneof"` // Batch of audit log events and resume state.
+}
+
+type AuditLogStreamRequest_BulkSync struct {
+	BulkSync *BulkResumeStateSync `protobuf:"bytes,2,opt,name=bulk_sync,json=bulkSync,proto3,oneof"` // Command to prune server-side bulk export state.
+}
+
+func (*AuditLogStreamRequest_Events) isAuditLogStreamRequest_Action() {}
+
+func (*AuditLogStreamRequest_BulkSync) isAuditLogStreamRequest_Action() {}
+
+// AuditLogEvents bundles a batch of unstructured audit log events with the
+// appropriate resume state information for the type of events being sent
+// ('search' or 'bulk'). This allows the server to persist the client's
+// progress.
+type AuditLogEvents struct {
+	state  protoimpl.MessageState  `protogen:"open.v1"`
+	Events []*v1.EventUnstructured `protobuf:"bytes,1,rep,name=events,proto3" json:"events,omitempty"` // Batch of audit log events.
+	// Types that are valid to be assigned to ResumeState:
+	//
+	//	*AuditLogEvents_SearchResumeState
+	//	*AuditLogEvents_BulkResumeStateUpdate
+	ResumeState   isAuditLogEvents_ResumeState `protobuf_oneof:"resume_state"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AuditLogEvents) Reset() {
+	*x = AuditLogEvents{}
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AuditLogEvents) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AuditLogEvents) ProtoMessage() {}
+
+func (x *AuditLogEvents) ProtoReflect() protoreflect.Message {
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AuditLogEvents.ProtoReflect.Descriptor instead.
+func (*AuditLogEvents) Descriptor() ([]byte, []int) {
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *AuditLogEvents) GetEvents() []*v1.EventUnstructured {
+	if x != nil {
+		return x.Events
+	}
+	return nil
+}
+
+func (x *AuditLogEvents) GetResumeState() isAuditLogEvents_ResumeState {
+	if x != nil {
+		return x.ResumeState
+	}
+	return nil
+}
+
+func (x *AuditLogEvents) GetSearchResumeState() *SearchResumeState {
+	if x != nil {
+		if x, ok := x.ResumeState.(*AuditLogEvents_SearchResumeState); ok {
+			return x.SearchResumeState
+		}
+	}
+	return nil
+}
+
+func (x *AuditLogEvents) GetBulkResumeStateUpdate() *BulkResumeStateUpdate {
+	if x != nil {
+		if x, ok := x.ResumeState.(*AuditLogEvents_BulkResumeStateUpdate); ok {
+			return x.BulkResumeStateUpdate
+		}
+	}
+	return nil
+}
+
+type isAuditLogEvents_ResumeState interface {
+	isAuditLogEvents_ResumeState()
+}
+
+type AuditLogEvents_SearchResumeState struct {
+	SearchResumeState *SearchResumeState `protobuf:"bytes,2,opt,name=search_resume_state,json=searchResumeState,proto3,oneof"` // Complete resume state when sending 'search' events.
+}
+
+type AuditLogEvents_BulkResumeStateUpdate struct {
+	BulkResumeStateUpdate *BulkResumeStateUpdate `protobuf:"bytes,3,opt,name=bulk_resume_state_update,json=bulkResumeStateUpdate,proto3,oneof"` // Incremental resume state update when sending 'bulk' events.
+}
+
+func (*AuditLogEvents_SearchResumeState) isAuditLogEvents_ResumeState() {}
+
+func (*AuditLogEvents_BulkResumeStateUpdate) isAuditLogEvents_ResumeState() {}
+
+// SearchResumeState represents the complete, self-contained state required by a
+// client to resume exporting 'search' type audit events.
+//
+// This state is:
+//   - Sent by the client *with each batch* of 'search' events
+//     (`AuditLogRequest`).
+//   - Sent by the server *to the client* on stream initiation
+//     (`AuditLogResponse`) if the client should resume in 'search' mode.
+type SearchResumeState struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// start_key is a key used as cursor indicating where the *next* search for
+	// events should begin.
+	StartKey string `protobuf:"bytes,1,opt,name=start_key,json=startKey,proto3" json:"start_key,omitempty"`
+	// last_event_id is the ID of the most recent event processed for this
+	// specific `start_key` as of the last fetch. It is empty if this `start_key`
+	// has not yet been used for a search.
+	LastEventId string `protobuf:"bytes,2,opt,name=last_event_id,json=lastEventId,proto3" json:"last_event_id,omitempty"`
+	// last_event_time is the timestamp of the last event successfully processed,
+	// it corresponds to last_event_id if not empty. The clients can leave
+	// last_event_time empty in requests as the server infers it from the last
+	// event in the batch. last_event_time MUST be set by the server in the
+	// initial `AuditLogResponse`.
+	LastEventTime *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=last_event_time,json=lastEventTime,proto3" json:"last_event_time,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SearchResumeState) Reset() {
+	*x = SearchResumeState{}
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SearchResumeState) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SearchResumeState) ProtoMessage() {}
+
+func (x *SearchResumeState) ProtoReflect() protoreflect.Message {
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SearchResumeState.ProtoReflect.Descriptor instead.
+func (*SearchResumeState) Descriptor() ([]byte, []int) {
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *SearchResumeState) GetStartKey() string {
+	if x != nil {
+		return x.StartKey
+	}
+	return ""
+}
+
+func (x *SearchResumeState) GetLastEventId() string {
+	if x != nil {
+		return x.LastEventId
+	}
+	return ""
+}
+
+func (x *SearchResumeState) GetLastEventTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.LastEventTime
+	}
+	return nil
+}
+
+// BulkResumeStateUpdate provides an incremental update to the server about the
+// client's progress within a specific chunk of a bulk export for a given date.
+// It is sent by the client along with batches of 'bulk' type events. A single
+// batch of bulk events is assumed to be sequential and belong to one chunk.
+type BulkResumeStateUpdate struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Date          *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=date,proto3" json:"date,omitempty"`            // UTC date of chunk, normalized to 00:00:00.
+	Chunk         string                 `protobuf:"bytes,2,opt,name=chunk,proto3" json:"chunk,omitempty"`          // Chunk identifier within the date.
+	Cursor        string                 `protobuf:"bytes,3,opt,name=cursor,proto3" json:"cursor,omitempty"`        // Position *after* the last event processed in this chunk.
+	Completed     bool                   `protobuf:"varint,4,opt,name=completed,proto3" json:"completed,omitempty"` // True if this chunk is now fully completed.
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BulkResumeStateUpdate) Reset() {
+	*x = BulkResumeStateUpdate{}
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BulkResumeStateUpdate) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BulkResumeStateUpdate) ProtoMessage() {}
+
+func (x *BulkResumeStateUpdate) ProtoReflect() protoreflect.Message {
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BulkResumeStateUpdate.ProtoReflect.Descriptor instead.
+func (*BulkResumeStateUpdate) Descriptor() ([]byte, []int) {
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *BulkResumeStateUpdate) GetDate() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Date
+	}
+	return nil
+}
+
+func (x *BulkResumeStateUpdate) GetChunk() string {
+	if x != nil {
+		return x.Chunk
+	}
+	return ""
+}
+
+func (x *BulkResumeStateUpdate) GetCursor() string {
+	if x != nil {
+		return x.Cursor
+	}
+	return ""
+}
+
+func (x *BulkResumeStateUpdate) GetCompleted() bool {
+	if x != nil {
+		return x.Completed
+	}
+	return false
+}
+
+// BulkResumeStateSync is a request sent by the client to the server,
+// independently of sending log events, to manage the overall state of bulk
+// exports. It informs the server which export dates are still considered
+// active by the client, allowing the server to prune the state for all chunks
+// for dates that are no longer active and are older than the most recent
+// active date.
+type BulkResumeStateSync struct {
+	state         protoimpl.MessageState   `protogen:"open.v1"`
+	ActiveDates   []*timestamppb.Timestamp `protobuf:"bytes,1,rep,name=active_dates,json=activeDates,proto3" json:"active_dates,omitempty"` // UTC date normalized to 00:00:00.
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BulkResumeStateSync) Reset() {
+	*x = BulkResumeStateSync{}
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BulkResumeStateSync) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BulkResumeStateSync) ProtoMessage() {}
+
+func (x *BulkResumeStateSync) ProtoReflect() protoreflect.Message {
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BulkResumeStateSync.ProtoReflect.Descriptor instead.
+func (*BulkResumeStateSync) Descriptor() ([]byte, []int) {
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *BulkResumeStateSync) GetActiveDates() []*timestamppb.Timestamp {
+	if x != nil {
+		return x.ActiveDates
+	}
+	return nil
+}
+
+// AuditLogStreamResponse is sent from the server to the client over the
+// AuditLogStream. It's used on stream initiation to provide the client with
+// the necessary starting point (state) to resume exporting.
+type AuditLogStreamResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// start_date is the start date of the export, relevant on initial, back-fill
+	// export. It defaults to 90 days ago.
+	StartDate *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=start_date,json=startDate,proto3" json:"start_date,omitempty"`
+	// Types that are valid to be assigned to ResumeState:
+	//
+	//	*AuditLogStreamResponse_SearchResumeState
+	//	*AuditLogStreamResponse_BulkResumeState
+	ResumeState   isAuditLogStreamResponse_ResumeState `protobuf_oneof:"resume_state"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AuditLogStreamResponse) Reset() {
+	*x = AuditLogStreamResponse{}
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AuditLogStreamResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AuditLogStreamResponse) ProtoMessage() {}
+
+func (x *AuditLogStreamResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AuditLogStreamResponse.ProtoReflect.Descriptor instead.
+func (*AuditLogStreamResponse) Descriptor() ([]byte, []int) {
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *AuditLogStreamResponse) GetStartDate() *timestamppb.Timestamp {
+	if x != nil {
+		return x.StartDate
+	}
+	return nil
+}
+
+func (x *AuditLogStreamResponse) GetResumeState() isAuditLogStreamResponse_ResumeState {
+	if x != nil {
+		return x.ResumeState
+	}
+	return nil
+}
+
+func (x *AuditLogStreamResponse) GetSearchResumeState() *SearchResumeState {
+	if x != nil {
+		if x, ok := x.ResumeState.(*AuditLogStreamResponse_SearchResumeState); ok {
+			return x.SearchResumeState
+		}
+	}
+	return nil
+}
+
+func (x *AuditLogStreamResponse) GetBulkResumeState() *BulkResumeState {
+	if x != nil {
+		if x, ok := x.ResumeState.(*AuditLogStreamResponse_BulkResumeState); ok {
+			return x.BulkResumeState
+		}
+	}
+	return nil
+}
+
+type isAuditLogStreamResponse_ResumeState interface {
+	isAuditLogStreamResponse_ResumeState()
+}
+
+type AuditLogStreamResponse_SearchResumeState struct {
+	SearchResumeState *SearchResumeState `protobuf:"bytes,2,opt,name=search_resume_state,json=searchResumeState,proto3,oneof"` // Complete resume state for 'search' mode.
+}
+
+type AuditLogStreamResponse_BulkResumeState struct {
+	BulkResumeState *BulkResumeState `protobuf:"bytes,3,opt,name=bulk_resume_state,json=bulkResumeState,proto3,oneof"` // Complete resume state for 'bulk' mode.
+}
+
+func (*AuditLogStreamResponse_SearchResumeState) isAuditLogStreamResponse_ResumeState() {}
+
+func (*AuditLogStreamResponse_BulkResumeState) isAuditLogStreamResponse_ResumeState() {}
+
+// BulkResumeState is the complete, standalone state for bulk exports across
+// various dates. It is sent by the server to the client
+// (within `AuditLogResponse`) to allow the client to resume bulk exporting
+// accurately.
+type BulkResumeState struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Dates         []*BulkResumeDate      `protobuf:"bytes,1,rep,name=dates,proto3" json:"dates,omitempty"` // List of resume states, one for each relevant date.
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BulkResumeState) Reset() {
+	*x = BulkResumeState{}
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BulkResumeState) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BulkResumeState) ProtoMessage() {}
+
+func (x *BulkResumeState) ProtoReflect() protoreflect.Message {
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BulkResumeState.ProtoReflect.Descriptor instead.
+func (*BulkResumeState) Descriptor() ([]byte, []int) {
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *BulkResumeState) GetDates() []*BulkResumeDate {
+	if x != nil {
+		return x.Dates
+	}
+	return nil
+}
+
+// BulkResumeDate details the bulk export resume state for a *single* specific
+// date.
+type BulkResumeDate struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	Date            *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=date,proto3" json:"date,omitempty"`                                                                                                               // UTC date normalized to 00:00:00.
+	CompletedChunks []string               `protobuf:"bytes,2,rep,name=completed_chunks,json=completedChunks,proto3" json:"completed_chunks,omitempty"`                                                                  // Fully exported chunks for this date; skip on resume.
+	ChunkCursors    map[string]string      `protobuf:"bytes,3,rep,name=chunk_cursors,json=chunkCursors,proto3" json:"chunk_cursors,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // Cursors for resuming incomplete chunks (chunk_id -> cursor).
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *BulkResumeDate) Reset() {
+	*x = BulkResumeDate{}
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BulkResumeDate) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BulkResumeDate) ProtoMessage() {}
+
+func (x *BulkResumeDate) ProtoReflect() protoreflect.Message {
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BulkResumeDate.ProtoReflect.Descriptor instead.
+func (*BulkResumeDate) Descriptor() ([]byte, []int) {
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *BulkResumeDate) GetDate() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Date
+	}
+	return nil
+}
+
+func (x *BulkResumeDate) GetCompletedChunks() []string {
+	if x != nil {
+		return x.CompletedChunks
+	}
+	return nil
+}
+
+func (x *BulkResumeDate) GetChunkCursors() map[string]string {
+	if x != nil {
+		return x.ChunkCursors
+	}
+	return nil
+}
+
 // RegisterRequest is the request for Register.
 type RegisterRequest struct {
 	state     protoimpl.MessageState `protogen:"open.v1"`
@@ -751,7 +1359,7 @@ type RegisterRequest struct {
 
 func (x *RegisterRequest) Reset() {
 	*x = RegisterRequest{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[10]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -763,7 +1371,7 @@ func (x *RegisterRequest) String() string {
 func (*RegisterRequest) ProtoMessage() {}
 
 func (x *RegisterRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[10]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -776,7 +1384,7 @@ func (x *RegisterRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RegisterRequest.ProtoReflect.Descriptor instead.
 func (*RegisterRequest) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{10}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *RegisterRequest) GetHostCaPem() []byte {
@@ -802,7 +1410,7 @@ type RegisterResponse struct {
 
 func (x *RegisterResponse) Reset() {
 	*x = RegisterResponse{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[11]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -814,7 +1422,7 @@ func (x *RegisterResponse) String() string {
 func (*RegisterResponse) ProtoMessage() {}
 
 func (x *RegisterResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[11]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -827,7 +1435,7 @@ func (x *RegisterResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RegisterResponse.ProtoReflect.Descriptor instead.
 func (*RegisterResponse) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{11}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{19}
 }
 
 // ReplaceCAsRequest is the request for ReplaceCAs.
@@ -840,7 +1448,7 @@ type ReplaceCAsRequest struct {
 
 func (x *ReplaceCAsRequest) Reset() {
 	*x = ReplaceCAsRequest{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[12]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -852,7 +1460,7 @@ func (x *ReplaceCAsRequest) String() string {
 func (*ReplaceCAsRequest) ProtoMessage() {}
 
 func (x *ReplaceCAsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[12]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -865,7 +1473,7 @@ func (x *ReplaceCAsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReplaceCAsRequest.ProtoReflect.Descriptor instead.
 func (*ReplaceCAsRequest) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{12}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ReplaceCAsRequest) GetHostCaPem() [][]byte {
@@ -884,7 +1492,7 @@ type ReplaceCAsResponse struct {
 
 func (x *ReplaceCAsResponse) Reset() {
 	*x = ReplaceCAsResponse{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[13]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -896,7 +1504,7 @@ func (x *ReplaceCAsResponse) String() string {
 func (*ReplaceCAsResponse) ProtoMessage() {}
 
 func (x *ReplaceCAsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[13]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -909,7 +1517,7 @@ func (x *ReplaceCAsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReplaceCAsResponse.ProtoReflect.Descriptor instead.
 func (*ReplaceCAsResponse) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{13}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{21}
 }
 
 // AWSEventsStreamRequest is a request to send commands to the AWS importer.
@@ -930,7 +1538,7 @@ type AWSEventsStreamRequest struct {
 
 func (x *AWSEventsStreamRequest) Reset() {
 	*x = AWSEventsStreamRequest{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[14]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -942,7 +1550,7 @@ func (x *AWSEventsStreamRequest) String() string {
 func (*AWSEventsStreamRequest) ProtoMessage() {}
 
 func (x *AWSEventsStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[14]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -955,7 +1563,7 @@ func (x *AWSEventsStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AWSEventsStreamRequest.ProtoReflect.Descriptor instead.
 func (*AWSEventsStreamRequest) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{14}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *AWSEventsStreamRequest) GetOperation() isAWSEventsStreamRequest_Operation {
@@ -1028,7 +1636,7 @@ type AWSSyncOperation struct {
 
 func (x *AWSSyncOperation) Reset() {
 	*x = AWSSyncOperation{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[15]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1040,7 +1648,7 @@ func (x *AWSSyncOperation) String() string {
 func (*AWSSyncOperation) ProtoMessage() {}
 
 func (x *AWSSyncOperation) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[15]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1053,7 +1661,7 @@ func (x *AWSSyncOperation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AWSSyncOperation.ProtoReflect.Descriptor instead.
 func (*AWSSyncOperation) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{15}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{23}
 }
 
 // AWSEventsStreamResponse is the response from AWSEventsStream.
@@ -1065,7 +1673,7 @@ type AWSEventsStreamResponse struct {
 
 func (x *AWSEventsStreamResponse) Reset() {
 	*x = AWSEventsStreamResponse{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[16]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1077,7 +1685,7 @@ func (x *AWSEventsStreamResponse) String() string {
 func (*AWSEventsStreamResponse) ProtoMessage() {}
 
 func (x *AWSEventsStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[16]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1090,7 +1698,7 @@ func (x *AWSEventsStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AWSEventsStreamResponse.ProtoReflect.Descriptor instead.
 func (*AWSEventsStreamResponse) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{16}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{24}
 }
 
 // GitlabEventsStreamRequest is a request to send commands to the Gitlab importer.
@@ -1110,7 +1718,7 @@ type GitlabEventsStreamRequest struct {
 
 func (x *GitlabEventsStreamRequest) Reset() {
 	*x = GitlabEventsStreamRequest{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[17]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1122,7 +1730,7 @@ func (x *GitlabEventsStreamRequest) String() string {
 func (*GitlabEventsStreamRequest) ProtoMessage() {}
 
 func (x *GitlabEventsStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[17]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1135,7 +1743,7 @@ func (x *GitlabEventsStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitlabEventsStreamRequest.ProtoReflect.Descriptor instead.
 func (*GitlabEventsStreamRequest) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{17}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *GitlabEventsStreamRequest) GetOperation() isGitlabEventsStreamRequest_Operation {
@@ -1207,7 +1815,7 @@ type GitlabEventsStreamResponse struct {
 
 func (x *GitlabEventsStreamResponse) Reset() {
 	*x = GitlabEventsStreamResponse{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[18]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1219,7 +1827,7 @@ func (x *GitlabEventsStreamResponse) String() string {
 func (*GitlabEventsStreamResponse) ProtoMessage() {}
 
 func (x *GitlabEventsStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[18]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1232,7 +1840,7 @@ func (x *GitlabEventsStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitlabEventsStreamResponse.ProtoReflect.Descriptor instead.
 func (*GitlabEventsStreamResponse) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{18}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{26}
 }
 
 // EntraEventsStreamRequest is a request to send commands to the Gitlab importer.
@@ -1252,7 +1860,7 @@ type EntraEventsStreamRequest struct {
 
 func (x *EntraEventsStreamRequest) Reset() {
 	*x = EntraEventsStreamRequest{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[19]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1264,7 +1872,7 @@ func (x *EntraEventsStreamRequest) String() string {
 func (*EntraEventsStreamRequest) ProtoMessage() {}
 
 func (x *EntraEventsStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[19]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1277,7 +1885,7 @@ func (x *EntraEventsStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EntraEventsStreamRequest.ProtoReflect.Descriptor instead.
 func (*EntraEventsStreamRequest) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{19}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *EntraEventsStreamRequest) GetOperation() isEntraEventsStreamRequest_Operation {
@@ -1349,7 +1957,7 @@ type EntraEventsStreamResponse struct {
 
 func (x *EntraEventsStreamResponse) Reset() {
 	*x = EntraEventsStreamResponse{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[20]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1361,7 +1969,7 @@ func (x *EntraEventsStreamResponse) String() string {
 func (*EntraEventsStreamResponse) ProtoMessage() {}
 
 func (x *EntraEventsStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[20]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1374,7 +1982,7 @@ func (x *EntraEventsStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EntraEventsStreamResponse.ProtoReflect.Descriptor instead.
 func (*EntraEventsStreamResponse) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{20}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{28}
 }
 
 // AzureEventsStreamRequest is a request to send commands to the Azure importer
@@ -1392,7 +2000,7 @@ type AzureEventsStreamRequest struct {
 
 func (x *AzureEventsStreamRequest) Reset() {
 	*x = AzureEventsStreamRequest{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[21]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1404,7 +2012,7 @@ func (x *AzureEventsStreamRequest) String() string {
 func (*AzureEventsStreamRequest) ProtoMessage() {}
 
 func (x *AzureEventsStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[21]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1417,7 +2025,7 @@ func (x *AzureEventsStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AzureEventsStreamRequest.ProtoReflect.Descriptor instead.
 func (*AzureEventsStreamRequest) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{21}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *AzureEventsStreamRequest) GetOperation() isAzureEventsStreamRequest_Operation {
@@ -1490,7 +2098,7 @@ type AzureSyncOperation struct {
 
 func (x *AzureSyncOperation) Reset() {
 	*x = AzureSyncOperation{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[22]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1502,7 +2110,7 @@ func (x *AzureSyncOperation) String() string {
 func (*AzureSyncOperation) ProtoMessage() {}
 
 func (x *AzureSyncOperation) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[22]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1515,7 +2123,7 @@ func (x *AzureSyncOperation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AzureSyncOperation.ProtoReflect.Descriptor instead.
 func (*AzureSyncOperation) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{22}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{30}
 }
 
 // AzureEventsStreamResponse is a response from AzureEventsStream
@@ -1527,7 +2135,7 @@ type AzureEventsStreamResponse struct {
 
 func (x *AzureEventsStreamResponse) Reset() {
 	*x = AzureEventsStreamResponse{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[23]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1539,7 +2147,7 @@ func (x *AzureEventsStreamResponse) String() string {
 func (*AzureEventsStreamResponse) ProtoMessage() {}
 
 func (x *AzureEventsStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[23]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1552,7 +2160,7 @@ func (x *AzureEventsStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AzureEventsStreamResponse.ProtoReflect.Descriptor instead.
 func (*AzureEventsStreamResponse) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{23}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{31}
 }
 
 // NetIQEventsStreamRequest is a request to send commands to the NetIQ importer
@@ -1570,7 +2178,7 @@ type NetIQEventsStreamRequest struct {
 
 func (x *NetIQEventsStreamRequest) Reset() {
 	*x = NetIQEventsStreamRequest{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[24]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1582,7 +2190,7 @@ func (x *NetIQEventsStreamRequest) String() string {
 func (*NetIQEventsStreamRequest) ProtoMessage() {}
 
 func (x *NetIQEventsStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[24]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1595,7 +2203,7 @@ func (x *NetIQEventsStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NetIQEventsStreamRequest.ProtoReflect.Descriptor instead.
 func (*NetIQEventsStreamRequest) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{24}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *NetIQEventsStreamRequest) GetOperation() isNetIQEventsStreamRequest_Operation {
@@ -1667,7 +2275,7 @@ type NetIQSyncOperation struct {
 
 func (x *NetIQSyncOperation) Reset() {
 	*x = NetIQSyncOperation{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[25]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1679,7 +2287,7 @@ func (x *NetIQSyncOperation) String() string {
 func (*NetIQSyncOperation) ProtoMessage() {}
 
 func (x *NetIQSyncOperation) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[25]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1692,7 +2300,7 @@ func (x *NetIQSyncOperation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NetIQSyncOperation.ProtoReflect.Descriptor instead.
 func (*NetIQSyncOperation) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{25}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{33}
 }
 
 // NetIQEventsStreamResponse is a response from NetIQEventsStream
@@ -1704,7 +2312,7 @@ type NetIQEventsStreamResponse struct {
 
 func (x *NetIQEventsStreamResponse) Reset() {
 	*x = NetIQEventsStreamResponse{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[26]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1716,7 +2324,7 @@ func (x *NetIQEventsStreamResponse) String() string {
 func (*NetIQEventsStreamResponse) ProtoMessage() {}
 
 func (x *NetIQEventsStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[26]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1729,14 +2337,14 @@ func (x *NetIQEventsStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NetIQEventsStreamResponse.ProtoReflect.Descriptor instead.
 func (*NetIQEventsStreamResponse) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{26}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{34}
 }
 
 var File_accessgraph_v1alpha_access_graph_service_proto protoreflect.FileDescriptor
 
 const file_accessgraph_v1alpha_access_graph_service_proto_rawDesc = "" +
 	"\n" +
-	".accessgraph/v1alpha/access_graph_service.proto\x12\x13accessgraph.v1alpha\x1a\x1daccessgraph/v1alpha/aws.proto\x1a\x1faccessgraph/v1alpha/azure.proto\x1a\x1faccessgraph/v1alpha/entra.proto\x1a accessgraph/v1alpha/events.proto\x1a accessgraph/v1alpha/gitlab.proto\x1a\x1faccessgraph/v1alpha/graph.proto\x1a\x1faccessgraph/v1alpha/netiq.proto\x1a#accessgraph/v1alpha/resources.proto\"$\n" +
+	".accessgraph/v1alpha/access_graph_service.proto\x12\x13accessgraph.v1alpha\x1a\x1daccessgraph/v1alpha/aws.proto\x1a\x1faccessgraph/v1alpha/azure.proto\x1a\x1faccessgraph/v1alpha/entra.proto\x1a accessgraph/v1alpha/events.proto\x1a accessgraph/v1alpha/gitlab.proto\x1a\x1faccessgraph/v1alpha/graph.proto\x1a\x1faccessgraph/v1alpha/netiq.proto\x1a#accessgraph/v1alpha/resources.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a#teleport/auditlog/v1/auditlog.proto\"$\n" +
 	"\fQueryRequest\x12\x14\n" +
 	"\x05query\x18\x01 \x01(\tR\x05query\"q\n" +
 	"\rQueryResponse\x12/\n" +
@@ -1768,7 +2376,42 @@ const file_accessgraph_v1alpha_access_graph_service_proto_rawDesc = "" +
 	"\n" +
 	"AuditEvent\x12X\n" +
 	"\x13access_path_changed\x18\x01 \x01(\v2&.accessgraph.v1alpha.AccessPathChangedH\x00R\x11accessPathChangedB\a\n" +
-	"\x05event\"T\n" +
+	"\x05event\"\xa9\x01\n" +
+	"\x15AuditLogStreamRequest\x12=\n" +
+	"\x06events\x18\x01 \x01(\v2#.accessgraph.v1alpha.AuditLogEventsH\x00R\x06events\x12G\n" +
+	"\tbulk_sync\x18\x02 \x01(\v2(.accessgraph.v1alpha.BulkResumeStateSyncH\x00R\bbulkSyncB\b\n" +
+	"\x06action\"\xa2\x02\n" +
+	"\x0eAuditLogEvents\x12?\n" +
+	"\x06events\x18\x01 \x03(\v2'.teleport.auditlog.v1.EventUnstructuredR\x06events\x12X\n" +
+	"\x13search_resume_state\x18\x02 \x01(\v2&.accessgraph.v1alpha.SearchResumeStateH\x00R\x11searchResumeState\x12e\n" +
+	"\x18bulk_resume_state_update\x18\x03 \x01(\v2*.accessgraph.v1alpha.BulkResumeStateUpdateH\x00R\x15bulkResumeStateUpdateB\x0e\n" +
+	"\fresume_state\"\x98\x01\n" +
+	"\x11SearchResumeState\x12\x1b\n" +
+	"\tstart_key\x18\x01 \x01(\tR\bstartKey\x12\"\n" +
+	"\rlast_event_id\x18\x02 \x01(\tR\vlastEventId\x12B\n" +
+	"\x0flast_event_time\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\rlastEventTime\"\x93\x01\n" +
+	"\x15BulkResumeStateUpdate\x12.\n" +
+	"\x04date\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x04date\x12\x14\n" +
+	"\x05chunk\x18\x02 \x01(\tR\x05chunk\x12\x16\n" +
+	"\x06cursor\x18\x03 \x01(\tR\x06cursor\x12\x1c\n" +
+	"\tcompleted\x18\x04 \x01(\bR\tcompleted\"T\n" +
+	"\x13BulkResumeStateSync\x12=\n" +
+	"\factive_dates\x18\x01 \x03(\v2\x1a.google.protobuf.TimestampR\vactiveDates\"\x91\x02\n" +
+	"\x16AuditLogStreamResponse\x129\n" +
+	"\n" +
+	"start_date\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\tstartDate\x12X\n" +
+	"\x13search_resume_state\x18\x02 \x01(\v2&.accessgraph.v1alpha.SearchResumeStateH\x00R\x11searchResumeState\x12R\n" +
+	"\x11bulk_resume_state\x18\x03 \x01(\v2$.accessgraph.v1alpha.BulkResumeStateH\x00R\x0fbulkResumeStateB\x0e\n" +
+	"\fresume_state\"L\n" +
+	"\x0fBulkResumeState\x129\n" +
+	"\x05dates\x18\x01 \x03(\v2#.accessgraph.v1alpha.BulkResumeDateR\x05dates\"\x88\x02\n" +
+	"\x0eBulkResumeDate\x12.\n" +
+	"\x04date\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x04date\x12)\n" +
+	"\x10completed_chunks\x18\x02 \x03(\tR\x0fcompletedChunks\x12Z\n" +
+	"\rchunk_cursors\x18\x03 \x03(\v25.accessgraph.v1alpha.BulkResumeDate.ChunkCursorsEntryR\fchunkCursors\x1a?\n" +
+	"\x11ChunkCursorsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"T\n" +
 	"\x0fRegisterRequest\x12\x1e\n" +
 	"\vhost_ca_pem\x18\x01 \x01(\fR\thostCaPem\x12!\n" +
 	"\fcluster_name\x18\x02 \x01(\tR\vclusterName\"\x12\n" +
@@ -1808,12 +2451,14 @@ const file_accessgraph_v1alpha_access_graph_service_proto_rawDesc = "" +
 	"\x06delete\x18\x03 \x01(\v2&.accessgraph.v1alpha.NetIQResourceListH\x00R\x06deleteB\v\n" +
 	"\toperation\"\x14\n" +
 	"\x12NetIQSyncOperation\"\x1b\n" +
-	"\x19NetIQEventsStreamResponse2\x9b\t\n" +
+	"\x19NetIQEventsStreamResponse2\x8a\n" +
+	"\n" +
 	"\x12AccessGraphService\x12N\n" +
 	"\x05Query\x12!.accessgraph.v1alpha.QueryRequest\x1a\".accessgraph.v1alpha.QueryResponse\x12T\n" +
 	"\aGetFile\x12#.accessgraph.v1alpha.GetFileRequest\x1a$.accessgraph.v1alpha.GetFileResponse\x12e\n" +
 	"\fEventsStream\x12(.accessgraph.v1alpha.EventsStreamRequest\x1a).accessgraph.v1alpha.EventsStreamResponse(\x01\x12m\n" +
-	"\x0eEventsStreamV2\x12*.accessgraph.v1alpha.EventsStreamV2Request\x1a+.accessgraph.v1alpha.EventsStreamV2Response(\x010\x01\x12W\n" +
+	"\x0eEventsStreamV2\x12*.accessgraph.v1alpha.EventsStreamV2Request\x1a+.accessgraph.v1alpha.EventsStreamV2Response(\x010\x01\x12m\n" +
+	"\x0eAuditLogStream\x12*.accessgraph.v1alpha.AuditLogStreamRequest\x1a+.accessgraph.v1alpha.AuditLogStreamResponse(\x010\x01\x12W\n" +
 	"\bRegister\x12$.accessgraph.v1alpha.RegisterRequest\x1a%.accessgraph.v1alpha.RegisterResponse\x12]\n" +
 	"\n" +
 	"ReplaceCAs\x12&.accessgraph.v1alpha.ReplaceCAsRequest\x1a'.accessgraph.v1alpha.ReplaceCAsResponse\x12n\n" +
@@ -1835,7 +2480,7 @@ func file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP() []byte {
 	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescData
 }
 
-var file_accessgraph_v1alpha_access_graph_service_proto_msgTypes = make([]protoimpl.MessageInfo, 27)
+var file_accessgraph_v1alpha_access_graph_service_proto_msgTypes = make([]protoimpl.MessageInfo, 36)
 var file_accessgraph_v1alpha_access_graph_service_proto_goTypes = []any{
 	(*QueryRequest)(nil),               // 0: accessgraph.v1alpha.QueryRequest
 	(*QueryResponse)(nil),              // 1: accessgraph.v1alpha.QueryResponse
@@ -1847,95 +2492,122 @@ var file_accessgraph_v1alpha_access_graph_service_proto_goTypes = []any{
 	(*EventsStreamResponse)(nil),       // 7: accessgraph.v1alpha.EventsStreamResponse
 	(*EventsStreamV2Response)(nil),     // 8: accessgraph.v1alpha.EventsStreamV2Response
 	(*AuditEvent)(nil),                 // 9: accessgraph.v1alpha.AuditEvent
-	(*RegisterRequest)(nil),            // 10: accessgraph.v1alpha.RegisterRequest
-	(*RegisterResponse)(nil),           // 11: accessgraph.v1alpha.RegisterResponse
-	(*ReplaceCAsRequest)(nil),          // 12: accessgraph.v1alpha.ReplaceCAsRequest
-	(*ReplaceCAsResponse)(nil),         // 13: accessgraph.v1alpha.ReplaceCAsResponse
-	(*AWSEventsStreamRequest)(nil),     // 14: accessgraph.v1alpha.AWSEventsStreamRequest
-	(*AWSSyncOperation)(nil),           // 15: accessgraph.v1alpha.AWSSyncOperation
-	(*AWSEventsStreamResponse)(nil),    // 16: accessgraph.v1alpha.AWSEventsStreamResponse
-	(*GitlabEventsStreamRequest)(nil),  // 17: accessgraph.v1alpha.GitlabEventsStreamRequest
-	(*GitlabEventsStreamResponse)(nil), // 18: accessgraph.v1alpha.GitlabEventsStreamResponse
-	(*EntraEventsStreamRequest)(nil),   // 19: accessgraph.v1alpha.EntraEventsStreamRequest
-	(*EntraEventsStreamResponse)(nil),  // 20: accessgraph.v1alpha.EntraEventsStreamResponse
-	(*AzureEventsStreamRequest)(nil),   // 21: accessgraph.v1alpha.AzureEventsStreamRequest
-	(*AzureSyncOperation)(nil),         // 22: accessgraph.v1alpha.AzureSyncOperation
-	(*AzureEventsStreamResponse)(nil),  // 23: accessgraph.v1alpha.AzureEventsStreamResponse
-	(*NetIQEventsStreamRequest)(nil),   // 24: accessgraph.v1alpha.NetIQEventsStreamRequest
-	(*NetIQSyncOperation)(nil),         // 25: accessgraph.v1alpha.NetIQSyncOperation
-	(*NetIQEventsStreamResponse)(nil),  // 26: accessgraph.v1alpha.NetIQEventsStreamResponse
-	(*Node)(nil),                       // 27: accessgraph.v1alpha.Node
-	(*Edge)(nil),                       // 28: accessgraph.v1alpha.Edge
-	(*ResourceList)(nil),               // 29: accessgraph.v1alpha.ResourceList
-	(*ResourceHeaderList)(nil),         // 30: accessgraph.v1alpha.ResourceHeaderList
-	(*AccessListsMembers)(nil),         // 31: accessgraph.v1alpha.AccessListsMembers
-	(*ExcludeAccessListsMembers)(nil),  // 32: accessgraph.v1alpha.ExcludeAccessListsMembers
-	(*AccessPathChanged)(nil),          // 33: accessgraph.v1alpha.AccessPathChanged
-	(*AWSResourceList)(nil),            // 34: accessgraph.v1alpha.AWSResourceList
-	(*GitlabSyncOperation)(nil),        // 35: accessgraph.v1alpha.GitlabSyncOperation
-	(*GitlabResourceList)(nil),         // 36: accessgraph.v1alpha.GitlabResourceList
-	(*EntraSyncOperation)(nil),         // 37: accessgraph.v1alpha.EntraSyncOperation
-	(*EntraResourceList)(nil),          // 38: accessgraph.v1alpha.EntraResourceList
-	(*AzureResourceList)(nil),          // 39: accessgraph.v1alpha.AzureResourceList
-	(*NetIQResourceList)(nil),          // 40: accessgraph.v1alpha.NetIQResourceList
+	(*AuditLogStreamRequest)(nil),      // 10: accessgraph.v1alpha.AuditLogStreamRequest
+	(*AuditLogEvents)(nil),             // 11: accessgraph.v1alpha.AuditLogEvents
+	(*SearchResumeState)(nil),          // 12: accessgraph.v1alpha.SearchResumeState
+	(*BulkResumeStateUpdate)(nil),      // 13: accessgraph.v1alpha.BulkResumeStateUpdate
+	(*BulkResumeStateSync)(nil),        // 14: accessgraph.v1alpha.BulkResumeStateSync
+	(*AuditLogStreamResponse)(nil),     // 15: accessgraph.v1alpha.AuditLogStreamResponse
+	(*BulkResumeState)(nil),            // 16: accessgraph.v1alpha.BulkResumeState
+	(*BulkResumeDate)(nil),             // 17: accessgraph.v1alpha.BulkResumeDate
+	(*RegisterRequest)(nil),            // 18: accessgraph.v1alpha.RegisterRequest
+	(*RegisterResponse)(nil),           // 19: accessgraph.v1alpha.RegisterResponse
+	(*ReplaceCAsRequest)(nil),          // 20: accessgraph.v1alpha.ReplaceCAsRequest
+	(*ReplaceCAsResponse)(nil),         // 21: accessgraph.v1alpha.ReplaceCAsResponse
+	(*AWSEventsStreamRequest)(nil),     // 22: accessgraph.v1alpha.AWSEventsStreamRequest
+	(*AWSSyncOperation)(nil),           // 23: accessgraph.v1alpha.AWSSyncOperation
+	(*AWSEventsStreamResponse)(nil),    // 24: accessgraph.v1alpha.AWSEventsStreamResponse
+	(*GitlabEventsStreamRequest)(nil),  // 25: accessgraph.v1alpha.GitlabEventsStreamRequest
+	(*GitlabEventsStreamResponse)(nil), // 26: accessgraph.v1alpha.GitlabEventsStreamResponse
+	(*EntraEventsStreamRequest)(nil),   // 27: accessgraph.v1alpha.EntraEventsStreamRequest
+	(*EntraEventsStreamResponse)(nil),  // 28: accessgraph.v1alpha.EntraEventsStreamResponse
+	(*AzureEventsStreamRequest)(nil),   // 29: accessgraph.v1alpha.AzureEventsStreamRequest
+	(*AzureSyncOperation)(nil),         // 30: accessgraph.v1alpha.AzureSyncOperation
+	(*AzureEventsStreamResponse)(nil),  // 31: accessgraph.v1alpha.AzureEventsStreamResponse
+	(*NetIQEventsStreamRequest)(nil),   // 32: accessgraph.v1alpha.NetIQEventsStreamRequest
+	(*NetIQSyncOperation)(nil),         // 33: accessgraph.v1alpha.NetIQSyncOperation
+	(*NetIQEventsStreamResponse)(nil),  // 34: accessgraph.v1alpha.NetIQEventsStreamResponse
+	nil,                                // 35: accessgraph.v1alpha.BulkResumeDate.ChunkCursorsEntry
+	(*Node)(nil),                       // 36: accessgraph.v1alpha.Node
+	(*Edge)(nil),                       // 37: accessgraph.v1alpha.Edge
+	(*ResourceList)(nil),               // 38: accessgraph.v1alpha.ResourceList
+	(*ResourceHeaderList)(nil),         // 39: accessgraph.v1alpha.ResourceHeaderList
+	(*AccessListsMembers)(nil),         // 40: accessgraph.v1alpha.AccessListsMembers
+	(*ExcludeAccessListsMembers)(nil),  // 41: accessgraph.v1alpha.ExcludeAccessListsMembers
+	(*AccessPathChanged)(nil),          // 42: accessgraph.v1alpha.AccessPathChanged
+	(*v1.EventUnstructured)(nil),       // 43: teleport.auditlog.v1.EventUnstructured
+	(*timestamppb.Timestamp)(nil),      // 44: google.protobuf.Timestamp
+	(*AWSResourceList)(nil),            // 45: accessgraph.v1alpha.AWSResourceList
+	(*GitlabSyncOperation)(nil),        // 46: accessgraph.v1alpha.GitlabSyncOperation
+	(*GitlabResourceList)(nil),         // 47: accessgraph.v1alpha.GitlabResourceList
+	(*EntraSyncOperation)(nil),         // 48: accessgraph.v1alpha.EntraSyncOperation
+	(*EntraResourceList)(nil),          // 49: accessgraph.v1alpha.EntraResourceList
+	(*AzureResourceList)(nil),          // 50: accessgraph.v1alpha.AzureResourceList
+	(*NetIQResourceList)(nil),          // 51: accessgraph.v1alpha.NetIQResourceList
 }
 var file_accessgraph_v1alpha_access_graph_service_proto_depIdxs = []int32{
-	27, // 0: accessgraph.v1alpha.QueryResponse.nodes:type_name -> accessgraph.v1alpha.Node
-	28, // 1: accessgraph.v1alpha.QueryResponse.edges:type_name -> accessgraph.v1alpha.Edge
+	36, // 0: accessgraph.v1alpha.QueryResponse.nodes:type_name -> accessgraph.v1alpha.Node
+	37, // 1: accessgraph.v1alpha.QueryResponse.edges:type_name -> accessgraph.v1alpha.Edge
 	6,  // 2: accessgraph.v1alpha.EventsStreamRequest.sync:type_name -> accessgraph.v1alpha.SyncOperation
-	29, // 3: accessgraph.v1alpha.EventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.ResourceList
-	30, // 4: accessgraph.v1alpha.EventsStreamRequest.delete:type_name -> accessgraph.v1alpha.ResourceHeaderList
-	31, // 5: accessgraph.v1alpha.EventsStreamRequest.access_lists_members:type_name -> accessgraph.v1alpha.AccessListsMembers
-	32, // 6: accessgraph.v1alpha.EventsStreamRequest.exclude_access_list_members:type_name -> accessgraph.v1alpha.ExcludeAccessListsMembers
+	38, // 3: accessgraph.v1alpha.EventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.ResourceList
+	39, // 4: accessgraph.v1alpha.EventsStreamRequest.delete:type_name -> accessgraph.v1alpha.ResourceHeaderList
+	40, // 5: accessgraph.v1alpha.EventsStreamRequest.access_lists_members:type_name -> accessgraph.v1alpha.AccessListsMembers
+	41, // 6: accessgraph.v1alpha.EventsStreamRequest.exclude_access_list_members:type_name -> accessgraph.v1alpha.ExcludeAccessListsMembers
 	6,  // 7: accessgraph.v1alpha.EventsStreamV2Request.sync:type_name -> accessgraph.v1alpha.SyncOperation
-	29, // 8: accessgraph.v1alpha.EventsStreamV2Request.upsert:type_name -> accessgraph.v1alpha.ResourceList
-	30, // 9: accessgraph.v1alpha.EventsStreamV2Request.delete:type_name -> accessgraph.v1alpha.ResourceHeaderList
-	31, // 10: accessgraph.v1alpha.EventsStreamV2Request.access_lists_members:type_name -> accessgraph.v1alpha.AccessListsMembers
-	32, // 11: accessgraph.v1alpha.EventsStreamV2Request.exclude_access_list_members:type_name -> accessgraph.v1alpha.ExcludeAccessListsMembers
+	38, // 8: accessgraph.v1alpha.EventsStreamV2Request.upsert:type_name -> accessgraph.v1alpha.ResourceList
+	39, // 9: accessgraph.v1alpha.EventsStreamV2Request.delete:type_name -> accessgraph.v1alpha.ResourceHeaderList
+	40, // 10: accessgraph.v1alpha.EventsStreamV2Request.access_lists_members:type_name -> accessgraph.v1alpha.AccessListsMembers
+	41, // 11: accessgraph.v1alpha.EventsStreamV2Request.exclude_access_list_members:type_name -> accessgraph.v1alpha.ExcludeAccessListsMembers
 	9,  // 12: accessgraph.v1alpha.EventsStreamV2Response.event:type_name -> accessgraph.v1alpha.AuditEvent
-	33, // 13: accessgraph.v1alpha.AuditEvent.access_path_changed:type_name -> accessgraph.v1alpha.AccessPathChanged
-	15, // 14: accessgraph.v1alpha.AWSEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.AWSSyncOperation
-	34, // 15: accessgraph.v1alpha.AWSEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.AWSResourceList
-	34, // 16: accessgraph.v1alpha.AWSEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.AWSResourceList
-	35, // 17: accessgraph.v1alpha.GitlabEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.GitlabSyncOperation
-	36, // 18: accessgraph.v1alpha.GitlabEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.GitlabResourceList
-	36, // 19: accessgraph.v1alpha.GitlabEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.GitlabResourceList
-	37, // 20: accessgraph.v1alpha.EntraEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.EntraSyncOperation
-	38, // 21: accessgraph.v1alpha.EntraEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.EntraResourceList
-	38, // 22: accessgraph.v1alpha.EntraEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.EntraResourceList
-	22, // 23: accessgraph.v1alpha.AzureEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.AzureSyncOperation
-	39, // 24: accessgraph.v1alpha.AzureEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.AzureResourceList
-	39, // 25: accessgraph.v1alpha.AzureEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.AzureResourceList
-	25, // 26: accessgraph.v1alpha.NetIQEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.NetIQSyncOperation
-	40, // 27: accessgraph.v1alpha.NetIQEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.NetIQResourceList
-	40, // 28: accessgraph.v1alpha.NetIQEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.NetIQResourceList
-	0,  // 29: accessgraph.v1alpha.AccessGraphService.Query:input_type -> accessgraph.v1alpha.QueryRequest
-	2,  // 30: accessgraph.v1alpha.AccessGraphService.GetFile:input_type -> accessgraph.v1alpha.GetFileRequest
-	4,  // 31: accessgraph.v1alpha.AccessGraphService.EventsStream:input_type -> accessgraph.v1alpha.EventsStreamRequest
-	5,  // 32: accessgraph.v1alpha.AccessGraphService.EventsStreamV2:input_type -> accessgraph.v1alpha.EventsStreamV2Request
-	10, // 33: accessgraph.v1alpha.AccessGraphService.Register:input_type -> accessgraph.v1alpha.RegisterRequest
-	12, // 34: accessgraph.v1alpha.AccessGraphService.ReplaceCAs:input_type -> accessgraph.v1alpha.ReplaceCAsRequest
-	14, // 35: accessgraph.v1alpha.AccessGraphService.AWSEventsStream:input_type -> accessgraph.v1alpha.AWSEventsStreamRequest
-	17, // 36: accessgraph.v1alpha.AccessGraphService.GitlabEventsStream:input_type -> accessgraph.v1alpha.GitlabEventsStreamRequest
-	19, // 37: accessgraph.v1alpha.AccessGraphService.EntraEventsStream:input_type -> accessgraph.v1alpha.EntraEventsStreamRequest
-	21, // 38: accessgraph.v1alpha.AccessGraphService.AzureEventsStream:input_type -> accessgraph.v1alpha.AzureEventsStreamRequest
-	24, // 39: accessgraph.v1alpha.AccessGraphService.NetIQEventsStream:input_type -> accessgraph.v1alpha.NetIQEventsStreamRequest
-	1,  // 40: accessgraph.v1alpha.AccessGraphService.Query:output_type -> accessgraph.v1alpha.QueryResponse
-	3,  // 41: accessgraph.v1alpha.AccessGraphService.GetFile:output_type -> accessgraph.v1alpha.GetFileResponse
-	7,  // 42: accessgraph.v1alpha.AccessGraphService.EventsStream:output_type -> accessgraph.v1alpha.EventsStreamResponse
-	8,  // 43: accessgraph.v1alpha.AccessGraphService.EventsStreamV2:output_type -> accessgraph.v1alpha.EventsStreamV2Response
-	11, // 44: accessgraph.v1alpha.AccessGraphService.Register:output_type -> accessgraph.v1alpha.RegisterResponse
-	13, // 45: accessgraph.v1alpha.AccessGraphService.ReplaceCAs:output_type -> accessgraph.v1alpha.ReplaceCAsResponse
-	16, // 46: accessgraph.v1alpha.AccessGraphService.AWSEventsStream:output_type -> accessgraph.v1alpha.AWSEventsStreamResponse
-	18, // 47: accessgraph.v1alpha.AccessGraphService.GitlabEventsStream:output_type -> accessgraph.v1alpha.GitlabEventsStreamResponse
-	20, // 48: accessgraph.v1alpha.AccessGraphService.EntraEventsStream:output_type -> accessgraph.v1alpha.EntraEventsStreamResponse
-	23, // 49: accessgraph.v1alpha.AccessGraphService.AzureEventsStream:output_type -> accessgraph.v1alpha.AzureEventsStreamResponse
-	26, // 50: accessgraph.v1alpha.AccessGraphService.NetIQEventsStream:output_type -> accessgraph.v1alpha.NetIQEventsStreamResponse
-	40, // [40:51] is the sub-list for method output_type
-	29, // [29:40] is the sub-list for method input_type
-	29, // [29:29] is the sub-list for extension type_name
-	29, // [29:29] is the sub-list for extension extendee
-	0,  // [0:29] is the sub-list for field type_name
+	42, // 13: accessgraph.v1alpha.AuditEvent.access_path_changed:type_name -> accessgraph.v1alpha.AccessPathChanged
+	11, // 14: accessgraph.v1alpha.AuditLogStreamRequest.events:type_name -> accessgraph.v1alpha.AuditLogEvents
+	14, // 15: accessgraph.v1alpha.AuditLogStreamRequest.bulk_sync:type_name -> accessgraph.v1alpha.BulkResumeStateSync
+	43, // 16: accessgraph.v1alpha.AuditLogEvents.events:type_name -> teleport.auditlog.v1.EventUnstructured
+	12, // 17: accessgraph.v1alpha.AuditLogEvents.search_resume_state:type_name -> accessgraph.v1alpha.SearchResumeState
+	13, // 18: accessgraph.v1alpha.AuditLogEvents.bulk_resume_state_update:type_name -> accessgraph.v1alpha.BulkResumeStateUpdate
+	44, // 19: accessgraph.v1alpha.SearchResumeState.last_event_time:type_name -> google.protobuf.Timestamp
+	44, // 20: accessgraph.v1alpha.BulkResumeStateUpdate.date:type_name -> google.protobuf.Timestamp
+	44, // 21: accessgraph.v1alpha.BulkResumeStateSync.active_dates:type_name -> google.protobuf.Timestamp
+	44, // 22: accessgraph.v1alpha.AuditLogStreamResponse.start_date:type_name -> google.protobuf.Timestamp
+	12, // 23: accessgraph.v1alpha.AuditLogStreamResponse.search_resume_state:type_name -> accessgraph.v1alpha.SearchResumeState
+	16, // 24: accessgraph.v1alpha.AuditLogStreamResponse.bulk_resume_state:type_name -> accessgraph.v1alpha.BulkResumeState
+	17, // 25: accessgraph.v1alpha.BulkResumeState.dates:type_name -> accessgraph.v1alpha.BulkResumeDate
+	44, // 26: accessgraph.v1alpha.BulkResumeDate.date:type_name -> google.protobuf.Timestamp
+	35, // 27: accessgraph.v1alpha.BulkResumeDate.chunk_cursors:type_name -> accessgraph.v1alpha.BulkResumeDate.ChunkCursorsEntry
+	23, // 28: accessgraph.v1alpha.AWSEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.AWSSyncOperation
+	45, // 29: accessgraph.v1alpha.AWSEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.AWSResourceList
+	45, // 30: accessgraph.v1alpha.AWSEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.AWSResourceList
+	46, // 31: accessgraph.v1alpha.GitlabEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.GitlabSyncOperation
+	47, // 32: accessgraph.v1alpha.GitlabEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.GitlabResourceList
+	47, // 33: accessgraph.v1alpha.GitlabEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.GitlabResourceList
+	48, // 34: accessgraph.v1alpha.EntraEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.EntraSyncOperation
+	49, // 35: accessgraph.v1alpha.EntraEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.EntraResourceList
+	49, // 36: accessgraph.v1alpha.EntraEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.EntraResourceList
+	30, // 37: accessgraph.v1alpha.AzureEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.AzureSyncOperation
+	50, // 38: accessgraph.v1alpha.AzureEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.AzureResourceList
+	50, // 39: accessgraph.v1alpha.AzureEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.AzureResourceList
+	33, // 40: accessgraph.v1alpha.NetIQEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.NetIQSyncOperation
+	51, // 41: accessgraph.v1alpha.NetIQEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.NetIQResourceList
+	51, // 42: accessgraph.v1alpha.NetIQEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.NetIQResourceList
+	0,  // 43: accessgraph.v1alpha.AccessGraphService.Query:input_type -> accessgraph.v1alpha.QueryRequest
+	2,  // 44: accessgraph.v1alpha.AccessGraphService.GetFile:input_type -> accessgraph.v1alpha.GetFileRequest
+	4,  // 45: accessgraph.v1alpha.AccessGraphService.EventsStream:input_type -> accessgraph.v1alpha.EventsStreamRequest
+	5,  // 46: accessgraph.v1alpha.AccessGraphService.EventsStreamV2:input_type -> accessgraph.v1alpha.EventsStreamV2Request
+	10, // 47: accessgraph.v1alpha.AccessGraphService.AuditLogStream:input_type -> accessgraph.v1alpha.AuditLogStreamRequest
+	18, // 48: accessgraph.v1alpha.AccessGraphService.Register:input_type -> accessgraph.v1alpha.RegisterRequest
+	20, // 49: accessgraph.v1alpha.AccessGraphService.ReplaceCAs:input_type -> accessgraph.v1alpha.ReplaceCAsRequest
+	22, // 50: accessgraph.v1alpha.AccessGraphService.AWSEventsStream:input_type -> accessgraph.v1alpha.AWSEventsStreamRequest
+	25, // 51: accessgraph.v1alpha.AccessGraphService.GitlabEventsStream:input_type -> accessgraph.v1alpha.GitlabEventsStreamRequest
+	27, // 52: accessgraph.v1alpha.AccessGraphService.EntraEventsStream:input_type -> accessgraph.v1alpha.EntraEventsStreamRequest
+	29, // 53: accessgraph.v1alpha.AccessGraphService.AzureEventsStream:input_type -> accessgraph.v1alpha.AzureEventsStreamRequest
+	32, // 54: accessgraph.v1alpha.AccessGraphService.NetIQEventsStream:input_type -> accessgraph.v1alpha.NetIQEventsStreamRequest
+	1,  // 55: accessgraph.v1alpha.AccessGraphService.Query:output_type -> accessgraph.v1alpha.QueryResponse
+	3,  // 56: accessgraph.v1alpha.AccessGraphService.GetFile:output_type -> accessgraph.v1alpha.GetFileResponse
+	7,  // 57: accessgraph.v1alpha.AccessGraphService.EventsStream:output_type -> accessgraph.v1alpha.EventsStreamResponse
+	8,  // 58: accessgraph.v1alpha.AccessGraphService.EventsStreamV2:output_type -> accessgraph.v1alpha.EventsStreamV2Response
+	15, // 59: accessgraph.v1alpha.AccessGraphService.AuditLogStream:output_type -> accessgraph.v1alpha.AuditLogStreamResponse
+	19, // 60: accessgraph.v1alpha.AccessGraphService.Register:output_type -> accessgraph.v1alpha.RegisterResponse
+	21, // 61: accessgraph.v1alpha.AccessGraphService.ReplaceCAs:output_type -> accessgraph.v1alpha.ReplaceCAsResponse
+	24, // 62: accessgraph.v1alpha.AccessGraphService.AWSEventsStream:output_type -> accessgraph.v1alpha.AWSEventsStreamResponse
+	26, // 63: accessgraph.v1alpha.AccessGraphService.GitlabEventsStream:output_type -> accessgraph.v1alpha.GitlabEventsStreamResponse
+	28, // 64: accessgraph.v1alpha.AccessGraphService.EntraEventsStream:output_type -> accessgraph.v1alpha.EntraEventsStreamResponse
+	31, // 65: accessgraph.v1alpha.AccessGraphService.AzureEventsStream:output_type -> accessgraph.v1alpha.AzureEventsStreamResponse
+	34, // 66: accessgraph.v1alpha.AccessGraphService.NetIQEventsStream:output_type -> accessgraph.v1alpha.NetIQEventsStreamResponse
+	55, // [55:67] is the sub-list for method output_type
+	43, // [43:55] is the sub-list for method input_type
+	43, // [43:43] is the sub-list for extension type_name
+	43, // [43:43] is the sub-list for extension extendee
+	0,  // [0:43] is the sub-list for field type_name
 }
 
 func init() { file_accessgraph_v1alpha_access_graph_service_proto_init() }
@@ -1971,27 +2643,39 @@ func file_accessgraph_v1alpha_access_graph_service_proto_init() {
 	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[9].OneofWrappers = []any{
 		(*AuditEvent_AccessPathChanged)(nil),
 	}
-	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[14].OneofWrappers = []any{
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[10].OneofWrappers = []any{
+		(*AuditLogStreamRequest_Events)(nil),
+		(*AuditLogStreamRequest_BulkSync)(nil),
+	}
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[11].OneofWrappers = []any{
+		(*AuditLogEvents_SearchResumeState)(nil),
+		(*AuditLogEvents_BulkResumeStateUpdate)(nil),
+	}
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[15].OneofWrappers = []any{
+		(*AuditLogStreamResponse_SearchResumeState)(nil),
+		(*AuditLogStreamResponse_BulkResumeState)(nil),
+	}
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[22].OneofWrappers = []any{
 		(*AWSEventsStreamRequest_Sync)(nil),
 		(*AWSEventsStreamRequest_Upsert)(nil),
 		(*AWSEventsStreamRequest_Delete)(nil),
 	}
-	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[17].OneofWrappers = []any{
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[25].OneofWrappers = []any{
 		(*GitlabEventsStreamRequest_Sync)(nil),
 		(*GitlabEventsStreamRequest_Upsert)(nil),
 		(*GitlabEventsStreamRequest_Delete)(nil),
 	}
-	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[19].OneofWrappers = []any{
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[27].OneofWrappers = []any{
 		(*EntraEventsStreamRequest_Sync)(nil),
 		(*EntraEventsStreamRequest_Upsert)(nil),
 		(*EntraEventsStreamRequest_Delete)(nil),
 	}
-	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[21].OneofWrappers = []any{
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[29].OneofWrappers = []any{
 		(*AzureEventsStreamRequest_Sync)(nil),
 		(*AzureEventsStreamRequest_Upsert)(nil),
 		(*AzureEventsStreamRequest_Delete)(nil),
 	}
-	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[24].OneofWrappers = []any{
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[32].OneofWrappers = []any{
 		(*NetIQEventsStreamRequest_Sync)(nil),
 		(*NetIQEventsStreamRequest_Upsert)(nil),
 		(*NetIQEventsStreamRequest_Delete)(nil),
@@ -2002,7 +2686,7 @@ func file_accessgraph_v1alpha_access_graph_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_accessgraph_v1alpha_access_graph_service_proto_rawDesc), len(file_accessgraph_v1alpha_access_graph_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   27,
+			NumMessages:   36,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/proto/go/accessgraph/v1alpha/access_graph_service.pb.go
+++ b/gen/proto/go/accessgraph/v1alpha/access_graph_service.pb.go
@@ -27,6 +27,7 @@ import (
 	v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/auditlog/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	emptypb "google.golang.org/protobuf/types/known/emptypb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
@@ -741,34 +742,44 @@ type AuditEvent_AccessPathChanged struct {
 func (*AuditEvent_AccessPathChanged) isAuditEvent_Event() {}
 
 // AuditLogStreamRequest is sent from the client to the server over the
-// AuditLogStream. It contains different actions related to sending audit logs
-// in unstructured events and managing resume state.
+// bi-directional AuditLogStream. It encapsulates distinct client actions for
+// configuring the export stream, sending batches of audit log events, and
+// managing the persistent resume state maintained by the server.
 //
-// The message uses a `oneof` to distinguish between two primary client actions:
-//  1. Sending a batch of audit log events (`events`): This includes the actual
-//     log data (unstructured format) and the corresponding resume state
-//     information relevant to the event source ('search' or 'bulk').
-//  2. Synchronizing bulk export resume state (`bulk_sync`): This is a command
-//     sent separately from log events, instructing the server to clean up state
-//     related to older, completed bulk export dates.
+// The message uses a `oneof` payload to represent one of three distinct actions:
 //
-// Behavior and Constraints
-//   - Direction: Client -> Server.
-//   - Stream Consistency: When sending the `events` payload, a single gRPC stream
-//     connection MUST consistently send *either only* 'search' type events
-//     *or only* 'bulk' type events. Mixing event types within the `events`
-//     payload on the same stream is not permitted.
-//   - State Management: Resume state sent with `events` allows the server to
-//     track the client's progress. The `bulk_sync` provides an explicit
-//     mechanism for purging old, completed dates of bulk exporting from the
-//     resume state.
-//   - Stream Evolution: While the overall system might support upgrading the
-//     event type processed from 'search' to 'bulk' handling across
-//     *different* connections or restarts, downgrading behavior is undefined.
+//  1. Configuration (`config`): First message on (re)connect. Client proposes
+//     `AuditLogConfig`. Server validates against its persisted state for the client
+//     identity. Initial server response confirms the effective config (which may
+//     be the proposed, an inferred default, or the existing persisted one).
+//     Irreconcilable conflicts (e.g., invalid start date) typically result in the
+//     server logging an error, using the persisted config, and signaling this outcome.
+//
+//  2. Event Batch (`events`): Sends a batch of audit logs (`AuditLogEvents`) in an
+//     unstructured format. Each batch must also include the corresponding
+//     `resume_state` information ('search' or 'bulk' type) reflecting the client's
+//     processing progress for that specific event source type up to the included events.
+//     This allows the server to persistently track the client's progress.
+//
+//  3. Bulk State Synchronization (`bulk_sync`): Sends `BulkResumeStateSync` command,
+//     separate from event batches, to request that the server prune state for past
+//     dates that are fully completed.
+//
+// Behavior and Constraints:
+//   - Direction: Client -> Server only.
+//   - Initial Message: First message on stream MUST be `config`.
+//   - Stream State Consistency: `resume_state` with `events` corresponds to
+//     'search' or 'bulk' tracking mode. While primarily one mode operates,
+//     upgrades 'search' -> 'bulk' may be possible; downgrading 'bulk' -> 'search'
+//     is not permitted per client identity.
+//   - State Management:
+//   - `events` includes `resume_state` for persistent progress tracking.
+//   - `bulk_sync` allows purging state for old, completed bulk export dates.
 type AuditLogStreamRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Action:
 	//
+	//	*AuditLogStreamRequest_Config
 	//	*AuditLogStreamRequest_Events
 	//	*AuditLogStreamRequest_BulkSync
 	Action        isAuditLogStreamRequest_Action `protobuf_oneof:"action"`
@@ -813,6 +824,15 @@ func (x *AuditLogStreamRequest) GetAction() isAuditLogStreamRequest_Action {
 	return nil
 }
 
+func (x *AuditLogStreamRequest) GetConfig() *AuditLogConfig {
+	if x != nil {
+		if x, ok := x.Action.(*AuditLogStreamRequest_Config); ok {
+			return x.Config
+		}
+	}
+	return nil
+}
+
 func (x *AuditLogStreamRequest) GetEvents() *AuditLogEvents {
 	if x != nil {
 		if x, ok := x.Action.(*AuditLogStreamRequest_Events); ok {
@@ -835,17 +855,68 @@ type isAuditLogStreamRequest_Action interface {
 	isAuditLogStreamRequest_Action()
 }
 
+type AuditLogStreamRequest_Config struct {
+	Config *AuditLogConfig `protobuf:"bytes,1,opt,name=config,proto3,oneof"` // Export configuration, e.g. start date. // Config negatiation phase
+}
+
 type AuditLogStreamRequest_Events struct {
-	Events *AuditLogEvents `protobuf:"bytes,1,opt,name=events,proto3,oneof"` // Batch of audit log events and resume state.
+	Events *AuditLogEvents `protobuf:"bytes,2,opt,name=events,proto3,oneof"` // Batch of audit log events and resume state.
 }
 
 type AuditLogStreamRequest_BulkSync struct {
-	BulkSync *BulkResumeStateSync `protobuf:"bytes,2,opt,name=bulk_sync,json=bulkSync,proto3,oneof"` // Command to prune server-side bulk export state.
+	BulkSync *BulkResumeStateSync `protobuf:"bytes,3,opt,name=bulk_sync,json=bulkSync,proto3,oneof"` // Command to prune server-side bulk export state.
 }
+
+func (*AuditLogStreamRequest_Config) isAuditLogStreamRequest_Action() {}
 
 func (*AuditLogStreamRequest_Events) isAuditLogStreamRequest_Action() {}
 
 func (*AuditLogStreamRequest_BulkSync) isAuditLogStreamRequest_Action() {}
+
+// AuditLogConfig is the configuration for exporting audit logs.
+type AuditLogConfig struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	StartDate     *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=start_date,json=startDate,proto3" json:"start_date,omitempty"` // Start date for exporting audit logs.
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AuditLogConfig) Reset() {
+	*x = AuditLogConfig{}
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AuditLogConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AuditLogConfig) ProtoMessage() {}
+
+func (x *AuditLogConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AuditLogConfig.ProtoReflect.Descriptor instead.
+func (*AuditLogConfig) Descriptor() ([]byte, []int) {
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *AuditLogConfig) GetStartDate() *timestamppb.Timestamp {
+	if x != nil {
+		return x.StartDate
+	}
+	return nil
+}
 
 // AuditLogEvents bundles a batch of unstructured audit log events with the
 // appropriate resume state information for the type of events being sent
@@ -865,7 +936,7 @@ type AuditLogEvents struct {
 
 func (x *AuditLogEvents) Reset() {
 	*x = AuditLogEvents{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[11]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -877,7 +948,7 @@ func (x *AuditLogEvents) String() string {
 func (*AuditLogEvents) ProtoMessage() {}
 
 func (x *AuditLogEvents) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[11]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -890,7 +961,7 @@ func (x *AuditLogEvents) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuditLogEvents.ProtoReflect.Descriptor instead.
 func (*AuditLogEvents) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{11}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *AuditLogEvents) GetEvents() []*v1.EventUnstructured {
@@ -970,7 +1041,7 @@ type SearchResumeState struct {
 
 func (x *SearchResumeState) Reset() {
 	*x = SearchResumeState{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[12]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -982,7 +1053,7 @@ func (x *SearchResumeState) String() string {
 func (*SearchResumeState) ProtoMessage() {}
 
 func (x *SearchResumeState) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[12]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -995,7 +1066,7 @@ func (x *SearchResumeState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SearchResumeState.ProtoReflect.Descriptor instead.
 func (*SearchResumeState) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{12}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *SearchResumeState) GetStartKey() string {
@@ -1035,7 +1106,7 @@ type BulkResumeStateUpdate struct {
 
 func (x *BulkResumeStateUpdate) Reset() {
 	*x = BulkResumeStateUpdate{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[13]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1047,7 +1118,7 @@ func (x *BulkResumeStateUpdate) String() string {
 func (*BulkResumeStateUpdate) ProtoMessage() {}
 
 func (x *BulkResumeStateUpdate) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[13]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1060,7 +1131,7 @@ func (x *BulkResumeStateUpdate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BulkResumeStateUpdate.ProtoReflect.Descriptor instead.
 func (*BulkResumeStateUpdate) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{13}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *BulkResumeStateUpdate) GetDate() *timestamppb.Timestamp {
@@ -1106,7 +1177,7 @@ type BulkResumeStateSync struct {
 
 func (x *BulkResumeStateSync) Reset() {
 	*x = BulkResumeStateSync{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[14]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1118,7 +1189,7 @@ func (x *BulkResumeStateSync) String() string {
 func (*BulkResumeStateSync) ProtoMessage() {}
 
 func (x *BulkResumeStateSync) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[14]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1131,7 +1202,7 @@ func (x *BulkResumeStateSync) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BulkResumeStateSync.ProtoReflect.Descriptor instead.
 func (*BulkResumeStateSync) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{14}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *BulkResumeStateSync) GetActiveDates() []*timestamppb.Timestamp {
@@ -1142,25 +1213,26 @@ func (x *BulkResumeStateSync) GetActiveDates() []*timestamppb.Timestamp {
 }
 
 // AuditLogStreamResponse is sent from the server to the client over the
-// AuditLogStream. It's used on stream initiation to provide the client with
-// the necessary starting point (state) to resume exporting.
+// AuditLogStream. It conveys state information during the export process.
+// NOTE: During stream initiation, the server MUST send two responses sequentially:
+// 1. The effective `AuditLogConfig`.
+// 2. The starting resume state (`SearchResumeState`, `BulkResumeState`, or Empty` if none).
 type AuditLogStreamResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// start_date is the start date of the export, relevant on initial, back-fill
-	// export. It defaults to 90 days ago.
-	StartDate *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=start_date,json=startDate,proto3" json:"start_date,omitempty"`
-	// Types that are valid to be assigned to ResumeState:
+	// Types that are valid to be assigned to State:
 	//
+	//	*AuditLogStreamResponse_AuditLogConfig
+	//	*AuditLogStreamResponse_NoResumeState
 	//	*AuditLogStreamResponse_SearchResumeState
 	//	*AuditLogStreamResponse_BulkResumeState
-	ResumeState   isAuditLogStreamResponse_ResumeState `protobuf_oneof:"resume_state"`
+	State         isAuditLogStreamResponse_State `protobuf_oneof:"state"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *AuditLogStreamResponse) Reset() {
 	*x = AuditLogStreamResponse{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[15]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1172,7 +1244,7 @@ func (x *AuditLogStreamResponse) String() string {
 func (*AuditLogStreamResponse) ProtoMessage() {}
 
 func (x *AuditLogStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[15]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1185,26 +1257,37 @@ func (x *AuditLogStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuditLogStreamResponse.ProtoReflect.Descriptor instead.
 func (*AuditLogStreamResponse) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{15}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{16}
 }
 
-func (x *AuditLogStreamResponse) GetStartDate() *timestamppb.Timestamp {
+func (x *AuditLogStreamResponse) GetState() isAuditLogStreamResponse_State {
 	if x != nil {
-		return x.StartDate
+		return x.State
 	}
 	return nil
 }
 
-func (x *AuditLogStreamResponse) GetResumeState() isAuditLogStreamResponse_ResumeState {
+func (x *AuditLogStreamResponse) GetAuditLogConfig() *AuditLogConfig {
 	if x != nil {
-		return x.ResumeState
+		if x, ok := x.State.(*AuditLogStreamResponse_AuditLogConfig); ok {
+			return x.AuditLogConfig
+		}
+	}
+	return nil
+}
+
+func (x *AuditLogStreamResponse) GetNoResumeState() *emptypb.Empty {
+	if x != nil {
+		if x, ok := x.State.(*AuditLogStreamResponse_NoResumeState); ok {
+			return x.NoResumeState
+		}
 	}
 	return nil
 }
 
 func (x *AuditLogStreamResponse) GetSearchResumeState() *SearchResumeState {
 	if x != nil {
-		if x, ok := x.ResumeState.(*AuditLogStreamResponse_SearchResumeState); ok {
+		if x, ok := x.State.(*AuditLogStreamResponse_SearchResumeState); ok {
 			return x.SearchResumeState
 		}
 	}
@@ -1213,28 +1296,40 @@ func (x *AuditLogStreamResponse) GetSearchResumeState() *SearchResumeState {
 
 func (x *AuditLogStreamResponse) GetBulkResumeState() *BulkResumeState {
 	if x != nil {
-		if x, ok := x.ResumeState.(*AuditLogStreamResponse_BulkResumeState); ok {
+		if x, ok := x.State.(*AuditLogStreamResponse_BulkResumeState); ok {
 			return x.BulkResumeState
 		}
 	}
 	return nil
 }
 
-type isAuditLogStreamResponse_ResumeState interface {
-	isAuditLogStreamResponse_ResumeState()
+type isAuditLogStreamResponse_State interface {
+	isAuditLogStreamResponse_State()
+}
+
+type AuditLogStreamResponse_AuditLogConfig struct {
+	AuditLogConfig *AuditLogConfig `protobuf:"bytes,1,opt,name=audit_log_config,json=auditLogConfig,proto3,oneof"` // Effective, negotiated configuration.
+}
+
+type AuditLogStreamResponse_NoResumeState struct {
+	NoResumeState *emptypb.Empty `protobuf:"bytes,2,opt,name=no_resume_state,json=noResumeState,proto3,oneof"` // No resume state available.
 }
 
 type AuditLogStreamResponse_SearchResumeState struct {
-	SearchResumeState *SearchResumeState `protobuf:"bytes,2,opt,name=search_resume_state,json=searchResumeState,proto3,oneof"` // Complete resume state for 'search' mode.
+	SearchResumeState *SearchResumeState `protobuf:"bytes,3,opt,name=search_resume_state,json=searchResumeState,proto3,oneof"` // Complete resume state for 'search' mode.
 }
 
 type AuditLogStreamResponse_BulkResumeState struct {
-	BulkResumeState *BulkResumeState `protobuf:"bytes,3,opt,name=bulk_resume_state,json=bulkResumeState,proto3,oneof"` // Complete resume state for 'bulk' mode.
+	BulkResumeState *BulkResumeState `protobuf:"bytes,4,opt,name=bulk_resume_state,json=bulkResumeState,proto3,oneof"` // Complete resume state for 'bulk' mode.
 }
 
-func (*AuditLogStreamResponse_SearchResumeState) isAuditLogStreamResponse_ResumeState() {}
+func (*AuditLogStreamResponse_AuditLogConfig) isAuditLogStreamResponse_State() {}
 
-func (*AuditLogStreamResponse_BulkResumeState) isAuditLogStreamResponse_ResumeState() {}
+func (*AuditLogStreamResponse_NoResumeState) isAuditLogStreamResponse_State() {}
+
+func (*AuditLogStreamResponse_SearchResumeState) isAuditLogStreamResponse_State() {}
+
+func (*AuditLogStreamResponse_BulkResumeState) isAuditLogStreamResponse_State() {}
 
 // BulkResumeState is the complete, standalone state for bulk exports across
 // various dates. It is sent by the server to the client
@@ -1242,14 +1337,14 @@ func (*AuditLogStreamResponse_BulkResumeState) isAuditLogStreamResponse_ResumeSt
 // accurately.
 type BulkResumeState struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Dates         []*BulkResumeDate      `protobuf:"bytes,1,rep,name=dates,proto3" json:"dates,omitempty"` // List of resume states, one for each relevant date.
+	Dates         []*BulkResumeDate      `protobuf:"bytes,2,rep,name=dates,proto3" json:"dates,omitempty"` // List of resume states, one for each relevant date.
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *BulkResumeState) Reset() {
 	*x = BulkResumeState{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[16]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1261,7 +1356,7 @@ func (x *BulkResumeState) String() string {
 func (*BulkResumeState) ProtoMessage() {}
 
 func (x *BulkResumeState) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[16]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1274,7 +1369,7 @@ func (x *BulkResumeState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BulkResumeState.ProtoReflect.Descriptor instead.
 func (*BulkResumeState) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{16}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *BulkResumeState) GetDates() []*BulkResumeDate {
@@ -1297,7 +1392,7 @@ type BulkResumeDate struct {
 
 func (x *BulkResumeDate) Reset() {
 	*x = BulkResumeDate{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[17]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1309,7 +1404,7 @@ func (x *BulkResumeDate) String() string {
 func (*BulkResumeDate) ProtoMessage() {}
 
 func (x *BulkResumeDate) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[17]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1322,7 +1417,7 @@ func (x *BulkResumeDate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BulkResumeDate.ProtoReflect.Descriptor instead.
 func (*BulkResumeDate) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{17}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *BulkResumeDate) GetDate() *timestamppb.Timestamp {
@@ -1359,7 +1454,7 @@ type RegisterRequest struct {
 
 func (x *RegisterRequest) Reset() {
 	*x = RegisterRequest{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[18]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1371,7 +1466,7 @@ func (x *RegisterRequest) String() string {
 func (*RegisterRequest) ProtoMessage() {}
 
 func (x *RegisterRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[18]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1384,7 +1479,7 @@ func (x *RegisterRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RegisterRequest.ProtoReflect.Descriptor instead.
 func (*RegisterRequest) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{18}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *RegisterRequest) GetHostCaPem() []byte {
@@ -1410,7 +1505,7 @@ type RegisterResponse struct {
 
 func (x *RegisterResponse) Reset() {
 	*x = RegisterResponse{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[19]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1422,7 +1517,7 @@ func (x *RegisterResponse) String() string {
 func (*RegisterResponse) ProtoMessage() {}
 
 func (x *RegisterResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[19]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1435,7 +1530,7 @@ func (x *RegisterResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RegisterResponse.ProtoReflect.Descriptor instead.
 func (*RegisterResponse) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{19}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{20}
 }
 
 // ReplaceCAsRequest is the request for ReplaceCAs.
@@ -1448,7 +1543,7 @@ type ReplaceCAsRequest struct {
 
 func (x *ReplaceCAsRequest) Reset() {
 	*x = ReplaceCAsRequest{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[20]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1460,7 +1555,7 @@ func (x *ReplaceCAsRequest) String() string {
 func (*ReplaceCAsRequest) ProtoMessage() {}
 
 func (x *ReplaceCAsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[20]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1473,7 +1568,7 @@ func (x *ReplaceCAsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReplaceCAsRequest.ProtoReflect.Descriptor instead.
 func (*ReplaceCAsRequest) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{20}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ReplaceCAsRequest) GetHostCaPem() [][]byte {
@@ -1492,7 +1587,7 @@ type ReplaceCAsResponse struct {
 
 func (x *ReplaceCAsResponse) Reset() {
 	*x = ReplaceCAsResponse{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[21]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1504,7 +1599,7 @@ func (x *ReplaceCAsResponse) String() string {
 func (*ReplaceCAsResponse) ProtoMessage() {}
 
 func (x *ReplaceCAsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[21]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1517,7 +1612,7 @@ func (x *ReplaceCAsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReplaceCAsResponse.ProtoReflect.Descriptor instead.
 func (*ReplaceCAsResponse) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{21}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{22}
 }
 
 // AWSEventsStreamRequest is a request to send commands to the AWS importer.
@@ -1538,7 +1633,7 @@ type AWSEventsStreamRequest struct {
 
 func (x *AWSEventsStreamRequest) Reset() {
 	*x = AWSEventsStreamRequest{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[22]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1550,7 +1645,7 @@ func (x *AWSEventsStreamRequest) String() string {
 func (*AWSEventsStreamRequest) ProtoMessage() {}
 
 func (x *AWSEventsStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[22]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1563,7 +1658,7 @@ func (x *AWSEventsStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AWSEventsStreamRequest.ProtoReflect.Descriptor instead.
 func (*AWSEventsStreamRequest) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{22}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *AWSEventsStreamRequest) GetOperation() isAWSEventsStreamRequest_Operation {
@@ -1636,7 +1731,7 @@ type AWSSyncOperation struct {
 
 func (x *AWSSyncOperation) Reset() {
 	*x = AWSSyncOperation{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[23]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1648,7 +1743,7 @@ func (x *AWSSyncOperation) String() string {
 func (*AWSSyncOperation) ProtoMessage() {}
 
 func (x *AWSSyncOperation) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[23]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1661,7 +1756,7 @@ func (x *AWSSyncOperation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AWSSyncOperation.ProtoReflect.Descriptor instead.
 func (*AWSSyncOperation) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{23}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{24}
 }
 
 // AWSEventsStreamResponse is the response from AWSEventsStream.
@@ -1673,7 +1768,7 @@ type AWSEventsStreamResponse struct {
 
 func (x *AWSEventsStreamResponse) Reset() {
 	*x = AWSEventsStreamResponse{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[24]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1685,7 +1780,7 @@ func (x *AWSEventsStreamResponse) String() string {
 func (*AWSEventsStreamResponse) ProtoMessage() {}
 
 func (x *AWSEventsStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[24]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1698,7 +1793,7 @@ func (x *AWSEventsStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AWSEventsStreamResponse.ProtoReflect.Descriptor instead.
 func (*AWSEventsStreamResponse) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{24}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{25}
 }
 
 // GitlabEventsStreamRequest is a request to send commands to the Gitlab importer.
@@ -1718,7 +1813,7 @@ type GitlabEventsStreamRequest struct {
 
 func (x *GitlabEventsStreamRequest) Reset() {
 	*x = GitlabEventsStreamRequest{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[25]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1730,7 +1825,7 @@ func (x *GitlabEventsStreamRequest) String() string {
 func (*GitlabEventsStreamRequest) ProtoMessage() {}
 
 func (x *GitlabEventsStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[25]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1743,7 +1838,7 @@ func (x *GitlabEventsStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitlabEventsStreamRequest.ProtoReflect.Descriptor instead.
 func (*GitlabEventsStreamRequest) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{25}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *GitlabEventsStreamRequest) GetOperation() isGitlabEventsStreamRequest_Operation {
@@ -1815,7 +1910,7 @@ type GitlabEventsStreamResponse struct {
 
 func (x *GitlabEventsStreamResponse) Reset() {
 	*x = GitlabEventsStreamResponse{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[26]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1827,7 +1922,7 @@ func (x *GitlabEventsStreamResponse) String() string {
 func (*GitlabEventsStreamResponse) ProtoMessage() {}
 
 func (x *GitlabEventsStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[26]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1840,7 +1935,7 @@ func (x *GitlabEventsStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitlabEventsStreamResponse.ProtoReflect.Descriptor instead.
 func (*GitlabEventsStreamResponse) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{26}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{27}
 }
 
 // EntraEventsStreamRequest is a request to send commands to the Gitlab importer.
@@ -1860,7 +1955,7 @@ type EntraEventsStreamRequest struct {
 
 func (x *EntraEventsStreamRequest) Reset() {
 	*x = EntraEventsStreamRequest{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[27]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1872,7 +1967,7 @@ func (x *EntraEventsStreamRequest) String() string {
 func (*EntraEventsStreamRequest) ProtoMessage() {}
 
 func (x *EntraEventsStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[27]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1885,7 +1980,7 @@ func (x *EntraEventsStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EntraEventsStreamRequest.ProtoReflect.Descriptor instead.
 func (*EntraEventsStreamRequest) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{27}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *EntraEventsStreamRequest) GetOperation() isEntraEventsStreamRequest_Operation {
@@ -1957,7 +2052,7 @@ type EntraEventsStreamResponse struct {
 
 func (x *EntraEventsStreamResponse) Reset() {
 	*x = EntraEventsStreamResponse{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[28]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1969,7 +2064,7 @@ func (x *EntraEventsStreamResponse) String() string {
 func (*EntraEventsStreamResponse) ProtoMessage() {}
 
 func (x *EntraEventsStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[28]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1982,7 +2077,7 @@ func (x *EntraEventsStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EntraEventsStreamResponse.ProtoReflect.Descriptor instead.
 func (*EntraEventsStreamResponse) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{28}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{29}
 }
 
 // AzureEventsStreamRequest is a request to send commands to the Azure importer
@@ -2000,7 +2095,7 @@ type AzureEventsStreamRequest struct {
 
 func (x *AzureEventsStreamRequest) Reset() {
 	*x = AzureEventsStreamRequest{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[29]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2012,7 +2107,7 @@ func (x *AzureEventsStreamRequest) String() string {
 func (*AzureEventsStreamRequest) ProtoMessage() {}
 
 func (x *AzureEventsStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[29]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2025,7 +2120,7 @@ func (x *AzureEventsStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AzureEventsStreamRequest.ProtoReflect.Descriptor instead.
 func (*AzureEventsStreamRequest) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{29}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *AzureEventsStreamRequest) GetOperation() isAzureEventsStreamRequest_Operation {
@@ -2098,7 +2193,7 @@ type AzureSyncOperation struct {
 
 func (x *AzureSyncOperation) Reset() {
 	*x = AzureSyncOperation{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[30]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2110,7 +2205,7 @@ func (x *AzureSyncOperation) String() string {
 func (*AzureSyncOperation) ProtoMessage() {}
 
 func (x *AzureSyncOperation) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[30]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2123,7 +2218,7 @@ func (x *AzureSyncOperation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AzureSyncOperation.ProtoReflect.Descriptor instead.
 func (*AzureSyncOperation) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{30}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{31}
 }
 
 // AzureEventsStreamResponse is a response from AzureEventsStream
@@ -2135,7 +2230,7 @@ type AzureEventsStreamResponse struct {
 
 func (x *AzureEventsStreamResponse) Reset() {
 	*x = AzureEventsStreamResponse{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[31]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2147,7 +2242,7 @@ func (x *AzureEventsStreamResponse) String() string {
 func (*AzureEventsStreamResponse) ProtoMessage() {}
 
 func (x *AzureEventsStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[31]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2160,7 +2255,7 @@ func (x *AzureEventsStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AzureEventsStreamResponse.ProtoReflect.Descriptor instead.
 func (*AzureEventsStreamResponse) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{31}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{32}
 }
 
 // NetIQEventsStreamRequest is a request to send commands to the NetIQ importer
@@ -2178,7 +2273,7 @@ type NetIQEventsStreamRequest struct {
 
 func (x *NetIQEventsStreamRequest) Reset() {
 	*x = NetIQEventsStreamRequest{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[32]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2190,7 +2285,7 @@ func (x *NetIQEventsStreamRequest) String() string {
 func (*NetIQEventsStreamRequest) ProtoMessage() {}
 
 func (x *NetIQEventsStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[32]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2203,7 +2298,7 @@ func (x *NetIQEventsStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NetIQEventsStreamRequest.ProtoReflect.Descriptor instead.
 func (*NetIQEventsStreamRequest) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{32}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *NetIQEventsStreamRequest) GetOperation() isNetIQEventsStreamRequest_Operation {
@@ -2275,7 +2370,7 @@ type NetIQSyncOperation struct {
 
 func (x *NetIQSyncOperation) Reset() {
 	*x = NetIQSyncOperation{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[33]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2287,7 +2382,7 @@ func (x *NetIQSyncOperation) String() string {
 func (*NetIQSyncOperation) ProtoMessage() {}
 
 func (x *NetIQSyncOperation) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[33]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2300,7 +2395,7 @@ func (x *NetIQSyncOperation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NetIQSyncOperation.ProtoReflect.Descriptor instead.
 func (*NetIQSyncOperation) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{33}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{34}
 }
 
 // NetIQEventsStreamResponse is a response from NetIQEventsStream
@@ -2312,7 +2407,7 @@ type NetIQEventsStreamResponse struct {
 
 func (x *NetIQEventsStreamResponse) Reset() {
 	*x = NetIQEventsStreamResponse{}
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[34]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2324,7 +2419,7 @@ func (x *NetIQEventsStreamResponse) String() string {
 func (*NetIQEventsStreamResponse) ProtoMessage() {}
 
 func (x *NetIQEventsStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[34]
+	mi := &file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2337,14 +2432,14 @@ func (x *NetIQEventsStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NetIQEventsStreamResponse.ProtoReflect.Descriptor instead.
 func (*NetIQEventsStreamResponse) Descriptor() ([]byte, []int) {
-	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{34}
+	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP(), []int{35}
 }
 
 var File_accessgraph_v1alpha_access_graph_service_proto protoreflect.FileDescriptor
 
 const file_accessgraph_v1alpha_access_graph_service_proto_rawDesc = "" +
 	"\n" +
-	".accessgraph/v1alpha/access_graph_service.proto\x12\x13accessgraph.v1alpha\x1a\x1daccessgraph/v1alpha/aws.proto\x1a\x1faccessgraph/v1alpha/azure.proto\x1a\x1faccessgraph/v1alpha/entra.proto\x1a accessgraph/v1alpha/events.proto\x1a accessgraph/v1alpha/gitlab.proto\x1a\x1faccessgraph/v1alpha/graph.proto\x1a\x1faccessgraph/v1alpha/netiq.proto\x1a#accessgraph/v1alpha/resources.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a#teleport/auditlog/v1/auditlog.proto\"$\n" +
+	".accessgraph/v1alpha/access_graph_service.proto\x12\x13accessgraph.v1alpha\x1a\x1daccessgraph/v1alpha/aws.proto\x1a\x1faccessgraph/v1alpha/azure.proto\x1a\x1faccessgraph/v1alpha/entra.proto\x1a accessgraph/v1alpha/events.proto\x1a accessgraph/v1alpha/gitlab.proto\x1a\x1faccessgraph/v1alpha/graph.proto\x1a\x1faccessgraph/v1alpha/netiq.proto\x1a#accessgraph/v1alpha/resources.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a#teleport/auditlog/v1/auditlog.proto\"$\n" +
 	"\fQueryRequest\x12\x14\n" +
 	"\x05query\x18\x01 \x01(\tR\x05query\"q\n" +
 	"\rQueryResponse\x12/\n" +
@@ -2376,11 +2471,15 @@ const file_accessgraph_v1alpha_access_graph_service_proto_rawDesc = "" +
 	"\n" +
 	"AuditEvent\x12X\n" +
 	"\x13access_path_changed\x18\x01 \x01(\v2&.accessgraph.v1alpha.AccessPathChangedH\x00R\x11accessPathChangedB\a\n" +
-	"\x05event\"\xa9\x01\n" +
+	"\x05event\"\xe8\x01\n" +
 	"\x15AuditLogStreamRequest\x12=\n" +
-	"\x06events\x18\x01 \x01(\v2#.accessgraph.v1alpha.AuditLogEventsH\x00R\x06events\x12G\n" +
-	"\tbulk_sync\x18\x02 \x01(\v2(.accessgraph.v1alpha.BulkResumeStateSyncH\x00R\bbulkSyncB\b\n" +
-	"\x06action\"\xa2\x02\n" +
+	"\x06config\x18\x01 \x01(\v2#.accessgraph.v1alpha.AuditLogConfigH\x00R\x06config\x12=\n" +
+	"\x06events\x18\x02 \x01(\v2#.accessgraph.v1alpha.AuditLogEventsH\x00R\x06events\x12G\n" +
+	"\tbulk_sync\x18\x03 \x01(\v2(.accessgraph.v1alpha.BulkResumeStateSyncH\x00R\bbulkSyncB\b\n" +
+	"\x06action\"K\n" +
+	"\x0eAuditLogConfig\x129\n" +
+	"\n" +
+	"start_date\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\tstartDate\"\xa2\x02\n" +
 	"\x0eAuditLogEvents\x12?\n" +
 	"\x06events\x18\x01 \x03(\v2'.teleport.auditlog.v1.EventUnstructuredR\x06events\x12X\n" +
 	"\x13search_resume_state\x18\x02 \x01(\v2&.accessgraph.v1alpha.SearchResumeStateH\x00R\x11searchResumeState\x12e\n" +
@@ -2396,15 +2495,15 @@ const file_accessgraph_v1alpha_access_graph_service_proto_rawDesc = "" +
 	"\x06cursor\x18\x03 \x01(\tR\x06cursor\x12\x1c\n" +
 	"\tcompleted\x18\x04 \x01(\bR\tcompleted\"T\n" +
 	"\x13BulkResumeStateSync\x12=\n" +
-	"\factive_dates\x18\x01 \x03(\v2\x1a.google.protobuf.TimestampR\vactiveDates\"\x91\x02\n" +
-	"\x16AuditLogStreamResponse\x129\n" +
-	"\n" +
-	"start_date\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\tstartDate\x12X\n" +
-	"\x13search_resume_state\x18\x02 \x01(\v2&.accessgraph.v1alpha.SearchResumeStateH\x00R\x11searchResumeState\x12R\n" +
-	"\x11bulk_resume_state\x18\x03 \x01(\v2$.accessgraph.v1alpha.BulkResumeStateH\x00R\x0fbulkResumeStateB\x0e\n" +
-	"\fresume_state\"L\n" +
+	"\factive_dates\x18\x01 \x03(\v2\x1a.google.protobuf.TimestampR\vactiveDates\"\xe2\x02\n" +
+	"\x16AuditLogStreamResponse\x12O\n" +
+	"\x10audit_log_config\x18\x01 \x01(\v2#.accessgraph.v1alpha.AuditLogConfigH\x00R\x0eauditLogConfig\x12@\n" +
+	"\x0fno_resume_state\x18\x02 \x01(\v2\x16.google.protobuf.EmptyH\x00R\rnoResumeState\x12X\n" +
+	"\x13search_resume_state\x18\x03 \x01(\v2&.accessgraph.v1alpha.SearchResumeStateH\x00R\x11searchResumeState\x12R\n" +
+	"\x11bulk_resume_state\x18\x04 \x01(\v2$.accessgraph.v1alpha.BulkResumeStateH\x00R\x0fbulkResumeStateB\a\n" +
+	"\x05state\"L\n" +
 	"\x0fBulkResumeState\x129\n" +
-	"\x05dates\x18\x01 \x03(\v2#.accessgraph.v1alpha.BulkResumeDateR\x05dates\"\x88\x02\n" +
+	"\x05dates\x18\x02 \x03(\v2#.accessgraph.v1alpha.BulkResumeDateR\x05dates\"\x88\x02\n" +
 	"\x0eBulkResumeDate\x12.\n" +
 	"\x04date\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x04date\x12)\n" +
 	"\x10completed_chunks\x18\x02 \x03(\tR\x0fcompletedChunks\x12Z\n" +
@@ -2480,7 +2579,7 @@ func file_accessgraph_v1alpha_access_graph_service_proto_rawDescGZIP() []byte {
 	return file_accessgraph_v1alpha_access_graph_service_proto_rawDescData
 }
 
-var file_accessgraph_v1alpha_access_graph_service_proto_msgTypes = make([]protoimpl.MessageInfo, 36)
+var file_accessgraph_v1alpha_access_graph_service_proto_msgTypes = make([]protoimpl.MessageInfo, 37)
 var file_accessgraph_v1alpha_access_graph_service_proto_goTypes = []any{
 	(*QueryRequest)(nil),               // 0: accessgraph.v1alpha.QueryRequest
 	(*QueryResponse)(nil),              // 1: accessgraph.v1alpha.QueryResponse
@@ -2493,121 +2592,126 @@ var file_accessgraph_v1alpha_access_graph_service_proto_goTypes = []any{
 	(*EventsStreamV2Response)(nil),     // 8: accessgraph.v1alpha.EventsStreamV2Response
 	(*AuditEvent)(nil),                 // 9: accessgraph.v1alpha.AuditEvent
 	(*AuditLogStreamRequest)(nil),      // 10: accessgraph.v1alpha.AuditLogStreamRequest
-	(*AuditLogEvents)(nil),             // 11: accessgraph.v1alpha.AuditLogEvents
-	(*SearchResumeState)(nil),          // 12: accessgraph.v1alpha.SearchResumeState
-	(*BulkResumeStateUpdate)(nil),      // 13: accessgraph.v1alpha.BulkResumeStateUpdate
-	(*BulkResumeStateSync)(nil),        // 14: accessgraph.v1alpha.BulkResumeStateSync
-	(*AuditLogStreamResponse)(nil),     // 15: accessgraph.v1alpha.AuditLogStreamResponse
-	(*BulkResumeState)(nil),            // 16: accessgraph.v1alpha.BulkResumeState
-	(*BulkResumeDate)(nil),             // 17: accessgraph.v1alpha.BulkResumeDate
-	(*RegisterRequest)(nil),            // 18: accessgraph.v1alpha.RegisterRequest
-	(*RegisterResponse)(nil),           // 19: accessgraph.v1alpha.RegisterResponse
-	(*ReplaceCAsRequest)(nil),          // 20: accessgraph.v1alpha.ReplaceCAsRequest
-	(*ReplaceCAsResponse)(nil),         // 21: accessgraph.v1alpha.ReplaceCAsResponse
-	(*AWSEventsStreamRequest)(nil),     // 22: accessgraph.v1alpha.AWSEventsStreamRequest
-	(*AWSSyncOperation)(nil),           // 23: accessgraph.v1alpha.AWSSyncOperation
-	(*AWSEventsStreamResponse)(nil),    // 24: accessgraph.v1alpha.AWSEventsStreamResponse
-	(*GitlabEventsStreamRequest)(nil),  // 25: accessgraph.v1alpha.GitlabEventsStreamRequest
-	(*GitlabEventsStreamResponse)(nil), // 26: accessgraph.v1alpha.GitlabEventsStreamResponse
-	(*EntraEventsStreamRequest)(nil),   // 27: accessgraph.v1alpha.EntraEventsStreamRequest
-	(*EntraEventsStreamResponse)(nil),  // 28: accessgraph.v1alpha.EntraEventsStreamResponse
-	(*AzureEventsStreamRequest)(nil),   // 29: accessgraph.v1alpha.AzureEventsStreamRequest
-	(*AzureSyncOperation)(nil),         // 30: accessgraph.v1alpha.AzureSyncOperation
-	(*AzureEventsStreamResponse)(nil),  // 31: accessgraph.v1alpha.AzureEventsStreamResponse
-	(*NetIQEventsStreamRequest)(nil),   // 32: accessgraph.v1alpha.NetIQEventsStreamRequest
-	(*NetIQSyncOperation)(nil),         // 33: accessgraph.v1alpha.NetIQSyncOperation
-	(*NetIQEventsStreamResponse)(nil),  // 34: accessgraph.v1alpha.NetIQEventsStreamResponse
-	nil,                                // 35: accessgraph.v1alpha.BulkResumeDate.ChunkCursorsEntry
-	(*Node)(nil),                       // 36: accessgraph.v1alpha.Node
-	(*Edge)(nil),                       // 37: accessgraph.v1alpha.Edge
-	(*ResourceList)(nil),               // 38: accessgraph.v1alpha.ResourceList
-	(*ResourceHeaderList)(nil),         // 39: accessgraph.v1alpha.ResourceHeaderList
-	(*AccessListsMembers)(nil),         // 40: accessgraph.v1alpha.AccessListsMembers
-	(*ExcludeAccessListsMembers)(nil),  // 41: accessgraph.v1alpha.ExcludeAccessListsMembers
-	(*AccessPathChanged)(nil),          // 42: accessgraph.v1alpha.AccessPathChanged
-	(*v1.EventUnstructured)(nil),       // 43: teleport.auditlog.v1.EventUnstructured
+	(*AuditLogConfig)(nil),             // 11: accessgraph.v1alpha.AuditLogConfig
+	(*AuditLogEvents)(nil),             // 12: accessgraph.v1alpha.AuditLogEvents
+	(*SearchResumeState)(nil),          // 13: accessgraph.v1alpha.SearchResumeState
+	(*BulkResumeStateUpdate)(nil),      // 14: accessgraph.v1alpha.BulkResumeStateUpdate
+	(*BulkResumeStateSync)(nil),        // 15: accessgraph.v1alpha.BulkResumeStateSync
+	(*AuditLogStreamResponse)(nil),     // 16: accessgraph.v1alpha.AuditLogStreamResponse
+	(*BulkResumeState)(nil),            // 17: accessgraph.v1alpha.BulkResumeState
+	(*BulkResumeDate)(nil),             // 18: accessgraph.v1alpha.BulkResumeDate
+	(*RegisterRequest)(nil),            // 19: accessgraph.v1alpha.RegisterRequest
+	(*RegisterResponse)(nil),           // 20: accessgraph.v1alpha.RegisterResponse
+	(*ReplaceCAsRequest)(nil),          // 21: accessgraph.v1alpha.ReplaceCAsRequest
+	(*ReplaceCAsResponse)(nil),         // 22: accessgraph.v1alpha.ReplaceCAsResponse
+	(*AWSEventsStreamRequest)(nil),     // 23: accessgraph.v1alpha.AWSEventsStreamRequest
+	(*AWSSyncOperation)(nil),           // 24: accessgraph.v1alpha.AWSSyncOperation
+	(*AWSEventsStreamResponse)(nil),    // 25: accessgraph.v1alpha.AWSEventsStreamResponse
+	(*GitlabEventsStreamRequest)(nil),  // 26: accessgraph.v1alpha.GitlabEventsStreamRequest
+	(*GitlabEventsStreamResponse)(nil), // 27: accessgraph.v1alpha.GitlabEventsStreamResponse
+	(*EntraEventsStreamRequest)(nil),   // 28: accessgraph.v1alpha.EntraEventsStreamRequest
+	(*EntraEventsStreamResponse)(nil),  // 29: accessgraph.v1alpha.EntraEventsStreamResponse
+	(*AzureEventsStreamRequest)(nil),   // 30: accessgraph.v1alpha.AzureEventsStreamRequest
+	(*AzureSyncOperation)(nil),         // 31: accessgraph.v1alpha.AzureSyncOperation
+	(*AzureEventsStreamResponse)(nil),  // 32: accessgraph.v1alpha.AzureEventsStreamResponse
+	(*NetIQEventsStreamRequest)(nil),   // 33: accessgraph.v1alpha.NetIQEventsStreamRequest
+	(*NetIQSyncOperation)(nil),         // 34: accessgraph.v1alpha.NetIQSyncOperation
+	(*NetIQEventsStreamResponse)(nil),  // 35: accessgraph.v1alpha.NetIQEventsStreamResponse
+	nil,                                // 36: accessgraph.v1alpha.BulkResumeDate.ChunkCursorsEntry
+	(*Node)(nil),                       // 37: accessgraph.v1alpha.Node
+	(*Edge)(nil),                       // 38: accessgraph.v1alpha.Edge
+	(*ResourceList)(nil),               // 39: accessgraph.v1alpha.ResourceList
+	(*ResourceHeaderList)(nil),         // 40: accessgraph.v1alpha.ResourceHeaderList
+	(*AccessListsMembers)(nil),         // 41: accessgraph.v1alpha.AccessListsMembers
+	(*ExcludeAccessListsMembers)(nil),  // 42: accessgraph.v1alpha.ExcludeAccessListsMembers
+	(*AccessPathChanged)(nil),          // 43: accessgraph.v1alpha.AccessPathChanged
 	(*timestamppb.Timestamp)(nil),      // 44: google.protobuf.Timestamp
-	(*AWSResourceList)(nil),            // 45: accessgraph.v1alpha.AWSResourceList
-	(*GitlabSyncOperation)(nil),        // 46: accessgraph.v1alpha.GitlabSyncOperation
-	(*GitlabResourceList)(nil),         // 47: accessgraph.v1alpha.GitlabResourceList
-	(*EntraSyncOperation)(nil),         // 48: accessgraph.v1alpha.EntraSyncOperation
-	(*EntraResourceList)(nil),          // 49: accessgraph.v1alpha.EntraResourceList
-	(*AzureResourceList)(nil),          // 50: accessgraph.v1alpha.AzureResourceList
-	(*NetIQResourceList)(nil),          // 51: accessgraph.v1alpha.NetIQResourceList
+	(*v1.EventUnstructured)(nil),       // 45: teleport.auditlog.v1.EventUnstructured
+	(*emptypb.Empty)(nil),              // 46: google.protobuf.Empty
+	(*AWSResourceList)(nil),            // 47: accessgraph.v1alpha.AWSResourceList
+	(*GitlabSyncOperation)(nil),        // 48: accessgraph.v1alpha.GitlabSyncOperation
+	(*GitlabResourceList)(nil),         // 49: accessgraph.v1alpha.GitlabResourceList
+	(*EntraSyncOperation)(nil),         // 50: accessgraph.v1alpha.EntraSyncOperation
+	(*EntraResourceList)(nil),          // 51: accessgraph.v1alpha.EntraResourceList
+	(*AzureResourceList)(nil),          // 52: accessgraph.v1alpha.AzureResourceList
+	(*NetIQResourceList)(nil),          // 53: accessgraph.v1alpha.NetIQResourceList
 }
 var file_accessgraph_v1alpha_access_graph_service_proto_depIdxs = []int32{
-	36, // 0: accessgraph.v1alpha.QueryResponse.nodes:type_name -> accessgraph.v1alpha.Node
-	37, // 1: accessgraph.v1alpha.QueryResponse.edges:type_name -> accessgraph.v1alpha.Edge
+	37, // 0: accessgraph.v1alpha.QueryResponse.nodes:type_name -> accessgraph.v1alpha.Node
+	38, // 1: accessgraph.v1alpha.QueryResponse.edges:type_name -> accessgraph.v1alpha.Edge
 	6,  // 2: accessgraph.v1alpha.EventsStreamRequest.sync:type_name -> accessgraph.v1alpha.SyncOperation
-	38, // 3: accessgraph.v1alpha.EventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.ResourceList
-	39, // 4: accessgraph.v1alpha.EventsStreamRequest.delete:type_name -> accessgraph.v1alpha.ResourceHeaderList
-	40, // 5: accessgraph.v1alpha.EventsStreamRequest.access_lists_members:type_name -> accessgraph.v1alpha.AccessListsMembers
-	41, // 6: accessgraph.v1alpha.EventsStreamRequest.exclude_access_list_members:type_name -> accessgraph.v1alpha.ExcludeAccessListsMembers
+	39, // 3: accessgraph.v1alpha.EventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.ResourceList
+	40, // 4: accessgraph.v1alpha.EventsStreamRequest.delete:type_name -> accessgraph.v1alpha.ResourceHeaderList
+	41, // 5: accessgraph.v1alpha.EventsStreamRequest.access_lists_members:type_name -> accessgraph.v1alpha.AccessListsMembers
+	42, // 6: accessgraph.v1alpha.EventsStreamRequest.exclude_access_list_members:type_name -> accessgraph.v1alpha.ExcludeAccessListsMembers
 	6,  // 7: accessgraph.v1alpha.EventsStreamV2Request.sync:type_name -> accessgraph.v1alpha.SyncOperation
-	38, // 8: accessgraph.v1alpha.EventsStreamV2Request.upsert:type_name -> accessgraph.v1alpha.ResourceList
-	39, // 9: accessgraph.v1alpha.EventsStreamV2Request.delete:type_name -> accessgraph.v1alpha.ResourceHeaderList
-	40, // 10: accessgraph.v1alpha.EventsStreamV2Request.access_lists_members:type_name -> accessgraph.v1alpha.AccessListsMembers
-	41, // 11: accessgraph.v1alpha.EventsStreamV2Request.exclude_access_list_members:type_name -> accessgraph.v1alpha.ExcludeAccessListsMembers
+	39, // 8: accessgraph.v1alpha.EventsStreamV2Request.upsert:type_name -> accessgraph.v1alpha.ResourceList
+	40, // 9: accessgraph.v1alpha.EventsStreamV2Request.delete:type_name -> accessgraph.v1alpha.ResourceHeaderList
+	41, // 10: accessgraph.v1alpha.EventsStreamV2Request.access_lists_members:type_name -> accessgraph.v1alpha.AccessListsMembers
+	42, // 11: accessgraph.v1alpha.EventsStreamV2Request.exclude_access_list_members:type_name -> accessgraph.v1alpha.ExcludeAccessListsMembers
 	9,  // 12: accessgraph.v1alpha.EventsStreamV2Response.event:type_name -> accessgraph.v1alpha.AuditEvent
-	42, // 13: accessgraph.v1alpha.AuditEvent.access_path_changed:type_name -> accessgraph.v1alpha.AccessPathChanged
-	11, // 14: accessgraph.v1alpha.AuditLogStreamRequest.events:type_name -> accessgraph.v1alpha.AuditLogEvents
-	14, // 15: accessgraph.v1alpha.AuditLogStreamRequest.bulk_sync:type_name -> accessgraph.v1alpha.BulkResumeStateSync
-	43, // 16: accessgraph.v1alpha.AuditLogEvents.events:type_name -> teleport.auditlog.v1.EventUnstructured
-	12, // 17: accessgraph.v1alpha.AuditLogEvents.search_resume_state:type_name -> accessgraph.v1alpha.SearchResumeState
-	13, // 18: accessgraph.v1alpha.AuditLogEvents.bulk_resume_state_update:type_name -> accessgraph.v1alpha.BulkResumeStateUpdate
-	44, // 19: accessgraph.v1alpha.SearchResumeState.last_event_time:type_name -> google.protobuf.Timestamp
-	44, // 20: accessgraph.v1alpha.BulkResumeStateUpdate.date:type_name -> google.protobuf.Timestamp
-	44, // 21: accessgraph.v1alpha.BulkResumeStateSync.active_dates:type_name -> google.protobuf.Timestamp
-	44, // 22: accessgraph.v1alpha.AuditLogStreamResponse.start_date:type_name -> google.protobuf.Timestamp
-	12, // 23: accessgraph.v1alpha.AuditLogStreamResponse.search_resume_state:type_name -> accessgraph.v1alpha.SearchResumeState
-	16, // 24: accessgraph.v1alpha.AuditLogStreamResponse.bulk_resume_state:type_name -> accessgraph.v1alpha.BulkResumeState
-	17, // 25: accessgraph.v1alpha.BulkResumeState.dates:type_name -> accessgraph.v1alpha.BulkResumeDate
-	44, // 26: accessgraph.v1alpha.BulkResumeDate.date:type_name -> google.protobuf.Timestamp
-	35, // 27: accessgraph.v1alpha.BulkResumeDate.chunk_cursors:type_name -> accessgraph.v1alpha.BulkResumeDate.ChunkCursorsEntry
-	23, // 28: accessgraph.v1alpha.AWSEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.AWSSyncOperation
-	45, // 29: accessgraph.v1alpha.AWSEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.AWSResourceList
-	45, // 30: accessgraph.v1alpha.AWSEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.AWSResourceList
-	46, // 31: accessgraph.v1alpha.GitlabEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.GitlabSyncOperation
-	47, // 32: accessgraph.v1alpha.GitlabEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.GitlabResourceList
-	47, // 33: accessgraph.v1alpha.GitlabEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.GitlabResourceList
-	48, // 34: accessgraph.v1alpha.EntraEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.EntraSyncOperation
-	49, // 35: accessgraph.v1alpha.EntraEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.EntraResourceList
-	49, // 36: accessgraph.v1alpha.EntraEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.EntraResourceList
-	30, // 37: accessgraph.v1alpha.AzureEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.AzureSyncOperation
-	50, // 38: accessgraph.v1alpha.AzureEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.AzureResourceList
-	50, // 39: accessgraph.v1alpha.AzureEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.AzureResourceList
-	33, // 40: accessgraph.v1alpha.NetIQEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.NetIQSyncOperation
-	51, // 41: accessgraph.v1alpha.NetIQEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.NetIQResourceList
-	51, // 42: accessgraph.v1alpha.NetIQEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.NetIQResourceList
-	0,  // 43: accessgraph.v1alpha.AccessGraphService.Query:input_type -> accessgraph.v1alpha.QueryRequest
-	2,  // 44: accessgraph.v1alpha.AccessGraphService.GetFile:input_type -> accessgraph.v1alpha.GetFileRequest
-	4,  // 45: accessgraph.v1alpha.AccessGraphService.EventsStream:input_type -> accessgraph.v1alpha.EventsStreamRequest
-	5,  // 46: accessgraph.v1alpha.AccessGraphService.EventsStreamV2:input_type -> accessgraph.v1alpha.EventsStreamV2Request
-	10, // 47: accessgraph.v1alpha.AccessGraphService.AuditLogStream:input_type -> accessgraph.v1alpha.AuditLogStreamRequest
-	18, // 48: accessgraph.v1alpha.AccessGraphService.Register:input_type -> accessgraph.v1alpha.RegisterRequest
-	20, // 49: accessgraph.v1alpha.AccessGraphService.ReplaceCAs:input_type -> accessgraph.v1alpha.ReplaceCAsRequest
-	22, // 50: accessgraph.v1alpha.AccessGraphService.AWSEventsStream:input_type -> accessgraph.v1alpha.AWSEventsStreamRequest
-	25, // 51: accessgraph.v1alpha.AccessGraphService.GitlabEventsStream:input_type -> accessgraph.v1alpha.GitlabEventsStreamRequest
-	27, // 52: accessgraph.v1alpha.AccessGraphService.EntraEventsStream:input_type -> accessgraph.v1alpha.EntraEventsStreamRequest
-	29, // 53: accessgraph.v1alpha.AccessGraphService.AzureEventsStream:input_type -> accessgraph.v1alpha.AzureEventsStreamRequest
-	32, // 54: accessgraph.v1alpha.AccessGraphService.NetIQEventsStream:input_type -> accessgraph.v1alpha.NetIQEventsStreamRequest
-	1,  // 55: accessgraph.v1alpha.AccessGraphService.Query:output_type -> accessgraph.v1alpha.QueryResponse
-	3,  // 56: accessgraph.v1alpha.AccessGraphService.GetFile:output_type -> accessgraph.v1alpha.GetFileResponse
-	7,  // 57: accessgraph.v1alpha.AccessGraphService.EventsStream:output_type -> accessgraph.v1alpha.EventsStreamResponse
-	8,  // 58: accessgraph.v1alpha.AccessGraphService.EventsStreamV2:output_type -> accessgraph.v1alpha.EventsStreamV2Response
-	15, // 59: accessgraph.v1alpha.AccessGraphService.AuditLogStream:output_type -> accessgraph.v1alpha.AuditLogStreamResponse
-	19, // 60: accessgraph.v1alpha.AccessGraphService.Register:output_type -> accessgraph.v1alpha.RegisterResponse
-	21, // 61: accessgraph.v1alpha.AccessGraphService.ReplaceCAs:output_type -> accessgraph.v1alpha.ReplaceCAsResponse
-	24, // 62: accessgraph.v1alpha.AccessGraphService.AWSEventsStream:output_type -> accessgraph.v1alpha.AWSEventsStreamResponse
-	26, // 63: accessgraph.v1alpha.AccessGraphService.GitlabEventsStream:output_type -> accessgraph.v1alpha.GitlabEventsStreamResponse
-	28, // 64: accessgraph.v1alpha.AccessGraphService.EntraEventsStream:output_type -> accessgraph.v1alpha.EntraEventsStreamResponse
-	31, // 65: accessgraph.v1alpha.AccessGraphService.AzureEventsStream:output_type -> accessgraph.v1alpha.AzureEventsStreamResponse
-	34, // 66: accessgraph.v1alpha.AccessGraphService.NetIQEventsStream:output_type -> accessgraph.v1alpha.NetIQEventsStreamResponse
-	55, // [55:67] is the sub-list for method output_type
-	43, // [43:55] is the sub-list for method input_type
-	43, // [43:43] is the sub-list for extension type_name
-	43, // [43:43] is the sub-list for extension extendee
-	0,  // [0:43] is the sub-list for field type_name
+	43, // 13: accessgraph.v1alpha.AuditEvent.access_path_changed:type_name -> accessgraph.v1alpha.AccessPathChanged
+	11, // 14: accessgraph.v1alpha.AuditLogStreamRequest.config:type_name -> accessgraph.v1alpha.AuditLogConfig
+	12, // 15: accessgraph.v1alpha.AuditLogStreamRequest.events:type_name -> accessgraph.v1alpha.AuditLogEvents
+	15, // 16: accessgraph.v1alpha.AuditLogStreamRequest.bulk_sync:type_name -> accessgraph.v1alpha.BulkResumeStateSync
+	44, // 17: accessgraph.v1alpha.AuditLogConfig.start_date:type_name -> google.protobuf.Timestamp
+	45, // 18: accessgraph.v1alpha.AuditLogEvents.events:type_name -> teleport.auditlog.v1.EventUnstructured
+	13, // 19: accessgraph.v1alpha.AuditLogEvents.search_resume_state:type_name -> accessgraph.v1alpha.SearchResumeState
+	14, // 20: accessgraph.v1alpha.AuditLogEvents.bulk_resume_state_update:type_name -> accessgraph.v1alpha.BulkResumeStateUpdate
+	44, // 21: accessgraph.v1alpha.SearchResumeState.last_event_time:type_name -> google.protobuf.Timestamp
+	44, // 22: accessgraph.v1alpha.BulkResumeStateUpdate.date:type_name -> google.protobuf.Timestamp
+	44, // 23: accessgraph.v1alpha.BulkResumeStateSync.active_dates:type_name -> google.protobuf.Timestamp
+	11, // 24: accessgraph.v1alpha.AuditLogStreamResponse.audit_log_config:type_name -> accessgraph.v1alpha.AuditLogConfig
+	46, // 25: accessgraph.v1alpha.AuditLogStreamResponse.no_resume_state:type_name -> google.protobuf.Empty
+	13, // 26: accessgraph.v1alpha.AuditLogStreamResponse.search_resume_state:type_name -> accessgraph.v1alpha.SearchResumeState
+	17, // 27: accessgraph.v1alpha.AuditLogStreamResponse.bulk_resume_state:type_name -> accessgraph.v1alpha.BulkResumeState
+	18, // 28: accessgraph.v1alpha.BulkResumeState.dates:type_name -> accessgraph.v1alpha.BulkResumeDate
+	44, // 29: accessgraph.v1alpha.BulkResumeDate.date:type_name -> google.protobuf.Timestamp
+	36, // 30: accessgraph.v1alpha.BulkResumeDate.chunk_cursors:type_name -> accessgraph.v1alpha.BulkResumeDate.ChunkCursorsEntry
+	24, // 31: accessgraph.v1alpha.AWSEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.AWSSyncOperation
+	47, // 32: accessgraph.v1alpha.AWSEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.AWSResourceList
+	47, // 33: accessgraph.v1alpha.AWSEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.AWSResourceList
+	48, // 34: accessgraph.v1alpha.GitlabEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.GitlabSyncOperation
+	49, // 35: accessgraph.v1alpha.GitlabEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.GitlabResourceList
+	49, // 36: accessgraph.v1alpha.GitlabEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.GitlabResourceList
+	50, // 37: accessgraph.v1alpha.EntraEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.EntraSyncOperation
+	51, // 38: accessgraph.v1alpha.EntraEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.EntraResourceList
+	51, // 39: accessgraph.v1alpha.EntraEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.EntraResourceList
+	31, // 40: accessgraph.v1alpha.AzureEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.AzureSyncOperation
+	52, // 41: accessgraph.v1alpha.AzureEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.AzureResourceList
+	52, // 42: accessgraph.v1alpha.AzureEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.AzureResourceList
+	34, // 43: accessgraph.v1alpha.NetIQEventsStreamRequest.sync:type_name -> accessgraph.v1alpha.NetIQSyncOperation
+	53, // 44: accessgraph.v1alpha.NetIQEventsStreamRequest.upsert:type_name -> accessgraph.v1alpha.NetIQResourceList
+	53, // 45: accessgraph.v1alpha.NetIQEventsStreamRequest.delete:type_name -> accessgraph.v1alpha.NetIQResourceList
+	0,  // 46: accessgraph.v1alpha.AccessGraphService.Query:input_type -> accessgraph.v1alpha.QueryRequest
+	2,  // 47: accessgraph.v1alpha.AccessGraphService.GetFile:input_type -> accessgraph.v1alpha.GetFileRequest
+	4,  // 48: accessgraph.v1alpha.AccessGraphService.EventsStream:input_type -> accessgraph.v1alpha.EventsStreamRequest
+	5,  // 49: accessgraph.v1alpha.AccessGraphService.EventsStreamV2:input_type -> accessgraph.v1alpha.EventsStreamV2Request
+	10, // 50: accessgraph.v1alpha.AccessGraphService.AuditLogStream:input_type -> accessgraph.v1alpha.AuditLogStreamRequest
+	19, // 51: accessgraph.v1alpha.AccessGraphService.Register:input_type -> accessgraph.v1alpha.RegisterRequest
+	21, // 52: accessgraph.v1alpha.AccessGraphService.ReplaceCAs:input_type -> accessgraph.v1alpha.ReplaceCAsRequest
+	23, // 53: accessgraph.v1alpha.AccessGraphService.AWSEventsStream:input_type -> accessgraph.v1alpha.AWSEventsStreamRequest
+	26, // 54: accessgraph.v1alpha.AccessGraphService.GitlabEventsStream:input_type -> accessgraph.v1alpha.GitlabEventsStreamRequest
+	28, // 55: accessgraph.v1alpha.AccessGraphService.EntraEventsStream:input_type -> accessgraph.v1alpha.EntraEventsStreamRequest
+	30, // 56: accessgraph.v1alpha.AccessGraphService.AzureEventsStream:input_type -> accessgraph.v1alpha.AzureEventsStreamRequest
+	33, // 57: accessgraph.v1alpha.AccessGraphService.NetIQEventsStream:input_type -> accessgraph.v1alpha.NetIQEventsStreamRequest
+	1,  // 58: accessgraph.v1alpha.AccessGraphService.Query:output_type -> accessgraph.v1alpha.QueryResponse
+	3,  // 59: accessgraph.v1alpha.AccessGraphService.GetFile:output_type -> accessgraph.v1alpha.GetFileResponse
+	7,  // 60: accessgraph.v1alpha.AccessGraphService.EventsStream:output_type -> accessgraph.v1alpha.EventsStreamResponse
+	8,  // 61: accessgraph.v1alpha.AccessGraphService.EventsStreamV2:output_type -> accessgraph.v1alpha.EventsStreamV2Response
+	16, // 62: accessgraph.v1alpha.AccessGraphService.AuditLogStream:output_type -> accessgraph.v1alpha.AuditLogStreamResponse
+	20, // 63: accessgraph.v1alpha.AccessGraphService.Register:output_type -> accessgraph.v1alpha.RegisterResponse
+	22, // 64: accessgraph.v1alpha.AccessGraphService.ReplaceCAs:output_type -> accessgraph.v1alpha.ReplaceCAsResponse
+	25, // 65: accessgraph.v1alpha.AccessGraphService.AWSEventsStream:output_type -> accessgraph.v1alpha.AWSEventsStreamResponse
+	27, // 66: accessgraph.v1alpha.AccessGraphService.GitlabEventsStream:output_type -> accessgraph.v1alpha.GitlabEventsStreamResponse
+	29, // 67: accessgraph.v1alpha.AccessGraphService.EntraEventsStream:output_type -> accessgraph.v1alpha.EntraEventsStreamResponse
+	32, // 68: accessgraph.v1alpha.AccessGraphService.AzureEventsStream:output_type -> accessgraph.v1alpha.AzureEventsStreamResponse
+	35, // 69: accessgraph.v1alpha.AccessGraphService.NetIQEventsStream:output_type -> accessgraph.v1alpha.NetIQEventsStreamResponse
+	58, // [58:70] is the sub-list for method output_type
+	46, // [46:58] is the sub-list for method input_type
+	46, // [46:46] is the sub-list for extension type_name
+	46, // [46:46] is the sub-list for extension extendee
+	0,  // [0:46] is the sub-list for field type_name
 }
 
 func init() { file_accessgraph_v1alpha_access_graph_service_proto_init() }
@@ -2644,38 +2748,41 @@ func file_accessgraph_v1alpha_access_graph_service_proto_init() {
 		(*AuditEvent_AccessPathChanged)(nil),
 	}
 	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[10].OneofWrappers = []any{
+		(*AuditLogStreamRequest_Config)(nil),
 		(*AuditLogStreamRequest_Events)(nil),
 		(*AuditLogStreamRequest_BulkSync)(nil),
 	}
-	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[11].OneofWrappers = []any{
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[12].OneofWrappers = []any{
 		(*AuditLogEvents_SearchResumeState)(nil),
 		(*AuditLogEvents_BulkResumeStateUpdate)(nil),
 	}
-	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[15].OneofWrappers = []any{
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[16].OneofWrappers = []any{
+		(*AuditLogStreamResponse_AuditLogConfig)(nil),
+		(*AuditLogStreamResponse_NoResumeState)(nil),
 		(*AuditLogStreamResponse_SearchResumeState)(nil),
 		(*AuditLogStreamResponse_BulkResumeState)(nil),
 	}
-	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[22].OneofWrappers = []any{
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[23].OneofWrappers = []any{
 		(*AWSEventsStreamRequest_Sync)(nil),
 		(*AWSEventsStreamRequest_Upsert)(nil),
 		(*AWSEventsStreamRequest_Delete)(nil),
 	}
-	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[25].OneofWrappers = []any{
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[26].OneofWrappers = []any{
 		(*GitlabEventsStreamRequest_Sync)(nil),
 		(*GitlabEventsStreamRequest_Upsert)(nil),
 		(*GitlabEventsStreamRequest_Delete)(nil),
 	}
-	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[27].OneofWrappers = []any{
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[28].OneofWrappers = []any{
 		(*EntraEventsStreamRequest_Sync)(nil),
 		(*EntraEventsStreamRequest_Upsert)(nil),
 		(*EntraEventsStreamRequest_Delete)(nil),
 	}
-	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[29].OneofWrappers = []any{
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[30].OneofWrappers = []any{
 		(*AzureEventsStreamRequest_Sync)(nil),
 		(*AzureEventsStreamRequest_Upsert)(nil),
 		(*AzureEventsStreamRequest_Delete)(nil),
 	}
-	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[32].OneofWrappers = []any{
+	file_accessgraph_v1alpha_access_graph_service_proto_msgTypes[33].OneofWrappers = []any{
 		(*NetIQEventsStreamRequest_Sync)(nil),
 		(*NetIQEventsStreamRequest_Upsert)(nil),
 		(*NetIQEventsStreamRequest_Delete)(nil),
@@ -2686,7 +2793,7 @@ func file_accessgraph_v1alpha_access_graph_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_accessgraph_v1alpha_access_graph_service_proto_rawDesc), len(file_accessgraph_v1alpha_access_graph_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   36,
+			NumMessages:   37,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/proto/go/accessgraph/v1alpha/access_graph_service_grpc.pb.go
+++ b/gen/proto/go/accessgraph/v1alpha/access_graph_service_grpc.pb.go
@@ -72,8 +72,8 @@ type AccessGraphServiceClient interface {
 	// This stream works the same way as EventsStream, but it returns a stream of events
 	// instead of a single response.
 	EventsStreamV2(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[EventsStreamV2Request, EventsStreamV2Response], error)
-	// AuditLogStream establishes a persistent bidirectional stream for efficiently
-	// exporting audit log events from a client (teleport) to a server (access-graph).
+	// AuditLogStream establishes a persistent bidirectional stream for exporting
+	// audit log events from a client (teleport) to a server (access-graph).
 	//
 	// This stream facilitates:
 	// - Initial configuration exchange and validation.
@@ -295,8 +295,8 @@ type AccessGraphServiceServer interface {
 	// This stream works the same way as EventsStream, but it returns a stream of events
 	// instead of a single response.
 	EventsStreamV2(grpc.BidiStreamingServer[EventsStreamV2Request, EventsStreamV2Response]) error
-	// AuditLogStream establishes a persistent bidirectional stream for efficiently
-	// exporting audit log events from a client (teleport) to a server (access-graph).
+	// AuditLogStream establishes a persistent bidirectional stream for exporting
+	// audit log events from a client (teleport) to a server (access-graph).
 	//
 	// This stream facilitates:
 	// - Initial configuration exchange and validation.

--- a/gen/proto/go/accessgraph/v1alpha/access_graph_service_grpc.pb.go
+++ b/gen/proto/go/accessgraph/v1alpha/access_graph_service_grpc.pb.go
@@ -72,27 +72,25 @@ type AccessGraphServiceClient interface {
 	// This stream works the same way as EventsStream, but it returns a stream of events
 	// instead of a single response.
 	EventsStreamV2(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[EventsStreamV2Request, EventsStreamV2Response], error)
-	// AuditLogStream establishes a bidirectional stream for exporting audit log
-	// events from a client (teleport) to a server (access-graph).
+	// AuditLogStream establishes a persistent bidirectional stream for efficiently
+	// exporting audit log events from a client (teleport) to a server (access-graph).
 	//
-	// This stream handles:
-	//   - Sending batches of audit log events (sourced by 'search' or 'bulk').
-	//   - Transmitting resume state information alongside events to ensure reliable
-	//     exporting, allowing clients to resume after disconnections without losing
-	//     data or sending duplicates.
-	//   - Server providing the initial resume state to the client upon connection.
-	//   - Client-initiated synchronization of bulk resume state to purge expired
-	//     dates.
+	// This stream facilitates:
+	// - Initial configuration exchange and validation.
+	// - Streaming batches of audit log events from client to server.
+	// - Reliable export resumption via client-provided resume state updates.
+	// - Server providing the initial resume state to the client upon connection.
+	// - Client requests for server-side bulk export state cleanup.
 	//
-	// Flow:
-	//  1. Client initiates the stream.
-	//  2. Server sends an initial `AuditLogResponse` containing the appropriate
-	//     `resume_state` (Search or Bulk) for the client to start or resume from,
-	//     plus a `start_date`.
-	//  3. Client sends `AuditLogRequest` messages:
-	//     - Containing `AuditLogEvents` (batches of events and current resume
-	//     state/update).
-	//     - OR containing `BulkStateSync` (requests to prune old bulk state).
+	// Basic Interaction Flow:
+	//  1. Client connects and sends an initial `AuditLogStreamRequest` with `config`.
+	//  2. Server replies with an initial `AuditLogStreamResponse`, confirming the
+	//     effective configuration and providing the starting `resume_state` (if any).
+	//  3. Client sends subsequent `AuditLogStreamRequest` messages containing either
+	//     `events` (with resume state updates) or `bulk_sync` commands.
+	//
+	// Refer to the `AuditLogStreamRequest` and `AuditLogStreamResponse` message
+	// definitions for detailed structure, payloads, behaviors, and constraints.
 	AuditLogStream(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[AuditLogStreamRequest, AuditLogStreamResponse], error)
 	// Register submits a new tenant representing this Teleport cluster to the TAG service,
 	// identified by its HostCA certificate.
@@ -297,27 +295,25 @@ type AccessGraphServiceServer interface {
 	// This stream works the same way as EventsStream, but it returns a stream of events
 	// instead of a single response.
 	EventsStreamV2(grpc.BidiStreamingServer[EventsStreamV2Request, EventsStreamV2Response]) error
-	// AuditLogStream establishes a bidirectional stream for exporting audit log
-	// events from a client (teleport) to a server (access-graph).
+	// AuditLogStream establishes a persistent bidirectional stream for efficiently
+	// exporting audit log events from a client (teleport) to a server (access-graph).
 	//
-	// This stream handles:
-	//   - Sending batches of audit log events (sourced by 'search' or 'bulk').
-	//   - Transmitting resume state information alongside events to ensure reliable
-	//     exporting, allowing clients to resume after disconnections without losing
-	//     data or sending duplicates.
-	//   - Server providing the initial resume state to the client upon connection.
-	//   - Client-initiated synchronization of bulk resume state to purge expired
-	//     dates.
+	// This stream facilitates:
+	// - Initial configuration exchange and validation.
+	// - Streaming batches of audit log events from client to server.
+	// - Reliable export resumption via client-provided resume state updates.
+	// - Server providing the initial resume state to the client upon connection.
+	// - Client requests for server-side bulk export state cleanup.
 	//
-	// Flow:
-	//  1. Client initiates the stream.
-	//  2. Server sends an initial `AuditLogResponse` containing the appropriate
-	//     `resume_state` (Search or Bulk) for the client to start or resume from,
-	//     plus a `start_date`.
-	//  3. Client sends `AuditLogRequest` messages:
-	//     - Containing `AuditLogEvents` (batches of events and current resume
-	//     state/update).
-	//     - OR containing `BulkStateSync` (requests to prune old bulk state).
+	// Basic Interaction Flow:
+	//  1. Client connects and sends an initial `AuditLogStreamRequest` with `config`.
+	//  2. Server replies with an initial `AuditLogStreamResponse`, confirming the
+	//     effective configuration and providing the starting `resume_state` (if any).
+	//  3. Client sends subsequent `AuditLogStreamRequest` messages containing either
+	//     `events` (with resume state updates) or `bulk_sync` commands.
+	//
+	// Refer to the `AuditLogStreamRequest` and `AuditLogStreamResponse` message
+	// definitions for detailed structure, payloads, behaviors, and constraints.
 	AuditLogStream(grpc.BidiStreamingServer[AuditLogStreamRequest, AuditLogStreamResponse]) error
 	// Register submits a new tenant representing this Teleport cluster to the TAG service,
 	// identified by its HostCA certificate.

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -506,6 +506,7 @@ func ApplyFileConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		cfg.AccessGraph.CA = fc.AccessGraph.CA
 		// TODO(tigrato): change this behavior when we drop support for plain text connections
 		cfg.AccessGraph.Insecure = fc.AccessGraph.Insecure
+		cfg.AccessGraph.AuditLogsEnabled = fc.AccessGraph.AuditLogsEnabled
 	}
 
 	applyString(fc.NodeName, &cfg.Hostname)

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -506,7 +506,7 @@ func ApplyFileConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		cfg.AccessGraph.CA = fc.AccessGraph.CA
 		// TODO(tigrato): change this behavior when we drop support for plain text connections
 		cfg.AccessGraph.Insecure = fc.AccessGraph.Insecure
-		cfg.AccessGraph.AuditLogsEnabled = fc.AccessGraph.AuditLogsEnabled
+		cfg.AccessGraph.AuditLog = servicecfg.AuditLogConfig(fc.AccessGraph.AuditLog)
 	}
 
 	applyString(fc.NodeName, &cfg.Hostname)

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -832,8 +832,16 @@ type AccessGraph struct {
 	CA string `yaml:"ca"`
 	// Insecure is true if the AccessGraph service should not verify the CA.
 	Insecure bool `yaml:"insecure"`
-	// AuditLogsEnabled is true if the access graph service should process audit logs.
-	AuditLogsEnabled bool `yaml:"audit_logs_enabled"`
+	// AuditLog contains audit log export details.
+	AuditLog AuditLogConfig `yaml:"audit_log"`
+}
+
+// AuditLogConfig sepcifies the audit log event export setup.
+type AuditLogConfig struct {
+	// Enabled indicates if Audit Log event exporting is enabled.
+	Enabled bool `yaml:"enabled"`
+	// StartDate is the start date for exporting audit logs. It defaults to 90 days ago on the first export.
+	StartDate time.Time `yaml:"start_date"`
 }
 
 // Opsgenie represents the configuration for the Opsgenie plugin.

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -832,6 +832,8 @@ type AccessGraph struct {
 	CA string `yaml:"ca"`
 	// Insecure is true if the AccessGraph service should not verify the CA.
 	Insecure bool `yaml:"insecure"`
+	// AuditLogsEnabled is true if the access graph service should process audit logs.
+	AuditLogsEnabled bool `yaml:"audit_logs_enabled"`
 }
 
 // Opsgenie represents the configuration for the Opsgenie plugin.

--- a/lib/events/export/date_exporter.go
+++ b/lib/events/export/date_exporter.go
@@ -474,8 +474,11 @@ Outer:
 	}
 }
 
-// batchExportEvents exports all events from the provided stream in bulk,
-// updating the supplied entry on each successful export.
+// batchExportEvents reads events from the provided stream and exports them in batches.
+// Batching adheres to the export configuration: batches are sent either when
+// they reach the configured maximum size (MaxSize) or after the maximum delay
+// (MaxDelay) has passed with pending events. Processing continues until the
+// stream closes or an error occurs.
 func (e *DateExporter) batchExportEvents(ctx context.Context, stream stream.Stream[*auditlogpb.ExportEventUnstructured], entry *chunkEntry, chunk string) error {
 	var (
 		events []*auditlogpb.EventUnstructured

--- a/lib/events/export/date_exporter.go
+++ b/lib/events/export/date_exporter.go
@@ -96,12 +96,8 @@ func (cfg *DateExporterConfig) CheckAndSetDefaults() error {
 		cfg.PollInterval = 16 * time.Second
 	}
 	if cfg.BatchExport != nil {
-		if cfg.BatchExport.MaxDelay == 0 {
-			cfg.BatchExport.MaxDelay = time.Second * 5
-		}
-		if cfg.BatchExport.MaxSize == 0 {
-			cfg.BatchExport.MaxSize = 2 * 1024 * 1024 // 2MiB
-		}
+		cfg.BatchExport.MaxDelay = cmp.Or(cfg.BatchExport.MaxDelay, 5 * time.Second)
+		cfg.BatchExport.MaxSize = cmp.Or(cfg.BatchExport.MaxSize, 2 * 1024 * 1024 /* 2MiB */)
 	}
 	return nil
 }

--- a/lib/events/export/date_exporter.go
+++ b/lib/events/export/date_exporter.go
@@ -19,6 +19,7 @@
 package export
 
 import (
+	"cmp"
 	"context"
 	"log/slog"
 	"sync"
@@ -86,18 +87,12 @@ func (cfg *DateExporterConfig) CheckAndSetDefaults() error {
 	if cfg.Date.IsZero() {
 		return trace.BadParameter("missing required parameter Date in DateExporterConfig")
 	}
-	if cfg.Concurrency == 0 {
-		cfg.Concurrency = 1
-	}
-	if cfg.MaxBackoff == 0 {
-		cfg.MaxBackoff = 90 * time.Second
-	}
-	if cfg.PollInterval == 0 {
-		cfg.PollInterval = 16 * time.Second
-	}
+	cfg.Concurrency = cmp.Or(cfg.Concurrency, 1)
+	cfg.MaxBackoff = cmp.Or(cfg.MaxBackoff, 90*time.Second)
+	cfg.PollInterval = cmp.Or(cfg.PollInterval, 16*time.Second)
 	if cfg.BatchExport != nil {
-		cfg.BatchExport.MaxDelay = cmp.Or(cfg.BatchExport.MaxDelay, 5 * time.Second)
-		cfg.BatchExport.MaxSize = cmp.Or(cfg.BatchExport.MaxSize, 2 * 1024 * 1024 /* 2MiB */)
+		cfg.BatchExport.MaxDelay = cmp.Or(cfg.BatchExport.MaxDelay, 5*time.Second)
+		cfg.BatchExport.MaxSize = cmp.Or(cfg.BatchExport.MaxSize, 2*1024*1024 /* 2MiB */)
 	}
 	return nil
 }

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -330,8 +330,16 @@ type AccessGraphConfig struct {
 	// Insecure is true if the connection to the Access Graph service should be insecure
 	Insecure bool
 
-	// AuditLogsEnabled is true if the access graph service should process audit logs.
-	AuditLogsEnabled bool
+	// AuditLog contains audit log export details.
+	AuditLog AuditLogConfig
+}
+
+// AuditLogConfig sepcifies the audit log event export setup.
+type AuditLogConfig struct {
+	// Enabled indicates if Audit Log event exporting is enabled.
+	Enabled bool
+	// StartDate is the start date for exporting audit logs. It defaults to 90 days ago on the first export.
+	StartDate time.Time
 }
 
 // RoleAndIdentityEvent is a role and its corresponding identity event.

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -329,6 +329,9 @@ type AccessGraphConfig struct {
 
 	// Insecure is true if the connection to the Access Graph service should be insecure
 	Insecure bool
+
+	// AuditLogsEnabled is true if the access graph service should process audit logs.
+	AuditLogsEnabled bool
 }
 
 // RoleAndIdentityEvent is a role and its corresponding identity event.

--- a/proto/accessgraph/v1alpha/access_graph_service.proto
+++ b/proto/accessgraph/v1alpha/access_graph_service.proto
@@ -65,8 +65,8 @@ service AccessGraphService {
   // instead of a single response.
   rpc EventsStreamV2(stream EventsStreamV2Request) returns (stream EventsStreamV2Response);
 
-  // AuditLogStream establishes a persistent bidirectional stream for efficiently
-  // exporting audit log events from a client (teleport) to a server (access-graph).
+  // AuditLogStream establishes a persistent bidirectional stream for exporting
+  // audit log events from a client (teleport) to a server (access-graph).
   //
   // This stream facilitates:
   // - Initial configuration exchange and validation.

--- a/proto/accessgraph/v1alpha/access_graph_service.proto
+++ b/proto/accessgraph/v1alpha/access_graph_service.proto
@@ -28,6 +28,8 @@ import "accessgraph/v1alpha/gitlab.proto";
 import "accessgraph/v1alpha/graph.proto";
 import "accessgraph/v1alpha/netiq.proto";
 import "accessgraph/v1alpha/resources.proto";
+import "google/protobuf/timestamp.proto";
+import "teleport/auditlog/v1/auditlog.proto";
 
 option go_package = "github.com/gravitational/teleport/gen/proto/go/accessgraph/v1alpha;accessgraphv1alpha";
 
@@ -61,6 +63,29 @@ service AccessGraphService {
   // This stream works the same way as EventsStream, but it returns a stream of events
   // instead of a single response.
   rpc EventsStreamV2(stream EventsStreamV2Request) returns (stream EventsStreamV2Response);
+
+  // AuditLogStream establishes a bidirectional stream for exporting audit log
+  // events from a client (teleport) to a server (access-graph).
+  //
+  // This stream handles:
+  // - Sending batches of audit log events (sourced by 'search' or 'bulk').
+  // - Transmitting resume state information alongside events to ensure reliable
+  //   exporting, allowing clients to resume after disconnections without losing
+  //   data or sending duplicates.
+  // - Server providing the initial resume state to the client upon connection.
+  // - Client-initiated synchronization of bulk resume state to purge expired
+  //   dates.
+  //
+  // Flow:
+  // 1. Client initiates the stream.
+  // 2. Server sends an initial `AuditLogResponse` containing the appropriate
+  //    `resume_state` (Search or Bulk) for the client to start or resume from,
+  //    plus a `start_date`.
+  // 3. Client sends `AuditLogRequest` messages:
+  //    - Containing `AuditLogEvents` (batches of events and current resume
+  //      state/update).
+  //    - OR containing `BulkStateSync` (requests to prune old bulk state).
+  rpc AuditLogStream(stream AuditLogStreamRequest) returns (stream AuditLogStreamResponse);
 
   // Register submits a new tenant representing this Teleport cluster to the TAG service,
   // identified by its HostCA certificate.
@@ -196,6 +221,125 @@ message AuditEvent {
     // access_path_changed is an event that should be logged when the access path changes.
     AccessPathChanged access_path_changed = 1;
   }
+}
+
+// AuditLogStreamRequest is sent from the client to the server over the
+// AuditLogStream. It contains different actions related to sending audit logs
+// in unstructured events and managing resume state.
+//
+// The message uses a `oneof` to distinguish between two primary client actions:
+// 1. Sending a batch of audit log events (`events`): This includes the actual
+//    log data (unstructured format) and the corresponding resume state
+//    information relevant to the event source ('search' or 'bulk').
+// 2. Synchronizing bulk export resume state (`bulk_sync`): This is a command
+//    sent separately from log events, instructing the server to clean up state
+//    related to older, completed bulk export dates.
+//
+// Behavior and Constraints
+// - Direction: Client -> Server.
+// - Stream Consistency: When sending the `events` payload, a single gRPC stream
+//   connection MUST consistently send *either only* 'search' type events
+//   *or only* 'bulk' type events. Mixing event types within the `events`
+//   payload on the same stream is not permitted.
+// - State Management: Resume state sent with `events` allows the server to
+//   track the client's progress. The `bulk_sync` provides an explicit
+//   mechanism for purging old, completed dates of bulk exporting from the
+//   resume state.
+// - Stream Evolution: While the overall system might support upgrading the
+//   event type processed from 'search' to 'bulk' handling across
+//   *different* connections or restarts, downgrading behavior is undefined.
+message AuditLogStreamRequest {
+  oneof action {
+    AuditLogEvents events = 1; // Batch of audit log events and resume state.
+    BulkResumeStateSync bulk_sync = 2; // Command to prune server-side bulk export state.
+  }
+}
+
+// AuditLogEvents bundles a batch of unstructured audit log events with the
+// appropriate resume state information for the type of events being sent
+// ('search' or 'bulk'). This allows the server to persist the client's
+// progress.
+message AuditLogEvents {
+  repeated teleport.auditlog.v1.EventUnstructured events = 1; // Batch of audit log events.
+  oneof resume_state {
+    SearchResumeState search_resume_state = 2; // Complete resume state when sending 'search' events.
+    BulkResumeStateUpdate bulk_resume_state_update = 3; // Incremental resume state update when sending 'bulk' events.
+  }
+}
+
+// SearchResumeState represents the complete, self-contained state required by a
+// client to resume exporting 'search' type audit events.
+//
+// This state is:
+// - Sent by the client *with each batch* of 'search' events
+//   (`AuditLogRequest`).
+// - Sent by the server *to the client* on stream initiation
+//   (`AuditLogResponse`) if the client should resume in 'search' mode.
+message SearchResumeState {
+  // start_key is a key used as cursor indicating where the *next* search for
+  // events should begin.
+  string start_key = 1;
+  // last_event_id is the ID of the most recent event processed for this
+  // specific `start_key` as of the last fetch. It is empty if this `start_key`
+  // has not yet been used for a search.
+  string last_event_id = 2;
+  // last_event_time is the timestamp of the last event successfully processed,
+  // it corresponds to last_event_id if not empty. The clients can leave
+  // last_event_time empty in requests as the server infers it from the last
+  // event in the batch. last_event_time MUST be set by the server in the
+  // initial `AuditLogResponse`.
+  google.protobuf.Timestamp last_event_time = 3;
+}
+
+// BulkResumeStateUpdate provides an incremental update to the server about the
+// client's progress within a specific chunk of a bulk export for a given date.
+// It is sent by the client along with batches of 'bulk' type events. A single
+// batch of bulk events is assumed to be sequential and belong to one chunk.
+message BulkResumeStateUpdate {
+  google.protobuf.Timestamp date = 1; // UTC date of chunk, normalized to 00:00:00.
+  string chunk = 2; // Chunk identifier within the date.
+  string cursor = 3; // Position *after* the last event processed in this chunk.
+  bool completed = 4; // True if this chunk is now fully completed.
+}
+
+// BulkResumeStateSync is a request sent by the client to the server,
+// independently of sending log events, to manage the overall state of bulk
+// exports. It informs the server which export dates are still considered
+// active by the client, allowing the server to prune the state for all chunks
+// for dates that are no longer active and are older than the most recent
+// active date.
+message BulkResumeStateSync {
+  repeated google.protobuf.Timestamp active_dates = 1; // UTC date normalized to 00:00:00.
+}
+
+// AuditLogStreamResponse is sent from the server to the client over the
+// AuditLogStream. It's used on stream initiation to provide the client with
+// the necessary starting point (state) to resume exporting.
+message AuditLogStreamResponse {
+  // start_date is the start date of the export, relevant on initial, back-fill
+  // export. It defaults to 90 days ago.
+  google.protobuf.Timestamp start_date = 1;
+
+  oneof resume_state {
+    SearchResumeState search_resume_state = 2; // Complete resume state for 'search' mode.
+    BulkResumeState bulk_resume_state = 3; // Complete resume state for 'bulk' mode.
+  }
+}
+
+// BulkResumeState is the complete, standalone state for bulk exports across
+// various dates. It is sent by the server to the client
+// (within `AuditLogResponse`) to allow the client to resume bulk exporting
+// accurately.
+message BulkResumeState {
+  repeated BulkResumeDate dates = 1; // List of resume states, one for each relevant date.
+}
+
+// BulkResumeDate details the bulk export resume state for a *single* specific
+// date.
+message BulkResumeDate {
+  google.protobuf.Timestamp date = 1; // UTC date normalized to 00:00:00.
+  repeated string completed_chunks = 2; // Fully exported chunks for this date; skip on resume.
+  map<string, string> chunk_cursors = 3; // Cursors for resuming incomplete chunks (chunk_id -> cursor).
 }
 
 // RegisterRequest is the request for Register.

--- a/proto/accessgraph/v1alpha/access_graph_service.proto
+++ b/proto/accessgraph/v1alpha/access_graph_service.proto
@@ -28,6 +28,7 @@ import "accessgraph/v1alpha/gitlab.proto";
 import "accessgraph/v1alpha/graph.proto";
 import "accessgraph/v1alpha/netiq.proto";
 import "accessgraph/v1alpha/resources.proto";
+import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 import "teleport/auditlog/v1/auditlog.proto";
 
@@ -64,27 +65,25 @@ service AccessGraphService {
   // instead of a single response.
   rpc EventsStreamV2(stream EventsStreamV2Request) returns (stream EventsStreamV2Response);
 
-  // AuditLogStream establishes a bidirectional stream for exporting audit log
-  // events from a client (teleport) to a server (access-graph).
+  // AuditLogStream establishes a persistent bidirectional stream for efficiently
+  // exporting audit log events from a client (teleport) to a server (access-graph).
   //
-  // This stream handles:
-  // - Sending batches of audit log events (sourced by 'search' or 'bulk').
-  // - Transmitting resume state information alongside events to ensure reliable
-  //   exporting, allowing clients to resume after disconnections without losing
-  //   data or sending duplicates.
+  // This stream facilitates:
+  // - Initial configuration exchange and validation.
+  // - Streaming batches of audit log events from client to server.
+  // - Reliable export resumption via client-provided resume state updates.
   // - Server providing the initial resume state to the client upon connection.
-  // - Client-initiated synchronization of bulk resume state to purge expired
-  //   dates.
+  // - Client requests for server-side bulk export state cleanup.
   //
-  // Flow:
-  // 1. Client initiates the stream.
-  // 2. Server sends an initial `AuditLogResponse` containing the appropriate
-  //    `resume_state` (Search or Bulk) for the client to start or resume from,
-  //    plus a `start_date`.
-  // 3. Client sends `AuditLogRequest` messages:
-  //    - Containing `AuditLogEvents` (batches of events and current resume
-  //      state/update).
-  //    - OR containing `BulkStateSync` (requests to prune old bulk state).
+  // Basic Interaction Flow:
+  // 1. Client connects and sends an initial `AuditLogStreamRequest` with `config`.
+  // 2. Server replies with an initial `AuditLogStreamResponse`, confirming the
+  //    effective configuration and providing the starting `resume_state` (if any).
+  // 3. Client sends subsequent `AuditLogStreamRequest` messages containing either
+  //    `events` (with resume state updates) or `bulk_sync` commands.
+  //
+  // Refer to the `AuditLogStreamRequest` and `AuditLogStreamResponse` message
+  // definitions for detailed structure, payloads, behaviors, and constraints.
   rpc AuditLogStream(stream AuditLogStreamRequest) returns (stream AuditLogStreamResponse);
 
   // Register submits a new tenant representing this Teleport cluster to the TAG service,
@@ -224,35 +223,50 @@ message AuditEvent {
 }
 
 // AuditLogStreamRequest is sent from the client to the server over the
-// AuditLogStream. It contains different actions related to sending audit logs
-// in unstructured events and managing resume state.
+// bi-directional AuditLogStream. It encapsulates distinct client actions for
+// configuring the export stream, sending batches of audit log events, and
+// managing the persistent resume state maintained by the server.
 //
-// The message uses a `oneof` to distinguish between two primary client actions:
-// 1. Sending a batch of audit log events (`events`): This includes the actual
-//    log data (unstructured format) and the corresponding resume state
-//    information relevant to the event source ('search' or 'bulk').
-// 2. Synchronizing bulk export resume state (`bulk_sync`): This is a command
-//    sent separately from log events, instructing the server to clean up state
-//    related to older, completed bulk export dates.
+// The message uses a `oneof` payload to represent one of three distinct actions:
 //
-// Behavior and Constraints
-// - Direction: Client -> Server.
-// - Stream Consistency: When sending the `events` payload, a single gRPC stream
-//   connection MUST consistently send *either only* 'search' type events
-//   *or only* 'bulk' type events. Mixing event types within the `events`
-//   payload on the same stream is not permitted.
-// - State Management: Resume state sent with `events` allows the server to
-//   track the client's progress. The `bulk_sync` provides an explicit
-//   mechanism for purging old, completed dates of bulk exporting from the
-//   resume state.
-// - Stream Evolution: While the overall system might support upgrading the
-//   event type processed from 'search' to 'bulk' handling across
-//   *different* connections or restarts, downgrading behavior is undefined.
+// 1. Configuration (`config`): First message on (re)connect. Client proposes
+//    `AuditLogConfig`. Server validates against its persisted state for the client
+//    identity. Initial server response confirms the effective config (which may
+//    be the proposed, an inferred default, or the existing persisted one).
+//    Irreconcilable conflicts (e.g., invalid start date) typically result in the
+//    server logging an error, using the persisted config, and signaling this outcome.
+//
+// 2. Event Batch (`events`): Sends a batch of audit logs (`AuditLogEvents`) in an
+//    unstructured format. Each batch must also include the corresponding
+//    `resume_state` information ('search' or 'bulk' type) reflecting the client's
+//    processing progress for that specific event source type up to the included events.
+//    This allows the server to persistently track the client's progress.
+//
+// 3. Bulk State Synchronization (`bulk_sync`): Sends `BulkResumeStateSync` command,
+//    separate from event batches, to request that the server prune state for past
+//    dates that are fully completed.
+//
+// Behavior and Constraints:
+// - Direction: Client -> Server only.
+// - Initial Message: First message on stream MUST be `config`.
+// - Stream State Consistency: `resume_state` with `events` corresponds to
+//   'search' or 'bulk' tracking mode. While primarily one mode operates,
+//   upgrades 'search' -> 'bulk' may be possible; downgrading 'bulk' -> 'search'
+//   is not permitted per client identity.
+// - State Management:
+//   - `events` includes `resume_state` for persistent progress tracking.
+//   - `bulk_sync` allows purging state for old, completed bulk export dates.
 message AuditLogStreamRequest {
   oneof action {
-    AuditLogEvents events = 1; // Batch of audit log events and resume state.
-    BulkResumeStateSync bulk_sync = 2; // Command to prune server-side bulk export state.
+    AuditLogConfig config = 1; // Export configuration, e.g. start date. // Config negatiation phase
+    AuditLogEvents events = 2; // Batch of audit log events and resume state.
+    BulkResumeStateSync bulk_sync = 3; // Command to prune server-side bulk export state.
   }
+}
+
+// AuditLogConfig is the configuration for exporting audit logs.
+message AuditLogConfig {
+  google.protobuf.Timestamp start_date = 1; // Start date for exporting audit logs.
 }
 
 // AuditLogEvents bundles a batch of unstructured audit log events with the
@@ -313,16 +327,16 @@ message BulkResumeStateSync {
 }
 
 // AuditLogStreamResponse is sent from the server to the client over the
-// AuditLogStream. It's used on stream initiation to provide the client with
-// the necessary starting point (state) to resume exporting.
+// AuditLogStream. It conveys state information during the export process.
+// NOTE: During stream initiation, the server MUST send two responses sequentially:
+// 1. The effective `AuditLogConfig`.
+// 2. The starting resume state (`SearchResumeState`, `BulkResumeState`, or Empty` if none).
 message AuditLogStreamResponse {
-  // start_date is the start date of the export, relevant on initial, back-fill
-  // export. It defaults to 90 days ago.
-  google.protobuf.Timestamp start_date = 1;
-
-  oneof resume_state {
-    SearchResumeState search_resume_state = 2; // Complete resume state for 'search' mode.
-    BulkResumeState bulk_resume_state = 3; // Complete resume state for 'bulk' mode.
+  oneof state {
+    AuditLogConfig audit_log_config = 1; // Effective, negotiated configuration.
+    google.protobuf.Empty no_resume_state = 2; // No resume state available.
+    SearchResumeState search_resume_state = 3; // Complete resume state for 'search' mode.
+    BulkResumeState bulk_resume_state = 4; // Complete resume state for 'bulk' mode.
   }
 }
 
@@ -331,7 +345,7 @@ message AuditLogStreamResponse {
 // (within `AuditLogResponse`) to allow the client to resume bulk exporting
 // accurately.
 message BulkResumeState {
-  repeated BulkResumeDate dates = 1; // List of resume states, one for each relevant date.
+  repeated BulkResumeDate dates = 2; // List of resume states, one for each relevant date.
 }
 
 // BulkResumeDate details the bulk export resume state for a *single* specific


### PR DESCRIPTION
Extend access_graph_service.proto with

	rpc AuditLogStream

Audit logs and resume state (update) get pushed from Teleport client to TAG server via bi-di grpc stream.

Add configuration item to `audit_logs_enabled` to yaml and proto to in access graph configuration section to enable audit log exporting.

Extend `export.Exporter` with new callback `BatchExport`, which exports a slice of `auditlog.EventStructured`, all belonging to the same chunk. Limit the size `BatchExportConfig.MaxSize` and send new events after a maximum delay of `BatchExportConfig.MaxDelay`.

---

This is a follow on from https://github.com/gravitational/teleport/pull/53624
where I rebased `iac` and `julia/auditlog-tag-export branches` onto master and 
pushed and somehow managed to trigger an automatic merge. Sorry.