### PR TITLE
Role editor metadata section improvements

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -972,6 +972,7 @@ func (h *Handler) bindDefaultEndpoints() {
 
 	h.GET("/webapi/roles", h.WithAuth(h.listRolesHandle))
 	h.POST("/webapi/roles", h.WithAuth(h.createRoleHandle))
+	h.GET("/webapi/roles/:name", h.WithAuth(h.getRole))
 	h.PUT("/webapi/roles/:name", h.WithAuth(h.updateRoleHandle))
 	h.DELETE("/webapi/roles/:name", h.WithAuth(h.deleteRole))
 	h.GET("/webapi/presetroles", h.WithUnauthenticatedHighLimiter(h.getPresetRoles))

--- a/lib/web/resources.go
+++ b/lib/web/resources.go
@@ -174,6 +174,22 @@ func (h *Handler) createRoleHandle(w http.ResponseWriter, r *http.Request, param
 	return item, trace.Wrap(err)
 }
 
+func (h *Handler) getRole(w http.ResponseWriter, r *http.Request, params httprouter.Params, ctx *SessionContext) (interface{}, error) {
+	clt, err := ctx.GetClient()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	roleName := params.ByName("name")
+	role, err := clt.GetRole(r.Context(), roleName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ri, err := ui.NewResourceItem(role)
+	return ri, trace.Wrap(err)
+}
+
 func (h *Handler) updateRoleHandle(w http.ResponseWriter, r *http.Request, params httprouter.Params, ctx *SessionContext) (interface{}, error) {
 	clt, err := ctx.GetClient()
 	if err != nil {

--- a/lib/web/resources_test.go
+++ b/lib/web/resources_test.go
@@ -360,6 +360,13 @@ func TestRoleCRUD(t *testing.T) {
 
 	created := unmarshalResponse(resp.Bytes())
 
+	// Validate the role can be retrieved.
+	resp, err = pack.clt.Get(ctx, pack.clt.Endpoint("webapi", "roles", expected.GetName()), url.Values{})
+	require.NoError(t, err, "unexpected error retrieving a role")
+	assert.Equal(t, http.StatusOK, resp.Code(), "unexpected status code retrieving a role")
+	retrieved := unmarshalResponse(resp.Bytes())
+	assert.Equal(t, created, retrieved, "expected the retrieved role to be equal to the created one")
+
 	// Validate that creating the role again fails.
 	resp, err = pack.clt.PostJSON(ctx, pack.clt.Endpoint("webapi", "roles"), createPayload(expected))
 	assert.Error(t, err, "expected an error creating a duplicate role")
@@ -416,6 +423,12 @@ func TestRoleCRUD(t *testing.T) {
 	for _, item := range getResponse.Items.([]interface{}) {
 		assert.NotEqual(t, "test-role", item.(map[string]interface{})["name"], "expected test-role to be deleted")
 	}
+
+	// Validate that attempting to retrieve a deleted role yields a NotFound error.
+	resp, err = pack.clt.Get(ctx, pack.clt.Endpoint("webapi", "roles", expected.GetName()), url.Values{})
+	assert.Error(t, err, "expected fetching a nonexistent role to fail")
+	assert.True(t, trace.IsNotFound(err), "expected a NotFound error, got %T", err)
+	assert.Equal(t, http.StatusNotFound, resp.Code(), "unexpected status code retrieving a role")
 }
 
 func TestGithubConnectorsCRUD(t *testing.T) {

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
@@ -23,7 +23,11 @@ import { render, screen, userEvent } from 'design/utils/testing';
 
 import cfg from 'teleport/config';
 import { createTeleportContext } from 'teleport/mocks/contexts';
-import { Role, RoleWithYaml } from 'teleport/services/resources';
+import { ApiError } from 'teleport/services/api/parseError';
+import ResourceService, {
+  Role,
+  RoleWithYaml,
+} from 'teleport/services/resources';
 import { storageService } from 'teleport/services/storageService';
 import { CaptureEvent, userEventService } from 'teleport/services/userEvent';
 import { yamlService } from 'teleport/services/yaml';
@@ -74,6 +78,15 @@ beforeEach(() => {
       return toFauxYaml(withDefaults(req.resource));
     });
   jest.spyOn(userEventService, 'captureUserEvent').mockImplementation(() => {});
+  jest
+    .spyOn(ResourceService.prototype, 'fetchRole')
+    .mockImplementation(async name => {
+      // Pretend that we never have a name collision.
+      throw new ApiError({
+        message: `role ${name} is not found`,
+        response: { status: 404 } as Response,
+      });
+    });
 });
 
 afterEach(() => {

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/MetadataSection.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/MetadataSection.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import userEvent from '@testing-library/user-event';
+import selectEvent from 'react-select-event';
+
+import { act, render, screen } from 'design/utils/testing';
+import { Validator } from 'shared/components/Validation';
+
+import { createTeleportContext } from 'teleport/mocks/contexts';
+import { ApiError } from 'teleport/services/api/parseError';
+import ResourceService from 'teleport/services/resources';
+import TeleportContextProvider from 'teleport/TeleportContextProvider';
+
+import { MetadataSection } from './MetadataSection';
+import { MetadataModel } from './standardmodel';
+import { StatefulSectionWithDispatch } from './StatefulSection';
+import { StandardModelDispatcher } from './useStandardModel';
+import { MetadataValidationResult } from './validation';
+
+beforeEach(() => {
+  jest
+    .spyOn(ResourceService.prototype, 'fetchRole')
+    .mockImplementation(async (name: string) => {
+      if (name === 'existing-role') {
+        return {
+          kind: 'role',
+          id: '',
+          name,
+          content: '',
+        };
+      }
+      throw new ApiError({
+        message: `role ${name} is not found`,
+        response: { status: 404 } as Response,
+      });
+    });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+const setup = () => {
+  const modelRef = jest.fn();
+  const ctx = createTeleportContext();
+  let validator: Validator;
+  let dispatch: StandardModelDispatcher;
+  render(
+    <TeleportContextProvider ctx={ctx}>
+      <StatefulSectionWithDispatch<MetadataModel, MetadataValidationResult>
+        selector={m => m.roleModel.metadata}
+        validationSelector={m => m.validationResult.metadata}
+        component={MetadataSection}
+        validatorRef={v => {
+          validator = v;
+        }}
+        modelRef={modelRef}
+        dispatchRef={d => {
+          dispatch = d;
+        }}
+      />
+    </TeleportContextProvider>
+  );
+  return { modelRef, dispatch, validator };
+};
+
+test('basic editing', async () => {
+  const user = userEvent.setup();
+  const { modelRef } = setup();
+  await user.clear(screen.getByLabelText('Role Name *'));
+  await user.type(screen.getByLabelText('Role Name *'), 'some-name');
+  await user.type(screen.getByLabelText('Description'), 'some-description');
+  await user.click(screen.getByRole('button', { name: 'Add a Label' }));
+  await user.type(screen.getByPlaceholderText('label key'), 'foo');
+  await user.type(screen.getByPlaceholderText('label value'), 'bar');
+  await selectEvent.select(screen.getByLabelText('Version'), 'v6');
+  expect(modelRef).toHaveBeenLastCalledWith({
+    name: 'some-name',
+    nameCollision: false,
+    description: 'some-description',
+    labels: [{ name: 'foo', value: 'bar' }],
+    version: { label: 'v6', value: 'v6' },
+  } as MetadataModel);
+});
+
+test('basic validation', async () => {
+  const user = userEvent.setup();
+  const { validator } = setup();
+  await user.clear(screen.getByLabelText('Role Name *'));
+  await user.click(screen.getByRole('button', { name: 'Add a Label' }));
+  act(() => validator.validate());
+
+  expect(screen.getByLabelText('Role Name *')).toHaveAccessibleDescription(
+    'Role name is required'
+  );
+  expect(screen.getByPlaceholderText('label key')).toHaveAccessibleDescription(
+    'required'
+  );
+});
+
+// We are testing debounced logic and we don't want the test to wait until the
+// timer fires, so we are using fake timers. Because of that, we wrap the test
+// with a custom pair of before/after routines.
+describe('asynchronous validation', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test('checking for existing roles', async () => {
+    // Required for userEvent to cooperate nicely with fake timers.
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const { validator } = setup();
+    await user.clear(screen.getByLabelText('Role Name *'));
+    await user.type(screen.getByLabelText('Role Name *'), 'existing-role');
+
+    await act(async () => {
+      validator.validate();
+      // Wait until the fetch is debounced and resolved.
+      await jest.runAllTimersAsync();
+    });
+    expect(screen.getByLabelText('Role Name *')).toHaveAccessibleDescription(
+      'Role with this name already exists'
+    );
+
+    await user.clear(screen.getByLabelText('Role Name *'));
+    await user.type(screen.getByLabelText('Role Name *'), 'foo');
+    await act(async () => {
+      // Wait until the fetch is debounced and resolved.
+      await jest.runAllTimersAsync();
+    });
+    expect(screen.getByLabelText('Role Name *')).toHaveAccessibleDescription(
+      ''
+    );
+  });
+});

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/MetadataSection.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/MetadataSection.tsx
@@ -16,70 +16,156 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import React, { memo, useCallback, useEffect } from 'react';
+import { useTheme } from 'styled-components';
+
 import Box from 'design/Box';
 import Flex from 'design/Flex';
 import Text from 'design/Text';
 import FieldInput from 'shared/components/FieldInput';
 import { FieldSelect } from 'shared/components/FieldSelect';
-import { precomputed } from 'shared/components/Validation/rules';
+import { FieldTextArea } from 'shared/components/FieldTextArea';
+import { precomputed, requiredAll } from 'shared/components/Validation/rules';
+import { useAsync } from 'shared/hooks/useAsync';
+import { debounce } from 'shared/utils/highbar';
 
 import { LabelsInput } from 'teleport/components/LabelsInput';
+import { ApiError } from 'teleport/services/api/parseError';
+import useTeleport from 'teleport/useTeleport';
 
-import { SectionBox, SectionPadding, SectionProps } from './sections';
+import { SectionPadding, SectionPropsWithDispatch } from './sections';
 import { MetadataModel, roleVersionOptions } from './standardmodel';
+import { ActionType } from './useStandardModel';
 import { MetadataValidationResult } from './validation';
 
-export const MetadataSection = ({
-  value,
-  isProcessing,
-  validation,
-  onChange,
-}: SectionProps<MetadataModel, MetadataValidationResult>) => (
-  <Flex flexDirection="column" gap={3}>
-    <SectionPadding>Basic information about this role</SectionPadding>
-    <SectionBox
-      titleSegments={['Role Information']}
-      isProcessing={isProcessing}
-      validation={validation}
-    >
-      <FieldInput
-        label="Role Name"
-        required
-        placeholder="Enter Role Name"
-        value={value.name}
-        disabled={isProcessing}
-        rule={precomputed(validation.fields.name)}
-        onChange={e => onChange({ ...value, name: e.target.value })}
-      />
-      <FieldInput
-        label="Description"
-        placeholder="Enter Role Description"
-        value={value.description || ''}
-        disabled={isProcessing}
-        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-          onChange({ ...value, description: e.target.value })
-        }
-      />
-      <Box mb={3}>
-        <Text typography="body3" mb={1}>
-          Labels
-        </Text>
-        <LabelsInput
-          disableBtns={isProcessing}
-          labels={value.labels}
-          setLabels={labels => onChange({ ...value, labels })}
-          rule={precomputed(validation.fields.labels)}
-        />
-      </Box>
-      <FieldSelect
-        label="Version"
-        isDisabled={isProcessing}
-        options={roleVersionOptions}
-        value={value.version}
-        onChange={version => onChange({ ...value, version })}
-        mb={0}
-        menuPosition="fixed"
-      />
-    </SectionBox>
-  </Flex>
+export const MetadataSection = memo(
+  ({
+    value,
+    isProcessing,
+    validation,
+    isEditing,
+    dispatch,
+  }: SectionPropsWithDispatch<MetadataModel, MetadataValidationResult> & {
+    isEditing: boolean;
+  }) => {
+    const theme = useTheme();
+    const { resourceService } = useTeleport();
+
+    // Verifies whether a role already exists with this name. This will be used
+    // to show a validation error if necessary.
+    const [, checkForNameCollisionNow] = useAsync(
+      useCallback(
+        async (name: string) => {
+          if (isEditing || name === '') {
+            return;
+          }
+          try {
+            await resourceService.fetchRole(name);
+            // `fetchRole` will throw an error if HTTP/404 is returned,
+            // indicating that there's no such role. If we end up here, it
+            // means that there is already a role with this name, so we need to
+            // report it back to the model.
+            //
+            // Compatibility note: if we hit a proxy that doesn't yet support
+            // this endpoint, we just get a 404 anyway, which simply means the
+            // validation won't work in this case, but it won't be a
+            // catastrophic failure; the user will just get their role rejected
+            // by the server and will see a server error instead.
+            dispatch({
+              type: ActionType.SetRoleNameCollision,
+              payload: true,
+            });
+          } catch (e) {
+            // If there's no such role, don't do anything. That's expected.
+            // Otherwise, print the exception, since it would be swallowed by
+            // `useAsync` anyway, and we don't use the returned attempt object.
+            if (!(e instanceof ApiError && e.response.status === 404)) {
+              console.error(e);
+            }
+          }
+        },
+        [resourceService, dispatch]
+      )
+    );
+
+    // Getting callback caching right is especially important here, as we want
+    // always to use the correct version of `checkForNameCollisionNow`, but we
+    // also don't want to call `debounce` on every render, as it would defeat
+    // the purpose of debouncing altogether.
+    const checkForNameCollision = useCallback(
+      debounce(checkForNameCollisionNow, 500),
+      [checkForNameCollisionNow]
+    );
+
+    useEffect(() => {
+      // Check if the default name is available right after the component is
+      // rendered for the first time.
+      checkForNameCollision(value.name);
+    }, []);
+
+    function handleChange(newValue: MetadataModel) {
+      dispatch({ type: ActionType.SetMetadata, payload: newValue });
+    }
+
+    function handleNameChange(e: React.ChangeEvent<HTMLInputElement>) {
+      const name = e.target.value;
+      handleChange({ ...value, name, nameCollision: false });
+      checkForNameCollision(name);
+    }
+
+    return (
+      <Flex flexDirection="column" gap={3}>
+        <SectionPadding>Basic information about this role</SectionPadding>
+        <Box
+          border={1}
+          borderColor={theme.colors.interactive.tonal.neutral[0]}
+          borderRadius={3}
+          p={3}
+        >
+          <FieldInput
+            label="Role Name"
+            required
+            placeholder="Enter Role Name"
+            value={value.name}
+            disabled={isProcessing}
+            readonly={isEditing}
+            rule={requiredAll(
+              precomputed(validation.fields.name),
+              precomputed(validation.fields.nameCollision)
+            )}
+            onChange={handleNameChange}
+          />
+          <FieldTextArea
+            label="Description"
+            placeholder="Enter Role Description"
+            value={value.description || ''}
+            disabled={isProcessing}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              handleChange({ ...value, description: e.target.value })
+            }
+          />
+          <Box mb={3}>
+            <Text typography="body3" mb={1}>
+              Labels
+            </Text>
+            <LabelsInput
+              disableBtns={isProcessing}
+              labels={value.labels}
+              setLabels={labels => handleChange({ ...value, labels })}
+              rule={precomputed(validation.fields.labels)}
+            />
+          </Box>
+          <FieldSelect
+            label="Version"
+            isDisabled={isProcessing}
+            options={roleVersionOptions}
+            value={value.version}
+            onChange={version => handleChange({ ...value, version })}
+            mb={0}
+            menuPosition="fixed"
+          />
+        </Box>
+      </Flex>
+    );
+  }
 );

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.test.tsx
@@ -25,7 +25,11 @@ import { render, screen, userEvent } from 'design/utils/testing';
 import Validation from 'shared/components/Validation';
 
 import { createTeleportContext } from 'teleport/mocks/contexts';
-import { Role, RoleWithYaml } from 'teleport/services/resources';
+import { ApiError } from 'teleport/services/api/parseError';
+import ResourceService, {
+  Role,
+  RoleWithYaml,
+} from 'teleport/services/resources';
 import TeleportContextProvider from 'teleport/TeleportContextProvider';
 
 import { StandardEditor, StandardEditorProps } from './StandardEditor';
@@ -53,11 +57,23 @@ let user: UserEvent;
 
 beforeEach(() => {
   user = userEvent.setup();
+  jest
+    .spyOn(ResourceService.prototype, 'fetchRole')
+    .mockImplementation(async name => {
+      // Pretend that we never have a name collision.
+      throw new ApiError({
+        message: `role ${name} is not found`,
+        response: { status: 404 } as Response,
+      });
+    });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
 });
 
 test('adding and removing sections', async () => {
   render(<TestStandardEditor originalRole={newRoleWithYaml(newRole())} />);
-  expect(getAllSectionNames()).toEqual(['Role Information']);
   await user.click(getTabByName('Resources'));
   expect(getAllSectionNames()).toEqual([]);
 
@@ -105,28 +121,6 @@ test('adding and removing sections', async () => {
   expect(getAllSectionNames()).toEqual([]);
 });
 
-test('collapsed sections still apply validation', async () => {
-  const onSave = jest.fn();
-  render(
-    <TestStandardEditor
-      originalRole={newRoleWithYaml(newRole())}
-      onSave={onSave}
-    />
-  );
-  // Intentionally cause a validation error.
-  await user.clear(screen.getByLabelText('Role Name *'));
-  // Collapse the section.
-  await user.click(screen.getByRole('heading', { name: 'Role Information' }));
-  await user.click(screen.getByRole('button', { name: 'Save Changes' }));
-  expect(onSave).not.toHaveBeenCalled();
-
-  // Expand the section, make it valid.
-  await user.click(screen.getByRole('heading', { name: 'Role Information' }));
-  await user.type(screen.getByLabelText('Role Name *'), 'foo');
-  await user.click(screen.getByRole('button', { name: 'Save Changes' }));
-  expect(onSave).toHaveBeenCalled();
-});
-
 test('invisible tabs still apply validation', async () => {
   const onSave = jest.fn();
   render(
@@ -135,8 +129,10 @@ test('invisible tabs still apply validation', async () => {
       onSave={onSave}
     />
   );
-  // Intentionally cause a validation error.
-  await user.clear(screen.getByLabelText('Role Name *'));
+
+  // Cause a validation error by adding an empty label.
+  await user.click(screen.getByRole('button', { name: 'Add a Label' }));
+
   // Switch to a different tab.
   await user.click(getTabByName('Resources'));
   await user.click(screen.getByRole('button', { name: 'Save Changes' }));
@@ -144,7 +140,8 @@ test('invisible tabs still apply validation', async () => {
 
   // Switch back, make it valid.
   await user.click(getTabByName('Invalid data Overview'));
-  await user.type(screen.getByLabelText('Role Name *'), 'foo');
+  await user.type(screen.getByPlaceholderText('label key'), 'foo');
+  await user.type(screen.getByPlaceholderText('label value'), 'bar');
   await user.click(screen.getByRole('button', { name: 'Save Changes' }));
   expect(onSave).toHaveBeenCalled();
 });
@@ -157,8 +154,9 @@ test('hidden validation errors should not propagate to tab headings', async () =
       onSave={onSave}
     />
   );
-  // Intentionally cause a validation error.
-  await user.clear(screen.getByLabelText('Role Name *'));
+
+  // Cause a validation error by adding an empty label.
+  await user.click(screen.getByRole('button', { name: 'Add a Label' }));
   await user.click(screen.getByRole('button', { name: 'Save Changes' }));
   expect(onSave).not.toHaveBeenCalled();
 

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.test.tsx
@@ -60,7 +60,7 @@ beforeEach(() => {
   jest
     .spyOn(ResourceService.prototype, 'fetchRole')
     .mockImplementation(async name => {
-      // Pretend that we never have a name collision.
+      // Make sure that validation never fails because of a role name collision.
       throw new ApiError({
         message: `role ${name} is not found`,
         response: { status: 404 } as Response,

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.tsx
@@ -201,12 +201,11 @@ export const StandardEditor = ({
           }}
         >
           <MetadataSection
+            isEditing={isEditing}
             value={roleModel.metadata}
             isProcessing={isProcessing}
             validation={validationResult.metadata}
-            onChange={metadata =>
-              dispatch({ type: ActionType.SetMetadata, payload: metadata })
-            }
+            dispatch={dispatch}
           />
         </Box>
         <Box

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.test.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.test.ts
@@ -69,6 +69,7 @@ const minimalRole = () =>
 const minimalRoleModel = (): RoleEditorModel => ({
   metadata: {
     name: 'foobar',
+    nameCollision: false,
     labels: [],
     version: roleVersionOptionsMap.get(defaultRoleVersion),
   },
@@ -146,6 +147,7 @@ describe.each<{ name: string; role: Role; model: RoleEditorModel }>([
       ...minimalRoleModel(),
       metadata: {
         name: 'role-name',
+        nameCollision: false,
         description: 'role-description',
         labels: [{ name: 'foo', value: 'bar' }],
         version: roleVersionOptionsMap.get(RoleVersion.V6),
@@ -859,13 +861,10 @@ describe('roleToRoleEditorModel', () => {
       )
     ).toEqual({
       ...minimalRoleModel(),
-      metadata: {
-        name: 'role-name',
+      metadata: expect.objectContaining({
         // We need to preserve the original revision.
         revision: originalRev,
-        labels: [],
-        version: roleVersionOptionsMap.get(defaultRoleVersion),
-      },
+      }),
       requiresReset: true,
       conversionErrors: [
         {
@@ -1105,6 +1104,7 @@ describe('roleEditorModelToRole', () => {
         ...minimalRoleModel(),
         metadata: {
           name: 'dog-walker',
+          nameCollision: false,
           description: 'walks dogs',
           revision: 'e2a3ccf8-09b9-4d97-8e47-6dbe3d53c0e5',
           labels: [{ name: 'kind', value: 'occupation' }],

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.ts
@@ -102,7 +102,7 @@ export type MetadataModel = {
    * Set to `true` when we detect an existing role with the same name. This is
    * for validation purposes only, but it's stored in the model, because our
    * validation framework doesn't currently have a native support for
-   * asynchronous validaiton. This flag is only being set if a new rule is
+   * asynchronous validation. This flag is only being set if a new rule is
    * being created.
    */
   nameCollision: boolean;
@@ -1335,7 +1335,8 @@ export function roleEditorModelToRole(roleModel: RoleEditorModel): Role {
   const { name, description, revision, labels, version, ...mRest } =
     roleModel.metadata;
   // Compile-time assert that protects us from silently losing fields.
-  // `nameCollision` is the only field we don't care about.
+  // `nameCollision` is the only field we don't care about, since its only use
+  // is validation, and it's not expected to be included in the result.
   mRest satisfies { nameCollision: boolean };
 
   const role: Role = {

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.ts
@@ -98,6 +98,14 @@ export function requiresReset(rm: RoleEditorModel | undefined): boolean {
 
 export type MetadataModel = {
   name: string;
+  /**
+   * Set to `true` when we detect an existing role with the same name. This is
+   * for validation purposes only, but it's stored in the model, because our
+   * validation framework doesn't currently have a native support for
+   * asynchronous validaiton. This flag is only being set if a new rule is
+   * being created.
+   */
+  nameCollision: boolean;
   description?: string;
   revision?: string;
   labels: UILabel[];
@@ -638,6 +646,7 @@ export function roleToRoleEditorModel(
   return {
     metadata: {
       name,
+      nameCollision: false,
       description,
       revision: originalRole?.metadata?.revision,
       labels: labelsToModel(labels),
@@ -1326,7 +1335,8 @@ export function roleEditorModelToRole(roleModel: RoleEditorModel): Role {
   const { name, description, revision, labels, version, ...mRest } =
     roleModel.metadata;
   // Compile-time assert that protects us from silently losing fields.
-  mRest satisfies Record<any, never>;
+  // `nameCollision` is the only field we don't care about.
+  mRest satisfies { nameCollision: boolean };
 
   const role: Role = {
     kind: 'role',

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/useStandardModel.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/useStandardModel.ts
@@ -85,6 +85,7 @@ export enum ActionType {
   SetModel = 'SetModel',
   ResetToStandard = 'ResetToStandard',
   SetMetadata = 'SetMetadata',
+  SetRoleNameCollision = 'SetRoleNameCollision',
   AddResourceAccess = 'AddResourceAccess',
   SetResourceAccess = 'SetResourceAccess',
   RemoveResourceAccess = 'RemoveResourceAccess',
@@ -102,6 +103,7 @@ type StandardModelAction =
   | SetModelAction
   | ResetToStandardAction
   | SetMetadataAction
+  | SetRoleNameCollisionAction
   | AddResourceAccessAction
   | SetResourceAccessAction
   | RemoveResourceAccessAction
@@ -123,6 +125,10 @@ type ResetToStandardAction = {
 type SetMetadataAction = {
   type: ActionType.SetMetadata;
   payload: MetadataModel;
+};
+type SetRoleNameCollisionAction = {
+  type: ActionType.SetRoleNameCollision;
+  payload: boolean;
 };
 type AddResourceAccessAction = {
   type: ActionType.AddResourceAccess;
@@ -190,6 +196,10 @@ const reduce = (
         state.roleModel.resources,
         payload.version.value
       );
+      break;
+
+    case ActionType.SetRoleNameCollision:
+      state.roleModel.metadata.nameCollision = payload;
       break;
 
     case ActionType.SetOptions:

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/validation.test.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/validation.test.ts
@@ -149,9 +149,17 @@ describe('validateRoleEditorModel', () => {
     expect(result.isValid).toBe(true);
   });
 
-  test('invalid metadata', () => {
+  test('invalid role name', () => {
     const model = minimalRoleModel();
     model.metadata.name = '';
+    const result = validateRoleEditorModel(model, undefined, undefined);
+    expect(result.metadata.valid).toBe(false);
+    expect(result.isValid).toBe(false);
+  });
+
+  test('conflicting role name', () => {
+    const model = minimalRoleModel();
+    model.metadata.nameCollision = true;
     const result = validateRoleEditorModel(model, undefined, undefined);
     expect(result.metadata.valid).toBe(false);
     expect(result.isValid).toBe(false);

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/validation.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/validation.ts
@@ -121,8 +121,14 @@ function validateMetadata(
   return runRules(model, metadataRules);
 }
 
+const mustBeFalse = (message: string) => (value: boolean) => () => ({
+  valid: !value,
+  message: value ? message : '',
+});
+
 const metadataRules = {
   name: requiredField('Role name is required'),
+  nameCollision: mustBeFalse('Role with this name already exists'),
   labels: nonEmptyLabels,
 };
 export type MetadataValidationResult = RuleSetValidationResult<

--- a/web/packages/teleport/src/services/resources/resource.ts
+++ b/web/packages/teleport/src/services/resources/resource.ts
@@ -118,6 +118,14 @@ class ResourceService {
       .then(res => makeResourceList<'role'>(res));
   }
 
+  async fetchRole(name: string): Promise<RoleResource> {
+    return makeResource<'role'>(
+      await api.get(cfg.getRoleUrl(name), undefined, undefined, {
+        allowRoleNotFound: true,
+      })
+    );
+  }
+
   createTrustedCluster(content: string) {
     return api
       .post(cfg.getTrustedClustersUrl(), { content })


### PR DESCRIPTION
- Make the name input read-only when editing an existing role.
- Don't use a collapsible section frame, as there's only one section.
- Remove the section title to minimize the UI verbosity (the tab title and explanatory text above is enough to convey the meaning here, and we gain consistency with the Options tab).
- Add a validation rule that alerts the user about using an existing rule name.
- Use a multi-line text area for role description.

[Demo](https://goteleport.zoom.us/clips/share/jhJgq8PjQYO7EddcGa6H_A)

Requires https://github.com/gravitational/teleport/pull/53770
Contributes to https://github.com/gravitational/teleport/issues/52221