### PR TITLE
Update delegated list on Join Methods reference

### DIFF
--- a/docs/pages/reference/join-methods.mdx
+++ b/docs/pages/reference/join-methods.mdx
@@ -114,16 +114,19 @@ based join methods can allow instances to join based on their Availability Zone,
 service account, or cloud account ID.
 
 Delegated join methods are:
-- [`iam`](#aws-iam-role-iam)
 - [`azure`](#azure-managed-identity-azure)
-- [`gcp`](#gcp-service-account-gcp)
-- [`ec2`](#aws-ec2-identity-document-ec2)
-- [`github`](#github-actions-github)
+- [`bitbucket`](#bitbucket-pipelines-bitbucket)
 - [`circleci`](#circleci-circleci)
+- [`ec2`](#aws-ec2-identity-document-ec2)
+- [`gcp`](#gcp-service-account-gcp)
+- [`github`](#github-actions-github)
 - [`gitlab`](#gitlab-gitlab)
+- [`iam`](#aws-iam-role-iam)
 - [`kubernetes`](#kubernetes-kubernetes)
-- [`tpm`](#trusted-platform-module-tpm)
+- [`oracle`](#oracle-oracle)
+- [`spacelift`](#spacelift-spacelift)
 - [`terraform_cloud`](#terraform-cloud-terraform_cloud)
+- [`tpm`](#trusted-platform-module-tpm)
 
 ### Renewable vs non-renewable
 

--- a/docs/pages/reference/join-methods.mdx
+++ b/docs/pages/reference/join-methods.mdx
@@ -123,7 +123,7 @@ Delegated join methods are:
 - [`gitlab`](#gitlab-gitlab)
 - [`iam`](#aws-iam-role-iam)
 - [`kubernetes`](#kubernetes-kubernetes)
-- [`oracle`](#oracle-oracle)
+- [`oracle`](#oracle-cloud-oracle)
 - [`spacelift`](#spacelift-spacelift)
 - [`terraform_cloud`](#terraform-cloud-terraform_cloud)
 - [`tpm`](#trusted-platform-module-tpm)


### PR DESCRIPTION
This list was missing a few join methods (bitbucket, spacelift, oracle). I've added the missing methods & sorted the list alphabetically to make it easier to scan visually.