### PR TITLE
scoped cache improvements

### DIFF
--- a/lib/scopes/cache/cache.go
+++ b/lib/scopes/cache/cache.go
@@ -19,28 +19,71 @@
 package cache
 
 import (
+	"cmp"
 	"iter"
+	"sync"
 
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/utils/sortmap"
 )
 
+// Cursor describes a starting position for a paginated iteration over the cache. A cursor is only
+// considered filled in if both the key and scope are nonzero.
+type Cursor[K cmp.Ordered] struct {
+	// Scope is the scope to resume from.
+	Scope string
+	// Key is the primary key of the item to resume from.
+	Key K
+}
+
+// IsZero returns true if the cursor is empty.
+func (c *Cursor[K]) IsZero() bool {
+	return c == nil || (c.Key == *new(K) && c.Scope == "")
+}
+
+// Option is a functional option that can be used to configure cache query behavior.
+type Option[K cmp.Ordered] func(*options[K])
+
+type options[K cmp.Ordered] struct {
+	cursor Cursor[K]
+}
+
+// WithCursor specifies a cursor to use when querying the cache. If specified, the cache will
+// resume iteration from position described by the cursor. Passing in a zero value cursor
+// has no effect.
+func WithCursor[K cmp.Ordered](cursor Cursor[K]) Option[K] {
+	return func(o *options[K]) {
+		o.cursor = cursor
+	}
+}
+
 // Config configures a cache.
-type Config[T any, K comparable] struct {
+type Config[T any, K cmp.Ordered] struct {
 	// Scope is the function used to determine the scope of a value.
 	Scope func(T) string
 	// Key is the function used to determine the primary key of a value.
 	Key func(T) K
+	// Clone is an optional clone function that can be used to create deep copies
+	// of values prior to yielding them.
+	Clone func(T) T
 }
 
 // node is a tree node in the cache which stores values at a given scope.
-type node[T any, K comparable] struct {
+type node[K cmp.Ordered] struct {
 	// members is the set of values "at" this scope.
-	members map[K]struct{}
+	members *sortmap.Map[K, struct{}]
 
 	// children is the set of child scopes.
-	children map[string]*node[T, K]
+	children *sortmap.Map[string, *node[K]]
+}
+
+func newNode[K cmp.Ordered]() *node[K] {
+	return &node[K]{
+		members:  sortmap.New[K, struct{}](),
+		children: sortmap.New[string, *node[K]](),
+	}
 }
 
 // Cache is a generic scoped value cache. It constructs a basic tree structure based on scope segments
@@ -52,14 +95,15 @@ type node[T any, K comparable] struct {
 //   - Not currently safe for concurrent use.
 //   - Iteration order of read methods is nondeterministic.
 //   - No cleanup of empty scopes.
-type Cache[T any, K comparable] struct {
+type Cache[T any, K cmp.Ordered] struct {
 	cfg   Config[T, K]
+	rw    sync.RWMutex
 	items map[K]T
-	root  *node[T, K]
+	root  *node[K]
 }
 
 // New builds a new cache instance based on the supplied config.
-func New[T any, K comparable](cfg Config[T, K]) (*Cache[T, K], error) {
+func New[T any, K cmp.Ordered](cfg Config[T, K]) (*Cache[T, K], error) {
 	if cfg.Scope == nil {
 		return nil, trace.BadParameter("missing required scope function for scope cache")
 	}
@@ -68,54 +112,33 @@ func New[T any, K comparable](cfg Config[T, K]) (*Cache[T, K], error) {
 		return nil, trace.BadParameter("missing required key function for scope cache")
 	}
 
+	if cfg.Clone == nil {
+		cfg.Clone = func(value T) T { return value }
+	}
+
 	return &Cache[T, K]{
 		cfg:   cfg,
 		items: make(map[K]T),
 	}, nil
 }
 
-// ScopedItems provides the canonical representation of a scope and an iterator over the items within it. Typically
-// used as the item of an outer iterator across multiple scopes.
-type ScopedItems[T any] struct {
-	scope string
-	items iter.Seq[T]
-}
-
-// Scope is the canonical representation of the scope to which the items belong. Note that
-// it is theoretically possible for this to be different than the scope value of any particular
-// item in the iterator.
-func (s *ScopedItems[T]) Scope() string {
-	// TODO(fspmarshall): should we lazily build the scope string? changes are that a lot of
-	// usecases won't care about it.
-	return s.scope
-}
-
-// Items is an iterator over the items within the above scope. Note that within an iterator of ScopedItems,
-// this iterator may only be safe to use during the current outer iteration.
-func (s *ScopedItems[T]) Items() iter.Seq[T] {
-	// TODO(fspmarshall): lazily build the iterator here so that iteration can happen multiple times
-	// if needed.
-	return s.items
-}
-
-// newScopedItems is a helper function for creating a ScopedItems instance within a top-level iterator.
-func newScopedItems[T any, K comparable](segments []string, members map[K]struct{}, items map[K]T) ScopedItems[T] {
-	return ScopedItems[T]{
-		scope: scopes.Join(segments...),
-		items: func(yield func(T) bool) {
-			for key := range members {
-				if !yield(items[key]) {
-					return
-				}
-			}
-		},
-	}
+// KeyOf returns the primary key of the given value.
+func (c *Cache[T, K]) KeyOf(value T) K {
+	return c.cfg.Key(value)
 }
 
 // PoliciesApplicableToResourceScope iterates over the cached items using policy-application rules (i.e.
 // a descending iteration from root, through the leaf of the specified scope).
-func (c *Cache[T, K]) PoliciesApplicableToResourceScope(scope string) iter.Seq[ScopedItems[T]] {
+func (c *Cache[T, K]) PoliciesApplicableToResourceScope(scope string, opts ...Option[K]) iter.Seq[ScopedItems[T]] {
 	return func(yield func(ScopedItems[T]) bool) {
+		c.rw.RLock()
+		defer c.rw.RUnlock()
+
+		var options options[K]
+		for _, opt := range opts {
+			opt(&options)
+		}
+
 		if c.root == nil {
 			return
 		}
@@ -126,27 +149,34 @@ func (c *Cache[T, K]) PoliciesApplicableToResourceScope(scope string) iter.Seq[S
 		// start at the root
 		current := c.root
 
+		descender := newDescender(options.cursor)
+		defer descender.Stop()
+
 		for segment := range scopes.DescendingSegments(scope) {
-			// yield the current scope if it is non-empty
-			if len(current.members) != 0 {
-				if !yield(newScopedItems(visited, current.members, c.items)) {
+			// yield the current scope if we've finished descending to resume position and it is non-empty
+			if descender.Yield() && current.members.Len() != 0 {
+				if !yield(newScopedItems(visited, descender.StartKey(), current.members, c.items, c.cfg.Clone)) {
 					return
 				}
 			}
 
-			// check for the next scope
-			if _, ok := current.children[segment]; !ok {
+			// get next scope if it exists
+			var ok bool
+			current, ok = current.children.Get(segment)
+			if !ok {
 				return
 			}
 
-			// advance to the next scope
+			// finish yielding from this scope, advance the descender
+			descender.Descend(segment)
+
+			// update visited segments
 			visited = append(visited, segment)
-			current = current.children[segment]
 		}
 
 		// yield the final scope if it is non-empty
-		if len(current.members) != 0 {
-			if !yield(newScopedItems(visited, current.members, c.items)) {
+		if current.members.Len() != 0 {
+			if !yield(newScopedItems(visited, descender.StartKey(), current.members, c.items, c.cfg.Clone)) {
 				return
 			}
 		}
@@ -154,9 +184,17 @@ func (c *Cache[T, K]) PoliciesApplicableToResourceScope(scope string) iter.Seq[S
 }
 
 // ResourcesSubjectToPolicyScope iterates over the cached items using resources-subjugation rules (i.e.
-// an exhaustive iteration of the specified scope and all of its descendants).
-func (c *Cache[T, K]) ResourcesSubjectToPolicyScope(scope string) iter.Seq[ScopedItems[T]] {
+// an exhaustive descending iteration of the specified scope and all of its descendants).
+func (c *Cache[T, K]) ResourcesSubjectToPolicyScope(scope string, opts ...Option[K]) iter.Seq[ScopedItems[T]] {
 	return func(yield func(ScopedItems[T]) bool) {
+		c.rw.RLock()
+		defer c.rw.RUnlock()
+
+		var options options[K]
+		for _, opt := range opts {
+			opt(&options)
+		}
+
 		if c.root == nil {
 			return
 		}
@@ -165,23 +203,30 @@ func (c *Cache[T, K]) ResourcesSubjectToPolicyScope(scope string) iter.Seq[Scope
 		var visited []string
 
 		// search for start position, beginning at the root
-		start := c.root
+		current := c.root
+
+		descender := newDescender(options.cursor)
+		defer descender.Stop()
 
 		for segment := range scopes.DescendingSegments(scope) {
-			// check for the next scope
-			if _, ok := start.children[segment]; !ok {
+			// get next scope if it exists
+			var ok bool
+			current, ok = current.children.Get(segment)
+			if !ok {
 				// reached the end prior to finding the target scope,
 				// nothing to yield.
 				return
 			}
 
-			// advance to the next scope
+			// advance the descender to the next scope
+			descender.Descend(segment)
+
+			// update visited segments
 			visited = append(visited, segment)
-			start = start.children[segment]
 		}
 
 		// recursively yield starting position and all of its descendants
-		if !recursiveYield(yield, visited, start, c.items) {
+		if !recursiveYield(yield, visited, &descender, current, c.items, c.cfg.Clone) {
 			return
 		}
 	}
@@ -189,17 +234,20 @@ func (c *Cache[T, K]) ResourcesSubjectToPolicyScope(scope string) iter.Seq[Scope
 
 // recursiveYield is a helper function for recursively yielding all members of a given scope node, and all
 // members of all of its children. The returned bool is the return value of the last call to yield.
-func recursiveYield[T any, K comparable](yield func(ScopedItems[T]) bool, visited []string, current *node[T, K], items map[K]T) bool {
-	// yield the current scope if it is non-empty
-	if len(current.members) != 0 {
-		if !yield(newScopedItems(visited, current.members, items)) {
+func recursiveYield[T any, K cmp.Ordered](yield func(ScopedItems[T]) bool, visited []string, descender *descender[K], current *node[K], items map[K]T, clone func(T) T) bool {
+	// yield the current scope if we've finished descending to resume position and it is non-empty
+	if descender.Yield() && current.members.Len() != 0 {
+		if !yield(newScopedItems(visited, descender.StartKey(), current.members, items, clone)) {
 			return false
 		}
 	}
 
 	// recursively yield all child scopes
-	for segment, child := range current.children {
-		if !recursiveYield(yield, append(visited, segment), child, items) {
+	for segment, child := range current.children.Ascend(descender.NextSegment()) {
+		descender.Descend(segment)
+
+		// recursively yield all child and all of its descendants
+		if !recursiveYield(yield, append(visited, segment), descender, child, items, clone) {
 			return false
 		}
 	}
@@ -210,33 +258,27 @@ func recursiveYield[T any, K comparable](yield func(ScopedItems[T]) bool, visite
 // Put inserts the given value, potentially displacing an existing value with the same
 // primary key.
 func (c *Cache[T, K]) Put(value T) {
+	c.rw.Lock()
+	defer c.rw.Unlock()
+
 	// get scope and key for this value
 	scope, key := c.cfg.Scope(value), c.cfg.Key(value)
 
 	// ensure that any previous value at this primary key has been removed
-	c.Del(key)
+	c.deleteLocked(key)
 
 	if c.root == nil {
-		c.root = &node[T, K]{
-			members:  make(map[K]struct{}),
-			children: make(map[string]*node[T, K]),
-		}
+		c.root = newNode[K]()
 	}
 
 	// find the node for this scope
 	current := c.root
 	for segment := range scopes.DescendingSegments(scope) {
-		if _, ok := current.children[segment]; !ok {
-			current.children[segment] = &node[T, K]{
-				members:  make(map[K]struct{}),
-				children: make(map[string]*node[T, K]),
-			}
-		}
-		current = current.children[segment]
+		current = current.children.GetOrCreate(segment, newNode[K])
 	}
 
 	// add the value to the set of members at this scope
-	current.members[key] = struct{}{}
+	current.members.Set(key, struct{}{})
 
 	// add the value to the set of members at this primary key
 	c.items[key] = value
@@ -244,6 +286,13 @@ func (c *Cache[T, K]) Put(value T) {
 
 // Del deletes the value associated with the given primary key.
 func (c *Cache[T, K]) Del(key K) {
+	c.rw.Lock()
+	defer c.rw.Unlock()
+
+	c.deleteLocked(key)
+}
+
+func (c *Cache[T, K]) deleteLocked(key K) {
 	// get the value associated with this primary key
 	value, ok := c.items[key]
 	if !ok {
@@ -256,11 +305,11 @@ func (c *Cache[T, K]) Del(key K) {
 	// get the node for this scope
 	current := c.root
 	for segment := range scopes.DescendingSegments(scope) {
-		current = current.children[segment]
+		current, _ = current.children.Get(segment)
 	}
 
 	// remove the value from the set of members at this scope
-	delete(current.members, key)
+	current.members.Del(key)
 
 	// remove the value from the set of members at this primary key
 	delete(c.items, key)
@@ -268,5 +317,140 @@ func (c *Cache[T, K]) Del(key K) {
 
 // Len gets the total number of unique items stored in the cache.
 func (c *Cache[T, K]) Len() int {
+	c.rw.RLock()
+	defer c.rw.RUnlock()
 	return len(c.items)
+}
+
+// ScopedItems provides the canonical representation of a scope and an iterator over the items within it. Typically
+// used as the item of an outer iterator across multiple scopes. ScopedItems instances are not safe for use outside
+// of the context of the iterator that yielded them.
+type ScopedItems[T any] struct {
+	segments []string
+	items    func() iter.Seq[T]
+}
+
+// Scope returns the canonical representation of the scope to which the items belong. Calling code should
+// prefer to retain the returned value rather than call this method multiple times, as the returned
+// value is lazily constructed. Note that it is theoretically possible for the returned value to be
+// different than the scope value of any particular item in the iterator.
+func (s *ScopedItems[T]) Scope() string {
+	return scopes.Join(s.segments...)
+}
+
+// Items returns an iterator over the items within the associated scope. Note that within an iterator of
+// ScopedItems, this iterator may only be safe to use during the current outer iteration.
+func (s *ScopedItems[T]) Items() iter.Seq[T] {
+	return s.items()
+}
+
+// newScopedItems is a helper function for creating a ScopedItems instance within a top-level iterator.
+func newScopedItems[T any, K cmp.Ordered](segments []string, start K, members *sortmap.Map[K, struct{}], items map[K]T, clone func(T) T) ScopedItems[T] {
+	return ScopedItems[T]{
+		segments: segments,
+		items: func() iter.Seq[T] {
+			return func(yield func(T) bool) {
+				for key, _ := range members.Ascend(start) {
+					if !yield(clone(items[key])) {
+						return
+					}
+				}
+			}
+		},
+	}
+}
+
+// descender is a helper for descending to the correct target scope component when resuming iteration
+// using a cursor value. the descender is intended to make the logic of descent/resumption cleaner, and
+// to reduce branching in primary query logic by encapsulating most resumption logic into an iterative
+// state-machine. the zero value of the descender is a valid descender with behavior equivalent to a query
+// with no cursor.
+type descender[K cmp.Ordered] struct {
+	startKey   K
+	next       func() (string, bool)
+	stop       func()
+	segment    string
+	descending bool
+}
+
+// Descend advances the descender by one scope component depth. this should only be called
+// after any necessary invocations of yield/next/peek for the current scope level. it must
+// be called with the value of the segment that we are descending *into*.
+func (d *descender[K]) Descend(segment string) {
+	if !d.descending {
+		// we are continuing to descend after already having reached the target scope on a previous
+		// iteration. ensure the start key is cleared out so that we don't continue to use it on
+		// this or any future segments.
+		d.startKey = *new(K)
+		return
+	}
+
+	if segment != d.segment {
+		// we were still in descending mode and our path diverged from the expected one. this indicates
+		// that the target scope has been deleted/emptied since the time the initial cursor value was
+		// created. stop the underlying iterator and back out of descending mode. when the target scope
+		// no longer exists, we end up in the next existing scope in iteration order, so the next item
+		// encountered will be the proper place to start yielding items from.
+		d.Stop()
+		return
+	}
+
+	d.segment, d.descending = d.next()
+}
+
+// Yield indicates wether or not we've descended to the appropriate depth to
+// start yielding items.
+func (d *descender[K]) Yield() bool {
+	return !d.descending
+}
+
+// StartKey gets the StartKey that should be used for the current scope level. This will
+// be the zero value for all scopes except the resumption target scope.
+func (d *descender[K]) StartKey() K {
+	if !d.descending {
+		// we are at exactly the descent target, use the
+		// start key from our cursor.
+		return d.startKey
+	}
+
+	return *new(K)
+}
+
+// NextSegment reports the next scope component to descend to (only relevant in exhaustive descents,
+// where we need to know the next value in order to skip previously visited scopes).
+func (d *descender[K]) NextSegment() string {
+	return d.segment
+}
+
+// stop *must* be called to ensure that the descender doesn't leak coroutines. safe for double-call.
+func (d *descender[K]) Stop() {
+	if d.stop == nil {
+		return
+	}
+
+	// halt the underlying iterator
+	d.stop()
+
+	// clear the descender (only relevant for early halts due to scope path divergence)
+	*d = descender[K]{}
+}
+
+// newDescender creates a descender instance for use in managing descent to a target scope during
+// resumption of a previous iteration.
+func newDescender[K cmp.Ordered](cursor Cursor[K]) descender[K] {
+	if cursor.IsZero() {
+		return descender[K]{}
+	}
+
+	next, stop := iter.Pull(scopes.DescendingSegments(cursor.Scope))
+
+	segment, descending := next()
+
+	return descender[K]{
+		startKey:   cursor.Key,
+		next:       next,
+		stop:       stop,
+		segment:    segment,
+		descending: descending,
+	}
 }

--- a/lib/scopes/cache/cache_test.go
+++ b/lib/scopes/cache/cache_test.go
@@ -20,8 +20,8 @@ package cache
 
 import (
 	"iter"
-	"slices"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -29,31 +29,628 @@ import (
 )
 
 // item is a a basic helper used for cache testing.
-type item struct {
-	key   string
+type item[K any] struct {
+	key   K
 	scope string
 }
 
-func (i *item) Key() string {
+func (i item[K]) Key() K {
 	return i.key
 }
 
-func (i *item) Scope() string {
+func (i item[K]) Scope() string {
 	return i.scope
 }
 
-// TestCacheBasics verifies basic functionality of the cache, including insertion, query, and deletion, and
-// correct handling of collisions.
-func TestCacheBasics(t *testing.T) {
+// TestCacheConcurrency verifies the basic expected concurrency behavior of the cache.
+func TestCacheConcurrency(t *testing.T) {
 	t.Parallel()
 
-	items := []*item{
+	items := []item[int]{
+		{1, "/"},
+		{2, "/aa"},
+		{3, "/aa/bb"},
+		{4, "/aa/bb/cc"},
+	}
+
+	cache, err := New(Config[item[int], int]{
+		Scope: (item[int]).Scope,
+		Key:   (item[int]).Key,
+	})
+	require.NoError(t, err)
+
+	for _, item := range items {
+		cache.Put(item)
+	}
+
+	// lockstepC is used to force the background queries to progress in lockstep
+	lockstepC := make(chan struct{})
+
+	// proceedC is used to signal the leading background query to proceed
+	proceedC := make(chan struct{})
+
+	go func() {
+		// perform a policy application query that will match all items
+		for _ = range cache.PoliciesApplicableToResourceScope("/aa/bb/cc") {
+			lockstepC <- struct{}{} // block until the second query has caught up
+			<-proceedC              // wait for the main test routine to unblock us
+		}
+	}()
+
+	go func() {
+		// perform a resource subjugation query that will match all items
+		for _ = range cache.ResourcesSubjectToPolicyScope("/") {
+			<-lockstepC // wait until we get the signal from the first query
+		}
+	}()
+
+	// send proceed signal (ensures that background queries have got their first
+	// item and will start acquiring the next, ensuring that both queries are "in progress").
+	select {
+	case proceedC <- struct{}{}:
+	case <-time.After(time.Second * 5):
+		t.Fatalf("timed out waiting for proceed signal send")
+	}
+
+	// start a writer now that we know we have a "happens after" relationship to the
+	// background queries.
+	putDone := make(chan struct{})
+	go func() {
+		// perform a write that will block until the background queries are done
+		cache.Put(item[int]{5, "/aa/bb/cc/dd"})
+		close(putDone)
+	}()
+
+	delDone := make(chan struct{})
+	go func() {
+		// perform a delete that will block until the background queries are done
+		cache.Del(1)
+		close(delDone)
+	}()
+
+	// we can't really guarantee that the background writer is waiting, but we can
+	// be reasonably sure by stepping through multiple qery cycles and asserting that
+	// the writer hasn't completed at each iteration.
+	for i := 0; i < 3; i++ {
+		// perform initial check to verify that write hasn't succeeded (racy)
+		select {
+		case <-putDone:
+			t.Fatal("put was able to proceed while queries were in progress")
+		case <-delDone:
+			t.Fatal("del was able to proceed while queries were in progress")
+		case <-time.After(time.Millisecond * 333):
+		}
+
+		// progress both background queries to start processing their next items
+		select {
+		case proceedC <- struct{}{}:
+		case <-time.After(time.Second * 5):
+			t.Fatalf("timed out waiting for proceed signal send")
+		}
+	}
+
+	// our final proceed signal should have unblocked the queries for the last time,
+	// the writers should now succeed.
+
+	select {
+	case <-putDone:
+	case <-time.After(time.Second * 5):
+		t.Fatalf("timed out waiting for put to complete")
+	}
+
+	select {
+	case <-delDone:
+	case <-time.After(time.Second * 5):
+		t.Fatalf("timed out waiting for del to complete")
+	}
+}
+
+// TestCursorScenarios verifies the expected output of the cache given various cursor values.
+func TestCursorScenarios(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name                 string
+		items                []item[int]
+		scope                string
+		cursor               Cursor[int]
+		policiesApplicableTo []item[int]
+		resourcesSubjectTo   []item[int]
+	}{
+		{
+			name: "basic",
+			items: []item[int]{
+				{9, "/"},
+				{8, "/aa"},
+				{7, "/aa"},
+				{6, "/aa"},
+				{5, "/xx"},
+				{4, "/aa/bb"},
+				{3, "/aa/bb"},
+				{2, "/aa/bb"},
+				{1, "/xx/yy"},
+			},
+			scope: "/aa",
+			cursor: Cursor[int]{
+				Scope: "/aa",
+				Key:   7,
+			},
+			policiesApplicableTo: []item[int]{
+				{7, "/aa"},
+				{8, "/aa"},
+			},
+			resourcesSubjectTo: []item[int]{
+				{7, "/aa"},
+				{8, "/aa"},
+				{2, "/aa/bb"},
+				{3, "/aa/bb"},
+				{4, "/aa/bb"},
+			},
+		},
+		{
+			name: "missing item at beginning of scope range",
+			items: []item[int]{
+				{9, "/"},
+				{8, "/aa"},
+				{7, "/aa"},
+				{5, "/xx"},
+				{4, "/aa/bb"},
+				{3, "/aa/bb"},
+				{2, "/aa/bb"},
+				{1, "/xx/yy"},
+			},
+			scope: "/aa",
+			cursor: Cursor[int]{
+				Scope: "/aa",
+				Key:   6,
+			},
+			policiesApplicableTo: []item[int]{
+				{7, "/aa"},
+				{8, "/aa"},
+			},
+			resourcesSubjectTo: []item[int]{
+				{7, "/aa"},
+				{8, "/aa"},
+				{2, "/aa/bb"},
+				{3, "/aa/bb"},
+				{4, "/aa/bb"},
+			},
+		},
+		{
+			name: "missing item in middle of scope range",
+			items: []item[int]{
+				{9, "/"},
+				{8, "/aa"},
+				{6, "/aa"},
+				{5, "/xx"},
+				{4, "/aa/bb"},
+				{3, "/aa/bb"},
+				{2, "/aa/bb"},
+				{1, "/xx/yy"},
+			},
+			scope: "/aa",
+			cursor: Cursor[int]{
+				Scope: "/aa",
+				Key:   7,
+			},
+			policiesApplicableTo: []item[int]{
+				{8, "/aa"},
+			},
+			resourcesSubjectTo: []item[int]{
+				{8, "/aa"},
+				{2, "/aa/bb"},
+				{3, "/aa/bb"},
+				{4, "/aa/bb"},
+			},
+		},
+		{
+			name: "missing item at end of scope range",
+			items: []item[int]{
+				{9, "/"},
+				{7, "/aa"},
+				{6, "/aa"},
+				{5, "/xx"},
+				{4, "/aa/bb"},
+				{3, "/aa/bb"},
+				{2, "/aa/bb"},
+				{1, "/xx/yy"},
+			},
+			scope: "/aa",
+			cursor: Cursor[int]{
+				Scope: "/aa",
+				Key:   8,
+			},
+			policiesApplicableTo: nil,
+			resourcesSubjectTo: []item[int]{
+				{2, "/aa/bb"},
+				{3, "/aa/bb"},
+				{4, "/aa/bb"},
+			},
+		},
+		{
+			name: "deep scopes with high cursor",
+			items: []item[int]{
+				{0, "/"},
+				{1, "/"},
+				{2, "/aa"},
+				{3, "/aa"},
+				{4, "/aa/bb"},
+				{5, "/aa/bb"},
+				{6, "/aa/bb/cc"},
+				{7, "/aa/bb/cc"},
+				{8, "/aa/bb/cc/dd"},
+				{9, "/aa/bb/cc/dd"},
+				{10, "/aa/bb/cc/dd/ee"},
+				{11, "/aa/bb/cc/dd/ee"},
+			},
+			scope: "/aa/bb/cc",
+			cursor: Cursor[int]{
+				Scope: "/aa",
+				Key:   3,
+			},
+			policiesApplicableTo: []item[int]{
+				{3, "/aa"},
+				{4, "/aa/bb"},
+				{5, "/aa/bb"},
+				{6, "/aa/bb/cc"},
+				{7, "/aa/bb/cc"},
+			},
+			resourcesSubjectTo: []item[int]{
+				{6, "/aa/bb/cc"},
+				{7, "/aa/bb/cc"},
+				{8, "/aa/bb/cc/dd"},
+				{9, "/aa/bb/cc/dd"},
+				{10, "/aa/bb/cc/dd/ee"},
+				{11, "/aa/bb/cc/dd/ee"},
+			},
+		},
+		{
+			name: "deep scopes with low cursor",
+			items: []item[int]{
+				{0, "/"},
+				{1, "/"},
+				{2, "/aa"},
+				{3, "/aa"},
+				{4, "/aa/bb"},
+				{5, "/aa/bb"},
+				{6, "/aa/bb/cc"},
+				{7, "/aa/bb/cc"},
+				{8, "/aa/bb/cc/dd"},
+				{9, "/aa/bb/cc/dd"},
+				{10, "/aa/bb/cc/dd/ee"},
+				{11, "/aa/bb/cc/dd/ee"},
+			},
+			scope: "/aa/bb/cc",
+			cursor: Cursor[int]{
+				Scope: "/aa/bb/cc",
+				Key:   6,
+			},
+			policiesApplicableTo: []item[int]{
+				{6, "/aa/bb/cc"},
+				{7, "/aa/bb/cc"},
+			},
+			resourcesSubjectTo: []item[int]{
+				{6, "/aa/bb/cc"},
+				{7, "/aa/bb/cc"},
+				{8, "/aa/bb/cc/dd"},
+				{9, "/aa/bb/cc/dd"},
+				{10, "/aa/bb/cc/dd/ee"},
+				{11, "/aa/bb/cc/dd/ee"},
+			},
+		},
+		{
+			name: "low scope high cursor sparse",
+			items: []item[int]{
+				{0, "/"},
+				{1, "/"},
+				{4, "/aa/bb"},
+				{5, "/aa/bb"},
+				{8, "/aa/bb/cc/dd"},
+				{9, "/aa/bb/cc/dd"},
+				{12, "/aa/bb/cc/dd/ee/ff"},
+				{13, "/aa/bb/cc/dd/ee/ff"},
+			},
+			scope: "/aa/bb/cc",
+			cursor: Cursor[int]{
+				Scope: "/aa",
+				Key:   2,
+			},
+			policiesApplicableTo: []item[int]{
+				{4, "/aa/bb"},
+				{5, "/aa/bb"},
+			},
+			resourcesSubjectTo: []item[int]{
+				{8, "/aa/bb/cc/dd"},
+				{9, "/aa/bb/cc/dd"},
+				{12, "/aa/bb/cc/dd/ee/ff"},
+				{13, "/aa/bb/cc/dd/ee/ff"},
+			},
+		},
+		{
+			name: "high scope low cursor sparse",
+			items: []item[int]{
+				{0, "/"},
+				{1, "/"},
+				{4, "/aa/bb"},
+				{5, "/aa/bb"},
+				{8, "/aa/bb/cc/dd"},
+				{9, "/aa/bb/cc/dd"},
+				{12, "/aa/bb/cc/dd/ee/ff"},
+				{13, "/aa/bb/cc/dd/ee/ff"},
+			},
+			scope: "/aa",
+			cursor: Cursor[int]{
+				Scope: "/aa/bb/cc",
+				Key:   7,
+			},
+			policiesApplicableTo: nil,
+			resourcesSubjectTo: []item[int]{
+				{8, "/aa/bb/cc/dd"},
+				{9, "/aa/bb/cc/dd"},
+				{12, "/aa/bb/cc/dd/ee/ff"},
+				{13, "/aa/bb/cc/dd/ee/ff"},
+			},
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			cache, err := New(Config[item[int], int]{
+				Scope: (item[int]).Scope,
+				Key:   (item[int]).Key,
+			})
+			require.NoError(t, err)
+
+			for _, item := range tt.items {
+				cache.Put(item)
+			}
+
+			// verify policies-applicable-to-resource iteration
+			var policiesApplicableTo []item[int]
+			for scope := range cache.PoliciesApplicableToResourceScope(tt.scope, WithCursor(tt.cursor)) {
+				for item := range scope.Items() {
+					policiesApplicableTo = append(policiesApplicableTo, item)
+				}
+			}
+
+			require.Equal(t, tt.policiesApplicableTo, policiesApplicableTo)
+
+			// verify resources-subject-to-policy iteration
+			var resourcesSubjectTo []item[int]
+			for scope := range cache.ResourcesSubjectToPolicyScope(tt.scope, WithCursor(tt.cursor)) {
+				for item := range scope.Items() {
+					resourcesSubjectTo = append(resourcesSubjectTo, item)
+				}
+			}
+
+			require.Equal(t, tt.resourcesSubjectTo, resourcesSubjectTo)
+		})
+	}
+}
+
+// TestCursorPagination verifies the expected behavior of the ordering and resumption behavior of cache queries
+// using basic pagination logic/cursor construction.
+func TestCursorPagination(t *testing.T) {
+	t.Parallel()
+
+	type expected struct {
+		firstPage []item[int]
+		remaining []item[int]
+	}
+
+	tts := []struct {
+		name                 string
+		items                []item[int]
+		scope                string
+		limit                int
+		policiesApplicableTo expected
+		resourcesSubjectTo   expected
+	}{
+		{
+			name:  "empty root",
+			items: nil,
+			scope: "/",
+			limit: 2,
+			policiesApplicableTo: expected{
+				firstPage: nil,
+				remaining: nil,
+			},
+			resourcesSubjectTo: expected{
+				firstPage: nil,
+				remaining: nil,
+			},
+		},
+		{
+			name:  "empty child",
+			items: nil,
+			scope: "/child",
+			limit: 2,
+			policiesApplicableTo: expected{
+				firstPage: nil,
+				remaining: nil,
+			},
+			resourcesSubjectTo: expected{
+				firstPage: nil,
+				remaining: nil,
+			},
+		},
+		{
+			name: "basic root",
+			items: []item[int]{
+				{1, "/"},
+				{2, "/aa/bb"},
+				{3, "/aa/bb"},
+				{4, "/cc"},
+			},
+			scope: "/",
+			limit: 2,
+			policiesApplicableTo: expected{
+				firstPage: []item[int]{
+					{1, "/"},
+				},
+				remaining: nil,
+			},
+			resourcesSubjectTo: expected{
+				firstPage: []item[int]{
+					{1, "/"},
+					{2, "/aa/bb"},
+				},
+				remaining: []item[int]{
+					{3, "/aa/bb"},
+					{4, "/cc"},
+				},
+			},
+		},
+		{
+			name: "basic child",
+			items: []item[int]{
+				{1, "/"},
+				{2, "/aa/bb"},
+				{3, "/aa/bb"},
+				{4, "/cc"},
+			},
+			scope: "/aa/bb",
+			limit: 2,
+			policiesApplicableTo: expected{
+				firstPage: []item[int]{
+					{1, "/"},
+					{2, "/aa/bb"},
+				},
+				remaining: []item[int]{
+					{3, "/aa/bb"},
+				},
+			},
+			resourcesSubjectTo: expected{
+				firstPage: []item[int]{
+					{2, "/aa/bb"},
+					{3, "/aa/bb"},
+				},
+				remaining: nil,
+			},
+		},
+		{
+			name: "high depth",
+			items: []item[int]{
+				{1, "/"},
+				{2, "/aa"},
+				{3, "/aa/bb"},
+				{4, "/aa/bb/cc"},
+				{5, "/aa/bb/cc/dd"},
+				{6, "/aa/bb/cc/dd/ee"},
+			},
+			scope: "/aa/bb/cc",
+			limit: 2,
+			policiesApplicableTo: expected{
+				firstPage: []item[int]{
+					{1, "/"},
+					{2, "/aa"},
+				},
+				remaining: []item[int]{
+					{3, "/aa/bb"},
+					{4, "/aa/bb/cc"},
+				},
+			},
+			resourcesSubjectTo: expected{
+				firstPage: []item[int]{
+					{4, "/aa/bb/cc"},
+					{5, "/aa/bb/cc/dd"},
+				},
+				remaining: []item[int]{
+					{6, "/aa/bb/cc/dd/ee"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			cache, err := New(Config[item[int], int]{
+				Scope: (item[int]).Scope,
+				Key:   (item[int]).Key,
+			})
+			require.NoError(t, err)
+
+			for _, item := range tt.items {
+				cache.Put(item)
+			}
+
+			// verify policies-applicable-to-resource iteration
+			var firstPage []item[int]
+			var remaining []item[int]
+			var cursor Cursor[int]
+		PolicyApplicationOuter:
+			for scope := range cache.PoliciesApplicableToResourceScope(tt.scope) {
+				for item := range scope.Items() {
+					if len(firstPage) == tt.limit {
+						cursor = Cursor[int]{
+							Scope: scope.Scope(),
+							Key:   item.Key(),
+						}
+						break PolicyApplicationOuter
+					}
+					firstPage = append(firstPage, item)
+				}
+			}
+
+			require.Equal(t, tt.policiesApplicableTo.firstPage, firstPage)
+
+			if !cursor.IsZero() {
+				for scope := range cache.PoliciesApplicableToResourceScope(tt.scope, WithCursor(cursor)) {
+					for item := range scope.Items() {
+						remaining = append(remaining, item)
+					}
+				}
+			}
+
+			require.Equal(t, tt.policiesApplicableTo.remaining, remaining)
+
+			// verify resources-subject-to-policy iteration
+
+			firstPage = nil
+			remaining = nil
+			cursor = Cursor[int]{}
+
+		ResourceSubjugationOuter:
+			for scope := range cache.ResourcesSubjectToPolicyScope(tt.scope) {
+				for item := range scope.Items() {
+					if len(firstPage) == tt.limit {
+						cursor = Cursor[int]{
+							Scope: scope.Scope(),
+							Key:   item.Key(),
+						}
+						break ResourceSubjugationOuter
+					}
+					firstPage = append(firstPage, item)
+				}
+			}
+
+			require.Equal(t, tt.resourcesSubjectTo.firstPage, firstPage)
+
+			if !cursor.IsZero() {
+				for scope := range cache.ResourcesSubjectToPolicyScope(tt.scope, WithCursor(cursor)) {
+					for item := range scope.Items() {
+						remaining = append(remaining, item)
+					}
+				}
+			}
+
+			require.Equal(t, tt.resourcesSubjectTo.remaining, remaining)
+		})
+	}
+}
+
+// TestCacheOperations verifies basic functionality of the cache, including insertion, query, and deletion, and
+// correct handling of collisions.
+func TestCacheOperations(t *testing.T) {
+	t.Parallel()
+
+	items := []item[string]{
 		{
 			key:   "root-scoped",
 			scope: "/",
 		},
 		{
-			key:   "other-root-scoped",
+			key:   "root-scoped-other",
 			scope: "/",
 		},
 		{
@@ -61,7 +658,7 @@ func TestCacheBasics(t *testing.T) {
 			scope: "/child",
 		},
 		{
-			key:   "other-child-scoped",
+			key:   "child-scoped-other",
 			scope: "/child",
 		},
 		{
@@ -74,20 +671,20 @@ func TestCacheBasics(t *testing.T) {
 		},
 	}
 
-	cache, err := New(Config[*item, string]{
-		Scope: (*item).Scope,
-		Key:   (*item).Key,
+	cache, err := New(Config[item[string], string]{
+		Scope: (item[string]).Scope,
+		Key:   (item[string]).Key,
 	})
 	require.NoError(t, err)
 	require.Equal(t, 0, cache.Len())
 
 	// verify empty reads of root
-	requireEqualItemKeys(t, map[string][]string{}, collectScopedItemKeys(cache.PoliciesApplicableToResourceScope("/")))
-	requireEqualItemKeys(t, map[string][]string{}, collectScopedItemKeys(cache.ResourcesSubjectToPolicyScope("/")))
+	require.Equal(t, map[string][]string{}, collectScopedItemKeys(cache.PoliciesApplicableToResourceScope("/")))
+	require.Equal(t, map[string][]string{}, collectScopedItemKeys(cache.ResourcesSubjectToPolicyScope("/")))
 
 	// verify empty sub-scope reads
-	requireEqualItemKeys(t, map[string][]string{}, collectScopedItemKeys(cache.PoliciesApplicableToResourceScope("/child")))
-	requireEqualItemKeys(t, map[string][]string{}, collectScopedItemKeys(cache.ResourcesSubjectToPolicyScope("/child")))
+	require.Equal(t, map[string][]string{}, collectScopedItemKeys(cache.PoliciesApplicableToResourceScope("/child")))
+	require.Equal(t, map[string][]string{}, collectScopedItemKeys(cache.ResourcesSubjectToPolicyScope("/child")))
 
 	for _, item := range items {
 		cache.Put(item)
@@ -97,38 +694,38 @@ func TestCacheBasics(t *testing.T) {
 
 	// verify basic policies-applicable-to-resource iteration
 
-	requireEqualItemKeys(t, map[string][]string{
-		"/": {"root-scoped", "other-root-scoped"},
+	require.Equal(t, map[string][]string{
+		"/": {"root-scoped", "root-scoped-other"},
 	}, collectScopedItemKeys(cache.PoliciesApplicableToResourceScope("/")))
 
-	requireEqualItemKeys(t, map[string][]string{
-		"/":      {"root-scoped", "other-root-scoped"},
-		"/child": {"child-scoped", "other-child-scoped"},
+	require.Equal(t, map[string][]string{
+		"/":      {"root-scoped", "root-scoped-other"},
+		"/child": {"child-scoped", "child-scoped-other"},
 	}, collectScopedItemKeys(cache.PoliciesApplicableToResourceScope("/child")))
 
-	requireEqualItemKeys(t, map[string][]string{
-		"/":               {"root-scoped", "other-root-scoped"},
-		"/child":          {"child-scoped", "other-child-scoped"},
+	require.Equal(t, map[string][]string{
+		"/":               {"root-scoped", "root-scoped-other"},
+		"/child":          {"child-scoped", "child-scoped-other"},
 		"/child/subchild": {"child-sub-scoped"},
 	}, collectScopedItemKeys(cache.PoliciesApplicableToResourceScope("/child/subchild")))
 
 	// verify basic resources-subject-to-policy iteration
 
-	requireEqualItemKeys(t, map[string][]string{},
+	require.Equal(t, map[string][]string{},
 		collectScopedItemKeys(cache.ResourcesSubjectToPolicyScope("/nonexistent")))
 
-	requireEqualItemKeys(t, map[string][]string{
+	require.Equal(t, map[string][]string{
 		"/child/subchild": {"child-sub-scoped"},
 	}, collectScopedItemKeys(cache.ResourcesSubjectToPolicyScope("/child/subchild")))
 
-	requireEqualItemKeys(t, map[string][]string{
-		"/child":          {"child-scoped", "other-child-scoped"},
+	require.Equal(t, map[string][]string{
+		"/child":          {"child-scoped", "child-scoped-other"},
 		"/child/subchild": {"child-sub-scoped"},
 	}, collectScopedItemKeys(cache.ResourcesSubjectToPolicyScope("/child")))
 
-	requireEqualItemKeys(t, map[string][]string{
-		"/":               {"root-scoped", "other-root-scoped"},
-		"/child":          {"child-scoped", "other-child-scoped"},
+	require.Equal(t, map[string][]string{
+		"/":               {"root-scoped", "root-scoped-other"},
+		"/child":          {"child-scoped", "child-scoped-other"},
 		"/child/subchild": {"child-sub-scoped"},
 		"/orthogonal":     {"child-orthogonal"},
 	}, collectScopedItemKeys(cache.ResourcesSubjectToPolicyScope("/")))
@@ -149,15 +746,15 @@ func TestCacheBasics(t *testing.T) {
 	cache.Del("child-scoped")
 	require.Equal(t, len(items)-1, cache.Len())
 
-	requireEqualItemKeys(t, map[string][]string{
-		"/":               {"root-scoped", "other-root-scoped"},
-		"/child":          {"other-child-scoped"},
+	require.Equal(t, map[string][]string{
+		"/":               {"root-scoped", "root-scoped-other"},
+		"/child":          {"child-scoped-other"},
 		"/child/subchild": {"child-sub-scoped"},
 	}, collectScopedItemKeys(cache.PoliciesApplicableToResourceScope("/child/subchild")))
 
-	requireEqualItemKeys(t, map[string][]string{
-		"/":               {"root-scoped", "other-root-scoped"},
-		"/child":          {"other-child-scoped"},
+	require.Equal(t, map[string][]string{
+		"/":               {"root-scoped", "root-scoped-other"},
+		"/child":          {"child-scoped-other"},
 		"/child/subchild": {"child-sub-scoped"},
 		"/orthogonal":     {"child-orthogonal"},
 	}, collectScopedItemKeys(cache.ResourcesSubjectToPolicyScope("/")))
@@ -166,43 +763,43 @@ func TestCacheBasics(t *testing.T) {
 	cache.Del("root-scoped")
 	require.Equal(t, len(items)-2, cache.Len())
 
-	requireEqualItemKeys(t, map[string][]string{
-		"/":               {"other-root-scoped"},
-		"/child":          {"other-child-scoped"},
+	require.Equal(t, map[string][]string{
+		"/":               {"root-scoped-other"},
+		"/child":          {"child-scoped-other"},
 		"/child/subchild": {"child-sub-scoped"},
 	}, collectScopedItemKeys(cache.PoliciesApplicableToResourceScope("/child/subchild")))
 
-	requireEqualItemKeys(t, map[string][]string{
-		"/":               {"other-root-scoped"},
-		"/child":          {"other-child-scoped"},
+	require.Equal(t, map[string][]string{
+		"/":               {"root-scoped-other"},
+		"/child":          {"child-scoped-other"},
 		"/child/subchild": {"child-sub-scoped"},
 		"/orthogonal":     {"child-orthogonal"},
 	}, collectScopedItemKeys(cache.ResourcesSubjectToPolicyScope("/")))
 
 	// verify full deletion of all contents of an intermediate scope
-	cache.Del("other-child-scoped")
+	cache.Del("child-scoped-other")
 	require.Equal(t, len(items)-3, cache.Len())
 
-	requireEqualItemKeys(t, map[string][]string{
-		"/":               {"other-root-scoped"},
+	require.Equal(t, map[string][]string{
+		"/":               {"root-scoped-other"},
 		"/child/subchild": {"child-sub-scoped"},
 	}, collectScopedItemKeys(cache.PoliciesApplicableToResourceScope("/child/subchild")))
 
-	requireEqualItemKeys(t, map[string][]string{
-		"/":               {"other-root-scoped"},
+	require.Equal(t, map[string][]string{
+		"/":               {"root-scoped-other"},
 		"/child/subchild": {"child-sub-scoped"},
 		"/orthogonal":     {"child-orthogonal"},
 	}, collectScopedItemKeys(cache.ResourcesSubjectToPolicyScope("/")))
 
 	// verfiy full deletion of all contents of a root scope
-	cache.Del("other-root-scoped")
+	cache.Del("root-scoped-other")
 	require.Equal(t, len(items)-4, cache.Len())
 
-	requireEqualItemKeys(t, map[string][]string{
+	require.Equal(t, map[string][]string{
 		"/child/subchild": {"child-sub-scoped"},
 	}, collectScopedItemKeys(cache.PoliciesApplicableToResourceScope("/child/subchild")))
 
-	requireEqualItemKeys(t, map[string][]string{
+	require.Equal(t, map[string][]string{
 		"/child/subchild": {"child-sub-scoped"},
 		"/orthogonal":     {"child-orthogonal"},
 	}, collectScopedItemKeys(cache.ResourcesSubjectToPolicyScope("/")))
@@ -211,70 +808,55 @@ func TestCacheBasics(t *testing.T) {
 	cache.Del("child-sub-scoped")
 	require.Equal(t, len(items)-5, cache.Len())
 
-	requireEqualItemKeys(t, map[string][]string{},
+	require.Equal(t, map[string][]string{},
 		collectScopedItemKeys(cache.PoliciesApplicableToResourceScope("/child/subchild")))
 
-	requireEqualItemKeys(t, map[string][]string{
+	require.Equal(t, map[string][]string{
 		"/orthogonal": {"child-orthogonal"},
 	}, collectScopedItemKeys(cache.ResourcesSubjectToPolicyScope("/")))
 
 	// verify basic re-add
-	cache.Put(&item{
+	cache.Put(item[string]{
 		key:   "child-scoped",
 		scope: "/child",
 	})
 	require.Equal(t, len(items)-4, cache.Len())
 
-	requireEqualItemKeys(t, map[string][]string{
+	require.Equal(t, map[string][]string{
 		"/child": {"child-scoped"},
 	}, collectScopedItemKeys(cache.PoliciesApplicableToResourceScope("/child")))
 
-	requireEqualItemKeys(t, map[string][]string{
+	require.Equal(t, map[string][]string{
 		"/child":      {"child-scoped"},
 		"/orthogonal": {"child-orthogonal"},
 	}, collectScopedItemKeys(cache.ResourcesSubjectToPolicyScope("/")))
 
 	// verify overwrite of existing item by primary key
-	cache.Put(&item{
+	cache.Put(item[string]{
 		key:   "child-scoped",
 		scope: "/child/other",
 	})
 	require.Equal(t, len(items)-4, cache.Len())
 
-	requireEqualItemKeys(t, map[string][]string{},
+	require.Equal(t, map[string][]string{},
 		collectScopedItemKeys(cache.PoliciesApplicableToResourceScope("/child/subchild")))
 
-	requireEqualItemKeys(t, map[string][]string{
+	require.Equal(t, map[string][]string{
 		"/child/other": {"child-scoped"},
 	}, collectScopedItemKeys(cache.PoliciesApplicableToResourceScope("/child/other")))
 
-	requireEqualItemKeys(t, map[string][]string{
+	require.Equal(t, map[string][]string{
 		"/child/other": {"child-scoped"},
 		"/orthogonal":  {"child-orthogonal"},
 	}, collectScopedItemKeys(cache.ResourcesSubjectToPolicyScope("/")))
 }
 
-// requireEualItemKeys is a workaround because scope/item iteration is currently unordered.
-// TODO(fspmarshall): make scope/item iteration ordered.
-func requireEqualItemKeys(t *testing.T, expected, actual map[string][]string) {
-	t.Helper()
-	for _, val := range expected {
-		slices.Sort(val)
-	}
-
-	for _, val := range actual {
-		slices.Sort(val)
-	}
-
-	require.Equal(t, expected, actual)
-}
-
 // collectScopedItemKeys aggregates a scoped iterator from one of the cache iteration
 // methods into a map of scope -> keys.
-func collectScopedItemKeys(iterator iter.Seq[ScopedItems[*item]]) map[string][]string {
-	itemKeys := make(map[string][]string)
+func collectScopedItemKeys[K any](iterator iter.Seq[ScopedItems[item[K]]]) map[string][]K {
+	itemKeys := make(map[string][]K)
 	for scope := range iterator {
-		var keys []string
+		var keys []K
 		for item := range scope.Items() {
 			keys = append(keys, item.Key())
 		}

--- a/lib/utils/sortmap/map.go
+++ b/lib/utils/sortmap/map.go
@@ -1,0 +1,138 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package sortmap
+
+import (
+	"cmp"
+	"iter"
+
+	"github.com/google/btree"
+)
+
+// Map is a very thin wrapper around btree.BTreeG that provides a more intuitive
+// map-like interface and avoids the need to define a separate entry type
+// and comparison function. It also provides a more intuitive form of start key
+// for resumption/pagination where zero values always mean "get everything". Handy
+// for cases where you want to add ordered/resumable iteration to existing logic that
+// currently relies on a map.
+//
+// Note that this type performs no internal synchronization. Its read methods are safe for
+// concurrent use, but its write methods are not.
+type Map[K cmp.Ordered, V any] btree.BTreeG[entry[K, V]]
+
+type entry[K cmp.Ordered, V any] struct {
+	key   K
+	value V
+}
+
+func compare[K cmp.Ordered, V any](a, b entry[K, V]) bool {
+	return a.key < b.key
+}
+
+// New creates a new empty [Map] instance.
+func New[K cmp.Ordered, V any]() *Map[K, V] {
+	const (
+		// bTreeDegree of 8 is standard across most of the teleport codebase
+		bTreeDegree = 8
+	)
+
+	return (*Map[K, V])(btree.NewG[entry[K, V]](bTreeDegree, compare))
+}
+
+// Get retrieves the value associated with the given key if one exists.
+func (m *Map[K, V]) Get(key K) (V, bool) {
+	if m == nil {
+		return *new(V), false
+	}
+	entry, exists := (*btree.BTreeG[entry[K, V]])(m).Get(entry[K, V]{key: key})
+	return entry.value, exists
+}
+
+// GetOrCreate retrieves the value associated with the given key if one exists,
+// falling back to creating and inserting a new value using the provided function.
+func (m *Map[K, V]) GetOrCreate(key K, fn func() V) V {
+	if val, ok := m.Get(key); ok {
+		return val
+	}
+	val := fn()
+	m.Set(key, val)
+	return val
+}
+
+// Set sets the value associated with the given key, replacing any existing value.
+func (m *Map[K, V]) Set(key K, value V) {
+	(*btree.BTreeG[entry[K, V]])(m).ReplaceOrInsert(entry[K, V]{key: key, value: value})
+}
+
+// Del removes the entry associated with the given key.
+func (m *Map[K, V]) Del(key K) {
+	(*btree.BTreeG[entry[K, V]])(m).Delete(entry[K, V]{key: key})
+}
+
+// Descend returns a sequence of key-value pairs in descending order. If the provided start key
+// is nonzero, iteration will start from the provided key position (inclusive).
+func (m *Map[K, V]) Descend(start K) iter.Seq2[K, V] {
+	if m == nil {
+		return func(yield func(K, V) bool) {}
+	}
+
+	if start == *new(K) {
+		return func(yield func(K, V) bool) {
+			(*btree.BTreeG[entry[K, V]])(m).Descend(func(ent entry[K, V]) bool {
+				return yield(ent.key, ent.value)
+			})
+		}
+	}
+
+	return func(yield func(K, V) bool) {
+		(*btree.BTreeG[entry[K, V]])(m).DescendLessOrEqual(entry[K, V]{key: start}, func(ent entry[K, V]) bool {
+			return yield(ent.key, ent.value)
+		})
+	}
+}
+
+// Ascend returns a sequence of key-value pairs in ascending order. If the provided 'start' key
+// is nonzero, iteration will start from the provided key position (inclusive).
+func (m *Map[K, V]) Ascend(start K) iter.Seq2[K, V] {
+	if m == nil {
+		return func(yield func(K, V) bool) {}
+	}
+	if start == *new(K) {
+		return func(yield func(K, V) bool) {
+			(*btree.BTreeG[entry[K, V]])(m).Ascend(func(ent entry[K, V]) bool {
+				return yield(ent.key, ent.value)
+			})
+		}
+	}
+
+	return func(yield func(K, V) bool) {
+		(*btree.BTreeG[entry[K, V]])(m).AscendGreaterOrEqual(entry[K, V]{key: start}, func(ent entry[K, V]) bool {
+			return yield(ent.key, ent.value)
+		})
+	}
+}
+
+// Len returns the number of entries in the map.
+func (m *Map[K, V]) Len() int {
+	if m == nil {
+		return 0
+	}
+
+	return (*btree.BTreeG[entry[K, V]])(m).Len()
+}

--- a/lib/utils/sortmap/map_test.go
+++ b/lib/utils/sortmap/map_test.go
@@ -1,0 +1,262 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package sortmap
+
+import (
+	"iter"
+	"maps"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestIteration verifies the expected behavior of ascending/descending map iteration
+// with and without a start key in various scenarios.
+func TestIteration(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name                  string
+		state                 map[string]string
+		start                 string
+		ascending, descending []string
+	}{
+		{
+			name:       "empty",
+			state:      nil,
+			start:      "",
+			ascending:  nil,
+			descending: nil,
+		},
+		{
+			name:       "empty with start key",
+			state:      nil,
+			start:      "a",
+			ascending:  nil,
+			descending: nil,
+		},
+		{
+			name: "single element",
+			state: map[string]string{
+				"a": "val",
+			},
+			start:      "",
+			ascending:  []string{"a"},
+			descending: []string{"a"},
+		},
+		{
+			name:       "single element with lower start key",
+			state:      map[string]string{"b": "val"},
+			start:      "a",
+			ascending:  []string{"b"},
+			descending: nil,
+		},
+		{
+			name:       "single element with higher start key",
+			state:      map[string]string{"b": "val"},
+			start:      "c",
+			ascending:  nil,
+			descending: []string{"b"},
+		},
+		{
+			name: "multiple elements",
+			state: map[string]string{
+				"a": "val1",
+				"b": "val2",
+				"c": "val3",
+			},
+			start:      "",
+			ascending:  []string{"a", "b", "c"},
+			descending: []string{"c", "b", "a"},
+		},
+		{
+			name:       "multiple elements with start key",
+			state:      map[string]string{"a": "val1", "b": "val2", "c": "val3"},
+			start:      "b",
+			ascending:  []string{"b", "c"},
+			descending: []string{"b", "a"},
+		},
+		{
+			name:       "multiple elements with lower start key",
+			state:      map[string]string{"a": "val1", "b": "val2", "c": "val3"},
+			start:      "a",
+			ascending:  []string{"a", "b", "c"},
+			descending: []string{"a"},
+		},
+		{
+			name:       "multiple elements with higher start key",
+			state:      map[string]string{"a": "val1", "b": "val2", "c": "val3"},
+			start:      "c",
+			ascending:  []string{"c"},
+			descending: []string{"c", "b", "a"},
+		},
+		{
+			name:       "multiple elements with non-existent start key",
+			state:      map[string]string{"a": "val1", "c": "val2", "e": "val3", "g": "val4"},
+			start:      "d",
+			ascending:  []string{"e", "g"},
+			descending: []string{"c", "a"},
+		},
+		{
+			name:       "multiple elements with lower non-existent start key",
+			state:      map[string]string{"a": "val1", "c": "val2", "e": "val3", "g": "val4"},
+			start:      "b",
+			ascending:  []string{"c", "e", "g"},
+			descending: []string{"a"},
+		},
+		{
+			name:       "multiple elements with higher non-existent start key",
+			state:      map[string]string{"a": "val1", "c": "val2", "e": "val3", "g": "val4"},
+			start:      "f",
+			ascending:  []string{"g"},
+			descending: []string{"e", "c", "a"},
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			m := New[string, string]()
+
+			for k, v := range tt.state {
+				m.Set(k, v)
+			}
+
+			require.Equal(t, tt.ascending, collectKeys(m.Ascend(tt.start)))
+			require.Equal(t, tt.descending, collectKeys(m.Descend(tt.start)))
+		})
+	}
+}
+
+// TestWrites verifies the expected behavior of basic write operations.
+func TestWrites(t *testing.T) {
+	t.Parallel()
+
+	type op struct {
+		set    map[string]string
+		del    []string
+		expect map[string]string
+	}
+
+	tts := []struct {
+		name string
+		ops  []op
+	}{
+		{
+			name: "empty",
+			ops: []op{
+				{
+					set:    nil,
+					del:    nil,
+					expect: map[string]string{},
+				},
+			},
+		},
+		{
+			name: "basic sets and delete",
+			ops: []op{
+				{
+					set:    map[string]string{"a": "1", "b": "2"},
+					del:    []string{"a"},
+					expect: map[string]string{"b": "2"},
+				},
+			},
+		},
+		{
+			name: "basic multi-operation",
+			ops: []op{
+				{
+					set:    map[string]string{"a": "1", "b": "2"},
+					del:    []string{"b"},
+					expect: map[string]string{"a": "1"},
+				},
+				{
+					set:    map[string]string{"c": "3"},
+					del:    []string{"b"}, // no effect
+					expect: map[string]string{"a": "1", "c": "3"},
+				},
+				{
+					set:    map[string]string{"d": "4"},
+					del:    []string{"a"},
+					expect: map[string]string{"c": "3", "d": "4"},
+				},
+				{
+					set:    nil,
+					del:    []string{"c"},
+					expect: map[string]string{"d": "4"},
+				},
+				{
+					set:    map[string]string{"e": "5"},
+					del:    []string{"d", "e"},
+					expect: map[string]string{},
+				},
+			},
+		},
+		{
+			name: "repeated fill and empty",
+			ops: []op{
+				{
+					set:    map[string]string{"a": "1", "b": "2"},
+					del:    nil,
+					expect: map[string]string{"a": "1", "b": "2"},
+				},
+				{
+					set:    nil,
+					del:    []string{"a", "b", "c"},
+					expect: map[string]string{},
+				},
+				{
+					set:    map[string]string{"b": "3", "c": "4"},
+					del:    nil,
+					expect: map[string]string{"b": "3", "c": "4"},
+				},
+				{
+					set:    nil,
+					del:    []string{"a", "b", "c"},
+					expect: map[string]string{},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			m := New[string, string]()
+
+			for i, op := range tt.ops {
+				for k, v := range op.set {
+					m.Set(k, v)
+				}
+				for _, k := range op.del {
+					m.Del(k)
+				}
+
+				require.Equal(t, op.expect, maps.Collect(m.Ascend("")), "i=%d, op=%+v", i, op)
+			}
+		})
+	}
+}
+
+// collectKeys aggregates the keys from a Key-Value sequence, preserving order.
+func collectKeys[K, V any](seq iter.Seq2[K, V]) []K {
+	var keys []K
+	for key, _ := range seq {
+		keys = append(keys, key)
+	}
+	return keys
+}


### PR DESCRIPTION
Adds deterministic iteration order, cursors, and concurrency-safety to `scopes/cache`.

Special care has been taken to ensure that cursor values are sane in contexts where different caches might serve different pages for the same request (e.g. due to load-balancing/resets), and that they behave in a sensible manner in the context of concurrent deletes and/or concurrent changes to the scoping of values.

This PR is a direct follow-up to https://github.com/gravitational/teleport/pull/54616, which introduced a simple scoped cache as a proof of concept for the data layout and querying methodology.

This PR also introduces `utils/sortmap`, a small helper intended to simplify the process of switching existing logic from the `map` type to a btree when ordered iteration is required.

Part of ongoing work related to Scopes (https://github.com/gravitational/teleport/issues/54601).