### PR TITLE
Add autoupdate_agent_report backend service

### DIFF
--- a/api/types/autoupdate/report.go
+++ b/api/types/autoupdate/report.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2025 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autoupdate
+
+import (
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	"github.com/gravitational/teleport/api/types"
+)
+
+// NewAutoUpdateAgentReport creates a new auto update version resource.
+func NewAutoUpdateAgentReport(spec *autoupdate.AutoUpdateAgentReportSpec, authName string) (*autoupdate.AutoUpdateAgentReport, error) {
+	rollout := &autoupdate.AutoUpdateAgentReport{
+		Kind:    types.KindAutoUpdateAgentReport,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: authName,
+		},
+		Spec: spec,
+	}
+	if err := ValidateAutoUpdateAgentReport(rollout); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return rollout, nil
+}
+
+// ValidateAutoUpdateAgentReport checks that required parameters are set
+// for the specified AutoUpdateAgentReport.
+func ValidateAutoUpdateAgentReport(v *autoupdate.AutoUpdateAgentReport) error {
+	if v.GetMetadata().GetName() == "" {
+		return trace.BadParameter("Metadata.Name is empty")
+	}
+	if v.Spec == nil {
+		return trace.BadParameter("Spec is nil")
+	}
+
+	// TODO: see if we need more validation
+	return nil
+}

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -332,6 +332,9 @@ const (
 	// KindAutoUpdateAgentRollout is the resource that controls and tracks agent rollouts.
 	KindAutoUpdateAgentRollout = "autoupdate_agent_rollout"
 
+	// KindAutoUpdateAgentReport is the resource that tracks connected agents.
+	KindAutoUpdateAgentReport = "autoupdate_agent_report"
+
 	// MetaNameAutoUpdateConfig is the name of a configuration resource for autoupdate config.
 	MetaNameAutoUpdateConfig = "autoupdate-config"
 

--- a/lib/services/local/autoupdate.go
+++ b/lib/services/local/autoupdate.go
@@ -99,7 +99,6 @@ func NewAutoUpdateService(b backend.Backend) (*AutoUpdateService, error) {
 			BackendPrefix: backend.NewKey(autoUpdateAgentRolloutPrefix),
 			MarshalFunc:   services.MarshalProtoResource[*autoupdate.AutoUpdateAgentReport],
 			UnmarshalFunc: services.UnmarshalProtoResource[*autoupdate.AutoUpdateAgentReport],
-			ValidateFunc:  update.ValidateAutoUpdateAgentReport,
 		})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -241,18 +240,27 @@ func (s *AutoUpdateService) GetAutoUpdateAgentReport(ctx context.Context, name s
 
 // CreateAutoUpdateAgentReport creates a new AutoUpdateAgentReport resource.
 func (s *AutoUpdateService) CreateAutoUpdateAgentReport(ctx context.Context, agentReport *autoupdate.AutoUpdateAgentReport) (*autoupdate.AutoUpdateAgentReport, error) {
+	if err := update.ValidateAutoUpdateAgentReport(agentReport); err != nil {
+		return nil, trace.Wrap(err, "validating autoupdate agent report")
+	}
 	created, err := s.report.CreateResource(ctx, agentReport)
 	return created, trace.Wrap(err)
 }
 
 // UpdateAutoUpdateAgentReport updates an existing AutoUpdateAgentReport resource.
 func (s *AutoUpdateService) UpdateAutoUpdateAgentReport(ctx context.Context, agentReport *autoupdate.AutoUpdateAgentReport) (*autoupdate.AutoUpdateAgentReport, error) {
+	if err := update.ValidateAutoUpdateAgentReport(agentReport); err != nil {
+		return nil, trace.Wrap(err, "validating autoupdate agent report")
+	}
 	updated, err := s.report.ConditionalUpdateResource(ctx, agentReport)
 	return updated, trace.Wrap(err)
 }
 
 // UpsertAutoUpdateAgentReport upserts a AutoUpdateAgentReport resource.
 func (s *AutoUpdateService) UpsertAutoUpdateAgentReport(ctx context.Context, agentReport *autoupdate.AutoUpdateAgentReport) (*autoupdate.AutoUpdateAgentReport, error) {
+	if err := update.ValidateAutoUpdateAgentReport(agentReport); err != nil {
+		return nil, trace.Wrap(err, "validating autoupdate agent report")
+	}
 	upserted, err := s.report.UpsertResource(ctx, agentReport)
 	return upserted, trace.Wrap(err)
 }

--- a/lib/services/local/autoupdate.go
+++ b/lib/services/local/autoupdate.go
@@ -42,6 +42,7 @@ type AutoUpdateService struct {
 	config  *generic.ServiceWrapper[*autoupdate.AutoUpdateConfig]
 	version *generic.ServiceWrapper[*autoupdate.AutoUpdateVersion]
 	rollout *generic.ServiceWrapper[*autoupdate.AutoUpdateAgentRollout]
+	report  *generic.ServiceWrapper[*autoupdate.AutoUpdateAgentReport]
 }
 
 // NewAutoUpdateService returns a new AutoUpdateService.
@@ -91,11 +92,24 @@ func NewAutoUpdateService(b backend.Backend) (*AutoUpdateService, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	report, err := generic.NewServiceWrapper(
+		generic.ServiceConfig[*autoupdate.AutoUpdateAgentReport]{
+			Backend:       b,
+			ResourceKind:  types.KindAutoUpdateAgentRollout,
+			BackendPrefix: backend.NewKey(autoUpdateAgentRolloutPrefix),
+			MarshalFunc:   services.MarshalProtoResource[*autoupdate.AutoUpdateAgentReport],
+			UnmarshalFunc: services.UnmarshalProtoResource[*autoupdate.AutoUpdateAgentReport],
+			ValidateFunc:  update.ValidateAutoUpdateAgentReport,
+		})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 
 	return &AutoUpdateService{
 		config:  config,
 		version: version,
 		rollout: rollout,
+		report:  report,
 	}, nil
 }
 
@@ -211,6 +225,46 @@ func (s *AutoUpdateService) GetAutoUpdateAgentRollout(ctx context.Context) (*aut
 // DeleteAutoUpdateAgentRollout deletes the AutoUpdateAgentRollout singleton resource.
 func (s *AutoUpdateService) DeleteAutoUpdateAgentRollout(ctx context.Context) error {
 	return trace.Wrap(s.rollout.DeleteResource(ctx, types.MetaNameAutoUpdateAgentRollout))
+}
+
+// ListAutoUpdateAgentReports returns a paginated list of AutoUpdateAgentReport resources.
+func (s *AutoUpdateService) ListAutoUpdateAgentReports(ctx context.Context, pageSize int, pageToken string) ([]*autoupdate.AutoUpdateAgentReport, string, error) {
+	agentReports, nextKey, err := s.report.ListResources(ctx, pageSize, pageToken)
+	return agentReports, nextKey, trace.Wrap(err)
+}
+
+// GetAutoUpdateAgentReport returns the specified AutoUpdateAgentReport resource.
+func (s *AutoUpdateService) GetAutoUpdateAgentReport(ctx context.Context, name string) (*autoupdate.AutoUpdateAgentReport, error) {
+	agentReport, err := s.report.GetResource(ctx, name)
+	return agentReport, trace.Wrap(err)
+}
+
+// CreateAutoUpdateAgentReport creates a new AutoUpdateAgentReport resource.
+func (s *AutoUpdateService) CreateAutoUpdateAgentReport(ctx context.Context, agentReport *autoupdate.AutoUpdateAgentReport) (*autoupdate.AutoUpdateAgentReport, error) {
+	created, err := s.report.CreateResource(ctx, agentReport)
+	return created, trace.Wrap(err)
+}
+
+// UpdateAutoUpdateAgentReport updates an existing AutoUpdateAgentReport resource.
+func (s *AutoUpdateService) UpdateAutoUpdateAgentReport(ctx context.Context, agentReport *autoupdate.AutoUpdateAgentReport) (*autoupdate.AutoUpdateAgentReport, error) {
+	updated, err := s.report.ConditionalUpdateResource(ctx, agentReport)
+	return updated, trace.Wrap(err)
+}
+
+// UpsertAutoUpdateAgentReport upserts a AutoUpdateAgentReport resource.
+func (s *AutoUpdateService) UpsertAutoUpdateAgentReport(ctx context.Context, agentReport *autoupdate.AutoUpdateAgentReport) (*autoupdate.AutoUpdateAgentReport, error) {
+	upserted, err := s.report.UpsertResource(ctx, agentReport)
+	return upserted, trace.Wrap(err)
+}
+
+// DeleteAutoUpdateAgentReport removes the specified AutoUpdateAgentReport resource.
+func (s *AutoUpdateService) DeleteAutoUpdateAgentReport(ctx context.Context, name string) error {
+	return trace.Wrap(s.report.DeleteResource(ctx, name))
+}
+
+// DeleteAllAutoUpdateAgentReports removes all AutoUpdateAgentReport resources.
+func (s *AutoUpdateService) DeleteAllAutoUpdateAgentReports(ctx context.Context) error {
+	return trace.Wrap(s.report.DeleteAllResources(ctx))
 }
 
 // itemFromAutoUpdateConfig generates `backend.Item` from `AutoUpdateConfig` resource type.


### PR DESCRIPTION
This PR adds the autoupdate_agent_report backend service.

Part of: [RFD 184](https://github.com/gravitational/teleport/blob/master/rfd/0184-agent-auto-updates.md)

Goal (internal): https://github.com/gravitational/cloud/issues/11856