### PR TITLE
Okta: Align sync settings methods

### DIFF
--- a/api/types/okta.go
+++ b/api/types/okta.go
@@ -508,29 +508,29 @@ func (o *PluginOktaSettings) GetSyncSettings() *PluginOktaSyncSettings {
 	return o.SyncSettings
 }
 
-func (o *PluginOktaSyncSettings) GetUserSyncEnabled() bool {
+func (o *PluginOktaSyncSettings) GetEnableUserSync() bool {
 	if o == nil {
 		return false
 	}
 	return o.SyncUsers
 }
 
-func (o *PluginOktaSyncSettings) GetAppGroupSyncEnabled() bool {
-	if !o.GetUserSyncEnabled() {
+func (o *PluginOktaSyncSettings) GetEnableAppGroupSync() bool {
+	if !o.GetEnableUserSync() {
 		return false
 	}
 	return !o.DisableSyncAppGroups
 }
 
-func (o *PluginOktaSyncSettings) GetAccessListSyncEnabled() bool {
+func (o *PluginOktaSyncSettings) GetEnableAccessListSync() bool {
 	if o == nil {
 		return false
 	}
 	return o.SyncAccessLists
 }
 
-func (o *PluginOktaSyncSettings) GetBidirectionalSyncEnabled() bool {
-	if !o.GetAccessListSyncEnabled() {
+func (o *PluginOktaSyncSettings) GetEnableBidirectionalSync() bool {
+	if !o.GetEnableAccessListSync() {
 		return false
 	}
 	return !o.DisableBidirectionalSync

--- a/api/types/okta_test.go
+++ b/api/types/okta_test.go
@@ -309,19 +309,19 @@ func Test_PluginOktaSyncSettings_SyncEnabledGetters(t *testing.T) {
 	t.Run("on nil settings", func(t *testing.T) {
 		syncSettings := (*PluginOktaSyncSettings)(nil)
 
-		require.False(t, syncSettings.GetUserSyncEnabled())
-		require.False(t, syncSettings.GetAppGroupSyncEnabled())
-		require.False(t, syncSettings.GetAccessListSyncEnabled())
-		require.False(t, syncSettings.GetBidirectionalSyncEnabled())
+		require.False(t, syncSettings.GetEnableUserSync())
+		require.False(t, syncSettings.GetEnableAppGroupSync())
+		require.False(t, syncSettings.GetEnableAccessListSync())
+		require.False(t, syncSettings.GetEnableBidirectionalSync())
 	})
 
 	t.Run("on empty settings", func(t *testing.T) {
 		syncSettings := &PluginOktaSyncSettings{}
 
-		require.False(t, syncSettings.GetUserSyncEnabled())
-		require.False(t, syncSettings.GetAppGroupSyncEnabled())
-		require.False(t, syncSettings.GetAccessListSyncEnabled())
-		require.False(t, syncSettings.GetBidirectionalSyncEnabled())
+		require.False(t, syncSettings.GetEnableUserSync())
+		require.False(t, syncSettings.GetEnableAppGroupSync())
+		require.False(t, syncSettings.GetEnableAccessListSync())
+		require.False(t, syncSettings.GetEnableBidirectionalSync())
 	})
 
 	t.Run("on user sync enabled", func(t *testing.T) {
@@ -329,10 +329,10 @@ func Test_PluginOktaSyncSettings_SyncEnabledGetters(t *testing.T) {
 			SyncUsers: true,
 		}
 
-		require.True(t, syncSettings.GetUserSyncEnabled())
-		require.True(t, syncSettings.GetAppGroupSyncEnabled()) // true by default
-		require.False(t, syncSettings.GetAccessListSyncEnabled())
-		require.False(t, syncSettings.GetBidirectionalSyncEnabled())
+		require.True(t, syncSettings.GetEnableUserSync())
+		require.True(t, syncSettings.GetEnableAppGroupSync()) // true by default
+		require.False(t, syncSettings.GetEnableAccessListSync())
+		require.False(t, syncSettings.GetEnableBidirectionalSync())
 	})
 
 	t.Run("on user sync enabled with disabled app and group sync", func(t *testing.T) {
@@ -341,10 +341,10 @@ func Test_PluginOktaSyncSettings_SyncEnabledGetters(t *testing.T) {
 			DisableSyncAppGroups: true,
 		}
 
-		require.True(t, syncSettings.GetUserSyncEnabled())
-		require.False(t, syncSettings.GetAppGroupSyncEnabled())
-		require.False(t, syncSettings.GetAccessListSyncEnabled())
-		require.False(t, syncSettings.GetBidirectionalSyncEnabled())
+		require.True(t, syncSettings.GetEnableUserSync())
+		require.False(t, syncSettings.GetEnableAppGroupSync())
+		require.False(t, syncSettings.GetEnableAccessListSync())
+		require.False(t, syncSettings.GetEnableBidirectionalSync())
 	})
 
 	t.Run("on access list sync enabled", func(t *testing.T) {
@@ -352,10 +352,10 @@ func Test_PluginOktaSyncSettings_SyncEnabledGetters(t *testing.T) {
 			SyncAccessLists: true,
 		}
 
-		require.False(t, syncSettings.GetUserSyncEnabled())
-		require.False(t, syncSettings.GetAppGroupSyncEnabled())
-		require.True(t, syncSettings.GetAccessListSyncEnabled())
-		require.True(t, syncSettings.GetBidirectionalSyncEnabled()) // true by default
+		require.False(t, syncSettings.GetEnableUserSync())
+		require.False(t, syncSettings.GetEnableAppGroupSync())
+		require.True(t, syncSettings.GetEnableAccessListSync())
+		require.True(t, syncSettings.GetEnableBidirectionalSync()) // true by default
 	})
 
 	t.Run("on access list sync enabled with bidirectional sync disabled", func(t *testing.T) {
@@ -364,9 +364,9 @@ func Test_PluginOktaSyncSettings_SyncEnabledGetters(t *testing.T) {
 			DisableBidirectionalSync: true,
 		}
 
-		require.False(t, syncSettings.GetUserSyncEnabled())
-		require.False(t, syncSettings.GetAppGroupSyncEnabled())
-		require.True(t, syncSettings.GetAccessListSyncEnabled())
-		require.False(t, syncSettings.GetBidirectionalSyncEnabled())
+		require.False(t, syncSettings.GetEnableUserSync())
+		require.False(t, syncSettings.GetEnableAppGroupSync())
+		require.True(t, syncSettings.GetEnableAccessListSync())
+		require.False(t, syncSettings.GetEnableBidirectionalSync())
 	})
 }

--- a/lib/auth/okta/auth.go
+++ b/lib/auth/okta/auth.go
@@ -106,7 +106,7 @@ func BidirectionalSyncEnabled(ctx context.Context, plugins services.Plugins) (bo
 	} else if err != nil {
 		return false, trace.Wrap(err, "getting Okta plugin")
 	}
-	return plugin.Spec.GetOkta().GetSyncSettings().GetBidirectionalSyncEnabled(), nil
+	return plugin.Spec.GetOkta().GetSyncSettings().GetEnableBidirectionalSync(), nil
 }
 
 // AccessPoint provides services required by [CheckResourcesRequestable].


### PR DESCRIPTION
So the same interface can be used for PluginOktaSyncSettings, CreateIntegrationRequest and UpdateIntegration request for checking scopes.