### PR TITLE
Refactor RegisterUsingToken for perf and better audit log on failure

### DIFF
--- a/lib/auth/join.go
+++ b/lib/auth/join.go
@@ -44,17 +44,6 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 )
 
-// tokenJoinMethod returns the join method of the token with the given tokenName
-func (a *Server) tokenJoinMethod(ctx context.Context, tokenName string) types.JoinMethod {
-	provisionToken, err := a.GetToken(ctx, tokenName)
-	if err != nil {
-		// could not find dynamic token, assume static token. If it does not
-		// exist this will be caught later.
-		return types.JoinMethodToken
-	}
-	return provisionToken.GetJoinMethod()
-}
-
 // checkTokenJoinRequestCommon checks all token join rules that are common to
 // all join methods, including token existence, token TTL, and allowed roles.
 func (a *Server) checkTokenJoinRequestCommon(ctx context.Context, req *types.RegisterUsingTokenRequest) (types.ProvisionToken, error) {
@@ -221,19 +210,31 @@ func (a *Server) RegisterUsingToken(ctx context.Context, req *types.RegisterUsin
 		return nil, trace.Wrap(err)
 	}
 
-	method := a.tokenJoinMethod(ctx, req.Token)
-	switch method {
+	// perform common token checks
+	provisionToken, err = a.checkTokenJoinRequestCommon(ctx, req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	// nb: token returned by checkTokenJoinRequestCommon may be a
+	// ProvisionTokenV2 derived from a static token. You cannot assume you will
+	// be able to fetch this same token directly from the backend.
+	method := provisionToken.GetJoinMethod()
+
+	// Call join method-specific validation
+	switch provisionToken.GetJoinMethod() {
 	case types.JoinMethodEC2:
 		if err := a.checkEC2JoinRequest(ctx, req); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	case types.JoinMethodIAM, types.JoinMethodAzure, types.JoinMethodTPM, types.JoinMethodOracle:
-		// These join methods must use gRPC register methods
+		// Some join methods require use of a specific RPC - reject those here.
+		// This would generally be a developer error - but can be triggered if
+		// the user has configured the wrong join method on the client-side.
 		return nil, trace.AccessDenied("this token is only valid for the %s "+
 			"join method but the node has connected to the wrong endpoint, make "+
 			"sure your node is configured to use the %s join method", method, method)
 	case types.JoinMethodGitHub:
-		claims, err := a.checkGitHubJoinRequest(ctx, req)
+		claims, err := a.checkGitHubJoinRequest(ctx, req, provisionToken)
 		if claims != nil {
 			rawClaims = claims
 			attrs.Github = claims.JoinAttrs()
@@ -242,7 +243,7 @@ func (a *Server) RegisterUsingToken(ctx context.Context, req *types.RegisterUsin
 			return nil, trace.Wrap(err)
 		}
 	case types.JoinMethodGitLab:
-		claims, err := a.checkGitLabJoinRequest(ctx, req)
+		claims, err := a.checkGitLabJoinRequest(ctx, req, provisionToken)
 		if claims != nil {
 			rawClaims = claims
 			attrs.Gitlab = claims.JoinAttrs()
@@ -251,7 +252,7 @@ func (a *Server) RegisterUsingToken(ctx context.Context, req *types.RegisterUsin
 			return nil, trace.Wrap(err)
 		}
 	case types.JoinMethodCircleCI:
-		claims, err := a.checkCircleCIJoinRequest(ctx, req)
+		claims, err := a.checkCircleCIJoinRequest(ctx, req, provisionToken)
 		if claims != nil {
 			rawClaims = claims
 			attrs.Circleci = claims.JoinAttrs()
@@ -260,7 +261,7 @@ func (a *Server) RegisterUsingToken(ctx context.Context, req *types.RegisterUsin
 			return nil, trace.Wrap(err)
 		}
 	case types.JoinMethodKubernetes:
-		claims, err := a.checkKubernetesJoinRequest(ctx, req)
+		claims, err := a.checkKubernetesJoinRequest(ctx, req, provisionToken)
 		if claims != nil {
 			rawClaims = claims
 			attrs.Kubernetes = claims.JoinAttrs()
@@ -269,7 +270,7 @@ func (a *Server) RegisterUsingToken(ctx context.Context, req *types.RegisterUsin
 			return nil, trace.Wrap(err)
 		}
 	case types.JoinMethodGCP:
-		claims, err := a.checkGCPJoinRequest(ctx, req)
+		claims, err := a.checkGCPJoinRequest(ctx, req, provisionToken)
 		if claims != nil {
 			rawClaims = claims
 			attrs.Gcp = claims.JoinAttrs()
@@ -278,7 +279,7 @@ func (a *Server) RegisterUsingToken(ctx context.Context, req *types.RegisterUsin
 			return nil, trace.Wrap(err)
 		}
 	case types.JoinMethodSpacelift:
-		claims, err := a.checkSpaceliftJoinRequest(ctx, req)
+		claims, err := a.checkSpaceliftJoinRequest(ctx, req, provisionToken)
 		if claims != nil {
 			rawClaims = claims
 			attrs.Spacelift = claims.JoinAttrs()
@@ -287,7 +288,7 @@ func (a *Server) RegisterUsingToken(ctx context.Context, req *types.RegisterUsin
 			return nil, trace.Wrap(err)
 		}
 	case types.JoinMethodTerraformCloud:
-		claims, err := a.checkTerraformCloudJoinRequest(ctx, req)
+		claims, err := a.checkTerraformCloudJoinRequest(ctx, req, provisionToken)
 		if claims != nil {
 			rawClaims = claims
 			attrs.TerraformCloud = claims.JoinAttrs()
@@ -296,7 +297,7 @@ func (a *Server) RegisterUsingToken(ctx context.Context, req *types.RegisterUsin
 			return nil, trace.Wrap(err)
 		}
 	case types.JoinMethodBitbucket:
-		claims, err := a.checkBitbucketJoinRequest(ctx, req)
+		claims, err := a.checkBitbucketJoinRequest(ctx, req, provisionToken)
 		if claims != nil {
 			rawClaims = claims
 			attrs.Bitbucket = claims.JoinAttrs()
@@ -311,12 +312,6 @@ func (a *Server) RegisterUsingToken(ctx context.Context, req *types.RegisterUsin
 		// above (empty join method will be set to JoinMethodToken by
 		// CheckAndSetDefaults)
 		return nil, trace.BadParameter("unrecognized token join method")
-	}
-
-	// perform common token checks
-	provisionToken, err = a.checkTokenJoinRequestCommon(ctx, req)
-	if err != nil {
-		return nil, trace.Wrap(err)
 	}
 
 	// With all elements of the token validated, we can now generate & return

--- a/lib/auth/join.go
+++ b/lib/auth/join.go
@@ -306,7 +306,7 @@ func (a *Server) RegisterUsingToken(ctx context.Context, req *types.RegisterUsin
 			return nil, trace.Wrap(err)
 		}
 	case types.JoinMethodToken:
-		// carry on to common token checking logic
+		// no additional validation to perform - the name is enough.
 	default:
 		// this is a logic error, all valid join methods should be captured
 		// above (empty join method will be set to JoinMethodToken by

--- a/lib/auth/join_bitbucket.go
+++ b/lib/auth/join_bitbucket.go
@@ -33,15 +33,14 @@ type bitbucketIDTokenValidator interface {
 	) (*bitbucket.IDTokenClaims, error)
 }
 
-func (a *Server) checkBitbucketJoinRequest(ctx context.Context, req *types.RegisterUsingTokenRequest) (*bitbucket.IDTokenClaims, error) {
+func (a *Server) checkBitbucketJoinRequest(
+	ctx context.Context,
+	req *types.RegisterUsingTokenRequest,
+	pt types.ProvisionToken,
+) (*bitbucket.IDTokenClaims, error) {
 	if req.IDToken == "" {
 		return nil, trace.BadParameter("id_token not provided for bitbucket join request")
 	}
-	pt, err := a.GetToken(ctx, req.Token)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	token, ok := pt.(*types.ProvisionTokenV2)
 	if !ok {
 		return nil, trace.BadParameter("bitbucket join method only supports ProvisionTokenV2, '%T' was provided", pt)

--- a/lib/auth/join_circleci.go
+++ b/lib/auth/join_circleci.go
@@ -36,10 +36,6 @@ func (a *Server) checkCircleCIJoinRequest(
 	if req.IDToken == "" {
 		return nil, trace.BadParameter("IDToken not provided for %q join request", types.JoinMethodCircleCI)
 	}
-	pt, err := a.GetToken(ctx, req.Token)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 	token, ok := pt.(*types.ProvisionTokenV2)
 	if !ok {
 		return nil, trace.BadParameter("%q join method only support ProvisionTokenV2, '%T' was provided", types.JoinMethodCircleCI, pt)

--- a/lib/auth/join_circleci.go
+++ b/lib/auth/join_circleci.go
@@ -28,7 +28,11 @@ import (
 	"github.com/gravitational/teleport/lib/circleci"
 )
 
-func (a *Server) checkCircleCIJoinRequest(ctx context.Context, req *types.RegisterUsingTokenRequest) (*circleci.IDTokenClaims, error) {
+func (a *Server) checkCircleCIJoinRequest(
+	ctx context.Context,
+	req *types.RegisterUsingTokenRequest,
+	pt types.ProvisionToken,
+) (*circleci.IDTokenClaims, error) {
 	if req.IDToken == "" {
 		return nil, trace.BadParameter("IDToken not provided for %q join request", types.JoinMethodCircleCI)
 	}

--- a/lib/auth/join_gcp.go
+++ b/lib/auth/join_gcp.go
@@ -33,15 +33,14 @@ type gcpIDTokenValidator interface {
 	Validate(ctx context.Context, token string) (*gcp.IDTokenClaims, error)
 }
 
-func (a *Server) checkGCPJoinRequest(ctx context.Context, req *types.RegisterUsingTokenRequest) (*gcp.IDTokenClaims, error) {
+func (a *Server) checkGCPJoinRequest(
+	ctx context.Context,
+	req *types.RegisterUsingTokenRequest,
+	pt types.ProvisionToken,
+) (*gcp.IDTokenClaims, error) {
 	if req.IDToken == "" {
 		return nil, trace.BadParameter("IDToken not provided for GCP join request")
 	}
-	pt, err := a.GetToken(ctx, req.Token)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	token, ok := pt.(*types.ProvisionTokenV2)
 	if !ok {
 		return nil, trace.BadParameter("gcp join method only supports ProvisionTokenV2, '%T' was provided", pt)

--- a/lib/auth/join_kubernetes.go
+++ b/lib/auth/join_kubernetes.go
@@ -35,13 +35,13 @@ type k8sTokenReviewValidator interface {
 
 type k8sJWKSValidator func(now time.Time, jwksData []byte, clusterName string, token string) (*kubetoken.ValidationResult, error)
 
-func (a *Server) checkKubernetesJoinRequest(ctx context.Context, req *types.RegisterUsingTokenRequest) (*kubetoken.ValidationResult, error) {
+func (a *Server) checkKubernetesJoinRequest(
+	ctx context.Context,
+	req *types.RegisterUsingTokenRequest,
+	unversionedToken types.ProvisionToken,
+) (*kubetoken.ValidationResult, error) {
 	if req.IDToken == "" {
 		return nil, trace.BadParameter("IDToken not provided for Kubernetes join request")
-	}
-	unversionedToken, err := a.GetToken(ctx, req.Token)
-	if err != nil {
-		return nil, trace.Wrap(err)
 	}
 	token, ok := unversionedToken.(*types.ProvisionTokenV2)
 	if !ok {

--- a/lib/auth/join_spacelift.go
+++ b/lib/auth/join_spacelift.go
@@ -35,15 +35,14 @@ type spaceliftIDTokenValidator interface {
 	) (*spacelift.IDTokenClaims, error)
 }
 
-func (a *Server) checkSpaceliftJoinRequest(ctx context.Context, req *types.RegisterUsingTokenRequest) (*spacelift.IDTokenClaims, error) {
+func (a *Server) checkSpaceliftJoinRequest(
+	ctx context.Context,
+	req *types.RegisterUsingTokenRequest,
+	pt types.ProvisionToken,
+) (*spacelift.IDTokenClaims, error) {
 	if req.IDToken == "" {
 		return nil, trace.BadParameter("id_token not provided for spacelift join request")
 	}
-	pt, err := a.GetToken(ctx, req.Token)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	token, ok := pt.(*types.ProvisionTokenV2)
 	if !ok {
 		return nil, trace.BadParameter("spacelift join method only supports ProvisionTokenV2, '%T' was provided", pt)

--- a/lib/auth/join_terraformcloud.go
+++ b/lib/auth/join_terraformcloud.go
@@ -35,15 +35,14 @@ type terraformCloudIDTokenValidator interface {
 	) (*terraformcloud.IDTokenClaims, error)
 }
 
-func (a *Server) checkTerraformCloudJoinRequest(ctx context.Context, req *types.RegisterUsingTokenRequest) (*terraformcloud.IDTokenClaims, error) {
+func (a *Server) checkTerraformCloudJoinRequest(
+	ctx context.Context,
+	req *types.RegisterUsingTokenRequest,
+	pt types.ProvisionToken,
+) (*terraformcloud.IDTokenClaims, error) {
 	if req.IDToken == "" {
 		return nil, trace.BadParameter("id_token not provided for terraform_cloud join request")
 	}
-	pt, err := a.GetToken(ctx, req.Token)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	token, ok := pt.(*types.ProvisionTokenV2)
 	if !ok {
 		return nil, trace.BadParameter("terraform_cloud join method only supports ProvisionTokenV2, '%T' was provided", pt)

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -1419,15 +1419,15 @@ export const formatters: Formatters = {
   [eventCodes.BOT_JOIN]: {
     type: 'bot.join',
     desc: 'Bot Joined',
-    format: ({ bot_name, method }) => {
-      return `Bot [${bot_name}] joined the cluster using the [${method}] join method`;
+    format: ({ bot_name, method, token_name }) => {
+      return `Bot [${bot_name}] joined the cluster using the [${method}] join method and the [${token_name || 'unknown'}] token`;
     },
   },
   [eventCodes.BOT_JOIN_FAILURE]: {
     type: 'bot.join',
     desc: 'Bot Join Failed',
-    format: ({ bot_name }) => {
-      return `Bot [${bot_name || 'unknown'}] failed to join the cluster`;
+    format: ({ bot_name, method, token_name }) => {
+      return `Bot [${bot_name || 'unknown'}] failed to join the cluster using the [${method || 'unknown'}] join method and the [${token_name || 'unknown'}] token`;
     },
   },
   [eventCodes.INSTANCE_JOIN]: {

--- a/web/packages/teleport/src/services/audit/types.ts
+++ b/web/packages/teleport/src/services/audit/types.ts
@@ -1327,6 +1327,7 @@ export type RawEvents = {
     {
       bot_name: string;
       method: string;
+      token_name: string;
     }
   >;
   [eventCodes.BOT_JOIN_FAILURE]: RawEvent<
@@ -1334,6 +1335,7 @@ export type RawEvents = {
     {
       bot_name: string;
       method: string;
+      token_name: string;
     }
   >;
   [eventCodes.INSTANCE_JOIN]: RawEvent<


### PR DESCRIPTION
Addresses:
- Adds additional comments to highlight some potential footguns when working with this code.
- Removes the `tokenJoinMethod()` method and rearranges the code to call `GetToken()` once at most. Previously, we were calling GetToken() three times for most join methods 😅 
- Rearranged code means that when a delegated join fails because the allow rules reject the join, the audit log event will now include the name of the token and the name of the Bot. Previously, you could only see this information if the join succeeded. Partially addresses https://github.com/gravitational/teleport/issues/54248

## For a join where the allow rules lead to rejection.

### After this PR

![image](https://github.com/user-attachments/assets/f7aaccf7-9d94-4551-aaa3-f84ada338caf)

```json
{
  "addr.remote": "52.176.37.103",
  "attributes": {
    "actor": "strideynet",
    "actor_id": "16336790",
    "base_ref": "",
    "environment": "",
    "event_name": "push",
    "head_ref": "",
    "job_workflow_ref": "strideynet/zta-machine-id-demo/.github/workflows/deploy.yaml@refs/heads/main",
    "ref": "refs/heads/main",
    "ref_type": "branch",
    "repository": "strideynet/zta-machine-id-demo",
    "repository_id": "974717262",
    "repository_owner": "strideynet",
    "repository_owner_id": "16336790",
    "repository_visibility": "private",
    "run_attempt": "1",
    "run_id": "14994181133",
    "run_number": "10",
    "sha": "1a076df8319651819613f69b53059402fd3ce6f8",
    "sub": "repo:strideynet/zta-machine-id-demo:ref:refs/heads/main",
    "workflow": ".github/workflows/deploy.yaml"
  },
  "bot_name": "github-machine-identity-demo",
  "cluster_name": "leaf.tele.ottr.sh",
  "code": "TJ001E",
  "ei": 0,
  "error": "id token claims did not match any allow rules",
  "event": "bot.join",
  "method": "github",
  "success": false,
  "time": "2025-05-13T10:21:16.285Z",
  "token_name": "github-machine-identity-demo",
  "uid": "98fc5562-c512-44c8-9eda-6df8664341aa"
}
```

### Before this PR

![image](https://github.com/user-attachments/assets/19d8d042-4c04-4de7-8e31-818347dad184)

```json
{
  "addr.remote": "70.37.166.212",
  "attributes": {
    "actor": "strideynet",
    "actor_id": "16336790",
    "base_ref": "",
    "environment": "",
    "event_name": "push",
    "head_ref": "",
    "job_workflow_ref": "strideynet/zta-machine-id-demo/.github/workflows/deploy.yaml@refs/heads/main",
    "ref": "refs/heads/main",
    "ref_type": "branch",
    "repository": "strideynet/zta-machine-id-demo",
    "repository_id": "974717262",
    "repository_owner": "strideynet",
    "repository_owner_id": "16336790",
    "repository_visibility": "private",
    "run_attempt": "1",
    "run_id": "14994737037",
    "run_number": "11",
    "sha": "0a5f2b53caf44a24ff3152ac4148718318083ef1",
    "sub": "repo:strideynet/zta-machine-id-demo:ref:refs/heads/main",
    "workflow": ".github/workflows/deploy.yaml"
  },
  "cluster_name": "leaf.tele.ottr.sh",
  "code": "TJ001E",
  "ei": 0,
  "error": "id token claims did not match any allow rules",
  "event": "bot.join",
  "success": false,
  "time": "2025-05-13T10:51:14.236Z",
  "uid": "d8d90bdd-894f-4f83-b153-e0c8d0631c8f"
}
```

changelog: Improved performance of joining & improved audit log entries for failed joins.