### PR TITLE
[v17] Update the database connect dialog (WebUI) to include database roles

### DIFF
--- a/api/types/database.go
+++ b/api/types/database.go
@@ -145,7 +145,7 @@ type Database interface {
 	// IsUsernameCaseInsensitive returns true if the database username is case
 	// insensitive.
 	IsUsernameCaseInsensitive() bool
-	// IsAutoUsersEnabled reutrns true if the database have auto user
+	// IsAutoUsersEnabled returns true if the database has auto user
 	// provisioning enabled.
 	IsAutoUsersEnabled() bool
 }
@@ -1133,8 +1133,8 @@ func (d *DatabaseV3) IsUsernameCaseInsensitive() bool {
 	return d.GetProtocol() == DatabaseProtocolCockroachDB
 }
 
-// IsAutoUsersEnabled reutrns true if the database have auto user provisioning
-// enabled.
+// IsAutoUsersEnabled returns true if the database has auto user
+// provisioning enabled.
 func (d *DatabaseV3) IsAutoUsersEnabled() bool {
 	return d.SupportsAutoUsers() && d.GetAdminUser().Name != ""
 }

--- a/api/types/database.go
+++ b/api/types/database.go
@@ -145,6 +145,9 @@ type Database interface {
 	// IsUsernameCaseInsensitive returns true if the database username is case
 	// insensitive.
 	IsUsernameCaseInsensitive() bool
+	// IsAutoUsersEnabled reutrns true if the database have auto user
+	// provisioning enabled.
+	IsAutoUsersEnabled() bool
 }
 
 // NewDatabaseV3 creates a new database resource.
@@ -1128,6 +1131,12 @@ func (d *DatabaseV3) IsUsernameCaseInsensitive() bool {
 	// CockroachDB usernames are case-insensitive:
 	// https://www.cockroachlabs.com/docs/stable/create-user#user-names
 	return d.GetProtocol() == DatabaseProtocolCockroachDB
+}
+
+// IsAutoUsersEnabled reutrns true if the database have auto user provisioning
+// enabled.
+func (d *DatabaseV3) IsAutoUsersEnabled() bool {
+	return d.SupportsAutoUsers() && d.GetAdminUser().Name != ""
 }
 
 const (

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -658,6 +658,7 @@ func (a *accessChecker) checkDatabaseRoles(database types.Database) (*checkDatab
 		deniedRoleSet = append(deniedRoleSet, role)
 
 	}
+
 	// The collected role list can be empty and that should be ok, we want to
 	// leave the behavior of what happens when a user is created with default
 	// "no roles" configuration up to the target database.
@@ -690,7 +691,7 @@ func (a *accessChecker) GetDatabasePermissions(database types.Database) (allow t
 // EnumerateDatabaseUsers specializes EnumerateEntities to enumerate db_users.
 func (a *accessChecker) EnumerateDatabaseUsers(database types.Database, extraUsers ...string) (EnumerationResult, error) {
 	// When auto-user provisioning is enabled, only Teleport username is allowed.
-	if database.SupportsAutoUsers() && database.GetAdminUser().Name != "" {
+	if database.IsAutoUsersEnabled() {
 		result := NewEnumerationResult()
 		autoUser, err := a.DatabaseAutoUserMode(database)
 		if err != nil {
@@ -765,10 +766,10 @@ func (a *accessChecker) EnumerateEntities(resource AccessCheckable, listFn roleE
 
 		result.wildcardDenied = result.wildcardDenied || wildcardDenied
 
-		if err := NewRoleSet(role).checkAccess(resource, a.info.Traits, AccessState{MFAVerified: true}); err == nil {
+		err := NewRoleSet(role).checkAccess(resource, a.info.Traits, AccessState{MFAVerified: true})
+		if err == nil {
 			result.wildcardAllowed = result.wildcardAllowed || wildcardAllowed
 		}
-
 	}
 
 	entities = apiutils.Deduplicate(append(entities, extraEntities...))

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -570,7 +570,7 @@ func (a *accessChecker) CheckDatabaseRoles(database types.Database, userRequeste
 
 	switch {
 	case !result.createDatabaseUserMode().IsEnabled():
-		return nil, nil
+		return []string{}, nil
 
 	// If user requested a list of roles, make sure all requested roles are
 	// allowed.

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -570,7 +570,7 @@ func (a *accessChecker) CheckDatabaseRoles(database types.Database, userRequeste
 
 	switch {
 	case !result.createDatabaseUserMode().IsEnabled():
-		return []string{}, nil
+		return nil, nil
 
 	// If user requested a list of roles, make sure all requested roles are
 	// allowed.
@@ -766,8 +766,7 @@ func (a *accessChecker) EnumerateEntities(resource AccessCheckable, listFn roleE
 
 		result.wildcardDenied = result.wildcardDenied || wildcardDenied
 
-		err := NewRoleSet(role).checkAccess(resource, a.info.Traits, AccessState{MFAVerified: true})
-		if err == nil {
+		if err := NewRoleSet(role).checkAccess(resource, a.info.Traits, AccessState{MFAVerified: true}); err == nil {
 			result.wildcardAllowed = result.wildcardAllowed || wildcardAllowed
 		}
 	}

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -7407,6 +7407,7 @@ func TestCreateDatabase(t *testing.T) {
 		Allow: types.RoleConditions{
 			DatabaseNames: []string{"name1"},
 			DatabaseUsers: []string{"user1"},
+			DatabaseRoles: []string{"readonly"},
 			Rules: []types.Rule{
 				types.NewRule(types.KindDatabase,
 					[]string{types.VerbCreate}),
@@ -7414,6 +7415,9 @@ func TestCreateDatabase(t *testing.T) {
 			DatabaseLabels: types.Labels{
 				types.Wildcard: {types.Wildcard},
 			},
+		},
+		Options: types.RoleOptions{
+			CreateDatabaseUserMode: types.CreateDatabaseUserMode_DB_USER_MODE_KEEP,
 		},
 	})
 	require.NoError(t, err)
@@ -7574,6 +7578,7 @@ func TestCreateDatabase(t *testing.T) {
 				Hostname:      "someuri",
 				DatabaseUsers: []string{"user1"},
 				DatabaseNames: []string{"name1"},
+				DatabaseRoles: []string{"readonly"},
 				URI:           "someuri:3306",
 			}
 			require.Equal(t, expected, result)

--- a/lib/web/ui/server.go
+++ b/lib/web/ui/server.go
@@ -302,7 +302,7 @@ type Database struct {
 	DatabaseUsers []string `json:"database_users,omitempty"`
 	// DatabaseNames is the list of allowed Database RBAC names that the user can login.
 	DatabaseNames []string `json:"database_names,omitempty"`
-	// DatabaseNames is the list of allowed Database RBAC roles that the user can login.
+	// DatabaseRoles is the list of allowed Database RBAC roles that the user can login.
 	DatabaseRoles []string `json:"database_roles,omitempty"`
 	// AWS contains AWS specific fields.
 	AWS *AWS `json:"aws,omitempty"`

--- a/lib/web/ui/server.go
+++ b/lib/web/ui/server.go
@@ -354,7 +354,10 @@ func MakeDatabase(database types.Database, accessChecker services.AccessChecker,
 		}
 	}
 	if roles, err := accessChecker.CheckDatabaseRoles(database, nil); err == nil {
-		dbRoles = roles
+		// Avoid assigning empty slice to keep the resulting roles nil.
+		if len(roles) > 0 {
+			dbRoles = roles
+		}
 	}
 
 	uiLabels := ui.MakeLabelsWithoutInternalPrefixes(database.GetAllLabels())

--- a/lib/web/ui/server.go
+++ b/lib/web/ui/server.go
@@ -302,6 +302,8 @@ type Database struct {
 	DatabaseUsers []string `json:"database_users,omitempty"`
 	// DatabaseNames is the list of allowed Database RBAC names that the user can login.
 	DatabaseNames []string `json:"database_names,omitempty"`
+	// DatabaseNames is the list of allowed Database RBAC roles that the user can login.
+	DatabaseRoles []string `json:"database_roles,omitempty"`
 	// AWS contains AWS specific fields.
 	AWS *AWS `json:"aws,omitempty"`
 	// RequireRequest indicates if a returned resource is only accessible after an access request
@@ -309,6 +311,9 @@ type Database struct {
 	// SupportsInteractive is a flag to indicate the database supports
 	// interactive sessions using database REPLs.
 	SupportsInteractive bool `json:"supports_interactive,omitempty"`
+	// AutoUsersEnabled is a flag to indicate the database has user auto
+	// provisioning enabled
+	AutoUsersEnabled bool `json:"auto_users_enabled,omitempty"`
 }
 
 // AWS contains AWS specific fields.
@@ -333,10 +338,23 @@ type DatabaseInteractiveChecker interface {
 
 // MakeDatabase creates database objects.
 func MakeDatabase(database types.Database, accessChecker services.AccessChecker, interactiveChecker DatabaseInteractiveChecker, requiresRequest bool) Database {
-	dbNames := accessChecker.EnumerateDatabaseNames(database)
-	var dbUsers []string
+	var (
+		dbUsers []string
+		dbRoles []string
+	)
+	dbNamesResult := accessChecker.EnumerateDatabaseNames(database)
+	dbNames := dbNamesResult.Allowed()
+	if dbNamesResult.WildcardAllowed() {
+		dbNames = append(dbNames, types.Wildcard)
+	}
 	if res, err := accessChecker.EnumerateDatabaseUsers(database); err == nil {
 		dbUsers = res.Allowed()
+		if res.WildcardAllowed() {
+			dbUsers = append(dbUsers, types.Wildcard)
+		}
+	}
+	if roles, err := accessChecker.CheckDatabaseRoles(database, nil); err == nil {
+		dbRoles = roles
 	}
 
 	uiLabels := ui.MakeLabelsWithoutInternalPrefixes(database.GetAllLabels())
@@ -349,11 +367,13 @@ func MakeDatabase(database types.Database, accessChecker services.AccessChecker,
 		Type:                database.GetType(),
 		Labels:              uiLabels,
 		DatabaseUsers:       dbUsers,
-		DatabaseNames:       dbNames.Allowed(),
+		DatabaseNames:       dbNames,
+		DatabaseRoles:       dbRoles,
 		Hostname:            stripProtocolAndPort(database.GetURI()),
 		URI:                 database.GetURI(),
 		RequiresRequest:     requiresRequest,
 		SupportsInteractive: interactiveChecker.IsSupported(database.GetProtocol()),
+		AutoUsersEnabled:    database.IsAutoUsersEnabled(),
 	}
 
 	if database.IsAWSHosted() {

--- a/lib/web/ui/server_test.go
+++ b/lib/web/ui/server_test.go
@@ -759,8 +759,6 @@ func makeTestDatabase(t *testing.T, labels map[string]string, autoProvisioningEn
 	return db
 }
 
-type mockAccessCheckerDatabaseOptions struct{}
-
 type mockDatabaseInteractiveChecker struct {
 	supports bool
 }

--- a/lib/web/ui/server_test.go
+++ b/lib/web/ui/server_test.go
@@ -26,6 +26,7 @@ import (
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/ui"
 )
@@ -613,6 +614,152 @@ func TestMakeDatabaseSupportsInteractive(t *testing.T) {
 		})
 	}
 }
+
+func TestMakeDatabaseConnectOptions(t *testing.T) {
+	interactiveChecker := &mockDatabaseInteractiveChecker{}
+
+	for name, tc := range map[string]struct {
+		roles        services.RoleSet
+		db           *types.DatabaseV3
+		assertResult require.ValueAssertionFunc
+	}{
+		"names wildcard": {
+			db: makeTestDatabase(t, map[string]string{"env": "dev"}, false),
+			roles: services.NewRoleSet(&types.RoleV6{
+				Spec: types.RoleSpecV6{
+					Allow: types.RoleConditions{
+						Namespaces:     []string{apidefaults.Namespace},
+						DatabaseLabels: types.Labels{"*": []string{"*"}},
+						DatabaseNames:  []string{"*", "mydatabase"},
+					},
+				},
+			}),
+			assertResult: func(t require.TestingT, v interface{}, _ ...interface{}) {
+				db, _ := v.(Database)
+				require.ElementsMatch(t, []string{"*", "mydatabase"}, db.DatabaseNames)
+			},
+		},
+		"users wildcard": {
+			db: makeTestDatabase(t, map[string]string{"env": "dev"}, false),
+			roles: services.NewRoleSet(&types.RoleV6{
+				Spec: types.RoleSpecV6{
+					Allow: types.RoleConditions{
+						Namespaces:     []string{apidefaults.Namespace},
+						DatabaseLabels: types.Labels{"*": []string{"*"}},
+						DatabaseUsers:  []string{"*", "myuser"},
+					},
+				},
+			}),
+			assertResult: func(t require.TestingT, v interface{}, _ ...interface{}) {
+				db, _ := v.(Database)
+				require.ElementsMatch(t, []string{"*", "myuser"}, db.DatabaseUsers)
+			},
+		},
+		"roles wildcard": {
+			db: makeTestDatabase(t, map[string]string{"env": "dev"}, false),
+			roles: services.NewRoleSet(&types.RoleV6{
+				Spec: types.RoleSpecV6{
+					Allow: types.RoleConditions{
+						Namespaces:     []string{apidefaults.Namespace},
+						DatabaseLabels: types.Labels{"*": []string{"*"}},
+						DatabaseRoles:  []string{"*", "myrole"},
+					},
+					Options: types.RoleOptions{
+						CreateDatabaseUserMode: types.CreateDatabaseUserMode_DB_USER_MODE_BEST_EFFORT_DROP,
+					},
+				},
+			}),
+			assertResult: func(t require.TestingT, v interface{}, _ ...interface{}) {
+				db, _ := v.(Database)
+				require.ElementsMatch(t, []string{"*", "myrole"}, db.DatabaseRoles)
+			},
+		},
+		"only wildcards": {
+			db: makeTestDatabase(t, map[string]string{"env": "dev"}, false),
+			roles: services.NewRoleSet(&types.RoleV6{
+				Spec: types.RoleSpecV6{
+					Allow: types.RoleConditions{
+						Namespaces:     []string{apidefaults.Namespace},
+						DatabaseLabels: types.Labels{"*": []string{"*"}},
+						DatabaseNames:  []string{"*"},
+						DatabaseUsers:  []string{"*"},
+						DatabaseRoles:  []string{"*"},
+					},
+					Options: types.RoleOptions{
+						CreateDatabaseUserMode: types.CreateDatabaseUserMode_DB_USER_MODE_BEST_EFFORT_DROP,
+					},
+				},
+			}),
+			assertResult: func(t require.TestingT, v interface{}, _ ...interface{}) {
+				db, _ := v.(Database)
+				require.ElementsMatch(t, []string{"*"}, db.DatabaseNames)
+				require.ElementsMatch(t, []string{"*"}, db.DatabaseUsers)
+				require.ElementsMatch(t, []string{"*"}, db.DatabaseRoles)
+			},
+		},
+		"auto-user provisioning enabled": {
+			db: makeTestDatabase(t, map[string]string{"env": "dev"}, true),
+			roles: services.NewRoleSet(&types.RoleV6{
+				Spec: types.RoleSpecV6{
+					Allow: types.RoleConditions{
+						Namespaces:     []string{apidefaults.Namespace},
+						DatabaseLabels: types.Labels{"*": []string{"*"}},
+						DatabaseRoles:  []string{"myrole"},
+					},
+					Options: types.RoleOptions{
+						CreateDatabaseUserMode: types.CreateDatabaseUserMode_DB_USER_MODE_BEST_EFFORT_DROP,
+					},
+				},
+			}),
+			assertResult: func(t require.TestingT, v interface{}, _ ...interface{}) {
+				db, _ := v.(Database)
+				require.ElementsMatch(t, []string{"myrole"}, db.DatabaseRoles)
+				require.True(t, db.AutoUsersEnabled)
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			accessChecker := services.NewAccessCheckerWithRoleSet(&services.AccessInfo{}, "clusterName", tc.roles)
+			single := MakeDatabase(tc.db, accessChecker, interactiveChecker, false)
+			tc.assertResult(t, single)
+
+			multi := MakeDatabases([]*types.DatabaseV3{tc.db}, accessChecker, interactiveChecker)
+			require.Len(t, multi, 1)
+			tc.assertResult(t, multi[0])
+		})
+	}
+}
+
+// makeTestDatabase creates a database with labels and admin options.
+func makeTestDatabase(t *testing.T, labels map[string]string, autoProvisioningEnabled bool) *types.DatabaseV3 {
+	t.Helper()
+
+	spec := types.DatabaseSpecV3{
+		Protocol: defaults.ProtocolPostgres,
+		URI:      "localhost:5432",
+	}
+	if autoProvisioningEnabled {
+		spec.AdminUser = &types.DatabaseAdminUser{
+			Name:            "teleport-admin",
+			DefaultDatabase: "teleport",
+		}
+	}
+
+	db, err := types.NewDatabaseV3(
+		types.Metadata{
+			Name:   "db",
+			Labels: labels,
+		}, spec,
+	)
+	require.NoError(t, err)
+	if autoProvisioningEnabled {
+		require.True(t, db.IsAutoUsersEnabled(), "The database was expected to have auto-users enabled but it isn't. Check if the auto-users enabled definition changed and update this helper to match it.")
+	}
+
+	return db
+}
+
+type mockAccessCheckerDatabaseOptions struct{}
 
 type mockDatabaseInteractiveChecker struct {
 	supports bool

--- a/tool/tsh/common/db_print.go
+++ b/tool/tsh/common/db_print.go
@@ -118,7 +118,7 @@ func printDatabaseTable(cfg printDatabaseTableConfig) {
 }
 
 func formatDatabaseRolesForDB(database types.Database, accessChecker services.AccessChecker) string {
-	if database.SupportsAutoUsers() && database.GetAdminUser().Name != "" {
+	if database.IsAutoUsersEnabled() {
 		// may happen if fetching the role set failed for any reason.
 		if accessChecker == nil {
 			return "(unknown)"

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -3136,7 +3136,7 @@ func newDatabaseWithUsers(db types.Database, accessChecker services.AccessChecke
 		return nil, trace.BadParameter("unrecognized database type %T", db)
 	}
 
-	if db.SupportsAutoUsers() && db.GetAdminUser().Name != "" {
+	if db.IsAutoUsersEnabled() {
 		roles, err := accessChecker.CheckDatabaseRoles(db, nil)
 		if err != nil {
 			log.Warnf("Failed to CheckDatabaseRoles for database %v: %v.", db.GetName(), err)
@@ -3185,7 +3185,7 @@ func formatUsersForDB(database types.Database, accessChecker services.AccessChec
 	}
 
 	// Add a note for auto-provisioned user.
-	if database.SupportsAutoUsers() && database.GetAdminUser().Name != "" {
+	if database.IsAutoUsersEnabled() {
 		autoUser, err := accessChecker.DatabaseAutoUserMode(database)
 		if err != nil {
 			log.Warnf("Failed to get DatabaseAutoUserMode for database %v: %v.", database.GetName(), err)

--- a/web/packages/teleport/src/Console/DocumentDb/ConnectDialog.tsx
+++ b/web/packages/teleport/src/Console/DocumentDb/ConnectDialog.tsx
@@ -105,24 +105,12 @@ function ConnectForm(props: {
   onConnect(data: DbConnectData): void;
   onClose(): void;
 }) {
-  const dbUserOpts = props.db.users
-    ?.map(user => ({
-      value: user,
-      label: user,
-    }))
-    .filter(removeWildcardOption);
-  const dbNamesOpts = props.db.names
-    ?.map(name => ({
-      value: name,
-      label: name,
-    }))
-    .filter(removeWildcardOption);
-  const dbRolesOpts = props.db.roles
-    ?.map(role => ({
-      value: role,
-      label: role,
-    }))
-    .filter(removeWildcardOption);
+  const { options: dbNamesOpts, hasWildcard: dbNameHasWildcard } =
+    prepareOptions(props.db.names);
+  const { options: dbUserOpts, hasWildcard: dbUserHasWildcard } =
+    prepareOptions(props.db.users);
+  const { options: dbRolesOpts, hasWildcard: dbRoleHasWildcard } =
+    prepareOptions(props.db.roles);
 
   const [selectedName, setSelectedName] = useState<Option>(dbNamesOpts?.[0]);
   const [selectedUser, setSelectedUser] = useState<Option>(dbUserOpts?.[0]);
@@ -144,36 +132,57 @@ function ConnectForm(props: {
       {({ validator }) => (
         <form>
           <DialogContent flex="0 0 auto">
-            <FieldSelectCreatable
+            <ConnectionField
+              hasWildcard={dbNameHasWildcard}
               label="Database name"
               menuPosition="fixed"
               onChange={option => setSelectedName(option as Option)}
               value={selectedName}
               options={dbNamesOpts}
-              formatCreateLabel={userInput =>
-                `Use "${userInput}" database name`
-              }
+              creatableOptions={{
+                formatCreateLabel: userInput =>
+                  `Use "${userInput}" database name`,
+                toolTipContent:
+                  'You can type on the select box to use a custom database name instead of the available options.',
+              }}
               rule={requiredField('Database name is required')}
             />
-            <FieldSelectCreatable
+            <ConnectionField
+              hasWildcard={dbUserHasWildcard}
               label="Database user"
               menuPosition="fixed"
               onChange={option => setSelectedUser(option as Option)}
               value={selectedUser}
               options={dbUserOpts}
-              formatCreateLabel={userInput =>
-                `Use "${userInput}" database user`
-              }
+              creatableOptions={{
+                formatCreateLabel: userInput =>
+                  `Use "${userInput}" database user`,
+                toolTipContent:
+                  'You can type on the select box to use a custom database user instead of the available options.',
+              }}
               rule={requiredField('Database user is required')}
+              isDisabled={props.db.autoUsersEnabled}
+              helperText={
+                props.db.autoUsersEnabled
+                  ? 'Using auto provisioned user, you cannot change the database user.'
+                  : null
+              }
             />
-            {dbRolesOpts?.length > 0 && (
-              <FieldSelect
+            {(dbRolesOpts?.length > 0 || dbRoleHasWildcard) && (
+              <ConnectionField
+                hasWildcard={dbRoleHasWildcard}
                 label="Database roles"
                 menuPosition="fixed"
                 isMulti={true}
                 onChange={setSelectedRoles}
                 value={selectedRoles}
                 options={dbRolesOpts}
+                creatableOptions={{
+                  formatCreateLabel: userInput =>
+                    `Use "${userInput}" database role`,
+                  toolTipContent:
+                    'You can type on the select box to use a custom database role in addition to the available options.',
+                }}
                 rule={requiredField('At least one database role is required')}
               />
             )}
@@ -207,8 +216,38 @@ function ConnectForm(props: {
   );
 }
 
-function removeWildcardOption({ value }: Option): boolean {
-  return value !== '*';
+function ConnectionField({
+  hasWildcard,
+  creatableOptions = {},
+  ...commonOptions
+}) {
+  return hasWildcard ? (
+    <FieldSelectCreatable {...commonOptions} {...creatableOptions} />
+  ) : (
+    <FieldSelect {...commonOptions} />
+  );
+}
+
+function prepareOptions(rawOpts: string[]): {
+  options: Option[];
+  hasWildcard: boolean;
+} {
+  let hasWildcard = false;
+  const options = rawOpts
+    ?.map(role => ({
+      value: role,
+      label: role,
+    }))
+    .filter(({ value }: Option) => {
+      if (value === '*') {
+        hasWildcard = true;
+        return false;
+      }
+
+      return true;
+    });
+
+  return { options, hasWildcard };
 }
 
 const dialogCss = () => `

--- a/web/packages/teleport/src/Console/DocumentDb/ConnectDialog.tsx
+++ b/web/packages/teleport/src/Console/DocumentDb/ConnectDialog.tsx
@@ -158,7 +158,7 @@ function ConnectForm(props: {
                 formatCreateLabel: userInput =>
                   `Use "${userInput}" database user`,
                 toolTipContent:
-                  'You can type on the select box to use a custom database user instead of the available options.',
+                  'You can type in the select box to use a custom database user instead of the available options.',
               }}
               rule={requiredField('Database user is required')}
               isDisabled={props.db.autoUsersEnabled}
@@ -181,7 +181,7 @@ function ConnectForm(props: {
                   formatCreateLabel: userInput =>
                     `Use "${userInput}" database role`,
                   toolTipContent:
-                    'You can type on the select box to use a custom database role in addition to the available options.',
+                    'You can type in the select box to use a custom database role in addition to the available options.',
                 }}
                 rule={requiredField('At least one database role is required')}
               />

--- a/web/packages/teleport/src/Console/DocumentDb/ConnectDialog.tsx
+++ b/web/packages/teleport/src/Console/DocumentDb/ConnectDialog.tsx
@@ -143,7 +143,7 @@ function ConnectForm(props: {
                 formatCreateLabel: userInput =>
                   `Use "${userInput}" database name`,
                 toolTipContent:
-                  'You can type on the select box to use a custom database name instead of the available options.',
+                  'You can type in the select box to use a custom database name instead of the available options.',
               }}
               rule={requiredField('Database name is required')}
             />

--- a/web/packages/teleport/src/Console/DocumentDb/DocumentDb.story.tsx
+++ b/web/packages/teleport/src/Console/DocumentDb/DocumentDb.story.tsx
@@ -111,6 +111,32 @@ export const ConnectWithWildcards = () => {
           labels: [],
           names: ['postgres', '*'],
           users: ['*'],
+          roles: ['*'],
+          hostname: '',
+          supportsInteractive: true,
+        },
+      ],
+    })
+  );
+
+  return <DocumentDbWrapper ctx={ctx} consoleCtx={consoleCtx} doc={baseDoc} />;
+};
+
+export const ConnectWithAutoUserProvisioning = () => {
+  const { ctx, consoleCtx } = getContexts(
+    Promise.resolve({
+      agents: [
+        {
+          kind: 'db',
+          name: 'mydb',
+          description: '',
+          type: '',
+          protocol: 'postgres',
+          labels: [],
+          names: ['postgres', '*'],
+          users: ['alice'],
+          roles: ['readonly', 'read-write'],
+          autoUsersEnabled: true,
           hostname: '',
           supportsInteractive: true,
         },

--- a/web/packages/teleport/src/services/databases/databases.test.ts
+++ b/web/packages/teleport/src/services/databases/databases.test.ts
@@ -56,6 +56,7 @@ test('correct formatting of database fetch response', async () => {
           iamPolicyStatus: IamPolicyStatus.Success,
         },
         supportsInteractive: false,
+        autoUsersEnabled: false,
       },
       {
         kind: 'db',
@@ -69,6 +70,7 @@ test('correct formatting of database fetch response', async () => {
         labels: [],
         aws: undefined,
         supportsInteractive: true,
+        autoUsersEnabled: false,
       },
     ],
     startKey: mockResponse.startKey,

--- a/web/packages/teleport/src/services/databases/makeDatabase.ts
+++ b/web/packages/teleport/src/services/databases/makeDatabase.ts
@@ -56,6 +56,7 @@ export function makeDatabase(json: any): Database {
     aws: madeAws,
     requiresRequest,
     supportsInteractive: json.supports_interactive || false,
+    autoUsersEnabled: json.auto_users_enabled || false,
   };
 }
 

--- a/web/packages/teleport/src/services/databases/types.ts
+++ b/web/packages/teleport/src/services/databases/types.ts
@@ -53,6 +53,7 @@ export interface Database {
   aws?: Aws;
   requiresRequest?: boolean;
   supportsInteractive?: boolean;
+  autoUsersEnabled?: boolean;
 }
 
 export type DatabasesResponse = {


### PR DESCRIPTION
Backport #54014 to branch/v17

changelog: Added an option for users to select database roles when connecting to PostgreSQL databases using WebUI.
