### PR TITLE
Standardize dashboard styles

### DIFF
--- a/web/packages/design/src/SyncStamp/SyncStamp.story.tsx
+++ b/web/packages/design/src/SyncStamp/SyncStamp.story.tsx
@@ -1,0 +1,25 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { SyncStamp } from './SyncStamp';
+
+export default {
+  title: 'Design/SyncStamp',
+};
+
+export const Story = () => <SyncStamp date={new Date()} />;

--- a/web/packages/design/src/SyncStamp/SyncStamp.test.tsx
+++ b/web/packages/design/src/SyncStamp/SyncStamp.test.tsx
@@ -1,0 +1,26 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { render, screen } from 'design/utils/testing';
+
+import { SyncStamp } from './SyncStamp';
+
+test('renders time since date', () => {
+  render(<SyncStamp date={new Date()} />);
+  expect(screen.getByText('Last Sync: 0 seconds ago')).toBeInTheDocument();
+});

--- a/web/packages/design/src/SyncStamp/SyncStamp.tsx
+++ b/web/packages/design/src/SyncStamp/SyncStamp.tsx
@@ -1,0 +1,37 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { formatDistanceStrict } from 'date-fns';
+
+import Flex from 'design/Flex';
+import { SyncAlt } from 'design/Icon';
+import { P3 } from 'design/Text';
+
+export function SyncStamp({ date }: { date: Date }) {
+  return (
+    <Flex data-testid="sync">
+      <SyncAlt color="text.muted" size="small" mr={1} />
+      <P3 color="text.muted">
+        Last Sync:{' '}
+        {formatDistanceStrict(new Date(date), new Date(), {
+          addSuffix: true,
+        })}
+      </P3>
+    </Flex>
+  );
+}

--- a/web/packages/design/src/SyncStamp/index.ts
+++ b/web/packages/design/src/SyncStamp/index.ts
@@ -1,0 +1,19 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export { SyncStamp } from './SyncStamp';

--- a/web/packages/design/src/index.ts
+++ b/web/packages/design/src/index.ts
@@ -46,6 +46,7 @@ import { Pill } from './Pill';
 import Popover from './Popover';
 import { ResourceIcon } from './ResourceIcon';
 import { StepSlider } from './StepSlider';
+import { SyncStamp } from './SyncStamp';
 import Text, {
   H1,
   H2,
@@ -106,6 +107,7 @@ export {
   Subtitle1,
   Subtitle2,
   Subtitle3,
+  SyncStamp,
   Text,
   TextArea,
   Toggle,

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.tsx
@@ -60,7 +60,7 @@ export function AwsOidcDashboard() {
   return (
     <>
       <AwsOidcHeader integration={integration} />
-      <FeatureBox maxWidth={1440} margin="auto" gap={3} paddingLeft={5}>
+      <FeatureBox maxWidth={1440} margin="auto" gap={3}>
         {integration && (
           <>
             <AwsOidcTitle integration={integration} />

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcHeader.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcHeader.tsx
@@ -45,12 +45,11 @@ export function AwsOidcHeader({
     <Flex
       alignItems="center"
       borderBottom={1}
-      borderColor="levels.surface"
+      borderColor="interactive.tonal.neutral.0"
       width={'100%'}
-      pl={5}
+      pl={6}
       py={1}
       gap={1}
-      my={2}
       data-testid="aws-oidc-header"
     >
       <HoverTooltip placement="bottom" tipContent="Back to Integrations">

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcTitle.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcTitle.tsx
@@ -65,17 +65,22 @@ export function AwsOidcTitle({
   }
 
   return (
-    <Flex justifyContent="space-between">
+    <Flex mt={3} justifyContent="space-between" alignItems="center">
       <Flex alignItems="center" data-testid="aws-oidc-title">
         <HoverTooltip placement="bottom" tipContent={content.helper}>
           <ButtonIcon as={InternalLink} to={content.to} aria-label="back">
             <ArrowLeft size="medium" />
           </ButtonIcon>
         </HoverTooltip>
-        <Flex flexDirection="column" mx={2}>
-          <Text bold fontSize={6}>
-            {content.content}
-          </Text>
+        <Flex flexDirection="column" ml={1}>
+          <Flex alignItems="center" gap={2}>
+            <Text bold fontSize={6}>
+              {content.content}
+            </Text>
+            <Label kind={labelKind} aria-label="status" px={3}>
+              {status}
+            </Label>
+          </Flex>
           <Flex gap={1}>
             Role ARN:{' '}
             <Link
@@ -92,9 +97,6 @@ export function AwsOidcTitle({
             </Link>
           </Flex>
         </Flex>
-        <Label kind={labelKind} aria-label="status" px={3}>
-          {status}
-        </Label>
       </Flex>
       <Flex gap={1} alignItems="center">
         {!resource && !tasks && (

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Details.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Details.tsx
@@ -72,7 +72,7 @@ export function Details() {
       {integration && (
         <AwsOidcHeader integration={integration} resource={resourceKind} />
       )}
-      <FeatureBox maxWidth={1440} margin="auto" gap={3} paddingLeft={5}>
+      <FeatureBox maxWidth={1440} margin="auto" gap={3}>
         <>
           {integration && (
             <>

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/StatCard.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/StatCard.tsx
@@ -16,12 +16,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { formatDistanceStrict } from 'date-fns';
 import { Link as InternalLink } from 'react-router-dom';
 
 import { CardTile, Flex, H2, P2, Text } from 'design';
 import * as Icons from 'design/Icon';
 import { ResourceIcon } from 'design/ResourceIcon';
+import { SyncStamp } from 'design/SyncStamp/SyncStamp';
 
 import cfg from 'teleport/config';
 import { EnrollCard } from 'teleport/Integrations/status/AwsOidc/EnrollCard';
@@ -104,18 +104,7 @@ export function StatCard({ name, item, resource, summary }: StatCardProps) {
             </Flex>
           </Flex>
         </Flex>
-        {updated && (
-          <Text
-            typography="body3"
-            color="text.slightlyMuted"
-            data-testid="sync"
-          >
-            Last Sync:{' '}
-            {formatDistanceStrict(new Date(updated), new Date(), {
-              addSuffix: true,
-            })}
-          </Text>
-        )}
+        {updated && <SyncStamp date={updated} />}
       </Flex>
     </CardTile>
   );

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/SidePanel.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/SidePanel.tsx
@@ -38,7 +38,7 @@ export const SidePanel = ({
       width="500px"
       flexDirection="column"
       borderLeft={1}
-      borderColor="levels.surface"
+      borderColor="interactive.tonal.neutral.0"
     >
       <Flex alignItems="center" justifyContent="space-between" my={3} px={4}>
         {header}


### PR DESCRIPTION
Continuing to [standardize](https://www.figma.com/design/Gpjs9vjhzUKF1GDbeG9JGE/Application-Design-System?node-id=19783-7260&p=f&m=dev) the Okta/AWS oidc dashboards. This PR updates the aws oidc dash.

* Adds a design component called SyncStamp which should be used to show time since update (after merge, can update other dash cards to use shared component)
* Removes inline 32 padding (which was per design) to match other implementations of 40px
* Use interactive colors instead of levels
* Reorganize the title bar such that the status pill is inline with the main header rather than centered on the header+subheader