### PR TITLE
Web: create status info panel component

### DIFF
--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -643,6 +643,19 @@ export function useUnifiedResourcesFetch<T>(props: {
   });
 }
 
+export function useResourceServersFetch<T>(props: {
+  fetchFunc(
+    paginationParams: { limit: number; startKey: string },
+    signal: AbortSignal
+  ): Promise<ResourcesResponse<T>>;
+}) {
+  return useKeyBasedPagination({
+    fetchFunc: props.fetchFunc,
+    initialFetchSize: 20,
+    fetchMoreSize: 10,
+  });
+}
+
 function getResourcePinningSupport(
   pinning: UnifiedResourcesPinning['kind'],
   updatePinnedResourcesAttempt: AsyncAttempt<void>

--- a/web/packages/shared/components/UnifiedResources/shared/StatusInfo.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/shared/StatusInfo.story.tsx
@@ -24,8 +24,8 @@ import { resourceStatusPanelWidth } from 'shared/components/SlidingSidePanel/Inf
 import { Attempt } from 'shared/hooks/useAttemptNext';
 
 import {
+  DatabaseServer,
   ResourceStatus,
-  SharedDatabaseServer,
   SharedResourceServer,
   UnifiedResourceDefinition,
 } from '../types';
@@ -132,7 +132,7 @@ const loremTxt =
   quas reiciendis fugiat molestias delectus perspiciatis vero \
   similique minima mollitia accusantium eligendi impedit.';
 
-const fewDbServers: SharedDatabaseServer[] = [
+const fewDbServers: DatabaseServer[] = [
   {
     kind: 'db_server',
     hostId: 'host-id-1',
@@ -155,7 +155,7 @@ const fewDbServers: SharedDatabaseServer[] = [
   },
 ];
 
-const manyDbServers: SharedDatabaseServer[] = [
+const manyDbServers: DatabaseServer[] = [
   ...fewDbServers,
   ...fewDbServers,
   ...fewDbServers,

--- a/web/packages/shared/components/UnifiedResources/shared/StatusInfo.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/shared/StatusInfo.story.tsx
@@ -1,0 +1,164 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Meta } from '@storybook/react';
+
+import { SlidingSidePanel } from 'shared/components/SlidingSidePanel';
+import { InfoGuideContainer } from 'shared/components/SlidingSidePanel/InfoGuide';
+import { resourceStatusPanelWidth } from 'shared/components/SlidingSidePanel/InfoGuide/const';
+import { Attempt } from 'shared/hooks/useAttemptNext';
+
+import {
+  ResourceStatus,
+  SharedDatabaseServer,
+  SharedResourceServer,
+  UnifiedResourceDefinition,
+} from '../types';
+import {
+  UnhealthyStatusInfo as Component,
+  StatusInfoHeader,
+} from './StatusInfo';
+
+type StoryProps = {
+  attemptState: 'success' | 'processing' | 'failed' | '';
+  resourceKind: 'db';
+  healthStatus: ResourceStatus | 'empty';
+  serverLength: 'few' | 'none' | 'many' | 'single';
+};
+
+const meta: Meta<StoryProps> = {
+  title: 'Shared/UnifiedResources/UnhealthyStatusInfo',
+  component: UnhealthyStatusInfo,
+  argTypes: {
+    attemptState: {
+      control: { type: 'select' },
+      options: ['success', 'processing', 'failed', ''],
+    },
+    resourceKind: {
+      control: { type: 'select' },
+      options: ['db'],
+    },
+    healthStatus: {
+      control: { type: 'select' },
+      options: ['unhealthy', 'unknown', 'empty'],
+    },
+    serverLength: {
+      control: { type: 'select' },
+      options: ['few', 'none', 'many', 'single'],
+    },
+  },
+  // default
+  args: {
+    attemptState: 'success',
+    resourceKind: 'db',
+    healthStatus: 'unhealthy',
+    serverLength: 'few',
+  },
+};
+export default meta;
+
+export function UnhealthyStatusInfo(props: StoryProps) {
+  let attempt: Attempt = { status: props.attemptState };
+  if (props.attemptState === 'failed') {
+    attempt = { status: 'failed', statusText: 'some kind of error' };
+  }
+
+  let resource: UnifiedResourceDefinition;
+  let servers: SharedResourceServer[] = [];
+  if (props.resourceKind === 'db') {
+    resource = {
+      kind: 'db',
+      type: 'postgres',
+      description: 'some database description',
+      name: 'testing-database-resource-long-title-name',
+      protocol: 'postgres',
+      labels: [],
+      targetHealth: {
+        status: props.healthStatus === 'empty' ? '' : props.healthStatus,
+      },
+    };
+    if (props.serverLength === 'many') {
+      servers = manyDbServers;
+    }
+    if (props.serverLength === 'few') {
+      servers = fewDbServers;
+    }
+    if (props.serverLength === 'single') {
+      servers = [fewDbServers[0]];
+    }
+  }
+
+  return (
+    <SlidingSidePanel
+      panelWidth={resourceStatusPanelWidth}
+      isVisible={true}
+      slideFrom="right"
+      zIndex={1}
+      skipAnimation={false}
+    >
+      <InfoGuideContainer
+        onClose={() => null}
+        title={<StatusInfoHeader resource={resource} />}
+      >
+        <Component
+          attempt={attempt}
+          resource={resource}
+          fetch={() => null}
+          servers={servers}
+        />
+      </InfoGuideContainer>
+    </SlidingSidePanel>
+  );
+}
+
+const loremTxt =
+  'Lorem ipsum dolor sit amet consectetur adipisicing elit. \
+  Hic facere accusamus vel dolorum sunt, magni incidunt rem \
+  quas reiciendis fugiat molestias delectus perspiciatis vero \
+  similique minima mollitia accusantium eligendi impedit.';
+
+const fewDbServers: SharedDatabaseServer[] = [
+  {
+    kind: 'db_server',
+    hostId: 'host-id-1',
+    hostname: 'hostname-1',
+    targetHealth: { status: 'unhealthy', reason: 'reason 1' },
+  },
+  {
+    kind: 'db_server',
+    hostId: 'host-id-2',
+    hostname: 'hostname-2',
+    targetHealth: { status: 'unhealthy', reason: 'reason 2' },
+  },
+  {
+    kind: 'db_server',
+    hostId:
+      'host-id-long-george-washington-cherry-blossom-apple-banana-orange-chocolate-meow',
+    hostname:
+      'hostname-long-really-long-like-really-long-longer-pumpkin-pie-halloween',
+    targetHealth: { status: 'unknown', reason: loremTxt },
+  },
+];
+
+const manyDbServers: SharedDatabaseServer[] = [
+  ...fewDbServers,
+  ...fewDbServers,
+  ...fewDbServers,
+  ...fewDbServers,
+  ...fewDbServers,
+];

--- a/web/packages/shared/components/UnifiedResources/shared/StatusInfo.tsx
+++ b/web/packages/shared/components/UnifiedResources/shared/StatusInfo.tsx
@@ -1,0 +1,282 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { css } from 'styled-components';
+
+import { Box, ButtonBorder, Indicator, Mark, Text } from 'design';
+import { Alert } from 'design/Alert';
+import Flex from 'design/Flex';
+import {
+  BookOpenText,
+  Database as DatabaseIcon,
+  Warning as WarningIcon,
+} from 'design/Icon';
+import { ResourceIcon } from 'design/ResourceIcon';
+import { H2, H3 } from 'design/Text';
+import {
+  InfoParagraph,
+  InfoTitle,
+} from 'shared/components/SlidingSidePanel/InfoGuide';
+import { useInfiniteScroll } from 'shared/hooks';
+import { Attempt } from 'shared/hooks/useAttemptNext';
+import { pluralize } from 'shared/utils/text';
+
+import { SharedResourceServer, UnifiedResourceDefinition } from '../types';
+import { SingleLineBox } from './SingleLineBox';
+import { getDatabaseIconName } from './viewItemsFactory';
+
+export function UnhealthyStatusInfo({
+  resource,
+  fetch,
+  attempt,
+  servers = [],
+}: {
+  resource: UnifiedResourceDefinition;
+  fetch(options?: { force?: boolean }): Promise<void>;
+  attempt: Attempt;
+  servers: SharedResourceServer[];
+}) {
+  const { setTrigger } = useInfiniteScroll({
+    fetch: fetch,
+  });
+
+  function retryAttempt() {
+    fetch({ force: true });
+  }
+
+  const unhealthyOrUnknownServers = servers.filter(
+    s => !s.targetHealth || s.targetHealth?.status !== 'healthy'
+  );
+
+  return (
+    <>
+      <Box>
+        <ConnectionHeader resource={resource} />
+        <InfoParagraph>
+          <StatusDescription
+            resource={resource}
+            numUnhealthyServers={unhealthyOrUnknownServers.length}
+          />
+        </InfoParagraph>
+        <InfoParagraph mb={4}>
+          <ButtonBorder
+            as="a"
+            size="large"
+            gap={2}
+            intent="primary"
+            target="_blank"
+            href={getTroubleShootingLink(resource)}
+          >
+            <BookOpenText /> Troubleshooting Guide
+          </ButtonBorder>
+        </InfoParagraph>
+
+        <InfoTitle mt={6}>
+          Affected Teleport {getAffectedResourceKind(resource)}:
+        </InfoTitle>
+        {attempt.status === 'failed' && (
+          <Alert
+            kind="danger"
+            primaryAction={{ content: 'Retry', onClick: retryAttempt }}
+          >
+            <Flex alignItems="center">
+              <Text>{attempt.statusText}</Text>
+            </Flex>
+          </Alert>
+        )}
+        <InfoParagraph>
+          {attempt.status === 'success' && !servers?.length && (
+            <Text bold>No Results</Text>
+          )}
+          {attempt.status === 'success' && servers?.length > 0 && (
+            <Box
+              css={`
+                position: relative;
+                // negative margin to remove the padding we set
+                // for the root container, b/c we want the list
+                // to render flushed against the sides of box.
+                margin-left: -${p => p.theme.space[3]}px;
+                margin-right: -${p => p.theme.space[3]}px;
+              `}
+            >
+              <UnhealthyServerList servers={unhealthyOrUnknownServers} />
+            </Box>
+          )}
+          {attempt.status === 'processing' && (
+            <Flex justifyContent="center">
+              <Indicator />
+            </Flex>
+          )}
+        </InfoParagraph>
+      </Box>
+      <div ref={setTrigger} />
+    </>
+  );
+}
+
+export function StatusInfoHeader({
+  resource,
+}: {
+  resource: UnifiedResourceDefinition;
+}) {
+  if (resource.kind === 'db') {
+    const icon = getDatabaseIconName(resource.protocol);
+    return (
+      <Flex gap={3}>
+        <ResourceIcon name={icon} width="45px" height="45px" />
+        <Box>
+          <SingleLineBox width="300px">
+            <H2>{resource.name}</H2>
+          </SingleLineBox>
+          {resource.type && (
+            <Flex gap={1}>
+              <DatabaseIcon size={18} />
+              <SingleLineBox width="270px">
+                <Text
+                  typography="body3"
+                  color="text.slightlyMuted"
+                  title={resource.type}
+                >
+                  {resource.type}
+                </Text>
+              </SingleLineBox>
+            </Flex>
+          )}
+        </Box>
+      </Flex>
+    );
+  }
+}
+
+function ConnectionHeader({
+  resource,
+}: {
+  resource: UnifiedResourceDefinition;
+}) {
+  if (resource.kind === 'db') {
+    return (
+      <Flex gap={2} my={3}>
+        <WarningIcon size={16} />
+        <H3>DB Connection Issue</H3>
+      </Flex>
+    );
+  }
+}
+
+function StatusDescription({
+  resource,
+  numUnhealthyServers,
+}: {
+  resource: UnifiedResourceDefinition;
+  numUnhealthyServers: number;
+}) {
+  if (resource.kind === 'db') {
+    const health = resource.targetHealth;
+    const startingWord = numUnhealthyServers > 1 ? 'Some' : 'A';
+    const servicedWord = numUnhealthyServers
+      ? pluralize(numUnhealthyServers, 'service')
+      : 'service';
+    switch (health.status) {
+      case 'unhealthy':
+        return (
+          <>
+            {startingWord} Teleport database {servicedWord} proxying access to
+            this database cannot reach the database endpoint.
+          </>
+        );
+      case 'unknown':
+        return (
+          <>
+            {startingWord} Teleport database {servicedWord} proxying access to
+            this database {numUnhealthyServers > 1 ? 'are' : 'is'} not running
+            network health checks for the database endpoint. User connections
+            will not be routed through affected Teleport database services as
+            long as other database services report a healthy connection to the
+            database.
+          </>
+        );
+      default: // empty
+        return (
+          <>
+            {startingWord} Teleport database {servicedWord} proxying access to
+            this database requires upgrading to Teleport version{' '}
+            <Mark>18.0.0</Mark> to run network health checks.
+          </>
+        );
+    }
+  }
+}
+
+function getTroubleShootingLink(resource: UnifiedResourceDefinition) {
+  if (resource.kind == 'db') {
+    return 'https://goteleport.com/docs/enroll-resources/database-access/getting-started/#troubleshooting';
+  }
+}
+
+function getAffectedResourceKind(resource: UnifiedResourceDefinition) {
+  switch (resource.kind) {
+    case 'db':
+      return 'database services';
+  }
+}
+
+function UnhealthyServerList({ servers }: { servers: SharedResourceServer[] }) {
+  const lastServerInList = servers.length - 1;
+  return servers.map((server, index) => (
+    <Box
+      key={`${server.kind}/${server.hostId}`}
+      css={`
+        background-color: ${p => p.theme.colors.levels.sunken};
+        padding: ${p => p.theme.space[3]}px;
+        border-left: 4px solid
+          ${p => p.theme.colors.interactive.solid.alert.default};
+        ${index !== lastServerInList &&
+        css`
+          border-bottom: 1px solid ${p => p.theme.colors.spotBackground[1]};
+        `}
+      `}
+    >
+      <Text>
+        <b>Hostname:</b> {server.hostname}
+      </Text>
+      <Text>
+        <b>UUID:</b> {server.hostId}
+      </Text>
+      <Text>
+        <b>Reason:</b> {server.targetHealth?.reason}
+      </Text>
+    </Box>
+  ));
+}
+
+/**
+ * Returns a unique id by appending the resource kind with
+ * their name/id (for most resources their id is the "name" field,
+ * other resources does not have name field, but an "id" field).
+ */
+export function getResourceId(resource: UnifiedResourceDefinition) {
+  const kind = resource.kind;
+  let id;
+  if (kind === 'node' || kind === 'git_server') {
+    id = resource.id;
+  } else {
+    id = resource.name;
+  }
+
+  return `${kind}/${id}`;
+}

--- a/web/packages/shared/components/UnifiedResources/shared/StatusInfo.tsx
+++ b/web/packages/shared/components/UnifiedResources/shared/StatusInfo.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { css } from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { Box, ButtonBorder, Indicator, Mark, Text } from 'design';
 import { Alert } from 'design/Alert';
@@ -238,7 +238,9 @@ function getAffectedResourceKind(resource: UnifiedResourceDefinition) {
 function UnhealthyServerList({ servers }: { servers: SharedResourceServer[] }) {
   const lastServerInList = servers.length - 1;
   return servers.map((server, index) => (
-    <Box
+    <Flex
+      gap={2}
+      flexDirection="column"
       key={`${server.kind}/${server.hostId}`}
       css={`
         background-color: ${p => p.theme.colors.levels.sunken};
@@ -252,15 +254,15 @@ function UnhealthyServerList({ servers }: { servers: SharedResourceServer[] }) {
       `}
     >
       <Text>
-        <b>Hostname:</b> {server.hostname}
+        <InfoField>Hostname:</InfoField> {server.hostname}
       </Text>
       <Text>
-        <b>UUID:</b> {server.hostId}
+        <InfoField>UUID:</InfoField> {server.hostId}
       </Text>
       <Text>
-        <b>Reason:</b> {server.targetHealth?.reason}
+        <InfoField>Reason:</InfoField> {server.targetHealth?.reason}
       </Text>
-    </Box>
+    </Flex>
   ));
 }
 
@@ -280,3 +282,7 @@ export function getResourceId(resource: UnifiedResourceDefinition) {
 
   return `${kind}/${id}`;
 }
+
+const InfoField = styled.span`
+  font-weight: bold;
+`;

--- a/web/packages/shared/components/UnifiedResources/shared/StatusInfo.tsx
+++ b/web/packages/shared/components/UnifiedResources/shared/StatusInfo.tsx
@@ -60,7 +60,7 @@ export function UnhealthyStatusInfo({
   }
 
   const unhealthyOrUnknownServers = servers.filter(
-    s => !s.targetHealth || s.targetHealth?.status !== 'healthy'
+    s => s.targetHealth?.status !== 'healthy'
   );
 
   return (
@@ -140,12 +140,10 @@ export function StatusInfoHeader({
       <Flex gap={3}>
         <ResourceIcon name={icon} width="45px" height="45px" />
         <Box>
-          <SingleLineBox width="300px">
-            <H2>{resource.name}</H2>
-          </SingleLineBox>
+          <H2>{resource.name}</H2>
           {resource.type && (
             <Flex gap={1}>
-              <DatabaseIcon size={18} />
+              <DatabaseIcon size="small" color="text.slightlyMuted" />
               <SingleLineBox width="270px">
                 <Text
                   typography="body3"
@@ -264,23 +262,6 @@ function UnhealthyServerList({ servers }: { servers: SharedResourceServer[] }) {
       </Text>
     </Flex>
   ));
-}
-
-/**
- * Returns a unique id by appending the resource kind with
- * their name/id (for most resources their id is the "name" field,
- * other resources does not have name field, but an "id" field).
- */
-export function getResourceId(resource: UnifiedResourceDefinition) {
-  const kind = resource.kind;
-  let id;
-  if (kind === 'node' || kind === 'git_server') {
-    id = resource.id;
-  } else {
-    id = resource.name;
-  }
-
-  return `${kind}/${id}`;
 }
 
 const InfoField = styled.span`

--- a/web/packages/shared/components/UnifiedResources/types.ts
+++ b/web/packages/shared/components/UnifiedResources/types.ts
@@ -238,11 +238,16 @@ export type ResourceViewProps = {
   expandAllLabels: boolean;
 };
 
-export type SharedDatabaseServer = {
+/**
+ * DatabaseServer (db_server) describes a database heartbeat signal
+ * reported from an agent (db_service) that is proxying
+ * the database.
+ */
+export type DatabaseServer = {
   kind: 'db_server';
   hostname: string;
   hostId: string;
   targetHealth?: ResourceTargetHealth;
 };
 
-export type SharedResourceServer = SharedDatabaseServer;
+export type SharedResourceServer = DatabaseServer;

--- a/web/packages/shared/components/UnifiedResources/types.ts
+++ b/web/packages/shared/components/UnifiedResources/types.ts
@@ -237,3 +237,12 @@ export type ResourceViewProps = {
   }[];
   expandAllLabels: boolean;
 };
+
+export type SharedDatabaseServer = {
+  kind: 'db_server';
+  hostname: string;
+  hostId: string;
+  targetHealth?: ResourceTargetHealth;
+};
+
+export type SharedResourceServer = SharedDatabaseServer;

--- a/web/packages/teleport/src/UnifiedResources/StatusInfo.tsx
+++ b/web/packages/teleport/src/UnifiedResources/StatusInfo.tsx
@@ -1,0 +1,79 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  SharedDatabaseServer,
+  SharedResourceServer,
+  UnifiedResourceDefinition,
+  useResourceServersFetch,
+} from 'shared/components/UnifiedResources';
+import { UnhealthyStatusInfo } from 'shared/components/UnifiedResources/shared/StatusInfo';
+
+import { ResourcesResponse } from 'teleport/services/agents';
+import { fetchDatabaseServers } from 'teleport/services/databases/databases';
+
+export function StatusInfo({
+  resource,
+  clusterId,
+}: {
+  /**
+   * the resource the user selected to look into the status of
+   */
+  resource: UnifiedResourceDefinition;
+  clusterId: string;
+}) {
+  const {
+    fetch: fetchResourceServers,
+    resources: resourceServers,
+    attempt: fetchResourceServersAttempt,
+  } = useResourceServersFetch({
+    fetchFunc: async (params, signal) => {
+      let response: ResourcesResponse<SharedResourceServer>;
+
+      if (resource.kind === 'db') {
+        const resp = await fetchDatabaseServers({
+          clusterId,
+          params: {
+            ...params,
+            query: `name == "${resource.name}"`,
+          },
+          signal,
+        });
+        const servers: SharedDatabaseServer[] = resp.agents.map(d => ({
+          kind: 'db_server',
+          ...d,
+        }));
+        response = {
+          agents: servers,
+          startKey: resp.startKey,
+        };
+      }
+
+      return response;
+    },
+  });
+
+  return (
+    <UnhealthyStatusInfo
+      resource={resource}
+      fetch={fetchResourceServers}
+      servers={resourceServers}
+      attempt={fetchResourceServersAttempt}
+    />
+  );
+}

--- a/web/packages/teleport/src/UnifiedResources/StatusInfo.tsx
+++ b/web/packages/teleport/src/UnifiedResources/StatusInfo.tsx
@@ -17,7 +17,7 @@
  */
 
 import {
-  SharedDatabaseServer,
+  DatabaseServer,
   SharedResourceServer,
   UnifiedResourceDefinition,
   useResourceServersFetch,
@@ -54,7 +54,7 @@ export function StatusInfo({
           },
           signal,
         });
-        const servers: SharedDatabaseServer[] = resp.agents.map(d => ({
+        const servers: DatabaseServer[] = resp.agents.map(d => ({
           kind: 'db_server',
           ...d,
         }));

--- a/web/packages/teleport/src/services/databases/databases.ts
+++ b/web/packages/teleport/src/services/databases/databases.ts
@@ -30,7 +30,7 @@ import type {
   CreateDatabaseRequest,
   Database,
   DatabaseIamPolicyResponse,
-  DatabaseServerResponse,
+  DatabaseServer,
   DatabaseServicesResponse,
   UpdateDatabaseRequest,
 } from './types';
@@ -104,7 +104,7 @@ export function fetchDatabaseServers({
   clusterId: string;
   params: UrlResourcesParams;
   signal?: AbortSignal;
-}): Promise<DatabaseServerResponse | void> {
+}): Promise<ResourcesResponse<DatabaseServer>> {
   return (
     api
       .get(cfg.getDatabaseServerUrl(clusterId, params), signal)
@@ -112,7 +112,7 @@ export function fetchDatabaseServers({
         const items = json?.items || [];
 
         return {
-          items: items.map(makeDatabaseServer),
+          agents: items.map(makeDatabaseServer),
           startKey: json?.startKey,
         };
       })

--- a/web/packages/teleport/src/services/databases/types.ts
+++ b/web/packages/teleport/src/services/databases/types.ts
@@ -110,8 +110,3 @@ export type DatabaseServer = {
   hostId: string;
   targetHealth?: ResourceTargetHealth;
 };
-
-export type DatabaseServerResponse = {
-  items: DatabaseServer[];
-  startKey?: string;
-};

--- a/web/packages/teleport/src/services/version/unsupported.ts
+++ b/web/packages/teleport/src/services/version/unsupported.ts
@@ -65,7 +65,7 @@ export function isPathNotFoundError(err: unknown) {
 export function withGenericUnsupportedError(
   err: unknown,
   supportedVersion: string
-) {
+): never {
   if (err instanceof ApiError && err.response.status === 404) {
     if (err.proxyVersion) {
       throw new Error(


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/20544

This feature doesn't currently work as the backend required field is not defined yet, but I wrote a story with all the possible controls.

story:
https://localhost:9002/?path=/story/shared-unifiedresources-unhealthystatusinfo--unhealthy-status-info