### PR TITLE
Increase test timeout

### DIFF
--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/StandardEditor.test.tsx
@@ -270,7 +270,7 @@ test('triggers v6 validation for Kubernetes resources', async () => {
   await selectEvent.select(screen.getByLabelText('Version'), 'v7');
   await user.click(screen.getByRole('button', { name: 'Save Changes' }));
   expect(onSave).toHaveBeenCalled();
-});
+}, 10000);
 
 test('creating a new role', async () => {
   async function forwardToTab(name: string) {


### PR DESCRIPTION
Doubles the current timeout to fix flakiness. Note that there's a possibility that we could actually optimize the UI here a bit more, but my attempts to do so by memoizing the Kubernetes resource views failed to change much for the test itself.