### PR TITLE
Fix 31 Vale warnings and one error

### DIFF
--- a/docs/pages/admin-guides/access-controls/device-trust/jamf-integration.mdx
+++ b/docs/pages/admin-guides/access-controls/device-trust/jamf-integration.mdx
@@ -6,6 +6,8 @@ description: Sync your Jamf Pro inventory into Teleport
 Device Trust Jamf Pro integration lets you automatically sync your Jamf Pro computer
 inventory into Teleport.
 
+## How it works
+
 The Teleport Jamf Pro service is a distinct `teleport` process that periodically
 reads your computer inventory from Jamf Pro and syncs it to Teleport. It performs
 both incremental (called "partial") and full syncs, as well as removals from

--- a/docs/pages/admin-guides/api/automatically-register-agents.mdx
+++ b/docs/pages/admin-guides/api/automatically-register-agents.mdx
@@ -17,6 +17,8 @@ In this guide, we will demonstrate some libraries you can use to automatically
 register resources with Teleport. We will use an example you can run locally on
 your workstation.
 
+## How it works
+
 Automatic registration consists of the following steps:
 
 - Look up resources in your infrastructure from a service discovery solution,

--- a/docs/pages/admin-guides/deploy-a-cluster/aws-kms.mdx
+++ b/docs/pages/admin-guides/deploy-a-cluster/aws-kms.mdx
@@ -8,6 +8,8 @@ This guide will show you how to set up your Teleport cluster to use the AWS Key
 Management Service (KMS) to store and handle the CA private key material used to
 sign all certificates issued by your cluster.
 
+## How it works
+
 Teleport generates private key material for its internal Certificate Authorities
 (CAs) during the first Auth Service instance's initial startup.
 These CAs are used to sign all certificates issued to clients and hosts in the

--- a/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/spacelift.mdx
+++ b/docs/pages/admin-guides/infrastructure-as-code/terraform-provider/spacelift.mdx
@@ -11,6 +11,8 @@ truth for operators to examine.
 This guide shows you how to configure the Teleport Terraform Provider to
 authenticate to a Teleport cluster using Machine ID when running on Spacelift.
 
+## How it works
+
 In this setup, the Teleport Terraform Provider proves its identity to the
 Teleport Auth Service by presenting an ID token signed by Spacelift. This
 allows it to authenticate with the Teleport cluster without the need for a

--- a/docs/pages/admin-guides/management/admin/trustedclusters.mdx
+++ b/docs/pages/admin-guides/management/admin/trustedclusters.mdx
@@ -30,21 +30,6 @@ instance running on the root cluster.
    firewall to ensure leaf Proxy services are only allowed to connect to the appropriate resources.  
 </Admonition>
 
-## Who uses trusted clusters?
-
-Most organizations don't need to configure trusted clusters. In most cases, you can add 
-multiple Teleport Proxy Service instances to enroll and manage thousands of resources 
-without creating a new cluster.
-
-However, there are a few specific scenarios where trusted clusters can be particularly useful.
-For example, if you have a large and widely-distributed infrastructure or must provide access
-to resources for external agencies, contractors, or clients, you might benefit from setting up 
-a trusted cluster. The most common use cases for trusted clusters include:
-
-- Managed service providers (MSP) remotely managing the infrastructure of their clients.
-- Device manufacturers remotely maintaining computing appliances deployed on premises.
-- Large cloud software vendors managing multiple data centers using a common proxy.
-
 ## How it works
 
 In the following example, a managed service provider uses three independent clusters to 
@@ -94,6 +79,21 @@ on the leaf cluster and service running on the root cluster:
 
 Note that trusted clusters only work in one direction. 
 Users from the leaf cluster can't see or connect to resources in the root cluster.
+
+## Who uses trusted clusters?
+
+Most organizations don't need to configure trusted clusters. In most cases, you can add 
+multiple Teleport Proxy Service instances to enroll and manage thousands of resources 
+without creating a new cluster.
+
+However, there are a few specific scenarios where trusted clusters can be particularly useful.
+For example, if you have a large and widely-distributed infrastructure or must provide access
+to resources for external agencies, contractors, or clients, you might benefit from setting up 
+a trusted cluster. The most common use cases for trusted clusters include:
+
+- Managed service providers (MSP) remotely managing the infrastructure of their clients.
+- Device manufacturers remotely maintaining computing appliances deployed on premises.
+- Large cloud software vendors managing multiple data centers using a common proxy.
 
 ## Role relationships in a trusted cluster
 

--- a/docs/pages/admin-guides/teleport-policy/integrations/azure-sync.mdx
+++ b/docs/pages/admin-guides/teleport-policy/integrations/azure-sync.mdx
@@ -65,7 +65,7 @@ how to set up Access Graph.
   Discovery Service within your cluster.
 </Admonition>
 
-### Installing the Discovery Service
+## Step 1/4. Install the Discovery Service
 
 <Admonition type="tip">
   If you plan on running the Discovery Service on a host that is already running
@@ -80,7 +80,7 @@ via Entra ID integration.
 
 (!docs/pages/includes/install-linux.mdx!)
 
-### Configuring the Discovery Service
+## Step 2/4. Configure the Discovery Service
 
 To activate the Teleport Discovery Service, add a top level discovery_service section to the `teleport.yaml`
 config file. This service monitors dynamic `discovery_config` resources that are set up
@@ -112,7 +112,7 @@ discovery_service:
 
 The Discovery Service will now periodically fetch resources from your Azure subscription.
 
-### Activating the Discovery Service
+## Step 3/4. Activate the Discovery Service
 
 To activate the Discovery Service for fetching Azure resources, you'll need to authorize the identity running the
 Discovery service. Two options for authorization are available.
@@ -139,7 +139,8 @@ Discovery service. Two options for authorization are available.
       Use the application object ID as the principal ID in step 2 of the integration command.
     </Admonition>
 
-    Lastly, add the name of the <Var name="integration" /> to the configuration, typically this is `entra-id`:
+    Lastly, add the name of the <Var name="azure-integration" /> to the configuration, typically this is `entra-id`:
+
     ```yaml
     discovery_service:
       access_graph:
@@ -151,7 +152,7 @@ Discovery service. Two options for authorization are available.
   </TabItem>
 </Tabs>
 
-## Step 2/2. Set up Access Graph Azure Sync
+## Step 4/4. Set up Access Graph Azure Sync
 
 To configure the Teleport Discovery Service, the Azure managed identity running the Discovery Service within
 Azure must be given the right permissions to fetch Azure resources. Within the

--- a/docs/pages/enroll-resources/agents/join-services-to-your-cluster/kubernetes.mdx
+++ b/docs/pages/enroll-resources/agents/join-services-to-your-cluster/kubernetes.mdx
@@ -7,6 +7,8 @@ This guide will explain how to use the **Kubernetes join method** to configure
 Teleport services to join your Teleport cluster without sharing any
 secrets when running in the same Kubernetes cluster as the Auth Service.
 
+## How it works
+
 When a Teleport service wants to be part of the cluster, it needs to prove
 its identity to the Teleport Auth Service before receiving its certificates.
 Kubernetes issues signed proof to each pod describing which Kubernetes

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
@@ -15,6 +15,8 @@ This guide will explain how to:
 - Access the AWS Command Line Interface (CLI) through Teleport.
 - Access applications using AWS SDKs through Teleport.
 
+## How it works
+
 In this setup, the Teleport Application Service has an AWS IAM role that can
 assume one or more target IAM roles. Teleport users access the AWS Management
 Console and APIs through the Teleport Web UI and `tsh`. When a user visits the
@@ -120,7 +122,7 @@ AWS APIs.
    ```
    
    Create a file called `app-service-tp.json` with the following content,
-   assigning <Var name="oidc-issuer" /> to the issuer string you retrieved and
+   assigning <Var name="OIDC_ISSUER" /> to the issuer string you retrieved and
    <Var name="EKS_ACCOUNT" /> to the ID of the AWS account that belongs to your
    EKS cluster:
    
@@ -386,7 +388,8 @@ $ tctl tokens add --type=app --ttl=1h --format=text
 <TabItem label="EC2">
 
 On the host where you will install the Teleport Application Service, create a
-file called `/tmp/token` that consists only of your token:
+file called `/tmp/token` that consists only of your token, assigning 
+<Var name="join-token" /> to the value of the token:
 
 ```code
 $ echo <Var name="join-token" /> | sudo tee /tmp/token

--- a/docs/pages/enroll-resources/application-access/cloud-apis/azure-aks-workload-id.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/azure-aks-workload-id.mdx
@@ -40,12 +40,17 @@ the client IDs of the managed identities for user access. This managed identity
 will be assigned as the default identity for the Kubernetes service account.
 
 Log in to your Azure admin account with `az login` command if you haven't
-already, and prepare some environment variables for later steps:
+already, and prepare some environment variables for later steps. Assign <Var
+name="eastus" /> to an Azure region name, <Var name="myResourceGroup" /> to the
+name of your Azure resource group, <Var name="myAKSCluster" /> to the name of
+your AKS cluster, and <Var name="teleport-azure-cli-aks-agent" /> to the Azure
+identity to assign to the Teleport Agent:
+
 ```code
 $ export SUBSCRIPTION="$(az account show --query id --output tsv)"
 $ export LOCATION="<Var name="eastus" />"
 $ export RESOURCE_GROUP="<Var name="myResourceGroup" />"
-$ export AKS_CLUSTER_NAME="<Var name="myASKCluster" />"
+$ export AKS_CLUSTER_NAME="<Var name="myAKSCluster" />"
 $ export USER_ASSIGNED_IDENTITY_NAME="<Var name="teleport-azure-cli-aks-agent" />"
 ```
 
@@ -170,8 +175,8 @@ $ tctl tokens add --type=app --ttl=1h --format=text
 ### Start the Teleport Application Service
 
 Create a Helm values file called `values.yaml`, assigning <Var name="token" />
-to the value of the join token you retrieved above, <Var
-name="example.teleport.sh:443" /> to the host **and port** of your Teleport
+to the value of the join token you retrieved above, 
+<Var name="example.teleport.sh:443" /> to the host **and port** of your Teleport
 Proxy Service (e.g., `teleport.example.com:443`):
 
 ```code

--- a/docs/pages/enroll-resources/application-access/cloud-apis/google-cloud.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/google-cloud.mdx
@@ -8,17 +8,18 @@ Cloud's APIs. This lets you control access to your infrastructure's management
 APIs using the same RBAC system that you use to protect your infrastructure
 itself.
 
+## How it works
+
 The Teleport Application Service manages access to Google Cloud's APIs by
 proxying requests from CLI applications. The Application Service authenticates
 these requests using tokens retrieved from Google Cloud. This enables Teleport
 operators to control the service accounts that users can assume in order to
 interact with Google Cloud APIs.
 
-{/* TODO: Add a mermaidjs graph here when available*/}
-
 The Teleport Application Service connects to the Teleport Proxy Service over a
 reverse tunnel, so you can run the Application Service in a private network and
-prevent unauthorized access to your organization's Google Cloud service accounts.
+prevent unauthorized access to your organization's Google Cloud service
+accounts.
 
 ## Prerequisites
 
@@ -335,7 +336,7 @@ service accounts you have assigned to the user.
 
 Assign the target service account we created earlier (or another service
 account) to your Teleport user by running the following command, setting 
-<Var name ="teleport-user" /> to the name of your Teleport user:
+<Var name="teleport-user" /> to the name of your Teleport user:
 
 ```code
 $ tctl users update <Var name="teleport-user" /> \

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/azure.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/azure.mdx
@@ -7,6 +7,8 @@ AKS Auto-Discovery can automatically
 discover any AKS cluster and enroll it in Teleport if its tags match the
 configured labels.
 
+## How it works
+
 (!docs/pages/includes/discovery/step-description.mdx serviceName="Kubernetes" resourceDesc="cluster" resourceKind="kube_cluster" !)
 
 (!docs/pages/includes/discovery/same-host-tip.mdx serviceName="Kubernetes" resourceDesc="cluster" !)

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/google-cloud.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/google-cloud.mdx
@@ -12,7 +12,7 @@ each creation.
 In this guide, we will show you how to get started with Teleport Kubernetes
 Discovery for GKE.
 
-## Overview
+## How it works
 
 (!docs/pages/includes/discovery/step-description.mdx serviceName="Kubernetes" resourceDesc="cluster" resourceKind="kube_cluster" !)
 

--- a/docs/pages/enroll-resources/desktop-access/directory-sharing.mdx
+++ b/docs/pages/enroll-resources/desktop-access/directory-sharing.mdx
@@ -7,6 +7,8 @@ Directory Sharing is a Teleport feature of that makes it easy to move files
 between a local machine and a remote desktop—and apply changes to those
 files—without compromising security.
 
+## How it works
+
 During a remote desktop session, you can select a folder on your local
 workstation to share with the remote desktop. Changes to the folder on either
 the remote desktop or your workstation are reflected on both machines for the

--- a/docs/pages/enroll-resources/kubernetes-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/getting-started.mdx
@@ -8,6 +8,8 @@ This guide demonstrates how to enroll a Kubernetes cluster as a Teleport
 resource by deploying the Teleport Kubernetes Service on the Kubernetes cluster
 you want to protect. 
 
+## How it works
+
 In this scenario, the Teleport Kubernetes Service pod detects that it is running
 on Kubernetes and enrolls the Kubernetes cluster automatically. The following
 diagram provides a simplified overview of this deployment scenario with the

--- a/docs/pages/enroll-resources/kubernetes-access/manage-access.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/manage-access.mdx
@@ -6,15 +6,17 @@ description: How to configure Teleport roles to access clusters, groups, users, 
 The Teleport Kubernetes Service is a proxy that sits between Kubernetes users
 and one or more Kubernetes clusters.
 
+In this guide, we will use a local Kubernetes cluster to show you how to
+configure Teleport's role-based access control (RBAC) system to manage access to
+Kubernetes clusers, groups, users, and resources.
+
+## How it works
+
 When a user authenticates to Teleport, they receive a kubeconfig that lets them
 send requests to their authorized Kubernetes clusters via the Teleport
 Kubernetes Service. The Kubernetes Service can then inspect, modify, or disallow
 these requests depending on the privileges you have assigned to the Teleport
 user via their roles.
-
-In this guide, we will use a local Kubernetes cluster to show you how to
-configure Teleport's role-based access control (RBAC) system to manage access to
-Kubernetes clusers, groups, users, and resources.
 
 ## Prerequisites
 

--- a/docs/pages/enroll-resources/kubernetes-access/register-clusters/iam-joining.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/register-clusters/iam-joining.mdx
@@ -6,6 +6,8 @@ description: Connecting a Kubernetes cluster to Teleport with IAM joining.
 In this guide, we will show you how to register a Kubernetes cluster with
 Teleport by using the agent's IAM identity to automatically join the Teleport cluster.
 
+## How it works
+
 You can register multiple Kubernetes clusters with Teleport by deploying the
 Teleport Kubernetes Service on each cluster you want to register without having
 to distribute a joining secret to the Kubernetes cluster.
@@ -13,9 +15,6 @@ to distribute a joining secret to the Kubernetes cluster.
 Once the Kubernetes cluster is registered for the first time, the agent will store
 its Teleport identity in a Kubernetes secret. The agent will use this identity
 to automatically join the cluster on subsequent restarts.
-
-Support for joining a cluster with the Proxy Service behind a layer 7 load
-balancer or reverse proxy is available in Teleport 13.0+.
 
 ## Prerequisites
 

--- a/docs/pages/enroll-resources/machine-id/deployment/aws.mdx
+++ b/docs/pages/enroll-resources/machine-id/deployment/aws.mdx
@@ -6,6 +6,8 @@ description: How to install and configure Machine ID on an AWS EC2 instance
 This guide explains how to deploy Machine ID on Amazon Web Services by running
 the `tbot` binary and joining it to your Teleport cluster.
 
+## How it works
+
 On AWS, virtual machines can be assigned an IAM role, which they can assume in
 order to request a signed document that includes information about the machine.
 The Teleport `iam` join method instructs the Machine ID bot to request this

--- a/docs/pages/enroll-resources/machine-id/deployment/azure.mdx
+++ b/docs/pages/enroll-resources/machine-id/deployment/azure.mdx
@@ -8,6 +8,8 @@ bot will be configured to use the `azure` delegated joining method to
 authenticate to your Teleport cluster. This eliminates the need for long-lived
 secrets.
 
+## How it works
+
 On the Azure platform, virtual machines can be assigned a managed identity. The
 Azure platform will then make available to the virtual machine an attested
 data document and JWT that allows the virtual machine to act as this identity.

--- a/docs/pages/enroll-resources/machine-id/deployment/gcp.mdx
+++ b/docs/pages/enroll-resources/machine-id/deployment/gcp.mdx
@@ -6,6 +6,8 @@ description: How to install and configure Machine ID on a GCP VM
 This guide explains how to deploy Machine ID on Google Cloud Platform (GCP) by
 running the `tbot` binary and joining it to your Teleport cluster.
 
+## How it works
+
 On GCP, virtual machines can be assigned a service account. These machines can
 then request a signed JSON web token from GCP, which allows third parties to
 verify information about them, including their service accounts, using the GCP

--- a/docs/pages/enroll-resources/machine-id/deployment/kubernetes.mdx
+++ b/docs/pages/enroll-resources/machine-id/deployment/kubernetes.mdx
@@ -6,6 +6,8 @@ description: How to install and configure Machine ID on Kubernetes
 This guide shows you how to deploy the Machine ID daemon `tbot`, on a Kubernetes
 cluster.
 
+## How it works
+
 In the setup we demonstrate in this guide, `tbot` runs as a Kubernetes
 deployment. It writes output credentials to a Kubernetes secret, which can then
 be mounted in the pods that need to use the credentials. While `tbot` can also

--- a/docs/pages/enroll-resources/machine-id/deployment/linux.mdx
+++ b/docs/pages/enroll-resources/machine-id/deployment/linux.mdx
@@ -5,6 +5,8 @@ description: How to install and configure Machine ID on a Linux host
 
 This page explains how to deploy Machine ID on a Linux host.
 
+## How it works
+
 The process in which `tbot` initially authenticates with the Teleport cluster is
 known as joining. A join method is a specific technique for the bot to prove its
 identity.

--- a/docs/pages/enroll-resources/server-access/openssh/openssh-agentless.mdx
+++ b/docs/pages/enroll-resources/server-access/openssh/openssh-agentless.mdx
@@ -19,6 +19,8 @@ and running, but in the long run, we would recommend replacing `sshd` with `tele
 - [Session sharing](../../../connect-your-client/tsh.mdx)
 - [Advanced session recording](../guides/bpf-session-recording.mdx)
 
+## How it works
+
 Teleport supports OpenSSH by proxying SSH connections through the Proxy Service. When a Teleport user requests to connect to an OpenSSH node, the Proxy Service checks the user's Teleport roles.
 
 If the RBAC checks succeed, the Proxy Service authenticates to the OpenSSH node with a dynamically generated certificate signed by a Teleport CA. This allows the

--- a/docs/pages/enroll-resources/server-access/openssh/openssh-manual-install.mdx
+++ b/docs/pages/enroll-resources/server-access/openssh/openssh-manual-install.mdx
@@ -17,6 +17,8 @@ and running, but in the long run, we would recommend replacing `sshd` with `tele
 - [Session sharing](../../../connect-your-client/tsh.mdx)
 - [Advanced session recording](../guides/bpf-session-recording.mdx)
 
+## How it works
+
 Teleport supports OpenSSH by proxying SSH connections through the Proxy Service. When a Teleport user requests to connect to an OpenSSH node, the Proxy Service checks the user's Teleport roles.
 
 If the RBAC checks succeed, the Proxy Service authenticates to the OpenSSH node with a dynamically generated certificate signed by a Teleport CA. This allows the

--- a/docs/pages/get-started.mdx
+++ b/docs/pages/get-started.mdx
@@ -7,21 +7,23 @@ tocDepth: 3
 Teleport Enterprise helps organizations provide secure access to their
 infrastructure with minimal configuration and cluster management. 
 
+After you start a [free trial](https://goteleport.com/signup) of Teleport
+Enterprise (Cloud), you can set up role-based access control (RBAC), enable
+single sign-on, and prevent unauthorized use of organization resources.
+
+This guide explains how to register a local server with a Teleport Enterprise
+(Cloud) account. After you register the server, you can access it through the
+Teleport Web UI in a browser or using the terminal. You can also record your
+sessions, so you can review them later.
+
+## How it works
+
 With Teleport Enterprise (Cloud), the Teleport Auth Service and Teleport Proxy
 Service are managed for you as cloud-based services. These services provide you
 with immediate access to a scalable and fault-tolerant certificate authority and
 reverse proxy that you don't need to manage or maintain. You can focus on
 enrolling the resources you want to protect and configuring secure role-based
 access for private and public networks across the globe.
-
-After you start a [free trial](https://goteleport.com/signup) of Teleport
-Enterprise (Cloud), you can set up role-based access control (RBAC), enable
-single sign-on, and prevent unauthorized use of organization resources.
-
-This guide explains how to register a local server with a Teleport Enterprise
-(Cloud) account.  After you register the server, you can access it through the
-Teleport Web UI in a browser or using the terminal. You can also record your
-sessions, so you can review them later.
 
 ## Prerequisites
 


### PR DESCRIPTION
Fix step numbeing and `Var` name mismatch issues in the Azure Sync guide.

Fix minor issues in the following guides:
- AWS Console
- Azure AKS Workload ID
- Google Cloud API guide

Add "How it works" H2s to pages that already include an architectural explanation at the top of the page, and only need the H2 to be consistent with the intended structure of a docs how-to guide.