### PR TITLE
docs: update git clone for terraform starter

### DIFF
--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-starter/enroll-resources.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-starter/enroll-resources.mdx
@@ -89,7 +89,7 @@ production.
    <TabItem label="AWS">
 
    ```code
-   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone
+   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone -b branch/v(=teleport.major_version=)
    $ cp -R teleport-clone/examples/terraform-starter/agent-installation teleport
    $ cp -R teleport-clone/examples/terraform-starter/aws cloud
    $ rm -rf teleport-clone
@@ -99,7 +99,7 @@ production.
    <TabItem label="Google Cloud">
 
    ```code
-   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone
+   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone -b branch/v(=teleport.major_version=)
    $ cp -R teleport-clone/examples/terraform-starter/agent-installation teleport
    $ cp -R teleport-clone/examples/terraform-starter/gcp cloud
    $ rm -rf teleport-clone
@@ -109,7 +109,7 @@ production.
    <TabItem label="Azure">
 
    ```code
-   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone
+   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone -b branch/v(=teleport.major_version=)
    $ cp -R teleport-clone/examples/terraform-starter/agent-installation teleport
    $ cp -R teleport-clone/examples/terraform-starter/azure cloud
    $ rm -rf teleport-clone

--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-starter/enroll-resources.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-starter/enroll-resources.mdx
@@ -89,7 +89,7 @@ production.
    <TabItem label="AWS">
 
    ```code
-   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone -b branch/v(=teleport.major_version=)
+   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone --branch branch/v(=teleport.major_version=)
    $ cp -R teleport-clone/examples/terraform-starter/agent-installation teleport
    $ cp -R teleport-clone/examples/terraform-starter/aws cloud
    $ rm -rf teleport-clone
@@ -99,7 +99,7 @@ production.
    <TabItem label="Google Cloud">
 
    ```code
-   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone -b branch/v(=teleport.major_version=)
+   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone --branch branch/v(=teleport.major_version=)
    $ cp -R teleport-clone/examples/terraform-starter/agent-installation teleport
    $ cp -R teleport-clone/examples/terraform-starter/gcp cloud
    $ rm -rf teleport-clone
@@ -109,7 +109,7 @@ production.
    <TabItem label="Azure">
 
    ```code
-   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone -b branch/v(=teleport.major_version=)
+   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone --branch branch/v(=teleport.major_version=)
    $ cp -R teleport-clone/examples/terraform-starter/agent-installation teleport
    $ cp -R teleport-clone/examples/terraform-starter/azure cloud
    $ rm -rf teleport-clone

--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-starter/enroll-resources.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-starter/enroll-resources.mdx
@@ -89,7 +89,7 @@ production.
    <TabItem label="AWS">
 
    ```code
-   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone --branch branch/v(=teleport.major_version=)
+   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone --branch=branch/v(=teleport.major_version=)
    $ cp -R teleport-clone/examples/terraform-starter/agent-installation teleport
    $ cp -R teleport-clone/examples/terraform-starter/aws cloud
    $ rm -rf teleport-clone
@@ -99,7 +99,7 @@ production.
    <TabItem label="Google Cloud">
 
    ```code
-   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone --branch branch/v(=teleport.major_version=)
+   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone --branch=branch/v(=teleport.major_version=)
    $ cp -R teleport-clone/examples/terraform-starter/agent-installation teleport
    $ cp -R teleport-clone/examples/terraform-starter/gcp cloud
    $ rm -rf teleport-clone
@@ -109,7 +109,7 @@ production.
    <TabItem label="Azure">
 
    ```code
-   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone --branch branch/v(=teleport.major_version=)
+   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone --branch=branch/v(=teleport.major_version=)
    $ cp -R teleport-clone/examples/terraform-starter/agent-installation teleport
    $ cp -R teleport-clone/examples/terraform-starter/azure cloud
    $ rm -rf teleport-clone

--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-starter/rbac.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-starter/rbac.mdx
@@ -85,7 +85,7 @@ production.
    <TabItem label="OIDC">
 
    ```code
-   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone --branch branch/v(=teleport.major_version=)
+   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone --branch=branch/v(=teleport.major_version=)
    $ cp -R teleport-clone/examples/terraform-starter/env_role env_role
    $ cp -R teleport-clone/examples/terraform-starter/oidc oidc
    $ rm -rf teleport-clone
@@ -94,7 +94,7 @@ production.
    <TabItem label="SAML">
 
    ```code
-   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone --branch branch/v(=teleport.major_version=)
+   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone --branch=branch/v(=teleport.major_version=)
    $ cp -R teleport-clone/examples/terraform-starter/env_role env_role
    $ cp -R teleport-clone/examples/terraform-starter/saml saml
    $ rm -rf teleport-clone

--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-starter/rbac.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-starter/rbac.mdx
@@ -85,7 +85,7 @@ production.
    <TabItem label="OIDC">
 
    ```code
-   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone -b branch/v(=teleport.major_version=)
+   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone --branch branch/v(=teleport.major_version=)
    $ cp -R teleport-clone/examples/terraform-starter/env_role env_role
    $ cp -R teleport-clone/examples/terraform-starter/oidc oidc
    $ rm -rf teleport-clone
@@ -94,7 +94,7 @@ production.
    <TabItem label="SAML">
 
    ```code
-   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone -b branch/v(=teleport.major_version=)
+   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone --branch branch/v(=teleport.major_version=)
    $ cp -R teleport-clone/examples/terraform-starter/env_role env_role
    $ cp -R teleport-clone/examples/terraform-starter/saml saml
    $ rm -rf teleport-clone

--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-starter/rbac.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-starter/rbac.mdx
@@ -85,7 +85,7 @@ production.
    <TabItem label="OIDC">
 
    ```code
-   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone
+   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone -b branch/v(=teleport.major_version=)
    $ cp -R teleport-clone/examples/terraform-starter/env_role env_role
    $ cp -R teleport-clone/examples/terraform-starter/oidc oidc
    $ rm -rf teleport-clone
@@ -94,7 +94,7 @@ production.
    <TabItem label="SAML">
 
    ```code
-   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone
+   $ git clone --depth=1 https://github.com/gravitational/teleport teleport-clone -b branch/v(=teleport.major_version=)
    $ cp -R teleport-clone/examples/terraform-starter/env_role env_role
    $ cp -R teleport-clone/examples/terraform-starter/saml saml
    $ rm -rf teleport-clone


### PR DESCRIPTION
Use the Teleport repo branch for the `git clone`. Prevents issues since that pulls from the `master` branch by default.