### PR TITLE
Adding docs for `proxy_protocol_allow_downgrade`

### DIFF
--- a/docs/pages/admin-guides/management/security/proxy-protocol.mdx
+++ b/docs/pages/admin-guides/management/security/proxy-protocol.mdx
@@ -87,6 +87,10 @@ your network setup:
    from the same IP address from Teleport's point of view, compromising the
    Teleport audit log and IP pinning feature.
 
+1. If you need to connect from an IPv6-only network to an IPv4-only network, you
+   can downgrade the source address by using your Teleport configuration file
+   (explained in the next step).
+
 ## Step 2/2. Edit your static Teleport configuration
 
 On a Teleport process, the Auth Service and Proxy Service can each support the
@@ -97,6 +101,7 @@ the Teleport configuration file:
 ```yaml
 proxy_service:
   proxy_protocol: on | off
+  proxy_protocol_allow_downgrade: on | off
   # ...
 auth_service:
   proxy_protocol: on | off
@@ -104,6 +109,13 @@ auth_service:
 
 By default,  `proxy_protocol` is unspecified. Users can manually set
 `proxy_protocol` to `on` or `off`:
+- unspecified (default): The associated Teleport service does not require the
+  PROXY header for the connection, but will parse it if present, and replace the
+  client's source IP address with the one from the PROXY header. This address will
+  appear in audit events. Incoming connections with the PROXY header will also be
+  marked by setting source port to `0`, and this will be visible in audit events
+  as well. This is only suitable for test environments and must never be enabled
+  in production.
 - `on`: the PROXY protocol is enabled and mandatory. If a PROXY protocol header
   is received, the Teleport service will parse the header and extract the
   client's IP address and port. If the header isn't present, the Teleport
@@ -114,21 +126,23 @@ By default,  `proxy_protocol` is unspecified. Users can manually set
 We encourage users to explicitly set their `proxy_protocol` setting to `on` or
 `off` mode depending on the network setup. 
 
-If `proxy_protocol` is unspecified, the associated Teleport service does not
-require the PROXY header for the connection, but will parse it if present, and
-replace the client's source IP address with the one from the PROXY header. This
-address will appear in audit events. Incoming connections with the PROXY header
-will also be marked by setting source port to `0`, and this will be visible in
-audit events as well.
+Users can also enable `proxy_protocol_allow_downgrade` to facilitate connections
+from IPv6 networks into IPv4 networks without dual-stack networking:
+- `on`: PROXY protocol headers with an IPv6 source address and an IPv4
+  destination will have their source addresses downgraded to a pseudo IPv4.
+- `off`: PROXY protocol header source addresses will not be modified and mixed IP
+  versions will result in errors.
 
-IP pinning will not work if `proxy_protocol` setting wasn't explicitly set in
-the config. Connections that are marked with `0` as the source port will be
-rejected during IP pinning checks.
+<Admonition type="warning">
 
-<Admonition type="danger">
-
-The default unspecified value mode is not suitable for production. It is only
-suitable for test environments. 
+If you are upgrading Teleport in order to enable `proxy_protocol_allow_downgrade`,
+you will need to upgrade all instances of Teleport Proxy Service before enabling
+it. Versions that do not support this configuration will be unable to verify the
+PROXY header signature and fail to accept downgraded connections.
 
 </Admonition>
+
+IP pinning will not work if `proxy_protocol` setting wasn't explicitly set in
+the config or if a connection is downgraded. Connections that are marked with
+`0` as the source port will be rejected during IP pinning checks.
 

--- a/docs/pages/includes/config-reference/proxy-service.yaml
+++ b/docs/pages/includes/config-reference/proxy-service.yaml
@@ -16,6 +16,19 @@ proxy_service:
     # headers, otherwise set to `off`.
     proxy_protocol: on
 
+    # proxy_protocol_allow_downgrade controls support for automatic downgrading of
+    # PROXY header source addresses from IPv6 to pseudo IPv4.
+    # Defaults to 'off', possible values:
+    # 'on' - Downgrade PROXY header source IPv6 addresses to pseudo IPv4 addresses.
+    # 'off' - Do not modify PROXY header source addresses.
+    #
+    # Because the PROXY protocol spec does not support source and destination addresses
+    # with mixed TCP versions, this allows for environments where Teleport is proxying
+    # between IPv6 networks into IPv4 networks. Downgrading to IPv4 comes with the
+    # posibility of collisions, which means IP pinning functionality will not work for
+    # downgraded connections.
+    proxy_protocol_allow_downgrade: on
+
     # SSH forwarding/proxy address. Command line (CLI) clients always begin
     # their SSH sessions by connecting to this port
     #


### PR DESCRIPTION
This PR adds documentation for the `proxy_service.proxy_protocol_allow_downgrade` field added in #51632.
