### PR TITLE
No longer show "Fatal error" on normal closure of SPIFFEFederationSyncer

### DIFF
--- a/lib/auth/machineid/machineidv1/spiffe_federation_syncer.go
+++ b/lib/auth/machineid/machineidv1/spiffe_federation_syncer.go
@@ -183,7 +183,7 @@ func (s *SPIFFEFederationSyncer) Run(ctx context.Context) error {
 				RetryInterval: time.Second * 30,
 			},
 		}, s.syncTrustDomains)
-		if err != nil {
+		if err != nil && ctx.Err() == nil {
 			s.cfg.Logger.ErrorContext(
 				ctx,
 				"SPIFFEFederation syncer encountered a fatal error, it will restart after backoff",


### PR DESCRIPTION
The SPIFFEFederationSyncer used to emit an error log stating that a "Fatal error occurred" during normal shutdowns. This has the potential to be a red herring for customers trying to diagnose a crash. This PR modifies the logic to not emit the log if the root context has cancelled and the Teleport Auth Service is shuttingdown.