### PR TITLE
[v16] build: Add log groupings to release builds

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -23,6 +23,7 @@ UID := $$(id -u)
 GID := $$(id -g)
 NOROOT := -u $(UID):$(GID)
 
+include util.mk
 include versions.mk
 include arch.mk
 # BUILDBOX_VERSION, BUILDBOX and BUILDBOX_variant variables are included in images.mk
@@ -103,6 +104,7 @@ build-binaries-fips: buildbox-centos7-fips webassets
 #
 .PHONY:buildbox
 buildbox:
+	$(call LOG_GROUP_START)
 	docker buildx build \
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
@@ -122,6 +124,7 @@ buildbox:
 		--cache-from $(BUILDBOX) \
 		$(if $(PUSH),--push,--load) \
 		--tag $(BUILDBOX) .
+	$(call LOG_GROUP_END)
 
 # Builds a Docker buildbox for FIPS
 #
@@ -141,6 +144,7 @@ buildbox-fips: buildbox-centos7-fips
 #
 .PHONY:buildbox-centos7
 buildbox-centos7:
+	$(call LOG_GROUP_START)
 	$(REQUIRE_HOST_ARCH)
 	docker buildx build \
 		--target buildbox \
@@ -159,6 +163,7 @@ buildbox-centos7:
 		--cache-from $(BUILDBOX_CENTOS7) \
 		$(if $(PUSH),--push,--load) \
 		--tag $(BUILDBOX_CENTOS7) -f Dockerfile-centos7 .
+	$(call LOG_GROUP_END)
 
 #
 # Builds a Docker buildbox for CentOS 7 FIPS builds. This uses the same
@@ -169,6 +174,7 @@ buildbox-centos7:
 #
 .PHONY:buildbox-centos7-fips
 buildbox-centos7-fips:
+	$(call LOG_GROUP_START)
 	docker buildx build \
 		--target buildbox-fips \
 		--build-arg UID=$(UID) \
@@ -186,6 +192,7 @@ buildbox-centos7-fips:
 		--cache-from $(BUILDBOX_CENTOS7_FIPS) \
 		$(if $(PUSH),--push,--load) \
 		--tag $(BUILDBOX_CENTOS7_FIPS) -f Dockerfile-centos7 .
+	$(call LOG_GROUP_END)
 
 #
 # Builds a Docker buildbox for ARMv7/ARM64 builds
@@ -194,6 +201,7 @@ buildbox-centos7-fips:
 #
 .PHONY:buildbox-arm
 buildbox-arm:
+	$(call LOG_GROUP_START)
 	docker buildx build \
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
@@ -205,6 +213,7 @@ buildbox-arm:
 		--cache-from $(BUILDBOX_ARM) \
 		$(if $(PUSH),--push,--load) \
 		--tag $(BUILDBOX_ARM) -f Dockerfile-arm .
+	$(call LOG_GROUP_END)
 
 CONNECT_VERSION ?= $(VERSION)
 ifeq ($(CONNECT_VERSION),)
@@ -217,6 +226,7 @@ endif
 #
 .PHONY:buildbox-node
 buildbox-node:
+	$(call LOG_GROUP_START)
 	docker buildx build \
 		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
 		--build-arg UID=$(UID) \
@@ -228,6 +238,7 @@ buildbox-node:
 		--cache-from $(BUILDBOX_NODE) \
 		$(if $(PUSH),--push,--load) \
 		--tag $(BUILDBOX_NODE) -f Dockerfile-node .
+	$(call LOG_GROUP_END)
 
 #
 # Builds Teleport Connect inside the buildbox container.
@@ -251,8 +262,10 @@ ui: buildbox
 # submodule is present.
 .PHONY: webassets
 webassets: buildbox-node
+	$(call LOG_GROUP_START)
 	docker run $(DOCKERFLAGS) $(NOROOT) $(BUILDBOX_NODE) \
 		/usr/bin/make ensure-webassets $(if $(wildcard ../e/Makefile),ensure-webassets-e)
+	$(call LOG_GROUP_END)
 
 # grpc generates GRPC stubs from inside the buildbox
 .PHONY: grpc
@@ -471,9 +484,11 @@ BUILDBOX_TARGET = $(or $(BUILDBOX_TARGET_$(BUILDBOX)),buildbox)
 #
 .PHONY:release
 release: $(BUILDBOX_TARGET)
+	$(call LOG_GROUP_START)
 	@echo "Build Assets Release"
 	docker run $(DOCKERFLAGS) $(NOROOT) $(BUILDBOX) \
 		/usr/bin/make $(RELEASE_TARGET) -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIDO2=$(FIDO2) PIV=$(PIV) REPRODUCIBLE=yes
+	$(call LOG_GROUP_END)
 
 #
 # Create a Teleport FIPS package using the build container.
@@ -498,9 +513,11 @@ release-fips: buildbox-centos7-fips webassets
 #
 .PHONY:release-centos7
 release-centos7: buildbox-centos7 webassets
+	$(LOG_GROUP_START)
 	$(REQUIRE_HOST_ARCH)
 	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS7) \
 		/usr/bin/scl enable $(DEVTOOLSET) 'make release-unix-preserving-webassets -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIDO2=$(FIDO2) PIV=$(PIV) REPRODUCIBLE=no'
+	$(LOG_GROUP_END)
 
 #
 # Create a Teleport FIPS package for CentOS 7 using the build container.
@@ -512,8 +529,10 @@ release-centos7: buildbox-centos7 webassets
 #
 .PHONY:release-centos7-fips
 release-centos7-fips: buildbox-centos7-fips webassets
+	$(LOG_GROUP_START)
 	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS7_FIPS) \
 		/usr/bin/scl enable $(DEVTOOLSET) '/usr/bin/make -C e release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIDO2=$(FIDO2) PIV=$(PIV) FIPS=yes VERSION=$(VERSION) GITTAG=v$(VERSION) REPRODUCIBLE=no'
+	$(LOG_GROUP_END)
 
 #
 # Create a Windows Teleport package using the build container.

--- a/build.assets/util.mk
+++ b/build.assets/util.mk
@@ -1,0 +1,37 @@
+# This file contains a bunch of "utilities" for using make.
+
+# Detect if running on github. If not, assume local. This var should be
+# expanded to support detection of other CI systems.
+CI_SYSTEM = $(if $(GITHUB_ACTIONS),github,local)
+
+# LOG_GROUP_START and LOG_GROUP_END can be called at the start and end of make
+# recipes that produce a lot of output or would otherwise benefit from being
+# grouped. On GitHub, the group is placed into an collapsable section. For
+# local runs, start/end markers are printed.
+#
+# Use in a recipe:
+#
+# target:
+#         $(call LOG_GROUP_START)
+#         ...
+#         $(call LOG_GROUP_END)
+#
+# The default title is "make <target>" which can be overridden by providing
+# the title as a parameter to the $(call)s: $(call LOG_GROUP_START,Boogying)
+# and $(call LOG_GROUP_END).
+
+LOG_GROUP_START = $(LOG_GROUP_START_$(CI_SYSTEM))
+LOG_GROUP_END = $(LOG_GROUP_END_$(CI_SYSTEM))
+
+# Use the provided title if provided or default to "make <target>".
+log_group_title = $(or $(1),make $@)
+
+# GitHub has a group marker.
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#grouping-log-lines
+LOG_GROUP_START_github = @echo '::group::$(log_group_title)'
+LOG_GROUP_END_github = @echo '::endgroup::'
+
+# Use a markdown syntax for local, even if the rest of the output is not
+# markdown. The markers are reasonably searchable.
+LOG_GROUP_START_local = @echo '\#\# Start: $(log_group_title)'
+LOG_GROUP_END_local = @echo '---'


### PR DESCRIPTION
Add log grouping to release builds of the builds and the buildboxes. On
GitHub actions, this will add special log markers that allow the log
group to be collapsed, and when timestamps are enabled in the log
display, see how long these groups take to run. Building the buildboxes
when doing a release sometimes takes a while and emits a lot of output,
so this helps analyse the output. When running locally, a markdown style
heading is output.

Some conflicts around the buildbox-ng targets were not backported. Those
sections were just removed.

Backport: https://github.com/gravitational/teleport/pull/53944
