### PR TITLE
Fix duplicate CopyNSString symbol in `lib/utils/darwinbundle`

### DIFF
--- a/lib/auth/touchid/common.m
+++ b/lib/auth/touchid/common.m
@@ -26,8 +26,12 @@
 #include <string.h>
 
 char *CopyNSString(NSString *val) {
-  if (val) {
-    return strdup([val UTF8String]);
+  if (!val) {
+    return strdup("");
   }
-  return strdup("");
+  const char *utf8String = [val UTF8String];
+  if (!utf8String) {
+    return strdup("");
+  }
+  return strdup(utf8String);
 }

--- a/lib/utils/darwinbundle/darwinbundle_darwin.m
+++ b/lib/utils/darwinbundle/darwinbundle_darwin.m
@@ -19,9 +19,9 @@
 
 #include <string.h>
 
-// CopyNSString converts and copies an Obj-C string to a C string which can be used with cgo.
+// TELCopyNSString converts and copies an Obj-C string to a C string which can be used with cgo.
 // The caller is expected to free the returned pointer.
-char *CopyNSString(NSString *val) {
+char *TELCopyNSString(NSString *val) {
   if (val) {
     return strdup([val UTF8String]);
   }
@@ -37,7 +37,7 @@ const char *BundleIdentifier(const char *bundlePath) {
   // objects that are no longer needed (such as bundleIdentifier).
   @autoreleasepool {
     NSString *bundleIdentifier = TELBundleIdentifier(@(bundlePath));
-    return CopyNSString(bundleIdentifier);
+    return TELCopyNSString(bundleIdentifier);
   }
 }
 

--- a/lib/utils/darwinbundle/darwinbundle_darwin.m
+++ b/lib/utils/darwinbundle/darwinbundle_darwin.m
@@ -22,10 +22,14 @@
 // TELCopyNSString converts and copies an Obj-C string to a C string which can be used with cgo.
 // The caller is expected to free the returned pointer.
 char *TELCopyNSString(NSString *val) {
-  if (val) {
-    return strdup([val UTF8String]);
+  if (!val) {
+    return strdup("");
   }
-  return strdup("");
+  const char *utf8String = [val UTF8String];
+  if (!utf8String) {
+    return strdup("");
+  }
+  return strdup(utf8String);
 }
 
 const char *BundleIdentifier(const char *bundlePath) {

--- a/lib/vnet/daemon/common_darwin.m
+++ b/lib/vnet/daemon/common_darwin.m
@@ -47,10 +47,14 @@ NSString *VNEDaemonLabel(NSString *bundlePath) {
 }
 
 const char *VNECopyNSString(NSString *val) {
-  if (val) {
-    return strdup([val UTF8String]);
+  if (!val) {
+    return strdup("");
   }
-  return strdup("");
+  const char *utf8String = [val UTF8String];
+  if (!utf8String) {
+    return strdup("");
+  }
+  return strdup(utf8String);
 }
 
 bool getCodeSigningRequirement(NSString **outRequirement, NSError **outError) {


### PR DESCRIPTION
When writing Objective-C code with cgo, it's a common occurrence where you want to get a string out of the Objective-C world into Go. To do so, you must first convert the Objective-C string into C string, hence why the function `CopyNSString` exists.

However, symbols in C are global. `lib/auth/touchid` already defines `CopyNSString` and in #54239 I added another `CopyNSString` to `lib/utils/darwinbundle`. I didn't catch this because I was building without `TOUCHID=yes`, so the compiler has never run into duplicate symbols.

Once that PR got merged, [it broke the build](https://github.com/gravitational/teleport.e/actions/runs/14882316222/job/41793108028#step:15:1696):

```
ld: warning: ignoring duplicate libraries: '-lobjc'
duplicate symbol '_CopyNSString' in:
    /private/var/folders/bd/l1x285495zn1w585jdkgqhg80000gn/T/go-link-1192996920/000005.o
    /private/var/folders/bd/l1x285495zn1w585jdkgqhg80000gn/T/go-link-1192996920/000012.o
ld: 1 duplicate symbols
```

Initially, I attempted to extract `CopyNSString` to `lib/utils/string_darwin.h`. The problem with that is that Go (or is it cgo?) doesn't allow you to have Objective-C (or just C) source files if the package is not using cgo. So I'd have to add an empty `lib/utils/string_darwin.go` which does `import C` and nothing else, as `CopyNSString` is used solely by C code, never by Go code. And because tbot uses `lib/utils` but doesn't use cgo, I'd likely have to move that to a completely separate package, but then how do I name it? `lib/utils/string`? `lib/utils/nsstring`?

To avoid dealing with this awkwardness in `lib/utils`, I decided to just rename `CopyNSString` from `lib/utils/darwinbundle` to `TELCopyNSString`. It's an approach we already use in `lib/vnet/daemon` where the same function is named `VNECopyNSString`.

I verified that this fixes the problem by building tsh with `VNETDAEMON=yes TOUCHID=yes`.