### PR TITLE
Web: create list db_server endpoint

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -928,6 +928,9 @@ func (h *Handler) bindDefaultEndpoints() {
 	// DatabaseService handlers
 	h.GET("/webapi/sites/:site/databaseservices", h.WithClusterAuth(h.clusterDatabaseServicesList))
 
+	// Database server handlers
+	h.GET("/webapi/sites/:site/databaseservers", h.WithClusterAuth(h.clusterDatabaseServersList))
+
 	// Kube access handlers.
 	h.GET("/webapi/sites/:site/kubernetes", h.WithClusterAuth(h.clusterKubesGet))
 	h.GET("/webapi/sites/:site/kubernetes/resources", h.WithClusterAuth(h.clusterKubeResourcesGet))

--- a/lib/web/databases_test.go
+++ b/lib/web/databases_test.go
@@ -415,6 +415,66 @@ func TestHandleDatabaseServicesGet(t *testing.T) {
 	require.Equal(t, &types.Labels{"env": []string{"prod"}}, respResourceMatcher.Labels)
 }
 
+type listDatabaseServerResp struct {
+	Items []types.DatabaseServerV3 `json:"items"`
+}
+
+func TestHandleDatabaseServerGet(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	user := "user"
+	roleDatabaseServer, err := types.NewRole(services.RoleNameForUser(user), types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			DatabaseLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+			Rules: []types.Rule{
+				types.NewRule(types.KindDatabaseServer,
+					[]string{types.VerbRead, types.VerbList}),
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	env := newWebPack(t, 1)
+	proxy := env.proxies[0]
+	pack := proxy.authPack(t, user, []types.Role{roleDatabaseServer})
+
+	var listDBServerResp listDatabaseServerResp
+
+	// No database server exists
+	resp, err := pack.clt.Get(ctx, pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "databaseservers"), nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.Code())
+	require.NoError(t, json.Unmarshal(resp.Bytes(), &listDBServerResp))
+
+	require.Empty(t, listDBServerResp.Items)
+
+	// Adding one database server
+	dbServiceName := uuid.NewString()
+	dbService001, err := types.NewDatabaseServerV3(types.Metadata{
+		Name: "postgres",
+	}, types.DatabaseServerSpecV3{HostID: dbServiceName, Hostname: "some-hostname",
+		Database: &types.DatabaseV3{Metadata: types.Metadata{Name: "postgres"},
+			Spec: types.DatabaseSpecV3{Protocol: "postgres", URI: "some-uri"}}})
+	require.NoError(t, err)
+
+	_, err = env.server.Auth().UpsertDatabaseServer(ctx, dbService001)
+	require.NoError(t, err)
+
+	// The API returns one database server.
+	resp, err = pack.clt.Get(ctx, pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "databaseservers"), nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.Code())
+	require.NoError(t, json.Unmarshal(resp.Bytes(), &listDBServerResp))
+
+	dbServers := listDBServerResp.Items
+	require.Len(t, dbServers, 1)
+	respDBServer := dbServers[0]
+
+	require.Equal(t, dbServiceName, respDBServer.GetHostID())
+	require.Equal(t, "some-hostname", respDBServer.GetHostname())
+}
+
 func TestHandleSQLServerConfigureScript(t *testing.T) {
 	ctx := context.Background()
 	env := newWebPack(t, 1)

--- a/lib/web/servers.go
+++ b/lib/web/servers.go
@@ -180,6 +180,29 @@ func (h *Handler) clusterDatabaseServicesList(w http.ResponseWriter, r *http.Req
 	}, nil
 }
 
+// clusterDatabaseServersList returns a list of database servers in a form the UI can present.
+func (h *Handler) clusterDatabaseServersList(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
+	clt, err := ctx.GetUserClient(r.Context(), site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	req, err := convertListResourcesRequest(r, types.KindDatabaseServer)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	page, err := client.GetResourcePage[types.DatabaseServer](r.Context(), clt, req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return listResourcesGetResponse{
+		Items:    page.Resources,
+		StartKey: page.NextKey,
+	}, nil
+}
+
 // clusterDesktopsGet returns a list of desktops in a form the UI can present.
 func (h *Handler) clusterDesktopsGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (interface{}, error) {
 	clt, err := sctx.GetUserClient(r.Context(), site)

--- a/web/packages/shared/components/UnifiedResources/types.ts
+++ b/web/packages/shared/components/UnifiedResources/types.ts
@@ -26,6 +26,17 @@ import { DbProtocol } from 'shared/services/databases';
 import { ResourceLabel } from 'teleport/services/agents';
 import { AppSubKind, PermissionSet } from 'teleport/services/apps';
 
+/**
+ * status == '' is a result of an older agent that does not
+ * support the health check feature.
+ */
+export type ResourceStatus = 'healthy' | 'unhealthy' | 'unknown' | '';
+
+export type ResourceTargetHealth = {
+  status: ResourceStatus;
+  reason: string;
+};
+
 export type UnifiedResourceApp = {
   kind: 'app';
   id: string;

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -279,6 +279,10 @@ const cfg = {
     databasePath: `/v1/webapi/sites/:clusterId/databases/:database`,
     databasesPath: `/v1/webapi/sites/:clusterId/databases?searchAsRoles=:searchAsRoles?&limit=:limit?&startKey=:startKey?&query=:query?&search=:search?&sort=:sort?`,
 
+    databaseServer: {
+      list: `/v1/webapi/sites/:clusterId/databaseservers?&limit=:limit?&startKey=:startKey?&query=:query?`,
+    },
+
     desktopsPath: `/v1/webapi/sites/:clusterId/desktops?searchAsRoles=:searchAsRoles?&limit=:limit?&startKey=:startKey?&query=:query?&search=:search?&sort=:sort?`,
     desktopPath: `/v1/webapi/sites/:clusterId/desktops/:desktopName`,
     desktopWsAddr:
@@ -938,6 +942,13 @@ const cfg = {
 
   getDatabasesUrl(clusterId: string, params?: UrlResourcesParams) {
     return generateResourcePath(cfg.api.databasesPath, {
+      clusterId,
+      ...params,
+    });
+  },
+
+  getDatabaseServerUrl(clusterId: string, params?: UrlResourcesParams) {
+    return generateResourcePath(cfg.api.databaseServer.list, {
       clusterId,
       ...params,
     });

--- a/web/packages/teleport/src/services/databases/makeDatabase.ts
+++ b/web/packages/teleport/src/services/databases/makeDatabase.ts
@@ -18,7 +18,7 @@
 
 import { formatDatabaseInfo } from 'shared/services/databases';
 
-import { Aws, Database, DatabaseService } from './types';
+import { Aws, Database, DatabaseServer, DatabaseService } from './types';
 
 export function makeDatabase(json: any): Database {
   const { name, desc, protocol, type, aws, requiresRequest } = json;
@@ -92,4 +92,18 @@ function combineResourceMatcherLabels(
   });
 
   return labelMap;
+}
+
+export function makeDatabaseServer(json: any): DatabaseServer {
+  const { spec, status } = json;
+
+  return {
+    hostname: spec?.hostname,
+    hostId: spec?.host_id,
+    targetHealth: status &&
+      status.target_health && {
+        status: status.target_health.status,
+        reason: status.target_health.transition_error,
+      },
+  };
 }

--- a/web/packages/teleport/src/services/databases/types.ts
+++ b/web/packages/teleport/src/services/databases/types.ts
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { ResourceTargetHealth } from 'shared/components/UnifiedResources';
 import { DbProtocol } from 'shared/services/databases';
 
 import { ResourceLabel } from 'teleport/services/agents';
@@ -101,4 +102,15 @@ export type DatabaseServicesResponse = {
   services: DatabaseService[];
   startKey?: string;
   totalCount?: number;
+};
+
+export type DatabaseServer = {
+  hostname: string;
+  hostId: string;
+  targetHealth?: ResourceTargetHealth;
+};
+
+export type DatabaseServerResponse = {
+  items: DatabaseServer[];
+  startKey?: string;
 };


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/20544

PR just adds a web endpoint (and related boilerplate) where we can get a list of db_servers. This is required when user expands `show connection issue`, we need to list all `db_servers` where `status !== unhealthy`

This endpoint also supports `query` where we can use predicate expression `name == "db name"` to get all db_servers for that given `db_name`

note: i'm backporting b/c it doesn't hurt to