### PR TITLE
Add Access Request fields to the Role Reference

### DIFF
--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -409,6 +409,50 @@ spec:
       where: '!contains(session_tracker.participants, user.metadata.name)'
 ```
 
+## Access Requests
+
+The following role fields configure Access Requests. For a full description of
+Access Request configuration fields and their relationship to one another, see
+the [Access Request configuration
+guide](../../admin-guides/access-controls/access-requests/access-request-configuration.mdx).
+
+### Creating Access Requests
+
+Within a role, the `request` field configures a user's ability to create Access
+Requests. The `request` field can fall under both `spec.allow` and `spec.deny`:
+
+|Role Field|Description|Further Information|
+|---|---|---|
+| `request.roles` |Teleport roles that a user can or cannot request|[Restrict role requests](../../admin-guides/access-controls/access-requests/access-request-configuration.mdx#restrict-role-requests)|
+| `request.claims_to_roles`|Teleport roles that a user can or cannot access based on their traits.|[Restrict role requests](../../admin-guides/access-controls/access-requests/access-request-configuration.mdx#restrict-role-requests)|
+| `request.search_as_roles`|Teleport roles that a user can or cannot assume while searching for resources to request access to.|[Restrict resource requests](../../admin-guides/access-controls/access-requests/access-request-configuration.mdx#restrict-resource-requests)|
+| `request.max_duration`|The maximum duration of elevated privileges if an Access Request were granted. | [How long access lasts](../../admin-guides/access-controls/access-requests/access-request-configuration.mdx#how-long-access-lasts) |
+| `request.reason`|Configures the behavior of Access Request reasons. | [Requiring request reasons](../../admin-guides/access-controls/access-requests/access-request-configuration.mdx#requiring-request-reasons) | 
+| `request.thresholds`|Configures the criteria that an Access Request must meet before Teleport approves or denies it.| [Review thresholds](../../admin-guides/access-controls/access-requests/access-request-configuration.mdx#review-thresholds) |
+| `request.suggested_reviewers`|Reviewers to add to an Access Request by default.| [Suggested reviewers](../../admin-guides/access-controls/access-requests/access-request-configuration.mdx#suggested-reviewers)|
+| `request.annotations`|Arbitrary data to write (or prevent writing) to an Access Request|[Request annotations](../../admin-guides/access-controls/access-requests/access-request-configuration.mdx#request-annotations)|
+
+### Reviewing Access Requests
+
+The `review_requests` field configures the role's ability to review Access
+Requests, and like `request`, can fall under `allow` or `deny`:
+
+|Role Field|Description|Further Information|
+|---|---|---|
+|`review_requests.roles`|Allows or denies the ability to review requests for particular roles.|[Reviews for specific roles](../../admin-guides/access-controls/access-requests/access-request-configuration.mdx#allowing-and-denying-reviews-for-specific-roles)|
+|`review_requests.where`|Configures conditions in which a user with the role may review an Access Request|[`where` expressions](../../admin-guides/access-controls/access-requests/access-request-configuration.mdx#where-expressions)|
+|`review_requests.preview_as_roles`|Allows or denies the ability to list resources that a user with the requested role can access|[Inspecting requested resources](../../admin-guides/access-controls/access-requests/access-request-configuration.mdx#inspecting-requested-resources)|
+|`review_requests.claims_to_roles`|Teleport roles that a user can or cannot review requests for based on their traits.|[Reviews for specific roles](../../admin-guides/access-controls/access-requests/access-request-configuration.mdx#allowing-and-denying-reviews-for-specific-roles)|
+
+### Client options
+
+The `options` field, a property of `spec`, applies additional settings:
+
+|Role Field|Description|Further Information|
+|---|---|---|
+|`options.request_access`|Configures Teleport client behavior for creating Access Requests|[How clients request access](../../admin-guides/access-controls/access-requests/access-request-configuration.mdx#how-clients-request-access)|
+|`options.request_prompt`|Configures the prompt that Teleport clients display when a user requests access|[How clients request access](../../admin-guides/access-controls/access-requests/access-request-configuration.mdx#how-clients-request-access)|
+
 ## Role templates
 
 In a Teleport role resource, certain fields allow you to use functions and

--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -428,7 +428,7 @@ Requests. The `request` field can fall under both `spec.allow` and `spec.deny`:
 | `request.search_as_roles`|Teleport roles that a user can or cannot assume while searching for resources to request access to.|[Restrict resource requests](../../admin-guides/access-controls/access-requests/access-request-configuration.mdx#restrict-resource-requests)|
 | `request.max_duration`|The maximum duration of elevated privileges if an Access Request were granted. | [How long access lasts](../../admin-guides/access-controls/access-requests/access-request-configuration.mdx#how-long-access-lasts) |
 | `request.reason`|Configures the behavior of Access Request reasons. | [Requiring request reasons](../../admin-guides/access-controls/access-requests/access-request-configuration.mdx#requiring-request-reasons) | 
-| `request.thresholds`|Configures the criteria that an Access Request must meet before Teleport approves or denies it.| [Review thresholds](../../admin-guides/access-controls/access-requests/access-request-configuration.mdx#review-thresholds) |
+| `request.thresholds`|Configures the criteria that an Access Request must meet.| [Review thresholds](../../admin-guides/access-controls/access-requests/access-request-configuration.mdx#review-thresholds) |
 | `request.suggested_reviewers`|Reviewers to add to an Access Request by default.| [Suggested reviewers](../../admin-guides/access-controls/access-requests/access-request-configuration.mdx#suggested-reviewers)|
 | `request.annotations`|Arbitrary data to write (or prevent writing) to an Access Request|[Request annotations](../../admin-guides/access-controls/access-requests/access-request-configuration.mdx#request-annotations)|
 


### PR DESCRIPTION
Closes #39842

Add a table of role fields related to Access Requests. Since the Access Request configuration guide already contains extensive conceptual information about how these fields work, limit the Role Reference to brief descriptions of each field, followed by a link to the conceptual guide.