### PR TITLE
[buddy] Install jq if Teleport binary was installed

### DIFF
--- a/api/types/installers/agentless-installer.sh.tmpl
+++ b/api/types/installers/agentless-installer.sh.tmpl
@@ -107,7 +107,7 @@ get_labels() {
   echo "$LABELS"
 }
 
-install_jq() {
+install_deps() {
   # shellcheck disable=SC1091
   . /etc/os-release
 
@@ -227,12 +227,9 @@ install_teleport() {
 
   TOKEN="$1"
 
-  if ! test -f /usr/bin/jq; then
-    if ! test -f /usr/local/bin/teleport; then
-      install_teleport
-    else
-      install_jq
-    fi
+  install_deps
+  if ! test -f /usr/local/bin/teleport; then
+    install_teleport
   fi
 
   IMDS_TOKEN=$(curl -m5 -sS -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 300")

--- a/api/types/installers/agentless-installer.sh.tmpl
+++ b/api/types/installers/agentless-installer.sh.tmpl
@@ -107,6 +107,23 @@ get_labels() {
   echo "$LABELS"
 }
 
+install_jq() {
+  # shellcheck disable=SC1091
+  . /etc/os-release
+
+  if [ "$ID" = "debian" ] || [ "$ID" = "ubuntu" ]; then
+    sudo apt-get update
+    sudo apt-get install -y jq
+  elif [ "$ID" = "amzn" ] || [ "$ID" = "rhel" ]; then
+    sudo yum install -y jq
+  elif [ "$ID" = "sles" ] || [ "$ID" = "opensuse-tumbleweed" ] || [ "$ID" = "opensuse-leap" ]; then
+    sudo zypper --non-interactive install -y jq
+  else
+    echo "Unsupported distro: $ID"
+    exit 1
+  fi
+}
+
 install_teleport() {
   # shellcheck disable=SC1091
   . /etc/os-release
@@ -210,8 +227,12 @@ install_teleport() {
 
   TOKEN="$1"
 
-  if ! test -f /usr/local/bin/teleport; then
-    install_teleport
+  if ! test -f /usr/bin/jq; then
+    if ! test -f /usr/local/bin/teleport; then
+      install_teleport
+    else
+      install_jq
+    fi
   fi
 
   IMDS_TOKEN=$(curl -m5 -sS -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 300")


### PR DESCRIPTION
@tunguyen9889 

> I found a bug when using the script in my company environment. During the AMI building process in AWS, we installed the Teleport binary, but not configure and start the service.
> 
> When an EC2 instance spun up with that AMI, Teleport Discovery Service triggers the SSM and installer script, but it failed in the `get_labels` function, as `teleport` binary is found, but `jq` not.
> 
> This PR adds a `install_jq` function, and a check to decide whether to run `install_teleport` or `install_jq` only.