### PR TITLE
[v17] MWI: Include expiration time in AWS Roles Anywhere output

### DIFF
--- a/lib/tbot/service_workload_identity_aws_ra_test.go
+++ b/lib/tbot/service_workload_identity_aws_ra_test.go
@@ -46,6 +46,7 @@ func Test_renderAWSCreds(t *testing.T) {
 		AccessKeyId:     "AKIAIOSFODNN7EXAMPLEAKID",
 		SessionToken:    "AQoDYXdzEJrtyWJ4NjK7PiEXAMPLEST",
 		SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLESAK",
+		Expiration:      "2028-07-27T04:36:55Z",
 	}
 	ctx := context.Background()
 

--- a/lib/tbot/testdata/TestBotWorkloadIdentityAWSRA.golden
+++ b/lib/tbot/testdata/TestBotWorkloadIdentityAWSRA.golden
@@ -2,3 +2,4 @@
 aws_secret_access_key=secretAccessKey
 aws_access_key_id=accessKeyId
 aws_session_token=sessionToken
+expiration=1848285415000

--- a/lib/tbot/testdata/Test_renderAWSCreds/merge_with_existing_data.golden
+++ b/lib/tbot/testdata/Test_renderAWSCreds/merge_with_existing_data.golden
@@ -7,3 +7,4 @@ aws_session_token=existing
 aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLESAK
 aws_access_key_id=AKIAIOSFODNN7EXAMPLEAKID
 aws_session_token=AQoDYXdzEJrtyWJ4NjK7PiEXAMPLEST
+expiration=1848285415000

--- a/lib/tbot/testdata/Test_renderAWSCreds/normal.golden
+++ b/lib/tbot/testdata/Test_renderAWSCreds/normal.golden
@@ -2,3 +2,4 @@
 aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLESAK
 aws_access_key_id=AKIAIOSFODNN7EXAMPLEAKID
 aws_session_token=AQoDYXdzEJrtyWJ4NjK7PiEXAMPLEST
+expiration=1848285415000

--- a/lib/tbot/testdata/Test_renderAWSCreds/overwrite_existing_data.golden
+++ b/lib/tbot/testdata/Test_renderAWSCreds/overwrite_existing_data.golden
@@ -2,3 +2,4 @@
 aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLESAK
 aws_access_key_id=AKIAIOSFODNN7EXAMPLEAKID
 aws_session_token=AQoDYXdzEJrtyWJ4NjK7PiEXAMPLEST
+expiration=1848285415000

--- a/lib/tbot/testdata/Test_renderAWSCreds/replace_with_existing_data.golden
+++ b/lib/tbot/testdata/Test_renderAWSCreds/replace_with_existing_data.golden
@@ -2,3 +2,4 @@
 aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLESAK
 aws_access_key_id=AKIAIOSFODNN7EXAMPLEAKID
 aws_session_token=AQoDYXdzEJrtyWJ4NjK7PiEXAMPLEST
+expiration=1848285415000

--- a/lib/tbot/testdata/Test_renderAWSCreds/with_artifact_name_override.golden
+++ b/lib/tbot/testdata/Test_renderAWSCreds/with_artifact_name_override.golden
@@ -2,3 +2,4 @@
 aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLESAK
 aws_access_key_id=AKIAIOSFODNN7EXAMPLEAKID
 aws_session_token=AQoDYXdzEJrtyWJ4NjK7PiEXAMPLEST
+expiration=1848285415000

--- a/lib/tbot/testdata/Test_renderAWSCreds/with_named_profile.golden
+++ b/lib/tbot/testdata/Test_renderAWSCreds/with_named_profile.golden
@@ -2,3 +2,4 @@
 aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLESAK
 aws_access_key_id=AKIAIOSFODNN7EXAMPLEAKID
 aws_session_token=AQoDYXdzEJrtyWJ4NjK7PiEXAMPLEST
+expiration=1848285415000


### PR DESCRIPTION
Backport #54339 to branch/v17

changelog: AWS Roles Anywhere output now includes the expiration time as milliseconds since unix epoch
