### PR TITLE
Avoid protoc invocation in web/packages/teleterm script

### DIFF
--- a/web/packages/teleterm/buf.gen.yaml
+++ b/web/packages/teleterm/buf.gen.yaml
@@ -1,0 +1,31 @@
+version: v2
+
+inputs:
+  - directory: src/sharedProcess/api/proto
+
+clean: true
+
+plugins:
+  - local:
+      - npm
+      - exec
+      - --yes
+      # we're using an exact version so if the package is already available
+      # there's no need to reach out to the registry, even if we could use more
+      # recent dependencies
+      - --prefer-offline
+      # this version should be kept in sync with build.assets/Dockerfile-grpcbox
+      - --package=@protobuf-ts/plugin@2.9.3
+      - --
+      - protoc-gen-ts
+    out: src/sharedProcess/api/protogen
+    opt:
+      # the next time we tweak the ts codegen we should put the options in
+      # alphabetical order
+      - long_type_number
+      - eslint_disable
+      - add_pb_suffix
+      - client_grpc1
+      - server_grpc1
+      - ts_nocheck
+    strategy: all

--- a/web/packages/teleterm/buf.yaml
+++ b/web/packages/teleterm/buf.yaml
@@ -1,0 +1,11 @@
+version: v2
+
+modules:
+  - path: src/sharedProcess/api/proto
+
+lint:
+  use:
+    - MINIMAL
+  ignore_only:
+    PACKAGE_DEFINED:
+      - src/sharedProcess/api/proto/ptyHostService.proto

--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -13,7 +13,7 @@
     "start": "electron-vite dev",
     "build": "electron-vite build",
     "package": "electron-builder build --config electron-builder-config.js --publish never -c.extraMetadata.name=teleport-connect",
-    "generate-grpc-shared": "npx -y --target_arch=x64 --package=@protobuf-ts/plugin@2.9.3 -- protoc -I=src/sharedProcess/api/proto --ts_opt long_type_number,eslint_disable,add_pb_suffix,client_grpc1,server_grpc1,ts_nocheck --ts_out=src/sharedProcess/api/protogen src/sharedProcess/api/proto/*.proto"
+    "generate-grpc-shared": "buf generate"
   },
   "repository": {
     "type": "git",

--- a/web/packages/teleterm/src/sharedProcess/api/proto/ptyHostService.proto
+++ b/web/packages/teleterm/src/sharedProcess/api/proto/ptyHostService.proto
@@ -90,4 +90,3 @@ message PtyEventStartError {
 message PtyCwd {
   string cwd = 1;
 }
-


### PR DESCRIPTION
This PR gets rid of a protoc invocation for the teleterm `ptyHostService.proto` codegen by switching to buf (which should also make it easier to integrate the code generation in the rest of the protobuf codegen in the future).