### PR TITLE
Empty sections validation and label input tweaks

### DIFF
--- a/web/packages/shared/components/FieldMultiInput/FieldMultiInput.test.tsx
+++ b/web/packages/shared/components/FieldMultiInput/FieldMultiInput.test.tsx
@@ -68,6 +68,12 @@ test('adding, editing, and removing items', async () => {
 
   await user.click(screen.getAllByRole('button', { name: 'Remove Item' })[0]);
   expect(onChange).toHaveBeenLastCalledWith([]);
+
+  await user.type(screen.getByRole('textbox'), 'bananas');
+  expect(onChange).toHaveBeenLastCalledWith(['bananas']);
+
+  await user.clear(screen.getByRole('textbox'));
+  expect(onChange).toHaveBeenLastCalledWith([]);
 });
 
 test('keyboard handling', async () => {

--- a/web/packages/shared/components/FieldMultiInput/FieldMultiInput.tsx
+++ b/web/packages/shared/components/FieldMultiInput/FieldMultiInput.tsx
@@ -84,6 +84,9 @@ export function FieldMultiInput({
     value = [''];
   }
 
+  const unspecifiedGlobalValidationError =
+    hasUnspecifiedGlobalValidationError(validationResult);
+
   const theme = useTheme();
   // Index of the input to be focused after the next rendering.
   const toFocus = useRef<number | undefined>();
@@ -93,12 +96,21 @@ export function FieldMultiInput({
     toFocus.current = undefined;
   };
 
+  function updateItems(newList: string[]) {
+    if (newList.length === 1 && newList[0] === '') {
+      // Collapse the single empty row into an empty model.
+      onChange?.([]);
+    } else {
+      onChange?.(newList);
+    }
+  }
+
   function insertItem(index: number) {
-    onChange?.(value.toSpliced(index, 0, ''));
+    updateItems?.(value.toSpliced(index, 0, ''));
   }
 
   function removeItem(index: number) {
-    onChange?.(value.toSpliced(index, 1));
+    updateItems?.(value.toSpliced(index, 1));
   }
 
   function handleKeyDown(index: number, e: React.KeyboardEvent) {
@@ -122,43 +134,49 @@ export function FieldMultiInput({
             </LabelContent>
           </Legend>
         )}
-        {value.map((val, i) => (
-          // Note on keys: using index as a key is an anti-pattern in general,
-          // but here, we can safely assume that even though the list is
-          // editable, we don't rely on any unmanaged HTML element state other
-          // than focus, which we deal with separately anyway. The alternatives
-          // would be either to require an array with keys generated
-          // synthetically and injected from outside (which would make the API
-          // difficult to use) or to keep the array with generated IDs as local
-          // state (which would require us to write a prop/state reconciliation
-          // procedure whose complexity would probably outweigh the benefits).
-          <Flex key={i} alignItems="center" gap={2}>
-            <Box flex="1">
-              <FieldInput
-                value={val}
-                rule={precomputed(
-                  validationResult.results?.[i] ?? { valid: true }
-                )}
-                ref={toFocus.current === i ? setFocus : null}
-                onChange={e =>
-                  onChange?.(
-                    value.map((v, j) => (j === i ? e.target.value : v))
-                  )
-                }
-                onKeyDown={e => handleKeyDown(i, e)}
-                mb={0}
-              />
-            </Box>
-            <ButtonIcon
-              size="0"
-              title="Remove Item"
-              onClick={() => removeItem(i)}
-              disabled={disabled}
-            >
-              <Icon.Cross size="small" color={theme.colors.text.muted} />
-            </ButtonIcon>
-          </Flex>
-        ))}
+        {value.map((val, i) => {
+          let vr = validationResult.results?.[i];
+          if (unspecifiedGlobalValidationError) {
+            vr = { valid: false };
+          } else if (!vr) {
+            vr = { valid: true };
+          }
+          return (
+            // Note on keys: using index as a key is an anti-pattern in general,
+            // but here, we can safely assume that even though the list is
+            // editable, we don't rely on any unmanaged HTML element state other
+            // than focus, which we deal with separately anyway. The alternatives
+            // would be either to require an array with keys generated
+            // synthetically and injected from outside (which would make the API
+            // difficult to use) or to keep the array with generated IDs as local
+            // state (which would require us to write a prop/state reconciliation
+            // procedure whose complexity would probably outweigh the benefits).
+            <Flex key={i} alignItems="center" gap={2}>
+              <Box flex="1">
+                <FieldInput
+                  value={val}
+                  rule={precomputed(vr)}
+                  ref={toFocus.current === i ? setFocus : null}
+                  onChange={e =>
+                    updateItems(
+                      value.map((v, j) => (j === i ? e.target.value : v))
+                    )
+                  }
+                  onKeyDown={e => handleKeyDown(i, e)}
+                  mb={0}
+                />
+              </Box>
+              <ButtonIcon
+                size="0"
+                title="Remove Item"
+                onClick={() => removeItem(i)}
+                disabled={disabled}
+              >
+                <Icon.Cross size="small" color={theme.colors.text.muted} />
+              </ButtonIcon>
+            </Flex>
+          );
+        })}
         <ButtonSecondary
           alignSelf="start"
           onClick={() => insertItem(value.length)}
@@ -172,6 +190,10 @@ export function FieldMultiInput({
 }
 
 const defaultRule = () => () => ({ valid: true });
+
+function hasUnspecifiedGlobalValidationError(slvr: StringListValidationResult) {
+  return !slvr.valid && (!slvr.results || slvr.results.every(vr => vr.valid));
+}
 
 const Fieldset = styled.fieldset`
   border: none;

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.tsx
@@ -91,6 +91,7 @@ export const RoleEditor = ({
   const yamlEditorId = `${idPrefix}-yaml`;
 
   const [standardModel, dispatch] = useStandardModel(originalRole?.object);
+  const standardModelValid = standardModel.validationResult?.isValid ?? true;
 
   useEffect(() => {
     const { roleModel, validationResult } = standardModel;
@@ -170,6 +171,17 @@ export const RoleEditor = ({
 
   const [confirmingExit, setConfirmingExit] = useState(false);
 
+  const validate = useCallback(
+    (validator: Validator) => {
+      // Show validation errors on newly added sections.
+      dispatch({ type: ActionType.EnableValidation });
+      // Enable instant validation messages and make sure that neither the
+      // standard model validation nor the validator itself are complaining.
+      return validator.validate() && standardModelValid;
+    },
+    [dispatch, standardModelValid]
+  );
+
   const isProcessing =
     parseAttempt.status === 'processing' ||
     yamlifyAttempt.status === 'processing' ||
@@ -187,9 +199,10 @@ export const RoleEditor = ({
     if (
       standardModel.roleModel !== undefined &&
       !standardModel.roleModel?.requiresReset &&
-      !validator.validate()
-    )
+      !validate(validator)
+    ) {
       return;
+    }
     validator.reset();
 
     switch (activeIndex) {

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/AdminRules.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/AdminRules.tsx
@@ -227,7 +227,7 @@ function VerbEditor({
   onVerbChange(verb: Verb, checked: boolean): void;
   onAllVerbsChange(checked: boolean): void;
 }) {
-  const id = useId();
+  const helperTextId = useId();
   const { valid, message } = useRule(rule(verbs));
 
   // Hardcoded column works here because the editor is fixed-width (defined in
@@ -239,7 +239,7 @@ function VerbEditor({
     : 3;
 
   return (
-    <PermissionsFieldset id={id}>
+    <PermissionsFieldset aria-describedby={helperTextId}>
       <Legend>
         <LabelContent required>Permissions</LabelContent>
       </Legend>
@@ -263,7 +263,7 @@ function VerbEditor({
       </PermissionsGrid>
       <HelperTextLine
         hasError={!valid}
-        helperTextId={id}
+        helperTextId={helperTextId}
         errorMessage={message}
       />
     </PermissionsFieldset>

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/MetadataSection.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/MetadataSection.test.tsx
@@ -86,7 +86,6 @@ test('basic editing', async () => {
   await user.clear(screen.getByLabelText('Role Name *'));
   await user.type(screen.getByLabelText('Role Name *'), 'some-name');
   await user.type(screen.getByLabelText('Description'), 'some-description');
-  await user.click(screen.getByRole('button', { name: 'Add a Label' }));
   await user.type(screen.getByPlaceholderText('label key'), 'foo');
   await user.type(screen.getByPlaceholderText('label value'), 'bar');
   await selectEvent.select(screen.getByLabelText('Version'), 'v6');
@@ -103,7 +102,7 @@ test('basic validation', async () => {
   const user = userEvent.setup();
   const { validator } = setup();
   await user.clear(screen.getByLabelText('Role Name *'));
-  await user.click(screen.getByRole('button', { name: 'Add a Label' }));
+  await user.type(screen.getByPlaceholderText('label value'), 'some-value');
   act(() => validator.validate());
 
   expect(screen.getByLabelText('Role Name *')).toHaveAccessibleDescription(

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/MetadataSection.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/MetadataSection.tsx
@@ -158,6 +158,7 @@ export const MetadataSection = memo(
               Labels
             </Text>
             <LabelsInput
+              atLeastOneRow
               disableBtns={isProcessing}
               labels={value.labels}
               setLabels={labels => handleChange({ ...value, labels })}

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.test.tsx
@@ -44,7 +44,6 @@ import {
 } from './standardmodel';
 import { StatefulSection } from './StatefulSection';
 import {
-  GitHubOrganizationAccessValidationResult,
   ResourceAccessValidationResult,
   validateResourceAccess,
 } from './validation';
@@ -69,7 +68,6 @@ describe('ServerAccessSection', () => {
 
   test('editing', async () => {
     const { user, onChange } = setup();
-    await user.click(screen.getByRole('button', { name: 'Add a Label' }));
     await user.type(screen.getByPlaceholderText('label key'), 'some-key');
     await user.type(screen.getByPlaceholderText('label value'), 'some-value');
     await selectEvent.create(screen.getByLabelText('Logins'), 'root', {
@@ -96,7 +94,7 @@ describe('ServerAccessSection', () => {
 
   test('validation', async () => {
     const { user, validator } = setup();
-    await user.click(screen.getByRole('button', { name: 'Add a Label' }));
+    await user.type(screen.getByPlaceholderText('label value'), 'some-value');
     await selectEvent.create(screen.getByLabelText('Logins'), '*', {
       createOptionText: 'Login: *',
     });
@@ -141,7 +139,6 @@ describe('KubernetesAccessSection', () => {
       createOptionText: 'Group: group2',
     });
 
-    await user.click(screen.getByRole('button', { name: 'Add a Label' }));
     await user.type(screen.getByPlaceholderText('label key'), 'some-key');
     await user.type(screen.getByPlaceholderText('label value'), 'some-value');
 
@@ -257,7 +254,7 @@ describe('KubernetesAccessSection', () => {
 
   test('validation', async () => {
     const { user, validator } = setup(RoleVersion.V6);
-    await user.click(screen.getByRole('button', { name: 'Add a Label' }));
+    await user.type(screen.getByPlaceholderText('label value'), 'some-value');
     await user.click(
       screen.getByRole('button', { name: 'Add a Kubernetes Resource' })
     );
@@ -323,7 +320,6 @@ describe('AppAccessSection', () => {
 
   test('editing', async () => {
     const { user, onChange } = setup();
-    await user.click(screen.getByRole('button', { name: 'Add a Label' }));
     await user.type(screen.getByPlaceholderText('label key'), 'env');
     await user.type(screen.getByPlaceholderText('label value'), 'prod');
 
@@ -369,7 +365,7 @@ describe('AppAccessSection', () => {
 
   test('validation', async () => {
     const { user, validator } = setup();
-    await user.click(screen.getByRole('button', { name: 'Add a Label' }));
+    await user.type(screen.getByPlaceholderText('label value'), 'some-value');
     await user.click(
       within(awsRoleArns()).getByRole('button', { name: 'Add More' })
     );
@@ -420,7 +416,6 @@ describe('DatabaseAccessSection', () => {
     const { user, onChange } = setup();
 
     const labels = within(screen.getByRole('group', { name: 'Labels' }));
-    await user.click(labels.getByRole('button', { name: 'Add a Label' }));
     await user.type(labels.getByPlaceholderText('label key'), 'env');
     await user.type(labels.getByPlaceholderText('label value'), 'prod');
 
@@ -436,9 +431,6 @@ describe('DatabaseAccessSection', () => {
 
     const dbServiceLabels = within(
       screen.getByRole('group', { name: 'Database Service Labels' })
-    );
-    await user.click(
-      dbServiceLabels.getByRole('button', { name: 'Add a Label' })
     );
     await user.type(dbServiceLabels.getByPlaceholderText('label key'), 'foo');
     await user.type(dbServiceLabels.getByPlaceholderText('label value'), 'bar');
@@ -466,12 +458,13 @@ describe('DatabaseAccessSection', () => {
   test('validation', async () => {
     const { user, validator } = setup();
     const labels = within(screen.getByRole('group', { name: 'Labels' }));
-    await user.click(labels.getByRole('button', { name: 'Add a Label' }));
+    await user.type(labels.getByPlaceholderText('label value'), 'some-value');
     const dbServiceLabelsGroup = within(
       screen.getByRole('group', { name: 'Database Service Labels' })
     );
-    await user.click(
-      dbServiceLabelsGroup.getByRole('button', { name: 'Add a Label' })
+    await user.type(
+      dbServiceLabelsGroup.getByPlaceholderText('label value'),
+      'some-value'
     );
     await selectEvent.create(screen.getByLabelText('Database Roles'), '*', {
       createOptionText: 'Database Role: *',
@@ -509,7 +502,6 @@ describe('WindowsDesktopAccessSection', () => {
 
   test('editing', async () => {
     const { user, onChange } = setup();
-    await user.click(screen.getByRole('button', { name: 'Add a Label' }));
     await user.type(screen.getByPlaceholderText('label key'), 'os');
     await user.type(screen.getByPlaceholderText('label value'), 'win-xp');
     await selectEvent.create(screen.getByLabelText('Logins'), 'julio', {
@@ -528,7 +520,7 @@ describe('WindowsDesktopAccessSection', () => {
 
   test('validation', async () => {
     const { user, validator } = setup();
-    await user.click(screen.getByRole('button', { name: 'Add a Label' }));
+    await user.type(screen.getByPlaceholderText('label value'), 'some-value');
     act(() => validator.validate());
     expect(
       screen.getByPlaceholderText('label key')
@@ -541,10 +533,7 @@ describe('GitHubOrganizationAccessSection', () => {
     const onChange = jest.fn();
     let validator: Validator;
     render(
-      <StatefulSection<
-        GitHubOrganizationAccess,
-        GitHubOrganizationAccessValidationResult
-      >
+      <StatefulSection<GitHubOrganizationAccess, ResourceAccessValidationResult>
         component={GitHubOrganizationAccessSection}
         defaultValue={newResourceAccess('git_server', defaultRoleVersion)}
         onChange={onChange}

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.tsx
@@ -20,7 +20,7 @@ import { memo } from 'react';
 import styled, { useTheme } from 'styled-components';
 
 import Box from 'design/Box';
-import { ButtonSecondary } from 'design/Button';
+import { Button } from 'design/Button';
 import ButtonIcon from 'design/ButtonIcon';
 import Flex from 'design/Flex';
 import { Add, Plus, Trash } from 'design/Icon';
@@ -33,6 +33,7 @@ import {
   FieldSelectCreatable,
 } from 'shared/components/FieldSelect';
 import { MenuButton, MenuItem } from 'shared/components/MenuAction';
+import { useRule } from 'shared/components/Validation';
 import { precomputed } from 'shared/components/Validation/rules';
 import { ValidationSuspender } from 'shared/components/Validation/Validation';
 
@@ -245,6 +246,7 @@ export function ServerAccessSection({
   return (
     <>
       <LabelsInput
+        atLeastOneRow
         legend="Labels"
         disableBtns={isProcessing}
         labels={value.labels}
@@ -278,6 +280,9 @@ export function KubernetesAccessSection({
   validation,
   onChange,
 }: SectionProps<KubernetesAccess, KubernetesAccessValidationResult>) {
+  const resourcesValidationResult = useRule(
+    precomputed(validation.fields.resources)(value.resources)
+  );
   return (
     <>
       <FieldSelectCreatable
@@ -293,6 +298,7 @@ export function KubernetesAccessSection({
         value={value.groups}
         onChange={groups => onChange?.({ ...value, groups })}
         menuPosition="fixed"
+        rule={precomputed(validation.fields.groups)}
       />
 
       <FieldSelectCreatable
@@ -308,9 +314,11 @@ export function KubernetesAccessSection({
         value={value.users}
         onChange={users => onChange?.({ ...value, users })}
         menuPosition="fixed"
+        rule={precomputed(validation.fields.users)}
       />
 
       <LabelsInput
+        atLeastOneRow
         legend="Labels"
         disableBtns={isProcessing}
         labels={value.labels}
@@ -343,7 +351,9 @@ export function KubernetesAccessSection({
         ))}
 
         <Box>
-          <ButtonSecondary
+          <Button
+            fill={resourcesValidationResult.valid ? 'filled' : 'border'}
+            intent={resourcesValidationResult.valid ? 'neutral' : 'danger'}
             disabled={isProcessing}
             gap={1}
             onClick={() =>
@@ -360,7 +370,7 @@ export function KubernetesAccessSection({
             {value.resources.length > 0
               ? 'Add Another Kubernetes Resource'
               : 'Add a Kubernetes Resource'}
-          </ButtonSecondary>
+          </Button>
         </Box>
       </Flex>
     </>
@@ -465,6 +475,7 @@ export function AppAccessSection({
   return (
     <Flex flexDirection="column" gap={3}>
       <LabelsInput
+        atLeastOneRow
         legend="Labels"
         disableBtns={isProcessing}
         labels={value.labels}
@@ -506,6 +517,7 @@ export function DatabaseAccessSection({
     <>
       <Box mb={3}>
         <LabelsInput
+          atLeastOneRow
           legend="Labels"
           tooltipContent="Access to databases with these labels will be affected by this role"
           disableBtns={isProcessing}
@@ -533,6 +545,7 @@ export function DatabaseAccessSection({
         value={value.names}
         onChange={names => onChange?.({ ...value, names })}
         menuPosition="fixed"
+        rule={precomputed(validation.fields.names)}
       />
       <FieldSelectCreatable
         isMulti
@@ -553,6 +566,7 @@ export function DatabaseAccessSection({
         value={value.users}
         onChange={users => onChange?.({ ...value, users })}
         menuPosition="fixed"
+        rule={precomputed(validation.fields.users)}
       />
       <FieldSelectCreatable
         isMulti
@@ -571,6 +585,7 @@ export function DatabaseAccessSection({
         menuPosition="fixed"
       />
       <LabelsInput
+        atLeastOneRow
         legend="Database Service Labels"
         tooltipContent="The database service labels control which Database Services (Teleport Agents) are visible to the user, which is required when adding Databases in the Enroll New Resource wizard. Access to Databases themselves is controlled by the Database Labels field."
         disableBtns={isProcessing}
@@ -592,6 +607,7 @@ export function WindowsDesktopAccessSection({
     <>
       <Box mb={3}>
         <LabelsInput
+          atLeastOneRow
           legend="Labels"
           disableBtns={isProcessing}
           labels={value.labels}
@@ -613,6 +629,7 @@ export function WindowsDesktopAccessSection({
         value={value.logins}
         onChange={logins => onChange?.({ ...value, logins })}
         menuPosition="fixed"
+        rule={precomputed(validation.fields.logins)}
       />
     </>
   );
@@ -621,6 +638,7 @@ export function WindowsDesktopAccessSection({
 export function GitHubOrganizationAccessSection({
   value,
   isProcessing,
+  validation,
   onChange,
 }: SectionProps<
   GitHubOrganizationAccess,
@@ -641,6 +659,8 @@ export function GitHubOrganizationAccessSection({
       value={value.organizations}
       onChange={organizations => onChange?.({ ...value, organizations })}
       menuPosition="fixed"
+      rule={precomputed(validation.fields.organizations)}
+      mb={0}
     />
   );
 }

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.test.tsx
@@ -133,8 +133,8 @@ test('invisible tabs still apply validation', async () => {
     />
   );
 
-  // Cause a validation error by adding an empty label.
-  await user.click(screen.getByRole('button', { name: 'Add a Label' }));
+  // Cause a validation error by adding a label with an empty key.
+  await user.type(screen.getByPlaceholderText('label value'), 'bar');
 
   // Switch to a different tab.
   await user.click(getTabByName('Resources'));
@@ -144,7 +144,6 @@ test('invisible tabs still apply validation', async () => {
   // Switch back, make it valid.
   await user.click(getTabByName('Invalid data Overview'));
   await user.type(screen.getByPlaceholderText('label key'), 'foo');
-  await user.type(screen.getByPlaceholderText('label value'), 'bar');
   await user.click(screen.getByRole('button', { name: 'Save Changes' }));
   expect(onSave).toHaveBeenCalled();
 });
@@ -158,8 +157,8 @@ test('hidden validation errors should not propagate to tab headings', async () =
     />
   );
 
-  // Cause a validation error by adding an empty label.
-  await user.click(screen.getByRole('button', { name: 'Add a Label' }));
+  // Cause a validation error by adding a label with an empty key.
+  await user.type(screen.getByPlaceholderText('label value'), 'bar');
   await user.click(screen.getByRole('button', { name: 'Save Changes' }));
   expect(onSave).not.toHaveBeenCalled();
 
@@ -169,7 +168,10 @@ test('hidden validation errors should not propagate to tab headings', async () =
     screen.getByRole('button', { name: 'Add Teleport Resource Access' })
   );
   await user.click(screen.getByRole('menuitem', { name: 'SSH Server Access' }));
-  await user.click(screen.getByRole('button', { name: 'Add a Label' }));
+  await user.type(
+    within(getSectionByName('Servers')).getByPlaceholderText('label value'),
+    'some-value'
+  );
 
   // Switch to the Admin Rules tab. Add a new section (it's invalid by
   // default).
@@ -326,16 +328,21 @@ test('tab-level validation when creating a new role', async () => {
     screen.getByRole('button', { name: 'Add Teleport Resource Access' })
   );
   await user.click(screen.getByRole('menuitem', { name: 'SSH Server Access' }));
-  await user.click(screen.getByRole('button', { name: 'Add a Label' }));
-  // The form should not be validating until we try to switch to the next tab.
-  expect(screen.getByPlaceholderText('label key')).toHaveAccessibleDescription(
-    ''
+  await user.type(
+    within(getSectionByName('Servers')).getByPlaceholderText('label value'),
+    'bar'
   );
+  // The form should not be validating until we try to switch to the next tab.
+  expect(
+    within(getSectionByName('Servers')).getByPlaceholderText('label key')
+  ).toHaveAccessibleDescription('');
   await user.click(screen.getByRole('button', { name: 'Next: Admin Rules' }));
   expect(getTabByName('Admin Rules')).toHaveAttribute('aria-selected', 'false');
   // Fix the field value and retry.
-  await user.type(screen.getByPlaceholderText('label key'), 'foo');
-  await user.type(screen.getByPlaceholderText('label value'), 'bar');
+  await user.type(
+    within(getSectionByName('Servers')).getByPlaceholderText('label key'),
+    'foo'
+  );
   await user.click(screen.getByRole('button', { name: 'Next: Admin Rules' }));
   expect(getTabByName('Admin Rules')).toHaveAttribute('aria-selected', 'true');
 });

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.test.tsx
@@ -169,7 +169,9 @@ test('hidden validation errors should not propagate to tab headings', async () =
   );
   await user.click(screen.getByRole('menuitem', { name: 'SSH Server Access' }));
   await user.type(
-    within(getSectionByName('Servers')).getByPlaceholderText('label value'),
+    within(getSectionByName('SSH Server Access')).getByPlaceholderText(
+      'label value'
+    ),
     'some-value'
   );
 
@@ -329,18 +331,24 @@ test('tab-level validation when creating a new role', async () => {
   );
   await user.click(screen.getByRole('menuitem', { name: 'SSH Server Access' }));
   await user.type(
-    within(getSectionByName('Servers')).getByPlaceholderText('label value'),
+    within(getSectionByName('SSH Server Access')).getByPlaceholderText(
+      'label value'
+    ),
     'bar'
   );
   // The form should not be validating until we try to switch to the next tab.
   expect(
-    within(getSectionByName('Servers')).getByPlaceholderText('label key')
+    within(getSectionByName('SSH Server Access')).getByPlaceholderText(
+      'label key'
+    )
   ).toHaveAccessibleDescription('');
   await user.click(screen.getByRole('button', { name: 'Next: Admin Rules' }));
   expect(getTabByName('Admin Rules')).toHaveAttribute('aria-selected', 'false');
   // Fix the field value and retry.
   await user.type(
-    within(getSectionByName('Servers')).getByPlaceholderText('label key'),
+    within(getSectionByName('SSH Server Access')).getByPlaceholderText(
+      'label key'
+    ),
     'foo'
   );
   await user.click(screen.getByRole('button', { name: 'Next: Admin Rules' }));

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/sections.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/sections.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Fragment, PropsWithChildren, useEffect, useState } from 'react';
+import { Fragment, PropsWithChildren, useEffect, useId, useState } from 'react';
 import styled, { useTheme } from 'styled-components';
 
 import Box, { BoxProps } from 'design/Box';
@@ -26,6 +26,7 @@ import { Check, ChevronDown, Trash, WarningCircle } from 'design/Icon';
 import Text, { H3 } from 'design/Text';
 import { HoverTooltip, IconTooltip } from 'design/Tooltip';
 import { useResizeObserver } from 'design/utils/useResizeObserver';
+import { HelperTextLine } from 'shared/components/FieldInput/FieldInput';
 import { useValidation } from 'shared/components/Validation';
 import { ValidationResult } from 'shared/components/Validation/rules';
 
@@ -97,6 +98,7 @@ export const SectionBox = ({
     expansionState === ExpansionState.Collapsed ? 'Collapse' : 'Expand';
   const validator = useValidation();
   const [contentHeight, setContentHeight] = useState(0);
+  const helperTextId = useId();
 
   // Points to the content element whose height will be observed for setting
   // target height of the expand animation.
@@ -151,6 +153,7 @@ export const SectionBox = ({
       }
       borderRadius={3}
       role="group"
+      aria-describedby={helperTextId}
     >
       <Summary
         height="56px"
@@ -250,6 +253,21 @@ export const SectionBox = ({
             children. */}
         <Box px={sectionBoxPadding} pb={sectionBoxPadding} ref={contentRef}>
           {children}
+          <Box
+            mt={
+              validator.state.validating &&
+              !validation.valid &&
+              validation.message
+                ? 2
+                : 0
+            }
+          >
+            <HelperTextLine
+              hasError={validator.state.validating && !validation.valid}
+              errorMessage={validation.message}
+              helperTextId={helperTextId}
+            />
+          </Box>
         </Box>
       </ContentExpander>
     </Box>

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/validation.test.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/validation.test.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ResourceKind } from 'teleport/services/resources';
+import { ResourceKind, RoleVersion } from 'teleport/services/resources';
 
 import {
   defaultRoleVersion,
@@ -165,7 +165,7 @@ describe('validateRoleEditorModel', () => {
     expect(result.isValid).toBe(false);
   });
 
-  test('invalid resource', () => {
+  test('invalid resources', () => {
     const model = minimalRoleModel();
     model.resources = [
       {
@@ -174,9 +174,54 @@ describe('validateRoleEditorModel', () => {
         logins: [],
         hideValidationErrors: false,
       },
+      {
+        kind: 'node',
+        labels: [],
+        logins: [],
+        hideValidationErrors: false,
+      },
+      {
+        kind: 'kube_cluster',
+        groups: [],
+        labels: [],
+        resources: [],
+        users: [],
+        hideValidationErrors: false,
+        roleVersion: RoleVersion.V7,
+      },
+      {
+        kind: 'db',
+        labels: [],
+        names: [],
+        users: [],
+        roles: [],
+        dbServiceLabels: [],
+        hideValidationErrors: false,
+      },
+      {
+        kind: 'app',
+        labels: [],
+        awsRoleARNs: [],
+        azureIdentities: [],
+        gcpServiceAccounts: [],
+        hideValidationErrors: false,
+      },
+      {
+        kind: 'windows_desktop',
+        labels: [],
+        logins: [],
+        hideValidationErrors: false,
+      },
     ];
     const result = validateRoleEditorModel(model, undefined, undefined);
-    expect(validity(result.resources)).toEqual([false]);
+    expect(validity(result.resources)).toEqual([
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+    ]);
     expect(result.isValid).toBe(false);
   });
 

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/validation.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/validation.ts
@@ -32,13 +32,19 @@ import {
 } from 'teleport/services/resources';
 
 import {
+  AppAccess,
+  DatabaseAccess,
+  KubernetesAccess,
   KubernetesResourceModel,
   KubernetesVerbOption,
   MetadataModel,
   ResourceAccess,
+  ResourceKindOption,
   RoleEditorModel,
   RuleModel,
+  ServerAccess,
   VerbModel,
+  WindowsDesktopAccess,
 } from './standardmodel';
 
 export const kubernetesClusterWideResourceKinds: KubernetesResourceKind[] = [
@@ -160,17 +166,17 @@ export function validateResourceAccess(
   const { kind } = resource;
   switch (kind) {
     case 'kube_cluster':
-      return runRules(resource, kubernetesAccessValidationRules);
+      return validateKubernetesAccess(resource);
     case 'node':
-      return runRules(resource, serverAccessValidationRules);
+      return validateServerAccess(resource);
     case 'app':
-      return runRules(resource, appAccessValidationRules);
+      return validateAppAccess(resource);
     case 'db':
-      return runRules(resource, databaseAccessValidationRules);
+      return validateDatabaseAccess(resource);
     case 'windows_desktop':
-      return runRules(resource, windowsDesktopAccessValidationRules);
+      return validateWindowsDesktopAccess(resource);
     case 'git_server':
-      return { valid: true };
+      return runRules(resource, gitHubOrganizationAccessValidationRules);
     default:
       kind satisfies never;
   }
@@ -254,7 +260,31 @@ const validKubernetesVerbs = (
   };
 };
 
+const validateKubernetesAccess = (
+  a: KubernetesAccess
+): KubernetesAccessValidationResult => {
+  const result = runRules(a, kubernetesAccessValidationRules);
+  if (
+    a.groups.length === 0 &&
+    a.users.length === 0 &&
+    a.labels.length === 0 &&
+    a.resources.length === 0
+  ) {
+    result.valid = false;
+    result.message = 'At least one group, user, label, or resource required';
+    result.fields.groups.valid = false;
+    result.fields.users.valid = false;
+    result.fields.labels.valid = false;
+    result.fields.resources.valid = false;
+  }
+  return result;
+};
+
+const alwaysValid = () => () => ({ valid: true });
+
 const kubernetesAccessValidationRules = {
+  groups: alwaysValid,
+  users: alwaysValid,
   labels: nonEmptyLabels,
   resources: arrayOf(validKubernetesResource),
 };
@@ -272,6 +302,19 @@ const noWildcardOptions = (message: string) => (options: Option[]) => () => {
   return { valid, message: valid ? '' : message };
 };
 
+const validateServerAccess = (
+  a: ServerAccess
+): ServerAccessValidationResult => {
+  const result = runRules(a, serverAccessValidationRules);
+  if (a.labels.length === 0 && a.logins.length === 0) {
+    result.valid = false;
+    result.message = 'At least one label or login required';
+    result.fields.labels.valid = false;
+    result.fields.logins.valid = false;
+  }
+  return result;
+};
+
 const serverAccessValidationRules = {
   labels: nonEmptyLabels,
   logins: noWildcardOptions('Wildcard is not allowed in logins'),
@@ -279,6 +322,25 @@ const serverAccessValidationRules = {
 export type ServerAccessValidationResult = RuleSetValidationResult<
   typeof serverAccessValidationRules
 >;
+
+const validateAppAccess = (a: AppAccess): AppAccessValidationResult => {
+  const result = runRules(a, appAccessValidationRules);
+  if (
+    a.labels.length === 0 &&
+    a.awsRoleARNs.length === 0 &&
+    a.azureIdentities.length === 0 &&
+    a.gcpServiceAccounts.length === 0
+  ) {
+    result.valid = false;
+    result.message =
+      'At least one label, AWS role ARN, Azure identity, or GCP service account required';
+    result.fields.labels.valid = false;
+    result.fields.awsRoleARNs.valid = false;
+    result.fields.azureIdentities.valid = false;
+    result.fields.gcpServiceAccounts.valid = false;
+  }
+  return result;
+};
 
 const appAccessValidationRules = {
   labels: nonEmptyLabels,
@@ -294,8 +356,33 @@ export type AppAccessValidationResult = RuleSetValidationResult<
   typeof appAccessValidationRules
 >;
 
+const validateDatabaseAccess = (
+  a: DatabaseAccess
+): DatabaseAccessValidationResult => {
+  const result = runRules(a, databaseAccessValidationRules);
+  if (
+    a.labels.length === 0 &&
+    a.names.length === 0 &&
+    a.users.length === 0 &&
+    a.roles.length === 0 &&
+    a.dbServiceLabels.length === 0
+  ) {
+    result.valid = false;
+    result.message =
+      'At least one label, database name, user, role, or service label required';
+    result.fields.labels.valid = false;
+    result.fields.names.valid = false;
+    result.fields.users.valid = false;
+    result.fields.roles.valid = false;
+    result.fields.dbServiceLabels.valid = false;
+  }
+  return result;
+};
+
 const databaseAccessValidationRules = {
   labels: nonEmptyLabels,
+  names: alwaysValid,
+  users: alwaysValid,
   roles: noWildcardOptions('Wildcard is not allowed in database roles'),
   dbServiceLabels: nonEmptyLabels,
 };
@@ -303,14 +390,33 @@ export type DatabaseAccessValidationResult = RuleSetValidationResult<
   typeof databaseAccessValidationRules
 >;
 
+const validateWindowsDesktopAccess = (
+  a: WindowsDesktopAccess
+): WindowsDesktopAccessValidationResult => {
+  const result = runRules(a, windowsDesktopAccessValidationRules);
+  if (a.labels.length === 0 && a.logins.length === 0) {
+    result.valid = false;
+    result.message = 'At least one label or login required';
+    result.fields.labels.valid = false;
+    result.fields.logins.valid = false;
+  }
+  return result;
+};
+
 const windowsDesktopAccessValidationRules = {
   labels: nonEmptyLabels,
+  logins: alwaysValid,
 };
 export type WindowsDesktopAccessValidationResult = RuleSetValidationResult<
   typeof windowsDesktopAccessValidationRules
 >;
 
-export type GitHubOrganizationAccessValidationResult = ValidationResult;
+const gitHubOrganizationAccessValidationRules = {
+  organizations: requiredField<Option>('At least one organization required'),
+};
+export type GitHubOrganizationAccessValidationResult = RuleSetValidationResult<
+  typeof gitHubOrganizationAccessValidationRules
+>;
 
 export function validateAdminRuleList(
   rules: RuleModel[],
@@ -343,7 +449,9 @@ const requiredVerbs = (message: string) => (verbs: VerbModel[]) => () => {
 };
 
 const adminRuleValidationRules = {
-  resources: requiredField('At least one resource kind is required'),
+  resources: requiredField<ResourceKindOption>(
+    'At least one resource kind is required'
+  ),
   verbs: requiredVerbs('At least one permission is required'),
 };
 export type AdminRuleValidationResult = RuleSetValidationResult<

--- a/web/packages/teleport/src/components/LabelsInput/LabelsInput.story.tsx
+++ b/web/packages/teleport/src/components/LabelsInput/LabelsInput.story.tsx
@@ -36,14 +36,14 @@ const meta: Meta = {
 export default meta;
 
 export const Default = () => {
-  const [labels, setLables] = useState<Label[]>([]);
+  const [labels, setLabels] = useState<Label[]>([]);
 
   return (
     <Validation>
       {({ validator }) => (
         <div>
           <div>
-            <LabelsInput labels={labels} setLabels={setLables} />
+            <LabelsInput labels={labels} setLabels={setLabels} />
           </div>
           <ButtonSecondary
             mt={6}
@@ -62,12 +62,12 @@ export const Default = () => {
 };
 
 export const Custom = () => {
-  const [labels, setLables] = useState<Label[]>([]);
+  const [labels, setLabels] = useState<Label[]>([]);
   return (
     <Validation>
       <LabelsInput
         labels={labels}
-        setLabels={setLables}
+        setLabels={setLabels}
         legend="List of Labels"
         tooltipContent="List of labels, 'nuff said"
         labelKey={{
@@ -85,34 +85,48 @@ export const Custom = () => {
 };
 
 export const Disabled = () => {
-  const [labels, setLables] = useState<Label[]>([
+  const [labels, setLabels] = useState<Label[]>([
     { name: 'some-name', value: 'some-value' },
   ]);
   return (
     <Validation>
-      <LabelsInput labels={labels} setLabels={setLables} disableBtns={true} />
+      <LabelsInput labels={labels} setLabels={setLabels} disableBtns={true} />
     </Validation>
   );
 };
 
 export const AutoFocus = () => {
-  const [labels, setLables] = useState<Label[]>([{ name: '', value: '' }]);
+  const [labels, setLabels] = useState<Label[]>([{ name: '', value: '' }]);
   return (
     <Validation>
-      <LabelsInput labels={labels} setLabels={setLables} autoFocus={true} />
+      <LabelsInput labels={labels} setLabels={setLabels} autoFocus={true} />
     </Validation>
   );
 };
 
 export const AtLeastOneRequired = () => {
-  const [labels, setLables] = useState<Label[]>([{ name: '', value: '' }]);
+  const [labels, setLabels] = useState<Label[]>([{ name: '', value: '' }]);
   return (
     <Validation>
       <LabelsInput
         legend="Labels"
         labels={labels}
-        setLabels={setLables}
+        setLabels={setLabels}
         required={true}
+      />
+    </Validation>
+  );
+};
+
+export const AtLeastOneRowVisible = () => {
+  const [labels, setLabels] = useState<Label[]>([]);
+  return (
+    <Validation>
+      <LabelsInput
+        legend="Labels"
+        labels={labels}
+        setLabels={setLabels}
+        atLeastOneRow
       />
     </Validation>
   );

--- a/web/packages/teleport/src/components/LabelsInput/LabelsInput.test.tsx
+++ b/web/packages/teleport/src/components/LabelsInput/LabelsInput.test.tsx
@@ -17,11 +17,18 @@
  */
 
 import { act } from '@testing-library/react';
+import { useState } from 'react';
 
-import { fireEvent, render, screen } from 'design/utils/testing';
+import { fireEvent, render, screen, userEvent } from 'design/utils/testing';
 import Validation, { Validator } from 'shared/components/Validation';
 
-import { Label, LabelsInput, LabelsRule, nonEmptyLabels } from './LabelsInput';
+import {
+  Label,
+  LabelsInput,
+  LabelsInputProps,
+  LabelsRule,
+  nonEmptyLabels,
+} from './LabelsInput';
 import {
   AtLeastOneRequired,
   Custom,
@@ -90,12 +97,18 @@ test('with custom texts', async () => {
 });
 
 test('disabled buttons', async () => {
+  const user = userEvent.setup();
   render(<Disabled />);
 
   expect(screen.getByTitle(/remove label/i)).toBeDisabled();
   expect(
     screen.getByRole('button', { name: 'Add another Label' })
   ).toBeDisabled();
+
+  await user.click(screen.getByTitle(/remove label/i));
+  expect(
+    screen.getAllByRole('textbox').map((t: HTMLInputElement) => t.value)
+  ).toEqual(['some-name', 'some-value']);
 });
 
 test('removing last label is not possible due to requiring labels', async () => {
@@ -110,16 +123,70 @@ test('removing last label is not possible due to requiring labels', async () => 
   expect(screen.getByPlaceholderText('label value')).toBeInTheDocument();
 });
 
+test('at least one row', async () => {
+  function TestCase({ onLabelsChange }: { onLabelsChange(l: Label[]): void }) {
+    const [labels, setLabels] = useState<Label[]>([]);
+    function handleSetLabels(l) {
+      setLabels(l);
+      onLabelsChange(l);
+    }
+    return (
+      <Validation>
+        <LabelsInput
+          legend="Labels"
+          labels={labels}
+          setLabels={handleSetLabels}
+          atLeastOneRow
+        />
+      </Validation>
+    );
+  }
+
+  const user = userEvent.setup();
+  const onLabelsChange = jest.fn();
+  render(<TestCase onLabelsChange={onLabelsChange} />);
+
+  expect(screen.getByTitle(/remove label/i)).toBeDisabled();
+
+  // Set one label.
+  await user.type(screen.getByPlaceholderText('label key'), 'foo');
+  await user.type(screen.getByPlaceholderText('label value'), 'bar');
+  expect(onLabelsChange).toHaveBeenLastCalledWith([
+    { name: 'foo', value: 'bar' },
+  ]);
+
+  // Remove the label, expect an empty model.
+  await user.click(screen.getByTitle(/remove label/i));
+  expect(
+    screen.getAllByRole('textbox').map((t: HTMLInputElement) => t.value)
+  ).toEqual(['', '']);
+  expect(onLabelsChange).toHaveBeenLastCalledWith([]);
+
+  // Start typing, expect a non-empty model.
+  await user.type(screen.getAllByRole('textbox')[0], 'foo');
+  expect(onLabelsChange).toHaveBeenLastCalledWith([{ name: 'foo', value: '' }]);
+
+  // Clear the text box, expect an empty model.
+  await user.clear(screen.getAllByRole('textbox')[0]);
+  expect(onLabelsChange).toHaveBeenLastCalledWith([]);
+
+  // Set the first label, add another empty one, and then remove the first one.
+  // Expect an empty model.
+  await user.type(screen.getByPlaceholderText('label key'), 'foo');
+  await user.type(screen.getByPlaceholderText('label value'), 'bar');
+  await user.click(screen.getByRole('button', { name: 'Add another Label' }));
+  await user.click(screen.getAllByTitle(/remove label/i)[0]);
+  expect(onLabelsChange).toHaveBeenLastCalledWith([]);
+});
+
 describe('validation rules', () => {
-  function setup(labels: Label[], rule: LabelsRule) {
+  function setup(props: Partial<LabelsInputProps>) {
     let validator: Validator;
     render(
       <Validation>
         {({ validator: v }) => {
           validator = v;
-          return (
-            <LabelsInput labels={labels} setLabels={() => {}} rule={rule} />
-          );
+          return <LabelsInput labels={[]} setLabels={() => {}} {...props} />;
         }}
       </Validation>
     );
@@ -131,14 +198,14 @@ describe('validation rules', () => {
     { name: 'implicit standard rule', rule: undefined },
   ])('$name', ({ rule }) => {
     test('invalid', () => {
-      const { validator } = setup(
-        [
+      const { validator } = setup({
+        labels: [
           { name: '', value: 'foo' },
           { name: 'bar', value: '' },
           { name: 'asdf', value: 'qwer' },
         ],
-        rule
-      );
+        rule,
+      });
       act(() => validator.validate());
       expect(validator.state.valid).toBe(false);
       expect(screen.getAllByRole('textbox')[0]).toHaveAccessibleDescription(
@@ -154,14 +221,14 @@ describe('validation rules', () => {
     });
 
     test('valid', () => {
-      const { validator } = setup(
-        [
+      const { validator } = setup({
+        labels: [
           { name: '', value: 'foo' },
           { name: 'bar', value: '' },
           { name: 'asdf', value: 'qwer' },
         ],
-        rule
-      );
+        rule,
+      });
       act(() => validator.validate());
       expect(validator.state.valid).toBe(false);
       expect(screen.getAllByRole('textbox')[0]).toHaveAccessibleDescription(
@@ -174,6 +241,13 @@ describe('validation rules', () => {
       ); // ''
       expect(screen.getAllByRole('textbox')[4]).toHaveAccessibleDescription(''); // 'asdf'
       expect(screen.getAllByRole('textbox')[5]).toHaveAccessibleDescription(''); // 'qwer'
+    });
+
+    test('at least one row, no labels', () => {
+      const { validator } = setup({ labels: [], rule, atLeastOneRow: true });
+      act(() => validator.validate());
+      expect(screen.getAllByRole('textbox')[0]).toHaveAccessibleDescription('');
+      expect(screen.getAllByRole('textbox')[1]).toHaveAccessibleDescription('');
     });
   });
 
@@ -192,13 +266,13 @@ describe('validation rules', () => {
   };
 
   test('custom rule, invalid', async () => {
-    const { validator } = setup(
-      [
+    const { validator } = setup({
+      labels: [
         { name: 'foo', value: 'bar' },
         { name: 'bar', value: 'foo' },
       ],
-      nameNotFoo
-    );
+      rule: nameNotFoo,
+    });
     act(() => validator.validate());
     expect(validator.state.valid).toBe(false);
     expect(screen.getAllByRole('textbox')[0]).toHaveAccessibleDescription(
@@ -210,13 +284,13 @@ describe('validation rules', () => {
   });
 
   test('custom rule, valid', async () => {
-    const { validator } = setup(
-      [
+    const { validator } = setup({
+      labels: [
         { name: 'xyz', value: 'bar' },
         { name: 'bar', value: 'foo' },
       ],
-      nameNotFoo
-    );
+      rule: nameNotFoo,
+    });
     act(() => validator.validate());
     expect(validator.state.valid).toBe(true);
     expect(screen.getAllByRole('textbox')[0]).toHaveAccessibleDescription('');

--- a/web/packages/teleport/src/components/LabelsInput/LabelsInput.tsx
+++ b/web/packages/teleport/src/components/LabelsInput/LabelsInput.tsx
@@ -66,20 +66,7 @@ export type LabelsRule = Rule<Label[], LabelListValidationResult>;
 
 const buttonIconSize = 0;
 
-export function LabelsInput({
-  legend,
-  tooltipContent,
-  tooltipSticky,
-  labels = [],
-  setLabels,
-  disableBtns = false,
-  autoFocus = false,
-  required = false,
-  adjective = 'Label',
-  labelKey = { fieldName: 'Key', placeholder: 'label key' },
-  labelVal = { fieldName: 'Value', placeholder: 'label value' },
-  rule = defaultRule,
-}: {
+export type LabelsInputProps = {
   legend?: string;
   tooltipContent?: string;
   tooltipSticky?: boolean;
@@ -100,12 +87,55 @@ export function LabelsInput({
    * input as required if this property is undefined.
    */
   rule?: LabelsRule;
-}) {
+  /**
+   * Always show at least one row, even if the label list is empty. Caveat: the
+   * list input in this mode has no way to correctly represent a single label
+   * with empty key and value.
+   */
+  atLeastOneRow?: boolean;
+};
+
+export function LabelsInput({
+  legend,
+  tooltipContent,
+  tooltipSticky,
+  labels = [],
+  setLabels,
+  disableBtns = false,
+  autoFocus = false,
+  required = false,
+  adjective = 'Label',
+  labelKey = { fieldName: 'Key', placeholder: 'label key' },
+  labelVal = { fieldName: 'Value', placeholder: 'label value' },
+  rule = defaultRule,
+  atLeastOneRow = false,
+}: LabelsInputProps) {
   const validator = useValidation() as Validator;
   const validationResult: LabelListValidationResult = useRule(rule(labels));
+  const unspecifiedGlobalValidationError =
+    hasUnspecifiedGlobalValidationError(validationResult);
+  const singleEmptyRow = atLeastOneRow && labels.length === 0;
+
+  if (singleEmptyRow) {
+    labels = [{ name: '', value: '' }];
+  }
+
+  function updateLabels(newList: Label[]) {
+    if (
+      atLeastOneRow &&
+      newList.length === 1 &&
+      newList[0].name === '' &&
+      newList[0].value === ''
+    ) {
+      // Collapse the single empty row into an empty model.
+      setLabels([]);
+    } else {
+      setLabels(newList);
+    }
+  }
 
   function addLabel() {
-    setLabels([...labels, { name: '', value: '' }]);
+    updateLabels([...labels, { name: '', value: '' }]);
   }
 
   function removeLabel(index: number) {
@@ -122,7 +152,7 @@ export function LabelsInput({
     }
     const newList = [...labels];
     newList.splice(index, 1);
-    setLabels(newList);
+    updateLabels(newList);
   }
 
   const handleChange = (
@@ -133,7 +163,7 @@ export function LabelsInput({
     const { value } = event.target;
     const newList = [...labels];
     newList[index] = { ...newList[index], [labelField]: value };
-    setLabels(newList);
+    updateLabels(newList);
   };
 
   const requiredKey = value => () => {
@@ -181,8 +211,21 @@ export function LabelsInput({
         )}
         <tbody>
           {labels.map((label, index) => {
-            const validationItem: LabelValidationResult | undefined =
+            let validationItem: LabelValidationResult | undefined =
               validationResult.results?.[index];
+            if (unspecifiedGlobalValidationError) {
+              validationItem = {
+                name: { valid: false },
+                value: { valid: false },
+              };
+            } else if (singleEmptyRow) {
+              // Special case: a single empty row in the "at least one row" mode
+              // is always valid.
+              validationItem = {
+                name: { valid: true },
+                value: { valid: true },
+              };
+            }
             return (
               <tr key={index}>
                 <td>
@@ -231,10 +274,9 @@ export function LabelsInput({
                       css={`
                         &:disabled {
                           opacity: 0.65;
-                          pointer-events: none;
                         }
                       `}
-                      disabled={disableBtns}
+                      disabled={disableBtns || singleEmptyRow}
                     >
                       <Icons.Cross color="text.muted" size="small" />
                     </ButtonIcon>
@@ -262,16 +304,24 @@ export function LabelsInput({
 
 const defaultRule = () => () => ({ valid: true });
 
-export const nonEmptyLabels: LabelsRule = labels => () => {
-  const results = labels.map(label => ({
-    name: requiredField('required')(label.name)(),
-    value: requiredField('required')(label.value)(),
-  }));
-  return {
-    valid: results.every(r => r.name.valid && r.value.valid),
-    results: results,
+function hasUnspecifiedGlobalValidationError(llvr: LabelListValidationResult) {
+  return (
+    !llvr.valid &&
+    (!llvr.results || llvr.results.every(vr => vr.name.valid && vr.value.valid))
+  );
+}
+
+export const nonEmptyLabels: LabelsRule =
+  labels => (): LabelListValidationResult => {
+    const results = labels.map(label => ({
+      name: requiredField('required')(label.name)(),
+      value: requiredField('required')(label.value)(),
+    }));
+    return {
+      valid: results.every(r => r.name.valid && r.value.valid),
+      results: results,
+    };
   };
-};
 
 const Fieldset = styled.fieldset`
   border: none;


### PR DESCRIPTION
This is a group of two related changes:

- Add section-wide validations that communicate to the user that they can't make a resource access section with no data at all. This resource section would simply disappear when saved.
- Make the label inputs always show at least one row. This makes it easier to jump right into editing data that may be required, and thus shouldn't be hidden behind a button.

Since there's no formal validation error state for buttons, in case of Kubernetes resources, I decided to just use the red outlined button version if the section is empty.

This change also fixes a related existing issue where validations on newly added sections were not taken into account when switching between standard and YAML editors, blocking the user on a server error instead.

[**Demo**](https://goteleport.zoom.us/clips/share/EuzjPKSgQCea9yprgCHDkg)

Contributes to https://github.com/gravitational/teleport/issues/52221