### PR TITLE
[v16] Allow downgrading PROXY headers from IPv6 to pseudo IPv4

### DIFF
--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -626,21 +626,22 @@ func (a *authorizer) convertAuthorizerError(err error) error {
 }
 
 // ErrIPPinningMissing is returned when user cert should be pinned but isn't.
-var ErrIPPinningMissing = trace.AccessDenied("pinned IP is required for the user, but is not present on identity")
+var ErrIPPinningMissing = &trace.AccessDeniedError{Message: "pinned IP is required for the user, but is not present on identity"}
 
 // ErrIPPinningMismatch is returned when user's pinned IP doesn't match observed IP.
-var ErrIPPinningMismatch = trace.AccessDenied("pinned IP doesn't match observed client IP")
+var ErrIPPinningMismatch = &trace.AccessDeniedError{Message: "pinned IP doesn't match observed client IP"}
 
 // ErrIPPinningNotAllowed is returned when user's pinned IP doesn't match observed IP.
-var ErrIPPinningNotAllowed = trace.AccessDenied("IP pinning is not allowed for connections behind L4 load balancers with " +
-	"PROXY protocol enabled without explicitly setting 'proxy_protocol: on' in the proxy_service and/or auth_service config.")
+var ErrIPPinningNotAllowed = &trace.AccessDeniedError{Message: "IP pinning is not allowed for connections that have been" +
+	"downgraded or are behind a L4 load balancers with PROXY protocol enabled without explicitly setting 'proxy_protocol: on'" +
+	"in the proxy_service and/or auth_service config."}
 
 // CheckIPPinning verifies IP pinning for the identity, using the client IP taken from context.
 // Check is considered successful if no error is returned.
 func CheckIPPinning(ctx context.Context, identity tlsca.Identity, pinSourceIP bool, log logrus.FieldLogger) error {
 	if identity.PinnedIP == "" {
 		if pinSourceIP {
-			return ErrIPPinningMissing
+			return trace.Wrap(ErrIPPinningMissing)
 		}
 		return nil
 	}
@@ -662,7 +663,7 @@ func CheckIPPinning(ctx context.Context, identity tlsca.Identity, pinSourceIP bo
 				"pinned_ip": identity.PinnedIP,
 			}).Debug("Pinned IP and client IP mismatch")
 		}
-		return ErrIPPinningMismatch
+		return trace.Wrap(ErrIPPinningMismatch)
 	}
 	// If connection has port 0 it means it was marked by multiplexer's 'detect()' function as affected by unexpected PROXY header.
 	// For security reason we don't allow such connection for IP pinning because we can't rely on client IP being correct.
@@ -671,9 +672,10 @@ func CheckIPPinning(ctx context.Context, identity tlsca.Identity, pinSourceIP bo
 			log.WithFields(logrus.Fields{
 				"client_ip": clientIP,
 				"pinned_ip": identity.PinnedIP,
-			}).Debug(ErrIPPinningNotAllowed.Error())
+				"error":     ErrIPPinningNotAllowed.Message,
+			}).Debug("client address is not allowed to use IP pinning")
 		}
-		return ErrIPPinningMismatch
+		return trace.Wrap(ErrIPPinningNotAllowed)
 	}
 
 	return nil
@@ -762,7 +764,7 @@ func (a *authorizer) authorizeRemoteUser(ctx context.Context, u RemoteUser) (*Co
 		UserType:          u.Identity.UserType,
 	}
 	if checker.PinSourceIP() && identity.PinnedIP == "" {
-		return nil, ErrIPPinningMissing
+		return nil, trace.Wrap(ErrIPPinningMissing)
 	}
 
 	return &Context{

--- a/lib/authz/permissions_test.go
+++ b/lib/authz/permissions_test.go
@@ -934,7 +934,7 @@ func TestCheckIPPinning(t *testing.T) {
 			clientAddr: "127.0.0.1:0",
 			pinnedIP:   "127.0.0.1",
 			pinIP:      true,
-			wantErr:    ErrIPPinningMismatch.Error(),
+			wantErr:    ErrIPPinningNotAllowed.Error(),
 		},
 		{
 			desc:       "correct IP pinning",

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1209,6 +1209,9 @@ func applyProxyConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		cfg.Proxy.PROXYProtocolMode = val
 	}
 
+	allowDowngrade := fc.Proxy.ProxyProtocolAllowDowngrade
+	cfg.Proxy.PROXYAllowDowngrade = allowDowngrade != nil && allowDowngrade.Value
+
 	if fc.Proxy.ListenAddress != "" {
 		addr, err := utils.ParseHostPortAddr(fc.Proxy.ListenAddress, defaults.SSHProxyListenPort)
 		if err != nil {

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -2089,6 +2089,9 @@ type Proxy struct {
 	// as only admin knows whether service is in front of trusted load balancer
 	// or not.
 	ProxyProtocol string `yaml:"proxy_protocol,omitempty"`
+	// ProxyProtocolAllowDowngrade controls support for downgrading IPv6 source addresses in PROXY headers to pseudo IPv4
+	// addresses when connecting to an IPv4 destination
+	ProxyProtocolAllowDowngrade *types.BoolOption `yaml:"proxy_protocol_allow_downgrade,omitempty"`
 	// KubeProxy configures kubernetes protocol support of the proxy
 	Kube KubeProxy `yaml:"kubernetes,omitempty"`
 	// KubeAddr is a shorthand for enabling the Kubernetes endpoint without a

--- a/lib/multiplexer/multiplexer_test.go
+++ b/lib/multiplexer/multiplexer_test.go
@@ -860,7 +860,13 @@ func TestMux(t *testing.T) {
 			require.NoError(t, err)
 			defer conn.Close()
 
-			signedHeader, err := signPROXYHeader(&addr1, &addr2, clusterName, tlsProxyCert, jwtSigner)
+			signedHeader, err := signPROXYHeader(signPROXYHeaderInput{
+				source:      &addr1,
+				destination: &addr2,
+				clusterName: clusterName,
+				signingCert: tlsProxyCert,
+				signer:      jwtSigner,
+			})
 			require.NoError(t, err)
 
 			_, err = conn.Write(signedHeader)
@@ -881,7 +887,14 @@ func TestMux(t *testing.T) {
 
 			defer conn.Close()
 
-			signedHeader, err := signPROXYHeader(&addrV6, &addrV6, clusterName, tlsProxyCert, jwtSigner)
+			signedHeader, err := signPROXYHeader(signPROXYHeaderInput{
+				source:         &addrV6,
+				destination:    &addrV6,
+				clusterName:    clusterName,
+				signingCert:    tlsProxyCert,
+				signer:         jwtSigner,
+				allowDowngrade: false,
+			})
 			require.NoError(t, err)
 
 			_, err = conn.Write(signedHeader)
@@ -893,12 +906,77 @@ func TestMux(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, addrV6.String(), out)
 		})
+		t.Run("single signed PROXY header from IPv6 to IPv4", func(t *testing.T) {
+			conn, err := net.Dial("tcp", listener4.Addr().String())
+			require.NoError(t, err)
+
+			defer conn.Close()
+
+			signedHeader, err := signPROXYHeader(signPROXYHeaderInput{
+				source:         &addrV6,
+				destination:    &addr1,
+				clusterName:    clusterName,
+				signingCert:    tlsProxyCert,
+				signer:         jwtSigner,
+				allowDowngrade: true,
+			})
+			require.NoError(t, err)
+
+			_, err = conn.Write(signedHeader)
+			require.NoError(t, err)
+
+			clt := tls.Client(conn, clientConfig(backend4))
+
+			out, err := utils.RoundtripWithConn(clt)
+			require.NoError(t, err)
+
+			// returned address should be marked with port 0 to prevent IP pinning
+			expected := addrV6
+			expected.Port = 0
+			require.Equal(t, expected.String(), out)
+		})
+		t.Run("single signed PROXY header from IPv6 to IPv4, no downgrade", func(t *testing.T) {
+			conn, err := net.Dial("tcp", listener4.Addr().String())
+			require.NoError(t, err)
+
+			defer conn.Close()
+
+			_, err = signPROXYHeader(signPROXYHeaderInput{
+				source:      &addrV6,
+				destination: &addr1,
+				clusterName: clusterName,
+				signingCert: tlsProxyCert,
+				signer:      jwtSigner,
+			})
+			require.Error(t, err)
+		})
+		t.Run("single signed PROXY header from IPv4 to IPv6 should fail to downgrade dst address", func(t *testing.T) {
+			conn, err := net.Dial("tcp", listener4.Addr().String())
+			require.NoError(t, err)
+
+			defer conn.Close()
+
+			_, err = signPROXYHeader(signPROXYHeaderInput{
+				source:      &addr1,
+				destination: &addrV6,
+				clusterName: clusterName,
+				signingCert: tlsProxyCert,
+				signer:      jwtSigner,
+			})
+			require.Error(t, err)
+		})
 		t.Run("two signed PROXY headers", func(t *testing.T) {
 			conn, err := net.Dial("tcp", listener4.Addr().String())
 			require.NoError(t, err)
 			defer conn.Close()
 
-			signedHeader, err := signPROXYHeader(&addr1, &addr2, clusterName, tlsProxyCert, jwtSigner)
+			signedHeader, err := signPROXYHeader(signPROXYHeaderInput{
+				source:      &addr1,
+				destination: &addr2,
+				clusterName: clusterName,
+				signingCert: tlsProxyCert,
+				signer:      jwtSigner,
+			})
 			require.NoError(t, err)
 
 			_, err = conn.Write(signedHeader)
@@ -916,9 +994,21 @@ func TestMux(t *testing.T) {
 			require.NoError(t, err)
 			defer conn.Close()
 
-			signedHeader, err := signPROXYHeader(&addr1, &addr2, clusterName, tlsProxyCert, jwtSigner)
+			signedHeader, err := signPROXYHeader(signPROXYHeaderInput{
+				source:      &addr1,
+				destination: &addr2,
+				clusterName: clusterName,
+				signingCert: tlsProxyCert,
+				signer:      jwtSigner,
+			})
 			require.NoError(t, err)
-			signedHeader2, err := signPROXYHeader(&addr2, &addr1, clusterName+"wrong", tlsProxyCert, jwtSigner)
+			signedHeader2, err := signPROXYHeader(signPROXYHeaderInput{
+				source:      &addr2,
+				destination: &addr1,
+				clusterName: clusterName + "wrong",
+				signingCert: tlsProxyCert,
+				signer:      jwtSigner,
+			})
 			require.NoError(t, err)
 
 			_, err = conn.Write(signedHeader)
@@ -936,7 +1026,13 @@ func TestMux(t *testing.T) {
 			require.NoError(t, err)
 			defer conn.Close()
 
-			signedHeader, err := signPROXYHeader(&addr1, &addr2, clusterName, tlsProxyCert, jwtSigner)
+			signedHeader, err := signPROXYHeader(signPROXYHeaderInput{
+				source:      &addr1,
+				destination: &addr2,
+				clusterName: clusterName,
+				signingCert: tlsProxyCert,
+				signer:      jwtSigner,
+			})
 			require.NoError(t, err)
 
 			pl := ProxyLine{
@@ -964,7 +1060,13 @@ func TestMux(t *testing.T) {
 			require.NoError(t, err)
 			defer conn.Close()
 
-			signedHeader, err := signPROXYHeader(&addr1, &addr2, clusterName, tlsProxyCert, jwtSigner)
+			signedHeader, err := signPROXYHeader(signPROXYHeaderInput{
+				source:      &addr1,
+				destination: &addr2,
+				clusterName: clusterName,
+				signingCert: tlsProxyCert,
+				signer:      jwtSigner,
+			})
 			require.NoError(t, err)
 
 			pl := ProxyLine{
@@ -1056,7 +1158,13 @@ func TestMux(t *testing.T) {
 			require.NoError(t, err)
 			defer conn.Close()
 
-			signedHeader, err := signPROXYHeader(&addr1, &addr2, clusterName, tlsProxyCert, jwtSigner)
+			signedHeader, err := signPROXYHeader(signPROXYHeaderInput{
+				source:      &addr1,
+				destination: &addr2,
+				clusterName: clusterName,
+				signingCert: tlsProxyCert,
+				signer:      jwtSigner,
+			})
 			require.NoError(t, err)
 
 			_, err = conn.Write(signedHeader)
@@ -1276,7 +1384,13 @@ func BenchmarkMux_ProxyV2Signature(b *testing.B) {
 			require.NoError(b, err)
 			defer conn.Close()
 
-			signedHeader, err := signPROXYHeader(&sAddr, &dAddr, clusterName, tlsProxyCert, jwtSigner)
+			signedHeader, err := signPROXYHeader(signPROXYHeaderInput{
+				source:      &sAddr,
+				destination: &dAddr,
+				clusterName: clusterName,
+				signingCert: tlsProxyCert,
+				signer:      jwtSigner,
+			})
 			require.NoError(b, err)
 
 			_, err = conn.Write(signedHeader)

--- a/lib/multiplexer/proxyline.go
+++ b/lib/multiplexer/proxyline.go
@@ -65,8 +65,9 @@ const (
 
 	PP2TypeTeleport PP2Type = 0xE4 // Teleport own type for transferring our custom data such as connection metadata
 
-	PP2TeleportSubtypeSigningCert PP2TeleportSubtype = 0x01 // Certificate used to sign JWT
-	PP2TeleportSubtypeJWT         PP2TeleportSubtype = 0x02 // JWT used to verify information sent in plain PROXY header
+	PP2TeleportSubtypeSigningCert  PP2TeleportSubtype = 0x01 // Certificate used to sign JWT
+	PP2TeleportSubtypeJWT          PP2TeleportSubtype = 0x02 // JWT used to verify information sent in plain PROXY header
+	PP2TeleportSubtypeOriginalAddr PP2TeleportSubtype = 0x03 // Original IPv6 source address when downgrading to IPv4
 )
 
 var (
@@ -86,6 +87,9 @@ var (
 	ErrNonLocalCluster = errors.New("signing certificate is not signed by local cluster CA")
 	// ErrNoHostCA is returned when CAGetter could not get host CA, for example if auth server is not available
 	ErrNoHostCA = errors.New("could not get specified host CA to verify signed PROXY header")
+	// ErrInvalidPseudoIPv4 is returned when the proxy line source address is a pseudo IPv4 that does not match the signed IPv6
+	// included in the TLVs
+	ErrInvalidPseudoIPv4 = errors.New("mismatched pseudo IPv4 source and original IPv6 in proxy line")
 )
 
 // ProxyLine implements PROXY protocol version 1 and 2
@@ -387,9 +391,9 @@ func MarshalTLVs(tlvs []TLV) ([]byte, error) {
 	return raw, nil
 }
 
-// AddSignature adds provided signature and cert to the proxy line, marshaling it
-// into appropriate TLV structure.
-func (p *ProxyLine) AddSignature(signature, signingCert []byte) error {
+// AddTeleportTLVs adds the provided signature, cert, and an optional original address to the proxy line,
+// marshaling it into appropriate TLV structure.
+func (p *ProxyLine) AddTeleportTLVs(signature, signingCert []byte, originalAddr *net.TCPAddr) error {
 	if len(signature) == 0 {
 		return trace.BadParameter("missing signature")
 	}
@@ -397,7 +401,7 @@ func (p *ProxyLine) AddSignature(signature, signingCert []byte) error {
 		return trace.BadParameter("missing signing certificate")
 	}
 
-	signatureTLVs := []TLV{
+	teleportTLVs := []TLV{
 		{
 			Type:  PP2Type(PP2TeleportSubtypeSigningCert),
 			Value: signingCert,
@@ -407,7 +411,15 @@ func (p *ProxyLine) AddSignature(signature, signingCert []byte) error {
 			Value: signature,
 		},
 	}
-	signatureBytes, err := MarshalTLVs(signatureTLVs)
+
+	if originalAddr != nil {
+		teleportTLVs = append(teleportTLVs, TLV{
+			Type:  PP2Type(PP2TeleportSubtypeOriginalAddr),
+			Value: []byte(originalAddr.String()),
+		})
+	}
+
+	teleportTLVBytes, err := MarshalTLVs(teleportTLVs)
 	if err != nil {
 		return err
 	}
@@ -415,13 +427,13 @@ func (p *ProxyLine) AddSignature(signature, signingCert []byte) error {
 	// If there's already signature among TLVs, we replace it
 	for i := range p.TLVs {
 		if p.TLVs[i].Type == PP2TypeTeleport {
-			p.TLVs[i].Value = signatureBytes
+			p.TLVs[i].Value = teleportTLVBytes
 			return nil
 		}
 	}
 
 	// Otherwise we append it
-	p.TLVs = append(p.TLVs, TLV{Type: PP2TypeTeleport, Value: signatureBytes})
+	p.TLVs = append(p.TLVs, TLV{Type: PP2TypeTeleport, Value: teleportTLVBytes})
 
 	return nil
 }
@@ -429,34 +441,44 @@ func (p *ProxyLine) AddSignature(signature, signingCert []byte) error {
 // IsSigned returns true if proxy line's TLV contains signature.
 // Does not take into account if signature is valid or not, just the presence of it.
 func (p *ProxyLine) IsSigned() bool {
-	token, proxyCert, _ := p.getSignatureAndSigningCert()
-	return len(token) > 0 || proxyCert != nil
+	tlvs, _ := p.getTeleportTLVs()
+	return len(tlvs.token) > 0 || tlvs.proxyCert != nil
 }
 
-// getSignatureAndSigningCert finds signature and signing certificate in TLVs if they are present
-func (p *ProxyLine) getSignatureAndSigningCert() (string, []byte, error) {
-	var proxyCert []byte
-	var token string
+type teleportTLVs struct {
+	token           string
+	proxyCert       []byte
+	originalAddress *net.TCPAddr
+}
+
+// getTeleportTLVs returns custom teleport TLVs present in the ProxyLine, if any
+func (p *ProxyLine) getTeleportTLVs() (teleportTLVs, error) {
+	var tlvs teleportTLVs
 	for _, tlv := range p.TLVs {
 		if tlv.Type == PP2TypeTeleport {
 			teleportSubTLVs, err := UnmarshalTLVs(tlv.Value)
 			if err != nil {
-				return "", nil, trace.Wrap(err)
+				return tlvs, trace.Wrap(err)
 			}
 
 			for _, subTLV := range teleportSubTLVs {
-				if subTLV.Type == PP2Type(PP2TeleportSubtypeSigningCert) {
-					proxyCert = subTLV.Value
-				}
-
-				if subTLV.Type == PP2Type(PP2TeleportSubtypeJWT) {
-					token = string(subTLV.Value)
+				switch PP2TeleportSubtype(subTLV.Type) {
+				case PP2TeleportSubtypeSigningCert:
+					tlvs.proxyCert = subTLV.Value
+				case PP2TeleportSubtypeJWT:
+					tlvs.token = string(subTLV.Value)
+				case PP2TeleportSubtypeOriginalAddr:
+					addr, err := net.ResolveTCPAddr("tcp", string(subTLV.Value))
+					if err != nil {
+						return tlvs, trace.Wrap(err)
+					}
+					tlvs.originalAddress = addr
 				}
 			}
 			break
 		}
 	}
-	return token, proxyCert, nil
+	return tlvs, nil
 }
 
 // VerifySignature checks that signature contained in the proxy line is securely signed.
@@ -466,15 +488,15 @@ func (p *ProxyLine) VerifySignature(ctx context.Context, caGetter CertAuthorityG
 		return trace.Wrap(ErrNoSignature)
 	}
 
-	token, proxyCert, err := p.getSignatureAndSigningCert()
+	tlvs, err := p.getTeleportTLVs()
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if len(token) == 0 || proxyCert == nil {
+	if len(tlvs.token) == 0 || tlvs.proxyCert == nil {
 		return trace.Wrap(ErrNoSignature)
 	}
 
-	signingCert, err := x509.ParseCertificate(proxyCert)
+	signingCert, err := x509.ParseCertificate(tlvs.proxyCert)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -526,11 +548,26 @@ func (p *ProxyLine) VerifySignature(ctx context.Context, caGetter CertAuthorityG
 	if err != nil {
 		return trace.Wrap(err)
 	}
+
+	// Determine if a pseudo IPv4 was used and validate
+	sAddr := p.Source.String()
+	if tlvs.originalAddress != nil {
+		expectedPLSource, err := getPseudoIPV4(*tlvs.originalAddress)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		if !expectedPLSource.IP.Equal(p.Source.IP) {
+			return trace.Wrap(ErrInvalidPseudoIPv4)
+		}
+
+		sAddr = tlvs.originalAddress.String()
+	}
 	_, err = jwtVerifier.VerifyPROXY(jwt.PROXYVerifyParams{
 		ClusterName:        localClusterName,
-		SourceAddress:      p.Source.String(),
+		SourceAddress:      sAddr,
 		DestinationAddress: p.Destination.String(),
-		RawToken:           token,
+		RawToken:           tlvs.token,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -538,6 +575,22 @@ func (p *ProxyLine) VerifySignature(ctx context.Context, caGetter CertAuthorityG
 
 	p.IsVerified = true
 	return nil
+}
+
+// ResolveSource returns the source IP address associated with a ProxyLine. If the Source is a class E address
+// then we need to return the IPv6 stored in the teleport TLVs instead.
+func (p *ProxyLine) ResolveSource() net.Addr {
+	// check if class E address
+	if []byte(p.Source.IP)[0] < classEPrefix {
+		return &p.Source
+	}
+
+	tlvs, err := p.getTeleportTLVs()
+	if err != nil {
+		return &p.Source
+	}
+
+	return tlvs.originalAddress
 }
 
 func getTLSCerts(ca types.CertAuthority) [][]byte {

--- a/lib/multiplexer/wrapper_test.go
+++ b/lib/multiplexer/wrapper_test.go
@@ -36,8 +36,28 @@ func TestPROXYEnabledListener_Accept(t *testing.T) {
 
 	addr1 := net.TCPAddr{IP: net.ParseIP("1.2.3.4"), Port: 444}
 	addr2 := net.TCPAddr{IP: net.ParseIP("5.4.3.2"), Port: 555}
+	addrV6 := net.TCPAddr{IP: net.ParseIP("::1"), Port: 999}
+	markedAddrV6 := addrV6
+	markedAddrV6.Port = 0
 
-	signedHeader, err := signPROXYHeader(&addr1, &addr2, clusterName, tlsProxyCert, jwtSigner)
+	signedHeader, err := signPROXYHeader(signPROXYHeaderInput{
+		source:         &addr1,
+		destination:    &addr2,
+		clusterName:    clusterName,
+		signingCert:    tlsProxyCert,
+		signer:         jwtSigner,
+		allowDowngrade: false,
+	})
+	require.NoError(t, err)
+
+	signedHeaderDowngrade, err := signPROXYHeader(signPROXYHeaderInput{
+		source:         &addrV6,
+		destination:    &addr2,
+		clusterName:    clusterName,
+		signingCert:    tlsProxyCert,
+		signer:         jwtSigner,
+		allowDowngrade: true,
+	})
 	require.NoError(t, err)
 
 	testCases := []struct {
@@ -45,41 +65,68 @@ func TestPROXYEnabledListener_Accept(t *testing.T) {
 		proxyLine          []byte
 		expectedRemoteAddr string
 		expectedLocalAddr  string
-		PROXYProtocolMode  PROXYProtocolMode
+		proxyMode          PROXYProtocolMode
+		allowDowngrade     bool
 	}{
 		{
 			name:               "PROXY v1 header",
 			proxyLine:          []byte(sampleProxyV1Line),
 			expectedLocalAddr:  "127.0.0.2:42",
 			expectedRemoteAddr: "127.0.0.1:12345",
-			PROXYProtocolMode:  PROXYProtocolOn,
+			proxyMode:          PROXYProtocolOn,
+			allowDowngrade:     false,
 		},
 		{
 			name:               "PROXY v1 header, unspecified mode",
 			proxyLine:          []byte(sampleProxyV1Line),
 			expectedLocalAddr:  "127.0.0.2:42",
 			expectedRemoteAddr: "127.0.0.1:0",
-			PROXYProtocolMode:  PROXYProtocolUnspecified,
+			proxyMode:          PROXYProtocolUnspecified,
+			allowDowngrade:     false,
 		},
 		{
 			name:               "unsigned PROXY v2 header",
 			proxyLine:          sampleProxyV2Line,
 			expectedLocalAddr:  "127.0.0.2:42",
 			expectedRemoteAddr: "127.0.0.1:12345",
-			PROXYProtocolMode:  PROXYProtocolOn,
+			proxyMode:          PROXYProtocolOn,
+			allowDowngrade:     false,
 		},
 		{
 			name:               "signed PROXY v2 header",
 			proxyLine:          signedHeader,
 			expectedLocalAddr:  addr2.String(),
 			expectedRemoteAddr: addr1.String(),
-			PROXYProtocolMode:  PROXYProtocolOff,
+			proxyMode:          PROXYProtocolOff,
+			allowDowngrade:     false,
+		},
+		{
+			name:               "signed PROXY v2 header on, mixed version in downgrade mode",
+			proxyLine:          signedHeaderDowngrade,
+			expectedLocalAddr:  addr2.String(),
+			expectedRemoteAddr: markedAddrV6.String(),
+			proxyMode:          PROXYProtocolOn,
+			allowDowngrade:     true,
+		},
+		{
+			name:               "signed PROXY v2 header unspecified, mixed version in downgrade mode",
+			proxyLine:          signedHeaderDowngrade,
+			expectedLocalAddr:  addr2.String(),
+			expectedRemoteAddr: markedAddrV6.String(),
+			proxyMode:          PROXYProtocolUnspecified,
+			allowDowngrade:     true,
 		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			proto := "tcp"
+			listenAddr := "127.0.0.1:0"
+			if tt.allowDowngrade {
+				proto = "tcp6"
+				listenAddr = "[::1]:0"
+			}
+			listener, err := net.Listen(proto, listenAddr)
 			require.NoError(t, err)
 			t.Cleanup(func() { listener.Close() })
 
@@ -87,7 +134,8 @@ func TestPROXYEnabledListener_Accept(t *testing.T) {
 				Listener:            listener,
 				Context:             context.Background(),
 				ID:                  "test",
-				PROXYProtocolMode:   tt.PROXYProtocolMode,
+				PROXYProtocolMode:   tt.proxyMode,
+				PROXYAllowDowngrade: tt.allowDowngrade,
 				CertAuthorityGetter: casGetter,
 				LocalClusterName:    clusterName,
 			})
@@ -103,7 +151,7 @@ func TestPROXYEnabledListener_Accept(t *testing.T) {
 				}
 				connChan <- conn
 			}()
-			conn, err := net.Dial("tcp", proxyListener.Addr().String())
+			conn, err := net.Dial(proto, proxyListener.Addr().String())
 			require.NoError(t, err)
 			defer conn.Close()
 

--- a/lib/multiplexer/wrappers.go
+++ b/lib/multiplexer/wrappers.go
@@ -83,8 +83,9 @@ func (c *Conn) LocalAddr() net.Addr {
 // RemoteAddr returns remote address of the connection
 func (c *Conn) RemoteAddr() net.Addr {
 	if c.proxyLine != nil {
-		return &c.proxyLine.Source
+		return c.proxyLine.ResolveSource()
 	}
+
 	return c.Conn.RemoteAddr()
 }
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4331,7 +4331,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	proxySigner, err := process.getPROXYSigner(conn.ServerIdentity)
+	proxySigner, err := process.getPROXYSigner(conn.ServerIdentity, cfg.Proxy.PROXYAllowDowngrade)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -5372,7 +5372,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	return nil
 }
 
-func (process *TeleportProcess) getPROXYSigner(ident *state.Identity) (multiplexer.PROXYHeaderSigner, error) {
+func (process *TeleportProcess) getPROXYSigner(ident *state.Identity, allowDowngrade bool) (multiplexer.PROXYHeaderSigner, error) {
 	signer, err := keys.ParsePrivateKey(ident.KeyBytes)
 	if err != nil {
 		return nil, trace.Wrap(err, "could not parse identity's private key")
@@ -5383,7 +5383,7 @@ func (process *TeleportProcess) getPROXYSigner(ident *state.Identity) (multiplex
 		return nil, trace.Wrap(err, "could not create JWT signer")
 	}
 
-	proxySigner, err := multiplexer.NewPROXYSigner(ident.XCert, jwtSigner)
+	proxySigner, err := multiplexer.NewPROXYSigner(ident.XCert, jwtSigner, allowDowngrade)
 	if err != nil {
 		return nil, trace.Wrap(err, "could not create PROXY signer")
 	}

--- a/lib/service/servicecfg/proxy.go
+++ b/lib/service/servicecfg/proxy.go
@@ -61,6 +61,9 @@ type ProxyConfig struct {
 	// PROXYProtocolMode controls behavior related to unsigned PROXY protocol headers.
 	PROXYProtocolMode multiplexer.PROXYProtocolMode
 
+	// PROXYAllowDowngrade
+	PROXYAllowDowngrade bool
+
 	// WebAddr is address for web portal of the proxy
 	WebAddr utils.NetAddr
 


### PR DESCRIPTION
Backport #51632 to branch/v16

This PR adds a new `proxy_protocol_allow_downgrade` option to the `proxy_service` configuration. It replaces source IPv6 addresses in the `PROXY` header with [pseudo IPv4](https://developers.cloudflare.com/network/pseudo-ipv4) addresses generated by hashing the original IPv6 and applying the class E prefix. This change should be compatible with older agents for headers that are not downgraded, but downgraded headers will fail validation.

The original source IPv6 address is returned when calling `conn.RemoteAddr()` in order to preserve logging and audit logs. However, it is marked with a `0` port just like we currently do when `PROXY` headers are present without `proxy_protocol_mode: on`. This is to prevent IP pinning against downgraded source addresses since there's a non-trivial risk of collisions.

changelog: Added new `proxy_protocol_allow_downgrade` field to the `proxy_service` configuration in support of environments where single stack IPv6 sources are connecting to single stack IPv4 destinations. This feature is not compatible with IP pinning.
