### PR TITLE
Add desktop session-related ACLs to Connect

### DIFF
--- a/gen/proto/go/teleport/lib/teleterm/v1/cluster.pb.go
+++ b/gen/proto/go/teleport/lib/teleterm/v1/cluster.pb.go
@@ -463,8 +463,12 @@ type ACL struct {
 	ActiveSessions *ResourceAccess `protobuf:"bytes,14,opt,name=active_sessions,json=activeSessions,proto3" json:"active_sessions,omitempty"`
 	// review_requests defines the ability to review requests
 	ReviewRequests bool `protobuf:"varint,15,opt,name=review_requests,json=reviewRequests,proto3" json:"review_requests,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Indicates whether the user can share a local directory with the remote machine during desktop sessions.
+	DirectorySharingEnabled bool `protobuf:"varint,16,opt,name=directory_sharing_enabled,json=directorySharingEnabled,proto3" json:"directory_sharing_enabled,omitempty"`
+	// Indicates whether the user can share their clipboard with the remote machine during desktop sessions.
+	ClipboardSharingEnabled bool `protobuf:"varint,17,opt,name=clipboard_sharing_enabled,json=clipboardSharingEnabled,proto3" json:"clipboard_sharing_enabled,omitempty"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
 }
 
 func (x *ACL) Reset() {
@@ -591,6 +595,20 @@ func (x *ACL) GetActiveSessions() *ResourceAccess {
 func (x *ACL) GetReviewRequests() bool {
 	if x != nil {
 		return x.ReviewRequests
+	}
+	return false
+}
+
+func (x *ACL) GetDirectorySharingEnabled() bool {
+	if x != nil {
+		return x.DirectorySharingEnabled
+	}
+	return false
+}
+
+func (x *ACL) GetClipboardSharingEnabled() bool {
+	if x != nil {
+		return x.ClipboardSharingEnabled
 	}
 	return false
 }
@@ -777,7 +795,7 @@ const file_teleport_lib_teleterm_v1_cluster_proto_rawDesc = "" +
 	"\bUserType\x12\x19\n" +
 	"\x15USER_TYPE_UNSPECIFIED\x10\x00\x12\x13\n" +
 	"\x0fUSER_TYPE_LOCAL\x10\x01\x12\x11\n" +
-	"\rUSER_TYPE_SSO\x10\x02\"\xf1\a\n" +
+	"\rUSER_TYPE_SSO\x10\x02\"\xe9\b\n" +
 	"\x03ACL\x12Q\n" +
 	"\x0fauth_connectors\x18\x02 \x01(\v2(.teleport.lib.teleterm.v1.ResourceAccessR\x0eauthConnectors\x12>\n" +
 	"\x05roles\x18\x03 \x01(\v2(.teleport.lib.teleterm.v1.ResourceAccessR\x05roles\x12>\n" +
@@ -793,7 +811,9 @@ const file_teleport_lib_teleterm_v1_cluster_proto_rawDesc = "" +
 	"\x0faccess_requests\x18\f \x01(\v2(.teleport.lib.teleterm.v1.ResourceAccessR\x0eaccessRequests\x12U\n" +
 	"\x11recorded_sessions\x18\r \x01(\v2(.teleport.lib.teleterm.v1.ResourceAccessR\x10recordedSessions\x12Q\n" +
 	"\x0factive_sessions\x18\x0e \x01(\v2(.teleport.lib.teleterm.v1.ResourceAccessR\x0eactiveSessions\x12'\n" +
-	"\x0freview_requests\x18\x0f \x01(\bR\x0ereviewRequestsJ\x04\b\x01\x10\x02R\bsessions\"\x8e\x01\n" +
+	"\x0freview_requests\x18\x0f \x01(\bR\x0ereviewRequests\x12:\n" +
+	"\x19directory_sharing_enabled\x18\x10 \x01(\bR\x17directorySharingEnabled\x12:\n" +
+	"\x19clipboard_sharing_enabled\x18\x11 \x01(\bR\x17clipboardSharingEnabledJ\x04\b\x01\x10\x02R\bsessions\"\x8e\x01\n" +
 	"\x0eResourceAccess\x12\x12\n" +
 	"\x04list\x18\x01 \x01(\bR\x04list\x12\x12\n" +
 	"\x04read\x18\x02 \x01(\bR\x04read\x12\x12\n" +

--- a/gen/proto/ts/teleport/lib/teleterm/v1/cluster_pb.ts
+++ b/gen/proto/ts/teleport/lib/teleterm/v1/cluster_pb.ts
@@ -306,6 +306,18 @@ export interface ACL {
      * @generated from protobuf field: bool review_requests = 15;
      */
     reviewRequests: boolean;
+    /**
+     * Indicates whether the user can share a local directory with the remote machine during desktop sessions.
+     *
+     * @generated from protobuf field: bool directory_sharing_enabled = 16;
+     */
+    directorySharingEnabled: boolean;
+    /**
+     * Indicates whether the user can share their clipboard with the remote machine during desktop sessions.
+     *
+     * @generated from protobuf field: bool clipboard_sharing_enabled = 17;
+     */
+    clipboardSharingEnabled: boolean;
 }
 /**
  * ResourceAccess describes access verbs
@@ -656,12 +668,16 @@ class ACL$Type extends MessageType<ACL> {
             { no: 12, name: "access_requests", kind: "message", T: () => ResourceAccess },
             { no: 13, name: "recorded_sessions", kind: "message", T: () => ResourceAccess },
             { no: 14, name: "active_sessions", kind: "message", T: () => ResourceAccess },
-            { no: 15, name: "review_requests", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
+            { no: 15, name: "review_requests", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
+            { no: 16, name: "directory_sharing_enabled", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
+            { no: 17, name: "clipboard_sharing_enabled", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
         ]);
     }
     create(value?: PartialMessage<ACL>): ACL {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.reviewRequests = false;
+        message.directorySharingEnabled = false;
+        message.clipboardSharingEnabled = false;
         if (value !== undefined)
             reflectionMergePartial<ACL>(this, message, value);
         return message;
@@ -712,6 +728,12 @@ class ACL$Type extends MessageType<ACL> {
                     break;
                 case /* bool review_requests */ 15:
                     message.reviewRequests = reader.bool();
+                    break;
+                case /* bool directory_sharing_enabled */ 16:
+                    message.directorySharingEnabled = reader.bool();
+                    break;
+                case /* bool clipboard_sharing_enabled */ 17:
+                    message.clipboardSharingEnabled = reader.bool();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -767,6 +789,12 @@ class ACL$Type extends MessageType<ACL> {
         /* bool review_requests = 15; */
         if (message.reviewRequests !== false)
             writer.tag(15, WireType.Varint).bool(message.reviewRequests);
+        /* bool directory_sharing_enabled = 16; */
+        if (message.directorySharingEnabled !== false)
+            writer.tag(16, WireType.Varint).bool(message.directorySharingEnabled);
+        /* bool clipboard_sharing_enabled = 17; */
+        if (message.clipboardSharingEnabled !== false)
+            writer.tag(17, WireType.Varint).bool(message.clipboardSharingEnabled);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/lib/teleterm/clusters/cluster.go
+++ b/lib/teleterm/clusters/cluster.go
@@ -198,20 +198,22 @@ func (c *Cluster) GetWithDetails(ctx context.Context, authClient authclient.Clie
 	roleSet := services.NewRoleSet(roles...)
 	userACL := services.NewUserACL(user, roleSet, *authPingResponse.ServerFeatures, false, false)
 	acl := &api.ACL{
-		RecordedSessions: convertToAPIResourceAccess(userACL.RecordedSessions),
-		ActiveSessions:   convertToAPIResourceAccess(userACL.ActiveSessions),
-		AuthConnectors:   convertToAPIResourceAccess(userACL.AuthConnectors),
-		Roles:            convertToAPIResourceAccess(userACL.Roles),
-		Users:            convertToAPIResourceAccess(userACL.Users),
-		TrustedClusters:  convertToAPIResourceAccess(userACL.TrustedClusters),
-		Events:           convertToAPIResourceAccess(userACL.Events),
-		Tokens:           convertToAPIResourceAccess(userACL.Tokens),
-		Servers:          convertToAPIResourceAccess(userACL.Nodes),
-		Apps:             convertToAPIResourceAccess(userACL.AppServers),
-		Dbs:              convertToAPIResourceAccess(userACL.DBServers),
-		Kubeservers:      convertToAPIResourceAccess(userACL.KubeServers),
-		AccessRequests:   convertToAPIResourceAccess(userACL.AccessRequests),
-		ReviewRequests:   userACL.ReviewRequests,
+		RecordedSessions:        convertToAPIResourceAccess(userACL.RecordedSessions),
+		ActiveSessions:          convertToAPIResourceAccess(userACL.ActiveSessions),
+		AuthConnectors:          convertToAPIResourceAccess(userACL.AuthConnectors),
+		Roles:                   convertToAPIResourceAccess(userACL.Roles),
+		Users:                   convertToAPIResourceAccess(userACL.Users),
+		TrustedClusters:         convertToAPIResourceAccess(userACL.TrustedClusters),
+		Events:                  convertToAPIResourceAccess(userACL.Events),
+		Tokens:                  convertToAPIResourceAccess(userACL.Tokens),
+		Servers:                 convertToAPIResourceAccess(userACL.Nodes),
+		Apps:                    convertToAPIResourceAccess(userACL.AppServers),
+		Dbs:                     convertToAPIResourceAccess(userACL.DBServers),
+		Kubeservers:             convertToAPIResourceAccess(userACL.KubeServers),
+		AccessRequests:          convertToAPIResourceAccess(userACL.AccessRequests),
+		ReviewRequests:          userACL.ReviewRequests,
+		DirectorySharingEnabled: userACL.DirectorySharing,
+		ClipboardSharingEnabled: userACL.Clipboard,
 	}
 
 	withDetails := &ClusterWithDetails{

--- a/proto/teleport/lib/teleterm/v1/cluster.proto
+++ b/proto/teleport/lib/teleterm/v1/cluster.proto
@@ -143,6 +143,10 @@ message ACL {
   ResourceAccess active_sessions = 14;
   // review_requests defines the ability to review requests
   bool review_requests = 15;
+  // Indicates whether the user can share a local directory with the remote machine during desktop sessions.
+  bool directory_sharing_enabled = 16;
+  // Indicates whether the user can share their clipboard with the remote machine during desktop sessions.
+  bool clipboard_sharing_enabled = 17;
 }
 
 // ResourceAccess describes access verbs

--- a/web/packages/teleterm/src/services/tshd/testHelpers.ts
+++ b/web/packages/teleterm/src/services/tshd/testHelpers.ts
@@ -135,7 +135,7 @@ export const makeLeafCluster = (
   ...props,
 });
 
-export const makeAcl = (props: Partial<ACL> = {}) => ({
+export const makeAcl = (props: Partial<ACL> = {}): ACL => ({
   recordedSessions: {
     list: true,
     read: true,
@@ -241,6 +241,8 @@ export const makeAcl = (props: Partial<ACL> = {}) => ({
     use: true,
   },
   reviewRequests: true,
+  directorySharingEnabled: true,
+  clipboardSharingEnabled: true,
   ...props,
 });
 


### PR DESCRIPTION
Contributes to https://github.com/gravitational/teleport/issues/20802

ACL names follow the naming convention used in Web UI: https://github.com/gravitational/teleport/blob/c39f0043063696542cc8e461ba5b7810b8913f1c/web/packages/teleport/src/services/user/types.ts#L75-L78

