### PR TITLE
fix: fixes a possible panic during auth start if upsert operation fails

### DIFF
--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -1223,13 +1223,13 @@ func createPresetUsers(ctx context.Context, um PresetUsers) error {
 
 		if types.IsSystemResource(user) {
 			// System resources *always* get reset on every auth startup
-			if user, err := um.UpsertUser(ctx, user); err != nil {
+			if _, err := um.UpsertUser(ctx, user); err != nil {
 				return trace.Wrap(err, "failed upserting system user %s", user.GetName())
 			}
 			continue
 		}
 
-		if user, err := um.CreateUser(ctx, user); err != nil && !trace.IsAlreadyExists(err) {
+		if _, err := um.CreateUser(ctx, user); err != nil && !trace.IsAlreadyExists(err) {
 			return trace.Wrap(err, "failed creating preset user %s", user.GetName())
 		}
 	}


### PR DESCRIPTION
This PR addresses a potential panic that could occur due to a backend failure. In the event of such a failure, the user object is replaced with the result of the `{Upsert|Create}User` operation. If this operation also fails, both return nil, err, and since we attempted to access the user during error string construction, a nil pointer dereference could occur.

Changelog: Fixed a potential panic during Auth Server startup when the backend returns an error.