### PR TITLE
Convert headless authentication to new cache mechanism

### DIFF
--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -131,6 +131,13 @@ func setupCollections(c Config) (*collections, error) {
 		resourceKind := resourceKindFromWatchKind(watch)
 
 		switch watch.Kind {
+		case types.KindHeadlessAuthentication:
+			collect, err := newHeadlessAuthenticationCollection(watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out.byKind[resourceKind] = collect
 		case types.KindToken:
 			collect, err := newProvisionTokensCollection(c.Provisioner, watch)
 			if err != nil {

--- a/lib/cache/headless_authentication.go
+++ b/lib/cache/headless_authentication.go
@@ -1,0 +1,52 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+// newHeadlessAuthenticationCollection creates a collection that does not
+// fetch from upstream and does not store the entire set of resources.
+// The collection is only required so that watchers can be created and
+// events can be processed.
+func newHeadlessAuthenticationCollection(w types.WatchKind) (*collection[*types.HeadlessAuthentication, string], error) {
+	return &collection[*types.HeadlessAuthentication, string]{
+		store: newStore(map[string]func(*types.HeadlessAuthentication) string{
+			"default": func(ha *types.HeadlessAuthentication) string {
+				return "default"
+			},
+		}),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]*types.HeadlessAuthentication, error) {
+			return nil, nil
+		},
+		headerTransform: func(hdr *types.ResourceHeader) *types.HeadlessAuthentication {
+			return &types.HeadlessAuthentication{
+				ResourceHeader: types.ResourceHeader{
+					Kind:    hdr.Kind,
+					Version: hdr.Version,
+					Metadata: types.Metadata{
+						Name: hdr.Metadata.Name,
+					},
+				},
+			}
+		},
+		watch: w,
+	}, nil
+}

--- a/lib/cache/legacy_collections.go
+++ b/lib/cache/legacy_collections.go
@@ -155,9 +155,6 @@ func setupLegacyCollections(c *Cache, watches []types.WatchKind) (*legacyCollect
 			}
 			collections.discoveryConfigs = &genericCollection[*discoveryconfig.DiscoveryConfig, services.DiscoveryConfigsGetter, discoveryConfigExecutor]{cache: c, watch: watch}
 			collections.byKind[resourceKind] = collections.discoveryConfigs
-		case types.KindHeadlessAuthentication:
-			// For headless authentications, we need only process events. We don't need to keep the cache up to date.
-			collections.byKind[resourceKind] = &genericCollection[*types.HeadlessAuthentication, noReader, noopExecutor]{cache: c, watch: watch}
 		case types.KindAuditQuery:
 			if c.SecReports == nil {
 				return nil, trace.BadParameter("missing parameter SecReports")
@@ -782,31 +779,3 @@ func (secReportStateExecutor) getReader(cache *Cache, cacheOK bool) services.Sec
 }
 
 var _ executor[*secreports.ReportState, services.SecurityReportStateGetter] = secReportStateExecutor{}
-
-// noopExecutor can be used when a resource's events do not need to processed by
-// the cache itself, only passed on to other watchers.
-type noopExecutor struct{}
-
-func (noopExecutor) getAll(ctx context.Context, cache *Cache, loadSecrets bool) ([]*types.HeadlessAuthentication, error) {
-	return nil, nil
-}
-
-func (noopExecutor) upsert(ctx context.Context, cache *Cache, resource *types.HeadlessAuthentication) error {
-	return nil
-}
-
-func (noopExecutor) deleteAll(ctx context.Context, cache *Cache) error {
-	return nil
-}
-
-func (noopExecutor) delete(ctx context.Context, cache *Cache, resource types.Resource) error {
-	return nil
-}
-
-func (noopExecutor) isSingleton() bool { return false }
-
-func (noopExecutor) getReader(_ *Cache, _ bool) noReader {
-	return noReader{}
-}
-
-var _ executor[*types.HeadlessAuthentication, noReader] = noopExecutor{}


### PR DESCRIPTION
Moves headless authentication resources to the new cache collection scheme that was introduced in #52210. This collection is a bit different than the rest since the cache does not need to store the resources, the collection exists solely so that watchers of the headless authentication types can be created.

In the future we should consider refactoring the machinery for types that exist solely  for watchers, as of now there are only two: headless authenticaion and access requests.