### PR TITLE
Add health_check_config bootstrap support

### DIFF
--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -47,6 +47,7 @@ import (
 	autoupdatev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
 	dbobjectimportrulev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobjectimportrule/v1"
+	healthcheckconfigv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/clusterconfig"
@@ -1551,6 +1552,8 @@ func applyResources(ctx context.Context, service *Services, resources []types.Re
 			_, err = autoupdatev1.UpsertAutoUpdateConfig(ctx, service, r.UnwrapT())
 		case types.Resource153UnwrapperT[*autoupdatev1pb.AutoUpdateVersion]:
 			_, err = autoupdatev1.UpsertAutoUpdateVersion(ctx, service, r.UnwrapT())
+		case types.Resource153UnwrapperT[*healthcheckconfigv1pb.HealthCheckConfig]:
+			_, err = service.UpsertHealthCheckConfig(ctx, r.UnwrapT())
 		default:
 			return trace.NotImplemented("cannot apply resource of type %T", resource)
 		}

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	dbobjectimportrulev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobjectimportrule/v1"
+	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/label"
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
@@ -1502,6 +1503,18 @@ spec:
   type: saml_idp
 sub_kind: saml_idp
 version: v2`
+	healthCheckConfigYAML = `kind: health_check_config
+metadata:
+  name: valid
+  revision: c1159783-930e-4a79-bb19-0d0d866d7af6
+spec:
+  enabled: true
+  match:
+    db_labels:
+    - name: "*"
+      values:
+      - "*"
+version: v1`
 )
 
 func TestInit_bootstrap(t *testing.T) {
@@ -1551,6 +1564,28 @@ func TestInit_bootstrap(t *testing.T) {
 				)
 			},
 			assertError: require.NoError,
+		},
+		{
+			name: "OK bootstrap health check config",
+			modifyConfig: func(cfg *InitConfig) {
+				cfg.BootstrapResources = append(
+					cfg.BootstrapResources,
+					newHealthCheckConfig(t),
+				)
+			},
+			assertError: require.NoError,
+		},
+		{
+			name: "NOK bootstrap health check config invalid",
+			modifyConfig: func(cfg *InitConfig) {
+				cfg.BootstrapResources = append(
+					cfg.BootstrapResources,
+					newHealthCheckConfig(t, func(hcc *healthcheckconfigv1.HealthCheckConfig) {
+						hcc.Spec.HealthyThreshold = 9000
+					}),
+				)
+			},
+			assertError: require.Error,
 		},
 		{
 			name: "NOK bootstrap Host CA missing keys",
@@ -1818,6 +1853,13 @@ func TestInit_ApplyOnStartup(t *testing.T) {
 			},
 			assertError: require.NoError,
 		},
+		{
+			name: "Apply HealthCheckConfig",
+			modifyConfig: func(cfg *InitConfig) {
+				cfg.ApplyOnStartupResources = append(cfg.ApplyOnStartupResources, newHealthCheckConfig(t))
+			},
+			assertError: require.NoError,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -1846,6 +1888,15 @@ func resourceDiff(res1, res2 types.Resource) string {
 	return cmp.Diff(res1, res2,
 		cmpopts.IgnoreFields(types.Metadata{}, "Revision", "Namespace"),
 		cmpopts.EquateEmpty())
+}
+
+func newHealthCheckConfig(t *testing.T, opts ...func(*healthcheckconfigv1.HealthCheckConfig)) types.Resource {
+	r := resourceFromYAML(t, healthCheckConfigYAML)
+	inner := r.(types.Resource153UnwrapperT[*healthcheckconfigv1.HealthCheckConfig]).UnwrapT()
+	for _, opt := range opts {
+		opt(inner)
+	}
+	return r
 }
 
 // TestSyncUpgadeWindowStartHour verifies the core logic of the upgrade window start

--- a/lib/services/local/health_check_config.go
+++ b/lib/services/local/health_check_config.go
@@ -145,3 +145,28 @@ func (healthCheckConfigParser) parse(event backend.Event) (types.Resource, error
 		return nil, trace.BadParameter("event %s is not supported", event.Type)
 	}
 }
+
+func itemFromHealthCheckConfig(cfg *healthcheckconfigv1.HealthCheckConfig) (*backend.Item, error) {
+	if err := services.ValidateHealthCheckConfig(cfg); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	rev, err := types.GetRevision(cfg)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	value, err := services.MarshalHealthCheckConfig(cfg)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	expires, err := types.GetExpiry(cfg)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	item := &backend.Item{
+		Key:      backend.NewKey(healthCheckConfigPrefix, cfg.GetMetadata().GetName()),
+		Value:    value,
+		Expires:  expires,
+		Revision: rev,
+	}
+	return item, nil
+}

--- a/lib/services/local/resource.go
+++ b/lib/services/local/resource.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gravitational/trace"
 
 	autoupdatev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
+	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/services"
@@ -103,6 +104,8 @@ func itemsFromResource(resource types.Resource) ([]backend.Item, error) {
 		item, err = itemFromAutoUpdateConfig(r.UnwrapT())
 	case types.Resource153UnwrapperT[*autoupdatev1pb.AutoUpdateVersion]:
 		item, err = itemFromAutoUpdateVersion(r.UnwrapT())
+	case types.Resource153UnwrapperT[*healthcheckconfigv1.HealthCheckConfig]:
+		item, err = itemFromHealthCheckConfig(r.UnwrapT())
 	default:
 		return nil, trace.NotImplemented("cannot itemFrom resource of type %T", resource)
 	}

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -33,6 +33,7 @@ import (
 
 	autoupdatev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
@@ -764,6 +765,26 @@ func init() {
 			return nil, trace.Wrap(err)
 		}
 		return types.Resource153ToLegacy(v), nil
+	})
+	// add health_check_config to tctl get all
+	RegisterResourceMarshaler(types.KindHealthCheckConfig, func(resource types.Resource, opts ...MarshalOption) ([]byte, error) {
+		wrapper, ok := resource.(types.Resource153UnwrapperT[*healthcheckconfigv1.HealthCheckConfig])
+		if !ok {
+			return nil, trace.BadParameter("expected health check config, got %T", resource)
+		}
+		bytes, err := MarshalHealthCheckConfig(wrapper.UnwrapT(), opts...)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return bytes, nil
+	})
+	// support health_check_config --bootstrap and --apply-on-startup
+	RegisterResourceUnmarshaler(types.KindHealthCheckConfig, func(data []byte, options ...MarshalOption) (types.Resource, error) {
+		cfg, err := UnmarshalHealthCheckConfig(data, options...)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return types.Resource153ToLegacy(cfg), nil
 	})
 }
 

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -1465,6 +1465,9 @@ func TestCreateResources(t *testing.T) {
 		{
 			kind:   types.KindHealthCheckConfig,
 			create: testCreateHealthCheckConfig,
+			getAllCheck: func(t *testing.T, s string) {
+				assert.Contains(t, s, "kind: health_check_config")
+			},
 		},
 	}
 


### PR DESCRIPTION
Supports health check config resources with --bootstrap or --apply-on-startup.

Part of:
- #20544