### PR TITLE
Convert access graph resources to new in memory cache collection

### DIFF
--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -1560,34 +1560,6 @@ func TestUserLoginStates(t *testing.T) {
 	})
 }
 
-// TestCrownJewel tests that CRUD operations on user notification resources are
-// replicated from the backend to the cache.
-func TestCrownJewel(t *testing.T) {
-	t.Parallel()
-
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	testResources153(t, p, testFuncs153[*crownjewelv1.CrownJewel]{
-		newResource: func(name string) (*crownjewelv1.CrownJewel, error) {
-			return newCrownJewel(t, name), nil
-		},
-		create: func(ctx context.Context, item *crownjewelv1.CrownJewel) error {
-			_, err := p.crownJewels.CreateCrownJewel(ctx, item)
-			return trace.Wrap(err)
-		},
-		list: func(ctx context.Context) ([]*crownjewelv1.CrownJewel, error) {
-			items, _, err := p.crownJewels.ListCrownJewels(ctx, 0, "")
-			return items, trace.Wrap(err)
-		},
-		cacheList: func(ctx context.Context) ([]*crownjewelv1.CrownJewel, error) {
-			items, _, err := p.crownJewels.ListCrownJewels(ctx, 0, "")
-			return items, trace.Wrap(err)
-		},
-		deleteAll: p.crownJewels.DeleteAllCrownJewels,
-	})
-}
-
 func TestDatabaseObjects(t *testing.T) {
 	t.Parallel()
 

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -22,6 +22,8 @@ import (
 	"github.com/gravitational/trace"
 
 	autoupdatev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
+	clusterconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
+	crownjewelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/crownjewel/v1"
 	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
 	identitycenterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/identitycenter/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
@@ -99,6 +101,8 @@ type collections struct {
 	accessLists                      *collection[*accesslist.AccessList, accessListIndex]
 	accessListMembers                *collection[*accesslist.AccessListMember, accessListMemberIndex]
 	accessListReviews                *collection[*accesslist.Review, accessListReviewIndex]
+	crownJewels                      *collection[*crownjewelv1.CrownJewel, crownJewelIndex]
+	accessGraphSettings              *collection[*clusterconfigv1.AccessGraphSettings, accessGraphSettingsIndex]
 }
 
 // setupCollections ensures that the appropriate [collection] is
@@ -468,6 +472,22 @@ func setupCollections(c Config) (*collections, error) {
 
 			out.accessListReviews = collect
 			out.byKind[resourceKind] = out.accessListReviews
+		case types.KindCrownJewel:
+			collect, err := newCrownJewelCollection(c.CrownJewels, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out.crownJewels = collect
+			out.byKind[resourceKind] = out.crownJewels
+		case types.KindAccessGraphSettings:
+			collect, err := newAccessGraphSettingsCollection(c.ClusterConfig, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out.accessGraphSettings = collect
+			out.byKind[resourceKind] = out.accessGraphSettings
 		}
 	}
 

--- a/lib/cache/crown_jewel.go
+++ b/lib/cache/crown_jewel.go
@@ -1,0 +1,114 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	crownjewelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/crownjewel/v1"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+type crownJewelIndex string
+
+const crownJewelNameIndex crownJewelIndex = "name"
+
+func newCrownJewelCollection(upstream services.CrownJewels, w types.WatchKind) (*collection[*crownjewelv1.CrownJewel, crownJewelIndex], error) {
+	if upstream == nil {
+		return nil, trace.BadParameter("missing parameter CrownJewels")
+	}
+
+	return &collection[*crownjewelv1.CrownJewel, crownJewelIndex]{
+		store: newStore(map[crownJewelIndex]func(*crownjewelv1.CrownJewel) string{
+			crownJewelNameIndex: func(r *crownjewelv1.CrownJewel) string {
+				return r.GetMetadata().GetName()
+			},
+		}),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]*crownjewelv1.CrownJewel, error) {
+			var out []*crownjewelv1.CrownJewel
+			var nextToken string
+			for {
+				var page []*crownjewelv1.CrownJewel
+				var err error
+
+				const defaultPageSize = 0
+				page, nextToken, err = upstream.ListCrownJewels(ctx, defaultPageSize, nextToken)
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+				out = append(out, page...)
+				if nextToken == "" {
+					break
+				}
+			}
+			return out, nil
+		},
+		headerTransform: func(hdr *types.ResourceHeader) *crownjewelv1.CrownJewel {
+			return &crownjewelv1.CrownJewel{
+				Kind:    hdr.Kind,
+				Version: hdr.Version,
+				Metadata: &headerv1.Metadata{
+					Name: hdr.Metadata.Name,
+				},
+			}
+		},
+		watch: w,
+	}, nil
+}
+
+// ListCrownJewels returns a list of CrownJewel resources.
+func (c *Cache) ListCrownJewels(ctx context.Context, pageSize int64, pageToken string) ([]*crownjewelv1.CrownJewel, string, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/ListCrownJewels")
+	defer span.End()
+
+	lister := genericLister[*crownjewelv1.CrownJewel, crownJewelIndex]{
+		cache:      c,
+		collection: c.collections.crownJewels,
+		index:      crownJewelNameIndex,
+		upstreamList: func(ctx context.Context, pageSize int, pageToken string) ([]*crownjewelv1.CrownJewel, string, error) {
+			out, next, err := c.Config.CrownJewels.ListCrownJewels(ctx, int64(pageSize), pageToken)
+			return out, next, trace.Wrap(err)
+		},
+		nextToken: func(t *crownjewelv1.CrownJewel) string {
+			return t.GetMetadata().GetName()
+		},
+		clone: utils.CloneProtoMsg[*crownjewelv1.CrownJewel],
+	}
+	out, next, err := lister.list(ctx, int(pageSize), pageToken)
+	return out, next, trace.Wrap(err)
+}
+
+// GetCrownJewel returns the specified CrownJewel resource.
+func (c *Cache) GetCrownJewel(ctx context.Context, name string) (*crownjewelv1.CrownJewel, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetCrownJewel")
+	defer span.End()
+
+	getter := genericGetter[*crownjewelv1.CrownJewel, crownJewelIndex]{
+		cache:       c,
+		collection:  c.collections.crownJewels,
+		index:       crownJewelNameIndex,
+		upstreamGet: c.Config.CrownJewels.GetCrownJewel,
+		clone:       utils.CloneProtoMsg[*crownjewelv1.CrownJewel],
+	}
+	out, err := getter.get(ctx, name)
+	return out, trace.Wrap(err)
+}

--- a/lib/cache/crown_jewel_test.go
+++ b/lib/cache/crown_jewel_test.go
@@ -1,0 +1,54 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/trace"
+
+	crownjewelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/crownjewel/v1"
+)
+
+// TestCrownJewel tests that CRUD operations on user notification resources are
+// replicated from the backend to the cache.
+func TestCrownJewel(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	testResources153(t, p, testFuncs153[*crownjewelv1.CrownJewel]{
+		newResource: func(name string) (*crownjewelv1.CrownJewel, error) {
+			return newCrownJewel(t, name), nil
+		},
+		create: func(ctx context.Context, item *crownjewelv1.CrownJewel) error {
+			_, err := p.crownJewels.CreateCrownJewel(ctx, item)
+			return trace.Wrap(err)
+		},
+		list: func(ctx context.Context) ([]*crownjewelv1.CrownJewel, error) {
+			items, _, err := p.crownJewels.ListCrownJewels(ctx, 0, "")
+			return items, trace.Wrap(err)
+		},
+		cacheList: func(ctx context.Context) ([]*crownjewelv1.CrownJewel, error) {
+			items, _, err := p.crownJewels.ListCrownJewels(ctx, 0, "")
+			return items, trace.Wrap(err)
+		},
+		deleteAll: p.crownJewels.DeleteAllCrownJewels,
+	})
+}


### PR DESCRIPTION
Moves crown jewels and access graph settings to the new cache collection scheme that was introduced in https://github.com/gravitational/teleport/pull/52210. No additional functionality changes have been made here. This should be a purely mechanical translation to the new internal caching machinery.