### PR TITLE
WMI: Add `spec.jwt.maximum_ttl` and `spec.x509.maximum_ttl` to WorkloadIdentity reference

### DIFF
--- a/docs/pages/reference/workload-identity/workload-identity-resource.mdx
+++ b/docs/pages/reference/workload-identity/workload-identity-resource.mdx
@@ -72,6 +72,14 @@ spec:
         # name. Supports templating. If not provided, the organizational unit
         # will be omitted.
         organizational_unit: my-organizational-unit
+      # Controls the maximum TTL of X509-SVIDs issued using this
+      # WorkloadIdentity. Specified in seconds with 's' suffix.
+      #
+      # If a X509-SVID is requested with a TTL greater than this value, then the
+      # return X509-SVID will have a TTL of this value.
+      #
+      # Defaults to 24 hours (86400s). Maximum value is 14 days (1209600s).
+      maximum_ttl: 3600s
     # Grouped configuration for JWT credentials.
     jwt:
       # Optional extra claims that will be added to the JWT-SVID. It's an
@@ -81,6 +89,14 @@ spec:
         message: "Hello, {{strings.upper(user.name)}}!"
         foo:
           bar: ["baz", 1234, "{{user.bot_instance_id}}", true]
+      # Controls the maximum TTL of JWT-SVIDs issued using this
+      # WorkloadIdentity. Specified in seconds with 's' suffix.
+      #
+      # If a JWT-SVID is requested with a TTL greater than this value, then the
+      # return JWT-SVID will have a TTL of this value.
+      #
+      # Defaults to 24 hours (86400s). Maximum value is 24 hours (86400s).
+      maximum_ttl: 300s
   # The rules control when this WorkloadIdentity can be used to issue a
   # credential.
   rules:


### PR DESCRIPTION
Documents https://github.com/gravitational/teleport/pull/53787

