### PR TITLE
fix flaky TestMarshalAndParseKey

### DIFF
--- a/api/utils/keys/privatekey_test.go
+++ b/api/utils/keys/privatekey_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -54,13 +55,14 @@ func TestMarshalAndParseKey(t *testing.T) {
 			require.NoError(t, err)
 			gotKey, err := ParsePrivateKey(keyPEM)
 			require.NoError(t, err)
-			require.Equal(t, key, gotKey.Signer)
+			assert.Empty(t, cmp.Diff(key, gotKey.Signer), "parsed private key is not equal to the original")
 
 			pubKeyPEM, err := MarshalPublicKey(key.Public())
 			require.NoError(t, err)
 			gotPubKey, err := ParsePublicKey(pubKeyPEM)
 			require.NoError(t, err)
 			require.Equal(t, key.Public(), gotPubKey)
+			assert.Empty(t, cmp.Diff(key.Public(), gotPubKey), "parsed public key is not equal to the original")
 		})
 	}
 }


### PR DESCRIPTION
The test is currently flaky and may fail with an error like below if one of the `*big.Int` precomputed values happens to have a leading 0 that does not remain after a marshal/unmarshal cycle. This PR switches to using `cmp.Diff` over `require.Equal` because it will call `*rsa.PrivateKey`'s `Equal` method, which correctly compares the two keys as equal.

`cmp.Diff` is simply more convenient than doing the type assertion and calling the `Equal` method directly, and is more likely to have some helpful output if this ever breaks again somehow.

```
=== FAIL: utils/keys TestMarshalAndParseKey/rsa (0.00s)
    privatekey_test.go:57: 
        	Error Trace:	/__w/teleport/teleport/api/utils/keys/privatekey_test.go:57
        	Error:      	Not equal: 
        	            	expected: &rsa.PrivateKey{PublicKey:rsa.PublicKey{N:113386223446200575930819218250773258557779804252194728950217782344525653691295448512229203662225865073375323810471329692785256631508505940163307327667729131342886321079806189024773286005137953823456342797093607315689517925526434711693777761261108866670915259895951797379036283772080437947362136934811986689659, E:65537}, D:42622126550023258439411276854554291639839851803636773807972445747418431443488548786533142298560588660071986659945777845287565646055324444037614746948416016751194635801982475500209238447469519646774786063299236879000926280143609508248740088016443381931956048974117832494633826738029579251664329184003414986689, Primes:[]*big.Int{10103975028877056517475969703801796415339748788345789051301669510334853568183050855695473943065548198384412760569251250314435249500502785321783651288904513, 11221942168517233830715160552423884660844094834830008374189454494180278446429919629291200343941543061354725879203277435170573654036816770391829854785261243}, Precomputed:rsa.PrecomputedValues{Dp:1375060702848077682520838210296599206988650982548119269245763314809597005884075111493475931125953650325626400529733614623105238114271088732853020215233217, Dq:7705378604197255327253036069076625566290557510526120769008734794667325786797479031968262439192661210628540588738384188819686809461170860241273531979443, Qinv:2840369630895225463155454463749740560965140482572409201858355493661421478184560944136273084103684078633532161571226491307251220426591488918488431095127985, CRTValues:[]rsa.CRTValue{}, fips:(*rsa.PrivateKey)(0xc0001a2000)}}
        	            	actual  : &rsa.PrivateKey{PublicKey:rsa.PublicKey{N:113386223446200575930819218250773258557779804252194728950217782344525653691295448512229203662225865073375323810471329692785256631508505940163307327667729131342886321079806189024773286005137953823456342797093607315689517925526434711693777761261108866670915259895951797379036283772080437947362136934811986689659, E:65537}, D:42622126550023258439411276854554291639839851803636773807972445747418431443488548786533142298560588660071986659945777845287565646055324444037614746948416016751194635801982475500209238447469519646774786063299236879000926280143609508248740088016443381931956048974117832494633826738029579251664329184003414986689, Primes:[]*big.Int{10103975028877056517475969703801796415339748788345789051301669510334853568183050855695473943065548198384412760569251250314435249500502785321783651288904513, 11221942168517233830715160552423884660844094834830008374189454494180278446429919629291200343941543061354725879203277435170573654036816770391829854785261243}, Precomputed:rsa.PrecomputedValues{Dp:1375060702848077682520838210296599206988650982548119269245763314809597005884075111493475931125953650325626400529733614623105238114271088732853020215233217, Dq:7705378604197255327253036069076625566290557510526120769008734794667325786797479031968262439192661210628540588738384188819686809461170860241273531979443, Qinv:2840369630895225463155454463749740560965140482572409201858355493661421478184560944136273084103684078633532161571226491307251220426591488918488431095127985, CRTValues:[]rsa.CRTValue{}, fips:(*rsa.PrivateKey)(0xc0001a2150)}}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -246,7 +246,7 @@
        	            	    },
        	            	-   dQ: ([]uint8) (len=64) {
        	            	-    00000000  00 25 a9 c1 51 bb cc 4e  d9 c0 7b c6 59 9c 71 08  |.%..Q..N..{.Y.q.|
        	            	-    00000010  6b 3b f1 5f cf 84 69 e7  7e c0 1c 6c bf 6f fa 6c  |k;._..i.~..l.o.l|
        	            	-    00000020  b9 14 02 ed ef 33 b0 07  68 06 74 05 54 b9 00 9e  |.....3..h.t.T...|
        	            	-    00000030  90 f2 ea d9 e4 6e bf d8  d2 bf d4 6a b1 88 d6 b3  |.....n.....j....|
        	            	+   dQ: ([]uint8) (len=63) {
        	            	+    00000000  25 a9 c1 51 bb cc 4e d9  c0 7b c6 59 9c 71 08 6b  |%..Q..N..{.Y.q.k|
        	            	+    00000010  3b f1 5f cf 84 69 e7 7e  c0 1c 6c bf 6f fa 6c b9  |;._..i.~..l.o.l.|
        	            	+    00000020  14 02 ed ef 33 b0 07 68  06 74 05 54 b9 00 9e 90  |....3..h.t.T....|
        	            	+    00000030  f2 ea d9 e4 6e bf d8 d2  bf d4 6a b1 88 d6 b3     |....n.....j....|
        	            	    },
        	Test:       	TestMarshalAndParseKey/rsa
```

The new test passes 10000x for me, the previous flaky version failed pretty reliably within 1000 attempts.