### PR TITLE
Clean up cache collections

### DIFF
--- a/api/types/desktop.go
+++ b/api/types/desktop.go
@@ -150,7 +150,7 @@ type DynamicWindowsDesktop interface {
 	// use the size passed by the client over TDP.
 	GetScreenSize() (width, height uint32)
 	// Copy returns a copy of this dynamic Windows desktop
-	Copy() *DynamicWindowsDesktopV1
+	Copy() DynamicWindowsDesktop
 }
 
 var _ DynamicWindowsDesktop = &DynamicWindowsDesktopV1{}
@@ -225,7 +225,7 @@ func (d *DynamicWindowsDesktopV1) MatchSearch(values []string) bool {
 }
 
 // Copy returns a deep copy of this dynamic Windows desktop object.
-func (d *DynamicWindowsDesktopV1) Copy() *DynamicWindowsDesktopV1 {
+func (d *DynamicWindowsDesktopV1) Copy() DynamicWindowsDesktop {
 	return utils.CloneProtoMsg(d)
 }
 
@@ -320,7 +320,7 @@ type WindowsDesktop interface {
 	// use the size passed by the client over TDP.
 	GetScreenSize() (width, height uint32)
 	// Copy returns a copy of this windows desktop
-	Copy() *WindowsDesktopV3
+	Copy() WindowsDesktop
 	// CloneResource returns a copy of the WindowDesktop as a ResourceWithLabels
 	CloneResource() ResourceWithLabels
 }
@@ -402,7 +402,7 @@ func (d *WindowsDesktopV3) MatchSearch(values []string) bool {
 }
 
 // Copy returns a copy of this windows desktop object.
-func (d *WindowsDesktopV3) Copy() *WindowsDesktopV3 {
+func (d *WindowsDesktopV3) Copy() WindowsDesktop {
 	return utils.CloneProtoMsg(d)
 }
 

--- a/api/types/kubernetes.go
+++ b/api/types/kubernetes.go
@@ -74,7 +74,7 @@ type KubeCluster interface {
 	// IsKubeconfig identifies if the KubeCluster contains kubeconfig data.
 	IsKubeconfig() bool
 	// Copy returns a copy of this kube cluster resource.
-	Copy() *KubernetesClusterV3
+	Copy() KubeCluster
 	// GetCloud gets the cloud this kube cluster is running on, or an empty string if it
 	// isn't running on a cloud provider.
 	GetCloud() string
@@ -119,9 +119,9 @@ func NewKubernetesClusterV3WithoutSecrets(cluster KubeCluster) (*KubernetesClust
 	// Force a copy of the cluster to deep copy the Metadata fields.
 	copiedCluster := cluster.Copy()
 	clusterWithoutCreds, err := NewKubernetesClusterV3(
-		copiedCluster.Metadata,
+		copiedCluster.GetMetadata(),
 		KubernetesClusterSpecV3{
-			DynamicLabels: copiedCluster.Spec.DynamicLabels,
+			DynamicLabels: LabelsToV2(copiedCluster.GetDynamicLabels()),
 		},
 	)
 	return clusterWithoutCreds, trace.Wrap(err)
@@ -337,7 +337,7 @@ func (k *KubernetesClusterV3) String() string {
 }
 
 // Copy returns a copy of this resource.
-func (k *KubernetesClusterV3) Copy() *KubernetesClusterV3 {
+func (k *KubernetesClusterV3) Copy() KubeCluster {
 	return utils.CloneProtoMsg(k)
 }
 

--- a/lib/cache/access_list.go
+++ b/lib/cache/access_list.go
@@ -39,11 +39,13 @@ func newAccessListCollection(upstream services.AccessLists, w types.WatchKind) (
 	}
 
 	return &collection[*accesslist.AccessList, accessListIndex]{
-		store: newStore(map[accessListIndex]func(*accesslist.AccessList) string{
-			accessListNameIndex: func(al *accesslist.AccessList) string {
-				return al.GetMetadata().Name
-			},
-		}),
+		store: newStore(
+			(*accesslist.AccessList).Clone,
+			map[accessListIndex]func(*accesslist.AccessList) string{
+				accessListNameIndex: func(al *accesslist.AccessList) string {
+					return al.GetMetadata().Name
+				},
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*accesslist.AccessList, error) {
 			var resources []*accesslist.AccessList
 			var nextToken string
@@ -115,9 +117,6 @@ func (c *Cache) ListAccessLists(ctx context.Context, pageSize int, pageToken str
 		nextToken: func(t *accesslist.AccessList) string {
 			return t.GetMetadata().Name
 		},
-		clone: func(al *accesslist.AccessList) *accesslist.AccessList {
-			return al.Clone()
-		},
 	}
 	out, next, err := lister.list(ctx, pageSize, pageToken)
 	return out, next, trace.Wrap(err)
@@ -136,9 +135,6 @@ func (c *Cache) GetAccessList(ctx context.Context, name string) (*accesslist.Acc
 		upstreamGet: func(ctx context.Context, s string) (*accesslist.AccessList, error) {
 			upstreamRead = true
 			return c.Config.AccessLists.GetAccessList(ctx, s)
-		},
-		clone: func(al *accesslist.AccessList) *accesslist.AccessList {
-			return al.Clone()
 		},
 	}
 	out, err := getter.get(ctx, name)
@@ -165,14 +161,16 @@ func newAccessListMemberCollection(upstream services.AccessLists, w types.WatchK
 	}
 
 	return &collection[*accesslist.AccessListMember, accessListMemberIndex]{
-		store: newStore(map[accessListMemberIndex]func(*accesslist.AccessListMember) string{
-			accessListMemberNameIndex: func(r *accesslist.AccessListMember) string {
-				return r.Spec.AccessList + "/" + r.GetName()
-			},
-			accessListMemberKindIndex: func(r *accesslist.AccessListMember) string {
-				return r.Spec.AccessList + "/" + r.Spec.MembershipKind + "/" + r.GetName()
-			},
-		}),
+		store: newStore(
+			(*accesslist.AccessListMember).Clone,
+			map[accessListMemberIndex]func(*accesslist.AccessListMember) string{
+				accessListMemberNameIndex: func(r *accesslist.AccessListMember) string {
+					return r.Spec.AccessList + "/" + r.GetName()
+				},
+				accessListMemberKindIndex: func(r *accesslist.AccessListMember) string {
+					return r.Spec.AccessList + "/" + r.Spec.MembershipKind + "/" + r.GetName()
+				},
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*accesslist.AccessListMember, error) {
 			var resources []*accesslist.AccessListMember
 			var nextToken string
@@ -288,9 +286,6 @@ func (c *Cache) ListAllAccessListMembers(ctx context.Context, pageSize int, page
 		nextToken: func(t *accesslist.AccessListMember) string {
 			return t.GetMetadata().Name
 		},
-		clone: func(al *accesslist.AccessListMember) *accesslist.AccessListMember {
-			return al.Clone()
-		},
 	}
 	out, next, err := lister.list(ctx, pageSize, nextToken)
 	return out, next, trace.Wrap(err)
@@ -332,11 +327,13 @@ func newAccessListReviewCollection(upstream services.AccessLists, w types.WatchK
 	}
 
 	return &collection[*accesslist.Review, accessListReviewIndex]{
-		store: newStore(map[accessListReviewIndex]func(*accesslist.Review) string{
-			accessListReviewNameIndex: func(r *accesslist.Review) string {
-				return r.Spec.AccessList + "/" + r.GetName()
-			},
-		}),
+		store: newStore(
+			(*accesslist.Review).Clone,
+			map[accessListReviewIndex]func(*accesslist.Review) string{
+				accessListReviewNameIndex: func(r *accesslist.Review) string {
+					return r.Spec.AccessList + "/" + r.GetName()
+				},
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*accesslist.Review, error) {
 			var resources []*accesslist.Review
 			var nextToken string
@@ -390,9 +387,6 @@ func (c *Cache) ListAccessListReviews(ctx context.Context, accessList string, pa
 		},
 		nextToken: func(t *accesslist.Review) string {
 			return t.GetName()
-		},
-		clone: func(r *accesslist.Review) *accesslist.Review {
-			return r.Clone()
 		},
 	}
 

--- a/lib/cache/access_monitoring_rule.go
+++ b/lib/cache/access_monitoring_rule.go
@@ -20,11 +20,11 @@ import (
 	"context"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
 
 	accessmonitoringrulesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessmonitoringrules/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -38,11 +38,13 @@ func newAccessMonitoringRuleCollection(upstream services.AccessMonitoringRules, 
 	}
 
 	return &collection[*accessmonitoringrulesv1.AccessMonitoringRule, accessMonitoringRuleIndex]{
-		store: newStore(map[accessMonitoringRuleIndex]func(*accessmonitoringrulesv1.AccessMonitoringRule) string{
-			accessMonitoringRuleNameIndex: func(r *accessmonitoringrulesv1.AccessMonitoringRule) string {
-				return r.GetMetadata().Name
-			},
-		}),
+		store: newStore(
+			proto.CloneOf[*accessmonitoringrulesv1.AccessMonitoringRule],
+			map[accessMonitoringRuleIndex]func(*accessmonitoringrulesv1.AccessMonitoringRule) string{
+				accessMonitoringRuleNameIndex: func(r *accessmonitoringrulesv1.AccessMonitoringRule) string {
+					return r.GetMetadata().Name
+				},
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*accessmonitoringrulesv1.AccessMonitoringRule, error) {
 			var resources []*accessmonitoringrulesv1.AccessMonitoringRule
 			var nextToken string
@@ -87,7 +89,6 @@ func (c *Cache) ListAccessMonitoringRules(ctx context.Context, pageSize int, pag
 		nextToken: func(t *accessmonitoringrulesv1.AccessMonitoringRule) string {
 			return t.GetMetadata().Name
 		},
-		clone: utils.CloneProtoMsg[*accessmonitoringrulesv1.AccessMonitoringRule],
 	}
 	out, next, err := lister.list(ctx, pageSize, pageToken)
 	return out, next, trace.Wrap(err)
@@ -106,7 +107,6 @@ func (c *Cache) ListAccessMonitoringRulesWithFilter(ctx context.Context, req *ac
 		nextToken: func(t *accessmonitoringrulesv1.AccessMonitoringRule) string {
 			return t.GetMetadata().Name
 		},
-		clone: utils.CloneProtoMsg[*accessmonitoringrulesv1.AccessMonitoringRule],
 		filter: func(rule *accessmonitoringrulesv1.AccessMonitoringRule) bool {
 			return services.MatchAccessMonitoringRule(rule, req.GetSubjects(), req.GetNotificationName(), req.GetAutomaticReviewName())
 		},
@@ -125,7 +125,6 @@ func (c *Cache) GetAccessMonitoringRule(ctx context.Context, name string) (*acce
 		collection:  c.collections.accessMonitoringRules,
 		index:       accessMonitoringRuleNameIndex,
 		upstreamGet: c.Config.AccessMonitoringRules.GetAccessMonitoringRule,
-		clone:       utils.CloneProtoMsg[*accessmonitoringrulesv1.AccessMonitoringRule],
 	}
 	out, err := getter.get(ctx, name)
 	return out, trace.Wrap(err)

--- a/lib/cache/auth_server.go
+++ b/lib/cache/auth_server.go
@@ -34,19 +34,19 @@ func newAuthServerCollection(p services.Presence, w types.WatchKind) (*collectio
 	}
 
 	return &collection[types.Server, authServerIndex]{
-		store: newStore(map[authServerIndex]func(types.Server) string{
-			authServerNameIndex: func(u types.Server) string {
-				return u.GetName()
-			},
-		}),
+		store: newStore(
+			types.Server.DeepCopy,
+			map[authServerIndex]func(types.Server) string{
+				authServerNameIndex: types.Server.GetName,
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.Server, error) {
 			servers, err := p.GetAuthServers()
 			return servers, trace.Wrap(err)
 		},
 		headerTransform: func(hdr *types.ResourceHeader) types.Server {
 			return &types.ServerV2{
-				Kind:    types.KindAuthServer,
-				Version: types.V2,
+				Kind:    hdr.Kind,
+				Version: hdr.Version,
 				Metadata: types.Metadata{
 					Name: hdr.GetName(),
 				},

--- a/lib/cache/auto_update.go
+++ b/lib/cache/auto_update.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
 
 	autoupdatev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
@@ -39,11 +40,13 @@ func newAutoUpdateConfigCollection(upstream services.AutoUpdateServiceGetter, w 
 	}
 
 	return &collection[*autoupdatev1.AutoUpdateConfig, autoUpdateConfigIndex]{
-		store: newStore(map[autoUpdateConfigIndex]func(*autoupdatev1.AutoUpdateConfig) string{
-			autoUpdateConfigNameIndex: func(r *autoupdatev1.AutoUpdateConfig) string {
-				return r.GetMetadata().GetName()
-			},
-		}),
+		store: newStore(
+			proto.CloneOf[*autoupdatev1.AutoUpdateConfig],
+			map[autoUpdateConfigIndex]func(*autoupdatev1.AutoUpdateConfig) string{
+				autoUpdateConfigNameIndex: func(r *autoupdatev1.AutoUpdateConfig) string {
+					return r.GetMetadata().GetName()
+				},
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*autoupdatev1.AutoUpdateConfig, error) {
 			cfg, err := upstream.GetAutoUpdateConfig(ctx)
 			if err != nil {
@@ -88,7 +91,6 @@ func (c *Cache) GetAutoUpdateConfig(ctx context.Context) (*autoupdatev1.AutoUpda
 			}
 			return apiutils.CloneProtoMsg(cachedConfig), nil
 		},
-		clone: apiutils.CloneProtoMsg[*autoupdatev1.AutoUpdateConfig],
 	}
 	out, err := getter.get(ctx, types.MetaNameAutoUpdateConfig)
 	return out, trace.Wrap(err)
@@ -104,11 +106,13 @@ func newAutoUpdateVersionCollection(upstream services.AutoUpdateServiceGetter, w
 	}
 
 	return &collection[*autoupdatev1.AutoUpdateVersion, autoUpdateVersionIndex]{
-		store: newStore(map[autoUpdateVersionIndex]func(*autoupdatev1.AutoUpdateVersion) string{
-			autoUpdateVersionNameIndex: func(r *autoupdatev1.AutoUpdateVersion) string {
-				return r.GetMetadata().GetName()
-			},
-		}),
+		store: newStore(
+			proto.CloneOf[*autoupdatev1.AutoUpdateVersion],
+			map[autoUpdateVersionIndex]func(*autoupdatev1.AutoUpdateVersion) string{
+				autoUpdateVersionNameIndex: func(r *autoupdatev1.AutoUpdateVersion) string {
+					return r.GetMetadata().GetName()
+				},
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*autoupdatev1.AutoUpdateVersion, error) {
 			version, err := upstream.GetAutoUpdateVersion(ctx)
 			if err != nil {
@@ -149,7 +153,6 @@ func (c *Cache) GetAutoUpdateVersion(ctx context.Context) (*autoupdatev1.AutoUpd
 			}
 			return apiutils.CloneProtoMsg(cachedVersion), nil
 		},
-		clone: apiutils.CloneProtoMsg[*autoupdatev1.AutoUpdateVersion],
 	}
 	out, err := getter.get(ctx, types.MetaNameAutoUpdateVersion)
 	return out, trace.Wrap(err)
@@ -165,11 +168,13 @@ func newAutoUpdateRolloutCollection(upstream services.AutoUpdateServiceGetter, w
 	}
 
 	return &collection[*autoupdatev1.AutoUpdateAgentRollout, autoUpdateAgentRolloutIndex]{
-		store: newStore(map[autoUpdateAgentRolloutIndex]func(*autoupdatev1.AutoUpdateAgentRollout) string{
-			autoUpdateAgentRolloutNameIndex: func(r *autoupdatev1.AutoUpdateAgentRollout) string {
-				return r.GetMetadata().GetName()
-			},
-		}),
+		store: newStore(
+			proto.CloneOf[*autoupdatev1.AutoUpdateAgentRollout],
+			map[autoUpdateAgentRolloutIndex]func(*autoupdatev1.AutoUpdateAgentRollout) string{
+				autoUpdateAgentRolloutNameIndex: func(r *autoupdatev1.AutoUpdateAgentRollout) string {
+					return r.GetMetadata().GetName()
+				},
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*autoupdatev1.AutoUpdateAgentRollout, error) {
 			rollout, err := upstream.GetAutoUpdateAgentRollout(ctx)
 			if err != nil {
@@ -210,7 +215,6 @@ func (c *Cache) GetAutoUpdateAgentRollout(ctx context.Context) (*autoupdatev1.Au
 			}
 			return apiutils.CloneProtoMsg(cachedRollout), nil
 		},
-		clone: apiutils.CloneProtoMsg[*autoupdatev1.AutoUpdateAgentRollout],
 	}
 	out, err := getter.get(ctx, types.MetaNameAutoUpdateAgentRollout)
 	return out, trace.Wrap(err)

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -2054,9 +2054,7 @@ func TestPartialHealth(t *testing.T) {
 	require.Equal(t, "cache", resultUser.GetMetadata().Labels["origin"])
 
 	// query cache storage directly to ensure roles haven't been replicated
-	rolesStoredInCache, err := p.cache.accessCache.GetRoles(ctx)
-	require.NoError(t, err)
-	require.Empty(t, rolesStoredInCache)
+	require.Empty(t, p.cache.collections.roles.store.len())
 
 	// non-empty result here proves that it was not served from cache
 	resultRoles, err := p.cache.GetRoles(ctx)

--- a/lib/cache/cert_authority.go
+++ b/lib/cache/cert_authority.go
@@ -40,17 +40,19 @@ func newCertAuthorityCollection(t services.Trust, w types.WatchKind) (*collectio
 	filter.FromMap(w.Filter)
 
 	return &collection[types.CertAuthority, certAuthorityIndex]{
-		store: newStore(map[certAuthorityIndex]func(types.CertAuthority) string{
-			certAuthorityIDIndex: func(ca types.CertAuthority) string {
-				return string(ca.GetType()) + "/" + ca.GetID().DomainName
-			},
-		}),
+		store: newStore(
+			types.CertAuthority.Clone,
+			map[certAuthorityIndex]func(types.CertAuthority) string{
+				certAuthorityIDIndex: func(ca types.CertAuthority) string {
+					return string(ca.GetType()) + "/" + ca.GetID().DomainName
+				},
+			}),
 		watch:  w,
 		filter: filter.Match,
 		headerTransform: func(hdr *types.ResourceHeader) types.CertAuthority {
 			return &types.CertAuthorityV2{
-				Kind:    types.KindCertAuthority,
-				Version: types.V2,
+				Kind:    hdr.Kind,
+				Version: hdr.Version,
 				Metadata: types.Metadata{
 					Name: hdr.Metadata.Name,
 				},

--- a/lib/cache/cert_authority_test.go
+++ b/lib/cache/cert_authority_test.go
@@ -78,7 +78,7 @@ func TestNodeCAFiltering(t *testing.T) {
 		ClusterName: "example.com",
 	})
 	require.NoError(t, err)
-	err = p.cache.clusterConfigCache.UpsertClusterName(clusterName)
+	err = p.clusterConfigS.UpsertClusterName(clusterName)
 	require.NoError(t, err)
 
 	nodeCacheBackend, err := memory.New(memory.Config{})
@@ -88,15 +88,15 @@ func TestNodeCAFiltering(t *testing.T) {
 	// this mimics a cache for a node pulling events from the auth server via WatchEvents
 	nodeCache, err := New(ForNode(Config{
 		Events:                  p.cache,
-		Trust:                   p.cache.trustCache,
-		ClusterConfig:           p.cache.clusterConfigCache,
-		Access:                  p.cache.accessCache,
-		DynamicAccess:           p.cache.dynamicAccessCache,
-		Presence:                p.cache.presenceCache,
+		Trust:                   p.cache.Trust,
+		ClusterConfig:           p.cache.ClusterConfig,
+		Access:                  p.cache.Access,
+		DynamicAccess:           p.cache.DynamicAccess,
+		Presence:                p.cache.Presence,
 		Restrictions:            p.cache.Restrictions,
-		SAMLIdPServiceProviders: p.samlIDPServiceProviders,
-		UserGroups:              p.userGroups,
-		StaticHostUsers:         p.staticHostUsers,
+		SAMLIdPServiceProviders: p.cache.SAMLIdPServiceProviders,
+		UserGroups:              p.cache.UserGroups,
+		StaticHostUsers:         p.cache.StaticHostUsers,
 		Backend:                 nodeCacheBackend,
 	}))
 	require.NoError(t, err)

--- a/lib/cache/cluster_config.go
+++ b/lib/cache/cluster_config.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
 
 	clusterconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
@@ -39,11 +40,11 @@ func newClusterNameCollection(c services.ClusterConfiguration, w types.WatchKind
 	}
 
 	return &collection[types.ClusterName, clusterNameIndex]{
-		store: newStore(map[clusterNameIndex]func(types.ClusterName) string{
-			clusterNameDefaultIndex: func(n types.ClusterName) string {
-				return n.GetName()
-			},
-		}),
+		store: newStore(
+			types.ClusterName.Clone,
+			map[clusterNameIndex]func(types.ClusterName) string{
+				clusterNameDefaultIndex: types.ClusterName.GetName,
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.ClusterName, error) {
 			name, err := c.GetClusterName(ctx)
 			if err != nil {
@@ -101,11 +102,11 @@ func newClusterAuditConfigCollection(c services.ClusterConfiguration, w types.Wa
 	}
 
 	return &collection[types.ClusterAuditConfig, clusterAuditConfigIndex]{
-		store: newStore(map[clusterAuditConfigIndex]func(types.ClusterAuditConfig) string{
-			clusterAuditConfigNameIndex: func(n types.ClusterAuditConfig) string {
-				return n.GetName()
-			},
-		}),
+		store: newStore(
+			types.ClusterAuditConfig.Clone,
+			map[clusterAuditConfigIndex]func(types.ClusterAuditConfig) string{
+				clusterAuditConfigNameIndex: types.ClusterAuditConfig.GetName,
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.ClusterAuditConfig, error) {
 			cfg, err := c.GetClusterAuditConfig(ctx)
 			if err != nil {
@@ -167,11 +168,11 @@ func newClusterNetworkingConfigCollection(c services.ClusterConfiguration, w typ
 	}
 
 	return &collection[types.ClusterNetworkingConfig, clusterNetworkingConfigIndex]{
-		store: newStore(map[clusterNetworkingConfigIndex]func(types.ClusterNetworkingConfig) string{
-			clusterNetworkingConfigNameIndex: func(n types.ClusterNetworkingConfig) string {
-				return n.GetName()
-			},
-		}),
+		store: newStore(
+			types.ClusterNetworkingConfig.Clone,
+			map[clusterNetworkingConfigIndex]func(types.ClusterNetworkingConfig) string{
+				clusterNetworkingConfigNameIndex: types.ClusterNetworkingConfig.GetName,
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.ClusterNetworkingConfig, error) {
 			cfg, err := c.GetClusterNetworkingConfig(ctx)
 			if err != nil {
@@ -229,11 +230,11 @@ func newAuthPreferenceCollection(c services.ClusterConfiguration, w types.WatchK
 	}
 
 	return &collection[types.AuthPreference, authPreferenceIndex]{
-		store: newStore(map[authPreferenceIndex]func(types.AuthPreference) string{
-			authPreferenceNameIndex: func(n types.AuthPreference) string {
-				return n.GetName()
-			},
-		}),
+		store: newStore(
+			types.AuthPreference.Clone,
+			map[authPreferenceIndex]func(types.AuthPreference) string{
+				authPreferenceNameIndex: types.AuthPreference.GetName,
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.AuthPreference, error) {
 			pref, err := c.GetAuthPreference(ctx)
 			if err != nil {
@@ -285,11 +286,11 @@ func newSessionRecordingConfigCollection(c services.ClusterConfiguration, w type
 	}
 
 	return &collection[types.SessionRecordingConfig, sessionRecordingConfigIndex]{
-		store: newStore(map[sessionRecordingConfigIndex]func(types.SessionRecordingConfig) string{
-			sessionRecordingConfigNameIndex: func(n types.SessionRecordingConfig) string {
-				return n.GetName()
-			},
-		}),
+		store: newStore(
+			types.SessionRecordingConfig.Clone,
+			map[sessionRecordingConfigIndex]func(types.SessionRecordingConfig) string{
+				sessionRecordingConfigNameIndex: types.SessionRecordingConfig.GetName,
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.SessionRecordingConfig, error) {
 			cfg, err := c.GetSessionRecordingConfig(ctx)
 			if err != nil {
@@ -341,11 +342,13 @@ func newAccessGraphSettingsCollection(upstream services.ClusterConfiguration, w 
 	}
 
 	return &collection[*clusterconfigv1.AccessGraphSettings, accessGraphSettingsIndex]{
-		store: newStore(map[accessGraphSettingsIndex]func(*clusterconfigv1.AccessGraphSettings) string{
-			accessGraphSettingsNameIndex: func(r *clusterconfigv1.AccessGraphSettings) string {
-				return r.GetMetadata().GetName()
-			},
-		}),
+		store: newStore(
+			proto.CloneOf[*clusterconfigv1.AccessGraphSettings],
+			map[accessGraphSettingsIndex]func(*clusterconfigv1.AccessGraphSettings) string{
+				accessGraphSettingsNameIndex: func(r *clusterconfigv1.AccessGraphSettings) string {
+					return r.GetMetadata().GetName()
+				},
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*clusterconfigv1.AccessGraphSettings, error) {
 			set, err := upstream.GetAccessGraphSettings(ctx)
 			if err != nil {
@@ -387,7 +390,6 @@ func (c *Cache) GetAccessGraphSettings(ctx context.Context) (*clusterconfigv1.Ac
 
 			return apiutils.CloneProtoMsg(cachedCfg), nil
 		},
-		clone: apiutils.CloneProtoMsg[*clusterconfigv1.AccessGraphSettings],
 	}
 	out, err := getter.get(ctx, types.MetaNameAccessGraphSettings)
 	return out, trace.Wrap(err)

--- a/lib/cache/crown_jewel.go
+++ b/lib/cache/crown_jewel.go
@@ -20,11 +20,11 @@ import (
 	"context"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
 
 	crownjewelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/crownjewel/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -38,11 +38,13 @@ func newCrownJewelCollection(upstream services.CrownJewels, w types.WatchKind) (
 	}
 
 	return &collection[*crownjewelv1.CrownJewel, crownJewelIndex]{
-		store: newStore(map[crownJewelIndex]func(*crownjewelv1.CrownJewel) string{
-			crownJewelNameIndex: func(r *crownjewelv1.CrownJewel) string {
-				return r.GetMetadata().GetName()
-			},
-		}),
+		store: newStore(
+			proto.CloneOf[*crownjewelv1.CrownJewel],
+			map[crownJewelIndex]func(*crownjewelv1.CrownJewel) string{
+				crownJewelNameIndex: func(r *crownjewelv1.CrownJewel) string {
+					return r.GetMetadata().GetName()
+				},
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*crownjewelv1.CrownJewel, error) {
 			var out []*crownjewelv1.CrownJewel
 			var nextToken string
@@ -91,7 +93,6 @@ func (c *Cache) ListCrownJewels(ctx context.Context, pageSize int64, pageToken s
 		nextToken: func(t *crownjewelv1.CrownJewel) string {
 			return t.GetMetadata().GetName()
 		},
-		clone: utils.CloneProtoMsg[*crownjewelv1.CrownJewel],
 	}
 	out, next, err := lister.list(ctx, int(pageSize), pageToken)
 	return out, next, trace.Wrap(err)
@@ -107,7 +108,6 @@ func (c *Cache) GetCrownJewel(ctx context.Context, name string) (*crownjewelv1.C
 		collection:  c.collections.crownJewels,
 		index:       crownJewelNameIndex,
 		upstreamGet: c.Config.CrownJewels.GetCrownJewel,
-		clone:       utils.CloneProtoMsg[*crownjewelv1.CrownJewel],
 	}
 	out, err := getter.get(ctx, name)
 	return out, trace.Wrap(err)

--- a/lib/cache/generic_operations.go
+++ b/lib/cache/generic_operations.go
@@ -35,8 +35,6 @@ type genericGetter[T any, I comparable] struct {
 	// upstreamGet is used to retrieve the item if the
 	// cache is not healthy.
 	upstreamGet func(context.Context, string) (T, error)
-	// clone is used to make a copy of the item returned.
-	clone func(T) T
 }
 
 // get retrieves a single item by an identifier from
@@ -60,7 +58,8 @@ func (g genericGetter[T, I]) get(ctx context.Context, identifier string) (T, err
 	if err != nil {
 		return t, trace.Wrap(err)
 	}
-	return g.clone(out), nil
+
+	return g.collection.store.clone(out), nil
 }
 
 // genericLister is a helper to retrieve a page of items from a cache collection.
@@ -81,8 +80,6 @@ type genericLister[T any, I comparable] struct {
 	// nextToken is used to derive the next token returned from
 	// the item at which the next page should start from.
 	nextToken func(T) string
-	// clone is used to make a copy of the item returned.
-	clone func(T) T
 	// filter is an optional function used to exclude items from
 	// cache reads.
 	filter func(T) bool
@@ -121,7 +118,7 @@ func (l genericLister[T, I]) list(ctx context.Context, pageSize int, startToken 
 		if l.filter != nil && !l.filter(sf) {
 			continue
 		}
-		out = append(out, l.clone(sf))
+		out = append(out, l.collection.store.clone(sf))
 	}
 
 	return out, "", nil

--- a/lib/cache/git_server.go
+++ b/lib/cache/git_server.go
@@ -39,11 +39,11 @@ func newGitServerCollection(upstream services.GitServerGetter, w types.WatchKind
 	}
 
 	return &collection[types.Server, gitServerIndex]{
-		store: newStore(map[gitServerIndex]func(types.Server) string{
-			gitServerNameIndex: func(u types.Server) string {
-				return u.GetName()
-			},
-		}),
+		store: newStore(
+			types.Server.DeepCopy,
+			map[gitServerIndex]func(types.Server) string{
+				gitServerNameIndex: types.Server.GetName,
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.Server, error) {
 			var all []types.Server
 			var nextToken string
@@ -90,7 +90,6 @@ func (c *Cache) GetGitServer(ctx context.Context, name string) (types.Server, er
 		collection:  c.collections.gitServers,
 		index:       gitServerNameIndex,
 		upstreamGet: c.Config.GitServers.GetGitServer,
-		clone:       types.Server.DeepCopy,
 	}
 	out, err := getter.get(ctx, name)
 	return out, trace.Wrap(err)
@@ -108,7 +107,6 @@ func (c *Cache) ListGitServers(ctx context.Context, pageSize int, pageToken stri
 		nextToken: func(t types.Server) string {
 			return t.GetMetadata().Name
 		},
-		clone: types.Server.DeepCopy,
 	}
 	out, next, err := lister.list(ctx, pageSize, pageToken)
 	return out, next, trace.Wrap(err)

--- a/lib/cache/identitycenter.go
+++ b/lib/cache/identitycenter.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	identitycenterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/identitycenter/v1"
@@ -39,11 +40,13 @@ func newIdentityCenterAccountCollection(ic services.IdentityCenter, w types.Watc
 	}
 
 	return &collection[*identitycenterv1.Account, identityCenterAccountIndex]{
-		store: newStore(map[identityCenterAccountIndex]func(*identitycenterv1.Account) string{
-			identityCenterAccountNameIndex: func(r *identitycenterv1.Account) string {
-				return r.GetMetadata().GetName()
-			},
-		}),
+		store: newStore(
+			proto.CloneOf[*identitycenterv1.Account],
+			map[identityCenterAccountIndex]func(*identitycenterv1.Account) string{
+				identityCenterAccountNameIndex: func(r *identitycenterv1.Account) string {
+					return r.GetMetadata().GetName()
+				},
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*identitycenterv1.Account, error) {
 			var pageToken pagination.PageRequestToken
 			var accounts []*identitycenterv1.Account
@@ -146,11 +149,13 @@ func newIdentityCenterAccountAssignmentCollection(ic services.IdentityCenter, w 
 	}
 
 	return &collection[*identitycenterv1.AccountAssignment, identityCenterAccountAssignmentIndex]{
-		store: newStore(map[identityCenterAccountAssignmentIndex]func(*identitycenterv1.AccountAssignment) string{
-			identityCenterAccountAssignmentNameIndex: func(r *identitycenterv1.AccountAssignment) string {
-				return r.GetMetadata().GetName()
-			},
-		}),
+		store: newStore(
+			proto.CloneOf[*identitycenterv1.AccountAssignment],
+			map[identityCenterAccountAssignmentIndex]func(*identitycenterv1.AccountAssignment) string{
+				identityCenterAccountAssignmentNameIndex: func(r *identitycenterv1.AccountAssignment) string {
+					return r.GetMetadata().GetName()
+				},
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*identitycenterv1.AccountAssignment, error) {
 			var pageToken pagination.PageRequestToken
 			var accounts []*identitycenterv1.AccountAssignment
@@ -256,11 +261,13 @@ func newIdentityCenterPrincipalAssignmentCollection(upstream services.IdentityCe
 	}
 
 	return &collection[*identitycenterv1.PrincipalAssignment, identityCenterPrincipalAssignmentIndex]{
-		store: newStore(map[identityCenterPrincipalAssignmentIndex]func(*identitycenterv1.PrincipalAssignment) string{
-			identityCenterPrincipalAssignmentNameIndex: func(r *identitycenterv1.PrincipalAssignment) string {
-				return r.GetMetadata().GetName()
-			},
-		}),
+		store: newStore(
+			proto.CloneOf[*identitycenterv1.PrincipalAssignment],
+			map[identityCenterPrincipalAssignmentIndex]func(*identitycenterv1.PrincipalAssignment) string{
+				identityCenterPrincipalAssignmentNameIndex: func(r *identitycenterv1.PrincipalAssignment) string {
+					return r.GetMetadata().GetName()
+				},
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*identitycenterv1.PrincipalAssignment, error) {
 			var pageToken pagination.PageRequestToken
 			var resources []*identitycenterv1.PrincipalAssignment
@@ -304,7 +311,6 @@ func (c *Cache) GetPrincipalAssignment(ctx context.Context, id services.Principa
 			out, err := c.Config.IdentityCenter.GetPrincipalAssignment(ctx, services.PrincipalAssignmentID(s))
 			return out, trace.Wrap(err)
 		},
-		clone: utils.CloneProtoMsg[*identitycenterv1.PrincipalAssignment],
 	}
 	out, err := getter.get(ctx, string(id))
 	return out, trace.Wrap(err)
@@ -325,7 +331,6 @@ func (c *Cache) ListPrincipalAssignments(ctx context.Context, pageSize int, req 
 		nextToken: func(t *identitycenterv1.PrincipalAssignment) string {
 			return t.GetMetadata().GetName()
 		},
-		clone: utils.CloneProtoMsg[*identitycenterv1.PrincipalAssignment],
 	}
 
 	nextToken, err := req.Consume()

--- a/lib/cache/installer.go
+++ b/lib/cache/installer.go
@@ -35,9 +35,11 @@ func newInstallerCollection(upstream services.ClusterConfiguration, w types.Watc
 	}
 
 	return &collection[types.Installer, installerIndex]{
-		store: newStore(map[installerIndex]func(types.Installer) string{
-			installerNameIndex: types.Installer.GetName,
-		}),
+		store: newStore(
+			types.Installer.Clone,
+			map[installerIndex]func(types.Installer) string{
+				installerNameIndex: types.Installer.GetName,
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.Installer, error) {
 			installers, err := upstream.GetInstallers(ctx)
 			return installers, trace.Wrap(err)
@@ -65,7 +67,6 @@ func (c *Cache) GetInstaller(ctx context.Context, name string) (types.Installer,
 		collection:  c.collections.installers,
 		index:       installerNameIndex,
 		upstreamGet: c.Config.ClusterConfig.GetInstaller,
-		clone:       types.Installer.Clone,
 	}
 	out, err := getter.get(ctx, name)
 	return out, trace.Wrap(err)

--- a/lib/cache/integrations.go
+++ b/lib/cache/integrations.go
@@ -35,11 +35,11 @@ func newIntegrationCollection(upstream services.Integrations, w types.WatchKind)
 	}
 
 	return &collection[types.Integration, integrationIndex]{
-		store: newStore(map[integrationIndex]func(types.Integration) string{
-			integrationNameIndex: func(r types.Integration) string {
-				return r.GetMetadata().Name
-			},
-		}),
+		store: newStore(
+			types.Integration.Clone,
+			map[integrationIndex]func(types.Integration) string{
+				integrationNameIndex: types.Integration.GetName,
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.Integration, error) {
 			var startKey string
 			var resources []types.Integration
@@ -88,7 +88,6 @@ func (c *Cache) ListIntegrations(ctx context.Context, pageSize int, pageToken st
 		nextToken: func(t types.Integration) string {
 			return t.GetMetadata().Name
 		},
-		clone: types.Integration.Clone,
 	}
 	out, next, err := lister.list(ctx, pageSize, pageToken)
 	return out, next, trace.Wrap(err)
@@ -104,7 +103,6 @@ func (c *Cache) GetIntegration(ctx context.Context, name string) (types.Integrat
 		collection:  c.collections.integrations,
 		index:       integrationNameIndex,
 		upstreamGet: c.Config.Integrations.GetIntegration,
-		clone:       types.Integration.Clone,
 	}
 	out, err := getter.get(ctx, name)
 	return out, trace.Wrap(err)

--- a/lib/cache/kube.go
+++ b/lib/cache/kube.go
@@ -20,11 +20,11 @@ import (
 	"context"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	kubewaitingcontainerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -38,18 +38,20 @@ func newKubernetesServerCollection(p services.Presence, w types.WatchKind) (*col
 	}
 
 	return &collection[types.KubeServer, kubeServerIndex]{
-		store: newStore(map[kubeServerIndex]func(types.KubeServer) string{
-			kubeServerNameIndex: func(u types.KubeServer) string {
-				return u.GetHostID() + "/" + u.GetName()
-			},
-		}),
+		store: newStore(
+			types.KubeServer.Copy,
+			map[kubeServerIndex]func(types.KubeServer) string{
+				kubeServerNameIndex: func(u types.KubeServer) string {
+					return u.GetHostID() + "/" + u.GetName()
+				},
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.KubeServer, error) {
 			return p.GetKubernetesServers(ctx)
 		},
 		headerTransform: func(hdr *types.ResourceHeader) types.KubeServer {
 			return &types.KubernetesServerV3{
-				Kind:    types.KindKubeServer,
-				Version: types.V3,
+				Kind:    hdr.Kind,
+				Version: hdr.Version,
 				Metadata: types.Metadata{
 					Name: hdr.Metadata.Name,
 				},
@@ -96,18 +98,18 @@ func newKubernetesClusterCollection(k services.Kubernetes, w types.WatchKind) (*
 	}
 
 	return &collection[types.KubeCluster, kubeClusterIndex]{
-		store: newStore(map[kubeClusterIndex]func(types.KubeCluster) string{
-			kubeClusterNameIndex: func(u types.KubeCluster) string {
-				return u.GetName()
-			},
-		}),
+		store: newStore(
+			types.KubeCluster.Copy,
+			map[kubeClusterIndex]func(types.KubeCluster) string{
+				kubeClusterNameIndex: types.KubeCluster.GetName,
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.KubeCluster, error) {
 			return k.GetKubernetesClusters(ctx)
 		},
 		headerTransform: func(hdr *types.ResourceHeader) types.KubeCluster {
 			return &types.KubernetesClusterV3{
-				Kind:    types.KindKubernetesCluster,
-				Version: types.V3,
+				Kind:    hdr.Kind,
+				Version: hdr.Version,
 				Metadata: types.Metadata{
 					Name: hdr.Metadata.Name,
 				},
@@ -175,11 +177,13 @@ func newKubernetesWaitingContainerCollection(upstream services.KubeWaitingContai
 	}
 
 	return &collection[*kubewaitingcontainerv1.KubernetesWaitingContainer, kubeWaitingContainerIndex]{
-		store: newStore(map[kubeWaitingContainerIndex]func(*kubewaitingcontainerv1.KubernetesWaitingContainer) string{
-			kubeWaitingContainerNameIndex: func(u *kubewaitingcontainerv1.KubernetesWaitingContainer) string {
-				return u.GetMetadata().GetName()
-			},
-		}),
+		store: newStore(
+			proto.CloneOf[*kubewaitingcontainerv1.KubernetesWaitingContainer],
+			map[kubeWaitingContainerIndex]func(*kubewaitingcontainerv1.KubernetesWaitingContainer) string{
+				kubeWaitingContainerNameIndex: func(u *kubewaitingcontainerv1.KubernetesWaitingContainer) string {
+					return u.GetMetadata().GetName()
+				},
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*kubewaitingcontainerv1.KubernetesWaitingContainer, error) {
 			var startKey string
 			var allConts []*kubewaitingcontainerv1.KubernetesWaitingContainer
@@ -200,8 +204,8 @@ func newKubernetesWaitingContainerCollection(upstream services.KubeWaitingContai
 		},
 		headerTransform: func(hdr *types.ResourceHeader) *kubewaitingcontainerv1.KubernetesWaitingContainer {
 			return &kubewaitingcontainerv1.KubernetesWaitingContainer{
-				Kind:    types.KindKubeServer,
-				Version: types.V3,
+				Kind:    hdr.Kind,
+				Version: hdr.Version,
 				Metadata: &headerv1.Metadata{
 					Name: hdr.Metadata.Name,
 				},
@@ -227,7 +231,6 @@ func (c *Cache) ListKubernetesWaitingContainers(ctx context.Context, pageSize in
 			spec := t.GetSpec()
 			return spec.GetUsername() + "/" + spec.GetCluster() + "/" + spec.GetNamespace() + "/" + spec.GetPodName() + "/" + t.GetMetadata().GetName()
 		},
-		clone: utils.CloneProtoMsg[*kubewaitingcontainerv1.KubernetesWaitingContainer],
 	}
 	out, next, err := lister.list(ctx, pageSize, pageToken)
 	return out, next, trace.Wrap(err)

--- a/lib/cache/legacy_collections.go
+++ b/lib/cache/legacy_collections.go
@@ -26,7 +26,6 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/client/proto"
-	userspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/users/v1"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/secreports"
@@ -165,42 +164,6 @@ func (r resourceKind) String() string {
 	}
 	return fmt.Sprintf("%s/%s", r.kind, r.subkind)
 }
-
-type userExecutor struct{}
-
-func (userExecutor) getAll(ctx context.Context, cache *Cache, loadSecrets bool) ([]types.User, error) {
-	return cache.Users.GetUsers(ctx, loadSecrets)
-}
-
-func (userExecutor) upsert(ctx context.Context, cache *Cache, resource types.User) error {
-	_, err := cache.usersCache.UpsertUser(ctx, resource)
-	return err
-}
-
-func (userExecutor) deleteAll(ctx context.Context, cache *Cache) error {
-	return cache.usersCache.DeleteAllUsers(ctx)
-}
-
-func (userExecutor) delete(ctx context.Context, cache *Cache, resource types.Resource) error {
-	return cache.usersCache.DeleteUser(ctx, resource.GetName())
-}
-
-func (userExecutor) isSingleton() bool { return false }
-
-func (userExecutor) getReader(cache *Cache, cacheOK bool) userGetter {
-	if cacheOK {
-		return cache.usersCache
-	}
-	return cache.Config.Users
-}
-
-type userGetter interface {
-	GetUser(ctx context.Context, user string, withSecrets bool) (types.User, error)
-	GetUsers(ctx context.Context, withSecrets bool) ([]types.User, error)
-	ListUsers(ctx context.Context, req *userspb.ListUsersRequest) (*userspb.ListUsersResponse, error)
-}
-
-var _ executor[types.User, userGetter] = userExecutor{}
 
 // collectionReader extends the collection interface, adding routing capabilities.
 type collectionReader[R any] interface {

--- a/lib/cache/lock.go
+++ b/lib/cache/lock.go
@@ -36,9 +36,11 @@ func newLockCollection(upstream services.Access, w types.WatchKind) (*collection
 	}
 
 	return &collection[types.Lock, lockIndex]{
-		store: newStore(map[lockIndex]func(types.Lock) string{
-			lockNameIndex: types.Lock.GetName,
-		}),
+		store: newStore(
+			types.Lock.Clone,
+			map[lockIndex]func(types.Lock) string{
+				lockNameIndex: types.Lock.GetName,
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.Lock, error) {
 			locks, err := upstream.GetLocks(ctx, false)
 			return locks, trace.Wrap(err)
@@ -71,7 +73,6 @@ func (c *Cache) GetLock(ctx context.Context, name string) (types.Lock, error) {
 			lock, err := c.Config.Access.GetLock(ctx, name)
 			return lock, trace.Wrap(err)
 		},
-		clone: types.Lock.Clone,
 	}
 	out, err := getter.get(ctx, types.MetaNameAutoUpdateConfig)
 	if trace.IsNotFound(err) && !upstreamRead {
@@ -108,13 +109,13 @@ func (c *Cache) GetLocks(ctx context.Context, inForceOnly bool, targets ...types
 		}
 		// If no targets specified, return all of the found/in-force locks.
 		if len(targets) == 0 {
-			locks = append(locks, lock)
+			locks = append(locks, lock.Clone())
 			continue
 		}
 		// Otherwise, use the targets as filters.
 		for _, target := range targets {
 			if target.Match(lock) {
-				locks = append(locks, lock)
+				locks = append(locks, lock.Clone())
 				break
 			}
 		}

--- a/lib/cache/network_restrictions.go
+++ b/lib/cache/network_restrictions.go
@@ -35,9 +35,11 @@ func newNetworkingRestrictionCollection(upstream services.Restrictions, w types.
 	}
 
 	return &collection[types.NetworkRestrictions, networkingRestrictionIndex]{
-		store: newStore(map[networkingRestrictionIndex]func(types.NetworkRestrictions) string{
-			networkingRestrictionNameIndex: types.NetworkRestrictions.GetName,
-		}),
+		store: newStore(
+			types.NetworkRestrictions.Clone,
+			map[networkingRestrictionIndex]func(types.NetworkRestrictions) string{
+				networkingRestrictionNameIndex: types.NetworkRestrictions.GetName,
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.NetworkRestrictions, error) {
 			restrictions, err := upstream.GetNetworkRestrictions(ctx)
 			if err != nil {
@@ -71,7 +73,6 @@ func (c *Cache) GetNetworkRestrictions(ctx context.Context) (types.NetworkRestri
 			restriction, err := c.Config.Restrictions.GetNetworkRestrictions(ctx)
 			return restriction, trace.Wrap(err)
 		},
-		clone: types.NetworkRestrictions.Clone,
 	}
 	out, err := getter.get(ctx, types.MetaNameNetworkRestrictions)
 	return out, trace.Wrap(err)

--- a/lib/cache/node.go
+++ b/lib/cache/node.go
@@ -37,18 +37,18 @@ func newNodeCollection(p services.Presence, w types.WatchKind) (*collection[type
 	}
 
 	return &collection[types.Server, nodeIndex]{
-		store: newStore(map[nodeIndex]func(types.Server) string{
-			nodeNameIndex: func(u types.Server) string {
-				return u.GetName()
-			},
-		}),
+		store: newStore(
+			types.Server.DeepCopy,
+			map[nodeIndex]func(types.Server) string{
+				nodeNameIndex: types.Server.GetName,
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.Server, error) {
 			return p.GetNodes(ctx, defaults.Namespace)
 		},
 		headerTransform: func(hdr *types.ResourceHeader) types.Server {
 			return &types.ServerV2{
-				Kind:    types.KindNode,
-				Version: types.V2,
+				Kind:    hdr.Kind,
+				Version: hdr.Version,
 				Metadata: types.Metadata{
 					Name: hdr.Metadata.Name,
 				},

--- a/lib/cache/okta.go
+++ b/lib/cache/okta.go
@@ -35,11 +35,11 @@ func newOktaImportRuleCollection(upstream services.Okta, w types.WatchKind) (*co
 	}
 
 	return &collection[types.OktaImportRule, oktaImportRuleIndex]{
-		store: newStore(map[oktaImportRuleIndex]func(types.OktaImportRule) string{
-			oktaImportRuleNameIndex: func(r types.OktaImportRule) string {
-				return r.GetMetadata().Name
-			},
-		}),
+		store: newStore(
+			types.OktaImportRule.Clone,
+			map[oktaImportRuleIndex]func(types.OktaImportRule) string{
+				oktaImportRuleNameIndex: types.OktaImportRule.GetName,
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.OktaImportRule, error) {
 			var startKey string
 			var resources []types.OktaImportRule
@@ -88,7 +88,6 @@ func (c *Cache) ListOktaImportRules(ctx context.Context, pageSize int, pageToken
 		nextToken: func(t types.OktaImportRule) string {
 			return t.GetMetadata().Name
 		},
-		clone: types.OktaImportRule.Clone,
 	}
 	out, next, err := lister.list(ctx, pageSize, pageToken)
 	return out, next, trace.Wrap(err)
@@ -104,7 +103,6 @@ func (c *Cache) GetOktaImportRule(ctx context.Context, name string) (types.OktaI
 		collection:  c.collections.oktaImportRules,
 		index:       oktaImportRuleNameIndex,
 		upstreamGet: c.Config.Okta.GetOktaImportRule,
-		clone:       types.OktaImportRule.Clone,
 	}
 	out, err := getter.get(ctx, name)
 	return out, trace.Wrap(err)
@@ -120,11 +118,11 @@ func newOktaImportAssignmentCollection(upstream services.Okta, w types.WatchKind
 	}
 
 	return &collection[types.OktaAssignment, oktaAssignmentIndex]{
-		store: newStore(map[oktaAssignmentIndex]func(types.OktaAssignment) string{
-			oktaAssignmentNameIndex: func(r types.OktaAssignment) string {
-				return r.GetMetadata().Name
-			},
-		}),
+		store: newStore(
+			types.OktaAssignment.Copy,
+			map[oktaAssignmentIndex]func(types.OktaAssignment) string{
+				oktaAssignmentNameIndex: types.OktaAssignment.GetName,
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.OktaAssignment, error) {
 			var startKey string
 			var resources []types.OktaAssignment
@@ -173,7 +171,6 @@ func (c *Cache) ListOktaAssignments(ctx context.Context, pageSize int, pageToken
 		nextToken: func(t types.OktaAssignment) string {
 			return t.GetMetadata().Name
 		},
-		clone: types.OktaAssignment.Copy,
 	}
 	out, next, err := lister.list(ctx, pageSize, pageToken)
 	return out, next, trace.Wrap(err)
@@ -189,7 +186,6 @@ func (c *Cache) GetOktaAssignment(ctx context.Context, name string) (types.OktaA
 		collection:  c.collections.oktaAssignments,
 		index:       oktaAssignmentNameIndex,
 		upstreamGet: c.Config.Okta.GetOktaAssignment,
-		clone:       types.OktaAssignment.Copy,
 	}
 	out, err := getter.get(ctx, name)
 	return out, trace.Wrap(err)

--- a/lib/cache/plugin_static_credentials.go
+++ b/lib/cache/plugin_static_credentials.go
@@ -35,11 +35,11 @@ func newPluginStaticCredentialsCollection(upstream services.PluginStaticCredenti
 	}
 
 	return &collection[types.PluginStaticCredentials, pluginStaticCredentialsIndex]{
-		store: newStore(map[pluginStaticCredentialsIndex]func(types.PluginStaticCredentials) string{
-			pluginStaticCredentialsNameIndex: func(r types.PluginStaticCredentials) string {
-				return r.GetMetadata().Name
-			},
-		}),
+		store: newStore(
+			types.PluginStaticCredentials.Clone,
+			map[pluginStaticCredentialsIndex]func(types.PluginStaticCredentials) string{
+				pluginStaticCredentialsNameIndex: types.PluginStaticCredentials.GetName,
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.PluginStaticCredentials, error) {
 			creds, err := upstream.GetAllPluginStaticCredentials(ctx)
 			return creds, trace.Wrap(err)
@@ -70,7 +70,6 @@ func (c *Cache) GetPluginStaticCredentials(ctx context.Context, name string) (ty
 		collection:  c.collections.pluginStaticCredentials,
 		index:       pluginStaticCredentialsNameIndex,
 		upstreamGet: c.Config.PluginStaticCredentials.GetPluginStaticCredentials,
-		clone:       types.PluginStaticCredentials.Clone,
 	}
 	out, err := getter.get(ctx, name)
 	return out, trace.Wrap(err)

--- a/lib/cache/proxy_server.go
+++ b/lib/cache/proxy_server.go
@@ -35,19 +35,19 @@ func newProxyServerCollection(p services.Presence, w types.WatchKind) (*collecti
 	}
 
 	return &collection[types.Server, proxyServerIndex]{
-		store: newStore(map[proxyServerIndex]func(types.Server) string{
-			proxyServerNameIndex: func(u types.Server) string {
-				return u.GetName()
-			},
-		}),
+		store: newStore(
+			types.Server.DeepCopy,
+			map[proxyServerIndex]func(types.Server) string{
+				proxyServerNameIndex: types.Server.GetName,
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.Server, error) {
 			servers, err := p.GetProxies()
 			return servers, trace.Wrap(err)
 		},
 		headerTransform: func(hdr *types.ResourceHeader) types.Server {
 			return &types.ServerV2{
-				Kind:    types.KindProxy,
-				Version: types.V2,
+				Kind:    hdr.Kind,
+				Version: hdr.Version,
 				Metadata: types.Metadata{
 					Name: hdr.GetName(),
 				},

--- a/lib/cache/reverse_tunnel.go
+++ b/lib/cache/reverse_tunnel.go
@@ -36,11 +36,11 @@ func newReverseTunnelCollection(upstream services.Presence, w types.WatchKind) (
 	}
 
 	return &collection[types.ReverseTunnel, reverseTunnelIndex]{
-		store: newStore(map[reverseTunnelIndex]func(types.ReverseTunnel) string{
-			reverseTunnelNameIndex: func(r types.ReverseTunnel) string {
-				return r.GetName()
-			},
-		}),
+		store: newStore(
+			types.ReverseTunnel.Clone,
+			map[reverseTunnelIndex]func(types.ReverseTunnel) string{
+				reverseTunnelNameIndex: types.ReverseTunnel.GetName,
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.ReverseTunnel, error) {
 			var out []types.ReverseTunnel
 			var nextToken string
@@ -86,7 +86,6 @@ func (c *Cache) ListReverseTunnels(ctx context.Context, pageSize int, pageToken 
 		nextToken: func(t types.ReverseTunnel) string {
 			return t.GetMetadata().Name
 		},
-		clone: types.ReverseTunnel.Clone,
 	}
 	out, next, err := lister.list(ctx, pageSize, pageToken)
 	return out, next, trace.Wrap(err)

--- a/lib/cache/role.go
+++ b/lib/cache/role.go
@@ -35,18 +35,18 @@ func newRoleCollection(a services.Access, w types.WatchKind) (*collection[types.
 	}
 
 	return &collection[types.Role, roleIndex]{
-		store: newStore(map[roleIndex]func(types.Role) string{
-			roleNameIndex: func(r types.Role) string {
-				return r.GetName()
-			},
-		}),
+		store: newStore(
+			types.Role.Clone,
+			map[roleIndex]func(types.Role) string{
+				roleNameIndex: types.Role.GetName,
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.Role, error) {
 			return a.GetRoles(ctx)
 		},
 		headerTransform: func(hdr *types.ResourceHeader) types.Role {
 			return &types.RoleV6{
-				Kind:    types.KindRole,
-				Version: types.V7,
+				Kind:    hdr.Kind,
+				Version: hdr.Version,
 				Metadata: types.Metadata{
 					Name: hdr.Metadata.Name,
 				},

--- a/lib/cache/saml_idp.go
+++ b/lib/cache/saml_idp.go
@@ -35,11 +35,11 @@ func newSAMLIdPServiceProviderCollection(upstream services.SAMLIdPServiceProvide
 	}
 
 	return &collection[types.SAMLIdPServiceProvider, samlIdPServiceProviderIndex]{
-		store: newStore(map[samlIdPServiceProviderIndex]func(types.SAMLIdPServiceProvider) string{
-			samlIdPServiceProviderNameIndex: func(r types.SAMLIdPServiceProvider) string {
-				return r.GetMetadata().Name
-			},
-		}),
+		store: newStore(
+			types.SAMLIdPServiceProvider.Copy,
+			map[samlIdPServiceProviderIndex]func(types.SAMLIdPServiceProvider) string{
+				samlIdPServiceProviderNameIndex: types.SAMLIdPServiceProvider.GetName,
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.SAMLIdPServiceProvider, error) {
 			var startKey string
 			var sps []types.SAMLIdPServiceProvider
@@ -89,7 +89,6 @@ func (c *Cache) ListSAMLIdPServiceProviders(ctx context.Context, pageSize int, p
 		nextToken: func(t types.SAMLIdPServiceProvider) string {
 			return t.GetMetadata().Name
 		},
-		clone: types.SAMLIdPServiceProvider.Copy,
 	}
 	out, next, err := lister.list(ctx, pageSize, pageToken)
 	return out, next, trace.Wrap(err)
@@ -105,7 +104,6 @@ func (c *Cache) GetSAMLIdPServiceProvider(ctx context.Context, name string) (typ
 		collection:  c.collections.samlIdPServiceProviders,
 		index:       samlIdPServiceProviderNameIndex,
 		upstreamGet: c.Config.SAMLIdPServiceProviders.GetSAMLIdPServiceProvider,
-		clone:       types.SAMLIdPServiceProvider.Copy,
 	}
 	out, err := getter.get(ctx, name)
 	return out, trace.Wrap(err)
@@ -121,11 +119,11 @@ func newSAMLIdPSessionCollection(upstream services.SAMLIdPSession, w types.Watch
 	}
 
 	return &collection[types.WebSession, samlIdPSessionIndex]{
-		store: newStore(map[samlIdPSessionIndex]func(types.WebSession) string{
-			samlIdPSessionNameIndex: func(r types.WebSession) string {
-				return r.GetMetadata().Name
-			},
-		}),
+		store: newStore(
+			types.WebSession.Copy,
+			map[samlIdPSessionIndex]func(types.WebSession) string{
+				samlIdPSessionNameIndex: types.WebSession.GetName,
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.WebSession, error) {
 			var startKey string
 			var sessions []types.WebSession
@@ -180,7 +178,6 @@ func (c *Cache) GetSAMLIdPSession(ctx context.Context, req types.GetSAMLIdPSessi
 			session, err := c.Config.SAMLIdPSession.GetSAMLIdPSession(ctx, types.GetSAMLIdPSessionRequest{SessionID: s})
 			return session, trace.Wrap(err)
 		},
-		clone: types.WebSession.Copy,
 	}
 	out, err := getter.get(ctx, req.SessionID)
 	if trace.IsNotFound(err) && !upstreamRead {

--- a/lib/cache/store.go
+++ b/lib/cache/store.go
@@ -27,13 +27,15 @@ import (
 // store persists cached resources directly in memory.
 type store[T any, I comparable] struct {
 	cache   *sortcache.SortCache[T, I]
+	clone   func(T) T
 	indexes map[I]func(T) string
 }
 
 // newStore creates a store that will index the resource
 // based on the provided indexes.
-func newStore[T any, I comparable](indexes map[I]func(T) string) *store[T, I] {
+func newStore[T any, I comparable](clone func(T) T, indexes map[I]func(T) string) *store[T, I] {
 	return &store[T, I]{
+		clone:   clone,
 		indexes: indexes,
 		cache: sortcache.New(sortcache.Config[T, I]{
 			Indexes: indexes,
@@ -49,7 +51,7 @@ func (s *store[T, I]) clear() error {
 
 // put adds a new item, or updates an existing item.
 func (s *store[T, I]) put(t T) error {
-	s.cache.Put(t)
+	s.cache.Put(s.clone(t))
 	return nil
 }
 

--- a/lib/cache/store_test.go
+++ b/lib/cache/store_test.go
@@ -27,6 +27,7 @@ import (
 
 func TestResourceStore(t *testing.T) {
 	store := newStore(
+		func(i int) int { return i },
 		map[string]func(i int) string{
 			"numbers":    strconv.Itoa,
 			"characters": func(i int) string { return strconv.FormatUint(uint64(i), 16) },

--- a/lib/cache/tokens.go
+++ b/lib/cache/tokens.go
@@ -35,11 +35,11 @@ func newStaticTokensCollection(c services.ClusterConfiguration, w types.WatchKin
 	}
 
 	return &collection[types.StaticTokens, staticTokensIndex]{
-		store: newStore(map[staticTokensIndex]func(types.StaticTokens) string{
-			staticTokensNameIndex: func(u types.StaticTokens) string {
-				return u.GetName()
-			},
-		}),
+		store: newStore(
+			types.StaticTokens.Clone,
+			map[staticTokensIndex]func(types.StaticTokens) string{
+				staticTokensNameIndex: types.StaticTokens.GetName,
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.StaticTokens, error) {
 			token, err := c.GetStaticTokens()
 			if err != nil {
@@ -49,8 +49,8 @@ func newStaticTokensCollection(c services.ClusterConfiguration, w types.WatchKin
 		},
 		headerTransform: func(hdr *types.ResourceHeader) types.StaticTokens {
 			return &types.StaticTokensV2{
-				Kind:    types.KindStaticTokens,
-				Version: types.V2,
+				Kind:    hdr.Kind,
+				Version: hdr.Version,
 				Metadata: types.Metadata{
 					Name: types.MetaNameStaticTokens,
 				},
@@ -90,21 +90,21 @@ func newProvisionTokensCollection(p services.Provisioner, w types.WatchKind) (*c
 	}
 
 	return &collection[types.ProvisionToken, provisionTokenIndex]{
-		store: newStore(map[provisionTokenIndex]func(types.ProvisionToken) string{
-			provisionTokenStoreNameIndex: func(u types.ProvisionToken) string {
-				return u.GetName()
-			},
-		}),
+		store: newStore(
+			types.ProvisionToken.Clone,
+			map[provisionTokenIndex]func(types.ProvisionToken) string{
+				provisionTokenStoreNameIndex: types.ProvisionToken.GetName,
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.ProvisionToken, error) {
 			tokens, err := p.GetTokens(ctx)
 			return tokens, trace.Wrap(err)
 		},
 		headerTransform: func(hdr *types.ResourceHeader) types.ProvisionToken {
 			return &types.ProvisionTokenV2{
-				Kind:    types.KindToken,
+				Kind:    hdr.Kind,
 				Version: hdr.Version,
 				Metadata: types.Metadata{
-					Name: hdr.GetName(),
+					Name: hdr.Metadata.Name,
 				},
 			}
 		},

--- a/lib/cache/user_group.go
+++ b/lib/cache/user_group.go
@@ -36,11 +36,11 @@ func newUserGroupCollection(u services.UserGroups, w types.WatchKind) (*collecti
 	}
 
 	return &collection[types.UserGroup, userGroupIndex]{
-		store: newStore(map[userGroupIndex]func(types.UserGroup) string{
-			userGroupNameIndex: func(r types.UserGroup) string {
-				return r.GetName()
-			},
-		}),
+		store: newStore(
+			types.UserGroup.Clone,
+			map[userGroupIndex]func(types.UserGroup) string{
+				userGroupNameIndex: types.UserGroup.GetName,
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.UserGroup, error) {
 			var startKey string
 			var groups []types.UserGroup
@@ -59,7 +59,13 @@ func newUserGroupCollection(u services.UserGroups, w types.WatchKind) (*collecti
 		},
 		headerTransform: func(hdr *types.ResourceHeader) types.UserGroup {
 			return &types.UserGroupV1{
-				ResourceHeader: *hdr,
+				ResourceHeader: types.ResourceHeader{
+					Kind:    hdr.Kind,
+					Version: hdr.Version,
+					Metadata: types.Metadata{
+						Name: hdr.Metadata.Name,
+					},
+				},
 			}
 		},
 		watch: w,

--- a/lib/cache/user_login_state.go
+++ b/lib/cache/user_login_state.go
@@ -37,11 +37,13 @@ func newUserLoginStateCollection(upstream services.UserLoginStates, w types.Watc
 	}
 
 	return &collection[*userloginstate.UserLoginState, userLoginStateIndex]{
-		store: newStore(map[userLoginStateIndex]func(*userloginstate.UserLoginState) string{
-			userLoginStateNameIndex: func(r *userloginstate.UserLoginState) string {
-				return r.GetMetadata().Name
-			},
-		}),
+		store: newStore(
+			(*userloginstate.UserLoginState).Clone,
+			map[userLoginStateIndex]func(*userloginstate.UserLoginState) string{
+				userLoginStateNameIndex: func(r *userloginstate.UserLoginState) string {
+					return r.GetMetadata().Name
+				},
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*userloginstate.UserLoginState, error) {
 			out, err := upstream.GetUserLoginStates(ctx)
 			return out, trace.Wrap(err)
@@ -99,9 +101,6 @@ func (c *Cache) GetUserLoginState(ctx context.Context, name string) (*userlogins
 			upstreamRead = true
 			state, err := c.Config.UserLoginStates.GetUserLoginState(ctx, name)
 			return state, trace.Wrap(err)
-		},
-		clone: func(uls *userloginstate.UserLoginState) *userloginstate.UserLoginState {
-			return uls.Clone()
 		},
 	}
 	out, err := getter.get(ctx, name)

--- a/lib/cache/user_task.go
+++ b/lib/cache/user_task.go
@@ -20,11 +20,11 @@ import (
 	"context"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -38,11 +38,13 @@ func newUserTaskCollection(upstream services.UserTasks, w types.WatchKind) (*col
 	}
 
 	return &collection[*usertasksv1.UserTask, userTaskIndex]{
-		store: newStore(map[userTaskIndex]func(*usertasksv1.UserTask) string{
-			userTaskNameIndex: func(r *usertasksv1.UserTask) string {
-				return r.GetMetadata().GetName()
-			},
-		}),
+		store: newStore(
+			proto.CloneOf[*usertasksv1.UserTask],
+			map[userTaskIndex]func(*usertasksv1.UserTask) string{
+				userTaskNameIndex: func(r *usertasksv1.UserTask) string {
+					return r.GetMetadata().GetName()
+				},
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*usertasksv1.UserTask, error) {
 			var resources []*usertasksv1.UserTask
 			var nextToken string
@@ -90,7 +92,6 @@ func (c *Cache) ListUserTasks(ctx context.Context, pageSize int64, pageToken str
 		nextToken: func(t *usertasksv1.UserTask) string {
 			return t.GetMetadata().Name
 		},
-		clone: utils.CloneProtoMsg[*usertasksv1.UserTask],
 		filter: func(ut *usertasksv1.UserTask) bool {
 			return services.MatchUserTask(ut, filters)
 		},
@@ -109,7 +110,6 @@ func (c *Cache) GetUserTask(ctx context.Context, name string) (*usertasksv1.User
 		collection:  c.collections.userTasks,
 		index:       userTaskNameIndex,
 		upstreamGet: c.Config.UserTasks.GetUserTask,
-		clone:       utils.CloneProtoMsg[*usertasksv1.UserTask],
 	}
 	out, err := getter.get(ctx, name)
 	return out, trace.Wrap(err)

--- a/lib/cache/users.go
+++ b/lib/cache/users.go
@@ -39,18 +39,18 @@ func newUserCollection(u services.UsersService, w types.WatchKind) (*collection[
 	}
 
 	return &collection[types.User, userIndex]{
-		store: newStore(map[userIndex]func(types.User) string{
-			userNameIndex: func(u types.User) string {
-				return u.GetName()
-			},
-		}),
+		store: newStore(
+			types.User.Clone,
+			map[userIndex]func(types.User) string{
+				userNameIndex: types.User.GetName,
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.User, error) {
 			return u.GetUsers(ctx, loadSecrets)
 		},
 		headerTransform: func(hdr *types.ResourceHeader) types.User {
 			return &types.UserV2{
-				Kind:    types.KindUser,
-				Version: types.V2,
+				Kind:    hdr.Kind,
+				Version: hdr.Version,
 				Metadata: types.Metadata{
 					Name: hdr.Metadata.Name,
 				},

--- a/lib/cache/web_session.go
+++ b/lib/cache/web_session.go
@@ -37,11 +37,11 @@ func newWebSessionCollection(upstream types.WebSessionInterface, w types.WatchKi
 	}
 
 	return &collection[types.WebSession, webSessionIndex]{
-		store: newStore(map[webSessionIndex]func(types.WebSession) string{
-			webSessionNameIndex: func(r types.WebSession) string {
-				return r.GetMetadata().Name
-			},
-		}),
+		store: newStore(
+			types.WebSession.Copy,
+			map[webSessionIndex]func(types.WebSession) string{
+				webSessionNameIndex: types.WebSession.GetName,
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.WebSession, error) {
 			webSessions, err := upstream.List(ctx)
 			if err != nil {
@@ -86,7 +86,6 @@ func (c *Cache) GetWebSession(ctx context.Context, req types.GetWebSessionReques
 			session, err := c.Config.WebSession.Get(ctx, types.GetWebSessionRequest{SessionID: s})
 			return session, trace.Wrap(err)
 		},
-		clone: types.WebSession.Copy,
 	}
 	out, err := getter.get(ctx, req.SessionID)
 	if trace.IsNotFound(err) && !upstreamRead {
@@ -116,14 +115,14 @@ func newAppSessionCollection(upstream services.AppSession, w types.WatchKind) (*
 	}
 
 	return &collection[types.WebSession, appSessionIndex]{
-		store: newStore(map[appSessionIndex]func(types.WebSession) string{
-			appSessionNameIndex: func(r types.WebSession) string {
-				return r.GetMetadata().Name
-			},
-			appSessionUserIndex: func(r types.WebSession) string {
-				return r.GetUser() + "/" + r.GetMetadata().Name
-			},
-		}),
+		store: newStore(
+			types.WebSession.Copy,
+			map[appSessionIndex]func(types.WebSession) string{
+				appSessionNameIndex: types.WebSession.GetName,
+				appSessionUserIndex: func(r types.WebSession) string {
+					return r.GetUser() + "/" + r.GetMetadata().Name
+				},
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.WebSession, error) {
 			var startKey string
 			var sessions []types.WebSession
@@ -179,7 +178,6 @@ func (c *Cache) GetAppSession(ctx context.Context, req types.GetAppSessionReques
 			session, err := c.Config.AppSession.GetAppSession(ctx, types.GetAppSessionRequest{SessionID: s})
 			return session, trace.Wrap(err)
 		},
-		clone: types.WebSession.Copy,
 	}
 	out, err := getter.get(ctx, req.SessionID)
 	if trace.IsNotFound(err) && !upstreamRead {
@@ -253,11 +251,11 @@ func newSnowflakeSessionCollection(upstream services.SnowflakeSession, w types.W
 	}
 
 	return &collection[types.WebSession, snowflakeSessionIndex]{
-		store: newStore(map[snowflakeSessionIndex]func(types.WebSession) string{
-			snowflakeSessionNameIndex: func(r types.WebSession) string {
-				return r.GetMetadata().Name
-			},
-		}),
+		store: newStore(
+			types.WebSession.Copy,
+			map[snowflakeSessionIndex]func(types.WebSession) string{
+				snowflakeSessionNameIndex: types.WebSession.GetName,
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.WebSession, error) {
 			webSessions, err := upstream.GetSnowflakeSessions(ctx)
 			if err != nil {
@@ -302,7 +300,6 @@ func (c *Cache) GetSnowflakeSession(ctx context.Context, req types.GetSnowflakeS
 			session, err := c.Config.SnowflakeSession.GetSnowflakeSession(ctx, types.GetSnowflakeSessionRequest{SessionID: s})
 			return session, trace.Wrap(err)
 		},
-		clone: types.WebSession.Copy,
 	}
 	out, err := getter.get(ctx, req.SessionID)
 	if trace.IsNotFound(err) && !upstreamRead {

--- a/lib/cache/web_tokens.go
+++ b/lib/cache/web_tokens.go
@@ -34,9 +34,11 @@ func newWebTokenCollection(upstream types.WebTokenInterface, w types.WatchKind) 
 	}
 
 	return &collection[types.WebToken, webTokenIndex]{
-		store: newStore(map[webTokenIndex]func(types.WebToken) string{
-			webTokenNameIndex: types.WebToken.GetName,
-		}),
+		store: newStore(
+			types.WebToken.Clone,
+			map[webTokenIndex]func(types.WebToken) string{
+				webTokenNameIndex: types.WebToken.GetName,
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.WebToken, error) {
 			installers, err := upstream.List(ctx)
 			return installers, trace.Wrap(err)
@@ -67,7 +69,6 @@ func (c *Cache) GetWebToken(ctx context.Context, req types.GetWebTokenRequest) (
 			token, err := c.Config.WebToken.Get(ctx, req)
 			return token, trace.Wrap(err)
 		},
-		clone: types.WebToken.Clone,
 	}
 	out, err := getter.get(ctx, req.Token)
 	return out, trace.Wrap(err)

--- a/lib/cache/web_ui_config.go
+++ b/lib/cache/web_ui_config.go
@@ -35,9 +35,11 @@ func newWebUIConfigCollection(upstream services.ClusterConfiguration, w types.Wa
 	}
 
 	return &collection[types.UIConfig, webUIConfigIndex]{
-		store: newStore(map[webUIConfigIndex]func(types.UIConfig) string{
-			webUIConfigNameIndex: types.UIConfig.GetName,
-		}),
+		store: newStore(
+			types.UIConfig.Clone,
+			map[webUIConfigIndex]func(types.UIConfig) string{
+				webUIConfigNameIndex: types.UIConfig.GetName,
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.UIConfig, error) {
 			uiConfig, err := upstream.GetUIConfig(ctx)
 			if err != nil {
@@ -72,7 +74,6 @@ func (c *Cache) GetUIConfig(ctx context.Context) (types.UIConfig, error) {
 			cfg, err := c.Config.ClusterConfig.GetUIConfig(ctx)
 			return cfg, trace.Wrap(err)
 		},
-		clone: types.UIConfig.Clone,
 	}
 	out, err := getter.get(ctx, types.MetaNameUIConfig)
 	return out, trace.Wrap(err)

--- a/lib/cache/workload_identity.go
+++ b/lib/cache/workload_identity.go
@@ -21,11 +21,11 @@ import (
 	"context"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -39,11 +39,13 @@ func newWorkloadIdentityCollection(upstream services.WorkloadIdentities, w types
 	}
 
 	return &collection[*workloadidentityv1pb.WorkloadIdentity, workloadIdentityIndex]{
-		store: newStore(map[workloadIdentityIndex]func(*workloadidentityv1pb.WorkloadIdentity) string{
-			workloadIdentityNameIndex: func(r *workloadidentityv1pb.WorkloadIdentity) string {
-				return r.GetMetadata().GetName()
-			},
-		}),
+		store: newStore(
+			proto.CloneOf[*workloadidentityv1pb.WorkloadIdentity],
+			map[workloadIdentityIndex]func(*workloadidentityv1pb.WorkloadIdentity) string{
+				workloadIdentityNameIndex: func(r *workloadidentityv1pb.WorkloadIdentity) string {
+					return r.GetMetadata().GetName()
+				},
+			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*workloadidentityv1pb.WorkloadIdentity, error) {
 			var out []*workloadidentityv1pb.WorkloadIdentity
 			var nextToken string
@@ -89,7 +91,6 @@ func (c *Cache) ListWorkloadIdentities(ctx context.Context, pageSize int, nextTo
 		nextToken: func(t *workloadidentityv1pb.WorkloadIdentity) string {
 			return t.GetMetadata().GetName()
 		},
-		clone: utils.CloneProtoMsg[*workloadidentityv1pb.WorkloadIdentity],
 	}
 	out, next, err := lister.list(ctx, pageSize, nextToken)
 	return out, next, trace.Wrap(err)
@@ -105,7 +106,6 @@ func (c *Cache) GetWorkloadIdentity(ctx context.Context, name string) (*workload
 		collection:  c.collections.workloadIdentity,
 		index:       workloadIdentityNameIndex,
 		upstreamGet: c.Config.WorkloadIdentity.GetWorkloadIdentity,
-		clone:       utils.CloneProtoMsg[*workloadidentityv1pb.WorkloadIdentity],
 	}
 	out, err := getter.get(ctx, name)
 	return out, trace.Wrap(err)


### PR DESCRIPTION
The store now takes a clone function and uses it to clone all resources within calls to put. This ensures that there are no races caused by any modifications of the resource by the event stream. This also allowed the clone function to be removed from the genericGetter and genericLister as they can now leverage the store clone function.

All header transforms now populate the kind and version based on the information in the ResourceHeader instead of hardcoding the currently known values.

All indexes derived from the only the resource name are specified using `Resource.GetName` instead of defining a function in line that called r.GetName(). The one caveat being this only works for types that are behind an interface and none of the RFD 153 style resources.

The clone function of all non-gogo proto resources were switched from utils.CloneProtoMsg to proto.CloneOf. The clone utility is only required to prevent panics when cloning gogo proto resources.

All remaining local resource caches have been removed.

All unused legacy executors have been removed.