### PR TITLE
Convert proxy servers to new in memory cache collection

### DIFF
--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -2195,19 +2195,6 @@ func (c *Cache) getNodesWithTTLCache(ctx context.Context, svc nodeGetter, namesp
 	return clonedNodes, trace.Wrap(err)
 }
 
-// GetProxies is a part of auth.Cache implementation
-func (c *Cache) GetProxies() ([]types.Server, error) {
-	_, span := c.Tracer.Start(context.TODO(), "cache/GetProxies")
-	defer span.End()
-
-	rg, err := readLegacyCollectionCache(c, c.legacyCacheCollections.proxies)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	defer rg.Release()
-	return rg.reader.GetProxies()
-}
-
 type remoteClustersCacheKey struct {
 	name string
 }

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -1503,31 +1503,6 @@ func TestNodes(t *testing.T) {
 	})
 }
 
-// TestProxies tests proxies cache
-func TestProxies(t *testing.T) {
-	t.Parallel()
-
-	p := newTestPack(t, ForProxy)
-	t.Cleanup(p.Close)
-
-	testResources(t, p, testFuncs[types.Server]{
-		newResource: func(name string) (types.Server, error) {
-			return suite.NewServer(types.KindProxy, name, "127.0.0.1:2022", apidefaults.Namespace), nil
-		},
-		create: p.presenceS.UpsertProxy,
-		list: func(_ context.Context) ([]types.Server, error) {
-			return p.presenceS.GetProxies()
-		},
-		cacheList: func(_ context.Context) ([]types.Server, error) {
-			return p.cache.GetProxies()
-		},
-		update: p.presenceS.UpsertProxy,
-		deleteAll: func(_ context.Context) error {
-			return p.presenceS.DeleteAllProxies()
-		},
-	})
-}
-
 // TestRemoteClusters tests remote clusters caching
 func TestRemoteClusters(t *testing.T) {
 	t.Parallel()

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -53,6 +53,7 @@ type collections struct {
 	users           *collection[types.User]
 	roles           *collection[types.Role]
 	authServers     *collection[types.Server]
+	proxyServers    *collection[types.Server]
 }
 
 // setupCollections ensures that the appropriate [collection] is
@@ -107,6 +108,14 @@ func setupCollections(c Config) (*collections, error) {
 
 			out.authServers = collect
 			out.byKind[resourceKind] = out.authServers
+		case types.KindProxy:
+			collect, err := newProxyServerCollection(c.Presence, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out.proxyServers = collect
+			out.byKind[resourceKind] = out.proxyServers
 		}
 	}
 

--- a/lib/cache/legacy_collections.go
+++ b/lib/cache/legacy_collections.go
@@ -266,15 +266,6 @@ func setupLegacyCollections(c *Cache, watches []types.WatchKind) (*legacyCollect
 				watch: watch,
 			}
 			collections.byKind[resourceKind] = collections.nodes
-		case types.KindProxy:
-			if c.Presence == nil {
-				return nil, trace.BadParameter("missing parameter Presence")
-			}
-			collections.proxies = &genericCollection[types.Server, services.ProxyGetter, proxyExecutor]{
-				cache: c,
-				watch: watch,
-			}
-			collections.byKind[resourceKind] = collections.proxies
 		case types.KindReverseTunnel:
 			if c.Presence == nil {
 				return nil, trace.BadParameter("missing parameter Presence")
@@ -927,35 +918,6 @@ type remoteClusterGetter interface {
 }
 
 var _ executor[types.RemoteCluster, remoteClusterGetter] = remoteClusterExecutor{}
-
-type proxyExecutor struct{}
-
-func (proxyExecutor) getAll(ctx context.Context, cache *Cache, loadSecrets bool) ([]types.Server, error) {
-	return cache.Presence.GetProxies()
-}
-
-func (proxyExecutor) upsert(ctx context.Context, cache *Cache, resource types.Server) error {
-	return cache.presenceCache.UpsertProxy(ctx, resource)
-}
-
-func (proxyExecutor) deleteAll(ctx context.Context, cache *Cache) error {
-	return cache.presenceCache.DeleteAllProxies()
-}
-
-func (proxyExecutor) delete(ctx context.Context, cache *Cache, resource types.Resource) error {
-	return cache.presenceCache.DeleteProxy(ctx, resource.GetName())
-}
-
-func (proxyExecutor) isSingleton() bool { return false }
-
-func (proxyExecutor) getReader(cache *Cache, cacheOK bool) services.ProxyGetter {
-	if cacheOK {
-		return cache.presenceCache
-	}
-	return cache.Config.Presence
-}
-
-var _ executor[types.Server, services.ProxyGetter] = proxyExecutor{}
 
 type nodeExecutor struct{}
 

--- a/lib/cache/proxy_server.go
+++ b/lib/cache/proxy_server.go
@@ -1,0 +1,80 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+const proxyServerStoreNameIndex = "name"
+
+func newProxyServerCollection(p services.Presence, w types.WatchKind) (*collection[types.Server], error) {
+	if p == nil {
+		return nil, trace.BadParameter("missing parameter Presence")
+	}
+
+	return &collection[types.Server]{
+		store: newStore(map[string]func(types.Server) string{
+			proxyServerStoreNameIndex: func(u types.Server) string {
+				return u.GetName()
+			},
+		}),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.Server, error) {
+			servers, err := p.GetProxies()
+			return servers, trace.Wrap(err)
+		},
+		headerTransform: func(hdr *types.ResourceHeader) types.Server {
+			return &types.ServerV2{
+				Kind:    types.KindProxy,
+				Version: types.V2,
+				Metadata: types.Metadata{
+					Name: hdr.GetName(),
+				},
+			}
+		},
+		watch: w,
+	}, nil
+}
+
+// GetProxies is a part of auth.Cache implementation
+func (c *Cache) GetProxies() ([]types.Server, error) {
+	_, span := c.Tracer.Start(context.TODO(), "cache/GetProxies")
+	defer span.End()
+
+	rg, err := acquireReadGuard(c, c.collections.proxyServers)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+
+	if !rg.ReadCache() {
+		servers, err := c.Config.Presence.GetAuthServers()
+		return servers, trace.Wrap(err)
+	}
+
+	servers := make([]types.Server, 0, rg.store.len())
+	for s := range rg.store.resources(proxyServerStoreNameIndex, "", "") {
+		servers = append(servers, s.DeepCopy())
+	}
+
+	return servers, nil
+}

--- a/lib/cache/proxy_server_test.go
+++ b/lib/cache/proxy_server_test.go
@@ -1,0 +1,58 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+// TestProxies tests proxies cache
+func TestProxies(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForProxy)
+	t.Cleanup(p.Close)
+
+	testResources(t, p, testFuncs[types.Server]{
+		newResource: func(name string) (types.Server, error) {
+			return &types.ServerV2{
+				Kind:    types.KindProxy,
+				Version: types.V2,
+				Metadata: types.Metadata{
+					Name: name,
+				},
+				Spec: types.ServerSpecV2{
+					Addr: "127.0.0.1:2022",
+				},
+			}, nil
+		},
+		create: p.presenceS.UpsertProxy,
+		list: func(_ context.Context) ([]types.Server, error) {
+			return p.presenceS.GetProxies()
+		},
+		cacheList: func(_ context.Context) ([]types.Server, error) {
+			return p.cache.GetProxies()
+		},
+		update: p.presenceS.UpsertProxy,
+		deleteAll: func(_ context.Context) error {
+			return p.presenceS.DeleteAllProxies()
+		},
+	})
+}


### PR DESCRIPTION
Moves proxy servers to the new cache collection scheme that was introduced in #52210. No additional functionality changes have been made here. This should be a purely mechanical translation to the new internal caching machinery.