### PR TITLE
Add `DeleteProfile` to `client.ProfileStore`

### DIFF
--- a/api/profile/profile.go
+++ b/api/profile/profile.go
@@ -282,16 +282,6 @@ func SetCurrentProfileName(dir string, name string) error {
 	return nil
 }
 
-// RemoveProfile removes cluster profile file
-func RemoveProfile(dir, name string) error {
-	profilePath := filepath.Join(dir, name+".yaml")
-	if err := os.Remove(profilePath); err != nil {
-		return trace.ConvertSystemError(err)
-	}
-
-	return nil
-}
-
 // GetCurrentProfileName attempts to load the current profile name.
 func GetCurrentProfileName(dir string) (name string, err error) {
 	if dir == "" {
@@ -310,33 +300,6 @@ func GetCurrentProfileName(dir string) (name string, err error) {
 		return "", trace.NotFound("current-profile is not set")
 	}
 	return name, nil
-}
-
-// ListProfileNames lists all available profiles.
-func ListProfileNames(dir string) ([]string, error) {
-	if dir == "" {
-		return nil, trace.BadParameter("cannot list profiles: missing dir")
-	}
-	files, err := os.ReadDir(dir)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	var names []string
-	for _, file := range files {
-		if file.IsDir() {
-			continue
-		}
-
-		if file.Type()&os.ModeSymlink != 0 {
-			continue
-		}
-		if !strings.HasSuffix(file.Name(), ".yaml") {
-			continue
-		}
-		names = append(names, strings.TrimSuffix(file.Name(), ".yaml"))
-	}
-	return names, nil
 }
 
 // FullProfilePath returns the full path to the user profile directory.

--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -571,6 +571,8 @@ func (a *LocalKeyAgent) addKeyRing(keyRing *KeyRing) error {
 // DeleteKey removes the key with all its certs from the key store
 // and unloads the key from the agent.
 func (a *LocalKeyAgent) DeleteKey() error {
+	// TODO(Joerger): Delete profile? Delete current profile if it matches?
+
 	// remove key from key store
 	err := a.clientStore.DeleteKeyRing(KeyRingIndex{ProxyHost: a.proxyHost, Username: a.username})
 	if err != nil {

--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"slices"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -55,6 +56,10 @@ type ProfileStore interface {
 	// SaveProfile saves the given profile. If makeCurrent
 	// is true, it makes this profile current.
 	SaveProfile(profile *profile.Profile, setCurrent bool) error
+
+	// DeleteProfile deletes the given profile. If it is the
+	// current profile, it also deletes that record.
+	DeleteProfile(profileName string) error
 }
 
 // MemProfileStore is an in-memory implementation of ProfileStore.
@@ -107,6 +112,21 @@ func (ms *MemProfileStore) SaveProfile(profile *profile.Profile, makecurrent boo
 	return nil
 }
 
+// DeleteProfile deletes the given profile. If it is the
+// current profile, it also deletes that record.
+func (ms *MemProfileStore) DeleteProfile(profileName string) error {
+	if _, ok := ms.profiles[profileName]; !ok {
+		return trace.NotFound("profile for proxy host %q not found", profileName)
+	}
+
+	if ms.currentProfile == profileName {
+		ms.currentProfile = ""
+	}
+
+	delete(ms.profiles, profileName)
+	return nil
+}
+
 // FSProfileStore is an on-disk implementation of the ProfileStore interface.
 //
 // The FS store uses the file layout outlined in `api/utils/keypaths.go`.
@@ -134,11 +154,26 @@ func (fs *FSProfileStore) CurrentProfile() (string, error) {
 
 // ListProfiles returns a list of all profiles.
 func (fs *FSProfileStore) ListProfiles() ([]string, error) {
-	profileNames, err := profile.ListProfileNames(fs.Dir)
+	files, err := os.ReadDir(fs.Dir)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return profileNames, nil
+
+	var names []string
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+
+		if file.Type()&os.ModeSymlink != 0 {
+			continue
+		}
+		if !strings.HasSuffix(file.Name(), ".yaml") {
+			continue
+		}
+		names = append(names, strings.TrimSuffix(file.Name(), ".yaml"))
+	}
+	return names, nil
 }
 
 // GetProfile returns the requested profile.
@@ -159,6 +194,24 @@ func (fs *FSProfileStore) SaveProfile(profile *profile.Profile, makeCurrent bool
 
 	err := profile.SaveToDir(fs.Dir, makeCurrent)
 	return trace.Wrap(err)
+}
+
+// DeleteProfile deletes the given profile. If it is the
+// current profile, it also deletes that record.
+func (fs *FSProfileStore) DeleteProfile(profileName string) error {
+	if _, err := profile.FromDir(fs.Dir, profileName); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if current, err := fs.CurrentProfile(); err != nil && !trace.IsNotFound(err) {
+		return trace.Wrap(err)
+	} else if current == profileName {
+		if err := os.Remove(keypaths.CurrentProfileFilePath(fs.Dir)); err != nil {
+			return trace.ConvertSystemError(err)
+		}
+	}
+
+	return trace.ConvertSystemError(os.Remove(keypaths.ProfileFilePath(fs.Dir, profileName)))
 }
 
 // ProfileStatus combines metadata from the logged in profile and associated

--- a/lib/teleterm/clusters/storage.go
+++ b/lib/teleterm/clusters/storage.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/lib/client"
 	dtauthn "github.com/gravitational/teleport/lib/devicetrust/authn"
 	dtenroll "github.com/gravitational/teleport/lib/devicetrust/enroll"
@@ -43,7 +42,8 @@ func NewStorage(cfg Config) (*Storage, error) {
 
 // ListProfileNames returns just the names of profiles in s.Dir.
 func (s *Storage) ListProfileNames() ([]string, error) {
-	pfNames, err := profile.ListProfileNames(s.Dir)
+	profileStore := client.NewFSProfileStore(s.Dir)
+	pfNames, err := profileStore.ListProfiles()
 	return pfNames, trace.Wrap(err)
 }
 
@@ -112,11 +112,8 @@ func (s *Storage) ResolveCluster(resourceURI uri.ResourceURI) (*Cluster, *client
 
 // Remove removes a cluster
 func (s *Storage) Remove(ctx context.Context, profileName string) error {
-	if err := profile.RemoveProfile(s.Dir, profileName); err != nil {
-		return trace.Wrap(err)
-	}
-
-	return nil
+	profileStore := client.NewFSProfileStore(s.Dir)
+	return profileStore.DeleteProfile(profileName)
 }
 
 // Add adds a cluster
@@ -125,7 +122,7 @@ func (s *Storage) Remove(ctx context.Context, profileName string) error {
 // clusters.Cluster a regular struct with no extra behavior and a much smaller interface.
 // https://github.com/gravitational/teleport/issues/13278
 func (s *Storage) Add(ctx context.Context, webProxyAddress string) (*Cluster, *client.TeleportClient, error) {
-	profiles, err := profile.ListProfileNames(s.Dir)
+	profiles, err := s.ListProfileNames()
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}

--- a/lib/vnet/profile_osconfig_provider_darwin.go
+++ b/lib/vnet/profile_osconfig_provider_darwin.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 
-	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys/piv"
 	"github.com/gravitational/teleport/lib/client"
@@ -99,7 +98,7 @@ func (p *profileOSConfigProvider) targetOSConfig(ctx context.Context) (*osConfig
 	// to access p.homePath that it sent when starting the daemon.
 	// Otherwise a client could make the daemon read a profile out of any directory.
 	if err := doWithDroppedRootPrivileges(ctx, p.daemonClientCred, func() error {
-		profileNames, err := profile.ListProfileNames(p.homePath)
+		profileNames, err := p.clientStore.ListProfiles()
 		if err != nil {
 			return trace.Wrap(err, "listing user profiles")
 		}


### PR DESCRIPTION
Use profile store instead of adhoc profile methods with a directory input for more consistency and extendability.

Related to https://github.com/gravitational/teleport/pull/53707