### PR TITLE
codeowners: Use pnpm-lock.yaml instead of package.json

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,5 @@
 /build.assets/tooling/cmd/difftest/ @klizhentas @russjones @r0mant @zmb3
 
 # Owners for dependency updates in JS packages.
-package.json @avatus @gzdunek @ravicious
+pnpm-lock.yaml @avatus @gzdunek @ravicious
 web/packages/teleterm/package.json @gzdunek @ravicious


### PR DESCRIPTION
This occurred to me only after we merged #54629. Instead of requiring code owners for every package.json update, which might not even be related to JS dependencies (say someone adding a new package script), we can assign code owners only to pnpm-lock.yaml changes.

This should still result in Dependabot PRs being automatically assigned to people while reducing the number of PRs code owners are assigned to.