### PR TITLE
Add ShuffleVisit utility function

### DIFF
--- a/lib/kube/proxy/transport.go
+++ b/lib/kube/proxy/transport.go
@@ -23,7 +23,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"math/rand/v2"
 	"net"
 	"net/http"
 	"time"
@@ -319,15 +318,12 @@ func (f *Forwarder) localClusterDialer(kubeClusterName string, opts ...contextDi
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		// Shuffle the list of servers to avoid always connecting to the same
-		// server.
-		rand.Shuffle(len(kubeServers), func(i, j int) {
-			kubeServers[i], kubeServers[j] = kubeServers[j], kubeServers[i]
-		})
 
 		var errs []error
-		// Validate that the requested kube cluster is registered.
-		for _, s := range kubeServers {
+		// Shuffle the list of servers to avoid always connecting to the same
+		// server.
+		for _, s := range utils.ShuffleVisit(kubeServers) {
+			// Validate that the requested kube cluster is registered.
 			kubeCluster := s.GetCluster()
 			if kubeCluster.GetName() != kubeClusterName || !opt.matches(s.GetHostID()) {
 				continue

--- a/lib/utils/rand.go
+++ b/lib/utils/rand.go
@@ -21,7 +21,9 @@ package utils
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"iter"
 	"math/big"
+	mathrand "math/rand/v2"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -47,4 +49,29 @@ func RandomDuration(max time.Duration) time.Duration {
 		return max / 2
 	}
 	return time.Duration(randomVal.Int64())
+}
+
+// ShuffleVisit yields the items of a slice in random order, while arranging
+// them in the same order at the head of the slice. Exiting early from the
+// iterator will result in a slice that's partially shuffled - specifically,
+// pulling N items from the iterator will also arrange for the slice to contain
+// the same items in the same order at indices 0 through N-1. The slice is
+// updated as items are yielded from the iterator, so the first N items are
+// fixed in position and inspectable during the iteration at step N.
+func ShuffleVisit[S ~[]E, E any](s S) iter.Seq2[int, E] {
+	return func(yield func(int, E) bool) {
+		for i := range len(s) {
+			j := mathrand.N(len(s))
+			// swapping here (instead of swapping after the yield) ensures that
+			// pulling items from the iterator also puts them in order at the
+			// beginning of the slice, otherwise there would be a difference
+			// between exhausting the iterator and exiting early; the items are
+			// also accessible during the iteration
+			s[0], s[j] = s[j], s[0]
+			if !yield(i, s[0]) {
+				return
+			}
+			s = s[1:]
+		}
+	}
 }

--- a/lib/utils/rand_test.go
+++ b/lib/utils/rand_test.go
@@ -1,0 +1,35 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShuffleVisit(t *testing.T) {
+	const N = 1000
+	s := make([]int, 0, N)
+	for i := range N {
+		s = append(s, i)
+	}
+
+	var out []int
+	for i, v := range ShuffleVisit(s) {
+		require.Equal(t, len(out), i)
+		out = append(out, v)
+		require.Equal(t, out, s[:len(out)])
+	}
+	require.Len(t, out, N)
+
+	var fixed int
+	for i, v := range s {
+		if i == v {
+			fixed++
+		}
+	}
+	// this is a check with a HUGE margin of error, seeing that a perfect
+	// shuffle of 1000 items would have a 1 in 99_524_607 chance of having more
+	// than 10 fixed points, and the chance to have 500 or more is 1 in
+	// 3.02e1134
+	require.Less(t, fixed, N/2)
+}

--- a/lib/utils/rand_test.go
+++ b/lib/utils/rand_test.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package utils
 
 import (

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -31,6 +31,7 @@ import (
 	"html/template"
 	"io"
 	"log/slog"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"net/url"
@@ -360,7 +361,7 @@ func (h *APIHandler) handlePreflight(w http.ResponseWriter, r *http.Request) {
 	}
 	publicAddr := raddr.Host()
 
-	servers, err := app.Match(r.Context(), h.handler.cfg.AccessPoint, app.MatchPublicAddr(publicAddr))
+	servers, err := app.MatchUnshuffled(r.Context(), h.handler.cfg.AccessPoint, app.MatchPublicAddr(publicAddr))
 	if err != nil {
 		h.handler.logger.InfoContext(r.Context(), "failed to match application with public addr", "public_addr", publicAddr)
 		return
@@ -371,7 +372,7 @@ func (h *APIHandler) handlePreflight(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	foundApp := servers[0].GetApp()
+	foundApp := servers[rand.N(len(servers))].GetApp()
 	corsPolicy := foundApp.GetCORS()
 	if corsPolicy == nil {
 		return

--- a/lib/web/app/match.go
+++ b/lib/web/app/match.go
@@ -40,10 +40,10 @@ type Getter interface {
 	GetClusterName(ctx context.Context) (types.ClusterName, error)
 }
 
-// Match will match a list of applications with the passed in matcher function. Matcher
-// functions that can match on public address and name are available. The
-// resulting list is shuffled before it is returned.
-func Match(ctx context.Context, authClient Getter, fn Matcher) ([]types.AppServer, error) {
+// MatchUnshuffled will match a list of applications with the passed in matcher
+// function. Matcher functions that can match on public address and name are
+// available.
+func MatchUnshuffled(ctx context.Context, authClient Getter, fn Matcher) ([]types.AppServer, error) {
 	servers, err := authClient.GetApplicationServers(ctx, defaults.Namespace)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -55,10 +55,6 @@ func Match(ctx context.Context, authClient Getter, fn Matcher) ([]types.AppServe
 			as = append(as, server)
 		}
 	}
-
-	rand.Shuffle(len(as), func(i, j int) {
-		as[i], as[j] = as[j], as[i]
-	})
 
 	return as, nil
 }
@@ -146,13 +142,13 @@ func MatchAll(matchers ...Matcher) Matcher {
 // resolve an application.
 func ResolveFQDN(ctx context.Context, clt Getter, tunnel reversetunnelclient.Tunnel, proxyDNSNames []string, fqdn string) (types.AppServer, string, error) {
 	// Try and match FQDN to public address of application within cluster.
-	servers, err := Match(ctx, clt, MatchPublicAddr(fqdn))
+	servers, err := MatchUnshuffled(ctx, clt, MatchPublicAddr(fqdn))
 	if err == nil && len(servers) > 0 {
 		clusterName, err := clt.GetClusterName(ctx)
 		if err != nil {
 			return nil, "", trace.Wrap(err)
 		}
-		return servers[0], clusterName.GetClusterName(), nil
+		return servers[rand.N(len(servers))], clusterName.GetClusterName(), nil
 	}
 
 	// Extract the first subdomain from the FQDN and attempt to use this as the
@@ -179,9 +175,9 @@ func ResolveFQDN(ctx context.Context, clt Getter, tunnel reversetunnelclient.Tun
 			return nil, "", trace.Wrap(err)
 		}
 
-		servers, err = Match(ctx, authClient, MatchName(appName))
+		servers, err = MatchUnshuffled(ctx, authClient, MatchName(appName))
 		if err == nil && len(servers) > 0 {
-			return servers[0], clusterClient.GetName(), nil
+			return servers[rand.N(len(servers))], clusterClient.GetName(), nil
 		}
 	}
 

--- a/lib/web/apps.go
+++ b/lib/web/apps.go
@@ -22,6 +22,7 @@ package web
 
 import (
 	"context"
+	"math/rand/v2"
 	"net/http"
 	"sort"
 
@@ -374,7 +375,7 @@ func (h *Handler) resolveAppByName(ctx context.Context, proxy reversetunnelclien
 		return nil, "", trace.Wrap(err)
 	}
 
-	servers, err := app.Match(ctx, authClient, app.MatchName(appName))
+	servers, err := app.MatchUnshuffled(ctx, authClient, app.MatchName(appName))
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
@@ -383,7 +384,7 @@ func (h *Handler) resolveAppByName(ctx context.Context, proxy reversetunnelclien
 		return nil, "", trace.NotFound("failed to match applications with name %s", appName)
 	}
 
-	return servers[0], clusterName, nil
+	return servers[rand.N(len(servers))], clusterName, nil
 }
 
 // resolveDirect takes a public address and cluster name and exactly resolves
@@ -399,7 +400,7 @@ func (h *Handler) resolveDirect(ctx context.Context, proxy reversetunnelclient.T
 		return nil, "", trace.Wrap(err)
 	}
 
-	servers, err := app.Match(ctx, authClient, app.MatchPublicAddr(publicAddr))
+	servers, err := app.MatchUnshuffled(ctx, authClient, app.MatchPublicAddr(publicAddr))
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
@@ -408,7 +409,7 @@ func (h *Handler) resolveDirect(ctx context.Context, proxy reversetunnelclient.T
 		return nil, "", trace.NotFound("failed to match applications with public addr %s", publicAddr)
 	}
 
-	return servers[0], clusterName, nil
+	return servers[rand.N(len(servers))], clusterName, nil
 }
 
 // resolveFQDN makes a best effort attempt to resolve FQDN to an application

--- a/lib/web/desktop.go
+++ b/lib/web/desktop.go
@@ -26,7 +26,6 @@ import (
 	"errors"
 	"io"
 	"log/slog"
-	"math/rand/v2"
 	"net"
 	"net/http"
 	"sync"
@@ -159,9 +158,6 @@ func (h *Handler) createDesktopConnection(
 		}
 		validServiceIDs = append(validServiceIDs, desktop.GetHostID())
 	}
-	rand.Shuffle(len(validServiceIDs), func(i, j int) {
-		validServiceIDs[i], validServiceIDs[j] = validServiceIDs[j], validServiceIDs[i]
-	})
 
 	// Parse the private key of the user from the session context.
 	pk, err := keys.ParsePrivateKey(sctx.cfg.Session.GetTLSPriv())
@@ -494,7 +490,7 @@ func (c *connector) connectToWindowsService(
 	clusterName string,
 	desktopServiceIDs []string,
 ) (conn net.Conn, version string, err error) {
-	for _, id := range desktopServiceIDs {
+	for _, id := range utils.ShuffleVisit(desktopServiceIDs) {
 		conn, ver, err := c.tryConnect(ctx, clusterName, id)
 		if err != nil && !trace.IsConnectionProblem(err) {
 			return nil, "", trace.WrapWithMessage(err,


### PR DESCRIPTION
This PR adds a utility function to iterate over a slice while shuffling it. It's better than shuffling the slice and then ranging over it in all situations where it's possible that we will only need a few items in the slice (for example, if we are trying to connect to one of many servers in random order, stopping at the first successful one).