### PR TITLE
feat: Hardware Key Agent - command hint

### DIFF
--- a/api/utils/keys/hardwarekey/cliprompt.go
+++ b/api/utils/keys/hardwarekey/cliprompt.go
@@ -58,18 +58,22 @@ func NewCLIPrompt(w io.Writer, r prompt.StdinReader) *cliPrompt {
 
 // AskPIN prompts the user for a PIN. If the requirement is [PINOptional],
 // the prompt will offer the default PIN as a default value.
-func (c *cliPrompt) AskPIN(ctx context.Context, requirement PINPromptRequirement, _ ContextualKeyInfo) (string, error) {
-	message := "Enter your YubiKey PIV PIN"
+func (c *cliPrompt) AskPIN(ctx context.Context, requirement PINPromptRequirement, keyInfo ContextualKeyInfo) (string, error) {
+	message := fmt.Sprintf("Hardware key PIN is required to continue with command %q\n", keyInfo.Command)
+
+	message += "Enter your YubiKey PIV PIN"
 	if requirement == PINOptional {
-		message = "Enter your YubiKey PIV PIN [blank to use default PIN]"
+		message += " [blank to use default PIN]"
 	}
+
 	password, err := prompt.Password(ctx, c.writer, c.reader, message)
 	return password, trace.Wrap(err)
 }
 
 // Touch prompts the user to touch the hardware key.
-func (c *cliPrompt) Touch(_ context.Context, _ ContextualKeyInfo) error {
-	_, err := fmt.Fprintln(c.writer, "Tap your YubiKey")
+func (c *cliPrompt) Touch(_ context.Context, keyInfo ContextualKeyInfo) error {
+	message := fmt.Sprintf("Hardware key touch is required to continue with command %q\nTap your YubiKey", keyInfo.Command)
+	_, err := fmt.Fprintln(c.writer, message)
 	return trace.Wrap(err)
 }
 

--- a/api/utils/keys/hardwarekey/cliprompt.go
+++ b/api/utils/keys/hardwarekey/cliprompt.go
@@ -59,21 +59,32 @@ func NewCLIPrompt(w io.Writer, r prompt.StdinReader) *cliPrompt {
 // AskPIN prompts the user for a PIN. If the requirement is [PINOptional],
 // the prompt will offer the default PIN as a default value.
 func (c *cliPrompt) AskPIN(ctx context.Context, requirement PINPromptRequirement, keyInfo ContextualKeyInfo) (string, error) {
-	message := fmt.Sprintf("Hardware key PIN is required to continue with command %q\n", keyInfo.Command)
+	msg := "Enter your YubiKey PIV PIN"
 
-	message += "Enter your YubiKey PIV PIN"
+	// The user may need to set their PIN for the first time during login,
+	// give them a hint to continue to setting the PIN.
 	if requirement == PINOptional {
-		message += " [blank to use default PIN]"
+		msg += " [blank to use default PIN]"
 	}
 
-	password, err := prompt.Password(ctx, c.writer, c.reader, message)
+	// If this is a hardware key agent request with command context info,
+	// include the command in the prompt.
+	if keyInfo.Command != "" {
+		msg = fmt.Sprintf("%v to continue with command %q", msg, keyInfo.Command)
+	}
+
+	password, err := prompt.Password(ctx, c.writer, c.reader, msg)
 	return password, trace.Wrap(err)
 }
 
 // Touch prompts the user to touch the hardware key.
 func (c *cliPrompt) Touch(_ context.Context, keyInfo ContextualKeyInfo) error {
-	message := fmt.Sprintf("Hardware key touch is required to continue with command %q\nTap your YubiKey", keyInfo.Command)
-	_, err := fmt.Fprintln(c.writer, message)
+	msg := "Tap your YubiKey"
+	if keyInfo.Command != "" {
+		msg = fmt.Sprintf("%v to continue with command %q", msg, keyInfo.Command)
+	}
+
+	_, err := fmt.Fprintln(c.writer, msg)
 	return trace.Wrap(err)
 }
 

--- a/api/utils/keys/hardwarekey/hardwarekey.go
+++ b/api/utils/keys/hardwarekey/hardwarekey.go
@@ -262,6 +262,8 @@ type ContextualKeyInfo struct {
 	// metadata certificate format, to ensure the agent doesn't provide access to
 	// non teleport client PIV keys.
 	AgentKey bool
+	// Command is the running command utilizing this key.
+	Command string
 }
 
 // SignatureAlgorithm is a signature key algorithm option.

--- a/api/utils/keys/hardwarekeyagent/agent.go
+++ b/api/utils/keys/hardwarekeyagent/agent.go
@@ -102,6 +102,7 @@ func (s *agentService) Sign(ctx context.Context, req *hardwarekeyagentv1.SignReq
 		Username:    req.KeyInfo.Username,
 		ClusterName: req.KeyInfo.ClusterName,
 		AgentKey:    true,
+		Command:     req.Command,
 	}
 
 	var signerOpts crypto.SignerOpts

--- a/api/utils/keys/hardwarekeyagent/service.go
+++ b/api/utils/keys/hardwarekeyagent/service.go
@@ -123,9 +123,9 @@ func (s *Service) agentSign(ctx context.Context, ref *hardwarekey.PrivateKeyRef,
 		}
 	}
 
-	// Trim leading path from command for user readability.
+	// Trim leading path (/ or \ on windows) from command for user readability.
 	command := os.Args[0]
-	if i := strings.LastIndex(command, "/"); i != -1 {
+	if i := strings.LastIndexAny(command, "/\\"); i != -1 {
 		command = command[i+1:]
 	}
 	commandString := fmt.Sprintf("%v %v", command, strings.Join(os.Args[1:], " "))

--- a/api/utils/keys/hardwarekeyagent/service.go
+++ b/api/utils/keys/hardwarekeyagent/service.go
@@ -123,16 +123,12 @@ func (s *Service) agentSign(ctx context.Context, ref *hardwarekey.PrivateKeyRef,
 		}
 	}
 
-	command, err := os.Executable()
-	if err != nil {
-		return nil, trace.Wrap(err)
+	// Trim leading path from command for user readability.
+	command := os.Args[0]
+	if i := strings.LastIndex(command, "/"); i != -1 {
+		command = command[i+1:]
 	}
-
-	var commandString string = fmt.Sprintf("%v %v", command, strings.Join(os.Args[:3], " "))
-	if len(os.Args) > 3 {
-		// Abbreviate the command displayed in prompts.
-		commandString += " ..."
-	}
+	commandString := fmt.Sprintf("%v %v", command, strings.Join(os.Args[1:], " "))
 
 	req := &hardwarekeyagentv1.SignRequest{
 		Digest:     digest,

--- a/gen/proto/go/teleport/lib/teleterm/v1/tshd_events_service.pb.go
+++ b/gen/proto/go/teleport/lib/teleterm/v1/tshd_events_service.pb.go
@@ -965,12 +965,13 @@ func (x *PromptMFAResponse) GetTotpCode() string {
 
 // Request for PromptHardwareKeyPIN.
 type PromptHardwareKeyPINRequest struct {
-	state          protoimpl.MessageState `protogen:"open.v1"`
-	RootClusterUri string                 `protobuf:"bytes,1,opt,name=root_cluster_uri,json=rootClusterUri,proto3" json:"root_cluster_uri,omitempty"`
-	// Specifies if a PIN is optional, allowing the user to set it up if left empty.
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// PinOptional specified if a PIN is optional, allowing the user to set it up if left empty.
 	PinOptional bool `protobuf:"varint,2,opt,name=pin_optional,json=pinOptional,proto3" json:"pin_optional,omitempty"`
+	// ProxyHost is the proxy hostname of the client key.
+	ProxyHost string `protobuf:"bytes,3,opt,name=proxy_host,json=proxyHost,proto3" json:"proxy_host,omitempty"`
 	// Command is an optional command string to provide context for the prompt.
-	Command       string `protobuf:"bytes,3,opt,name=command,proto3" json:"command,omitempty"`
+	Command       string `protobuf:"bytes,4,opt,name=command,proto3" json:"command,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1005,18 +1006,18 @@ func (*PromptHardwareKeyPINRequest) Descriptor() ([]byte, []int) {
 	return file_teleport_lib_teleterm_v1_tshd_events_service_proto_rawDescGZIP(), []int{15}
 }
 
-func (x *PromptHardwareKeyPINRequest) GetRootClusterUri() string {
-	if x != nil {
-		return x.RootClusterUri
-	}
-	return ""
-}
-
 func (x *PromptHardwareKeyPINRequest) GetPinOptional() bool {
 	if x != nil {
 		return x.PinOptional
 	}
 	return false
+}
+
+func (x *PromptHardwareKeyPINRequest) GetProxyHost() string {
+	if x != nil {
+		return x.ProxyHost
+	}
+	return ""
 }
 
 func (x *PromptHardwareKeyPINRequest) GetCommand() string {
@@ -1074,8 +1075,9 @@ func (x *PromptHardwareKeyPINResponse) GetPin() string {
 
 // Request for PromptHardwareKeyTouchRequest.
 type PromptHardwareKeyTouchRequest struct {
-	state          protoimpl.MessageState `protogen:"open.v1"`
-	RootClusterUri string                 `protobuf:"bytes,1,opt,name=root_cluster_uri,json=rootClusterUri,proto3" json:"root_cluster_uri,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// ProxyHost is the proxy hostname of the client key.
+	ProxyHost string `protobuf:"bytes,2,opt,name=proxy_host,json=proxyHost,proto3" json:"proxy_host,omitempty"`
 	// Command is an optional command string to provide context for the prompt.
 	Command       string `protobuf:"bytes,3,opt,name=command,proto3" json:"command,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -1112,9 +1114,9 @@ func (*PromptHardwareKeyTouchRequest) Descriptor() ([]byte, []int) {
 	return file_teleport_lib_teleterm_v1_tshd_events_service_proto_rawDescGZIP(), []int{17}
 }
 
-func (x *PromptHardwareKeyTouchRequest) GetRootClusterUri() string {
+func (x *PromptHardwareKeyTouchRequest) GetProxyHost() string {
 	if x != nil {
-		return x.RootClusterUri
+		return x.ProxyHost
 	}
 	return ""
 }
@@ -1165,10 +1167,11 @@ func (*PromptHardwareKeyTouchResponse) Descriptor() ([]byte, []int) {
 
 // Response for PromptHardwareKeyPINChange.
 type PromptHardwareKeyPINChangeRequest struct {
-	state          protoimpl.MessageState `protogen:"open.v1"`
-	RootClusterUri string                 `protobuf:"bytes,1,opt,name=root_cluster_uri,json=rootClusterUri,proto3" json:"root_cluster_uri,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// ProxyHost is the proxy hostname of the client key.
+	ProxyHost     string `protobuf:"bytes,2,opt,name=proxy_host,json=proxyHost,proto3" json:"proxy_host,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *PromptHardwareKeyPINChangeRequest) Reset() {
@@ -1201,9 +1204,9 @@ func (*PromptHardwareKeyPINChangeRequest) Descriptor() ([]byte, []int) {
 	return file_teleport_lib_teleterm_v1_tshd_events_service_proto_rawDescGZIP(), []int{19}
 }
 
-func (x *PromptHardwareKeyPINChangeRequest) GetRootClusterUri() string {
+func (x *PromptHardwareKeyPINChangeRequest) GetProxyHost() string {
 	if x != nil {
-		return x.RootClusterUri
+		return x.ProxyHost
 	}
 	return ""
 }
@@ -1275,10 +1278,11 @@ func (x *PromptHardwareKeyPINChangeResponse) GetPukChanged() bool {
 
 // Request for ConfirmHardwareKeySlotOverwrite.
 type ConfirmHardwareKeySlotOverwriteRequest struct {
-	state          protoimpl.MessageState `protogen:"open.v1"`
-	RootClusterUri string                 `protobuf:"bytes,1,opt,name=root_cluster_uri,json=rootClusterUri,proto3" json:"root_cluster_uri,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
 	// Message to display in the prompt.
-	Message       string `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	Message string `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	// ProxyHost is the proxy hostname of the client key.
+	ProxyHost     string `protobuf:"bytes,3,opt,name=proxy_host,json=proxyHost,proto3" json:"proxy_host,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1313,16 +1317,16 @@ func (*ConfirmHardwareKeySlotOverwriteRequest) Descriptor() ([]byte, []int) {
 	return file_teleport_lib_teleterm_v1_tshd_events_service_proto_rawDescGZIP(), []int{21}
 }
 
-func (x *ConfirmHardwareKeySlotOverwriteRequest) GetRootClusterUri() string {
+func (x *ConfirmHardwareKeySlotOverwriteRequest) GetMessage() string {
 	if x != nil {
-		return x.RootClusterUri
+		return x.Message
 	}
 	return ""
 }
 
-func (x *ConfirmHardwareKeySlotOverwriteRequest) GetMessage() string {
+func (x *ConfirmHardwareKeySlotOverwriteRequest) GetProxyHost() string {
 	if x != nil {
-		return x.Message
+		return x.ProxyHost
 	}
 	return ""
 }
@@ -1648,27 +1652,31 @@ const file_teleport_lib_teleterm_v1_tshd_events_service_proto_rawDesc = "" +
 	"\fdisplay_name\x18\x03 \x01(\tR\vdisplayName\x12!\n" +
 	"\fredirect_url\x18\x04 \x01(\tR\vredirectUrl\"0\n" +
 	"\x11PromptMFAResponse\x12\x1b\n" +
-	"\ttotp_code\x18\x01 \x01(\tR\btotpCode\"\x84\x01\n" +
-	"\x1bPromptHardwareKeyPINRequest\x12(\n" +
-	"\x10root_cluster_uri\x18\x01 \x01(\tR\x0erootClusterUri\x12!\n" +
-	"\fpin_optional\x18\x02 \x01(\bR\vpinOptional\x12\x18\n" +
-	"\acommand\x18\x03 \x01(\tR\acommand\"0\n" +
+	"\ttotp_code\x18\x01 \x01(\tR\btotpCode\"\x91\x01\n" +
+	"\x1bPromptHardwareKeyPINRequest\x12!\n" +
+	"\fpin_optional\x18\x02 \x01(\bR\vpinOptional\x12\x1d\n" +
+	"\n" +
+	"proxy_host\x18\x03 \x01(\tR\tproxyHost\x12\x18\n" +
+	"\acommand\x18\x04 \x01(\tR\acommandJ\x04\b\x01\x10\x02R\x10root_cluster_uri\"0\n" +
 	"\x1cPromptHardwareKeyPINResponse\x12\x10\n" +
-	"\x03pin\x18\x01 \x01(\tR\x03pin\"c\n" +
-	"\x1dPromptHardwareKeyTouchRequest\x12(\n" +
-	"\x10root_cluster_uri\x18\x01 \x01(\tR\x0erootClusterUri\x12\x18\n" +
-	"\acommand\x18\x03 \x01(\tR\acommand\" \n" +
-	"\x1ePromptHardwareKeyTouchResponse\"M\n" +
-	"!PromptHardwareKeyPINChangeRequest\x12(\n" +
-	"\x10root_cluster_uri\x18\x01 \x01(\tR\x0erootClusterUri\"i\n" +
+	"\x03pin\x18\x01 \x01(\tR\x03pin\"p\n" +
+	"\x1dPromptHardwareKeyTouchRequest\x12\x1d\n" +
+	"\n" +
+	"proxy_host\x18\x02 \x01(\tR\tproxyHost\x12\x18\n" +
+	"\acommand\x18\x03 \x01(\tR\acommandJ\x04\b\x01\x10\x02R\x10root_cluster_uri\" \n" +
+	"\x1ePromptHardwareKeyTouchResponse\"Z\n" +
+	"!PromptHardwareKeyPINChangeRequest\x12\x1d\n" +
+	"\n" +
+	"proxy_host\x18\x02 \x01(\tR\tproxyHostJ\x04\b\x01\x10\x02R\x10root_cluster_uri\"i\n" +
 	"\"PromptHardwareKeyPINChangeResponse\x12\x10\n" +
 	"\x03pin\x18\x01 \x01(\tR\x03pin\x12\x10\n" +
 	"\x03puk\x18\x02 \x01(\tR\x03puk\x12\x1f\n" +
 	"\vpuk_changed\x18\x03 \x01(\bR\n" +
-	"pukChanged\"l\n" +
-	"&ConfirmHardwareKeySlotOverwriteRequest\x12(\n" +
-	"\x10root_cluster_uri\x18\x01 \x01(\tR\x0erootClusterUri\x12\x18\n" +
-	"\amessage\x18\x02 \x01(\tR\amessage\"G\n" +
+	"pukChanged\"y\n" +
+	"&ConfirmHardwareKeySlotOverwriteRequest\x12\x18\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\x12\x1d\n" +
+	"\n" +
+	"proxy_host\x18\x03 \x01(\tR\tproxyHostJ\x04\b\x01\x10\x02R\x10root_cluster_uri\"G\n" +
 	"'ConfirmHardwareKeySlotOverwriteResponse\x12\x1c\n" +
 	"\tconfirmed\x18\x01 \x01(\bR\tconfirmed\"\"\n" +
 	" GetUsageReportingSettingsRequest\"\x8f\x01\n" +

--- a/gen/proto/go/teleport/lib/teleterm/v1/tshd_events_service.pb.go
+++ b/gen/proto/go/teleport/lib/teleterm/v1/tshd_events_service.pb.go
@@ -968,7 +968,9 @@ type PromptHardwareKeyPINRequest struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	RootClusterUri string                 `protobuf:"bytes,1,opt,name=root_cluster_uri,json=rootClusterUri,proto3" json:"root_cluster_uri,omitempty"`
 	// Specifies if a PIN is optional, allowing the user to set it up if left empty.
-	PinOptional   bool `protobuf:"varint,2,opt,name=pin_optional,json=pinOptional,proto3" json:"pin_optional,omitempty"`
+	PinOptional bool `protobuf:"varint,2,opt,name=pin_optional,json=pinOptional,proto3" json:"pin_optional,omitempty"`
+	// Command is an optional command string to provide context for the prompt.
+	Command       string `protobuf:"bytes,3,opt,name=command,proto3" json:"command,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1015,6 +1017,13 @@ func (x *PromptHardwareKeyPINRequest) GetPinOptional() bool {
 		return x.PinOptional
 	}
 	return false
+}
+
+func (x *PromptHardwareKeyPINRequest) GetCommand() string {
+	if x != nil {
+		return x.Command
+	}
+	return ""
 }
 
 // Response for PromptHardwareKeyPIN.
@@ -1067,8 +1076,10 @@ func (x *PromptHardwareKeyPINResponse) GetPin() string {
 type PromptHardwareKeyTouchRequest struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	RootClusterUri string                 `protobuf:"bytes,1,opt,name=root_cluster_uri,json=rootClusterUri,proto3" json:"root_cluster_uri,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Command is an optional command string to provide context for the prompt.
+	Command       string `protobuf:"bytes,3,opt,name=command,proto3" json:"command,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *PromptHardwareKeyTouchRequest) Reset() {
@@ -1104,6 +1115,13 @@ func (*PromptHardwareKeyTouchRequest) Descriptor() ([]byte, []int) {
 func (x *PromptHardwareKeyTouchRequest) GetRootClusterUri() string {
 	if x != nil {
 		return x.RootClusterUri
+	}
+	return ""
+}
+
+func (x *PromptHardwareKeyTouchRequest) GetCommand() string {
+	if x != nil {
+		return x.Command
 	}
 	return ""
 }
@@ -1630,14 +1648,16 @@ const file_teleport_lib_teleterm_v1_tshd_events_service_proto_rawDesc = "" +
 	"\fdisplay_name\x18\x03 \x01(\tR\vdisplayName\x12!\n" +
 	"\fredirect_url\x18\x04 \x01(\tR\vredirectUrl\"0\n" +
 	"\x11PromptMFAResponse\x12\x1b\n" +
-	"\ttotp_code\x18\x01 \x01(\tR\btotpCode\"j\n" +
+	"\ttotp_code\x18\x01 \x01(\tR\btotpCode\"\x84\x01\n" +
 	"\x1bPromptHardwareKeyPINRequest\x12(\n" +
 	"\x10root_cluster_uri\x18\x01 \x01(\tR\x0erootClusterUri\x12!\n" +
-	"\fpin_optional\x18\x02 \x01(\bR\vpinOptional\"0\n" +
+	"\fpin_optional\x18\x02 \x01(\bR\vpinOptional\x12\x18\n" +
+	"\acommand\x18\x03 \x01(\tR\acommand\"0\n" +
 	"\x1cPromptHardwareKeyPINResponse\x12\x10\n" +
-	"\x03pin\x18\x01 \x01(\tR\x03pin\"I\n" +
+	"\x03pin\x18\x01 \x01(\tR\x03pin\"c\n" +
 	"\x1dPromptHardwareKeyTouchRequest\x12(\n" +
-	"\x10root_cluster_uri\x18\x01 \x01(\tR\x0erootClusterUri\" \n" +
+	"\x10root_cluster_uri\x18\x01 \x01(\tR\x0erootClusterUri\x12\x18\n" +
+	"\acommand\x18\x03 \x01(\tR\acommand\" \n" +
 	"\x1ePromptHardwareKeyTouchResponse\"M\n" +
 	"!PromptHardwareKeyPINChangeRequest\x12(\n" +
 	"\x10root_cluster_uri\x18\x01 \x01(\tR\x0erootClusterUri\"i\n" +

--- a/gen/proto/go/teleport/lib/teleterm/v1/tshd_events_service.pb.go
+++ b/gen/proto/go/teleport/lib/teleterm/v1/tshd_events_service.pb.go
@@ -968,8 +968,8 @@ type PromptHardwareKeyPINRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// PinOptional specified if a PIN is optional, allowing the user to set it up if left empty.
 	PinOptional bool `protobuf:"varint,2,opt,name=pin_optional,json=pinOptional,proto3" json:"pin_optional,omitempty"`
-	// ProxyHost is the proxy hostname of the client key.
-	ProxyHost string `protobuf:"bytes,3,opt,name=proxy_host,json=proxyHost,proto3" json:"proxy_host,omitempty"`
+	// ProxyHostname is the proxy hostname of the client key.
+	ProxyHostname string `protobuf:"bytes,3,opt,name=proxy_hostname,json=proxyHostname,proto3" json:"proxy_hostname,omitempty"`
 	// Command is an optional command string to provide context for the prompt.
 	Command       string `protobuf:"bytes,4,opt,name=command,proto3" json:"command,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -1013,9 +1013,9 @@ func (x *PromptHardwareKeyPINRequest) GetPinOptional() bool {
 	return false
 }
 
-func (x *PromptHardwareKeyPINRequest) GetProxyHost() string {
+func (x *PromptHardwareKeyPINRequest) GetProxyHostname() string {
 	if x != nil {
-		return x.ProxyHost
+		return x.ProxyHostname
 	}
 	return ""
 }
@@ -1076,8 +1076,8 @@ func (x *PromptHardwareKeyPINResponse) GetPin() string {
 // Request for PromptHardwareKeyTouchRequest.
 type PromptHardwareKeyTouchRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// ProxyHost is the proxy hostname of the client key.
-	ProxyHost string `protobuf:"bytes,2,opt,name=proxy_host,json=proxyHost,proto3" json:"proxy_host,omitempty"`
+	// ProxyHostname is the proxy hostname of the client key.
+	ProxyHostname string `protobuf:"bytes,2,opt,name=proxy_hostname,json=proxyHostname,proto3" json:"proxy_hostname,omitempty"`
 	// Command is an optional command string to provide context for the prompt.
 	Command       string `protobuf:"bytes,3,opt,name=command,proto3" json:"command,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -1114,9 +1114,9 @@ func (*PromptHardwareKeyTouchRequest) Descriptor() ([]byte, []int) {
 	return file_teleport_lib_teleterm_v1_tshd_events_service_proto_rawDescGZIP(), []int{17}
 }
 
-func (x *PromptHardwareKeyTouchRequest) GetProxyHost() string {
+func (x *PromptHardwareKeyTouchRequest) GetProxyHostname() string {
 	if x != nil {
-		return x.ProxyHost
+		return x.ProxyHostname
 	}
 	return ""
 }
@@ -1168,8 +1168,8 @@ func (*PromptHardwareKeyTouchResponse) Descriptor() ([]byte, []int) {
 // Response for PromptHardwareKeyPINChange.
 type PromptHardwareKeyPINChangeRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// ProxyHost is the proxy hostname of the client key.
-	ProxyHost     string `protobuf:"bytes,2,opt,name=proxy_host,json=proxyHost,proto3" json:"proxy_host,omitempty"`
+	// ProxyHostname is the proxy hostname of the client key.
+	ProxyHostname string `protobuf:"bytes,2,opt,name=proxy_hostname,json=proxyHostname,proto3" json:"proxy_hostname,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1204,9 +1204,9 @@ func (*PromptHardwareKeyPINChangeRequest) Descriptor() ([]byte, []int) {
 	return file_teleport_lib_teleterm_v1_tshd_events_service_proto_rawDescGZIP(), []int{19}
 }
 
-func (x *PromptHardwareKeyPINChangeRequest) GetProxyHost() string {
+func (x *PromptHardwareKeyPINChangeRequest) GetProxyHostname() string {
 	if x != nil {
-		return x.ProxyHost
+		return x.ProxyHostname
 	}
 	return ""
 }
@@ -1281,8 +1281,8 @@ type ConfirmHardwareKeySlotOverwriteRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Message to display in the prompt.
 	Message string `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
-	// ProxyHost is the proxy hostname of the client key.
-	ProxyHost     string `protobuf:"bytes,3,opt,name=proxy_host,json=proxyHost,proto3" json:"proxy_host,omitempty"`
+	// ProxyHostname is the proxy hostname of the client key.
+	ProxyHostname string `protobuf:"bytes,3,opt,name=proxy_hostname,json=proxyHostname,proto3" json:"proxy_hostname,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1324,9 +1324,9 @@ func (x *ConfirmHardwareKeySlotOverwriteRequest) GetMessage() string {
 	return ""
 }
 
-func (x *ConfirmHardwareKeySlotOverwriteRequest) GetProxyHost() string {
+func (x *ConfirmHardwareKeySlotOverwriteRequest) GetProxyHostname() string {
 	if x != nil {
-		return x.ProxyHost
+		return x.ProxyHostname
 	}
 	return ""
 }
@@ -1652,31 +1652,27 @@ const file_teleport_lib_teleterm_v1_tshd_events_service_proto_rawDesc = "" +
 	"\fdisplay_name\x18\x03 \x01(\tR\vdisplayName\x12!\n" +
 	"\fredirect_url\x18\x04 \x01(\tR\vredirectUrl\"0\n" +
 	"\x11PromptMFAResponse\x12\x1b\n" +
-	"\ttotp_code\x18\x01 \x01(\tR\btotpCode\"\x91\x01\n" +
+	"\ttotp_code\x18\x01 \x01(\tR\btotpCode\"\x99\x01\n" +
 	"\x1bPromptHardwareKeyPINRequest\x12!\n" +
-	"\fpin_optional\x18\x02 \x01(\bR\vpinOptional\x12\x1d\n" +
-	"\n" +
-	"proxy_host\x18\x03 \x01(\tR\tproxyHost\x12\x18\n" +
+	"\fpin_optional\x18\x02 \x01(\bR\vpinOptional\x12%\n" +
+	"\x0eproxy_hostname\x18\x03 \x01(\tR\rproxyHostname\x12\x18\n" +
 	"\acommand\x18\x04 \x01(\tR\acommandJ\x04\b\x01\x10\x02R\x10root_cluster_uri\"0\n" +
 	"\x1cPromptHardwareKeyPINResponse\x12\x10\n" +
-	"\x03pin\x18\x01 \x01(\tR\x03pin\"p\n" +
-	"\x1dPromptHardwareKeyTouchRequest\x12\x1d\n" +
-	"\n" +
-	"proxy_host\x18\x02 \x01(\tR\tproxyHost\x12\x18\n" +
+	"\x03pin\x18\x01 \x01(\tR\x03pin\"x\n" +
+	"\x1dPromptHardwareKeyTouchRequest\x12%\n" +
+	"\x0eproxy_hostname\x18\x02 \x01(\tR\rproxyHostname\x12\x18\n" +
 	"\acommand\x18\x03 \x01(\tR\acommandJ\x04\b\x01\x10\x02R\x10root_cluster_uri\" \n" +
-	"\x1ePromptHardwareKeyTouchResponse\"Z\n" +
-	"!PromptHardwareKeyPINChangeRequest\x12\x1d\n" +
-	"\n" +
-	"proxy_host\x18\x02 \x01(\tR\tproxyHostJ\x04\b\x01\x10\x02R\x10root_cluster_uri\"i\n" +
+	"\x1ePromptHardwareKeyTouchResponse\"b\n" +
+	"!PromptHardwareKeyPINChangeRequest\x12%\n" +
+	"\x0eproxy_hostname\x18\x02 \x01(\tR\rproxyHostnameJ\x04\b\x01\x10\x02R\x10root_cluster_uri\"i\n" +
 	"\"PromptHardwareKeyPINChangeResponse\x12\x10\n" +
 	"\x03pin\x18\x01 \x01(\tR\x03pin\x12\x10\n" +
 	"\x03puk\x18\x02 \x01(\tR\x03puk\x12\x1f\n" +
 	"\vpuk_changed\x18\x03 \x01(\bR\n" +
-	"pukChanged\"y\n" +
+	"pukChanged\"\x81\x01\n" +
 	"&ConfirmHardwareKeySlotOverwriteRequest\x12\x18\n" +
-	"\amessage\x18\x02 \x01(\tR\amessage\x12\x1d\n" +
-	"\n" +
-	"proxy_host\x18\x03 \x01(\tR\tproxyHostJ\x04\b\x01\x10\x02R\x10root_cluster_uri\"G\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\x12%\n" +
+	"\x0eproxy_hostname\x18\x03 \x01(\tR\rproxyHostnameJ\x04\b\x01\x10\x02R\x10root_cluster_uri\"G\n" +
 	"'ConfirmHardwareKeySlotOverwriteResponse\x12\x1c\n" +
 	"\tconfirmed\x18\x01 \x01(\bR\tconfirmed\"\"\n" +
 	" GetUsageReportingSettingsRequest\"\x8f\x01\n" +

--- a/gen/proto/ts/teleport/lib/teleterm/v1/tshd_events_service_pb.ts
+++ b/gen/proto/ts/teleport/lib/teleterm/v1/tshd_events_service_pb.ts
@@ -338,11 +338,11 @@ export interface PromptHardwareKeyPINRequest {
      */
     pinOptional: boolean;
     /**
-     * ProxyHost is the proxy hostname of the client key.
+     * ProxyHostname is the proxy hostname of the client key.
      *
-     * @generated from protobuf field: string proxy_host = 3;
+     * @generated from protobuf field: string proxy_hostname = 3;
      */
-    proxyHost: string;
+    proxyHostname: string;
     /**
      * Command is an optional command string to provide context for the prompt.
      *
@@ -370,11 +370,11 @@ export interface PromptHardwareKeyPINResponse {
  */
 export interface PromptHardwareKeyTouchRequest {
     /**
-     * ProxyHost is the proxy hostname of the client key.
+     * ProxyHostname is the proxy hostname of the client key.
      *
-     * @generated from protobuf field: string proxy_host = 2;
+     * @generated from protobuf field: string proxy_hostname = 2;
      */
-    proxyHost: string;
+    proxyHostname: string;
     /**
      * Command is an optional command string to provide context for the prompt.
      *
@@ -396,11 +396,11 @@ export interface PromptHardwareKeyTouchResponse {
  */
 export interface PromptHardwareKeyPINChangeRequest {
     /**
-     * ProxyHost is the proxy hostname of the client key.
+     * ProxyHostname is the proxy hostname of the client key.
      *
-     * @generated from protobuf field: string proxy_host = 2;
+     * @generated from protobuf field: string proxy_hostname = 2;
      */
-    proxyHost: string;
+    proxyHostname: string;
 }
 /**
  * Response for PromptHardwareKeyPINChange.
@@ -441,11 +441,11 @@ export interface ConfirmHardwareKeySlotOverwriteRequest {
      */
     message: string;
     /**
-     * ProxyHost is the proxy hostname of the client key.
+     * ProxyHostname is the proxy hostname of the client key.
      *
-     * @generated from protobuf field: string proxy_host = 3;
+     * @generated from protobuf field: string proxy_hostname = 3;
      */
-    proxyHost: string;
+    proxyHostname: string;
 }
 /**
  * Response for ConfirmHardwareKeySlotOverwrite.
@@ -1327,14 +1327,14 @@ class PromptHardwareKeyPINRequest$Type extends MessageType<PromptHardwareKeyPINR
     constructor() {
         super("teleport.lib.teleterm.v1.PromptHardwareKeyPINRequest", [
             { no: 2, name: "pin_optional", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
-            { no: 3, name: "proxy_host", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "proxy_hostname", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 4, name: "command", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<PromptHardwareKeyPINRequest>): PromptHardwareKeyPINRequest {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.pinOptional = false;
-        message.proxyHost = "";
+        message.proxyHostname = "";
         message.command = "";
         if (value !== undefined)
             reflectionMergePartial<PromptHardwareKeyPINRequest>(this, message, value);
@@ -1348,8 +1348,8 @@ class PromptHardwareKeyPINRequest$Type extends MessageType<PromptHardwareKeyPINR
                 case /* bool pin_optional */ 2:
                     message.pinOptional = reader.bool();
                     break;
-                case /* string proxy_host */ 3:
-                    message.proxyHost = reader.string();
+                case /* string proxy_hostname */ 3:
+                    message.proxyHostname = reader.string();
                     break;
                 case /* string command */ 4:
                     message.command = reader.string();
@@ -1369,9 +1369,9 @@ class PromptHardwareKeyPINRequest$Type extends MessageType<PromptHardwareKeyPINR
         /* bool pin_optional = 2; */
         if (message.pinOptional !== false)
             writer.tag(2, WireType.Varint).bool(message.pinOptional);
-        /* string proxy_host = 3; */
-        if (message.proxyHost !== "")
-            writer.tag(3, WireType.LengthDelimited).string(message.proxyHost);
+        /* string proxy_hostname = 3; */
+        if (message.proxyHostname !== "")
+            writer.tag(3, WireType.LengthDelimited).string(message.proxyHostname);
         /* string command = 4; */
         if (message.command !== "")
             writer.tag(4, WireType.LengthDelimited).string(message.command);
@@ -1436,13 +1436,13 @@ export const PromptHardwareKeyPINResponse = new PromptHardwareKeyPINResponse$Typ
 class PromptHardwareKeyTouchRequest$Type extends MessageType<PromptHardwareKeyTouchRequest> {
     constructor() {
         super("teleport.lib.teleterm.v1.PromptHardwareKeyTouchRequest", [
-            { no: 2, name: "proxy_host", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "proxy_hostname", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 3, name: "command", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<PromptHardwareKeyTouchRequest>): PromptHardwareKeyTouchRequest {
         const message = globalThis.Object.create((this.messagePrototype!));
-        message.proxyHost = "";
+        message.proxyHostname = "";
         message.command = "";
         if (value !== undefined)
             reflectionMergePartial<PromptHardwareKeyTouchRequest>(this, message, value);
@@ -1453,8 +1453,8 @@ class PromptHardwareKeyTouchRequest$Type extends MessageType<PromptHardwareKeyTo
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* string proxy_host */ 2:
-                    message.proxyHost = reader.string();
+                case /* string proxy_hostname */ 2:
+                    message.proxyHostname = reader.string();
                     break;
                 case /* string command */ 3:
                     message.command = reader.string();
@@ -1471,9 +1471,9 @@ class PromptHardwareKeyTouchRequest$Type extends MessageType<PromptHardwareKeyTo
         return message;
     }
     internalBinaryWrite(message: PromptHardwareKeyTouchRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* string proxy_host = 2; */
-        if (message.proxyHost !== "")
-            writer.tag(2, WireType.LengthDelimited).string(message.proxyHost);
+        /* string proxy_hostname = 2; */
+        if (message.proxyHostname !== "")
+            writer.tag(2, WireType.LengthDelimited).string(message.proxyHostname);
         /* string command = 3; */
         if (message.command !== "")
             writer.tag(3, WireType.LengthDelimited).string(message.command);
@@ -1516,12 +1516,12 @@ export const PromptHardwareKeyTouchResponse = new PromptHardwareKeyTouchResponse
 class PromptHardwareKeyPINChangeRequest$Type extends MessageType<PromptHardwareKeyPINChangeRequest> {
     constructor() {
         super("teleport.lib.teleterm.v1.PromptHardwareKeyPINChangeRequest", [
-            { no: 2, name: "proxy_host", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+            { no: 2, name: "proxy_hostname", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<PromptHardwareKeyPINChangeRequest>): PromptHardwareKeyPINChangeRequest {
         const message = globalThis.Object.create((this.messagePrototype!));
-        message.proxyHost = "";
+        message.proxyHostname = "";
         if (value !== undefined)
             reflectionMergePartial<PromptHardwareKeyPINChangeRequest>(this, message, value);
         return message;
@@ -1531,8 +1531,8 @@ class PromptHardwareKeyPINChangeRequest$Type extends MessageType<PromptHardwareK
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* string proxy_host */ 2:
-                    message.proxyHost = reader.string();
+                case /* string proxy_hostname */ 2:
+                    message.proxyHostname = reader.string();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1546,9 +1546,9 @@ class PromptHardwareKeyPINChangeRequest$Type extends MessageType<PromptHardwareK
         return message;
     }
     internalBinaryWrite(message: PromptHardwareKeyPINChangeRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* string proxy_host = 2; */
-        if (message.proxyHost !== "")
-            writer.tag(2, WireType.LengthDelimited).string(message.proxyHost);
+        /* string proxy_hostname = 2; */
+        if (message.proxyHostname !== "")
+            writer.tag(2, WireType.LengthDelimited).string(message.proxyHostname);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -1627,13 +1627,13 @@ class ConfirmHardwareKeySlotOverwriteRequest$Type extends MessageType<ConfirmHar
     constructor() {
         super("teleport.lib.teleterm.v1.ConfirmHardwareKeySlotOverwriteRequest", [
             { no: 2, name: "message", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 3, name: "proxy_host", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+            { no: 3, name: "proxy_hostname", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<ConfirmHardwareKeySlotOverwriteRequest>): ConfirmHardwareKeySlotOverwriteRequest {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.message = "";
-        message.proxyHost = "";
+        message.proxyHostname = "";
         if (value !== undefined)
             reflectionMergePartial<ConfirmHardwareKeySlotOverwriteRequest>(this, message, value);
         return message;
@@ -1646,8 +1646,8 @@ class ConfirmHardwareKeySlotOverwriteRequest$Type extends MessageType<ConfirmHar
                 case /* string message */ 2:
                     message.message = reader.string();
                     break;
-                case /* string proxy_host */ 3:
-                    message.proxyHost = reader.string();
+                case /* string proxy_hostname */ 3:
+                    message.proxyHostname = reader.string();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1664,9 +1664,9 @@ class ConfirmHardwareKeySlotOverwriteRequest$Type extends MessageType<ConfirmHar
         /* string message = 2; */
         if (message.message !== "")
             writer.tag(2, WireType.LengthDelimited).string(message.message);
-        /* string proxy_host = 3; */
-        if (message.proxyHost !== "")
-            writer.tag(3, WireType.LengthDelimited).string(message.proxyHost);
+        /* string proxy_hostname = 3; */
+        if (message.proxyHostname !== "")
+            writer.tag(3, WireType.LengthDelimited).string(message.proxyHostname);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/gen/proto/ts/teleport/lib/teleterm/v1/tshd_events_service_pb.ts
+++ b/gen/proto/ts/teleport/lib/teleterm/v1/tshd_events_service_pb.ts
@@ -332,19 +332,21 @@ export interface PromptMFAResponse {
  */
 export interface PromptHardwareKeyPINRequest {
     /**
-     * @generated from protobuf field: string root_cluster_uri = 1;
-     */
-    rootClusterUri: string;
-    /**
-     * Specifies if a PIN is optional, allowing the user to set it up if left empty.
+     * PinOptional specified if a PIN is optional, allowing the user to set it up if left empty.
      *
      * @generated from protobuf field: bool pin_optional = 2;
      */
     pinOptional: boolean;
     /**
+     * ProxyHost is the proxy hostname of the client key.
+     *
+     * @generated from protobuf field: string proxy_host = 3;
+     */
+    proxyHost: string;
+    /**
      * Command is an optional command string to provide context for the prompt.
      *
-     * @generated from protobuf field: string command = 3;
+     * @generated from protobuf field: string command = 4;
      */
     command: string;
 }
@@ -368,9 +370,11 @@ export interface PromptHardwareKeyPINResponse {
  */
 export interface PromptHardwareKeyTouchRequest {
     /**
-     * @generated from protobuf field: string root_cluster_uri = 1;
+     * ProxyHost is the proxy hostname of the client key.
+     *
+     * @generated from protobuf field: string proxy_host = 2;
      */
-    rootClusterUri: string;
+    proxyHost: string;
     /**
      * Command is an optional command string to provide context for the prompt.
      *
@@ -392,9 +396,11 @@ export interface PromptHardwareKeyTouchResponse {
  */
 export interface PromptHardwareKeyPINChangeRequest {
     /**
-     * @generated from protobuf field: string root_cluster_uri = 1;
+     * ProxyHost is the proxy hostname of the client key.
+     *
+     * @generated from protobuf field: string proxy_host = 2;
      */
-    rootClusterUri: string;
+    proxyHost: string;
 }
 /**
  * Response for PromptHardwareKeyPINChange.
@@ -429,15 +435,17 @@ export interface PromptHardwareKeyPINChangeResponse {
  */
 export interface ConfirmHardwareKeySlotOverwriteRequest {
     /**
-     * @generated from protobuf field: string root_cluster_uri = 1;
-     */
-    rootClusterUri: string;
-    /**
      * Message to display in the prompt.
      *
      * @generated from protobuf field: string message = 2;
      */
     message: string;
+    /**
+     * ProxyHost is the proxy hostname of the client key.
+     *
+     * @generated from protobuf field: string proxy_host = 3;
+     */
+    proxyHost: string;
 }
 /**
  * Response for ConfirmHardwareKeySlotOverwrite.
@@ -1318,15 +1326,15 @@ export const PromptMFAResponse = new PromptMFAResponse$Type();
 class PromptHardwareKeyPINRequest$Type extends MessageType<PromptHardwareKeyPINRequest> {
     constructor() {
         super("teleport.lib.teleterm.v1.PromptHardwareKeyPINRequest", [
-            { no: 1, name: "root_cluster_uri", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 2, name: "pin_optional", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
-            { no: 3, name: "command", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+            { no: 3, name: "proxy_host", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 4, name: "command", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<PromptHardwareKeyPINRequest>): PromptHardwareKeyPINRequest {
         const message = globalThis.Object.create((this.messagePrototype!));
-        message.rootClusterUri = "";
         message.pinOptional = false;
+        message.proxyHost = "";
         message.command = "";
         if (value !== undefined)
             reflectionMergePartial<PromptHardwareKeyPINRequest>(this, message, value);
@@ -1337,13 +1345,13 @@ class PromptHardwareKeyPINRequest$Type extends MessageType<PromptHardwareKeyPINR
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* string root_cluster_uri */ 1:
-                    message.rootClusterUri = reader.string();
-                    break;
                 case /* bool pin_optional */ 2:
                     message.pinOptional = reader.bool();
                     break;
-                case /* string command */ 3:
+                case /* string proxy_host */ 3:
+                    message.proxyHost = reader.string();
+                    break;
+                case /* string command */ 4:
                     message.command = reader.string();
                     break;
                 default:
@@ -1358,15 +1366,15 @@ class PromptHardwareKeyPINRequest$Type extends MessageType<PromptHardwareKeyPINR
         return message;
     }
     internalBinaryWrite(message: PromptHardwareKeyPINRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* string root_cluster_uri = 1; */
-        if (message.rootClusterUri !== "")
-            writer.tag(1, WireType.LengthDelimited).string(message.rootClusterUri);
         /* bool pin_optional = 2; */
         if (message.pinOptional !== false)
             writer.tag(2, WireType.Varint).bool(message.pinOptional);
-        /* string command = 3; */
+        /* string proxy_host = 3; */
+        if (message.proxyHost !== "")
+            writer.tag(3, WireType.LengthDelimited).string(message.proxyHost);
+        /* string command = 4; */
         if (message.command !== "")
-            writer.tag(3, WireType.LengthDelimited).string(message.command);
+            writer.tag(4, WireType.LengthDelimited).string(message.command);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -1428,13 +1436,13 @@ export const PromptHardwareKeyPINResponse = new PromptHardwareKeyPINResponse$Typ
 class PromptHardwareKeyTouchRequest$Type extends MessageType<PromptHardwareKeyTouchRequest> {
     constructor() {
         super("teleport.lib.teleterm.v1.PromptHardwareKeyTouchRequest", [
-            { no: 1, name: "root_cluster_uri", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "proxy_host", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 3, name: "command", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<PromptHardwareKeyTouchRequest>): PromptHardwareKeyTouchRequest {
         const message = globalThis.Object.create((this.messagePrototype!));
-        message.rootClusterUri = "";
+        message.proxyHost = "";
         message.command = "";
         if (value !== undefined)
             reflectionMergePartial<PromptHardwareKeyTouchRequest>(this, message, value);
@@ -1445,8 +1453,8 @@ class PromptHardwareKeyTouchRequest$Type extends MessageType<PromptHardwareKeyTo
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* string root_cluster_uri */ 1:
-                    message.rootClusterUri = reader.string();
+                case /* string proxy_host */ 2:
+                    message.proxyHost = reader.string();
                     break;
                 case /* string command */ 3:
                     message.command = reader.string();
@@ -1463,9 +1471,9 @@ class PromptHardwareKeyTouchRequest$Type extends MessageType<PromptHardwareKeyTo
         return message;
     }
     internalBinaryWrite(message: PromptHardwareKeyTouchRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* string root_cluster_uri = 1; */
-        if (message.rootClusterUri !== "")
-            writer.tag(1, WireType.LengthDelimited).string(message.rootClusterUri);
+        /* string proxy_host = 2; */
+        if (message.proxyHost !== "")
+            writer.tag(2, WireType.LengthDelimited).string(message.proxyHost);
         /* string command = 3; */
         if (message.command !== "")
             writer.tag(3, WireType.LengthDelimited).string(message.command);
@@ -1508,12 +1516,12 @@ export const PromptHardwareKeyTouchResponse = new PromptHardwareKeyTouchResponse
 class PromptHardwareKeyPINChangeRequest$Type extends MessageType<PromptHardwareKeyPINChangeRequest> {
     constructor() {
         super("teleport.lib.teleterm.v1.PromptHardwareKeyPINChangeRequest", [
-            { no: 1, name: "root_cluster_uri", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+            { no: 2, name: "proxy_host", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<PromptHardwareKeyPINChangeRequest>): PromptHardwareKeyPINChangeRequest {
         const message = globalThis.Object.create((this.messagePrototype!));
-        message.rootClusterUri = "";
+        message.proxyHost = "";
         if (value !== undefined)
             reflectionMergePartial<PromptHardwareKeyPINChangeRequest>(this, message, value);
         return message;
@@ -1523,8 +1531,8 @@ class PromptHardwareKeyPINChangeRequest$Type extends MessageType<PromptHardwareK
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* string root_cluster_uri */ 1:
-                    message.rootClusterUri = reader.string();
+                case /* string proxy_host */ 2:
+                    message.proxyHost = reader.string();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1538,9 +1546,9 @@ class PromptHardwareKeyPINChangeRequest$Type extends MessageType<PromptHardwareK
         return message;
     }
     internalBinaryWrite(message: PromptHardwareKeyPINChangeRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* string root_cluster_uri = 1; */
-        if (message.rootClusterUri !== "")
-            writer.tag(1, WireType.LengthDelimited).string(message.rootClusterUri);
+        /* string proxy_host = 2; */
+        if (message.proxyHost !== "")
+            writer.tag(2, WireType.LengthDelimited).string(message.proxyHost);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -1618,14 +1626,14 @@ export const PromptHardwareKeyPINChangeResponse = new PromptHardwareKeyPINChange
 class ConfirmHardwareKeySlotOverwriteRequest$Type extends MessageType<ConfirmHardwareKeySlotOverwriteRequest> {
     constructor() {
         super("teleport.lib.teleterm.v1.ConfirmHardwareKeySlotOverwriteRequest", [
-            { no: 1, name: "root_cluster_uri", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 2, name: "message", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+            { no: 2, name: "message", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "proxy_host", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<ConfirmHardwareKeySlotOverwriteRequest>): ConfirmHardwareKeySlotOverwriteRequest {
         const message = globalThis.Object.create((this.messagePrototype!));
-        message.rootClusterUri = "";
         message.message = "";
+        message.proxyHost = "";
         if (value !== undefined)
             reflectionMergePartial<ConfirmHardwareKeySlotOverwriteRequest>(this, message, value);
         return message;
@@ -1635,11 +1643,11 @@ class ConfirmHardwareKeySlotOverwriteRequest$Type extends MessageType<ConfirmHar
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* string root_cluster_uri */ 1:
-                    message.rootClusterUri = reader.string();
-                    break;
                 case /* string message */ 2:
                     message.message = reader.string();
+                    break;
+                case /* string proxy_host */ 3:
+                    message.proxyHost = reader.string();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1653,12 +1661,12 @@ class ConfirmHardwareKeySlotOverwriteRequest$Type extends MessageType<ConfirmHar
         return message;
     }
     internalBinaryWrite(message: ConfirmHardwareKeySlotOverwriteRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* string root_cluster_uri = 1; */
-        if (message.rootClusterUri !== "")
-            writer.tag(1, WireType.LengthDelimited).string(message.rootClusterUri);
         /* string message = 2; */
         if (message.message !== "")
             writer.tag(2, WireType.LengthDelimited).string(message.message);
+        /* string proxy_host = 3; */
+        if (message.proxyHost !== "")
+            writer.tag(3, WireType.LengthDelimited).string(message.proxyHost);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/gen/proto/ts/teleport/lib/teleterm/v1/tshd_events_service_pb.ts
+++ b/gen/proto/ts/teleport/lib/teleterm/v1/tshd_events_service_pb.ts
@@ -341,6 +341,12 @@ export interface PromptHardwareKeyPINRequest {
      * @generated from protobuf field: bool pin_optional = 2;
      */
     pinOptional: boolean;
+    /**
+     * Command is an optional command string to provide context for the prompt.
+     *
+     * @generated from protobuf field: string command = 3;
+     */
+    command: string;
 }
 /**
  * Response for PromptHardwareKeyPIN.
@@ -365,6 +371,12 @@ export interface PromptHardwareKeyTouchRequest {
      * @generated from protobuf field: string root_cluster_uri = 1;
      */
     rootClusterUri: string;
+    /**
+     * Command is an optional command string to provide context for the prompt.
+     *
+     * @generated from protobuf field: string command = 3;
+     */
+    command: string;
 }
 /**
  * Response for PromptHardwareKeyTouch.
@@ -1307,13 +1319,15 @@ class PromptHardwareKeyPINRequest$Type extends MessageType<PromptHardwareKeyPINR
     constructor() {
         super("teleport.lib.teleterm.v1.PromptHardwareKeyPINRequest", [
             { no: 1, name: "root_cluster_uri", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 2, name: "pin_optional", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
+            { no: 2, name: "pin_optional", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
+            { no: 3, name: "command", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<PromptHardwareKeyPINRequest>): PromptHardwareKeyPINRequest {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.rootClusterUri = "";
         message.pinOptional = false;
+        message.command = "";
         if (value !== undefined)
             reflectionMergePartial<PromptHardwareKeyPINRequest>(this, message, value);
         return message;
@@ -1328,6 +1342,9 @@ class PromptHardwareKeyPINRequest$Type extends MessageType<PromptHardwareKeyPINR
                     break;
                 case /* bool pin_optional */ 2:
                     message.pinOptional = reader.bool();
+                    break;
+                case /* string command */ 3:
+                    message.command = reader.string();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1347,6 +1364,9 @@ class PromptHardwareKeyPINRequest$Type extends MessageType<PromptHardwareKeyPINR
         /* bool pin_optional = 2; */
         if (message.pinOptional !== false)
             writer.tag(2, WireType.Varint).bool(message.pinOptional);
+        /* string command = 3; */
+        if (message.command !== "")
+            writer.tag(3, WireType.LengthDelimited).string(message.command);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -1408,12 +1428,14 @@ export const PromptHardwareKeyPINResponse = new PromptHardwareKeyPINResponse$Typ
 class PromptHardwareKeyTouchRequest$Type extends MessageType<PromptHardwareKeyTouchRequest> {
     constructor() {
         super("teleport.lib.teleterm.v1.PromptHardwareKeyTouchRequest", [
-            { no: 1, name: "root_cluster_uri", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+            { no: 1, name: "root_cluster_uri", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "command", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<PromptHardwareKeyTouchRequest>): PromptHardwareKeyTouchRequest {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.rootClusterUri = "";
+        message.command = "";
         if (value !== undefined)
             reflectionMergePartial<PromptHardwareKeyTouchRequest>(this, message, value);
         return message;
@@ -1425,6 +1447,9 @@ class PromptHardwareKeyTouchRequest$Type extends MessageType<PromptHardwareKeyTo
             switch (fieldNo) {
                 case /* string root_cluster_uri */ 1:
                     message.rootClusterUri = reader.string();
+                    break;
+                case /* string command */ 3:
+                    message.command = reader.string();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1441,6 +1466,9 @@ class PromptHardwareKeyTouchRequest$Type extends MessageType<PromptHardwareKeyTo
         /* string root_cluster_uri = 1; */
         if (message.rootClusterUri !== "")
             writer.tag(1, WireType.LengthDelimited).string(message.rootClusterUri);
+        /* string command = 3; */
+        if (message.command !== "")
+            writer.tag(3, WireType.LengthDelimited).string(message.command);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/lib/teleterm/daemon/hardwarekeyprompt.go
+++ b/lib/teleterm/daemon/hardwarekeyprompt.go
@@ -20,6 +20,7 @@ package daemon
 
 import (
 	"context"
+	"strings"
 
 	"github.com/gravitational/trace"
 
@@ -54,8 +55,14 @@ type hardwareKeyPrompter struct {
 
 // Touch prompts the user to touch the hardware key.
 func (h *hardwareKeyPrompter) Touch(ctx context.Context, keyInfo hardwarekey.ContextualKeyInfo) error {
+	// Don't include "tsh daemon" commands.
+	if strings.Contains(keyInfo.Command, "tsh daemon") {
+		keyInfo.Command = ""
+	}
+
 	_, err := h.s.tshdEventsClient.PromptHardwareKeyTouch(ctx, &api.PromptHardwareKeyTouchRequest{
-		RootClusterUri: keyInfo.ProxyHost,
+		ProxyHost: keyInfo.ProxyHost,
+		Command:   keyInfo.Command,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -65,9 +72,15 @@ func (h *hardwareKeyPrompter) Touch(ctx context.Context, keyInfo hardwarekey.Con
 
 // AskPIN prompts the user for a PIN.
 func (h *hardwareKeyPrompter) AskPIN(ctx context.Context, requirement hardwarekey.PINPromptRequirement, keyInfo hardwarekey.ContextualKeyInfo) (string, error) {
+	// Don't include "tsh daemon" commands.
+	if strings.Contains(keyInfo.Command, "tsh daemon") {
+		keyInfo.Command = ""
+	}
+
 	res, err := h.s.tshdEventsClient.PromptHardwareKeyPIN(ctx, &api.PromptHardwareKeyPINRequest{
-		RootClusterUri: keyInfo.ProxyHost,
-		PinOptional:    requirement == hardwarekey.PINOptional,
+		ProxyHost:   keyInfo.ProxyHost,
+		PinOptional: requirement == hardwarekey.PINOptional,
+		Command:     keyInfo.Command,
 	})
 	if err != nil {
 		return "", trace.Wrap(err)
@@ -80,7 +93,7 @@ func (h *hardwareKeyPrompter) AskPIN(ctx context.Context, requirement hardwareke
 // preventing the user from submitting empty/default values.
 func (h *hardwareKeyPrompter) ChangePIN(ctx context.Context, keyInfo hardwarekey.ContextualKeyInfo) (*hardwarekey.PINAndPUK, error) {
 	res, err := h.s.tshdEventsClient.PromptHardwareKeyPINChange(ctx, &api.PromptHardwareKeyPINChangeRequest{
-		RootClusterUri: keyInfo.ProxyHost,
+		ProxyHost: keyInfo.ProxyHost,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -95,8 +108,8 @@ func (h *hardwareKeyPrompter) ChangePIN(ctx context.Context, keyInfo hardwarekey
 // ConfirmSlotOverwrite asks the user if the slot's private key and certificate can be overridden.
 func (h *hardwareKeyPrompter) ConfirmSlotOverwrite(ctx context.Context, message string, keyInfo hardwarekey.ContextualKeyInfo) (bool, error) {
 	res, err := h.s.tshdEventsClient.ConfirmHardwareKeySlotOverwrite(ctx, &api.ConfirmHardwareKeySlotOverwriteRequest{
-		RootClusterUri: keyInfo.ProxyHost,
-		Message:        message,
+		ProxyHost: keyInfo.ProxyHost,
+		Message:   message,
 	})
 	if err != nil {
 		return false, trace.Wrap(err)

--- a/lib/teleterm/daemon/hardwarekeyprompt.go
+++ b/lib/teleterm/daemon/hardwarekeyprompt.go
@@ -61,8 +61,8 @@ func (h *hardwareKeyPrompter) Touch(ctx context.Context, keyInfo hardwarekey.Con
 	}
 
 	_, err := h.s.tshdEventsClient.PromptHardwareKeyTouch(ctx, &api.PromptHardwareKeyTouchRequest{
-		ProxyHost: keyInfo.ProxyHost,
-		Command:   keyInfo.Command,
+		ProxyHostname: keyInfo.ProxyHost,
+		Command:       keyInfo.Command,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -78,9 +78,9 @@ func (h *hardwareKeyPrompter) AskPIN(ctx context.Context, requirement hardwareke
 	}
 
 	res, err := h.s.tshdEventsClient.PromptHardwareKeyPIN(ctx, &api.PromptHardwareKeyPINRequest{
-		ProxyHost:   keyInfo.ProxyHost,
-		PinOptional: requirement == hardwarekey.PINOptional,
-		Command:     keyInfo.Command,
+		ProxyHostname: keyInfo.ProxyHost,
+		PinOptional:   requirement == hardwarekey.PINOptional,
+		Command:       keyInfo.Command,
 	})
 	if err != nil {
 		return "", trace.Wrap(err)
@@ -93,7 +93,7 @@ func (h *hardwareKeyPrompter) AskPIN(ctx context.Context, requirement hardwareke
 // preventing the user from submitting empty/default values.
 func (h *hardwareKeyPrompter) ChangePIN(ctx context.Context, keyInfo hardwarekey.ContextualKeyInfo) (*hardwarekey.PINAndPUK, error) {
 	res, err := h.s.tshdEventsClient.PromptHardwareKeyPINChange(ctx, &api.PromptHardwareKeyPINChangeRequest{
-		ProxyHost: keyInfo.ProxyHost,
+		ProxyHostname: keyInfo.ProxyHost,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -108,8 +108,8 @@ func (h *hardwareKeyPrompter) ChangePIN(ctx context.Context, keyInfo hardwarekey
 // ConfirmSlotOverwrite asks the user if the slot's private key and certificate can be overridden.
 func (h *hardwareKeyPrompter) ConfirmSlotOverwrite(ctx context.Context, message string, keyInfo hardwarekey.ContextualKeyInfo) (bool, error) {
 	res, err := h.s.tshdEventsClient.ConfirmHardwareKeySlotOverwrite(ctx, &api.ConfirmHardwareKeySlotOverwriteRequest{
-		ProxyHost: keyInfo.ProxyHost,
-		Message:   message,
+		ProxyHostname: keyInfo.ProxyHost,
+		Message:       message,
 	})
 	if err != nil {
 		return false, trace.Wrap(err)

--- a/proto/teleport/lib/teleterm/v1/tshd_events_service.proto
+++ b/proto/teleport/lib/teleterm/v1/tshd_events_service.proto
@@ -211,6 +211,8 @@ message PromptHardwareKeyPINRequest {
   string root_cluster_uri = 1;
   // Specifies if a PIN is optional, allowing the user to set it up if left empty.
   bool pin_optional = 2;
+  // Command is an optional command string to provide context for the prompt.
+  string command = 3;
 }
 
 // Response for PromptHardwareKeyPIN.
@@ -222,6 +224,8 @@ message PromptHardwareKeyPINResponse {
 // Request for PromptHardwareKeyTouchRequest.
 message PromptHardwareKeyTouchRequest {
   string root_cluster_uri = 1;
+  // Command is an optional command string to provide context for the prompt.
+  string command = 3;
 }
 
 // Response for PromptHardwareKeyTouch.

--- a/proto/teleport/lib/teleterm/v1/tshd_events_service.proto
+++ b/proto/teleport/lib/teleterm/v1/tshd_events_service.proto
@@ -208,11 +208,14 @@ message PromptMFAResponse {
 
 // Request for PromptHardwareKeyPIN.
 message PromptHardwareKeyPINRequest {
-  string root_cluster_uri = 1;
-  // Specifies if a PIN is optional, allowing the user to set it up if left empty.
+  reserved 1;
+  reserved "root_cluster_uri";
+  // PinOptional specified if a PIN is optional, allowing the user to set it up if left empty.
   bool pin_optional = 2;
+  // ProxyHost is the proxy hostname of the client key.
+  string proxy_host = 3;
   // Command is an optional command string to provide context for the prompt.
-  string command = 3;
+  string command = 4;
 }
 
 // Response for PromptHardwareKeyPIN.
@@ -223,7 +226,10 @@ message PromptHardwareKeyPINResponse {
 
 // Request for PromptHardwareKeyTouchRequest.
 message PromptHardwareKeyTouchRequest {
-  string root_cluster_uri = 1;
+  reserved 1;
+  reserved "root_cluster_uri";
+  // ProxyHost is the proxy hostname of the client key.
+  string proxy_host = 2;
   // Command is an optional command string to provide context for the prompt.
   string command = 3;
 }
@@ -233,7 +239,10 @@ message PromptHardwareKeyTouchResponse {}
 
 // Response for PromptHardwareKeyPINChange.
 message PromptHardwareKeyPINChangeRequest {
-  string root_cluster_uri = 1;
+  reserved 1;
+  reserved "root_cluster_uri";
+  // ProxyHost is the proxy hostname of the client key.
+  string proxy_host = 2;
 }
 
 // Response for PromptHardwareKeyPINChange.
@@ -249,9 +258,12 @@ message PromptHardwareKeyPINChangeResponse {
 
 // Request for ConfirmHardwareKeySlotOverwrite.
 message ConfirmHardwareKeySlotOverwriteRequest {
-  string root_cluster_uri = 1;
+  reserved 1;
+  reserved "root_cluster_uri";
   // Message to display in the prompt.
   string message = 2;
+  // ProxyHost is the proxy hostname of the client key.
+  string proxy_host = 3;
 }
 
 // Response for ConfirmHardwareKeySlotOverwrite.

--- a/proto/teleport/lib/teleterm/v1/tshd_events_service.proto
+++ b/proto/teleport/lib/teleterm/v1/tshd_events_service.proto
@@ -212,8 +212,8 @@ message PromptHardwareKeyPINRequest {
   reserved "root_cluster_uri";
   // PinOptional specified if a PIN is optional, allowing the user to set it up if left empty.
   bool pin_optional = 2;
-  // ProxyHost is the proxy hostname of the client key.
-  string proxy_host = 3;
+  // ProxyHostname is the proxy hostname of the client key.
+  string proxy_hostname = 3;
   // Command is an optional command string to provide context for the prompt.
   string command = 4;
 }
@@ -228,8 +228,8 @@ message PromptHardwareKeyPINResponse {
 message PromptHardwareKeyTouchRequest {
   reserved 1;
   reserved "root_cluster_uri";
-  // ProxyHost is the proxy hostname of the client key.
-  string proxy_host = 2;
+  // ProxyHostname is the proxy hostname of the client key.
+  string proxy_hostname = 2;
   // Command is an optional command string to provide context for the prompt.
   string command = 3;
 }
@@ -241,8 +241,8 @@ message PromptHardwareKeyTouchResponse {}
 message PromptHardwareKeyPINChangeRequest {
   reserved 1;
   reserved "root_cluster_uri";
-  // ProxyHost is the proxy hostname of the client key.
-  string proxy_host = 2;
+  // ProxyHostname is the proxy hostname of the client key.
+  string proxy_hostname = 2;
 }
 
 // Response for PromptHardwareKeyPINChange.
@@ -262,8 +262,8 @@ message ConfirmHardwareKeySlotOverwriteRequest {
   reserved "root_cluster_uri";
   // Message to display in the prompt.
   string message = 2;
-  // ProxyHost is the proxy hostname of the client key.
-  string proxy_host = 3;
+  // ProxyHostname is the proxy hostname of the client key.
+  string proxy_hostname = 3;
 }
 
 // Response for ConfirmHardwareKeySlotOverwrite.

--- a/tool/tsh/common/daemon.go
+++ b/tool/tsh/common/daemon.go
@@ -51,7 +51,7 @@ func onDaemonStart(cf *CLIConf) error {
 		AgentsDir:          cf.DaemonAgentsDir,
 		InstallationID:     cf.DaemonInstallationID,
 		AddKeysToAgent:     cf.AddKeysToAgent,
-		HardwareKeyAgent:   cf.HardwareKeyAgent,
+		HardwareKeyAgent:   cf.HardwareKeyAgentServer,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -580,7 +580,7 @@ type CLIConf struct {
 	// lookPathOverride overrides return of LookPath(). used in tests.
 	lookPathOverride string
 
-	// HardwareKeyAgentServer determines whether `tsh daemon`` will run the hardware key agent server.
+	// HardwareKeyAgentServer determines whether `tsh daemon` will run the hardware key agent server.
 	HardwareKeyAgentServer bool
 	// disableHardwareKeyAgentClient determines whether the client will attempt to connect
 	// to the hardware key agent. Some commands, like login, are better with the
@@ -1913,6 +1913,8 @@ func onLogin(cf *CLIConf, reExecArgs ...string) error {
 		cf.DesiredRoles = ""
 	}
 
+	// For login operations, we use the hardware key
+	// service directly instead of the agent.
 	cf.disableHardwareKeyAgentClient = true
 
 	if cf.IdentityFileIn != "" {

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -68,6 +68,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/teleport/api/utils/keys/hardwarekey"
+	"github.com/gravitational/teleport/api/utils/keys/piv"
 	"github.com/gravitational/teleport/api/utils/prompt"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
@@ -579,8 +580,12 @@ type CLIConf struct {
 	// lookPathOverride overrides return of LookPath(). used in tests.
 	lookPathOverride string
 
-	// HardwareKeyAgent determines whether the daemon will run the hardware key agent.
-	HardwareKeyAgent bool
+	// HardwareKeyAgentServer determines whether `tsh daemon`` will run the hardware key agent server.
+	HardwareKeyAgentServer bool
+	// disableHardwareKeyAgentClient determines whether the client will attempt to connect
+	// to the hardware key agent. Some commands, like login, are better with the
+	// direct PIV service.
+	disableHardwareKeyAgentClient bool
 }
 
 // Stdout returns the stdout writer.
@@ -862,7 +867,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	daemonStart.Flag("kubeconfigs-dir", "Directory containing kubeconfig for Kubernetes Access").StringVar(&cf.DaemonKubeconfigsDir)
 	daemonStart.Flag("agents-dir", "Directory containing agent config files and data directories for Connect My Computer").StringVar(&cf.DaemonAgentsDir)
 	daemonStart.Flag("installation-id", "Unique ID identifying a specific Teleport Connect installation").StringVar(&cf.DaemonInstallationID)
-	daemonStart.Flag("hardware-key-agent", "Serve the hardware key agent as part of the daemon process").BoolVar(&cf.HardwareKeyAgent)
+	daemonStart.Flag("hardware-key-agent", "Serve the hardware key agent as part of the daemon process").BoolVar(&cf.HardwareKeyAgentServer)
 	daemonStop := daemon.Command("stop", "Gracefully stops a process on Windows by sending Ctrl-Break to it.").Hidden()
 	daemonStop.Flag("pid", "PID to be stopped").IntVar(&cf.DaemonPid)
 
@@ -1907,6 +1912,8 @@ func onLogin(cf *CLIConf, reExecArgs ...string) error {
 		autoRequest = false
 		cf.DesiredRoles = ""
 	}
+
+	cf.disableHardwareKeyAgentClient = true
 
 	if cf.IdentityFileIn != "" {
 		err := flattenIdentity(cf)
@@ -4606,7 +4613,12 @@ func setEnvVariables(c *client.Config, options Options) {
 }
 
 func initClientStore(cf *CLIConf, proxy string) (*client.Store, error) {
-	hwks := libhwk.NewService(cf.Context, nil /*prompt*/)
+	var hwks hardwarekey.Service
+	if cf.disableHardwareKeyAgentClient {
+		hwks = piv.NewYubiKeyService(nil /*prompt*/)
+	} else {
+		hwks = libhwk.NewService(cf.Context, nil /*prompt*/)
+	}
 
 	switch {
 	case cf.IdentityFileIn != "":

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -584,7 +584,7 @@ type CLIConf struct {
 	HardwareKeyAgentServer bool
 	// disableHardwareKeyAgentClient determines whether the client will attempt to connect
 	// to the hardware key agent. Some commands, like login, are better with the
-	// direct PIV service.
+	// direct PIV service so that prompts are not split between processes.
 	disableHardwareKeyAgentClient bool
 }
 

--- a/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.story.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.story.tsx
@@ -34,7 +34,8 @@ export default {
 const hardwareKeyTouchDialog: DialogHardwareKeyTouch = {
   kind: 'hardware-key-touch',
   req: {
-    rootClusterUri: '/clusters/foo',
+    proxyHost: 'foo.example.com',
+    command: '',
   },
   onCancel: () => {},
 };
@@ -42,8 +43,9 @@ const hardwareKeyTouchDialog: DialogHardwareKeyTouch = {
 const hardwareKeyPinDialog: DialogHardwareKeyPin = {
   kind: 'hardware-key-pin',
   req: {
-    rootClusterUri: '/clusters/foo',
+    proxyHost: 'foo.example.com',
     pinOptional: false,
+    command: '',
   },
   onSuccess: () => {},
   onCancel: () => {},

--- a/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.story.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.story.tsx
@@ -34,7 +34,7 @@ export default {
 const hardwareKeyTouchDialog: DialogHardwareKeyTouch = {
   kind: 'hardware-key-touch',
   req: {
-    proxyHost: 'foo.example.com',
+    proxyHostname: 'foo.example.com',
     command: '',
   },
   onCancel: () => {},
@@ -43,7 +43,7 @@ const hardwareKeyTouchDialog: DialogHardwareKeyTouch = {
 const hardwareKeyPinDialog: DialogHardwareKeyPin = {
   kind: 'hardware-key-pin',
   req: {
-    proxyHost: 'foo.example.com',
+    proxyHostname: 'foo.example.com',
     pinOptional: false,
     command: '',
   },

--- a/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.test.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.test.tsx
@@ -43,7 +43,7 @@ const clusterConnectDialog: DialogClusterConnect = {
 const hardwareKeyTouchDialog: DialogHardwareKeyTouch = {
   kind: 'hardware-key-touch',
   req: {
-    proxyHost: 'foo.example.com',
+    proxyHostname: 'foo.example.com',
     command: '',
   },
   onCancel: () => {},

--- a/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.test.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.test.tsx
@@ -43,7 +43,8 @@ const clusterConnectDialog: DialogClusterConnect = {
 const hardwareKeyTouchDialog: DialogHardwareKeyTouch = {
   kind: 'hardware-key-touch',
   req: {
-    rootClusterUri: '/clusters/foo',
+    proxyHost: 'foo.example.com',
+    command: '',
   },
   onCancel: () => {},
 };

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/AskPin.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/AskPin.tsx
@@ -58,7 +58,7 @@ export function AskPin(props: {
           >
             <CommonHeader
               onCancel={props.onCancel}
-              proxyHost={props.req.proxyHost}
+              proxyHostname={props.req.proxyHostname}
             />
 
             <DialogContent mb={4}>

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/AskPin.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/AskPin.tsx
@@ -65,12 +65,12 @@ export function AskPin(props: {
               <Flex flexDirection="column" gap={4} alignItems="flex-start">
                 <P2 color="text.slightlyMuted">
                   Enter your YubiKey PIV PIN to continue
-                  {props.req.command && ' with command:'}
-                  <br />
-                  {
-                    props.req.command &&
-                      props.req.command /**TODO(Joerger): style text */
-                  }
+                  {props.req.command && (
+                    <>
+                      {' with command:'}
+                      <pre>{props.req.command}</pre>
+                    </>
+                  )}
                   <br />
                   {props.req.pinOptional &&
                     'To change the default PIN, leave the field blank.'}

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/AskPin.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/AskPin.tsx
@@ -65,9 +65,13 @@ export function AskPin(props: {
               <Flex flexDirection="column" gap={4} alignItems="flex-start">
                 <P2 color="text.slightlyMuted">
                   Enter your YubiKey PIV PIN to continue
-                  {props.req.command != ''
-                    ? ` with command "${props.req.command}"`
-                    : ''}
+                  {props.req.command && ' with command:'}
+                  <br />
+                  {
+                    props.req.command &&
+                      props.req.command /**TODO(Joerger): style text */
+                  }
+                  <br />
                   {props.req.pinOptional &&
                     'To change the default PIN, leave the field blank.'}
                 </P2>

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/AskPin.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/AskPin.tsx
@@ -58,14 +58,16 @@ export function AskPin(props: {
           >
             <CommonHeader
               onCancel={props.onCancel}
-              rootClusterUri={props.req.rootClusterUri}
+              proxyHost={props.req.proxyHost}
             />
 
             <DialogContent mb={4}>
               <Flex flexDirection="column" gap={4} alignItems="flex-start">
                 <P2 color="text.slightlyMuted">
-                  Enter your YubiKey PIV PIN.
-                  <br />
+                  Enter your YubiKey PIV PIN to continue
+                  {props.req.command != ''
+                    ? ` with command "${props.req.command}"`
+                    : ''}
                   {props.req.pinOptional &&
                     'To change the default PIN, leave the field blank.'}
                 </P2>

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/ChangePin.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/ChangePin.tsx
@@ -77,7 +77,7 @@ export function ChangePin(props: {
             }}
           >
             <CommonHeader
-              rootClusterUri={props.req.rootClusterUri}
+              proxyHost={props.req.proxyHost}
               onCancel={props.onCancel}
             />
 

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/ChangePin.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/ChangePin.tsx
@@ -77,7 +77,7 @@ export function ChangePin(props: {
             }}
           >
             <CommonHeader
-              proxyHost={props.req.proxyHost}
+              proxyHostname={props.req.proxyHostname}
               onCancel={props.onCancel}
             />
 

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/CommonHeader.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/CommonHeader.tsx
@@ -20,18 +20,11 @@ import { ButtonIcon, H2 } from 'design';
 import { DialogHeader } from 'design/Dialog';
 import * as icons from 'design/Icon';
 
-import { RootClusterUri, routing } from 'teleterm/ui/uri';
-
-export function CommonHeader(props: {
-  onCancel(): void;
-  rootClusterUri: RootClusterUri;
-}) {
-  const rootClusterName = routing.parseClusterName(props.rootClusterUri);
-
+export function CommonHeader(props: { onCancel(): void; proxyHost: string }) {
   return (
     <DialogHeader justifyContent="space-between" mb={0} alignItems="baseline">
       <H2 mb={4}>
-        Unlock hardware key to access <strong>{rootClusterName}</strong>
+        Verify your identity on <strong>{props.proxyHost}</strong>
       </H2>
 
       <ButtonIcon

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/CommonHeader.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/CommonHeader.tsx
@@ -20,11 +20,14 @@ import { ButtonIcon, H2 } from 'design';
 import { DialogHeader } from 'design/Dialog';
 import * as icons from 'design/Icon';
 
-export function CommonHeader(props: { onCancel(): void; proxyHost: string }) {
+export function CommonHeader(props: {
+  onCancel(): void;
+  proxyHostname: string;
+}) {
   return (
     <DialogHeader justifyContent="space-between" mb={0} alignItems="baseline">
       <H2 mb={4}>
-        Verify your identity on <strong>{props.proxyHost}</strong>
+        Verify your identity on <strong>{props.proxyHostname}</strong>
       </H2>
 
       <ButtonIcon

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/OverwriteSlot.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/OverwriteSlot.tsx
@@ -49,7 +49,7 @@ export function OverwriteSlot(props: {
       >
         <CommonHeader
           onCancel={props.onCancel}
-          proxyHost={props.req.proxyHost}
+          proxyHostname={props.req.proxyHostname}
         />
 
         <DialogContent mb={4}>

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/OverwriteSlot.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/OverwriteSlot.tsx
@@ -49,7 +49,7 @@ export function OverwriteSlot(props: {
       >
         <CommonHeader
           onCancel={props.onCancel}
-          rootClusterUri={props.req.rootClusterUri}
+          proxyHost={props.req.proxyHost}
         />
 
         <DialogContent mb={4}>

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/Touch.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/Touch.tsx
@@ -54,12 +54,12 @@ export function Touch(props: {
           <Image mb={4} width="200px" src={svgHardwareKey} />
           <P2 bold>
             Touch your YubiKey to continue
-            {props.req.command && ' with command:'}
-            <br />
-            {
-              props.req.command &&
-                props.req.command /**TODO(Joerger): style text */
-            }
+            {props.req.command && (
+              <>
+                {' with command:'}
+                <pre>{props.req.command}</pre>
+              </>
+            )}
           </P2>
           <LinearProgress />
         </Flex>

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/Touch.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/Touch.tsx
@@ -40,7 +40,10 @@ export function Touch(props: {
         width: '100%',
       })}
     >
-      <CommonHeader onCancel={props.onCancel} proxyHost={props.req.proxyHost} />
+      <CommonHeader
+        onCancel={props.onCancel}
+        proxyHostname={props.req.proxyHostname}
+      />
 
       <DialogContent mb={4}>
         <Flex

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/Touch.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/Touch.tsx
@@ -40,10 +40,7 @@ export function Touch(props: {
         width: '100%',
       })}
     >
-      <CommonHeader
-        onCancel={props.onCancel}
-        rootClusterUri={props.req.rootClusterUri}
-      />
+      <CommonHeader onCancel={props.onCancel} proxyHost={props.req.proxyHost} />
 
       <DialogContent mb={4}>
         <Flex
@@ -55,7 +52,12 @@ export function Touch(props: {
           `}
         >
           <Image mb={4} width="200px" src={svgHardwareKey} />
-          <P2 bold>Touch your YubiKey</P2>
+          <P2 bold>
+            Touch your YubiKey to continue
+            {props.req.command != ''
+              ? ` with command "${props.req.command}"`
+              : ''}
+          </P2>
           <LinearProgress />
         </Flex>
       </DialogContent>

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/Touch.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/Touch.tsx
@@ -54,9 +54,12 @@ export function Touch(props: {
           <Image mb={4} width="200px" src={svgHardwareKey} />
           <P2 bold>
             Touch your YubiKey to continue
-            {props.req.command != ''
-              ? ` with command "${props.req.command}"`
-              : ''}
+            {props.req.command && ' with command:'}
+            <br />
+            {
+              props.req.command &&
+                props.req.command /**TODO(Joerger): style text */
+            }
           </P2>
           <LinearProgress />
         </Flex>

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/index.story.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/index.story.tsx
@@ -37,8 +37,9 @@ export function AskPinOptional() {
       onSuccess={() => {}}
       onCancel={() => {}}
       req={{
-        rootClusterUri: rootCluster.uri,
+        proxyHost: rootCluster.proxyHost,
         pinOptional: true,
+        command: '',
       }}
     />
   );
@@ -50,8 +51,9 @@ export function AskPinRequired() {
       onSuccess={() => {}}
       onCancel={() => {}}
       req={{
-        rootClusterUri: rootCluster.uri,
+        proxyHost: rootCluster.proxyHost,
         pinOptional: false,
+        command: '',
       }}
     />
   );
@@ -62,7 +64,8 @@ export function Touch() {
     <TouchComponent
       onCancel={() => {}}
       req={{
-        rootClusterUri: rootCluster.uri,
+        proxyHost: rootCluster.proxyHost,
+        command: '',
       }}
     />
   );
@@ -73,7 +76,9 @@ export function ChangePin() {
     <ChangePinComponent
       onSuccess={() => {}}
       onCancel={() => {}}
-      req={{ rootClusterUri: rootCluster.uri }}
+      req={{
+        proxyHost: rootCluster.proxyHost,
+      }}
     />
   );
 }
@@ -84,7 +89,7 @@ export function OverwriteSlot() {
       onConfirm={() => {}}
       onCancel={() => {}}
       req={{
-        rootClusterUri: rootCluster.uri,
+        proxyHost: rootCluster.proxyHost,
         message:
           "Would you like to overwrite this slot's private key and certificate?",
       }}

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/index.story.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/HardwareKeys/index.story.tsx
@@ -37,7 +37,7 @@ export function AskPinOptional() {
       onSuccess={() => {}}
       onCancel={() => {}}
       req={{
-        proxyHost: rootCluster.proxyHost,
+        proxyHostname: rootCluster.proxyHost,
         pinOptional: true,
         command: '',
       }}
@@ -51,7 +51,7 @@ export function AskPinRequired() {
       onSuccess={() => {}}
       onCancel={() => {}}
       req={{
-        proxyHost: rootCluster.proxyHost,
+        proxyHostname: rootCluster.proxyHost,
         pinOptional: false,
         command: '',
       }}
@@ -64,7 +64,7 @@ export function Touch() {
     <TouchComponent
       onCancel={() => {}}
       req={{
-        proxyHost: rootCluster.proxyHost,
+        proxyHostname: rootCluster.proxyHost,
         command: '',
       }}
     />
@@ -77,7 +77,7 @@ export function ChangePin() {
       onSuccess={() => {}}
       onCancel={() => {}}
       req={{
-        proxyHost: rootCluster.proxyHost,
+        proxyHostname: rootCluster.proxyHost,
       }}
     />
   );
@@ -89,7 +89,7 @@ export function OverwriteSlot() {
       onConfirm={() => {}}
       onCancel={() => {}}
       req={{
-        proxyHost: rootCluster.proxyHost,
+        proxyHostname: rootCluster.proxyHost,
         message:
           "Would you like to overwrite this slot's private key and certificate?",
       }}


### PR DESCRIPTION
Part of [RFD 199](https://github.com/gravitational/teleport/pull/52495)

Includes the [client command](https://github.com/gravitational/teleport/blob/master/rfd/0199-hardware-key-agent.md#hardware-key-prompts) in hardware key agent server prompts to provide context.

Also fixes the proxy host context in Teleport Connect hardware key prompts, which actually regressed in https://github.com/gravitational/teleport/pull/53703 due to the proxy host being parsed by `routing.parseClusterName` into `""` on the front end.

![Screenshot 2025-04-16 at 2 15 09 PM](https://github.com/user-attachments/assets/b1626053-8b95-43f7-a5ee-4cd7c1663ab1)
![Screenshot 2025-04-16 at 2 15 23 PM](https://github.com/user-attachments/assets/8e925c18-8a68-493d-b1dc-4180db917bf0)

https://github.com/gravitational/teleport/pull/54026