### PR TITLE
[v15] Fix docs index page issues

### DIFF
--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -2,18 +2,13 @@
   "docs": [
     {
       "type": "category",
-      "label": "Get Started",
+      "label": "Introduction",
       "collapsible": true,
       "link": {
         "type": "doc",
         "id": "index"
       },
       "items": [
-        {
-          "type": "doc",
-          "label": "Introduction to Teleport",
-          "id": "index"
-        },
         {
           "type": "doc",
           "label": "Get Started",


### PR DESCRIPTION
Backports #53953

- Remove the "Introduction to Teleport" link from the sidebar. There is already one link to the docs index page, the "Get Started" topic link. Rename the section index link to "Introduction" for clarity. This prevents the Introduction page from having a "Next" link to the same page.