### PR TITLE
Fix health check worker not stopping

### DIFF
--- a/lib/healthcheck/manager_test.go
+++ b/lib/healthcheck/manager_test.go
@@ -197,6 +197,9 @@ func TestManager(t *testing.T) {
 		onConfigUpdate: func() {
 			eventsCh <- configUpdateTestEvent(prodDB.GetName())
 		},
+		onClose: func() {
+			eventsCh <- closedTestEvent(prodDB.GetName())
+		},
 	})
 	require.NoError(t, err)
 
@@ -218,6 +221,9 @@ func TestManager(t *testing.T) {
 		},
 		onConfigUpdate: func() {
 			eventsCh <- configUpdateTestEvent(devDB.GetName())
+		},
+		onClose: func() {
+			eventsCh <- closedTestEvent(devDB.GetName())
 		},
 	})
 	require.NoError(t, err)
@@ -388,6 +394,14 @@ func TestManager(t *testing.T) {
 
 	// prodDB should still be disabled
 	requireTargetHealth(t, prodDB, types.TargetHealthStatusUnknown, types.TargetHealthTransitionReasonDisabled)
+	err = mgr.RemoveTarget(prodDB)
+	require.NoError(t, err)
+
+	// make sure the workers have stopped.
+	awaitTestEvents(t, eventsCh, clock,
+		advanceByHCC(prodHCC, devHCC),
+		expect(closedTestEvent(devDB.GetName()), closedTestEvent(prodDB.GetName())),
+	)
 }
 
 func healthCheckConfigFixture(t *testing.T, name string) *healthcheckconfigv1.HealthCheckConfig {
@@ -552,10 +566,18 @@ type testEvent struct {
 type testEventName string
 
 const (
+	closed         testEventName = "closed"
 	configUpdate   testEventName = "configUpdate"
 	lastResultPass testEventName = "lastResultPass"
 	lastResultFail testEventName = "lastResultFail"
 )
+
+func closedTestEvent(targetName string) testEvent {
+	return testEvent{
+		name:   closed,
+		target: targetName,
+	}
+}
 
 func configUpdateTestEvent(targetName string) testEvent {
 	return testEvent{

--- a/lib/healthcheck/target.go
+++ b/lib/healthcheck/target.go
@@ -48,6 +48,8 @@ type Target struct {
 	onHealthCheck func(lastResultErr error)
 	// onConfigUpdate is called after each config update.
 	onConfigUpdate func()
+	// onClose is called after the target's worker closes.
+	onClose func()
 }
 
 func (t *Target) checkAndSetDefaults() error {

--- a/lib/healthcheck/worker.go
+++ b/lib/healthcheck/worker.go
@@ -72,7 +72,7 @@ func newWorker(ctx context.Context, cfg workerConfig) (*worker, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	go w.run(ctx)
+	go w.run()
 	return w, nil
 }
 
@@ -83,6 +83,7 @@ func newUnstartedWorker(ctx context.Context, cfg workerConfig) (*worker, error) 
 	}
 	ctx, cancel := context.WithCancel(ctx)
 	w := &worker{
+		closeContext:              ctx,
 		cancel:                    cancel,
 		clock:                     cfg.Clock,
 		healthCheckCfg:            cfg.HealthCheckCfg,
@@ -101,6 +102,8 @@ func newUnstartedWorker(ctx context.Context, cfg workerConfig) (*worker, error) 
 // worker perform health checks against a target resource and keeps track of
 // the target resource's health.
 type worker struct {
+	// closeContext is the work close context.
+	closeContext context.Context
 	// cancel stops the worker permanently when called.
 	cancel context.CancelFunc
 	// clock is used to control time in tests.
@@ -166,15 +169,18 @@ func (w *worker) Close() error {
 	return nil
 }
 
-func (w *worker) run(ctx context.Context) {
+func (w *worker) run() {
 	defer func() {
 		if w.healthCheckInterval != nil {
 			w.healthCheckInterval.Stop()
 		}
+		if w.target.onClose != nil {
+			w.target.onClose()
+		}
 	}()
 
 	if w.healthCheckCfg != nil {
-		w.startHealthCheckInterval(ctx)
+		w.startHealthCheckInterval(w.closeContext)
 		// no delay for the first health check after a target is registered
 		w.healthCheckInterval.FireNow()
 	}
@@ -185,13 +191,13 @@ func (w *worker) run(ctx context.Context) {
 	for {
 		select {
 		case <-w.nextHealthCheck():
-			w.checkHealth(ctx)
+			w.checkHealth(w.closeContext)
 			if w.target.onHealthCheck != nil {
 				w.target.onHealthCheck(w.lastResultErr)
 			}
 		case newCfg := <-w.healthCheckConfigUpdateCh:
-			w.updateHealthCheckConfig(ctx, newCfg)
-		case <-ctx.Done():
+			w.updateHealthCheckConfig(w.closeContext, newCfg)
+		case <-w.closeContext.Done():
 			return
 		}
 	}


### PR DESCRIPTION
Fixes a bug I introduced while fixing a flaky test in:
- https://github.com/gravitational/teleport/pull/54527

Basically in the above PR diff I accidentally made the cancel func no longer apply to the worker's run loop, so removing/closing the worker wouldn't stop it from health checking forever: 
```diff
 // newWorker creates and starts a new worker.
 func newWorker(ctx context.Context, cfg workerConfig) (*worker, error) {
+       w, err := newUnstartedWorker(ctx, cfg)
+       if err != nil {
+               return nil, trace.Wrap(err)
+       }
+       go w.run(ctx)
+       return w, nil
+}
+
+// newUnstartedWorker creates a worker without running it.
+func newUnstartedWorker(ctx context.Context, cfg workerConfig) (*worker, error) {
```

In this PR I refactored the worker to make this mistake impossible and added some tests to verify that closing a worker causes it to exit.
(This bug was not released)