### PR TITLE
[v16] feat(join-tokens): [44794] Add Join Token form for GitHub

### DIFF
--- a/web/packages/design/src/Flex/Flex.tsx
+++ b/web/packages/design/src/Flex/Flex.tsx
@@ -42,7 +42,10 @@ interface FlexProps
     FlexWrapProps,
     FlexDirectionProps,
     FlexBasisProps,
-    GapProps {}
+    GapProps {
+  /** Makes the element and its immediate children have 100% width. */
+  fullWidth?: boolean;
+}
 
 const Flex = styled(Box)<FlexProps>`
   display: flex;
@@ -52,6 +55,15 @@ const Flex = styled(Box)<FlexProps>`
   ${flexBasis}
   ${flexDirection}
   ${gap};
+
+  ${props =>
+    props.fullWidth &&
+    `
+      width: 100%;
+      & > * {
+        width: 100%;
+      }
+    `}
 `;
 
 Flex.displayName = 'Flex';

--- a/web/packages/design/src/utils/testing.tsx
+++ b/web/packages/design/src/utils/testing.tsx
@@ -25,6 +25,7 @@ import {
   render as testingRender,
   waitFor,
   waitForElementToBeRemoved,
+  within,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
@@ -58,13 +59,23 @@ function render(ui: React.ReactElement<any>, options?: RenderOptions) {
   return testingRender(ui, { wrapper: Providers, ...options });
 }
 
+/*
+ Returns a Promise resolving on the next macrotask, allowing any pending state
+ updates / timeouts to finish.
+ */
+function tick() {
+  return new Promise<void>(res =>
+    jest.requireActual('timers').setImmediate(res)
+  );
+}
+
 screen.debug = () => {
   window.console.log(prettyDOM());
 };
 
 type RenderOptions = {
-  wrapper: React.FC;
-  container: HTMLElement;
+  wrapper?: React.FC;
+  container?: HTMLElement;
 };
 
 export {
@@ -72,6 +83,7 @@ export {
   screen,
   fireEvent,
   darkTheme as theme,
+  tick,
   render,
   prettyDOM,
   waitFor,
@@ -79,4 +91,5 @@ export {
   Router,
   userEvent,
   waitForElementToBeRemoved,
+  within,
 };

--- a/web/packages/shared/utils/collectKeys.test.ts
+++ b/web/packages/shared/utils/collectKeys.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { collectKeys } from './collectKeys';
+
+describe('collectKeys', () => {
+  it.each`
+    value
+    ${undefined}
+    ${null}
+    ${1}
+    ${true}
+    ${() => {}}
+  `('supports non object values ($value)', ({ value }) => {
+    const actual = collectKeys(value);
+    expect(actual).toBeNull();
+  });
+
+  it('supports empty object values', () => {
+    const actual = collectKeys({});
+    expect(actual).toEqual([]);
+  });
+
+  it('supports empty array values', () => {
+    const actual = collectKeys([]);
+    expect(actual).toEqual([]);
+  });
+
+  it('supports simple object values', () => {
+    const actual = collectKeys({
+      number: 1,
+      boolean: true,
+      string: 'string',
+      function: () => {},
+      null: null,
+      undefined: undefined,
+    });
+    expect(actual).toEqual([
+      '.number',
+      '.boolean',
+      '.string',
+      '.function',
+      '.null',
+      '.undefined',
+    ]);
+  });
+
+  it('supports simple array values', () => {
+    const actual = collectKeys([
+      { alpha: true },
+      { alpha: true },
+      { beta: true },
+    ]);
+    expect(actual).toEqual(['.alpha', '.alpha', '.beta']);
+  });
+
+  it('supports nested object values', () => {
+    const actual = collectKeys([
+      {
+        inner: {
+          foo: 'bar',
+        },
+      },
+    ]);
+    expect(actual).toEqual(['.inner.foo']);
+  });
+
+  it('supports nested array values', () => {
+    const actual = collectKeys([[{ foo: 'bar' }], { bar: 'foo' }]);
+    expect(actual).toEqual(['.foo', '.bar']);
+  });
+
+  it('allows a custom key prefix', () => {
+    const actual = collectKeys(
+      {
+        foo: 1,
+      },
+      'root'
+    );
+    expect(actual).toEqual(['root.foo']);
+  });
+});

--- a/web/packages/shared/utils/collectKeys.ts
+++ b/web/packages/shared/utils/collectKeys.ts
@@ -1,0 +1,42 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * `collectKeys` gathers object keys recursively and returns them. Arrays are
+ * traversed, but are transparent. Returns null if the value is not an object
+ * or array of objects, and an empty array of no keys are present.
+ *
+ * @param value Value from which keys will be collected
+ * @param prefix An optional value to be prepended to all keys returned
+ * @returns An array of the keys collected (if any) or null
+ */
+export const collectKeys = (value: unknown, prefix: string = '') => {
+  if (typeof value !== 'object' || value === null) {
+    return prefix ? [prefix] : null;
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap(val => {
+      return collectKeys(val, prefix);
+    });
+  }
+
+  return Object.entries(value).flatMap(([k, v]) => {
+    return collectKeys(v, `${prefix}.${k}`);
+  });
+};

--- a/web/packages/teleport/src/JoinTokens/JoinTokenForms.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokenForms.tsx
@@ -29,9 +29,11 @@ import { NewJoinTokenState, OptionGCP, RuleBox } from './UpsertJoinTokenDialog';
 export const JoinTokenIAMForm = ({
   tokenState,
   onUpdateState,
+  readonly,
 }: {
   tokenState: NewJoinTokenState;
   onUpdateState: (newToken: NewJoinTokenState) => void;
+  readonly: boolean;
 }) => {
   const rules = tokenState.iam;
 
@@ -102,6 +104,7 @@ export const JoinTokenIAMForm = ({
             onChange={e =>
               setTokenRulesField(index, 'aws_account', e.target.value)
             }
+            readonly={readonly}
           />
           <FieldInput
             label="ARN"
@@ -109,6 +112,7 @@ export const JoinTokenIAMForm = ({
             placeholder="arn:aws:iam::account-id:role/*"
             value={rule.aws_arn}
             onChange={e => setTokenRulesField(index, 'aws_arn', e.target.value)}
+            readonly={readonly}
           />
         </RuleBox>
       ))}
@@ -123,9 +127,11 @@ export const JoinTokenIAMForm = ({
 export const JoinTokenGCPForm = ({
   tokenState,
   onUpdateState,
+  readonly,
 }: {
   tokenState: NewJoinTokenState;
   onUpdateState: (newToken: NewJoinTokenState) => void;
+  readonly: boolean;
 }) => {
   const rules = tokenState.gcp;
   function removeRule(index: number) {
@@ -196,6 +202,7 @@ export const JoinTokenGCPForm = ({
             value={rule.project_ids}
             label="Add Project ID(s)"
             rule={requiredField('At least 1 Project ID required')}
+            isDisabled={readonly}
           />
           <FieldSelectCreatable
             placeholder="us-west1, us-east1-a"
@@ -207,7 +214,8 @@ export const JoinTokenGCPForm = ({
             }
             value={rule.locations}
             label="Add Locations"
-            labelTip="Allows regions and/or zones."
+            helperText="Allows regions and/or zones."
+            isDisabled={readonly}
           />
           <FieldSelectCreatable
             placeholder="PROJECT_compute@developer.gserviceaccount.com"
@@ -219,6 +227,7 @@ export const JoinTokenGCPForm = ({
             }
             value={rule.service_accounts}
             label="Add Service Account Emails"
+            isDisabled={readonly}
           />
         </RuleBox>
       ))}

--- a/web/packages/teleport/src/JoinTokens/JoinTokenGithubForm.test.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokenGithubForm.test.tsx
@@ -1,0 +1,391 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import userEvent from '@testing-library/user-event';
+import { PropsWithChildren } from 'react';
+
+import ThemeProvider from 'design/ThemeProvider';
+import { fireEvent, render, screen, within } from 'design/utils/testing';
+import Validation, {
+  useValidation,
+  Validator,
+} from 'shared/components/Validation';
+
+import { JoinTokenGithubForm } from './JoinTokenGithubForm';
+import { NewJoinTokenState } from './UpsertJoinTokenDialog';
+
+const populateRuleFieldTest =
+  (
+    field: keyof NewJoinTokenState['github']['rules'][number],
+    placeholer: string,
+    value: string
+  ) =>
+  async () => {
+    const state = baseState();
+    const onUpdate = jest.fn();
+
+    render(
+      <JoinTokenGithubForm
+        tokenState={state}
+        onUpdateState={onUpdate}
+        readonly={false}
+      />,
+      { wrapper: Wrapper }
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(placeholer), {
+      target: { value },
+    });
+
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect(onUpdate).toHaveBeenLastCalledWith(
+      baseState({
+        rules: [
+          {
+            ...state.github.rules[0],
+            [field]: value,
+          },
+        ],
+      })
+    );
+  };
+
+const populateFieldTest =
+  ({
+    field,
+    placeholer,
+    value,
+  }: {
+    field: keyof NewJoinTokenState['github'];
+    placeholer: string;
+    value: string;
+  }) =>
+  async () => {
+    const state = baseState();
+    const onUpdate = jest.fn();
+
+    render(
+      <JoinTokenGithubForm
+        tokenState={state}
+        onUpdateState={onUpdate}
+        readonly={false}
+      />,
+      { wrapper: Wrapper }
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(placeholer), {
+      target: { value },
+    });
+
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect(onUpdate).toHaveBeenLastCalledWith(
+      baseState({
+        [field]: value,
+      })
+    );
+  };
+
+describe('GithubJoinTokenForm', () => {
+  it('a rule can be added', async () => {
+    const state = baseState();
+    const onUpdate = jest.fn();
+
+    render(
+      <JoinTokenGithubForm
+        tokenState={state}
+        onUpdateState={onUpdate}
+        readonly={false}
+      />,
+      { wrapper: Wrapper }
+    );
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /Add another GitHub rule/i })
+    );
+
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect(onUpdate).toHaveBeenLastCalledWith(
+      baseState({
+        rules: [
+          ...state.github.rules,
+          {
+            ref_type: 'any',
+          },
+        ],
+      })
+    );
+  });
+
+  it('delete button is hidden when only one rule exists', async () => {
+    const state = baseState();
+
+    render(
+      <JoinTokenGithubForm
+        tokenState={state}
+        onUpdateState={jest.fn()}
+        readonly={false}
+      />,
+      { wrapper: Wrapper }
+    );
+
+    expect(screen.queryByTestId('delete_rule')).not.toBeInTheDocument();
+  });
+
+  it('delete button is visible when more than one rule exists', async () => {
+    const state = baseState({
+      rules: [{}, {}],
+    });
+
+    render(
+      <JoinTokenGithubForm
+        tokenState={state}
+        onUpdateState={jest.fn()}
+        readonly={false}
+      />,
+      { wrapper: Wrapper }
+    );
+
+    expect(screen.queryAllByTestId('delete_rule').length).toBe(2);
+  });
+
+  it('a rule can be deleted', async () => {
+    const state = baseState({
+      rules: [{}, {}],
+    });
+    const onUpdate = jest.fn();
+
+    render(
+      <JoinTokenGithubForm
+        tokenState={state}
+        onUpdateState={onUpdate}
+        readonly={false}
+      />,
+      { wrapper: Wrapper }
+    );
+
+    const rule0 = screen.getByTestId('rule_0');
+    const deleteButton0 = within(rule0).getByTestId('delete_rule');
+
+    await userEvent.click(deleteButton0);
+
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect(onUpdate).toHaveBeenLastCalledWith(
+      baseState({
+        rules: [state.github.rules[0]],
+      })
+    );
+  });
+
+  // eslint-disable-next-line jest/expect-expect
+  it(
+    'repository field can be populated',
+    populateRuleFieldTest(
+      'repository',
+      'gravitational/teleport',
+      'gravitational/teleport'
+    )
+  );
+
+  it('repository field shows a validation message', async () => {
+    const state = baseState();
+
+    render(
+      <JoinTokenGithubForm
+        tokenState={state}
+        onUpdateState={jest.fn()}
+        readonly={false}
+      />,
+      { wrapper: Wrapper }
+    );
+
+    await userEvent.click(screen.getByTestId('submit'));
+
+    expect(
+      screen.getByText('Either repository name or owner is required')
+    ).toBeInTheDocument();
+  });
+
+  // eslint-disable-next-line jest/expect-expect
+  it(
+    'repository owner field can be populated',
+    populateRuleFieldTest('repository_owner', 'gravitational', 'gravitational')
+  );
+
+  it('repository owner field shows a validation message', async () => {
+    const state = baseState();
+
+    render(
+      <JoinTokenGithubForm
+        tokenState={state}
+        onUpdateState={jest.fn()}
+        readonly={false}
+      />,
+      { wrapper: Wrapper }
+    );
+
+    await userEvent.click(screen.getByTestId('submit'));
+
+    expect(
+      screen.getByText('Either repository owner or name is required')
+    ).toBeInTheDocument();
+  });
+
+  // eslint-disable-next-line jest/expect-expect
+  it(
+    'workflow field can be populated',
+    populateRuleFieldTest('workflow', 'my-workflow', 'my-workflow')
+  );
+
+  // eslint-disable-next-line jest/expect-expect
+  it(
+    'environment field can be populated',
+    populateRuleFieldTest('environment', 'production', 'production')
+  );
+
+  // eslint-disable-next-line jest/expect-expect
+  it(
+    'ref field can be populated',
+    populateRuleFieldTest('ref', 'ref/heads/main', 'ref/heads/main')
+  );
+
+  it('ref type is disabled when ref is not populated', async () => {
+    const state = baseState();
+
+    render(
+      <JoinTokenGithubForm
+        tokenState={state}
+        onUpdateState={jest.fn()}
+        readonly={false}
+      />,
+      { wrapper: Wrapper }
+    );
+
+    expect(screen.getByLabelText('Ref type')).toBeDisabled();
+  });
+
+  it('ref type can be selected', async () => {
+    const state = baseState({
+      rules: [
+        {
+          ref: 'ref/heads/main',
+          ref_type: 'any',
+        },
+      ],
+    });
+    const onUpdate = jest.fn();
+
+    render(
+      <JoinTokenGithubForm
+        tokenState={state}
+        onUpdateState={onUpdate}
+        readonly={false}
+      />,
+      { wrapper: Wrapper }
+    );
+
+    const selectElement = screen.getByLabelText('Ref type');
+    expect(selectElement).toBeEnabled();
+
+    // Seems to be the only way to interact with react-select component
+    fireEvent.keyDown(selectElement, { key: 'ArrowDown' });
+    const existingItem = await screen.findByText('Branch');
+    fireEvent.click(existingItem);
+
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect(onUpdate).toHaveBeenLastCalledWith(
+      baseState({
+        rules: [
+          {
+            ...state.github.rules[0],
+            ref_type: 'branch',
+          },
+        ],
+      })
+    );
+  });
+
+  // eslint-disable-next-line jest/expect-expect
+  it(
+    'server host field can be populated',
+    populateFieldTest({
+      field: 'server_host',
+      placeholer: 'github.example.com',
+      value: 'github.example.com',
+    })
+  );
+
+  // eslint-disable-next-line jest/expect-expect
+  it(
+    'slug field can be populated',
+    populateFieldTest({
+      field: 'enterprise_slug',
+      placeholer: 'octo-enterprise',
+      value: 'octo-enterprise',
+    })
+  );
+
+  // eslint-disable-next-line jest/expect-expect
+  it(
+    'jwks field can be populated',
+    populateFieldTest({
+      field: 'static_jwks',
+      placeholer: '{"keys":[--snip--]}',
+      value: '{"keys":[]}',
+    })
+  );
+});
+
+const Wrapper = ({ children }: PropsWithChildren) => {
+  return (
+    <ThemeProvider>
+      <Validation>
+        <SubmitWrapper>{children}</SubmitWrapper>
+      </Validation>
+    </ThemeProvider>
+  );
+};
+
+const SubmitWrapper = ({ children }: PropsWithChildren) => {
+  const validation = useValidation() as Validator;
+
+  return (
+    <>
+      {children}
+      <button data-testid="submit" onClick={() => validation.validate()} />
+    </>
+  );
+};
+
+const baseState = (
+  github: Partial<NewJoinTokenState['github']> = {}
+): NewJoinTokenState => ({
+  name: 'test-name',
+  method: { label: 'github', value: 'github' },
+  roles: [{ label: 'Bot', value: 'Bot' }],
+  bot_name: 'test-bot-name',
+  github: {
+    ...github,
+    rules: github.rules ?? [
+      {
+        ref_type: 'any',
+      },
+    ],
+  },
+  iam: [],
+  gcp: [],
+});

--- a/web/packages/teleport/src/JoinTokens/JoinTokenGithubForm.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokenGithubForm.tsx
@@ -1,0 +1,289 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import styled from 'styled-components';
+
+import { Info } from 'design/Alert/Alert';
+import Box from 'design/Box/Box';
+import { ButtonText } from 'design/Button/Button';
+import ButtonIcon from 'design/ButtonIcon/ButtonIcon';
+import Flex from 'design/Flex/Flex';
+import { Plus } from 'design/Icon/Icons/Plus';
+import { Trash } from 'design/Icon/Icons/Trash';
+import Link from 'design/Link/Link';
+import Text from 'design/Text/Text';
+import FieldInput from 'shared/components/FieldInput/FieldInput';
+import FieldSelect from 'shared/components/FieldSelect';
+import { requiredField } from 'shared/components/Validation/rules';
+
+import cfg from 'teleport/config';
+
+import { NewJoinTokenState } from './UpsertJoinTokenDialog';
+
+export const JoinTokenGithubForm = ({
+  tokenState,
+  onUpdateState,
+  readonly,
+}: {
+  tokenState: NewJoinTokenState;
+  onUpdateState: (newToken: NewJoinTokenState) => void;
+  readonly: boolean;
+}) => {
+  const { github } = tokenState;
+  const { rules } = github;
+
+  function removeRule(index: number) {
+    const newRules = rules.filter((_, i) => index !== i);
+    const newState = {
+      ...tokenState,
+      github: {
+        ...tokenState.github,
+        rules: newRules,
+      },
+    };
+    onUpdateState(newState);
+  }
+
+  function addNewRule() {
+    const newState = {
+      ...tokenState,
+      github: {
+        ...tokenState.github,
+        rules: [
+          ...rules,
+          {
+            ref_type: 'any' as const,
+          },
+        ],
+      },
+    };
+    onUpdateState(newState);
+  }
+
+  function updateRuleField(index: number, fieldName: string, opts: unknown) {
+    const newState = {
+      ...tokenState,
+      github: {
+        ...tokenState.github,
+        rules: rules.map((rule, i) => {
+          if (i === index) {
+            return { ...rule, [fieldName]: opts };
+          }
+          return rule;
+        }),
+      },
+    };
+    onUpdateState(newState);
+  }
+
+  return (
+    <>
+      {rules.map((rule, index) => (
+        <RuleBox
+          data-testid={`rule_${index}`}
+          key={index} // order doesn't change without updating the referrenced array
+        >
+          <Flex alignItems="center" justifyContent="space-between">
+            <Text fontWeight={700} mb={2}>
+              GitHub Rule
+            </Text>
+
+            {rules.length > 1 && ( // at least one rule is required, so lets not allow the user to remove it
+              <ButtonIcon
+                data-testid="delete_rule"
+                onClick={() => removeRule(index)}
+              >
+                <Trash size={16} color="text.muted" />
+              </ButtonIcon>
+            )}
+          </Flex>
+
+          <FieldInput
+            label="Repository"
+            placeholder="gravitational/teleport"
+            toolTipContent="Fully qualified name of a GitHub repository (i.e. including the owner)"
+            value={rule.repository}
+            onChange={e => updateRuleField(index, 'repository', e.target.value)}
+            rule={
+              rule.repository_owner
+                ? undefined
+                : requiredField('Either repository name or owner is required')
+            }
+            readonly={readonly}
+          />
+
+          <FieldInput
+            label="Repository owner"
+            placeholder="gravitational"
+            toolTipContent="Name of an organization or user that a repository belongs to"
+            value={rule.repository_owner}
+            onChange={e =>
+              updateRuleField(index, 'repository_owner', e.target.value)
+            }
+            rule={
+              rule.repository
+                ? undefined
+                : requiredField('Either repository owner or name is required')
+            }
+            readonly={readonly}
+          />
+
+          <FieldInput
+            label="Workflow name"
+            placeholder="my-workflow"
+            value={rule.workflow}
+            onChange={e => updateRuleField(index, 'workflow', e.target.value)}
+            readonly={readonly}
+          />
+
+          <FieldInput
+            label="Environment"
+            placeholder="production"
+            value={rule.environment}
+            onChange={e =>
+              updateRuleField(index, 'environment', e.target.value)
+            }
+            readonly={readonly}
+          />
+
+          <Flex fullWidth gap={2}>
+            <FieldInput
+              flex={2}
+              label="Git ref"
+              placeholder="ref/heads/main"
+              value={rule.ref}
+              onChange={e => updateRuleField(index, 'ref', e.target.value)}
+              readonly={readonly}
+            />
+
+            <FieldSelect
+              flex={1}
+              label="Ref type"
+              options={refTypeOptions}
+              value={refTypeOptions.find(o => o.value === rule.ref_type)}
+              isMulti={false}
+              onChange={opts =>
+                updateRuleField(
+                  index,
+                  'ref_type',
+                  Array.isArray(opts) ? opts[0]?.value : opts.value
+                )
+              }
+              isDisabled={!rule.ref || readonly}
+              data-testid="ref-type-select"
+            />
+          </Flex>
+        </RuleBox>
+      ))}
+
+      <ButtonText onClick={addNewRule} compact mb={4}>
+        <Plus size={16} mr={2} />
+        Add another GitHub rule
+      </ButtonText>
+
+      <Text fontWeight={700} mb={2}>
+        GitHub Enterprise Server
+      </Text>
+      <Text fontWeight="regular" mb={3}>
+        Additional settings for configuring GHES.
+      </Text>
+
+      {cfg.edition !== 'ent' ? (
+        <Info alignItems="flex-start">
+          <Box>
+            GitHub Enterprise Server configuration requires Teleport Enterprise.
+            Please use a repository hosted at github.com or{' '}
+            <Link
+              target="_blank"
+              href="https://goteleport.com/signup/enterprise/"
+            >
+              contact us
+            </Link>
+            .
+          </Box>
+        </Info>
+      ) : undefined}
+
+      <FieldInput
+        label="Server host"
+        placeholder="github.example.com"
+        value={github.server_host}
+        onChange={e =>
+          onUpdateState({
+            ...tokenState,
+            github: {
+              ...tokenState.github,
+              server_host: e.target.value,
+            },
+          })
+        }
+        readonly={readonly || cfg.edition !== 'ent'}
+      />
+
+      <FieldInput
+        label="Slug"
+        placeholder="octo-enterprise"
+        value={github.enterprise_slug}
+        onChange={e =>
+          onUpdateState({
+            ...tokenState,
+            github: {
+              ...tokenState.github,
+              enterprise_slug: e.target.value,
+            },
+          })
+        }
+        readonly={readonly || cfg.edition !== 'ent'}
+      />
+
+      <FieldInput
+        label="Static JWKS"
+        placeholder='{"keys":[--snip--]}'
+        toolTipContent="JSON Web Key Set used to verify the token issued by GitHub Actions"
+        value={github.static_jwks}
+        onChange={e =>
+          onUpdateState({
+            ...tokenState,
+            github: {
+              ...tokenState.github,
+              static_jwks: e.target.value,
+            },
+          })
+        }
+        readonly={readonly || cfg.edition !== 'ent'}
+      />
+    </>
+  );
+};
+
+const refTypeOptions = [
+  { value: 'any' as const, label: 'Any' },
+  { value: 'branch' as const, label: 'Branch' },
+  { value: 'tag' as const, label: 'Tag' },
+];
+
+const RuleBox = styled(Box)`
+  border-color: ${props => props.theme.colors.interactive.tonal.neutral[0]};
+  border-width: 2px;
+  border-style: solid;
+  border-radius: ${props => props.theme.radii[2]}px;
+
+  margin-bottom: ${props => props.theme.space[3]}px;
+
+  padding: ${props => props.theme.space[3]}px;
+`;

--- a/web/packages/teleport/src/JoinTokens/JoinTokens.test.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokens.test.tsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { act, within } from '@testing-library/react';
+import { act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { fireEvent, render, screen, tick } from 'design/utils/testing';

--- a/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
@@ -127,6 +127,9 @@ export const JoinTokens = () => {
 
   useEffect(() => {
     runJoinTokensAttempt();
+
+    // runJoinTokensAttempt is not stable and causes a render loop
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
@@ -151,7 +154,7 @@ export const JoinTokens = () => {
           </Button>
         )}
       </FeatureHeader>
-      <Flex>
+      <Flex gap={24}>
         <Box
           css={`
             flex-grow: 1;
@@ -221,7 +224,8 @@ export const JoinTokens = () => {
                         if (
                           token.method === 'iam' ||
                           token.method === 'gcp' ||
-                          token.method === 'token'
+                          token.method === 'token' ||
+                          (token.method === 'github' && token.github)
                         ) {
                           setEditingToken(token);
                           return;
@@ -385,7 +389,7 @@ function TokenDelete({
         <DialogTitle>Delete Join Token?</DialogTitle>
       </DialogHeader>
       <DialogContent>
-        {attempt.status === 'error' && <Alert children={attempt.statusText} />}
+        {attempt.status === 'error' && <Alert>{attempt.statusText}</Alert>}
         <Text mb={4}>
           You are about to delete join token
           <Text bold as="span">

--- a/web/packages/teleport/src/JoinTokens/UpsertJoinTokenDialog.tsx
+++ b/web/packages/teleport/src/JoinTokens/UpsertJoinTokenDialog.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import styled from 'styled-components';
 
 import {
@@ -27,16 +27,19 @@ import {
   ButtonSecondary,
   ButtonText,
   Flex,
+  Indicator,
   Text,
 } from 'design';
+import { Info } from 'design/Alert/Alert';
 import { Cross } from 'design/Icon';
 import FieldInput from 'shared/components/FieldInput';
 import { FieldSelect } from 'shared/components/FieldSelect';
 import { Option } from 'shared/components/Select';
-import { HoverTooltip } from 'shared/components/ToolTip';
-import Validation from 'shared/components/Validation';
+import { HoverTooltip } from 'shared/components/ToolTip/HoverTooltip';
+import Validation, { Validator } from 'shared/components/Validation';
 import { requiredField } from 'shared/components/Validation/rules';
 import { useAsync } from 'shared/hooks/useAsync';
+import { collectKeys } from 'shared/utils/collectKeys';
 
 import { useTeleport } from 'teleport';
 import {
@@ -46,8 +49,10 @@ import {
   JoinRole,
   JoinToken,
 } from 'teleport/services/joinToken';
+import { YamlSupportedResourceKind } from 'teleport/services/yaml/types';
 
 import { JoinTokenGCPForm, JoinTokenIAMForm } from './JoinTokenForms';
+import { JoinTokenGithubForm } from './JoinTokenGithubForm';
 
 const maxWidth = '550px';
 
@@ -61,10 +66,12 @@ const joinRoleOptions: OptionJoinRole[] = [
   'Discovery',
 ].map(role => ({ value: role as JoinRole, label: role as JoinRole }));
 
-const availableJoinMethods: OptionJoinMethod[] = ['iam', 'gcp'].map(method => ({
-  value: method as JoinMethod,
-  label: method as JoinMethod,
-}));
+const availableJoinMethods: OptionJoinMethod[] = ['iam', 'gcp', 'github'].map(
+  method => ({
+    value: method as JoinMethod,
+    label: method as JoinMethod,
+  })
+);
 
 export type OptionGCP = Option<string, string>;
 type OptionJoinMethod = Option<JoinMethod, JoinMethod>;
@@ -75,6 +82,20 @@ type NewJoinTokenGCPState = {
   locations: OptionGCP[];
 };
 
+type NewJoinTokenGithubState = {
+  server_host?: string;
+  static_jwks?: string | undefined;
+  enterprise_slug?: string | undefined;
+  rules: {
+    repository?: string;
+    repository_owner?: string | undefined;
+    workflow?: string | undefined;
+    environment?: string | undefined;
+    ref?: string;
+    ref_type?: 'any' | 'branch' | 'tag';
+  }[];
+};
+
 export type NewJoinTokenState = {
   name: string;
   // bot_name is only required when Bot is selected in the roles
@@ -83,6 +104,7 @@ export type NewJoinTokenState = {
   roles: OptionJoinRole[];
   iam: AWSRules[];
   gcp: NewJoinTokenGCPState[];
+  github: NewJoinTokenGithubState;
 };
 
 export const defaultNewTokenState: NewJoinTokenState = {
@@ -92,6 +114,13 @@ export const defaultNewTokenState: NewJoinTokenState = {
   roles: [],
   iam: [{ aws_account: '', aws_arn: '' }],
   gcp: [{ project_ids: [], service_accounts: [], locations: [] }],
+  github: {
+    rules: [
+      {
+        ref_type: 'any',
+      },
+    ],
+  },
 };
 
 function makeDefaultEditState(token: JoinToken): NewJoinTokenState {
@@ -109,7 +138,33 @@ function makeDefaultEditState(token: JoinToken): NewJoinTokenState {
       service_accounts: r.service_accounts?.map(i => ({ value: i, label: i })),
       locations: r.locations?.map(i => ({ value: i, label: i })),
     })),
+    github: token.github
+      ? {
+          server_host: token.github.enterprise_server_host,
+          enterprise_slug: token.github.enterprise_slug,
+          static_jwks: token.github.static_jwks,
+          rules: token.github.allow.map(r => ({
+            repository: r.repository,
+            actor: r.actor,
+            environment: r.environment,
+            ref: r.ref,
+            ref_type: parseGithubRefType(r.ref_type),
+            repository_owner: r.repository_owner,
+            workflow: r.workflow,
+          })),
+        }
+      : undefined,
   };
+}
+
+function parseGithubRefType(refType: string) {
+  if (refType == 'branch') {
+    return 'branch';
+  } else if (refType == 'tag') {
+    return 'tag';
+  } else {
+    return 'any';
+  }
 }
 
 export const UpsertJoinTokenDialog = ({
@@ -129,19 +184,76 @@ export const UpsertJoinTokenDialog = ({
   );
 
   const [createTokenAttempt, runCreateTokenAttempt] = useAsync(
-    async (req: CreateJoinTokenRequest) => {
-      const token = await ctx.joinTokenService.createJoinToken(req);
+    async (req: CreateJoinTokenRequest, isEdit: boolean) => {
+      const token = isEdit
+        ? await ctx.joinTokenService.editJoinToken(req)
+        : await ctx.joinTokenService.createJoinToken(req);
       updateTokenList(token);
       onClose();
     }
   );
 
-  function reset(validator) {
+  const [parseYAMLAttempt, parseYAML] = useAsync(
+    async (yaml: string): Promise<unknown | null> => {
+      return {
+        yaml,
+        object: await ctx.yamlService.parse<unknown>(
+          YamlSupportedResourceKind.ProvisionToken,
+          {
+            yaml,
+          }
+        ),
+      };
+    }
+  );
+
+  // Convert the resource YAML to an object for compatibility checking
+  useEffect(() => {
+    if (editToken) {
+      parseYAML(editToken.content);
+    }
+    // parseYAML is not stable
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editToken]);
+
+  const hasUnsupportedFields = useMemo(() => {
+    if (!editToken) {
+      return false;
+    }
+
+    const { data } = parseYAMLAttempt;
+
+    if (!checkYAMLData(data)) {
+      return true;
+    }
+
+    switch (data.object.spec.join_method) {
+      case 'iam':
+        return !checkYamlData(
+          data.object.spec.allow,
+          data.object.spec.join_method
+        );
+      case 'gcp':
+        return !checkYamlData(
+          data.object.spec.gcp,
+          data.object.spec.join_method
+        );
+      case 'github':
+        return !checkYamlData(
+          data.object.spec.github,
+          data.object.spec.join_method
+        );
+    }
+
+    return false;
+  }, [editToken, parseYAMLAttempt]);
+
+  function reset(validator: Validator) {
     validator.reset();
     setNewTokenState(defaultNewTokenState);
   }
 
-  async function save(validator) {
+  async function save(validator: Validator) {
     if (!validator.validate()) {
       return;
     }
@@ -173,7 +285,28 @@ export const UpsertJoinTokenDialog = ({
       request.gcp = gcp;
     }
 
-    runCreateTokenAttempt(request);
+    if (newTokenState.method.value === 'github') {
+      const github: (typeof request)['github'] = {
+        allow: newTokenState.github.rules.map(rule => ({
+          environment: rule.environment,
+          ref: rule.ref,
+          ref_type: rule.ref ? rule.ref_type : undefined,
+          repository: rule.repository,
+          repository_owner: rule.repository_owner,
+          workflow: rule.workflow,
+
+          actor: null, // Unsupported field
+          sub: null, // Unsupported field
+        })),
+        enterprise_server_host: newTokenState.github.server_host,
+        enterprise_slug: newTokenState.github.enterprise_slug,
+        static_jwks: newTokenState.github.static_jwks,
+      };
+
+      request.github = github;
+    }
+
+    runCreateTokenAttempt(request, !!editToken);
   }
 
   function setTokenRoles(roles: OptionJoinRole[]) {
@@ -200,158 +333,247 @@ export const UpsertJoinTokenDialog = ({
   }
 
   return (
-    <Flex width="500px">
-      <Box
-        pr={4}
-        pl={4}
-        css={`
-          overflow: auto;
-          width: 100%;
-          min-height: 50vh;
-          padding-bottom: 0;
-        `}
-      >
-        <Flex
-          alignItems="center"
-          mb={3}
-          justifyContent="space-between"
-          maxWidth={maxWidth}
-        >
-          <Flex alignItems="center" mr={3}>
-            <HoverTooltip tipContent="Back to Join Tokens">
-              <ButtonIcon onClick={onClose} mr={2} ml={'-8px'}>
-                <Cross size="medium" />
-              </ButtonIcon>
-            </HoverTooltip>
-            <Text typography="h3" fontWeight={400}>
-              {editToken ? `Edit Token` : 'Create a New Join Token'}
-            </Text>
-          </Flex>
-          {editToken && (
-            <ButtonText
-              p={2}
-              onClick={() => {
-                onClose();
-                editTokenWithYAML(editToken.id);
-              }}
-            >
-              <Text color="buttons.link.default">Use YAML editor</Text>
-            </ButtonText>
-          )}
+    <>
+      {parseYAMLAttempt.status === 'processing' && (
+        <Flex justifyContent="center">
+          <Indicator />
         </Flex>
-        <Validation>
-          {({ validator }) => (
-            <Box maxWidth={maxWidth}>
-              {createTokenAttempt.status === 'error' && (
-                <Alert kind="danger">{createTokenAttempt.statusText}</Alert>
-              )}
-              {!editToken && ( // We only want to change the method when creating a new token
-                <FieldSelect
-                  label="Method"
-                  rule={requiredField('Select a join method')}
-                  isSearchable
-                  isSimpleValue
-                  isClearable={false}
-                  value={newTokenState.method}
-                  onChange={setTokenMethod}
-                  options={availableJoinMethods}
-                />
-              )}
-              {newTokenState.method.value !== 'token' && ( // if the method is token, we generate the name for them on the backend
-                <FieldInput
-                  label="Token name"
-                  data-testid="name_field"
-                  toolTipContent={
-                    editToken ? 'Editing token names is not supported.' : ''
-                  }
-                  rule={requiredField('Token name is required')}
-                  placeholder={
-                    newTokenState.method.value === 'iam'
-                      ? 'iam-token-name'
-                      : 'gcp-token-name'
-                  }
-                  autoFocus
-                  value={newTokenState.name}
-                  onChange={e => setTokenField('name', e.target.value)}
-                  readonly={!!editToken}
-                />
-              )}
-              <FieldSelect
-                label="Join Roles"
-                data-testid="role_select"
-                rule={requiredField('At least one role is required')}
-                placeholder="Click to select roles"
-                isSearchable
-                isMulti
-                isSimpleValue
-                mb={5}
-                isClearable={false}
-                value={newTokenState.roles}
-                onChange={setTokenRoles}
-                options={joinRoleOptions}
-              />
-              {newTokenState.roles.some(i => i.value === 'Bot') && ( // if Bot is included, we must get a bot name as well
-                <FieldInput
-                  label="Bot name"
-                  toolTipContent="Bot names are required when the Bot role is selected"
-                  rule={requiredField('Bot name is required')}
-                  placeholder="Enter bot name"
-                  value={newTokenState.bot_name}
-                  onChange={e => setTokenField('bot_name', e.target.value)}
-                />
-              )}
-              {newTokenState.method.value === 'iam' && (
-                <JoinTokenIAMForm
-                  tokenState={newTokenState}
-                  onUpdateState={newState => setNewTokenState(newState)}
-                />
-              )}
-              {newTokenState.method.value === 'gcp' && (
-                <JoinTokenGCPForm
-                  tokenState={newTokenState}
-                  onUpdateState={newState => setNewTokenState(newState)}
-                />
-              )}
-              <Flex
-                mt={4}
-                py={4}
-                gap={2}
-                css={`
-                  position: sticky;
-                  bottom: 0;
-                  background: ${({ theme }) => theme.colors.levels.sunken};
-                  border-top: 1px solid
-                    ${props => props.theme.colors.spotBackground[1]};
-                `}
-              >
-                <ButtonPrimary
-                  width="100%"
-                  size="large"
-                  textTransform="none"
-                  onClick={() => save(validator)}
-                  disabled={createTokenAttempt.status === 'processing'}
-                >
-                  {editToken ? 'Edit' : 'Create'} Join Token
-                </ButtonPrimary>
-                <ButtonSecondary
-                  width="100%"
-                  textTransform="none"
-                  size="large"
-                  onClick={() => {
-                    reset(validator);
-                    onClose();
-                  }}
-                  disabled={false}
-                >
-                  Cancel
-                </ButtonSecondary>
+      )}
+
+      {parseYAMLAttempt.status === 'error' && (
+        <Alert kind="danger">{parseYAMLAttempt.statusText}</Alert>
+      )}
+
+      {parseYAMLAttempt.status !== 'error' ? (
+        <Flex width="500px">
+          <Box
+            css={`
+              overflow: auto;
+              width: 100%;
+              min-height: 50vh;
+              padding-bottom: 0;
+            `}
+          >
+            <Flex
+              alignItems="center"
+              mb={3}
+              justifyContent="space-between"
+              maxWidth={maxWidth}
+            >
+              <Flex alignItems="center" mr={3}>
+                <HoverTooltip tipContent="Back to Join Tokens">
+                  <ButtonIcon onClick={onClose} mr={2}>
+                    <Cross size="medium" />
+                  </ButtonIcon>
+                </HoverTooltip>
+                <Text typography="h3" fontWeight={400}>
+                  {editToken ? `Edit Token` : 'Create a New Join Token'}
+                </Text>
               </Flex>
-            </Box>
-          )}
-        </Validation>
-      </Box>
-    </Flex>
+
+              {editToken && !hasUnsupportedFields && (
+                <ButtonText
+                  p={2}
+                  onClick={() => {
+                    onClose();
+                    editTokenWithYAML(editToken.id);
+                  }}
+                >
+                  <Text color="buttons.link.default">Use YAML editor</Text>
+                </ButtonText>
+              )}
+            </Flex>
+
+            {hasUnsupportedFields ? (
+              <Info alignItems="flex-start">
+                <Box>
+                  <Text>
+                    This token has configuration that is not visible. To edit
+                    this token please use the YAML editor.
+                  </Text>
+                  <ButtonSecondary
+                    size="large"
+                    my={2}
+                    onClick={() => {
+                      onClose();
+                      editTokenWithYAML(editToken.id);
+                    }}
+                  >
+                    Use YAML editor
+                  </ButtonSecondary>
+                </Box>
+              </Info>
+            ) : undefined}
+
+            <Validation>
+              {({ validator }) => (
+                <Box maxWidth={maxWidth}>
+                  {createTokenAttempt.status === 'error' && (
+                    <Alert kind="danger">{createTokenAttempt.statusText}</Alert>
+                  )}
+                  {!editToken && ( // We only want to change the method when creating a new token
+                    <FieldSelect
+                      label="Method"
+                      rule={requiredField<Option>('Select a join method')}
+                      isSearchable
+                      isClearable={false}
+                      value={newTokenState.method}
+                      onChange={setTokenMethod}
+                      options={availableJoinMethods}
+                    />
+                  )}
+                  {newTokenState.method.value !== 'token' && ( // if the method is token, we generate the name for them on the backend
+                    <FieldInput
+                      label="Token name"
+                      data-testid="name_field"
+                      toolTipContent={
+                        editToken ? 'Editing token names is not supported.' : ''
+                      }
+                      rule={requiredField('Token name is required')}
+                      placeholder={`${newTokenState.method.value}-token-name`}
+                      autoFocus
+                      value={newTokenState.name}
+                      onChange={e => setTokenField('name', e.target.value)}
+                      readonly={!!editToken}
+                    />
+                  )}
+                  <FieldSelect
+                    label="Join Roles"
+                    inputId="role_select"
+                    rule={requiredField('At least one role is required')}
+                    placeholder="Click to select roles"
+                    isSearchable
+                    isMulti
+                    mb={5}
+                    isClearable={false}
+                    value={newTokenState.roles}
+                    onChange={setTokenRoles}
+                    options={joinRoleOptions}
+                    isDisabled={hasUnsupportedFields}
+                  />
+                  {newTokenState.roles.some(i => i.value === 'Bot') && ( // if Bot is included, we must get a bot name as well
+                    <FieldInput
+                      label="Bot name"
+                      toolTipContent="Bot names are required when the Bot role is selected"
+                      rule={requiredField('Bot name is required')}
+                      placeholder="Enter bot name"
+                      value={newTokenState.bot_name}
+                      onChange={e => setTokenField('bot_name', e.target.value)}
+                      readonly={hasUnsupportedFields}
+                    />
+                  )}
+                  {newTokenState.method.value === 'iam' && (
+                    <JoinTokenIAMForm
+                      tokenState={newTokenState}
+                      onUpdateState={newState => setNewTokenState(newState)}
+                      readonly={hasUnsupportedFields}
+                    />
+                  )}
+                  {newTokenState.method.value === 'gcp' && (
+                    <JoinTokenGCPForm
+                      tokenState={newTokenState}
+                      onUpdateState={newState => setNewTokenState(newState)}
+                      readonly={hasUnsupportedFields}
+                    />
+                  )}
+                  {newTokenState.method.value === 'github' && (
+                    <JoinTokenGithubForm
+                      tokenState={newTokenState}
+                      onUpdateState={setNewTokenState}
+                      readonly={hasUnsupportedFields}
+                    />
+                  )}
+                  <Flex
+                    mt={4}
+                    py={4}
+                    gap={2}
+                    css={`
+                      position: sticky;
+                      bottom: 0;
+                      background: ${({ theme }) => theme.colors.levels.sunken};
+                      border-top: 1px solid
+                        ${({ theme }) => theme.colors.spotBackground[1]};
+                    `}
+                  >
+                    <ButtonPrimary
+                      width="100%"
+                      size="large"
+                      textTransform="none"
+                      onClick={() => save(validator)}
+                      disabled={
+                        createTokenAttempt.status === 'processing' ||
+                        hasUnsupportedFields
+                      }
+                    >
+                      {editToken ? 'Edit' : 'Create'} Join Token
+                    </ButtonPrimary>
+                    <ButtonSecondary
+                      width="100%"
+                      textTransform="none"
+                      size="large"
+                      onClick={() => {
+                        reset(validator);
+                        onClose();
+                      }}
+                      disabled={false}
+                    >
+                      Cancel
+                    </ButtonSecondary>
+                  </Flex>
+                </Box>
+              )}
+            </Validation>
+          </Box>
+        </Flex>
+      ) : undefined}
+    </>
   );
+};
+
+const checkYAMLData = (
+  data: unknown
+): data is {
+  object: {
+    spec: {
+      join_method: string;
+      allow: unknown;
+      gcp: unknown;
+      github: unknown;
+    };
+  };
+} => {
+  if (
+    !data ||
+    typeof data !== 'object' ||
+    data === null ||
+    !('object' in data)
+  ) {
+    return false;
+  }
+
+  const { object } = data;
+
+  if (
+    !object ||
+    typeof object !== 'object' ||
+    object === null ||
+    !('spec' in object)
+  ) {
+    return false;
+  }
+
+  const { spec } = object;
+
+  if (
+    !spec ||
+    typeof spec !== 'object' ||
+    spec === null ||
+    !('join_method' in spec)
+  ) {
+    return false;
+  }
+
+  return typeof spec.join_method === 'string';
 };
 
 export const RuleBox = styled(Box)`
@@ -364,3 +586,32 @@ export const RuleBox = styled(Box)`
 
   padding: ${props => props.theme.space[3]}px;
 `;
+
+const checkYamlData = (data: unknown, joinMethod: JoinMethod) => {
+  const supportedFields = supportedFieldsMap[joinMethod];
+  if (!supportedFields) {
+    return true;
+  }
+  const keys = collectKeys(data);
+  return !keys || new Set(keys).isSubsetOf(supportedFields);
+};
+
+const supportedFieldsMap: Partial<Record<JoinMethod, Set<string>>> = {
+  iam: new Set(['.aws_account', '.aws_arn']),
+  gcp: new Set([
+    '.allow.project_ids',
+    '.allow.locations',
+    '.allow.service_accounts',
+  ]),
+  github: new Set([
+    '.enterprise_server_host',
+    '.static_jwks',
+    '.enterprise_slug',
+    '.allow.repository',
+    '.allow.repository_owner',
+    '.allow.workflow',
+    '.allow.environment',
+    '.allow.ref',
+    '.allow.ref_type',
+  ]),
+};

--- a/web/packages/teleport/src/services/joinToken/joinToken.ts
+++ b/web/packages/teleport/src/services/joinToken/joinToken.ts
@@ -21,7 +21,12 @@ import api from 'teleport/services/api';
 
 import { makeLabelMapOfStrArrs } from '../agents/make';
 import makeJoinToken from './makeJoinToken';
-import { JoinRule, JoinToken, JoinTokenRequest } from './types';
+import {
+  CreateJoinTokenRequest,
+  JoinRule,
+  JoinToken,
+  JoinTokenRequest,
+} from './types';
 
 const TeleportTokenNameHeader = 'X-Teleport-TokenName';
 
@@ -65,8 +70,13 @@ class JoinTokenService {
       .then(makeJoinToken);
   }
 
-  createJoinToken(req: JoinTokenRequest): Promise<JoinToken> {
+  async createJoinToken(req: CreateJoinTokenRequest) {
     return api.post(cfg.getJoinTokensUrl(), req).then(makeJoinToken);
+  }
+
+  async editJoinToken(req: CreateJoinTokenRequest) {
+    const json = await api.put(cfg.getJoinTokensUrl(), req);
+    return makeJoinToken(json);
   }
 
   fetchJoinTokens(signal: AbortSignal = null): Promise<{ items: JoinToken[] }> {

--- a/web/packages/teleport/src/services/joinToken/makeJoinToken.ts
+++ b/web/packages/teleport/src/services/joinToken/makeJoinToken.ts
@@ -22,7 +22,7 @@ import type { JoinToken } from './types';
 
 export const INTERNAL_RESOURCE_ID_LABEL_KEY = 'teleport.internal/resource-id';
 
-export default function makeToken(json): JoinToken {
+export default function makeToken(json: any): JoinToken {
   json = json || {};
   const {
     id,
@@ -30,6 +30,7 @@ export default function makeToken(json): JoinToken {
     isStatic,
     allow,
     gcp,
+    github,
     bot_name,
     expiry,
     method,
@@ -48,6 +49,7 @@ export default function makeToken(json): JoinToken {
     method,
     allow,
     gcp,
+    github,
     roles: roles?.sort((a, b) => a.localeCompare(b)) || [],
     suggestedLabels: labels,
     internalResourceId: extractInternalResourceId(labels),

--- a/web/packages/teleport/src/services/joinToken/types.ts
+++ b/web/packages/teleport/src/services/joinToken/types.ts
@@ -47,6 +47,7 @@ export type JoinToken = {
   gcp?: {
     allow: GCPRules[];
   };
+  github?: GithubConfig;
 };
 
 // JoinRole defines built-in system roles and are roles associated with
@@ -104,6 +105,36 @@ export type GCPRules = {
   service_accounts: string[];
 };
 
+type GithubConfig = {
+  /** enterprise_server_host allows joining from GitHub Actions workflows in a GitHub Enterprise Server instance. For normal situations, where you are using github.com, this option should be omitted. If you are using GHES, this value should be configured to the hostname of your GHES instance. */
+  enterprise_server_host: string | null;
+  /** static_jwks allows the JSON Web Key Set (JWKS) used to verify the token issued by GitHub Actions to be overridden. This can be used in scenarios where the Teleport Auth Service is unable to reach a GHES server. */
+  static_jwks: string | null;
+  /** enterprise_slug allows the slug of a GitHub Enterprise organisation to be included in the expected issuer of the OIDC tokens. This is for compatibility with the include_enterprise_slug option in GHE. */
+  enterprise_slug: string | null;
+  /** allow is an array of rule configurations for which GitHub Actions workflows should be allowed to join */
+  allow: GithubRules[];
+};
+
+export type GithubRules = {
+  /** repository is a fully qualified (e.g. including the owner) name of a GitHub repository. */
+  repository: string | null;
+  /** repository_owner is the name of an organization or user that a repository belongs to. */
+  repository_owner: string | null;
+  /** workflow is the exact name of a workflow as configured in the GitHub Action workflow YAML file. */
+  workflow: string | null;
+  /** environment is the environment associated with the GitHub Actions run. If no environment is configured for the GitHub Actions run, this will be empty. */
+  environment: string | null;
+  /** actor is the GitHub username that caused the GitHub Actions run, whether by committing or by directly despatching the workflow. */
+  actor: string | null;
+  /** ref is the git ref that triggered the action run. */
+  ref: string | null;
+  /** ref_type is the type of the git ref that triggered the action run. */
+  ref_type: string | null;
+  /** sub is a concatenated string of various attributes of the workflow run. GitHub explains the format of this string at: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#example-subject-claims */
+  sub: string | null;
+};
+
 export type JoinTokenRulesObject = AWSRules | GCPRules;
 
 export type CreateJoinTokenRequest = {
@@ -121,6 +152,7 @@ export type CreateJoinTokenRequest = {
   gcp?: {
     allow: GCPRules[];
   };
+  github?: GithubConfig;
 };
 
 export type JoinTokenRequest = {

--- a/web/packages/teleport/src/services/yaml/types.ts
+++ b/web/packages/teleport/src/services/yaml/types.ts
@@ -26,4 +26,5 @@ export type YamlStringifyRequest<T> = {
 
 export enum YamlSupportedResourceKind {
   AccessMonitoringRule = 'access_monitoring_rule',
+  ProvisionToken = 'token',
 }

--- a/web/packages/teleport/src/teleportContext.tsx
+++ b/web/packages/teleport/src/teleportContext.tsx
@@ -38,6 +38,7 @@ import sessionService from './services/session';
 import { storageService } from './services/storageService';
 import userService from './services/user';
 import userGroupService from './services/userGroups';
+import { yamlService } from './services/yaml/yaml';
 import { StoreNav, StoreNotifications, StoreUserContext } from './stores';
 import * as types from './types';
 
@@ -63,6 +64,7 @@ class TeleportContext implements types.Context {
   userGroupService = userGroupService;
   mfaService = new MfaService();
   notificationService = new NotificationService();
+  yamlService = yamlService;
 
   notificationContentFactory = notificationContentFactory;
 


### PR DESCRIPTION
⚠️ **Non-trivial backport** 🕵️ 

Backport https://github.com/gravitational/teleport/pull/54308 to branch/v16

changelog: Create and edit GitHub join tokens from the Join Tokens page

## Changes

- Removed collapsable feature of GHES section - required shared component is not backported and is not easy to copy across.
- Copied `fullWidth` prop to `<Flex />`
- Copied `tick` testing util
- Fixed element selection failure in test "create form fails if roles arent selected" - not quite sure why it stopped working

## Demo

https://github.com/user-attachments/assets/6f85a19c-67d6-457c-ae18-db17950e604c

