### PR TITLE
Turn off `strictPeerDependencies` to fix Dependabot

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,10 @@ onlyBuiltDependencies:
 # is defined as a peer dep of one of electron-builder deps, while in reality it's more like an
 # optional dep.
 autoInstallPeers: false
-strictPeerDependencies: true
+# strictPeerDependencies cannot be set to true. Dependabot updates deps one-by-one and runs `pnpm
+# install` after each update. With this option set to true, that command is likely to fail when
+# updating a dep without updating its peer deps at the same time.
+strictPeerDependencies: false
 peerDependencyRules:
   ignoreMissing:
     # This dep is needed only when using Squirrel.Windows as an installer in electron-build which we


### PR DESCRIPTION
Dependabot failed to create the PR with monthly updates. [The summary](https://github.com/gravitational/teleport/network/updates/1008260665) says "Missing or invalid configuration while installing peer dependencies" and in [the logs](https://github.com/gravitational/teleport/actions/runs/14772912580/job/41475976807#step:3:12254) we found this:

```
 ERR_PNPM_PEER_DEP_ISSUES  Unmet peer dependencies

.
└─┬ @storybook/addon-controls 8.6.12
  └── ✕ unmet peer storybook@^8.6.12: found 8.6.11
hint: If you want peer dependencies to be automatically installed, add "auto-install-peers=true" to an .npmrc file at the root of your project.
hint: If you don't want pnpm to fail on peer dependency issues, add "strict-peer-dependencies=false" to an .npmrc file at the root of your project.
  proxy | 2025/05/01 09:14:19 [050] POST /update_jobs/1008260665/record_update_job_error
2025/05/01 09:14:19 [050] 204 /update_jobs/1008260665/record_update_job_error
updater | 2025/05/01 09:14:19 INFO <job_1008260665> Handled error whilst updating @storybook/addon-controls: dependency_file_not_resolvable {:message=>"Missing or invalid configuration while installing peer dependencies."}
```

Turning off `strictPeerDependencies` is an attempt to make Dependabot work again.