### PR TITLE
[teleport-update] Stabilize binary paths in generated tbot config

### DIFF
--- a/lib/autoupdate/agent/config.go
+++ b/lib/autoupdate/agent/config.go
@@ -21,13 +21,12 @@ package agent
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
-	"github.com/google/renameio/v2"
 	"github.com/gravitational/trace"
 	"gopkg.in/yaml.v3"
 
@@ -198,21 +197,9 @@ func readConfig(path string) (*UpdateConfig, error) {
 
 // writeConfig writes UpdateConfig to a file atomically, ensuring the file cannot be corrupted.
 func writeConfig(filename string, cfg *UpdateConfig) error {
-	opts := []renameio.Option{
-		renameio.WithPermissions(configFileMode),
-		renameio.WithExistingPermissions(),
-		renameio.WithTempDir(filepath.Dir(filename)),
-	}
-	t, err := renameio.NewPendingFile(filename, opts...)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	defer t.Cleanup()
-	err = yaml.NewEncoder(t).Encode(cfg)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	return trace.Wrap(t.CloseAtomicallyReplace())
+	return trace.Wrap(writeAtomicWithinDir(filename, configFileMode, func(w io.Writer) error {
+		return trace.Wrap(yaml.NewEncoder(w).Encode(cfg))
+	}))
 }
 
 func validateConfigSpec(spec *UpdateSpec, override OverrideConfig) error {

--- a/lib/autoupdate/agent/integrations.go
+++ b/lib/autoupdate/agent/integrations.go
@@ -159,9 +159,11 @@ func stablePathForBinary(origPath, defaultPath string) (string, error) {
 	return origPath, nil
 }
 
-func findParentMatching(dir, name string, pos int) string {
+// findParentMatching returns the directory above name, if name is at rpos.
+// Otherwise, it returns empty string.
+func findParentMatching(dir, name string, rpos int) string {
 	var base string
-	for range pos {
+	for range rpos {
 		dir, base = filepath.Split(filepath.Clean(dir))
 	}
 	if base == name {

--- a/lib/autoupdate/agent/integrations.go
+++ b/lib/autoupdate/agent/integrations.go
@@ -111,6 +111,7 @@ var ErrUnstableExecutable = errors.New("executable has unstable path")
 // StableExecutable returns a stable path to Teleport binaries that may or may not be managed by Agent Managed Updates.
 // Note that StableExecutable is not guaranteed to return the same binary, as the binary may have been updated
 // since it started running. If a stable path cannot be found, an unstable path is returned with ErrUnstableExecutable.
+// The unstable path returned along with ErrUnstableExecutable will always be the result of os.Executable.
 func StableExecutable() (string, error) {
 	origPath, err := os.Executable()
 	if err != nil {

--- a/lib/autoupdate/agent/integrations.go
+++ b/lib/autoupdate/agent/integrations.go
@@ -105,12 +105,13 @@ func hasParentDir(dir, parent string) (bool, error) {
 	return strings.HasPrefix(absDir, absParent), nil
 }
 
-var ErrUnstablePath = errors.New("binary has unstable path")
+// ErrUnstableExecutable is returned by StableExecutable when no stable path can be found.
+var ErrUnstableExecutable = errors.New("executable has unstable path")
 
-// StablePath returns a stable path to Teleport binaries that may or may not be managed by Agent Managed Updates.
-// Note that StablePath is not guaranteed to return the same binary, as the binary may have been updated
-// since it started running. If a stable path cannot be found, an unstable path is returned with ErrUnstablePath.
-func StablePath() (string, error) {
+// StableExecutable returns a stable path to Teleport binaries that may or may not be managed by Agent Managed Updates.
+// Note that StableExecutable is not guaranteed to return the same binary, as the binary may have been updated
+// since it started running. If a stable path cannot be found, an unstable path is returned with ErrUnstableExecutable.
+func StableExecutable() (string, error) {
 	origPath, err := os.Executable()
 	if err != nil {
 		return origPath, trace.Wrap(err)
@@ -129,7 +130,7 @@ func stablePathForBinary(origPath, defaultPath string) (string, error) {
 		if _, err := os.Stat(linkPath); err == nil {
 			return linkPath, nil
 		}
-		return origPath, ErrUnstablePath
+		return origPath, ErrUnstableExecutable
 	}
 
 	// If we are a Managed Updates install, find the correct path from Managed Updates config.
@@ -143,7 +144,7 @@ func stablePathForBinary(origPath, defaultPath string) (string, error) {
 			}
 		}
 		if _, err := os.Stat(cfgPath); err == nil {
-			return origPath, ErrUnstablePath
+			return origPath, ErrUnstableExecutable
 		}
 	}
 	return origPath, nil

--- a/lib/autoupdate/agent/integrations_test.go
+++ b/lib/autoupdate/agent/integrations_test.go
@@ -138,13 +138,13 @@ func TestStablePath(t *testing.T) {
 			path:         "/opt/teleport/system/bin/teleport",
 			resultIsLink: true,
 			result:       "/opt/teleport/system/bin/teleport",
-			err:          ErrUnstablePath,
+			err:          ErrUnstableExecutable,
 		},
 		{
 			name:   "packaged path is missing",
 			path:   "/opt/teleport/system/bin/teleport",
 			result: "/opt/teleport/system/bin/teleport",
-			err:    ErrUnstablePath,
+			err:    ErrUnstableExecutable,
 		},
 		{
 			name:         "managed path is file",
@@ -170,13 +170,13 @@ func TestStablePath(t *testing.T) {
 			path:         "versions/version/bin/teleport",
 			resultIsLink: true,
 			result:       "[ns]/versions/version/bin/teleport",
-			err:          ErrUnstablePath,
+			err:          ErrUnstableExecutable,
 		},
 		{
 			name:   "managed path is missing",
 			path:   "versions/version/bin/teleport",
 			result: "[ns]/versions/version/bin/teleport",
-			err:    ErrUnstablePath,
+			err:    ErrUnstableExecutable,
 		},
 		{
 			name:   "managed path is missing config",

--- a/lib/autoupdate/agent/integrations_test.go
+++ b/lib/autoupdate/agent/integrations_test.go
@@ -117,74 +117,79 @@ func TestStablePath(t *testing.T) {
 		path         string
 		resultIsFile bool
 		resultIsLink bool
-		wantResult   string
+		result       string
+		err          error
 	}{
 		{
 			name:         "packaged path is file",
 			path:         "/opt/teleport/system/bin/teleport",
 			resultIsFile: true,
-			wantResult:   "/usr/local/bin/teleport",
+			result:       "/usr/local/bin/teleport",
 		},
 		{
 			name:         "packaged path is link",
 			path:         "/opt/teleport/system/bin/teleport",
 			resultIsFile: true,
 			resultIsLink: true,
-			wantResult:   "/usr/local/bin/teleport",
+			result:       "/usr/local/bin/teleport",
 		},
 		{
 			name:         "packaged path is broken link",
 			path:         "/opt/teleport/system/bin/teleport",
 			resultIsLink: true,
-			wantResult:   "/opt/teleport/system/bin/teleport",
+			result:       "/opt/teleport/system/bin/teleport",
+			err:          ErrUnstablePath,
 		},
 		{
-			name:       "packaged path is missing",
-			path:       "/opt/teleport/system/bin/teleport",
-			wantResult: "/opt/teleport/system/bin/teleport",
-		},
-		{
-			name:         "managed path is file",
-			path:         "versions/version/bin/teleport",
-			resultIsFile: true,
-			wantResult:   "[ns]/bin/teleport",
+			name:   "packaged path is missing",
+			path:   "/opt/teleport/system/bin/teleport",
+			result: "/opt/teleport/system/bin/teleport",
+			err:    ErrUnstablePath,
 		},
 		{
 			name:         "managed path is file",
 			path:         "versions/version/bin/teleport",
 			resultIsFile: true,
-			wantResult:   "[ns]/bin/teleport",
+			result:       "[ns]/bin/teleport",
+		},
+		{
+			name:         "managed path is file",
+			path:         "versions/version/bin/teleport",
+			resultIsFile: true,
+			result:       "[ns]/bin/teleport",
 		},
 		{
 			name:         "managed path is link",
 			path:         "versions/version/bin/teleport",
 			resultIsFile: true,
 			resultIsLink: true,
-			wantResult:   "[ns]/bin/teleport",
+			result:       "[ns]/bin/teleport",
 		},
 		{
 			name:         "managed path is broken link",
 			path:         "versions/version/bin/teleport",
 			resultIsLink: true,
-			wantResult:   "[ns]/versions/version/bin/teleport",
+			result:       "[ns]/versions/version/bin/teleport",
+			err:          ErrUnstablePath,
 		},
 		{
-			name:       "managed path is missing",
-			path:       "versions/version/bin/teleport",
-			wantResult: "[ns]/versions/version/bin/teleport",
+			name:   "managed path is missing",
+			path:   "versions/version/bin/teleport",
+			result: "[ns]/versions/version/bin/teleport",
+			err:    ErrUnstablePath,
 		},
 		{
-			name:       "managed path is missing config",
-			path:       "/test/versions/version/bin/teleport",
-			wantResult: "/test/versions/version/bin/teleport",
+			name:   "managed path is missing config",
+			path:   "/test/versions/version/bin/teleport",
+			result: "/test/versions/version/bin/teleport",
 		},
 		{
 			name: "empty",
 		},
 		{
-			name:       "other",
-			path:       "/other",
-			wantResult: "/other",
+			name:   "other",
+			path:   "/other",
+			result: "/other",
 		},
 	}
 
@@ -219,11 +224,12 @@ func TestStablePath(t *testing.T) {
 				createEmptyFile(t, filepath.Join(createPath, name))
 			}
 
-			result := stablePathForBinary(tt.path, defaultPath)
-			require.Equal(t, tt.wantResult, strings.NewReplacer(
+			result, err := stablePathForBinary(tt.path, defaultPath)
+			require.Equal(t, tt.result, strings.NewReplacer(
 				defaultPath, "/usr/local/bin",
 				nsDir, "[ns]",
 			).Replace(result))
+			require.Equal(t, tt.err, err)
 		})
 	}
 }

--- a/lib/autoupdate/agent/integrations_test.go
+++ b/lib/autoupdate/agent/integrations_test.go
@@ -153,12 +153,6 @@ func TestStablePath(t *testing.T) {
 			result:       "[ns]/bin/teleport",
 		},
 		{
-			name:         "managed path is file",
-			path:         "versions/version/bin/teleport",
-			resultIsFile: true,
-			result:       "[ns]/bin/teleport",
-		},
-		{
 			name:         "managed path is link",
 			path:         "versions/version/bin/teleport",
 			resultIsFile: true,

--- a/lib/autoupdate/agent/io.go
+++ b/lib/autoupdate/agent/io.go
@@ -1,0 +1,77 @@
+//go:build !windows
+
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package agent
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/google/renameio/v2"
+	"github.com/gravitational/trace"
+)
+
+// SetRequiredUmask sets the umask to match the systemd umask that the teleport-update service will execute with.
+// This ensures consistent file permissions.
+// NOTE: This must be run in main.go before any goroutines that create files are started.
+func SetRequiredUmask(ctx context.Context, log *slog.Logger) {
+	warnUmask(ctx, log, syscall.Umask(requiredUmask))
+}
+
+// writeAtomicWithinDir atomically creates a new file with renameio, while ensuring that temporary
+// files use the same directory as the target file (with format: .[base][randints]).
+// This ensures that SELinux contexts for important files are set correctly.
+// writeAtomicWithinDir provider a callback with a writer.
+func writeAtomicWithinDir(filename string, perm os.FileMode, fn func(io.Writer) error) error {
+	opts := []renameio.Option{
+		renameio.WithPermissions(perm),
+		renameio.WithExistingPermissions(),
+		renameio.WithTempDir(filepath.Dir(filename)),
+	}
+	f, err := renameio.NewPendingFile(filename, opts...)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer f.Cleanup()
+
+	if err := fn(f); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return trace.Wrap(f.CloseAtomicallyReplace())
+}
+
+// writeFileAtomicWithinDir atomically creates a new file with renameio, while ensuring that temporary
+// files use the same directory as the target file (with format: .[base][randints]).
+// This ensures that SELinux contexts for important files are set correctly.
+func writeFileAtomicWithinDir(filename string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(filename)
+	err := renameio.WriteFile(filename, data, perm, renameio.WithTempDir(dir))
+	return trace.Wrap(err)
+}
+
+// atomicSymlink atomically replaces a symlink.
+func atomicSymlink(oldpath, newpath string) error {
+	return trace.Wrap(renameio.Symlink(oldpath, newpath))
+}

--- a/lib/autoupdate/agent/io_windows.go
+++ b/lib/autoupdate/agent/io_windows.go
@@ -1,0 +1,45 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package agent
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+
+	"github.com/gravitational/trace"
+)
+
+// SetRequiredUmask does nothing on Windows, which does not support umask.
+func SetRequiredUmask(ctx context.Context, log *slog.Logger) {
+	return
+}
+
+func writeAtomicWithinDir(filename string, perm os.FileMode, fn func(io.Writer) error) error {
+	return trace.NotImplemented("atomic write not supported on Windows")
+}
+
+func writeFileAtomicWithinDir(filename string, data []byte, perm os.FileMode) error {
+	return trace.NotImplemented("atomic write not supported on Windows")
+}
+
+func atomicSymlink(oldpath, newpath string) error {
+	return trace.NotImplemented("atomic symlink not supported on Windows")
+}

--- a/lib/autoupdate/agent/telemetry.go
+++ b/lib/autoupdate/agent/telemetry.go
@@ -112,10 +112,10 @@ func StablePath() (string, error) {
 	if err != nil {
 		return origPath, trace.Wrap(err)
 	}
-	return stablePathForFile(origPath, defaultPathDir), nil
+	return stablePathForBinary(origPath, defaultPathDir), nil
 }
 
-func stablePathForFile(origPath, defaultPath string) string {
+func stablePathForBinary(origPath, defaultPath string) string {
 	_, name := filepath.Split(origPath)
 
 	// If we are a package-based install, always use /usr/local/bin if it is valid.
@@ -128,16 +128,13 @@ func stablePathForFile(origPath, defaultPath string) string {
 	}
 
 	// If we are a Managed Updates install, find the correct path from Managed Updates config.
-	// If that path is missing, use the default (/usr/local/bin)
 	if p := findParentMatching(origPath, versionsDirName, 4); p != "" {
-		binPath := defaultPath
 		cfg, err := readConfig(filepath.Join(p, updateConfigName))
 		if err == nil && cfg.Spec.Path != "" {
-			binPath = cfg.Spec.Path
-		}
-		linkPath := filepath.Join(binPath, name)
-		if _, err := os.Stat(linkPath); err == nil {
-			return linkPath
+			linkPath := filepath.Join(cfg.Spec.Path, name)
+			if _, err := os.Stat(linkPath); err == nil {
+				return linkPath
+			}
 		}
 	}
 	return origPath

--- a/lib/autoupdate/agent/telemetry.go
+++ b/lib/autoupdate/agent/telemetry.go
@@ -19,7 +19,6 @@
 package agent
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -127,10 +126,10 @@ func stablePathForFile(origPath, defaultPath string) string {
 			return linkPath
 		}
 	}
-	// If we are a package-based install, always use /usr/local/bin if it is valid.
-	// This ensures that the path is stable if Managed Updates is enabled/disabled.
+
+	// If we are a Managed Updates install, find the correct path from Managed Updates config.
+	// If that path is missing, use the default (/usr/local/bin)
 	if p := findParentMatching(origPath, versionsDirName, 4); p != "" {
-		fmt.Println(p)
 		binPath := defaultPath
 		cfg, err := readConfig(filepath.Join(p, updateConfigName))
 		if err == nil && cfg.Spec.Path != "" {

--- a/lib/autoupdate/agent/telemetry_test.go
+++ b/lib/autoupdate/agent/telemetry_test.go
@@ -174,6 +174,11 @@ func TestStablePath(t *testing.T) {
 			wantResult: "[ns]/versions/version/bin/teleport",
 		},
 		{
+			name:       "managed path is missing config",
+			path:       "/test/versions/version/bin/teleport",
+			wantResult: "/test/versions/version/bin/teleport",
+		},
+		{
 			name: "empty",
 		},
 		{
@@ -214,7 +219,7 @@ func TestStablePath(t *testing.T) {
 				createEmptyFile(t, filepath.Join(createPath, name))
 			}
 
-			result := stablePathForFile(tt.path, defaultPath)
+			result := stablePathForBinary(tt.path, defaultPath)
 			require.Equal(t, tt.wantResult, strings.NewReplacer(
 				defaultPath, "/usr/local/bin",
 				nsDir, "[ns]",

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -35,7 +35,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
-	"syscall"
 	"time"
 
 	"github.com/google/uuid"
@@ -84,13 +83,6 @@ const (
 var (
 	initTime = time.Now().UTC()
 )
-
-// SetRequiredUmask sets the umask to match the systemd umask that the teleport-update service will execute with.
-// This ensures consistent file permissions.
-// NOTE: This must be run in main.go before any goroutines that create files are started.
-func SetRequiredUmask(ctx context.Context, log *slog.Logger) {
-	warnUmask(ctx, log, syscall.Umask(requiredUmask))
-}
 
 func warnUmask(ctx context.Context, log *slog.Logger, old int) {
 	if old&^requiredUmask != 0 {

--- a/lib/tbot/service_identity_output.go
+++ b/lib/tbot/service_identity_output.go
@@ -310,7 +310,7 @@ func renderSSHConfig(
 
 	executablePath, err := getExecutablePath()
 	if errors.Is(err, autoupdate.ErrUnstableExecutable) {
-		log.WarnContext(ctx, "ssh_config will be created with an unstable path to the tbot executable. Please fix your Managed Updates installation to prevent instability.")
+		log.WarnContext(ctx, "ssh_config will be created with an unstable path to the tbot executable. Please reinstall tbot with Managed Updates to prevent instability.")
 	} else if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/tbot/service_identity_output.go
+++ b/lib/tbot/service_identity_output.go
@@ -309,7 +309,7 @@ func renderSSHConfig(
 	}
 
 	executablePath, err := getExecutablePath()
-	if errors.Is(err, autoupdate.ErrUnstablePath) {
+	if errors.Is(err, autoupdate.ErrUnstableExecutable) {
 		log.WarnContext(ctx, "ssh_config will be created with an unstable path to the tbot executable. Please fix your Managed Updates installation to prevent instability.")
 	} else if err != nil {
 		return trace.Wrap(err)

--- a/lib/tbot/service_identity_output.go
+++ b/lib/tbot/service_identity_output.go
@@ -21,6 +21,7 @@ package tbot
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"path/filepath"
@@ -31,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	autoupdate "github.com/gravitational/teleport/lib/autoupdate/agent"
 	"github.com/gravitational/teleport/lib/config/openssh"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tbot/bot"
@@ -307,7 +309,9 @@ func renderSSHConfig(
 	}
 
 	executablePath, err := getExecutablePath()
-	if err != nil {
+	if errors.Is(err, autoupdate.ErrUnstablePath) {
+		log.WarnContext(ctx, "ssh_config will be created with an unstable path to the tbot executable. Please fix your Managed Updates installation to prevent instability.")
+	} else if err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/tbot/service_kubernetes_output.go
+++ b/lib/tbot/service_kubernetes_output.go
@@ -266,7 +266,7 @@ func (s *KubernetesOutputService) render(
 		}
 	} else {
 		executablePath, err := s.executablePath()
-		if errors.Is(err, autoupdate.ErrUnstablePath) {
+		if errors.Is(err, autoupdate.ErrUnstableExecutable) {
 			s.log.WarnContext(ctx, "Kubernetes template will be rendered with an unstable path to the tbot executable. Please fix your Managed Updates installation to prevent instability.")
 		} else if err != nil {
 			return trace.Wrap(err)

--- a/lib/tbot/service_kubernetes_output.go
+++ b/lib/tbot/service_kubernetes_output.go
@@ -267,7 +267,7 @@ func (s *KubernetesOutputService) render(
 	} else {
 		executablePath, err := s.executablePath()
 		if errors.Is(err, autoupdate.ErrUnstableExecutable) {
-			s.log.WarnContext(ctx, "Kubernetes template will be rendered with an unstable path to the tbot executable. Please fix your Managed Updates installation to prevent instability.")
+			s.log.WarnContext(ctx, "Kubernetes template will be rendered with an unstable path to the tbot executable. Please reinstall tbot with Managed Updates to prevent instability.")
 		} else if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/tbot/service_kubernetes_output.go
+++ b/lib/tbot/service_kubernetes_output.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -36,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	autoupdate "github.com/gravitational/teleport/lib/autoupdate/agent"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -264,7 +266,9 @@ func (s *KubernetesOutputService) render(
 		}
 	} else {
 		executablePath, err := s.executablePath()
-		if err != nil {
+		if errors.Is(err, autoupdate.ErrUnstablePath) {
+			s.log.WarnContext(ctx, "Kubernetes template will be rendered with an unstable path to the tbot executable. Please fix your Managed Updates installation to prevent instability.")
+		} else if err != nil {
 			return trace.Wrap(err)
 		}
 

--- a/lib/tbot/service_kubernetes_v2_output.go
+++ b/lib/tbot/service_kubernetes_v2_output.go
@@ -307,7 +307,7 @@ func (s *KubernetesV2OutputService) render(
 	} else {
 		executablePath, err := s.executablePath()
 		if errors.Is(err, autoupdate.ErrUnstableExecutable) {
-			s.log.WarnContext(ctx, "Kubernetes template will be rendered with an unstable path to the tbot executable. Please fix your Managed Updates installation to prevent instability.")
+			s.log.WarnContext(ctx, "Kubernetes template will be rendered with an unstable path to the tbot executable. Please reinstall tbot with Managed Updates to prevent instability.")
 		} else if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/tbot/service_kubernetes_v2_output.go
+++ b/lib/tbot/service_kubernetes_v2_output.go
@@ -23,6 +23,7 @@ import (
 	"cmp"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"log/slog"
 	"path/filepath"
@@ -37,6 +38,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	autoupdate "github.com/gravitational/teleport/lib/autoupdate/agent"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -304,7 +306,9 @@ func (s *KubernetesV2OutputService) render(
 		}
 	} else {
 		executablePath, err := s.executablePath()
-		if err != nil {
+		if errors.Is(err, autoupdate.ErrUnstablePath) {
+			s.log.WarnContext(ctx, "Kubernetes template will be rendered with an unstable path to the tbot executable. Please fix your Managed Updates installation to prevent instability.")
+		} else if err != nil {
 			return trace.Wrap(err)
 		}
 

--- a/lib/tbot/service_kubernetes_v2_output.go
+++ b/lib/tbot/service_kubernetes_v2_output.go
@@ -306,7 +306,7 @@ func (s *KubernetesV2OutputService) render(
 		}
 	} else {
 		executablePath, err := s.executablePath()
-		if errors.Is(err, autoupdate.ErrUnstablePath) {
+		if errors.Is(err, autoupdate.ErrUnstableExecutable) {
 			s.log.WarnContext(ctx, "Kubernetes template will be rendered with an unstable path to the tbot executable. Please fix your Managed Updates installation to prevent instability.")
 		} else if err != nil {
 			return trace.Wrap(err)

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -413,7 +413,7 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 				proxyPingCache:    proxyPingCache,
 				reloadBroadcaster: reloadBroadcaster,
 				resolver:          resolver,
-				executablePath:    agent.StablePath,
+				executablePath:    agent.StableExecutable,
 			}
 			svc.log = b.log.With(
 				teleport.ComponentKey, teleport.Component(componentTBot, "svc", svc.String()),
@@ -428,7 +428,7 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 				proxyPingCache:    proxyPingCache,
 				reloadBroadcaster: reloadBroadcaster,
 				resolver:          resolver,
-				executablePath:    agent.StablePath,
+				executablePath:    agent.StableExecutable,
 			}
 			svc.log = b.log.With(
 				teleport.ComponentKey, teleport.Component(componentTBot, "svc", svc.String()),
@@ -504,7 +504,7 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 				getBotIdentity:    b.botIdentitySvc.GetIdentity,
 				reloadBroadcaster: reloadBroadcaster,
 				resolver:          resolver,
-				executablePath:    agent.StablePath,
+				executablePath:    agent.StableExecutable,
 				alpnUpgradeCache:  alpnUpgradeCache,
 				proxyPingCache:    proxyPingCache,
 			}

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -44,6 +44,7 @@ import (
 	apitracing "github.com/gravitational/teleport/api/observability/tracing"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/autoupdate/agent"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -412,7 +413,7 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 				proxyPingCache:    proxyPingCache,
 				reloadBroadcaster: reloadBroadcaster,
 				resolver:          resolver,
-				executablePath:    os.Executable,
+				executablePath:    agent.StablePath,
 			}
 			svc.log = b.log.With(
 				teleport.ComponentKey, teleport.Component(componentTBot, "svc", svc.String()),
@@ -427,7 +428,7 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 				proxyPingCache:    proxyPingCache,
 				reloadBroadcaster: reloadBroadcaster,
 				resolver:          resolver,
-				executablePath:    os.Executable,
+				executablePath:    agent.StablePath,
 			}
 			svc.log = b.log.With(
 				teleport.ComponentKey, teleport.Component(componentTBot, "svc", svc.String()),
@@ -503,7 +504,7 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 				getBotIdentity:    b.botIdentitySvc.GetIdentity,
 				reloadBroadcaster: reloadBroadcaster,
 				resolver:          resolver,
-				executablePath:    os.Executable,
+				executablePath:    agent.StablePath,
 				alpnUpgradeCache:  alpnUpgradeCache,
 				proxyPingCache:    proxyPingCache,
 			}

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -44,7 +44,7 @@ import (
 	apitracing "github.com/gravitational/teleport/api/observability/tracing"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authclient"
-	"github.com/gravitational/teleport/lib/autoupdate/agent"
+	autoupdate "github.com/gravitational/teleport/lib/autoupdate/agent"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -413,7 +413,7 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 				proxyPingCache:    proxyPingCache,
 				reloadBroadcaster: reloadBroadcaster,
 				resolver:          resolver,
-				executablePath:    agent.StableExecutable,
+				executablePath:    autoupdate.StableExecutable,
 			}
 			svc.log = b.log.With(
 				teleport.ComponentKey, teleport.Component(componentTBot, "svc", svc.String()),
@@ -428,7 +428,7 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 				proxyPingCache:    proxyPingCache,
 				reloadBroadcaster: reloadBroadcaster,
 				resolver:          resolver,
-				executablePath:    agent.StableExecutable,
+				executablePath:    autoupdate.StableExecutable,
 			}
 			svc.log = b.log.With(
 				teleport.ComponentKey, teleport.Component(componentTBot, "svc", svc.String()),
@@ -504,7 +504,7 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 				getBotIdentity:    b.botIdentitySvc.GetIdentity,
 				reloadBroadcaster: reloadBroadcaster,
 				resolver:          resolver,
-				executablePath:    agent.StableExecutable,
+				executablePath:    autoupdate.StableExecutable,
 				alpnUpgradeCache:  alpnUpgradeCache,
 				proxyPingCache:    proxyPingCache,
 			}

--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
+	autoupdate "github.com/gravitational/teleport/lib/autoupdate/agent"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/observability/tracing"
 	"github.com/gravitational/teleport/lib/tbot"
@@ -263,7 +264,7 @@ func Run(args []string, stdout io.Writer) error {
 		tpm.PrintQuery(query, globalCfg.Debug, os.Stdout)
 		return nil
 	case installSystemdCmdStr:
-		return installSystemdCmdFn(ctx, log, globalCfg.ConfigPath, os.Executable, os.Stdout)
+		return installSystemdCmdFn(ctx, log, globalCfg.ConfigPath, autoupdate.StableExecutable, os.Stdout)
 	}
 
 	// Attempt to run each new-style command.

--- a/tool/tbot/systemd.go
+++ b/tool/tbot/systemd.go
@@ -32,6 +32,8 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
+
+	autoupdate "github.com/gravitational/teleport/lib/autoupdate/agent"
 )
 
 type onInstallSystemdCmdFunc func(
@@ -118,7 +120,9 @@ func onInstallSystemdCmd(
 	}
 
 	tbotPath, err := getExecutablePath()
-	if err != nil {
+	if errors.Is(err, autoupdate.ErrUnstableExecutable) {
+		log.WarnContext(ctx, "Systemd template will be rendered with an unstable path to the tbot executable. Please reinstall tbot with Managed Updates to ensure this service continues to work after an update.")
+	} else if err != nil {
 		return trace.Wrap(err, "determining path to current executable")
 	}
 

--- a/tool/tbot/systemd.go
+++ b/tool/tbot/systemd.go
@@ -121,7 +121,7 @@ func onInstallSystemdCmd(
 
 	tbotPath, err := getExecutablePath()
 	if errors.Is(err, autoupdate.ErrUnstableExecutable) {
-		log.WarnContext(ctx, "Systemd template will be rendered with an unstable path to the tbot executable. Please reinstall tbot with Managed Updates to ensure this service continues to work after an update.")
+		log.WarnContext(ctx, "Systemd template will be rendered with an unstable path to the tbot executable. Please adjust the service to use a stable path instead.")
 	} else if err != nil {
 		return trace.Wrap(err, "determining path to current executable")
 	}


### PR DESCRIPTION
tbot generates ssh_config and kubeconfig files that include a path back to tbot. When tbot is updated with `teleport-update`, these paths can break until tbot rewrites the configuration file.

For example:
```
 ProxyCommand '/opt/teleport/default/versions/v1.2.3/bin/tbot' ssh-proxy-command --destination-dir='/opt/machine-id' --proxy-server='example.com:443' --cluster='example.com' --tls-routing --no-connection-upgrade --resume --user=%r --host=%h --port=%p
```

This PR ensures the paths are stable when the tbot binary is managed by `teleport-update`.

---

changelog: teleport-update: stabilize binary paths in generated tbot config

---

The `teleport-update` binary is used to enable, disable, and trigger automatic Teleport agent updates. The new Managed Updates system manages a local installation of the cluster-specified version of Teleport stored in `/opt/teleport`.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/11856