### PR TITLE
[v17] Make preset logic able to add windows desktop labels

### DIFF
--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -796,9 +796,10 @@ func defaultAllowLabels(enterprise bool) map[string]types.RoleConditions {
 			DatabaseRoles:         []string{teleport.TraitInternalDBRolesVariable},
 		},
 		teleport.PresetTerraformProviderRoleName: {
-			AppLabels:      wildcardLabels,
-			DatabaseLabels: wildcardLabels,
-			NodeLabels:     wildcardLabels,
+			AppLabels:            wildcardLabels,
+			DatabaseLabels:       wildcardLabels,
+			NodeLabels:           wildcardLabels,
+			WindowsDesktopLabels: wildcardLabels,
 		},
 	}
 
@@ -949,6 +950,7 @@ func AddRoleDefaults(role types.Role) (types.Role, error) {
 			types.KindDatabaseService,
 			types.KindNode,
 			types.KindUserGroup,
+			types.KindWindowsDesktop,
 		} {
 			var labels types.Labels
 			switch kind {
@@ -962,6 +964,8 @@ func AddRoleDefaults(role types.Role) (types.Role, error) {
 				labels = defaultLabels.NodeLabels
 			case types.KindUserGroup:
 				labels = defaultLabels.GroupLabels
+			case types.KindWindowsDesktop:
+				labels = defaultLabels.WindowsDesktopLabels
 			}
 			labelsUpdated, err := updateAllowLabels(role, kind, labels)
 			if err != nil {

--- a/lib/services/presets_test.go
+++ b/lib/services/presets_test.go
@@ -663,10 +663,7 @@ func TestAddRoleDefaults(t *testing.T) {
 				},
 				Spec: types.RoleSpecV6{
 					Allow: types.RoleConditions{
-						AppLabels:            map[string]apiutils.Strings{types.Wildcard: []string{types.Wildcard}},
-						DatabaseLabels:       map[string]apiutils.Strings{types.Wildcard: []string{types.Wildcard}},
-						NodeLabels:           map[string]apiutils.Strings{types.Wildcard: []string{types.Wildcard}},
-						WindowsDesktopLabels: map[string]apiutils.Strings{types.Wildcard: []string{types.Wildcard}},
+						// Missing all the node/app/database/windows labels here, they should be added
 						Rules: []types.Rule{
 							{
 								Resources: []string{


### PR DESCRIPTION
Backport #54119 to branch/v17

changelog: Fix a bug where the `terraform-provider` preset role to lacked permissions to list Windows Desktops on clusters that got updated from v16 to v17.
