### PR TITLE
[v17] Enable SSO MFA for headless (#53741)

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -7575,9 +7575,11 @@ func (a *ServerWithRoles) UpdateHeadlessAuthenticationState(ctx context.Context,
 			return err
 		}
 
-		// Only WebAuthn is supported in headless login flow for superior phishing prevention.
-		if _, ok := mfaResp.Response.(*proto.MFAAuthenticateResponse_Webauthn); !ok {
-			err = trace.BadParameter("expected WebAuthn challenge response, but got %T", mfaResp.Response)
+		// Only WebAuthn and SSO are supported in headless login flow for superior phishing prevention.
+		switch mfaResp.Response.(type) {
+		case *proto.MFAAuthenticateResponse_Webauthn, *proto.MFAAuthenticateResponse_SSO:
+		default:
+			err = trace.BadParameter("MFA response of type %T is not supported for headless authentication", mfaResp.Response)
 			emitHeadlessLoginEvent(ctx, events.UserHeadlessLoginApprovedFailureCode, a.authServer.emitter, headlessAuthn, err)
 			return err
 		}

--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -391,7 +391,10 @@ type AuthenticateWebUserRequest struct {
 type HeadlessRequest struct {
 	// Actions can be either accept or deny.
 	Action string `json:"action"`
+	// MFAResponse is an MFA response used to authenticate the headless request.
+	MFAResponse *MFAChallengeResponse `json:"mfaResponse"`
 	// WebauthnAssertionResponse is a signed WebAuthn credential assertion.
+	// TODO(Joerger): DELETE IN v19.0.0, new clients send mfaResponse
 	WebauthnAssertionResponse *wantypes.CredentialAssertionResponse `json:"webauthnAssertionResponse,omitempty"`
 }
 

--- a/lib/web/headless.go
+++ b/lib/web/headless.go
@@ -24,9 +24,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
 
-	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
-	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/httplib"
 )
@@ -67,17 +65,21 @@ func (h *Handler) putHeadlessState(_ http.ResponseWriter, r *http.Request, param
 		return nil, trace.Wrap(err)
 	}
 
-	var action types.HeadlessAuthenticationState
-	var resp = &proto.MFAAuthenticateResponse{}
+	if req.MFAResponse == nil && req.WebauthnAssertionResponse != nil {
+		req.MFAResponse = &client.MFAChallengeResponse{
+			WebauthnResponse: req.WebauthnAssertionResponse,
+		}
+	}
 
+	mfaResp, err := req.MFAResponse.GetOptionalMFAResponseProtoReq()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var action types.HeadlessAuthenticationState
 	switch req.Action {
 	case "accept":
 		action = types.HeadlessAuthenticationState_HEADLESS_AUTHENTICATION_STATE_APPROVED
-		resp = &proto.MFAAuthenticateResponse{
-			Response: &proto.MFAAuthenticateResponse_Webauthn{
-				Webauthn: wantypes.CredentialAssertionResponseToProto(req.WebauthnAssertionResponse),
-			},
-		}
 	case "denied":
 		action = types.HeadlessAuthenticationState_HEADLESS_AUTHENTICATION_STATE_DENIED
 	default:
@@ -89,9 +91,7 @@ func (h *Handler) putHeadlessState(_ http.ResponseWriter, r *http.Request, param
 		return nil, trace.Wrap(err)
 	}
 
-	err = authClient.UpdateHeadlessAuthenticationState(r.Context(), headlessAuthenticationID,
-		action, resp)
-	if err != nil {
+	if err := authClient.UpdateHeadlessAuthenticationState(r.Context(), headlessAuthenticationID, action, mfaResp); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/web/packages/teleport/src/HeadlessRequest/HeadlessRequest.test.tsx
+++ b/web/packages/teleport/src/HeadlessRequest/HeadlessRequest.test.tsx
@@ -26,7 +26,7 @@ import { HeadlessRequest } from 'teleport/HeadlessRequest/HeadlessRequest';
 import auth from 'teleport/services/auth';
 
 test('ip address should be visible', async () => {
-  jest.spyOn(auth, 'headlessSSOGet').mockImplementation(
+  jest.spyOn(auth, 'headlessSsoGet').mockImplementation(
     () =>
       new Promise(resolve => {
         resolve({ clientIpAddress: '1.2.3.4' });

--- a/web/packages/teleport/src/HeadlessRequest/HeadlessRequest.tsx
+++ b/web/packages/teleport/src/HeadlessRequest/HeadlessRequest.tsx
@@ -47,7 +47,7 @@ export function HeadlessRequest() {
     };
 
     auth
-      .headlessSSOGet(requestId)
+      .headlessSsoGet(requestId)
       .then(setIpAddress)
       .catch(e => {
         setState({
@@ -106,7 +106,7 @@ export function HeadlessRequest() {
         setState({ ...state, status: 'in-progress' });
 
         auth
-          .headlessSSOAccept(requestId)
+          .headlessSsoAccept(requestId)
           .then(setSuccess)
           .catch(e => {
             setState({

--- a/web/packages/teleport/src/services/auth/auth.ts
+++ b/web/packages/teleport/src/services/auth/auth.ts
@@ -218,26 +218,25 @@ const auth = {
     return api.put(cfg.api.changeUserPasswordPath, data);
   },
 
-  headlessSSOGet(transactionId: string) {
-    return auth
-      .checkWebauthnSupport()
-      .then(() => api.get(cfg.getHeadlessSsoPath(transactionId)))
-      .then((json: any) => {
-        json = json || {};
+  headlessSsoGet(transactionId: string) {
+    return api.get(cfg.getHeadlessSsoPath(transactionId)).then((json: any) => {
+      json = json || {};
 
-        return {
-          clientIpAddress: json.client_ip_address,
-        };
-      });
+      return {
+        clientIpAddress: json.client_ip_address,
+      };
+    });
   },
 
-  headlessSSOAccept(transactionId: string) {
+  headlessSsoAccept(transactionId: string) {
     return auth
       .getMfaChallenge({ scope: MfaChallengeScope.HEADLESS_LOGIN })
-      .then(challenge => auth.getMfaChallengeResponse(challenge, 'webauthn'))
+      .then(challenge => auth.getMfaChallengeResponse(challenge))
       .then(res => {
         const request = {
           action: 'accept',
+          mfaResponse: res,
+          // TODO(Joerger): DELETE IN v19.0.0, new clients send mfaResponse.
           webauthnAssertionResponse: res.webauthn_response,
         };
 


### PR DESCRIPTION
Backport #53741 to branch/v17

Changelog: Added support for SSO MFA as a headless MFA method