### PR TITLE
[v15] web: add role description to roles page

### DIFF
--- a/web/packages/teleport/src/Roles/RoleList/RoleList.tsx
+++ b/web/packages/teleport/src/Roles/RoleList/RoleList.tsx
@@ -66,6 +66,10 @@ export function RoleList({
           headerText: 'Name',
         },
         {
+          key: 'description',
+          headerText: 'Description',
+        },
+        {
           altKey: 'options-btn',
           render: (role: RoleResource) => (
             <ActionCell

--- a/web/packages/teleport/src/Roles/Roles.tsx
+++ b/web/packages/teleport/src/Roles/Roles.tsx
@@ -123,7 +123,7 @@ export function Roles(props: State) {
         </ButtonPrimary>
       </FeatureHeader>
       {serverSidePagination.attempt.status === 'failed' && (
-        <Alert children={serverSidePagination.attempt.statusText} />
+        <Alert>{serverSidePagination.attempt.statusText}</Alert>
       )}
       <Flex>
         <Box width="100%" mr="6" mb="4">


### PR DESCRIPTION
Backport #54079 to branch/v15

changelog: the web UI now shows role descriptions in the roles table.
