### PR TITLE
WMI: Enable Sigstore Integration

### DIFF
--- a/gen/preset-roles.json
+++ b/gen/preset-roles.json
@@ -1081,6 +1081,18 @@
               "update",
               "delete"
             ]
+          },
+          {
+            "resources": [
+              "sigstore_policy"
+            ],
+            "verbs": [
+              "list",
+              "create",
+              "read",
+              "update",
+              "delete"
+            ]
           }
         ]
       },

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -215,6 +215,7 @@ func NewPresetEditorRole() types.Role {
 					types.NewRule(types.KindGitServer, RW()),
 					types.NewRule(types.KindWorkloadIdentityX509Revocation, RW()),
 					types.NewRule(types.KindHealthCheckConfig, RW()),
+					types.NewRule(types.KindSigstorePolicy, RW()),
 				},
 			},
 		},


### PR DESCRIPTION
This PR ~~bumps the `e` dependency to get the Sigstore policy evaluator,~~ adds the `tctl` resource mappings and updates the editor role preset to allow editing `SigstorePolicy` resources.

changelog: Workload Identity: Sigstore Workload Attestation
