### PR TITLE
[v17] Restrict agent updates on Cloud to Mon-Thu

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1352,6 +1352,7 @@ func (a *Server) syncUpgradeWindowStartHour(ctx context.Context) error {
 	agentWindow, _ := cmc.GetAgentUpgradeWindow()
 
 	agentWindow.UTCStartHour = uint32(startHour)
+	agentWindow.Weekdays = []string{"Mon", "Tue", "Wed", "Thu"}
 
 	cmc.SetAgentUpgradeWindow(agentWindow)
 

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -1861,6 +1861,7 @@ func TestSyncUpgradeWindowStartHour(t *testing.T) {
 	require.True(t, ok)
 
 	require.Equal(t, uint32(0), agentWindow.UTCStartHour)
+	require.Equal(t, []string{"Mon", "Tue", "Wed", "Thu"}, agentWindow.Weekdays)
 
 	// change the served hour
 	mu.Lock()


### PR DESCRIPTION
Backport #53734 to branch/v17

changelog: Restrict agent update days to Mon-Thu on Cloud
