### PR TITLE
[v16] build: Add Makefile target to install wasm-{pack,bindgen}

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -38,7 +38,6 @@ jobs:
           echo NODE_VERSION=$(make -s -C build.assets print-node-version) >> $GITHUB_ENV
           echo GOLANG_VERSION=$(make -s -C build.assets print-go-version | sed 's/^go//') >> $GITHUB_ENV
           echo RUST_VERSION=$(make -s -C build.assets print-rust-version) >> $GITHUB_ENV
-          echo WASM_PACK_VERSION=$(make -s -C build.assets print-wasm-pack-version) >> $GITHUB_ENV
           echo PKG_CONFIG_PATH="$(build.assets/build-fido2-macos.sh pkg_config_path)" >> $GITHUB_ENV
 
       - name: Print versions
@@ -47,7 +46,6 @@ jobs:
           echo "node: ${NODE_VERSION}"
           echo "go: ${GOLANG_VERSION}"
           echo "rust: ${RUST_VERSION}"
-          echo "wasm-pack: ${WASM_PACK_VERSION}"
 
       - name: Install Node Toolchain
         uses: actions/setup-node@v4
@@ -69,19 +67,7 @@ jobs:
           rustup override set ${{ env.RUST_VERSION }}
 
       - name: Install wasm-pack
-        run: |
-          BINDGEN_VERSION=$(\
-            cargo metadata --locked --format-version=1 | \
-            jq -r '[.packages[] | select(.name == "wasm-bindgen") | .version] | if length == 1 then .[0] else "NO VERSION" end' \
-          )
-          if [ "${BINDGEN_VERSION}" = 'NO VERSION' ]; then
-            echo 'Unknown bindgen version. Is it in Cargo.lock?'
-            exit 1
-          fi
-          # Install wasm-bindgen-cli so wasm-pack does not try to compile it itself.
-          # We have more control this way.
-          cargo install wasm-bindgen-cli --locked --version "${BINDGEN_VERSION}"
-          cargo install wasm-pack --locked --version ${WASM_PACK_VERSION}
+        run: make ensure-wasm-deps
 
       - name: Build
         run: make binaries

--- a/Makefile
+++ b/Makefile
@@ -1707,12 +1707,52 @@ ensure-js-deps:
 	@if [[ "${WEBASSETS_SKIP_BUILD}" -eq 1 ]]; then mkdir -p webassets/teleport && touch webassets/teleport/index.html; \
 	else $(MAKE) ensure-js-package-manager && pnpm install --frozen-lockfile; fi
 
+.PHONY: ensure-wasm-deps
+ifeq ($(WEBASSETS_SKIP_BUILD),1)
+ensure-wasm-deps:
+else
+ensure-wasm-deps: ensure-wasm-pack ensure-wasm-bindgen
+
+# Get the version of wasm-bindgen from cargo, as that is what wasm-pack is
+# going to do when it checks for the right version. The buildboxes do not
+# have jq installed (yet), so have a hacky awk version on standby.
+CARGO_GET_VERSION_JQ = cargo metadata --locked --format-version=1 | jq -r 'first(.packages[] | select(.name? == "$(1)") | .version)'
+CARGO_GET_VERSION_AWK = awk -F '[ ="]+' '/^name = "$(1)"$$/ {inpkg = 1} inpkg && $$1 == "version" {print $$2; exit}' Cargo.lock
+
+BIN_JQ = $(shell which jq 2>/dev/null)
+CARGO_GET_VERSION = $(if $(BIN_JQ),$(CARGO_GET_VERSION_JQ),$(CARGO_GET_VERSION_AWK))
+
+ensure-wasm-pack: NEED_VERSION = $(shell $(MAKE) --no-print-directory -s -C build.assets print-wasm-pack-version)
+ensure-wasm-pack: INSTALLED_VERSION = $(lastword $(shell wasm-pack --version 2>/dev/null))
+ensure-wasm-pack:
+	$(if $(filter-out $(INSTALLED_VERSION),$(NEED_VERSION)),\
+		cargo install wasm-pack --locked --version "$(NEED_VERSION)", \
+		@echo wasm-pack up-to-date: $(INSTALLED_VERSION) \
+	)
+
+# TODO: Use CARGO_GET_VERSION_AWK instead of hardcoded version
+#       On 386 Arch, calling the variable produces a malformed command that fails the build.
+#ensure-wasm-bindgen: NEED_VERSION = $(shell $(call CARGO_GET_VERSION,wasm-bindgen))
+ensure-wasm-bindgen: NEED_VERSION = 0.2.95
+ensure-wasm-bindgen: INSTALLED_VERSION = $(lastword $(shell wasm-bindgen --version 2>/dev/null))
+ensure-wasm-bindgen:
+ifeq ($(CI),true)
+	@: $(or $(NEED_VERSION),$(error Unknown wasm-bindgen version. Is it in Cargo.lock?))
+	$(if $(filter-out $(INSTALLED_VERSION),$(NEED_VERSION)),\
+		cargo install wasm-bindgen-cli --locked --version "$(NEED_VERSION)", \
+		@echo wasm-bindgen-cli up-to-date: $(INSTALLED_VERSION) \
+	)
+else
+	@echo Skipping ensure-wasm-bindgen, to run set CI=true
+endif
+endif
+
 .PHONY: build-ui
-build-ui: ensure-js-deps
+build-ui: ensure-js-deps ensure-wasm-deps
 	@[ "${WEBASSETS_SKIP_BUILD}" -eq 1 ] || pnpm build-ui-oss
 
 .PHONY: build-ui-e
-build-ui-e: ensure-js-deps
+build-ui-e: ensure-js-deps ensure-wasm-deps
 	@[ "${WEBASSETS_SKIP_BUILD}" -eq 1 ] || pnpm build-ui-e
 
 .PHONY: docker-ui

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -8,7 +8,7 @@ HOSTNAME=buildbox
 SRCDIR=/go/src/github.com/gravitational/teleport
 GOMODCACHE ?= /tmp/gomodcache
 # TODO(hugoShaka) remove HELM_PLUGINS with teleport13 buildbox
-DOCKERFLAGS := --rm=true -v "$$(pwd)/../":$(SRCDIR) -v /tmp:/tmp -w $(SRCDIR) -h $(HOSTNAME) -e GOMODCACHE=$(GOMODCACHE) -e HELM_PLUGINS=/home/ci/.local/share/helm/plugins-new -e GITHUB_REPOSITORY_OWNER=$(GITHUB_REPOSITORY_OWNER) -e MAKEFLAGS
+DOCKERFLAGS := --rm=true -v "$$(pwd)/../":$(SRCDIR) -v /tmp:/tmp -w $(SRCDIR) -h $(HOSTNAME) -e GOMODCACHE=$(GOMODCACHE) -e HELM_PLUGINS=/home/ci/.local/share/helm/plugins-new -e GITHUB_REPOSITORY_OWNER=$(GITHUB_REPOSITORY_OWNER) -e MAKEFLAGS -e CI=true
 # Teleport version - some targets require this to be set
 VERSION ?= $(shell egrep ^VERSION ../Makefile | cut -d= -f2)
 


### PR DESCRIPTION
Add a `Makefile` target, `ensure-wasm-deps` to install `wasm-pack` and
`wasm-bindgen` if they are not installed or are the wrong version, but
only on CI for now (if the CI env var is set).

We want to install `wasm-bindgen` ourselves as we want to install it
with `--locked`. `wasm-pack` will install it if it is not present or the
wrong version, but it does not use `--locked` which sometimes causes the
build of `wasm-bindgen` to fail if versions of stuff on crates.io change
or the tea leaves say so. This way is more deterministic and prevents us
breaking from stuff that others do.

Remove the commands from the `build-macos.yaml` workflow that install
`wasm-pack` and `wasm-bindgen` and call the new `Makefile` target
instead. We keep this separate, as even though it is a proper dependency
of building the UI, keeping it separate makes it easier to diagnose
failures in the CI logs.

This currently has the wasm-bindgen-cli package hard-coded to 0.2.99,
which will need to be changed to 0.2.95 for v16 and v17 backports and
0.2.100 for v15. Current issues with this change on the i386 build has
forced this hardcoding for expediency to get a release out. This will be
revisited to be dynamic.

This backport changes 0.2.99 to 0.2.95 for branch/v16.

Backport: https://github.com/gravitational/teleport/pull/54652
