### PR TITLE
AWS IAM Roles Anywhere: one-off script for integration set up

### DIFF
--- a/lib/cloud/aws/identity_test.go
+++ b/lib/cloud/aws/identity_test.go
@@ -22,9 +22,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/stretchr/testify/require"
-
-	"github.com/gravitational/teleport/lib/cloud/mocks"
 )
 
 // TestGetIdentity verifies parsing of AWS identity received from STS API.
@@ -77,7 +77,7 @@ func TestGetIdentity(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			identity, err := GetIdentityWithClient(context.Background(), &mocks.STSClient{ARN: test.inARN})
+			identity, err := GetIdentityWithClient(context.Background(), &STSClient{ARN: test.inARN})
 			require.NoError(t, err)
 			require.IsType(t, test.outIdentity, identity)
 			require.Equal(t, test.outName, identity.GetName())
@@ -86,4 +86,14 @@ func TestGetIdentity(t *testing.T) {
 			require.Equal(t, test.outType, identity.GetType())
 		})
 	}
+}
+
+type STSClient struct {
+	ARN string
+}
+
+func (m *STSClient) GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	return &sts.GetCallerIdentityOutput{
+		Arn: aws.String(m.ARN),
+	}, nil
 }

--- a/lib/cloud/aws/policy_statements.go
+++ b/lib/cloud/aws/policy_statements.go
@@ -534,3 +534,40 @@ func StatementForAWSIdentityCenterAccess() *Statement {
 		Resources: allResources,
 	}
 }
+
+// StatementForAWSRolesAnywhereSyncRoleTrustRelationship returns the Trust Relationship which allows its usage from the given Trust Anchor ARN.
+// See https://docs.aws.amazon.com/rolesanywhere/latest/userguide/getting-started.html#getting-started-step2
+func StatementForAWSRolesAnywhereSyncRoleTrustRelationship(region, accountID, trustAnchorID string) *Statement {
+	return &Statement{
+		Effect: EffectAllow,
+		Actions: SliceOrString{
+			"sts:AssumeRole",
+			"sts:SetSourceIdentity",
+			"sts:TagSession",
+		},
+		Principals: map[string]SliceOrString{
+			"Service": []string{"rolesanywhere.amazonaws.com"},
+		},
+		Conditions: map[string]StringOrMap{
+			"ArnEquals": {
+				"aws:SourceArn": []string{
+					fmt.Sprintf("arn:aws:rolesanywhere:%s:%s:trust-anchor/%s", region, accountID, trustAnchorID),
+				},
+			},
+		},
+	}
+}
+
+// StatementForAWSRolesAnywhereSyncRolePolicy returns the policy required to perform the sync operation, which imports Roles Anywhere Profiles into Teleport AWS Apps.
+func StatementForAWSRolesAnywhereSyncRolePolicy() *Statement {
+	return &Statement{
+		Effect: EffectAllow,
+		Actions: SliceOrString{
+			"rolesanywhere:ListProfiles",
+			"rolesanywhere:ListTagsForResource",
+			"rolesanywhere:ImportCrl",
+			"iam:GetRole",
+		},
+		Resources: allResources,
+	}
+}

--- a/lib/cloud/provisioning/awsactions/create_role_for_trustanchor.go
+++ b/lib/cloud/provisioning/awsactions/create_role_for_trustanchor.go
@@ -77,7 +77,7 @@ func createRoleInputForTrustAnchor(req CreateRoleForTrustAnchorRequest, region, 
 	return input, trustPolicy, nil
 }
 
-// CreateRole returns a [provisioning.Action] that creates or updates an IAM
+// CreateRoleForTrustAnchor returns a [provisioning.Action] that creates or updates an IAM
 // role when invoked.
 func CreateRoleForTrustAnchor(
 	clt interface {

--- a/lib/cloud/provisioning/awsactions/create_role_for_trustanchor.go
+++ b/lib/cloud/provisioning/awsactions/create_role_for_trustanchor.go
@@ -1,0 +1,162 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsactions
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/gravitational/trace"
+
+	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+	"github.com/gravitational/teleport/lib/cloud/aws/tags"
+	"github.com/gravitational/teleport/lib/cloud/provisioning"
+)
+
+// CreateRoleForTrustAnchorRequest are the request parameters for creating a Role which can be used by the Trust Anchor.
+type CreateRoleForTrustAnchorRequest struct {
+	// AccountID is the AWS account ID
+	AccountID string
+	// RoleName is the name of the IAM role to create.
+	RoleName string
+	// RoleDescription is the description of the IAM role to create.
+	RoleDescription string
+	// TrustAnchorName is the name of the Trust Anchor to associate with the role.
+	TrustAnchorName string
+	// Tags are the tags to apply to the IAM role.
+	Tags tags.AWSTags
+}
+
+// CreateRole returns a [provisioning.Action] that creates or updates an IAM
+// role when invoked.
+func CreateRoleForTrustAnchor(
+	clt interface {
+		AssumeRolePolicyUpdater
+		RoleCreator
+		RoleGetter
+		RoleTagger
+		RolesAnywhereTrustAnchorLister
+	},
+	req CreateRoleForTrustAnchorRequest,
+) (*provisioning.Action, error) {
+	trustPolicy := awslib.NewPolicyDocument(
+		awslib.StatementForAWSRolesAnywhereSyncRoleTrustRelationship("_Region_", req.AccountID, "_TrustAnchorID_"),
+	)
+	trustPolicyJSON, err := trustPolicy.Marshal()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	input := &iam.CreateRoleInput{
+		RoleName:                 &req.RoleName,
+		Description:              &req.RoleDescription,
+		AssumeRolePolicyDocument: &trustPolicyJSON,
+		Tags:                     req.Tags.ToIAMTags(),
+	}
+	type createRoleInput struct {
+		// AssumeRolePolicyDocument shadows the input's field of the same name
+		// to marshal the trust policy doc as unescaped JSON.
+		AssumeRolePolicyDocument *awslib.PolicyDocument
+		*iam.CreateRoleInput
+	}
+	details, err := formatDetails(createRoleInput{
+		AssumeRolePolicyDocument: trustPolicy,
+		CreateRoleInput:          input,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	config := provisioning.ActionConfig{
+		Name:    "CreateRole",
+		Summary: fmt.Sprintf("Create IAM role %q which can be used by IAM Roles Anywhere", req.RoleName),
+		Details: details,
+		RunnerFn: func(ctx context.Context) error {
+			slog.InfoContext(ctx, "Getting the Trust Anchor ID",
+				"trust_anchor", req.TrustAnchorName,
+			)
+
+			trustAnchorDetails, err := trustAnchorDetails(ctx, req.TrustAnchorName, clt)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
+			trustAnchorParsedARN, err := arn.Parse(aws.ToString(trustAnchorDetails.TrustAnchorArn))
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			region := trustAnchorParsedARN.Region
+
+			// Replace the placeholder in the trust policy with the actual Trust Anchor ID.
+			trustPolicy := awslib.NewPolicyDocument(
+				awslib.StatementForAWSRolesAnywhereSyncRoleTrustRelationship(region, req.AccountID, aws.ToString(trustAnchorDetails.TrustAnchorId)),
+			)
+			trustPolicyJSON, err = trustPolicy.Marshal()
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
+			getRoleOut, err := clt.GetRole(ctx, &iam.GetRoleInput{
+				RoleName: aws.String(req.RoleName),
+			})
+			if err != nil {
+				convertedErr := awslib.ConvertIAMError(err)
+				if !trace.IsNotFound(convertedErr) {
+					return trace.Wrap(convertedErr)
+				}
+				slog.InfoContext(ctx, "Creating IAM role", "role", req.RoleName)
+				_, err = clt.CreateRole(ctx, input)
+				if err != nil {
+					return trace.Wrap(awslib.ConvertIAMError(err))
+				}
+				return nil
+			}
+
+			slog.InfoContext(ctx, "IAM role already exists",
+				"role", req.RoleName,
+			)
+			existingTrustPolicy, err := awslib.ParsePolicyDocument(aws.ToString(getRoleOut.Role.AssumeRolePolicyDocument))
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			err = ensureTrustPolicy(ctx, clt, req.RoleName, trustPolicy, existingTrustPolicy)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
+			err = ensureTags(ctx, clt, req.RoleName, req.Tags, getRoleOut.Role.Tags)
+			if err != nil {
+				// Tagging an existing role after we update it is a
+				// nice-to-have, but not a need-to-have.
+				slog.WarnContext(ctx, "Failed to update IAM role tags",
+					"role", req.RoleName,
+					"error", err,
+					"tags", req.Tags.ToMap(),
+				)
+			}
+			return nil
+		},
+	}
+	action, err := provisioning.NewAction(config)
+	return action, trace.Wrap(err)
+}

--- a/lib/cloud/provisioning/awsactions/create_rolesanywhere_profile.go
+++ b/lib/cloud/provisioning/awsactions/create_rolesanywhere_profile.go
@@ -1,0 +1,170 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsactions
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rolesanywhere"
+	ratypes "github.com/aws/aws-sdk-go-v2/service/rolesanywhere/types"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/cloud/aws/tags"
+	"github.com/gravitational/teleport/lib/cloud/provisioning"
+)
+
+// RolesAnywhereProfileLister can list IAM Roles Anywhere Profiles.
+type RolesAnywhereProfileLister interface {
+	// ListProfiles lists IAM Roles Anywhere Profiles.
+	ListProfiles(ctx context.Context, params *rolesanywhere.ListProfilesInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.ListProfilesOutput, error)
+}
+
+// RolesAnywhereProfileCreator can create an IAM Roles Anywhere Profiles.
+type RolesAnywhereProfileCreator interface {
+	// CreateProfile creates an IAM Roles Anywhere Profile in AWS IAM.
+	CreateProfile(ctx context.Context, params *rolesanywhere.CreateProfileInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.CreateProfileOutput, error)
+}
+
+// RolesAnywhereProfileUpdater can update an IAM Roles Anywhere Profiles.
+type RolesAnywhereProfileUpdater interface {
+	// UpdateProfile updates an IAM Roles Anywhere Profile in AWS IAM.
+	UpdateProfile(ctx context.Context, params *rolesanywhere.UpdateProfileInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.UpdateProfileOutput, error)
+	// Enables temporary credential requests for a profile.
+	EnableProfile(ctx context.Context, params *rolesanywhere.EnableProfileInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.EnableProfileOutput, error)
+}
+
+// CreateRolesAnywhereProfileProvider wraps a [RolesAnywhereProfileCreator] in a
+// [provisioning.Action] that creates an IAM Roles Anywhere Profile in AWS IAM when invoked.
+func CreateRolesAnywhereProfileProvider(
+	clt interface {
+		RolesAnywhereProfileLister
+		RolesAnywhereProfileCreator
+		RolesAnywhereProfileUpdater
+		RolesAnywhereResourceTagsGetter
+	},
+	name string,
+	roleARN string,
+	tags tags.AWSTags,
+) (*provisioning.Action, error) {
+	input := &rolesanywhere.CreateProfileInput{
+		Name:                  aws.String(name),
+		Enabled:               aws.Bool(true),
+		RoleArns:              []string{roleARN},
+		AcceptRoleSessionName: aws.Bool(true),
+		Tags:                  tags.ToRolesAnywhereTags(),
+	}
+	details, err := formatDetails(input)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	config := provisioning.ActionConfig{
+		Name:    "CreateRolesAnywhereProfileProvider",
+		Summary: "Create a Roles Anywhere Profile in AWS IAM for your Teleport cluster",
+		Details: details,
+		RunnerFn: func(ctx context.Context) error {
+			profileDetails, err := profileDetails(ctx, name, clt)
+			switch {
+			case trace.IsNotFound(err):
+				slog.InfoContext(ctx, "Creating a new Roles Anywhere Profile")
+				_, err = clt.CreateProfile(ctx, input)
+				return trace.Wrap(err)
+
+			case err != nil:
+				return trace.Wrap(err)
+
+			}
+
+			resourceTags, err := clt.ListTagsForResource(ctx, &rolesanywhere.ListTagsForResourceInput{
+				ResourceArn: profileDetails.ProfileArn,
+			})
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
+			if !tags.MatchesRolesAnywhereTags(resourceTags.Tags) {
+				return trace.AccessDenied("Roles Anywhere Profile %q is not owned by this integration", name)
+			}
+
+			requiresUpdate := false
+			if !aws.ToBool(profileDetails.AcceptRoleSessionName) {
+				profileDetails.AcceptRoleSessionName = aws.Bool(true)
+				requiresUpdate = true
+			}
+
+			if !slices.Contains(profileDetails.RoleArns, roleARN) {
+				requiresUpdate = true
+				profileDetails.RoleArns = append(profileDetails.RoleArns, roleARN)
+			}
+
+			if requiresUpdate {
+				slog.InfoContext(ctx, "Updating the existing Roles Anywhere Profile")
+				_, err = clt.UpdateProfile(ctx, &rolesanywhere.UpdateProfileInput{
+					Name:                  profileDetails.Name,
+					ProfileId:             profileDetails.ProfileId,
+					AcceptRoleSessionName: profileDetails.AcceptRoleSessionName,
+					RoleArns:              profileDetails.RoleArns,
+				})
+				if err != nil {
+					return trace.Wrap(err)
+				}
+			}
+
+			if !aws.ToBool(profileDetails.Enabled) {
+				_, err := clt.EnableProfile(ctx, &rolesanywhere.EnableProfileInput{
+					ProfileId: profileDetails.ProfileId,
+				})
+				if err != nil {
+					return trace.Wrap(err)
+				}
+			}
+
+			return nil
+		},
+	}
+	action, err := provisioning.NewAction(config)
+	return action, trace.Wrap(err)
+}
+
+func profileDetails(ctx context.Context, profileName string, clt RolesAnywhereProfileLister) (*ratypes.ProfileDetail, error) {
+	var nextToken *string
+	for {
+		profilesResp, err := clt.ListProfiles(ctx, &rolesanywhere.ListProfilesInput{
+			NextToken: nextToken,
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		for _, profile := range profilesResp.Profiles {
+			if aws.ToString(profile.Name) == profileName {
+				return &profile, nil
+			}
+		}
+
+		if aws.ToString(profilesResp.NextToken) == "" {
+			return nil, trace.NotFound("Roles Anywhere Profile %q not found", profileName)
+		}
+
+		nextToken = profilesResp.NextToken
+	}
+}

--- a/lib/cloud/provisioning/awsactions/create_rolesanywhere_trustanchor.go
+++ b/lib/cloud/provisioning/awsactions/create_rolesanywhere_trustanchor.go
@@ -1,0 +1,180 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsactions
+
+import (
+	"cmp"
+	"context"
+	"log/slog"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rolesanywhere"
+	ratypes "github.com/aws/aws-sdk-go-v2/service/rolesanywhere/types"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/cloud/aws/tags"
+	"github.com/gravitational/teleport/lib/cloud/provisioning"
+)
+
+// RolesAnywhereTrustAnchorLister is an interface that defines methods for listing IAM Roles Anywhere Trust Anchors.
+type RolesAnywhereTrustAnchorLister interface {
+	// ListTrustAnchors lists IAM Roles Anywhere Trust Anchors.
+	ListTrustAnchors(ctx context.Context, params *rolesanywhere.ListTrustAnchorsInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.ListTrustAnchorsOutput, error)
+}
+
+// RolesAnywhereResourceTagsGetter is an interface that defines methods for getting IAM Roles Anywhere resource tags.
+type RolesAnywhereResourceTagsGetter interface {
+	// ListTagsForResource lists IAM Roles Anywhere resource tags.
+	ListTagsForResource(ctx context.Context, params *rolesanywhere.ListTagsForResourceInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.ListTagsForResourceOutput, error)
+}
+
+// RolesAnywhereTrustAnchorCreator is an interface that defines methods for creating IAM Roles Anywhere Trust Anchors.
+type RolesAnywhereTrustAnchorCreator interface {
+	// CreateTrustAnchor creates an IAM Roles Anywhere Trust Anchor in AWS IAM.
+	CreateTrustAnchor(ctx context.Context, params *rolesanywhere.CreateTrustAnchorInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.CreateTrustAnchorOutput, error)
+}
+
+// RolesAnywhereTrustAnchorUpdater is an interface that defines methods for updating IAM Roles Anywhere Trust Anchors.
+type RolesAnywhereTrustAnchorUpdater interface {
+	// UpdateTrustAnchor updates an IAM Roles Anywhere Trust Anchor in AWS IAM.
+	UpdateTrustAnchor(ctx context.Context, params *rolesanywhere.UpdateTrustAnchorInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.UpdateTrustAnchorOutput, error)
+	// EnableTrustAnchor enables temporary credential requests for a trust anchor.
+	EnableTrustAnchor(ctx context.Context, params *rolesanywhere.EnableTrustAnchorInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.EnableTrustAnchorOutput, error)
+}
+
+// CreateRolesAnywhereTrustAnchorProvider wraps a [RolesAnywhereTrustAnchorCreator] in a
+// [provisioning.Action] that creates an IAM Roles Anywhere Trust Anchor in AWS IAM when invoked.
+func CreateRolesAnywhereTrustAnchorProvider(
+	clt interface {
+		RolesAnywhereTrustAnchorLister
+		RolesAnywhereTrustAnchorCreator
+		RolesAnywhereTrustAnchorUpdater
+		RolesAnywhereResourceTagsGetter
+	},
+	name string,
+	trustAnchorCertificate string,
+	tags tags.AWSTags,
+) (*provisioning.Action, error) {
+	input := &rolesanywhere.CreateTrustAnchorInput{
+		Name: aws.String(name),
+		Source: &ratypes.Source{
+			SourceType: ratypes.TrustAnchorTypeCertificateBundle,
+			SourceData: &ratypes.SourceDataMemberX509CertificateData{
+				Value: trustAnchorCertificate,
+			},
+		},
+		Enabled: aws.Bool(true),
+		Tags:    tags.ToRolesAnywhereTags(),
+	}
+	details, err := formatDetails(input)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	config := provisioning.ActionConfig{
+		Name:    "CreateRolesAnywhereTrustAnchorProvider",
+		Summary: "Create a Roles Anywhere Trust Anchor in AWS IAM for your Teleport cluster",
+		Details: details,
+		RunnerFn: func(ctx context.Context) error {
+			trustAnchorDetails, err := trustAnchorDetails(ctx, name, clt)
+			switch {
+			case trace.IsNotFound(err):
+				slog.InfoContext(ctx, "Creating a new Roles Anywhere Trust Anchor")
+				_, err = clt.CreateTrustAnchor(ctx, input)
+				return trace.Wrap(err)
+
+			case err != nil:
+				return trace.Wrap(err)
+			}
+
+			resourceTags, err := clt.ListTagsForResource(ctx, &rolesanywhere.ListTagsForResourceInput{
+				ResourceArn: trustAnchorDetails.TrustAnchorArn,
+			})
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
+			if !tags.MatchesRolesAnywhereTags(resourceTags.Tags) {
+				return trace.AccessDenied("Roles Anywhere Trust Anchor %q is not owned by this integration", name)
+			}
+
+			requiresUpdate := false
+
+			trustAnchorSource := cmp.Or(trustAnchorDetails.Source, &ratypes.Source{})
+			if trustAnchorSource.SourceType != input.Source.SourceType {
+				trustAnchorDetails.Source.SourceType = input.Source.SourceType
+				requiresUpdate = true
+			}
+
+			if trustAnchorSource.SourceData != input.Source.SourceData {
+				trustAnchorDetails.Source.SourceData = input.Source.SourceData
+				requiresUpdate = true
+			}
+
+			if requiresUpdate {
+				slog.InfoContext(ctx, "Updating the existing Roles Anywhere Profile")
+				_, err = clt.UpdateTrustAnchor(ctx, &rolesanywhere.UpdateTrustAnchorInput{
+					Name:          trustAnchorDetails.Name,
+					TrustAnchorId: trustAnchorDetails.TrustAnchorId,
+					Source:        input.Source,
+				})
+				if err != nil {
+					return trace.Wrap(err)
+				}
+			}
+
+			if !aws.ToBool(trustAnchorDetails.Enabled) {
+				_, err := clt.EnableTrustAnchor(ctx, &rolesanywhere.EnableTrustAnchorInput{
+					TrustAnchorId: trustAnchorDetails.TrustAnchorId,
+				})
+				if err != nil {
+					return trace.Wrap(err)
+				}
+			}
+
+			return nil
+		},
+	}
+	action, err := provisioning.NewAction(config)
+	return action, trace.Wrap(err)
+}
+
+func trustAnchorDetails(ctx context.Context, trustAnchorName string, clt RolesAnywhereTrustAnchorLister) (*ratypes.TrustAnchorDetail, error) {
+	var nextToken *string
+	for {
+		trustAnchorResp, err := clt.ListTrustAnchors(ctx, &rolesanywhere.ListTrustAnchorsInput{
+			NextToken: nextToken,
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		for _, trustAnchor := range trustAnchorResp.TrustAnchors {
+			if aws.ToString(trustAnchor.Name) == trustAnchorName {
+				return &trustAnchor, nil
+			}
+		}
+
+		if aws.ToString(trustAnchorResp.NextToken) == "" {
+			return nil, trace.NotFound("Roles Anywhere Trust Anchor %q not found", trustAnchorName)
+		}
+
+		nextToken = trustAnchorResp.NextToken
+	}
+}

--- a/lib/cloud/provisioning/awsactions/trustanchor_setup_arns.go
+++ b/lib/cloud/provisioning/awsactions/trustanchor_setup_arns.go
@@ -1,0 +1,100 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsactions
+
+import (
+	"context"
+	"io"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/cloud/provisioning"
+)
+
+// TrustAnchorSetUpARNs prints the IAM Roles Anywhere set up ARNs to output.
+func TrustAnchorSetUpARNs(
+	clt interface {
+		RolesAnywhereTrustAnchorLister
+		RolesAnywhereProfileLister
+		RoleGetter
+	},
+	trustAnchorName string,
+	profileName string,
+	roleName string,
+	output io.Writer,
+) (*provisioning.Action, error) {
+
+	type trustAnchorARNs struct {
+		TrustAnchorName string
+		ProfileName     string
+		RoleName        string
+	}
+	details, err := formatDetails(trustAnchorARNs{
+		TrustAnchorName: trustAnchorName,
+		ProfileName:     profileName,
+		RoleName:        roleName,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	config := provisioning.ActionConfig{
+		Name:    "TrustAnchorSetUpARNs",
+		Summary: "Prints the ARNs for the Trust Anchor, Profile, and Role",
+		Details: details,
+		RunnerFn: func(ctx context.Context) error {
+			trustAnchorDetails, err := trustAnchorDetails(ctx, trustAnchorName, clt)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
+			profileDetails, err := profileDetails(ctx, profileName, clt)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
+			roleDetails, err := clt.GetRole(ctx, &iam.GetRoleInput{
+				RoleName: aws.String(roleName),
+			})
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
+			summaryBuilder := strings.Builder{}
+			summaryBuilder.WriteString("\nCopy and paste the following values to Teleport UI\n\n")
+			summaryBuilder.WriteString("=================================================\n")
+			summaryBuilder.WriteString(aws.ToString(trustAnchorDetails.TrustAnchorArn) + "\n")
+			summaryBuilder.WriteString(aws.ToString(profileDetails.ProfileArn) + "\n")
+			summaryBuilder.WriteString(aws.ToString(roleDetails.Role.Arn) + "\n")
+			summaryBuilder.WriteString("=================================================\n\n")
+
+			_, err = io.WriteString(output, summaryBuilder.String())
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
+			return nil
+		},
+	}
+	action, err := provisioning.NewAction(config)
+	return action, trace.Wrap(err)
+}

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -251,6 +251,10 @@ type CommandLineFlags struct {
 	// `teleport integration configure samlidp gcp-workforce` command
 	IntegrationConfSAMLIdPGCPWorkforceArguments samlidpconfig.GCPWorkforceAPIParams
 
+	// IntegrationConfAWSRATrustAnchorArguments contains the arguments of
+	// `teleport integration configure awsra-trust-anchor` command
+	IntegrationConfAWSRATrustAnchorArguments IntegrationConfAWSRATrustAnchor
+
 	// LogLevel is the new application's log level.
 	LogLevel string
 
@@ -407,6 +411,25 @@ type IntegrationConfAWSOIDCIdP struct {
 	// PolicyPreset is the name of a pre-defined policy statement which will be
 	// assigned to the AWS Role associate with the OIDC integration.
 	PolicyPreset string
+}
+
+// IntegrationConfAWSRATrustAnchor contains the arguments of
+// `teleport integration configure awsra-trust-anchor` command
+type IntegrationConfAWSRATrustAnchor struct {
+	// Cluster is the teleport cluster name.
+	Cluster string
+	// Name is the integration name.
+	Name string
+	// TrustAnchor is the AWS IAM Roles Anywhere Trust Anchor name to create.
+	TrustAnchor string
+	// TrustAnchorCertBase64 is trust anchor certificate, encoded in base64.
+	TrustAnchorCertBase64 string
+	// SyncProfile is the AWS IAM Roles Anywhere Profile name to create, that will be used to sync profiles as entry points for AWS Access.
+	SyncProfile string
+	// SyncRole is the AWS IAM Role name to create, that will be used to sync profiles as entry points for AWS Access.
+	SyncRole string
+	// AutoConfirm skips user confirmation of the operation plan if true.
+	AutoConfirm bool
 }
 
 // IntegrationConfListDatabasesIAM contains the arguments of

--- a/lib/integrations/awsra/resource_tags.go
+++ b/lib/integrations/awsra/resource_tags.go
@@ -1,0 +1,32 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsra
+
+import (
+	"github.com/gravitational/teleport/api/types/common"
+	"github.com/gravitational/teleport/lib/cloud/aws/tags"
+)
+
+// defaultResourceCreationTags returns the AWS Tags which are set on resources created by this integration.
+// It will serve two purposes:
+// - to identify resources created by this integration
+// - when updating AWS resources, only those containing this label will be updated
+func defaultResourceCreationTags(clusterName, integrationName string) tags.AWSTags {
+	return tags.DefaultResourceCreationTags(clusterName, integrationName, common.OriginIntegrationAWSRolesAnywhere)
+}

--- a/lib/integrations/awsra/trustanchor_config.go
+++ b/lib/integrations/awsra/trustanchor_config.go
@@ -1,0 +1,284 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsra
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/rolesanywhere"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/gravitational/trace"
+
+	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+	"github.com/gravitational/teleport/lib/cloud/aws/tags"
+	"github.com/gravitational/teleport/lib/cloud/provisioning"
+	"github.com/gravitational/teleport/lib/cloud/provisioning/awsactions"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/utils/aws/iamutils"
+	"github.com/gravitational/teleport/lib/utils/aws/stsutils"
+)
+
+// TrustAnchorConfigureRequest represents a request to configure AWS IAM Roles Anywhere integration.
+type TrustAnchorConfigureRequest struct {
+	// Cluster is the Teleport Cluster.
+	// Used for tagging the created RolesAnywhere Trust Anchor/Profile and IAM Role.
+	Cluster string
+
+	// AccountID is the AWS Account ID.
+	// Optional. sts.GetCallerIdentity is used if not provided.
+	AccountID string
+
+	// IntegrationName is the Integration Name.
+	// Used for tagging the created RolesAnywhere Trust Anchor/Profile and IAM Role.
+	IntegrationName string
+
+	// TrustAnchorName is the name of the trust anchor.
+	TrustAnchorName string
+
+	// TrustAnchorCertBase64 is the base64 encoded PEM certificate of the trust anchor.
+	TrustAnchorCertBase64 string
+
+	// SyncProfileName is the name of the AWS IAM Roles Anywhere Profile to create, used to sync profiles.
+	SyncProfileName string
+
+	// SyncRoleName is the name of the AWS IAM Role to create, used to sync profiles.
+	SyncRoleName string
+
+	// AutoConfirm skips user confirmation of the operation plan if true.
+	AutoConfirm bool
+
+	ownershipTags tags.AWSTags
+
+	// stdout is used to override stdout output in tests.
+	stdout io.Writer
+}
+
+// CheckAndSetDefaults ensures the required fields are present.
+func (r *TrustAnchorConfigureRequest) CheckAndSetDefaults() error {
+	if r.Cluster == "" {
+		return trace.BadParameter("cluster is required")
+	}
+
+	if r.IntegrationName == "" {
+		return trace.BadParameter("integration name is required")
+	}
+
+	if r.TrustAnchorName == "" {
+		return trace.BadParameter("trust anchor name is required")
+	}
+
+	if r.TrustAnchorCertBase64 == "" {
+		return trace.BadParameter("trust anchor's certificate is required")
+	}
+
+	if r.SyncProfileName == "" {
+		return trace.BadParameter("roles anywhere profile name used for the sync process is required")
+	}
+
+	if r.SyncRoleName == "" {
+		return trace.BadParameter("role name used for the sync process is required")
+	}
+
+	r.ownershipTags = defaultResourceCreationTags(r.Cluster, r.IntegrationName)
+
+	if r.stdout == nil {
+		r.stdout = os.Stdout
+	}
+
+	return nil
+}
+
+// CallerIdentityGetter is an interface that defines the method to get the caller identity from AWS STS.
+type CallerIdentityGetter interface {
+	// GetCallerIdentity retrieves the AWS caller identity.
+	GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
+}
+
+// RolesAnywhereIAMConfigurationClient describes the required methods to create the AWS IAM Roles Anywhere Trust Anchor, Profile and the IAM Role.
+// There is no guarantee that the client is thread safe.
+type RolesAnywhereIAMConfigurationClient interface {
+	CallerIdentityGetter
+
+	awsactions.RolesAnywhereTrustAnchorLister
+	awsactions.RolesAnywhereTrustAnchorCreator
+	awsactions.RolesAnywhereTrustAnchorUpdater
+
+	awsactions.RolesAnywhereProfileLister
+	awsactions.RolesAnywhereProfileCreator
+	awsactions.RolesAnywhereProfileUpdater
+
+	awsactions.RolesAnywhereResourceTagsGetter
+
+	awsactions.AssumeRolePolicyUpdater
+	awsactions.RoleCreator
+	awsactions.RoleGetter
+	awsactions.RoleTagger
+	awsactions.PolicyAssigner
+}
+
+type defaultRolesAnywhereIAMConfigurationClient struct {
+	CallerIdentityGetter
+	*rolesanywhere.Client
+	iamClient *iam.Client
+
+	httpClient *http.Client
+}
+
+func (c *defaultRolesAnywhereIAMConfigurationClient) CreateRole(ctx context.Context, params *iam.CreateRoleInput, optFns ...func(*iam.Options)) (*iam.CreateRoleOutput, error) {
+	return c.iamClient.CreateRole(ctx, params, optFns...)
+}
+func (c *defaultRolesAnywhereIAMConfigurationClient) GetRole(ctx context.Context, params *iam.GetRoleInput, optFns ...func(*iam.Options)) (*iam.GetRoleOutput, error) {
+	return c.iamClient.GetRole(ctx, params, optFns...)
+}
+func (c *defaultRolesAnywhereIAMConfigurationClient) PutRolePolicy(ctx context.Context, params *iam.PutRolePolicyInput, optFns ...func(*iam.Options)) (*iam.PutRolePolicyOutput, error) {
+	return c.iamClient.PutRolePolicy(ctx, params, optFns...)
+}
+func (c *defaultRolesAnywhereIAMConfigurationClient) TagRole(ctx context.Context, params *iam.TagRoleInput, optFns ...func(*iam.Options)) (*iam.TagRoleOutput, error) {
+	return c.iamClient.TagRole(ctx, params, optFns...)
+}
+func (c *defaultRolesAnywhereIAMConfigurationClient) UpdateAssumeRolePolicy(ctx context.Context, params *iam.UpdateAssumeRolePolicyInput, optFns ...func(*iam.Options)) (*iam.UpdateAssumeRolePolicyOutput, error) {
+	return c.iamClient.UpdateAssumeRolePolicy(ctx, params, optFns...)
+}
+
+// NewRolesAnywhereIAMConfigurationClient creates a new RolesAnywhereIAMConfigurationClient.
+// The client is not thread safe.
+func NewRolesAnywhereIAMConfigurationClient(ctx context.Context) (RolesAnywhereIAMConfigurationClient, error) {
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	httpClient, err := defaults.HTTPClient()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &defaultRolesAnywhereIAMConfigurationClient{
+		httpClient:           httpClient,
+		Client:               rolesanywhere.NewFromConfig(cfg),
+		iamClient:            iamutils.NewFromConfig(cfg),
+		CallerIdentityGetter: stsutils.NewFromConfig(cfg),
+	}, nil
+}
+
+// ConfigureRolesAnywhereIAM creates a new AWS IAM Roles Anywhere Trust Anchor.
+// It also creates a new AWS IAM Roles Anywhere Profile and a new AWS IAM Role which is used to sync Profiles into Teleport resources (AWS Apps).
+//
+// The following actions must be allowed by the IAM Role assigned in the Client.
+//   - rolesanywhere:CreateTrustAnchor
+//   - rolesanywhere:CreateProfile
+//   - iam:CreateRole
+//   - iam:GetRole
+//   - iam:UpdateAssumeRolePolicy
+func ConfigureRolesAnywhereIAM(ctx context.Context, clt RolesAnywhereIAMConfigurationClient, req TrustAnchorConfigureRequest) error {
+	if err := req.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if req.AccountID == "" {
+		callerIdentity, err := clt.GetCallerIdentity(ctx, nil)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		req.AccountID = aws.ToString(callerIdentity.Account)
+	}
+
+	createRolesAnywhereTrustAnchorAction, err := createIAMRolesAnywhereTrustAnchor(clt, req)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	createIAMSyncRoleAction, err := createIAMSyncRoleAction(clt, req)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	assignListProfilesPolicyToSyncRoleAction, err := assignProfileSyncPolicyToRoleAction(clt, req)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	createIAMSyncProfileAction, err := createIAMSyncProfileAction(clt, req)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	trustAnchorSetUpARNsAction, err := awsactions.TrustAnchorSetUpARNs(clt, req.TrustAnchorName, req.SyncProfileName, req.SyncRoleName, req.stdout)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	actions := []provisioning.Action{
+		*createRolesAnywhereTrustAnchorAction,
+		*createIAMSyncRoleAction,
+		*assignListProfilesPolicyToSyncRoleAction,
+		*createIAMSyncProfileAction,
+		*trustAnchorSetUpARNsAction,
+	}
+
+	return trace.Wrap(provisioning.Run(ctx, provisioning.OperationConfig{
+		Name:        "awsra-trust-anchor",
+		Actions:     actions,
+		AutoConfirm: req.AutoConfirm,
+		Output:      req.stdout,
+	}))
+}
+
+func createIAMRolesAnywhereTrustAnchor(clt RolesAnywhereIAMConfigurationClient, req TrustAnchorConfigureRequest) (*provisioning.Action, error) {
+	return awsactions.CreateRolesAnywhereTrustAnchorProvider(clt, req.TrustAnchorName, req.TrustAnchorCertBase64, req.ownershipTags)
+}
+
+func createIAMSyncRoleAction(clt RolesAnywhereIAMConfigurationClient, req TrustAnchorConfigureRequest) (*provisioning.Action, error) {
+	return awsactions.CreateRoleForTrustAnchor(clt, awsactions.CreateRoleForTrustAnchorRequest{
+		AccountID:       req.AccountID,
+		RoleName:        req.SyncRoleName,
+		RoleDescription: "Used by Teleport to provide access to AWS resources.",
+		TrustAnchorName: req.TrustAnchorName,
+		Tags:            req.ownershipTags,
+	})
+}
+
+func createIAMSyncProfileAction(clt RolesAnywhereIAMConfigurationClient, req TrustAnchorConfigureRequest) (*provisioning.Action, error) {
+	syncRoleARN := fmt.Sprintf("arn:aws:iam::%s:role/%s", req.AccountID, req.SyncRoleName)
+
+	return awsactions.CreateRolesAnywhereProfileProvider(clt,
+		req.SyncProfileName,
+		syncRoleARN,
+		req.ownershipTags,
+	)
+}
+
+func assignProfileSyncPolicyToRoleAction(clt RolesAnywhereIAMConfigurationClient, req TrustAnchorConfigureRequest) (*provisioning.Action, error) {
+	policyStatement := awslib.StatementForAWSRolesAnywhereSyncRolePolicy()
+
+	return awsactions.AssignRolePolicy(
+		clt,
+		awsactions.RolePolicy{
+			RoleName:        req.SyncRoleName,
+			PolicyName:      "TeleportRolesAnywhereProfileSync",
+			PolicyStatement: policyStatement,
+		})
+}

--- a/lib/integrations/awsra/trustanchor_config_test.go
+++ b/lib/integrations/awsra/trustanchor_config_test.go
@@ -1,0 +1,467 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsra
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"maps"
+	"os"
+	"slices"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/aws-sdk-go-v2/service/rolesanywhere"
+	ratypes "github.com/aws/aws-sdk-go-v2/service/rolesanywhere/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/cloud/aws/tags"
+)
+
+var badParameterCheck = func(t require.TestingT, err error, msgAndArgs ...interface{}) {
+	require.True(t, trace.IsBadParameter(err), `expected "bad parameter", but got %v`, err)
+}
+
+func TestConfigureRolesAnywhereIAMReqDefaults(t *testing.T) {
+	baseRolesAnywhereConfigReq := func() TrustAnchorConfigureRequest {
+		return TrustAnchorConfigureRequest{
+			Cluster:               "mycluster",
+			AccountID:             "123456789012",
+			IntegrationName:       "myintegration",
+			TrustAnchorName:       "mytrustanchor",
+			TrustAnchorCertBase64: base64.StdEncoding.EncodeToString([]byte("-----BEGIN CERTIFICATE-----\nMIID...==\n-----END CERTIFICATE-----")),
+			SyncProfileName:       "mysyncprofile",
+			SyncRoleName:          "myrole",
+			AutoConfirm:           true,
+		}
+	}
+
+	for _, tt := range []struct {
+		name     string
+		req      func() TrustAnchorConfigureRequest
+		errCheck require.ErrorAssertionFunc
+		expected TrustAnchorConfigureRequest
+	}{
+		{
+			name:     "set defaults",
+			req:      baseRolesAnywhereConfigReq,
+			errCheck: require.NoError,
+			expected: TrustAnchorConfigureRequest{
+				Cluster:               "mycluster",
+				AccountID:             "123456789012",
+				IntegrationName:       "myintegration",
+				TrustAnchorName:       "mytrustanchor",
+				TrustAnchorCertBase64: base64.StdEncoding.EncodeToString([]byte("-----BEGIN CERTIFICATE-----\nMIID...==\n-----END CERTIFICATE-----")),
+				SyncProfileName:       "mysyncprofile",
+				SyncRoleName:          "myrole",
+				AutoConfirm:           true,
+				ownershipTags: tags.AWSTags{
+					"teleport.dev/origin":      "integration_awsrolesanywhere",
+					"teleport.dev/cluster":     "mycluster",
+					"teleport.dev/integration": "myintegration",
+				},
+				stdout: os.Stdout,
+			},
+		},
+		{
+			name: "missing cluster name",
+			req: func() TrustAnchorConfigureRequest {
+				req := baseRolesAnywhereConfigReq()
+				req.Cluster = ""
+				return req
+			},
+			errCheck: badParameterCheck,
+		},
+		{
+			name: "missing integration name",
+			req: func() TrustAnchorConfigureRequest {
+				req := baseRolesAnywhereConfigReq()
+				req.IntegrationName = ""
+				return req
+			},
+			errCheck: badParameterCheck,
+		},
+		{
+			name: "missing trust anchor name",
+			req: func() TrustAnchorConfigureRequest {
+				req := baseRolesAnywhereConfigReq()
+				req.TrustAnchorName = ""
+				return req
+			},
+			errCheck: badParameterCheck,
+		},
+		{
+			name: "missing trust anchor cert",
+			req: func() TrustAnchorConfigureRequest {
+				req := baseRolesAnywhereConfigReq()
+				req.TrustAnchorCertBase64 = ""
+				return req
+			},
+			errCheck: badParameterCheck,
+		},
+		{
+			name: "missing sync profile name",
+			req: func() TrustAnchorConfigureRequest {
+				req := baseRolesAnywhereConfigReq()
+				req.SyncProfileName = ""
+				return req
+			},
+			errCheck: badParameterCheck,
+		},
+		{
+			name: "missing sync role name",
+			req: func() TrustAnchorConfigureRequest {
+				req := baseRolesAnywhereConfigReq()
+				req.SyncRoleName = ""
+				return req
+			},
+			errCheck: badParameterCheck,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := tt.req()
+			err := req.CheckAndSetDefaults()
+			tt.errCheck(t, err)
+			if err != nil {
+				return
+			}
+
+			require.Equal(t, tt.expected, req)
+		})
+	}
+}
+
+func TestConfigureIdPIAM(t *testing.T) {
+	ctx := context.Background()
+
+	baseRolesAnywhereConfigReq := func() TrustAnchorConfigureRequest {
+		return TrustAnchorConfigureRequest{
+			Cluster:               "mycluster",
+			AccountID:             "123456789012",
+			IntegrationName:       "myintegration",
+			TrustAnchorName:       "mytrustanchor",
+			TrustAnchorCertBase64: base64.StdEncoding.EncodeToString([]byte("-----BEGIN CERTIFICATE-----\nMIID...==\n-----END CERTIFICATE-----")),
+			SyncProfileName:       "mysyncprofile",
+			SyncRoleName:          "mysyncrole",
+			AutoConfirm:           true,
+		}
+	}
+
+	for _, tt := range []struct {
+		name                   string
+		req                    func() TrustAnchorConfigureRequest
+		existingTrustAnchors   []ratypes.TrustAnchorDetail
+		existingProfiles       []ratypes.ProfileDetail
+		existingRAResourceTags map[string][]ratypes.Tag
+		existingRoles          []mockRole
+		errCheck               require.ErrorAssertionFunc
+		externalStateCheck     func(*testing.T, mockIAMRolesAnywhereClient)
+	}{
+		{
+			name:     "valid",
+			req:      baseRolesAnywhereConfigReq,
+			errCheck: require.NoError,
+		},
+		{
+			name: "trust anchor already exists but is missing the required ownership tags",
+			req:  baseRolesAnywhereConfigReq,
+			existingTrustAnchors: []ratypes.TrustAnchorDetail{{
+				Name: aws.String("mytrustanchor"),
+			}},
+			errCheck: func(tt require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(tt, err, "is not owned by this integration")
+			},
+		},
+		{
+			name: "profile already exists but is missing the required ownership tags",
+			req:  baseRolesAnywhereConfigReq,
+			existingProfiles: []ratypes.ProfileDetail{{
+				Name: aws.String("mysyncprofile"),
+			}},
+			errCheck: func(tt require.TestingT, err error, i ...interface{}) {
+				require.ErrorContains(tt, err, "is not owned by this integration")
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			existingTrustAnchors := make(map[string]ratypes.TrustAnchorDetail, len(tt.existingTrustAnchors))
+			for _, trustAnchor := range tt.existingTrustAnchors {
+				existingTrustAnchors[aws.ToString(trustAnchor.TrustAnchorId)] = trustAnchor
+			}
+
+			existingProfiles := make(map[string]ratypes.ProfileDetail, len(tt.existingProfiles))
+			for _, profile := range tt.existingProfiles {
+				existingProfiles[aws.ToString(profile.ProfileId)] = profile
+			}
+
+			existingResourceTags := make(map[string][]ratypes.Tag, len(tt.existingRAResourceTags))
+			for resourceARN, resourceTags := range tt.existingRAResourceTags {
+				existingResourceTags[resourceARN] = resourceTags
+			}
+
+			existingRoles := make(map[string]iamtypes.Role, len(tt.existingRoles))
+			for _, role := range tt.existingRoles {
+				existingRoles[role.name] = iamtypes.Role{
+					Arn:                      aws.String("arn:aws:iam::123456789012:role/" + role.name),
+					AssumeRolePolicyDocument: role.assumeRolePolicyDoc,
+					Tags:                     role.tags,
+				}
+			}
+
+			clt := mockIAMRolesAnywhereClient{
+				mockIAMRolesAnywhere: mockIAMRolesAnywhere{
+					trustAnchorsByID: existingTrustAnchors,
+					profilesByID:     existingProfiles,
+					resourceTags:     existingResourceTags,
+				},
+				mockIAMRoles: mockIAMRoles{
+					existingRoles: make(map[string]mockRole),
+				},
+			}
+
+			err := ConfigureRolesAnywhereIAM(ctx, &clt, tt.req())
+			tt.errCheck(t, err)
+
+			if tt.externalStateCheck != nil {
+				tt.externalStateCheck(t, clt)
+			}
+		})
+	}
+}
+
+type mockIAMRolesAnywhere struct {
+	trustAnchorsByID map[string]ratypes.TrustAnchorDetail
+	profilesByID     map[string]ratypes.ProfileDetail
+	resourceTags     map[string][]ratypes.Tag
+}
+
+func (m *mockIAMRolesAnywhere) ListTrustAnchors(ctx context.Context, params *rolesanywhere.ListTrustAnchorsInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.ListTrustAnchorsOutput, error) {
+	return &rolesanywhere.ListTrustAnchorsOutput{
+		TrustAnchors: slices.Collect(maps.Values(m.trustAnchorsByID)),
+	}, nil
+}
+
+func (m *mockIAMRolesAnywhere) CreateTrustAnchor(ctx context.Context, params *rolesanywhere.CreateTrustAnchorInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.CreateTrustAnchorOutput, error) {
+	newTrustAnchorID := uuid.NewString()
+	newTrustAnchorARN := "arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/" + newTrustAnchorID
+
+	m.trustAnchorsByID[newTrustAnchorID] = ratypes.TrustAnchorDetail{
+		Name:           params.Name,
+		TrustAnchorArn: aws.String(newTrustAnchorARN),
+		TrustAnchorId:  aws.String(newTrustAnchorID),
+		Enabled:        params.Enabled,
+	}
+
+	m.resourceTags[newTrustAnchorARN] = params.Tags
+
+	return nil, nil
+}
+
+func (m *mockIAMRolesAnywhere) UpdateTrustAnchor(ctx context.Context, params *rolesanywhere.UpdateTrustAnchorInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.UpdateTrustAnchorOutput, error) {
+	existingTrustAnchor, ok := m.trustAnchorsByID[aws.ToString(params.TrustAnchorId)]
+	if !ok {
+		return nil, trace.NotFound("trust anchor %q not found", aws.ToString(params.TrustAnchorId))
+	}
+	existingTrustAnchor.Source = params.Source
+
+	m.trustAnchorsByID[aws.ToString(params.TrustAnchorId)] = existingTrustAnchor
+	return nil, nil
+}
+
+func (m *mockIAMRolesAnywhere) EnableTrustAnchor(ctx context.Context, params *rolesanywhere.EnableTrustAnchorInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.EnableTrustAnchorOutput, error) {
+	existingTrustAnchor, ok := m.trustAnchorsByID[aws.ToString(params.TrustAnchorId)]
+	if !ok {
+		return nil, trace.NotFound("trust anchor %q not found", aws.ToString(params.TrustAnchorId))
+	}
+	existingTrustAnchor.Enabled = aws.Bool(true)
+
+	m.trustAnchorsByID[aws.ToString(params.TrustAnchorId)] = existingTrustAnchor
+	return nil, nil
+}
+
+func (m *mockIAMRolesAnywhere) ListTagsForResource(ctx context.Context, params *rolesanywhere.ListTagsForResourceInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.ListTagsForResourceOutput, error) {
+	return &rolesanywhere.ListTagsForResourceOutput{
+		Tags: m.resourceTags[aws.ToString(params.ResourceArn)],
+	}, nil
+}
+
+func (m *mockIAMRolesAnywhere) ListProfiles(ctx context.Context, params *rolesanywhere.ListProfilesInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.ListProfilesOutput, error) {
+	if m.profilesByID == nil {
+		m.profilesByID = make(map[string]ratypes.ProfileDetail)
+	}
+	return &rolesanywhere.ListProfilesOutput{
+		Profiles: slices.Collect(maps.Values(m.profilesByID)),
+	}, nil
+}
+
+func (m *mockIAMRolesAnywhere) CreateProfile(ctx context.Context, params *rolesanywhere.CreateProfileInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.CreateProfileOutput, error) {
+	newProfileID := uuid.NewString()
+	newProfileARN := "arn:aws:rolesanywhere:eu-west-2:123456789012:profile/" + newProfileID
+
+	m.profilesByID[newProfileID] = ratypes.ProfileDetail{
+		Name:       params.Name,
+		ProfileArn: aws.String(newProfileARN),
+		ProfileId:  aws.String(newProfileID),
+		Enabled:    params.Enabled,
+	}
+
+	m.resourceTags[newProfileARN] = params.Tags
+
+	return nil, nil
+}
+
+func (m *mockIAMRolesAnywhere) UpdateProfile(ctx context.Context, params *rolesanywhere.UpdateProfileInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.UpdateProfileOutput, error) {
+	existingProfile, ok := m.profilesByID[aws.ToString(params.ProfileId)]
+	if !ok {
+		return nil, trace.NotFound("trust anchor %q not found", aws.ToString(params.ProfileId))
+	}
+	existingProfile.AcceptRoleSessionName = params.AcceptRoleSessionName
+	existingProfile.RoleArns = params.RoleArns
+
+	m.profilesByID[aws.ToString(params.ProfileId)] = existingProfile
+	return nil, nil
+}
+
+func (m *mockIAMRolesAnywhere) EnableProfile(ctx context.Context, params *rolesanywhere.EnableProfileInput, optFns ...func(*rolesanywhere.Options)) (*rolesanywhere.EnableProfileOutput, error) {
+	existingProfile, ok := m.profilesByID[aws.ToString(params.ProfileId)]
+	if !ok {
+		return nil, trace.NotFound("trust anchor %q not found", aws.ToString(params.ProfileId))
+	}
+	existingProfile.Enabled = aws.Bool(true)
+
+	m.profilesByID[aws.ToString(params.ProfileId)] = existingProfile
+	return nil, nil
+}
+
+type mockIAMRolesAnywhereClient struct {
+	mockIAMRolesAnywhere
+	mockIAMRoles
+}
+
+func (m *mockIAMRolesAnywhereClient) GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	return &sts.GetCallerIdentityOutput{
+		Account: aws.String("123456789012"),
+	}, nil
+}
+
+type mockRole struct {
+	name                string
+	assumeRolePolicyDoc *string
+	tags                []iamtypes.Tag
+	presetPolicyDoc     *string
+}
+
+type mockIAMRoles struct {
+	existingRoles map[string]mockRole
+}
+
+// CreateRole creates a new IAM Role.
+func (m *mockIAMRoles) CreateRole(ctx context.Context, params *iam.CreateRoleInput, optFns ...func(*iam.Options)) (*iam.CreateRoleOutput, error) {
+	alreadyExistsMessage := fmt.Sprintf("Role %q already exists.", *params.RoleName)
+	_, found := m.existingRoles[aws.ToString(params.RoleName)]
+	if found {
+		return nil, &iamtypes.EntityAlreadyExistsException{
+			Message: &alreadyExistsMessage,
+		}
+	}
+	m.existingRoles[*params.RoleName] = mockRole{
+		tags:                params.Tags,
+		assumeRolePolicyDoc: params.AssumeRolePolicyDocument,
+	}
+
+	return &iam.CreateRoleOutput{
+		Role: &iamtypes.Role{
+			Arn: aws.String("arn:something"),
+		},
+	}, nil
+}
+
+// PutRolePolicy assigns a policy to an existing IAM Role.
+func (m *mockIAMRoles) PutRolePolicy(ctx context.Context, params *iam.PutRolePolicyInput, optFns ...func(*iam.Options)) (*iam.PutRolePolicyOutput, error) {
+	doesNotExistMessage := fmt.Sprintf("Role %q does not exist.", *params.RoleName)
+	if _, ok := m.existingRoles[aws.ToString(params.RoleName)]; !ok {
+		return nil, &iamtypes.NoSuchEntityException{
+			Message: &doesNotExistMessage,
+		}
+	}
+
+	m.existingRoles[*params.RoleName] = mockRole{
+		tags:                m.existingRoles[*params.RoleName].tags,
+		assumeRolePolicyDoc: m.existingRoles[*params.RoleName].assumeRolePolicyDoc,
+		presetPolicyDoc:     params.PolicyDocument,
+	}
+
+	return &iam.PutRolePolicyOutput{}, nil
+}
+
+// GetRole retrieves information about the specified role, including the role's path,
+// GUID, ARN, and the role's trust policy that grants permission to assume the
+// role.
+func (m *mockIAMRoles) GetRole(ctx context.Context, params *iam.GetRoleInput, optFns ...func(*iam.Options)) (*iam.GetRoleOutput, error) {
+	role, found := m.existingRoles[aws.ToString(params.RoleName)]
+	if !found {
+		return nil, trace.NotFound("role not found")
+	}
+	return &iam.GetRoleOutput{
+		Role: &iamtypes.Role{
+			Tags:                     role.tags,
+			AssumeRolePolicyDocument: role.assumeRolePolicyDoc,
+			Arn:                      aws.String("arn:aws:iam::123456789012:role/" + aws.ToString(params.RoleName)),
+		},
+	}, nil
+}
+
+// UpdateAssumeRolePolicy updates the policy that grants an IAM entity permission to assume a role.
+// This is typically referred to as the "role trust policy".
+func (m *mockIAMRoles) UpdateAssumeRolePolicy(ctx context.Context, params *iam.UpdateAssumeRolePolicyInput, optFns ...func(*iam.Options)) (*iam.UpdateAssumeRolePolicyOutput, error) {
+	role, found := m.existingRoles[aws.ToString(params.RoleName)]
+	if !found {
+		return nil, trace.NotFound("role not found")
+	}
+
+	role.assumeRolePolicyDoc = params.PolicyDocument
+	m.existingRoles[aws.ToString(params.RoleName)] = role
+
+	return &iam.UpdateAssumeRolePolicyOutput{}, nil
+}
+
+func (m *mockIAMRoles) TagRole(ctx context.Context, params *iam.TagRoleInput, _ ...func(*iam.Options)) (*iam.TagRoleOutput, error) {
+	roleName := aws.ToString(params.RoleName)
+	role, found := m.existingRoles[roleName]
+	if !found {
+		return nil, trace.NotFound("role not found")
+	}
+
+	tags := tags.AWSTags{}
+	for _, existingTag := range role.tags {
+		tags[*existingTag.Key] = *existingTag.Value
+	}
+	for _, newTag := range params.Tags {
+		tags[*newTag.Key] = *newTag.Value
+	}
+	role.tags = tags.ToIAMTags()
+	m.existingRoles[roleName] = role
+	return &iam.TagRoleOutput{}, nil
+}

--- a/tool/teleport/common/integration_configure.go
+++ b/tool/teleport/common/integration_configure.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/config"
 	"github.com/gravitational/teleport/lib/integrations/awsoidc"
+	"github.com/gravitational/teleport/lib/integrations/awsra"
 	"github.com/gravitational/teleport/lib/integrations/azureoidc"
 	"github.com/gravitational/teleport/lib/integrations/externalauditstorage"
 	"github.com/gravitational/teleport/lib/integrations/externalauditstorage/easconfig"
@@ -286,4 +287,28 @@ func onIntegrationConfSAMLIdPGCPWorkforce(ctx context.Context, params samlidpcon
 	}
 
 	return trace.Wrap(gcpWorkforceService.CreateWorkforcePoolAndProvider(ctx))
+}
+
+func onIntegrationConfAWSRATrustAnchor(ctx context.Context, clf config.CommandLineFlags) error {
+	// pass the value of --insecure flag to the runtime
+	lib.SetInsecureDevMode(clf.InsecureMode)
+
+	// Ensure we print output to the user. LogLevel at this point was set to Error.
+	utils.InitLogger(utils.LoggingForDaemon, slog.LevelInfo)
+
+	rolesAnywhereConfigClient, err := awsra.NewRolesAnywhereIAMConfigurationClient(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	confReq := awsra.TrustAnchorConfigureRequest{
+		Cluster:               clf.IntegrationConfAWSRATrustAnchorArguments.Cluster,
+		IntegrationName:       clf.IntegrationConfAWSRATrustAnchorArguments.Name,
+		TrustAnchorName:       clf.IntegrationConfAWSRATrustAnchorArguments.TrustAnchor,
+		TrustAnchorCertBase64: clf.IntegrationConfAWSRATrustAnchorArguments.TrustAnchorCertBase64,
+		SyncProfileName:       clf.IntegrationConfAWSRATrustAnchorArguments.SyncProfile,
+		SyncRoleName:          clf.IntegrationConfAWSRATrustAnchorArguments.SyncRole,
+		AutoConfirm:           clf.IntegrationConfAWSRATrustAnchorArguments.AutoConfirm,
+	}
+	return trace.Wrap(awsra.ConfigureRolesAnywhereIAM(ctx, rolesAnywhereConfigClient, confReq))
 }

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -581,6 +581,15 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	integrationSAMLIdPGCPWorkforce.Flag("pool-provider-name", "Name for the new workforce identity pool provider.").Required().StringVar(&ccf.IntegrationConfSAMLIdPGCPWorkforceArguments.PoolProviderName)
 	integrationSAMLIdPGCPWorkforce.Flag("idp-metadata-url", "Teleport SAML IdP metadata endpoint.").Required().StringVar(&ccf.IntegrationConfSAMLIdPGCPWorkforceArguments.SAMLIdPMetadataURL)
 
+	integrationConfAWSRATrustAnchor := integrationConfigureCmd.Command("awsra-trust-anchor", "Configure AWS IAM Roles Anywhere Integration by creating resources in AWS.")
+	integrationConfAWSRATrustAnchor.Flag("cluster", "Teleport Cluster's name.").Required().StringVar(&ccf.IntegrationConfAWSRATrustAnchorArguments.Cluster)
+	integrationConfAWSRATrustAnchor.Flag("name", "Integration name.").Required().StringVar(&ccf.IntegrationConfAWSRATrustAnchorArguments.Name)
+	integrationConfAWSRATrustAnchor.Flag("trust-anchor", "AWS Roles Anywhere Trust Anchor name.").Required().StringVar(&ccf.IntegrationConfAWSRATrustAnchorArguments.TrustAnchor)
+	integrationConfAWSRATrustAnchor.Flag("trust-anchor-cert-b64", "AWS Roles Anywhere Trust Anchor's certificate, encoded in base64.").Required().StringVar(&ccf.IntegrationConfAWSRATrustAnchorArguments.TrustAnchorCertBase64)
+	integrationConfAWSRATrustAnchor.Flag("sync-profile", "The AWS IAM Roles Anywhere Profile name to create, which will be used to sync profiles as apps.").Required().StringVar(&ccf.IntegrationConfAWSRATrustAnchorArguments.SyncProfile)
+	integrationConfAWSRATrustAnchor.Flag("sync-role", "The AWS IAM Role name to create, which will be used to sync profiles as apps.").Required().StringVar(&ccf.IntegrationConfAWSRATrustAnchorArguments.SyncRole)
+	integrationConfAWSRATrustAnchor.Flag("confirm", "Apply changes without confirmation prompt.").BoolVar(&ccf.IntegrationConfAWSRATrustAnchorArguments.AutoConfirm)
+
 	tpmCmd := app.Command("tpm", "Commands related to managing TPM joining functionality.")
 	tpmIdentifyCmd := tpmCmd.Command("identify", "Output identifying information related to the TPM detected on the system.")
 
@@ -760,6 +769,8 @@ Examples:
 		err = onIntegrationConfAzureOIDCCmd(ctx, ccf.IntegrationConfAzureOIDCArguments)
 	case integrationSAMLIdPGCPWorkforce.FullCommand():
 		err = onIntegrationConfSAMLIdPGCPWorkforce(ctx, ccf.IntegrationConfSAMLIdPGCPWorkforceArguments)
+	case integrationConfAWSRATrustAnchor.FullCommand():
+		err = onIntegrationConfAWSRATrustAnchor(ctx, ccf)
 	case tpmIdentifyCmd.FullCommand():
 		var query *tpm.QueryRes
 		query, err = tpm.Query(context.Background(), slog.Default())


### PR DESCRIPTION
This PR adds a new teleport configuration command which performs the AWS
IAM Roles Anywhere Integration set up.

It does the following:
- creates a new Roles Anywhere Trust Anchor using the certificate received
- creates a new IAM Role which allows the required APIs for sync, and is
  usable by the Roles Anywhere service, filtered by the created Trust
  Anchor
- creates a new Roles Anywhere Profile which can use the IAM Role above

This is part of the new AWS IAM Roles Anywhere integration required set
up.

Demo:


```
teleport integration configure awsra-trust-anchor --cluster=my-cluster --name=ra-integration --trust-anchor=MarcoTrustAnchorFromCLI --trust-anchor-cert-b64=$b64 --sync-profile=MarcoRAProfileFromCLI --sync-role=MarcoRARoleFromCLI --confirm
"awsra-trust-anchor" will perform the following actions:

1. Create a Roles Anywhere Trust Anchor in AWS IAM for your Teleport cluster.
CreateRolesAnywhereTrustAnchorProvider: {
    "Name": "MarcoTrustAnchorFromCLI",
    "Source": {
        "SourceData": {
            "Value": "<b64 encoded certificate>"
        },
        "SourceType": "CERTIFICATE_BUNDLE"
    },
    "Enabled": true,
    "NotificationSettings": null,
    "Tags": [
        {
            "Key": "teleport.dev/cluster",
            "Value": "my-cluster"
        },
        {
            "Key": "teleport.dev/integration",
            "Value": "ra-integration"
        },
        {
            "Key": "teleport.dev/origin",
            "Value": "integration_awsrolesanywhere"
        }
    ]
}

2. Create IAM role "MarcoRARoleFromCLI" which can be used by IAM Roles Anywhere.
CreateRole: {
    "AssumeRolePolicyDocument": {
        "Version": "2012-10-17",
        "Statement": [
            {
                "Effect": "Allow",
                "Action": [
                    "sts:AssumeRole",
                    "sts:SetSourceIdentity",
                    "sts:TagSession"
                ],
                "Principal": {
                    "Service": "rolesanywhere.amazonaws.com"
                },
                "Condition": {
                    "ArnEquals": {
                        "aws:SourceArn": "arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/_TrustAnchorID_"
                    }
                }
            }
        ]
    },
    "RoleName": "MarcoRARoleFromCLI",
    "Description": "Used by Teleport to provide access to AWS resources.",
    "MaxSessionDuration": null,
    "Path": null,
    "PermissionsBoundary": null,
    "Tags": [
        {
            "Key": "teleport.dev/cluster",
            "Value": "my-cluster"
        },
        {
            "Key": "teleport.dev/integration",
            "Value": "ra-integration"
        },
        {
            "Key": "teleport.dev/origin",
            "Value": "integration_awsrolesanywhere"
        }
    ]
}

3. Assign IAM role "MarcoRARoleFromCLI" with an inline policy "TeleportRolesAnywhereProfileSync".
AssignPolicy: {
    "PolicyDocument": {
        "Effect": "Allow",
        "Action": [
            "rolesanywhere:ListProfiles",
            "rolesanywhere:ListTagsForResource",
            "rolesanywhere:ImportCrl",
            "iam:GetRole"
        ],
        "Resource": "*"
    },
    "PolicyName": "TeleportRolesAnywhereProfileSync",
    "RoleName": "MarcoRARoleFromCLI"
}

4. Create a Roles Anywhere Profile in AWS IAM for your Teleport cluster.
CreateRolesAnywhereProfileProvider: {
    "Name": "MarcoRAProfileFromCLI",
    "RoleArns": [
        "arn:aws:iam::123456789012:role/MarcoRARoleFromCLI"
    ],
    "AcceptRoleSessionName": true,
    "DurationSeconds": null,
    "Enabled": true,
    "ManagedPolicyArns": null,
    "RequireInstanceProperties": null,
    "SessionPolicy": null,
    "Tags": [
        {
            "Key": "teleport.dev/cluster",
            "Value": "my-cluster"
        },
        {
            "Key": "teleport.dev/integration",
            "Value": "ra-integration"
        },
        {
            "Key": "teleport.dev/origin",
            "Value": "integration_awsrolesanywhere"
        }
    ]
}

5. Prints the ARNs for the Trust Anchor, Profile, and Role.
TrustAnchorSetUpARNs: {
    "TrustAnchorName": "MarcoTrustAnchorFromCLI",
    "ProfileName": "MarcoRAProfileFromCLI",
    "RoleName": "MarcoRARoleFromCLI"
}

2025-05-15T16:30:19.627+01:00 INFO  Running step:1 action:CreateRolesAnywhereTrustAnchorProvider provisioning/operations.go:178
2025-05-15T16:30:20.057+01:00 INFO  Updating the existing Roles Anywhere Profile awsactions/create_rolesanywhere_trustanchor.go:128
2025-05-15T16:30:20.197+01:00 INFO  Running step:2 action:CreateRole provisioning/operations.go:178
2025-05-15T16:30:20.197+01:00 INFO  Getting the Trust Anchor ID trust_anchor:MarcoTrustAnchorFromCLI awsactions/create_role_for_trustanchor.go:96
2025-05-15T16:30:20.899+01:00 INFO  IAM role already exists role:MarcoRARoleFromCLI awsactions/create_role_for_trustanchor.go:130
2025-05-15T16:30:20.899+01:00 INFO  Checking IAM role trust policy role:MarcoRARoleFromCLI awsactions/create_role.go:164
2025-05-15T16:30:20.899+01:00 INFO  IAM role trust policy does not require update role:MarcoRARoleFromCLI awsactions/create_role.go:169
2025-05-15T16:30:20.899+01:00 INFO  Checking for tags on IAM role role:MarcoRARoleFromCLI awsactions/create_role.go:197
2025-05-15T16:30:20.899+01:00 INFO  IAM role is already tagged role:MarcoRARoleFromCLI awsactions/create_role.go:201
2025-05-15T16:30:20.899+01:00 INFO  Running step:3 action:AssignPolicy provisioning/operations.go:178
2025-05-15T16:30:21.067+01:00 INFO  Running step:4 action:CreateRolesAnywhereProfileProvider provisioning/operations.go:178
2025-05-15T16:30:21.293+01:00 INFO  Running step:5 action:TrustAnchorSetUpARNs provisioning/operations.go:178

Copy and paste the following values to Teleport UI

=================================================
arn:aws:rolesanywhere:eu-west-2:123456789012:trust-anchor/00000000-0000-0000-0000-000000000000
arn:aws:rolesanywhere:eu-west-2:123456789012:profile/00000000-0000-0000-0000-000000000000
arn:aws:iam::123456789012:role/MarcoRARoleFromCLI
=================================================

2025-05-15T16:30:21.683+01:00 INFO  Success! operation:awsra-trust-anchor provisioning/operations.go:190
```

See https://github.com/gravitational/teleport/issues/53192