### PR TITLE
add basic scopes pkgs

### DIFF
--- a/lib/scopes/cache/cache.go
+++ b/lib/scopes/cache/cache.go
@@ -1,0 +1,272 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cache
+
+import (
+	"iter"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/scopes"
+)
+
+// Config configures a cache.
+type Config[T any, K comparable] struct {
+	// Scope is the function used to determine the scope of a value.
+	Scope func(T) string
+	// Key is the function used to determine the primary key of a value.
+	Key func(T) K
+}
+
+// node is a tree node in the cache which stores values at a given scope.
+type node[T any, K comparable] struct {
+	// members is the set of values "at" this scope.
+	members map[K]struct{}
+
+	// children is the set of child scopes.
+	children map[string]*node[T, K]
+}
+
+// Cache is a generic scoped value cache. It constructs a basic tree structure based on scope segments
+// to support efficient lookings up values based on common scoping patterns. This cache is intended to be
+// a tool for building more purpose-specific wrappers and should not be used directly in access-control
+// logic due to ease of misuse.
+//
+// NOTE: this is an early stage prototype and has a few notable limitations:
+//   - Not currently safe for concurrent use.
+//   - Iteration order of read methods is nondeterministic.
+//   - No cleanup of empty scopes.
+type Cache[T any, K comparable] struct {
+	cfg   Config[T, K]
+	items map[K]T
+	root  *node[T, K]
+}
+
+// New builds a new cache instance based on the supplied config.
+func New[T any, K comparable](cfg Config[T, K]) (*Cache[T, K], error) {
+	if cfg.Scope == nil {
+		return nil, trace.BadParameter("missing required scope function for scope cache")
+	}
+
+	if cfg.Key == nil {
+		return nil, trace.BadParameter("missing required key function for scope cache")
+	}
+
+	return &Cache[T, K]{
+		cfg:   cfg,
+		items: make(map[K]T),
+	}, nil
+}
+
+// ScopedItems provides the canonical representation of a scope and an iterator over the items within it. Typically
+// used as the item of an outer iterator across multiple scopes.
+type ScopedItems[T any] struct {
+	scope string
+	items iter.Seq[T]
+}
+
+// Scope is the canonical representation of the scope to which the items belong. Note that
+// it is theoretically possible for this to be different than the scope value of any particular
+// item in the iterator.
+func (s *ScopedItems[T]) Scope() string {
+	// TODO(fspmarshall): should we lazily build the scope string? changes are that a lot of
+	// usecases won't care about it.
+	return s.scope
+}
+
+// Items is an iterator over the items within the above scope. Note that within an iterator of ScopedItems,
+// this iterator may only be safe to use during the current outer iteration.
+func (s *ScopedItems[T]) Items() iter.Seq[T] {
+	// TODO(fspmarshall): lazily build the iterator here so that iteration can happen multiple times
+	// if needed.
+	return s.items
+}
+
+// newScopedItems is a helper function for creating a ScopedItems instance within a top-level iterator.
+func newScopedItems[T any, K comparable](segments []string, members map[K]struct{}, items map[K]T) ScopedItems[T] {
+	return ScopedItems[T]{
+		scope: scopes.Join(segments...),
+		items: func(yield func(T) bool) {
+			for key := range members {
+				if !yield(items[key]) {
+					return
+				}
+			}
+		},
+	}
+}
+
+// PoliciesApplicableToResourceScope iterates over the cached items using policy-application rules (i.e.
+// a descending iteration from root, through the leaf of the specified scope).
+func (c *Cache[T, K]) PoliciesApplicableToResourceScope(scope string) iter.Seq[ScopedItems[T]] {
+	return func(yield func(ScopedItems[T]) bool) {
+		if c.root == nil {
+			return
+		}
+
+		// keep track of the segments visited
+		var visited []string
+
+		// start at the root
+		current := c.root
+
+		for segment := range scopes.DescendingSegments(scope) {
+			// yield the current scope if it is non-empty
+			if len(current.members) != 0 {
+				if !yield(newScopedItems(visited, current.members, c.items)) {
+					return
+				}
+			}
+
+			// check for the next scope
+			if _, ok := current.children[segment]; !ok {
+				return
+			}
+
+			// advance to the next scope
+			visited = append(visited, segment)
+			current = current.children[segment]
+		}
+
+		// yield the final scope if it is non-empty
+		if len(current.members) != 0 {
+			if !yield(newScopedItems(visited, current.members, c.items)) {
+				return
+			}
+		}
+	}
+}
+
+// ResourcesSubjectToPolicyScope iterates over the cached items using resources-subjugation rules (i.e.
+// an exhaustive iteration of the specified scope and all of its descendants).
+func (c *Cache[T, K]) ResourcesSubjectToPolicyScope(scope string) iter.Seq[ScopedItems[T]] {
+	return func(yield func(ScopedItems[T]) bool) {
+		if c.root == nil {
+			return
+		}
+
+		// keep track of the segments visited
+		var visited []string
+
+		// search for start position, beginning at the root
+		start := c.root
+
+		for segment := range scopes.DescendingSegments(scope) {
+			// check for the next scope
+			if _, ok := start.children[segment]; !ok {
+				// reached the end prior to finding the target scope,
+				// nothing to yield.
+				return
+			}
+
+			// advance to the next scope
+			visited = append(visited, segment)
+			start = start.children[segment]
+		}
+
+		// recursively yield starting position and all of its descendants
+		if !recursiveYield(yield, visited, start, c.items) {
+			return
+		}
+	}
+}
+
+// recursiveYield is a helper function for recursively yielding all members of a given scope node, and all
+// members of all of its children. The returned bool is the return value of the last call to yield.
+func recursiveYield[T any, K comparable](yield func(ScopedItems[T]) bool, visited []string, current *node[T, K], items map[K]T) bool {
+	// yield the current scope if it is non-empty
+	if len(current.members) != 0 {
+		if !yield(newScopedItems(visited, current.members, items)) {
+			return false
+		}
+	}
+
+	// recursively yield all child scopes
+	for segment, child := range current.children {
+		if !recursiveYield(yield, append(visited, segment), child, items) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Put inserts the given value, potentially displacing an existing value with the same
+// primary key.
+func (c *Cache[T, K]) Put(value T) {
+	// get scope and key for this value
+	scope, key := c.cfg.Scope(value), c.cfg.Key(value)
+
+	// ensure that any previous value at this primary key has been removed
+	c.Del(key)
+
+	if c.root == nil {
+		c.root = &node[T, K]{
+			members:  make(map[K]struct{}),
+			children: make(map[string]*node[T, K]),
+		}
+	}
+
+	// find the node for this scope
+	current := c.root
+	for segment := range scopes.DescendingSegments(scope) {
+		if _, ok := current.children[segment]; !ok {
+			current.children[segment] = &node[T, K]{
+				members:  make(map[K]struct{}),
+				children: make(map[string]*node[T, K]),
+			}
+		}
+		current = current.children[segment]
+	}
+
+	// add the value to the set of members at this scope
+	current.members[key] = struct{}{}
+
+	// add the value to the set of members at this primary key
+	c.items[key] = value
+}
+
+// Del deletes the value associated with the given primary key.
+func (c *Cache[T, K]) Del(key K) {
+	// get the value associated with this primary key
+	value, ok := c.items[key]
+	if !ok {
+		return
+	}
+
+	// determine the scope for this value
+	scope := c.cfg.Scope(value)
+
+	// get the node for this scope
+	current := c.root
+	for segment := range scopes.DescendingSegments(scope) {
+		current = current.children[segment]
+	}
+
+	// remove the value from the set of members at this scope
+	delete(current.members, key)
+
+	// remove the value from the set of members at this primary key
+	delete(c.items, key)
+}
+
+// Len gets the total number of unique items stored in the cache.
+func (c *Cache[T, K]) Len() int {
+	return len(c.items)
+}

--- a/lib/scopes/cache/cache_test.go
+++ b/lib/scopes/cache/cache_test.go
@@ -1,0 +1,284 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cache
+
+import (
+	"iter"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/scopes"
+)
+
+// item is a a basic helper used for cache testing.
+type item struct {
+	key   string
+	scope string
+}
+
+func (i *item) Key() string {
+	return i.key
+}
+
+func (i *item) Scope() string {
+	return i.scope
+}
+
+// TestCacheBasics verifies basic functionality of the cache, including insertion, query, and deletion, and
+// correct handling of collisions.
+func TestCacheBasics(t *testing.T) {
+	t.Parallel()
+
+	items := []*item{
+		{
+			key:   "root-scoped",
+			scope: "/",
+		},
+		{
+			key:   "other-root-scoped",
+			scope: "/",
+		},
+		{
+			key:   "child-scoped",
+			scope: "/child",
+		},
+		{
+			key:   "other-child-scoped",
+			scope: "/child",
+		},
+		{
+			key:   "child-sub-scoped",
+			scope: "/child/subchild",
+		},
+		{
+			key:   "child-orthogonal",
+			scope: "/orthogonal",
+		},
+	}
+
+	cache, err := New(Config[*item, string]{
+		Scope: (*item).Scope,
+		Key:   (*item).Key,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, cache.Len())
+
+	// verify empty reads of root
+	requireEqualItemKeys(t, map[string][]string{}, collectScopedItemKeys(cache.PoliciesApplicableToResourceScope("/")))
+	requireEqualItemKeys(t, map[string][]string{}, collectScopedItemKeys(cache.ResourcesSubjectToPolicyScope("/")))
+
+	// verify empty sub-scope reads
+	requireEqualItemKeys(t, map[string][]string{}, collectScopedItemKeys(cache.PoliciesApplicableToResourceScope("/child")))
+	requireEqualItemKeys(t, map[string][]string{}, collectScopedItemKeys(cache.ResourcesSubjectToPolicyScope("/child")))
+
+	for _, item := range items {
+		cache.Put(item)
+	}
+
+	require.Equal(t, len(items), cache.Len())
+
+	// verify basic policies-applicable-to-resource iteration
+
+	requireEqualItemKeys(t, map[string][]string{
+		"/": {"root-scoped", "other-root-scoped"},
+	}, collectScopedItemKeys(cache.PoliciesApplicableToResourceScope("/")))
+
+	requireEqualItemKeys(t, map[string][]string{
+		"/":      {"root-scoped", "other-root-scoped"},
+		"/child": {"child-scoped", "other-child-scoped"},
+	}, collectScopedItemKeys(cache.PoliciesApplicableToResourceScope("/child")))
+
+	requireEqualItemKeys(t, map[string][]string{
+		"/":               {"root-scoped", "other-root-scoped"},
+		"/child":          {"child-scoped", "other-child-scoped"},
+		"/child/subchild": {"child-sub-scoped"},
+	}, collectScopedItemKeys(cache.PoliciesApplicableToResourceScope("/child/subchild")))
+
+	// verify basic resources-subject-to-policy iteration
+
+	requireEqualItemKeys(t, map[string][]string{},
+		collectScopedItemKeys(cache.ResourcesSubjectToPolicyScope("/nonexistent")))
+
+	requireEqualItemKeys(t, map[string][]string{
+		"/child/subchild": {"child-sub-scoped"},
+	}, collectScopedItemKeys(cache.ResourcesSubjectToPolicyScope("/child/subchild")))
+
+	requireEqualItemKeys(t, map[string][]string{
+		"/child":          {"child-scoped", "other-child-scoped"},
+		"/child/subchild": {"child-sub-scoped"},
+	}, collectScopedItemKeys(cache.ResourcesSubjectToPolicyScope("/child")))
+
+	requireEqualItemKeys(t, map[string][]string{
+		"/":               {"root-scoped", "other-root-scoped"},
+		"/child":          {"child-scoped", "other-child-scoped"},
+		"/child/subchild": {"child-sub-scoped"},
+		"/orthogonal":     {"child-orthogonal"},
+	}, collectScopedItemKeys(cache.ResourcesSubjectToPolicyScope("/")))
+
+	// verify that the concept of policies-applicable-to-resource used by the cache
+	// matches up with the definition expected by the scopes package.
+	for scope := range cache.PoliciesApplicableToResourceScope("/child/subchild") {
+		require.True(t, scopes.ResourceScope("/child/subchild").IsSubjectToPolicyScope(scope.Scope()), "scope=%s", scope.Scope())
+	}
+
+	// verify that the concept of resources-subject-to-policy used by the cache
+	// matches up with the definition expected by the scopes package.
+	for scope := range cache.ResourcesSubjectToPolicyScope("/child") {
+		require.True(t, scopes.PolicyScope("/child").AppliesToResourceScope(scope.Scope()), "scope=%s", scope.Scope())
+	}
+
+	// verify deletion of a single intermediate item
+	cache.Del("child-scoped")
+	require.Equal(t, len(items)-1, cache.Len())
+
+	requireEqualItemKeys(t, map[string][]string{
+		"/":               {"root-scoped", "other-root-scoped"},
+		"/child":          {"other-child-scoped"},
+		"/child/subchild": {"child-sub-scoped"},
+	}, collectScopedItemKeys(cache.PoliciesApplicableToResourceScope("/child/subchild")))
+
+	requireEqualItemKeys(t, map[string][]string{
+		"/":               {"root-scoped", "other-root-scoped"},
+		"/child":          {"other-child-scoped"},
+		"/child/subchild": {"child-sub-scoped"},
+		"/orthogonal":     {"child-orthogonal"},
+	}, collectScopedItemKeys(cache.ResourcesSubjectToPolicyScope("/")))
+
+	// verify deletion of a single root-scoped item
+	cache.Del("root-scoped")
+	require.Equal(t, len(items)-2, cache.Len())
+
+	requireEqualItemKeys(t, map[string][]string{
+		"/":               {"other-root-scoped"},
+		"/child":          {"other-child-scoped"},
+		"/child/subchild": {"child-sub-scoped"},
+	}, collectScopedItemKeys(cache.PoliciesApplicableToResourceScope("/child/subchild")))
+
+	requireEqualItemKeys(t, map[string][]string{
+		"/":               {"other-root-scoped"},
+		"/child":          {"other-child-scoped"},
+		"/child/subchild": {"child-sub-scoped"},
+		"/orthogonal":     {"child-orthogonal"},
+	}, collectScopedItemKeys(cache.ResourcesSubjectToPolicyScope("/")))
+
+	// verify full deletion of all contents of an intermediate scope
+	cache.Del("other-child-scoped")
+	require.Equal(t, len(items)-3, cache.Len())
+
+	requireEqualItemKeys(t, map[string][]string{
+		"/":               {"other-root-scoped"},
+		"/child/subchild": {"child-sub-scoped"},
+	}, collectScopedItemKeys(cache.PoliciesApplicableToResourceScope("/child/subchild")))
+
+	requireEqualItemKeys(t, map[string][]string{
+		"/":               {"other-root-scoped"},
+		"/child/subchild": {"child-sub-scoped"},
+		"/orthogonal":     {"child-orthogonal"},
+	}, collectScopedItemKeys(cache.ResourcesSubjectToPolicyScope("/")))
+
+	// verfiy full deletion of all contents of a root scope
+	cache.Del("other-root-scoped")
+	require.Equal(t, len(items)-4, cache.Len())
+
+	requireEqualItemKeys(t, map[string][]string{
+		"/child/subchild": {"child-sub-scoped"},
+	}, collectScopedItemKeys(cache.PoliciesApplicableToResourceScope("/child/subchild")))
+
+	requireEqualItemKeys(t, map[string][]string{
+		"/child/subchild": {"child-sub-scoped"},
+		"/orthogonal":     {"child-orthogonal"},
+	}, collectScopedItemKeys(cache.ResourcesSubjectToPolicyScope("/")))
+
+	// verify deletion of leaf scope
+	cache.Del("child-sub-scoped")
+	require.Equal(t, len(items)-5, cache.Len())
+
+	requireEqualItemKeys(t, map[string][]string{},
+		collectScopedItemKeys(cache.PoliciesApplicableToResourceScope("/child/subchild")))
+
+	requireEqualItemKeys(t, map[string][]string{
+		"/orthogonal": {"child-orthogonal"},
+	}, collectScopedItemKeys(cache.ResourcesSubjectToPolicyScope("/")))
+
+	// verify basic re-add
+	cache.Put(&item{
+		key:   "child-scoped",
+		scope: "/child",
+	})
+	require.Equal(t, len(items)-4, cache.Len())
+
+	requireEqualItemKeys(t, map[string][]string{
+		"/child": {"child-scoped"},
+	}, collectScopedItemKeys(cache.PoliciesApplicableToResourceScope("/child")))
+
+	requireEqualItemKeys(t, map[string][]string{
+		"/child":      {"child-scoped"},
+		"/orthogonal": {"child-orthogonal"},
+	}, collectScopedItemKeys(cache.ResourcesSubjectToPolicyScope("/")))
+
+	// verify overwrite of existing item by primary key
+	cache.Put(&item{
+		key:   "child-scoped",
+		scope: "/child/other",
+	})
+	require.Equal(t, len(items)-4, cache.Len())
+
+	requireEqualItemKeys(t, map[string][]string{},
+		collectScopedItemKeys(cache.PoliciesApplicableToResourceScope("/child/subchild")))
+
+	requireEqualItemKeys(t, map[string][]string{
+		"/child/other": {"child-scoped"},
+	}, collectScopedItemKeys(cache.PoliciesApplicableToResourceScope("/child/other")))
+
+	requireEqualItemKeys(t, map[string][]string{
+		"/child/other": {"child-scoped"},
+		"/orthogonal":  {"child-orthogonal"},
+	}, collectScopedItemKeys(cache.ResourcesSubjectToPolicyScope("/")))
+}
+
+// requireEualItemKeys is a workaround because scope/item iteration is currently unordered.
+// TODO(fspmarshall): make scope/item iteration ordered.
+func requireEqualItemKeys(t *testing.T, expected, actual map[string][]string) {
+	t.Helper()
+	for _, val := range expected {
+		slices.Sort(val)
+	}
+
+	for _, val := range actual {
+		slices.Sort(val)
+	}
+
+	require.Equal(t, expected, actual)
+}
+
+// collectScopedItemKeys aggregates a scoped iterator from one of the cache iteration
+// methods into a map of scope -> keys.
+func collectScopedItemKeys(iterator iter.Seq[ScopedItems[*item]]) map[string][]string {
+	itemKeys := make(map[string][]string)
+	for scope := range iterator {
+		var keys []string
+		for item := range scope.Items() {
+			keys = append(keys, item.Key())
+		}
+		itemKeys[scope.Scope()] = keys
+	}
+	return itemKeys
+}

--- a/lib/scopes/doc.go
+++ b/lib/scopes/doc.go
@@ -1,0 +1,37 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// The scopes package provides helpers for validating and evaluating the scoping of resources and access-control policies. The core principals of scoping are as follows:
+//
+//   - A scope is a path-like string with segments separated by slashes (e.g. '/foo/bar').
+//   - The outermost scope is the root scope ('/').
+//   - Given any two valid scopes, they will either be equivalent ('/foo' and '/foo'), orthogonal ('/foo' and '/bar'), or have an ancestore/descendant relationship (e.g. '/foo' and '/foo/bar/bin').
+//   - Resources are assigned to exactly one scope.
+//   - Policies/permissions are assigned at a scope, but apply to that scope and all descendant scopes (e.g. 'scoped_token:create' in '/foo' implies 'scoped_token:create' in '/foo/bar').
+//   - Access-control decision evaluation starts at the root scope, and halts at the first sub-scope where an allow decision is reached (e.g. when evaluating access to a resource in '/foo/bar', an allow decision in '/foo' will ignore policies assigned at '/foo/bar').
+//   - A policy/permission is conceptually distinct from the resource that defines it. Assignment of a policy/permission may happen at the same scope as the resource that defines it, or at a child of that scope.
+//
+// General usage guidance:
+//
+//   - When reading in a scope value from an external source (user input, identity provider, etc) check it with [StrongValidate].
+//   - When reading in a scope value from a trusted source (control-plane, backend, etc) check it with [WeakValidate].
+//   - When constructing a scope from component strings (e.g. during string interpolation), call [ValidateSegment] on each segment in addition to calling [StrongValidate] on the final scope.
+//   - If you have a resource at a given scope and want to filter for applicable policies/permissions, use [ResourceScope].
+//   - If you have a policy/permission at a given scope and want to filter for subject resources, use [PolicyScope].
+//   - Avoid using [Compare] and the associated [Relationship] type directly in access-control logic.
+package scopes

--- a/lib/scopes/scopes.go
+++ b/lib/scopes/scopes.go
@@ -1,0 +1,334 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package scopes
+
+import (
+	"fmt"
+	"iter"
+	"regexp"
+	"strings"
+	"unicode"
+
+	"github.com/gravitational/trace"
+)
+
+// segmentRegexp is the regular expression used to validate scope segments. It allows
+// alphanumeric characters, hyphens, underscores, and periods. It also requires that the
+// segment starts and ends with an alphanumeric character.
+var segmentRegexp = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9\-\_\.]*[a-zA-Z0-9]$`)
+
+const (
+	// separator is the character used to separate segments in a scope and is the the value of the root scope.
+	separator = "/"
+
+	// exclusiveChildGlobSuffix is a special suffix used in roles to indicate that the role can be
+	// assigned to any *child* of a given scope, but not to the scope itself (e.g. an assignable scope of
+	// `/aa/**` allows assignment to `/aa/bb`, but not to `/aa`).
+	exclusiveChildGlobSuffix = separator + "**"
+
+	// maxScopeSize is the maximum size of a scope, including separators.
+	maxScopeSize = 64
+
+	// maxSegmentSize is the maximum size of a segment, excluding separators.
+	maxSegmentSize = 32
+
+	// minSegmentSize is the minimum size of a segment, excluding separators.
+	minSegmentSize = 2
+
+	// breakingChars is a special set of characters that we explicitly consider to be invalid
+	// members even when performing looser/weaker validation. This it intended to be an additional
+	// guardrail against erroneous interpretation of future extensions to scope syntax by outdated
+	// agents in the event of improper cross-version compat logic.
+	breakingChars = "\\@(){}\"'%*?#$!+=|<>,;~`&[]"
+)
+
+// ValidateSegment checks if a given scope segment is valid. Generally, one of either [StrongValidate] or
+// [WeakValidate] should be called against the entire scope, but this function is useful for validating segments
+// prior to performing variable interpolation or other operations that involve building scopes from
+// external input. Among other things, using this function in that context is an easy way to prevent
+// multi-segment injection in places where a single segment is expected.
+func ValidateSegment(segment string) error {
+	if segment == "" {
+		return trace.BadParameter("segment is empty")
+	}
+
+	if len(segment) < minSegmentSize {
+		return trace.BadParameter("segment %q is too short (min characters %d)", segment, minSegmentSize)
+	}
+
+	if !segmentRegexp.MatchString(segment) {
+		return trace.BadParameter("segment %q is malformed", segment)
+	}
+
+	if len(segment) > maxSegmentSize {
+		return trace.BadParameter("segment %q is too long (max characters %d)", segment, maxSegmentSize)
+	}
+
+	return nil
+}
+
+// StrongValidate checks if the scope is valid according to all scope formatting rules. This function
+// *must* be called on all scope values received from user input and/or cluster-external sources (e.g.
+// an identity provider). Use of this function should be avoided when checking the validity of scopes
+// from the control-plane in logic that may be run agent-side. Prefer [WeakValidate] in those cases, which
+// is more forgiving of changes to scope formatting rules.
+func StrongValidate(scope string) error {
+	if scope == "" {
+		return trace.BadParameter("scope is empty")
+	}
+
+	if !strings.HasPrefix(scope, separator) {
+		return trace.BadParameter("scope %q is missing required prefix %q", scope, separator)
+	}
+
+	if scope != separator && strings.HasSuffix(scope, separator) {
+		return trace.BadParameter("scope %q has dangling separator %q", scope, separator)
+	}
+
+	for segment := range DescendingSegments(scope) {
+		if err := ValidateSegment(segment); err != nil {
+			return trace.BadParameter("scope %q is invalid: %v", scope, err)
+		}
+	}
+
+	if len(scope) > maxScopeSize {
+		return trace.BadParameter("scope %q is too long (max characters %d)", scope, maxScopeSize)
+	}
+
+	return nil
+}
+
+// WeakValidate performs a weak form of validation on a scope. This is useful primarily for ensuring
+// that scopes received from trusted sources haven't been altered beyond our ability to reason effectively
+// about them (e.g. due to significant version drift). Prefer using [StrongValidate] for scopes received from
+// external sources (e.g. user input or identity provider).
+func WeakValidate(scope string) error {
+	for segment := range DescendingSegments(scope) {
+		// check for spaces and control characters
+		for _, r := range segment {
+			if unicode.IsSpace(r) || unicode.IsControl(r) {
+				return trace.BadParameter("scope %q contains invalid segment %q (whitespace or control character)", scope, segment)
+			}
+		}
+
+		// check for breaking characters
+		if strings.ContainsAny(segment, breakingChars) {
+			return trace.BadParameter("scope %q contains invalid segment %q (invalid character)", scope, segment)
+		}
+	}
+
+	return nil
+}
+
+// ValidateGlob checks if a scope glob is valid. A scope glob is a special type of scope that
+// may be either a literal or a very simplistic matcher.
+func ValidateGlob(scope string) error {
+	if scope == "" {
+		return trace.BadParameter("scope is empty")
+	}
+
+	if scope == exclusiveChildGlobSuffix {
+		// this is just a matcher for any child of root
+		return nil
+	}
+
+	return StrongValidate(strings.TrimSuffix(scope, exclusiveChildGlobSuffix))
+}
+
+// DescendingSegments produces an iterator over the segments of a scope in descending order.
+// e.g. `DescendingSegments("/a/b/c")` will result in an iterator that returns `a`, `b`, and
+// `c` in that order. `DescendingSegments("/")` will return an empty iterator.
+//
+// Note that this function does not perform validation and is deliberately more relaxed about
+// its inputs than our validation functions allow.
+func DescendingSegments(scope string) iter.Seq[string] {
+	if scope == "" || scope == separator {
+		return func(yield func(string) bool) {}
+	}
+	return strings.SplitSeq(strings.TrimSuffix(strings.TrimPrefix(scope, "/"), "/"), "/")
+}
+
+// Join joins the given segments into a single scope string. Note that this function
+// does not perform validation and will produce invalid scopes if one or more segments
+// are invalid.
+func Join(segments ...string) string {
+	scope := separator + strings.Join(segments, separator)
+
+	// a tricky bit of how scope splitting/joining works is that an empty scope component
+	// as the last component is represented by `/aa//` not `/aa/`, because we chose not to assign trailing
+	// separators any meaning (i.e. `/aa/` does not imply the existence of an empty scope segment
+	// after `aa`).  Trailing separators and empty scope segments are both considered invalid, but adding
+	// this behavior ensures that our splitting/joining logic cannot cannot change the meaning of a scope
+	// value when applied to one-another's outputs. If we don't add this logic, then
+	// DescendingSegments(Join([]string{"aa", ""}...)) will produce []string{"aa"}. We could just as easily amend
+	// `DescendingSegments` to emit an empty segment in the event of a trailing separator, but
+	// we judged that to be the higher risk behavior since that would effectively "move" a value to a new
+	// scope in the event of a trailing separator making it past validation. Our chosen behavior only "moves" an assignment
+	// in the event of a double-separator getting through, which is a much more visually obvious and intuitively incorrect
+	// value, and therefore less likely to be hit during processing of user input.
+	if len(segments) > 0 && segments[len(segments)-1] == "" {
+		scope += separator
+	}
+
+	return scope
+}
+
+// Relationship describes the relationship between two scopes, as determined by the [Compare] function. Note
+// that direct use of this type in access-control logic is discouraged, as it is easier to accidentally
+// misuse than the provided helpers (e.g. [PolicyScope]).
+type Relationship int
+
+const (
+	// Orhogonal indicates that the scopes are divergents/unrelated (e.g. '/foo' and '/bar').
+	Orthogonal Relationship = iota
+	// Equivalent indicates that the scopes are equal. Some non-equal scope strings are still
+	// considered equivalent by [Compare] (e.g. 'foo' and '/foo/'), though the canonical representations
+	// (e.g. '/foo') will also have string equality.
+	Equivalent
+	// Ancestor indicates that one scope is an ancestor of another (including multi-level ancestors,
+	// e.g. '/foo' is an ancestor of '/foo/bar' and '/foo/bar/bin', and '/' is an ancestor to all
+	// other scope values).
+	Ancestor
+	// Descendant indicates that one scope is a descendant of another (including multi-level descendants,
+	// e.g. '/foo/bar/bin' is a descendant of '/foo/bar' and '/foo', and all other scope values are
+	// descendants of '/').
+	Descendant
+)
+
+// String returns the human-readable representation of the relationship.
+func (rel Relationship) String() string {
+	switch rel {
+	case Orthogonal:
+		return "Orthogonal"
+	case Equivalent:
+		return "Equivalent"
+	case Ancestor:
+		return "Ancestor"
+	case Descendant:
+		return "Descendant"
+	default:
+		return fmt.Sprintf("Unknown(%d)", rel)
+	}
+}
+
+// Compare compares the relationship between two scopes. The returned value is the
+// relationship of the second scope to the first. I.e. if Compare(x, y) returns Ancestor,
+// then y is an ancestor of x.
+//
+// Returns:
+//
+//	Compare(/aa, /aa)    => Equivalent
+//	Compare(/aa, /bb)    => Orthogonal
+//	Compare(/aa, /aa/bb) => Descendant
+//	Compare(/aa/bb, /aa) => Ancestor
+//
+// Prefer using one of the provided helpers (e.g. [PolicyScope]) over using this function directly,
+// as direct usage of this function can lead to ambiguity and accidental misuse.
+//
+// Note that this function does not perform validation, and may return unexpected results when
+// called against invalid scope values.
+func Compare(lhs, rhs string) Relationship {
+	lNext, lStop := iter.Pull(DescendingSegments(lhs))
+	defer lStop()
+
+	rNext, rStop := iter.Pull(DescendingSegments(rhs))
+	defer rStop()
+
+	for {
+		lVal, lOk := lNext()
+		rVal, rOk := rNext()
+
+		switch {
+		case lOk && rOk:
+			// both scopes have segments left to compare
+			if lVal == rVal {
+				// scopes are still equivalent at this level, continue processing
+				continue
+			}
+			// scopes have diverged
+			return Orthogonal
+		case lOk && !rOk:
+			// the right hand side scope is an ancestor of the left hand side scope
+			return Ancestor
+		case !lOk && rOk:
+			// the left hand side scope is an ancestor of the right hand side scope
+			return Descendant
+		case !lOk && !rOk:
+			// scopes are equivalent
+			return Equivalent
+		}
+	}
+}
+
+// PolicyScope is a helper for constructing unambiguous checks in access control logic. Prefer helpers like
+// this over using the Compare function directly, as it improves readability and reduces the risk of misuse. Ex:
+//
+//	if scopes.PolicyScope(roleAssignmentScope).AppliesToResourceScope(nodeScope) { ... }
+//
+// Note that this helper does not perform validation, and may produce unexpected results when used against
+// invalid scope values.
+type PolicyScope string
+
+// AppliesToResourceScope checks if a resource in the specified scope would be subject to this policy scope.
+func (s PolicyScope) AppliesToResourceScope(scope string) bool {
+	rel := Compare(string(s), scope)
+	return rel == Equivalent || rel == Descendant
+}
+
+// ResourceScope is a helper for constructing unambiguous checks in access control logic. Prefer helpers like
+// this over using the Compare function directly, as it improves readability and reduces the risk of misuse. Ex:
+//
+//	if scopes.ResourceScope(nodeScope).IsSubjectToPolicyScope(roleAssignmentScope) { ... }
+//
+// Note that this helper does not perform validation, and may produce unexpected results when used against
+// invalid scope values.
+type ResourceScope string
+
+// IsSubjectToPolicyScope checks if this resource scope is subject to the specified policy scope.
+func (s ResourceScope) IsSubjectToPolicyScope(scope string) bool {
+	rel := Compare(string(s), scope)
+	return rel == Equivalent || rel == Ancestor
+}
+
+// Glob is a helper for matching scope globs against scopes. This is currently used to support exactly
+// one piece of special syntax, the use of `/component/**` to indicate that a role can be assigned to any child of
+// the specified scope, but not to the scope itself. Ex:
+//
+//	if scopes.Glob(assignableScope).Matches(assignmentScope) { ... }
+//
+// Note that this helper does not perform validation, and may produce unexpected results when used against
+// invalid scope or glob values.
+type Glob string
+
+// Matches checks if the given scope matches this scope glob.
+func (s Glob) Matches(scope string) bool {
+	glob := string(s)
+	var exclusiveChildMatcher bool
+	if strings.HasSuffix(glob, exclusiveChildGlobSuffix) {
+		glob = strings.TrimSuffix(glob, exclusiveChildGlobSuffix)
+		exclusiveChildMatcher = true
+	}
+
+	rel := Compare(glob, scope)
+	if exclusiveChildMatcher {
+		return rel == Descendant
+	} else {
+		return rel == Equivalent
+	}
+}

--- a/lib/scopes/scopes_test.go
+++ b/lib/scopes/scopes_test.go
@@ -1,0 +1,679 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package scopes
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateSegment tests the ValidateSegment function for a few specific special cases. Most coverage is actually
+// done by the StrongValidate test, which relies on ValidateSegment internally for most of its functionality.
+func TestValidateSegment(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name    string
+		segment string
+		ok      bool
+	}{
+		{
+			name:    "valid segment",
+			segment: "aa",
+			ok:      true,
+		},
+		{
+			name:    "empty segment",
+			segment: "",
+			ok:      false,
+		},
+		{
+			name:    "segment with middle separator",
+			segment: "aa/bb",
+			ok:      false,
+		},
+		{
+			name:    "segment with leading separator",
+			segment: "/aa",
+			ok:      false,
+		},
+		{
+			name:    "segment with trailing separator",
+			segment: "aa/",
+			ok:      false,
+		},
+		{
+			name:    "root-like segment",
+			segment: "/",
+			ok:      false,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateSegment(tt.segment)
+			if tt.ok {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+// TestStrongValidate tests the StrongValidate function for various combinations of scopes.
+func TestStrongValidate(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name  string
+		scope string
+		ok    bool
+	}{
+		{
+			name:  "valid root",
+			scope: "/",
+			ok:    true,
+		},
+		{
+			name:  "valid single-segment",
+			scope: "/aa",
+			ok:    true,
+		},
+		{
+			name:  "valid multi-segment",
+			scope: "/aa/bb/cc",
+			ok:    true,
+		},
+		{
+			name:  "empty rejected",
+			scope: "",
+			ok:    false,
+		},
+		{
+			name:  "missing prefix rejected",
+			scope: "aa/bb/cc",
+			ok:    false,
+		},
+		{
+			name:  "dangling separator rejected",
+			scope: "/aa/bb/cc/",
+			ok:    false,
+		},
+		{
+			name:  "single-segment invalid chars",
+			scope: "/a ",
+			ok:    false,
+		},
+		{
+			name:  "multi-segment invalid chars fist",
+			scope: "/a(a/bb",
+			ok:    false,
+		},
+		{
+			name:  "multi-segment invalid chars last",
+			scope: "/aa/b)b",
+			ok:    false,
+		},
+		{
+			name:  "multi-segment invalid chars middle",
+			scope: "/aa/b!b/cc",
+			ok:    false,
+		},
+		{
+			name:  "single-segment too short",
+			scope: "/a",
+			ok:    false,
+		},
+		{
+			name:  "multi-segment too short",
+			scope: "/aa/b",
+			ok:    false,
+		},
+		{
+			name:  "long but ok scope",
+			scope: "/aaaaaaaaaaaaaaa/bbbbbbbbbbbbbbb/ccccccccccccccc/ddddddddddddddd",
+			ok:    true,
+		},
+		{
+			name:  "scope too long",
+			scope: "/aaaaaaaaaaaaaaa/bbbbbbbbbbbbbbb/ccccccccccccccc/dddddddddddddddd",
+			ok:    false,
+		},
+		{
+			name:  "long but ok segment",
+			scope: "/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			ok:    true,
+		},
+		{
+			name:  "segment too long",
+			scope: "/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			ok:    false,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			err := StrongValidate(tt.scope)
+			if tt.ok {
+				require.NoError(t, err)
+				require.NoError(t, WeakValidate(tt.scope)) // weak validate should accept all strongly valid scopes too
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+// TestWeakValidate tests the WeakValidate function for various combinations of scopes. The WeakValidate function
+// is already partially tested in the StrongValidate tests, so this test focuses on the specific cases that are
+// not covered there.
+func TestWeakValidate(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name  string
+		scope string
+		ok    bool
+	}{
+		{
+			name:  "explicitly disallowed character is disallowed",
+			scope: "/a@a/bb/cc",
+			ok:    false,
+		},
+		{
+			name:  "control character disallowed",
+			scope: "/a\na/bb/cc",
+			ok:    false,
+		},
+		{
+			name:  "unsupported character passes",
+			scope: "/aaa/b:b/cc",
+			ok:    true,
+		},
+		{
+			name:  "short segment passes",
+			scope: "/a/bb/cc",
+			ok:    true,
+		},
+		{
+			name:  "long segment passes",
+			scope: "/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/bbbbbbbbbbbbbbb/ccccccccccccccc/ddddddddddddddd",
+			ok:    true,
+		},
+		{
+			name:  "empty segment passes",
+			scope: "/aa//bb/cc",
+			ok:    true,
+		},
+		{
+			name:  "dangling separator passes",
+			scope: "/aa/bb/cc/",
+			ok:    true,
+		},
+		{
+			name:  "empty passes",
+			scope: "",
+			ok:    true,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			err := WeakValidate(tt.scope)
+			if tt.ok {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+// TestDescendingSegments tests the DescendingSegments iterator for various combinations of scopes, and verifies that
+// re-joining and re-segmenting produces the same segments.
+func TestDescendingSegments(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name     string
+		scope    string
+		segments []string
+	}{
+		{
+			name:     "root",
+			scope:    "/",
+			segments: nil,
+		},
+		{
+			name:     "empty",
+			scope:    "",
+			segments: nil,
+		},
+		{
+			name:     "single-segment",
+			scope:    "/aa",
+			segments: []string{"aa"},
+		},
+		{
+			name:     "multi-segment",
+			scope:    "/aa/bb/cc",
+			segments: []string{"aa", "bb", "cc"},
+		},
+		{
+			name:     "dangling separator single",
+			scope:    "/aa/",
+			segments: []string{"aa"},
+		},
+		{
+			name:     "dangling separator multi",
+			scope:    "/aa/bb/cc/",
+			segments: []string{"aa", "bb", "cc"},
+		},
+		{
+			name:     "leading empty segment",
+			scope:    "//aa/bb",
+			segments: []string{"", "aa", "bb"},
+		},
+		{
+			name:     "middle empty segment",
+			scope:    "/aa//bb",
+			segments: []string{"aa", "", "bb"},
+		},
+		{
+			name:     "trailing empty segment",
+			scope:    "/aa/bb//",
+			segments: []string{"aa", "bb", ""},
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			// verify that the iterator produces the expected segments
+			segs := slices.Collect(DescendingSegments(tt.scope))
+			require.Equal(t, tt.segments, segs)
+
+			// verfiy that joining and re-segmenting produces the same segments
+			segs2 := slices.Collect(DescendingSegments(Join(segs...)))
+			require.Equal(t, tt.segments, segs2)
+		})
+	}
+}
+
+// TestJoin tests the Join function for various combinations of segments, and verifies that re-segmenting
+// the joined value produces the original segments.
+func TestJoin(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name     string
+		segments []string
+		expect   string
+	}{
+		{
+			name:     "root",
+			segments: nil,
+			expect:   "/",
+		},
+		{
+			name:     "single segment",
+			segments: []string{"aa"},
+			expect:   "/aa",
+		},
+		{
+			name:     "multi segment",
+			segments: []string{"aa", "bb", "cc"},
+			expect:   "/aa/bb/cc",
+		},
+		{
+			name:     "leading empty segment preserved",
+			segments: []string{"", "aa", "bb"},
+			expect:   "//aa/bb",
+		},
+		{
+			name:     "middle empty segment preserved",
+			segments: []string{"aa", "", "bb"},
+			expect:   "/aa//bb",
+		},
+		{
+			name:     "trailing empty segment preserved",
+			segments: []string{"aa", "bb", ""},
+			expect:   "/aa/bb//",
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			// verify that Join produces the expected scope value
+			joined := Join(tt.segments...)
+			require.Equal(t, tt.expect, joined)
+
+			// verify that re-segmentation of the joined value produces the original segments
+			reSegmented := slices.Collect(DescendingSegments(joined))
+			require.Equal(t, tt.segments, reSegmented)
+		})
+	}
+}
+
+// TestCompare tests the Compare function for various combinations of scopes.
+func TestCompare(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name     string
+		lhs, rhs string
+		rel      Relationship
+	}{
+		{
+			name: "simple equivalence",
+			lhs:  "/aa/bb/cc",
+			rhs:  "/aa/bb/cc",
+			rel:  Equivalent,
+		},
+		{
+			name: "simple ancestor",
+			lhs:  "/aa/bb/cc",
+			rhs:  "/aa/bb",
+			rel:  Ancestor,
+		},
+		{
+			name: "simple descendant",
+			lhs:  "/aa/bb",
+			rhs:  "/aa/bb/cc",
+			rel:  Descendant,
+		},
+		{
+			name: "simple orthogonal",
+			lhs:  "/aa/bb/cc",
+			rhs:  "/dd/ee/ff",
+			rel:  Orthogonal,
+		},
+		{
+			name: "multi-level ancestor",
+			lhs:  "/aa/bb/cc",
+			rhs:  "/aa",
+			rel:  Ancestor,
+		},
+		{
+			name: "multi-level descendant",
+			lhs:  "/aa",
+			rhs:  "/aa/bb/cc",
+			rel:  Descendant,
+		},
+		{
+			name: "root equivalence",
+			lhs:  "/",
+			rhs:  "/",
+			rel:  Equivalent,
+		},
+		{
+			name: "root in descendant case",
+			lhs:  "/",
+			rhs:  "/aa",
+			rel:  Descendant,
+		},
+		{
+			name: "root in ancestor case",
+			lhs:  "/aa",
+			rhs:  "/",
+			rel:  Ancestor,
+		},
+		{
+			name: "empty root equivalence",
+			lhs:  "",
+			rhs:  "",
+			rel:  Equivalent,
+		},
+		{
+			name: "empty lhs root in equivalence case",
+			lhs:  "",
+			rhs:  "/",
+			rel:  Equivalent,
+		},
+		{
+			name: "empty rhs root in equivalence case",
+			lhs:  "/",
+			rhs:  "",
+			rel:  Equivalent,
+		},
+		{
+			name: "empty root in descendant case",
+			lhs:  "",
+			rhs:  "/aa",
+			rel:  Descendant,
+		},
+		{
+			name: "empty root in ancestor case",
+			lhs:  "/aa",
+			rhs:  "",
+			rel:  Ancestor,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.rel, Compare(tt.lhs, tt.rhs), "Compare(%q, %q)", tt.lhs, tt.rhs)
+		})
+	}
+}
+
+// TestPolicyAndResourceScope tests the relationship between policy and resource scopes helpers
+// given various combinations of policy and resource scopes.
+func TestPolicyAndResourceScope(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name      string
+		privilege string
+		resource  string
+		applies   bool
+	}{
+		{
+			name:      "simple root",
+			privilege: "/",
+			resource:  "/",
+			applies:   true,
+		},
+		{
+			name:      "simple root privilege",
+			privilege: "/",
+			resource:  "/aa",
+			applies:   true,
+		},
+		{
+			name:      "simple root resource",
+			privilege: "/aa",
+			resource:  "/",
+			applies:   false,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.applies, PolicyScope(tt.privilege).AppliesToResourceScope(tt.resource),
+				"PolicyScope(%q).AppliesToResourceScope(%q)", tt.privilege, tt.resource)
+
+			require.Equal(t, tt.applies, ResourceScope(tt.resource).IsSubjectToPolicyScope(tt.privilege),
+				"ResourceScope(%q).IsSubjectToPolicyScope(%q)", tt.resource, tt.privilege)
+		})
+	}
+}
+
+// TestValidateGlob tests the ValidateGlob function for various combinations of globs.
+func TestValidateGlob(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name string
+		glob string
+		ok   bool
+	}{
+		{
+			name: "standard literal",
+			glob: "/aa/bb/cc",
+			ok:   true,
+		},
+		{
+			name: "root literal",
+			glob: "/",
+			ok:   true,
+		},
+		{
+			name: "valid exclusive child glob",
+			glob: "/aa/bb/**",
+			ok:   true,
+		},
+		{
+			name: "inclusive glob rejected",
+			glob: "/aa/bb/*",
+			ok:   false,
+		},
+		{
+			name: "inline exclusive glob rejected",
+			glob: "/aa/**/cc",
+			ok:   false,
+		},
+		{
+			name: "root exclusive child glob",
+			glob: "/**",
+			ok:   true,
+		},
+		{
+			name: "root exclusive child glob with trailing slash",
+			glob: "/**/",
+			ok:   false,
+		},
+		{
+			name: "root glob without leading slash",
+			glob: "**",
+			ok:   false,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateGlob(tt.glob)
+			if tt.ok {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+// TestGlob tests Glob.Matches for various combinations of globs and scopes.
+func TestGlob(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name  string
+		glob  string
+		scope string
+		match bool
+	}{
+		{
+			name:  "simple literal match",
+			glob:  "/aa/bb/cc",
+			scope: "/aa/bb/cc",
+			match: true,
+		},
+		{
+			name:  "simple literal mismatch",
+			glob:  "/aa/bb/cc",
+			scope: "/aa/bb/dd",
+			match: false,
+		},
+		{
+			name:  "root literal match",
+			glob:  "/",
+			scope: "/",
+			match: true,
+		},
+		{
+			name:  "root literal mismatch",
+			glob:  "/",
+			scope: "/aa",
+			match: false,
+		},
+		{
+			name:  "exclusive child glob match",
+			glob:  "/aa/bb/**",
+			scope: "/aa/bb/cc",
+			match: true,
+		},
+		{
+			name:  "exclusive child glob match multipart",
+			glob:  "/aa/bb/**",
+			scope: "/aa/bb/cc/dd",
+			match: true,
+		},
+		{
+			name:  "exclusive child glob mismatch equivalent",
+			glob:  "/aa/bb/**",
+			scope: "/aa/bb",
+			match: false,
+		},
+		{
+			name:  "exclusive child glob mismatch ancestor",
+			glob:  "/aa/bb/**",
+			scope: "/aa",
+			match: false,
+		},
+		{
+			name:  "exclusive child glob mismatch orthogonal",
+			glob:  "/aa/bb/**",
+			scope: "/aa/cc/dd",
+			match: false,
+		},
+		{
+			name:  "exclusive child glob match root",
+			glob:  "/**",
+			scope: "/aa",
+			match: true,
+		},
+		{
+			name:  "exclusive child glob match root multipart",
+			glob:  "/**",
+			scope: "/aa/bb/cc",
+			match: true,
+		},
+		{
+			name:  "exclusive child glob mismatch root",
+			glob:  "/**",
+			scope: "/",
+			match: false,
+		},
+		{
+			name:  "exclusive child glob mismatch empty root",
+			glob:  "/**",
+			scope: "",
+			match: false,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.match, Glob(tt.glob).Matches(tt.scope),
+				"Glob(%q).Matches(%q)", tt.glob, tt.scope)
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces new functionality intended to support upcoming scopes work.  Most importantly, it introduces the `lib/scopes` package which provides tools for validating, examining, and manipulating scope strings.  It also introduces `lib/scopes/cache`, which is a prototype cache intended to store scoped values for efficient queries of the kinds that will be needed for future scoped operations.

These two packages were developed in lockstep as a sanity-check against one another, to make sure that scopes as a model, and the resource/policy scoping rules in particular, behave in a sensible manner.  Both as path-like strings and as a mechanism of organizing/querying tree-like data.

Generally speaking the `lib/scopes` package is complete barring additional helpers that might be needed in the future. The `lib/scopes/cache` package is a starting point that I intend to iterate upon. It has the intended scoping behavior, but currently has some rough edges that make it inconvenient as a general purpose caching tool, including unsorted query output and no internal locking.

Part of ongoing work related to Scopes (https://github.com/gravitational/teleport/issues/54601).