### PR TITLE
MWI: Bound Keypair Joining - Minimal Client Implementation

### DIFF
--- a/lib/auth/join/boundkeypair/boundkeypair.go
+++ b/lib/auth/join/boundkeypair/boundkeypair.go
@@ -191,7 +191,7 @@ func NewUnboundClientState(ctx context.Context, getSuite cryptosuites.GetSuiteFu
 
 	privateKeyBytes, err := keys.MarshalPrivateKey(key)
 	if err != nil {
-		return nil, trace.Wrap(err, "marshalling private key")
+		return nil, trace.Wrap(err, "marshallng private key")
 	}
 
 	sshPubKey, err := ssh.NewPublicKey(key.Public())

--- a/lib/auth/join/boundkeypair/boundkeypair.go
+++ b/lib/auth/join/boundkeypair/boundkeypair.go
@@ -1,0 +1,213 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package boundkeypair
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/auth/join"
+	"github.com/gravitational/teleport/lib/cryptosuites"
+	"github.com/gravitational/trace"
+	"golang.org/x/crypto/ssh"
+)
+
+const (
+	PrivateKeyPath = "id_bkp"
+	PublicKeyPath  = PrivateKeyPath + ".pub"
+	JoinStatePath  = "bkp_state"
+
+	StandardFileWriteMode = 0600
+)
+
+// ClientState contains state parameters stored on disk needed to complete the
+// bound keypair join process.
+type ClientState struct {
+	// PrivateKey is the parsed private key.
+	PrivateKey *keys.PrivateKey
+
+	// PrivateKeyBytes contains the private key bytes. This value should always
+	// be nonempty.
+	PrivateKeyBytes []byte
+
+	// PublicKeyBytes contains the public key bytes. This value is not used at
+	// runtime, and is only set when a public key should be written to disk,
+	// like on first creation or during rotation. To consistently access the
+	// public key, use `.PrivateKey.Public()`.
+	PublicKeyBytes []byte
+
+	// JoinStateBytes contains join state bytes. This value will be empty if
+	// this client has not yet joined.
+	JoinStateBytes []byte
+}
+
+// ToJoinParams creates joining parameters for use with `join.Register()` from
+// this client state.
+func (c *ClientState) ToJoinParams(initialJoinSecret string) *join.BoundKeypairParams {
+	if len(c.JoinStateBytes) > 0 {
+		// This identity has been bound, so don't pass along the join secret (if
+		// any)
+		initialJoinSecret = ""
+	}
+
+	return &join.BoundKeypairParams{
+		// Note: pass the internal signer because go-jose does type assertions
+		// on the standard library types.
+		CurrentKey:        c.PrivateKey.Signer,
+		PreviousJoinState: c.JoinStateBytes,
+		InitialJoinSecret: initialJoinSecret,
+	}
+}
+
+// ToPublicKeyBytes returns the public key bytes in ssh authorized_keys format.
+func (c *ClientState) ToPublicKeyBytes() ([]byte, error) {
+	sshPubKey, err := ssh.NewPublicKey(c.PrivateKey.Public())
+	if err != nil {
+		return nil, trace.Wrap(err, "creating ssh public key")
+	}
+
+	return ssh.MarshalAuthorizedKey(sshPubKey), nil
+}
+
+type FS interface {
+	Read(ctx context.Context, name string) ([]byte, error)
+	Write(ctx context.Context, name string, data []byte) error
+}
+
+type StandardFS struct {
+	parentDir string
+}
+
+func (f *StandardFS) Read(ctx context.Context, name string) ([]byte, error) {
+	data, err := os.ReadFile(name)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return data, nil
+}
+
+func (f *StandardFS) Write(ctx context.Context, name string, data []byte) error {
+	path := filepath.Join(f.parentDir, name)
+
+	return trace.Wrap(os.WriteFile(path, data, StandardFileWriteMode))
+}
+
+// NewStandardFS creates a new standard FS implementation.
+func NewStandardFS(parentDir string) FS {
+	return &StandardFS{
+		parentDir: parentDir,
+	}
+}
+
+// LoadClientState attempts to load bound keypair client state from the given
+// filesystem implementation. Callers should expect to handle NotFound errors
+// returned here if a private key is not found; this indicates no prior client
+// state exists and initial secret joining should be attempted if possible. If
+// a keypair has been pregenerated, no prior join state will exist, and the
+// join state will be empty; any corresponding errors while reading nonexistent
+// join state documents will be ignored.
+func LoadClientState(ctx context.Context, fs FS) (*ClientState, error) {
+	privateKeyBytes, err := fs.Read(ctx, PrivateKeyPath)
+	if err != nil {
+		return nil, trace.Wrap(err, "reading private key")
+	}
+
+	joinStateBytes, err := fs.Read(ctx, JoinStatePath)
+	if trace.IsNotFound(err) {
+		// Join state doesn't exist, this is allowed.
+	} else if err != nil {
+		return nil, trace.Wrap(err, "reading previous join state")
+	}
+
+	pk, err := keys.ParsePrivateKey(privateKeyBytes)
+	if err != nil {
+		return nil, trace.Wrap(err, "parsing private key")
+	}
+
+	return &ClientState{
+		PrivateKey: pk,
+
+		PrivateKeyBytes: privateKeyBytes,
+		JoinStateBytes:  joinStateBytes,
+	}, nil
+}
+
+// StoreClientState writes bound keypair client state to the given filesystem
+// wrapper. Public keys and join state will only be written if
+func StoreClientState(ctx context.Context, fs FS, state *ClientState) error {
+	if err := fs.Write(ctx, PrivateKeyPath, state.PrivateKeyBytes); err != nil {
+		return trace.Wrap(err, "writing private key")
+	}
+
+	// TODO: maybe consider just not writing the public key at all. End users
+	// aren't really meant to look in the internal storage, and we can just
+	// derive the public key whenever we want.
+
+	// Only write the public key if it was explicitly provided. This helps save
+	// an unnecessary file write.
+	if len(state.PublicKeyBytes) > 0 {
+		if err := fs.Write(ctx, PublicKeyPath, state.PublicKeyBytes); err != nil {
+			return trace.Wrap(err, "writing public key")
+		}
+	}
+
+	if len(state.JoinStateBytes) > 0 {
+		if err := fs.Write(ctx, JoinStatePath, state.JoinStateBytes); err != nil {
+			return trace.Wrap(err, "writing previous join state")
+		}
+	}
+
+	return nil
+}
+
+// NewUnboundClientState creates a new client state that has not yet been bound,
+// i.e. a new keypair that has not been registered with Auth, and no prior join
+// state.
+func NewUnboundClientState(ctx context.Context, getSuite cryptosuites.GetSuiteFunc) (*ClientState, error) {
+	key, err := cryptosuites.GenerateKey(ctx, getSuite, cryptosuites.BoundKeypairJoining)
+	if err != nil {
+		return nil, trace.Wrap(err, "generating keypair")
+	}
+
+	privateKeyBytes, err := keys.MarshalPrivateKey(key)
+	if err != nil {
+		return nil, trace.Wrap(err, "marshalling private key")
+	}
+
+	sshPubKey, err := ssh.NewPublicKey(key.Public())
+	if err != nil {
+		return nil, trace.Wrap(err, "creating ssh public key")
+	}
+
+	publicKeyBytes := ssh.MarshalAuthorizedKey(sshPubKey)
+
+	pk, err := keys.NewPrivateKey(key)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &ClientState{
+		PrivateKeyBytes: privateKeyBytes,
+		PublicKeyBytes:  publicKeyBytes,
+		PrivateKey:      pk,
+	}, nil
+}

--- a/lib/auth/join/boundkeypair/boundkeypair.go
+++ b/lib/auth/join/boundkeypair/boundkeypair.go
@@ -23,11 +23,12 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/gravitational/trace"
+	"golang.org/x/crypto/ssh"
+
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/auth/join"
 	"github.com/gravitational/teleport/lib/cryptosuites"
-	"github.com/gravitational/trace"
-	"golang.org/x/crypto/ssh"
 )
 
 const (

--- a/lib/auth/join/join.go
+++ b/lib/auth/join/join.go
@@ -706,7 +706,7 @@ type joinServiceClient interface {
 		ctx context.Context,
 		req *proto.RegisterUsingBoundKeypairInitialRequest,
 		challengeResponse client.RegisterUsingBoundKeypairChallengeResponseFunc,
-	) (*proto.Certs, error)
+	) (*proto.Certs, string, error)
 }
 
 func registerUsingTokenRequestForParams(token string, hostKeys *newHostKeys, params RegisterParams) *types.RegisterUsingTokenRequest {
@@ -929,7 +929,8 @@ func registerUsingBoundKeypairMethod(
 		PreviousJoinState: bkParams.PreviousJoinState,
 	}
 
-	certs, err := client.RegisterUsingBoundKeypairMethod(
+	// TODO: inform the caller about the returned public key?
+	certs, _, err := client.RegisterUsingBoundKeypairMethod(
 		ctx,
 		initReq,
 		func(resp *proto.RegisterUsingBoundKeypairMethodResponse) (*proto.RegisterUsingBoundKeypairMethodRequest, error) {

--- a/lib/auth/join/join.go
+++ b/lib/auth/join/join.go
@@ -898,6 +898,8 @@ func sshPubKeyFromSigner(signer crypto.Signer) (string, error) {
 	return strings.TrimSpace(string(ssh.MarshalAuthorizedKey(sshKey))), nil
 }
 
+// registerUsingBoundKeypairMethod performs bound keypair-type registration and
+// handles the joining ceremony.
 func registerUsingBoundKeypairMethod(
 	ctx context.Context,
 	client joinServiceClient,
@@ -929,7 +931,8 @@ func registerUsingBoundKeypairMethod(
 		PreviousJoinState: bkParams.PreviousJoinState,
 	}
 
-	// TODO: inform the caller about the returned public key?
+	// TODO: When implementing rotation, we should make use of the returned
+	// public key to ensure that key is marked as the primary.
 	certs, _, err := client.RegisterUsingBoundKeypairMethod(
 		ctx,
 		initReq,

--- a/lib/auth/join/join.go
+++ b/lib/auth/join/join.go
@@ -23,8 +23,10 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
+	"github.com/go-jose/go-jose/v3"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"go.opentelemetry.io/otel"
@@ -52,6 +54,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/githubactions"
 	"github.com/gravitational/teleport/lib/gitlab"
+	"github.com/gravitational/teleport/lib/jwt"
 	kubetoken "github.com/gravitational/teleport/lib/kube/token"
 	"github.com/gravitational/teleport/lib/spacelift"
 	"github.com/gravitational/teleport/lib/terraformcloud"
@@ -79,6 +82,29 @@ type GitlabParams struct {
 	// EnvVarName is the name of the environment variable that contains the
 	// IDToken. If unset, this will default to "TBOT_GITLAB_JWT".
 	EnvVarName string
+}
+
+// BoundKeypairParams are parameters specific to bound-keypair joining.
+type BoundKeypairParams struct {
+	// InitialJoinSecret is a one-time-use joining token for use on first join.
+	// May be unset if a keypair was registered with Auth out of band.
+	InitialJoinSecret string
+
+	// CurrentKey is the keypair currently registered with Auth. On initial
+	// join using `InitialJoinSecret`, this should be nil in favor of `NewKey`.
+	CurrentKey crypto.Signer
+
+	// NewKey is a new keypair that will be registered with Auth. On an initial
+	// join when `InitialJoinSecret` is set, only a single challenge will be
+	// issued to verify this key. If this is rotating an existing registered
+	// key, a second challenge will be issued: one for the current key, to
+	// verify the client identity, and one against this new key.
+	NewKey crypto.Signer
+
+	// PreviousJoinState is the previous join state document provided by Auth
+	// alongside the previous set of certs. If this is initial registration, it
+	// can be empty.
+	PreviousJoinState []byte
 }
 
 // RegisterParams specifies parameters
@@ -152,6 +178,8 @@ type RegisterParams struct {
 	TerraformCloudAudienceTag string
 	// GitlabParams is the parameters specific to the gitlab join method.
 	GitlabParams GitlabParams
+	// BoundKeypairParams contains parameters specific to bound keypair joining.
+	BoundKeypairParams *BoundKeypairParams
 }
 
 func (r *RegisterParams) checkAndSetDefaults() error {
@@ -275,6 +303,10 @@ func Register(ctx context.Context, params RegisterParams) (result *RegisterResul
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
+	case types.JoinMethodBoundKeypair:
+		if params.BoundKeypairParams == nil {
+			return nil, trace.BadParameter("bound keypair parameters are required")
+		}
 	}
 
 	// If an explicit AuthClient has been provided, we want to go straight to
@@ -372,7 +404,9 @@ func registerThroughProxy(
 	case types.JoinMethodIAM,
 		types.JoinMethodAzure,
 		types.JoinMethodTPM,
-		types.JoinMethodOracle:
+		types.JoinMethodOracle,
+		types.JoinMethodBoundKeypair:
+
 		// These join methods require gRPC client
 		conn, err := proxyinsecureclient.NewConnection(
 			ctx,
@@ -399,6 +433,8 @@ func registerThroughProxy(
 			certs, err = registerUsingTPMMethod(ctx, joinServiceClient, token, hostKeys, params)
 		case types.JoinMethodOracle:
 			certs, err = registerUsingOracleMethod(ctx, joinServiceClient, token, hostKeys, params)
+		case types.JoinMethodBoundKeypair:
+			certs, err = registerUsingBoundKeypairMethod(ctx, joinServiceClient, token, hostKeys, params)
 		default:
 			return nil, trace.BadParameter("unhandled join method %q", params.JoinMethod)
 		}
@@ -487,6 +523,8 @@ func registerThroughAuthClient(
 		certs, err = registerUsingAzureMethod(ctx, client, token, hostKeys, params)
 	case types.JoinMethodTPM:
 		certs, err = registerUsingTPMMethod(ctx, client, token, hostKeys, params)
+	case types.JoinMethodBoundKeypair:
+		certs, err = registerUsingBoundKeypairMethod(ctx, client, token, hostKeys, params)
 	default:
 		// non-IAM join methods use HTTP endpoint
 		// Get the SSH and X509 certificates for a node.
@@ -671,6 +709,11 @@ type joinServiceClient interface {
 		tokenReq *types.RegisterUsingTokenRequest,
 		challengeResponse client.RegisterOracleChallengeResponseFunc,
 	) (*proto.Certs, error)
+	RegisterUsingBoundKeypairMethod(
+		ctx context.Context,
+		req *proto.RegisterUsingBoundKeypairInitialRequest,
+		challengeResponse client.RegisterUsingBoundKeypairChallengeResponseFunc,
+	) (*proto.Certs, error)
 }
 
 func registerUsingTokenRequestForParams(token string, hostKeys *newHostKeys, params RegisterParams) *types.RegisterUsingTokenRequest {
@@ -848,6 +891,101 @@ func registerUsingOracleMethod(
 				PayloadHeaders: mapFromHeader(innerHeaders),
 			}, nil
 		})
+	return certs, trace.Wrap(err)
+}
+
+// sshPubKeyFromSigner returns the public key of the given signer in ssh
+// authorized_keys format.
+func sshPubKeyFromSigner(signer crypto.Signer) (string, error) {
+	sshKey, err := ssh.NewPublicKey(signer.Public())
+	if err != nil {
+		return "", trace.Wrap(err, "creating SSH public key from signer")
+	}
+
+	return strings.TrimSpace(string(ssh.MarshalAuthorizedKey(sshKey))), nil
+}
+
+func registerUsingBoundKeypairMethod(
+	ctx context.Context, client joinServiceClient, token string, hostKeys *newHostKeys, params RegisterParams,
+) (*proto.Certs, error) {
+	bkParams := params.BoundKeypairParams
+
+	// Build a map of all public keys to signers.
+	signers := map[string]crypto.Signer{}
+
+	if bkParams.CurrentKey != nil {
+		pub, err := sshPubKeyFromSigner(bkParams.CurrentKey)
+		if err != nil {
+			return nil, trace.Wrap(err, "generating ssh public key from current key signer")
+		}
+
+		signers[pub] = bkParams.CurrentKey
+	}
+
+	var err error
+	newSSHPub := ""
+	if bkParams.NewKey != nil {
+		newSSHPub, err = sshPubKeyFromSigner(bkParams.NewKey)
+		if err != nil {
+			return nil, trace.Wrap(err, "generating ssh public key from new key signer")
+		}
+
+		signers[newSSHPub] = bkParams.NewKey
+	}
+
+	initReq := &proto.RegisterUsingBoundKeypairInitialRequest{
+		JoinRequest:       registerUsingTokenRequestForParams(token, hostKeys, params),
+		InitialJoinSecret: bkParams.InitialJoinSecret,
+		PreviousJoinState: bkParams.PreviousJoinState,
+		NewPublicKey:      newSSHPub,
+	}
+
+	certs, err := client.RegisterUsingBoundKeypairMethod(
+		ctx,
+		initReq,
+		func(publicKey string, challenge string) (*proto.RegisterUsingBoundKeypairChallengeResponse, error) {
+			// Unlike other join methods, this function may be called multiple
+			// times to complete challenges using one or both signers, so we'll
+			// use the passed publicKey hint to resolve the proper signer to
+			// use.
+			signer, ok := signers[publicKey]
+			if !ok {
+				return nil, trace.NotFound("could not complete challenge for unknown public key: %+#v", publicKey)
+			}
+
+			// TODO: might not be worth exporting this func; may be cheaper to
+			// just copy the function here instead.
+			alg, err := jwt.AlgorithmForPublicKey(signer.Public())
+			if err != nil {
+				return nil, trace.Wrap(err, "determining signing algorithm for public key")
+			}
+
+			opts := (&jose.SignerOptions{}).WithType("JWT")
+			key := jose.SigningKey{
+				Algorithm: alg,
+				Key:       signer,
+			}
+
+			joseSigner, err := jose.NewSigner(key, opts)
+			if err != nil {
+				return nil, trace.Wrap(err, "creating signer")
+			}
+
+			jws, err := joseSigner.Sign([]byte(challenge))
+			if err != nil {
+				return nil, trace.Wrap(err, "signing challenge")
+			}
+
+			serialized, err := jws.CompactSerialize()
+			if err != nil {
+				return nil, trace.Wrap(err, "serializing signed challenge")
+			}
+
+			return &proto.RegisterUsingBoundKeypairChallengeResponse{
+				Solution: []byte(serialized),
+			}, nil
+		})
+
 	return certs, trace.Wrap(err)
 }
 

--- a/lib/tbot/cli/keypair_create.go
+++ b/lib/tbot/cli/keypair_create.go
@@ -18,12 +18,16 @@
 
 package cli
 
+import "github.com/gravitational/teleport"
+
 // KeypairCreateCommand handles `tbot keypair create`
 type KeypairCreateCommand struct {
 	*genericExecutorHandler[KeypairCreateCommand]
 
 	ProxyServer string
 	Storage     string
+	Overwrite   bool
+	Format      string
 }
 
 // NewKeypairCreateCommand initializes the `keypair create` command and returns
@@ -36,6 +40,8 @@ func NewKeypairCreateCommand(parentCmd KingpinClause, action func(*KeypairCreate
 
 	cmd.Flag("storage", "An internal storage URI to write the keypair, such as file:///var/lib/teleport/bot").Required().StringVar(&c.Storage)
 	cmd.Flag("proxy-server", "The proxy server, which will be pinged to determine the current cryptographic suite in use").Required().StringVar(&c.ProxyServer)
+	cmd.Flag("overwrite", "If set, overwrite any existing keypair. If unset and a keypair already exists, its key will be printed for use.").BoolVar(&c.Overwrite)
+	cmd.Flag("format", "Output format, one of: text, json").Default(teleport.Text).EnumVar(&c.Format, teleport.Text, teleport.JSON)
 
 	return c
 }

--- a/lib/tbot/cli/keypair_create.go
+++ b/lib/tbot/cli/keypair_create.go
@@ -1,0 +1,41 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cli
+
+// KeypairCreateCommand handles `tbot keypair create`
+type KeypairCreateCommand struct {
+	*genericExecutorHandler[KeypairCreateCommand]
+
+	ProxyServer string
+	Storage     string
+}
+
+// NewKeypairCreateCommand initializes the `keypair create` command and returns
+// a struct to contain the parse result.
+func NewKeypairCreateCommand(parentCmd KingpinClause, action func(*KeypairCreateCommand) error) *KeypairCreateCommand {
+	cmd := parentCmd.Command("create", "Create a keypair to preregister for bound-keypair joining")
+
+	c := &KeypairCreateCommand{}
+	c.genericExecutorHandler = newGenericExecutorHandler(cmd, c, action)
+
+	cmd.Flag("storage", "An internal storage URI to write the keypair, such as file:///var/lib/teleport/bot").Required().StringVar(&c.Storage)
+	cmd.Flag("proxy-server", "The proxy server, which will be pinged to determine the current cryptographic suite in use").Required().StringVar(&c.ProxyServer)
+
+	return c
+}

--- a/lib/tbot/cli/keypair_create.go
+++ b/lib/tbot/cli/keypair_create.go
@@ -33,7 +33,7 @@ type KeypairCreateCommand struct {
 // NewKeypairCreateCommand initializes the `keypair create` command and returns
 // a struct to contain the parse result.
 func NewKeypairCreateCommand(parentCmd KingpinClause, action func(*KeypairCreateCommand) error) *KeypairCreateCommand {
-	cmd := parentCmd.Command("create", "Create a keypair to preregister for bound-keypair joining")
+	cmd := parentCmd.Command("create", "Create a keypair to preregister for bound-keypair joining").Hidden()
 
 	c := &KeypairCreateCommand{}
 	c.genericExecutorHandler = newGenericExecutorHandler(cmd, c, action)

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -62,6 +62,7 @@ var SupportedJoinMethods = []string{
 	string(types.JoinMethodToken),
 	string(types.JoinMethodTPM),
 	string(types.JoinMethodTerraformCloud),
+	string(types.JoinMethodBoundKeypair),
 }
 
 var log = logutils.NewPackageLogger(teleport.ComponentKey, teleport.ComponentTBot)
@@ -87,6 +88,15 @@ type GitlabOnboardingConfig struct {
 	// GitLab ID token. This can be useful to override in cases where a single
 	// gitlab job needs to authenticate to multiple Teleport clusters.
 	TokenEnvVarName string `yaml:"token_env_var_name,omitempty"`
+}
+
+// BoundKeypairOnboardingConfig contains parameters for the `bound_keypair` join
+// method
+type BoundKeypairOnboardingConfig struct {
+	// InitialJoinSecret is the name of the initial joining secret, if any. If
+	// not specified, a keypair must be created using `tbot keypair create` and
+	// registered with Teleport in advance.
+	InitialJoinSecret string
 }
 
 // OnboardingConfig contains values relevant to how the bot authenticates with
@@ -118,6 +128,9 @@ type OnboardingConfig struct {
 
 	// Gitlab holds configuration relevant to the `gitlab` join method.
 	Gitlab GitlabOnboardingConfig `yaml:"gitlab,omitempty"`
+
+	// BoundKeypair holds configuration relevant to the `bound_keypair` join method
+	BoundKeypair BoundKeypairOnboardingConfig `yaml:"bound_keypair,omitempty"`
 }
 
 // HasToken gives the ability to check if there has been a token value stored

--- a/lib/tbot/config/destination_bound_keypair_adapter.go
+++ b/lib/tbot/config/destination_bound_keypair_adapter.go
@@ -21,8 +21,9 @@ package config
 import (
 	"context"
 
-	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/tbot/bot"
 )
 
 // BoundKeypairBotFSAdapter is an adapter to use bot destinations with the FS

--- a/lib/tbot/config/destination_bound_keypair_adapter.go
+++ b/lib/tbot/config/destination_bound_keypair_adapter.go
@@ -1,0 +1,54 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package config
+
+import (
+	"context"
+
+	"github.com/gravitational/teleport/lib/tbot/bot"
+	"github.com/gravitational/trace"
+)
+
+// BoundKeypairBotFSAdapter is an adapter to use bot destinations with the FS
+// abstraction for bound keypair joining. This allows keypair and state storage
+// to be written to all supported bot destination types.
+type BoundKeypairDestinationAdapter struct {
+	destination bot.Destination
+}
+
+func (f *BoundKeypairDestinationAdapter) Read(ctx context.Context, name string) ([]byte, error) {
+	bytes, err := f.destination.Read(ctx, name)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return bytes, nil
+}
+
+func (f *BoundKeypairDestinationAdapter) Write(ctx context.Context, name string, data []byte) error {
+	return trace.Wrap(f.destination.Write(ctx, name, data))
+}
+
+// NewBoundkeypairDestinationAdapter creates a new destination adapter for bound
+// keypair loading and storage.
+func NewBoundkeypairDestinationAdapter(d bot.Destination) *BoundKeypairDestinationAdapter {
+	return &BoundKeypairDestinationAdapter{
+		destination: d,
+	}
+}

--- a/lib/tbot/service_bot_identity.go
+++ b/lib/tbot/service_bot_identity.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/join"
+	"github.com/gravitational/teleport/lib/auth/join/boundkeypair"
 	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/cryptosuites"
@@ -486,6 +487,20 @@ func botIdentityFromToken(
 		params.GitlabParams = join.GitlabParams{
 			EnvVarName: cfg.Onboarding.Gitlab.TokenEnvVarName,
 		}
+	}
+
+	if params.JoinMethod == types.JoinMethodBoundKeypair {
+		joinSecret := cfg.Onboarding.BoundKeypair.InitialJoinSecret
+
+		adapter := config.NewBoundkeypairDestinationAdapter(cfg.Storage.Destination)
+		state, err := boundkeypair.LoadClientState(ctx, adapter)
+		if trace.IsNotFound(err) && joinSecret != "" {
+			return nil, trace.NotImplemented("no existing client state was found and join secrets are not yet supported")
+		} else if err != nil {
+			return nil, trace.Wrap(err, "loading bound keypair client state")
+		}
+
+		params.BoundKeypairParams = state.ToJoinParams(joinSecret)
 	}
 
 	result, err := join.Register(ctx, params)

--- a/tool/tbot/keypair.go
+++ b/tool/tbot/keypair.go
@@ -24,6 +24,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/gravitational/trace"
+
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/types"
@@ -31,7 +33,6 @@ import (
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/tbot/cli"
 	"github.com/gravitational/teleport/lib/tbot/config"
-	"github.com/gravitational/trace"
 )
 
 // getSuiteFromProxy fetches cryptosuite config from the given remote proxy.
@@ -88,7 +89,7 @@ func printKeypair(state *boundkeypair.ClientState, format string) error {
 
 		fmt.Printf("%s\n", string(bytes))
 	default:
-		return trace.BadParameter("unsupported output format %s; keypair has been generated")
+		return trace.BadParameter("unsupported output format %s; keypair has been generated", format)
 	}
 
 	return nil

--- a/tool/tbot/keypair.go
+++ b/tool/tbot/keypair.go
@@ -1,0 +1,90 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gravitational/teleport/api/client/webclient"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/join/boundkeypair"
+	"github.com/gravitational/teleport/lib/cryptosuites"
+	"github.com/gravitational/teleport/lib/tbot/cli"
+	"github.com/gravitational/teleport/lib/tbot/config"
+	"github.com/gravitational/trace"
+)
+
+func getSuiteFromProxy(proxyAddr string, insecure bool) cryptosuites.GetSuiteFunc {
+	return func(ctx context.Context) (types.SignatureAlgorithmSuite, error) {
+		pr, err := webclient.Find(&webclient.Config{
+			Context:   ctx,
+			ProxyAddr: proxyAddr,
+			Insecure:  insecure,
+		})
+		if err != nil {
+			return types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_UNSPECIFIED, trace.Wrap(err, "pinging proxy to determine signature algorithm suite")
+		}
+		return pr.Auth.SignatureAlgorithmSuite, nil
+	}
+}
+
+func onKeypairCreateCommand(ctx context.Context, globals *cli.GlobalArgs, cmd *cli.KeypairCreateCommand) error {
+	dest, err := config.DestinationFromURI(cmd.Storage)
+	if err != nil {
+		return trace.Wrap(err, "parsing storage URI")
+	}
+
+	if err := dest.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err, "initializing storage")
+	}
+
+	state, err := boundkeypair.NewUnboundClientState(
+		ctx,
+		getSuiteFromProxy(cmd.ProxyServer, globals.Insecure),
+	)
+	if err != nil {
+		return trace.Wrap(err, "initializing new client state")
+	}
+
+	if err := boundkeypair.StoreClientState(ctx, config.NewBoundkeypairDestinationAdapter(dest), state); err != nil {
+		return trace.Wrap(err, "writing bound keypair state")
+	}
+
+	log.InfoContext(
+		ctx,
+		"keypair has been written to storage",
+		"storage", dest.String(),
+	)
+
+	publicKeyBytes, err := state.ToPublicKeyBytes()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// TODO: maybe just print out an example token resource to copy and paste? Or a tctl command.
+	fmt.Printf(
+		"\nTo register the keypair with Teleport, include this public key in the token's\n"+
+			"`spec.bound_keypair.onboarding.initial_public_key`:\n\n"+
+			"\t%s\n\n",
+		string(publicKeyBytes),
+	)
+
+	return nil
+}

--- a/tool/tbot/keypair.go
+++ b/tool/tbot/keypair.go
@@ -34,7 +34,12 @@ import (
 	"github.com/gravitational/trace"
 )
 
+// getSuiteFromProxy fetches cryptosuite config from the given remote proxy.
 func getSuiteFromProxy(proxyAddr string, insecure bool) cryptosuites.GetSuiteFunc {
+	// TODO: It's annoying to need to specify a proxy here. This won't be needed
+	// for keypairs generated at normal runtime since we'll have a proxy address
+	// available, but alternatives should be explored, since this UX is not
+	// good.
 	return func(ctx context.Context) (types.SignatureAlgorithmSuite, error) {
 		pr, err := webclient.Find(&webclient.Config{
 			Context:   ctx,
@@ -48,10 +53,14 @@ func getSuiteFromProxy(proxyAddr string, insecure bool) cryptosuites.GetSuiteFun
 	}
 }
 
+// KeypairDocument is the JSON struct printed to stdout when `--format=json` is
+// specified.
 type KeypairDocument struct {
 	PublicKey string `json:"public_key"`
 }
 
+// printKeypair prints the current keypair from the given client state using the
+// specified format.
 func printKeypair(state *boundkeypair.ClientState, format string) error {
 	publicKeyBytes, err := state.ToPublicKeyBytes()
 	if err != nil {
@@ -85,6 +94,7 @@ func printKeypair(state *boundkeypair.ClientState, format string) error {
 	return nil
 }
 
+// onKeypairCreate command handles `tbot keypair create`
 func onKeypairCreateCommand(ctx context.Context, globals *cli.GlobalArgs, cmd *cli.KeypairCreateCommand) error {
 	dest, err := config.DestinationFromURI(cmd.Storage)
 	if err != nil {

--- a/tool/tbot/keypair.go
+++ b/tool/tbot/keypair.go
@@ -70,7 +70,6 @@ func printKeypair(state *boundkeypair.ClientState, format string) error {
 			keyString,
 		)
 	case teleport.JSON:
-
 		bytes, err := json.Marshal(&KeypairDocument{
 			PublicKey: keyString,
 		})

--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -84,6 +84,8 @@ func Run(args []string, stdout io.Writer) error {
 	configureCmd := app.Command("configure", "Creates a config file based on flags provided, and writes it to stdout or a file (-c <path>).")
 	configureCmd.Flag("output", "Path to write the generated configuration file to rather than write to stdout.").Short('o').StringVar(&configureOutPath)
 
+	keypairCmd := app.Command("keypair", "Manage keypairs for bound-keypair joining")
+
 	// TODO: consider discarding config flag for non-legacy. These should always be self contained.
 
 	// Initialize all new-style commands.
@@ -115,6 +117,10 @@ func Run(args []string, stdout io.Writer) error {
 
 		cli.NewKubeCredentialsCommand(kubeCmd, func(kubeCredentialsCmd *cli.KubeCredentialsCommand) error {
 			return onKubeCredentialsCommand(ctx, kubeCredentialsCmd)
+		}),
+
+		cli.NewKeypairCreateCommand(keypairCmd, func(keypairCreateCmd *cli.KeypairCreateCommand) error {
+			return onKeypairCreateCommand(ctx, globalCfg, keypairCreateCmd)
 		}),
 
 		// `start` and `configure` commands


### PR DESCRIPTION
This contains a minimal client-side implementation of bound keypair joining for `tbot`. This first iteration supports only preregistered keys, and so adds a new `tbot keypair create` subcommand that generates a keypair and prints a public key that can be copied into a token.

In an effort to still take advantange of tbot's secure filesystem abstraction and to not permanently tie the new join method to it, this includes a minimal filesystem wrapper to adapt tbot's destinations to a generic file read/write interface.

Protos PR: https://github.com/gravitational/teleport/pull/53566
Backend PR: https://github.com/gravitational/teleport/pull/54371
RFD: https://github.com/gravitational/teleport/pull/52546

changelog: Add experimental support for Bound Keypair joining