### PR TITLE
[v15] fix: fixes a possible panic during auth start if upsert operation fails

### DIFF
--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -1090,13 +1090,13 @@ func createPresetUsers(ctx context.Context, um PresetUsers) error {
 
 		if types.IsSystemResource(user) {
 			// System resources *always* get reset on every auth startup
-			if user, err := um.UpsertUser(ctx, user); err != nil {
+			if _, err := um.UpsertUser(ctx, user); err != nil {
 				return trace.Wrap(err, "failed upserting system user %s", user.GetName())
 			}
 			continue
 		}
 
-		if user, err := um.CreateUser(ctx, user); err != nil && !trace.IsAlreadyExists(err) {
+		if _, err := um.CreateUser(ctx, user); err != nil && !trace.IsAlreadyExists(err) {
 			return trace.Wrap(err, "failed creating preset user %s", user.GetName())
 		}
 	}


### PR DESCRIPTION
Backport #54323 to branch/v15

changelog: Fixed a potential panic during Auth Server startup when the backend returns an error.
