### PR TITLE
Link aws agent to aws dashboard

### DIFF
--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Agents.test.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Agents.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * Teleport
+ * Copyright (C) 2024 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+
+import { render, screen, userEvent, waitFor } from 'design/utils/testing';
+
+import { Route } from 'teleport/components/Router';
+import cfg from 'teleport/config';
+import { Agents } from 'teleport/Integrations/status/AwsOidc/Details/Agents';
+import { integrationService } from 'teleport/services/integrations';
+
+test('renders service name & labels from response', async () => {
+  jest.spyOn(window, 'open').mockImplementation();
+
+  jest
+    .spyOn(integrationService, 'fetchAwsOidcDatabaseServices')
+    .mockResolvedValue({
+      services: [
+        {
+          name: 'dev-db',
+          matchingLabels: [{ name: 'region', value: 'us-west-2' }],
+          dashboardUrl: 'some-aws-url',
+          validTeleportConfig: true,
+        },
+        {
+          name: 'dev-db',
+          matchingLabels: [
+            { name: 'region', value: 'us-west-1' },
+            { name: '*', value: '*' },
+          ],
+          dashboardUrl: 'some-aws-url',
+          validTeleportConfig: true,
+        },
+        {
+          name: 'staging-db',
+          matchingLabels: [{ name: '*', value: '*' }],
+          dashboardUrl: 'some-aws-url',
+          validTeleportConfig: true,
+        },
+      ],
+    });
+  render(
+    <MemoryRouter
+      initialEntries={[
+        `/web/integrations/status/aws-oidc/some-name/resources/rds?tab=agents`,
+      ]}
+    >
+      <Route
+        path={cfg.routes.integrationStatusResources}
+        render={() => <Agents />}
+      />
+    </MemoryRouter>
+  );
+
+  await waitFor(() => {
+    screen.getAllByText('dev-db');
+  });
+
+  expect(getTableCellContents()).toEqual({
+    header: ['Service Name', 'Labels'],
+    rows: [
+      ['dev-db', 'region:us-west-2'],
+      ['dev-db', 'region:us-west-1*:*'],
+      ['staging-db', '*:*'],
+    ],
+  });
+
+  await userEvent.click(screen.getAllByRole('row')[1]);
+  expect(window.open).toHaveBeenCalledWith('some-aws-url', '_blank');
+
+  jest.clearAllMocks();
+});
+
+function getTableCellContents() {
+  const [header, ...rows] = screen.getAllByRole('row');
+  return {
+    header: within(header)
+      .getAllByRole('columnheader')
+      .map(cell => cell.textContent),
+    rows: rows.map(row =>
+      within(row)
+        .getAllByRole('cell')
+        .map(cell => cell.textContent)
+    ),
+  };
+}

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Agents.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Agents.tsx
@@ -63,6 +63,13 @@ export function Agents() {
       )}
       <Table<AWSOIDCDeployedDatabaseService>
         data={servicesAttempt.data?.services}
+        row={{
+          onClick: (item: AWSOIDCDeployedDatabaseService) =>
+            window.open(item.dashboardUrl, '_blank'),
+          getStyle: () => ({
+            cursor: 'pointer',
+          }),
+        }}
         columns={[
           {
             key: 'name',

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Agents.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Agents.tsx
@@ -70,7 +70,7 @@ export function Agents() {
           },
           {
             key: 'matchingLabels',
-            headerText: 'Tags',
+            headerText: 'Labels',
             render: ({ matchingLabels }) => (
               <LabelCell
                 data={matchingLabels.map(l => `${l.name}:${l.value}`)}

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Rules.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Rules.tsx
@@ -65,7 +65,7 @@ export function Rules() {
         },
         {
           key: 'labelMatcher',
-          headerText: getResourceTerm(resourceKind),
+          headerText: 'Labels',
           render: ({ labelMatcher }) => (
             <LabelCell data={labelMatcher.map(l => `${l.name}:${l.value}`)} />
           ),
@@ -95,13 +95,4 @@ export function Rules() {
       }}
     />
   );
-}
-
-function getResourceTerm(resource: AwsResource): string {
-  switch (resource) {
-    case AwsResource.rds:
-      return 'Tags';
-    default:
-      return 'Labels';
-  }
 }


### PR DESCRIPTION
* AWS agent rows will now link to the aws dashboard
* Updates table column to be consistent with other tables ('Tags' -> 'Labels')