### PR TITLE
ci: Update CI buildbox to teleport18, part 2

### DIFF
--- a/.github/workflows/unit-tests-code.yaml
+++ b/.github/workflows/unit-tests-code.yaml
@@ -36,7 +36,7 @@ jobs:
       packages: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport17
+      image: ghcr.io/gravitational/teleport-buildbox:teleport18
       env:
         TELEPORT_ETCD_TEST: yes
         TELEPORT_ETCD_TEST_ENDPOINT: https://etcd0:2379

--- a/.github/workflows/unit-tests-helm.yaml
+++ b/.github/workflows/unit-tests-helm.yaml
@@ -39,7 +39,7 @@ jobs:
       contents: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport17
+      image: ghcr.io/gravitational/teleport-buildbox:teleport18
       env:
         # TODO(hugoShaka) remove the '-new' prefix when updating to teleport13 buildbox
         HELM_PLUGINS: /home/ci/.local/share/helm/plugins-new

--- a/.github/workflows/unit-tests-integrations.yaml
+++ b/.github/workflows/unit-tests-integrations.yaml
@@ -48,7 +48,7 @@ jobs:
       contents: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport17
+      image: ghcr.io/gravitational/teleport-buildbox:teleport18
       options: --cap-add=SYS_ADMIN --privileged
 
     steps:

--- a/.github/workflows/unit-tests-rust.yaml
+++ b/.github/workflows/unit-tests-rust.yaml
@@ -41,7 +41,7 @@ jobs:
       contents: read
 
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport17
+      image: ghcr.io/gravitational/teleport-buildbox:teleport18
       options: --cap-add=SYS_ADMIN --privileged
 
     steps:

--- a/.github/workflows/unit-tests-ui.yaml
+++ b/.github/workflows/unit-tests-ui.yaml
@@ -34,7 +34,7 @@ jobs:
     name: Test UI
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/gravitational/teleport-buildbox:teleport17
+      image: ghcr.io/gravitational/teleport-buildbox:teleport18
       # See https://github.com/gravitational/teleport/blob/2aaa3ec9a129213db8a18083d5b4681f86328d34/web/packages/teleterm/src/agentCleanupDaemon/agentCleanupDaemon.test.ts#L82-L89
       # for the original impetus for adding --init.
       options: --init


### PR DESCRIPTION
Update the remainder of the CI workflows to use the `:teleport18`
buildbox. For some reason, github was returning an error of too many
files in the PR, so it had to be split.

A continuation of https://github.com/gravitational/teleport/pull/54585
