### PR TITLE
Fix Teleport re-execs on Managed Updates installations of Teleport

### DIFF
--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -280,6 +280,7 @@ func (e *localExec) transformSecureCopy() error {
 
 	// for scp requests update the command to execute to launch teleport with
 	// scp parameters just like openssh does.
+	// TODO: execute /proc/self/exec directly instead, to avoid version change.
 	teleportBin, err := autoupdate.StableExecutable()
 	if errors.Is(err, autoupdate.ErrUnstableExecutable) {
 		slog.WarnContext(e.Ctx.CancelContext(), "Re-execution may fail if binary is updated. Please reinstall Teleport with Managed Updates to fix this.")

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -1023,6 +1023,7 @@ func buildCommand(c *ExecCommand, localUser *user.User, tty *os.File, pamEnviron
 	if c.RequestType == sshutils.SubsystemRequest {
 		switch c.Command {
 		case teleport.SFTPSubsystem:
+			// TODO: execute /proc/self/exec directly instead, to avoid version change.
 			executable, err := autoupdate.StableExecutable()
 			if errors.Is(err, autoupdate.ErrUnstableExecutable) {
 				slog.WarnContext(context.Background(), "Re-execution for SFTP may fail if binary is updated. Please reinstall Teleport with Managed Updates to fix this.")
@@ -1210,6 +1211,7 @@ func ConfigureCommand(ctx *ServerContext, extraFiles ...*os.File) (*exec.Cmd, er
 	go copyCommand(ctx, cmdmsg)
 
 	// Find the Teleport executable and its directory on disk.
+	// TODO: execute /proc/self/exec directly instead, to avoid version change.
 	executable, err := autoupdate.StableExecutable()
 	if errors.Is(err, autoupdate.ErrUnstableExecutable) {
 		slog.WarnContext(ctx.CancelContext(), "Re-execution may fail if binary is updated. Please reinstall Teleport with Managed Updates to fix this.")
@@ -1347,6 +1349,7 @@ func CheckHomeDir(localUser *user.User) (bool, error) {
 		return true, nil
 	}
 
+	// TODO: execute /proc/self/exec directly instead, to avoid version change.
 	executable, err := autoupdate.StableExecutable()
 	if errors.Is(err, autoupdate.ErrUnstableExecutable) {
 		slog.WarnContext(context.Background(), "Re-execution may fail if binary is updated. Please reinstall Teleport with Managed Updates to fix this.")
@@ -1387,6 +1390,7 @@ func CheckHomeDir(localUser *user.User) (bool, error) {
 
 // Spawns a process with the given credentials, outliving the context.
 func (o *osWrapper) newParker(ctx context.Context, credential syscall.Credential) error {
+	// TODO: execute /proc/self/exec directly instead, to avoid version change.
 	executable, err := autoupdate.StableExecutable()
 	if errors.Is(err, autoupdate.ErrUnstableExecutable) {
 		slog.WarnContext(ctx, "Re-execution may fail if binary is updated. Please reinstall Teleport with Managed Updates to fix this.")


### PR DESCRIPTION
As part of https://github.com/gravitational/teleport/pull/54145, we discovered that when Teleport re-execs itself in various scenarios, it may fail to re-exec if the running version has not been restarted or reloaded recently. This is because `os.Executable()` resolves symlinks.

For example:

Before update:
/opt/teleport/…/v17.4.1/bin/teleport <- /usr/local/bin
/opt/teleport/…/v17.4.0/bin/teleport
os.Executable will return: /opt/teleport/…/v17.4.1/bin/teleport

After an update without a reload:
/opt/teleport/…/v17.4.2/bin/teleport <- /usr/local/bin
/opt/teleport/…/v17.4.1/bin/teleport
os.Executable will return: /opt/teleport/…/v17.4.1/bin/teleport (outdated)

After another update without a reload:
/opt/teleport/…/v17.4.3/bin/teleport <- /usr/local/bin
/opt/teleport/…/v17.4.2/bin/teleport
os.Executable will return: /opt/teleport/…/v17.4.1/bin/teleport (broken)

Various other failure cases are possible if Managed Updates is enabled/disabled while Teleport is running.
Soft reloads are not impacted, as they exec `teleport` off of `PATH`.

This PR fixes various problematic uses of `os.Executable` by switching to `autoupdate.StableExecutable`.
In a future PR, I will introduce a linter rule to prevent this from happening.

The code base contains many other valid usages of `os.Executable`. The only other suspect usage I found was:
https://github.com/gravitational/teleport/blob/master/lib/auditd/auditd_linux.go#L208
However, I believe auditd should receive the path to the running binary.

Note that the current behavior has a bug unrelated to Managed Updates: some uses of os.Executable should be execing `/proc/self/exe` directly, to ensure they exec the same binary running in memory, and not an updated version that could be incompatible. This should be addressed separately, to avoid too many changes in one release, and to expedite the above fix.

---

changelog: teleport-update: stabilize binary paths on teleport re-exec

---

The `teleport-update` binary is used to enable, disable, and trigger automatic Teleport agent updates. The new Managed Updates system manages a local installation of the cluster-specified version of Teleport stored in `/opt/teleport`.

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/11856