### PR TITLE
An endpoint that returns a single role

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -972,6 +972,7 @@ func (h *Handler) bindDefaultEndpoints() {
 
 	h.GET("/webapi/roles", h.WithAuth(h.listRolesHandle))
 	h.POST("/webapi/roles", h.WithAuth(h.createRoleHandle))
+	h.GET("/webapi/roles/:name", h.WithAuth(h.getRole))
 	h.PUT("/webapi/roles/:name", h.WithAuth(h.updateRoleHandle))
 	h.DELETE("/webapi/roles/:name", h.WithAuth(h.deleteRole))
 	h.GET("/webapi/presetroles", h.WithUnauthenticatedHighLimiter(h.getPresetRoles))

--- a/lib/web/resources.go
+++ b/lib/web/resources.go
@@ -174,6 +174,22 @@ func (h *Handler) createRoleHandle(w http.ResponseWriter, r *http.Request, param
 	return item, trace.Wrap(err)
 }
 
+func (h *Handler) getRole(w http.ResponseWriter, r *http.Request, params httprouter.Params, ctx *SessionContext) (interface{}, error) {
+	clt, err := ctx.GetClient()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	roleName := params.ByName("name")
+	role, err := clt.GetRole(r.Context(), roleName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ri, err := ui.NewResourceItem(role)
+	return ri, trace.Wrap(err)
+}
+
 func (h *Handler) updateRoleHandle(w http.ResponseWriter, r *http.Request, params httprouter.Params, ctx *SessionContext) (interface{}, error) {
 	clt, err := ctx.GetClient()
 	if err != nil {

--- a/lib/web/resources_test.go
+++ b/lib/web/resources_test.go
@@ -360,6 +360,13 @@ func TestRoleCRUD(t *testing.T) {
 
 	created := unmarshalResponse(resp.Bytes())
 
+	// Validate the role can be retrieved.
+	resp, err = pack.clt.Get(ctx, pack.clt.Endpoint("webapi", "roles", expected.GetName()), url.Values{})
+	require.NoError(t, err, "unexpected error retrieving a role")
+	assert.Equal(t, http.StatusOK, resp.Code(), "unexpected status code retrieving a role")
+	retrieved := unmarshalResponse(resp.Bytes())
+	assert.Equal(t, created, retrieved, "expected the retrieved role to be equal to the created one")
+
 	// Validate that creating the role again fails.
 	resp, err = pack.clt.PostJSON(ctx, pack.clt.Endpoint("webapi", "roles"), createPayload(expected))
 	assert.Error(t, err, "expected an error creating a duplicate role")
@@ -416,6 +423,12 @@ func TestRoleCRUD(t *testing.T) {
 	for _, item := range getResponse.Items.([]interface{}) {
 		assert.NotEqual(t, "test-role", item.(map[string]interface{})["name"], "expected test-role to be deleted")
 	}
+
+	// Validate that attempting to retrieve a deleted role yields a NotFound error.
+	resp, err = pack.clt.Get(ctx, pack.clt.Endpoint("webapi", "roles", expected.GetName()), url.Values{})
+	assert.Error(t, err, "expected fetching a nonexistent role to fail")
+	assert.True(t, trace.IsNotFound(err), "expected a NotFound error, got %T", err)
+	assert.Equal(t, http.StatusNotFound, resp.Code(), "unexpected status code retrieving a role")
 }
 
 func TestGithubConnectorsCRUD(t *testing.T) {


### PR DESCRIPTION
This will be used in an upcoming front-end PR to check whether given role exists.

Contributes to https://github.com/gravitational/teleport/issues/52221
Followed up by https://github.com/gravitational/teleport/pull/53784