### PR TITLE
[v16] Move auth preference module validation to RPC layer

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -4800,6 +4800,10 @@ func (a *ServerWithRoles) DeleteAllInstallers(ctx context.Context) error {
 // SetAuthPreference sets cluster auth preference.
 // Deprecated: Use Update/UpsertAuthPreference where appropriate.
 func (a *ServerWithRoles) SetAuthPreference(ctx context.Context, newAuthPref types.AuthPreference) error {
+	if err := modules.ValidateResource(newAuthPref); err != nil {
+		return trace.Wrap(err)
+	}
+
 	storedAuthPref, err := a.authServer.GetAuthPreference(ctx)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/auth/clusterconfig/clusterconfigv1/service.go
+++ b/lib/auth/clusterconfig/clusterconfigv1/service.go
@@ -32,6 +32,7 @@ import (
 	dtconfig "github.com/gravitational/teleport/lib/devicetrust/config"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/readonly"
 )
 
@@ -170,6 +171,10 @@ func (s *Service) CreateAuthPreference(ctx context.Context, p types.AuthPreferen
 		return nil, trace.AccessDenied("this request can be only executed by an auth server")
 	}
 
+	if err := services.ValidateAuthPreference(p); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	// check that the given RequireMFAType is supported in this build.
 	if p.GetPrivateKeyPolicy().IsHardwareKeyPolicy() && modules.GetModules().BuildType() != modules.BuildEnterprise {
 		return nil, trace.AccessDenied("Hardware Key support is only available with an enterprise license")
@@ -214,6 +219,10 @@ func (s *Service) UpdateAuthPreference(ctx context.Context, req *clusterconfigpb
 	}
 
 	if err := authzCtx.CheckAccessToKind(types.KindClusterAuthPreference, types.VerbUpdate); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := services.ValidateAuthPreference(req.GetAuthPreference()); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -281,6 +290,10 @@ func (s *Service) UpsertAuthPreference(ctx context.Context, req *clusterconfigpb
 
 	// Support reused MFA for bulk tctl create requests.
 	if err := authzCtx.AuthorizeAdminActionAllowReusedMFA(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := services.ValidateAuthPreference(req.GetAuthPreference()); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -342,29 +342,15 @@ func TestAuthPreferenceSecondFactorOnly(t *testing.T) {
 	defer modules.SetInsecureTestMode(true)
 	ctx := context.Background()
 
-	t.Run("starting with second_factor disabled fails", func(t *testing.T) {
-		conf := setupConfig(t)
-		authPref, err := types.NewAuthPreferenceFromConfigFile(types.AuthPreferenceSpecV2{
-			SecondFactor: constants.SecondFactorOff,
-		})
-		require.NoError(t, err)
-
-		conf.AuthPreference = authPref
-		_, err = Init(ctx, conf)
-		require.Error(t, err)
+	conf := setupConfig(t)
+	authPref, err := types.NewAuthPreferenceFromConfigFile(types.AuthPreferenceSpecV2{
+		SecondFactor: constants.SecondFactorOff,
 	})
+	require.NoError(t, err)
 
-	t.Run("starting with defaults and dynamically updating to disable second factor fails", func(t *testing.T) {
-		conf := setupConfig(t)
-		s, err := Init(ctx, conf)
-		require.NoError(t, err)
-		authpref, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
-			SecondFactor: constants.SecondFactorOff,
-		})
-		require.NoError(t, err)
-		_, err = s.UpsertAuthPreference(ctx, authpref)
-		require.Error(t, err)
-	})
+	conf.AuthPreference = authPref
+	_, err = Init(ctx, conf)
+	require.Error(t, err)
 }
 
 func TestClusterNetworkingConfig(t *testing.T) {

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -798,7 +798,7 @@ func TestApplyConfig(t *testing.T) {
 		},
 		Spec: types.AuthPreferenceSpecV2{
 			Type:         constants.Local,
-			SecondFactor: constants.SecondFactorOptional,
+			SecondFactor: constants.SecondFactorWebauthn,
 			Webauthn: &types.Webauthn{
 				RPID: "goteleport.com",
 				AttestationAllowedCAs: []string{

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -681,7 +681,7 @@ func TestAuthenticationConfig_Parse_deviceTrustPB(t *testing.T) {
 			configYAML: editConfig(t, func(cfg cfgMap) {
 				cfg["auth_service"].(cfgMap)["authentication"] = cfgMap{
 					"type":          "local",
-					"second_factor": "off", // uncharacteristic, but not necessary for this test
+					"second_factor": "otp",
 					"device_trust": cfgMap{
 						"mode": "optional",
 					},
@@ -696,7 +696,7 @@ func TestAuthenticationConfig_Parse_deviceTrustPB(t *testing.T) {
 			configYAML: editConfig(t, func(cfg cfgMap) {
 				cfg["auth_service"].(cfgMap)["authentication"] = cfgMap{
 					"type":          "local",
-					"second_factor": "off", // uncharacteristic, but not necessary for this test
+					"second_factor": "otp",
 					"device_trust": cfgMap{
 						"mode":        "required",
 						"auto_enroll": "yes",
@@ -750,7 +750,7 @@ func TestAuthenticationConfig_Parse_deviceTrustPB(t *testing.T) {
 			configYAML: editConfig(t, func(cfg cfgMap) {
 				cfg["auth_service"].(cfgMap)["authentication"] = cfgMap{
 					"type":          "local",
-					"second_factor": "off", // uncharacteristic, but not necessary for this test
+					"second_factor": "otp",
 					"device_trust": cfgMap{
 						"mode":        "required",
 						"auto_enroll": "NOT A BOOLEAN", // invalid

--- a/lib/config/testdata_test.go
+++ b/lib/config/testdata_test.go
@@ -125,7 +125,7 @@ auth_service:
       slot_number: 1
       pin: "example_pin"
   authentication:
-    second_factor: "optional"
+    second_factor: "webauthn"
     webauthn:
       rp_id: "goteleport.com"
       attestation_allowed_cas:
@@ -346,7 +346,7 @@ auth_service:
   - "auth:yyy"
   authentication:
     type: local
-    second_factor: off
+    second_factor: otp
 
 ssh_service:
   enabled: no

--- a/lib/services/configuration.go
+++ b/lib/services/configuration.go
@@ -21,8 +21,11 @@ package services
 import (
 	"context"
 
+	"github.com/gravitational/trace"
+
 	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/modules"
 )
 
 // ClusterConfiguration stores the cluster configuration in the backend. All
@@ -127,4 +130,17 @@ type ClusterConfiguration interface {
 	UpsertAccessGraphSettings(context.Context, *clusterconfigpb.AccessGraphSettings) (*clusterconfigpb.AccessGraphSettings, error)
 	// DeleteAccessGraphSettings deletes the access graph settings from the backend.
 	DeleteAccessGraphSettings(context.Context) error
+}
+
+// ValidateAuthPreference performs checks that should happen before persisting a
+// new version of the preference resource, typically only as part of Auth
+// service operations.
+func ValidateAuthPreference(ap types.AuthPreference) error {
+	// TODO(espadolini): the checks that are duplicated in
+	// {Set,Create,Update,Upsert}AuthPreference should be moved here
+	if err := modules.ValidateResource(ap); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
 }

--- a/lib/services/configuration_test.go
+++ b/lib/services/configuration_test.go
@@ -1,0 +1,106 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package services
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/modules"
+)
+
+func TestAuthPreferenceValidate(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		t.Parallel()
+
+		require.NoError(t, ValidateAuthPreference(types.DefaultAuthPreference()))
+	})
+
+	disableSecondFactorAssertion := func(t require.TestingT, err error, a ...any) {
+		require.ErrorIs(t, err, modules.ErrCannotDisableSecondFactor, a...)
+	}
+	t.Run("second_factors", func(t *testing.T) {
+		type testCase struct {
+			name     string
+			spec     types.AuthPreferenceSpecV2
+			features modules.Features
+			bypass   bool
+			check    require.ErrorAssertionFunc
+		}
+
+		testCases := []testCase{
+			{
+				name:  "disabling prevented",
+				spec:  types.AuthPreferenceSpecV2{SecondFactor: constants.SecondFactorOff},
+				check: disableSecondFactorAssertion,
+			},
+			{
+				name:   "cloud prevents disabling",
+				bypass: true,
+				spec:   types.AuthPreferenceSpecV2{SecondFactor: constants.SecondFactorOff},
+				features: modules.Features{
+					Cloud: true,
+				},
+				check: disableSecondFactorAssertion,
+			},
+			{
+				name: "webauthn allowed",
+				spec: types.AuthPreferenceSpecV2{
+					SecondFactor: constants.SecondFactorWebauthn,
+					Webauthn: &types.Webauthn{
+						RPID: "test.example.com",
+					},
+				},
+				check: require.NoError,
+			},
+			{
+				name: "otp allowed",
+				spec: types.AuthPreferenceSpecV2{
+					SecondFactor: constants.SecondFactorOTP,
+				},
+				check: require.NoError,
+			},
+			{
+				name:   "bypass self hosted",
+				spec:   types.AuthPreferenceSpecV2{SecondFactor: constants.SecondFactorOff},
+				check:  require.NoError,
+				bypass: true,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				if tc.bypass {
+					t.Setenv(teleport.EnvVarAllowNoSecondFactor, "true")
+				}
+
+				modules.SetTestModules(t, &modules.TestModules{
+					TestFeatures: tc.features,
+				})
+
+				authPref := &types.AuthPreferenceV2{
+					Spec: tc.spec,
+				}
+				tc.check(t, ValidateAuthPreference(authPref))
+			})
+		}
+	})
+}

--- a/lib/services/local/configuration.go
+++ b/lib/services/local/configuration.go
@@ -190,11 +190,6 @@ func (s *ClusterConfigurationService) GetAuthPreference(ctx context.Context) (ty
 
 // CreateAuthPreference creates an auth preference if once does not already exist.
 func (s *ClusterConfigurationService) CreateAuthPreference(ctx context.Context, preference types.AuthPreference) (types.AuthPreference, error) {
-	// Perform the modules-provided checks.
-	if err := modules.ValidateResource(preference); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	value, err := services.MarshalAuthPreference(preference)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -216,12 +211,7 @@ func (s *ClusterConfigurationService) CreateAuthPreference(ctx context.Context, 
 
 // UpdateAuthPreference updates an existing auth preference.
 func (s *ClusterConfigurationService) UpdateAuthPreference(ctx context.Context, preference types.AuthPreference) (types.AuthPreference, error) {
-	// Perform the modules-provided checks.
 	rev := preference.GetRevision()
-	if err := modules.ValidateResource(preference); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	value, err := services.MarshalAuthPreference(preference)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -244,11 +234,6 @@ func (s *ClusterConfigurationService) UpdateAuthPreference(ctx context.Context, 
 
 // UpsertAuthPreference creates a new auth preference or overwrites an existing auth preference.
 func (s *ClusterConfigurationService) UpsertAuthPreference(ctx context.Context, preference types.AuthPreference) (types.AuthPreference, error) {
-	// Perform the modules-provided checks.
-	if err := modules.ValidateResource(preference); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	rev := preference.GetRevision()
 	value, err := services.MarshalAuthPreference(preference)
 	if err != nil {


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/54687 to branch/v16

changelog: Prevent restrictive validation of cluster auth preferences from causing non-auth instances to become healthy.