### PR TITLE
Convert discovery config to new cache mechanism

### DIFF
--- a/api/types/discoveryconfig/discoveryconfig.go
+++ b/api/types/discoveryconfig/discoveryconfig.go
@@ -159,6 +159,30 @@ func (a *DiscoveryConfig) CheckAndSetDefaults() error {
 	return nil
 }
 
+// Clone returns a copy of the config.
+func (a *DiscoveryConfig) Clone() *DiscoveryConfig {
+	var copy *DiscoveryConfig
+	utils.StrictObjectToStruct(a, &copy)
+
+	if len(a.Spec.AWS) == 0 && a.Spec.AWS != nil {
+		copy.Spec.AWS = []types.AWSMatcher{}
+	}
+
+	if len(a.Spec.Azure) == 0 && a.Spec.Azure != nil {
+		copy.Spec.Azure = []types.AzureMatcher{}
+	}
+
+	if len(a.Spec.GCP) == 0 && a.Spec.GCP != nil {
+		copy.Spec.GCP = []types.GCPMatcher{}
+	}
+
+	if len(a.Spec.Kube) == 0 && a.Spec.Kube != nil {
+		copy.Spec.Kube = []types.KubernetesMatcher{}
+	}
+
+	return copy
+}
+
 // GetDiscoveryGroup returns the DiscoveryGroup from the discovery config.
 func (a *DiscoveryConfig) GetDiscoveryGroup() string {
 	return a.Spec.DiscoveryGroup

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -36,6 +36,7 @@ import (
 	workloadidentityv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	"github.com/gravitational/teleport/api/types/userloginstate"
 )
 
@@ -126,6 +127,7 @@ type collections struct {
 	databaseObjects                  *collection[*dbobjectv1.DatabaseObject, databaseObjectIndex]
 	staticHostUsers                  *collection[*userprovisioningv2.StaticHostUser, staticHostUserIndex]
 	networkRestrictions              *collection[types.NetworkRestrictions, networkingRestrictionIndex]
+	discoveryConfigs                 *collection[*discoveryconfig.DiscoveryConfig, discoveryConfigIndex]
 }
 
 // setupCollections ensures that the appropriate [collection] is
@@ -648,6 +650,14 @@ func setupCollections(c Config) (*collections, error) {
 
 			out.networkRestrictions = collect
 			out.byKind[resourceKind] = out.networkRestrictions
+		case types.KindDiscoveryConfig:
+			collect, err := newDiscoveryConfigCollection(c.DiscoveryConfigs, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out.discoveryConfigs = collect
+			out.byKind[resourceKind] = out.discoveryConfigs
 		}
 	}
 

--- a/lib/cache/discovery_config.go
+++ b/lib/cache/discovery_config.go
@@ -1,0 +1,117 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/discoveryconfig"
+	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+type discoveryConfigIndex string
+
+const discoveryConfigNameIndex discoveryConfigIndex = "name"
+
+func newDiscoveryConfigCollection(upstream services.DiscoveryConfigs, w types.WatchKind) (*collection[*discoveryconfig.DiscoveryConfig, discoveryConfigIndex], error) {
+	if upstream == nil {
+		return nil, trace.BadParameter("missing parameter DiscoveryConfigs")
+	}
+
+	return &collection[*discoveryconfig.DiscoveryConfig, discoveryConfigIndex]{
+		store: newStore(map[discoveryConfigIndex]func(*discoveryconfig.DiscoveryConfig) string{
+			discoveryConfigNameIndex: func(r *discoveryconfig.DiscoveryConfig) string {
+				return r.GetMetadata().Name
+			},
+		}),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]*discoveryconfig.DiscoveryConfig, error) {
+			var discoveryConfigs []*discoveryconfig.DiscoveryConfig
+			var nextToken string
+			for {
+				var page []*discoveryconfig.DiscoveryConfig
+				var err error
+
+				page, nextToken, err = upstream.ListDiscoveryConfigs(ctx, 0 /* default page size */, nextToken)
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+
+				discoveryConfigs = append(discoveryConfigs, page...)
+
+				if nextToken == "" {
+					break
+				}
+			}
+			return discoveryConfigs, nil
+		},
+		headerTransform: func(hdr *types.ResourceHeader) *discoveryconfig.DiscoveryConfig {
+			return &discoveryconfig.DiscoveryConfig{
+				ResourceHeader: header.ResourceHeader{
+					Kind:    hdr.Kind,
+					Version: hdr.Version,
+					Metadata: header.Metadata{
+						Name: hdr.Metadata.Name,
+					},
+				},
+			}
+		},
+		watch: w,
+	}, nil
+}
+
+// ListDiscoveryConfigs returns a paginated list of all DiscoveryConfig resources.
+func (c *Cache) ListDiscoveryConfigs(ctx context.Context, pageSize int, pageToken string) ([]*discoveryconfig.DiscoveryConfig, string, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/ListDiscoveryConfigs")
+	defer span.End()
+
+	lister := genericLister[*discoveryconfig.DiscoveryConfig, discoveryConfigIndex]{
+		cache:        c,
+		collection:   c.collections.discoveryConfigs,
+		index:        discoveryConfigNameIndex,
+		upstreamList: c.Config.DiscoveryConfigs.ListDiscoveryConfigs,
+		nextToken: func(t *discoveryconfig.DiscoveryConfig) string {
+			return t.GetMetadata().Name
+		},
+		clone: func(dc *discoveryconfig.DiscoveryConfig) *discoveryconfig.DiscoveryConfig {
+			return dc.Clone()
+		},
+	}
+	out, next, err := lister.list(ctx, pageSize, pageToken)
+	return out, next, trace.Wrap(err)
+}
+
+// GetDiscoveryConfig returns the specified DiscoveryConfig resource.
+func (c *Cache) GetDiscoveryConfig(ctx context.Context, name string) (*discoveryconfig.DiscoveryConfig, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetDiscoveryConfig")
+	defer span.End()
+
+	getter := genericGetter[*discoveryconfig.DiscoveryConfig, discoveryConfigIndex]{
+		cache:       c,
+		collection:  c.collections.discoveryConfigs,
+		index:       discoveryConfigNameIndex,
+		upstreamGet: c.Config.DiscoveryConfigs.GetDiscoveryConfig,
+		clone: func(dc *discoveryconfig.DiscoveryConfig) *discoveryconfig.DiscoveryConfig {
+			return dc.Clone()
+		},
+	}
+	out, err := getter.get(ctx, name)
+	return out, trace.Wrap(err)
+}

--- a/lib/cache/discovery_config_test.go
+++ b/lib/cache/discovery_config_test.go
@@ -1,0 +1,67 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types/discoveryconfig"
+	"github.com/gravitational/teleport/api/types/header"
+)
+
+// TestDiscoveryConfig tests that CRUD operations on DiscoveryConfig resources are
+// replicated from the backend to the cache.
+func TestDiscoveryConfig(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	testResources(t, p, testFuncs[*discoveryconfig.DiscoveryConfig]{
+		newResource: func(name string) (*discoveryconfig.DiscoveryConfig, error) {
+			dc, err := discoveryconfig.NewDiscoveryConfig(
+				header.Metadata{Name: "mydc"},
+				discoveryconfig.Spec{
+					DiscoveryGroup: "group001",
+				})
+			require.NoError(t, err)
+			return dc, nil
+		},
+		create: func(ctx context.Context, discoveryConfig *discoveryconfig.DiscoveryConfig) error {
+			_, err := p.discoveryConfigs.CreateDiscoveryConfig(ctx, discoveryConfig)
+			return trace.Wrap(err)
+		},
+		list: func(ctx context.Context) ([]*discoveryconfig.DiscoveryConfig, error) {
+			results, _, err := p.discoveryConfigs.ListDiscoveryConfigs(ctx, 0, "")
+			return results, err
+		},
+		cacheGet: p.cache.GetDiscoveryConfig,
+		cacheList: func(ctx context.Context) ([]*discoveryconfig.DiscoveryConfig, error) {
+			results, _, err := p.cache.ListDiscoveryConfigs(ctx, 0, "")
+			return results, err
+		},
+		update: func(ctx context.Context, discoveryConfig *discoveryconfig.DiscoveryConfig) error {
+			_, err := p.discoveryConfigs.UpdateDiscoveryConfig(ctx, discoveryConfig)
+			return trace.Wrap(err)
+		},
+		deleteAll: p.discoveryConfigs.DeleteAllDiscoveryConfigs,
+	})
+}


### PR DESCRIPTION
Moves discovery configs to the new cache collection scheme that was introduced in #52210. No additional functionality changes have been made here. This should be a purely mechanical translation to the new internal caching machinery.