### PR TITLE
Revert pin caching change for connect to fix race condition

### DIFF
--- a/lib/teleterm/clusters/storage.go
+++ b/lib/teleterm/clusters/storage.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/api/utils/keys/hardwarekey"
 	"github.com/gravitational/teleport/lib/client"
 	dtauthn "github.com/gravitational/teleport/lib/devicetrust/authn"
 	dtenroll "github.com/gravitational/teleport/lib/devicetrust/enroll"
@@ -218,8 +217,6 @@ func (s *Storage) fromProfile(profileName, leafClusterName string) (*Cluster, *c
 	if err := cfg.LoadProfile(profileStore, profileName); err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
-
-	s.CustomHardwareKeyPrompt = hardwarekey.NewPINCachingPrompt(s.CustomHardwareKeyPrompt, cfg.PIVPINCacheTTL)
 
 	if leafClusterName != "" {
 		clusterNameForKey = leafClusterName


### PR DESCRIPTION
Fixes race condition added in https://github.com/gravitational/teleport/pull/53976

In a follow up I'll change the way the PIN caching prompt or TTL is set for cross-cluster scenarios.

Closes https://github.com/gravitational/teleport/issues/29771