### PR TITLE
Group makefile `$(VERSRC)` targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1348,7 +1348,7 @@ update-version: version test-helm-update-snapshots
 version: $(VERSRC)
 
 # This rule triggers re-generation of version files specified if Makefile changes.
-$(VERSRC): Makefile version.mk
+$(VERSRC) &: Makefile version.mk
 	VERSION=$(VERSION) $(MAKE) -f version.mk setver
 
 # Pushes GITTAG and api/GITTAG to GitHub.


### PR DESCRIPTION
This fixes a race condition ([example](https://github.com/gravitational/teleport/actions/runs/14650817237/job/41115943812#step:6:10)) where the `helm-version` target is called multiple times.

This requires make 4.3 or newer, which is not installed by default on macos. On the 3.81 version that is installed by default, make will treat `&:` as the current `:`, and sometimes run the target multiple times when `-j` is > 1.

Docs on grouped targets: https://www.gnu.org/software/make/manual/html_node/Multiple-Targets.html