### PR TITLE
Fix flaky test `TestWithRsync/with_headless_tsh`

### DIFF
--- a/tool/tsh/common/proxy_test.go
+++ b/tool/tsh/common/proxy_test.go
@@ -250,17 +250,30 @@ func TestWithRsync(t *testing.T) {
 	_, err := exec.LookPath("rsync")
 	require.NoError(t, err)
 
-	s := newTestSuite(t)
+	accessUser, err := types.NewUser("access")
+	require.NoError(t, err)
+	accessUser.SetRoles([]string{"access"})
 
-	// login and get host info
-	tshHome, _ := mustLoginLegacy(t, s)
+	user, err := user.Current()
+	require.NoError(t, err)
+	accessUser.SetLogins([]string{user.Username})
+
+	connector := mockConnector(t)
+	serverOpts := []testserver.TestServerOptFunc{
+		testserver.WithBootstrap(connector, accessUser),
+		testserver.WithHostname("node01"),
+		testserver.WithClusterName(t, "root"),
+	}
+
+	process := testserver.MakeTestServer(t, serverOpts...)
+	tshHome, _ := mustLogin(t, process, accessUser, connector.GetName())
 
 	testBin, err := os.Executable()
 	require.NoError(t, err)
 
-	host, port, err := net.SplitHostPort(s.root.Config.SSH.Addr.String())
+	host, port, err := net.SplitHostPort(process.Config.SSH.Addr.String())
 	require.NoError(t, err)
-	proxyAddr, err := s.root.ProxyWebAddr()
+	proxyAddr, err := process.ProxyWebAddr()
 	require.NoError(t, err)
 
 	var mockHeadlessAddr string
@@ -298,7 +311,7 @@ func TestWithRsync(t *testing.T) {
 			name: "with headless tsh",
 			setup: func(t *testing.T, dir string) {
 				// setup webauthn for headless auth
-				asrv := s.root.GetAuthServer()
+				asrv := process.GetAuthServer()
 				ctx := context.Background()
 
 				_, err = asrv.UpsertAuthPreference(ctx, &types.AuthPreferenceV2{
@@ -323,7 +336,7 @@ func TestWithRsync(t *testing.T) {
 				}, 5*time.Second, 100*time.Millisecond)
 
 				token, err := asrv.CreateResetPasswordToken(ctx, authclient.CreateUserTokenRequest{
-					Name: s.user.GetName(),
+					Name: accessUser.GetName(),
 				})
 				require.NoError(t, err)
 				tokenID := token.GetName()
@@ -384,7 +397,7 @@ func TestWithRsync(t *testing.T) {
 					sshCert, tlsCert, err := asrv.GenerateUserTestCerts(auth.GenerateUserTestCertsRequest{
 						SSHPubKey:      sshPubKey,
 						TLSPubKey:      tlsPubKey,
-						Username:       s.user.GetName(),
+						Username:       accessUser.GetName(),
 						TTL:            time.Hour,
 						Compatibility:  constants.CertificateFormatStandard,
 						RouteToCluster: clusterName.GetClusterName(),
@@ -406,7 +419,7 @@ func TestWithRsync(t *testing.T) {
 
 					// send login response to the client
 					resp := authclient.SSHLoginResponse{
-						Username:    s.user.GetName(),
+						Username:    accessUser.GetName(),
 						Cert:        sshCert,
 						TLSCert:     tlsCert,
 						HostSigners: authclient.AuthoritiesToTrustedCerts([]types.CertAuthority{authority}),
@@ -427,7 +440,7 @@ func TestWithRsync(t *testing.T) {
 					"rsync",
 					// ensure headless tsh will be used to authenticate
 					"-e",
-					fmt.Sprintf("%s ssh -d --insecure --headless --proxy=%s --user=%s", testBin, proxyAddr, s.user.GetName()),
+					fmt.Sprintf("%s ssh -d --insecure --headless --proxy=%s --user=%s", testBin, proxyAddr, accessUser.GetName()),
 					src,
 					fmt.Sprintf("%s:%s", host, dst),
 				)


### PR DESCRIPTION
The root of the flake was that the test would call `UpdateAuthPreference` to set webauthn and allow headless, and then `tsh --headless` would call `/webapi/ping` to get the cluster info. Due to the inefficiencies of the old test suite, sometimes the proxy's cache would not get updated with the new cluster auth preference in time for the Ping call, resulting in the wrong cluster info being reported.

Shifting to the newer test server scaffolding solved the issue and improved the speed of the test by ~2x.

Closes https://github.com/gravitational/teleport/issues/32958