### PR TITLE
Add `--os-log` to tsh, make `--debug` take precedence over `TELEPORT_DEBUG`

### DIFF
--- a/lib/utils/darwinbundle/darwinbundle_darwin.go
+++ b/lib/utils/darwinbundle/darwinbundle_darwin.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"unsafe"
 
 	"github.com/gravitational/trace"
 
@@ -60,4 +61,27 @@ func Path() (string, error) {
 	}
 
 	return strings.TrimSuffix(dir, appBundleSuffix), nil
+}
+
+// Identifier returns the identifier of the bundle that the current executable comes from. Returns
+// either a non-empty string or an error.
+func Identifier() (string, error) {
+	path, err := Path()
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	cIdentifier := C.BundleIdentifier(cPath)
+	defer C.free(unsafe.Pointer(cIdentifier))
+
+	identifier := C.GoString(cIdentifier)
+
+	if identifier == "" {
+		return "", trace.Errorf("could not get details for bundle under %s", path)
+	}
+
+	return identifier, nil
 }

--- a/lib/utils/darwinbundle/darwinbundle_darwin.h
+++ b/lib/utils/darwinbundle/darwinbundle_darwin.h
@@ -3,7 +3,11 @@
 
 #import <Foundation/Foundation.h>
 
-// TELBundleIdentifier returns the identifier of the bundle under the current path.
+// BundleIdentifier returns the identifier of the bundle under the given path.
+// The caller is expected to free the returned pointer.
+const char *BundleIdentifier(const char *bundlePath);
+
+// TELBundleIdentifier returns the identifier of the bundle under the given path.
 // Always returns a string, but it might be empty if there's no bundle under the given path or the bundle
 // details couldn't have been read.
 NSString *TELBundleIdentifier(NSString *bundlePath);

--- a/tool/tsh/common/logger.go
+++ b/tool/tsh/common/logger.go
@@ -17,6 +17,7 @@
 package common
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 	"strconv"
@@ -81,4 +82,10 @@ func parseLoggingOptsFromEnvAndArgv(cf *CLIConf) loggingOpts {
 	}
 
 	return opts
+}
+
+func printInitLoggerError(err error) {
+	// If initLogger, logger and slog.Default() are likely not going to output any messages anywhere.
+	// That's why this functions prints directly to stderr instead.
+	fmt.Fprintf(os.Stderr, "WARNING: Could not initialize the logger due to an error, no messages will be logged %s\n\n", trace.DebugReport(err))
 }

--- a/tool/tsh/common/logger.go
+++ b/tool/tsh/common/logger.go
@@ -65,8 +65,8 @@ func parseLoggingOptsFromEnv() loggingOpts {
 }
 
 // parseLoggingOptsFromEnvAndArgv calculates logging opts taking into account env vars and argv.
-// It should be called only after calling kingpin.Application.Parse, so that
-// kingpin.FlagCause.IsSetByUser is processed by kingpin.
+// Before calling this function, make sure that argv has been processed by kingpin (by calling
+// kingpin.Application.Parse) so that cf fields set from argv are up-to-date.
 //
 // CLI flags take precedence over env vars.
 func parseLoggingOptsFromEnvAndArgv(cf *CLIConf) loggingOpts {

--- a/tool/tsh/common/logger.go
+++ b/tool/tsh/common/logger.go
@@ -37,40 +37,40 @@ const (
 // It is called twice, first soon after launching tsh before argv is parsed and then again after
 // kingpin parses argv. This makes it possible to debug early startup functionality, particularly
 // command aliases.
-func initLogger(cf *CLIConf, opts debugOpts) error {
+func initLogger(cf *CLIConf, opts loggingOpts) error {
 	cf.OSLog = opts.osLog
 	cf.Debug = opts.debug || opts.osLog
 
-	loggerOpts := getPlatformInitLoggerOpts(cf)
+	initLoggerOpts := getPlatformInitLoggerOpts(cf)
 
 	level := slog.LevelWarn
 	if cf.Debug {
 		level = slog.LevelDebug
 	}
 
-	return trace.Wrap(utils.InitLogger(utils.LoggingForCLI, level, loggerOpts...))
+	return trace.Wrap(utils.InitLogger(utils.LoggingForCLI, level, initLoggerOpts...))
 }
 
-type debugOpts struct {
+type loggingOpts struct {
 	debug bool
 	osLog bool
 }
 
-// parseDebugOptsFromEnv calculates debug opts taking into account only env vars.
-func parseDebugOptsFromEnv() debugOpts {
-	var opts debugOpts
+// parseLoggingOptsFromEnv calculates logging opts taking into account only env vars.
+func parseLoggingOptsFromEnv() loggingOpts {
+	var opts loggingOpts
 	opts.debug, _ = strconv.ParseBool(os.Getenv(debugEnvVar))
 	opts.osLog, _ = strconv.ParseBool(os.Getenv(osLogEnvVar))
 	return opts
 }
 
-// parseDebugFromEnvAndArgv calculates debug opts taking into account env vars and argv.
+// parseLoggingOptsFromEnvAndArgv calculates logging opts taking into account env vars and argv.
 // It should be called only after calling kingpin.Application.Parse, so that
 // kingpin.FlagCause.IsSetByUser is processed by kingpin.
 //
 // CLI flags take precedence over env vars.
-func parseDebugOptsFromEnvAndArgv(cf *CLIConf) debugOpts {
-	opts := parseDebugOptsFromEnv()
+func parseLoggingOptsFromEnvAndArgv(cf *CLIConf) loggingOpts {
+	opts := parseLoggingOptsFromEnv()
 
 	if cf.DebugSet {
 		opts.debug = cf.Debug

--- a/tool/tsh/common/logger.go
+++ b/tool/tsh/common/logger.go
@@ -72,11 +72,11 @@ func parseLoggingOptsFromEnv() loggingOpts {
 func parseLoggingOptsFromEnvAndArgv(cf *CLIConf) loggingOpts {
 	opts := parseLoggingOptsFromEnv()
 
-	if cf.DebugSet {
+	if cf.DebugSetByUser {
 		opts.debug = cf.Debug
 	}
 
-	if cf.OSLogSet {
+	if cf.OSLogSetByUser {
 		opts.osLog = cf.OSLog
 	}
 

--- a/tool/tsh/common/logger_darwin.go
+++ b/tool/tsh/common/logger_darwin.go
@@ -1,0 +1,44 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package common
+
+import (
+	"fmt"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/darwinbundle"
+	"github.com/gravitational/teleport/lib/utils/log/oslog"
+)
+
+func getPlatformInitLoggerOpts(cf *CLIConf) []utils.LoggerOption {
+	if !cf.OSLog {
+		return nil
+	}
+
+	subsystem, err := darwinbundle.Identifier()
+	if err != nil {
+		subsystem = "tsh"
+
+		// The actual logger isn't initialized yet, so let's log the error to os_log.
+		logger := oslog.NewLogger(subsystem, teleport.ComponentTSH)
+		message := fmt.Sprintf("Could not get bundle identifier to set it as os_log subsystem, using 'tsh' as a fallback error=%v", err)
+		logger.Log(oslog.OsLogTypeDebug, message)
+	}
+
+	return []utils.LoggerOption{utils.WithOSLog(subsystem)}
+}

--- a/tool/tsh/common/logger_other.go
+++ b/tool/tsh/common/logger_other.go
@@ -13,36 +13,16 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#include "darwinbundle_darwin.h"
 
-#import <Foundation/Foundation.h>
+//go:build !darwin
+// +build !darwin
 
-#include <string.h>
+package common
 
-char *CopyNSString(NSString *val) {
-  if (val) {
-    return strdup([val UTF8String]);
-  }
-  return strdup("");
-}
+import (
+	"github.com/gravitational/teleport/lib/utils"
+)
 
-const char *BundleIdentifier(const char *bundlePath) {
-  @autoreleasepool {
-    NSString *bundleIdentifier = TELBundleIdentifier(@(bundlePath));
-    return CopyNSString(bundleIdentifier);
-  }
-}
-
-NSString *TELBundleIdentifier(NSString *bundlePath) {
-  NSBundle *main = [NSBundle bundleWithPath:bundlePath];
-  if (!main) {
-    return @"";
-  }
-
-  NSString *bundleIdentifier = [main bundleIdentifier];
-  if (!bundleIdentifier || [bundleIdentifier length] == 0) {
-    return @"";
-  }
-
-  return bundleIdentifier;
+func getPlatformInitLoggerOpts(cf *CLIConf) []utils.LoggerOption {
+	return nil
 }

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -364,6 +364,9 @@ type CLIConf struct {
 	// Debug sends debug logs to stdout.
 	Debug bool
 
+	// OSLog sends debug logs to the unified log system on macOS.
+	OSLog bool
+
 	// Browser can be used to pass the name of a browser to override the system default
 	// (not currently implemented), or set to 'none' to suppress browser opening entirely.
 	Browser string
@@ -760,14 +763,17 @@ var tshStatusEnvVars = [...]string{proxyEnvVar, clusterEnvVar, siteEnvVar, kubeC
 type CliOption func(*CLIConf) error
 
 // initLogger initializes the logger taking into account --debug and TELEPORT_DEBUG. If TELEPORT_DEBUG is set, it will also enable CLIConf.Debug.
-func initLogger(cf *CLIConf) {
+func initLogger(cf *CLIConf) error {
+	opts := getPlatformInitLoggerOpts(cf)
 	isDebug, _ := strconv.ParseBool(os.Getenv(debugEnvVar))
-	cf.Debug = cf.Debug || isDebug
+	cf.Debug = cf.Debug || isDebug || cf.OSLog
+
+	level := slog.LevelWarn
 	if cf.Debug {
-		utils.InitLogger(utils.LoggingForCLI, slog.LevelDebug)
-	} else {
-		utils.InitLogger(utils.LoggingForCLI, slog.LevelWarn)
+		level = slog.LevelDebug
 	}
+
+	return trace.Wrap(utils.InitLogger(utils.LoggingForCLI, level, opts...))
 }
 
 // Run executes TSH client. same as main() but easier to test. Note that this
@@ -790,7 +796,9 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 
 	// run early to enable debug logging if env var is set.
 	// this makes it possible to debug early startup functionality, particularly command aliases.
-	initLogger(&cf)
+	if err := initLogger(&cf); err != nil {
+		return trace.Wrap(err)
+	}
 
 	moduleCfg := modules.GetModules()
 	var cpuProfile, memProfile, traceProfile string
@@ -829,6 +837,11 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	// - we already process TELEPORT_DEBUG with initLogger(), so we don't need to do it second time
 	// - Kingpin is strict about syntax, so TELEPORT_DEBUG=rubbish will crash a program; we don't want such behavior for this variable.
 	app.Flag("debug", "Verbose logging to stdout").Short('d').BoolVar(&cf.Debug)
+	osLogFlag := app.Flag("os-log", "Verbose logging to the unified logging system. This flag implies --debug. https://developer.apple.com/documentation/os/viewing-log-messages")
+	if runtime.GOOS != constants.DarwinOS {
+		osLogFlag.Hidden()
+	}
+	osLogFlag.BoolVar(&cf.OSLog)
 	app.Flag("add-keys-to-agent", fmt.Sprintf("Controls how keys are handled. Valid values are %v.", client.AllAddKeysOptions)).Short('k').Envar(addKeysToAgentEnvVar).Default(client.AddKeysToAgentAuto).StringVar(&cf.AddKeysToAgent)
 	app.Flag("use-local-ssh-agent", "Deprecated in favor of the add-keys-to-agent flag.").
 		Hidden().
@@ -1424,7 +1437,9 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 
 	// Enable debug logging if requested by --debug.
 	// If TELEPORT_DEBUG was set, it was already enabled by prior call to initLogger().
-	initLogger(&cf)
+	if err := initLogger(&cf); err != nil {
+		return trace.Wrap(err)
+	}
 
 	stopTracing := initializeTracing(&cf)
 	defer stopTracing()

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"maps"
 	"net"
 	"net/url"
@@ -361,11 +360,16 @@ type CLIConf struct {
 	// X11ForwardingTimeout can optionally set to set a timeout for untrusted X11 forwarding.
 	X11ForwardingTimeout time.Duration
 
-	// Debug sends debug logs to stdout.
+	// Debug sets log level to debug and sends logs to stdout.
 	Debug bool
+	// DebugSet specifies whether the flag was set by the user.
+	DebugSet bool
 
-	// OSLog sends debug logs to the unified log system on macOS.
+	// OSLog sends logs to the unified log system on macOS.
 	OSLog bool
+	// OSLogSet specifies whether the flag was set by the user or not. This makes it possible to enable
+	// OSLog through env var and then disable it selectively with --no-os-log.
+	OSLogSet bool
 
 	// Browser can be used to pass the name of a browser to override the system default
 	// (not currently implemented), or set to 'none' to suppress browser opening entirely.
@@ -726,7 +730,6 @@ const (
 	globalTshConfigEnvVar    = "TELEPORT_GLOBAL_TSH_CONFIG"
 	mfaModeEnvVar            = "TELEPORT_MFA_MODE"
 	mlockModeEnvVar          = "TELEPORT_MLOCK_MODE"
-	debugEnvVar              = teleport.VerboseLogsEnvVar // "TELEPORT_DEBUG"
 	identityFileEnvVar       = "TELEPORT_IDENTITY_FILE"
 	gcloudSecretEnvVar       = "TELEPORT_GCLOUD_SECRET"
 	awsAccessKeyIDEnvVar     = "TELEPORT_AWS_ACCESS_KEY_ID"
@@ -762,20 +765,6 @@ var tshStatusEnvVars = [...]string{proxyEnvVar, clusterEnvVar, siteEnvVar, kubeC
 // CliOption is used in tests to inject/override configuration within Run
 type CliOption func(*CLIConf) error
 
-// initLogger initializes the logger taking into account --debug and TELEPORT_DEBUG. If TELEPORT_DEBUG is set, it will also enable CLIConf.Debug.
-func initLogger(cf *CLIConf) error {
-	opts := getPlatformInitLoggerOpts(cf)
-	isDebug, _ := strconv.ParseBool(os.Getenv(debugEnvVar))
-	cf.Debug = cf.Debug || isDebug || cf.OSLog
-
-	level := slog.LevelWarn
-	if cf.Debug {
-		level = slog.LevelDebug
-	}
-
-	return trace.Wrap(utils.InitLogger(utils.LoggingForCLI, level, opts...))
-}
-
 // Run executes TSH client. same as main() but easier to test. Note that this
 // function modifies global state in `tsh` (e.g. the system logger), and WILL
 // ALSO MODIFY EXTERNAL SHARED STATE in its default configuration (e.g. the
@@ -796,7 +785,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 
 	// run early to enable debug logging if env var is set.
 	// this makes it possible to debug early startup functionality, particularly command aliases.
-	if err := initLogger(&cf); err != nil {
+	if err := initLogger(&cf, parseDebugOptsFromEnv()); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -836,8 +825,11 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	// we don't want to add `.Envar(debugEnvVar)` here:
 	// - we already process TELEPORT_DEBUG with initLogger(), so we don't need to do it second time
 	// - Kingpin is strict about syntax, so TELEPORT_DEBUG=rubbish will crash a program; we don't want such behavior for this variable.
-	app.Flag("debug", "Verbose logging to stdout").Short('d').BoolVar(&cf.Debug)
-	osLogFlag := app.Flag("os-log", "Verbose logging to the unified logging system. This flag implies --debug. https://developer.apple.com/documentation/os/viewing-log-messages")
+	app.Flag("debug", "Verbose logging to stdout.").Short('d').IsSetByUser(&cf.DebugSet).BoolVar(&cf.Debug)
+	osLogFlag := app.Flag("os-log",
+		fmt.Sprintf("Verbose logging to the unified logging system. This flag implies --debug. Also available through the %s env var. https://developer.apple.com/documentation/os/viewing-log-messages",
+			osLogEnvVar)).
+		IsSetByUser(&cf.OSLogSet)
 	if runtime.GOOS != constants.DarwinOS {
 		osLogFlag.Hidden()
 	}
@@ -1436,8 +1428,9 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	}
 
 	// Enable debug logging if requested by --debug.
-	// If TELEPORT_DEBUG was set, it was already enabled by prior call to initLogger().
-	if err := initLogger(&cf); err != nil {
+	// If TELEPORT_DEBUG was set and --debug/--no-debug was not passed, debug logs were already
+	// enabled by a prior call to initLogger.
+	if err := initLogger(&cf, parseDebugOptsFromEnvAndArgv(&cf)); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -4728,7 +4721,7 @@ func (c *CLIConf) initClientStore() {
 	// address will be provided later on and the client will attempt to load the identity file then.
 	if c.IdentityFileIn != "" {
 		if err := identityfile.LoadIdentityFileIntoClientStore(c.clientStore, c.IdentityFileIn, c.Proxy, c.SiteName); err == nil {
-			slog.DebugContext(c.Context, "failed to load identity file into client store", "err", err)
+			logger.DebugContext(c.Context, "failed to load identity file into client store", "err", err)
 		}
 	}
 }

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -362,14 +362,14 @@ type CLIConf struct {
 
 	// Debug sets log level to debug and sends logs to stdout.
 	Debug bool
-	// DebugSet specifies whether the flag was set by the user.
-	DebugSet bool
+	// DebugSetByUser specifies whether the flag was set by the user.
+	DebugSetByUser bool
 
 	// OSLog sends logs to the unified log system on macOS.
 	OSLog bool
-	// OSLogSet specifies whether the flag was set by the user or not. This makes it possible to enable
-	// OSLog through env var and then disable it selectively with --no-os-log.
-	OSLogSet bool
+	// OSLogSetByUser specifies whether the flag was set by the user or not. This makes it possible to
+	// enable OSLog through env var and then disable it selectively with --no-os-log.
+	OSLogSetByUser bool
 
 	// Browser can be used to pass the name of a browser to override the system default
 	// (not currently implemented), or set to 'none' to suppress browser opening entirely.
@@ -825,11 +825,11 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	// we don't want to add `.Envar(debugEnvVar)` here:
 	// - we already process TELEPORT_DEBUG with initLogger(), so we don't need to do it second time
 	// - Kingpin is strict about syntax, so TELEPORT_DEBUG=rubbish will crash a program; we don't want such behavior for this variable.
-	app.Flag("debug", "Verbose logging to stdout.").Short('d').IsSetByUser(&cf.DebugSet).BoolVar(&cf.Debug)
+	app.Flag("debug", "Verbose logging to stdout.").Short('d').IsSetByUser(&cf.DebugSetByUser).BoolVar(&cf.Debug)
 	osLogFlag := app.Flag("os-log",
 		fmt.Sprintf("Verbose logging to the unified logging system. This flag implies --debug. Also available through the %s env var. https://developer.apple.com/documentation/os/viewing-log-messages",
 			osLogEnvVar)).
-		IsSetByUser(&cf.OSLogSet)
+		IsSetByUser(&cf.OSLogSetByUser)
 	if runtime.GOOS != constants.DarwinOS {
 		osLogFlag.Hidden()
 	}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -786,7 +786,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	// run early to enable debug logging if env var is set.
 	// this makes it possible to debug early startup functionality, particularly command aliases.
 	if err := initLogger(&cf, parseLoggingOptsFromEnv()); err != nil {
-		return trace.Wrap(err)
+		printInitLoggerError(err)
 	}
 
 	moduleCfg := modules.GetModules()
@@ -1431,7 +1431,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	// If TELEPORT_DEBUG was set and --debug/--no-debug was not passed, debug logs were already
 	// enabled by a prior call to initLogger.
 	if err := initLogger(&cf, parseLoggingOptsFromEnvAndArgv(&cf)); err != nil {
-		return trace.Wrap(err)
+		printInitLoggerError(err)
 	}
 
 	stopTracing := initializeTracing(&cf)

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -785,7 +785,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 
 	// run early to enable debug logging if env var is set.
 	// this makes it possible to debug early startup functionality, particularly command aliases.
-	if err := initLogger(&cf, parseDebugOptsFromEnv()); err != nil {
+	if err := initLogger(&cf, parseLoggingOptsFromEnv()); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -1430,7 +1430,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	// Enable debug logging if requested by --debug.
 	// If TELEPORT_DEBUG was set and --debug/--no-debug was not passed, debug logs were already
 	// enabled by a prior call to initLogger.
-	if err := initLogger(&cf, parseDebugOptsFromEnvAndArgv(&cf)); err != nil {
+	if err := initLogger(&cf, parseLoggingOptsFromEnvAndArgv(&cf)); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -7237,7 +7237,7 @@ func TestSetEnvVariables(t *testing.T) {
 	}
 }
 
-func TestDebugOpts(t *testing.T) {
+func TestLoggingOpts(t *testing.T) {
 	tmpHomePath := t.TempDir()
 
 	tests := []struct {
@@ -7417,12 +7417,12 @@ func TestDebugOpts(t *testing.T) {
 				}
 			}
 
-			mustReadDebugOpts, setDebugOptsFromCLIConf := prepareCLIOptionForReadingDebugOpts()
+			mustReadLoggingOpts, setLoggingOptsFromCLIConf := prepareCLIOptionForReadingLoggingOpts()
 			err := Run(t.Context(), append([]string{"version"}, flags...),
-				setHomePath(tmpHomePath), setDebugOptsFromCLIConf)
+				setHomePath(tmpHomePath), setLoggingOptsFromCLIConf)
 			require.NoError(t, err)
 
-			opts := mustReadDebugOpts(t)
+			opts := mustReadLoggingOpts(t)
 			tt.wantDebug(t, opts.debug, "unexpected cf.Debug value")
 			tt.wantOSLog(t, opts.osLog, "unexpected cf.OSLog value")
 		})
@@ -7433,26 +7433,26 @@ func boolPtr(b bool) *bool {
 	return &b
 }
 
-func prepareCLIOptionForReadingDebugOpts() (func(t *testing.T) debugOpts, CliOption) {
+func prepareCLIOptionForReadingLoggingOpts() (func(t *testing.T) loggingOpts, CliOption) {
 	var cf *CLIConf
 
-	setDebugOptsFromCLIConf := func(cliConfFromRun *CLIConf) error {
+	setLoggingOptsFromCLIConf := func(cliConfFromRun *CLIConf) error {
 		cf = cliConfFromRun
 		return nil
 	}
 
-	mustReadDebugOpts := func(t *testing.T) debugOpts {
+	mustReadLoggingOpts := func(t *testing.T) loggingOpts {
 		t.Helper()
 
 		if cf == nil {
-			t.Fatalf("mustReadDebugOpts was called before setDebugOptsFromCLIConf was executed")
+			t.Fatalf("mustReadLoggingOpts was called before setLoggingOptsFromCLIConf was executed")
 		}
 
-		return debugOpts{
+		return loggingOpts{
 			debug: cf.Debug,
 			osLog: cf.OSLog,
 		}
 	}
 
-	return mustReadDebugOpts, setDebugOptsFromCLIConf
+	return mustReadLoggingOpts, setLoggingOptsFromCLIConf
 }

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -39,6 +39,7 @@ import (
 	"regexp"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -7234,4 +7235,224 @@ func TestSetEnvVariables(t *testing.T) {
 			require.Equal(t, tc.expectedExtraEnvs, c.ExtraEnvs)
 		})
 	}
+}
+
+func TestDebugOpts(t *testing.T) {
+	tmpHomePath := t.TempDir()
+
+	tests := []struct {
+		name      string
+		envDebug  *bool
+		envOSLog  *bool
+		flagDebug *bool
+		flagOSLog *bool
+		wantDebug require.BoolAssertionFunc
+		wantOSLog require.BoolAssertionFunc
+	}{
+		{
+			name:      "no flags or env vars",
+			wantDebug: require.False,
+			wantOSLog: require.False,
+		},
+		{
+			name:      "just debug flag",
+			flagDebug: boolPtr(true),
+			wantDebug: require.True,
+			wantOSLog: require.False,
+		},
+		{
+			name:      "just os-log flag",
+			flagOSLog: boolPtr(true),
+			wantDebug: require.True,
+			wantOSLog: require.True,
+		},
+		{
+			name:      "debug and os-log flags",
+			flagDebug: boolPtr(true),
+			flagOSLog: boolPtr(true),
+			wantDebug: require.True,
+			wantOSLog: require.True,
+		},
+		{
+			name:      "just debug env var",
+			envDebug:  boolPtr(true),
+			wantDebug: require.True,
+			wantOSLog: require.False,
+		},
+		{
+			name:      "just os-log env var",
+			envOSLog:  boolPtr(true),
+			wantDebug: require.True,
+			wantOSLog: require.True,
+		},
+		{
+			name:      "debug and os-log flags",
+			envDebug:  boolPtr(true),
+			envOSLog:  boolPtr(true),
+			wantDebug: require.True,
+			wantOSLog: require.True,
+		},
+		{
+			name:      "everything on",
+			envDebug:  boolPtr(true),
+			envOSLog:  boolPtr(true),
+			flagDebug: boolPtr(true),
+			flagOSLog: boolPtr(true),
+			wantDebug: require.True,
+			wantOSLog: require.True,
+		},
+		{
+			name:      "everything explicitly off",
+			envDebug:  boolPtr(false),
+			envOSLog:  boolPtr(false),
+			flagDebug: boolPtr(false),
+			flagOSLog: boolPtr(false),
+			wantDebug: require.False,
+			wantOSLog: require.False,
+		},
+		{
+			name:      "debug enabled by env, disabled by flag",
+			envDebug:  boolPtr(true),
+			flagDebug: boolPtr(false),
+			wantDebug: require.False,
+			wantOSLog: require.False,
+		},
+		{
+			name:      "debug disabled by env, enabled by flag",
+			envDebug:  boolPtr(false),
+			flagDebug: boolPtr(true),
+			wantDebug: require.True,
+			wantOSLog: require.False,
+		},
+		{
+			name:      "os-log enabled by env, disabled by flag",
+			envOSLog:  boolPtr(true),
+			flagOSLog: boolPtr(false),
+			wantDebug: require.False,
+			wantOSLog: require.False,
+		},
+		{
+			name:      "os-log disabled by env, enabled by flag",
+			envOSLog:  boolPtr(false),
+			flagOSLog: boolPtr(true),
+			wantDebug: require.True,
+			wantOSLog: require.True,
+		},
+
+		// Verify that final values are set after consulting both env and argv, e.g., disabling os-log
+		// by flag doesn't disable debug set by env.
+		{
+			name:      "os-log enabled by env, disabled by flag; debug enabled by env",
+			envOSLog:  boolPtr(true),
+			flagOSLog: boolPtr(false),
+			envDebug:  boolPtr(true),
+			wantDebug: require.True,
+			wantOSLog: require.False,
+		},
+		{
+			name:      "os-log disabled by env, enabled by flag; debug disabled by flag",
+			envOSLog:  boolPtr(false),
+			flagOSLog: boolPtr(true),
+			flagDebug: boolPtr(false),
+			wantDebug: require.True,
+			wantOSLog: require.True,
+		},
+
+		// Debug is always enabled together with os-log.
+		{
+			name:      "os-log enabled by flag, debug disabled by env",
+			flagOSLog: boolPtr(true),
+			envDebug:  boolPtr(false),
+			wantDebug: require.True,
+			wantOSLog: require.True,
+		},
+		{
+			name:      "os-log enabled by flag, debug disabled by flag",
+			flagOSLog: boolPtr(true),
+			flagDebug: boolPtr(false),
+			wantDebug: require.True,
+			wantOSLog: require.True,
+		},
+		{
+			name:      "os-log enabled by env, debug disabled by env",
+			envOSLog:  boolPtr(true),
+			envDebug:  boolPtr(false),
+			wantDebug: require.True,
+			wantOSLog: require.True,
+		},
+		{
+			name:      "os-log enabled by env, debug disabled by flag",
+			envOSLog:  boolPtr(true),
+			flagDebug: boolPtr(false),
+			wantDebug: require.True,
+			wantOSLog: require.True,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envDebug != nil {
+				t.Setenv(debugEnvVar, strconv.FormatBool(*tt.envDebug))
+			}
+
+			if tt.envOSLog != nil {
+				t.Setenv(osLogEnvVar, strconv.FormatBool(*tt.envOSLog))
+			}
+
+			var flags []string
+
+			if tt.flagDebug != nil {
+				if *tt.flagDebug {
+					flags = append(flags, "--debug")
+				} else {
+					flags = append(flags, "--no-debug")
+				}
+			}
+
+			if tt.flagOSLog != nil {
+				if *tt.flagOSLog {
+					flags = append(flags, "--os-log")
+				} else {
+					flags = append(flags, "--no-os-log")
+				}
+			}
+
+			mustReadDebugOpts, setDebugOptsFromCLIConf := prepareCLIOptionForReadingDebugOpts()
+			err := Run(t.Context(), append([]string{"version"}, flags...),
+				setHomePath(tmpHomePath), setDebugOptsFromCLIConf)
+			require.NoError(t, err)
+
+			opts := mustReadDebugOpts(t)
+			tt.wantDebug(t, opts.debug, "unexpected cf.Debug value")
+			tt.wantOSLog(t, opts.osLog, "unexpected cf.OSLog value")
+		})
+	}
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+func prepareCLIOptionForReadingDebugOpts() (func(t *testing.T) debugOpts, CliOption) {
+	var cf *CLIConf
+
+	setDebugOptsFromCLIConf := func(cliConfFromRun *CLIConf) error {
+		cf = cliConfFromRun
+		return nil
+	}
+
+	mustReadDebugOpts := func(t *testing.T) debugOpts {
+		t.Helper()
+
+		if cf == nil {
+			t.Fatalf("mustReadDebugOpts was called before setDebugOptsFromCLIConf was executed")
+		}
+
+		return debugOpts{
+			debug: cf.Debug,
+			osLog: cf.OSLog,
+		}
+	}
+
+	return mustReadDebugOpts, setDebugOptsFromCLIConf
 }


### PR DESCRIPTION
This PR adds `--os-log` flag to tsh on macOS that makes tsh send its logs to os_log, the unified logging system. Some customers have complained that `--debug` makes it impossible to see login and webauthn prompts when used with some commands, this flag can alleviate those problems.

This PR builds on top of #54192 which added a slog handler for os_log and #54237 which added os_log support to `lib/utils.InitLogger`. For more info about os_log, see those PRs and [`lib/utils/log/oslog/README.md`](https://github.com/gravitational/teleport/blob/r7s/oslog-tsh/lib/utils/log/oslog/README.md).

After I added the flag, I realized that there are some weird edge cases where, for example, `TELEPORT_MACOS_OS_LOG=1 tsh status --no-os-log` would result in `cf.Debug` still being true while `cf.OSLog` was false. This is because the existing code was written in a way where `initLogger` was executed twice. The first time it's executed before argv was parsed, so `cf.Debug` was set based solely on the state of env vars. The second time it looked at the argv flag _and_ the env var but the env var essentially always had priority over the flag.

I changed it so that the flag always has priority over the env var, for both `--os-log` and `--debug`. The reasoning is that flags can typically be changed per-invocation, while env vars typically persist across invocations. I believe this is how most programs work and this also enables the user to provide `--no-debug` when `TELEPORT_DEBUG` is set to `1`.

This PR includes a tiny bit of Objective-C and C, but just really a tiny bit. I exposed to Go a function that was previously available only in Obj-C.

## How to test it

Compile tsh, run the below command and in a separate shell session run `tsh status --os-log`.

```
log stream --predicate 'subsystem CONTAINS "tsh"' --style syslog --level debug
```

changelog: Added `--os-log` to tsh on macOS which sends debug logs to os_log; in tsh, `--debug`/`--no-debug` now takes precedence over `TELEPORT_DEBUG`