### PR TITLE
Prevent panic in initAWSOIDCDeployServiceUpdater

### DIFF
--- a/lib/service/awsoidc.go
+++ b/lib/service/awsoidc.go
@@ -65,7 +65,7 @@ func (process *TeleportProcess) initAWSOIDCDeployServiceUpdater(channels automat
 		return trace.Wrap(err)
 	}
 
-	if !resp.ServerFeatures.AutomaticUpgrades {
+	if !resp.GetServerFeatures().GetAutomaticUpgrades() {
 		return nil
 	}
 


### PR DESCRIPTION
Uses the nil safe getter methods on the ping response to prevent nil pointer dereferences.

Closes https://github.com/gravitational/teleport/issues/54540.