### PR TITLE
Use tile styles in aws oidc dashboard

### DIFF
--- a/web/packages/design/src/CardTile/CardTile.story.tsx
+++ b/web/packages/design/src/CardTile/CardTile.story.tsx
@@ -1,0 +1,57 @@
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Link as InternalLink, MemoryRouter } from 'react-router-dom';
+
+import { Text } from '..';
+import { CardTile } from './CardTile';
+
+export default {
+  title: 'Design/Card/Tile',
+};
+
+export const Story = () => (
+  <CardTile>
+    <Text as="h1" typography="h1">
+      Curabitur ullamcorper diam sed ante gravida imperdiet
+    </Text>
+    <Text>{loremIpsum}</Text>
+  </CardTile>
+);
+
+export const WithBorder = () => (
+  <CardTile withBorder>
+    <Text as="h1" typography="h1">
+      Curabitur ullamcorper diam sed ante gravida imperdiet
+    </Text>
+    <Text>{loremIpsum}</Text>
+  </CardTile>
+);
+
+export const AsLink = () => (
+  <MemoryRouter>
+    <CardTile as={InternalLink} to="goteleport.com">
+      <Text as="h1" typography="h1">
+        Curabitur ullamcorper diam sed ante gravida imperdiet
+      </Text>
+      <Text>{loremIpsum}</Text>
+    </CardTile>
+  </MemoryRouter>
+);
+
+const loremIpsum =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus ligula leo, dictum ac bibendum ut, dapibus sed ex. Morbi eget posuere arcu. Duis consectetur felis sed consequat dignissim. In id semper arcu, vitae fringilla lacus. Donec justo justo, feugiat eget lobortis eu, venenatis eu nulla. Morbi scelerisque vitae tortor quis tempus. Integer a nulla pellentesque, pellentesque nisl eleifend, dapibus quam. Donec eget odio vel justo efficitur commodo.';

--- a/web/packages/design/src/CardTile/CardTile.tsx
+++ b/web/packages/design/src/CardTile/CardTile.tsx
@@ -1,0 +1,99 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import styled from 'styled-components';
+
+import { BoxProps } from 'design/Box';
+import Flex, { FlexProps } from 'design/Flex';
+import {
+  alignItems,
+  alignSelf,
+  borders,
+  boxShadow,
+  color,
+  columnGap,
+  flex,
+  flexBasis,
+  flexDirection,
+  flexWrap,
+  gap,
+  height,
+  justifyContent,
+  justifySelf,
+  lineHeight,
+  maxHeight,
+  maxWidth,
+  minHeight,
+  minWidth,
+  overflow,
+  rowGap,
+  space,
+  textAlign,
+  width,
+} from 'design/system';
+
+export const CardTile = styled(Flex)<
+  FlexProps & BoxProps & { withBorder?: boolean }
+>`
+  padding: ${p => p.theme.space[4]}px;
+  border-radius: ${p => p.theme.radii[3]}px;
+  flex-direction: column;
+  gap: ${p => p.theme.space[3]}px;
+  flex-basis: 100%;
+  min-width: 0;
+  background-color: ${p => p.theme.colors.levels.surface};
+  border: ${p =>
+    p.withBorder
+      ? `1px solid ${p.theme.colors.interactive.tonal.neutral[2]}`
+      : 'none'};
+  box-shadow: ${p => p.theme.boxShadow[0]};
+
+  &:is(a) {
+    text-decoration: none;
+    color: ${p => p.theme.colors.text.main};
+    &:hover {
+      background-color: ${p => p.theme.colors.levels.elevated};
+      box-shadow: ${p => p.theme.boxShadow[2]};
+    }
+  }
+
+  ${maxWidth}
+  ${alignItems}
+  ${alignSelf}
+  ${borders}
+  ${boxShadow}
+  ${color}
+  ${columnGap}
+  ${flexBasis}
+  ${flexDirection}
+  ${flexWrap}
+  ${flex}
+  ${gap}
+  ${height}
+  ${justifyContent}
+  ${justifySelf}
+  ${lineHeight}
+  ${maxHeight}
+  ${minHeight}
+  ${minWidth}
+  ${overflow}
+  ${rowGap}
+  ${space}
+  ${textAlign}
+  ${width}
+`;

--- a/web/packages/design/src/CardTile/index.ts
+++ b/web/packages/design/src/CardTile/index.ts
@@ -1,0 +1,19 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export { CardTile } from './CardTile';

--- a/web/packages/design/src/index.ts
+++ b/web/packages/design/src/index.ts
@@ -31,6 +31,7 @@ import ButtonLink from './ButtonLink';
 import { ButtonWithMenu } from './ButtonWithMenu';
 import Card from './Card';
 import CardSuccess, { CardSuccessLogin } from './CardSuccess';
+import { CardTile } from './CardTile';
 import Flex from './Flex';
 import Image from './Image';
 import { Indicator } from './Indicator';
@@ -78,6 +79,7 @@ export {
   Card,
   CardSuccess,
   CardSuccessLogin,
+  CardTile,
   Flex,
   H1,
   H2,

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/EnrollCard.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/EnrollCard.tsx
@@ -15,10 +15,10 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { Link as InternalLink } from 'react-router-dom';
-import styled from 'styled-components';
 
-import { Box, Card, Flex, H2, H3, P2, ResourceIcon } from 'design';
+import { Link as InternalLink } from 'react-router-dom';
+
+import { Box, CardTile, Flex, H2, H3, P2, ResourceIcon } from 'design';
 import * as Icons from 'design/Icon';
 
 import cfg from 'teleport/config';
@@ -32,7 +32,8 @@ export function EnrollCard({
   item: string;
 }) {
   return (
-    <Enroll
+    <CardTile
+      width="33%"
       data-testid={`${resource}-enroll`}
       as={InternalLink}
       to={{
@@ -55,22 +56,6 @@ export function EnrollCard({
           <Icons.ArrowForward />
         </Flex>
       </Flex>
-    </Enroll>
+    </CardTile>
   );
 }
-
-const Enroll = styled(Card)`
-  width: 33%;
-  background-color: ${props => props.theme.colors.levels.surface};
-  padding: ${props => props.theme.space[3]}px;
-  border-radius: ${props => props.theme.radii[2]}px;
-  border: ${props => `1px solid ${props.theme.colors.levels.surface}`};
-  cursor: pointer;
-  text-decoration: none;
-  color: ${props => props.theme.colors.text.main};
-
-  &:hover {
-    background-color: ${props => props.theme.colors.levels.elevated};
-    box-shadow: ${({ theme }) => theme.boxShadow[2]};
-  }
-`;

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/StatCard.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/StatCard.tsx
@@ -18,9 +18,8 @@
 
 import { formatDistanceStrict } from 'date-fns';
 import { Link as InternalLink } from 'react-router-dom';
-import styled from 'styled-components';
 
-import { Card, Flex, H2, P2, Text } from 'design';
+import { CardTile, Flex, H2, P2, Text } from 'design';
 import * as Icons from 'design/Icon';
 import { ResourceIcon } from 'design/ResourceIcon';
 
@@ -57,7 +56,8 @@ export function StatCard({ name, item, resource, summary }: StatCardProps) {
   }
 
   return (
-    <SelectCard
+    <CardTile
+      width="33%"
       data-testid={`${resource}-stats`}
       as={InternalLink}
       to={cfg.getIntegrationStatusResourcesRoute(
@@ -117,7 +117,7 @@ export function StatCard({ name, item, resource, summary }: StatCardProps) {
           </Text>
         )}
       </Flex>
-    </SelectCard>
+    </CardTile>
   );
 }
 
@@ -144,19 +144,3 @@ function foundResource(resource: ResourceTypeSummary): boolean {
 
   return resource.rulesCount != 0 || resource.resourcesFound != 0;
 }
-
-export const SelectCard = styled(Card)`
-  width: 33%;
-  background-color: ${props => props.theme.colors.levels.surface};
-  padding: ${props => props.theme.space[3]}px;
-  border-radius: ${props => props.theme.radii[2]}px;
-  border: ${props => `1px solid ${props.theme.colors.levels.surface}`};
-  cursor: pointer;
-  text-decoration: none;
-  color: ${props => props.theme.colors.text.main};
-
-  &:hover {
-    background-color: ${props => props.theme.colors.levels.elevated};
-    box-shadow: ${({ theme }) => theme.boxShadow[2]};
-  }
-`;


### PR DESCRIPTION
The goal is for aws oidc dashboard cards to match okta, sso, etc. 

Okta, sso, scim do not use `Card`, instead they use a shared component called `Panel` which lives in [/e](https://github.com/gravitational/teleport.e/blob/21449077baa92153e78f014da292d43d79032a32/web/teleport/src/Integrations/IntegrationStatus/OktaStatusDetails/Shared.tsx#L20-L32). 

This PR pulls that styled flex into a new design element called `CardTile` (name, location with card, etc. is per Design aka Kenny). It also adds a subset of styles if the tile in question is a link.

This new component is then utilized in the aws oidc dashboard for enrolled and unenrolled resources instead of `Card`.

<img width="1054" alt="Screenshot 2025-04-10 at 1 07 51 PM" src="https://github.com/user-attachments/assets/5c458e83-7b80-4e1a-87b0-4aadecde760a" />