### PR TITLE
[v16] Use new access_list_title when showing audit events

### DIFF
--- a/web/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
+++ b/web/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
@@ -2486,7 +2486,7 @@ exports[`list of all events 1`] = `
         <td
           style="word-break: break-word;"
         >
-          User [mike] failed to remove all members from access list [access-list]
+          User [mike] failed to remove all members from access list [example_title]
         </td>
         <td
           style="min-width: 120px;"
@@ -2534,7 +2534,7 @@ exports[`list of all events 1`] = `
         <td
           style="word-break: break-word;"
         >
-          User [mike] removed all members from access list [access-list]
+          User [mike] removed all members from access list [example_title]
         </td>
         <td
           style="min-width: 120px;"
@@ -2588,7 +2588,7 @@ exports[`list of all events 1`] = `
         <td
           style="word-break: break-word;"
         >
-          User [mike] failed to remove members [carrot, apple, banana] from access list [access-list]
+          User [mike] failed to remove members [carrot, apple, banana] from access list [example_title]
         </td>
         <td
           style="min-width: 120px;"
@@ -2636,7 +2636,7 @@ exports[`list of all events 1`] = `
         <td
           style="word-break: break-word;"
         >
-          User [mike] removed member [user] from access list [access-list]
+          User [mike] removed member [user] from access list [example_title]
         </td>
         <td
           style="min-width: 120px;"
@@ -2690,7 +2690,7 @@ exports[`list of all events 1`] = `
         <td
           style="word-break: break-word;"
         >
-          User [mike] failed to update member [user] in access list [access-list]
+          User [mike] failed to update member [user] in access list [example_title]
         </td>
         <td
           style="min-width: 120px;"
@@ -2738,7 +2738,7 @@ exports[`list of all events 1`] = `
         <td
           style="word-break: break-word;"
         >
-          User [mike] updated member [user] in access list [access-list]
+          User [mike] updated member [user] in access list [example_title]
         </td>
         <td
           style="min-width: 120px;"
@@ -2792,7 +2792,7 @@ exports[`list of all events 1`] = `
         <td
           style="word-break: break-word;"
         >
-          User [mike] failed to add member [user] to access list [access-list]
+          User [mike] failed to add member [user] to access list [example_title]
         </td>
         <td
           style="min-width: 120px;"
@@ -2840,7 +2840,7 @@ exports[`list of all events 1`] = `
         <td
           style="word-break: break-word;"
         >
-          User [mike] added member [user] to access list [access-list]
+          User [mike] added member [user] to access list [example_title]
         </td>
         <td
           style="min-width: 120px;"
@@ -2894,7 +2894,7 @@ exports[`list of all events 1`] = `
         <td
           style="word-break: break-word;"
         >
-          User [mike] failed to to review access list [access-list]
+          User [mike] failed to to review access list [example_title]
         </td>
         <td
           style="min-width: 120px;"
@@ -2948,7 +2948,7 @@ exports[`list of all events 1`] = `
         <td
           style="word-break: break-word;"
         >
-          User [mike] reviewed access list [access-list]
+          User [mike] reviewed access list [example_title]
         </td>
         <td
           style="min-width: 120px;"
@@ -3002,7 +3002,7 @@ exports[`list of all events 1`] = `
         <td
           style="word-break: break-word;"
         >
-          User [mike] failed to delete access list [access-list]
+          User [mike] failed to delete access list [example_title]
         </td>
         <td
           style="min-width: 120px;"
@@ -3056,7 +3056,7 @@ exports[`list of all events 1`] = `
         <td
           style="word-break: break-word;"
         >
-          User [mike] deleted access list [access-list]
+          User [mike] deleted access list [example_title]
         </td>
         <td
           style="min-width: 120px;"
@@ -3110,7 +3110,7 @@ exports[`list of all events 1`] = `
         <td
           style="word-break: break-word;"
         >
-          User [mike] failed to update access list [access-list]
+          User [mike] failed to update access list [example_title]
         </td>
         <td
           style="min-width: 120px;"
@@ -3164,7 +3164,7 @@ exports[`list of all events 1`] = `
         <td
           style="word-break: break-word;"
         >
-          User [mike] updated access list [access-list]
+          User [mike] updated access list [example_title]
         </td>
         <td
           style="min-width: 120px;"
@@ -3218,7 +3218,7 @@ exports[`list of all events 1`] = `
         <td
           style="word-break: break-word;"
         >
-          User [mike] failed to create access list [access-list]
+          User [mike] failed to create access list [example_title]
         </td>
         <td
           style="min-width: 120px;"
@@ -3272,7 +3272,7 @@ exports[`list of all events 1`] = `
         <td
           style="word-break: break-word;"
         >
-          User [mike] created access list [access-list]
+          User [mike] created access list [example_title]
         </td>
         <td
           style="min-width: 120px;"

--- a/web/packages/teleport/src/Audit/fixtures/index.ts
+++ b/web/packages/teleport/src/Audit/fixtures/index.ts
@@ -3320,6 +3320,7 @@ export const events = [
     time: '2023-05-08T19:21:36.144Z',
     name: 'access-list',
     updated_by: 'mike',
+    access_list_title: 'example_title',
   },
   {
     code: 'TAL001E',
@@ -3327,6 +3328,7 @@ export const events = [
     time: '2023-05-08T19:21:36.144Z',
     name: 'access-list',
     updated_by: 'mike',
+    access_list_title: 'example_title',
   },
   {
     code: 'TAL002I',
@@ -3334,6 +3336,7 @@ export const events = [
     time: '2023-05-08T19:21:36.144Z',
     name: 'access-list',
     updated_by: 'mike',
+    access_list_title: 'example_title',
   },
   {
     code: 'TAL002E',
@@ -3341,6 +3344,7 @@ export const events = [
     time: '2023-05-08T19:21:36.144Z',
     name: 'access-list',
     updated_by: 'mike',
+    access_list_title: 'example_title',
   },
   {
     code: 'TAL003I',
@@ -3348,6 +3352,7 @@ export const events = [
     time: '2023-05-08T19:21:36.144Z',
     name: 'access-list',
     updated_by: 'mike',
+    access_list_title: 'example_title',
   },
   {
     code: 'TAL003E',
@@ -3355,6 +3360,7 @@ export const events = [
     time: '2023-05-08T19:21:36.144Z',
     name: 'access-list',
     updated_by: 'mike',
+    access_list_title: 'example_title',
   },
   {
     code: 'TAL004I',
@@ -3362,6 +3368,7 @@ export const events = [
     time: '2023-05-08T19:21:36.144Z',
     name: 'access-list',
     updated_by: 'mike',
+    access_list_title: 'example_title',
   },
   {
     code: 'TAL004E',
@@ -3369,12 +3376,14 @@ export const events = [
     time: '2023-05-08T19:21:36.144Z',
     name: 'access-list',
     updated_by: 'mike',
+    access_list_title: 'example_title',
   },
   {
     code: 'TAL005I',
     event: 'access_list.member.add',
     time: '2023-05-08T19:21:36.144Z',
     access_list_name: 'access-list',
+    access_list_title: 'example_title',
     members: [
       {
         member_name: 'user',
@@ -3387,6 +3396,7 @@ export const events = [
     event: 'access_list.member.add',
     time: '2023-05-08T19:21:36.144Z',
     access_list_name: 'access-list',
+    access_list_title: 'example_title',
     members: [
       {
         member_name: 'user',
@@ -3399,6 +3409,7 @@ export const events = [
     event: 'access_list.member.update',
     time: '2023-05-08T19:21:36.144Z',
     access_list_name: 'access-list',
+    access_list_title: 'example_title',
     members: [
       {
         member_name: 'user',
@@ -3411,6 +3422,7 @@ export const events = [
     event: 'access_list.member.update',
     time: '2023-05-08T19:21:36.144Z',
     access_list_name: 'access-list',
+    access_list_title: 'example_title',
     members: [
       {
         member_name: 'user',
@@ -3423,6 +3435,7 @@ export const events = [
     event: 'access_list.member.delete',
     time: '2023-05-08T19:21:36.144Z',
     access_list_name: 'access-list',
+    access_list_title: 'example_title',
     members: [
       {
         member_name: 'user',
@@ -3435,6 +3448,7 @@ export const events = [
     event: 'access_list.member.delete',
     time: '2023-05-08T19:21:36.144Z',
     access_list_name: 'access-list',
+    access_list_title: 'example_title',
     members: [
       {
         member_name: 'carrot',
@@ -3453,6 +3467,7 @@ export const events = [
     event: 'access_list.member.delete_all_members',
     time: '2023-05-08T19:21:36.144Z',
     access_list_name: 'access-list',
+    access_list_title: 'example_title',
     updated_by: 'mike',
   },
   {
@@ -3460,6 +3475,7 @@ export const events = [
     event: 'access_list.member.delete_all_members',
     time: '2023-05-08T19:21:36.144Z',
     access_list_name: 'access-list',
+    access_list_title: 'example_title',
     updated_by: 'mike',
   },
   {

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -1882,15 +1882,15 @@ export const formatters: Formatters = {
   [eventCodes.ACCESS_LIST_MEMBER_DELETE_ALL_FOR_ACCESS_LIST_FAILURE]: {
     type: 'access_list.member.delete_all_members',
     desc: 'Access list member delete all members failure',
-      format: ({ access_list_title, access_list_name, updated_by }) => {
+    format: ({ access_list_title, access_list_name, updated_by }) => {
       return `User [${updated_by}] failed to remove all members from access list [${access_list_title || access_list_name}]`;
     },
   },
   [eventCodes.USER_LOGIN_INVALID_ACCESS_LIST]: {
     type: 'user_login.invalid_access_list',
     desc: 'Access list skipped.',
-    format: ({ access_list_title, user, missing_roles }) =>
-      `Access list [${access_list_title}] is invalid and was skipped for member [${user}] because it references non-existent role${missing_roles.length > 1 ? 's' : ''} [${missing_roles}]`,
+    format: ({ access_list_title, access_list_name, user, missing_roles }) =>
+      `Access list [${access_list_title || access_list_name}] is invalid and was skipped for member [${user}] because it references non-existent role${missing_roles.length > 1 ? 's' : ''} [${missing_roles}]`,
   },
   [eventCodes.SECURITY_REPORT_AUDIT_QUERY_RUN]: {
     type: 'secreports.audit.query.run"',

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -1767,110 +1767,172 @@ export const formatters: Formatters = {
   [eventCodes.ACCESS_LIST_CREATE]: {
     type: 'access_list.create',
     desc: 'Access list created',
-    format: ({ access_list_title, updated_by }) =>
-      `User [${updated_by}] created access list [${access_list_title}]`,
+    format: ({ access_list_title, name, updated_by }) => {
+      return (
+        `User [${updated_by}] created access list ` +
+        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
+      );
+    },
   },
   [eventCodes.ACCESS_LIST_CREATE_FAILURE]: {
     type: 'access_list.create',
     desc: 'Access list create failed',
-    format: ({ access_list_title, updated_by }) =>
-      `User [${updated_by}] failed to create access list [${access_list_title}]`,
+    format: ({ access_list_title, name, updated_by }) => {
+      return (
+        `User [${updated_by}] failed to create access list ` +
+        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
+      );
+    },
   },
   [eventCodes.ACCESS_LIST_UPDATE]: {
     type: 'access_list.update',
     desc: 'Access list updated',
-    format: ({ access_list_title, updated_by }) =>
-      `User [${updated_by}] updated access list [${access_list_title}]`,
+    format: ({ access_list_title, name, updated_by }) => {
+      return (
+        `User [${updated_by}] updated access list ` +
+        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
+      );
+    },
   },
   [eventCodes.ACCESS_LIST_UPDATE_FAILURE]: {
     type: 'access_list.update',
     desc: 'Access list update failed',
-    format: ({ access_list_title, updated_by }) =>
-      `User [${updated_by}] failed to update access list [${access_list_title}]`,
+    format: ({ access_list_title, name, updated_by }) => {
+      return (
+        `User [${updated_by}] failed to update access list ` +
+        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
+      );
+    },
   },
   [eventCodes.ACCESS_LIST_DELETE]: {
     type: 'access_list.delete',
     desc: 'Access list deleted',
-    format: ({ access_list_title, updated_by }) =>
-      `User [${updated_by}] deleted access list [${access_list_title}]`,
+    format: ({ access_list_title, name, updated_by }) => {
+      return (
+        `User [${updated_by}] deleted access list ` +
+        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
+      );
+    },
   },
   [eventCodes.ACCESS_LIST_DELETE_FAILURE]: {
     type: 'access_list.delete',
     desc: 'Access list delete failed',
-    format: ({ access_list_title, updated_by }) =>
-      `User [${updated_by}] failed to delete access list [${access_list_title}]`,
+    format: ({ access_list_title, name, updated_by }) => {
+      return (
+        `User [${updated_by}] failed to delete access list ` +
+        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
+      );
+    },
   },
   [eventCodes.ACCESS_LIST_REVIEW]: {
     type: 'access_list.review',
     desc: 'Access list reviewed',
-    format: ({ access_list_title, updated_by }) =>
-      `User [${updated_by}] reviewed access list [${access_list_title}]`,
+    format: ({ access_list_title, name, updated_by }) => {
+      return (
+        `User [${updated_by}] reviewed access list ` +
+        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
+      );
+    },
   },
   [eventCodes.ACCESS_LIST_REVIEW_FAILURE]: {
     type: 'access_list.review',
     desc: 'Access list review failed',
-    format: ({ access_list_title, updated_by }) =>
-      `User [${updated_by}] failed to to review access list [${access_list_title}]`,
+    format: ({ access_list_title, name, updated_by }) => {
+      return (
+        `User [${updated_by}] failed to to review access list ` +
+        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
+      );
+    },
   },
   [eventCodes.ACCESS_LIST_MEMBER_CREATE]: {
     type: 'access_list.member.create',
     desc: 'Access list member added',
-    format: ({ access_list_title, members, updated_by }) =>
-      `User [${updated_by}] added ${formatMembers(
-        members
-      )} to access list [${access_list_title}]`,
+    format: ({ access_list_title, members, access_list_name, updated_by }) => {
+      return (
+        `User [${updated_by}] added ${formatMembers(members)} to access list ` +
+        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
+      );
+    },
   },
   [eventCodes.ACCESS_LIST_MEMBER_CREATE_FAILURE]: {
     type: 'access_list.member.create',
     desc: 'Access list member addition failure',
-    format: ({ access_list_title, members, updated_by }) =>
-      `User [${updated_by}] failed to add ${formatMembers(
-        members
-      )} to access list [${access_list_title}]`,
+    format: ({ access_list_title, members, access_list_name, updated_by }) => {
+      return (
+        `User [${updated_by}] failed to add ${formatMembers(
+          members
+        )} to access list ` +
+        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
+      );
+    },
   },
   [eventCodes.ACCESS_LIST_MEMBER_UPDATE]: {
     type: 'access_list.member.update',
     desc: 'Access list member updated',
-    format: ({ access_list_title, members, updated_by }) =>
-      `User [${updated_by}] updated ${formatMembers(
-        members
-      )} in access list [${access_list_title}]`,
+    format: ({ access_list_title, members, access_list_name, updated_by }) => {
+      return (
+        `User [${updated_by}] updated ${formatMembers(
+          members
+        )} in access list ` +
+        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
+      );
+    },
   },
   [eventCodes.ACCESS_LIST_MEMBER_UPDATE_FAILURE]: {
     type: 'access_list.member.update',
     desc: 'Access list member update failure',
-    format: ({ access_list_title, members, updated_by }) =>
-      `User [${updated_by}] failed to update ${formatMembers(
-        members
-      )} in access list [${access_list_title}]`,
+    format: ({ access_list_title, members, access_list_name, updated_by }) => {
+      return (
+        `User [${updated_by}] failed to update ${formatMembers(
+          members
+        )} in access list ` +
+        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
+      );
+    },
   },
   [eventCodes.ACCESS_LIST_MEMBER_DELETE]: {
     type: 'access_list.member.delete',
     desc: 'Access list member removed',
-    format: ({ access_list_title, members, updated_by }) =>
-      `User [${updated_by}] removed ${formatMembers(
-        members
-      )} from access list [${access_list_title}]`,
+    format: ({ access_list_title, members, access_list_name, updated_by }) => {
+      return (
+        `User [${updated_by}] removed ${formatMembers(
+          members
+        )} from access list ` +
+        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
+      );
+    },
   },
   [eventCodes.ACCESS_LIST_MEMBER_DELETE_FAILURE]: {
     type: 'access_list.member.delete',
     desc: 'Access list member removal failure',
-    format: ({ access_list_title, members, updated_by }) =>
-      `User [${updated_by}] failed to remove ${formatMembers(
-        members
-      )} from access list [${access_list_title}]`,
+    format: ({ access_list_title, members, access_list_name, updated_by }) => {
+      return (
+        `User [${updated_by}] failed to remove ${formatMembers(
+          members
+        )} from access list [${access_list_title}]` +
+        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
+      );
+    },
   },
   [eventCodes.ACCESS_LIST_MEMBER_DELETE_ALL_FOR_ACCESS_LIST]: {
     type: 'access_list.member.delete_all_members',
     desc: 'All members removed from access list',
-    format: ({ access_list_title, updated_by }) =>
-      `User [${updated_by}] removed all members from access list [${access_list_title}]`,
+    format: ({ access_list_title, access_list_name, updated_by }) => {
+      return (
+        `User [${updated_by}] removed all members from access list ` +
+        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
+      );
+    },
   },
   [eventCodes.ACCESS_LIST_MEMBER_DELETE_ALL_FOR_ACCESS_LIST_FAILURE]: {
     type: 'access_list.member.delete_all_members',
     desc: 'Access list member delete all members failure',
-    format: ({ access_list_title, updated_by }) =>
-      `User [${updated_by}] failed to remove all members from access list [${access_list_title}]`,
+    format: ({ access_list_title, updated_by }) => {
+      return (
+        `User [${updated_by}] failed to remove all members from access list ` +
+        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
+      );
+    },
   },
   [eventCodes.USER_LOGIN_INVALID_ACCESS_LIST]: {
     type: 'user_login.invalid_access_list',

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -1882,7 +1882,7 @@ export const formatters: Formatters = {
   [eventCodes.ACCESS_LIST_MEMBER_DELETE_ALL_FOR_ACCESS_LIST_FAILURE]: {
     type: 'access_list.member.delete_all_members',
     desc: 'Access list member delete all members failure',
-    format: ({ access_list_title, updated_by }) => {
+      format: ({ access_list_title, access_list_name, updated_by }) => {
       return `User [${updated_by}] failed to remove all members from access list [${access_list_title || access_list_name}]`;
     },
   },

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -1767,116 +1767,116 @@ export const formatters: Formatters = {
   [eventCodes.ACCESS_LIST_CREATE]: {
     type: 'access_list.create',
     desc: 'Access list created',
-    format: ({ name, updated_by }) =>
-      `User [${updated_by}] created access list [${name}]`,
+    format: ({ access_list_title, updated_by }) =>
+      `User [${updated_by}] created access list [${access_list_title}]`,
   },
   [eventCodes.ACCESS_LIST_CREATE_FAILURE]: {
     type: 'access_list.create',
     desc: 'Access list create failed',
-    format: ({ name, updated_by }) =>
-      `User [${updated_by}] failed to create access list [${name}]`,
+    format: ({ access_list_title, updated_by }) =>
+      `User [${updated_by}] failed to create access list [${access_list_title}]`,
   },
   [eventCodes.ACCESS_LIST_UPDATE]: {
     type: 'access_list.update',
     desc: 'Access list updated',
-    format: ({ name, updated_by }) =>
-      `User [${updated_by}] updated access list [${name}]`,
+    format: ({ access_list_title, updated_by }) =>
+      `User [${updated_by}] updated access list [${access_list_title}]`,
   },
   [eventCodes.ACCESS_LIST_UPDATE_FAILURE]: {
     type: 'access_list.update',
     desc: 'Access list update failed',
-    format: ({ name, updated_by }) =>
-      `User [${updated_by}] failed to update access list [${name}]`,
+    format: ({ access_list_title, updated_by }) =>
+      `User [${updated_by}] failed to update access list [${access_list_title}]`,
   },
   [eventCodes.ACCESS_LIST_DELETE]: {
     type: 'access_list.delete',
     desc: 'Access list deleted',
-    format: ({ name, updated_by }) =>
-      `User [${updated_by}] deleted access list [${name}]`,
+    format: ({ access_list_title, updated_by }) =>
+      `User [${updated_by}] deleted access list [${access_list_title}]`,
   },
   [eventCodes.ACCESS_LIST_DELETE_FAILURE]: {
     type: 'access_list.delete',
     desc: 'Access list delete failed',
-    format: ({ name, updated_by }) =>
-      `User [${updated_by}] failed to delete access list [${name}]`,
+    format: ({ access_list_title, updated_by }) =>
+      `User [${updated_by}] failed to delete access list [${access_list_title}]`,
   },
   [eventCodes.ACCESS_LIST_REVIEW]: {
     type: 'access_list.review',
     desc: 'Access list reviewed',
-    format: ({ name, updated_by }) =>
-      `User [${updated_by}] reviewed access list [${name}]`,
+    format: ({ access_list_title, updated_by }) =>
+      `User [${updated_by}] reviewed access list [${access_list_title}]`,
   },
   [eventCodes.ACCESS_LIST_REVIEW_FAILURE]: {
     type: 'access_list.review',
     desc: 'Access list review failed',
-    format: ({ name, updated_by }) =>
-      `User [${updated_by}] failed to to review access list [${name}]`,
+    format: ({ access_list_title, updated_by }) =>
+      `User [${updated_by}] failed to to review access list [${access_list_title}]`,
   },
   [eventCodes.ACCESS_LIST_MEMBER_CREATE]: {
     type: 'access_list.member.create',
     desc: 'Access list member added',
-    format: ({ access_list_name, members, updated_by }) =>
+    format: ({ access_list_title, members, updated_by }) =>
       `User [${updated_by}] added ${formatMembers(
         members
-      )} to access list [${access_list_name}]`,
+      )} to access list [${access_list_title}]`,
   },
   [eventCodes.ACCESS_LIST_MEMBER_CREATE_FAILURE]: {
     type: 'access_list.member.create',
     desc: 'Access list member addition failure',
-    format: ({ access_list_name, members, updated_by }) =>
+    format: ({ access_list_title, members, updated_by }) =>
       `User [${updated_by}] failed to add ${formatMembers(
         members
-      )} to access list [${access_list_name}]`,
+      )} to access list [${access_list_title}]`,
   },
   [eventCodes.ACCESS_LIST_MEMBER_UPDATE]: {
     type: 'access_list.member.update',
     desc: 'Access list member updated',
-    format: ({ access_list_name, members, updated_by }) =>
+    format: ({ access_list_title, members, updated_by }) =>
       `User [${updated_by}] updated ${formatMembers(
         members
-      )} in access list [${access_list_name}]`,
+      )} in access list [${access_list_title}]`,
   },
   [eventCodes.ACCESS_LIST_MEMBER_UPDATE_FAILURE]: {
     type: 'access_list.member.update',
     desc: 'Access list member update failure',
-    format: ({ access_list_name, members, updated_by }) =>
+    format: ({ access_list_title, members, updated_by }) =>
       `User [${updated_by}] failed to update ${formatMembers(
         members
-      )} in access list [${access_list_name}]`,
+      )} in access list [${access_list_title}]`,
   },
   [eventCodes.ACCESS_LIST_MEMBER_DELETE]: {
     type: 'access_list.member.delete',
     desc: 'Access list member removed',
-    format: ({ access_list_name, members, updated_by }) =>
+    format: ({ access_list_title, members, updated_by }) =>
       `User [${updated_by}] removed ${formatMembers(
         members
-      )} from access list [${access_list_name}]`,
+      )} from access list [${access_list_title}]`,
   },
   [eventCodes.ACCESS_LIST_MEMBER_DELETE_FAILURE]: {
     type: 'access_list.member.delete',
     desc: 'Access list member removal failure',
-    format: ({ access_list_name, members, updated_by }) =>
+    format: ({ access_list_title, members, updated_by }) =>
       `User [${updated_by}] failed to remove ${formatMembers(
         members
-      )} from access list [${access_list_name}]`,
+      )} from access list [${access_list_title}]`,
   },
   [eventCodes.ACCESS_LIST_MEMBER_DELETE_ALL_FOR_ACCESS_LIST]: {
     type: 'access_list.member.delete_all_members',
     desc: 'All members removed from access list',
-    format: ({ access_list_name, updated_by }) =>
-      `User [${updated_by}] removed all members from access list [${access_list_name}]`,
+    format: ({ access_list_title, updated_by }) =>
+      `User [${updated_by}] removed all members from access list [${access_list_title}]`,
   },
   [eventCodes.ACCESS_LIST_MEMBER_DELETE_ALL_FOR_ACCESS_LIST_FAILURE]: {
     type: 'access_list.member.delete_all_members',
     desc: 'Access list member delete all members failure',
-    format: ({ access_list_name, updated_by }) =>
-      `User [${updated_by}] failed to remove all members from access list [${access_list_name}]`,
+    format: ({ access_list_title, updated_by }) =>
+      `User [${updated_by}] failed to remove all members from access list [${access_list_title}]`,
   },
   [eventCodes.USER_LOGIN_INVALID_ACCESS_LIST]: {
     type: 'user_login.invalid_access_list',
     desc: 'Access list skipped.',
-    format: ({ access_list_name, user, missing_roles }) =>
-      `Access list [${access_list_name}] is invalid and was skipped for member [${user}] because it references non-existent role${missing_roles.length > 1 ? 's' : ''} [${missing_roles}]`,
+    format: ({ access_list_title, user, missing_roles }) =>
+      `Access list [${access_list_title}] is invalid and was skipped for member [${user}] because it references non-existent role${missing_roles.length > 1 ? 's' : ''} [${missing_roles}]`,
   },
   [eventCodes.SECURITY_REPORT_AUDIT_QUERY_RUN]: {
     type: 'secreports.audit.query.run"',

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -1768,170 +1768,122 @@ export const formatters: Formatters = {
     type: 'access_list.create',
     desc: 'Access list created',
     format: ({ access_list_title, name, updated_by }) => {
-      return (
-        `User [${updated_by}] created access list ` +
-        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
-      );
+      return `User [${updated_by}] created access list [${access_list_title || name}]`;
     },
   },
   [eventCodes.ACCESS_LIST_CREATE_FAILURE]: {
     type: 'access_list.create',
     desc: 'Access list create failed',
     format: ({ access_list_title, name, updated_by }) => {
-      return (
-        `User [${updated_by}] failed to create access list ` +
-        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
-      );
+      return `User [${updated_by}] failed to create access list [${access_list_title || name}]`;
     },
   },
   [eventCodes.ACCESS_LIST_UPDATE]: {
     type: 'access_list.update',
     desc: 'Access list updated',
     format: ({ access_list_title, name, updated_by }) => {
-      return (
-        `User [${updated_by}] updated access list ` +
-        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
-      );
+      return `User [${updated_by}] updated access list [${access_list_title || name}]`;
     },
   },
   [eventCodes.ACCESS_LIST_UPDATE_FAILURE]: {
     type: 'access_list.update',
     desc: 'Access list update failed',
     format: ({ access_list_title, name, updated_by }) => {
-      return (
-        `User [${updated_by}] failed to update access list ` +
-        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
-      );
+      return `User [${updated_by}] failed to update access list [${access_list_title || name}]`;
     },
   },
   [eventCodes.ACCESS_LIST_DELETE]: {
     type: 'access_list.delete',
     desc: 'Access list deleted',
     format: ({ access_list_title, name, updated_by }) => {
-      return (
-        `User [${updated_by}] deleted access list ` +
-        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
-      );
+      return `User [${updated_by}] deleted access list [${access_list_title || name}]`;
     },
   },
   [eventCodes.ACCESS_LIST_DELETE_FAILURE]: {
     type: 'access_list.delete',
     desc: 'Access list delete failed',
     format: ({ access_list_title, name, updated_by }) => {
-      return (
-        `User [${updated_by}] failed to delete access list ` +
-        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
-      );
+      return `User [${updated_by}] failed to delete access list [${access_list_title || name}]`;
     },
   },
   [eventCodes.ACCESS_LIST_REVIEW]: {
     type: 'access_list.review',
     desc: 'Access list reviewed',
     format: ({ access_list_title, name, updated_by }) => {
-      return (
-        `User [${updated_by}] reviewed access list ` +
-        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
-      );
+      return `User [${updated_by}] reviewed access list [${access_list_title || name}]`;
     },
   },
   [eventCodes.ACCESS_LIST_REVIEW_FAILURE]: {
     type: 'access_list.review',
     desc: 'Access list review failed',
     format: ({ access_list_title, name, updated_by }) => {
-      return (
-        `User [${updated_by}] failed to to review access list ` +
-        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
-      );
+      return `User [${updated_by}] failed to to review access list [${access_list_title || name}]`;
     },
   },
   [eventCodes.ACCESS_LIST_MEMBER_CREATE]: {
     type: 'access_list.member.create',
     desc: 'Access list member added',
     format: ({ access_list_title, members, access_list_name, updated_by }) => {
-      return (
-        `User [${updated_by}] added ${formatMembers(members)} to access list ` +
-        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
-      );
+      return `User [${updated_by}] added ${formatMembers(members)} to access list [${access_list_title || access_list_name}]`;
     },
   },
   [eventCodes.ACCESS_LIST_MEMBER_CREATE_FAILURE]: {
     type: 'access_list.member.create',
     desc: 'Access list member addition failure',
     format: ({ access_list_title, members, access_list_name, updated_by }) => {
-      return (
-        `User [${updated_by}] failed to add ${formatMembers(
-          members
-        )} to access list ` +
-        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
-      );
+      return `User [${updated_by}] failed to add ${formatMembers(
+        members
+      )} to access list [${access_list_title || access_list_name}]`;
     },
   },
   [eventCodes.ACCESS_LIST_MEMBER_UPDATE]: {
     type: 'access_list.member.update',
     desc: 'Access list member updated',
     format: ({ access_list_title, members, access_list_name, updated_by }) => {
-      return (
-        `User [${updated_by}] updated ${formatMembers(
-          members
-        )} in access list ` +
-        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
-      );
+      return `User [${updated_by}] updated ${formatMembers(
+        members
+      )} in access list [${access_list_title || access_list_name}]`;
     },
   },
   [eventCodes.ACCESS_LIST_MEMBER_UPDATE_FAILURE]: {
     type: 'access_list.member.update',
     desc: 'Access list member update failure',
     format: ({ access_list_title, members, access_list_name, updated_by }) => {
-      return (
-        `User [${updated_by}] failed to update ${formatMembers(
-          members
-        )} in access list ` +
-        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
-      );
+      return `User [${updated_by}] failed to update ${formatMembers(
+        members
+      )} in access list [${access_list_title || access_list_name}]`;
     },
   },
   [eventCodes.ACCESS_LIST_MEMBER_DELETE]: {
     type: 'access_list.member.delete',
     desc: 'Access list member removed',
     format: ({ access_list_title, members, access_list_name, updated_by }) => {
-      return (
-        `User [${updated_by}] removed ${formatMembers(
-          members
-        )} from access list ` +
-        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
-      );
+      return `User [${updated_by}] removed ${formatMembers(
+        members
+      )} from access list [${access_list_title || access_list_name}]`;
     },
   },
   [eventCodes.ACCESS_LIST_MEMBER_DELETE_FAILURE]: {
     type: 'access_list.member.delete',
     desc: 'Access list member removal failure',
     format: ({ access_list_title, members, access_list_name, updated_by }) => {
-      return (
-        `User [${updated_by}] failed to remove ${formatMembers(
-          members
-        )} from access list [${access_list_title}]` +
-        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
-      );
+      return `User [${updated_by}] failed to remove ${formatMembers(
+        members
+      )} from access list [${access_list_title || access_list_name}]`;
     },
   },
   [eventCodes.ACCESS_LIST_MEMBER_DELETE_ALL_FOR_ACCESS_LIST]: {
     type: 'access_list.member.delete_all_members',
     desc: 'All members removed from access list',
     format: ({ access_list_title, access_list_name, updated_by }) => {
-      return (
-        `User [${updated_by}] removed all members from access list ` +
-        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
-      );
+      return `User [${updated_by}] removed all members from access list [${access_list_title || access_list_name}]`;
     },
   },
   [eventCodes.ACCESS_LIST_MEMBER_DELETE_ALL_FOR_ACCESS_LIST_FAILURE]: {
     type: 'access_list.member.delete_all_members',
     desc: 'Access list member delete all members failure',
     format: ({ access_list_title, updated_by }) => {
-      return (
-        `User [${updated_by}] failed to remove all members from access list ` +
-        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
-      );
+      return `User [${updated_by}] failed to remove all members from access list [${access_list_title || access_list_name}]`;
     },
   },
   [eventCodes.USER_LOGIN_INVALID_ACCESS_LIST]: {

--- a/web/packages/teleport/src/services/audit/types.ts
+++ b/web/packages/teleport/src/services/audit/types.ts
@@ -1642,6 +1642,7 @@ export type RawEvents = {
     typeof eventCodes.USER_LOGIN_INVALID_ACCESS_LIST,
     {
       access_list_name: string;
+      access_list_title: string;
       user: string;
       missing_roles: string[];
     }

--- a/web/packages/teleport/src/services/audit/types.ts
+++ b/web/packages/teleport/src/services/audit/types.ts
@@ -1544,6 +1544,7 @@ export type RawEvents = {
     typeof eventCodes.ACCESS_LIST_CREATE,
     {
       name: string;
+      access_list_title: string;
       updated_by: string;
     }
   >;
@@ -1551,6 +1552,7 @@ export type RawEvents = {
     typeof eventCodes.ACCESS_LIST_CREATE_FAILURE,
     {
       name: string;
+      access_list_title: string;
       updated_by: string;
     }
   >;
@@ -1558,6 +1560,7 @@ export type RawEvents = {
     typeof eventCodes.ACCESS_LIST_UPDATE,
     {
       name: string;
+      access_list_title: string;
       updated_by: string;
     }
   >;
@@ -1565,6 +1568,7 @@ export type RawEvents = {
     typeof eventCodes.ACCESS_LIST_UPDATE_FAILURE,
     {
       name: string;
+      access_list_title: string;
       updated_by: string;
     }
   >;
@@ -1572,6 +1576,7 @@ export type RawEvents = {
     typeof eventCodes.ACCESS_LIST_DELETE,
     {
       name: string;
+      access_list_title: string;
       updated_by: string;
     }
   >;
@@ -1579,6 +1584,7 @@ export type RawEvents = {
     typeof eventCodes.ACCESS_LIST_DELETE_FAILURE,
     {
       name: string;
+      access_list_title: string;
       updated_by: string;
     }
   >;
@@ -1586,6 +1592,7 @@ export type RawEvents = {
     typeof eventCodes.ACCESS_LIST_REVIEW,
     {
       name: string;
+      access_list_title: string;
       updated_by: string;
     }
   >;
@@ -1593,6 +1600,7 @@ export type RawEvents = {
     typeof eventCodes.ACCESS_LIST_REVIEW_FAILURE,
     {
       name: string;
+      access_list_title: string;
       updated_by: string;
     }
   >;
@@ -1618,6 +1626,7 @@ export type RawEvents = {
     typeof eventCodes.ACCESS_LIST_MEMBER_DELETE_ALL_FOR_ACCESS_LIST,
     {
       access_list_name: string;
+      access_list_title: string;
       updated_by: string;
     }
   >;
@@ -1625,6 +1634,7 @@ export type RawEvents = {
     typeof eventCodes.ACCESS_LIST_MEMBER_DELETE_ALL_FOR_ACCESS_LIST_FAILURE,
     {
       access_list_name: string;
+      access_list_title: string;
       updated_by: string;
     }
   >;
@@ -1992,6 +2002,7 @@ type RawEventAccessList<T extends EventCode> = RawEvent<
     access_list_name: string;
     members: { member_name: string }[];
     updated_by: string;
+    access_list_title: string;
   }
 >;
 


### PR DESCRIPTION
Backport #54350 to branch/v16

changelog: Show human readable title for access list audit logs
