### PR TITLE
Stabilize TestInteractiveCompatibilityFlags

### DIFF
--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -6877,8 +6877,14 @@ func TestInteractiveCompatibilityFlags(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			err := exec.Command(tshBin, "ssh", tt.flag, hostname, tty).Run()
-			tt.assertError(t, err)
+
+			// Add some resiliency for cases where connections are attempted
+			// prior to the inventory being updated to contain the target node
+			// above.
+			require.EventuallyWithT(t, func(t *assert.CollectT) {
+				out, err := exec.Command(tshBin, "ssh", tt.flag, hostname, tty).CombinedOutput()
+				tt.assertError(t, err, string(out))
+			}, 20*time.Second, 100*time.Millisecond)
 		})
 	}
 }


### PR DESCRIPTION
The test was immediately attempting to connect to the target host, but due to cache propagation the proxy may not yet have it's inventory updated. This sporadically causes the test to fail as dial requests to the target cannot be honored. To make the test more robust to this situation a retry mechanism was added. In other tests we first wait for the node to be visible in the correct cache, however, this is not exposed in the TeleportProcess and thus not available to this test.

Closes #53736.