### PR TITLE
Convert roles to new in memory cache collection

### DIFF
--- a/api/types/role.go
+++ b/api/types/role.go
@@ -298,6 +298,8 @@ type Role interface {
 	// GetIdentityCenterAccountAssignments sets the allow or deny Account
 	// Assignments for the role
 	SetIdentityCenterAccountAssignments(RoleConditionType, []IdentityCenterAccountAssignment)
+	// Clone creats a copy of the role.
+	Clone() Role
 }
 
 // NewRole constructs new standard V7 role.
@@ -2138,6 +2140,10 @@ func (r *RoleV6) SetIdentityCenterAccountAssignments(rct RoleConditionType, assi
 		cond = &r.Spec.Allow
 	}
 	cond.AccountAssignments = assignments
+}
+
+func (r *RoleV6) Clone() Role {
+	return utils.CloneProtoMsg(r)
 }
 
 // LabelMatcherKinds is the complete list of resource kinds that support label

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -2139,55 +2139,6 @@ func (c *Cache) GetInstallers(ctx context.Context) ([]types.Installer, error) {
 	return inst, trace.Wrap(err)
 }
 
-// GetRoles is a part of auth.Cache implementation
-func (c *Cache) GetRoles(ctx context.Context) ([]types.Role, error) {
-	ctx, span := c.Tracer.Start(ctx, "cache/GetRoles")
-	defer span.End()
-
-	rg, err := readLegacyCollectionCache(c, c.legacyCacheCollections.roles)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	defer rg.Release()
-	return rg.reader.GetRoles(ctx)
-}
-
-// ListRoles is a paginated role getter.
-func (c *Cache) ListRoles(ctx context.Context, req *proto.ListRolesRequest) (*proto.ListRolesResponse, error) {
-	ctx, span := c.Tracer.Start(ctx, "cache/ListRoles")
-	defer span.End()
-
-	rg, err := readLegacyCollectionCache(c, c.legacyCacheCollections.roles)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	defer rg.Release()
-	return rg.reader.ListRoles(ctx, req)
-}
-
-// GetRole is a part of auth.Cache implementation
-func (c *Cache) GetRole(ctx context.Context, name string) (types.Role, error) {
-	ctx, span := c.Tracer.Start(ctx, "cache/GetRole")
-	defer span.End()
-
-	rg, err := readLegacyCollectionCache(c, c.legacyCacheCollections.roles)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	defer rg.Release()
-	role, err := rg.reader.GetRole(ctx, name)
-	if trace.IsNotFound(err) && rg.IsCacheRead() {
-		// release read lock early
-		rg.Release()
-		// fallback is sane because method is never used
-		// in construction of derivative caches.
-		if role, err := c.Config.Access.GetRole(ctx, name); err == nil {
-			return role, nil
-		}
-	}
-	return role, err
-}
-
 // GetNode finds and returns a node by name and namespace.
 func (c *Cache) GetNode(ctx context.Context, namespace, name string) (types.Server, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/GetNode")

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -1445,43 +1445,6 @@ func TestClusterName(t *testing.T) {
 	require.Empty(t, cmp.Diff(outName, clusterName, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 }
 
-// TestRoles tests caching of roles
-func TestRoles(t *testing.T) {
-	t.Parallel()
-
-	p := newTestPack(t, ForNode)
-	t.Cleanup(p.Close)
-
-	testResources(t, p, testFuncs[types.Role]{
-		newResource: func(name string) (types.Role, error) {
-			return types.NewRole("role1", types.RoleSpecV6{
-				Options: types.RoleOptions{
-					MaxSessionTTL: types.Duration(time.Hour),
-				},
-				Allow: types.RoleConditions{
-					Logins:     []string{"root", "bob"},
-					NodeLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
-				},
-				Deny: types.RoleConditions{},
-			})
-		},
-		create: func(ctx context.Context, role types.Role) error {
-			_, err := p.accessS.UpsertRole(ctx, role)
-			return err
-		},
-		list:      p.accessS.GetRoles,
-		cacheGet:  p.cache.GetRole,
-		cacheList: p.cache.GetRoles,
-		update: func(ctx context.Context, role types.Role) error {
-			_, err := p.accessS.UpsertRole(ctx, role)
-			return err
-		},
-		deleteAll: func(ctx context.Context) error {
-			return p.accessS.DeleteAllRoles(ctx)
-		},
-	})
-}
-
 // TestTunnelConnections tests tunnel connections caching
 func TestTunnelConnections(t *testing.T) {
 	t.Parallel()

--- a/lib/cache/cert_authority.go
+++ b/lib/cache/cert_authority.go
@@ -27,6 +27,8 @@ import (
 	"github.com/gravitational/teleport/lib/utils/sortcache"
 )
 
+const certAuthorityStoreIDIndex = "id"
+
 func newCertAuthorityCollection(t services.Trust, w types.WatchKind) (*collection[types.CertAuthority], error) {
 	if t == nil {
 		return nil, trace.BadParameter("missing parameter Trust")
@@ -37,7 +39,7 @@ func newCertAuthorityCollection(t services.Trust, w types.WatchKind) (*collectio
 
 	return &collection[types.CertAuthority]{
 		store: newStore(map[string]func(types.CertAuthority) string{
-			"id": func(ca types.CertAuthority) string {
+			certAuthorityStoreIDIndex: func(ca types.CertAuthority) string {
 				return string(ca.GetType()) + "/" + ca.GetID().DomainName
 			},
 		}),
@@ -105,7 +107,7 @@ func (c *Cache) GetCertAuthority(ctx context.Context, id types.CertAuthID, loadS
 	defer rg.Release()
 
 	if rg.ReadCache() {
-		ca, err := rg.store.get("id", string(id.Type)+"/"+id.DomainName)
+		ca, err := rg.store.get(certAuthorityStoreIDIndex, string(id.Type)+"/"+id.DomainName)
 		if err != nil {
 			// release read lock early
 			rg.Release()
@@ -163,7 +165,7 @@ func (c *Cache) GetCertAuthorities(ctx context.Context, caType types.CertAuthTyp
 
 	if rg.ReadCache() {
 		cas := make([]types.CertAuthority, 0, c.collections.certAuthorities.store.len())
-		for ca := range rg.store.resources("id", string(caType), sortcache.NextKey(string(caType))) {
+		for ca := range rg.store.resources(certAuthorityStoreIDIndex, string(caType), sortcache.NextKey(string(caType))) {
 			if loadSigningKeys {
 				cas = append(cas, ca.Clone())
 			} else {

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -51,6 +51,7 @@ type collections struct {
 	staticTokens    *collection[types.StaticTokens]
 	certAuthorities *collection[types.CertAuthority]
 	users           *collection[types.User]
+	roles           *collection[types.Role]
 }
 
 // setupCollections ensures that the appropriate [collection] is
@@ -89,6 +90,14 @@ func setupCollections(c Config) (*collections, error) {
 
 			out.users = collect
 			out.byKind[resourceKind] = out.users
+		case types.KindRole:
+			collect, err := newRoleCollection(c.Access, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out.roles = collect
+			out.byKind[resourceKind] = out.roles
 		}
 	}
 

--- a/lib/cache/role.go
+++ b/lib/cache/role.go
@@ -1,0 +1,162 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+package cache
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+const roleStoreNameIndex = "name"
+
+func newRoleCollection(a services.Access, w types.WatchKind) (*collection[types.Role], error) {
+	if a == nil {
+		return nil, trace.BadParameter("missing parameter Access")
+	}
+
+	return &collection[types.Role]{
+		store: newStore(map[string]func(types.Role) string{
+			roleStoreNameIndex: func(r types.Role) string {
+				return r.GetName()
+			},
+		}),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.Role, error) {
+			return a.GetRoles(ctx)
+		},
+		headerTransform: func(hdr *types.ResourceHeader) types.Role {
+			return &types.RoleV6{
+				Kind:    types.KindRole,
+				Version: types.V7,
+				Metadata: types.Metadata{
+					Name: hdr.Metadata.Name,
+				},
+			}
+		},
+		watch: w,
+	}, nil
+}
+
+// GetRoles is a part of auth.Cache implementation
+func (c *Cache) GetRoles(ctx context.Context) ([]types.Role, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetRoles")
+	defer span.End()
+
+	rg, err := acquireReadGuard(c, c.collections.roles)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+
+	if !rg.ReadCache() {
+		roles, err := c.Config.Access.GetRoles(ctx)
+		return roles, trace.Wrap(err)
+	}
+
+	roles := make([]types.Role, 0, rg.store.len())
+	for r := range rg.store.resources(roleStoreNameIndex, "", "") {
+		roles = append(roles, r.Clone())
+	}
+
+	return roles, nil
+}
+
+// ListRoles is a paginated role getter.
+func (c *Cache) ListRoles(ctx context.Context, req *proto.ListRolesRequest) (*proto.ListRolesResponse, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/ListRoles")
+	defer span.End()
+
+	rg, err := acquireReadGuard(c, c.collections.roles)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+
+	if !rg.ReadCache() {
+		resp, err := c.Config.Access.ListRoles(ctx, req)
+		return resp, trace.Wrap(err)
+	}
+
+	// Match the page sizing behavior from backend reads.
+	pageSize := int(req.Limit)
+	if pageSize == 0 {
+		pageSize = 100
+	}
+
+	const maxPageSize = 16_000
+	if pageSize > maxPageSize {
+		return nil, trace.BadParameter("page size of %d is too large", pageSize)
+	}
+
+	var resp proto.ListRolesResponse
+	for r := range rg.store.resources(roleStoreNameIndex, req.StartKey, "") {
+		rv6, ok := r.(*types.RoleV6)
+		if !ok {
+			continue
+		}
+
+		if req.Filter != nil && !req.Filter.Match(rv6) {
+			continue
+		}
+
+		if len(resp.Roles) == pageSize {
+			resp.NextKey = r.GetName()
+			break
+		}
+
+		resp.Roles = append(resp.Roles, r.Clone().(*types.RoleV6))
+
+	}
+	return &resp, nil
+}
+
+// GetRole is a part of auth.Cache implementation
+func (c *Cache) GetRole(ctx context.Context, name string) (types.Role, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetRole")
+	defer span.End()
+
+	rg, err := acquireReadGuard(c, c.collections.roles)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+
+	if !rg.ReadCache() {
+		role, err := c.Config.Access.GetRole(ctx, name)
+		return role, trace.Wrap(err)
+	}
+
+	r, err := rg.store.get("name", name)
+	if err != nil {
+		// release read lock early
+		rg.Release()
+
+		// fallback is sane because method is never used
+		// in construction of derivative caches.
+		if trace.IsNotFound(err) {
+			if role, err := c.Config.Access.GetRole(ctx, name); err == nil {
+				return role, nil
+			}
+		}
+		return nil, trace.Wrap(err)
+	}
+
+	return r.Clone(), nil
+}

--- a/lib/cache/role_test.go
+++ b/lib/cache/role_test.go
@@ -1,0 +1,138 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/types"
+)
+
+// TestRoles tests caching of roles
+func TestRoles(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForNode)
+	t.Cleanup(p.Close)
+
+	t.Run("GetRoles", func(t *testing.T) {
+		testResources(t, p, testFuncs[types.Role]{
+			newResource: func(name string) (types.Role, error) {
+				return types.NewRole("role1", types.RoleSpecV6{
+					Options: types.RoleOptions{
+						MaxSessionTTL: types.Duration(time.Hour),
+					},
+					Allow: types.RoleConditions{
+						Logins:     []string{"root", "bob"},
+						NodeLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+					},
+					Deny: types.RoleConditions{},
+				})
+			},
+			create: func(ctx context.Context, role types.Role) error {
+				_, err := p.accessS.UpsertRole(ctx, role)
+				return err
+			},
+			list:      p.accessS.GetRoles,
+			cacheGet:  p.cache.GetRole,
+			cacheList: p.cache.GetRoles,
+			update: func(ctx context.Context, role types.Role) error {
+				_, err := p.accessS.UpsertRole(ctx, role)
+				return err
+			},
+			deleteAll: func(ctx context.Context) error {
+				return p.accessS.DeleteAllRoles(ctx)
+			},
+		})
+	})
+
+	t.Run("ListRoles", func(t *testing.T) {
+		testResources(t, p, testFuncs[types.Role]{
+			newResource: func(name string) (types.Role, error) {
+				return types.NewRole("role1", types.RoleSpecV6{
+					Options: types.RoleOptions{
+						MaxSessionTTL: types.Duration(time.Hour),
+					},
+					Allow: types.RoleConditions{
+						Logins:     []string{"root", "bob"},
+						NodeLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+					},
+					Deny: types.RoleConditions{},
+				})
+			},
+			create: func(ctx context.Context, role types.Role) error {
+				_, err := p.accessS.UpsertRole(ctx, role)
+				return err
+			},
+			list: func(ctx context.Context) ([]types.Role, error) {
+				var out []types.Role
+				req := &proto.ListRolesRequest{}
+				for {
+					resp, err := p.accessS.ListRoles(ctx, req)
+					if err != nil {
+						return nil, trace.Wrap(err)
+					}
+
+					for _, r := range resp.Roles {
+						out = append(out, r)
+					}
+
+					req.StartKey = resp.NextKey
+					if resp.NextKey == "" {
+						break
+					}
+				}
+
+				return out, nil
+			},
+			cacheGet: p.cache.GetRole,
+			cacheList: func(ctx context.Context) ([]types.Role, error) {
+				var out []types.Role
+				req := &proto.ListRolesRequest{}
+				for {
+					resp, err := p.cache.ListRoles(ctx, req)
+					if err != nil {
+						return nil, trace.Wrap(err)
+					}
+
+					for _, r := range resp.Roles {
+						out = append(out, r)
+					}
+
+					req.StartKey = resp.NextKey
+					if resp.NextKey == "" {
+						break
+					}
+				}
+
+				return out, nil
+			},
+			update: func(ctx context.Context, role types.Role) error {
+				_, err := p.accessS.UpsertRole(ctx, role)
+				return err
+			},
+			deleteAll: func(ctx context.Context) error {
+				return p.accessS.DeleteAllRoles(ctx)
+			},
+		})
+	})
+
+}

--- a/lib/cache/static_tokens.go
+++ b/lib/cache/static_tokens.go
@@ -25,6 +25,8 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 )
 
+const staticTokensStoreNameIndex = "name"
+
 func newStaticTokensCollection(c services.ClusterConfiguration, w types.WatchKind) (*collection[types.StaticTokens], error) {
 	if c == nil {
 		return nil, trace.BadParameter("missing parameter ClusterConfig")
@@ -32,7 +34,7 @@ func newStaticTokensCollection(c services.ClusterConfiguration, w types.WatchKin
 
 	return &collection[types.StaticTokens]{
 		store: newStore(map[string]func(types.StaticTokens) string{
-			"name": func(u types.StaticTokens) string {
+			staticTokensStoreNameIndex: func(u types.StaticTokens) string {
 				return u.GetName()
 			},
 		}),
@@ -69,7 +71,7 @@ func (c *Cache) GetStaticTokens() (types.StaticTokens, error) {
 	defer rg.Release()
 
 	if rg.ReadCache() {
-		st, err := rg.store.get("name", types.MetaNameStaticTokens)
+		st, err := rg.store.get(staticTokensStoreNameIndex, types.MetaNameStaticTokens)
 		return st.Clone(), trace.Wrap(err)
 	}
 

--- a/lib/cache/users.go
+++ b/lib/cache/users.go
@@ -29,6 +29,8 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 )
 
+const userStoreNameIndex = "name"
+
 func newUserCollection(u services.UsersService, w types.WatchKind) (*collection[types.User], error) {
 	if u == nil {
 		return nil, trace.BadParameter("missing parameter UsersService")
@@ -36,7 +38,7 @@ func newUserCollection(u services.UsersService, w types.WatchKind) (*collection[
 
 	return &collection[types.User]{
 		store: newStore(map[string]func(types.User) string{
-			"name": func(u types.User) string {
+			userStoreNameIndex: func(u types.User) string {
 				return u.GetName()
 			},
 		}),
@@ -76,7 +78,7 @@ func (c *Cache) GetUser(ctx context.Context, name string, withSecrets bool) (typ
 		return user, trace.Wrap(err)
 	}
 
-	u, err := rg.store.get("name", name)
+	u, err := rg.store.get(userStoreNameIndex, name)
 	if err != nil {
 		// release read lock early
 		rg.Release()
@@ -118,8 +120,8 @@ func (c *Cache) GetUsers(ctx context.Context, withSecrets bool) ([]types.User, e
 		return users, trace.Wrap(err)
 	}
 
-	users := make([]types.User, 0, c.collections.users.store.len())
-	for u := range rg.store.resources("name", "", "") {
+	users := make([]types.User, 0, rg.store.len())
+	for u := range rg.store.resources(userStoreNameIndex, "", "") {
 		if withSecrets {
 			users = append(users, u.Clone())
 		} else {
@@ -158,7 +160,7 @@ func (c *Cache) ListUsers(ctx context.Context, req *userspb.ListUsersRequest) (*
 	}
 
 	var resp userspb.ListUsersResponse
-	for u := range rg.store.resources("name", req.PageToken, "") {
+	for u := range rg.store.resources(userStoreNameIndex, req.PageToken, "") {
 		uv2, ok := u.(*types.UserV2)
 		if !ok {
 			continue


### PR DESCRIPTION
Moves roles to the new cache collection scheme that was introduced in #52210. No additional functionality changes have been made here. This should be a purely mechanical translation to the new internal caching machinery.