### PR TITLE
Fix imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1217,7 +1217,7 @@ fix-imports/host:
 		echo 'gci is not installed or is missing from PATH, consider installing it ("go install github.com/daixiang0/gci@latest") or use "make -C build.assets/ fix-imports"';\
 		exit 1;\
 	fi
-	gci write -s standard -s default  -s 'prefix(github.com/gravitational/teleport)' -s 'prefix(github.com/gravitational/teleport/integrations/terraform,github.com/gravitational/teleport/integrations/event-handler)' --skip-generated .
+	GOEXPERIMENT=synctest gci write -s standard -s default  -s 'prefix(github.com/gravitational/teleport)' -s 'prefix(github.com/gravitational/teleport/integrations/terraform,github.com/gravitational/teleport/integrations/event-handler)' --skip-generated .
 
 lint-build-tooling: GO_LINT_FLAGS ?=
 lint-build-tooling:

--- a/lib/player/player_experimental_test.go
+++ b/lib/player/player_experimental_test.go
@@ -25,8 +25,9 @@ import (
 	"testing/synctest"
 	"time"
 
-	"github.com/gravitational/teleport/lib/player"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/player"
 )
 
 /*


### PR DESCRIPTION
This went undetected by linters since the test file is behind a build tag.

In order to ensure that testing/synctest is recognized by gci as a standard library package, we need to run it with the GOEXPERIMENT env var.