### PR TITLE
[v16] Document `workload_identity_labels` and `workload_identity_labels_expression`

### DIFF
--- a/docs/pages/includes/role-spec.mdx
+++ b/docs/pages/includes/role-spec.mdx
@@ -293,6 +293,11 @@ spec:
     cluster_labels:
       'env': 'prod'
 
+    # workload_identity_labels: a user/bot with this role will be allowed to
+    # issue Workload Identities with labels matching below.
+    workload_identity_labels:
+      'env': 'prod'
+
     # node_labels_expression has the same purpose as node_labels but
     # supports predicate expressions to configure custom logic.
     # A user with this role will be allowed to access nodes if they are in the
@@ -311,6 +316,7 @@ spec:
     db_service_labels_expression: 'labels["env"] == "staging"'
     windows_desktop_labels_expression: 'labels["env"] == "staging"'
     group_labels_expression: 'labels["env"] == "staging"'
+    workload_identity_labels_expression: 'labels["env"] == "staging"'
 
     # aws_role_arns allows a user with this role to assume AWS roles when
     # accessing AWS console using UI or AWS API using CLI

--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -227,6 +227,7 @@ conditions:
 - `db_service_labels_expression`
 - `windows_desktop_labels_expression`
 - `group_labels_expression`
+- `workload_identity_labels_expression`
 
 Check out our
 [predicate language](../predicate-language.mdx)
@@ -440,6 +441,7 @@ Labels for resources enrolled with Teleport:
 |`kubernetes_labels`|[Kubernetes clusters](../../enroll-resources/kubernetes-access/controls.mdx)|
 |`node_labels`|[SSH Servers](../../enroll-resources/server-access/server-access.mdx)|
 |`windows_desktop_labels`|[Windows desktops](../../enroll-resources/server-access/server-access.mdx)|
+|`workload_identity_labels`|[Workload Identities](../workload-identity/workload-identity-resource.mdx)|
 
 Principals a user can assume on infrastructure resources:
 - `aws_role_arns`


### PR DESCRIPTION
Backport #54271 to branch/v16