### PR TITLE
Require ClientStore in `client.Config`

### DIFF
--- a/api/profile/profile.go
+++ b/api/profile/profile.go
@@ -37,6 +37,8 @@ import (
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/keys/hardwarekey"
 	"github.com/gravitational/teleport/api/utils/sshutils"
+	libdefaults "github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 const (
@@ -488,4 +490,15 @@ func (p *Profile) AppCertPath(appName string) string {
 // is no guarantee that there is an actual key at that location.
 func (p *Profile) AppKeyPath(appName string) string {
 	return keypaths.AppKeyPath(p.Dir, p.Name(), p.Username, p.SiteName, appName)
+}
+
+// WebProxyHostPort returns the host and port of the web proxy.
+func (p *Profile) WebProxyHostPort() (string, int) {
+	if p.WebProxyAddr != "" {
+		addr, err := utils.ParseAddr(p.WebProxyAddr)
+		if err == nil {
+			return addr.Host(), addr.Port(libdefaults.HTTPListenPort)
+		}
+	}
+	return "unknown", libdefaults.HTTPListenPort
 }

--- a/api/profile/profile.go
+++ b/api/profile/profile.go
@@ -37,8 +37,6 @@ import (
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/keys/hardwarekey"
 	"github.com/gravitational/teleport/api/utils/sshutils"
-	libdefaults "github.com/gravitational/teleport/lib/defaults"
-	"github.com/gravitational/teleport/lib/utils"
 )
 
 const (
@@ -490,15 +488,4 @@ func (p *Profile) AppCertPath(appName string) string {
 // is no guarantee that there is an actual key at that location.
 func (p *Profile) AppKeyPath(appName string) string {
 	return keypaths.AppKeyPath(p.Dir, p.Name(), p.Username, p.SiteName, appName)
-}
-
-// WebProxyHostPort returns the host and port of the web proxy.
-func (p *Profile) WebProxyHostPort() (string, int) {
-	if p.WebProxyAddr != "" {
-		addr, err := utils.ParseAddr(p.WebProxyAddr)
-		if err == nil {
-			return addr.Host(), addr.Port(libdefaults.HTTPListenPort)
-		}
-	}
-	return "unknown", libdefaults.HTTPListenPort
 }

--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -1479,7 +1479,7 @@ func (i *TeleInstance) NewUnauthenticatedClient(cfg ClientConfig) (tc *client.Te
 		TLSRoutingEnabled:             i.IsSinglePortSetup,
 		TLSRoutingConnUpgradeRequired: cfg.ALBAddr != "",
 		Tracer:                        tracing.NoopProvider().Tracer("test"),
-		EnableEscapeSequences:         cfg.EnableEscapeSequences,
+		DisableEscapeSequences:        !cfg.EnableEscapeSequences,
 		Stderr:                        cfg.Stderr,
 		Stdin:                         cfg.Stdin,
 		Stdout:                        cfg.Stdout,

--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -1469,7 +1469,6 @@ func (i *TeleInstance) NewUnauthenticatedClient(cfg ClientConfig) (tc *client.Te
 		HostLogin:                     cfg.Login,
 		InsecureSkipVerify:            true,
 		ClientStore:                   client.NewFSClientStore(keyDir),
-		KeysDir:                       keyDir,
 		SiteName:                      cfg.Cluster,
 		ForwardAgent:                  fwdAgentMode,
 		Labels:                        cfg.Labels,

--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -1468,6 +1468,7 @@ func (i *TeleInstance) NewUnauthenticatedClient(cfg ClientConfig) (tc *client.Te
 		HostPort:                      cfg.Port,
 		HostLogin:                     cfg.Login,
 		InsecureSkipVerify:            true,
+		ClientStore:                   client.NewFSClientStore(keyDir),
 		KeysDir:                       keyDir,
 		SiteName:                      cfg.Cluster,
 		ForwardAgent:                  fwdAgentMode,

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -2111,7 +2111,7 @@ func kubeJoin(ctx context.Context, kubeConfig kube.ProxyConfig, tc *client.Telep
 			KubeProxyAddr:                 tc.Config.KubeProxyAddr,
 			WebProxyAddr:                  tc.Config.WebProxyAddr,
 			TLSRoutingConnUpgradeRequired: tc.Config.TLSRoutingConnUpgradeRequired,
-			EnableEscapeSequences:         tc.Config.EnableEscapeSequences,
+			EnableEscapeSequences:         !tc.Config.DisableEscapeSequences,
 			Tracker:                       meta,
 			TLSConfig:                     tlsConfig,
 			Mode:                          mode,

--- a/integration/proxy/teleterm_test.go
+++ b/integration/proxy/teleterm_test.go
@@ -241,7 +241,6 @@ func testGatewayCertRenewal(ctx context.Context, t *testing.T, params gatewayCer
 
 	fakeClock := clockwork.NewFakeClockAt(time.Now())
 	storage, err := clusters.NewStorage(clusters.Config{
-		Dir:                tc.KeysDir,
 		ClientStore:        tc.ClientStore,
 		InsecureSkipVerify: tc.InsecureSkipVerify,
 		// Inject a fake clock into clusters.Storage so we can control when the middleware thinks the
@@ -879,7 +878,6 @@ func testTeletermAppGatewayTargetPortValidation(t *testing.T, pack *appaccess.Pa
 		require.NoError(t, err)
 
 		storage, err := clusters.NewStorage(clusters.Config{
-			Dir:                tc.KeysDir,
 			ClientStore:        tc.ClientStore,
 			InsecureSkipVerify: tc.InsecureSkipVerify,
 		})

--- a/integration/teleterm_test.go
+++ b/integration/teleterm_test.go
@@ -1282,7 +1282,7 @@ func testListDatabaseUsers(t *testing.T, pack *dbhelpers.DatabasePack) {
 }
 
 // mustLogin logs in as the given user by completely skipping the actual login flow and saving valid
-// certs to disk. clusters.Storage can then be pointed to tc.KeysDir and daemon.Service can act as
+// certs to disk. clusters.Storage can then be pointed to tc.ClientStore and daemon.Service can act as
 // if the user was successfully logged in.
 //
 // This is faster than going through the actual process, but keep in mind that it might skip some

--- a/integration/teleterm_test.go
+++ b/integration/teleterm_test.go
@@ -254,10 +254,8 @@ func TestTeleterm(t *testing.T) {
 func testAddingRootCluster(t *testing.T, pack *dbhelpers.DatabasePack, creds *helpers.UserCreds) {
 	t.Helper()
 
-	homeDir := t.TempDir()
 	storage, err := clusters.NewStorage(clusters.Config{
-		Dir:                homeDir,
-		ClientStore:        client.NewFSClientStore(homeDir),
+		ClientStore:        client.NewFSClientStore(t.TempDir()),
 		InsecureSkipVerify: true,
 	})
 	require.NoError(t, err)
@@ -289,7 +287,6 @@ func testListRootClustersReturnsLoggedInUser(t *testing.T, pack *dbhelpers.Datab
 	tc := mustLogin(t, pack.Root.User.GetName(), pack, creds)
 
 	storage, err := clusters.NewStorage(clusters.Config{
-		Dir:                tc.KeysDir,
 		ClientStore:        tc.ClientStore,
 		InsecureSkipVerify: tc.InsecureSkipVerify,
 	})
@@ -372,7 +369,6 @@ func testGetClusterReturnsPropertiesFromAuthServer(t *testing.T, pack *dbhelpers
 	tc := mustLogin(t, userName, pack, creds)
 
 	storage, err := clusters.NewStorage(clusters.Config{
-		Dir:                tc.KeysDir,
 		ClientStore:        tc.ClientStore,
 		InsecureSkipVerify: tc.InsecureSkipVerify,
 	})
@@ -425,7 +421,6 @@ func testHeadlessWatcher(t *testing.T, pack *dbhelpers.DatabasePack, creds *help
 	tc := mustLogin(t, pack.Root.User.GetName(), pack, creds)
 
 	storage, err := clusters.NewStorage(clusters.Config{
-		Dir:                tc.KeysDir,
 		ClientStore:        tc.ClientStore,
 		InsecureSkipVerify: tc.InsecureSkipVerify,
 	})
@@ -495,7 +490,6 @@ func testClientCache(t *testing.T, pack *dbhelpers.DatabasePack, creds *helpers.
 	storageFakeClock := clockwork.NewFakeClockAt(time.Now())
 
 	storage, err := clusters.NewStorage(clusters.Config{
-		Dir:                tc.KeysDir,
 		ClientStore:        tc.ClientStore,
 		Clock:              storageFakeClock,
 		InsecureSkipVerify: tc.InsecureSkipVerify,
@@ -757,10 +751,8 @@ func testCreateConnectMyComputerRole(t *testing.T, pack *dbhelpers.DatabasePack)
 			require.NoError(t, authServer.UpsertPassword(userName, []byte(userPassword)))
 
 			// Prepare daemon.Service.
-			homeDir := t.TempDir()
 			storage, err := clusters.NewStorage(clusters.Config{
-				Dir:                homeDir,
-				ClientStore:        client.NewFSClientStore(homeDir),
+				ClientStore:        client.NewFSClientStore(t.TempDir()),
 				InsecureSkipVerify: true,
 			})
 			require.NoError(t, err)
@@ -874,7 +866,6 @@ func testCreateConnectMyComputerToken(t *testing.T, pack *dbhelpers.DatabasePack
 
 	// Prepare daemon.Service.
 	storage, err := clusters.NewStorage(clusters.Config{
-		Dir:                tc.KeysDir,
 		ClientStore:        tc.ClientStore,
 		InsecureSkipVerify: tc.InsecureSkipVerify,
 		Clock:              fakeClock,
@@ -939,7 +930,6 @@ func testWaitForConnectMyComputerNodeJoin(t *testing.T, pack *dbhelpers.Database
 	tc := mustLogin(t, pack.Root.User.GetName(), pack, creds)
 
 	storage, err := clusters.NewStorage(clusters.Config{
-		Dir:                tc.KeysDir,
 		ClientStore:        tc.ClientStore,
 		InsecureSkipVerify: tc.InsecureSkipVerify,
 	})
@@ -1024,7 +1014,6 @@ func testDeleteConnectMyComputerNode(t *testing.T, pack *dbhelpers.DatabasePack)
 	tc := mustLogin(t, userName, pack, creds)
 
 	storage, err := clusters.NewStorage(clusters.Config{
-		Dir:                tc.KeysDir,
 		ClientStore:        tc.ClientStore,
 		InsecureSkipVerify: tc.InsecureSkipVerify,
 	})
@@ -1252,7 +1241,6 @@ func testListDatabaseUsers(t *testing.T, pack *dbhelpers.DatabasePack) {
 			tc := mustLogin(t, rootUserName, pack, creds)
 
 			storage, err := clusters.NewStorage(clusters.Config{
-				Dir:                tc.KeysDir,
 				ClientStore:        tc.ClientStore,
 				InsecureSkipVerify: tc.InsecureSkipVerify,
 			})

--- a/lib/benchmark/benchmark.go
+++ b/lib/benchmark/benchmark.go
@@ -283,8 +283,9 @@ func work(ctx context.Context, m benchMeasure, send chan<- benchMeasure, workloa
 // makeTeleportClient creates an instance of a teleport client
 func makeTeleportClient(host, login, proxy string) (*client.TeleportClient, error) {
 	c := client.Config{
-		Host:   host,
-		Tracer: tracing.NoopProvider().Tracer("test"),
+		Host:        host,
+		Tracer:      tracing.NoopProvider().Tracer("test"),
+		ClientStore: client.NewFSClientStore(""),
 	}
 
 	if login != "" {
@@ -295,8 +296,7 @@ func makeTeleportClient(host, login, proxy string) (*client.TeleportClient, erro
 		c.SSHProxyAddr = proxy
 	}
 
-	profileStore := client.NewFSProfileStore("")
-	if err := c.LoadProfile(profileStore, proxy); err != nil {
+	if err := c.LoadProfile(proxy); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	tc, err := client.NewClient(&c)

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -388,10 +388,10 @@ type Config struct {
 	//	off - do not attempt to load keys into agent
 	AddKeysToAgent string
 
-	// EnableEscapeSequences will scan Stdin for SSH escape sequences during
+	// DisableEscapeSequences will disable scanning Stdin for SSH escape sequences during
 	// command/shell execution. This also requires Stdin to be an interactive
 	// terminal.
-	EnableEscapeSequences bool
+	DisableEscapeSequences bool
 
 	// MockSSOLogin is used in tests for mocking the SSO login response.
 	MockSSOLogin SSOLoginFunc
@@ -536,12 +536,11 @@ type CachePolicy struct {
 // MakeDefaultConfig returns default client config
 func MakeDefaultConfig() *Config {
 	return &Config{
-		Stdout:                os.Stdout,
-		Stderr:                os.Stderr,
-		Stdin:                 os.Stdin,
-		AddKeysToAgent:        AddKeysToAgentAuto,
-		EnableEscapeSequences: true,
-		Tracer:                tracing.NoopProvider().Tracer("TeleportClient"),
+		Stdout:         os.Stdout,
+		Stderr:         os.Stderr,
+		Stdin:          os.Stdin,
+		AddKeysToAgent: AddKeysToAgentAuto,
+		Tracer:         tracing.NoopProvider().Tracer("TeleportClient"),
 	}
 }
 

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -902,13 +902,16 @@ func IsErrorResolvableWithRelogin(err error) bool {
 		IsNoCredentialsError(err)
 }
 
-// GetProfile gets the profile for the specified proxy address, or
-// the current profile if no proxy is specified.
-func (c *Config) GetProfile(ps ProfileStore, proxyAddr string) (*profile.Profile, error) {
+// GetProfile gets the client profile for the specified proxy address.
+func (c *Config) GetProfile(proxyAddr string) (*profile.Profile, error) {
+	if c.ClientStore == nil {
+		return nil, trace.BadParameter("client store can not be nil")
+	}
+
 	var proxyHost string
 	var err error
 	if proxyAddr == "" {
-		proxyHost, err = ps.CurrentProfile()
+		proxyHost, err = c.ClientStore.CurrentProfile()
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -919,18 +922,17 @@ func (c *Config) GetProfile(ps ProfileStore, proxyAddr string) (*profile.Profile
 		}
 	}
 
-	profile, err := ps.GetProfile(proxyHost)
+	profile, err := c.ClientStore.GetProfile(proxyHost)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return profile, nil
 }
 
-// LoadProfile populates Config with the values stored in the given
-// profiles directory. If profileDir is an empty string, the default profile
-// directory ~/.tsh is used.
-func (c *Config) LoadProfile(ps ProfileStore, proxyAddr string) error {
-	profile, err := c.GetProfile(ps, proxyAddr)
+// LoadProfile populates Config with the values stored in the client
+// profile for the specified proxy address.
+func (c *Config) LoadProfile(proxyAddr string) error {
+	profile, err := c.GetProfile(proxyAddr)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -86,7 +86,6 @@ import (
 	"github.com/gravitational/teleport/lib/devicetrust"
 	dtauthntypes "github.com/gravitational/teleport/lib/devicetrust/authn/types"
 	"github.com/gravitational/teleport/lib/events"
-	libhwk "github.com/gravitational/teleport/lib/hardwarekey"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/observability/tracing"
@@ -256,6 +255,7 @@ type Config struct {
 	// Agent is an SSH agent to use for local Agent procedures. Defaults to in-memory agent keyring.
 	Agent agent.ExtendedAgent
 
+	// ClientStore is the store for client data, e.g. keys, certs, profiles.
 	ClientStore *Store
 
 	// ForwardAgent is used by the client to request agent forwarding from the server.
@@ -533,15 +533,74 @@ type CachePolicy struct {
 	NeverExpires bool
 }
 
-// MakeDefaultConfig returns default client config
-func MakeDefaultConfig() *Config {
+// MakeDefaultConfig returns default client config.
+// If store is not provided, it will default to in-memory storage without
+// hardware key support. This should only be used with static auth methods
+// (TLS and AuthMethods fields).
+func MakeDefaultConfig(store *Store) *Config {
+	if store == nil {
+		store = NewMemClientStore()
+	}
 	return &Config{
 		Stdout:         os.Stdout,
 		Stderr:         os.Stderr,
 		Stdin:          os.Stdin,
 		AddKeysToAgent: AddKeysToAgentAuto,
 		Tracer:         tracing.NoopProvider().Tracer("TeleportClient"),
+		ClientStore:    store,
 	}
+}
+
+func (c *Config) CheckAndSetDefaults() error {
+	if c.ClientStore == nil {
+		if c.TLS == nil && c.AuthMethods == nil {
+			return trace.BadParameter("either client store is or static auth methods are required")
+		}
+		// Client will use static auth methods instead of client store.
+		// Initialize empty client store to prevent panics.
+		c.ClientStore = NewMemClientStore()
+	}
+
+	// validate configuration
+	var err error
+	if c.Username == "" {
+		c.Username, err = Username()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		log.InfoContext(context.Background(), "No teleport login given, using default", "default_login", c.Username)
+	}
+	if c.WebProxyAddr == "" {
+		return trace.BadParameter("No proxy address specified, missed --proxy flag?")
+	}
+	if c.HostLogin == "" {
+		c.HostLogin, err = Username()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		log.InfoContext(context.Background(), "no host login given, using default", "default_host_login", c.HostLogin)
+	}
+	if len(c.JumpHosts) > 1 {
+		return trace.BadParameter("only one jump host is supported, got %v", len(c.JumpHosts))
+	}
+
+	// set defaults
+	if c.Stdout == nil {
+		c.Stdout = os.Stdout
+	}
+	if c.Stderr == nil {
+		c.Stderr = os.Stderr
+	}
+	if c.Stdin == nil {
+		c.Stdin = os.Stdin
+	}
+	if c.AddKeysToAgent == "" {
+		c.AddKeysToAgent = AddKeysToAgentAuto
+	}
+	if c.Tracer == nil {
+		c.Tracer = tracing.NoopProvider().Tracer("TeleportClient")
+	}
+	return nil
 }
 
 // VirtualPathKind is the suffix component for env vars denoting the type of
@@ -1239,61 +1298,12 @@ type ShellCreatedCallback func(s *tracessh.Session, c *tracessh.Client, terminal
 
 // NewClient creates a TeleportClient object and fully configures it
 func NewClient(c *Config) (tc *TeleportClient, err error) {
-	if len(c.JumpHosts) > 1 {
-		return nil, trace.BadParameter("only one jump host is supported, got %v", len(c.JumpHosts))
-	}
-	// validate configuration
-	if c.Username == "" {
-		c.Username, err = Username()
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		log.InfoContext(context.Background(), "No teleport login given, using default", "default_login", c.Username)
-	}
-	if c.WebProxyAddr == "" {
-		return nil, trace.BadParameter("No proxy address specified, missed --proxy flag?")
-	}
-	if c.HostLogin == "" {
-		c.HostLogin, err = Username()
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		log.InfoContext(context.Background(), "no host login given, using default", "default_host_login", c.HostLogin)
-	}
-
-	if c.Tracer == nil {
-		c.Tracer = tracing.NoopProvider().Tracer(teleport.ComponentTeleport)
+	if err := c.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	tc = &TeleportClient{
 		Config: *c,
-	}
-
-	if tc.Stdout == nil {
-		tc.Stdout = os.Stdout
-	}
-	if tc.Stderr == nil {
-		tc.Stderr = os.Stderr
-	}
-	if tc.Stdin == nil {
-		tc.Stdin = os.Stdin
-	}
-
-	if tc.ClientStore == nil {
-		if tc.TLS != nil || tc.AuthMethods != nil {
-			// Client will use static auth methods instead of client store.
-			// Initialize empty client store to prevent panics.
-			tc.ClientStore = NewMemClientStore()
-		} else {
-			// TODO (Joerger): init hardware key service (and client store) earlier where it can
-			// be properly shared.
-			hardwareKeyService := libhwk.NewService(context.TODO(), nil /*prompt*/)
-			tc.ClientStore = NewFSClientStore(c.KeysDir, WithHardwareKeyService(hardwareKeyService))
-			if c.AddKeysToAgent == AddKeysToAgentOnly {
-				// Store client keys in memory, but still save trusted certs and profile to disk.
-				tc.ClientStore.KeyStore = NewMemKeyStore()
-			}
-		}
 	}
 
 	// Create a buffered channel to hold events that occurred during this session.

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -322,10 +322,6 @@ type Config struct {
 	// that uses local cache to validate hosts
 	HostKeyCallback ssh.HostKeyCallback
 
-	// KeyDir defines where temporary session keys will be stored.
-	// if empty, they'll go to ~/.tsh
-	KeysDir string
-
 	// SessionID is a session ID to use when opening a new session.
 	SessionID string
 
@@ -408,9 +404,6 @@ type Config struct {
 	// Useful in parallel tests so they don't all use the default path in the
 	// user home dir.
 	OverridePostgresServiceFilePath string
-
-	// HomePath is where tsh stores profiles
-	HomePath string
 
 	// TLSRoutingEnabled indicates that proxy supports ALPN SNI server where
 	// all proxy services are exposed on a single TLS listener (Proxy Web Listener).
@@ -947,7 +940,6 @@ func (c *Config) LoadProfile(proxyAddr string) error {
 	c.MongoProxyAddr = profile.MongoProxyAddr
 	c.TLSRoutingEnabled = profile.TLSRoutingEnabled
 	c.TLSRoutingConnUpgradeRequired = profile.TLSRoutingConnUpgradeRequired
-	c.KeysDir = profile.Dir
 	c.AuthConnector = profile.AuthConnector
 	c.LoadAllCAs = profile.LoadAllCAs
 	c.PrivateKeyPolicy = profile.PrivateKeyPolicy

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -273,7 +273,8 @@ func TestTeleportClient_Login_local(t *testing.T) {
 			otpKey := sa.OTPKey
 
 			// Prepare client config.
-			cfg := client.MakeDefaultConfig()
+			cfg := &client.Config{}
+			cfg.ClientStore = client.NewFSClientStore(t.TempDir())
 			cfg.Stdout = io.Discard
 			cfg.Stderr = io.Discard
 			cfg.Stdin = &bytes.Buffer{}
@@ -283,7 +284,6 @@ func TestTeleportClient_Login_local(t *testing.T) {
 			// Replace "127.0.0.1" with "localhost". The proxy address becomes the origin
 			// for Webauthn requests, and Webauthn doesn't take IP addresses.
 			cfg.WebProxyAddr = strings.Replace(sa.ProxyWebAddr, "127.0.0.1", "localhost", 1 /* n */)
-			cfg.KeysDir = t.TempDir()
 			cfg.InsecureSkipVerify = true
 
 			// Prepare the client proper.
@@ -339,7 +339,8 @@ func TestTeleportClient_DeviceLogin(t *testing.T) {
 	require.NoError(t, err, "UpsertAuthPreference failed")
 
 	// Prepare client config, it won't change throughout the test.
-	cfg := client.MakeDefaultConfig()
+	cfg := &client.Config{}
+	cfg.ClientStore = client.NewFSClientStore(t.TempDir())
 	cfg.Stdout = io.Discard
 	cfg.Stderr = io.Discard
 	cfg.Stdin = &bytes.Buffer{}
@@ -347,7 +348,6 @@ func TestTeleportClient_DeviceLogin(t *testing.T) {
 	cfg.HostLogin = username
 	cfg.AddKeysToAgent = client.AddKeysToAgentNo
 	cfg.WebProxyAddr = sa.ProxyWebAddr
-	cfg.KeysDir = t.TempDir()
 	cfg.InsecureSkipVerify = true
 
 	teleportClient, err := client.NewClient(cfg)
@@ -674,11 +674,11 @@ func TestRetryWithRelogin(t *testing.T) {
 	clock := clockwork.NewFakeClockAt(time.Now())
 	sa := newStandaloneTeleport(t, clock)
 
-	cfg := client.MakeDefaultConfig()
+	cfg := &client.Config{}
+	cfg.ClientStore = client.NewFSClientStore(t.TempDir())
 	cfg.Username = sa.Username
 	cfg.HostLogin = sa.Username
 	cfg.WebProxyAddr = sa.ProxyWebAddr
-	cfg.KeysDir = t.TempDir()
 	cfg.InsecureSkipVerify = true
 	cfg.AllowStdinHijack = true
 

--- a/lib/client/api_test.go
+++ b/lib/client/api_test.go
@@ -1157,8 +1157,7 @@ func TestLoadTLSConfigForClusters(t *testing.T) {
 }
 
 func TestConnectToProxyCancelledContext(t *testing.T) {
-	cfg := MakeDefaultConfig()
-
+	cfg := &Config{}
 	cfg.Agent = &mockAgent{}
 	cfg.AuthMethods = []ssh.AuthMethod{ssh.Password("xyz")}
 	cfg.AddKeysToAgent = AddKeysToAgentNo

--- a/lib/client/api_test.go
+++ b/lib/client/api_test.go
@@ -197,13 +197,13 @@ func TestParseProxyHostString(t *testing.T) {
 
 func TestNew(t *testing.T) {
 	conf := Config{
-		Host:      "localhost",
-		HostLogin: "vincent",
-		HostPort:  22,
-		KeysDir:   t.TempDir(),
-		Username:  "localuser",
-		SiteName:  "site",
-		Tracer:    tracing.NoopProvider().Tracer("test"),
+		Host:        "localhost",
+		HostLogin:   "vincent",
+		HostPort:    22,
+		Username:    "localuser",
+		SiteName:    "site",
+		Tracer:      tracing.NoopProvider().Tracer("test"),
+		ClientStore: NewMemClientStore(),
 	}
 	err := conf.ParseProxyHost("proxy")
 	require.NoError(t, err)
@@ -1162,7 +1162,6 @@ func TestConnectToProxyCancelledContext(t *testing.T) {
 	cfg.AuthMethods = []ssh.AuthMethod{ssh.Password("xyz")}
 	cfg.AddKeysToAgent = AddKeysToAgentNo
 	cfg.WebProxyAddr = "dummy"
-	cfg.KeysDir = t.TempDir()
 	cfg.TLSRoutingEnabled = true
 
 	clt, err := NewClient(cfg)

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -404,7 +404,7 @@ func (c *NodeClient) RunInteractiveShell(ctx context.Context, mode types.Session
 		env[teleport.SSHSessionWebProxyAddr] = c.ProxyPublicAddr
 	}
 
-	nodeSession, err := newSession(ctx, c, sessToJoin, env, c.TC.Stdin, c.TC.Stdout, c.TC.Stderr, c.TC.EnableEscapeSequences)
+	nodeSession, err := newSession(ctx, c, sessToJoin, env, c.TC.Stdin, c.TC.Stdout, c.TC.Stderr, !c.TC.DisableEscapeSequences)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -605,7 +605,7 @@ func (c *NodeClient) RunCommand(ctx context.Context, command []string, opts ...R
 		}
 	}
 
-	nodeSession, err := newSession(ctx, c, nil, c.TC.newSessionEnv(), c.TC.Stdin, stdout, stderr, c.TC.EnableEscapeSequences)
+	nodeSession, err := newSession(ctx, c, nil, c.TC.newSessionEnv(), c.TC.Stdin, stdout, stderr, !c.TC.DisableEscapeSequences)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/client/client_store.go
+++ b/lib/client/client_store.go
@@ -274,6 +274,7 @@ func (s *Store) ReadProfileStatus(profileName string) (*ProfileStatus, error) {
 		SAMLSingleLogoutEnabled: profile.SAMLSingleLogoutEnabled,
 		SSOHost:                 profile.SSOHost,
 		IsVirtual:               !onDisk,
+		TLSRoutingEnabled:       profile.TLSRoutingEnabled,
 	})
 }
 

--- a/lib/client/client_store_test.go
+++ b/lib/client/client_store_test.go
@@ -263,13 +263,14 @@ func TestClientStore(t *testing.T) {
 				err = clientStore.SaveProfile(profile, true)
 				require.NoError(t, err)
 				expectStatus, err := profileStatusFromKeyRing(keyRing, profileOptions{
-					ProfileName:   profile.Name(),
-					WebProxyAddr:  profile.WebProxyAddr,
-					ProfileDir:    profileDir,
-					Username:      profile.Username,
-					SiteName:      profile.SiteName,
-					KubeProxyAddr: profile.KubeProxyAddr,
-					IsVirtual:     profileDir == "",
+					ProfileName:       profile.Name(),
+					WebProxyAddr:      profile.WebProxyAddr,
+					ProfileDir:        profileDir,
+					Username:          profile.Username,
+					SiteName:          profile.SiteName,
+					KubeProxyAddr:     profile.KubeProxyAddr,
+					IsVirtual:         profileDir == "",
+					TLSRoutingEnabled: profile.TLSRoutingEnabled,
 				})
 				require.NoError(t, err)
 
@@ -292,13 +293,14 @@ func TestClientStore(t *testing.T) {
 				require.NoError(t, err)
 
 				expectOtherStatus, err := profileStatusFromKeyRing(keyRing, profileOptions{
-					ProfileName:   otherProfile.Name(),
-					WebProxyAddr:  otherProfile.WebProxyAddr,
-					ProfileDir:    profileDir,
-					Username:      otherProfile.Username,
-					SiteName:      otherProfile.SiteName,
-					KubeProxyAddr: otherProfile.KubeProxyAddr,
-					IsVirtual:     profileDir == "",
+					ProfileName:       otherProfile.Name(),
+					WebProxyAddr:      otherProfile.WebProxyAddr,
+					ProfileDir:        profileDir,
+					Username:          otherProfile.Username,
+					SiteName:          otherProfile.SiteName,
+					KubeProxyAddr:     otherProfile.KubeProxyAddr,
+					IsVirtual:         profileDir == "",
+					TLSRoutingEnabled: otherProfile.TLSRoutingEnabled,
 				})
 				require.NoError(t, err)
 

--- a/lib/client/conntest/ssh.go
+++ b/lib/client/conntest/ssh.go
@@ -185,7 +185,7 @@ func (s *SSHConnectionTester) TestConnection(ctx context.Context, req TestConnec
 
 	processStdout := &bytes.Buffer{}
 
-	clientConf := client.MakeDefaultConfig()
+	clientConf := &client.Config{}
 	clientConf.AddKeysToAgent = client.AddKeysToAgentNo
 	clientConf.AuthMethods = []ssh.AuthMethod{keyAuthMethod}
 	clientConf.Host = req.ResourceName

--- a/lib/client/db/dbcmd/dbcmd_test.go
+++ b/lib/client/db/dbcmd/dbcmd_test.go
@@ -61,11 +61,11 @@ func (f fakeExec) LookPath(path string) (string, error) {
 
 func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 	conf := &client.Config{
-		HomePath:     t.TempDir(),
 		Host:         "localhost",
 		WebProxyAddr: "proxy.example.com",
 		SiteName:     "db.example.com",
 		Tracer:       tracing.NoopProvider().Tracer("test"),
+		ClientStore:  client.NewMemClientStore(),
 	}
 
 	tc, err := client.NewClient(conf)
@@ -801,11 +801,11 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 
 func TestCLICommandBuilderGetConnectCommandAlternatives(t *testing.T) {
 	conf := &client.Config{
-		HomePath:     t.TempDir(),
 		Host:         "localhost",
 		WebProxyAddr: "proxy.example.com",
 		SiteName:     "db.example.com",
 		Tracer:       tracing.NoopProvider().Tracer("test"),
+		ClientStore:  client.NewMemClientStore(),
 	}
 
 	tc, err := client.NewClient(conf)
@@ -970,13 +970,12 @@ func TestCLICommandBuilderGetConnectCommandAlternatives(t *testing.T) {
 
 func TestConvertCommandError(t *testing.T) {
 	t.Parallel()
-	homePath := t.TempDir()
 	conf := &client.Config{
-		HomePath:     homePath,
 		Host:         "localhost",
 		WebProxyAddr: "localhost",
 		SiteName:     "db.example.com",
 		Tracer:       tracing.NoopProvider().Tracer("test"),
+		ClientStore:  client.NewMemClientStore(),
 	}
 
 	tc, err := client.NewClient(conf)
@@ -985,7 +984,6 @@ func TestConvertCommandError(t *testing.T) {
 	profile := &client.ProfileStatus{
 		Name:     "example.com",
 		Username: "bob",
-		Dir:      homePath,
 		Cluster:  "example.com",
 	}
 

--- a/lib/client/db/dbcmd/exec_test.go
+++ b/lib/client/db/dbcmd/exec_test.go
@@ -40,7 +40,7 @@ func TestCLICommandBuilderGetExecCommand(t *testing.T) {
 	}
 
 	conf := &client.Config{
-		HomePath:     t.TempDir(),
+		ClientStore:  client.NewFSClientStore(t.TempDir()),
 		Host:         "localhost",
 		WebProxyAddr: "proxy.example.com",
 		SiteName:     "db.example.com",

--- a/lib/client/identityfile/identity.go
+++ b/lib/client/identityfile/identity.go
@@ -829,26 +829,15 @@ func KeyRingFromIdentityFile(identityPath, proxyHost, clusterName string) (*clie
 	return keyRing, nil
 }
 
-// NewClientStoreFromIdentityFile initializes a new in-memory client store
-// and loads data from the given identity file into it. A temporary profile
-// is also added to its profile store with the limited profile data available
-// in the identity file.
+// LoadIdentityFileIntoClientStore loads the identityFile from the given path
+// into the given client store, assimilating it with other keys in the store.
+// A temporary profile is also added to its profile store with the limited profile
+// data available in the identity file.
 //
 // Use [proxyAddr] to specify the host:port-like address of the proxy.
 // This is necessary because identity files do not store the proxy address.
 // Additionally, the [clusterName] argument can ve used to target a leaf cluster
 // rather than the default root cluster.
-func NewClientStoreFromIdentityFile(identityFile, proxyAddr, clusterName string, opts ...client.StoreConfigOpt) (*client.Store, error) {
-	clientStore := client.NewMemClientStore(opts...)
-	if err := LoadIdentityFileIntoClientStore(clientStore, identityFile, proxyAddr, clusterName); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return clientStore, nil
-}
-
-// LoadIdentityFileIntoClientStore loads the identityFile from the given path
-// into the given client store, assimilating it with other keys in the store.
 func LoadIdentityFileIntoClientStore(store *client.Store, identityFile, proxyAddr, clusterName string) error {
 	if proxyAddr == "" {
 		return trace.BadParameter("missing a Proxy address when loading an Identity File.")

--- a/lib/client/identityfile/identity_test.go
+++ b/lib/client/identityfile/identity_test.go
@@ -422,7 +422,7 @@ func TestKeyFromIdentityFile(t *testing.T) {
 	})
 }
 
-func TestNewClientStoreFromIdentityFile(t *testing.T) {
+func TestLoadIdentityFileIntoClientStore(t *testing.T) {
 	t.Parallel()
 	keyRing := newClientKeyRing(t)
 	keyRing.ProxyHost = "proxy.example.com"
@@ -439,7 +439,8 @@ func TestNewClientStoreFromIdentityFile(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	clientStore, err := NewClientStoreFromIdentityFile(identityFilePath, keyRing.ProxyHost+":3080", keyRing.ClusterName)
+	clientStore := client.NewMemClientStore()
+	err = LoadIdentityFileIntoClientStore(clientStore, identityFilePath, keyRing.ProxyHost+":3080", keyRing.ClusterName)
 	require.NoError(t, err)
 
 	currentProfile, err := clientStore.CurrentProfile()

--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -639,7 +639,7 @@ func (p *ProfileStatus) DatabaseServices() (result []string) {
 
 // DatabasesForCluster returns a list of databases for this profile, for the
 // specified cluster name.
-func (p *ProfileStatus) DatabasesForCluster(clusterName string) ([]tlsca.RouteToDatabase, error) {
+func (p *ProfileStatus) DatabasesForCluster(clusterName string, store *Store) ([]tlsca.RouteToDatabase, error) {
 	if clusterName == "" || clusterName == p.Cluster {
 		return p.Databases, nil
 	}
@@ -649,7 +649,7 @@ func (p *ProfileStatus) DatabasesForCluster(clusterName string) ([]tlsca.RouteTo
 		Username:    p.Username,
 		ClusterName: clusterName,
 	}
-	store := NewFSKeyStore(p.Dir)
+
 	keyRing, err := store.GetKeyRing(idx, nil /*hwks*/, WithDBCerts{})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -659,7 +659,7 @@ func (p *ProfileStatus) DatabasesForCluster(clusterName string) ([]tlsca.RouteTo
 
 // AppsForCluster returns a list of apps for this profile, for the
 // specified cluster name.
-func (p *ProfileStatus) AppsForCluster(clusterName string) ([]tlsca.RouteToApp, error) {
+func (p *ProfileStatus) AppsForCluster(clusterName string, store *Store) ([]tlsca.RouteToApp, error) {
 	if clusterName == "" || clusterName == p.Cluster {
 		return p.Apps, nil
 	}
@@ -670,7 +670,6 @@ func (p *ProfileStatus) AppsForCluster(clusterName string) ([]tlsca.RouteToApp, 
 		ClusterName: clusterName,
 	}
 
-	store := NewFSKeyStore(p.Dir)
 	keyRing, err := store.GetKeyRing(idx, nil /*hwks*/, WithAppCerts{})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -302,6 +302,10 @@ type ProfileStatus struct {
 
 	// GitHubIdentity is the GitHub identity attached to the user.
 	GitHubIdentity *GitHubIdentity
+
+	// TLSRoutingEnabled indicates that proxy supports ALPN SNI server where
+	// all proxy services are exposed on a single TLS listener (Proxy Web Listener).
+	TLSRoutingEnabled bool
 }
 
 // GitHubIdentity is the GitHub identity attached to the user.
@@ -324,6 +328,7 @@ type profileOptions struct {
 	IsVirtual               bool
 	SAMLSingleLogoutEnabled bool
 	SSOHost                 string
+	TLSRoutingEnabled       bool
 }
 
 // profileStatueFromKeyRing returns a ProfileStatus for the given key ring and options.
@@ -428,6 +433,7 @@ func profileStatusFromKeyRing(keyRing *KeyRing, opts profileOptions) (*ProfileSt
 		SAMLSingleLogoutEnabled: opts.SAMLSingleLogoutEnabled,
 		SSOHost:                 opts.SSOHost,
 		GitHubIdentity:          gitHubIdentity,
+		TLSRoutingEnabled:       opts.TLSRoutingEnabled,
 	}, nil
 }
 

--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -656,7 +656,7 @@ func (p *ProfileStatus) DatabasesForCluster(clusterName string, store *Store) ([
 		ClusterName: clusterName,
 	}
 
-	keyRing, err := store.GetKeyRing(idx, nil /*hwks*/, WithDBCerts{})
+	keyRing, err := store.GetKeyRing(idx, WithDBCerts{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -676,7 +676,7 @@ func (p *ProfileStatus) AppsForCluster(clusterName string, store *Store) ([]tlsc
 		ClusterName: clusterName,
 	}
 
-	keyRing, err := store.GetKeyRing(idx, nil /*hwks*/, WithAppCerts{})
+	keyRing, err := store.GetKeyRing(idx, WithAppCerts{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/client/profile_test.go
+++ b/lib/client/profile_test.go
@@ -163,13 +163,14 @@ func Test_profileStatusFromKeyRing(t *testing.T) {
 	}
 	keyRing := auth.makeSignedKeyRing(t, idx, false)
 	profileStatus, err := profileStatusFromKeyRing(keyRing, profileOptions{
-		ProfileName:   profile.Name(),
-		WebProxyAddr:  profile.WebProxyAddr,
-		ProfileDir:    "",
-		Username:      profile.Username,
-		SiteName:      profile.SiteName,
-		KubeProxyAddr: profile.KubeProxyAddr,
-		IsVirtual:     true,
+		ProfileName:       profile.Name(),
+		WebProxyAddr:      profile.WebProxyAddr,
+		ProfileDir:        "",
+		Username:          profile.Username,
+		SiteName:          profile.SiteName,
+		KubeProxyAddr:     profile.KubeProxyAddr,
+		IsVirtual:         true,
+		TLSRoutingEnabled: true,
 	})
 	require.NoError(t, err)
 	require.Equal(t, &ProfileStatus{
@@ -191,6 +192,7 @@ func Test_profileStatusFromKeyRing(t *testing.T) {
 			UserID:   "1234567",
 			Username: "github-username",
 		},
-		CriticalOptions: map[string]string{},
+		CriticalOptions:   map[string]string{},
+		TLSRoutingEnabled: true,
 	}, profileStatus)
 }

--- a/lib/client/weblogin_test.go
+++ b/lib/client/weblogin_test.go
@@ -130,12 +130,12 @@ func TestSSHAgentPasswordlessLogin(t *testing.T) {
 	ctx := context.Background()
 
 	// Prepare client config, it won't change throughout the test.
-	cfg := client.MakeDefaultConfig()
+	cfg := &client.Config{}
+	cfg.ClientStore = client.NewFSClientStore(t.TempDir())
 	cfg.AddKeysToAgent = client.AddKeysToAgentNo
 	// Replace "127.0.0.1" with "localhost". The proxy address becomes the origin
 	// for Webauthn requests, and Webauthn doesn't take IP addresses.
 	cfg.WebProxyAddr = strings.Replace(sa.ProxyWebAddr, "127.0.0.1", "localhost", 1 /* n */)
-	cfg.KeysDir = t.TempDir()
 	cfg.InsecureSkipVerify = true
 
 	solvePwdless := func(ctx context.Context, origin string, assertion *wantypes.CredentialAssertion, prompt wancli.LoginPrompt) (*proto.MFAAuthenticateResponse, error) {

--- a/lib/teleterm/clusters/cluster.go
+++ b/lib/teleterm/clusters/cluster.go
@@ -51,8 +51,6 @@ type Cluster struct {
 	ProfileName string
 	// Logger is a component logger
 	Logger *slog.Logger
-	// dir is the directory where cluster certificates are stored
-	dir string
 	// Status is the cluster status
 	status client.ProfileStatus
 	// If not empty, it means that there was a problem with reading the cluster status.

--- a/lib/teleterm/clusters/config.go
+++ b/lib/teleterm/clusters/config.go
@@ -30,8 +30,6 @@ import (
 
 // Config is the cluster service config
 type Config struct {
-	// Dir is the directory to store cluster profiles
-	Dir string
 	// Clock is a clock for time-related operations
 	Clock clockwork.Clock
 	// InsecureSkipVerify is an option to skip TLS cert check
@@ -49,10 +47,6 @@ type Config struct {
 
 // CheckAndSetDefaults checks the configuration for its validity and sets default values if needed
 func (c *Config) CheckAndSetDefaults() error {
-	if c.Dir == "" {
-		return trace.BadParameter("missing working directory")
-	}
-
 	if c.ClientStore == nil {
 		return trace.BadParameter("missing client store")
 	}

--- a/lib/teleterm/clusters/storage.go
+++ b/lib/teleterm/clusters/storage.go
@@ -272,7 +272,7 @@ func (s *Storage) loadProfileStatusAndClusterKey(clusterClient *client.TeleportC
 }
 
 func (s *Storage) makeClientConfig() *client.Config {
-	cfg := client.MakeDefaultConfig()
+	cfg := &client.Config{}
 	cfg.HomePath = s.Dir
 	cfg.KeysDir = s.Dir
 	cfg.InsecureSkipVerify = s.InsecureSkipVerify

--- a/lib/teleterm/clusters/storage.go
+++ b/lib/teleterm/clusters/storage.go
@@ -210,7 +210,7 @@ func (s *Storage) fromProfile(profileName, leafClusterName string) (*Cluster, *c
 	clusterURI := uri.NewClusterURI(profileName)
 
 	cfg := s.makeClientConfig()
-	if err := cfg.LoadProfile(s.ClientStore, profileName); err != nil {
+	if err := cfg.LoadProfile(profileName); err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 

--- a/lib/teleterm/clusters/storage.go
+++ b/lib/teleterm/clusters/storage.go
@@ -47,7 +47,7 @@ func (s *Storage) ListProfileNames() ([]string, error) {
 
 // ListRootClusters reads root clusters from profiles.
 func (s *Storage) ListRootClusters() ([]*Cluster, error) {
-	pfNames, err := s.ListProfileNames()
+	pfNames, err := s.ClientStore.ListProfiles()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -110,8 +110,7 @@ func (s *Storage) ResolveCluster(resourceURI uri.ResourceURI) (*Cluster, *client
 
 // Remove removes a cluster
 func (s *Storage) Remove(ctx context.Context, profileName string) error {
-	profileStore := client.NewFSProfileStore(s.Dir)
-	return profileStore.DeleteProfile(profileName)
+	return s.ClientStore.DeleteProfile(profileName)
 }
 
 // Add adds a cluster
@@ -136,7 +135,7 @@ func (s *Storage) Add(ctx context.Context, webProxyAddress string) (*Cluster, *c
 		}
 	}
 
-	cluster, clusterClient, err := s.addCluster(ctx, s.Dir, webProxyAddress)
+	cluster, clusterClient, err := s.addCluster(ctx, webProxyAddress)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
@@ -147,13 +146,9 @@ func (s *Storage) Add(ctx context.Context, webProxyAddress string) (*Cluster, *c
 // addCluster adds a new cluster. This makes the underlying profile .yaml file to be saved to the
 // tsh home dir without logging in the user yet. Adding a cluster makes it show up in the UI as the
 // list of clusters depends on the profiles in the home dir of tsh.
-func (s *Storage) addCluster(ctx context.Context, dir, webProxyAddress string) (*Cluster, *client.TeleportClient, error) {
+func (s *Storage) addCluster(ctx context.Context, webProxyAddress string) (*Cluster, *client.TeleportClient, error) {
 	if webProxyAddress == "" {
 		return nil, nil, trace.BadParameter("cluster address is missing")
-	}
-
-	if dir == "" {
-		return nil, nil, trace.BadParameter("cluster directory is missing")
 	}
 
 	profileName := parseName(webProxyAddress)
@@ -194,7 +189,6 @@ func (s *Storage) addCluster(ctx context.Context, dir, webProxyAddress string) (
 		Name:          pingResponse.ClusterName,
 		ProfileName:   profileName,
 		clusterClient: clusterClient,
-		dir:           s.Dir,
 		clock:         s.Clock,
 		Logger:        clusterLog,
 	}, clusterClient, nil
@@ -231,7 +225,6 @@ func (s *Storage) fromProfile(profileName, leafClusterName string) (*Cluster, *c
 		Name:          clusterClient.SiteName,
 		ProfileName:   profileName,
 		clusterClient: clusterClient,
-		dir:           s.Dir,
 		clock:         s.Clock,
 		statusError:   err,
 		Logger:        s.Logger.With("cluster", clusterURI),
@@ -273,8 +266,6 @@ func (s *Storage) loadProfileStatusAndClusterKey(clusterClient *client.TeleportC
 
 func (s *Storage) makeClientConfig() *client.Config {
 	cfg := &client.Config{}
-	cfg.HomePath = s.Dir
-	cfg.KeysDir = s.Dir
 	cfg.InsecureSkipVerify = s.InsecureSkipVerify
 	cfg.AddKeysToAgent = s.AddKeysToAgent
 	cfg.WebauthnLogin = s.WebauthnLogin

--- a/lib/teleterm/daemon/daemon_test.go
+++ b/lib/teleterm/daemon/daemon_test.go
@@ -342,11 +342,8 @@ func TestGatewayCRUD(t *testing.T) {
 }
 
 func TestUpdateTshdEventsServerAddress(t *testing.T) {
-	homeDir := t.TempDir()
-
 	storage, err := clusters.NewStorage(clusters.Config{
-		Dir:                homeDir,
-		ClientStore:        client.NewFSClientStore(homeDir),
+		ClientStore:        client.NewFSClientStore(t.TempDir()),
 		InsecureSkipVerify: true,
 	})
 	require.NoError(t, err)
@@ -378,11 +375,8 @@ func TestUpdateTshdEventsServerAddress(t *testing.T) {
 }
 
 func TestUpdateTshdEventsServerAddress_CredsErr(t *testing.T) {
-	homeDir := t.TempDir()
-
 	storage, err := clusters.NewStorage(clusters.Config{
-		Dir:                homeDir,
-		ClientStore:        client.NewFSClientStore(homeDir),
+		ClientStore:        client.NewFSClientStore(t.TempDir()),
 		InsecureSkipVerify: true,
 	})
 	require.NoError(t, err)
@@ -483,10 +477,8 @@ func TestRetryWithRelogin(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			homeDir := t.TempDir()
 			storage, err := clusters.NewStorage(clusters.Config{
-				Dir:                homeDir,
-				ClientStore:        client.NewFSClientStore(homeDir),
+				ClientStore:        client.NewFSClientStore(t.TempDir()),
 				InsecureSkipVerify: true,
 			})
 			require.NoError(t, err)
@@ -540,10 +532,8 @@ func TestConcurrentHeadlessAuthPrompts(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	homeDir := t.TempDir()
 	storage, err := clusters.NewStorage(clusters.Config{
-		Dir:                homeDir,
-		ClientStore:        client.NewFSClientStore(homeDir),
+		ClientStore:        client.NewFSClientStore(t.TempDir()),
 		InsecureSkipVerify: true,
 	})
 	require.NoError(t, err)

--- a/lib/teleterm/teleterm.go
+++ b/lib/teleterm/teleterm.go
@@ -61,7 +61,6 @@ func Serve(ctx context.Context, cfg Config) error {
 	hwks := piv.NewYubiKeyService(tshdEventsClient.NewHardwareKeyPrompt())
 
 	storage, err := clusters.NewStorage(clusters.Config{
-		Dir:                cfg.HomeDir,
 		Clock:              clock,
 		InsecureSkipVerify: cfg.InsecureSkipVerify,
 		AddKeysToAgent:     cfg.AddKeysToAgent,

--- a/lib/vnet/user_process.go
+++ b/lib/vnet/user_process.go
@@ -18,12 +18,9 @@ package vnet
 
 import (
 	"context"
-	"os"
 
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/api/profile"
-	"github.com/gravitational/teleport/api/types"
 	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
 )
 
@@ -32,17 +29,11 @@ type UserProcessConfig struct {
 	// ClientApplication is a required field providing an interface implementation for
 	// [ClientApplication].
 	ClientApplication ClientApplication
-	// HomePath is the tsh home used for Teleport clients created by VNet. Resolved using the same
-	// rules as HomeDir in tsh.
-	HomePath string
 }
 
 func (c *UserProcessConfig) checkAndSetDefaults() error {
 	if c.ClientApplication == nil {
 		return trace.BadParameter("missing ClientApplication")
-	}
-	if c.HomePath == "" {
-		c.HomePath = profile.FullProfilePath(os.Getenv(types.HomeEnvVar))
 	}
 	return nil
 }

--- a/tool/tctl/common/config/profile.go
+++ b/tool/tctl/common/config/profile.go
@@ -49,9 +49,8 @@ func LoadConfigFromProfile(ccf *GlobalCLIFlags, cfg *servicecfg.Config) (*authcl
 	hwks := libhwk.NewService(ctx, nil /*prompt*/)
 	clientStore := client.NewFSClientStore(cfg.TeleportHome, client.WithHardwareKeyService(hwks))
 	if ccf.IdentityFilePath != "" {
-		var err error
-		clientStore, err = identityfile.NewClientStoreFromIdentityFile(ccf.IdentityFilePath, proxyAddr, "", client.WithHardwareKeyService(hwks))
-		if err != nil {
+		clientStore = client.NewMemClientStore(client.WithHardwareKeyService(hwks))
+		if err := identityfile.LoadIdentityFileIntoClientStore(clientStore, ccf.IdentityFilePath, proxyAddr, ""); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}

--- a/tool/tsh/common/app.go
+++ b/tool/tsh/common/app.go
@@ -294,7 +294,8 @@ func onAppLogout(cf *CLIConf) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	activeRoutes, err := profile.AppsForCluster(tc.SiteName)
+
+	activeRoutes, err := profile.AppsForCluster(tc.SiteName, tc.ClientStore)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -365,7 +366,7 @@ func onAppConfig(cf *CLIConf) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	routes, err := profile.AppsForCluster(tc.SiteName)
+	routes, err := profile.AppsForCluster(tc.SiteName, tc.ClientStore)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tsh/common/db.go
+++ b/tool/tsh/common/db.go
@@ -95,7 +95,7 @@ func onListDatabases(cf *CLIConf) error {
 		logger.DebugContext(cf.Context, "Failed to fetch user roles", "error", err)
 	}
 
-	activeDatabases, err := profile.DatabasesForCluster(tc.SiteName)
+	activeDatabases, err := profile.DatabasesForCluster(tc.SiteName, tc.ClientStore)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -251,7 +251,7 @@ func onDatabaseLogin(cf *CLIConf) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	routes, err := profile.DatabasesForCluster(tc.SiteName)
+	routes, err := profile.DatabasesForCluster(tc.SiteName, tc.ClientStore)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -367,7 +367,7 @@ func onDatabaseLogout(cf *CLIConf) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	activeRoutes, err := profile.DatabasesForCluster(tc.SiteName)
+	activeRoutes, err := profile.DatabasesForCluster(tc.SiteName, tc.ClientStore)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -447,7 +447,7 @@ func onDatabaseEnv(cf *CLIConf) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	routes, err := profile.DatabasesForCluster(tc.SiteName)
+	routes, err := profile.DatabasesForCluster(tc.SiteName, tc.ClientStore)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -509,7 +509,7 @@ func onDatabaseConfig(cf *CLIConf) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	routes, err := profile.DatabasesForCluster(tc.SiteName)
+	routes, err := profile.DatabasesForCluster(tc.SiteName, tc.ClientStore)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -754,7 +754,7 @@ func onDatabaseConnect(cf *CLIConf) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	routes, err := profile.DatabasesForCluster(tc.SiteName)
+	routes, err := profile.DatabasesForCluster(tc.SiteName, tc.ClientStore)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1086,7 +1086,10 @@ func chooseOneDatabase(cf *CLIConf, databases types.Databases) (types.Database, 
 			"%v not found, use '%v' to see registered databases", selectors,
 			formatDatabaseListCommand(cf.SiteName))
 	}
-	errMsg := formatAmbiguousDB(cf, selectors, databases)
+	errMsg, err := formatAmbiguousDB(cf, selectors, databases)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	return nil, trace.BadParameter("%s", errMsg)
 }
 
@@ -1357,7 +1360,7 @@ func needDatabaseRelogin(cf *CLIConf, tc *client.TeleportClient, route tlsca.Rou
 		}
 	}
 	found := false
-	activeDatabases, err := profile.DatabasesForCluster(tc.SiteName)
+	activeDatabases, err := profile.DatabasesForCluster(tc.SiteName, tc.ClientStore)
 	if err != nil {
 		return false, trace.Wrap(err)
 	}
@@ -1812,10 +1815,10 @@ func getDbCmdAlternatives(clusterFlag string, route tlsca.RouteToDatabase) []str
 
 // formatAmbiguousDB is a helper func that formats an ambiguous database error
 // message.
-func formatAmbiguousDB(cf *CLIConf, selectors resourceSelectors, matchedDBs types.Databases) string {
+func formatAmbiguousDB(cf *CLIConf, selectors resourceSelectors, matchedDBs types.Databases) (string, error) {
 	var activeDBs []tlsca.RouteToDatabase
 	if profile, err := cf.ProfileStatus(); err == nil {
-		if dbs, err := profile.DatabasesForCluster(cf.SiteName); err == nil {
+		if dbs, err := profile.DatabasesForCluster(cf.SiteName, cf.clientStore); err == nil {
 			activeDBs = dbs
 		}
 	}
@@ -1828,7 +1831,7 @@ func formatAmbiguousDB(cf *CLIConf, selectors resourceSelectors, matchedDBs type
 
 	listCommand := formatDatabaseListCommand(cf.SiteName)
 	fullNameExample := matchedDBs[0].GetName()
-	return formatAmbiguityErrTemplate(cf, selectors, listCommand, sb.String(), fullNameExample)
+	return formatAmbiguityErrTemplate(cf, selectors, listCommand, sb.String(), fullNameExample), nil
 }
 
 // resourceSelectors is a helper struct for gathering up the selectors for a

--- a/tool/tsh/common/db.go
+++ b/tool/tsh/common/db.go
@@ -1818,7 +1818,7 @@ func getDbCmdAlternatives(clusterFlag string, route tlsca.RouteToDatabase) []str
 func formatAmbiguousDB(cf *CLIConf, selectors resourceSelectors, matchedDBs types.Databases) (string, error) {
 	var activeDBs []tlsca.RouteToDatabase
 	if profile, err := cf.ProfileStatus(); err == nil {
-		if dbs, err := profile.DatabasesForCluster(cf.SiteName, cf.clientStore); err == nil {
+		if dbs, err := profile.DatabasesForCluster(cf.SiteName, cf.getClientStore()); err == nil {
 			activeDBs = dbs
 		}
 	}

--- a/tool/tsh/common/git_list_test.go
+++ b/tool/tsh/common/git_list_test.go
@@ -157,8 +157,7 @@ func mustCreateEmptyProfile(t *testing.T, cf *CLIConf) {
 		cf.HomePath = t.TempDir()
 	}
 
-	cf.initClientStore()
-	err := cf.clientStore.SaveProfile(&profile.Profile{
+	err := cf.getClientStore().SaveProfile(&profile.Profile{
 		SSHProxyAddr: cf.Proxy,
 		WebProxyAddr: cf.Proxy,
 	}, true)

--- a/tool/tsh/common/git_list_test.go
+++ b/tool/tsh/common/git_list_test.go
@@ -157,9 +157,8 @@ func mustCreateEmptyProfile(t *testing.T, cf *CLIConf) {
 		cf.HomePath = t.TempDir()
 	}
 
-	clientStore, err := initClientStore(cf, cf.Proxy)
-	require.NoError(t, err)
-	err = clientStore.SaveProfile(&profile.Profile{
+	cf.initClientStore()
+	err := cf.clientStore.SaveProfile(&profile.Profile{
 		SSHProxyAddr: cf.Proxy,
 		WebProxyAddr: cf.Proxy,
 	}, true)

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -214,7 +214,7 @@ func (c *kubeJoinCommand) run(cf *CLIConf) error {
 			KubeProxyAddr:                 tc.Config.KubeProxyAddr,
 			WebProxyAddr:                  tc.Config.WebProxyAddr,
 			TLSRoutingConnUpgradeRequired: tc.Config.TLSRoutingConnUpgradeRequired,
-			EnableEscapeSequences:         tc.Config.EnableEscapeSequences,
+			EnableEscapeSequences:         !tc.Config.DisableEscapeSequences,
 			Tracker:                       meta,
 			TLSConfig:                     tlsConfig,
 			Mode:                          types.SessionParticipantMode(c.mode),

--- a/tool/tsh/common/proxy.go
+++ b/tool/tsh/common/proxy.go
@@ -143,7 +143,7 @@ func onProxyCommandDB(cf *CLIConf) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	routes, err := profile.DatabasesForCluster(tc.SiteName)
+	routes, err := profile.DatabasesForCluster(tc.SiteName, tc.ClientStore)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -4344,8 +4344,7 @@ func loadClientConfigFromCLIConf(cf *CLIConf, proxy string) (*client.Config, err
 	}
 
 	// 1: start with the defaults
-	c := client.MakeDefaultConfig()
-
+	c := &client.Config{}
 	c.DialOpts = append(c.DialOpts, metadata.WithUserAgentFromTeleportComponent(teleport.ComponentTSH))
 	c.Tracer = cf.tracer
 

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -4238,7 +4238,7 @@ func makeClientForProxy(cf *CLIConf, proxy string) (*client.TeleportClient, erro
 	// Load SSH key for the cluster indicated in the profile.
 	// Handle gracefully if the profile is empty, the key cannot
 	// be found, or the key isn't supported as an agent key.
-	profile, profileError := c.GetProfile(c.ClientStore, proxy)
+	profile, profileError := c.GetProfile(proxy)
 	if profileError == nil {
 		if err := tc.LoadKeyForCluster(ctx, profile.SiteName); err != nil {
 			if !trace.IsNotFound(err) && !trace.IsConnectionProblem(err) && !trace.IsCompareFailed(err) {
@@ -4471,7 +4471,7 @@ func loadClientConfigFromCLIConf(cf *CLIConf, proxy string) (*client.Config, err
 
 	// load profile. if no --proxy is given the currently active profile is used, otherwise
 	// fetch profile for exact proxy we are trying to connect to.
-	profileErr := c.LoadProfile(c.ClientStore, proxy)
+	profileErr := c.LoadProfile(proxy)
 	if profileErr != nil && !trace.IsNotFound(profileErr) {
 		fmt.Printf("WARNING: Failed to load tsh profile for %q: %v\n", proxy, profileErr)
 	}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -4603,7 +4603,7 @@ func loadClientConfigFromCLIConf(cf *CLIConf, proxy string) (*client.Config, err
 		c.AddKeysToAgent = client.AddKeysToAgentNo
 	}
 
-	c.EnableEscapeSequences = cf.EnableEscapeSequences
+	c.DisableEscapeSequences = !cf.EnableEscapeSequences
 
 	// pass along mock functions if provided (only used in tests)
 	c.MockSSOLogin = cf.MockSSOLogin

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1994,7 +1994,6 @@ func onLogin(cf *CLIConf, reExecArgs ...string) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	tc.HomePath = cf.HomePath
 
 	// The user is not logged in and has typed in `tsh --proxy=... login`, if
 	// the running binary needs to be updated, update and re-exec.
@@ -4627,13 +4626,6 @@ func loadClientConfigFromCLIConf(cf *CLIConf, proxy string) (*client.Config, err
 	// pass along MySQL/Postgres path overrides (only used in tests).
 	c.OverrideMySQLOptionFilePath = cf.overrideMySQLOptionFilePath
 	c.OverridePostgresServiceFilePath = cf.overridePostgresServiceFilePath
-
-	// Set tsh home directory
-	c.HomePath = cf.HomePath
-
-	if c.KeysDir == "" {
-		c.KeysDir = c.HomePath
-	}
 
 	if cf.IdentityFileIn != "" {
 		c.NonInteractive = true

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -606,7 +606,10 @@ type CLIConf struct {
 	//
 	// Use getClientStore instead of using this directly to ensure the client store is initialized,
 	// instead of performing nil checks.
-	clientStore    *client.Store
+	clientStore *client.Store
+	// clientStoreSet ensures that the client store is only initialized once. Generally, using an
+	// atomic here is overkill as the CLIConf is generally consumed sequentially. However, occasionally
+	// we need concurrency safety, such as for [forEachProfileParallel].
 	clientStoreSet int32
 }
 

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -927,13 +927,12 @@ func TestMakeClient(t *testing.T) {
 	conf.HomePath = t.TempDir()
 
 	// Create a empty profile so we don't ping proxy.
-	clientStore, err := initClientStore(&conf, conf.Proxy)
-	require.NoError(t, err)
+	conf.initClientStore()
 	profile := &profile.Profile{
 		SSHProxyAddr: "proxy:3023",
 		WebProxyAddr: "proxy:3080",
 	}
-	err = clientStore.SaveProfile(profile, true)
+	err = conf.clientStore.SaveProfile(profile, true)
 	require.NoError(t, err)
 
 	tc, err = makeClient(&conf)
@@ -6458,13 +6457,13 @@ func TestProxyTemplatesMakeClient(t *testing.T) {
 		}
 
 		// Create a empty profile so we don't ping proxy.
-		clientStore, err := initClientStore(conf, conf.Proxy)
+		err := conf.initClientStore()
 		require.NoError(t, err)
 		profile := &profile.Profile{
 			SSHProxyAddr: "proxy:3023",
 			WebProxyAddr: "proxy:3080",
 		}
-		err = clientStore.SaveProfile(profile, true)
+		err = conf.clientStore.SaveProfile(profile, true)
 		require.NoError(t, err)
 
 		modify(conf)

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -6045,7 +6045,13 @@ func TestFlatten(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test execution: validate that flattening succeeds if a profile already exists.
-	conf.IdentityFileIn = identityPath
+	conf = CLIConf{
+		Proxy:              proxyAddr.String(),
+		InsecureSkipVerify: true,
+		IdentityFileIn:     identityPath,
+		HomePath:           freshHome,
+		Context:            context.Background(),
+	}
 	require.NoError(t, flattenIdentity(&conf), "unexpected error when overwriting a tsh profile")
 }
 

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -927,12 +927,12 @@ func TestMakeClient(t *testing.T) {
 	conf.HomePath = t.TempDir()
 
 	// Create a empty profile so we don't ping proxy.
-	conf.initClientStore()
 	profile := &profile.Profile{
 		SSHProxyAddr: "proxy:3023",
 		WebProxyAddr: "proxy:3080",
 	}
-	err = conf.clientStore.SaveProfile(profile, true)
+
+	err = conf.getClientStore().SaveProfile(profile, true)
 	require.NoError(t, err)
 
 	tc, err = makeClient(&conf)
@@ -6457,13 +6457,11 @@ func TestProxyTemplatesMakeClient(t *testing.T) {
 		}
 
 		// Create a empty profile so we don't ping proxy.
-		err := conf.initClientStore()
-		require.NoError(t, err)
 		profile := &profile.Profile{
 			SSHProxyAddr: "proxy:3023",
 			WebProxyAddr: "proxy:3080",
 		}
-		err = conf.clientStore.SaveProfile(profile, true)
+		err := conf.getClientStore().SaveProfile(profile, true)
 		require.NoError(t, err)
 
 		modify(conf)

--- a/tool/tsh/common/vnet_client_application.go
+++ b/tool/tsh/common/vnet_client_application.go
@@ -233,7 +233,7 @@ func (p *vnetClientApplication) newTeleportClient(ctx context.Context, profileNa
 	cfg := &client.Config{
 		ClientStore: p.clientStore,
 	}
-	if err := cfg.LoadProfile(p.clientStore, profileName); err != nil {
+	if err := cfg.LoadProfile(profileName); err != nil {
 		return nil, trace.Wrap(err, "loading client profile")
 	}
 	if leafClusterName != "" {


### PR DESCRIPTION
Related to the [hardware key agent changes](https://github.com/gravitational/teleport/pull/53974). These changes ensure that the hardware key agent is initialized once for `tsh`, `tctl`, and Teleport Connect. As a result, I can remove the global `YubiKeyPIVService` in a follow up, after doing some due diligence to ensure that that wouldn't break arbitrary api clients.

Changes:
- Replace `MakeDefaultConfig` with `CheckAndSetDefaults` to ensure required config is provided
  - Inverted `EnableEscapeSequences` to `DisableEscapeSequences` so that false can be the default.
- Ensure `ClientStore` is always provided in the config for `client.NewClient`
- Ensure `tsh` does not re-initialize client store e.g. after initial profile checks
- Replace remaining uses of `KeysDir` with `ClientStore`. Mostly cleanup work, with one notable change:
   - `tsh config` now returns a useful error if you try to perform it with an identity file. Also future proofed error for unsupported memory client store usage.

Depends on [5422](https://github.com/gravitational/teleport/pull/54226)