### PR TITLE
[v17] Use new access_list_title when showing audit events

### DIFF
--- a/web/packages/teleport/src/Audit/fixtures/index.ts
+++ b/web/packages/teleport/src/Audit/fixtures/index.ts
@@ -3327,6 +3327,7 @@ export const events = [
     time: '2023-05-08T19:21:36.144Z',
     name: 'access-list',
     updated_by: 'mike',
+    access_list_title: 'example_title',
   },
   {
     code: 'TAL001E',
@@ -3334,6 +3335,7 @@ export const events = [
     time: '2023-05-08T19:21:36.144Z',
     name: 'access-list',
     updated_by: 'mike',
+    access_list_title: 'example_title',
   },
   {
     code: 'TAL002I',
@@ -3341,6 +3343,7 @@ export const events = [
     time: '2023-05-08T19:21:36.144Z',
     name: 'access-list',
     updated_by: 'mike',
+    access_list_title: 'example_title',
   },
   {
     code: 'TAL002E',
@@ -3348,6 +3351,7 @@ export const events = [
     time: '2023-05-08T19:21:36.144Z',
     name: 'access-list',
     updated_by: 'mike',
+    access_list_title: 'example_title',
   },
   {
     code: 'TAL003I',
@@ -3355,6 +3359,7 @@ export const events = [
     time: '2023-05-08T19:21:36.144Z',
     name: 'access-list',
     updated_by: 'mike',
+    access_list_title: 'example_title',
   },
   {
     code: 'TAL003E',
@@ -3362,6 +3367,7 @@ export const events = [
     time: '2023-05-08T19:21:36.144Z',
     name: 'access-list',
     updated_by: 'mike',
+    access_list_title: 'example_title',
   },
   {
     code: 'TAL004I',
@@ -3369,6 +3375,7 @@ export const events = [
     time: '2023-05-08T19:21:36.144Z',
     name: 'access-list',
     updated_by: 'mike',
+    access_list_title: 'example_title',
   },
   {
     code: 'TAL004E',
@@ -3376,12 +3383,14 @@ export const events = [
     time: '2023-05-08T19:21:36.144Z',
     name: 'access-list',
     updated_by: 'mike',
+    access_list_title: 'example_title',
   },
   {
     code: 'TAL005I',
     event: 'access_list.member.add',
     time: '2023-05-08T19:21:36.144Z',
     access_list_name: 'access-list',
+    access_list_title: 'example_title',
     members: [
       {
         member_name: 'user',
@@ -3394,6 +3403,7 @@ export const events = [
     event: 'access_list.member.add',
     time: '2023-05-08T19:21:36.144Z',
     access_list_name: 'access-list',
+    access_list_title: 'example_title',
     members: [
       {
         member_name: 'user',
@@ -3406,6 +3416,7 @@ export const events = [
     event: 'access_list.member.update',
     time: '2023-05-08T19:21:36.144Z',
     access_list_name: 'access-list',
+    access_list_title: 'example_title',
     members: [
       {
         member_name: 'user',
@@ -3418,6 +3429,7 @@ export const events = [
     event: 'access_list.member.update',
     time: '2023-05-08T19:21:36.144Z',
     access_list_name: 'access-list',
+    access_list_title: 'example_title',
     members: [
       {
         member_name: 'user',
@@ -3430,6 +3442,7 @@ export const events = [
     event: 'access_list.member.delete',
     time: '2023-05-08T19:21:36.144Z',
     access_list_name: 'access-list',
+    access_list_title: 'example_title',
     members: [
       {
         member_name: 'user',
@@ -3442,6 +3455,7 @@ export const events = [
     event: 'access_list.member.delete',
     time: '2023-05-08T19:21:36.144Z',
     access_list_name: 'access-list',
+    access_list_title: 'example_title',
     members: [
       {
         member_name: 'carrot',
@@ -3460,6 +3474,7 @@ export const events = [
     event: 'access_list.member.delete_all_members',
     time: '2023-05-08T19:21:36.144Z',
     access_list_name: 'access-list',
+    access_list_title: 'example_title',
     updated_by: 'mike',
   },
   {
@@ -3467,6 +3482,7 @@ export const events = [
     event: 'access_list.member.delete_all_members',
     time: '2023-05-08T19:21:36.144Z',
     access_list_name: 'access-list',
+    access_list_title: 'example_title',
     updated_by: 'mike',
   },
   {

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -1642,116 +1642,116 @@ export const formatters: Formatters = {
   [eventCodes.ACCESS_LIST_CREATE]: {
     type: 'access_list.create',
     desc: 'Access list created',
-    format: ({ name, updated_by }) =>
-      `User [${updated_by}] created access list [${name}]`,
+    format: ({ access_list_title, updated_by }) =>
+      `User [${updated_by}] created access list [${access_list_title}]`,
   },
   [eventCodes.ACCESS_LIST_CREATE_FAILURE]: {
     type: 'access_list.create',
     desc: 'Access list create failed',
-    format: ({ name, updated_by }) =>
-      `User [${updated_by}] failed to create access list [${name}]`,
+    format: ({ access_list_title, updated_by }) =>
+      `User [${updated_by}] failed to create access list [${access_list_title}]`,
   },
   [eventCodes.ACCESS_LIST_UPDATE]: {
     type: 'access_list.update',
     desc: 'Access list updated',
-    format: ({ name, updated_by }) =>
-      `User [${updated_by}] updated access list [${name}]`,
+    format: ({ access_list_title, updated_by }) =>
+      `User [${updated_by}] updated access list [${access_list_title}]`,
   },
   [eventCodes.ACCESS_LIST_UPDATE_FAILURE]: {
     type: 'access_list.update',
     desc: 'Access list update failed',
-    format: ({ name, updated_by }) =>
-      `User [${updated_by}] failed to update access list [${name}]`,
+    format: ({ access_list_title, updated_by }) =>
+      `User [${updated_by}] failed to update access list [${access_list_title}]`,
   },
   [eventCodes.ACCESS_LIST_DELETE]: {
     type: 'access_list.delete',
     desc: 'Access list deleted',
-    format: ({ name, updated_by }) =>
-      `User [${updated_by}] deleted access list [${name}]`,
+    format: ({ access_list_title, updated_by }) =>
+      `User [${updated_by}] deleted access list [${access_list_title}]`,
   },
   [eventCodes.ACCESS_LIST_DELETE_FAILURE]: {
     type: 'access_list.delete',
     desc: 'Access list delete failed',
-    format: ({ name, updated_by }) =>
-      `User [${updated_by}] failed to delete access list [${name}]`,
+    format: ({ access_list_title, updated_by }) =>
+      `User [${updated_by}] failed to delete access list [${access_list_title}]`,
   },
   [eventCodes.ACCESS_LIST_REVIEW]: {
     type: 'access_list.review',
     desc: 'Access list reviewed',
-    format: ({ name, updated_by }) =>
-      `User [${updated_by}] reviewed access list [${name}]`,
+    format: ({ access_list_title, updated_by }) =>
+      `User [${updated_by}] reviewed access list [${access_list_title}]`,
   },
   [eventCodes.ACCESS_LIST_REVIEW_FAILURE]: {
     type: 'access_list.review',
     desc: 'Access list review failed',
-    format: ({ name, updated_by }) =>
-      `User [${updated_by}] failed to to review access list [${name}]`,
+    format: ({ access_list_title, updated_by }) =>
+      `User [${updated_by}] failed to to review access list [${access_list_title}]`,
   },
   [eventCodes.ACCESS_LIST_MEMBER_CREATE]: {
     type: 'access_list.member.create',
     desc: 'Access list member added',
-    format: ({ access_list_name, members, updated_by }) =>
+    format: ({ access_list_title, members, updated_by }) =>
       `User [${updated_by}] added ${formatMembers(
         members
-      )} to access list [${access_list_name}]`,
+      )} to access list [${access_list_title}]`,
   },
   [eventCodes.ACCESS_LIST_MEMBER_CREATE_FAILURE]: {
     type: 'access_list.member.create',
     desc: 'Access list member addition failure',
-    format: ({ access_list_name, members, updated_by }) =>
+    format: ({ access_list_title, members, updated_by }) =>
       `User [${updated_by}] failed to add ${formatMembers(
         members
-      )} to access list [${access_list_name}]`,
+      )} to access list [${access_list_title}]`,
   },
   [eventCodes.ACCESS_LIST_MEMBER_UPDATE]: {
     type: 'access_list.member.update',
     desc: 'Access list member updated',
-    format: ({ access_list_name, members, updated_by }) =>
+    format: ({ access_list_title, members, updated_by }) =>
       `User [${updated_by}] updated ${formatMembers(
         members
-      )} in access list [${access_list_name}]`,
+      )} in access list [${access_list_title}]`,
   },
   [eventCodes.ACCESS_LIST_MEMBER_UPDATE_FAILURE]: {
     type: 'access_list.member.update',
     desc: 'Access list member update failure',
-    format: ({ access_list_name, members, updated_by }) =>
+    format: ({ access_list_title, members, updated_by }) =>
       `User [${updated_by}] failed to update ${formatMembers(
         members
-      )} in access list [${access_list_name}]`,
+      )} in access list [${access_list_title}]`,
   },
   [eventCodes.ACCESS_LIST_MEMBER_DELETE]: {
     type: 'access_list.member.delete',
     desc: 'Access list member removed',
-    format: ({ access_list_name, members, updated_by }) =>
+    format: ({ access_list_title, members, updated_by }) =>
       `User [${updated_by}] removed ${formatMembers(
         members
-      )} from access list [${access_list_name}]`,
+      )} from access list [${access_list_title}]`,
   },
   [eventCodes.ACCESS_LIST_MEMBER_DELETE_FAILURE]: {
     type: 'access_list.member.delete',
     desc: 'Access list member removal failure',
-    format: ({ access_list_name, members, updated_by }) =>
+    format: ({ access_list_title, members, updated_by }) =>
       `User [${updated_by}] failed to remove ${formatMembers(
         members
-      )} from access list [${access_list_name}]`,
+      )} from access list [${access_list_title}]`,
   },
   [eventCodes.ACCESS_LIST_MEMBER_DELETE_ALL_FOR_ACCESS_LIST]: {
     type: 'access_list.member.delete_all_members',
     desc: 'All members removed from access list',
-    format: ({ access_list_name, updated_by }) =>
-      `User [${updated_by}] removed all members from access list [${access_list_name}]`,
+    format: ({ access_list_title, updated_by }) =>
+      `User [${updated_by}] removed all members from access list [${access_list_title}]`,
   },
   [eventCodes.ACCESS_LIST_MEMBER_DELETE_ALL_FOR_ACCESS_LIST_FAILURE]: {
     type: 'access_list.member.delete_all_members',
     desc: 'Access list member delete all members failure',
-    format: ({ access_list_name, updated_by }) =>
-      `User [${updated_by}] failed to remove all members from access list [${access_list_name}]`,
+    format: ({ access_list_title, updated_by }) =>
+      `User [${updated_by}] failed to remove all members from access list [${access_list_title}]`,
   },
   [eventCodes.USER_LOGIN_INVALID_ACCESS_LIST]: {
     type: 'user_login.invalid_access_list',
     desc: 'Access list skipped.',
-    format: ({ access_list_name, user, missing_roles }) =>
-      `Access list [${access_list_name}] is invalid and was skipped for member [${user}] because it references non-existent role${missing_roles.length > 1 ? 's' : ''} [${missing_roles}]`,
+    format: ({ access_list_title, user, missing_roles }) =>
+      `Access list [${access_list_title}] is invalid and was skipped for member [${user}] because it references non-existent role${missing_roles.length > 1 ? 's' : ''} [${missing_roles}]`,
   },
   [eventCodes.SECURITY_REPORT_AUDIT_QUERY_RUN]: {
     type: 'secreports.audit.query.run"',

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -1642,110 +1642,172 @@ export const formatters: Formatters = {
   [eventCodes.ACCESS_LIST_CREATE]: {
     type: 'access_list.create',
     desc: 'Access list created',
-    format: ({ access_list_title, updated_by }) =>
-      `User [${updated_by}] created access list [${access_list_title}]`,
+    format: ({ access_list_title, name, updated_by }) => {
+      return (
+        `User [${updated_by}] created access list ` +
+        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
+      );
+    },
   },
   [eventCodes.ACCESS_LIST_CREATE_FAILURE]: {
     type: 'access_list.create',
     desc: 'Access list create failed',
-    format: ({ access_list_title, updated_by }) =>
-      `User [${updated_by}] failed to create access list [${access_list_title}]`,
+    format: ({ access_list_title, name, updated_by }) => {
+      return (
+        `User [${updated_by}] failed to create access list ` +
+        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
+      );
+    },
   },
   [eventCodes.ACCESS_LIST_UPDATE]: {
     type: 'access_list.update',
     desc: 'Access list updated',
-    format: ({ access_list_title, updated_by }) =>
-      `User [${updated_by}] updated access list [${access_list_title}]`,
+    format: ({ access_list_title, name, updated_by }) => {
+      return (
+        `User [${updated_by}] updated access list ` +
+        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
+      );
+    },
   },
   [eventCodes.ACCESS_LIST_UPDATE_FAILURE]: {
     type: 'access_list.update',
     desc: 'Access list update failed',
-    format: ({ access_list_title, updated_by }) =>
-      `User [${updated_by}] failed to update access list [${access_list_title}]`,
+    format: ({ access_list_title, name, updated_by }) => {
+      return (
+        `User [${updated_by}] failed to update access list ` +
+        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
+      );
+    },
   },
   [eventCodes.ACCESS_LIST_DELETE]: {
     type: 'access_list.delete',
     desc: 'Access list deleted',
-    format: ({ access_list_title, updated_by }) =>
-      `User [${updated_by}] deleted access list [${access_list_title}]`,
+    format: ({ access_list_title, name, updated_by }) => {
+      return (
+        `User [${updated_by}] deleted access list ` +
+        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
+      );
+    },
   },
   [eventCodes.ACCESS_LIST_DELETE_FAILURE]: {
     type: 'access_list.delete',
     desc: 'Access list delete failed',
-    format: ({ access_list_title, updated_by }) =>
-      `User [${updated_by}] failed to delete access list [${access_list_title}]`,
+    format: ({ access_list_title, name, updated_by }) => {
+      return (
+        `User [${updated_by}] failed to delete access list ` +
+        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
+      );
+    },
   },
   [eventCodes.ACCESS_LIST_REVIEW]: {
     type: 'access_list.review',
     desc: 'Access list reviewed',
-    format: ({ access_list_title, updated_by }) =>
-      `User [${updated_by}] reviewed access list [${access_list_title}]`,
+    format: ({ access_list_title, name, updated_by }) => {
+      return (
+        `User [${updated_by}] reviewed access list ` +
+        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
+      );
+    },
   },
   [eventCodes.ACCESS_LIST_REVIEW_FAILURE]: {
     type: 'access_list.review',
     desc: 'Access list review failed',
-    format: ({ access_list_title, updated_by }) =>
-      `User [${updated_by}] failed to to review access list [${access_list_title}]`,
+    format: ({ access_list_title, name, updated_by }) => {
+      return (
+        `User [${updated_by}] failed to to review access list ` +
+        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
+      );
+    },
   },
   [eventCodes.ACCESS_LIST_MEMBER_CREATE]: {
     type: 'access_list.member.create',
     desc: 'Access list member added',
-    format: ({ access_list_title, members, updated_by }) =>
-      `User [${updated_by}] added ${formatMembers(
-        members
-      )} to access list [${access_list_title}]`,
+    format: ({ access_list_title, members, access_list_name, updated_by }) => {
+      return (
+        `User [${updated_by}] added ${formatMembers(members)} to access list ` +
+        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
+      );
+    },
   },
   [eventCodes.ACCESS_LIST_MEMBER_CREATE_FAILURE]: {
     type: 'access_list.member.create',
     desc: 'Access list member addition failure',
-    format: ({ access_list_title, members, updated_by }) =>
-      `User [${updated_by}] failed to add ${formatMembers(
-        members
-      )} to access list [${access_list_title}]`,
+    format: ({ access_list_title, members, access_list_name, updated_by }) => {
+      return (
+        `User [${updated_by}] failed to add ${formatMembers(
+          members
+        )} to access list ` +
+        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
+      );
+    },
   },
   [eventCodes.ACCESS_LIST_MEMBER_UPDATE]: {
     type: 'access_list.member.update',
     desc: 'Access list member updated',
-    format: ({ access_list_title, members, updated_by }) =>
-      `User [${updated_by}] updated ${formatMembers(
-        members
-      )} in access list [${access_list_title}]`,
+    format: ({ access_list_title, members, access_list_name, updated_by }) => {
+      return (
+        `User [${updated_by}] updated ${formatMembers(
+          members
+        )} in access list ` +
+        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
+      );
+    },
   },
   [eventCodes.ACCESS_LIST_MEMBER_UPDATE_FAILURE]: {
     type: 'access_list.member.update',
     desc: 'Access list member update failure',
-    format: ({ access_list_title, members, updated_by }) =>
-      `User [${updated_by}] failed to update ${formatMembers(
-        members
-      )} in access list [${access_list_title}]`,
+    format: ({ access_list_title, members, access_list_name, updated_by }) => {
+      return (
+        `User [${updated_by}] failed to update ${formatMembers(
+          members
+        )} in access list ` +
+        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
+      );
+    },
   },
   [eventCodes.ACCESS_LIST_MEMBER_DELETE]: {
     type: 'access_list.member.delete',
     desc: 'Access list member removed',
-    format: ({ access_list_title, members, updated_by }) =>
-      `User [${updated_by}] removed ${formatMembers(
-        members
-      )} from access list [${access_list_title}]`,
+    format: ({ access_list_title, members, access_list_name, updated_by }) => {
+      return (
+        `User [${updated_by}] removed ${formatMembers(
+          members
+        )} from access list ` +
+        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
+      );
+    },
   },
   [eventCodes.ACCESS_LIST_MEMBER_DELETE_FAILURE]: {
     type: 'access_list.member.delete',
     desc: 'Access list member removal failure',
-    format: ({ access_list_title, members, updated_by }) =>
-      `User [${updated_by}] failed to remove ${formatMembers(
-        members
-      )} from access list [${access_list_title}]`,
+    format: ({ access_list_title, members, access_list_name, updated_by }) => {
+      return (
+        `User [${updated_by}] failed to remove ${formatMembers(
+          members
+        )} from access list [${access_list_title}]` +
+        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
+      );
+    },
   },
   [eventCodes.ACCESS_LIST_MEMBER_DELETE_ALL_FOR_ACCESS_LIST]: {
     type: 'access_list.member.delete_all_members',
     desc: 'All members removed from access list',
-    format: ({ access_list_title, updated_by }) =>
-      `User [${updated_by}] removed all members from access list [${access_list_title}]`,
+    format: ({ access_list_title, access_list_name, updated_by }) => {
+      return (
+        `User [${updated_by}] removed all members from access list ` +
+        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
+      );
+    },
   },
   [eventCodes.ACCESS_LIST_MEMBER_DELETE_ALL_FOR_ACCESS_LIST_FAILURE]: {
     type: 'access_list.member.delete_all_members',
     desc: 'Access list member delete all members failure',
-    format: ({ access_list_title, updated_by }) =>
-      `User [${updated_by}] failed to remove all members from access list [${access_list_title}]`,
+    format: ({ access_list_title, updated_by }) => {
+      return (
+        `User [${updated_by}] failed to remove all members from access list ` +
+        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
+      );
+    },
   },
   [eventCodes.USER_LOGIN_INVALID_ACCESS_LIST]: {
     type: 'user_login.invalid_access_list',

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -1643,170 +1643,122 @@ export const formatters: Formatters = {
     type: 'access_list.create',
     desc: 'Access list created',
     format: ({ access_list_title, name, updated_by }) => {
-      return (
-        `User [${updated_by}] created access list ` +
-        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
-      );
+      return `User [${updated_by}] created access list [${access_list_title || name}]`;
     },
   },
   [eventCodes.ACCESS_LIST_CREATE_FAILURE]: {
     type: 'access_list.create',
     desc: 'Access list create failed',
     format: ({ access_list_title, name, updated_by }) => {
-      return (
-        `User [${updated_by}] failed to create access list ` +
-        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
-      );
+      return `User [${updated_by}] failed to create access list [${access_list_title || name}]`;
     },
   },
   [eventCodes.ACCESS_LIST_UPDATE]: {
     type: 'access_list.update',
     desc: 'Access list updated',
     format: ({ access_list_title, name, updated_by }) => {
-      return (
-        `User [${updated_by}] updated access list ` +
-        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
-      );
+      return `User [${updated_by}] updated access list [${access_list_title || name}]`;
     },
   },
   [eventCodes.ACCESS_LIST_UPDATE_FAILURE]: {
     type: 'access_list.update',
     desc: 'Access list update failed',
     format: ({ access_list_title, name, updated_by }) => {
-      return (
-        `User [${updated_by}] failed to update access list ` +
-        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
-      );
+      return `User [${updated_by}] failed to update access list [${access_list_title || name}]`;
     },
   },
   [eventCodes.ACCESS_LIST_DELETE]: {
     type: 'access_list.delete',
     desc: 'Access list deleted',
     format: ({ access_list_title, name, updated_by }) => {
-      return (
-        `User [${updated_by}] deleted access list ` +
-        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
-      );
+      return `User [${updated_by}] deleted access list [${access_list_title || name}]`;
     },
   },
   [eventCodes.ACCESS_LIST_DELETE_FAILURE]: {
     type: 'access_list.delete',
     desc: 'Access list delete failed',
     format: ({ access_list_title, name, updated_by }) => {
-      return (
-        `User [${updated_by}] failed to delete access list ` +
-        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
-      );
+      return `User [${updated_by}] failed to delete access list [${access_list_title || name}]`;
     },
   },
   [eventCodes.ACCESS_LIST_REVIEW]: {
     type: 'access_list.review',
     desc: 'Access list reviewed',
     format: ({ access_list_title, name, updated_by }) => {
-      return (
-        `User [${updated_by}] reviewed access list ` +
-        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
-      );
+      return `User [${updated_by}] reviewed access list [${access_list_title || name}]`;
     },
   },
   [eventCodes.ACCESS_LIST_REVIEW_FAILURE]: {
     type: 'access_list.review',
     desc: 'Access list review failed',
     format: ({ access_list_title, name, updated_by }) => {
-      return (
-        `User [${updated_by}] failed to to review access list ` +
-        (access_list_title ? `[${access_list_title}]` : `[${name}]`)
-      );
+      return `User [${updated_by}] failed to to review access list [${access_list_title || name}]`;
     },
   },
   [eventCodes.ACCESS_LIST_MEMBER_CREATE]: {
     type: 'access_list.member.create',
     desc: 'Access list member added',
     format: ({ access_list_title, members, access_list_name, updated_by }) => {
-      return (
-        `User [${updated_by}] added ${formatMembers(members)} to access list ` +
-        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
-      );
+      return `User [${updated_by}] added ${formatMembers(members)} to access list [${access_list_title || access_list_name}]`;
     },
   },
   [eventCodes.ACCESS_LIST_MEMBER_CREATE_FAILURE]: {
     type: 'access_list.member.create',
     desc: 'Access list member addition failure',
     format: ({ access_list_title, members, access_list_name, updated_by }) => {
-      return (
-        `User [${updated_by}] failed to add ${formatMembers(
-          members
-        )} to access list ` +
-        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
-      );
+      return `User [${updated_by}] failed to add ${formatMembers(
+        members
+      )} to access list [${access_list_title || access_list_name}]`;
     },
   },
   [eventCodes.ACCESS_LIST_MEMBER_UPDATE]: {
     type: 'access_list.member.update',
     desc: 'Access list member updated',
     format: ({ access_list_title, members, access_list_name, updated_by }) => {
-      return (
-        `User [${updated_by}] updated ${formatMembers(
-          members
-        )} in access list ` +
-        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
-      );
+      return `User [${updated_by}] updated ${formatMembers(
+        members
+      )} in access list [${access_list_title || access_list_name}]`;
     },
   },
   [eventCodes.ACCESS_LIST_MEMBER_UPDATE_FAILURE]: {
     type: 'access_list.member.update',
     desc: 'Access list member update failure',
     format: ({ access_list_title, members, access_list_name, updated_by }) => {
-      return (
-        `User [${updated_by}] failed to update ${formatMembers(
-          members
-        )} in access list ` +
-        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
-      );
+      return `User [${updated_by}] failed to update ${formatMembers(
+        members
+      )} in access list [${access_list_title || access_list_name}]`;
     },
   },
   [eventCodes.ACCESS_LIST_MEMBER_DELETE]: {
     type: 'access_list.member.delete',
     desc: 'Access list member removed',
     format: ({ access_list_title, members, access_list_name, updated_by }) => {
-      return (
-        `User [${updated_by}] removed ${formatMembers(
-          members
-        )} from access list ` +
-        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
-      );
+      return `User [${updated_by}] removed ${formatMembers(
+        members
+      )} from access list [${access_list_title || access_list_name}]`;
     },
   },
   [eventCodes.ACCESS_LIST_MEMBER_DELETE_FAILURE]: {
     type: 'access_list.member.delete',
     desc: 'Access list member removal failure',
     format: ({ access_list_title, members, access_list_name, updated_by }) => {
-      return (
-        `User [${updated_by}] failed to remove ${formatMembers(
-          members
-        )} from access list [${access_list_title}]` +
-        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
-      );
+      return `User [${updated_by}] failed to remove ${formatMembers(
+        members
+      )} from access list [${access_list_title || access_list_name}]`;
     },
   },
   [eventCodes.ACCESS_LIST_MEMBER_DELETE_ALL_FOR_ACCESS_LIST]: {
     type: 'access_list.member.delete_all_members',
     desc: 'All members removed from access list',
     format: ({ access_list_title, access_list_name, updated_by }) => {
-      return (
-        `User [${updated_by}] removed all members from access list ` +
-        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
-      );
+      return `User [${updated_by}] removed all members from access list [${access_list_title || access_list_name}]`;
     },
   },
   [eventCodes.ACCESS_LIST_MEMBER_DELETE_ALL_FOR_ACCESS_LIST_FAILURE]: {
     type: 'access_list.member.delete_all_members',
     desc: 'Access list member delete all members failure',
     format: ({ access_list_title, updated_by }) => {
-      return (
-        `User [${updated_by}] failed to remove all members from access list ` +
-        (access_list_title ? `[${access_list_title}]` : `[${access_list_name}]`)
-      );
+      return `User [${updated_by}] failed to remove all members from access list [${access_list_title || access_list_name}]`;
     },
   },
   [eventCodes.USER_LOGIN_INVALID_ACCESS_LIST]: {

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -1757,15 +1757,15 @@ export const formatters: Formatters = {
   [eventCodes.ACCESS_LIST_MEMBER_DELETE_ALL_FOR_ACCESS_LIST_FAILURE]: {
     type: 'access_list.member.delete_all_members',
     desc: 'Access list member delete all members failure',
-      format: ({ access_list_title, access_list_name, updated_by }) => {
+    format: ({ access_list_title, access_list_name, updated_by }) => {
       return `User [${updated_by}] failed to remove all members from access list [${access_list_title || access_list_name}]`;
     },
   },
   [eventCodes.USER_LOGIN_INVALID_ACCESS_LIST]: {
     type: 'user_login.invalid_access_list',
     desc: 'Access list skipped.',
-    format: ({ access_list_title, user, missing_roles }) =>
-      `Access list [${access_list_title}] is invalid and was skipped for member [${user}] because it references non-existent role${missing_roles.length > 1 ? 's' : ''} [${missing_roles}]`,
+    format: ({ access_list_title, access_list_name, user, missing_roles }) =>
+      `Access list [${access_list_title || access_list_name}] is invalid and was skipped for member [${user}] because it references non-existent role${missing_roles.length > 1 ? 's' : ''} [${missing_roles}]`,
   },
   [eventCodes.SECURITY_REPORT_AUDIT_QUERY_RUN]: {
     type: 'secreports.audit.query.run"',

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -1757,7 +1757,7 @@ export const formatters: Formatters = {
   [eventCodes.ACCESS_LIST_MEMBER_DELETE_ALL_FOR_ACCESS_LIST_FAILURE]: {
     type: 'access_list.member.delete_all_members',
     desc: 'Access list member delete all members failure',
-    format: ({ access_list_title, updated_by }) => {
+      format: ({ access_list_title, access_list_name, updated_by }) => {
       return `User [${updated_by}] failed to remove all members from access list [${access_list_title || access_list_name}]`;
     },
   },

--- a/web/packages/teleport/src/services/audit/types.ts
+++ b/web/packages/teleport/src/services/audit/types.ts
@@ -1606,6 +1606,7 @@ export type RawEvents = {
     typeof eventCodes.USER_LOGIN_INVALID_ACCESS_LIST,
     {
       access_list_name: string;
+      access_list_title: string;
       user: string;
       missing_roles: string[];
     }

--- a/web/packages/teleport/src/services/audit/types.ts
+++ b/web/packages/teleport/src/services/audit/types.ts
@@ -1508,6 +1508,7 @@ export type RawEvents = {
     typeof eventCodes.ACCESS_LIST_CREATE,
     {
       name: string;
+      access_list_title: string;
       updated_by: string;
     }
   >;
@@ -1515,6 +1516,7 @@ export type RawEvents = {
     typeof eventCodes.ACCESS_LIST_CREATE_FAILURE,
     {
       name: string;
+      access_list_title: string;
       updated_by: string;
     }
   >;
@@ -1522,6 +1524,7 @@ export type RawEvents = {
     typeof eventCodes.ACCESS_LIST_UPDATE,
     {
       name: string;
+      access_list_title: string;
       updated_by: string;
     }
   >;
@@ -1529,6 +1532,7 @@ export type RawEvents = {
     typeof eventCodes.ACCESS_LIST_UPDATE_FAILURE,
     {
       name: string;
+      access_list_title: string;
       updated_by: string;
     }
   >;
@@ -1536,6 +1540,7 @@ export type RawEvents = {
     typeof eventCodes.ACCESS_LIST_DELETE,
     {
       name: string;
+      access_list_title: string;
       updated_by: string;
     }
   >;
@@ -1543,6 +1548,7 @@ export type RawEvents = {
     typeof eventCodes.ACCESS_LIST_DELETE_FAILURE,
     {
       name: string;
+      access_list_title: string;
       updated_by: string;
     }
   >;
@@ -1550,6 +1556,7 @@ export type RawEvents = {
     typeof eventCodes.ACCESS_LIST_REVIEW,
     {
       name: string;
+      access_list_title: string;
       updated_by: string;
     }
   >;
@@ -1557,6 +1564,7 @@ export type RawEvents = {
     typeof eventCodes.ACCESS_LIST_REVIEW_FAILURE,
     {
       name: string;
+      access_list_title: string;
       updated_by: string;
     }
   >;
@@ -1582,6 +1590,7 @@ export type RawEvents = {
     typeof eventCodes.ACCESS_LIST_MEMBER_DELETE_ALL_FOR_ACCESS_LIST,
     {
       access_list_name: string;
+      access_list_title: string;
       updated_by: string;
     }
   >;
@@ -1589,6 +1598,7 @@ export type RawEvents = {
     typeof eventCodes.ACCESS_LIST_MEMBER_DELETE_ALL_FOR_ACCESS_LIST_FAILURE,
     {
       access_list_name: string;
+      access_list_title: string;
       updated_by: string;
     }
   >;
@@ -1993,6 +2003,7 @@ type RawEventAccessList<T extends EventCode> = RawEvent<
     access_list_name: string;
     members: { member_name: string }[];
     updated_by: string;
+    access_list_title: string;
   }
 >;
 


### PR DESCRIPTION
Backport #54350 to branch/v17

changelog: Show human readable title for access list audit logs
