### PR TITLE
Convert user tasks and user login state to new cache collections

### DIFF
--- a/api/types/userloginstate/user_login_state.go
+++ b/api/types/userloginstate/user_login_state.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/types/header/convert/legacy"
 	"github.com/gravitational/teleport/api/types/trait"
+	"github.com/gravitational/teleport/api/utils"
 )
 
 // UserLoginState is the ephemeral user login state. This will hold data to differentiate
@@ -97,6 +98,13 @@ func (u *UserLoginState) CheckAndSetDefaults() error {
 	}
 
 	return nil
+}
+
+// Clone returns a copy of the member.
+func (u *UserLoginState) Clone() *UserLoginState {
+	var copy *UserLoginState
+	utils.StrictObjectToStruct(u, &copy)
+	return copy
 }
 
 // GetOriginalRoles returns the original roles that the user login state was derived from.

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -1223,34 +1223,6 @@ func mustCreateDatabase(t *testing.T, name, protocol, uri string) *types.Databas
 	return database
 }
 
-// TestUserTasks tests that CRUD operations on user notification resources are
-// replicated from the backend to the cache.
-func TestUserTasks(t *testing.T) {
-	t.Parallel()
-
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	testResources153(t, p, testFuncs153[*usertasksv1.UserTask]{
-		newResource: func(name string) (*usertasksv1.UserTask, error) {
-			return newUserTasks(t), nil
-		},
-		create: func(ctx context.Context, item *usertasksv1.UserTask) error {
-			_, err := p.userTasks.CreateUserTask(ctx, item)
-			return trace.Wrap(err)
-		},
-		list: func(ctx context.Context) ([]*usertasksv1.UserTask, error) {
-			items, _, err := p.userTasks.ListUserTasks(ctx, 0, "", &usertasksv1.ListUserTasksFilters{})
-			return items, trace.Wrap(err)
-		},
-		cacheList: func(ctx context.Context) ([]*usertasksv1.UserTask, error) {
-			items, _, err := p.userTasks.ListUserTasks(ctx, 0, "", &usertasksv1.ListUserTasksFilters{})
-			return items, trace.Wrap(err)
-		},
-		deleteAll: p.userTasks.DeleteAllUserTasks,
-	})
-}
-
 func newUserTasks(t *testing.T) *usertasksv1.UserTask {
 	t.Helper()
 
@@ -1394,33 +1366,6 @@ func TestSecurityReportState(t *testing.T) {
 			return trace.Wrap(err)
 		},
 		deleteAll: p.secReports.DeleteAllSecurityReportsStates,
-	})
-}
-
-// TestUserLoginStates tests that CRUD operations on user login state resources are
-// replicated from the backend to the cache.
-func TestUserLoginStates(t *testing.T) {
-	t.Parallel()
-
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	testResources(t, p, testFuncs[*userloginstate.UserLoginState]{
-		newResource: func(name string) (*userloginstate.UserLoginState, error) {
-			return newUserLoginState(t, name), nil
-		},
-		create: func(ctx context.Context, uls *userloginstate.UserLoginState) error {
-			_, err := p.userLoginStates.UpsertUserLoginState(ctx, uls)
-			return trace.Wrap(err)
-		},
-		list:      p.userLoginStates.GetUserLoginStates,
-		cacheGet:  p.cache.GetUserLoginState,
-		cacheList: p.cache.GetUserLoginStates,
-		update: func(ctx context.Context, uls *userloginstate.UserLoginState) error {
-			_, err := p.userLoginStates.UpsertUserLoginState(ctx, uls)
-			return trace.Wrap(err)
-		},
-		deleteAll: p.userLoginStates.DeleteAllUserLoginStates,
 	})
 }
 

--- a/lib/cache/user_login_state.go
+++ b/lib/cache/user_login_state.go
@@ -1,0 +1,116 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/api/types/userloginstate"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+type userLoginStateIndex string
+
+const userLoginStateNameIndex userLoginStateIndex = "name"
+
+func newUserLoginStateCollection(upstream services.UserLoginStates, w types.WatchKind) (*collection[*userloginstate.UserLoginState, userLoginStateIndex], error) {
+	if upstream == nil {
+		return nil, trace.BadParameter("missing parameter UserTasks")
+	}
+
+	return &collection[*userloginstate.UserLoginState, userLoginStateIndex]{
+		store: newStore(map[userLoginStateIndex]func(*userloginstate.UserLoginState) string{
+			userLoginStateNameIndex: func(r *userloginstate.UserLoginState) string {
+				return r.GetMetadata().Name
+			},
+		}),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]*userloginstate.UserLoginState, error) {
+			out, err := upstream.GetUserLoginStates(ctx)
+			return out, trace.Wrap(err)
+		},
+		headerTransform: func(hdr *types.ResourceHeader) *userloginstate.UserLoginState {
+			return &userloginstate.UserLoginState{
+				ResourceHeader: header.ResourceHeader{
+					Kind:    hdr.Kind,
+					Version: hdr.Version,
+					Metadata: header.Metadata{
+						Name: hdr.Metadata.Name,
+					},
+				},
+			}
+		},
+		watch: w,
+	}, nil
+}
+
+// GetUserLoginStates returns the all user login state resources.
+func (c *Cache) GetUserLoginStates(ctx context.Context) ([]*userloginstate.UserLoginState, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetUserLoginStates")
+	defer span.End()
+
+	rg, err := acquireReadGuard(c, c.collections.userLoginStates)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+
+	if !rg.ReadCache() {
+		states, err := c.Config.UserLoginStates.GetUserLoginStates(ctx)
+		return states, trace.Wrap(err)
+	}
+
+	states := make([]*userloginstate.UserLoginState, 0, rg.store.len())
+	for uls := range rg.store.resources(userLoginStateNameIndex, "", "") {
+		states = append(states, uls.Clone())
+	}
+
+	return states, nil
+}
+
+// GetUserLoginState returns the specified user login state resource.
+func (c *Cache) GetUserLoginState(ctx context.Context, name string) (*userloginstate.UserLoginState, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetUserLoginState")
+	defer span.End()
+
+	var upstreamRead bool
+	getter := genericGetter[*userloginstate.UserLoginState, userLoginStateIndex]{
+		cache:      c,
+		collection: c.collections.userLoginStates,
+		index:      userLoginStateNameIndex,
+		upstreamGet: func(ctx context.Context, name string) (*userloginstate.UserLoginState, error) {
+			upstreamRead = true
+			state, err := c.Config.UserLoginStates.GetUserLoginState(ctx, name)
+			return state, trace.Wrap(err)
+		},
+		clone: func(uls *userloginstate.UserLoginState) *userloginstate.UserLoginState {
+			return uls.Clone()
+		},
+	}
+	out, err := getter.get(ctx, name)
+	if trace.IsNotFound(err) && !upstreamRead {
+		// fallback is sane because method is never used
+		// in construction of derivative caches.
+		if uls, err := c.Config.UserLoginStates.GetUserLoginState(ctx, name); err == nil {
+			return uls, nil
+		}
+	}
+	return out, trace.Wrap(err)
+}

--- a/lib/cache/user_login_state_test.go
+++ b/lib/cache/user_login_state_test.go
@@ -1,0 +1,53 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types/userloginstate"
+)
+
+// TestUserLoginStates tests that CRUD operations on user login state resources are
+// replicated from the backend to the cache.
+func TestUserLoginStates(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	testResources(t, p, testFuncs[*userloginstate.UserLoginState]{
+		newResource: func(name string) (*userloginstate.UserLoginState, error) {
+			return newUserLoginState(t, name), nil
+		},
+		create: func(ctx context.Context, uls *userloginstate.UserLoginState) error {
+			_, err := p.userLoginStates.UpsertUserLoginState(ctx, uls)
+			return trace.Wrap(err)
+		},
+		list:      p.userLoginStates.GetUserLoginStates,
+		cacheGet:  p.cache.GetUserLoginState,
+		cacheList: p.cache.GetUserLoginStates,
+		update: func(ctx context.Context, uls *userloginstate.UserLoginState) error {
+			_, err := p.userLoginStates.UpsertUserLoginState(ctx, uls)
+			return trace.Wrap(err)
+		},
+		deleteAll: p.userLoginStates.DeleteAllUserLoginStates,
+	})
+}

--- a/lib/cache/user_task.go
+++ b/lib/cache/user_task.go
@@ -1,0 +1,116 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+type userTaskIndex string
+
+const userTaskNameIndex userTaskIndex = "name"
+
+func newUserTaskCollection(upstream services.UserTasks, w types.WatchKind) (*collection[*usertasksv1.UserTask, userTaskIndex], error) {
+	if upstream == nil {
+		return nil, trace.BadParameter("missing parameter UserTasks")
+	}
+
+	return &collection[*usertasksv1.UserTask, userTaskIndex]{
+		store: newStore(map[userTaskIndex]func(*usertasksv1.UserTask) string{
+			userTaskNameIndex: func(r *usertasksv1.UserTask) string {
+				return r.GetMetadata().GetName()
+			},
+		}),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]*usertasksv1.UserTask, error) {
+			var resources []*usertasksv1.UserTask
+			var nextToken string
+			for {
+				var page []*usertasksv1.UserTask
+				var err error
+				page, nextToken, err = upstream.ListUserTasks(ctx, 0 /* page size */, nextToken, &usertasksv1.ListUserTasksFilters{})
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+				resources = append(resources, page...)
+
+				if nextToken == "" {
+					break
+				}
+			}
+			return resources, nil
+		},
+		headerTransform: func(hdr *types.ResourceHeader) *usertasksv1.UserTask {
+			return &usertasksv1.UserTask{
+				Kind:    hdr.Kind,
+				Version: hdr.Version,
+				Metadata: &headerv1.Metadata{
+					Name: hdr.Metadata.Name,
+				},
+			}
+		},
+		watch: w,
+	}, nil
+}
+
+// ListUserTasks returns a list of UserTask resources.
+func (c *Cache) ListUserTasks(ctx context.Context, pageSize int64, pageToken string, filters *usertasksv1.ListUserTasksFilters) ([]*usertasksv1.UserTask, string, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/ListUserTasks")
+	defer span.End()
+
+	lister := genericLister[*usertasksv1.UserTask, userTaskIndex]{
+		cache:      c,
+		collection: c.collections.userTasks,
+		index:      userTaskNameIndex,
+		upstreamList: func(ctx context.Context, i int, s string) ([]*usertasksv1.UserTask, string, error) {
+			out, next, err := c.Config.UserTasks.ListUserTasks(ctx, pageSize, pageToken, filters)
+			return out, next, trace.Wrap(err)
+		},
+		nextToken: func(t *usertasksv1.UserTask) string {
+			return t.GetMetadata().Name
+		},
+		clone: utils.CloneProtoMsg[*usertasksv1.UserTask],
+		filter: func(ut *usertasksv1.UserTask) bool {
+			return services.MatchUserTask(ut, filters)
+		},
+	}
+	out, next, err := lister.list(ctx, int(pageSize), pageToken)
+	return out, next, trace.Wrap(err)
+}
+
+// GetUserTask returns the specified UserTask resource.
+func (c *Cache) GetUserTask(ctx context.Context, name string) (*usertasksv1.UserTask, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetUserTask")
+	defer span.End()
+
+	getter := genericGetter[*usertasksv1.UserTask, userTaskIndex]{
+		cache:       c,
+		collection:  c.collections.userTasks,
+		index:       userTaskNameIndex,
+		upstreamGet: c.Config.UserTasks.GetUserTask,
+		clone:       utils.CloneProtoMsg[*usertasksv1.UserTask],
+	}
+	out, err := getter.get(ctx, name)
+	return out, trace.Wrap(err)
+}

--- a/lib/cache/user_task_test.go
+++ b/lib/cache/user_task_test.go
@@ -1,0 +1,54 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/trace"
+
+	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
+)
+
+// TestUserTasks tests that CRUD operations on user notification resources are
+// replicated from the backend to the cache.
+func TestUserTasks(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	testResources153(t, p, testFuncs153[*usertasksv1.UserTask]{
+		newResource: func(name string) (*usertasksv1.UserTask, error) {
+			return newUserTasks(t), nil
+		},
+		create: func(ctx context.Context, item *usertasksv1.UserTask) error {
+			_, err := p.userTasks.CreateUserTask(ctx, item)
+			return trace.Wrap(err)
+		},
+		list: func(ctx context.Context) ([]*usertasksv1.UserTask, error) {
+			items, _, err := p.userTasks.ListUserTasks(ctx, 0, "", &usertasksv1.ListUserTasksFilters{})
+			return items, trace.Wrap(err)
+		},
+		cacheList: func(ctx context.Context) ([]*usertasksv1.UserTask, error) {
+			items, _, err := p.cache.ListUserTasks(ctx, 0, "", &usertasksv1.ListUserTasksFilters{})
+			return items, trace.Wrap(err)
+		},
+		deleteAll: p.userTasks.DeleteAllUserTasks,
+	})
+}

--- a/lib/services/local/user_task.go
+++ b/lib/services/local/user_task.go
@@ -55,17 +55,7 @@ func NewUserTasksService(b backend.Backend) (*UserTasksService, error) {
 
 func (s *UserTasksService) ListUserTasks(ctx context.Context, pagesize int64, lastKey string, filters *usertasksv1.ListUserTasksFilters) ([]*usertasksv1.UserTask, string, error) {
 	r, nextToken, err := s.service.ListResourcesWithFilter(ctx, int(pagesize), lastKey, func(ut *usertasksv1.UserTask) bool {
-		integrationFilter := filters.GetIntegration()
-		if integrationFilter != "" && integrationFilter != ut.GetSpec().GetIntegration() {
-			return false
-		}
-
-		stateFilter := filters.GetTaskState()
-		if stateFilter != "" && stateFilter != ut.GetSpec().GetState() {
-			return false
-		}
-
-		return true
+		return services.MatchUserTask(ut, filters)
 	})
 	return r, nextToken, trace.Wrap(err)
 }

--- a/lib/services/user_task.go
+++ b/lib/services/user_task.go
@@ -51,3 +51,17 @@ func MarshalUserTask(object *usertasksv1.UserTask, opts ...MarshalOption) ([]byt
 func UnmarshalUserTask(data []byte, opts ...MarshalOption) (*usertasksv1.UserTask, error) {
 	return UnmarshalProtoResource[*usertasksv1.UserTask](data, opts...)
 }
+
+func MatchUserTask(ut *usertasksv1.UserTask, filters *usertasksv1.ListUserTasksFilters) bool {
+	integrationFilter := filters.GetIntegration()
+	if integrationFilter != "" && integrationFilter != ut.GetSpec().GetIntegration() {
+		return false
+	}
+
+	stateFilter := filters.GetTaskState()
+	if stateFilter != "" && stateFilter != ut.GetSpec().GetState() {
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
Moves the resources to the new cache collection scheme that was introduced in #52210. No additional functionality changes have been made here. This should be a purely mechanical translation to the new internal caching machinery.