### PR TITLE
[v15] Log discovery fetcher string representation

### DIFF
--- a/lib/srv/discovery/common/interfaces.go
+++ b/lib/srv/discovery/common/interfaces.go
@@ -20,6 +20,7 @@ package common
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gravitational/teleport/api/types"
 )
@@ -35,4 +36,6 @@ type Fetcher interface {
 	FetcherType() string
 	// Cloud returns the cloud the fetcher is operating.
 	Cloud() string
+
+	fmt.Stringer
 }

--- a/lib/srv/discovery/common/watcher.go
+++ b/lib/srv/discovery/common/watcher.go
@@ -155,9 +155,9 @@ func (w *Watcher) fetchAndSend() {
 				// not others. This is acceptable, so make a debug log instead
 				// of a warning.
 				if trace.IsAccessDenied(err) || trace.IsNotFound(err) {
-					w.cfg.Log.WithError(err).WithField("fetcher", lFetcher).Debugf("Skipped fetcher for %s at %s.", lFetcher.ResourceType(), lFetcher.Cloud())
+					w.cfg.Log.WithError(err).WithField("fetcher", lFetcher.String()).Debugf("Skipped fetcher for %s at %s.", lFetcher.ResourceType(), lFetcher.Cloud())
 				} else {
-					w.cfg.Log.WithError(err).WithField("fetcher", lFetcher).Warnf("Unable to fetch resources for %s at %s.", lFetcher.ResourceType(), lFetcher.Cloud())
+					w.cfg.Log.WithError(err).WithField("fetcher", lFetcher.String()).Warnf("Unable to fetch resources for %s at %s.", lFetcher.ResourceType(), lFetcher.Cloud())
 				}
 				// never return the error otherwise it will impact other watchers.
 				return nil

--- a/lib/srv/discovery/common/watcher_test.go
+++ b/lib/srv/discovery/common/watcher_test.go
@@ -152,6 +152,10 @@ type mockFetcher struct {
 	noAuth       bool
 }
 
+func (m *mockFetcher) String() string {
+	return "mock-fetcher"
+}
+
 func (m *mockFetcher) Get(ctx context.Context) (types.ResourcesWithLabels, error) {
 	if m.noAuth {
 		return nil, trace.AccessDenied("access denied")


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/54071 to branch/v15

Changelog: reduce log spam in discovery service error messaging