### PR TITLE
MWI: Add SSRF protection to Sigstore discovery

### DIFF
--- a/docs/pages/reference/machine-id/configuration.mdx
+++ b/docs/pages/reference/machine-id/configuration.mdx
@@ -714,6 +714,7 @@ attestors:
     # reduce the surface area for SSRF attacks.
     allowed_private_network_prefixes:
       - "192.168.1.42/32"
+      - "fd12:3456:789a:1::1/128"
   # systemd is configuration for the Systemd Workload Attestor. See the Workload
   # Identity API & Workload Attestation reference for more information.
   systemd:

--- a/docs/pages/reference/machine-id/configuration.mdx
+++ b/docs/pages/reference/machine-id/configuration.mdx
@@ -708,6 +708,12 @@ attestors:
     # credentials_path is the path to a Docker or Podman configuration file
     # containing per-registry credentials.
     credentials_path: /path/to/docker/config.json
+    # allowed_network_prefixes are the private IP address prefixes (CIDR blocks)
+    # that the Sigstore attestor is allowed to connect to. By default, tbot will
+    # only connect to registries at publicly-routable IP addresses to reduce the
+    # surface area for SSRF attacks.
+    allowed_network_prefixes:
+      - "192.168.1.42/32"
   # systemd is configuration for the Systemd Workload Attestor. See the Workload
   # Identity API & Workload Attestation reference for more information.
   systemd:

--- a/docs/pages/reference/machine-id/configuration.mdx
+++ b/docs/pages/reference/machine-id/configuration.mdx
@@ -708,11 +708,11 @@ attestors:
     # credentials_path is the path to a Docker or Podman configuration file
     # containing per-registry credentials.
     credentials_path: /path/to/docker/config.json
-    # allowed_network_prefixes are the private IP address prefixes (CIDR blocks)
-    # that the Sigstore attestor is allowed to connect to. By default, tbot will
-    # only connect to registries at publicly-routable IP addresses to reduce the
-    # surface area for SSRF attacks.
-    allowed_network_prefixes:
+    # allowed_private_network_prefixes are the private IP address prefixes (CIDR
+    # blocks) that the Sigstore attestor is allowed to connect to. By default,
+    # tbot will only connect to registries at publicly-routable IP addresses to
+    # reduce the surface area for SSRF attacks.
+    allowed_private_network_prefixes:
       - "192.168.1.42/32"
   # systemd is configuration for the Systemd Workload Attestor. See the Workload
   # Identity API & Workload Attestation reference for more information.

--- a/docs/pages/reference/workload-identity/sigstore-attestation.mdx
+++ b/docs/pages/reference/workload-identity/sigstore-attestation.mdx
@@ -248,6 +248,8 @@ services:
         additional_registries:
           - host: ghcr.io
         credentials_path: /path/to/docker/config.json
+        allowed_network_prefixes:
+          - "192.168.1.42/32"
 ```
 
 In order for `tbot` to discover signatures for a workload's container image, you
@@ -278,6 +280,13 @@ such as [`docker-credential-gcr`](https://github.com/GoogleCloudPlatform/docker-
 Often, the most straightforward way to create a credentials file for `tbot` is
 to use `docker login` and copy the `auths` and `credHelpers` sections out of
 `$HOME/.docker/config.json`.
+
+By default, `tbot` will refuse to connect to registries hosted at private network
+addresses (e.g. in IP ranges designated for private use by [RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918))
+to reduce the surface area for SSRF attacks. If your registry is on a private
+network, you can add its IP to the `allowed_network_prefixes` list using CIDR
+notation.
+
 
 ### Using Kubernetes registry credentials
 

--- a/docs/pages/reference/workload-identity/sigstore-attestation.mdx
+++ b/docs/pages/reference/workload-identity/sigstore-attestation.mdx
@@ -250,6 +250,7 @@ services:
         credentials_path: /path/to/docker/config.json
         allowed_private_network_prefixes:
           - "192.168.1.42/32"
+          - "fd12:3456:789a:1::1/128"
 ```
 
 In order for `tbot` to discover signatures for a workload's container image, you

--- a/docs/pages/reference/workload-identity/sigstore-attestation.mdx
+++ b/docs/pages/reference/workload-identity/sigstore-attestation.mdx
@@ -248,7 +248,7 @@ services:
         additional_registries:
           - host: ghcr.io
         credentials_path: /path/to/docker/config.json
-        allowed_network_prefixes:
+        allowed_private_network_prefixes:
           - "192.168.1.42/32"
 ```
 
@@ -284,8 +284,8 @@ to use `docker login` and copy the `auths` and `credHelpers` sections out of
 By default, `tbot` will refuse to connect to registries hosted at private network
 addresses (e.g. in IP ranges designated for private use by [RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918))
 to reduce the surface area for SSRF attacks. If your registry is on a private
-network, you can add its IP to the `allowed_network_prefixes` list using CIDR
-notation.
+network, you can add its IP to the `allowed_private_network_prefixes` list using
+CIDR notation.
 
 
 ### Using Kubernetes registry credentials

--- a/docs/pages/reference/workload-identity/workload-identity-api-and-workload-attestation.mdx
+++ b/docs/pages/reference/workload-identity/workload-identity-api-and-workload-attestation.mdx
@@ -119,6 +119,7 @@ attestors:
     # reduce the surface area for SSRF attacks.
     allowed_private_network_prefixes:
       - "192.168.1.42/32"
+      - "fd12:3456:789a:1::1/128"
   # systemd is configuration for the Systemd Workload attestor. See the Systemd
   # section below for more information.
   systemd:

--- a/docs/pages/reference/workload-identity/workload-identity-api-and-workload-attestation.mdx
+++ b/docs/pages/reference/workload-identity/workload-identity-api-and-workload-attestation.mdx
@@ -113,6 +113,12 @@ attestors:
     # credentials_path is the path to a Docker or Podman configuration file
     # containing per-registry credentials.
     credentials_path: /path/to/docker/config.json
+    # allowed_network_prefixes are the private IP address prefixes (CIDR blocks)
+    # that the Sigstore attestor is allowed to connect to. By default, tbot will
+    # only connect to registries at publicly-routable IP addresses to reduce the
+    # surface area for SSRF attacks.
+    allowed_network_prefixes:
+      - "192.168.1.42/32"
   # systemd is configuration for the Systemd Workload attestor. See the Systemd
   # section below for more information.
   systemd:

--- a/docs/pages/reference/workload-identity/workload-identity-api-and-workload-attestation.mdx
+++ b/docs/pages/reference/workload-identity/workload-identity-api-and-workload-attestation.mdx
@@ -113,11 +113,11 @@ attestors:
     # credentials_path is the path to a Docker or Podman configuration file
     # containing per-registry credentials.
     credentials_path: /path/to/docker/config.json
-    # allowed_network_prefixes are the private IP address prefixes (CIDR blocks)
-    # that the Sigstore attestor is allowed to connect to. By default, tbot will
-    # only connect to registries at publicly-routable IP addresses to reduce the
-    # surface area for SSRF attacks.
-    allowed_network_prefixes:
+    # allowed_private_network_prefixes are the private IP address prefixes (CIDR
+    # blocks) that the Sigstore attestor is allowed to connect to. By default,
+    # tbot will only connect to registries at publicly-routable IP addresses to
+    # reduce the surface area for SSRF attacks.
+    allowed_private_network_prefixes:
       - "192.168.1.42/32"
   # systemd is configuration for the Systemd Workload attestor. See the Systemd
   # section below for more information.

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	cloud.google.com/go/resourcemanager v1.10.6
 	cloud.google.com/go/spanner v1.80.0
 	cloud.google.com/go/storage v1.52.0
+	code.dny.dev/ssrf v0.2.0
 	connectrpc.com/connect v1.18.1
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -630,6 +630,8 @@ cloud.google.com/go/workflows v1.7.0/go.mod h1:JhSrZuVZWuiDfKEFxU0/F1PQjmpnpcoIS
 cloud.google.com/go/workflows v1.8.0/go.mod h1:ysGhmEajwZxGn1OhGOGKsTXc5PyxOc0vfKf5Af+to4M=
 cloud.google.com/go/workflows v1.9.0/go.mod h1:ZGkj1aFIOd9c8Gerkjjq7OW7I5+l6cSvT3ujaO/WwSA=
 cloud.google.com/go/workflows v1.10.0/go.mod h1:fZ8LmRmZQWacon9UCX1r/g/DfAXx5VcPALq2CxzdePw=
+code.dny.dev/ssrf v0.2.0 h1:wCBP990rQQ1CYfRpW+YK1+8xhwUjv189AQ3WMo1jQaI=
+code.dny.dev/ssrf v0.2.0/go.mod h1:B+91l25OnyaLIeCx0WRJN5qfJ/4/ZTZxRXgm0lj/2w8=
 connectrpc.com/connect v1.18.1 h1:PAg7CjSAGvscaf6YZKUefjoih5Z/qYkyaTrBW8xvYPw=
 connectrpc.com/connect v1.18.1/go.mod h1:0292hj1rnx8oFrStN7cB4jjVBeqs+Yx5yDIC2prWDO8=
 cuelabs.dev/go/oci/ociregistry v0.0.0-20241125120445-2c00c104c6e1 h1:mRwydyTyhtRX2wXS3mqYWzR2qlv6KsmoKXmlz5vInjg=

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -31,6 +31,7 @@ require (
 	cloud.google.com/go/kms v1.21.2 // indirect
 	cloud.google.com/go/longrunning v0.6.6 // indirect
 	cloud.google.com/go/resourcemanager v1.10.6 // indirect
+	code.dny.dev/ssrf v0.2.0 // indirect
 	connectrpc.com/connect v1.18.1 // indirect
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -61,6 +61,8 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 cloud.google.com/go/storage v1.52.0 h1:ROpzMW/IwipKtatA69ikxibdzQSiXJrY9f6IgBa9AlA=
 cloud.google.com/go/storage v1.52.0/go.mod h1:4wrBAbAYUvYkbrf19ahGm4I5kDQhESSqN3CGEkMGvOY=
+code.dny.dev/ssrf v0.2.0 h1:wCBP990rQQ1CYfRpW+YK1+8xhwUjv189AQ3WMo1jQaI=
+code.dny.dev/ssrf v0.2.0/go.mod h1:B+91l25OnyaLIeCx0WRJN5qfJ/4/ZTZxRXgm0lj/2w8=
 connectrpc.com/connect v1.18.1 h1:PAg7CjSAGvscaf6YZKUefjoih5Z/qYkyaTrBW8xvYPw=
 connectrpc.com/connect v1.18.1/go.mod h1:0292hj1rnx8oFrStN7cB4jjVBeqs+Yx5yDIC2prWDO8=
 dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=

--- a/lib/tbot/workloadidentity/workloadattest/sigstore.go
+++ b/lib/tbot/workloadidentity/workloadattest/sigstore.go
@@ -56,11 +56,11 @@ type SigstoreAttestorConfig struct {
 	// the default locations (e.g. `$HOME/.docker/config.json`).
 	CredentialsPath string `yaml:"credentials_path,omitempty"`
 
-	// AllowedNetworkPrefixes configures the private network prefixes at which
-	// registries can be reached. By default, the attestor will refuse to connect
-	// to registries hosted at IPs designated for private use (e.g. 10.0.0.0/8)
+	// AllowedPrivateNetworkPrefixes configures the private network prefixes at
+	// which registries can be reached. By default, the attestor will refuse to
+	// connect to registries hosted at IPs designated for private use (e.g. 10.0.0.0/8)
 	// in order to mitigate SSRF attacks.
-	AllowedNetworkPrefixes []string `yaml:"allowed_network_prefixes,omitempty"`
+	AllowedPrivateNetworkPrefixes []string `yaml:"allowed_private_network_prefixes,omitempty"`
 }
 
 func (s SigstoreAttestorConfig) CheckAndSetDefaults() error {
@@ -90,9 +90,9 @@ func (s SigstoreAttestorConfig) CheckAndSetDefaults() error {
 		}
 	}
 
-	for idx, prefix := range s.AllowedNetworkPrefixes {
+	for idx, prefix := range s.AllowedPrivateNetworkPrefixes {
 		if _, err := netip.ParsePrefix(prefix); err != nil {
-			return trace.Wrap(err, "parsing allowed_network_prefixes[%d])", idx)
+			return trace.Wrap(err, "parsing allowed_private_network_prefixes[%d])", idx)
 		}
 	}
 
@@ -171,10 +171,10 @@ func (a *SigstoreAttestor) Attest(ctx context.Context, ctr Container) (*workload
 		ctr.GetImage(),
 		ctr.GetImageDigest(),
 		sigstore.DiscoveryConfig{
-			Logger:                 a.log,
-			Keychain:               a.keychain,
-			AdditionalRegistries:   a.registryHosts,
-			AllowedNetworkPrefixes: a.cfg.AllowedNetworkPrefixes,
+			Logger:                        a.log,
+			Keychain:                      a.keychain,
+			AdditionalRegistries:          a.registryHosts,
+			AllowedPrivateNetworkPrefixes: a.cfg.AllowedPrivateNetworkPrefixes,
 		},
 	)
 	if err != nil {

--- a/lib/tbot/workloadidentity/workloadattest/sigstore.go
+++ b/lib/tbot/workloadidentity/workloadattest/sigstore.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/netip"
 	"os"
 	"sync"
 	"time"
@@ -54,6 +55,12 @@ type SigstoreAttestorConfig struct {
 	// will be used to find registry credentials. If it's unset, we'll look in
 	// the default locations (e.g. `$HOME/.docker/config.json`).
 	CredentialsPath string `yaml:"credentials_path,omitempty"`
+
+	// AllowedNetworkPrefixes configures the private network prefixes at which
+	// registries can be reached. By default, the attestor will refuse to connect
+	// to registries hosted at IPs designated for private use (e.g. 10.0.0.0/8)
+	// in order to mitigate SSRF attacks.
+	AllowedNetworkPrefixes []string `yaml:"allowed_network_prefixes,omitempty"`
 }
 
 func (s SigstoreAttestorConfig) CheckAndSetDefaults() error {
@@ -80,6 +87,12 @@ func (s SigstoreAttestorConfig) CheckAndSetDefaults() error {
 
 		if _, err := name.NewRegistry(reg.Host); err != nil {
 			return trace.Wrap(err, "parsing %s", field)
+		}
+	}
+
+	for idx, prefix := range s.AllowedNetworkPrefixes {
+		if _, err := netip.ParsePrefix(prefix); err != nil {
+			return trace.Wrap(err, "parsing allowed_network_prefixes[%d])", idx)
 		}
 	}
 
@@ -158,9 +171,10 @@ func (a *SigstoreAttestor) Attest(ctx context.Context, ctr Container) (*workload
 		ctr.GetImage(),
 		ctr.GetImageDigest(),
 		sigstore.DiscoveryConfig{
-			Logger:               a.log,
-			Keychain:             a.keychain,
-			AdditionalRegistries: a.registryHosts,
+			Logger:                 a.log,
+			Keychain:               a.keychain,
+			AdditionalRegistries:   a.registryHosts,
+			AllowedNetworkPrefixes: a.cfg.AllowedNetworkPrefixes,
 		},
 	)
 	if err != nil {

--- a/lib/tbot/workloadidentity/workloadattest/sigstore/discovery.go
+++ b/lib/tbot/workloadidentity/workloadattest/sigstore/discovery.go
@@ -37,10 +37,10 @@ const maxPayloads = 25
 
 // DiscoveryConfig contains configuration for the Sigstore discovery process.
 type DiscoveryConfig struct {
-	Logger                 *slog.Logger
-	Keychain               authn.Keychain
-	AdditionalRegistries   []string
-	AllowedNetworkPrefixes []string
+	Logger                        *slog.Logger
+	Keychain                      authn.Keychain
+	AdditionalRegistries          []string
+	AllowedPrivateNetworkPrefixes []string
 }
 
 // Discover signatures and attestations for the given image digest.
@@ -64,8 +64,8 @@ func Discover(ctx context.Context, image, digest string, cfg DiscoveryConfig) ([
 		return nil, trace.Wrap(err, "parsing image digest")
 	}
 
-	allowedPrefixes := make([]netip.Prefix, len(cfg.AllowedNetworkPrefixes))
-	for idx, prefix := range cfg.AllowedNetworkPrefixes {
+	allowedPrefixes := make([]netip.Prefix, len(cfg.AllowedPrivateNetworkPrefixes))
+	for idx, prefix := range cfg.AllowedPrivateNetworkPrefixes {
 		nip, err := netip.ParsePrefix(prefix)
 		if err != nil {
 			return nil, trace.Wrap(err, "parsing allowed network prefix [%d]: %q", idx, prefix)

--- a/lib/tbot/workloadidentity/workloadattest/sigstore/discovery.go
+++ b/lib/tbot/workloadidentity/workloadattest/sigstore/discovery.go
@@ -20,6 +20,7 @@ package sigstore
 import (
 	"context"
 	"log/slog"
+	"net/netip"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -36,9 +37,10 @@ const maxPayloads = 25
 
 // DiscoveryConfig contains configuration for the Sigstore discovery process.
 type DiscoveryConfig struct {
-	Logger               *slog.Logger
-	Keychain             authn.Keychain
-	AdditionalRegistries []string
+	Logger                 *slog.Logger
+	Keychain               authn.Keychain
+	AdditionalRegistries   []string
+	AllowedNetworkPrefixes []string
 }
 
 // Discover signatures and attestations for the given image digest.
@@ -62,11 +64,21 @@ func Discover(ctx context.Context, image, digest string, cfg DiscoveryConfig) ([
 		return nil, trace.Wrap(err, "parsing image digest")
 	}
 
+	allowedPrefixes := make([]netip.Prefix, len(cfg.AllowedNetworkPrefixes))
+	for idx, prefix := range cfg.AllowedNetworkPrefixes {
+		nip, err := netip.ParsePrefix(prefix)
+		if err != nil {
+			return nil, trace.Wrap(err, "parsing allowed network prefix [%d]: %q", idx, prefix)
+		}
+		allowedPrefixes[idx] = nip
+	}
+	transport := buildSafeTransport(allowedPrefixes)
+
 	payloads := make([]*workloadidentityv1.SigstoreVerificationPayload, 0)
 	for _, reg := range registries {
 		name := reg.Repo(ref.Context().RepositoryStr())
 
-		repo, err := NewRepository(name, cfg.Logger, cfg.Keychain)
+		repo, err := NewRepository(name, cfg.Logger, cfg.Keychain, transport)
 		if err != nil {
 			return nil, trace.Wrap(err, "constructing repository")
 		}

--- a/lib/tbot/workloadidentity/workloadattest/sigstore/discovery_test.go
+++ b/lib/tbot/workloadidentity/workloadattest/sigstore/discovery_test.go
@@ -39,6 +39,8 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
+var loopbackPrefixes = []string{"127.0.0.1/8", "::1/128"}
+
 func TestDiscovery_SimpleSigning(t *testing.T) {
 	registry := sigstoretest.RunTestRegistry(t, sigstoretest.NoAuth)
 
@@ -47,7 +49,8 @@ func TestDiscovery_SimpleSigning(t *testing.T) {
 		fmt.Sprintf("%s/simple-signing:v1", registry),
 		"sha256:21c76c650023cac8d753af4cb591e6f7450c6e2b499b5751d4a21e26e2fc5012",
 		sigstore.DiscoveryConfig{
-			Logger: utils.NewSlogLoggerForTests(),
+			Logger:                 utils.NewSlogLoggerForTests(),
+			AllowedNetworkPrefixes: loopbackPrefixes,
 		},
 	)
 	require.NoError(t, err)
@@ -125,7 +128,8 @@ func TestDiscovery_Attestations(t *testing.T) {
 		fmt.Sprintf("%s/attestations:v1", registry),
 		"sha256:32c91fcdf8b41ef78cf63e7be080a366597fd5a748480f5d2a6dc0cff5203807",
 		sigstore.DiscoveryConfig{
-			Logger: utils.NewSlogLoggerForTests(),
+			Logger:                 utils.NewSlogLoggerForTests(),
+			AllowedNetworkPrefixes: loopbackPrefixes,
 		},
 	)
 	require.NoError(t, err)
@@ -164,7 +168,8 @@ func TestDiscovery_InfiniteRedirects(t *testing.T) {
 		fmt.Sprintf("%s/foo:v1", regURL.Host),
 		"sha256:32c91fcdf8b41ef78cf63e7be080a366597fd5a748480f5d2a6dc0cff5203807",
 		sigstore.DiscoveryConfig{
-			Logger: utils.NewSlogLoggerForTests(),
+			Logger:                 utils.NewSlogLoggerForTests(),
+			AllowedNetworkPrefixes: loopbackPrefixes,
 		},
 	)
 	require.NoError(t, err)

--- a/lib/tbot/workloadidentity/workloadattest/sigstore/discovery_test.go
+++ b/lib/tbot/workloadidentity/workloadattest/sigstore/discovery_test.go
@@ -49,8 +49,8 @@ func TestDiscovery_SimpleSigning(t *testing.T) {
 		fmt.Sprintf("%s/simple-signing:v1", registry),
 		"sha256:21c76c650023cac8d753af4cb591e6f7450c6e2b499b5751d4a21e26e2fc5012",
 		sigstore.DiscoveryConfig{
-			Logger:                 utils.NewSlogLoggerForTests(),
-			AllowedNetworkPrefixes: loopbackPrefixes,
+			Logger:                        utils.NewSlogLoggerForTests(),
+			AllowedPrivateNetworkPrefixes: loopbackPrefixes,
 		},
 	)
 	require.NoError(t, err)
@@ -128,8 +128,8 @@ func TestDiscovery_Attestations(t *testing.T) {
 		fmt.Sprintf("%s/attestations:v1", registry),
 		"sha256:32c91fcdf8b41ef78cf63e7be080a366597fd5a748480f5d2a6dc0cff5203807",
 		sigstore.DiscoveryConfig{
-			Logger:                 utils.NewSlogLoggerForTests(),
-			AllowedNetworkPrefixes: loopbackPrefixes,
+			Logger:                        utils.NewSlogLoggerForTests(),
+			AllowedPrivateNetworkPrefixes: loopbackPrefixes,
 		},
 	)
 	require.NoError(t, err)
@@ -168,8 +168,8 @@ func TestDiscovery_InfiniteRedirects(t *testing.T) {
 		fmt.Sprintf("%s/foo:v1", regURL.Host),
 		"sha256:32c91fcdf8b41ef78cf63e7be080a366597fd5a748480f5d2a6dc0cff5203807",
 		sigstore.DiscoveryConfig{
-			Logger:                 utils.NewSlogLoggerForTests(),
-			AllowedNetworkPrefixes: loopbackPrefixes,
+			Logger:                        utils.NewSlogLoggerForTests(),
+			AllowedPrivateNetworkPrefixes: loopbackPrefixes,
 		},
 	)
 	require.NoError(t, err)

--- a/lib/tbot/workloadidentity/workloadattest/sigstore/repository.go
+++ b/lib/tbot/workloadidentity/workloadattest/sigstore/repository.go
@@ -198,6 +198,11 @@ func buildSafeTransport(allowedPrefixes []netip.Prefix) http.RoundTripper {
 	}
 	return &http.Transport{
 		DialContext: (&net.Dialer{
+			// By default, ssrf.New blocks all private IPv4 and IPv6 addresses
+			// including the loopback addresses, RFC 1918, link local addresses,
+			// broadcast addresses, and some other special cases.
+			//
+			// It also only allows port 80 and 443, but we relax that requirement.
 			Control: ssrf.New(
 				ssrf.WithAnyPort(),
 				ssrf.WithAllowedV4Prefixes(v4...),

--- a/lib/tbot/workloadidentity/workloadattest/sigstore/repository.go
+++ b/lib/tbot/workloadidentity/workloadattest/sigstore/repository.go
@@ -22,7 +22,11 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"net"
+	"net/http"
+	"net/netip"
 
+	"code.dny.dev/ssrf"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -36,20 +40,22 @@ const MaxLayerSize = 10 << 20 // 10MiB
 
 // Repository is a handle on a repository in an OCI registry.
 type Repository struct {
-	repo     name.Repository
-	logger   *slog.Logger
-	keychain authn.Keychain
+	repo      name.Repository
+	logger    *slog.Logger
+	keychain  authn.Keychain
+	transport http.RoundTripper
 }
 
 // NewRepository creates a new Repository with the given reference.
-func NewRepository(repo name.Repository, logger *slog.Logger, keychain authn.Keychain) (*Repository, error) {
+func NewRepository(repo name.Repository, logger *slog.Logger, keychain authn.Keychain, transport http.RoundTripper) (*Repository, error) {
 	if keychain == nil {
 		keychain = authn.DefaultKeychain
 	}
 	return &Repository{
-		repo:     repo,
-		logger:   logger,
-		keychain: keychain,
+		repo:      repo,
+		logger:    logger,
+		keychain:  keychain,
+		transport: transport,
 	}, nil
 }
 
@@ -60,6 +66,7 @@ func (r *Repository) Manifest(ctx context.Context, ref Reference) (*v1.Manifest,
 		ref.String(r.repo),
 		crane.WithContext(ctx),
 		crane.WithAuthFromKeychain(r.keychain),
+		crane.WithTransport(r.transport),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err, "fetching manifest")
@@ -78,6 +85,7 @@ func (r *Repository) Layer(ctx context.Context, digest v1.Hash) ([]byte, error) 
 		Digest(digest.String()).String(r.repo),
 		crane.WithContext(ctx),
 		crane.WithAuthFromKeychain(r.keychain),
+		crane.WithTransport(r.transport),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err, "pulling layer")
@@ -130,6 +138,7 @@ func (r *Repository) Referrers(ctx context.Context, digest v1.Hash) (*v1.IndexMa
 		r.repo.Digest(digest.String()),
 		remote.WithContext(ctx),
 		remote.WithAuthFromKeychain(r.keychain),
+		remote.WithTransport(r.transport),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err, "finding referrers")
@@ -173,4 +182,27 @@ type DigestReference string
 // String satisfies the Reference interface.
 func (t DigestReference) String(repo name.Repository) string {
 	return repo.Digest(string(t)).Name()
+}
+
+// buildSafeTransport builds an http.RoundTripper which refuses to access private
+// network addresses by default to prevent SSRF attacks. You can override this on
+// a per-address basis by passing a list of allowed prefixes (i.e. CIDR blocks).
+func buildSafeTransport(allowedPrefixes []netip.Prefix) http.RoundTripper {
+	var v4, v6 []netip.Prefix
+	for _, prefix := range allowedPrefixes {
+		if prefix.Addr().Is4() {
+			v4 = append(v4, prefix)
+		} else {
+			v6 = append(v6, prefix)
+		}
+	}
+	return &http.Transport{
+		DialContext: (&net.Dialer{
+			Control: ssrf.New(
+				ssrf.WithAnyPort(),
+				ssrf.WithAllowedV4Prefixes(v4...),
+				ssrf.WithAllowedV6Prefixes(v6...),
+			).Safe,
+		}).DialContext,
+	}
 }

--- a/lib/tbot/workloadidentity/workloadattest/sigstore_test.go
+++ b/lib/tbot/workloadidentity/workloadattest/sigstore_test.go
@@ -74,12 +74,12 @@ func TestSigstoreAttestorConfig_CheckAndSetDefaults(t *testing.T) {
 			},
 			err: "registries must be valid RFC 3986 URI authorities",
 		},
-		"allowed_network_prefixes is invalid": {
+		"allowed_private_network_prefixes is invalid": {
 			cfg: SigstoreAttestorConfig{
-				Enabled:                true,
-				AllowedNetworkPrefixes: []string{"::1/128", "NOT VALID"},
+				Enabled:                       true,
+				AllowedPrivateNetworkPrefixes: []string{"::1/128", "NOT VALID"},
 			},
-			err: "parsing allowed_network_prefixes[1]",
+			err: "parsing allowed_private_network_prefixes[1]",
 		},
 	}
 	for desc, tc := range testCases {
@@ -114,9 +114,9 @@ func TestSigstoreAttestor_Attest_WithCredentials(t *testing.T) {
 
 	attestor, err := NewSigstoreAttestor(
 		SigstoreAttestorConfig{
-			Enabled:                true,
-			CredentialsPath:        dockerConfigFile,
-			AllowedNetworkPrefixes: loopbackPrefixes,
+			Enabled:                       true,
+			CredentialsPath:               dockerConfigFile,
+			AllowedPrivateNetworkPrefixes: loopbackPrefixes,
 		},
 		utils.NewSlogLoggerForTests(),
 	)
@@ -148,8 +148,8 @@ func TestSigstoreAttestor_Attest_Caching(t *testing.T) {
 
 	attestor, err := NewSigstoreAttestor(
 		SigstoreAttestorConfig{
-			Enabled:                true,
-			AllowedNetworkPrefixes: loopbackPrefixes,
+			Enabled:                       true,
+			AllowedPrivateNetworkPrefixes: loopbackPrefixes,
 		},
 		utils.NewSlogLoggerForTests(),
 	)

--- a/lib/tbot/workloadidentity/workloadattest/sigstore_test.go
+++ b/lib/tbot/workloadidentity/workloadattest/sigstore_test.go
@@ -35,6 +35,8 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
+var loopbackPrefixes = []string{"127.0.0.1/8", "::1/128"}
+
 func TestSigstoreAttestorConfig_CheckAndSetDefaults(t *testing.T) {
 	testCases := map[string]struct {
 		cfg SigstoreAttestorConfig
@@ -72,6 +74,13 @@ func TestSigstoreAttestorConfig_CheckAndSetDefaults(t *testing.T) {
 			},
 			err: "registries must be valid RFC 3986 URI authorities",
 		},
+		"allowed_network_prefixes is invalid": {
+			cfg: SigstoreAttestorConfig{
+				Enabled:                true,
+				AllowedNetworkPrefixes: []string{"::1/128", "NOT VALID"},
+			},
+			err: "parsing allowed_network_prefixes[1]",
+		},
 	}
 	for desc, tc := range testCases {
 		t.Run(desc, func(t *testing.T) {
@@ -105,8 +114,9 @@ func TestSigstoreAttestor_Attest_WithCredentials(t *testing.T) {
 
 	attestor, err := NewSigstoreAttestor(
 		SigstoreAttestorConfig{
-			Enabled:         true,
-			CredentialsPath: dockerConfigFile,
+			Enabled:                true,
+			CredentialsPath:        dockerConfigFile,
+			AllowedNetworkPrefixes: loopbackPrefixes,
 		},
 		utils.NewSlogLoggerForTests(),
 	)
@@ -138,7 +148,8 @@ func TestSigstoreAttestor_Attest_Caching(t *testing.T) {
 
 	attestor, err := NewSigstoreAttestor(
 		SigstoreAttestorConfig{
-			Enabled: true,
+			Enabled:                true,
+			AllowedNetworkPrefixes: loopbackPrefixes,
 		},
 		utils.NewSlogLoggerForTests(),
 	)


### PR DESCRIPTION
It's unlikely to mount a successful SSRF attack using the Sigstore attestor because:

1. `tbot` runs alongside the workload, so typically does not have much greater access to the network than the workload itself.

2. The only user-controlled input is the container image, which the runtime itself (e.g. Kubelet or Docker Engine) would've already had to have pulled from the registry. So in a sense, the attack has already happened by the time the workload reaches out to `tbot`.

3. `tbot`'s SPIFFE Workload API is usually only reachable via a Unix domain socket on the same host.

That said, it's straightforward to disallow private networks by default and make them opt-in via allowed CIDR blocks.

Follow up from: https://github.com/gravitational/teleport/pull/53273#discussion_r2071092181

changelog: Workload Identity: Sigstore attestor no longer connects to OCI registries at private network addresses by default, use `allowed_network_prefixes` to allow-list private CIDR blocks
