### PR TITLE
chore: Bump Go to 1.24.2

### DIFF
--- a/build.assets/Dockerfile-grpcbox
+++ b/build.assets/Dockerfile-grpcbox
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/golang:1.24.1
+FROM docker.io/golang:1.24.2
 
 # Image layers go from less likely to most likely to change.
 RUN apt-get update && \

--- a/build.assets/tooling/go.mod
+++ b/build.assets/tooling/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/build.assets/tooling
 
-go 1.24.1
+go 1.24.2
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -3,7 +3,7 @@
 # Keep versions in sync with devbox.json, when applicable.
 
 # Sync with devbox.json.
-GOLANG_VERSION ?= go1.24.1
+GOLANG_VERSION ?= go1.24.2
 GOLANGCI_LINT_VERSION ?= v1.64.7
 
 # NOTE: Remember to update engines.node in package.json to match the major version.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport
 
-go 1.24.1
+go 1.24.2
 
 require (
 	cloud.google.com/go/cloudsqlconn v1.16.0

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/event-handler
 
-go 1.24.1
+go 1.24.2
 
 require (
 	github.com/alecthomas/kong v1.8.1

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/terraform
 
-go 1.24.1
+go 1.24.2
 
 // TF provider dependencies
 require (

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -1104,8 +1104,6 @@ func BenchmarkListResourcesWithSort(b *testing.B) {
 		}
 	}
 
-	b.ResetTimer()
-
 	for _, limit := range []int32{100, 1_000, 10_000, 100_000} {
 		for _, totalCount := range []bool{true, false} {
 			b.Run(fmt.Sprintf("limit=%d,needTotal=%t", limit, totalCount), func(b *testing.B) {

--- a/lib/client/tncon/buffer_test.go
+++ b/lib/client/tncon/buffer_test.go
@@ -156,21 +156,28 @@ func BenchmarkBufferedChannelPipe(b *testing.B) {
 			buffer := newBufferedChannelPipe(s)
 			b.Cleanup(func() { require.NoError(b, buffer.Close()) })
 
-			errCh := make(chan error)
+			errCh := make(chan error, 1)
+			readCh := make(chan struct{})
+			defer close(readCh)
 			go func() {
-				readBuffer := make([]byte, b.N*len(data))
-				_, err := io.ReadFull(buffer, readBuffer)
-				errCh <- err
+				readBuffer := make([]byte, len(data))
+				for range readCh {
+					_, err := io.ReadFull(buffer, readBuffer)
+					errCh <- err
+					if err != nil {
+						return
+					}
+				}
 			}()
 
 			// benchmark write+read
 			for b.Loop() {
+				readCh <- struct{}{}
 				written, err := buffer.Write(data)
 				require.NoError(b, err)
 				require.Len(b, data, written)
+				require.NoError(b, <-errCh)
 			}
-			require.NoError(b, <-errCh)
-			b.StopTimer()
 		})
 	}
 }

--- a/lib/services/local/perf_test.go
+++ b/lib/services/local/perf_test.go
@@ -60,9 +60,6 @@ func BenchmarkGetNodes(b *testing.B) {
 
 		// run the sub benchmark
 		b.Run(name, func(sb *testing.B) {
-
-			sb.StopTimer() // stop timer while running setup
-
 			// configure the backend instance
 			var bk backend.Backend
 			var err error
@@ -83,11 +80,7 @@ func BenchmarkGetNodes(b *testing.B) {
 			// seed the test nodes
 			insertNodes(ctx, b, svc, tt.nodes)
 
-			sb.StartTimer() // restart timer for benchmark operations
-
 			benchmarkGetNodes(ctx, sb, svc, tt.nodes)
-
-			sb.StopTimer() // stop timer to exclude deferred cleanup
 		})
 	}
 }

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -2571,12 +2571,13 @@ func TestMFAVerificationInterval(t *testing.T) {
 		{
 			name: "Single role with MFA requirement, TTL adjusted to MFA verification interval",
 			roles: []types.RoleV6{
-				{Spec: types.RoleSpecV6{
-					Options: types.RoleOptions{
-						RequireMFAType:          types.RequireMFAType_SESSION,
-						MFAVerificationInterval: 5 * time.Minute,
+				{
+					Spec: types.RoleSpecV6{
+						Options: types.RoleOptions{
+							RequireMFAType:          types.RequireMFAType_SESSION,
+							MFAVerificationInterval: 5 * time.Minute,
+						},
 					},
-				},
 				},
 			},
 			enforce:     false,
@@ -4884,7 +4885,6 @@ func TestGetAllowedSearchAsRoles_WithAllowedKubernetesResourceKindFilter(t *test
 	for _, tc := range tt {
 		accessChecker := makeAccessCheckerWithRoleSet(tc.roleSet)
 		t.Run(tc.name, func(t *testing.T) {
-
 			allowedRoles := accessChecker.GetAllowedSearchAsRolesForKubeResourceKind(tc.requestType)
 			require.ElementsMatch(t, tc.expectedAllowedRoles, allowedRoles)
 		})
@@ -7048,9 +7048,6 @@ func BenchmarkCheckAccessToServer(b *testing.B) {
 		})
 	}
 	userTraits := wrappers.Traits{}
-
-	// Initialization is complete, start the benchmark timer.
-	b.ResetTimer()
 
 	// Build a map of all allowed logins.
 	allowLogins := map[string]bool{}

--- a/lib/srv/db/benchmark_test.go
+++ b/lib/srv/db/benchmark_test.go
@@ -43,7 +43,6 @@ BenchmarkPostgresReadLargeTable/size=8000-10       	       3	 215046472 ns/op
 // BenchmarkPostgresReadLargeTable is a benchmark for read-heavy usage of Postgres.
 // Depending on the message size we may get different performance, due to the way the respective engine is written.
 func BenchmarkPostgresReadLargeTable(b *testing.B) {
-	b.StopTimer()
 	ctx := context.Background()
 	testCtx := setupTestContext(ctx, b, withSelfHostedPostgres("postgres", func(db *types.DatabaseV3) {
 		db.SetStaticLabels(map[string]string{"foo": "bar"})

--- a/lib/web/ui/perf_test.go
+++ b/lib/web/ui/perf_test.go
@@ -68,9 +68,6 @@ func BenchmarkGetClusterDetails(b *testing.B) {
 
 		// run the sub benchmark
 		b.Run(name, func(sb *testing.B) {
-
-			sb.StopTimer() // stop timer while running setup
-
 			// configure the backend instance
 			var bk backend.Backend
 			var err error


### PR DESCRIPTION
The update addresses CVE-2025-22871.

Changelog: Updated Go to 1.24.2