### PR TITLE
Update proxy AccessGraphSettings permissions

### DIFF
--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -927,6 +927,7 @@ func roleSpecForProxy(clusterName string) types.RoleSpecV6 {
 				types.NewRule(types.KindSecurityReportState, services.RO()),
 				types.NewRule(types.KindUserTask, services.RO()),
 				types.NewRule(types.KindGitServer, services.RO()),
+				types.NewRule(types.KindAccessGraphSettings, services.RO()),
 				// this rule allows cloud proxies to read
 				// plugins of `openai` type, since Assist uses the OpenAI API and runs in Proxy.
 				{

--- a/lib/services/useracl.go
+++ b/lib/services/useracl.go
@@ -196,8 +196,9 @@ func NewUserACL(user types.User, userRoles RoleSet, features proto.Features, des
 	var accessGraphSettings ResourceAccess
 	if features.AccessGraph {
 		accessGraphAccess = newAccess(userRoles, ctx, types.KindAccessGraph)
-		accessGraphSettings = newAccess(userRoles, ctx, types.KindAccessGraphSettings)
 	}
+	// accessGraphSettings should always be enabled for users to interact with demo mode
+	accessGraphSettings = newAccess(userRoles, ctx, types.KindAccessGraphSettings)
 
 	clipboard := userRoles.DesktopClipboard()
 	desktopSessionRecording := desktopRecordingEnabled && userRoles.RecordDesktopSession()

--- a/lib/services/useracl_test.go
+++ b/lib/services/useracl_test.go
@@ -257,7 +257,7 @@ func TestNewAccessGraph(t *testing.T) {
 	t.Run("access graph disabled", func(t *testing.T) {
 		denied := ResourceAccess{false, false, false, false, false, false}
 		userContext := NewUserACL(user, roleSet, proto.Features{}, false, false)
-		require.Empty(t, cmp.Diff(userContext.AccessGraphSettings, denied))
+		require.Empty(t, cmp.Diff(userContext.AccessGraph, denied))
 	})
 
 	t.Run("access graph ACL is false when user doesn't have access even when enabled", func(t *testing.T) {
@@ -265,7 +265,6 @@ func TestNewAccessGraph(t *testing.T) {
 		denied := ResourceAccess{false, false, false, false, false, false}
 		userContext := NewUserACL(user, roleSet, proto.Features{AccessGraph: true}, false, true)
 		require.Empty(t, cmp.Diff(userContext.AccessGraph, denied))
-		require.Empty(t, cmp.Diff(userContext.AccessGraphSettings, denied))
 	})
 
 	t.Run("access graph ACL is true when user has access", func(t *testing.T) {

--- a/web/packages/teleport/src/Roles/PolicyPlaceholder.tsx
+++ b/web/packages/teleport/src/Roles/PolicyPlaceholder.tsx
@@ -46,10 +46,12 @@ const promoFlows = {
 };
 
 export function PolicyPlaceholder({
+  canUpdateAccessGraphSettings,
   currentFlow,
   enableDemoMode,
   roleDiffProps,
 }: {
+  canUpdateAccessGraphSettings: boolean;
   currentFlow: 'creating' | 'updating';
   enableDemoMode?: () => void;
   roleDiffProps?: RoleDiffProps;
@@ -74,7 +76,8 @@ export function PolicyPlaceholder({
           </P>
         </Box>
         <Flex flex="0 0 auto" alignItems="start">
-          {!cfg.isPolicyEnabled &&
+          {canUpdateAccessGraphSettings &&
+            !cfg.isPolicyEnabled &&
             cfg.isCloud &&
             enableDemoMode && ( // cloud can enable a demo mode so show that button
               <ButtonPrimary

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditorVisualizer.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditorVisualizer.test.tsx
@@ -19,7 +19,12 @@
 import { fireEvent, render, screen } from 'design/utils/testing';
 
 import cfg from 'teleport/config';
-import { createTeleportContext } from 'teleport/mocks/contexts';
+import {
+  createTeleportContext,
+  getAcl,
+  noAccess,
+} from 'teleport/mocks/contexts';
+import TeleportContext from 'teleport/teleportContext';
 import TeleportContextProvider from 'teleport/TeleportContextProvider';
 
 import { RoleDiffProps, RoleDiffState } from '../Roles';
@@ -73,6 +78,24 @@ test('Preview Identity Security button displays for cloud users', async () => {
     )
   );
   expect(screen.getByText('Preview Identity Security')).toBeInTheDocument();
+});
+
+test('Preview Identity Security button does not show if user does not have update ACL', async () => {
+  cfg.isCloud = true;
+  const ctx = createTeleportContext({
+    customAcl: { ...getAcl(), accessGraphSettings: noAccess },
+  });
+  render(
+    getComponent(
+      makeRoleDiffProps({
+        roleDiffState: RoleDiffState.Disabled,
+      }),
+      ctx
+    )
+  );
+  expect(
+    screen.queryByText('Preview Identity Security')
+  ).not.toBeInTheDocument();
 });
 
 test('DEMO_READY displays roll diff visualizer with demo banner', async () => {
@@ -139,8 +162,8 @@ function makeRoleDiffProps(props?: Partial<RoleDiffProps>) {
   };
 }
 
-function getComponent(props: RoleDiffProps) {
-  const ctx = createTeleportContext();
+function getComponent(props: RoleDiffProps, customCtx?: TeleportContext) {
+  const ctx = customCtx || createTeleportContext();
   return (
     <TeleportContextProvider ctx={ctx}>
       <RoleEditorVisualizer currentFlow="creating" roleDiffProps={props} />

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditorVisualizer.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditorVisualizer.tsx
@@ -42,6 +42,8 @@ export function RoleEditorVisualizer({
 }) {
   const ctx = useTeleport();
   const version = ctx.storeUser.state.cluster.authVersion;
+  const canUpdateAccessGraphSettings =
+    ctx.storeUser.state.acl.accessGraphSettings.edit;
   // the demo banner should show every time they load the role editor
   const [demoDismissed, setDemoDismissed] = useState(false);
   if (
@@ -95,6 +97,7 @@ export function RoleEditorVisualizer({
   return (
     <Flex flex="1" alignItems="center" justifyContent="center" m={3}>
       <PolicyPlaceholder
+        canUpdateAccessGraphSettings={canUpdateAccessGraphSettings}
         roleDiffProps={roleDiffProps}
         enableDemoMode={roleDiffProps?.enableDemoMode}
         currentFlow={currentFlow}

--- a/web/packages/teleport/src/mocks/contexts.ts
+++ b/web/packages/teleport/src/mocks/contexts.ts
@@ -77,6 +77,7 @@ export const allAccessAcl: Acl = {
   discoverConfigs: fullAccess,
   contacts: fullAccess,
   gitServers: fullAccess,
+  accessGraphSettings: fullAccess,
 };
 
 export function getAcl(cfg?: { noAccess: boolean }) {

--- a/web/packages/teleport/src/services/user/makeAcl.ts
+++ b/web/packages/teleport/src/services/user/makeAcl.ts
@@ -82,6 +82,7 @@ export function makeAcl(json): Acl {
 
   const contacts = json.contact || defaultAccess;
   const gitServers = json.gitServers || defaultAccess;
+  const accessGraphSettings = json.accessGraphSettings || defaultAccess;
 
   return {
     accessList,
@@ -123,6 +124,7 @@ export function makeAcl(json): Acl {
     contacts,
     fileTransferAccess,
     gitServers,
+    accessGraphSettings,
   };
 }
 

--- a/web/packages/teleport/src/services/user/types.ts
+++ b/web/packages/teleport/src/services/user/types.ts
@@ -111,6 +111,7 @@ export interface Acl {
   contacts: Access;
   fileTransferAccess: boolean;
   gitServers: Access;
+  accessGraphSettings: Access;
 }
 
 // AllTraits represent all the traits defined for a user.

--- a/web/packages/teleport/src/services/user/user.test.ts
+++ b/web/packages/teleport/src/services/user/user.test.ts
@@ -58,6 +58,13 @@ test('undefined values in context response gives proper default values', async (
       create: false,
       remove: false,
     },
+    accessGraphSettings: {
+      list: false,
+      read: false,
+      edit: false,
+      create: false,
+      remove: false,
+    },
     accessMonitoringRule: {
       list: false,
       read: false,


### PR DESCRIPTION
This allows proxy to Read AccessGraphSettings, as well as prevents the "Preview Identity Security" button from showing up if the user does not have access to update access graph settings

see more context here https://github.com/gravitational/teleport.e/pull/6231#discussion_r2042666858

