### PR TITLE
[v16] ci: Pre-install wasm-bindgen on macos CI build

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -70,6 +70,17 @@ jobs:
 
       - name: Install wasm-pack
         run: |
+          BINDGEN_VERSION=$(\
+            cargo metadata --locked --format-version=1 | \
+            jq -r '[.packages[] | select(.name == "wasm-bindgen") | .version] | if length == 1 then .[0] else "NO VERSION" end' \
+          )
+          if [ "${BINDGEN_VERSION}" = 'NO VERSION' ]; then
+            echo 'Unknown bindgen version. Is it in Cargo.lock?'
+            exit 1
+          fi
+          # Install wasm-bindgen-cli so wasm-pack does not try to compile it itself.
+          # We have more control this way.
+          cargo install wasm-bindgen-cli --locked --version "${BINDGEN_VERSION}"
           cargo install wasm-pack --locked --version ${WASM_PACK_VERSION}
 
       - name: Build


### PR DESCRIPTION

Pre-install the correct version of `wasm-bindgen` in the
`build-macos.yaml` workflow when we install `wasm-pack`.

If `wasm-bindgen` is not installed when `wasm-pack` is run, it will
build it itself but do so without `--locked`. This ends up with "random"
versions of dependencies, some of which require a newer version of rust
than we have installed.

Backport: https://github.com/gravitational/teleport/pull/54647
