### PR TITLE
[v17] Increase the timeout for sending e-mails from 5 to 15 seconds

### DIFF
--- a/integrations/access/email/app.go
+++ b/integrations/access/email/app.go
@@ -42,7 +42,7 @@ const (
 	// initTimeout is used to bound execution time of health check and teleport version check.
 	initTimeout = time.Second * 10
 	// handlerTimeout is used to bound the execution time of watcher event handler.
-	handlerTimeout = time.Second * 5
+	handlerTimeout = time.Second * 15
 	// maxModifyPluginDataTries is a maximum number of compare-and-swap tries when modifying plugin data.
 	maxModifyPluginDataTries = 5
 )


### PR DESCRIPTION
Backport #53990 to branch/v17

changelog: Increased the email access plugin timeout for sending e-mails from 5 to 15 seconds
