### PR TITLE
Improve lib/healthcheck

### DIFF
--- a/lib/healthcheck/manager_test.go
+++ b/lib/healthcheck/manager_test.go
@@ -35,6 +35,7 @@ import (
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
+	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/healthcheckconfig"
 	"github.com/gravitational/teleport/lib/backend/memory"
@@ -100,13 +101,14 @@ func TestNewManager(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			mgr, err := NewManager(test.cfg)
+			mgr, err := NewManager(context.Background(), test.cfg)
 			if test.wantErr != "" {
 				require.ErrorContains(t, err, test.wantErr)
 				require.Nil(t, mgr)
 				return
 			}
 			require.NoError(t, err)
+			require.NoError(t, mgr.Close())
 			require.NotNil(t, mgr)
 		})
 	}
@@ -131,7 +133,7 @@ func TestManager(t *testing.T) {
 
 	clock := clockwork.NewFakeClock()
 	eventsCh := make(chan testEvent, 1024)
-	mgr, err := NewManager(ManagerConfig{
+	mgr, err := NewManager(ctx, ManagerConfig{
 		Component:               "test",
 		Events:                  local.NewEventsService(bk),
 		HealthCheckConfigReader: healthConfigSvc,
@@ -139,13 +141,17 @@ func TestManager(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NoError(t, mgr.Start(ctx))
+	t.Cleanup(func() {
+		require.NoError(t, mgr.Close())
+	})
 
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
+	{
 		mgr := mgr.(*manager)
 		mgr.mu.RLock()
-		defer mgr.mu.RUnlock()
-		assert.Len(t, mgr.configs, 1)
-	}, 5*time.Second, 100*time.Millisecond, "waiting for manager config watcher to observe the health check config")
+		configs := mgr.configs[:]
+		mgr.mu.RUnlock()
+		require.Len(t, configs, 1, "starting the manager should have blocked until configs were initialized")
+	}
 
 	listener, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)
@@ -173,7 +179,7 @@ func TestManager(t *testing.T) {
 
 	var endpointMu sync.Mutex
 	prodDialer := fakeDialer{}
-	err = mgr.AddTarget(ctx, Target{
+	err = mgr.AddTarget(Target{
 		GetResource: func() types.ResourceWithLabels {
 			endpointMu.Lock()
 			defer endpointMu.Unlock()
@@ -195,7 +201,7 @@ func TestManager(t *testing.T) {
 	require.NoError(t, err)
 
 	devDialer := fakeDialer{}
-	err = mgr.AddTarget(ctx, Target{
+	err = mgr.AddTarget(Target{
 		GetResource: func() types.ResourceWithLabels {
 			endpointMu.Lock()
 			defer endpointMu.Unlock()
@@ -217,7 +223,7 @@ func TestManager(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("duplicate target is an error", func(t *testing.T) {
-		err = mgr.AddTarget(ctx, Target{
+		err = mgr.AddTarget(Target{
 			GetResource: func() types.ResourceWithLabels { return devDB },
 			ResolverFn:  func(ctx context.Context) ([]string, error) { return nil, nil },
 		})
@@ -225,7 +231,7 @@ func TestManager(t *testing.T) {
 		require.IsType(t, trace.AlreadyExists(""), err)
 	})
 	t.Run("unsupported target resource is an error", func(t *testing.T) {
-		err = mgr.AddTarget(ctx, Target{
+		err = mgr.AddTarget(Target{
 			GetResource: func() types.ResourceWithLabels { return &fakeResource{kind: "node"} },
 			ResolverFn:  func(ctx context.Context) ([]string, error) { return nil, nil },
 		})
@@ -250,7 +256,7 @@ func TestManager(t *testing.T) {
 		denyAll(devDB.GetName()),
 	)
 	requireTargetHealth(t, devDB, types.TargetHealthStatusUnknown, types.TargetHealthTransitionReasonDisabled)
-	requireTargetHealth(t, prodDB, types.TargetHealthStatusHealthy, types.TargetHealthTransitionReasonInit)
+	requireTargetHealth(t, prodDB, types.TargetHealthStatusHealthy, types.TargetHealthTransitionReasonThreshold)
 
 	// another check should reach the prodHCC configured threshold.
 	awaitTestEvents(t, eventsCh, clock,
@@ -291,7 +297,7 @@ func TestManager(t *testing.T) {
 		expect(devFail, prodFail),
 		deny(prodPass, devPass),
 	)
-	requireTargetHealth(t, devDB, types.TargetHealthStatusUnhealthy, types.TargetHealthTransitionReasonInit)
+	requireTargetHealth(t, devDB, types.TargetHealthStatusUnhealthy, types.TargetHealthTransitionReasonThreshold)
 
 	// the next dev check should update health status because the unhealthy threshold was met
 	awaitTestEvents(t, eventsCh, clock,
@@ -389,7 +395,10 @@ func healthCheckConfigFixture(t *testing.T, name string) *healthcheckconfigv1.He
 	out, err := healthcheckconfig.NewHealthCheckConfig(name,
 		&healthcheckconfigv1.HealthCheckConfigSpec{
 			Match: &healthcheckconfigv1.Matcher{
-				DbLabelsExpression: `labels["*"] == "*"`,
+				DbLabels: []*labelv1.Label{{
+					Name:   types.Wildcard,
+					Values: []string{types.Wildcard},
+				}},
 			},
 			Interval:           durationpb.New(apidefaults.HealthCheckInterval),
 			Timeout:            durationpb.New(apidefaults.HealthCheckTimeout),

--- a/lib/healthcheck/worker.go
+++ b/lib/healthcheck/worker.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/utils/interval"
+	"github.com/gravitational/teleport/lib/utils/log"
 )
 
 // workerConfig is the configuration for a [workerI].
@@ -67,6 +68,16 @@ func (cfg *workerConfig) checkAndSetDefaults() error {
 
 // newWorker creates and starts a new worker.
 func newWorker(ctx context.Context, cfg workerConfig) (*worker, error) {
+	w, err := newUnstartedWorker(ctx, cfg)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	go w.run(ctx)
+	return w, nil
+}
+
+// newUnstartedWorker creates a worker without running it.
+func newUnstartedWorker(ctx context.Context, cfg workerConfig) (*worker, error) {
 	if err := cfg.checkAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -80,13 +91,10 @@ func newWorker(ctx context.Context, cfg workerConfig) (*worker, error) {
 		target:                    cfg.Target,
 	}
 	if w.healthCheckCfg != nil {
-		const reason = types.TargetHealthTransitionReasonInit
-		const message = "Health checker initialized"
-		w.setTargetHealthStatus(types.TargetHealthStatusUnknown, reason, message)
+		w.setTargetInit(ctx)
 	} else {
 		w.setTargetDisabled(ctx)
 	}
-	go w.run(ctx)
 	return w, nil
 }
 
@@ -194,8 +202,8 @@ func (w *worker) startHealthCheckInterval(ctx context.Context) {
 	w.log.InfoContext(ctx, "Health checker started",
 		"health_check_config", w.healthCheckCfg.name,
 		"protocol", w.healthCheckCfg.protocol,
-		"interval", w.healthCheckCfg.interval,
-		"timeout", w.healthCheckCfg.timeout,
+		"interval", log.StringerAttr(w.healthCheckCfg.interval),
+		"timeout", log.StringerAttr(w.healthCheckCfg.timeout),
 		"healthy_threshold", w.healthCheckCfg.healthyThreshold,
 		"unhealthy_threshold", w.healthCheckCfg.unhealthyThreshold,
 	)
@@ -249,26 +257,9 @@ func (w *worker) checkHealth(ctx context.Context) {
 			"error", w.lastResultErr,
 		)
 	}
-	threshold := w.getThreshold(w.healthCheckCfg)
-	switch {
-	// when initializing the effective threshold is 1 regardless of configured
-	// threshold, but if the configured threshold is 1 then there is no need for
-	// that special behavior
-	case !initializing || threshold == 1:
-		// we don't want every result above the threshold to trigger a target
-		// health update, so only update target health when we exactly reach the
-		// threshold
-		if threshold == w.lastResultCount {
-			w.setThresholdReached(ctx)
-		}
-	case w.lastResultErr == nil:
-		w.setTargetHealthy(ctx, types.TargetHealthTransitionReasonInit,
-			"Passed the initial health check",
-		)
-	default:
-		w.setTargetUnhealthy(ctx, types.TargetHealthTransitionReasonInit,
-			"Failed the initial health check",
-		)
+	// update target health when we exactly reach the threshold or initialize
+	if initializing || w.getThreshold(w.healthCheckCfg) == w.lastResultCount {
+		w.setThresholdReached(ctx)
 	}
 }
 
@@ -294,8 +285,8 @@ func (w *worker) updateHealthCheckConfig(ctx context.Context, newCfg *healthChec
 	w.log.DebugContext(ctx, "Updated health check config",
 		"health_check_config", w.healthCheckCfg.name,
 		"protocol", w.healthCheckCfg.protocol,
-		"interval", w.healthCheckCfg.interval,
-		"timeout", w.healthCheckCfg.timeout,
+		"interval", log.StringerAttr(w.healthCheckCfg.interval),
+		"timeout", log.StringerAttr(w.healthCheckCfg.timeout),
 		"healthy_threshold", w.healthCheckCfg.healthyThreshold,
 		"unhealthy_threshold", w.healthCheckCfg.unhealthyThreshold,
 	)
@@ -323,7 +314,7 @@ func (w *worker) dialEndpoints(ctx context.Context) error {
 	defer cancel()
 	endpoints, err := w.target.ResolverFn(ctx)
 	if err != nil {
-		return trace.Wrap(err)
+		return trace.Wrap(err, "failed to resolve target endpoints")
 	}
 	w.lastResolvedEndpoints = endpoints
 	switch len(endpoints) {
@@ -365,45 +356,57 @@ func (w *worker) getThreshold(cfg *healthCheckConfig) uint32 {
 func (w *worker) setThresholdReached(ctx context.Context) {
 	const transitionReason = types.TargetHealthTransitionReasonThreshold
 	if w.lastResultErr == nil {
-		msg := fmt.Sprintf("%d consecutive health checks passed", w.lastResultCount)
+		msg := fmt.Sprintf("%d health checks passed", w.lastResultCount)
 		w.setTargetHealthy(ctx, transitionReason, msg)
 	} else {
-		msg := fmt.Sprintf("%d consecutive health checks failed", w.lastResultCount)
+		msg := fmt.Sprintf("%d health checks failed", w.lastResultCount)
 		w.setTargetUnhealthy(ctx, transitionReason, msg)
 	}
 }
 
+func (w *worker) setTargetInit(ctx context.Context) {
+	const reason = types.TargetHealthTransitionReasonInit
+	const message = "Health checker initialized"
+	w.setTargetHealthStatus(ctx, types.TargetHealthStatusUnknown, reason, message)
+}
+
 func (w *worker) setTargetHealthy(ctx context.Context, reason types.TargetHealthTransitionReason, message string) {
-	w.log.InfoContext(ctx, "Target became healthy",
-		"reason", reason,
-		"message", message,
-	)
-	w.setTargetHealthStatus(types.TargetHealthStatusHealthy, reason, message)
+	w.setTargetHealthStatus(ctx, types.TargetHealthStatusHealthy, reason, message)
 }
 
 func (w *worker) setTargetUnhealthy(ctx context.Context, reason types.TargetHealthTransitionReason, message string) {
-	w.log.WarnContext(ctx, "Target became unhealthy",
-		"reason", reason,
-		"message", message,
-	)
-	w.setTargetHealthStatus(types.TargetHealthStatusUnhealthy, reason, message)
+	w.setTargetHealthStatus(ctx, types.TargetHealthStatusUnhealthy, reason, message)
 }
 
 func (w *worker) setTargetDisabled(ctx context.Context) {
 	const reason = types.TargetHealthTransitionReasonDisabled
 	const message = "No health check config matches this resource"
-	w.log.InfoContext(ctx, "Target health checks are disabled",
-		"message", message,
-	)
-	w.setTargetHealthStatus(types.TargetHealthStatusUnknown, reason, message)
+	w.setTargetHealthStatus(ctx, types.TargetHealthStatusUnknown, reason, message)
 }
 
-func (w *worker) setTargetHealthStatus(newStatus types.TargetHealthStatus, reason types.TargetHealthTransitionReason, message string) {
+func (w *worker) setTargetHealthStatus(ctx context.Context, newStatus types.TargetHealthStatus, reason types.TargetHealthTransitionReason, message string) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	oldHealth := w.targetHealth
 	if oldHealth.Status == string(newStatus) && oldHealth.TransitionReason == string(reason) {
 		return
+	}
+	switch newStatus {
+	case types.TargetHealthStatusHealthy:
+		w.log.InfoContext(ctx, "Target became healthy",
+			"reason", reason,
+			"message", message,
+		)
+	case types.TargetHealthStatusUnhealthy:
+		w.log.WarnContext(ctx, "Target became unhealthy",
+			"reason", reason,
+			"message", message,
+		)
+	case types.TargetHealthStatusUnknown:
+		w.log.DebugContext(ctx, "Target health status is unknown",
+			"reason", reason,
+			"message", message,
+		)
 	}
 	now := w.clock.Now()
 	w.targetHealth = types.TargetHealth{

--- a/lib/healthcheck/worker_test.go
+++ b/lib/healthcheck/worker_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 )
 
-func Test_newWorker(t *testing.T) {
+func Test_newUnstartedWorker(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	listener, err := net.Listen("tcp", "localhost:0")
@@ -56,6 +56,7 @@ func Test_newWorker(t *testing.T) {
 		desc       string
 		cfg        workerConfig
 		wantHealth types.TargetHealth
+		wantErr    string
 	}{
 		{
 			desc: "disabled",
@@ -100,10 +101,31 @@ func Test_newWorker(t *testing.T) {
 				Message:          "Health checker initialized",
 			},
 		},
+		{
+			desc: "invalid target",
+			cfg: workerConfig{
+				HealthCheckCfg: &healthCheckConfig{
+					interval:           time.Minute,
+					timeout:            time.Minute,
+					healthyThreshold:   10,
+					unhealthyThreshold: 10,
+				},
+				Target: Target{
+					ResolverFn: func(ctx context.Context) ([]string, error) {
+						return []string{db.GetURI()}, nil
+					},
+				},
+			},
+			wantErr: "missing target resource getter",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			w, err := newWorker(ctx, test.cfg)
+			w, err := newUnstartedWorker(ctx, test.cfg)
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+				return
+			}
 			require.NoError(t, err)
 			t.Cleanup(func() { require.NoError(t, w.Close()) })
 			require.Empty(t, cmp.Diff(test.wantHealth, *w.GetTargetHealth(),


### PR DESCRIPTION
* fix flaky worker test. The test raced with the worker startup, but all the test is trying to verify is the unstarted worker behavior, so now it tests against an unstarted worker
* prevent target registration until after health check config watcher init. This avoids pointlessly triggering a heartbeat update on databases shortly after a DB agent starts
* avoid transitioning a target from status=healthy|unhealthy,reason=init to status=healthy|unhealthy,reason=threshold transitions. This was also a pointless heartbeat update that would only add backend write pressure for no real benefit. Instead, the first check after a target is enabled will just behave as if threshold=1 and use reason=threshold

Part of:
- #20544