### PR TITLE
docs: update helm example

### DIFF
--- a/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/aws.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/aws.mdx
@@ -425,8 +425,6 @@ pod/teleport-proxy-c6bf55cfc-z256w   1/1     Running   0          22h
 NAME                        TYPE           CLUSTER-IP     EXTERNAL-IP                         PORT(S)                                                                     AGE
 service/teleport            LoadBalancer   10.40.11.180   xxxxx.elb.us-east-1.amazonaws.com   443:30258/TCP                                                               22h
 service/teleport-auth       ClusterIP      10.40.8.251    <none>                              3025/TCP,3026/TCP                                                           22h
-service/teleport-auth-v11   ClusterIP      None           <none>                              <none>                                                                      22h
-service/teleport-auth-v12   ClusterIP      None           <none>                              <none>                                                                      22h
 
 NAME                             READY   UP-TO-DATE   AVAILABLE   AGE
 deployment.apps/teleport-auth    2/2     2            2           22h

--- a/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/azure.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/azure.mdx
@@ -225,8 +225,6 @@ pod/teleport-proxy-c6bf55cfc-z256w   1/1     Running   0          22h
 NAME                        TYPE           CLUSTER-IP     EXTERNAL-IP     PORT(S)                                                                     AGE
 service/teleport            LoadBalancer   10.40.11.180   34.138.177.11   443:30258/TCP,3023:31802/TCP,3026:32182/TCP,3024:30101/TCP,3036:30302/TCP   22h
 service/teleport-auth       ClusterIP      10.40.8.251    <none>          3025/TCP,3026/TCP                                                           22h
-service/teleport-auth-v13   ClusterIP      None           <none>          <none>                                                                      22h
-service/teleport-auth-v14   ClusterIP      None           <none>          <none>                                                                      22h
 
 NAME                             READY   UP-TO-DATE   AVAILABLE   AGE
 deployment.apps/teleport-auth    2/2     2            2           22h

--- a/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/custom.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/custom.mdx
@@ -188,8 +188,6 @@ pod/teleport-proxy-c6bf55cfc-z256w   1/1     Running   0          22h
 NAME                        TYPE           CLUSTER-IP     EXTERNAL-IP     PORT(S)                                                                     AGE
 service/teleport            LoadBalancer   10.40.11.180   34.138.177.11   443:30258/TCP,3023:31802/TCP,3026:32182/TCP,3024:30101/TCP,3036:30302/TCP   22h
 service/teleport-auth       ClusterIP      10.40.8.251    <none>          3025/TCP,3026/TCP                                                           22h
-service/teleport-auth-v11   ClusterIP      None           <none>          <none>                                                                      22h
-service/teleport-auth-v12   ClusterIP      None           <none>          <none>                                                                      22h
 
 NAME                             READY   UP-TO-DATE   AVAILABLE   AGE
 deployment.apps/teleport-auth    1/1     1            1           22h

--- a/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/gcp.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/helm-deployments/gcp.mdx
@@ -346,8 +346,6 @@ pod/teleport-proxy-c6bf55cfc-z256w   1/1     Running   0          22h
 NAME                        TYPE           CLUSTER-IP     EXTERNAL-IP     PORT(S)                                                                     AGE
 service/teleport            LoadBalancer   10.40.11.180   34.138.177.11   443:30258/TCP,3023:31802/TCP,3026:32182/TCP,3024:30101/TCP,3036:30302/TCP   22h
 service/teleport-auth       ClusterIP      10.40.8.251    <none>          3025/TCP,3026/TCP                                                           22h
-service/teleport-auth-v11   ClusterIP      None           <none>          <none>                                                                      22h
-service/teleport-auth-v12   ClusterIP      None           <none>          <none>                                                                      22h
 
 NAME                             READY   UP-TO-DATE   AVAILABLE   AGE
 deployment.apps/teleport-auth    2/2     2            2           22h


### PR DESCRIPTION
Removing `teleport-auth-v#` in `kubectl get all` example. These only apply for existing installations, not first time.