### PR TITLE
[teleport-update] Stop writing updater ID from teleport-update

### DIFF
--- a/lib/autoupdate/agent/config.go
+++ b/lib/autoupdate/agent/config.go
@@ -250,6 +250,8 @@ type Status struct {
 	UpdateSpec   `yaml:",inline"`
 	UpdateStatus `yaml:",inline"`
 	FindResp     `yaml:",inline"`
+	// ID is the updater ID.
+	ID string `yaml:"id,omitempty"`
 }
 
 // FindResp summarizes the auto-update status response from cluster.
@@ -262,6 +264,4 @@ type FindResp struct {
 	Jitter time.Duration `yaml:"jitter"`
 	// AGPL installations cannot use the official CDN.
 	AGPL bool `yaml:"agpl,omitempty"`
-	// ID provided to the updater.
-	ID string `yaml:"id,omitempty"`
 }

--- a/lib/autoupdate/agent/setup.go
+++ b/lib/autoupdate/agent/setup.go
@@ -31,7 +31,6 @@ import (
 	"text/template"
 
 	"github.com/google/renameio/v2"
-	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"gopkg.in/yaml.v3"
 
@@ -208,27 +207,6 @@ func (ns *Namespace) Init() (lockFile string, err error) {
 		return "", trace.Wrap(err)
 	}
 	return filepath.Join(ns.Dir(), lockFileName), nil
-}
-
-// EnsureID ensures the updater ID file is present, creating it if it does not exist.
-// EnsureID always returns the path to the updater ID file.
-func (ns *Namespace) EnsureID() (path string, err error) {
-	_, err = os.Lstat(ns.updaterIDFile)
-	if errors.Is(err, fs.ErrNotExist) {
-		id, err := uuid.NewRandom()
-		if err != nil {
-			return ns.updaterIDFile, trace.Wrap(err)
-		}
-		err = renameio.WriteFile(ns.updaterIDFile, []byte(id.String()), configFileMode)
-		if err != nil {
-			return ns.updaterIDFile, trace.Wrap(err)
-		}
-		return ns.updaterIDFile, nil
-	}
-	if err != nil {
-		return ns.updaterIDFile, trace.Wrap(err)
-	}
-	return ns.updaterIDFile, nil
 }
 
 // Setup installs service and timer files for the teleport-update binary.

--- a/lib/autoupdate/agent/setup_test.go
+++ b/lib/autoupdate/agent/setup_test.go
@@ -344,58 +344,6 @@ func TestNamespace_overrideFromConfig(t *testing.T) {
 	}
 }
 
-func TestNamespace_EnsureID(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name   string
-		exists bool
-		fails  bool
-	}{
-		{
-			name: "does not exist",
-		},
-		{
-			name:   "exists",
-			exists: true,
-		},
-		{
-			name:  "fails",
-			fails: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ns := &Namespace{
-				log:           slog.Default(),
-				updaterIDFile: filepath.Join(t.TempDir(), "id"),
-			}
-			if tt.exists {
-				err := os.WriteFile(ns.updaterIDFile, []byte("test"), os.ModePerm)
-				require.NoError(t, err)
-			}
-			if tt.fails {
-				ns.updaterIDFile = ""
-			}
-			p, err := ns.EnsureID()
-			require.Equal(t, ns.updaterIDFile, p)
-			if tt.fails {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-			b, err := os.ReadFile(ns.updaterIDFile)
-			require.NoError(t, err)
-
-			if tt.exists {
-				require.Equal(t, "test", string(b))
-			} else {
-				require.Len(t, b, 36)
-			}
-		})
-	}
-}
-
 // In the future, the latest version of the updater may need to read a version of teleport.yaml that has
 // an unsupported version which is supported by the updater-managed version of Teleport.
 // This test will break if Teleport removes a field that the updater reads.

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -618,7 +618,7 @@ func (u *Updater) readID(ctx context.Context) string {
 	}
 	out, err := FindDBPID(u.UpdateIDFile, bytes.TrimSpace(mid), bytes.TrimSpace(tid), false)
 	if err != nil {
-		u.Log.ErrorContext(ctx, "Unable to generate unique ID for this host.")
+		u.Log.ErrorContext(ctx, "Unable to generate unique ID for this host.", errorKey, err)
 		u.Log.ErrorContext(ctx, "The Teleport agent may not be tracked, and may fail if used as a canary.")
 		return ""
 	}

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -21,8 +21,10 @@ package agent
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/asn1"
 	"errors"
 	"io/fs"
 	"log/slog"
@@ -36,6 +38,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/client/webclient"
@@ -50,6 +53,8 @@ import (
 const (
 	// BinaryName specifies the name of the updater binary.
 	BinaryName = "teleport-update"
+	// SystemdMachineIDFile is a path containing a machine-unique identifier created by systemd.
+	SystemdMachineIDFile = "/etc/machine-id"
 )
 
 const (
@@ -64,6 +69,8 @@ const (
 	// requiredUmask must be set before this package can be used.
 	// Use syscall.Umask to set when no other goroutines are running.
 	requiredUmask = 0o022
+	// teleportHostIDFileName is the name of Teleport's host ID file.
+	teleportHostIDFileName = "host_uuid"
 )
 
 // Log keys
@@ -126,6 +133,9 @@ func NewLocalUpdater(cfg LocalUpdaterConfig, ns *Namespace) (*Updater, error) {
 		Pool:                certPool,
 		InsecureSkipVerify:  cfg.InsecureSkipVerify,
 		UpdateConfigFile:    filepath.Join(ns.Dir(), updateConfigName),
+		UpdateIDFile:        ns.updaterIDFile,
+		MachineIDFile:       SystemdMachineIDFile,
+		TeleportIDFile:      filepath.Join(ns.dataDir, teleportHostIDFileName),
 		TeleportConfigFile:  ns.configFile,
 		TeleportServiceName: filepath.Base(ns.serviceFile),
 		DefaultProxyAddr:    ns.defaultProxyAddr,
@@ -176,7 +186,6 @@ func NewLocalUpdater(cfg LocalUpdaterConfig, ns *Namespace) (*Updater, error) {
 		SetupNamespace:    ns.Setup,
 		TeardownNamespace: ns.Teardown,
 		LogConfigWarnings: ns.LogWarnings,
-		EnsureUpdateID:    ns.EnsureID,
 	}, nil
 }
 
@@ -211,6 +220,13 @@ type Updater struct {
 	InsecureSkipVerify bool
 	// UpdateConfigFile contains the path to the agent auto-updates configuration.
 	UpdateConfigFile string
+	// UpdateIDFile contains the path to the ID used to track the Teleport agent during updates.
+	// This ID is written and read by the Teleport agent and used to schedule progressive updates.
+	UpdateIDFile string
+	// MachineIDFile contains the path to a system-unique ID file.
+	MachineIDFile string
+	// TeleportIDFile contains the path to Teleport's host ID.
+	TeleportIDFile string
 	// TeleportConfigFile contains the path to Teleport's configuration.
 	TeleportConfigFile string
 	// TeleportServiceName contains the full name of the systemd service for Teleport
@@ -232,9 +248,6 @@ type Updater struct {
 	TeardownNamespace func(ctx context.Context) error
 	// LogConfigWarnings logs warnings related to the configuration Namespace.
 	LogConfigWarnings func(ctx context.Context, pathDir string)
-	// EnsureUpdateID generates and/or retrieves an ID for the updater, ensuring it is persisted.
-	// This ID is read by the Teleport agent and used to schedule progressive updates.
-	EnsureUpdateID func() (string, error)
 }
 
 // Installer provides an API for installing Teleport agents.
@@ -364,11 +377,6 @@ func (u *Updater) Install(ctx context.Context, override OverrideConfig) error {
 	if err := validateConfigSpec(&cfg.Spec, override); err != nil {
 		return trace.Wrap(err)
 	}
-	// Always ensure the ID file is created, even if we do not write the path to disk on this run.
-	cfg.Status.IDFile, err = u.EnsureUpdateID()
-	if err != nil {
-		u.Log.ErrorContext(ctx, "Failed to write updater ID file. Update tracking is degraded.", "id_file", cfg.Status.IDFile, errorKey, err)
-	}
 
 	if cfg.Spec.Proxy == "" {
 		cfg.Spec.Proxy = u.DefaultProxyAddr
@@ -381,13 +389,14 @@ func (u *Updater) Install(ctx context.Context, override OverrideConfig) error {
 	if cfg.Spec.Path == "" {
 		cfg.Spec.Path = u.DefaultPathDir
 	}
+	cfg.Status.IDFile = u.UpdateIDFile
 
 	active := cfg.Status.Active
 	skip := deref(cfg.Status.Skip)
 
 	// Lookup target version from the proxy.
 
-	resp, err := u.find(ctx, cfg)
+	resp, err := u.find(ctx, cfg, u.readID(ctx))
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -589,18 +598,103 @@ func (u *Updater) removeWithoutSystem(ctx context.Context, cfg *UpdateConfig) er
 	return nil
 }
 
-// readID returns the update ID, if present on disk.
+// readID generates a DBPID based on both the systemd machine ID and Teleport host ID.
+// This reduces the chance that multiple hosts will have the same updater ID, while
+// allowing both the teleport and teleport-update binaries to deterministically derive
+// the same value. This also avoids issues caused by non-UUID values in host_uuid,
+// and ensures that updaters without running agents have a unique value.
+// The ID must be persisted to ensure it does not change between Teleport updates.
+// Only the Teleport Agent may persist the ID, as it may start first at system boot and must
+// know the value immediately when it starts.
 // Errors will be logged.
-func (u *Updater) readID(ctx context.Context, path string) string {
-	idBytes, err := os.ReadFile(path)
-	if errors.Is(err, fs.ErrNotExist) {
+func (u *Updater) readID(ctx context.Context) string {
+	tid, err := os.ReadFile(u.TeleportIDFile)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		u.Log.WarnContext(ctx, "Failed to read Teleport host ID.", "path", u.TeleportIDFile, errorKey, err)
+	}
+	mid, err := os.ReadFile(u.MachineIDFile)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		u.Log.WarnContext(ctx, "Failed to read systemd machine ID.", "path", u.MachineIDFile, errorKey, err)
+	}
+	out, err := FindDBPID(u.UpdateIDFile, bytes.TrimSpace(mid), bytes.TrimSpace(tid), false)
+	if err != nil {
+		u.Log.ErrorContext(ctx, "Unable to generate unique ID for this host.")
+		u.Log.ErrorContext(ctx, "The Teleport agent may not be tracked, and may fail if used as a canary.")
 		return ""
 	}
+	return out
+}
+
+func readIfPresent(path string) string {
+	idBytes, err := os.ReadFile(path)
 	if err != nil {
-		u.Log.ErrorContext(ctx, "Failed to read update ID file.", "path", path, errorKey, err)
 		return ""
 	}
 	return string(bytes.TrimSpace(idBytes))
+}
+
+// FindDBPID returns a deterministic boot-persistent identifier (DBPID).
+// This is a sha256-based UUIDv5 that is regenerated at each boot using a
+// machine-derived identifier and a namespace identifier.
+// DBPIDs are stable across reboots as long as their identifiers remain the
+// same and the logic implementing the ID generation remains the same.
+// This reduces the risk that the ID changes unexpectedly when a new version
+// of the process in launched, because both the system must be rebooted
+// and the IDs (or logic) must change for the DBPID to change.
+// ASN.1 is used to support binary identifiers and to ensure stability across
+// versions of the Go standard library.
+//
+// It is safe for other code to read path directly to determine the cached DBPID.
+// FindDBPID may be called concurrently on the same path with persist set to false.
+// Calls with persist set to true are not reentrant.
+func FindDBPID(path string, systemID, namespaceID []byte, persist bool) (string, error) {
+	idBytes, err := os.ReadFile(path)
+	if err == nil {
+		return string(bytes.TrimSpace(idBytes)), nil
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		return "", err
+	}
+	id, err := generateDBPID(systemID, namespaceID)
+	if err != nil {
+		return id, trace.Wrap(err)
+	}
+	if persist {
+		err = writeFileAtomicWithinDir(path, []byte(id), configFileMode)
+	}
+	return id, trace.Wrap(err)
+}
+
+func generateDBPID(systemID, namespaceID []byte) (string, error) {
+	/*
+		--- ASN.1 Schema
+
+		DBPID DEFINITIONS  ::=  BEGIN
+		    DBPID  ::=  SEQUENCE  {
+		        systemID     OCTET STRING,
+		        namespaceID  OCTET STRING
+		    }
+		END
+	*/
+
+	// changing this struct will change all hashes
+	obj := struct {
+		SID  []byte
+		NSID []byte
+	}{
+		SID:  systemID,
+		NSID: namespaceID,
+	}
+	if len(obj.SID) == 0 && len(obj.NSID) == 0 {
+		return "", trace.BadParameter("all provided IDs are empty")
+	}
+	der, err := asn1.Marshal(obj)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	// this only uses the first 16 bytes of the sha256 hash, which is acceptable
+	// for uniquely identify agents connected to a cluster
+	return uuid.NewHash(sha256.New(), uuid.Nil, der, 5).String(), nil
 }
 
 // Status returns all available local and remote fields related to agent auto-updates.
@@ -623,12 +717,13 @@ func (u *Updater) Status(ctx context.Context) (Status, error) {
 	out.UpdateStatus = cfg.Status
 
 	// Lookup target version from the proxy.
-	resp, err := u.find(ctx, cfg)
+	out.ID = readIfPresent(cfg.Status.IDFile)
+	resp, err := u.find(ctx, cfg, out.ID)
 	if err != nil {
 		return out, trace.Wrap(err)
 	}
 	out.FindResp = resp
-	out.IDFile = "" // actual ID is is find response
+	out.IDFile = ""
 	return out, nil
 }
 
@@ -682,11 +777,6 @@ func (u *Updater) Update(ctx context.Context, now bool) error {
 	if err := validateConfigSpec(&cfg.Spec, OverrideConfig{}); err != nil {
 		return trace.Wrap(err)
 	}
-	// Always ensure the ID file is created, even if we do not write the path to disk on this run.
-	cfg.Status.IDFile, err = u.EnsureUpdateID()
-	if err != nil {
-		u.Log.ErrorContext(ctx, "Failed to write updater ID file. Update tracking is degraded.", "id_file", cfg.Status.IDFile, errorKey, err)
-	}
 
 	active := cfg.Status.Active
 	skip := deref(cfg.Status.Skip)
@@ -704,8 +794,9 @@ func (u *Updater) Update(ctx context.Context, now bool) error {
 	if cfg.Spec.Path == "" {
 		return trace.Errorf("failed to read destination path for binary links from %s", updateConfigName)
 	}
+	cfg.Status.IDFile = u.UpdateIDFile
 
-	resp, err := u.find(ctx, cfg)
+	resp, err := u.find(ctx, cfg, u.readID(ctx))
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -785,7 +876,7 @@ func (u *Updater) Update(ctx context.Context, now bool) error {
 	return trace.NewAggregate(updateErr, writeErr)
 }
 
-func (u *Updater) find(ctx context.Context, cfg *UpdateConfig) (FindResp, error) {
+func (u *Updater) find(ctx context.Context, cfg *UpdateConfig, id string) (FindResp, error) {
 	if cfg.Spec.Proxy == "" {
 		return FindResp{}, trace.Errorf("Teleport proxy URL must be specified with --proxy or present in %s", updateConfigName)
 	}
@@ -793,7 +884,6 @@ func (u *Updater) find(ctx context.Context, cfg *UpdateConfig) (FindResp, error)
 	if err != nil {
 		return FindResp{}, trace.Wrap(err, "failed to parse proxy server address")
 	}
-	id := u.readID(ctx, cfg.Status.IDFile)
 	resp, err := webclient.Find(&webclient.Config{
 		Context:     ctx,
 		ProxyAddr:   addr.Addr,
@@ -827,7 +917,6 @@ func (u *Updater) find(ctx context.Context, cfg *UpdateConfig) (FindResp, error)
 		InWindow: resp.AutoUpdate.AgentAutoUpdate,
 		Jitter:   time.Duration(jitterSec) * time.Second,
 		AGPL:     agpl,
-		ID:       id,
 	}, nil
 }
 

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -649,11 +649,11 @@ func readIfPresent(path string) string {
 // Calls with persist set to true are not reentrant.
 func FindDBPID(path string, systemID, namespaceID []byte, persist bool) (string, error) {
 	idBytes, err := os.ReadFile(path)
-	if err == nil {
-		return string(bytes.TrimSpace(idBytes)), nil
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return "", trace.Wrap(err)
 	}
-	if !errors.Is(err, fs.ErrNotExist) {
-		return "", err
+	if s := bytes.TrimSpace(idBytes); err == nil && len(s) > 0 {
+		return string(s), nil
 	}
 	id, err := generateDBPID(systemID, namespaceID)
 	if err != nil {

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -53,8 +53,6 @@ import (
 const (
 	// BinaryName specifies the name of the updater binary.
 	BinaryName = "teleport-update"
-	// SystemdMachineIDFile is a path containing a machine-unique identifier created by systemd.
-	SystemdMachineIDFile = "/etc/machine-id"
 )
 
 const (
@@ -71,6 +69,8 @@ const (
 	requiredUmask = 0o022
 	// teleportHostIDFileName is the name of Teleport's host ID file.
 	teleportHostIDFileName = "host_uuid"
+	// systemdMachineIDFile is a path containing a machine-unique identifier created by systemd.
+	systemdMachineIDFile = "/etc/machine-id"
 )
 
 // Log keys
@@ -134,7 +134,7 @@ func NewLocalUpdater(cfg LocalUpdaterConfig, ns *Namespace) (*Updater, error) {
 		InsecureSkipVerify:  cfg.InsecureSkipVerify,
 		UpdateConfigFile:    filepath.Join(ns.Dir(), updateConfigName),
 		UpdateIDFile:        ns.updaterIDFile,
-		MachineIDFile:       SystemdMachineIDFile,
+		MachineIDFile:       systemdMachineIDFile,
 		TeleportIDFile:      filepath.Join(ns.dataDir, teleportHostIDFileName),
 		TeleportConfigFile:  ns.configFile,
 		TeleportServiceName: filepath.Base(ns.serviceFile),

--- a/lib/autoupdate/agent/updater_test.go
+++ b/lib/autoupdate/agent/updater_test.go
@@ -744,6 +744,7 @@ func TestUpdater_Update(t *testing.T) {
 			ns := &Namespace{
 				installDir:     dir,
 				defaultPathDir: "ignored",
+				updaterIDFile:  "updater-id-file",
 			}
 			_, err := ns.Init()
 			require.NoError(t, err)
@@ -835,9 +836,6 @@ func TestUpdater_Update(t *testing.T) {
 			updater.SetupNamespace = func(_ context.Context, path string) error {
 				revertSetupCalls++
 				return nil
-			}
-			updater.EnsureUpdateID = func() (string, error) {
-				return "updater-id-file", nil
 			}
 
 			ctx := context.Background()
@@ -1675,6 +1673,7 @@ func TestUpdater_Install(t *testing.T) {
 				installDir:       dir,
 				defaultPathDir:   defaultPathDir,
 				defaultProxyAddr: "default-proxy",
+				updaterIDFile:    "updater-id-file",
 			}
 			_, err := ns.Init()
 			require.NoError(t, err)
@@ -1777,9 +1776,6 @@ func TestUpdater_Install(t *testing.T) {
 			updater.SetupNamespace = func(_ context.Context, path string) error {
 				revertSetupCalls++
 				return nil
-			}
-			updater.EnsureUpdateID = func() (string, error) {
-				return "updater-id-file", nil
 			}
 
 			ctx := context.Background()
@@ -1979,6 +1975,103 @@ func TestUpdater_Setup(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.errMatch)
 			} else {
 				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestFindDBPID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		existingID  string
+		systemID    string
+		namespaceID string
+		persist     bool
+
+		result   string
+		resFile  string
+		errMatch string
+	}{
+		{
+			name:     "no ids",
+			errMatch: "empty",
+		},
+		{
+			name:        "both ids",
+			systemID:    "test1",
+			namespaceID: "test2",
+			result:      "2c652f3c-ae11-5e5a-ba40-73cba91149cd",
+		},
+		{
+			name:     "systemID",
+			systemID: "test1",
+			result:   "6abf58ef-f6cc-55ae-91e2-376af6b0ba90",
+		},
+		{
+			name:        "systemID matching namespaceID",
+			namespaceID: "test1",
+			result:      "35321002-ed1c-51e3-a3b3-cbf0f0bc2d88",
+		},
+		{
+			name:        "namespaceID",
+			namespaceID: "test2",
+			result:      "906a648e-038b-576a-893e-d6b32a9d8aee",
+		},
+		{
+			name:     "namespaceID matching systemID",
+			systemID: "test2",
+			result:   "42929c01-bcc8-5a49-af36-e5f21344d5f5",
+		},
+		{
+			name:        "existing file not replaced",
+			existingID:  "existing",
+			systemID:    "test1",
+			namespaceID: "test2",
+			result:      "existing",
+			resFile:     "existing",
+		},
+		{
+			name:        "existing file not replaced on persist",
+			existingID:  "existing",
+			systemID:    "test1",
+			namespaceID: "test2",
+			persist:     true,
+			result:      "existing",
+			resFile:     "existing",
+		},
+		{
+			name:        "persisted when missing",
+			systemID:    "test1",
+			namespaceID: "test2",
+			persist:     true,
+			result:      "2c652f3c-ae11-5e5a-ba40-73cba91149cd",
+			resFile:     "2c652f3c-ae11-5e5a-ba40-73cba91149cd",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			existing := filepath.Join(t.TempDir(), "existing")
+			if tt.existingID != "" {
+				err := os.WriteFile(existing, []byte(tt.existingID), os.ModePerm)
+				require.NoError(t, err)
+			}
+			s, err := FindDBPID(existing, []byte(tt.systemID), []byte(tt.namespaceID), tt.persist)
+			if tt.errMatch != "" {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.result, s)
+
+			if tt.resFile != "" {
+				b, err := os.ReadFile(existing)
+				require.NoError(t, err)
+				require.Equal(t, tt.resFile, string(b))
+			} else {
+				require.NoFileExists(t, existing)
 			}
 		})
 	}


### PR DESCRIPTION
After discussing with @hugoShaka, we are going to use a combination of the Teleport host ID and `/etc/machine-id` to derive a unique updater ID for the host. This will make it easier to avoid race conditions between `teleport-update` and `teleport`, where they could both attempt to write the ID and disagree about the resulting value. Additionally, this will ensure that all agents have a unique ID, even when the host_uuid or `/etc/machine-id` are cloned by mistake.

---

The `teleport-update` binary is used to enable, disable, and trigger automatic Teleport agent updates. The new Managed Updates system manages a local installation of the cluster-specified version of Teleport stored in `/opt/teleport`.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/11856