### PR TITLE
[tbot] Support for logging `allowedRoles`

### DIFF
--- a/lib/tbot/service_bot_identity.go
+++ b/lib/tbot/service_bot_identity.go
@@ -146,7 +146,7 @@ func (s *identityService) loadIdentityFromStore(ctx context.Context, store bot.D
 	s.log.InfoContext(
 		ctx,
 		"Loaded existing bot identity from store",
-		"identity", describeTLSIdentity(ctx, s.log, loadedIdent),
+		"identity", describeTLSIdentity(ctx, nil, s.log, loadedIdent),
 	)
 
 	now := time.Now().UTC()
@@ -221,7 +221,7 @@ func (s *identityService) Initialize(ctx context.Context) error {
 		}
 	}
 
-	s.log.InfoContext(ctx, "Fetched new bot identity", "identity", describeTLSIdentity(ctx, s.log, newIdentity))
+	s.log.InfoContext(ctx, "Fetched new bot identity", "identity", describeTLSIdentity(ctx, s.client, s.log, newIdentity))
 	if err := identity.SaveIdentity(ctx, newIdentity, s.cfg.Storage.Destination, identity.BotKinds()...); err != nil {
 		return trace.Wrap(err)
 	}
@@ -300,13 +300,13 @@ func (s *identityService) renew(
 		return trace.Wrap(err, "renewing identity")
 	}
 
-	s.log.InfoContext(ctx, "Fetched new bot identity", "identity", describeTLSIdentity(ctx, s.log, newIdentity))
+	s.log.InfoContext(ctx, "Fetched new bot identity", "identity", describeTLSIdentity(ctx, s.client, s.log, newIdentity))
 	s.facade.Set(newIdentity)
 
 	if err := identity.SaveIdentity(ctx, newIdentity, botDestination, identity.BotKinds()...); err != nil {
 		return trace.Wrap(err, "saving new identity")
 	}
-	s.log.DebugContext(ctx, "Bot identity persisted", "identity", describeTLSIdentity(ctx, s.log, newIdentity))
+	s.log.DebugContext(ctx, "Bot identity persisted", "identity", describeTLSIdentity(ctx, s.client, s.log, newIdentity))
 
 	return nil
 }

--- a/lib/tbot/service_kubernetes_output.go
+++ b/lib/tbot/service_kubernetes_output.go
@@ -173,7 +173,7 @@ func (s *KubernetesOutputService) generate(ctx context.Context) error {
 		"Generated identity for Kubernetes cluster",
 		"kubernetes_cluster",
 		kubeClusterName,
-		"identity", describeTLSIdentity(ctx, s.log, routedIdentity),
+		"identity", describeTLSIdentity(ctx, s.botAuthClient, s.log, routedIdentity),
 	)
 
 	// Ping the proxy to resolve connection addresses.

--- a/lib/tbot/service_kubernetes_v2_output.go
+++ b/lib/tbot/service_kubernetes_v2_output.go
@@ -154,7 +154,7 @@ func (s *KubernetesV2OutputService) generate(ctx context.Context) error {
 		ctx,
 		"Generated identity for Kubernetes access",
 		"matched_cluster_count", len(clusterNames),
-		"identity", describeTLSIdentity(ctx, s.log, id),
+		"identity", describeTLSIdentity(ctx, s.botAuthClient, s.log, id),
 	)
 
 	// Ping the proxy to resolve connection addresses.

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -382,6 +382,12 @@ func TestBot(t *testing.T) {
 		// testenv cluster uses balanced-v1 suite, sanity check we generated an
 		// ECDSA key.
 		require.IsType(t, &ecdsa.PublicKey{}, botIdent.PrivateKey.Public())
+
+		// Check if we can output/print the TLS Identity properly
+		output := describeTLSIdentity(ctx, rootClient, log, botIdent)
+
+		var expectedString = fmt.Sprintf("allowedRoles=[%s %s]", mainRole, secondaryRole)
+		require.Contains(t, output, expectedString, "Output must contain the allowedRoles field with the proper roles")
 	})
 
 	t.Run("output: identity", func(t *testing.T) {


### PR DESCRIPTION
Currently the tbot renewal log messages print only the role that the bot has directly assigned.
This is almost always a single, dedicated role that is bound to the bot instance, which allows the bot to impersonate other roles.

This PR adds the roles that the tbot is allowed to impersonate to the log output.

This `nil` is a bit weird: https://github.com/gravitational/teleport/compare/master...FireDrunk:teleport:feature/log-impersonated-roles-for-tbot?expand=1#diff-ea5bfe98c38ed686f95f9f563c342ee84b0f371977bdadd43e30e25edfb38b69R149

The reason is that the identity is loaded from disk, and the `authClient` has not yet been instantiated so we have no way to know what the `allowedRoles` are (I think).
I therefor added an option to pass nil to the `authClient`.

I also added a test, and it works :)

output example:
```paste
"test, id=f0d31889-dffe-4855-9d4d-a7ea7d2cae73 | valid: after=2025-05-06T14:46:31Z, before=2025-05-06T15:47:31Z, duration=1h1m0s | kind=tls, renewable=true, disallow-reissue=false, botRoles=[bot-test], allowedRoles=[main-role secondary-role], principals=[-teleport-internal-join], generation=1" should not contain "allowedRoles=[main-role secondary-role]"
```