### PR TITLE
[v15] Make UnknownResource proto-friendly

### DIFF
--- a/lib/services/github.go
+++ b/lib/services/github.go
@@ -163,7 +163,15 @@ func UnmarshalOSSGithubConnector(bytes []byte, opts ...MarshalOption) (types.Git
 
 // MarshalGithubConnector marshals a GithubConnector resource to JSON.
 func MarshalGithubConnector(connector types.GithubConnector, opts ...MarshalOption) ([]byte, error) {
-	return MarshalResource(connector, opts...)
+	marshal, ok := getResourceMarshaler(connector.GetKind())
+	if !ok {
+		return nil, trace.NotImplemented("cannot dynamically marshal resources of kind %q", connector.GetKind())
+	}
+	m, err := marshal(connector, opts...)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return m, nil
 }
 
 // MarshalOSSGithubConnector marshals the open source variant of the GithubConnector resource to JSON.

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -730,31 +730,6 @@ func CheckAndSetDefaults(r any) error {
 	return nil
 }
 
-// MarshalResource attempts to marshal a resource dynamically, returning NotImplementedError
-// if no marshaler has been registered.
-//
-// NOTE: This function only supports the subset of resources which may be imported/exported
-// by users (e.g. via `tctl get`).
-func MarshalResource(resource types.Resource, opts ...MarshalOption) ([]byte, error) {
-	marshal, ok := getResourceMarshaler(resource.GetKind())
-	if !ok {
-		return nil, trace.NotImplemented("cannot dynamically marshal resources of kind %q", resource.GetKind())
-	}
-	// Handle the case where `resource` was never fully unmarshaled.
-	if r, ok := resource.(*UnknownResource); ok {
-		u, err := UnmarshalResource(r.GetKind(), r.Raw, opts...)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		resource = u
-	}
-	m, err := marshal(resource, opts...)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return m, nil
-}
-
 // UnmarshalResource attempts to unmarshal a resource dynamically, returning NotImplementedError
 // if no unmarshaler has been registered.
 //
@@ -772,22 +747,26 @@ func UnmarshalResource(kind string, raw []byte, opts ...MarshalOption) (types.Re
 	return u, nil
 }
 
+type MetadataWithRawID struct {
+	ID json.RawMessage `json:"id,omitempty"`
+	types.Metadata
+}
+
 // UnknownResource is used to detect resources
 type UnknownResource struct {
-	types.ResourceHeader
+	Kind              string `json:"kind,omitempty"`
+	MetadataWithRawID `json:"metadata,omitempty"`
 	// Raw is raw representation of the resource
-	Raw []byte
+	Raw []byte `json:"-"`
 }
 
 // UnmarshalJSON unmarshals header and captures raw state
 func (u *UnknownResource) UnmarshalJSON(raw []byte) error {
-	var h types.ResourceHeader
-	if err := json.Unmarshal(raw, &h); err != nil {
+	type rawUnknownResource UnknownResource
+	if err := json.Unmarshal(raw, (*rawUnknownResource)(u)); err != nil {
 		return trace.Wrap(err)
 	}
-	u.Raw = make([]byte, len(raw))
-	u.ResourceHeader = h
-	copy(u.Raw, raw)
+	u.Raw = append([]byte(nil), raw...)
 	return nil
 }
 


### PR DESCRIPTION
**This is not a backport, please review this PR as new code**

This PR fixes an issue found when backporting autoupdates to branch/v15. I think that this issue affects `autoupdate_version` and `autoupdate_config` that have already been backported.

## The problem

In v16 we removed `metadata.id`, in v15 the field is still present. The ID is marshalled as a string by protojson, and as an integer by `json.Marshal`. This inconsistency makes tsh/tctl and every function parsing a manifest as `UnknownResource` trip on proto resources.

## The solution

In every case but the GitHub connector (which we'll discuss below), `UnknownResource` is used only to recover the kind. By not unmarshalling other fields, we avoid hitting the issue. Once we got the proper kind, we are passing the manifest to the proper resource unmarshaller which will use `json` or `protojson` depending on the resource.

## The GitHub connector case

For some reason github connector was the only user of `MarshalResource()`. This made little sense because the connector in the function args is already typed and we can get the right marshaller without trying to figure out the resource kind via UnknownResource unmarshalling.

Note for reviewers: tests which detected this specific failure are in [this PR](https://github.com/gravitational/teleport/pull/53286). With this commit, the tests are now passing.

Changelog: fix a bug in Teleport 15 causing `autoupdate_version` and `autoupdate_config` creation to fail when `metadata.id` field is set.