### PR TITLE
[v16] Fix Azure VM auto discover when not filtering by resource group

### DIFF
--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -572,7 +572,7 @@ func (s *Server) azureServerFetchersFromMatchers(matchers []types.AzureMatcher) 
 		return matcherType == types.AzureMatcherVM
 	})
 
-	return server.MatchersToAzureInstanceFetchers(serverMatchers, s.CloudClients)
+	return server.MatchersToAzureInstanceFetchers(s.Log, serverMatchers, s.CloudClients)
 }
 
 // gcpServerFetchersFromMatchers converts Matchers into a set of GCP Servers Fetchers.
@@ -656,7 +656,7 @@ func (s *Server) initAzureWatchers(ctx context.Context, matchers []types.AzureMa
 		return matcherType == types.AzureMatcherVM
 	})
 
-	s.staticServerAzureFetchers = server.MatchersToAzureInstanceFetchers(vmMatchers, s.CloudClients)
+	s.staticServerAzureFetchers = server.MatchersToAzureInstanceFetchers(s.Log, vmMatchers, s.CloudClients)
 
 	// VM watcher.
 	var err error

--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -20,9 +20,11 @@ package server
 
 import (
 	"context"
+	"log/slog"
 	"slices"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v3"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/gravitational/trace"
@@ -97,7 +99,7 @@ func NewAzureWatcher(ctx context.Context, fetchersFn func() []Fetcher, opts ...O
 }
 
 // MatchersToAzureInstanceFetchers converts a list of Azure VM Matchers into a list of Azure VM Fetchers.
-func MatchersToAzureInstanceFetchers(matchers []types.AzureMatcher, clients azureClientGetter) []Fetcher {
+func MatchersToAzureInstanceFetchers(logger *slog.Logger, matchers []types.AzureMatcher, clients azureClientGetter) []Fetcher {
 	ret := make([]Fetcher, 0)
 	for _, matcher := range matchers {
 		for _, subscription := range matcher.Subscriptions {
@@ -107,6 +109,7 @@ func MatchersToAzureInstanceFetchers(matchers []types.AzureMatcher, clients azur
 					Subscription:      subscription,
 					ResourceGroup:     resourceGroup,
 					AzureClientGetter: clients,
+					Logger:            logger,
 				})
 				ret = append(ret, fetcher)
 			}
@@ -120,6 +123,7 @@ type azureFetcherConfig struct {
 	Subscription      string
 	ResourceGroup     string
 	AzureClientGetter azureClientGetter
+	Logger            *slog.Logger
 }
 
 type azureInstanceFetcher struct {
@@ -130,6 +134,7 @@ type azureInstanceFetcher struct {
 	Labels            types.Labels
 	Parameters        map[string]string
 	ClientID          string
+	Logger            *slog.Logger
 }
 
 func newAzureInstanceFetcher(cfg azureFetcherConfig) *azureInstanceFetcher {
@@ -139,6 +144,7 @@ func newAzureInstanceFetcher(cfg azureFetcherConfig) *azureInstanceFetcher {
 		Subscription:      cfg.Subscription,
 		ResourceGroup:     cfg.ResourceGroup,
 		Labels:            cfg.Matcher.ResourceTags,
+		Logger:            cfg.Logger,
 	}
 
 	if cfg.Matcher.Params != nil {
@@ -157,18 +163,16 @@ func (*azureInstanceFetcher) GetMatchingInstances(_ []types.Server, _ bool) ([]I
 	return nil, trace.NotImplemented("not implemented for azure fetchers")
 }
 
+type resourceGroupLocation struct {
+	resourceGroup string
+	location      string
+}
+
 // GetInstances fetches all Azure virtual machines matching configured filters.
 func (f *azureInstanceFetcher) GetInstances(ctx context.Context, _ bool) ([]Instances, error) {
 	client, err := f.AzureClientGetter.GetAzureVirtualMachinesClient(f.Subscription)
 	if err != nil {
 		return nil, trace.Wrap(err)
-	}
-	instancesByRegion := make(map[string][]*armcompute.VirtualMachine)
-	allowAllRegions := slices.Contains(f.Regions, types.Wildcard)
-	if !allowAllRegions {
-		for _, region := range f.Regions {
-			instancesByRegion[region] = []*armcompute.VirtualMachine{}
-		}
 	}
 
 	vms, err := client.ListVirtualMachines(ctx, f.ResourceGroup)
@@ -176,11 +180,17 @@ func (f *azureInstanceFetcher) GetInstances(ctx context.Context, _ bool) ([]Inst
 		return nil, trace.Wrap(err)
 	}
 
+	instancesByRegionAndResourceGroup := make(map[resourceGroupLocation][]*armcompute.VirtualMachine)
+
+	allowAllLocations := slices.Contains(f.Regions, types.Wildcard)
+	allowAllResourceGroups := f.ResourceGroup == types.Wildcard
+
 	for _, vm := range vms {
-		location := aws.StringValue(vm.Location)
-		if _, ok := instancesByRegion[location]; !ok && !allowAllRegions {
+		location := azure.StringVal(vm.Location)
+		if !slices.Contains(f.Regions, location) && !allowAllLocations {
 			continue
 		}
+
 		vmTags := make(map[string]string, len(vm.Tags))
 		for key, value := range vm.Tags {
 			vmTags[key] = aws.StringValue(value)
@@ -188,23 +198,45 @@ func (f *azureInstanceFetcher) GetInstances(ctx context.Context, _ bool) ([]Inst
 		if match, _, _ := services.MatchLabels(f.Labels, vmTags); !match {
 			continue
 		}
-		instancesByRegion[location] = append(instancesByRegion[location], vm)
+
+		resourceGroup := f.ResourceGroup
+		if allowAllResourceGroups {
+			resourceMetadata, err := arm.ParseResourceID(azure.StringVal(vm.ID))
+			if err != nil {
+				f.Logger.WarnContext(ctx, "Skipping Teleport installation on Azure VM - failed to infer resource group from vm id",
+					"subscription_id", f.Subscription,
+					"vm_id", azure.StringVal(vm.ID),
+					"error", err,
+				)
+				continue
+			}
+			resourceGroup = resourceMetadata.ResourceGroupName
+		}
+
+		batchGroup := resourceGroupLocation{
+			resourceGroup: resourceGroup,
+			location:      location,
+		}
+
+		if _, ok := instancesByRegionAndResourceGroup[batchGroup]; !ok {
+			instancesByRegionAndResourceGroup[batchGroup] = make([]*armcompute.VirtualMachine, 0)
+		}
+
+		instancesByRegionAndResourceGroup[batchGroup] = append(instancesByRegionAndResourceGroup[batchGroup], vm)
 	}
 
 	var instances []Instances
-	for region, vms := range instancesByRegion {
-		if len(vms) > 0 {
-			instances = append(instances, Instances{Azure: &AzureInstances{
-				SubscriptionID:  f.Subscription,
-				Region:          region,
-				ResourceGroup:   f.ResourceGroup,
-				Instances:       vms,
-				ScriptName:      f.Parameters["scriptName"],
-				PublicProxyAddr: f.Parameters["publicProxyAddr"],
-				Parameters:      []string{f.Parameters["token"]},
-				ClientID:        f.ClientID,
-			}})
-		}
+	for batchGroup, vms := range instancesByRegionAndResourceGroup {
+		instances = append(instances, Instances{Azure: &AzureInstances{
+			SubscriptionID:  f.Subscription,
+			Region:          batchGroup.location,
+			ResourceGroup:   batchGroup.resourceGroup,
+			Instances:       vms,
+			ScriptName:      f.Parameters["scriptName"],
+			PublicProxyAddr: f.Parameters["publicProxyAddr"],
+			Parameters:      []string{f.Parameters["token"]},
+			ClientID:        f.ClientID,
+		}})
 	}
 
 	return instances, nil

--- a/lib/srv/server/azure_watcher_test.go
+++ b/lib/srv/server/azure_watcher_test.go
@@ -23,12 +23,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v3"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud/azure"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 func (c *mockClients) GetAzureVirtualMachinesClient(subscription string) (azure.VirtualMachinesClient, error) {
@@ -43,35 +45,35 @@ func TestAzureWatcher(t *testing.T) {
 			VirtualMachines: map[string][]*armcompute.VirtualMachine{
 				"rg1": {
 					{
-						ID:       to.Ptr("vm1"),
+						ID:       to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1"),
 						Location: to.Ptr("location1"),
 					},
 					{
-						ID:       to.Ptr("vm2"),
+						ID:       to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm2"),
 						Location: to.Ptr("location1"),
 						Tags: map[string]*string{
 							"teleport": to.Ptr("yes"),
 						},
 					},
 					{
-						ID:       to.Ptr("vm5"),
+						ID:       to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm5"),
 						Location: to.Ptr("location2"),
 					},
 				},
 				"rg2": {
 					{
-						ID:       to.Ptr("vm3"),
+						ID:       to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm3"),
 						Location: to.Ptr("location1"),
 					},
 					{
-						ID:       to.Ptr("vm4"),
+						ID:       to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm4"),
 						Location: to.Ptr("location1"),
 						Tags: map[string]*string{
 							"teleport": to.Ptr("yes"),
 						},
 					},
 					{
-						ID:       to.Ptr("vm6"),
+						ID:       to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm6"),
 						Location: to.Ptr("location2"),
 					},
 				},
@@ -129,8 +131,18 @@ func TestAzureWatcher(t *testing.T) {
 			},
 			wantVMs: []string{"vm1", "vm2", "vm3", "vm4", "vm5", "vm6"},
 		},
+		{
+			name: "resource group wildcard",
+			matcher: types.AzureMatcher{
+				ResourceGroups: []string{"*"},
+				Regions:        []string{types.Wildcard},
+				ResourceTags:   types.Labels{"*": []string{"*"}},
+			},
+			wantVMs: []string{"vm1", "vm2", "vm3", "vm4", "vm5", "vm6"},
+		},
 	}
 
+	logger := utils.NewSlogLoggerForTests()
 	for _, tc := range tests {
 		tc.matcher.Types = []string{"vm"}
 		tc.matcher.Subscriptions = []string{"sub1"}
@@ -139,7 +151,7 @@ func TestAzureWatcher(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			t.Cleanup(cancel)
 			watcher, err := NewAzureWatcher(ctx, func() []Fetcher {
-				return MatchersToAzureInstanceFetchers([]types.AzureMatcher{tc.matcher}, &clients)
+				return MatchersToAzureInstanceFetchers(logger, []types.AzureMatcher{tc.matcher}, &clients)
 			})
 			require.NoError(t, err)
 
@@ -152,8 +164,12 @@ func TestAzureWatcher(t *testing.T) {
 				select {
 				case results := <-watcher.InstancesC:
 					for _, vm := range results.Azure.Instances {
-						vmIDs = append(vmIDs, *vm.ID)
+						parsedResource, err := arm.ParseResourceID(*vm.ID)
+						require.NoError(t, err)
+						vmID := parsedResource.Name
+						vmIDs = append(vmIDs, vmID)
 					}
+					require.NotEqual(t, "*", results.Azure.ResourceGroup)
 				case <-ctx.Done():
 					require.Fail(t, "Expected %v VMs, got %v", tc.wantVMs, len(vmIDs))
 				}


### PR DESCRIPTION
Backport #53758 to v16

changelog: Fix Azure VM auto discovery when not filtering by resource group