### PR TITLE
[web] [accesslists] Surface caller's ownership and membership status from `GetAccessList`

### DIFF
--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist.pb.go
@@ -267,6 +267,60 @@ func (IneligibleStatus) EnumDescriptor() ([]byte, []int) {
 	return file_teleport_accesslist_v1_accesslist_proto_rawDescGZIP(), []int{3}
 }
 
+// AccessListUserAssignmentType describes the type of membership anr/or ownership
+// a user has in an access list.
+type AccessListUserAssignmentType int32
+
+const (
+	// ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED means the user is not an explicit nor an inherited member or owner
+	AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED AccessListUserAssignmentType = 0
+	// ACCESS_LIST_USER_ASSIGNMENT_TYPE_EXPLICIT means the user has explicit membership or ownership
+	AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_EXPLICIT AccessListUserAssignmentType = 1
+	// ACCESS_LIST_USER_ASSIGNMENT_TYPE_INHERITED means the user has inherited membership or ownership
+	AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_INHERITED AccessListUserAssignmentType = 2
+)
+
+// Enum value maps for AccessListUserAssignmentType.
+var (
+	AccessListUserAssignmentType_name = map[int32]string{
+		0: "ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED",
+		1: "ACCESS_LIST_USER_ASSIGNMENT_TYPE_EXPLICIT",
+		2: "ACCESS_LIST_USER_ASSIGNMENT_TYPE_INHERITED",
+	}
+	AccessListUserAssignmentType_value = map[string]int32{
+		"ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED": 0,
+		"ACCESS_LIST_USER_ASSIGNMENT_TYPE_EXPLICIT":    1,
+		"ACCESS_LIST_USER_ASSIGNMENT_TYPE_INHERITED":   2,
+	}
+)
+
+func (x AccessListUserAssignmentType) Enum() *AccessListUserAssignmentType {
+	p := new(AccessListUserAssignmentType)
+	*p = x
+	return p
+}
+
+func (x AccessListUserAssignmentType) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (AccessListUserAssignmentType) Descriptor() protoreflect.EnumDescriptor {
+	return file_teleport_accesslist_v1_accesslist_proto_enumTypes[4].Descriptor()
+}
+
+func (AccessListUserAssignmentType) Type() protoreflect.EnumType {
+	return &file_teleport_accesslist_v1_accesslist_proto_enumTypes[4]
+}
+
+func (x AccessListUserAssignmentType) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use AccessListUserAssignmentType.Descriptor instead.
+func (AccessListUserAssignmentType) EnumDescriptor() ([]byte, []int) {
+	return file_teleport_accesslist_v1_accesslist_proto_rawDescGZIP(), []int{4}
+}
+
 // AccessList describes the basic building block of access grants, which are
 // similar to access requests but for longer lived permissions that need to be
 // regularly audited.
@@ -1189,6 +1243,61 @@ func (x *ReviewChanges) GetReviewDayOfMonthChanged() ReviewDayOfMonth {
 	return ReviewDayOfMonth_REVIEW_DAY_OF_MONTH_UNSPECIFIED
 }
 
+// CurrentUserAssignments describes the current user's ownership and membership status in the access list.
+type CurrentUserAssignments struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// ownership_type represents the current user's ownership type (explicit, inherited, or none) in the access list.
+	OwnershipType AccessListUserAssignmentType `protobuf:"varint,1,opt,name=ownership_type,json=ownershipType,proto3,enum=teleport.accesslist.v1.AccessListUserAssignmentType" json:"ownership_type,omitempty"`
+	// membership_type represents the current user's membership type (explicit, inherited, or none) in the access list.
+	MembershipType AccessListUserAssignmentType `protobuf:"varint,2,opt,name=membership_type,json=membershipType,proto3,enum=teleport.accesslist.v1.AccessListUserAssignmentType" json:"membership_type,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *CurrentUserAssignments) Reset() {
+	*x = CurrentUserAssignments{}
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CurrentUserAssignments) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CurrentUserAssignments) ProtoMessage() {}
+
+func (x *CurrentUserAssignments) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CurrentUserAssignments.ProtoReflect.Descriptor instead.
+func (*CurrentUserAssignments) Descriptor() ([]byte, []int) {
+	return file_teleport_accesslist_v1_accesslist_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *CurrentUserAssignments) GetOwnershipType() AccessListUserAssignmentType {
+	if x != nil {
+		return x.OwnershipType
+	}
+	return AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED
+}
+
+func (x *CurrentUserAssignments) GetMembershipType() AccessListUserAssignmentType {
+	if x != nil {
+		return x.MembershipType
+	}
+	return AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED
+}
+
 // AccessListStatus contains dynamic fields calculated during retrieval.
 type AccessListStatus struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1199,14 +1308,16 @@ type AccessListStatus struct {
 	// owner_of describes Access Lists where this Access List is an explicit owner.
 	OwnerOf []string `protobuf:"bytes,3,rep,name=owner_of,json=ownerOf,proto3" json:"owner_of,omitempty"`
 	// member_of describes Access Lists where this Access List is an explicit member.
-	MemberOf      []string `protobuf:"bytes,4,rep,name=member_of,json=memberOf,proto3" json:"member_of,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	MemberOf []string `protobuf:"bytes,4,rep,name=member_of,json=memberOf,proto3" json:"member_of,omitempty"`
+	// current_user_assignments describes the current user's ownership and membership status in the access list.
+	CurrentUserAssignments *CurrentUserAssignments `protobuf:"bytes,5,opt,name=current_user_assignments,json=currentUserAssignments,proto3" json:"current_user_assignments,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *AccessListStatus) Reset() {
 	*x = AccessListStatus{}
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[13]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1218,7 +1329,7 @@ func (x *AccessListStatus) String() string {
 func (*AccessListStatus) ProtoMessage() {}
 
 func (x *AccessListStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[13]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1231,7 +1342,7 @@ func (x *AccessListStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccessListStatus.ProtoReflect.Descriptor instead.
 func (*AccessListStatus) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_proto_rawDescGZIP(), []int{13}
+	return file_teleport_accesslist_v1_accesslist_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *AccessListStatus) GetMemberCount() uint32 {
@@ -1258,6 +1369,13 @@ func (x *AccessListStatus) GetOwnerOf() []string {
 func (x *AccessListStatus) GetMemberOf() []string {
 	if x != nil {
 		return x.MemberOf
+	}
+	return nil
+}
+
+func (x *AccessListStatus) GetCurrentUserAssignments() *CurrentUserAssignments {
+	if x != nil {
+		return x.CurrentUserAssignments
 	}
 	return nil
 }
@@ -1339,12 +1457,16 @@ const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\x1fmembership_requirements_changed\x18\x02 \x01(\v2*.teleport.accesslist.v1.AccessListRequiresR\x1dmembershipRequirementsChanged\x12'\n" +
 	"\x0fremoved_members\x18\x03 \x03(\tR\x0eremovedMembers\x12a\n" +
 	"\x18review_frequency_changed\x18\x04 \x01(\x0e2'.teleport.accesslist.v1.ReviewFrequencyR\x16reviewFrequencyChanged\x12f\n" +
-	"\x1breview_day_of_month_changed\x18\x05 \x01(\x0e2(.teleport.accesslist.v1.ReviewDayOfMonthR\x17reviewDayOfMonthChangedJ\x04\b\x01\x10\x02R\x11frequency_changed\"\xca\x01\n" +
+	"\x1breview_day_of_month_changed\x18\x05 \x01(\x0e2(.teleport.accesslist.v1.ReviewDayOfMonthR\x17reviewDayOfMonthChangedJ\x04\b\x01\x10\x02R\x11frequency_changed\"\xd4\x01\n" +
+	"\x16CurrentUserAssignments\x12[\n" +
+	"\x0eownership_type\x18\x01 \x01(\x0e24.teleport.accesslist.v1.AccessListUserAssignmentTypeR\rownershipType\x12]\n" +
+	"\x0fmembership_type\x18\x02 \x01(\x0e24.teleport.accesslist.v1.AccessListUserAssignmentTypeR\x0emembershipType\"\xb4\x02\n" +
 	"\x10AccessListStatus\x12&\n" +
 	"\fmember_count\x18\x01 \x01(\rH\x00R\vmemberCount\x88\x01\x01\x12/\n" +
 	"\x11member_list_count\x18\x02 \x01(\rH\x01R\x0fmemberListCount\x88\x01\x01\x12\x19\n" +
 	"\bowner_of\x18\x03 \x03(\tR\aownerOf\x12\x1b\n" +
-	"\tmember_of\x18\x04 \x03(\tR\bmemberOfB\x0f\n" +
+	"\tmember_of\x18\x04 \x03(\tR\bmemberOf\x12h\n" +
+	"\x18current_user_assignments\x18\x05 \x01(\v2..teleport.accesslist.v1.CurrentUserAssignmentsR\x16currentUserAssignmentsB\x0f\n" +
 	"\r_member_countB\x14\n" +
 	"\x12_member_list_count*\xb6\x01\n" +
 	"\x0fReviewFrequency\x12 \n" +
@@ -1367,7 +1489,11 @@ const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\x1aINELIGIBLE_STATUS_ELIGIBLE\x10\x01\x12$\n" +
 	" INELIGIBLE_STATUS_USER_NOT_EXIST\x10\x02\x12*\n" +
 	"&INELIGIBLE_STATUS_MISSING_REQUIREMENTS\x10\x03\x12\x1d\n" +
-	"\x19INELIGIBLE_STATUS_EXPIRED\x10\x04BXZVgithub.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1;accesslistv1b\x06proto3"
+	"\x19INELIGIBLE_STATUS_EXPIRED\x10\x04*\xaf\x01\n" +
+	"\x1cAccessListUserAssignmentType\x120\n" +
+	",ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED\x10\x00\x12-\n" +
+	")ACCESS_LIST_USER_ASSIGNMENT_TYPE_EXPLICIT\x10\x01\x12.\n" +
+	"*ACCESS_LIST_USER_ASSIGNMENT_TYPE_INHERITED\x10\x02BXZVgithub.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1;accesslistv1b\x06proto3"
 
 var (
 	file_teleport_accesslist_v1_accesslist_proto_rawDescOnce sync.Once
@@ -1381,70 +1507,75 @@ func file_teleport_accesslist_v1_accesslist_proto_rawDescGZIP() []byte {
 	return file_teleport_accesslist_v1_accesslist_proto_rawDescData
 }
 
-var file_teleport_accesslist_v1_accesslist_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_teleport_accesslist_v1_accesslist_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
+var file_teleport_accesslist_v1_accesslist_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
+var file_teleport_accesslist_v1_accesslist_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_teleport_accesslist_v1_accesslist_proto_goTypes = []any{
-	(ReviewFrequency)(0),          // 0: teleport.accesslist.v1.ReviewFrequency
-	(ReviewDayOfMonth)(0),         // 1: teleport.accesslist.v1.ReviewDayOfMonth
-	(MembershipKind)(0),           // 2: teleport.accesslist.v1.MembershipKind
-	(IneligibleStatus)(0),         // 3: teleport.accesslist.v1.IneligibleStatus
-	(*AccessList)(nil),            // 4: teleport.accesslist.v1.AccessList
-	(*AccessListSpec)(nil),        // 5: teleport.accesslist.v1.AccessListSpec
-	(*AccessListOwner)(nil),       // 6: teleport.accesslist.v1.AccessListOwner
-	(*AccessListAudit)(nil),       // 7: teleport.accesslist.v1.AccessListAudit
-	(*Recurrence)(nil),            // 8: teleport.accesslist.v1.Recurrence
-	(*Notifications)(nil),         // 9: teleport.accesslist.v1.Notifications
-	(*AccessListRequires)(nil),    // 10: teleport.accesslist.v1.AccessListRequires
-	(*AccessListGrants)(nil),      // 11: teleport.accesslist.v1.AccessListGrants
-	(*Member)(nil),                // 12: teleport.accesslist.v1.Member
-	(*MemberSpec)(nil),            // 13: teleport.accesslist.v1.MemberSpec
-	(*Review)(nil),                // 14: teleport.accesslist.v1.Review
-	(*ReviewSpec)(nil),            // 15: teleport.accesslist.v1.ReviewSpec
-	(*ReviewChanges)(nil),         // 16: teleport.accesslist.v1.ReviewChanges
-	(*AccessListStatus)(nil),      // 17: teleport.accesslist.v1.AccessListStatus
-	(*v1.ResourceHeader)(nil),     // 18: teleport.header.v1.ResourceHeader
-	(*timestamppb.Timestamp)(nil), // 19: google.protobuf.Timestamp
-	(*durationpb.Duration)(nil),   // 20: google.protobuf.Duration
-	(*v11.Trait)(nil),             // 21: teleport.trait.v1.Trait
+	(ReviewFrequency)(0),              // 0: teleport.accesslist.v1.ReviewFrequency
+	(ReviewDayOfMonth)(0),             // 1: teleport.accesslist.v1.ReviewDayOfMonth
+	(MembershipKind)(0),               // 2: teleport.accesslist.v1.MembershipKind
+	(IneligibleStatus)(0),             // 3: teleport.accesslist.v1.IneligibleStatus
+	(AccessListUserAssignmentType)(0), // 4: teleport.accesslist.v1.AccessListUserAssignmentType
+	(*AccessList)(nil),                // 5: teleport.accesslist.v1.AccessList
+	(*AccessListSpec)(nil),            // 6: teleport.accesslist.v1.AccessListSpec
+	(*AccessListOwner)(nil),           // 7: teleport.accesslist.v1.AccessListOwner
+	(*AccessListAudit)(nil),           // 8: teleport.accesslist.v1.AccessListAudit
+	(*Recurrence)(nil),                // 9: teleport.accesslist.v1.Recurrence
+	(*Notifications)(nil),             // 10: teleport.accesslist.v1.Notifications
+	(*AccessListRequires)(nil),        // 11: teleport.accesslist.v1.AccessListRequires
+	(*AccessListGrants)(nil),          // 12: teleport.accesslist.v1.AccessListGrants
+	(*Member)(nil),                    // 13: teleport.accesslist.v1.Member
+	(*MemberSpec)(nil),                // 14: teleport.accesslist.v1.MemberSpec
+	(*Review)(nil),                    // 15: teleport.accesslist.v1.Review
+	(*ReviewSpec)(nil),                // 16: teleport.accesslist.v1.ReviewSpec
+	(*ReviewChanges)(nil),             // 17: teleport.accesslist.v1.ReviewChanges
+	(*CurrentUserAssignments)(nil),    // 18: teleport.accesslist.v1.CurrentUserAssignments
+	(*AccessListStatus)(nil),          // 19: teleport.accesslist.v1.AccessListStatus
+	(*v1.ResourceHeader)(nil),         // 20: teleport.header.v1.ResourceHeader
+	(*timestamppb.Timestamp)(nil),     // 21: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),       // 22: google.protobuf.Duration
+	(*v11.Trait)(nil),                 // 23: teleport.trait.v1.Trait
 }
 var file_teleport_accesslist_v1_accesslist_proto_depIdxs = []int32{
-	18, // 0: teleport.accesslist.v1.AccessList.header:type_name -> teleport.header.v1.ResourceHeader
-	5,  // 1: teleport.accesslist.v1.AccessList.spec:type_name -> teleport.accesslist.v1.AccessListSpec
-	17, // 2: teleport.accesslist.v1.AccessList.status:type_name -> teleport.accesslist.v1.AccessListStatus
-	6,  // 3: teleport.accesslist.v1.AccessListSpec.owners:type_name -> teleport.accesslist.v1.AccessListOwner
-	7,  // 4: teleport.accesslist.v1.AccessListSpec.audit:type_name -> teleport.accesslist.v1.AccessListAudit
-	10, // 5: teleport.accesslist.v1.AccessListSpec.membership_requires:type_name -> teleport.accesslist.v1.AccessListRequires
-	10, // 6: teleport.accesslist.v1.AccessListSpec.ownership_requires:type_name -> teleport.accesslist.v1.AccessListRequires
-	11, // 7: teleport.accesslist.v1.AccessListSpec.grants:type_name -> teleport.accesslist.v1.AccessListGrants
-	11, // 8: teleport.accesslist.v1.AccessListSpec.owner_grants:type_name -> teleport.accesslist.v1.AccessListGrants
+	20, // 0: teleport.accesslist.v1.AccessList.header:type_name -> teleport.header.v1.ResourceHeader
+	6,  // 1: teleport.accesslist.v1.AccessList.spec:type_name -> teleport.accesslist.v1.AccessListSpec
+	19, // 2: teleport.accesslist.v1.AccessList.status:type_name -> teleport.accesslist.v1.AccessListStatus
+	7,  // 3: teleport.accesslist.v1.AccessListSpec.owners:type_name -> teleport.accesslist.v1.AccessListOwner
+	8,  // 4: teleport.accesslist.v1.AccessListSpec.audit:type_name -> teleport.accesslist.v1.AccessListAudit
+	11, // 5: teleport.accesslist.v1.AccessListSpec.membership_requires:type_name -> teleport.accesslist.v1.AccessListRequires
+	11, // 6: teleport.accesslist.v1.AccessListSpec.ownership_requires:type_name -> teleport.accesslist.v1.AccessListRequires
+	12, // 7: teleport.accesslist.v1.AccessListSpec.grants:type_name -> teleport.accesslist.v1.AccessListGrants
+	12, // 8: teleport.accesslist.v1.AccessListSpec.owner_grants:type_name -> teleport.accesslist.v1.AccessListGrants
 	3,  // 9: teleport.accesslist.v1.AccessListOwner.ineligible_status:type_name -> teleport.accesslist.v1.IneligibleStatus
 	2,  // 10: teleport.accesslist.v1.AccessListOwner.membership_kind:type_name -> teleport.accesslist.v1.MembershipKind
-	19, // 11: teleport.accesslist.v1.AccessListAudit.next_audit_date:type_name -> google.protobuf.Timestamp
-	8,  // 12: teleport.accesslist.v1.AccessListAudit.recurrence:type_name -> teleport.accesslist.v1.Recurrence
-	9,  // 13: teleport.accesslist.v1.AccessListAudit.notifications:type_name -> teleport.accesslist.v1.Notifications
+	21, // 11: teleport.accesslist.v1.AccessListAudit.next_audit_date:type_name -> google.protobuf.Timestamp
+	9,  // 12: teleport.accesslist.v1.AccessListAudit.recurrence:type_name -> teleport.accesslist.v1.Recurrence
+	10, // 13: teleport.accesslist.v1.AccessListAudit.notifications:type_name -> teleport.accesslist.v1.Notifications
 	0,  // 14: teleport.accesslist.v1.Recurrence.frequency:type_name -> teleport.accesslist.v1.ReviewFrequency
 	1,  // 15: teleport.accesslist.v1.Recurrence.day_of_month:type_name -> teleport.accesslist.v1.ReviewDayOfMonth
-	20, // 16: teleport.accesslist.v1.Notifications.start:type_name -> google.protobuf.Duration
-	21, // 17: teleport.accesslist.v1.AccessListRequires.traits:type_name -> teleport.trait.v1.Trait
-	21, // 18: teleport.accesslist.v1.AccessListGrants.traits:type_name -> teleport.trait.v1.Trait
-	18, // 19: teleport.accesslist.v1.Member.header:type_name -> teleport.header.v1.ResourceHeader
-	13, // 20: teleport.accesslist.v1.Member.spec:type_name -> teleport.accesslist.v1.MemberSpec
-	19, // 21: teleport.accesslist.v1.MemberSpec.joined:type_name -> google.protobuf.Timestamp
-	19, // 22: teleport.accesslist.v1.MemberSpec.expires:type_name -> google.protobuf.Timestamp
+	22, // 16: teleport.accesslist.v1.Notifications.start:type_name -> google.protobuf.Duration
+	23, // 17: teleport.accesslist.v1.AccessListRequires.traits:type_name -> teleport.trait.v1.Trait
+	23, // 18: teleport.accesslist.v1.AccessListGrants.traits:type_name -> teleport.trait.v1.Trait
+	20, // 19: teleport.accesslist.v1.Member.header:type_name -> teleport.header.v1.ResourceHeader
+	14, // 20: teleport.accesslist.v1.Member.spec:type_name -> teleport.accesslist.v1.MemberSpec
+	21, // 21: teleport.accesslist.v1.MemberSpec.joined:type_name -> google.protobuf.Timestamp
+	21, // 22: teleport.accesslist.v1.MemberSpec.expires:type_name -> google.protobuf.Timestamp
 	3,  // 23: teleport.accesslist.v1.MemberSpec.ineligible_status:type_name -> teleport.accesslist.v1.IneligibleStatus
 	2,  // 24: teleport.accesslist.v1.MemberSpec.membership_kind:type_name -> teleport.accesslist.v1.MembershipKind
-	18, // 25: teleport.accesslist.v1.Review.header:type_name -> teleport.header.v1.ResourceHeader
-	15, // 26: teleport.accesslist.v1.Review.spec:type_name -> teleport.accesslist.v1.ReviewSpec
-	19, // 27: teleport.accesslist.v1.ReviewSpec.review_date:type_name -> google.protobuf.Timestamp
-	16, // 28: teleport.accesslist.v1.ReviewSpec.changes:type_name -> teleport.accesslist.v1.ReviewChanges
-	10, // 29: teleport.accesslist.v1.ReviewChanges.membership_requirements_changed:type_name -> teleport.accesslist.v1.AccessListRequires
+	20, // 25: teleport.accesslist.v1.Review.header:type_name -> teleport.header.v1.ResourceHeader
+	16, // 26: teleport.accesslist.v1.Review.spec:type_name -> teleport.accesslist.v1.ReviewSpec
+	21, // 27: teleport.accesslist.v1.ReviewSpec.review_date:type_name -> google.protobuf.Timestamp
+	17, // 28: teleport.accesslist.v1.ReviewSpec.changes:type_name -> teleport.accesslist.v1.ReviewChanges
+	11, // 29: teleport.accesslist.v1.ReviewChanges.membership_requirements_changed:type_name -> teleport.accesslist.v1.AccessListRequires
 	0,  // 30: teleport.accesslist.v1.ReviewChanges.review_frequency_changed:type_name -> teleport.accesslist.v1.ReviewFrequency
 	1,  // 31: teleport.accesslist.v1.ReviewChanges.review_day_of_month_changed:type_name -> teleport.accesslist.v1.ReviewDayOfMonth
-	32, // [32:32] is the sub-list for method output_type
-	32, // [32:32] is the sub-list for method input_type
-	32, // [32:32] is the sub-list for extension type_name
-	32, // [32:32] is the sub-list for extension extendee
-	0,  // [0:32] is the sub-list for field type_name
+	4,  // 32: teleport.accesslist.v1.CurrentUserAssignments.ownership_type:type_name -> teleport.accesslist.v1.AccessListUserAssignmentType
+	4,  // 33: teleport.accesslist.v1.CurrentUserAssignments.membership_type:type_name -> teleport.accesslist.v1.AccessListUserAssignmentType
+	18, // 34: teleport.accesslist.v1.AccessListStatus.current_user_assignments:type_name -> teleport.accesslist.v1.CurrentUserAssignments
+	35, // [35:35] is the sub-list for method output_type
+	35, // [35:35] is the sub-list for method input_type
+	35, // [35:35] is the sub-list for extension type_name
+	35, // [35:35] is the sub-list for extension extendee
+	0,  // [0:35] is the sub-list for field type_name
 }
 
 func init() { file_teleport_accesslist_v1_accesslist_proto_init() }
@@ -1452,14 +1583,14 @@ func file_teleport_accesslist_v1_accesslist_proto_init() {
 	if File_teleport_accesslist_v1_accesslist_proto != nil {
 		return
 	}
-	file_teleport_accesslist_v1_accesslist_proto_msgTypes[13].OneofWrappers = []any{}
+	file_teleport_accesslist_v1_accesslist_proto_msgTypes[14].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_accesslist_v1_accesslist_proto_rawDesc), len(file_teleport_accesslist_v1_accesslist_proto_rawDesc)),
-			NumEnums:      4,
-			NumMessages:   14,
+			NumEnums:      5,
+			NumMessages:   15,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/accesslist/v1/accesslist.proto
+++ b/api/proto/teleport/accesslist/v1/accesslist.proto
@@ -285,6 +285,25 @@ message ReviewChanges {
   ReviewDayOfMonth review_day_of_month_changed = 5;
 }
 
+// AccessListUserAssignmentType describes the type of membership anr/or ownership
+// a user has in an access list.
+enum AccessListUserAssignmentType {
+  // ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED means the user is not an explicit nor an inherited member or owner
+  ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED = 0;
+  // ACCESS_LIST_USER_ASSIGNMENT_TYPE_EXPLICIT means the user has explicit membership or ownership
+  ACCESS_LIST_USER_ASSIGNMENT_TYPE_EXPLICIT = 1;
+  // ACCESS_LIST_USER_ASSIGNMENT_TYPE_INHERITED means the user has inherited membership or ownership
+  ACCESS_LIST_USER_ASSIGNMENT_TYPE_INHERITED = 2;
+}
+
+// CurrentUserAssignments describes the current user's ownership and membership status in the access list.
+message CurrentUserAssignments {
+  // ownership_type represents the current user's ownership type (explicit, inherited, or none) in the access list.
+  AccessListUserAssignmentType ownership_type = 1;
+  // membership_type represents the current user's membership type (explicit, inherited, or none) in the access list.
+  AccessListUserAssignmentType membership_type = 2;
+}
+
 // AccessListStatus contains dynamic fields calculated during retrieval.
 message AccessListStatus {
   // member_count is the number of members in the Access List.
@@ -295,4 +314,6 @@ message AccessListStatus {
   repeated string owner_of = 3;
   // member_of describes Access Lists where this Access List is an explicit member.
   repeated string member_of = 4;
+  // current_user_assignments describes the current user's ownership and membership status in the access list.
+  CurrentUserAssignments current_user_assignments = 5;
 }

--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -251,6 +251,27 @@ type Status struct {
 	OwnerOf []string `json:"owner_of" yaml:"owner_of"`
 	// MemberOf is a list of Access List UUIDs where this access list is an explicit member.
 	MemberOf []string `json:"member_of" yaml:"member_of"`
+
+	// CurrentUserAssignments describes the current user's ownership and membership in the access list.
+	CurrentUserAssignments *CurrentUserAssignments `json:"-" yaml:"-"`
+}
+
+// CurrentUserAssignments describes the current user's ownership and membership status in the access list.
+type CurrentUserAssignments struct {
+	// OwnershipType represents the current user's ownership type (explicit, inherited, or none) in the access list.
+	OwnershipType accesslistv1.AccessListUserAssignmentType `json:"ownership_type" yaml:"ownership_type"`
+	// MembershipType represents the current user's membership type (explicit, inherited, or none) in the access list.
+	MembershipType accesslistv1.AccessListUserAssignmentType `json:"membership_type" yaml:"membership_type"`
+}
+
+// IsMember returns true if the MembershipType is either explicit or inherited.
+func (c *CurrentUserAssignments) IsMember() bool {
+	return c.MembershipType != accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED
+}
+
+// IsOwner returns true if the OwnershipType is either explicit or inherited.
+func (c *CurrentUserAssignments) IsOwner() bool {
+	return c.OwnershipType != accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED
 }
 
 // NewAccessList will create a new access list.
@@ -371,6 +392,11 @@ func (a *AccessList) GetOwnerGrants() Grants {
 // and should be removed when possible.
 func (a *AccessList) GetMetadata() types.Metadata {
 	return legacy.FromHeaderMetadata(a.Metadata)
+}
+
+// GetStatus returns the status of the access list.
+func (a *AccessList) GetStatus() Status {
+	return a.Status
 }
 
 // MatchSearch goes through select field values of a resource

--- a/api/types/accesslist/convert/v1/accesslist.go
+++ b/api/types/accesslist/convert/v1/accesslist.go
@@ -90,26 +90,6 @@ func FromProto(msg *accesslistv1.AccessList, opts ...AccessListOption) (*accessl
 		nextAuditDate = msg.Spec.Audit.NextAuditDate.AsTime()
 	}
 
-	var memberCount *uint32
-	var memberListCount *uint32
-	if msg.Status != nil && msg.Status.MemberCount != nil {
-		memberCount = new(uint32)
-		*memberCount = *msg.Status.MemberCount
-	}
-	if msg.Status != nil && msg.Status.MemberListCount != nil {
-		memberListCount = new(uint32)
-		*memberListCount = *msg.Status.MemberListCount
-	}
-
-	var ownerOf []string
-	var memberOf []string
-	if msg.Status != nil && msg.Status.OwnerOf != nil {
-		ownerOf = msg.Status.OwnerOf
-	}
-	if msg.Status != nil && msg.Status.MemberOf != nil {
-		memberOf = msg.Status.MemberOf
-	}
-
 	accessList, err := accesslist.NewAccessList(headerv1.FromMetadataProto(msg.Header.Metadata), accesslist.Spec{
 		Title:       msg.Spec.Title,
 		Description: msg.Spec.Description,
@@ -136,11 +116,9 @@ func FromProto(msg *accesslistv1.AccessList, opts ...AccessListOption) (*accessl
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	accessList.Status = accesslist.Status{
-		MemberCount:     memberCount,
-		MemberListCount: memberListCount,
-		OwnerOf:         ownerOf,
-		MemberOf:        memberOf,
+
+	if status := fromStatusProto(msg); status != nil {
+		accessList.Status = *status
 	}
 
 	for _, opt := range opts {
@@ -178,27 +156,7 @@ func ToProto(accessList *accesslist.AccessList) *accesslistv1.AccessList {
 		nextAuditDate = timestamppb.New(accessList.Spec.Audit.NextAuditDate)
 	}
 
-	var memberCount *uint32
-	var memberListCount *uint32
-	if accessList.Status.MemberCount != nil {
-		memberCount = new(uint32)
-		*memberCount = *accessList.Status.MemberCount
-	}
-	if accessList.Status.MemberListCount != nil {
-		memberListCount = new(uint32)
-		*memberListCount = *accessList.Status.MemberListCount
-	}
-
-	var ownerOf []string
-	var memberOf []string
-	if accessList.Status.OwnerOf != nil {
-		ownerOf = accessList.Status.OwnerOf
-	}
-	if accessList.Status.MemberOf != nil {
-		memberOf = accessList.Status.MemberOf
-	}
-
-	return &accesslistv1.AccessList{
+	proto := &accesslistv1.AccessList{
 		Header: headerv1.ToResourceHeaderProto(accessList.ResourceHeader),
 		Spec: &accesslistv1.AccessListSpec{
 			Title:       accessList.Spec.Title,
@@ -228,13 +186,10 @@ func ToProto(accessList *accesslist.AccessList) *accesslistv1.AccessList {
 			},
 			OwnerGrants: ownerGrants,
 		},
-		Status: &accesslistv1.AccessListStatus{
-			MemberCount:     memberCount,
-			MemberListCount: memberListCount,
-			OwnerOf:         ownerOf,
-			MemberOf:        memberOf,
-		},
+		Status: toStatusProto(&accessList.Status),
 	}
+
+	return proto
 }
 
 // ToOwnerProto converts an internal access list owner into a v1 access list owner object.
@@ -290,5 +245,81 @@ func WithOwnersIneligibleStatusField(protoOwners []*accesslistv1.AccessListOwner
 			updatedOwners[i] = owner
 		}
 		a.SetOwners(updatedOwners)
+	}
+}
+
+func toStatusProto(status *accesslist.Status) *accesslistv1.AccessListStatus {
+	if status == nil {
+		return nil
+	}
+
+	protoStatus := &accesslistv1.AccessListStatus{}
+
+	if status.MemberCount != nil {
+		protoStatus.MemberCount = new(uint32)
+		*protoStatus.MemberCount = *status.MemberCount
+	}
+	if status.MemberListCount != nil {
+		protoStatus.MemberListCount = new(uint32)
+		*protoStatus.MemberListCount = *status.MemberListCount
+	}
+
+	if status.OwnerOf != nil {
+		protoStatus.OwnerOf = status.OwnerOf
+	}
+	if status.MemberOf != nil {
+		protoStatus.MemberOf = status.MemberOf
+	}
+
+	protoStatus.CurrentUserAssignments = toCurrentUserAssignmentsProto(status.CurrentUserAssignments)
+
+	return protoStatus
+}
+
+func fromStatusProto(msg *accesslistv1.AccessList) *accesslist.Status {
+	if msg.Status == nil {
+		return nil
+	}
+
+	status := &accesslist.Status{}
+
+	if msg.Status.MemberCount != nil {
+		status.MemberCount = new(uint32)
+		*status.MemberCount = *msg.Status.MemberCount
+	}
+	if msg.Status.MemberListCount != nil {
+		status.MemberListCount = new(uint32)
+		*status.MemberListCount = *msg.Status.MemberListCount
+	}
+
+	if msg.Status.OwnerOf != nil {
+		status.OwnerOf = msg.Status.OwnerOf
+	}
+	if msg.Status.MemberOf != nil {
+		status.MemberOf = msg.Status.MemberOf
+	}
+
+	status.CurrentUserAssignments = fromCurrentUserAssignmentsProto(msg.Status.CurrentUserAssignments)
+
+	return status
+}
+
+func toCurrentUserAssignmentsProto(assignments *accesslist.CurrentUserAssignments) *accesslistv1.CurrentUserAssignments {
+	if assignments == nil {
+		return nil
+	}
+	return &accesslistv1.CurrentUserAssignments{
+		OwnershipType:  assignments.OwnershipType,
+		MembershipType: assignments.MembershipType,
+	}
+}
+
+func fromCurrentUserAssignmentsProto(assignments *accesslistv1.CurrentUserAssignments) *accesslist.CurrentUserAssignments {
+	if assignments == nil {
+		return nil
+	}
+	return &accesslist.CurrentUserAssignments{
+		OwnershipType:  assignments.OwnershipType,
+		MembershipType: assignments.MembershipType,
 	}
 }

--- a/gen/proto/ts/teleport/accesslist/v1/accesslist_pb.ts
+++ b/gen/proto/ts/teleport/accesslist/v1/accesslist_pb.ts
@@ -426,6 +426,25 @@ export interface ReviewChanges {
     reviewDayOfMonthChanged: ReviewDayOfMonth;
 }
 /**
+ * CurrentUserAssignments describes the current user's ownership and membership status in the access list.
+ *
+ * @generated from protobuf message teleport.accesslist.v1.CurrentUserAssignments
+ */
+export interface CurrentUserAssignments {
+    /**
+     * ownership_type represents the current user's ownership type (explicit, inherited, or none) in the access list.
+     *
+     * @generated from protobuf field: teleport.accesslist.v1.AccessListUserAssignmentType ownership_type = 1;
+     */
+    ownershipType: AccessListUserAssignmentType;
+    /**
+     * membership_type represents the current user's membership type (explicit, inherited, or none) in the access list.
+     *
+     * @generated from protobuf field: teleport.accesslist.v1.AccessListUserAssignmentType membership_type = 2;
+     */
+    membershipType: AccessListUserAssignmentType;
+}
+/**
  * AccessListStatus contains dynamic fields calculated during retrieval.
  *
  * @generated from protobuf message teleport.accesslist.v1.AccessListStatus
@@ -455,6 +474,12 @@ export interface AccessListStatus {
      * @generated from protobuf field: repeated string member_of = 4;
      */
     memberOf: string[];
+    /**
+     * current_user_assignments describes the current user's ownership and membership status in the access list.
+     *
+     * @generated from protobuf field: teleport.accesslist.v1.CurrentUserAssignments current_user_assignments = 5;
+     */
+    currentUserAssignments?: CurrentUserAssignments;
 }
 /**
  * ReviewFrequency is the frequency of reviews.
@@ -572,6 +597,32 @@ export enum IneligibleStatus {
      * @generated from protobuf enum value: INELIGIBLE_STATUS_EXPIRED = 4;
      */
     EXPIRED = 4
+}
+/**
+ * AccessListUserAssignmentType describes the type of membership anr/or ownership
+ * a user has in an access list.
+ *
+ * @generated from protobuf enum teleport.accesslist.v1.AccessListUserAssignmentType
+ */
+export enum AccessListUserAssignmentType {
+    /**
+     * ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED means the user is not an explicit nor an inherited member or owner
+     *
+     * @generated from protobuf enum value: ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED = 0;
+     */
+    UNSPECIFIED = 0,
+    /**
+     * ACCESS_LIST_USER_ASSIGNMENT_TYPE_EXPLICIT means the user has explicit membership or ownership
+     *
+     * @generated from protobuf enum value: ACCESS_LIST_USER_ASSIGNMENT_TYPE_EXPLICIT = 1;
+     */
+    EXPLICIT = 1,
+    /**
+     * ACCESS_LIST_USER_ASSIGNMENT_TYPE_INHERITED means the user has inherited membership or ownership
+     *
+     * @generated from protobuf enum value: ACCESS_LIST_USER_ASSIGNMENT_TYPE_INHERITED = 2;
+     */
+    INHERITED = 2
 }
 // @generated message type with reflection information, may provide speed optimized methods
 class AccessList$Type extends MessageType<AccessList> {
@@ -1428,13 +1479,69 @@ class ReviewChanges$Type extends MessageType<ReviewChanges> {
  */
 export const ReviewChanges = new ReviewChanges$Type();
 // @generated message type with reflection information, may provide speed optimized methods
+class CurrentUserAssignments$Type extends MessageType<CurrentUserAssignments> {
+    constructor() {
+        super("teleport.accesslist.v1.CurrentUserAssignments", [
+            { no: 1, name: "ownership_type", kind: "enum", T: () => ["teleport.accesslist.v1.AccessListUserAssignmentType", AccessListUserAssignmentType, "ACCESS_LIST_USER_ASSIGNMENT_TYPE_"] },
+            { no: 2, name: "membership_type", kind: "enum", T: () => ["teleport.accesslist.v1.AccessListUserAssignmentType", AccessListUserAssignmentType, "ACCESS_LIST_USER_ASSIGNMENT_TYPE_"] }
+        ]);
+    }
+    create(value?: PartialMessage<CurrentUserAssignments>): CurrentUserAssignments {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.ownershipType = 0;
+        message.membershipType = 0;
+        if (value !== undefined)
+            reflectionMergePartial<CurrentUserAssignments>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: CurrentUserAssignments): CurrentUserAssignments {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* teleport.accesslist.v1.AccessListUserAssignmentType ownership_type */ 1:
+                    message.ownershipType = reader.int32();
+                    break;
+                case /* teleport.accesslist.v1.AccessListUserAssignmentType membership_type */ 2:
+                    message.membershipType = reader.int32();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: CurrentUserAssignments, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* teleport.accesslist.v1.AccessListUserAssignmentType ownership_type = 1; */
+        if (message.ownershipType !== 0)
+            writer.tag(1, WireType.Varint).int32(message.ownershipType);
+        /* teleport.accesslist.v1.AccessListUserAssignmentType membership_type = 2; */
+        if (message.membershipType !== 0)
+            writer.tag(2, WireType.Varint).int32(message.membershipType);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message teleport.accesslist.v1.CurrentUserAssignments
+ */
+export const CurrentUserAssignments = new CurrentUserAssignments$Type();
+// @generated message type with reflection information, may provide speed optimized methods
 class AccessListStatus$Type extends MessageType<AccessListStatus> {
     constructor() {
         super("teleport.accesslist.v1.AccessListStatus", [
             { no: 1, name: "member_count", kind: "scalar", opt: true, T: 13 /*ScalarType.UINT32*/ },
             { no: 2, name: "member_list_count", kind: "scalar", opt: true, T: 13 /*ScalarType.UINT32*/ },
             { no: 3, name: "owner_of", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
-            { no: 4, name: "member_of", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ }
+            { no: 4, name: "member_of", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
+            { no: 5, name: "current_user_assignments", kind: "message", T: () => CurrentUserAssignments }
         ]);
     }
     create(value?: PartialMessage<AccessListStatus>): AccessListStatus {
@@ -1462,6 +1569,9 @@ class AccessListStatus$Type extends MessageType<AccessListStatus> {
                 case /* repeated string member_of */ 4:
                     message.memberOf.push(reader.string());
                     break;
+                case /* teleport.accesslist.v1.CurrentUserAssignments current_user_assignments */ 5:
+                    message.currentUserAssignments = CurrentUserAssignments.internalBinaryRead(reader, reader.uint32(), options, message.currentUserAssignments);
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -1486,6 +1596,9 @@ class AccessListStatus$Type extends MessageType<AccessListStatus> {
         /* repeated string member_of = 4; */
         for (let i = 0; i < message.memberOf.length; i++)
             writer.tag(4, WireType.LengthDelimited).string(message.memberOf[i]);
+        /* teleport.accesslist.v1.CurrentUserAssignments current_user_assignments = 5; */
+        if (message.currentUserAssignments)
+            CurrentUserAssignments.internalBinaryWrite(message.currentUserAssignments, writer.tag(5, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/lib/accesslists/hierarchy.go
+++ b/lib/accesslists/hierarchy.go
@@ -541,7 +541,7 @@ func IsAccessListMember(
 
 	for _, member := range members {
 		// Is user an explicit member?
-		if member.Spec.MembershipKind != accesslist.MembershipKindList && member.GetName() == user.GetName() {
+		if member.Spec.MembershipKind != accesslist.MembershipKindList && member.Spec.Name == user.GetName() {
 			if !UserMeetsRequirements(user, accessList.Spec.MembershipRequires) {
 				// Avoid non-deterministic behavior in these checks. Rather than returning immediately, continue
 				// through all members to make sure there isn't a valid match later on.
@@ -556,7 +556,7 @@ func IsAccessListMember(
 		}
 		// Is user an inherited member through any potential member AccessLists?
 		if member.Spec.MembershipKind == accesslist.MembershipKindList {
-			memberAccessList, err := g.GetAccessList(ctx, member.GetName())
+			memberAccessList, err := g.GetAccessList(ctx, member.Spec.Name)
 			if err != nil {
 				membershipErr = trace.Wrap(err)
 				continue

--- a/lib/accesslists/hierarchy.go
+++ b/lib/accesslists/hierarchy.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 
+	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/trait"
@@ -38,18 +39,6 @@ type RelationshipKind int
 const (
 	RelationshipKindMember RelationshipKind = iota
 	RelationshipKindOwner
-)
-
-// MembershipOrOwnershipType represents the type of membership or ownership a User has for an Access List.
-type MembershipOrOwnershipType int
-
-const (
-	// MembershipOrOwnershipTypeNone indicates that the User lacks valid Membership or Ownership for the Access List.
-	MembershipOrOwnershipTypeNone MembershipOrOwnershipType = iota
-	// MembershipOrOwnershipTypeExplicit indicates that the User has explicit Membership or Ownership for the Access List.
-	MembershipOrOwnershipTypeExplicit
-	// MembershipOrOwnershipTypeInherited indicates that the User has inherited Membership or Ownership for the Access List.
-	MembershipOrOwnershipTypeInherited
 )
 
 // AccessListAndMembersGetter is a minimal interface for fetching AccessLists by name, and AccessListMembers for an Access List.
@@ -83,7 +72,7 @@ func getMembersFor(ctx context.Context, accessListName string, g AccessListAndMe
 			allMembers = append(allMembers, member)
 			continue
 		}
-		childMembers, err := getMembersFor(ctx, member.Spec.Name, g, visited)
+		childMembers, err := getMembersFor(ctx, member.GetName(), g, visited)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -133,7 +122,7 @@ func ValidateAccessListWithMembers(ctx context.Context, accessList *accesslist.A
 		if member.Spec.MembershipKind != accesslist.MembershipKindList {
 			continue
 		}
-		memberList, err := g.GetAccessList(ctx, member.Spec.Name)
+		memberList, err := g.GetAccessList(ctx, member.GetName())
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -146,7 +135,6 @@ func ValidateAccessListWithMembers(ctx context.Context, accessList *accesslist.A
 
 // collectOwners is a helper to recursively collect all Owners for an Access List, including inherited Owners.
 func collectOwners(ctx context.Context, accessList *accesslist.AccessList, g AccessListAndMembersGetter, owners map[string]*accesslist.Owner, visited map[string]struct{}) error {
-	//owners := make([]*accesslist.Owner, 0)
 	if _, ok := visited[accessList.GetName()]; ok {
 		return nil
 	}
@@ -164,7 +152,6 @@ func collectOwners(ctx context.Context, accessList *accesslist.AccessList, g Acc
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		//owners = append(owners, ownerMembers...)
 		for _, ownerMember := range ownerMembers {
 			owners[ownerMember.Name] = ownerMember
 		}
@@ -188,7 +175,7 @@ func collectMembersAsOwners(ctx context.Context, accessListName string, g Access
 
 	for _, member := range listMembers {
 		owners = append(owners, &accesslist.Owner{
-			Name:             member.Spec.Name,
+			Name:             member.GetName(),
 			Description:      member.Metadata.Description,
 			IneligibleStatus: "",
 			MembershipKind:   accesslist.MembershipKindUser,
@@ -224,7 +211,7 @@ func ValidateAccessListMember(
 	if member.Spec.MembershipKind != accesslist.MembershipKindList {
 		return nil
 	}
-	return validateAccessListMemberOrOwner(ctx, parentList, member.Spec.Name, RelationshipKindMember, g)
+	return validateAccessListMemberOrOwner(ctx, parentList, member.GetName(), RelationshipKindMember, g)
 }
 
 // ValidateAccessListOwner validates a new or existing AccessListOwner for an Access List.
@@ -319,7 +306,7 @@ func isReachable(
 	}
 	for _, member := range listMembers {
 		if member.Spec.MembershipKind == accesslist.MembershipKindList {
-			childList, err := g.GetAccessList(ctx, member.Spec.Name)
+			childList, err := g.GetAccessList(ctx, member.GetName())
 			if err != nil {
 				return false, trace.Wrap(err)
 			}
@@ -402,7 +389,7 @@ func maxDepthDownwards(
 	}
 	for _, member := range listMembers {
 		if member.Spec.MembershipKind == accesslist.MembershipKindList {
-			childListName := member.Spec.Name
+			childListName := member.GetName()
 			depth, err := maxDepthDownwards(ctx, childListName, seen, g)
 			if err != nil {
 				return 0, trace.Wrap(err)
@@ -460,16 +447,16 @@ func IsAccessListOwner(
 	g AccessListAndMembersGetter,
 	lockGetter services.LockGetter,
 	clock clockwork.Clock,
-) (MembershipOrOwnershipType, error) {
+) (accesslistv1.AccessListUserAssignmentType, error) {
 	if lockGetter != nil {
 		locks, err := lockGetter.GetLocks(ctx, true, types.LockTarget{
 			User: user.GetName(),
 		})
 		if err != nil {
-			return MembershipOrOwnershipTypeNone, trace.Wrap(err)
+			return accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED, trace.Wrap(err)
 		}
 		if len(locks) > 0 {
-			return MembershipOrOwnershipTypeNone, trace.AccessDenied("User '%s' is currently locked", user.GetName())
+			return accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED, trace.AccessDenied("User '%s' is currently locked", user.GetName())
 		}
 	}
 
@@ -484,7 +471,7 @@ func IsAccessListOwner(
 				ownershipErr = trace.AccessDenied("User '%s' does not meet the ownership requirements for Access List '%s'", user.GetName(), accessList.Spec.Title)
 				continue
 			}
-			return MembershipOrOwnershipTypeExplicit, nil
+			return accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_EXPLICIT, nil
 		}
 		// Is user an inherited owner through any potential owner AccessLists?
 		if owner.MembershipKind == accesslist.MembershipKindList {
@@ -499,17 +486,17 @@ func IsAccessListOwner(
 				ownershipErr = trace.Wrap(err)
 				continue
 			}
-			if membershipType != MembershipOrOwnershipTypeNone {
+			if membershipType != accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED {
 				if !UserMeetsRequirements(user, accessList.Spec.OwnershipRequires) {
 					ownershipErr = trace.AccessDenied("User '%s' does not meet the ownership requirements for Access List '%s'", user.GetName(), accessList.Spec.Title)
 					continue
 				}
-				return MembershipOrOwnershipTypeInherited, nil
+				return accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_INHERITED, nil
 			}
 		}
 	}
 
-	return MembershipOrOwnershipTypeNone, trace.Wrap(ownershipErr)
+	return accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED, trace.Wrap(ownershipErr)
 }
 
 func IsAccessListMember(
@@ -519,29 +506,29 @@ func IsAccessListMember(
 	g AccessListAndMembersGetter,
 	lockGetter services.LockGetter,
 	clock clockwork.Clock,
-) (MembershipOrOwnershipType, error) {
+) (accesslistv1.AccessListUserAssignmentType, error) {
 	if lockGetter != nil {
 		locks, err := lockGetter.GetLocks(ctx, true, types.LockTarget{
 			User: user.GetName(),
 		})
 		if err != nil {
-			return MembershipOrOwnershipTypeNone, trace.Wrap(err)
+			return accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED, trace.Wrap(err)
 		}
 		if len(locks) > 0 {
-			return MembershipOrOwnershipTypeNone, trace.AccessDenied("User '%s' is currently locked", user.GetName())
+			return accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED, trace.AccessDenied("User '%s' is currently locked", user.GetName())
 		}
 	}
 
 	members, err := fetchMembers(ctx, accessList.GetName(), g)
 	if err != nil {
-		return MembershipOrOwnershipTypeNone, trace.Wrap(err)
+		return accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED, trace.Wrap(err)
 	}
 
 	var membershipErr error
 
 	for _, member := range members {
 		// Is user an explicit member?
-		if member.Spec.MembershipKind != accesslist.MembershipKindList && member.Spec.Name == user.GetName() {
+		if member.Spec.MembershipKind != accesslist.MembershipKindList && member.GetName() == user.GetName() {
 			if !UserMeetsRequirements(user, accessList.Spec.MembershipRequires) {
 				// Avoid non-deterministic behavior in these checks. Rather than returning immediately, continue
 				// through all members to make sure there isn't a valid match later on.
@@ -552,11 +539,11 @@ func IsAccessListMember(
 				membershipErr = trace.AccessDenied("User '%s's membership in Access List '%s' has expired", user.GetName(), accessList.Spec.Title)
 				continue
 			}
-			return MembershipOrOwnershipTypeExplicit, nil
+			return accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_EXPLICIT, nil
 		}
 		// Is user an inherited member through any potential member AccessLists?
 		if member.Spec.MembershipKind == accesslist.MembershipKindList {
-			memberAccessList, err := g.GetAccessList(ctx, member.Spec.Name)
+			memberAccessList, err := g.GetAccessList(ctx, member.GetName())
 			if err != nil {
 				membershipErr = trace.Wrap(err)
 				continue
@@ -567,7 +554,7 @@ func IsAccessListMember(
 				membershipErr = trace.Wrap(err)
 				continue
 			}
-			if membershipType != MembershipOrOwnershipTypeNone {
+			if membershipType != accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED {
 				if !UserMeetsRequirements(user, accessList.Spec.MembershipRequires) {
 					membershipErr = trace.AccessDenied("User '%s' does not meet the membership requirements for Access List '%s'", user.GetName(), accessList.Spec.Title)
 					continue
@@ -576,12 +563,12 @@ func IsAccessListMember(
 					membershipErr = trace.AccessDenied("User '%s's membership in Access List '%s' has expired", user.GetName(), accessList.Spec.Title)
 					continue
 				}
-				return MembershipOrOwnershipTypeInherited, nil
+				return accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_INHERITED, nil
 			}
 		}
 	}
 
-	return MembershipOrOwnershipTypeNone, trace.Wrap(membershipErr)
+	return accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED, trace.Wrap(membershipErr)
 }
 
 // UserMeetsRequirements is a helper which will return whether the User meets the AccessList Ownership/MembershipRequires.

--- a/lib/accesslists/hierarchy_test.go
+++ b/lib/accesslists/hierarchy_test.go
@@ -643,24 +643,21 @@ func newAccessList(t *testing.T, name string, clock clockwork.Clock) *accesslist
 	return accessList
 }
 
-func newAccessListMember(t *testing.T, accessListName, memberName string, memberKind string, clock clockwork.Clock) *accesslist.AccessListMember {
+func newAccessListMember(t *testing.T, accessListName, memberName string, memberKind string, clk clockwork.Clock) *accesslist.AccessListMember {
 	t.Helper()
 
+	metaName := fmt.Sprintf("%s-%s", accessListName, memberName)
 	member, err := accesslist.NewAccessListMember(
-		header.Metadata{
-			Name: memberName,
-		},
+		header.Metadata{Name: metaName},
 		accesslist.AccessListMemberSpec{
 			AccessList:     accessListName,
 			Name:           memberName,
-			Joined:         clock.Now().UTC(),
-			Expires:        clock.Now().UTC().Add(24 * time.Hour),
+			Joined:         clk.Now().UTC(),
+			Expires:        clk.Now().UTC().Add(24 * time.Hour),
 			Reason:         "because",
-			AddedBy:        "maxim.dietz@goteleport.com",
+			AddedBy:        "tester",
 			MembershipKind: memberKind,
-		},
-	)
+		})
 	require.NoError(t, err)
-
 	return member
 }

--- a/lib/accesslists/hierarchy_test.go
+++ b/lib/accesslists/hierarchy_test.go
@@ -21,6 +21,7 @@ package accesslists
 import (
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
+	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/header"
@@ -350,7 +352,7 @@ func TestAccessListHierarchyIsOwner(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, trace.AccessDenied("User '%s' does not meet the membership requirements for Access List '%s'", member1, acl1.Spec.Title))
 	// Should not have inherited ownership due to missing OwnershipRequires.
-	require.Equal(t, MembershipOrOwnershipTypeNone, ownershipType)
+	require.Equal(t, accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED, ownershipType)
 
 	// User which only meets acl1's Membership requirements.
 	stubUserMeetsMemberRequires, err := types.NewUser(member1)
@@ -364,7 +366,7 @@ func TestAccessListHierarchyIsOwner(t *testing.T) {
 	ownershipType, err = IsAccessListOwner(ctx, stubUserMeetsMemberRequires, acl4, accessListAndMembersGetter, nil, clock)
 	require.Error(t, err)
 	require.ErrorIs(t, err, trace.AccessDenied("User '%s' does not meet the ownership requirements for Access List '%s'", member1, acl4.Spec.Title))
-	require.Equal(t, MembershipOrOwnershipTypeNone, ownershipType)
+	require.Equal(t, accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED, ownershipType)
 
 	// User which meets acl1's Membership and acl1's Ownership requirements.
 	stubUserMeetsAllRequires, err := types.NewUser(member1)
@@ -380,13 +382,13 @@ func TestAccessListHierarchyIsOwner(t *testing.T) {
 	ownershipType, err = IsAccessListOwner(ctx, stubUserMeetsAllRequires, acl4, accessListAndMembersGetter, nil, clock)
 	require.NoError(t, err)
 	// Should have inherited ownership from acl1's inclusion in acl4's Owners.
-	require.Equal(t, MembershipOrOwnershipTypeInherited, ownershipType)
+	require.Equal(t, accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_INHERITED, ownershipType)
 
 	stubUserMeetsAllRequires.SetName(member2)
 	ownershipType, err = IsAccessListOwner(ctx, stubUserMeetsAllRequires, acl4, accessListAndMembersGetter, nil, clock)
 	require.NoError(t, err)
 	// Should not have ownership.
-	require.Equal(t, MembershipOrOwnershipTypeNone, ownershipType)
+	require.Equal(t, accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED, ownershipType)
 }
 
 func TestAccessListIsMember(t *testing.T) {
@@ -418,7 +420,7 @@ func TestAccessListIsMember(t *testing.T) {
 
 	membershipType, err := IsAccessListMember(ctx, stubMember1, acl1, accessListAndMembersGetter, locksGetter, clock)
 	require.NoError(t, err)
-	require.Equal(t, MembershipOrOwnershipTypeExplicit, membershipType)
+	require.Equal(t, accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_EXPLICIT, membershipType)
 
 	// When user is Locked, should not be considered a Member.
 	lock, err := types.NewLock("user-lock", types.LockSpecV2{
@@ -431,7 +433,43 @@ func TestAccessListIsMember(t *testing.T) {
 
 	membershipType, err = IsAccessListMember(ctx, stubMember1, acl1, accessListAndMembersGetter, locksGetter, clock)
 	require.ErrorIs(t, err, trace.AccessDenied("User '%s' is currently locked", member1))
-	require.Equal(t, MembershipOrOwnershipTypeNone, membershipType)
+	require.Equal(t, accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED, membershipType)
+}
+
+func TestAccessListIsMember_RequirementsAndExpiry(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	ctx := context.Background()
+	acl := newAccessList(t, "acl", clock)
+
+	// single user member
+	member := newAccessListMember(t, "acl", "u", accesslist.MembershipKindUser, clock)
+	aclGetter := &mockAccessListAndMembersGetter{
+		accessLists: map[string]*accesslist.AccessList{"acl": acl},
+		members:     map[string][]*accesslist.AccessListMember{"acl": {member}},
+	}
+
+	u, _ := types.NewUser("u")
+	u.SetRoles([]string{"wrong-role"})
+	u.SetTraits(map[string][]string{})
+	locks := &mockLocksGetter{}
+
+	// Missing membershipRequires should be AccessDenied
+	typ, err := IsAccessListMember(ctx, u, acl, aclGetter, locks, clock)
+	require.Equal(t, accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED, typ)
+	require.ErrorIs(t, err, trace.AccessDenied("User '%s' does not meet the membership requirements for Access List '%s'", u.GetName(), acl.GetName()))
+
+	// Give correct traits/roles, but expire the membership
+	u.SetRoles([]string{"mrole1", "mrole2"})
+	u.SetTraits(map[string][]string{
+		"mtrait1": {"mvalue1", "mvalue2"},
+		"mtrait2": {"mvalue3", "mvalue4"},
+	})
+	// advance clock past Expires
+	clock.Advance(48 * time.Hour)
+
+	typ, err = IsAccessListMember(ctx, u, acl, aclGetter, locks, clock)
+	require.Equal(t, accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED, typ)
+	require.ErrorIs(t, err, trace.AccessDenied("User '%s's membership in Access List '%s' has expired", u.GetName(), acl.GetName()))
 }
 
 func TestGetOwners(t *testing.T) {
@@ -502,8 +540,8 @@ func TestGetOwners(t *testing.T) {
 	// Note: Owners of acl2 ("ownerB") and members/owners of acl3 are not inherited by acl1
 
 	expectedOwners := map[string]bool{
-		"ownerA":  true, // Direct owner of acl1
-		"memberB": true, // Member of acl2 (owner list of acl1)
+		"ownerA":         true, // Direct owner of acl1
+		acl2m1.GetName(): true, // Member of acl2 (owner list of acl1)
 	}
 
 	actualOwners := make(map[string]bool)
@@ -523,8 +561,8 @@ func TestGetOwners(t *testing.T) {
 	//   - Members of acl3: "memberC"
 
 	expectedOwners = map[string]bool{
-		"ownerB":  true, // Direct owner of acl2
-		"memberC": true, // Member of acl3 (owner list of acl2)
+		"ownerB":         true, // Direct owner of acl2
+		acl3m1.GetName(): true, // Member of acl3 (owner list of acl2)
 	}
 
 	actualOwners = make(map[string]bool)
@@ -595,6 +633,42 @@ func TestGetInheritedGrants(t *testing.T) {
 	require.Equal(t, expectedGrants, grants)
 }
 
+func TestGetMembersFor_FlattensAndStopsOnCycles(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	ctx := context.Background()
+
+	// A -> B -> C -> B (cycle)
+	a := newAccessList(t, "A", clock)
+	b := newAccessList(t, "B", clock)
+	c := newAccessList(t, "C", clock)
+
+	getter := &mockAccessListAndMembersGetter{
+		accessLists: map[string]*accesslist.AccessList{
+			"A": a, "B": b, "C": c,
+		},
+		members: map[string][]*accesslist.AccessListMember{
+			"A": {newAccessListMember(t, "A", "userA", accesslist.MembershipKindUser, clock),
+				newAccessListMember(t, "A", "B", accesslist.MembershipKindList, clock)},
+			"B": {newAccessListMember(t, "B", "userB", accesslist.MembershipKindUser, clock),
+				newAccessListMember(t, "B", "C", accesslist.MembershipKindList, clock)},
+			"C": {newAccessListMember(t, "C", "userC", accesslist.MembershipKindUser, clock),
+				newAccessListMember(t, "C", "B", accesslist.MembershipKindList, clock)}, // cycle back
+		},
+	}
+
+	members, err := GetMembersFor(ctx, "A", getter)
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(members))
+	for _, m := range members {
+		names = append(names, m.GetName())
+	}
+	sort.Strings(names)
+
+	// Should be userA, userB, userC exactly once each
+	require.Equal(t, []string{"userA", "userB", "userC"}, names)
+}
+
 func newAccessList(t *testing.T, name string, clock clockwork.Clock) *accesslist.AccessList {
 	t.Helper()
 
@@ -646,9 +720,8 @@ func newAccessList(t *testing.T, name string, clock clockwork.Clock) *accesslist
 func newAccessListMember(t *testing.T, accessListName, memberName string, memberKind string, clk clockwork.Clock) *accesslist.AccessListMember {
 	t.Helper()
 
-	metaName := fmt.Sprintf("%s-%s", accessListName, memberName)
 	member, err := accesslist.NewAccessListMember(
-		header.Metadata{Name: metaName},
+		header.Metadata{Name: memberName},
 		accesslist.AccessListMemberSpec{
 			AccessList:     accessListName,
 			Name:           memberName,

--- a/lib/auth/userloginstate/generator.go
+++ b/lib/auth/userloginstate/generator.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jonboulle/clockwork"
 
 	"github.com/gravitational/teleport/api/client/proto"
+	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	usageeventsv1 "github.com/gravitational/teleport/api/gen/proto/go/usageevents/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
@@ -255,7 +256,7 @@ func (g *Generator) handleAccessListMembership(ctx context.Context, user types.U
 
 	membershipKind, err := accesslists.IsAccessListMember(ctx, user, accessList, g.accessLists, g.accessLists, g.clock)
 	// Return early if there was an error or the user isn't a member of the access list.
-	if err != nil || membershipKind == accesslists.MembershipOrOwnershipTypeNone {
+	if err != nil || membershipKind == accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED {
 		// Log any error.
 		if err != nil {
 			g.log.WarnContext(ctx, "checking access list membership", "error", err)
@@ -281,7 +282,7 @@ func (g *Generator) handleAccessListMembership(ctx context.Context, user types.U
 	}
 
 	g.grantRolesAndTraits(accessList.Spec.Grants, state)
-	if membershipKind == accesslists.MembershipOrOwnershipTypeInherited {
+	if membershipKind == accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_INHERITED {
 		inheritedRoles = append(inheritedRoles, accessList.Spec.Grants.Roles...)
 		for k, values := range accessList.Spec.Grants.Traits {
 			inheritedTraits[k] = append(inheritedTraits[k], values...)
@@ -300,7 +301,7 @@ func (g *Generator) handleAccessListOwnership(ctx context.Context, user types.Us
 
 	ownershipType, err := accesslists.IsAccessListOwner(ctx, user, accessList, g.accessLists, g.accessLists, g.clock)
 	// Return early if there was an error or the user isn't an owner of the access list.
-	if err != nil || ownershipType == accesslists.MembershipOrOwnershipTypeNone {
+	if err != nil || ownershipType == accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED {
 		// Log any error.
 		if err != nil {
 			g.log.WarnContext(ctx, "checking access list ownership", "error", err)
@@ -326,7 +327,7 @@ func (g *Generator) handleAccessListOwnership(ctx context.Context, user types.Us
 	}
 
 	g.grantRolesAndTraits(accessList.Spec.OwnerGrants, state)
-	if ownershipType == accesslists.MembershipOrOwnershipTypeInherited {
+	if ownershipType == accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_INHERITED {
 		inheritedRoles = append(inheritedRoles, accessList.Spec.OwnerGrants.Roles...)
 		for k, values := range accessList.Spec.OwnerGrants.Traits {
 			inheritedTraits[k] = append(inheritedTraits[k], values...)
@@ -337,7 +338,7 @@ func (g *Generator) handleAccessListOwnership(ctx context.Context, user types.Us
 }
 
 // grantRolesAndTraits will append the roles and traits from the provided Grants to the UserLoginState,
-// returning inherited roles and traits if membershipOrOwnershipType is inherited.
+// returning inherited roles and traits if AccessListUserAssignmentType is inherited.
 func (g *Generator) grantRolesAndTraits(grants accesslist.Grants, state *userloginstate.UserLoginState) {
 	state.Spec.Roles = append(state.Spec.Roles, grants.Roles...)
 


### PR DESCRIPTION
### Background
The web UI was incorrectly validating inherited ownership for members of nested Access Lists, preventing managing members or viewing members without using the CLI.

### Changes
- Extend `AccessList.Status` struct with new `CurrentUserAssignments` struct containing the type of membership and ownership for the current user. Surface already-calculated info from `GetAccessList`/`GetAccessLists` for use in the web UI.
- (While here), add some missing tests for `hierarchy`-related utilities.
- Update types/pbs.

Required for [#6387](https://github.com/gravitational/teleport.e/pull/6378).

See #54097.