### PR TITLE
fix: unlock teleterm vnet mutex

### DIFF
--- a/lib/teleterm/vnet/service.go
+++ b/lib/teleterm/vnet/service.go
@@ -229,10 +229,11 @@ func (s *Service) ListDNSZones(ctx context.Context, req *api.ListDNSZonesRequest
 	s.mu.Lock()
 
 	if s.status != statusRunning {
+		s.mu.Unlock()
 		return nil, trace.CompareFailed("VNet is not running")
 	}
 
-	defer s.mu.Unlock()
+	s.mu.Unlock()
 
 	profileNames, err := s.cfg.DaemonService.ListProfileNames()
 	if err != nil {


### PR DESCRIPTION
This fixes a mutex bug I noticed while implementing https://github.com/gravitational/teleport/pull/54645, opening this in a separate PR for a hopefully quicker review process and easier backporting. I suspect it is very unlikely to hit the path where we actually fail to unlock the mutex since we probably won't call ListDNSZones while VNet is not running, so I don't believe a changelog is necessary. Removing the defer on the Unlock call at least better matches the intent in the comment above the Lock call.