### PR TITLE
Auth: Initialize VNet config

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -637,6 +637,9 @@ const (
 	// access graph settings.
 	MetaNameAccessGraphSettings = "access-graph-settings"
 
+	// MetaNameVnetConfig is the exact name of the singleton resource holding VNet config.
+	MetaNameVnetConfig = "vnet-config"
+
 	// V8 is the eighth version of resources.
 	V8 = "v8"
 

--- a/api/types/vnet/vnet.go
+++ b/api/types/vnet/vnet.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/gravitational/trace"
 
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
 	"github.com/gravitational/teleport/api/types"
 )
@@ -28,6 +29,29 @@ const (
 	// VNet config of the cluster doesn't specify any range.
 	DefaultIPv4CIDRRange = "100.64.0.0/10"
 )
+
+// NewVnetConfig initializes a new VNet config resource given the spec.
+func NewVnetConfig(spec *vnet.VnetConfigSpec) (*vnet.VnetConfig, error) {
+	config := &vnet.VnetConfig{
+		Kind:    types.KindVnetConfig,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: types.MetaNameVnetConfig,
+		},
+		Spec: spec,
+	}
+
+	if err := ValidateVnetConfig(config); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return config, nil
+}
+
+// DefaultVnetConfig returns the default VNet config.
+func DefaultVnetConfig() (*vnet.VnetConfig, error) {
+	return NewVnetConfig(&vnet.VnetConfigSpec{Ipv4CidrRange: DefaultIPv4CIDRRange})
+}
 
 // ValidateVnetConfig validates the provided VNet config resource.
 func ValidateVnetConfig(vnetConfig *vnet.VnetConfig) error {

--- a/api/types/vnet/vnet.go
+++ b/api/types/vnet/vnet.go
@@ -1,0 +1,59 @@
+// Copyright 2025 Gravitational, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vnet
+
+import (
+	"net"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
+	"github.com/gravitational/teleport/api/types"
+)
+
+const (
+	// DefaultIPv4CIDRRange is the range VNet is going to use to assign addresses to resources if the
+	// VNet config of the cluster doesn't specify any range.
+	DefaultIPv4CIDRRange = "100.64.0.0/10"
+)
+
+// ValidateVnetConfig validates the provided VNet config resource.
+func ValidateVnetConfig(vnetConfig *vnet.VnetConfig) error {
+	if vnetConfig.GetKind() != types.KindVnetConfig {
+		return trace.BadParameter("kind must be %q", types.KindVnetConfig)
+	}
+	if vnetConfig.GetVersion() != types.V1 {
+		return trace.BadParameter("version must be %q", types.V1)
+	}
+	if vnetConfig.GetMetadata().GetName() != types.MetaNameVnetConfig {
+		return trace.BadParameter("name must be %q", types.MetaNameVnetConfig)
+	}
+	if cidrRange := vnetConfig.GetSpec().GetIpv4CidrRange(); cidrRange != "" {
+		ip, _, err := net.ParseCIDR(cidrRange)
+		if err != nil {
+			return trace.Wrap(err, "parsing ipv4_cidr_range")
+		}
+		if ip4 := ip.To4(); ip4 == nil {
+			return trace.BadParameter("ipv4_cidr_range must be valid IPv4")
+		}
+	}
+	for _, zone := range vnetConfig.GetSpec().GetCustomDnsZones() {
+		suffix := zone.GetSuffix()
+		if len(suffix) == 0 {
+			return trace.BadParameter("custom_dns_zone must have a non-empty suffix")
+		}
+	}
+	return nil
+}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -448,6 +448,12 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 			return nil, trace.Wrap(err, "creating BackendInfo service")
 		}
 	}
+	if cfg.VnetConfigService == nil {
+		cfg.VnetConfigService, err = local.NewVnetConfigService(cfg.Backend)
+		if err != nil {
+			return nil, trace.Wrap(err, "creating VnetConfigService")
+		}
+	}
 
 	if cfg.Logger == nil {
 		cfg.Logger = slog.With(teleport.ComponentKey, teleport.ComponentAuth)
@@ -555,6 +561,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 		SigstorePolicies:                cfg.SigstorePolicies,
 		HealthCheckConfig:               cfg.HealthCheckConfig,
 		BackendInfoService:              cfg.BackendInfo,
+		VnetConfigService:               cfg.VnetConfigService,
 	}
 
 	as := Server{
@@ -792,6 +799,7 @@ type Services struct {
 	services.SigstorePolicies
 	services.HealthCheckConfig
 	services.BackendInfoService
+	services.VnetConfigService
 }
 
 // GetWebSession returns existing web session described by req.

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -5627,11 +5627,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	}
 	notificationsv1pb.RegisterNotificationServiceServer(server, notificationsServer)
 
-	vnetConfigStorage, err := local.NewVnetConfigService(cfg.AuthServer.bk)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	vnetConfigServiceServer := vnetconfigv1.NewService(vnetConfigStorage, cfg.Authorizer)
+	vnetConfigServiceServer := vnetconfigv1.NewService(cfg.AuthServer.VnetConfigService, cfg.Authorizer)
 	vnetv1pb.RegisterVnetConfigServiceServer(server, vnetConfigServiceServer)
 
 	staticHostUserServer, err := userprovisioningv2.NewService(userprovisioningv2.ServiceConfig{

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -5297,7 +5297,6 @@ func TestGetVnetConfig(t *testing.T) {
 	require.NoError(t, err)
 	actualConfig, err := client.GetVnetConfig(t.Context())
 	require.NoError(t, err)
-	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(createdConfig, actualConfig, protocmp.Transform()))
 }
 

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -373,6 +373,9 @@ type InitConfig struct {
 
 	// SkipVersionCheck skips version check during major version upgrade/downgrade.
 	SkipVersionCheck bool
+
+	// VnetConfigService manages the VNet config resource.
+	VnetConfigService services.VnetConfigService
 }
 
 // Init instantiates and configures an instance of AuthServer

--- a/lib/services/local/vnet_config.go
+++ b/lib/services/local/vnet_config.go
@@ -19,7 +19,6 @@ package local
 import (
 	"context"
 	"log/slog"
-	"net"
 
 	"github.com/gravitational/trace"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -27,14 +26,10 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
 	"github.com/gravitational/teleport/api/types"
+	typesvnet "github.com/gravitational/teleport/api/types/vnet"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local/generic"
-)
-
-const (
-	vnetConfigPrefix        = "vnet_config"
-	vnetConfigSingletonName = "vnet-config"
 )
 
 // VnetConfigService implements the storage layer for the VnetConfig resource.
@@ -49,7 +44,7 @@ func NewVnetConfigService(b backend.Backend) (*VnetConfigService, error) {
 		generic.ServiceConfig[*vnet.VnetConfig]{
 			Backend:       b,
 			ResourceKind:  types.KindVnetConfig,
-			BackendPrefix: backend.NewKey(vnetConfigPrefix),
+			BackendPrefix: backend.NewKey(types.KindVnetConfig),
 			MarshalFunc:   services.MarshalProtoResource[*vnet.VnetConfig],
 			UnmarshalFunc: services.UnmarshalProtoResource[*vnet.VnetConfig],
 			ValidateFunc:  validateVnetConfig,
@@ -66,7 +61,7 @@ func NewVnetConfigService(b backend.Backend) (*VnetConfigService, error) {
 
 // GetVnetConfig returns the singleton VnetConfig resource.
 func (s *VnetConfigService) GetVnetConfig(ctx context.Context) (*vnet.VnetConfig, error) {
-	vnetConfig, err := s.svc.GetResource(ctx, vnetConfigSingletonName)
+	vnetConfig, err := s.svc.GetResource(ctx, types.MetaNameVnetConfig)
 	return vnetConfig, trace.Wrap(err)
 }
 
@@ -90,37 +85,23 @@ func (s *VnetConfigService) UpsertVnetConfig(ctx context.Context, vnetConfig *vn
 
 // DeleteVnetConfig deletes the singleton VnetConfig resource.
 func (s *VnetConfigService) DeleteVnetConfig(ctx context.Context) error {
-	return trace.Wrap(s.svc.DeleteResource(ctx, vnetConfigSingletonName))
+	return trace.Wrap(s.svc.DeleteResource(ctx, types.MetaNameVnetConfig))
 }
 
 func validateVnetConfig(vnetConfig *vnet.VnetConfig) error {
-	if vnetConfig.GetKind() != types.KindVnetConfig {
-		return trace.BadParameter("kind must be %q", types.KindVnetConfig)
+	if err := typesvnet.ValidateVnetConfig(vnetConfig); err != nil {
+		return trace.Wrap(err)
 	}
-	if vnetConfig.GetVersion() != types.V1 {
-		return trace.BadParameter("version must be %q", types.V1)
-	}
-	if vnetConfig.GetMetadata().GetName() != vnetConfigSingletonName {
-		return trace.BadParameter("name must be %q", vnetConfigSingletonName)
-	}
-	if cidrRange := vnetConfig.GetSpec().GetIpv4CidrRange(); cidrRange != "" {
-		ip, _, err := net.ParseCIDR(cidrRange)
-		if err != nil {
-			return trace.Wrap(err, "parsing ipv4_cidr_range")
-		}
-		if ip4 := ip.To4(); ip4 == nil {
-			return trace.BadParameter("ipv4_cidr_range must be valid IPv4")
-		}
-	}
+
+	// This validation is not present in typesvnet.ValidateVnetConfig because the api package does not
+	// have k8s.io/apimachinery in its deps.
 	for _, zone := range vnetConfig.GetSpec().GetCustomDnsZones() {
 		suffix := zone.GetSuffix()
-		if len(suffix) == 0 {
-			return trace.BadParameter("custom_dns_zone must have a non-empty suffix")
-		}
 		errs := validation.IsDNS1123Subdomain(suffix)
 		if len(errs) > 0 {
 			return trace.BadParameter("validating custom_dns_zone.suffix %q: %s", suffix, errs)
 		}
 	}
+
 	return nil
 }

--- a/lib/services/local/vnet_config_test.go
+++ b/lib/services/local/vnet_config_test.go
@@ -44,7 +44,7 @@ func TestVnetConfigService(t *testing.T) {
 	vnetConfig := &vnet.VnetConfig{
 		Kind:     types.KindVnetConfig,
 		Version:  types.V1,
-		Metadata: &headerv1.Metadata{Name: vnetConfigSingletonName},
+		Metadata: &headerv1.Metadata{Name: types.MetaNameVnetConfig},
 		Spec:     &vnet.VnetConfigSpec{Ipv4CidrRange: "192.168.1.0/24"},
 	}
 
@@ -116,7 +116,7 @@ func TestVnetConfigValidation(t *testing.T) {
 			config: &vnet.VnetConfig{
 				Kind:     "invalidKind",
 				Version:  types.V1,
-				Metadata: &headerv1.Metadata{Name: vnetConfigSingletonName},
+				Metadata: &headerv1.Metadata{Name: types.MetaNameVnetConfig},
 				Spec:     &vnet.VnetConfigSpec{Ipv4CidrRange: "192.168.1.0/24"},
 			},
 			wantErr: true,
@@ -126,7 +126,7 @@ func TestVnetConfigValidation(t *testing.T) {
 			config: &vnet.VnetConfig{
 				Kind:     types.KindVnetConfig,
 				Version:  "v2",
-				Metadata: &headerv1.Metadata{Name: vnetConfigSingletonName},
+				Metadata: &headerv1.Metadata{Name: types.MetaNameVnetConfig},
 				Spec:     &vnet.VnetConfigSpec{Ipv4CidrRange: "192.168.1.0/24"},
 			},
 			wantErr: true,
@@ -146,7 +146,7 @@ func TestVnetConfigValidation(t *testing.T) {
 			config: &vnet.VnetConfig{
 				Kind:     types.KindVnetConfig,
 				Version:  types.V1,
-				Metadata: &headerv1.Metadata{Name: vnetConfigSingletonName},
+				Metadata: &headerv1.Metadata{Name: types.MetaNameVnetConfig},
 				Spec:     &vnet.VnetConfigSpec{Ipv4CidrRange: "192.168.300.0/24"},
 			},
 			wantErr: true,
@@ -156,7 +156,7 @@ func TestVnetConfigValidation(t *testing.T) {
 			config: &vnet.VnetConfig{
 				Kind:     types.KindVnetConfig,
 				Version:  types.V1,
-				Metadata: &headerv1.Metadata{Name: vnetConfigSingletonName},
+				Metadata: &headerv1.Metadata{Name: types.MetaNameVnetConfig},
 				Spec: &vnet.VnetConfigSpec{
 					Ipv4CidrRange: "192.168.1.0/24",
 					CustomDnsZones: []*vnet.CustomDNSZone{
@@ -173,7 +173,7 @@ func TestVnetConfigValidation(t *testing.T) {
 			config: &vnet.VnetConfig{
 				Kind:     types.KindVnetConfig,
 				Version:  types.V1,
-				Metadata: &headerv1.Metadata{Name: vnetConfigSingletonName},
+				Metadata: &headerv1.Metadata{Name: types.MetaNameVnetConfig},
 				Spec: &vnet.VnetConfigSpec{
 					Ipv4CidrRange: "192.168.1.0/24",
 					CustomDnsZones: []*vnet.CustomDNSZone{
@@ -190,7 +190,7 @@ func TestVnetConfigValidation(t *testing.T) {
 			config: &vnet.VnetConfig{
 				Kind:     types.KindVnetConfig,
 				Version:  types.V1,
-				Metadata: &headerv1.Metadata{Name: vnetConfigSingletonName},
+				Metadata: &headerv1.Metadata{Name: types.MetaNameVnetConfig},
 				Spec: &vnet.VnetConfigSpec{
 					Ipv4CidrRange: "192.168.1.0/24",
 					CustomDnsZones: []*vnet.CustomDNSZone{

--- a/lib/vnet/clusterconfigcache.go
+++ b/lib/vnet/clusterconfigcache.go
@@ -27,6 +27,8 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"golang.org/x/sync/singleflight"
+
+	typesvnet "github.com/gravitational/teleport/api/types/vnet"
 )
 
 type ClusterConfig struct {
@@ -115,7 +117,7 @@ func (c *ClusterConfigCache) getClusterConfigUncached(ctx context.Context, clust
 	}
 
 	dnsZones := []string{proxyPublicAddr}
-	ipv4CIDRRange := defaultIPv4CIDRRange
+	ipv4CIDRRange := typesvnet.DefaultIPv4CIDRRange
 
 	vnetConfig, err := clusterClient.CurrentCluster().GetVnetConfig(ctx)
 	if trace.IsNotFound(err) || trace.IsNotImplemented(err) {
@@ -126,7 +128,7 @@ func (c *ClusterConfigCache) getClusterConfigUncached(ctx context.Context, clust
 		for _, zone := range vnetConfig.GetSpec().GetCustomDnsZones() {
 			dnsZones = append(dnsZones, zone.GetSuffix())
 		}
-		ipv4CIDRRange = cmp.Or(vnetConfig.GetSpec().GetIpv4CidrRange(), defaultIPv4CIDRRange)
+		ipv4CIDRRange = cmp.Or(vnetConfig.GetSpec().GetIpv4CidrRange(), typesvnet.DefaultIPv4CIDRRange)
 	}
 
 	return &ClusterConfig{

--- a/lib/vnet/network_stack.go
+++ b/lib/vnet/network_stack.go
@@ -53,7 +53,6 @@ const (
 	mtu                              = 1500
 	tcpReceiveBufferSize             = 0 // 0 means a default will be used.
 	maxInFlightTCPConnectionAttempts = 1024
-	defaultIPv4CIDRRange             = "100.64.0.0/10"
 )
 
 // networkStackConfig holds configuration parameters for the VNet network stack.

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -55,6 +55,7 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
 	"github.com/gravitational/teleport/api/types"
+	typesvnet "github.com/gravitational/teleport/api/types/vnet"
 	"github.com/gravitational/teleport/api/utils/grpc/interceptors"
 	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
 	"github.com/gravitational/teleport/lib/auth/authclient"
@@ -629,7 +630,7 @@ func TestDialFakeApp(t *testing.T) {
 		},
 		{
 			app:        "echo1.leaf1.example.com",
-			expectCIDR: defaultIPv4CIDRRange,
+			expectCIDR: typesvnet.DefaultIPv4CIDRRange,
 			expectRouteToApp: proto.RouteToApp{
 				Name:        "echo1.leaf1.example.com",
 				PublicAddr:  "echo1.leaf1.example.com",
@@ -638,7 +639,7 @@ func TestDialFakeApp(t *testing.T) {
 		},
 		{
 			app:        "echo1.leaf2.example.com",
-			expectCIDR: defaultIPv4CIDRRange,
+			expectCIDR: typesvnet.DefaultIPv4CIDRRange,
 			expectRouteToApp: proto.RouteToApp{
 				Name:        "echo1.leaf2.example.com",
 				PublicAddr:  "echo1.leaf2.example.com",
@@ -647,7 +648,7 @@ func TestDialFakeApp(t *testing.T) {
 		},
 		{
 			app:        "echo1.root2.example.com",
-			expectCIDR: defaultIPv4CIDRRange,
+			expectCIDR: typesvnet.DefaultIPv4CIDRRange,
 			expectRouteToApp: proto.RouteToApp{
 				Name:        "echo1.root2.example.com",
 				PublicAddr:  "echo1.root2.example.com",
@@ -656,7 +657,7 @@ func TestDialFakeApp(t *testing.T) {
 		},
 		{
 			app:        "echo2.root2.example.com",
-			expectCIDR: defaultIPv4CIDRRange,
+			expectCIDR: typesvnet.DefaultIPv4CIDRRange,
 			expectRouteToApp: proto.RouteToApp{
 				Name:        "echo2.root2.example.com",
 				PublicAddr:  "echo2.root2.example.com",
@@ -665,7 +666,7 @@ func TestDialFakeApp(t *testing.T) {
 		},
 		{
 			app:        "echo1.leaf3.example.com",
-			expectCIDR: defaultIPv4CIDRRange,
+			expectCIDR: typesvnet.DefaultIPv4CIDRRange,
 			expectRouteToApp: proto.RouteToApp{
 				Name:        "echo1.leaf3.example.com",
 				PublicAddr:  "echo1.leaf3.example.com",
@@ -686,7 +687,7 @@ func TestDialFakeApp(t *testing.T) {
 		{
 			app:        "multi-port.leaf1.example.com",
 			port:       1337,
-			expectCIDR: defaultIPv4CIDRRange,
+			expectCIDR: typesvnet.DefaultIPv4CIDRRange,
 			expectRouteToApp: proto.RouteToApp{
 				Name:        "multi-port.leaf1.example.com",
 				PublicAddr:  "multi-port.leaf1.example.com",


### PR DESCRIPTION
Contributes to #53288.

By initializing the VNet config when the cluster starts we ensure that `tctl edit vnet_config` works OOTB. Docs update is in #54414.

I set a specific IPv4 CIDR range in the default config so that in the future we're able to change the default without breaking setups on existing clusters. The CIDR is used on end user devices when VNet is running. However, it's still technically possible to remove the CIDR from the config altogether in which case VNet is still going to use the default.