### PR TITLE
Implement shared directory file system in tsh daemon 

### DIFF
--- a/lib/teleterm/services/desktop/directorysharing.go
+++ b/lib/teleterm/services/desktop/directorysharing.go
@@ -161,30 +161,29 @@ func (s *DirectoryAccess) ReadDir(relativePath string) ([]*FileOrDirInfo, error)
 	return results, nil
 }
 
-// Read reads a slice of a file.
-func (s *DirectoryAccess) Read(relativePath string, offset int64, length uint32) ([]byte, error) {
+// Read reads a slice of a file into buf. Returns the number of read bytes.
+func (s *DirectoryAccess) Read(relativePath string, offset int64, buf []byte) (int, error) {
 	path, err := s.getSafePath(relativePath)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return 0, trace.Wrap(err)
 	}
 
 	opened, err := os.Open(path)
 	if err != nil {
-		return nil, err
+		return 0, trace.Wrap(err)
 	}
 	defer opened.Close()
 
-	buf := make([]byte, length)
 	_, err = opened.Seek(offset, io.SeekStart)
 	if err != nil {
-		return nil, err
+		return 0, trace.Wrap(err)
 	}
 
 	n, err := opened.Read(buf)
 	if err != nil && !errors.Is(err, io.EOF) {
-		return nil, trace.Wrap(err)
+		return 0, trace.Wrap(err)
 	}
-	return buf[:n], nil
+	return n, nil
 }
 
 // Write writes data to a file at a given offset.

--- a/lib/teleterm/services/desktop/directorysharing.go
+++ b/lib/teleterm/services/desktop/directorysharing.go
@@ -1,0 +1,296 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package desktop
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gravitational/trace"
+)
+
+// DirectoryAccess allows access to the shared directory.
+// Should be kept in sync with web/packages/shared/libs/tdp/sharedDirectoryAccess.ts
+// where FS events are handled for Web UI.
+type DirectoryAccess struct {
+	// safePathGetter allows building a safe path by joining the shared directory path
+	// and a relative path.
+	// The shared directory path is not exposed to avoid unsafe operations.
+	//
+	// TODO(gzdunek): This code can be greatly simplified with os.OpenRoot.
+	// Switch to it when branch/v17 is updated to Go 1.24.
+	safePathGetter func(relativePath string) (string, error)
+}
+
+// FileOrDirInfo contains metadata about a file or a directory.
+type FileOrDirInfo struct {
+	Size         int64
+	LastModified int64
+	FileType     FileType // "file" or "directory"
+	IsEmpty      bool
+	Path         string
+}
+
+type FileType uint32
+
+const (
+	FileTypeFile FileType = iota
+	FileTypeDir
+)
+
+const StandardDirSize = 4096
+
+func (s *DirectoryAccess) Open(baseDir string) error {
+	if s.safePathGetter != nil {
+		return errors.New("only one shared directory is supported")
+	}
+
+	base, err := filepath.EvalSymlinks(baseDir)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	stat, err := os.Stat(base)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if !stat.IsDir() {
+		return trace.BadParameter("%q is not a directory", baseDir)
+	}
+
+	s.safePathGetter = func(relativePath string) (string, error) {
+		full := filepath.Join(base, relativePath)
+		resolved, err := filepath.EvalSymlinks(full)
+		if err != nil {
+			// EvalSymlinks returns an error if the target file does not exist.
+			// In that case, attempt to resolve the symlinks of the parent directory instead.
+			if os.IsNotExist(err) {
+				parent := filepath.Dir(full)
+				resolvedParent, perr := filepath.EvalSymlinks(parent)
+				if perr != nil {
+					return "", trace.Wrap(perr)
+				}
+
+				// Reconstruct the full path by joining the resolved parent with the original file name.
+				resolved = filepath.Join(resolvedParent, filepath.Base(full))
+			} else {
+				return "", trace.Wrap(err)
+			}
+		}
+		if !isSubPath(base, resolved) {
+			return "", trace.BadParameter("path escapes from parent")
+		}
+		return resolved, nil
+	}
+	return nil
+}
+
+func isSubPath(parent, child string) bool {
+	return child == parent || strings.HasPrefix(child, parent+string(filepath.Separator))
+}
+
+// Stat retrieves metadata about a file or directory at the given path.
+func (s *DirectoryAccess) Stat(relativePath string) (*FileOrDirInfo, error) {
+	path, err := s.safePathGetter(relativePath)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	stat, err := os.Stat(path)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	info, err := s.readFileOrDirInfo(relativePath, stat)
+	return info, trace.Wrap(err)
+}
+
+// ReadDir lists files and directories within the given directory path, skips symlinks.
+func (s *DirectoryAccess) ReadDir(relativePath string) ([]*FileOrDirInfo, error) {
+	path, err := s.safePathGetter(relativePath)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var results []*FileOrDirInfo
+	for _, entry := range entries {
+		fileInfo, err := entry.Info()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		// Skip symlinks, we can't present them properly in the remote machine.
+		if fileInfo.Mode().Type()&os.ModeSymlink != 0 {
+			continue
+		}
+
+		entryRelativePath := filepath.Join(relativePath, fileInfo.Name())
+		fileOrDir, err := s.readFileOrDirInfo(entryRelativePath, fileInfo)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		results = append(results, fileOrDir)
+	}
+
+	return results, nil
+}
+
+// Read reads a slice of a file.
+func (s *DirectoryAccess) Read(relativePath string, offset int64, length uint32) ([]byte, error) {
+	path, err := s.safePathGetter(relativePath)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	opened, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer opened.Close()
+
+	buf := make([]byte, length)
+	_, err = opened.Seek(offset, io.SeekStart)
+	if err != nil {
+		return nil, err
+	}
+
+	n, err := opened.Read(buf)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, trace.Wrap(err)
+	}
+	return buf[:n], nil
+}
+
+// Write writes data to a file at a given offset.
+func (s *DirectoryAccess) Write(relativePath string, offset int64, data []byte) (int, error) {
+	path, err := s.safePathGetter(relativePath)
+	if err != nil {
+		return 0, trace.Wrap(err)
+	}
+
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		return 0, err
+	}
+	defer file.Close()
+
+	_, err = file.Seek(offset, io.SeekStart)
+	if err != nil {
+		return 0, err
+	}
+
+	n, err := file.Write(data)
+	if err != nil {
+		return 0, trace.Wrap(err)
+	}
+
+	return n, nil
+}
+
+// Truncate truncates a file to the specified size.
+func (s *DirectoryAccess) Truncate(relativePath string, size int64) error {
+	path, err := s.safePathGetter(relativePath)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return trace.Wrap(os.Truncate(path, size))
+}
+
+// Create creates a new file or directory at the given path.
+func (s *DirectoryAccess) Create(relativePath string, fileType FileType) error {
+	path, err := s.safePathGetter(relativePath)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	switch fileType {
+	case FileTypeFile:
+		file, err := os.Create(path)
+		if err != nil {
+			if os.IsExist(err) {
+				return nil // Ignore if file already exists
+			}
+			return err
+		}
+		return file.Close()
+	case FileTypeDir:
+		err := os.Mkdir(path, 0700)
+		if os.IsExist(err) {
+			return nil // Ignore if directory already exists
+		}
+		return err
+	default:
+		return errors.New("unknown file type")
+	}
+}
+
+// Delete removes a file or directory at the given path.
+func (s *DirectoryAccess) Delete(relativePath string) error {
+	path, err := s.safePathGetter(relativePath)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	err = os.RemoveAll(path)
+	return trace.Wrap(err)
+}
+
+func (s *DirectoryAccess) readFileOrDirInfo(relativePath string, f os.FileInfo) (*FileOrDirInfo, error) {
+	path, err := s.safePathGetter(relativePath)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	info := &FileOrDirInfo{
+		Size:         f.Size(),
+		LastModified: f.ModTime().Unix(),
+		Path:         relativePath,
+		IsEmpty:      false,
+	}
+
+	if f.IsDir() {
+		r, err := os.Open(path)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		defer r.Close()
+		info.FileType = FileTypeDir
+		// Read up to one entry.
+		if _, err := r.Readdirnames(1); err != nil {
+			if errors.Is(err, io.EOF) {
+				info.IsEmpty = true
+			} else {
+				return nil, trace.Wrap(err)
+			}
+		}
+		info.Size = StandardDirSize
+	} else {
+		info.FileType = FileTypeFile
+	}
+
+	return info, nil
+}

--- a/lib/teleterm/services/desktop/directorysharing.go
+++ b/lib/teleterm/services/desktop/directorysharing.go
@@ -162,7 +162,7 @@ func (d *DirectoryAccess) ReadDir(relativePath string) ([]*FileOrDirInfo, error)
 }
 
 // Read reads a slice of a file into buf. Returns the number of read bytes.
-func (d *DirectoryAccess) Read(relativePath string, offset int64, buf []byte) (int, error) {
+func (d *DirectoryAccess) Read(relativePath string, offset int64, buf []byte) (n int, err error) {
 	path, err := d.getSafePath(relativePath)
 	if err != nil {
 		return 0, trace.Wrap(err)
@@ -174,7 +174,7 @@ func (d *DirectoryAccess) Read(relativePath string, offset int64, buf []byte) (i
 	}
 	defer func() {
 		closeErr := file.Close()
-		if closeErr != nil && err == nil {
+		if err == nil {
 			// Only update err if no previous error occurred.
 			err = trace.Wrap(closeErr)
 		}
@@ -185,7 +185,7 @@ func (d *DirectoryAccess) Read(relativePath string, offset int64, buf []byte) (i
 		return 0, trace.Wrap(err)
 	}
 
-	n, err := file.Read(buf)
+	n, err = file.Read(buf)
 	if err != nil && !errors.Is(err, io.EOF) {
 		return 0, trace.Wrap(err)
 	}
@@ -193,7 +193,7 @@ func (d *DirectoryAccess) Read(relativePath string, offset int64, buf []byte) (i
 }
 
 // Write writes data to a file at a given offset.
-func (d *DirectoryAccess) Write(relativePath string, offset int64, data []byte) (int, error) {
+func (d *DirectoryAccess) Write(relativePath string, offset int64, data []byte) (n int, err error) {
 	path, err := d.getSafePath(relativePath)
 	if err != nil {
 		return 0, trace.Wrap(err)
@@ -206,7 +206,7 @@ func (d *DirectoryAccess) Write(relativePath string, offset int64, data []byte) 
 
 	defer func() {
 		closeErr := file.Close()
-		if closeErr != nil && err == nil {
+		if err == nil {
 			// Only update err if no previous error occurred.
 			err = trace.Wrap(closeErr)
 		}
@@ -217,7 +217,7 @@ func (d *DirectoryAccess) Write(relativePath string, offset int64, data []byte) 
 		return 0, trace.Wrap(err)
 	}
 
-	n, err := file.Write(data)
+	n, err = file.Write(data)
 	return n, trace.Wrap(err)
 }
 
@@ -270,13 +270,13 @@ func (d *DirectoryAccess) Delete(relativePath string) error {
 	return trace.Wrap(err)
 }
 
-func (d *DirectoryAccess) readFileOrDirInfo(relativePath string, f os.FileInfo) (*FileOrDirInfo, error) {
+func (d *DirectoryAccess) readFileOrDirInfo(relativePath string, f os.FileInfo) (info *FileOrDirInfo, err error) {
 	path, err := d.getSafePath(relativePath)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	info := &FileOrDirInfo{
+	info = &FileOrDirInfo{
 		Size:         f.Size(),
 		LastModified: f.ModTime().Unix(),
 		Path:         relativePath,
@@ -294,7 +294,7 @@ func (d *DirectoryAccess) readFileOrDirInfo(relativePath string, f os.FileInfo) 
 	}
 	defer func() {
 		closeErr := opened.Close()
-		if closeErr != nil && err == nil {
+		if err == nil {
 			// Only update err if no previous error occurred.
 			err = trace.Wrap(closeErr)
 		}

--- a/lib/teleterm/services/desktop/directorysharing.go
+++ b/lib/teleterm/services/desktop/directorysharing.go
@@ -195,13 +195,13 @@ func (s *DirectoryAccess) Write(relativePath string, offset int64, data []byte) 
 
 	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
-		return 0, err
+		return 0, trace.Wrap(err)
 	}
 	defer file.Close()
 
 	_, err = file.Seek(offset, io.SeekStart)
 	if err != nil {
-		return 0, err
+		return 0, trace.Wrap(err)
 	}
 
 	n, err := file.Write(data)
@@ -236,9 +236,9 @@ func (s *DirectoryAccess) Create(relativePath string, fileType FileType) error {
 			if os.IsExist(err) {
 				return nil // Ignore if file already exists
 			}
-			return err
+			return trace.Wrap(err)
 		}
-		return file.Close()
+		return trace.Wrap(file.Close())
 	case FileTypeDir:
 		err := os.Mkdir(path, 0700)
 		if os.IsExist(err) {
@@ -281,7 +281,7 @@ func (s *DirectoryAccess) readFileOrDirInfo(relativePath string, f os.FileInfo) 
 		}
 		defer r.Close()
 		info.FileType = FileTypeDir
-		// Read up to one entry.
+		// Determine if the dir is not empty by checking if it contains at least one file.
 		if _, err := r.Readdirnames(1); err != nil {
 			if errors.Is(err, io.EOF) {
 				info.IsEmpty = true

--- a/lib/teleterm/services/desktop/directorysharing.go
+++ b/lib/teleterm/services/desktop/directorysharing.go
@@ -19,6 +19,7 @@ package desktop
 import (
 	"errors"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -85,7 +86,7 @@ func (s *DirectoryAccess) getSafePath(relativePath string) (string, error) {
 	if err != nil {
 		// EvalSymlinks returns an error if the target file does not exist.
 		// In that case, attempt to resolve the symlinks of the parent directory instead.
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			parent := filepath.Dir(full)
 			resolvedParent, perr := filepath.EvalSymlinks(parent)
 			if perr != nil {

--- a/lib/teleterm/services/desktop/directorysharing_test.go
+++ b/lib/teleterm/services/desktop/directorysharing_test.go
@@ -1,0 +1,176 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package desktop
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenSharedDirectory(t *testing.T) {
+	path := t.TempDir()
+	filePath := filepath.Join(path, testFilename)
+	err := os.WriteFile(filePath, []byte("test"), 0600)
+	require.NoError(t, err)
+	access := DirectoryAccess{}
+	err = access.Open(filePath)
+	require.True(t, trace.IsBadParameter(err), "%q is not a directory", filePath)
+}
+
+const (
+	testDirname         = "test_dir"
+	testFilename        = "test_file"
+	testSymlinkFilename = "test_symlink"
+)
+
+func setUpSharedDir(t *testing.T) (*DirectoryAccess, string) {
+	path := t.TempDir()
+	err := os.Mkdir(filepath.Join(path, testDirname), 0700)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(path, testFilename), []byte("test"), 0600)
+	require.NoError(t, err)
+	err = os.Symlink(filepath.Join(path, testFilename), filepath.Join(path, testSymlinkFilename))
+	require.NoError(t, err)
+	access := DirectoryAccess{}
+	err = access.Open(path)
+	require.NoError(t, err)
+	return &access, path
+}
+
+func TestDirectoryAccessEscapingPaths(t *testing.T) {
+	outOfRootPath := filepath.Join(testDirname, "../..")
+	tests := []struct {
+		name string
+		call func(*DirectoryAccess) error
+	}{
+		{"Stat", func(a *DirectoryAccess) error { _, err := a.Stat(outOfRootPath); return err }},
+		{"ReadDir", func(a *DirectoryAccess) error { _, err := a.ReadDir(outOfRootPath); return err }},
+		{"Read", func(a *DirectoryAccess) error { _, err := a.Read(outOfRootPath, 0, 100); return err }},
+		{"Write", func(a *DirectoryAccess) error { _, err := a.Write(outOfRootPath, 0, []byte("test")); return err }},
+		{"Truncate", func(a *DirectoryAccess) error { err := a.Truncate(outOfRootPath, 100); return err }},
+		{"Create", func(a *DirectoryAccess) error { err := a.Create(outOfRootPath, FileTypeDir); return err }},
+		{"Delete", func(a *DirectoryAccess) error { err := a.Delete(outOfRootPath); return err }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+"_Escape", func(t *testing.T) {
+			t.Helper()
+			access, _ := setUpSharedDir(t)
+			err := tt.call(access)
+			require.ErrorContains(t, err, "path escapes from parent")
+		})
+	}
+}
+
+func TestDirectoryAccessSuccessOperations(t *testing.T) {
+	t.Run("Stat", func(t *testing.T) {
+		access, path := setUpSharedDir(t)
+		info, err := access.Stat("")
+		require.NoError(t, err)
+
+		osStat, err := os.Stat(path)
+		require.NoError(t, err)
+
+		require.Equal(t, &FileOrDirInfo{
+			Size:         4096,
+			LastModified: osStat.ModTime().Unix(),
+			FileType:     FileTypeDir,
+			IsEmpty:      false,
+			Path:         "",
+		}, info)
+	})
+
+	t.Run("ReadDir", func(t *testing.T) {
+		access, path := setUpSharedDir(t)
+		dir, err := access.ReadDir("")
+		require.NoError(t, err)
+
+		require.Len(t, dir, 2)
+		osStat, err := os.Stat(filepath.Join(path, testDirname))
+		require.NoError(t, err)
+		require.Contains(t, dir, &FileOrDirInfo{
+			Size:         4096,
+			LastModified: osStat.ModTime().Unix(),
+			FileType:     FileTypeDir,
+			IsEmpty:      true,
+			Path:         testDirname,
+		})
+		osStat, err = os.Stat(filepath.Join(path, testFilename))
+		require.NoError(t, err)
+		require.Contains(t, dir, &FileOrDirInfo{
+			Size:         osStat.Size(),
+			LastModified: osStat.ModTime().Unix(),
+			FileType:     FileTypeFile,
+			IsEmpty:      false,
+			Path:         testFilename,
+		})
+	})
+
+	t.Run("Read", func(t *testing.T) {
+		access, _ := setUpSharedDir(t)
+		read, err := access.Read(testFilename, 0, 100)
+		require.NoError(t, err)
+		require.Equal(t, []byte("test"), read)
+	})
+
+	t.Run("Write", func(t *testing.T) {
+		access, _ := setUpSharedDir(t)
+		written, err := access.Write(testFilename, 4, []byte("_new_content"))
+		require.NoError(t, err)
+		require.Equal(t, 12, written)
+
+		read, err := access.Read(testFilename, 0, 100)
+		require.NoError(t, err)
+		require.Equal(t, []byte("test_new_content"), read)
+	})
+
+	t.Run("Truncate", func(t *testing.T) {
+		access, _ := setUpSharedDir(t)
+		err := access.Truncate(testFilename, 100)
+		require.NoError(t, err)
+		stat, err := access.Stat(testFilename)
+		require.NoError(t, err)
+		require.Equal(t, int64(100), stat.Size)
+	})
+
+	t.Run("Create", func(t *testing.T) {
+		access, _ := setUpSharedDir(t)
+
+		err := access.Create("new_file", FileTypeFile)
+		require.NoError(t, err)
+		createdFile, err := access.Stat("new_file")
+		require.NoError(t, err)
+		require.Equal(t, FileTypeFile, createdFile.FileType)
+
+		err = access.Create("new_dir", FileTypeDir)
+		require.NoError(t, err)
+		createdDir, err := access.Stat("new_dir")
+		require.NoError(t, err)
+		require.Equal(t, FileTypeDir, createdDir.FileType)
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		access, _ := setUpSharedDir(t)
+		err := access.Delete(testFilename)
+		require.NoError(t, err)
+		require.NoFileExists(t, testFilename)
+	})
+}

--- a/lib/teleterm/services/desktop/directorysharing_test.go
+++ b/lib/teleterm/services/desktop/directorysharing_test.go
@@ -41,6 +41,7 @@ const (
 )
 
 func setUpSharedDir(t *testing.T) (*DirectoryAccess, string) {
+	t.Helper()
 	path := t.TempDir()
 	err := os.Mkdir(filepath.Join(path, testDirname), 0700)
 	require.NoError(t, err)
@@ -74,7 +75,6 @@ func TestDirectoryAccessEscapingPaths(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name+"_Escape", func(t *testing.T) {
-			t.Helper()
 			access, _ := setUpSharedDir(t)
 			err := tt.call(access)
 			require.ErrorContains(t, err, "path escapes from parent")

--- a/lib/teleterm/services/desktop/directorysharing_test.go
+++ b/lib/teleterm/services/desktop/directorysharing_test.go
@@ -61,7 +61,11 @@ func TestDirectoryAccessEscapingPaths(t *testing.T) {
 	}{
 		{"Stat", func(a *DirectoryAccess) error { _, err := a.Stat(outOfRootPath); return err }},
 		{"ReadDir", func(a *DirectoryAccess) error { _, err := a.ReadDir(outOfRootPath); return err }},
-		{"Read", func(a *DirectoryAccess) error { _, err := a.Read(outOfRootPath, 0, 100); return err }},
+		{"Read", func(a *DirectoryAccess) error {
+			buf := make([]byte, 10)
+			_, err := a.Read(outOfRootPath, 0, buf)
+			return err
+		}},
 		{"Write", func(a *DirectoryAccess) error { _, err := a.Write(outOfRootPath, 0, []byte("test")); return err }},
 		{"Truncate", func(a *DirectoryAccess) error { err := a.Truncate(outOfRootPath, 100); return err }},
 		{"Create", func(a *DirectoryAccess) error { err := a.Create(outOfRootPath, FileTypeDir); return err }},
@@ -124,9 +128,11 @@ func TestDirectoryAccessSuccessOperations(t *testing.T) {
 
 	t.Run("Read", func(t *testing.T) {
 		access, _ := setUpSharedDir(t)
-		read, err := access.Read(testFilename, 0, 100)
+		buf := make([]byte, 4)
+		read, err := access.Read(testFilename, 0, buf)
 		require.NoError(t, err)
-		require.Equal(t, []byte("test"), read)
+		require.Equal(t, 4, read)
+		require.Equal(t, []byte("test"), buf)
 	})
 
 	t.Run("Write", func(t *testing.T) {
@@ -135,9 +141,11 @@ func TestDirectoryAccessSuccessOperations(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 12, written)
 
-		read, err := access.Read(testFilename, 0, 100)
+		buf := make([]byte, 16)
+		read, err := access.Read(testFilename, 0, buf)
 		require.NoError(t, err)
-		require.Equal(t, []byte("test_new_content"), read)
+		require.Equal(t, 16, read)
+		require.Equal(t, []byte("test_new_content"), buf)
 	})
 
 	t.Run("Truncate", func(t *testing.T) {

--- a/lib/teleterm/services/desktop/directorysharing_test.go
+++ b/lib/teleterm/services/desktop/directorysharing_test.go
@@ -30,8 +30,7 @@ func TestOpenSharedDirectory(t *testing.T) {
 	filePath := filepath.Join(path, testFilename)
 	err := os.WriteFile(filePath, []byte("test"), 0600)
 	require.NoError(t, err)
-	access := DirectoryAccess{}
-	err = access.Open(filePath)
+	_, err = NewDirectoryAccess(filePath)
 	require.True(t, trace.IsBadParameter(err), "%q is not a directory", filePath)
 }
 
@@ -49,10 +48,9 @@ func setUpSharedDir(t *testing.T) (*DirectoryAccess, string) {
 	require.NoError(t, err)
 	err = os.Symlink(filepath.Join(path, testFilename), filepath.Join(path, testSymlinkFilename))
 	require.NoError(t, err)
-	access := DirectoryAccess{}
-	err = access.Open(path)
+	access, err := NewDirectoryAccess(path)
 	require.NoError(t, err)
-	return &access, path
+	return access, path
 }
 
 func TestDirectoryAccessEscapingPaths(t *testing.T) {

--- a/web/packages/shared/libs/tdp/sharedDirectoryAccess.ts
+++ b/web/packages/shared/libs/tdp/sharedDirectoryAccess.ts
@@ -42,6 +42,8 @@ export interface SharedDirectoryAccess {
 /**
  * Enables directory sharing using FileSystem API.
  * Most of the methods can potentially throw errors and so should be wrapped in try/catch blocks.
+ * Should be kept in sync with lib/teleterm/services/desktop/directorysharing.go
+ * where file system events are handled for Connect.
  */
 export class BrowserFileSystem implements SharedDirectoryAccess {
   private dir: FileSystemDirectoryHandle | undefined;


### PR DESCRIPTION
Contributes to https://github.com/gravitational/teleport/issues/20802

Part 1/2 of directory sharing in Connect.

This mirrors the file operations performed with File System API on the JS side. https://github.com/gravitational/teleport/blob/980ce61efc86e0efb01b2cdf732cde9e9411b58e/web/packages/shared/libs/tdp/sharedDirectoryAccess.ts#L46