### PR TITLE
Convert static host user to new cache mechanism

### DIFF
--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -39,7 +39,6 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	identitycenterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/identitycenter/v1"
 	provisioningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/provisioning/v1"
-	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	"github.com/gravitational/teleport/api/internalutils/stream"
 	apitracing "github.com/gravitational/teleport/api/observability/tracing"
 	"github.com/gravitational/teleport/api/types"
@@ -507,7 +506,6 @@ type Cache struct {
 	secReportsCache              services.SecReports
 	eventsFanout                 *services.FanoutV2
 	lowVolumeEventsFanout        *utils.RoundRobin[*services.FanoutV2]
-	staticHostUsersCache         *local.StaticHostUserService
 	provisioningStatesCache      *local.ProvisioningStateService
 	identityCenterCache          *local.IdentityCenterService
 	pluginStaticCredentialsCache *local.PluginStaticCredentialsService
@@ -927,12 +925,6 @@ func New(config Config) (*Cache, error) {
 		lowVolumeFanouts = append(lowVolumeFanouts, services.NewFanoutV2(services.FanoutV2Config{}))
 	}
 
-	staticHostUserCache, err := local.NewStaticHostUserService(config.Backend)
-	if err != nil {
-		cancel()
-		return nil, trace.Wrap(err)
-	}
-
 	identityService, err := local.NewIdentityService(config.Backend)
 	if err != nil {
 		cancel()
@@ -983,7 +975,6 @@ func New(config Config) (*Cache, error) {
 		secReportsCache:              secReportsCache,
 		eventsFanout:                 fanout,
 		lowVolumeEventsFanout:        utils.NewRoundRobin(lowVolumeFanouts),
-		staticHostUsersCache:         staticHostUserCache,
 		provisioningStatesCache:      provisioningStatesCache,
 		identityCenterCache:          identityCenterCache,
 		pluginStaticCredentialsCache: pluginStaticCredentialsCache,
@@ -1738,32 +1729,6 @@ func (c *Cache) processEvent(ctx context.Context, event types.Event) error {
 	}
 
 	return nil
-}
-
-// ListStaticHostUsers lists static host users.
-func (c *Cache) ListStaticHostUsers(ctx context.Context, pageSize int, pageToken string) ([]*userprovisioningpb.StaticHostUser, string, error) {
-	ctx, span := c.Tracer.Start(ctx, "cache/ListStaticHostUsers")
-	defer span.End()
-
-	rg, err := readLegacyCollectionCache(c, c.legacyCacheCollections.staticHostUsers)
-	if err != nil {
-		return nil, "", trace.Wrap(err)
-	}
-	defer rg.Release()
-	return rg.reader.ListStaticHostUsers(ctx, pageSize, pageToken)
-}
-
-// GetStaticHostUser returns a static host user by name.
-func (c *Cache) GetStaticHostUser(ctx context.Context, name string) (*userprovisioningpb.StaticHostUser, error) {
-	ctx, span := c.Tracer.Start(ctx, "cache/GetStaticHostUser")
-	defer span.End()
-
-	rg, err := readLegacyCollectionCache(c, c.legacyCacheCollections.staticHostUsers)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	defer rg.Release()
-	return rg.reader.GetStaticHostUser(ctx, name)
 }
 
 // GetNetworkRestrictions gets the network restrictions.

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -140,7 +140,7 @@ type testPack struct {
 	crownJewels             services.CrownJewels
 	databaseObjects         services.DatabaseObjects
 	spiffeFederations       *local.SPIFFEFederationService
-	staticHostUsers         services.StaticHostUser
+	staticHostUsers         *local.StaticHostUserService
 	autoUpdateService       services.AutoUpdateService
 	provisioningStates      services.ProvisioningStates
 	identityCenter          services.IdentityCenter
@@ -1366,34 +1366,6 @@ func TestSecurityReportState(t *testing.T) {
 			return trace.Wrap(err)
 		},
 		deleteAll: p.secReports.DeleteAllSecurityReportsStates,
-	})
-}
-
-// TestStaticHostUsers tests that CRUD operations on static host user resources are
-// replicated from the backend to the cache.
-func TestStaticHostUsers(t *testing.T) {
-	t.Parallel()
-
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	testResources153(t, p, testFuncs153[*userprovisioningpb.StaticHostUser]{
-		newResource: func(name string) (*userprovisioningpb.StaticHostUser, error) {
-			return newStaticHostUser(t, name), nil
-		},
-		create: func(ctx context.Context, item *userprovisioningpb.StaticHostUser) error {
-			_, err := p.staticHostUsers.CreateStaticHostUser(ctx, item)
-			return trace.Wrap(err)
-		},
-		list: func(ctx context.Context) ([]*userprovisioningpb.StaticHostUser, error) {
-			items, _, err := p.staticHostUsers.ListStaticHostUsers(ctx, 0, "")
-			return items, trace.Wrap(err)
-		},
-		cacheList: func(ctx context.Context) ([]*userprovisioningpb.StaticHostUser, error) {
-			items, _, err := p.cache.ListStaticHostUsers(ctx, 0, "")
-			return items, trace.Wrap(err)
-		},
-		deleteAll: p.cache.staticHostUsersCache.DeleteAllStaticHostUsers,
 	})
 }
 

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -31,6 +31,7 @@ import (
 	kubewaitingcontainerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	notificationsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
+	userprovisioningv2 "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
 	workloadidentityv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -123,6 +124,7 @@ type collections struct {
 	userLoginStates                  *collection[*userloginstate.UserLoginState, userLoginStateIndex]
 	gitServers                       *collection[types.Server, gitServerIndex]
 	databaseObjects                  *collection[*dbobjectv1.DatabaseObject, databaseObjectIndex]
+	staticHostUsers                  *collection[*userprovisioningv2.StaticHostUser, staticHostUserIndex]
 }
 
 // setupCollections ensures that the appropriate [collection] is
@@ -629,6 +631,14 @@ func setupCollections(c Config) (*collections, error) {
 
 			out.gitServers = collect
 			out.byKind[resourceKind] = out.gitServers
+		case types.KindStaticHostUser:
+			collect, err := newStaticHostUserCollection(c.StaticHostUsers, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out.staticHostUsers = collect
+			out.byKind[resourceKind] = out.staticHostUsers
 		}
 	}
 

--- a/lib/cache/static_host_user.go
+++ b/lib/cache/static_host_user.go
@@ -1,0 +1,111 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	userprovisioningv2 "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+type staticHostUserIndex string
+
+const staticHostUserNameIndex staticHostUserIndex = "name"
+
+func newStaticHostUserCollection(upstream services.StaticHostUser, w types.WatchKind) (*collection[*userprovisioningv2.StaticHostUser, staticHostUserIndex], error) {
+	if upstream == nil {
+		return nil, trace.BadParameter("missing parameter StaticHostUser")
+	}
+
+	return &collection[*userprovisioningv2.StaticHostUser, staticHostUserIndex]{
+		store: newStore(map[staticHostUserIndex]func(*userprovisioningv2.StaticHostUser) string{
+			staticHostUserNameIndex: func(shu *userprovisioningv2.StaticHostUser) string {
+				return shu.GetMetadata().GetName()
+			},
+		}),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]*userprovisioningv2.StaticHostUser, error) {
+			var startKey string
+			var allUsers []*userprovisioningv2.StaticHostUser
+
+			for {
+				users, nextKey, err := upstream.ListStaticHostUsers(ctx, 0, startKey)
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+
+				allUsers = append(allUsers, users...)
+
+				if nextKey == "" {
+					break
+				}
+				startKey = nextKey
+			}
+			return allUsers, nil
+		},
+		headerTransform: func(hdr *types.ResourceHeader) *userprovisioningv2.StaticHostUser {
+			return &userprovisioningv2.StaticHostUser{
+				Kind:    hdr.Kind,
+				Version: hdr.Version,
+				Metadata: &headerv1.Metadata{
+					Name: hdr.Metadata.Name,
+				},
+			}
+		},
+		watch: w,
+	}, nil
+}
+
+// ListStaticHostUsers lists static host users.
+func (c *Cache) ListStaticHostUsers(ctx context.Context, pageSize int, pageToken string) ([]*userprovisioningv2.StaticHostUser, string, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/ListStaticHostUsers")
+	defer span.End()
+
+	lister := genericLister[*userprovisioningv2.StaticHostUser, staticHostUserIndex]{
+		cache:        c,
+		collection:   c.collections.staticHostUsers,
+		index:        staticHostUserNameIndex,
+		upstreamList: c.Config.StaticHostUsers.ListStaticHostUsers,
+		nextToken: func(t *userprovisioningv2.StaticHostUser) string {
+			return t.GetMetadata().GetName()
+		},
+		clone: utils.CloneProtoMsg[*userprovisioningv2.StaticHostUser],
+	}
+	out, next, err := lister.list(ctx, pageSize, pageToken)
+	return out, next, trace.Wrap(err)
+}
+
+// GetStaticHostUser returns a static host user by name.
+func (c *Cache) GetStaticHostUser(ctx context.Context, name string) (*userprovisioningv2.StaticHostUser, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetStaticHostUser")
+	defer span.End()
+
+	getter := genericGetter[*userprovisioningv2.StaticHostUser, staticHostUserIndex]{
+		cache:       c,
+		collection:  c.collections.staticHostUsers,
+		index:       staticHostUserNameIndex,
+		upstreamGet: c.Config.StaticHostUsers.GetStaticHostUser,
+		clone:       utils.CloneProtoMsg[*userprovisioningv2.StaticHostUser],
+	}
+	out, err := getter.get(ctx, name)
+	return out, trace.Wrap(err)
+}

--- a/lib/cache/static_host_user_test.go
+++ b/lib/cache/static_host_user_test.go
@@ -1,0 +1,55 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/trace"
+
+	userprovisioningv2 "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
+)
+
+// TestStaticHostUsers tests that CRUD operations on static host user resources are
+// replicated from the backend to the cache.
+func TestStaticHostUsers(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	testResources153(t, p, testFuncs153[*userprovisioningv2.StaticHostUser]{
+		newResource: func(name string) (*userprovisioningv2.StaticHostUser, error) {
+			return newStaticHostUser(t, name), nil
+		},
+		create: func(ctx context.Context, item *userprovisioningv2.StaticHostUser) error {
+			_, err := p.staticHostUsers.CreateStaticHostUser(ctx, item)
+			return trace.Wrap(err)
+		},
+		list: func(ctx context.Context) ([]*userprovisioningv2.StaticHostUser, error) {
+			items, _, err := p.staticHostUsers.ListStaticHostUsers(ctx, 0, "")
+			return items, trace.Wrap(err)
+		},
+		cacheList: func(ctx context.Context) ([]*userprovisioningv2.StaticHostUser, error) {
+			items, _, err := p.cache.ListStaticHostUsers(ctx, 0, "")
+			return items, trace.Wrap(err)
+		},
+		cacheGet:  p.cache.GetStaticHostUser,
+		deleteAll: p.staticHostUsers.DeleteAllStaticHostUsers,
+	})
+}


### PR DESCRIPTION
Moves static host users to the new cache collection scheme  that was introduced in #52210. No additional functionality  changes have been made here. This should be a purely  mechanical translation to the new internal caching machinery.