### PR TITLE
Move demo mode check to RoleEditor

### DIFF
--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
@@ -161,7 +161,7 @@ test('rendering and switching tabs for a non-standard role', async () => {
 it('calls onRoleUpdate on each modification in the standard editor', async () => {
   cfg.isPolicyEnabled = true;
   const onRoleUpdate = jest.fn();
-  render(<TestRoleEditor onRoleUpdate={onRoleUpdate} />);
+  render(<TestRoleEditor demoMode onRoleUpdate={onRoleUpdate} />);
   expect(onRoleUpdate).toHaveBeenLastCalledWith(
     withDefaults({ metadata: { name: 'new_role_name' } })
   );

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.tsx
@@ -65,6 +65,7 @@ export type RoleEditorProps = {
   onCancel?(): void;
   onSave?(r: Partial<RoleWithYaml>): Promise<void>;
   onRoleUpdate?(r: Role): void;
+  demoMode?: boolean;
 };
 
 /**
@@ -78,9 +79,11 @@ export const RoleEditor = ({
   onCancel,
   onSave,
   onRoleUpdate,
+  demoMode,
 }: RoleEditorProps) => {
   const roleTesterEnabled =
-    cfg.isPolicyEnabled && storageService.getAccessGraphRoleTesterEnabled();
+    (cfg.isPolicyEnabled && storageService.getAccessGraphRoleTesterEnabled()) ||
+    demoMode;
   const idPrefix = useId();
   // These IDs are needed to connect accessibility attributes between the
   // standard/YAML tab switcher and the switched panels.
@@ -91,10 +94,10 @@ export const RoleEditor = ({
 
   useEffect(() => {
     const { roleModel, validationResult } = standardModel;
-    if (roleModel && validationResult?.isValid) {
+    if (roleTesterEnabled && roleModel && validationResult?.isValid) {
       onRoleUpdate?.(roleEditorModelToRole(roleModel));
     }
-  }, [standardModel, onRoleUpdate]);
+  }, [standardModel, onRoleUpdate, roleTesterEnabled, demoMode]);
 
   const [yamlModel, setYamlModel] = useState<YamlEditorModel>({
     content: originalRole?.yaml ?? '',

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditorAdapter.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditorAdapter.tsx
@@ -30,7 +30,7 @@ import { Role, RoleWithYaml } from 'teleport/services/resources';
 import { yamlService } from 'teleport/services/yaml';
 import { YamlSupportedResourceKind } from 'teleport/services/yaml/types';
 
-import { RolesProps } from '../Roles';
+import { RoleDiffState, RolesProps } from '../Roles';
 import { RoleEditor } from './RoleEditor';
 import { RoleEditorVisualizer } from './RoleEditorVisualizer';
 
@@ -111,6 +111,7 @@ export function RoleEditorAdapter({
             onCancel={onCancel}
             onSave={onSave}
             onRoleUpdate={onRoleUpdate}
+            demoMode={roleDiffProps.roleDiffState === RoleDiffState.DemoReady}
           />
         )}
       </Flex>


### PR DESCRIPTION
This check was added to the `e` side originally, but it makes more sense to have the login in the component rather than the call itself do "nothing" depending on where its called. 

no semantic changes, just moved the check out of the https://github.com/gravitational/teleport.e/pull/6272 PR and moved it closer in the `Roles` PR here