### PR TITLE
Web: tweaks to info guide context

### DIFF
--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
@@ -810,7 +810,10 @@ const requireText = (value: string, requireReason: boolean) => () => {
 
 const SidePanel = styled(Box)`
   position: absolute;
-  z-index: 11;
+  // This z-index must be a higher value than the top bar z-index defined for
+  // Teleport web UI navigation found in teleport/src/Navigation/zIndexMap.ts.
+  // It prevents this SidePanel from rendering underneath the navigation bits.
+  z-index: 100;
   top: 0px;
   right: 0px;
   background: ${({ theme }) => theme.colors.levels.sunken};

--- a/web/packages/shared/components/SlidingSidePanel/InfoGuide/InfoGuide.tsx
+++ b/web/packages/shared/components/SlidingSidePanel/InfoGuide/InfoGuide.tsx
@@ -33,42 +33,57 @@ import {
  * Meant to be used with SlidingSidePanel.tsx.
  */
 export const InfoGuideContainer: React.FC<
-  PropsWithChildren<{ onClose(): void; title: string }>
+  PropsWithChildren<{ onClose(): void; title: React.ReactNode }>
 > = ({ onClose, title, children }) => (
-  <Box css={{ height: '100%', overflow: 'auto' }}>
-    <InfoGuideHeader title={title} onClose={onClose} />
-    <Box px={3} pb={3}>
-      {children}
-    </Box>
-  </Box>
+  <>
+    {children && (
+      <Box css={{ height: '100%', overflow: 'auto' }}>
+        <InfoGuideHeader title={title} onClose={onClose} />
+        <Box px={3} pb={3}>
+          {children}
+        </Box>
+      </Box>
+    )}
+  </>
 );
 
 const InfoGuideHeader = ({
   onClose,
-  title = 'Page Info',
+  title: customTitle,
 }: {
   onClose(): void;
-  title?: string;
-}) => (
-  <Flex
-    gap={2}
-    alignItems="center"
-    justifyContent="space-between"
-    px={3}
-    py={2}
-    css={`
-      position: sticky;
-      top: 0;
-      background: ${p => p.theme.colors.levels.surface};
-      border-bottom: 1px solid ${p => p.theme.colors.spotBackground[1]};
-    `}
-  >
-    <Text bold>{title}</Text>
-    <ButtonIcon onClick={onClose} data-testid="info-guide-btn-close">
-      <Cross size="small" />
-    </ButtonIcon>
-  </Flex>
-);
+  title?: React.ReactNode;
+}) => {
+  let title: React.ReactNode = <Text bold>Page Info</Text>;
+  if (customTitle) {
+    if (typeof customTitle === 'string') {
+      title = <Text bold>{customTitle}</Text>;
+    } else {
+      title = customTitle;
+    }
+  }
+  return (
+    <Flex
+      gap={2}
+      alignItems="center"
+      justifyContent="space-between"
+      px={3}
+      py={2}
+      css={`
+        position: sticky;
+        top: 0;
+        background: ${p => p.theme.colors.levels.surface};
+        border-bottom: 1px solid ${p => p.theme.colors.spotBackground[1]};
+        z-index: 1;
+      `}
+    >
+      <Text bold>{title}</Text>
+      <ButtonIcon onClick={onClose} data-testid="info-guide-btn-close">
+        <Cross size="small" />
+      </ButtonIcon>
+    </Flex>
+  );
+};
 
 const FilledButtonIcon = styled(Button)`
   width: 32px;

--- a/web/packages/shared/components/SlidingSidePanel/InfoGuide/InfoGuideContext.tsx
+++ b/web/packages/shared/components/SlidingSidePanel/InfoGuide/InfoGuideContext.tsx
@@ -24,9 +24,12 @@ import {
   useState,
 } from 'react';
 
+import { generalInfoPanelWidth } from './const';
+
 type InfoGuidePanelContextState = {
   infoGuideConfig: InfoGuideConfig | null;
   setInfoGuideConfig: (cfg: InfoGuideConfig) => void;
+  panelWidth: number;
 };
 
 export type InfoGuideConfig = {
@@ -37,7 +40,7 @@ export type InfoGuideConfig = {
   /**
    * Optional custom title for the guide panel.
    */
-  title?: string;
+  title?: React.ReactNode;
   /**
    * Optional custom panel width.
    */
@@ -55,15 +58,19 @@ export type InfoGuideConfig = {
 
 const InfoGuidePanelContext = createContext<InfoGuidePanelContextState>(null);
 
-export const InfoGuidePanelProvider: React.FC<PropsWithChildren> = ({
-  children,
-}) => {
+export const InfoGuidePanelProvider: React.FC<
+  PropsWithChildren<{ defaultPanelWidth?: number }>
+> = ({ children, defaultPanelWidth = generalInfoPanelWidth }) => {
   const [infoGuideConfig, setInfoGuideConfig] =
     useState<InfoGuideConfig | null>(null);
 
   return (
     <InfoGuidePanelContext.Provider
-      value={{ infoGuideConfig, setInfoGuideConfig }}
+      value={{
+        infoGuideConfig,
+        setInfoGuideConfig,
+        panelWidth: infoGuideConfig?.panelWidth || defaultPanelWidth,
+      }}
     >
       {children}
     </InfoGuidePanelContext.Provider>
@@ -84,7 +91,7 @@ export const useInfoGuide = () => {
     throw new Error('useInfoGuide must be used within a InfoGuidePanelContext');
   }
 
-  const { infoGuideConfig, setInfoGuideConfig } = context;
+  const { infoGuideConfig, setInfoGuideConfig, panelWidth } = context;
 
   useEffect(() => {
     return () => {
@@ -95,5 +102,6 @@ export const useInfoGuide = () => {
   return {
     infoGuideConfig,
     setInfoGuideConfig,
+    panelWidth,
   };
 };

--- a/web/packages/shared/components/SlidingSidePanel/InfoGuide/const.ts
+++ b/web/packages/shared/components/SlidingSidePanel/InfoGuide/const.ts
@@ -1,0 +1,37 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Used to display unified resource status info
+ */
+export const resourceStatusPanelWidth = 430;
+/**
+ * Used to display documentation/help/hint info
+ */
+export const generalInfoPanelWidth = 300;
+
+export const marginTransitionCss = ({
+  sidePanelOpened,
+  panelWidth,
+}: {
+  sidePanelOpened: boolean;
+  panelWidth?: number;
+}) => `
+  margin-right: ${sidePanelOpened ? panelWidth : '0'}px;
+  transition: ${sidePanelOpened ? 'margin 150ms' : 'margin 300ms'};
+`;

--- a/web/packages/teleport/src/Main/Main.tsx
+++ b/web/packages/teleport/src/Main/Main.tsx
@@ -35,6 +35,7 @@ import {
   InfoGuidePanelProvider,
   useInfoGuide,
 } from 'shared/components/SlidingSidePanel/InfoGuide';
+import { marginTransitionCss } from 'shared/components/SlidingSidePanel/InfoGuide/const';
 import useAttempt from 'shared/hooks/useAttemptNext';
 
 import { BannerList } from 'teleport/components/BannerList';
@@ -42,10 +43,7 @@ import type { BannerType } from 'teleport/components/BannerList/BannerList';
 import { useAlerts } from 'teleport/components/BannerList/useAlerts';
 import { CatchError } from 'teleport/components/CatchError';
 import { Redirect, Route, Switch } from 'teleport/components/Router';
-import {
-  infoGuidePanelWidth,
-  InfoGuideSidePanel,
-} from 'teleport/components/SlidingSidePanel/InfoGuideSidePanel';
+import { InfoGuideSidePanel } from 'teleport/components/SlidingSidePanel/InfoGuideSidePanel';
 import cfg from 'teleport/config';
 import { FeaturesContextProvider, useFeatures } from 'teleport/FeaturesContext';
 import { Navigation } from 'teleport/Navigation';
@@ -312,7 +310,7 @@ export const useNoMinWidth = () => {
 
 export const ContentMinWidth = ({ children }: { children: ReactNode }) => {
   const [enforceMinWidth, setEnforceMinWidth] = useState(true);
-  const { infoGuideConfig } = useInfoGuide();
+  const { infoGuideConfig, panelWidth } = useInfoGuide();
   const infoGuideSidePanelOpened = infoGuideConfig != null;
 
   return (
@@ -324,13 +322,11 @@ export const ContentMinWidth = ({ children }: { children: ReactNode }) => {
           flex: 1;
           ${enforceMinWidth ? 'min-width: 1000px;' : ''}
           min-height: 0;
-          margin-right: ${infoGuideSidePanelOpened
-            ? infoGuideConfig?.panelWidth || infoGuidePanelWidth
-            : '0'}px;
-          transition: ${infoGuideSidePanelOpened
-            ? 'margin 150ms'
-            : 'margin 300ms'};
           overflow-y: auto;
+          ${marginTransitionCss({
+            sidePanelOpened: infoGuideSidePanelOpened,
+            panelWidth,
+          })}
         `}
       >
         {children}

--- a/web/packages/teleport/src/components/SlidingSidePanel/InfoGuideSidePanel/InfoGuideSidePanel.tsx
+++ b/web/packages/teleport/src/components/SlidingSidePanel/InfoGuideSidePanel/InfoGuideSidePanel.tsx
@@ -25,8 +25,6 @@ import { zIndexMap } from 'teleport/Navigation/zIndexMap';
 
 import { SlidingSidePanel } from '../SlidingSidePanel';
 
-export const infoGuidePanelWidth = 300;
-
 /**
  * An info panel that always slides from the right and supports closing
  * from inside of panel (by clicking on x button from the sticky header).
@@ -34,14 +32,14 @@ export const infoGuidePanelWidth = 300;
  * The panel will always render below the web ui's tob bar menu.
  */
 export const InfoGuideSidePanel = () => {
-  const { infoGuideConfig, setInfoGuideConfig } = useInfoGuide();
+  const { infoGuideConfig, setInfoGuideConfig, panelWidth } = useInfoGuide();
   const infoGuideSidePanelOpened = infoGuideConfig != null;
 
   return (
     <SlidingSidePanel
       isVisible={infoGuideSidePanelOpened}
       skipAnimation={false}
-      panelWidth={infoGuideConfig?.panelWidth || infoGuidePanelWidth}
+      panelWidth={panelWidth}
       zIndex={zIndexMap.infoGuideSidePanel}
       slideFrom="right"
     >


### PR DESCRIPTION
I initially had some of these changes in another PR, then realized I won't be backporting that, so I moved backportable code here. 

- Move default info guide panel widths to context provider
- Cleaned up consts
- Allow custom title to accept React.ReactNode