### PR TITLE
Convert locks to new cache mechanism

### DIFF
--- a/api/types/lock.go
+++ b/api/types/lock.go
@@ -58,6 +58,8 @@ type Lock interface {
 
 	// IsInForce returns whether the lock is in force at a particular time.
 	IsInForce(time.Time) bool
+	// Clone returns a copy of the lock.
+	Clone() Lock
 }
 
 // NewLock is a convenience method to create a Lock resource.
@@ -72,6 +74,11 @@ func NewLock(name string, spec LockSpecV2) (Lock, error) {
 		return nil, trace.Wrap(err)
 	}
 	return lock, nil
+}
+
+// Clone returns a copy of the lock.
+func (c *LockV2) Clone() Lock {
+	return utils.CloneProtoMsg(c)
 }
 
 // GetVersion returns resource version.

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -1984,44 +1984,6 @@ func (c *Cache) GetNetworkRestrictions(ctx context.Context) (types.NetworkRestri
 	return rg.reader.GetNetworkRestrictions(ctx)
 }
 
-// GetLock gets a lock by name.
-func (c *Cache) GetLock(ctx context.Context, name string) (types.Lock, error) {
-	ctx, span := c.Tracer.Start(ctx, "cache/GetLock")
-	defer span.End()
-
-	rg, err := readLegacyCollectionCache(c, c.legacyCacheCollections.locks)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	defer rg.Release()
-
-	lock, err := rg.reader.GetLock(ctx, name)
-	if trace.IsNotFound(err) && rg.IsCacheRead() {
-		// release read lock early
-		rg.Release()
-		// fallback is sane because method is never used
-		// in construction of derivative caches.
-		if lock, err := c.Config.Access.GetLock(ctx, name); err == nil {
-			return lock, nil
-		}
-	}
-	return lock, trace.Wrap(err)
-}
-
-// GetLocks gets all/in-force locks that match at least one of the targets
-// when specified.
-func (c *Cache) GetLocks(ctx context.Context, inForceOnly bool, targets ...types.LockTarget) ([]types.Lock, error) {
-	ctx, span := c.Tracer.Start(ctx, "cache/GetLocks")
-	defer span.End()
-
-	rg, err := readLegacyCollectionCache(c, c.legacyCacheCollections.locks)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	defer rg.Release()
-	return rg.reader.GetLocks(ctx, inForceOnly, targets...)
-}
-
 // GetDynamicWindowsDesktop returns registered dynamic Windows desktop by name.
 func (c *Cache) GetDynamicWindowsDesktop(ctx context.Context, name string) (types.DynamicWindowsDesktop, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/GetDynamicWindowsDesktop")

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -1287,40 +1287,6 @@ func mustCreateDatabase(t *testing.T, name, protocol, uri string) *types.Databas
 	return database
 }
 
-// TestLocks tests that CRUD operations on lock resources are
-// replicated from the backend to the cache.
-func TestLocks(t *testing.T) {
-	t.Parallel()
-
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	testResources(t, p, testFuncs[types.Lock]{
-		newResource: func(name string) (types.Lock, error) {
-			return types.NewLock(
-				name,
-				types.LockSpecV2{
-					Target: types.LockTarget{
-						Role: "target-role",
-					},
-				},
-			)
-		},
-		create: p.accessS.UpsertLock,
-		list: func(ctx context.Context) ([]types.Lock, error) {
-			results, err := p.accessS.GetLocks(ctx, false)
-			return results, err
-		},
-		cacheGet: p.cache.GetLock,
-		cacheList: func(ctx context.Context) ([]types.Lock, error) {
-			results, err := p.cache.GetLocks(ctx, false)
-			return results, err
-		},
-		update:    p.accessS.UpsertLock,
-		deleteAll: p.accessS.DeleteAllLocks,
-	})
-}
-
 // TestUserTasks tests that CRUD operations on user notification resources are
 // replicated from the backend to the cache.
 func TestUserTasks(t *testing.T) {

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -110,6 +110,7 @@ type collections struct {
 	webTokens                        *collection[types.WebToken, webTokenIndex]
 	uiConfigs                        *collection[types.UIConfig, webUIConfigIndex]
 	installers                       *collection[types.Installer, installerIndex]
+	locks                            *collection[types.Lock, lockIndex]
 }
 
 // setupCollections ensures that the appropriate [collection] is
@@ -543,6 +544,14 @@ func setupCollections(c Config) (*collections, error) {
 
 			out.installers = collect
 			out.byKind[resourceKind] = out.installers
+		case types.KindLock:
+			collect, err := newLockCollection(c.Access, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out.locks = collect
+			out.byKind[resourceKind] = out.locks
 		}
 	}
 

--- a/lib/cache/lock.go
+++ b/lib/cache/lock.go
@@ -1,0 +1,124 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+type lockIndex string
+
+const lockNameIndex lockIndex = "name"
+
+func newLockCollection(upstream services.Access, w types.WatchKind) (*collection[types.Lock, lockIndex], error) {
+	if upstream == nil {
+		return nil, trace.BadParameter("missing parameter Access")
+	}
+
+	return &collection[types.Lock, lockIndex]{
+		store: newStore(map[lockIndex]func(types.Lock) string{
+			lockNameIndex: types.Lock.GetName,
+		}),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.Lock, error) {
+			locks, err := upstream.GetLocks(ctx, false)
+			return locks, trace.Wrap(err)
+		},
+		headerTransform: func(hdr *types.ResourceHeader) types.Lock {
+			return &types.LockV2{
+				Kind:    hdr.Kind,
+				Version: hdr.Version,
+				Metadata: types.Metadata{
+					Name: hdr.Metadata.Name,
+				},
+			}
+		},
+		watch: w,
+	}, nil
+}
+
+// GetLock gets a lock by name.
+func (c *Cache) GetLock(ctx context.Context, name string) (types.Lock, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetLock")
+	defer span.End()
+
+	var upstreamRead bool
+	getter := genericGetter[types.Lock, lockIndex]{
+		cache:      c,
+		collection: c.collections.locks,
+		index:      lockNameIndex,
+		upstreamGet: func(ctx context.Context, s string) (types.Lock, error) {
+			upstreamRead = true
+			lock, err := c.Config.Access.GetLock(ctx, name)
+			return lock, trace.Wrap(err)
+		},
+		clone: types.Lock.Clone,
+	}
+	out, err := getter.get(ctx, types.MetaNameAutoUpdateConfig)
+	if trace.IsNotFound(err) && !upstreamRead {
+		// fallback is sane because method is never used
+		// in construction of derivative caches.
+		if lock, err := c.Config.Access.GetLock(ctx, name); err == nil {
+			return lock, nil
+		}
+	}
+	return out, trace.Wrap(err)
+}
+
+// GetLocks gets all/in-force locks that match at least one of the targets
+// when specified.
+func (c *Cache) GetLocks(ctx context.Context, inForceOnly bool, targets ...types.LockTarget) ([]types.Lock, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetLocks")
+	defer span.End()
+
+	rg, err := acquireReadGuard(c, c.collections.locks)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+
+	if !rg.ReadCache() {
+		users, err := c.Config.Access.GetLocks(ctx, inForceOnly, targets...)
+		return users, trace.Wrap(err)
+	}
+
+	var locks []types.Lock
+	for lock := range rg.store.resources(lockNameIndex, "", "") {
+		if inForceOnly && !lock.IsInForce(time.Now()) {
+			continue
+		}
+		// If no targets specified, return all of the found/in-force locks.
+		if len(targets) == 0 {
+			locks = append(locks, lock)
+			continue
+		}
+		// Otherwise, use the targets as filters.
+		for _, target := range targets {
+			if target.Match(lock) {
+				locks = append(locks, lock)
+				break
+			}
+		}
+	}
+
+	return locks, nil
+}

--- a/lib/cache/lock_test.go
+++ b/lib/cache/lock_test.go
@@ -1,0 +1,58 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+// TestLocks tests that CRUD operations on lock resources are
+// replicated from the backend to the cache.
+func TestLocks(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	testResources(t, p, testFuncs[types.Lock]{
+		newResource: func(name string) (types.Lock, error) {
+			return types.NewLock(
+				name,
+				types.LockSpecV2{
+					Target: types.LockTarget{
+						Role: "target-role",
+					},
+				},
+			)
+		},
+		create: p.accessS.UpsertLock,
+		list: func(ctx context.Context) ([]types.Lock, error) {
+			results, err := p.accessS.GetLocks(ctx, false)
+			return results, err
+		},
+		cacheGet: p.cache.GetLock,
+		cacheList: func(ctx context.Context) ([]types.Lock, error) {
+			results, err := p.cache.GetLocks(ctx, false)
+			return results, err
+		},
+		update:    p.accessS.UpsertLock,
+		deleteAll: p.accessS.DeleteAllLocks,
+	})
+}


### PR DESCRIPTION
Moves locks to the new cache collection scheme that  was introduced in #52210. No additional functionality  changes have been made here. This should be a purely  mechanical translation to the new internal caching  machinery.