### PR TITLE
Synchronize access to tsh exit status

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -288,10 +288,6 @@ type Config struct {
 	Stderr io.Writer
 	Stdin  io.Reader
 
-	// ExitStatus carries the returned value (exit status) of the remote
-	// process execution (via SSH exec)
-	ExitStatus int
-
 	// SiteName specifies site to execute operation,
 	// if omitted, first available site will be selected
 	SiteName string
@@ -1264,6 +1260,9 @@ type DTAutoEnrollFunc func(context.Context, devicepb.DeviceTrustServiceClient) (
 // TeleportClient is NOT safe for concurrent use.
 type TeleportClient struct {
 	Config
+	exitStatus int
+	statusMu   sync.Mutex
+
 	localAgent *LocalKeyAgent
 
 	// OnChannelRequest gets called when SSH channel requests are
@@ -1328,6 +1327,22 @@ func NewClient(c *Config) (tc *TeleportClient, err error) {
 	}
 
 	return tc, nil
+}
+
+// ExitStatus returns the exit status of the most recent SSH command. It is the
+// caller's responsibility to ensure the command has finished before checking
+// the exit status.
+func (tc *TeleportClient) ExitStatus() int {
+	tc.statusMu.Lock()
+	defer tc.statusMu.Unlock()
+	return tc.exitStatus
+}
+
+// SetExitStatus sets the exit status of the most recent SSH command.
+func (tc *TeleportClient) SetExitStatus(status int) {
+	tc.statusMu.Lock()
+	defer tc.statusMu.Unlock()
+	tc.exitStatus = status
 }
 
 func (tc *TeleportClient) stdin() prompt.StdinReader {
@@ -2175,7 +2190,7 @@ func (tc *TeleportClient) runShellOrCommandOnSingleNode(ctx context.Context, clt
 		tc.Config.HostLogin,
 	)
 	if err != nil {
-		tc.ExitStatus = 1
+		tc.SetExitStatus(1)
 		return trace.Wrap(err)
 	}
 	defer nodeClient.Close()
@@ -2974,7 +2989,7 @@ func (tc *TeleportClient) runCommandOnNodes(ctx context.Context, clt *ClusterCli
 				WithLabeledOutput(width),
 				WithOutput(stdout, stderr),
 			)
-			// Use the status from the error to avoid a race on tc.ExitStatus.
+			// Use the status from the error to avoid a race on the exit status.
 			exitStatus := getExitStatus(err)
 			if err != nil && exitStatus == 0 {
 				fmt.Fprintln(stderr, err)

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -418,9 +418,9 @@ func (c *NodeClient) RunInteractiveShell(ctx context.Context, mode types.Session
 		var exitMissingErr *ssh.ExitMissingError
 		switch err := trace.Unwrap(err); {
 		case errors.As(err, &exitErr):
-			c.TC.ExitStatus = exitErr.ExitStatus()
+			c.TC.SetExitStatus(exitErr.ExitStatus())
 		case errors.As(err, &exitMissingErr):
-			c.TC.ExitStatus = 1
+			c.TC.SetExitStatus(1)
 		}
 
 		return trace.Wrap(err)
@@ -615,7 +615,9 @@ func (c *NodeClient) RunCommand(ctx context.Context, command []string, opts ...R
 	}
 	defer nodeSession.Close()
 	err = nodeSession.runCommand(ctx, types.SessionPeerMode, command, c.TC.OnChannelRequest, c.TC.OnShellCreated, c.TC.Config.InteractiveCommand)
-	c.TC.ExitStatus = getExitStatus(err)
+	if err != nil {
+		c.TC.SetExitStatus(getExitStatus(err))
+	}
 	return trace.Wrap(err)
 }
 

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -3772,7 +3772,7 @@ func retryWithAccessRequest(
 
 	// Retry now that request has been approved and certs updated.
 	// Clear the original exit status.
-	tc.ExitStatus = 0
+	tc.SetExitStatus(0)
 	return trace.Wrap(fn())
 }
 
@@ -3875,7 +3875,7 @@ func onSSHLatency(cf *CLIConf) error {
 		tc.Config.HostLogin,
 	)
 	if err != nil {
-		tc.ExitStatus = 1
+		tc.SetExitStatus(1)
 		return trace.Wrap(err)
 	}
 	defer nodeClient.Close()
@@ -4091,7 +4091,7 @@ func onSSH(cf *CLIConf) error {
 }
 
 func convertSSHExitCode(tc *client.TeleportClient, err error) error {
-	if tc.ExitStatus != 0 {
+	if status := tc.ExitStatus(); status != 0 {
 		var exitErr *common.ExitCodeError
 		if errors.As(err, &exitErr) {
 			// Already have an exitCodeError, return that.
@@ -4101,7 +4101,7 @@ func convertSSHExitCode(tc *client.TeleportClient, err error) error {
 			// Print the error here so we don't lose it when returning the exitCodeError.
 			fmt.Fprintln(tc.Stderr, utils.UserMessageFromError(err))
 		}
-		err = &common.ExitCodeError{Code: tc.ExitStatus}
+		err = &common.ExitCodeError{Code: status}
 		return trace.Wrap(err)
 	}
 	return trace.Wrap(err)


### PR DESCRIPTION
This change synchronizes access to the exit status in the Teleport client. It also reverts a RunCommand change in #54423 to only set the exit status on error.

Fixes #21089.