### PR TITLE
Role editor dialog layout tweaks

### DIFF
--- a/web/packages/design/src/SlideTabs/SlideTabs.story.tsx
+++ b/web/packages/design/src/SlideTabs/SlideTabs.story.tsx
@@ -157,7 +157,7 @@ export const Small = () => {
       <SlideTabs
         tabs={[
           { key: 'kraken', title: 'Kraken' },
-          { key: 'chubacabra', title: 'Chubacabra' },
+          { key: 'chupacabra', title: 'Chupacabra' },
           { key: 'yeti', title: 'Yeti' },
         ]}
         size="small"
@@ -201,6 +201,18 @@ export const StatusIcons = () => {
       <SlideTabs
         tabs={tabs}
         hideStatusIconOnActiveTab
+        activeIndex={activeIndex}
+        onChange={setActiveIndex}
+      />
+      <SlideTabs
+        size="medium"
+        tabs={tabs}
+        activeIndex={activeIndex}
+        onChange={setActiveIndex}
+      />
+      <SlideTabs
+        size="small"
+        tabs={tabs}
         activeIndex={activeIndex}
         onChange={setActiveIndex}
       />

--- a/web/packages/design/src/SlideTabs/SlideTabs.tsx
+++ b/web/packages/design/src/SlideTabs/SlideTabs.tsx
@@ -126,6 +126,8 @@ export function SlideTabs({
                   whose left edge is the left edge of the content (not the tab
                   button, which can be much wider). */}
                 <TabContent gap={1}>
+                  {Icon && <Icon size={size} role="graphics-symbol" />}
+                  {title}
                   <StatusIconContainer>
                     <StatusIconOrSpinner
                       statusKind={statusKind}
@@ -135,8 +137,6 @@ export function SlideTabs({
                       color={selected ? statusIconColorActive : undefined}
                     />
                   </StatusIconContainer>
-                  {Icon && <Icon size={size} role="graphics-symbol" />}
-                  {title}
                 </TabContent>
               </TabButton>
             </HoverTooltip>
@@ -317,6 +317,76 @@ const TabSliderInner = styled.div<{ appearance: Appearance }>`
   border-radius: ${props => (props.appearance === 'square' ? '8px' : '60px')};
 `;
 
+// For the small and medium sizes, we don't use paddings between tab buttons.
+// Therefore, the area of tab list is evenly divided into segments, and we
+// anchor the slider relative to the box with horizontal padding. With larger
+// sizes, we expect to have some distance between the tab buttons. It means
+// that the positions of the slider, expressed as relative to what the padding
+// box would be, are no longer proportional to the tab index (there is distance
+// between the tabs, but no distance on the left of the first tab and on the
+// right of the last tab). Therefore, to calculate the position of slider as a
+// percentage of its container's width, we set the wrapper's horizontal padding
+// to 0, thus giving us a couple of pixels of breathing room; now we can go
+// back to using a linear formula to calculate the slider position. This lack
+// of padding will be then compensated for by adjusting tab button margins
+// appropriately.
+
+const wrapperPadding = ({ size }: { size: Size }) => {
+  switch (size) {
+    case 'small':
+      return { padding: '4px 4px' };
+    case 'medium':
+      return { padding: '8px 8px' };
+    case 'large':
+      return { padding: '8px 0' };
+    default:
+      size satisfies never;
+      return;
+  }
+};
+
+const buttonMargin = ({ size }: { size: Size }) => {
+  switch (size) {
+    case 'small':
+      return { margin: '0 0' };
+    case 'medium':
+      return { margin: '0 0' };
+    case 'large':
+      return { margin: '0 8px' };
+    default:
+      size satisfies never;
+      return;
+  }
+};
+
+const buttonPadding = ({ size }: { size: Size }) => {
+  switch (size) {
+    case 'small':
+      return { padding: '8px 8px' };
+    case 'medium':
+      return { padding: '8px 8px' };
+    case 'large':
+      return { padding: '8px 16px' };
+    default:
+      size satisfies never;
+      return;
+  }
+};
+
+const sliderPadding = ({ size }: { size: Size }) => {
+  switch (size) {
+    case 'small':
+      return { padding: '0 0' };
+    case 'medium':
+      return { padding: '0 0' };
+    case 'large':
+      return { padding: '0 8px' };
+    default:
+      size satisfies never;
+      return;
+  }
+};
+
 const Wrapper = styled.div<{
   fitContent: boolean;
   size: Size;
@@ -324,22 +394,7 @@ const Wrapper = styled.div<{
 }>`
   position: relative;
   ${props => (props.fitContent ? 'width: fit-content;' : '')}
-  /*
-   * For the small size, we don't use paddings between tab buttons. Therefore,
-   * the area of tab list is evenly divided into segments, and we anchor the
-   * slider relative to the box with horizontal padding. With larger sizes, we
-   * expect to have some distance between the tab buttons. It means that the
-   * positions of the slider, expressed as relative to what the padding box
-   * would be, are no longer proportional to the tab index (there is distance
-   * between the tabs, but no distance on the left of the first tab and on the
-   * right of the last tab). Therefore, to calculate the position of slider as
-   * a percentage of its container's width, we set the wrapper's horizontal
-   * padding to 0, thus giving us a couple of pixels of breathing room; now we
-   * can go back to using a linear formula to calculate the slider position.
-   * This lack of padding will be then compensated for by adjusting tab button
-   * margins appropriately.
-   */
-  padding: ${props => (props.size === 'small' ? '4px 4px' : '8px 0')};
+  ${wrapperPadding}
   background-color: ${props => props.theme.colors.interactive.tonal.neutral[0]};
   border-radius: ${props => (props.appearance === 'square' ? '8px' : '60px')};
 
@@ -372,7 +427,7 @@ const TabButton = styled.button<{
   outline: none;
   border: none;
   background: transparent;
-  padding: ${props => (props.size === 'small' ? '8px 8px' : '8px 16px')};
+  ${buttonPadding}
 
   ${props => props.theme.typography.body2}
 
@@ -387,7 +442,7 @@ const TabButton = styled.button<{
    * Using similar logic as with wrapper padding, we compensate for the lack of
    * thereof with button margins if needed.
    */
-  margin: 0 ${props => (props.size === 'small' ? '0' : '8px')};
+  ${buttonMargin}
   color: ${props =>
     props.selected
       ? props.theme.colors.text.primaryInverse
@@ -410,7 +465,7 @@ const TabSlider = styled.div<{
   top: 0;
   bottom: 0;
   width: ${props => 100 / props.itemCount}%;
-  padding: 0 ${props => (props.size === 'small' ? '0' : '8px')};
+  ${sliderPadding}
   transition:
     all 0.3s ease,
     outline 0s,
@@ -436,9 +491,12 @@ const Spinner = styled(Indicator)`
   color: ${p => p.theme.colors.levels.deep};
 `;
 
-const StatusIconContainer = styled.div`
+const StatusIconContainer = styled(Flex)`
   position: absolute;
-  left: -${p => p.theme.space[5]}px;
+  transform: translate(100%, 0);
+  right: -${p => p.theme.space[1]}px;
+  top: 0;
+  bottom: 0;
 `;
 
 const TabContent = styled(Flex)`

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.story.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.story.tsx
@@ -25,7 +25,7 @@ import { ButtonPrimary } from 'design/Button';
 import Flex from 'design/Flex';
 import { Indicator } from 'design/Indicator';
 import Text from 'design/Text';
-import { Attempt, useAsync } from 'shared/hooks/useAsync';
+import { useAsync } from 'shared/hooks/useAsync';
 import { wait } from 'shared/utils/wait';
 
 import useResources from 'teleport/components/useResources';
@@ -37,6 +37,7 @@ import { Access } from 'teleport/services/user';
 import { YamlSupportedResourceKind } from 'teleport/services/yaml/types';
 import TeleportContextProvider from 'teleport/TeleportContextProvider';
 
+import { RoleDiffState } from '../Roles';
 import { RoleEditor } from './RoleEditor';
 import { RoleEditorDialog } from './RoleEditorDialog';
 import { unableToUpdatePreviewMessage } from './Shared';
@@ -49,12 +50,12 @@ const defaultGetAccessGraphRoleTesterEnabled =
 export default {
   title: 'Teleport/Roles/Role Editor',
   decorators: [
-    (Story, { parameters }) => {
+    (Story, { args, parameters }) => {
       const ctx = createTeleportContext();
       if (parameters.acl) {
         ctx.storeUser.getRoleAccess = () => parameters.acl;
       }
-      if (parameters.roleTesterEnabled) {
+      if (args.roleDiffEnabled) {
         cfg.isPolicyEnabled = true;
         storageService.getAccessGraphRoleTesterEnabled = () => true;
       }
@@ -303,70 +304,48 @@ export const noAccess: StoryObj = {
 };
 
 export const Dialog: StoryObj = {
-  render() {
-    const [open, setOpen] = useState(false);
-    const resources = useResources([], {});
-    return (
-      <>
-        <ButtonPrimary onClick={() => setOpen(true)}>Open</ButtonPrimary>
-        <RoleEditorDialog
-          resources={resources}
-          open={open}
-          onClose={() => setOpen(false)}
-          onSave={async () => setOpen(false)}
-        />
-      </>
-    );
-  },
-  parameters: {
-    msw: {
-      handlers: [yamlifyHandler, parseHandler],
-    },
-  },
-};
-
-export const DialogWithPolicyEnabled: StoryObj = {
-  render() {
-    const [open, setOpen] = useState(false);
-    const resources = useResources([], {});
-    const [roleDiffAttempt, mockGetDiff] = useAsync(() => wait(1000));
-    return (
-      <>
-        <ButtonPrimary onClick={() => setOpen(true)}>Open</ButtonPrimary>
-        <RoleEditorDialog
-          resources={resources}
-          roleDiffProps={getRoleDiffProps(roleDiffAttempt, mockGetDiff)}
-          open={open}
-          onClose={() => setOpen(false)}
-          onSave={async () => setOpen(false)}
-        />
-      </>
-    );
-  },
-  parameters: {
-    msw: {
-      handlers: [yamlifyHandler, parseHandler],
-    },
-    roleTesterEnabled: true,
-  },
-};
-
-export const AccessGraphError: StoryObj = {
-  render() {
+  render({
+    roleDiffEnabled,
+    roleDiffState,
+    accessGraphError,
+  }: {
+    roleDiffEnabled: boolean;
+    roleDiffState: RoleDiffState;
+    accessGraphError: boolean;
+  }) {
     const [open, setOpen] = useState(false);
     const resources = useResources([], {});
     const [roleDiffAttempt, mockGetDiff] = useAsync(async () => {
       await wait(1000);
-      throw new Error(unableToUpdatePreviewMessage, {
-        cause: new Error("There's a raccoon in the router"),
-      });
+      if (accessGraphError) {
+        throw new Error(unableToUpdatePreviewMessage, {
+          cause: new Error("There's a raccoon in the router"),
+        });
+      }
     });
+    const roleDiffProps = {
+      roleDiffElement: (
+        <Flex
+          flex="1"
+          alignItems="center"
+          justifyContent="center"
+          flexDirection="column"
+          gap="2"
+        >
+          <Text typography="h1">Access Graph Placeholder</Text>
+          {roleDiffAttempt.status === 'processing' && <Indicator />}
+        </Flex>
+      ),
+      updateRoleDiff: mockGetDiff,
+      roleDiffAttempt,
+      roleDiffState,
+    };
     return (
       <>
         <ButtonPrimary onClick={() => setOpen(true)}>Open</ButtonPrimary>
         <RoleEditorDialog
           resources={resources}
-          roleDiffProps={getRoleDiffProps(roleDiffAttempt, mockGetDiff)}
+          roleDiffProps={roleDiffEnabled ? roleDiffProps : undefined}
           open={open}
           onClose={() => setOpen(false)}
           onSave={async () => setOpen(false)}
@@ -378,29 +357,20 @@ export const AccessGraphError: StoryObj = {
     msw: {
       handlers: [yamlifyHandler, parseHandler],
     },
-    roleTesterEnabled: true,
+  },
+  argTypes: {
+    roleDiffState: {
+      control: { type: 'select' },
+      options: Object.values(RoleDiffState).filter(s => typeof s === 'string'),
+      mapping: RoleDiffState,
+    },
+  },
+  args: {
+    roleDiffEnabled: false,
+    roleDiffState: RoleDiffState.Disabled,
+    accessGraphError: false,
   },
 };
-
-const getRoleDiffProps = (
-  roleDiffAttempt: Attempt<unknown>,
-  getRoleDiff: () => void
-) => ({
-  roleDiffElement: (
-    <Flex
-      flex="1"
-      alignItems="center"
-      justifyContent="center"
-      flexDirection="column"
-      gap="2"
-    >
-      <Text typography="h1">Access Graph Placeholder</Text>
-      {roleDiffAttempt.status === 'processing' && <Indicator />}
-    </Flex>
-  ),
-  updateRoleDiff: getRoleDiff,
-  roleDiffAttempt,
-});
 
 const dummyRoleYaml = `kind: role
 metadata:

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.tsx
@@ -66,6 +66,8 @@ export type RoleEditorProps = {
   onSave?(r: Partial<RoleWithYaml>): Promise<void>;
   onRoleUpdate?(r: Role): void;
   demoMode?: boolean;
+  minimized?: boolean;
+  onMinimizedChange?(minimized: boolean): void;
 };
 
 /**
@@ -80,6 +82,8 @@ export const RoleEditor = ({
   onSave,
   onRoleUpdate,
   demoMode,
+  minimized = false,
+  onMinimizedChange,
 }: RoleEditorProps) => {
   const roleTesterEnabled =
     (cfg.isPolicyEnabled && storageService.getAccessGraphRoleTesterEnabled()) ||
@@ -262,6 +266,8 @@ export const RoleEditor = ({
                 standardEditorId={standardEditorId}
                 yamlEditorId={yamlEditorId}
                 onClose={confirmExit}
+                minimized={minimized}
+                onMinimizedChange={onMinimizedChange}
               />
               <AttemptAlert attempt={saveAttempt} />
               <AttemptAlert attempt={parseAttempt} />
@@ -269,41 +275,45 @@ export const RoleEditor = ({
               <AttemptAlert attempt={yamlPreviewAttempt} />
               <AttemptAlert attempt={roleDiffAttempt} />
             </Box>
-            {selectedEditorTab === EditorTab.Standard && (
-              <Flex flexDirection="column" flex="1" id={standardEditorId}>
-                <CatchError fallbackFn={StandardEditorRenderingError}>
-                  <StandardEditor
-                    originalRole={originalRole}
-                    onSave={object => handleSave({ object })}
-                    standardEditorModel={standardModel}
+            <ShowHide flexDirection="column" flex="1" hidden={minimized}>
+              {selectedEditorTab === EditorTab.Standard && (
+                <Flex flexDirection="column" flex="1" id={standardEditorId}>
+                  <CatchError fallbackFn={StandardEditorRenderingError}>
+                    <StandardEditor
+                      originalRole={originalRole}
+                      onSave={object => handleSave({ object })}
+                      standardEditorModel={standardModel}
+                      isProcessing={isProcessing}
+                      dispatch={dispatch}
+                    />
+                  </CatchError>
+                </Flex>
+              )}
+              {/* Hiding instead of unmounting the info alert allows us to keep
+                  the dismissed state throughout the lifetime of the role
+                  editor without keeping this state in the editor model. */}
+              <ShowHide hidden={selectedEditorTab !== EditorTab.Yaml}>
+                <Info dismissible mx={3} mb={3} alignItems="flex-start">
+                  Not all YAML edits can be represented in the standard editor.
+                  You may have to revert changes in the YAML if you return to
+                  using the standard editor.
+                </Info>
+              </ShowHide>
+              {selectedEditorTab === EditorTab.Yaml && (
+                <Flex flexDirection="column" flex="1" id={yamlEditorId}>
+                  <YamlEditor
+                    yamlEditorModel={yamlModel}
+                    onChange={setYamlModel}
+                    onSave={async yaml => void (await handleSave({ yaml }))}
                     isProcessing={isProcessing}
-                    dispatch={dispatch}
+                    originalRole={originalRole}
+                    onPreview={
+                      roleTesterEnabled ? handleYamlPreview : undefined
+                    }
                   />
-                </CatchError>
-              </Flex>
-            )}
-            {/* Hiding instead of unmounting the info alert allows us to keep
-                the dismissed state throughout the lifetime of the role editor
-                without keeping this state in the editor model. */}
-            <ShowHide hidden={selectedEditorTab !== EditorTab.Yaml}>
-              <Info dismissible mx={3} mb={3} alignItems="flex-start">
-                Not all YAML edits can be represented in the standard editor.
-                You may have to revert changes in the YAML if you return to
-                using the standard editor.
-              </Info>
+                </Flex>
+              )}
             </ShowHide>
-            {selectedEditorTab === EditorTab.Yaml && (
-              <Flex flexDirection="column" flex="1" id={yamlEditorId}>
-                <YamlEditor
-                  yamlEditorModel={yamlModel}
-                  onChange={setYamlModel}
-                  onSave={async yaml => void (await handleSave({ yaml }))}
-                  isProcessing={isProcessing}
-                  originalRole={originalRole}
-                  onPreview={roleTesterEnabled ? handleYamlPreview : undefined}
-                />
-              </Flex>
-            )}
           </Flex>
         )}
       </Validation>
@@ -369,6 +379,6 @@ const ErrorAlert = ({ error }: { error: Error }) =>
     </Danger>
   );
 
-const ShowHide = styled.div<{ hidden: boolean }>`
+const ShowHide = styled(Flex)<{ hidden: boolean }>`
   display: ${props => (props.hidden ? 'none' : '')};
 `;

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditorAdapter.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditorAdapter.tsx
@@ -16,8 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useCallback, useEffect } from 'react';
-import { useTheme } from 'styled-components';
+import { useCallback, useEffect, useState } from 'react';
+import styled, { useTheme } from 'styled-components';
 
 import { Danger } from 'design/Alert';
 import Flex from 'design/Flex';
@@ -32,7 +32,10 @@ import { YamlSupportedResourceKind } from 'teleport/services/yaml/types';
 
 import { RoleDiffState, RolesProps } from '../Roles';
 import { RoleEditor } from './RoleEditor';
-import { RoleEditorVisualizer } from './RoleEditorVisualizer';
+import {
+  RoleEditorVisualizer,
+  shouldShowRoleDiff,
+} from './RoleEditorVisualizer';
 
 /**
  * This component is responsible for converting from the `Resource`
@@ -49,6 +52,7 @@ export function RoleEditorAdapter({
   onSave: (role: Partial<RoleWithYaml>) => Promise<void>;
   onCancel: () => void;
 } & RolesProps) {
+  const showRoleDiff = roleDiffProps && shouldShowRoleDiff(roleDiffProps);
   const theme = useTheme();
   const [convertAttempt, convertToRole] = useAsync(
     async (yaml: string): Promise<RoleWithYaml | null> => {
@@ -64,6 +68,8 @@ export function RoleEditorAdapter({
     }
   );
 
+  const [editorMinimized, setEditorMinimized] = useState(false);
+
   const originalContent = resources.item?.content ?? '';
   useEffect(() => {
     convertToRole(originalContent);
@@ -75,15 +81,18 @@ export function RoleEditorAdapter({
   );
 
   return (
-    <Flex flex="1">
+    <Container flex="1">
       {/* This component's width influences how we lay out the permission
           checkboxes in AdminRules. */}
-      <Flex
+      <EditorPane
+        minimized={editorMinimized}
         flexDirection="column"
         borderLeft={1}
         borderColor={theme.colors.interactive.tonal.neutral[0]}
         backgroundColor={theme.colors.levels.surface}
-        width="550px"
+        width="35%"
+        minWidth="494px"
+        maxWidth="672px"
       >
         {convertAttempt.status === 'processing' && (
           <Flex
@@ -99,11 +108,6 @@ export function RoleEditorAdapter({
           <Danger>{convertAttempt.statusText}</Danger>
         )}
 
-        {/* TODO(bl-nero): Remove once RoleE doesn't set this attribute. */}
-        {roleDiffProps?.errorMessage && (
-          <Danger>{roleDiffProps.errorMessage}</Danger>
-        )}
-
         {convertAttempt.status === 'success' && (
           <RoleEditor
             originalRole={convertAttempt.data}
@@ -112,13 +116,37 @@ export function RoleEditorAdapter({
             onSave={onSave}
             onRoleUpdate={onRoleUpdate}
             demoMode={roleDiffProps?.roleDiffState === RoleDiffState.DemoReady}
+            minimized={editorMinimized}
+            onMinimizedChange={showRoleDiff ? setEditorMinimized : undefined}
           />
         )}
-      </Flex>
+      </EditorPane>
       <RoleEditorVisualizer
         roleDiffProps={roleDiffProps}
         currentFlow={resources.status === 'creating' ? 'creating' : 'updating'}
       />
-    </Flex>
+    </Container>
   );
 }
+
+const Container = styled(Flex)`
+  position: relative;
+`;
+
+const EditorPane = styled(Flex)<{ minimized: boolean }>`
+  position: ${props => (props.minimized ? 'absolute' : 'static')};
+  left: ${props => props.theme.space[4]}px;
+  top: ${props => props.theme.space[4]}px;
+
+  border-top-left-radius: ${props =>
+    props.minimized ? props.theme.radii[3] : 0}px;
+  border-top-right-radius: ${props => props.theme.radii[3]}px;
+  border-bottom-right-radius: ${props => props.theme.radii[3]}px;
+  border-bottom-left-radius: ${props =>
+    props.minimized ? props.theme.radii[3] : 0}px;
+  box-shadow: ${props => props.theme.boxShadow[3]};
+
+  // The editor pane needs to appear on top, even though it's before the
+  // visualizer in the DOM tree.
+  z-index: 1;
+`;

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditorVisualizer.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditorVisualizer.tsx
@@ -46,11 +46,7 @@ export function RoleEditorVisualizer({
     ctx.storeUser.state.acl.accessGraphSettings.edit;
   // the demo banner should show every time they load the role editor
   const [demoDismissed, setDemoDismissed] = useState(false);
-  if (
-    roleDiffProps &&
-    (roleDiffProps.roleDiffState === RoleDiffState.DemoReady ||
-      roleDiffProps.roleDiffState === RoleDiffState.PolicyEnabled)
-  ) {
+  if (roleDiffProps && shouldShowRoleDiff(roleDiffProps)) {
     return (
       <Flex
         flex="1"
@@ -103,5 +99,12 @@ export function RoleEditorVisualizer({
         currentFlow={currentFlow}
       />
     </Flex>
+  );
+}
+
+export function shouldShowRoleDiff(rdp: RoleDiffProps) {
+  return (
+    rdp.roleDiffState === RoleDiffState.DemoReady ||
+    rdp.roleDiffState === RoleDiffState.PolicyEnabled
   );
 }

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.test.tsx
@@ -142,7 +142,7 @@ test('invisible tabs still apply validation', async () => {
   expect(onSave).not.toHaveBeenCalled();
 
   // Switch back, make it valid.
-  await user.click(getTabByName('Invalid data Overview'));
+  await user.click(getTabByName('Overview Invalid data'));
   await user.type(screen.getByPlaceholderText('label key'), 'foo');
   await user.type(screen.getByPlaceholderText('label value'), 'bar');
   await user.click(screen.getByRole('button', { name: 'Save Changes' }));
@@ -178,15 +178,15 @@ test('hidden validation errors should not propagate to tab headings', async () =
 
   // Switch back. The newly invalid tabs should not bear the invalid indicator,
   // as the section has its validation errors hidden.
-  await user.click(getTabByName('Invalid data Overview'));
+  await user.click(getTabByName('Overview Invalid data'));
   expect(getTabByName('Resources')).toBeInTheDocument();
   expect(getTabByName('Admin Rules')).toBeInTheDocument();
 
   // Attempt to save, causing global validation. Now the invalid tabs should be
   // marked as invalid.
   await user.click(screen.getByRole('button', { name: 'Save Changes' }));
-  expect(getTabByName('Invalid data Resources')).toBeInTheDocument();
-  expect(getTabByName('Invalid data Admin Rules')).toBeInTheDocument();
+  expect(getTabByName('Resources Invalid data')).toBeInTheDocument();
+  expect(getTabByName('Admin Rules Invalid data')).toBeInTheDocument();
   expect(onSave).not.toHaveBeenCalled();
 });
 

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.tsx
@@ -139,6 +139,7 @@ export const StandardEditor = ({
       <Box mb={3} mx={3}>
         <SlideTabs
           appearance="round"
+          size="medium"
           hideStatusIconOnActiveTab
           tabs={[
             tabSpec(

--- a/web/packages/teleport/src/Roles/Roles.tsx
+++ b/web/packages/teleport/src/Roles/Roles.tsx
@@ -68,10 +68,6 @@ export type RoleDiffProps = {
   roleDiffElement: React.ReactNode;
   updateRoleDiff: (role: Role) => void;
 
-  /** @deprecated Use {@link RoleDiffProps.roleDiffAttempt} instead. */
-  // TODO(bl-nero): Remove this property once the Enterprise code is updated.
-  errorMessage?: string;
-
   /**
    * State of the attempt to fetch the information required by the role diff
    * visualizer. Required to show an error message in the editor UI.


### PR DESCRIPTION
Set minimum and maximum width of the editor and a default split ratio. Allow minimizing the editor when access graph is enabled.

To achieve this goal, this PR tweaks the internal structure of the `SlideTabs` component to allow tighter margins in the medium size. It also moves the alert icons to the right side of tab buttons, per the UX team's request.

[Demo](https://goteleport.zoom.us/clips/share/T1M4_SLrRRK6nMHMUqG40Q) (recorded with the minimum allowed editor width)

Contributes to https://github.com/gravitational/teleport/issues/52221