### PR TITLE
[v17] Remove non-Bourne-shell-compatible script option

### DIFF
--- a/lib/srv/server/installer/defaultinstallers.go
+++ b/lib/srv/server/installer/defaultinstallers.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	scriptShebangAndSetOptions = `#!/usr/bin/env sh
-set -euo pipefail`
+set -eu`
 	execGenericInstallScript = `
 INSTALL_SCRIPT_URL="https://{{.PublicProxyAddr}}/scripts/install.sh"
 

--- a/lib/srv/server/installer/defaultinstallers_test.go
+++ b/lib/srv/server/installer/defaultinstallers_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 const defaultInstallerSnapshot = `#!/usr/bin/env sh
-set -euo pipefail
+set -eu
 
 
 INSTALL_SCRIPT_URL="https://teleport.example.com:443/scripts/install.sh"


### PR DESCRIPTION
Backport #54425 to branch/v17

changelog: Fix a bug in the EC2 installer script causing `Illegal option -o pipefail` errors on several distros when Managed Updates v2 are enabled.
