### PR TITLE
Fix import order in `lib/vnet`

### DIFF
--- a/lib/vnet/daemon/service_darwin.go
+++ b/lib/vnet/daemon/service_darwin.go
@@ -28,10 +28,10 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/gravitational/teleport/lib/utils/darwinbundle"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/utils/darwinbundle"
 )
 
 // Start starts an XPC listener and waits for it to receive a message with VNet config.

--- a/lib/vnet/service_windows.go
+++ b/lib/vnet/service_windows.go
@@ -27,12 +27,12 @@ import (
 	"time"
 
 	"github.com/alecthomas/kingpin/v2"
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/mgr"
 
+	"github.com/gravitational/teleport"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 


### PR DESCRIPTION
branch/v17 seems fine, `make fix-imports` doesn't introduce any changes, hence no backport.