### PR TITLE
[Web] Fix MAU banner showing up during loading on users page

### DIFF
--- a/web/packages/teleport/src/Users/Users.tsx
+++ b/web/packages/teleport/src/Users/Users.tsx
@@ -164,7 +164,7 @@ export function Users(props: State) {
           <Indicator />
         </Box>
       )}
-      {showMauInfo && (
+      {showMauInfo && !users.isFetching && (
         <Alert
           data-testid="users-not-mau-alert"
           dismissible


### PR DESCRIPTION
## Purpose

This PR fixes a minor bug where the MAU banner would show up during the loading state on the users page.