### PR TITLE
Set min and max width for LoginForm

### DIFF
--- a/web/packages/teleport/src/components/FormLogin/FormLogin.tsx
+++ b/web/packages/teleport/src/components/FormLogin/FormLogin.tsx
@@ -91,7 +91,7 @@ export default function LoginForm(props: Props) {
 
   // Everything below requires local auth to be enabled.
   return (
-    <Card my="5" mx="auto" width={500} py={4}>
+    <Card my="5" mx="auto" maxWidth={500} minWidth={300} py={4}>
       <Text typography="h1" mb={4} textAlign="center">
         Sign in to Teleport
       </Text>


### PR DESCRIPTION
When viewing the Teleport login screen on mobile/smaller screen sizes, anything below 500 would begin to add a horizontal scroll bar. this is because the width was set explicitly to 500px. This change sets the `maxWidth` to 500 instead, and then a some _reasonable but arbitrary_ `minWidth` to 300. anything below 300 will still have the horizontal scroll bar but is also quite unusable anyway so, I chose 300.

the goal is for no horizontal scroll (with mobile devices) and centered Logo


problem (image is off center and horizontal scroll bar)
![image](https://github.com/user-attachments/assets/c1dd737a-3664-4598-872c-cb73f5449e9c)


300
![Screenshot 2025-04-15 at 12 04 30 PM](https://github.com/user-attachments/assets/e22bcd90-6b28-4a23-b098-34d317ed4d29)

400
![Screenshot 2025-04-15 at 12 04 39 PM](https://github.com/user-attachments/assets/eb5e3c97-10d6-4a5a-8d26-e5161087dcac)


>500
![Screenshot 2025-04-15 at 12 04 46 PM](https://github.com/user-attachments/assets/cd868554-e5b9-4828-933f-3e3c006bba62)
