### PR TITLE
Fix Azure VM auto discover when not filtering by resource group

### DIFF
--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -700,7 +700,7 @@ func (s *Server) azureServerFetchersFromMatchers(matchers []types.AzureMatcher, 
 		return matcherType == types.AzureMatcherVM
 	})
 
-	return server.MatchersToAzureInstanceFetchers(serverMatchers, s.CloudClients, discoveryConfigName)
+	return server.MatchersToAzureInstanceFetchers(s.Log, serverMatchers, s.CloudClients, discoveryConfigName)
 }
 
 // gcpServerFetchersFromMatchers converts Matchers into a set of GCP Servers Fetchers.
@@ -784,7 +784,7 @@ func (s *Server) initAzureWatchers(ctx context.Context, matchers []types.AzureMa
 		return matcherType == types.AzureMatcherVM
 	})
 
-	s.staticServerAzureFetchers = server.MatchersToAzureInstanceFetchers(vmMatchers, s.CloudClients, discoveryConfigName)
+	s.staticServerAzureFetchers = server.MatchersToAzureInstanceFetchers(s.Log, vmMatchers, s.CloudClients, discoveryConfigName)
 
 	// VM watcher.
 	var err error

--- a/lib/srv/server/azure_watcher_test.go
+++ b/lib/srv/server/azure_watcher_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	"github.com/stretchr/testify/require"
@@ -30,6 +31,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/cloud/azure"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 type mockClients struct {
@@ -50,35 +52,35 @@ func TestAzureWatcher(t *testing.T) {
 			VirtualMachines: map[string][]*armcompute.VirtualMachine{
 				"rg1": {
 					{
-						ID:       to.Ptr("vm1"),
+						ID:       to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1"),
 						Location: to.Ptr("location1"),
 					},
 					{
-						ID:       to.Ptr("vm2"),
+						ID:       to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm2"),
 						Location: to.Ptr("location1"),
 						Tags: map[string]*string{
 							"teleport": to.Ptr("yes"),
 						},
 					},
 					{
-						ID:       to.Ptr("vm5"),
+						ID:       to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm5"),
 						Location: to.Ptr("location2"),
 					},
 				},
 				"rg2": {
 					{
-						ID:       to.Ptr("vm3"),
+						ID:       to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm3"),
 						Location: to.Ptr("location1"),
 					},
 					{
-						ID:       to.Ptr("vm4"),
+						ID:       to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm4"),
 						Location: to.Ptr("location1"),
 						Tags: map[string]*string{
 							"teleport": to.Ptr("yes"),
 						},
 					},
 					{
-						ID:       to.Ptr("vm6"),
+						ID:       to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm6"),
 						Location: to.Ptr("location2"),
 					},
 				},
@@ -136,8 +138,18 @@ func TestAzureWatcher(t *testing.T) {
 			},
 			wantVMs: []string{"vm1", "vm2", "vm3", "vm4", "vm5", "vm6"},
 		},
+		{
+			name: "resource group wildcard",
+			matcher: types.AzureMatcher{
+				ResourceGroups: []string{"*"},
+				Regions:        []string{types.Wildcard},
+				ResourceTags:   types.Labels{"*": []string{"*"}},
+			},
+			wantVMs: []string{"vm1", "vm2", "vm3", "vm4", "vm5", "vm6"},
+		},
 	}
 
+	logger := utils.NewSlogLoggerForTests()
 	for _, tc := range tests {
 		tc.matcher.Types = []string{"vm"}
 		tc.matcher.Subscriptions = []string{"sub1"}
@@ -146,7 +158,7 @@ func TestAzureWatcher(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			t.Cleanup(cancel)
 			watcher, err := NewAzureWatcher(ctx, func() []Fetcher {
-				return MatchersToAzureInstanceFetchers([]types.AzureMatcher{tc.matcher}, &clients, "" /* discovery config */)
+				return MatchersToAzureInstanceFetchers(logger, []types.AzureMatcher{tc.matcher}, &clients, "" /* discovery config */)
 			})
 			require.NoError(t, err)
 
@@ -159,8 +171,12 @@ func TestAzureWatcher(t *testing.T) {
 				select {
 				case results := <-watcher.InstancesC:
 					for _, vm := range results.Azure.Instances {
-						vmIDs = append(vmIDs, *vm.ID)
+						parsedResource, err := arm.ParseResourceID(*vm.ID)
+						require.NoError(t, err)
+						vmID := parsedResource.Name
+						vmIDs = append(vmIDs, vmID)
 					}
+					require.NotEqual(t, "*", results.Azure.ResourceGroup)
 				case <-ctx.Done():
 					require.Fail(t, "Expected %v VMs, got %v", tc.wantVMs, len(vmIDs))
 				}


### PR DESCRIPTION
When setting up auto discovery for Azure VMs, users can add a couple of filters.
Required fields: subscription
Optional filters: location, resource group, tag matchers

When no resource group is set, the process calls:
https://learn.microsoft.com/en-us/rest/api/compute/virtual-machines/list-all?view=rest-compute-2024-11-04&tabs=HTTP
https://github.com/gravitational/teleport/blob/66c019c36148b79c60d48b0639fa15f325768405/lib/cloud/azure/vm.go#L266

After getting the list of VMs, the discovery service tries to run the teleport installation script on them.
The issue here was that we were using the `*` as the resource group.

This PR changes the code to ensure that when the resource group is `*`, it gets replaced by the actual resource group.
It extracts the resource group using the VM's ID using [`arm.ParseResourceID`](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azcore/arm#ParseResourceID).

Manually tested and works as expected.

changelog: Fix Azure VM auto discovery when not filtering by resource group