### PR TITLE
feat: Hardware Key Agent - consolidate globally shared PIV service variables

### DIFF
--- a/api/utils/keys/piv/service.go
+++ b/api/utils/keys/piv/service.go
@@ -35,8 +35,8 @@ import (
 	"github.com/gravitational/teleport/api/utils/keys/hardwarekey"
 )
 
-// yubiKeyService is a globally shared YubiKeyService used to share mutually yubikey
-// connections and prompt mutex logic across the process in cases where [NewYubiKeyService]
+// yubiKeyService is a global YubiKeyService used to share yubikey connections
+// and prompt mutex logic across the process in cases where [NewYubiKeyService]
 // is called multiple times.
 //
 // TODO(Joerger): Ensure all clients initialize [NewYubiKeyService] only once so we can

--- a/api/utils/keys/piv/service.go
+++ b/api/utils/keys/piv/service.go
@@ -35,23 +35,25 @@ import (
 	"github.com/gravitational/teleport/api/utils/keys/hardwarekey"
 )
 
-// TODO(Joerger): Rather than using a global cache and mutexes, clients should be updated
-// to create a single YubiKeyService and ensure it is reused across the program execution.
-var (
-	// yubiKeys is a shared, thread-safe [YubiKey] cache by serial number. It allows for
-	// separate goroutines to share a YubiKey connection to work around the single PC/SC
-	// transaction (connection) per-yubikey limit.
-	yubiKeys    map[uint32]*YubiKey = map[uint32]*YubiKey{}
-	yubiKeysMux sync.Mutex
-
-	// promptMux is used to prevent over-prompting, especially for back-to-back sign requests
-	// since touch/PIN from the first signature should be cached for following signatures.
-	promptMux sync.Mutex
-)
+// yubiKeyService is a globally shared YubiKeyService used to share mutually yubikey
+// connections and prompt mutex logic across the process in cases where [NewYubiKeyService]
+// is called multiple times.
+//
+// TODO(Joerger): Ensure all clients initialize [NewYubiKeyService] only once so we can
+// remove this global variable.
+var yubiKeyService *YubiKeyService
+var yubiKeyServiceMux sync.Mutex
 
 // YubiKeyService is a YubiKey PIV implementation of [hardwarekey.Service].
 type YubiKeyService struct {
-	prompt hardwarekey.Prompt
+	prompt    hardwarekey.Prompt
+	promptMux sync.Mutex
+
+	// yubiKeys is a shared, thread-safe [YubiKey] cache by serial number. It allows for
+	// separate goroutines to share a YubiKey connection to work around the single PC/SC
+	// transaction (connection) per-yubikey limit.
+	yubiKeys    map[uint32]*YubiKey
+	yubiKeysMux sync.Mutex
 }
 
 // Returns a new [YubiKeyService]. If [customPrompt] is nil, the default CLI prompt will be used.
@@ -59,13 +61,26 @@ type YubiKeyService struct {
 // Only a single service should be created for each process to ensure the cached connections
 // are shared and multiple services don't compete for PIV resources.
 func NewYubiKeyService(customPrompt hardwarekey.Prompt) *YubiKeyService {
+	yubiKeyServiceMux.Lock()
+	defer yubiKeyServiceMux.Unlock()
+
+	if yubiKeyService != nil {
+		// If a prompt is provided, prioritize it over the existing prompt value.
+		if customPrompt != nil {
+			yubiKeyService.prompt = customPrompt
+		}
+		return yubiKeyService
+	}
+
 	if customPrompt == nil {
 		customPrompt = hardwarekey.NewStdCLIPrompt()
 	}
 
-	return &YubiKeyService{
-		prompt: customPrompt,
+	yubiKeyService = &YubiKeyService{
+		prompt:   customPrompt,
+		yubiKeys: map[uint32]*YubiKey{},
 	}
+	return yubiKeyService
 }
 
 // NewPrivateKey creates a hardware private key that satisfies the provided [config],
@@ -170,8 +185,8 @@ func (s *YubiKeyService) Sign(ctx context.Context, ref *hardwarekey.PrivateKeyRe
 		return nil, trace.Wrap(err)
 	}
 
-	promptMux.Lock()
-	defer promptMux.Unlock()
+	s.promptMux.Lock()
+	defer s.promptMux.Unlock()
 
 	return y.sign(ctx, ref, keyInfo, s.prompt, rand, digest, opts)
 }
@@ -227,10 +242,10 @@ func (s *YubiKeyService) GetFullKeyRef(serialNumber uint32, slotKey hardwarekey.
 // Get the given YubiKey with the serial number. If the provided serialNumber is "0",
 // return the first YubiKey found in the smart card list.
 func (s *YubiKeyService) getYubiKey(serialNumber uint32) (*YubiKey, error) {
-	yubiKeysMux.Lock()
-	defer yubiKeysMux.Unlock()
+	s.yubiKeysMux.Lock()
+	defer s.yubiKeysMux.Unlock()
 
-	if y, ok := yubiKeys[serialNumber]; ok {
+	if y, ok := s.yubiKeys[serialNumber]; ok {
 		return y, nil
 	}
 
@@ -239,7 +254,7 @@ func (s *YubiKeyService) getYubiKey(serialNumber uint32) (*YubiKey, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	yubiKeys[y.serialNumber] = y
+	s.yubiKeys[y.serialNumber] = y
 	return y, nil
 }
 
@@ -247,8 +262,8 @@ func (s *YubiKeyService) getYubiKey(serialNumber uint32) (*YubiKey, error) {
 // If the user provides the default PIN, they will be prompted to set a
 // non-default PIN and PUK before continuing.
 func (s *YubiKeyService) checkOrSetPIN(ctx context.Context, y *YubiKey, keyInfo hardwarekey.ContextualKeyInfo) error {
-	promptMux.Lock()
-	defer promptMux.Unlock()
+	s.promptMux.Lock()
+	defer s.promptMux.Unlock()
 
 	pin, err := s.prompt.AskPIN(ctx, hardwarekey.PINOptional, keyInfo)
 	if err != nil {
@@ -270,8 +285,8 @@ func (s *YubiKeyService) checkOrSetPIN(ctx context.Context, y *YubiKey, keyInfo 
 }
 
 func (s *YubiKeyService) promptOverwriteSlot(ctx context.Context, msg string, keyInfo hardwarekey.ContextualKeyInfo) error {
-	promptMux.Lock()
-	defer promptMux.Unlock()
+	s.promptMux.Lock()
+	defer s.promptMux.Unlock()
 
 	promptQuestion := fmt.Sprintf("%v\nWould you like to overwrite this slot's private key and certificate?", msg)
 	if confirmed, confirmErr := s.prompt.ConfirmSlotOverwrite(ctx, promptQuestion, keyInfo); confirmErr != nil {


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport/pull/52495

This PR consolidates the globally shared PIV service variables into a globally shared PIV service. This in turn ensures that the prompt is also shared, which is required for [hardware key PIN caching](https://github.com/gravitational/teleport/pull/52495).

The end goal is to remove these global variables altogether in favor of ensuring the hardware key service for a process is only initialized once. This will be handled in a series of follow up PRs broken up from https://github.com/gravitational/teleport/pull/53707.