### PR TITLE
docs: include signature algorithm suite in auth config

### DIFF
--- a/docs/pages/includes/config-reference/auth-service.yaml
+++ b/docs/pages/includes/config-reference/auth-service.yaml
@@ -274,6 +274,26 @@ auth_service:
       # assignment. Ignored if enabled is set to false.
       #first_uid: 90000
       #last_uid: 95000
+    
+    # Sets the cryptographic signature algorithm used to sign each kind of 
+    # certificate issued by Teleport.
+    # The following values are supported:
+    #  'legacy'      : For clusters created prior to v17.0.0 with
+    #                  signatures based on 2048-bit RSA keys.
+    #  'balanced-v1' : (default) For self-hosted clusters created v17.0.0+.
+    #                  Ed25519 is used for all SSH certificates and ECDSA with
+    #                  the NIST P-256 curve is used for all TLS certificates.
+    #                  RSA is still used where for compatibility when non-RSA
+    #                  algorithms are unsupported.
+    #  'fips-v1'     : Used by default for FIPS mode clusters created v17.0.0+.
+    #                  Based on 'balanced-v1' and replaces all uses of Ed25519
+    #                  with ECDSA. HSM or KMS configuration is fully supported.
+    #  'hsm-v1'      : Default suite for new clusters created after version 17.0.0
+    #                  that have an HSM or KMS configured. 'hsm-v1' suite is based
+    #                  on the 'balanced-v1' suite but uses ECDSA in place of Ed25519
+    #                  for all Certificate Authority keys. User and host SSH keys
+    #                  still use Ed25519.
+    signature_algorithm_suite: "balanced-v1"
 
   # IP and the port to bind to. Other Teleport Nodes will be connecting to
   # this port (AKA "Auth API" or "Cluster API") to validate client


### PR DESCRIPTION
Includes `signature_algorithm_suite` supported in v17 for `auth_service.authentication`.