### PR TITLE
Convert notifications to new in memory cache collection

### DIFF
--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -45,7 +45,6 @@ import (
 	dbobjectv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobject/v1"
 	identitycenterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/identitycenter/v1"
 	kubewaitingcontainerpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1"
-	notificationsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
 	provisioningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/provisioning/v1"
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
@@ -535,7 +534,6 @@ type Cache struct {
 	eventsFanout                 *services.FanoutV2
 	lowVolumeEventsFanout        *utils.RoundRobin[*services.FanoutV2]
 	kubeWaitingContsCache        *local.KubeWaitingContainerService
-	notificationsCache           services.Notifications
 	accessMontoringRuleCache     services.AccessMonitoringRules
 	staticHostUsersCache         *local.StaticHostUserService
 	provisioningStatesCache      *local.ProvisioningStateService
@@ -994,12 +992,6 @@ func New(config Config) (*Cache, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	notificationsCache, err := local.NewNotificationsService(config.Backend, config.Clock)
-	if err != nil {
-		cancel()
-		return nil, trace.Wrap(err)
-	}
-
 	accessMonitoringRuleCache, err := local.NewAccessMonitoringRulesService(config.Backend)
 	if err != nil {
 		cancel()
@@ -1106,7 +1098,6 @@ func New(config Config) (*Cache, error) {
 		userLoginStateCache:          userLoginStatesCache,
 		accessListCache:              accessListCache,
 		databaseObjectsCache:         databaseObjectsCache,
-		notificationsCache:           notificationsCache,
 		eventsFanout:                 fanout,
 		lowVolumeEventsFanout:        utils.NewRoundRobin(lowVolumeFanouts),
 		kubeWaitingContsCache:        kubeWaitingContsCache,
@@ -2979,36 +2970,6 @@ func (c *Cache) ListAccessListReviews(ctx context.Context, accessList string, pa
 	}
 	defer rg.Release()
 	return rg.reader.ListAccessListReviews(ctx, accessList, pageSize, pageToken)
-}
-
-// ListUserNotifications returns a paginated list of user-specific notifications for all users.
-func (c *Cache) ListUserNotifications(ctx context.Context, pageSize int, startKey string) ([]*notificationsv1.Notification, string, error) {
-	ctx, span := c.Tracer.Start(ctx, "cache/ListUserNotifications")
-	defer span.End()
-
-	rg, err := readLegacyCollectionCache(c, c.legacyCacheCollections.userNotifications)
-	if err != nil {
-		return nil, "", trace.Wrap(err)
-	}
-
-	defer rg.Release()
-
-	out, nextKey, err := rg.reader.ListUserNotifications(ctx, pageSize, startKey)
-	return out, nextKey, trace.Wrap(err)
-}
-
-// ListGlobalNotifications returns a paginated list of global notifications.
-func (c *Cache) ListGlobalNotifications(ctx context.Context, pageSize int, startKey string) ([]*notificationsv1.GlobalNotification, string, error) {
-	ctx, span := c.Tracer.Start(ctx, "cache/ListGlobalNotifications")
-	defer span.End()
-
-	rg, err := readLegacyCollectionCache(c, c.legacyCacheCollections.globalNotifications)
-	if err != nil {
-		return nil, "", trace.Wrap(err)
-	}
-	defer rg.Release()
-	out, nextKey, err := rg.reader.ListGlobalNotifications(ctx, pageSize, startKey)
-	return out, nextKey, trace.Wrap(err)
 }
 
 // ListAccessMonitoringRules returns a paginated list of access monitoring rules.

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -2035,34 +2035,6 @@ func TestAccessListReviews(t *testing.T) {
 	})
 }
 
-// TestUserNotifications tests that CRUD operations on user notification resources are
-// replicated from the backend to the cache.
-func TestUserNotifications(t *testing.T) {
-	t.Parallel()
-
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	testResources153(t, p, testFuncs153[*notificationsv1.Notification]{
-		newResource: func(name string) (*notificationsv1.Notification, error) {
-			return newUserNotification(t, name), nil
-		},
-		create: func(ctx context.Context, item *notificationsv1.Notification) error {
-			_, err := p.notifications.CreateUserNotification(ctx, item)
-			return trace.Wrap(err)
-		},
-		list: func(ctx context.Context) ([]*notificationsv1.Notification, error) {
-			items, _, err := p.notifications.ListUserNotifications(ctx, 0, "")
-			return items, trace.Wrap(err)
-		},
-		cacheList: func(ctx context.Context) ([]*notificationsv1.Notification, error) {
-			items, _, err := p.cache.ListUserNotifications(ctx, 0, "")
-			return items, trace.Wrap(err)
-		},
-		deleteAll: p.notifications.DeleteAllUserNotifications,
-	})
-}
-
 // TestCrownJewel tests that CRUD operations on user notification resources are
 // replicated from the backend to the cache.
 func TestCrownJewel(t *testing.T) {
@@ -2247,34 +2219,6 @@ func TestAutoUpdateAgentRollout(t *testing.T) {
 		deleteAll: func(ctx context.Context) error {
 			return trace.Wrap(p.autoUpdateService.DeleteAutoUpdateAgentRollout(ctx))
 		},
-	})
-}
-
-// TestGlobalNotifications tests that CRUD operations on global notification resources are
-// replicated from the backend to the cache.
-func TestGlobalNotifications(t *testing.T) {
-	t.Parallel()
-
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	testResources153(t, p, testFuncs153[*notificationsv1.GlobalNotification]{
-		newResource: func(name string) (*notificationsv1.GlobalNotification, error) {
-			return newGlobalNotification(t, name), nil
-		},
-		create: func(ctx context.Context, item *notificationsv1.GlobalNotification) error {
-			_, err := p.notifications.CreateGlobalNotification(ctx, item)
-			return trace.Wrap(err)
-		},
-		list: func(ctx context.Context) ([]*notificationsv1.GlobalNotification, error) {
-			items, _, err := p.notifications.ListGlobalNotifications(ctx, 0, "")
-			return items, trace.Wrap(err)
-		},
-		cacheList: func(ctx context.Context) ([]*notificationsv1.GlobalNotification, error) {
-			items, _, err := p.cache.ListGlobalNotifications(ctx, 0, "")
-			return items, trace.Wrap(err)
-		},
-		deleteAll: p.notifications.DeleteAllGlobalNotifications,
 	})
 }
 

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -24,6 +24,7 @@ import (
 	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
 	identitycenterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/identitycenter/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	notificationsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
 	workloadidentityv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 )
@@ -75,6 +76,8 @@ type collections struct {
 	reverseTunnels                   *collection[types.ReverseTunnel]
 	spiffeFederations                *collection[*machineidv1.SPIFFEFederation]
 	workloadIdentity                 *collection[*workloadidentityv1.WorkloadIdentity]
+	userNotifications                *collection[*notificationsv1.Notification]
+	globalNotifications              *collection[*notificationsv1.GlobalNotification]
 }
 
 // setupCollections ensures that the appropriate [collection] is
@@ -273,6 +276,22 @@ func setupCollections(c Config) (*collections, error) {
 
 			out.workloadIdentity = collect
 			out.byKind[resourceKind] = out.workloadIdentity
+		case types.KindNotification:
+			collect, err := newUserNotificationCollection(c.Notifications, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out.userNotifications = collect
+			out.byKind[resourceKind] = out.userNotifications
+		case types.KindGlobalNotification:
+			collect, err := newGlobalNotificationCollection(c.Notifications, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out.globalNotifications = collect
+			out.byKind[resourceKind] = out.globalNotifications
 		}
 	}
 

--- a/lib/cache/notification.go
+++ b/lib/cache/notification.go
@@ -1,0 +1,136 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	notificationsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+const userNotificationStoreNameIndex = "name"
+
+func newUserNotificationCollection(upstream services.NotificationGetter, w types.WatchKind) (*collection[*notificationsv1.Notification], error) {
+	if upstream == nil {
+		return nil, trace.BadParameter("missing parameter NotificationGetter")
+	}
+
+	return &collection[*notificationsv1.Notification]{
+		store: newStore(map[string]func(*notificationsv1.Notification) string{
+			userNotificationStoreNameIndex: func(r *notificationsv1.Notification) string {
+				return r.GetMetadata().GetName()
+			},
+		}),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]*notificationsv1.Notification, error) {
+			var notifications []*notificationsv1.Notification
+			var startKey string
+			for {
+				notifs, nextKey, err := upstream.ListUserNotifications(ctx, 0, startKey)
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+				notifications = append(notifications, notifs...)
+
+				if nextKey == "" {
+					break
+				}
+				startKey = nextKey
+			}
+
+			return notifications, nil
+		},
+		watch: w,
+	}, nil
+}
+
+// ListUserNotifications returns a paginated list of user-specific notifications for all users.
+func (c *Cache) ListUserNotifications(ctx context.Context, pageSize int, startKey string) ([]*notificationsv1.Notification, string, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/ListUserNotifications")
+	defer span.End()
+
+	lister := genericLister[*notificationsv1.Notification]{
+		cache:        c,
+		collection:   c.collections.userNotifications,
+		index:        userNotificationStoreNameIndex,
+		upstreamList: c.Config.Notifications.ListUserNotifications,
+		nextToken: func(t *notificationsv1.Notification) string {
+			return t.GetMetadata().GetName()
+		},
+		clone: utils.CloneProtoMsg[*notificationsv1.Notification],
+	}
+	out, next, err := lister.list(ctx, pageSize, startKey)
+	return out, next, trace.Wrap(err)
+}
+
+const globalNotificationStoreNameIndex = "name"
+
+func newGlobalNotificationCollection(upstream services.NotificationGetter, w types.WatchKind) (*collection[*notificationsv1.GlobalNotification], error) {
+	if upstream == nil {
+		return nil, trace.BadParameter("missing parameter NotificationGetter")
+	}
+
+	return &collection[*notificationsv1.GlobalNotification]{
+		store: newStore(map[string]func(*notificationsv1.GlobalNotification) string{
+			userNotificationStoreNameIndex: func(r *notificationsv1.GlobalNotification) string {
+				return r.GetMetadata().GetName()
+			},
+		}),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]*notificationsv1.GlobalNotification, error) {
+			var notifications []*notificationsv1.GlobalNotification
+			var startKey string
+			for {
+				notifs, nextKey, err := upstream.ListGlobalNotifications(ctx, 0, startKey)
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+				notifications = append(notifications, notifs...)
+
+				if nextKey == "" {
+					break
+				}
+				startKey = nextKey
+			}
+
+			return notifications, nil
+		},
+		watch: w,
+	}, nil
+}
+
+// ListGlobalNotifications returns a paginated list of global notifications.
+func (c *Cache) ListGlobalNotifications(ctx context.Context, pageSize int, startKey string) ([]*notificationsv1.GlobalNotification, string, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/ListGlobalNotifications")
+	defer span.End()
+
+	lister := genericLister[*notificationsv1.GlobalNotification]{
+		cache:        c,
+		collection:   c.collections.globalNotifications,
+		index:        globalNotificationStoreNameIndex,
+		upstreamList: c.Config.Notifications.ListGlobalNotifications,
+		nextToken: func(t *notificationsv1.GlobalNotification) string {
+			return t.GetMetadata().GetName()
+		},
+		clone: utils.CloneProtoMsg[*notificationsv1.GlobalNotification],
+	}
+	out, next, err := lister.list(ctx, pageSize, startKey)
+	return out, next, trace.Wrap(err)
+}

--- a/lib/cache/notification_test.go
+++ b/lib/cache/notification_test.go
@@ -1,0 +1,82 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/trace"
+
+	notificationsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
+)
+
+// TestUserNotifications tests that CRUD operations on user notification resources are
+// replicated from the backend to the cache.
+func TestUserNotifications(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	testResources153(t, p, testFuncs153[*notificationsv1.Notification]{
+		newResource: func(name string) (*notificationsv1.Notification, error) {
+			return newUserNotification(t, name), nil
+		},
+		create: func(ctx context.Context, item *notificationsv1.Notification) error {
+			_, err := p.notifications.CreateUserNotification(ctx, item)
+			return trace.Wrap(err)
+		},
+		list: func(ctx context.Context) ([]*notificationsv1.Notification, error) {
+			items, _, err := p.notifications.ListUserNotifications(ctx, 0, "")
+			return items, trace.Wrap(err)
+		},
+		cacheList: func(ctx context.Context) ([]*notificationsv1.Notification, error) {
+			items, _, err := p.cache.ListUserNotifications(ctx, 0, "")
+			return items, trace.Wrap(err)
+		},
+		deleteAll: p.notifications.DeleteAllUserNotifications,
+	})
+}
+
+// TestGlobalNotifications tests that CRUD operations on global notification resources are
+// replicated from the backend to the cache.
+func TestGlobalNotifications(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	testResources153(t, p, testFuncs153[*notificationsv1.GlobalNotification]{
+		newResource: func(name string) (*notificationsv1.GlobalNotification, error) {
+			return newGlobalNotification(t, name), nil
+		},
+		create: func(ctx context.Context, item *notificationsv1.GlobalNotification) error {
+			_, err := p.notifications.CreateGlobalNotification(ctx, item)
+			return trace.Wrap(err)
+		},
+		list: func(ctx context.Context) ([]*notificationsv1.GlobalNotification, error) {
+			items, _, err := p.notifications.ListGlobalNotifications(ctx, 0, "")
+			return items, trace.Wrap(err)
+		},
+		cacheList: func(ctx context.Context) ([]*notificationsv1.GlobalNotification, error) {
+			items, _, err := p.cache.ListGlobalNotifications(ctx, 0, "")
+			return items, trace.Wrap(err)
+		},
+		deleteAll: p.notifications.DeleteAllGlobalNotifications,
+	})
+}


### PR DESCRIPTION
Moves user and global notifications to the new cache collection scheme that was introduced in #52210. No additional functionality changes have been made here. This should be a purely mechanical translation to the new internal caching machinery.