### PR TITLE
Add DemoMode entitlement to Identity Security Preview button

### DIFF
--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditorVisualizer.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditorVisualizer.test.tsx
@@ -30,9 +30,11 @@ import TeleportContextProvider from 'teleport/TeleportContextProvider';
 import { RoleDiffProps, RoleDiffState } from '../Roles';
 import { RoleEditorVisualizer } from './RoleEditorVisualizer';
 
+const defaultDemoMode = cfg.entitlements.AccessGraphDemoMode;
 const defaultIsPolicyEnabled = cfg.isPolicyEnabled;
 const defaultIsCloud = cfg.isCloud;
 afterEach(() => {
+  cfg.entitlements.AccessGraphDemoMode = defaultDemoMode;
   cfg.isPolicyEnabled = defaultIsPolicyEnabled;
   cfg.isCloud = defaultIsCloud;
 });
@@ -68,8 +70,23 @@ test('Preview Identity Security button does not show for non-cloud', async () =>
   ).not.toBeInTheDocument();
 });
 
-test('Preview Identity Security button displays for cloud users', async () => {
+test('Preview Identity Security button does not show if entitlement not enabled', async () => {
   cfg.isCloud = true;
+  render(
+    getComponent(
+      makeRoleDiffProps({
+        roleDiffState: RoleDiffState.Disabled,
+      })
+    )
+  );
+  expect(
+    screen.queryByText('Preview Identity Security')
+  ).not.toBeInTheDocument();
+});
+
+test('Preview Identity Security button displays for cloud users with entitlement', async () => {
+  cfg.isCloud = true;
+  cfg.entitlements.AccessGraphDemoMode = { enabled: true, limit: 0 };
   render(
     getComponent(
       makeRoleDiffProps({
@@ -82,6 +99,7 @@ test('Preview Identity Security button displays for cloud users', async () => {
 
 test('Preview Identity Security button does not show if user does not have update ACL', async () => {
   cfg.isCloud = true;
+  cfg.entitlements.AccessGraphDemoMode = { enabled: true, limit: 0 };
   const ctx = createTeleportContext({
     customAcl: { ...getAcl(), accessGraphSettings: noAccess },
   });
@@ -135,6 +153,7 @@ test('ERROR displays policy placeholder with error', async () => {
 
 test('LOADING_SETTINGS displays policy placeholder with a preview button in a loading state', async () => {
   cfg.isCloud = true;
+  cfg.entitlements.AccessGraphDemoMode = { enabled: true, limit: 0 };
   render(
     getComponent(
       makeRoleDiffProps({ roleDiffState: RoleDiffState.LoadingSettings })
@@ -145,6 +164,7 @@ test('LOADING_SETTINGS displays policy placeholder with a preview button in a lo
 
 test('WAITING_FOR_SYNC displays policy placeholder with a preview button in a loading state', async () => {
   cfg.isCloud = true;
+  cfg.entitlements.AccessGraphDemoMode = { enabled: true, limit: 0 };
   render(
     getComponent(
       makeRoleDiffProps({ roleDiffState: RoleDiffState.WaitingForSync })

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditorVisualizer.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditorVisualizer.tsx
@@ -26,6 +26,7 @@ import Box from 'design/Box';
 import Flex from 'design/Flex';
 import { ShieldCheck } from 'design/Icon';
 
+import cfg from 'teleport/config';
 import { getSalesURL } from 'teleport/services/sales';
 import useTeleport from 'teleport/useTeleport';
 
@@ -43,7 +44,8 @@ export function RoleEditorVisualizer({
   const ctx = useTeleport();
   const version = ctx.storeUser.state.cluster.authVersion;
   const canUpdateAccessGraphSettings =
-    ctx.storeUser.state.acl.accessGraphSettings.edit;
+    ctx.storeUser.state.acl.accessGraphSettings.edit &&
+    cfg.entitlements.AccessGraphDemoMode.enabled;
   // the demo banner should show every time they load the role editor
   const [demoDismissed, setDemoDismissed] = useState(false);
   if (roleDiffProps && shouldShowRoleDiff(roleDiffProps)) {

--- a/web/packages/teleport/src/entitlement.ts
+++ b/web/packages/teleport/src/entitlement.ts
@@ -21,6 +21,7 @@ type entitlement =
   | 'AccessLists'
   | 'AccessMonitoring'
   | 'AccessRequests'
+  | 'AccessGraphDemoMode'
   | 'App'
   | 'CloudAuditLogRetention'
   | 'DB'
@@ -48,6 +49,7 @@ export const defaultEntitlements: Record<
 > = {
   AccessLists: { enabled: false, limit: 0 },
   AccessMonitoring: { enabled: false, limit: 0 },
+  AccessGraphDemoMode: { enabled: false, limit: 0 },
   AccessRequests: { enabled: false, limit: 0 },
   App: { enabled: false, limit: 0 },
   CloudAuditLogRetention: { enabled: false, limit: 0 },


### PR DESCRIPTION
This adds one extra conditional to display the access graph demo button. The user must also have the entitlement enabled. This is already checked when enabling demo mode in the backend, but with this frontend check we will hide the button if the request was going to fail anyway.

This also adds the entitlement to the entitlement types