### PR TITLE
Fix avatar link in the Discord guide

### DIFF
--- a/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-discord.mdx
+++ b/docs/pages/admin-guides/access-controls/access-request-plugins/ssh-approval-discord.mdx
@@ -3,6 +3,8 @@ title: Run the Discord Access Request Plugin
 description: How to set up Teleport's Discord plugin for privilege elevation approvals.
 ---
 
+import BotLogo from "/static/avatar_logo.png";
+
 This guide will explain how to set up Discord to receive Access Request messages
 from Teleport. Teleport's Discord integration notifies individuals and channels of
 Access Requests. Users can then approve and deny Access Requests from within
@@ -78,10 +80,10 @@ Set the application icon ([download application icon here](../../../../img/sso/o
 
 ### Create the application bot
 
-Go to the "Bot" tab and choose "Add Bot". Set the bot icon ([download bot icon
-here](../../../../img/enterprise/plugins/teleport_bot@2x.png)). Un-check the
-"Public Bot" toggle as this bot should only be used within your Discord
-servers. Finally, press "Reset Token", copy and save the new token into a safe place.
+Go to the "Bot" tab and choose "Add Bot". You can <a href={BotLogo}
+download>download</a> our avatar to set as your Bot icon. Un-check the "Public
+Bot" toggle as this bot should only be used within your Discord servers.
+Finally, press "Reset Token", copy and save the new token into a safe place.
 This token will be used by the Teleport plugin to authenticate against the
 Discord API.
 


### PR DESCRIPTION
Closes #54042 

The avatar image download link in the Discord guide 404s. Use the approach we took in #51193 to fix the link: include an `<a>` tag instead of a Markdown link, and use an `import` statement to retrieve the URL path of the static asset. The URL path points to the `static` directory, where we host images reachable by import statements in Docusaurus.