### PR TITLE
Convert provision tokens to new in memory cache collection

### DIFF
--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/utils"
 	apiutils "github.com/gravitational/teleport/api/utils"
 )
 
@@ -161,6 +162,8 @@ type ProvisionToken interface {
 	// join methods where the name is secret. This should be used when logging
 	// the token name.
 	GetSafeName() string
+	// Clone creates a copy of the token.
+	Clone() ProvisionToken
 }
 
 // NewProvisionToken returns a new provision token with the given roles.
@@ -193,6 +196,10 @@ func MustCreateProvisionToken(token string, roles SystemRoles, expires time.Time
 		panic(err)
 	}
 	return t
+}
+
+func (p *ProvisionTokenV2) Clone() ProvisionToken {
+	return utils.CloneProtoMsg(p)
 }
 
 // setStaticFields sets static resource header and metadata fields.

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -1210,46 +1210,6 @@ func TestRecovery(t *testing.T) {
 	require.Empty(t, cmp.Diff(ca2, out, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 }
 
-// TestDynamicTokens tests the dynamic tokens cache.
-func TestDynamicTokens(t *testing.T) {
-	t.Parallel()
-
-	ctx := context.Background()
-	p := newPackForAuth(t)
-	t.Cleanup(p.Close)
-
-	expires := time.Now().Add(10 * time.Hour).Truncate(time.Second).UTC()
-	token, err := types.NewProvisionToken("token", types.SystemRoles{types.RoleAuth, types.RoleNode}, expires)
-	require.NoError(t, err)
-
-	err = p.provisionerS.UpsertToken(ctx, token)
-	require.NoError(t, err)
-
-	select {
-	case event := <-p.eventsC:
-		require.Equal(t, EventProcessed, event.Type)
-	case <-time.After(time.Second):
-		t.Fatalf("timeout waiting for event")
-	}
-
-	tout, err := p.cache.GetToken(ctx, token.GetName())
-	require.NoError(t, err)
-	require.Empty(t, cmp.Diff(token, tout, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
-
-	err = p.provisionerS.DeleteToken(ctx, token.GetName())
-	require.NoError(t, err)
-
-	select {
-	case event := <-p.eventsC:
-		require.Equal(t, EventProcessed, event.Type)
-	case <-time.After(time.Second):
-		t.Fatalf("timeout waiting for event")
-	}
-
-	_, err = p.cache.GetToken(ctx, token.GetName())
-	require.True(t, trace.IsNotFound(err))
-}
-
 func TestAuthPreference(t *testing.T) {
 	t.Parallel()
 

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -49,6 +49,7 @@ type collectionHandler interface {
 type collections struct {
 	byKind map[resourceKind]collectionHandler
 
+	provisionTokens                  *collection[types.ProvisionToken]
 	staticTokens                     *collection[types.StaticTokens]
 	certAuthorities                  *collection[types.CertAuthority]
 	users                            *collection[types.User]
@@ -82,6 +83,14 @@ func setupCollections(c Config) (*collections, error) {
 		resourceKind := resourceKindFromWatchKind(watch)
 
 		switch watch.Kind {
+		case types.KindToken:
+			collect, err := newProvisionTokensCollection(c.Provisioner, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out.provisionTokens = collect
+			out.byKind[resourceKind] = out.provisionTokens
 		case types.KindStaticTokens:
 			collect, err := newStaticTokensCollection(c.ClusterConfig, watch)
 			if err != nil {

--- a/lib/cache/legacy_collections.go
+++ b/lib/cache/legacy_collections.go
@@ -141,7 +141,6 @@ type legacyCollections struct {
 	samlIdPSessions                    collectionReader[samlIdPSessionGetter]
 	sessionRecordingConfigs            collectionReader[sessionRecordingConfigGetter]
 	snowflakeSessions                  collectionReader[snowflakeSessionGetter]
-	tokens                             collectionReader[tokenGetter]
 	uiConfigs                          collectionReader[uiConfigGetter]
 	userLoginStates                    collectionReader[services.UserLoginStatesGetter]
 	webSessions                        collectionReader[webSessionGetter]
@@ -171,15 +170,6 @@ func setupLegacyCollections(c *Cache, watches []types.WatchKind) (*legacyCollect
 	for _, watch := range watches {
 		resourceKind := resourceKindFromWatchKind(watch)
 		switch watch.Kind {
-		case types.KindToken:
-			if c.Provisioner == nil {
-				return nil, trace.BadParameter("missing parameter Provisioner")
-			}
-			collections.tokens = &genericCollection[types.ProvisionToken, tokenGetter, provisionTokenExecutor]{
-				cache: c,
-				watch: watch,
-			}
-			collections.byKind[resourceKind] = collections.tokens
 		case types.KindClusterName:
 			if c.ClusterConfig == nil {
 				return nil, trace.BadParameter("missing parameter ClusterConfig")
@@ -778,40 +768,6 @@ type remoteClusterGetter interface {
 }
 
 var _ executor[types.RemoteCluster, remoteClusterGetter] = remoteClusterExecutor{}
-
-type provisionTokenExecutor struct{}
-
-func (provisionTokenExecutor) getAll(ctx context.Context, cache *Cache, loadSecrets bool) ([]types.ProvisionToken, error) {
-	return cache.Provisioner.GetTokens(ctx)
-}
-
-func (provisionTokenExecutor) upsert(ctx context.Context, cache *Cache, resource types.ProvisionToken) error {
-	return cache.provisionerCache.UpsertToken(ctx, resource)
-}
-
-func (provisionTokenExecutor) deleteAll(ctx context.Context, cache *Cache) error {
-	return cache.provisionerCache.DeleteAllTokens()
-}
-
-func (provisionTokenExecutor) delete(ctx context.Context, cache *Cache, resource types.Resource) error {
-	return cache.provisionerCache.DeleteToken(ctx, resource.GetName())
-}
-
-func (provisionTokenExecutor) isSingleton() bool { return false }
-
-func (provisionTokenExecutor) getReader(cache *Cache, cacheOK bool) tokenGetter {
-	if cacheOK {
-		return cache.provisionerCache
-	}
-	return cache.Config.Provisioner
-}
-
-type tokenGetter interface {
-	GetTokens(ctx context.Context) ([]types.ProvisionToken, error)
-	GetToken(ctx context.Context, token string) (types.ProvisionToken, error)
-}
-
-var _ executor[types.ProvisionToken, tokenGetter] = provisionTokenExecutor{}
 
 type clusterNameExecutor struct{}
 


### PR DESCRIPTION
Moves join tokens to the new cache collection scheme that was introduced in #52210. No additional functionality changes have been made here. This should be a purely mechanical translation to the new internal caching machinery.