### PR TITLE
ci: Install wasm-pack for Windows Teleport Connect build

### DIFF
--- a/build.assets/windows/build.ps1
+++ b/build.assets/windows/build.ps1
@@ -164,6 +164,25 @@ function Enable-Node {
     }
 }
 
+function Install-WasmPack {
+    <#
+    .SYNOPSIS
+        Builds and installs wasm-pack and dependent tooling.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string] $WasmPackVersion
+    )
+    begin {
+        Write-Host "::group::Installing wasm-pack $WasmPackVersion"
+        # TODO(camscale): Don't hard-code wasm-binden-cli version
+        cargo install wasm-bindgen-cli --locked --version 0.2.99
+        cargo install wasm-pack --locked --version "$WasmPackVersion"
+        Write-Host "::endgroup::"
+    }
+}
+
 function Install-Wintun {
     <#
     .SYNOPSIS
@@ -294,6 +313,9 @@ function Install-BuildRequirements {
 
         $GoVersion = $(make --no-print-directory -C "$TeleportSourceDirectory/build.assets" print-go-version).TrimStart("go")
         Install-Go -GoVersion "$GoVersion" -ToolchainDir "$InstallDirectory"
+
+        $WasmPackVersion = $(make --no-print-directory -C "$TeleportSourceDirectory/build.assets" print-wasm-pack-version).Trim()
+        Install-WasmPack -WasmPackVersion "$WasmPackVersion"
     }
     Write-Host $("All build requirements installed in {0:g}" -f $CommandDuration)
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,3 +26,5 @@ peerDependencyRules:
     # This dep is needed only when using Squirrel.Windows as an installer in electron-build which we
     # don't use. https://www.electron.build/squirrel-windows.html
     - electron-builder-squirrel-windows
+# shellEmulator enables cross-platform scripting, allowing POSIX-style shell variables to work on Windows.
+shellEmulator: true

--- a/web/packages/teleterm/README.md
+++ b/web/packages/teleterm/README.md
@@ -41,6 +41,17 @@ cd teleport
 pnpm install && make build/tsh
 ```
 
+The app depends on Rust WASM code. To compile it, the following tools have to be installed:
+* `Rust` and `Cargo`. The required version is specified by `RUST_VERSION` in [build.assets/Makefile](https://github.com/gravitational/teleport/blob/master/build.assets/versions.mk#L11).
+* [`wasm-pack`](https://github.com/rustwasm/wasm-pack). The required version is specified by `WASM_PACK_VERSION` in [build.assets/Makefile](https://github.com/gravitational/teleport/blob/master/build.assets/versions.mk#L12).
+* [`binaryen`](https://github.com/WebAssembly/binaryen) which contains `wasm-opt`. This is required on on linux aarch64 (64-bit ARM).
+  You can check if it's already installed on your system by running `which wasm-opt`. If not you can install it like `apt-get install binaryen` (for Debian-based Linux). `wasm-pack` will install this automatically on other platforms.
+
+To automatically install `wasm-pack`, run the following command:
+```shell
+make ensure-wasm-deps
+```
+
 To launch `teleterm` in development mode:
 
 ```sh


### PR DESCRIPTION
Install wasm-pack in `windows/build.ps1` as Teleport Connect now needs it to build.

Windows build https://github.com/gravitational/teleport.e/actions/runs/14967484584/job/42040621494