### PR TITLE
Fix dependency review workflow

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -11,7 +11,12 @@ jobs:
       contents: read
       pull-requests: write
     with:
-      base-ref: ${{ github.event.pull_request.base.sha || 'master' }}
+      base-ref: >
+        ${{ 
+          github.event_name == 'pull_request' && github.event.pull_request.base.sha ||
+          github.event_name == 'merge_group' && github.event.merge_group.base_sha ||
+          'Invalid reference (workflow bug)'
+        }}
       # 'GHSA-6xf3-5hp7-xqqg' is a false positive. That's an old Teleport Vuln,
       # but because of the replace, the dependency cannot find the correct
       # Teleport version.


### PR DESCRIPTION
One of the two causes of the dependency review workflow failing in the merge queue is that the workflow uses the wrong base ref (`master`) for all PRs in the queue. This has never worked properly, and just recently became obvious due to the other cause (diff size too big for step summary).

Fixing this on master and then backporting. This should allow PRs to merge.