### PR TITLE
Fix Bot status in app.session.start event

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3412,6 +3412,13 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 			AppName:           req.RouteToApp.Name,
 			AppURI:            req.RouteToApp.URI,
 			AppTargetPort:     int(req.RouteToApp.TargetPort),
+
+			BotName: getBotName(user),
+			// Always pass through a bot instance ID if available. Legacy bots
+			// joining without an instance ID may have one generated when
+			// `updateBotInstance()` is called below, and this (empty) value will be
+			// overridden.
+			BotInstanceID: a.context.Identity.GetIdentity().BotInstanceID,
 		})
 		if err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -419,6 +419,13 @@ type NewAppSessionRequest struct {
 	Identity tlsca.Identity
 	// ClientAddr is a client (user's) address.
 	ClientAddr string
+
+	// BotName is the name of the bot that is creating this session.
+	// Empty if not a bot.
+	BotName string
+	// BotInstanceID is the ID of the bot instance that is creating this session.
+	// Empty if not a bot.
+	BotInstanceID string
 }
 
 // CreateAppSession creates and inserts a services.WebSession into the
@@ -572,6 +579,9 @@ func (a *Server) CreateAppSessionFromReq(ctx context.Context, req NewAppSessionR
 		// Pass along device extensions from the user.
 		deviceExtensions: req.DeviceExtensions,
 		mfaVerified:      req.MFAVerified,
+		// Pass along bot details to ensure audit logs are correct.
+		botName:       req.BotName,
+		botInstanceID: req.BotInstanceID,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/53803

Before:

```json
{
  "app_name": "dumper",
  "app_public_addr": "dumper.leaf.tele.ottr.sh",
  "cluster_name": "leaf.tele.ottr.sh",
  "code": "T2007I",
  "ei": 0,
  "event": "app.session.start",
  "namespace": "default",
  "public_addr": "dumper.leaf.tele.ottr.sh",
  "server_id": "7f7f0519-c93f-4bc8-845f-26e97450b069",
  "server_version": "18.0.0-dev",
  "sid": "5545a8b9d3200ede8b979f53854a09edecd95c3d773f97a7d1343c192fd01c48",
  "time": "2025-04-23T14:08:16.368Z",
  "uid": "547f3139-8700-4491-ac1d-ec3288b7ccbe",
  "user": "bot-app-access-test-12334",
  "user_kind": 1
}
```

After:

```json
{
  "app_name": "dumper",
  "app_public_addr": "dumper.leaf.tele.ottr.sh",
  "bot_instance_id": "fa4d75b6-2077-4919-94e1-5e4708865ba2",
  "bot_name": "app-access-test-12334",
  "cluster_name": "leaf.tele.ottr.sh",
  "code": "T2007I",
  "ei": 0,
  "event": "app.session.start",
  "namespace": "default",
  "public_addr": "dumper.leaf.tele.ottr.sh",
  "server_id": "7f7f0519-c93f-4bc8-845f-26e97450b069",
  "server_version": "18.0.0-dev",
  "sid": "603b0f258742abda8df054f7bf4e899dbe6c8a41ac230196432346be7b837248",
  "time": "2025-04-23T14:16:48.276Z",
  "uid": "2c463112-a3e3-4a91-bdfd-21f03397d5dd",
  "user": "bot-app-access-test-12334",
  "user_kind": 2
}
```

changelog: User Kind is now correctly reported for Bots in the `app.session.start` audit log event