### PR TITLE
[v17] Allow env var used for `gitlab` joining to be overridden

### DIFF
--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -515,4 +515,7 @@ const (
 	// joining. The audience tag specifies the optional suffix for the TF_WORKLOAD_IDENTITY_AUDIENCE variable when
 	// specifically using the `terraform` join method.
 	EnvVarTerraformCloudJoinAudienceTag = "TF_TELEPORT_JOIN_AUDIENCE_TAG"
+	// EnvVarTerraformRootCertificates is the environment variable configuring the path the Terraform provider loads its
+	// trusted CA certificates from. This only works for direct auth joining.
+	EnvVarGitlabIDTokenEnvVar = "TF_TELEPORT_GITLAB_ID_TOKEN_ENV_VAR"
 )

--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -515,7 +515,8 @@ const (
 	// joining. The audience tag specifies the optional suffix for the TF_WORKLOAD_IDENTITY_AUDIENCE variable when
 	// specifically using the `terraform` join method.
 	EnvVarTerraformCloudJoinAudienceTag = "TF_TELEPORT_JOIN_AUDIENCE_TAG"
-	// EnvVarTerraformRootCertificates is the environment variable configuring the path the Terraform provider loads its
-	// trusted CA certificates from. This only works for direct auth joining.
+	// EnvVarGitlabIDTokenEnvVar is the environment variable that specifies the name of the environment variable
+	// that contains the GitLab ID token. This can be used to authenticate to multiple Teleport clusters from a single
+	// GitLab CI job.
 	EnvVarGitlabIDTokenEnvVar = "TF_TELEPORT_GITLAB_ID_TOKEN_ENV_VAR"
 )

--- a/docs/pages/reference/terraform-provider/terraform-provider.mdx
+++ b/docs/pages/reference/terraform-provider/terraform-provider.mdx
@@ -172,6 +172,7 @@ This auth method has the following limitations:
 - `cert_base64` (String) Base64 encoded TLS auth certificate. This can also be set with the environment variable `TF_TELEPORT_CERT_BASE64`.
 - `cert_path` (String) Path to Teleport auth certificate file. This can also be set with the environment variable `TF_TELEPORT_CERT`.
 - `dial_timeout_duration` (String) DialTimeout sets timeout when trying to connect to the server. This can also be set with the environment variable `TF_TELEPORT_DIAL_TIMEOUT_DURATION`.
+- `gitlab_id_token_env_var` (String) Environment variable used to fetch the ID token issued by GitLab for the `gitlab` join method. If unset, this defaults to `TBOT_GITLAB_JWT`. This can also be set with the environment variable `TF_TELEPORT_GITLAB_ID_TOKEN_ENV_VAR`.
 - `identity_file` (String, Sensitive) Teleport identity file content. This can also be set with the environment variable `TF_TELEPORT_IDENTITY_FILE`.
 - `identity_file_base64` (String, Sensitive) Teleport identity file content base64 encoded. This can also be set with the environment variable `TF_TELEPORT_IDENTITY_FILE_BASE64`.
 - `identity_file_path` (String) Teleport identity file path. This can also be set with the environment variable `TF_TELEPORT_IDENTITY_FILE_PATH`.

--- a/integrations/terraform/provider/credentials.go
+++ b/integrations/terraform/provider/credentials.go
@@ -522,7 +522,7 @@ See https://goteleport.com/docs/reference/join-methods for more details.`)
 				AudienceTag: audienceTag,
 			},
 			Gitlab: tbotconfig.GitlabOnboardingConfig{
-				EnvVarName: gitlabIDTokenEnvVar,
+				TokenEnvVarName: gitlabIDTokenEnvVar,
 			},
 		},
 		CredentialLifetime: tbotconfig.CredentialLifetime{

--- a/integrations/terraform/provider/credentials.go
+++ b/integrations/terraform/provider/credentials.go
@@ -486,6 +486,7 @@ func (CredentialsFromNativeMachineID) Credentials(ctx context.Context, config pr
 	audienceTag := stringFromConfigOrEnv(config.AudienceTag, constants.EnvVarTerraformCloudJoinAudienceTag, "")
 	addr := stringFromConfigOrEnv(config.Addr, constants.EnvVarTerraformAddress, "")
 	caPath := stringFromConfigOrEnv(config.RootCaPath, constants.EnvVarTerraformRootCertificates, "")
+	gitlabIDTokenEnvVar := stringFromConfigOrEnv(config.GitlabIDTokenEnvVar, constants.EnvVarGitlabIDTokenEnvVar, "")
 
 	if joinMethod == "" {
 		return nil, trace.BadParameter("missing parameter %q or environment variable %q", attributeTerraformJoinMethod, constants.EnvVarTerraformJoinMethod)
@@ -519,6 +520,9 @@ See https://goteleport.com/docs/reference/join-methods for more details.`)
 			JoinMethod: apitypes.JoinMethod(joinMethod),
 			Terraform: tbotconfig.TerraformOnboardingConfig{
 				AudienceTag: audienceTag,
+			},
+			Gitlab: tbotconfig.GitlabOnboardingConfig{
+				EnvVarName: gitlabIDTokenEnvVar,
 			},
 		},
 		CredentialLifetime: tbotconfig.CredentialLifetime{

--- a/integrations/terraform/provider/provider.go
+++ b/integrations/terraform/provider/provider.go
@@ -89,6 +89,9 @@ const (
 	// attributeTerraformJoinAudienceTag is the attribute configuring the audience tag when using the `terraform` join
 	// method.
 	attributeTerraformJoinAudienceTag = "audience_tag"
+	// attributeTerraformGitlabIDTokenEnvVar is the attribute configuring the environment variable used to fetch the ID
+	// token issued by GitLab for the `gitlab` join method. If unset, this defaults to `TBOT_GITLAB_JWT`.
+	attributeTerraformGitlabIDTokenEnvVar = "gitlab_id_token_env_var"
 )
 
 type RetryConfig struct {
@@ -145,6 +148,11 @@ type providerData struct {
 	JoinToken types.String `tfsdk:"join_token"`
 	// AudienceTag is the audience  tag for the `terraform` join method
 	AudienceTag types.String `tfsdk:"audience_tag"`
+	// GitlabIDTokenEnvVar is the environment variable used to fetch the ID
+	// token issued by GitLab for the `gitlab` join method. If unset, this
+	// defaults to `TBOT_GITLAB_JWT`. Useful in cases where multiple Teleport
+	// clusters are managed by the same GitLab job.
+	GitlabIDTokenEnvVar types.String `tfsdk:"gitlab_id_token_env_var"`
 }
 
 // New returns an empty provider struct
@@ -260,6 +268,12 @@ func (p *Provider) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics)
 				Sensitive:   false,
 				Optional:    true,
 				Description: fmt.Sprintf("Name of the optional audience tag used for native Machine ID joining with the `terraform` method. This can also be set with the environment variable `%s`.", constants.EnvVarTerraformCloudJoinAudienceTag),
+			},
+			attributeTerraformGitlabIDTokenEnvVar: {
+				Type:        types.StringType,
+				Sensitive:   false,
+				Optional:    true,
+				Description: fmt.Sprintf("Environment variable used to fetch the ID token issued by GitLab for the `gitlab` join method. If unset, this defaults to `TBOT_GITLAB_JWT`."),
 			},
 		},
 	}, nil

--- a/integrations/terraform/provider/provider.go
+++ b/integrations/terraform/provider/provider.go
@@ -273,7 +273,7 @@ func (p *Provider) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics)
 				Type:        types.StringType,
 				Sensitive:   false,
 				Optional:    true,
-				Description: fmt.Sprintf("Environment variable used to fetch the ID token issued by GitLab for the `gitlab` join method. If unset, this defaults to `TBOT_GITLAB_JWT`."),
+				Description: fmt.Sprintf("Environment variable used to fetch the ID token issued by GitLab for the `gitlab` join method. If unset, this defaults to `TBOT_GITLAB_JWT`. This can also be set with the environment variable `%s`.", constants.EnvVarGitlabIDTokenEnvVar),
 			},
 		},
 	}, nil

--- a/lib/auth/join/join.go
+++ b/lib/auth/join/join.go
@@ -74,6 +74,13 @@ type AzureParams struct {
 	ClientID string
 }
 
+// GitlabParams is the parameters specific to the gitlab join method.
+type GitlabParams struct {
+	// EnvVarName is the name of the environment variable that contains the
+	// IDToken. If unset, this will default to "TBOT_GITLAB_JWT".
+	EnvVarName string
+}
+
 // RegisterParams specifies parameters
 // for first time register operation with auth server
 type RegisterParams struct {
@@ -143,6 +150,8 @@ type RegisterParams struct {
 	// containing TF Cloud's Workload Identity Token when using Terraform Cloud
 	// joining.
 	TerraformCloudAudienceTag string
+	// GitlabParams is the parameters specific to the gitlab join method.
+	GitlabParams GitlabParams
 }
 
 func (r *RegisterParams) checkAndSetDefaults() error {
@@ -230,7 +239,9 @@ func Register(ctx context.Context, params RegisterParams) (result *RegisterResul
 			return nil, trace.Wrap(err)
 		}
 	case types.JoinMethodGitLab:
-		params.IDToken, err = gitlab.NewIDTokenSource(os.Getenv).GetIDToken()
+		params.IDToken, err = gitlab.NewIDTokenSource(gitlab.IDTokenSourceConfig{
+			EnvVarName: params.GitlabParams.EnvVarName,
+		}).GetIDToken()
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/gitlab/token_source_test.go
+++ b/lib/gitlab/token_source_test.go
@@ -70,7 +70,7 @@ func TestIDTokenSource_GetIDToken(t *testing.T) {
 		require.Equal(t, "", tok)
 	})
 
-	t.Run("overriden env value present", func(t *testing.T) {
+	t.Run("overridden env value present", func(t *testing.T) {
 		cfg := makeConfig(
 			t,
 			"OVERRIDDEN",

--- a/lib/gitlab/token_source_test.go
+++ b/lib/gitlab/token_source_test.go
@@ -26,29 +26,60 @@ import (
 )
 
 func TestIDTokenSource_GetIDToken(t *testing.T) {
-	t.Run("value present", func(t *testing.T) {
-		its := &IDTokenSource{
-			getEnv: func(key string) string {
-				if key == "TBOT_GITLAB_JWT" {
-					return "foo"
+	makeConfig := func(
+		t *testing.T,
+		configuredEnvVar string,
+		wantKey string,
+		returnValue string,
+	) IDTokenSourceConfig {
+		return IDTokenSourceConfig{
+			EnvVarName: configuredEnvVar,
+			EnvGetter: func(gotKey string) string {
+				if gotKey == wantKey {
+					return returnValue
 				}
+				t.Errorf("Expected key %q, got %q", wantKey, gotKey)
 				return ""
 			},
 		}
+	}
+	t.Run("value present", func(t *testing.T) {
+		cfg := makeConfig(
+			t,
+			"",
+			"TBOT_GITLAB_JWT",
+			"foo",
+		)
+		its := NewIDTokenSource(cfg)
 		tok, err := its.GetIDToken()
 		require.NoError(t, err)
 		require.Equal(t, "foo", tok)
 	})
 
 	t.Run("value missing", func(t *testing.T) {
-		its := &IDTokenSource{
-			getEnv: func(key string) string {
-				return ""
-			},
-		}
+		cfg := makeConfig(
+			t,
+			"",
+			"TBOT_GITLAB_JWT",
+			"",
+		)
+		its := NewIDTokenSource(cfg)
 		tok, err := its.GetIDToken()
 		require.Error(t, err)
 		require.True(t, trace.IsBadParameter(err))
 		require.Equal(t, "", tok)
+	})
+
+	t.Run("overriden env value present", func(t *testing.T) {
+		cfg := makeConfig(
+			t,
+			"OVERRIDDEN",
+			"OVERRIDDEN",
+			"foo",
+		)
+		its := NewIDTokenSource(cfg)
+		tok, err := its.GetIDToken()
+		require.NoError(t, err)
+		require.Equal(t, "foo", tok)
 	})
 }

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -83,10 +83,10 @@ type TerraformOnboardingConfig struct {
 
 // GitlabOnboardingConfig holds configuration relevant to the "gitlab" join method.
 type GitlabOnboardingConfig struct {
-	// EnvVarName is the name of the environment variable that contains the
+	// TokenEnvVarName is the name of the environment variable that contains the
 	// GitLab ID token. This can be useful to override in cases where a single
 	// gitlab job needs to authenticate to multiple Teleport clusters.
-	EnvVarName string `yaml:"env_var_name,omitempty"`
+	TokenEnvVarName string `yaml:"token_env_var_name,omitempty"`
 }
 
 // OnboardingConfig contains values relevant to how the bot authenticates with

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -81,6 +81,14 @@ type TerraformOnboardingConfig struct {
 	AudienceTag string `yaml:"audience_tag,omitempty"`
 }
 
+// GitlabOnboardingConfig holds configuration relevant to the "gitlab" join method.
+type GitlabOnboardingConfig struct {
+	// EnvVarName is the name of the environment variable that contains the
+	// GitLab ID token. This can be useful to override in cases where a single
+	// gitlab job needs to authenticate to multiple Teleport clusters.
+	EnvVarName string `yaml:"env_var_name,omitempty"`
+}
+
 // OnboardingConfig contains values relevant to how the bot authenticates with
 // the Teleport cluster.
 type OnboardingConfig struct {
@@ -107,6 +115,9 @@ type OnboardingConfig struct {
 
 	// Terraform holds configuration relevant to the `terraform` join method.
 	Terraform TerraformOnboardingConfig `yaml:"terraform,omitempty"`
+
+	// Gitlab holds configuration relevant to the `gitlab` join method.
+	Gitlab GitlabOnboardingConfig `yaml:"gitlab,omitempty"`
 }
 
 // HasToken gives the ability to check if there has been a token value stored

--- a/lib/tbot/config/config_test.go
+++ b/lib/tbot/config/config_test.go
@@ -198,6 +198,13 @@ func TestBotConfig_YAML(t *testing.T) {
 						Symlinks: botfs.SymlinksSecure,
 					},
 				},
+				Onboarding: OnboardingConfig{
+					JoinMethod: "gitlab",
+					TokenValue: "my-gitlab-token",
+					Gitlab: GitlabOnboardingConfig{
+						EnvVarName: "MY_CUSTOM_ENV_VAR",
+					},
+				},
 				FIPS:       true,
 				Debug:      true,
 				Oneshot:    true,

--- a/lib/tbot/config/config_test.go
+++ b/lib/tbot/config/config_test.go
@@ -202,7 +202,7 @@ func TestBotConfig_YAML(t *testing.T) {
 					JoinMethod: "gitlab",
 					TokenValue: "my-gitlab-token",
 					Gitlab: GitlabOnboardingConfig{
-						EnvVarName: "MY_CUSTOM_ENV_VAR",
+						TokenEnvVarName: "MY_CUSTOM_ENV_VAR",
 					},
 				},
 				FIPS:       true,

--- a/lib/tbot/config/testdata/TestBotConfig_YAML/standard_config.golden
+++ b/lib/tbot/config/testdata/TestBotConfig_YAML/standard_config.golden
@@ -1,4 +1,9 @@
 version: v2
+onboarding:
+  token: my-gitlab-token
+  join_method: gitlab
+  gitlab:
+    env_var_name: MY_CUSTOM_ENV_VAR
 storage:
   type: directory
   path: /bot/storage

--- a/lib/tbot/config/testdata/TestBotConfig_YAML/standard_config.golden
+++ b/lib/tbot/config/testdata/TestBotConfig_YAML/standard_config.golden
@@ -3,7 +3,7 @@ onboarding:
   token: my-gitlab-token
   join_method: gitlab
   gitlab:
-    env_var_name: MY_CUSTOM_ENV_VAR
+    token_env_var_name: MY_CUSTOM_ENV_VAR
 storage:
   type: directory
   path: /bot/storage

--- a/lib/tbot/service_bot_identity.go
+++ b/lib/tbot/service_bot_identity.go
@@ -475,14 +475,17 @@ func botIdentityFromToken(
 		return nil, trace.BadParameter("unsupported address kind: %v", addrKind)
 	}
 
-	if params.JoinMethod == types.JoinMethodAzure {
+	switch params.JoinMethod {
+	case types.JoinMethodAzure:
 		params.AzureParams = join.AzureParams{
 			ClientID: cfg.Onboarding.Azure.ClientID,
 		}
-	}
-
-	if params.JoinMethod == types.JoinMethodTerraformCloud {
+	case types.JoinMethodTerraformCloud:
 		params.TerraformCloudAudienceTag = cfg.Onboarding.Terraform.AudienceTag
+	case types.JoinMethodGitLab:
+		params.GitlabParams = join.GitlabParams{
+			EnvVarName: cfg.Onboarding.Gitlab.EnvVarName,
+		}
 	}
 
 	result, err := join.Register(ctx, params)

--- a/lib/tbot/service_bot_identity.go
+++ b/lib/tbot/service_bot_identity.go
@@ -484,7 +484,7 @@ func botIdentityFromToken(
 		params.TerraformCloudAudienceTag = cfg.Onboarding.Terraform.AudienceTag
 	case types.JoinMethodGitLab:
 		params.GitlabParams = join.GitlabParams{
-			EnvVarName: cfg.Onboarding.Gitlab.EnvVarName,
+			EnvVarName: cfg.Onboarding.Gitlab.TokenEnvVarName,
 		}
 	}
 


### PR DESCRIPTION
Backport #54104 to branch/v17

changelog: tbot can now be configured to use a non-standard environment variable when sourcing the ID Token for GitLab joining.
