### PR TITLE
Convert auth servers to new in memory cache collection

### DIFF
--- a/lib/cache/auth_server.go
+++ b/lib/cache/auth_server.go
@@ -1,0 +1,79 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+package cache
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+const authServerStoreNameIndex = "name"
+
+func newAuthServerCollection(p services.Presence, w types.WatchKind) (*collection[types.Server], error) {
+	if p == nil {
+		return nil, trace.BadParameter("missing parameter Presence")
+	}
+
+	return &collection[types.Server]{
+		store: newStore(map[string]func(types.Server) string{
+			authServerStoreNameIndex: func(u types.Server) string {
+				return u.GetName()
+			},
+		}),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.Server, error) {
+			servers, err := p.GetAuthServers()
+			return servers, trace.Wrap(err)
+		},
+		headerTransform: func(hdr *types.ResourceHeader) types.Server {
+			return &types.ServerV2{
+				Kind:    types.KindAuthServer,
+				Version: types.V2,
+				Metadata: types.Metadata{
+					Name: hdr.GetName(),
+				},
+			}
+		},
+		watch: w,
+	}, nil
+}
+
+// GetAuthServers returns a list of registered servers
+func (c *Cache) GetAuthServers() ([]types.Server, error) {
+	_, span := c.Tracer.Start(context.TODO(), "cache/GetAuthServers")
+	defer span.End()
+
+	rg, err := acquireReadGuard(c, c.collections.authServers)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+
+	if !rg.ReadCache() {
+		servers, err := c.Config.Presence.GetAuthServers()
+		return servers, trace.Wrap(err)
+	}
+
+	servers := make([]types.Server, 0, rg.store.len())
+	for s := range rg.store.resources(authServerStoreNameIndex, "", "") {
+		servers = append(servers, s.DeepCopy())
+	}
+
+	return servers, nil
+}

--- a/lib/cache/auth_server_test.go
+++ b/lib/cache/auth_server_test.go
@@ -1,0 +1,57 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+// TestAuthServers tests auth servers cache
+func TestAuthServers(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForProxy)
+	t.Cleanup(p.Close)
+
+	testResources(t, p, testFuncs[types.Server]{
+		newResource: func(name string) (types.Server, error) {
+			return &types.ServerV2{
+				Kind:    types.KindAuthServer,
+				Version: types.V2,
+				Metadata: types.Metadata{
+					Name: name,
+				},
+				Spec: types.ServerSpecV2{
+					Addr: "127.0.0.1:2022",
+				},
+			}, nil
+		},
+		create: p.presenceS.UpsertAuthServer,
+		list: func(_ context.Context) ([]types.Server, error) {
+			return p.presenceS.GetAuthServers()
+		},
+		cacheList: func(_ context.Context) ([]types.Server, error) {
+			return p.cache.GetAuthServers()
+		},
+		update: p.presenceS.UpsertAuthServer,
+		deleteAll: func(_ context.Context) error {
+			return p.presenceS.DeleteAllAuthServers()
+		},
+	})
+}

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -2195,19 +2195,6 @@ func (c *Cache) getNodesWithTTLCache(ctx context.Context, svc nodeGetter, namesp
 	return clonedNodes, trace.Wrap(err)
 }
 
-// GetAuthServers returns a list of registered servers
-func (c *Cache) GetAuthServers() ([]types.Server, error) {
-	_, span := c.Tracer.Start(context.TODO(), "cache/GetAuthServers")
-	defer span.End()
-
-	rg, err := readLegacyCollectionCache(c, c.legacyCacheCollections.authServers)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	defer rg.Release()
-	return rg.reader.GetAuthServers()
-}
-
 // GetProxies is a part of auth.Cache implementation
 func (c *Cache) GetProxies() ([]types.Server, error) {
 	_, span := c.Tracer.Start(context.TODO(), "cache/GetProxies")

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -1528,31 +1528,6 @@ func TestProxies(t *testing.T) {
 	})
 }
 
-// TestAuthServers tests auth servers cache
-func TestAuthServers(t *testing.T) {
-	t.Parallel()
-
-	p := newTestPack(t, ForProxy)
-	t.Cleanup(p.Close)
-
-	testResources(t, p, testFuncs[types.Server]{
-		newResource: func(name string) (types.Server, error) {
-			return suite.NewServer(types.KindAuthServer, name, "127.0.0.1:2022", apidefaults.Namespace), nil
-		},
-		create: p.presenceS.UpsertAuthServer,
-		list: func(_ context.Context) ([]types.Server, error) {
-			return p.presenceS.GetAuthServers()
-		},
-		cacheList: func(_ context.Context) ([]types.Server, error) {
-			return p.cache.GetAuthServers()
-		},
-		update: p.presenceS.UpsertAuthServer,
-		deleteAll: func(_ context.Context) error {
-			return p.presenceS.DeleteAllAuthServers()
-		},
-	})
-}
-
 // TestRemoteClusters tests remote clusters caching
 func TestRemoteClusters(t *testing.T) {
 	t.Parallel()

--- a/lib/cache/cert_authority.go
+++ b/lib/cache/cert_authority.go
@@ -164,7 +164,7 @@ func (c *Cache) GetCertAuthorities(ctx context.Context, caType types.CertAuthTyp
 	defer rg.Release()
 
 	if rg.ReadCache() {
-		cas := make([]types.CertAuthority, 0, c.collections.certAuthorities.store.len())
+		cas := make([]types.CertAuthority, 0, rg.store.len())
 		for ca := range rg.store.resources(certAuthorityStoreIDIndex, string(caType), sortcache.NextKey(string(caType))) {
 			if loadSigningKeys {
 				cas = append(cas, ca.Clone())

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -52,6 +52,7 @@ type collections struct {
 	certAuthorities *collection[types.CertAuthority]
 	users           *collection[types.User]
 	roles           *collection[types.Role]
+	authServers     *collection[types.Server]
 }
 
 // setupCollections ensures that the appropriate [collection] is
@@ -98,6 +99,14 @@ func setupCollections(c Config) (*collections, error) {
 
 			out.roles = collect
 			out.byKind[resourceKind] = out.roles
+		case types.KindAuthServer:
+			collect, err := newAuthServerCollection(c.Presence, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out.authServers = collect
+			out.byKind[resourceKind] = out.authServers
 		}
 	}
 


### PR DESCRIPTION
Moves auth servers to the new cache collection scheme that was introduced in #52210. No additional functionality changes have been made here. This should be a purely mechanical translation to the new internal caching machinery.