### PR TITLE
[v17] Use `second_factor` in the v17 `teleport-cluster` chart

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -303,12 +303,12 @@ Defaults to Teleport's binary default when empty: `best_effort`.
 ### `authentication.secondFactor`
 
 <Admonition type="warning">
-Deprecated, you should use [`authentication.secondFactors`](#authenticationsecondfactors) instead.
+Deprecated, after upgrading your Teleport cluster to v17.0.0 or higher you should use [`authentication.secondFactors`](#authenticationsecondfactors) instead.
 </Admonition>
 
 | Type     | Default value | Required? | `teleport.yaml` equivalent                  |
 |----------|---------------|-----------|---------------------------------------------|
-| `string` | none          | Yes       | `auth_service.authentication.second_factor` |
+| `string` | `on`          | Yes       | `auth_service.authentication.second_factor` |
 
 `authentication.secondFactor` configures multi-factor authentication for local users.
 Possible values supported by this chart are `on`, `otp`, and `webauthn`.
@@ -338,7 +338,7 @@ Changing the RP ID will invalidate all already registered webauthn second factor
 
 | Type    | Default value         | Required? | `teleport.yaml` equivalent                   |
 |---------|-----------------------|-----------|----------------------------------------------|
-| `array` | `["otp", "webauthn"]` | No        | `auth_service.authentication.second_factors` |
+| `array` | none                  | No        | `auth_service.authentication.second_factors` |
 
 `authentication.secondFactors` configures multi-factor authentication types.
 Supported item values are `otp`, `sso`, and `webauthn`.

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
@@ -24,9 +24,7 @@ configures access monitoring when its values are set:
           workgroup: example_access_monitoring_workgroup
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: test-aws-cluster
@@ -103,9 +101,7 @@ keeps the session_recording type even when it's "off":
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: helm-lint
@@ -141,9 +137,7 @@ matches snapshot for acme-off.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: test-cluster-name
@@ -178,9 +172,7 @@ matches snapshot for acme-on.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: test-acme-cluster
@@ -215,9 +207,7 @@ matches snapshot for acme-uri-staging.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: test-acme-cluster
@@ -253,9 +243,7 @@ matches snapshot for auth-connector-name.yaml:
         authentication:
           connector_name: okta
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: helm-lint
@@ -324,9 +312,7 @@ matches snapshot for auth-locking-mode.yaml:
         authentication:
           local_auth: true
           locking_mode: strict
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: helm-lint
@@ -397,9 +383,10 @@ matches snapshot for auth-secondfactors-sso.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - sso
+          second_factor: "on"
           type: local
+          webauthn:
+            rp_id: helm-lint
         cluster_name: helm-lint
         enabled: true
         proxy_listener_mode: separate
@@ -431,9 +418,7 @@ matches snapshot for auth-secondfactors-webauthn.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - sso
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             attestation_allowed_cas:
@@ -472,9 +457,7 @@ matches snapshot for auth-type-legacy.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: github
           webauthn:
             rp_id: helm-lint
@@ -509,9 +492,7 @@ matches snapshot for auth-type.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: github
           webauthn:
             rp_id: helm-lint
@@ -624,9 +605,7 @@ matches snapshot for aws-dynamodb-autoscaling.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: test-aws-cluster
@@ -677,9 +656,7 @@ matches snapshot for aws-ha-acme.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: test-aws-cluster
@@ -725,9 +702,7 @@ matches snapshot for aws-ha-antiaffinity.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: test-aws-cluster
@@ -773,9 +748,7 @@ matches snapshot for aws-ha-log.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: test-aws-cluster
@@ -822,9 +795,7 @@ matches snapshot for aws-ha.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: test-aws-cluster
@@ -870,9 +841,7 @@ matches snapshot for aws.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: test-aws-cluster
@@ -918,9 +887,7 @@ matches snapshot for azure.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: test-azure-cluster
@@ -963,9 +930,7 @@ matches snapshot for azure.yaml without pool_max_conn:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: test-azure-cluster
@@ -1008,9 +973,7 @@ matches snapshot for existing-tls-secret-with-ca.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: test-cluster-name
@@ -1045,9 +1008,7 @@ matches snapshot for existing-tls-secret.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: test-cluster-name
@@ -1082,9 +1043,7 @@ matches snapshot for gcp-ha-acme.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: test-gcp-cluster
@@ -1129,9 +1088,7 @@ matches snapshot for gcp-ha-antiaffinity.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: test-gcp-cluster
@@ -1176,9 +1133,7 @@ matches snapshot for gcp-ha-log.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: test-gcp-cluster
@@ -1224,9 +1179,7 @@ matches snapshot for gcp.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: test-gcp-cluster
@@ -1271,9 +1224,7 @@ matches snapshot for initcontainers.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: helm-lint
@@ -1308,9 +1259,7 @@ matches snapshot for kube-cluster-name.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: test-aws-cluster
@@ -1345,9 +1294,7 @@ matches snapshot for log-basic.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: test-log-cluster
@@ -1382,9 +1329,7 @@ matches snapshot for log-extra.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: test-log-cluster
@@ -1419,9 +1364,7 @@ matches snapshot for log-legacy.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: test-log-cluster
@@ -1456,9 +1399,7 @@ matches snapshot for priority-class-name.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: helm-lint
@@ -1493,9 +1434,7 @@ matches snapshot for proxy-listener-mode-multiplex.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: test-proxy-listener-mode
@@ -1530,9 +1469,7 @@ matches snapshot for proxy-listener-mode-separate.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: test-proxy-listener-mode
@@ -1567,9 +1504,7 @@ matches snapshot for public-addresses.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: helm-lint
@@ -1604,9 +1539,7 @@ matches snapshot for separate-mongo-listener.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: helm-lint
@@ -1641,9 +1574,7 @@ matches snapshot for separate-postgres-listener.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: helm-lint
@@ -1678,9 +1609,7 @@ matches snapshot for service.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: helm-lint
@@ -1715,9 +1644,7 @@ matches snapshot for session-recording.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: helm-lint
@@ -1753,9 +1680,7 @@ matches snapshot for standalone-customsize.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: test-standalone-cluster
@@ -1792,9 +1717,7 @@ matches snapshot for standalone-existingpvc.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: test-standalone-cluster
@@ -1831,9 +1754,7 @@ matches snapshot for tolerations.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: test-aws-cluster
@@ -1877,9 +1798,7 @@ matches snapshot for version-override.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: test-cluster-name
@@ -1917,9 +1836,7 @@ matches snapshot for volumes.yaml:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: helm-lint
@@ -2002,9 +1919,7 @@ sets clusterDomain on Configmap:
         auth_service:
           authentication:
             local_auth: true
-            second_factors:
-            - otp
-            - webauthn
+            second_factor: "on"
             type: local
             webauthn:
               rp_id: teleport.example.com
@@ -2051,9 +1966,7 @@ uses athena as primary backend when configured:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: teleport.example.com
@@ -2098,9 +2011,7 @@ uses athena, dynamo, and stdout when everything is on:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: teleport.example.com
@@ -2146,9 +2057,7 @@ uses dynamo as primary backend when configured:
       auth_service:
         authentication:
           local_auth: true
-          second_factors:
-          - otp
-          - webauthn
+          second_factor: "on"
           type: local
           webauthn:
             rp_id: teleport.example.com

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -129,11 +129,12 @@ authentication:
   # See https://goteleport.com/docs/access-controls/guides/locking/#next-steps-locking-modes.
   lockingMode: ""
 
-  # DEPRECATED: Second factor requirements for users of the Teleport cluster.
-  # Controls the `auth_config.authentication.second_factor` field in `teleport.yaml`.
-  # Possible values are 'off', 'on', 'otp', 'optional' and 'webauthn'.
-  # This field is kept for backward compatibility purposes, you should use
-  # `secondFactors` instead.
+  # Second factor requirements for users of the Teleport cluster. Controls the
+  # `auth_config.authentication.second_factor` field in `teleport.yaml`.
+  # Possible values are 'off', 'on', 'otp', 'optional' and 'webauthn'. This
+  # field is kept for backward compatibility purposes, you should use
+  # `secondFactors` instead, after the cluster has been fully upgraded to
+  # version 17.0.0 or later.
   #
   # WARNING:
   #   If you set `publicAddr` for users to access the cluster under a domain different
@@ -150,12 +151,13 @@ authentication:
   #   "teleport.example.com", RP ID can be "teleport.example.com" or "example.com".
   #
   #   Changing the RP ID will invalidate all already registered webauthn second factors.
-  # secondFactor: ""
+  secondFactor: "on"
 
-  # Second factor requirements for users of the Teleport cluster.
-  # Controls the `auth_config.authentication.second_factors` field in `teleport.yaml`.
-  # This is a list whose possible item values are item values are 'otp', 'sso' and 'webauthn'.
-  # This should be preferred over `secondFactor`.
+  # Second factor requirements for users of the Teleport cluster. Controls the
+  # `auth_config.authentication.second_factors` field in `teleport.yaml`. This
+  # is a list whose possible item values are item values are 'otp', 'sso' and
+  # 'webauthn'. This should be preferred over `secondFactor` once the cluster
+  # has been fully upgraded to version 17.0.0 or later.
   #
   # WARNING:
   #   If you set `publicAddr` for users to access the cluster under a domain different
@@ -172,7 +174,7 @@ authentication:
   #   "teleport.example.com", RP ID can be "teleport.example.com" or "example.com".
   #
   #   Changing the RP ID will invalidate all already registered webauthn second factors.
-  secondFactors: ["otp", "webauthn"]
+  # secondFactors: ["otp", "webauthn"]
 
   # (Optional) When using webauthn this allows to restrict which vendor and key models can be used.
   # webauthn:


### PR DESCRIPTION
Using the `second_factors` field in the `cluster-auth-preference` of a v17 cluster that still has v16 agents or clients can result in widespread problems due to our overly strict checks in `(*AuthPreferenceV2).CheckAndSetDefaults`. This PR reverts the change in default values in the `teleport-cluster` chart done in #53319, since the problem can be avoided just by not using the new field in favor of the old one.

This PR is straight for v17 since v18 will only have to deal with v17+ clients which will all support the new field correctly.

changelog: reverted the default behavior of the `teleport-cluster` Helm chart to use `authentication.secondFactor` rather than `authentication.secondFactors` to avoid incompatibility during upgrades