### PR TITLE
Web: show status on unhealthy state only

### DIFF
--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
@@ -35,6 +35,7 @@ import {
 import { PinButton } from '../shared/PinButton';
 import { ResourceActionButtonWrapper } from '../shared/ResourceActionButton';
 import { SingleLineBox } from '../shared/SingleLineBox';
+import { isUnhealthy } from '../shared/StatusInfo';
 import { ResourceItemProps } from '../types';
 import { WarningRightEdgeBadgeSvg } from './WarningRightEdgeBadgeSvg';
 
@@ -167,7 +168,7 @@ export function ResourceCard({
     }
   };
 
-  const hasUnhealthyStatus = status && status !== 'healthy';
+  const hasUnhealthyStatus = isUnhealthy(status);
 
   return (
     <CardContainer

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
@@ -35,6 +35,7 @@ import {
 } from '../shared/getBackgroundColor';
 import { PinButton } from '../shared/PinButton';
 import { ResourceActionButtonWrapper } from '../shared/ResourceActionButton';
+import { isUnhealthy } from '../shared/StatusInfo';
 import { ResourceItemProps } from '../types';
 
 export function ResourceListItem({
@@ -70,7 +71,7 @@ export function ResourceListItem({
   }, [expandAllLabels]);
 
   const showLabelsButton = labels.length > 0 && (hovered || showLabels);
-  const hasUnhealthyStatus = status && status !== 'healthy';
+  const hasUnhealthyStatus = isUnhealthy(status);
 
   // Determines which column the resource type text should end at.
   // We do this because if there is no address, or the labels button

--- a/web/packages/shared/components/UnifiedResources/shared/StatusInfo.tsx
+++ b/web/packages/shared/components/UnifiedResources/shared/StatusInfo.tsx
@@ -39,7 +39,11 @@ import { useInfiniteScroll } from 'shared/hooks';
 import { Attempt } from 'shared/hooks/useAttemptNext';
 import { pluralize } from 'shared/utils/text';
 
-import { SharedResourceServer, UnifiedResourceDefinition } from '../types';
+import {
+  ResourceStatus,
+  SharedResourceServer,
+  UnifiedResourceDefinition,
+} from '../types';
 import { SingleLineBox } from './SingleLineBox';
 import { getDatabaseIconName } from './viewItemsFactory';
 
@@ -310,4 +314,8 @@ export function openStatusInfoPanel({
       viewHasOwnSidePanel: isEnterprise,
     });
   }
+}
+
+export function isUnhealthy(status: ResourceStatus): boolean {
+  return status && status === 'unhealthy';
 }


### PR DESCRIPTION
Prior, status `unknown` were being shown in the web UI. For unknown it could be one of:
- not intialized (havent run/reported a health check yet, but one is coming basically)
- disabled health checks
- internal_error (shouldn’t happen, this is a bug)

Only times when `unknown` statuses should be shown is when there are multiple servers (eg: db_servers), and they all have differing statuses. Currently, unified resource listing does not support reading/processing multiple db_servers for the same database to determine this, so this PR will only show status state if it's explicitly `unhealthy`.