### PR TITLE
[web] Adjust tooltip spacing for CopyButton

### DIFF
--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
@@ -197,17 +197,11 @@ export function ResourceCard({
           {...(hasUnhealthyStatus && !showAllLabels && { pr: '35px' })}
           {...(hasUnhealthyStatus && showAllLabels && { pr: '7px' })}
         >
-          <HoverTooltip tipContent={selected ? 'Deselect' : 'Select'}>
-            <CheckboxInput
-              css={`
-                position: absolute;
-                top: 16px;
-                left: 16px;
-              `}
-              checked={selected}
-              onChange={selectResource}
-            />
-          </HoverTooltip>
+          <CheckboxInput
+            checked={selected}
+            onChange={selectResource}
+            style={{ position: 'absolute', top: '16px', left: '16px' }}
+          />
           <Box
             css={`
               position: absolute;

--- a/web/packages/shared/components/UnifiedResources/shared/CopyButton.tsx
+++ b/web/packages/shared/components/UnifiedResources/shared/CopyButton.tsx
@@ -18,6 +18,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 
+import Box from 'design/Box';
 import ButtonIcon from 'design/ButtonIcon';
 import { Check, Copy } from 'design/Icon';
 import { HoverTooltip } from 'design/Tooltip';
@@ -60,20 +61,16 @@ export function CopyButton({
   }, []);
 
   return (
-    <HoverTooltip tipContent={copiedText}>
-      <ButtonIcon
-        setRef={copyAnchorEl}
-        size={0}
-        mr={mr}
-        ml={ml}
-        onClick={handleCopy}
-      >
-        {copiedText === copySuccess ? (
-          <Check size="small" />
-        ) : (
-          <Copy size="small" />
-        )}
-      </ButtonIcon>
-    </HoverTooltip>
+    <Box mr={mr} ml={ml}>
+      <HoverTooltip tipContent={copiedText}>
+        <ButtonIcon setRef={copyAnchorEl} size={0} onClick={handleCopy}>
+          {copiedText === copySuccess ? (
+            <Check size="small" />
+          ) : (
+            <Copy size="small" />
+          )}
+        </ButtonIcon>
+      </HoverTooltip>
+    </Box>
   );
 }


### PR DESCRIPTION
## Background
Small spacing fix: Apply margin around tooltip instead of its target for CopyButton. Remove tooltip from ResourceCards' "select" checkbox. 

## Before / after
<img width="180" alt="Screenshot 2025-05-07 at 15 36 09" src="https://github.com/user-attachments/assets/c2285adb-e30b-4d34-891f-3b614f8f4f3e" />
<img width="250" alt="Screenshot 2025-05-07 at 15 35 57" src="https://github.com/user-attachments/assets/b71f42cf-c9da-4a51-9df4-88f4bc541d5b" />
