### PR TITLE
Fix icon link 404s in the One Login guide

### DIFF
--- a/docs/pages/admin-guides/access-controls/sso/one-login.mdx
+++ b/docs/pages/admin-guides/access-controls/sso/one-login.mdx
@@ -4,6 +4,9 @@ description: How to configure Teleport access using OneLogin as an SSO provider
 h1: Teleport Authentication with OneLogin
 ---
 
+import SquareIcon from "@version/docs/img/sso/onelogin/teleport.png"
+import RectangleIcon from "@version/docs/img/sso/onelogin/teleportlogo@2x.png"
+
 This guide will explain how to configure [OneLogin](https://www.onelogin.com/)
 to issue Teleport credentials to specific groups of users. When used in
 combination with role based access control (RBAC) it allows SSH administrators
@@ -37,8 +40,8 @@ to define policies like:
 
    You can find Teleport icons to upload from the following links:
 
-   - [Square Icon](../../../../img/sso/onelogin/teleport.png)
-   - [Rectangular Icon](../../../../img/sso/onelogin/teleportlogo@2x.png)
+   - <a href={SquareIcon} download>Square Icon</a>
+   - <a href={RectangleIcon} download>Rectangular Icon</a>
 
 1. From the application's **Configuration** page, set the following values:
 


### PR DESCRIPTION
Use `import` statements and `a` tags instead of Markdown links to get the download-only icon links in the One Login guide to work without 404ing.

A bug with the plugin that the docs engine uses to evaluate `@version` paths means that we need to include a paragraph break between `import` statements.