### PR TITLE
Changed error message for major version downgrade

### DIFF
--- a/lib/auth/version.go
+++ b/lib/auth/version.go
@@ -87,9 +87,9 @@ func validateAndUpdateTeleportVersion(
 		}
 		if lastKnownVersion.Major > currentVersion.Major {
 			return trace.BadParameter("Unsupported downgrade path detected: from %v to %v. "+
-				"Teleport doesn't support major version downgrade. Downgrading may lead to an inconsistent database state.\n  "+
-				"Use at your own risk: to allow downgrade, set the environment variable `TELEPORT_UNSTABLE_SKIP_VERSION_UPGRADE_CHECK=yes`.\n  "+
-				"See compatibility guarantees for details: "+
+				"Teleport doesn't support major version downgrades. Downgrading may lead to an inconsistent cluster state.\n  "+
+				"Use at your own risk: to allow downgrading, set the environment variable `TELEPORT_UNSTABLE_SKIP_VERSION_UPGRADE_CHECK=yes`.\n  "+
+				"See our upgrading guide for details: "+
 				"https://goteleport.com/docs/upgrading/overview/#component-compatibility.",
 				lastKnownVersion, currentVersion.String())
 		}

--- a/lib/auth/version.go
+++ b/lib/auth/version.go
@@ -87,10 +87,11 @@ func validateAndUpdateTeleportVersion(
 		}
 		if lastKnownVersion.Major > currentVersion.Major {
 			return trace.BadParameter("Unsupported downgrade path detected: from %v to %v. "+
-				"Teleport doesn't support major version downgrade.\n Please downgrade "+
-				"your cluster to version %d.x.x first. See compatibility guarantees for details: "+
+				"Teleport doesn't support major version downgrade. Downgrading may lead to an inconsistent database state.\n  "+
+				"Use at your own risk: to allow downgrade, set the environment variable `TELEPORT_UNSTABLE_SKIP_VERSION_UPGRADE_CHECK=yes`.\n  "+
+				"See compatibility guarantees for details: "+
 				"https://goteleport.com/docs/upgrading/overview/#component-compatibility.",
-				lastKnownVersion, currentVersion.String(), lastKnownVersion.Major-1)
+				lastKnownVersion, currentVersion.String())
 		}
 
 		backendInfo.GetSpec().TeleportVersion = currentVersion.String()


### PR DESCRIPTION
Replaced error message that restricts major version downgrade since it is not supported. https://goteleport.com/docs/upgrading/overview/#component-compatibility.