### PR TITLE
Revert "Enable 128-bit SIMD operations for WASM build"

### DIFF
--- a/web/packages/shared/package.json
+++ b/web/packages/shared/package.json
@@ -10,7 +10,7 @@
     "directory": "packages/shared"
   },
   "scripts": {
-    "build-wasm": "node ../../scripts/clean-up-ironrdp-artifacts.mjs && RUST_MIN_STACK=16777216 RUSTFLAGS=-Ctarget-feature=+simd128 wasm-pack build ./libs/ironrdp --target web"
+    "build-wasm": "node ../../scripts/clean-up-ironrdp-artifacts.mjs && RUST_MIN_STACK=16777216 wasm-pack build ./libs/ironrdp --target web"
   },
   "dependencies": {
     "@gravitational/design": "workspace:*",


### PR DESCRIPTION
This reverts commit 20fc46baf0725c924e71108e6df282ce033e0632.

The version of wasm-opt that we're using in builds struggles to optimize modules with SIMD instructions, so we need to either figure out how to fix that or determine whether wasm-opt or SIMD have a greater impact on performance.