### PR TITLE
Update `(*TunnelConnectionV2) Clone` to do a full copy

### DIFF
--- a/api/types/tunnelconn.go
+++ b/api/types/tunnelconn.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/utils"
 )
 
 // TunnelConnection is SSH reverse tunnel connection
@@ -97,8 +98,7 @@ func (r *TunnelConnectionV2) SetRevision(rev string) {
 
 // Clone returns a copy of this tunnel connection
 func (r *TunnelConnectionV2) Clone() TunnelConnection {
-	out := *r
-	return &out
+	return utils.CloneProtoMsg(r)
 }
 
 // String returns user-friendly description of this connection


### PR DESCRIPTION
The shallow clone has always been liable to cause races but only started to become an issue after the TunnelConnection resource was converted to the new caching machinery which relies on said clone function to create unique copies.

Closes https://github.com/gravitational/teleport/issues/54655.