### PR TITLE
Edit the Resource Requests guide

### DIFF
--- a/docs/pages/admin-guides/access-controls/access-requests/resource-requests.mdx
+++ b/docs/pages/admin-guides/access-controls/access-requests/resource-requests.mdx
@@ -258,6 +258,11 @@ Use the `tsh request drop` command to "drop" the request and resume regular acce
 $ tsh request drop
 ```
 
+When you drop an Access Request, Teleport issues a new user certificate. The new
+certificate retains the expiration of the previous certificate. Once your
+session expires and you reauthenticate to Teleport, you receive a user
+certificate with your user's originally configured time to live.
+
 ## Next Steps
 
 ### Automatically request access for SSH


### PR DESCRIPTION
Closes #33820

Document the implications of dropping an Access Request on the duration of the current session.