### PR TITLE
[web] Use `floating-ui` for remaining Tooltip components

### DIFF
--- a/web/packages/design/src/Popover/Popover.story.tsx
+++ b/web/packages/design/src/Popover/Popover.story.tsx
@@ -378,49 +378,16 @@ const popoverSets: PopoverSet[] = [
 export const Positioning = () => {
   return (
     <>
-      <H2 my={2}>Without arrows</H2>
+      <H2 my={2}>Without margins</H2>
       <Flex flexWrap="wrap">
         {popoverSets.map((popovers, i) => (
           <ManyPopovers popovers={popovers} key={i} />
         ))}
       </Flex>
-      <H2 my={2}>With arrows</H2>
+      <H2 my={2}>With margins</H2>
       <Flex flexWrap="wrap">
         {popoverSets.map((popovers, i) => (
-          <ManyPopovers popovers={popovers} key={i} arrows />
-        ))}
-        <ManyPopovers
-          arrows
-          anchorSize="200px"
-          margin="30px"
-          popovers={[
-            {
-              anchorOrigin: { horizontal: 'center', vertical: 'top' },
-              transformOrigin: { horizontal: 'center', vertical: 'top' },
-              name: 'Top',
-            },
-            {
-              anchorOrigin: { horizontal: 'right', vertical: 'center' },
-              transformOrigin: { horizontal: 'right', vertical: 'center' },
-              name: 'Right',
-            },
-            {
-              anchorOrigin: { horizontal: 'center', vertical: 'bottom' },
-              transformOrigin: { horizontal: 'center', vertical: 'bottom' },
-              name: 'Bottom',
-            },
-            {
-              anchorOrigin: { horizontal: 'left', vertical: 'center' },
-              transformOrigin: { horizontal: 'left', vertical: 'center' },
-              name: 'Left',
-            },
-          ]}
-        />
-      </Flex>
-      <H2 my={2}>With arrows and margins</H2>
-      <Flex flexWrap="wrap">
-        {popoverSets.map((popovers, i) => (
-          <ManyPopovers popovers={popovers} key={i} arrows popoverMargin={5} />
+          <ManyPopovers popovers={popovers} key={i} popoverMargin={5} />
         ))}
       </Flex>
     </>
@@ -429,7 +396,6 @@ export const Positioning = () => {
 
 const ManyPopovers = ({
   popovers,
-  arrows,
   anchorSize = '100px',
   margin = '80px',
   popoverMargin = 0,
@@ -457,7 +423,6 @@ const ManyPopovers = ({
           open={!!anchorRef}
           anchorOrigin={anchorOrigin}
           transformOrigin={transformOrigin}
-          arrow={arrows}
           popoverMargin={popoverMargin}
         >
           <Box padding={3}>{name}</Box>

--- a/web/packages/design/src/SlideTabs/SlideTabs.test.tsx
+++ b/web/packages/design/src/SlideTabs/SlideTabs.test.tsx
@@ -100,7 +100,8 @@ describe('design/SlideTabs', () => {
     expect(getTab('first')).not.toHaveFocus();
     expect(getTab('second')).not.toHaveFocus();
 
-    getTab('first').focus();
+    // Click to focus first tab
+    await user.click(getTab('first'));
     expect(getTab('first')).toHaveAttribute('aria-selected', 'true');
     expect(getTab('first')).toHaveAttribute('aria-controls', 'tabpanel-1');
     expect(getTab('second')).toHaveAttribute('aria-selected', 'false');

--- a/web/packages/design/src/Tooltip/HoverTooltip.tsx
+++ b/web/packages/design/src/Tooltip/HoverTooltip.tsx
@@ -16,28 +16,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {
-  arrow,
-  autoUpdate,
-  flip,
-  FloatingArrow,
-  FloatingPortal,
-  offset,
-  shift,
-  useDismiss,
-  useFloating,
-  useFocus,
-  useHover,
-  useInteractions,
-  useRole,
-  useTransitionStyles,
-  type Placement,
-} from '@floating-ui/react';
-import React, { PropsWithChildren, useRef, useState } from 'react';
-import styled, { useTheme } from 'styled-components';
+import { type Placement } from '@floating-ui/react';
+import React, { PropsWithChildren } from 'react';
 
 import Flex from 'design/Flex';
-import Text from 'design/Text';
+import { BaseTooltip } from 'design/Tooltip/shared';
 
 type HoverTooltipProps = {
   /**
@@ -53,6 +36,10 @@ type HoverTooltipProps = {
    * styled-components' `css` property.
    */
   className?: string;
+  /**
+   * Show arrow on the tooltip.
+   */
+  arrow?: boolean;
   /**
    * Specifies the position of tooltip relative to trigger content.
    */
@@ -70,155 +57,31 @@ type HoverTooltipProps = {
    */
   delay?: number | { open: number; close: number };
   /**
-   * Don't flip the tooltip's placement when tooltip runs out of the viewport.
+   * Flip the tooltip's placement when tooltip runs out of the viewport.
    */
-  disableFlip?: boolean;
+  flip?: boolean;
   /**
-   * Don't transition the tooltip in/out on mount/unmount.
+   * Transition the tooltip in/out on mount/unmount.
    */
-  disableTransitions?: boolean;
+  animate?: boolean;
 };
 
 export const HoverTooltip = ({
   tipContent,
   children,
   showOnlyOnOverflow = false,
-  className,
-  placement = 'top',
   position,
-  offset: offsetDistance = 8,
-  delay = 0,
-  disableFlip = false,
-  disableTransitions = false,
-}: PropsWithChildren<HoverTooltipProps>) => {
-  const theme = useTheme();
-  const [open, setOpen] = useState(false);
-  const arrowRef = useRef(null);
-  const contentRef = useRef<HTMLElement | null>(null);
-
-  if (position) {
-    placement = position;
-  }
-
-  const { x, y, strategy, refs, context } = useFloating({
-    placement,
-    open,
-    onOpenChange: setOpen,
-    middleware: [
-      offset(offsetDistance),
-      !disableFlip && flip(),
-      shift({ padding: 8 }),
-      arrow({ element: arrowRef }),
-    ].filter(Boolean),
-    whileElementsMounted: autoUpdate,
-  });
-
-  const { isMounted, styles: transitionStyles } = useTransitionStyles(context, {
-    duration: 100,
-    initial: {
-      opacity: '0',
-      transform: 'scale(0.96)',
-    },
-    common: ({ side }) => ({
-      transformOrigin: {
-        top: 'bottom',
-        bottom: 'top',
-        left: 'right',
-        right: 'left',
-      }[side],
-      transitionTimingFunction: 'ease',
-    }),
-  });
-
-  const openDelay = typeof delay === 'object' ? delay.open : delay;
-  const closeDelay = typeof delay === 'object' ? delay.close : delay;
-
-  const { getReferenceProps, getFloatingProps } = useInteractions([
-    useHover(context, {
-      delay: { open: openDelay, close: closeDelay },
-      handleClose: null,
-    }),
-    useFocus(context),
-    useDismiss(context),
-    useRole(context, { role: 'tooltip' }),
-  ]);
-
-  if (!tipContent) {
-    return <>{children}</>;
-  }
-
-  const handleMouseEnter = (event: React.MouseEvent<Element>) => {
-    const { currentTarget } = event;
-    contentRef.current = currentTarget as HTMLElement;
-
-    if (showOnlyOnOverflow) {
-      if (
-        currentTarget instanceof Element &&
-        currentTarget.parentElement &&
-        currentTarget.scrollWidth > currentTarget.parentElement.offsetWidth
-      ) {
-        setOpen(true);
-      }
-      return;
-    }
-
-    setOpen(true);
-  };
-
-  return (
-    <Flex
-      ref={refs.setReference}
-      {...getReferenceProps({
-        onMouseEnter: handleMouseEnter,
-        onMouseLeave: () => setOpen(false),
-      })}
-      className={className}
-    >
-      {children}
-      {isMounted && (
-        <FloatingPortal>
-          <StyledTooltip
-            ref={refs.setFloating}
-            style={{
-              position: strategy,
-              top: y ?? 0,
-              left: x ?? 0,
-              background: theme.colors.tooltip.background,
-              backdropFilter: 'blur(2px)',
-              color: theme.colors.text.primaryInverse,
-              ...(!disableTransitions ? transitionStyles : { opacity: 1 }),
-            }}
-            {...getFloatingProps()}
-          >
-            <FloatingArrow
-              ref={arrowRef}
-              context={context}
-              style={{
-                fill: theme.colors.tooltip.background,
-                backdropFilter: 'blur(2px)',
-              }}
-            />
-            <StyledContent px={3} py={2}>
-              {tipContent}
-            </StyledContent>
-          </StyledTooltip>
-        </FloatingPortal>
-      )}
-    </Flex>
-  );
-};
-
-const StyledTooltip = styled.div`
-  max-width: 350px;
-  word-wrap: break-word;
-  z-index: 1500;
-  border-radius: 4px;
-  pointer-events: none;
-  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.15));
-  backdrop-filter: blur(2px);
-`;
-
-const StyledContent = styled(Text)`
-  max-width: 350px;
-  word-wrap: break-word;
-`;
+  placement = 'top',
+  arrow = true,
+  ...tooltipProps
+}: PropsWithChildren<HoverTooltipProps>) => (
+  <BaseTooltip
+    content={tipContent}
+    placement={position || placement}
+    onlyOnOverflow={showOnlyOnOverflow}
+    arrow={arrow}
+    {...tooltipProps}
+  >
+    <Flex>{children}</Flex>
+  </BaseTooltip>
+);

--- a/web/packages/design/src/Tooltip/IconTooltip.tsx
+++ b/web/packages/design/src/Tooltip/IconTooltip.tsx
@@ -16,97 +16,80 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { PropsWithChildren, useState } from 'react';
-import styled, { useTheme } from 'styled-components';
+import { type Placement } from '@floating-ui/react';
+import React, { PropsWithChildren } from 'react';
+import styled from 'styled-components';
 
 import * as Icons from 'design/Icon';
-import Popover from 'design/Popover';
-import { Position } from 'design/Popover/Popover';
-import Text from 'design/Text';
-
-import { anchorOriginForPosition, transformOriginForPosition } from './shared';
+import { BaseTooltip } from 'design/Tooltip/shared';
 
 type ToolTipKind = 'info' | 'warning' | 'error';
 
-export const IconTooltip: React.FC<
-  PropsWithChildren<{
-    trigger?: 'click' | 'hover';
-    position?: Position;
-    muteIconColor?: boolean;
-    sticky?: boolean;
-    maxWidth?: number;
-    kind?: ToolTipKind;
-  }>
-> = ({
-  children,
-  trigger = 'hover',
-  position = 'bottom',
-  muteIconColor = false,
-  sticky = false,
-  maxWidth = 350,
-  kind = 'info',
-}) => {
-  const theme = useTheme();
-  const [anchorEl, setAnchorEl] = useState<Element>();
-  const open = Boolean(anchorEl);
-
-  function handlePopoverOpen(event: React.MouseEvent) {
-    setAnchorEl(event.currentTarget);
-  }
-
-  function handlePopoverClose() {
-    setAnchorEl(undefined);
-  }
-
-  const triggerOnHoverProps = {
-    onMouseEnter: handlePopoverOpen,
-    onMouseLeave: sticky ? undefined : handlePopoverClose,
-  };
-  const triggerOnClickProps = {
-    onClick: handlePopoverOpen,
-  };
-
-  return (
-    <>
-      <span
-        role="icon"
-        aria-owns={open ? 'mouse-over-popover' : undefined}
-        {...(trigger === 'hover' && triggerOnHoverProps)}
-        {...(trigger === 'click' && triggerOnClickProps)}
-        css={`
-          &:hover {
-            cursor: pointer;
-          }
-          vertical-align: middle;
-          display: inline-block;
-          height: 18px;
-        `}
-      >
-        <ToolTipIcon kind={kind} muteIconColor={muteIconColor} />
-      </span>
-      <Popover
-        modalCss={() =>
-          trigger === 'hover' && `pointer-events: ${sticky ? 'auto' : 'none'}`
-        }
-        popoverCss={() => ({
-          background: theme.colors.tooltip.background,
-          backdropFilter: 'blur(2px)',
-        })}
-        onClose={handlePopoverClose}
-        open={open}
-        anchorEl={anchorEl}
-        anchorOrigin={anchorOriginForPosition(position)}
-        transformOrigin={transformOriginForPosition(position)}
-        arrow
-        popoverMargin={4}
-      >
-        <StyledOnHover px={3} py={2} $maxWidth={maxWidth}>
-          {children}
-        </StyledOnHover>
-      </Popover>
-    </>
-  );
+type IconToolTipProps = {
+  trigger?: 'click' | 'hover';
+  muteIconColor?: boolean;
+  sticky?: boolean;
+  maxWidth?: number;
+  kind?: ToolTipKind;
+  /**
+   * Specifies the position of tooltip relative to trigger content.
+   */
+  placement?: Placement;
+  /**
+   * @deprecated – Prefer specifying `placement` instead.
+   */
+  position?: Placement;
+  /**
+   * Offset the tooltip relative to trigger content. Defaults to `8`.
+   */
+  offset?: number;
+  /**
+   * Delay opening and/or closing of the tooltip.
+   */
+  delay?: number | { open: number; close: number };
+  /**
+   * Flip the tooltip's placement when tooltip runs out of the viewport.
+   */
+  flip?: boolean;
+  /**
+   * Transition the tooltip in/out on mount/unmount.
+   */
+  animate?: boolean;
 };
+
+export const IconTooltip: React.FC<PropsWithChildren<IconToolTipProps>> = ({
+  children,
+  position,
+  placement = 'bottom',
+  muteIconColor = false,
+  kind = 'info',
+  trigger = 'hover',
+  sticky = false,
+  ...tooltipProps
+}) => (
+  <BaseTooltip
+    content={children}
+    trigger={trigger}
+    placement={position || placement}
+    interactive={sticky}
+    {...tooltipProps}
+    arrow
+  >
+    <span
+      role="icon"
+      css={`
+        &:hover {
+          cursor: pointer;
+        }
+        vertical-align: middle;
+        display: inline-block;
+        height: 18px;
+      `}
+    >
+      <ToolTipIcon kind={kind} muteIconColor={muteIconColor} />
+    </span>
+  </BaseTooltip>
+);
 
 const ToolTipIcon = ({
   kind,
@@ -124,11 +107,6 @@ const ToolTipIcon = ({
       return <ErrorIcon $muteIconColor={muteIconColor} size="medium" />;
   }
 };
-
-const StyledOnHover = styled(Text)<{ $maxWidth: number }>`
-  color: ${props => props.theme.colors.text.primaryInverse};
-  max-width: ${p => p.$maxWidth}px;
-`;
 
 const InfoIcon = styled(Icons.Info)<{ $muteIconColor?: boolean }>`
   height: 18px;

--- a/web/packages/design/src/Tooltip/shared.tsx
+++ b/web/packages/design/src/Tooltip/shared.tsx
@@ -16,31 +16,320 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Origin } from 'design/Popover';
-import { Position } from 'design/Popover/Popover';
+import {
+  arrow,
+  autoUpdate,
+  flip,
+  FloatingArrow,
+  FloatingContext,
+  FloatingPortal,
+  offset,
+  Placement,
+  ReferenceType,
+  safePolygon,
+  shift,
+  useClick,
+  useDismiss,
+  useFloating,
+  useFocus,
+  useHover,
+  useInteractions,
+  useRole,
+  useTransitionStyles,
+} from '@floating-ui/react';
+import React, { useMemo, useRef, useState } from 'react';
+import styled, { useTheme } from 'styled-components';
 
-export const anchorOriginForPosition = (pos: Position): Origin => {
-  switch (pos) {
-    case 'top':
-      return { horizontal: 'center', vertical: 'top' };
-    case 'right':
-      return { horizontal: 'right', vertical: 'center' };
-    case 'bottom':
-      return { horizontal: 'center', vertical: 'bottom' };
-    case 'left':
-      return { horizontal: 'left', vertical: 'center' };
-  }
+import Text from 'design/Text';
+
+type TooltipTrigger = 'hover' | 'click';
+
+type UseTooltipProps = {
+  /**
+   * Specifies the position of tooltip relative to trigger content.
+   */
+  placement?: Placement;
+  /**
+   * Offset the tooltip relative to trigger content. Defaults to `8`.
+   */
+  offset?: number;
+  /**
+   * Show arrow on the tooltip.
+   */
+  arrow?: boolean;
+  /**
+   * Delay opening and/or closing of the tooltip.
+   */
+  delay?: number | { open: number; close: number };
+  /**
+   * Flip the tooltip's placement when tooltip runs out of the viewport.
+   */
+  flip?: boolean;
+  /**
+   * Transition the tooltip in/out on mount/unmount.
+   */
+  animate?: boolean;
+  /**
+   * Trigger for showing the tooltip: hover or click.
+   */
+  trigger?: TooltipTrigger;
+  /**
+   * Allow mouse interaction with the tooltip content, and prevent closing on mouseOut.
+   */
+  interactive?: boolean;
+  /**
+   * Only show tooltip if trigger content is overflowing its container.
+   */
+  onlyOnOverflow?: boolean;
+  /**
+   * Optional callback when tooltip open state changes.
+   */
+  onOpenChange?: (open: boolean) => void;
 };
 
-export const transformOriginForPosition = (pos: Position): Origin => {
-  switch (pos) {
-    case 'top':
-      return { horizontal: 'center', vertical: 'bottom' };
-    case 'right':
-      return { horizontal: 'left', vertical: 'center' };
-    case 'bottom':
-      return { horizontal: 'center', vertical: 'top' };
-    case 'left':
-      return { horizontal: 'right', vertical: 'center' };
-  }
+type UseTooltipReturn = {
+  context: FloatingContext;
+  isMounted: boolean;
+  refs: {
+    arrow: React.RefObject<SVGSVGElement>;
+    reference: React.MutableRefObject<ReferenceType | null>;
+    floating: React.RefObject<HTMLElement | null>;
+  };
+  props: {
+    arrow?: {
+      ref: React.Ref<SVGSVGElement>;
+      context: FloatingContext;
+      style: React.CSSProperties;
+    } & Record<string, unknown>;
+    reference: {
+      ref: (node: ReferenceType | null) => void;
+    } & Record<string, unknown>;
+    floating: {
+      ref: (node: HTMLElement | null) => void;
+      style: React.CSSProperties;
+    } & Record<string, unknown>;
+  };
 };
+
+const ARROW_HEIGHT = 7;
+const ANIMATE_DURATION = 100;
+
+export const useTooltip = ({
+  placement = 'top',
+  trigger = 'hover',
+  interactive = false,
+  offset: offsetDistance = 8,
+  delay = 0,
+  arrow: useArrow = false,
+  flip: useFlip = true,
+  animate = true,
+  onlyOnOverflow = false,
+  onOpenChange,
+}: UseTooltipProps = {}): UseTooltipReturn => {
+  const theme = useTheme();
+  const [open, setOpen] = useState(false);
+  const arrowRef = useRef<SVGSVGElement | null>(null);
+
+  const setOpenState = (value: boolean) => {
+    setOpen(value);
+    if (onOpenChange) {
+      onOpenChange(value);
+    }
+  };
+
+  const middleware = [
+    offset(offsetDistance + (useArrow ? ARROW_HEIGHT : 0)),
+    useFlip && flip(),
+    shift({ padding: 8 }),
+    useArrow && arrow({ element: arrowRef }),
+  ].filter(Boolean);
+
+  const { x, y, strategy, refs, context } = useFloating({
+    placement,
+    open,
+    onOpenChange: setOpenState,
+    middleware,
+    whileElementsMounted: autoUpdate,
+  });
+
+  const { isMounted, styles: transitionStyles } = useTransitionStyles(context, {
+    duration: ANIMATE_DURATION,
+    initial: {
+      opacity: '0',
+      transform: 'scale(0.96)',
+    },
+    common: ({ side }) => ({
+      transformOrigin: {
+        top: 'bottom',
+        bottom: 'top',
+        left: 'right',
+        right: 'left',
+      }[side],
+      transitionTimingFunction: 'ease',
+    }),
+  });
+
+  const openDelay = typeof delay === 'object' ? delay.open : delay;
+  const closeDelay = typeof delay === 'object' ? delay.close : delay;
+
+  const interactions = [
+    useClick(context, { enabled: trigger === 'click' }),
+    useHover(context, {
+      enabled: trigger === 'hover',
+      delay: { open: openDelay, close: closeDelay },
+      handleClose: interactive ? safePolygon() : null,
+      restMs: interactive ? 150 : undefined,
+    }),
+    useFocus(context),
+    useDismiss(context),
+    useRole(context, { role: 'tooltip' }),
+  ];
+
+  const { getReferenceProps, getFloatingProps } = useInteractions(interactions);
+
+  const handleMouseEnter = (event: React.MouseEvent<Element>) => {
+    if (onlyOnOverflow) {
+      const { currentTarget } = event;
+      if (
+        currentTarget instanceof Element &&
+        currentTarget.parentElement &&
+        currentTarget.scrollWidth > currentTarget.parentElement.offsetWidth
+      ) {
+        setOpenState(true);
+      }
+    } else if (trigger === 'hover') {
+      setOpenState(true);
+    }
+  };
+
+  const handleMouseLeave = () => {
+    if (interactive) return;
+    if (trigger === 'hover') {
+      setOpenState(false);
+    }
+  };
+
+  const handleClick = () => {
+    if (trigger === 'click') {
+      setOpenState(!open);
+    }
+  };
+
+  const getRefProps = (additionalProps = {}) => {
+    const props: any = { ...additionalProps };
+
+    if (trigger === 'hover') {
+      props.onMouseEnter = handleMouseEnter;
+      props.onMouseLeave = handleMouseLeave;
+    } else if (trigger === 'click') {
+      props.onClick = handleClick;
+    }
+
+    return getReferenceProps(props);
+  };
+
+  const pointerEvents: 'auto' | 'none' =
+    trigger === 'hover' && interactive ? 'auto' : 'none';
+
+  return {
+    context,
+    isMounted,
+    refs: {
+      arrow: arrowRef,
+      reference: refs.reference,
+      floating: refs.floating,
+    },
+    props: {
+      arrow: useArrow
+        ? {
+            ref: arrowRef,
+            context,
+            height: ARROW_HEIGHT,
+            style: {
+              fill: theme.colors.tooltip.background,
+              pointerEvents: 'none' as const,
+            },
+          }
+        : undefined,
+      reference: {
+        ref: refs.setReference,
+        ...getRefProps(),
+      },
+      floating: {
+        ref: refs.setFloating,
+        style: {
+          position: strategy,
+          top: y ?? 0,
+          left: x ?? 0,
+          background: theme.colors.tooltip.background,
+          backdropFilter: 'blur(2px)',
+          color: theme.colors.text.primaryInverse,
+          pointerEvents,
+          ...(animate ? transitionStyles : { opacity: 1 }),
+        },
+        ...getFloatingProps(),
+      },
+    },
+  };
+};
+
+export const BaseTooltip = ({
+  children,
+  content,
+  maxWidth,
+  testId = 'tooltip',
+  contentTestId = 'tooltip-msg',
+  ...tooltipProps
+}: {
+  children: React.ReactElement;
+  content: React.ReactNode;
+  maxWidth?: number;
+  testId?: string;
+  contentTestId?: string;
+} & UseTooltipProps) => {
+  const { isMounted, props } = useTooltip(tooltipProps);
+  const childrenWithProps = useMemo(
+    () =>
+      React.cloneElement(children, {
+        ['data-testid']: testId,
+        ...props.reference,
+        ...children.props,
+      }),
+    [children, props.reference, testId]
+  );
+
+  return (
+    <>
+      {childrenWithProps}
+      {isMounted && (
+        <FloatingPortal>
+          <StyledTooltip maxWidth={maxWidth} {...props.floating}>
+            {props.arrow && <FloatingArrow {...props.arrow} />}
+            <StyledTooltipContent
+              px={3}
+              py={2}
+              maxWidth={maxWidth}
+              data-testid={contentTestId}
+            >
+              {content}
+            </StyledTooltipContent>
+          </StyledTooltip>
+        </FloatingPortal>
+      )}
+    </>
+  );
+};
+
+const StyledTooltip = styled.div<{ maxWidth?: number }>`
+  max-width: ${({ maxWidth }) => maxWidth || 350}px;
+  word-wrap: break-word;
+  z-index: 1500;
+  border-radius: 4px;
+  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.15));
+  backdrop-filter: blur(2px);
+`;
+
+const StyledTooltipContent = styled(Text)<{ maxWidth?: number }>`
+  max-width: ${({ maxWidth }) => maxWidth || 350}px;
+  word-wrap: break-word;
+`;

--- a/web/packages/teleport/src/components/ToolTipBadge/ToolTipBadge.test.tsx
+++ b/web/packages/teleport/src/components/ToolTipBadge/ToolTipBadge.test.tsx
@@ -18,7 +18,7 @@
 
 import styled from 'styled-components';
 
-import { render, screen, userEvent } from 'design/utils/testing';
+import { render, screen, userEvent, waitFor } from 'design/utils/testing';
 
 import { ToolTipBadge } from './ToolTipBadge';
 
@@ -38,10 +38,14 @@ test('hovering renders tooltip msg and unhovering makes it disappear', async () 
   const badge = screen.getByTestId('tooltip');
 
   await userEvent.hover(badge);
-  expect(screen.getByTestId('tooltip-msg')).toBeInTheDocument();
+  await waitFor(() => {
+    expect(screen.getByTestId('tooltip-msg')).toBeInTheDocument();
+  });
 
   await userEvent.unhover(badge);
-  expect(screen.queryByTestId('tooltip-msg')).not.toBeInTheDocument();
+  await waitFor(() => {
+    expect(screen.queryByTestId('tooltip-msg')).not.toBeInTheDocument();
+  });
 });
 
 test('sticky prop prevents tooltip from disappearing until child element is unhovered', async () => {
@@ -61,17 +65,23 @@ test('sticky prop prevents tooltip from disappearing until child element is unho
   const badge = screen.getByTestId('tooltip');
 
   await userEvent.hover(badge);
-  expect(screen.getByTestId('tooltip-msg')).toBeInTheDocument();
+  await waitFor(() => {
+    expect(screen.getByTestId('tooltip-msg')).toBeInTheDocument();
+  });
 
   const badgeChild = screen.getByTestId('tooltip-msg');
 
   // tooltip should be open on unhover
   await userEvent.unhover(badge);
-  expect(screen.getByTestId('tooltip-msg')).toBeInTheDocument();
+  await waitFor(() => {
+    expect(screen.getByTestId('tooltip-msg')).toBeInTheDocument();
+  });
 
   // tooltip dissapears on child unhover
   await userEvent.unhover(badgeChild);
-  expect(screen.queryByTestId('tooltip-msg')).not.toBeInTheDocument();
+  await waitFor(() => {
+    expect(screen.queryByTestId('tooltip-msg')).not.toBeInTheDocument();
+  });
 });
 
 const SomeBox = styled.div`

--- a/web/packages/teleport/src/components/ToolTipBadge/ToolTipBadge.tsx
+++ b/web/packages/teleport/src/components/ToolTipBadge/ToolTipBadge.tsx
@@ -16,10 +16,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { PropsWithChildren, useState } from 'react';
-import styled, { useTheme } from 'styled-components';
+import React, { PropsWithChildren } from 'react';
 
-import { Box, Popover } from 'design';
+import { Box } from 'design';
+import { BaseTooltip } from 'design/Tooltip/shared';
 
 type Props = {
   borderRadius?: number;
@@ -34,72 +34,21 @@ export const ToolTipBadge: React.FC<PropsWithChildren<Props>> = ({
   badgeTitle,
   sticky = false,
   color,
-}) => {
-  const theme = useTheme();
-  const [anchorEl, setAnchorEl] = useState();
-  const open = Boolean(anchorEl);
-
-  function handlePopoverOpen(event) {
-    setAnchorEl(event.currentTarget);
-  }
-
-  function handlePopoverClose() {
-    setAnchorEl(null);
-  }
-
-  return (
-    <>
-      <Box
-        data-testid="tooltip"
-        aria-owns={open ? 'mouse-over-popover' : undefined}
-        onMouseEnter={handlePopoverOpen}
-        onMouseLeave={!sticky ? handlePopoverClose : undefined}
-        borderTopRightRadius={borderRadius}
-        borderBottomLeftRadius={borderRadius}
-        bg={color}
-        css={`
-          position: absolute;
-          padding: 0px 6px;
-          top: 0px;
-          right: 0px;
-          font-size: 10px;
-        `}
-      >
-        {badgeTitle}
-      </Box>
-      <Popover
-        arrow
-        modalCss={() => `pointer-events: ${sticky ? 'auto' : 'none'}`}
-        popoverCss={() => ({
-          background: theme.colors.tooltip.background,
-          backdropFilter: 'blur(2px)',
-        })}
-        onClose={handlePopoverClose}
-        open={open}
-        anchorEl={anchorEl}
-        anchorOrigin={{
-          vertical: 'bottom',
-          horizontal: 'left',
-        }}
-        transformOrigin={{
-          vertical: 'top',
-          horizontal: 'left',
-        }}
-      >
-        <StyledOnHover
-          px={3}
-          py={2}
-          data-testid="tooltip-msg"
-          onMouseLeave={handlePopoverClose}
-        >
-          {children}
-        </StyledOnHover>
-      </Popover>
-    </>
-  );
-};
-
-const StyledOnHover = styled(Box)`
-  color: ${props => props.theme.colors.text.primaryInverse};
-  max-width: 350px;
-`;
+}) => (
+  <BaseTooltip content={children} interactive={sticky}>
+    <Box
+      borderTopRightRadius={borderRadius}
+      borderBottomLeftRadius={borderRadius}
+      bg={color}
+      css={`
+        position: absolute;
+        padding: 0px 6px;
+        top: 0px;
+        right: 0px;
+        font-size: 10px;
+      `}
+    >
+      {badgeTitle}
+    </Box>
+  </BaseTooltip>
+);

--- a/web/packages/teleport/src/components/ToolTipNoPermBadge/ToolTipNoPermBadge.test.tsx
+++ b/web/packages/teleport/src/components/ToolTipNoPermBadge/ToolTipNoPermBadge.test.tsx
@@ -18,7 +18,7 @@
 
 import styled from 'styled-components';
 
-import { render, screen, userEvent } from 'design/utils/testing';
+import { render, screen, userEvent, waitFor } from 'design/utils/testing';
 
 import { BadgeTitle, ToolTipNoPermBadge } from './ToolTipNoPermBadge';
 
@@ -34,10 +34,14 @@ test('hovering renders tooltip msg and unhovering makes it disappear', async () 
   const badge = screen.getByTestId('tooltip');
 
   await userEvent.hover(badge);
-  expect(screen.getByTestId('tooltip-msg')).toBeInTheDocument();
+  await waitFor(() => {
+    expect(screen.getByTestId('tooltip-msg')).toBeInTheDocument();
+  });
 
   await userEvent.unhover(badge);
-  expect(screen.queryByTestId('tooltip-msg')).not.toBeInTheDocument();
+  await waitFor(() => {
+    expect(screen.queryByTestId('tooltip-msg')).not.toBeInTheDocument();
+  });
 });
 
 test('sticky prop prevents tooltip from disappearing until child element is unhovered', async () => {
@@ -52,17 +56,23 @@ test('sticky prop prevents tooltip from disappearing until child element is unho
   const badge = screen.getByTestId('tooltip');
 
   await userEvent.hover(badge);
-  expect(screen.getByTestId('tooltip-msg')).toBeInTheDocument();
+  await waitFor(() => {
+    expect(screen.getByTestId('tooltip-msg')).toBeInTheDocument();
+  });
 
   const badgeChild = screen.getByTestId('tooltip-msg');
 
   // tooltip should be open on unhover
   await userEvent.unhover(badge);
-  expect(screen.getByTestId('tooltip-msg')).toBeInTheDocument();
+  await waitFor(() => {
+    expect(screen.getByTestId('tooltip-msg')).toBeInTheDocument();
+  });
 
   // tooltip dissapears on child unhover
   await userEvent.unhover(badgeChild);
-  expect(screen.queryByTestId('tooltip-msg')).not.toBeInTheDocument();
+  await waitFor(() => {
+    expect(screen.queryByTestId('tooltip-msg')).not.toBeInTheDocument();
+  });
 });
 
 test('badgeTitle prop shows different text', async () => {


### PR DESCRIPTION
## Background
Previously implemented in `HoverToolTip`, this uses floating-ui instead of `Popover` for remaining Tooltip components and consolidates the logic to `design/Tooltip/shared`. Allows removing `arrow`-related logic from `Popover`.
