### PR TITLE
[v16] Fix Bot status in app.session.start event

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3341,6 +3341,13 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 				DeviceExtensions:  DeviceExtensions(a.context.Identity.GetIdentity().DeviceExtensions),
 				AppName:           req.RouteToApp.Name,
 				AppURI:            req.RouteToApp.URI,
+
+				BotName: getBotName(user),
+				// Always pass through a bot instance ID if available. Legacy bots
+				// joining without an instance ID may have one generated when
+				// `updateBotInstance()` is called below, and this (empty) value will be
+				// overridden.
+				BotInstanceID: a.context.Identity.GetIdentity().BotInstanceID,
 			})
 			if err != nil {
 				return nil, trace.Wrap(err)

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -372,6 +372,13 @@ type NewAppSessionRequest struct {
 	Identity tlsca.Identity
 	// ClientAddr is a client (user's) address.
 	ClientAddr string
+
+	// BotName is the name of the bot that is creating this session.
+	// Empty if not a bot.
+	BotName string
+	// BotInstanceID is the ID of the bot instance that is creating this session.
+	// Empty if not a bot.
+	BotInstanceID string
 }
 
 // CreateAppSession creates and inserts a services.WebSession into the
@@ -515,6 +522,9 @@ func (a *Server) CreateAppSessionFromReq(ctx context.Context, req NewAppSessionR
 		// Pass along device extensions from the user.
 		deviceExtensions: req.DeviceExtensions,
 		mfaVerified:      req.MFAVerified,
+		// Pass along bot details to ensure audit logs are correct.
+		botName:       req.BotName,
+		botInstanceID: req.BotInstanceID,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/54235 to branch/v16

changelog: User Kind is now correctly reported for Bots in the app.session.start audit log event