### PR TITLE
[v15] fix leaf cluster rejection

### DIFF
--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -512,7 +512,10 @@ func (a *Server) validateTrustedCluster(ctx context.Context, validateRequest *au
 	remoteCluster.SetConnectionStatus(teleport.RemoteClusterStatusOffline)
 
 	_, err = a.CreateRemoteClusterInternal(ctx, remoteCluster, []types.CertAuthority{remoteCA})
-	if err != nil && !trace.IsAlreadyExists(err) {
+	if err != nil {
+		if trace.IsAlreadyExists(err) {
+			return nil, trace.AlreadyExists("leaf cluster %q or a cert authority with the same name is already registered with this root cluster, if you are attempting to re-join try removing the existing "+types.KindRemoteCluster+" resource from the root cluster first", remoteClusterName)
+		}
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/trustedcluster_test.go
+++ b/lib/auth/trustedcluster_test.go
@@ -298,7 +298,7 @@ func TestValidateTrustedCluster(t *testing.T) {
 	})
 
 	t.Run("all CAs are returned when v10+", func(t *testing.T) {
-		leafClusterCA := types.CertAuthority(suite.NewTestCA(types.HostCA, "leafcluster"))
+		leafClusterCA := types.CertAuthority(suite.NewTestCA(types.HostCA, "leafcluster-1"))
 		resp, err := a.validateTrustedCluster(ctx, &authclient.ValidateTrustedClusterRequest{
 			Token:           validToken,
 			CAs:             []types.CertAuthority{leafClusterCA},
@@ -362,10 +362,18 @@ func TestValidateTrustedCluster(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, osshCAs, 1)
 		require.Equal(t, localClusterName, osshCAs[0].GetName())
+
+		// verify that we reject an attempt to re-register the leaf cluster
+		_, err = a.validateTrustedCluster(ctx, &authclient.ValidateTrustedClusterRequest{
+			Token: validToken,
+			CAs:   []types.CertAuthority{leafClusterCA},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "already registered")
 	})
 
 	t.Run("Host User and Database CA are returned by default", func(t *testing.T) {
-		leafClusterCA := types.CertAuthority(suite.NewTestCA(types.HostCA, "leafcluster"))
+		leafClusterCA := types.CertAuthority(suite.NewTestCA(types.HostCA, "leafcluster-2"))
 		resp, err := a.validateTrustedCluster(ctx, &authclient.ValidateTrustedClusterRequest{
 			Token:           validToken,
 			CAs:             []types.CertAuthority{leafClusterCA},


### PR DESCRIPTION
Backport #54107 to branch/v15

changelog: leaf cluster joining attempts that conflict with an existing cluster registered with the root now generate an error instead of failing silently
