### PR TITLE
Web/Teleterm: Add db status state to shared unified resources view

### DIFF
--- a/web/packages/shared/components/UnifiedResources/CardsView/CardsView.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/CardsView.tsx
@@ -38,24 +38,22 @@ export function CardsView({
 }: ResourceViewProps) {
   return (
     <CardsContainer className="CardsContainer" gap={2}>
-      {mappedResources.map(({ item, key }) => (
-        <ResourceCard
-          key={key}
-          name={item.name}
-          ActionButton={item.ActionButton}
-          primaryIconName={item.primaryIconName}
-          onLabelClick={onLabelClick}
-          SecondaryIcon={item.SecondaryIcon}
-          cardViewProps={item.cardViewProps}
-          labels={item.labels}
-          pinned={pinnedResources.includes(key)}
-          requiresRequest={item.requiresRequest}
-          pinningSupport={pinningSupport}
-          selected={selectedResources.includes(key)}
-          selectResource={() => onSelectResource(key)}
-          pinResource={() => onPinResource(key)}
-        />
-      ))}
+      {mappedResources.map(
+        ({ item, key, onShowStatusInfo, showingStatusInfo }) => (
+          <ResourceCard
+            key={key}
+            viewItem={item}
+            onLabelClick={onLabelClick}
+            pinned={pinnedResources.includes(key)}
+            pinningSupport={pinningSupport}
+            selected={selectedResources.includes(key)}
+            selectResource={() => onSelectResource(key)}
+            pinResource={() => onPinResource(key)}
+            onShowStatusInfo={onShowStatusInfo}
+            showingStatusInfo={showingStatusInfo}
+          />
+        )
+      )}
       {isProcessing && (
         <LoadingSkeleton count={FETCH_MORE_SIZE} Element={<LoadingCard />} />
       )}

--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.story.tsx
@@ -134,12 +134,9 @@ export const Cards: Story = {
                 selectResource={() => {}}
                 selected={false}
                 pinningSupport={PinningSupport.Supported}
-                name={res.name}
-                primaryIconName={res.primaryIconName}
-                SecondaryIcon={res.SecondaryIcon}
-                cardViewProps={res.cardViewProps}
-                labels={res.labels}
-                ActionButton={res.ActionButton}
+                onShowStatusInfo={() => null}
+                showingStatusInfo={false}
+                viewItem={res}
               />
             ))}
           </Grid>

--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
@@ -30,9 +30,12 @@ import { CopyButton } from '../shared/CopyButton';
 import {
   BackgroundColorProps,
   getBackgroundColor,
+  getStatusBackgroundColor,
 } from '../shared/getBackgroundColor';
 import { PinButton } from '../shared/PinButton';
+import { SingleLineBox } from '../shared/SingleLineBox';
 import { ResourceItemProps } from '../types';
+import { WarningRightEdgeBadgeSvg } from './WarningRightEdgeBadgeSvg';
 
 // Since we do a lot of manual resizing and some absolute positioning, we have
 // to put some layout constants in place here.
@@ -51,20 +54,26 @@ const ResTypeIconBox = styled(Box)`
 `;
 
 export function ResourceCard({
-  name,
-  primaryIconName,
-  SecondaryIcon,
   onLabelClick,
-  cardViewProps,
-  ActionButton,
-  labels,
   pinningSupport,
   pinned,
   pinResource,
   selectResource,
-  requiresRequest,
   selected,
-}: Omit<ResourceItemProps, 'listViewProps' | 'expandAllLabels'>) {
+  onShowStatusInfo,
+  showingStatusInfo,
+  viewItem,
+}: Omit<ResourceItemProps, 'expandAllLabels'>) {
+  const {
+    name,
+    primaryIconName,
+    SecondaryIcon,
+    cardViewProps,
+    ActionButton,
+    labels,
+    requiresRequest,
+    status,
+  } = viewItem;
   const { primaryDesc, secondaryDesc } = cardViewProps;
 
   const [showMoreLabelsButton, setShowMoreLabelsButton] = useState(false);
@@ -157,12 +166,18 @@ export function ResourceCard({
     }
   };
 
+  const hasUnhealthyStatus = status && status !== 'healthy';
+
   return (
     <CardContainer
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
+      showingStatusInfo={showingStatusInfo}
     >
-      <CardOuterContainer showAllLabels={showAllLabels}>
+      <CardOuterContainer
+        showAllLabels={showAllLabels}
+        hasUnhealthyStatus={hasUnhealthyStatus}
+      >
         <CardInnerContainer
           ref={innerContainer}
           p={3}
@@ -174,6 +189,12 @@ export function ResourceCard({
           pinned={pinned}
           requiresRequest={requiresRequest}
           selected={selected}
+          showingStatusInfo={showingStatusInfo}
+          hasUnhealthyStatus={hasUnhealthyStatus}
+          // we set extra padding to push contents to the right to make
+          // space for the WarningRightEdgeBadgeIcon.
+          {...(hasUnhealthyStatus && !showAllLabels && { pr: '35px' })}
+          {...(hasUnhealthyStatus && showAllLabels && { pr: '7px' })}
         >
           <HoverTooltip tipContent={selected ? 'Deselect' : 'Select'}>
             <CheckboxInput
@@ -242,7 +263,10 @@ export function ResourceCard({
               )}
             </Flex>
             <LabelsContainer showAll={showAllLabels}>
-              <LabelsInnerContainer ref={labelsInnerContainer}>
+              <LabelsInnerContainer
+                ref={labelsInnerContainer}
+                hasUnhealthyStatus={hasUnhealthyStatus}
+              >
                 <MoreLabelsButton
                   style={{
                     visibility:
@@ -271,11 +295,37 @@ export function ResourceCard({
               </LabelsInnerContainer>
             </LabelsContainer>
           </Flex>
+          {hasUnhealthyStatus && !showAllLabels && (
+            <HoverTooltip tipContent={'Show Connection Issue'} placement="left">
+              <WarningRightEdgeBadgeIcon onClick={onShowStatusInfo} />
+            </HoverTooltip>
+          )}
         </CardInnerContainer>
       </CardOuterContainer>
+      {/* This is to let the WarningRightEdgeBadgeIcon stay in place while the
+        InnerContainer pops out and expands vertically from rendering all
+        labels. */}
+      {hasUnhealthyStatus && showAllLabels && <WarningRightEdgeBadgeIcon />}
     </CardContainer>
   );
 }
+
+const WarningRightEdgeBadgeIcon = ({ onClick }: { onClick?(): void }) => {
+  return (
+    <Box
+      onClick={onClick}
+      css={`
+        position: absolute;
+        top: 0;
+        right: 0;
+        cursor: pointer;
+        height: 100%;
+      `}
+    >
+      <WarningRightEdgeBadgeSvg />
+    </Box>
+  );
+};
 
 /**
  * The outer container's purpose is to reserve horizontal space on the resource
@@ -284,15 +334,40 @@ export function ResourceCard({
  * clicks the "more" button, the inner container "pops out" by changing its
  * position to absolute.
  *
+ * The card height is fixed to allow the WarningRightEdgeBadgeIcon to stay in
+ * place when user clicks on "showAllLabels". Without the fixed height, the
+ * container's height shrinks when the inner container pops out, resulting in
+ * the svg to jump around (from size difference) and or disappearing.
+ *
  * TODO(bl-nero): Known issue: this doesn't really work well with one-column
- * layout; we may need to globally set the card height to fixed size on the
- * outer container.
+ * layout;
  */
-const CardContainer = styled(Box)`
+const CardContainer = styled(Box)<{
+  showingStatusInfo: boolean;
+}>`
+  height: 110px;
+
   position: relative;
+  .resource-health-status-svg {
+    width: 100%;
+    height: 100%;
+
+    fill: ${p =>
+      p.showingStatusInfo
+        ? p.theme.colors.interactive.solid.alert.active
+        : p.theme.colors.interactive.solid.alert.default};
+  }
+  &:hover {
+    .resource-health-status-svg {
+      fill: ${p => p.theme.colors.interactive.solid.alert.hover};
+    }
+  }
 `;
 
-const CardOuterContainer = styled(Box)<{ showAllLabels?: boolean }>`
+const CardOuterContainer = styled(Box)<{
+  showAllLabels?: boolean;
+  hasUnhealthyStatus: boolean;
+}>`
   border-radius: ${props => props.theme.radii[3]}px;
 
   ${props =>
@@ -300,7 +375,8 @@ const CardOuterContainer = styled(Box)<{ showAllLabels?: boolean }>`
     css`
       position: absolute;
       left: 0;
-      right: 0;
+      // The padding is required to show the WarningRightEdgeBadgeIcon
+      right: ${props.hasUnhealthyStatus ? '28px' : 0};
       z-index: 1;
     `}
   transition: all 150ms;
@@ -340,16 +416,40 @@ const CardInnerContainer = styled(Flex)<BackgroundColorProps>`
   border-radius: ${props => props.theme.radii[3]}px;
   background-color: ${props => getBackgroundColor(props)};
 
+  ${p =>
+    p.hasUnhealthyStatus &&
+    css`
+      border: 2px solid ${p.theme.colors.interactive.solid.alert.default};
+      background-color: ${getStatusBackgroundColor({
+        showingStatusInfo: p.showingStatusInfo,
+        theme: p.theme,
+        action: '',
+        viewType: 'card',
+      })};
+    `}
+
+  ${p =>
+    p.showingStatusInfo &&
+    css`
+      border: 2px solid ${p.theme.colors.interactive.solid.alert.active};
+    `}
+
   &:hover {
     // Make the border invisible instead of removing it, this is to prevent things from shifting due to the size change.
     border: ${props => props.theme.borders[2]} rgba(0, 0, 0, 0);
-  }
-`;
 
-const SingleLineBox = styled(Box)`
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
+    ${p =>
+      p.hasUnhealthyStatus &&
+      css`
+        border-color: ${p.theme.colors.interactive.solid.alert.hover};
+        background-color: ${getStatusBackgroundColor({
+          showingStatusInfo: p.showingStatusInfo,
+          theme: p.theme,
+          action: 'hover',
+          viewType: 'card',
+        })};
+      `}
+  }
 `;
 
 /**
@@ -376,12 +476,16 @@ const StyledLabel = styled(Label)`
  * The inner labels container always adapts to the size of labels.  Its height
  * is measured by the resize observer.
  */
-const LabelsInnerContainer = styled(Flex)`
+const LabelsInnerContainer = styled(Flex)<{ hasUnhealthyStatus: boolean }>`
   position: relative;
   flex-wrap: wrap;
   align-items: start;
   gap: ${props => props.theme.space[1]}px;
-  padding-right: 60px;
+  // Padding is required to prevent the more label button to not collide
+  // with the rendered labels. Just a tiny bit more padding needed to
+  // accomodate contents getting pushed more to the right when a
+  // WarningRightEdgeBadgeIcon renders.
+  padding-right: ${p => (p.hasUnhealthyStatus ? '75px' : '74px')};
 `;
 
 /**
@@ -397,10 +501,14 @@ const MoreLabelsButton = styled(ButtonLink)`
   margin: ${labelVerticalMargin}px 0;
   min-height: 0;
 
-  background-color: ${props => getBackgroundColor(props)};
+  background-color: transparent;
   color: ${props => props.theme.colors.text.slightlyMuted};
   font-style: italic;
 
   transition: visibility 0s;
   transition: background 150ms;
+
+  &:hover {
+    background-color: transparent;
+  }
 `;

--- a/web/packages/shared/components/UnifiedResources/CardsView/WarningRightEdgeBadgeSvg.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/WarningRightEdgeBadgeSvg.tsx
@@ -1,0 +1,60 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This svg is different from existing warning svg's in that it's specifically
+ * tailored to fit the design of unified ResourceCard.tsx to the right edge
+ * of the component.
+ */
+export function WarningRightEdgeBadgeSvg() {
+  return (
+    <svg
+      /**
+       * "className" is used instead of "fill" to style (color) the svg.
+       * The svg needs to change style when user hovers anywhere in the
+       * container the svg is a part of. This required the use of "className"
+       * to target the svg as part of a container.
+       */
+      className="resource-health-status-svg"
+      width="32"
+      height="102"
+      viewBox="0 0 32 102"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      preserveAspectRatio="none"
+    >
+      <path d="M24 0H0V2C3.31371 2 6 4.68629 6 8H32C32 3.58172 28.4183 0 24 0Z" />
+      <path d="M6 7H32V95H6V8Z" />
+      <path d="M32 94H6C6 97.3137 3.31371 100 0 100V102H24C28.4183 102 32 98.4183 32 94Z" />
+      <path
+        d="M19 49.0007C19.2761 49.0007 19.5 49.2245 19.5 49.5007V52.0007C19.5 52.2768 19.2761 52.5007 19 52.5007C18.7239 52.5007 18.5 52.2768 18.5 52.0007V49.5007C18.5 49.2245 18.7239 49.0007 19 49.0007Z"
+        fill="black"
+      />
+      <path
+        d="M19 54.8757C19.3452 54.8757 19.625 54.5958 19.625 54.2507C19.625 53.9055 19.3452 53.6257 19 53.6257C18.6548 53.6257 18.375 53.9055 18.375 54.2507C18.375 54.5958 18.6548 54.8757 19 54.8757Z"
+        fill="black"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M17.7267 45.2292L12.254 54.8064C11.6953 55.7842 12.4013 57.0007 13.5274 57.0007H24.4728C25.5989 57.0007 26.3049 55.7842 25.7462 54.8064L20.2735 45.2292C19.7105 44.2439 18.2897 44.2439 17.7267 45.2292ZM13.1222 55.3025L18.5949 45.7254C18.7741 45.4119 19.2261 45.4119 19.4053 45.7254L24.8779 55.3025C25.0557 55.6136 24.8311 56.0007 24.4728 56.0007H13.5274C13.1691 56.0007 12.9445 55.6136 13.1222 55.3025Z"
+        fill="black"
+      />
+    </svg>
+  );
+}

--- a/web/packages/shared/components/UnifiedResources/ListView/ListView.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ListView.tsx
@@ -37,25 +37,23 @@ export function ListView({
 }: ResourceViewProps) {
   return (
     <Flex className="ListContainer">
-      {mappedResources.map(({ item, key }) => (
-        <ResourceListItem
-          key={key}
-          name={item.name}
-          ActionButton={item.ActionButton}
-          primaryIconName={item.primaryIconName}
-          onLabelClick={onLabelClick}
-          SecondaryIcon={item.SecondaryIcon}
-          listViewProps={item.listViewProps}
-          labels={item.labels}
-          pinned={pinnedResources.includes(key)}
-          pinningSupport={pinningSupport}
-          requiresRequest={item.requiresRequest}
-          selected={selectedResources.includes(key)}
-          selectResource={() => onSelectResource(key)}
-          pinResource={() => onPinResource(key)}
-          expandAllLabels={expandAllLabels}
-        />
-      ))}
+      {mappedResources.map(
+        ({ item, key, onShowStatusInfo, showingStatusInfo }) => (
+          <ResourceListItem
+            key={key}
+            viewItem={item}
+            onLabelClick={onLabelClick}
+            pinned={pinnedResources.includes(key)}
+            pinningSupport={pinningSupport}
+            selected={selectedResources.includes(key)}
+            selectResource={() => onSelectResource(key)}
+            pinResource={() => onPinResource(key)}
+            expandAllLabels={expandAllLabels}
+            onShowStatusInfo={onShowStatusInfo}
+            showingStatusInfo={showingStatusInfo}
+          />
+        )
+      )}
       {isProcessing && (
         <LoadingSkeleton
           count={FETCH_MORE_SIZE}

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.story.tsx
@@ -117,13 +117,10 @@ export const ListItems: Story = {
             selectResource={() => {}}
             selected={false}
             pinningSupport={PinningSupport.Supported}
-            name={res.name}
-            primaryIconName={res.primaryIconName}
-            SecondaryIcon={res.SecondaryIcon}
-            listViewProps={res.listViewProps}
-            labels={res.labels}
-            ActionButton={res.ActionButton}
             expandAllLabels={false}
+            onShowStatusInfo={() => null}
+            showingStatusInfo={false}
+            viewItem={res}
           />
         ))}
       </Flex>

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
@@ -17,11 +17,11 @@
  */
 
 import { useEffect, useState } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { Box, ButtonIcon, Flex, Label, Text } from 'design';
 import { CheckboxInput } from 'design/Checkbox';
-import { Tags } from 'design/Icon';
+import { Tags, Warning } from 'design/Icon';
 import { ResourceIcon } from 'design/ResourceIcon';
 import { HoverTooltip } from 'design/Tooltip';
 
@@ -31,26 +31,33 @@ import { CopyButton } from '../shared/CopyButton';
 import {
   BackgroundColorProps,
   getBackgroundColor,
+  getStatusBackgroundColor,
 } from '../shared/getBackgroundColor';
 import { PinButton } from '../shared/PinButton';
 import { ResourceItemProps } from '../types';
 
 export function ResourceListItem({
-  name,
-  primaryIconName,
-  SecondaryIcon,
   onLabelClick,
-  listViewProps,
-  ActionButton,
-  labels,
   pinningSupport,
   pinned,
   pinResource,
   selectResource,
   selected,
   expandAllLabels,
-  requiresRequest = false,
-}: Omit<ResourceItemProps, 'cardViewProps'>) {
+  onShowStatusInfo,
+  showingStatusInfo,
+  viewItem,
+}: ResourceItemProps) {
+  const {
+    name,
+    primaryIconName,
+    SecondaryIcon,
+    listViewProps,
+    ActionButton,
+    labels,
+    requiresRequest = false,
+    status,
+  } = viewItem;
   const { description, resourceType, addr } = listViewProps;
 
   const [showLabels, setShowLabels] = useState(expandAllLabels);
@@ -62,6 +69,7 @@ export function ResourceListItem({
   }, [expandAllLabels]);
 
   const showLabelsButton = labels.length > 0 && (hovered || showLabels);
+  const hasUnhealthyStatus = status && status !== 'healthy';
 
   // Determines which column the resource type text should end at.
   // We do this because if there is no address, or the labels button
@@ -81,12 +89,16 @@ export function ResourceListItem({
     <RowContainer
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
+      hasUnhealthyStatus={hasUnhealthyStatus}
+      showingStatusInfo={showingStatusInfo}
     >
       <RowInnerContainer
         requiresRequest={requiresRequest}
         alignItems="start"
         pinned={pinned}
         selected={selected}
+        hasUnhealthyStatus={hasUnhealthyStatus}
+        showingStatusInfo={showingStatusInfo}
       >
         {/* checkbox */}
         <HoverTooltip
@@ -210,13 +222,28 @@ export function ResourceListItem({
               grid-area: labels-btn;
             `}
           >
-            <ShowLabelsButton
+            <HoverIconButton
               size={1}
               onClick={() => setShowLabels(prevState => !prevState)}
               className={showLabels ? 'active' : ''}
             >
               <Tags size={18} color={showLabels ? 'text.main' : 'text.muted'} />
-            </ShowLabelsButton>
+            </HoverIconButton>
+          </HoverTooltip>
+        )}
+
+        {/* warning icon if status is unhealthy */}
+        {hasUnhealthyStatus && (
+          <HoverTooltip
+            tipContent={'Show Connection Issue'}
+            css={`
+              grid-area: warning-icon;
+              cursor: pointer;
+            `}
+          >
+            <HoverIconButton size={1} onClick={onShowStatusInfo}>
+              <Warning size={18} />
+            </HoverIconButton>
           </HoverTooltip>
         )}
 
@@ -273,12 +300,37 @@ const ResTypeIconBox = styled(Box)`
   line-height: 0;
 `;
 
-const RowContainer = styled(Box)`
+const RowContainer = styled(Box)<{
+  hasUnhealthyStatus: boolean;
+  showingStatusInfo: boolean;
+}>`
   transition: all 150ms;
   position: relative;
 
+  ${p =>
+    p.hasUnhealthyStatus &&
+    css`
+      background-color: ${getStatusBackgroundColor({
+        showingStatusInfo: p.showingStatusInfo,
+        theme: p.theme,
+        action: '',
+        viewType: 'list',
+      })};
+    `}
+
   &:hover {
     background-color: ${props => props.theme.colors.levels.surface};
+
+    ${p =>
+      p.hasUnhealthyStatus &&
+      css`
+        background-color: ${getStatusBackgroundColor({
+          showingStatusInfo: p.showingStatusInfo,
+          theme: p.theme,
+          action: 'hover',
+          viewType: 'list',
+        })};
+      `}
 
     // We use a pseudo element for the shadow with position: absolute in order to prevent
     // the shadow from increasing the size of the layout and causing scrollbar flicker.
@@ -301,8 +353,8 @@ const RowInnerContainer = styled(Flex)<BackgroundColorProps>`
   column-gap: ${props => props.theme.space[3]}px;
   grid-template-rows: 56px min-content;
   grid-template-areas:
-    'checkbox pin icon name type address labels-btn button'
-    '. . labels labels labels labels labels labels';
+    'checkbox pin icon name type address labels-btn warning-icon button'
+    '. . labels labels labels labels labels labels labels';
   align-items: center;
   height: 100%;
   min-width: 100%;
@@ -332,7 +384,7 @@ const Description = styled(Text)`
   color: ${props => props.theme.colors.text.muted};
 `;
 
-const ShowLabelsButton = styled(ButtonIcon)`
+const HoverIconButton = styled(ButtonIcon)`
   .active {
     background: ${props => props.theme.colors.buttons.secondary.default};
 

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.story.tsx
@@ -37,6 +37,7 @@ import { kubes, moreKubes } from 'teleport/Kubes/fixtures';
 import { moreNodes, nodes } from 'teleport/Nodes/fixtures';
 import { ResourcesResponse } from 'teleport/services/agents';
 
+import { InfoGuidePanelProvider } from '../SlidingSidePanel/InfoGuide';
 import { SharedUnifiedResource, UnifiedResourcesQueryParams } from './types';
 import {
   UnifiedResources,
@@ -106,45 +107,47 @@ const story = ({
       fetchFunc,
     });
     return (
-      <UnifiedResources
-        availableKinds={[
-          {
-            kind: 'app',
-            disabled: false,
-          },
-          {
-            kind: 'db',
-            disabled: false,
-          },
-          {
-            kind: 'node',
-            disabled: false,
-          },
-          {
-            kind: 'kube_cluster',
-            disabled: false,
-          },
-          {
-            kind: 'windows_desktop',
-            disabled: false,
-          },
-        ]}
-        params={mergedParams}
-        setParams={() => undefined}
-        pinning={pinning}
-        unifiedResourcePreferences={userPrefs}
-        updateUnifiedResourcesPreferences={setUserPrefs}
-        NoResources={undefined}
-        fetchResources={fetch}
-        resourcesFetchAttempt={attempt}
-        resources={resources.map(resource => ({
-          resource,
-          ui: {
-            ActionButton: <ButtonBorder size="small">Connect</ButtonBorder>,
-          },
-        }))}
-        {...props}
-      />
+      <InfoGuidePanelProvider>
+        <UnifiedResources
+          availableKinds={[
+            {
+              kind: 'app',
+              disabled: false,
+            },
+            {
+              kind: 'db',
+              disabled: false,
+            },
+            {
+              kind: 'node',
+              disabled: false,
+            },
+            {
+              kind: 'kube_cluster',
+              disabled: false,
+            },
+            {
+              kind: 'windows_desktop',
+              disabled: false,
+            },
+          ]}
+          params={mergedParams}
+          setParams={() => undefined}
+          pinning={pinning}
+          unifiedResourcePreferences={userPrefs}
+          updateUnifiedResourcesPreferences={setUserPrefs}
+          NoResources={undefined}
+          fetchResources={fetch}
+          resourcesFetchAttempt={attempt}
+          resources={resources.map(resource => ({
+            resource,
+            ui: {
+              ActionButton: <ButtonBorder size="small">Connect</ButtonBorder>,
+            },
+          }))}
+          {...props}
+        />
+      </InfoGuidePanelProvider>
     );
   };
 };
@@ -156,6 +159,18 @@ export const Empty = story({
 export const List = story({
   fetchFunc: async () => ({
     agents: allResources,
+  }),
+});
+
+export const Single = story({
+  fetchFunc: async () => ({
+    agents: [{ ...aLotOfLabels, targetHealth: null }],
+  }),
+});
+
+export const SingleWithStatusWarning = story({
+  fetchFunc: async () => ({
+    agents: [aLotOfLabels],
   }),
 });
 

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -605,6 +605,8 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
                   },
                 }),
                 key: generateUnifiedResourceKey(resource),
+                onShowStatusInfo: () => null,
+                showingStatusInfo: false,
               }))
             : []
         }

--- a/web/packages/shared/components/UnifiedResources/shared/SingleLineBox.tsx
+++ b/web/packages/shared/components/UnifiedResources/shared/SingleLineBox.tsx
@@ -1,0 +1,27 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import styled from 'styled-components';
+
+import Box from 'design/Box';
+
+export const SingleLineBox = styled(Box)`
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+`;

--- a/web/packages/shared/components/UnifiedResources/shared/getBackgroundColor.ts
+++ b/web/packages/shared/components/UnifiedResources/shared/getBackgroundColor.ts
@@ -23,9 +23,14 @@ export interface BackgroundColorProps {
   selected?: boolean;
   pinned?: boolean;
   theme: Theme;
+  hasUnhealthyStatus: boolean;
+  showingStatusInfo: boolean;
 }
 
 export const getBackgroundColor = (props: BackgroundColorProps) => {
+  if (props.hasUnhealthyStatus) {
+    return 'transparent';
+  }
   if (props.requiresRequest && props.pinned) {
     return props.theme.colors.interactive.tonal.primary[0];
   }
@@ -39,4 +44,32 @@ export const getBackgroundColor = (props: BackgroundColorProps) => {
     return props.theme.colors.interactive.tonal.primary[1];
   }
   return 'transparent';
+};
+
+export const getStatusBackgroundColor = (props: {
+  showingStatusInfo: boolean;
+  theme: Theme;
+  action: '' | 'hover';
+  viewType: 'card' | 'list';
+}) => {
+  switch (props.action) {
+    case 'hover':
+      return props.theme.colors.interactive.tonal.alert[1];
+    case '':
+      if (props.showingStatusInfo) {
+        return props.theme.colors.interactive.tonal.alert[2];
+      }
+
+      switch (props.viewType) {
+        case 'card':
+          return 'transparent';
+        case 'list':
+          return props.theme.colors.interactive.tonal.alert[0];
+        default:
+          props.viewType satisfies never;
+          return;
+      }
+    default:
+      props.action satisfies never;
+  }
 };

--- a/web/packages/shared/components/UnifiedResources/shared/viewItemsFactory.ts
+++ b/web/packages/shared/components/UnifiedResources/shared/viewItemsFactory.ts
@@ -86,6 +86,7 @@ export function makeUnifiedResourceViewItemDatabase(
       secondaryDesc: resource.description,
     },
     requiresRequest: resource.requiresRequest,
+    status: resource.targetHealth?.status,
   };
 }
 

--- a/web/packages/shared/components/UnifiedResources/types.ts
+++ b/web/packages/shared/components/UnifiedResources/types.ts
@@ -34,7 +34,7 @@ export type ResourceStatus = 'healthy' | 'unhealthy' | 'unknown' | '';
 
 export type ResourceTargetHealth = {
   status: ResourceStatus;
-  reason: string;
+  reason?: string;
 };
 
 export type UnifiedResourceApp = {
@@ -60,6 +60,7 @@ export interface UnifiedResourceDatabase {
   protocol: DbProtocol;
   labels: ResourceLabel[];
   requiresRequest?: boolean;
+  targetHealth?: ResourceTargetHealth;
 }
 
 export interface UnifiedResourceNode {
@@ -115,15 +116,17 @@ export type UnifiedResourceUi = {
   ActionButton: React.ReactElement;
 };
 
+export type UnifiedResourceDefinition =
+  | UnifiedResourceApp
+  | UnifiedResourceDatabase
+  | UnifiedResourceNode
+  | UnifiedResourceKube
+  | UnifiedResourceDesktop
+  | UnifiedResourceUserGroup
+  | UnifiedResourceGitServer;
+
 export type SharedUnifiedResource = {
-  resource:
-    | UnifiedResourceApp
-    | UnifiedResourceDatabase
-    | UnifiedResourceNode
-    | UnifiedResourceKube
-    | UnifiedResourceDesktop
-    | UnifiedResourceUserGroup
-    | UnifiedResourceGitServer;
+  resource: UnifiedResourceDefinition;
   ui: UnifiedResourceUi;
 };
 
@@ -153,6 +156,7 @@ export interface UnifiedResourceViewItem {
   cardViewProps: CardViewSpecificProps;
   listViewProps: ListViewSpecificProps;
   requiresRequest?: boolean;
+  status?: ResourceStatus;
 }
 
 export enum PinningSupport {
@@ -175,21 +179,20 @@ export type IncludedResourceMode =
   | 'accessible';
 
 export type ResourceItemProps = {
-  name: string;
-  primaryIconName: ResourceIconName;
-  SecondaryIcon: typeof Icon;
-  cardViewProps: CardViewSpecificProps;
-  listViewProps: ListViewSpecificProps;
-  labels: ResourceLabel[];
-  ActionButton: React.ReactElement;
   onLabelClick?: (label: ResourceLabel) => void;
   pinResource: () => void;
   selectResource: () => void;
   selected: boolean;
   pinned: boolean;
-  requiresRequest?: boolean;
   pinningSupport: PinningSupport;
   expandAllLabels: boolean;
+  viewItem: UnifiedResourceViewItem;
+  onShowStatusInfo(): void;
+  /**
+   * True, when the InfoGuideSidePanel is opened.
+   * Used as a flag to render different styling.
+   */
+  showingStatusInfo: boolean;
 };
 
 // Props that are needed for the Card view.
@@ -226,6 +229,11 @@ export type ResourceViewProps = {
   onPinResource: (resourceId: string) => void;
   pinningSupport: PinningSupport;
   isProcessing: boolean;
-  mappedResources: { item: UnifiedResourceViewItem; key: string }[];
+  mappedResources: {
+    item: UnifiedResourceViewItem;
+    key: string;
+    onShowStatusInfo(): void;
+    showingStatusInfo: boolean;
+  }[];
   expandAllLabels: boolean;
 };

--- a/web/packages/teleport/src/Databases/fixtures/index.ts
+++ b/web/packages/teleport/src/Databases/fixtures/index.ts
@@ -30,7 +30,10 @@ export const databases: Database[] = [
       { name: 'env', value: 'aws' },
     ],
     hostname: 'aurora-hostname',
-  },
+    targetHealth: { status: 'unhealthy' },
+    // TODO(kimlisa): remove as any once we add
+    // "targetHealth" field to db response
+  } as any,
   {
     kind: 'db',
     name: 'mongodbizzle',
@@ -42,7 +45,10 @@ export const databases: Database[] = [
       { name: 'env', value: 'aws' },
     ],
     hostname: 'mongo-bongo',
-  },
+    targetHealth: { status: 'unknown' },
+    // TODO(kimlisa): remove as any once we add
+    // "targetHealth" field to db response
+  } as any,
   {
     kind: 'db',
     name: 'Dynamooooo',
@@ -102,7 +108,10 @@ export const databases: Database[] = [
       { name: 'env', value: 'gcp' },
     ],
     hostname: 'postgres-hostname',
-  },
+    targetHealth: { status: 'unhealthy' },
+    // TODO(kimlisa): remove as any once we add
+    // "targetHealth" field to db response
+  } as any,
   {
     kind: 'db',
     name: 'mysql-aurora-56',

--- a/web/packages/teleterm/src/ui/DocumentCluster/InfoGuideSidePanel.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/InfoGuideSidePanel.story.tsx
@@ -1,0 +1,119 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useRef } from 'react';
+import styled from 'styled-components';
+
+import { Box, Flex } from 'design';
+import {
+  InfoGuideButton,
+  InfoGuidePanelProvider,
+} from 'shared/components/SlidingSidePanel/InfoGuide';
+import { LongGuideContent } from 'shared/components/SlidingSidePanel/InfoGuide/storyHelper';
+
+import {
+  makeRootCluster,
+  rootClusterUri,
+} from 'teleterm/services/tshd/testHelpers';
+import AppContextProvider from 'teleterm/ui/appContextProvider';
+import { ConnectMyComputerContextProvider } from 'teleterm/ui/ConnectMyComputer';
+import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
+import { MockWorkspaceContextProvider } from 'teleterm/ui/fixtures/MockWorkspaceContextProvider';
+import { makeDocumentCluster } from 'teleterm/ui/services/workspacesService/documentsService/testHelpers';
+import { ConnectionsContextProvider } from 'teleterm/ui/TopBar/Connections/connectionsContext';
+import { VnetContextProvider } from 'teleterm/ui/Vnet';
+
+import { StatusBar } from '../StatusBar';
+import { StyledTabs } from '../Tabs';
+import { TopBar } from '../TopBar';
+import { InfoGuideSidePanel as MainComponent } from './InfoGuideSidePanel';
+import { ResourcesContextProvider } from './resourcesContext';
+
+export default {
+  title: 'Teleterm/DocumentCluster/InfoGuideSidePanel',
+};
+
+const rootClusterDoc = makeDocumentCluster({
+  clusterUri: rootClusterUri,
+  uri: '/docs/123',
+});
+
+export function InfoGuideSidePanel() {
+  const topBarConnectMyComputerRef = useRef<HTMLDivElement>();
+  const topBarAccessRequestRef = useRef<HTMLDivElement>();
+
+  const appContext = new MockAppContext();
+  const cluster = makeRootCluster({
+    uri: rootClusterDoc.clusterUri,
+  });
+  appContext.addRootClusterWithDoc(cluster, rootClusterDoc);
+
+  return (
+    <AppContextProvider value={appContext}>
+      <ConnectionsContextProvider>
+        <VnetContextProvider>
+          <MockWorkspaceContextProvider>
+            <ResourcesContextProvider>
+              <ConnectMyComputerContextProvider rootClusterUri={rootClusterUri}>
+                <Wrapper>
+                  <InfoGuidePanelProvider>
+                    <Flex flexDirection="column" height="100%">
+                      <Flex flex="1" flexDirection="column">
+                        <TopBar
+                          connectMyComputerRef={topBarConnectMyComputerRef}
+                          accessRequestRef={topBarAccessRequestRef}
+                        />
+                        <StyledTabs width="100%" pl={2}>
+                          Dummy tab just for height placement for the guide
+                          info.
+                        </StyledTabs>
+                        <Example />
+                      </Flex>
+                      <StatusBar onAssumedRolesClick={() => null} />
+                    </Flex>
+                  </InfoGuidePanelProvider>
+                </Wrapper>
+              </ConnectMyComputerContextProvider>
+            </ResourcesContextProvider>
+          </MockWorkspaceContextProvider>
+        </VnetContextProvider>
+      </ConnectionsContextProvider>
+    </AppContextProvider>
+  );
+}
+
+const Wrapper = styled.div`
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+`;
+
+function Example() {
+  return (
+    <>
+      <Box mt={3}>
+        <InfoGuideButton config={{ guide: <LongGuideContent /> }}>
+          <Box ml={3}>Click the info button</Box>
+        </InfoGuideButton>
+      </Box>
+      <MainComponent />
+    </>
+  );
+}

--- a/web/packages/teleterm/src/ui/DocumentCluster/InfoGuideSidePanel.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/InfoGuideSidePanel.tsx
@@ -1,0 +1,61 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { SlidingSidePanel } from 'shared/components/SlidingSidePanel';
+import {
+  InfoGuideContainer,
+  useInfoGuide,
+} from 'shared/components/SlidingSidePanel/InfoGuide';
+
+import { statusBarHeight } from '../StatusBar/constants';
+import { tabHeight } from '../Tabs/constants';
+
+/**
+ * An info panel that always slides from the right and supports closing
+ * from inside of panel (by clicking on x button from the sticky header).
+ *
+ * The panel will always render below teleterm's tabs and above
+ * teleterm's status bar.
+ */
+export const InfoGuideSidePanel = () => {
+  const { infoGuideConfig, setInfoGuideConfig, panelWidth } = useInfoGuide();
+  const infoGuideSidePanelOpened = infoGuideConfig != null;
+
+  return (
+    <SlidingSidePanel
+      isVisible={infoGuideSidePanelOpened}
+      skipAnimation={false}
+      panelWidth={panelWidth}
+      zIndex={10}
+      slideFrom="right"
+      css={`
+        top: ${p => p.theme.topBarHeight[1] + tabHeight}px;
+        bottom: ${statusBarHeight}px;
+        border-top: 1px solid
+          ${p => p.theme.colors.interactive.tonal.neutral[0]};
+      `}
+    >
+      <InfoGuideContainer
+        onClose={() => setInfoGuideConfig(null)}
+        title={infoGuideConfig?.title}
+      >
+        {infoGuideConfig?.guide}
+      </InfoGuideContainer>
+    </SlidingSidePanel>
+  );
+};

--- a/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
@@ -18,7 +18,7 @@
 
 import { memo, useCallback, useEffect, useMemo } from 'react';
 
-import { ButtonPrimary, Flex, H1, Link, ResourceIcon, Text } from 'design';
+import { Box, ButtonPrimary, Flex, H1, Link, ResourceIcon, Text } from 'design';
 import * as icons from 'design/Icon';
 import { ShowResources } from 'gen-proto-ts/teleport/lib/teleterm/v1/cluster_pb';
 import {
@@ -26,6 +26,14 @@ import {
   UserPreferences,
 } from 'gen-proto-ts/teleport/lib/teleterm/v1/service_pb';
 import { DefaultTab } from 'gen-proto-ts/teleport/userpreferences/v1/unified_resource_preferences_pb';
+import {
+  InfoGuidePanelProvider,
+  useInfoGuide,
+} from 'shared/components/SlidingSidePanel/InfoGuide';
+import {
+  marginTransitionCss,
+  resourceStatusPanelWidth,
+} from 'shared/components/SlidingSidePanel/InfoGuide/const';
 import {
   getResourceAvailabilityFilter,
   ResourceAvailabilityFilter,
@@ -68,6 +76,7 @@ import {
   ConnectServerActionButton,
   ConnectWindowsDesktopActionButton,
 } from './ActionButtons';
+import { InfoGuideSidePanel } from './InfoGuideSidePanel';
 import { useResourcesContext } from './resourcesContext';
 import { useUserPreferences } from './useUserPreferences';
 
@@ -223,26 +232,28 @@ export function UnifiedResources(props: {
   );
 
   return (
-    <Resources
-      getAccessRequestButton={getAccessRequestButton}
-      queryParams={mergedParams}
-      onParamsChange={onParamsChange}
-      clusterUri={props.clusterUri}
-      userPreferencesAttempt={userPreferencesAttempt}
-      updateUserPreferences={updateUserPreferences}
-      userPreferences={userPreferences}
-      canAddResources={canAddResources}
-      canUseConnectMyComputer={canUseConnectMyComputer}
-      openConnectMyComputerDocument={openConnectMyComputerDocument}
-      onResourcesRefreshRequest={onResourcesRefreshRequest}
-      bulkAddResources={bulkAddResources}
-      getAddedItemsCount={getAddedItemsCount}
-      discoverUrl={discoverUrl}
-      integratedAccessRequests={integratedAccessRequests}
-      // Reset the component state when query params object change.
-      // JSON.stringify on the same object will always produce the same string.
-      key={`${JSON.stringify(mergedParams)}-${JSON.stringify(integratedAccessRequests)}`}
-    />
+    <InfoGuidePanelProvider defaultPanelWidth={resourceStatusPanelWidth}>
+      <Resources
+        getAccessRequestButton={getAccessRequestButton}
+        queryParams={mergedParams}
+        onParamsChange={onParamsChange}
+        clusterUri={props.clusterUri}
+        userPreferencesAttempt={userPreferencesAttempt}
+        updateUserPreferences={updateUserPreferences}
+        userPreferences={userPreferences}
+        canAddResources={canAddResources}
+        canUseConnectMyComputer={canUseConnectMyComputer}
+        openConnectMyComputerDocument={openConnectMyComputerDocument}
+        onResourcesRefreshRequest={onResourcesRefreshRequest}
+        bulkAddResources={bulkAddResources}
+        getAddedItemsCount={getAddedItemsCount}
+        discoverUrl={discoverUrl}
+        integratedAccessRequests={integratedAccessRequests}
+        // Reset the component state when query params object change.
+        // JSON.stringify on the same object will always produce the same string.
+        key={`${JSON.stringify(mergedParams)}-${JSON.stringify(integratedAccessRequests)}`}
+      />
+    </InfoGuidePanelProvider>
   );
 }
 
@@ -380,80 +391,91 @@ const Resources = memo(
         }),
     };
 
+    const { infoGuideConfig, panelWidth } = useInfoGuide();
+    const infoGuideSidePanelOpened = infoGuideConfig != null;
+
     return (
-      <SharedUnifiedResources
-        params={props.queryParams}
-        setParams={props.onParamsChange}
-        unifiedResourcePreferencesAttempt={props.userPreferencesAttempt}
-        bulkActions={
-          props.integratedAccessRequests.supported === 'yes'
-            ? [
-                {
-                  key: 'requestAccess',
-                  Icon: icons.AddCircle,
-                  text:
-                    props.getAddedItemsCount() > 0
-                      ? 'Add/Remove to Request'
-                      : 'Request Access',
-                  disabled: false,
-                  action: selectedResources =>
-                    props.bulkAddResources(
-                      selectedResources.map(sharedResource =>
-                        getUnifiedResourceFromSharedResource(
-                          sharedResource.resource
+      <Box
+        css={marginTransitionCss({
+          sidePanelOpened: infoGuideSidePanelOpened,
+          panelWidth,
+        })}
+      >
+        <SharedUnifiedResources
+          params={props.queryParams}
+          setParams={props.onParamsChange}
+          unifiedResourcePreferencesAttempt={props.userPreferencesAttempt}
+          bulkActions={
+            props.integratedAccessRequests.supported === 'yes'
+              ? [
+                  {
+                    key: 'requestAccess',
+                    Icon: icons.AddCircle,
+                    text:
+                      props.getAddedItemsCount() > 0
+                        ? 'Add/Remove to Request'
+                        : 'Request Access',
+                    disabled: false,
+                    action: selectedResources =>
+                      props.bulkAddResources(
+                        selectedResources.map(sharedResource =>
+                          getUnifiedResourceFromSharedResource(
+                            sharedResource.resource
+                          )
                         )
-                      )
-                    ),
-                },
-              ]
-            : []
-        }
-        unifiedResourcePreferences={
-          props.userPreferences.unifiedResourcePreferences
-        }
-        updateUnifiedResourcesPreferences={unifiedResourcePreferences =>
-          props.updateUserPreferences({ unifiedResourcePreferences })
-        }
-        pinning={pinning}
-        availabilityFilter={
-          props.integratedAccessRequests.supported === 'yes'
-            ? props.integratedAccessRequests.availabilityFilter
-            : undefined
-        }
-        resources={sharedResources}
-        resourcesFetchAttempt={attempt}
-        fetchResources={fetch}
-        availableKinds={[
-          {
-            kind: 'node',
-            disabled: false,
-          },
-          {
-            kind: 'app',
-            disabled: false,
-          },
-          {
-            kind: 'db',
-            disabled: false,
-          },
-          {
-            kind: 'kube_cluster',
-            disabled: false,
-          },
-          {
-            kind: 'windows_desktop',
-            disabled: false,
-          },
-        ]}
-        NoResources={
-          <NoResources
-            canCreate={props.canAddResources}
-            discoverUrl={props.discoverUrl}
-            canUseConnectMyComputer={props.canUseConnectMyComputer}
-            onConnectMyComputerCtaClick={props.openConnectMyComputerDocument}
-          />
-        }
-      />
+                      ),
+                  },
+                ]
+              : []
+          }
+          unifiedResourcePreferences={
+            props.userPreferences.unifiedResourcePreferences
+          }
+          updateUnifiedResourcesPreferences={unifiedResourcePreferences =>
+            props.updateUserPreferences({ unifiedResourcePreferences })
+          }
+          pinning={pinning}
+          availabilityFilter={
+            props.integratedAccessRequests.supported === 'yes'
+              ? props.integratedAccessRequests.availabilityFilter
+              : undefined
+          }
+          resources={sharedResources}
+          resourcesFetchAttempt={attempt}
+          fetchResources={fetch}
+          availableKinds={[
+            {
+              kind: 'node',
+              disabled: false,
+            },
+            {
+              kind: 'app',
+              disabled: false,
+            },
+            {
+              kind: 'db',
+              disabled: false,
+            },
+            {
+              kind: 'kube_cluster',
+              disabled: false,
+            },
+            {
+              kind: 'windows_desktop',
+              disabled: false,
+            },
+          ]}
+          NoResources={
+            <NoResources
+              canCreate={props.canAddResources}
+              discoverUrl={props.discoverUrl}
+              canUseConnectMyComputer={props.canUseConnectMyComputer}
+              onConnectMyComputerCtaClick={props.openConnectMyComputerDocument}
+            />
+          }
+        />
+        <InfoGuideSidePanel />
+      </Box>
     );
   }
 );

--- a/web/packages/teleterm/src/ui/StatusBar/StatusBar.tsx
+++ b/web/packages/teleterm/src/ui/StatusBar/StatusBar.tsx
@@ -27,6 +27,7 @@ import { getAssumedRequests } from 'teleterm/ui/services/clusters';
 import { ConnectionStatusIndicator } from 'teleterm/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionStatusIndicator';
 
 import { AccessRequestCheckoutButton } from './AccessRequestCheckoutButton';
+import { statusBarHeight } from './constants';
 import { ShareFeedback } from './ShareFeedback';
 import { useActiveDocumentClusterBreadcrumbs } from './useActiveDocumentClusterBreadcrumbs';
 
@@ -51,7 +52,7 @@ export function StatusBar(props: { onAssumedRolesClick(): void }) {
   return (
     <Flex
       width="100%"
-      height="28px"
+      height={`${statusBarHeight}px`}
       css={`
         border-top: 1px solid ${props => props.theme.colors.spotBackground[1]};
       `}

--- a/web/packages/teleterm/src/ui/StatusBar/constants.ts
+++ b/web/packages/teleterm/src/ui/StatusBar/constants.ts
@@ -1,0 +1,19 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export const statusBarHeight = 28;

--- a/web/packages/teleterm/src/ui/Tabs/Tabs.tsx
+++ b/web/packages/teleterm/src/ui/Tabs/Tabs.tsx
@@ -27,6 +27,7 @@ import {
   getStaticNameAndIcon,
 } from 'teleterm/ui/services/workspacesService';
 
+import { tabHeight } from './constants';
 import { NewTabItem, TabItem } from './TabItem';
 
 export function Tabs(props: Props) {
@@ -93,9 +94,9 @@ type Props = {
 };
 
 // TODO(bl-nero): Typography should have a more restrictive type.
-const StyledTabs = styled(Box)<TypographyProps>`
+export const StyledTabs = styled(Box)<TypographyProps>`
   background-color: ${props => props.theme.colors.levels.surface};
-  min-height: 32px;
+  min-height: ${tabHeight}px;
   display: flex;
   flex-wrap: nowrap;
   align-items: center;

--- a/web/packages/teleterm/src/ui/Tabs/constants.ts
+++ b/web/packages/teleterm/src/ui/Tabs/constants.ts
@@ -1,0 +1,19 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export const tabHeight = 32;

--- a/web/packages/teleterm/src/ui/TopBar/TopBar.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/TopBar.tsx
@@ -58,7 +58,7 @@ export function TopBar(props: {
 const Grid = styled(Flex).attrs({ gap: 3, py: 2, px: 3 })`
   background: ${props => props.theme.colors.levels.surface};
   width: 100%;
-  height: 56px;
+  height: ${p => p.theme.topBarHeight[1]}px;
   align-items: center;
   justify-content: space-between;
 `;


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/20544

recommend reviewing by commit

- [ ] requires https://github.com/gravitational/teleport/pull/53941

This only adds the status state handling and [design](https://www.figma.com/design/JKd0Bgs30AnNfNCLUuzzc2/Resources?node-id=3656-29158&t=PI9QNtc5N78tIfhG-0), the feature itself is "disabled" in that there is no backend handling of the required field for this to work.

It also adds info guide side panel for teleterm's unified resource (not used yet)

stories for stasuses are updated on story shared-unifiedresources: 
https://localhost:9002/?path=/story/shared-unifiedresources--list 

teleterm story (how the side panel will look like): 
https://localhost:9002/?path=/story/teleterm-documentcluster-infoguidesidepanel--info-guide-side-panel