### PR TITLE
Remove comments from Info.plist

### DIFF
--- a/build.assets/macos/tsh/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tsh/tsh.app/Contents/Info.plist
@@ -52,9 +52,6 @@
 		<string>NSApplication</string>
 		<key>OSLogPreferences</key>
 		<dict>
-			<!-- VNet sends its logs to os_log as `com.gravitational.teleport.tsh.vnetd`. By default only warn level+
-			logs are visible and persisted on disk. The settings below make sure that os_log persists info
-			logs to disk too, but only for VNet and not for tsh invocations with the os-log flag. -->
 			<key>com.gravitational.teleport.tsh.vnetd</key>
 			<dict>
 				<key>DEFAULT-OPTIONS</key>

--- a/build.assets/macos/tshdev/README.md
+++ b/build.assets/macos/tshdev/README.md
@@ -211,3 +211,10 @@ tail -f /var/log/com.apple.xpc.launchd/launchd.log
 
 Capturing logs in Console.app might be useful too. However, the logs from launchd were sufficient
 for any debugging we had to do so far.
+
+## `OSLogPreferences` in `Info.plist`
+
+VNet sends its logs to os_log as `com.goteleport.tshdev.vnetd`
+(`com.gravitational.teleport.tsh.vnetd` in official releases). By default only warn level+ logs are
+visible and persisted on disk. The settings in `OSLogPreferences` make sure that os_log persists
+info logs to disk too, but only for VNet and not for tsh invocations with the `--os-log` flag.

--- a/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
@@ -50,9 +50,6 @@
 		<string>NSApplication</string>
 		<key>OSLogPreferences</key>
 		<dict>
-			<!-- VNet sends its logs to os_log as `com.goteleport.tshdev.vnetd`. By default only warn level+
-			logs are visible and persisted on disk. The settings below make sure that os_log persists info
-			logs to disk too, but only for VNet and not for tsh invocations with the os-log flag. -->
 			<key>com.goteleport.tshdev.vnetd</key>
 			<dict>
 				<key>DEFAULT-OPTIONS</key>


### PR DESCRIPTION
When running the `tsh-version` target as a part of `make full`, `build.assets/tooling/cmd/update-plist-version/main.go` parses Info.plist files and updates the version in them, discarding any comments. This results in dirty `Info.plist` files after running `make full`.