### PR TITLE
RFD 208: Add ProxyWindowsDesktopSession API to Teleport Proxy Service

### DIFF
--- a/rfd/0208-proxy-desktop-session.md
+++ b/rfd/0208-proxy-desktop-session.md
@@ -82,31 +82,24 @@ rpc ProxyDesktopSession(stream ProxyDesktopSessionRequest) returns (stream Proxy
 ```protobuf
 // Request message for a proxied desktop session.
 message ProxyDesktopSessionRequest {
-  // Target cluster and desktop. Must be sent as the first message.
-  TargetDesktop dial_target = 1;
-
-   // Payload from Teleport Desktop Protocol. 
-   DesktopSessionMessage message = 2;
+   // A chunk of data from the connection. Can be nonempty even in the first message, but it's also legal for it to be empty.
+   bytes data = 1;
+   // Target cluster and desktop. Must be set in the first message and unset in subsequent messages.
+   TargetDesktop dial_target = 2;
 }
 
 // Response message for a proxied desktop session.
 message ProxyDesktopSessionResponse {
-   // Payload from Teleport Desktop Protocol.
-   DesktopSessionMessage message = 1;
+   // A chunk of data from the connection. Can be empty (for example, to send a message
+   // signaling a successful connection even if there's no data available in the connection).
+   bytes data = 1;
 }
 
 // Identifies the destination desktop within a specific cluster.
 message TargetDesktop {
-  // Name of the desktop to connect to.
-  string desktop_name = 1;
-
-  // Name of the cluster the desktop belongs to.
-  string cluster = 2;
-}
-
-// Encapsulates Teleport Desktop Protocol payload.
-message DesktopSessionMessage {
-   // Raw payload.
-   bytes payload = 1;
+   // Name of the desktop to connect to.
+   string desktop_name = 1;
+   // Name of the cluster the desktop belongs to.
+   string cluster = 2;
 }
 ```

--- a/rfd/0208-proxy-desktop-session.md
+++ b/rfd/0208-proxy-desktop-session.md
@@ -97,9 +97,17 @@ message ProxyDesktopSessionResponse {
 
 // Identifies the destination desktop within a specific cluster.
 message TargetDesktop {
+   // Operating system of the target desktop.
+   DesktopOS desktop_os = 1;
    // Name of the desktop to connect to.
-   string desktop_name = 1;
+   string desktop_name = 2;
    // Name of the cluster the desktop belongs to.
-   string cluster = 2;
+   string cluster = 3;
+}
+
+// Supported desktop operating systems.
+enum DesktopOS {
+   DESKTOP_OS_UNSPECIFIED = 0;
+   DESKTOP_OS_WINDOWS = 1;
 }
 ```

--- a/rfd/0208-proxy-desktop-session.md
+++ b/rfd/0208-proxy-desktop-session.md
@@ -97,17 +97,9 @@ message ProxyDesktopSessionResponse {
 
 // Identifies the destination desktop within a specific cluster.
 message TargetDesktop {
-   // Operating system of the target desktop.
-   DesktopOS desktop_os = 1;
    // Name of the desktop to connect to.
-   string desktop_name = 2;
+   string desktop_name = 1;
    // Name of the cluster the desktop belongs to.
-   string cluster = 3;
-}
-
-// Supported desktop operating systems.
-enum DesktopOS {
-   DESKTOP_OS_UNSPECIFIED = 0;
-   DESKTOP_OS_WINDOWS = 1;
+   string cluster = 2;
 }
 ```

--- a/rfd/0208-proxy-desktop-session.md
+++ b/rfd/0208-proxy-desktop-session.md
@@ -3,7 +3,7 @@ authors: Grzegorz Zdunek (grzegorz.zdunek@goteleport.com)
 state: draft
 ---
 
-# RFD 208 - Add ProxyDesktopSession API to Teleport Proxy Service
+# RFD 208 - Add ProxyWindowsDesktopSession API to Teleport Proxy Service
 
 ## Required Approvals
 
@@ -23,27 +23,27 @@ To support interactive sessions, a bidirectional stream must be established betw
 In the Web UI, the TDP stream is transmitted over a cookie-authenticated WebSocket. 
 
 However, Teleport Connect (which uses tsh under the hood) does not rely on cookies for authentication—instead, it uses client certificates.
-To support this scenario, a new gRPC-based API called `ProxyDesktopSession` will be added to the `TransportService` in the Teleport Proxy. 
+To support this scenario, a new gRPC-based API called `ProxyWindowsDesktopSession` will be added to the `TransportService` in the Teleport Proxy. 
 
 ### Architecture
 
 ```
-            gRPC bidi stream   
-+-----+   (ProxyDesktopSession)    +----------------+      TCP connection     +-------------------------+
-| tsh | <=======================>  |  Proxy Service | <=====================> | Windows Desktop Service |
-+-----+                            +----------------+                         +-------------------------+
-        <===================================================================>
-                              TLS connection (end-to-end)
+               gRPC bidi stream   
++-----+  (ProxyWindowsDesktopSession)   +----------------+      TCP connection     +-------------------------+
+| tsh | <=============================> |  Proxy Service | <=====================> | Windows Desktop Service |
++-----+                                 +----------------+                         +-------------------------+
+        <========================================================================>
+                                      TLS connection (end-to-end)
 ```
 
-`ProxyDesktopSession` won't transmit TDP messages directly.
+`ProxyWindowsDesktopSession` won't transmit TDP messages directly.
 Instead, it will tunnel a TLS connection over gRPC, which will then carry the TDP messages.
 
 This design simplifies per-session MFA by allowing the client to present an MFA-verified certificate over a single TLS connection that terminates at the Windows Desktop Service.
 
 ### Session Initialization Flow
 
-1. The connection is initiated by tsh, which opens the `ProxyDesktopSession` gRPC stream.
+1. The connection is initiated by tsh, which opens the `ProxyWindowsDesktopSession` gRPC stream.
    * The first message sent by tsh must contain the `dial_target`, specifying the desktop name and target cluster. 
    * If the first message does not include the `dial_target`, the Proxy will immediately terminate the connection.
 2. The Teleport Proxy uses the provided `dial_target` to dial the Desktop Service, following the logic in a Web UI handler.
@@ -63,7 +63,7 @@ The Desktop Service will enforce access control and return an error if the user 
 Tunneling a TLS connection over a gRPC stream introduces some overhead due to the added TLS metadata in each message. 
 This could impact performance slightly, although manual testing did not show any noticeable latency.
 
-A potential alternative design would terminate the client's TLS connection in the Proxy, then open a separate TLS connection to the Desktop Service. 
+A potential alternative design would terminate the client's TLS connection in the Proxy, then open a separate TLS connection to the Windows Desktop Service. 
 This would require the Proxy to detect whether per-session MFA is needed, issue an MFA challenge to the client and verify the response.
 However, this approach is not currently feasible, since Proxy has no straightforward way to determine whether per-session MFA is required 
 for a given user—it doesn’t interact with the Auth Service using a user's identity.
@@ -73,30 +73,30 @@ for a given user—it doesn’t interact with the Auth Service using a user's id
 #### Service definition
 
 ```protobuf
-// Bidirectional stream for proxying desktop sessions.
-rpc ProxyDesktopSession(stream ProxyDesktopSessionRequest) returns (stream ProxyDesktopSessionResponse);
+// Bidirectional stream for proxying Windows desktop sessions.
+rpc ProxyWindowsDesktopSession(stream ProxyWindowsDesktopSessionRequest) returns (stream ProxyWindowsDesktopSessionResponse);
 ```
 
 #### Message definitions
 
 ```protobuf
-// Request message for a proxied desktop session.
-message ProxyDesktopSessionRequest {
+// Request message for a proxied Windows desktop session.
+message ProxyWindowsDesktopSessionRequest {
    // A chunk of data from the connection. Can be nonempty even in the first message, but it's also legal for it to be empty.
    bytes data = 1;
    // Target cluster and desktop. Must be set in the first message and unset in subsequent messages.
-   TargetDesktop dial_target = 2;
+   TargetWindowsDesktop dial_target = 2;
 }
 
-// Response message for a proxied desktop session.
-message ProxyDesktopSessionResponse {
+// Response message for a proxied Windows desktop session.
+message ProxyWindowsDesktopSessionResponse {
    // A chunk of data from the connection. Can be empty (for example, to send a message
    // signaling a successful connection even if there's no data available in the connection).
    bytes data = 1;
 }
 
 // Identifies the destination desktop within a specific cluster.
-message TargetDesktop {
+message TargetWindowsDesktop {
    // Name of the desktop to connect to.
    string desktop_name = 1;
    // Name of the cluster the desktop belongs to.

--- a/rfd/0208-proxy-desktop-session.md
+++ b/rfd/0208-proxy-desktop-session.md
@@ -1,0 +1,112 @@
+---
+authors: Grzegorz Zdunek (grzegorz.zdunek@goteleport.com)
+state: draft
+---
+
+# RFD 208 - Add ProxyDesktopSession API to Teleport Proxy Service
+
+## Required Approvals
+
+- Engineering: @zmb3 && (@rosstimothy || @espadolini)
+
+## What
+
+Introduce a new API in the Teleport Proxy Service to support streaming desktop sessions to Teleport Connect.
+
+## Why
+
+Remote desktop sessions in Teleport rely on the Teleport Desktop Protocol (TDP) for communication.
+To support interactive sessions, a bidirectional stream must be established between the client and the Windows Desktop Service to send and receive TDP messages in real time.
+
+## Details
+
+In the Web UI, the TDP stream is transmitted over a cookie-authenticated WebSocket. 
+
+However, Teleport Connect (which uses tsh under the hood) does not rely on cookies for authentication—instead, it uses client certificates.
+To support this scenario, a new gRPC-based API called `ProxyDesktopSession` will be added to the `TransportService` in the Teleport Proxy. 
+
+### Architecture
+
+```
+            gRPC bidi stream   
++-----+   (ProxyDesktopSession)    +----------------+      TCP connection     +-------------------------+
+| tsh | <=======================>  |  Proxy Service | <=====================> | Windows Desktop Service |
++-----+                            +----------------+                         +-------------------------+
+        <===================================================================>
+                              TLS connection (end-to-end)
+```
+
+`ProxyDesktopSession` won't transmit TDP messages directly.
+Instead, it will tunnel a TLS connection over gRPC, which will then carry the TDP messages.
+
+This design simplifies per-session MFA by allowing the client to present an MFA-verified certificate over a single TLS connection that terminates at the Windows Desktop Service.
+
+### Session Initialization Flow
+
+1. The connection is initiated by tsh, which opens the `ProxyDesktopSession` gRPC stream.
+   * The first message sent by tsh must contain the `dial_target`, specifying the desktop name and target cluster. 
+   * If the first message does not include the `dial_target`, the Proxy will immediately terminate the connection.
+2. The Teleport Proxy uses the provided `dial_target` to dial the Desktop Service, following the logic in a Web UI handler.
+   * The Proxy queries the cluster's desktops looking for the ones that match the `desktop_name` in `dial_target`.
+   * The returned desktops are then mapped to desktop services reporting them.
+   * The Proxy attempts to connect to these services in a randomized order until one succeeds.
+3. Data tunneling starts.
+   * Once a Desktop Service is successfully reached, the Proxy begins forwarding raw data between tsh and the Desktop Service.
+   * Meanwhile, tsh initiates a TLS connection over the gRPC stream using its MFA-verified client certificate.
+   * The TLS connection is established when the Desktop Service accepts the handshake.
+
+Note that Proxy won't enforce RBAC checks. It will attempt to connect to the Windows Desktop Service even if the user doesn’t have access to the target desktop.
+The Desktop Service will enforce access control and return an error if the user isn’t allowed.
+
+### Drawbacks and considered alternatives
+
+Tunneling a TLS connection over a gRPC stream introduces some overhead due to the added TLS metadata in each message. 
+This could impact performance slightly, although manual testing did not show any noticeable latency.
+
+A potential alternative design would terminate the client's TLS connection in the Proxy, then open a separate TLS connection to the Desktop Service. 
+This would require the Proxy to detect whether per-session MFA is needed, issue an MFA challenge to the client and verify the response.
+However, this approach is not currently feasible, since Proxy has no straightforward way to determine whether per-session MFA is required 
+for a given user—it doesn’t interact with the Auth Service using a user's identity.
+
+### gRPC Definitions
+
+#### Service definition
+
+```protobuf
+// Bidirectional stream for proxying desktop sessions.
+rpc ProxyDesktopSession(stream ProxyDesktopSessionRequest) returns (stream ProxyDesktopSessionResponse);
+```
+
+#### Message definitions
+
+```protobuf
+// Request message for a proxied desktop session.
+message ProxyDesktopSessionRequest {
+  // Target cluster and desktop. Must be sent as the first message.
+  TargetDesktop dial_target = 1;
+
+   // Payload from Teleport Desktop Protocol. 
+   DesktopSessionMessage message = 2;
+}
+
+// Response message for a proxied desktop session.
+message ProxyDesktopSessionResponse {
+   // Payload from Teleport Desktop Protocol.
+   DesktopSessionMessage message = 1;
+}
+
+// Identifies the destination desktop within a specific cluster.
+message TargetDesktop {
+  // Name of the desktop to connect to.
+  string desktop_name = 1;
+
+  // Name of the cluster the desktop belongs to.
+  string cluster = 2;
+}
+
+// Encapsulates Teleport Desktop Protocol payload.
+message DesktopSessionMessage {
+   // Raw payload.
+   bytes payload = 1;
+}
+```

--- a/rfd/0208-proxy-desktop-session.md
+++ b/rfd/0208-proxy-desktop-session.md
@@ -28,12 +28,12 @@ To support this scenario, a new gRPC-based API called `ProxyWindowsDesktopSessio
 ### Architecture
 
 ```
-               gRPC bidi stream   
-+-----+  (ProxyWindowsDesktopSession)   +----------------+      TCP connection     +-------------------------+
-| tsh | <=============================> |  Proxy Service | <=====================> | Windows Desktop Service |
-+-----+                                 +----------------+                         +-------------------------+
-        <========================================================================>
-                                      TLS connection (end-to-end)
+          gRPC bidirectional stream   
++-----+  (ProxyWindowsDesktopSession)   +---------------+     TCP connection     +-------------------------+
+| tsh | <============================> |  Proxy Service | <====================> | Windows Desktop Service |
++-----+                                 +---------------+                        +-------------------------+
+        <======================================================================>
+                                    TLS connection (end-to-end)
 ```
 
 `ProxyWindowsDesktopSession` won't transmit TDP messages directly.


### PR DESCRIPTION
Contribues to https://github.com/gravitational/teleport/issues/20802.

As I’m planning to extend the Proxy API, let's discuss it first.

[Rendered](https://github.com/gravitational/teleport/blob/rfd/0208-proxy-desktop-session/rfd/0208-proxy-desktop-session.md)