### PR TITLE
Avoid throttling on dynamodb DescribeStream

### DIFF
--- a/lib/backend/dynamo/shards.go
+++ b/lib/backend/dynamo/shards.go
@@ -152,8 +152,8 @@ func (b *Backend) pollStreams(externalCtx context.Context) error {
 	b.buf.SetInit()
 	defer b.buf.Reset()
 
-	ticker := time.NewTicker(b.PollStreamPeriod)
-	defer ticker.Stop()
+	timer := time.NewTimer(b.PollStreamPeriod)
+	defer timer.Stop()
 
 	for {
 		select {
@@ -174,10 +174,11 @@ func (b *Backend) pollStreams(externalCtx context.Context) error {
 			} else {
 				b.buf.Emit(event.events...)
 			}
-		case <-ticker.C:
+		case <-timer.C:
 			if err := refreshShards(false); err != nil {
 				return trace.Wrap(err)
 			}
+			timer.Reset(b.PollStreamPeriod)
 		case <-ctx.Done():
 			b.logger.Log(ctx, logutils.TraceLevel, "Context is closing, returning.")
 			return nil

--- a/lib/backend/dynamo/shards.go
+++ b/lib/backend/dynamo/shards.go
@@ -282,6 +282,12 @@ func (b *Backend) collectActiveShards(ctx context.Context, streamArn *string) ([
 			return filterActiveShards(out), nil
 		}
 		input.ExclusiveStartShardId = streamInfo.StreamDescription.LastEvaluatedShardId
+		select {
+		case <-ctx.Done():
+			// let the next call deal with the context error
+		case <-time.After(200 * time.Millisecond):
+			// 10 calls per second with two auths, with ample margin
+		}
 	}
 }
 


### PR DESCRIPTION
The DynamoDB backend driver updates its known list of DynamoDB stream shards periodically (every `PollStreamPeriod`, defaulting to 1 second) by calling the `dynamodb:DescribeStream` API. Said API is documented to be rate limited (for a given stream) to 10 calls per second, but it's paginated, and certain abnormal DynamoDB workloads (often as a result of bugs, like the one fixed by #53298) can result in the creation of _a lot_ of shards, such that it takes several pages of results from `DescribeStream` to get a full list. We currently don't limit how quickly we advance through pages, and Teleport deployments on DynamoDB usually run two auths, which can result in so much throttling that the default retry behavior of the AWS SDK ends up surfacing the throttling error anyway.

Such throttling ends up tripping up the backend event stream periodically (even as often as once every 2 or 3 minutes) which leads to the auth cache being reset which leads to all instances resetting their cache and general poor UX (a broken backend event stream can lead to changes only taking effect after a while, breaking web logins and the terraform provider).

This PR adds a forced wait between calls to `DescribeStream`, and changes the interval of shard refreshing from once every `PollStreamPeriod` to a `PollStreamPeriod` between the end of the previous refresh and the beginning of the next.

This change has been tested with a dev build for a cloud tenant affected by the throttling and solved the issue. I have ran the `lib/backend/dynamo` tests a few times locally (against AWS, seeing as there's still no good dynamodb simulator unfortunately) with no failures.

Example error in the Auth Service logs:
```
"message":"Poll streams returned with error","component":"dynamodb","error":"operation error DynamoDB Streams: DescribeStream, exceeded maximum number of attempts, 3, https response error StatusCode: 400, RequestID: [cut], api error ThrottlingException: Rate exceeded"
```

changelog: fixed throttling in the DynamoDB backend event stream for tables with a high amount of stream shards