### PR TITLE
Log discovery fetcher string representation

### DIFF
--- a/lib/srv/discovery/common/interfaces.go
+++ b/lib/srv/discovery/common/interfaces.go
@@ -20,6 +20,7 @@ package common
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gravitational/teleport/api/types"
 )
@@ -42,4 +43,6 @@ type Fetcher interface {
 	GetDiscoveryConfigName() string
 	// Cloud returns the cloud the fetcher is operating.
 	Cloud() string
+
+	fmt.Stringer
 }

--- a/lib/srv/discovery/common/watcher.go
+++ b/lib/srv/discovery/common/watcher.go
@@ -30,6 +30,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/gravitational/teleport/api/types"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 const (
@@ -163,9 +164,17 @@ func (w *Watcher) fetchAndSend() {
 				// not others. This is acceptable, so make a debug log instead
 				// of a warning.
 				if trace.IsAccessDenied(err) || trace.IsNotFound(err) {
-					w.cfg.Logger.DebugContext(groupCtx, "Skipped fetcher for resources", "error", err, "fetcher", lFetcher, "resource", lFetcher.ResourceType(), "cloud", lFetcher.Cloud())
+					w.cfg.Logger.DebugContext(groupCtx, "Skipped fetcher for resources",
+						"error", err,
+						"fetcher", logutils.StringerAttr(lFetcher),
+						"resource", lFetcher.ResourceType(),
+						"cloud", lFetcher.Cloud())
 				} else {
-					w.cfg.Logger.WarnContext(groupCtx, "Unable to fetch resources", "error", err, "fetcher", lFetcher, "resource", lFetcher.ResourceType(), "cloud", lFetcher.Cloud())
+					w.cfg.Logger.WarnContext(groupCtx, "Unable to fetch resources",
+						"error", err,
+						"fetcher", logutils.StringerAttr(lFetcher),
+						"resource", lFetcher.ResourceType(),
+						"cloud", lFetcher.Cloud())
 				}
 				// never return the error otherwise it will impact other watchers.
 				return nil

--- a/lib/srv/discovery/common/watcher_test.go
+++ b/lib/srv/discovery/common/watcher_test.go
@@ -159,6 +159,10 @@ type mockFetcher struct {
 	noAuth       bool
 }
 
+func (m *mockFetcher) String() string {
+	return "mock-fetcher"
+}
+
 func (m *mockFetcher) Get(ctx context.Context) (types.ResourcesWithLabels, error) {
 	if m.noAuth {
 		return nil, trace.AccessDenied("access denied")


### PR DESCRIPTION
Ensure that the fmt.Stringer implementation of the fetcher interface is used when logging the fetcher in error messages.

Closes #54052


Changelog: reduce log spam in discovery service error messaging