### PR TITLE
[v17] Web: remove unified resource card styling when require request

### DIFF
--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
@@ -32,6 +32,7 @@ import {
   getBackgroundColor,
 } from '../shared/getBackgroundColor';
 import { PinButton } from '../shared/PinButton';
+import { ResourceActionButtonWrapper } from '../shared/ResourceActionButton';
 import { ResourceItemProps } from '../types';
 
 // Since we do a lot of manual resizing and some absolute positioning, we have
@@ -220,7 +221,9 @@ export function ResourceCard({
                 </HoverTooltip>
               </SingleLineBox>
               {hovered && <CopyButton name={name} mr={2} />}
-              {ActionButton}
+              <ResourceActionButtonWrapper requiresRequest={requiresRequest}>
+                {ActionButton}
+              </ResourceActionButtonWrapper>
             </Flex>
             <Flex flexDirection="row" alignItems="center">
               <ResTypeIconBox>

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
@@ -33,6 +33,7 @@ import {
   getBackgroundColor,
 } from '../shared/getBackgroundColor';
 import { PinButton } from '../shared/PinButton';
+import { ResourceActionButtonWrapper } from '../shared/ResourceActionButton';
 import { ResourceItemProps } from '../types';
 
 export function ResourceListItem({
@@ -226,7 +227,9 @@ export function ResourceListItem({
             grid-area: button;
           `}
         >
-          {ActionButton}
+          <ResourceActionButtonWrapper requiresRequest={requiresRequest}>
+            {ActionButton}
+          </ResourceActionButtonWrapper>
         </Box>
 
         {/* labels */}

--- a/web/packages/shared/components/UnifiedResources/shared/ResourceActionButton.tsx
+++ b/web/packages/shared/components/UnifiedResources/shared/ResourceActionButton.tsx
@@ -1,6 +1,6 @@
 /**
  * Teleport
- * Copyright (C) 2024 Gravitational, Inc.
+ * Copyright (C) 2025  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,21 +16,25 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Theme } from 'design/theme/themes/types';
+import styled, { css } from 'styled-components';
 
-export interface BackgroundColorProps {
-  requiresRequest?: boolean;
-  selected?: boolean;
-  pinned?: boolean;
-  theme: Theme;
-}
+/**
+ * Wrapper to apply shared styles across action buttons that does
+ * not require request. This is to help distinguish between
+ * requestable and non requestable buttons.
+ */
+export const ResourceActionButtonWrapper = styled.div<{
+  requiresRequest: boolean;
+}>`
+  line-height: 0;
 
-export const getBackgroundColor = (props: BackgroundColorProps) => {
-  if (props.selected) {
-    return props.theme.colors.interactive.tonal.primary[2];
-  }
-  if (props.pinned) {
-    return props.theme.colors.interactive.tonal.primary[1];
-  }
-  return 'transparent';
-};
+  ${p =>
+    !p.requiresRequest &&
+    css`
+      button,
+      a {
+        background-color: ${p => p.theme.colors.interactive.tonal.neutral[0]};
+        border: none;
+      }
+    `}
+`;


### PR DESCRIPTION
backport #54427 to branch/v17

manual backport because conflict with changes that are in master that are not backported

changelog: Removed background color for resources that required access request in the web UI Resources view.