### PR TITLE
[v17] Fixes potential nil return from `multiplexer.Conn.RemoteAddr()`

### DIFF
--- a/lib/multiplexer/proxyline.go
+++ b/lib/multiplexer/proxyline.go
@@ -583,12 +583,13 @@ func (p *ProxyLine) ResolveSource() net.Addr {
 		return &p.Source
 	}
 
-	tlvs, err := p.getTeleportTLVs()
-	if err != nil {
-		return &p.Source
+	if tlvs, err := p.getTeleportTLVs(); err == nil {
+		if tlvs.originalAddress != nil {
+			return tlvs.originalAddress
+		}
 	}
 
-	return tlvs.originalAddress
+	return &p.Source
 }
 
 func getTLSCerts(ca types.CertAuthority) [][]byte {

--- a/lib/service/servicecfg/proxy.go
+++ b/lib/service/servicecfg/proxy.go
@@ -61,7 +61,8 @@ type ProxyConfig struct {
 	// PROXYProtocolMode controls behavior related to unsigned PROXY protocol headers.
 	PROXYProtocolMode multiplexer.PROXYProtocolMode
 
-	// PROXYAllowDowngrade
+	// PROXYAllowDowngrade controls whether or not pseudo IPv4 downgrading is allowed for
+	// IPv6 sources communicating with IPv4 destinations.
 	PROXYAllowDowngrade bool
 
 	// WebAddr is address for web portal of the proxy


### PR DESCRIPTION
Backport #54578 to branch/v17

changelog: Fixed an issue preventing connections due to missing client IPs when using class E address space with GKE or CloudFlare pseudo IPv4 forward headers.
