### PR TITLE
Report updater info in Hello

### DIFF
--- a/lib/autoupdate/agent/integrations.go
+++ b/lib/autoupdate/agent/integrations.go
@@ -30,7 +30,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/types"
 )
 
 const (
@@ -185,8 +185,8 @@ func findParentMatching(dir, name string, rpos int) string {
 // that can be reported in the inventory hello message.
 // This function performs io operations, its usage must be cached
 // (the downstream inventory handler does this for us).
-func ReadHelloUpdaterInfo(ctx context.Context, log *slog.Logger, hostUUID string) (*proto.UpdaterV2Info, error) {
-	info := &proto.UpdaterV2Info{}
+func ReadHelloUpdaterInfo(ctx context.Context, log *slog.Logger, hostUUID string) (*types.UpdaterV2Info, error) {
+	info := &types.UpdaterV2Info{}
 
 	configPath := os.Getenv(updateConfigFileEnvVar)
 	if configPath == "" {
@@ -219,11 +219,11 @@ func ReadHelloUpdaterInfo(ctx context.Context, log *slog.Logger, hostUUID string
 
 	switch {
 	case !cfg.Spec.Enabled:
-		info.UpdaterStatus = proto.UpdaterStatus_UPDATER_STATUS_DISABLED
+		info.UpdaterStatus = types.UpdaterStatus_UPDATER_STATUS_DISABLED
 	case cfg.Spec.Pinned:
-		info.UpdaterStatus = proto.UpdaterStatus_UPDATER_STATUS_PINNED
+		info.UpdaterStatus = types.UpdaterStatus_UPDATER_STATUS_PINNED
 	default:
-		info.UpdaterStatus = proto.UpdaterStatus_UPDATER_STATUS_OK
+		info.UpdaterStatus = types.UpdaterStatus_UPDATER_STATUS_OK
 	}
 	return info, nil
 }

--- a/lib/inventory/controller_test.go
+++ b/lib/inventory/controller_test.go
@@ -1049,9 +1049,11 @@ func TestUpdateLabels(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	downstreamHandle := NewDownstreamHandle(func(ctx context.Context) (client.DownstreamInventoryControlStream, error) {
+	downstreamHandle, err := NewDownstreamHandle(func(ctx context.Context) (client.DownstreamInventoryControlStream, error) {
 		return downstream, nil
-	}, upstreamHello)
+	}, func(_ context.Context) (proto.UpstreamInventoryHello, error) { return upstreamHello, nil })
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, downstreamHandle.Close()) })
 
 	// Wait for upstream hello.
 	select {
@@ -1111,11 +1113,11 @@ func TestAgentMetadata(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	NewDownstreamHandle(
+	inventoryHandle, err := NewDownstreamHandle(
 		func(ctx context.Context) (client.DownstreamInventoryControlStream, error) {
 			return downstream, nil
 		},
-		upstreamHello,
+		func(ctx context.Context) (proto.UpstreamInventoryHello, error) { return upstreamHello, nil },
 		withMetadataGetter(func(ctx context.Context) (*metadata.Metadata, error) {
 			return &metadata.Metadata{
 				OS:                    "llamaOS",
@@ -1129,6 +1131,8 @@ func TestAgentMetadata(t *testing.T) {
 			}, nil
 		}),
 	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, inventoryHandle.Close()) })
 
 	// Wait for upstream hello.
 	select {
@@ -1198,9 +1202,11 @@ func TestGoodbye(t *testing.T) {
 
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			handle := NewDownstreamHandle(func(ctx context.Context) (client.DownstreamInventoryControlStream, error) {
+			handle, err := NewDownstreamHandle(func(ctx context.Context) (client.DownstreamInventoryControlStream, error) {
 				return downstream, nil
-			}, upstreamHello)
+			}, func(ctx context.Context) (proto.UpstreamInventoryHello, error) { return upstreamHello, nil })
+			require.NoError(t, err)
+			// downstream handler is closed later in the test, no need to defer the cleanup
 
 			// Wait for upstream hello.
 			select {
@@ -1507,9 +1513,11 @@ func TestGetSender(t *testing.T) {
 		Services: []types.SystemRole{types.RoleNode, types.RoleApp},
 	}
 
-	handle := NewDownstreamHandle(func(ctx context.Context) (client.DownstreamInventoryControlStream, error) {
+	handle, err := NewDownstreamHandle(func(ctx context.Context) (client.DownstreamInventoryControlStream, error) {
 		return downstream, nil
-	}, upstreamHello)
+	}, func(ctx context.Context) (proto.UpstreamInventoryHello, error) { return upstreamHello, nil })
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, handle.Close()) })
 
 	// Validate that the sender is not present prior to
 	// the stream becoming healthy.

--- a/lib/kube/grpc/utils_test.go
+++ b/lib/kube/grpc/utils_test.go
@@ -228,12 +228,17 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 	testCtx.kubeProxyListener, err = net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	inventoryHandle := inventory.NewDownstreamHandle(client.InventoryControlStream, proto.UpstreamInventoryHello{
-		ServerID: testCtx.HostID,
-		Version:  teleport.Version,
-		Services: []types.SystemRole{types.RoleKube},
-		Hostname: "test",
-	})
+	inventoryHandle, err := inventory.NewDownstreamHandle(client.InventoryControlStream,
+		func(ctx context.Context) (proto.UpstreamInventoryHello, error) {
+			return proto.UpstreamInventoryHello{
+				ServerID: testCtx.HostID,
+				Version:  teleport.Version,
+				Services: []types.SystemRole{types.RoleKube},
+				Hostname: "test",
+			}, nil
+		})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, inventoryHandle.Close()) })
 
 	// Create kubernetes service server.
 	testCtx.KubeServer, err = proxy.NewTLSServer(proxy.TLSServerConfig{

--- a/lib/kube/proxy/utils_test.go
+++ b/lib/kube/proxy/utils_test.go
@@ -227,12 +227,17 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 	testCtx.kubeProxyListener, err = net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	inventoryHandle := inventory.NewDownstreamHandle(client.InventoryControlStream, proto.UpstreamInventoryHello{
-		ServerID: testCtx.HostID,
-		Version:  teleport.Version,
-		Services: []types.SystemRole{types.RoleKube},
-		Hostname: "test",
-	})
+	inventoryHandle, err := inventory.NewDownstreamHandle(client.InventoryControlStream,
+		func(_ context.Context) (proto.UpstreamInventoryHello, error) {
+			return proto.UpstreamInventoryHello{
+				ServerID: testCtx.HostID,
+				Version:  teleport.Version,
+				Services: []types.SystemRole{types.RoleKube},
+				Hostname: "test",
+			}, nil
+		})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, inventoryHandle.Close()) })
 
 	// Create kubernetes service server.
 	testCtx.KubeServer, err = NewTLSServer(TLSServerConfig{

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1275,6 +1275,9 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 		getHello,
 		inventory.WithDownstreamClock(process.Clock),
 	)
+	if err != nil {
+		return nil, trace.Wrap(err, "building inventory handle")
+	}
 
 	process.inventoryHandle.RegisterPingHandler(func(sender inventory.DownstreamSender, ping proto.DownstreamInventoryPing) {
 		systemClock := process.Clock.Now().UTC()

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1257,7 +1257,7 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 		}
 
 		if upgraderKind == types.UpgraderKindTeleportUpdate {
-			info, err := autoupdate.ReadHelloUpdaterInfo()
+			info, err := autoupdate.ReadHelloUpdaterInfo(supervisor.ExitContext(), cfg.Logger, cfg.HostUUID)
 			if err != nil {
 				// Failing to detect teleport-update info is not fatal, we continue.
 				cfg.Logger.WarnContext(supervisor.ExitContext(), "Error recovering teleport-update status, this might affect automatic update tracking and progress.", "error", err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1261,9 +1261,9 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 			if err != nil {
 				// Failing to detect teleport-update info is not fatal, we continue.
 				cfg.Logger.WarnContext(supervisor.ExitContext(), "Error recovering teleport-update status, this might affect automatic update tracking and progress.", "error", err)
-				info = &proto.UpdaterV2Info{UpdaterStatus: proto.UpdaterStatus_UPDATER_STATUS_UNREADABLE}
+				info = &types.UpdaterV2Info{UpdaterStatus: types.UpdaterStatus_UPDATER_STATUS_UNREADABLE}
 			}
-			hello.UpdaterV2Info = info
+			hello.UpdaterInfo = info
 		}
 		return hello, nil
 	}

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -374,12 +374,17 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 	})
 	require.NoError(t, err)
 
-	inventoryHandle := inventory.NewDownstreamHandle(s.authClient.InventoryControlStream, proto.UpstreamInventoryHello{
-		ServerID: s.hostUUID,
-		Version:  teleport.Version,
-		Services: []types.SystemRole{types.RoleApp},
-		Hostname: "test",
-	})
+	inventoryHandle, err := inventory.NewDownstreamHandle(s.authClient.InventoryControlStream,
+		func(ctx context.Context) (proto.UpstreamInventoryHello, error) {
+			return proto.UpstreamInventoryHello{
+				ServerID: s.hostUUID,
+				Version:  teleport.Version,
+				Services: []types.SystemRole{types.RoleApp},
+				Hostname: "test",
+			}, nil
+		})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, inventoryHandle.Close()) })
 
 	s.appServer, err = New(s.closeContext, &Config{
 		Clock:              s.clock,

--- a/lib/srv/heartbeatv2_test.go
+++ b/lib/srv/heartbeatv2_test.go
@@ -139,7 +139,7 @@ func newFakeHeartbeatDriver(t *testing.T) *fakeHeartbeatDriver {
 		Services: []types.SystemRole{types.RoleNode},
 	}
 
-	handle := inventory.NewDownstreamHandle(func(ctx context.Context) (client.DownstreamInventoryControlStream, error) {
+	handle, err := inventory.NewDownstreamHandle(func(ctx context.Context) (client.DownstreamInventoryControlStream, error) {
 		// we're emulating an inventory.DownstreamCreateFunc here, but those are typically
 		// expected to return an error if no stream can be acquired. we're deliberately going
 		// with a blocking strategy instead here to avoid dealing w/ backoff that could make the
@@ -150,7 +150,8 @@ func newFakeHeartbeatDriver(t *testing.T) *fakeHeartbeatDriver {
 		case stream := <-streamC:
 			return stream, nil
 		}
-	}, hello)
+	}, func(ctx context.Context) (proto.UpstreamInventoryHello, error) { return hello, nil })
+	require.NoError(t, err)
 
 	t.Cleanup(func() {
 		handle.Close()

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -9211,12 +9211,16 @@ func startKubeWithoutCleanup(ctx context.Context, t *testing.T, cfg startKubeOpt
 	})
 	require.NoError(t, err)
 
-	inventoryHandle := inventory.NewDownstreamHandle(client.InventoryControlStream, clientproto.UpstreamInventoryHello{
-		ServerID: hostID,
-		Version:  teleport.Version,
-		Services: []types.SystemRole{role},
-		Hostname: "test",
-	})
+	inventoryHandle, err := inventory.NewDownstreamHandle(client.InventoryControlStream,
+		func(ctx context.Context) (clientproto.UpstreamInventoryHello, error) {
+			return clientproto.UpstreamInventoryHello{
+				ServerID: hostID,
+				Version:  teleport.Version,
+				Services: []types.SystemRole{role},
+				Hostname: "test",
+			}, nil
+		})
+	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, inventoryHandle.Close()) })
 
 	kubeServer, err := kubeproxy.NewTLSServer(kubeproxy.TLSServerConfig{


### PR DESCRIPTION
Second PR to add agent update tracking. This PR makes the teleport process report the updater status in the inventory hello message using the fields introduced in https://github.com/gravitational/teleport/pull/53911

This does not report the UpdaterID yet because we are still working on a better way to build/get an ID. The TODO will be addressed in another PR, once @sclevine's changes are merged.

Part of: [RFD 184](https://github.com/gravitational/teleport/blob/master/rfd/0184-agent-auto-updates.md)

Goal (internal): https://github.com/gravitational/cloud/issues/11856