### PR TITLE
Update docs link to feature matrix

### DIFF
--- a/docs/pages/core-concepts.mdx
+++ b/docs/pages/core-concepts.mdx
@@ -130,8 +130,8 @@ source core, which is available at the
 on GitHub.
 
 You can find a detailed comparison of the features available in each Teleport
-edition in [Frequently Asked
-Questions](./faq.mdx#how-is-teleports-community-edition-different-from-enterprise).
+edition on the [Feature Matrix
+](./feature-matrix.mdx).
 
 ### Teleport Enterprise Cloud
 


### PR DESCRIPTION
A link on the core concepts page confusingly sent you to FAQ page which no longer has a feature comparison matrix.