### PR TITLE
Apply traits to logins in plugin messages

### DIFF
--- a/docs/pages/includes/plugins/rbac-with-friendly-name.mdx
+++ b/docs/pages/includes/plugins/rbac-with-friendly-name.mdx
@@ -28,6 +28,10 @@ spec:
       # permission to read the role resource.
       - resources: ['role']
         verbs: ['read']
+      # Optional: To have the users traits apply when evaluating the roles,
+      # the plugin also neads permission to read users.
+      - resources: ['user']
+        verbs: ['read']
 
     # Optional: To display user-friendly names in resource-based Access
     # Requests instead of resource IDs, the plugin also needs permission

--- a/docs/pages/includes/plugins/rbac-with-friendly-name.mdx
+++ b/docs/pages/includes/plugins/rbac-with-friendly-name.mdx
@@ -29,7 +29,7 @@ spec:
       - resources: ['role']
         verbs: ['read']
       # Optional: To have the users traits apply when evaluating the roles,
-      # the plugin also neads permission to read users.
+      # the plugin also needs permission to read users.
       - resources: ['user']
         verbs: ['read']
 

--- a/integrations/access/accessrequest/app.go
+++ b/integrations/access/accessrequest/app.go
@@ -548,6 +548,9 @@ func (a *App) getLoginsByRole(ctx context.Context, req types.AccessRequest) (map
 			return nil, trace.Wrap(err)
 		}
 		logins := currentRole.GetLogins(types.Allow)
+		if logins == nil {
+			logins = []string{}
+		}
 		loginsByRole[role] = logins
 	}
 	return loginsByRole, nil

--- a/integrations/access/accessrequest/app.go
+++ b/integrations/access/accessrequest/app.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/integrations/lib/logger"
 	pd "github.com/gravitational/teleport/integrations/lib/plugindata"
 	"github.com/gravitational/teleport/integrations/lib/watcherjob"
+	"github.com/gravitational/teleport/lib/services"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
@@ -524,14 +525,22 @@ func (a *App) updateMessages(ctx context.Context, reqID string, tag pd.Resolutio
 func (a *App) getLoginsByRole(ctx context.Context, req types.AccessRequest) (map[string][]string, error) {
 	loginsByRole := make(map[string][]string, len(req.GetRoles()))
 
+	user, err := a.apiClient.GetUser(ctx, req.GetUser(), false)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	for _, role := range req.GetRoles() {
 		currentRole, err := a.apiClient.GetRole(ctx, role)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		loginsByRole[role] = currentRole.GetLogins(types.Allow)
+		currentRole, err = services.ApplyTraits(currentRole, user.GetTraits())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		logins := currentRole.GetLogins(types.Allow)
+		loginsByRole[role] = logins
 	}
-
 	return loginsByRole, nil
 }
 

--- a/integrations/access/common/teleport/client.go
+++ b/integrations/access/common/teleport/client.go
@@ -43,4 +43,5 @@ type Client interface {
 	ListAccessLists(context.Context, int, string) ([]*accesslist.AccessList, string, error)
 	ListAccessMonitoringRulesWithFilter(ctx context.Context, req *accessmonitoringrulesv1.ListAccessMonitoringRulesWithFilterRequest) ([]*accessmonitoringrulesv1.AccessMonitoringRule, string, error)
 	GetAccessListOwners(ctx context.Context, accessListName string) ([]*accesslist.Owner, error)
+	GetUser(ctx context.Context, name string, withSecrets bool) (types.User, error)
 }


### PR DESCRIPTION
Closes #53047 
Applies requesting users traits to login values when showing plugin messages.