### PR TITLE
Set empty state for sync timestamps

### DIFF
--- a/web/packages/design/src/SyncStamp/SyncStamp.test.tsx
+++ b/web/packages/design/src/SyncStamp/SyncStamp.test.tsx
@@ -24,3 +24,8 @@ test('renders time since date', () => {
   render(<SyncStamp date={new Date()} />);
   expect(screen.getByText('Last Sync: 0 seconds ago')).toBeInTheDocument();
 });
+
+test('renders empty state text', () => {
+  render(<SyncStamp />);
+  expect(screen.getByText('Last Sync: N/A')).toBeInTheDocument();
+});

--- a/web/packages/design/src/SyncStamp/SyncStamp.tsx
+++ b/web/packages/design/src/SyncStamp/SyncStamp.tsx
@@ -16,22 +16,22 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { formatDistanceStrict } from 'date-fns';
+import { formatDistanceToNowStrict } from 'date-fns';
 
 import Flex from 'design/Flex';
 import { SyncAlt } from 'design/Icon';
 import { P3 } from 'design/Text';
 
-export function SyncStamp({ date }: { date: Date }) {
+export function SyncStamp({ date }: { date?: Date }) {
+  let content = 'N/A';
+  if (date && date.getTime() >= 0) {
+    content = formatDistanceToNowStrict(date, { addSuffix: true });
+  }
+
   return (
     <Flex data-testid="sync">
       <SyncAlt color="text.muted" size="small" mr={1} />
-      <P3 color="text.muted">
-        Last Sync:{' '}
-        {formatDistanceStrict(new Date(date), new Date(), {
-          addSuffix: true,
-        })}
-      </P3>
+      <P3 color="text.muted">Last Sync: {content}</P3>
     </Flex>
   );
 }

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/StatCard.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/StatCard.tsx
@@ -104,7 +104,7 @@ export function StatCard({ name, item, resource, summary }: StatCardProps) {
             </Flex>
           </Flex>
         </Flex>
-        {updated && <SyncStamp date={updated} />}
+        <SyncStamp date={updated} />
       </Flex>
     </CardTile>
   );


### PR DESCRIPTION
Updates our last sync timestamp component to optionally accept a date, and show empty state when not present.

Per @roraback the copy is `N/A`