### PR TITLE
AWS IAM Roles Anywhere Create Session wrapper

### DIFF
--- a/lib/integrations/awsra/createsession/createsession.go
+++ b/lib/integrations/awsra/createsession/createsession.go
@@ -1,0 +1,301 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package createsession
+
+import (
+	"bytes"
+	"cmp"
+	"context"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/utils/aws"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// CreateSessionRequest is a request to create a session with AWS IAM Roles Anywhere.
+type CreateSessionRequest struct {
+	// TrustAnchorARN is the ARN of the AWS IAM Roles Anywhere Trust Anchor.
+	TrustAnchorARN string
+	// ProfileARN is the ARN of the AWS IAM Roles Anywhere Profile.
+	ProfileARN string
+	// RoleARN is the ARN of the AWS IAM Role to generate credentials.
+	RoleARN string
+	// RoleSessionName is the name of the session to create.
+	// It will be visible in AWS CloudTrail logs.
+	// Only set this value if the Profile Accepts Custom Session Names.
+	RoleSessionName string
+	// Duration is the duration of the session.
+	// Omitting this value means the session will be valid for the profile's default duration.
+	// Valid values are between 15 minutes and 12 hours.
+	DurationSeconds *int
+
+	// Certificate is the certificate that will be exchanged to obtain the credentials.
+	Certificate *x509.Certificate
+	// PrivateKey is the private key that will be used to sign the request.
+	PrivateKey *ecdsa.PrivateKey
+
+	awsRegion string
+
+	// httpClient is the HTTP client used to make the request.
+	// If not set, a default HTTP client will be used.
+	// Used for testing purposes.
+	httpClient utils.HTTPDoClient
+
+	// clock is the clock used to get the current time.
+	// If not set, a real clock will be used.
+	// Used for testing purposes.
+	clock clockwork.Clock
+}
+
+func (req *CreateSessionRequest) checkAndSetDefaults() error {
+	raTrustAnchor, err := arn.Parse(req.TrustAnchorARN)
+	if err != nil {
+		return trace.BadParameter("invalid roles anywhere trust anchor arn: %v", err)
+	}
+
+	_, err = arn.Parse(req.ProfileARN)
+	if err != nil {
+		return trace.BadParameter("invalid roles anywhere profile arn: %v", err)
+	}
+
+	_, err = arn.Parse(req.RoleARN)
+	if err != nil {
+		return trace.BadParameter("invalid iam role arn: %v", err)
+	}
+
+	if req.DurationSeconds != nil {
+		const minDurationSecs = 15 * 60      // 15 minutes
+		const maxDurationSecs = 12 * 60 * 60 // 12 hours
+		if *req.DurationSeconds < minDurationSecs || *req.DurationSeconds > maxDurationSecs {
+			return trace.BadParameter("duration must be between 15 minutes and 12 hours")
+		}
+	}
+
+	if req.Certificate == nil {
+		return trace.BadParameter("certificate is required")
+	}
+
+	if req.PrivateKey == nil {
+		return trace.BadParameter("private key is required")
+	}
+
+	if req.httpClient == nil {
+		httpClient, err := defaults.HTTPClient()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		req.httpClient = httpClient
+	}
+
+	req.awsRegion = raTrustAnchor.Region
+	if err := aws.IsValidRegion(req.awsRegion); err != nil {
+		return trace.BadParameter("invalid region: %v", err)
+	}
+
+	req.clock = cmp.Or(req.clock, clockwork.NewRealClock())
+
+	return nil
+}
+
+// CreateSession exchanges a certificate for AWS credentials using the AWS IAM Roles Anywhere service.
+// This method is based on the following guide:
+// https://docs.aws.amazon.com/rolesanywhere/latest/userguide/authentication-sign-process.html
+func CreateSession(ctx context.Context, req CreateSessionRequest) (*CreateSessionResponse, error) {
+	if err := req.checkAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Task 1: Create a canonical request
+	// https://docs.aws.amazon.com/rolesanywhere/latest/userguide/authentication-sign-process.html#authentication-task1
+
+	createSessionRequestBody := struct {
+		ProfileARN      string `json:"profileArn"`
+		RoleARN         string `json:"roleArn"`
+		TrustAnchorARN  string `json:"trustAnchorArn"`
+		RoleSessionName string `json:"roleSessionName,omitempty"`
+		DurationSeconds *int   `json:"durationSeconds,omitempty"`
+	}{
+		ProfileARN:      req.ProfileARN,
+		RoleARN:         req.RoleARN,
+		TrustAnchorARN:  req.TrustAnchorARN,
+		RoleSessionName: req.RoleSessionName,
+		DurationSeconds: req.DurationSeconds,
+	}
+
+	canonicalRequestBody, err := json.Marshal(createSessionRequestBody)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	canonicalRequestURL := &url.URL{
+		Scheme: "https",
+		Host:   fmt.Sprintf("rolesanywhere.%v.amazonaws.com", req.awsRegion),
+		Path:   "/sessions", // Task 1-2
+	}
+
+	canonicalRequest, err := http.NewRequestWithContext(ctx,
+		http.MethodPost, // Task 1-1
+		canonicalRequestURL.String(),
+		bytes.NewReader(canonicalRequestBody),
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Task 1-4,5
+	formatedDate := req.clock.Now().UTC().Round(time.Second).Format("20060102T150405Z")
+	const signedHeaders = "content-type;host;x-amz-date;x-amz-x509"
+	canonicalRequest.Header.Set("Content-Type", "application/json")
+	canonicalRequest.Header.Set("Host", canonicalRequest.Host)
+	canonicalRequest.Header.Set("X-Amz-Date", formatedDate)
+	canonicalRequest.Header.Set("X-Amz-X509", base64.StdEncoding.EncodeToString(req.Certificate.Raw))
+
+	// Task 1-6
+	canonicalRequestBodyHash := sha256.Sum256(canonicalRequestBody)
+
+	// Task 1-7
+	canonicalRequestString := fmt.Sprintf(`POST
+/sessions
+
+content-type:application/json
+host:%s
+x-amz-date:%s
+x-amz-x509:%s
+
+%s
+%x`,
+		canonicalRequest.Header.Get("Host"),
+		canonicalRequest.Header.Get("X-Amz-Date"),
+		canonicalRequest.Header.Get("X-Amz-X509"),
+		signedHeaders,
+		canonicalRequestBodyHash,
+	)
+
+	// Task 1-8
+	canonicalRequestHashBytes := sha256.New()
+	canonicalRequestHashBytes.Write([]byte(canonicalRequestString))
+	canonicalRequestHash := hex.EncodeToString(canonicalRequestHashBytes.Sum(nil))
+
+	// Task 2: Create a string to sign
+	// https://docs.aws.amazon.com/rolesanywhere/latest/userguide/authentication-sign-process.html#authentication-task2
+
+	// Teleport only uses ECDSA keys in Roles Anywhere integration.
+	const algorithm = "AWS4-X509-ECDSA-SHA256"
+	credentialScope := formatedDate[:8] + "/" + req.awsRegion + "/rolesanywhere/aws4_request"
+
+	stringToSign := algorithm + "\n" +
+		formatedDate + "\n" +
+		credentialScope + "\n" +
+		canonicalRequestHash
+
+	// Task 3: Calculate the signature
+	// https://docs.aws.amazon.com/rolesanywhere/latest/userguide/authentication-sign-process.html#authentication-task3
+	signatureHash := sha256.Sum256([]byte(stringToSign))
+	signature, err := ecdsa.SignASN1(rand.Reader, req.PrivateKey, signatureHash[:])
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Task 4-2
+	credentialString := req.Certificate.SerialNumber.String() + "/" + credentialScope
+	// Task 4-3
+	canonicalRequest.Header.Set("Authorization",
+		algorithm+" "+
+			"Credential="+credentialString+", "+
+			"SignedHeaders="+signedHeaders+", "+
+			"Signature="+hex.EncodeToString(signature),
+	)
+
+	resp, err := req.httpClient.Do(canonicalRequest)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	defer resp.Body.Close()
+
+	respBody, err := utils.ReadAtMost(resp.Body, teleport.MaxHTTPResponseSize)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, trace.ReadError(resp.StatusCode, respBody)
+	}
+
+	// https://docs.aws.amazon.com/rolesanywhere/latest/userguide/authentication-create-session.html#response-syntax
+	createSessionResp := struct {
+		CredentialSet []struct {
+			Credentials struct {
+				AccessKeyId     string `json:"accessKeyId"`
+				SecretAccessKey string `json:"secretAccessKey"`
+				SessionToken    string `json:"sessionToken"`
+				Expiration      string `json:"expiration"`
+			} `json:"credentials"`
+		} `json:"credentialSet"`
+	}{}
+
+	if err := json.Unmarshal(respBody, &createSessionResp); err != nil {
+		return nil, trace.BadParameter("parsing response: %v", err)
+	}
+
+	if len(createSessionResp.CredentialSet) == 0 {
+		return nil, trace.BadParameter("no credentials received from rolesanywhere.CreateSession API")
+	}
+
+	credentials := createSessionResp.CredentialSet[0].Credentials
+
+	return &CreateSessionResponse{
+		Version:         1,
+		AccessKeyID:     credentials.AccessKeyId,
+		SecretAccessKey: credentials.SecretAccessKey,
+		SessionToken:    credentials.SessionToken,
+		Expiration:      credentials.Expiration,
+	}, nil
+}
+
+// CreateSessionResponse contains the response from the CreateSession API call.
+// It contains the credentials that can be used to access AWS APIs.
+type CreateSessionResponse struct {
+	// Version is always 1.
+	Version int
+	// AccessKeyID is the AWS access key ID.
+	AccessKeyID string
+	// SecretAccessKey is the AWS secret access key.
+	SecretAccessKey string
+	// SessionToken is the AWS session token.
+	SessionToken string
+	// Expiration is the expiration time of the credentials, format: RFC3339.
+	Expiration string
+}

--- a/lib/integrations/awsra/createsession/createsession_test.go
+++ b/lib/integrations/awsra/createsession/createsession_test.go
@@ -1,0 +1,240 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package createsession
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateSession(t *testing.T) {
+	oneHourInSeconds := 60 * 60
+
+	baseReq := func() CreateSessionRequest {
+		return CreateSessionRequest{
+			TrustAnchorARN:  "arn:aws:rolesanywhere:us-east-1:123456789012:trust-anchor/12345678-1234-1234-1234-123456789012",
+			ProfileARN:      "arn:aws:rolesanywhere:us-east-1:123456789012:profile/12345678-1234-1234-1234-123456789012",
+			RoleARN:         "arn:aws:iam::123456789012:role/teleport-role",
+			RoleSessionName: "teleport-session",
+			DurationSeconds: &oneHourInSeconds,
+			Certificate:     &x509.Certificate{},
+			PrivateKey:      &ecdsa.PrivateKey{},
+		}
+	}
+
+	t.Run("check defaults", func(t *testing.T) {
+		for _, tt := range []struct {
+			name     string
+			req      func() *CreateSessionRequest
+			errCheck require.ErrorAssertionFunc
+		}{
+			{
+				name: "valid",
+				req: func() *CreateSessionRequest {
+					req := baseReq()
+					return &req
+				},
+				errCheck: require.NoError,
+			},
+			{
+				name: "invalid trust anchor",
+				req: func() *CreateSessionRequest {
+					req := baseReq()
+					req.TrustAnchorARN = "invalid"
+					return &req
+				},
+				errCheck: require.Error,
+			},
+			{
+				name: "invalid profile",
+				req: func() *CreateSessionRequest {
+					req := baseReq()
+					req.ProfileARN = "invalid"
+					return &req
+				},
+				errCheck: require.Error,
+			},
+			{
+				name: "invalid role",
+				req: func() *CreateSessionRequest {
+					req := baseReq()
+					req.RoleARN = "invalid"
+					return &req
+				},
+				errCheck: require.Error,
+			},
+			{
+				name: "duration too long",
+				req: func() *CreateSessionRequest {
+					req := baseReq()
+					oneDayInSeconds := 24 * 60 * 60
+					req.DurationSeconds = &oneDayInSeconds
+					return &req
+				},
+				errCheck: require.Error,
+			},
+			{
+				name: "duration too short",
+				req: func() *CreateSessionRequest {
+					req := baseReq()
+					oneMinute := 1 * 60
+					req.DurationSeconds = &oneMinute
+					return &req
+				},
+				errCheck: require.Error,
+			},
+			{
+				name: "missing certificate",
+				req: func() *CreateSessionRequest {
+					req := baseReq()
+					req.Certificate = nil
+					return &req
+				},
+				errCheck: require.Error,
+			},
+			{
+				name: "missing private key",
+				req: func() *CreateSessionRequest {
+					req := baseReq()
+					req.PrivateKey = nil
+					return &req
+				},
+				errCheck: require.Error,
+			},
+			{
+				name: "invalid region in trust anchor",
+				req: func() *CreateSessionRequest {
+					req := baseReq()
+					req.TrustAnchorARN = "arn:aws:rolesanywhere:invalid-region:123456789012:trust-anchor/12345678-1234-1234-1234-123456789012"
+					return &req
+				},
+				errCheck: require.Error,
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				tt.errCheck(t, tt.req().checkAndSetDefaults())
+			})
+		}
+	})
+
+	t.Run("golden request", func(t *testing.T) {
+		ctx := context.Background()
+		clock := clockwork.NewFakeClockAt(time.Date(1984, time.April, 4, 0, 0, 0, 0, time.UTC))
+
+		privateKey, x509Cert := newHardcodedPrivateKeyAndCert(t)
+
+		httpClient := &fakeHTTPClient{
+			resp: []byte(`{
+  "credentialSet": [
+    {
+      "credentials": {
+        "accessKeyId": "access key id",
+        "expiration": "1984-04-04T01:00:00Z",
+        "secretAccessKey": "access key",
+        "sessionToken": "session token"
+      }
+    }
+  ]
+}`),
+			statusCode: http.StatusCreated,
+			requestChecker: func(r *http.Request) {
+				expectedAuthorizationHeaderPrefix := "AWS4-X509-ECDSA-SHA256 Credential=12345/19840404/us-east-1/rolesanywhere/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-x509, Signature="
+				expectedX509Header := "MIIBZzCCAQygAwIBAgICMDkwCgYIKoZIzj0EAwIwGTEXMBUGA1UEAxMObXktY29tbW9uLW5hbWUwIBgPMDAwMTAxMDEwMDAwMDBaFw04NDA0MDQwMDAxMDBaMBkxFzAVBgNVBAMTDm15LWNvbW1vbi1uYW1lMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQ1RGW1ejV5FfT4Vi3TLdw9fp6OuWpxJTf5Su/PE23rq406tzEF172VOlIklAHv5CFactwvWPcQfx5FTN8/wFGaNCMEAwDgYDVR0PAQH/BAQDAgeAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFLVszSqeFZx+PqHJrb6JvqEcGl0eMAoGCCqGSM49BAMCA0kAMEYCIQDFa3U+zI6l/V8b3IukoxZd5N+UN4k/ZohChsM7srfk+QIhAMDxA2u8I09u6qsVyHB0T47Bx56X4suEZR5+qTgR1JWu"
+				expectedBody := `{"profileArn":"arn:aws:rolesanywhere:us-east-1:123456789012:profile/12345678-1234-1234-1234-123456789012","roleArn":"arn:aws:iam::123456789012:role/teleport-role","trustAnchorArn":"arn:aws:rolesanywhere:us-east-1:123456789012:trust-anchor/12345678-1234-1234-1234-123456789012","roleSessionName":"teleport-session","durationSeconds":3600}`
+
+				bodyBytes, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+				defer r.Body.Close()
+
+				require.Equal(t, http.MethodPost, r.Method)
+				require.Equal(t, "/sessions", r.URL.Path)
+				require.Equal(t, "rolesanywhere.us-east-1.amazonaws.com", r.Host)
+				require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+				require.Equal(t, "19840404T000000Z", r.Header.Get("X-Amz-Date"))
+				require.Equal(t, expectedX509Header, r.Header.Get("X-Amz-X509"))
+				require.Contains(t, r.Header.Get("Authorization"), expectedAuthorizationHeaderPrefix)
+				require.Equal(t, expectedBody, string(bodyBytes))
+
+			},
+		}
+
+		req := baseReq()
+		req.httpClient = httpClient
+		req.clock = clock
+		req.Certificate = x509Cert
+		req.PrivateKey = privateKey
+
+		resp, err := CreateSession(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, 1, resp.Version)
+		require.Equal(t, "access key id", resp.AccessKeyID)
+		require.Equal(t, "access key", resp.SecretAccessKey)
+		require.Equal(t, "session token", resp.SessionToken)
+	})
+}
+
+func newHardcodedPrivateKeyAndCert(t *testing.T) (*ecdsa.PrivateKey, *x509.Certificate) {
+	privateKeyBytes, _ := pem.Decode([]byte(`-----BEGIN PRIVATE KEY-----
+MHcCAQEEIKanMDk2rw+0MTczJZA+uUJBPqUDPjpmpdcvFR3ZE3SboAoGCCqGSM49
+AwEHoUQDQgAEQ1RGW1ejV5FfT4Vi3TLdw9fp6OuWpxJTf5Su/PE23rq406tzEF17
+2VOlIklAHv5CFactwvWPcQfx5FTN8/wFGQ==
+-----END PRIVATE KEY-----`))
+	privateKey, err := x509.ParseECPrivateKey(privateKeyBytes.Bytes)
+	require.NoError(t, err)
+
+	certBase64EncodedBytes := "MIIBZzCCAQygAwIBAgICMDkwCgYIKoZIzj0EAwIwGTEXMBUGA1UEAxMObXktY29tbW9uLW5hbWUwIBgPMDAwMTAxMDEwMDAwMDBaFw04NDA0MDQwMDAxMDBaMBkxFzAVBgNVBAMTDm15LWNvbW1vbi1uYW1lMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQ1RGW1ejV5FfT4Vi3TLdw9fp6OuWpxJTf5Su/PE23rq406tzEF172VOlIklAHv5CFactwvWPcQfx5FTN8/wFGaNCMEAwDgYDVR0PAQH/BAQDAgeAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFLVszSqeFZx+PqHJrb6JvqEcGl0eMAoGCCqGSM49BAMCA0kAMEYCIQDFa3U+zI6l/V8b3IukoxZd5N+UN4k/ZohChsM7srfk+QIhAMDxA2u8I09u6qsVyHB0T47Bx56X4suEZR5+qTgR1JWu"
+	certBytes, err := base64.StdEncoding.DecodeString(certBase64EncodedBytes)
+	require.NoError(t, err)
+
+	x509Cert, err := x509.ParseCertificate(certBytes)
+	require.NoError(t, err)
+
+	return privateKey, x509Cert
+}
+
+type fakeHTTPClient struct {
+	requestChecker func(*http.Request)
+	resp           []byte
+	statusCode     int
+}
+
+func (f *fakeHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	// Simulate a successful response from the STS service
+	resp := &http.Response{
+		StatusCode: f.statusCode,
+		Body:       io.NopCloser(bytes.NewReader(f.resp)),
+	}
+
+	if f.requestChecker != nil {
+		f.requestChecker(req)
+	}
+	return resp, nil
+}

--- a/lib/integrations/awsra/generate_credentials.go
+++ b/lib/integrations/awsra/generate_credentials.go
@@ -1,0 +1,234 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsra
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/cryptosuites"
+	"github.com/gravitational/teleport/lib/integrations/awsra/createsession"
+	"github.com/gravitational/teleport/lib/tlsca"
+)
+
+const (
+	// AWSCredentialsSourceRolesAnywhere is the source of the credentials.
+	// There's no official constant in AWS docs.
+	AWSCredentialsSourceRolesAnywhere = "RolesAnywhere"
+)
+
+// CertificateGenerator is an interface that generates a certificate.
+type CertificateGenerator interface {
+	GenerateCertificate(req tlsca.CertificateRequest) ([]byte, error)
+}
+
+// GenerateCredentialsRequest is a request to generate AWS credentials using the AWS IAM Roles Anywhere integration.
+type GenerateCredentialsRequest struct {
+	// Clock is the clock used to calculate the expiration time of the credentials.
+	Clock clockwork.Clock
+	// TrustAnchorARN is the ARN of the AWS IAM Roles Anywhere Trust Anchor.
+	TrustAnchorARN string
+	// ProfileARN is the ARN of the AWS IAM Roles Anywhere Profile.
+	ProfileARN string
+	// RoleARN is the ARN of the AWS IAM Role to generate credentials.
+	RoleARN string
+	// SubjectCommonName is the common name to use in the certificate.
+	SubjectCommonName string
+	// DurationSeconds is the duration of the session.
+	// If nil, the default duration of the Profile will be used.
+	DurationSeconds *int
+	// AcceptRoleSessionName indicates whether this Profile accepts a role session name.
+	// Setting the role session name when the Profile does not accept it will result in an error.
+	AcceptRoleSessionName bool
+	// KeyStoreManager grants access to the AWS Roles Anywhere signer.
+	KeyStoreManager KeyStoreManager
+	/// Cache is used to get the current cluster name and cert authority keys.
+	Cache Cache
+
+	// CreateSession is the API used to create a session with AWS IAM Roles Anywhere.
+	// This is used to mock the CreateSession API in tests.
+	CreateSession func(ctx context.Context, req createsession.CreateSessionRequest) (*createsession.CreateSessionResponse, error)
+}
+
+// KeyStoreManager defines methods to get signers using the server's keystore.
+type KeyStoreManager interface {
+	// GetTLSCertAndSigner selects a usable TLS keypair from the given CA
+	// and returns the PEM-encoded TLS certificate and a [crypto.Signer].
+	GetTLSCertAndSigner(ctx context.Context, ca types.CertAuthority) ([]byte, crypto.Signer, error)
+}
+
+// Cache is the subset of the cached resources that the Service queries.
+type Cache interface {
+	// GetCertAuthority returns cert authority by id
+	GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error)
+	// GetClusterName returns the current cluster name.
+	GetClusterName(ctx context.Context) (types.ClusterName, error)
+}
+
+func (r *GenerateCredentialsRequest) checkAndSetDefaults() error {
+	if r.TrustAnchorARN == "" {
+		return trace.BadParameter("trust anchor ARN is required")
+	}
+	if r.ProfileARN == "" {
+		return trace.BadParameter("profile ARN is required")
+	}
+	if r.RoleARN == "" {
+		return trace.BadParameter("role ARN is required")
+	}
+	if r.SubjectCommonName == "" {
+		return trace.BadParameter("subject common name is required")
+	}
+	if r.KeyStoreManager == nil {
+		return trace.BadParameter("certificate generator is required")
+	}
+	if r.KeyStoreManager == nil {
+		return trace.BadParameter("certificate generator is required")
+	}
+	if r.Cache == nil {
+		return trace.BadParameter("backend cache is required")
+	}
+
+	if r.CreateSession == nil {
+		// Use the default CreateSession API.
+		r.CreateSession = createsession.CreateSession
+	}
+
+	if r.Clock == nil {
+		r.Clock = clockwork.NewRealClock()
+	}
+
+	return nil
+}
+
+// Credentials contains the AWS credentials.
+type Credentials struct {
+	// Version is the schema version.
+	// Always 1.
+	Version int `json:"Version"`
+	// AccessKeyId is an AWS access key id.
+	AccessKeyID string `json:"AccessKeyId"`
+	// SecretAccessKey is the AWS secret access key.
+	SecretAccessKey string `json:"SecretAccessKey"`
+	// SessionToken is the the AWS session token for temporary credentials.
+	SessionToken string `json:"SessionToken"`
+	// Expiration is ISO8601 timestamp string when the credentials expire.
+	Expiration string `json:"Expiration"`
+	// SerialNumber is the serial number of the certificate which was created and exchanged to obtain AWS Credentials.
+	// When using these credentials, CloudTrail will log the certificate's Subject Common Name, if the profile accepts it.
+	// Otherwise, the serial number is logged.
+	// This field is not part of the credential_process schema.
+	SerialNumber string `json:"-"`
+}
+
+// GenerateCredentials generates AWS IAM Roles Anywhere credentials for the Application (IAM Roles Anywhere Profile) and Role ARN.
+func GenerateCredentials(ctx context.Context, req GenerateCredentialsRequest) (*Credentials, error) {
+	if err := req.checkAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	privateKey, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	privateKeyECDSA, ok := privateKey.(*ecdsa.PrivateKey)
+	if !ok {
+		return nil, trace.BadParameter("unexpected private key type %T", privateKey)
+	}
+
+	clusterName, err := req.Cache.GetClusterName(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	awsRACA, err := req.Cache.GetCertAuthority(ctx, types.CertAuthID{
+		Type:       types.AWSRACA,
+		DomainName: clusterName.GetClusterName(),
+	}, true)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	tlsCert, tlsSigner, err := req.KeyStoreManager.GetTLSCertAndSigner(ctx, awsRACA)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	tlsCA, err := tlsca.FromCertAndSigner(tlsCert, tlsSigner)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	certPEMBytes, err := tlsCA.GenerateCertificate(tlsca.CertificateRequest{
+		Clock:     req.Clock,
+		PublicKey: privateKey.Public(),
+		KeyUsage:  x509.KeyUsageDigitalSignature,
+		Subject: pkix.Name{
+			CommonName: req.SubjectCommonName,
+		},
+		// The certificate only needs to be valid for a very short time: the time it takes to exchange it for AWS credentials.
+		// Setting it to 1 minutes is enough to account for clock drift and network latency.
+		NotAfter: req.Clock.Now().Add(1 * time.Minute),
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	x509Cert, _, err := keys.X509Certificate(certPEMBytes)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	createSessionReq := createsession.CreateSessionRequest{
+		TrustAnchorARN:  req.TrustAnchorARN,
+		ProfileARN:      req.ProfileARN,
+		RoleARN:         req.RoleARN,
+		Certificate:     x509Cert,
+		PrivateKey:      privateKeyECDSA,
+		DurationSeconds: req.DurationSeconds,
+	}
+
+	// Providing a custom role session name to the CreateSessionAPI for a Profile that doesn't accept it, results in an Access Denied error.
+	// https://docs.aws.amazon.com/rolesanywhere/latest/userguide/authentication-create-session.html#create-session-and-assume-role
+	if req.AcceptRoleSessionName {
+		createSessionReq.RoleSessionName = req.SubjectCommonName
+	}
+
+	createSessionResp, err := req.CreateSession(ctx, createSessionReq)
+	if err != nil {
+		return nil, trace.BadParameter("failed to create session %v", err)
+	}
+
+	return &Credentials{
+		Version:         createSessionResp.Version,
+		AccessKeyID:     createSessionResp.AccessKeyID,
+		SecretAccessKey: createSessionResp.SecretAccessKey,
+		SessionToken:    createSessionResp.SessionToken,
+		Expiration:      createSessionResp.Expiration,
+		SerialNumber:    x509Cert.SerialNumber.String(),
+	}, nil
+}

--- a/lib/integrations/awsra/generate_credentials_test.go
+++ b/lib/integrations/awsra/generate_credentials_test.go
@@ -1,0 +1,118 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsra
+
+import (
+	"context"
+	"crypto/x509/pkix"
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/keystore"
+	"github.com/gravitational/teleport/lib/integrations/awsra/createsession"
+	"github.com/gravitational/teleport/lib/tlsca"
+)
+
+func TestGenerateCredentials(t *testing.T) {
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	mockCreateSessionAPI := func(ctx context.Context, req createsession.CreateSessionRequest) (*createsession.CreateSessionResponse, error) {
+		return &createsession.CreateSessionResponse{
+			Version:         1,
+			AccessKeyID:     "mock-access-key-id",
+			SecretAccessKey: "mock-secret-access-key",
+			SessionToken:    "mock-session-token",
+			Expiration:      clock.Now().Add(1 * time.Hour).Format(time.RFC3339),
+		}, nil
+	}
+
+	ca := newCertAuthority(t, types.AWSRACA, "cluster-name")
+
+	req := GenerateCredentialsRequest{
+		Clock:                 clock,
+		TrustAnchorARN:        "arn:aws:rolesanywhere:us-east-1:123456789012:trust-anchor/12345678-1234-1234-1234-123456789012",
+		ProfileARN:            "arn:aws:rolesanywhere:us-east-1:123456789012:profile/12345678-1234-1234-1234-123456789012",
+		RoleARN:               "arn:aws:iam::123456789012:role/teleport-role",
+		SubjectCommonName:     "test-common-name",
+		DurationSeconds:       nil,
+		AcceptRoleSessionName: true,
+		KeyStoreManager:       keystore.NewSoftwareKeystoreForTests(t),
+		Cache: &mockCache{
+			domainName: "cluster-name",
+			ca:         ca,
+		},
+		CreateSession: mockCreateSessionAPI,
+	}
+
+	credentials, err := GenerateCredentials(ctx, req)
+	require.NoError(t, err)
+
+	// Validate the returned credentials
+	require.Equal(t, 1, credentials.Version)
+	require.Equal(t, "mock-access-key-id", credentials.AccessKeyID)
+	require.Equal(t, "mock-secret-access-key", credentials.SecretAccessKey)
+	require.Equal(t, "mock-session-token", credentials.SessionToken)
+	require.NotEmpty(t, credentials.Expiration)
+}
+
+type mockCache struct {
+	domainName string
+	ca         types.CertAuthority
+}
+
+// GetClusterName returns local auth domain of the current auth server
+func (m *mockCache) GetClusterName(_ context.Context) (types.ClusterName, error) {
+	return &types.ClusterNameV2{
+		Spec: types.ClusterNameSpecV2{
+			ClusterName: m.domainName,
+		},
+	}, nil
+}
+
+// GetCertAuthority returns certificate authority by given id. Parameter loadSigningKeys
+// controls if signing keys are loaded
+func (m *mockCache) GetCertAuthority(ctx context.Context, id types.CertAuthID, loadSigningKeys bool) (types.CertAuthority, error) {
+	return m.ca, nil
+}
+
+func newCertAuthority(t *testing.T, caType types.CertAuthType, domain string) types.CertAuthority {
+	t.Helper()
+
+	key, cert, err := tlsca.GenerateSelfSignedCA(pkix.Name{CommonName: domain}, nil, time.Minute)
+	require.NoError(t, err)
+
+	ca, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
+		Type:        caType,
+		ClusterName: domain,
+		ActiveKeys: types.CAKeySet{
+			TLS: []*types.TLSKeyPair{{
+				Key:  key,
+				Cert: cert,
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	return ca
+}


### PR DESCRIPTION
This PR adds a wrapper to the IAM Roles Anywhere CreatesSessionAPI.

AWS does not provide this API in their SDK.
Instead, they provide an AWS guide (see code) where they explain how to call it.

See https://github.com/gravitational/teleport/issues/53192