### PR TITLE
Update product naming in the Okta guide

### DIFF
--- a/docs/pages/admin-guides/access-controls/okta/app-and-group-sync.mdx
+++ b/docs/pages/admin-guides/access-controls/okta/app-and-group-sync.mdx
@@ -38,7 +38,7 @@ List will be removed from Teleport on the next sync.
 
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)
 
-- Teleport Identity enabled on your account.
+- Teleport Identity Governance enabled on your account.
 
 - An Okta authentication connector. 
 

--- a/docs/pages/admin-guides/access-controls/okta/okta.mdx
+++ b/docs/pages/admin-guides/access-controls/okta/okta.mdx
@@ -20,8 +20,8 @@ Enrolling the Okta integration is a guided process and contains four components:
 2. **System for Cross-domain Identity Management (SCIM) integration:** Uses the
    [SCIM standard](https://developer.okta.com/docs/concepts/scim/) to
    allow nearly instant provisioning of Okta users in Teleport. This is
-   available only if Teleport Identity is enabled. The SCIM integration is
-   optional for enabling user, application, and group sync.
+   available only if Teleport Identity Governance is enabled. The SCIM
+   integration is optional for enabling user, application, and group sync.
 3. **User sync:** Imports Okta users as Teleport users via a continuous
    reconciliation loop. It is usually slower than SCIM, but but more reliable,
    and does not require a publicly accessible Teleport cluster. Combined with

--- a/docs/pages/admin-guides/access-controls/okta/scim-integration.mdx
+++ b/docs/pages/admin-guides/access-controls/okta/scim-integration.mdx
@@ -45,7 +45,7 @@ Okta does not send SCIM updates to Teleport when a user is suspended. Even thoug
 
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)
 
-- Teleport Identity enabled on your account.
+- Teleport Identity Governance enabled on your account.
 
 - An Okta authentication connector. 
 


### PR DESCRIPTION
Use "Teleport Identity Governance" instead of "Teleport Identity".