### PR TITLE
ci: Update CI buildbox to teleport18

### DIFF
--- a/.github/workflows/aws-e2e-tests-non-root.yaml
+++ b/.github/workflows/aws-e2e-tests-non-root.yaml
@@ -68,7 +68,7 @@ jobs:
       id-token: write
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport17
+      image: ghcr.io/gravitational/teleport-buildbox:teleport18
       env:
         WEBASSETS_SKIP_BUILD: 1
       options: --cap-add=SYS_ADMIN --privileged

--- a/.github/workflows/benchmark-code-nonroot.yaml
+++ b/.github/workflows/benchmark-code-nonroot.yaml
@@ -43,7 +43,7 @@ jobs:
       contents: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport17
+      image: ghcr.io/gravitational/teleport-buildbox:teleport18
       env:
         TELEPORT_XAUTH_TEST: yes
         WEBASSETS_SKIP_BUILD: 1

--- a/.github/workflows/benchmark-code-root.yaml
+++ b/.github/workflows/benchmark-code-root.yaml
@@ -43,7 +43,7 @@ jobs:
       contents: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport17
+      image: ghcr.io/gravitational/teleport-buildbox:teleport18
       options: --cap-add=SYS_ADMIN --privileged
       env:
         WEBASSETS_SKIP_BUILD: 1

--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -25,7 +25,7 @@ jobs:
       contents: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport17
+      image: ghcr.io/gravitational/teleport-buildbox:teleport18
 
     steps:
       - name: Checkout base

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -14,7 +14,7 @@ jobs:
       contents: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox-centos7:teleport17-amd64
+      image: ghcr.io/gravitational/teleport-buildbox-centos7:teleport18-amd64
       env:
         GOCACHE: /tmp/gocache
 

--- a/.github/workflows/flaky-tests.yaml
+++ b/.github/workflows/flaky-tests.yaml
@@ -21,7 +21,7 @@ jobs:
       packages: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport17
+      image: ghcr.io/gravitational/teleport-buildbox:teleport18
       env:
         TELEPORT_ETCD_TEST: yes
         TELEPORT_ETCD_TEST_ENDPOINT: https://etcd0:2379

--- a/.github/workflows/integration-tests-non-root.yaml
+++ b/.github/workflows/integration-tests-non-root.yaml
@@ -44,7 +44,7 @@ jobs:
       packages: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport17
+      image: ghcr.io/gravitational/teleport-buildbox:teleport18
       env:
         TELEPORT_ETCD_TEST: yes
         TELEPORT_ETCD_TEST_ENDPOINT: https://etcd0:2379

--- a/.github/workflows/integration-tests-root.yaml
+++ b/.github/workflows/integration-tests-root.yaml
@@ -43,7 +43,7 @@ jobs:
       contents: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport17
+      image: ghcr.io/gravitational/teleport-buildbox:teleport18
       options: --cap-add=SYS_ADMIN --privileged
       env:
         WEBASSETS_SKIP_BUILD: 1

--- a/.github/workflows/kube-integration-tests-non-root.yaml
+++ b/.github/workflows/kube-integration-tests-non-root.yaml
@@ -49,7 +49,7 @@ jobs:
       packages: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport17
+      image: ghcr.io/gravitational/teleport-buildbox:teleport18
       env:
         WEBASSETS_SKIP_BUILD: 1
       options: --cap-add=SYS_ADMIN --privileged

--- a/.github/workflows/lint-ui.yaml
+++ b/.github/workflows/lint-ui.yaml
@@ -30,7 +30,7 @@ jobs:
     name: Prettier, ESLint, & TSC
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport17
+      image: ghcr.io/gravitational/teleport-buildbox:teleport18
     steps:
       - name: Checkout OSS Teleport
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -81,7 +81,7 @@ jobs:
       contents: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport17
+      image: ghcr.io/gravitational/teleport-buildbox:teleport18
 
     steps:
       - name: Checkout
@@ -198,7 +198,7 @@ jobs:
       contents: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport17
+      image: ghcr.io/gravitational/teleport-buildbox:teleport18
 
     steps:
       - name: Checkout

--- a/.github/workflows/os-compatibility-test.yaml
+++ b/.github/workflows/os-compatibility-test.yaml
@@ -36,7 +36,7 @@ jobs:
       contents: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox-centos7:teleport17-amd64
+      image: ghcr.io/gravitational/teleport-buildbox-centos7:teleport18-amd64
       env:
         GOCACHE: /tmp/gocache
         WEBASSETS_SKIP_BUILD: 1

--- a/docs/preflight.md
+++ b/docs/preflight.md
@@ -19,7 +19,12 @@ This checklist is to be run prior to cutting the release branch.
     first run will build the "assets" buildbox and the other builds will likely
     fail. Run again after the first has finished to build the others that use
     the "assets" buldbox:
-  
+
       today=$(LOCALE=C TZ=UTC date +%A)
       gh workflow run --repo gravitational/teleport.e --field assets-day="${today}" build-buildboxes.yaml
       gh workflow run --repo gravitational/teleport.e build-buildboxes.yaml
+
+  - [ ] Update all the CI jobs in `.github/workflows` that use `teleport-buildbox:teleportX`
+    and `teleport-buildbox-centos7:teleportX-amd64` and bump X to the new version.
+  - [ ] Update all the CI jobs in `e/.github/workflows` that use `teleport-buildbox:teleportX`
+    and bump X to the new version.


### PR DESCRIPTION
Update the buildbox used by the various CI jobs to `:teleport18` from
`:teleport17`. This should have been done when `branch/v17` was created,
but got missed.

Update the preflight docs to include steps to do this when we cut a new
release branch. Maybe we won't forget next time (next week!)

I have verified the images referenced do exist.

* https://github.com/gravitational/teleport/pkgs/container/teleport-buildbox/409028465?tag=teleport18
* https://github.com/gravitational/teleport/pkgs/container/teleport-buildbox-centos7/393465048?tag=teleport18-amd64

Companion: https://github.com/gravitational/teleport.e/pull/6482