### PR TITLE
Fix unified resources case-sensitive duplicates

### DIFF
--- a/lib/services/unified_resource.go
+++ b/lib/services/unified_resource.go
@@ -615,8 +615,8 @@ func makeResourceSortKey(resource types.Resource) resourceSortKey {
 	return resourceSortKey{
 		// names should be stored as lowercase to keep items sorted as
 		// expected, regardless of case
-		byName: backend.NewKey(prefix, strings.ToLower(name), kind),
-		byType: backend.NewKey(prefix, kind, strings.ToLower(name)),
+		byName: backend.NewKey(prefix, strings.ToLower(name), name, kind),
+		byType: backend.NewKey(prefix, kind, strings.ToLower(name), name),
 	}
 }
 


### PR DESCRIPTION
We map resource names to lowercase in the cache index to provide case-insensitive sorting in the UI, but to make this a one-to-one mapping we must include the original name in the key as well.

Changelog: Fixed a bug where two resources of the same name except for case, for example "foo" and "FOO", would only display one of the resources in the web UI.

Example new behavior: it will first do a case insensitive sort, then a case-sensitive sort for lowercased duplicates. In this case I have duplicated "self-hosted-postgres" with "SELF-HOSTED-POSTGRES":

![image](https://github.com/user-attachments/assets/1c39c229-996b-4d2f-9868-f164d37066de)

