### PR TITLE
Workload Identity: Kubernetes Attestor Bug Fixes

### DIFF
--- a/lib/tbot/workloadidentity/workloadattest/kubernetes_unix.go
+++ b/lib/tbot/workloadidentity/workloadattest/kubernetes_unix.go
@@ -34,6 +34,7 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -103,7 +104,8 @@ func (a *KubernetesAttestor) Attest(ctx context.Context, pid int) (*workloadiden
 
 	var ctr *workloadidentityv1pb.WorkloadAttrsKubernetesContainer
 	for _, status := range pod.Status.ContainerStatuses {
-		if status.ContainerID != container.ID {
+		// Kubelet returns the container ID prefixed by `<type>://`.
+		if _, id, _ := strings.Cut(status.ContainerID, "://"); id != container.ID {
 			continue
 		}
 		ctr = &workloadidentityv1pb.WorkloadAttrsKubernetesContainer{

--- a/lib/tbot/workloadidentity/workloadattest/kubernetes_unix.go
+++ b/lib/tbot/workloadidentity/workloadattest/kubernetes_unix.go
@@ -152,7 +152,7 @@ LOOP:
 		pod, containerStatus, err = a.tryGetPodAndContainerStatus(ctx, podID, containerID)
 		switch {
 		case err != nil:
-			log.WarnContext(ctx, "Failed to get pod and container status from kubelet", "error", err)
+			return nil, nil, err
 		case containerStatus == nil:
 			// It's possible for a workload container to start and request a SVID
 			// before the kubelet has updated its state, in which case we might

--- a/lib/tbot/workloadidentity/workloadattest/kubernetes_unix.go
+++ b/lib/tbot/workloadidentity/workloadattest/kubernetes_unix.go
@@ -163,6 +163,7 @@ LOOP:
 			break LOOP
 		}
 
+		retry.Inc()
 		select {
 		case <-ctx.Done():
 			break LOOP

--- a/lib/tbot/workloadidentity/workloadattest/kubernetes_unix_test.go
+++ b/lib/tbot/workloadidentity/workloadattest/kubernetes_unix_test.go
@@ -135,7 +135,7 @@ func TestKubernetesAttestor_Attest(t *testing.T) {
 		},
 	}, log)
 	attestor.rootPath = tmpDir
-	attestor.clock = clockwork.NewFakeClock()
+	attestor.clock = clockwork.NewRealClock()
 	attestor.kubeletClient.getEnv = func(s string) string {
 		env := map[string]string{
 			"TELEPORT_NODE_NAME": host,

--- a/lib/tbot/workloadidentity/workloadattest/kubernetes_unix_test.go
+++ b/lib/tbot/workloadidentity/workloadattest/kubernetes_unix_test.go
@@ -32,6 +32,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -55,11 +56,31 @@ func TestKubernetesAttestor_Attest(t *testing.T) {
 	mockContainerID := "9da25af0b548c8c60aa60f77f299ba727bf72d58248bd7528eb5390ffcce555a"
 
 	// Setup mock Kubelet Secure API
+	var requests int
 	mockKubeletAPI := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.URL.Path != "/pods" {
 			http.NotFound(w, req)
 			return
 		}
+
+		// Don't return the container status in the first response, to simulate
+		// the kubelet API's eventual consistency.
+		var containerStatuses []v1.ContainerStatus
+		switch {
+		case requests == 1:
+			containerStatuses = append(containerStatuses, v1.ContainerStatus{
+				ContainerID: "docker://totally-wrong-container-id",
+			})
+		case requests > 1:
+			containerStatuses = append(containerStatuses, v1.ContainerStatus{
+				ContainerID: "docker://" + mockContainerID,
+				Name:        "container-1",
+				Image:       "my.registry.io/my-app:v1",
+				ImageID:     "docker-pullable://my.registry.io/my-app@sha256:84c998f7610b356a5eed24f801c01b273cf3e83f081f25c9b16aa8136c2cafb1",
+			})
+		}
+		requests++
+
 		out := v1.PodList{
 			Items: []v1.Pod{
 				{
@@ -75,14 +96,7 @@ func TestKubernetesAttestor_Attest(t *testing.T) {
 						ServiceAccountName: "my-service-account",
 					},
 					Status: v1.PodStatus{
-						ContainerStatuses: []v1.ContainerStatus{
-							{
-								ContainerID: "docker://" + mockContainerID,
-								Name:        "container-1",
-								Image:       "my.registry.io/my-app:v1",
-								ImageID:     "docker-pullable://my.registry.io/my-app@sha256:84c998f7610b356a5eed24f801c01b273cf3e83f081f25c9b16aa8136c2cafb1",
-							},
-						},
+						ContainerStatuses: containerStatuses,
 					},
 				},
 			},
@@ -121,6 +135,7 @@ func TestKubernetesAttestor_Attest(t *testing.T) {
 		},
 	}, log)
 	attestor.rootPath = tmpDir
+	attestor.clock = clockwork.NewFakeClock()
 	attestor.kubeletClient.getEnv = func(s string) string {
 		env := map[string]string{
 			"TELEPORT_NODE_NAME": host,

--- a/lib/tbot/workloadidentity/workloadattest/kubernetes_unix_test.go
+++ b/lib/tbot/workloadidentity/workloadattest/kubernetes_unix_test.go
@@ -77,7 +77,7 @@ func TestKubernetesAttestor_Attest(t *testing.T) {
 					Status: v1.PodStatus{
 						ContainerStatuses: []v1.ContainerStatus{
 							{
-								ContainerID: mockContainerID,
+								ContainerID: "docker://" + mockContainerID,
 								Name:        "container-1",
 								Image:       "my.registry.io/my-app:v1",
 								ImageID:     "docker-pullable://my.registry.io/my-app@sha256:84c998f7610b356a5eed24f801c01b273cf3e83f081f25c9b16aa8136c2cafb1",


### PR DESCRIPTION
Closes #54283.

Fixes two bugs in the Kubernetes attestor which prevented it from picking up container details:

1. We were comparing the hexadecimal ID from the container's cgroup path to the kubelet API's `containerID` field as-is, but kubelet returns this in the form: `<type>://<hex id>`.
2. There's a race condition where if the container calls the SPIFFE workload identity API too quickly (e.g. on start), the kubelet might return no container status or a previous run's status. We now retry for up to 30s.

changelog: Workload Identity: bug fixes for the Kubernetes workload attestor's container resolution
