### PR TITLE
Move hardware key change pin stderr message to `cliPrompt`

### DIFF
--- a/api/utils/keys/hardwarekey/cliprompt.go
+++ b/api/utils/keys/hardwarekey/cliprompt.go
@@ -93,6 +93,8 @@ func (c *cliPrompt) Touch(_ context.Context, keyInfo ContextualKeyInfo) error {
 // If an invalid PIN or PUK is provided, the user will be re-prompted until a
 // valid value is provided.
 func (c *cliPrompt) ChangePIN(ctx context.Context, _ ContextualKeyInfo) (*PINAndPUK, error) {
+	fmt.Fprintf(os.Stderr, "The default PIN %q is not supported.\n", DefaultPIN)
+
 	var pinAndPUK = &PINAndPUK{}
 	for {
 		fmt.Fprintf(c.writer, "Please set a new 6-8 character PIN.\n")

--- a/api/utils/keys/piv/yubikey.go
+++ b/api/utils/keys/piv/yubikey.go
@@ -30,7 +30,6 @@ import (
 	"fmt"
 	"io"
 	"math/big"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -474,10 +473,7 @@ func (y *YubiKey) checkOrSetPIN(ctx context.Context, prompt hardwarekey.Prompt, 
 	}
 
 	switch pin {
-	case piv.DefaultPIN:
-		fmt.Fprintf(os.Stderr, "The default PIN %q is not supported.\n", piv.DefaultPIN)
-		fallthrough
-	case "":
+	case piv.DefaultPIN, "":
 		pin, err = y.setPINAndPUKFromDefault(ctx, prompt, keyInfo)
 		if err != nil {
 			return trace.Wrap(err)


### PR DESCRIPTION
This stderr message should only be output for the `CLIPrompt`.

Note that `ChangePIN` is only called when the user provides the default pin or `""`, so the output now looks like:
```
Enter your YubiKey PIV PIN [blank to use default]:
// return OR 123456
The default PIN 123456 is not supported.
Please set a new 6-8 character PIN.
...
```

Alternatively we could pass the context of whether `""` or the default pin was passed by the user to determine whether or not to display the extra line, but I think it doesn't hurt to always output it.

resolves https://github.com/gravitational/teleport/pull/54144#discussion_r2053238658