### PR TITLE
[v17] fix: don't cache an incorrect PIV PIN

### DIFF
--- a/api/utils/keys/hardwarekey/cliprompt.go
+++ b/api/utils/keys/hardwarekey/cliprompt.go
@@ -73,8 +73,16 @@ func (c *cliPrompt) AskPIN(ctx context.Context, requirement PINPromptRequirement
 		msg = fmt.Sprintf("%v to continue with command %q", msg, keyInfo.Command)
 	}
 
-	password, err := prompt.Password(ctx, c.writer, c.reader, msg)
-	return password, trace.Wrap(err)
+	pin, err := prompt.Password(ctx, c.writer, c.reader, msg)
+	if err != nil {
+		return "", nil
+	}
+
+	if pin == "" {
+		pin = DefaultPIN
+	}
+
+	return pin, trace.Wrap(err)
 }
 
 // Touch prompts the user to touch the hardware key.

--- a/api/utils/keys/piv/pincache_test.go
+++ b/api/utils/keys/piv/pincache_test.go
@@ -1,3 +1,5 @@
+//go:build pivtest
+
 // Copyright 2025 Gravitational, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/utils/keys/piv/yubikey.go
+++ b/api/utils/keys/piv/yubikey.go
@@ -238,8 +238,8 @@ func (y *YubiKey) sign(ctx context.Context, ref *hardwarekey.PrivateKeyRef, keyI
 				defer touchPromptDelayTimer.Reset(signTouchPromptDelay)
 			}
 		}
-		pin, err := y.pinCache.PromptOrGetPIN(ctx, prompt, hardwarekey.PINRequired, keyInfo, ref.PINCacheTTL)
-		return pin, trace.Wrap(err)
+
+		return y.promptPIN(ctx, prompt, hardwarekey.PINRequired, keyInfo, ref.PINCacheTTL)
 	}
 
 	pinPolicy := piv.PINPolicyNever
@@ -371,7 +371,7 @@ func (y *YubiKey) generatePrivateKey(slot piv.Slot, policy hardwarekey.PromptPol
 		TouchPolicy: touchPolicy,
 	}
 
-	if _, err := y.conn.generateKey(piv.DefaultManagementKey, slot, opts); err != nil {
+	if err := y.GenerateKey(slot, opts); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -383,6 +383,12 @@ func (y *YubiKey) generatePrivateKey(slot piv.Slot, policy hardwarekey.PromptPol
 	}
 
 	return y.getKeyRef(slot, pinCacheTTL)
+}
+
+// GenerateKey generates a new private key in the given PIV slot.
+func (y *YubiKey) GenerateKey(slot piv.Slot, opts piv.Key) error {
+	_, err := y.conn.generateKey(piv.DefaultManagementKey, slot, opts)
+	return trace.Wrap(err)
 }
 
 // SetMetadataCertificate creates a self signed certificate and stores it in the YubiKey's
@@ -468,27 +474,62 @@ func (y *YubiKey) SetPIN(oldPin, newPin string) error {
 // If the user provides the default PIN, they will be prompted to set a
 // non-default PIN and PUK before continuing.
 func (y *YubiKey) checkOrSetPIN(ctx context.Context, prompt hardwarekey.Prompt, keyInfo hardwarekey.ContextualKeyInfo, pinCacheTTL time.Duration) error {
-	pin, err := y.pinCache.PromptOrGetPIN(ctx, prompt, hardwarekey.PINOptional, keyInfo, pinCacheTTL)
+	pin, err := y.promptPIN(ctx, prompt, hardwarekey.PINOptional, keyInfo, pinCacheTTL)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	switch pin {
-	case piv.DefaultPIN:
+	if pin == piv.DefaultPIN {
 		fmt.Fprintf(os.Stderr, "The default PIN %q is not supported.\n", piv.DefaultPIN)
-		fallthrough
-	case "":
-		pin, err = y.setPINAndPUKFromDefault(ctx, prompt, keyInfo)
+
+		pin, err = y.setPINAndPUKFromDefault(ctx, prompt, keyInfo, pinCacheTTL)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		y.pinCache.setPIN(pin, pinCacheTTL)
 	}
 
-	return trace.Wrap(y.verifyPIN(pin))
+	return nil
 }
 
-func (y *YubiKey) setPINAndPUKFromDefault(ctx context.Context, prompt hardwarekey.Prompt, keyInfo hardwarekey.ContextualKeyInfo) (string, error) {
+// PIN (or PUK) prompts time out after 1 minute to prevent an indefinite hold of
+// the pin cache mutex or the exclusive PC/SC transaction.
+const pinPromptTimeout = time.Minute
+
+func (y *YubiKey) promptPIN(ctx context.Context, prompt hardwarekey.Prompt, requirement hardwarekey.PINPromptRequirement, keyInfo hardwarekey.ContextualKeyInfo, pinCacheTTL time.Duration) (string, error) {
+	y.pinCache.mu.Lock()
+	defer y.pinCache.mu.Unlock()
+
+	pin := y.pinCache.getPIN(pinCacheTTL)
+	if pin != "" {
+		return pin, nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, pinPromptTimeout)
+	defer cancel()
+
+	pin, err := prompt.AskPIN(ctx, requirement, keyInfo)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	// Verify that the PIN is correct before we cache it. This also caches it internally in the PC/SC transaction.
+	// TODO(Joerger): In the signature pin prompt logic, we unfortunately repeat this verification
+	// due to the way the upstream piv-go library handles PIN prompts.
+	if err := y.verifyPIN(pin); err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	y.pinCache.setPIN(pin, pinCacheTTL)
+	return pin, nil
+}
+
+func (y *YubiKey) setPINAndPUKFromDefault(ctx context.Context, prompt hardwarekey.Prompt, keyInfo hardwarekey.ContextualKeyInfo, pinCacheTTL time.Duration) (string, error) {
+	y.pinCache.mu.Lock()
+	defer y.pinCache.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(ctx, pinPromptTimeout)
+	defer cancel()
+
 	pinAndPUK, err := prompt.ChangePIN(ctx, keyInfo)
 	if err != nil {
 		return "", trace.Wrap(err)
@@ -504,10 +545,12 @@ func (y *YubiKey) setPINAndPUKFromDefault(ctx context.Context, prompt hardwareke
 		}
 	}
 
+	// unblock caches the new PIN the same way verify does.
 	if err := y.conn.unblock(pinAndPUK.PUK, pinAndPUK.PIN); err != nil {
 		return "", trace.Wrap(err)
 	}
 
+	y.pinCache.setPIN(pinAndPUK.PIN, pinCacheTTL)
 	return pinAndPUK.PIN, nil
 }
 

--- a/lib/teleterm/daemon/hardwarekeyprompt.go
+++ b/lib/teleterm/daemon/hardwarekeyprompt.go
@@ -95,7 +95,13 @@ func (h *hardwareKeyPrompter) AskPIN(ctx context.Context, requirement hardwareke
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
-	return res.Pin, nil
+
+	pin := res.Pin
+	if pin == "" {
+		pin = hardwarekey.DefaultPIN
+	}
+
+	return pin, nil
 }
 
 // ChangePIN asks for a new PIN.


### PR DESCRIPTION
Changelog: Fix an issue with PIV PIN caching where a PIN that is incorrect would be cached.

Backport https://github.com/gravitational/teleport/pull/54614 to branch/v17