### PR TITLE
Fix docs index page issues

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -17,13 +17,7 @@ and identity security into a single platform, eliminating overhead and operation
 Teleport improves the velocity of engineering teams, improving engineering productivity, scaling infrastructure operations, 
 and protecting time to market. 
 
-## Use cases and benefits
-
-![Use cases](../img/cloud/getting-started/intro-velocity-resiliency.png)
-
 ## Products
-
-![Products](../img/cloud/getting-started/identity-platform.png)
 
 The **Teleport** Infrastructure Identity **Platform** consists of four products:
 

--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -2,18 +2,13 @@
   "docs": [
     {
       "type": "category",
-      "label": "Get Started",
+      "label": "Introduction",
       "collapsible": true,
       "link": {
         "type": "doc",
         "id": "index"
       },
       "items": [
-        {
-          "type": "doc",
-          "label": "Introduction to Teleport",
-          "id": "index"
-        },
         {
           "type": "doc",
           "label": "Get Started",


### PR DESCRIPTION
- Remove the "Introduction to Teleport" link from the sidebar. There is already one link to the docs index page, the "Get Started" topic link. Rename the section index link to "Introduction" for clarity.  This prevents the Introduction page from having a "Next" link to the same page.

- Remove the images from the index page. We obtained these from a slide deck as placeholders, but have not replaced them with final images. Since the index page is a high-traffic docs page, removing them ensures docs viewers have a more polished docs experience.