### PR TITLE
Fix CMC weekdays bug

### DIFF
--- a/api/types/maintenance.go
+++ b/api/types/maintenance.go
@@ -288,13 +288,14 @@ func (m *ClusterMaintenanceConfigV1) WithinUpgradeWindow(t time.Time) bool {
 		}
 	}
 
-	weekday := t.Weekday().String()
-	for _, upgradeWeekday := range upgradeWindow.Weekdays {
-		if weekday == upgradeWeekday {
-			if int(upgradeWindow.UTCStartHour) == t.Hour() {
-				return true
-			}
-		}
+	upgradeWeekDays, err := ParseWeekdays(upgradeWindow.Weekdays)
+	if err != nil {
+		return false
 	}
-	return false
+
+	if _, ok := upgradeWeekDays[t.Weekday()]; !ok {
+		return false
+	}
+
+	return int(upgradeWindow.UTCStartHour) == t.Hour()
 }

--- a/api/types/maintenance_test.go
+++ b/api/types/maintenance_test.go
@@ -244,7 +244,7 @@ func TestWithinUpgradeWindow(t *testing.T) {
 			desc: "within upgrade window weekday",
 			upgradeWindow: AgentUpgradeWindow{
 				UTCStartHour: 8,
-				Weekdays:     []string{"Monday"},
+				Weekdays:     []string{"Mon"},
 			},
 			date:         "Mon, 02 Jan 2006 08:04:05 UTC",
 			withinWindow: true,
@@ -253,7 +253,7 @@ func TestWithinUpgradeWindow(t *testing.T) {
 			desc: "not within upgrade window weekday",
 			upgradeWindow: AgentUpgradeWindow{
 				UTCStartHour: 8,
-				Weekdays:     []string{"Tuesday"},
+				Weekdays:     []string{"Tue"},
 			},
 			date:         "Mon, 02 Jan 2006 08:04:05 UTC",
 			withinWindow: false,

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -135,6 +135,10 @@ const (
 	// This cache is here to protect against accidental or intentional DDoS, the TTL must be low to quickly reflect
 	// cluster configuration changes.
 	findEndpointCacheTTL = 10 * time.Second
+	// cmcCacheTTL is the cache TTL for the clusterMaintenanceConfig resource.
+	// This cache is here to protect against accidental or intentional DDoS, the TTL must be low to quickly reflect
+	// cluster configuration changes.
+	cmcCacheTTL = time.Minute
 	// DefaultAgentUpdateJitterSeconds is the default jitter agents should wait before updating.
 	DefaultAgentUpdateJitterSeconds = 60
 )
@@ -488,13 +492,13 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 
 	// We create the cache after applying the options to make sure we use the fake clock if it was passed.
 	cmcCache, err := utils.NewFnCache(utils.FnCacheConfig{
-		TTL:         findEndpointCacheTTL,
+		TTL:         cmcCacheTTL,
 		Clock:       h.clock,
 		Context:     cfg.Context,
 		ReloadOnErr: false,
 	})
 	if err != nil {
-		return nil, trace.Wrap(err, "creating /find cache")
+		return nil, trace.Wrap(err, "creating cluster maintenance config cache")
 	}
 	h.clusterMaintenanceConfigCache = cmcCache
 

--- a/lib/web/autoupdate_common.go
+++ b/lib/web/autoupdate_common.go
@@ -205,17 +205,24 @@ func getVersionFromChannel(ctx context.Context, channels automaticupgrades.Chann
 
 // getTriggerFromWindowThenChannel gets the target version from the RFD109 maintenance window and channels.
 func (h *Handler) getTriggerFromWindowThenChannel(ctx context.Context, groupName string) (bool, error) {
-	// Caching the CMC for 10 seconds because this resource is cached neither by the auth nor the proxy.
+	// Caching the CMC for 60 seconds because this resource is cached neither by the auth nor the proxy.
 	// And this function can be accessed via unauthenticated endpoints.
 	cmc, err := utils.FnCacheGet(ctx, h.clusterMaintenanceConfigCache, "cmc", func(ctx context.Context) (types.ClusterMaintenanceConfig, error) {
 		return h.cfg.ProxyClient.GetClusterMaintenanceConfig(ctx)
 	})
 
-	// If we have a CMC, we check if the window is active, else we just check if the update is critical.
-	if err == nil && cmc.WithinUpgradeWindow(h.clock.Now()) {
-		return true, nil
+	// If there's no CMC or we failed to get it, we fallback directly to the channel
+	if err != nil {
+		if !trace.IsNotFound(err) {
+			h.logger.WarnContext(ctx, "Failed to get cluster maintenance config", "error", err)
+		}
+		return getTriggerFromChannel(ctx, h.cfg.AutomaticUpgradesChannels, groupName)
 	}
 
+	// If we have a CMC, we check if the window is active, else we just check if the update is critical.
+	if cmc.WithinUpgradeWindow(h.clock.Now()) {
+		return true, nil
+	}
 	return getTriggerFromChannel(ctx, h.cfg.AutomaticUpgradesChannels, groupName)
 }
 


### PR DESCRIPTION
This PR fixes a bug in the CMC's `WithinUpgradeWindow` function.

It was comparing the weekday string (e.g "Wednesday") with the weekdays in the CMC (e.g. "Wed"). This affected 2 things:
- the managed update v2 backward compatbility with CMCs (updates were never firing)
- the AWS oidc updater was never updating

This bug was only triggered when the CMC.Weekdays field was set, which was not the case in cloud by default (we changed this in the latest v17 version but it's not deployed yet).

Changelog: Fix a bug in managed updates v1 causing updaters v2 and AWS integrations to never update if weekdays were set in the `cluster_maintenance_config` resource.