### PR TITLE
docs: mention Teleport SAML IdP in Identity Center guide next steps

### DIFF
--- a/docs/pages/admin-guides/management/guides/aws-iam-identity-center/guide.mdx
+++ b/docs/pages/admin-guides/management/guides/aws-iam-identity-center/guide.mdx
@@ -317,8 +317,9 @@ Provider and its role from your AWS IAM console as well.
 
 - Take a deeper dive into fundamental Teleport concepts used in Identity Center
   integration such as [RBAC](../../../access-controls/guides/guides.mdx),
-  [JIT Access Requests](../../../access-controls/access-requests/access-requests.mdx)
-  and [Access Lists](../../../access-controls/access-lists/access-lists.mdx).
+  [JIT Access Requests](../../../access-controls/access-requests/access-requests.mdx),
+  [Access Lists](../../../access-controls/access-lists/access-lists.mdx) 
+  and [Teleport SAML IdP](../../../access-controls/idps/idps.mdx).
 - Learn how to enable [Okta integration](../../../../enroll-resources/application-access/okta/hosted-guide.mdx)
   to sync apps, users and groups from Okta in conjunction with Identity Center
   integration.


### PR DESCRIPTION
Teleport SAML IdP is the core part of Identity Center integration and user needs to learn about SAML attribute mapping for advance integration use cases. This doc patch mentions SAML IdP and the link points to the root SAML IdP docs page. 