### PR TITLE
[v17] No longer show "Fatal error" on normal closure of SPIFFEFederationSyncer

### DIFF
--- a/lib/auth/machineid/machineidv1/spiffe_federation_syncer.go
+++ b/lib/auth/machineid/machineidv1/spiffe_federation_syncer.go
@@ -183,7 +183,7 @@ func (s *SPIFFEFederationSyncer) Run(ctx context.Context) error {
 				RetryInterval: time.Second * 30,
 			},
 		}, s.syncTrustDomains)
-		if err != nil {
+		if err != nil && ctx.Err() == nil {
 			s.cfg.Logger.ErrorContext(
 				ctx,
 				"SPIFFEFederation syncer encountered a fatal error, it will restart after backoff",


### PR DESCRIPTION
Backport #53751 to branch/v17