### PR TITLE
Web: Use `$HOME/.config/teleport` folder for App Access

### DIFF
--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -95,7 +95,7 @@ const cfg = {
   // isPolicyEnabled refers to the Teleport Policy product
   isPolicyEnabled: false,
 
-  configDir: '$HOME/.config',
+  configDir: '$HOME/.config/teleport',
 
   baseUrl: window.location.origin,
 


### PR DESCRIPTION
Instead of using `$HOME/.config` folder, which is the XDG_CONFIG_HOME variable, used by a lot of applications to store their configuration.

If teleport owns this directory, other applications will misbehave and we are not complying with the freedesktop specification https://specifications.freedesktop.org/basedir-spec/latest/

When this folder is not empty, teleport emits a warning:

```
WARNING: The data directory /root/.config is not empty and may contain existing cluster state. Running this configuration is likely a mistake. To join a new cluster, specify an alternate --data-dir or clear the /root/.config directory.
```

This value appears here:
![image](https://github.com/user-attachments/assets/7379ec33-01cf-477d-9a25-da72084f2570)
