### PR TITLE
Avoid losing events at the end of a DynamoDB shard

### DIFF
--- a/lib/backend/dynamo/shards.go
+++ b/lib/backend/dynamo/shards.go
@@ -21,7 +21,6 @@ package dynamo
 import (
 	"context"
 	"errors"
-	"io"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -73,6 +72,12 @@ func (b *Backend) asyncPollStreams(ctx context.Context) error {
 			return nil
 		}
 	}
+}
+
+type shardClosedError struct{}
+
+func (shardClosedError) Error() string {
+	return "shard closed"
 }
 
 func (b *Backend) pollStreams(externalCtx context.Context) error {
@@ -166,7 +171,7 @@ func (b *Backend) pollStreams(externalCtx context.Context) error {
 					return trace.BadParameter("empty shard ID")
 				}
 				delete(set, event.shardID)
-				if !errors.Is(event.err, io.EOF) {
+				if !errors.Is(event.err, shardClosedError{}) {
 					b.logger.DebugContext(ctx, "Shard closed with error, resetting buffers.", "shard_id", event.shardID, "error", event.err)
 					return trace.Wrap(event.err)
 				}
@@ -221,32 +226,23 @@ func (b *Backend) pollShard(ctx context.Context, streamArn *string, shard stream
 	defer ticker.Stop()
 	iterator := shardIterator.ShardIterator
 	shardID := aws.ToString(shard.ShardId)
-	for {
+	for iterator != nil {
 		select {
 		case <-ctx.Done():
 			return trace.ConnectionProblem(ctx.Err(), "context is closing")
 		case <-ticker.C:
-			out, err := b.streams.GetRecords(ctx, &dynamodbstreams.GetRecordsInput{
-				ShardIterator: iterator,
-			})
-			if err != nil {
-				return convertError(err)
-			}
-			if len(out.Records) > 0 {
-				b.logger.Log(ctx, logutils.TraceLevel, "Got new stream shard records.", "num_records", len(out.Records))
-			}
-			if len(out.Records) == 0 {
-				if out.NextShardIterator == nil {
-					b.logger.Log(ctx, logutils.TraceLevel, "Shard is closed", "shard_id", aws.ToString(shard.ShardId))
-					return io.EOF
-				}
-				iterator = out.NextShardIterator
-				continue
-			}
-			if out.NextShardIterator == nil {
-				b.logger.Log(ctx, logutils.TraceLevel, "Shard is closed", "shard_id", aws.ToString(shard.ShardId))
-				return io.EOF
-			}
+		}
+
+		out, err := b.streams.GetRecords(ctx, &dynamodbstreams.GetRecordsInput{
+			ShardIterator: iterator,
+		})
+		if err != nil {
+			return convertError(err)
+		}
+
+		if len(out.Records) > 0 {
+			b.logger.Log(ctx, logutils.TraceLevel, "Got new stream shard records.", "shard_id", shardID, "num_records", len(out.Records))
+
 			events := make([]backend.Event, 0, len(out.Records))
 			for i := range out.Records {
 				event, err := toEvent(out.Records[i])
@@ -260,9 +256,13 @@ func (b *Backend) pollShard(ctx context.Context, streamArn *string, shard stream
 				return trace.ConnectionProblem(ctx.Err(), "context is closing")
 			case eventsC <- shardEvent{shardID: shardID, events: events}:
 			}
-			iterator = out.NextShardIterator
 		}
+
+		iterator = out.NextShardIterator
 	}
+
+	b.logger.Log(ctx, logutils.TraceLevel, "Shard is closed", "shard_id", shardID)
+	return shardClosedError{}
 }
 
 // collectActiveShards collects shards


### PR DESCRIPTION
The current behavior of the dynamodb backend driver ignores records that come as part of a `dynamodb:GetRecords` at the end of a shard. The `GetRecords` docs make no mention of the last call at the end of a shard being guaranteed to have no records, so this PR changes the `pollShard` implementation to go through the records (if any) before exiting if the shard iteration is done. The fact that shards tend to be quite long-lived and that most of the write volume in a given cluster is ephemeral is the reason why this problem (if it exists) hasn't really shown itself.

Tested locally a few times and the `lib/backend/dynamo` tests pass (against the real AWS DynamoDB, as there's no good simulators).