### PR TITLE
Fix flaky test `TestListUnifiedResources_MixedAccess`

### DIFF
--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -6152,7 +6152,7 @@ func TestListUnifiedResources_MixedAccess(t *testing.T) {
 		})
 		assert.True(t, trace.IsAccessDenied(err), "Expected Access Denied, got %v", err)
 		assert.Nil(t, resp)
-	}, 3*time.Second, 200*time.Millisecond)
+	}, 10*time.Second, 200*time.Millisecond)
 
 	// Validate that an error is returned when a subset of kinds are requested.
 	resp, err = clt.ListUnifiedResources(ctx, &proto.ListUnifiedResourcesRequest{

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -6122,7 +6122,7 @@ func TestListUnifiedResources_MixedAccess(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Empty(t, resp.NextKey)
 		assert.Len(t, resp.Resources, 6)
-	}, 3*time.Second, 200*time.Millisecond)
+	}, 10*time.Second, 200*time.Millisecond)
 
 	// only receive databases because nodes are denied with labels and desktops are denied with a verb rule
 	for _, resource := range resp.Resources {

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -6108,16 +6108,21 @@ func TestListUnifiedResources_MixedAccess(t *testing.T) {
 	clt, err := srv.NewClient(identity)
 	require.NoError(t, err)
 
-	// ensure updated roles have propagated to auth cache
+	// ensure updated roles have propagated to auth cache. Since ListUnifiedResources
+	// uses a separate, custom cache, this is not guaranteed to flush that cache, so
+	// we still use an Eventually loop below.
 	flushCache(t, srv.Auth())
 
-	resp, err := clt.ListUnifiedResources(ctx, &proto.ListUnifiedResourcesRequest{
-		Limit:  20,
-		SortBy: types.SortBy{IsDesc: true, Field: types.ResourceMetadataName},
-	})
-	require.NoError(t, err)
-	require.Len(t, resp.Resources, 6)
-	require.Empty(t, resp.NextKey)
+	var resp *proto.ListUnifiedResourcesResponse
+	inlineEventually(t, func() bool {
+		resp, err = clt.ListUnifiedResources(ctx, &proto.ListUnifiedResourcesRequest{
+			Limit:  20,
+			SortBy: types.SortBy{IsDesc: true, Field: types.ResourceMetadataName},
+		})
+		require.NoError(t, err)
+		require.Empty(t, resp.NextKey)
+		return len(resp.Resources) == 6
+	}, 3*time.Second, 200*time.Millisecond)
 
 	// only receive databases because nodes are denied with labels and desktops are denied with a verb rule
 	for _, resource := range resp.Resources {
@@ -6130,7 +6135,9 @@ func TestListUnifiedResources_MixedAccess(t *testing.T) {
 	_, err = srv.Auth().UpsertRole(ctx, role)
 	require.NoError(t, err)
 
-	// ensure updated roles have propagated to auth cache
+	// ensure updated roles have propagated to auth cache. Since ListUnifiedResources
+	// uses a separate, custom cache, this is not guaranteed to flush that cache, so
+	// we still use an Eventually loop below.
 	flushCache(t, srv.Auth())
 
 	// Get a new client to test with the new roles.
@@ -6138,13 +6145,13 @@ func TestListUnifiedResources_MixedAccess(t *testing.T) {
 	require.NoError(t, err)
 
 	// Validate that an error is returned when no kinds are requested.
-	resp, err = clt.ListUnifiedResources(ctx, &proto.ListUnifiedResourcesRequest{
-		Limit:  20,
-		SortBy: types.SortBy{IsDesc: true, Field: types.ResourceMetadataName},
-	})
-
-	require.True(t, trace.IsAccessDenied(err), "Expected Access Denied, got %v", err)
-	require.Nil(t, resp)
+	inlineEventually(t, func() bool {
+		_, err = clt.ListUnifiedResources(ctx, &proto.ListUnifiedResourcesRequest{
+			Limit:  20,
+			SortBy: types.SortBy{IsDesc: true, Field: types.ResourceMetadataName},
+		})
+		return trace.IsAccessDenied(err)
+	}, 3*time.Second, 200*time.Millisecond)
 
 	// Validate that an error is returned when a subset of kinds are requested.
 	resp, err = clt.ListUnifiedResources(ctx, &proto.ListUnifiedResourcesRequest{


### PR DESCRIPTION
This test was flaky because `flushCache` is not guaranteed to flush the `ListUnifiedResources` cache, [only the Auth cache is actually flushed](https://github.com/gravitational/teleport/issues/53872#issuecomment-2828840337).

Closes https://github.com/gravitational/teleport/issues/53872