### PR TITLE
[vnet] feat: add transparent SSH proxy

### DIFF
--- a/lib/vnet/ssh_proxy.go
+++ b/lib/vnet/ssh_proxy.go
@@ -175,7 +175,7 @@ func proxyChannel(
 	}()
 
 	// ProxyConn copies channel data bidirectionally. If the context is
-	// cancelled it will terminate, it always closes both channels before
+	// canceled it will terminate, it always closes both channels before
 	// returning.
 	if err := utils.ProxyConn(ctx, incomingChan, targetChan); err != nil &&
 		!utils.IsOKNetworkError(err) && !errors.Is(err, context.Canceled) {

--- a/lib/vnet/ssh_proxy.go
+++ b/lib/vnet/ssh_proxy.go
@@ -1,0 +1,239 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// proxySSHConnection transparently proxies incoming SSH channels and requests
+// to a target SSH client.
+func proxySSHConnection(
+	ctx context.Context,
+	targetClient *ssh.Client,
+	channels <-chan ssh.NewChannel,
+	requests <-chan *ssh.Request,
+) error {
+	g, ctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		return proxyChannels(ctx, targetClient, channels)
+	})
+	g.Go(func() error {
+		return proxyGlobalRequests(ctx, targetClient, requests)
+	})
+	return trace.Wrap(g.Wait(), "proxying SSH connection")
+}
+
+func proxyGlobalRequests(
+	ctx context.Context,
+	targetClient *ssh.Client,
+	requests <-chan *ssh.Request,
+) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case req, ok := <-requests:
+			if !ok {
+				return nil
+			}
+			ok, reply, err := targetClient.SendRequest(req.Type, req.WantReply, req.Payload)
+			if err != nil {
+				if !req.WantReply {
+					// No reply was expected, log the error and continue
+					// handling global requests.
+					log.WarnContext(ctx, "Failed to forward global SSH request to target", "error", err)
+					continue
+				}
+				err = trace.Wrap(err, "forwarding global request to target")
+				if replyErr := req.Reply(false, nil); replyErr != nil {
+					// A reply was expected and we failed to send one, we're in a
+					// bad state, return an error to terminate the connection.
+					return trace.NewAggregate(err, trace.Wrap(replyErr, "replying to request with error"))
+				}
+				// We failed to send the request, but we informed the client of
+				// the failure with req.Reply(false, nil), so it's safe to
+				// continue.
+				continue
+			}
+			if err := req.Reply(ok, reply); err != nil {
+				// A reply was expected by the client and returned by the target
+				// but we failed to forward it back. We're in a bad state,
+				// return an error to terminate the connection.
+				return trace.Wrap(err, "forwarding reply from target back to client")
+			}
+		}
+	}
+}
+
+func proxyChannels(
+	ctx context.Context,
+	targetClient *ssh.Client,
+	channels <-chan ssh.NewChannel,
+) (err error) {
+	// Every channel will be handled in its own goroutine, but a recoverable
+	// error from a single channel should not terminate other channels, so
+	// handleNewChannel must avoid returning errors that should not terminate
+	// the connection.
+	g, ctx := errgroup.WithContext(ctx)
+	defer func() {
+		chanErr := g.Wait()
+		if chanErr == nil ||
+			utils.IsOKNetworkError(chanErr) ||
+			errors.Is(chanErr, context.Canceled) {
+			return
+		}
+		err = trace.NewAggregate(err, chanErr)
+	}()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case newChan, ok := <-channels:
+			if !ok {
+				return nil
+			}
+			g.Go(func() error {
+				return trace.Wrap(handleNewChannel(ctx, targetClient, newChan),
+					"unexpected error while handling SSH channel")
+			})
+		}
+	}
+}
+
+func handleNewChannel(ctx context.Context, targetClient *ssh.Client, newChan ssh.NewChannel) error {
+	log.DebugContext(ctx, "Handling new SSH channel", "type", newChan.ChannelType())
+
+	// Try to open a corresponding channel on the target. If the target rejects
+	// the channel, reject the incoming channel request.
+	targetChan, targetChanRequests, err := targetClient.OpenChannel(newChan.ChannelType(), newChan.ExtraData())
+	if err != nil {
+		reason, message, unexpectedOpenChannelErr := rejectChannelReason(err)
+		rejectErr := trace.Wrap(newChan.Reject(reason, message),
+			"rejecting incoming channel request after failing to open channel on target")
+		if unexpectedOpenChannelErr != nil || rejectErr != nil {
+			// Either of these errors is unexpected so return an error
+			// to terminate the full SSH connection.
+			return trace.NewAggregate(unexpectedOpenChannelErr, rejectErr)
+		}
+		// The channel was successfully rejected, this is fine, the client may
+		// have requested a channel type the target doesn't support.
+		return nil
+	}
+
+	// Now that the target accepted the channel, accept the incoming channel
+	// request.
+	serverChan, serverChanRequests, acceptErr := newChan.Accept()
+	if acceptErr != nil {
+		acceptErr = trace.Wrap(acceptErr,
+			"accepting incoming channel request")
+		closeTargetChanErr := trace.Wrap(targetChan.Close(),
+			"closing target channel after failing to accept incoming channel request")
+		// Failing to accept an incoming channel request that the target already
+		// accepted should probably be fatal, so return an error to terminate
+		// the full SSH connection.
+		return trace.NewAggregate(acceptErr, closeTargetChanErr)
+	}
+
+	// Use separate goroutines to:
+	// 1. Bidirectionally copy channel data.
+	// 2. Proxy requests from the client to the target.
+	// 3. Proxy requests from the target to the client.
+	// If any of these returns an error it will terminate this channel only.
+	// No error will be returned from handleNewChannel because the error is
+	// specific to this channel and should not terminate the full SSH
+	// connection.
+	g, ctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		// ProxyConn will copy channel data bidirectionally and close both
+		// channels before returning.
+		err := utils.ProxyConn(ctx, serverChan, targetChan)
+		return trace.Wrap(err, "proxying channel data")
+	})
+	g.Go(func() error {
+		err := proxyChannelRequests(ctx, targetChan, serverChan, serverChanRequests)
+		return trace.Wrap(err, "forwarding channel requests from server to target")
+	})
+	g.Go(func() error {
+		err := proxyChannelRequests(ctx, serverChan, targetChan, targetChanRequests)
+		return trace.Wrap(err, "forwarding channel requests from target to server")
+	})
+	if err := g.Wait(); err != nil &&
+		!utils.IsOKNetworkError(err) && !errors.Is(err, context.Canceled) {
+		log.DebugContext(ctx, "SSH channel closed", "error", err)
+	}
+	return nil
+}
+
+func rejectChannelReason(err error) (reason ssh.RejectionReason, message string, unexpectedErr error) {
+	var openChannelErr *ssh.OpenChannelError
+	if errors.As(err, &openChannelErr) {
+		return openChannelErr.Reason, openChannelErr.Message, nil
+	}
+	unexpectedErr = fmt.Errorf("unexpected error opening SSH channel: %w", err)
+	return ssh.ConnectionFailed, unexpectedErr.Error(), trace.Wrap(unexpectedErr)
+}
+
+func proxyChannelRequests(
+	ctx context.Context,
+	dst, src ssh.Channel,
+	requests <-chan *ssh.Request,
+) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case req, ok := <-requests:
+			if !ok {
+				return nil
+			}
+			ok, err := dst.SendRequest(req.Type, req.WantReply, req.Payload)
+			if err != nil {
+				if !req.WantReply {
+					// No reply was expected, log the error and continue
+					// handling channel requests.
+					log.WarnContext(ctx, "Failed to forward channel SSH request", "error", err)
+					continue
+				}
+				err = trace.Wrap(err, "forwarding channel request")
+				if replyErr := req.Reply(false, nil); replyErr != nil {
+					// A reply was expected but we failed to send one, we're in
+					// a bad state, return an error to terminate the channel.
+					return trace.NewAggregate(err, trace.Wrap(replyErr, "replying to channel request with error"))
+				}
+				// We failed to forward the request, but we informed the client of
+				// the failure with req.Reply(false, nil), so it's safe to
+				// continue.
+				continue
+			}
+			if err := req.Reply(ok, nil); err != nil {
+				// A reply was expected, and we got one but failed to forward
+				// it back. We're in a bad state, return an error to terminate
+				// the channel.
+				return trace.Wrap(err, "forwarding reply to channel request")
+			}
+		}
+	}
+}

--- a/lib/vnet/ssh_proxy.go
+++ b/lib/vnet/ssh_proxy.go
@@ -19,221 +19,242 @@ package vnet
 import (
 	"context"
 	"errors"
-	"fmt"
+	"log/slog"
+	"sync"
 
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-// proxySSHConnection transparently proxies incoming SSH channels and requests
-// to a target SSH client.
-func proxySSHConnection(
-	ctx context.Context,
-	targetClient *ssh.Client,
-	channels <-chan ssh.NewChannel,
-	requests <-chan *ssh.Request,
-) error {
-	g, ctx := errgroup.WithContext(ctx)
-	g.Go(func() error {
-		return proxyChannels(ctx, targetClient, channels)
-	})
-	g.Go(func() error {
-		return proxyGlobalRequests(ctx, targetClient, requests)
-	})
-	return trace.Wrap(g.Wait(), "proxying SSH connection")
+// sshConn represents an established SSH client or server connection.
+type sshConn struct {
+	conn  ssh.Conn
+	chans <-chan ssh.NewChannel
+	reqs  <-chan *ssh.Request
 }
 
-func proxyGlobalRequests(
+// proxySSHConnection transparently proxies SSH channels and requests
+// between 2 established SSH connections. serverConn represents an incoming SSH
+// connection where this proxy acts as a server, client represents an outgoing
+// SSH connection where this proxy acts as a client.
+func proxySSHConnection(
 	ctx context.Context,
-	targetClient *ssh.Client,
-	requests <-chan *ssh.Request,
-) error {
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case req, ok := <-requests:
-			if !ok {
-				return nil
-			}
-			ok, reply, err := targetClient.SendRequest(req.Type, req.WantReply, req.Payload)
-			if err != nil {
-				if !req.WantReply {
-					// No reply was expected, log the error and continue
-					// handling global requests.
-					log.WarnContext(ctx, "Failed to forward global SSH request to target", "error", err)
-					continue
-				}
-				err = trace.Wrap(err, "forwarding global request to target")
-				if replyErr := req.Reply(false, nil); replyErr != nil {
-					// A reply was expected and we failed to send one, we're in a
-					// bad state, return an error to terminate the connection.
-					return trace.NewAggregate(err, trace.Wrap(replyErr, "replying to request with error"))
-				}
-				// We failed to send the request, but we informed the client of
-				// the failure with req.Reply(false, nil), so it's safe to
-				// continue.
-				continue
-			}
-			if err := req.Reply(ok, reply); err != nil {
-				// A reply was expected by the client and returned by the target
-				// but we failed to forward it back. We're in a bad state,
-				// return an error to terminate the connection.
-				return trace.Wrap(err, "forwarding reply from target back to client")
-			}
-		}
+	serverConn sshConn,
+	clientConn sshConn,
+) {
+	closeConnections := func() {
+		clientConn.conn.Close()
+		serverConn.conn.Close()
 	}
+
+	// Avoid leaking goroutines by tracking them with a waitgroup.
+	var wg sync.WaitGroup
+	wg.Add(5)
+
+	// Close both connections if the context is canceled.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go func() {
+		defer wg.Done()
+		<-ctx.Done()
+		closeConnections()
+	}()
+
+	// Proxy channels initiated by either connection.
+	go func() {
+		defer wg.Done()
+		proxyChannels(ctx, serverConn.conn, clientConn.chans, closeConnections)
+	}()
+	go func() {
+		defer wg.Done()
+		proxyChannels(ctx, clientConn.conn, serverConn.chans, closeConnections)
+	}()
+
+	// Proxy global requests in both directions.
+	go func() {
+		defer wg.Done()
+		proxyGlobalRequests(ctx, serverConn.conn, clientConn.reqs, closeConnections)
+	}()
+	go func() {
+		defer wg.Done()
+		proxyGlobalRequests(ctx, clientConn.conn, serverConn.reqs, closeConnections)
+	}()
+
+	wg.Wait()
 }
 
 func proxyChannels(
 	ctx context.Context,
-	targetClient *ssh.Client,
-	channels <-chan ssh.NewChannel,
-) (err error) {
-	// Every channel will be handled in its own goroutine, but a recoverable
-	// error from a single channel should not terminate other channels, so
-	// handleNewChannel must avoid returning errors that should not terminate
-	// the connection.
-	g, ctx := errgroup.WithContext(ctx)
-	defer func() {
-		chanErr := g.Wait()
-		if chanErr == nil ||
-			utils.IsOKNetworkError(chanErr) ||
-			errors.Is(chanErr, context.Canceled) {
-			return
-		}
-		err = trace.NewAggregate(err, chanErr)
-	}()
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case newChan, ok := <-channels:
-			if !ok {
-				return nil
-			}
-			g.Go(func() error {
-				return trace.Wrap(handleNewChannel(ctx, targetClient, newChan),
-					"unexpected error while handling SSH channel")
-			})
-		}
+	targetConn ssh.Conn,
+	chans <-chan ssh.NewChannel,
+	closeConnections func(),
+) {
+	// Proxy each SSH channel in its own goroutine, make sure they don't leak by
+	// tracking with a WaitGroup.
+	var wg sync.WaitGroup
+	for newChan := range chans {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			proxyChannel(ctx, targetConn, newChan, closeConnections)
+		}()
 	}
+	// We get here when the source SSH connection was closed, make sure to close
+	// the opposite connection too.
+	closeConnections()
+	wg.Wait()
 }
 
-func handleNewChannel(ctx context.Context, targetClient *ssh.Client, newChan ssh.NewChannel) error {
-	log.DebugContext(ctx, "Handling new SSH channel", "type", newChan.ChannelType())
+func proxyChannel(
+	ctx context.Context,
+	targetConn ssh.Conn,
+	newChan ssh.NewChannel,
+	closeConnections func(),
+) {
+	log := log.With("channel_type", newChan.ChannelType())
+	log.DebugContext(ctx, "Proxying new SSH channel")
 
-	// Try to open a corresponding channel on the target. If the target rejects
-	// the channel, reject the incoming channel request.
-	targetChan, targetChanRequests, err := targetClient.OpenChannel(newChan.ChannelType(), newChan.ExtraData())
+	// Try to open a corresponding channel on the target.
+	targetChan, targetChanRequests, err := targetConn.OpenChannel(
+		newChan.ChannelType(), newChan.ExtraData())
 	if err != nil {
-		reason, message, unexpectedOpenChannelErr := rejectChannelReason(err)
-		rejectErr := trace.Wrap(newChan.Reject(reason, message),
-			"rejecting incoming channel request after failing to open channel on target")
-		if unexpectedOpenChannelErr != nil || rejectErr != nil {
-			// Either of these errors is unexpected so return an error
-			// to terminate the full SSH connection.
-			return trace.NewAggregate(unexpectedOpenChannelErr, rejectErr)
+		var openChannelErr *ssh.OpenChannelError
+		var rejectErr error
+		if errors.As(err, &openChannelErr) {
+			// The target rejected the channel, this is totally expected in some
+			// cases, just reject the incoming channel request.
+			rejectErr = trace.Wrap(newChan.Reject(openChannelErr.Reason, openChannelErr.Message))
+		} else {
+			// We got an unexpected error trying to open the channel on the
+			// target, this is fatal, log and kill the connection.
+			log.DebugContext(ctx, "Unexpected error opening SSH channel on target",
+				"error", err)
+			msg := "unexpected error opening channel on target: " + err.Error()
+			rejectErr = trace.Wrap(newChan.Reject(ssh.ConnectionFailed, msg))
+			closeConnections()
 		}
-		// The channel was successfully rejected, this is fine, the client may
-		// have requested a channel type the target doesn't support.
-		return nil
+		if rejectErr != nil {
+			// We failed to reject the incoming channel, this is fatal, log and
+			// kill the connection.
+			log.DebugContext(ctx, "Failed to reject SSH channel request",
+				"error", err)
+			closeConnections()
+		}
+		return
 	}
 
 	// Now that the target accepted the channel, accept the incoming channel
 	// request.
-	serverChan, serverChanRequests, acceptErr := newChan.Accept()
-	if acceptErr != nil {
-		acceptErr = trace.Wrap(acceptErr,
-			"accepting incoming channel request")
-		closeTargetChanErr := trace.Wrap(targetChan.Close(),
-			"closing target channel after failing to accept incoming channel request")
+	incomingChan, incomingChanRequests, err := newChan.Accept()
+	if err != nil {
 		// Failing to accept an incoming channel request that the target already
-		// accepted should probably be fatal, so return an error to terminate
-		// the full SSH connection.
-		return trace.NewAggregate(acceptErr, closeTargetChanErr)
+		// accepted is fatal. Log, close the channel we just opened on the
+		// target, and kill the connection.
+		log.DebugContext(ctx, "Failed to accept SSH channel request already accepted by the target, killing the connection",
+			"error", err)
+		if err := targetChan.Close(); err != nil {
+			log.DebugContext(ctx, "Failed to close SSH channel on target",
+				"error", err)
+		}
+		closeConnections()
+		return
 	}
 
-	// Use separate goroutines to:
-	// 1. Bidirectionally copy channel data.
-	// 2. Proxy requests from the client to the target.
-	// 3. Proxy requests from the target to the client.
-	// If any of these returns an error it will terminate this channel only.
-	// No error will be returned from handleNewChannel because the error is
-	// specific to this channel and should not terminate the full SSH
-	// connection.
-	g, ctx := errgroup.WithContext(ctx)
-	g.Go(func() error {
-		// ProxyConn will copy channel data bidirectionally and close both
-		// channels before returning.
-		err := utils.ProxyConn(ctx, serverChan, targetChan)
-		return trace.Wrap(err, "proxying channel data")
-	})
-	g.Go(func() error {
-		err := proxyChannelRequests(ctx, targetChan, serverChan, serverChanRequests)
-		return trace.Wrap(err, "forwarding channel requests from server to target")
-	})
-	g.Go(func() error {
-		err := proxyChannelRequests(ctx, serverChan, targetChan, targetChanRequests)
-		return trace.Wrap(err, "forwarding channel requests from target to server")
-	})
-	if err := g.Wait(); err != nil &&
+	// Use 2 goroutines to proxy channel requests bidirectionally. The
+	// goroutines will terminate after the channels has been closed, and either
+	// will close the channels upon any unrecoverable error.
+	closeChannels := func() {
+		incomingChan.Close()
+		targetChan.Close()
+	}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		proxyChannelRequests(ctx, log, targetChan, incomingChanRequests, closeChannels)
+	}()
+	go func() {
+		defer wg.Done()
+		proxyChannelRequests(ctx, log, incomingChan, targetChanRequests, closeChannels)
+	}()
+
+	// Proxy channel data bidirectionally.
+	if err := utils.ProxyConn(ctx, incomingChan, targetChan); err != nil &&
 		!utils.IsOKNetworkError(err) && !errors.Is(err, context.Canceled) {
-		log.DebugContext(ctx, "SSH channel closed", "error", err)
+		log.DebugContext(ctx, "Unexpected error proxying channel data", "error", err)
 	}
-	return nil
-}
 
-func rejectChannelReason(err error) (reason ssh.RejectionReason, message string, unexpectedErr error) {
-	var openChannelErr *ssh.OpenChannelError
-	if errors.As(err, &openChannelErr) {
-		return openChannelErr.Reason, openChannelErr.Message, nil
-	}
-	unexpectedErr = fmt.Errorf("unexpected error opening SSH channel: %w", err)
-	return ssh.ConnectionFailed, unexpectedErr.Error(), trace.Wrap(unexpectedErr)
+	// utils.ProxyConn will close both channels before returning, causing the
+	// channel request goroutines to terminate.
+	wg.Wait()
 }
 
 func proxyChannelRequests(
 	ctx context.Context,
-	dst, src ssh.Channel,
-	requests <-chan *ssh.Request,
-) error {
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case req, ok := <-requests:
-			if !ok {
-				return nil
+	log *slog.Logger,
+	targetChan ssh.Channel,
+	reqs <-chan *ssh.Request,
+	closeChannels func(),
+) {
+	log = log.With("request_layer", "channel")
+	sendRequest := func(name string, wantReply bool, payload []byte) (bool, []byte, error) {
+		ok, err := targetChan.SendRequest(name, wantReply, payload)
+		// Replies to channel requests never have a payload.
+		return ok, nil, err
+	}
+	proxyRequests(ctx, log, sendRequest, reqs, closeChannels)
+}
+
+func proxyGlobalRequests(
+	ctx context.Context,
+	targetConn ssh.Conn,
+	reqs <-chan *ssh.Request,
+	closeConnections func(),
+) {
+	log := log.With("request_layer", "global")
+	sendRequest := targetConn.SendRequest
+	proxyRequests(ctx, log, sendRequest, reqs, closeConnections)
+}
+
+func proxyRequests(
+	ctx context.Context,
+	log *slog.Logger,
+	sendRequest func(name string, wantReply bool, payload []byte) (bool, []byte, error),
+	reqs <-chan *ssh.Request,
+	closeRequestSources func(),
+) {
+	for req := range reqs {
+		log := log.With("request_type", req.Type)
+		log.DebugContext(ctx, "Proxying SSH request")
+		ok, reply, err := sendRequest(req.Type, req.WantReply, req.Payload)
+		if err != nil {
+			// We failed to send the request, the target must be dead.
+			log.DebugContext(ctx, "Failed to forward SSH request", "request_type", req.Type, "error", err)
+			// We must first send a reply if one was expected.
+			if req.WantReply {
+				req.Reply(false, nil)
 			}
-			ok, err := dst.SendRequest(req.Type, req.WantReply, req.Payload)
-			if err != nil {
-				if !req.WantReply {
-					// No reply was expected, log the error and continue
-					// handling channel requests.
-					log.WarnContext(ctx, "Failed to forward channel SSH request", "error", err)
-					continue
-				}
-				err = trace.Wrap(err, "forwarding channel request")
-				if replyErr := req.Reply(false, nil); replyErr != nil {
-					// A reply was expected but we failed to send one, we're in
-					// a bad state, return an error to terminate the channel.
-					return trace.NewAggregate(err, trace.Wrap(replyErr, "replying to channel request with error"))
-				}
-				// We failed to forward the request, but we informed the client of
-				// the failure with req.Reply(false, nil), so it's safe to
-				// continue.
-				continue
-			}
-			if err := req.Reply(ok, nil); err != nil {
-				// A reply was expected, and we got one but failed to forward
-				// it back. We're in a bad state, return an error to terminate
-				// the channel.
-				return trace.Wrap(err, "forwarding reply to channel request")
-			}
+			// Close both connections or channels to clean up but we must continue handling
+			// requests on the chan until it is closed by crypto/ssh.
+			closeRequestSources()
+			continue
+		}
+		if !req.WantReply {
+			continue
+		}
+		if err := req.Reply(ok, reply); err != nil {
+			// A reply was expected and returned by the target but we failed to
+			// forward it back, the connection that initiated the request must
+			// be dead.
+			log.DebugContext(ctx, "Failed to reply to SSH request", "request_type", req.Type, "error", err)
+			// Close both connections or channels to clean up but we must continue handling
+			// requests on the chan until it is closed by crypto/ssh.
+			closeRequestSources()
 		}
 	}
+	// We get here when the source SSH connection or channel was closed, make
+	// sure the opposite one is closed too.
+	closeRequestSources()
 }

--- a/lib/vnet/ssh_proxy.go
+++ b/lib/vnet/ssh_proxy.go
@@ -48,7 +48,8 @@ func proxySSHConnection(
 		serverConn.conn.Close()
 	})
 	// Close both connections if the context is canceled.
-	context.AfterFunc(ctx, closeConnections)
+	stop := context.AfterFunc(ctx, closeConnections)
+	defer stop()
 
 	// Avoid leaking goroutines by tracking them with a waitgroup.
 	// If any task exits make sure to close both connections so that all other

--- a/lib/vnet/ssh_proxy_test.go
+++ b/lib/vnet/ssh_proxy_test.go
@@ -1,0 +1,340 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/gravitational/teleport/lib/cryptosuites"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// TestProxySSHConnection exercises [proxySSHConnection] to test that it
+// transparently proxies SSH channels and requests.
+//
+// The test starts a target SSH server implemented in this file that handles
+// channels and requests of type "echo", each handler echos input back to
+// output.
+//
+// The test also starts a proxy server that proxies incoming SSH connections to
+// the target server using [proxySSHConnection].
+//
+// The test asserts that connecting directly to the target server or to the
+// proxy appears identical to the client.
+func TestProxySSHConnection(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	proxyListener := bufconn.Listen(100)
+	serverListener := bufconn.Listen(100)
+
+	targetServerConfig := sshServerConfig(t)
+	proxyServerConfig := sshServerConfig(t)
+
+	proxyClientConfig := sshClientConfig(t)
+
+	utils.RunTestBackgroundTask(ctx, t, &utils.TestBackgroundTask{
+		Name: "target server",
+		Task: func(ctx context.Context) error {
+			return runTestSSHServer(serverListener, targetServerConfig)
+		},
+		Terminate: func() error {
+			return trace.Wrap(serverListener.Close())
+		},
+	})
+	utils.RunTestBackgroundTask(ctx, t, &utils.TestBackgroundTask{
+		Name: "proxy server",
+		Task: func(ctx context.Context) error {
+			return runTestSSHProxy(ctx,
+				proxyListener,
+				proxyServerConfig,
+				serverListener,
+				proxyClientConfig,
+			)
+		},
+		Terminate: func() error {
+			return trace.Wrap(proxyListener.Close())
+		},
+	})
+
+	for name, dial := range map[string]dialer{
+		"direct":  serverListener,
+		"proxied": proxyListener,
+	} {
+		t.Run(name, func(t *testing.T) {
+			tcpConn, err := dial.Dial()
+			require.NoError(t, err)
+			defer tcpConn.Close()
+
+			clientConfig := sshClientConfig(t)
+			sshConn, chans, reqs, err := ssh.NewClientConn(tcpConn, "localhost", clientConfig)
+			require.NoError(t, err)
+			clt := ssh.NewClient(sshConn, chans, reqs)
+			defer clt.Close()
+
+			// Try sending some global requests.
+			t.Run("global requests", func(t *testing.T) {
+				testGlobalRequests(t, clt)
+			})
+
+			// Try opening a channel that the target server will reject.
+			t.Run("unexpected channel", func(t *testing.T) {
+				_, _, err := clt.OpenChannel("unexpected", nil)
+				require.Error(t, err)
+				require.ErrorAs(t, err, new(*ssh.OpenChannelError))
+			})
+
+			// Try opening a channel that echoes input data back to output, run
+			// it twice to make sure multiple channels can be opened.
+			// testEchoChannel will also send channel requests.
+			t.Run("echo channel 1", func(t *testing.T) {
+				testEchoChannel(t, clt)
+			})
+			t.Run("echo channel 2", func(t *testing.T) {
+				testEchoChannel(t, clt)
+			})
+		})
+	}
+}
+
+func testGlobalRequests(t *testing.T, clt *ssh.Client) {
+	// Send an echo request.
+	msg := []byte("hello")
+	reply, replyPayload, err := clt.SendRequest("echo", true, msg)
+	assert.NoError(t, err)
+	assert.True(t, reply)
+	assert.Equal(t, msg, replyPayload)
+
+	// Send an unexepected request type.
+	reply, replyPayload, err = clt.SendRequest("unexpected", true, msg)
+	assert.NoError(t, err)
+	assert.False(t, reply)
+	assert.Empty(t, replyPayload)
+}
+
+func testEchoChannel(t *testing.T, clt *ssh.Client) {
+	ch, reqs, err := clt.OpenChannel("echo", nil)
+	require.NoError(t, err)
+	go ssh.DiscardRequests(reqs)
+	defer ch.Close()
+
+	// Try sending a message over the SSH channel and asserting that it is
+	// echoed back.
+	msg := []byte("hello")
+	_, err = ch.Write(msg)
+	require.NoError(t, err)
+	var buf [16]byte
+	n, err := ch.Read(buf[:])
+	require.NoError(t, err)
+	require.Equal(t, len(msg), n)
+	require.Equal(t, msg, buf[:n])
+
+	// Try sending a channel request that expects a reply.
+	reply, err := ch.SendRequest("echo", true, nil)
+	require.NoError(t, err)
+	require.True(t, reply)
+
+	// The test server reply false to channel requests with type other than
+	// "echo".
+	reply, err = ch.SendRequest("unknown", true, nil)
+	require.NoError(t, err)
+	require.False(t, reply)
+}
+
+type dialer interface {
+	Dial() (net.Conn, error)
+}
+
+// runTestSSHProxy runs an SSH proxy server. The function under test
+// [proxySSHConnection] requires an established client and server SSH connection
+// and only handles proxying SSH requests and channels between them, this server
+// is the glue that handles accepting connections from a listener, dialing the
+// target server, completing SSH handshakes with each of them, and then finally
+// calling [proxySSHConnection].
+func runTestSSHProxy(
+	ctx context.Context,
+	lis net.Listener,
+	serverCfg *ssh.ServerConfig,
+	serverDialer dialer,
+	clientCfg *ssh.ClientConfig,
+) error {
+	for {
+		incomingConn, err := lis.Accept()
+		if err != nil {
+			if err.Error() == "closed" {
+				return nil
+			}
+			return trace.Wrap(err)
+		}
+		outgoingConn, err := serverDialer.Dial()
+		if err != nil {
+			incomingConn.Close()
+			if err.Error() == "closed" {
+				return nil
+			}
+			return trace.Wrap(err)
+		}
+		if err := runTestSSHProxyInstance(
+			ctx,
+			incomingConn,
+			serverCfg,
+			outgoingConn,
+			clientCfg,
+		); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+}
+
+func runTestSSHProxyInstance(
+	ctx context.Context,
+	incomingConn net.Conn,
+	serverCfg *ssh.ServerConfig,
+	outgoingConn net.Conn,
+	clientCfg *ssh.ClientConfig,
+) error {
+	defer incomingConn.Close()
+	defer outgoingConn.Close()
+	incomingSSHConn, incomingChans, incomingReqs, err := ssh.NewServerConn(incomingConn, serverCfg)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer incomingSSHConn.Close()
+	outgoingSSHConn, outgoingChans, outgoingReqs, err := ssh.NewClientConn(outgoingConn, "localhost", clientCfg)
+	if err != nil {
+		return trace.Wrap(err, "proxying SSH conn in test")
+	}
+	outgoingClient := ssh.NewClient(outgoingSSHConn, outgoingChans, outgoingReqs)
+	err = proxySSHConnection(ctx, outgoingClient, incomingChans, incomingReqs)
+	return trace.Wrap(err)
+}
+
+// runTestSSHServer runs a test SSH server that responds to new channel
+// requests, global requests, and channel requests of type "echo". It handles
+// each by replying with an "echo" of the input.
+func runTestSSHServer(lis net.Listener, cfg *ssh.ServerConfig) error {
+	for {
+		tcpConn, err := lis.Accept()
+		if err != nil {
+			if err.Error() == "closed" {
+				return nil
+			}
+			return trace.Wrap(err)
+		}
+		if err := runTestSSHServerInstance(tcpConn, cfg); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+}
+
+func runTestSSHServerInstance(tcpConn net.Conn, cfg *ssh.ServerConfig) error {
+	sshConn, chans, reqs, err := ssh.NewServerConn(tcpConn, cfg)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer sshConn.Close()
+loop:
+	for {
+		select {
+		case newChan, ok := <-chans:
+			if !ok {
+				return nil
+			}
+			switch newChan.ChannelType() {
+			case "echo":
+				if err := handleEchoChannel(newChan); err != nil {
+					return trace.Wrap(err)
+				}
+			default:
+				newChan.Reject(ssh.UnknownChannelType, "unknown channel type")
+				continue loop
+			}
+		case req, ok := <-reqs:
+			if !ok {
+				return nil
+			}
+			switch req.Type {
+			case "echo":
+				// Handle global SSH requests of type "echo" by replying with
+				// the request payload.
+				req.Reply(true, req.Payload)
+			default:
+				req.Reply(false, nil)
+			}
+		}
+	}
+}
+
+func handleEchoChannel(newChan ssh.NewChannel) error {
+	ch, reqs, err := newChan.Accept()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// Handle all channel requests in the background.
+	go func() {
+		for req := range reqs {
+			switch req.Type {
+			case "echo":
+				// Channel requests have no payload.
+				req.Reply(true, nil)
+			default:
+				req.Reply(false, nil)
+			}
+		}
+	}()
+	defer ch.Close()
+	// Copy input channel data back to the output.
+	_, err = io.Copy(ch, ch)
+	return trace.Wrap(err)
+}
+
+func sshServerConfig(t *testing.T) *ssh.ServerConfig {
+	serverKey, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.Ed25519)
+	require.NoError(t, err)
+	hostSigner, err := ssh.NewSignerFromSigner(serverKey)
+	require.NoError(t, err)
+	serverConfig := &ssh.ServerConfig{
+		PublicKeyCallback: func(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
+			// We're not testing SSH authentication here, just accept and user
+			// key.
+			return nil, nil
+		},
+	}
+	serverConfig.AddHostKey(hostSigner)
+	return serverConfig
+}
+
+func sshClientConfig(t *testing.T) *ssh.ClientConfig {
+	clientKey, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.Ed25519)
+	require.NoError(t, err)
+	clientSigner, err := ssh.NewSignerFromSigner(clientKey)
+	require.NoError(t, err)
+	return &ssh.ClientConfig{
+		Auth: []ssh.AuthMethod{ssh.PublicKeys(clientSigner)},
+		// We're not testing SSH authentication here, just accept any host key.
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+}


### PR DESCRIPTION
Part of [RFD 207: VNet SSH](https://github.com/gravitational/teleport/pull/53370)

This PR adds a transparent SSH proxy that takes an established incoming SSH connection from the client and an outgoing SSH connection to the target, and proxies all SSH requests, channels, and channel requests between the two.