### PR TITLE
Fix TF update conflicts on dynamic windows desktop and autoupdate resources

### DIFF
--- a/integrations/terraform/gen/main.go
+++ b/integrations/terraform/gen/main.go
@@ -38,7 +38,9 @@ type payload struct {
 	GetMethod string
 	// CreateMethod represents API create method name
 	CreateMethod string
-	// CreateMethod represents API update method name
+	// UpdateMethod represents the API update method name.
+	// On services without conditional updates, you can use the Update method.
+	// On services with conditional updates, you must use the Upsert variant.
 	UpdateMethod string
 	// DeleteMethod represents API reset method used in singular resources
 	DeleteMethod string
@@ -216,7 +218,7 @@ var (
 		IfaceName:              "DynamicWindowsDesktop",
 		GetMethod:              "DynamicDesktopClient().GetDynamicWindowsDesktop",
 		CreateMethod:           "DynamicDesktopClient().CreateDynamicWindowsDesktop",
-		UpdateMethod:           "DynamicDesktopClient().UpdateDynamicWindowsDesktop",
+		UpdateMethod:           "DynamicDesktopClient().UpsertDynamicWindowsDesktop",
 		DeleteMethod:           "DynamicDesktopClient().DeleteDynamicWindowsDesktop",
 		UpsertMethodArity:      2,
 		ID:                     `desktop.Metadata.Name`,
@@ -553,7 +555,7 @@ var (
 		GetMethod:             "GetAutoUpdateVersion",
 		CreateMethod:          "CreateAutoUpdateVersion",
 		UpsertMethodArity:     2,
-		UpdateMethod:          "UpdateAutoUpdateVersion",
+		UpdateMethod:          "UpsertAutoUpdateVersion",
 		DeleteMethod:          "DeleteAutoUpdateVersion",
 		ID:                    "autoUpdateVersion.Metadata.Name",
 		Kind:                  "autoupdate_version",
@@ -580,7 +582,7 @@ var (
 		GetMethod:             "GetAutoUpdateConfig",
 		CreateMethod:          "CreateAutoUpdateConfig",
 		UpsertMethodArity:     2,
-		UpdateMethod:          "UpdateAutoUpdateConfig",
+		UpdateMethod:          "UpsertAutoUpdateConfig",
 		DeleteMethod:          "DeleteAutoUpdateConfig",
 		ID:                    "autoUpdateConfig.Metadata.Name",
 		Kind:                  "autoupdate_config",

--- a/integrations/terraform/provider/resource_teleport_autoupdate_config.go
+++ b/integrations/terraform/provider/resource_teleport_autoupdate_config.go
@@ -203,7 +203,7 @@ func (r resourceTeleportAutoUpdateConfig) Update(ctx context.Context, req tfsdk.
 		return
 	}
 
-	_, err = r.p.Client.UpdateAutoUpdateConfig(ctx, autoUpdateConfig)
+	_, err = r.p.Client.UpsertAutoUpdateConfig(ctx, autoUpdateConfig)
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error updating AutoUpdateConfig", trace.Wrap(err), "autoupdate_config"))
 		return

--- a/integrations/terraform/provider/resource_teleport_autoupdate_version.go
+++ b/integrations/terraform/provider/resource_teleport_autoupdate_version.go
@@ -203,7 +203,7 @@ func (r resourceTeleportAutoUpdateVersion) Update(ctx context.Context, req tfsdk
 		return
 	}
 
-	_, err = r.p.Client.UpdateAutoUpdateVersion(ctx, autoUpdateVersion)
+	_, err = r.p.Client.UpsertAutoUpdateVersion(ctx, autoUpdateVersion)
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error updating AutoUpdateVersion", trace.Wrap(err), "autoupdate_version"))
 		return

--- a/integrations/terraform/provider/resource_teleport_dynamic_windows_desktop.go
+++ b/integrations/terraform/provider/resource_teleport_dynamic_windows_desktop.go
@@ -230,7 +230,7 @@ func (r resourceTeleportDynamicWindowsDesktop) Update(ctx context.Context, req t
 		return
 	}
 
-	_, err = r.p.Client.DynamicDesktopClient().UpdateDynamicWindowsDesktop(ctx, desktopResource)
+	_, err = r.p.Client.DynamicDesktopClient().UpsertDynamicWindowsDesktop(ctx, desktopResource)
 	if err != nil {
 		resp.Diagnostics.Append(diagFromWrappedErr("Error updating DynamicWindowsDesktop", err, "dynamic_windows_desktop"))
 		return


### PR DESCRIPTION
This PR fixes an issue in the TF provider that affected the dynamic windows dekstop and the (not backported yet) autoupdate version and config resources. Terraform was using Update instead of Upsert, which made it unable to update the resource if it got updated by another entity.

I was not able to reproduce the issue in the tests, it's unclear why tests were not failing.

Fixes: https://github.com/gravitational/teleport/issues/52954
Changelog: Fix a bug causing the Terraform provider to fail to update `dynamic_windows_desktop` resources.