### PR TITLE
[v17] feat(join-tokens): [44794] API changes for managing GitHub Join Tokens

### DIFF
--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -135,6 +135,8 @@ type ProvisionToken interface {
 	SetAllowRules([]*TokenRule)
 	// GetGCPRules will return the GCP rules within this token.
 	GetGCPRules() *ProvisionTokenSpecV2GCP
+	// GetGithubRules will return the GitHub rules within this token.
+	GetGithubRules() *ProvisionTokenSpecV2GitHub
 	// GetAWSIIDTTL returns the TTL of EC2 IIDs
 	GetAWSIIDTTL() Duration
 	// GetJoinMethod returns joining method that must be used with this token.
@@ -435,6 +437,11 @@ func (p *ProvisionTokenV2) SetAllowRules(rules []*TokenRule) {
 // GetGCPRules will return the GCP rules within this token.
 func (p *ProvisionTokenV2) GetGCPRules() *ProvisionTokenSpecV2GCP {
 	return p.Spec.GCP
+}
+
+// GetGithubRules will return the GitHub rules within this token.
+func (p *ProvisionTokenV2) GetGithubRules() *ProvisionTokenSpecV2GitHub {
+	return p.Spec.GitHub
 }
 
 // GetAWSIIDTTL returns the TTL of EC2 IIDs

--- a/lib/web/join_tokens.go
+++ b/lib/web/join_tokens.go
@@ -207,9 +207,11 @@ func (h *Handler) upsertTokenHandle(w http.ResponseWriter, r *http.Request, para
 	}
 
 	var existingToken types.ProvisionToken
-	existingToken, err = clt.GetToken(r.Context(), tokenId)
-	if err != nil && !trace.IsNotFound(err) {
-		return nil, trace.Wrap(err)
+	if tokenId != "" {
+		existingToken, err = clt.GetToken(r.Context(), tokenId)
+		if err != nil && !trace.IsNotFound(err) {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	var expires time.Time

--- a/lib/web/join_tokens.go
+++ b/lib/web/join_tokens.go
@@ -190,25 +190,14 @@ func (h *Handler) upsertTokenHandle(w http.ResponseWriter, r *http.Request, para
 		return nil, trace.Wrap(err)
 	}
 
-	var tokenId string = req.Name
-	if r.Method == "PUT" {
-		// if using the PUT route, tokenId will be present
-		// in the X-Teleport-TokenName header
-		tokenId = r.Header.Get(HeaderTokenName)
-
-		if tokenId != "" && tokenId != req.Name {
-			return nil, trace.BadParameter("renaming tokens is not supported")
-		}
-	}
-
 	clt, err := ctx.GetClient()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	var existingToken types.ProvisionToken
-	if tokenId != "" {
-		existingToken, err = clt.GetToken(r.Context(), tokenId)
+	if req.Name != "" {
+		existingToken, err = clt.GetToken(r.Context(), req.Name)
 		if err != nil && !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/web/join_tokens.go
+++ b/lib/web/join_tokens.go
@@ -190,7 +190,7 @@ func (h *Handler) upsertTokenHandle(w http.ResponseWriter, r *http.Request, para
 		return nil, trace.Wrap(err)
 	}
 
-	var tokenId string
+	var tokenId string = req.Name
 	if r.Method == "PUT" {
 		// if using the PUT route, tokenId will be present
 		// in the X-Teleport-TokenName header
@@ -199,8 +199,6 @@ func (h *Handler) upsertTokenHandle(w http.ResponseWriter, r *http.Request, para
 		if tokenId != "" && tokenId != req.Name {
 			return nil, trace.BadParameter("renaming tokens is not supported")
 		}
-	} else {
-		tokenId = req.Name
 	}
 
 	clt, err := ctx.GetClient()
@@ -209,11 +207,9 @@ func (h *Handler) upsertTokenHandle(w http.ResponseWriter, r *http.Request, para
 	}
 
 	var existingToken types.ProvisionToken
-	if tokenId != "" {
-		existingToken, err = clt.GetToken(r.Context(), tokenId)
-		if err != nil && !trace.IsNotFound(err) {
-			return nil, trace.Wrap(err)
-		}
+	existingToken, err = clt.GetToken(r.Context(), tokenId)
+	if err != nil && !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
 	}
 
 	var expires time.Time

--- a/lib/web/join_tokens.go
+++ b/lib/web/join_tokens.go
@@ -184,29 +184,43 @@ type upsertTokenHandleRequest struct {
 	Name string `json:"name"`
 }
 
-func (h *Handler) upsertTokenHandle(w http.ResponseWriter, r *http.Request, params httprouter.Params, ctx *SessionContext) (interface{}, error) {
-	// if using the PUT route, tokenId will be present
-	// in the X-Teleport-TokenName header
-	editing := r.Method == "PUT"
-	tokenId := r.Header.Get(HeaderTokenName)
-	if editing && tokenId == "" {
-		return nil, trace.BadParameter("requires a token name to edit")
-	}
-
+func (h *Handler) upsertTokenHandle(w http.ResponseWriter, r *http.Request, params httprouter.Params, ctx *SessionContext) (any, error) {
 	var req upsertTokenHandleRequest
 	if err := httplib.ReadResourceJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if editing && tokenId != req.Name {
-		return nil, trace.BadParameter("renaming tokens is not supported")
+	var tokenId string
+	if r.Method == "PUT" {
+		// if using the PUT route, tokenId will be present
+		// in the X-Teleport-TokenName header
+		tokenId = r.Header.Get(HeaderTokenName)
+
+		if tokenId != "" && tokenId != req.Name {
+			return nil, trace.BadParameter("renaming tokens is not supported")
+		}
+	} else {
+		tokenId = req.Name
+	}
+
+	clt, err := ctx.GetClient()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var existingToken types.ProvisionToken
+	if tokenId != "" {
+		existingToken, err = clt.GetToken(r.Context(), tokenId)
+		if err != nil && !trace.IsNotFound(err) {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	var expires time.Time
 	switch req.JoinMethod {
-	case types.JoinMethodGCP, types.JoinMethodIAM, types.JoinMethodOracle:
-		// IAM, GCP, and Oracle tokens should never expire.
-		expires = time.Now().UTC().AddDate(1000, 0, 0)
+	case types.JoinMethodGCP, types.JoinMethodIAM, types.JoinMethodOracle, types.JoinMethodGitHub:
+		// IAM, GCP, Oracle and GitHub tokens should never expire.
+		expires = time.Time{}
 	default:
 		// Set expires time to default node join token TTL.
 		expires = time.Now().UTC().Add(defaults.NodeJoinTokenTTL)
@@ -226,9 +240,9 @@ func (h *Handler) upsertTokenHandle(w http.ResponseWriter, r *http.Request, para
 		return nil, trace.Wrap(err)
 	}
 
-	clt, err := ctx.GetClient()
-	if err != nil {
-		return nil, trace.Wrap(err)
+	// If this is an edit, then overwrite the metadata to retain the existing fields
+	if existingToken != nil {
+		token.SetMetadata(existingToken.GetMetadata())
 	}
 
 	err = clt.UpsertToken(r.Context(), token)

--- a/lib/web/join_tokens_test.go
+++ b/lib/web/join_tokens_test.go
@@ -27,7 +27,6 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
-	"slices"
 	"strconv"
 	"testing"
 	"time"
@@ -96,8 +95,8 @@ func TestGenerateIAMTokenName(t *testing.T) {
 
 type tokenData struct {
 	name   string
-	roles  types.SystemRoles
 	expiry time.Time
+	spec   types.ProvisionTokenSpecV2
 }
 
 func TestGetTokens(t *testing.T) {
@@ -149,25 +148,31 @@ func TestGetTokens(t *testing.T) {
 			tokenData: []tokenData{
 				{
 					name: "test-token",
-					roles: types.SystemRoles{
-						types.RoleNode,
+					spec: types.ProvisionTokenSpecV2{
+						Roles: types.SystemRoles{
+							types.RoleNode,
+						},
 					},
 					expiry: expiry,
 				},
 				{
 					name: "test-token-2",
-					roles: types.SystemRoles{
-						types.RoleNode,
-						types.RoleDatabase,
+					spec: types.ProvisionTokenSpecV2{
+						Roles: types.SystemRoles{
+							types.RoleNode,
+							types.RoleDatabase,
+						},
 					},
 					expiry: expiry,
 				},
 				{
 					name: "test-token-3-and-super-duper-long",
-					roles: types.SystemRoles{
-						types.RoleNode,
-						types.RoleKube,
-						types.RoleDatabase,
+					spec: types.ProvisionTokenSpecV2{
+						Roles: types.SystemRoles{
+							types.RoleNode,
+							types.RoleKube,
+							types.RoleDatabase,
+						},
 					},
 					expiry: expiry,
 				},
@@ -205,6 +210,64 @@ func TestGetTokens(t *testing.T) {
 						types.RoleDatabase,
 					},
 					Method: types.JoinMethodToken,
+				},
+				staticUIToken,
+			},
+		},
+		{
+			name: "github token",
+			tokenData: []tokenData{
+				{
+					name: "github-test-token",
+					spec: types.ProvisionTokenSpecV2{
+						Roles: types.SystemRoles{
+							types.RoleBot,
+						},
+						BotName:    "test-bot",
+						JoinMethod: types.JoinMethodGitHub,
+						GitHub: &types.ProvisionTokenSpecV2GitHub{
+							EnterpriseServerHost: "github.example.com",
+							StaticJWKS:           "{\"keys\":[]}",
+							Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
+								{
+									Repository:      "gravitational/teleport",
+									RepositoryOwner: "gravitational",
+									Sub:             "test-sub",
+									Workflow:        "test-workflow",
+									Environment:     "test-environment",
+									Actor:           "octocat",
+									Ref:             "ref/heads/main",
+									RefType:         "branch",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []ui.JoinToken{
+				{
+					ID:       "github-test-token",
+					SafeName: "github-test-token",
+					BotName:  "test-bot",
+					Expiry:   time.Time{},
+					Roles:    types.SystemRoles{"Bot"},
+					Method:   types.JoinMethodGitHub,
+					Github: &types.ProvisionTokenSpecV2GitHub{
+						EnterpriseServerHost: "github.example.com",
+						StaticJWKS:           "{\"keys\":[]}",
+						Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
+							{
+								Repository:      "gravitational/teleport",
+								RepositoryOwner: "gravitational",
+								Sub:             "test-sub",
+								Workflow:        "test-workflow",
+								Environment:     "test-environment",
+								Actor:           "octocat",
+								Ref:             "ref/heads/main",
+								RefType:         "branch",
+							},
+						},
+					},
 				},
 				staticUIToken,
 			},
@@ -249,9 +312,7 @@ func TestGetTokens(t *testing.T) {
 			}
 
 			for _, td := range tc.tokenData {
-				token, err := types.NewProvisionTokenFromSpec(td.name, td.expiry, types.ProvisionTokenSpecV2{
-					Roles: td.roles,
-				})
+				token, err := types.NewProvisionTokenFromSpec(td.name, td.expiry, td.spec)
 				require.NoError(t, err)
 				err = env.server.Auth().CreateToken(ctx, token)
 				require.NoError(t, err)
@@ -267,86 +328,6 @@ func TestGetTokens(t *testing.T) {
 			require.Empty(t, cmp.Diff(resp.Items, tc.expected, cmpopts.IgnoreFields(ui.JoinToken{}, "Content")))
 		})
 	}
-}
-
-func TestGetGithubTokens(t *testing.T) {
-	t.Parallel()
-	ctx := context.Background()
-
-	username := "test-user@example.com"
-	expiry := time.Now().UTC().Add(30 * time.Minute)
-
-	env := newWebPack(t, 1)
-	proxy := env.proxies[0]
-	pack := proxy.authPack(t, username, nil /* roles */)
-
-	td := tokenData{
-		name:   "github-test-token",
-		expiry: expiry,
-		roles:  types.SystemRoles{types.RoleBot},
-	}
-
-	token, err := types.NewProvisionTokenFromSpec(td.name, td.expiry, types.ProvisionTokenSpecV2{
-		Roles:      td.roles,
-		BotName:    "test-bot",
-		JoinMethod: types.JoinMethodGitHub,
-
-		GitHub: &types.ProvisionTokenSpecV2GitHub{
-			EnterpriseServerHost: "github.example.com",
-			StaticJWKS:           "{\"keys\":[]}",
-			Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
-				{
-					Repository:      "gravitational/teleport",
-					RepositoryOwner: "gravitational",
-					Sub:             "test-sub",
-					Workflow:        "test-workflow",
-					Environment:     "test-environment",
-					Actor:           "octocat",
-					Ref:             "ref/heads/main",
-					RefType:         "branch",
-				},
-			},
-		},
-	})
-	require.NoError(t, err)
-	err = env.server.Auth().CreateToken(ctx, token)
-	require.NoError(t, err)
-
-	endpoint := pack.clt.Endpoint("webapi", "tokens")
-	re, err := pack.clt.Get(ctx, endpoint, url.Values{})
-	require.NoError(t, err)
-
-	resp := GetTokensResponse{}
-	require.NoError(t, json.Unmarshal(re.Bytes(), &resp))
-
-	require.Len(t, resp.Items, 2) // Including a static token
-
-	githubTokenIndex := slices.IndexFunc(resp.Items, func(item ui.JoinToken) bool { return item.Method == types.JoinMethodGitHub })
-	require.NotEqual(t, githubTokenIndex, -1)
-	require.Empty(t, cmp.Diff(resp.Items[githubTokenIndex], ui.JoinToken{
-		ID:       "github-test-token",
-		SafeName: "github-test-token",
-		BotName:  "test-bot",
-		Expiry:   expiry,
-		Roles:    types.SystemRoles{"Bot"},
-		Method:   types.JoinMethodGitHub,
-		Github: &types.ProvisionTokenSpecV2GitHub{
-			EnterpriseServerHost: "github.example.com",
-			StaticJWKS:           "{\"keys\":[]}",
-			Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
-				{
-					Repository:      "gravitational/teleport",
-					RepositoryOwner: "gravitational",
-					Sub:             "test-sub",
-					Workflow:        "test-workflow",
-					Environment:     "test-environment",
-					Actor:           "octocat",
-					Ref:             "ref/heads/main",
-					RefType:         "branch",
-				},
-			},
-		},
-	}, cmpopts.IgnoreFields(ui.JoinToken{}, "Content")))
 }
 
 func TestDeleteToken(t *testing.T) {

--- a/lib/web/join_tokens_test.go
+++ b/lib/web/join_tokens_test.go
@@ -406,6 +406,8 @@ func TestEditToken(t *testing.T) {
 	proxy := env.proxies[0]
 	pack := proxy.authPack(t, username, nil /* roles */)
 
+	expiry := time.Now().UTC()
+
 	// Setup an existing token
 	spec := types.ProvisionTokenSpecV2{
 		Roles:      types.SystemRoles{types.RoleBot},
@@ -422,6 +424,7 @@ func TestEditToken(t *testing.T) {
 	}
 	token, err := types.NewProvisionTokenFromSpec("github-test-token", time.Time{}, spec)
 	require.NoError(t, err)
+	token.SetExpiry(expiry)
 	token.SetLabels(map[string]string{
 		"test-key": "test-value",
 	})
@@ -445,6 +448,7 @@ func TestEditToken(t *testing.T) {
 	editedToken, err := env.server.Auth().GetToken(ctx, "github-test-token")
 	require.NoError(t, err)
 	require.Equal(t, "test-bot_EDITED", editedToken.GetBotName())
+	require.Equal(t, expiry, *editedToken.GetMetadata().Expires)
 	require.Equal(t, map[string]string{
 		"test-key": "test-value",
 	}, editedToken.GetMetadata().Labels)

--- a/lib/web/ui/join_token.go
+++ b/lib/web/ui/join_token.go
@@ -47,6 +47,8 @@ type JoinToken struct {
 	Allow []*types.TokenRule `json:"allow,omitempty"`
 	// GCP allows the configuration of options specific to the "gcp" join method.
 	GCP *types.ProvisionTokenSpecV2GCP `json:"gcp,omitempty"`
+	// GitHub-specific configuration for the join method.
+	Github *types.ProvisionTokenSpecV2GitHub `json:"github,omitempty"`
 	// Content is resource yaml content.
 	Content string `json:"content"`
 }
@@ -71,6 +73,11 @@ func MakeJoinToken(token types.ProvisionToken) (*JoinToken, error) {
 	if uiToken.Method == types.JoinMethodGCP {
 		uiToken.GCP = token.GetGCPRules()
 	}
+
+	if uiToken.Method == types.JoinMethodGitHub {
+		uiToken.Github = token.GetGithubRules()
+	}
+
 	return uiToken, nil
 }
 

--- a/lib/web/yaml.go
+++ b/lib/web/yaml.go
@@ -71,6 +71,14 @@ func (h *Handler) yamlParse(w http.ResponseWriter, r *http.Request, params httpr
 
 		return yamlParseResponse{Resource: resource}, nil
 
+	case types.KindToken:
+		resource, err := yamlToProvisionToken(req.YAML)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		return yamlParseResponse{Resource: resource}, nil
+
 	default:
 		return nil, trace.NotImplemented("parsing YAML for kind %q is not supported", kind)
 	}
@@ -142,6 +150,22 @@ func yamlToRole(yaml string) (types.Role, error) {
 		return nil, trace.BadParameter("resource kind %q is invalid, only role is allowed", extractedRes.Kind)
 	}
 	resource, err := services.UnmarshalRole(extractedRes.Raw)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return resource, nil
+}
+
+func yamlToProvisionToken(yaml string) (types.ProvisionToken, error) {
+	extractedRes, err := extractResource(yaml)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if extractedRes.Kind != types.KindToken {
+		return nil, trace.BadParameter("resource kind %q is invalid, only token is allowed", extractedRes.Kind)
+	}
+	resource, err := services.UnmarshalProvisionToken(extractedRes.Raw)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
Backport #54374 to branch/v17

changelog: Fixed an issue causing Join Token expiries to be overwritten when editing a token
