### PR TITLE
Convert web session and SAML service provider cache collections

### DIFF
--- a/api/types/session.go
+++ b/api/types/session.go
@@ -22,6 +22,8 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/utils"
 )
 
 // WebSessionsGetter provides access to web sessions
@@ -115,6 +117,8 @@ type WebSession interface {
 	// requirement.
 	// See [TrustedDeviceRequirement].
 	GetTrustedDeviceRequirement() TrustedDeviceRequirement
+	// Copy returns a clone of the session resource.
+	Copy() WebSession
 }
 
 // NewWebSession returns new instance of the web session based on the V2 spec
@@ -136,6 +140,11 @@ func NewWebSession(name string, subkind string, spec WebSessionSpecV2) (WebSessi
 // GetKind gets resource Kind
 func (ws *WebSessionV2) GetKind() string {
 	return ws.Kind
+}
+
+// Copy returns a clone of the session resource.
+func (ws *WebSessionV2) Copy() WebSession {
+	return utils.CloneProtoMsg(ws)
 }
 
 // GetSubKind gets resource SubKind

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -1288,40 +1288,6 @@ func mustCreateDatabase(t *testing.T, name, protocol, uri string) *types.Databas
 	return database
 }
 
-// TestSAMLIdPServiceProviders tests that CRUD operations on SAML IdP service provider resources are
-// replicated from the backend to the cache.
-func TestSAMLIdPServiceProviders(t *testing.T) {
-	t.Parallel()
-
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	testResources(t, p, testFuncs[types.SAMLIdPServiceProvider]{
-		newResource: func(name string) (types.SAMLIdPServiceProvider, error) {
-			return types.NewSAMLIdPServiceProvider(
-				types.Metadata{
-					Name: name,
-				},
-				types.SAMLIdPServiceProviderSpecV1{
-					EntityDescriptor: testEntityDescriptor,
-					EntityID:         "IAMShowcase",
-				})
-		},
-		create: p.samlIDPServiceProviders.CreateSAMLIdPServiceProvider,
-		list: func(ctx context.Context) ([]types.SAMLIdPServiceProvider, error) {
-			results, _, err := p.samlIDPServiceProviders.ListSAMLIdPServiceProviders(ctx, 0, "")
-			return results, err
-		},
-		cacheGet: p.cache.GetSAMLIdPServiceProvider,
-		cacheList: func(ctx context.Context) ([]types.SAMLIdPServiceProvider, error) {
-			results, _, err := p.cache.ListSAMLIdPServiceProviders(ctx, 0, "")
-			return results, err
-		},
-		update:    p.samlIDPServiceProviders.UpdateSAMLIdPServiceProvider,
-		deleteAll: p.samlIDPServiceProviders.DeleteAllSAMLIdPServiceProviders,
-	})
-}
-
 // TestLocks tests that CRUD operations on lock resources are
 // replicated from the backend to the cache.
 func TestLocks(t *testing.T) {

--- a/lib/cache/cert_authority_test.go
+++ b/lib/cache/cert_authority_test.go
@@ -94,8 +94,6 @@ func TestNodeCAFiltering(t *testing.T) {
 		DynamicAccess:           p.cache.dynamicAccessCache,
 		Presence:                p.cache.presenceCache,
 		Restrictions:            p.cache.restrictionsCache,
-		AppSession:              p.cache.appSessionCache,
-		WebSession:              p.cache.webSessionCache,
 		WebToken:                p.cache.webTokenCache,
 		DynamicWindowsDesktops:  p.cache.dynamicWindowsDesktopsCache,
 		SAMLIdPServiceProviders: p.samlIDPServiceProviders,

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -90,6 +90,11 @@ type collections struct {
 	autoUpdateRollout                *collection[*autoupdatev1.AutoUpdateAgentRollout, autoUpdateAgentRolloutIndex]
 	oktaImportRules                  *collection[types.OktaImportRule, oktaImportRuleIndex]
 	oktaAssignments                  *collection[types.OktaAssignment, oktaAssignmentIndex]
+	samlIdPServiceProviders          *collection[types.SAMLIdPServiceProvider, samlIdPServiceProviderIndex]
+	samlIdPSessions                  *collection[types.WebSession, samlIdPSessionIndex]
+	webSessions                      *collection[types.WebSession, webSessionIndex]
+	appSessions                      *collection[types.WebSession, appSessionIndex]
+	snowflakeSessions                *collection[types.WebSession, snowflakeSessionIndex]
 }
 
 // setupCollections ensures that the appropriate [collection] is
@@ -392,6 +397,49 @@ func setupCollections(c Config) (*collections, error) {
 
 			out.oktaAssignments = collect
 			out.byKind[resourceKind] = out.oktaAssignments
+		case types.KindSAMLIdPServiceProvider:
+			collect, err := newSAMLIdPServiceProviderCollection(c.SAMLIdPServiceProviders, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out.samlIdPServiceProviders = collect
+			out.byKind[resourceKind] = out.samlIdPServiceProviders
+		case types.KindWebSession:
+			switch watch.SubKind {
+			case types.KindAppSession:
+				collect, err := newAppSessionCollection(c.AppSession, watch)
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+
+				out.appSessions = collect
+				out.byKind[resourceKind] = out.appSessions
+			case types.KindSnowflakeSession:
+				collect, err := newSnowflakeSessionCollection(c.SnowflakeSession, watch)
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+
+				out.snowflakeSessions = collect
+				out.byKind[resourceKind] = out.snowflakeSessions
+			case types.KindSAMLIdPSession:
+				collect, err := newSAMLIdPSessionCollection(c.SAMLIdPSession, watch)
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+
+				out.samlIdPSessions = collect
+				out.byKind[resourceKind] = out.samlIdPSessions
+			case types.KindWebSession:
+				collect, err := newWebSessionCollection(c.WebSession, watch)
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+
+				out.webSessions = collect
+				out.byKind[resourceKind] = out.webSessions
+			}
 		}
 	}
 

--- a/lib/cache/generic_operations.go
+++ b/lib/cache/generic_operations.go
@@ -57,7 +57,10 @@ func (g genericGetter[T, I]) get(ctx context.Context, identifier string) (T, err
 	}
 
 	out, err := rg.store.get(g.index, identifier)
-	return g.clone(out), trace.Wrap(err)
+	if err != nil {
+		return t, trace.Wrap(err)
+	}
+	return g.clone(out), nil
 }
 
 // genericLister is a helper to retrieve a page of items from a cache collection.

--- a/lib/cache/saml_idp.go
+++ b/lib/cache/saml_idp.go
@@ -1,0 +1,194 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+type samlIdPServiceProviderIndex string
+
+const samlIdPServiceProviderNameIndex samlIdPServiceProviderIndex = "name"
+
+func newSAMLIdPServiceProviderCollection(upstream services.SAMLIdPServiceProviders, w types.WatchKind) (*collection[types.SAMLIdPServiceProvider, samlIdPServiceProviderIndex], error) {
+	if upstream == nil {
+		return nil, trace.BadParameter("missing parameter SAMLIdPSession")
+	}
+
+	return &collection[types.SAMLIdPServiceProvider, samlIdPServiceProviderIndex]{
+		store: newStore(map[samlIdPServiceProviderIndex]func(types.SAMLIdPServiceProvider) string{
+			samlIdPServiceProviderNameIndex: func(r types.SAMLIdPServiceProvider) string {
+				return r.GetMetadata().Name
+			},
+		}),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.SAMLIdPServiceProvider, error) {
+			var startKey string
+			var sps []types.SAMLIdPServiceProvider
+			for {
+				var samlProviders []types.SAMLIdPServiceProvider
+				var err error
+				samlProviders, startKey, err = upstream.ListSAMLIdPServiceProviders(ctx, 0, startKey)
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+
+				sps = append(sps, samlProviders...)
+
+				if startKey == "" {
+					break
+				}
+			}
+
+			return sps, nil
+		},
+		headerTransform: func(hdr *types.ResourceHeader) types.SAMLIdPServiceProvider {
+			return &types.SAMLIdPServiceProviderV1{
+				ResourceHeader: types.ResourceHeader{
+					Kind:    hdr.Kind,
+					Version: hdr.Version,
+					Metadata: types.Metadata{
+						Name: hdr.Metadata.Name,
+					},
+				},
+			}
+		},
+		watch: w,
+	}, nil
+}
+
+// ListSAMLIdPServiceProviders returns a paginated list of SAML IdP service provider resources.
+func (c *Cache) ListSAMLIdPServiceProviders(ctx context.Context, pageSize int, pageToken string) ([]types.SAMLIdPServiceProvider, string, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/ListSAMLIdPServiceProviders")
+	defer span.End()
+
+	lister := genericLister[types.SAMLIdPServiceProvider, samlIdPServiceProviderIndex]{
+		cache:           c,
+		collection:      c.collections.samlIdPServiceProviders,
+		index:           samlIdPServiceProviderNameIndex,
+		defaultPageSize: 200,
+		upstreamList:    c.Config.SAMLIdPServiceProviders.ListSAMLIdPServiceProviders,
+		nextToken: func(t types.SAMLIdPServiceProvider) string {
+			return t.GetMetadata().Name
+		},
+		clone: types.SAMLIdPServiceProvider.Copy,
+	}
+	out, next, err := lister.list(ctx, pageSize, pageToken)
+	return out, next, trace.Wrap(err)
+}
+
+// GetSAMLIdPServiceProvider returns the specified SAML IdP service provider resources.
+func (c *Cache) GetSAMLIdPServiceProvider(ctx context.Context, name string) (types.SAMLIdPServiceProvider, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetSAMLIdPServiceProvider")
+	defer span.End()
+
+	getter := genericGetter[types.SAMLIdPServiceProvider, samlIdPServiceProviderIndex]{
+		cache:       c,
+		collection:  c.collections.samlIdPServiceProviders,
+		index:       samlIdPServiceProviderNameIndex,
+		upstreamGet: c.Config.SAMLIdPServiceProviders.GetSAMLIdPServiceProvider,
+		clone:       types.SAMLIdPServiceProvider.Copy,
+	}
+	out, err := getter.get(ctx, name)
+	return out, trace.Wrap(err)
+}
+
+type samlIdPSessionIndex string
+
+const samlIdPSessionNameIndex samlIdPSessionIndex = "name"
+
+func newSAMLIdPSessionCollection(upstream services.SAMLIdPSession, w types.WatchKind) (*collection[types.WebSession, samlIdPSessionIndex], error) {
+	if upstream == nil {
+		return nil, trace.BadParameter("missing parameter SAMLIdPSession")
+	}
+
+	return &collection[types.WebSession, samlIdPSessionIndex]{
+		store: newStore(map[samlIdPSessionIndex]func(types.WebSession) string{
+			samlIdPSessionNameIndex: func(r types.WebSession) string {
+				return r.GetMetadata().Name
+			},
+		}),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.WebSession, error) {
+			var startKey string
+			var sessions []types.WebSession
+			for {
+				webSessions, nextKey, err := upstream.ListSAMLIdPSessions(ctx, 0, startKey, "")
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+
+				if !loadSecrets {
+					for i := 0; i < len(webSessions); i++ {
+						webSessions[i] = webSessions[i].WithoutSecrets()
+					}
+				}
+
+				sessions = append(sessions, webSessions...)
+
+				if nextKey == "" {
+					break
+				}
+				startKey = nextKey
+			}
+			return sessions, nil
+		},
+		headerTransform: func(hdr *types.ResourceHeader) types.WebSession {
+			return &types.WebSessionV2{
+				Kind:    hdr.Kind,
+				SubKind: hdr.SubKind,
+				Version: hdr.Version,
+				Metadata: types.Metadata{
+					Name: hdr.Metadata.Name,
+				},
+			}
+		},
+		watch: w,
+	}, nil
+}
+
+// GetSAMLIdPSession gets a SAML IdP session.
+func (c *Cache) GetSAMLIdPSession(ctx context.Context, req types.GetSAMLIdPSessionRequest) (types.WebSession, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetSAMLIdPSession")
+	defer span.End()
+
+	var upstreamRead bool
+	getter := genericGetter[types.WebSession, samlIdPSessionIndex]{
+		cache:      c,
+		collection: c.collections.samlIdPSessions,
+		index:      samlIdPSessionNameIndex,
+		upstreamGet: func(ctx context.Context, s string) (types.WebSession, error) {
+			upstreamRead = true
+
+			session, err := c.Config.SAMLIdPSession.GetSAMLIdPSession(ctx, types.GetSAMLIdPSessionRequest{SessionID: s})
+			return session, trace.Wrap(err)
+		},
+		clone: types.WebSession.Copy,
+	}
+	out, err := getter.get(ctx, req.SessionID)
+	if trace.IsNotFound(err) && !upstreamRead {
+		// fallback is sane because method is never used
+		// in construction of derivative caches.
+		if item, err := c.Config.SAMLIdPSession.GetSAMLIdPSession(ctx, req); err == nil {
+			return item, nil
+		}
+	}
+	return out, trace.Wrap(err)
+}

--- a/lib/cache/saml_idp_test.go
+++ b/lib/cache/saml_idp_test.go
@@ -1,0 +1,104 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+// TestSAMLIdPServiceProviders tests that CRUD operations on SAML IdP service provider resources are
+// replicated from the backend to the cache.
+func TestSAMLIdPServiceProviders(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	testResources(t, p, testFuncs[types.SAMLIdPServiceProvider]{
+		newResource: func(name string) (types.SAMLIdPServiceProvider, error) {
+			return types.NewSAMLIdPServiceProvider(
+				types.Metadata{
+					Name: name,
+				},
+				types.SAMLIdPServiceProviderSpecV1{
+					EntityDescriptor: testEntityDescriptor,
+					EntityID:         "IAMShowcase",
+				})
+		},
+		create: p.samlIDPServiceProviders.CreateSAMLIdPServiceProvider,
+		list: func(ctx context.Context) ([]types.SAMLIdPServiceProvider, error) {
+			results, _, err := p.samlIDPServiceProviders.ListSAMLIdPServiceProviders(ctx, 0, "")
+			return results, err
+		},
+		cacheGet: p.cache.GetSAMLIdPServiceProvider,
+		cacheList: func(ctx context.Context) ([]types.SAMLIdPServiceProvider, error) {
+			results, _, err := p.cache.ListSAMLIdPServiceProviders(ctx, 0, "")
+			return results, err
+		},
+		update:    p.samlIDPServiceProviders.UpdateSAMLIdPServiceProvider,
+		deleteAll: p.samlIDPServiceProviders.DeleteAllSAMLIdPServiceProviders,
+	})
+}
+
+func TestSAMLIdPSessions(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	for i := 0; i < 31; i++ {
+		err := p.samlIdPSessionsS.UpsertSAMLIdPSession(t.Context(), &types.WebSessionV2{
+			Kind:    types.KindWebSession,
+			SubKind: types.KindSAMLIdPSession,
+			Version: types.V2,
+			Metadata: types.Metadata{
+				Name: "saml-session" + strconv.Itoa(i+1),
+			},
+			Spec: types.WebSessionSpecV2{
+				User: "fish",
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		for i := 0; i < 31; i++ {
+			session, err := p.cache.GetSAMLIdPSession(ctx, types.GetSAMLIdPSessionRequest{SessionID: "saml-session" + strconv.Itoa(i+1)})
+			assert.NoError(t, err)
+			assert.NotNil(t, session)
+		}
+	}, 15*time.Second, 100*time.Millisecond)
+
+	require.NoError(t, p.samlIdPSessionsS.DeleteAllSAMLIdPSessions(ctx))
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		for i := 0; i < 31; i++ {
+			session, err := p.cache.GetSAMLIdPSession(ctx, types.GetSAMLIdPSessionRequest{SessionID: "saml-session" + strconv.Itoa(i+1)})
+			assert.Error(t, err)
+			assert.Nil(t, session)
+		}
+	}, 15*time.Second, 100*time.Millisecond)
+}

--- a/lib/cache/web_session.go
+++ b/lib/cache/web_session.go
@@ -1,0 +1,320 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+	"iter"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils/sortcache"
+)
+
+type webSessionIndex string
+
+const webSessionNameIndex webSessionIndex = "name"
+
+func newWebSessionCollection(upstream types.WebSessionInterface, w types.WatchKind) (*collection[types.WebSession, webSessionIndex], error) {
+	if upstream == nil {
+		return nil, trace.BadParameter("missing parameter SAMLIdPSession")
+	}
+
+	return &collection[types.WebSession, webSessionIndex]{
+		store: newStore(map[webSessionIndex]func(types.WebSession) string{
+			webSessionNameIndex: func(r types.WebSession) string {
+				return r.GetMetadata().Name
+			},
+		}),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.WebSession, error) {
+			webSessions, err := upstream.List(ctx)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			if !loadSecrets {
+				for i := 0; i < len(webSessions); i++ {
+					webSessions[i] = webSessions[i].WithoutSecrets()
+				}
+			}
+
+			return webSessions, nil
+		},
+		headerTransform: func(hdr *types.ResourceHeader) types.WebSession {
+			return &types.WebSessionV2{
+				Kind:    hdr.Kind,
+				SubKind: hdr.SubKind,
+				Version: hdr.Version,
+				Metadata: types.Metadata{
+					Name: hdr.Metadata.Name,
+				},
+			}
+		},
+		watch: w,
+	}, nil
+}
+
+// GetWebSession gets a regular web session.
+func (c *Cache) GetWebSession(ctx context.Context, req types.GetWebSessionRequest) (types.WebSession, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetWebSession")
+	defer span.End()
+
+	var upstreamRead bool
+	getter := genericGetter[types.WebSession, webSessionIndex]{
+		cache:      c,
+		collection: c.collections.webSessions,
+		index:      webSessionNameIndex,
+		upstreamGet: func(ctx context.Context, s string) (types.WebSession, error) {
+			upstreamRead = true
+
+			session, err := c.Config.WebSession.Get(ctx, types.GetWebSessionRequest{SessionID: s})
+			return session, trace.Wrap(err)
+		},
+		clone: types.WebSession.Copy,
+	}
+	out, err := getter.get(ctx, req.SessionID)
+	if trace.IsNotFound(err) && !upstreamRead {
+		// fallback is sane because method is never used
+		// in construction of derivative caches.
+		if sess, err := c.Config.WebSession.Get(ctx, req); err == nil {
+			c.Logger.DebugContext(ctx, "Cache was forced to load session from upstream",
+				"session_kind", sess.GetSubKind(),
+				"session", sess.GetName(),
+			)
+			return sess, nil
+		}
+	}
+	return out, trace.Wrap(err)
+}
+
+type appSessionIndex string
+
+const (
+	appSessionNameIndex appSessionIndex = "name"
+	appSessionUserIndex appSessionIndex = "user"
+)
+
+func newAppSessionCollection(upstream services.AppSession, w types.WatchKind) (*collection[types.WebSession, appSessionIndex], error) {
+	if upstream == nil {
+		return nil, trace.BadParameter("missing parameter AppSession")
+	}
+
+	return &collection[types.WebSession, appSessionIndex]{
+		store: newStore(map[appSessionIndex]func(types.WebSession) string{
+			appSessionNameIndex: func(r types.WebSession) string {
+				return r.GetMetadata().Name
+			},
+			appSessionUserIndex: func(r types.WebSession) string {
+				return r.GetUser() + "/" + r.GetMetadata().Name
+			},
+		}),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.WebSession, error) {
+			var startKey string
+			var sessions []types.WebSession
+
+			for {
+				webSessions, nextKey, err := upstream.ListAppSessions(ctx, 0, startKey, "")
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+
+				if !loadSecrets {
+					for i := 0; i < len(webSessions); i++ {
+						webSessions[i] = webSessions[i].WithoutSecrets()
+					}
+				}
+
+				sessions = append(sessions, webSessions...)
+
+				if nextKey == "" {
+					break
+				}
+				startKey = nextKey
+			}
+			return sessions, nil
+		},
+		headerTransform: func(hdr *types.ResourceHeader) types.WebSession {
+			return &types.WebSessionV2{
+				Kind:    hdr.Kind,
+				SubKind: hdr.SubKind,
+				Version: hdr.Version,
+				Metadata: types.Metadata{
+					Name: hdr.Metadata.Name,
+				},
+			}
+		},
+		watch: w,
+	}, nil
+}
+
+// GetAppSession gets an application web session.
+func (c *Cache) GetAppSession(ctx context.Context, req types.GetAppSessionRequest) (types.WebSession, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetAppSession")
+	defer span.End()
+
+	var upstreamRead bool
+	getter := genericGetter[types.WebSession, appSessionIndex]{
+		cache:      c,
+		collection: c.collections.appSessions,
+		index:      appSessionNameIndex,
+		upstreamGet: func(ctx context.Context, s string) (types.WebSession, error) {
+			upstreamRead = true
+
+			session, err := c.Config.AppSession.GetAppSession(ctx, types.GetAppSessionRequest{SessionID: s})
+			return session, trace.Wrap(err)
+		},
+		clone: types.WebSession.Copy,
+	}
+	out, err := getter.get(ctx, req.SessionID)
+	if trace.IsNotFound(err) && !upstreamRead {
+		// fallback is sane because method is never used
+		// in construction of derivative caches.
+		if sess, err := c.Config.AppSession.GetAppSession(ctx, req); err == nil {
+			c.Logger.DebugContext(ctx, "Cache was forced to load session from upstream",
+				"session_kind", sess.GetSubKind(),
+				"session", sess.GetName(),
+			)
+			return sess, nil
+		}
+	}
+	return out, trace.Wrap(err)
+}
+
+// ListAppSessions returns a page of application web sessions.
+func (c *Cache) ListAppSessions(ctx context.Context, pageSize int, pageToken, user string) ([]types.WebSession, string, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/ListAppSessions")
+	defer span.End()
+
+	rg, err := acquireReadGuard(c, c.collections.appSessions)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	defer rg.Release()
+
+	if !rg.ReadCache() {
+		out, next, err := c.Config.AppSession.ListAppSessions(ctx, pageSize, pageToken, user)
+		return out, next, trace.Wrap(err)
+	}
+
+	// Adjust page size, so it can't be too large.
+	const maxSessionPageSize = 200
+	if pageSize <= 0 || pageSize > maxSessionPageSize {
+		pageSize = maxSessionPageSize
+	}
+
+	var sessions iter.Seq[types.WebSession]
+	if user == "" {
+		sessions = rg.store.resources(appSessionNameIndex, pageToken, "")
+	} else {
+		startKey := user + "/"
+		endKey := sortcache.NextKey(startKey)
+		if pageToken != "" {
+			startKey += pageToken
+		}
+
+		sessions = rg.store.resources(appSessionUserIndex, startKey, endKey)
+	}
+
+	var out []types.WebSession
+	for sess := range sessions {
+		if len(out) == pageSize {
+			return out, sess.GetName(), nil
+		}
+
+		out = append(out, sess.Copy())
+	}
+
+	return out, "", nil
+}
+
+type snowflakeSessionIndex string
+
+const snowflakeSessionNameIndex snowflakeSessionIndex = "name"
+
+func newSnowflakeSessionCollection(upstream services.SnowflakeSession, w types.WatchKind) (*collection[types.WebSession, snowflakeSessionIndex], error) {
+	if upstream == nil {
+		return nil, trace.BadParameter("missing parameter AppSession")
+	}
+
+	return &collection[types.WebSession, snowflakeSessionIndex]{
+		store: newStore(map[snowflakeSessionIndex]func(types.WebSession) string{
+			snowflakeSessionNameIndex: func(r types.WebSession) string {
+				return r.GetMetadata().Name
+			},
+		}),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.WebSession, error) {
+			webSessions, err := upstream.GetSnowflakeSessions(ctx)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			if !loadSecrets {
+				for i := 0; i < len(webSessions); i++ {
+					webSessions[i] = webSessions[i].WithoutSecrets()
+				}
+			}
+
+			return webSessions, nil
+		},
+		headerTransform: func(hdr *types.ResourceHeader) types.WebSession {
+			return &types.WebSessionV2{
+				Kind:    hdr.Kind,
+				SubKind: hdr.SubKind,
+				Version: hdr.Version,
+				Metadata: types.Metadata{
+					Name: hdr.Metadata.Name,
+				},
+			}
+		},
+		watch: w,
+	}, nil
+}
+
+// GetSnowflakeSession gets Snowflake web session.
+func (c *Cache) GetSnowflakeSession(ctx context.Context, req types.GetSnowflakeSessionRequest) (types.WebSession, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetSnowflakeSession")
+	defer span.End()
+
+	var upstreamRead bool
+	getter := genericGetter[types.WebSession, snowflakeSessionIndex]{
+		cache:      c,
+		collection: c.collections.snowflakeSessions,
+		index:      snowflakeSessionNameIndex,
+		upstreamGet: func(ctx context.Context, s string) (types.WebSession, error) {
+			upstreamRead = true
+
+			session, err := c.Config.SnowflakeSession.GetSnowflakeSession(ctx, types.GetSnowflakeSessionRequest{SessionID: s})
+			return session, trace.Wrap(err)
+		},
+		clone: types.WebSession.Copy,
+	}
+	out, err := getter.get(ctx, req.SessionID)
+	if trace.IsNotFound(err) && !upstreamRead {
+		// fallback is sane because method is never used
+		// in construction of derivative caches.
+		if sess, err := c.Config.SnowflakeSession.GetSnowflakeSession(ctx, req); err == nil {
+			c.Logger.DebugContext(ctx, "Cache was forced to load session from upstream",
+				"session_kind", sess.GetSubKind(),
+				"session", sess.GetName(),
+			)
+			return sess, nil
+		}
+	}
+	return out, trace.Wrap(err)
+}

--- a/lib/cache/web_session_test.go
+++ b/lib/cache/web_session_test.go
@@ -1,0 +1,220 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+func TestAppSessions(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	for i := 0; i < 31; i++ {
+		err := p.appSessionS.UpsertAppSession(t.Context(), &types.WebSessionV2{
+			Kind:    types.KindWebSession,
+			SubKind: types.KindAppSession,
+			Version: types.V2,
+			Metadata: types.Metadata{
+				Name: "app-session" + strconv.Itoa(i+1),
+			},
+			Spec: types.WebSessionSpecV2{
+				User: "fish",
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	for i := 0; i < 3; i++ {
+		err := p.appSessionS.UpsertAppSession(t.Context(), &types.WebSessionV2{
+			Kind:    types.KindWebSession,
+			SubKind: types.KindAppSession,
+			Version: types.V2,
+			Metadata: types.Metadata{
+				Name: "app-session" + strconv.Itoa(i+100),
+			},
+			Spec: types.WebSessionSpecV2{
+				User: "llama",
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		expected, next, err := p.appSessionS.ListAppSessions(ctx, 0, "", "")
+		assert.NoError(t, err)
+		assert.Empty(t, next)
+		assert.Len(t, expected, 34)
+
+		cached, next, err := p.cache.ListAppSessions(ctx, 0, "", "")
+		assert.NoError(t, err)
+		assert.Empty(t, next)
+		assert.Len(t, cached, 34)
+	}, 15*time.Second, 100*time.Millisecond)
+
+	session, err := p.cache.GetAppSession(ctx, types.GetAppSessionRequest{
+		SessionID: "app-session100",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	require.Equal(t, "llama", session.GetUser())
+
+	session, err = p.cache.GetAppSession(ctx, types.GetAppSessionRequest{
+		SessionID: "app-session1",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	require.Equal(t, "fish", session.GetUser())
+
+	var sessions []types.WebSession
+	for pageToken := ""; ; {
+		cached, next, err := p.cache.ListAppSessions(ctx, 1, pageToken, "llama")
+		if !assert.NoError(t, err) {
+			return
+		}
+		sessions = append(sessions, cached...)
+		pageToken = next
+		if next == "" {
+			break
+		}
+	}
+	assert.Len(t, sessions, 3)
+
+	sessions = nil
+	for pageToken := ""; ; {
+		cached, next, err := p.cache.ListAppSessions(ctx, 7, pageToken, "fish")
+		if !assert.NoError(t, err) {
+			return
+		}
+		sessions = append(sessions, cached...)
+		pageToken = next
+		if next == "" {
+			break
+		}
+	}
+	assert.Len(t, sessions, 31)
+
+	require.NoError(t, p.appSessionS.DeleteAllAppSessions(ctx))
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		cached, next, err := p.cache.ListAppSessions(ctx, 0, "", "")
+		assert.NoError(t, err)
+		assert.Empty(t, next)
+		assert.Empty(t, cached)
+	}, 15*time.Second, 100*time.Millisecond)
+}
+
+func TestWebSessions(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	for i := 0; i < 31; i++ {
+		err := p.webSessionS.Upsert(t.Context(), &types.WebSessionV2{
+			Kind:    types.KindWebSession,
+			SubKind: types.KindWebSession,
+			Version: types.V2,
+			Metadata: types.Metadata{
+				Name: "web-session" + strconv.Itoa(i+1),
+			},
+			Spec: types.WebSessionSpecV2{
+				User: "fish",
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		expected, err := p.webSessionS.List(ctx)
+		assert.NoError(t, err)
+		assert.Len(t, expected, 31)
+
+		for _, session := range expected {
+			cached, err := p.cache.GetWebSession(ctx, types.GetWebSessionRequest{SessionID: session.GetName()})
+			assert.NoError(t, err)
+			assert.Empty(t, cmp.Diff(session, cached))
+		}
+	}, 15*time.Second, 100*time.Millisecond)
+
+	require.NoError(t, p.webSessionS.DeleteAll(ctx))
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		for i := 0; i < 31; i++ {
+			session, err := p.cache.GetWebSession(ctx, types.GetWebSessionRequest{SessionID: "web-session" + strconv.Itoa(i+1)})
+			assert.Error(t, err)
+			assert.Nil(t, session)
+		}
+	}, 15*time.Second, 100*time.Millisecond)
+}
+
+func TestSnowflakeSessions(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	for i := 0; i < 31; i++ {
+		err := p.snowflakeSessionS.UpsertSnowflakeSession(t.Context(), &types.WebSessionV2{
+			Kind:    types.KindWebSession,
+			SubKind: types.KindSnowflakeSession,
+			Version: types.V2,
+			Metadata: types.Metadata{
+				Name: "snow-session" + strconv.Itoa(i+1),
+			},
+			Spec: types.WebSessionSpecV2{
+				User: "fish",
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		expected, err := p.snowflakeSessionS.GetSnowflakeSessions(ctx)
+		assert.NoError(t, err)
+		assert.Len(t, expected, 31)
+
+		for _, session := range expected {
+			cached, err := p.cache.GetSnowflakeSession(ctx, types.GetSnowflakeSessionRequest{SessionID: session.GetName()})
+			assert.NoError(t, err)
+			assert.Empty(t, cmp.Diff(session, cached))
+		}
+	}, 15*time.Second, 100*time.Millisecond)
+
+	require.NoError(t, p.snowflakeSessionS.DeleteAllSnowflakeSessions(ctx))
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		for i := 0; i < 31; i++ {
+			session, err := p.cache.GetSnowflakeSession(ctx, types.GetSnowflakeSessionRequest{SessionID: "snow-session" + strconv.Itoa(i+1)})
+			assert.Error(t, err)
+			assert.Nil(t, session)
+		}
+	}, 15*time.Second, 100*time.Millisecond)
+}


### PR DESCRIPTION
Moves SAMLIdPServiceProviders, AppSessions, WebSession, SAMLSessions, and SnowflakeSessions to the new cache collection scheme that was introduced in #52210. No additional functionality changes have been made here. This should be a purely mechanical translation to the new internal caching machinery.