### PR TITLE
Support Windows desktop certs in tsh

### DIFF
--- a/api/utils/keypaths/keypaths.go
+++ b/api/utils/keypaths/keypaths.go
@@ -57,6 +57,8 @@ const (
 	dbDirSuffix = "-db"
 	// kubeDirSuffix is the suffix of a sub-directory where kube TLS certs are stored.
 	kubeDirSuffix = "-kube"
+	// windowsDesktopDirSuffix is the suffix of a subdirectory where Windows desktop TLS certs are stored.
+	windowsDesktopDirSuffix = "-windowsdesktop"
 	// kubeConfigSuffix is the suffix of a kubeconfig file stored under the keys directory.
 	kubeConfigSuffix = "-kubeconfig"
 	// fileNameKubeCredLock is file name of lockfile used to prevent excessive login attempts.
@@ -112,20 +114,29 @@ const (
 //    │   │   │   ├── dbC.crt          --> TLS cert for database service "dbC"
 //    │   │   │   └── dbC.key          --> private key for database service "dbC"
 //    │   │   └── proxy-localca.pem    --> Self-signed TLS Routing local proxy CA
+//    │   ├── foo-windowsdesktop       --> Windows desktop access certs for user "foo"
+//    │   │   ├── root                 --> Windows desktop access certs for cluster "root"
+//    │   │   │   ├── desktopA.crt     --> TLS cert for desktop service "desktopA"
+//    │   │   │   ├── desktopA.key     --> private key for desktop service "desktopA"
+//    │   │   │   ├── desktopB.crt     --> TLS cert for desktop service "desktopB"
+//    │   │   │   └── desktopB.key     --> private key for desktop service "desktopB"
+//    │   │   └── leaf                 --> Windows desktop access for cluster "leaf"
+//    │   │       ├── desktopC.crt     --> TLS cert for desktop service "desktopC"
+//    │   │       └── desktopC.key     --> private key for desktop service "desktopC"
 //    │   ├── foo-kube                 --> Kubernetes certs for user "foo"
-//    │   |    ├── root                 --> Kubernetes certs for Teleport cluster "root"
-//    │   |    │   ├── kubeA-kubeconfig --> standalone kubeconfig for Kubernetes cluster "kubeA"
-//    │   |    │   ├── kubeA.cred       --> TLS private key and cert for Kubernetes cluster "kubeA"
-//    │   |    │   ├── kubeB-kubeconfig --> standalone kubeconfig for Kubernetes cluster "kubeB"
-//    │   |    │   ├── kubeB.cred       --> TLS private key and cert for Kubernetes cluster "kubeB"
-//    │   |    │   └── localca.pem      --> Self-signed localhost CA cert for Teleport cluster "root"
-//    │   |    └── leaf                 --> Kubernetes certs for Teleport cluster "leaf"
-//    │   |        ├── kubeC-kubeconfig --> standalone kubeconfig for Kubernetes cluster "kubeC"
-//    │   |        └── kubeC.cred       --> TLS private key and cert for Kubernetes cluster "kubeC"
-//    |   └── cas                       --> Trusted clusters certificates
-//    |        ├── root.pem             --> TLS CA for teleport cluster "root"
-//    |        ├── leaf1.pem            --> TLS CA for teleport cluster "leaf1"
-//    |        └── leaf2.pem            --> TLS CA for teleport cluster "leaf2"
+//    │   │    ├── root                 --> Kubernetes certs for Teleport cluster "root"
+//    │   │    │   ├── kubeA-kubeconfig --> standalone kubeconfig for Kubernetes cluster "kubeA"
+//    │   │    │   ├── kubeA.cred       --> TLS private key and cert for Kubernetes cluster "kubeA"
+//    │   │    │   ├── kubeB-kubeconfig --> standalone kubeconfig for Kubernetes cluster "kubeB"
+//    │   │    │   ├── kubeB.cred       --> TLS private key and cert for Kubernetes cluster "kubeB"
+//    │   │    │   └── localca.pem      --> Self-signed localhost CA cert for Teleport cluster "root"
+//    │   │    └── leaf                 --> Kubernetes certs for Teleport cluster "leaf"
+//    │   │        ├── kubeC-kubeconfig --> standalone kubeconfig for Kubernetes cluster "kubeC"
+//    │   │        └── kubeC.cred       --> TLS private key and cert for Kubernetes cluster "kubeC"
+//    │   └── cas                       --> Trusted clusters certificates
+//    │        ├── root.pem             --> TLS CA for teleport cluster "root"
+//    │        ├── leaf1.pem            --> TLS CA for teleport cluster "leaf1"
+//    │        └── leaf2.pem            --> TLS CA for teleport cluster "leaf2"
 //    └── two.example.com			    --> Additional proxy host entries follow the same format
 //		  ...
 
@@ -287,6 +298,38 @@ func AppKeyPath(baseDir, proxy, username, cluster, appname string) string {
 // <baseDir>/keys/<proxy>/<username>-app/<cluster>/<appname>-localca.pem
 func AppLocalCAPath(baseDir, proxy, username, cluster, appname string) string {
 	return filepath.Join(AppCredentialDir(baseDir, proxy, username, cluster), appname+fileExtLocalCA)
+}
+
+// WindowsDesktopDir returns the path to the user's Windows desktop directory
+// for the given proxy.
+//
+// <baseDir>/keys/<proxy>/<username>-windowsdesktop
+func WindowsDesktopDir(baseDir, proxy, username string) string {
+	return filepath.Join(ProxyKeyDir(baseDir, proxy), username+windowsDesktopDirSuffix)
+}
+
+// WindowsDesktopCredentialDir returns the path to the user's Windows desktop credential directory for
+// the given proxy and cluster.
+//
+// <baseDir>/keys/<proxy>/<username>-windowsdesktop/<cluster>
+func WindowsDesktopCredentialDir(baseDir, proxy, username, cluster string) string {
+	return filepath.Join(WindowsDesktopDir(baseDir, proxy, username), cluster)
+}
+
+// WindowsDesktopCertPath returns the path to the user's TLS certificate
+// for the given proxy, cluster, and Windows desktop.
+//
+// <baseDir>/keys/<proxy>/<username>-windowsdesktop/<cluster>/<desktop>.crt
+func WindowsDesktopCertPath(baseDir, proxy, username, cluster, desktop string) string {
+	return filepath.Join(WindowsDesktopCredentialDir(baseDir, proxy, username, cluster), desktop+FileExtTLSCert)
+}
+
+// WindowsDesktopKeyPath returns the path to the user's private key for the given proxy,
+// cluster, and Windows desktop.
+//
+// <baseDir>/keys/<proxy>/<username>-windowsdesktop/<cluster>/<desktop>.key
+func WindowsDesktopKeyPath(baseDir, proxy, username, cluster, desktop string) string {
+	return filepath.Join(WindowsDesktopCredentialDir(baseDir, proxy, username, cluster), desktop+fileExtTLSKey)
 }
 
 // DatabaseDir returns the path to the user's database directory

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -131,9 +131,10 @@ type ReissueParams struct {
 	KubernetesCluster string
 	AccessRequests    []string
 	// See [proto.UserCertsRequest.DropAccessRequests].
-	DropAccessRequests []string
-	RouteToDatabase    proto.RouteToDatabase
-	RouteToApp         proto.RouteToApp
+	DropAccessRequests    []string
+	RouteToDatabase       proto.RouteToDatabase
+	RouteToApp            proto.RouteToApp
+	RouteToWindowsDesktop proto.RouteToWindowsDesktop
 
 	// ExistingCreds is a gross hack for lib/web/terminal.go to pass in
 	// existing user credentials. The TeleportClient in lib/web/terminal.go
@@ -181,6 +182,10 @@ func (p ReissueParams) usage() proto.UserCertsRequest_CertUsage {
 		// App means a request for a TLS certificate for access to a specific
 		// web app, as specified by RouteToApp.
 		return proto.UserCertsRequest_App
+	case p.RouteToWindowsDesktop.WindowsDesktop != "":
+		// Windows desktop means a request for a TLS certificate for access to a specific
+		// desktop, as specified by RouteToWindowsDesktop.
+		return proto.UserCertsRequest_WindowsDesktop
 	default:
 		// All means a request for both SSH and TLS certificates for the
 		// overall user session. These certificates are not specific to any SSH
@@ -200,6 +205,8 @@ func (p ReissueParams) isMFARequiredRequest(sshLogin string) (*proto.IsMFARequir
 		req.Target = &proto.IsMFARequiredRequest_Database{Database: &p.RouteToDatabase}
 	case p.RouteToApp.Name != "":
 		req.Target = &proto.IsMFARequiredRequest_App{App: &p.RouteToApp}
+	case p.RouteToWindowsDesktop.WindowsDesktop != "":
+		req.Target = &proto.IsMFARequiredRequest_WindowsDesktop{WindowsDesktop: &p.RouteToWindowsDesktop}
 	default:
 		return nil, trace.BadParameter("reissue params have no valid MFA target")
 	}

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -138,6 +138,9 @@ type KeyRing struct {
 	// AppTLSCredentials are TLS credentials for application access.
 	// Map key is the application name.
 	AppTLSCredentials map[string]TLSCredential
+	// WindowsDesktopTLSCredentials are TLS credentials for desktop access.
+	// Map key is the desktop name.
+	WindowsDesktopTLSCredentials map[string]TLSCredential
 	// TrustedCerts is a list of trusted certificate authorities
 	TrustedCerts []authclient.TrustedCerts
 }
@@ -529,6 +532,15 @@ func (k *KeyRing) AppTLSCert(appName string) (tls.Certificate, error) {
 	cred, ok := k.AppTLSCredentials[appName]
 	if !ok {
 		return tls.Certificate{}, trace.NotFound("TLS certificate for application %q not found", appName)
+	}
+	return cred.TLSCertificate()
+}
+
+// WindowsDesktopTLSCert returns the tls.Certificate for authentication against a named desktop.
+func (k *KeyRing) WindowsDesktopTLSCert(desktopName string) (tls.Certificate, error) {
+	cred, ok := k.WindowsDesktopTLSCredentials[desktopName]
+	if !ok {
+		return tls.Certificate{}, trace.NotFound("TLS certificate for Windows desktop %q not found", desktopName)
 	}
 	return cred.TLSCertificate()
 }

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -184,11 +184,12 @@ func (k *KeyRing) generateSubjectTLSKey(ctx context.Context, tc *TeleportClient,
 // NewKeyRing creates a new KeyRing for the given private keys.
 func NewKeyRing(sshPriv, tlsPriv *keys.PrivateKey) *KeyRing {
 	return &KeyRing{
-		SSHPrivateKey:      sshPriv,
-		TLSPrivateKey:      tlsPriv,
-		KubeTLSCredentials: make(map[string]TLSCredential),
-		DBTLSCredentials:   make(map[string]TLSCredential),
-		AppTLSCredentials:  make(map[string]TLSCredential),
+		SSHPrivateKey:                sshPriv,
+		TLSPrivateKey:                tlsPriv,
+		KubeTLSCredentials:           make(map[string]TLSCredential),
+		DBTLSCredentials:             make(map[string]TLSCredential),
+		AppTLSCredentials:            make(map[string]TLSCredential),
+		WindowsDesktopTLSCredentials: make(map[string]TLSCredential),
 	}
 }
 

--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -531,6 +531,15 @@ func (a *LocalKeyAgent) AddAppKeyRing(keyRing *KeyRing) error {
 	return a.addKeyRing(keyRing)
 }
 
+// AddWindowsDesktopKeyRing activates a new signed desktop key by adding it into the keystore.
+// key must contain at least one desktop credential. ssh cert is not required.
+func (a *LocalKeyAgent) AddWindowsDesktopKeyRing(keyRing *KeyRing) error {
+	if len(keyRing.WindowsDesktopTLSCredentials) == 0 {
+		return trace.BadParameter("key ring must contain at least one Windows desktop access certificate")
+	}
+	return a.addKeyRing(keyRing)
+}
+
 // addKeyRing activates a new signed session key ring by adding it into the keystore.
 func (a *LocalKeyAgent) addKeyRing(keyRing *KeyRing) error {
 	if keyRing == nil {


### PR DESCRIPTION
Contributes to https://github.com/gravitational/teleport/issues/20802

This allows for generation of MFA-verified certificates to connect to the Windows service.

The implementation is based on existing code for other protocols.
When it comes to naming, I've decided to consistently use "windows desktop". Once we add Linux support, we can either introduce "linux desktop" certs or rename everything to "desktop", but I'll leave that decision for later.