### PR TITLE
[v16] Fix CMC weekdays bug

### DIFF
--- a/api/types/maintenance.go
+++ b/api/types/maintenance.go
@@ -288,13 +288,14 @@ func (m *ClusterMaintenanceConfigV1) WithinUpgradeWindow(t time.Time) bool {
 		}
 	}
 
-	weekday := t.Weekday().String()
-	for _, upgradeWeekday := range upgradeWindow.Weekdays {
-		if weekday == upgradeWeekday {
-			if int(upgradeWindow.UTCStartHour) == t.Hour() {
-				return true
-			}
-		}
+	upgradeWeekDays, err := ParseWeekdays(upgradeWindow.Weekdays)
+	if err != nil {
+		return false
 	}
-	return false
+
+	if _, ok := upgradeWeekDays[t.Weekday()]; !ok {
+		return false
+	}
+
+	return int(upgradeWindow.UTCStartHour) == t.Hour()
 }

--- a/api/types/maintenance_test.go
+++ b/api/types/maintenance_test.go
@@ -244,7 +244,7 @@ func TestWithinUpgradeWindow(t *testing.T) {
 			desc: "within upgrade window weekday",
 			upgradeWindow: AgentUpgradeWindow{
 				UTCStartHour: 8,
-				Weekdays:     []string{"Monday"},
+				Weekdays:     []string{"Mon"},
 			},
 			date:         "Mon, 02 Jan 2006 08:04:05 UTC",
 			withinWindow: true,
@@ -253,7 +253,7 @@ func TestWithinUpgradeWindow(t *testing.T) {
 			desc: "not within upgrade window weekday",
 			upgradeWindow: AgentUpgradeWindow{
 				UTCStartHour: 8,
-				Weekdays:     []string{"Tuesday"},
+				Weekdays:     []string{"Tue"},
 			},
 			date:         "Mon, 02 Jan 2006 08:04:05 UTC",
 			withinWindow: false,

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -134,6 +134,10 @@ const (
 	// This cache is here to protect against accidental or intentional DDoS, the TTL must be low to quickly reflect
 	// cluster configuration changes.
 	findEndpointCacheTTL = 10 * time.Second
+	// cmcCacheTTL is the cache TTL for the clusterMaintenanceConfig resource.
+	// This cache is here to protect against accidental or intentional DDoS, the TTL must be low to quickly reflect
+	// cluster configuration changes.
+	cmcCacheTTL = time.Minute
 	// DefaultAgentUpdateJitterSeconds is the default jitter agents should wait before updating.
 	DefaultAgentUpdateJitterSeconds = 60
 )
@@ -511,13 +515,13 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 
 	// We create the cache after applying the options to make sure we use the fake clock if it was passed.
 	cmcCache, err := utils.NewFnCache(utils.FnCacheConfig{
-		TTL:         findEndpointCacheTTL,
+		TTL:         cmcCacheTTL,
 		Clock:       h.clock,
 		Context:     cfg.Context,
 		ReloadOnErr: false,
 	})
 	if err != nil {
-		return nil, trace.Wrap(err, "creating /find cache")
+		return nil, trace.Wrap(err, "creating cluster maintenance config cache")
 	}
 	h.clusterMaintenanceConfigCache = cmcCache
 


### PR DESCRIPTION
Backport #54076 to branch/v16

changelog: Fix a bug in managed updates v1 causing updaters v2 and AWS integrations to never update if weekdays were set in the `cluster_maintenance_config` resource.
