### PR TITLE
Show desktops in connection tracker

### DIFF
--- a/web/packages/teleterm/src/services/tshd/testHelpers.ts
+++ b/web/packages/teleterm/src/services/tshd/testHelpers.ts
@@ -48,7 +48,7 @@ export const makeServer = (props: Partial<tsh.Server> = {}): tsh.Server => ({
 export const databaseUri = `${rootClusterUri}/dbs/foo`;
 export const kubeUri = `${rootClusterUri}/kubes/foo`;
 export const appUri = `${rootClusterUri}/apps/foo`;
-export const windowsDesktopUri = `${rootClusterUri}/windowsDesktops/foo`;
+export const windowsDesktopUri = `${rootClusterUri}/windows_desktops/foo`;
 
 export const makeDatabase = (
   props: Partial<tsh.Database> = {}

--- a/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ActionButtons.story.tsx
@@ -288,7 +288,7 @@ function WindowsDesktop() {
   return (
     <ConnectWindowsDesktopActionButton
       windowsDesktop={makeWindowsDesktop({
-        uri: `${testCluster.uri}/windowsDesktops/bar`,
+        uri: `${testCluster.uri}/windows_desktops/bar`,
       })}
     />
   );

--- a/web/packages/teleterm/src/ui/DocumentDesktopSession/DocumentDesktopSession.tsx
+++ b/web/packages/teleterm/src/ui/DocumentDesktopSession/DocumentDesktopSession.tsx
@@ -57,7 +57,7 @@ export function DocumentDesktopSession(props: {
   const { documentsService } = useWorkspaceContext();
   const loggedInUser = useWorkspaceLoggedInUser();
   const acl = useMemo<Attempt<ACL>>(() => {
-    if (!loggedInUser) {
+    if (!loggedInUser?.acl) {
       return makeProcessingAttempt();
     }
     return makeSuccessAttempt(loggedInUser.acl);

--- a/web/packages/teleterm/src/ui/DocumentDesktopSession/DocumentDesktopSession.tsx
+++ b/web/packages/teleterm/src/ui/DocumentDesktopSession/DocumentDesktopSession.tsx
@@ -18,6 +18,7 @@
 
 import { useMemo, useState } from 'react';
 
+import { Text } from 'design';
 import { ACL } from 'gen-proto-ts/teleport/lib/teleterm/v1/cluster_pb';
 import { DesktopSession } from 'shared/components/DesktopSession';
 import {
@@ -35,7 +36,7 @@ import Document from 'teleterm/ui/Document';
 import { useWorkspaceLoggedInUser } from 'teleterm/ui/hooks/useLoggedInUser';
 import { useLogger } from 'teleterm/ui/hooks/useLogger';
 import * as types from 'teleterm/ui/services/workspacesService';
-import { routing, WindowsDesktopUri } from 'teleterm/ui/uri';
+import { DesktopUri, isWindowsDesktopUri, routing } from 'teleterm/ui/uri';
 
 // The check for another active session is disabled in Connect:
 // 1. This protection was added to the Web UI to prevent a situation where a user could be tricked
@@ -83,8 +84,16 @@ export function DocumentDesktopSession(props: {
       }, new BrowserFileSystem())
   );
 
-  return (
-    <Document visible={props.visible}>
+  let content = (
+    <Text m="auto" mt={10} textAlign="center">
+      Cannot open a connection to "{desktopUri}".
+      <br />
+      Only Windows desktops are supported.
+    </Text>
+  );
+
+  if (isWindowsDesktopUri(desktopUri)) {
+    content = (
       <DesktopSession
         hasAnotherSession={noOtherSession}
         desktop={
@@ -94,14 +103,16 @@ export function DocumentDesktopSession(props: {
         username={login}
         aclAttempt={acl}
       />
-    </Document>
-  );
+    );
+  }
+
+  return <Document visible={props.visible}>{content}</Document>;
 }
 
 async function adaptGRPCStreamToTdpTransport(
   stream: ReturnType<TshdClient['connectToDesktop']>,
   targetDesktop: {
-    desktopUri: WindowsDesktopUri;
+    desktopUri: DesktopUri;
     login: string;
   },
   logger: Logger

--- a/web/packages/teleterm/src/ui/Search/pickers/results.story.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/results.story.tsx
@@ -486,7 +486,7 @@ const SearchResultItems = () => {
       kind: 'windows_desktop',
       requiresRequest: false,
       resource: makeWindowsDesktopWithoutDefaultPort({
-        uri: `${clusterUri}/windowsDesktops/long-name`,
+        uri: `${clusterUri}/windows_desktops/long-name`,
         name: 'super-long-windows-desktop-name-with-uuid-7a96e498-88ec-442f-a25b-569fa9150123c',
         labels: makeLabelsList({
           'aws/Environment': 'demo-13-biz',
@@ -499,7 +499,7 @@ const SearchResultItems = () => {
     makeResourceResult({
       kind: 'windows_desktop',
       resource: makeWindowsDesktopWithoutDefaultPort({
-        uri: `${clusterUri}/windowsDesktops/long-label-list`,
+        uri: `${clusterUri}/windows_desktops/long-label-list`,
         name: 'long-label-list',
         labels: makeLabelsList({
           'aws/Environment': 'demo-13-biz',
@@ -514,7 +514,7 @@ const SearchResultItems = () => {
       kind: 'windows_desktop',
       requiresRequest: true,
       resource: makeWindowsDesktopWithoutDefaultPort({
-        uri: `${clusterUri}/windowsDesktops/short-label-list`,
+        uri: `${clusterUri}/windows_desktops/short-label-list`,
         name: 'short-label-list',
         labels: makeLabelsList({
           'im-just-a-smol': 'win',

--- a/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionItem.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionItem.tsx
@@ -169,12 +169,6 @@ function getKindName(connection: ExtendedTrackedConnection): string {
     case 'connection.desktop':
       return 'DESKTOP';
     default:
-      // The default branch is triggered when the state read from the disk
-      // contains a connection not supported by the given Connect version.
-      //
-      // For example, the user can open an app connection in Connect v15
-      // and then downgrade to a version that doesn't support apps.
-      // That connection should be shown as 'UNKNOWN' in the connection list.
       return 'UNKNOWN';
   }
 }

--- a/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionItem.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionItem.tsx
@@ -166,6 +166,8 @@ function getKindName(connection: ExtendedTrackedConnection): string {
       return 'SSH';
     case 'connection.kube':
       return 'KUBE';
+    case 'connection.desktop':
+      return 'DESKTOP';
     default:
       // The default branch is triggered when the state read from the disk
       // contains a connection not supported by the given Connect version.

--- a/web/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.ts
+++ b/web/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.ts
@@ -343,7 +343,7 @@ export class ConnectionTrackerService extends ImmutableStore<ConnectionTrackerSt
             );
 
             if (desktopConn) {
-              desktopConn.connected = true;
+              desktopConn.connected = doc.status === 'connected';
             } else {
               const newItem = createDesktopConnection(doc);
               draft.connections.push(newItem);

--- a/web/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.ts
+++ b/web/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.ts
@@ -78,15 +78,27 @@ export class ConnectionTrackerService extends ImmutableStore<ConnectionTrackerSt
   }
 
   getConnections(): ExtendedTrackedConnection[] {
-    return this.state.connections.map(connection => {
-      const { rootClusterUri, leafClusterUri } =
-        this._trackedConnectionOperationsFactory.create(connection);
-      const clusterUri = leafClusterUri || rootClusterUri;
-      const clusterName =
-        this._clusterService.findCluster(clusterUri)?.name ||
-        routing.parseClusterName(clusterUri);
-      return { ...connection, clusterName };
-    });
+    return this.state.connections
+      .map(connection => {
+        const trackedConnection =
+          this._trackedConnectionOperationsFactory.create(connection);
+        // A connection is undefined when the state read from the disk
+        // contains a connection not supported by the given Connect version.
+        //
+        // For example, the user can open a desktop connection in Connect v18
+        // and then downgrade to a version that doesn't support desktops.
+        // That connection should be shown as 'UNKNOWN' in the connection list.
+        if (!trackedConnection) {
+          return;
+        }
+        const { rootClusterUri, leafClusterUri } = trackedConnection;
+        const clusterUri = leafClusterUri || rootClusterUri;
+        const clusterName =
+          this._clusterService.findCluster(clusterUri)?.name ||
+          routing.parseClusterName(clusterUri);
+        return { ...connection, clusterName };
+      })
+      .filter(Boolean);
   }
 
   async activateItem(

--- a/web/packages/teleterm/src/ui/services/connectionTracker/trackedConnectionOperationsFactory.ts
+++ b/web/packages/teleterm/src/ui/services/connectionTracker/trackedConnectionOperationsFactory.ts
@@ -255,19 +255,19 @@ export class TrackedConnectionOperationsFactory {
       rootClusterUri,
       leafClusterUri,
       activate: params => {
-        let gwDoc = documentsService
+        let doc = documentsService
           .getDocuments()
           .find(getDesktopDocumentByConnection(connection));
 
-        if (!gwDoc) {
-          gwDoc = createDesktopSessionDocument({
+        if (!doc) {
+          doc = createDesktopSessionDocument({
             desktopUri: connection.desktopUri,
             login: connection.login,
             origin: params.origin,
           });
-          documentsService.add(gwDoc);
+          documentsService.add(doc);
         }
-        documentsService.open(gwDoc.uri);
+        documentsService.open(doc.uri);
       },
       disconnect: async () => {
         documentsService

--- a/web/packages/teleterm/src/ui/services/connectionTracker/trackedConnectionOperationsFactory.ts
+++ b/web/packages/teleterm/src/ui/services/connectionTracker/trackedConnectionOperationsFactory.ts
@@ -18,6 +18,7 @@
 
 import { ClustersService } from 'teleterm/ui/services/clusters';
 import {
+  createDesktopSessionDocument,
   DocumentGateway,
   DocumentOrigin,
   WorkspacesService,
@@ -25,6 +26,7 @@ import {
 import { LeafClusterUri, RootClusterUri, routing } from 'teleterm/ui/uri';
 
 import {
+  getDesktopDocumentByConnection,
   getGatewayDocumentByConnection,
   getGatewayKubeDocumentByConnection,
   getKubeDocumentByConnection,
@@ -32,6 +34,7 @@ import {
 } from './trackedConnectionUtils';
 import {
   TrackedConnection,
+  TrackedDesktopConnection,
   TrackedGatewayConnection,
   TrackedKubeConnection,
   TrackedServerConnection,
@@ -51,6 +54,8 @@ export class TrackedConnectionOperationsFactory {
         return this.getConnectionGatewayOperations(connection);
       case 'connection.kube':
         return this.getConnectionGatewayKubeOperations(connection);
+      case 'connection.desktop':
+        return this.getConnectionDesktopOperations(connection);
     }
   }
 
@@ -227,6 +232,50 @@ export class TrackedConnectionOperationsFactory {
                 });
             })
         );
+      },
+      remove: async () => {},
+    };
+  }
+
+  private getConnectionDesktopOperations(
+    connection: TrackedDesktopConnection
+  ): TrackedConnectionOperations {
+    const { rootClusterId, leafClusterId } = routing.parseClusterUri(
+      connection.desktopUri
+    ).params;
+    const { rootClusterUri, leafClusterUri } = this.getClusterUris({
+      rootClusterId,
+      leafClusterId,
+    });
+
+    const documentsService =
+      this._workspacesService.getWorkspaceDocumentService(rootClusterUri);
+
+    return {
+      rootClusterUri,
+      leafClusterUri,
+      activate: params => {
+        let gwDoc = documentsService
+          .getDocuments()
+          .find(getDesktopDocumentByConnection(connection));
+
+        if (!gwDoc) {
+          gwDoc = createDesktopSessionDocument({
+            desktopUri: connection.desktopUri,
+            login: connection.login,
+            origin: params.origin,
+          });
+          documentsService.add(gwDoc);
+        }
+        documentsService.open(gwDoc.uri);
+      },
+      disconnect: async () => {
+        documentsService
+          .getDocuments()
+          .filter(getDesktopDocumentByConnection(connection))
+          .forEach(document => {
+            documentsService.close(document.uri);
+          });
       },
       remove: async () => {},
     };

--- a/web/packages/teleterm/src/ui/services/connectionTracker/trackedConnectionUtils.ts
+++ b/web/packages/teleterm/src/ui/services/connectionTracker/trackedConnectionUtils.ts
@@ -18,6 +18,7 @@
 
 import {
   Document,
+  DocumentDesktopSession,
   DocumentGateway,
   DocumentGatewayKube,
   DocumentTshKube,
@@ -30,6 +31,7 @@ import { unique } from 'teleterm/ui/utils/uid';
 
 import {
   TrackedConnection,
+  TrackedDesktopConnection,
   TrackedGatewayConnection,
   TrackedKubeConnection,
   TrackedServerConnection,
@@ -97,6 +99,24 @@ export function getGatewayKubeConnectionByDocument(
 ) {
   return (i: TrackedKubeConnection) =>
     i.kind === 'connection.kube' && i.kubeUri === document.targetUri;
+}
+
+export function getDesktopDocumentByConnection(
+  connection: TrackedDesktopConnection
+): (d: Document) => boolean {
+  return d =>
+    d.kind === 'doc.desktop_session' &&
+    d.desktopUri === connection.desktopUri &&
+    d.login === connection.login;
+}
+
+export function getDesktopConnectionByDocument(
+  document: DocumentDesktopSession
+) {
+  return (i: TrackedDesktopConnection) =>
+    i.kind === 'connection.desktop' &&
+    i.desktopUri === document.desktopUri &&
+    i.login === document.login;
 }
 
 /*
@@ -218,5 +238,18 @@ export function createGatewayKubeConnection(
     id: unique(),
     title: document.title,
     kubeUri: document.targetUri,
+  };
+}
+
+export function createDesktopConnection(
+  document: DocumentDesktopSession
+): TrackedDesktopConnection {
+  return {
+    kind: 'connection.desktop',
+    connected: true,
+    id: unique(),
+    title: document.title,
+    desktopUri: document.desktopUri,
+    login: document.login,
   };
 }

--- a/web/packages/teleterm/src/ui/services/connectionTracker/types.ts
+++ b/web/packages/teleterm/src/ui/services/connectionTracker/types.ts
@@ -16,7 +16,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { AppUri, DatabaseUri, KubeUri, ServerUri } from 'teleterm/ui/uri';
+import {
+  AppUri,
+  DatabaseUri,
+  DesktopUri,
+  KubeUri,
+  ServerUri,
+} from 'teleterm/ui/uri';
 
 type TrackedConnectionBase = {
   connected: boolean;
@@ -49,10 +55,17 @@ export interface TrackedKubeConnection extends TrackedConnectionBase {
   kubeUri: KubeUri;
 }
 
+export interface TrackedDesktopConnection extends TrackedConnectionBase {
+  kind: 'connection.desktop';
+  desktopUri: DesktopUri;
+  login: string;
+}
+
 export type TrackedConnection =
   | TrackedServerConnection
   | TrackedGatewayConnection
-  | TrackedKubeConnection;
+  | TrackedKubeConnection
+  | TrackedDesktopConnection;
 
 export type ExtendedTrackedConnection = TrackedConnection & {
   clusterName: string;

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
@@ -605,6 +605,7 @@ export function createDesktopSessionDocument(opts: {
     desktopUri: opts.desktopUri,
     login: opts.login,
     origin: opts.origin,
+    status: '',
   };
 }
 

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
@@ -23,6 +23,7 @@ import type { RuntimeSettings } from 'teleterm/mainProcess/types';
 import * as uri from 'teleterm/ui/uri';
 import {
   DocumentUri,
+  isWindowsDesktopUri,
   KubeUri,
   paths,
   RootClusterUri,
@@ -591,14 +592,16 @@ export function createClusterDocument(opts: {
 }
 
 export function createDesktopSessionDocument(opts: {
-  desktopUri: uri.WindowsDesktopUri;
+  desktopUri: uri.DesktopUri;
   login: string;
   origin: DocumentOrigin;
 }): DocumentDesktopSession {
   return {
     kind: 'doc.desktop_session' as const,
     uri: routing.getDocUri({ docId: unique() }),
-    title: `${opts.login} on ${routing.parseWindowsDesktopUri(opts.desktopUri).params?.windowsDesktopId}`,
+    title: isWindowsDesktopUri(opts.desktopUri)
+      ? `${opts.login} on ${routing.parseWindowsDesktopUri(opts.desktopUri).params.windowsDesktopId}`
+      : 'Unknown',
     desktopUri: opts.desktopUri,
     login: opts.login,
     origin: opts.origin,

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/testHelpers.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/testHelpers.ts
@@ -235,6 +235,7 @@ export function makeDocumentDesktopSession(
     desktopUri: windowsDesktopUri,
     login: 'admin',
     origin: 'resource_table',
+    status: '',
     ...props,
   };
 }

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
@@ -308,7 +308,7 @@ export interface DocumentAuthorizeWebSession extends DocumentBase {
 
 export interface DocumentDesktopSession extends DocumentBase {
   kind: 'doc.desktop_session';
-  desktopUri: uri.WindowsDesktopUri;
+  desktopUri: uri.DesktopUri;
   login: string;
   origin: DocumentOrigin;
 }

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
@@ -311,6 +311,8 @@ export interface DocumentDesktopSession extends DocumentBase {
   desktopUri: uri.DesktopUri;
   login: string;
   origin: DocumentOrigin;
+  // status is used merely to indicate that a connection is established in the connection tracker.
+  status: '' | 'connected' | 'error';
 }
 
 export interface WebSessionRequest {

--- a/web/packages/teleterm/src/ui/uri.ts
+++ b/web/packages/teleterm/src/ui/uri.ts
@@ -77,6 +77,9 @@ export type WindowsDesktopUri =
 export type ClusterOrResourceUri = ResourceUri | ClusterUri;
 export type GatewayTargetUri = DatabaseUri | KubeUri | AppUri;
 
+/** General type for desktop URI. */
+export type DesktopUri = WindowsDesktopUri;
+
 /*
  * Document URIs
  * These are for documents (tabs) within the app.
@@ -354,6 +357,10 @@ export function isServerUri(uri: string): uri is ServerUri {
 
 export function isKubeUri(uri: string): uri is KubeUri {
   return !!routing.parseKubeUri(uri);
+}
+
+export function isWindowsDesktopUri(uri: string): uri is WindowsDesktopUri {
+  return !!routing.parseWindowsDesktopUri(uri);
 }
 
 export type Params = {


### PR DESCRIPTION
Contributes to https://github.com/gravitational/teleport/issues/20802

It's the last PR that should be merged before the release.

The code for showing desktop connection is a copy-paste of code for other connections.

I also reorganized the types slightly to make supporting non-Windows desktops easier in the future. In short, most places use now `DesktopUri` instead of `WindowsDesktopUri`. If they need to read `windowsDesktopId`, they should check if it's a `WindowsDesktopUri`. Thanks to that, if in the future someone opens a document for non-Windows session and then downgrades the app, it won't crash.