### PR TITLE
Update GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Report 🐛
 about: Something isn't working as expected? Report it here.
-labels: bug
+type: Bug
 ---
 Expected behavior:
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,6 +2,7 @@
 name: Feature Request 💡
 about: Have an idea? Tell us about it.
 labels: feature-request
+type: Enhancement
 ---
 What would you like Teleport to do?
 

--- a/.github/ISSUE_TEMPLATE/flaky_test.md
+++ b/.github/ISSUE_TEMPLATE/flaky_test.md
@@ -3,6 +3,7 @@ name: Flaky Test ❄
 about: Report a flaky unit or integration test
 title: "`TestName` flakiness"
 labels: flaky tests
+type: Task
 ---
 
 ## Before submitting a new issue


### PR DESCRIPTION
GitHub now has issue types, so we can use that in templates in places where it makes more sense than labels ("bug" for example).