### PR TITLE
Update web editor for rolev8 crd support.

### DIFF
--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.test.tsx
@@ -153,11 +153,14 @@ describe('KubernetesAccessSection', () => {
       screen.getByRole('button', { name: 'Add a Kubernetes Resource' })
     );
     expect(
-      reactSelectValueContainer(screen.getByLabelText('Kind'))
+      reactSelectValueContainer(screen.getByLabelText('Kind (plural)'))
     ).toHaveTextContent('Any kind');
+    expect(screen.getByLabelText('API Group *')).toHaveValue('*');
     expect(screen.getByLabelText('Name *')).toHaveValue('*');
     expect(screen.getByLabelText('Namespace *')).toHaveValue('*');
-    await selectEvent.select(screen.getByLabelText('Kind'), 'Job');
+    await selectEvent.select(screen.getByLabelText('Kind (plural)'), 'jobs');
+    await user.clear(screen.getByLabelText('API Group *'));
+    await user.type(screen.getByLabelText('API Group *'), 'api-group-name');
     await user.clear(screen.getByLabelText('Name *'));
     await user.type(screen.getByLabelText('Name *'), 'job-name');
     await user.clear(screen.getByLabelText('Namespace *'));
@@ -178,13 +181,14 @@ describe('KubernetesAccessSection', () => {
       resources: [
         {
           id: expect.any(String),
-          kind: expect.objectContaining({ value: 'job' }),
+          kind: expect.objectContaining({ value: 'jobs' }),
           name: 'job-name',
           namespace: 'job-namespace',
           verbs: [
             expect.objectContaining({ value: 'create' }),
             expect.objectContaining({ value: 'delete' }),
           ],
+          apiGroup: 'api-group-name',
           roleVersion: 'v8',
         },
       ],
@@ -258,7 +262,10 @@ describe('KubernetesAccessSection', () => {
     await user.click(
       screen.getByRole('button', { name: 'Add a Kubernetes Resource' })
     );
-    await selectEvent.select(screen.getByLabelText('Kind'), 'Service');
+
+    screen.getByLabelText('Kind').setAttribute('value', 'Service');
+
+    screen.getByLabelText('Kind');
     await user.clear(screen.getByLabelText('Name *'));
     await user.clear(screen.getByLabelText('Namespace *'));
     await selectEvent.select(screen.getByLabelText('Verbs'), [

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.tsx
@@ -38,6 +38,7 @@ import { precomputed } from 'shared/components/Validation/rules';
 import { ValidationSuspender } from 'shared/components/Validation/Validation';
 
 import { LabelsInput } from 'teleport/components/LabelsInput';
+import { RoleVersion } from 'teleport/services/resources';
 
 import {
   SectionBox,
@@ -50,13 +51,15 @@ import {
   DatabaseAccess,
   GitHubOrganizationAccess,
   KubernetesAccess,
-  kubernetesResourceKindOptions,
+  kubernetesResourceKindOptionsV7,
+  kubernetesResourceKindOptionsV8,
   KubernetesResourceModel,
   kubernetesVerbOptions,
   newKubernetesResourceModel,
   ResourceAccess,
   ResourceAccessKind,
   ServerAccess,
+  supportsKubernetesCustomResources,
   WindowsDesktopAccess,
 } from './standardmodel';
 import { ActionType } from './useStandardModel';
@@ -65,10 +68,10 @@ import {
   DatabaseAccessValidationResult,
   GitHubOrganizationAccessValidationResult,
   KubernetesAccessValidationResult,
-  kubernetesClusterWideResourceKinds,
   KubernetesResourceValidationResult,
   ResourceAccessValidationResult,
   ServerAccessValidationResult,
+  v7kubernetesClusterWideResourceKinds,
   WindowsDesktopAccessValidationResult,
 } from './validation';
 
@@ -379,6 +382,58 @@ export function KubernetesAccessSection({
   );
 }
 
+function KubernetesResourceKindView({
+  value,
+  validation,
+  isProcessing,
+  onChange,
+  roleVersion,
+}: {
+  value: KubernetesResourceModel;
+  validation: KubernetesResourceValidationResult['kind'];
+  isProcessing: boolean;
+  onChange?(m: KubernetesResourceModel): void;
+  roleVersion: RoleVersion;
+}) {
+  if (!supportsKubernetesCustomResources(roleVersion)) {
+    return (
+      <FieldSelect
+        label="Kind"
+        isDisabled={isProcessing}
+        options={kubernetesResourceKindOptionsV7.filter(
+          elem => roleVersion == 'v7' || elem.value == 'pod' // In v7, we have the fill list, in v6 and earlier, only pod.
+        )}
+        value={value.kind}
+        rule={precomputed(validation)}
+        onChange={k => onChange?.({ ...value, kind: k })}
+      />
+    );
+  }
+  return (
+    <FieldSelectCreatable
+      isSearchable
+      label="Kind (plural)"
+      toolTipContent={
+        <>
+          Resource plural name, e.g. pods, deployments, mycustomresources.
+          Special value <MarkInverse>*</MarkInverse> means any kind.
+        </>
+      }
+      isDisabled={isProcessing}
+      formatCreateLabel={label => `Kind: ${label}`}
+      openMenuOnClick
+      value={value.kind}
+      onChange={kind => onChange?.({ ...value, kind })}
+      menuPosition="fixed"
+      rule={precomputed(validation)}
+      options={kubernetesResourceKindOptionsV8}
+      components={{
+        DropdownIndicator: null,
+      }}
+    />
+  );
+}
+
 function KubernetesResourceView({
   value,
   validation,
@@ -392,8 +447,9 @@ function KubernetesResourceView({
   onChange(m: KubernetesResourceModel): void;
   onRemove(): void;
 }) {
-  const { kind, name, namespace, verbs } = value;
+  const { kind, name, namespace, verbs, apiGroup } = value;
   const theme = useTheme();
+  const supportsCrds = supportsKubernetesCustomResources(value.roleVersion);
   return (
     <Box
       border={1}
@@ -416,15 +472,29 @@ function KubernetesResourceView({
           />
         </ButtonIcon>
       </Flex>
-      <FieldSelect
-        label="Kind"
-        isDisabled={isProcessing}
-        options={kubernetesResourceKindOptions}
-        value={kind}
-        rule={precomputed(validation.kind)}
-        onChange={k => onChange?.({ ...value, kind: k })}
-        menuPosition="fixed"
+      <KubernetesResourceKindView
+        value={value}
+        validation={validation.kind}
+        isProcessing={isProcessing}
+        onChange={k => onChange?.({ ...value, ...k })}
+        roleVersion={value.roleVersion}
       />
+      {(supportsCrds || apiGroup) && (
+        <FieldInput
+          label="API Group"
+          required
+          toolTipContent={
+            <>
+              Resource API Group. Special value <MarkInverse>*</MarkInverse>{' '}
+              means any group.
+            </>
+          }
+          disabled={isProcessing}
+          value={apiGroup}
+          rule={precomputed(validation.apiGroup)}
+          onChange={e => onChange?.({ ...value, apiGroup: e.target.value })}
+        />
+      )}
       <FieldInput
         label="Name"
         required
@@ -441,7 +511,7 @@ function KubernetesResourceView({
       />
       <FieldInput
         label="Namespace"
-        required={!kubernetesClusterWideResourceKinds.includes(kind.value)}
+        required={!v7kubernetesClusterWideResourceKinds.includes(kind.value)}
         toolTipContent={
           <>
             Namespace that contains the resource. Special value{' '}

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.test.tsx
@@ -239,7 +239,9 @@ test('triggers v6 validation for Kubernetes resources', async () => {
       onSave={onSave}
     />
   );
-  await selectEvent.select(screen.getByLabelText('Version'), 'v6');
+
+  // Select v7 so we can set a different value.
+  await selectEvent.select(screen.getByLabelText('Version'), 'v7');
   await user.click(getTabByName('Resources'));
   await user.click(
     screen.getByRole('button', { name: 'Add Teleport Resource Access' })
@@ -249,6 +251,11 @@ test('triggers v6 validation for Kubernetes resources', async () => {
     screen.getByRole('button', { name: 'Add a Kubernetes Resource' })
   );
   await selectEvent.select(screen.getByLabelText('Kind'), 'Job');
+
+  // Back to v6 to check validation.
+  await user.click(getTabByName('Overview'));
+  await selectEvent.select(screen.getByLabelText('Version'), 'v6');
+  await user.click(getTabByName('Resources'));
 
   // Adding a second resource to make sure that we don't run into attempting to
   // modify an immer-frozen object. This might happen if the reducer tried to
@@ -268,6 +275,123 @@ test('triggers v6 validation for Kubernetes resources', async () => {
   // Back to v7, try again
   await user.click(getTabByName('Overview'));
   await selectEvent.select(screen.getByLabelText('Version'), 'v7');
+  await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+  expect(onSave).toHaveBeenCalled();
+}, 10000);
+
+test('triggers v7 validation for Kubernetes resources', async () => {
+  const onSave = jest.fn();
+  render(
+    <TestStandardEditor
+      originalRole={newRoleWithYaml(newRole())}
+      onSave={onSave}
+    />
+  );
+
+  // Select v8 so we can set a different value.
+  await selectEvent.select(screen.getByLabelText('Version'), 'v8');
+  await user.click(getTabByName('Resources'));
+  await user.click(
+    screen.getByRole('button', { name: 'Add Teleport Resource Access' })
+  );
+  await user.click(screen.getByRole('menuitem', { name: 'Kubernetes Access' }));
+  await user.click(
+    screen.getByRole('button', { name: 'Add a Kubernetes Resource' })
+  );
+  await selectEvent.select(screen.getByLabelText('Kind (plural)'), 'jobs');
+
+  // Go to v7 to check validation.
+  await user.click(getTabByName('Overview'));
+  await selectEvent.select(screen.getByLabelText('Version'), 'v7');
+  await user.click(getTabByName('Resources'));
+
+  // Adding a second resource to make sure that we don't run into attempting to
+  // modify an immer-frozen object. This might happen if the reducer tried to
+  // modify resources that were already there.
+  await user.click(
+    screen.getByRole('button', { name: 'Add Another Kubernetes Resource' })
+  );
+
+  await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+  // Validation should have failed on a jobs resource and role v7.
+  expect(
+    screen.getByText(
+      'Only core predefined kinds are allowed for role version v7'
+    )
+  ).toBeVisible();
+  // Validation should have failed on a api groups being set and role v7.
+  expect(
+    screen.getByText('API Group not supported for role version v7.')
+  ).toBeVisible();
+  expect(onSave).not.toHaveBeenCalled();
+
+  // Back to v8, try again
+  await user.click(getTabByName('Overview'));
+  await selectEvent.select(screen.getByLabelText('Version'), 'v8');
+
+  await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+  expect(onSave).not.toHaveBeenCalled();
+}, 10000);
+
+test('triggers v8 validation for Kubernetes resources', async () => {
+  const onSave = jest.fn();
+  render(
+    <TestStandardEditor
+      originalRole={newRoleWithYaml(newRole())}
+      onSave={onSave}
+    />
+  );
+
+  // Select v7 so we can set a known value.
+  await selectEvent.select(screen.getByLabelText('Version'), 'v7');
+  await user.click(getTabByName('Resources'));
+  await user.click(
+    screen.getByRole('button', { name: 'Add Teleport Resource Access' })
+  );
+  await user.click(screen.getByRole('menuitem', { name: 'Kubernetes Access' }));
+  await user.click(
+    screen.getByRole('button', { name: 'Add a Kubernetes Resource' })
+  );
+  await selectEvent.select(screen.getByLabelText('Kind'), 'Job');
+
+  // Go to v8 to check validation.
+  await user.click(getTabByName('Overview'));
+  await selectEvent.select(screen.getByLabelText('Version'), 'v8');
+  await user.click(getTabByName('Resources'));
+
+  // Adding a second resource to make sure that we don't run into attempting to
+  // modify an immer-frozen object. This might happen if the reducer tried to
+  // modify resources that were already there.
+  await user.click(
+    screen.getByRole('button', { name: 'Add Another Kubernetes Resource' })
+  );
+
+  // Set the api group for the first resource.
+  await user.type(screen.getAllByLabelText('API Group *')[0], '*');
+  // Clear the api group for the second resource.
+  await user.clear(screen.getAllByLabelText('API Group *')[1]);
+
+  await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+  // Validation should have failed on a v7 kind and role v8.
+  expect(
+    screen.getByText('Kind must use k8s plural name. Did you mean "jobs"?')
+  ).toBeVisible();
+
+  // Validation should have failed on a api group being missing and role v8.
+  expect(
+    screen.getByText('API Group required. Use "*" for any group.')
+  ).toBeVisible();
+  expect(onSave).not.toHaveBeenCalled();
+
+  // Fix the validation errors and try again.
+  await selectEvent.select(
+    screen.getAllByLabelText('Kind (plural)')[0],
+    'jobs'
+  );
+  await user.type(screen.getAllByLabelText('API Group *')[1], '*');
+
   await user.click(screen.getByRole('button', { name: 'Save Changes' }));
   expect(onSave).toHaveBeenCalled();
 }, 10000);

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.test.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.test.ts
@@ -47,7 +47,7 @@ import {
   defaultRoleVersion,
   gitHubOrganizationsToModel,
   KubernetesAccess,
-  kubernetesResourceKindOptionsMap,
+  kubernetesResourceKindOptionsMapV7,
   kubernetesVerbOptionsMap,
   labelsModelToLabels,
   labelsToModel,
@@ -63,15 +63,17 @@ import {
 } from './standardmodel';
 import { withDefaults } from './withDefaults';
 
-const minimalRole = (roleVersion?: RoleVersion) =>
+const minimalRole = (roleVersion = defaultRoleVersion) =>
   withDefaults({ metadata: { name: 'foobar' } }, roleVersion);
 
-const minimalRoleModel = (roleVersion?: RoleVersion): RoleEditorModel => ({
+const minimalRoleModel = (
+  roleVersion = defaultRoleVersion
+): RoleEditorModel => ({
   metadata: {
     name: 'foobar',
     nameCollision: false,
     labels: [],
-    version: roleVersionOptionsMap.get(roleVersion || defaultRoleVersion),
+    version: roleVersionOptionsMap.get(roleVersion),
   },
   resources: [],
   rules: [],
@@ -645,8 +647,7 @@ describe('roleToRoleEditorModel', () => {
           ...minRole.spec.allow,
           allowUnknown: 123,
           kubernetes_resources: [
-            { kind: 'job', resUnknown: 123 } as KubernetesResource,
-            { kind: 'illegal' } as unknown as KubernetesResource,
+            { kind: 'jobs', resUnknown: 123 } as KubernetesResource,
             {
               kind: '*',
               verbs: ['illegal', 'get'],
@@ -708,8 +709,7 @@ describe('roleToRoleEditorModel', () => {
         {
           type: ConversionErrorType.UnsupportedValue,
           errors: simpleConversionErrors(ConversionErrorType.UnsupportedValue, [
-            'spec.allow.kubernetes_resources[1]',
-            'spec.allow.kubernetes_resources[2].verbs[0]',
+            'spec.allow.kubernetes_resources[1].verbs[0]',
             'spec.allow.rules[1].verbs[1]',
             'spec.allow.rules[2].verbs[1]',
             'spec.options.ssh_port_forwarding',
@@ -761,7 +761,7 @@ describe('roleToRoleEditorModel', () => {
           ...newKubeClusterResourceAccess(),
           resources: [
             expect.objectContaining({
-              kind: kubernetesResourceKindOptionsMap.get('job'),
+              kind: { value: 'jobs', label: 'jobs' },
             }),
             expect.objectContaining({
               verbs: [kubernetesVerbOptionsMap.get('get')],
@@ -839,6 +839,120 @@ describe('roleToRoleEditorModel', () => {
     } as RoleEditorModel);
   });
 
+  test('support custom resource', () => {
+    expect(
+      roleToRoleEditorModel({
+        ...minRole,
+        spec: {
+          ...minRole.spec,
+          allow: {
+            ...minRole.spec.allow,
+            kubernetes_resources: [
+              { kind: 'unknown', api_group: 'group.example.com' },
+              { kind: 'jobs', api_group: '*' },
+            ],
+          },
+        },
+      })
+    ).toEqual({
+      ...minRoleModel,
+      resources: [
+        {
+          ...newKubeClusterResourceAccess(),
+          resources: [
+            expect.objectContaining({
+              kind: { value: 'unknown', label: 'unknown' },
+              apiGroup: 'group.example.com',
+            }),
+            expect.objectContaining({
+              kind: { value: 'jobs', label: 'jobs' },
+              apiGroup: '*',
+            }),
+          ],
+        },
+      ],
+    });
+  });
+
+  test('not support custom resource', () => {
+    expect(
+      roleToRoleEditorModel({
+        ...minimalRole(RoleVersion.V7),
+        spec: {
+          ...minimalRole(RoleVersion.V7).spec,
+          allow: {
+            ...minimalRole(RoleVersion.V7).spec.allow,
+            kubernetes_resources: [
+              { kind: 'unknown', api_group: 'group.example.com' },
+              { kind: 'jobs', api_group: '*' },
+            ],
+          },
+          options: {
+            ...minimalRole(RoleVersion.V7).spec.options,
+            idp: { saml: { enabled: true } },
+          },
+        },
+      })
+    ).toEqual({
+      ...minimalRoleModel(RoleVersion.V7),
+      requiresReset: true,
+      resources: [],
+      conversionErrors: [
+        {
+          type: ConversionErrorType.UnsupportedValue,
+          errors: [
+            {
+              type: ConversionErrorType.UnsupportedValue,
+              path: 'spec.allow.kubernetes_resources[0].kind',
+            },
+            {
+              type: ConversionErrorType.UnsupportedValue,
+              path: 'spec.allow.kubernetes_resources[1].kind',
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  test('v8 not support v7 kind', () => {
+    expect(
+      roleToRoleEditorModel({
+        ...minimalRole(RoleVersion.V8),
+        spec: {
+          ...minRole.spec,
+          allow: {
+            ...minRole.spec.allow,
+            kubernetes_resources: [{ kind: 'job', api_group: '*' }],
+          },
+        },
+      })
+    ).toEqual({
+      ...minimalRoleModel(RoleVersion.V8),
+      requiresReset: true,
+      resources: [
+        {
+          ...newKubeClusterResourceAccess(),
+          resources: [
+            expect.objectContaining({ kind: { value: 'jobs', label: 'jobs' } }),
+          ],
+        },
+      ],
+      conversionErrors: [
+        {
+          type: ConversionErrorType.UnsupportedValueWithReplacement,
+          errors: [
+            {
+              type: ConversionErrorType.UnsupportedValueWithReplacement,
+              path: 'spec.allow.kubernetes_resources[0].kind',
+              replacement: '"jobs"',
+            },
+          ],
+        },
+      ],
+    });
+  });
+
   it('revision change requires reset', () => {
     const rev = '5d7e724b-a52c-4c12-9372-60a8d1af5d33';
     const originalRev = '9c2d5732-c514-46c3-b18d-2009b65af7b8';
@@ -889,14 +1003,14 @@ describe('roleToRoleEditorModel', () => {
             kubernetes_labels: { bar: 'foo' },
             kubernetes_resources: [
               {
-                kind: 'pod',
+                kind: 'pods',
                 name: 'some-pod',
                 namespace: '*',
                 verbs: ['get', 'update'],
               },
               {
                 // No namespace required for cluster-wide resources.
-                kind: 'kube_node',
+                kind: 'nodes',
                 name: 'some-node',
               },
             ],
@@ -917,7 +1031,7 @@ describe('roleToRoleEditorModel', () => {
           resources: [
             {
               id: expect.any(String),
-              kind: kubernetesResourceKindOptionsMap.get('pod'),
+              kind: { value: 'pods', label: 'pods' },
               name: 'some-pod',
               namespace: '*',
               verbs: [
@@ -928,7 +1042,7 @@ describe('roleToRoleEditorModel', () => {
             },
             {
               id: expect.any(String),
-              kind: kubernetesResourceKindOptionsMap.get('kube_node'),
+              kind: { value: 'nodes', label: 'nodes' },
               name: 'some-node',
               namespace: '',
               verbs: [],
@@ -1136,7 +1250,7 @@ describe('roleEditorModelToRole', () => {
             resources: [
               {
                 id: 'dummy-id-1',
-                kind: kubernetesResourceKindOptionsMap.get('pod'),
+                kind: kubernetesResourceKindOptionsMapV7.get('pod'),
                 name: 'some-pod',
                 namespace: '*',
                 verbs: [
@@ -1147,7 +1261,7 @@ describe('roleEditorModelToRole', () => {
               },
               {
                 id: 'dummy-id-2',
-                kind: kubernetesResourceKindOptionsMap.get('kube_node'),
+                kind: kubernetesResourceKindOptionsMapV7.get('kube_node'),
                 name: 'some-node',
                 namespace: '',
                 verbs: [],

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.ts
@@ -31,7 +31,6 @@ import {
   CreateHostUserMode,
   GitHubPermission,
   isLegacySamlIdpRbac,
-  KubernetesResourceKind,
   KubernetesVerb,
   RequireMFAType,
   ResourceKind,
@@ -185,7 +184,7 @@ export type KubernetesResourceModel = {
   name: string;
   namespace: string;
   verbs: readonly KubernetesVerbOption[];
-
+  apiGroup?: string;
   /**
    * Version of the role that owns this section. Required in order to support
    * version-specific validation rules. It's the responsibility of
@@ -195,13 +194,16 @@ export type KubernetesResourceModel = {
   roleVersion: RoleVersion;
 };
 
-type KubernetesResourceKindOption = Option<KubernetesResourceKind, string>;
+type KubernetesResourceKindOption = Option<string, string>;
 
 /**
  * All possible resource kind drop-down options. This array needs to be kept in
  * sync with `KubernetesResourcesKinds` in `api/types/constants.go.
+ *
+ * This type list needs to be kept in sync with
+ * `KubernetesResourcesKinds` in `api/types/constants.go for roles <=v7.
  */
-export const kubernetesResourceKindOptions: KubernetesResourceKindOption[] = [
+export const kubernetesResourceKindOptionsV7: KubernetesResourceKindOption[] = [
   // The "any kind" option goes first.
   { value: '*', label: 'Any kind' },
 
@@ -236,11 +238,92 @@ export const kubernetesResourceKindOptions: KubernetesResourceKindOption[] = [
   ).toSorted((a, b) => a.label.localeCompare(b.label)),
 ];
 
+// Map of kinds/groups to detect v7->v8 upgrade issues.
+//
+// Record<v7kind, { group: ['main group', 'optional additional groups'], v8name: 'v8 plural name' }>
+export const kubernetesResourceKindV7Groups: Record<
+  string,
+  { groups: string[]; v8name: string }
+> = {
+  pod: { groups: ['core'], v8name: 'pods' },
+  secret: { groups: ['core'], v8name: 'secrets' },
+  configmap: { groups: ['core'], v8name: 'configmaps' },
+  namespace: { groups: ['core'], v8name: 'namespaces' },
+  service: { groups: ['core'], v8name: 'services' },
+  serviceaccount: { groups: ['core'], v8name: 'serviceaccounts' },
+  kube_node: { groups: ['core'], v8name: 'nodes' },
+  persistentvolume: { groups: ['core'], v8name: 'persistentvolumes' },
+  persistentvolumeclaim: { groups: ['core'], v8name: 'persistentvolumeclaims' },
+  deployment: { groups: ['apps', 'extensions'], v8name: 'deployments' },
+  replicaset: { groups: ['apps', 'extensions'], v8name: 'replicasets' },
+  statefulset: { groups: ['apps'], v8name: 'statefulsets' },
+  daemonset: { groups: ['apps', 'extensions'], v8name: 'daemonsets' },
+  clusterrole: {
+    groups: ['rbac.authorization.k8s.io'],
+    v8name: 'clusterroles',
+  },
+  kube_role: { groups: ['rbac.authorization.k8s.io'], v8name: 'roles' },
+  clusterrolebinding: {
+    groups: ['rbac.authorization.k8s.io'],
+    v8name: 'clusterrolebindings',
+  },
+  rolebinding: {
+    groups: ['rbac.authorization.k8s.io'],
+    v8name: 'rolebindings',
+  },
+  cronjob: { groups: ['batch'], v8name: 'cronjobs' },
+  job: { groups: ['batch'], v8name: 'jobs' },
+  certificatesigningrequest: {
+    groups: ['certificates.k8s.io'],
+    v8name: 'certificatesigningrequests',
+  },
+  ingress: { groups: ['networking.k8s.io', 'extensions'], v8name: 'ingresses' },
+} as const;
+
+/**
+ * Some of the possible values for the Kubernetes resource kind drop-down.
+ * Arbitrary list, only preset for the sake of the UI.
+ */
+export const kubernetesResourceKindOptionsV8: KubernetesResourceKindOption[] = [
+  // The "any kind" option goes first.
+  { value: '*', label: 'Any kind' },
+
+  // The rest is sorted by label.
+  ...(
+    [
+      { value: 'pods', label: 'pods' },
+      { value: 'secrets', label: 'secrets' },
+      { value: 'configmaps', label: 'configmaps' },
+      { value: 'namespaces', label: 'namespaces' },
+      { value: 'services', label: 'services' },
+      { value: 'serviceaccounts', label: 'serviceaccounts' },
+      { value: 'nodes', label: 'nodes' },
+      { value: 'persistentvolumes', label: 'persistentvolumes' },
+      { value: 'persistentvolumeclaims', label: 'persistentvolumeclaims' },
+      { value: 'deployments', label: 'deployments' },
+      { value: 'replicasets', label: 'replicasets' },
+      { value: 'statefulsets', label: 'statefulsets' },
+      { value: 'daemonsets', label: 'daemonsets' },
+      { value: 'clusterroles', label: 'clusterroles' },
+      { value: 'roles', label: 'roles' },
+      { value: 'clusterrolebindings', label: 'clusterrolebindings' },
+      { value: 'rolebindings', label: 'rolebindings' },
+      { value: 'cronjobs', label: 'cronjobs' },
+      { value: 'jobs', label: 'jobs' },
+      {
+        value: 'certificatesigningrequests',
+        label: 'certificatesigningrequests',
+      },
+      { value: 'ingresses', label: 'ingresses' },
+    ] as const
+  ).toSorted((a, b) => a.label.localeCompare(b.label)),
+];
+
 const optionsToMap = <K, V>(opts: Option<K, V>[]) =>
   new Map(opts.map(o => [o.value, o]));
 
-export const kubernetesResourceKindOptionsMap = optionsToMap(
-  kubernetesResourceKindOptions
+export const kubernetesResourceKindOptionsMapV7 = optionsToMap(
+  kubernetesResourceKindOptionsV7
 );
 
 export type KubernetesVerbOption = Option<KubernetesVerb, string>;
@@ -579,15 +662,26 @@ export function newResourceAccess(
   }
 }
 
+export function supportsKubernetesCustomResources(roleVersion: RoleVersion) {
+  return ![
+    RoleVersion.V3,
+    RoleVersion.V4,
+    RoleVersion.V5,
+    RoleVersion.V6,
+    RoleVersion.V7,
+  ].includes(roleVersion);
+}
+
 export function newKubernetesResourceModel(
   roleVersion: RoleVersion
 ): KubernetesResourceModel {
   return {
     id: crypto.randomUUID(),
-    kind: kubernetesResourceKindOptions.find(k => k.value === '*'),
+    kind: kubernetesResourceKindOptionsV7.find(k => k.value === '*'),
     name: '*',
     namespace: '*',
     verbs: [],
+    apiGroup: supportsKubernetesCustomResources(roleVersion) ? '*' : '',
     roleVersion,
   };
 }
@@ -915,17 +1009,40 @@ function kubernetesResourceToModel(
   model?: KubernetesResourceModel;
   conversionErrors: ConversionError[];
 } {
-  const { kind, name, namespace = '', verbs = [], ...unsupported } = res;
+  const {
+    kind,
+    name,
+    namespace = '',
+    verbs = [],
+    api_group: apiGroup,
+    ...unsupported
+  } = res;
   const conversionErrors = unsupportedFieldErrorsFromObject(
     pathPrefix,
     unsupported
   );
 
-  const kindOption = kubernetesResourceKindOptionsMap.get(kind);
-  if (kindOption === undefined) {
+  const supportsCrds = supportsKubernetesCustomResources(roleVersion);
+  const kindOption = supportsCrds
+    ? { value: kind, label: kind }
+    : kubernetesResourceKindOptionsMapV7.get(kind);
+
+  if (supportsCrds) {
+    // If we have an exact match with a v7 entry, it is most likely a mistake.
+    const v7groups = kubernetesResourceKindV7Groups[kind];
+    if (v7groups && (apiGroup == '*' || v7groups.groups.includes(apiGroup))) {
+      kindOption.value = v7groups.v8name;
+      kindOption.label = v7groups.v8name;
+      conversionErrors.push(
+        unsupportedValueWithReplacement(`${pathPrefix}.kind`, v7groups.v8name)
+      );
+    }
+  }
+
+  if (!kindOption) {
     conversionErrors.push({
       type: ConversionErrorType.UnsupportedValue,
-      path: pathPrefix,
+      path: `${pathPrefix}.kind`,
     });
   }
 
@@ -952,6 +1069,7 @@ function kubernetesResourceToModel(
             namespace,
             verbs: knownVerbOptions,
             roleVersion,
+            apiGroup,
           }
         : undefined,
     conversionErrors,
@@ -1392,11 +1510,12 @@ export function roleEditorModelToRole(roleModel: RoleEditorModel): Role {
         role.spec.allow.kubernetes_groups = optionsToStrings(res.groups);
         role.spec.allow.kubernetes_labels = labelsModelToLabels(res.labels);
         role.spec.allow.kubernetes_resources = res.resources.map(
-          ({ kind, name, namespace, verbs }) => ({
+          ({ kind, name, namespace, verbs, apiGroup }) => ({
             kind: kind.value,
             name,
             namespace,
             verbs: optionsToStrings(verbs),
+            api_group: apiGroup,
           })
         );
         role.spec.allow.kubernetes_users = optionsToStrings(res.users);

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/validation.test.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/validation.test.ts
@@ -20,7 +20,7 @@ import { ResourceKind, RoleVersion } from 'teleport/services/resources';
 
 import {
   defaultRoleVersion,
-  kubernetesResourceKindOptionsMap,
+  kubernetesResourceKindOptionsMapV7,
   kubernetesVerbOptionsMap,
   newKubernetesResourceModel,
   ResourceAccess,
@@ -35,11 +35,11 @@ import {
 } from './validation';
 import { withDefaults } from './withDefaults';
 
-const minimalRoleModel = () =>
+const minimalRoleModel = (version = defaultRoleVersion) =>
   roleToRoleEditorModel(
     withDefaults({
       metadata: { name: 'role-name' },
-      version: defaultRoleVersion,
+      version: version,
     })
   );
 
@@ -70,10 +70,11 @@ describe('validateRoleEditorModel', () => {
         resources: [
           {
             id: 'dummy-id',
-            kind: { label: 'pod', value: 'pod' },
+            kind: { label: 'pods', value: 'pods' },
             name: 'res-name',
             namespace: 'dummy-namespace',
             verbs: [],
+            apiGroup: '*',
             roleVersion: defaultRoleVersion,
           },
         ],
@@ -250,6 +251,133 @@ describe('validateRoleEditorModel', () => {
     expect(validity(result.resources)).toEqual([false]);
   });
 
+  test('forbids v7 kind in v8', () => {
+    const model = minimalRoleModel(RoleVersion.V8);
+    model.resources = [
+      {
+        kind: 'kube_cluster',
+        groups: [],
+        labels: [],
+        users: [],
+        resources: [
+          {
+            ...newKubernetesResourceModel(RoleVersion.V8),
+            kind: kubernetesResourceKindOptionsMapV7.get('job'),
+          },
+        ],
+        roleVersion: RoleVersion.V8,
+        hideValidationErrors: false,
+      },
+    ];
+    const result = validateRoleEditorModel(model, undefined, undefined);
+    expect(validity(result.resources)).toEqual([false]);
+  });
+
+  test('forbids v8 kind in v7', () => {
+    const model = minimalRoleModel(RoleVersion.V7);
+    model.resources = [
+      {
+        kind: 'kube_cluster',
+        groups: [],
+        labels: [],
+        users: [],
+        resources: [
+          {
+            ...newKubernetesResourceModel(RoleVersion.V7),
+            kind: { value: 'pods', label: 'pods' },
+          },
+        ],
+        roleVersion: RoleVersion.V7,
+        hideValidationErrors: false,
+      },
+    ];
+    const result = validateRoleEditorModel(model, undefined, undefined);
+    expect(validity(result.resources)).toEqual([false]);
+  });
+
+  test('force api group in v8', () => {
+    const model = minimalRoleModel(RoleVersion.V8);
+    model.resources = [
+      {
+        kind: 'kube_cluster',
+        groups: [],
+        labels: [],
+        users: [],
+        resources: [
+          {
+            ...newKubernetesResourceModel(RoleVersion.V8),
+            kind: { value: 'pods', label: 'pods' },
+            apiGroup: '',
+          },
+        ],
+        roleVersion: RoleVersion.V8,
+        hideValidationErrors: false,
+      },
+    ];
+
+    const result = validateRoleEditorModel(model, undefined, undefined);
+    expect(validity(result.resources)).toEqual([false]);
+  });
+
+  test('forbids api group in v7', () => {
+    const model = minimalRoleModel(RoleVersion.V7);
+    model.resources = [
+      {
+        kind: 'kube_cluster',
+        groups: [],
+        labels: [],
+        users: [],
+        resources: [
+          {
+            ...newKubernetesResourceModel(RoleVersion.V7),
+            kind: kubernetesResourceKindOptionsMapV7.get('pod'),
+            apiGroup: 'core',
+          },
+        ],
+        roleVersion: RoleVersion.V7,
+        hideValidationErrors: false,
+      },
+    ];
+    const result = validateRoleEditorModel(model, undefined, undefined);
+    expect(validity(result.resources)).toEqual([false]);
+  });
+
+  test('correct v8 kinds', () => {
+    const model = minimalRoleModel(RoleVersion.V8);
+    model.resources = [
+      {
+        kind: 'kube_cluster',
+        groups: [],
+        labels: [],
+        users: [],
+        resources: [
+          {
+            ...newKubernetesResourceModel(RoleVersion.V8),
+            kind: { value: 'pods', label: 'pods' },
+          },
+        ],
+        roleVersion: RoleVersion.V8,
+        hideValidationErrors: false,
+      },
+      {
+        kind: 'kube_cluster',
+        groups: [],
+        labels: [],
+        users: [],
+        resources: [
+          {
+            ...newKubernetesResourceModel(RoleVersion.V8),
+            kind: { value: 'mycustomresources', label: 'stable.example.com' },
+          },
+        ],
+        roleVersion: RoleVersion.V8,
+        hideValidationErrors: false,
+      },
+    ];
+    const result = validateRoleEditorModel(model, undefined, undefined);
+    expect(validity(result.resources)).toEqual([true, true]);
+  });
+
   test.each`
     roleVersion | results
     ${'v3'}     | ${[false, true, false]}
@@ -257,6 +385,7 @@ describe('validateRoleEditorModel', () => {
     ${'v5'}     | ${[false, true, false]}
     ${'v6'}     | ${[false, true, false]}
     ${'v7'}     | ${[true, true, true]}
+    ${'v8'}     | ${[false, false, false]}
   `(
     'correct types of resources allowed for $roleVersion',
     ({ roleVersion, results }) => {
@@ -270,18 +399,18 @@ describe('validateRoleEditorModel', () => {
           roleVersion,
           resources: [
             {
-              ...newKubernetesResourceModel(defaultRoleVersion),
-              kind: kubernetesResourceKindOptionsMap.get('job'),
+              ...newKubernetesResourceModel(roleVersion),
+              kind: kubernetesResourceKindOptionsMapV7.get('job'),
               roleVersion,
             },
             {
-              ...newKubernetesResourceModel(defaultRoleVersion),
-              kind: kubernetesResourceKindOptionsMap.get('pod'),
+              ...newKubernetesResourceModel(roleVersion),
+              kind: kubernetesResourceKindOptionsMapV7.get('pod'),
               roleVersion,
             },
             {
-              ...newKubernetesResourceModel(defaultRoleVersion),
-              kind: kubernetesResourceKindOptionsMap.get('service'),
+              ...newKubernetesResourceModel(roleVersion),
+              kind: kubernetesResourceKindOptionsMapV7.get('service'),
               roleVersion,
             },
           ],

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/validation.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/validation.ts
@@ -26,28 +26,28 @@ import {
 } from 'shared/components/Validation/rules';
 
 import { nonEmptyLabels } from 'teleport/components/LabelsInput/LabelsInput';
-import {
-  KubernetesResourceKind,
-  RoleVersion,
-} from 'teleport/services/resources';
+import { RoleVersion } from 'teleport/services/resources';
 
 import {
   AppAccess,
   DatabaseAccess,
   KubernetesAccess,
+  kubernetesResourceKindV7Groups,
   KubernetesResourceModel,
   KubernetesVerbOption,
   MetadataModel,
   ResourceAccess,
   ResourceKindOption,
+  resourceKindOptions,
   RoleEditorModel,
   RuleModel,
   ServerAccess,
+  supportsKubernetesCustomResources,
   VerbModel,
   WindowsDesktopAccess,
 } from './standardmodel';
 
-export const kubernetesClusterWideResourceKinds: KubernetesResourceKind[] = [
+export const v7kubernetesClusterWideResourceKinds: string[] = [
   'namespace',
   'kube_node',
   'persistentvolume',
@@ -191,29 +191,107 @@ export type ResourceAccessValidationResult =
   | GitHubOrganizationAccessValidationResult;
 
 const validKubernetesResource = (res: KubernetesResourceModel) => () => {
-  const kind = validKubernetesKind(res.kind.value, res.roleVersion);
+  const kind = validKubernetesKind(
+    res.kind.value,
+    res.apiGroup,
+    res.roleVersion
+  );
   const name = requiredField(
     'Resource name is required, use "*" for any resource'
   )(res.name)();
-  const namespace = kubernetesClusterWideResourceKinds.includes(res.kind.value)
-    ? { valid: true }
-    : requiredField('Namespace is required for resources of this kind')(
-        res.namespace
-      )();
+  const namespace = validKubernetesNamespace(res);
   const verbs = validKubernetesVerbs(res.verbs);
+  const apiGroup = validKubernetesGroup(res.apiGroup, res.roleVersion);
+
   return {
-    valid: kind.valid && name.valid && namespace.valid && verbs.valid,
+    valid:
+      kind.valid &&
+      name.valid &&
+      namespace.valid &&
+      verbs.valid &&
+      apiGroup.valid,
     kind,
     name,
     namespace,
     verbs,
+    apiGroup,
   };
 };
+
 export type KubernetesResourceValidationResult = {
   kind: ValidationResult;
   name: ValidationResult;
   namespace: ValidationResult;
   verbs: ValidationResult;
+  apiGroup: ValidationResult;
+};
+
+// Best-effort validation for namespace requirement.
+// Generated from `kubectl api-resources --namespaced=true -o name --sort-by=name`
+const v8kubernetesNamespacedResourceKinds = [
+  'bindings',
+  'configmaps',
+  'controllerrevisions.apps',
+  'cronjobs.batch',
+  'csistoragecapacities.storage.k8s.io',
+  'daemonsets.apps',
+  'deployments.apps',
+  'endpoints',
+  'endpointslices.discovery.k8s.io',
+  'events.events.k8s.io',
+  'events',
+  'horizontalpodautoscalers.autoscaling',
+  'ingresses.networking.k8s.io',
+  'jobs.batch',
+  'leases.coordination.k8s.io',
+  'limitranges',
+  'localsubjectaccessreviews.authorization.k8s.io',
+  'networkpolicies.networking.k8s.io',
+  'persistentvolumeclaims',
+  'poddisruptionbudgets.policy',
+  'pods',
+  'podtemplates',
+  'replicasets.apps',
+  'replicationcontrollers',
+  'resourcequotas',
+  'rolebindings.rbac.authorization.k8s.io',
+  'roles.rbac.authorization.k8s.io',
+  'secrets',
+  'serviceaccounts',
+  'services',
+  'statefulsets.apps',
+];
+
+const validKubernetesNamespace = (
+  res: KubernetesResourceModel
+): ValidationResult => {
+  const supportsCrds = supportsKubernetesCustomResources(res.roleVersion);
+
+  // If we don't support CRDs we validate against the v7 cluster wide values.
+  if (!supportsCrds) {
+    return v7kubernetesClusterWideResourceKinds.includes(res.kind.value)
+      ? { valid: true }
+      : requiredField('Namespace is required for resources of this kind')(
+          res.namespace
+        )();
+  }
+
+  // Otherwise we validate against the v8 namespaced values.
+  const kindGroup = !res.apiGroup
+    ? res.kind.value
+    : `res.kind.value.${res.apiGroup}`;
+  if (
+    !res.namespace &&
+    v8kubernetesNamespacedResourceKinds.includes(kindGroup)
+  ) {
+    return requiredField('Namespace is required for resources of this kind')(
+      res.namespace
+    )();
+  }
+
+  // If we didn't have a match, it doesn't mean it is valid, but we can't known about
+  // it at this point.
+  return { valid: true };
 };
 
 /**
@@ -222,7 +300,8 @@ export type KubernetesResourceValidationResult = {
  * Kubernetes resources.
  */
 const validKubernetesKind = (
-  kind: KubernetesResourceKind,
+  kind: string,
+  apiGroup: string | undefined,
   ver: RoleVersion
 ): ValidationResult => {
   switch (ver) {
@@ -239,8 +318,65 @@ const validKubernetesKind = (
       };
 
     case RoleVersion.V7:
+      // NOTE: We need to validate in case the user switches between role versions.
+      // Valid values in rolev8 could be invalid in older versions.
+      const v7valid = resourceKindOptions.some(elem => elem.value === kind);
+
+      return {
+        valid: v7valid,
+        message: v7valid
+          ? undefined
+          : `Only core predefined kinds are allowed for role version ${ver}`,
+      };
+
     case RoleVersion.V8:
+      const v7groups = kubernetesResourceKindV7Groups[kind];
+      const v8valid =
+        !v7groups || (apiGroup !== '*' && !v7groups.groups.includes(apiGroup));
+      return {
+        valid: v8valid,
+        message: v8valid
+          ? undefined
+          : `Kind must use k8s plural name. Did you mean "${v7groups.v8name}"?`,
+      };
+
+    default:
+      ver satisfies never;
       return { valid: true };
+  }
+};
+
+/**
+ * Validates a `group` field of a `KubernetesResourceModel`. In roles with
+ * version prior to v8, the auth server only accepts empty string or "*".
+ */
+const validKubernetesGroup = (
+  group: string,
+  ver: RoleVersion
+): ValidationResult => {
+  switch (ver) {
+    case RoleVersion.V3:
+    case RoleVersion.V4:
+    case RoleVersion.V5:
+    case RoleVersion.V6:
+    case RoleVersion.V7:
+      const v7valid = !group;
+
+      return {
+        valid: v7valid,
+        message: v7valid
+          ? undefined
+          : `API Group not supported for role version ${ver}.`,
+      };
+
+    case RoleVersion.V8:
+      const v8valid = !!group;
+      return {
+        valid: v8valid,
+        message: v8valid
+          ? undefined
+          : `API Group required. Use "*" for any group.`,
+      };
 
     default:
       ver satisfies never;

--- a/web/packages/teleport/src/services/resources/types.ts
+++ b/web/packages/teleport/src/services/resources/types.ts
@@ -127,41 +127,12 @@ export type DefaultAuthConnector = {
 };
 
 export type KubernetesResource = {
-  kind?: KubernetesResourceKind;
+  kind?: string;
   name?: string;
   namespace?: string;
   verbs?: KubernetesVerb[];
+  api_group?: string;
 };
-
-/**
- * Supported Kubernetes resource kinds. This type needs to be kept in sync with
- * `KubernetesResourcesKinds` in `api/types/constants.go, as well as
- * `kubernetesResourceKindOptions` in
- * `web/packages/teleport/src/Roles/RoleEditor/standardmodel.ts`.
- */
-export type KubernetesResourceKind =
-  | '*'
-  | 'pod'
-  | 'secret'
-  | 'configmap'
-  | 'namespace'
-  | 'service'
-  | 'serviceaccount'
-  | 'kube_node'
-  | 'persistentvolume'
-  | 'persistentvolumeclaim'
-  | 'deployment'
-  | 'replicaset'
-  | 'statefulset'
-  | 'daemonset'
-  | 'clusterrole'
-  | 'kube_role'
-  | 'clusterrolebinding'
-  | 'rolebinding'
-  | 'cronjob'
-  | 'job'
-  | 'certificatesigningrequest'
-  | 'ingress';
 
 /**
  * Supported Kubernetes resource verbs. This type needs to be kept in sync with


### PR DESCRIPTION
Based on #54426.

Keeps the existing "Kind" dropdown with preset values and make it creatable as we can set any arbitrary string.
Add a "API Group" field.

changelog: Update web UI role editor for CRDs support in role v8


<img width="529" alt="image" src="https://github.com/user-attachments/assets/fc208f21-0596-4a0b-8e7b-6ec9426a544a" />

