### PR TITLE
Convert installers, web tokens and ui config to new cache collections

### DIFF
--- a/api/types/installer.go
+++ b/api/types/installer.go
@@ -20,6 +20,8 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/utils"
 )
 
 // Installer is an installer script resource
@@ -32,6 +34,9 @@ type Installer interface {
 	SetScript(string)
 
 	String() string
+
+	// Clone returns a copy of the installer.
+	Clone() Installer
 }
 
 // NewInstallerV1 returns a new installer resource
@@ -59,6 +64,11 @@ func MustNewInstallerV1(name, script string) *InstallerV1 {
 		panic(err)
 	}
 	return inst
+}
+
+// Clone returns a copy of the installer.
+func (c *InstallerV1) Clone() Installer {
+	return utils.CloneProtoMsg(c)
 }
 
 // CheckAndSetDefaults implements Installer

--- a/api/types/session.go
+++ b/api/types/session.go
@@ -522,9 +522,17 @@ type WebToken interface {
 	SetUser(user string)
 	// String returns the text representation of this token
 	String() string
+	// Clone returns a copy of the token.
+	Clone() WebToken
 }
 
 var _ WebToken = &WebTokenV3{}
+
+// Clone returns a copy of the token.
+// GetMetadata returns the token metadata
+func (r *WebTokenV3) Clone() WebToken {
+	return utils.CloneProtoMsg(r)
+}
 
 // GetMetadata returns the token metadata
 func (r *WebTokenV3) GetMetadata() Metadata {

--- a/api/types/ui_config.go
+++ b/api/types/ui_config.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/api/utils"
 )
 
 // UIConfig defines configuration for the web UI served
@@ -37,6 +38,8 @@ type UIConfig interface {
 	SetScrollbackLines(int32)
 
 	String() string
+	// Clone returns a copy of the config.
+	Clone() UIConfig
 }
 
 func NewUIConfigV1() (*UIConfigV1, error) {
@@ -68,6 +71,11 @@ func (c *UIConfigV1) CheckAndSetDefaults() error {
 		return trace.BadParameter("show resources %q not supported", c.Spec.ShowResources)
 	}
 	return nil
+}
+
+// Clone returns a copy of the config.
+func (c *UIConfigV1) Clone() UIConfig {
+	return utils.CloneProtoMsg(c)
 }
 
 // GetVersion returns resource version.

--- a/lib/cache/cert_authority_test.go
+++ b/lib/cache/cert_authority_test.go
@@ -94,7 +94,6 @@ func TestNodeCAFiltering(t *testing.T) {
 		DynamicAccess:           p.cache.dynamicAccessCache,
 		Presence:                p.cache.presenceCache,
 		Restrictions:            p.cache.restrictionsCache,
-		WebToken:                p.cache.webTokenCache,
 		DynamicWindowsDesktops:  p.cache.dynamicWindowsDesktopsCache,
 		SAMLIdPServiceProviders: p.samlIDPServiceProviders,
 		UserGroups:              p.userGroups,

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -107,6 +107,9 @@ type collections struct {
 	integrations                     *collection[types.Integration, integrationIndex]
 	pluginStaticCredentials          *collection[types.PluginStaticCredentials, pluginStaticCredentialsIndex]
 	accessMonitoringRules            *collection[*accessmonitoringrulesv1.AccessMonitoringRule, accessMonitoringRuleIndex]
+	webTokens                        *collection[types.WebToken, webTokenIndex]
+	uiConfigs                        *collection[types.UIConfig, webUIConfigIndex]
+	installers                       *collection[types.Installer, installerIndex]
 }
 
 // setupCollections ensures that the appropriate [collection] is
@@ -516,6 +519,30 @@ func setupCollections(c Config) (*collections, error) {
 
 			out.accessMonitoringRules = collect
 			out.byKind[resourceKind] = out.accessMonitoringRules
+		case types.KindUIConfig:
+			collect, err := newWebUIConfigCollection(c.ClusterConfig, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out.uiConfigs = collect
+			out.byKind[resourceKind] = out.uiConfigs
+		case types.KindWebToken:
+			collect, err := newWebTokenCollection(c.WebToken, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out.webTokens = collect
+			out.byKind[resourceKind] = out.webTokens
+		case types.KindInstaller:
+			collect, err := newInstallerCollection(c.ClusterConfig, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out.installers = collect
+			out.byKind[resourceKind] = out.installers
 		}
 	}
 

--- a/lib/cache/installer.go
+++ b/lib/cache/installer.go
@@ -1,0 +1,96 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+type installerIndex string
+
+const installerNameIndex installerIndex = "name"
+
+func newInstallerCollection(upstream services.ClusterConfiguration, w types.WatchKind) (*collection[types.Installer, installerIndex], error) {
+	if upstream == nil {
+		return nil, trace.BadParameter("missing parameter ClusterConfiguration")
+	}
+
+	return &collection[types.Installer, installerIndex]{
+		store: newStore(map[installerIndex]func(types.Installer) string{
+			installerNameIndex: types.Installer.GetName,
+		}),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.Installer, error) {
+			installers, err := upstream.GetInstallers(ctx)
+			return installers, trace.Wrap(err)
+		},
+		headerTransform: func(hdr *types.ResourceHeader) types.Installer {
+			return &types.InstallerV1{
+				Kind:    hdr.Kind,
+				Version: hdr.Version,
+				Metadata: types.Metadata{
+					Name: hdr.Metadata.Name,
+				},
+			}
+		},
+		watch: w,
+	}, nil
+}
+
+// GetInstaller gets the installer script resource for the cluster
+func (c *Cache) GetInstaller(ctx context.Context, name string) (types.Installer, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetInstaller")
+	defer span.End()
+
+	getter := genericGetter[types.Installer, installerIndex]{
+		cache:       c,
+		collection:  c.collections.installers,
+		index:       installerNameIndex,
+		upstreamGet: c.Config.ClusterConfig.GetInstaller,
+		clone:       types.Installer.Clone,
+	}
+	out, err := getter.get(ctx, name)
+	return out, trace.Wrap(err)
+}
+
+// GetInstallers gets all the installer script resources for the cluster
+func (c *Cache) GetInstallers(ctx context.Context) ([]types.Installer, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetInstallers")
+	defer span.End()
+
+	rg, err := acquireReadGuard(c, c.collections.installers)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+
+	if !rg.ReadCache() {
+		users, err := c.Config.ClusterConfig.GetInstallers(ctx)
+		return users, trace.Wrap(err)
+	}
+
+	installers := make([]types.Installer, 0, rg.store.len())
+	for i := range rg.store.resources(installerNameIndex, "", "") {
+		installers = append(installers, i.Clone())
+	}
+
+	return installers, nil
+}

--- a/lib/cache/installer_test.go
+++ b/lib/cache/installer_test.go
@@ -1,0 +1,47 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+func TestInstallers(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForProxy)
+	t.Cleanup(p.Close)
+
+	testResources(t, p, testFuncs[types.Installer]{
+		newResource: func(name string) (types.Installer, error) {
+			return types.NewInstallerV1("test", "test.sh")
+		},
+		create: p.clusterConfigS.SetInstaller,
+		list: func(ctx context.Context) ([]types.Installer, error) {
+			return p.clusterConfigS.GetInstallers(ctx)
+		},
+		cacheList: func(ctx context.Context) ([]types.Installer, error) {
+			return p.cache.GetInstallers(ctx)
+		},
+		deleteAll: func(ctx context.Context) error {
+			return p.clusterConfigS.DeleteAllInstallers(ctx)
+		},
+	})
+}

--- a/lib/cache/web_tokens.go
+++ b/lib/cache/web_tokens.go
@@ -1,0 +1,97 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+type webTokenIndex string
+
+const webTokenNameIndex webTokenIndex = "name"
+
+func newWebTokenCollection(upstream types.WebTokenInterface, w types.WatchKind) (*collection[types.WebToken, webTokenIndex], error) {
+	if upstream == nil {
+		return nil, trace.BadParameter("missing parameter WebTokenInterface")
+	}
+
+	return &collection[types.WebToken, webTokenIndex]{
+		store: newStore(map[webTokenIndex]func(types.WebToken) string{
+			webTokenNameIndex: types.WebToken.GetName,
+		}),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.WebToken, error) {
+			installers, err := upstream.List(ctx)
+			return installers, trace.Wrap(err)
+		},
+		headerTransform: func(hdr *types.ResourceHeader) types.WebToken {
+			return &types.WebTokenV3{
+				Kind:    hdr.Kind,
+				Version: hdr.Version,
+				Metadata: types.Metadata{
+					Name: hdr.Metadata.Name,
+				},
+			}
+		},
+		watch: w,
+	}, nil
+}
+
+// GetWebToken gets a web token.
+func (c *Cache) GetWebToken(ctx context.Context, req types.GetWebTokenRequest) (types.WebToken, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetWebToken")
+	defer span.End()
+
+	getter := genericGetter[types.WebToken, webTokenIndex]{
+		cache:      c,
+		collection: c.collections.webTokens,
+		index:      webTokenNameIndex,
+		upstreamGet: func(ctx context.Context, s string) (types.WebToken, error) {
+			token, err := c.Config.WebToken.Get(ctx, req)
+			return token, trace.Wrap(err)
+		},
+		clone: types.WebToken.Clone,
+	}
+	out, err := getter.get(ctx, req.Token)
+	return out, trace.Wrap(err)
+}
+
+func (c *Cache) GetWebTokens(ctx context.Context) ([]types.WebToken, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetInstallers")
+	defer span.End()
+
+	rg, err := acquireReadGuard(c, c.collections.webTokens)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+
+	if !rg.ReadCache() {
+		users, err := c.Config.WebToken.List(ctx)
+		return users, trace.Wrap(err)
+	}
+
+	tokens := make([]types.WebToken, 0, rg.store.len())
+	for token := range rg.store.resources(webTokenNameIndex, "", "") {
+		tokens = append(tokens, token.Clone())
+	}
+
+	return tokens, nil
+}

--- a/lib/cache/web_tokens_test.go
+++ b/lib/cache/web_tokens_test.go
@@ -1,0 +1,44 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+func TestWebTokens(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForProxy)
+	t.Cleanup(p.Close)
+
+	testResources(t, p, testFuncs[types.WebToken]{
+		newResource: func(name string) (types.WebToken, error) {
+			return types.NewWebToken(time.Now().Add(time.Hour), types.WebTokenSpecV3{
+				Token: "test",
+				User:  "llama",
+			})
+		},
+		create:    p.webTokenS.Upsert,
+		list:      p.webTokenS.List,
+		cacheList: p.cache.GetWebTokens,
+		deleteAll: p.webTokenS.DeleteAll,
+	})
+}

--- a/lib/cache/web_ui_config.go
+++ b/lib/cache/web_ui_config.go
@@ -1,0 +1,79 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+type webUIConfigIndex string
+
+const webUIConfigNameIndex webUIConfigIndex = "name"
+
+func newWebUIConfigCollection(upstream services.ClusterConfiguration, w types.WatchKind) (*collection[types.UIConfig, webUIConfigIndex], error) {
+	if upstream == nil {
+		return nil, trace.BadParameter("missing parameter ClusterConfiguration")
+	}
+
+	return &collection[types.UIConfig, webUIConfigIndex]{
+		store: newStore(map[webUIConfigIndex]func(types.UIConfig) string{
+			webUIConfigNameIndex: types.UIConfig.GetName,
+		}),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.UIConfig, error) {
+			uiConfig, err := upstream.GetUIConfig(ctx)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			return []types.UIConfig{uiConfig}, nil
+		},
+		headerTransform: func(hdr *types.ResourceHeader) types.UIConfig {
+			return &types.UIConfigV1{
+				ResourceHeader: types.ResourceHeader{
+					Kind:    hdr.Kind,
+					Version: hdr.Version,
+					Metadata: types.Metadata{
+						Name: hdr.Metadata.Name,
+					},
+				},
+			}
+		},
+		watch: w,
+	}, nil
+}
+
+func (c *Cache) GetUIConfig(ctx context.Context) (types.UIConfig, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetUIConfig")
+	defer span.End()
+
+	getter := genericGetter[types.UIConfig, webUIConfigIndex]{
+		cache:      c,
+		collection: c.collections.uiConfigs,
+		index:      webUIConfigNameIndex,
+		upstreamGet: func(ctx context.Context, s string) (types.UIConfig, error) {
+			cfg, err := c.Config.ClusterConfig.GetUIConfig(ctx)
+			return cfg, trace.Wrap(err)
+		},
+		clone: types.UIConfig.Clone,
+	}
+	out, err := getter.get(ctx, types.MetaNameUIConfig)
+	return out, trace.Wrap(err)
+}

--- a/lib/cache/web_ui_config_test.go
+++ b/lib/cache/web_ui_config_test.go
@@ -1,0 +1,66 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+func TestWebUIConfig(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForProxy)
+	t.Cleanup(p.Close)
+
+	testResources(t, p, testFuncs[types.UIConfig]{
+		newResource: func(name string) (types.UIConfig, error) {
+			return &types.UIConfigV1{
+				ResourceHeader: types.ResourceHeader{
+					Metadata: types.Metadata{
+						Name: types.MetaNameUIConfig,
+					},
+				},
+			}, nil
+		},
+		create: p.clusterConfigS.SetUIConfig,
+		list: func(ctx context.Context) ([]types.UIConfig, error) {
+			cfg, err := p.clusterConfigS.GetUIConfig(ctx)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			return []types.UIConfig{cfg}, nil
+		},
+		cacheList: func(ctx context.Context) ([]types.UIConfig, error) {
+			cfg, err := p.cache.GetUIConfig(ctx)
+			if err != nil {
+				if trace.IsNotFound(err) {
+					return nil, nil
+				}
+				return nil, trace.Wrap(err)
+			}
+
+			return []types.UIConfig{cfg}, nil
+		},
+		deleteAll: p.clusterConfigS.DeleteUIConfig,
+	})
+}


### PR DESCRIPTION
Moves the resources to the new cache collection scheme that was introduced in #52210. No additional functionality changes have been made here. This should be a purely mechanical translation to the new internal caching machinery.