### PR TITLE
Cache the grpcbox tools for make grpc

### DIFF
--- a/buf-ts.gen.yaml
+++ b/buf-ts.gen.yaml
@@ -18,6 +18,9 @@ plugins:
       - npm
       - exec
       - --yes
+      # we're using an exact version so if the package is already available
+      # there's no need to reach out to the registry, even if we could use more
+      # recent dependencies
       - --prefer-offline
       # this version should be kept in sync with build.assets/Dockerfile-grpcbox
       - --package=@protobuf-ts/plugin@2.9.3

--- a/buf-ts.gen.yaml
+++ b/buf-ts.gen.yaml
@@ -18,6 +18,8 @@ plugins:
       - npm
       - exec
       - --yes
+      - --prefer-offline
+      # this version should be kept in sync with build.assets/Dockerfile-grpcbox
       - --package=@protobuf-ts/plugin@2.9.3
       - --
       - protoc-gen-ts

--- a/build.assets/Dockerfile-grpcbox
+++ b/build.assets/Dockerfile-grpcbox
@@ -4,31 +4,32 @@ FROM docker.io/golang:1.24.2
 
 # Image layers go from less likely to most likely to change.
 RUN apt-get update && \
-  apt-get install -y --no-install-recommends \
-    npm \
-    unzip \
-    && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends npm && \
   rm -rf /var/lib/apt/lists/*
 
-# protoc-gen-js and protoc-gen-ts
-# eg, "1.12.4"
-ARG NODE_GRPC_TOOLS_VERSION
-# eg, "5.0.1"
-ARG NODE_PROTOC_TS_VERSION
-RUN npm install --global "grpc-tools@$NODE_GRPC_TOOLS_VERSION" "grpc_tools_node_protoc_ts@$NODE_PROTOC_TS_VERSION"
+# Pre-cache the `npm exec`ed packages. We execute `true` in the exec environment
+# so `npm exec` will download, build and install packages but not actually run
+# anything.
+#
+# The version should be kept in sync with buf-ts.gen.yaml.
+RUN npm exec --yes --package=@protobuf-ts/plugin@2.9.3 -- true
 
-# buf
-# eg, "v1.26.1"
+# buf version including v, like "v1.26.1"
 ARG BUF_VERSION
-RUN VERSION="$BUF_VERSION"; \
-    go install "github.com/bufbuild/buf/cmd/buf@$VERSION"
+RUN go install "github.com/bufbuild/buf/cmd/buf@${BUF_VERSION}"
 
-# Pre-install go-runned binaries.
+# Pre-cache `go run`ned binaries. We use `true` as the launcher so `go run` will
+# cache the final linked binaries but not actually run anything. This can be
+# verified to work in the final image by using `go run -n` (dry-run) from the
+# teleport workdir to confirm that the binary is immediately available for
+# running.
+#
 # This is meant to be the only step that changes depending on the Teleport
 # branch.
 COPY go.mod go.sum /teleport-module/
-RUN go -C /teleport-module install \
-    connectrpc.com/connect/cmd/protoc-gen-connect-go \
-    github.com/gogo/protobuf/protoc-gen-gogofast \
-    google.golang.org/grpc/cmd/protoc-gen-go-grpc \
-    google.golang.org/protobuf/cmd/protoc-gen-go
+RUN \
+  go -C /teleport-module run -exec true connectrpc.com/connect/cmd/protoc-gen-connect-go && \
+  go -C /teleport-module run -exec true github.com/gogo/protobuf/protoc-gen-gogofast && \
+  go -C /teleport-module run -exec true google.golang.org/grpc/cmd/protoc-gen-go-grpc && \
+  go -C /teleport-module run -exec true google.golang.org/protobuf/cmd/protoc-gen-go && \
+  rm -rf /teleport-module

--- a/build.assets/grpcbox.mk
+++ b/build.assets/grpcbox.mk
@@ -27,9 +27,6 @@ GRPCBOX_RUN := $(DOCKER) run -it --rm -v "$$(pwd)/../:/workdir" -w /workdir $(GR
 grpcbox:
 	$(DOCKER) buildx build \
 		--build-arg BUF_VERSION=$(BUF_VERSION) \
-		--build-arg GOGO_PROTO_TAG=$(GOGO_PROTO_TAG) \
-		--build-arg NODE_GRPC_TOOLS_VERSION=$(NODE_GRPC_TOOLS_VERSION) \
-		--build-arg NODE_PROTOC_TS_VERSION=$(NODE_PROTOC_TS_VERSION) \
 		-f Dockerfile-grpcbox \
 		-t "$(GRPCBOX)" \
 		../


### PR DESCRIPTION
This PR cleans up the "grpcbox" docker image such that no download or go compilation happens during a `make grpc` invocation - currently the go `protoc` plugins end up being compiled (but not downloaded) during generation and `protoc-gen-ts` gets downloaded. In addition, this PR gets rid of some dependencies in the image that are no longer used.