### PR TITLE
Convert zero trust access related resources to new in memory cache collection

### DIFF
--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -504,7 +504,6 @@ type Cache struct {
 	presenceCache                services.Presence
 	restrictionsCache            services.Restrictions
 	databaseObjectsCache         *local.DatabaseObjectService
-	dynamicWindowsDesktopsCache  services.DynamicWindowsDesktops
 	userGroupsCache              services.UserGroups
 	discoveryConfigsCache        services.DiscoveryConfigs
 	headlessAuthenticationsCache services.HeadlessAuthenticationService
@@ -956,12 +955,6 @@ func New(config Config) (*Cache, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	dynamicDesktopsService, err := local.NewDynamicWindowsDesktopService(config.Backend)
-	if err != nil {
-		cancel()
-		return nil, trace.Wrap(err)
-	}
-
 	identityCenterCache, err := local.NewIdentityCenterService(local.IdentityCenterServiceConfig{
 		Backend: config.Backend})
 	if err != nil {
@@ -1000,7 +993,6 @@ func New(config Config) (*Cache, error) {
 		dynamicAccessCache:           local.NewDynamicAccessService(config.Backend),
 		presenceCache:                local.NewPresenceService(config.Backend),
 		restrictionsCache:            local.NewRestrictionsService(config.Backend),
-		dynamicWindowsDesktopsCache:  dynamicDesktopsService,
 		userGroupsCache:              userGroupsCache,
 		discoveryConfigsCache:        discoveryConfigsCache,
 		headlessAuthenticationsCache: identityService,
@@ -1858,32 +1850,6 @@ func (c *Cache) GetNetworkRestrictions(ctx context.Context) (types.NetworkRestri
 	defer rg.Release()
 
 	return rg.reader.GetNetworkRestrictions(ctx)
-}
-
-// GetDynamicWindowsDesktop returns registered dynamic Windows desktop by name.
-func (c *Cache) GetDynamicWindowsDesktop(ctx context.Context, name string) (types.DynamicWindowsDesktop, error) {
-	ctx, span := c.Tracer.Start(ctx, "cache/GetDynamicWindowsDesktop")
-	defer span.End()
-
-	rg, err := readLegacyCollectionCache(c, c.legacyCacheCollections.dynamicWindowsDesktops)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	defer rg.Release()
-	return rg.reader.GetDynamicWindowsDesktop(ctx, name)
-}
-
-// ListDynamicWindowsDesktops returns all registered dynamic Windows desktop.
-func (c *Cache) ListDynamicWindowsDesktops(ctx context.Context, pageSize int, nextPage string) ([]types.DynamicWindowsDesktop, string, error) {
-	ctx, span := c.Tracer.Start(ctx, "cache/ListDynamicWindowsDesktops")
-	defer span.End()
-
-	rg, err := readLegacyCollectionCache(c, c.legacyCacheCollections.dynamicWindowsDesktops)
-	if err != nil {
-		return nil, "", trace.Wrap(err)
-	}
-	defer rg.Release()
-	return rg.reader.ListDynamicWindowsDesktops(ctx, pageSize, nextPage)
 }
 
 // ListDiscoveryConfigs returns a paginated list of all DiscoveryConfig resources.

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -507,7 +507,6 @@ type Cache struct {
 	secReportsCache              services.SecReports
 	eventsFanout                 *services.FanoutV2
 	lowVolumeEventsFanout        *utils.RoundRobin[*services.FanoutV2]
-	kubeWaitingContsCache        *local.KubeWaitingContainerService
 	staticHostUsersCache         *local.StaticHostUserService
 	provisioningStatesCache      *local.ProvisioningStateService
 	identityCenterCache          *local.IdentityCenterService

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -1369,57 +1369,6 @@ func TestSecurityReportState(t *testing.T) {
 	})
 }
 
-func TestDatabaseObjects(t *testing.T) {
-	t.Parallel()
-
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	testResources153(t, p, testFuncs153[*dbobjectv1.DatabaseObject]{
-		newResource: func(name string) (*dbobjectv1.DatabaseObject, error) {
-			return newDatabaseObject(t, name), nil
-		},
-		create: func(ctx context.Context, item *dbobjectv1.DatabaseObject) error {
-			_, err := p.databaseObjects.CreateDatabaseObject(ctx, item)
-			return trace.Wrap(err)
-		},
-		list: func(ctx context.Context) ([]*dbobjectv1.DatabaseObject, error) {
-			items, _, err := p.databaseObjects.ListDatabaseObjects(ctx, 0, "")
-			return items, trace.Wrap(err)
-		},
-		cacheList: func(ctx context.Context) ([]*dbobjectv1.DatabaseObject, error) {
-			items, _, err := p.databaseObjects.ListDatabaseObjects(ctx, 0, "")
-			return items, trace.Wrap(err)
-		},
-		deleteAll: func(ctx context.Context) error {
-			token := ""
-			var objects []*dbobjectv1.DatabaseObject
-
-			for {
-				resp, nextToken, err := p.databaseObjects.ListDatabaseObjects(ctx, 0, token)
-				if err != nil {
-					return err
-				}
-
-				objects = append(objects, resp...)
-
-				if nextToken == "" {
-					break
-				}
-				token = nextToken
-			}
-
-			for _, object := range objects {
-				err := p.databaseObjects.DeleteDatabaseObject(ctx, object.GetMetadata().GetName())
-				if err != nil {
-					return err
-				}
-			}
-			return nil
-		},
-	})
-}
-
 // TestStaticHostUsers tests that CRUD operations on static host user resources are
 // replicated from the backend to the cache.
 func TestStaticHostUsers(t *testing.T) {

--- a/lib/cache/cert_authority_test.go
+++ b/lib/cache/cert_authority_test.go
@@ -94,7 +94,6 @@ func TestNodeCAFiltering(t *testing.T) {
 		DynamicAccess:           p.cache.dynamicAccessCache,
 		Presence:                p.cache.presenceCache,
 		Restrictions:            p.cache.restrictionsCache,
-		DynamicWindowsDesktops:  p.cache.dynamicWindowsDesktopsCache,
 		SAMLIdPServiceProviders: p.samlIDPServiceProviders,
 		UserGroups:              p.userGroups,
 		StaticHostUsers:         p.staticHostUsers,

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -77,6 +77,7 @@ type collections struct {
 	kubeClusters                     *collection[types.KubeCluster, kubeClusterIndex]
 	windowsDesktops                  *collection[types.WindowsDesktop, windowsDesktopIndex]
 	windowsDesktopServices           *collection[types.WindowsDesktopService, windowsDesktopServiceIndex]
+	dynamicWindowsDesktops           *collection[types.DynamicWindowsDesktop, dynamicWindowsDesktopIndex]
 	userGroups                       *collection[types.UserGroup, userGroupIndex]
 	identityCenterAccounts           *collection[*identitycenterv1.Account, identityCenterAccountIndex]
 	identityCenterAccountAssignments *collection[*identitycenterv1.AccountAssignment, identityCenterAccountAssignmentIndex]
@@ -267,6 +268,14 @@ func setupCollections(c Config) (*collections, error) {
 
 			out.windowsDesktopServices = collect
 			out.byKind[resourceKind] = out.windowsDesktopServices
+		case types.KindDynamicWindowsDesktop:
+			collect, err := newDynamicWindowsDesktopCollection(c.DynamicWindowsDesktops, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out.dynamicWindowsDesktops = collect
+			out.byKind[resourceKind] = out.dynamicWindowsDesktops
 		case types.KindUserGroup:
 			collect, err := newUserGroupCollection(c.UserGroups, watch)
 			if err != nil {

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -25,6 +25,7 @@ import (
 	autoupdatev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	clusterconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
 	crownjewelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/crownjewel/v1"
+	dbobjectv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobject/v1"
 	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
 	identitycenterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/identitycenter/v1"
 	kubewaitingcontainerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1"
@@ -121,6 +122,7 @@ type collections struct {
 	userTasks                        *collection[*usertasksv1.UserTask, userTaskIndex]
 	userLoginStates                  *collection[*userloginstate.UserLoginState, userLoginStateIndex]
 	gitServers                       *collection[types.Server, gitServerIndex]
+	databaseObjects                  *collection[*dbobjectv1.DatabaseObject, databaseObjectIndex]
 }
 
 // setupCollections ensures that the appropriate [collection] is
@@ -239,6 +241,14 @@ func setupCollections(c Config) (*collections, error) {
 
 			out.dbServices = collect
 			out.byKind[resourceKind] = out.dbServices
+		case types.KindDatabaseObject:
+			collect, err := newDatabaseObjectCollection(c.DatabaseObjects, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out.databaseObjects = collect
+			out.byKind[resourceKind] = out.databaseObjects
 		case types.KindKubeServer:
 			collect, err := newKubernetesServerCollection(c.Presence, watch)
 			if err != nil {

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -120,6 +120,7 @@ type collections struct {
 	remoteClusters                   *collection[types.RemoteCluster, remoteClusterIndex]
 	userTasks                        *collection[*usertasksv1.UserTask, userTaskIndex]
 	userLoginStates                  *collection[*userloginstate.UserLoginState, userLoginStateIndex]
+	gitServers                       *collection[types.Server, gitServerIndex]
 }
 
 // setupCollections ensures that the appropriate [collection] is
@@ -610,6 +611,14 @@ func setupCollections(c Config) (*collections, error) {
 
 			out.userLoginStates = collect
 			out.byKind[resourceKind] = out.userLoginStates
+		case types.KindGitServer:
+			collect, err := newGitServerCollection(c.GitServers, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out.gitServers = collect
+			out.byKind[resourceKind] = out.gitServers
 		}
 	}
 

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -27,6 +27,7 @@ import (
 	crownjewelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/crownjewel/v1"
 	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
 	identitycenterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/identitycenter/v1"
+	kubewaitingcontainerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	notificationsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
@@ -75,6 +76,7 @@ type collections struct {
 	dbServices                       *collection[types.DatabaseService, databaseServiceIndex]
 	kubeServers                      *collection[types.KubeServer, kubeServerIndex]
 	kubeClusters                     *collection[types.KubeCluster, kubeClusterIndex]
+	kubeWaitingContainers            *collection[*kubewaitingcontainerv1.KubernetesWaitingContainer, kubeWaitingContainerIndex]
 	windowsDesktops                  *collection[types.WindowsDesktop, windowsDesktopIndex]
 	windowsDesktopServices           *collection[types.WindowsDesktopService, windowsDesktopServiceIndex]
 	dynamicWindowsDesktops           *collection[types.DynamicWindowsDesktop, dynamicWindowsDesktopIndex]
@@ -252,6 +254,14 @@ func setupCollections(c Config) (*collections, error) {
 
 			out.kubeClusters = collect
 			out.byKind[resourceKind] = out.kubeClusters
+		case types.KindKubeWaitingContainer:
+			collect, err := newKubernetesWaitingContainerCollection(c.KubeWaitingContainers, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out.kubeWaitingContainers = collect
+			out.byKind[resourceKind] = out.kubeWaitingContainers
 		case types.KindWindowsDesktop:
 			collect, err := newWindowsDesktopCollection(c.WindowsDesktops, watch)
 			if err != nil {

--- a/lib/cache/database_test.go
+++ b/lib/cache/database_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	dbobjectv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobject/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
 )
@@ -198,4 +199,55 @@ func TestDatabaseServers(t *testing.T) {
 		})
 	})
 
+}
+
+func TestDatabaseObjects(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	testResources153(t, p, testFuncs153[*dbobjectv1.DatabaseObject]{
+		newResource: func(name string) (*dbobjectv1.DatabaseObject, error) {
+			return newDatabaseObject(t, name), nil
+		},
+		create: func(ctx context.Context, item *dbobjectv1.DatabaseObject) error {
+			_, err := p.databaseObjects.CreateDatabaseObject(ctx, item)
+			return trace.Wrap(err)
+		},
+		list: func(ctx context.Context) ([]*dbobjectv1.DatabaseObject, error) {
+			items, _, err := p.databaseObjects.ListDatabaseObjects(ctx, 0, "")
+			return items, trace.Wrap(err)
+		},
+		cacheList: func(ctx context.Context) ([]*dbobjectv1.DatabaseObject, error) {
+			items, _, err := p.databaseObjects.ListDatabaseObjects(ctx, 0, "")
+			return items, trace.Wrap(err)
+		},
+		deleteAll: func(ctx context.Context) error {
+			token := ""
+			var objects []*dbobjectv1.DatabaseObject
+
+			for {
+				resp, nextToken, err := p.databaseObjects.ListDatabaseObjects(ctx, 0, token)
+				if err != nil {
+					return err
+				}
+
+				objects = append(objects, resp...)
+
+				if nextToken == "" {
+					break
+				}
+				token = nextToken
+			}
+
+			for _, object := range objects {
+				err := p.databaseObjects.DeleteDatabaseObject(ctx, object.GetMetadata().GetName())
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	})
 }

--- a/lib/cache/git_server.go
+++ b/lib/cache/git_server.go
@@ -29,6 +29,49 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 )
 
+type gitServerIndex string
+
+const gitServerNameIndex gitServerIndex = "name"
+
+func newGitServerCollection(upstream services.GitServerGetter, w types.WatchKind) (*collection[types.Server, gitServerIndex], error) {
+	if upstream == nil {
+		return nil, trace.BadParameter("missing parameter GitServerGetter")
+	}
+
+	return &collection[types.Server, gitServerIndex]{
+		store: newStore(map[gitServerIndex]func(types.Server) string{
+			gitServerNameIndex: func(u types.Server) string {
+				return u.GetName()
+			},
+		}),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.Server, error) {
+			var all []types.Server
+			var nextToken string
+			for {
+				page, nextToken, err := upstream.ListGitServers(ctx, apidefaults.DefaultChunkSize, nextToken)
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+				all = append(all, page...)
+				if nextToken == "" {
+					break
+				}
+			}
+			return all, nil
+		},
+		headerTransform: func(hdr *types.ResourceHeader) types.Server {
+			return &types.ServerV2{
+				Kind:    hdr.Kind,
+				Version: hdr.Version,
+				Metadata: types.Metadata{
+					Name: hdr.Metadata.Name,
+				},
+			}
+		},
+		watch: w,
+	}, nil
+}
+
 // GitServerReadOnlyClient returns the read-only client for Git servers.
 //
 // Note that Cache implements GitServerReadOnlyClient to satisfy
@@ -42,64 +85,31 @@ func (c *Cache) GetGitServer(ctx context.Context, name string) (types.Server, er
 	ctx, span := c.Tracer.Start(ctx, "cache/GetGitServer")
 	defer span.End()
 
-	rg, err := readLegacyCollectionCache(c, c.legacyCacheCollections.gitServers)
-	if err != nil {
-		return nil, trace.Wrap(err)
+	getter := genericGetter[types.Server, gitServerIndex]{
+		cache:       c,
+		collection:  c.collections.gitServers,
+		index:       gitServerNameIndex,
+		upstreamGet: c.Config.GitServers.GetGitServer,
+		clone:       types.Server.DeepCopy,
 	}
-	defer rg.Release()
-	return rg.reader.GetGitServer(ctx, name)
+	out, err := getter.get(ctx, name)
+	return out, trace.Wrap(err)
 }
 
 func (c *Cache) ListGitServers(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/ListGitServers")
 	defer span.End()
 
-	rg, err := readLegacyCollectionCache(c, c.legacyCacheCollections.gitServers)
-	if err != nil {
-		return nil, "", trace.Wrap(err)
+	lister := genericLister[types.Server, gitServerIndex]{
+		cache:        c,
+		collection:   c.collections.gitServers,
+		index:        gitServerNameIndex,
+		upstreamList: c.Config.GitServers.ListGitServers,
+		nextToken: func(t types.Server) string {
+			return t.GetMetadata().Name
+		},
+		clone: types.Server.DeepCopy,
 	}
-	defer rg.Release()
-	return rg.reader.ListGitServers(ctx, pageSize, pageToken)
+	out, next, err := lister.list(ctx, pageSize, pageToken)
+	return out, next, trace.Wrap(err)
 }
-
-type gitServerExecutor struct{}
-
-func (gitServerExecutor) getAll(ctx context.Context, cache *Cache, loadSecrets bool) (all []types.Server, err error) {
-	var page []types.Server
-	var nextToken string
-	for {
-		page, nextToken, err = cache.GitServers.ListGitServers(ctx, apidefaults.DefaultChunkSize, nextToken)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		all = append(all, page...)
-		if nextToken == "" {
-			break
-		}
-	}
-	return all, nil
-}
-
-func (gitServerExecutor) upsert(ctx context.Context, cache *Cache, resource types.Server) error {
-	_, err := cache.gitServersCache.UpsertGitServer(ctx, resource)
-	return trace.Wrap(err)
-}
-
-func (gitServerExecutor) deleteAll(ctx context.Context, cache *Cache) error {
-	return cache.gitServersCache.DeleteAllGitServers(ctx)
-}
-
-func (gitServerExecutor) delete(ctx context.Context, cache *Cache, resource types.Resource) error {
-	return cache.gitServersCache.DeleteGitServer(ctx, resource.GetName())
-}
-
-func (gitServerExecutor) isSingleton() bool { return false }
-
-func (gitServerExecutor) getReader(cache *Cache, cacheOK bool) services.GitServerGetter {
-	if cacheOK {
-		return cache.gitServersCache
-	}
-	return cache.Config.GitServers
-}
-
-var _ executor[types.Server, services.GitServerGetter] = gitServerExecutor{}

--- a/lib/cache/legacy_collections.go
+++ b/lib/cache/legacy_collections.go
@@ -103,6 +103,7 @@ type legacyCollections struct {
 	networkRestrictions                collectionReader[networkRestrictionGetter]
 	provisioningStates                 collectionReader[provisioningStateGetter]
 	identityCenterPrincipalAssignments collectionReader[identityCenterPrincipalAssignmentGetter]
+	pluginStaticCredentials            collectionReader[pluginStaticCredentialsGetter]
 	gitServers                         collectionReader[services.GitServerGetter]
 }
 
@@ -195,19 +196,6 @@ func setupLegacyCollections(c *Cache, watches []types.WatchKind) (*legacyCollect
 				watch: watch,
 			}
 			collections.byKind[resourceKind] = collections.identityCenterPrincipalAssignments
-		case types.KindGitServer:
-			if c.GitServers == nil {
-				return nil, trace.BadParameter("missing parameter GitServers")
-			}
-			collections.gitServers = &genericCollection[
-				types.Server,
-				services.GitServerGetter,
-				gitServerExecutor,
-			]{
-				cache: c,
-				watch: watch,
-			}
-			collections.byKind[resourceKind] = collections.gitServers
 		default:
 			if _, ok := c.collections.byKind[resourceKind]; !ok {
 				return nil, trace.BadParameter("resource %q is not supported", watch.Kind)

--- a/lib/cache/legacy_collections.go
+++ b/lib/cache/legacy_collections.go
@@ -34,7 +34,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	"github.com/gravitational/teleport/api/types/secreports"
-	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -101,8 +100,6 @@ type legacyCollections struct {
 	networkRestrictions                collectionReader[networkRestrictionGetter]
 	provisioningStates                 collectionReader[provisioningStateGetter]
 	identityCenterPrincipalAssignments collectionReader[identityCenterPrincipalAssignmentGetter]
-	pluginStaticCredentials            collectionReader[pluginStaticCredentialsGetter]
-	gitServers                         collectionReader[services.GitServerGetter]
 }
 
 // setupLegacyCollections returns a registry of legacyCollections.

--- a/lib/cache/node.go
+++ b/lib/cache/node.go
@@ -29,7 +29,7 @@ import (
 
 type nodeIndex string
 
-const nodeNameIndex = "name"
+const nodeNameIndex nodeIndex = "name"
 
 func newNodeCollection(p services.Presence, w types.WatchKind) (*collection[types.Server, nodeIndex], error) {
 	if p == nil {

--- a/lib/cache/windows_desktop_test.go
+++ b/lib/cache/windows_desktop_test.go
@@ -124,3 +124,39 @@ func TestWindowsDesktopService(t *testing.T) {
 		})
 	})
 }
+
+func TestDynamicWindowsDesktop(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	testResources(t, p, testFuncs[types.DynamicWindowsDesktop]{
+		newResource: func(name string) (types.DynamicWindowsDesktop, error) {
+			return types.NewDynamicWindowsDesktopV1(name,
+				nil,
+				types.DynamicWindowsDesktopSpecV1{
+					Addr: "localhost:123",
+				},
+			)
+		},
+		create: func(ctx context.Context, dwd types.DynamicWindowsDesktop) error {
+			_, err := p.dynamicWindowsDesktops.CreateDynamicWindowsDesktop(ctx, dwd)
+			return err
+		},
+		list: func(ctx context.Context) ([]types.DynamicWindowsDesktop, error) {
+			desktops, _, err := p.dynamicWindowsDesktops.ListDynamicWindowsDesktops(ctx, 0, "")
+			return desktops, err
+		},
+		cacheGet: p.cache.GetDynamicWindowsDesktop,
+		cacheList: func(ctx context.Context) ([]types.DynamicWindowsDesktop, error) {
+			desktops, _, err := p.cache.ListDynamicWindowsDesktops(ctx, 0, "")
+			return desktops, err
+		},
+		update: func(ctx context.Context, dwd types.DynamicWindowsDesktop) error {
+			_, err := p.dynamicWindowsDesktops.UpdateDynamicWindowsDesktop(ctx, dwd)
+			return err
+		},
+		deleteAll: p.dynamicWindowsDesktops.DeleteAllDynamicWindowsDesktops,
+	})
+}


### PR DESCRIPTION
Moves dynamic windows desktops, kubernetes waiting containers, git servers, and database objects to the new cache collection scheme that was introduced in https://github.com/gravitational/teleport/pull/52210. No additional functionality changes have been made here. This should be a purely mechanical translation to the new internal caching machinery.