### PR TITLE
Allow cloud to request access graph config

### DIFF
--- a/lib/auth/clusterconfig/clusterconfigv1/service.go
+++ b/lib/auth/clusterconfig/clusterconfigv1/service.go
@@ -962,8 +962,8 @@ func (s *Service) GetClusterAccessGraphConfig(ctx context.Context, _ *clustercon
 		return nil, trace.AccessDenied("this request can be only executed by a Teleport service")
 	}
 
-	// If the policy feature is disabled in the license, return a disabled response.
-	if !modules.GetModules().Features().GetEntitlement(entitlements.Policy).Enabled && !modules.GetModules().Features().AccessGraph {
+	// If the policy feature is disabled in the license, return a disabled response. if cloud, return the response to allow demo mode enabling
+	if !modules.GetModules().Features().GetEntitlement(entitlements.Policy).Enabled && !modules.GetModules().Features().AccessGraph && !modules.GetModules().Features().Cloud {
 		return &clusterconfigpb.GetClusterAccessGraphConfigResponse{
 			AccessGraph: &clusterconfigpb.AccessGraphConfig{
 				Enabled: false,


### PR DESCRIPTION
Because all cloud clusters will eventually be able to use Access Graph (even in just demo mode) they must be able to receive the accessgraphconfig even if policy isnt enabled.

related `e` https://github.com/gravitational/teleport.e/pull/6437