### PR TITLE
Add codeowners for /web dep updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,7 @@
 # .github/workflows directory (and the merge logic) using CODEOWNERS.
 /.github/workflows/ @klizhentas @russjones @r0mant @zmb3 @fheinecke @camscale @tcsc @rosstimothy
 /build.assets/tooling/cmd/difftest/ @klizhentas @russjones @r0mant @zmb3
+
+# Owners for dependency updates in JS packages.
+package.json @avatus @gzdunek @ravicious
+web/packages/teleterm/package.json @gzdunek @ravicious


### PR DESCRIPTION
With [the dependabot.yaml `reviewers` deprecation](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/) the suggested change is to add reviewers to the CODEOWNERS file directly. Unfortunately this doesn't seem to give us the granularity to select "only dependabot PRs" and so I think the next best thing is just assign us to any PR that updates the package.json files (which is usually just dependabot).

