### PR TITLE
Update cloud docs to include ap-southeast-2

### DIFF
--- a/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
+++ b/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
@@ -66,7 +66,9 @@ The Teleport [Proxy Service](proxy.mdx) is deployed to multiple AWS regions arou
 - sa-east-1
 - ap-southeast-2*
 
-** Proxies in these regions are available upon request or when the Auth Service is deployed to the region.*
+<Admonition type="note">
+  * Proxies in these regions are available upon request or when the Auth Service is deployed to the region.
+</Admonition>
 
 ## Releases
 

--- a/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
+++ b/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
@@ -18,7 +18,7 @@ security auditors on a regular basis to identify and correct any gaps, while als
 continuing to iterate on improvements to fortify the platform for the most strict of
 compliance use-cases.
 
-The Teleport Enterprise Cloud environment is protected from network and transport layer DDoS attacks 
+The Teleport Enterprise Cloud environment is protected from network and transport layer DDoS attacks
 that may target Teleport tenants by leveraging [AWS Shield](https://aws.amazon.com/shield/).
 
 ## Compliance
@@ -53,6 +53,7 @@ Teleport Enterprise Cloud can run in one of the following AWS regions:
 - ap-south-1
 - ap-southeast-1
 - sa-east-1
+- ap-southeast-2
 
 ### Proxies
 The Teleport [Proxy Service](proxy.mdx) is deployed to multiple AWS regions around the world for low-latency access to distributed infrastructure.
@@ -63,6 +64,9 @@ The Teleport [Proxy Service](proxy.mdx) is deployed to multiple AWS regions arou
 - ap-south-1
 - ap-southeast-1
 - sa-east-1
+- ap-southeast-2*
+
+** Proxies in these regions are available upon request or when the Auth Service is deployed to the region.*
 
 ## Releases
 

--- a/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
+++ b/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
@@ -67,7 +67,7 @@ The Teleport [Proxy Service](proxy.mdx) is deployed to multiple AWS regions arou
 - ap-southeast-2*
 
 <Admonition type="note">
-  * Proxies in these regions are available upon request or when the Auth Service is deployed to the region.
+  * Proxies in the ap-southeast-2 region are available upon request or when the Auth Service is deployed to the region.
 </Admonition>
 
 ## Releases

--- a/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
+++ b/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
@@ -64,10 +64,10 @@ The Teleport [Proxy Service](proxy.mdx) is deployed to multiple AWS regions arou
 - ap-south-1
 - ap-southeast-1
 - sa-east-1
-- ap-southeast-2*
+- ap-southeast-2
 
 <Admonition type="note">
-  * Proxies in the ap-southeast-2 region are available upon request or when the Auth Service is deployed to the region.
+  Proxy Service in the ap-southeast-2 region is available upon request or when the Auth Service is deployed to the region.
 </Admonition>
 
 ## Releases


### PR DESCRIPTION
Adds `ap-southeast-2` to the cloud architecture docs.