### PR TITLE
Default resource unresolved count values to zero

### DIFF
--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Details.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Details/Details.tsx
@@ -57,13 +57,13 @@ export function Details() {
   let pendingTasks = unresolvedUserTasks;
   switch (resourceKind) {
     case AwsResource.rds:
-      pendingTasks = awsrds.unresolvedUserTasks;
+      pendingTasks = awsrds.unresolvedUserTasks || 0;
       break;
     case AwsResource.ec2:
-      pendingTasks = awsec2.unresolvedUserTasks;
+      pendingTasks = awsec2.unresolvedUserTasks || 0;
       break;
     case AwsResource.eks:
-      pendingTasks = awseks.unresolvedUserTasks;
+      pendingTasks = awseks.unresolvedUserTasks || 0;
       break;
   }
 

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -581,7 +581,7 @@ export type ResourceTypeSummary = {
   // discoverLastSync contains the time when this integration tried to auto-enroll resources.
   discoverLastSync: number;
   // unresolvedUserTasks contains the count of unresolved user tasks related to this integration and resource type.
-  unresolvedUserTasks: number;
+  unresolvedUserTasks?: number;
   // ecsDatabaseServiceCount is the total number of DatabaseServices that were deployed into Amazon ECS.
   // Only applicable for AWS RDS resource summary.
   ecsDatabaseServiceCount: number;


### PR DESCRIPTION
The `unresolvedUserTasks` field is optional from the API, when not present in the response, default to 0