### PR TITLE
[v16] feat(join-tokens): API changes for managing GitHub Join Tokens

### DIFF
--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -131,6 +131,8 @@ type ProvisionToken interface {
 	SetAllowRules([]*TokenRule)
 	// GetGCPRules will return the GCP rules within this token.
 	GetGCPRules() *ProvisionTokenSpecV2GCP
+	// GetGithubRules will return the GitHub rules within this token.
+	GetGithubRules() *ProvisionTokenSpecV2GitHub
 	// GetAWSIIDTTL returns the TTL of EC2 IIDs
 	GetAWSIIDTTL() Duration
 	// GetJoinMethod returns joining method that must be used with this token.
@@ -420,6 +422,11 @@ func (p *ProvisionTokenV2) SetAllowRules(rules []*TokenRule) {
 // GetGCPRules will return the GCP rules within this token.
 func (p *ProvisionTokenV2) GetGCPRules() *ProvisionTokenSpecV2GCP {
 	return p.Spec.GCP
+}
+
+// GetGithubRules will return the GitHub rules within this token.
+func (p *ProvisionTokenV2) GetGithubRules() *ProvisionTokenSpecV2GitHub {
+	return p.Spec.GitHub
 }
 
 // GetAWSIIDTTL returns the TTL of EC2 IIDs

--- a/lib/web/join_tokens.go
+++ b/lib/web/join_tokens.go
@@ -206,7 +206,7 @@ func (h *Handler) upsertTokenHandle(w http.ResponseWriter, r *http.Request, para
 	var expires time.Time
 	switch req.JoinMethod {
 	case types.JoinMethodGCP, types.JoinMethodIAM, types.JoinMethodGitHub:
-		// IAM, GCP, Oracle and GitHub tokens should never expire.
+		// IAM, GCP and GitHub tokens should never expire.
 		expires = time.Time{}
 	default:
 		// Set expires time to default node join token TTL.

--- a/lib/web/join_tokens.go
+++ b/lib/web/join_tokens.go
@@ -184,29 +184,33 @@ type upsertTokenHandleRequest struct {
 	Name string `json:"name"`
 }
 
-func (h *Handler) upsertTokenHandle(w http.ResponseWriter, r *http.Request, params httprouter.Params, ctx *SessionContext) (interface{}, error) {
-	// if using the PUT route, tokenId will be present
-	// in the X-Teleport-TokenName header
-	editing := r.Method == "PUT"
-	tokenId := r.Header.Get(HeaderTokenName)
-	if editing && tokenId == "" {
-		return nil, trace.BadParameter("requires a token name to edit")
-	}
-
+func (h *Handler) upsertTokenHandle(w http.ResponseWriter, r *http.Request, params httprouter.Params, ctx *SessionContext) (any, error) {
 	var req upsertTokenHandleRequest
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if editing && tokenId != req.Name {
-		return nil, trace.BadParameter("renaming tokens is not supported")
+	clt, err := ctx.GetClient()
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
-	// set expires time to default node join token TTL
-	expires := time.Now().UTC().Add(defaults.NodeJoinTokenTTL)
-	// IAM and GCP tokens should never expire
-	if req.JoinMethod == types.JoinMethodGCP || req.JoinMethod == types.JoinMethodIAM {
-		expires = time.Now().UTC().AddDate(1000, 0, 0)
+	var existingToken types.ProvisionToken
+	if req.Name != "" {
+		existingToken, err = clt.GetToken(r.Context(), req.Name)
+		if err != nil && !trace.IsNotFound(err) {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	var expires time.Time
+	switch req.JoinMethod {
+	case types.JoinMethodGCP, types.JoinMethodIAM, types.JoinMethodGitHub:
+		// IAM, GCP, Oracle and GitHub tokens should never expire.
+		expires = time.Time{}
+	default:
+		// Set expires time to default node join token TTL.
+		expires = time.Now().UTC().Add(defaults.NodeJoinTokenTTL)
 	}
 
 	name := req.Name
@@ -223,9 +227,9 @@ func (h *Handler) upsertTokenHandle(w http.ResponseWriter, r *http.Request, para
 		return nil, trace.Wrap(err)
 	}
 
-	clt, err := ctx.GetClient()
-	if err != nil {
-		return nil, trace.Wrap(err)
+	// If this is an edit, then overwrite the metadata to retain the existing fields
+	if existingToken != nil {
+		token.SetMetadata(existingToken.GetMetadata())
 	}
 
 	err = clt.UpsertToken(r.Context(), token)

--- a/lib/web/join_tokens_test.go
+++ b/lib/web/join_tokens_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/gravitational/roundtrip"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -94,8 +95,8 @@ func TestGenerateIAMTokenName(t *testing.T) {
 
 type tokenData struct {
 	name   string
-	roles  types.SystemRoles
 	expiry time.Time
+	spec   types.ProvisionTokenSpecV2
 }
 
 func TestGetTokens(t *testing.T) {
@@ -147,25 +148,31 @@ func TestGetTokens(t *testing.T) {
 			tokenData: []tokenData{
 				{
 					name: "test-token",
-					roles: types.SystemRoles{
-						types.RoleNode,
+					spec: types.ProvisionTokenSpecV2{
+						Roles: types.SystemRoles{
+							types.RoleNode,
+						},
 					},
 					expiry: expiry,
 				},
 				{
 					name: "test-token-2",
-					roles: types.SystemRoles{
-						types.RoleNode,
-						types.RoleDatabase,
+					spec: types.ProvisionTokenSpecV2{
+						Roles: types.SystemRoles{
+							types.RoleNode,
+							types.RoleDatabase,
+						},
 					},
 					expiry: expiry,
 				},
 				{
 					name: "test-token-3-and-super-duper-long",
-					roles: types.SystemRoles{
-						types.RoleNode,
-						types.RoleKube,
-						types.RoleDatabase,
+					spec: types.ProvisionTokenSpecV2{
+						Roles: types.SystemRoles{
+							types.RoleNode,
+							types.RoleKube,
+							types.RoleDatabase,
+						},
 					},
 					expiry: expiry,
 				},
@@ -203,6 +210,64 @@ func TestGetTokens(t *testing.T) {
 						types.RoleDatabase,
 					},
 					Method: types.JoinMethodToken,
+				},
+				staticUIToken,
+			},
+		},
+		{
+			name: "github token",
+			tokenData: []tokenData{
+				{
+					name: "github-test-token",
+					spec: types.ProvisionTokenSpecV2{
+						Roles: types.SystemRoles{
+							types.RoleBot,
+						},
+						BotName:    "test-bot",
+						JoinMethod: types.JoinMethodGitHub,
+						GitHub: &types.ProvisionTokenSpecV2GitHub{
+							EnterpriseServerHost: "github.example.com",
+							StaticJWKS:           "{\"keys\":[]}",
+							Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
+								{
+									Repository:      "gravitational/teleport",
+									RepositoryOwner: "gravitational",
+									Sub:             "test-sub",
+									Workflow:        "test-workflow",
+									Environment:     "test-environment",
+									Actor:           "octocat",
+									Ref:             "ref/heads/main",
+									RefType:         "branch",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []ui.JoinToken{
+				{
+					ID:       "github-test-token",
+					SafeName: "github-test-token",
+					BotName:  "test-bot",
+					Expiry:   time.Time{},
+					Roles:    types.SystemRoles{"Bot"},
+					Method:   types.JoinMethodGitHub,
+					Github: &types.ProvisionTokenSpecV2GitHub{
+						EnterpriseServerHost: "github.example.com",
+						StaticJWKS:           "{\"keys\":[]}",
+						Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
+							{
+								Repository:      "gravitational/teleport",
+								RepositoryOwner: "gravitational",
+								Sub:             "test-sub",
+								Workflow:        "test-workflow",
+								Environment:     "test-environment",
+								Actor:           "octocat",
+								Ref:             "ref/heads/main",
+								RefType:         "branch",
+							},
+						},
+					},
 				},
 				staticUIToken,
 			},
@@ -247,9 +312,7 @@ func TestGetTokens(t *testing.T) {
 			}
 
 			for _, td := range tc.tokenData {
-				token, err := types.NewProvisionTokenFromSpec(td.name, td.expiry, types.ProvisionTokenSpecV2{
-					Roles: td.roles,
-				})
+				token, err := types.NewProvisionTokenFromSpec(td.name, td.expiry, td.spec)
 				require.NoError(t, err)
 				err = env.server.Auth().CreateToken(ctx, token)
 				require.NoError(t, err)
@@ -333,6 +396,216 @@ func TestDeleteToken(t *testing.T) {
 	require.NoError(t, json.Unmarshal(re.Bytes(), &resp))
 	require.Len(t, resp.Items, 1 /* only static again */)
 	require.Empty(t, cmp.Diff(resp.Items, []ui.JoinToken{staticUIToken}, cmpopts.IgnoreFields(ui.JoinToken{}, "Content")))
+}
+
+func TestEditToken(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	username := "test-user@example.com"
+	env := newWebPack(t, 1)
+	proxy := env.proxies[0]
+	pack := proxy.authPack(t, username, nil /* roles */)
+
+	expiry := time.Now().UTC()
+
+	tcs := []struct {
+		Name   string
+		Method func(ctx context.Context, endpoint string, val any) (*roundtrip.Response, error)
+	}{
+		{Name: "http_post", Method: pack.clt.PostJSON},
+		{Name: "http_put", Method: pack.clt.PutJSON},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+
+			// Setup an existing token
+			spec := types.ProvisionTokenSpecV2{
+				Roles:      types.SystemRoles{types.RoleBot},
+				BotName:    "test-bot",
+				JoinMethod: types.JoinMethodGitHub,
+
+				GitHub: &types.ProvisionTokenSpecV2GitHub{
+					Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
+						{
+							Repository: "gravitational/teleport",
+						},
+					},
+				},
+			}
+			tokenName := "github-test-token" + tc.Name
+			token, err := types.NewProvisionTokenFromSpec(tokenName, time.Time{}, spec)
+			require.NoError(t, err)
+			token.SetExpiry(expiry)
+			token.SetLabels(map[string]string{
+				"test-key": "test-value",
+			})
+			err = env.server.Auth().CreateToken(ctx, token)
+			require.NoError(t, err)
+
+			// Make a simple edit
+			spec.BotName = "test-bot_EDITED"
+			data := struct {
+				types.ProvisionTokenSpecV2
+				Name string `json:"name"`
+			}{
+				ProvisionTokenSpecV2: spec,
+				Name:                 tokenName,
+			}
+			endpointV1 := pack.clt.Endpoint("v1", "webapi", "tokens")
+			_, err = tc.Method(ctx, endpointV1, data)
+			require.NoError(t, err)
+
+			// Fetch the token and compare
+			editedToken, err := env.server.Auth().GetToken(ctx, tokenName)
+			require.NoError(t, err)
+			require.Equal(t, "test-bot_EDITED", editedToken.GetBotName())
+			require.Equal(t, expiry, *editedToken.GetMetadata().Expires)
+			require.Equal(t, map[string]string{
+				"test-key": "test-value",
+			}, editedToken.GetMetadata().Labels)
+		})
+	}
+}
+
+func TestCreateTokenExpiry(t *testing.T) {
+	// Can't t.Parallel because of modules.SetTestModules.
+	// Use enterprise build to access token types such as TPM and Spacelift
+	modules.SetTestModules(t, &modules.TestModules{
+		TestBuildType: modules.BuildEnterprise,
+		TestFeatures: modules.Features{
+			Cloud: false,
+		},
+	})
+
+	ctx := context.Background()
+	username := "test-user@example.com"
+	env := newWebPack(t, 1)
+	proxy := env.proxies[0]
+	pack := proxy.authPack(t, username, nil /* roles */)
+
+	for _, method := range types.JoinMethods {
+		t.Run(string(method), func(t *testing.T) {
+			spec := types.ProvisionTokenSpecV2{
+				Roles:      []types.SystemRole{types.RoleNode},
+				JoinMethod: method,
+			}
+			setMinimalConfigForMethod(&spec, method)
+
+			var expectedExpiry time.Time
+			switch method {
+			case types.JoinMethodGCP, types.JoinMethodIAM, types.JoinMethodGitHub:
+				expectedExpiry = time.Time{}
+			default:
+				expectedExpiry = time.Now().UTC().Add(4 * time.Hour)
+			}
+
+			endpointV1 := pack.clt.Endpoint("v1", "webapi", "tokens")
+			re, err := pack.clt.PostJSON(ctx, endpointV1, spec)
+			require.NoError(t, err)
+
+			resp := nodeJoinToken{}
+			require.NoError(t, json.Unmarshal(re.Bytes(), &resp))
+			require.Equal(t, method, resp.Method)
+			require.WithinDuration(t, expectedExpiry, resp.Expiry, 100*time.Millisecond)
+		})
+	}
+}
+
+func setMinimalConfigForMethod(spec *types.ProvisionTokenSpecV2, method types.JoinMethod) {
+	switch method {
+	case types.JoinMethodIAM, types.JoinMethodEC2:
+		spec.Allow = []*types.TokenRule{
+			{
+				AWSAccount: "test-account",
+			},
+		}
+	case types.JoinMethodAzure:
+		spec.Azure = &types.ProvisionTokenSpecV2Azure{
+			Allow: []*types.ProvisionTokenSpecV2Azure_Rule{
+				{
+					Subscription: "test-sub",
+				},
+			},
+		}
+	case types.JoinMethodBitbucket:
+		spec.Bitbucket = &types.ProvisionTokenSpecV2Bitbucket{
+			Audience:            "test-audience",
+			IdentityProviderURL: "test-identity-provider-url",
+			Allow: []*types.ProvisionTokenSpecV2Bitbucket_Rule{
+				{
+					WorkspaceUUID: "test-workspace-uuid",
+				},
+			},
+		}
+	case types.JoinMethodTerraformCloud:
+		spec.TerraformCloud = &types.ProvisionTokenSpecV2TerraformCloud{
+			Allow: []*types.ProvisionTokenSpecV2TerraformCloud_Rule{
+				{
+					OrganizationID: "test-org-id",
+					ProjectID:      "test-proj-id",
+				},
+			},
+		}
+	case types.JoinMethodKubernetes:
+		spec.Kubernetes = &types.ProvisionTokenSpecV2Kubernetes{
+			Allow: []*types.ProvisionTokenSpecV2Kubernetes_Rule{
+				{
+					ServiceAccount: "test:service-account",
+				},
+			},
+		}
+	case types.JoinMethodGitLab:
+		spec.GitLab = &types.ProvisionTokenSpecV2GitLab{
+			Allow: []*types.ProvisionTokenSpecV2GitLab_Rule{
+				{
+					Sub: "test-sub",
+				},
+			},
+		}
+	case types.JoinMethodGitHub:
+		spec.GitHub = &types.ProvisionTokenSpecV2GitHub{
+			Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
+				{
+					Sub: "test-sub",
+				},
+			},
+		}
+	case types.JoinMethodGCP:
+		spec.GCP = &types.ProvisionTokenSpecV2GCP{
+			Allow: []*types.ProvisionTokenSpecV2GCP_Rule{
+				{
+					ProjectIDs: []string{"test-project-id"},
+				},
+			},
+		}
+	case types.JoinMethodCircleCI:
+		spec.CircleCI = &types.ProvisionTokenSpecV2CircleCI{
+			Allow: []*types.ProvisionTokenSpecV2CircleCI_Rule{
+				{
+					ProjectID: "test-project-id",
+				},
+			},
+			OrganizationID: "test-org-id",
+		}
+	case types.JoinMethodTPM:
+		spec.TPM = &types.ProvisionTokenSpecV2TPM{
+			Allow: []*types.ProvisionTokenSpecV2TPM_Rule{
+				{
+					EKPublicHash: "test-hash",
+				},
+			},
+		}
+	case types.JoinMethodSpacelift:
+		spec.Spacelift = &types.ProvisionTokenSpecV2Spacelift{
+			Hostname: "test-hostname",
+			Allow: []*types.ProvisionTokenSpecV2Spacelift_Rule{
+				{
+					SpaceID: "test-space-id",
+				},
+			},
+		}
+	}
 }
 
 func TestGenerateAzureTokenName(t *testing.T) {

--- a/lib/web/ui/join_token.go
+++ b/lib/web/ui/join_token.go
@@ -47,6 +47,8 @@ type JoinToken struct {
 	Allow []*types.TokenRule `json:"allow,omitempty"`
 	// GCP allows the configuration of options specific to the "gcp" join method.
 	GCP *types.ProvisionTokenSpecV2GCP `json:"gcp,omitempty"`
+	// GitHub-specific configuration for the join method.
+	Github *types.ProvisionTokenSpecV2GitHub `json:"github,omitempty"`
 	// Content is resource yaml content.
 	Content string `json:"content"`
 }
@@ -71,6 +73,11 @@ func MakeJoinToken(token types.ProvisionToken) (*JoinToken, error) {
 	if uiToken.Method == types.JoinMethodGCP {
 		uiToken.GCP = token.GetGCPRules()
 	}
+
+	if uiToken.Method == types.JoinMethodGitHub {
+		uiToken.Github = token.GetGithubRules()
+	}
+
 	return uiToken, nil
 }
 

--- a/lib/web/yaml.go
+++ b/lib/web/yaml.go
@@ -63,6 +63,14 @@ func (h *Handler) yamlParse(w http.ResponseWriter, r *http.Request, params httpr
 
 		return yamlParseResponse{Resource: resource}, nil
 
+	case types.KindToken:
+		resource, err := yamlToProvisionToken(req.YAML)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		return yamlParseResponse{Resource: resource}, nil
+
 	default:
 		return nil, trace.NotImplemented("parsing YAML for kind %q is not supported", kind)
 	}
@@ -106,6 +114,22 @@ func ConvertYAMLToAccessMonitoringRuleResource(yaml string) (*accessmonitoringru
 		return nil, trace.BadParameter("resource kind %q is invalid", extractedRes.Kind)
 	}
 	resource, err := services.UnmarshalAccessMonitoringRule(extractedRes.Raw)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return resource, nil
+}
+
+func yamlToProvisionToken(yaml string) (types.ProvisionToken, error) {
+	extractedRes, err := extractResource(yaml)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if extractedRes.Kind != types.KindToken {
+		return nil, trace.BadParameter("resource kind %q is invalid, only token is allowed", extractedRes.Kind)
+	}
+	resource, err := services.UnmarshalProvisionToken(extractedRes.Raw)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/54374 to branch/v16

changelog: Fixed an issue causing Join Token expiries to be overwritten when editing a token