### PR TITLE
fix leaf cluster rejection

### DIFF
--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -615,7 +615,10 @@ func (a *Server) validateTrustedCluster(ctx context.Context, validateRequest *au
 	remoteCluster.SetConnectionStatus(teleport.RemoteClusterStatusOffline)
 
 	_, err = a.CreateRemoteClusterInternal(ctx, remoteCluster, []types.CertAuthority{remoteCA})
-	if err != nil && !trace.IsAlreadyExists(err) {
+	if err != nil {
+		if trace.IsAlreadyExists(err) {
+			return nil, trace.AlreadyExists("leaf cluster %q or a cert authority with the same name is already registered with this root cluster, if you are attempting to re-join try removing the existing "+types.KindRemoteCluster+" resource from the root cluster first", remoteClusterName)
+		}
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/trustedcluster_test.go
+++ b/lib/auth/trustedcluster_test.go
@@ -296,7 +296,7 @@ func TestValidateTrustedCluster(t *testing.T) {
 	})
 
 	t.Run("all CAs are returned when v10+", func(t *testing.T) {
-		leafClusterCA := types.CertAuthority(suite.NewTestCA(types.HostCA, "leafcluster"))
+		leafClusterCA := types.CertAuthority(suite.NewTestCA(types.HostCA, "leafcluster-1"))
 		resp, err := a.validateTrustedCluster(ctx, &authclient.ValidateTrustedClusterRequest{
 			Token:           validToken,
 			CAs:             []types.CertAuthority{leafClusterCA},
@@ -360,10 +360,18 @@ func TestValidateTrustedCluster(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, osshCAs, 1)
 		require.Equal(t, localClusterName, osshCAs[0].GetName())
+
+		// verify that we reject an attempt to re-register the leaf cluster
+		_, err = a.validateTrustedCluster(ctx, &authclient.ValidateTrustedClusterRequest{
+			Token: validToken,
+			CAs:   []types.CertAuthority{leafClusterCA},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "already registered")
 	})
 
 	t.Run("Host User and Database CA are returned by default", func(t *testing.T) {
-		leafClusterCA := types.CertAuthority(suite.NewTestCA(types.HostCA, "leafcluster"))
+		leafClusterCA := types.CertAuthority(suite.NewTestCA(types.HostCA, "leafcluster-2"))
 		resp, err := a.validateTrustedCluster(ctx, &authclient.ValidateTrustedClusterRequest{
 			Token:           validToken,
 			CAs:             []types.CertAuthority{leafClusterCA},


### PR DESCRIPTION
We've been refusing to overwrite existing  remote cluster resources since https://github.com/gravitational/teleport/pull/48009, but weren't bubbling back the error when this refusal happened.  If a new leaf cluster is joined under an old name, this results in an apparently successful handshake, but the new leaf cannot actually join because its CAs aren't trusted by the root.

Prior to https://github.com/gravitational/teleport/pull/48009, new leaf clusters were allowed to overwrite the CAs of existing leaf clusters.  The current behavior is more secure/correct, but results in confusing behavior that is hard to debug.  This PR updates the handshake to explicitly fail with a helpful error message if an existing cluster conflicts with the cluster trying to join.

changelog: leaf cluster joining attempts that conflict with an existing cluster registered with the root now generate an error instead of failing silently