### PR TITLE
fix: handle switching between VNet apps on Windows

### DIFF
--- a/lib/vnet/local_app_provider.go
+++ b/lib/vnet/local_app_provider.go
@@ -235,6 +235,7 @@ func (p *localAppProvider) resolveAppInfoForCluster(
 		AppKey: &vnetv1.AppKey{
 			Profile:     profileName,
 			LeafCluster: leafClusterName,
+			Name:        app.GetName(),
 		},
 		Cluster:       clusterClient.ClusterName(),
 		App:           app,

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -875,13 +875,15 @@ func testRemoteAppProvider(t *testing.T, alg cryptosuites.Algorithm) {
 	clientApp := newFakeClientApp(map[string]testClusterSpec{
 		"root.example.com": {
 			apps: []appSpec{
-				appSpec{publicAddr: "echo"},
+				appSpec{publicAddr: "echo1"},
+				appSpec{publicAddr: "echo2"},
 			},
 			cidrRange: "192.168.2.0/24",
 			leafClusters: map[string]testClusterSpec{
 				"leaf.example.com": {
 					apps: []appSpec{
-						appSpec{publicAddr: "echo"},
+						appSpec{publicAddr: "echo1"},
+						appSpec{publicAddr: "echo2"},
 					},
 					cidrRange: "192.168.2.0/24",
 				},
@@ -933,8 +935,12 @@ func testRemoteAppProvider(t *testing.T, alg cryptosuites.Algorithm) {
 	})
 
 	for _, app := range []string{
-		"echo.root.example.com",
-		"echo.leaf.example.com",
+		"echo1.root.example.com",
+		"echo2.root.example.com",
+		"echo1.root.example.com",
+		"echo1.leaf.example.com",
+		"echo2.leaf.example.com",
+		"echo1.leaf.example.com",
 	} {
 		conn, err := p.dialHost(ctx, app, 123)
 		require.NoError(t, err)


### PR DESCRIPTION
Currently VNet Windows is pretty broken, if you connect to 2 different apps in the same cluster and try to switch back and forth between them, you will get TLS handshake errors and app connections will not work. This is because:
- on Windows the VNet service has no access to user private keys and uses a crypto.Signer implemented over a gRPC service provided by tshd
- clientApplicationService holds a map of crypto.Signers for each app keyed by AppKey
- localAppProvider left AppKey.Name empty, so all AppKeys in a cluster were matching and every new app cert issued would overwrite the signer used by all other apps in the cluster

This commit:
- updates TestRemoteAppProvider to catch the bug
- updates localAppProvider to correctly fill in AppKey.Name
- adds some sanity checking of the app key to clientApplicationService

Changelog: Fixed TLS errors when switching between VNet apps on Windows