### PR TITLE
Tweak the role editor animations

### DIFF
--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditorDialog.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditorDialog.tsx
@@ -17,7 +17,7 @@
  */
 
 import { forwardRef, useRef } from 'react';
-import { Transition, TransitionStatus } from 'react-transition-group';
+import { CSSTransition } from 'react-transition-group';
 import { css } from 'styled-components';
 
 import Dialog from 'design/Dialog';
@@ -27,6 +27,8 @@ import { RoleWithYaml } from 'teleport/services/resources';
 
 import { RolesProps } from '../Roles';
 import { RoleEditorAdapter } from './RoleEditorAdapter';
+
+const animationDuration = 300;
 
 /**
  * Renders a full-screen dialog with a slide-in effect.
@@ -48,24 +50,21 @@ export function RoleEditorDialog({
 } & RolesProps) {
   const transitionRef = useRef<HTMLDivElement>();
   return (
-    <Transition
+    <CSSTransition
       in={open}
       nodeRef={transitionRef}
-      timeout={300}
+      timeout={animationDuration}
       mountOnEnter
       unmountOnExit
     >
-      {transitionState => (
-        <DialogInternal
-          ref={transitionRef}
-          onClose={onClose}
-          transitionState={transitionState}
-          resources={resources}
-          onSave={onSave}
-          roleDiffProps={roleDiffProps}
-        />
-      )}
-    </Transition>
+      <DialogInternal
+        ref={transitionRef}
+        onClose={onClose}
+        resources={resources}
+        onSave={onSave}
+        roleDiffProps={roleDiffProps}
+      />
+    </CSSTransition>
   );
 }
 
@@ -73,18 +72,18 @@ const DialogInternal = forwardRef<
   HTMLDivElement,
   {
     onClose(): void;
-    transitionState: TransitionStatus;
     resources: ResourcesState;
     onSave(role: Partial<RoleWithYaml>): Promise<void>;
   } & RolesProps
->(({ onClose, transitionState, resources, onSave, roleDiffProps }, ref) => {
+>(({ onClose, resources, onSave, roleDiffProps }, ref) => {
   return (
     <Dialog
-      dialogCss={() => fullScreenDialogCss()}
+      modalCss={() => modalCss}
       disableEscapeKeyDown={false}
       open={true}
-      ref={ref}
-      className={transitionState}
+      modalRef={ref}
+      BackdropProps={{ className: 'backdrop' }}
+      className="dialog"
     >
       <RoleEditorAdapter
         resources={resources}
@@ -96,33 +95,72 @@ const DialogInternal = forwardRef<
   );
 });
 
-const fullScreenDialogCss = () => css`
-  padding: 0;
-  width: 100%;
-  height: 100%;
-  max-height: 100%;
-  right: 0;
-  border-radius: 0;
-  overflow-y: hidden;
-  flex-direction: row;
-  background: ${props => props.theme.colors.levels.sunken};
-  transition: width 300ms ease-out;
-
-  &.entering {
-    right: -100%;
+const modalCss = css`
+  & .dialog {
+    padding: 0;
+    width: 100%;
+    height: 100%;
+    max-height: 100%;
+    right: 0;
+    border-radius: 0;
+    overflow-y: hidden;
+    flex-direction: row;
+    background: ${props => props.theme.colors.levels.sunken};
   }
 
-  &.entered {
-    right: 0px;
-    transition: right 300ms ease-out;
+  &.enter {
+    .backdrop {
+      opacity: 0;
+    }
+
+    .dialog {
+      transform: scale(0.8);
+      opacity: 0;
+    }
   }
 
-  &.exiting {
-    right: -100%;
-    transition: right 300ms ease-out;
+  &.enter-active {
+    .backdrop {
+      opacity: 100%;
+      // Chakra likes to globally disable transitions when mounting the access
+      // graph component, and it does so with an !important rule matching all
+      // elements. We override it with our own !important rule.
+      transition: opacity ${animationDuration}ms ease-out !important;
+    }
+
+    .dialog {
+      transform: scale(1);
+      opacity: 100%;
+      // See the comment above about the !important hack.
+      transition:
+        transform ${animationDuration}ms ease-out,
+        opacity ${animationDuration}ms ease-out !important;
+    }
   }
 
-  &.exited {
-    right: -100%;
+  &.exit {
+    .backdrop {
+      opacity: 100%;
+    }
+
+    .dialog {
+      transform: scale(1);
+      opacity: 100%;
+    }
+  }
+
+  &.exit-active {
+    .backdrop {
+      opacity: 0;
+      transition: opacity ${animationDuration}ms ease-in;
+    }
+
+    .dialog {
+      transform: scale(0.8);
+      opacity: 0;
+      transition:
+        transform ${animationDuration}ms ease-in,
+        opacity ${animationDuration}ms ease-in;
+    }
   }
 `;

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/sections.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/sections.tsx
@@ -243,7 +243,7 @@ export const SectionBox = ({
       {/* This element is the one being animated when the section is expanded
           or collapsed. */}
       <ContentExpander
-        height={expansionState === ExpansionState.Expanded ? contentHeight : 0}
+        height={contentExpanderHeight(contentHeight, expansionState)}
         onTransitionEnd={handleContentExpanderTransitionEnd}
       >
         {/* This element is measured, so its size must reflect the size of
@@ -255,6 +255,19 @@ export const SectionBox = ({
     </Box>
   );
 };
+
+function contentExpanderHeight(
+  contentHeight: number,
+  expansionState: ExpansionState
+) {
+  // `contentHeight` is 0 when it's not yet known. In this case, don't
+  // explicitly set the height; it will only cause a spurious opening animation
+  // after the first measurement is made.
+  if (contentHeight === 0) {
+    return undefined;
+  }
+  return expansionState === ExpansionState.Expanded ? contentHeight : 0;
+}
 
 const Summary = styled(Flex).attrs({ as: 'summary' })`
   cursor: pointer;


### PR DESCRIPTION
Change the opening and closing animation. To support this, add ability to get a ref to the backdrop element from the modals. Also tweak the `SectionBox` component to prevent opening animations on first rendering.

Demo:

https://github.com/user-attachments/assets/76d860db-dd70-4cb9-93fc-3debeb7c2665

Contributes to #https://github.com/gravitational/teleport/issues/52221