### PR TITLE
Trim unnecessary language in the index page

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -1,41 +1,30 @@
 ---
 h1: Introduction to Teleport
-title: "Introduction to the Teleport Infrastructure Identity Platform: Zero Trust Security for Your Infrastructure"
+title: "Introduction to the Teleport Infrastructure Identity Platform"
 description: Read an overview of the Teleport Access Platform. Learn how to implement Zero Trust Security across all your infrastructure for enhanced protection and streamlined access control.
 tocDepth: 3
 ---
 
 Teleport is the easiest, most secure way to access and protect all your infrastructure.
 
-The Teleport Infrastructure Identity Platform modernizes identity, access, and policy for infrastructure, for both human and non-human identities, 
-improving engineering velocity and resiliency of critical infrastructure against human factors and/or compromise. 
-Teleport is purpose-built for infrastructure use cases and implements trusted computing at scale, with unified 
-cryptographic identities for humans, machines and workloads, endpoints, infrastructure assets, and AI agents. 
-
-Our identity-everywhere approach vertically integrates access management, zero trust networking, identity governance, 
-and identity security into a single platform, eliminating overhead and operational silos. 
-Teleport improves the velocity of engineering teams, improving engineering productivity, scaling infrastructure operations, 
-and protecting time to market. 
+The Teleport Infrastructure Identity Platform implements trusted computing at
+scale, with unified cryptographic identities for humans, machines and workloads,
+endpoints, infrastructure assets, and AI agents. 
 
 ## Products
 
-The **Teleport** Infrastructure Identity **Platform** consists of four products:
+The Teleport Infrastructure Identity Platform consists of four products.
 
-- **Teleport Zero Trust Access** provides engineers with least-privileged access 
-to applications, servers, databases, Kubernetes clusters, remote desktops, and other resources across distributed infrastructure, improving engineering time to market and strengthening infrastructure resiliency.
-- **Teleport Machine & Workload Identity**  provides identity management and access control of 
-non-human identities, improving infrastructure resiliency by securing system and data access between machines and workloads.   
-- **Teleport Identity Governance** hardens and monitors identities for both human and non-human identities, improving resiliency of infrastructure from compromise due to human factor or identity attacks.
-- **Teleport Identity Security** secures identities and access policies across all of your infrastructure. Eliminates shadow access and blind spots.
+- [Teleport Zero Trust Access](#teleport-zero-trust-access)
+- [Teleport Machine & Workload Identity](#teleport-machine--workload-identity)
+- [Teleport Identity Governance](#teleport-identity-governance)
+- [Teleport Identity Security](#teleport-identity-security)
 
 ### Teleport Zero Trust Access
 
-Teleport Zero Trust Access provides engineers with just-in-time, least-privileged access to applications, servers, databases, Kubernetes clusters, and other resources across distributed 
-infrastructures, improving engineering time to market and strengthening  infrastructure resiliency.
-
-Built on a foundation of cryptographic identity and purpose-built for infrastructure, Teleport Zero Trust Access transforms security models 
-by eliminating static credentials, enforcing granular access policies, leveraging short-lived certificates for ephemeral authorization, and 
-enforcing zero trust principles.
+Teleport Zero Trust Access uses cryptographic identity to provide engineers with
+just-in-time, least-privileged access to applications, servers, databases,
+Kubernetes clusters, and other resources across distributed infrastructure. 
 
 Get started with Teleport Zero Trust Access:
 
@@ -51,10 +40,9 @@ Get started with Teleport Zero Trust Access:
 
 ### Teleport Machine & Workload Identity
 
-Teleport Machine & Workload Identity is a solution for non-human identity management and access control, 
-improving infrastructure resiliency by securing system and data access between machines and workloads. 
-As part  of Teleport's Infrastructure Identity Platform, Teleport Machine & Workload Identity is purpose-built 
-for infrastructure and is part of a unified access control strategy for both human and non-human identities.
+Teleport Machine & Workload Identity is a solution for non-human identity
+management and access control, improving infrastructure resiliency by securing
+system and data access between machines and workloads.
 
 Get started with Teleport Machine & Workload Identity:
 
@@ -63,9 +51,9 @@ Get started with Teleport Machine & Workload Identity:
 
 ### Teleport Identity Governance
 
-Teleport Identity Governance hardens and monitors identities for both human and non-human identities, improving resiliency of infrastructure from compromise due to human factor or identity attacks.
-
-Teleport Identity Governance is tightly coupled with Teleport Zero Trust Access and Teleport Machine & Workload Identity, providing companies with a unified governance strategy that improves security posture and is tightly coupled with access control.
+Teleport Identity Governance hardens and monitors identities for both human and
+non-human identities, improving resiliency of infrastructure from compromise due
+to human factor or identity attacks.
 
 Get started with Teleport Identity Governance:
 
@@ -86,7 +74,9 @@ Get started with Teleport Identity Governance:
 
 ### Teleport Identity Security
 
-**Teleport Identity Security** secures identities and access policies across all of your infrastructure.  It detects standing privileges and eliminates shadow access and blind spots. 
+**Teleport Identity Security** secures identities and access policies across all
+of your infrastructure. It detects standing privileges and eliminates shadow
+access and blind spots. 
 
 - Get started with [Teleport Identity Security](admin-guides/teleport-policy/teleport-policy.mdx).
 - Define [Crown Jewels](admin-guides/teleport-policy/crown-jewels.mdx) so you can track changes to your most sensitive users and resources.


### PR DESCRIPTION
Make it easier for visitors to the Teleport documentation index page to find useful information by removing some unnecessary marketing language.

- Remove the colon and subtitle text after the title.
- Remove descriptions after product names in the initial list. These descriptions are repeated in section intro paragraphs. Add anchor links to each section instead.
- Reduce product H3 intro descriptions to two paragraphs each, rather than three.

This change is intended to improve the usability of the index page until we can make more substantial revisions.