### PR TITLE
[v17] web: add role description to roles page

### DIFF
--- a/web/packages/teleport/src/Roles/RoleList/RoleList.tsx
+++ b/web/packages/teleport/src/Roles/RoleList/RoleList.tsx
@@ -70,6 +70,10 @@ export function RoleList({
           headerText: 'Name',
         },
         {
+          key: 'description',
+          headerText: 'Description',
+        },
+        {
           altKey: 'options-btn',
           render: (role: RoleResource) => (
             <ActionCell

--- a/web/packages/teleport/src/Roles/Roles.tsx
+++ b/web/packages/teleport/src/Roles/Roles.tsx
@@ -227,7 +227,7 @@ export function Roles(props: State & RolesProps) {
         </InfoGuideButton>
       </FeatureHeader>
       {serverSidePagination.attempt.status === 'failed' && (
-        <Alert children={serverSidePagination.attempt.statusText} />
+        <Alert>{serverSidePagination.attempt.statusText}</Alert>
       )}
       <Flex flex="1">
         <Box flex="1" mb="4">


### PR DESCRIPTION
Backport #54079 to branch/v17

changelog: the web UI now shows role descriptions in the roles table.
