### PR TITLE
Add links between Azure protection guides

### DIFF
--- a/docs/pages/enroll-resources/application-access/cloud-apis/azure.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/azure.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Protect Azure CLIs with Teleport Application Access"
+title: Protect Azure CLIs and APIs with Teleport
 description: How to enable secure access to Azure CLIs.
 labels:
  - how-to
@@ -11,8 +11,13 @@ labels:
 In this guide, you will:
 
 1. Create an Azure managed identity for user access and attach it your VM.
-1. Deploy a Teleport Application Service with an Azure app in your Teleport cluster.
+1. Deploy the Teleport Application Service with an Azure app in your Teleport cluster.
 1. Assume the managed identity and run `az` commands via `tsh`.
+
+If you have enabled the Teleport SAML IdP, you can use it instead of the
+Teleport Application Service to manage access to Azure CLI applications. For
+instructions, read [Access Azure Portal and
+CLI](../../../admin-guides/access-controls/idps/saml-microsoft-entra-external-id.mdx).
 
 ## How it works
 

--- a/docs/pages/enroll-resources/application-access/cloud-apis/azure.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/azure.mdx
@@ -19,13 +19,14 @@ In this guide, you will:
 (!docs/pages/includes/application-access/azure-how-it-works.mdx deployment="on an Azure VM" credential="managed identities"!)
 
 Alternatively, you can use the [Teleport SAML IdP](
-../../../admin-guides/access-controls/idps/saml-microsoft-entra-external-id.mdx)-based
-integration to manage access to Azure Portal and CLI applications. 
-In this approach, user [interactively sign-in](
-https://learn.microsoft.com/en-us/cli/azure/authenticate-azure-cli-interactively) 
-to Azure portal and CLI and Azure services tags audit logs on behalf of Teleport user
-account, providing more visibility into how Teleport users are interacting with Azure. 
-It is also the only supported method to manage access to the Azure portal.
+../../../identity-governance/idps/saml-microsoft-entra-external-id.mdx)-based
+integration to manage access to Azure Portal and CLI applications.  In this
+approach, users [interactively sign in](
+https://learn.microsoft.com/en-us/cli/azure/authenticate-azure-cli-interactively)
+to Azure portal and CLI tools, and Azure services tag audit logs on behalf of
+Teleport user account, providing more visibility into how Teleport users are
+interacting with Azure. It is also the only supported method to manage access to
+the Azure portal.
 
 ## Prerequisites
 

--- a/docs/pages/enroll-resources/application-access/cloud-apis/azure.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/azure.mdx
@@ -18,12 +18,14 @@ In this guide, you will:
 
 (!docs/pages/includes/application-access/azure-how-it-works.mdx deployment="on an Azure VM" credential="managed identities"!)
 
-You can use the Teleport SAML IdP instead of the Teleport Application Service to
-manage access to Azure CLI applications. For instructions, read [Access Azure
-Portal and
-CLI](../../../admin-guides/access-controls/idps/saml-microsoft-entra-external-id.mdx).
-In this approach, Azure tags audit logs with Teleport user accounts, providing
-more visibility into how Teleport users are interacting with Azure. 
+Alternatively, you can use the [Teleport SAML IdP](
+../../../admin-guides/access-controls/idps/saml-microsoft-entra-external-id.mdx)-based
+integration to manage access to Azure Portal and CLI applications. 
+In this approach, user [interactively sign-in](
+https://learn.microsoft.com/en-us/cli/azure/authenticate-azure-cli-interactively) 
+to Azure portal and CLI and Azure services tags audit logs on behalf of Teleport user
+account, providing more visibility into how Teleport users are interacting with Azure. 
+It is also the only supported method to manage access to the Azure portal.
 
 ## Prerequisites
 

--- a/docs/pages/enroll-resources/application-access/cloud-apis/azure.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/azure.mdx
@@ -14,14 +14,16 @@ In this guide, you will:
 1. Deploy the Teleport Application Service with an Azure app in your Teleport cluster.
 1. Assume the managed identity and run `az` commands via `tsh`.
 
-If you have enabled the Teleport SAML IdP, you can use it instead of the
-Teleport Application Service to manage access to Azure CLI applications. For
-instructions, read [Access Azure Portal and
-CLI](../../../admin-guides/access-controls/idps/saml-microsoft-entra-external-id.mdx).
-
 ## How it works
 
 (!docs/pages/includes/application-access/azure-how-it-works.mdx deployment="on an Azure VM" credential="managed identities"!)
+
+You can use the Teleport SAML IdP instead of the Teleport Application Service to
+manage access to Azure CLI applications. For instructions, read [Access Azure
+Portal and
+CLI](../../../admin-guides/access-controls/idps/saml-microsoft-entra-external-id.mdx).
+In this approach, Azure tags audit logs with Teleport user accounts, providing
+more visibility into how Teleport users are interacting with Azure. 
 
 ## Prerequisites
 

--- a/docs/pages/identity-governance/idps/saml-microsoft-entra-external-id.mdx
+++ b/docs/pages/identity-governance/idps/saml-microsoft-entra-external-id.mdx
@@ -13,24 +13,26 @@ so that users can access Azure Portal and the Azure CLI by authenticating with T
 
 ## How it works
 
-In this setup, Teleport users can authenticate to Microsoft Azure Portal, the
-Azure CLI, and Azure API clients using Security Assertion Markup Language
-(SAML). The [Teleport SAML
-IdP](../../../admin-guides/access-controls/idps/idps.mdx) acts as a SAML
-identity provider, and Microsoft Entra External ID acts as a service provider.
-Azure Portal can verify that a user has authenticated to Teleport by verifying
-an assertion from the Teleport SAML IdP against the Teleport SAML certificate
-authority.
+This integration is based on [Microsoft Entra External ID](https://learn.microsoft.com/en-us/entra/external-id/) 
+and [Teleport SAML IdP](saml-guide.mdx).
 
-Azure tags authentication logs on behalf of Teleport user accounts, providing
-visibility into the Teleport users accessing Azure.
+In Microsoft Entra External ID, Teleport SAML IdP will be configured as an external IdP.
+And users who are to be granted access to Azure will be configured as an external users.
+As long as the user account is associated with a domain that is assigned to the 
+Teleport SAML IdP, users can access Azure portal and CLI by authenticating with Teleport.
 
-You can also manage Azure API and CLI authentication (but not Azure Portal
-access) by deploying the Teleport Application Service. For instructions, read
-[Protect Azure CLIs and APIs with Teleport](
-../../../enroll-resources/application-access/cloud-apis/azure.mdx). One downside
-of this approach is that Azure audit logs are not tied to Teleport user
-accounts.
+Authentication is based on the [interactive sign-in](
+https://learn.microsoft.com/en-us/cli/azure/authenticate-azure-cli-interactively) 
+process. User audit events in Azure are tagged on behalf of Teleport user account,
+providing better audit visibility.
+
+Alternatively, you can also manage accesss to Azure API and CLI by deploying the 
+[Teleport Application Service](../../../enroll-resources/application-access/cloud-apis/azure.mdx). 
+This approach supports access based on [managed identity](
+https://learn.microsoft.com/en-us/cli/azure/authenticate-azure-cli-managed-identity), 
+which may be suitable for automated access. The downside to this approach is that it cannot
+be used to provision access to Azure portal and the audit logs are not tied to the 
+Teleport user account, limiting user account visibility on the the audit events.
 
 ## Prerequisites
 

--- a/docs/pages/identity-governance/idps/saml-microsoft-entra-external-id.mdx
+++ b/docs/pages/identity-governance/idps/saml-microsoft-entra-external-id.mdx
@@ -11,10 +11,26 @@ labels:
 This guide explains how to integrate the Teleport SAML IdP with [Microsoft Entra External ID](https://learn.microsoft.com/en-us/entra/external-id/)
 so that users can access Azure Portal and the Azure CLI by authenticating with Teleport.
 
-If you have not enabled the Teleport SAML IdP, you can still manage Azure API
-and CLI authentication (but not Azure Portal access) by deploying the Teleport
-Application Service. For instructions, read [Protect Azure CLIs and APIs with
-Teleport]( ../../../enroll-resources/application-access/cloud-apis/azure.mdx).
+## How it works
+
+In this setup, Teleport users can authenticate to Microsoft Azure Portal, the
+Azure CLI, and Azure API clients using Security Assertion Markup Language
+(SAML). The [Teleport SAML
+IdP](../../../admin-guides/access-controls/idps/idps.mdx) acts as a SAML
+identity provider, and Microsoft Entra External ID acts as a service provider.
+Azure Portal can verify that a user has authenticated to Teleport by verifying
+an assertion from the Teleport SAML IdP against the Teleport SAML certificate
+authority.
+
+Azure tags authentication logs on behalf of Teleport user accounts, providing
+visibility into the Teleport users accessing Azure.
+
+You can also manage Azure API and CLI authentication (but not Azure Portal
+access) by deploying the Teleport Application Service. For instructions, read
+[Protect Azure CLIs and APIs with Teleport](
+../../../enroll-resources/application-access/cloud-apis/azure.mdx). One downside
+of this approach is that Azure audit logs are not tied to Teleport user
+accounts.
 
 ## Prerequisites
 

--- a/docs/pages/identity-governance/idps/saml-microsoft-entra-external-id.mdx
+++ b/docs/pages/identity-governance/idps/saml-microsoft-entra-external-id.mdx
@@ -13,21 +13,20 @@ so that users can access Azure Portal and the Azure CLI by authenticating with T
 
 ## How it works
 
-This integration is based on [Microsoft Entra External ID](https://learn.microsoft.com/en-us/entra/external-id/) 
-and [Teleport SAML IdP](saml-guide.mdx).
-
-In Microsoft Entra External ID, Teleport SAML IdP will be configured as an external IdP.
-And users who are to be granted access to Azure will be configured as an external users.
-As long as the user account is associated with a domain that is assigned to the 
-Teleport SAML IdP, users can access Azure portal and CLI by authenticating with Teleport.
+An administrator configures the [Teleport SAML IdP](saml-guide.mdx) as an
+external IdP in Microsoft Entra External ID, and configures users who are to be
+granted access to Azure as external users. As long as the accounts of these
+users are associated with a domain that is assigned to the Teleport SAML IdP,
+these users can access Azure portal and CLI tools by authenticating with
+Teleport.
 
 Authentication is based on the [interactive sign-in](
 https://learn.microsoft.com/en-us/cli/azure/authenticate-azure-cli-interactively) 
 process. User audit events in Azure are tagged on behalf of Teleport user account,
 providing better audit visibility.
 
-Alternatively, you can also manage accesss to Azure API and CLI by deploying the 
-[Teleport Application Service](../../../enroll-resources/application-access/cloud-apis/azure.mdx). 
+Alternatively, you can also manage access to Azure API and CLI by deploying the 
+[Teleport Application Service](../../enroll-resources/application-access/cloud-apis/azure.mdx). 
 This approach supports access based on [managed identity](
 https://learn.microsoft.com/en-us/cli/azure/authenticate-azure-cli-managed-identity), 
 which may be suitable for automated access. The downside to this approach is that it cannot

--- a/docs/pages/identity-governance/idps/saml-microsoft-entra-external-id.mdx
+++ b/docs/pages/identity-governance/idps/saml-microsoft-entra-external-id.mdx
@@ -11,6 +11,11 @@ labels:
 This guide explains how to integrate the Teleport SAML IdP with [Microsoft Entra External ID](https://learn.microsoft.com/en-us/entra/external-id/)
 so that users can access Azure Portal and the Azure CLI by authenticating with Teleport.
 
+If you have not enabled the Teleport SAML IdP, you can still manage Azure API
+and CLI authentication (but not Azure Portal access) by deploying the Teleport
+Application Service. For instructions, read [Protect Azure CLIs and APIs with
+Teleport]( ../../../enroll-resources/application-access/cloud-apis/azure.mdx).
+
 ## Prerequisites
 
 - A running Teleport Enterprise cluster v17.5.1 or higher. If you


### PR DESCRIPTION
Closes #54091

There are two guides for protecting Azure with Teleport, and each uses a different set of Teleport features. Add links between the two guides.