### PR TITLE
Always specify Bot Kind/Version

### DIFF
--- a/integrations/terraform/provider/resource_teleport_bot.go
+++ b/integrations/terraform/provider/resource_teleport_bot.go
@@ -28,6 +28,7 @@ import (
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	apitypes "github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils"
 
 	"github.com/gravitational/teleport/integrations/terraform/tfschema"
@@ -175,6 +176,8 @@ func (r resourceTeleportBot) Create(ctx context.Context, req tfsdk.CreateResourc
 	// This is a temporary workaround to fix the provider compilation in v16 (the legacy RPC got removed).
 	// We must do a breaking change in v16 and rely on the new bot schema and the tf code generator.
 	response, err := r.p.Client.BotServiceClient().CreateBot(ctx, &machineidv1.CreateBotRequest{Bot: &machineidv1.Bot{
+		Kind:    apitypes.KindBot,
+		Version: apitypes.V1,
 		Metadata: &headerv1.Metadata{
 			Name: plan.Name.Value,
 		},

--- a/integrations/terraform/testlib/machineid_join_test.go
+++ b/integrations/terraform/testlib/machineid_join_test.go
@@ -93,6 +93,8 @@ func TestTerraformJoin(t *testing.T) {
 	require.NoError(t, err)
 
 	bot := &machineidv1.Bot{
+		Kind:    types.KindBot,
+		Version: types.V1,
 		Metadata: &headerv1.Metadata{
 			Name: testBotName,
 		},

--- a/lib/auth/access_request_test.go
+++ b/lib/auth/access_request_test.go
@@ -1042,6 +1042,8 @@ func testBotAccessRequestReview(t *testing.T, testPack *accessRequestTestPack) {
 	defer adminClient.Close()
 	bot, err := adminClient.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{
 		Bot: &machineidv1pb.Bot{
+			Kind:    types.KindBot,
+			Version: types.V1,
 			Metadata: &headerv1.Metadata{
 				Name: "request-approver",
 			},

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -129,6 +129,8 @@ func TestRegisterBotCertificateGenerationCheck(t *testing.T) {
 	require.NoError(t, err)
 	bot, err := client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{
 		Bot: &machineidv1pb.Bot{
+			Kind:    types.KindBot,
+			Version: types.V1,
 			Metadata: &headerv1.Metadata{
 				Name: "test",
 			},
@@ -239,6 +241,8 @@ func TestBotJoinAttrs_Kubernetes(t *testing.T) {
 	require.NoError(t, err)
 	bot, err := client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{
 		Bot: &machineidv1pb.Bot{
+			Kind:    types.KindBot,
+			Version: types.V1,
 			Metadata: &headerv1.Metadata{
 				Name: "test",
 			},
@@ -376,6 +380,8 @@ func TestRegisterBotInstance(t *testing.T) {
 	require.NoError(t, err)
 	bot, err := client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{
 		Bot: &machineidv1pb.Bot{
+			Kind:    types.KindBot,
+			Version: types.V1,
 			Metadata: &headerv1.Metadata{
 				Name: "test",
 			},
@@ -515,6 +521,8 @@ func TestRegisterBotCertificateGenerationStolen(t *testing.T) {
 	require.NoError(t, err)
 	bot, err := client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{
 		Bot: &machineidv1pb.Bot{
+			Kind:    types.KindBot,
+			Version: types.V1,
 			Metadata: &headerv1.Metadata{
 				Name: "test",
 			},
@@ -579,6 +587,8 @@ func TestRegisterBotCertificateExtensions(t *testing.T) {
 	require.NoError(t, err)
 	bot, err := client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{
 		Bot: &machineidv1pb.Bot{
+			Kind:    types.KindBot,
+			Version: types.V1,
 			Metadata: &headerv1.Metadata{
 				Name: "test",
 			},
@@ -643,6 +653,8 @@ func TestRegisterBot_RemoteAddr(t *testing.T) {
 
 	botName := "botty"
 	_, err = machineidv1.UpsertBot(ctx, a, &machineidv1pb.Bot{
+		Kind:    types.KindBot,
+		Version: types.V1,
 		Metadata: &headerv1.Metadata{
 			Name: botName,
 		},
@@ -934,6 +946,8 @@ func TestRegisterBot_BotInstanceRejoin(t *testing.T) {
 
 	botName := "bot"
 	_, err = machineidv1.UpsertBot(ctx, a, &machineidv1pb.Bot{
+		Kind:    types.KindBot,
+		Version: types.V1,
 		Metadata: &headerv1.Metadata{
 			Name: botName,
 		},
@@ -1088,6 +1102,8 @@ func TestRegisterBotWithInvalidInstanceID(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = machineidv1.UpsertBot(ctx, a, &machineidv1pb.Bot{
+		Kind:    types.KindBot,
+		Version: types.V1,
 		Metadata: &headerv1.Metadata{
 			Name: botName,
 		},
@@ -1165,6 +1181,8 @@ func TestRegisterBotMultipleTokens(t *testing.T) {
 	require.NoError(t, err)
 	bot, err := client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{
 		Bot: &machineidv1pb.Bot{
+			Kind:    types.KindBot,
+			Version: types.V1,
 			Metadata: &headerv1.Metadata{
 				Name: "test",
 			},

--- a/lib/auth/join/join_test.go
+++ b/lib/auth/join/join_test.go
@@ -162,6 +162,8 @@ func TestRegister_Bot(t *testing.T) {
 	srv := newTestTLSServer(t)
 
 	bot, err := machineidv1.UpsertBot(ctx, srv.Auth(), &machineidv1pb.Bot{
+		Kind:    types.KindBot,
+		Version: types.V1,
 		Metadata: &headerv1.Metadata{
 			Name: "test",
 		},
@@ -304,6 +306,8 @@ func TestRegister_Bot_Expiry(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			botName := uuid.NewString()
 			_, err := machineidv1.UpsertBot(ctx, srv.Auth(), &machineidv1pb.Bot{
+				Kind:    types.KindBot,
+				Version: types.V1,
 				Metadata: &headerv1.Metadata{
 					Name: botName,
 				},

--- a/lib/auth/join_test.go
+++ b/lib/auth/join_test.go
@@ -306,6 +306,8 @@ func TestRegister_Bot(t *testing.T) {
 	srv := newTestTLSServer(t)
 
 	bot, err := machineidv1.UpsertBot(ctx, srv.Auth(), &machineidv1pb.Bot{
+		Kind:    types.KindBot,
+		Version: types.V1,
 		Metadata: &headerv1.Metadata{
 			Name: "test",
 		},
@@ -448,6 +450,8 @@ func TestRegister_Bot_Expiry(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			botName := uuid.NewString()
 			_, err := machineidv1.UpsertBot(ctx, srv.Auth(), &machineidv1pb.Bot{
+				Kind:    types.KindBot,
+				Version: types.V1,
 				Metadata: &headerv1.Metadata{
 					Name: botName,
 				},

--- a/lib/auth/machineid/machineidv1/machineidv1_test.go
+++ b/lib/auth/machineid/machineidv1/machineidv1_test.go
@@ -96,6 +96,8 @@ func TestCreateBot(t *testing.T) {
 		ctx,
 		&machineidv1pb.CreateBotRequest{
 			Bot: &machineidv1pb.Bot{
+				Kind:    types.KindBot,
+				Version: types.V1,
 				Metadata: &headerv1.Metadata{
 					Name: "pre-existing",
 				},
@@ -123,6 +125,8 @@ func TestCreateBot(t *testing.T) {
 			user: botCreator.GetName(),
 			req: &machineidv1pb.CreateBotRequest{
 				Bot: &machineidv1pb.Bot{
+					Kind:    types.KindBot,
+					Version: types.V1,
 					Metadata: &headerv1.Metadata{
 						Name: "success",
 						Labels: map[string]string{
@@ -231,6 +235,8 @@ func TestCreateBot(t *testing.T) {
 			user: botCreator.GetName(),
 			req: &machineidv1pb.CreateBotRequest{
 				Bot: &machineidv1pb.Bot{
+					Kind:    types.KindBot,
+					Version: types.V1,
 					Metadata: &headerv1.Metadata{
 						Name: "success-with-expiry",
 						Labels: map[string]string{
@@ -374,6 +380,8 @@ func TestCreateBot(t *testing.T) {
 			user: botCreator.GetName(),
 			req: &machineidv1pb.CreateBotRequest{
 				Bot: &machineidv1pb.Bot{
+					Kind:     types.KindBot,
+					Version:  types.V1,
 					Metadata: nil,
 					Spec: &machineidv1pb.BotSpec{
 						Roles: []string{testRole.GetName()},
@@ -390,6 +398,8 @@ func TestCreateBot(t *testing.T) {
 			user: botCreator.GetName(),
 			req: &machineidv1pb.CreateBotRequest{
 				Bot: &machineidv1pb.Bot{
+					Kind:     types.KindBot,
+					Version:  types.V1,
 					Metadata: &headerv1.Metadata{},
 					Spec: &machineidv1pb.BotSpec{
 						Roles: []string{testRole.GetName()},
@@ -406,6 +416,8 @@ func TestCreateBot(t *testing.T) {
 			user: botCreator.GetName(),
 			req: &machineidv1pb.CreateBotRequest{
 				Bot: &machineidv1pb.Bot{
+					Kind:    types.KindBot,
+					Version: types.V1,
 					Metadata: &headerv1.Metadata{
 						Name: "terminator",
 					},
@@ -422,6 +434,8 @@ func TestCreateBot(t *testing.T) {
 			user: botCreator.GetName(),
 			req: &machineidv1pb.CreateBotRequest{
 				Bot: &machineidv1pb.Bot{
+					Kind:    types.KindBot,
+					Version: types.V1,
 					Metadata: &headerv1.Metadata{
 						Name: "empty-string-role",
 					},
@@ -501,6 +515,8 @@ func TestUpdateBot(t *testing.T) {
 	require.NoError(t, err)
 	preExistingBot, err := client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{
 		Bot: &machineidv1pb.Bot{
+			Kind:    types.KindBot,
+			Version: types.V1,
 			Metadata: &headerv1.Metadata{
 				Name: "pre-existing",
 			},
@@ -544,6 +560,8 @@ func TestUpdateBot(t *testing.T) {
 			user: botUpdaterUser.GetName(),
 			req: &machineidv1pb.UpdateBotRequest{
 				Bot: &machineidv1pb.Bot{
+					Kind:    types.KindBot,
+					Version: types.V1,
 					Metadata: &headerv1.Metadata{
 						Name: preExistingBot.Metadata.Name,
 					},
@@ -675,6 +693,8 @@ func TestUpdateBot(t *testing.T) {
 			user: botUpdaterUser.GetName(),
 			req: &machineidv1pb.UpdateBotRequest{
 				Bot: &machineidv1pb.Bot{
+					Kind:    types.KindBot,
+					Version: types.V1,
 					Metadata: &headerv1.Metadata{
 						Name: "bernard-lowe",
 					},
@@ -694,6 +714,8 @@ func TestUpdateBot(t *testing.T) {
 			user: botUpdaterUser.GetName(),
 			req: &machineidv1pb.UpdateBotRequest{
 				Bot: &machineidv1pb.Bot{
+					Kind:    types.KindBot,
+					Version: types.V1,
 					Spec: &machineidv1pb.BotSpec{
 						Roles: []string{beforeRole.GetName()},
 					},
@@ -712,6 +734,8 @@ func TestUpdateBot(t *testing.T) {
 			user: botUpdaterUser.GetName(),
 			req: &machineidv1pb.UpdateBotRequest{
 				Bot: &machineidv1pb.Bot{
+					Kind:    types.KindBot,
+					Version: types.V1,
 					Metadata: &headerv1.Metadata{
 						Name: "",
 					},
@@ -733,6 +757,8 @@ func TestUpdateBot(t *testing.T) {
 			user: botUpdaterUser.GetName(),
 			req: &machineidv1pb.UpdateBotRequest{
 				Bot: &machineidv1pb.Bot{
+					Kind:    types.KindBot,
+					Version: types.V1,
 					Metadata: &headerv1.Metadata{
 						Name: "foo",
 					},
@@ -752,6 +778,8 @@ func TestUpdateBot(t *testing.T) {
 			user: botUpdaterUser.GetName(),
 			req: &machineidv1pb.UpdateBotRequest{
 				Bot: &machineidv1pb.Bot{
+					Kind:    types.KindBot,
+					Version: types.V1,
 					Metadata: &headerv1.Metadata{
 						Name: "foo",
 					},
@@ -773,6 +801,8 @@ func TestUpdateBot(t *testing.T) {
 			user: botUpdaterUser.GetName(),
 			req: &machineidv1pb.UpdateBotRequest{
 				Bot: &machineidv1pb.Bot{
+					Kind:    types.KindBot,
+					Version: types.V1,
 					Metadata: &headerv1.Metadata{
 						Name: preExistingBot.Metadata.Name,
 					},
@@ -863,6 +893,8 @@ func TestUpsertBot(t *testing.T) {
 	require.NoError(t, err)
 	preExistingBot, err := client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{
 		Bot: &machineidv1pb.Bot{
+			Kind:    types.KindBot,
+			Version: types.V1,
 			Metadata: &headerv1.Metadata{
 				Name: "pre-existing",
 				Labels: map[string]string{
@@ -905,6 +937,8 @@ func TestUpsertBot(t *testing.T) {
 			user: botCreator.GetName(),
 			req: &machineidv1pb.UpsertBotRequest{
 				Bot: &machineidv1pb.Bot{
+					Kind:    types.KindBot,
+					Version: types.V1,
 					Metadata: &headerv1.Metadata{
 						Name: "new",
 						Labels: map[string]string{
@@ -1003,6 +1037,8 @@ func TestUpsertBot(t *testing.T) {
 			user: botCreator.GetName(),
 			req: &machineidv1pb.UpsertBotRequest{
 				Bot: &machineidv1pb.Bot{
+					Kind:    types.KindBot,
+					Version: types.V1,
 					Metadata: &headerv1.Metadata{
 						Name: "new-with-expiry",
 						Labels: map[string]string{
@@ -1184,6 +1220,8 @@ func TestUpsertBot(t *testing.T) {
 			user: botCreator.GetName(),
 			req: &machineidv1pb.UpsertBotRequest{
 				Bot: &machineidv1pb.Bot{
+					Kind:     types.KindBot,
+					Version:  types.V1,
 					Metadata: nil,
 					Spec: &machineidv1pb.BotSpec{
 						Roles: []string{testRole.GetName()},
@@ -1200,6 +1238,8 @@ func TestUpsertBot(t *testing.T) {
 			user: botCreator.GetName(),
 			req: &machineidv1pb.UpsertBotRequest{
 				Bot: &machineidv1pb.Bot{
+					Kind:     types.KindBot,
+					Version:  types.V1,
 					Metadata: &headerv1.Metadata{},
 					Spec: &machineidv1pb.BotSpec{
 						Roles: []string{testRole.GetName()},
@@ -1216,6 +1256,8 @@ func TestUpsertBot(t *testing.T) {
 			user: botCreator.GetName(),
 			req: &machineidv1pb.UpsertBotRequest{
 				Bot: &machineidv1pb.Bot{
+					Kind:    types.KindBot,
+					Version: types.V1,
 					Metadata: &headerv1.Metadata{
 						Name: "empty-string-role",
 					},
@@ -1301,6 +1343,8 @@ func TestGetBot(t *testing.T) {
 		ctx,
 		&machineidv1pb.CreateBotRequest{
 			Bot: &machineidv1pb.Bot{
+				Kind:    types.KindBot,
+				Version: types.V1,
 				Metadata: &headerv1.Metadata{
 					Name: "pre-existing",
 					Labels: map[string]string{
@@ -1412,6 +1456,8 @@ func TestListBots(t *testing.T) {
 		ctx,
 		&machineidv1pb.CreateBotRequest{
 			Bot: &machineidv1pb.Bot{
+				Kind:    types.KindBot,
+				Version: types.V1,
 				Metadata: &headerv1.Metadata{
 					Name: "pre-existing",
 					Labels: map[string]string{
@@ -1430,6 +1476,8 @@ func TestListBots(t *testing.T) {
 		ctx,
 		&machineidv1pb.CreateBotRequest{
 			Bot: &machineidv1pb.Bot{
+				Kind:    types.KindBot,
+				Version: types.V1,
 				Metadata: &headerv1.Metadata{
 					Name: "pre-existing-2",
 				},
@@ -1534,6 +1582,8 @@ func TestDeleteBot(t *testing.T) {
 		ctx,
 		&machineidv1pb.CreateBotRequest{
 			Bot: &machineidv1pb.Bot{
+				Kind:    types.KindBot,
+				Version: types.V1,
 				Metadata: &headerv1.Metadata{
 					Name: "pre-existing",
 				},
@@ -1548,6 +1598,8 @@ func TestDeleteBot(t *testing.T) {
 		ctx,
 		&machineidv1pb.CreateBotRequest{
 			Bot: &machineidv1pb.Bot{
+				Kind:    types.KindBot,
+				Version: types.V1,
 				Metadata: &headerv1.Metadata{
 					Name: "pre-existing-3",
 				},

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -101,6 +101,8 @@ func makeBot(t *testing.T, client *authclient.Client, name string, roles ...stri
 
 	b, err := client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{
 		Bot: &machineidv1pb.Bot{
+			Kind:    types.KindBot,
+			Version: types.V1,
 			Metadata: &headerv1.Metadata{
 				Name: name,
 			},

--- a/lib/web/machineid.go
+++ b/lib/web/machineid.go
@@ -97,6 +97,8 @@ func (h *Handler) createBot(w http.ResponseWriter, r *http.Request, p httprouter
 	}
 	_, err = clt.BotServiceClient().CreateBot(r.Context(), &machineidv1.CreateBotRequest{
 		Bot: &machineidv1.Bot{
+			Kind:    types.KindBot,
+			Version: types.V1,
 			Metadata: &headerv1.Metadata{
 				Name: req.BotName,
 				Labels: map[string]string{
@@ -237,6 +239,8 @@ func (h *Handler) updateBot(w http.ResponseWriter, r *http.Request, p httprouter
 	updated, err := clt.BotServiceClient().UpdateBot(r.Context(), &machineidv1.UpdateBotRequest{
 		UpdateMask: mask,
 		Bot: &machineidv1.Bot{
+			Kind:    types.KindBot,
+			Version: types.V1,
 			Metadata: &headerv1.Metadata{
 				Name: botName,
 			},

--- a/tool/tctl/common/admin_action_test.go
+++ b/tool/tctl/common/admin_action_test.go
@@ -142,6 +142,8 @@ func (s *adminActionTestSuite) testBots(t *testing.T) {
 	botName := "bot"
 	botReq := &machineidv1pb.CreateBotRequest{
 		Bot: &machineidv1pb.Bot{
+			Kind:    types.KindBot,
+			Version: types.V1,
 			Metadata: &headerv1.Metadata{
 				Name: botName,
 			},

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -306,6 +306,8 @@ func (c *BotsCommand) AddBot(ctx context.Context, client *authclient.Client) err
 	}
 
 	bot := &machineidv1pb.Bot{
+		Kind:    types.KindBot,
+		Version: types.V1,
 		Metadata: &headerv1.Metadata{
 			Name: c.botName,
 		},

--- a/tool/tctl/common/bots_command_test.go
+++ b/tool/tctl/common/bots_command_test.go
@@ -105,6 +105,8 @@ func TestUpdateBotLogins(t *testing.T) {
 			}
 
 			bot := &machineidv1pb.Bot{
+				Kind:    types.KindBot,
+				Version: types.V1,
 				Metadata: &headerv1.Metadata{
 					Name: botName,
 				},
@@ -210,6 +212,8 @@ func TestUpdateBotRoles(t *testing.T) {
 			}
 
 			bot := &machineidv1pb.Bot{
+				Kind:    types.KindBot,
+				Version: types.V1,
 				Metadata: &headerv1.Metadata{
 					Name: botName,
 				},
@@ -257,6 +261,8 @@ func TestAddAndListBotInstancesJSON(t *testing.T) {
 	// Create an initial bot
 	bot, err := client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{
 		Bot: &machineidv1pb.Bot{
+			Kind:    types.KindBot,
+			Version: types.V1,
 			Metadata: &headerv1.Metadata{
 				Name: "test",
 			},

--- a/tool/tctl/common/terraform_command.go
+++ b/tool/tctl/common/terraform_command.go
@@ -250,6 +250,8 @@ func (c *TerraformCommand) createTransientBotAndToken(ctx context.Context, clien
 
 	// Create bot
 	bot := &machineidv1pb.Bot{
+		Kind:    types.KindBot,
+		Version: types.V1,
 		Metadata: &headerv1.Metadata{
 			Name:    botName,
 			Expires: timestamppb.New(time.Now().Add(c.botTTL)),


### PR DESCRIPTION
Today, the RPCs don't require that the Bot Kind/Version is set however this poses a challenge if in the future, we desire to introduce a new soft version or similar. This PR updates all Bot instantiations to specify the Kind of "bot" and Version of "v1". Fortunately, this doesn't pose any significant issues because we don't persist Bots in the backend yet - however it can interfere with the use of functions which accept a generic resource and expect Kind and Version to return correctly.

With this PR merged in v18, we'll be able to enforce that from V19 that Kind/Version must be provided to the RPCs.