### PR TITLE
New CA for AWS IAM Roles Anywhere Integration

### DIFF
--- a/api/types/trust.go
+++ b/api/types/trust.go
@@ -63,6 +63,9 @@ const (
 	// OktaCA identifies the certificate authority that will be used by the
 	// integration with Okta.
 	OktaCA CertAuthType = "okta"
+	// AWSRACA identifies the certificate authority that will be used by the
+	// AWS IAM Roles Anywhere integration functionality.
+	AWSRACA CertAuthType = "awsra"
 )
 
 // CertAuthTypes lists all certificate authority types.
@@ -76,6 +79,7 @@ var CertAuthTypes = []CertAuthType{HostCA,
 	OIDCIdPCA,
 	SPIFFECA,
 	OktaCA,
+	AWSRACA,
 }
 
 // NewlyAdded should return true for CA types that were added in the current
@@ -98,6 +102,8 @@ func (c CertAuthType) addedInMajorVer() int64 {
 		return 15
 	case OktaCA:
 		return 16
+	case AWSRACA:
+		return 18
 	default:
 		// We don't care about other CAs added before v4.0.0
 		return 4

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -7621,7 +7621,7 @@ func newKeySet(ctx context.Context, keyStore *keystore.Manager, caID types.CertA
 
 	// Add TLS keys if necessary.
 	switch caID.Type {
-	case types.UserCA, types.HostCA, types.DatabaseCA, types.DatabaseClientCA, types.SAMLIDPCA, types.SPIFFECA:
+	case types.UserCA, types.HostCA, types.DatabaseCA, types.DatabaseClientCA, types.SAMLIDPCA, types.SPIFFECA, types.AWSRACA:
 		tlsKeyPair, err := keyStore.NewTLSKeyPair(ctx, caID.DomainName, tlsCAKeyPurpose(caID.Type))
 		if err != nil {
 			return keySet, trace.Wrap(err)
@@ -7668,6 +7668,8 @@ func tlsCAKeyPurpose(caType types.CertAuthType) cryptosuites.KeyPurpose {
 		return cryptosuites.SAMLIdPCATLS
 	case types.SPIFFECA:
 		return cryptosuites.SPIFFECATLS
+	case types.AWSRACA:
+		return cryptosuites.AWSRACATLS
 	}
 	return cryptosuites.KeyPurposeUnspecified
 }

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -1334,7 +1334,7 @@ func checkResourceConsistency(ctx context.Context, keyStore *keystore.Manager, c
 			switch r.GetType() {
 			case types.HostCA, types.UserCA, types.OpenSSHCA:
 				_, signerErr = keyStore.GetSSHSigner(ctx, r)
-			case types.DatabaseCA, types.DatabaseClientCA, types.SAMLIDPCA, types.SPIFFECA:
+			case types.DatabaseCA, types.DatabaseClientCA, types.SAMLIDPCA, types.SPIFFECA, types.AWSRACA:
 				_, _, signerErr = keyStore.GetTLSCertAndSigner(ctx, r)
 			case types.JWTSigner, types.OIDCIdPCA, types.OktaCA:
 				_, signerErr = keyStore.GetJWTSigner(ctx, r)

--- a/lib/client/ca_export.go
+++ b/lib/client/ca_export.go
@@ -164,6 +164,13 @@ func exportAuth(ctx context.Context, client authclient.ClientI, req ExportAuthor
 			ExportPrivateKeys: exportSecrets,
 		}
 		return exportTLSAuthority(ctx, client, req)
+	case "awsra":
+		req := exportTLSAuthorityRequest{
+			AuthType:          types.AWSRACA,
+			UnpackPEM:         false,
+			ExportPrivateKeys: exportSecrets,
+		}
+		return exportTLSAuthority(ctx, client, req)
 	case "db":
 		req := exportTLSAuthorityRequest{
 			AuthType:          types.DatabaseCA,

--- a/lib/client/ca_export_test.go
+++ b/lib/client/ca_export_test.go
@@ -278,6 +278,15 @@ func TestExportAuthorities(t *testing.T) {
 			assertNoSecrets: validateTLSCertificateDERFunc,
 			assertSecrets:   validateRSAPrivateKeyDERFunc,
 		},
+		{
+			name: "aws iam roles anywhere",
+			req: ExportAuthoritiesRequest{
+				AuthType: "awsra",
+			},
+			errorCheck:      require.NoError,
+			assertNoSecrets: validateTLSCertificatePEMFunc,
+			assertSecrets:   validatePrivateKeyPEMFunc,
+		},
 	} {
 		runTest := func(
 			t *testing.T,

--- a/lib/cryptosuites/suites.go
+++ b/lib/cryptosuites/suites.go
@@ -118,6 +118,9 @@ const (
 	// like GitHub.
 	GitClient
 
+	// AWSRACATLS represents the TLS key for the AWS IAM Roles Anywhere CA.
+	AWSRACATLS
+
 	// keyPurposeMax is 1 greater than the last valid key purpose, used to test that all values less than this
 	// are valid for each suite.
 	keyPurposeMax
@@ -193,6 +196,7 @@ var (
 		// EC2InstanceConnect has always used Ed25519 by default.
 		EC2InstanceConnect: Ed25519,
 		GitClient:          Ed25519,
+		AWSRACATLS:         ECDSAP256,
 	}
 
 	// balancedV1 strikes a balance between security, compatibility, and
@@ -224,6 +228,7 @@ var (
 		ProxyKubeClient:         ECDSAP256,
 		EC2InstanceConnect:      Ed25519,
 		GitClient:               Ed25519,
+		AWSRACATLS:              ECDSAP256,
 	}
 
 	// fipsv1 is an algorithm suite tailored for FIPS compliance. It is based on
@@ -256,6 +261,7 @@ var (
 		ProxyKubeClient:         ECDSAP256,
 		EC2InstanceConnect:      ECDSAP256,
 		GitClient:               ECDSAP256,
+		AWSRACATLS:              ECDSAP256,
 	}
 
 	// hsmv1 in an algorithm suite tailored for clusters using an HSM or KMS
@@ -290,6 +296,7 @@ var (
 		ProxyKubeClient:         ECDSAP256,
 		EC2InstanceConnect:      Ed25519,
 		GitClient:               Ed25519,
+		AWSRACATLS:              ECDSAP256,
 	}
 
 	allSuites = map[types.SignatureAlgorithmSuite]suite{

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -74,6 +74,8 @@ func ValidateCertAuthority(ca types.CertAuthority) (err error) {
 		err = checkSAMLIDPCA(ca)
 	case types.SPIFFECA:
 		err = checkSPIFFECA(ca)
+	case types.AWSRACA:
+		err = checkAWSRACA(ca)
 	default:
 		return trace.BadParameter("invalid CA type %q", ca.GetType())
 	}
@@ -90,6 +92,17 @@ func checkSPIFFECA(cai types.CertAuthority) error {
 	}
 	if len(ca.Spec.ActiveKeys.JWT) == 0 {
 		return trace.BadParameter("certificate authority missing JWT key pairs")
+	}
+	return nil
+}
+
+func checkAWSRACA(cai types.CertAuthority) error {
+	ca, ok := cai.(*types.CertAuthorityV2)
+	if !ok {
+		return trace.BadParameter("unknown CA type %T", cai)
+	}
+	if len(ca.Spec.ActiveKeys.TLS) == 0 {
+		return trace.BadParameter("certificate authority missing TLS key pairs")
 	}
 	return nil
 }

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -154,7 +154,7 @@ func NewTestCAWithConfig(config TestCAConfig) *types.CertAuthorityV2 {
 
 	// Add TLS keys if necessary.
 	switch config.Type {
-	case types.UserCA, types.HostCA, types.DatabaseCA, types.DatabaseClientCA, types.SAMLIDPCA, types.SPIFFECA:
+	case types.UserCA, types.HostCA, types.DatabaseCA, types.DatabaseClientCA, types.SAMLIDPCA, types.SPIFFECA, types.AWSRACA:
 		cert, err := tlsca.GenerateSelfSignedCAWithConfig(tlsca.GenerateCAConfig{
 			Signer: key.Signer,
 			Entity: pkix.Name{

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -220,6 +220,7 @@ var allowedCertificateTypes = []string{
 	"openssh",
 	"saml-idp",
 	"github",
+	"awsra",
 }
 
 // allowedCRLCertificateTypes list of certificate authorities types that can

--- a/tool/tctl/common/auth_rotate_command.go
+++ b/tool/tctl/common/auth_rotate_command.go
@@ -1235,6 +1235,9 @@ func manualSteps(caType types.CertAuthType, phase string) []string {
 	case types.OktaCA:
 		// TODO(smallinsky): populate any known manual steps during Okta CA rotation.
 		fallthrough
+	case types.AWSRACA:
+		// TODO(marco): populate any known manual steps during AWS IAM Roles Anywhere CA rotation.
+		fallthrough
 	default:
 		return []string{"Consult the CA rotation docs for any manual steps that may be required: https://goteleport.com/docs/admin-guides/management/operations/ca-rotation/"}
 	}


### PR DESCRIPTION
This PR adds a new CA which will be used by the AWS IAM Roles Anywhere Integration.

See https://github.com/gravitational/teleport/issues/53192