### PR TITLE
Release 15.4.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 15.4.33 (04/17/25)
+
+* Fix a bug in managed updates v1 causing updaters v2 and AWS integrations to never update if weekdays were set in the `cluster_maintenance_config` resource. [#54116](https://github.com/gravitational/teleport/pull/54116)
+* Fix a bug in Teleport 15 causing `autoupdate_version` and `autoupdate_config` creation to fail when `metadata.id` field is set. [#54047](https://github.com/gravitational/teleport/pull/54047)
+
 ## 15.4.32 (04/14/25)
 
 * Fixed web UI and tsh issues when a SAML metadata URL takes an unusually long time to respond. [#53935](https://github.com/gravitational/teleport/pull/53935)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 #   Stable releases:   "1.0.0"
 #   Pre-releases:      "1.0.0-alpha.1", "1.0.0-beta.2", "1.0.0-rc.3"
 #   Master/dev branch: "1.0.0-dev"
-VERSION=15.4.32
+VERSION=15.4.33
 
 DOCKER_IMAGE ?= teleport
 

--- a/api/version.go
+++ b/api/version.go
@@ -3,6 +3,6 @@ package api
 
 import "github.com/coreos/go-semver/semver"
 
-const Version = "15.4.32"
+const Version = "15.4.33"
 
 var SemVersion = semver.New(Version)

--- a/build.assets/macos/tsh/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tsh/tsh.app/Contents/Info.plist
@@ -19,13 +19,13 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>15.4.32</string>
+		<string>15.4.33</string>
 		<key>CFBundleSupportedPlatforms</key>
 		<array>
 			<string>MacOSX</string>
 		</array>
 		<key>CFBundleVersion</key>
-		<string>15.4.32</string>
+		<string>15.4.33</string>
 		<key>DTCompiler</key>
 		<string>com.apple.compilers.llvm.clang.1_0</string>
 		<key>DTPlatformBuild</key>

--- a/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
@@ -17,13 +17,13 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>15.4.32</string>
+		<string>15.4.33</string>
 		<key>CFBundleSupportedPlatforms</key>
 		<array>
 			<string>MacOSX</string>
 		</array>
 		<key>CFBundleVersion</key>
-		<string>15.4.32</string>
+		<string>15.4.33</string>
 		<key>DTCompiler</key>
 		<string>com.apple.compilers.llvm.clang.1_0</string>
 		<key>DTPlatformBuild</key>

--- a/examples/chart/access/discord/Chart.yaml
+++ b/examples/chart/access/discord/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "15.4.32"
+.version: &version "15.4.33"
 
 apiVersion: v2
 name: teleport-plugin-discord

--- a/examples/chart/access/discord/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/discord/tests/__snapshot__/configmap_test.yaml.snap
@@ -24,6 +24,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-discord
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-plugin-discord-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-plugin-discord-15.4.33
       name: RELEASE-NAME-teleport-plugin-discord

--- a/examples/chart/access/discord/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/discord/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-discord
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-plugin-discord-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-plugin-discord-15.4.33
       name: RELEASE-NAME-teleport-plugin-discord
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-discord
-            app.kubernetes.io/version: 15.4.32
-            helm.sh/chart: teleport-plugin-discord-15.4.32
+            app.kubernetes.io/version: 15.4.33
+            helm.sh/chart: teleport-plugin-discord-15.4.33
         spec:
           containers:
           - command:

--- a/examples/chart/access/email/Chart.yaml
+++ b/examples/chart/access/email/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "15.4.32"
+.version: &version "15.4.33"
 
 apiVersion: v2
 name: teleport-plugin-email

--- a/examples/chart/access/email/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/email/tests/__snapshot__/configmap_test.yaml.snap
@@ -26,8 +26,8 @@ should match the snapshot (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-plugin-email-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-plugin-email-15.4.33
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on):
   1: |
@@ -59,8 +59,8 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-plugin-email-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-plugin-email-15.4.33
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, no starttls):
   1: |
@@ -92,8 +92,8 @@ should match the snapshot (smtp on, no starttls):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-plugin-email-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-plugin-email-15.4.33
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, password file):
   1: |
@@ -125,8 +125,8 @@ should match the snapshot (smtp on, password file):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-plugin-email-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-plugin-email-15.4.33
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, roleToRecipients set):
   1: |
@@ -161,8 +161,8 @@ should match the snapshot (smtp on, roleToRecipients set):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-plugin-email-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-plugin-email-15.4.33
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, starttls disabled):
   1: |
@@ -194,6 +194,6 @@ should match the snapshot (smtp on, starttls disabled):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-plugin-email-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-plugin-email-15.4.33
       name: RELEASE-NAME-teleport-plugin-email

--- a/examples/chart/access/email/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/email/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should be possible to override volume name (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-plugin-email-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-plugin-email-15.4.33
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should be possible to override volume name (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 15.4.32
-            helm.sh/chart: teleport-plugin-email-15.4.32
+            app.kubernetes.io/version: 15.4.33
+            helm.sh/chart: teleport-plugin-email-15.4.33
         spec:
           containers:
           - command:
@@ -34,7 +34,7 @@ should be possible to override volume name (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:15.4.32
+            image: public.ecr.aws/gravitational/teleport-plugin-email:15.4.33
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -75,8 +75,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-plugin-email-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-plugin-email-15.4.33
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -90,8 +90,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 15.4.32
-            helm.sh/chart: teleport-plugin-email-15.4.32
+            app.kubernetes.io/version: 15.4.33
+            helm.sh/chart: teleport-plugin-email-15.4.33
         spec:
           containers:
           - command:
@@ -136,8 +136,8 @@ should match the snapshot (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-plugin-email-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-plugin-email-15.4.33
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -151,8 +151,8 @@ should match the snapshot (mailgun on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 15.4.32
-            helm.sh/chart: teleport-plugin-email-15.4.32
+            app.kubernetes.io/version: 15.4.33
+            helm.sh/chart: teleport-plugin-email-15.4.33
         spec:
           containers:
           - command:
@@ -163,7 +163,7 @@ should match the snapshot (mailgun on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:15.4.32
+            image: public.ecr.aws/gravitational/teleport-plugin-email:15.4.33
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -204,8 +204,8 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-plugin-email-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-plugin-email-15.4.33
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -219,8 +219,8 @@ should match the snapshot (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 15.4.32
-            helm.sh/chart: teleport-plugin-email-15.4.32
+            app.kubernetes.io/version: 15.4.33
+            helm.sh/chart: teleport-plugin-email-15.4.33
         spec:
           containers:
           - command:
@@ -231,7 +231,7 @@ should match the snapshot (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:15.4.32
+            image: public.ecr.aws/gravitational/teleport-plugin-email:15.4.33
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -272,8 +272,8 @@ should mount external secret (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-plugin-email-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-plugin-email-15.4.33
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -287,8 +287,8 @@ should mount external secret (mailgun on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 15.4.32
-            helm.sh/chart: teleport-plugin-email-15.4.32
+            app.kubernetes.io/version: 15.4.33
+            helm.sh/chart: teleport-plugin-email-15.4.33
         spec:
           containers:
           - command:
@@ -299,7 +299,7 @@ should mount external secret (mailgun on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:15.4.32
+            image: public.ecr.aws/gravitational/teleport-plugin-email:15.4.33
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -340,8 +340,8 @@ should mount external secret (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-plugin-email-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-plugin-email-15.4.33
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -355,8 +355,8 @@ should mount external secret (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 15.4.32
-            helm.sh/chart: teleport-plugin-email-15.4.32
+            app.kubernetes.io/version: 15.4.33
+            helm.sh/chart: teleport-plugin-email-15.4.33
         spec:
           containers:
           - command:
@@ -367,7 +367,7 @@ should mount external secret (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:15.4.32
+            image: public.ecr.aws/gravitational/teleport-plugin-email:15.4.33
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:

--- a/examples/chart/access/jira/Chart.yaml
+++ b/examples/chart/access/jira/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "15.4.32"
+.version: &version "15.4.33"
 
 apiVersion: v2
 name: teleport-plugin-jira

--- a/examples/chart/access/jira/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/jira/tests/__snapshot__/configmap_test.yaml.snap
@@ -32,6 +32,6 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-jira
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-plugin-jira-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-plugin-jira-15.4.33
       name: RELEASE-NAME-teleport-plugin-jira

--- a/examples/chart/access/jira/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/jira/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-jira
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-plugin-jira-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-plugin-jira-15.4.33
       name: RELEASE-NAME-teleport-plugin-jira
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-jira
-            app.kubernetes.io/version: 15.4.32
-            helm.sh/chart: teleport-plugin-jira-15.4.32
+            app.kubernetes.io/version: 15.4.33
+            helm.sh/chart: teleport-plugin-jira-15.4.33
         spec:
           containers:
           - command:

--- a/examples/chart/access/mattermost/Chart.yaml
+++ b/examples/chart/access/mattermost/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "15.4.32"
+.version: &version "15.4.33"
 
 apiVersion: v2
 name: teleport-plugin-mattermost

--- a/examples/chart/access/mattermost/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/mattermost/tests/__snapshot__/configmap_test.yaml.snap
@@ -22,6 +22,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-plugin-mattermost-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-plugin-mattermost-15.4.33
       name: RELEASE-NAME-teleport-plugin-mattermost

--- a/examples/chart/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-plugin-mattermost-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-plugin-mattermost-15.4.33
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 15.4.32
-            helm.sh/chart: teleport-plugin-mattermost-15.4.32
+            app.kubernetes.io/version: 15.4.33
+            helm.sh/chart: teleport-plugin-mattermost-15.4.33
         spec:
           containers:
           - command:
@@ -75,8 +75,8 @@ should mount external secret:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-plugin-mattermost-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-plugin-mattermost-15.4.33
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -90,8 +90,8 @@ should mount external secret:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 15.4.32
-            helm.sh/chart: teleport-plugin-mattermost-15.4.32
+            app.kubernetes.io/version: 15.4.33
+            helm.sh/chart: teleport-plugin-mattermost-15.4.33
         spec:
           containers:
           - command:
@@ -102,7 +102,7 @@ should mount external secret:
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:15.4.32
+            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:15.4.33
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
             ports:
@@ -143,8 +143,8 @@ should override volume name:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-plugin-mattermost-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-plugin-mattermost-15.4.33
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -158,8 +158,8 @@ should override volume name:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 15.4.32
-            helm.sh/chart: teleport-plugin-mattermost-15.4.32
+            app.kubernetes.io/version: 15.4.33
+            helm.sh/chart: teleport-plugin-mattermost-15.4.33
         spec:
           containers:
           - command:
@@ -170,7 +170,7 @@ should override volume name:
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:15.4.32
+            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:15.4.33
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
             ports:

--- a/examples/chart/access/msteams/Chart.yaml
+++ b/examples/chart/access/msteams/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "15.4.32"
+.version: &version "15.4.33"
 
 apiVersion: v2
 name: teleport-plugin-msteams

--- a/examples/chart/access/msteams/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/msteams/tests/__snapshot__/configmap_test.yaml.snap
@@ -29,6 +29,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-msteams
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-plugin-msteams-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-plugin-msteams-15.4.33
       name: RELEASE-NAME-teleport-plugin-msteams

--- a/examples/chart/access/msteams/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/msteams/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-msteams
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-plugin-msteams-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-plugin-msteams-15.4.33
       name: RELEASE-NAME-teleport-plugin-msteams
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-msteams
-            app.kubernetes.io/version: 15.4.32
-            helm.sh/chart: teleport-plugin-msteams-15.4.32
+            app.kubernetes.io/version: 15.4.33
+            helm.sh/chart: teleport-plugin-msteams-15.4.33
         spec:
           containers:
           - command:

--- a/examples/chart/access/pagerduty/Chart.yaml
+++ b/examples/chart/access/pagerduty/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "15.4.32"
+.version: &version "15.4.33"
 
 apiVersion: v2
 name: teleport-plugin-pagerduty

--- a/examples/chart/access/pagerduty/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/pagerduty/tests/__snapshot__/configmap_test.yaml.snap
@@ -21,6 +21,6 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-pagerduty
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-plugin-pagerduty-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-plugin-pagerduty-15.4.33
       name: RELEASE-NAME-teleport-plugin-pagerduty

--- a/examples/chart/access/pagerduty/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/pagerduty/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-pagerduty
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-plugin-pagerduty-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-plugin-pagerduty-15.4.33
       name: RELEASE-NAME-teleport-plugin-pagerduty
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-pagerduty
-            app.kubernetes.io/version: 15.4.32
-            helm.sh/chart: teleport-plugin-pagerduty-15.4.32
+            app.kubernetes.io/version: 15.4.33
+            helm.sh/chart: teleport-plugin-pagerduty-15.4.33
         spec:
           containers:
           - command:

--- a/examples/chart/access/slack/Chart.yaml
+++ b/examples/chart/access/slack/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "15.4.32"
+.version: &version "15.4.33"
 
 apiVersion: v2
 name: teleport-plugin-slack

--- a/examples/chart/access/slack/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/slack/tests/__snapshot__/configmap_test.yaml.snap
@@ -24,6 +24,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-slack
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-plugin-slack-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-plugin-slack-15.4.33
       name: RELEASE-NAME-teleport-plugin-slack

--- a/examples/chart/access/slack/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/slack/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-slack
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-plugin-slack-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-plugin-slack-15.4.33
       name: RELEASE-NAME-teleport-plugin-slack
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-slack
-            app.kubernetes.io/version: 15.4.32
-            helm.sh/chart: teleport-plugin-slack-15.4.32
+            app.kubernetes.io/version: 15.4.33
+            helm.sh/chart: teleport-plugin-slack-15.4.33
         spec:
           containers:
           - command:

--- a/examples/chart/event-handler/Chart.yaml
+++ b/examples/chart/event-handler/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "15.4.32"
+.version: &version "15.4.33"
 
 apiVersion: v2
 name: teleport-plugin-event-handler

--- a/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
@@ -26,6 +26,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-plugin-event-handler-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-plugin-event-handler-15.4.33
       name: RELEASE-NAME-teleport-plugin-event-handler

--- a/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-plugin-event-handler-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-plugin-event-handler-15.4.33
       name: RELEASE-NAME-teleport-plugin-event-handler
     spec:
       replicas: 1
@@ -82,7 +82,7 @@ should mount tls.existingCASecretName and set environment when set in values:
         value: "true"
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-plugin-event-handler:15.4.32
+      image: public.ecr.aws/gravitational/teleport-plugin-event-handler:15.4.33
       imagePullPolicy: IfNotPresent
       name: teleport-plugin-event-handler
       ports:

--- a/examples/chart/tbot/Chart.yaml
+++ b/examples/chart/tbot/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "15.4.32"
+.version: &version "15.4.33"
 
 name: tbot
 apiVersion: v2

--- a/examples/chart/tbot/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/tbot/tests/__snapshot__/deployment_test.yaml.snap
@@ -29,7 +29,7 @@ should match the snapshot (full):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: tbot
-            helm.sh/chart: tbot-15.4.32
+            helm.sh/chart: tbot-15.4.33
             test-key: test-label-pod
         spec:
           affinity:
@@ -68,7 +68,7 @@ should match the snapshot (full):
               value: "1"
             - name: TEST_ENV
               value: test-value
-            image: public.ecr.aws/gravitational/tbot-distroless:15.4.32
+            image: public.ecr.aws/gravitational/tbot-distroless:15.4.33
             imagePullPolicy: Always
             livenessProbe:
               failureThreshold: 6
@@ -164,7 +164,7 @@ should match the snapshot (simple):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: tbot
-            helm.sh/chart: tbot-15.4.32
+            helm.sh/chart: tbot-15.4.33
         spec:
           containers:
           - args:
@@ -186,7 +186,7 @@ should match the snapshot (simple):
                   fieldPath: spec.nodeName
             - name: KUBERNETES_TOKEN_PATH
               value: /var/run/secrets/tokens/join-sa-token
-            image: public.ecr.aws/gravitational/tbot-distroless:15.4.32
+            image: public.ecr.aws/gravitational/tbot-distroless:15.4.33
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6

--- a/examples/chart/teleport-cluster/Chart.yaml
+++ b/examples/chart/teleport-cluster/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "15.4.32"
+.version: &version "15.4.33"
 
 name: teleport-cluster
 apiVersion: v2

--- a/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "15.4.32"
+.version: &version "15.4.33"
 
 name: teleport-operator
 apiVersion: v2

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_clusterrole_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_clusterrole_test.yaml.snap
@@ -8,8 +8,8 @@ adds operator permissions to ClusterRole:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-cluster-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-cluster-15.4.33
         teleport.dev/majorVersion: "15"
       name: RELEASE-NAME
     rules:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
@@ -1848,8 +1848,8 @@ sets clusterDomain on Configmap:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-cluster-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-cluster-15.4.33
         teleport.dev/majorVersion: "15"
       name: RELEASE-NAME-auth
       namespace: NAMESPACE

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
@@ -8,7 +8,7 @@
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -141,7 +141,7 @@ should set nodeSelector when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -238,7 +238,7 @@ should set resources when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -324,7 +324,7 @@ should set securityContext when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_config_test.yaml.snap
@@ -567,8 +567,8 @@ sets clusterDomain on Configmap:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-cluster-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-cluster-15.4.33
         teleport.dev/majorVersion: "15"
       name: RELEASE-NAME-proxy
       namespace: NAMESPACE

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
@@ -11,8 +11,8 @@ sets clusterDomain on Deployment Pods:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 15.4.32
-        helm.sh/chart: teleport-cluster-15.4.32
+        app.kubernetes.io/version: 15.4.33
+        helm.sh/chart: teleport-cluster-15.4.33
         teleport.dev/majorVersion: "15"
       name: RELEASE-NAME-proxy
       namespace: NAMESPACE
@@ -26,7 +26,7 @@ sets clusterDomain on Deployment Pods:
       template:
         metadata:
           annotations:
-            checksum/config: f7f8c50f662e75fbbc16e2f8750fb0ffefe70a3d79fe49a9e9036fbf29c4cdcd
+            checksum/config: 0bd8f5bb50cde90dce08672e9bf1587ddeacfdb58ede8d829a3d6c8fb1a87a17
             kubernetes.io/pod: test-annotation
             kubernetes.io/pod-different: 4
           labels:
@@ -34,8 +34,8 @@ sets clusterDomain on Deployment Pods:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-cluster
-            app.kubernetes.io/version: 15.4.32
-            helm.sh/chart: teleport-cluster-15.4.32
+            app.kubernetes.io/version: 15.4.33
+            helm.sh/chart: teleport-cluster-15.4.33
             teleport.dev/majorVersion: "15"
         spec:
           affinity:
@@ -44,7 +44,7 @@ sets clusterDomain on Deployment Pods:
           containers:
           - args:
             - --diag-addr=0.0.0.0:3000
-            image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+            image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
             imagePullPolicy: IfNotPresent
             lifecycle:
               preStop:
@@ -105,7 +105,7 @@ sets clusterDomain on Deployment Pods:
             - wait
             - no-resolve
             - RELEASE-NAME-auth-v14.NAMESPACE.svc.test.com
-            image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+            image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
             name: wait-auth-update
           serviceAccountName: RELEASE-NAME-proxy
           terminationGracePeriodSeconds: 60
@@ -137,7 +137,7 @@ should provision initContainer correctly when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v14.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       name: wait-auth-update
       resources:
         limits:
@@ -201,7 +201,7 @@ should set nodeSelector when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -262,7 +262,7 @@ should set nodeSelector when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v14.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       name: wait-auth-update
     nodeSelector:
       environment: security
@@ -313,7 +313,7 @@ should set resources for wait-auth-update initContainer when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -381,7 +381,7 @@ should set resources for wait-auth-update initContainer when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v14.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       name: wait-auth-update
       resources:
         limits:
@@ -421,7 +421,7 @@ should set resources when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -489,7 +489,7 @@ should set resources when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v14.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       name: wait-auth-update
       resources:
         limits:
@@ -529,7 +529,7 @@ should set securityContext for initContainers when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -597,7 +597,7 @@ should set securityContext for initContainers when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v14.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       name: wait-auth-update
       securityContext:
         allowPrivilegeEscalation: false
@@ -637,7 +637,7 @@ should set securityContext when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -705,7 +705,7 @@ should set securityContext when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v14.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       name: wait-auth-update
       securityContext:
         allowPrivilegeEscalation: false

--- a/examples/chart/teleport-kube-agent/Chart.yaml
+++ b/examples/chart/teleport-kube-agent/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "15.4.32"
+.version: &version "15.4.33"
 
 name: teleport-kube-agent
 apiVersion: v2

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
@@ -32,7 +32,7 @@ sets Deployment annotations when specified if action is Upgrade:
               value: "true"
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+            image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -107,7 +107,7 @@ sets Deployment labels when specified if action is Upgrade:
             value: "true"
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-          image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+          image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -169,7 +169,7 @@ sets Pod annotations when specified if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -231,7 +231,7 @@ sets Pod labels when specified if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -310,7 +310,7 @@ should add emptyDir for data when existingDataVolume is not set if action is Upg
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -373,7 +373,7 @@ should add insecureSkipProxyTLSVerify to args when set in values if action is Up
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -435,7 +435,7 @@ should correctly configure existingDataVolume when set if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -495,7 +495,7 @@ should expose diag port if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -569,7 +569,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -643,7 +643,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -705,7 +705,7 @@ should have one replica when replicaCount is not set if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -767,7 +767,7 @@ should mount extraVolumes and extraVolumeMounts if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -836,7 +836,7 @@ should mount tls.existingCASecretName and set environment when set in values if 
         value: cluster.local
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -908,7 +908,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: http://username:password@my.proxy.host:3128
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -976,7 +976,7 @@ should provision initContainer correctly when set in values if action is Upgrade
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1074,7 +1074,7 @@ should set SecurityContext if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1156,7 +1156,7 @@ should set affinity when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1218,7 +1218,7 @@ should set default serviceAccountName when not set in values if action is Upgrad
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1293,7 +1293,7 @@ should set environment when extraEnv set in values if action is Upgrade:
         value: cluster.local
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1417,7 +1417,7 @@ should set imagePullPolicy when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -1479,7 +1479,7 @@ should set nodeSelector if set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1543,7 +1543,7 @@ should set not set priorityClassName when not set in values if action is Upgrade
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1617,7 +1617,7 @@ should set preferred affinity when more than one replica is used if action is Up
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1679,7 +1679,7 @@ should set priorityClassName when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1742,7 +1742,7 @@ should set probeTimeoutSeconds when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1814,7 +1814,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set if
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1876,7 +1876,7 @@ should set resources when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1945,7 +1945,7 @@ should set serviceAccountName when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2007,7 +2007,7 @@ should set tolerations when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
@@ -25,7 +25,7 @@ should create ServiceAccount for post-delete hook by default:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -106,7 +106,7 @@ should not create ServiceAccount for post-delete hook if serviceAccount.create i
                   fieldPath: metadata.namespace
             - name: RELEASE_NAME
               value: RELEASE-NAME
-            image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+            image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
             imagePullPolicy: IfNotPresent
             name: post-delete-job
             securityContext:
@@ -134,7 +134,7 @@ should not create ServiceAccount, Role or RoleBinding for post-delete hook if se
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -162,7 +162,7 @@ should set nodeSelector in post-delete hook:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -192,7 +192,7 @@ should set resources in the Job's pod spec if resources is set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       resources:
@@ -227,7 +227,7 @@ should set securityContext in post-delete hook:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
@@ -18,7 +18,7 @@ sets Pod annotations when specified:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -88,7 +88,7 @@ sets Pod labels when specified:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -182,7 +182,7 @@ sets StatefulSet labels when specified:
               value: RELEASE-NAME
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+            image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -280,7 +280,7 @@ should add insecureSkipProxyTLSVerify to args when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -350,7 +350,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and action
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -440,7 +440,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and is Fre
               value: RELEASE-NAME
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+            image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -520,7 +520,7 @@ should add volumeMount for data volume when using StatefulSet:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -590,7 +590,7 @@ should expose diag port:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -660,7 +660,7 @@ should generate Statefulset when storage is disabled and mode is a Upgrade:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -744,7 +744,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -826,7 +826,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -896,7 +896,7 @@ should have one replica when replicaCount is not set:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -966,7 +966,7 @@ should install Statefulset when storage is disabled and mode is a Fresh Install:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1038,7 +1038,7 @@ should mount extraVolumes and extraVolumeMounts:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1115,7 +1115,7 @@ should mount tls.existingCASecretName and set environment when set in values:
         value: cluster.local
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1197,7 +1197,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: /etc/teleport-tls-ca/ca.pem
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1275,7 +1275,7 @@ should not add emptyDir for data when using StatefulSet:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1345,7 +1345,7 @@ should provision initContainer correctly when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1451,7 +1451,7 @@ should set SecurityContext:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1541,7 +1541,7 @@ should set affinity when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1611,7 +1611,7 @@ should set default serviceAccountName when not set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1694,7 +1694,7 @@ should set environment when extraEnv set in values:
         value: cluster.local
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1834,7 +1834,7 @@ should set imagePullPolicy when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -1904,7 +1904,7 @@ should set nodeSelector if set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1988,7 +1988,7 @@ should set preferred affinity when more than one replica is used:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2058,7 +2058,7 @@ should set probeTimeoutSeconds when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2138,7 +2138,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2208,7 +2208,7 @@ should set resources when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2285,7 +2285,7 @@ should set serviceAccountName when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2355,7 +2355,7 @@ should set storage.requests when set in values and action is an Upgrade:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2425,7 +2425,7 @@ should set storage.storageClassName when set in values and action is an Upgrade:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2495,7 +2495,7 @@ should set tolerations when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:15.4.32
+      image: public.ecr.aws/gravitational/teleport-distroless:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
@@ -27,7 +27,7 @@ sets the affinity:
       - --base-image=public.ecr.aws/gravitational/teleport-distroless
       - --version-server=https://my-custom-version-server/v1
       - --version-channel=custom/preview
-      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:15.4.32
+      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -71,7 +71,7 @@ sets the tolerations:
       - --base-image=public.ecr.aws/gravitational/teleport-distroless
       - --version-server=https://my-custom-version-server/v1
       - --version-channel=custom/preview
-      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:15.4.32
+      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:15.4.33
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6


### PR DESCRIPTION
* Fix a bug in managed updates v1 causing updaters v2 and AWS integrations to never update if weekdays were set in the `cluster_maintenance_config` resource. [#54116](https://github.com/gravitational/teleport/pull/54116)
* Fix a bug in Teleport 15 causing `autoupdate_version` and `autoupdate_config` creation to fail when `metadata.id` field is set. [#54047](https://github.com/gravitational/teleport/pull/54047)