### PR TITLE
WASM: Fix SIMD support

### DIFF
--- a/web/packages/shared/libs/ironrdp/.cargo/config.toml
+++ b/web/packages/shared/libs/ironrdp/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-C", "target-feature=+simd128"]

--- a/web/packages/shared/libs/ironrdp/Cargo.toml
+++ b/web/packages/shared/libs/ironrdp/Cargo.toml
@@ -5,7 +5,8 @@ edition.workspace = true
 license.workspace = true
 publish.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-O", "--enable-simd"]
 
 [lib]
 crate-type = ["cdylib"]

--- a/web/packages/shared/package.json
+++ b/web/packages/shared/package.json
@@ -10,7 +10,7 @@
     "directory": "packages/shared"
   },
   "scripts": {
-    "build-wasm": "node ../../scripts/clean-up-ironrdp-artifacts.mjs && RUST_MIN_STACK=16777216 RUSTFLAGS=-Ctarget-feature=+simd128 wasm-pack build ./libs/ironrdp --target web"
+    "build-wasm": "node ../../scripts/clean-up-ironrdp-artifacts.mjs && RUST_MIN_STACK=16777216 wasm-pack build ./libs/ironrdp --target web"
   },
   "dependencies": {
     "@gravitational/design": "workspace:*",


### PR DESCRIPTION
1. Set RUSTFLAGS via a cargo config file instead of via env var. This ensures that we're only enabling SIMD when compiling the WASM binary (otherwise the env var was picked up when wasm-pack does a bunch of cargo install operations).
2. Explicitly pass --enable-simd to wasm-opt.