### PR TITLE
Fixing flaky test case in `TestPROXYEnabledListener_Accept`

### DIFF
--- a/lib/multiplexer/wrapper_test.go
+++ b/lib/multiplexer/wrapper_test.go
@@ -122,10 +122,6 @@ func TestPROXYEnabledListener_Accept(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			proto := "tcp"
 			listenAddr := "127.0.0.1:0"
-			if tt.allowDowngrade {
-				proto = "tcp6"
-				listenAddr = "[::1]:0"
-			}
 			listener, err := net.Listen(proto, listenAddr)
 			require.NoError(t, err)
 			t.Cleanup(func() { listener.Close() })


### PR DESCRIPTION
The proxy listener doesn't actually need to bind to an IPv6 address to properly exercise that the correct `RemoteAddr` is returned for the configured proxy line. The flaky test seems to be related to binding to `[::1]:0`, so this should resolve it.
