### PR TITLE
[v17] Document tbot GitLab joining `token_env_var_name` option

### DIFF
--- a/docs/pages/reference/machine-id/configuration.mdx
+++ b/docs/pages/reference/machine-id/configuration.mdx
@@ -111,6 +111,17 @@ onboarding:
   # Teleport Proxy. The ca_pins option should be preferred over ca_path.
   ca_path: "/path/to/ca.pem"
 
+  # gitlab holds configuration specific to the "gitlab" join method.
+  gitlab:
+    # token_env_var_name allows the environment variable that contains the
+    # GitLab ID token to be specified. If unspecified, this defaults to
+    # "TBOT_GITLAB_JWT".
+    #
+    # Overriding this is useful when you need to use `tbot` to authenticate to
+    # multiple Teleport clusters from a single GitLab CI job.
+    token_env_var_name: "MY_GITLAB_ID_TOKEN"
+
+
 # storage specifies the destination that `tbot` should use to store its
 # internal state. This state is sensitive, and you should ensure that the
 # destination you specify here can only be accessed by `tbot`.


### PR DESCRIPTION
Backport #54196 to branch/v17