### PR TITLE
Deflake EKS/UserTasks in discovery service

### DIFF
--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -963,13 +963,15 @@ func TestDiscoveryServer(t *testing.T) {
 					instances := installer.GetInstalledInstances()
 					slices.Sort(instances)
 					return slices.Equal(tc.wantInstalledInstances, instances) && len(tc.wantInstalledInstances) == reporter.ResourceCreateEventCount()
-				}, 5000*time.Millisecond, 50*time.Millisecond)
+				}, 5*time.Second, 50*time.Millisecond)
 			} else {
 				require.Never(t, func() bool {
 					return len(installer.GetInstalledInstances()) > 0 || reporter.ResourceCreateEventCount() > 0
 				}, 500*time.Millisecond, 50*time.Millisecond)
 			}
-			require.GreaterOrEqual(t, reporter.DiscoveryFetchEventCount(), 1)
+			require.Eventually(t, func() bool {
+				return reporter.DiscoveryFetchEventCount() > 0
+			}, 5*time.Second, 50*time.Millisecond)
 
 			// Discovery Config Status is updated accordingly
 			if tc.wantDiscoveryConfigStatus != nil {
@@ -1029,7 +1031,7 @@ func fetchAllUserTasks(t *testing.T, userTasksClt services.UserTasks, minUserTas
 			gotResources += len(task.GetSpec().GetDiscoverRds().GetDatabases())
 		}
 		assert.GreaterOrEqual(t, gotResources, minUserTaskResources)
-	}, 5*time.Second, 50*time.Millisecond)
+	}, 10*time.Second, 50*time.Millisecond)
 
 	return existingTasks
 }

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -963,7 +963,7 @@ func TestDiscoveryServer(t *testing.T) {
 					instances := installer.GetInstalledInstances()
 					slices.Sort(instances)
 					return slices.Equal(tc.wantInstalledInstances, instances) && len(tc.wantInstalledInstances) == reporter.ResourceCreateEventCount()
-				}, 5*time.Second, 50*time.Millisecond)
+				}, 10*time.Second, 50*time.Millisecond)
 			} else {
 				require.Never(t, func() bool {
 					return len(installer.GetInstalledInstances()) > 0 || reporter.ResourceCreateEventCount() > 0

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -971,7 +971,7 @@ func TestDiscoveryServer(t *testing.T) {
 			}
 			require.Eventually(t, func() bool {
 				return reporter.DiscoveryFetchEventCount() > 0
-			}, 5*time.Second, 50*time.Millisecond)
+			}, 10*time.Second, 50*time.Millisecond)
 
 			// Discovery Config Status is updated accordingly
 			if tc.wantDiscoveryConfigStatus != nil {


### PR DESCRIPTION
The `github.com/gravitational/teleport/lib/srv/discovery.TestDiscoveryServer/multiple_EKS_clusters_failed_to_autoenroll_and_user_tasks_are_created` is flaky and we've seen some reports.
Example:
https://github.com/gravitational/teleport.e/actions/runs/14442884133/job/40496811837

While I couldn't reproduce the test failure locally, while doing so, I was able to get other failures.

This PR increments some timeouts before returning a failure.
This helped to fix the failures that I was able to reproduce locally.

Hopefully, it will also fix the `TestDiscoveryServer/multiple_EKS_clusters_failed_to_autoenroll_and_user_tasks_are_created` test