### PR TITLE
[v17] Add support for Where expression to Bot resource CRUD

### DIFF
--- a/api/types/resource_153.go
+++ b/api/types/resource_153.go
@@ -366,6 +366,14 @@ type protoResource153ToLegacyAdapter struct {
 	resource153ToLegacyAdapter
 }
 
+// UnwrapT is an escape hatch for Resource153 instances that are piped down into
+// the codebase as a legacy Resource.
+//
+// Ideally you shouldn't depend on this.
+func (r *protoResource153ToLegacyAdapter[T]) UnwrapT() T {
+	return r.inner
+}
+
 // MarshalJSON adds support for marshaling the wrapped resource (instead of
 // marshaling the adapter itself).
 func (r *protoResource153ToLegacyAdapter) MarshalJSON() ([]byte, error) {

--- a/api/types/resource_153.go
+++ b/api/types/resource_153.go
@@ -366,14 +366,6 @@ type protoResource153ToLegacyAdapter struct {
 	resource153ToLegacyAdapter
 }
 
-// UnwrapT is an escape hatch for Resource153 instances that are piped down into
-// the codebase as a legacy Resource.
-//
-// Ideally you shouldn't depend on this.
-func (r *protoResource153ToLegacyAdapter[T]) UnwrapT() T {
-	return r.inner
-}
-
 // MarshalJSON adds support for marshaling the wrapped resource (instead of
 // marshaling the adapter itself).
 func (r *protoResource153ToLegacyAdapter) MarshalJSON() ([]byte, error) {

--- a/lib/auth/machineid/machineidv1/bot_service.go
+++ b/lib/auth/machineid/machineidv1/bot_service.go
@@ -193,7 +193,9 @@ func (bs *BotService) GetBot(ctx context.Context, req *pb.GetBotRequest) (*pb.Bo
 	if err := authCtx.CheckAccessToResource153(
 		bot, types.VerbRead,
 	); err != nil {
-		return nil, trace.Wrap(err)
+		// Return NotFound rather than Forbidden to avoid leaking existence of
+		// bot.
+		return nil, trace.NotFound("bot %q not found", req.BotName)
 	}
 
 	return bot, nil

--- a/lib/auth/machineid/machineidv1/bot_service.go
+++ b/lib/auth/machineid/machineidv1/bot_service.go
@@ -263,8 +263,8 @@ func (bs *BotService) CreateBot(
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToResource(
-		types.ProtoResource153ToLegacy(req.Bot),
+	if err := authCtx.CheckAccessToResource153(
+		req.Bot,
 		types.VerbCreate,
 	); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/machineid/machineidv1/bot_service.go
+++ b/lib/auth/machineid/machineidv1/bot_service.go
@@ -658,7 +658,7 @@ func (bs *BotService) DeleteBot(
 // that these fields are set correctly.
 func setKindAndVersion(b *pb.Bot) error {
 	if b == nil {
-		return trace.BadParameter("must be non-nil bot")
+		return trace.BadParameter("bot: must be non-nil")
 	}
 	if b.Kind == "" {
 		b.Kind = types.KindBot

--- a/lib/auth/machineid/machineidv1/bot_service.go
+++ b/lib/auth/machineid/machineidv1/bot_service.go
@@ -191,7 +191,7 @@ func (bs *BotService) GetBot(ctx context.Context, req *pb.GetBotRequest) (*pb.Bo
 	}
 
 	if err := authCtx.CheckAccessToResource153(
-		bot, types.KindBot, types.VerbRead,
+		bot, types.VerbRead,
 	); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -256,7 +256,7 @@ func (bs *BotService) ListBots(
 
 		// Check if user can access this specific Bot.
 		if err := authCtx.CheckAccessToResource153(
-			bot, types.KindBot, types.VerbList,
+			bot, types.VerbList,
 		); err != nil {
 			continue
 		}

--- a/lib/auth/machineid/machineidv1/bot_service.go
+++ b/lib/auth/machineid/machineidv1/bot_service.go
@@ -166,7 +166,9 @@ func (bs *BotService) GetBot(ctx context.Context, req *pb.GetBotRequest) (*pb.Bo
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(types.KindBot, types.VerbRead); err != nil {
+	if err := authCtx.MaybeAccessToKind(
+		types.KindBot, types.VerbRead,
+	); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -188,6 +190,12 @@ func (bs *BotService) GetBot(ctx context.Context, req *pb.GetBotRequest) (*pb.Bo
 		return nil, trace.Wrap(err, "converting from resources")
 	}
 
+	if err := authCtx.CheckAccessToResource153(
+		bot, types.KindBot, types.VerbRead,
+	); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	return bot, nil
 }
 
@@ -200,7 +208,11 @@ func (bs *BotService) ListBots(
 		return nil, trace.Wrap(err)
 	}
 
-	if err := authCtx.CheckAccessToKind(types.KindBot, types.VerbList); err != nil {
+	// Check generally if this user may have the ability to list bots - ignoring
+	// where conditions.
+	if err := authCtx.MaybeAccessToKind(
+		types.KindBot, types.VerbList,
+	); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -241,6 +253,14 @@ func (bs *BotService) ListBots(
 			)
 			continue
 		}
+
+		// Check if user can access this specific Bot.
+		if err := authCtx.CheckAccessToResource153(
+			bot, types.KindBot, types.VerbList,
+		); err != nil {
+			continue
+		}
+
 		bots = append(bots, bot)
 	}
 

--- a/lib/auth/machineid/machineidv1/machineidv1_test.go
+++ b/lib/auth/machineid/machineidv1/machineidv1_test.go
@@ -89,7 +89,7 @@ func TestCreateBot(t *testing.T) {
 			{
 				Resources: []string{types.KindBot},
 				Verbs:     []string{types.VerbCreate},
-				Where:     `startsWith(name, "foo")`,
+				Where:     `startsWith(resource.metadata.name, "foo")`,
 			},
 		})
 	require.NoError(t, err)
@@ -382,7 +382,7 @@ func TestCreateBot(t *testing.T) {
 					},
 				},
 			},
-			assertError: require.NoError,
+			assertError: require.Error,
 		},
 		{
 			name: "bot already exists",

--- a/lib/auth/machineid/machineidv1/machineidv1_test.go
+++ b/lib/auth/machineid/machineidv1/machineidv1_test.go
@@ -901,6 +901,14 @@ func TestUpsertBot(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+	botWhereCreator, _, err := auth.CreateUserAndRole(srv.Auth(), "bot-where-creator", []string{}, []types.Rule{
+		{
+			Resources: []string{types.KindBot},
+			Verbs:     []string{types.VerbCreate, types.VerbUpdate},
+			Where:     `startsWith(resource.metadata.name, "foo")`,
+		},
+	})
+	require.NoError(t, err)
 	testRole, err := auth.CreateRole(ctx, srv.Auth(), "test-role", types.RoleSpecV6{})
 	require.NoError(t, err)
 	unprivilegedUser, err := auth.CreateUser(ctx, srv.Auth(), "no-perms", testRole)
@@ -1208,9 +1216,56 @@ func TestUpsertBot(t *testing.T) {
 			},
 		},
 		{
+			name: "new with where",
+			user: botWhereCreator.GetName(),
+			req: &machineidv1pb.UpsertBotRequest{
+				Bot: &machineidv1pb.Bot{
+					Kind:    types.KindBot,
+					Version: types.V1,
+					Metadata: &headerv1.Metadata{
+						Name: "foo-new",
+					},
+					Spec: &machineidv1pb.BotSpec{
+						Roles: []string{testRole.GetName()},
+					},
+				},
+			},
+			assertError: require.NoError,
+		},
+		{
+			name: "failed new with where",
+			user: botWhereCreator.GetName(),
+			req: &machineidv1pb.UpsertBotRequest{
+				Bot: &machineidv1pb.Bot{
+					Kind:    types.KindBot,
+					Version: types.V1,
+					Metadata: &headerv1.Metadata{
+						Name: "not-foo-new",
+					},
+					Spec: &machineidv1pb.BotSpec{
+						Roles: []string{testRole.GetName()},
+					},
+				},
+			},
+			assertError: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAccessDenied(err), "error should be access denied")
+			},
+		},
+		{
 			name: "no permissions",
 			user: unprivilegedUser.GetName(),
-			req:  &machineidv1pb.UpsertBotRequest{},
+			req: &machineidv1pb.UpsertBotRequest{
+				Bot: &machineidv1pb.Bot{
+					Kind:    types.KindBot,
+					Version: types.V1,
+					Metadata: &headerv1.Metadata{
+						Name: "not-foo-new",
+					},
+					Spec: &machineidv1pb.BotSpec{
+						Roles: []string{testRole.GetName()},
+					},
+				},
+			},
 
 			assertError: func(t require.TestingT, err error, i ...interface{}) {
 				require.True(t, trace.IsAccessDenied(err), "error should be access denied")
@@ -1334,6 +1389,17 @@ func TestGetBot(t *testing.T) {
 			},
 		})
 	require.NoError(t, err)
+	botGetterWhereUser, _, err := auth.CreateUserAndRole(
+		srv.Auth(),
+		"bot-getter",
+		[]string{},
+		[]types.Rule{
+			{
+				Resources: []string{types.KindBot},
+				Verbs:     []string{types.VerbRead},
+			},
+		})
+	require.NoError(t, err)
 	testRole, err := auth.CreateRole(
 		ctx, srv.Auth(), "test-role", types.RoleSpecV6{},
 	)
@@ -1363,6 +1429,22 @@ func TestGetBot(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
+	preExistingBot2, err := client.BotServiceClient().CreateBot(
+		ctx,
+		&machineidv1pb.CreateBotRequest{
+			Bot: &machineidv1pb.Bot{
+				Kind:    types.KindBot,
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "foo-pre-existing",
+				},
+				Spec: &machineidv1pb.BotSpec{
+					Roles: []string{testRole.GetName()},
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
 
 	tests := []struct {
 		name        string
@@ -1374,6 +1456,26 @@ func TestGetBot(t *testing.T) {
 		{
 			name: "success",
 			user: botGetterUser.GetName(),
+			req: &machineidv1pb.GetBotRequest{
+				BotName: preExistingBot.Metadata.Name,
+			},
+
+			assertError: require.NoError,
+			want:        preExistingBot,
+		},
+		{
+			name: "success with where",
+			user: botGetterWhereUser.GetName(),
+			req: &machineidv1pb.GetBotRequest{
+				BotName: preExistingBot2.Metadata.Name,
+			},
+
+			assertError: require.NoError,
+			want:        preExistingBot2,
+		},
+		{
+			name: "no permissions with where",
+			user: botGetterWhereUser.GetName(),
 			req: &machineidv1pb.GetBotRequest{
 				BotName: preExistingBot.Metadata.Name,
 			},
@@ -1596,6 +1698,18 @@ func TestDeleteBot(t *testing.T) {
 			},
 		})
 	require.NoError(t, err)
+	botWhereDeleterUser, _, err := auth.CreateUserAndRole(
+		srv.Auth(),
+		"bot-deleter-where",
+		[]string{},
+		[]types.Rule{
+			{
+				Resources: []string{types.KindBot},
+				Verbs:     []string{types.VerbDelete},
+				Where:     `startsWith(resource.metadata.name, "foo")`,
+			},
+		})
+	require.NoError(t, err)
 	testRole, err := auth.CreateRole(
 		ctx, srv.Auth(), "test-role", types.RoleSpecV6{},
 	)
@@ -1646,6 +1760,38 @@ func TestDeleteBot(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
+	preExistingBot4, err := client.BotServiceClient().CreateBot(
+		ctx,
+		&machineidv1pb.CreateBotRequest{
+			Bot: &machineidv1pb.Bot{
+				Kind:    types.KindBot,
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "foo-pre-existing",
+				},
+				Spec: &machineidv1pb.BotSpec{
+					Roles: []string{testRole.GetName()},
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+	preExistingBot5, err := client.BotServiceClient().CreateBot(
+		ctx,
+		&machineidv1pb.CreateBotRequest{
+			Bot: &machineidv1pb.Bot{
+				Kind:    types.KindBot,
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "not-foo-pre-existing",
+				},
+				Spec: &machineidv1pb.BotSpec{
+					Roles: []string{testRole.GetName()},
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
 
 	tests := []struct {
 		name                  string
@@ -1662,6 +1808,25 @@ func TestDeleteBot(t *testing.T) {
 			},
 			assertError:           require.NoError,
 			checkResourcesDeleted: true,
+		},
+		{
+			name: "success with where",
+			user: botWhereDeleterUser.GetName(),
+			req: &machineidv1pb.DeleteBotRequest{
+				BotName: preExistingBot4.Metadata.Name,
+			},
+			assertError:           require.NoError,
+			checkResourcesDeleted: true,
+		},
+		{
+			name: "no permissions with where",
+			user: botWhereDeleterUser.GetName(),
+			req: &machineidv1pb.DeleteBotRequest{
+				BotName: preExistingBot5.Metadata.Name,
+			},
+			assertError: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAccessDenied(err), "error should be access denied")
+			},
 		},
 		{
 			name: "no permissions",

--- a/lib/auth/machineid/machineidv1/machineidv1_test.go
+++ b/lib/auth/machineid/machineidv1/machineidv1_test.go
@@ -1402,12 +1402,13 @@ func TestGetBot(t *testing.T) {
 	require.NoError(t, err)
 	botGetterWhereUser, _, err := auth.CreateUserAndRole(
 		srv.Auth(),
-		"bot-getter",
+		"bot-getter-where",
 		[]string{},
 		[]types.Rule{
 			{
 				Resources: []string{types.KindBot},
 				Verbs:     []string{types.VerbRead},
+				Where:     `has_prefix(resource.metadata.name, "foo")`,
 			},
 		})
 	require.NoError(t, err)
@@ -1490,9 +1491,9 @@ func TestGetBot(t *testing.T) {
 			req: &machineidv1pb.GetBotRequest{
 				BotName: preExistingBot.Metadata.Name,
 			},
-
-			assertError: require.NoError,
-			want:        preExistingBot,
+			assertError: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsNotFound(err), "error should be not found")
+			},
 		},
 		{
 			name: "no permissions",

--- a/lib/auth/machineid/machineidv1/machineidv1_test.go
+++ b/lib/auth/machineid/machineidv1/machineidv1_test.go
@@ -1442,6 +1442,7 @@ func TestListBots(t *testing.T) {
 			{
 				Resources: []string{types.KindBot},
 				Verbs:     []string{types.VerbList},
+				Where:     `startsWith(resource.metadata.name, "foo")`,
 			},
 		})
 	require.NoError(t, err)

--- a/lib/auth/machineid/machineidv1/machineidv1_test.go
+++ b/lib/auth/machineid/machineidv1/machineidv1_test.go
@@ -89,7 +89,7 @@ func TestCreateBot(t *testing.T) {
 			{
 				Resources: []string{types.KindBot},
 				Verbs:     []string{types.VerbCreate},
-				Where:     `startsWith(resource.metadata.name, "foo")`,
+				Where:     `has_prefix(resource.metadata.name, "foo")`,
 			},
 		})
 	require.NoError(t, err)
@@ -916,7 +916,7 @@ func TestUpsertBot(t *testing.T) {
 		{
 			Resources: []string{types.KindBot},
 			Verbs:     []string{types.VerbCreate, types.VerbUpdate},
-			Where:     `startsWith(resource.metadata.name, "foo")`,
+			Where:     `has_prefix(resource.metadata.name, "foo")`,
 		},
 	})
 	require.NoError(t, err)
@@ -1566,7 +1566,7 @@ func TestListBots(t *testing.T) {
 			{
 				Resources: []string{types.KindBot},
 				Verbs:     []string{types.VerbList},
-				Where:     `startsWith(resource.metadata.name, "foo")`,
+				Where:     `has_prefix(resource.metadata.name, "foo")`,
 			},
 		})
 	require.NoError(t, err)
@@ -1717,7 +1717,7 @@ func TestDeleteBot(t *testing.T) {
 			{
 				Resources: []string{types.KindBot},
 				Verbs:     []string{types.VerbDelete},
-				Where:     `startsWith(resource.metadata.name, "foo")`,
+				Where:     `has_prefix(resource.metadata.name, "foo")`,
 			},
 		})
 	require.NoError(t, err)

--- a/lib/auth/machineid/machineidv1/machineidv1_test.go
+++ b/lib/auth/machineid/machineidv1/machineidv1_test.go
@@ -699,7 +699,18 @@ func TestUpdateBot(t *testing.T) {
 		{
 			name: "no permissions",
 			user: unprivilegedUser.GetName(),
-			req:  &machineidv1pb.UpdateBotRequest{},
+			req: &machineidv1pb.UpdateBotRequest{
+				Bot: &machineidv1pb.Bot{
+					Kind:    types.KindBot,
+					Version: types.V1,
+					Metadata: &headerv1.Metadata{
+						Name: "valid-bot",
+					},
+					Spec: &machineidv1pb.BotSpec{
+						Roles: []string{beforeRole.GetName()},
+					},
+				},
+			},
 			assertError: func(t require.TestingT, err error, i ...interface{}) {
 				require.True(t, trace.IsAccessDenied(err), "error should be access denied")
 			},

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1497,6 +1497,25 @@ func (c *Context) CheckAccessToKind(kind string, verb string, additionalVerbs ..
 	return c.CheckAccessToRule(ruleCtx, kind, verb, additionalVerbs...)
 }
 
+// MaybeAccessToKind will check if the user has access to the given verbs for
+// the given kind, ignoring any where clauses configured. This is useful for
+// avoiding work where the user has no chance of having access to the resource.
+// Prefer using CheckAccessToResource where feasible.
+func (c *Context) MaybeAccessToKind(kind string, verb string, additionalVerbs ...string) error {
+	ruleCtx := &services.Context{
+		User: c.User,
+	}
+
+	var errs []error
+	for _, verb := range append(additionalVerbs, verb) {
+		if err := c.Checker.GuessIfAccessIsPossible(ruleCtx, defaults.Namespace, kind, verb); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return trace.NewAggregate(errs...)
+}
+
 // CheckAccessToResource will ensure that the user has access to the given verbs for the given resource.
 func (c *Context) CheckAccessToResource(resource types.Resource, verb string, additionalVerbs ...string) error {
 	ruleCtx := &services.Context{

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1507,6 +1507,16 @@ func (c *Context) CheckAccessToResource(resource types.Resource, verb string, ad
 	return c.CheckAccessToRule(ruleCtx, resource.GetKind(), verb, additionalVerbs...)
 }
 
+// CheckAccessToResource153 will ensure that the user has access to the given verbs for the given resource.
+func (c *Context) CheckAccessToResource153(resource types.Resource153, verb string, additionalVerbs ...string) error {
+	ruleCtx := &services.Context{
+		User:        c.User,
+		Resource153: resource,
+	}
+
+	return c.CheckAccessToRule(ruleCtx, resource.GetKind(), verb, additionalVerbs...)
+}
+
 // CheckAccessToRule will ensure that the user has access to the given verbs for the given [services.Context] and kind.
 // Prefer to use [Context.CheckAccessToKind] or [Context.CheckAccessToResource] for common checks.
 func (c *Context) CheckAccessToRule(ruleCtx *services.Context, kind string, verb string, additionalVerbs ...string) error {

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -65,6 +65,14 @@ type AccessChecker interface {
 	// CheckAccessToRule checks access to a rule within a namespace.
 	CheckAccessToRule(context RuleContext, namespace string, rule string, verb string) error
 
+	// GuessIfAccessIsPossible guesses if access is possible for an entire category
+	// of resources.
+	// It responds the question: "is it possible that there is a resource of this
+	// kind that the current user can access?".
+	// GuessIfAccessIsPossible is used, mainly, for UI decisions ("should the tab
+	// for resource X appear"?). Most callers should use CheckAccessToRule instead.
+	GuessIfAccessIsPossible(ctx RuleContext, namespace string, resource string, verb string) error
+
 	// CheckLoginDuration checks if role set can login up to given duration and
 	// returns a combined list of allowed logins.
 	CheckLoginDuration(ttl time.Duration) ([]string, error)

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -283,6 +283,9 @@ type Context struct {
 	// Resource is an optional resource, in case if the rule
 	// checks access to the resource
 	Resource types.Resource
+	// Resource153 is an optional resource, in case if the rule
+	// checks access to the resource
+	Resource153 types.Resource153
 	// Session is an optional session.end or windows.desktop.session.end event.
 	// These events hold information about session recordings.
 	Session events.AuditEvent
@@ -296,7 +299,7 @@ type Context struct {
 
 // String returns user friendly representation of this context
 func (ctx *Context) String() string {
-	return fmt.Sprintf("user %v, resource: %v", ctx.User, ctx.Resource)
+	return fmt.Sprintf("user %v, resource: %v, resource153: %v", ctx.User, ctx.Resource, ctx.Resource153)
 }
 
 const (
@@ -331,10 +334,16 @@ const (
 // GetResource returns resource specified in the context,
 // returns error if not specified.
 func (ctx *Context) GetResource() (types.Resource, error) {
-	if ctx.Resource == nil {
+	switch {
+	case ctx.Resource == nil && ctx.Resource153 == nil:
 		return nil, trace.NotFound("resource is not set in the context")
+	case ctx.Resource == nil && ctx.Resource153 != nil:
+		return types.Resource153ToLegacy(ctx.Resource153), nil
+	case ctx.Resource != nil && ctx.Resource153 == nil:
+		return ctx.Resource, nil
+	default:
+		return nil, trace.BadParameter("only one resource should be provided")
 	}
-	return ctx.Resource, nil
 }
 
 // GetIdentifier returns identifier defined in a context
@@ -349,13 +358,19 @@ func (ctx *Context) GetIdentifier(fields []string) (interface{}, error) {
 		}
 		return predicate.GetFieldByTag(user, teleport.JSON, fields[1:])
 	case ResourceIdentifier:
-		var resource types.Resource
-		if ctx.Resource == nil {
-			resource = emptyResource
-		} else {
-			resource = ctx.Resource
+		var r any
+		switch {
+		case ctx.Resource == nil && ctx.Resource153 == nil:
+			r = emptyResource
+		case ctx.Resource == nil && ctx.Resource153 != nil:
+			r = ctx.Resource153
+		case ctx.Resource != nil && ctx.Resource153 == nil:
+			r = ctx.Resource
+		default:
+			return nil, trace.BadParameter("only one resource should be provided")
 		}
-		return predicate.GetFieldByTag(resource, teleport.JSON, fields[1:])
+
+		return predicate.GetFieldByTag(r, teleport.JSON, fields[1:])
 	case SessionIdentifier:
 		var session events.AuditEvent = &events.SessionEnd{}
 		switch ctx.Session.(type) {
@@ -386,13 +401,17 @@ func (ctx *Context) GetIdentifier(fields []string) (interface{}, error) {
 				fields,
 			)
 		}
-		var resource types.Resource
-		if ctx.Resource == nil {
-			resource = emptyResource
-		} else {
-			resource = ctx.Resource
+
+		switch {
+		case ctx.Resource == nil && ctx.Resource153 == nil:
+			return "", nil
+		case ctx.Resource == nil && ctx.Resource153 != nil:
+			return ctx.Resource153.GetMetadata().GetName(), nil
+		case ctx.Resource != nil && ctx.Resource153 == nil:
+			return ctx.Resource.GetName(), nil
+		default:
+			return nil, trace.BadParameter("only one resource should be provided")
 		}
-		return resource.GetName(), nil
 	default:
 		return nil, trace.NotFound("%v is not defined", strings.Join(fields, "."))
 	}

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -175,7 +175,7 @@ func NewWhereParser(ctx RuleContext) (predicate.Parser, error) {
 				}
 				return string(ca.GetType()), nil
 			},
-			"startsWith": func(a, b interface{}) predicate.BoolPredicate {
+			"has_prefix": func(a, b interface{}) predicate.BoolPredicate {
 				return func() bool {
 					aval, ok := a.(string)
 					if !ok {

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -175,6 +175,19 @@ func NewWhereParser(ctx RuleContext) (predicate.Parser, error) {
 				}
 				return string(ca.GetType()), nil
 			},
+			"startsWith": func(a, b interface{}) predicate.BoolPredicate {
+				return func() bool {
+					aval, ok := a.(string)
+					if !ok {
+						return false
+					}
+					bval, ok := b.(string)
+					if !ok {
+						return false
+					}
+					return strings.HasPrefix(aval, bval)
+				}
+			},
 		},
 		GetIdentifier: ctx.GetIdentifier,
 		GetProperty:   GetStringMapValue,
@@ -364,6 +377,22 @@ func (ctx *Context) GetIdentifier(fields []string) (interface{}, error) {
 		return predicate.GetFieldByTag(hostCert, teleport.JSON, fields[1:])
 	case SessionTrackerIdentifier:
 		return predicate.GetFieldByTag(toCtxTracker(ctx.SessionTracker), teleport.JSON, fields[1:])
+	case ResourceNameIdentifier:
+		if len(fields) > 1 {
+			return nil, trace.BadParameter(
+				"only one field is supported with identifier %q, got %d: %v",
+				ResourceNameIdentifier,
+				len(fields),
+				fields,
+			)
+		}
+		var resource types.Resource
+		if ctx.Resource == nil {
+			resource = emptyResource
+		} else {
+			resource = ctx.Resource
+		}
+		return resource.GetName(), nil
 	default:
 		return nil, trace.NotFound("%v is not defined", strings.Join(fields, "."))
 	}


### PR DESCRIPTION
Backport #53956 to branch/v17

changelog: Allow the use of expressions in the Where condition on Role RBAC rules for the Bot resource
