### PR TITLE
[v16] [17.4.6] Bump cloud docs version

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -17,7 +17,7 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "17.4.3",
+      "version": "17.4.6",
       "major_version": "17",
       "sla": {
         "monthly_percentage": "99.9%",


### PR DESCRIPTION
Backport #54362 to branch/v16