### PR TITLE
Fixes potential nil return from `multiplexer.Conn.RemoteAddr()`

### DIFF
--- a/lib/multiplexer/proxyline.go
+++ b/lib/multiplexer/proxyline.go
@@ -583,12 +583,13 @@ func (p *ProxyLine) ResolveSource() net.Addr {
 		return &p.Source
 	}
 
-	tlvs, err := p.getTeleportTLVs()
-	if err != nil {
-		return &p.Source
+	if tlvs, err := p.getTeleportTLVs(); err == nil {
+		if tlvs.originalAddress != nil {
+			return tlvs.originalAddress
+		}
 	}
 
-	return tlvs.originalAddress
+	return &p.Source
 }
 
 func getTLSCerts(ca types.CertAuthority) [][]byte {

--- a/lib/service/servicecfg/proxy.go
+++ b/lib/service/servicecfg/proxy.go
@@ -61,7 +61,8 @@ type ProxyConfig struct {
 	// PROXYProtocolMode controls behavior related to unsigned PROXY protocol headers.
 	PROXYProtocolMode multiplexer.PROXYProtocolMode
 
-	// PROXYAllowDowngrade
+	// PROXYAllowDowngrade controls whether or not pseudo IPv4 downgrading is allowed for
+	// IPv6 sources communicating with IPv4 destinations.
 	PROXYAllowDowngrade bool
 
 	// WebAddr is address for web portal of the proxy


### PR DESCRIPTION
This PR fixes a regression that made it possible for `multiplexer.Conn.RemoteAddr()` to return a nil `net.Addr`. This bug was introduced by the addition of the `proxy_protocol_allow_downgrade` feature and happens when a genuine class E source address appears in a `PROXY` header. The existing behavior assumed we would find an original source address TLV whenever a class E source address was present since they're technically reserved for experimental purposes. However GKE has a [feature](https://cloud.google.com/blog/products/containers-kubernetes/how-class-e-addresses-solve-for-ip-address-exhaustion-in-gke) that allows for networking using class E addresses. I'm also fairly certain this same behavior would have appeared in conjunction with CloudFlare's [pseudo IPv4](https://developers.cloudflare.com/network/pseudo-ipv4/) feature which was the original inspiration for `proxy_protocol_allow_downgrade`. The fix is to fallback to the proxy line's source address when an original address isn't found in the TLVs.

changelog: Fixed an issue preventing connections due to missing client IPs when using class E address space with GKE or CloudFlare pseudo IPv4 forward headers.