### PR TITLE
[v15] Update teleport.teleport_install_script_url

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -72,7 +72,7 @@
       "latest_oss_debug_docker_image": "public.ecr.aws/gravitational/teleport-distroless-debug:15.4.32",
       "latest_ent_docker_image": "public.ecr.aws/gravitational/teleport-ent-distroless:15.4.32",
       "latest_ent_debug_docker_image": "public.ecr.aws/gravitational/teleport-ent-distroless-debug:15.4.32",
-      "teleport_install_script_url": "https://cdn.teleport.dev/install-v15.4.32.sh"
+      "teleport_install_script_url": "https://cdn.teleport.dev/install.sh"
     },
     "terraform": {
       "version": "1.0.0"


### PR DESCRIPTION
Backports #53342

Closes #48766

Use the shim install script URL, which is less potentially misleading than the script URL that includes a version.