### PR TITLE
[v16] Fix panic when listing malformed SSO users in web UI

### DIFF
--- a/lib/web/ui/user.go
+++ b/lib/web/ui/user.go
@@ -80,7 +80,7 @@ func NewUserListEntry(teleUser types.User) (*UserListEntry, error) {
 			authType = connector.Type
 		} else {
 			// We handle gracefully a malformed SSO user that doesn't have a "CreatedBy"
-			authType = "unknown sso"
+			authType = "unknown SSO"
 		}
 	}
 

--- a/lib/web/ui/user.go
+++ b/lib/web/ui/user.go
@@ -76,7 +76,12 @@ func NewUserListEntry(teleUser types.User) (*UserListEntry, error) {
 
 	authType := "local"
 	if teleUser.GetUserType() == types.UserTypeSSO {
-		authType = teleUser.GetCreatedBy().Connector.Type
+		if connector := teleUser.GetCreatedBy().Connector; connector != nil {
+			authType = connector.Type
+		} else {
+			// We handle gracefully a malformed SSO user that doesn't have a "CreatedBy"
+			authType = "unknown sso"
+		}
 	}
 
 	return &UserListEntry{

--- a/lib/web/ui/user.go
+++ b/lib/web/ui/user.go
@@ -80,11 +80,10 @@ func NewUserListEntry(teleUser types.User) (*UserListEntry, error) {
 
 	authType := "local"
 	if teleUser.GetUserType() == types.UserTypeSSO {
+		// Gracefully handle a malformed SSO user that doesn't have a "CreatedBy"
+		authType = unknownSSOAuthType
 		if connector := teleUser.GetCreatedBy().Connector; connector != nil {
 			authType = connector.Type
-		} else {
-			// We handle gracefully a malformed SSO user that doesn't have a "CreatedBy"
-			authType = unknownSSOAuthType
 		}
 	}
 

--- a/lib/web/ui/user.go
+++ b/lib/web/ui/user.go
@@ -62,6 +62,10 @@ type userTraits struct {
 	AWSRoleARNs []string `json:"awsRoleArns,omitempty"`
 }
 
+// unknownSSOAUthType is used when we know the user is from SSO, but we don't
+// know the SSO connector name or type.
+const unknownSSOAuthType = "unknown SSO"
+
 // User contains data needed by the web UI to display locally saved users.
 type User struct {
 	UserListEntry
@@ -80,7 +84,7 @@ func NewUserListEntry(teleUser types.User) (*UserListEntry, error) {
 			authType = connector.Type
 		} else {
 			// We handle gracefully a malformed SSO user that doesn't have a "CreatedBy"
-			authType = "unknown SSO"
+			authType = unknownSSOAuthType
 		}
 	}
 

--- a/lib/web/ui/user_test.go
+++ b/lib/web/ui/user_test.go
@@ -72,7 +72,6 @@ func TestNewUserListEntry(t *testing.T) {
 						{
 							ConnectorID: "github",
 							Username:    "malformed-sso",
-							UserID:      "malformed-sso",
 						},
 					},
 				},

--- a/lib/web/ui/user_test.go
+++ b/lib/web/ui/user_test.go
@@ -81,7 +81,7 @@ func TestNewUserListEntry(t *testing.T) {
 				Name:  "malformed-sso",
 				Roles: []string{"behavioral-analyst"},
 				// We should not panic and display that we don't know who created the user
-				AuthType: "unknown sso",
+				AuthType: unknownSSOAuthType,
 			},
 		},
 	}

--- a/lib/web/ui/user_test.go
+++ b/lib/web/ui/user_test.go
@@ -59,6 +59,31 @@ func TestNewUserListEntry(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "malformed sso",
+			user: &types.UserV2{
+				Metadata: types.Metadata{
+					Name: "malformed-sso",
+				},
+				Spec: types.UserSpecV2{
+					Roles: []string{"behavioral-analyst"},
+					// CreatedBy is not set BUT there's a GitHub identity, so the user's type will be SSO
+					GithubIdentities: []types.ExternalIdentity{
+						{
+							ConnectorID: "github",
+							Username:    "malformed-sso",
+							UserID:      "malformed-sso",
+						},
+					},
+				},
+			},
+			want: &UserListEntry{
+				Name:  "malformed-sso",
+				Roles: []string{"behavioral-analyst"},
+				// We should not panic and display that we don't know who created the user
+				AuthType: "unknown sso",
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Backport #54673 to branch/v16

changelog: fix a bug causing a malformed user to break Teleport web UI's "Users" page
