### PR TITLE
web: add role description to roles page

### DIFF
--- a/web/packages/teleport/src/Roles/RoleList/RoleList.tsx
+++ b/web/packages/teleport/src/Roles/RoleList/RoleList.tsx
@@ -70,6 +70,10 @@ export function RoleList({
           headerText: 'Name',
         },
         {
+          key: 'description',
+          headerText: 'Description',
+        },
+        {
           altKey: 'options-btn',
           render: (role: RoleResource) => (
             <ActionCell

--- a/web/packages/teleport/src/Roles/Roles.tsx
+++ b/web/packages/teleport/src/Roles/Roles.tsx
@@ -239,7 +239,7 @@ export function Roles(props: State & RolesProps) {
         </InfoGuideButton>
       </FeatureHeader>
       {serverSidePagination.attempt.status === 'failed' && (
-        <Alert children={serverSidePagination.attempt.statusText} />
+        <Alert>{serverSidePagination.attempt.statusText}</Alert>
       )}
       <Flex flex="1">
         <Box flex="1" mb="4">


### PR DESCRIPTION
<img width="1802" alt="image" src="https://github.com/user-attachments/assets/60a9c98b-267b-4ee2-b832-6a34ea981f0f" />

Changelog: the web UI now shows role descriptions in the roles table.