### PR TITLE
Omit unresolved tasks on resource if empty

### DIFF
--- a/lib/web/ui/integration.go
+++ b/lib/web/ui/integration.go
@@ -99,7 +99,7 @@ type ResourceTypeSummary struct {
 	// DiscoverLastSync contains the time when this integration tried to auto-enroll resources.
 	DiscoverLastSync *time.Time `json:"discoverLastSync,omitempty"`
 	// UnresolvedUserTasks contains the count of unresolved user tasks related to this integration and resource type.
-	UnresolvedUserTasks int `json:"unresolvedUserTasks"`
+	UnresolvedUserTasks int `json:"unresolvedUserTasks,omitempty"`
 	// ECSDatabaseServiceCount is the total number of DatabaseServices that were deployed into Amazon ECS.
 	// Only applicable for AWS RDS resource summary.
 	ECSDatabaseServiceCount int `json:"ecsDatabaseServiceCount,omitempty"`


### PR DESCRIPTION
This PR adds omit empty to the unresolved task field on AWS resources. This way if an AWS OIDC resource is not enrolled, we do not return a 0 count on unresolved tasks