### PR TITLE
Add missing redirect

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -339,6 +339,11 @@
       "source": "/enroll-resources/application-access/okta/",
       "destination": "/admin-guides/access-controls/okta/",
       "permanent": true
+    },
+    {
+      "source": "/api/getting-started/",
+      "destination": "/admin-guides/api/getting-started/",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
Closes #54472

The API getting started guide was moved in #44327 without a corresponding redirect. This change adds the redirect.