### PR TITLE
Web: add support for rendering status panel

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -3168,7 +3168,7 @@ func (h *Handler) clusterUnifiedResourcesGet(w http.ResponseWriter, request *htt
 				unifiedResources = append(unifiedResources, ui.MakeGitServer(site.GetName(), r, enriched.RequiresRequest))
 			}
 		case types.DatabaseServer:
-			db := ui.MakeDatabase(r.GetDatabase(), accessChecker, h.cfg.DatabaseREPLRegistry, enriched.RequiresRequest)
+			db := ui.MakeDatabaseFromDatabaseServer(r, accessChecker, h.cfg.DatabaseREPLRegistry, enriched.RequiresRequest)
 			unifiedResources = append(unifiedResources, db)
 		case types.AppServer:
 			allowedAWSRoles, err := calculateAppLogins(accessChecker, r, enriched.Logins)

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1348,6 +1348,7 @@ func TestUnifiedResourcesGet(t *testing.T) {
 		_, err = env.server.Auth().UpsertNode(context.Background(), node)
 		require.NoError(t, err)
 	}
+
 	// add db
 	db, err := types.NewDatabaseV3(types.Metadata{
 		Name: "dbdb",
@@ -1367,6 +1368,7 @@ func TestUnifiedResourcesGet(t *testing.T) {
 		Database: db,
 	})
 	require.NoError(t, err)
+	dbServer.SetTargetHealth(types.TargetHealth{Status: "testing-status"})
 	_, err = env.server.Auth().UpsertDatabaseServer(context.Background(), dbServer)
 	require.NoError(t, err)
 
@@ -1422,6 +1424,28 @@ func TestUnifiedResourcesGet(t *testing.T) {
 	res = clusterNodesGetResponse{}
 	require.NoError(t, json.Unmarshal(re.Bytes(), &res))
 	require.Empty(t, res.Items)
+
+	// query only databases
+	type dbResponse struct {
+		Items      []webui.Database `json:"items"`
+		TotalCount int              `json:"totalCount"`
+	}
+	query = url.Values{"sort": []string{"name"}, "limit": []string{"1"}, "kinds": []string{types.KindDatabase}}
+	re, err = pack.clt.Get(context.Background(), endpoint, query)
+	require.NoError(t, err)
+	dbRes := dbResponse{}
+	require.NoError(t, json.Unmarshal(re.Bytes(), &dbRes))
+	require.Len(t, dbRes.Items, 1)
+	require.ElementsMatch(t, dbRes.Items, []webui.Database{{
+		Kind:         types.KindDatabase,
+		Name:         "dbdb",
+		Type:         types.DatabaseTypeSelfHosted,
+		Labels:       []ui.Label{{Name: "env", Value: "prod"}},
+		Protocol:     "test-protocol",
+		Hostname:     "test-uri",
+		URI:          "test-uri",
+		TargetHealth: types.TargetHealth{Status: "testing-status"},
+	}})
 
 	// should return first page and have a second page
 	query = url.Values{"sort": []string{"name"}, "limit": []string{"15"}}
@@ -4115,6 +4139,7 @@ func TestClusterDatabasesGet_NoRole(t *testing.T) {
 		Database: db,
 	})
 	require.NoError(t, err)
+	dbServer.SetTargetHealth(types.TargetHealth{Status: "testing-status"})
 
 	_, err = env.server.Auth().UpsertDatabaseServer(context.Background(), dbServer)
 	require.NoError(t, err)
@@ -4127,13 +4152,14 @@ func TestClusterDatabasesGet_NoRole(t *testing.T) {
 	require.NoError(t, json.Unmarshal(re.Bytes(), &resp))
 	require.Len(t, resp.Items, 1)
 	require.ElementsMatch(t, resp.Items, []webui.Database{{
-		Kind:     types.KindDatabase,
-		Name:     "dbdb",
-		Type:     types.DatabaseTypeSelfHosted,
-		Labels:   []ui.Label{{Name: "env", Value: "prod"}},
-		Protocol: "test-protocol",
-		Hostname: "test-uri",
-		URI:      "test-uri:1234",
+		Kind:         types.KindDatabase,
+		Name:         "dbdb",
+		Type:         types.DatabaseTypeSelfHosted,
+		Labels:       []ui.Label{{Name: "env", Value: "prod"}},
+		Protocol:     "test-protocol",
+		Hostname:     "test-uri",
+		URI:          "test-uri:1234",
+		TargetHealth: types.TargetHealth{Status: "testing-status"},
 	}})
 }
 

--- a/lib/web/databases.go
+++ b/lib/web/databases.go
@@ -303,10 +303,11 @@ func (h *Handler) handleDatabaseGetIAMPolicy(w http.ResponseWriter, r *http.Requ
 		return nil, trace.Wrap(err)
 	}
 
-	database, err := fetchDatabaseWithName(r.Context(), clt, r, databaseName)
+	dbServer, err := fetchDatabaseServerByDatabaseName(r.Context(), clt, r, databaseName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	database := dbServer.GetDatabase()
 
 	switch {
 	case database.IsAWSHosted():
@@ -818,8 +819,8 @@ func (s *databaseInteractiveSession) sendSessionMetadata() error {
 	return nil
 }
 
-// fetchDatabaseWithName fetch a database with provided database name.
-func fetchDatabaseWithName(ctx context.Context, clt resourcesAPIGetter, r *http.Request, databaseName string) (types.Database, error) {
+// fetchDatabaseServerByDatabaseName fetch a database with provided database name.
+func fetchDatabaseServerByDatabaseName(ctx context.Context, clt resourcesAPIGetter, r *http.Request, databaseName string) (types.DatabaseServer, error) {
 	resp, err := clt.ListResources(ctx, proto.ListResourcesRequest{
 		Limit:               defaults.MaxIterationLimit,
 		ResourceType:        types.KindDatabaseServer,
@@ -839,7 +840,7 @@ func fetchDatabaseWithName(ctx context.Context, clt resourcesAPIGetter, r *http.
 	case 0:
 		return nil, trace.NotFound("database %q not found", databaseName)
 	default:
-		return servers[0].GetDatabase(), nil
+		return servers[0], nil
 	}
 }
 

--- a/lib/web/ui/server.go
+++ b/lib/web/ui/server.go
@@ -314,6 +314,16 @@ type Database struct {
 	// AutoUsersEnabled is a flag to indicate the database has user auto
 	// provisioning enabled
 	AutoUsersEnabled bool `json:"auto_users_enabled,omitempty"`
+	// TargetHealth describes the health status of network connectivity
+	// reported from an agent (db_service) that is proxying this database.
+	//
+	// This field will be empty if the database was not extracted from
+	// a db_server resource. The following endpoints will set this field
+	// since these endpoints query for db_server under the hood and then
+	// extract db from it:
+	// - webapi/sites/:site/databases/:database (singular)
+	// - webapi/sites/:site/resources (unified resources)
+	TargetHealth types.TargetHealth `json:"targetHealth,omitempty"`
 }
 
 // AWS contains AWS specific fields.
@@ -390,6 +400,13 @@ func MakeDatabase(database types.Database, accessChecker services.AccessChecker,
 		}
 	}
 
+	return db
+}
+
+// MakeDatabaseFromDatabaseServer creates a database object with db_server target health info.
+func MakeDatabaseFromDatabaseServer(dbServer types.DatabaseServer, accessChecker services.AccessChecker, interactiveChecker DatabaseInteractiveChecker, requiresRequest bool) Database {
+	db := MakeDatabase(dbServer.GetDatabase(), accessChecker, interactiveChecker, requiresRequest)
+	db.TargetHealth = dbServer.GetTargetHealth()
 	return db
 }
 

--- a/web/packages/shared/components/SlidingSidePanel/InfoGuide/InfoGuideContext.tsx
+++ b/web/packages/shared/components/SlidingSidePanel/InfoGuide/InfoGuideContext.tsx
@@ -38,6 +38,27 @@ export type InfoGuideConfig = {
    */
   guide: JSX.Element;
   /**
+   * If true, means the view where this guide will get
+   * rendered already has it's own side panel. Normally
+   * the parent container that renders this guide will need
+   * to set a margin-right equal to the guide's panelWidth
+   * to make space to render the guide (so it doesn't render
+   * over existing contents), but with this flag set to true,
+   * the parent container will not set any margin-right since
+   * it's assumed the space will already be accounted for.
+   *
+   * Eg: In unified resources view (UnifiedResourcesE.tsx) in
+   * enterprise version, there exists a side panel for access request
+   * checkout. If a resource is checked out, the view will render a side
+   * panel that already pushes contents out of the way. If the guide
+   * renders, we will use the same side panel to push contents
+   * out of the way. This avoids extra widths added and width flickering
+   * if we try to conditionally push contents out of the way with the
+   * guides parent container when both the guide and the checkout
+   * is activated.
+   */
+  viewHasOwnSidePanel?: boolean;
+  /**
    * Optional custom title for the guide panel.
    */
   title?: React.ReactNode;

--- a/web/packages/shared/components/SlidingSidePanel/InfoGuide/const.ts
+++ b/web/packages/shared/components/SlidingSidePanel/InfoGuide/const.ts
@@ -19,7 +19,7 @@
 /**
  * Used to display unified resource status info
  */
-export const resourceStatusPanelWidth = 430;
+export const resourceStatusPanelWidth = 450;
 /**
  * Used to display documentation/help/hint info
  */

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.story.tsx
@@ -131,6 +131,7 @@ const story = ({
               disabled: false,
             },
           ]}
+          onShowStatusInfo={() => null}
           params={mergedParams}
           setParams={() => undefined}
           pinning={pinning}

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -57,15 +57,18 @@ import { makeAdvancedSearchQueryForLabel } from 'shared/utils/advancedSearchLabe
 
 import { ResourcesResponse } from 'teleport/services/agents';
 
+import { useInfoGuide } from '../SlidingSidePanel/InfoGuide';
 import { CardsView } from './CardsView/CardsView';
 import { FilterPanel } from './FilterPanel';
 import { ListView } from './ListView/ListView';
 import { ResourceTab } from './ResourceTab';
+import { getResourceId } from './shared/StatusInfo';
 import { mapResourceToViewItem } from './shared/viewItemsFactory';
 import {
   IncludedResourceMode,
   PinningSupport,
   SharedUnifiedResource,
+  UnifiedResourceDefinition,
   UnifiedResourcesPinning,
   UnifiedResourcesQueryParams,
 } from './types';
@@ -172,6 +175,12 @@ export interface UnifiedResourcesProps {
   updateUnifiedResourcesPreferences(
     preferences: UnifiedResourcePreferences
   ): void;
+
+  /**
+   * When called, slides opens a InfoGuideSidePanel component
+   * with selected resources status info.
+   */
+  onShowStatusInfo(resource: UnifiedResourceDefinition): void;
 }
 
 export function UnifiedResources(props: UnifiedResourcesProps) {
@@ -189,6 +198,7 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
     unifiedResourcePreferences,
     ClusterDropdown,
     bulkActions = [],
+    onShowStatusInfo,
   } = props;
 
   const containerRef = useRef<HTMLDivElement>();
@@ -196,6 +206,8 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
   const { setTrigger } = useInfiniteScroll({
     fetch: fetchResources,
   });
+
+  const { infoGuideConfig } = useInfoGuide();
 
   const [selectedResources, setSelectedResources] = useState<string[]>([]);
   const [forceCardView, setForceCardView] = useState(false);
@@ -605,8 +617,13 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
                   },
                 }),
                 key: generateUnifiedResourceKey(resource),
-                onShowStatusInfo: () => null,
-                showingStatusInfo: false,
+                // TODO(kimlisa): teleterm will pass this field as "null"
+                // to add support later.
+                onShowStatusInfo: () =>
+                  onShowStatusInfo ? onShowStatusInfo(resource) : null,
+                showingStatusInfo:
+                  infoGuideConfig?.id &&
+                  infoGuideConfig.id === getResourceId(resource),
               }))
             : []
         }

--- a/web/packages/shared/components/UnifiedResources/shared/StatusInfo.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/shared/StatusInfo.story.tsx
@@ -137,13 +137,13 @@ const fewDbServers: DatabaseServer[] = [
     kind: 'db_server',
     hostId: 'host-id-1',
     hostname: 'hostname-1',
-    targetHealth: { status: 'unhealthy', reason: 'reason 1' },
+    targetHealth: { status: 'unhealthy', error: 'error reason 1' },
   },
   {
     kind: 'db_server',
     hostId: 'host-id-2',
     hostname: 'hostname-2',
-    targetHealth: { status: 'unhealthy', reason: 'reason 2' },
+    targetHealth: { status: 'unhealthy', error: 'error reason 2' },
   },
   {
     kind: 'db_server',
@@ -151,7 +151,7 @@ const fewDbServers: DatabaseServer[] = [
       'host-id-long-george-washington-cherry-blossom-apple-banana-orange-chocolate-meow',
     hostname:
       'hostname-long-really-long-like-really-long-longer-pumpkin-pie-halloween',
-    targetHealth: { status: 'unknown', reason: loremTxt },
+    targetHealth: { status: 'unknown', error: loremTxt },
   },
 ];
 

--- a/web/packages/shared/components/UnifiedResources/shared/StatusInfo.tsx
+++ b/web/packages/shared/components/UnifiedResources/shared/StatusInfo.tsx
@@ -29,9 +29,11 @@ import {
 import { ResourceIcon } from 'design/ResourceIcon';
 import { H2, H3 } from 'design/Text';
 import {
+  InfoGuideConfig,
   InfoParagraph,
   InfoTitle,
 } from 'shared/components/SlidingSidePanel/InfoGuide';
+import { resourceStatusPanelWidth } from 'shared/components/SlidingSidePanel/InfoGuide/const';
 import { useInfiniteScroll } from 'shared/hooks';
 import { Attempt } from 'shared/hooks/useAttemptNext';
 import { pluralize } from 'shared/utils/text';
@@ -258,7 +260,7 @@ function UnhealthyServerList({ servers }: { servers: SharedResourceServer[] }) {
         <InfoField>UUID:</InfoField> {server.hostId}
       </Text>
       <Text>
-        <InfoField>Reason:</InfoField> {server.targetHealth?.reason}
+        <InfoField>Reason:</InfoField> {server.targetHealth?.error}
       </Text>
     </Flex>
   ));
@@ -267,3 +269,42 @@ function UnhealthyServerList({ servers }: { servers: SharedResourceServer[] }) {
 const InfoField = styled.span`
   font-weight: bold;
 `;
+
+/**
+ * Returns a unique id by appending the resource kind with
+ * their name/id (for most resources their id is the "name" field,
+ * other resources does not have name field, but an "id" field).
+ */
+export function getResourceId(resource: UnifiedResourceDefinition) {
+  const kind = resource.kind;
+  let id;
+  if (kind === 'node' || kind === 'git_server') {
+    id = resource.id;
+  } else {
+    id = resource.name;
+  }
+
+  return `${kind}/${id}`;
+}
+
+export function openStatusInfoPanel({
+  resource,
+  setInfoGuideConfig,
+  guide,
+  isEnterprise = false,
+}: {
+  resource: UnifiedResourceDefinition;
+  setInfoGuideConfig: (cfg: InfoGuideConfig) => void;
+  guide: JSX.Element;
+  isEnterprise?: boolean;
+}) {
+  if (resource.kind === 'db') {
+    setInfoGuideConfig({
+      guide,
+      id: getResourceId(resource),
+      title: <StatusInfoHeader resource={resource} />,
+      panelWidth: resourceStatusPanelWidth,
+      viewHasOwnSidePanel: isEnterprise,
+    });
+  }
+}

--- a/web/packages/shared/components/UnifiedResources/shared/StatusInfo.tsx
+++ b/web/packages/shared/components/UnifiedResources/shared/StatusInfo.tsx
@@ -259,9 +259,11 @@ function UnhealthyServerList({ servers }: { servers: SharedResourceServer[] }) {
       <Text>
         <InfoField>UUID:</InfoField> {server.hostId}
       </Text>
-      <Text>
-        <InfoField>Reason:</InfoField> {server.targetHealth?.error}
-      </Text>
+      {server.targetHealth?.error && (
+        <Text>
+          <InfoField>Reason:</InfoField> {server.targetHealth.error}
+        </Text>
+      )}
     </Flex>
   ));
 }

--- a/web/packages/shared/components/UnifiedResources/types.ts
+++ b/web/packages/shared/components/UnifiedResources/types.ts
@@ -34,7 +34,7 @@ export type ResourceStatus = 'healthy' | 'unhealthy' | 'unknown' | '';
 
 export type ResourceTargetHealth = {
   status: ResourceStatus;
-  reason?: string;
+  error?: string;
 };
 
 export type UnifiedResourceApp = {

--- a/web/packages/teleport/src/Databases/fixtures/index.ts
+++ b/web/packages/teleport/src/Databases/fixtures/index.ts
@@ -31,9 +31,7 @@ export const databases: Database[] = [
     ],
     hostname: 'aurora-hostname',
     targetHealth: { status: 'unhealthy' },
-    // TODO(kimlisa): remove as any once we add
-    // "targetHealth" field to db response
-  } as any,
+  },
   {
     kind: 'db',
     name: 'mongodbizzle',
@@ -46,9 +44,7 @@ export const databases: Database[] = [
     ],
     hostname: 'mongo-bongo',
     targetHealth: { status: 'unknown' },
-    // TODO(kimlisa): remove as any once we add
-    // "targetHealth" field to db response
-  } as any,
+  },
   {
     kind: 'db',
     name: 'Dynamooooo',
@@ -109,9 +105,7 @@ export const databases: Database[] = [
     ],
     hostname: 'postgres-hostname',
     targetHealth: { status: 'unhealthy' },
-    // TODO(kimlisa): remove as any once we add
-    // "targetHealth" field to db response
-  } as any,
+  },
   {
     kind: 'db',
     name: 'mysql-aurora-56',

--- a/web/packages/teleport/src/Main/Main.tsx
+++ b/web/packages/teleport/src/Main/Main.tsx
@@ -319,7 +319,7 @@ export const ContentMinWidth = ({ children }: { children: ReactNode }) => {
           overflow-y: auto;
           ${marginTransitionCss({
             sidePanelOpened: infoGuideSidePanelOpened,
-            panelWidth,
+            panelWidth: infoGuideConfig?.viewHasOwnSidePanel ? 0 : panelWidth,
           })}
         `}
       >

--- a/web/packages/teleport/src/UnifiedResources/StatusInfo.tsx
+++ b/web/packages/teleport/src/UnifiedResources/StatusInfo.tsx
@@ -51,6 +51,7 @@ export function StatusInfo({
           params: {
             ...params,
             query: `name == "${resource.name}"`,
+            searchAsRoles: resource.requiresRequest ? 'yes' : '',
           },
           signal,
         });

--- a/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/teleport/src/UnifiedResources/UnifiedResources.tsx
@@ -22,15 +22,21 @@ import styled from 'styled-components';
 import { Box, Flex } from 'design';
 import { Danger } from 'design/Alert';
 import { DefaultTab } from 'gen-proto-ts/teleport/userpreferences/v1/unified_resource_preferences_pb';
+import { useInfoGuide } from 'shared/components/SlidingSidePanel/InfoGuide';
 import {
   BulkAction,
   FilterKind,
   IncludedResourceMode,
   ResourceAvailabilityFilter,
   UnifiedResources as SharedUnifiedResources,
+  UnifiedResourceDefinition,
   UnifiedResourcesPinning,
   useUnifiedResourcesFetch,
 } from 'shared/components/UnifiedResources';
+import {
+  getResourceId,
+  openStatusInfoPanel,
+} from 'shared/components/UnifiedResources/shared/StatusInfo';
 
 import { useTeleport } from 'teleport';
 import AgentButtonAdd from 'teleport/components/AgentButtonAdd';
@@ -43,6 +49,7 @@ import {
   FeatureHeaderTitle,
 } from 'teleport/components/Layout';
 import { ServersideSearchPanel } from 'teleport/components/ServersideSearchPanel';
+import cfg from 'teleport/config';
 import { SearchResource } from 'teleport/Discover/SelectResource';
 import { useNoMinWidth } from 'teleport/Main';
 import {
@@ -55,6 +62,7 @@ import { useUser } from 'teleport/User/UserContext';
 import useStickyClusterId from 'teleport/useStickyClusterId';
 
 import { ResourceActionButton } from './ResourceActionButton';
+import { StatusInfo } from './StatusInfo';
 
 export function UnifiedResources() {
   const { clusterId, isLeafCluster } = useStickyClusterId();
@@ -245,10 +253,27 @@ export function ClusterResources({
     clear();
   }
 
+  const { setInfoGuideConfig } = useInfoGuide();
+  function onShowStatusInfo(resource: UnifiedResourceDefinition) {
+    openStatusInfoPanel({
+      isEnterprise: cfg.edition === 'ent',
+      resource,
+      setInfoGuideConfig,
+      guide: (
+        <StatusInfo
+          resource={resource}
+          clusterId={clusterId}
+          key={getResourceId(resource)}
+        />
+      ),
+    });
+  }
+
   return (
     <>
       {loadClusterError && <Danger>{loadClusterError}</Danger>}
       <SharedUnifiedResources
+        onShowStatusInfo={onShowStatusInfo}
         bulkActions={bulkActions}
         params={params}
         fetchResources={fetch}

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -52,7 +52,7 @@ export type Cfg = typeof cfg;
 const cfg = {
   /** @deprecated Use cfg.edition instead. */
   isEnterprise: false,
-  edition: 'oss',
+  edition: 'oss', // oss, community, ent
   isCloud: false,
   automaticUpgrades: false,
   // TODO (avatus) this is a temporary escape hatch. Delete in v18
@@ -264,7 +264,7 @@ const cfg = {
     passwordTokenPath: '/v1/webapi/users/password/token/:tokenId?',
     changeUserPasswordPath: '/v1/webapi/users/password',
     unifiedResourcesPath:
-      '/v1/webapi/sites/:clusterId/resources?searchAsRoles=:searchAsRoles?&limit=:limit?&startKey=:startKey?&kinds=:kinds?&query=:query?&search=:search?&sort=:sort?&pinnedOnly=:pinnedOnly?&includedResourceMode=:includedResourceMode?',
+      '/v1/webapi/sites/:clusterId/resources?searchAsRoles=:searchAsRoles?&limit=:limit?&startKey=:startKey?&kinds=:kinds?&query=:query?&search=:search?&sort=:sort?&pinnedOnly=:pinnedOnly?&includedResourceMode=:includedResourceMode?&status=:status?',
     nodesPath:
       '/v1/webapi/sites/:clusterId/nodes?searchAsRoles=:searchAsRoles?&limit=:limit?&startKey=:startKey?&query=:query?&search=:search?&sort=:sort?',
     nodesPathNoParams: '/v1/webapi/sites/:clusterId/nodes',
@@ -280,7 +280,7 @@ const cfg = {
     databasesPath: `/v1/webapi/sites/:clusterId/databases?searchAsRoles=:searchAsRoles?&limit=:limit?&startKey=:startKey?&query=:query?&search=:search?&sort=:sort?`,
 
     databaseServer: {
-      list: `/v1/webapi/sites/:clusterId/databaseservers?&limit=:limit?&startKey=:startKey?&query=:query?`,
+      list: `/v1/webapi/sites/:clusterId/databaseservers?searchAsRoles=:searchAsRoles?&limit=:limit?&startKey=:startKey?&query=:query?`,
     },
 
     desktopsPath: `/v1/webapi/sites/:clusterId/desktops?searchAsRoles=:searchAsRoles?&limit=:limit?&startKey=:startKey?&query=:query?&search=:search?&sort=:sort?`,

--- a/web/packages/teleport/src/services/databases/makeDatabase.ts
+++ b/web/packages/teleport/src/services/databases/makeDatabase.ts
@@ -21,7 +21,8 @@ import { formatDatabaseInfo } from 'shared/services/databases';
 import { Aws, Database, DatabaseServer, DatabaseService } from './types';
 
 export function makeDatabase(json: any): Database {
-  const { name, desc, protocol, type, aws, requiresRequest } = json;
+  const { name, desc, protocol, type, aws, requiresRequest, targetHealth } =
+    json;
 
   const labels = json.labels || [];
 
@@ -57,6 +58,10 @@ export function makeDatabase(json: any): Database {
     requiresRequest,
     supportsInteractive: json.supports_interactive || false,
     autoUsersEnabled: json.auto_users_enabled || false,
+    targetHealth: targetHealth && {
+      status: targetHealth.status,
+      error: targetHealth.transition_error,
+    },
   };
 }
 
@@ -104,7 +109,7 @@ export function makeDatabaseServer(json: any): DatabaseServer {
     targetHealth: status &&
       status.target_health && {
         status: status.target_health.status,
-        reason: status.target_health.transition_error,
+        error: status.target_health.transition_error,
       },
   };
 }

--- a/web/packages/teleport/src/services/databases/types.ts
+++ b/web/packages/teleport/src/services/databases/types.ts
@@ -55,6 +55,18 @@ export interface Database {
   requiresRequest?: boolean;
   supportsInteractive?: boolean;
   autoUsersEnabled?: boolean;
+  /**
+   * targetHealth describes the health status of network connectivity
+   * reported from an agent (db_service) that is proxying this database.
+   *
+   * This field will be empty if the database was not extracted from
+   * a db_server resource. The following endpoints will set this field
+   * since these endpoints query for db_server under the hood and then
+   * extract db from it:
+   * - webapi/sites/:site/databases/:database (singular)
+   * - webapi/sites/:site/resources (unified resources)
+   */
+  targetHealth?: ResourceTargetHealth;
 }
 
 export type DatabasesResponse = {

--- a/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/UnifiedResources.tsx
@@ -402,6 +402,8 @@ const Resources = memo(
         })}
       >
         <SharedUnifiedResources
+          // TODO(kimlisa): add support later
+          onShowStatusInfo={() => null}
           params={props.queryParams}
           setParams={props.onParamsChange}
           unifiedResourcePreferencesAttempt={props.userPreferencesAttempt}


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/20544

recommend reviewing by commit

This PR just adds support for the target health field, so that unhealthy status shows up on unified resources view, and users can click on the status badges to see more info (teleterm support will come later)

Since this PR is based on https://github.com/gravitational/teleport/pull/54474, commits to that PR, may mess up this PR, so the commits for my changes start at commit message `Return target health field with db's extracted from db_servers`

changelog: Adds support for viewing status information for databases where connection is unhealthy in the Unified Resources view in the web UI



https://github.com/user-attachments/assets/6ea94f64-56ee-413c-af2c-ffadfa66619e


