### PR TITLE
Add a way to visit all handles in the inventory store

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1872,7 +1872,7 @@ func (a *Server) doReleaseAlertSync(ctx context.Context, current vc.Target, visi
 	// connected instances is a poor approximation and may lead to missed notifications if auth
 	// server is up to date, but instances not connected to this auth need update.
 	var instanceVisitor vc.Visitor
-	a.inventory.Iter(func(handle inventory.UpstreamHandle) {
+	a.inventory.UniqueHandles(func(handle inventory.UpstreamHandle) {
 		v := vc.Normalize(handle.Hello().Version)
 		instanceVisitor.Visit(vc.NewTarget(v))
 	})
@@ -1921,7 +1921,7 @@ func (a *Server) doReleaseAlertSync(ctx context.Context, current vc.Target, visi
 func (a *Server) updateAgentMetrics() {
 	imp := newInstanceMetricsPeriodic()
 
-	a.inventory.Iter(func(handle inventory.UpstreamHandle) {
+	a.inventory.UniqueHandles(func(handle inventory.UpstreamHandle) {
 		imp.VisitInstance(handle.Hello(), handle.AgentMetadata())
 	})
 
@@ -4931,7 +4931,7 @@ func (a *Server) MakeLocalInventoryControlStream(opts ...client.ICSPipeOption) c
 func (a *Server) GetInventoryStatus(ctx context.Context, req proto.InventoryStatusRequest) (proto.InventoryStatusSummary, error) {
 	var rsp proto.InventoryStatusSummary
 	if req.Connected {
-		a.inventory.Iter(func(handle inventory.UpstreamHandle) {
+		a.inventory.UniqueHandles(func(handle inventory.UpstreamHandle) {
 			rsp.Connected = append(rsp.Connected, handle.Hello())
 		})
 

--- a/lib/auth/server_monitor.go
+++ b/lib/auth/server_monitor.go
@@ -77,7 +77,7 @@ func (a *Server) MonitorSystemTime(ctx context.Context) error {
 func (a *Server) checkInventorySystemClocks(ctx context.Context) {
 	var counter int
 	var messages []string
-	a.inventory.Iter(func(handle inventory.UpstreamHandle) {
+	a.inventory.UniqueHandles(func(handle inventory.UpstreamHandle) {
 		hello := handle.Hello()
 		handle.VisitInstanceState(func(ref inventory.InstanceStateRef) (update inventory.InstanceStateUpdate) {
 			if ref.LastHeartbeat != nil && ref.LastHeartbeat.GetLastMeasurement() != nil {

--- a/lib/inventory/controller.go
+++ b/lib/inventory/controller.go
@@ -364,14 +364,14 @@ func (c *Controller) GetControlStream(serverID string) (handle UpstreamHandle, o
 // note: if multiple handles are registered for a given server, only
 // one handle is selected pseudorandomly to be observed.
 func (c *Controller) Iter(fn func(UpstreamHandle)) {
-	c.store.Iter(fn)
+	c.store.UniqueHandles(fn)
 }
 
 // IterWithDuplicates iterates across all handles registered with this
 // controller. If multiple handles are registered for a given server,
 // all of them will be observed.
 func (c *Controller) IterWithDuplicates(fn func(UpstreamHandle)) {
-	c.store.IterWithDuplicates(fn)
+	c.store.AllHandles(fn)
 }
 
 // ConnectedInstances gets the total number of connected instances. Note that this is the total number of

--- a/lib/inventory/controller.go
+++ b/lib/inventory/controller.go
@@ -367,6 +367,13 @@ func (c *Controller) Iter(fn func(UpstreamHandle)) {
 	c.store.Iter(fn)
 }
 
+// IterWithDuplicates iterates across all handles registered with this
+// controller. If multiple handles are registered for a given server,
+// all of them will be observed.
+func (c *Controller) IterWithDuplicates(fn func(UpstreamHandle)) {
+	c.store.IterWithDuplicates(fn)
+}
+
 // ConnectedInstances gets the total number of connected instances. Note that this is the total number of
 // *handles*, not the number of unique instances by id.
 func (c *Controller) ConnectedInstances() int {

--- a/lib/inventory/controller.go
+++ b/lib/inventory/controller.go
@@ -360,17 +360,17 @@ func (c *Controller) GetControlStream(serverID string) (handle UpstreamHandle, o
 	return
 }
 
-// Iter iterates across all handles registered with this controller.
-// note: if multiple handles are registered for a given server, only
+// UniqueHandles iterates across unique handles registered with this controller.
+// If multiple handles are registered for a given server, only
 // one handle is selected pseudorandomly to be observed.
-func (c *Controller) Iter(fn func(UpstreamHandle)) {
+func (c *Controller) UniqueHandles(fn func(UpstreamHandle)) {
 	c.store.UniqueHandles(fn)
 }
 
-// IterWithDuplicates iterates across all handles registered with this
+// AllHandles iterates across all handles registered with this
 // controller. If multiple handles are registered for a given server,
 // all of them will be observed.
-func (c *Controller) IterWithDuplicates(fn func(UpstreamHandle)) {
+func (c *Controller) AllHandles(fn func(UpstreamHandle)) {
 	c.store.AllHandles(fn)
 }
 

--- a/lib/inventory/store.go
+++ b/lib/inventory/store.go
@@ -73,19 +73,19 @@ func (s *Store) Remove(handle UpstreamHandle) {
 	s.getShard(handle.Hello().ServerID).remove(handle)
 }
 
-// Iter iterates across all handles registered with this store.
-// note: if multiple handles are registered for a given server, only
+// UniqueHandles iterates across unique handles registered with this store.
+// If multiple handles are registered for a given server, only
 // one handle is selected pseudorandomly to be observed.
-func (s *Store) Iter(fn func(UpstreamHandle)) {
+func (s *Store) UniqueHandles(fn func(UpstreamHandle)) {
 	for _, shard := range s.shards {
 		shard.iter(fn)
 	}
 }
 
-// IterWithDuplicates iterates across all handles registered with this
+// AllHandles iterates across all handles registered with this
 // store. If multiple handles are registered for a given server,
 // all of them will be observed.
-func (s *Store) IterWithDuplicates(fn func(UpstreamHandle)) {
+func (s *Store) AllHandles(fn func(UpstreamHandle)) {
 	for _, shard := range s.shards {
 		shard.iterWithDuplicates(fn)
 	}

--- a/lib/inventory/store_test.go
+++ b/lib/inventory/store_test.go
@@ -73,7 +73,7 @@ func BenchmarkStore(b *testing.B) {
 					go func() {
 						defer wg.Done()
 						var foundServer bool
-						store.Iter(func(h UpstreamHandle) {
+						store.UniqueHandles(func(h UpstreamHandle) {
 							if h.Hello().ServerID == serverID {
 								foundServer = true
 							}
@@ -126,7 +126,7 @@ func TestStoreAccess(t *testing.T) {
 
 	// ensure that all handles are visited if we iterate many times
 	for i := 0; i < 1_000; i++ {
-		store.Iter(func(h UpstreamHandle) {
+		store.UniqueHandles(func(h UpstreamHandle) {
 			ptr := h.(*upstreamHandle)
 			n, ok := handles[ptr]
 			require.True(t, ok)
@@ -142,16 +142,16 @@ func TestStoreAccess(t *testing.T) {
 
 	// verify that all handles were removed
 	var count int
-	store.Iter(func(h UpstreamHandle) {
+	store.UniqueHandles(func(h UpstreamHandle) {
 		count++
 	})
 	require.Zero(t, count)
 }
 
-// TestIterWithDuplicates verifies that IterWithDuplicates allows us to visit
+// TestAllHandles verifies that AllHandles allows us to visit
 // every handle in the store, even when multiple handles are registered with
 // the same server ID.
-func TestIterWithDuplicates(t *testing.T) {
+func TestAllHandles(t *testing.T) {
 	store := NewStore()
 
 	// we keep a record of all handles inserted into the store
@@ -172,7 +172,7 @@ func TestIterWithDuplicates(t *testing.T) {
 	}
 
 	// ensure that all handles are visited
-	store.IterWithDuplicates(func(h UpstreamHandle) {
+	store.AllHandles(func(h UpstreamHandle) {
 		ptr := h.(*upstreamHandle)
 		n, ok := handles[ptr]
 		require.True(t, ok)
@@ -187,7 +187,7 @@ func TestIterWithDuplicates(t *testing.T) {
 
 	// verify that all handles were removed
 	var count int
-	store.Iter(func(h UpstreamHandle) {
+	store.UniqueHandles(func(h UpstreamHandle) {
 		count++
 	})
 	require.Zero(t, count)


### PR DESCRIPTION
This new function offers a way to iterate over every registered handle.

Workaround for: https://github.com/gravitational/teleport/issues/54174

Part of: [RFD 184](https://github.com/gravitational/teleport/blob/master/rfd/0184-agent-auto-updates.md)

Goal (internal): https://github.com/gravitational/cloud/issues/11856