### PR TITLE
[v16] Do not crash when reading unsupported connection from app state

### DIFF
--- a/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionItem.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionItem.tsx
@@ -167,12 +167,6 @@ function getKindName(connection: ExtendedTrackedConnection): string {
     case 'connection.kube':
       return 'KUBE';
     default:
-      // The default branch is triggered when the state read from the disk
-      // contains a connection not supported by the given Connect version.
-      //
-      // For example, the user can open an app connection in Connect v15
-      // and then downgrade to a version that doesn't support apps.
-      // That connection should be shown as 'UNKNOWN' in the connection list.
       return 'UNKNOWN';
   }
 }

--- a/web/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.ts
+++ b/web/packages/teleterm/src/ui/services/connectionTracker/connectionTrackerService.ts
@@ -85,7 +85,7 @@ export class ConnectionTrackerService extends ImmutableStore<ConnectionTrackerSt
         //
         // For example, the user can open a desktop connection in Connect v18
         // and then downgrade to a version that doesn't support desktops.
-        // That connection should be shown as 'UNKNOWN' in the connection list.
+        // That connection shouldn't be shown on the list.
         if (!trackedConnection) {
           return;
         }


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/54668 (part)

Changelog: Resolved an issue that could cause Teleport Connect to crash after downgrading from a newer version