### PR TITLE
Web: remove unified resource card styling when require request

### DIFF
--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
@@ -33,6 +33,7 @@ import {
   getStatusBackgroundColor,
 } from '../shared/getBackgroundColor';
 import { PinButton } from '../shared/PinButton';
+import { ResourceActionButtonWrapper } from '../shared/ResourceActionButton';
 import { SingleLineBox } from '../shared/SingleLineBox';
 import { ResourceItemProps } from '../types';
 import { WarningRightEdgeBadgeSvg } from './WarningRightEdgeBadgeSvg';
@@ -241,7 +242,9 @@ export function ResourceCard({
                 </HoverTooltip>
               </SingleLineBox>
               {hovered && <CopyButton name={name} mr={2} />}
-              {ActionButton}
+              <ResourceActionButtonWrapper requiresRequest={requiresRequest}>
+                {ActionButton}
+              </ResourceActionButtonWrapper>
             </Flex>
             <Flex flexDirection="row" alignItems="center">
               <ResTypeIconBox>

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
@@ -34,6 +34,7 @@ import {
   getStatusBackgroundColor,
 } from '../shared/getBackgroundColor';
 import { PinButton } from '../shared/PinButton';
+import { ResourceActionButtonWrapper } from '../shared/ResourceActionButton';
 import { ResourceItemProps } from '../types';
 
 export function ResourceListItem({
@@ -253,7 +254,9 @@ export function ResourceListItem({
             grid-area: button;
           `}
         >
-          {ActionButton}
+          <ResourceActionButtonWrapper requiresRequest={requiresRequest}>
+            {ActionButton}
+          </ResourceActionButtonWrapper>
         </Box>
 
         {/* labels */}

--- a/web/packages/shared/components/UnifiedResources/shared/ResourceActionButton.tsx
+++ b/web/packages/shared/components/UnifiedResources/shared/ResourceActionButton.tsx
@@ -1,0 +1,40 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import styled, { css } from 'styled-components';
+
+/**
+ * Wrapper to apply shared styles across action buttons that does
+ * not require request. This is to help distinguish between
+ * requestable and non requestable buttons.
+ */
+export const ResourceActionButtonWrapper = styled.div<{
+  requiresRequest: boolean;
+}>`
+  line-height: 0;
+
+  ${p =>
+    !p.requiresRequest &&
+    css`
+      button,
+      a {
+        background-color: ${p => p.theme.colors.interactive.tonal.neutral[0]};
+        border: none;
+      }
+    `}
+`;

--- a/web/packages/shared/components/UnifiedResources/shared/getBackgroundColor.ts
+++ b/web/packages/shared/components/UnifiedResources/shared/getBackgroundColor.ts
@@ -31,12 +31,6 @@ export const getBackgroundColor = (props: BackgroundColorProps) => {
   if (props.hasUnhealthyStatus) {
     return 'transparent';
   }
-  if (props.requiresRequest && props.pinned) {
-    return props.theme.colors.interactive.tonal.primary[0];
-  }
-  if (props.requiresRequest) {
-    return props.theme.colors.spotBackground[0];
-  }
   if (props.selected) {
     return props.theme.colors.interactive.tonal.primary[2];
   }


### PR DESCRIPTION
As discussed with UX team, we decided to remove all [styling](https://www.figma.com/design/Gpjs9vjhzUKF1GDbeG9JGE/Application-Design-System?node-id=21075-46651&t=lTkCOsPdkDtwQiNQ-0) regarding resources that require access request.
In exchange for removing the background, all action buttons are now filled except for buttons that are to request access (to help differentiate the buttons)

This handles the confusion that resources that required access may have looked `disabled`.


before:
<img width="885" alt="image" src="https://github.com/user-attachments/assets/dfd7c0a9-cfea-4972-ab77-7720ca25dedb" />

after (notice filled action buttons)
<img width="883" alt="image" src="https://github.com/user-attachments/assets/e8d7817c-79ec-4068-9a2a-0e1136a76c35" />



changelog: Removed background color for resources that required access request in the web UI Resources view.
