### PR TITLE
Convert desktop session dialogs to inline messages

### DIFF
--- a/web/packages/build/jest/jest-environment-patched-jsdom.js
+++ b/web/packages/build/jest/jest-environment-patched-jsdom.js
@@ -89,7 +89,16 @@ export default class PatchedJSDOMEnvironment extends JSDOMEnvironment {
         this.unobserve = () => {};
         this.disconnect = () => {};
       }
+
       global.ResizeObserver = NullResizeObserver;
+    }
+
+    if (!global.navigator.permissions) {
+      global.navigator.permissions = {
+        query: async () => ({
+          onchange: () => {},
+        }),
+      };
     }
   }
 }

--- a/web/packages/shared/components/DesktopSession/DesktopSession.story.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSession.story.tsx
@@ -30,6 +30,7 @@ import {
   TdpClient,
   TdpClientEvent,
 } from 'shared/libs/tdp';
+import { TdpError as RemoteTdpError } from 'shared/libs/tdp/client';
 
 import { DesktopSession, DesktopSessionProps } from './DesktopSession';
 
@@ -86,7 +87,15 @@ export const FetchError = () => (
 export const TdpError = () => {
   const client = fakeClient();
   client.connect = async () => {
-    client.emit(TdpClientEvent.ERROR, new Error('some tdp error'));
+    client.emit(
+      TdpClientEvent.ERROR,
+      new RemoteTdpError(
+        'RDP client exited with an error: Connection Timed Out.\n\n' +
+          'Teleport could not connect to the host within the timeout period. This may be due to a firewall blocking the connection, an overloaded system, or network congestion.\n\n' +
+          'To resolve this issue, ensure that the Teleport agent can reach the Windows host.\n\n' +
+          'You can use the command "nc -vz HOST 3389" to help diagnose connectivity problems.'
+      )
+    );
   };
 
   return <DesktopSession {...props} client={client} />;
@@ -96,10 +105,10 @@ export const Connected = () => {
   return <DesktopSession {...props} />;
 };
 
-export const Disconnected = () => {
+export const DisconnectedWithNoMessage = () => {
   const client = fakeClient();
   client.connect = async () => {
-    client.emit(TdpClientEvent.TRANSPORT_CLOSE, 'session disconnected');
+    client.emit(TdpClientEvent.TRANSPORT_CLOSE);
   };
 
   return <DesktopSession {...props} client={client} />;

--- a/web/packages/shared/components/DesktopSession/DesktopSession.test.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSession.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { EventEmitter } from 'events';
+
+import { screen } from '@testing-library/react';
+
+import { render } from 'design/utils/testing';
+import { makeSuccessAttempt } from 'shared/hooks/useAsync';
+import { TdpClient } from 'shared/libs/tdp';
+import { wait } from 'shared/utils/wait';
+
+import { DesktopSession } from './DesktopSession';
+
+import 'jest-canvas-mock';
+
+import userEvent from '@testing-library/user-event';
+
+import { TdpTransport } from 'shared/libs/tdp/client';
+
+// Disable WASM in tests.
+jest.mock('shared/libs/ironrdp/pkg/ironrdp');
+
+const hasNoOtherSession = jest.fn().mockResolvedValue(false);
+const aclAttempt = makeSuccessAttempt({
+  clipboardSharingEnabled: true,
+  directorySharingEnabled: true,
+});
+const getMockTransport = () => {
+  const emitter = new EventEmitter();
+  return {
+    emitTransportError: () =>
+      emitter.emit('error', new Error('Could not send bytes')),
+    getTransport: async (abortSignal: AbortSignal): Promise<TdpTransport> => {
+      abortSignal.onabort = async () => {
+        await wait(50);
+        emitter.emit('complete');
+      };
+      return {
+        send: () => {},
+        onMessage: callback => {
+          emitter.on('message', callback);
+          return () => emitter.off('message', callback);
+        },
+        onComplete: callback => {
+          emitter.on('complete', callback);
+          return () => emitter.off('complete', callback);
+        },
+        onError: callback => {
+          emitter.on('error', callback);
+          return () => emitter.off('error', callback);
+        },
+      };
+    },
+  };
+};
+
+test('reconnect button reinitializes the connection', async () => {
+  const transport = getMockTransport();
+  const tpdClient = new TdpClient(transport.getTransport);
+  jest.spyOn(tpdClient, 'connect');
+  jest.spyOn(tpdClient, 'shutdown');
+  const { unmount } = render(
+    <DesktopSession
+      client={tpdClient}
+      username="admin"
+      desktop="win-lab"
+      aclAttempt={aclAttempt}
+      hasAnotherSession={hasNoOtherSession}
+    />
+  );
+
+  // The session is initializing.
+  expect(await screen.findByTestId('indicator')).toBeInTheDocument();
+
+  // An error occurred, the connection has been closed.
+  transport.emitTransportError();
+
+  expect(
+    await screen.findByText('The desktop session is offline.')
+  ).toBeInTheDocument();
+  expect(await screen.findByText('Could not send bytes')).toBeInTheDocument();
+  const reconnect = await screen.findByRole('button', { name: 'Reconnect' });
+
+  await userEvent.click(reconnect);
+
+  // The session is initializing again.
+  expect(
+    screen.queryByText('The desktop session is offline.')
+  ).not.toBeInTheDocument();
+  expect(await screen.findByTestId('indicator')).toBeInTheDocument();
+
+  expect(hasNoOtherSession).toHaveBeenCalledTimes(2);
+  expect(tpdClient.connect).toHaveBeenCalledTimes(2);
+  unmount();
+  // Called 2 times: the first one during reconnecting, the second one after unmounting.
+  expect(tpdClient.shutdown).toHaveBeenCalledTimes(2);
+});

--- a/web/packages/shared/components/DesktopSession/DesktopSession.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSession.tsx
@@ -449,7 +449,7 @@ function AnotherSessionActive(props: {
       <Warning
         mt={3}
         details={
-          <Stack>
+          <Stack gap={2}>
             This desktop has an active session, connecting to it may close the
             other session. <br />
             Do you wish to continue?

--- a/web/packages/shared/components/DesktopSession/DesktopSession.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSession.tsx
@@ -168,8 +168,11 @@ export function DesktopSession({
   useListener(
     client.onTransportClose,
     useCallback(
-      statusText => {
-        setTdpConnectionStatus({ status: 'disconnected', message: statusText });
+      error => {
+        setTdpConnectionStatus({
+          status: 'disconnected',
+          message: error?.message || error?.toString(),
+        });
         initialTdpConnectionSucceeded.current = false;
       },
       [setTdpConnectionStatus]

--- a/web/packages/shared/components/DesktopSession/DesktopSession.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSession.tsx
@@ -299,8 +299,12 @@ export function DesktopSession({
     client.sendKeyboardInput('Delete', ButtonState.DOWN);
   }
 
-  //TODO(gzdunek): Replace with client.connect(), so that we don't refresh the entire page.
-  const onRetry = () => window.location.reload();
+  /** Cleans attempts to rerun effects. */
+  const onRetry = async () => {
+    setTdpConnectionStatus({ status: '' });
+    setAnotherDesktopActiveAttempt(makeEmptyAttempt());
+  };
+
   const screenState = getScreenState(
     aclAttempt,
     anotherDesktopActiveAttempt,
@@ -341,6 +345,9 @@ export function DesktopSession({
         onRemoveAlert={onRemoveAlert}
       />
 
+      {/* The UI states below (except the loading indicator) take up space.*/}
+      {/* They're hidden while the canvas is visible, so when `connect()` reads the screen size, */}
+      {/* it's not affected by these elements.*/}
       {screenState.state === 'another-session-active' && (
         <AnotherSessionActiveDialog
           onContinue={() =>

--- a/web/packages/shared/components/DesktopSession/TopBar.tsx
+++ b/web/packages/shared/components/DesktopSession/TopBar.tsx
@@ -38,6 +38,7 @@ export default function TopBar(props: Props) {
     onCtrlAltDel,
     alerts,
     onRemoveAlert,
+    isConnected,
   } = props;
   const theme = useTheme();
 
@@ -59,29 +60,34 @@ export default function TopBar(props: Props) {
         {userHost}
       </Text>
 
-      <Flex px={3}>
-        <Flex alignItems="center">
-          <HoverTooltip
-            tipContent={directorySharingToolTip(
-              canShareDirectory,
-              isSharingDirectory
-            )}
-            placement="bottom"
-          >
-            <FolderShared style={primaryOnTrue(isSharingDirectory)} pr={3} />
-          </HoverTooltip>
-          <HoverTooltip tipContent={clipboardSharingMessage} placement="bottom">
-            <Clipboard style={primaryOnTrue(isSharingClipboard)} pr={3} />
-          </HoverTooltip>
-          <AlertDropdown alerts={alerts} onRemoveAlert={onRemoveAlert} />
+      {isConnected && (
+        <Flex px={3}>
+          <Flex alignItems="center">
+            <HoverTooltip
+              tipContent={directorySharingToolTip(
+                canShareDirectory,
+                isSharingDirectory
+              )}
+              placement="bottom"
+            >
+              <FolderShared style={primaryOnTrue(isSharingDirectory)} pr={3} />
+            </HoverTooltip>
+            <HoverTooltip
+              tipContent={clipboardSharingMessage}
+              placement="bottom"
+            >
+              <Clipboard style={primaryOnTrue(isSharingClipboard)} pr={3} />
+            </HoverTooltip>
+            <AlertDropdown alerts={alerts} onRemoveAlert={onRemoveAlert} />
+          </Flex>
+          <ActionMenu
+            onDisconnect={onDisconnect}
+            showShareDirectory={canShareDirectory && !isSharingDirectory}
+            onShareDirectory={onShareDirectory}
+            onCtrlAltDel={onCtrlAltDel}
+          />
         </Flex>
-        <ActionMenu
-          onDisconnect={onDisconnect}
-          showShareDirectory={canShareDirectory && !isSharingDirectory}
-          onShareDirectory={onShareDirectory}
-          onCtrlAltDel={onCtrlAltDel}
-        />
-      </Flex>
+      )}
     </TopNav>
   );
 }
@@ -109,5 +115,6 @@ type Props = {
   onShareDirectory: VoidFunction;
   onCtrlAltDel: VoidFunction;
   alerts: NotificationItem[];
+  isConnected: boolean;
   onRemoveAlert(id: string): void;
 };

--- a/web/packages/shared/components/DesktopSession/index.ts
+++ b/web/packages/shared/components/DesktopSession/index.ts
@@ -16,4 +16,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export { DesktopSession, AlertDialog } from './DesktopSession';
+export { DesktopSession, DisconnectedState } from './DesktopSession';

--- a/web/packages/shared/libs/tdp/client.ts
+++ b/web/packages/shared/libs/tdp/client.ts
@@ -144,7 +144,7 @@ export class TdpClient extends EventEmitter {
         this.transportAbortController.signal
       );
     } catch (error) {
-      this.emit(TdpClientEvent.ERROR, error.message);
+      this.emit(TdpClientEvent.ERROR, error);
       return;
     }
 
@@ -183,9 +183,9 @@ export class TdpClient extends EventEmitter {
 
     // 'Processing' errors are the most important.
     if (processingError) {
-      this.emit(TdpClientEvent.ERROR, processingError.message);
+      this.emit(TdpClientEvent.ERROR, processingError);
     } else if (connectionError) {
-      this.emit(TdpClientEvent.TRANSPORT_CLOSE, connectionError.message);
+      this.emit(TdpClientEvent.TRANSPORT_CLOSE, connectionError);
     } else {
       this.emit(TdpClientEvent.TRANSPORT_CLOSE, 'Session disconnected');
     }
@@ -235,7 +235,7 @@ export class TdpClient extends EventEmitter {
     return () => this.off(TdpClientEvent.TDP_WARNING, listener);
   };
 
-  onTransportClose = (listener: (message: string) => void) => {
+  onTransportClose = (listener: (error?: Error) => void) => {
     this.on(TdpClientEvent.TRANSPORT_CLOSE, listener);
     return () => this.off(TdpClientEvent.TRANSPORT_CLOSE, listener);
   };

--- a/web/packages/shared/libs/tdp/client.ts
+++ b/web/packages/shared/libs/tdp/client.ts
@@ -187,7 +187,7 @@ export class TdpClient extends EventEmitter {
     } else if (connectionError) {
       this.emit(TdpClientEvent.TRANSPORT_CLOSE, connectionError);
     } else {
-      this.emit(TdpClientEvent.TRANSPORT_CLOSE, 'Session disconnected');
+      this.emit(TdpClientEvent.TRANSPORT_CLOSE);
     }
 
     this.logger.info('Transport is closed');

--- a/web/packages/shared/libs/tdp/client.ts
+++ b/web/packages/shared/libs/tdp/client.ts
@@ -392,7 +392,7 @@ export class TdpClient extends EventEmitter {
     const alert = this.codec.decodeAlert(buffer);
     // TODO(zmb3): info and warning should use the same handler
     if (alert.severity === Severity.Error) {
-      throw new Error(alert.message);
+      throw new TdpError(alert.message);
     } else if (alert.severity === Severity.Warning) {
       this.handleWarning(alert.message, TdpClientEvent.TDP_WARNING);
     } else {
@@ -806,4 +806,12 @@ export function useListener<T extends any[]>(
       unregister();
     };
   }, [emitter, listener]);
+}
+
+/** Represents an alert emitted by the TDP service with "error" severity. */
+export class TdpError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TdpError';
+  }
 }

--- a/web/packages/teleport/src/DesktopSession/DesktopSession.tsx
+++ b/web/packages/teleport/src/DesktopSession/DesktopSession.tsx
@@ -57,7 +57,11 @@ export function DesktopSession() {
         )
       )
   );
-  const mfa = useMfaEmitter(client);
+  const mfa = useMfaEmitter(client, undefined, {
+    // When the user cancels the MFA prompt, shut down the connection.
+    // To get a new challenge, we need to recreate it.
+    onPromptCancel: useCallback(() => client.shutdown(), [client]),
+  });
 
   const [aclAttempt, fetchAcl] = useAsync(
     useCallback(async () => {

--- a/web/packages/teleport/src/DesktopSession/DesktopSession.tsx
+++ b/web/packages/teleport/src/DesktopSession/DesktopSession.tsx
@@ -89,7 +89,11 @@ export function DesktopSession() {
                 title: 'This session requires multi factor authentication',
                 details: mfa.attempt.statusText,
               }}
-              onRetry={retry}
+              onRetry={() => {
+                // Clear the MFA attempt to hide this alert state.
+                mfa.reset();
+                retry();
+              }}
             />
           );
         }

--- a/web/packages/teleport/src/DesktopSession/DesktopSession.tsx
+++ b/web/packages/teleport/src/DesktopSession/DesktopSession.tsx
@@ -20,7 +20,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router';
 
 import {
-  AlertDialog,
+  DisconnectedState,
   DesktopSession as SharedDesktopSession,
 } from 'shared/components/DesktopSession';
 import { useAsync } from 'shared/hooks/useAsync';
@@ -88,11 +88,12 @@ export function DesktopSession() {
         // Errors, except for dialog cancellations, are handled within the MFA dialog.
         if (mfa.attempt.status === 'error' && !shouldShowMfaPrompt(mfa)) {
           return (
-            <AlertDialog
+            <DisconnectedState
               message={{
                 title: 'This session requires multi factor authentication',
                 details: mfa.attempt.statusText,
               }}
+              desktopName={desktopName}
               onRetry={() => {
                 // Clear the MFA attempt to hide this alert state.
                 mfa.reset();

--- a/web/packages/teleport/src/lib/tdp/webSocketTransportAdapter.ts
+++ b/web/packages/teleport/src/lib/tdp/webSocketTransportAdapter.ts
@@ -30,6 +30,9 @@ export async function adaptWebSocketToTdpTransport(
   socket: WebSocket,
   signal: AbortSignal
 ): Promise<TdpTransport> {
+  if (signal.aborted) {
+    throw new DOMException('Websocket was aborted.', 'AbortError');
+  }
   // WebsocketCloseCode.NORMAL
   signal.addEventListener('abort', () => socket.close(1000));
   socket.binaryType = 'arraybuffer';

--- a/web/packages/teleport/src/lib/useMfa.ts
+++ b/web/packages/teleport/src/lib/useMfa.ts
@@ -175,6 +175,10 @@ export function useMfa(props?: MfaProps): MfaState {
     submit,
     attempt,
     cancelAttempt,
+    reset: () => {
+      setMfaChallenge(null);
+      setMfaAttempt(makeEmptyAttempt());
+    },
   };
 }
 
@@ -213,6 +217,8 @@ export type MfaState = {
   submit: (mfaType?: DeviceType, totpCode?: string) => Promise<void>;
   attempt: Attempt<any>;
   cancelAttempt: () => void;
+  /** Clears the challenge and the attempt state. */
+  reset: () => void;
 };
 
 /** Indicates if an MFA dialog should be visible. */
@@ -237,6 +243,7 @@ export function makeDefaultMfaState(): MfaState {
     submit: () => null,
     attempt: makeEmptyAttempt(),
     cancelAttempt: () => null,
+    reset: () => {},
   };
 }
 

--- a/web/packages/teleport/src/lib/useMfa.ts
+++ b/web/packages/teleport/src/lib/useMfa.ts
@@ -211,7 +211,7 @@ export function useMfaEmitter(
 
     emitterSender?.on(TermEvent.MFA_CHALLENGE, challengeHandler);
     return () => {
-      emitterSender?.off(TermEvent.MFA_CHALLENGE, challengeHandler);
+      emitterSender?.removeListener(TermEvent.MFA_CHALLENGE, challengeHandler);
     };
   }, [mfa, emitterSender, onPromptCancel]);
 


### PR DESCRIPTION
Contribues to https://github.com/gravitational/teleport/issues/20802

This PR aligns the desktop session component to Teleport Connect environment:
1. "Refresh" button was replaced with "Reconnect" that reinitializes the connection instead of refreshing the entire page.
2. The dialog alerts were replaced with inline messages. Connect has its own dialog system, displaying both of them at the same time wouldn't look good.

Note that TDP errors are shown as informational alerts. This is because the backend sends "graceful disconnection" events as TDP error alerts. On the frontend side I don't know if the particular error was a "graceful disconnection", so it's better to just show all TDP errors as informational (as before).

|Before|After|
|---|---|
| ![image](https://github.com/user-attachments/assets/de76b17d-d1de-4f6d-a5a8-ae218302f737) | ![image](https://github.com/user-attachments/assets/85b55509-5ee4-4d8e-813e-9f6422b59492) |
| ![image](https://github.com/user-attachments/assets/fa730ec2-5284-476d-bc54-736a1bed3f82) | ![image](https://github.com/user-attachments/assets/40548b6d-de55-498a-acb6-89b51616942c) |
| ![image](https://github.com/user-attachments/assets/a0dcd03a-5ca6-405a-b8b4-cd04c3ac1b8d) |  ![image](https://github.com/user-attachments/assets/beab00c2-ec5e-49d1-820c-a0e7a2c9ce52) |
| ![image](https://github.com/user-attachments/assets/4136fb7e-a70a-42ae-8045-b82fc1c961b9) | ![image](https://github.com/user-attachments/assets/e3f8f1ee-6ce5-4b03-9217-4f475d544f81) | 
| ![image](https://github.com/user-attachments/assets/c4c3fdfc-9902-46ed-b866-c30554076323) | ![image](https://github.com/user-attachments/assets/6994a7ff-8fe1-40a3-a5dc-6cc173fad0c9) |

