### PR TITLE
Add os_log support to SlogTextHandler

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -421,9 +421,6 @@ const (
 	// LogsDir is a log subdirectory for events and logs
 	LogsDir = "log"
 
-	// Syslog is a mode for syslog logging
-	Syslog = "syslog"
-
 	// DebugLevel is a debug logging level name
 	DebugLevel = "debug"
 

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -4865,7 +4865,7 @@ func loopbackPool(proxyAddr string) *x509.CertPool {
 // connectToSSHAgent connects to the system SSH agent and returns an agent.Agent.
 func connectToSSHAgent() agent.ExtendedAgent {
 	ctx := context.Background()
-	logger := log.With(teleport.ComponentKey, "KEYAGENT")
+	logger := log.With(teleport.ComponentKey, teleport.ComponentKeyAgent)
 
 	socketPath := os.Getenv(teleport.SSHAuthSock)
 	conn, err := agentconn.Dial(socketPath)

--- a/lib/utils/log/formatter_test.go
+++ b/lib/utils/log/formatter_test.go
@@ -127,10 +127,6 @@ func TestOutput(t *testing.T) {
 				name:      "error",
 				slogLevel: slog.LevelError,
 			},
-			{
-				name:      "fatal",
-				slogLevel: slog.LevelError + 1,
-			},
 		}
 
 		for _, test := range tests {
@@ -223,10 +219,6 @@ func TestOutput(t *testing.T) {
 				name:      "error",
 				slogLevel: slog.LevelError,
 			},
-			{
-				name:      "fatal",
-				slogLevel: slog.LevelError + 1,
-			},
 		}
 
 		expectedFields := map[string]any{
@@ -275,8 +267,6 @@ func TestOutput(t *testing.T) {
 					expectedLevel = "trace"
 				case slog.LevelWarn:
 					expectedLevel = "warning"
-				case slog.LevelError + 1:
-					expectedLevel = "fatal"
 				default:
 					expectedLevel = test.slogLevel.String()
 				}

--- a/lib/utils/log/log.go
+++ b/lib/utils/log/log.go
@@ -50,8 +50,12 @@ type Config struct {
 	OSLogSubsystem string
 }
 
-// LogOutputOSLog represents os_log, the unified logging system on macOS, as the destination for logs.
-const LogOutputOSLog = "os_log"
+const (
+	// LogOutputSyslog represents syslog as the destination for logs.
+	LogOutputSyslog = "syslog"
+	// LogOutputOSLog represents os_log, the unified logging system on macOS, as the destination for logs.
+	LogOutputOSLog = "os_log"
+)
 
 // Initialize configures the default global logger based on the
 // provided configuration. The [slog.Logger] and [slog.LevelVar]
@@ -74,7 +78,7 @@ func Initialize(loggerConfig Config) (*slog.Logger, *slog.LevelVar, error) {
 		w = os.Stderr
 	case "stdout", "out", "1":
 		w = os.Stdout
-	case teleport.Syslog:
+	case LogOutputSyslog:
 		var err error
 		w, err = NewSyslogWriter()
 		if err != nil {

--- a/lib/utils/log/log.go
+++ b/lib/utils/log/log.go
@@ -36,13 +36,15 @@ type Config struct {
 	Output string
 	// Severity defines how verbose the log will be. Possible values are "error", "info", "warn"
 	Severity string
-	// Format defines the output format. Possible values are 'text' and 'json'.
+	// Format defines the output format. Possible values are 'text' and 'json'. Ignored when Output is
+	// set to "os_log" which always uses text format.
 	Format string
-	// ExtraFields lists the output fields from KnownFormatFields. Example format: [timestamp, component, caller]
+	// ExtraFields lists the output fields from KnownFormatFields. Example format: [timestamp, component, caller].
+	// Used only when Format is set to "text" or "json".
 	ExtraFields []string
-	// EnableColors dictates if output should be colored.
+	// EnableColors dictates if output should be colored when Format is set to "text".
 	EnableColors bool
-	// Padding to use for various components.
+	// Padding to use for various components when Format is set to "text".
 	Padding int
 	// OSLogSubsystem is the subsystem under which logs will be visible in os_log if Output is set to
 	// "os_log". If used from within a packaged app, this should include the identifier of the app in
@@ -60,52 +62,7 @@ const (
 // Initialize configures the default global logger based on the
 // provided configuration. The [slog.Logger] and [slog.LevelVar]
 func Initialize(loggerConfig Config) (*slog.Logger, *slog.LevelVar, error) {
-	const (
-		// logFileDefaultMode is the preferred permissions mode for log file.
-		logFileDefaultMode fs.FileMode = 0o644
-		// logFileDefaultFlag is the preferred flags set to log file.
-		logFileDefaultFlag = os.O_WRONLY | os.O_CREATE | os.O_APPEND
-	)
-
-	var w io.Writer
 	level := new(slog.LevelVar)
-	format := strings.ToLower(loggerConfig.Format)
-
-	switch loggerConfig.Output {
-	case "":
-		w = os.Stderr
-	case "stderr", "error", "2":
-		w = os.Stderr
-	case "stdout", "out", "1":
-		w = os.Stdout
-	case LogOutputSyslog:
-		var err error
-		w, err = NewSyslogWriter()
-		if err != nil {
-			slog.ErrorContext(context.Background(), "Failed to switch logging to syslog", "error", err)
-			slog.SetDefault(slog.New(DiscardHandler{}))
-			return slog.Default(), level, nil
-		}
-	case LogOutputOSLog:
-		if format != "text" {
-			return nil, nil, trace.BadParameter("os_log is supported as output only when format is set to text")
-		}
-
-		if loggerConfig.OSLogSubsystem == "" {
-			return nil, nil, trace.BadParameter("OSLogSubsystem must be set when using os_log as output")
-		}
-	default:
-		// Assume a file path for all other provided output values.
-		sharedWriter, err := NewFileSharedWriter(loggerConfig.Output, logFileDefaultFlag, logFileDefaultMode)
-		if err != nil {
-			return nil, nil, trace.Wrap(err, "failed to init the log file shared writer")
-		}
-		w = NewWriterFinalizer(sharedWriter)
-		if err := sharedWriter.RunWatcherReopen(context.Background()); err != nil {
-			return nil, nil, trace.Wrap(err)
-		}
-	}
-
 	switch strings.ToLower(loggerConfig.Severity) {
 	case "", "info":
 		level.Set(slog.LevelInfo)
@@ -121,32 +78,74 @@ func Initialize(loggerConfig Config) (*slog.Logger, *slog.LevelVar, error) {
 		return nil, nil, trace.BadParameter("unsupported logger severity: %q", loggerConfig.Severity)
 	}
 
+	if loggerConfig.Output == LogOutputOSLog {
+		if loggerConfig.OSLogSubsystem == "" {
+			return nil, nil, trace.BadParameter("OSLogSubsystem must be set when using os_log as output")
+		}
+
+		//nolint:staticcheck // SA4023. NewSlogOSLogHandler on unsupported platforms always returns err.
+		handler, err := NewSlogOSLogHandler(loggerConfig.OSLogSubsystem, level)
+		//nolint:staticcheck // SA4023.
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+		logger := slog.New(handler)
+		slog.SetDefault(logger)
+		return logger, level, nil
+	}
+
+	const (
+		// logFileDefaultMode is the preferred permissions mode for log file.
+		logFileDefaultMode fs.FileMode = 0o644
+		// logFileDefaultFlag is the preferred flags set to log file.
+		logFileDefaultFlag = os.O_WRONLY | os.O_CREATE | os.O_APPEND
+	)
+
+	var w io.Writer
+	switch loggerConfig.Output {
+	case "":
+		w = os.Stderr
+	case "stderr", "error", "2":
+		w = os.Stderr
+	case "stdout", "out", "1":
+		w = os.Stdout
+	case LogOutputSyslog:
+		var err error
+		w, err = NewSyslogWriter()
+		if err != nil {
+			slog.ErrorContext(context.Background(), "Failed to switch logging to syslog", "error", err)
+			slog.SetDefault(slog.New(DiscardHandler{}))
+			return slog.Default(), level, nil
+		}
+	default:
+		// Assume a file path for all other provided output values.
+		sharedWriter, err := NewFileSharedWriter(loggerConfig.Output, logFileDefaultFlag, logFileDefaultMode)
+		if err != nil {
+			return nil, nil, trace.Wrap(err, "failed to init the log file shared writer")
+		}
+		w = NewWriterFinalizer(sharedWriter)
+		if err := sharedWriter.RunWatcherReopen(context.Background()); err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+	}
+
 	configuredFields, err := ValidateFields(loggerConfig.ExtraFields)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 
+	format := strings.ToLower(loggerConfig.Format)
 	var logger *slog.Logger
 	switch format {
 	case "":
 		fallthrough // not set. defaults to 'text'
 	case "text":
-		if loggerConfig.Output == LogOutputOSLog {
-			//nolint:staticcheck // SA4023. NewSlogOSLogHandler on unsupported platforms always returns err.
-			handler, err := NewSlogOSLogHandler(loggerConfig.OSLogSubsystem, level)
-			//nolint:staticcheck // SA4023.
-			if err != nil {
-				return nil, nil, trace.Wrap(err)
-			}
-			logger = slog.New(handler)
-		} else {
-			logger = slog.New(NewSlogTextHandler(w, SlogTextHandlerConfig{
-				Level:            level,
-				EnableColors:     loggerConfig.EnableColors,
-				ConfiguredFields: configuredFields,
-				Padding:          loggerConfig.Padding,
-			}))
-		}
+		logger = slog.New(NewSlogTextHandler(w, SlogTextHandlerConfig{
+			Level:            level,
+			EnableColors:     loggerConfig.EnableColors,
+			ConfiguredFields: configuredFields,
+			Padding:          loggerConfig.Padding,
+		}))
 		slog.SetDefault(logger)
 	case "json":
 		logger = slog.New(NewSlogJSONHandler(w, SlogJSONHandlerConfig{

--- a/lib/utils/log/oslog/README.md
+++ b/lib/utils/log/oslog/README.md
@@ -1,0 +1,67 @@
+# oslog
+
+The oslog package provides access to the unified logging system on macOS.
+
+Useful resources:
+
+* [Your Friend the System Log](https://developer.apple.com/forums/thread/705868)
+* [Logging | Apple Developer Documentation](https://developer.apple.com/documentation/os/logging?language=objc)
+
+## Generating messages
+
+os_log supports [five log
+types](https://developer.apple.com/documentation/os/oslogtype?language=objc): debug, info, default,
+error, fault. The documentation and os_log(5) state that debug level logging is disabled by default,
+but as of macOS 15.4 this doesn't seem to be the case – debug messages are stored in memory. Info
+messages are not peristed to disk by default, every other level is logged and persisted to disk. In
+our codebase, default is functionally equivalent to warn.
+
+os_log_t can be distinguished by subsystem and category. Think of subsystem as a program (though
+multiple programs can share the same subsystem and category) and of category as teleport.ComponentKey.
+Unlike teleport.ComponentKey, subsystem and category needs to be set ahead of time when creating a
+logger and cannot be specified per message.
+
+Messages have a 1024-byte encoded size limit. Messages over this size will be truncated. The limit
+can be increased to 32 kilobytes on a per-subsystem or per-category level through
+`Enable-Oversize-Messages`, see os_log(5) and [Customizing logging
+behavior](#customizing-logging-behavior). Apple does not recommended enabling this for
+performance-sensitive code paths. Since at Teleport any component can log long stack traces at any
+code path, it's generally recommend to leave it turned off.
+
+All messages are logged as [public messages](https://developer.apple.com/documentation/os/generating-log-messages-from-your-code?language=objc#Redact-Sensitive-User-Data-from-a-Log-Message)
+since the Teleport codebase doesn't have the notion of public and private log messages.
+
+## Reading messages
+
+There are two main ways to consume logs. There's Console.app which is a convenient GUI for searching
+and filtering logs. Just make sure to include info and debug messages since they're not shown by
+default (options for including them are under the Action menu). When viewing message details,
+Console.app shows "Volatile" next to the message level if the message is stored only in memory.
+
+The other way to read logs is the `log` CLI tool. It can dump logs to a file, it can show them in a
+pager, it can stream them. It supports predicate filtering.
+
+```
+# Stream logs from tsh process.
+log stream --level debug --style syslog --predicate 'process == "tsh"'
+
+# Show logs from a specific subsystem.
+log show --info --debug --style syslog --predicate 'subsystem == "com.goteleport.tshdev.vnetd"'
+```
+
+## Customizing logging behavior
+
+There are at least two ways in which logging behavior can be customized:
+
+* `OSLogPreferences` dictionary in `Info.plist` of an app (see os_log(5) for available options).
+* `sudo log config` with `--subsystem` and `--mode` flags.
+
+In theory there's also `/Library/Preferences/Logging/Subsystems/` which is mentioned by the Apple
+Developer Documentation, but we haven't tested it yet.
+
+In theory, this enables developers to customize the behavior without modifying the code. In
+practice, we found that configuring logging through `sudo log config` doesn't seem to have an effect
+on an app with specific options set in `OSLogPreferences`, almost as if `OSLogPreferences` from
+`Info.plist` always took precedence over what's set through `sudo log config`.
+
+* [Customizing Logging Behavior While Debugging | Apple Developer Documentation](https://developer.apple.com/documentation/os/customizing-logging-behavior-while-debugging?language=objc)

--- a/lib/utils/log/oslog/oslog_darwin.go
+++ b/lib/utils/log/oslog/oslog_darwin.go
@@ -1,0 +1,94 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package oslog
+
+// #cgo CFLAGS: -Wall -xobjective-c -fblocks -fobjc-arc -mmacosx-version-min=11.0
+// #cgo LDFLAGS: -framework Foundation
+// #include <stdlib.h>
+// #include <os/log.h>
+// #include "oslog_darwin.h"
+import "C"
+
+import (
+	"unsafe"
+)
+
+// Logger encapsulates os_log_t object.
+type Logger struct {
+	osLog unsafe.Pointer
+}
+
+// NewLogger creates a new logger that writes to os_log. The caller is expected to call the Close
+// method when Logger is no longer needed.
+//
+// Calling this function twice with the same arguments returns a pointer to a different Go struct,
+// but the underlying osLog pointer is the same. This is handled by the logging runtime. The
+// underlying os_log_t object is never deallocated. See os_log_create(3) for more details.
+//
+// https://developer.apple.com/documentation/os/1643744-os_log_create/
+func NewLogger(subsystem string, category string) *Logger {
+	cSubsystem := C.CString(subsystem)
+	defer C.free(unsafe.Pointer(cSubsystem))
+	cCategory := C.CString(category)
+	defer C.free(unsafe.Pointer(cCategory))
+
+	osLog := C.TELCreateLog(cSubsystem, cCategory)
+	logger := Logger{osLog: osLog}
+
+	return &logger
+}
+
+// Log logs the given message as the given logType.
+//
+// All messages are logged as public messages [1] since the Teleport codebase doesn't have the
+// notion of public and private log messages.
+//
+// Log messages have a 1024-byte encoded size limit. Messages over this size will be truncated.
+// The limit can be increased to 32 kilobytes on a per-subsystem or per-category level through
+// Enable-Oversize-Messages, see os_log(5). Apple does not recommended enabling this for
+// performance-sensitive code paths. Since at Teleport any component can log long stack traces at
+// any code path, it's generally recommend to leave it turned off.
+//
+// [1]: https://developer.apple.com/documentation/os/generating-log-messages-from-your-code?language=objc#Redact-Sensitive-User-Data-from-a-Log-Message
+func (l *Logger) Log(logType OsLogType, message string) {
+	cMessage := C.CString(message)
+	defer C.free(unsafe.Pointer(cMessage))
+
+	C.TELLog(l.osLog, C.uint(logType), cMessage)
+}
+
+// OsLogType describes available log types that can be passed to Logger.Log.
+// By default OsLogTypeDebug and OsLogTypeInfo are stored only in memory and other log types are
+// persisted to disk.
+type OsLogType int
+
+const (
+	// OsLogTypeDebug is the equivalent of slog.LevelDebug. Messages of this type are stored only in
+	// memory unless the subsystem or the category is configured to store them on disk.
+	// See os_log(5) and https://developer.apple.com/documentation/os/customizing-logging-behavior-while-debugging?language=objc
+	OsLogTypeDebug OsLogType = C.OS_LOG_TYPE_DEBUG
+	// OsLogTypeInfo is the equivalent of slog.LevelInfo. Messages of this type are stored only in
+	// memory unless the subsystem or the category is configured to store them on disk.
+	// See man 5 os_log and https://developer.apple.com/documentation/os/customizing-logging-behavior-while-debugging?language=objc
+	OsLogTypeInfo OsLogType = C.OS_LOG_TYPE_INFO
+	// OsLogTypeDefault is functionally the equivalent of slog.LevelWarn. Messages of this type are
+	// always persisted in the data store.
+	OsLogTypeDefault OsLogType = C.OS_LOG_TYPE_DEFAULT
+	// OsLogTypeError is the equivalent of slog.LevelError. Messages of this type are always persisted
+	// in the data store.
+	OsLogTypeError OsLogType = C.OS_LOG_TYPE_ERROR
+)

--- a/lib/utils/log/oslog/oslog_darwin.h
+++ b/lib/utils/log/oslog/oslog_darwin.h
@@ -1,0 +1,17 @@
+#ifndef TELEPORT_LIB_UTILS_LOG_OSLOG_DARWIN_H
+#define TELEPORT_LIB_UTILS_LOG_OSLOG_DARWIN_H
+
+#import <os/log.h>
+
+// TELCreateLog creates a new os_log_t object. This function returns void* rather than os_log_t so that Go code
+// can operate on the pointer as unsafe.Pointer.
+//
+// The logging runtime maintains a global collection of all os_log_t objects, one per subsystem/category pair.
+// These objects are never deallocated. See os_log_create(3) for more details.
+void* TELCreateLog(const char *subsystem, const char *category);
+
+// TELLog logs the message as public on the given log with the given type (see os_log_type_t).
+// log is expected to be a pointer to os_log_t.
+void TELLog(void *log, uint type, const char *message);
+
+#endif /* TELEPORT_LIB_UTILS_LOG_OSLOG_DARWIN_H */

--- a/lib/utils/log/oslog/oslog_darwin.m
+++ b/lib/utils/log/oslog/oslog_darwin.m
@@ -1,0 +1,36 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "oslog_darwin.h"
+
+#import <os/log.h>
+#import <Foundation/Foundation.h>
+
+void* TELCreateLog(const char *subsystem, const char *category) {
+  os_log_t log = os_log_create(subsystem, category);
+  // __bridge_retained casts an Obj-C pointer to a Core Foundation pointer and transfers ownership to the callsite.
+  // The pointer is cast to void* so that it can be used as unsafe.Pointer in Go code.
+  // https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFDesignConcepts/Articles/tollFreeBridgedTypes.html#//apple_ref/doc/uid/TP40010677-SW2
+  // https://www.informit.com/articles/article.aspx?p=1745876&seqNum=2
+  return (__bridge_retained void*)log;
+}
+
+void TELLog(void *log, uint type, const char *message) {
+  // __bridge transfers a pointer between Obj-C and Core Foundation with no transfer of ownership.
+  // Since the pointer comes from a callsite that owns log and that is going to continue using it,
+  // there's no need to transfer ownership.
+  os_log_with_type((__bridge os_log_t)log, type, "%{public}s", message);
+}

--- a/lib/utils/log/slog_handler_test.go
+++ b/lib/utils/log/slog_handler_test.go
@@ -269,3 +269,55 @@ func TestSlogTextHandlerComponentPadding(t *testing.T) {
 		})
 	}
 }
+
+// TestSlogTextHandlerRawComponent checks if the value of the component field is forwarded from the
+// handler to the writer without any changes. This allows certain writers, such as the os_log writer
+// on macOS, to log the component in its full form since os_log provides dedicated fields for such
+// metadata.
+func TestSlogTextHandlerRawComponent(t *testing.T) {
+	var buf bytes.Buffer
+	out := &rawComponentWriter{}
+	h := NewSlogTextHandler(&buf, SlogTextHandlerConfig{
+		Level:            slog.LevelDebug,
+		Padding:          6,
+		ConfiguredFields: []string{ComponentField},
+	})
+	h.out = out
+
+	logger := slog.New(h)
+	logger.DebugContext(t.Context(), "bar", teleport.ComponentKey, "foobarbaz")
+	require.Equal(t, "foobarbaz", out.lastRawComponent(),
+		"raw component wasn't properly processed when teleport.ComponentKey was passed only directly with message")
+
+	logger = logger.With(teleport.ComponentKey, "foobarbaz")
+	logger.DebugContext(t.Context(), "bar")
+	require.Equal(t, "foobarbaz", out.lastRawComponent(),
+		"raw component wasn't properly processed when teleport.ComponentKey was passed to slog.Logger.With")
+
+	logger.With("quux", "xuuq").DebugContext(t.Context(), "bar")
+	require.Equal(t, "foobarbaz", out.lastRawComponent(),
+		"raw component wasn't properly cloned when teleport.ComponentKey wasn't passed to slog.Logger.With")
+
+	logger.DebugContext(t.Context(), "bar", teleport.ComponentKey, "bazbarfoo")
+	require.Equal(t, "bazbarfoo", out.lastRawComponent(),
+		"raw component wasn't properly processed when teleport.ComponentKey was meant to override existing component")
+}
+
+// rawComponentWriter is a writer that persists only rawComponent values that were passed to its
+// Write method.
+type rawComponentWriter struct {
+	rawComponents []string
+}
+
+func (r *rawComponentWriter) Write(bytes []byte, rawComponent string, level slog.Level) error {
+	r.rawComponents = append(r.rawComponents, rawComponent)
+	return nil
+}
+
+func (r *rawComponentWriter) lastRawComponent() string {
+	if len(r.rawComponents) == 0 {
+		return ""
+	}
+
+	return r.rawComponents[len(r.rawComponents)-1]
+}

--- a/lib/utils/log/slog_json_handler.go
+++ b/lib/utils/log/slog_json_handler.go
@@ -90,8 +90,6 @@ func NewSlogJSONHandler(w io.Writer, cfg SlogJSONHandlerConfig) *SlogJSONHandler
 						level = "warning"
 					case slog.LevelError:
 						level = "error"
-					case slog.LevelError + 1:
-						level = "fatal"
 					default:
 						level = strings.ToLower(lvl.String())
 					}

--- a/lib/utils/log/slog_text_handler.go
+++ b/lib/utils/log/slog_text_handler.go
@@ -253,9 +253,6 @@ func formatLevel(value slog.Level, enableColors bool) string {
 	case slog.LevelError:
 		level = "ERROR"
 		color = red
-	case slog.LevelError + 1:
-		level = "FATAL"
-		color = red
 	default:
 		color = blue
 		level = value.String()

--- a/lib/utils/log/slog_text_handler.go
+++ b/lib/utils/log/slog_text_handler.go
@@ -71,7 +71,12 @@ type SlogTextHandlerConfig struct {
 	Level slog.Leveler
 	// EnableColors allows the level to be printed in color.
 	EnableColors bool
-	// Padding to use for various components.
+	// Padding to use for [ComponentField] to ensure that the initial columns in the output line up.
+	// The component is wrapped in square brackets. If the length of the component exceeds Padding+2,
+	// the component is truncated. If the length is less than Padding+2, the component in square
+	// brackets is followed by spaces to pad it to the given Padding.
+	//
+	// If set to zero, no padding is done and components are not truncated.
 	Padding int
 	// ConfiguredFields are fields explicitly set by users to be included in
 	// the output message. If there are any entries configured, they will be honored.
@@ -271,8 +276,12 @@ func formatLevel(value slog.Level, enableColors bool) string {
 }
 
 func formatComponent(value slog.Value, padding int) string {
-	component := fmt.Sprintf("[%v]", value)
-	component = strings.ToUpper(padMax(component, padding))
+	component := strings.ToUpper(fmt.Sprintf("[%v]", value))
+	if padding <= 0 {
+		return component
+	}
+
+	component = padMax(component, padding)
 	if component[len(component)-1] != ' ' {
 		component = component[:len(component)-1] + "]"
 	}
@@ -318,10 +327,12 @@ func (s *SlogTextHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	for _, a := range attrs {
 		switch a.Key {
 		case teleport.ComponentKey:
-			component := fmt.Sprintf("[%v]", a.Value.String())
-			component = strings.ToUpper(padMax(component, s.cfg.Padding))
-			if component[len(component)-1] != ' ' {
-				component = component[:len(component)-1] + "]"
+			component := strings.ToUpper(fmt.Sprintf("[%v]", a.Value.String()))
+			if s.cfg.Padding > 0 {
+				component = padMax(component, s.cfg.Padding)
+				if component[len(component)-1] != ' ' {
+					component = component[:len(component)-1] + "]"
+				}
 			}
 			s2.component = component
 		case teleport.ComponentFields:

--- a/lib/utils/log/slog_text_handler_darwin.go
+++ b/lib/utils/log/slog_text_handler_darwin.go
@@ -1,0 +1,99 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package log
+
+import (
+	"log/slog"
+	"sync"
+
+	"github.com/gravitational/teleport/lib/utils/log/oslog"
+)
+
+// NewSlogOSLogHandler creates a SlogTextHandler that writes messages to os_log as subsystem.
+func NewSlogOSLogHandler(subsystem string, level slog.Leveler) (*SlogTextHandler, error) {
+	handler := SlogTextHandler{
+		cfg: SlogTextHandlerConfig{
+			Level: level,
+			// os_log doesn't support colors.
+			EnableColors: false,
+			// Pass only CallerField so that the logger does not include the level, component and
+			// timestamp fields in the message. os_log has dedicated handling for this kind of metadata.
+			ConfiguredFields: []string{CallerField},
+		},
+		out:        newOSLogWriter(subsystem),
+		withCaller: true,
+	}
+
+	return &handler, nil
+}
+
+// osLogWriter is an [outputWriter] that writes to os_log, the
+// unified logging system on macOS.
+type osLogWriter struct {
+	subsystem string
+	mu        sync.Mutex
+	loggers   map[string]*oslog.Logger
+}
+
+// newOSLogWriter creates a new output that writes to os_log. All oslog.Logger instances created by
+// this output are going to use the given subsystem, whereas the category comes from the component
+// passed to the Write method.
+func newOSLogWriter(subsystem string) *osLogWriter {
+	return &osLogWriter{
+		subsystem: subsystem,
+		loggers:   map[string]*oslog.Logger{},
+	}
+}
+
+// Write sends the message from buf to os_log and maps level to a specific oslog.OsLogType.
+// os_log truncates messages by default, see [oslog.Logger.Log] for more details.
+func (o *osLogWriter) Write(bytes []byte, rawComponent string, level slog.Level) error {
+	logger := o.getLogger(rawComponent)
+
+	var osLogType oslog.OsLogType
+
+	switch level {
+	case TraceLevel, slog.LevelDebug:
+		osLogType = oslog.OsLogTypeDebug
+	case slog.LevelInfo:
+		osLogType = oslog.OsLogTypeInfo
+	case slog.LevelWarn:
+		osLogType = oslog.OsLogTypeDefault
+	case slog.LevelError:
+		osLogType = oslog.OsLogTypeError
+	default:
+		osLogType = oslog.OsLogTypeDefault
+	}
+
+	logger.Log(osLogType, string(bytes))
+
+	return nil
+}
+
+func (o *osLogWriter) getLogger(rawComponent string) *oslog.Logger {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	logger, found := o.loggers[rawComponent]
+	if found {
+		return logger
+	}
+
+	logger = oslog.NewLogger(o.subsystem, rawComponent)
+	o.loggers[rawComponent] = logger
+	return logger
+}

--- a/lib/utils/log/slog_text_handler_darwin.go
+++ b/lib/utils/log/slog_text_handler_darwin.go
@@ -1,3 +1,5 @@
+//go:build darwin && cgo
+
 // Teleport
 // Copyright (C) 2025 Gravitational, Inc.
 //

--- a/lib/utils/log/slog_text_handler_other.go
+++ b/lib/utils/log/slog_text_handler_other.go
@@ -1,0 +1,29 @@
+//go:build !darwin
+
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+package log
+
+import (
+	"log/slog"
+
+	"github.com/gravitational/trace"
+)
+
+//nolint:staticcheck // SA4023. NewOSLogWriter on unsupported platforms always returns err.
+func NewSlogOSLogHandler(subsystem string, level slog.Leveler) (*SlogTextHandler, error) {
+	return nil, trace.NotImplemented("os_log is supported on macOS")
+}

--- a/lib/utils/log/slog_text_handler_other.go
+++ b/lib/utils/log/slog_text_handler_other.go
@@ -1,4 +1,4 @@
-//go:build !darwin
+//go:build !(darwin && cgo)
 
 // Teleport
 // Copyright (C) 2025 Gravitational, Inc.
@@ -25,5 +25,5 @@ import (
 
 //nolint:staticcheck // SA4023. NewOSLogWriter on unsupported platforms always returns err.
 func NewSlogOSLogHandler(subsystem string, level slog.Leveler) (*SlogTextHandler, error) {
-	return nil, trace.NotImplemented("os_log is supported on macOS")
+	return nil, trace.NotImplemented("os_log is not supported on this platform")
 }

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -1029,7 +1029,7 @@ func onSCP(scpFlags *scp.Flags) error {
 		verbosity = teleport.DebugLevel
 	}
 	_, _, err := logutils.Initialize(logutils.Config{
-		Output:   teleport.Syslog,
+		Output:   logutils.LogOutputSyslog,
 		Severity: verbosity,
 	})
 	if err != nil {


### PR DESCRIPTION
This PR includes changes in `lib/utils/log.SlogTextHandler` that are necessary to make it write logs to [os_log](https://developer.apple.com/documentation/os/logging?language=objc), the unified logging system on macOS. This is all so that the VNet daemon on macOS can write logs there (#54237) instead of storing them on disk (where they aren't rotated). It also enables us to add `--os-log` flag to tsh for writing debug logs there (#54239).

To make it possible for `SlogTextHandler` to write to os_log, I had to abstract away the underlying `io.Writer` that `SlogTextHandler` was using as an output so far. [os_log loggers](https://developer.apple.com/documentation/os/generating-log-messages-from-your-code?language=objc#Create-a-Log-Object-to-Organize-Messages) have support for subsystems, categories and log levels as separate metadata fields – things that the previous writer didn't understand as it was just writing bytes to `io.Writer`.

A subsystem can be thought of as a program or a process. In our case, we're going to use `com.gravitational.teleport.tsh` for tsh and `com.gravitational.teleport.tsh.vnetd` for the VNet daemon. A category can be thought of as a component that we use in our loggers, e.g. in tsh we have "keyagent" and "client". [Log levels in os_log](https://developer.apple.com/documentation/os/generating-log-messages-from-your-code?language=objc#Choose-the-Appropriate-Log-Level-for-Each-Message) map directly to log levels in slog. For more information, see [`lib/utils/log/oslog/README.md`](https://github.com/gravitational/teleport/blob/r7s/oslog/lib/utils/log/oslog/README.md).

This PR involves some Objective-C code, fortunately not that much _and_ we don't have to worry about ownership a lot because os_log loggers are never deallocated, as explained by os_log_create(3). I checked that this does not leak memory by cloning the branch with tsh integration, then making `tsh status` generate a hundred of uuids every 4 milliseconds and log them to os_log. Soon after launching, memory usage stabilized and remained stable for around a minute of running the program.

## How to test this

As this PR doesn't introduce os_log usage but merely APIs to use it, if you want to see it in action you have to clone the PR which adds `--os-log` to tsh: https://github.com/gravitational/teleport/pull/54239.