### PR TITLE
Make Access Request validator private

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -5234,7 +5234,7 @@ func (a *Server) CreateAccessRequestV2(ctx context.Context, req types.AccessRequ
 
 	// Always perform variable expansion on creation only; this ensures the
 	// access request that is reviewed is the same that is approved.
-	expandOpts := services.ExpandVars(true)
+	expandOpts := services.WithExpandVars(true)
 	if err := services.ValidateAccessRequestForUser(ctx, a.clock, a, req, identity, expandOpts); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -215,7 +215,7 @@ func CalculateAccessCapabilities(ctx context.Context, clock clockwork.Clock, clt
 	var caps types.AccessCapabilities
 	// all capabilities require use of a request validator.  calculating suggested reviewers
 	// requires that the validator be configured for variable expansion.
-	v, err := NewRequestValidator(ctx, clock, clt, req.User, ExpandVars(req.SuggestedReviewers))
+	v, err := newRequestValidator(ctx, clock, clt, req.User, WithExpandVars(req.SuggestedReviewers))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -232,14 +232,14 @@ func CalculateAccessCapabilities(ctx context.Context, clock clockwork.Clock, clt
 		if req.FilterRequestableRolesByResource {
 			resourceIDs = req.ResourceIDs
 		}
-		caps.RequestableRoles, err = v.GetRequestableRoles(ctx, identity, resourceIDs, req.Login)
+		caps.RequestableRoles, err = v.getRequestableRoles(ctx, identity, resourceIDs, req.Login)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
 
 	if req.SuggestedReviewers {
-		caps.SuggestedReviewers = v.SuggestedReviewers
+		caps.SuggestedReviewers = v.suggestedReviewers
 	}
 
 	caps.RequireReason, err = v.calcRequireReasonCap(ctx, req, caps)
@@ -252,7 +252,7 @@ func CalculateAccessCapabilities(ctx context.Context, clock clockwork.Clock, clt
 	return &caps, nil
 }
 
-func (v *RequestValidator) calcRequireReasonCap(ctx context.Context, req types.AccessCapabilitiesRequest, caps types.AccessCapabilities) (requireReason bool, err error) {
+func (v *requestValidator) calcRequireReasonCap(ctx context.Context, req types.AccessCapabilitiesRequest, caps types.AccessCapabilities) (requireReason bool, err error) {
 	var roles []string
 	if req.RequestableRoles {
 		roles = caps.RequestableRoles
@@ -271,10 +271,10 @@ func (v *RequestValidator) calcRequireReasonCap(ctx context.Context, req types.A
 // allowedSearchAsRoles returns all allowed `allow.request.search_as_roles` for the user that are
 // not in the `deny.request.search_as_roles`. It does not filter out any roles that should not be
 // allowed based on requests.
-func (m *RequestValidator) allowedSearchAsRoles() ([]string, error) {
+func (m *requestValidator) allowedSearchAsRoles() ([]string, error) {
 	var rolesToRequest []string
-	for _, roleName := range m.Roles.AllowSearch {
-		if !m.CanSearchAsRole(roleName) {
+	for _, roleName := range m.roles.allowSearch {
+		if !m.canSearchAsRole(roleName) {
 			continue
 		}
 		rolesToRequest = append(rolesToRequest, roleName)
@@ -290,7 +290,7 @@ func (m *RequestValidator) allowedSearchAsRoles() ([]string, error) {
 // applicable for the given list of resourceIDs.
 //
 // If loginHint is provided, it will attempt to prune the list to a single role.
-func (m *RequestValidator) applicableSearchAsRoles(ctx context.Context, resourceIDs []types.ResourceID, loginHint string) ([]string, error) {
+func (m *requestValidator) applicableSearchAsRoles(ctx context.Context, resourceIDs []types.ResourceID, loginHint string) ([]string, error) {
 	rolesToRequest, err := m.allowedSearchAsRoles()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1022,13 +1022,14 @@ func (c *ReviewPermissionChecker) push(role types.Role) error {
 	return nil
 }
 
-// RequestValidator a helper for validating access requests.
+// requestValidator a helper for validating access requests.
 // a user's statically assigned roles are "added" to the
 // validator via the push() method, which extracts all the
 // relevant rules, performs variable substitutions, and builds
 // a set of simple Allow/Deny datastructures.  These, in turn,
 // are used to validate and expand the access request.
-type RequestValidator struct {
+type requestValidator struct {
+	logger    *slog.Logger
 	clock     clockwork.Clock
 	getter    RequestValidatorGetter
 	userState UserState
@@ -1059,57 +1060,54 @@ type RequestValidator struct {
 	}
 	autoRequest bool
 	prompt      string
-	opts        struct {
-		expandVars bool
+	opts        ValidateRequestOptions
+	roles       struct {
+		allowRequest, denyRequest []parse.Matcher
+		allowSearch, denySearch   []string
 	}
-	Roles struct {
-		AllowRequest, DenyRequest []parse.Matcher
-		AllowSearch, DenySearch   []string
-	}
-	Annotations struct {
-		// Allowed annotations are not greedy, the role that defines the annotation must allow requesting one
+	annotations struct {
+		// allow annotations are not greedy, the role that defines the annotation must allow requesting one
 		// of the roles that are being requested in order for the annotation to be applied.
-		Allow map[singleAnnotation]annotationMatcher
-		// Denied annotations match greedily, if a user has any role that denies a specific annotation it will
+		allow map[singleAnnotation]annotationMatcher
+		// deny annotations match greedily, if a user has any role that denies a specific annotation it will
 		// always be denied.
-		Deny map[singleAnnotation]struct{}
+		deny map[singleAnnotation]struct{}
 	}
-	ThresholdMatchers []struct {
-		Matchers   []parse.Matcher
-		Thresholds []types.AccessReviewThreshold
+	thresholdMatchers []struct {
+		matchers   []parse.Matcher
+		thresholds []types.AccessReviewThreshold
 	}
-	SuggestedReviewers  []string
-	MaxDurationMatchers []struct {
-		Matchers    []parse.Matcher
-		MaxDuration time.Duration
+	suggestedReviewers  []string
+	maxDurationMatchers []struct {
+		matchers    []parse.Matcher
+		maxDuration time.Duration
 	}
-	logger *slog.Logger
 }
 
-// NewRequestValidator configures a new RequestValidator for the specified user.
-func NewRequestValidator(ctx context.Context, clock clockwork.Clock, getter RequestValidatorGetter, username string, opts ...ValidateRequestOption) (RequestValidator, error) {
+// newRequestValidator configures a new RequestValidator for the specified user.
+func newRequestValidator(ctx context.Context, clock clockwork.Clock, getter RequestValidatorGetter, username string, opts ...ValidateRequestOption) (requestValidator, error) {
 	uls, err := GetUserOrLoginState(ctx, getter, username)
 	if err != nil {
-		return RequestValidator{}, trace.Wrap(err)
+		return requestValidator{}, trace.Wrap(err)
 	}
 
-	m := RequestValidator{
+	m := requestValidator{
+		logger:    slog.With(teleport.ComponentKey, "request.validator"),
 		clock:     clock,
 		getter:    getter,
 		userState: uls,
-		logger:    slog.With(teleport.ComponentKey, "request.validator"),
 
 		requiringReasonRoles: make(map[string]struct{}),
 	}
 	for _, opt := range opts {
-		opt(&m)
+		opt(&m.opts)
 	}
 	if m.opts.expandVars {
 		// validation process for incoming access requests requires
 		// generating system annotations to be attached to the request
 		// before it is inserted into the backend.
-		m.Annotations.Allow = make(map[singleAnnotation]annotationMatcher)
-		m.Annotations.Deny = make(map[singleAnnotation]struct{})
+		m.annotations.allow = make(map[singleAnnotation]annotationMatcher)
+		m.annotations.deny = make(map[singleAnnotation]struct{})
 	}
 
 	m.kubernetesResource.allow = make(map[string][]types.RequestKubernetesResource)
@@ -1119,18 +1117,18 @@ func NewRequestValidator(ctx context.Context, clock clockwork.Clock, getter Requ
 	for _, roleName := range m.userState.GetRoles() {
 		role, err := m.getter.GetRole(ctx, roleName)
 		if err != nil {
-			return RequestValidator{}, trace.Wrap(err)
+			return requestValidator{}, trace.Wrap(err)
 		}
 		if err := m.push(ctx, role); err != nil {
-			return RequestValidator{}, trace.Wrap(err)
+			return requestValidator{}, trace.Wrap(err)
 		}
 	}
 	return m, nil
 }
 
-// Validate validates an access request and potentially modifies it depending on how
+// validate validates an access request and potentially modifies it depending on how
 // the validator was configured.
-func (m *RequestValidator) Validate(ctx context.Context, req types.AccessRequest, identity tlsca.Identity) error {
+func (m *requestValidator) validate(ctx context.Context, req types.AccessRequest, identity tlsca.Identity) error {
 	if m.userState.GetName() != req.GetUser() {
 		return trace.BadParameter("request validator configured for different user (this is a bug)")
 	}
@@ -1156,7 +1154,7 @@ func (m *RequestValidator) Validate(ctx context.Context, req types.AccessRequest
 			return trace.BadParameter("unexpected wildcard request (this is a bug)")
 		}
 
-		requestable, err := m.GetRequestableRoles(ctx, identity, nil, "")
+		requestable, err := m.getRequestableRoles(ctx, identity, nil, "")
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -1182,14 +1180,14 @@ func (m *RequestValidator) Validate(ctx context.Context, req types.AccessRequest
 	// verify that all requested roles are permissible
 	for _, roleName := range req.GetRoles() {
 		if len(req.GetRequestedResourceIDs()) > 0 {
-			if !m.CanSearchAsRole(roleName) {
+			if !m.canSearchAsRole(roleName) {
 				// Roles are normally determined automatically for resource
 				// access requests, this role must have been explicitly
 				// requested, or a new deny rule has since been added.
 				return trace.BadParameter("user %q can not request role %q", req.GetUser(), roleName)
 			}
 		} else {
-			if !m.CanRequestRole(roleName) {
+			if !m.canRequestRole(roleName) {
 				return trace.BadParameter("user %q can not request role %q", req.GetUser(), roleName)
 			}
 		}
@@ -1257,7 +1255,7 @@ func (m *RequestValidator) Validate(ctx context.Context, req types.AccessRequest
 		// incoming requests must have system annotations attached
 		// before being inserted into the backend. this is how the
 		// RBAC system propagates sideband information to plugins.
-		systemAnnotations, err := m.SystemAnnotations(req)
+		systemAnnotations, err := m.systemAnnotations(req)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -1266,7 +1264,7 @@ func (m *RequestValidator) Validate(ctx context.Context, req types.AccessRequest
 		// if no suggested reviewers were provided by the user, then
 		// use the defaults suggested by the user's static roles.
 		if len(req.GetSuggestedReviewers()) == 0 {
-			req.SetSuggestedReviewers(apiutils.Deduplicate(m.SuggestedReviewers))
+			req.SetSuggestedReviewers(apiutils.Deduplicate(m.suggestedReviewers))
 		}
 
 		// Pin the time to the current time to prevent time drift.
@@ -1325,7 +1323,7 @@ func (m *RequestValidator) Validate(ctx context.Context, req types.AccessRequest
 }
 
 // isReasonRequired checks if the reason is required for the given roles and resource IDs.
-func (v *RequestValidator) isReasonRequired(ctx context.Context, requestedRoles []string, requestedResourceIDs []types.ResourceID) (required bool, explanation string, err error) {
+func (v *requestValidator) isReasonRequired(ctx context.Context, requestedRoles []string, requestedResourceIDs []types.ResourceID) (required bool, explanation string, err error) {
 	if v.requireReasonForAllRoles {
 		return true, "request reason must be specified (required request_access option in one of the roles)", nil
 	}
@@ -1356,7 +1354,7 @@ func (v *RequestValidator) isReasonRequired(ctx context.Context, requestedRoles 
 // calculateMaxAccessDuration calculates the maximum time for the access request.
 // The max duration time is the minimum of the max_duration time set on the request
 // and the max_duration time set on the request role.
-func (m *RequestValidator) calculateMaxAccessDuration(req types.AccessRequest, sessionTTL time.Duration) (time.Duration, error) {
+func (m *requestValidator) calculateMaxAccessDuration(req types.AccessRequest, sessionTTL time.Duration) (time.Duration, error) {
 	// Check if the maxDuration time is set.
 	maxDurationTime := req.GetMaxDuration()
 	maxDuration := maxDurationTime.Sub(req.GetCreationTime())
@@ -1397,13 +1395,13 @@ func (m *RequestValidator) calculateMaxAccessDuration(req types.AccessRequest, s
 	return minAdjDuration, nil
 }
 
-func (m *RequestValidator) maxDurationForRole(roleName string) time.Duration {
+func (m *requestValidator) maxDurationForRole(roleName string) time.Duration {
 	var maxDurationForRole time.Duration
-	for _, tms := range m.MaxDurationMatchers {
-		for _, matcher := range tms.Matchers {
+	for _, tms := range m.maxDurationMatchers {
+		for _, matcher := range tms.matchers {
 			if matcher.Match(roleName) {
-				if tms.MaxDuration > maxDurationForRole {
-					maxDurationForRole = tms.MaxDuration
+				if tms.maxDuration > maxDurationForRole {
+					maxDurationForRole = tms.maxDuration
 				}
 			}
 		}
@@ -1414,7 +1412,7 @@ func (m *RequestValidator) maxDurationForRole(roleName string) time.Duration {
 // calculatePendingRequestTTL calculates the TTL of the Access Request (how long it will await
 // approval). request TTL is capped to the smaller value between the const requestTTL and the
 // access request access expiry.
-func (m *RequestValidator) calculatePendingRequestTTL(r types.AccessRequest, now time.Time) (time.Duration, error) {
+func (m *requestValidator) calculatePendingRequestTTL(r types.AccessRequest, now time.Time) (time.Duration, error) {
 	accessExpiryTTL := r.GetAccessExpiry().Sub(now)
 
 	// If no expiration provided, use default.
@@ -1450,7 +1448,7 @@ func (m *RequestValidator) calculatePendingRequestTTL(r types.AccessRequest, now
 
 // sessionTTL calculates the TTL of the elevated certificate that will be issued
 // if the Access Request is approved.
-func (m *RequestValidator) sessionTTL(ctx context.Context, identity tlsca.Identity, r types.AccessRequest, now time.Time) (time.Duration, error) {
+func (m *requestValidator) sessionTTL(ctx context.Context, identity tlsca.Identity, r types.AccessRequest, now time.Time) (time.Duration, error) {
 	ttl, err := m.truncateTTL(ctx, identity, r.GetAccessExpiry(), r.GetRoles(), now)
 	if err != nil {
 		return 0, trace.BadParameter("invalid session TTL: %v", err)
@@ -1469,7 +1467,7 @@ func (m *RequestValidator) sessionTTL(ctx context.Context, identity tlsca.Identi
 
 // truncateTTL will truncate given expiration by identity expiration and
 // shortest session TTL of any role.
-func (m *RequestValidator) truncateTTL(ctx context.Context, identity tlsca.Identity, expiry time.Time, roles []string, now time.Time) (time.Duration, error) {
+func (m *requestValidator) truncateTTL(ctx context.Context, identity tlsca.Identity, expiry time.Time, roles []string, now time.Time) (time.Duration, error) {
 	ttl := apidefaults.MaxCertDuration
 
 	// Reduce by remaining TTL on requesting certificate (identity).
@@ -1504,23 +1502,23 @@ func (m *RequestValidator) truncateTTL(ctx context.Context, identity tlsca.Ident
 
 // getResourceViewingRoles gets the subset of the user's roles that could be used
 // to view resources (i.e., base roles + search as roles).
-func (m *RequestValidator) getResourceViewingRoles() []string {
+func (m *requestValidator) getResourceViewingRoles() []string {
 	roles := slices.Clone(m.userState.GetRoles())
-	for _, role := range m.Roles.AllowSearch {
-		if m.CanSearchAsRole(role) {
+	for _, role := range m.roles.allowSearch {
+		if m.canSearchAsRole(role) {
 			roles = append(roles, role)
 		}
 	}
 	return apiutils.Deduplicate(roles)
 }
 
-// GetRequestableRoles gets the list of all existent roles which the user is
+// getRequestableRoles gets the list of all existent roles which the user is
 // able to request.  This operation is expensive since it loads all existent
 // roles to determine the role list.  Prefer calling CanRequestRole
 // when checking against a known role list. If resource IDs or a login hints
 // are provided, roles will be filtered to only include those that would
 // allow access to the given resource with the given login.
-func (m *RequestValidator) GetRequestableRoles(ctx context.Context, identity tlsca.Identity, resourceIDs []types.ResourceID, loginHint string) ([]string, error) {
+func (m *requestValidator) getRequestableRoles(ctx context.Context, identity tlsca.Identity, resourceIDs []types.ResourceID, loginHint string) ([]string, error) {
 	allRoles, err := m.getter.GetRoles(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1556,7 +1554,7 @@ func (m *RequestValidator) GetRequestableRoles(ctx context.Context, identity tls
 	var expanded []string
 	for _, role := range allRoles {
 		n := role.GetName()
-		if slices.Contains(m.userState.GetRoles(), n) || !m.CanRequestRole(n) {
+		if slices.Contains(m.userState.GetRoles(), n) || !m.canRequestRole(n) {
 			continue
 		}
 
@@ -1605,7 +1603,7 @@ func setAllowRequestKubeResourceLookup(allowKubernetesResources []types.RequestK
 // push compiles a role's configuration into the request validator.
 // All of the requesting user's statically assigned roles must be pushed
 // before validation begins.
-func (m *RequestValidator) push(ctx context.Context, role types.Role) error {
+func (m *requestValidator) push(ctx context.Context, role types.Role) error {
 	var err error
 
 	m.requireReasonForAllRoles = m.requireReasonForAllRoles || role.GetOptions().RequestAccess.RequireReason()
@@ -1631,27 +1629,27 @@ func (m *RequestValidator) push(ctx context.Context, role types.Role) error {
 		m.kubernetesResource.deny = append(m.kubernetesResource.deny, deny.KubernetesResources...)
 	}
 
-	m.Roles.DenyRequest, err = appendRoleMatchers(m.Roles.DenyRequest, deny.Roles, deny.ClaimsToRoles, m.userState.GetTraits())
+	m.roles.denyRequest, err = appendRoleMatchers(m.roles.denyRequest, deny.Roles, deny.ClaimsToRoles, m.userState.GetTraits())
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	// record what will be the starting index of the allow and deny matchers for this role, if it applies any.
-	astart := len(m.Roles.AllowRequest)
+	astart := len(m.roles.allowRequest)
 
-	m.Roles.AllowRequest, err = appendRoleMatchers(m.Roles.AllowRequest, allow.Roles, allow.ClaimsToRoles, m.userState.GetTraits())
+	m.roles.allowRequest, err = appendRoleMatchers(m.roles.allowRequest, allow.Roles, allow.ClaimsToRoles, m.userState.GetTraits())
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	m.Roles.AllowSearch = apiutils.Deduplicate(append(m.Roles.AllowSearch, allow.SearchAsRoles...))
-	m.Roles.DenySearch = apiutils.Deduplicate(append(m.Roles.DenySearch, deny.SearchAsRoles...))
+	m.roles.allowSearch = apiutils.Deduplicate(append(m.roles.allowSearch, allow.SearchAsRoles...))
+	m.roles.denySearch = apiutils.Deduplicate(append(m.roles.denySearch, deny.SearchAsRoles...))
 
 	if m.opts.expandVars {
 		// if this role added additional allow matchers, then we need to record the relationship
 		// between its matchers and its thresholds. This information is used later to calculate
 		// the rtm and threshold list.
-		newAllowRequestMatchers := m.Roles.AllowRequest[astart:]
+		newAllowRequestMatchers := m.roles.allowRequest[astart:]
 		newAllowSearchMatchers := literalMatchers(allow.SearchAsRoles)
 
 		allNewAllowMatchers := make([]parse.Matcher, 0, len(newAllowRequestMatchers)+len(newAllowSearchMatchers))
@@ -1659,22 +1657,22 @@ func (m *RequestValidator) push(ctx context.Context, role types.Role) error {
 		allNewAllowMatchers = append(allNewAllowMatchers, newAllowSearchMatchers...)
 
 		if len(allNewAllowMatchers) > 0 {
-			m.ThresholdMatchers = append(m.ThresholdMatchers, struct {
-				Matchers   []parse.Matcher
-				Thresholds []types.AccessReviewThreshold
+			m.thresholdMatchers = append(m.thresholdMatchers, struct {
+				matchers   []parse.Matcher
+				thresholds []types.AccessReviewThreshold
 			}{
-				Matchers:   allNewAllowMatchers,
-				Thresholds: allow.Thresholds,
+				matchers:   allNewAllowMatchers,
+				thresholds: allow.Thresholds,
 			})
 		}
 
 		if allow.MaxDuration != 0 {
-			m.MaxDurationMatchers = append(m.MaxDurationMatchers, struct {
-				Matchers    []parse.Matcher
-				MaxDuration time.Duration
+			m.maxDurationMatchers = append(m.maxDurationMatchers, struct {
+				matchers    []parse.Matcher
+				maxDuration time.Duration
 			}{
-				Matchers:    allNewAllowMatchers,
-				MaxDuration: allow.MaxDuration.Duration(),
+				matchers:    allNewAllowMatchers,
+				maxDuration: allow.MaxDuration.Duration(),
 			})
 		}
 
@@ -1684,7 +1682,7 @@ func (m *RequestValidator) push(ctx context.Context, role types.Role) error {
 		m.insertAllowedAnnotations(ctx, allow, newAllowRequestMatchers, newAllowSearchMatchers)
 		m.insertDeniedAnnotations(ctx, deny)
 
-		m.SuggestedReviewers = append(m.SuggestedReviewers, allow.SuggestedReviewers...)
+		m.suggestedReviewers = append(m.suggestedReviewers, allow.SuggestedReviewers...)
 	}
 	return nil
 }
@@ -1692,7 +1690,7 @@ func (m *RequestValidator) push(ctx context.Context, role types.Role) error {
 // setRolesForResourceRequest determines if the given access request is
 // resource-based, and if so, it determines which underlying roles are necessary
 // and adds them to the request.
-func (m *RequestValidator) setRolesForResourceRequest(ctx context.Context, req types.AccessRequest) error {
+func (m *requestValidator) setRolesForResourceRequest(ctx context.Context, req types.AccessRequest) error {
 	if !m.opts.expandVars {
 		// Don't set the roles if expandVars is not set, they have probably
 		// already been set and we are just validating the request.
@@ -1722,7 +1720,7 @@ func (m *RequestValidator) setRolesForResourceRequest(ctx context.Context, req t
 //
 // Returns pruned roles, and a map of requested roles with allowed kinds (with denied applied), used to help aid user in case a request gets rejected,
 // lets user know which kinds are allowed for each requested roles.
-func (m *RequestValidator) pruneRequestedRolesNotMatchingKubernetesResourceKinds(requestedResourceIDs []types.ResourceID, requestedRoles []string) ([]string, map[string][]string) {
+func (m *requestValidator) pruneRequestedRolesNotMatchingKubernetesResourceKinds(requestedResourceIDs []types.ResourceID, requestedRoles []string) ([]string, map[string][]string) {
 	// Filter for the kube_cluster and its subresource kinds.
 	requestedKubeKinds := make(map[string]struct{})
 	for _, resourceID := range requestedResourceIDs {
@@ -1835,14 +1833,14 @@ func (c *thresholdCollector) pushThreshold(t types.AccessReviewThreshold) (uint3
 	return uint32(len(c.Thresholds) - 1), nil
 }
 
-// CanRequestRole checks if a given role can be requested.
-func (m *RequestValidator) CanRequestRole(name string) bool {
-	for _, deny := range m.Roles.DenyRequest {
+// canRequestRole checks if a given role can be requested.
+func (m *requestValidator) canRequestRole(name string) bool {
+	for _, deny := range m.roles.denyRequest {
 		if deny.Match(name) {
 			return false
 		}
 	}
-	for _, allow := range m.Roles.AllowRequest {
+	for _, allow := range m.roles.allowRequest {
 		if allow.Match(name) {
 			return true
 		}
@@ -1850,30 +1848,30 @@ func (m *RequestValidator) CanRequestRole(name string) bool {
 	return false
 }
 
-// CanSearchAsRole check if a given role can be requested through a search-based
+// canSearchAsRole check if a given role can be requested through a search-based
 // access request
-func (m *RequestValidator) CanSearchAsRole(name string) bool {
-	if slices.Contains(m.Roles.DenySearch, name) {
+func (m *requestValidator) canSearchAsRole(name string) bool {
+	if slices.Contains(m.roles.denySearch, name) {
 		return false
 	}
-	for _, deny := range m.Roles.DenyRequest {
+	for _, deny := range m.roles.denyRequest {
 		if deny.Match(name) {
 			return false
 		}
 	}
-	return slices.Contains(m.Roles.AllowSearch, name)
+	return slices.Contains(m.roles.allowSearch, name)
 }
 
 // collectSetsForRole collects the threshold index sets which describe the various groups of
 // thresholds which must pass in order for a request for the given role to be approved.
-func (m *RequestValidator) collectSetsForRole(c *thresholdCollector, role string) ([]types.ThresholdIndexSet, error) {
+func (m *requestValidator) collectSetsForRole(c *thresholdCollector, role string) ([]types.ThresholdIndexSet, error) {
 	var sets []types.ThresholdIndexSet
 
 Outer:
-	for _, tms := range m.ThresholdMatchers {
-		for _, matcher := range tms.Matchers {
+	for _, tms := range m.thresholdMatchers {
+		for _, matcher := range tms.matchers {
 			if matcher.Match(role) {
-				set, err := c.push(tms.Thresholds)
+				set, err := c.push(tms.thresholds)
 				if err != nil {
 					return nil, trace.Wrap(err)
 				}
@@ -1931,7 +1929,7 @@ func (m *annotationMatcher) matchesRequest(req types.AccessRequest) bool {
 //
 // Annotations are only applied to access requests requests when one of the requested roles matches one of the
 // role matchers.
-func (m *RequestValidator) insertAllowedAnnotations(ctx context.Context, conditions types.AccessRequestConditions, roleRequestMatchers, resourceRequestMatchers []parse.Matcher) {
+func (m *requestValidator) insertAllowedAnnotations(ctx context.Context, conditions types.AccessRequestConditions, roleRequestMatchers, resourceRequestMatchers []parse.Matcher) {
 	for annotationKey, annotationValueTemplates := range conditions.Annotations {
 		// iterate through all new values and expand any
 		// variable interpolation syntax they contain.
@@ -1945,10 +1943,10 @@ func (m *RequestValidator) insertAllowedAnnotations(ctx context.Context, conditi
 			}
 			for _, expanded := range expandedValues {
 				annotation := singleAnnotation{annotationKey, expanded}
-				matchers := m.Annotations.Allow[annotation]
+				matchers := m.annotations.allow[annotation]
 				matchers.roleRequestMatchers = append(matchers.roleRequestMatchers, roleRequestMatchers...)
 				matchers.resourceRequestMatchers = append(matchers.resourceRequestMatchers, resourceRequestMatchers...)
-				m.Annotations.Allow[annotation] = matchers
+				m.annotations.allow[annotation] = matchers
 			}
 		}
 	}
@@ -1956,7 +1954,7 @@ func (m *RequestValidator) insertAllowedAnnotations(ctx context.Context, conditi
 
 // insertDeniedAnnotations constructs all denied annotations for a given AccessRequestConditions instance
 // from one of the users current roles and adds them to the denied annotations set.
-func (m *RequestValidator) insertDeniedAnnotations(ctx context.Context, conditions types.AccessRequestConditions) {
+func (m *requestValidator) insertDeniedAnnotations(ctx context.Context, conditions types.AccessRequestConditions) {
 	for annotationKey, annotationValueTemplates := range conditions.Annotations {
 		// iterate through all new values and expand any
 		// variable interpolation syntax they contain.
@@ -1970,19 +1968,19 @@ func (m *RequestValidator) insertDeniedAnnotations(ctx context.Context, conditio
 			}
 			for _, expanded := range expandedValues {
 				annotation := singleAnnotation{annotationKey, expanded}
-				m.Annotations.Deny[annotation] = struct{}{}
+				m.annotations.deny[annotation] = struct{}{}
 			}
 		}
 	}
 }
 
-// SystemAnnotations calculates the system annotations for a pending
+// systemAnnotations calculates the system annotations for a pending
 // access request.
-func (m *RequestValidator) SystemAnnotations(req types.AccessRequest) (map[string][]string, error) {
+func (m *requestValidator) systemAnnotations(req types.AccessRequest) (map[string][]string, error) {
 	annotations := make(map[string][]string)
 
-	for annotation, allowMatchers := range m.Annotations.Allow {
-		if _, denied := m.Annotations.Deny[annotation]; denied {
+	for annotation, allowMatchers := range m.annotations.allow {
+		if _, denied := m.annotations.deny[annotation]; denied {
 			// Deny matches are greedy, if any of the users roles denies this annotation it is filtered out.
 			continue
 		}
@@ -2002,28 +2000,32 @@ func (m *RequestValidator) SystemAnnotations(req types.AccessRequest) (map[strin
 	return annotations, nil
 }
 
-type ValidateRequestOption func(*RequestValidator)
+type ValidateRequestOptions struct {
+	expandVars bool
+}
 
-// ExpandVars toggles variable expansion during request validation.  Variable expansion includes
+type ValidateRequestOption func(*ValidateRequestOptions)
+
+// WithExpandVars toggles variable expansion during request validation.  Variable expansion includes
 // expanding wildcard requests, setting system annotations, finding applicable roles for
 // resource-based requests and gathering threshold information.  Variable expansion should be run
 // by the auth server prior to storing an access request for the first time.
-func ExpandVars(expand bool) ValidateRequestOption {
-	return func(v *RequestValidator) {
-		v.opts.expandVars = expand
+func WithExpandVars(expandVars bool) ValidateRequestOption {
+	return func(v *ValidateRequestOptions) {
+		v.expandVars = expandVars
 	}
 }
 
 // ValidateAccessRequestForUser validates an access request against the associated users's
-// *statically assigned* roles. If [[ExpandVars]] is set to true, it will also expand wildcard
+// *statically assigned* roles. If [[WithExpandVars]] is set to true, it will also expand wildcard
 // requests, setting their role list to include all roles the user is allowed to request.
 // Expansion should be performed before an access request is initially placed in the backend.
 func ValidateAccessRequestForUser(ctx context.Context, clock clockwork.Clock, getter RequestValidatorGetter, req types.AccessRequest, identity tlsca.Identity, opts ...ValidateRequestOption) error {
-	v, err := NewRequestValidator(ctx, clock, getter, req.GetUser(), opts...)
+	v, err := newRequestValidator(ctx, clock, getter, req.GetUser(), opts...)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return trace.Wrap(v.Validate(ctx, req, identity))
+	return trace.Wrap(v.validate(ctx, req, identity))
 }
 
 // UnmarshalAccessRequest unmarshals the AccessRequest resource from JSON.
@@ -2116,7 +2118,7 @@ func getInvalidKubeKindAccessRequestsError(mappedRequestedRolesToAllowedKinds ma
 // resource is in a leaf cluster.
 //
 // If loginHint is provided, it will attempt to prune the list to a single role.
-func (m *RequestValidator) pruneResourceRequestRoles(
+func (m *requestValidator) pruneResourceRequestRoles(
 	ctx context.Context,
 	resourceIDs []types.ResourceID,
 	loginHint string,
@@ -2288,7 +2290,7 @@ func getAllowedKubeResourceKinds(allowedKinds []string, deniedKinds []string) []
 	return slices.Collect(maps.Keys(allowed))
 }
 
-func (m *RequestValidator) roleAllowsResource(
+func (m *requestValidator) roleAllowsResource(
 	role types.Role,
 	resource types.ResourceWithLabels,
 	loginHint string,
@@ -2318,7 +2320,7 @@ func (m *RequestValidator) roleAllowsResource(
 // requested access. Except for resource Kinds present in types.KubernetesResourcesKinds,
 // the underlying resources are the same as requested. If the resource requested
 // is a Kubernetes resource, we return the underlying Kubernetes cluster.
-func (m *RequestValidator) getUnderlyingResourcesByResourceIDs(ctx context.Context, resourceIDs []types.ResourceID) ([]types.ResourceWithLabels, error) {
+func (m *requestValidator) getUnderlyingResourcesByResourceIDs(ctx context.Context, resourceIDs []types.ResourceID) ([]types.ResourceWithLabels, error) {
 	if len(resourceIDs) == 0 {
 		return []types.ResourceWithLabels{}, nil
 	}

--- a/tool/tctl/common/access_request_command.go
+++ b/tool/tctl/common/access_request_command.go
@@ -332,7 +332,7 @@ func (c *AccessRequestCommand) Create(ctx context.Context, client *authclient.Cl
 			Client:                client,
 			UserLoginStatesGetter: client.UserLoginStateClient(),
 		}
-		err = services.ValidateAccessRequestForUser(ctx, clockwork.NewRealClock(), users, req, tlsca.Identity{}, services.ExpandVars(true))
+		err = services.ValidateAccessRequestForUser(ctx, clockwork.NewRealClock(), users, req, tlsca.Identity{}, services.WithExpandVars(true))
 		if err != nil {
 			return trace.Wrap(err)
 		}


### PR DESCRIPTION
Changes:

- RequestValidator -> requestValidator
- requestValidator.opts are now typed as a public struct. This is for ValidateAccessRequestForUser godoc
- made all fields private - there was probably some convention at the beginning but it seems to be lost and it feels more confusing than anything
- NewRequestValidator -> newRequestValidator
- GetRequestableRoles -> getRequestableRoles
- CanSearchAsRole -> canSearchAsRole
- CanRequestRole -> canRequestRole
- SystemAnnotations -> systemAnnotations
- ExpandVars -> WithExpandVars (I'm adding WithDryRun in a subsequent PR and DryRun looks strange)