### PR TITLE
fix: don't cache an incorrect PIV PIN

### DIFF
--- a/api/utils/keys/hardwarekey/cliprompt.go
+++ b/api/utils/keys/hardwarekey/cliprompt.go
@@ -73,8 +73,16 @@ func (c *cliPrompt) AskPIN(ctx context.Context, requirement PINPromptRequirement
 		msg = fmt.Sprintf("%v to continue with command %q", msg, keyInfo.Command)
 	}
 
-	password, err := prompt.Password(ctx, c.writer, c.reader, msg)
-	return password, trace.Wrap(err)
+	pin, err := prompt.Password(ctx, c.writer, c.reader, msg)
+	if err != nil {
+		return "", nil
+	}
+
+	if pin == "" {
+		pin = DefaultPIN
+	}
+
+	return pin, trace.Wrap(err)
 }
 
 // Touch prompts the user to touch the hardware key.

--- a/api/utils/keys/piv/pincache.go
+++ b/api/utils/keys/piv/pincache.go
@@ -1,3 +1,5 @@
+//go:build piv || pivtest
+
 // Copyright 2025 Gravitational, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,14 +17,10 @@
 package piv
 
 import (
-	"context"
 	"sync"
 	"time"
 
-	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-
-	"github.com/gravitational/teleport/api/utils/keys/hardwarekey"
 )
 
 // pinCache is a PIN cache that supports consumers with varying required TTLs.
@@ -44,34 +42,6 @@ func newPINCache() *pinCache { //nolint:unused // used in yubikey.go with piv bu
 	return &pinCache{
 		clock: clockwork.NewRealClock(),
 	}
-}
-
-// PromptOrGetPIN retrieves the cached PIN if set. Otherwise it prompts for the PIN and caches it.
-func (p *pinCache) PromptOrGetPIN(ctx context.Context, prompt hardwarekey.Prompt, requirement hardwarekey.PINPromptRequirement, keyInfo hardwarekey.ContextualKeyInfo, pinCacheTTL time.Duration) (string, error) {
-	// If the provided ttl is 0, it doesn't support caching, so we just prompt.
-	if pinCacheTTL == 0 {
-		return prompt.AskPIN(ctx, requirement, keyInfo)
-	}
-
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	if pin := p.getPIN(pinCacheTTL); pin != "" {
-		return pin, nil
-	}
-
-	// Add a timeout to prevent an unanswered PIN prompt from holding the lock.
-	const pinPromptTimeout = time.Minute
-	ctx, cancel := context.WithTimeout(ctx, pinPromptTimeout)
-	defer cancel()
-
-	pin, err := prompt.AskPIN(ctx, requirement, keyInfo)
-	if err != nil {
-		return "", trace.Wrap(err)
-	}
-
-	p.setPIN(pin, pinCacheTTL)
-	return pin, nil
 }
 
 // getPIN retrieves the cached PIN. If the PIN was cached before by an amount of

--- a/api/utils/keys/piv/pincache.go
+++ b/api/utils/keys/piv/pincache.go
@@ -48,6 +48,10 @@ func newPINCache() *pinCache { //nolint:unused // used in yubikey.go with piv bu
 // time equal to the provided TTL, the PIN will not be returned.
 // Must be called under [p.mu] lock.
 func (p *pinCache) getPIN(ttl time.Duration) string {
+	if ttl == 0 {
+		return ""
+	}
+
 	if p.pin == "" {
 		return ""
 	}
@@ -75,6 +79,10 @@ func (p *pinCache) getPIN(ttl time.Duration) string {
 // TTL would exceed that expiration.
 // Must be called under [p.mu] lock.
 func (p *pinCache) setPIN(pin string, ttl time.Duration) {
+	if ttl == 0 {
+		return
+	}
+
 	now := p.clock.Now()
 	expiry := now.Add(ttl)
 

--- a/api/utils/keys/piv/pincache_test.go
+++ b/api/utils/keys/piv/pincache_test.go
@@ -1,3 +1,5 @@
+//go:build pivtest
+
 // Copyright 2025 Gravitational, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/utils/keys/piv/yubikey.go
+++ b/api/utils/keys/piv/yubikey.go
@@ -237,8 +237,8 @@ func (y *YubiKey) sign(ctx context.Context, ref *hardwarekey.PrivateKeyRef, keyI
 				defer touchPromptDelayTimer.Reset(signTouchPromptDelay)
 			}
 		}
-		pin, err := y.pinCache.PromptOrGetPIN(ctx, prompt, hardwarekey.PINRequired, keyInfo, ref.PINCacheTTL)
-		return pin, trace.Wrap(err)
+
+		return y.promptPIN(ctx, prompt, hardwarekey.PINRequired, keyInfo, ref.PINCacheTTL)
 	}
 
 	pinPolicy := piv.PINPolicyNever
@@ -467,24 +467,77 @@ func (y *YubiKey) SetPIN(oldPin, newPin string) error {
 // If the user provides the default PIN, they will be prompted to set a
 // non-default PIN and PUK before continuing.
 func (y *YubiKey) checkOrSetPIN(ctx context.Context, prompt hardwarekey.Prompt, keyInfo hardwarekey.ContextualKeyInfo, pinCacheTTL time.Duration) error {
-	pin, err := y.pinCache.PromptOrGetPIN(ctx, prompt, hardwarekey.PINOptional, keyInfo, pinCacheTTL)
+	pin, err := y.promptPIN(ctx, prompt, hardwarekey.PINOptional, keyInfo, pinCacheTTL)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	switch pin {
-	case piv.DefaultPIN, "":
-		pin, err = y.setPINAndPUKFromDefault(ctx, prompt, keyInfo)
+	if pin == piv.DefaultPIN {
+		pin, err = y.setPINAndPUKFromDefault(ctx, prompt, keyInfo, pinCacheTTL)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		y.pinCache.setPIN(pin, pinCacheTTL)
 	}
 
-	return trace.Wrap(y.verifyPIN(pin))
+	return nil
 }
 
-func (y *YubiKey) setPINAndPUKFromDefault(ctx context.Context, prompt hardwarekey.Prompt, keyInfo hardwarekey.ContextualKeyInfo) (string, error) {
+// PIN (or PUK) prompts time out after 1 minute to prevent an indefinite hold of
+// the pin cache mutex or the exclusive PC/SC transaction.
+const pinPromptTimeout = time.Minute
+
+func (y *YubiKey) promptPIN(ctx context.Context, prompt hardwarekey.Prompt, requirement hardwarekey.PINPromptRequirement, keyInfo hardwarekey.ContextualKeyInfo, pinCacheTTL time.Duration) (string, error) {
+	if pinCacheTTL == 0 {
+		pin, err := prompt.AskPIN(ctx, requirement, keyInfo)
+		if err != nil {
+			return "", trace.Wrap(err)
+		}
+
+		if pin == "" {
+			pin = piv.DefaultPIN
+		}
+
+		return pin, nil
+	}
+
+	y.pinCache.mu.Lock()
+	defer y.pinCache.mu.Unlock()
+
+	pin := y.pinCache.getPIN(pinCacheTTL)
+	if pin != "" {
+		return pin, nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, pinPromptTimeout)
+	defer cancel()
+
+	pin, err := prompt.AskPIN(ctx, requirement, keyInfo)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	if pin == "" {
+		pin = piv.DefaultPIN
+	}
+
+	// Verify that the PIN is correct before we cache it. This also caches it internally in the PC/SC transaction.
+	// TODO(Joerger): In the signature pin prompt logic, we unfortunately repeat this verification
+	// due to the way the upstream piv-go library handles PIN prompts.
+	if err := y.verifyPIN(pin); err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	y.pinCache.setPIN(pin, pinCacheTTL)
+	return pin, nil
+}
+
+func (y *YubiKey) setPINAndPUKFromDefault(ctx context.Context, prompt hardwarekey.Prompt, keyInfo hardwarekey.ContextualKeyInfo, pinCacheTTL time.Duration) (string, error) {
+	y.pinCache.mu.Lock()
+	defer y.pinCache.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(ctx, pinPromptTimeout)
+	defer cancel()
+
 	pinAndPUK, err := prompt.ChangePIN(ctx, keyInfo)
 	if err != nil {
 		return "", trace.Wrap(err)
@@ -500,10 +553,12 @@ func (y *YubiKey) setPINAndPUKFromDefault(ctx context.Context, prompt hardwareke
 		}
 	}
 
+	// unblock caches the new PIN the same way verify does.
 	if err := y.conn.unblock(pinAndPUK.PUK, pinAndPUK.PIN); err != nil {
 		return "", trace.Wrap(err)
 	}
 
+	y.pinCache.setPIN(pinAndPUK.PIN, pinCacheTTL)
 	return pinAndPUK.PIN, nil
 }
 

--- a/api/utils/keys/piv/yubikey.go
+++ b/api/utils/keys/piv/yubikey.go
@@ -493,19 +493,6 @@ func (y *YubiKey) checkOrSetPIN(ctx context.Context, prompt hardwarekey.Prompt, 
 const pinPromptTimeout = time.Minute
 
 func (y *YubiKey) promptPIN(ctx context.Context, prompt hardwarekey.Prompt, requirement hardwarekey.PINPromptRequirement, keyInfo hardwarekey.ContextualKeyInfo, pinCacheTTL time.Duration) (string, error) {
-	if pinCacheTTL == 0 {
-		pin, err := prompt.AskPIN(ctx, requirement, keyInfo)
-		if err != nil {
-			return "", trace.Wrap(err)
-		}
-
-		if pin == "" {
-			pin = piv.DefaultPIN
-		}
-
-		return pin, nil
-	}
-
 	y.pinCache.mu.Lock()
 	defer y.pinCache.mu.Unlock()
 
@@ -520,10 +507,6 @@ func (y *YubiKey) promptPIN(ctx context.Context, prompt hardwarekey.Prompt, requ
 	pin, err := prompt.AskPIN(ctx, requirement, keyInfo)
 	if err != nil {
 		return "", trace.Wrap(err)
-	}
-
-	if pin == "" {
-		pin = piv.DefaultPIN
 	}
 
 	// Verify that the PIN is correct before we cache it. This also caches it internally in the PC/SC transaction.

--- a/api/utils/keys/piv/yubikey.go
+++ b/api/utils/keys/piv/yubikey.go
@@ -370,7 +370,7 @@ func (y *YubiKey) generatePrivateKey(slot piv.Slot, policy hardwarekey.PromptPol
 		TouchPolicy: touchPolicy,
 	}
 
-	if _, err := y.conn.generateKey(piv.DefaultManagementKey, slot, opts); err != nil {
+	if err := y.GenerateKey(slot, opts); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -382,6 +382,12 @@ func (y *YubiKey) generatePrivateKey(slot piv.Slot, policy hardwarekey.PromptPol
 	}
 
 	return y.getKeyRef(slot, pinCacheTTL)
+}
+
+// GenerateKey generates a new private key in the given PIV slot.
+func (y *YubiKey) GenerateKey(slot piv.Slot, opts piv.Key) error {
+	_, err := y.conn.generateKey(piv.DefaultManagementKey, slot, opts)
+	return trace.Wrap(err)
 }
 
 // SetMetadataCertificate creates a self signed certificate and stores it in the YubiKey's

--- a/lib/teleterm/daemon/hardwarekeyprompt.go
+++ b/lib/teleterm/daemon/hardwarekeyprompt.go
@@ -95,7 +95,13 @@ func (h *hardwareKeyPrompter) AskPIN(ctx context.Context, requirement hardwareke
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
-	return res.Pin, nil
+
+	pin := res.Pin
+	if pin == "" {
+		pin = hardwarekey.DefaultPIN
+	}
+
+	return pin, nil
 }
 
 // ChangePIN asks for a new PIN.


### PR DESCRIPTION
Follow up to https://github.com/gravitational/teleport/pull/53976 to prevent an incorrect PIN from being cached by verifying the PIN against the YubiKey first.

Changelog: Fix an issue with PIV PIN caching where a PIN that is incorrect would be cached.

Note: Once https://github.com/go-piv/piv-go/pull/174 gets merged and released, I can take care of the TODO about the redundant PIN verification taking place.