### PR TITLE
Add CHANGELOG.md as an update-docs-webhook trigger

### DIFF
--- a/.github/workflows/update-docs-webhook.yaml
+++ b/.github/workflows/update-docs-webhook.yaml
@@ -3,6 +3,9 @@ on:
   push:
     paths:
       - 'docs/**'
+      # docs/pages/changelog.mdx includes the main changelog, so redeploy the
+      # docs site to reflect any updates to this file.
+      - 'CHANGELOG.md'
     branches:
       - master
       - branch/v*


### PR DESCRIPTION
Since we display the changelog on the docs site, updates to the changelog should trigger a redeployment of the docs site. The changelog docs page, `docs/pages/changelog.mdx`, gets its content from including the main `CHANGELOG.md` file, so trigger docs site redeployments when a pull request changes that file.