### PR TITLE
[vnet] chore: refactor for better cache sharing

### DIFF
--- a/lib/teleterm/vnet/service.go
+++ b/lib/teleterm/vnet/service.go
@@ -29,7 +29,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/api/utils"
 	prehogv1alpha "github.com/gravitational/teleport/gen/proto/go/prehog/v1alpha"
 	apiteleterm "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/vnet/v1"
@@ -61,7 +60,7 @@ type Service struct {
 	mu                 sync.Mutex
 	status             status
 	usageReporter      usageReporter
-	processManager     *vnet.ProcessManager
+	vnetProcess        *vnet.UserProcess
 	clusterConfigCache *vnet.ClusterConfigCache
 	networkStackInfo   *vnetv1.NetworkStackInfo
 }
@@ -160,15 +159,13 @@ func (s *Service) Start(ctx context.Context, req *api.StartRequest) (*api.StartR
 		clientApplication.usageReporter = usageReporter
 	}
 
-	processManager, nsi, err := vnet.RunUserProcess(ctx, &vnet.UserProcessConfig{
-		ClientApplication: clientApplication,
-	})
+	vnetProcess, err := vnet.RunUserProcess(ctx, clientApplication)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	go func() {
-		err := processManager.Wait()
+		err := vnetProcess.Wait()
 		if err != nil && !errors.Is(err, context.Canceled) {
 			log.ErrorContext(ctx, "VNet closed with an error", "error", err)
 		} else {
@@ -179,7 +176,7 @@ func (s *Service) Start(ctx context.Context, req *api.StartRequest) (*api.StartR
 		defer s.mu.Unlock()
 
 		// Handle unexpected shutdown.
-		// If processManager.Wait has returned but status is stil "running", then it means that VNet
+		// If vnetProcess.Wait has returned but status is stil "running", then it means that VNet
 		// unexpectedly shut down rather than stopped through the Stop RPC.
 		if s.status == statusRunning {
 			s.status = statusNotRunning
@@ -194,8 +191,8 @@ func (s *Service) Start(ctx context.Context, req *api.StartRequest) (*api.StartR
 		}
 	}()
 
-	s.processManager = processManager
-	s.networkStackInfo = nsi
+	s.vnetProcess = vnetProcess
+	s.networkStackInfo = vnetProcess.NetworkStackInfo()
 	s.usageReporter = clientApplication.usageReporter
 	s.status = statusRunning
 	return &api.StartResponse{}, nil
@@ -217,84 +214,27 @@ func (s *Service) Stop(ctx context.Context, req *api.StopRequest) (*api.StopResp
 // ListDNSZones returns DNS zones of all root and leaf clusters with non-expired user certs. This
 // includes the proxy service hostnames and custom DNS zones configured in vnet_config.
 //
-// This is fetched independently of what the Electron app thinks the current state of the cluster
-// looks like, since the VNet admin process also fetches this data independently of the Electron
-// app.
-//
-// Just like the admin process, it skips root and leaf clusters for which DNS couldn't be fetched
-// (due to e.g., a network error or an expired cert).
+// This is fetched exactly the same way the VNet process fetches the DNS zones
+// but may be slightly out of sync with the OS configuration if the admin
+// process hasn't configured a recent change yet.
 func (s *Service) ListDNSZones(ctx context.Context, req *api.ListDNSZonesRequest) (*api.ListDNSZonesResponse, error) {
 	// Acquire the lock just to check the status of the service. We don't want the actual process of
 	// listing DNS zones to block the user from performing other operations.
 	s.mu.Lock()
-
 	if s.status != statusRunning {
 		s.mu.Unlock()
 		return nil, trace.CompareFailed("VNet is not running")
 	}
-
+	osConfigProvider := s.vnetProcess.GetOSConfigProvider()
 	s.mu.Unlock()
 
-	profileNames, err := s.cfg.DaemonService.ListProfileNames()
+	targetOSConfig, err := osConfigProvider.GetTargetOSConfiguration(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	dnsZones, _ := s.listDNSZonesAndCIDRRanges(ctx, profileNames)
-
 	return &api.ListDNSZonesResponse{
-		DnsZones: dnsZones,
+		DnsZones: targetOSConfig.GetDnsZones(),
 	}, nil
-}
-
-func (s *Service) listDNSZonesAndCIDRRanges(ctx context.Context, profileNames []string) (dnsZones []string, cidrRanges []string) {
-	for _, profileName := range profileNames {
-		rootClusterURI := uri.NewClusterURI(profileName)
-		cLog := log.With("cluster", rootClusterURI)
-
-		rootClient, err := s.cfg.DaemonService.GetCachedClient(ctx, rootClusterURI)
-		if err != nil {
-			cLog.WarnContext(ctx, "Failed to create root cluster client, profile may be expired, skipping DNS zones of this cluster", "error", err)
-			continue
-		}
-		clusterConfig, err := s.clusterConfigCache.GetClusterConfig(ctx, rootClient)
-		if err != nil {
-			cLog.WarnContext(ctx, "Failed to load VNet configuration, profile may be expired, skipping DNS zones of this cluster", "error", err)
-			continue
-		}
-
-		dnsZones = append(dnsZones, clusterConfig.DNSZones...)
-		cidrRanges = append(cidrRanges, clusterConfig.IPv4CIDRRange)
-
-		leafClusters, err := s.cfg.DaemonService.ListLeafClusters(ctx, rootClusterURI.String())
-		if err != nil {
-			cLog.WarnContext(ctx, "Failed to list leaf clusters, profile may be expired, skipping DNS zones from leaf clusters of this cluster", "error", err)
-			continue
-		}
-
-		for _, leafCluster := range leafClusters {
-			cLog := log.With("cluster", leafCluster.URI.String())
-
-			clusterClient, err := s.cfg.DaemonService.GetCachedClient(ctx, leafCluster.URI)
-			if err != nil {
-				cLog.WarnContext(ctx, "Failed to create leaf cluster client, skipping DNS zones for this leaf cluster", "error", err)
-				continue
-			}
-			clusterConfig, err := s.clusterConfigCache.GetClusterConfig(ctx, clusterClient)
-			if err != nil {
-				cLog.WarnContext(ctx, "Failed to load VNet configuration, skipping DNS zones for this leaf cluster", "error", err)
-				continue
-			}
-
-			dnsZones = append(dnsZones, clusterConfig.DNSZones...)
-			cidrRanges = append(cidrRanges, clusterConfig.IPv4CIDRRange)
-		}
-	}
-
-	dnsZones = utils.Deduplicate(dnsZones)
-	cidrRanges = utils.Deduplicate(cidrRanges)
-
-	return dnsZones, cidrRanges
 }
 
 func (s *Service) stopLocked() error {
@@ -306,8 +246,8 @@ func (s *Service) stopLocked() error {
 		return nil
 	}
 
-	s.processManager.Close()
-	err := s.processManager.Wait()
+	s.vnetProcess.Close()
+	err := s.vnetProcess.Wait()
 	if err != nil && !errors.Is(err, context.Canceled) {
 		return trace.Wrap(err)
 	}

--- a/lib/teleterm/vnet/service_darwin.go
+++ b/lib/teleterm/vnet/service_darwin.go
@@ -77,17 +77,14 @@ func (s *Service) RunDiagnostics(ctx context.Context, req *api.RunDiagnosticsReq
 }
 
 func (s *Service) getNetworkStack(ctx context.Context) (*diagv1.NetworkStack, error) {
-	profileNames, err := s.cfg.DaemonService.ListProfileNames()
+	targetOSConfig, err := s.vnetProcess.GetOSConfigProvider().GetTargetOSConfiguration(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	dnsZones, cidrRanges := s.listDNSZonesAndCIDRRanges(ctx, profileNames)
-
 	return &diagv1.NetworkStack{
 		InterfaceName:  s.networkStackInfo.InterfaceName,
 		Ipv6Prefix:     s.networkStackInfo.Ipv6Prefix,
-		Ipv4CidrRanges: cidrRanges,
-		DnsZones:       dnsZones,
+		Ipv4CidrRanges: targetOSConfig.GetIpv4CidrRanges(),
+		DnsZones:       targetOSConfig.GetDnsZones(),
 	}, nil
 }

--- a/lib/vnet/daemon/service_darwin.go
+++ b/lib/vnet/daemon/service_darwin.go
@@ -28,10 +28,10 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/gravitational/teleport/lib/utils/darwinbundle"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/utils/darwinbundle"
 )
 
 // Start starts an XPC listener and waits for it to receive a message with VNet config.

--- a/lib/vnet/local_osconfig_provider.go
+++ b/lib/vnet/local_osconfig_provider.go
@@ -1,0 +1,137 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/utils"
+	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
+)
+
+// LocalOSConfigProvider fetches target OS configuration parameters.
+// Its methods get exposed by [clientApplicationService] so that
+// [remoteOSConfigProvider] can be implemented by calling these methods from the
+// VNet admin process.
+type LocalOSConfigProvider struct {
+	cfg *LocalOSConfigProviderConfig
+}
+
+// LocalOSConfigProviderConfig holds configuration parameters for
+// LocalOSConfigProvider.
+type LocalOSConfigProviderConfig struct {
+	clientApplication  ClientApplication
+	clusterConfigCache *ClusterConfigCache
+}
+
+// NewLocalOSConfigProvider returns a new LocalOSConfigProvider.
+func NewLocalOSConfigProvider(cfg *LocalOSConfigProviderConfig) *LocalOSConfigProvider {
+	return &LocalOSConfigProvider{
+		cfg: cfg,
+	}
+}
+
+// GetTargetOSConfiguration returns the configuration values that should be
+// configured in the OS, including DNS zones that should be handled by the VNet
+// DNS nameserver and the IPv4 CIDR ranges that should be routed to the VNet TUN
+// interface. This is not all of the OS configuration values, only the ones that
+// must be communicated from the client application to the admin process.
+func (p *LocalOSConfigProvider) GetTargetOSConfiguration(ctx context.Context) (*vnetv1.TargetOSConfiguration, error) {
+	profiles, err := p.cfg.clientApplication.ListProfiles()
+	if err != nil {
+		return nil, trace.Wrap(err, "listing profiles")
+	}
+	var targetOSConfig vnetv1.TargetOSConfiguration
+	for _, profileName := range profiles {
+		profileTargetConfig := p.targetOSConfigurationForProfile(ctx, profileName)
+		targetOSConfig.DnsZones = append(targetOSConfig.DnsZones, profileTargetConfig.DnsZones...)
+		targetOSConfig.Ipv4CidrRanges = append(targetOSConfig.Ipv4CidrRanges, profileTargetConfig.Ipv4CidrRanges...)
+	}
+	targetOSConfig.DnsZones = utils.Deduplicate(targetOSConfig.DnsZones)
+	targetOSConfig.Ipv4CidrRanges = utils.Deduplicate(targetOSConfig.Ipv4CidrRanges)
+	return &targetOSConfig, nil
+}
+
+// targetOSConfigurationForProfile does not return errors, it is better to
+// configure VNet for any working profiles and log errors for failures.
+func (p *LocalOSConfigProvider) targetOSConfigurationForProfile(ctx context.Context, profileName string) *vnetv1.TargetOSConfiguration {
+	targetOSConfig := &vnetv1.TargetOSConfiguration{}
+	rootClusterClient, err := p.cfg.clientApplication.GetCachedClient(ctx, profileName, "" /*leafClusterName*/)
+	if err != nil {
+		log.WarnContext(ctx,
+			"Failed to get root cluster client from cache, profile may be expired, not configuring VNet for this cluster",
+			"profile", profileName, "error", err)
+		return targetOSConfig
+	}
+	rootClusterConfig, err := p.cfg.clusterConfigCache.GetClusterConfig(ctx, rootClusterClient)
+	if err != nil {
+		log.WarnContext(ctx,
+			"Failed to load VNet configuration, profile may be expired, not configuring VNet for this cluster",
+			"profile", profileName, "error", err)
+		return targetOSConfig
+	}
+	targetOSConfig.DnsZones = rootClusterConfig.DNSZones
+	targetOSConfig.Ipv4CidrRanges = []string{rootClusterConfig.IPv4CIDRRange}
+
+	leafClusterNames, err := getLeafClusters(ctx, rootClusterClient)
+	if err != nil {
+		log.WarnContext(ctx,
+			"Failed to list leaf clusters, profile may be expired, not configuring VNet for leaf clusters of this cluster",
+			"profile", profileName, "error", err)
+		return targetOSConfig
+	}
+	for _, leafClusterName := range leafClusterNames {
+		leafClusterClient, err := p.cfg.clientApplication.GetCachedClient(ctx, profileName, leafClusterName)
+		if err != nil {
+			log.WarnContext(ctx,
+				"Failed to create leaf cluster client, not configuring VNet for this cluster",
+				"profile", profileName, "leaf_cluster", leafClusterName, "error", err)
+			return targetOSConfig
+		}
+		leafClusterConfig, err := p.cfg.clusterConfigCache.GetClusterConfig(ctx, leafClusterClient)
+		if err != nil {
+			log.WarnContext(ctx,
+				"Failed to load VNet configuration, not configuring VNet for this cluster",
+				"profile", profileName, "leaf_cluster", leafClusterName, "error", err)
+			return targetOSConfig
+		}
+		targetOSConfig.DnsZones = append(targetOSConfig.DnsZones, leafClusterConfig.DNSZones...)
+		targetOSConfig.Ipv4CidrRanges = append(targetOSConfig.Ipv4CidrRanges, leafClusterConfig.IPv4CIDRRange)
+	}
+	return targetOSConfig
+}
+
+// TODO(nklaassen): cache the list of leaf clusters for each root cluster, no
+// need to refetch them all the time and the list doesn't change very often.
+func getLeafClusters(ctx context.Context, rootClient ClusterClient) ([]string, error) {
+	var leafClusters []string
+	nextPage := ""
+	for {
+		remoteClusters, nextPage, err := rootClient.CurrentCluster().ListRemoteClusters(ctx, 0, nextPage)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		for _, rc := range remoteClusters {
+			leafClusters = append(leafClusters, rc.GetName())
+		}
+		if nextPage == "" {
+			return leafClusters, nil
+		}
+	}
+}

--- a/lib/vnet/remote_osconfig_provider.go
+++ b/lib/vnet/remote_osconfig_provider.go
@@ -24,9 +24,9 @@ import (
 	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
 )
 
-// remoteOSConfigProvider implements targetOSConfigProvider when the admin
+// remoteOSConfigProvider implements [targetOSConfigProvider] when the admin
 // service fetches cluster DNS zones and CIDR ranges from the client application
-// process over gRPC. It is currently used in the Windows admin service.
+// process over gRPC.
 type remoteOSConfigProvider struct {
 	clt     targetOSConfigGetter
 	tunName string

--- a/lib/vnet/unsupported_os.go
+++ b/lib/vnet/unsupported_os.go
@@ -23,15 +23,13 @@ import (
 	"runtime"
 
 	"github.com/gravitational/trace"
-
-	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
 )
 
 // ErrVnetNotImplemented is an error indicating that VNet is not implemented on the host OS.
 var ErrVnetNotImplemented = &trace.NotImplementedError{Message: "VNet is not implemented on " + runtime.GOOS}
 
-func runPlatformUserProcess(_ context.Context, _ *UserProcessConfig) (*ProcessManager, *vnetv1.NetworkStackInfo, error) {
-	return nil, nil, trace.Wrap(ErrVnetNotImplemented)
+func (*UserProcess) runPlatformUserProcess(_ context.Context) error {
+	return trace.Wrap(ErrVnetNotImplemented)
 }
 
 type platformOSConfigState struct{}

--- a/lib/vnet/user_process.go
+++ b/lib/vnet/user_process.go
@@ -18,39 +18,128 @@ package vnet
 
 import (
 	"context"
+	"crypto/tls"
 
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 
 	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 )
 
-// UserProcessConfig provides the necessary configuration to run VNet.
-type UserProcessConfig struct {
-	// ClientApplication is a required field providing an interface implementation for
-	// [ClientApplication].
-	ClientApplication ClientApplication
+// ClientApplication is the common interface implemented by each VNet client
+// application: Connect and tsh. It provides methods to list user profiles, get
+// cluster clients, issue app certificates, and report metrics and errors -
+// anything that uses the user's credentials or a Teleport client.
+// The name "client application" refers to a user-facing client application, in
+// contrast to the MacOS daemon or Windows service.
+type ClientApplication interface {
+	// ListProfiles lists the names of all profiles saved for the user.
+	ListProfiles() ([]string, error)
+
+	// GetCachedClient returns a [*client.ClusterClient] for the given profile and leaf cluster.
+	// [leafClusterName] may be empty when requesting a client for the root cluster. Returned clients are
+	// expected to be cached, as this may be called frequently.
+	GetCachedClient(ctx context.Context, profileName, leafClusterName string) (ClusterClient, error)
+
+	// ReissueAppCert issues a new cert for the target app.
+	ReissueAppCert(ctx context.Context, appInfo *vnetv1.AppInfo, targetPort uint16) (tls.Certificate, error)
+
+	// GetDialOptions returns ALPN dial options for the profile.
+	GetDialOptions(ctx context.Context, profileName string) (*vnetv1.DialOptions, error)
+
+	// OnNewConnection gets called whenever a new connection is about to be established through VNet.
+	// By the time OnNewConnection, VNet has already verified that the user holds a valid cert for the
+	// app.
+	//
+	// The connection won't be established until OnNewConnection returns. Returning an error prevents
+	// the connection from being made.
+	OnNewConnection(ctx context.Context, appKey *vnetv1.AppKey) error
+
+	// OnInvalidLocalPort gets called before VNet refuses to handle a connection to a multi-port TCP app
+	// because the provided port does not match any of the TCP ports in the app spec.
+	OnInvalidLocalPort(ctx context.Context, appInfo *vnetv1.AppInfo, targetPort uint16)
 }
 
-func (c *UserProcessConfig) checkAndSetDefaults() error {
-	if c.ClientApplication == nil {
-		return trace.BadParameter("missing ClientApplication")
-	}
-	return nil
+// ClusterClient is an interface defining the subset of [client.ClusterClient]
+// methods used by via [ClientApplication].
+type ClusterClient interface {
+	CurrentCluster() authclient.ClientI
+	ClusterName() string
+	RootClusterName() string
 }
 
-// RunUserProcess is called by all VNet client applications (tsh, Connect) to
-// start and run all VNet tasks.  It returns a [ProcessManager] which controls
-// the lifecycle of all tasks and background processes.
+// RunUserProcess is the entry point called by all VNet client applications
+// (tsh, Connect) to start and run all VNet tasks.
 //
 // ctx is used for setup steps that happen before RunUserProcess passes control
 // to the process manager. Canceling ctx after RunUserProcess returns will _not_
-// cancel the background tasks. If [RunUserProcess] returns without error, the
-// caller is expected to call Close on the process manager to clean up any
-// resources, terminate all processes, and remove any OS configuration used for
-// actively running VNet.
-func RunUserProcess(ctx context.Context, cfg *UserProcessConfig) (*ProcessManager, *vnetv1.NetworkStackInfo, error) {
-	if err := cfg.checkAndSetDefaults(); err != nil {
-		return nil, nil, trace.Wrap(err)
+// cancel the background tasks.
+//
+// If [RunUserProcess] returns without error the caller is expected to
+// eventually call Close on the UserProcess to clean up any resources, terminate
+// all child processes, and remove any OS configuration used for actively
+// running VNet. Callers should also call Wait to get notified if the process
+// terminates early due to an error.
+func RunUserProcess(ctx context.Context, clientApplication ClientApplication) (*UserProcess, error) {
+	clock := clockwork.NewRealClock()
+	clusterConfigCache := NewClusterConfigCache(clock)
+	appProvider := newLocalAppProvider(&localAppProviderConfig{
+		clientApplication:  clientApplication,
+		clusterConfigCache: clusterConfigCache,
+	})
+	osConfigProvider := NewLocalOSConfigProvider(&LocalOSConfigProviderConfig{
+		clientApplication:  clientApplication,
+		clusterConfigCache: clusterConfigCache,
+	})
+	clientApplicationService := newClientApplicationService(&clientApplicationServiceConfig{
+		localAppProvider:      appProvider,
+		localOSConfigProvider: osConfigProvider,
+	})
+	userProcess := &UserProcess{
+		clientApplication:        clientApplication,
+		clusterConfigCache:       clusterConfigCache,
+		appProvider:              appProvider,
+		osConfigProvider:         osConfigProvider,
+		clientApplicationService: clientApplicationService,
+		clock:                    clock,
 	}
-	return runPlatformUserProcess(ctx, cfg)
+	if err := userProcess.runPlatformUserProcess(ctx); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return userProcess, nil
+}
+
+// UserProcess holds the state of the VNet user process, see the comment on
+// [RunUserProcess] for usage details.
+type UserProcess struct {
+	clientApplication ClientApplication
+
+	clock                    clockwork.Clock
+	clusterConfigCache       *ClusterConfigCache
+	appProvider              *localAppProvider
+	osConfigProvider         *LocalOSConfigProvider
+	clientApplicationService *clientApplicationService
+
+	processManager   *ProcessManager
+	networkStackInfo *vnetv1.NetworkStackInfo
+}
+
+func (p *UserProcess) Close() {
+	p.processManager.Close()
+}
+
+func (p *UserProcess) Wait() error {
+	return p.processManager.Wait()
+}
+
+func (p *UserProcess) NetworkStackInfo() *vnetv1.NetworkStackInfo {
+	return p.networkStackInfo
+}
+
+// GetTargetOSConfiguration returns the LocalOSConfigProvider which clients may
+// use to report the proxied DNS zones, run diagnostics, etc. The returned
+// *LocalOSConfigProvider will remain valid even if the UserProcess is closed.
+func (p *UserProcess) GetOSConfigProvider() *LocalOSConfigProvider {
+	return p.osConfigProvider
 }

--- a/lib/vnet/user_process_darwin.go
+++ b/lib/vnet/user_process_darwin.go
@@ -22,7 +22,6 @@ import (
 	"os"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 	"google.golang.org/grpc"
 	grpccredentials "google.golang.org/grpc/credentials"
 
@@ -34,31 +33,31 @@ import (
 // runPlatformUserProcess launches a daemon in the background that will handle
 // all networking and OS configuration. The user process exposes a gRPC
 // interface that the daemon uses to query application names and get user
-// certificates for apps. It returns a [ProcessManager] which controls the
-// lifecycle of both the user and daemon processes.
-func runPlatformUserProcess(ctx context.Context, cfg *UserProcessConfig) (*ProcessManager, *vnetv1.NetworkStackInfo, error) {
+// certificates for apps. If successful it sets p.processManager and
+// p.networkStackInfo.
+func (p *UserProcess) runPlatformUserProcess(ctx context.Context) error {
 	ipcCreds, err := newIPCCredentials()
 	if err != nil {
-		return nil, nil, trace.Wrap(err, "creating credentials for IPC")
+		return trace.Wrap(err, "creating credentials for IPC")
 	}
 	serverTLSConfig, err := ipcCreds.server.serverTLSConfig()
 	if err != nil {
-		return nil, nil, trace.Wrap(err, "generating gRPC server TLS config")
+		return trace.Wrap(err, "generating gRPC server TLS config")
 	}
 
 	credDir, err := os.MkdirTemp("", "vnet_service_certs")
 	if err != nil {
-		return nil, nil, trace.Wrap(err, "creating temp dir for service certs")
+		return trace.Wrap(err, "creating temp dir for service certs")
 	}
 	// Write credentials with 0200 so that only root can read them and no user
 	// processes should be able to connect to the service.
 	if err := ipcCreds.client.write(credDir, 0200); err != nil {
-		return nil, nil, trace.Wrap(err, "writing service IPC credentials")
+		return trace.Wrap(err, "writing service IPC credentials")
 	}
 
 	listener, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
-		return nil, nil, trace.Wrap(err, "listening on tcp socket")
+		return trace.Wrap(err, "listening on tcp socket")
 	}
 	// grpcServer.Serve takes ownership of (and closes) the listener.
 	grpcServer := grpc.NewServer(
@@ -66,12 +65,10 @@ func runPlatformUserProcess(ctx context.Context, cfg *UserProcessConfig) (*Proce
 		grpc.UnaryInterceptor(interceptors.GRPCServerUnaryErrorInterceptor),
 		grpc.StreamInterceptor(interceptors.GRPCServerStreamErrorInterceptor),
 	)
-	clock := clockwork.NewRealClock()
-	appProvider := newLocalAppProvider(cfg.ClientApplication, clock)
-	svc := newClientApplicationService(appProvider)
-	vnetv1.RegisterClientApplicationServiceServer(grpcServer, svc)
+	vnetv1.RegisterClientApplicationServiceServer(grpcServer, p.clientApplicationService)
 
 	pm, processCtx := newProcessManager()
+	p.processManager = pm
 	pm.AddCriticalBackgroundTask("admin process", func() error {
 		defer func() {
 			// Delete service credentials after the service terminates.
@@ -103,9 +100,10 @@ func runPlatformUserProcess(ctx context.Context, cfg *UserProcessConfig) (*Proce
 	})
 
 	select {
-	case nsi := <-svc.networkStackInfo:
-		return pm, nsi, nil
+	case nsi := <-p.clientApplicationService.networkStackInfo:
+		p.networkStackInfo = nsi
+		return nil
 	case <-processCtx.Done():
-		return nil, nil, trace.Wrap(pm.Wait(), "process manager exited before network stack info was received")
+		return trace.Wrap(pm.Wait(), "process manager exited before network stack info was received")
 	}
 }

--- a/lib/vnet/user_process_windows.go
+++ b/lib/vnet/user_process_windows.go
@@ -24,7 +24,6 @@ import (
 	"os/user"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 	"golang.org/x/sys/windows"
 	"google.golang.org/grpc"
 	grpccredentials "google.golang.org/grpc/credentials"
@@ -38,37 +37,37 @@ import (
 // interface that the admin process uses to query application names and get user
 // certificates for apps. It returns a [ProcessManager] which controls the
 // lifecycle of both the user and admin processes.
-func runPlatformUserProcess(ctx context.Context, config *UserProcessConfig) (*ProcessManager, *vnetv1.NetworkStackInfo, error) {
+func (p *UserProcess) runPlatformUserProcess(ctx context.Context) error {
 	ipcCreds, err := newIPCCredentials()
 	if err != nil {
-		return nil, nil, trace.Wrap(err, "creating credentials for IPC")
+		return trace.Wrap(err, "creating credentials for IPC")
 	}
 	serverTLSConfig, err := ipcCreds.server.serverTLSConfig()
 	if err != nil {
-		return nil, nil, trace.Wrap(err, "generating gRPC server TLS config")
+		return trace.Wrap(err, "generating gRPC server TLS config")
 	}
 
 	u, err := user.Current()
 	if err != nil {
-		return nil, nil, trace.Wrap(err, "getting current OS user")
+		return trace.Wrap(err, "getting current OS user")
 	}
 	// Uid is documented to be the user's SID on Windows.
 	userSID := u.Uid
 
 	credDir, err := os.MkdirTemp("", "vnet_service_certs")
 	if err != nil {
-		return nil, nil, trace.Wrap(err, "creating temp dir for service certs")
+		return trace.Wrap(err, "creating temp dir for service certs")
 	}
 	if err := secureCredDir(credDir, userSID); err != nil {
-		return nil, nil, trace.Wrap(err, "applying permissions to service credential dir")
+		return trace.Wrap(err, "applying permissions to service credential dir")
 	}
 	if err := ipcCreds.client.write(credDir, 0200); err != nil {
-		return nil, nil, trace.Wrap(err, "writing service IPC credentials")
+		return trace.Wrap(err, "writing service IPC credentials")
 	}
 
 	listener, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
-		return nil, nil, trace.Wrap(err, "listening on tcp socket")
+		return trace.Wrap(err, "listening on tcp socket")
 	}
 	// grpcServer.Serve takes ownership of (and closes) the listener.
 	grpcServer := grpc.NewServer(
@@ -76,12 +75,10 @@ func runPlatformUserProcess(ctx context.Context, config *UserProcessConfig) (*Pr
 		grpc.UnaryInterceptor(interceptors.GRPCServerUnaryErrorInterceptor),
 		grpc.StreamInterceptor(interceptors.GRPCServerStreamErrorInterceptor),
 	)
-	clock := clockwork.NewRealClock()
-	appProvider := newLocalAppProvider(config.ClientApplication, clock)
-	svc := newClientApplicationService(appProvider)
-	vnetv1.RegisterClientApplicationServiceServer(grpcServer, svc)
+	vnetv1.RegisterClientApplicationServiceServer(grpcServer, p.clientApplicationService)
 
 	pm, processCtx := newProcessManager()
+	p.processManager = pm
 	pm.AddCriticalBackgroundTask("admin process", func() error {
 		log.InfoContext(processCtx, "Starting Windows service")
 		defer func() {
@@ -114,10 +111,11 @@ func runPlatformUserProcess(ctx context.Context, config *UserProcessConfig) (*Pr
 	})
 
 	select {
-	case nsi := <-svc.networkStackInfo:
-		return pm, nsi, nil
+	case nsi := <-p.clientApplicationService.networkStackInfo:
+		p.networkStackInfo = nsi
+		return nil
 	case <-processCtx.Done():
-		return nil, nil, trace.Wrap(pm.Wait(), "process manager exited before network stack info was received")
+		return trace.Wrap(pm.Wait(), "process manager exited before network stack info was received")
 	}
 }
 

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -581,9 +581,13 @@ func TestDialFakeApp(t *testing.T) {
 		},
 	}, dialOpts, reissueClientCert, clock)
 
+	clusterConfigCache := NewClusterConfigCache(clock)
 	p := newTestPack(t, ctx, testPackConfig{
-		clock:       clock,
-		appProvider: newLocalAppProvider(clientApp, clock),
+		clock: clock,
+		appProvider: newLocalAppProvider(&localAppProviderConfig{
+			clientApplication:  clientApp,
+			clusterConfigCache: clusterConfigCache,
+		}),
 	})
 
 	validTestCases := []struct {
@@ -825,9 +829,13 @@ func TestOnNewConnection(t *testing.T) {
 	validAppName := "echo1.root1.example.com"
 	invalidAppName := "not.an.app.example.com."
 
+	clusterConfigCache := NewClusterConfigCache(clock)
 	p := newTestPack(t, ctx, testPackConfig{
-		clock:       clock,
-		appProvider: newLocalAppProvider(clientApp, clock),
+		clock: clock,
+		appProvider: newLocalAppProvider(&localAppProviderConfig{
+			clientApplication:  clientApp,
+			clusterConfigCache: clusterConfigCache,
+		}),
 	})
 
 	// Attempt to establish a connection to an invalid app and verify that OnNewConnection was not
@@ -902,8 +910,15 @@ func testRemoteAppProvider(t *testing.T, alg cryptosuites.Algorithm) {
 		grpc.UnaryInterceptor(interceptors.GRPCServerUnaryErrorInterceptor),
 		grpc.StreamInterceptor(interceptors.GRPCServerStreamErrorInterceptor),
 	)
-	appProvider := newLocalAppProvider(clientApp, clock)
-	svc := newClientApplicationService(appProvider)
+	clusterConfigCache := NewClusterConfigCache(clock)
+	appProvider := newLocalAppProvider(&localAppProviderConfig{
+		clientApplication:  clientApp,
+		clusterConfigCache: clusterConfigCache,
+	})
+	svc := newClientApplicationService(&clientApplicationServiceConfig{
+		localAppProvider:      appProvider,
+		localOSConfigProvider: nil, // OS config is not needed for this test.
+	})
 	vnetv1.RegisterClientApplicationServiceServer(grpcServer, svc)
 	listener, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)


### PR DESCRIPTION
This PR prepares for the VNet SSH implementation with a relatively minor VNet process refactor that better enables shared caching of cluster `vnet_config`s and the list of leaf clusters (in the next PR).

Previously we had the `getTargetOSConfiguration`, which has nothing to do with apps, implemented on `localAppProvider` just because that was the easiest way to share the `ClusterConfigCache` it created. New components coming soon for SSH access will be better off sharing the `ClusterConfigCache` too so we're better off creating a single common cache for everything in the process. We should really be caching the list of leaf clusters for each root cluster too instead of calling an RPC to fetch that on every query, all add that cache in a following PR.

The other benefit here is teleterm no longer has its own duplicated logic for fetching the list of DNS zones and CIDR ranges, it now calls the exact same function the VNet process uses.