### PR TITLE
Change the size of "add more" buttons to small

### DIFF
--- a/web/packages/shared/components/FieldMultiInput/FieldMultiInput.tsx
+++ b/web/packages/shared/components/FieldMultiInput/FieldMultiInput.tsx
@@ -161,6 +161,8 @@ export function FieldMultiInput({
         ))}
         <ButtonSecondary
           alignSelf="start"
+          size="small"
+          inputAlignment
           onClick={() => insertItem(value.length)}
         >
           <Icon.Plus size="small" mr={2} />

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.tsx
@@ -355,6 +355,8 @@ export function KubernetesAccessSection({
                 ],
               })
             }
+            size="small"
+            inputAlignment
           >
             <Add disabled={isProcessing} size="small" />
             {value.resources.length > 0

--- a/web/packages/teleport/src/components/LabelsInput/LabelsInput.tsx
+++ b/web/packages/teleport/src/components/LabelsInput/LabelsInput.tsx
@@ -252,6 +252,8 @@ export function LabelsInput({
         }}
         disabled={disableBtns}
         gap={1}
+        size="small"
+        inputAlignment
       >
         <Icons.Add className="icon-add" disabled={disableBtns} size="small" />
         {labels.length > 0 ? `Add another ${adjective}` : `Add a ${adjective}`}


### PR DESCRIPTION
This change is motivated by the role editor UI, where we want to introduce a visual hierarchy of buttons (large — dialog actions, medium — adding sections, small — actions inside sections). Note that this could also be configurable, but it doesn't look bad in the other place where the labels input control is used, so I decided to trim the complexity. We may revisit this when we decide to unify the label inputs across the role editor and the Discovery feature.

<img width="613" alt="Screenshot 2025-04-23 at 13 20 41" src="https://github.com/user-attachments/assets/75cb7e8f-333c-4856-bc86-88b9acb3bc95" />
<img width="783" alt="Screenshot 2025-04-23 at 13 17 48" src="https://github.com/user-attachments/assets/f14ffe7b-ef7f-416b-9ffa-c35460c120ae" />

Contributes to https://github.com/gravitational/teleport/issues/52222