### PR TITLE
Convert access requests to new cache mechanism

### DIFF
--- a/lib/cache/access_request.go
+++ b/lib/cache/access_request.go
@@ -1,0 +1,51 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+func newAccessRequestCollection(upstream services.DynamicAccessCore, w types.WatchKind) (*collection[types.AccessRequest, string], error) {
+	if upstream == nil {
+		return nil, trace.BadParameter("missing parameter DynamicAccess")
+	}
+
+	return &collection[types.AccessRequest, string]{
+		store: newStore(map[string]func(types.AccessRequest) string{
+			"default": func(types.AccessRequest) string { return "default" },
+		}),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.AccessRequest, error) {
+			return nil, nil
+		},
+		headerTransform: func(hdr *types.ResourceHeader) types.AccessRequest {
+			return &types.AccessRequestV3{
+				Kind:    hdr.Kind,
+				Version: hdr.Version,
+				Metadata: types.Metadata{
+					Name: hdr.GetName(),
+				},
+			}
+		},
+		watch: w,
+	}, nil
+}

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -131,6 +131,13 @@ func setupCollections(c Config) (*collections, error) {
 		resourceKind := resourceKindFromWatchKind(watch)
 
 		switch watch.Kind {
+		case types.KindAccessRequest:
+			collect, err := newAccessRequestCollection(c.DynamicAccess, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out.byKind[resourceKind] = collect
 		case types.KindToken:
 			collect, err := newProvisionTokensCollection(c.Provisioner, watch)
 			if err != nil {

--- a/lib/cache/legacy_collections.go
+++ b/lib/cache/legacy_collections.go
@@ -117,11 +117,6 @@ func setupLegacyCollections(c *Cache, watches []types.WatchKind) (*legacyCollect
 	for _, watch := range watches {
 		resourceKind := resourceKindFromWatchKind(watch)
 		switch watch.Kind {
-		case types.KindAccessRequest:
-			if c.DynamicAccess == nil {
-				return nil, trace.BadParameter("missing parameter DynamicAccess")
-			}
-			collections.byKind[resourceKind] = &genericCollection[types.AccessRequest, noReader, accessRequestExecutor]{cache: c, watch: watch}
 		case types.KindDatabaseObject:
 			if c.DatabaseObjects == nil {
 				return nil, trace.BadParameter("missing parameter DatabaseObject")
@@ -279,32 +274,6 @@ func (r resourceKind) String() string {
 	}
 	return fmt.Sprintf("%s/%s", r.kind, r.subkind)
 }
-
-type accessRequestExecutor struct{}
-
-func (accessRequestExecutor) getAll(ctx context.Context, cache *Cache, loadSecrets bool) ([]types.AccessRequest, error) {
-	return cache.DynamicAccess.GetAccessRequests(ctx, types.AccessRequestFilter{})
-}
-
-func (accessRequestExecutor) upsert(ctx context.Context, cache *Cache, resource types.AccessRequest) error {
-	return cache.dynamicAccessCache.UpsertAccessRequest(ctx, resource)
-}
-
-func (accessRequestExecutor) deleteAll(ctx context.Context, cache *Cache) error {
-	return cache.dynamicAccessCache.DeleteAllAccessRequests(ctx)
-}
-
-func (accessRequestExecutor) delete(ctx context.Context, cache *Cache, resource types.Resource) error {
-	return cache.dynamicAccessCache.DeleteAccessRequest(ctx, resource.GetName())
-}
-
-func (accessRequestExecutor) isSingleton() bool { return false }
-
-func (accessRequestExecutor) getReader(_ *Cache, _ bool) noReader {
-	return noReader{}
-}
-
-var _ executor[types.AccessRequest, noReader] = accessRequestExecutor{}
 
 type userExecutor struct{}
 


### PR DESCRIPTION
Moves access requests to the new cache collection scheme that was introduced in #52210. No additional functionality changes have been made here. This should be a purely mechanical translation to the new internal caching machinery.